### PR TITLE
refactor(extensions): rename runtime layer to adapter

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -58,9 +58,9 @@ import type { ModelSelectorSelection } from "@/cli/components/ModelSelector";
 import { buildStatuslineRenderContext } from "@/cli/display/statusline/context";
 import type { ExtensionConversationCloseReason } from "@/cli/extensions/types";
 import {
-  type LocalExtensionRuntime,
-  useLocalExtensionRuntime,
-} from "@/cli/extensions/use-local-extension-runtime";
+  type LocalExtensionAdapter,
+  useLocalExtensionAdapter,
+} from "@/cli/extensions/use-local-extension-adapter";
 import {
   appendStreamingOutput,
   type Buffers,
@@ -1027,7 +1027,7 @@ export function App({
   const sessionStartTimeRef = useRef(Date.now());
   const sessionHooksRanRef = useRef(false);
   const sessionExtensionStartAttemptedRef = useRef(false);
-  const extensionRuntimeRef = useRef<LocalExtensionRuntime | null>(null);
+  const extensionAdapterRef = useRef<LocalExtensionAdapter | null>(null);
 
   // Initialize chunk log for this agent + session (clears buffer, GCs old files).
   // Re-runs when agentId changes (e.g. agent switch via /agents).
@@ -1143,14 +1143,14 @@ export function App({
         // Silently ignore hook errors
       }
 
-      const extensionRuntime = extensionRuntimeRef.current;
+      const extensionAdapter = extensionAdapterRef.current;
       if (
-        extensionRuntime &&
-        !extensionRuntime.isLoading &&
-        extensionRuntime.hasExtensionSources
+        extensionAdapter &&
+        !extensionAdapter.isLoading &&
+        extensionAdapter.hasExtensionSources
       ) {
         try {
-          await extensionRuntime.emitEvent("conversation_close", {
+          await extensionAdapter.emitEvent("conversation_close", {
             agentId: agentIdRef.current ?? null,
             conversationId: conversationIdRef.current ?? null,
             durationMs,
@@ -1591,7 +1591,7 @@ export function App({
           conversationId: conversationIdRef.current,
           overrideModel: desiredModel,
           workingDirectory,
-          extensionEventEmitter: extensionRuntimeRef.current?.eventEmitter,
+          extensionEventEmitter: extensionAdapterRef.current?.eventEmitter,
         });
       }
 
@@ -1599,7 +1599,7 @@ export function App({
         return prepareToolExecutionContextForResolvedTarget({
           modelIdentifier: desiredModel,
           conversationId: conversationIdRef.current,
-          extensionEventEmitter: extensionRuntimeRef.current?.eventEmitter,
+          extensionEventEmitter: extensionAdapterRef.current?.eventEmitter,
           toolsetPreference: currentToolsetPreference,
           workingDirectory,
         });
@@ -1608,7 +1608,7 @@ export function App({
       return prepareToolExecutionContextForResolvedTarget({
         modelIdentifier: null,
         conversationId: conversationIdRef.current,
-        extensionEventEmitter: extensionRuntimeRef.current?.eventEmitter,
+        extensionEventEmitter: extensionAdapterRef.current?.eventEmitter,
         toolsetPreference: currentToolsetPreference,
         workingDirectory,
       });
@@ -2313,28 +2313,28 @@ export function App({
       statusLinePayload,
     ],
   );
-  const extensionRuntime = useLocalExtensionRuntime(extensionContext, {
+  const extensionAdapter = useLocalExtensionAdapter(extensionContext, {
     disabled: extensionsDisabled,
   });
 
   useEffect(() => {
-    extensionRuntimeRef.current = extensionRuntime;
-  }, [extensionRuntime]);
+    extensionAdapterRef.current = extensionAdapter;
+  }, [extensionAdapter]);
 
   useEffect(() => {
     if (!agentId || agentId === "loading") return;
     if (sessionExtensionStartAttemptedRef.current) return;
-    if (extensionRuntime.isLoading) return;
-    if (!extensionRuntime.hasExtensionSources) return;
+    if (extensionAdapter.isLoading) return;
+    if (!extensionAdapter.hasExtensionSources) return;
 
     sessionExtensionStartAttemptedRef.current = true;
-    void extensionRuntime.emitEvent("conversation_open", {
+    void extensionAdapter.emitEvent("conversation_open", {
       agentId,
       agentName: agentName ?? null,
       conversationId: conversationIdRef.current ?? null,
       reason: "startup",
     });
-  }, [agentId, agentName, extensionRuntime]);
+  }, [agentId, agentName, extensionAdapter]);
 
   // Keep buffers in sync with agentId for server-side tool hooks
   useEffect(() => {
@@ -3136,7 +3136,7 @@ export function App({
       });
     };
 
-    if (!extensionRuntime.isLoading) {
+    if (!extensionAdapter.isLoading) {
       refreshAgentFromRegisteredProviderMetadata();
     }
 
@@ -3149,7 +3149,7 @@ export function App({
     };
   }, [
     agentId,
-    extensionRuntime.isLoading,
+    extensionAdapter.isLoading,
     hasConversationModelOverrideRef,
     isLocalBackend,
     loadingState,
@@ -3626,7 +3626,7 @@ export function App({
     emptyResponseRetriesRef,
     executingToolCallIdsRef,
     generateConversationDescription,
-    extensionRuntime,
+    extensionAdapter,
     generateConversationTitle,
     hasConversationModelOverrideRef,
     interruptQueuedRef,
@@ -3945,7 +3945,7 @@ export function App({
     currentModelHandle,
     currentModelId,
     emittedIdsRef,
-    extensionRuntime,
+    extensionAdapter,
     hasBackfilledRef,
     isAgentBusy,
     maybeCarryOverActiveConversationModel,
@@ -4034,7 +4034,7 @@ export function App({
     currentModelProvider,
     effectiveContextWindowSize,
     emittedIdsRef,
-    extensionRuntime,
+    extensionAdapter,
     firstUserQueryRef,
     flushPendingReasoningEffort: () => flushPendingReasoningEffort(),
     generateConversationDescription,
@@ -4906,7 +4906,7 @@ export function App({
       staticRenderEpoch={staticRenderEpoch}
       statusLinePayload={statusLinePayload}
       statusLinePrompt={CLI_GLYPHS.prompt}
-      extensionRuntime={extensionRuntime}
+      extensionAdapter={extensionAdapter}
       streaming={streaming}
       stubDescriptions={stubDescriptions}
       thinkingMessage={thinkingMessage}

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -57,7 +57,7 @@ import { WelcomeScreen } from "@/cli/components/WelcomeScreen";
 import { WindowTitlePicker } from "@/cli/components/WindowTitlePicker";
 import { WorktreeDiffSelector } from "@/cli/components/WorktreeDiffSelector";
 import { AnimationProvider } from "@/cli/contexts/AnimationContext";
-import type { LocalExtensionRuntime } from "@/cli/extensions/use-local-extension-runtime";
+import type { LocalExtensionAdapter } from "@/cli/extensions/use-local-extension-adapter";
 import { type Buffers, type Line, toLines } from "@/cli/helpers/accumulator";
 import { backfillBuffers } from "@/cli/helpers/backfill";
 import {
@@ -319,7 +319,7 @@ type AppViewProps = {
   staticRenderEpoch: number;
   statusLinePayload: StatusLinePayload;
   statusLinePrompt: string;
-  extensionRuntime: LocalExtensionRuntime;
+  extensionAdapter: LocalExtensionAdapter;
   fileAutocompleteFdPath?: string | null;
   streaming: boolean;
   stubDescriptions: Map<string, string>;
@@ -465,7 +465,7 @@ export function AppView(props: AppViewProps) {
     staticRenderEpoch,
     statusLinePayload,
     statusLinePrompt,
-    extensionRuntime,
+    extensionAdapter,
     streaming,
     stubDescriptions,
     thinkingMessage,
@@ -746,7 +746,7 @@ export function AppView(props: AppViewProps) {
                 terminalWidth={chromeColumns}
                 shouldAnimate={shouldAnimate}
                 statusLinePayload={statusLinePayload}
-                extensionRuntime={extensionRuntime}
+                extensionAdapter={extensionAdapter}
                 statusLinePrompt={statusLinePrompt}
                 footerNotification={footerUpdateText}
                 showInspirationalPromptHints={showInspirationalPromptHints}

--- a/src/cli/app/use-conversation-loop.ts
+++ b/src/cli/app/use-conversation-loop.ts
@@ -40,7 +40,7 @@ import {
   hasActiveSubagents,
 } from "@/agent/subagent-state";
 import { type ConversationMessageStreamBody, getBackend } from "@/backend";
-import type { LocalExtensionRuntime } from "@/cli/extensions/use-local-extension-runtime";
+import type { LocalExtensionAdapter } from "@/cli/extensions/use-local-extension-adapter";
 import {
   type Buffers,
   type Line,
@@ -201,7 +201,7 @@ type ConversationLoopContext = {
   generateConversationDescription: (options?: {
     force?: boolean;
   }) => Promise<void>;
-  extensionRuntime: LocalExtensionRuntime;
+  extensionAdapter: LocalExtensionAdapter;
   generateConversationTitle: () => Promise<string | null>;
   hasConversationModelOverrideRef: MutableRefObject<boolean>;
   interruptQueuedRef: MutableRefObject<boolean>;
@@ -299,7 +299,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
     emptyResponseRetriesRef,
     executingToolCallIdsRef,
     generateConversationDescription,
-    extensionRuntime,
+    extensionAdapter,
     generateConversationTitle,
     hasConversationModelOverrideRef,
     interruptQueuedRef,
@@ -632,8 +632,8 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
 
       if (
         hasUserMessageInput(currentInput) &&
-        extensionRuntime.hasExtensionSources &&
-        !extensionRuntime.isLoading
+        extensionAdapter.hasExtensionSources &&
+        !extensionAdapter.isLoading
       ) {
         const originalInput = currentInput;
         try {
@@ -642,7 +642,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
             conversationId: conversationIdRef.current ?? null,
             input: currentInput,
           };
-          await extensionRuntime.emitEvent("turn_start", turnStartEvent);
+          await extensionAdapter.emitEvent("turn_start", turnStartEvent);
           currentInput = isTurnInputArray(turnStartEvent.input)
             ? turnStartEvent.input
             : originalInput;
@@ -2985,7 +2985,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
       setUiPermissionMode,
       prepareScopedToolExecutionContext,
       maybeStreamSyntheticNoModelResponse,
-      extensionRuntime,
+      extensionAdapter,
     ],
   );
 

--- a/src/cli/app/use-conversation-switching.ts
+++ b/src/cli/app/use-conversation-switching.ts
@@ -33,7 +33,7 @@ import {
 import { getServerUrl } from "@/backend/api/client";
 import type { BtwState } from "@/cli/components/BtwPane";
 import type { ExtensionConversationCloseReason } from "@/cli/extensions/types";
-import type { LocalExtensionRuntime } from "@/cli/extensions/use-local-extension-runtime";
+import type { LocalExtensionAdapter } from "@/cli/extensions/use-local-extension-adapter";
 import {
   type Buffers,
   extractTextPart,
@@ -82,7 +82,7 @@ type ConversationSwitchingContext = {
   currentModelHandle: string | null;
   currentModelId: string | null;
   emittedIdsRef: MutableRefObject<Set<string>>;
-  extensionRuntime: LocalExtensionRuntime;
+  extensionAdapter: LocalExtensionAdapter;
   hasBackfilledRef: MutableRefObject<boolean>;
   isAgentBusy: () => boolean;
   maybeCarryOverActiveConversationModel: (
@@ -141,7 +141,7 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
     currentModelHandle,
     currentModelId,
     emittedIdsRef,
-    extensionRuntime,
+    extensionAdapter,
     hasBackfilledRef,
     isAgentBusy,
     maybeCarryOverActiveConversationModel,
@@ -434,7 +434,7 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
           })
           .catch(() => {});
         sessionHooksRanRef.current = true;
-        void extensionRuntime.emitEvent("conversation_open", {
+        void extensionAdapter.emitEvent("conversation_open", {
           agentId,
           agentName: agentName ?? null,
           conversationId,
@@ -468,7 +468,7 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
       setCommandRunning,
       setStreaming,
       recoverRestoredPendingApprovals,
-      extensionRuntime,
+      extensionAdapter,
       resetDeferredToolCallCommits,
       resetTrajectoryBases,
       abortControllerRef,

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -53,7 +53,7 @@ import type {
   ExtensionCommandContext,
   ExtensionConversationCloseReason,
 } from "@/cli/extensions/types";
-import type { LocalExtensionRuntime } from "@/cli/extensions/use-local-extension-runtime";
+import type { LocalExtensionAdapter } from "@/cli/extensions/use-local-extension-adapter";
 import { type Buffers, type Line, toLines } from "@/cli/helpers/accumulator";
 import { buildChatUrl, isLocalAgentId } from "@/cli/helpers/app-urls";
 import {
@@ -204,7 +204,7 @@ type SubmitHandlerContext = {
   currentModelProvider: string | null;
   effectiveContextWindowSize: number | undefined;
   emittedIdsRef: MutableRefObject<Set<string>>;
-  extensionRuntime: LocalExtensionRuntime;
+  extensionAdapter: LocalExtensionAdapter;
   firstUserQueryRef: MutableRefObject<string | null>;
   flushPendingReasoningEffort: () => Promise<void>;
   generateConversationDescription: (options?: {
@@ -349,7 +349,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
     currentModelProvider,
     effectiveContextWindowSize,
     emittedIdsRef,
-    extensionRuntime,
+    extensionAdapter,
     firstUserQueryRef,
     flushPendingReasoningEffort,
     generateConversationDescription,
@@ -579,7 +579,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
         ? parseExtensionSlashCommand(userTextForInput.trim())
         : null;
       const queueBypassExtensionCommand = parsedExtensionCommand
-        ? extensionRuntime.registry?.commands[parsedExtensionCommand.command]
+        ? extensionAdapter.registry?.commands[parsedExtensionCommand.command]
         : undefined;
       const isExtensionCommandShadowedByCustom =
         isAgentBusy() && queueBypassExtensionCommand?.runWhenBusy === true
@@ -1465,7 +1465,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               })
               .catch(() => {});
             sessionHooksRanRef.current = true;
-            void extensionRuntime.emitEvent("conversation_open", {
+            void extensionAdapter.emitEvent("conversation_open", {
               agentId,
               agentName: agentName ?? null,
               conversationId: conversation.id,
@@ -1563,7 +1563,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               })
               .catch(() => {});
             sessionHooksRanRef.current = true;
-            void extensionRuntime.emitEvent("conversation_open", {
+            void extensionAdapter.emitEvent("conversation_open", {
               agentId,
               agentName: agentName ?? null,
               conversationId: forked.id,
@@ -1679,7 +1679,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               })
               .catch(() => {});
             sessionHooksRanRef.current = true;
-            void extensionRuntime.emitEvent("conversation_open", {
+            void extensionAdapter.emitEvent("conversation_open", {
               agentId,
               agentName: agentName ?? null,
               conversationId: conversation.id,
@@ -3053,7 +3053,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
 
         const matchedExtensionCommand: ExtensionCommand | undefined =
           parsedExtensionCommand
-            ? extensionRuntime.registry?.commands[
+            ? extensionAdapter.registry?.commands[
                 parsedExtensionCommand.command
               ]
             : undefined;
@@ -3078,11 +3078,11 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           }
 
           try {
-            const extensionContext = extensionRuntime.getContext();
+            const extensionContext = extensionAdapter.getContext();
             const cwd = getCurrentWorkingDirectory();
             const conversation = createExtensionConversationHandle({
               agentId,
-              backend: extensionRuntime.getBackendApi(),
+              backend: extensionAdapter.getBackendApi(),
               conversationId: conversationIdRef.current,
               workingDirectory: cwd,
             });
@@ -3093,7 +3093,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               command: parsedExtensionCommand.command,
               conversation: { ...conversation, id: conversationIdRef.current },
               cwd,
-              getContext: extensionRuntime.getContext,
+              getContext: extensionAdapter.getContext,
               model: {
                 id:
                   currentModelId ??
@@ -3522,7 +3522,7 @@ ${SYSTEM_REMINDER_CLOSE}
       conversationId,
       currentModelHandle,
       currentModelId,
-      extensionRuntime,
+      extensionAdapter,
       effectiveContextWindowSize,
       commandRunner,
       handleExit,

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -24,7 +24,7 @@ import {
 } from "@/cli/display/statusline/registry";
 import { buildDefaultStatuslineParts } from "@/cli/display/statusline/renderers/Default";
 import { evaluateLocalExtensionStatuses } from "@/cli/extensions/local-extension-loader";
-import type { LocalExtensionRuntime } from "@/cli/extensions/use-local-extension-runtime";
+import type { LocalExtensionAdapter } from "@/cli/extensions/use-local-extension-adapter";
 import { bytesToTokens, formatCompact } from "@/cli/helpers/format";
 import { CLI_GLYPHS } from "@/cli/helpers/glyphs";
 import { formatGoalStatusIndicator } from "@/cli/helpers/goal-command";
@@ -458,7 +458,7 @@ const StatuslineSlot = memo(function StatuslineSlot({
   hideFooter,
   rightColumnWidth,
   statusLinePayload,
-  extensionRuntime,
+  extensionAdapter,
   transientHint,
 }: {
   ctrlCPressed: boolean;
@@ -476,7 +476,7 @@ const StatuslineSlot = memo(function StatuslineSlot({
   hideFooter: boolean;
   rightColumnWidth: number;
   statusLinePayload: StatusLinePayload;
-  extensionRuntime: LocalExtensionRuntime;
+  extensionAdapter: LocalExtensionAdapter;
   transientHint?: StatuslineTransientHint | null;
 }) {
   const hideFooterContent = hideFooter;
@@ -501,21 +501,21 @@ const StatuslineSlot = memo(function StatuslineSlot({
   const statuslineContext = {
     ...baseStatuslineContext,
     statuses: evaluateLocalExtensionStatuses(
-      extensionRuntime.registry,
+      extensionAdapter.registry,
       baseStatuslineContext,
     ),
   };
-  extensionRuntime.updateContext(statuslineContext);
+  extensionAdapter.updateContext(statuslineContext);
 
   const builtInStatuslineRenderer = getBuiltinStatuslineRenderer(
     DEFAULT_STATUSLINE_RENDERER_ID,
   );
   const localStatuslineRenderer =
-    extensionRuntime.registry?.ui.statuslineRenderer ?? null;
+    extensionAdapter.registry?.ui.statuslineRenderer ?? null;
   const extensionStatuslineLoading =
-    extensionRuntime.isLoading &&
-    (extensionRuntime.hasExtensionSources ||
-      extensionRuntime.hadStatuslineRenderer);
+    extensionAdapter.isLoading &&
+    (extensionAdapter.hasExtensionSources ||
+      extensionAdapter.hadStatuslineRenderer);
   const customStatuslineActive = Boolean(
     localStatuslineRenderer || extensionStatuslineLoading,
   );
@@ -929,7 +929,7 @@ export function Input({
   terminalWidth,
   shouldAnimate = true,
   statusLinePayload,
-  extensionRuntime,
+  extensionAdapter,
   statusLinePrompt,
   onCycleReasoningEffort,
   footerNotification,
@@ -982,7 +982,7 @@ export function Input({
   terminalWidth: number;
   shouldAnimate?: boolean;
   statusLinePayload: StatusLinePayload;
-  extensionRuntime: LocalExtensionRuntime;
+  extensionAdapter: LocalExtensionAdapter;
   statusLinePrompt?: string;
   onCycleReasoningEffort?: () => void;
   footerNotification?: string | null;
@@ -1929,7 +1929,7 @@ export function Input({
           <Box flexDirection="column">
             {!suppressDividers && (
               <ExtensionPanelRow
-                panels={extensionRuntime.registry?.ui.panels}
+                panels={extensionAdapter.registry?.ui.panels}
                 terminalWidth={terminalWidth}
               />
             )}
@@ -2012,7 +2012,7 @@ export function Input({
                 serverUrl={serverUrl}
                 workingDirectory={process.cwd()}
                 conversationId={conversationId}
-                extensionCommands={extensionRuntime.registry?.commands}
+                extensionCommands={extensionAdapter.registry?.commands}
               />
             )}
 
@@ -2038,7 +2038,7 @@ export function Input({
                 hideFooter={hideFooter}
                 rightColumnWidth={footerRightColumnWidth}
                 statusLinePayload={statusLinePayload}
-                extensionRuntime={extensionRuntime}
+                extensionAdapter={extensionAdapter}
                 transientHint={statuslineTransientHint}
               />
             )}
@@ -2087,7 +2087,7 @@ export function Input({
     reserveInputSpace,
     inputChromeHeight,
     statusLinePayload,
-    extensionRuntime,
+    extensionAdapter,
 
     goalStatusText,
     promptChar,

--- a/src/cli/extensions/local-extension-loader.ts
+++ b/src/cli/extensions/local-extension-loader.ts
@@ -1,4 +1,6 @@
 import { commands as builtinCommands } from "@/cli/commands/registry";
+import type { CreateExtensionAdapterOptions } from "@/extensions/extension-adapter";
+import { createExtensionAdapter as createExtensionAdapterBase } from "@/extensions/extension-adapter";
 import type {
   CreateExtensionHostOptions,
   LoadLocalExtensionsOptions,
@@ -13,8 +15,6 @@ import {
   loadLocalExtensions as loadLocalExtensionsBase,
   resolveLocalExtensionSources,
 } from "@/extensions/extension-host";
-import type { CreateExtensionRuntimeOptions } from "@/extensions/extension-runtime";
-import { createExtensionRuntime as createExtensionRuntimeBase } from "@/extensions/extension-runtime";
 import type { ExtensionCapabilities } from "@/extensions/types";
 import { getAllLettaToolNames, getServerToolName } from "@/tools/manager";
 import { TUI_EXTENSION_CAPABILITIES } from "./capabilities";
@@ -61,8 +61,8 @@ export function createExtensionHost(options: CreateExtensionHostOptions) {
   return createExtensionHostBase(withDefaultReservations(options));
 }
 
-export function createExtensionRuntime(options: CreateExtensionRuntimeOptions) {
-  return createExtensionRuntimeBase(withDefaultReservations(options));
+export function createExtensionAdapter(options: CreateExtensionAdapterOptions) {
+  return createExtensionAdapterBase(withDefaultReservations(options));
 }
 
 export function loadLocalExtensions(options: LoadLocalExtensionsOptions) {
@@ -79,6 +79,12 @@ export {
 };
 
 export type {
+  CreateExtensionAdapterOptions,
+  ExtensionAdapter,
+  ExtensionAdapterLoadState,
+  ExtensionAdapterSnapshot,
+} from "@/extensions/extension-adapter";
+export type {
   CreateExtensionHostOptions,
   ExtensionHost,
   ExtensionStatusValue,
@@ -94,10 +100,4 @@ export type {
   ResolveLocalExtensionSourcesOptions,
   StatuslineRenderFunction,
 } from "@/extensions/extension-host";
-export type {
-  CreateExtensionRuntimeOptions,
-  ExtensionRuntime,
-  ExtensionRuntimeLoadState,
-  ExtensionRuntimeSnapshot,
-} from "@/extensions/extension-runtime";
 export { TUI_EXTENSION_CAPABILITIES } from "./capabilities";

--- a/src/cli/extensions/use-local-extension-adapter.ts
+++ b/src/cli/extensions/use-local-extension-adapter.ts
@@ -3,11 +3,11 @@ import { sendMessageStreamWithBackend } from "@/agent/message";
 import { type Backend, getBackend } from "@/backend";
 import { getClient } from "@/backend/api/client";
 import { loadExtensionConversationHistoryFromBackend } from "@/extensions/conversation-history";
-import type { ExtensionRuntimeBackendApi } from "@/extensions/types";
+import type { ExtensionAdapterBackendApi } from "@/extensions/types";
 import {
-  createExtensionRuntime,
-  type ExtensionRuntime,
-  type ExtensionRuntimeSnapshot,
+  createExtensionAdapter,
+  type ExtensionAdapter,
+  type ExtensionAdapterSnapshot,
 } from "./local-extension-loader";
 import type {
   ExtensionContext,
@@ -16,26 +16,26 @@ import type {
   ExtensionEventName,
 } from "./types";
 
-export interface LocalExtensionRuntime {
+export interface LocalExtensionAdapter {
   emitEvent: <TName extends ExtensionEventName>(
     name: TName,
     event: ExtensionEventMap[TName],
   ) => Promise<ExtensionEventEmissionResult<TName>>;
-  eventEmitter: ExtensionRuntime["eventEmitter"];
-  getBackendApi: () => ExtensionRuntimeBackendApi | undefined;
+  eventEmitter: ExtensionAdapter["eventEmitter"];
+  getBackendApi: () => ExtensionAdapterBackendApi | undefined;
   getContext: () => ExtensionContext;
-  hadStatuslineRenderer: boolean;
+  hadStatuslineRenderer: boolean; // Used to prevent flicker on reload
   hasExtensionSources: boolean;
-  host: ExtensionRuntime["host"];
+  host: ExtensionAdapter["host"];
   isLoading: boolean;
-  registry: ExtensionRuntimeSnapshot["registry"];
+  registry: ExtensionAdapterSnapshot["registry"];
   reload: () => Promise<void>;
   updateContext: (context: ExtensionContext) => void;
 }
 
 function createExtensionBackendApi(
   backend: Backend,
-): ExtensionRuntimeBackendApi {
+): ExtensionAdapterBackendApi {
   return {
     forkConversation(conversationId, options) {
       return backend.forkConversation(conversationId, options);
@@ -62,14 +62,14 @@ function createExtensionBackendApi(
   };
 }
 
-export function useLocalExtensionRuntime(
+export function useLocalExtensionAdapter(
   initialContext: ExtensionContext,
   options: { disabled?: boolean } = {},
-): LocalExtensionRuntime {
-  // biome-ignore lint/correctness/useExhaustiveDependencies: the runtime is process-local; context updates are pushed through updateContext below.
-  const runtime = useMemo(
+): LocalExtensionAdapter {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the adapter is process-local; context updates are pushed through updateContext below.
+  const adapter = useMemo(
     () =>
-      createExtensionRuntime({
+      createExtensionAdapter({
         disabled: options.disabled,
         getBackendApi: () => createExtensionBackendApi(getBackend()),
         getClient,
@@ -79,37 +79,37 @@ export function useLocalExtensionRuntime(
   );
 
   const snapshot = useSyncExternalStore(
-    runtime.subscribe,
-    runtime.getSnapshot,
-    runtime.getSnapshot,
+    adapter.subscribe,
+    adapter.getSnapshot,
+    adapter.getSnapshot,
   );
 
   useEffect(() => {
-    runtime.updateContext(initialContext);
-  }, [initialContext, runtime]);
+    adapter.updateContext(initialContext);
+  }, [initialContext, adapter]);
 
   useEffect(() => {
-    void runtime.reload();
+    void adapter.reload();
 
     return () => {
-      runtime.dispose();
+      adapter.dispose();
     };
-  }, [runtime]);
+  }, [adapter]);
 
   return useMemo(
     () => ({
-      emitEvent: runtime.emitEvent,
-      eventEmitter: runtime.eventEmitter,
-      getBackendApi: runtime.getBackendApi,
-      getContext: runtime.getContext,
+      emitEvent: adapter.emitEvent,
+      eventEmitter: adapter.eventEmitter,
+      getBackendApi: adapter.getBackendApi,
+      getContext: adapter.getContext,
       hadStatuslineRenderer: snapshot.hadStatuslineRenderer,
       hasExtensionSources: snapshot.hasExtensionSources,
-      host: runtime.host,
+      host: adapter.host,
       isLoading: snapshot.isLoading,
       registry: snapshot.registry,
-      reload: runtime.reload,
-      updateContext: runtime.updateContext,
+      reload: adapter.reload,
+      updateContext: adapter.updateContext,
     }),
-    [runtime, snapshot],
+    [adapter, snapshot],
   );
 }

--- a/src/extensions/conversation-handle.ts
+++ b/src/extensions/conversation-handle.ts
@@ -1,11 +1,11 @@
 import type {
+  ExtensionAdapterBackendApi,
   ExtensionConversationHandle,
-  ExtensionRuntimeBackendApi,
 } from "@/extensions/types";
 
 export function createExtensionConversationHandle(options: {
   agentId?: string | null;
-  backend?: ExtensionRuntimeBackendApi;
+  backend?: ExtensionAdapterBackendApi;
   conversationId?: string | null;
   workingDirectory?: string | null;
 }): ExtensionConversationHandle {

--- a/src/extensions/event-emitter.ts
+++ b/src/extensions/event-emitter.ts
@@ -4,7 +4,7 @@ import type {
   ExtensionEventName,
 } from "@/extensions/types";
 
-export type ExtensionRuntimeEventSnapshot = {
+export type ExtensionAdapterEventSnapshot = {
   hasExtensionSources: boolean;
   isLoading: boolean;
 };
@@ -14,7 +14,7 @@ export type ExtensionEventEmitter = {
     name: TName,
     event: ExtensionEventMap[TName],
   ) => Promise<ExtensionEventEmissionResult<TName>>;
-  getSnapshot: () => ExtensionRuntimeEventSnapshot;
+  getSnapshot: () => ExtensionAdapterEventSnapshot;
 };
 
 export function emptyEventEmissionResult<TName extends ExtensionEventName>(

--- a/src/extensions/extension-adapter.test.ts
+++ b/src/extensions/extension-adapter.test.ts
@@ -10,24 +10,24 @@ import {
 } from "@/backend/dev/pi-provider-extension-registry";
 import { DISABLED_EXTENSION_CAPABILITIES } from "@/extensions/capabilities";
 import { LETTA_DISABLE_EXTENSIONS_ENV } from "@/extensions/disable";
-import { createExtensionRuntime } from "@/extensions/extension-runtime";
+import { createExtensionAdapter } from "@/extensions/extension-adapter";
 import {
   clearExtensionTools,
   getExtensionToolDefinition,
   registerExtensionTool,
 } from "@/extensions/tool-registry";
 import type {
+  ExtensionAdapterBackendApi,
   ExtensionContext,
-  ExtensionRuntimeBackendApi,
 } from "@/extensions/types";
 
-type ExtensionRuntimeTestGlobal = typeof globalThis & {
-  __lettaRuntimeEvents?: string[];
+type ExtensionAdapterTestGlobal = typeof globalThis & {
+  __lettaAdapterEvents?: string[];
   __lettaDisabledExtensionLoaded?: boolean;
 };
 
 function createTempDir(): string {
-  return mkdtempSync(path.join(tmpdir(), "letta-extension-runtime-"));
+  return mkdtempSync(path.join(tmpdir(), "letta-extension-adapter-"));
 }
 
 function createExtensionContext(agentName = "Amelia"): ExtensionContext {
@@ -74,21 +74,21 @@ function createExtensionContext(agentName = "Amelia"): ExtensionContext {
   };
 }
 
-describe("extension runtime", () => {
-  test("LETTA_DISABLE_EXTENSIONS disables the runtime", () => {
+describe("extension adapter", () => {
+  test("LETTA_DISABLE_EXTENSIONS disables the adapter", () => {
     const original = process.env[LETTA_DISABLE_EXTENSIONS_ENV];
     try {
       process.env[LETTA_DISABLE_EXTENSIONS_ENV] = "1";
-      const runtime = createExtensionRuntime({
+      const adapter = createExtensionAdapter({
         getClient: async () => ({}) as unknown as Letta,
         initialContext: createExtensionContext(),
       });
 
-      expect(runtime.getSnapshot()).toMatchObject({
+      expect(adapter.getSnapshot()).toMatchObject({
         hasExtensionSources: false,
         isLoading: false,
       });
-      expect(runtime.getSnapshot().registry.capabilities).toEqual(
+      expect(adapter.getSnapshot().registry.capabilities).toEqual(
         DISABLED_EXTENSION_CAPABILITIES,
       );
     } finally {
@@ -100,9 +100,9 @@ describe("extension runtime", () => {
     }
   });
 
-  test("disabled runtime does not load extensions or expose extension capabilities", async () => {
+  test("disabled adapter does not load extensions or expose extension capabilities", async () => {
     const root = createTempDir();
-    const testGlobal = globalThis as ExtensionRuntimeTestGlobal;
+    const testGlobal = globalThis as ExtensionAdapterTestGlobal;
     const originalDisableEnv = process.env[LETTA_DISABLE_EXTENSIONS_ENV];
 
     try {
@@ -169,7 +169,7 @@ describe("extension runtime", () => {
         ],
       });
 
-      const runtime = createExtensionRuntime({
+      const adapter = createExtensionAdapter({
         cacheDirectory: path.join(root, "extension-cache"),
         disabled: true,
         getClient: async () => {
@@ -199,18 +199,18 @@ describe("extension runtime", () => {
         run: () => "post-disabled",
       });
 
-      expect(runtime.getSnapshot()).toMatchObject({
+      expect(adapter.getSnapshot()).toMatchObject({
         hadStatuslineRenderer: false,
         hasExtensionSources: false,
         isLoading: false,
       });
-      expect(runtime.getSnapshot().registry.capabilities).toEqual(
+      expect(adapter.getSnapshot().registry.capabilities).toEqual(
         DISABLED_EXTENSION_CAPABILITIES,
       );
-      expect(runtime.getSnapshot().registry.sources).toEqual([]);
+      expect(adapter.getSnapshot().registry.sources).toEqual([]);
 
-      await runtime.reload();
-      const result = await runtime.emitEvent("conversation_open", {
+      await adapter.reload();
+      const result = await adapter.emitEvent("conversation_open", {
         agentId: "agent-1",
         agentName: "Amelia",
         conversationId: "conversation-1",
@@ -219,11 +219,11 @@ describe("extension runtime", () => {
 
       expect(result.handlerCount).toBe(0);
       expect(testGlobal.__lettaDisabledExtensionLoaded).toBeUndefined();
-      expect(runtime.getSnapshot().registry.loadedPaths).toEqual([]);
-      expect(runtime.getSnapshot().registry.commands).toEqual({});
-      expect(runtime.getSnapshot().registry.tools).toEqual({});
-      expect(runtime.getSnapshot().registry.ui.panels).toEqual({});
-      expect(runtime.getSnapshot().registry.ui.statuslineRenderer).toBeNull();
+      expect(adapter.getSnapshot().registry.loadedPaths).toEqual([]);
+      expect(adapter.getSnapshot().registry.commands).toEqual({});
+      expect(adapter.getSnapshot().registry.tools).toEqual({});
+      expect(adapter.getSnapshot().registry.ui.panels).toEqual({});
+      expect(adapter.getSnapshot().registry.ui.statuslineRenderer).toBeNull();
       expect(
         getExtensionToolDefinition("stale_extension_tool"),
       ).toBeUndefined();
@@ -247,8 +247,8 @@ describe("extension runtime", () => {
 
   test("loads extensions and dispatches events with fresh context and backend", async () => {
     const root = createTempDir();
-    const testGlobal = globalThis as ExtensionRuntimeTestGlobal;
-    testGlobal.__lettaRuntimeEvents = [];
+    const testGlobal = globalThis as ExtensionAdapterTestGlobal;
+    testGlobal.__lettaAdapterEvents = [];
 
     try {
       const extensionDir = path.join(root, "global-extensions");
@@ -258,19 +258,19 @@ describe("extension runtime", () => {
         `export default function(letta) {
           letta.events.on("conversation_open", async (event, ctx) => {
             const fork = await ctx.conversation.fork({ hidden: true });
-            globalThis.__lettaRuntimeEvents.push(
+            globalThis.__lettaAdapterEvents.push(
               event.reason + ":" + ctx.context.agent.name + ":" + fork.id,
             );
           });
         }`,
       );
 
-      const backend: ExtensionRuntimeBackendApi = {
+      const backend: ExtensionAdapterBackendApi = {
         forkConversation: async () => ({ id: "forked-conversation" }),
         getConversationHistory: async () => [],
         sendMessageStream: async () => (async function* () {})(),
       };
-      const runtime = createExtensionRuntime({
+      const adapter = createExtensionAdapter({
         cacheDirectory: path.join(root, "extension-cache"),
         getBackendApi: () => backend,
         getClient: async () => ({}) as unknown as Letta,
@@ -278,35 +278,35 @@ describe("extension runtime", () => {
         initialContext: createExtensionContext(),
       });
 
-      expect(runtime.getSnapshot()).toMatchObject({
+      expect(adapter.getSnapshot()).toMatchObject({
         hasExtensionSources: true,
         isLoading: true,
       });
-      expect(runtime.getSnapshot()).toBe(runtime.getSnapshot());
+      expect(adapter.getSnapshot()).toBe(adapter.getSnapshot());
 
-      await runtime.reload();
-      runtime.updateContext(createExtensionContext("Updated Agent"));
+      await adapter.reload();
+      adapter.updateContext(createExtensionContext("Updated Agent"));
 
-      expect(runtime.getSnapshot()).toMatchObject({
+      expect(adapter.getSnapshot()).toMatchObject({
         hasExtensionSources: true,
         isLoading: false,
       });
-      expect(runtime.getSnapshot().registry.loadedPaths).toHaveLength(1);
+      expect(adapter.getSnapshot().registry.loadedPaths).toHaveLength(1);
 
-      await runtime.emitEvent("conversation_open", {
+      await adapter.emitEvent("conversation_open", {
         agentId: "agent-1",
         agentName: "Updated Agent",
         conversationId: "conversation-1",
         reason: "startup",
       });
 
-      expect(testGlobal.__lettaRuntimeEvents).toEqual([
+      expect(testGlobal.__lettaAdapterEvents).toEqual([
         "startup:Updated Agent:forked-conversation",
       ]);
 
-      runtime.dispose();
+      adapter.dispose();
     } finally {
-      delete testGlobal.__lettaRuntimeEvents;
+      delete testGlobal.__lettaAdapterEvents;
       rmSync(root, { force: true, recursive: true });
     }
   });

--- a/src/extensions/extension-adapter.ts
+++ b/src/extensions/extension-adapter.ts
@@ -21,28 +21,28 @@ import {
 } from "@/extensions/extension-host";
 import { clearExtensionTools } from "@/extensions/tool-registry";
 import type {
+  ExtensionAdapterBackendApi,
   ExtensionContext,
   ExtensionEventEmissionResult,
   ExtensionEventMap,
   ExtensionEventName,
-  ExtensionRuntimeBackendApi,
 } from "@/extensions/types";
 import { debugLog } from "@/utils/debug";
 
-export interface ExtensionRuntimeLoadState {
+export interface ExtensionAdapterLoadState {
   hadStatuslineRenderer: boolean;
   hasExtensionSources: boolean;
   isLoading: boolean;
 }
 
-export interface ExtensionRuntimeSnapshot extends ExtensionRuntimeLoadState {
+export interface ExtensionAdapterSnapshot extends ExtensionAdapterLoadState {
   registry: ReturnType<ExtensionHost["getSnapshot"]>;
 }
 
-export interface CreateExtensionRuntimeOptions
+export interface CreateExtensionAdapterOptions
   extends Omit<CreateExtensionHostOptions, "backend" | "getContext"> {
   disabled?: boolean;
-  getBackendApi?: () => ExtensionRuntimeBackendApi | undefined;
+  getBackendApi?: () => ExtensionAdapterBackendApi | undefined;
   getClient: () => Promise<Letta>;
   initialContext: ExtensionContext;
 }
@@ -90,16 +90,16 @@ function createDisabledExtensionHost(
   };
 }
 
-function createDisabledExtensionRuntime(
-  options: CreateExtensionRuntimeOptions,
-): ExtensionRuntime {
+function createDisabledExtensionAdapter(
+  options: CreateExtensionAdapterOptions,
+): ExtensionAdapter {
   clearExtensionTools();
   clearRegisteredPiProviders();
 
   let context = options.initialContext;
   const registry = createDisabledExtensionRegistry();
   const host = createDisabledExtensionHost(registry);
-  const snapshot: ExtensionRuntimeSnapshot = {
+  const snapshot: ExtensionAdapterSnapshot = {
     hadStatuslineRenderer: false,
     hasExtensionSources: false,
     isLoading: false,
@@ -142,16 +142,16 @@ function createDisabledExtensionRuntime(
   };
 }
 
-export interface ExtensionRuntime {
+export interface ExtensionAdapter {
   dispose: () => void;
   emitEvent: <TName extends ExtensionEventName>(
     name: TName,
     event: ExtensionEventMap[TName],
   ) => Promise<ExtensionEventEmissionResult<TName>>;
   eventEmitter: ExtensionEventEmitter;
-  getBackendApi: () => ExtensionRuntimeBackendApi | undefined;
+  getBackendApi: () => ExtensionAdapterBackendApi | undefined;
   getContext: () => ExtensionContext;
-  getSnapshot: () => ExtensionRuntimeSnapshot;
+  getSnapshot: () => ExtensionAdapterSnapshot;
   host: ExtensionHost;
   reload: () => Promise<void>;
   subscribe: (listener: () => void) => () => void;
@@ -160,7 +160,7 @@ export interface ExtensionRuntime {
 
 function hasExtensionSources(
   options: Pick<
-    CreateExtensionRuntimeOptions,
+    CreateExtensionAdapterOptions,
     "cacheDirectory" | "globalExtensionsDirectory"
   >,
 ): boolean {
@@ -169,9 +169,9 @@ function hasExtensionSources(
   );
 }
 
-function createLazyRuntimeBackendApi(
-  getBackendApi: () => ExtensionRuntimeBackendApi | undefined,
-): ExtensionRuntimeBackendApi {
+function createLazyAdapterBackendApi(
+  getBackendApi: () => ExtensionAdapterBackendApi | undefined,
+): ExtensionAdapterBackendApi {
   const requireBackend = () => {
     const backend = getBackendApi();
     if (!backend) {
@@ -198,15 +198,15 @@ function createLazyRuntimeBackendApi(
   };
 }
 
-export function createExtensionRuntime(
-  options: CreateExtensionRuntimeOptions,
-): ExtensionRuntime {
+export function createExtensionAdapter(
+  options: CreateExtensionAdapterOptions,
+): ExtensionAdapter {
   if (options.disabled) {
     disableExtensionsForProcess();
   }
 
   if (options.disabled || areExtensionsDisabled()) {
-    return createDisabledExtensionRuntime(options);
+    return createDisabledExtensionAdapter(options);
   }
 
   const {
@@ -217,7 +217,7 @@ export function createExtensionRuntime(
   let context = initialContext;
   let disposed = false;
   const initialHasExtensionSources = hasExtensionSources(hostOptions);
-  let loadState: ExtensionRuntimeLoadState = {
+  let loadState: ExtensionAdapterLoadState = {
     hadStatuslineRenderer: false,
     hasExtensionSources: initialHasExtensionSources,
     isLoading: initialHasExtensionSources,
@@ -227,7 +227,7 @@ export function createExtensionRuntime(
   const getBackendApi = () => resolveBackendApi?.();
   const getContext = () => context;
   const backend = resolveBackendApi
-    ? createLazyRuntimeBackendApi(getBackendApi)
+    ? createLazyAdapterBackendApi(getBackendApi)
     : undefined;
 
   const host = createExtensionHost({
@@ -245,7 +245,7 @@ export function createExtensionRuntime(
     },
   };
 
-  const buildSnapshot = (): ExtensionRuntimeSnapshot => ({
+  const buildSnapshot = (): ExtensionAdapterSnapshot => ({
     registry: host.getSnapshot(),
     ...loadState,
   });

--- a/src/extensions/extension-host.test.ts
+++ b/src/extensions/extension-host.test.ts
@@ -16,10 +16,10 @@ import {
   getExtensionToolDefinition,
 } from "@/extensions/tool-registry";
 import type {
+  ExtensionAdapterBackendApi,
   ExtensionCapabilities,
   ExtensionContext,
   ExtensionPanelHandle,
-  ExtensionRuntimeBackendApi,
 } from "@/extensions/types";
 
 type ExtensionTestGlobal = typeof globalThis & {
@@ -84,7 +84,7 @@ function createExtensionContext(): ExtensionContext {
 function createHost(
   root: string,
   capabilities?: ExtensionCapabilities,
-  backend?: ExtensionRuntimeBackendApi,
+  backend?: ExtensionAdapterBackendApi,
 ): ExtensionHost {
   return createExtensionHost({
     cacheDirectory: path.join(root, "extension-cache"),
@@ -214,7 +214,7 @@ describe("extension host", () => {
     delete testGlobal.__lettaExtensionBackend;
     delete testGlobal.__lettaExtensionForkResult;
 
-    const backend: ExtensionRuntimeBackendApi = {
+    const backend: ExtensionAdapterBackendApi = {
       forkConversation: async (conversationId, options) => ({
         id: `${conversationId}:${options?.agentId}:${options?.hidden ? "hidden" : "visible"}`,
       }),
@@ -373,7 +373,7 @@ describe("extension host", () => {
         }`,
       );
 
-      const backend: ExtensionRuntimeBackendApi = {
+      const backend: ExtensionAdapterBackendApi = {
         forkConversation: async () => ({ id: "forked" }),
         getConversationHistory: async () => [],
         sendMessageStream: async () => (async function* () {})(),

--- a/src/extensions/extension-host.ts
+++ b/src/extensions/extension-host.ts
@@ -39,6 +39,7 @@ import {
   unregisterExtensionToolsForOwner,
 } from "@/extensions/tool-registry";
 import type {
+  ExtensionAdapterBackendApi,
   ExtensionCapabilities,
   ExtensionCommand,
   ExtensionCommandRegistration,
@@ -57,7 +58,6 @@ import type {
   ExtensionPanelHandle,
   ExtensionPanelOptions,
   ExtensionPanelUpdate,
-  ExtensionRuntimeBackendApi,
   ExtensionTool,
   ExtensionToolRegistration,
   ExtensionToolStartEvent,
@@ -207,7 +207,7 @@ export interface LoadLocalExtensionsOptions
   extends ResolveLocalExtensionSourcesOptions {
   getContext?: () => ExtensionContext;
   getClient: () => Promise<Letta>;
-  backend?: ExtensionRuntimeBackendApi;
+  backend?: ExtensionAdapterBackendApi;
   capabilities?: ExtensionCapabilities;
   generation?: number;
   onChange?: () => void;
@@ -221,7 +221,7 @@ export interface ExtensionHost {
   emitEvent: <TName extends ExtensionEventName>(
     name: TName,
     event: ExtensionEventMap[TName],
-    backend?: ExtensionRuntimeBackendApi,
+    backend?: ExtensionAdapterBackendApi,
   ) => Promise<ExtensionEventEmissionResult<TName>>;
   getSnapshot: () => LocalExtensionRegistry;
   reload: () => Promise<void>;
@@ -232,7 +232,7 @@ export interface CreateExtensionHostOptions
   extends ResolveLocalExtensionSourcesOptions {
   getContext?: () => ExtensionContext;
   getClient: () => Promise<Letta>;
-  backend?: ExtensionRuntimeBackendApi;
+  backend?: ExtensionAdapterBackendApi;
   capabilities?: ExtensionCapabilities;
   reservedCommandIds?: Iterable<string>;
   reservedToolNames?: Iterable<string>;
@@ -1243,7 +1243,7 @@ export async function emitLocalExtensionEvent<TName extends ExtensionEventName>(
   name: TName,
   event: ExtensionEventMap[TName],
   getContext: () => ExtensionContext,
-  backend?: ExtensionRuntimeBackendApi,
+  backend?: ExtensionAdapterBackendApi,
   onDiagnostic?: (diagnostic: ExtensionDiagnostic) => void,
 ): Promise<ExtensionEventEmissionResult<TName>> {
   if (!registry) {

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -127,34 +127,34 @@ export interface ExtensionConversationHandle {
   ) => Promise<AsyncIterable<LettaStreamingResponse>>;
 }
 
-export interface ExtensionRuntimeBackendForkConversationOptions
+export interface ExtensionAdapterBackendForkConversationOptions
   extends ExtensionConversationForkOptions {
   agentId?: string;
 }
 
-export interface ExtensionRuntimeBackendSendMessageOptions
+export interface ExtensionAdapterBackendSendMessageOptions
   extends ExtensionConversationSendMessageOptions {
   agentId?: string;
 }
 
-export interface ExtensionRuntimeBackendHistoryOptions
+export interface ExtensionAdapterBackendHistoryOptions
   extends ExtensionConversationHistoryOptions {
   agentId?: string | null;
 }
 
-export interface ExtensionRuntimeBackendApi {
+export interface ExtensionAdapterBackendApi {
   forkConversation: (
     conversationId: string,
-    options?: ExtensionRuntimeBackendForkConversationOptions,
+    options?: ExtensionAdapterBackendForkConversationOptions,
   ) => Promise<{ id: string }>;
   getConversationHistory: (
     conversationId: string,
-    options?: ExtensionRuntimeBackendHistoryOptions,
+    options?: ExtensionAdapterBackendHistoryOptions,
   ) => Promise<Message[]>;
   sendMessageStream: (
     conversationId: string,
     messages: ExtensionConversationMessage[],
-    options?: ExtensionRuntimeBackendSendMessageOptions,
+    options?: ExtensionAdapterBackendSendMessageOptions,
     requestOptions?: ExtensionConversationSendMessageRequestOptions,
   ) => Promise<AsyncIterable<LettaStreamingResponse>>;
 }

--- a/src/headless-extension-adapter.ts
+++ b/src/headless-extension-adapter.ts
@@ -8,14 +8,14 @@ import { getClient } from "@/backend/api/client";
 import type { ReflectionSettings } from "@/cli/helpers/memory-reminder";
 import { loadExtensionConversationHistoryFromBackend } from "@/extensions/conversation-history";
 import {
-  createExtensionRuntime,
-  type ExtensionRuntime,
-} from "@/extensions/extension-runtime";
+  createExtensionAdapter,
+  type ExtensionAdapter,
+} from "@/extensions/extension-adapter";
 import type {
+  ExtensionAdapterBackendApi,
   ExtensionCapabilities,
   ExtensionContext,
   ExtensionConversationOpenReason,
-  ExtensionRuntimeBackendApi,
 } from "@/extensions/types";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
 import { settingsManager } from "@/settings-manager";
@@ -40,7 +40,7 @@ export const HEADLESS_EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 
 function createHeadlessExtensionBackendApi(
   backend: Backend,
-): ExtensionRuntimeBackendApi {
+): ExtensionAdapterBackendApi {
   return {
     forkConversation(conversationId, options) {
       return backend.forkConversation(conversationId, options);
@@ -159,7 +159,7 @@ export function createHeadlessExtensionContext(options: {
   };
 }
 
-export function createHeadlessExtensionRuntime(options: {
+export function createHeadlessExtensionAdapter(options: {
   agent: AgentState;
   backend: Backend;
   cacheDirectory?: string;
@@ -169,8 +169,8 @@ export function createHeadlessExtensionRuntime(options: {
   permissionMode?: string | null;
   reflectionSettings?: ReflectionSettings;
   sessionStats?: SessionStats | null;
-}): ExtensionRuntime {
-  return createExtensionRuntime({
+}): ExtensionAdapter {
+  return createExtensionAdapter({
     ...(options.cacheDirectory
       ? { cacheDirectory: options.cacheDirectory }
       : {}),
@@ -189,11 +189,11 @@ export async function emitHeadlessConversationOpen(options: {
   agent: AgentState;
   conversationId: string;
   reason: ExtensionConversationOpenReason;
-  runtime: ExtensionRuntime;
+  adapter: ExtensionAdapter;
 }): Promise<void> {
-  if (!options.runtime.getSnapshot().hasExtensionSources) return;
+  if (!options.adapter.getSnapshot().hasExtensionSources) return;
 
-  await options.runtime.emitEvent("conversation_open", {
+  await options.adapter.emitEvent("conversation_open", {
     agentId: options.agent.id,
     agentName: options.agent.name ?? null,
     conversationId: options.conversationId,
@@ -205,11 +205,11 @@ export async function emitHeadlessConversationClose(options: {
   agent: AgentState;
   conversationId: string;
   durationMs: number | null;
-  runtime: ExtensionRuntime;
+  adapter: ExtensionAdapter;
 }): Promise<void> {
-  if (!options.runtime.getSnapshot().hasExtensionSources) return;
+  if (!options.adapter.getSnapshot().hasExtensionSources) return;
 
-  await options.runtime.emitEvent("conversation_close", {
+  await options.adapter.emitEvent("conversation_close", {
     agentId: options.agent.id,
     conversationId: options.conversationId,
     durationMs: options.durationMs,

--- a/src/headless-extension-lifecycle.test.ts
+++ b/src/headless-extension-lifecycle.test.ts
@@ -18,10 +18,10 @@ import {
 } from "@/extensions/tool-registry";
 import { __headlessTestUtils } from "@/headless";
 import {
+  createHeadlessExtensionAdapter,
   createHeadlessExtensionContext,
-  createHeadlessExtensionRuntime,
   HEADLESS_EXTENSION_CAPABILITIES,
-} from "@/headless-extension-runtime";
+} from "@/headless-extension-adapter";
 import { executeTool } from "@/tools/manager";
 
 function readHeadlessSource(): string {
@@ -31,7 +31,7 @@ function readHeadlessSource(): string {
   );
 }
 
-describe("headless extension runtime", () => {
+describe("headless extension adapter", () => {
   afterEach(() => {
     clearExtensionTools();
   });
@@ -79,24 +79,24 @@ describe("headless extension runtime", () => {
     expect(context.contextWindow.size).toBe(200000);
   });
 
-  test("loads the runtime before headless modes and emits lifecycle events on exit", () => {
+  test("loads the adapter before headless modes and emits lifecycle events on exit", () => {
     const source = readHeadlessSource();
 
-    const runtimeIndex = source.indexOf(
-      "const headlessExtensionRuntime = createHeadlessExtensionRuntime",
+    const adapterIndex = source.indexOf(
+      "const headlessExtensionAdapter = createHeadlessExtensionAdapter",
     );
     const initialToolContextIndex = source.indexOf("const initialToolContext");
     const bidirectionalIndex = source.indexOf(
       "// If input-format is stream-json, use bidirectional mode",
     );
-    expect(runtimeIndex).toBeGreaterThan(-1);
-    expect(initialToolContextIndex).toBeGreaterThan(runtimeIndex);
-    expect(bidirectionalIndex).toBeGreaterThan(runtimeIndex);
+    expect(adapterIndex).toBeGreaterThan(-1);
+    expect(initialToolContextIndex).toBeGreaterThan(adapterIndex);
+    expect(bidirectionalIndex).toBeGreaterThan(adapterIndex);
 
-    expect(source).toContain("await headlessExtensionRuntime.reload()");
+    expect(source).toContain("await headlessExtensionAdapter.reload()");
     expect(source).toContain("await emitHeadlessConversationOpen({");
     expect(source).toContain("await emitHeadlessConversationClose({");
-    expect(source).toContain("headlessExtensionRuntime.dispose()");
+    expect(source).toContain("headlessExtensionAdapter.dispose()");
   });
 
   test("registers extension tools for headless tool snapshots and disables commands/UI", async () => {
@@ -151,7 +151,7 @@ describe("headless extension runtime", () => {
         }`,
       );
 
-      const runtime = createHeadlessExtensionRuntime({
+      const adapter = createHeadlessExtensionAdapter({
         agent,
         backend,
         cacheDirectory: path.join(root, "extension-cache"),
@@ -159,8 +159,8 @@ describe("headless extension runtime", () => {
         globalExtensionsDirectory: extensionDir,
       });
 
-      await runtime.reload();
-      const snapshot = runtime.getSnapshot().registry;
+      await adapter.reload();
+      const snapshot = adapter.getSnapshot().registry;
 
       expect(snapshot.tools[toolName]).toBeDefined();
       expect(snapshot.commands).toEqual({});
@@ -173,7 +173,7 @@ describe("headless extension runtime", () => {
           agentId: agent.id,
           cachedAgent: agent,
           conversationId: "default",
-          extensionEventEmitter: runtime.eventEmitter,
+          extensionEventEmitter: adapter.eventEmitter,
         });
       const clientToolNames =
         prepared.preparedToolContext.preparedToolContext.clientTools.map(
@@ -195,14 +195,14 @@ describe("headless extension runtime", () => {
       expect(result.status).toBe("success");
       expect(result.toolReturn).toBe("headless:ok:tool_start:agent-1:default");
 
-      runtime.dispose();
+      adapter.dispose();
       expect(getExtensionToolDefinition(toolName)).toBeUndefined();
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
   });
 
-  test("disabled headless runtime skips extension loading", async () => {
+  test("disabled headless adapter skips extension loading", async () => {
     const root = mkdtempSync(
       path.join(tmpdir(), "letta-headless-ext-disabled-"),
     );
@@ -239,7 +239,7 @@ describe("headless extension runtime", () => {
         }`,
       );
 
-      const runtime = createHeadlessExtensionRuntime({
+      const adapter = createHeadlessExtensionAdapter({
         agent,
         backend,
         cacheDirectory: path.join(root, "extension-cache"),
@@ -248,8 +248,8 @@ describe("headless extension runtime", () => {
         globalExtensionsDirectory: extensionDir,
       });
 
-      await runtime.reload();
-      const snapshot = runtime.getSnapshot();
+      await adapter.reload();
+      const snapshot = adapter.getSnapshot();
 
       expect(snapshot.hasExtensionSources).toBe(false);
       expect(snapshot.registry.loadedPaths).toEqual([]);
@@ -259,7 +259,7 @@ describe("headless extension runtime", () => {
       expect(getExtensionToolDefinition(toolName)).toBeUndefined();
       expect(process.env[LETTA_DISABLE_EXTENSIONS_ENV]).toBe("1");
 
-      runtime.dispose();
+      adapter.dispose();
     } finally {
       if (originalDisableEnv === undefined) {
         delete process.env[LETTA_DISABLE_EXTENSIONS_ENV];
@@ -299,7 +299,7 @@ describe("headless extension runtime", () => {
         }`,
       );
 
-      const runtime = createHeadlessExtensionRuntime({
+      const adapter = createHeadlessExtensionAdapter({
         agent,
         backend,
         cacheDirectory: path.join(root, "extension-cache"),
@@ -307,13 +307,13 @@ describe("headless extension runtime", () => {
         globalExtensionsDirectory: extensionDir,
       });
 
-      await runtime.reload();
+      await adapter.reload();
       const prepared =
         await __headlessTestUtils.prepareHeadlessToolExecutionContext({
           agentId: agent.id,
           cachedAgent: agent,
           conversationId: "default",
-          extensionEventEmitter: runtime.eventEmitter,
+          extensionEventEmitter: adapter.eventEmitter,
         });
 
       const result = await executeTool(
@@ -329,13 +329,13 @@ describe("headless extension runtime", () => {
       expect(result.toolReturn).toContain("replacement content");
       expect(result.toolReturn).not.toContain("original content");
 
-      runtime.dispose();
+      adapter.dispose();
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
   });
 
-  test("uses the captured runtime emitter for tool_start", async () => {
+  test("uses the captured adapter emitter for tool_start", async () => {
     const root = mkdtempSync(
       path.join(tmpdir(), "letta-headless-tool-start-captured-"),
     );
@@ -353,18 +353,18 @@ describe("headless extension runtime", () => {
       forkConversation: async () => ({ id: "forked" }),
       sendMessageStream: async () => (async function* () {})(),
     } as unknown as Backend;
-    let firstRuntime: ReturnType<typeof createHeadlessExtensionRuntime> | null =
+    let firstAdapter: ReturnType<typeof createHeadlessExtensionAdapter> | null =
       null;
-    let secondRuntime: ReturnType<
-      typeof createHeadlessExtensionRuntime
+    let secondAdapter: ReturnType<
+      typeof createHeadlessExtensionAdapter
     > | null = null;
 
     try {
       mkdirSync(firstExtensionDir, { recursive: true });
       mkdirSync(secondExtensionDir, { recursive: true });
       writeFileSync(originalPath, "original content");
-      writeFileSync(firstPath, "first runtime content");
-      writeFileSync(secondPath, "second runtime content");
+      writeFileSync(firstPath, "first adapter content");
+      writeFileSync(secondPath, "second adapter content");
       writeFileSync(
         path.join(firstExtensionDir, "tool-start.ts"),
         `export default function activate(letta) {
@@ -384,30 +384,30 @@ describe("headless extension runtime", () => {
         }`,
       );
 
-      firstRuntime = createHeadlessExtensionRuntime({
+      firstAdapter = createHeadlessExtensionAdapter({
         agent,
         backend,
         cacheDirectory: path.join(root, "first-cache"),
         conversationId: "default",
         globalExtensionsDirectory: firstExtensionDir,
       });
-      await firstRuntime.reload();
+      await firstAdapter.reload();
       const prepared =
         await __headlessTestUtils.prepareHeadlessToolExecutionContext({
           agentId: agent.id,
           cachedAgent: agent,
           conversationId: "default",
-          extensionEventEmitter: firstRuntime.eventEmitter,
+          extensionEventEmitter: firstAdapter.eventEmitter,
         });
 
-      secondRuntime = createHeadlessExtensionRuntime({
+      secondAdapter = createHeadlessExtensionAdapter({
         agent,
         backend,
         cacheDirectory: path.join(root, "second-cache"),
         conversationId: "default",
         globalExtensionsDirectory: secondExtensionDir,
       });
-      await secondRuntime.reload();
+      await secondAdapter.reload();
 
       const result = await executeTool(
         "Read",
@@ -419,12 +419,12 @@ describe("headless extension runtime", () => {
       );
 
       expect(result.status).toBe("success");
-      expect(result.toolReturn).toContain("first runtime content");
-      expect(result.toolReturn).not.toContain("second runtime content");
+      expect(result.toolReturn).toContain("first adapter content");
+      expect(result.toolReturn).not.toContain("second adapter content");
       expect(result.toolReturn).not.toContain("original content");
     } finally {
-      firstRuntime?.dispose();
-      secondRuntime?.dispose();
+      firstAdapter?.dispose();
+      secondAdapter?.dispose();
       rmSync(root, { force: true, recursive: true });
     }
   });

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -104,14 +104,14 @@ import {
   disableExtensionsForProcess,
   shouldDisableExtensions,
 } from "./extensions/disable";
-import type { ExtensionRuntime } from "./extensions/extension-runtime";
+import type { ExtensionAdapter } from "./extensions/extension-adapter";
 import type { ExtensionConversationOpenReason } from "./extensions/types";
 import {
+  createHeadlessExtensionAdapter,
   createHeadlessExtensionContext,
-  createHeadlessExtensionRuntime,
   emitHeadlessConversationClose,
   emitHeadlessConversationOpen,
-} from "./headless-extension-runtime";
+} from "./headless-extension-adapter";
 import { computeDiffPreviews } from "./helpers/diff-preview";
 import { formatPermissionDenial } from "./permissions/format-denial";
 import { QueueRuntime } from "./queue/queue-runtime";
@@ -426,7 +426,7 @@ async function prepareHeadlessToolExecutionContext(params: {
   conversationId: string;
   overrideModel?: string | null;
   cachedAgent?: AgentState | null;
-  extensionEventEmitter?: ExtensionRuntime["eventEmitter"];
+  extensionEventEmitter?: ExtensionAdapter["eventEmitter"];
 }): Promise<{
   preparedToolContext: Awaited<
     ReturnType<typeof prepareToolExecutionContextForScope>
@@ -464,9 +464,9 @@ async function emitHeadlessTurnStart(options: {
   agent: AgentState;
   conversationId: string;
   input: Array<MessageCreate | ApprovalCreate>;
-  runtime: ExtensionRuntime;
+  adapter: ExtensionAdapter;
 }): Promise<Array<MessageCreate | ApprovalCreate>> {
-  if (!options.runtime.getSnapshot().hasExtensionSources) return options.input;
+  if (!options.adapter.getSnapshot().hasExtensionSources) return options.input;
 
   try {
     const event = {
@@ -474,7 +474,7 @@ async function emitHeadlessTurnStart(options: {
       conversationId: options.conversationId,
       input: options.input,
     };
-    await options.runtime.emitEvent("turn_start", event);
+    await options.adapter.emitEvent("turn_start", event);
     return isTurnInputArray(event.input) ? event.input : options.input;
   } catch {
     // Extension turn_start handlers should not block sending the turn.
@@ -486,7 +486,7 @@ async function sendScopedApprovalMessages(params: {
   agentId: string;
   conversationId: string;
   approvalMessages: Array<MessageCreate | ApprovalCreate>;
-  extensionEventEmitter?: ExtensionRuntime["eventEmitter"];
+  extensionEventEmitter?: ExtensionAdapter["eventEmitter"];
 }): Promise<Awaited<ReturnType<typeof sendMessageStream>>> {
   const approvalToolContext = await prepareHeadlessToolExecutionContext({
     agentId: params.agentId,
@@ -1670,7 +1670,7 @@ export async function handleHeadlessCommand(
     : typeof permissionModeValue === "string"
       ? permissionModeValue
       : null;
-  const headlessExtensionRuntime = createHeadlessExtensionRuntime({
+  const headlessExtensionAdapter = createHeadlessExtensionAdapter({
     agent,
     backend,
     conversationId,
@@ -1679,13 +1679,13 @@ export async function handleHeadlessCommand(
     sessionStats,
     disabled: extensionsDisabled,
   });
-  await headlessExtensionRuntime.reload();
+  await headlessExtensionAdapter.reload();
   try {
     await emitHeadlessConversationOpen({
       agent,
       conversationId,
       reason: conversationOpenReason,
-      runtime: headlessExtensionRuntime,
+      adapter: headlessExtensionAdapter,
     });
   } catch {
     // Extension lifecycle events should not block headless startup.
@@ -1706,7 +1706,7 @@ export async function handleHeadlessCommand(
       agentId: agent.id,
       conversationId,
       cachedAgent: agent as AgentState,
-      extensionEventEmitter: headlessExtensionRuntime.eventEmitter,
+      extensionEventEmitter: headlessExtensionAdapter.eventEmitter,
     });
     availableTools = initialToolContext.availableTools;
     cachedAgent = initialToolContext.preparedToolContext.agent;
@@ -1725,7 +1725,7 @@ export async function handleHeadlessCommand(
       resolvedSkillSources,
       systemInfoReminderEnabled,
       effectiveReflectionSettings,
-      headlessExtensionRuntime,
+      headlessExtensionAdapter,
     );
     return;
   }
@@ -1746,7 +1746,7 @@ export async function handleHeadlessCommand(
     try {
       if (!headlessConversationClosed) {
         headlessConversationClosed = true;
-        headlessExtensionRuntime.updateContext(
+        headlessExtensionAdapter.updateContext(
           createHeadlessExtensionContext({
             agent,
             conversationId,
@@ -1761,7 +1761,7 @@ export async function handleHeadlessCommand(
             agent,
             conversationId,
             durationMs: sessionStats.getSnapshot().totalWallMs,
-            runtime: headlessExtensionRuntime,
+            adapter: headlessExtensionAdapter,
           });
         } catch {
           // Extension lifecycle events should not block headless shutdown.
@@ -1770,7 +1770,7 @@ export async function handleHeadlessCommand(
       telemetry.trackSessionEnd(sessionStats.getSnapshot(), exitReason);
       await telemetry.flush();
     } finally {
-      headlessExtensionRuntime.dispose();
+      headlessExtensionAdapter.dispose();
       telemetry.setSessionStatsGetter(undefined);
     }
     return await flushAndExit(code);
@@ -1878,7 +1878,7 @@ export async function handleHeadlessCommand(
         agentId: agent.id,
         conversationId,
         approvalMessages,
-        extensionEventEmitter: headlessExtensionRuntime.eventEmitter,
+        extensionEventEmitter: headlessExtensionAdapter.eventEmitter,
       });
       const drainResult = await drainStreamWithResume(
         approvalStream,
@@ -2038,7 +2038,7 @@ ${SYSTEM_REMINDER_CLOSE}
     ];
     queuedRecoveredApprovalResults = null;
   }
-  headlessExtensionRuntime.updateContext(
+  headlessExtensionAdapter.updateContext(
     createHeadlessExtensionContext({
       agent,
       conversationId,
@@ -2051,7 +2051,7 @@ ${SYSTEM_REMINDER_CLOSE}
     agent,
     conversationId,
     input: currentInput,
-    runtime: headlessExtensionRuntime,
+    adapter: headlessExtensionAdapter,
   });
 
   // Track lastRunId outside the while loop so it's available in catch block
@@ -2128,7 +2128,7 @@ ${SYSTEM_REMINDER_CLOSE}
           conversationId,
           overrideModel: overrideModelHandle ?? preparedEffectiveModel,
           cachedAgent,
-          extensionEventEmitter: headlessExtensionRuntime.eventEmitter,
+          extensionEventEmitter: headlessExtensionAdapter.eventEmitter,
         });
         availableTools = turnToolContext.availableTools;
         stream = await sendMessageStream(conversationId, currentInput, {
@@ -3112,7 +3112,7 @@ async function runBidirectionalMode(
   skillSources: SkillSource[],
   systemInfoReminderEnabled: boolean,
   reflectionSettings: ReflectionSettings,
-  headlessExtensionRuntime: ExtensionRuntime,
+  headlessExtensionAdapter: ExtensionAdapter,
 ): Promise<void> {
   const sessionId = agent.id;
   const backend = getBackend();
@@ -3133,7 +3133,7 @@ async function runBidirectionalMode(
             agent,
             conversationId,
             durationMs: null,
-            runtime: headlessExtensionRuntime,
+            adapter: headlessExtensionAdapter,
           });
         } catch {
           // Extension lifecycle events should not block headless shutdown.
@@ -3142,7 +3142,7 @@ async function runBidirectionalMode(
       telemetry.trackSessionEnd(undefined, exitReason);
       await telemetry.flush();
     } finally {
-      headlessExtensionRuntime.dispose();
+      headlessExtensionAdapter.dispose();
     }
     return await flushAndExit(code);
   };
@@ -3254,7 +3254,7 @@ async function runBidirectionalMode(
         agentId: agent.id,
         conversationId,
         approvalMessages,
-        extensionEventEmitter: headlessExtensionRuntime.eventEmitter,
+        extensionEventEmitter: headlessExtensionAdapter.eventEmitter,
       });
       const drainResult = await drainStreamWithResume(
         approvalStream,
@@ -3634,7 +3634,7 @@ async function runBidirectionalMode(
         agentId: agent.id,
         conversationId: targetConversationId,
         approvalMessages: [approvalInput],
-        extensionEventEmitter: headlessExtensionRuntime.eventEmitter,
+        extensionEventEmitter: headlessExtensionAdapter.eventEmitter,
       });
 
       const drainResult = await drainStreamWithResume(
@@ -4030,7 +4030,7 @@ async function runBidirectionalMode(
           skillSources,
           maybeLaunchReflectionSubagent,
         });
-        headlessExtensionRuntime.updateContext(
+        headlessExtensionAdapter.updateContext(
           createHeadlessExtensionContext({
             agent,
             conversationId,
@@ -4049,7 +4049,7 @@ async function runBidirectionalMode(
           agent,
           conversationId,
           input: currentInput,
-          runtime: headlessExtensionRuntime,
+          adapter: headlessExtensionAdapter,
         });
 
         // Approval handling loop - continue until end_turn or error
@@ -4089,7 +4089,7 @@ async function runBidirectionalMode(
             const turnToolContext = await prepareHeadlessToolExecutionContext({
               agentId: agent.id,
               conversationId,
-              extensionEventEmitter: headlessExtensionRuntime.eventEmitter,
+              extensionEventEmitter: headlessExtensionAdapter.eventEmitter,
             });
             availableTools = turnToolContext.availableTools;
             stream = await sendMessageStream(conversationId, currentInput, {


### PR DESCRIPTION
## Summary
- rename the extension runtime wrapper/files/types to extension adapter
- update TUI/headless call sites and tests to use adapter terminology
- keep the hadStatuslineRenderer reload-flicker context on the local adapter surface

## Tests
- `bun test src/extensions/extension-adapter.test.ts src/headless-extension-lifecycle.test.ts src/cli/extensions/local-extension-loader.test.ts`
- `bunx --bun @biomejs/biome@2.2.5 check src/extensions/extension-adapter.ts src/extensions/extension-adapter.test.ts src/headless-extension-adapter.ts src/headless-extension-lifecycle.test.ts src/cli/extensions/use-local-extension-adapter.ts src/cli/extensions/local-extension-loader.ts src/cli/app/AppCoordinator.tsx src/cli/app/AppView.tsx src/cli/app/use-submit-handler.ts src/cli/app/use-conversation-loop.ts src/cli/app/use-conversation-switching.ts src/cli/components/InputRich.tsx src/extensions/types.ts src/extensions/conversation-handle.ts src/extensions/extension-host.ts src/extensions/extension-host.test.ts src/extensions/event-emitter.ts`
- `bun run typecheck`
- `git diff --check`