### PR TITLE
feat(cli): add Codex-style terminal title activity

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -55,6 +55,7 @@ import {
 } from "@/cli/commands/runner";
 import type { BtwState } from "@/cli/components/BtwPane";
 import type { ModelSelectorSelection } from "@/cli/components/ModelSelector";
+import { useFrameCycle } from "@/cli/components/spinners/use-frame-cycle";
 import { buildStatuslineRenderContext } from "@/cli/display/statusline/context";
 import type { ExtensionConversationCloseReason } from "@/cli/extensions/types";
 import {
@@ -99,6 +100,10 @@ import {
   hasInProgressTaskToolCalls,
 } from "@/cli/helpers/subagent-aggregation";
 import { buildStartupSystemPromptWarning } from "@/cli/helpers/system-prompt-warning.ts";
+import {
+  clearTerminalTitle,
+  setTerminalTitle,
+} from "@/cli/helpers/terminal-title";
 import { getRandomThinkingVerb } from "@/cli/helpers/thinking-messages";
 import {
   isFileEditTool,
@@ -110,8 +115,16 @@ import {
 import { isTaskTool } from "@/cli/helpers/tool-name-mapping.js";
 import { getTuiBlockedReason } from "@/cli/helpers/tui-queue-adapter";
 import {
+  renderActionRequiredWindowTitle,
   renderWindowTitle,
   resolveWindowTitleConfig,
+  TERMINAL_TITLE_ACTION_REQUIRED_INTERVAL_MS,
+  TERMINAL_TITLE_ACTION_REQUIRED_PREFIX,
+  TERMINAL_TITLE_ACTION_REQUIRED_PREFIX_HIDDEN,
+  TERMINAL_TITLE_SPINNER_FRAMES,
+  TERMINAL_TITLE_SPINNER_INTERVAL_MS,
+  titleUsesActivity,
+  type WindowTitleData,
 } from "@/cli/helpers/window-title-config";
 import { useSyncedState } from "@/cli/hooks/use-synced-state";
 import {
@@ -314,6 +327,11 @@ function hasConversationContent(lines: Line[]): boolean {
     }
   });
 }
+
+const TERMINAL_TITLE_ACTION_REQUIRED_FRAMES = [
+  TERMINAL_TITLE_ACTION_REQUIRED_PREFIX,
+  TERMINAL_TITLE_ACTION_REQUIRED_PREFIX_HIDDEN,
+] as const;
 
 export function App({
   agentId: initialAgentId,
@@ -915,18 +933,6 @@ export function App({
     startupModelDisplayOverride,
   ]);
 
-  // Set terminal title from window title config
-  useEffect(() => {
-    const items = resolveWindowTitleConfig(projectDirectory);
-    const title = renderWindowTitle(items, {
-      agentName: agentState?.name ?? null,
-      appName: "Letta Code",
-      version: getVersion(),
-      conversationSummary,
-    });
-    process.stdout.write(`\x1b]0;${title}\x07`);
-  }, [agentState?.name, conversationSummary, projectDirectory]);
-
   const currentModelProvider = llmConfig?.provider_name ?? null;
   const isLocalBackend = isLocalBackendEnabled();
   const currentReasoningEffort: ModelReasoningEffort | null =
@@ -1021,6 +1027,7 @@ export function App({
   const [thinkingMessage, setThinkingMessage] = useState(
     getRandomThinkingVerb(),
   );
+  const lastManagedTerminalTitleRef = useRef<string | null>(null);
 
   // Session stats tracking
   const sessionStatsRef = useRef(new SessionStats());
@@ -4634,6 +4641,145 @@ export function App({
     });
   }, [estimatedLiveHeight, terminalRows]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: activeOverlay changes after /title persists settings; recompute the config on close.
+  const terminalTitleItems = useMemo(
+    () => resolveWindowTitleConfig(projectDirectory),
+    [projectDirectory, activeOverlay],
+  );
+  const terminalTitleUsesActivity = titleUsesActivity(terminalTitleItems);
+  const terminalTitleRequiresAction = pendingApprovals.length > 0;
+  const terminalTitleShowsActionRequired =
+    terminalTitleRequiresAction && terminalTitleUsesActivity;
+  const terminalTitleTaskRunning =
+    loadingState !== "ready" ||
+    streaming ||
+    isExecutingTool ||
+    commandRunning ||
+    bashRunning ||
+    pendingApprovals.length > 0;
+  const terminalTitleHasActiveProgress =
+    !terminalTitleShowsActionRequired && terminalTitleTaskRunning;
+  const terminalTitleRunState =
+    loadingState !== "ready"
+      ? "Starting"
+      : !terminalTitleTaskRunning
+        ? "Ready"
+        : executionPhase === "thinking"
+          ? "Thinking"
+          : "Working";
+  const terminalTitleSpinnerFrameIndex = useFrameCycle(
+    TERMINAL_TITLE_SPINNER_FRAMES,
+    TERMINAL_TITLE_SPINNER_INTERVAL_MS,
+    shouldAnimate &&
+      terminalTitleUsesActivity &&
+      terminalTitleHasActiveProgress,
+  );
+  const terminalTitleActionFrameIndex = useFrameCycle(
+    TERMINAL_TITLE_ACTION_REQUIRED_FRAMES,
+    TERMINAL_TITLE_ACTION_REQUIRED_INTERVAL_MS,
+    shouldAnimate && terminalTitleShowsActionRequired,
+  );
+  const terminalTitleActionPrefix =
+    TERMINAL_TITLE_ACTION_REQUIRED_FRAMES[terminalTitleActionFrameIndex] ??
+    TERMINAL_TITLE_ACTION_REQUIRED_PREFIX;
+  const terminalTitleData = useMemo<WindowTitleData>(
+    () => ({
+      agentName,
+      appName: "Letta Code",
+      version: getVersion(),
+      conversationSummary,
+      conversationId,
+      projectDirectory,
+      currentDirectory: statusLinePayload.workspace.current_dir,
+      activityFrame:
+        shouldAnimate && terminalTitleHasActiveProgress
+          ? (TERMINAL_TITLE_SPINNER_FRAMES[terminalTitleSpinnerFrameIndex] ??
+            null)
+          : null,
+      runState: terminalTitleRunState,
+      modelDisplayName: currentModelDisplay,
+      reasoningEffort: currentReasoningEffort,
+      contextUsedPercentage: statusLinePayload.context_window.used_percentage,
+      contextRemainingPercentage:
+        statusLinePayload.context_window.remaining_percentage,
+      totalInputTokens: statusLinePayload.context_window.total_input_tokens,
+      totalOutputTokens: statusLinePayload.context_window.total_output_tokens,
+      fastMode: currentModelServiceTier === CHATGPT_FAST_SERVICE_TIER,
+    }),
+    [
+      agentName,
+      conversationId,
+      conversationSummary,
+      currentModelDisplay,
+      currentModelServiceTier,
+      currentReasoningEffort,
+      projectDirectory,
+      shouldAnimate,
+      statusLinePayload.context_window.remaining_percentage,
+      statusLinePayload.context_window.total_input_tokens,
+      statusLinePayload.context_window.total_output_tokens,
+      statusLinePayload.context_window.used_percentage,
+      statusLinePayload.workspace.current_dir,
+      terminalTitleHasActiveProgress,
+      terminalTitleRunState,
+      terminalTitleSpinnerFrameIndex,
+    ],
+  );
+  const terminalTitle = useMemo(
+    () =>
+      terminalTitleShowsActionRequired
+        ? renderActionRequiredWindowTitle(
+            terminalTitleItems,
+            terminalTitleData,
+            terminalTitleActionPrefix,
+          )
+        : renderWindowTitle(terminalTitleItems, terminalTitleData),
+    [
+      terminalTitleActionPrefix,
+      terminalTitleData,
+      terminalTitleItems,
+      terminalTitleShowsActionRequired,
+    ],
+  );
+
+  const applyManagedTerminalTitle = useCallback((title: string | null) => {
+    if (title === lastManagedTerminalTitleRef.current) {
+      return;
+    }
+
+    if (title === null) {
+      if (lastManagedTerminalTitleRef.current !== null) {
+        clearTerminalTitle();
+        lastManagedTerminalTitleRef.current = null;
+      }
+      return;
+    }
+
+    const result = setTerminalTitle(title);
+    if (result === "applied") {
+      lastManagedTerminalTitleRef.current = title;
+      return;
+    }
+
+    if (lastManagedTerminalTitleRef.current !== null) {
+      clearTerminalTitle();
+      lastManagedTerminalTitleRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    applyManagedTerminalTitle(terminalTitle);
+  }, [applyManagedTerminalTitle, terminalTitle]);
+
+  useEffect(() => {
+    return () => {
+      if (lastManagedTerminalTitleRef.current !== null) {
+        clearTerminalTitle();
+        lastManagedTerminalTitleRef.current = null;
+      }
+    };
+  }, []);
+
   // Commit welcome snapshot once when ready for fresh sessions (no history)
   // Wait for agentProvenance to be available for new agents (continueSession=false)
   useEffect(() => {
@@ -4906,6 +5052,8 @@ export function App({
       staticRenderEpoch={staticRenderEpoch}
       statusLinePayload={statusLinePayload}
       statusLinePrompt={CLI_GLYPHS.prompt}
+      terminalTitleData={terminalTitleData}
+      onTitlePreview={applyManagedTerminalTitle}
       extensionAdapter={extensionAdapter}
       streaming={streaming}
       stubDescriptions={stubDescriptions}

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -55,7 +55,7 @@ import {
 } from "@/cli/commands/runner";
 import type { BtwState } from "@/cli/components/BtwPane";
 import type { ModelSelectorSelection } from "@/cli/components/ModelSelector";
-import { useFrameCycle } from "@/cli/components/spinners/use-frame-cycle";
+import { TerminalTitleWriter } from "@/cli/components/TerminalTitleWriter";
 import { buildStatuslineRenderContext } from "@/cli/display/statusline/context";
 import type { ExtensionConversationCloseReason } from "@/cli/extensions/types";
 import {
@@ -100,10 +100,6 @@ import {
   hasInProgressTaskToolCalls,
 } from "@/cli/helpers/subagent-aggregation";
 import { buildStartupSystemPromptWarning } from "@/cli/helpers/system-prompt-warning.ts";
-import {
-  clearTerminalTitle,
-  setTerminalTitle,
-} from "@/cli/helpers/terminal-title";
 import { getRandomThinkingVerb } from "@/cli/helpers/thinking-messages";
 import {
   isFileEditTool,
@@ -114,18 +110,7 @@ import {
 } from "@/cli/helpers/tool-name-mapping";
 import { isTaskTool } from "@/cli/helpers/tool-name-mapping.js";
 import { getTuiBlockedReason } from "@/cli/helpers/tui-queue-adapter";
-import {
-  renderActionRequiredWindowTitle,
-  renderWindowTitle,
-  resolveWindowTitleConfig,
-  TERMINAL_TITLE_ACTION_REQUIRED_INTERVAL_MS,
-  TERMINAL_TITLE_ACTION_REQUIRED_PREFIX,
-  TERMINAL_TITLE_ACTION_REQUIRED_PREFIX_HIDDEN,
-  TERMINAL_TITLE_SPINNER_FRAMES,
-  TERMINAL_TITLE_SPINNER_INTERVAL_MS,
-  titleUsesActivity,
-  type WindowTitleData,
-} from "@/cli/helpers/window-title-config";
+import type { WindowTitleData } from "@/cli/helpers/window-title-config";
 import { useSyncedState } from "@/cli/hooks/use-synced-state";
 import {
   useTerminalRows,
@@ -327,11 +312,6 @@ function hasConversationContent(lines: Line[]): boolean {
     }
   });
 }
-
-const TERMINAL_TITLE_ACTION_REQUIRED_FRAMES = [
-  TERMINAL_TITLE_ACTION_REQUIRED_PREFIX,
-  TERMINAL_TITLE_ACTION_REQUIRED_PREFIX_HIDDEN,
-] as const;
 
 export function App({
   agentId: initialAgentId,
@@ -1027,7 +1007,11 @@ export function App({
   const [thinkingMessage, setThinkingMessage] = useState(
     getRandomThinkingVerb(),
   );
-  const lastManagedTerminalTitleRef = useRef<string | null>(null);
+  const [terminalTitlePreviewOverride, setTerminalTitlePreviewOverride] =
+    useState<string | null | undefined>(undefined);
+  const clearTerminalTitlePreviewOverride = useCallback(() => {
+    setTerminalTitlePreviewOverride(undefined);
+  }, []);
 
   // Session stats tracking
   const sessionStatsRef = useRef(new SessionStats());
@@ -4641,15 +4625,6 @@ export function App({
     });
   }, [estimatedLiveHeight, terminalRows]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: activeOverlay changes after /title persists settings; recompute the config on close.
-  const terminalTitleItems = useMemo(
-    () => resolveWindowTitleConfig(projectDirectory),
-    [projectDirectory, activeOverlay],
-  );
-  const terminalTitleUsesActivity = titleUsesActivity(terminalTitleItems);
-  const terminalTitleRequiresAction = pendingApprovals.length > 0;
-  const terminalTitleShowsActionRequired =
-    terminalTitleRequiresAction && terminalTitleUsesActivity;
   const terminalTitleTaskRunning =
     loadingState !== "ready" ||
     streaming ||
@@ -4657,8 +4632,6 @@ export function App({
     commandRunning ||
     bashRunning ||
     pendingApprovals.length > 0;
-  const terminalTitleHasActiveProgress =
-    !terminalTitleShowsActionRequired && terminalTitleTaskRunning;
   const terminalTitleRunState =
     loadingState !== "ready"
       ? "Starting"
@@ -4667,21 +4640,6 @@ export function App({
         : executionPhase === "thinking"
           ? "Thinking"
           : "Working";
-  const terminalTitleSpinnerFrameIndex = useFrameCycle(
-    TERMINAL_TITLE_SPINNER_FRAMES,
-    TERMINAL_TITLE_SPINNER_INTERVAL_MS,
-    shouldAnimate &&
-      terminalTitleUsesActivity &&
-      terminalTitleHasActiveProgress,
-  );
-  const terminalTitleActionFrameIndex = useFrameCycle(
-    TERMINAL_TITLE_ACTION_REQUIRED_FRAMES,
-    TERMINAL_TITLE_ACTION_REQUIRED_INTERVAL_MS,
-    shouldAnimate && terminalTitleShowsActionRequired,
-  );
-  const terminalTitleActionPrefix =
-    TERMINAL_TITLE_ACTION_REQUIRED_FRAMES[terminalTitleActionFrameIndex] ??
-    TERMINAL_TITLE_ACTION_REQUIRED_PREFIX;
   const terminalTitleData = useMemo<WindowTitleData>(
     () => ({
       agentName,
@@ -4691,11 +4649,6 @@ export function App({
       conversationId,
       projectDirectory,
       currentDirectory: statusLinePayload.workspace.current_dir,
-      activityFrame:
-        shouldAnimate && terminalTitleHasActiveProgress
-          ? (TERMINAL_TITLE_SPINNER_FRAMES[terminalTitleSpinnerFrameIndex] ??
-            null)
-          : null,
       runState: terminalTitleRunState,
       modelDisplayName: currentModelDisplay,
       reasoningEffort: currentReasoningEffort,
@@ -4714,71 +4667,14 @@ export function App({
       currentModelServiceTier,
       currentReasoningEffort,
       projectDirectory,
-      shouldAnimate,
       statusLinePayload.context_window.remaining_percentage,
       statusLinePayload.context_window.total_input_tokens,
       statusLinePayload.context_window.total_output_tokens,
       statusLinePayload.context_window.used_percentage,
       statusLinePayload.workspace.current_dir,
-      terminalTitleHasActiveProgress,
       terminalTitleRunState,
-      terminalTitleSpinnerFrameIndex,
     ],
   );
-  const terminalTitle = useMemo(
-    () =>
-      terminalTitleShowsActionRequired
-        ? renderActionRequiredWindowTitle(
-            terminalTitleItems,
-            terminalTitleData,
-            terminalTitleActionPrefix,
-          )
-        : renderWindowTitle(terminalTitleItems, terminalTitleData),
-    [
-      terminalTitleActionPrefix,
-      terminalTitleData,
-      terminalTitleItems,
-      terminalTitleShowsActionRequired,
-    ],
-  );
-
-  const applyManagedTerminalTitle = useCallback((title: string | null) => {
-    if (title === lastManagedTerminalTitleRef.current) {
-      return;
-    }
-
-    if (title === null) {
-      if (lastManagedTerminalTitleRef.current !== null) {
-        clearTerminalTitle();
-        lastManagedTerminalTitleRef.current = null;
-      }
-      return;
-    }
-
-    const result = setTerminalTitle(title);
-    if (result === "applied") {
-      lastManagedTerminalTitleRef.current = title;
-      return;
-    }
-
-    if (lastManagedTerminalTitleRef.current !== null) {
-      clearTerminalTitle();
-      lastManagedTerminalTitleRef.current = null;
-    }
-  }, []);
-
-  useEffect(() => {
-    applyManagedTerminalTitle(terminalTitle);
-  }, [applyManagedTerminalTitle, terminalTitle]);
-
-  useEffect(() => {
-    return () => {
-      if (lastManagedTerminalTitleRef.current !== null) {
-        clearTerminalTitle();
-        lastManagedTerminalTitleRef.current = null;
-      }
-    };
-  }, []);
 
   // Commit welcome snapshot once when ready for fresh sessions (no history)
   // Wait for agentProvenance to be available for new agents (continueSession=false)
@@ -4918,152 +4814,166 @@ export function App({
   }, [trajectoryTokenDisplay]);
 
   return (
-    <AppView
-      activeOverlay={activeOverlay}
-      agentId={agentId}
-      agentName={agentName}
-      agentState={agentState}
-      anySelectorOpen={anySelectorOpen}
-      approvalMap={approvalMap}
-      bashRunning={bashRunning}
-      billingTier={billingTier}
-      btwState={btwState}
-      buffersRef={buffersRef}
-      chromeColumns={chromeColumns}
-      closeOverlay={closeOverlay}
-      columns={columns}
-      commandRunner={commandRunner}
-      completeOverlay={completeOverlay}
-      contextTrackerRef={contextTrackerRef}
-      continueSession={continueSession}
-      conversationId={conversationId}
-      conversationSummary={conversationSummary}
-      projectDirectory={projectDirectory}
-      currentApproval={currentApproval}
-      currentApprovalContext={currentApprovalContext}
-      currentModelDisplay={currentModelDisplay}
-      currentModelHandle={currentModelHandle}
-      currentModelId={currentModelId}
-      currentModelServiceTier={currentModelServiceTier}
-      currentModelProvider={currentModelProvider}
-      isLocalBackend={isLocalBackend}
-      currentPersonalityId={currentPersonalityId}
-      currentReasoningEffort={currentReasoningEffort}
-      currentSystemPromptId={currentSystemPromptId}
-      currentToolset={currentToolset}
-      currentToolsetPreference={currentToolsetPreference}
-      expandedToolCallId={expandedToolCallId}
-      lastShellToolCallId={lastShellToolCallId}
-      handleCtrlO={handleCtrlO}
-      queueMode={queueMode}
-      deferModeSupported={deferModeSupported}
-      handleCtrlD={handleCtrlD}
-      emittedIdsRef={emittedIdsRef}
-      feedbackPrefill={feedbackPrefill}
-      footerUpdateText={footerUpdateText}
-      showInspirationalPromptHints={showInspirationalPromptHints}
-      onEscapeCommandCancel={onEscapeCommandCancel}
-      handleAgentSelect={handleAgentSelect}
-      handleApproveAlways={handleApproveAlways}
-      handleApproveCurrent={handleApproveCurrent}
-      handleBashInterrupt={handleBashInterrupt}
-      handleBashSubmit={handleBashSubmit}
-      handleBtwJump={handleBtwJump}
-      handleCancelApprovals={handleCancelApprovals}
-      handleCompactionModeSelect={handleCompactionModeSelect}
-      handleCreateNewAgent={handleCreateNewAgent}
-      handleCycleReasoningEffort={handleCycleReasoningEffort}
-      handleDenyCurrent={handleDenyCurrent}
-      handleQueueEdit={handleQueueEdit}
-      handleExit={handleExit}
-      handleExperimentsConfirm={handleExperimentsConfirm}
-      handleFeedbackSubmit={handleFeedbackSubmit}
-      handleInterrupt={handleInterrupt}
-      handleModelSelect={handleModelSelect}
-      handlePasteError={handlePasteError}
-      handlePermissionModeChange={handlePermissionModeChange}
-      handlePersonalitySelect={handlePersonalitySelect}
-      handleProfileEscapeCancel={handleProfileEscapeCancel}
-      handleQuestionSubmit={handleQuestionSubmit}
-      handleGoalLoopExit={handleGoalLoopExit}
-      handleSleeptimeModeSelect={handleSleeptimeModeSelect}
-      handleSystemPromptSelect={handleSystemPromptSelect}
-      handleToolsetSelect={handleToolsetSelect}
-      hasBackfilledRef={hasBackfilledRef}
-      hasTemporaryModelOverride={hasTemporaryModelOverride}
-      includeSystemPromptUpgradeTip={includeSystemPromptUpgradeTip}
-      inputEnabled={inputEnabled}
-      inputVisible={inputVisible}
-      interruptRequested={interruptRequested}
-      isAgentBusy={isAgentBusy}
-      liveItems={liveItems}
-      liveTrajectoryElapsedBaseMs={liveTrajectoryElapsedBaseMs}
-      loadingState={loadingState}
-      markLocalModelsAvailable={markLocalModelsAvailable}
-      maybeCarryOverActiveConversationModel={
-        maybeCarryOverActiveConversationModel
-      }
-      modelReasoningPrompt={modelReasoningPrompt}
-      modelSelectorOptions={modelSelectorOptions}
-      networkPhase={networkPhase}
-      executionPhase={executionPhase}
-      fileAutocompleteFdPath={fileAutocompleteFdPath}
-      onSubmit={onSubmit}
-      pendingApprovals={pendingApprovals}
-      pendingConversationSwitchRef={pendingConversationSwitchRef}
-      pendingIds={pendingIds}
-      pinDialogLocal={pinDialogLocal}
-      precomputedDiffsRef={precomputedDiffsRef}
-      profileConfirmPending={profileConfirmPending}
-      queueDisplay={queueDisplay}
-      queuedDecisions={queuedDecisions}
-      queuedIds={queuedIds}
-      reasoningTabCycleEnabled={reasoningTabCycleEnabled}
-      recoverRestoredPendingApprovals={recoverRestoredPendingApprovals}
-      refreshDerived={refreshDerived}
-      resetBootstrapReminderState={resetBootstrapReminderState}
-      resetDeferredToolCallCommits={resetDeferredToolCallCommits}
-      resetTrajectoryBases={resetTrajectoryBases}
-      restoredInput={restoredInput}
-      resumeKey={resumeKey}
-      searchQuery={searchQuery}
-      sessionStatsRef={sessionStatsRef}
-      worktreeDiffSelectorPending={worktreeDiffSelectorPending}
-      setWorktreeDiffSelectorPending={setWorktreeDiffSelectorPending}
-      setActiveOverlay={setActiveOverlay}
-      setBtwState={setBtwState}
-      setCommandRunning={setCommandRunning}
-      setConversationAutoTitleEligibility={setConversationAutoTitleEligibility}
-      setConversationIdAndRef={setConversationIdAndRef}
-      setConversationSummary={setConversationSummary}
-      setLines={setLines}
-      setModelReasoningPrompt={setModelReasoningPrompt}
-      setModelSelectorOptions={setModelSelectorOptions}
-      setQueuedOverlayAction={setQueuedOverlayAction}
-      setRestoredInput={setRestoredInput}
-      setStaticItems={setStaticItems}
-      setStaticRenderEpoch={setStaticRenderEpoch}
-      shouldAnimate={shouldAnimate}
-      showApprovalPreview={showApprovalPreview}
-      showCompactionsEnabled={showCompactionsEnabled}
-      showExitStats={showExitStats}
-      openOverlay={openOverlay}
-      staticItems={staticItems}
-      staticRenderEpoch={staticRenderEpoch}
-      statusLinePayload={statusLinePayload}
-      statusLinePrompt={CLI_GLYPHS.prompt}
-      terminalTitleData={terminalTitleData}
-      onTitlePreview={applyManagedTerminalTitle}
-      extensionAdapter={extensionAdapter}
-      streaming={streaming}
-      stubDescriptions={stubDescriptions}
-      thinkingMessage={thinkingMessage}
-      trajectoryTokenDisplay={trajectoryTokenDisplay}
-      usedContextTokens={usedContextTokens}
-      contextWindowSize={effectiveContextWindowSize}
-      uiPermissionMode={uiPermissionMode}
-      uiGoalLoopActive={uiGoalLoopActive}
-      updateAgentName={updateAgentName}
-    />
+    <>
+      <TerminalTitleWriter
+        projectDirectory={projectDirectory}
+        configRefreshKey={activeOverlay}
+        titleData={terminalTitleData}
+        shouldAnimate={shouldAnimate}
+        hasActiveProgress={terminalTitleTaskRunning}
+        requiresAction={pendingApprovals.length > 0}
+        previewTitle={terminalTitlePreviewOverride}
+      />
+      <AppView
+        activeOverlay={activeOverlay}
+        agentId={agentId}
+        agentName={agentName}
+        agentState={agentState}
+        anySelectorOpen={anySelectorOpen}
+        approvalMap={approvalMap}
+        bashRunning={bashRunning}
+        billingTier={billingTier}
+        btwState={btwState}
+        buffersRef={buffersRef}
+        chromeColumns={chromeColumns}
+        closeOverlay={closeOverlay}
+        columns={columns}
+        commandRunner={commandRunner}
+        completeOverlay={completeOverlay}
+        contextTrackerRef={contextTrackerRef}
+        continueSession={continueSession}
+        conversationId={conversationId}
+        conversationSummary={conversationSummary}
+        projectDirectory={projectDirectory}
+        currentApproval={currentApproval}
+        currentApprovalContext={currentApprovalContext}
+        currentModelDisplay={currentModelDisplay}
+        currentModelHandle={currentModelHandle}
+        currentModelId={currentModelId}
+        currentModelServiceTier={currentModelServiceTier}
+        currentModelProvider={currentModelProvider}
+        isLocalBackend={isLocalBackend}
+        currentPersonalityId={currentPersonalityId}
+        currentReasoningEffort={currentReasoningEffort}
+        currentSystemPromptId={currentSystemPromptId}
+        currentToolset={currentToolset}
+        currentToolsetPreference={currentToolsetPreference}
+        expandedToolCallId={expandedToolCallId}
+        lastShellToolCallId={lastShellToolCallId}
+        handleCtrlO={handleCtrlO}
+        queueMode={queueMode}
+        deferModeSupported={deferModeSupported}
+        handleCtrlD={handleCtrlD}
+        emittedIdsRef={emittedIdsRef}
+        feedbackPrefill={feedbackPrefill}
+        footerUpdateText={footerUpdateText}
+        showInspirationalPromptHints={showInspirationalPromptHints}
+        onEscapeCommandCancel={onEscapeCommandCancel}
+        handleAgentSelect={handleAgentSelect}
+        handleApproveAlways={handleApproveAlways}
+        handleApproveCurrent={handleApproveCurrent}
+        handleBashInterrupt={handleBashInterrupt}
+        handleBashSubmit={handleBashSubmit}
+        handleBtwJump={handleBtwJump}
+        handleCancelApprovals={handleCancelApprovals}
+        handleCompactionModeSelect={handleCompactionModeSelect}
+        handleCreateNewAgent={handleCreateNewAgent}
+        handleCycleReasoningEffort={handleCycleReasoningEffort}
+        handleDenyCurrent={handleDenyCurrent}
+        handleQueueEdit={handleQueueEdit}
+        handleExit={handleExit}
+        handleExperimentsConfirm={handleExperimentsConfirm}
+        handleFeedbackSubmit={handleFeedbackSubmit}
+        handleInterrupt={handleInterrupt}
+        handleModelSelect={handleModelSelect}
+        handlePasteError={handlePasteError}
+        handlePermissionModeChange={handlePermissionModeChange}
+        handlePersonalitySelect={handlePersonalitySelect}
+        handleProfileEscapeCancel={handleProfileEscapeCancel}
+        handleQuestionSubmit={handleQuestionSubmit}
+        handleGoalLoopExit={handleGoalLoopExit}
+        handleSleeptimeModeSelect={handleSleeptimeModeSelect}
+        handleSystemPromptSelect={handleSystemPromptSelect}
+        handleToolsetSelect={handleToolsetSelect}
+        hasBackfilledRef={hasBackfilledRef}
+        hasTemporaryModelOverride={hasTemporaryModelOverride}
+        includeSystemPromptUpgradeTip={includeSystemPromptUpgradeTip}
+        inputEnabled={inputEnabled}
+        inputVisible={inputVisible}
+        interruptRequested={interruptRequested}
+        isAgentBusy={isAgentBusy}
+        liveItems={liveItems}
+        liveTrajectoryElapsedBaseMs={liveTrajectoryElapsedBaseMs}
+        loadingState={loadingState}
+        markLocalModelsAvailable={markLocalModelsAvailable}
+        maybeCarryOverActiveConversationModel={
+          maybeCarryOverActiveConversationModel
+        }
+        modelReasoningPrompt={modelReasoningPrompt}
+        modelSelectorOptions={modelSelectorOptions}
+        networkPhase={networkPhase}
+        executionPhase={executionPhase}
+        fileAutocompleteFdPath={fileAutocompleteFdPath}
+        onSubmit={onSubmit}
+        pendingApprovals={pendingApprovals}
+        pendingConversationSwitchRef={pendingConversationSwitchRef}
+        pendingIds={pendingIds}
+        pinDialogLocal={pinDialogLocal}
+        precomputedDiffsRef={precomputedDiffsRef}
+        profileConfirmPending={profileConfirmPending}
+        queueDisplay={queueDisplay}
+        queuedDecisions={queuedDecisions}
+        queuedIds={queuedIds}
+        reasoningTabCycleEnabled={reasoningTabCycleEnabled}
+        recoverRestoredPendingApprovals={recoverRestoredPendingApprovals}
+        refreshDerived={refreshDerived}
+        resetBootstrapReminderState={resetBootstrapReminderState}
+        resetDeferredToolCallCommits={resetDeferredToolCallCommits}
+        resetTrajectoryBases={resetTrajectoryBases}
+        restoredInput={restoredInput}
+        resumeKey={resumeKey}
+        searchQuery={searchQuery}
+        sessionStatsRef={sessionStatsRef}
+        worktreeDiffSelectorPending={worktreeDiffSelectorPending}
+        setWorktreeDiffSelectorPending={setWorktreeDiffSelectorPending}
+        setActiveOverlay={setActiveOverlay}
+        setBtwState={setBtwState}
+        setCommandRunning={setCommandRunning}
+        setConversationAutoTitleEligibility={
+          setConversationAutoTitleEligibility
+        }
+        setConversationIdAndRef={setConversationIdAndRef}
+        setConversationSummary={setConversationSummary}
+        setLines={setLines}
+        setModelReasoningPrompt={setModelReasoningPrompt}
+        setModelSelectorOptions={setModelSelectorOptions}
+        setQueuedOverlayAction={setQueuedOverlayAction}
+        setRestoredInput={setRestoredInput}
+        setStaticItems={setStaticItems}
+        setStaticRenderEpoch={setStaticRenderEpoch}
+        shouldAnimate={shouldAnimate}
+        showApprovalPreview={showApprovalPreview}
+        showCompactionsEnabled={showCompactionsEnabled}
+        showExitStats={showExitStats}
+        openOverlay={openOverlay}
+        staticItems={staticItems}
+        staticRenderEpoch={staticRenderEpoch}
+        statusLinePayload={statusLinePayload}
+        statusLinePrompt={CLI_GLYPHS.prompt}
+        terminalTitleData={terminalTitleData}
+        onTitlePreview={setTerminalTitlePreviewOverride}
+        onTitlePreviewEnd={clearTerminalTitlePreviewOverride}
+        extensionAdapter={extensionAdapter}
+        streaming={streaming}
+        stubDescriptions={stubDescriptions}
+        thinkingMessage={thinkingMessage}
+        trajectoryTokenDisplay={trajectoryTokenDisplay}
+        usedContextTokens={usedContextTokens}
+        contextWindowSize={effectiveContextWindowSize}
+        uiPermissionMode={uiPermissionMode}
+        uiGoalLoopActive={uiGoalLoopActive}
+        updateAgentName={updateAgentName}
+      />
+    </>
   );
 }

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -322,6 +322,7 @@ type AppViewProps = {
   statusLinePrompt: string;
   terminalTitleData: WindowTitleData;
   onTitlePreview: (title: string | null) => void;
+  onTitlePreviewEnd: () => void;
   extensionAdapter: LocalExtensionAdapter;
   fileAutocompleteFdPath?: string | null;
   streaming: boolean;
@@ -469,6 +470,7 @@ export function AppView(props: AppViewProps) {
     statusLinePrompt,
     terminalTitleData,
     onTitlePreview,
+    onTitlePreviewEnd,
     extensionAdapter,
     streaming,
     stubDescriptions,
@@ -849,6 +851,7 @@ export function AppView(props: AppViewProps) {
                 projectDirectory={projectDirectory}
                 titleData={terminalTitleData}
                 onTitlePreview={onTitlePreview}
+                onTitlePreviewEnd={onTitlePreviewEnd}
                 onClose={closeOverlay}
               />
             )}

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -80,6 +80,7 @@ import {
   isPatchTool,
 } from "@/cli/helpers/tool-name-mapping";
 import { isTaskTool } from "@/cli/helpers/tool-name-mapping.js";
+import type { WindowTitleData } from "@/cli/helpers/window-title-config";
 import { experimentManager } from "@/experiments/manager";
 import type { ExperimentId } from "@/experiments/types";
 import type { ApprovalContext } from "@/permissions/analyzer";
@@ -319,6 +320,8 @@ type AppViewProps = {
   staticRenderEpoch: number;
   statusLinePayload: StatusLinePayload;
   statusLinePrompt: string;
+  terminalTitleData: WindowTitleData;
+  onTitlePreview: (title: string | null) => void;
   extensionAdapter: LocalExtensionAdapter;
   fileAutocompleteFdPath?: string | null;
   streaming: boolean;
@@ -352,7 +355,6 @@ export function AppView(props: AppViewProps) {
     contextTrackerRef,
     continueSession,
     conversationId,
-    conversationSummary,
     projectDirectory,
     currentApproval,
     currentApprovalContext,
@@ -465,6 +467,8 @@ export function AppView(props: AppViewProps) {
     staticRenderEpoch,
     statusLinePayload,
     statusLinePrompt,
+    terminalTitleData,
+    onTitlePreview,
     extensionAdapter,
     streaming,
     stubDescriptions,
@@ -842,9 +846,9 @@ export function AppView(props: AppViewProps) {
             {/* Window Title Configurator - for customizing terminal title */}
             {activeOverlay === "window-title" && (
               <WindowTitlePicker
-                agentName={agentName ?? null}
                 projectDirectory={projectDirectory}
-                conversationSummary={conversationSummary}
+                titleData={terminalTitleData}
+                onTitlePreview={onTitlePreview}
                 onClose={closeOverlay}
               />
             )}

--- a/src/cli/components/MultiSelectPicker.tsx
+++ b/src/cli/components/MultiSelectPicker.tsx
@@ -9,7 +9,7 @@
 // - Items are identified by key (string), not index
 
 import { Box, type Key, useInput } from "ink";
-import { memo, useCallback, useEffect, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useTerminalWidth } from "@/cli/hooks/use-terminal-width";
 import { colors } from "./colors";
 import { Text } from "./Text";
@@ -29,6 +29,7 @@ export interface MultiSelectPickerProps {
   onCancel: () => void;
   onSelectionChange?: (selectedKeys: string[]) => void;
   preview?: string;
+  enableOrdering?: boolean;
 }
 
 export const MultiSelectPicker = memo(function MultiSelectPicker({
@@ -38,12 +39,27 @@ export const MultiSelectPicker = memo(function MultiSelectPicker({
   onCancel,
   onSelectionChange,
   preview,
+  enableOrdering = false,
 }: MultiSelectPickerProps) {
   const [cursor, setCursor] = useState(0);
+  const [orderedItems, setOrderedItems] = useState<SelectableItem[]>(items);
   const [selectedSet, setSelectedSet] = useState<Set<string>>(
     () => new Set(selected),
   );
   const columns = useTerminalWidth();
+
+  useEffect(() => {
+    setOrderedItems(items);
+    setCursor((c) => Math.min(c, Math.max(0, items.length - 1)));
+  }, [items]);
+
+  const selectedKeysInOrder = useMemo(
+    () =>
+      orderedItems
+        .filter((item) => selectedSet.has(item.key))
+        .map((item) => item.key),
+    [orderedItems, selectedSet],
+  );
 
   const toggle = useCallback((key: string) => {
     setSelectedSet((prev) => {
@@ -57,10 +73,33 @@ export const MultiSelectPicker = memo(function MultiSelectPicker({
     });
   }, []);
 
-  // Propagate selection changes to parent in a separate render cycle
+  const moveSelectedItem = useCallback(
+    (direction: "up" | "down") => {
+      if (!enableOrdering) return;
+      const nextIndex = direction === "up" ? cursor - 1 : cursor + 1;
+      setOrderedItems((prev) => {
+        if (cursor < 0 || cursor >= prev.length) return prev;
+        if (nextIndex < 0 || nextIndex >= prev.length) return prev;
+
+        const next = [...prev];
+        const current = next[cursor];
+        const target = next[nextIndex];
+        if (!current || !target) return prev;
+        next[cursor] = target;
+        next[nextIndex] = current;
+        return next;
+      });
+      if (nextIndex >= 0 && nextIndex < orderedItems.length) {
+        setCursor(nextIndex);
+      }
+    },
+    [cursor, enableOrdering, orderedItems.length],
+  );
+
+  // Propagate selection/order changes to parent in a separate render cycle
   useEffect(() => {
-    onSelectionChange?.([...selectedSet]);
-  }, [selectedSet, onSelectionChange]);
+    onSelectionChange?.(selectedKeysInOrder);
+  }, [selectedKeysInOrder, onSelectionChange]);
 
   const handleInput = useCallback(
     (input: string, key: Key) => {
@@ -69,7 +108,15 @@ export const MultiSelectPicker = memo(function MultiSelectPicker({
         return;
       }
       if (key.downArrow) {
-        setCursor((c) => Math.min(items.length - 1, c + 1));
+        setCursor((c) => Math.min(orderedItems.length - 1, c + 1));
+        return;
+      }
+      if (enableOrdering && key.leftArrow) {
+        moveSelectedItem("up");
+        return;
+      }
+      if (enableOrdering && key.rightArrow) {
+        moveSelectedItem("down");
         return;
       }
       if (key.escape) {
@@ -77,19 +124,28 @@ export const MultiSelectPicker = memo(function MultiSelectPicker({
         return;
       }
       if (key.return) {
-        onConfirm([...selectedSet]);
+        onConfirm(selectedKeysInOrder);
         return;
       }
       // Space toggles checkbox (no-op for disabled items)
       if (input === " ") {
-        const item = items[cursor];
+        const item = orderedItems[cursor];
         if (item && !item.disabled) {
           toggle(item.key);
         }
         return;
       }
     },
-    [items, cursor, onCancel, onConfirm, selectedSet, toggle],
+    [
+      cursor,
+      enableOrdering,
+      moveSelectedItem,
+      onCancel,
+      onConfirm,
+      orderedItems,
+      selectedKeysInOrder,
+      toggle,
+    ],
   );
 
   useInput(handleInput, { isActive: true });
@@ -98,7 +154,7 @@ export const MultiSelectPicker = memo(function MultiSelectPicker({
     <Box flexDirection="column">
       {/* Items */}
       <Box flexDirection="column">
-        {items.map((item, index) => {
+        {orderedItems.map((item, index) => {
           const isCursor = index === cursor;
           const isChecked = selectedSet.has(item.key);
           const isDisabled = item.disabled ?? false;
@@ -154,6 +210,7 @@ export const MultiSelectPicker = memo(function MultiSelectPicker({
       <Box marginTop={1}>
         <Text dimColor>
           Space to toggle · ↑↓ to navigate · Enter to confirm · Esc to cancel
+          {enableOrdering ? " · ←→ to reorder" : ""}
         </Text>
       </Box>
     </Box>

--- a/src/cli/components/TerminalTitleWriter.tsx
+++ b/src/cli/components/TerminalTitleWriter.tsx
@@ -1,0 +1,148 @@
+import { memo, useEffect, useMemo, useRef } from "react";
+import {
+  clearTerminalTitle,
+  setTerminalTitle,
+} from "@/cli/helpers/terminal-title";
+import {
+  renderActionRequiredWindowTitle,
+  renderWindowTitle,
+  resolveWindowTitleConfig,
+  TERMINAL_TITLE_ACTION_REQUIRED_INTERVAL_MS,
+  TERMINAL_TITLE_ACTION_REQUIRED_PREFIX,
+  TERMINAL_TITLE_ACTION_REQUIRED_PREFIX_HIDDEN,
+  TERMINAL_TITLE_SPINNER_FRAMES,
+  TERMINAL_TITLE_SPINNER_INTERVAL_MS,
+  titleUsesActivity,
+  type WindowTitleData,
+} from "@/cli/helpers/window-title-config";
+import { useFrameCycle } from "./spinners/use-frame-cycle";
+
+const TERMINAL_TITLE_ACTION_REQUIRED_FRAMES = [
+  TERMINAL_TITLE_ACTION_REQUIRED_PREFIX,
+  TERMINAL_TITLE_ACTION_REQUIRED_PREFIX_HIDDEN,
+] as const;
+
+export interface TerminalTitleWriterProps {
+  projectDirectory: string;
+  /** Changes when /title closes after persisting settings, so config is re-read. */
+  configRefreshKey: unknown;
+  titleData: WindowTitleData;
+  shouldAnimate: boolean;
+  hasActiveProgress: boolean;
+  requiresAction: boolean;
+  previewTitle: string | null | undefined;
+}
+
+/**
+ * Side-effect-only terminal-title writer.
+ *
+ * Keeping animation state here prevents the 10Hz title spinner from re-rendering
+ * AppCoordinator/AppView while still sharing Codex's frame cadence and title
+ * rendering rules.
+ */
+export const TerminalTitleWriter = memo(function TerminalTitleWriter({
+  projectDirectory,
+  configRefreshKey,
+  titleData,
+  shouldAnimate,
+  hasActiveProgress,
+  requiresAction,
+  previewTitle,
+}: TerminalTitleWriterProps) {
+  const lastManagedTerminalTitleRef = useRef<string | null>(null);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: configRefreshKey changes after /title persists settings; recompute the config on close.
+  const terminalTitleItems = useMemo(
+    () => resolveWindowTitleConfig(projectDirectory),
+    [projectDirectory, configRefreshKey],
+  );
+  const terminalTitleUsesActivity = titleUsesActivity(terminalTitleItems);
+  const terminalTitleShowsActionRequired =
+    requiresAction && terminalTitleUsesActivity;
+  const terminalTitleHasActiveProgress =
+    !terminalTitleShowsActionRequired && hasActiveProgress;
+  const terminalTitleSpinnerFrameIndex = useFrameCycle(
+    TERMINAL_TITLE_SPINNER_FRAMES,
+    TERMINAL_TITLE_SPINNER_INTERVAL_MS,
+    shouldAnimate &&
+      terminalTitleUsesActivity &&
+      terminalTitleHasActiveProgress,
+  );
+  const terminalTitleActionFrameIndex = useFrameCycle(
+    TERMINAL_TITLE_ACTION_REQUIRED_FRAMES,
+    TERMINAL_TITLE_ACTION_REQUIRED_INTERVAL_MS,
+    shouldAnimate && terminalTitleShowsActionRequired,
+  );
+  const terminalTitleActionPrefix =
+    TERMINAL_TITLE_ACTION_REQUIRED_FRAMES[terminalTitleActionFrameIndex] ??
+    TERMINAL_TITLE_ACTION_REQUIRED_PREFIX;
+  const terminalTitleData = useMemo<WindowTitleData>(
+    () => ({
+      ...titleData,
+      activityFrame:
+        shouldAnimate && terminalTitleHasActiveProgress
+          ? (TERMINAL_TITLE_SPINNER_FRAMES[terminalTitleSpinnerFrameIndex] ??
+            null)
+          : null,
+    }),
+    [
+      shouldAnimate,
+      terminalTitleHasActiveProgress,
+      terminalTitleSpinnerFrameIndex,
+      titleData,
+    ],
+  );
+  const computedTitle = useMemo(
+    () =>
+      terminalTitleShowsActionRequired
+        ? renderActionRequiredWindowTitle(
+            terminalTitleItems,
+            terminalTitleData,
+            terminalTitleActionPrefix,
+          )
+        : renderWindowTitle(terminalTitleItems, terminalTitleData),
+    [
+      terminalTitleActionPrefix,
+      terminalTitleData,
+      terminalTitleItems,
+      terminalTitleShowsActionRequired,
+    ],
+  );
+  const title = previewTitle === undefined ? computedTitle : previewTitle;
+
+  useEffect(() => {
+    if (title === lastManagedTerminalTitleRef.current) {
+      return;
+    }
+
+    if (title === null) {
+      if (lastManagedTerminalTitleRef.current !== null) {
+        clearTerminalTitle();
+        lastManagedTerminalTitleRef.current = null;
+      }
+      return;
+    }
+
+    const result = setTerminalTitle(title);
+    if (result === "applied") {
+      lastManagedTerminalTitleRef.current = title;
+      return;
+    }
+
+    if (lastManagedTerminalTitleRef.current !== null) {
+      clearTerminalTitle();
+      lastManagedTerminalTitleRef.current = null;
+    }
+  }, [title]);
+
+  useEffect(() => {
+    return () => {
+      if (lastManagedTerminalTitleRef.current !== null) {
+        clearTerminalTitle();
+        lastManagedTerminalTitleRef.current = null;
+      }
+    };
+  }, []);
+
+  return null;
+});

--- a/src/cli/components/WindowTitlePicker.tsx
+++ b/src/cli/components/WindowTitlePicker.tsx
@@ -5,7 +5,6 @@ import { memo, useCallback, useMemo, useRef, useState } from "react";
 import {
   normalizeWindowTitleItems,
   previewLineForWindowTitleItems,
-  renderWindowTitle,
   resolveWindowTitleConfig,
   WINDOW_TITLE_FIELD_INFO,
   WINDOW_TITLE_FIELDS,
@@ -20,6 +19,7 @@ interface WindowTitlePickerProps {
   projectDirectory: string;
   titleData: WindowTitleData;
   onTitlePreview: (title: string | null) => void;
+  onTitlePreviewEnd: () => void;
   onClose: () => void;
 }
 
@@ -27,6 +27,7 @@ export const WindowTitlePicker = memo(function WindowTitlePicker({
   projectDirectory,
   titleData,
   onTitlePreview,
+  onTitlePreviewEnd,
   onClose,
 }: WindowTitlePickerProps) {
   const currentItems = useMemo(
@@ -84,17 +85,16 @@ export const WindowTitlePicker = memo(function WindowTitlePicker({
       settingsManager.updateSettings({
         windowTitle: { items: normalizeWindowTitleItems(keys) },
       });
+      onTitlePreviewEnd();
       onClose();
     },
-    [onClose],
+    [onClose, onTitlePreviewEnd],
   );
 
   const handleCancel = useCallback(() => {
-    const savedItems = resolveWindowTitleConfig(projectDirectory);
-    const title = renderWindowTitle(savedItems, titleData);
-    onTitlePreview(title);
+    onTitlePreviewEnd();
     onClose();
-  }, [projectDirectory, titleData, onTitlePreview, onClose]);
+  }, [onTitlePreviewEnd, onClose]);
 
   return (
     <OverlayShell command="/title" title="Configure Terminal Title">

--- a/src/cli/components/WindowTitlePicker.tsx
+++ b/src/cli/components/WindowTitlePicker.tsx
@@ -1,30 +1,32 @@
 // Window title configuration picker.
 // Wraps MultiSelectPicker with window-title-specific logic.
 
-import { memo, useCallback, useMemo, useState } from "react";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
 import {
+  normalizeWindowTitleItems,
+  previewLineForWindowTitleItems,
   renderWindowTitle,
   resolveWindowTitleConfig,
   WINDOW_TITLE_FIELD_INFO,
   WINDOW_TITLE_FIELDS,
+  type WindowTitleData,
   type WindowTitleField,
 } from "@/cli/helpers/window-title-config";
 import { settingsManager } from "@/settings-manager";
-import { getVersion } from "@/version";
 import { MultiSelectPicker } from "./MultiSelectPicker";
 import { OverlayShell } from "./OverlayShell";
 
 interface WindowTitlePickerProps {
-  agentName: string | null;
   projectDirectory: string;
-  conversationSummary: string | null;
+  titleData: WindowTitleData;
+  onTitlePreview: (title: string | null) => void;
   onClose: () => void;
 }
 
 export const WindowTitlePicker = memo(function WindowTitlePicker({
-  agentName,
   projectDirectory,
-  conversationSummary,
+  titleData,
+  onTitlePreview,
   onClose,
 }: WindowTitlePickerProps) {
   const currentItems = useMemo(
@@ -32,42 +34,55 @@ export const WindowTitlePicker = memo(function WindowTitlePicker({
     [projectDirectory],
   );
 
-  const [selectedKeys, setSelectedKeys] = useState<string[]>(currentItems);
+  const [selectedKeys, setSelectedKeys] =
+    useState<WindowTitleField[]>(currentItems);
+  const hasHandledInitialSelectionChangeRef = useRef(false);
 
-  const items = useMemo(
-    () =>
-      WINDOW_TITLE_FIELDS.map((key) => ({
-        key,
-        label: WINDOW_TITLE_FIELD_INFO[key].label,
-        description: WINDOW_TITLE_FIELD_INFO[key].description,
-      })),
-    [],
+  const items = useMemo(() => {
+    const selected = uniqueWindowTitleItems(currentItems);
+    const selectedSet = new Set(selected);
+    const ordered = [
+      ...selected,
+      ...WINDOW_TITLE_FIELDS.filter((key) => !selectedSet.has(key)),
+    ];
+
+    return ordered.map((key) => ({
+      key,
+      label: WINDOW_TITLE_FIELD_INFO[key].label,
+      description: WINDOW_TITLE_FIELD_INFO[key].description,
+    }));
+  }, [currentItems]);
+
+  const preview = useMemo(
+    () => previewLineForWindowTitleItems(selectedKeys, titleData),
+    [selectedKeys, titleData],
   );
 
-  const titleData = useMemo(
-    () => ({
-      agentName,
-      appName: "Letta Code",
-      version: getVersion(),
-      conversationSummary,
-    }),
-    [agentName, conversationSummary],
+  const applyTitlePreview = useCallback(
+    (keys: WindowTitleField[]) => {
+      const title = previewLineForWindowTitleItems(keys, titleData);
+      onTitlePreview(title);
+    },
+    [onTitlePreview, titleData],
   );
 
   const handleSelectionChange = useCallback(
     (keys: string[]) => {
-      setSelectedKeys(keys);
-      // Update terminal title live so the user sees the effect immediately
-      const title = renderWindowTitle(keys as WindowTitleField[], titleData);
-      process.stdout.write(`\x1b]0;${title}\x07`);
+      const normalized = normalizeWindowTitleItems(keys);
+      setSelectedKeys(normalized);
+      if (!hasHandledInitialSelectionChangeRef.current) {
+        hasHandledInitialSelectionChangeRef.current = true;
+        return;
+      }
+      applyTitlePreview(normalized);
     },
-    [titleData],
+    [applyTitlePreview],
   );
 
   const handleConfirm = useCallback(
     (keys: string[]) => {
       settingsManager.updateSettings({
-        windowTitle: { items: keys },
+        windowTitle: { items: normalizeWindowTitleItems(keys) },
       });
       onClose();
     },
@@ -75,12 +90,11 @@ export const WindowTitlePicker = memo(function WindowTitlePicker({
   );
 
   const handleCancel = useCallback(() => {
-    // Revert terminal title to the persisted config
     const savedItems = resolveWindowTitleConfig(projectDirectory);
     const title = renderWindowTitle(savedItems, titleData);
-    process.stdout.write(`\x1b]0;${title}\x07`);
+    onTitlePreview(title);
     onClose();
-  }, [projectDirectory, titleData, onClose]);
+  }, [projectDirectory, titleData, onTitlePreview, onClose]);
 
   return (
     <OverlayShell command="/title" title="Configure Terminal Title">
@@ -90,7 +104,22 @@ export const WindowTitlePicker = memo(function WindowTitlePicker({
         onConfirm={handleConfirm}
         onCancel={handleCancel}
         onSelectionChange={handleSelectionChange}
+        preview={preview ?? undefined}
+        enableOrdering
       />
     </OverlayShell>
   );
 });
+
+function uniqueWindowTitleItems(
+  items: readonly WindowTitleField[],
+): WindowTitleField[] {
+  const seen = new Set<WindowTitleField>();
+  const unique: WindowTitleField[] = [];
+  for (const item of items) {
+    if (seen.has(item)) continue;
+    seen.add(item);
+    unique.push(item);
+  }
+  return unique;
+}

--- a/src/cli/helpers/terminal-title.test.ts
+++ b/src/cli/helpers/terminal-title.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import {
+  sanitizeTerminalTitle,
+  terminalTitleOsc,
+} from "@/cli/helpers/terminal-title";
+
+describe("terminal title writer helpers", () => {
+  test("sanitizes terminal title", () => {
+    const sanitized = sanitizeTerminalTitle(
+      "  Project\t|\nWorking\x1b\x07\u009d\u009c |  Thread  ",
+    );
+    expect(sanitized).toBe("Project | Working | Thread");
+  });
+
+  test("strips invisible format chars from terminal title", () => {
+    const sanitized = sanitizeTerminalTitle(
+      "Pro\u202ej\u2066e\u200fc\u061ct\u200b \ufeffT\u2060itle",
+    );
+    expect(sanitized).toBe("Project Title");
+  });
+
+  test("truncates terminal title", () => {
+    const input = "a".repeat(250);
+    const sanitized = sanitizeTerminalTitle(input);
+    expect(sanitized).toHaveLength(240);
+  });
+
+  test("truncation prefers visible char over pending space", () => {
+    const input = `${"a".repeat(239)} b`;
+    const sanitized = sanitizeTerminalTitle(input);
+    expect(sanitized).toHaveLength(240);
+    expect(sanitized.at(-1)).toBe("b");
+  });
+
+  test("writes OSC title with BEL terminator", () => {
+    expect(terminalTitleOsc("hello")).toBe("\x1b]0;hello\x07");
+  });
+});

--- a/src/cli/helpers/terminal-title.ts
+++ b/src/cli/helpers/terminal-title.ts
@@ -1,0 +1,99 @@
+/**
+ * Terminal-title output helpers for the TUI.
+ *
+ * This mirrors Codex's narrow OSC title writer: callers decide when a title
+ * should change, while this module owns sanitization and the BEL-terminated OSC
+ * 0 write. It does not try to restore the terminal's previous title because
+ * that is not portable across terminals.
+ */
+
+const MAX_TERMINAL_TITLE_CHARS = 240;
+
+export type SetTerminalTitleResult = "applied" | "no-visible-content";
+
+export function setTerminalTitle(title: string): SetTerminalTitleResult {
+  if (!process.stdout.isTTY) {
+    return "applied";
+  }
+
+  const sanitized = sanitizeTerminalTitle(title);
+  if (sanitized.length === 0) {
+    return "no-visible-content";
+  }
+
+  process.stdout.write(terminalTitleOsc(sanitized));
+  return "applied";
+}
+
+export function clearTerminalTitle(): void {
+  if (!process.stdout.isTTY) {
+    return;
+  }
+
+  process.stdout.write(terminalTitleOsc(""));
+}
+
+export function terminalTitleOsc(title: string): string {
+  return `\x1b]0;${title}\x07`;
+}
+
+export function sanitizeTerminalTitle(title: string): string {
+  let sanitized = "";
+  let charsWritten = 0;
+  let pendingSpace = false;
+
+  for (const ch of title) {
+    if (/\s/u.test(ch)) {
+      pendingSpace = sanitized.length > 0;
+      continue;
+    }
+
+    if (isDisallowedTerminalTitleChar(ch)) {
+      continue;
+    }
+
+    if (pendingSpace) {
+      const remaining = MAX_TERMINAL_TITLE_CHARS - charsWritten;
+      if (remaining > 1) {
+        sanitized += " ";
+        charsWritten += 1;
+        pendingSpace = false;
+      }
+    }
+
+    if (charsWritten >= MAX_TERMINAL_TITLE_CHARS) {
+      break;
+    }
+
+    sanitized += ch;
+    charsWritten += 1;
+  }
+
+  return sanitized;
+}
+
+function isDisallowedTerminalTitleChar(ch: string): boolean {
+  const code = ch.codePointAt(0);
+  if (code === undefined) {
+    return true;
+  }
+
+  if ((code >= 0x00 && code <= 0x1f) || (code >= 0x7f && code <= 0x9f)) {
+    return true;
+  }
+
+  return (
+    code === 0x00ad ||
+    code === 0x034f ||
+    code === 0x061c ||
+    code === 0x180e ||
+    (code >= 0x200b && code <= 0x200f) ||
+    (code >= 0x202a && code <= 0x202e) ||
+    (code >= 0x2060 && code <= 0x206f) ||
+    (code >= 0xfe00 && code <= 0xfe0f) ||
+    code === 0xfeff ||
+    (code >= 0xfff9 && code <= 0xfffb) ||
+    (code >= 0x1bca0 && code <= 0x1bca3) ||
+    (code >= 0xe0100 && code <= 0xe01ef)
+  );
+}

--- a/src/cli/helpers/window-title-config.test.ts
+++ b/src/cli/helpers/window-title-config.test.ts
@@ -13,6 +13,7 @@ import {
 } from "@/cli/helpers/window-title-config";
 
 const baseData: WindowTitleData = {
+  agentName: "Big Chungus",
   appName: "Letta Code",
   version: "0.0.0-test",
   conversationId: "thread-123",
@@ -34,17 +35,17 @@ function render(items: WindowTitleField[], data: WindowTitleData = baseData) {
 }
 
 describe("window title config", () => {
-  test("uses Codex default shape: activity then project name", () => {
+  test("uses Letta's agent-centric default shape: activity then agent name", () => {
     expect(
-      render(["activity", "project-name"], {
+      render(["activity", "agent-name"], {
         ...baseData,
         activityFrame: "⠋",
       }),
-    ).toBe("⠋ project");
+    ).toBe("⠋ Big Chungus");
   });
 
   test("omits inactive activity without leaving a separator", () => {
-    expect(render(["activity", "project-name"])).toBe("project");
+    expect(render(["activity", "agent-name"])).toBe("Big Chungus");
   });
 
   test("uses Codex activity separator rule", () => {

--- a/src/cli/helpers/window-title-config.test.ts
+++ b/src/cli/helpers/window-title-config.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ACTION_REQUIRED_PREVIEW_PREFIX,
+  normalizeWindowTitleItems,
+  previewLineForWindowTitleItems,
+  renderActionRequiredWindowTitle,
+  renderWindowTitle,
+  separatorFromPrevious,
+  TERMINAL_TITLE_ACTION_REQUIRED_PREFIX,
+  truncateTerminalTitlePart,
+  type WindowTitleData,
+  type WindowTitleField,
+} from "@/cli/helpers/window-title-config";
+
+const baseData: WindowTitleData = {
+  appName: "Letta Code",
+  version: "0.0.0-test",
+  conversationId: "thread-123",
+  conversationSummary: "Investigate title behavior",
+  projectDirectory: "/tmp/project",
+  currentDirectory: "/tmp/project",
+  runState: "Working",
+  modelDisplayName: "GPT-5.3-Codex",
+  reasoningEffort: "high",
+  contextUsedPercentage: 42,
+  contextRemainingPercentage: 58,
+  totalInputTokens: 1200,
+  totalOutputTokens: 300,
+  fastMode: true,
+};
+
+function render(items: WindowTitleField[], data: WindowTitleData = baseData) {
+  return renderWindowTitle(items, data);
+}
+
+describe("window title config", () => {
+  test("uses Codex default shape: activity then project name", () => {
+    expect(
+      render(["activity", "project-name"], {
+        ...baseData,
+        activityFrame: "⠋",
+      }),
+    ).toBe("⠋ project");
+  });
+
+  test("omits inactive activity without leaving a separator", () => {
+    expect(render(["activity", "project-name"])).toBe("project");
+  });
+
+  test("uses Codex activity separator rule", () => {
+    expect(separatorFromPrevious("activity", "project-name")).toBe(" ");
+    expect(separatorFromPrevious("run-state", "activity")).toBe(" ");
+    expect(separatorFromPrevious("model", "project-name")).toBe(" | ");
+    expect(
+      render(["project-name", "activity", "run-state"], {
+        ...baseData,
+        activityFrame: "⠋",
+      }),
+    ).toBe("project ⠋ Working");
+  });
+
+  test("renders action required like Codex and excludes run-state at runtime", () => {
+    expect(
+      renderActionRequiredWindowTitle(
+        ["activity", "run-state", "project-name"],
+        baseData,
+        TERMINAL_TITLE_ACTION_REQUIRED_PREFIX,
+      ),
+    ).toBe("[ ! ] Action Required | project");
+  });
+
+  test("normalizes Codex legacy aliases", () => {
+    expect(
+      normalizeWindowTitleItems([
+        "spinner",
+        "project",
+        "status",
+        "thread",
+        "context-usage",
+        "session-id",
+        "model-name",
+      ]),
+    ).toEqual([
+      "activity",
+      "project-name",
+      "run-state",
+      "thread-title",
+      "context-used",
+      "thread-id",
+      "model",
+    ]);
+  });
+
+  test("preserves configured order instead of sorting", () => {
+    expect(render(["model", "project-name", "run-state"])).toBe(
+      "GPT-5.3-Codex | project | Working",
+    );
+  });
+
+  test("preview action-required prefix includes non-runtime exclusions", () => {
+    expect(
+      previewLineForWindowTitleItems(
+        ["activity", "run-state", "project-name"],
+        baseData,
+      ),
+    ).toBe(`${ACTION_REQUIRED_PREVIEW_PREFIX} | Working | project`);
+  });
+
+  test("truncates title segment like Codex", () => {
+    expect(truncateTerminalTitlePart("abcdefghijklmnopqrstuvwxyz", 8)).toBe(
+      "abcde...",
+    );
+    expect(truncateTerminalTitlePart("abcdef", 3)).toBe("abc");
+  });
+});

--- a/src/cli/helpers/window-title-config.ts
+++ b/src/cli/helpers/window-title-config.ts
@@ -1,47 +1,183 @@
 // Config resolution and rendering for the terminal window title.
 // Precedence: local project > project > global settings.
 
+import { homedir } from "node:os";
+import { basename, resolve } from "node:path";
+import { formatCompact } from "@/cli/helpers/format";
 import { settingsManager } from "@/settings-manager";
 import { debugLog } from "@/utils/debug";
 
-/** All valid field keys for the window title. */
+/** All valid field keys for the window title, in Codex's terminal-title item order. */
 export const WINDOW_TITLE_FIELDS = [
-  "agent-name",
-  "conversation-name",
   "app-name",
+  "project-name",
+  "current-dir",
+  "activity",
+  "run-state",
+  "thread-title",
+  "git-branch",
+  "context-remaining",
+  "context-used",
+  "five-hour-limit",
+  "weekly-limit",
   "version",
+  "used-tokens",
+  "total-input-tokens",
+  "total-output-tokens",
+  "thread-id",
+  "fast-mode",
+  "model",
+  "model-with-reasoning",
+  "reasoning",
+  "task-progress",
+  "agent-name",
 ] as const;
 
 export type WindowTitleField = (typeof WINDOW_TITLE_FIELDS)[number];
+
+/** Items shown in the terminal title when the user has not configured a custom selection. */
+export const DEFAULT_WINDOW_TITLE_ITEMS = [
+  "activity",
+  "project-name",
+] as const satisfies readonly WindowTitleField[];
+
+/** Braille-pattern dot-spinner frames for the terminal title animation. */
+export const TERMINAL_TITLE_SPINNER_FRAMES = [
+  "⠋",
+  "⠙",
+  "⠹",
+  "⠸",
+  "⠼",
+  "⠴",
+  "⠦",
+  "⠧",
+  "⠇",
+  "⠏",
+] as const;
+
+/** Time between spinner frame advances in the terminal title. */
+export const TERMINAL_TITLE_SPINNER_INTERVAL_MS = 100;
+
+/** Time between action-required blink phases in the terminal title. */
+export const TERMINAL_TITLE_ACTION_REQUIRED_INTERVAL_MS = 1000;
+
+/** Prefix shown in the terminal title when the agent is blocked on user input. */
+export const TERMINAL_TITLE_ACTION_REQUIRED_PREFIX = "[ ! ] Action Required";
+export const TERMINAL_TITLE_ACTION_REQUIRED_PREFIX_HIDDEN =
+  "[ . ] Action Required";
+export const ACTION_REQUIRED_PREVIEW_PREFIX = "[ ! ] Action Required";
 
 /** Human-readable labels and descriptions for each field. */
 export const WINDOW_TITLE_FIELD_INFO: Record<
   WindowTitleField,
   { label: string; description: string }
 > = {
+  "app-name": {
+    label: "App Name",
+    description: "Letta Code app name",
+  },
+  "project-name": {
+    label: "Project Name",
+    description: "Project name (falls back to current directory name)",
+  },
+  "current-dir": {
+    label: "Current Directory",
+    description: "Current working directory",
+  },
+  activity: {
+    label: "Activity",
+    description:
+      "Spinner while working, action-required message while blocked.",
+  },
+  "run-state": {
+    label: "Run State",
+    description: "Compact session run-state text (Ready, Working, Thinking)",
+  },
+  "thread-title": {
+    label: "Thread Title",
+    description: "Current thread title, or thread identifier when unnamed",
+  },
+  "git-branch": {
+    label: "Git Branch",
+    description: "Current Git branch (omitted when unavailable)",
+  },
+  "context-remaining": {
+    label: "Context Remaining",
+    description:
+      "Percentage of context window remaining (omitted when unknown)",
+  },
+  "context-used": {
+    label: "Context Used",
+    description: "Percentage of context window used (omitted when unknown)",
+  },
+  "five-hour-limit": {
+    label: "Five Hour Limit",
+    description:
+      "Remaining usage on the primary usage limit (omitted when unavailable)",
+  },
+  "weekly-limit": {
+    label: "Weekly Limit",
+    description:
+      "Remaining usage on the secondary usage limit (omitted when unavailable)",
+  },
+  version: {
+    label: "Version",
+    description: "Letta Code application version",
+  },
+  "used-tokens": {
+    label: "Used Tokens",
+    description: "Total tokens used in session (omitted when zero)",
+  },
+  "total-input-tokens": {
+    label: "Total Input Tokens",
+    description: "Total input tokens used in session",
+  },
+  "total-output-tokens": {
+    label: "Total Output Tokens",
+    description: "Total output tokens used in session",
+  },
+  "thread-id": {
+    label: "Thread ID",
+    description: "Current thread identifier (omitted until thread starts)",
+  },
+  "fast-mode": {
+    label: "Fast Mode",
+    description: "Whether Fast mode is currently active",
+  },
+  model: {
+    label: "Model",
+    description: "Current model name",
+  },
+  "model-with-reasoning": {
+    label: "Model + Reasoning",
+    description: "Current model name with reasoning level",
+  },
+  reasoning: {
+    label: "Reasoning",
+    description: "Current reasoning level",
+  },
+  "task-progress": {
+    label: "Task Progress",
+    description:
+      "Latest task progress from update_plan (omitted until available)",
+  },
   "agent-name": {
     label: "Agent Name",
     description: "Current agent's name",
   },
-  "app-name": {
-    label: "App Name",
-    description: 'Application name (e.g. "Letta Code")',
-  },
-  version: {
-    label: "Version",
-    description: "Letta Code version",
-  },
-  "conversation-name": {
-    label: "Conversation",
-    description: "Current conversation title (omitted when unavailable)",
-  },
 };
 
-/** Default items when no config is set. */
-export const DEFAULT_WINDOW_TITLE_ITEMS: WindowTitleField[] = [
-  "agent-name",
-  "app-name",
-];
+const WINDOW_TITLE_FIELD_ALIASES: Record<string, WindowTitleField> = {
+  project: "project-name",
+  spinner: "activity",
+  status: "run-state",
+  thread: "thread-title",
+  "context-usage": "context-used",
+  "codex-version": "version",
+  "session-id": "thread-id",
+  "model-name": "model",
+  "conversation-name": "thread-title",
+};
 
 /** Data available for rendering the window title. */
 export interface WindowTitleData {
@@ -49,41 +185,67 @@ export interface WindowTitleData {
   appName?: string | null;
   version: string;
   conversationSummary?: string | null;
+  conversationId?: string | null;
+  projectDirectory?: string | null;
+  currentDirectory?: string | null;
+  activityFrame?: string | null;
+  runState?: string | null;
+  modelDisplayName?: string | null;
+  reasoningEffort?: string | null;
+  contextUsedPercentage?: number | null;
+  contextRemainingPercentage?: number | null;
+  totalInputTokens?: number | null;
+  totalOutputTokens?: number | null;
+  gitBranch?: string | null;
+  fastMode?: boolean | null;
+  taskProgress?: string | null;
+}
+
+export function isWindowTitleField(value: string): value is WindowTitleField {
+  return (WINDOW_TITLE_FIELDS as readonly string[]).includes(value);
+}
+
+export function parseWindowTitleField(value: string): WindowTitleField | null {
+  const trimmed = value.trim();
+  if (isWindowTitleField(trimmed)) {
+    return trimmed;
+  }
+  return WINDOW_TITLE_FIELD_ALIASES[trimmed] ?? null;
+}
+
+export function normalizeWindowTitleItems(
+  items: readonly string[],
+): WindowTitleField[] {
+  return items.flatMap((item) => {
+    const parsed = parseWindowTitleField(item);
+    return parsed ? [parsed] : [];
+  });
 }
 
 /**
  * Resolve the effective window title items from all settings levels.
- * Returns the default items when no config is set.
+ * Returns the Codex default items when no config is set. An explicitly empty
+ * configured list is preserved and means "clear the managed title".
  */
 export function resolveWindowTitleConfig(
   workingDirectory: string = process.cwd(),
 ): WindowTitleField[] {
   try {
-    // Local project settings (highest priority)
-    try {
-      const local =
-        settingsManager.getLocalProjectSettings(workingDirectory)?.windowTitle;
-      if (local?.items?.length) return local.items as WindowTitleField[];
-    } catch {
-      // Not loaded
-    }
+    const local = resolveItemsFromConfig(
+      () =>
+        settingsManager.getLocalProjectSettings(workingDirectory)?.windowTitle,
+    );
+    if (local) return local;
 
-    // Project settings
-    try {
-      const project =
-        settingsManager.getProjectSettings(workingDirectory)?.windowTitle;
-      if (project?.items?.length) return project.items as WindowTitleField[];
-    } catch {
-      // Not loaded
-    }
+    const project = resolveItemsFromConfig(
+      () => settingsManager.getProjectSettings(workingDirectory)?.windowTitle,
+    );
+    if (project) return project;
 
-    // Global settings
-    try {
-      const global = settingsManager.getSettings().windowTitle;
-      if (global?.items?.length) return global.items as WindowTitleField[];
-    } catch {
-      // Not initialized
-    }
+    const global = resolveItemsFromConfig(
+      () => settingsManager.getSettings().windowTitle,
+    );
+    if (global) return global;
 
     return [...DEFAULT_WINDOW_TITLE_ITEMS];
   } catch (error) {
@@ -99,50 +261,247 @@ export function resolveWindowTitleConfig(
 /**
  * Render the terminal window title from the selected items and available data.
  *
- * Format: `{selected items joined by | }`
- * Unavailable values are omitted. Falls back to app name if nothing resolves.
+ * Values render in configured order. Unavailable values are omitted. The
+ * activity item uses Codex's separator rule: a plain space next to activity,
+ * and ` | ` between all other adjacent rendered items.
  */
 export function renderWindowTitle(
-  items: WindowTitleField[],
+  items: readonly WindowTitleField[],
+  data: WindowTitleData,
+): string | null {
+  let previous: WindowTitleField | null = null;
+  let title = "";
+
+  for (const item of items) {
+    const value = resolveFieldValue(item, data);
+    if (value === null) continue;
+
+    title += separatorFromPrevious(item, previous);
+    title += value;
+    previous = item;
+  }
+
+  return title.length > 0 ? title : null;
+}
+
+export function renderActionRequiredWindowTitle(
+  items: readonly WindowTitleField[],
+  data: WindowTitleData,
+  prefix: string,
+): string {
+  return buildActionRequiredTitleText(prefix, items, ["run-state"], data);
+}
+
+export function previewLineForWindowTitleItems(
+  items: readonly WindowTitleField[],
+  data: WindowTitleData,
+): string | null {
+  if (items.includes("activity")) {
+    return buildActionRequiredTitleText(
+      ACTION_REQUIRED_PREVIEW_PREFIX,
+      items,
+      [],
+      data,
+    );
+  }
+
+  return renderWindowTitle(items, data);
+}
+
+export function buildActionRequiredTitleText(
+  prefix: string,
+  items: readonly WindowTitleField[],
+  excludedItems: readonly WindowTitleField[],
   data: WindowTitleData,
 ): string {
-  // Sort items to canonical field order before rendering
-  const ordered = items.slice().sort((a, b) => {
-    const aIdx = WINDOW_TITLE_FIELDS.indexOf(a);
-    const bIdx = WINDOW_TITLE_FIELDS.indexOf(b);
-    return aIdx - bIdx;
-  });
+  const parts = [prefix];
 
-  const segments: string[] = [];
-
-  for (const key of ordered) {
-    const value = resolveFieldValue(key, data);
+  for (const item of items) {
+    if (item === "activity" || excludedItems.includes(item)) continue;
+    const value = resolveFieldValue(item, data);
     if (value !== null) {
-      segments.push(value);
+      parts.push(value);
     }
   }
 
-  if (segments.length === 0) {
-    return data.appName || "Letta Code";
+  return parts.join(" | ");
+}
+
+export function titleUsesActivity(items: readonly WindowTitleField[]): boolean {
+  return items.includes("activity");
+}
+
+export function separatorFromPrevious(
+  item: WindowTitleField,
+  previous: WindowTitleField | null,
+): string {
+  if (previous === null) return "";
+  if (previous === "activity" || item === "activity") return " ";
+  return " | ";
+}
+
+export function truncateTerminalTitlePart(
+  value: string,
+  maxChars: number,
+): string {
+  if (maxChars === 0) {
+    return "";
   }
 
-  return segments.join(" | ");
+  const parts = graphemeClusters(value);
+  const head = parts.slice(0, maxChars).join("");
+  if (parts.length <= maxChars || maxChars <= 3) {
+    return head;
+  }
+
+  return `${parts.slice(0, maxChars - 3).join("")}...`;
+}
+
+function resolveItemsFromConfig(
+  getConfig: () => { items?: string[] } | undefined,
+): WindowTitleField[] | null {
+  try {
+    const config = getConfig();
+    if (!config || !Array.isArray(config.items)) return null;
+    return normalizeWindowTitleItems(config.items);
+  } catch {
+    return null;
+  }
 }
 
 function resolveFieldValue(
-  key: WindowTitleField,
+  item: WindowTitleField,
   data: WindowTitleData,
 ): string | null {
-  switch (key) {
-    case "agent-name":
-      return data.agentName || null;
+  switch (item) {
     case "app-name":
       return data.appName || null;
-    case "version":
-      return data.version;
-    case "conversation-name":
-      return data.conversationSummary || null;
-    default:
+    case "project-name":
+      return terminalTitleProjectName(data);
+    case "current-dir":
+      return truncateOptional(formatDirectoryDisplay(titleDirectory(data)), 32);
+    case "activity":
+      return data.activityFrame || null;
+    case "run-state":
+      return data.runState || null;
+    case "thread-title": {
+      const threadTitle =
+        nonEmpty(data.conversationSummary) ?? data.conversationId;
+      return truncateOptional(threadTitle, 48);
+    }
+    case "git-branch":
+      return truncateOptional(data.gitBranch, 32);
+    case "context-remaining":
+      return typeof data.contextRemainingPercentage === "number"
+        ? `Context ${data.contextRemainingPercentage}% left`
+        : null;
+    case "context-used":
+      return typeof data.contextUsedPercentage === "number"
+        ? `Context ${data.contextUsedPercentage}% used`
+        : null;
+    case "five-hour-limit":
+    case "weekly-limit":
       return null;
+    case "version":
+      return truncateTerminalTitlePart(data.version, 32);
+    case "used-tokens": {
+      const total =
+        Math.max(0, Math.floor(data.totalInputTokens ?? 0)) +
+        Math.max(0, Math.floor(data.totalOutputTokens ?? 0));
+      return total > 0 ? `${formatCompact(total)} used` : null;
+    }
+    case "total-input-tokens":
+      return `${formatCompact(Math.max(0, Math.floor(data.totalInputTokens ?? 0)))} in`;
+    case "total-output-tokens":
+      return `${formatCompact(Math.max(0, Math.floor(data.totalOutputTokens ?? 0)))} out`;
+    case "thread-id":
+      return truncateOptional(data.conversationId, 32);
+    case "fast-mode":
+      return data.fastMode === null || data.fastMode === undefined
+        ? null
+        : data.fastMode
+          ? "Fast on"
+          : "Fast off";
+    case "model":
+      return truncateOptional(data.modelDisplayName, 32);
+    case "model-with-reasoning": {
+      const model = nonEmpty(data.modelDisplayName);
+      if (!model) return null;
+      return truncateTerminalTitlePart(
+        `${model} ${reasoningDisplayName(data.reasoningEffort)}`,
+        32,
+      );
+    }
+    case "reasoning":
+      return reasoningDisplayName(data.reasoningEffort);
+    case "task-progress":
+      return data.taskProgress || null;
+    case "agent-name":
+      return truncateOptional(data.agentName, 32);
   }
+}
+
+function terminalTitleProjectName(data: WindowTitleData): string | null {
+  const directory = titleDirectory(data);
+  if (!directory) return null;
+
+  const resolved = resolve(directory);
+  const name =
+    basename(resolved) || formatDirectoryDisplay(resolved) || resolved;
+  return truncateTerminalTitlePart(name, 24);
+}
+
+function titleDirectory(data: WindowTitleData): string | null {
+  return data.projectDirectory || data.currentDirectory || null;
+}
+
+function formatDirectoryDisplay(directory: string | null): string | null {
+  if (!directory) return null;
+
+  const resolved = resolve(directory);
+  const home = homedir();
+  if (resolved === home) return "~";
+  if (resolved.startsWith(`${home}/`)) {
+    return `~/${resolved.slice(home.length + 1)}`;
+  }
+  return resolved;
+}
+
+function reasoningDisplayName(
+  reasoningEffort: string | null | undefined,
+): string {
+  return reasoningEffort && reasoningEffort !== "none"
+    ? reasoningEffort
+    : "default";
+}
+
+function truncateOptional(
+  value: string | null | undefined,
+  maxChars: number,
+): string | null {
+  const trimmed = nonEmpty(value);
+  return trimmed ? truncateTerminalTitlePart(trimmed, maxChars) : null;
+}
+
+function nonEmpty(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+type SegmenterLike = new (
+  locale: string | undefined,
+  options: { granularity: "grapheme" },
+) => { segment(value: string): Iterable<{ segment: string }> };
+
+function graphemeClusters(value: string): string[] {
+  const Segmenter = (Intl as unknown as { Segmenter?: SegmenterLike })
+    .Segmenter;
+  if (!Segmenter) {
+    return Array.from(value);
+  }
+
+  return Array.from(
+    new Segmenter(undefined, { granularity: "grapheme" }).segment(value),
+    (part) => part.segment,
+  );
 }

--- a/src/cli/helpers/window-title-config.ts
+++ b/src/cli/helpers/window-title-config.ts
@@ -38,7 +38,7 @@ export type WindowTitleField = (typeof WINDOW_TITLE_FIELDS)[number];
 /** Items shown in the terminal title when the user has not configured a custom selection. */
 export const DEFAULT_WINDOW_TITLE_ITEMS = [
   "activity",
-  "project-name",
+  "agent-name",
 ] as const satisfies readonly WindowTitleField[];
 
 /** Braille-pattern dot-spinner frames for the terminal title animation. */


### PR DESCRIPTION
## Summary

- Adds Codex-style terminal title activity with a Letta-specific default of `activity` + `agent-name` so terminal tabs reflect the long-lived agent you are talking to.
- Keeps `project-name` and the other Codex-style title items selectable/reorderable through `/title`, including aliases and ordered rendering.
- Adds a managed OSC title writer with sanitization, duplicate suppression, BEL termination, and clear-on-unmount behavior.
- Drives title activity from TUI runtime state, including the 100ms braille spinner while working and 1s Action Required blink while approval is pending.
- Validated with focused title tests and `bun run check`.

👾 Generated with [Letta Code](https://letta.com)