### PR TITLE
fix(tools): reuse PowerShell fallback for background Bash

### DIFF
--- a/src/tools/bash.test.ts
+++ b/src/tools/bash.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { runWithRuntimeContext } from "@/runtime-context";
 import { bash } from "@/tools/impl/bash";
+import { backgroundProcesses } from "@/tools/impl/process_manager";
 
 async function runBashInTemp(
   command: string,
@@ -97,6 +98,85 @@ describe("Bash tool", () => {
 
     expect(result.content[0]?.text).toContain("background with ID:");
     expect(result.content[0]?.text).toMatch(/bash_\d+/);
+  });
+
+  test("background mode falls back to available Windows PowerShell when pwsh is unavailable", async () => {
+    if (process.platform === "win32") return;
+
+    const tempDir = await mkdtemp(path.join(tmpdir(), "letta-bash-win-bg-"));
+    const fakePowerShell = path.join(tempDir, "powershell");
+    await writeFile(
+      fakePowerShell,
+      "#!/bin/sh\nprintf fake-background-powershell\n",
+      {
+        mode: 0o755,
+      },
+    );
+
+    const originalPlatform = Object.getOwnPropertyDescriptor(
+      process,
+      "platform",
+    );
+    const originalPath = process.env.PATH;
+    const originalPathext = process.env.PATHEXT;
+    const startedIds: string[] = [];
+
+    Object.defineProperty(process, "platform", { value: "win32" });
+    process.env.PATH = tempDir;
+    delete process.env.PATHEXT;
+
+    try {
+      const result = await bash({
+        command: "ignored",
+        description: "Test Windows PowerShell fallback",
+        run_in_background: true,
+      });
+
+      expect(result.status).toBe("success");
+      const bashId = result.content[0]?.text.match(/bash_\d+/)?.[0];
+      expect(bashId).toBeDefined();
+      if (!bashId) throw new Error("Expected background Bash id");
+      startedIds.push(bashId);
+
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        const processEntry = backgroundProcesses.get(bashId);
+        if (
+          processEntry?.status !== "running" ||
+          processEntry?.stdout.join("\n").includes("fake-background-powershell")
+        ) {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+
+      const processEntry = backgroundProcesses.get(bashId);
+      expect(processEntry?.stdout.join("\n")).toContain(
+        "fake-background-powershell",
+      );
+      expect(processEntry?.exitCode).toBe(0);
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, "platform", originalPlatform);
+      }
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+      if (originalPathext === undefined) delete process.env.PATHEXT;
+      else process.env.PATHEXT = originalPathext;
+
+      for (const id of startedIds) {
+        const processEntry = backgroundProcesses.get(id);
+        try {
+          processEntry?.process.kill("SIGTERM");
+        } catch {
+          // Ignore already-completed processes.
+        }
+        if (processEntry?.outputFile) {
+          await rm(processEntry.outputFile, { force: true });
+        }
+        backgroundProcesses.delete(id);
+      }
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   test("handles complex commands with pipes", async () => {

--- a/src/tools/impl/bash.ts
+++ b/src/tools/impl/bash.ts
@@ -15,6 +15,7 @@ import {
 import { getShellEnv } from "./shell-env.js";
 import {
   buildShellLaunchers,
+  selectAvailableShellLauncher,
   withStrictShellPrelude,
 } from "./shell-launchers.js";
 import { spawnWithLauncher } from "./shell-runner.js";
@@ -50,6 +51,7 @@ function rebuildCachedLauncher(
  */
 function getBackgroundLauncher(
   command: string,
+  env: NodeJS.ProcessEnv,
   secretEnv?: Record<string, string>,
 ): string[] {
   const cachedLauncher = rebuildCachedLauncher(command, secretEnv);
@@ -58,7 +60,7 @@ function getBackgroundLauncher(
   const launchers = buildShellLaunchers(command, {
     powershellEnvAliases: secretEnv ? Object.keys(secretEnv) : undefined,
   });
-  return launchers[0] || [];
+  return selectAvailableShellLauncher(launchers, env) || [];
 }
 
 /**
@@ -232,7 +234,7 @@ export async function bash(args: BashArgs): Promise<BashResult> {
     const bgCommand = withStrictShellPrelude(command, bgEnv);
     const bashId = getNextBashId();
     const outputFile = createBackgroundOutputFile(bashId);
-    const launcher = getBackgroundLauncher(bgCommand, secretEnv);
+    const launcher = getBackgroundLauncher(bgCommand, bgEnv, secretEnv);
     const [executable, ...launcherArgs] = launcher;
     if (!executable) {
       return {

--- a/src/tools/impl/exec-command.ts
+++ b/src/tools/impl/exec-command.ts
@@ -1,6 +1,4 @@
 import { type ChildProcess, spawn } from "node:child_process";
-import { existsSync } from "node:fs";
-import { delimiter, isAbsolute, join } from "node:path";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
 import { noteExpectedWorktreeForLauncher } from "@/websocket/listener/worktree-ownership";
 import {
@@ -17,6 +15,7 @@ import { getShellEnv } from "./shell-env.js";
 import {
   buildPowerShellCommand,
   buildShellLaunchers,
+  selectAvailableShellLauncher,
 } from "./shell-launchers.js";
 import { truncateByChars } from "./truncation.js";
 import { validateRequiredParams } from "./validation.js";
@@ -393,73 +392,6 @@ function buildExecLaunchers(args: ExecCommandArgs): string[][] {
   });
 }
 
-function pathEnvValue(env: NodeJS.ProcessEnv): string {
-  return env.PATH ?? env.Path ?? env.path ?? "";
-}
-
-function pathExtValue(env: NodeJS.ProcessEnv): string {
-  return env.PATHEXT ?? env.PathExt ?? ".COM;.EXE;.BAT;.CMD";
-}
-
-function hasPathSeparator(executable: string): boolean {
-  return executable.includes("/") || executable.includes("\\");
-}
-
-function hasFileExtension(executable: string): boolean {
-  const basename = executable.split(/[\\/]/).pop() ?? executable;
-  return /\.[^.]+$/.test(basename);
-}
-
-function resolveExecutablePath(
-  executable: string,
-  env: NodeJS.ProcessEnv,
-): string | null {
-  if (isAbsolute(executable) || hasPathSeparator(executable)) {
-    return existsSync(executable) ? executable : null;
-  }
-
-  const pathDelimiter = process.platform === "win32" ? ";" : delimiter;
-  const pathEntries = pathEnvValue(env).split(pathDelimiter).filter(Boolean);
-  const executableNames = [executable];
-  if (process.platform === "win32" && !hasFileExtension(executable)) {
-    for (const extension of pathExtValue(env).split(";").filter(Boolean)) {
-      executableNames.push(`${executable}${extension}`);
-    }
-  }
-
-  for (const entry of pathEntries) {
-    for (const name of executableNames) {
-      const candidate = join(entry, name);
-      if (existsSync(candidate)) {
-        return candidate;
-      }
-    }
-  }
-
-  return null;
-}
-
-function selectExecLauncher(
-  launchers: string[][],
-  env: NodeJS.ProcessEnv,
-): string[] | undefined {
-  if (process.platform !== "win32") {
-    return launchers[0];
-  }
-
-  for (const launcher of launchers) {
-    const executable = launcher[0];
-    if (!executable) continue;
-
-    const resolvedExecutable = resolveExecutablePath(executable, env);
-    if (resolvedExecutable) {
-      return [resolvedExecutable, ...launcher.slice(1)];
-    }
-  }
-
-  return launchers.at(-1);
-}
-
 function buildPtyEnv(env: NodeJS.ProcessEnv): Record<string, string> {
   const ptyEnv: Record<string, string> = {};
   for (const [key, value] of Object.entries(env)) {
@@ -713,7 +645,7 @@ async function startExecSession(args: ExecCommandArgs): Promise<ExecSession> {
   const cwd = resolveShellWorkdir(args.workdir);
   const env = { ...getShellEnv(), ...(args.secretEnv ?? {}) };
   const launchers = buildExecLaunchers(args);
-  const launcher = selectExecLauncher(launchers, env);
+  const launcher = selectAvailableShellLauncher(launchers, env);
   if (!launcher) {
     throw new Error("Command must be a non-empty string");
   }

--- a/src/tools/impl/shell-launchers.ts
+++ b/src/tools/impl/shell-launchers.ts
@@ -1,3 +1,6 @@
+import { existsSync } from "node:fs";
+import { delimiter, isAbsolute, join } from "node:path";
+
 const SEP = "\u0000";
 type ShellLaunchOptions = {
   login?: boolean;
@@ -152,6 +155,73 @@ function shellCommandFlag(shellName: string, login: boolean): string {
     return "-lc";
   }
   return "-c";
+}
+
+function pathEnvValue(env: NodeJS.ProcessEnv): string {
+  return env.PATH ?? env.Path ?? env.path ?? "";
+}
+
+function pathExtValue(env: NodeJS.ProcessEnv): string {
+  return env.PATHEXT ?? env.PathExt ?? ".COM;.EXE;.BAT;.CMD";
+}
+
+function hasPathSeparator(executable: string): boolean {
+  return executable.includes("/") || executable.includes("\\");
+}
+
+function hasFileExtension(executable: string): boolean {
+  const basename = executable.split(/[\\/]/).pop() ?? executable;
+  return /\.[^.]+$/.test(basename);
+}
+
+function resolveExecutablePath(
+  executable: string,
+  env: NodeJS.ProcessEnv,
+): string | null {
+  if (isAbsolute(executable) || hasPathSeparator(executable)) {
+    return existsSync(executable) ? executable : null;
+  }
+
+  const pathDelimiter = process.platform === "win32" ? ";" : delimiter;
+  const pathEntries = pathEnvValue(env).split(pathDelimiter).filter(Boolean);
+  const executableNames = [executable];
+  if (process.platform === "win32" && !hasFileExtension(executable)) {
+    for (const extension of pathExtValue(env).split(";").filter(Boolean)) {
+      executableNames.push(`${executable}${extension}`);
+    }
+  }
+
+  for (const entry of pathEntries) {
+    for (const name of executableNames) {
+      const candidate = join(entry, name);
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function selectAvailableShellLauncher(
+  launchers: string[][],
+  env: NodeJS.ProcessEnv = process.env,
+): string[] | undefined {
+  if (process.platform !== "win32") {
+    return launchers[0];
+  }
+
+  for (const launcher of launchers) {
+    const executable = launcher[0];
+    if (!executable) continue;
+
+    const resolvedExecutable = resolveExecutablePath(executable, env);
+    if (resolvedExecutable) {
+      return [resolvedExecutable, ...launcher.slice(1)];
+    }
+  }
+
+  return launchers.at(-1);
 }
 
 function unixLaunchers(command: string, login: boolean): string[][] {


### PR DESCRIPTION
## Summary

- Centralizes Windows shell launcher resolution in `shell-launchers.ts` so shell tools share the same Codex-aligned PowerShell fallback selection.
- Updates background Bash to select an available launcher before spawning, instead of defaulting to the first launcher (`pwsh`) when no foreground shell has populated the cache.
- Keeps `exec_command` on the same shared resolver and adds coverage for background Bash falling through to Windows PowerShell when `pwsh` is unavailable.

Validation: `bun run check`; `bun test src/tools/bash.test.ts src/tools/exec-command.test.ts src/tools/shell-launchers.test.ts src/tools/shell-secrets.test.ts`.
