### PR TITLE
feat(models): add MiniMax M3

### DIFF
--- a/src/agent/model-tier-selection.test.ts
+++ b/src/agent/model-tier-selection.test.ts
@@ -30,6 +30,16 @@ describe("getModelInfo", () => {
       enable_reasoner: true,
     });
   });
+
+  test("resolves MiniMax M3 registry metadata", () => {
+    const info = getModelInfo("minimax-m3");
+    expect(info?.handle).toBe("minimax/MiniMax-M3");
+    expect(info?.label).toBe("MiniMax M3");
+    expect(info?.updateArgs).toMatchObject({
+      context_window: 1000000,
+      parallel_tool_calls: true,
+    });
+  });
 });
 
 describe("getModelInfoForLlmConfig", () => {

--- a/src/models.json
+++ b/src/models.json
@@ -1480,10 +1480,21 @@
       }
     },
     {
+      "id": "minimax-m3",
+      "handle": "minimax/MiniMax-M3",
+      "label": "MiniMax M3",
+      "description": "MiniMax's frontier M-series model for agentic reasoning, tool use, coding, multimodal chat input, and long-context tasks",
+      "isFeatured": true,
+      "updateArgs": {
+        "context_window": 1000000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "minimax-m2.7",
       "handle": "minimax/MiniMax-M2.7",
       "label": "MiniMax 2.7",
-      "description": "MiniMax's latest coding model",
+      "description": "MiniMax's M2.7 coding model",
       "isFeatured": true,
       "free": true,
       "updateArgs": {
@@ -1495,8 +1506,8 @@
     {
       "id": "minimax-m2",
       "handle": "openrouter/minimax/minimax-m2",
-      "label": "Minimax M2",
-      "description": "Minimax's latest model",
+      "label": "MiniMax M2",
+      "description": "MiniMax's M2 model",
       "updateArgs": {
         "context_window": 160000,
         "max_output_tokens": 64000,


### PR DESCRIPTION
## Summary
- Add MiniMax M3 to the static model registry as `minimax/MiniMax-M3` with 1,000,000-token context metadata.
- Keep older MiniMax entries from describing themselves as the latest model.
- Add registry coverage for MiniMax M3 metadata resolution.

## Validation
- `bun -e 'JSON.parse(await Bun.file("src/models.json").text()); console.log("models.json OK")'`
- `bun test src/agent/model-tier-selection.test.ts src/tools/model-provider-detection.test.ts`
- `bunx --bun @biomejs/biome@2.2.5 check src/models.json src/agent/model-tier-selection.test.ts`

## Risk / limits
- Registry metadata only; pricing and server-side availability are handled outside this repository.
- Does not change local MiniMax provider defaults.

👾 Generated with [Letta Code](https://letta.com)