### PR TITLE
fix(cli): cap slash command autocomplete rows

### DIFF
--- a/src/cli/components/SlashCommandAutocomplete.tsx
+++ b/src/cli/components/SlashCommandAutocomplete.tsx
@@ -11,7 +11,9 @@ import { AutocompleteBox, AutocompleteItem } from "./Autocomplete";
 import { Text } from "./Text";
 import type { AutocompleteProps, CommandMatch } from "./types/autocomplete";
 
-const MAX_VISIBLE_COMMANDS = 12; // Maximum commands visible at once
+// Match Codex's slash-command popup behavior: a small hard cap that can shrink
+// on short terminals, but never expands just because the terminal is tall.
+const MAX_POPUP_ROWS = 8;
 const CMD_COL_WIDTH = 14;
 
 const BUILTIN_SKILL_ALIASES = new Set([
@@ -288,10 +290,8 @@ export function SlashCommandAutocomplete({
   }
 
   // Calculate visible window based on selected index, bounded by viewport.
-  const visibleCommandCount = Math.max(
-    3,
-    Math.min(MAX_VISIBLE_COMMANDS, terminalRows - 8),
-  );
+  const availablePopupRows = Math.max(1, terminalRows - 8);
+  const visibleCommandCount = Math.min(MAX_POPUP_ROWS, availablePopupRows);
   const totalMatches = matches.length;
   const needsScrolling = totalMatches > visibleCommandCount;
 


### PR DESCRIPTION
## Summary

- Caps slash-command autocomplete at 8 rows to match Codex-style compact popup behavior.
- Keeps the existing terminal-height shrink behavior for short terminals, but prevents tall terminals from expanding the list.
- Verified with `bun run check`.

👾 Generated with [Letta Code](https://letta.com)