### PR TITLE
chore(tools): align Codex schema descriptions

### DIFF
--- a/src/tools/schemas/ExecCommand.json
+++ b/src/tools/schemas/ExecCommand.json
@@ -8,11 +8,11 @@
     },
     "login": {
       "type": "boolean",
-      "description": "Whether to run the shell with -l/-i semantics. Defaults to true."
+      "description": "True runs the shell with -l/-i semantics; false disables them. Defaults to true."
     },
     "max_output_tokens": {
       "type": "number",
-      "description": "Maximum number of tokens to return. Excess output will be truncated."
+      "description": "Output token budget. Defaults to 10000 tokens; larger requests may be capped by policy."
     },
     "shell": {
       "type": "string",
@@ -20,15 +20,15 @@
     },
     "tty": {
       "type": "boolean",
-      "description": "Whether to allocate a TTY for the command. Defaults to false (plain pipes); set to true to open a PTY and access TTY process."
+      "description": "True allocates a PTY for the command; false or omitted uses plain pipes."
     },
     "workdir": {
       "type": "string",
-      "description": "Optional working directory to run the command in; defaults to the turn cwd."
+      "description": "Working directory for the command. Defaults to the turn cwd."
     },
     "yield_time_ms": {
       "type": "number",
-      "description": "How long to wait (in milliseconds) for output before yielding."
+      "description": "Wait before yielding output. Defaults to 10000 ms; effective range is 250-30000 ms."
     }
   },
   "required": ["cmd"],

--- a/src/tools/schemas/Shell.json
+++ b/src/tools/schemas/Shell.json
@@ -11,26 +11,27 @@
     },
     "workdir": {
       "type": "string",
-      "description": "The working directory to execute the command in"
+      "description": "Working directory for the command. Defaults to the turn cwd."
     },
     "timeout_ms": {
       "type": "number",
-      "description": "The timeout for the command in milliseconds"
+      "description": "Maximum command runtime. Defaults to 10000 ms."
     },
     "sandbox_permissions": {
       "type": "string",
-      "description": "Sandbox permissions for the command. Set to \"require_escalated\" to request running without sandbox restrictions; defaults to \"use_default\"."
+      "enum": ["use_default", "require_escalated"],
+      "description": "Per-command sandbox override. Defaults to `use_default`; use `require_escalated` for unsandboxed execution."
     },
     "justification": {
       "type": "string",
-      "description": "Only set if sandbox_permissions is \"require_escalated\". Request approval from the user to run this command outside the sandbox. Phrased as a simple question that summarizes the purpose of the command as it relates to the task at hand - e.g. 'Do you want to fetch and pull the latest version of this git branch?'"
+      "description": "User-facing approval question for `require_escalated`; omit otherwise."
     },
     "prefix_rule": {
       "type": "array",
       "items": {
         "type": "string"
       },
-      "description": "Only specify when sandbox_permissions is `require_escalated`. Suggest a prefix command pattern that will allow you to fulfill similar requests from the user in the future. Should be a short but reasonable prefix, e.g. [\"git\", \"pull\"] or [\"uv\", \"run\"] or [\"pytest\"]."
+      "description": "Reusable approval prefix for the command, only with `sandbox_permissions: \"require_escalated\"`; for example [\"git\", \"pull\"]."
     }
   },
   "required": ["command"],

