### PR TITLE
fix(local): preserve tool-call transcript snapshots

### DIFF
--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -20,6 +20,7 @@ import {
   type LocalAssistantMessage,
   type LocalMessage,
 } from "@/backend/local/local-message";
+import { removeOrphanLocalToolResults } from "@/backend/local/local-message-projection";
 import type { ClientTool } from "@/tools/manager";
 import { isRecord } from "@/utils/type-guards";
 import { isContextWindowOverflowError } from "./context-window-overflow";
@@ -251,7 +252,8 @@ function toPiMessage(message: LocalMessage): Message | undefined {
 }
 
 function toPiMessages(messages: LocalMessage[]): Message[] {
-  let normalized = messages.flatMap((message) => {
+  const providerSafeMessages = removeOrphanLocalToolResults(messages).messages;
+  let normalized = providerSafeMessages.flatMap((message) => {
     const piMessage = toPiMessage(message);
     return piMessage ? [piMessage] : [];
   });

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -1396,7 +1396,7 @@ describe("local backend pi transcript", () => {
     }
     const timestamp = new Date().toISOString();
     const orphanMessage = {
-      id: "ui-msg-orphan-tool-result",
+      id: "ui-msg-9999",
       role: "toolResult",
       toolCallId: "call-missing",
       toolName: "Read",
@@ -1459,6 +1459,22 @@ describe("local backend pi transcript", () => {
       orphanMessage.id,
     );
     expect(await readFile(messagesPath, "utf8")).toContain(orphanMessage.id);
+
+    await drain(
+      await reloadedBackend.createConversationMessageStream(conversation.id, {
+        agent_id: agent.id,
+        messages: [{ role: "user", content: "next" }],
+      } as ConversationMessageCreateBody),
+    );
+    const messagesAfterNextTurn = pageItems(
+      await reloadedBackend.listConversationMessages(conversation.id, {
+        agent_id: agent.id,
+        order: "asc",
+      } as never),
+    );
+    expect(messagesAfterNextTurn.map((message) => message.id)).toContain(
+      "ui-msg-10000",
+    );
   });
 
   test("defers unversioned transcript migration errors until transcript read", async () => {

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
 import {
+  appendFile,
   mkdir,
   mkdtemp,
   readdir,
@@ -1220,6 +1221,213 @@ describe("local backend pi transcript", () => {
       "tool_return_message",
       "assistant_message",
     ]);
+  });
+
+  test("persists updated assistant snapshots when tool calls are appended later", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-pi-tool-update-"),
+    );
+    let calls = 0;
+    const executor: HeadlessTurnExecutor = {
+      async execute() {
+        calls += 1;
+        if (calls === 1) {
+          return lettaStreamFromChunks([
+            {
+              message_type: "assistant_message",
+              content: [{ type: "text", text: "I will inspect that." }],
+            } as LettaStreamingResponse,
+            {
+              message_type: "stop_reason",
+              stop_reason: "end_turn",
+            } as LettaStreamingResponse,
+          ]);
+        }
+
+        return lettaStreamFromChunks([
+          {
+            message_type: "approval_request_message",
+            tool_call: {
+              tool_call_id: "call-readme",
+              name: "Read",
+              arguments: JSON.stringify({ path: "README.md" }),
+            },
+          } as LettaStreamingResponse,
+          {
+            message_type: "stop_reason",
+            stop_reason: "requires_approval",
+          } as LettaStreamingResponse,
+        ]);
+      },
+    };
+    const backend = new LocalBackend({
+      storageDir,
+      executor,
+      memfsEnabled: false,
+    });
+    const agent = await backend.createAgent({ name: "Local" } as never);
+    const conversation = await backend.createConversation({
+      agent_id: agent.id,
+    } as never);
+
+    await drain(
+      await backend.createConversationMessageStream(conversation.id, {
+        agent_id: agent.id,
+        messages: [{ role: "user", content: "inspect the readme" }],
+      } as ConversationMessageCreateBody),
+    );
+    await drain(
+      await backend.createConversationMessageStream(conversation.id, {
+        agent_id: agent.id,
+        messages: [],
+      } as never),
+    );
+
+    const conversationDir = await firstConversationDir(storageDir);
+    const entries = (
+      await readFile(join(conversationDir, "messages.jsonl"), "utf8")
+    )
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const assistantMessages = entries
+      .filter((entry) => entry.type === "message")
+      .map((entry) => entry.message as Record<string, unknown>)
+      .filter((message) => message.role === "assistant");
+    expect(assistantMessages).toHaveLength(2);
+    expect(new Set(assistantMessages.map((message) => message.id)).size).toBe(
+      1,
+    );
+    expect(JSON.stringify(assistantMessages.at(-1))).toContain("call-readme");
+
+    const reloadedBackend = new LocalBackend({
+      storageDir,
+      executor,
+      memfsEnabled: false,
+    });
+    const reloadedMessages = pageItems(
+      await reloadedBackend.listConversationMessages(conversation.id, {
+        agent_id: agent.id,
+        order: "asc",
+      } as never),
+    );
+    expect(reloadedMessages.map((message) => message.message_type)).toEqual([
+      "user_message",
+      "assistant_message",
+      "approval_request_message",
+    ]);
+  });
+
+  test("repairs orphan tool results from active local transcript context", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-pi-orphan-tool-result-"),
+    );
+    const executor: HeadlessTurnExecutor = {
+      async execute() {
+        return lettaStreamFromChunks([
+          {
+            message_type: "assistant_message",
+            content: [{ type: "text", text: "done" }],
+          } as LettaStreamingResponse,
+          {
+            message_type: "stop_reason",
+            stop_reason: "end_turn",
+          } as LettaStreamingResponse,
+        ]);
+      },
+    };
+    const backend = new LocalBackend({
+      storageDir,
+      executor,
+      memfsEnabled: false,
+    });
+    const agent = await backend.createAgent({ name: "Local" } as never);
+    const conversation = await backend.createConversation({
+      agent_id: agent.id,
+    } as never);
+    await drain(
+      await backend.createConversationMessageStream(conversation.id, {
+        agent_id: agent.id,
+        messages: [{ role: "user", content: "hello" }],
+      } as ConversationMessageCreateBody),
+    );
+
+    const conversationDir = await firstConversationDir(storageDir);
+    const messagesPath = join(conversationDir, "messages.jsonl");
+    const conversationPath = join(conversationDir, "conversation.json");
+    const rows = (await readFile(messagesPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const parentId = rows.at(-1)?.id;
+    if (typeof parentId !== "string") {
+      throw new Error("Expected a parent entry id");
+    }
+    const timestamp = new Date().toISOString();
+    const orphanMessage = {
+      id: "ui-msg-orphan-tool-result",
+      role: "toolResult",
+      toolCallId: "call-missing",
+      toolName: "Read",
+      content: [{ type: "text", text: "orphan output" }],
+      isError: false,
+      timestamp: Date.now(),
+      metadata: {
+        created_at: timestamp,
+        updated_at: timestamp,
+        agent_id: agent.id,
+        conversation_id: conversation.id,
+      },
+    };
+    await appendFile(
+      messagesPath,
+      `${JSON.stringify({
+        type: "message",
+        id: "orphan-entry",
+        parentId,
+        timestamp,
+        message: orphanMessage,
+      })}\n`,
+    );
+    const persistedConversation = JSON.parse(
+      await readFile(conversationPath, "utf8"),
+    ) as { in_context_message_ids?: string[] };
+    await writeFile(
+      conversationPath,
+      `${JSON.stringify(
+        {
+          ...persistedConversation,
+          in_context_message_ids: [
+            ...(persistedConversation.in_context_message_ids ?? []),
+            orphanMessage.id,
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const reloadedBackend = new LocalBackend({
+      storageDir,
+      executor,
+      memfsEnabled: false,
+    });
+    const reloadedMessages = pageItems(
+      await reloadedBackend.listConversationMessages(conversation.id, {
+        agent_id: agent.id,
+        order: "asc",
+      } as never),
+    );
+    expect(
+      reloadedMessages.map((message) => message.message_type),
+    ).not.toContain("tool_return_message");
+    const repairedConversation = JSON.parse(
+      await readFile(conversationPath, "utf8"),
+    ) as { in_context_message_ids?: string[] };
+    expect(repairedConversation.in_context_message_ids).not.toContain(
+      orphanMessage.id,
+    );
+    expect(await readFile(messagesPath, "utf8")).toContain(orphanMessage.id);
   });
 
   test("defers unversioned transcript migration errors until transcript read", async () => {

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -1316,6 +1316,37 @@ describe("local backend pi transcript", () => {
       "assistant_message",
       "approval_request_message",
     ]);
+
+    const conversationPath = join(conversationDir, "conversation.json");
+    const persistedConversation = JSON.parse(
+      await readFile(conversationPath, "utf8"),
+    ) as Record<string, unknown>;
+    await writeFile(
+      conversationPath,
+      `${JSON.stringify(
+        { ...persistedConversation, in_context_message_ids: [] },
+        null,
+        2,
+      )}\n`,
+    );
+    const reloadedWithoutActiveIds = new LocalBackend({
+      storageDir,
+      executor,
+      memfsEnabled: false,
+    });
+    const messagesWithoutActiveIds = pageItems(
+      await reloadedWithoutActiveIds.listConversationMessages(conversation.id, {
+        agent_id: agent.id,
+        order: "asc",
+      } as never),
+    );
+    expect(
+      messagesWithoutActiveIds.map((message) => message.message_type),
+    ).toEqual([
+      "user_message",
+      "assistant_message",
+      "approval_request_message",
+    ]);
   });
 
   test("repairs orphan tool results from active local transcript context", async () => {

--- a/src/backend/local/local-message-projection.ts
+++ b/src/backend/local/local-message-projection.ts
@@ -332,6 +332,68 @@ export function cloneLocalMessage(message: LocalMessage): LocalMessage {
   }
 }
 
+function toolCallIdLookupKeys(id: string): string[] {
+  const [baseId] = id.split("|");
+  return baseId && baseId !== id ? [id, baseId] : [id];
+}
+
+function addToolCallIdLookupKeys(ids: Set<string>, id: string): void {
+  for (const key of toolCallIdLookupKeys(id)) ids.add(key);
+}
+
+function hasToolCallIdLookupKey(ids: Set<string>, id: string): boolean {
+  return toolCallIdLookupKeys(id).some((key) => ids.has(key));
+}
+
+function assistantMessageCanContributeToolCalls(
+  message: LocalAssistantMessage,
+): boolean {
+  return message.stopReason !== "error" && message.stopReason !== "aborted";
+}
+
+export interface LocalToolResultRepairResult {
+  messages: LocalMessage[];
+  removedMessageIds: string[];
+}
+
+export function removeOrphanLocalToolResults(
+  messages: readonly LocalMessage[],
+): LocalToolResultRepairResult {
+  const seenToolCallIds = new Set<string>();
+  const repaired: LocalMessage[] = [];
+  const removedMessageIds: string[] = [];
+
+  for (const message of messages) {
+    if (message.role === "assistant") {
+      if (assistantMessageCanContributeToolCalls(message)) {
+        for (const content of message.content) {
+          if (isLocalToolCallContent(content)) {
+            addToolCallIdLookupKeys(seenToolCallIds, content.id);
+          }
+        }
+      }
+      repaired.push(message);
+      continue;
+    }
+
+    if (message.role === "toolResult") {
+      if (hasToolCallIdLookupKey(seenToolCallIds, message.toolCallId)) {
+        repaired.push(message);
+      } else {
+        removedMessageIds.push(message.id);
+      }
+      continue;
+    }
+
+    repaired.push(message);
+  }
+
+  return {
+    messages: removedMessageIds.length > 0 ? repaired : [...messages],
+    removedMessageIds,
+  };
+}
+
 export function mergeSnapshotContentWithExistingToolCalls(
   snapshotContent: LocalAssistantMessage["content"],
   existingContent: LocalAssistantMessage["content"],

--- a/src/backend/local/local-message-projection.ts
+++ b/src/backend/local/local-message-projection.ts
@@ -359,16 +359,20 @@ export interface LocalToolResultRepairResult {
 export function removeOrphanLocalToolResults(
   messages: readonly LocalMessage[],
 ): LocalToolResultRepairResult {
-  const seenToolCallIds = new Set<string>();
+  // Mirror pi-ai transformMessages() tool-flow boundaries: tool results only
+  // belong to the immediately pending assistant tool calls. A user or another
+  // assistant message closes that pending tool-result window.
+  let pendingToolCallIds = new Set<string>();
   const repaired: LocalMessage[] = [];
   const removedMessageIds: string[] = [];
 
   for (const message of messages) {
     if (message.role === "assistant") {
+      pendingToolCallIds = new Set<string>();
       if (assistantMessageCanContributeToolCalls(message)) {
         for (const content of message.content) {
           if (isLocalToolCallContent(content)) {
-            addToolCallIdLookupKeys(seenToolCallIds, content.id);
+            addToolCallIdLookupKeys(pendingToolCallIds, content.id);
           }
         }
       }
@@ -376,8 +380,14 @@ export function removeOrphanLocalToolResults(
       continue;
     }
 
+    if (message.role === "user") {
+      pendingToolCallIds = new Set<string>();
+      repaired.push(message);
+      continue;
+    }
+
     if (message.role === "toolResult") {
-      if (hasToolCallIdLookupKey(seenToolCallIds, message.toolCallId)) {
+      if (hasToolCallIdLookupKey(pendingToolCallIds, message.toolCallId)) {
         repaired.push(message);
       } else {
         removedMessageIds.push(message.id);

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -47,6 +47,7 @@ import {
   mergeSnapshotContentWithExistingToolCalls,
   projectedMessageLookupKeys,
   projectLocalMessageToStoredMessages,
+  removeOrphanLocalToolResults,
   withProjectedMessageDates,
 } from "./local-message-projection";
 import {
@@ -709,8 +710,27 @@ interface LocalTranscriptRowsResult {
   messages: LocalMessage[];
   entryIds: Set<string>;
   entryIdByMessageId: Map<string, string>;
+  messageById: Map<string, LocalMessage>;
   lastEntryId: string | null;
   sourceStartIndex: number;
+}
+
+function setLatestLocalMessage(
+  messagesById: Map<string, LocalMessage>,
+  message: LocalMessage,
+): void {
+  // Map#set does not move an existing key to the insertion tail. Delete first so
+  // append-only replacement snapshots preserve latest-message order when a
+  // conversation has no explicit in-context id list.
+  if (messagesById.has(message.id)) messagesById.delete(message.id);
+  messagesById.set(message.id, message);
+}
+
+function localMessagesHaveSameSnapshot(
+  a: LocalMessage,
+  b: LocalMessage,
+): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
 }
 
 function isLocalTranscriptSessionMessageEntry(
@@ -794,14 +814,15 @@ function localTranscriptRowsResult(
 ): LocalTranscriptRowsResult {
   if (messageFormat === LOCAL_TRANSCRIPT_LEGACY_MESSAGE_FORMAT) {
     const allMessages = rows as LocalMessage[];
-    const messageById = new Map(
-      allMessages.map((message) => [message.id, message] as const),
-    );
+    const messageById = new Map<string, LocalMessage>();
+    for (const message of allMessages) {
+      setLatestLocalMessage(messageById, message);
+    }
     const activeMessages = activeMessageIds.length
       ? activeMessageIds
           .map((id) => messageById.get(id))
           .filter((message): message is LocalMessage => message !== undefined)
-      : allMessages;
+      : Array.from(messageById.values());
     const firstActiveId = activeMessages[0]?.id;
     return {
       messages: activeMessages,
@@ -809,6 +830,7 @@ function localTranscriptRowsResult(
       entryIdByMessageId: new Map(
         allMessages.map((message) => [message.id, message.id] as const),
       ),
+      messageById,
       lastEntryId: allMessages.at(-1)?.id ?? null,
       sourceStartIndex: firstActiveId
         ? Math.max(0, activeMessageIds.indexOf(firstActiveId))
@@ -828,7 +850,7 @@ function localTranscriptRowsResult(
     lastEntryId = row.id;
     entryIdByMessageId.set(row.message.id, row.id);
     allMessages.push(row.message);
-    messageById.set(row.message.id, row.message);
+    setLatestLocalMessage(messageById, row.message);
   }
 
   const activeMessages = activeMessageIds.length
@@ -842,6 +864,7 @@ function localTranscriptRowsResult(
     messages: activeMessages,
     entryIds,
     entryIdByMessageId,
+    messageById,
     lastEntryId,
     sourceStartIndex: firstActiveId
       ? Math.max(0, activeMessageIds.indexOf(firstActiveId))
@@ -1091,6 +1114,10 @@ export class LocalStore {
     string,
     Map<string, string>
   >();
+  private readonly persistedMessageByMessageIdByConversationKey = new Map<
+    string,
+    Map<string, LocalMessage>
+  >();
   private readonly lastSessionEntryIdByConversationKey = new Map<
     string,
     string | null
@@ -1198,6 +1225,7 @@ export class LocalStore {
         this.transcriptMetadataByConversationKey.delete(key);
         this.sessionEntryIdsByConversationKey.delete(key);
         this.sessionEntryIdByMessageIdByConversationKey.delete(key);
+        this.persistedMessageByMessageIdByConversationKey.delete(key);
         this.lastSessionEntryIdByConversationKey.delete(key);
         if (this.storageDir) {
           rmSync(
@@ -2416,9 +2444,9 @@ export class LocalStore {
         this.storageDir ?? "",
         metadata.conversationDir,
       );
-      const normalizedMessages = transcript.messages.map(
-        normalizeLocalMessageForPi,
-      );
+      const normalizedMessages = removeOrphanLocalToolResults(
+        transcript.messages.map(normalizeLocalMessageForPi),
+      ).messages;
       const projected = this.projectLocalMessages(
         normalizedMessages,
         agentId,
@@ -2542,9 +2570,9 @@ export class LocalStore {
         this.storageDir ?? "",
         metadata.conversationDir,
       );
-      const normalizedMessages = transcript.messages.map(
-        normalizeLocalMessageForPi,
-      );
+      const normalizedMessages = removeOrphanLocalToolResults(
+        transcript.messages.map(normalizeLocalMessageForPi),
+      ).messages;
       this.projectLocalMessages(
         normalizedMessages,
         conversation.agent_id,
@@ -2599,23 +2627,40 @@ export class LocalStore {
       this.storageDir ?? "",
       metadata.conversationDir,
     );
-    const localMessages = repairSyntheticLocalMessageTimestamps(
+    const loadedMessages = repairSyntheticLocalMessageTimestamps(
       transcript.messages.map(normalizeLocalMessageForPi),
       metadata.timing,
     );
+    const toolResultRepair = removeOrphanLocalToolResults(loadedMessages);
+    const localMessages = toolResultRepair.messages;
     if (conversation) {
-      this.conversations.set(
-        key,
-        repairSyntheticConversationTimestamps(
-          conversation,
-          localMessages,
-          metadata.timing,
-        ),
+      let repairedConversation = repairSyntheticConversationTimestamps(
+        conversation,
+        localMessages,
+        metadata.timing,
       );
+      if (toolResultRepair.removedMessageIds.length > 0) {
+        const removedMessageIds = new Set(toolResultRepair.removedMessageIds);
+        repairedConversation = {
+          ...repairedConversation,
+          in_context_message_ids:
+            repairedConversation.in_context_message_ids.length > 0
+              ? repairedConversation.in_context_message_ids.filter(
+                  (id) => !removedMessageIds.has(id),
+                )
+              : localMessages.map((message) => message.id),
+        };
+      }
+      this.conversations.set(key, repairedConversation);
     }
     this.localMessagesByConversationKey.set(key, localMessages);
     this.loadedConversationKeys.add(key);
     this.resetPersistedSessionState(key, metadata.messageFormat, transcript);
+    if (conversation && toolResultRepair.removedMessageIds.length > 0) {
+      this.persistConversationState(conversation.id, agentId, {
+        transcript: "skip",
+      });
+    }
     for (const message of localMessages) {
       this.localMessageSeq = Math.max(
         this.localMessageSeq,
@@ -3076,7 +3121,17 @@ export class LocalStore {
     message: LocalMessage,
   ): void {
     const entryIdByMessageId = this.sessionEntryIdsByMessageId(key);
-    if (entryIdByMessageId.has(message.id)) return;
+    if (entryIdByMessageId.has(message.id)) {
+      const persistedMessage = this.persistedMessagesByMessageId(key).get(
+        message.id,
+      );
+      if (
+        persistedMessage &&
+        localMessagesHaveSameSnapshot(persistedMessage, message)
+      ) {
+        return;
+      }
+    }
 
     this.ensureConversationTranscriptHeader(conversation, messagesPath);
     const parentId = this.lastSessionEntryIdByConversationKey.get(key) ?? null;
@@ -3128,6 +3183,10 @@ export class LocalStore {
     appendFileSync(messagesPath, `${JSON.stringify(entry)}\n`);
     this.sessionEntryIds(key).add(entry.id);
     this.sessionEntryIdsByMessageId(key).set(entry.message.id, entry.id);
+    this.persistedMessagesByMessageId(key).set(
+      entry.message.id,
+      cloneLocalMessage(entry.message),
+    );
     this.lastSessionEntryIdByConversationKey.set(key, entry.id);
   }
 
@@ -3152,6 +3211,15 @@ export class LocalStore {
     this.sessionEntryIdByMessageIdByConversationKey.set(
       key,
       transcript.entryIdByMessageId,
+    );
+    this.persistedMessageByMessageIdByConversationKey.set(
+      key,
+      new Map(
+        Array.from(transcript.messageById, ([messageId, message]) => [
+          messageId,
+          cloneLocalMessage(message),
+        ]),
+      ),
     );
     this.lastSessionEntryIdByConversationKey.set(key, transcript.lastEntryId);
   }
@@ -3183,6 +3251,15 @@ export class LocalStore {
       this.sessionEntryIdByMessageIdByConversationKey.set(key, entryIds);
     }
     return entryIds;
+  }
+
+  private persistedMessagesByMessageId(key: string): Map<string, LocalMessage> {
+    let messages = this.persistedMessageByMessageIdByConversationKey.get(key);
+    if (!messages) {
+      messages = new Map<string, LocalMessage>();
+      this.persistedMessageByMessageIdByConversationKey.set(key, messages);
+    }
+    return messages;
   }
 
   private nextSessionEntryId(key: string): string {

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -857,7 +857,7 @@ function localTranscriptRowsResult(
     ? activeMessageIds
         .map((id) => messageById.get(id))
         .filter((message): message is LocalMessage => message !== undefined)
-    : allMessages;
+    : Array.from(messageById.values());
   const firstActiveId = activeMessages[0]?.id;
 
   return {

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -2661,7 +2661,7 @@ export class LocalStore {
         transcript: "skip",
       });
     }
-    for (const message of localMessages) {
+    for (const message of loadedMessages) {
       this.localMessageSeq = Math.max(
         this.localMessageSeq,
         numericSuffix(message.id, this.localMessageIdPrefix),

--- a/src/backend/pi-stream-adapter.test.ts
+++ b/src/backend/pi-stream-adapter.test.ts
@@ -418,6 +418,83 @@ describe("PiStreamAdapter", () => {
     expect(messages).toHaveLength(1);
   });
 
+  test("drops orphan tool results from provider context", async () => {
+    let capturedContext: Context | undefined;
+    const stream: PiStreamFunction = (
+      _model: Model<string>,
+      context: Context,
+    ) => {
+      capturedContext = context;
+      const finalMessage = assistantMessage();
+      return streamFromEvents(
+        [{ type: "done", reason: "stop", message: finalMessage }],
+        finalMessage,
+      );
+    };
+
+    const adapter = new PiStreamAdapter({ stream });
+    const turnInput: ProviderTurnInput = {
+      ...input(),
+      uiMessages: [
+        {
+          id: "ui-msg-1",
+          role: "user",
+          content: "hello",
+          timestamp: Date.now(),
+        },
+        {
+          id: "ui-msg-2",
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call-valid",
+              name: "Read",
+              arguments: { path: "README.md" },
+            },
+          ],
+          api: "openai-responses" as never,
+          provider: "openai" as never,
+          model: "gpt-5.5",
+          usage: emptyLocalUsage(),
+          stopReason: "toolUse",
+          timestamp: Date.now(),
+        },
+        {
+          id: "ui-msg-3",
+          role: "toolResult",
+          toolCallId: "call-valid",
+          toolName: "Read",
+          content: [{ type: "text", text: "README contents" }],
+          isError: false,
+          timestamp: Date.now(),
+        },
+        {
+          id: "ui-msg-4",
+          role: "toolResult",
+          toolCallId: "call-missing",
+          toolName: "Read",
+          content: [{ type: "text", text: "orphan contents" }],
+          isError: false,
+          timestamp: Date.now(),
+        },
+      ],
+    };
+
+    for await (const _event of adapter.stream(turnInput)) {
+      // drain
+    }
+
+    expect(capturedContext).toBeDefined();
+    // biome-ignore lint/style/noNonNullAssertion: capturedContext is asserted defined on the line above
+    const messages = capturedContext!.messages;
+    expect(JSON.stringify(messages)).toContain("README contents");
+    expect(JSON.stringify(messages)).not.toContain("orphan contents");
+    expect(
+      messages.filter((message) => message.role === "toolResult"),
+    ).toHaveLength(1);
+  });
+
   test("retries retryable Codex transport errors before model output", async () => {
     let calls = 0;
     const stream: PiStreamFunction = () => {


### PR DESCRIPTION
## Summary
- append changed local assistant snapshots instead of deduping solely by message id, preserving later tool calls across restart
- repair orphan active tool-result messages on local transcript load while preserving raw JSONL rows for audit/debugging
- filter orphan tool results before pi-ai provider replay so corrupted local sessions do not brick OpenAI Responses/Codex requests

## Tests
- bun test src/backend/pi-stream-adapter.test.ts src/backend/local-backend.test.ts
- bun run typecheck
- bun run check
