### PR TITLE
fix: correct Claude Code dispatch guidance

### DIFF
--- a/src/skills/builtin/dispatching-coding-agents/SKILL.md
+++ b/src/skills/builtin/dispatching-coding-agents/SKILL.md
@@ -108,6 +108,8 @@ For hard problems, use the strongest available models:
 codex exec "YOUR PROMPT" -m gpt-5.3-codex --full-auto -C /path/to/repo
 ```
 
+Claude Code does not support a `-C` working-directory flag. Run the Bash tool with its `workdir` set to the target repo, or `cd /path/to/repo && claude ...` inside the shell command. Use `--add-dir` only to grant access to additional directories outside the current working directory.
+
 ### Code review — cross-agent validation
 Have one agent write code or create a plan, then dispatch another to review:
 ```bash
@@ -123,8 +125,9 @@ claude -p "Review the following diff for correctness, edge cases, and missed err
 ### Get outside feedback on your work
 Write your plan or analysis to a file, then ask a subagent to critique it:
 ```bash
+# Run this from the target repo, or set the Bash tool's workdir to the repo.
 claude -p "Read /tmp/my-plan.md and critique it. What am I missing? What could go wrong?" \
-  --model opus --dangerously-skip-permissions -C /path/to/repo
+  --model opus --dangerously-skip-permissions
 ```
 
 ## Handling Failures
@@ -151,8 +154,10 @@ claude -p "YOUR PROMPT" --model MODEL --dangerously-skip-permissions
 | `--append-system-prompt "..."` | Inject additional system instructions |
 | `--allowedTools "Bash Edit Read"` | Restrict available tools |
 | `--max-budget-usd N` | Cap spend for the invocation |
-| `-C DIR` | Set working directory |
+| `--add-dir DIR` | Allow access to an additional directory; does not change the working directory |
 | `--output-format json` | Structured output with `session_id`, `cost_usd`, `duration_ms` |
+
+Set Claude Code's working directory via the surrounding shell/tool invocation, not a Claude flag. In Letta Code, pass `workdir` to the Bash tool. In a raw shell, use `cd /path/to/repo && claude ...`.
 
 ### Codex
 


### PR DESCRIPTION
## Summary
- remove stale Claude Code `-C` guidance from the dispatching-coding-agents skill
- document using the Bash tool `workdir` or `cd /path/to/repo && claude ...` for Claude working directory control
- clarify that `--add-dir` grants additional directory access but does not change cwd

## Testing
- `bun run check` (fails on unrelated pre-existing TypeScript errors in `src/web/generate-diff-viewer.ts` for missing `@pierre/diffs` declarations)
- verified the updated installed Claude Code CLI is `2.1.159` and does not expose `-C` in help