### PR TITLE
refactor(extensions): rename host layer to engine

### DIFF
--- a/src/cli/extensions/local-extension-loader.ts
+++ b/src/cli/extensions/local-extension-loader.ts
@@ -2,11 +2,11 @@ import { commands as builtinCommands } from "@/cli/commands/registry";
 import type { CreateExtensionAdapterOptions } from "@/extensions/extension-adapter";
 import { createExtensionAdapter as createExtensionAdapterBase } from "@/extensions/extension-adapter";
 import type {
-  CreateExtensionHostOptions,
+  CreateExtensionEngineOptions,
   LoadLocalExtensionsOptions,
-} from "@/extensions/extension-host";
+} from "@/extensions/extension-engine";
 import {
-  createExtensionHost as createExtensionHostBase,
+  createExtensionEngine as createExtensionEngineBase,
   disposeLocalExtensions,
   EXTENSION_CACHE_DIRECTORY,
   emitLocalExtensionEvent,
@@ -14,7 +14,7 @@ import {
   GLOBAL_EXTENSIONS_DIRECTORY,
   loadLocalExtensions as loadLocalExtensionsBase,
   resolveLocalExtensionSources,
-} from "@/extensions/extension-host";
+} from "@/extensions/extension-engine";
 import type { ExtensionCapabilities } from "@/extensions/types";
 import { getAllLettaToolNames, getServerToolName } from "@/tools/manager";
 import { TUI_EXTENSION_CAPABILITIES } from "./capabilities";
@@ -57,8 +57,8 @@ function withDefaultReservations<
   };
 }
 
