### PR TITLE
feat(cli): add vim-style j/k navigation to list selectors

### DIFF
--- a/src/cli/components/ConversationSelector.tsx
+++ b/src/cli/components/ConversationSelector.tsx
@@ -529,9 +529,9 @@ export function ConversationSelector({
 
     if (loading) return;
 
-    if (key.upArrow) {
+    if (key.upArrow || input === "k") {
       setSelectedIndex((prev) => Math.max(0, prev - 1));
-    } else if (key.downArrow) {
+    } else if (key.downArrow || input === "j") {
       setSelectedIndex((prev) =>
         Math.min(pageConversations.length - 1, prev + 1),
       );

--- a/src/cli/components/MultiSelectPicker.tsx
+++ b/src/cli/components/MultiSelectPicker.tsx
@@ -103,11 +103,13 @@ export const MultiSelectPicker = memo(function MultiSelectPicker({
 
   const handleInput = useCallback(
     (input: string, key: Key) => {
-      if (key.upArrow) {
+      // Up: arrow or vim-style "k"
+      if (key.upArrow || input === "k") {
         setCursor((c) => Math.max(0, c - 1));
         return;
       }
-      if (key.downArrow) {
+      // Down: arrow or vim-style "j"
+      if (key.downArrow || input === "j") {
         setCursor((c) => Math.min(orderedItems.length - 1, c + 1));
         return;
       }

--- a/src/cli/components/SingleSelectPicker.tsx
+++ b/src/cli/components/SingleSelectPicker.tsx
@@ -75,11 +75,13 @@ export const SingleSelectPicker = memo(function SingleSelectPicker({
         onCancel();
         return;
       }
-      if (key.upArrow) {
+      // Up: arrow or vim-style "k"
+      if (key.upArrow || input === "k") {
         setCursor((c) => Math.max(0, c - 1));
         return;
       }
-      if (key.downArrow) {
+      // Down: arrow or vim-style "j"
+      if (key.downArrow || input === "j") {
         setCursor((c) => Math.min(items.length - 1, c + 1));
         return;
       }
@@ -151,7 +153,7 @@ export const SingleSelectPicker = memo(function SingleSelectPicker({
       {/* Footer */}
       <Box marginTop={footer ? 0 : 1}>
         {footer ?? (
-          <Text dimColor> Enter select · ↑↓ navigate · Esc cancel</Text>
+          <Text dimColor> Enter select · ↑↓/jk navigate · Esc cancel</Text>
         )}
       </Box>
     </Box>

--- a/src/cli/components/vim-navigation.test.ts
+++ b/src/cli/components/vim-navigation.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+function readComponent(name: string): string {
+  const path = fileURLToPath(new URL(`./${name}`, import.meta.url));
+  return readFileSync(path, "utf-8");
+}
+
+describe("vim-style j/k navigation in list selectors", () => {
+  // Pure-list pickers (no inline text field), so binding bare j/k as
+  // down/up aliases cannot clash with typing. Filter-based selectors
+  // (AgentSelector, ProviderSelector, ...) deliberately avoid bare
+  // letter shortcuts and are intentionally excluded here.
+  const pickers = [
+    "SingleSelectPicker.tsx",
+    "MultiSelectPicker.tsx",
+    "ConversationSelector.tsx",
+  ];
+
+  for (const picker of pickers) {
+    test(`${picker} maps "k" to up and "j" to down`, () => {
+      const source = readComponent(picker);
+      expect(source).toContain('key.upArrow || input === "k"');
+      expect(source).toContain('key.downArrow || input === "j"');
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Closes #2063.

Adds vim-style `j`/`k` as aliases for the down/up arrow keys in CLI list selectors, so users with vim muscle memory (or `set -o vi` shells) can navigate without reaching for the arrow keys.

This follows the convention already present in the codebase — `PinDialog` already binds `j`/`k` to down/up (`input === "j" || key.downArrow`). This change extends the same pattern to the shared pickers and the `/resume` conversation selector.

## Changes

- **`SingleSelectPicker`** — the shared single-select base picker (used by `PersonalitySelector`, `CompactionSelector`, `WorktreeDiffSelector`, `SystemPromptSelector`). Also updated its default footer hint to `↑↓/jk navigate`.
- **`MultiSelectPicker`** — the shared multi-select base picker.
- **`ConversationSelector`** — the `/resume` conversation picker (explicitly called out in the issue).

In all three, `k` moves the cursor up and `j` moves it down, matching vim semantics.

## Scope / why these components

The bindings are added only to **pure-list selectors that have no inline text field**, so a bare `j`/`k` keypress can never clash with typing.

Deliberately **not** changed:
- **Filter-based selectors** (`AgentSelector`, `ProviderSelector`, `ModelSelector`, `SleeptimeSelector`, etc.) accept free-text search input. Binding bare letters there would swallow legitimate typing — `agent-selector-shortcuts.test.ts` documents this exact constraint (delete is `Shift+D` precisely so lowercase `d` stays typeable).
- **Autocomplete dropdowns** (`useAutocompleteNavigation`) are active *while the user is typing* in the prompt, so `j`/`k` must remain literal characters there.

This keeps the change small, safe, and free of typing regressions. The remaining typing-free selectors can be migrated in follow-ups using the same pattern.

## Tests

Added `src/cli/components/vim-navigation.test.ts`, which asserts the `j`/`k` → down/up bindings are wired in the three pure-list pickers (source-assertion style, matching the existing `agent-selector-shortcuts.test.ts`).

```
bun test src/cli/components/vim-navigation.test.ts   # 3 pass
```

Also verified locally: `bun run typecheck`, biome lint, layer-boundary / exported-function / filename-casing checks, and the existing `conversation-selector` + `agent-selector-shortcuts` suites all pass.