### PR TITLE
fix(tools): reject non-UTF-8 text mutations

### DIFF
--- a/src/tools/apply-patch.test.ts
+++ b/src/tools/apply-patch.test.ts
@@ -4,6 +4,13 @@ import { join } from "node:path";
 import { TestDirectory } from "@/test-utils/test-fs";
 import { apply_patch } from "@/tools/impl/apply-patch";
 
+function utf16leWithBom(content: string): Buffer {
+  return Buffer.concat([
+    Buffer.from([0xff, 0xfe]),
+    Buffer.from(content, "utf16le"),
+  ]);
+}
+
 describe("apply_patch tool", () => {
   let testDir: TestDirectory | undefined;
   let originalUserCwd: string | undefined;
@@ -107,6 +114,31 @@ describe("apply_patch tool", () => {
 
     const filePath = join(testDir.path, "module.py");
     expect(readFileSync(filePath, "utf-8")).toBe("import foo\nbar\n");
+  });
+
+  test("rejects UTF-16LE update targets without modifying them", async () => {
+    testDir = new TestDirectory();
+    originalUserCwd = process.env.USER_CWD;
+    process.env.USER_CWD = testDir.path;
+
+    const filePath = join(testDir.path, "utf16.md");
+    const original = utf16leWithBom("old\n");
+    writeFileSync(filePath, original);
+
+    await expect(
+      apply_patch({
+        input: `*** Begin Patch
+*** Update File: utf16.md
+@@
+-old
++new
+*** End Patch`,
+      }),
+    ).rejects.toThrow(
+      /Failed to read file to update utf16\.md: File is not valid UTF-8 text: .*Detected UTF-16LE BOM; convert the file to UTF-8 and retry\./,
+    );
+
+    expect(Buffer.compare(readFileSync(filePath), original)).toBe(0);
   });
 
   test("matches hunks with trailing whitespace tolerance", async () => {

--- a/src/tools/edit.test.ts
+++ b/src/tools/edit.test.ts
@@ -3,6 +3,13 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { TestDirectory } from "@/test-utils/test-fs";
 import { edit } from "@/tools/impl/edit";
 
+function utf16leWithBom(content: string): Buffer {
+  return Buffer.concat([
+    Buffer.from([0xff, 0xfe]),
+    Buffer.from(content, "utf16le"),
+  ]);
+}
+
 describe("Edit tool", () => {
   let testDir: TestDirectory;
 
@@ -120,6 +127,25 @@ describe("Edit tool", () => {
         new_string: "Bun",
       }),
     ).rejects.toThrow("old_string cannot be empty");
+  });
+
+  test("rejects UTF-16LE files without modifying them", async () => {
+    testDir = new TestDirectory();
+    const file = testDir.createFile("utf16.md", "");
+    const original = utf16leWithBom("hello\n");
+    writeFileSync(file, original);
+
+    await expect(
+      edit({
+        file_path: file,
+        old_string: "hello",
+        new_string: "goodbye",
+      }),
+    ).rejects.toThrow(
+      `File is not valid UTF-8 text: ${file}. Detected UTF-16LE BOM; convert the file to UTF-8 and retry.`,
+    );
+
+    expect(Buffer.compare(readFileSync(file), original)).toBe(0);
   });
 
   test("throws error when file_path is missing", async () => {

--- a/src/tools/impl/apply-patch.ts
+++ b/src/tools/impl/apply-patch.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
+import { readUtf8TextStrict, writeUtf8Text } from "@/utils/text-files";
 import { validateRequiredParams } from "./validation.js";
 
 interface ApplyPatchArgs {
@@ -77,7 +78,7 @@ export async function apply_patch(
       }
 
       const content = op.contentLines.map((line) => `${line}\n`).join("");
-      await fs.writeFile(targetPath, content, "utf8");
+      await writeUtf8Text(targetPath, content);
       affected.added.push(op.path);
       continue;
     }
@@ -108,7 +109,7 @@ export async function apply_patch(
       }
 
       try {
-        await fs.writeFile(destinationPath, newContents, "utf8");
+        await writeUtf8Text(destinationPath, newContents);
       } catch {
         throw new Error(`Failed to write file ${op.toPath}`);
       }
@@ -122,7 +123,7 @@ export async function apply_patch(
       affected.modified.push(op.toPath);
     } else {
       try {
-        await fs.writeFile(sourcePath, newContents, "utf8");
+        await writeUtf8Text(sourcePath, newContents);
       } catch {
         throw new Error(`Failed to write file ${op.fromPath}`);
       }
@@ -415,7 +416,7 @@ async function deriveNewContentsFromChunks(
 ): Promise<string> {
   let originalContents = "";
   try {
-    originalContents = await fs.readFile(absolutePath, "utf8");
+    originalContents = await readUtf8TextStrict(absolutePath);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(

--- a/src/tools/impl/edit.ts
+++ b/src/tools/impl/edit.ts
@@ -1,6 +1,6 @@
-import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
+import { readUtf8TextStrict, writeUtf8Text } from "@/utils/text-files";
 import { validateRequiredParams } from "./validation.js";
 
 interface EditArgs {
@@ -149,7 +149,7 @@ export async function edit(args: EditArgs): Promise<EditResult> {
       "No changes to make: old_string and new_string are exactly the same.",
     );
   try {
-    const rawContent = await fs.readFile(resolvedPath, "utf-8");
+    const rawContent = await readUtf8TextStrict(resolvedPath);
     // Normalize line endings to LF for consistent matching (Windows uses CRLF)
     const content = rawContent.replace(/\r\n/g, "\n");
     let occurrences = countOccurrences(content, old_string);
@@ -208,7 +208,7 @@ export async function edit(args: EditArgs): Promise<EditResult> {
         content.substring(index + finalOldString.length);
       replacements = 1;
     }
-    await fs.writeFile(resolvedPath, newContent, "utf-8");
+    await writeUtf8Text(resolvedPath, newContent);
 
     return {
       message: `Successfully replaced ${replacements} occurrence${replacements !== 1 ? "s" : ""} in ${resolvedPath}`,

--- a/src/tools/impl/memory-apply-patch.ts
+++ b/src/tools/impl/memory-apply-patch.ts
@@ -1,13 +1,5 @@
 import { existsSync } from "node:fs";
-import {
-  access,
-  mkdir,
-  readFile,
-  rm,
-  stat,
-  unlink,
-  writeFile,
-} from "node:fs/promises";
+import { access, mkdir, rm, stat, unlink } from "node:fs/promises";
 import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { getCurrentAgentId } from "@/agent/context";
 import { resolveScopedMemoryDir } from "@/agent/memory-filesystem";
@@ -16,6 +8,7 @@ import {
   commitAndSyncMemoryWrite,
   type MemoryWriteSyncMode,
 } from "@/agent/memory-git";
+import { readUtf8TextStrict, writeUtf8Text } from "@/utils/text-files";
 import { validateRequiredParams } from "./validation";
 
 type ParsedPatchOp =
@@ -207,7 +200,7 @@ async function applyMemoryPatch(
       return pending;
     }
 
-    const content = await readFile(absPath, "utf8").catch((error) => {
+    const content = await readUtf8TextStrict(absPath).catch((error) => {
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(
         `memory_apply_patch: failed to read ${sourcePathForErrors}: ${message}`,
@@ -290,7 +283,7 @@ async function applyMemoryPatch(
 
   for (const [absPath, content] of pendingWrites.entries()) {
     await mkdir(dirname(absPath), { recursive: true });
-    await writeFile(absPath, content, "utf8");
+    await writeUtf8Text(absPath, content);
   }
 
   for (const absPath of pendingDeletes) {
@@ -643,7 +636,7 @@ async function loadEditableMemoryFile(
   filePath: string,
   sourcePath: string,
 ): Promise<ParsedMemoryFile> {
-  const content = await readFile(filePath, "utf8").catch((error) => {
+  const content = await readUtf8TextStrict(filePath).catch((error) => {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(
       `memory_apply_patch: failed to read ${sourcePath}: ${message}`,

--- a/src/tools/impl/multi-edit.ts
+++ b/src/tools/impl/multi-edit.ts
@@ -1,6 +1,6 @@
-import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
+import { readUtf8TextStrict, writeUtf8Text } from "@/utils/text-files";
 import { validateRequiredParams } from "./validation.js";
 
 interface Edit {
@@ -49,7 +49,7 @@ export async function multi_edit(
       );
   }
   try {
-    const rawContent = await fs.readFile(resolvedPath, "utf-8");
+    const rawContent = await readUtf8TextStrict(resolvedPath);
     // Normalize line endings to LF for consistent matching (Windows uses CRLF)
     let content = rawContent.replace(/\r\n/g, "\n");
     const appliedEdits: EditWithLine[] = [];
@@ -86,7 +86,7 @@ export async function multi_edit(
         startLine,
       });
     }
-    await fs.writeFile(resolvedPath, content, "utf-8");
+    await writeUtf8Text(resolvedPath, content);
     const editList = appliedEdits
       .map((edit, i) => `${i + 1}. ${edit.description}`)
       .join("\n");

--- a/src/tools/impl/read-file-codex.ts
+++ b/src/tools/impl/read-file-codex.ts
@@ -1,4 +1,4 @@
-import { promises as fs } from "node:fs";
+import { readUtf8TextStrict } from "@/utils/text-files";
 import { validateRequiredParams } from "./validation.js";
 
 const MAX_LINE_LENGTH = 500;
@@ -81,7 +81,7 @@ async function readSliceMode(
   offset: number,
   limit: number,
 ): Promise<string[]> {
-  const content = await fs.readFile(filePath, "utf8");
+  const content = await readUtf8TextStrict(filePath);
   const allLines = content.split(/\r?\n/);
 
   const collected: string[] = [];
@@ -127,7 +127,7 @@ async function readIndentationMode(
   }
 
   // Read and parse all lines
-  const content = await fs.readFile(filePath, "utf8");
+  const content = await readUtf8TextStrict(filePath);
   const rawLines = content.split(/\r?\n/);
 
   if (rawLines.length === 0 || anchorLine > rawLines.length) {

--- a/src/tools/impl/read.ts
+++ b/src/tools/impl/read.ts
@@ -8,6 +8,7 @@ import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "@/constants";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
 import { debugLog } from "@/utils/debug.js";
 import { resizeImageIfNeeded } from "@/utils/image-resize.js";
+import { getUtf16Bom, readUtf8TextStrict } from "@/utils/text-files";
 import { OVERFLOW_CONFIG, writeOverflowFile } from "./overflow.js";
 import { LIMITS } from "./truncation.js";
 import { validateRequiredParams } from "./validation.js";
@@ -98,6 +99,7 @@ async function isBinaryFile(filePath: string): Promise<boolean> {
       const buffer = Buffer.alloc(bufferSize);
       const { bytesRead } = await fd.read(buffer, 0, bufferSize, 0);
       if (bytesRead === 0) return false;
+      if (getUtf16Bom(buffer.subarray(0, bytesRead))) return false;
 
       // Check for null bytes (definite binary indicator)
       for (let i = 0; i < bytesRead; i++) {
@@ -237,7 +239,7 @@ export async function read(args: ReadArgs): Promise<ReadResult> {
       );
     if (await isBinaryFile(resolvedPath))
       throw new Error(`Cannot read binary file: ${resolvedPath}`);
-    const content = await fs.readFile(resolvedPath, "utf-8");
+    const content = await readUtf8TextStrict(resolvedPath);
     if (content.trim() === "") {
       return {
         content: `${SYSTEM_REMINDER_OPEN}\nThe file ${resolvedPath} exists but has empty contents.\n${SYSTEM_REMINDER_CLOSE}`,

--- a/src/tools/impl/write.ts
+++ b/src/tools/impl/write.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
+import { writeUtf8Text } from "@/utils/text-files";
 import { validateRequiredParams } from "./validation.js";
 
 interface WriteArgs {
@@ -29,7 +30,7 @@ export async function write(args: WriteArgs): Promise<WriteResult> {
       const err = error as NodeJS.ErrnoException;
       if (err.code !== "ENOENT") throw err;
     }
-    await fs.writeFile(resolvedPath, content, "utf-8");
+    await writeUtf8Text(resolvedPath, content);
     return {
       message: `Successfully wrote ${content.length} characters to ${resolvedPath}`,
     };

--- a/src/tools/memory-apply-patch.test.ts
+++ b/src/tools/memory-apply-patch.test.ts
@@ -8,7 +8,7 @@ import {
   test,
 } from "bun:test";
 import { execFile as execFileCb } from "node:child_process";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -98,6 +98,13 @@ function runScopedMemoryApplyPatch(
   return runWithRuntimeContext({ agentId: TEST_AGENT_ID }, () =>
     memory_apply_patch(args),
   );
+}
+
+function utf16leWithBom(content: string): Buffer {
+  return Buffer.concat([
+    Buffer.from([0xff, 0xfe]),
+    Buffer.from(content, "utf16le"),
+  ]);
 }
 
 async function runGit(cwd: string, args: string[]): Promise<string> {
@@ -459,6 +466,36 @@ describe("memory_apply_patch tool", () => {
         ].join("\n"),
       }),
     ).rejects.toThrow(/read_only/i);
+  });
+
+  test("rejects UTF-16LE memory files without modifying them", async () => {
+    mkdirSync(join(memoryDir, "system"), { recursive: true });
+    const filePath = join(memoryDir, "system", "utf16.md");
+    const original = utf16leWithBom(
+      ["---", "description: UTF16", "---", "old"].join("\n"),
+    );
+    writeFileSync(filePath, original);
+    await runGit(memoryDir, ["add", "system/utf16.md"]);
+    await runGit(memoryDir, ["commit", "-m", "seed utf16 memory"]);
+    await runGit(memoryDir, ["push", "origin", "main"]);
+
+    await expect(
+      runScopedMemoryApplyPatch({
+        reason: "attempt edit utf16",
+        input: [
+          "*** Begin Patch",
+          "*** Update File: system/utf16.md",
+          "@@",
+          "-old",
+          "+new",
+          "*** End Patch",
+        ].join("\n"),
+      }),
+    ).rejects.toThrow(
+      /memory_apply_patch: failed to read system\/utf16\.md: File is not valid UTF-8 text: .*Detected UTF-16LE BOM; convert the file to UTF-8 and retry\./,
+    );
+
+    expect(Buffer.compare(readFileSync(filePath), original)).toBe(0);
   });
 
   test("returns error when push fails but keeps local commit", async () => {

--- a/src/utils/text-files.test.ts
+++ b/src/utils/text-files.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { TestDirectory } from "@/test-utils/test-fs";
+import {
+  decodeUtf8TextStrict,
+  readUtf8TextStrict,
+  writeUtf8Text,
+} from "@/utils/text-files";
+
+function utf16leWithBom(content: string): Buffer {
+  return Buffer.concat([
+    Buffer.from([0xff, 0xfe]),
+    Buffer.from(content, "utf16le"),
+  ]);
+}
+
+describe("text file helpers", () => {
+  let testDir: TestDirectory;
+
+  afterEach(() => {
+    testDir?.cleanup();
+  });
+
+  test("writes exact UTF-8 bytes without changing encoding", async () => {
+    testDir = new TestDirectory();
+    const file = testDir.resolve("unicode.txt");
+    const content = "café 漢字 😀";
+
+    await writeUtf8Text(file, content);
+
+    expect(
+      Buffer.compare(readFileSync(file), Buffer.from(content, "utf8")),
+    ).toBe(0);
+  });
+
+  test("strict read preserves UTF-8 BOM behavior", async () => {
+    testDir = new TestDirectory();
+    const file = testDir.createFile("bom.txt", "");
+    const content = Buffer.concat([
+      Buffer.from([0xef, 0xbb, 0xbf]),
+      Buffer.from("hello", "utf8"),
+    ]);
+    await Bun.write(file, content);
+
+    expect(await readUtf8TextStrict(file)).toBe("\ufeffhello");
+  });
+
+  test("strict decode rejects UTF-16LE BOM with stable error", () => {
+    const file = "/tmp/utf16.md";
+
+    expect(() => decodeUtf8TextStrict(utf16leWithBom("hello"), file)).toThrow(
+      `File is not valid UTF-8 text: ${file}. Detected UTF-16LE BOM; convert the file to UTF-8 and retry.`,
+    );
+  });
+
+  test("strict decode rejects invalid UTF-8 bytes with stable error", () => {
+    const file = "/tmp/invalid.txt";
+
+    expect(() => decodeUtf8TextStrict(Buffer.from([0xc3, 0x28]), file)).toThrow(
+      `File is not valid UTF-8 text: ${file}. The file contains bytes that cannot be decoded as UTF-8.`,
+    );
+  });
+});

--- a/src/utils/text-files.ts
+++ b/src/utils/text-files.ts
@@ -1,0 +1,54 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+const utf8Decoder = new TextDecoder("utf-8", {
+  fatal: true,
+  ignoreBOM: true,
+});
+
+export type Utf16Bom = "UTF-16LE" | "UTF-16BE";
+
+export function getUtf16Bom(bytes: Uint8Array): Utf16Bom | null {
+  if (bytes.length < 2) return null;
+  if (bytes[0] === 0xff && bytes[1] === 0xfe) return "UTF-16LE";
+  if (bytes[0] === 0xfe && bytes[1] === 0xff) return "UTF-16BE";
+  return null;
+}
+
+export function invalidUtf8TextFileMessage(
+  filePath: string,
+  detail?: Utf16Bom,
+): string {
+  if (detail) {
+    return `File is not valid UTF-8 text: ${filePath}. Detected ${detail} BOM; convert the file to UTF-8 and retry.`;
+  }
+
+  return `File is not valid UTF-8 text: ${filePath}. The file contains bytes that cannot be decoded as UTF-8.`;
+}
+
+export function decodeUtf8TextStrict(
+  bytes: Uint8Array,
+  filePath: string,
+): string {
+  const utf16Bom = getUtf16Bom(bytes);
+  if (utf16Bom) {
+    throw new Error(invalidUtf8TextFileMessage(filePath, utf16Bom));
+  }
+
+  try {
+    return utf8Decoder.decode(bytes);
+  } catch {
+    throw new Error(invalidUtf8TextFileMessage(filePath));
+  }
+}
+
+export async function readUtf8TextStrict(filePath: string): Promise<string> {
+  const bytes = await readFile(filePath);
+  return decodeUtf8TextStrict(bytes, filePath);
+}
+
+export async function writeUtf8Text(
+  filePath: string,
+  content: string,
+): Promise<void> {
+  await writeFile(filePath, Buffer.from(content, "utf8"));
+}

--- a/src/websocket/listener/file-commands.ts
+++ b/src/websocket/listener/file-commands.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import picomatch from "picomatch";
 import type WebSocket from "ws";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
+import { readUtf8TextStrict, writeUtf8Text } from "@/utils/text-files";
 import { runGrepInFiles } from "./grep-in-files";
 import {
   isEditFileCommand,
@@ -707,8 +708,7 @@ export function createFileCommandSession(params: {
       );
       runDetachedListenerTask("read_file", async () => {
         try {
-          const { readFile } = await import("node:fs/promises");
-          const content = await readFile(parsed.path, "utf-8");
+          const content = await readUtf8TextStrict(parsed.path);
           console.log(
             `[Listen] read_file success: ${parsed.path} (${content.length} bytes)`,
           );
@@ -760,14 +760,13 @@ export function createFileCommandSession(params: {
         try {
           const { edit } = await import("@/tools/impl/edit");
           const { write } = await import("@/tools/impl/write");
-          const { readFile } = await import("node:fs/promises");
 
           // Read current content so we can use edit for an atomic
           // read-modify-write that goes through the same code path as
           // the agent's Edit tool (CRLF normalisation, rich errors, etc.).
           let currentContent: string | null = null;
           try {
-            currentContent = await readFile(parsed.path, "utf-8");
+            currentContent = await readUtf8TextStrict(parsed.path);
           } catch (readErr) {
             const e = readErr as NodeJS.ErrnoException;
             if (e.code !== "ENOENT") throw readErr;
@@ -923,7 +922,6 @@ export function createFileCommandSession(params: {
       );
       runDetachedListenerTask("edit_file", async () => {
         try {
-          const { readFile } = await import("node:fs/promises");
           const { edit } = await import("@/tools/impl/edit");
 
           console.log(
@@ -942,7 +940,7 @@ export function createFileCommandSession(params: {
           // Notify web clients of the new content so they can update live.
           if (result.replacements > 0) {
             try {
-              const contentAfter = await readFile(parsed.file_path, "utf-8");
+              const contentAfter = await readUtf8TextStrict(parsed.file_path);
               safeSocketSend(
                 socket,
                 {
@@ -1010,9 +1008,8 @@ export function createFileCommandSession(params: {
       if (parsed.document_content !== undefined) {
         runDetachedListenerTask("file_ops", async () => {
           try {
-            const { writeFile } = await import("node:fs/promises");
             const content = parsed.document_content as string;
-            await writeFile(parsed.path, content, "utf-8");
+            await writeUtf8Text(parsed.path, content);
             console.log(
               `[Listen] file_ops: wrote ${content.length} bytes to ${parsed.path}`,
             );


### PR DESCRIPTION
## Summary

- Adds shared strict UTF-8 text helpers that preserve UTF-8 BOM behavior, reject UTF-16 BOMs with a clear error, and write explicit UTF-8 bytes.
- Routes text mutation/read-before-write paths through those helpers for Edit, MultiEdit, Write, apply_patch, memory_apply_patch, Codex read_file, Read, and listener file commands.
- Adds regression coverage ensuring UTF-16LE targets fail without modification and UTF-8 writes produce exact UTF-8 bytes.
- Validated with `bun run check` plus focused unit tests for the affected tool/listener paths.
