### PR TITLE
fix(telemetry): populated subagent_id on start + fix flush

### DIFF
--- a/src/cli/helpers/reflection-launcher.ts
+++ b/src/cli/helpers/reflection-launcher.ts
@@ -15,6 +15,27 @@ import { debugLog, debugWarn } from "@/utils/debug";
 
 export const AUTO_REFLECTION_DESCRIPTION = "Reflect on recent conversations";
 
+/**
+ * Maximum time to wait (in the background, non-blocking) for the spawned
+ * reflection subagent to be assigned a concrete agent ID before we emit the
+ * `reflection_start` telemetry event with whatever we have.
+ *
+ * Background: `spawnBackgroundSubagentTask` returns immediately with a local
+ * task id, but the actual Letta agent is created asynchronously via an HTTP
+ * POST that typically takes 1–10 seconds (longer under congestion or cold
+ * start). Previously this wait was capped at 1s AND awaited inline, which
+ * (a) blocked the reflection-launch path for up to 1s, and (b) almost always
+ * timed out, causing `reflection_start.subagent_id` to be empty in 100% of
+ * production rows.
+ *
+ * The fix: do the wait in the background and emit `reflection_start` when the
+ * ID resolves. The launcher returns immediately so the trigger UX is
+ * unaffected. 30s comfortably covers the agent-creation round trip in nearly
+ * all cases. If we exceed the deadline we emit with `subagent_id` empty as a
+ * last resort rather than dropping the event entirely.
+ */
+export const REFLECTION_AGENT_ID_WAIT_MS = 30_000;
+
 export type ReflectionLaunchTriggerSource =
   | "manual"
   | Exclude<ReflectionTrigger, "off">;
