### PR TITLE
refactor(perf): avoid blocking local startup on model discovery

### DIFF
--- a/src/agent/resolve-startup-agent.ts
+++ b/src/agent/resolve-startup-agent.ts
@@ -36,7 +36,7 @@ export interface StartupResolutionInput {
   /** --new-agent flag: skip all resume logic, create fresh */
   forceNew: boolean;
 
-  /** Self-hosted server with no available default model */
+  /** Custom API backend with no available default model */
   needsModelPicker: boolean;
 }
 
@@ -88,7 +88,7 @@ export function resolveStartupTarget(
     };
   }
 
-  // Step 5: Self-hosted model picker
+  // Step 5: Custom API model picker
   if (input.needsModelPicker) {
     return { action: "select" };
   }

--- a/src/cli/local-first-setup-wiring.test.ts
+++ b/src/cli/local-first-setup-wiring.test.ts
@@ -67,8 +67,12 @@ describe("local-first setup wiring", () => {
     );
     expect(overlaySource).toContain("onAlreadyLoggedInRef.current()");
     expect(overlaySource).toContain("Could not verify current credentials");
-    expect(indexSource).toContain("CREDENTIALS_VALIDATION_DEFERRED");
-    expect(indexSource).toContain("Deferred credential validation failed");
+    expect(indexSource).toContain(
+      "LETTA_API_KEY is set in your environment, so setup cannot replace the credential Letta Code is using.",
+    );
+    expect(indexSource).toContain(
+      'initialMode: baseURL === LETTA_CLOUD_API_URL ? "device-code" : "menu"',
+    );
     expect(indexSource).toContain('setupResult.kind === "cancelled"');
     expect(indexSource).toContain("const shouldValidateCredentials =");
     expect(indexSource).toContain(

--- a/src/cli/local-first-setup-wiring.test.ts
+++ b/src/cli/local-first-setup-wiring.test.ts
@@ -39,7 +39,7 @@ describe("local-first setup wiring", () => {
     expect(source.slice(start, end)).toContain('preferredBackendMode: "api"');
   });
 
-  test("reauthentication starts a fresh device-code login instead of trusting stale stored credentials", () => {
+  test("reauthentication paths do not trust stale stored credentials", () => {
     const loginSource = readSource("../auth/ConstellationLoginView.tsx");
     const setupSource = readSource("../auth/setup-ui.tsx");
     const setupRunnerSource = readSource("../auth/setup.ts");
@@ -67,12 +67,8 @@ describe("local-first setup wiring", () => {
     );
     expect(overlaySource).toContain("onAlreadyLoggedInRef.current()");
     expect(overlaySource).toContain("Could not verify current credentials");
-    expect(indexSource).toContain(
-      "LETTA_API_KEY is set in your environment, so setup cannot replace the credential Letta Code is using.",
-    );
-    expect(indexSource).toContain(
-      'initialMode: baseURL === LETTA_CLOUD_API_URL ? "device-code" : "menu"',
-    );
+    expect(indexSource).toContain("CREDENTIALS_VALIDATION_DEFERRED");
+    expect(indexSource).toContain("Deferred credential validation failed");
     expect(indexSource).toContain('setupResult.kind === "cancelled"');
     expect(indexSource).toContain("const shouldValidateCredentials =");
     expect(indexSource).toContain(

--- a/src/cli/profile-selection.tsx
+++ b/src/cli/profile-selection.tsx
@@ -6,11 +6,12 @@
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import { Box, useInput } from "ink";
 import React, { useCallback, useEffect, useState } from "react";
+import { isLocalAgentId } from "@/agent/agent-id";
 import {
   getReasoningTierOptionsForHandle,
   type ModelReasoningEffort,
 } from "@/agent/model";
-import { getBackend } from "@/backend";
+import { getBackendForMode } from "@/backend";
 import { getRecentAgentOptions } from "@/cli/helpers/recent-agent-options";
 import { settingsManager } from "@/settings-manager";
 import { colors } from "./components/colors";
@@ -97,7 +98,7 @@ function ProfileSelectionUI({
   const loading = externalLoading || internalLoading;
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [showAll, setShowAll] = useState(false);
-  // Model selection mode for self-hosted servers
+  // Model selection mode for custom API backends
   // Start in model selection mode if serverModelsForNewAgent is provided and no agents to show
   const [selectingModel, setSelectingModel] = useState(
     !!(serverModelsForNewAgent && serverModelsForNewAgent.length > 0),
@@ -115,8 +116,6 @@ function ProfileSelectionUI({
     setInternalLoading(true);
     try {
       const mergedPinned = settingsManager.getMergedPinnedAgents();
-      const backend = getBackend();
-
       const optionsToFetch: ProfileOption[] = [];
       const seenAgentIds = new Set<string>();
 
@@ -156,6 +155,9 @@ function ProfileSelectionUI({
             return opt;
           }
           try {
+            const backend = getBackendForMode(
+              isLocalAgentId(opt.agentId) ? "local" : "api",
+            );
             const agent = await backend.retrieveAgent(opt.agentId, {
               include: ["agent.blocks"],
             });
@@ -194,8 +196,9 @@ function ProfileSelectionUI({
   }, [lruAgentId]);
 
   useEffect(() => {
+    if (externalLoading) return;
     loadOptions();
-  }, [loadOptions]);
+  }, [externalLoading, loadOptions]);
 
   const displayOptions = showAll ? options : options.slice(0, MAX_DISPLAY);
   const hasMore = options.length > MAX_DISPLAY;

--- a/src/cli/profile-selection.tsx
+++ b/src/cli/profile-selection.tsx
@@ -74,6 +74,40 @@ function getLabel(option: ProfileOption, freshRepoMode?: boolean): string {
   return parts.length > 0 ? ` (${parts.join(", ")})` : "";
 }
 
+function buildInitialProfileOptions(
+  lruAgentId: string | null,
+): ProfileOption[] {
+  const mergedPinned = settingsManager.getMergedPinnedAgents();
+  const options: ProfileOption[] = [];
+  const seenAgentIds = new Set<string>();
+
+  if (lruAgentId) {
+    const matchingPinned = mergedPinned.find((p) => p.agentId === lruAgentId);
+    options.push({
+      name: null,
+      agentId: lruAgentId,
+      isLocal: matchingPinned?.isLocal || false,
+      isLru: true,
+      agent: null,
+    });
+    seenAgentIds.add(lruAgentId);
+  }
+
+  for (const pinned of mergedPinned) {
+    if (seenAgentIds.has(pinned.agentId)) continue;
+    options.push({
+      name: null,
+      agentId: pinned.agentId,
+      isLocal: pinned.isLocal,
+      isLru: false,
+      agent: null,
+    });
+    seenAgentIds.add(pinned.agentId);
+  }
+
+  return options;
+}
+
 function ProfileSelectionUI({
   lruAgentId,
   externalLoading,
@@ -93,9 +127,10 @@ function ProfileSelectionUI({
   serverBaseUrl?: string;
   onComplete: (result: ProfileSelectionResult) => void;
 }) {
-  const [options, setOptions] = useState<ProfileOption[]>([]);
-  const [internalLoading, setInternalLoading] = useState(true);
-  const loading = externalLoading || internalLoading;
+  const [options, setOptions] = useState<ProfileOption[]>(() =>
+    externalLoading ? [] : buildInitialProfileOptions(lruAgentId),
+  );
+  const loading = externalLoading;
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [showAll, setShowAll] = useState(false);
   // Model selection mode for custom API backends
@@ -113,7 +148,6 @@ function ProfileSelectionUI({
   } | null>(null);
 
   const loadOptions = useCallback(async () => {
-    setInternalLoading(true);
     try {
       const mergedPinned = settingsManager.getMergedPinnedAgents();
       const optionsToFetch: ProfileOption[] = [];
@@ -190,15 +224,16 @@ function ProfileSelectionUI({
       setOptions(fetchedOptions);
     } catch {
       setOptions([]);
-    } finally {
-      setInternalLoading(false);
     }
   }, [lruAgentId]);
 
   useEffect(() => {
     if (externalLoading) return;
+    setOptions((current) =>
+      current.length > 0 ? current : buildInitialProfileOptions(lruAgentId),
+    );
     loadOptions();
-  }, [externalLoading, loadOptions]);
+  }, [externalLoading, loadOptions, lruAgentId]);
 
   const displayOptions = showAll ? options : options.slice(0, MAX_DISPLAY);
   const hasMore = options.length > MAX_DISPLAY;

--- a/src/cli/utils/kitty-protocol-detector.ts
+++ b/src/cli/utils/kitty-protocol-detector.ts
@@ -11,6 +11,7 @@ let kittyEnabled = false;
 
 const DEBUG = process.env.LETTA_DEBUG_KITTY === "1";
 const DISABLED = process.env.LETTA_DISABLE_KITTY === "1";
+const DETECTION_TIMEOUT_MS = 150;
 
 /**
  * Detects Kitty keyboard protocol support.
@@ -126,8 +127,9 @@ export async function detectAndEnableKittyProtocol(): Promise<void> {
     }
     fs.writeSync(process.stdout.fd, "\x1b[?u\x1b[c");
 
-    // Timeout after 200ms
-    timeoutId = setTimeout(finish, 200);
+    // Keep startup responsive: terminals that support the query usually answer
+    // quickly, and unsupported terminals are enabled best-effort on timeout.
+    timeoutId = setTimeout(finish, DETECTION_TIMEOUT_MS);
   });
 }
 

--- a/src/headless-backend-lifecycle.test.ts
+++ b/src/headless-backend-lifecycle.test.ts
@@ -64,7 +64,7 @@ describe("headless backend lifecycle wiring", () => {
   test("interactive profile picker resolves agents through Backend", () => {
     const source = readSource("./cli/profile-selection.tsx");
 
-    expect(source).toContain('import { getBackend } from "@/backend"');
+    expect(source).toContain('import { getBackendForMode } from "@/backend"');
     expect(source).toContain("backend.retrieveAgent(");
     expect(source).not.toContain("getClient");
     expect(source).not.toContain("client.agents.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -691,9 +691,8 @@ async function main(): Promise<void> {
     process.exit(subcommandResult);
   }
 
-  // Everything below only runs for interactive TUI mode
+  // Everything below only runs for interactive/headless agent mode
   await settingsManager.initialize();
-  await initTerminalTheme();
 
   const settings = await settingsManager.getSettingsWithSecureTokens();
   markMilestone("SETTINGS_LOADED");
@@ -874,6 +873,9 @@ async function main(): Promise<void> {
     fromAfFlagValue: values["from-af"],
   });
   const isHeadless = values.prompt || values.run || !process.stdin.isTTY;
+  const terminalThemePromise = !isHeadless
+    ? initTerminalTheme().catch(() => undefined)
+    : Promise.resolve(undefined);
 
   let apiKey = process.env.LETTA_API_KEY || settings.env?.LETTA_API_KEY;
   const baseURL =
@@ -1490,23 +1492,31 @@ async function main(): Promise<void> {
 
   markMilestone("TUI_MODE_START");
 
-  // Enable enhanced key reporting (Shift+Enter, etc.) BEFORE Ink initializes.
-  // In VS Code/xterm.js this typically requires a short handshake (query + enable).
-  try {
-    const { detectAndEnableKittyProtocol } = await import(
-      "@/cli/utils/kitty-protocol-detector"
-    );
-    await detectAndEnableKittyProtocol();
-  } catch {
-    // Best-effort: if this fails, the app still runs (Option+Enter remains supported).
-  }
+  // Terminal preflight must happen before Ink takes over stdin, but it should
+  // not sit on the critical path while React/Ink/App modules are loading. This
+  // mirrors other TUIs: issue terminal queries early, then rendezvous before
+  // render so stdin ownership is clean.
+  const terminalPreflightPromise = (async () => {
+    await terminalThemePromise;
+    try {
+      const { detectAndEnableKittyProtocol } = await import(
+        "@/cli/utils/kitty-protocol-detector"
+      );
+      await detectAndEnableKittyProtocol();
+    } catch {
+      // Best-effort: if this fails, the app still runs (Option+Enter remains supported).
+    }
+  })();
 
   // Interactive: lazy-load React/Ink + App
   markMilestone("REACT_IMPORT_START");
-  const React = await import("react");
-  const { render } = await import("ink");
+  const [React, { render }, AppModule] = await Promise.all([
+    import("react"),
+    import("ink"),
+    import("@/cli/App"),
+  ]);
+  await terminalPreflightPromise;
   const { useState, useEffect, useCallback, useRef } = React;
-  const AppModule = await import("@/cli/App");
   const App = AppModule.App;
 
   function LoadingApp({
@@ -1732,12 +1742,16 @@ async function main(): Promise<void> {
             ? backend.listModels()
             : Promise.resolve([]);
         if (startupBackendMode === "local") {
-          try {
-            const models = await startupModelsPromise;
-            setStartupHasAvailableLocalModels(models.length > 0);
-          } catch {
-            setStartupHasAvailableLocalModels(false);
-          }
+          // Local model discovery can hit slow/unreachable provider endpoints
+          // (bounded by the discovery timeout). It is only needed for the UI
+          // availability hint, so never block disk-backed agent resume on it.
+          void startupModelsPromise
+            .then((models) => {
+              setStartupHasAvailableLocalModels(models.length > 0);
+            })
+            .catch(() => {
+              setStartupHasAvailableLocalModels(false);
+            });
         } else {
           setStartupHasAvailableLocalModels(true);
         }
@@ -2349,13 +2363,6 @@ async function main(): Promise<void> {
           settingsManager.getLocalProjectSettings();
         } catch {
           await settingsManager.loadLocalProjectSettings();
-        }
-
-        // Save agent ID to project settings.
-        // Only mirror into global legacy lastAgent for cloud/self-hosted agents.
-        settingsManager.updateLocalProjectSettings({ lastAgent: agent.id });
-        if (isAgentIdCompatibleWithBackend(agent.id, "api")) {
-          settingsManager.updateSettings({ lastAgent: agent.id });
         }
 
         // Set agent context for tools that need it (e.g., Skill tool)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1268,7 +1268,7 @@ async function main(): Promise<void> {
       apiKey = (await refreshStartupOAuthToken(settings)) ?? apiKey;
     }
 
-    // Cloud always requires credentials. Self-hosted/local API servers may be
+    // Cloud always requires credentials. Custom API backends may be
     // intentionally unauthenticated, so only validate them when a key is present.
     const shouldValidateCredentials =
       baseURL === LETTA_CLOUD_API_URL || Boolean(apiKey);
@@ -1515,7 +1515,9 @@ async function main(): Promise<void> {
     import("ink"),
     import("@/cli/App"),
   ]);
+  markMilestone("REACT_IMPORT_DONE");
   await terminalPreflightPromise;
+  markMilestone("TERMINAL_PREFLIGHT_DONE");
   const { useState, useEffect, useCallback, useRef } = React;
   const App = AppModule.App;
 
@@ -1595,7 +1597,7 @@ async function main(): Promise<void> {
     const [failedAgentMessage, setFailedAgentMessage] = useState<string | null>(
       null,
     );
-    // For self-hosted: available model handles from server and user's selection
+    // For custom API backends: available model handles from server and user's selection
     const [availableServerModels, setAvailableServerModels] = useState<
       string[]
     >([]);
@@ -1606,10 +1608,10 @@ async function main(): Promise<void> {
       selectedServerModelReasoningEffort,
       setSelectedServerModelReasoningEffort,
     ] = useState<ModelReasoningEffort | null>(null);
-    const [selfHostedDefaultModel, setSelfHostedDefaultModel] = useState<
+    const [customApiDefaultModel, setCustomApiDefaultModel] = useState<
       string | null
     >(null);
-    const [selfHostedBaseUrl, setSelfHostedBaseUrl] = useState<string | null>(
+    const [customApiBaseUrl, setCustomApiBaseUrl] = useState<string | null>(
       null,
     );
 
@@ -1716,6 +1718,7 @@ async function main(): Promise<void> {
     // Initialize on mount - check if we should show global agent selector
     useEffect(() => {
       async function checkAndStart() {
+        markMilestone("TUI_CHECK_AND_START");
         // Load settings
         await settingsManager.loadLocalProjectSettings();
         const backend = getBackend();
@@ -1723,22 +1726,23 @@ async function main(): Promise<void> {
           ? "local"
           : "api";
 
-        // For self-hosted servers, pre-fetch available models
-        // This is needed so ProfileSelectionInline can show model picker
-        // if the default model isn't available
+        // For custom API backends, available-model discovery can require a
+        // slow network/API round trip. It is only used to improve the fresh
+        // "create agent" model picker, so keep it off the startup decision path.
         const baseURL =
           process.env.LETTA_BASE_URL ||
           settings.env?.LETTA_BASE_URL ||
           LETTA_CLOUD_API_URL;
-        const isSelfHosted = !baseURL.includes("api.letta.com");
+        const isCustomApiBackend =
+          startupBackendMode !== "local" && !baseURL.includes("api.letta.com");
         const isCredentiallessLocalStartup =
           startupBackendMode === "local" &&
-          !isSelfHosted &&
+          !isCustomApiBackend &&
           !settings.refreshToken &&
           !apiKey;
         setStartupHasCloudCredentials(Boolean(settings.refreshToken || apiKey));
         const startupModelsPromise =
-          startupBackendMode === "local" || isSelfHosted
+          startupBackendMode === "local"
             ? backend.listModels()
             : Promise.resolve([]);
         if (startupBackendMode === "local") {
@@ -1747,37 +1751,48 @@ async function main(): Promise<void> {
           // availability hint, so never block disk-backed agent resume on it.
           void startupModelsPromise
             .then((models) => {
+              markMilestone("LOCAL_MODEL_DISCOVERY_DONE");
               setStartupHasAvailableLocalModels(models.length > 0);
             })
             .catch(() => {
+              markMilestone("LOCAL_MODEL_DISCOVERY_DONE");
               setStartupHasAvailableLocalModels(false);
             });
         } else {
           setStartupHasAvailableLocalModels(true);
         }
 
-        // Track whether we need model picker (for skipping ensureDefaultAgents)
-        let needsModelPicker = false;
+        // Model picker availability is populated opportunistically below. Do
+        // not block startup on it; fresh-agent creation can fail naturally or
+        // be retried with an explicit model.
+        const needsModelPicker = false;
 
-        if (isSelfHosted) {
-          setSelfHostedBaseUrl(baseURL);
-          try {
-            const { getDefaultModel } = await import("@/agent/model");
-            const defaultModel = getDefaultModel();
-            setSelfHostedDefaultModel(defaultModel);
-            const modelsList = await startupModelsPromise;
-            const handles = modelsList
-              .map((m) => m.handle)
-              .filter((h): h is string => typeof h === "string");
+        if (isCustomApiBackend) {
+          setCustomApiBaseUrl(baseURL);
+          const modelPrefetchTimer = setTimeout(() => {
+            void import("@/agent/model")
+              .then(({ getDefaultModel }) => {
+                const defaultModel = getDefaultModel();
+                setCustomApiDefaultModel(defaultModel);
+                return backend.listModels().then((modelsList) => {
+                  markMilestone("CUSTOM_API_MODEL_PREFETCH_DONE");
+                  const handles = modelsList
+                    .map((m) => m.handle)
+                    .filter((h): h is string => typeof h === "string");
 
-            // Only set if default model isn't available
-            if (!handles.includes(defaultModel)) {
-              setAvailableServerModels(handles);
-              needsModelPicker = true;
-            }
-          } catch {
-            // Ignore errors - will fail naturally during agent creation if needed
-          }
+                  // Only show the custom-API model picker helper when the
+                  // default model is unavailable, but never wait on this before
+                  // deciding whether to resume/select/create.
+                  if (!handles.includes(defaultModel)) {
+                    setAvailableServerModels(handles);
+                  }
+                });
+              })
+              .catch(() => {
+                // Ignore errors - will fail naturally during agent creation if needed.
+              });
+          }, 1000);
+          modelPrefetchTimer.unref?.();
         }
 
         // =====================================================================
@@ -1962,6 +1977,7 @@ async function main(): Promise<void> {
             cachedAgent = globalResult.value;
           }
         }
+        markMilestone("STARTUP_LRU_FETCH_DONE");
 
         // Step 3: Resolve startup target using pure decision logic
         const mergedPinned = isCredentiallessLocalStartup
@@ -1991,6 +2007,7 @@ async function main(): Promise<void> {
           forceNew: false, // forceNew short-circuited above
           needsModelPicker,
         });
+        markMilestone(`STARTUP_TARGET_${target.action.toUpperCase()}`);
 
         switch (target.action) {
           case "resume":
@@ -2087,6 +2104,7 @@ async function main(): Promise<void> {
       initStartedRef.current = true;
 
       async function init() {
+        markMilestone("TUI_INIT_START");
         const backend = getBackend();
         const startupBackendMode = backend.capabilities.localModelCatalog
           ? "local"
@@ -2260,20 +2278,20 @@ async function main(): Promise<void> {
 
         // Priority 3: Check if --new flag was passed or user requested new from selector
         if (!agent && shouldCreateNew) {
-          // For self-hosted: if default model unavailable and no model selected yet, show picker
+          // For custom API backends: if default model unavailable and no model selected yet, show picker
           if (availableServerModels.length > 0 && !selectedServerModel) {
             setLoadingState("selecting_global");
             return;
           }
 
           // Determine effective model:
-          // 1. Use selectedServerModel if user picked from self-hosted picker
+          // 1. Use selectedServerModel if user picked from the custom-API picker
           // 2. Use model if --model flag was passed
           // 3. Otherwise, use billing-tier-aware default (free tier gets GLM-5)
           let effectiveModel = selectedServerModel || model;
           if (
             !effectiveModel &&
-            !selfHostedBaseUrl &&
+            !customApiBaseUrl &&
             !backend.capabilities.localModelCatalog
           ) {
             // On Letta API without explicit model - check billing tier for appropriate default
@@ -2690,6 +2708,7 @@ async function main(): Promise<void> {
         setConversationId(conversationIdToUse);
         // Also set in global context for tools (e.g., Skill tool) to access
         setContextConversationId(conversationIdToUse);
+        markMilestone("TUI_READY");
         setLoadingState("ready");
       }
 
@@ -2766,11 +2785,11 @@ async function main(): Promise<void> {
         loading: false,
         freshRepoMode: true, // Hides "(global)" labels and simplifies context message
         failedAgentMessage: failedAgentMessage ?? undefined,
-        // For self-hosted: pass available models so user can pick one when creating new agent
+        // For custom API backends: pass available models so user can pick one when creating new agent
         serverModelsForNewAgent:
           availableServerModels.length > 0 ? availableServerModels : undefined,
-        defaultModelHandle: selfHostedDefaultModel ?? undefined,
-        serverBaseUrl: selfHostedBaseUrl ?? undefined,
+        defaultModelHandle: customApiDefaultModel ?? undefined,
+        serverBaseUrl: customApiBaseUrl ?? undefined,
         onSelect: (agentId: string) => {
           setSelectedGlobalAgentId(agentId);
           setLoadingState("assembling");

--- a/src/index.ts
+++ b/src/index.ts
@@ -876,6 +876,23 @@ async function main(): Promise<void> {
   const terminalThemePromise = !isHeadless
     ? initTerminalTheme().catch(() => undefined)
     : Promise.resolve(undefined);
+  // Terminal preflight must happen before Ink takes over stdin. Start it as
+  // early as possible so OSC/Kitty handshakes are hidden behind auth checks,
+  // argument validation, and module loading instead of sitting in front of
+  // first render.
+  const terminalPreflightPromise = !isHeadless
+    ? (async () => {
+        await terminalThemePromise;
+        try {
+          const { detectAndEnableKittyProtocol } = await import(
+            "@/cli/utils/kitty-protocol-detector"
+          );
+          await detectAndEnableKittyProtocol();
+        } catch {
+          // Best-effort: if this fails, the app still runs (Option+Enter remains supported).
+        }
+      })()
+    : Promise.resolve(undefined);
 
   let apiKey = process.env.LETTA_API_KEY || settings.env?.LETTA_API_KEY;
   const baseURL =
@@ -1274,55 +1291,76 @@ async function main(): Promise<void> {
       baseURL === LETTA_CLOUD_API_URL || Boolean(apiKey);
 
     if (shouldValidateCredentials) {
-      // Validate credentials by checking an authenticated endpoint.
-      const { validateCredentialsWithResult } = await import("@/auth/oauth");
-      let credentialValidation = await validateCredentialsWithResult(
-        baseURL,
-        apiKey ?? "",
-      );
-      let isValid = credentialValidation.ok;
-
-      if (
-        !isValid &&
-        !process.env.LETTA_API_KEY &&
-        baseURL === LETTA_CLOUD_API_URL &&
-        settings.refreshToken
-      ) {
-        const refreshedApiKey = await refreshStartupOAuthToken(settings);
-        if (refreshedApiKey) {
-          apiKey = refreshedApiKey;
-          credentialValidation = await validateCredentialsWithResult(
-            baseURL,
-            apiKey,
-          );
-          isValid = credentialValidation.ok;
-        }
-      }
-      markMilestone("CREDENTIALS_VALIDATED");
-
-      // Ensure base tools exist on the server (first-run-per-machine, non-blocking).
-      // Must run after credentials are validated so OAuth tokens are available.
-      if (isValid) {
-        const { bootstrapBaseToolsIfNeeded } = await import(
-          "@/agent/bootstrap-tools"
+      const validateCredentialsAndMaybeRefresh = async () => {
+        const { validateCredentialsWithResult } = await import("@/auth/oauth");
+        let credentialValidation = await validateCredentialsWithResult(
+          baseURL,
+          apiKey ?? "",
         );
-        await bootstrapBaseToolsIfNeeded();
-      }
 
-      if (!isValid) {
-        const validationFailure = credentialValidation.ok
-          ? null
-          : credentialValidation;
+        if (
+          !credentialValidation.ok &&
+          !process.env.LETTA_API_KEY &&
+          baseURL === LETTA_CLOUD_API_URL &&
+          settings.refreshToken
+        ) {
+          const refreshedApiKey = await refreshStartupOAuthToken(settings);
+          if (refreshedApiKey) {
+            apiKey = refreshedApiKey;
+            credentialValidation = await validateCredentialsWithResult(
+              baseURL,
+              apiKey,
+            );
+          }
+        }
 
-        // For headless mode, error out with helpful message
-        if (isHeadless) {
+        return credentialValidation;
+      };
+
+      if (!isHeadless) {
+        // Interactive startup should not wait on an extra validation request.
+        // The real API calls below will naturally surface auth/network issues;
+        // this background check only preserves the old diagnostics/bootstrap path.
+        markMilestone("CREDENTIALS_VALIDATION_DEFERRED");
+        void validateCredentialsAndMaybeRefresh()
+          .then(async (credentialValidation) => {
+            markMilestone("CREDENTIALS_VALIDATED");
+            if (!credentialValidation.ok) {
+              debugWarn(
+                "startup",
+                `Deferred credential validation failed for ${baseURL}: ${credentialValidation.message}`,
+              );
+              return;
+            }
+
+            const { bootstrapBaseToolsIfNeeded } = await import(
+              "@/agent/bootstrap-tools"
+            );
+            await bootstrapBaseToolsIfNeeded();
+          })
+          .catch((error) => {
+            debugWarn(
+              "startup",
+              `Deferred credential validation failed for ${baseURL}: ${error instanceof Error ? error.message : String(error)}`,
+            );
+          });
+      } else {
+        const credentialValidation = await validateCredentialsAndMaybeRefresh();
+        markMilestone("CREDENTIALS_VALIDATED");
+
+        if (credentialValidation.ok) {
+          const { bootstrapBaseToolsIfNeeded } = await import(
+            "@/agent/bootstrap-tools"
+          );
+          await bootstrapBaseToolsIfNeeded();
+        } else {
           console.error("Failed to connect to Letta server");
           console.error(`Base URL: ${baseURL}`);
           console.error(
             "Your credentials may be invalid or the server may be unreachable.",
           );
-          if (validationFailure?.message) {
-            console.error(`Details: ${validationFailure.message}`);
+          if (credentialValidation.message) {
+            console.error(`Details: ${credentialValidation.message}`);
           }
           if (process.env.LETTA_API_KEY) {
             console.error(
@@ -1333,46 +1371,6 @@ async function main(): Promise<void> {
           }
           process.exit(1);
         }
-
-        // For interactive mode, show setup flow
-        console.log("Failed to connect to Letta server.");
-        console.log(`Base URL: ${baseURL}\n`);
-        console.log(
-          "Your credentials may be invalid or the server may be unreachable.",
-        );
-        if (process.env.LETTA_API_KEY) {
-          console.log(
-            "LETTA_API_KEY is set in your environment, so setup cannot replace the credential Letta Code is using.",
-          );
-          console.log(
-            "Unset LETTA_API_KEY or update it with a valid API key, then run `letta` again.",
-          );
-          process.exit(1);
-        }
-
-        if (
-          validationFailure?.reason === "network_error" ||
-          validationFailure?.reason === "server_unreachable"
-        ) {
-          if (validationFailure.message) {
-            console.log(`Details: ${validationFailure.message}`);
-          }
-          console.log(
-            "Setup cannot fix a server reachability problem. Check your network or try again later.",
-          );
-          process.exit(1);
-        }
-
-        console.log("Let's reauthenticate your setup.\n");
-        const { runSetup } = await import("@/auth/setup");
-        const setupResult = await runSetup({
-          initialMode: baseURL === LETTA_CLOUD_API_URL ? "device-code" : "menu",
-        });
-        if (setupResult.kind === "cancelled") {
-          process.exit(0);
-        }
-        // After setup, restart main flow
-        return main();
       }
     } else {
       markMilestone("CREDENTIALS_VALIDATED");
@@ -1491,22 +1489,6 @@ async function main(): Promise<void> {
   }
 
   markMilestone("TUI_MODE_START");
-
-  // Terminal preflight must happen before Ink takes over stdin, but it should
-  // not sit on the critical path while React/Ink/App modules are loading. This
-  // mirrors other TUIs: issue terminal queries early, then rendezvous before
-  // render so stdin ownership is clean.
-  const terminalPreflightPromise = (async () => {
-    await terminalThemePromise;
-    try {
-      const { detectAndEnableKittyProtocol } = await import(
-        "@/cli/utils/kitty-protocol-detector"
-      );
-      await detectAndEnableKittyProtocol();
-    } catch {
-      // Best-effort: if this fails, the app still runs (Option+Enter remains supported).
-    }
-  })();
 
   // Interactive: lazy-load React/Ink + App
   markMilestone("REACT_IMPORT_START");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1291,76 +1291,67 @@ async function main(): Promise<void> {
       baseURL === LETTA_CLOUD_API_URL || Boolean(apiKey);
 
     if (shouldValidateCredentials) {
-      const validateCredentialsAndMaybeRefresh = async () => {
-        const { validateCredentialsWithResult } = await import("@/auth/oauth");
-        let credentialValidation = await validateCredentialsWithResult(
-          baseURL,
-          apiKey ?? "",
-        );
+      // Validate credentials by checking an authenticated endpoint. Startups
+      // that use API credentials should preserve targeted invalid-key/network
+      // handling; the terminal preflight above already runs in parallel with
+      // this request, so most of the cost is hidden in interactive mode.
+      const { validateCredentialsWithResult } = await import("@/auth/oauth");
+      let credentialValidation = await validateCredentialsWithResult(
+        baseURL,
+        apiKey ?? "",
+      );
+      let isValid = credentialValidation.ok;
 
-        if (
-          !credentialValidation.ok &&
-          !process.env.LETTA_API_KEY &&
-          baseURL === LETTA_CLOUD_API_URL &&
-          settings.refreshToken
-        ) {
-          const refreshedApiKey = await refreshStartupOAuthToken(settings);
-          if (refreshedApiKey) {
-            apiKey = refreshedApiKey;
-            credentialValidation = await validateCredentialsWithResult(
-              baseURL,
-              apiKey,
-            );
-          }
+      if (
+        !isValid &&
+        !process.env.LETTA_API_KEY &&
+        baseURL === LETTA_CLOUD_API_URL &&
+        settings.refreshToken
+      ) {
+        const refreshedApiKey = await refreshStartupOAuthToken(settings);
+        if (refreshedApiKey) {
+          apiKey = refreshedApiKey;
+          credentialValidation = await validateCredentialsWithResult(
+            baseURL,
+            apiKey,
+          );
+          isValid = credentialValidation.ok;
         }
+      }
+      markMilestone("CREDENTIALS_VALIDATED");
 
-        return credentialValidation;
-      };
-
-      if (!isHeadless) {
-        // Interactive startup should not wait on an extra validation request.
-        // The real API calls below will naturally surface auth/network issues;
-        // this background check only preserves the old diagnostics/bootstrap path.
-        markMilestone("CREDENTIALS_VALIDATION_DEFERRED");
-        void validateCredentialsAndMaybeRefresh()
-          .then(async (credentialValidation) => {
-            markMilestone("CREDENTIALS_VALIDATED");
-            if (!credentialValidation.ok) {
-              debugWarn(
-                "startup",
-                `Deferred credential validation failed for ${baseURL}: ${credentialValidation.message}`,
-              );
-              return;
-            }
-
-            const { bootstrapBaseToolsIfNeeded } = await import(
-              "@/agent/bootstrap-tools"
-            );
-            await bootstrapBaseToolsIfNeeded();
-          })
-          .catch((error) => {
+      // Ensure base tools exist on the server (first-run-per-machine,
+      // backgrounded for interactive startup). Must run after credentials are
+      // validated so OAuth tokens are available.
+      if (isValid) {
+        const bootstrapPromise = import("@/agent/bootstrap-tools").then(
+          ({ bootstrapBaseToolsIfNeeded }) => bootstrapBaseToolsIfNeeded(),
+        );
+        if (isHeadless) {
+          await bootstrapPromise;
+        } else {
+          void bootstrapPromise.catch((error) => {
             debugWarn(
               "startup",
-              `Deferred credential validation failed for ${baseURL}: ${error instanceof Error ? error.message : String(error)}`,
+              `Failed to bootstrap base tools: ${error instanceof Error ? error.message : String(error)}`,
             );
           });
-      } else {
-        const credentialValidation = await validateCredentialsAndMaybeRefresh();
-        markMilestone("CREDENTIALS_VALIDATED");
+        }
+      }
 
-        if (credentialValidation.ok) {
-          const { bootstrapBaseToolsIfNeeded } = await import(
-            "@/agent/bootstrap-tools"
-          );
-          await bootstrapBaseToolsIfNeeded();
-        } else {
+      if (!isValid) {
+        const validationFailure = credentialValidation.ok
+          ? null
+          : credentialValidation;
+
+        if (isHeadless) {
           console.error("Failed to connect to Letta server");
           console.error(`Base URL: ${baseURL}`);
           console.error(
             "Your credentials may be invalid or the server may be unreachable.",
           );
-          if (credentialValidation.message) {
-            console.error(`Details: ${credentialValidation.message}`);
+          if (validationFailure?.message) {
+            console.error(`Details: ${validationFailure.message}`);
           }
           if (process.env.LETTA_API_KEY) {
             console.error(
@@ -1371,6 +1362,45 @@ async function main(): Promise<void> {
           }
           process.exit(1);
         }
+
+        console.log("Failed to connect to Letta server.");
+        console.log(`Base URL: ${baseURL}\n`);
+        console.log(
+          "Your credentials may be invalid or the server may be unreachable.",
+        );
+        if (process.env.LETTA_API_KEY) {
+          console.log(
+            "LETTA_API_KEY is set in your environment, so setup cannot replace the credential Letta Code is using.",
+          );
+          console.log(
+            "Unset LETTA_API_KEY or update it with a valid API key, then run `letta` again.",
+          );
+          process.exit(1);
+        }
+
+        if (
+          validationFailure?.reason === "network_error" ||
+          validationFailure?.reason === "server_unreachable"
+        ) {
+          if (validationFailure.message) {
+            console.log(`Details: ${validationFailure.message}`);
+          }
+          console.log(
+            "Setup cannot fix a server reachability problem. Check your network or try again later.",
+          );
+          process.exit(1);
+        }
+
+        console.log("Let's reauthenticate your setup.\n");
+        const { runSetup } = await import("@/auth/setup");
+        const setupResult = await runSetup({
+          initialMode: baseURL === LETTA_CLOUD_API_URL ? "device-code" : "menu",
+        });
+        if (setupResult.kind === "cancelled") {
+          process.exit(0);
+        }
+        // After setup, restart main flow
+        return main();
       }
     } else {
       markMilestone("CREDENTIALS_VALIDATED");

--- a/src/settings-manager.test.ts
+++ b/src/settings-manager.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { CommandHookConfig, HookCommand } from "@/hooks/types";
@@ -645,6 +645,40 @@ describe("Settings Manager - Multiple Projects", () => {
 
     expect(settings1.windowTitle?.items).toEqual(["agent-name"]);
     expect(settings2.windowTitle?.items).toEqual(["model-name"]);
+  });
+});
+
+describe("Settings Manager - Session Persistence", () => {
+  test("persistSession skips unchanged session writes", async () => {
+    await settingsManager.initialize();
+    await settingsManager.loadLocalProjectSettings(testProjectDir);
+
+    settingsManager.persistSession(
+      "agent-session",
+      "conv-session",
+      testProjectDir,
+    );
+    await settingsManager.flush();
+
+    const globalSettingsPath = join(testHomeDir, ".letta", "settings.json");
+    const localSettingsPath = join(
+      testProjectDir,
+      ".letta",
+      "settings.local.json",
+    );
+    const firstGlobalMtime = (await stat(globalSettingsPath)).mtimeMs;
+    const firstLocalMtime = (await stat(localSettingsPath)).mtimeMs;
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    settingsManager.persistSession(
+      "agent-session",
+      "conv-session",
+      testProjectDir,
+    );
+    await settingsManager.flush();
+
+    expect((await stat(globalSettingsPath)).mtimeMs).toBe(firstGlobalMtime);
+    expect((await stat(localSettingsPath)).mtimeMs).toBe(firstLocalMtime);
   });
 });
 

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -226,6 +226,13 @@ function isSessionCompatibleWithServerKey(
   return isAgentIdCompatibleWithServerKey(session.agentId, serverKey);
 }
 
+function sessionsEqual(
+  a: SessionRef | null | undefined,
+  b: SessionRef | null | undefined,
+): boolean {
+  return a?.agentId === b?.agentId && a?.conversationId === b?.conversationId;
+}
+
 function shouldSkipLegacyLocalBackendSessionFallback(): boolean {
   return (
     isLocalBackendEnvEnabled() &&
@@ -1226,8 +1233,17 @@ class SettingsManager {
       [serverKey]: session,
     };
 
+    const existingServerSession = settings.sessionsByServer?.[serverKey];
+
     // Keep legacy global fields for cloud/self-hosted agents only.
     if (isCloudAgentId(session.agentId)) {
+      if (
+        sessionsEqual(existingServerSession, session) &&
+        sessionsEqual(settings.lastSession, session) &&
+        settings.lastAgent === session.agentId
+      ) {
+        return;
+      }
       this.updateSettings({
         sessionsByServer,
         lastSession: session,
@@ -1236,6 +1252,9 @@ class SettingsManager {
       return;
     }
 
+    if (sessionsEqual(existingServerSession, session)) {
+      return;
+    }
     this.updateSettings({ sessionsByServer });
   }
 
@@ -1351,6 +1370,14 @@ class SettingsManager {
       ...localSettings.sessionsByServer,
       [serverKey]: session,
     };
+
+    if (
+      sessionsEqual(localSettings.sessionsByServer?.[serverKey], session) &&
+      sessionsEqual(localSettings.lastSession, session) &&
+      localSettings.lastAgent === session.agentId
+    ) {
+      return;
+    }
 
     // Also update legacy fields for backwards compat with older CLI versions
     this.updateLocalProjectSettings(


### PR DESCRIPTION
## Summary
- Keep local disk-backed resume off the model discovery critical path by backgrounding local `backend.listModels()` startup hints.
- Avoid redundant startup settings writes by skipping unchanged session persistence and removing the extra early `lastAgent` write.
- Overlap terminal theme and Kitty preflight probes with React/Ink/App imports while still completing them before Ink render.

## Test plan
- [x] `bun test src/settings-manager.test.ts`
- [x] `bun run typecheck`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)