### PR TITLE
feat(ws): trigger cron immediately

### DIFF
--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -57,6 +57,9 @@ interface SchedulerState {
   token: string;
   tickInterval: NodeJS.Timeout;
   gcInterval: NodeJS.Timeout;
+  socket: ListenerTransport;
+  opts: StartListenerOptions;
+  processQueuedTurn: ProcessQueuedTurn;
   /** Last mtime of crons.json — skip re-reads when unchanged. */
   lastMtime: number;
   /** Cached active tasks (refreshed on file change). */
@@ -203,7 +206,7 @@ async function fireCronTask(
   socket: ListenerTransport,
   opts: StartListenerOptions,
   processQueuedTurn: ProcessQueuedTurn,
-): Promise<void> {
+): Promise<boolean> {
   const listener = getActiveRuntime();
   if (!listener) {
     setLastRunOutcome(task.id, {
@@ -220,7 +223,7 @@ async function fireCronTask(
       runAtMs: now.getTime(),
       scheduledFor: task.scheduled_for,
     });
-    return;
+    return false;
   }
 
   let targetConversationId: string | undefined;
@@ -234,7 +237,7 @@ async function fireCronTask(
       runAtMs: now.getTime(),
       scheduledFor: task.scheduled_for,
     });
-    return;
+    return false;
   }
 
   const rawRuntime = getOrCreateConversationRuntime(
@@ -258,7 +261,7 @@ async function fireCronTask(
       runAtMs: now.getTime(),
       scheduledFor: task.scheduled_for,
     });
-    return;
+    return false;
   }
 
   // Ensure the queue runtime is initialized (getOrCreateConversationRuntime
@@ -294,7 +297,7 @@ async function fireCronTask(
       runAtMs: now.getTime(),
       scheduledFor: task.scheduled_for,
     });
-    return;
+    return false;
   }
 
   scheduleQueuePump(conversationRuntime, socket, opts, processQueuedTurn);
@@ -335,6 +338,7 @@ async function fireCronTask(
     conversationId: targetConversationId ?? "default",
   });
   emitCronsUpdated(socket, task, targetConversationId ?? "default");
+  return true;
 }
 
 /** Returns true if the task was marked as missed (caller should skip firing). */
@@ -373,6 +377,52 @@ export function handleMissedOneShot(task: CronTask, now: Date): boolean {
     return true;
   }
   return false;
