### PR TITLE
fix(tools): align PowerShell launcher with Codex

### DIFF
--- a/src/tools/exec-command.test.ts
+++ b/src/tools/exec-command.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   __clearExecSessionsForTests,
   exec_command,
@@ -49,6 +51,40 @@ describe.skipIf(isWindows)("Codex unified exec tools", () => {
     expect(result.output).toContain("Original token count:");
     expect(result.output).toContain("Output:\nhello");
     expect(result.output).not.toContain("Process running with session ID");
+  });
+
+  test("falls back to available Windows PowerShell when pwsh is unavailable", async () => {
+    const tempDir = fs.mkdtempSync(join(tmpdir(), "letta-exec-win-shell-"));
+    const fakePowerShell = join(tempDir, "powershell");
+    fs.writeFileSync(fakePowerShell, "#!/bin/sh\nprintf fake-powershell\n");
+    fs.chmodSync(fakePowerShell, 0o755);
+
+    const originalPlatform = Object.getOwnPropertyDescriptor(
+      process,
+      "platform",
+    );
+    const originalPath = process.env.PATH;
+    const originalPathext = process.env.PATHEXT;
+
+    Object.defineProperty(process, "platform", { value: "win32" });
+    process.env.PATH = tempDir;
+    delete process.env.PATHEXT;
+
+    try {
+      const result = await exec_command({ cmd: "ignored" });
+
+      expect(result.output).toContain("Process exited with code 0");
+      expect(result.output).toContain("Output:\nfake-powershell");
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, "platform", originalPlatform);
+      }
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+      if (originalPathext === undefined) delete process.env.PATHEXT;
+      else process.env.PATHEXT = originalPathext;
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   test("returns session id for running command and write_stdin polls it", async () => {

--- a/src/tools/impl/exec-command.ts
+++ b/src/tools/impl/exec-command.ts
@@ -1,4 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { delimiter, isAbsolute, join } from "node:path";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
 import { noteExpectedWorktreeForLauncher } from "@/websocket/listener/worktree-ownership";
 import {
@@ -391,6 +393,73 @@ function buildExecLaunchers(args: ExecCommandArgs): string[][] {
   });
 }
 
+function pathEnvValue(env: NodeJS.ProcessEnv): string {
+  return env.PATH ?? env.Path ?? env.path ?? "";
+}
+
+function pathExtValue(env: NodeJS.ProcessEnv): string {
+  return env.PATHEXT ?? env.PathExt ?? ".COM;.EXE;.BAT;.CMD";
+}
+
+function hasPathSeparator(executable: string): boolean {
+  return executable.includes("/") || executable.includes("\\");
+}
+
+function hasFileExtension(executable: string): boolean {
+  const basename = executable.split(/[\\/]/).pop() ?? executable;
+  return /\.[^.]+$/.test(basename);
+}
+
+function resolveExecutablePath(
+  executable: string,
+  env: NodeJS.ProcessEnv,
+): string | null {
+  if (isAbsolute(executable) || hasPathSeparator(executable)) {
+    return existsSync(executable) ? executable : null;
+  }
+
+  const pathDelimiter = process.platform === "win32" ? ";" : delimiter;
+  const pathEntries = pathEnvValue(env).split(pathDelimiter).filter(Boolean);
+  const executableNames = [executable];
+  if (process.platform === "win32" && !hasFileExtension(executable)) {
+    for (const extension of pathExtValue(env).split(";").filter(Boolean)) {
+      executableNames.push(`${executable}${extension}`);
+    }
+  }
+
+  for (const entry of pathEntries) {
+    for (const name of executableNames) {
+      const candidate = join(entry, name);
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
+}
+
+function selectExecLauncher(
+  launchers: string[][],
+  env: NodeJS.ProcessEnv,
+): string[] | undefined {
+  if (process.platform !== "win32") {
+    return launchers[0];
+  }
+
+  for (const launcher of launchers) {
+    const executable = launcher[0];
+    if (!executable) continue;
+
+    const resolvedExecutable = resolveExecutablePath(executable, env);
+    if (resolvedExecutable) {
+      return [resolvedExecutable, ...launcher.slice(1)];
+    }
+  }
+
+  return launchers.at(-1);
+}
+
 function buildPtyEnv(env: NodeJS.ProcessEnv): Record<string, string> {
   const ptyEnv: Record<string, string> = {};
   for (const [key, value] of Object.entries(env)) {
@@ -644,7 +713,7 @@ async function startExecSession(args: ExecCommandArgs): Promise<ExecSession> {
   const cwd = resolveShellWorkdir(args.workdir);
   const env = { ...getShellEnv(), ...(args.secretEnv ?? {}) };
   const launchers = buildExecLaunchers(args);
-  const launcher = launchers[0];
+  const launcher = selectExecLauncher(launchers, env);
   if (!launcher) {
     throw new Error("Command must be a non-empty string");
   }

--- a/src/tools/impl/shell-env.ts
+++ b/src/tools/impl/shell-env.ts
@@ -53,6 +53,10 @@ function getPackageNodeModulesDir(): string | undefined {
   }
 }
 
+function shellPathDelimiter(): string {
+  return process.platform === "win32" ? ";" : path.delimiter;
+}
+
 interface LettaInvocation {
   command: string;
   args: string[];
@@ -319,8 +323,8 @@ export function getShellEnv(): NodeJS.ProcessEnv {
   if (pathPrefixes.length > 0) {
     const existingPath = env[pathKey] || "";
     env[pathKey] = existingPath
-      ? `${pathPrefixes.join(path.delimiter)}${path.delimiter}${existingPath}`
-      : pathPrefixes.join(path.delimiter);
+      ? `${pathPrefixes.join(shellPathDelimiter())}${shellPathDelimiter()}${existingPath}`
+      : pathPrefixes.join(shellPathDelimiter());
   }
 
   env.USER_CWD = getCurrentWorkingDirectory();
@@ -429,7 +433,7 @@ export function getShellEnv(): NodeJS.ProcessEnv {
   if (nodeModulesDir) {
     const currentNodePath = env.NODE_PATH || "";
     env.NODE_PATH = currentNodePath
-      ? `${nodeModulesDir}${path.delimiter}${currentNodePath}`
+      ? `${nodeModulesDir}${shellPathDelimiter()}${currentNodePath}`
       : nodeModulesDir;
   }
 

--- a/src/tools/impl/shell-launchers.ts
+++ b/src/tools/impl/shell-launchers.ts
@@ -7,6 +7,8 @@ type ShellLaunchOptions = {
 
 export const STRICT_SHELL_ENV_VAR = "LETTA_BASH_STRICT";
 export const STRICT_SHELL_PRELUDE = "set -euo pipefail";
+export const POWERSHELL_UTF8_OUTPUT_PREFIX =
+  "try { [Console]::OutputEncoding=[System.Text.Encoding]::UTF8 } catch {}\n";
 
 const POWERSHELL_ENV_ALIASES = [
   "MEMORY_DIR",
@@ -18,6 +20,10 @@ const POWERSHELL_ENV_ALIASES = [
   "LETTA_CONVERSATION_ID",
   "USER_CWD",
 ];
+
+const WINDOWS_PWSH_FALLBACK_PATH = "C:\\Program Files\\PowerShell\\7\\pwsh.exe";
+const WINDOWS_POWERSHELL_FALLBACK_PATH =
+  "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
 
 function isValidEnvAlias(name: string): boolean {
   return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name);
@@ -60,18 +66,40 @@ function normalizePowerShellCommand(command: string): string {
   return trimmed;
 }
 
+function prefixPowerShellCommandWithUtf8Output(command: string): string {
+  const trimmed = command.trimStart();
+  if (trimmed.startsWith(POWERSHELL_UTF8_OUTPUT_PREFIX)) {
+    return command;
+  }
+  return `${POWERSHELL_UTF8_OUTPUT_PREFIX}${command}`;
+}
+
+function stripPowerShellUtf8OutputPrefix(command: string): string {
+  const trimmed = command.trimStart();
+  if (!trimmed.startsWith(POWERSHELL_UTF8_OUTPUT_PREFIX)) {
+    return command;
+  }
+
+  const leadingWhitespace = command.slice(0, command.length - trimmed.length);
+  return `${leadingWhitespace}${trimmed.slice(POWERSHELL_UTF8_OUTPUT_PREFIX.length)}`;
+}
+
 export function buildPowerShellCommand(
   command: string,
   envAliases: string[] = [],
 ): string {
-  const powerShellCommand = normalizePowerShellCommand(command);
+  const powerShellCommand = stripPowerShellUtf8OutputPrefix(
+    normalizePowerShellCommand(command),
+  );
   const aliases = [
     ...new Set([...POWERSHELL_ENV_ALIASES, ...envAliases]),
   ].filter(isValidEnvAlias);
   const aliasPrelude = aliases
     .map((name) => `$${name} = $env:${name}`)
     .join("; ");
-  return `${aliasPrelude}; ${powerShellCommand}`;
+  return prefixPowerShellCommandWithUtf8Output(
+    `${aliasPrelude}; ${powerShellCommand}`,
+  );
 }
 
 function windowsLaunchers(
@@ -84,17 +112,28 @@ function windowsLaunchers(
   const seen = new Set<string>();
   const powerShellCommand = buildPowerShellCommand(trimmed, envAliases);
 
-  // Default to PowerShell on Windows (same as Gemini CLI and Codex CLI)
-  // This ensures better PATH compatibility since many tools are configured
-  // in PowerShell profiles rather than system-wide cmd.exe PATH
+  // Match Codex's PowerShell order: prefer PowerShell Core (`pwsh`) when
+  // available, then fall back to Windows PowerShell.
   pushUnique(launchers, seen, [
-    "powershell.exe",
+    "pwsh",
     "-NoProfile",
     "-Command",
     powerShellCommand,
   ]);
   pushUnique(launchers, seen, [
-    "pwsh",
+    WINDOWS_PWSH_FALLBACK_PATH,
+    "-NoProfile",
+    "-Command",
+    powerShellCommand,
+  ]);
+  pushUnique(launchers, seen, [
+    "powershell",
+    "-NoProfile",
+    "-Command",
+    powerShellCommand,
+  ]);
+  pushUnique(launchers, seen, [
+    WINDOWS_POWERSHELL_FALLBACK_PATH,
     "-NoProfile",
     "-Command",
     powerShellCommand,

--- a/src/tools/impl/shell-launchers.ts
+++ b/src/tools/impl/shell-launchers.ts
@@ -139,12 +139,7 @@ function windowsLaunchers(
     powerShellCommand,
   ]);
 
-  // Fall back to cmd.exe if PowerShell fails
-  const envComSpecRaw = process.env.ComSpec || process.env.COMSPEC;
-  const envComSpec = envComSpecRaw?.trim();
-  if (envComSpec) {
-    pushUnique(launchers, seen, [envComSpec, "/d", "/s", "/c", trimmed]);
-  }
+  // Fall back to cmd.exe if PowerShell fails.
   pushUnique(launchers, seen, ["cmd.exe", "/d", "/s", "/c", trimmed]);
 
   return launchers;

--- a/src/tools/shell-launchers.test.ts
+++ b/src/tools/shell-launchers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildPowerShellCommand,
   buildShellLaunchers,
+  POWERSHELL_UTF8_OUTPUT_PREFIX,
 } from "@/tools/impl/shell-launchers";
 
 describe("Shell Launchers", () => {
@@ -29,6 +30,23 @@ describe("Shell Launchers", () => {
     expect(command).toContain("$AGENT_ID = $env:AGENT_ID");
     expect(command).toContain("$CONVERSATION_ID = $env:CONVERSATION_ID");
     expect(command.endsWith('ls "$MEMORY_DIR/system/human/"')).toBe(true);
+    expect(command.startsWith(POWERSHELL_UTF8_OUTPUT_PREFIX)).toBe(true);
+  });
+
+  test("PowerShell command uses Codex UTF-8 output prefix", () => {
+    const command = buildPowerShellCommand("Write-Host hi");
+
+    expect(command.startsWith(POWERSHELL_UTF8_OUTPUT_PREFIX)).toBe(true);
+    expect(command.endsWith("Write-Host hi")).toBe(true);
+  });
+
+  test("PowerShell command does not duplicate Codex UTF-8 output prefix", () => {
+    const command = buildPowerShellCommand(
+      `${POWERSHELL_UTF8_OUTPUT_PREFIX}Write-Host hi`,
+    );
+
+    expect(command.split(POWERSHELL_UTF8_OUTPUT_PREFIX)).toHaveLength(2);
+    expect(command.endsWith("Write-Host hi")).toBe(true);
   });
 
   test("PowerShell command preserves quoted executable invocation", () => {
@@ -39,6 +57,35 @@ describe("Shell Launchers", () => {
     expect(
       command.endsWith('& "C:/Program Files/Git/bin/git.exe" status'),
     ).toBe(true);
+  });
+
+  test("Windows launchers match Codex PowerShell order", () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(
+      process,
+      "platform",
+    );
+    Object.defineProperty(process, "platform", { value: "win32" });
+
+    try {
+      const launchers = buildShellLaunchers("echo test");
+
+      expect(launchers[0]?.[0]).toBe("pwsh");
+      expect(launchers[1]?.[0]).toBe(
+        "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+      );
+      expect(launchers[2]?.[0]).toBe("powershell");
+      expect(launchers[3]?.[0]).toBe(
+        "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+      );
+      expect(launchers[0]?.at(-1)).toContain(POWERSHELL_UTF8_OUTPUT_PREFIX);
+      expect(launchers[1]?.at(-1)).toContain(POWERSHELL_UTF8_OUTPUT_PREFIX);
+      expect(launchers[2]?.at(-1)).toContain(POWERSHELL_UTF8_OUTPUT_PREFIX);
+      expect(launchers[3]?.at(-1)).toContain(POWERSHELL_UTF8_OUTPUT_PREFIX);
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, "platform", originalPlatform);
+      }
+    }
   });
 
   if (process.platform === "win32") {
@@ -62,6 +109,20 @@ describe("Shell Launchers", () => {
         expect(cmdIndex).toBeGreaterThanOrEqual(0);
         // PowerShell should come before cmd.exe
         expect(powershellIndex).toBeLessThan(cmdIndex);
+      });
+
+      test("pwsh is tried before Windows PowerShell", () => {
+        const launchers = buildShellLaunchers("echo test");
+        const pwshIndex = launchers.findIndex(
+          (l) => l[0]?.toLowerCase() === "pwsh",
+        );
+        const powershellIndex = launchers.findIndex((l) =>
+          l[0]?.toLowerCase().includes("powershell"),
+        );
+
+        expect(pwshIndex).toBeGreaterThanOrEqual(0);
+        expect(powershellIndex).toBeGreaterThanOrEqual(0);
+        expect(pwshIndex).toBeLessThan(powershellIndex);
       });
 
       test("includes PowerShell with -NoProfile flag", () => {

--- a/src/tools/shell-launchers.test.ts
+++ b/src/tools/shell-launchers.test.ts
@@ -77,6 +77,7 @@ describe("Shell Launchers", () => {
       expect(launchers[3]?.[0]).toBe(
         "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
       );
+      expect(launchers[4]?.[0]).toBe("cmd.exe");
       expect(launchers[0]?.at(-1)).toContain(POWERSHELL_UTF8_OUTPUT_PREFIX);
       expect(launchers[1]?.at(-1)).toContain(POWERSHELL_UTF8_OUTPUT_PREFIX);
       expect(launchers[2]?.at(-1)).toContain(POWERSHELL_UTF8_OUTPUT_PREFIX);

--- a/src/tools/shell-secrets.test.ts
+++ b/src/tools/shell-secrets.test.ts
@@ -2,7 +2,10 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { bash } from "@/tools/impl/bash";
 import { run_shell_command } from "@/tools/impl/run-shell-command-gemini";
 import { shell_command } from "@/tools/impl/shell-command.js";
-import { buildPowerShellCommand } from "@/tools/impl/shell-launchers";
+import {
+  buildPowerShellCommand,
+  POWERSHELL_UTF8_OUTPUT_PREFIX,
+} from "@/tools/impl/shell-launchers";
 import {
   executeTool,
   prepareToolExecutionContextForSpecificTools,
@@ -122,6 +125,7 @@ describe("shell secret execution", () => {
 
     expect(command).toContain("$API_KEY = $env:API_KEY");
     expect(command).not.toContain("BAD;Write-Output pwned");
+    expect(command.startsWith(POWERSHELL_UTF8_OUTPUT_PREFIX)).toBe(true);
     expect(command.endsWith("Write-Output $API_KEY")).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

- Aligns Windows PowerShell launcher order with Codex: `pwsh`, `C:\Program Files\PowerShell\7\pwsh.exe`, `powershell`, then `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`, before falling back to `cmd.exe`.
- Prefixes PowerShell scripts with the same Codex UTF-8 output guard: `try { [Console]::OutputEncoding=[System.Text.Encoding]::UTF8 } catch {}`.
- Keeps the prefix first in the script, preserves Letta env aliasing, and avoids duplicating the prefix if it is already present.
- Ensures unified `exec_command` resolves the available Windows shell before spawning, so missing `pwsh` falls through to Windows PowerShell like Codex instead of failing on the first launcher.
- Adds regression tests for the Codex launcher order, UTF-8 prefixing, de-duping, secret env aliasing, and unified exec fallback behavior.

Validation: `bun run check`; `bun test src/tools/shell-launchers.test.ts src/tools/shell-secrets.test.ts src/tools/exec-command.test.ts`.
