### PR TITLE
fix(permissions): scope memory guard defaults to headless

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -150,10 +150,10 @@ export const CLI_FLAG_CATALOG = {
   "permission-mode": { parser: { type: "string" }, mode: "both" },
   "disable-memory-guard": {
     parser: { type: "boolean" },
-    mode: "both",
+    mode: "headless",
     help: {
       description:
-        "Disable the cross-agent memory guard for this parent agent process.",
+        "Disable the headless cross-agent memory guard for this parent agent process.",
       continuationLines: [
         "Allows intentional access to other agents' memory directories.",
         "Ignored by subagents; their memory guard remains enabled.",

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -557,6 +557,12 @@ export async function handleHeadlessCommand(
     const { toolFilter } = await import("@/tools/filter");
     toolFilter.setEnabledTools(values.tools);
   }
+
+  const { cliPermissions } = await import(
+    "@/permissions/cli-permissions-instance"
+  );
+  cliPermissions.setMemoryGuardEnabledByDefault(true);
+
   // Set permission mode if provided (or via --yolo alias)
   const permissionModeValue = values["permission-mode"];
   const yoloMode = values.yolo;
@@ -579,9 +585,6 @@ export async function handleHeadlessCommand(
     values.disallowedTools ||
     values["disable-memory-guard"]
   ) {
-    const { cliPermissions } = await import(
-      "@/permissions/cli-permissions-instance"
-    );
     if (values.allowedTools) {
       cliPermissions.setAllowedTools(values.allowedTools);
     }

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -561,7 +561,7 @@ export async function handleHeadlessCommand(
   const { cliPermissions } = await import(
     "@/permissions/cli-permissions-instance"
   );
-  cliPermissions.setMemoryGuardEnabledByDefault(true);
+  cliPermissions.setMemoryGuardDisabled(false);
 
   // Set permission mode if provided (or via --yolo alias)
   const permissionModeValue = values["permission-mode"];

--- a/src/permissions/checker.ts
+++ b/src/permissions/checker.ts
@@ -118,9 +118,10 @@ function shouldAttachTrace(result: PermissionCheckResult): boolean {
  * Check permission for a tool execution.
  *
  * Decision logic:
- * 0. Cross-agent guard (unbypassable) → DENY any tool call targeting
- *    another agent's memory dir unless it targets the current agent, targets
- *    an explicit parent agent for a subagent process, or the parent process
+ * 0. Cross-agent guard (enabled by default for headless + subagents,
+ *    unbypassable when enabled) → DENY any tool call targeting another
+ *    agent's memory dir unless it targets the current agent, targets an
+ *    explicit parent agent for a subagent process, or the parent process
  *    passed --disable-memory-guard.
  * 1. Check deny rules from settings (first match wins) → DENY
  * 2. Check CLI disallowedTools (--disallowedTools flag) → DENY
@@ -270,9 +271,9 @@ function checkPermissionForEngine(
   const workingDirectoryTools =
     engine === "v2" ? WORKING_DIRECTORY_TOOLS_V2 : WORKING_DIRECTORY_TOOLS_V1;
 
-  // Cross-agent guard — denies any tool call targeting another agent's
-  // memory unless that agent is in the allowed set. Unbypassable by any
-  // mode, rule, or flag.
+  // Cross-agent guard — when enabled, denies any tool call targeting another
+  // agent's memory unless that agent is in the allowed set. Unbypassable by
+  // any mode, rule, or flag.
   const guardResult = evaluateCrossAgentGuard(
     toolName,
     toolArgs,

--- a/src/permissions/cli-permissions-instance.ts
+++ b/src/permissions/cli-permissions-instance.ts
@@ -3,9 +3,10 @@
  *
  * Keep this on globalThis instead of as a module-local singleton. The bundled
  * CLI can contain more than one copy of this module when multiple entrypoint
- * graphs are included (interactive + headless). CLI startup may set flags like
- * --disable-memory-guard through one copy while permission checks read from
- * another; a global symbol makes those copies share the same state.
+ * graphs are included (interactive + headless). Startup may set state like
+ * --disable-memory-guard or headless memory-guard default enablement through
+ * one copy while permission checks read from another; a global symbol makes
+ * those copies share the same state.
  */
 import { CliPermissions } from "./cli";
 

--- a/src/permissions/cli-permissions-instance.ts
+++ b/src/permissions/cli-permissions-instance.ts
@@ -3,10 +3,9 @@
  *
  * Keep this on globalThis instead of as a module-local singleton. The bundled
  * CLI can contain more than one copy of this module when multiple entrypoint
- * graphs are included (interactive + headless). Startup may set state like
- * --disable-memory-guard or headless memory-guard default enablement through
- * one copy while permission checks read from another; a global symbol makes
- * those copies share the same state.
+ * graphs are included (interactive + headless). Startup may set or clear
+ * --disable-memory-guard state through one copy while permission checks read
+ * from another; a global symbol makes those copies share the same state.
  */
 import { CliPermissions } from "./cli";
 

--- a/src/permissions/cli.ts
+++ b/src/permissions/cli.ts
@@ -17,6 +17,7 @@ import { normalizePermissionRule } from "./rule-normalization";
 export class CliPermissions {
   private allowedTools: string[] = [];
   private disallowedTools: string[] = [];
+  private memoryGuardEnabledByDefault = false;
   private memoryGuardDisabled = false;
 
   /**
@@ -33,6 +34,15 @@ export class CliPermissions {
    */
   setDisallowedTools(toolsString: string): void {
     this.disallowedTools = this.parseToolList(toolsString);
+  }
+
+  /**
+   * Set whether the parent process enables the cross-agent memory guard by
+   * default. Headless startup turns this on; interactive startup leaves it off.
+   * Subagent processes ignore this setting and always enable the guard.
+   */
+  setMemoryGuardEnabledByDefault(enabled: boolean): void {
+    this.memoryGuardEnabledByDefault = enabled;
   }
 
   /**
@@ -132,6 +142,13 @@ export class CliPermissions {
   }
 
   /**
+   * Whether this parent CLI process enables the memory guard by default.
+   */
+  isMemoryGuardEnabledByDefault(): boolean {
+    return this.memoryGuardEnabledByDefault;
+  }
+
+  /**
    * Whether --disable-memory-guard was set on the CLI.
    */
   isMemoryGuardDisabled(): boolean {
@@ -144,6 +161,7 @@ export class CliPermissions {
   clear(): void {
     this.allowedTools = [];
     this.disallowedTools = [];
+    this.memoryGuardEnabledByDefault = false;
     this.memoryGuardDisabled = false;
   }
 }

--- a/src/permissions/cli.ts
+++ b/src/permissions/cli.ts
@@ -17,8 +17,7 @@ import { normalizePermissionRule } from "./rule-normalization";
 export class CliPermissions {
   private allowedTools: string[] = [];
   private disallowedTools: string[] = [];
-  private memoryGuardEnabledByDefault = false;
-  private memoryGuardDisabled = false;
+  private memoryGuardDisabled = true;
 
   /**
    * Parse and set allowed tools from CLI flag
@@ -37,16 +36,8 @@ export class CliPermissions {
   }
 
   /**
-   * Set whether the parent process enables the cross-agent memory guard by
-   * default. Headless startup turns this on; interactive startup leaves it off.
-   * Subagent processes ignore this setting and always enable the guard.
-   */
-  setMemoryGuardEnabledByDefault(enabled: boolean): void {
-    this.memoryGuardEnabledByDefault = enabled;
-  }
-
-  /**
-   * Disable the cross-agent memory guard for this parent CLI process.
+   * Disable the cross-agent memory guard for this parent CLI process. Parent
+   * processes start disabled by default; headless startup clears this bit.
    * Subagent processes ignore this setting when evaluating the guard.
    */
   setMemoryGuardDisabled(disabled: boolean): void {
@@ -142,13 +133,6 @@ export class CliPermissions {
   }
 
   /**
-   * Whether this parent CLI process enables the memory guard by default.
-   */
-  isMemoryGuardEnabledByDefault(): boolean {
-    return this.memoryGuardEnabledByDefault;
-  }
-
-  /**
    * Whether --disable-memory-guard was set on the CLI.
    */
   isMemoryGuardDisabled(): boolean {
@@ -161,7 +145,6 @@ export class CliPermissions {
   clear(): void {
     this.allowedTools = [];
     this.disallowedTools = [];
-    this.memoryGuardEnabledByDefault = false;
-    this.memoryGuardDisabled = false;
+    this.memoryGuardDisabled = true;
   }
 }

--- a/src/permissions/cross-agent-guard.test.ts
+++ b/src/permissions/cross-agent-guard.test.ts
@@ -8,7 +8,6 @@ import {
   evaluateCrossAgentGuard,
   extractTargetAgentPaths,
   isMemoryGuardDisabled,
-  isMemoryGuardEnabled,
   resolveAllowedAgents,
 } from "@/permissions/cross-agent-guard";
 import { permissionMode } from "@/permissions/mode";
@@ -120,18 +119,18 @@ describe("resolveAllowedAgents", () => {
     expect(isMemoryGuardDisabled()).toBe(false);
   });
 
-  test("memory guard is disabled by default for parent processes", () => {
-    expect(isMemoryGuardEnabled()).toBe(false);
+  test("parent memory guard is disabled by default", () => {
+    expect(isMemoryGuardDisabled()).toBe(true);
   });
 
-  test("memory guard can be enabled by headless parent startup", () => {
+  test("headless parent startup clears the disabled bit", () => {
     cliPermissions.setMemoryGuardDisabled(false);
-    expect(isMemoryGuardEnabled()).toBe(true);
+    expect(isMemoryGuardDisabled()).toBe(false);
   });
 
-  test("memory guard is enabled by default for subagents", () => {
+  test("subagents ignore the parent disabled default", () => {
     process.env.LETTA_CODE_AGENT_ROLE = "subagent";
-    expect(isMemoryGuardEnabled()).toBe(true);
+    expect(isMemoryGuardDisabled()).toBe(false);
   });
 });
 

--- a/src/permissions/cross-agent-guard.test.ts
+++ b/src/permissions/cross-agent-guard.test.ts
@@ -8,6 +8,7 @@ import {
   evaluateCrossAgentGuard,
   extractTargetAgentPaths,
   isMemoryGuardDisabled,
+  isMemoryGuardEnabled,
   resolveAllowedAgents,
 } from "@/permissions/cross-agent-guard";
 import { permissionMode } from "@/permissions/mode";
@@ -117,6 +118,20 @@ describe("resolveAllowedAgents", () => {
 
     process.env.LETTA_CODE_AGENT_ROLE = "subagent";
     expect(isMemoryGuardDisabled()).toBe(false);
+  });
+
+  test("memory guard is disabled by default for parent processes", () => {
+    expect(isMemoryGuardEnabled()).toBe(false);
+  });
+
+  test("memory guard can be enabled by headless parent startup", () => {
+    cliPermissions.setMemoryGuardEnabledByDefault(true);
+    expect(isMemoryGuardEnabled()).toBe(true);
+  });
+
+  test("memory guard is enabled by default for subagents", () => {
+    process.env.LETTA_CODE_AGENT_ROLE = "subagent";
+    expect(isMemoryGuardEnabled()).toBe(true);
   });
 });
 
@@ -288,6 +303,20 @@ describe("extractTargetAgentPaths", () => {
 // ---------------------------------------------------------------------------
 
 describe("evaluateCrossAgentGuard", () => {
+  beforeEach(() => {
+    cliPermissions.setMemoryGuardEnabledByDefault(true);
+  });
+
+  test("parent processes skip the guard unless headless startup enables it", () => {
+    cliPermissions.setMemoryGuardEnabledByDefault(false);
+    const result = evaluateCrossAgentGuard(
+      "Write",
+      { file_path: otherMemory("system/a.md") },
+      "/tmp",
+    );
+    expect(result).toBeNull();
+  });
+
   test("returns null for own memory", () => {
     const result = evaluateCrossAgentGuard(
       "Write",
@@ -378,11 +407,28 @@ describe("evaluateCrossAgentGuard", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Integration with checkPermission — guard is unbypassable by any mode
+// Integration with checkPermission — when enabled, guard is unbypassable by any mode
 // ---------------------------------------------------------------------------
 
 describe("checkPermission integration", () => {
   const permissions = { allow: [], deny: [], ask: [] };
+
+  beforeEach(() => {
+    cliPermissions.setMemoryGuardEnabledByDefault(true);
+  });
+
+  test("parent processes use normal permissions when guard is not enabled", () => {
+    cliPermissions.setMemoryGuardEnabledByDefault(false);
+    permissionMode.setMode("acceptEdits");
+    const result = checkPermission(
+      "Write",
+      { file_path: otherMemory("system/a.md") },
+      permissions,
+      "/tmp",
+    );
+    expect(result.decision).toBe("allow");
+    expect(result.matchedRule).not.toBe("cross-agent guard");
+  });
 
   test("unrestricted mode does NOT let you write another agent's memory", () => {
     permissionMode.setMode("unrestricted");
@@ -511,6 +557,10 @@ describe("checkPermission integration", () => {
 // ---------------------------------------------------------------------------
 
 describe("shell bypass regression tests", () => {
+  beforeEach(() => {
+    cliPermissions.setMemoryGuardEnabledByDefault(true);
+  });
+
   test("enumeration: ls ~/.letta/agents is denied", () => {
     const result = evaluateCrossAgentGuard(
       "Bash",
@@ -620,6 +670,10 @@ cat "$TARGET/system/persona.md"`;
 
 describe("Grep/Glob ancestor-path regression tests", () => {
   const agentsTreeRoot = join(HOME, ".letta", "agents");
+
+  beforeEach(() => {
+    cliPermissions.setMemoryGuardEnabledByDefault(true);
+  });
 
   test("Glob with path='<home>/.letta/agents' is denied", () => {
     const result = evaluateCrossAgentGuard(

--- a/src/permissions/cross-agent-guard.test.ts
+++ b/src/permissions/cross-agent-guard.test.ts
@@ -125,7 +125,7 @@ describe("resolveAllowedAgents", () => {
   });
 
   test("memory guard can be enabled by headless parent startup", () => {
-    cliPermissions.setMemoryGuardEnabledByDefault(true);
+    cliPermissions.setMemoryGuardDisabled(false);
     expect(isMemoryGuardEnabled()).toBe(true);
   });
 
@@ -304,11 +304,11 @@ describe("extractTargetAgentPaths", () => {
 
 describe("evaluateCrossAgentGuard", () => {
   beforeEach(() => {
-    cliPermissions.setMemoryGuardEnabledByDefault(true);
+    cliPermissions.setMemoryGuardDisabled(false);
   });
 
   test("parent processes skip the guard unless headless startup enables it", () => {
-    cliPermissions.setMemoryGuardEnabledByDefault(false);
+    cliPermissions.setMemoryGuardDisabled(true);
     const result = evaluateCrossAgentGuard(
       "Write",
       { file_path: otherMemory("system/a.md") },
@@ -414,11 +414,11 @@ describe("checkPermission integration", () => {
   const permissions = { allow: [], deny: [], ask: [] };
 
   beforeEach(() => {
-    cliPermissions.setMemoryGuardEnabledByDefault(true);
+    cliPermissions.setMemoryGuardDisabled(false);
   });
 
   test("parent processes use normal permissions when guard is not enabled", () => {
-    cliPermissions.setMemoryGuardEnabledByDefault(false);
+    cliPermissions.setMemoryGuardDisabled(true);
     permissionMode.setMode("acceptEdits");
     const result = checkPermission(
       "Write",
@@ -558,7 +558,7 @@ describe("checkPermission integration", () => {
 
 describe("shell bypass regression tests", () => {
   beforeEach(() => {
-    cliPermissions.setMemoryGuardEnabledByDefault(true);
+    cliPermissions.setMemoryGuardDisabled(false);
   });
 
   test("enumeration: ls ~/.letta/agents is denied", () => {
@@ -672,7 +672,7 @@ describe("Grep/Glob ancestor-path regression tests", () => {
   const agentsTreeRoot = join(HOME, ".letta", "agents");
 
   beforeEach(() => {
-    cliPermissions.setMemoryGuardEnabledByDefault(true);
+    cliPermissions.setMemoryGuardDisabled(false);
   });
 
   test("Glob with path='<home>/.letta/agents' is denied", () => {

--- a/src/permissions/cross-agent-guard.ts
+++ b/src/permissions/cross-agent-guard.ts
@@ -1,7 +1,7 @@
 // src/permissions/crossAgentGuard.ts
-// Cross-agent guard: hard-denies any tool call whose target resolves under
-// another agent's memory directory unless the parent CLI process explicitly
-// disabled the guard.
+// Cross-agent guard: when enabled, hard-denies any tool call whose target
+// resolves under another agent's memory directory unless the parent CLI
+// process explicitly disabled the guard.
 //
 // The guard runs BEFORE any other permission logic (mode overrides, CLI
 // allow/deny rules, settings rules). Its deny is unbypassable by modes and
@@ -11,6 +11,8 @@
 //   - self:   current AGENT_ID
 //   - parent: explicit LETTA_PARENT_AGENT_ID for subagent processes
 //
+// The guard is enabled by default for headless parent processes and subagents.
+// Interactive parent processes leave it off by default.
 // --disable-memory-guard is parent-process only. Subagents always evaluate the
 // guard and cannot use the flag to open broad cross-agent memory access.
 
@@ -31,6 +33,7 @@ import { splitShellSegments, tokenizeShellWords } from "./shell-analysis";
 export interface CrossAgentGuardOptions {
   env?: NodeJS.ProcessEnv;
   currentAgentId?: string | null;
+  enableMemoryGuard?: boolean;
   disableMemoryGuard?: boolean;
 }
 
@@ -50,6 +53,17 @@ export function isMemoryGuardDisabled(
   const env = options.env ?? process.env;
   if (isSubagentProcess(env)) return false;
   return options.disableMemoryGuard ?? cliPermissions.isMemoryGuardDisabled();
+}
+
+export function isMemoryGuardEnabled(
+  options: CrossAgentGuardOptions = {},
+): boolean {
+  const env = options.env ?? process.env;
+  if (isSubagentProcess(env)) return true;
+  if (isMemoryGuardDisabled(options)) return false;
+  return (
+    options.enableMemoryGuard ?? cliPermissions.isMemoryGuardEnabledByDefault()
+  );
 }
 
 /**
@@ -619,7 +633,7 @@ export function evaluateCrossAgentGuard(
   const env = options.env ?? process.env;
   const homeDir = env.HOME ?? homedir();
 
-  if (isMemoryGuardDisabled(options)) {
+  if (!isMemoryGuardEnabled(options)) {
     return null;
   }
 

--- a/src/permissions/cross-agent-guard.ts
+++ b/src/permissions/cross-agent-guard.ts
@@ -33,7 +33,6 @@ import { splitShellSegments, tokenizeShellWords } from "./shell-analysis";
 export interface CrossAgentGuardOptions {
   env?: NodeJS.ProcessEnv;
   currentAgentId?: string | null;
-  enableMemoryGuard?: boolean;
   disableMemoryGuard?: boolean;
 }
 
@@ -60,10 +59,7 @@ export function isMemoryGuardEnabled(
 ): boolean {
   const env = options.env ?? process.env;
   if (isSubagentProcess(env)) return true;
-  if (isMemoryGuardDisabled(options)) return false;
-  return (
-    options.enableMemoryGuard ?? cliPermissions.isMemoryGuardEnabledByDefault()
-  );
+  return !isMemoryGuardDisabled(options);
 }
 
 /**

--- a/src/permissions/cross-agent-guard.ts
+++ b/src/permissions/cross-agent-guard.ts
@@ -54,14 +54,6 @@ export function isMemoryGuardDisabled(
   return options.disableMemoryGuard ?? cliPermissions.isMemoryGuardDisabled();
 }
 
-export function isMemoryGuardEnabled(
-  options: CrossAgentGuardOptions = {},
-): boolean {
-  const env = options.env ?? process.env;
-  if (isSubagentProcess(env)) return true;
-  return !isMemoryGuardDisabled(options);
-}
-
 /**
  * Resolve the set of agent IDs a guarded process is allowed to operate
  * against without disabling the guard.
@@ -629,7 +621,7 @@ export function evaluateCrossAgentGuard(
   const env = options.env ?? process.env;
   const homeDir = env.HOME ?? homedir();
 
-  if (!isMemoryGuardEnabled(options)) {
+  if (isMemoryGuardDisabled(options)) {
     return null;
   }
 

--- a/src/permissions/permissions-cli.test.ts
+++ b/src/permissions/permissions-cli.test.ts
@@ -67,6 +67,12 @@ test("tracks disable-memory-guard CLI override", () => {
   expect(cliPermissions.isMemoryGuardDisabled()).toBe(true);
 });
 
+test("tracks memory guard default enablement", () => {
+  expect(cliPermissions.isMemoryGuardEnabledByDefault()).toBe(false);
+  cliPermissions.setMemoryGuardEnabledByDefault(true);
+  expect(cliPermissions.isMemoryGuardEnabledByDefault()).toBe(true);
+});
+
 test("stores singleton on global symbol for bundled duplicate modules", () => {
   const key = Symbol.for("@letta/cliPermissions");
   const globals = globalThis as unknown as Record<symbol, unknown>;
@@ -75,8 +81,10 @@ test("stores singleton on global symbol for bundled duplicate modules", () => {
 });
 
 test("clear resets disable-memory-guard CLI override", () => {
+  cliPermissions.setMemoryGuardEnabledByDefault(true);
   cliPermissions.setMemoryGuardDisabled(true);
   cliPermissions.clear();
+  expect(cliPermissions.isMemoryGuardEnabledByDefault()).toBe(false);
   expect(cliPermissions.isMemoryGuardDisabled()).toBe(false);
 });
 

--- a/src/permissions/permissions-cli.test.ts
+++ b/src/permissions/permissions-cli.test.ts
@@ -61,16 +61,10 @@ test("Handle whitespace in tool list", () => {
   expect(tools).toEqual(["Bash(:*)", "Read(**)", "Write(**)"]);
 });
 
-test("tracks disable-memory-guard CLI override", () => {
-  expect(cliPermissions.isMemoryGuardDisabled()).toBe(false);
-  cliPermissions.setMemoryGuardDisabled(true);
+test("tracks memory guard disabled state", () => {
   expect(cliPermissions.isMemoryGuardDisabled()).toBe(true);
-});
-
-test("tracks memory guard default enablement", () => {
-  expect(cliPermissions.isMemoryGuardEnabledByDefault()).toBe(false);
-  cliPermissions.setMemoryGuardEnabledByDefault(true);
-  expect(cliPermissions.isMemoryGuardEnabledByDefault()).toBe(true);
+  cliPermissions.setMemoryGuardDisabled(false);
+  expect(cliPermissions.isMemoryGuardDisabled()).toBe(false);
 });
 
 test("stores singleton on global symbol for bundled duplicate modules", () => {
@@ -81,11 +75,9 @@ test("stores singleton on global symbol for bundled duplicate modules", () => {
 });
 
 test("clear resets disable-memory-guard CLI override", () => {
-  cliPermissions.setMemoryGuardEnabledByDefault(true);
-  cliPermissions.setMemoryGuardDisabled(true);
+  cliPermissions.setMemoryGuardDisabled(false);
   cliPermissions.clear();
-  expect(cliPermissions.isMemoryGuardEnabledByDefault()).toBe(false);
-  expect(cliPermissions.isMemoryGuardDisabled()).toBe(false);
+  expect(cliPermissions.isMemoryGuardDisabled()).toBe(true);
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Enable the cross-agent memory guard by default only for headless parent processes and subagents.
- Keep interactive/listen parent processes on normal permission behavior by defaulting the existing `memoryGuardDisabled` bit to `true`.
- Reuse the shared `cliPermissions` singleton from #2532: headless startup clears the disabled bit, while `--disable-memory-guard` sets it back to disabled.
- Mark `--disable-memory-guard` as headless-specific in the shared CLI flag catalog/help.

## Test plan
- [x] `bun test src/permissions/*.test.ts`
- [x] `bun test src/permissions/cross-agent-guard.test.ts src/permissions/permissions-cli.test.ts src/cli/args.test.ts`
- [x] `bun test src/cli/args.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)