--- a/src/tools/schemas/ShellCommand.json
+++ b/src/tools/schemas/ShellCommand.json
@@ -4,34 +4,35 @@
   "properties": {
     "command": {
       "type": "string",
-      "description": "The shell script to execute in the user's default shell"
+      "description": "Shell script to run in the user's default shell."
     },
     "workdir": {
       "type": "string",
-      "description": "The working directory to execute the command in"
+      "description": "Working directory for the command. Defaults to the turn cwd."
     },
     "login": {
       "type": "boolean",
-      "description": "Whether to run the shell with login shell semantics. Defaults to true."
+      "description": "True runs with login shell semantics; false disables them. Defaults to true."
     },
     "timeout_ms": {
       "type": "number",
-      "description": "The timeout for the command in milliseconds"
+      "description": "Maximum command runtime. Defaults to 10000 ms."
     },
     "sandbox_permissions": {
       "type": "string",
-      "description": "Sandbox permissions for the command. Set to \"require_escalated\" to request running without sandbox restrictions; defaults to \"use_default\"."
+      "enum": ["use_default", "require_escalated"],
+      "description": "Per-command sandbox override. Defaults to `use_default`; use `require_escalated` for unsandboxed execution."
     },
     "justification": {
       "type": "string",
-      "description": "Only set if sandbox_permissions is \"require_escalated\". Request approval from the user to run this command outside the sandbox. Phrased as a simple question that summarizes the purpose of the command as it relates to the task at hand - e.g. 'Do you want to fetch and pull the latest version of this git branch?'"
+      "description": "User-facing approval question for `require_escalated`; omit otherwise."
     },
     "prefix_rule": {
       "type": "array",
       "items": {
         "type": "string"
       },
-      "description": "Only specify when sandbox_permissions is `require_escalated`. Suggest a prefix command pattern that will allow you to fulfill similar requests from the user in the future. Should be a short but reasonable prefix, e.g. [\"git\", \"pull\"] or [\"uv\", \"run\"] or [\"pytest\"]."
+      "description": "Reusable approval prefix for the command, only with `sandbox_permissions: \"require_escalated\"`; for example [\"git\", \"pull\"]."
     }
   },
   "required": ["command"],

--- a/src/tools/schemas/UpdatePlan.json
+++ b/src/tools/schemas/UpdatePlan.json
@@ -3,7 +3,8 @@
   "type": "object",
   "properties": {
     "explanation": {
-      "type": "string"
+      "type": "string",
+      "description": "Optional explanation for this plan update."
     },
     "plan": {
       "type": "array",
@@ -12,11 +13,13 @@
         "type": "object",
         "properties": {
           "step": {
-            "type": "string"
+            "type": "string",
+            "description": "Task step text."
           },
           "status": {
             "type": "string",
-            "description": "One of: pending, in_progress, completed"
+            "enum": ["pending", "in_progress", "completed"],
+            "description": "Step status."
           }
         },
         "required": ["step", "status"],

--- a/src/tools/schemas/ViewImage.json
+++ b/src/tools/schemas/ViewImage.json
@@ -4,7 +4,7 @@
   "properties": {
     "path": {
       "type": "string",
-      "description": "Local filesystem path to an image file"
+      "description": "Local filesystem path to an image file."
     }
   },
   "required": ["path"],

--- a/src/tools/schemas/WriteStdin.json
+++ b/src/tools/schemas/WriteStdin.json
@@ -4,11 +4,11 @@
   "properties": {
     "chars": {
       "type": "string",
-      "description": "Bytes to write to stdin (may be empty to poll)."
+      "description": "Bytes to write to stdin. Defaults to empty, which polls without writing."
     },
     "max_output_tokens": {
       "type": "number",
-      "description": "Maximum number of tokens to return. Excess output will be truncated."
+      "description": "Output token budget. Defaults to 10000 tokens; larger requests may be capped by policy."
     },
     "session_id": {
       "type": "number",
@@ -16,7 +16,7 @@
     },
     "yield_time_ms": {
       "type": "number",
-      "description": "How long to wait (in milliseconds) for output before yielding."
+      "description": "Wait before yielding output. Non-empty writes default to 250 ms and cap at 30000 ms; empty polls wait 5000-300000 ms by default."
     }
   },
   "required": ["session_id"],


### PR DESCRIPTION
## Summary
- Align Codex-facing tool schema descriptions with upstream openai/codex rust-v0.136.0 wording.
- Add explicit enum constraints for sandbox permissions and update_plan status values.
- Keep runtime behavior unchanged; this is schema/documentation drift cleanup.

Closes #2648

## Test plan
- [x] bun test src/tools/codex-unified-exec-toolset.test.ts src/tools/model-facing-tool.test.ts
- [x] bun run check

👾 Generated with [Letta Code](https://letta.com)