@@ -143,6 +164,23 @@ export async function launchReflectionSubagent(
 
     const { spawnBackgroundSubagentTask, waitForBackgroundSubagentAgentId } =
       await import("@/tools/impl/task");
+
+    // We need the resolved agent ID on `reflection_start` so dashboards can
+    // identify the subagent for *in-flight* reflections (i.e. cases where
+    // `reflection_end` never lands — crashes, early exits, long-running).
+    // But we can't block the reflection-launch path on the agent-creation
+    // HTTP round trip (1–10s, sometimes longer). So we defer the
+    // `reflection_start` emission until the ID is known, in the background,
+    // with a bounded 30s timeout. The launch path returns immediately.
+    const emitReflectionStart = (resolvedAgentId: string | null) => {
+      telemetry.trackReflectionStart(triggerSource, {
+        subagentId: resolvedAgentId ?? undefined,
+        conversationId,
+        startMessageId: autoPayload.startMessageId,
+        endMessageId: autoPayload.endMessageId,
+      });
+    };
+
     const { subagentId } = spawnBackgroundSubagentTask({
       subagentType: "reflection",
       prompt: reflectionPrompt,
@@ -154,6 +192,8 @@ export async function launchReflectionSubagent(
         telemetry.trackReflectionEnd(triggerSource, success, {
           subagentId: reflectionAgentId ?? undefined,
           conversationId,
+          startMessageId: autoPayload.startMessageId,
+          endMessageId: autoPayload.endMessageId,
           error,
         });
         await finalizeAutoReflectionPayload(
@@ -188,23 +228,34 @@ export async function launchReflectionSubagent(
         });
       },
     });
-    const reflectionAgentId = await waitForBackgroundSubagentAgentId(
+    // Fire-and-forget: emit `reflection_start` as soon as the subagent has a
+    // concrete agent ID, or after the bounded timeout. Either way, the event
+    // ships with whatever ID is available at that point. The launcher itself
+    // returns immediately so we never delay the reflection trigger UX.
+    void waitForBackgroundSubagentAgentId(
       subagentId,
-      1000,
-    );
-    telemetry.trackReflectionStart(triggerSource, {
-      subagentId: reflectionAgentId ?? undefined,
-      conversationId,
-      startMessageId: autoPayload.startMessageId,
-      endMessageId: autoPayload.endMessageId,
-    });
+      REFLECTION_AGENT_ID_WAIT_MS,
+    )
+      .then((resolvedAgentId) => {
+        emitReflectionStart(resolvedAgentId);
+      })
+      .catch((err) => {
+        // Worst case — still emit the event with no subagent_id so we don't
+        // lose visibility into the reflection trigger entirely.
+        debugWarn(
+          "memory",
+          `Failed waiting for reflection agent ID: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+        emitReflectionStart(null);
+      });
 
     debugLog("memory", `Launched reflection subagent (${triggerSource})`);
     return {
       launched: true,
       payloadPath: autoPayload.payloadPath,
       subagentId,
-      reflectionAgentId: reflectionAgentId ?? undefined,
       startMessageId: autoPayload.startMessageId,
       endMessageId: autoPayload.endMessageId,
     };

--- a/src/cli/helpers/reflection-launcher.ts
+++ b/src/cli/helpers/reflection-launcher.ts
@@ -168,8 +168,6 @@ export async function launchReflectionSubagent(
         telemetry.trackReflectionEnd(triggerSource, success, {
           subagentId: reflectionAgentId ?? undefined,
           conversationId,
-          startMessageId: autoPayload.startMessageId,
-          endMessageId: autoPayload.endMessageId,
           error,
         });
         await finalizeAutoReflectionPayload(

--- a/src/cli/helpers/reflection-launcher.ts
+++ b/src/cli/helpers/reflection-launcher.ts
@@ -15,25 +15,7 @@ import { debugLog, debugWarn } from "@/utils/debug";
 
 export const AUTO_REFLECTION_DESCRIPTION = "Reflect on recent conversations";
 
-/**
- * Maximum time to wait (in the background, non-blocking) for the spawned
- * reflection subagent to be assigned a concrete agent ID before we emit the
- * `reflection_start` telemetry event with whatever we have.
- *
- * Background: `spawnBackgroundSubagentTask` returns immediately with a local
- * task id, but the actual Letta agent is created asynchronously via an HTTP
- * POST that typically takes 1–10 seconds (longer under congestion or cold
- * start). Previously this wait was capped at 1s AND awaited inline, which
- * (a) blocked the reflection-launch path for up to 1s, and (b) almost always
- * timed out, causing `reflection_start.subagent_id` to be empty in 100% of
- * production rows.
- *
- * The fix: do the wait in the background and emit `reflection_start` when the
- * ID resolves. The launcher returns immediately so the trigger UX is
- * unaffected. 30s comfortably covers the agent-creation round trip in nearly
- * all cases. If we exceed the deadline we emit with `subagent_id` empty as a
- * last resort rather than dropping the event entirely.
- */
+/** Max background wait for the reflection subagent's agent ID before emitting `reflection_start` (previously 1s inline, timed out ~100% of the time). */
 export const REFLECTION_AGENT_ID_WAIT_MS = 30_000;
 
 export type ReflectionLaunchTriggerSource =
@@ -165,13 +147,7 @@ export async function launchReflectionSubagent(
     const { spawnBackgroundSubagentTask, waitForBackgroundSubagentAgentId } =
       await import("@/tools/impl/task");
 
-    // We need the resolved agent ID on `reflection_start` so dashboards can
-    // identify the subagent for *in-flight* reflections (i.e. cases where
-    // `reflection_end` never lands — crashes, early exits, long-running).
-    // But we can't block the reflection-launch path on the agent-creation
-    // HTTP round trip (1–10s, sometimes longer). So we defer the
-    // `reflection_start` emission until the ID is known, in the background,
-    // with a bounded 30s timeout. The launch path returns immediately.
+    // Defer `reflection_start` until the agent ID resolves (background, bounded by REFLECTION_AGENT_ID_WAIT_MS).
     const emitReflectionStart = (resolvedAgentId: string | null) => {
       telemetry.trackReflectionStart(triggerSource, {
         subagentId: resolvedAgentId ?? undefined,
@@ -228,10 +204,7 @@ export async function launchReflectionSubagent(
         });
       },
     });
-    // Fire-and-forget: emit `reflection_start` as soon as the subagent has a
-    // concrete agent ID, or after the bounded timeout. Either way, the event
-    // ships with whatever ID is available at that point. The launcher itself
-    // returns immediately so we never delay the reflection trigger UX.
+    // Fire-and-forget: emit `reflection_start` when the agent ID resolves or after timeout.
     void waitForBackgroundSubagentAgentId(
       subagentId,
       REFLECTION_AGENT_ID_WAIT_MS,
@@ -240,8 +213,7 @@ export async function launchReflectionSubagent(
         emitReflectionStart(resolvedAgentId);
       })
       .catch((err) => {
-        // Worst case — still emit the event with no subagent_id so we don't
-        // lose visibility into the reflection trigger entirely.
+        // Worst case — still emit with no subagent_id so we don't lose the event.
         debugWarn(
           "memory",
           `Failed waiting for reflection agent ID: ${

--- a/src/telemetry/flush-batching.test.ts
+++ b/src/telemetry/flush-batching.test.ts
@@ -171,28 +171,6 @@ describe("reflection telemetry correlation", () => {
     settingsManager.getSettings = originalGetSettings;
   });
 
-  test("reflection_end carries start_message_id and end_message_id", () => {
-    telemetry.trackReflectionEnd("step-count", true, {
-      subagentId: "agent-deadbeef",
-      conversationId: "conv-1",
-      startMessageId: "message-start",
-      endMessageId: "message-end",
-    });
-
-    const event = telemetryState.events[0] as {
-      type: string;
-      data: {
-        subagent_id?: string;
-        start_message_id?: string;
-        end_message_id?: string;
-      };
-    };
-    expect(event.type).toBe("reflection_end");
-    expect(event.data.subagent_id).toBe("agent-deadbeef");
-    expect(event.data.start_message_id).toBe("message-start");
-    expect(event.data.end_message_id).toBe("message-end");
-  });
-
   test("both reflection_start and reflection_end carry subagent_id for in-flight tracking", () => {
     // Mirrors the post-deferred-emit launcher: by the time
     // trackReflectionStart fires (after the background agent-id wait), we
@@ -208,14 +186,12 @@ describe("reflection telemetry correlation", () => {
     telemetry.trackReflectionEnd("step-count", true, {
       subagentId: "agent-resolved-in-background",
       conversationId: "conv-1",
-      startMessageId: "message-start-1",
-      endMessageId: "message-end-1",
     });
 
     expect(telemetryState.events).toHaveLength(2);
     type ReflectionEvent = {
       type: string;
-      data: { start_message_id?: string; subagent_id?: string };
+      data: { subagent_id?: string };
     };
     const events = telemetryState.events as ReflectionEvent[];
     const startEvent = events[0];
@@ -231,11 +207,6 @@ describe("reflection telemetry correlation", () => {
     // identify the subagent from reflection_start alone (no JOIN needed).
     expect(startEvent.data.subagent_id).toBe("agent-resolved-in-background");
     expect(endEvent.data.subagent_id).toBe("agent-resolved-in-background");
-
-    // start_message_id is still the stable correlation key for pairing.
-    expect(startEvent.data.start_message_id).toBe(
-      endEvent.data.start_message_id,
-    );
   });
 
   test("reflection_start falls back to undefined subagent_id if wait times out", () => {

--- a/src/telemetry/flush-batching.test.ts
+++ b/src/telemetry/flush-batching.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { settingsManager } from "@/settings-manager";
+import { type TelemetrySurface, telemetry } from "@/telemetry";
+
+type TelemetryTestState = {
+  events: unknown[];
+  messageCount: number;
+  currentAgentId: string | null;
+  surface: TelemetrySurface;
+  sessionEndTracked: boolean;
+  inflightFlush: Promise<void> | null;
+  isCloudUser: () => boolean;
+};
+
+const telemetryState = telemetry as unknown as TelemetryTestState;
+
+function deleteEnvVarCaseInsensitive(name: string): void {
+  const normalized = name.toLowerCase();
+  for (const key of Object.keys(process.env)) {
+    if (key.toLowerCase() === normalized) {
+      delete process.env[key];
+    }
+  }
+}
+
+describe("telemetry flush batching", () => {
+  const originalFetch = globalThis.fetch;
+  const originalGetSettingsWithSecureTokens =
+    settingsManager.getSettingsWithSecureTokens;
+  const originalGetSettings = settingsManager.getSettings;
+
+  beforeEach(() => {
+    telemetry.cleanup();
+    telemetryState.events = [];
+    telemetryState.messageCount = 0;
+    telemetryState.currentAgentId = null;
+    telemetryState.surface = "letta_code_tui";
+    telemetryState.sessionEndTracked = false;
+    telemetryState.inflightFlush = null;
+    deleteEnvVarCaseInsensitive("LETTA_API_KEY");
+    deleteEnvVarCaseInsensitive("LETTA_TELEMETRY_DISABLED");
+    deleteEnvVarCaseInsensitive("LETTA_BASE_URL");
+    settingsManager.getSettings = mock(() => ({
+      env: {},
+    })) as unknown as typeof settingsManager.getSettings;
+    settingsManager.getSettingsWithSecureTokens = mock(async () => ({
+      env: { LETTA_API_KEY: "settings-key" },
+    })) as unknown as typeof settingsManager.getSettingsWithSecureTokens;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    settingsManager.getSettingsWithSecureTokens =
+      originalGetSettingsWithSecureTokens;
+    settingsManager.getSettings = originalGetSettings;
+  });
+
+  test("concurrent flush() callers share one in-flight POST", async () => {
+    const deferred: { resolve: (value: Response) => void } = {
+      resolve: () => {},
+    };
+    const pending = new Promise<Response>((resolve) => {
+      deferred.resolve = resolve;
+    });
+    const fetchMock = mock(() => pending);
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    telemetry.trackUserInput("hello", "user", "model-1");
+
+    // Fire three flushes back to back — they should all share the same POST,
+    // which is the core defense against the 429 route_rps_rate_limit_exceeded
+    // race we hit on shutdown when SIGINT + normal-exit handlers both flush.
+    const a = telemetry.flush();
+    const b = telemetry.flush();
+    const c = telemetry.flush();
+
+    // Yield long enough for performFlush's `await resolveTelemetryApiKey()`
+    // microtask to complete and the underlying fetch to be issued — but the
+    // fetch itself is hung on `pending`, so the in-flight guard still
+    // applies to b and c.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Resolve the single in-flight request and let all three callers settle.
+    deferred.resolve(new Response(null, { status: 200 }));
+    await Promise.all([a, b, c]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(telemetryState.events).toHaveLength(0);
+  });
+
+  test("drain awaits the in-flight flush and exits when queue is empty", async () => {
+    const fetchMock = mock(async () => new Response(null, { status: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    telemetry.trackUserInput("hello", "user", "model-1");
+    telemetry.trackUserInput("world", "user", "model-1");
+
+    const drainable = telemetry as unknown as { drain: () => Promise<void> };
+    await drainable.drain();
+
+    expect(telemetryState.events).toHaveLength(0);
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  test("drain re-runs flush when new events arrive mid-drain", async () => {
+    let firstCall = true;
+    const fetchMock = mock(async () => {
+      if (firstCall) {
+        firstCall = false;
+        // Simulate a trackError happening (e.g. uncaughtException handler)
+        // while the first POST is in flight.
+        telemetry.trackUserInput("late", "user", "model-1");
+      }
+      return new Response(null, { status: 200 });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    telemetry.trackUserInput("first", "user", "model-1");
+
+    const drainable = telemetry as unknown as { drain: () => Promise<void> };
+    await drainable.drain();
+
+    // First flush sent 1 event, then drain noticed the late event and flushed
+    // again. Queue should be empty after drain returns.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(telemetryState.events).toHaveLength(0);
+  });
+
+  test("flush failure re-queues events without throwing", async () => {
+    const fetchMock = mock(async () => new Response(null, { status: 500 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    telemetry.trackUserInput("hello", "user", "model-1");
+    expect(telemetryState.events).toHaveLength(1);
+
+    await telemetry.flush();
+
+    // 500 → submitTelemetryMetadata throws → performFlush re-queues.
+    expect(telemetryState.events).toHaveLength(1);
+  });
+});
+
+describe("reflection telemetry correlation", () => {
+  const originalFetch = globalThis.fetch;
+  const originalGetSettingsWithSecureTokens =
+    settingsManager.getSettingsWithSecureTokens;
+  const originalGetSettings = settingsManager.getSettings;
+
+  beforeEach(() => {
+    telemetry.cleanup();
+    telemetryState.events = [];
+    telemetryState.messageCount = 0;
+    telemetryState.currentAgentId = null;
+    telemetryState.surface = "letta_code_tui";
+    telemetryState.sessionEndTracked = false;
+    telemetryState.inflightFlush = null;
+    deleteEnvVarCaseInsensitive("LETTA_API_KEY");
+    settingsManager.getSettings = mock(() => ({
+      env: {},
+    })) as unknown as typeof settingsManager.getSettings;
+    settingsManager.getSettingsWithSecureTokens = mock(async () => ({
+      env: { LETTA_API_KEY: "settings-key" },
+    })) as unknown as typeof settingsManager.getSettingsWithSecureTokens;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    settingsManager.getSettingsWithSecureTokens =
+      originalGetSettingsWithSecureTokens;
+    settingsManager.getSettings = originalGetSettings;
+  });
+
+  test("reflection_end carries start_message_id and end_message_id", () => {
+    telemetry.trackReflectionEnd("step-count", true, {
+      subagentId: "agent-deadbeef",
+      conversationId: "conv-1",
+      startMessageId: "message-start",
+      endMessageId: "message-end",
+    });
+
+    const event = telemetryState.events[0] as {
+      type: string;
+      data: {
+        subagent_id?: string;
+        start_message_id?: string;
+        end_message_id?: string;
+      };
+    };
+    expect(event.type).toBe("reflection_end");
+    expect(event.data.subagent_id).toBe("agent-deadbeef");
+    expect(event.data.start_message_id).toBe("message-start");
+    expect(event.data.end_message_id).toBe("message-end");
+  });
+
+  test("both reflection_start and reflection_end carry subagent_id for in-flight tracking", () => {
+    // Mirrors the post-deferred-emit launcher: by the time
+    // trackReflectionStart fires (after the background agent-id wait), we
+    // have a real subagent_id, so in-flight reflections are identifiable
+    // even if reflection_end never lands (crash / early exit / long-running).
+    telemetry.trackReflectionStart("step-count", {
+      subagentId: "agent-resolved-in-background",
+      conversationId: "conv-1",
+      startMessageId: "message-start-1",
+      endMessageId: "message-end-1",
+    });
+
+    telemetry.trackReflectionEnd("step-count", true, {
+      subagentId: "agent-resolved-in-background",
+      conversationId: "conv-1",
+      startMessageId: "message-start-1",
+      endMessageId: "message-end-1",
+    });
+
+    expect(telemetryState.events).toHaveLength(2);
+    type ReflectionEvent = {
+      type: string;
+      data: { start_message_id?: string; subagent_id?: string };
+    };
+    const events = telemetryState.events as ReflectionEvent[];
+    const startEvent = events[0];
+    const endEvent = events[1];
+    if (!startEvent || !endEvent) {
+      throw new Error("Expected start + end reflection events");
+    }
+
+    expect(startEvent.type).toBe("reflection_start");
+    expect(endEvent.type).toBe("reflection_end");
+
+    // The key invariant: subagent_id is populated on both, so dashboards can
+    // identify the subagent from reflection_start alone (no JOIN needed).
+    expect(startEvent.data.subagent_id).toBe("agent-resolved-in-background");
+    expect(endEvent.data.subagent_id).toBe("agent-resolved-in-background");
+
+    // start_message_id is still the stable correlation key for pairing.
+    expect(startEvent.data.start_message_id).toBe(
+      endEvent.data.start_message_id,
+    );
+  });
+
+  test("reflection_start falls back to undefined subagent_id if wait times out", () => {
+    // Worst case: background wait times out before agent ID is assigned. We
+    // still emit the event (with undefined subagent_id) rather than dropping
+    // it, so we have at least a launch record.
+    telemetry.trackReflectionStart("step-count", {
+      subagentId: undefined,
+      conversationId: "conv-1",
+      startMessageId: "message-start-2",
+      endMessageId: "message-end-2",
+    });
+
+    const event = telemetryState.events[0] as {
+      type: string;
+      data: { subagent_id?: string; start_message_id?: string };
+    };
+    expect(event.type).toBe("reflection_start");
+    expect(event.data.subagent_id).toBeUndefined();
+    expect(event.data.start_message_id).toBe("message-start-2");
+  });
+});

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -99,6 +99,16 @@ export interface ReflectionEndData {
   success: boolean;
   subagent_id?: string;
   conversation_id?: string;
+  /**
+   * Message IDs bracketing the reflection window. Carried on both
+   * `reflection_start` and `reflection_end` so dashboards can correlate the
+   * two events via `start_message_id` — useful because
+   * `reflection_start.subagent_id` is often empty (the agent ID isn't
+   * resolved synchronously) but `reflection_end.subagent_id` is populated
+   * from the spawn callback.
+   */
+  start_message_id?: string;
+  end_message_id?: string;
   error?: string;
 }
 
@@ -231,6 +241,15 @@ class TelemetryManager {
   private initialized = false;
   private flushInterval: NodeJS.Timeout | null = null;
   private serverVersion: string | null = null;
+  /**
+   * Tracks an in-flight flush so concurrent callers can await it instead of
+   * starting a second POST. Prevents the "double-flush on shutdown" race that
+   * was causing 429 `route_rps_rate_limit_exceeded` errors when SIGINT and
+   * normal-exit handlers both kicked off a flush within milliseconds of each
+   * other, dropping the second batch (typically containing late `reflection_end`
+   * events).
+   */
+  private inflightFlush: Promise<void> | null = null;
 
   private async resolveTelemetryApiKey(): Promise<string | undefined> {
     if (process.env.LETTA_API_KEY) {
@@ -244,8 +263,26 @@ class TelemetryManager {
       return undefined;
     }
   }
-  private readonly FLUSH_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
-  private readonly MAX_BATCH_SIZE = 100;
+  /**
+   * Periodic flush cadence. Previously 5 minutes, which meant a typical
+   * session's entire telemetry payload (well under 100 events) rode on the
+   * exit-path flush alone — losing the queue on Ctrl+C, crashes, or any other
+   * abnormal termination. 30s gives us much more durable coverage while
+   * staying well below any reasonable per-route rate limit.
+   */
+  private readonly FLUSH_INTERVAL_MS = 30 * 1000; // 30 seconds
+  /**
+   * Maximum number of events to accumulate before triggering an immediate
+   * flush. Tuned down from 100 so that bursty sessions (e.g. ~20 `tool_usage`
+   * events from a single user turn) flush at natural conversation boundaries
+   * rather than holding the queue until exit.
+   */
+  private readonly MAX_BATCH_SIZE = 25;
+  /**
+   * Maximum time to wait for queued events to drain on exit before letting
+   * the process terminate anyway. Bounded so we never hang the user's shell.
+   */
+  private readonly DRAIN_TIMEOUT_MS = 3_000;
   private sessionStatsGetter?: () => {
     totalWallMs: number;
     totalApiMs: number;
@@ -329,58 +366,59 @@ class TelemetryManager {
     // Don't let the interval prevent process from exiting
     this.flushInterval.unref();
 
-    // Safety net: Handle Ctrl+C interruption
-    // Note: Normal exits via handleExit flush explicitly
+    // Safety net: Handle Ctrl+C interruption.
+    // Normal exits via handleExit drain explicitly.
+    // We await drain() (bounded by DRAIN_TIMEOUT_MS) before exiting so the
+    // final batch — which typically contains late-arriving reflection_end
+    // events and session_end — actually makes it over the wire.
     process.on("SIGINT", () => {
-      try {
-        this.trackSessionEnd(undefined, "sigint");
-        // Fire and forget - try to flush but don't wait (might not complete)
-        this.flush().catch(() => {
-          // Silently ignore
-        });
-      } catch {
-        // Silently ignore - don't prevent process from exiting
-      }
-      // Exit immediately - don't wait for flush
-      process.exit(0);
+      void (async () => {
+        try {
+          this.trackSessionEnd(undefined, "sigint");
+          await this.drain();
+        } catch {
+          // Silently ignore - don't prevent process from exiting
+        }
+        process.exit(0);
+      })();
     });
 
     process.on("uncaughtException", (error) => {
-      try {
-        const msg = error instanceof Error ? error.message : String(error);
-        // Broken pipe/TTY — not actionable (e.g. terminal closed while writing)
-        if (/\b(EPIPE|EIO|EBADF)\b/.test(msg)) return;
-        this.trackError(
-          "uncaught_exception",
-          msg,
-          "process_uncaught_exception",
-        );
-        this.flush().catch(() => {
-          // Silently ignore
-        });
-      } catch {
-        // Silently ignore - don't prevent process from exiting
-      }
+      void (async () => {
+        try {
+          const msg = error instanceof Error ? error.message : String(error);
+          // Broken pipe/TTY — not actionable (e.g. terminal closed while writing)
+          if (/\b(EPIPE|EIO|EBADF)\b/.test(msg)) return;
+          this.trackError(
+            "uncaught_exception",
+            msg,
+            "process_uncaught_exception",
+          );
+          await this.drain();
+        } catch {
+          // Silently ignore - don't prevent process from exiting
+        }
+      })();
     });
 
     process.on("unhandledRejection", (reason) => {
-      try {
-        const msg = reason instanceof Error ? reason.message : String(reason);
-        // Broken pipe/TTY — not actionable
-        if (/\b(EPIPE|EIO|EBADF)\b/.test(msg)) return;
-        // Rate limits surfacing as unhandled rejections — expected under load
-        if (/\b429\b/.test(msg) && /rate.?limit/i.test(msg)) return;
-        this.trackError(
-          "unhandled_rejection",
-          msg,
-          "process_unhandled_rejection",
-        );
-        this.flush().catch(() => {
-          // Silently ignore
-        });
-      } catch {
-        // Silently ignore - don't prevent process from exiting
-      }
+      void (async () => {
+        try {
+          const msg = reason instanceof Error ? reason.message : String(reason);
+          // Broken pipe/TTY — not actionable
+          if (/\b(EPIPE|EIO|EBADF)\b/.test(msg)) return;
+          // Rate limits surfacing as unhandled rejections — expected under load
+          if (/\b429\b/.test(msg) && /rate.?limit/i.test(msg)) return;
+          this.trackError(
+            "unhandled_rejection",
+            msg,
+            "process_unhandled_rejection",
+          );
+          await this.drain();
+        } catch {
+          // Silently ignore - don't prevent process from exiting
+        }
+      })();
     });
 
     // TODO: Add telemetry for crashes and abnormal exits
@@ -708,6 +746,8 @@ class TelemetryManager {
     options?: {
       subagentId?: string;
       conversationId?: string;
+      startMessageId?: string;
+      endMessageId?: string;
       error?: string;
     },
   ) {
@@ -716,19 +756,36 @@ class TelemetryManager {
       success,
       subagent_id: options?.subagentId,
       conversation_id: options?.conversationId,
+      start_message_id: options?.startMessageId,
+      end_message_id: options?.endMessageId,
       error: options?.error,
     };
     this.track("reflection_end", data);
   }
 
   /**
-   * Flush events to the server
+   * Flush events to the server.
+   *
+   * Concurrent callers (e.g. timer interval + size threshold + exit handler all
+   * firing within the same tick) all await the same in-flight POST instead of
+   * each starting their own. This is the fix for the 429
+   * `route_rps_rate_limit_exceeded` race we were hitting on shutdown.
    */
   async flush(): Promise<void> {
+    if (this.inflightFlush) {
+      return this.inflightFlush;
+    }
     if (this.events.length === 0 || !this.isTelemetryEnabled()) {
       return;
     }
 
+    this.inflightFlush = this.performFlush().finally(() => {
+      this.inflightFlush = null;
+    });
+    return this.inflightFlush;
+  }
+
+  private async performFlush(): Promise<void> {
     const eventsToSend = [...this.events];
     this.events = [];
 
@@ -748,6 +805,36 @@ class TelemetryManager {
     } catch {
       // If flush fails, put events back in queue, but don't throw error
       this.events.unshift(...eventsToSend);
+    }
+  }
+
+  /**
+   * Drain all queued events before exiting.
+   *
+   * Replaces the historical "fire and forget `flush()` then `process.exit(0)`"
+   * pattern in our exit handlers, which silently dropped any events that
+   * hadn't been POSTed by the time the process tore down. Awaits the
+   * in-flight flush (if any) and then drains the remaining queue, bounded by
+   * `DRAIN_TIMEOUT_MS` so a slow/unresponsive server never hangs the user's
+   * shell.
+   */
+  async drain(): Promise<void> {
+    if (!this.isTelemetryEnabled()) {
+      return;
+    }
+    const deadline = Date.now() + this.DRAIN_TIMEOUT_MS;
+    // Loop in case new events get tracked between awaits (e.g. trackError from
+    // an `uncaughtException` handler firing while drain is in flight).
+    while (this.events.length > 0 || this.inflightFlush) {
+      if (Date.now() >= deadline) {
+        return;
+      }
+      try {
+        await this.flush();
+      } catch {
+        // Swallow — already logged inside performFlush; don't block exit.
+        return;
+      }
     }
   }
 

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -246,10 +246,8 @@ class TelemetryManager {
       return undefined;
     }
   }
-  /** 30s (was 5min) — flushes events during the session rather than relying solely on the exit path. */
-  private readonly FLUSH_INTERVAL_MS = 30 * 1000; // 30 seconds
-  /** 25 (was 100) — flushes at natural conversation boundaries instead of holding until exit. */
-  private readonly MAX_BATCH_SIZE = 25;
+  private readonly FLUSH_INTERVAL_MS = 2 * 60 * 1000; // 2 minutes
+  private readonly MAX_BATCH_SIZE = 50;
   /** Max time to drain queued events on exit (bounded so we never hang the shell). */
   private readonly DRAIN_TIMEOUT_MS = 3_000;
   private sessionStatsGetter?: () => {

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -99,9 +99,6 @@ export interface ReflectionEndData {
   success: boolean;
   subagent_id?: string;
   conversation_id?: string;
-  /** Correlation keys for pairing `reflection_start` and `reflection_end` when `subagent_id` is absent on start. */
-  start_message_id?: string;
-  end_message_id?: string;
   error?: string;
 }
 
@@ -714,8 +711,6 @@ class TelemetryManager {
     options?: {
       subagentId?: string;
       conversationId?: string;
-      startMessageId?: string;
-      endMessageId?: string;
       error?: string;
     },
   ) {
@@ -724,8 +719,6 @@ class TelemetryManager {
       success,
       subagent_id: options?.subagentId,
       conversation_id: options?.conversationId,
-      start_message_id: options?.startMessageId,
-      end_message_id: options?.endMessageId,
       error: options?.error,
     };
     this.track("reflection_end", data);

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -99,14 +99,7 @@ export interface ReflectionEndData {
   success: boolean;
   subagent_id?: string;
   conversation_id?: string;
-  /**
-   * Message IDs bracketing the reflection window. Carried on both
-   * `reflection_start` and `reflection_end` so dashboards can correlate the
-   * two events via `start_message_id` — useful because
-   * `reflection_start.subagent_id` is often empty (the agent ID isn't
-   * resolved synchronously) but `reflection_end.subagent_id` is populated
-   * from the spawn callback.
-   */
+  /** Correlation keys for pairing `reflection_start` and `reflection_end` when `subagent_id` is absent on start. */
   start_message_id?: string;
   end_message_id?: string;
   error?: string;
@@ -241,14 +234,7 @@ class TelemetryManager {
   private initialized = false;
   private flushInterval: NodeJS.Timeout | null = null;
   private serverVersion: string | null = null;
-  /**
-   * Tracks an in-flight flush so concurrent callers can await it instead of
-   * starting a second POST. Prevents the "double-flush on shutdown" race that
-   * was causing 429 `route_rps_rate_limit_exceeded` errors when SIGINT and
-   * normal-exit handlers both kicked off a flush within milliseconds of each
-   * other, dropping the second batch (typically containing late `reflection_end`
-   * events).
-   */
+  /** Deduplicates concurrent flushes (prevents the 429 double-flush race on shutdown). */
   private inflightFlush: Promise<void> | null = null;
 
   private async resolveTelemetryApiKey(): Promise<string | undefined> {
@@ -263,25 +249,11 @@ class TelemetryManager {
       return undefined;
     }
   }
-  /**
-   * Periodic flush cadence. Previously 5 minutes, which meant a typical
-   * session's entire telemetry payload (well under 100 events) rode on the
-   * exit-path flush alone — losing the queue on Ctrl+C, crashes, or any other
-   * abnormal termination. 30s gives us much more durable coverage while
-   * staying well below any reasonable per-route rate limit.
-   */
+  /** 30s (was 5min) — flushes events during the session rather than relying solely on the exit path. */
   private readonly FLUSH_INTERVAL_MS = 30 * 1000; // 30 seconds
-  /**
-   * Maximum number of events to accumulate before triggering an immediate
-   * flush. Tuned down from 100 so that bursty sessions (e.g. ~20 `tool_usage`
-   * events from a single user turn) flush at natural conversation boundaries
-   * rather than holding the queue until exit.
-   */
+  /** 25 (was 100) — flushes at natural conversation boundaries instead of holding until exit. */
   private readonly MAX_BATCH_SIZE = 25;
-  /**
-   * Maximum time to wait for queued events to drain on exit before letting
-   * the process terminate anyway. Bounded so we never hang the user's shell.
-   */
+  /** Max time to drain queued events on exit (bounded so we never hang the shell). */
   private readonly DRAIN_TIMEOUT_MS = 3_000;
   private sessionStatsGetter?: () => {
     totalWallMs: number;
@@ -366,11 +338,7 @@ class TelemetryManager {
     // Don't let the interval prevent process from exiting
     this.flushInterval.unref();
 
-    // Safety net: Handle Ctrl+C interruption.
-    // Normal exits via handleExit drain explicitly.
-    // We await drain() (bounded by DRAIN_TIMEOUT_MS) before exiting so the
-    // final batch — which typically contains late-arriving reflection_end
-    // events and session_end — actually makes it over the wire.
+    // Await drain() (bounded by DRAIN_TIMEOUT_MS) so the final batch ships before exit.
     process.on("SIGINT", () => {
       void (async () => {
         try {
@@ -763,14 +731,7 @@ class TelemetryManager {
     this.track("reflection_end", data);
   }
 
-  /**
-   * Flush events to the server.
-   *
-   * Concurrent callers (e.g. timer interval + size threshold + exit handler all
-   * firing within the same tick) all await the same in-flight POST instead of
-   * each starting their own. This is the fix for the 429
-   * `route_rps_rate_limit_exceeded` race we were hitting on shutdown.
-   */
+  /** Concurrent callers share one in-flight POST (prevents 429 double-flush race on shutdown). */
   async flush(): Promise<void> {
     if (this.inflightFlush) {
       return this.inflightFlush;
@@ -808,23 +769,13 @@ class TelemetryManager {
     }
   }
 
-  /**
-   * Drain all queued events before exiting.
-   *
-   * Replaces the historical "fire and forget `flush()` then `process.exit(0)`"
-   * pattern in our exit handlers, which silently dropped any events that
-   * hadn't been POSTed by the time the process tore down. Awaits the
-   * in-flight flush (if any) and then drains the remaining queue, bounded by
-   * `DRAIN_TIMEOUT_MS` so a slow/unresponsive server never hangs the user's
-   * shell.
-   */
+  /** Await in-flight flush and drain remaining queue (bounded by DRAIN_TIMEOUT_MS). Replaces fire-and-forget flush on exit. */
   async drain(): Promise<void> {
     if (!this.isTelemetryEnabled()) {
       return;
     }
     const deadline = Date.now() + this.DRAIN_TIMEOUT_MS;
-    // Loop in case new events get tracked between awaits (e.g. trackError from
-    // an `uncaughtException` handler firing while drain is in flight).
+    // Loop in case new events arrive mid-drain (e.g. trackError from uncaughtException).
     while (this.events.length > 0 || this.inflightFlush) {
       if (Date.now() >= deadline) {
         return;


### PR DESCRIPTION
## Summary

Two fixes for missing reflection telemetry in PostHog.

### 1. `reflection_start` now carries `subagent_id`

The old code awaited the agent-creation ID lookup inline with a 1s timeout before emitting `reflection_start`. Agent creation takes 1–10s, so it timed out ~100% of the time, leaving `subagent_id` empty. Now the wait runs in the background (up to 30s) and emits when the ID resolves; the launcher returns immediately. Timeout → emit with `undefined` instead of dropping the event.

### 2. Telemetry flush no longer drops the final batch on shutdown

Two flushes racing ~22ms apart on exit hit 429, dropping the second batch (typically late `reflection_end` events). Fixes:

- `inflightFlush` guard — concurrent callers share one POST
- `flush()` split into guard + `performFlush()`
- New `drain()` (3s cap) — exit handlers `await drain()` instead of fire-and-forget
- Flush interval: 5min → 2min, batch size: 100 → 50

## Test plan

- [x] `bun test src/telemetry/` — 6/6 pass
- [x] `bun run typecheck` — clean
- [x] `biome check` on changed files — clean

## Notes

- Ctrl+C within ~1–3s of reflection launch may lose `reflection_start` — accepted, reflection itself also wouldn't have run
- No new event types, no schema-breaking changes

👾 Generated with [Letta Code](https://letta.com)