### PR TITLE
feat(extensions): allow slash command overrides

### DIFF
--- a/src/cli/app/command-routing.test.ts
+++ b/src/cli/app/command-routing.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { shouldSlashCommandBypassQueue } from "./command-routing";
+
+describe("command routing", () => {
+  test("uses source precedence for slash command queue bypass", () => {
+    expect(shouldSlashCommandBypassQueue("/reload")).toBe(true);
+
+    expect(
+      shouldSlashCommandBypassQueue("/reload", {
+        extensionCommand: { runWhenBusy: false },
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldSlashCommandBypassQueue("/review", {
+        extensionCommand: { runWhenBusy: true },
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldSlashCommandBypassQueue("/review", {
+        hasCustomCommand: true,
+        extensionCommand: { runWhenBusy: true },
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/cli/app/command-routing.ts
+++ b/src/cli/app/command-routing.ts
@@ -69,3 +69,15 @@ export function isNonStateCommand(msg: string): boolean {
   }
   return false;
 }
+
+export function shouldSlashCommandBypassQueue(
+  msg: string,
+  options: {
+    hasCustomCommand?: boolean;
+    extensionCommand?: { runWhenBusy: boolean };
+  } = {},
+): boolean {
+  if (options.hasCustomCommand) return false;
+  if (options.extensionCommand) return options.extensionCommand.runWhenBusy;
+  return isInteractiveCommand(msg) || isNonStateCommand(msg);
+}

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -40,6 +40,7 @@ import { recordSessionEnd } from "@/agent/session-history";
 import type { SessionStats } from "@/agent/stats";
 import { getBackend } from "@/backend";
 import { getClient } from "@/backend/api/client";
+import type { CustomCommand } from "@/cli/commands/custom";
 import type { CommandHandle } from "@/cli/commands/runner";
 import { validateAgentName } from "@/cli/components/PinDialog";
 import {
@@ -49,7 +50,6 @@ import {
   runExtensionCommandWithTimeout,
 } from "@/cli/extensions/command-runtime";
 import type {
-  ExtensionCommand,
   ExtensionCommandContext,
   ExtensionConversationCloseReason,
 } from "@/cli/extensions/types";
@@ -127,7 +127,7 @@ import { debugLog, debugWarn } from "@/utils/debug";
 import { extractTaskNotificationsForDisplay } from "@/utils/task-notifications";
 import { switchCurrentRuntimeWorkingDirectory } from "@/websocket/listener/cwd-change";
 
-import { isInteractiveCommand, isNonStateCommand } from "./command-routing";
+import { shouldSlashCommandBypassQueue } from "./command-routing";
 import { buildTextParts } from "./content-parts";
 import { buildGoalPrompt } from "./goal-loop";
 import { appendOptimisticUserLine, createClientOtid, uid } from "./ids";
@@ -169,9 +169,11 @@ type ModelSelectorOptions = {
   forceRefresh?: boolean;
 };
 
-async function hasCustomCommand(commandName: string): Promise<boolean> {
+async function findCustomCommandByName(
+  commandName: string,
+): Promise<CustomCommand | undefined> {
   const { findCustomCommand } = await import("@/cli/commands/custom.js");
-  return Boolean(await findCustomCommand(commandName));
+  return findCustomCommand(commandName);
 }
 
 type SubmitHandlerContext = {
@@ -578,21 +580,23 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
       const parsedExtensionCommand = isSlashCommand
         ? parseExtensionSlashCommand(userTextForInput.trim())
         : null;
-      const queueBypassExtensionCommand = parsedExtensionCommand
-        ? extensionAdapter.registry?.commands[parsedExtensionCommand.command]
+      const parsedSlashCommandName = parsedExtensionCommand?.command ?? null;
+      const matchedCustomCommand = parsedSlashCommandName
+        ? await findCustomCommandByName(parsedSlashCommandName)
         : undefined;
-      const isExtensionCommandShadowedByCustom =
-        isAgentBusy() && queueBypassExtensionCommand?.runWhenBusy === true
-          ? await hasCustomCommand(parsedExtensionCommand?.command ?? "")
-          : false;
+      const matchedExtensionCommand = parsedSlashCommandName
+        ? extensionAdapter.registry?.commands[parsedSlashCommandName]
+        : undefined;
       // Interactive/non-state slash commands bypass queueing so menus stay responsive
       // while the agent is busy. Overlay writes are still deferred via queuedOverlayAction.
       const shouldBypassQueue =
         isSlashCommand &&
-        (isInteractiveCommand(userTextForInput) ||
-          isNonStateCommand(userTextForInput) ||
-          (queueBypassExtensionCommand?.runWhenBusy === true &&
-            !isExtensionCommandShadowedByCustom));
+        shouldSlashCommandBypassQueue(userTextForInput, {
+          hasCustomCommand: Boolean(matchedCustomCommand),
+          ...(matchedExtensionCommand
+            ? { extensionCommand: matchedExtensionCommand }
+            : {}),
+        });
 
       if (isAgentBusy() && isSlashCommand && !shouldBypassQueue) {
         const attemptedCommand = userTextForInput.split(/\s+/)[0] || "/";
@@ -624,6 +628,172 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
       // Handle commands (messages starting with "/")
       if (aliasedMsg.startsWith("/")) {
         const trimmed = aliasedMsg.trim();
+
+        // Custom commands and extension commands override built-ins.
+        if (matchedCustomCommand) {
+          const { substituteArguments, expandBashCommands } = await import(
+            "@/cli/commands/custom.js"
+          );
+          const cmd = commandRunner.start(
+            trimmed,
+            `Running /${matchedCustomCommand.id}...`,
+          );
+
+          // Check for pending approvals before sending
+          const approvalCheck = await checkPendingApprovalsForSlashCommand();
+          if (approvalCheck.blocked) {
+            cmd.fail(
+              `Pending approval(s). Resolve approvals before running /${matchedCustomCommand.id}.`,
+            );
+            return { submitted: false }; // Keep custom command in input box, user handles approval first
+          }
+
+          // Extract arguments (everything after command name)
+          const args = trimmed
+            .slice(`/${matchedCustomCommand.id}`.length)
+            .trim();
+
+          // Build prompt: 1) substitute args, 2) expand bash commands
+          let prompt = substituteArguments(matchedCustomCommand.content, args);
+          prompt = await expandBashCommands(prompt);
+
+          // Show command in transcript (running phase for visual feedback)
+          setCommandRunning(true);
+
+          try {
+            // Mark command as finished BEFORE sending to agent
+            // (matches /remember pattern - command succeeded in triggering agent)
+            cmd.finish("Running custom command...", true);
+
+            // Send prompt to agent
+            // NOTE: Unlike /remember, we DON'T append args separately because
+            // they're already substituted into the prompt via $ARGUMENTS
+            await processConversationWithQueuedApprovals([
+              {
+                type: "message",
+                role: "user",
+                content: buildTextParts(
+                  `${SYSTEM_REMINDER_OPEN}\n${prompt}\n${SYSTEM_REMINDER_CLOSE}`,
+                ),
+                otid: randomUUID(),
+              },
+            ]);
+          } catch (error) {
+            // Only catch errors from processConversation setup, not agent execution
+            const errorDetails = formatErrorDetails(error, agentId);
+            cmd.fail(`Failed to run command: ${errorDetails}`);
+          } finally {
+            setCommandRunning(false);
+          }
+
+          return { submitted: true };
+        }
+
+        if (parsedExtensionCommand && matchedExtensionCommand) {
+          const showInTranscript = matchedExtensionCommand.showInTranscript;
+          const shouldLockCommand = !matchedExtensionCommand.runWhenBusy;
+          const cmd = showInTranscript
+            ? commandRunner.start(
+                trimmed,
+                `Running /${matchedExtensionCommand.id}...`,
+              )
+            : null;
+          const getFeedbackCommand = () =>
+            cmd ??
+            commandRunner.start(
+              trimmed,
+              `Running /${matchedExtensionCommand.id}...`,
+            );
+          if (shouldLockCommand) {
+            setCommandRunning(true);
+          }
+
+          try {
+            const extensionContext = extensionAdapter.getContext();
+            const cwd = getCurrentWorkingDirectory();
+            const conversation = createExtensionConversationHandle({
+              agentId,
+              backend: extensionAdapter.getBackendApi(),
+              conversationId: conversationIdRef.current,
+              workingDirectory: cwd,
+            });
+            const commandContext: ExtensionCommandContext = {
+              agent: { id: agentId, name: agentName },
+              args: parsedExtensionCommand.args,
+              argv: parseExtensionCommandArgv(parsedExtensionCommand.args),
+              command: parsedExtensionCommand.command,
+              conversation: { ...conversation, id: conversationIdRef.current },
+              cwd,
+              getContext: extensionAdapter.getContext,
+              model: {
+                id:
+                  currentModelId ??
+                  llmConfigRef.current?.model ??
+                  extensionContext.model.id,
+                displayName: extensionContext.model.displayName,
+              },
+              permissionMode: extensionContext.permissionMode,
+              rawInput: trimmed,
+            };
+            const result = await runExtensionCommandWithTimeout(
+              matchedExtensionCommand,
+              commandContext,
+            );
+
+            if (result.type === "prompt") {
+              if (!showInTranscript) {
+                getFeedbackCommand().fail(
+                  `/${matchedExtensionCommand.id} returned a prompt with showInTranscript: false. Hidden extension commands must return output or handled and own their UI.`,
+                );
+                return { submitted: true };
+              }
+
+              if (matchedExtensionCommand.runWhenBusy && isAgentBusy()) {
+                getFeedbackCommand().fail(
+                  `/${matchedExtensionCommand.id} returned a prompt while the agent is running. Busy-safe extension commands must handle their own SDK calls or return output.`,
+                );
+                return { submitted: true };
+              }
+
+              const approvalCheck =
+                await checkPendingApprovalsForSlashCommand();
+              if (approvalCheck.blocked) {
+                getFeedbackCommand().fail(
+                  `Pending approval(s). Resolve approvals before running /${matchedExtensionCommand.id}.`,
+                );
+                return { submitted: false };
+              }
+
+              cmd?.finish(`Running /${matchedExtensionCommand.id}...`, true);
+              await processConversationWithQueuedApprovals([
+                {
+                  type: "message",
+                  role: "user",
+                  content: buildTextParts(buildExtensionCommandPrompt(result)),
+                  otid: randomUUID(),
+                },
+              ]);
+            } else if (result.type === "output") {
+              getFeedbackCommand().finish(
+                result.output,
+                result.success ?? true,
+              );
+            } else {
+              cmd?.finish("Handled.", true, true);
+            }
+          } catch (error) {
+            const errorDetails = formatErrorDetails(error, agentId);
+            getFeedbackCommand().fail(
+              `Failed to run /${matchedExtensionCommand.id}: ${errorDetails}`,
+            );
+          } finally {
+            if (shouldLockCommand) {
+              setCommandRunning(false);
+            }
+          }
+
+          return { submitted: true };
+        }
 
         // Special handling for /model command - opens selector
         if (trimmed === "/model") {
@@ -2986,181 +3156,6 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           } finally {
             setCommandRunning(false);
           }
-          return { submitted: true };
-        }
-
-        // === Custom command handling ===
-        // Check BEFORE falling through to executeCommand()
-        const { findCustomCommand, substituteArguments, expandBashCommands } =
-          await import("@/cli/commands/custom.js");
-        const customCommandName = trimmed.split(/\s+/)[0]?.slice(1) || ""; // e.g., "review" from "/review arg"
-        const matchedCustom = await findCustomCommand(customCommandName);
-
-        if (matchedCustom) {
-          const cmd = commandRunner.start(
-            trimmed,
-            `Running /${matchedCustom.id}...`,
-          );
-
-          // Check for pending approvals before sending
-          const approvalCheck = await checkPendingApprovalsForSlashCommand();
-          if (approvalCheck.blocked) {
-            cmd.fail(
-              `Pending approval(s). Resolve approvals before running /${matchedCustom.id}.`,
-            );
-            return { submitted: false }; // Keep custom command in input box, user handles approval first
-          }
-
-          // Extract arguments (everything after command name)
-          const args = trimmed.slice(`/${matchedCustom.id}`.length).trim();
-
-          // Build prompt: 1) substitute args, 2) expand bash commands
-          let prompt = substituteArguments(matchedCustom.content, args);
-          prompt = await expandBashCommands(prompt);
-
-          // Show command in transcript (running phase for visual feedback)
-          setCommandRunning(true);
-
-          try {
-            // Mark command as finished BEFORE sending to agent
-            // (matches /remember pattern - command succeeded in triggering agent)
-            cmd.finish("Running custom command...", true);
-
-            // Send prompt to agent
-            // NOTE: Unlike /remember, we DON'T append args separately because
-            // they're already substituted into the prompt via $ARGUMENTS
-            await processConversationWithQueuedApprovals([
-              {
-                type: "message",
-                role: "user",
-                content: buildTextParts(
-                  `${SYSTEM_REMINDER_OPEN}\n${prompt}\n${SYSTEM_REMINDER_CLOSE}`,
-                ),
-                otid: randomUUID(),
-              },
-            ]);
-          } catch (error) {
-            // Only catch errors from processConversation setup, not agent execution
-            const errorDetails = formatErrorDetails(error, agentId);
-            cmd.fail(`Failed to run command: ${errorDetails}`);
-          } finally {
-            setCommandRunning(false);
-          }
-
-          return { submitted: true };
-        }
-        // === END custom command handling ===
-
-        const matchedExtensionCommand: ExtensionCommand | undefined =
-          parsedExtensionCommand
-            ? extensionAdapter.registry?.commands[
-                parsedExtensionCommand.command
-              ]
-            : undefined;
-
-        if (parsedExtensionCommand && matchedExtensionCommand) {
-          const showInTranscript = matchedExtensionCommand.showInTranscript;
-          const shouldLockCommand = !matchedExtensionCommand.runWhenBusy;
-          const cmd = showInTranscript
-            ? commandRunner.start(
-                trimmed,
-                `Running /${matchedExtensionCommand.id}...`,
-              )
-            : null;
-          const getFeedbackCommand = () =>
-            cmd ??
-            commandRunner.start(
-              trimmed,
-              `Running /${matchedExtensionCommand.id}...`,
-            );
-          if (shouldLockCommand) {
-            setCommandRunning(true);
-          }
-
-          try {
-            const extensionContext = extensionAdapter.getContext();
-            const cwd = getCurrentWorkingDirectory();
-            const conversation = createExtensionConversationHandle({
-              agentId,
-              backend: extensionAdapter.getBackendApi(),
-              conversationId: conversationIdRef.current,
-              workingDirectory: cwd,
-            });
-            const commandContext: ExtensionCommandContext = {
-              agent: { id: agentId, name: agentName },
-              args: parsedExtensionCommand.args,
-              argv: parseExtensionCommandArgv(parsedExtensionCommand.args),
-              command: parsedExtensionCommand.command,
-              conversation: { ...conversation, id: conversationIdRef.current },
-              cwd,
-              getContext: extensionAdapter.getContext,
-              model: {
-                id:
-                  currentModelId ??
-                  llmConfigRef.current?.model ??
-                  extensionContext.model.id,
-                displayName: extensionContext.model.displayName,
-              },
-              permissionMode: extensionContext.permissionMode,
-              rawInput: trimmed,
-            };
-            const result = await runExtensionCommandWithTimeout(
-              matchedExtensionCommand,
-              commandContext,
-            );
-
-            if (result.type === "prompt") {
-              if (!showInTranscript) {
-                getFeedbackCommand().fail(
-                  `/${matchedExtensionCommand.id} returned a prompt with showInTranscript: false. Hidden extension commands must return output or handled and own their UI.`,
-                );
-                return { submitted: true };
-              }
-
-              if (matchedExtensionCommand.runWhenBusy && isAgentBusy()) {
-                getFeedbackCommand().fail(
-                  `/${matchedExtensionCommand.id} returned a prompt while the agent is running. Busy-safe extension commands must handle their own SDK calls or return output.`,
-                );
-                return { submitted: true };
-              }
-
-              const approvalCheck =
-                await checkPendingApprovalsForSlashCommand();
-              if (approvalCheck.blocked) {
-                getFeedbackCommand().fail(
-                  `Pending approval(s). Resolve approvals before running /${matchedExtensionCommand.id}.`,
-                );
-                return { submitted: false };
-              }
-
-              cmd?.finish(`Running /${matchedExtensionCommand.id}...`, true);
-              await processConversationWithQueuedApprovals([
-                {
-                  type: "message",
-                  role: "user",
-                  content: buildTextParts(buildExtensionCommandPrompt(result)),
-                  otid: randomUUID(),
-                },
-              ]);
-            } else if (result.type === "output") {
-              getFeedbackCommand().finish(
-                result.output,
-                result.success ?? true,
-              );
-            } else {
-              cmd?.finish("Handled.", true, true);
-            }
-          } catch (error) {
-            const errorDetails = formatErrorDetails(error, agentId);
-            getFeedbackCommand().fail(
-              `Failed to run /${matchedExtensionCommand.id}: ${errorDetails}`,
-            );
-          } finally {
-            if (shouldLockCommand) {
-              setCommandRunning(false);
-            }
-          }
-
           return { submitted: true };
         }
 

--- a/src/cli/components/SlashCommandAutocomplete.tsx
+++ b/src/cli/components/SlashCommandAutocomplete.tsx
@@ -147,9 +147,21 @@ export function SlashCommandAutocomplete({
       order: command.order,
     }));
 
+    const customCommandNames = new Set(customCommands.map((cmd) => cmd.cmd));
+    const extensionCommandNames = new Set(
+      extensionCommandMatches.map((cmd) => cmd.cmd),
+    );
+    const visibleBuiltins = builtins.filter(
+      (cmd) =>
+        !customCommandNames.has(cmd.cmd) && !extensionCommandNames.has(cmd.cmd),
+    );
+    const visibleExtensionCommands = extensionCommandMatches.filter(
+      (cmd) => !customCommandNames.has(cmd.cmd),
+    );
+
     const reservedCommands = new Set([
-      ...builtins.map((cmd) => cmd.cmd),
-      ...extensionCommandMatches.map((cmd) => cmd.cmd),
+      ...visibleBuiltins.map((cmd) => cmd.cmd),
+      ...visibleExtensionCommands.map((cmd) => cmd.cmd),
       ...customCommands.map((cmd) => cmd.cmd),
     ]);
     const visibleSkillCommands = skillCommands.filter(
@@ -158,8 +170,8 @@ export function SlashCommandAutocomplete({
 
     // Merge command sources and sort by order.
     return [
-      ...builtins,
-      ...extensionCommandMatches,
+      ...visibleBuiltins,
+      ...visibleExtensionCommands,
       ...customCommands,
       ...visibleSkillCommands,
     ].sort((a, b) => (a.order ?? 100) - (b.order ?? 100));

--- a/src/cli/extensions/local-extension-loader.test.ts
+++ b/src/cli/extensions/local-extension-loader.test.ts
@@ -457,7 +457,7 @@ describe("local extension loader", () => {
     }
   });
 
-  test("rejects extension command id collisions", async () => {
+  test("rejects extension command id collisions and diagnoses built-in overrides", async () => {
     const root = createTempDir();
     try {
       const options = createLoadOptions(root);
@@ -506,17 +506,28 @@ describe("local extension loader", () => {
 
       const registry = await loadLocalExtensions(options);
 
-      expect(Object.keys(registry.commands)).toEqual(["dupe"]);
+      expect(Object.keys(registry.commands)).toEqual(["dupe", "reload"]);
+      expect(registry.commands.reload?.description).toBe("Built-in conflict");
       expect(registry.errors.map((entry) => entry.path).sort()).toEqual([
         path.join(extensionDir, "b.ts"),
-        path.join(extensionDir, "c.ts"),
         path.join(extensionDir, "d.ts"),
       ]);
       expect(registry.errors.map((entry) => entry.error.message)).toEqual([
         expect.stringContaining("already registered"),
-        expect.stringContaining("built-in command"),
         expect.stringContaining("must not start"),
       ]);
+      expect(registry.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            capability: { id: "reload", kind: "command" },
+            error: expect.objectContaining({
+              message: expect.stringContaining("overrides a built-in command"),
+            }),
+            path: path.join(extensionDir, "c.ts"),
+            phase: "command.override",
+          }),
+        ]),
+      );
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/src/cli/extensions/local-extension-loader.ts
+++ b/src/cli/extensions/local-extension-loader.ts
@@ -23,7 +23,7 @@ function stripSlash(command: string): string {
   return command.startsWith("/") ? command.slice(1) : command;
 }
 
-function getDefaultReservedCommandIds(): Set<string> {
+function getDefaultBuiltinCommandIds(): Set<string> {
   return new Set(Object.keys(builtinCommands).map(stripSlash));
 }
 
@@ -38,18 +38,18 @@ function getDefaultReservedToolNames(): Set<string> {
 
 function withDefaultReservations<
   T extends {
+    builtinCommandIds?: Iterable<string>;
     capabilities?: ExtensionCapabilities;
-    reservedCommandIds?: Iterable<string>;
     reservedToolNames?: Iterable<string>;
   },
 >(options: T): T {
   return {
     ...options,
-    capabilities: options.capabilities ?? TUI_EXTENSION_CAPABILITIES,
-    reservedCommandIds: [
-      ...getDefaultReservedCommandIds(),
-      ...(options.reservedCommandIds ?? []),
+    builtinCommandIds: [
+      ...getDefaultBuiltinCommandIds(),
+      ...(options.builtinCommandIds ?? []),
     ],
+    capabilities: options.capabilities ?? TUI_EXTENSION_CAPABILITIES,
     reservedToolNames: [
       ...getDefaultReservedToolNames(),
       ...(options.reservedToolNames ?? []),

--- a/src/extensions/extension-adapter.ts
+++ b/src/extensions/extension-adapter.ts
@@ -296,6 +296,11 @@ export function createExtensionAdapter(
       );
     }
 
+    for (const diagnostic of nextRegistry.diagnostics) {
+      if (diagnostic.phase !== "command.override") continue;
+      debugLog("extensions", "%s", diagnostic.error.message);
+    }
+
     loadState = {
       hadStatuslineRenderer: Boolean(nextRegistry.ui.statuslineRenderer),
       hasExtensionSources: nextRegistry.sources.some(

--- a/src/extensions/extension-engine.ts
+++ b/src/extensions/extension-engine.ts
@@ -209,10 +209,10 @@ export interface LoadLocalExtensionsOptions
   getClient: () => Promise<Letta>;
   backend?: ExtensionAdapterBackendApi;
   capabilities?: ExtensionCapabilities;
+  builtinCommandIds?: Iterable<string>;
   generation?: number;
   onChange?: () => void;
   onDiagnostic?: (diagnostic: ExtensionDiagnostic) => void;
-  reservedCommandIds?: Iterable<string>;
   reservedToolNames?: Iterable<string>;
 }
 
@@ -233,8 +233,8 @@ export interface CreateExtensionEngineOptions
   getContext?: () => ExtensionContext;
   getClient: () => Promise<Letta>;
   backend?: ExtensionAdapterBackendApi;
+  builtinCommandIds?: Iterable<string>;
   capabilities?: ExtensionCapabilities;
-  reservedCommandIds?: Iterable<string>;
   reservedToolNames?: Iterable<string>;
 }
 
@@ -324,7 +324,10 @@ function recordExtensionDiagnostic(
     timestamp: Date.now(),
   };
   registry.diagnostics.push(completeDiagnostic);
-  if (completeDiagnostic.phase !== "status.evaluate") {
+  if (
+    completeDiagnostic.phase !== "status.evaluate" &&
+    completeDiagnostic.phase !== "command.override"
+  ) {
     registry.errors.push({
       error: completeDiagnostic.error,
       ...(completeDiagnostic.owner ? { owner: completeDiagnostic.owner } : {}),
@@ -831,7 +834,7 @@ function createLettaExtensionApi(
   getContext: () => ExtensionContext,
   onChange: () => void,
   onDiagnostic: ((diagnostic: ExtensionDiagnostic) => void) | undefined,
-  reservedCommandIds: Set<string>,
+  builtinCommandIds: Set<string>,
   reservedToolNames: Set<string>,
   signal: AbortSignal,
 ): LettaExtensionApi {
@@ -975,9 +978,19 @@ function createLettaExtensionApi(
         }
 
         const normalized = normalizeExtensionCommand(command, owner);
-        if (reservedCommandIds.has(normalized.id)) {
-          throw new Error(
-            `Extension command '${normalized.id}' conflicts with a built-in command`,
+        if (builtinCommandIds.has(normalized.id)) {
+          recordExtensionDiagnostic(
+            registry,
+            {
+              capability: { id: normalized.id, kind: "command" },
+              error: new Error(
+                `Extension command '${normalized.id}' overrides a built-in command`,
+              ),
+              owner,
+              path: owner.path,
+              phase: "command.override",
+            },
+            onDiagnostic,
           );
         }
 
@@ -1132,7 +1145,7 @@ export async function loadLocalExtensions(
   const sources = resolveLocalExtensionSources(options);
   const capabilities = resolveExtensionCapabilities(options.capabilities);
   const generation = options.generation ?? 1;
-  const reservedCommandIds = new Set([...(options.reservedCommandIds ?? [])]);
+  const builtinCommandIds = new Set([...(options.builtinCommandIds ?? [])]);
   const reservedToolNames = new Set([...(options.reservedToolNames ?? [])]);
   const registry = createEmptyExtensionRegistry(
     sources,
@@ -1181,7 +1194,7 @@ export async function loadLocalExtensions(
             getContext,
             onChange,
             options.onDiagnostic,
-            reservedCommandIds,
+            builtinCommandIds,
             reservedToolNames,
             abortController.signal,
           ),
@@ -1442,7 +1455,10 @@ export function createExtensionEngine(
         // activation callback. Preserve the diagnostic on the current engine
         // snapshot without reviving the old registry.
         activeRegistry.diagnostics.push(diagnostic);
-        if (diagnostic.phase !== "status.evaluate") {
+        if (
+          diagnostic.phase !== "status.evaluate" &&
+          diagnostic.phase !== "command.override"
+        ) {
           activeRegistry.errors.push({
             error: diagnostic.error,
             ...(diagnostic.owner ? { owner: diagnostic.owner } : {}),

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -292,6 +292,7 @@ export type ExtensionDiagnosticPhase =
   | "transpile"
   | "import"
   | "activate"
+  | "command.override"
   | "dispose"
   | "event"
   | "stale_handle"

--- a/src/skills/builtin/creating-extensions/SKILL.md
+++ b/src/skills/builtin/creating-extensions/SKILL.md
@@ -106,7 +106,7 @@ letta.capabilities.ui.customStatuslineRenderer
 Before finishing, verify:
 
 - The extension has one clear owner/file and does not mix unrelated features.
-- Command/tool IDs are valid and do not collide with built-ins.
+- Command/tool IDs are valid; command overrides of built-ins are intentional, and tool IDs do not collide with built-ins.
 - Tool descriptions explain when the model should call them.
 - JSON schemas are object schemas with useful descriptions.
 - Optional UI/event/statusline APIs are capability-guarded.

--- a/src/skills/builtin/creating-extensions/references/commands.md
+++ b/src/skills/builtin/creating-extensions/references/commands.md
@@ -20,7 +20,7 @@ If the command represents a durable agent workflow (for example `/goal`), put th
 
 - Do not include the leading slash. Use `id: "review"`, not `id: "/review"`.
 - Use a lowercase slug with letters, numbers, and hyphens only.
-- Built-in commands like `/reload`, `/model`, `/statusline`, etc. are reserved.
+- Built-in commands like `/reload`, `/model`, `/statusline`, etc. can be overridden by trusted local extensions. Do this intentionally and keep recovery in mind: start with `--no-extensions` or `LETTA_DISABLE_EXTENSIONS=1` if an override breaks command handling.
 - Duplicate extension command IDs fail unless `override: true` is intentional.
 
 ## Prompt command


### PR DESCRIPTION
## Summary
- allow trusted extension slash commands to override built-in commands while keeping tool reservations unchanged
- route slash commands by source precedence: custom > extension > built-in/skill
- make busy queue bypass source-aware so extension overrides only bypass when `runWhenBusy` is set
- hide lower-precedence duplicate commands from autocomplete and update extension docs

## Tests
- `bun test src/cli/app/command-routing.test.ts src/cli/extensions/local-extension-loader.test.ts src/extensions/extension-engine.test.ts src/extensions/extension-adapter.test.ts src/cli/extensions/command-runtime.test.ts`
- `bun run typecheck`
- `bun run check`
- `git diff --check`