+}
+
+export async function runCronTaskNow(taskId: string): Promise<{
+  success: boolean;
+  found: boolean;
+  task?: CronTask;
+  error?: string;
+}> {
+  const task = getTask(taskId);
+  if (!task) {
+    return { success: false, found: false, error: "Schedule not found" };
+  }
+
+  if (task.status !== "active") {
+    return { success: false, found: true, task, error: "Schedule is not active" };
+  }
+
+  if (!schedulerState) {
+    return {
+      success: false,
+      found: true,
+      task,
+      error: "Cron scheduler is not running",
+    };
+  }
+
+  const now = new Date();
+  const fired = await fireCronTask(
+    task,
+    now,
+    schedulerState.socket,
+    schedulerState.opts,
+    schedulerState.processQueuedTurn,
+  );
+
+  if (!fired) {
+    return {
+      success: false,
+      found: true,
+      task,
+      error: "Failed to enqueue schedule run",
+    };
+  }
+
+  refreshTaskCache(schedulerState);
+  return { success: true, found: true, task: getTask(taskId) ?? task };
 }
 
 function tick(
@@ -511,6 +561,9 @@ export function startScheduler(
     token,
     tickInterval: null as unknown as NodeJS.Timeout,
     gcInterval: null as unknown as NodeJS.Timeout,
+    socket,
+    opts,
+    processQueuedTurn,
     lastMtime: 0,
     cachedTasks: [],
     firedThisMinute: new Set(),

--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -391,7 +391,12 @@ export async function runCronTaskNow(taskId: string): Promise<{
   }
 
   if (task.status !== "active") {
-    return { success: false, found: true, task, error: "Schedule is not active" };
+    return {
+      success: false,
+      found: true,
+      task,
+      error: "Schedule is not active",
+    };
   }
 
   if (!schedulerState) {

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -1056,6 +1056,13 @@ export interface CronRunsCommand {
   run_id?: string;
 }
 
+export interface CronRunCommand {
+  type: "cron_run";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  task_id: string;
+}
+
 export interface CronDeleteCommand {
   type: "cron_delete";
   /** Echoed back in the response for request correlation. */
@@ -1340,6 +1347,15 @@ export interface CronRunsResponseMessage {
   request_id: string;
   success: boolean;
   page?: CronRunLogPage;
+  error?: string;
+}
+
+export interface CronRunResponseMessage {
+  type: "cron_run_response";
+  request_id: string;
+  success: boolean;
+  found: boolean;
+  task?: CronTask;
   error?: string;
 }
 
@@ -1812,6 +1828,7 @@ export type WsProtocolCommand =
   | CronAddCommand
   | CronGetCommand
   | CronRunsCommand
+  | CronRunCommand
   | CronDeleteCommand
   | CronDeleteAllCommand
   | SkillEnableCommand

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -1056,8 +1056,8 @@ export interface CronRunsCommand {
   run_id?: string;
 }
 
-export interface CronRunCommand {
-  type: "cron_run";
+export interface CronTriggerCommand {
+  type: "cron_trigger";
   /** Echoed back in the response for request correlation. */
   request_id: string;
   task_id: string;
@@ -1350,8 +1350,8 @@ export interface CronRunsResponseMessage {
   error?: string;
 }
 
-export interface CronRunResponseMessage {
-  type: "cron_run_response";
+export interface CronTriggerResponseMessage {
+  type: "cron_trigger_response";
   request_id: string;
   success: boolean;
   found: boolean;
@@ -1828,7 +1828,7 @@ export type WsProtocolCommand =
   | CronAddCommand
   | CronGetCommand
   | CronRunsCommand
-  | CronRunCommand
+  | CronTriggerCommand
   | CronDeleteCommand
   | CronDeleteAllCommand
   | SkillEnableCommand

--- a/src/websocket/listener/commands/cron.ts
+++ b/src/websocket/listener/commands/cron.ts
@@ -15,7 +15,7 @@ import type {
   CronDeleteCommand,
   CronGetCommand,
   CronListCommand,
-  CronRunCommand,
+  CronTriggerCommand,
   CronRunsCommand,
 } from "@/types/protocol_v2";
 import {
@@ -24,7 +24,7 @@ import {
   isCronDeleteCommand,
   isCronGetCommand,
   isCronListCommand,
-  isCronRunCommand,
+  isCronTriggerCommand,
   isCronRunsCommand,
 } from "@/websocket/listener/protocol-inbound";
 import type { RunDetachedListenerTask, SafeSocketSend } from "./types";
@@ -34,7 +34,7 @@ export type CronCommand =
   | CronAddCommand
   | CronGetCommand
   | CronRunsCommand
-  | CronRunCommand
+  | CronTriggerCommand
   | CronDeleteCommand
   | CronDeleteAllCommand;
 
@@ -228,13 +228,13 @@ export async function handleCronCommand(
     return true;
   }
 
-  if (parsed.type === "cron_run") {
+  if (parsed.type === "cron_trigger") {
     try {
       const result = await runCronTaskNow(parsed.task_id);
       safeSocketSend(
         socket,
         {
-          type: "cron_run_response",
+          type: "cron_trigger_response",
           request_id: parsed.request_id,
           success: result.success,
           found: result.found,
@@ -248,11 +248,11 @@ export async function handleCronCommand(
       safeSocketSend(
         socket,
         {
-          type: "cron_run_response",
+          type: "cron_trigger_response",
           request_id: parsed.request_id,
           success: false,
           found: false,
-          error: err instanceof Error ? err.message : "Failed to run cron",
+          error: err instanceof Error ? err.message : "Failed to trigger cron",
         },
         "listener_cron_send_failed",
         "listener_cron_command",
@@ -347,7 +347,7 @@ export function handleCronProtocolCommand(
     isCronAddCommand(parsed) ||
     isCronGetCommand(parsed) ||
     isCronRunsCommand(parsed) ||
-    isCronRunCommand(parsed) ||
+    isCronTriggerCommand(parsed) ||
     isCronDeleteCommand(parsed) ||
     isCronDeleteAllCommand(parsed)
   ) {

--- a/src/websocket/listener/commands/cron.ts
+++ b/src/websocket/listener/commands/cron.ts
@@ -8,12 +8,14 @@ import {
   listTasks as listCronTasks,
   readCronRunLogEntriesPage,
 } from "@/cron";
+import { runCronTaskNow } from "@/cron/scheduler";
 import type {
   CronAddCommand,
   CronDeleteAllCommand,
   CronDeleteCommand,
   CronGetCommand,
   CronListCommand,
+  CronRunCommand,
   CronRunsCommand,
 } from "@/types/protocol_v2";
 import {
@@ -22,6 +24,7 @@ import {
   isCronDeleteCommand,
   isCronGetCommand,
   isCronListCommand,
+  isCronRunCommand,
   isCronRunsCommand,
 } from "@/websocket/listener/protocol-inbound";
 import type { RunDetachedListenerTask, SafeSocketSend } from "./types";
@@ -31,6 +34,7 @@ export type CronCommand =
   | CronAddCommand
   | CronGetCommand
   | CronRunsCommand
+  | CronRunCommand
   | CronDeleteCommand
   | CronDeleteAllCommand;
 
@@ -224,6 +228,39 @@ export async function handleCronCommand(
     return true;
   }
 
+  if (parsed.type === "cron_run") {
+    try {
+      const result = await runCronTaskNow(parsed.task_id);
+      safeSocketSend(
+        socket,
+        {
+          type: "cron_run_response",
+          request_id: parsed.request_id,
+          success: result.success,
+          found: result.found,
+          ...(result.task ? { task: result.task } : {}),
+          ...(result.error ? { error: result.error } : {}),
+        },
+        "listener_cron_send_failed",
+        "listener_cron_command",
+      );
+    } catch (err) {
+      safeSocketSend(
+        socket,
+        {
+          type: "cron_run_response",
+          request_id: parsed.request_id,
+          success: false,
+          found: false,
+          error: err instanceof Error ? err.message : "Failed to run cron",
+        },
+        "listener_cron_send_failed",
+        "listener_cron_command",
+      );
+    }
+    return true;
+  }
+
   if (parsed.type === "cron_delete") {
     try {
       const existingTask = getCronTask(parsed.task_id);
@@ -310,6 +347,7 @@ export function handleCronProtocolCommand(
     isCronAddCommand(parsed) ||
     isCronGetCommand(parsed) ||
     isCronRunsCommand(parsed) ||
+    isCronRunCommand(parsed) ||
     isCronDeleteCommand(parsed) ||
     isCronDeleteAllCommand(parsed)
   ) {

--- a/src/websocket/listener/commands/cron.ts
+++ b/src/websocket/listener/commands/cron.ts
@@ -15,8 +15,8 @@ import type {
   CronDeleteCommand,
   CronGetCommand,
   CronListCommand,
-  CronTriggerCommand,
   CronRunsCommand,
+  CronTriggerCommand,
 } from "@/types/protocol_v2";
 import {
   isCronAddCommand,
@@ -24,8 +24,8 @@ import {
   isCronDeleteCommand,
   isCronGetCommand,
   isCronListCommand,
-  isCronTriggerCommand,
   isCronRunsCommand,
+  isCronTriggerCommand,
 } from "@/websocket/listener/protocol-inbound";
 import type { RunDetachedListenerTask, SafeSocketSend } from "./types";
 

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -32,6 +32,7 @@ import type {
   CronDeleteCommand,
   CronGetCommand,
   CronListCommand,
+  CronRunCommand,
   CronRunsCommand,
   DeleteMemoryFileCommand,
   EditFileCommand,
@@ -801,6 +802,20 @@ export function isCronRunsCommand(value: unknown): value is CronRunsCommand {
     (c.limit === undefined || typeof c.limit === "number") &&
     (c.offset === undefined || typeof c.offset === "number") &&
     (c.run_id === undefined || typeof c.run_id === "string")
+  );
+}
+
+export function isCronRunCommand(value: unknown): value is CronRunCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    task_id?: unknown;
+  };
+  return (
+    c.type === "cron_run" &&
+    typeof c.request_id === "string" &&
+    typeof c.task_id === "string"
   );
 }
 
@@ -1632,6 +1647,7 @@ export function parseServerMessage(
       isCronAddCommand(parsed) ||
       isCronGetCommand(parsed) ||
       isCronRunsCommand(parsed) ||
+      isCronRunCommand(parsed) ||
       isCronDeleteCommand(parsed) ||
       isCronDeleteAllCommand(parsed) ||
       isSkillEnableCommand(parsed) ||

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -32,8 +32,8 @@ import type {
   CronDeleteCommand,
   CronGetCommand,
   CronListCommand,
-  CronTriggerCommand,
   CronRunsCommand,
+  CronTriggerCommand,
   DeleteMemoryFileCommand,
   EditFileCommand,
   EnableMemfsCommand,
@@ -805,7 +805,9 @@ export function isCronRunsCommand(value: unknown): value is CronRunsCommand {
   );
 }
 
-export function isCronTriggerCommand(value: unknown): value is CronTriggerCommand {
+export function isCronTriggerCommand(
+  value: unknown,
+): value is CronTriggerCommand {
   if (!value || typeof value !== "object") return false;
   const c = value as {
     type?: unknown;

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -32,7 +32,7 @@ import type {
   CronDeleteCommand,
   CronGetCommand,
   CronListCommand,
-  CronRunCommand,
+  CronTriggerCommand,
   CronRunsCommand,
   DeleteMemoryFileCommand,
   EditFileCommand,
@@ -805,7 +805,7 @@ export function isCronRunsCommand(value: unknown): value is CronRunsCommand {
   );
 }
 
-export function isCronRunCommand(value: unknown): value is CronRunCommand {
+export function isCronTriggerCommand(value: unknown): value is CronTriggerCommand {
   if (!value || typeof value !== "object") return false;
   const c = value as {
     type?: unknown;
@@ -813,7 +813,7 @@ export function isCronRunCommand(value: unknown): value is CronRunCommand {
     task_id?: unknown;
   };
   return (
-    c.type === "cron_run" &&
+    c.type === "cron_trigger" &&
     typeof c.request_id === "string" &&
     typeof c.task_id === "string"
   );
@@ -1647,7 +1647,7 @@ export function parseServerMessage(
       isCronAddCommand(parsed) ||
       isCronGetCommand(parsed) ||
       isCronRunsCommand(parsed) ||
-      isCronRunCommand(parsed) ||
+      isCronTriggerCommand(parsed) ||
       isCronDeleteCommand(parsed) ||
       isCronDeleteAllCommand(parsed) ||
       isSkillEnableCommand(parsed) ||


### PR DESCRIPTION
## Summary
- Added a new cron_run websocket command so clients can trigger an existing schedule immediately.
- Routed cron_run through the real cron scheduler firing path instead of simulating it as a normal chat message.