### PR TITLE
feat(models): add MiniMax M3

### DIFF
--- a/src/agent/model-tier-selection.test.ts
+++ b/src/agent/model-tier-selection.test.ts
@@ -30,6 +30,16 @@ describe("getModelInfo", () => {
       enable_reasoner: true,
     });
   });
+
+  test("resolves MiniMax M3 registry metadata", () => {
+    const info = getModelInfo("minimax-m3");
+    expect(info?.handle).toBe("minimax/MiniMax-M3");
+    expect(info?.label).toBe("MiniMax M3");
+    expect(info?.updateArgs).toMatchObject({
+      context_window: 1000000,
+      parallel_tool_calls: true,
+    });
+  });
 });
 
 describe("getModelInfoForLlmConfig", () => {

--- a/src/agent/model-tier-selection.test.ts
+++ b/src/agent/model-tier-selection.test.ts
@@ -36,7 +36,7 @@ describe("getModelInfo", () => {
     expect(info?.handle).toBe("minimax/MiniMax-M3");
     expect(info?.label).toBe("MiniMax M3");
     expect(info?.updateArgs).toMatchObject({
-      context_window: 1000000,
+      context_window: 500000,
       parallel_tool_calls: true,
     });
   });

--- a/src/models.json
+++ b/src/models.json
@@ -1486,7 +1486,7 @@
       "description": "MiniMax's frontier M-series model for agentic reasoning, tool use, coding, multimodal chat input, and long-context tasks",
       "isFeatured": true,
       "updateArgs": {
-        "context_window": 1000000,
+        "context_window": 500000,
         "parallel_tool_calls": true
       }
     },

--- a/src/models.json
+++ b/src/models.json
@@ -1480,10 +1480,21 @@
       }
     },
     {
+      "id": "minimax-m3",
+      "handle": "minimax/MiniMax-M3",
+      "label": "MiniMax M3",
+      "description": "MiniMax's frontier M-series model for agentic reasoning, tool use, coding, multimodal chat input, and long-context tasks",
+      "isFeatured": true,
+      "updateArgs": {
+        "context_window": 1000000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "minimax-m2.7",
       "handle": "minimax/MiniMax-M2.7",
       "label": "MiniMax 2.7",
-      "description": "MiniMax's latest coding model",
+      "description": "MiniMax's M2.7 coding model",
       "isFeatured": true,
       "free": true,
       "updateArgs": {
@@ -1495,8 +1506,8 @@
     {
       "id": "minimax-m2",
       "handle": "openrouter/minimax/minimax-m2",
-      "label": "Minimax M2",
-      "description": "Minimax's latest model",
+      "label": "MiniMax M2",
+      "description": "MiniMax's M2 model",
       "updateArgs": {
         "context_window": 160000,
         "max_output_tokens": 64000,

--- a/src/tools/model-provider-detection.test.ts
+++ b/src/tools/model-provider-detection.test.ts
@@ -51,6 +51,12 @@ describe("deriveToolsetFromModel", () => {
     expect(deriveToolsetFromModel("gemini-pro")).toBe("default");
   });
 
+  test("maps MiniMax M3 to default (anthropic) toolset", () => {
+    expect(isOpenAIModel("minimax-m3")).toBe(false);
+    expect(deriveToolsetFromModel("minimax-m3")).toBe("default");
+    expect(deriveToolsetFromModel("minimax/MiniMax-M3")).toBe("default");
+  });
+
   test("maps auto models to default (anthropic) toolset", () => {
     expect(deriveToolsetFromModel("auto")).toBe("default");
     expect(deriveToolsetFromModel("letta/auto")).toBe("default");


### PR DESCRIPTION
## Summary
- Add MiniMax M3 to the model registry as minimax-m3 with handle minimax/MiniMax-M3.
- Use a 500k selected/default context limit for the Letta Code preset while the provider model remains a 1M-context model server-side.
- Keep MiniMax model descriptions/casing current now that M3 is the frontier MiniMax entry.
- Add focused registry and provider-detection coverage for the new model.

## Validation
- bun test src/agent/model-tier-selection.test.ts src/tools/model-provider-detection.test.ts src/providers/byok-provider-aliases.test.ts
- bunx --bun @biomejs/biome@2.2.5 check src/models.json src/agent/model-tier-selection.test.ts src/tools/model-provider-detection.test.ts

## Risk / limits
- Registry metadata only; MiniMax API availability and billing are handled by existing provider/configuration paths.
- No local pricing metadata was added.

👾 Generated with [Letta Code](https://letta.com)