-export function createExtensionHost(options: CreateExtensionHostOptions) {
-  return createExtensionHostBase(withDefaultReservations(options));
+export function createExtensionEngine(options: CreateExtensionEngineOptions) {
+  return createExtensionEngineBase(withDefaultReservations(options));
 }
 
 export function createExtensionAdapter(options: CreateExtensionAdapterOptions) {
@@ -85,8 +85,8 @@ export type {
   ExtensionAdapterSnapshot,
 } from "@/extensions/extension-adapter";
 export type {
-  CreateExtensionHostOptions,
-  ExtensionHost,
+  CreateExtensionEngineOptions,
+  ExtensionEngine,
   ExtensionStatusValue,
   LettaExtensionApi,
   LettaExtensionDisposer,
@@ -99,5 +99,5 @@ export type {
   LocalExtensionUiRegistry,
   ResolveLocalExtensionSourcesOptions,
   StatuslineRenderFunction,
-} from "@/extensions/extension-host";
+} from "@/extensions/extension-engine";
 export { TUI_EXTENSION_CAPABILITIES } from "./capabilities";

--- a/src/cli/extensions/use-local-extension-adapter.ts
+++ b/src/cli/extensions/use-local-extension-adapter.ts
@@ -26,7 +26,7 @@ export interface LocalExtensionAdapter {
   getContext: () => ExtensionContext;
   hadStatuslineRenderer: boolean; // Used to prevent flicker on reload
   hasExtensionSources: boolean;
-  host: ExtensionAdapter["host"];
+  engine: ExtensionAdapter["engine"];
   isLoading: boolean;
   registry: ExtensionAdapterSnapshot["registry"];
   reload: () => Promise<void>;
@@ -104,7 +104,7 @@ export function useLocalExtensionAdapter(
       getContext: adapter.getContext,
       hadStatuslineRenderer: snapshot.hadStatuslineRenderer,
       hasExtensionSources: snapshot.hasExtensionSources,
-      host: adapter.host,
+      engine: adapter.engine,
       isLoading: snapshot.isLoading,
       registry: snapshot.registry,
       reload: adapter.reload,

--- a/src/extensions/extension-adapter.ts
+++ b/src/extensions/extension-adapter.ts
@@ -13,12 +13,12 @@ import {
   emptyEventEmissionResult,
 } from "@/extensions/event-emitter";
 import {
-  type CreateExtensionHostOptions,
-  createExtensionHost,
-  type ExtensionHost,
+  type CreateExtensionEngineOptions,
+  createExtensionEngine,
+  type ExtensionEngine,
   type LocalExtensionRegistry,
   resolveLocalExtensionSources,
-} from "@/extensions/extension-host";
+} from "@/extensions/extension-engine";
 import { clearExtensionTools } from "@/extensions/tool-registry";
 import type {
   ExtensionAdapterBackendApi,
@@ -36,11 +36,11 @@ export interface ExtensionAdapterLoadState {
 }
 
 export interface ExtensionAdapterSnapshot extends ExtensionAdapterLoadState {
-  registry: ReturnType<ExtensionHost["getSnapshot"]>;
+  registry: ReturnType<ExtensionEngine["getSnapshot"]>;
 }
 
 export interface CreateExtensionAdapterOptions
-  extends Omit<CreateExtensionHostOptions, "backend" | "getContext"> {
+  extends Omit<CreateExtensionEngineOptions, "backend" | "getContext"> {
   disabled?: boolean;
   getBackendApi?: () => ExtensionAdapterBackendApi | undefined;
   getClient: () => Promise<Letta>;
@@ -70,9 +70,9 @@ function createDisabledExtensionRegistry(): LocalExtensionRegistry {
   };
 }
 
-function createDisabledExtensionHost(
+function createDisabledExtensionEngine(
   registry: LocalExtensionRegistry,
-): ExtensionHost {
+): ExtensionEngine {
   return {
     dispose() {},
     emitEvent(name) {
@@ -98,7 +98,7 @@ function createDisabledExtensionAdapter(
 
   let context = options.initialContext;
   const registry = createDisabledExtensionRegistry();
-  const host = createDisabledExtensionHost(registry);
+  const engine = createDisabledExtensionEngine(registry);
   const snapshot: ExtensionAdapterSnapshot = {
     hadStatuslineRenderer: false,
     hasExtensionSources: false,
@@ -129,7 +129,7 @@ function createDisabledExtensionAdapter(
     getSnapshot() {
       return snapshot;
     },
-    host,
+    engine,
     reload() {
       return Promise.resolve();
     },
@@ -152,7 +152,7 @@ export interface ExtensionAdapter {
   getBackendApi: () => ExtensionAdapterBackendApi | undefined;
   getContext: () => ExtensionContext;
   getSnapshot: () => ExtensionAdapterSnapshot;
-  host: ExtensionHost;
+  engine: ExtensionEngine;
   reload: () => Promise<void>;
   subscribe: (listener: () => void) => () => void;
   updateContext: (context: ExtensionContext) => void;
@@ -212,11 +212,11 @@ export function createExtensionAdapter(
   const {
     getBackendApi: resolveBackendApi,
     initialContext,
-    ...hostOptions
+    ...engineOptions
   } = options;
   let context = initialContext;
   let disposed = false;
-  const initialHasExtensionSources = hasExtensionSources(hostOptions);
+  const initialHasExtensionSources = hasExtensionSources(engineOptions);
   let loadState: ExtensionAdapterLoadState = {
     hadStatuslineRenderer: false,
     hasExtensionSources: initialHasExtensionSources,
@@ -230,15 +230,15 @@ export function createExtensionAdapter(
     ? createLazyAdapterBackendApi(getBackendApi)
     : undefined;
 
-  const host = createExtensionHost({
-    ...hostOptions,
+  const engine = createExtensionEngine({
+    ...engineOptions,
     ...(backend ? { backend } : {}),
     getContext,
   });
 
   const eventEmitter: ExtensionEventEmitter = {
     emitEvent(name, event) {
-      return host.emitEvent(name, event, getBackendApi());
+      return engine.emitEvent(name, event, getBackendApi());
     },
     getSnapshot() {
       return loadState;
@@ -246,7 +246,7 @@ export function createExtensionAdapter(
   };
 
   const buildSnapshot = (): ExtensionAdapterSnapshot => ({
-    registry: host.getSnapshot(),
+    registry: engine.getSnapshot(),
     ...loadState,
   });
   let snapshot = buildSnapshot();
@@ -257,28 +257,28 @@ export function createExtensionAdapter(
       listener();
     }
   };
-  const unsubscribeHost = host.subscribe(publish);
+  const unsubscribeEngine = engine.subscribe(publish);
 
   const getSnapshot = () => snapshot;
 
   const reload = async () => {
     if (disposed) return;
 
-    const previousSnapshot = host.getSnapshot();
+    const previousSnapshot = engine.getSnapshot();
     const previousHadStatuslineRenderer =
       Boolean(previousSnapshot.ui.statuslineRenderer) ||
       loadState.hadStatuslineRenderer;
     loadState = {
       hadStatuslineRenderer: previousHadStatuslineRenderer,
-      hasExtensionSources: hasExtensionSources(hostOptions),
+      hasExtensionSources: hasExtensionSources(engineOptions),
       isLoading: true,
     };
     publish();
 
-    await host.reload();
+    await engine.reload();
     if (disposed) return;
 
-    const nextRegistry = host.getSnapshot();
+    const nextRegistry = engine.getSnapshot();
     debugLog(
       "extensions",
       "loaded %s extension(s) from %s source(s); renderer=%s",
@@ -310,18 +310,18 @@ export function createExtensionAdapter(
     dispose() {
       if (disposed) return;
       disposed = true;
-      host.dispose();
-      unsubscribeHost();
+      engine.dispose();
+      unsubscribeEngine();
       listeners.clear();
     },
     emitEvent(name, event) {
-      return host.emitEvent(name, event, getBackendApi());
+      return engine.emitEvent(name, event, getBackendApi());
     },
     eventEmitter,
     getBackendApi,
     getContext,
     getSnapshot,
-    host,
+    engine,
     reload,
     subscribe(listener) {
       listeners.add(listener);

--- a/src/extensions/extension-engine.test.ts
+++ b/src/extensions/extension-engine.test.ts
@@ -8,9 +8,9 @@ import {
   getRegisteredPiProvider,
 } from "@/backend/dev/pi-provider-extension-registry";
 import {
-  createExtensionHost,
-  type ExtensionHost,
-} from "@/extensions/extension-host";
+  createExtensionEngine,
+  type ExtensionEngine,
+} from "@/extensions/extension-engine";
 import {
   clearExtensionTools,
   getExtensionToolDefinition,
@@ -34,7 +34,7 @@ type ExtensionTestGlobal = typeof globalThis & {
 };
 
 function createTempDir(): string {
-  return mkdtempSync(path.join(tmpdir(), "letta-extension-host-"));
+  return mkdtempSync(path.join(tmpdir(), "letta-extension-engine-"));
 }
 
 function createExtensionContext(): ExtensionContext {
@@ -81,12 +81,12 @@ function createExtensionContext(): ExtensionContext {
   };
 }
 
-function createHost(
+function createEngine(
   root: string,
   capabilities?: ExtensionCapabilities,
   backend?: ExtensionAdapterBackendApi,
-): ExtensionHost {
-  return createExtensionHost({
+): ExtensionEngine {
+  return createExtensionEngine({
     cacheDirectory: path.join(root, "extension-cache"),
     ...(backend ? { backend } : {}),
     ...(capabilities ? { capabilities } : {}),
@@ -108,7 +108,7 @@ const TOOL_ONLY_EXTENSION_CAPABILITIES: ExtensionCapabilities = {
   },
 };
 
-describe("extension host", () => {
+describe("extension engine", () => {
   afterEach(() => {
     clearExtensionTools();
     clearRegisteredPiProviders();
@@ -131,14 +131,14 @@ describe("extension host", () => {
         }`,
       );
 
-      const host = createHost(root);
+      const engine = createEngine(root);
       let changes = 0;
-      const unsubscribe = host.subscribe(() => {
+      const unsubscribe = engine.subscribe(() => {
         changes += 1;
       });
 
-      await host.reload();
-      const snapshot = host.getSnapshot();
+      await engine.reload();
+      const snapshot = engine.getSnapshot();
 
       expect(changes).toBeGreaterThan(0);
       expect(snapshot.loadedPaths).toEqual([extensionPath]);
@@ -148,10 +148,10 @@ describe("extension host", () => {
         path: extensionPath,
         scope: "global",
       });
-      expect(host.getSnapshot()).toBe(snapshot);
+      expect(engine.getSnapshot()).toBe(snapshot);
 
       unsubscribe();
-      host.dispose();
+      engine.dispose();
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
@@ -190,9 +190,9 @@ describe("extension host", () => {
         }`,
       );
 
-      const host = createHost(root, TOOL_ONLY_EXTENSION_CAPABILITIES);
-      await host.reload();
-      const snapshot = host.getSnapshot();
+      const engine = createEngine(root, TOOL_ONLY_EXTENSION_CAPABILITIES);
+      await engine.reload();
+      const snapshot = engine.getSnapshot();
 
       const observedCapabilities = testGlobal.__lettaExtensionCapabilities as
         | ExtensionCapabilities
@@ -221,7 +221,7 @@ describe("extension host", () => {
       getConversationHistory: async () => [],
       sendMessageStream: async () =>
         (async function* () {
-          // Empty stream for host plumbing tests.
+          // Empty stream for engine plumbing tests.
         })(),
     };
 
@@ -239,9 +239,9 @@ describe("extension host", () => {
         }`,
       );
 
-      const host = createHost(root, undefined, backend);
-      await host.reload();
-      await host.emitEvent("conversation_open", {
+      const engine = createEngine(root, undefined, backend);
+      await engine.reload();
+      await engine.emitEvent("conversation_open", {
         agentId: "agent-1",
         agentName: "Amelia",
         conversationId: "conv-1",
@@ -255,7 +255,7 @@ describe("extension host", () => {
       expect(forkResult).toMatchObject({
         id: "conv-1:agent-1:hidden",
       });
-      expect(host.getSnapshot().errors).toEqual([]);
+      expect(engine.getSnapshot().errors).toEqual([]);
     } finally {
       delete testGlobal.__lettaExtensionBackend;
       delete testGlobal.__lettaExtensionForkResult;
@@ -289,8 +289,8 @@ describe("extension host", () => {
         }`,
       );
 
-      const host = createHost(root);
-      await host.reload();
+      const engine = createEngine(root);
+      await engine.reload();
 
       expect(
         getRegisteredPiProvider("lmstudio")?.config.models?.[0],
@@ -301,7 +301,7 @@ describe("extension host", () => {
         reasoning: true,
       });
 
-      host.dispose();
+      engine.dispose();
       expect(getRegisteredPiProvider("lmstudio")).toBeUndefined();
     } finally {
       rmSync(root, { force: true, recursive: true });
@@ -334,9 +334,9 @@ describe("extension host", () => {
         }`,
       );
 
-      const host = createHost(root, TOOL_ONLY_EXTENSION_CAPABILITIES);
-      await host.reload();
-      const snapshot = host.getSnapshot();
+      const engine = createEngine(root, TOOL_ONLY_EXTENSION_CAPABILITIES);
+      await engine.reload();
+      const snapshot = engine.getSnapshot();
 
       expect(snapshot.errors).toEqual([]);
       expect(snapshot.commands).toEqual({});
@@ -378,18 +378,18 @@ describe("extension host", () => {
         getConversationHistory: async () => [],
         sendMessageStream: async () => (async function* () {})(),
       };
-      const host = createHost(root, undefined, backend);
-      await host.reload();
-      expect(host.getSnapshot().events.conversation_open).toHaveLength(2);
+      const engine = createEngine(root, undefined, backend);
+      await engine.reload();
+      expect(engine.getSnapshot().events.conversation_open).toHaveLength(2);
 
-      const result = await host.emitEvent("conversation_open", {
+      const result = await engine.emitEvent("conversation_open", {
         agentId: "agent-1",
         agentName: "Amelia",
         conversationId: "conversation-1",
         reason: "startup",
       });
 
-      const snapshot = host.getSnapshot();
+      const snapshot = engine.getSnapshot();
       expect(result).toMatchObject({
         handlerCount: 2,
         name: "conversation_open",
@@ -404,7 +404,7 @@ describe("extension host", () => {
         error: expect.objectContaining({ message: "event failed" }),
       });
 
-      host.dispose();
+      engine.dispose();
     } finally {
       delete testGlobal.__lettaExtensionEvents;
       rmSync(root, { force: true, recursive: true });
@@ -451,15 +451,15 @@ describe("extension host", () => {
         }`,
       );
 
-      const host = createHost(root);
-      await host.reload();
+      const engine = createEngine(root);
+      await engine.reload();
       const event = {
         agentId: "agent-1",
         conversationId: "conversation-1",
         input: [{ role: "user" as const, content: "hello ??" }],
       };
 
-      const result = await host.emitEvent("turn_start", event);
+      const result = await engine.emitEvent("turn_start", event);
 
       expect(result).toMatchObject({
         handlerCount: 4,
@@ -469,7 +469,7 @@ describe("extension host", () => {
       expect(result.results).toHaveLength(1);
       expect(event.input).toEqual([{ role: "user", content: "hello final" }]);
 
-      host.dispose();
+      engine.dispose();
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
@@ -505,8 +505,8 @@ describe("extension host", () => {
         }`,
       );
 
-      const host = createHost(root);
-      await host.reload();
+      const engine = createEngine(root);
+      await engine.reload();
       const event = {
         agentId: "agent-1",
         conversationId: "conversation-1",
@@ -515,7 +515,7 @@ describe("extension host", () => {
         args: { command: "echo ??" },
       };
 
-      const result = await host.emitEvent("tool_start", event);
+      const result = await engine.emitEvent("tool_start", event);
 
       expect(result).toMatchObject({
         handlerCount: 4,
@@ -525,7 +525,7 @@ describe("extension host", () => {
       expect(result.results).toHaveLength(1);
       expect(event.args).toEqual({ command: "echo final" });
 
-      host.dispose();
+      engine.dispose();
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
@@ -552,8 +552,8 @@ describe("extension host", () => {
         }`,
       );
 
-      const host = createHost(root);
-      await host.reload();
+      const engine = createEngine(root);
+      await engine.reload();
       const firstSignal = testGlobal.__lettaExtensionSignal as
         | AbortSignal
         | undefined;
@@ -561,7 +561,7 @@ describe("extension host", () => {
         | ExtensionPanelHandle
         | undefined;
       expect(firstSignal?.aborted).toBe(false);
-      expect(Object.values(host.getSnapshot().ui.panels)).toHaveLength(1);
+      expect(Object.values(engine.getSnapshot().ui.panels)).toHaveLength(1);
 
       writeFileSync(
         extensionPath,
@@ -569,20 +569,20 @@ describe("extension host", () => {
           globalThis.__lettaExtensionSignal = letta.signal;
         }`,
       );
-      await host.reload();
+      await engine.reload();
 
       expect(firstSignal?.aborted).toBe(true);
-      expect(Object.values(host.getSnapshot().ui.panels)).toEqual([]);
+      expect(Object.values(engine.getSnapshot().ui.panels)).toEqual([]);
 
       stalePanel?.update({ content: "stale update" });
-      const snapshot = host.getSnapshot();
+      const snapshot = engine.getSnapshot();
       expect(Object.values(snapshot.ui.panels)).toEqual([]);
       expect(snapshot.diagnostics.at(-1)).toMatchObject({
         capability: { id: "status", kind: "panel" },
         phase: "stale_handle",
       });
 
-      host.dispose();
+      engine.dispose();
       const secondSignal = testGlobal.__lettaExtensionSignal as
         | AbortSignal
         | undefined;
@@ -615,9 +615,11 @@ describe("extension host", () => {
         }`,
       );
 
-      const host = createHost(root);
-      await host.reload();
-      expect(Object.keys(host.getSnapshot().commands)).toEqual(["old-command"]);
+      const engine = createEngine(root);
+      await engine.reload();
+      expect(Object.keys(engine.getSnapshot().commands)).toEqual([
+        "old-command",
+      ]);
 
       let releaseReload!: () => void;
       const reloadStarted = new Promise<void>((resolve) => {
@@ -639,17 +641,19 @@ describe("extension host", () => {
         }`,
       );
 
-      const reloadPromise = host.reload();
+      const reloadPromise = engine.reload();
       await reloadStarted;
 
-      expect(host.getSnapshot().commands).toEqual({});
-      expect(host.getSnapshot().loadedPaths).toEqual([]);
+      expect(engine.getSnapshot().commands).toEqual({});
+      expect(engine.getSnapshot().loadedPaths).toEqual([]);
 
       releaseReload();
       await reloadPromise;
-      expect(Object.keys(host.getSnapshot().commands)).toEqual(["new-command"]);
+      expect(Object.keys(engine.getSnapshot().commands)).toEqual([
+        "new-command",
+      ]);
 
-      host.dispose();
+      engine.dispose();
     } finally {
       delete testGlobal.__lettaExtensionGate;
       delete testGlobal.__lettaExtensionStarted;
@@ -687,8 +691,8 @@ describe("extension host", () => {
         }`,
       );
 
-      const host = createHost(root);
-      const firstReload = host.reload();
+      const engine = createEngine(root);
+      const firstReload = engine.reload();
       await firstReloadStarted;
 
       delete testGlobal.__lettaExtensionGate;
@@ -704,19 +708,19 @@ describe("extension host", () => {
         }`,
       );
 
-      await host.reload();
-      expect(Object.keys(host.getSnapshot().commands)).toEqual([
+      await engine.reload();
+      expect(Object.keys(engine.getSnapshot().commands)).toEqual([
         "fresh-command",
       ]);
 
       releaseFirstReload();
       await firstReload;
 
-      const snapshot = host.getSnapshot();
+      const snapshot = engine.getSnapshot();
       expect(snapshot.generation).toBe(2);
       expect(Object.keys(snapshot.commands)).toEqual(["fresh-command"]);
 
-      host.dispose();
+      engine.dispose();
     } finally {
       delete testGlobal.__lettaExtensionGate;
       delete testGlobal.__lettaExtensionStarted;
@@ -743,12 +747,12 @@ describe("extension host", () => {
         `export default function() { const value = ; }`,
       );
 
-      const host = createHost(root);
-      await host.reload();
+      const engine = createEngine(root);
+      await engine.reload();
 
       expect(
         Object.fromEntries(
-          host
+          engine
             .getSnapshot()
             .errors.map((entry) => [path.basename(entry.path), entry.phase]),
         ),
@@ -758,7 +762,7 @@ describe("extension host", () => {
         "phase-transpile.ts": "transpile",
       });
 
-      host.dispose();
+      engine.dispose();
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
@@ -788,9 +792,9 @@ describe("extension host", () => {
         }`,
       );
 
-      const host = createHost(root);
-      await host.reload();
-      const snapshot = host.getSnapshot();
+      const engine = createEngine(root);
+      await engine.reload();
+      const snapshot = engine.getSnapshot();
 
       expect(snapshot.errors).toEqual([]);
       expect(snapshot.tools.local_weather).toMatchObject({
@@ -805,7 +809,7 @@ describe("extension host", () => {
       });
       expect(getExtensionToolDefinition("local_weather")).toBeDefined();
 
-      host.dispose();
+      engine.dispose();
       expect(getExtensionToolDefinition("local_weather")).toBeUndefined();
     } finally {
       rmSync(root, { force: true, recursive: true });

--- a/src/extensions/extension-engine.ts
+++ b/src/extensions/extension-engine.ts
@@ -216,7 +216,7 @@ export interface LoadLocalExtensionsOptions
   reservedToolNames?: Iterable<string>;
 }
 
-export interface ExtensionHost {
+export interface ExtensionEngine {
   dispose: () => void;
   emitEvent: <TName extends ExtensionEventName>(
     name: TName,
@@ -228,7 +228,7 @@ export interface ExtensionHost {
   subscribe: (listener: () => void) => () => void;
 }
 
-export interface CreateExtensionHostOptions
+export interface CreateExtensionEngineOptions
   extends ResolveLocalExtensionSourcesOptions {
   getContext?: () => ExtensionContext;
   getClient: () => Promise<Letta>;
@@ -1381,9 +1381,9 @@ export function disposeLocalExtensions(registry: LocalExtensionRegistry): void {
   delete registry.ui.statuslineRendererOwner;
 }
 
-export function createExtensionHost(
-  options: CreateExtensionHostOptions,
-): ExtensionHost {
+export function createExtensionEngine(
+  options: CreateExtensionEngineOptions,
+): ExtensionEngine {
   let generation = 0;
   let disposed = false;
   const capabilities = resolveExtensionCapabilities(options.capabilities);
@@ -1439,7 +1439,7 @@ export function createExtensionHost(
           return;
         }
         // Stale handles from a prior generation report through their old
-        // activation callback. Preserve the diagnostic on the current host
+        // activation callback. Preserve the diagnostic on the current engine
         // snapshot without reviving the old registry.
         activeRegistry.diagnostics.push(diagnostic);
         if (diagnostic.phase !== "status.evaluate") {

--- a/src/skills/builtin/creating-extensions/references/architecture.md
+++ b/src/skills/builtin/creating-extensions/references/architecture.md
@@ -96,7 +96,7 @@ Keep state separate from source code. Do not store secrets in plain JSON; use ex
 
 ## Timers and subscriptions
 
-Timers are okay for active-session behavior, but they only run while the extension host is alive. Always clear them:
+Timers are okay for active-session behavior, but they only run while the extension engine is alive. Always clear them:
 
 ```ts
 const timer = setInterval(update, 30_000);


### PR DESCRIPTION
## Summary
- rename the extension host layer/files/types to extension engine
- update adapter and local loader references from host to engine
- update extension architecture docs to use engine terminology

## Tests
- `bun test src/extensions/extension-engine.test.ts src/extensions/extension-adapter.test.ts src/headless-extension-lifecycle.test.ts src/cli/extensions/local-extension-loader.test.ts`
- `bunx --bun @biomejs/biome@2.2.5 check src/extensions/extension-engine.ts src/extensions/extension-engine.test.ts src/extensions/extension-adapter.ts src/extensions/extension-adapter.test.ts src/headless-extension-adapter.ts src/headless-extension-lifecycle.test.ts src/cli/extensions/use-local-extension-adapter.ts src/cli/extensions/local-extension-loader.ts src/skills/builtin/creating-extensions/references/architecture.md`
- `bun run typecheck`
- `git diff --check`