### PR TITLE
docs: add system prompt release note

### DIFF
--- a/src/release-notes-logic.test.ts
+++ b/src/release-notes-logic.test.ts
@@ -8,12 +8,14 @@ import {
 describe("release notes logic", () => {
   test("shows only the current version note when there is no seen checkpoint", () => {
     expect(getPendingReleaseNoteVersions("0.25.7")).toEqual(["0.25.7"]);
+    expect(getPendingReleaseNoteVersions("0.27.0")).toEqual(["0.27.0"]);
     expect(getPendingReleaseNoteVersions("0.25.8")).toEqual([]);
   });
 
   test("backfills skipped notes across a version range", () => {
-    expect(getPendingReleaseNoteVersions("0.25.9", "0.25.4")).toEqual([
+    expect(getPendingReleaseNoteVersions("0.27.0", "0.25.4")).toEqual([
       "0.25.7",
+      "0.27.0",
     ]);
   });
 

--- a/src/release-notes.ts
+++ b/src/release-notes.ts
@@ -18,7 +18,7 @@ export const releaseNotes: Record<string, string> = {
   // Add release notes for new versions here.
   // Keep concise - 3-4 bullet points max.
   // Use → for bullets to match the command hints below.
-  "0.27.0": `🧠 **Updated system prompt available**
+  "0.27.0": `🧠 **Updated default system prompt available**
 → Improves Letta Code's understanding of time and memory retrieval
 → Run **/system** to upgrade your agent to the latest prompt`,
   "0.25.7": `🔐 **Permissions update in Letta Code 0.25.7**

--- a/src/release-notes.ts
+++ b/src/release-notes.ts
@@ -18,6 +18,9 @@ export const releaseNotes: Record<string, string> = {
   // Add release notes for new versions here.
   // Keep concise - 3-4 bullet points max.
   // Use → for bullets to match the command hints below.
+  "0.27.0": `🧠 **Updated system prompt available**
+→ Improves Letta Code's understanding of time and memory retrieval
+→ Run **/system** to upgrade your agent to the latest prompt`,
   "0.25.7": `🔐 **Permissions update in Letta Code 0.25.7**
 → The default permission mode is now **unrestricted**, so Letta Code starts without approval prompts unless you change it
 → Run **/permissions** and choose **standard** if you want the old request-approval behavior back

--- a/src/release-notes.ts
+++ b/src/release-notes.ts
@@ -20,7 +20,7 @@ export const releaseNotes: Record<string, string> = {
   // Use → for bullets to match the command hints below.
   "0.27.0": `🧠 **Updated default system prompt available**
 → Improves Letta Code's understanding of time and memory retrieval
-→ Run **/system** to upgrade your agent to the latest prompt`,
+→ Run **/system** and select "Default" to upgrade your agent to the latest prompt`,
   "0.25.7": `🔐 **Permissions update in Letta Code 0.25.7**
 → The default permission mode is now **unrestricted**, so Letta Code starts without approval prompts unless you change it
 → Run **/permissions** and choose **standard** if you want the old request-approval behavior back


### PR DESCRIPTION
Adds a 0.27.0 release note telling users that the updated system prompt is available and that they can run `/system` to upgrade their agent to the latest prompt.

Validated with:
- `bun test src/release-notes-logic.test.ts`
- `bun run check`