### PR TITLE
fix(bash): add opt-in strict shell mode

### DIFF
--- a/src/tools/bash.test.ts
+++ b/src/tools/bash.test.ts
@@ -5,13 +5,17 @@ import path from "node:path";
 import { runWithRuntimeContext } from "@/runtime-context";
 import { bash } from "@/tools/impl/bash";
 
-async function runBashInTemp(command: string) {
+async function runBashInTemp(
+  command: string,
+  args: Partial<Parameters<typeof bash>[0]> = {},
+) {
   const dir = await mkdtemp(path.join(tmpdir(), "letta-bash-worktree-test-"));
   try {
     return await runWithRuntimeContext({ workingDirectory: dir }, () =>
       bash({
         command,
         description: "Test worktree path handling",
+        ...args,
       }),
     );
   } finally {
@@ -53,30 +57,24 @@ describe("Bash tool", () => {
   test("strict mode fails fast on intermediate shell errors", async () => {
     if (process.platform === "win32") return;
 
-    const previous = process.env.LETTA_BASH_STRICT;
-    process.env.LETTA_BASH_STRICT = "1";
-    try {
-      const result = await runBashInTemp(
-        [
-          "cat > missing-dir/SKILL.md <<'EOF'",
-          "contents",
-          "EOF",
-          "echo 'SKILL.md written successfully'",
-        ].join("\n"),
-      );
+    const result = await runBashInTemp(
+      [
+        "cat > missing-dir/SKILL.md <<'EOF'",
+        "contents",
+        "EOF",
+        "echo 'SKILL.md written successfully'",
+      ].join("\n"),
+      {
+        description: "Test strict mode",
+        secretEnv: { LETTA_BASH_STRICT: "1" },
+      },
+    );
 
-      expect(result.status).toBe("error");
-      expect(result.content[0]?.text).toContain("missing-dir/SKILL.md");
-      expect(result.content[0]?.text).not.toContain(
-        "SKILL.md written successfully",
-      );
-    } finally {
-      if (previous === undefined) {
-        delete process.env.LETTA_BASH_STRICT;
-      } else {
-        process.env.LETTA_BASH_STRICT = previous;
-      }
-    }
+    expect(result.status).toBe("error");
+    expect(result.content[0]?.text).toContain("missing-dir/SKILL.md");
+    expect(result.content[0]?.text).not.toContain(
+      "SKILL.md written successfully",
+    );
   });
 
   test("times out long-running command", async () => {

--- a/src/tools/bash.test.ts
+++ b/src/tools/bash.test.ts
@@ -50,6 +50,35 @@ describe("Bash tool", () => {
     expect(result.content[0]?.text).toContain("Exit code");
   });
 
+  test("strict mode fails fast on intermediate shell errors", async () => {
+    if (process.platform === "win32") return;
+
+    const previous = process.env.LETTA_BASH_STRICT;
+    process.env.LETTA_BASH_STRICT = "1";
+    try {
+      const result = await runBashInTemp(
+        [
+          "cat > missing-dir/SKILL.md <<'EOF'",
+          "contents",
+          "EOF",
+          "echo 'SKILL.md written successfully'",
+        ].join("\n"),
+      );
+
+      expect(result.status).toBe("error");
+      expect(result.content[0]?.text).toContain("missing-dir/SKILL.md");
+      expect(result.content[0]?.text).not.toContain(
+        "SKILL.md written successfully",
+      );
+    } finally {
+      if (previous === undefined) {
+        delete process.env.LETTA_BASH_STRICT;
+      } else {
+        process.env.LETTA_BASH_STRICT = previous;
+      }
+    }
+  });
+
   test("times out long-running command", async () => {
     const result = await bash({
       command: "sleep 10",

--- a/src/tools/impl/bash.ts
+++ b/src/tools/impl/bash.ts
@@ -21,6 +21,19 @@ import { validateRequiredParams } from "./validation.js";
 // Cache the working shell launcher after first successful spawn
 let cachedWorkingLauncher: string[] | null = null;
 
+const STRICT_BASH_ENV_VAR = "LETTA_BASH_STRICT";
+const STRICT_BASH_PRELUDE = "set -euo pipefail";
+
+function isTruthyEnvValue(value: string | undefined): boolean {
+  return value === "1" || value?.toLowerCase() === "true";
+}
+
+function withStrictBashPrelude(command: string, env: NodeJS.ProcessEnv): string {
+  if (process.platform === "win32") return command;
+  if (!isTruthyEnvValue(env[STRICT_BASH_ENV_VAR])) return command;
+  return `${STRICT_BASH_PRELUDE}\n${command}`;
+}
+
 function rebuildCachedLauncher(
   command: string,
   secretEnv?: Record<string, string>,
@@ -78,13 +91,14 @@ export async function spawnCommand(
   const env = options.secretEnv
     ? { ...options.env, ...options.secretEnv }
     : options.env;
+  const commandToRun = withStrictBashPrelude(command, env);
 
   // On Unix (Linux/macOS), use simple bash -c approach (original behavior)
   // This avoids the complexity of fallback logic which caused issues on ARM64 CI
   if (process.platform !== "win32") {
     // On macOS, prefer zsh due to bash 3.2's HEREDOC bug with apostrophes
     const executable = process.platform === "darwin" ? "/bin/zsh" : "bash";
-    return spawnWithLauncher([executable, "-c", command], {
+    return spawnWithLauncher([executable, "-c", commandToRun], {
       cwd: options.cwd,
       env,
       timeoutMs: options.timeout,
@@ -95,7 +109,7 @@ export async function spawnCommand(
 
   // On Windows, use fallback logic to handle PowerShell ENOENT errors (PR #482)
   if (cachedWorkingLauncher) {
-    const newLauncher = rebuildCachedLauncher(command, options.secretEnv);
+    const newLauncher = rebuildCachedLauncher(commandToRun, options.secretEnv);
     if (newLauncher) {
       try {
         const result = await spawnWithLauncher(newLauncher, {
@@ -116,7 +130,7 @@ export async function spawnCommand(
     }
   }
 
-  const launchers = buildShellLaunchers(command, {
+  const launchers = buildShellLaunchers(commandToRun, {
     powershellEnvAliases: options.secretEnv
       ? Object.keys(options.secretEnv)
       : undefined,
@@ -222,9 +236,11 @@ export async function bash(args: BashArgs): Promise<BashResult> {
       };
     }
 
+    const bgEnv = secretEnv ? { ...getShellEnv(), ...secretEnv } : getShellEnv();
+    const bgCommand = withStrictBashPrelude(command, bgEnv);
     const bashId = getNextBashId();
     const outputFile = createBackgroundOutputFile(bashId);
-    const launcher = getBackgroundLauncher(command, secretEnv);
+    const launcher = getBackgroundLauncher(bgCommand, secretEnv);
     const [executable, ...launcherArgs] = launcher;
     if (!executable) {
       return {
@@ -236,7 +252,7 @@ export async function bash(args: BashArgs): Promise<BashResult> {
     const childProcess = spawn(executable, launcherArgs, {
       shell: false,
       cwd: userCwd,
-      env: secretEnv ? { ...getShellEnv(), ...secretEnv } : getShellEnv(),
+      env: bgEnv,
     });
     backgroundProcesses.set(bashId, {
       process: childProcess,

--- a/src/tools/impl/bash.ts
+++ b/src/tools/impl/bash.ts
@@ -28,7 +28,10 @@ function isTruthyEnvValue(value: string | undefined): boolean {
   return value === "1" || value?.toLowerCase() === "true";
 }
 
-function withStrictBashPrelude(command: string, env: NodeJS.ProcessEnv): string {
+function withStrictBashPrelude(
+  command: string,
+  env: NodeJS.ProcessEnv,
+): string {
   if (process.platform === "win32") return command;
   if (!isTruthyEnvValue(env[STRICT_BASH_ENV_VAR])) return command;
   return `${STRICT_BASH_PRELUDE}\n${command}`;
@@ -236,7 +239,9 @@ export async function bash(args: BashArgs): Promise<BashResult> {
       };
     }
 
-    const bgEnv = secretEnv ? { ...getShellEnv(), ...secretEnv } : getShellEnv();
+    const bgEnv = secretEnv
+      ? { ...getShellEnv(), ...secretEnv }
+      : getShellEnv();
     const bgCommand = withStrictBashPrelude(command, bgEnv);
     const bashId = getNextBashId();
     const outputFile = createBackgroundOutputFile(bashId);

--- a/src/tools/impl/bash.ts
+++ b/src/tools/impl/bash.ts
@@ -13,29 +13,16 @@ import {
   unrefTimer,
 } from "./process_manager.js";
 import { getShellEnv } from "./shell-env.js";
-import { buildShellLaunchers } from "./shell-launchers.js";
+import {
+  buildShellLaunchers,
+  withStrictShellPrelude,
+} from "./shell-launchers.js";
 import { spawnWithLauncher } from "./shell-runner.js";
 import { LIMITS, truncateByChars } from "./truncation.js";
 import { validateRequiredParams } from "./validation.js";
 
 // Cache the working shell launcher after first successful spawn
 let cachedWorkingLauncher: string[] | null = null;
-
-const STRICT_BASH_ENV_VAR = "LETTA_BASH_STRICT";
-const STRICT_BASH_PRELUDE = "set -euo pipefail";
-
-function isTruthyEnvValue(value: string | undefined): boolean {
-  return value === "1" || value?.toLowerCase() === "true";
-}
-
-function withStrictBashPrelude(
-  command: string,
-  env: NodeJS.ProcessEnv,
-): string {
-  if (process.platform === "win32") return command;
-  if (!isTruthyEnvValue(env[STRICT_BASH_ENV_VAR])) return command;
-  return `${STRICT_BASH_PRELUDE}\n${command}`;
-}
 
 function rebuildCachedLauncher(
   command: string,
@@ -94,7 +81,7 @@ export async function spawnCommand(
   const env = options.secretEnv
     ? { ...options.env, ...options.secretEnv }
     : options.env;
-  const commandToRun = withStrictBashPrelude(command, env);
+  const commandToRun = withStrictShellPrelude(command, env);
 
   // On Unix (Linux/macOS), use simple bash -c approach (original behavior)
   // This avoids the complexity of fallback logic which caused issues on ARM64 CI
@@ -242,7 +229,7 @@ export async function bash(args: BashArgs): Promise<BashResult> {
     const bgEnv = secretEnv
       ? { ...getShellEnv(), ...secretEnv }
       : getShellEnv();
-    const bgCommand = withStrictBashPrelude(command, bgEnv);
+    const bgCommand = withStrictShellPrelude(command, bgEnv);
     const bashId = getNextBashId();
     const outputFile = createBackgroundOutputFile(bashId);
     const launcher = getBackgroundLauncher(bgCommand, secretEnv);

--- a/src/tools/impl/shell-command.ts
+++ b/src/tools/impl/shell-command.ts
@@ -71,6 +71,7 @@ export async function shell_command(
   const resolvedWorkdir = resolveShellWorkdir(workdir);
   const launchers = buildShellLaunchers(command, {
     login,
+    env: { ...process.env, ...envOverrides },
     powershellEnvAliases: secretEnv ? Object.keys(secretEnv) : undefined,
   });
   if (launchers.length === 0) {

--- a/src/tools/impl/shell-launchers.ts
+++ b/src/tools/impl/shell-launchers.ts
@@ -1,8 +1,12 @@
 const SEP = "\u0000";
 type ShellLaunchOptions = {
   login?: boolean;
+  env?: NodeJS.ProcessEnv;
   powershellEnvAliases?: string[];
 };
+
+export const STRICT_SHELL_ENV_VAR = "LETTA_BASH_STRICT";
+export const STRICT_SHELL_PRELUDE = "set -euo pipefail";
 
 const POWERSHELL_ENV_ALIASES = [
   "MEMORY_DIR",
@@ -17,6 +21,19 @@ const POWERSHELL_ENV_ALIASES = [
 
 function isValidEnvAlias(name: string): boolean {
   return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name);
+}
+
+function isTruthyEnvValue(value: string | undefined): boolean {
+  return value === "1" || value?.toLowerCase() === "true";
+}
+
+export function withStrictShellPrelude(
+  command: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  if (process.platform === "win32") return command;
+  if (!isTruthyEnvValue(env[STRICT_SHELL_ENV_VAR])) return command;
+  return `${STRICT_SHELL_PRELUDE}\n${command}`;
 }
 
 function pushUnique(
@@ -168,7 +185,8 @@ export function buildShellLaunchers(
   options?: ShellLaunchOptions,
 ): string[][] {
   const login = options?.login ?? false;
+  const commandToRun = withStrictShellPrelude(command, options?.env);
   return process.platform === "win32"
-    ? windowsLaunchers(command, options?.powershellEnvAliases)
-    : unixLaunchers(command, login);
+    ? windowsLaunchers(commandToRun, options?.powershellEnvAliases)
+    : unixLaunchers(commandToRun, login);
 }

--- a/src/tools/run-shell-command.test.ts
+++ b/src/tools/run-shell-command.test.ts
@@ -25,6 +25,24 @@ describe("RunShellCommand tool (Gemini)", () => {
     expect(result.message).toBeTruthy();
   });
 
+  test("strict mode fails fast on intermediate shell errors", async () => {
+    if (process.platform === "win32") return;
+
+    const result = await run_shell_command({
+      command: [
+        "cat > missing-dir/SKILL.md <<'EOF'",
+        "contents",
+        "EOF",
+        "echo 'SKILL.md written successfully'",
+      ].join("\n"),
+      dir_path: process.cwd(),
+      secretEnv: { LETTA_BASH_STRICT: "1" },
+    });
+
+    expect(result.message).toContain("missing-dir/SKILL.md");
+    expect(result.message).not.toContain("SKILL.md written successfully");
+  });
+
   test("throws error when command is missing", async () => {
     await expect(
       run_shell_command({

--- a/src/tools/shell-command.test.ts
+++ b/src/tools/shell-command.test.ts
@@ -37,6 +37,24 @@ test("shell_command preserves stdout and stderr arrays when output is not trunca
   }
 });
 
+test("shell_command strict mode fails fast on intermediate shell errors", async () => {
+  if (process.platform === "win32") return;
+
+  const result = await shell_command({
+    command: [
+      "cat > missing-dir/SKILL.md <<'EOF'",
+      "contents",
+      "EOF",
+      "echo 'SKILL.md written successfully'",
+    ].join("\n"),
+    workdir: process.cwd(),
+    secretEnv: { LETTA_BASH_STRICT: "1" },
+  });
+
+  expect(result.output).toContain("missing-dir/SKILL.md");
+  expect(result.output).not.toContain("SKILL.md written successfully");
+});
+
 test("shell_command falls back when preferred shell is missing", async () => {
   const marker = "shell-fallback";
   if (process.platform === "win32") {

--- a/src/tools/shell-launchers.test.ts
+++ b/src/tools/shell-launchers.test.ts
@@ -77,6 +77,14 @@ describe("Shell Launchers", () => {
     });
   } else {
     describe("Unix-specific", () => {
+      test("prepends strict shell prelude when LETTA_BASH_STRICT is set", () => {
+        const launchers = buildShellLaunchers("echo test", {
+          env: { LETTA_BASH_STRICT: "1" },
+        });
+
+        expect(launchers[0]?.at(-1)).toBe("set -euo pipefail\necho test");
+      });
+
       test("includes bash with -c flag", () => {
         const launchers = buildShellLaunchers("echo test");
         const bashLauncher = launchers.find(


### PR DESCRIPTION
## Summary
- Add `LETTA_BASH_STRICT=1` to opt into running Unix shell commands with `set -euo pipefail`.
- Apply the strict prelude through the shared shell launcher path so `Bash`, `shell_command`, and `run_shell_command` all get the same behavior while default interactive behavior remains unchanged.
- Add regression/parity tests for the rollout bug where an intermediate shell failure can be masked by a later successful command.

## Context
While debugging Tinker skill-reflection rollouts, we found trajectories where the agent attempted to write a skill file to a missing directory, then printed a success message. Because the shell command ended with a successful command, Letta Code returned a successful tool result even though the actual write failed. Minimal example:

```bash
cat missing-file
echo "SKILL.md written successfully"
```

Without strict mode, the final `echo` can make the overall shell exit code `0`, so shell tools report success even though an earlier required operation failed. In the rollout, the observed feedback looked like:

```text
SKILL.md written successfully
bash: .../SKILL.md: No such file or directory
```

but the tool status was still `success`. That can corrupt eval/training signal because the policy sees a successful tool call for a failed file write. Harnesses can now set `LETTA_BASH_STRICT=1` so these intermediate shell failures propagate through the tool output.

## Test plan
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun test src/tools/bash.test.ts --test-name-pattern "strict mode"`
- [x] `bun test src/tools/shell-command.test.ts --test-name-pattern "strict mode"`
- [x] `bun test src/tools/run-shell-command.test.ts --test-name-pattern "strict mode"`
- [x] `bun test src/tools/shell-launchers.test.ts --test-name-pattern "strict shell"`

👾 Generated with [Letta Code](https://letta.com)
