### PR TITLE
feat: pass response state ids through letta-code streams

### DIFF
--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -11,6 +11,7 @@ import type {
 } from "@letta-ai/letta-client/resources/agents/messages";
 import type { MessageCreateParams as ConversationMessageCreateParams } from "@letta-ai/letta-client/resources/conversations/messages";
 import { type Backend, getBackend } from "@/backend";
+import { permissionMode } from "@/permissions/mode";
 import {
   type ClientTool,
   type PermissionModeState,
@@ -325,7 +326,14 @@ export async function sendMessageStreamWithBackend(
   );
   const isApprovalContinuation =
     isApprovalContinuationRequest(normalizedMessages);
-  const previousResponseId = isApprovalContinuation
+  const effectivePermissionMode =
+    opts.permissionModeState?.mode ?? permissionMode.getMode();
+  // Only reuse cached response state for the unrestricted auto-approval path.
+  // Manual approval modes can pause long enough for user-visible state to change,
+  // so they should keep using the full server-side context preparation path.
+  const canUsePreviousResponseState =
+    isApprovalContinuation && effectivePermissionMode === "unrestricted";
+  const previousResponseId = canUsePreviousResponseState
     ? responseStateIdsByScope.get(responseStateScope)
     : undefined;
   const requestBody = buildConversationMessagesCreateRequestBody(
@@ -385,7 +393,7 @@ export async function sendMessageStreamWithBackend(
       resolvedConversationId,
       opts.agentId ?? "none",
     );
-  } else if (!isApprovalContinuation) {
+  } else if (!canUsePreviousResponseState) {
     responseStateIdsByScope.delete(responseStateScope);
   }
   // Echo the cloud user id back to cloud-api so it can re-attribute

--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -370,12 +370,12 @@ export async function sendMessageStreamWithBackend(
   if (process.env.LETTA_RESPONSES_WS === "1") {
     extraHeaders["X-Experimental-OpenAI-Responses-Websocket"] = "true";
   }
-  extraHeaders[RESPONSE_STATE_HEADER] = encodeResponseStateHeader({
-    v: 1,
-    cache_scope: RESPONSE_STATE_CACHE_SCOPE,
-    ...(previousResponseId ? { previous_response_id: previousResponseId } : {}),
-  });
   if (previousResponseId) {
+    extraHeaders[RESPONSE_STATE_HEADER] = encodeResponseStateHeader({
+      v: 1,
+      cache_scope: RESPONSE_STATE_CACHE_SCOPE,
+      previous_response_id: previousResponseId,
+    });
     responseStateIdsByScope.delete(responseStateScope);
     debugLog(
       "response-state",

--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -57,7 +57,6 @@ type ResponseStateHeaderPayload = {
   v: 1;
   cache_scope: typeof RESPONSE_STATE_CACHE_SCOPE;
   previous_response_id?: string;
-  client_tool_context_id?: string;
 };
 
 function buildResponseStateScope(
@@ -374,19 +373,17 @@ export async function sendMessageStreamWithBackend(
   extraHeaders[RESPONSE_STATE_HEADER] = encodeResponseStateHeader({
     v: 1,
     cache_scope: RESPONSE_STATE_CACHE_SCOPE,
-    client_tool_context_id: contextId,
     ...(previousResponseId ? { previous_response_id: previousResponseId } : {}),
   });
   if (previousResponseId) {
     responseStateIdsByScope.delete(responseStateScope);
     debugLog(
       "response-state",
-      "sending previous_response_id=%s cache_scope=%s conversation_id=%s agent_id=%s tool_context_id=%s",
+      "sending previous_response_id=%s cache_scope=%s conversation_id=%s agent_id=%s",
       previousResponseId,
       RESPONSE_STATE_CACHE_SCOPE,
       resolvedConversationId,
       opts.agentId ?? "none",
-      contextId,
     );
   } else if (!isApprovalContinuation) {
     responseStateIdsByScope.delete(responseStateScope);

--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -11,7 +11,6 @@ import type {
 } from "@letta-ai/letta-client/resources/agents/messages";
 import type { MessageCreateParams as ConversationMessageCreateParams } from "@letta-ai/letta-client/resources/conversations/messages";
 import { type Backend, getBackend } from "@/backend";
-import { permissionMode } from "@/permissions/mode";
 import {
   type ClientTool,
   type PermissionModeState,
@@ -197,6 +196,12 @@ export type SendMessageStreamOptions = {
   overrideModel?: string;
   /** Explicit turn-scoped tool snapshot. When present, bypasses the global registry. */
   preparedToolContext?: PreparedToolExecutionContext;
+  /**
+   * Allow sending a cached previous response id for this request. Callers should
+   * set this only for approval continuations that were fully auto-handled by
+   * the client, with no human approval/denial in the loop.
+   */
+  allowResponseStateReuse?: boolean;
   /** Skip shared image normalization when the caller already did it. */
   skipImageNormalization?: boolean;
   /**
@@ -326,13 +331,11 @@ export async function sendMessageStreamWithBackend(
   );
   const isApprovalContinuation =
     isApprovalContinuationRequest(normalizedMessages);
-  const effectivePermissionMode =
-    opts.permissionModeState?.mode ?? permissionMode.getMode();
-  // Only reuse cached response state for the unrestricted auto-approval path.
-  // Manual approval modes can pause long enough for user-visible state to change,
-  // so they should keep using the full server-side context preparation path.
+  // Only reuse cached response state when the approval continuation was fully
+  // auto-handled by the client. If a human reviewed any approval, the pause can
+  // allow visible agent/conversation state to change, so use the full server path.
   const canUsePreviousResponseState =
-    isApprovalContinuation && effectivePermissionMode === "unrestricted";
+    isApprovalContinuation && opts.allowResponseStateReuse === true;
   const previousResponseId = canUsePreviousResponseState
     ? responseStateIdsByScope.get(responseStateScope)
     : undefined;

--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -2,6 +2,7 @@
  * Utilities for sending messages to an agent via conversations
  **/
 
+import { Buffer } from "node:buffer";
 import type { Stream } from "@letta-ai/letta-client/core/streaming";
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import type {
@@ -33,7 +34,8 @@ import { getSkillSources } from "./context";
 
 const streamRequestStartTimes = new WeakMap<object, number>();
 const streamToolContextIds = new WeakMap<object, string>();
-const PREVIOUS_RESPONSE_ID_HEADER = "X-Letta-Previous-Response-Id";
+const RESPONSE_STATE_HEADER = "X-Letta-Response-State";
+const RESPONSE_STATE_CACHE_SCOPE = "approval_boundary";
 const responseStateIdsByScope = new Map<string, string>();
 
 export type StreamRequestContext = {
@@ -48,6 +50,14 @@ const streamRequestContexts = new WeakMap<object, StreamRequestContext>();
 type ResponseStateChunk = {
   message_type?: unknown;
   response_id?: unknown;
+  cache_scope?: unknown;
+};
+
+type ResponseStateHeaderPayload = {
+  v: 1;
+  cache_scope: typeof RESPONSE_STATE_CACHE_SCOPE;
+  previous_response_id?: string;
+  client_tool_context_id?: string;
 };
 
 function buildResponseStateScope(
@@ -63,7 +73,10 @@ function getResponseStateId(chunk: unknown): string | null {
   }
 
   const candidate = chunk as ResponseStateChunk;
-  if (candidate.message_type !== "response_state") {
+  if (
+    candidate.message_type !== "response_state" ||
+    candidate.cache_scope !== RESPONSE_STATE_CACHE_SCOPE
+  ) {
     return null;
   }
 
@@ -71,6 +84,27 @@ function getResponseStateId(chunk: unknown): string | null {
     candidate.response_id.length > 0
     ? candidate.response_id
     : null;
+}
+
+function encodeResponseStateHeader(
+  payload: ResponseStateHeaderPayload,
+): string {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+function isApprovalContinuationRequest(
+  messages: Array<MessageCreate | ApprovalCreate>,
+): boolean {
+  if (messages.length !== 1) {
+    return false;
+  }
+
+  const [message] = messages;
+  return (
+    Boolean(message) &&
+    (message as { type?: unknown }).type === "approval" &&
+    Array.isArray((message as { approvals?: unknown }).approvals)
+  );
 }
 
 function attachResponseStateTracking(
@@ -290,7 +324,11 @@ export async function sendMessageStreamWithBackend(
     resolvedConversationId,
     opts.agentId ?? null,
   );
-  const previousResponseId = responseStateIdsByScope.get(responseStateScope);
+  const isApprovalContinuation =
+    isApprovalContinuationRequest(normalizedMessages);
+  const previousResponseId = isApprovalContinuation
+    ? responseStateIdsByScope.get(responseStateScope)
+    : undefined;
   const requestBody = buildConversationMessagesCreateRequestBody(
     conversationId,
     normalizedMessages,
@@ -333,15 +371,25 @@ export async function sendMessageStreamWithBackend(
   if (process.env.LETTA_RESPONSES_WS === "1") {
     extraHeaders["X-Experimental-OpenAI-Responses-Websocket"] = "true";
   }
+  extraHeaders[RESPONSE_STATE_HEADER] = encodeResponseStateHeader({
+    v: 1,
+    cache_scope: RESPONSE_STATE_CACHE_SCOPE,
+    client_tool_context_id: contextId,
+    ...(previousResponseId ? { previous_response_id: previousResponseId } : {}),
+  });
   if (previousResponseId) {
-    extraHeaders[PREVIOUS_RESPONSE_ID_HEADER] = previousResponseId;
+    responseStateIdsByScope.delete(responseStateScope);
     debugLog(
       "response-state",
-      "sending previous_response_id=%s conversation_id=%s agent_id=%s",
+      "sending previous_response_id=%s cache_scope=%s conversation_id=%s agent_id=%s tool_context_id=%s",
       previousResponseId,
+      RESPONSE_STATE_CACHE_SCOPE,
       resolvedConversationId,
       opts.agentId ?? "none",
+      contextId,
     );
+  } else if (!isApprovalContinuation) {
+    responseStateIdsByScope.delete(responseStateScope);
   }
   // Echo the cloud user id back to cloud-api so it can re-attribute
   // credits + rate limits on multi-user sandboxes. See

--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -33,6 +33,8 @@ import { getSkillSources } from "./context";
 
 const streamRequestStartTimes = new WeakMap<object, number>();
 const streamToolContextIds = new WeakMap<object, string>();
+const PREVIOUS_RESPONSE_ID_HEADER = "X-Letta-Previous-Response-Id";
+const responseStateIdsByScope = new Map<string, string>();
 
 export type StreamRequestContext = {
   conversationId: string;
@@ -42,6 +44,90 @@ export type StreamRequestContext = {
   otid?: string;
 };
 const streamRequestContexts = new WeakMap<object, StreamRequestContext>();
+
+type ResponseStateChunk = {
+  message_type?: unknown;
+  response_id?: unknown;
+};
+
+function buildResponseStateScope(
+  conversationId: string,
+  agentId: string | null | undefined,
+): string {
+  return agentId ? `${conversationId}:${agentId}` : conversationId;
+}
+
+function getResponseStateId(chunk: unknown): string | null {
+  if (typeof chunk !== "object" || chunk === null) {
+    return null;
+  }
+
+  const candidate = chunk as ResponseStateChunk;
+  if (candidate.message_type !== "response_state") {
+    return null;
+  }
+
+  return typeof candidate.response_id === "string" &&
+    candidate.response_id.length > 0
+    ? candidate.response_id
+    : null;
+}
+
+function attachResponseStateTracking(
+  stream: Stream<LettaStreamingResponse>,
+  params: {
+    scope: string;
+    conversationId: string;
+    agentId: string | null;
+  },
+): Stream<LettaStreamingResponse> {
+  const originalAsyncIterator = stream[Symbol.asyncIterator].bind(stream);
+  const streamWithIterator = stream as Stream<LettaStreamingResponse> & {
+    [Symbol.asyncIterator]: () => AsyncIterator<LettaStreamingResponse>;
+  };
+
+  streamWithIterator[Symbol.asyncIterator] = () => {
+    const iterator = originalAsyncIterator();
+
+    return {
+      async next() {
+        const result = await iterator.next();
+        if (!result.done) {
+          const responseId = getResponseStateId(result.value);
+          if (responseId) {
+            responseStateIdsByScope.set(params.scope, responseId);
+            debugLog(
+              "response-state",
+              "received response_id=%s conversation_id=%s agent_id=%s",
+              responseId,
+              params.conversationId,
+              params.agentId ?? "none",
+            );
+          }
+        }
+
+        return result;
+      },
+      return(value?: unknown) {
+        if (iterator.return) {
+          return iterator.return(value);
+        }
+        return Promise.resolve({
+          done: true as const,
+          value: value as LettaStreamingResponse,
+        });
+      },
+      throw(error?: unknown) {
+        if (iterator.throw) {
+          return iterator.throw(error);
+        }
+        return Promise.reject(error);
+      },
+    };
+  };
+
+  return stream;
+}
 
 export function getStreamRequestStartTime(
   stream: Stream<LettaStreamingResponse>,
@@ -200,6 +286,11 @@ export async function sendMessageStreamWithBackend(
     });
 
   const resolvedConversationId = conversationId;
+  const responseStateScope = buildResponseStateScope(
+    resolvedConversationId,
+    opts.agentId ?? null,
+  );
+  const previousResponseId = responseStateIdsByScope.get(responseStateScope);
   const requestBody = buildConversationMessagesCreateRequestBody(
     conversationId,
     normalizedMessages,
@@ -241,6 +332,16 @@ export async function sendMessageStreamWithBackend(
   const extraHeaders: Record<string, string> = {};
   if (process.env.LETTA_RESPONSES_WS === "1") {
     extraHeaders["X-Experimental-OpenAI-Responses-Websocket"] = "true";
+  }
+  if (previousResponseId) {
+    extraHeaders[PREVIOUS_RESPONSE_ID_HEADER] = previousResponseId;
+    debugLog(
+      "response-state",
+      "sending previous_response_id=%s conversation_id=%s agent_id=%s",
+      previousResponseId,
+      resolvedConversationId,
+      opts.agentId ?? "none",
+    );
   }
   // Echo the cloud user id back to cloud-api so it can re-attribute
   // credits + rate limits on multi-user sandboxes. See
@@ -294,6 +395,11 @@ export async function sendMessageStreamWithBackend(
         },
       },
     );
+    stream = attachResponseStateTracking(stream, {
+      scope: responseStateScope,
+      conversationId: resolvedConversationId,
+      agentId: opts.agentId ?? null,
+    });
   } catch (error) {
     abortRelay?.cleanup();
     debugWarn(

--- a/src/agent/send-message-stream-acting-user.test.ts
+++ b/src/agent/send-message-stream-acting-user.test.ts
@@ -49,7 +49,7 @@ describe("sendMessageStream acting-user header propagation (contract)", () => {
     expect(source).toMatch(/headers:\s*\{[\s\S]*?\.\.\.extraHeaders[\s\S]*?\}/);
   });
 
-  test("response-state header carries previous id only for unrestricted approval continuations", () => {
+  test("response-state header carries previous id only for explicitly allowed approval continuations", () => {
     expect(source).toContain(
       'const RESPONSE_STATE_HEADER = "X-Letta-Response-State"',
     );
@@ -59,12 +59,8 @@ describe("sendMessageStream acting-user header propagation (contract)", () => {
     expect(source).toContain(
       "isApprovalContinuationRequest(normalizedMessages)",
     );
-    expect(source).toContain(
-      "opts.permissionModeState?.mode ?? permissionMode.getMode()",
-    );
-    expect(source).toContain(
-      'isApprovalContinuation && effectivePermissionMode === "unrestricted"',
-    );
+    expect(source).toContain("allowResponseStateReuse?: boolean;");
+    expect(source).toContain("opts.allowResponseStateReuse === true");
     expect(source).toMatch(
       /if \(previousResponseId\) \{[\s\S]*?extraHeaders\[RESPONSE_STATE_HEADER\] = encodeResponseStateHeader/,
     );

--- a/src/agent/send-message-stream-acting-user.test.ts
+++ b/src/agent/send-message-stream-acting-user.test.ts
@@ -48,4 +48,24 @@ describe("sendMessageStream acting-user header propagation (contract)", () => {
     // call's options.headers.
     expect(source).toMatch(/headers:\s*\{[\s\S]*?\.\.\.extraHeaders[\s\S]*?\}/);
   });
+
+  test("previous response id is forwarded when a response state was observed", () => {
+    expect(source).toContain(
+      'const PREVIOUS_RESPONSE_ID_HEADER = "X-Letta-Previous-Response-Id"',
+    );
+    expect(source).toContain(
+      "const previousResponseId = responseStateIdsByScope.get(responseStateScope)",
+    );
+    expect(source).toContain(
+      "extraHeaders[PREVIOUS_RESPONSE_ID_HEADER] = previousResponseId",
+    );
+  });
+
+  test("response state ids are captured from the stream", () => {
+    expect(source).toContain('candidate.message_type !== "response_state"');
+    expect(source).toContain(
+      "responseStateIdsByScope.set(params.scope, responseId)",
+    );
+    expect(source).toContain("stream = attachResponseStateTracking(stream");
+  });
 });

--- a/src/agent/send-message-stream-acting-user.test.ts
+++ b/src/agent/send-message-stream-acting-user.test.ts
@@ -49,7 +49,7 @@ describe("sendMessageStream acting-user header propagation (contract)", () => {
     expect(source).toMatch(/headers:\s*\{[\s\S]*?\.\.\.extraHeaders[\s\S]*?\}/);
   });
 
-  test("response-state header carries previous id only for approval continuations", () => {
+  test("response-state header carries previous id only for unrestricted approval continuations", () => {
     expect(source).toContain(
       'const RESPONSE_STATE_HEADER = "X-Letta-Response-State"',
     );
@@ -58,6 +58,12 @@ describe("sendMessageStream acting-user header propagation (contract)", () => {
     );
     expect(source).toContain(
       "isApprovalContinuationRequest(normalizedMessages)",
+    );
+    expect(source).toContain(
+      "opts.permissionModeState?.mode ?? permissionMode.getMode()",
+    );
+    expect(source).toContain(
+      'isApprovalContinuation && effectivePermissionMode === "unrestricted"',
     );
     expect(source).toMatch(
       /if \(previousResponseId\) \{[\s\S]*?extraHeaders\[RESPONSE_STATE_HEADER\] = encodeResponseStateHeader/,

--- a/src/agent/send-message-stream-acting-user.test.ts
+++ b/src/agent/send-message-stream-acting-user.test.ts
@@ -59,8 +59,8 @@ describe("sendMessageStream acting-user header propagation (contract)", () => {
     expect(source).toContain(
       "isApprovalContinuationRequest(normalizedMessages)",
     );
-    expect(source).toContain(
-      "extraHeaders[RESPONSE_STATE_HEADER] = encodeResponseStateHeader",
+    expect(source).toMatch(
+      /if \(previousResponseId\) \{[\s\S]*?extraHeaders\[RESPONSE_STATE_HEADER\] = encodeResponseStateHeader/,
     );
     expect(source).not.toContain("client_tool_context_id");
     expect(source).toContain("previous_response_id: previousResponseId");

--- a/src/agent/send-message-stream-acting-user.test.ts
+++ b/src/agent/send-message-stream-acting-user.test.ts
@@ -49,20 +49,31 @@ describe("sendMessageStream acting-user header propagation (contract)", () => {
     expect(source).toMatch(/headers:\s*\{[\s\S]*?\.\.\.extraHeaders[\s\S]*?\}/);
   });
 
-  test("previous response id is forwarded when a response state was observed", () => {
+  test("response-state header carries tool context and previous id only for approval continuations", () => {
     expect(source).toContain(
-      'const PREVIOUS_RESPONSE_ID_HEADER = "X-Letta-Previous-Response-Id"',
+      'const RESPONSE_STATE_HEADER = "X-Letta-Response-State"',
     );
     expect(source).toContain(
-      "const previousResponseId = responseStateIdsByScope.get(responseStateScope)",
+      'const RESPONSE_STATE_CACHE_SCOPE = "approval_boundary"',
     );
     expect(source).toContain(
-      "extraHeaders[PREVIOUS_RESPONSE_ID_HEADER] = previousResponseId",
+      "isApprovalContinuationRequest(normalizedMessages)",
+    );
+    expect(source).toContain(
+      "extraHeaders[RESPONSE_STATE_HEADER] = encodeResponseStateHeader",
+    );
+    expect(source).toContain("client_tool_context_id: contextId");
+    expect(source).toContain("previous_response_id: previousResponseId");
+    expect(source).toContain(
+      "responseStateIdsByScope.delete(responseStateScope)",
     );
   });
 
-  test("response state ids are captured from the stream", () => {
+  test("approval-boundary response state ids are captured from the stream", () => {
     expect(source).toContain('candidate.message_type !== "response_state"');
+    expect(source).toContain(
+      "candidate.cache_scope !== RESPONSE_STATE_CACHE_SCOPE",
+    );
     expect(source).toContain(
       "responseStateIdsByScope.set(params.scope, responseId)",
     );

--- a/src/agent/send-message-stream-acting-user.test.ts
+++ b/src/agent/send-message-stream-acting-user.test.ts
@@ -49,7 +49,7 @@ describe("sendMessageStream acting-user header propagation (contract)", () => {
     expect(source).toMatch(/headers:\s*\{[\s\S]*?\.\.\.extraHeaders[\s\S]*?\}/);
   });
 
-  test("response-state header carries tool context and previous id only for approval continuations", () => {
+  test("response-state header carries previous id only for approval continuations", () => {
     expect(source).toContain(
       'const RESPONSE_STATE_HEADER = "X-Letta-Response-State"',
     );
@@ -62,7 +62,7 @@ describe("sendMessageStream acting-user header propagation (contract)", () => {
     expect(source).toContain(
       "extraHeaders[RESPONSE_STATE_HEADER] = encodeResponseStateHeader",
     );
-    expect(source).toContain("client_tool_context_id: contextId");
+    expect(source).not.toContain("client_tool_context_id");
     expect(source).toContain("previous_response_id: previousResponseId");
     expect(source).toContain(
       "responseStateIdsByScope.delete(responseStateScope)",

--- a/src/cli/app/use-conversation-loop.ts
+++ b/src/cli/app/use-conversation-loop.ts
@@ -473,6 +473,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
         allowReentry?: boolean;
         submissionGeneration?: number;
         transcriptStartLineIndex?: number | null;
+        allowResponseStateReuse?: boolean;
       },
     ): Promise<void> => {
       // Transient pre-stream retries can yield for seconds.
@@ -850,6 +851,8 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
                 agentId: agentIdRef.current,
                 overrideModel: tempModelOverrideRef.current ?? undefined,
                 preparedToolContext: preparedToolContext.preparedToolContext,
+                allowResponseStateReuse:
+                  options?.allowResponseStateReuse === true,
               },
             );
             stream = nextStream;
@@ -2204,7 +2207,10 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
                       otid: randomUUID(),
                     },
                   ],
-                  { allowReentry: true },
+                  {
+                    allowReentry: true,
+                    allowResponseStateReuse: true,
+                  },
                 );
                 toolResultsInFlightRef.current = false;
                 return;

--- a/src/cli/helpers/stream-processor.ts
+++ b/src/cli/helpers/stream-processor.ts
@@ -72,6 +72,11 @@ export class StreamProcessor {
     if (chunk.message_type === "ping") {
       return { shouldOutput: false };
     }
+    if (
+      (chunk as { message_type?: string }).message_type === "response_state"
+    ) {
+      return { shouldOutput: false };
+    }
 
     // Detect mid-stream errors
     // Case 1: LettaErrorMessage from the API (has message_type: "error_message")

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -217,6 +217,7 @@ export async function handleApprovalStop(params: {
       permissionModeState: turnPermissionModeState,
       agentId,
     });
+  const continuationWasFullyAutoHandled = needsUserInput.length === 0;
 
   let pendingNeedsUserInput = [...needsUserInput];
   let lastNeedsUserInputToolCallIds = pendingNeedsUserInput.map(
@@ -556,7 +557,12 @@ export async function handleApprovalStop(params: {
     stream = await sendApprovalContinuationWithRetry(
       conversationId,
       nextInputWithSkillContent,
-      buildSendOptions(),
+      {
+        ...buildSendOptions(),
+        ...(continuationWasFullyAutoHandled
+          ? { allowResponseStateReuse: true }
+          : {}),
+      },
       socket,
       runtime,
       abortController.signal,


### PR DESCRIPTION
## Goal
Implement the letta-code side of approval-boundary response state reuse. The client should remember response-state ids emitted by tmp cloud and send the previous id back only on the next eligible approval continuation, so cloud can later reuse prepared approval-boundary context instead of rebuilding it from the DB.

This is intentionally scoped to the hot path we can reason about safely: pure approval continuations that were fully auto-handled by the client. That includes auto-allowed tool execution and auto-denied permission results, regardless of permission mode. If a human reviewed any approval, the client does not send the response-state header because the user-visible pause creates more opportunity for agent/conversation state to change.

## What changed
- Capture `response_state` SSE metadata chunks and store the latest `response_id` by conversation/agent scope.
- Suppress `response_state` metadata chunks from normal CLI output.
- Send `X-Letta-Response-State` only when there is an actual `previous_response_id` and the approval continuation was explicitly marked as fully auto-handled.
- Keep the header minimal: `v`, `cache_scope`, and `previous_response_id`; no client-local tool context id is sent.
- Clear stale response-state ids when leaving the eligible path so ids are not reused across non-approval or manually reviewed flows.

## Notes
- This PR is safe to publish before the cloud PR: older servers ignore the custom header, and if cloud does not emit `response_state`, the client sends nothing.
- Companion cloud PR: letta-ai/letta-cloud#12046.

## Tests
- `bun test src/agent/send-message-stream-acting-user.test.ts`
- `bun test src/cli/approval-classification.test.ts`
- `bun test src/websocket/listen-client-concurrency.test.ts --test-name-pattern \"approval continuation\"`
- `bun run typecheck`
- `bun run check:boundaries`
- commit hook: biome/lint-staged + typecheck