### PR TITLE
feat(agent): version managed system prompts

### DIFF
--- a/src/agent/create.ts
+++ b/src/agent/create.ts
@@ -26,6 +26,7 @@ import {
   resolveAndBuildSystemPrompt,
   SLEEPTIME_MEMORY_PERSONA,
 } from "./prompt-assets";
+import { createSystemPromptRecipe } from "./system-prompt-versioning";
 
 /**
  * Describes where a memory block came from
@@ -414,11 +415,15 @@ export async function createAgent(
   // Guarded by isReady since settings may not be initialized in direct/test callers.
   if (!isSubagent && settingsManager.isReady) {
     if (options.systemPromptCustom) {
-      settingsManager.setSystemPromptPreset(fullAgent.id, "custom");
+      settingsManager.setSystemPromptCustom(fullAgent.id);
     } else if (isKnownPreset(options.systemPromptPreset ?? "default")) {
-      settingsManager.setSystemPromptPreset(
+      settingsManager.setSystemPromptRecipe(
         fullAgent.id,
-        options.systemPromptPreset ?? "default",
+        createSystemPromptRecipe(
+          options.systemPromptPreset ?? "default",
+          memMode,
+          systemPromptContent,
+        ),
       );
     }
     // Subagent names: don't persist (no reproducible recipe)

--- a/src/agent/create.ts
+++ b/src/agent/create.ts
@@ -26,7 +26,7 @@ import {
   resolveAndBuildSystemPrompt,
   SLEEPTIME_MEMORY_PERSONA,
 } from "./prompt-assets";
-import { createSystemPromptRecipe } from "./system-prompt-versioning";
+import { recordManagedSystemPrompt } from "./system-prompt-versioning";
 
 /**
  * Describes where a memory block came from
@@ -417,16 +417,14 @@ export async function createAgent(
     if (options.systemPromptCustom) {
       settingsManager.setSystemPromptCustom(fullAgent.id);
     } else if (isKnownPreset(options.systemPromptPreset ?? "default")) {
-      settingsManager.setSystemPromptRecipe(
+      recordManagedSystemPrompt(
         fullAgent.id,
-        createSystemPromptRecipe(
-          options.systemPromptPreset ?? "default",
-          memMode,
-          systemPromptContent,
-        ),
+        options.systemPromptPreset ?? "default",
+        memMode,
+        systemPromptContent,
       );
     }
-    // Subagent names: don't persist (no reproducible recipe)
+    // Subagent names: don't persist (no stable managed prompt metadata)
   }
 
   // Build provenance info

--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -439,6 +439,9 @@ export async function updateAgentSystemPrompt(
     const { isKnownPreset, resolveAndBuildSystemPrompt } = await import(
       "@/agent/prompt-assets"
     );
+    const { createSystemPromptRecipe } = await import(
+      "@/agent/system-prompt-versioning"
+    );
     const { settingsManager } = await import("@/settings-manager");
 
     const backend = getBackend();
@@ -470,7 +473,14 @@ export async function updateAgentSystemPrompt(
     // Persist preset for known presets; clear stale preset for subagent/unknown
     if (settingsManager.isReady) {
       if (isKnownPreset(systemPromptId)) {
-        settingsManager.setSystemPromptPreset(agentId, systemPromptId);
+        settingsManager.setSystemPromptRecipe(
+          agentId,
+          createSystemPromptRecipe(
+            systemPromptId,
+            memoryMode,
+            systemPromptContent,
+          ),
+        );
       } else {
         settingsManager.clearSystemPromptPreset(agentId);
       }
@@ -514,6 +524,9 @@ export async function updateAgentSystemPromptMemfs(
     const { isKnownPreset, buildSystemPrompt } = await import(
       "@/agent/prompt-assets"
     );
+    const { createSystemPromptRecipe, hashSystemPrompt } = await import(
+      "@/agent/system-prompt-versioning"
+    );
 
     const newMode = enableMemfs
       ? getBackend().capabilities.localMemfs
@@ -523,9 +536,44 @@ export async function updateAgentSystemPromptMemfs(
     const storedPreset = settingsManager.isReady
       ? settingsManager.getSystemPromptPreset(agentId)
       : undefined;
+    const storedRecipe = settingsManager.isReady
+      ? settingsManager.getSystemPromptRecipe(agentId)
+      : undefined;
 
     let nextSystemPrompt: string;
     if (storedPreset && isKnownPreset(storedPreset)) {
+      const agent = await getBackend().retrieveAgent(agentId);
+      const currentSystemPrompt = agent.system || "";
+      if (
+        storedRecipe &&
+        hashSystemPrompt(currentSystemPrompt) !== storedRecipe.contentHash
+      ) {
+        if (settingsManager.isReady) {
+          settingsManager.setSystemPromptCustom(agentId);
+        }
+        return {
+          success: true,
+          message: "Custom system prompt left unchanged for memory mode",
+        };
+      }
+
+      if (!storedRecipe && settingsManager.isReady) {
+        const currentMode = settingsManager.isMemfsEnabled(agentId)
+          ? getBackend().capabilities.localMemfs
+            ? "local-memfs"
+            : "memfs"
+          : "standard";
+        if (
+          currentSystemPrompt !== buildSystemPrompt(storedPreset, currentMode)
+        ) {
+          settingsManager.setSystemPromptCustom(agentId);
+          return {
+            success: true,
+            message: "Custom system prompt left unchanged for memory mode",
+          };
+        }
+      }
+
       nextSystemPrompt = buildSystemPrompt(storedPreset, newMode);
     } else {
       const agent = await getBackend().retrieveAgent(agentId);
@@ -535,6 +583,17 @@ export async function updateAgentSystemPromptMemfs(
     await getBackend().updateAgent(agentId, {
       system: nextSystemPrompt,
     });
+
+    if (
+      storedPreset &&
+      isKnownPreset(storedPreset) &&
+      settingsManager.isReady
+    ) {
+      settingsManager.setSystemPromptRecipe(
+        agentId,
+        createSystemPromptRecipe(storedPreset, newMode, nextSystemPrompt),
+      );
+    }
 
     return {
       success: true,

--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -439,7 +439,7 @@ export async function updateAgentSystemPrompt(
     const { isKnownPreset, resolveAndBuildSystemPrompt } = await import(
       "@/agent/prompt-assets"
     );
-    const { createSystemPromptRecipe } = await import(
+    const { recordManagedSystemPrompt } = await import(
       "@/agent/system-prompt-versioning"
     );
     const { settingsManager } = await import("@/settings-manager");
@@ -473,13 +473,11 @@ export async function updateAgentSystemPrompt(
     // Persist preset for known presets; clear stale preset for subagent/unknown
     if (settingsManager.isReady) {
       if (isKnownPreset(systemPromptId)) {
-        settingsManager.setSystemPromptRecipe(
+        recordManagedSystemPrompt(
           agentId,
-          createSystemPromptRecipe(
-            systemPromptId,
-            memoryMode,
-            systemPromptContent,
-          ),
+          systemPromptId,
+          memoryMode,
+          systemPromptContent,
         );
       } else {
         settingsManager.clearSystemPromptPreset(agentId);
@@ -508,7 +506,7 @@ export async function updateAgentSystemPrompt(
 
 /**
  * Updates an agent's system prompt to swap between full prompt variants when
- * the stored prompt recipe is known. Custom prompts are already complete and
+ * the stored managed prompt hash is known. Custom prompts are already complete and
  * are left unchanged.
  *
  * @param agentId - The agent ID to update
@@ -524,7 +522,7 @@ export async function updateAgentSystemPromptMemfs(
     const { isKnownPreset, buildSystemPrompt } = await import(
       "@/agent/prompt-assets"
     );
-    const { createSystemPromptRecipe, hashSystemPrompt } = await import(
+    const { hashSystemPrompt, recordManagedSystemPrompt } = await import(
       "@/agent/system-prompt-versioning"
     );
 
@@ -536,18 +534,15 @@ export async function updateAgentSystemPromptMemfs(
     const storedPreset = settingsManager.isReady
       ? settingsManager.getSystemPromptPreset(agentId)
       : undefined;
-    const storedRecipe = settingsManager.isReady
-      ? settingsManager.getSystemPromptRecipe(agentId)
+    const storedHash = settingsManager.isReady
+      ? settingsManager.getSystemPromptHash(agentId)
       : undefined;
 
     let nextSystemPrompt: string;
     if (storedPreset && isKnownPreset(storedPreset)) {
       const agent = await getBackend().retrieveAgent(agentId);
       const currentSystemPrompt = agent.system || "";
-      if (
-        storedRecipe &&
-        hashSystemPrompt(currentSystemPrompt) !== storedRecipe.contentHash
-      ) {
+      if (storedHash && hashSystemPrompt(currentSystemPrompt) !== storedHash) {
         if (settingsManager.isReady) {
           settingsManager.setSystemPromptCustom(agentId);
         }
@@ -557,7 +552,7 @@ export async function updateAgentSystemPromptMemfs(
         };
       }
 
-      if (!storedRecipe && settingsManager.isReady) {
+      if (!storedHash && settingsManager.isReady) {
         const currentMode = settingsManager.isMemfsEnabled(agentId)
           ? getBackend().capabilities.localMemfs
             ? "local-memfs"
@@ -584,14 +579,12 @@ export async function updateAgentSystemPromptMemfs(
       system: nextSystemPrompt,
     });
 
-    if (
-      storedPreset &&
-      isKnownPreset(storedPreset) &&
-      settingsManager.isReady
-    ) {
-      settingsManager.setSystemPromptRecipe(
+    if (storedPreset && isKnownPreset(storedPreset)) {
+      recordManagedSystemPrompt(
         agentId,
-        createSystemPromptRecipe(storedPreset, newMode, nextSystemPrompt),
+        storedPreset,
+        newMode,
+        nextSystemPrompt,
       );
     }
 

--- a/src/agent/system-prompt-versioning.test.ts
+++ b/src/agent/system-prompt-versioning.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentState } from "@letta-ai/letta-client/resources/agents";
+import { buildSystemPrompt } from "@/agent/prompt-assets";
+import {
+  createSystemPromptRecipe,
+  decideManagedSystemPromptUpdate,
+  hashSystemPrompt,
+} from "@/agent/system-prompt-versioning";
+
+function agent(
+  system: string,
+  tags: string[] = ["origin:letta-code"],
+): AgentState {
+  return {
+    id: "agent-test",
+    system,
+    tags,
+  } as AgentState;
+}
+
+describe("system prompt versioning", () => {
+  test("hashSystemPrompt is stable and content-sensitive", () => {
+    expect(hashSystemPrompt("hello")).toBe(hashSystemPrompt("hello"));
+    expect(hashSystemPrompt("hello")).not.toBe(hashSystemPrompt("hello!"));
+    expect(hashSystemPrompt("hello")).toStartWith("sha256:");
+  });
+
+  test("updates a managed prompt when the active memory mode has different bundled content", () => {
+    const storedPrompt = buildSystemPrompt("default", "standard");
+    const storedRecipe = createSystemPromptRecipe(
+      "default",
+      "standard",
+      storedPrompt,
+    );
+
+    const decision = decideManagedSystemPromptUpdate({
+      agent: agent(storedPrompt),
+      memoryMode: "memfs",
+      storedPreset: "default",
+      storedRecipe,
+    });
+
+    expect(decision.kind).toBe("update");
+    if (decision.kind === "update") {
+      expect(decision.nextSystemPrompt).toBe(
+        buildSystemPrompt("default", "memfs"),
+      );
+      expect(decision.nextRecipe.contentHash).toBe(
+        hashSystemPrompt(decision.nextSystemPrompt),
+      );
+      expect(decision.nextRecipe.memoryMode).toBe("memfs");
+    }
+  });
+
+  test("does not update when the agent prompt no longer matches the stored managed hash", () => {
+    const storedPrompt = buildSystemPrompt("default", "standard");
+    const storedRecipe = createSystemPromptRecipe(
+      "default",
+      "standard",
+      storedPrompt,
+    );
+    const modifiedPrompt = `${storedPrompt}\n\nUser customization.`;
+
+    const decision = decideManagedSystemPromptUpdate({
+      agent: agent(modifiedPrompt),
+      memoryMode: "memfs",
+      storedPreset: "default",
+      storedRecipe,
+    });
+
+    expect(decision.kind).toBe("custom");
+  });
+
+  test("adopts legacy Letta Code agents only when their prompt matches a current preset", () => {
+    const currentPrompt = buildSystemPrompt("default", "standard");
+
+    const decision = decideManagedSystemPromptUpdate({
+      agent: agent(currentPrompt),
+      memoryMode: "standard",
+    });
+
+    expect(decision.kind).toBe("adopt");
+    if (decision.kind === "adopt") {
+      expect(decision.recipe.preset).toBe("default");
+      expect(decision.recipe.contentHash).toBe(hashSystemPrompt(currentPrompt));
+    }
+  });
+
+  test("marks legacy Letta Code agents custom when their prompt is modified", () => {
+    const currentPrompt = buildSystemPrompt("default", "standard");
+
+    const decision = decideManagedSystemPromptUpdate({
+      agent: agent(`${currentPrompt}\n\nExtra local instruction.`),
+      memoryMode: "standard",
+    });
+
+    expect(decision.kind).toBe("custom");
+  });
+
+  test("ignores non-Letta-Code agents without prompt provenance", () => {
+    const decision = decideManagedSystemPromptUpdate({
+      agent: agent(buildSystemPrompt("default", "standard"), []),
+      memoryMode: "standard",
+    });
+
+    expect(decision.kind).toBe("noop");
+  });
+});

--- a/src/agent/system-prompt-versioning.test.ts
+++ b/src/agent/system-prompt-versioning.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents";
 import { buildSystemPrompt } from "@/agent/prompt-assets";
 import {
-  createSystemPromptRecipe,
   decideManagedSystemPromptUpdate,
   hashSystemPrompt,
 } from "@/agent/system-prompt-versioning";
@@ -27,17 +26,13 @@ describe("system prompt versioning", () => {
 
   test("updates a managed prompt when the active memory mode has different bundled content", () => {
     const storedPrompt = buildSystemPrompt("default", "standard");
-    const storedRecipe = createSystemPromptRecipe(
-      "default",
-      "standard",
-      storedPrompt,
-    );
 
     const decision = decideManagedSystemPromptUpdate({
       agent: agent(storedPrompt),
       memoryMode: "memfs",
       storedPreset: "default",
-      storedRecipe,
+      storedHash: hashSystemPrompt(storedPrompt),
+      storedVersion: "old-version",
     });
 
     expect(decision.kind).toBe("update");
@@ -45,33 +40,28 @@ describe("system prompt versioning", () => {
       expect(decision.nextSystemPrompt).toBe(
         buildSystemPrompt("default", "memfs"),
       );
-      expect(decision.nextRecipe.contentHash).toBe(
+      expect(decision.prompt.hash).toBe(
         hashSystemPrompt(decision.nextSystemPrompt),
       );
-      expect(decision.nextRecipe.memoryMode).toBe("memfs");
     }
   });
 
   test("does not update when the agent prompt no longer matches the stored managed hash", () => {
     const storedPrompt = buildSystemPrompt("default", "standard");
-    const storedRecipe = createSystemPromptRecipe(
-      "default",
-      "standard",
-      storedPrompt,
-    );
     const modifiedPrompt = `${storedPrompt}\n\nUser customization.`;
 
     const decision = decideManagedSystemPromptUpdate({
       agent: agent(modifiedPrompt),
       memoryMode: "memfs",
       storedPreset: "default",
-      storedRecipe,
+      storedHash: hashSystemPrompt(storedPrompt),
+      storedVersion: "old-version",
     });
 
     expect(decision.kind).toBe("custom");
   });
 
-  test("adopts legacy Letta Code agents only when their prompt matches a current preset", () => {
+  test("tracks legacy Letta Code agents only when their prompt matches a current preset", () => {
     const currentPrompt = buildSystemPrompt("default", "standard");
 
     const decision = decideManagedSystemPromptUpdate({
@@ -79,10 +69,10 @@ describe("system prompt versioning", () => {
       memoryMode: "standard",
     });
 
-    expect(decision.kind).toBe("adopt");
-    if (decision.kind === "adopt") {
-      expect(decision.recipe.preset).toBe("default");
-      expect(decision.recipe.contentHash).toBe(hashSystemPrompt(currentPrompt));
+    expect(decision.kind).toBe("track");
+    if (decision.kind === "track") {
+      expect(decision.prompt.preset).toBe("default");
+      expect(decision.prompt.hash).toBe(hashSystemPrompt(currentPrompt));
     }
   });
 

--- a/src/agent/system-prompt-versioning.ts
+++ b/src/agent/system-prompt-versioning.ts
@@ -1,0 +1,258 @@
+import { createHash } from "node:crypto";
+import type { AgentState } from "@letta-ai/letta-client/resources/agents";
+import { getBackend } from "@/backend";
+import { type SystemPromptRecipe, settingsManager } from "@/settings-manager";
+import { debugLog, debugWarn } from "@/utils/debug";
+import { getVersion } from "@/version";
+import {
+  buildSystemPrompt,
+  isKnownPreset,
+  type MemoryPromptMode,
+  SYSTEM_PROMPTS,
+} from "./prompt-assets";
+
+const SYSTEM_PROMPT_HASH_PREFIX = "sha256:";
+
+type SystemPromptUpdateDecision =
+  | { kind: "noop"; reason: string }
+  | { kind: "adopt"; recipe: SystemPromptRecipe }
+  | { kind: "custom"; reason: string }
+  | { kind: "clear"; reason: string }
+  | {
+      kind: "update";
+      preset: string;
+      nextSystemPrompt: string;
+      nextRecipe: SystemPromptRecipe;
+      reason: string;
+    };
+
+export interface ManagedSystemPromptUpdateOptions {
+  agent: AgentState;
+  memoryMode: MemoryPromptMode;
+  onUpdated?: (agent: AgentState) => void;
+}
+
+export function hashSystemPrompt(content: string): string {
+  const digest = createHash("sha256").update(content).digest("base64url");
+  return `${SYSTEM_PROMPT_HASH_PREFIX}${digest}`;
+}
+
+export function createSystemPromptRecipe(
+  preset: string,
+  memoryMode: MemoryPromptMode,
+  content: string = buildSystemPrompt(preset, memoryMode),
+): SystemPromptRecipe {
+  return {
+    preset,
+    lettaCodeVersion: getVersion(),
+    contentHash: hashSystemPrompt(content),
+    memoryMode,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export function getMemoryPromptModeForAgent(agentId: string): MemoryPromptMode {
+  const backend = getBackend();
+  if (backend.capabilities.localMemfs) {
+    return "local-memfs";
+  }
+  return settingsManager.isReady && settingsManager.isMemfsEnabled(agentId)
+    ? "memfs"
+    : "standard";
+}
+
+function isLettaCodePrimaryAgent(agent: AgentState): boolean {
+  const tags = agent.tags ?? [];
+  return tags.includes("origin:letta-code") && !tags.includes("role:subagent");
+}
+
+function findMatchingCurrentPreset(
+  systemPrompt: string,
+  memoryMode: MemoryPromptMode,
+): string | undefined {
+  for (const preset of SYSTEM_PROMPTS) {
+    if (buildSystemPrompt(preset.id, memoryMode) === systemPrompt) {
+      return preset.id;
+    }
+  }
+  return undefined;
+}
+
+function isValidRecipe(recipe: SystemPromptRecipe | undefined): boolean {
+  return (
+    !!recipe &&
+    typeof recipe.preset === "string" &&
+    typeof recipe.contentHash === "string" &&
+    recipe.contentHash.startsWith(SYSTEM_PROMPT_HASH_PREFIX) &&
+    isKnownPreset(recipe.preset)
+  );
+}
+
+export function decideManagedSystemPromptUpdate(input: {
+  agent: AgentState;
+  memoryMode: MemoryPromptMode;
+  storedPreset?: string;
+  storedRecipe?: SystemPromptRecipe;
+}): SystemPromptUpdateDecision {
+  const { agent, memoryMode, storedPreset, storedRecipe } = input;
+  const currentSystemPrompt = agent.system ?? "";
+  const currentHash = hashSystemPrompt(currentSystemPrompt);
+
+  if (storedPreset === "custom") {
+    return { kind: "noop", reason: "system prompt is marked custom" };
+  }
+
+  if (storedRecipe) {
+    if (!isValidRecipe(storedRecipe)) {
+      return { kind: "clear", reason: "stored recipe is invalid or stale" };
+    }
+
+    if (currentHash !== storedRecipe.contentHash) {
+      return {
+        kind: "custom",
+        reason: "agent prompt differs from stored managed prompt hash",
+      };
+    }
+
+    const nextSystemPrompt = buildSystemPrompt(storedRecipe.preset, memoryMode);
+    const nextRecipe = createSystemPromptRecipe(
+      storedRecipe.preset,
+      memoryMode,
+      nextSystemPrompt,
+    );
+
+    if (
+      nextRecipe.contentHash === storedRecipe.contentHash &&
+      nextRecipe.memoryMode === storedRecipe.memoryMode &&
+      nextRecipe.lettaCodeVersion === storedRecipe.lettaCodeVersion
+    ) {
+      return { kind: "noop", reason: "managed prompt is current" };
+    }
+
+    if (nextRecipe.contentHash === storedRecipe.contentHash) {
+      return { kind: "adopt", recipe: nextRecipe };
+    }
+
+    return {
+      kind: "update",
+      preset: storedRecipe.preset,
+      nextSystemPrompt,
+      nextRecipe,
+      reason: "managed prompt content changed for current Letta Code version",
+    };
+  }
+
+  if (storedPreset) {
+    if (!isKnownPreset(storedPreset)) {
+      return { kind: "clear", reason: "stored preset is no longer known" };
+    }
+
+    const expectedCurrentPrompt = buildSystemPrompt(storedPreset, memoryMode);
+    if (currentSystemPrompt === expectedCurrentPrompt) {
+      return {
+        kind: "adopt",
+        recipe: createSystemPromptRecipe(
+          storedPreset,
+          memoryMode,
+          expectedCurrentPrompt,
+        ),
+      };
+    }
+
+    return {
+      kind: "custom",
+      reason: "legacy preset tracking exists but prompt content was modified",
+    };
+  }
+
+  if (!isLettaCodePrimaryAgent(agent)) {
+    return { kind: "noop", reason: "agent is not a primary Letta Code agent" };
+  }
+
+  const matchingPreset = findMatchingCurrentPreset(
+    currentSystemPrompt,
+    memoryMode,
+  );
+  if (!matchingPreset) {
+    return {
+      kind: "custom",
+      reason: "legacy Letta Code agent prompt does not match a current preset",
+    };
+  }
+
+  return {
+    kind: "adopt",
+    recipe: createSystemPromptRecipe(
+      matchingPreset,
+      memoryMode,
+      currentSystemPrompt,
+    ),
+  };
+}
+
+export function scheduleManagedSystemPromptUpdate({
+  agent,
+  memoryMode,
+  onUpdated,
+}: ManagedSystemPromptUpdateOptions): void {
+  if (!settingsManager.isReady) {
+    return;
+  }
+
+  const decision = decideManagedSystemPromptUpdate({
+    agent,
+    memoryMode,
+    storedPreset: settingsManager.getSystemPromptPreset(agent.id),
+    storedRecipe: settingsManager.getSystemPromptRecipe(agent.id),
+  });
+
+  if (decision.kind === "noop") {
+    debugLog("startup", `System prompt version check noop: ${decision.reason}`);
+    return;
+  }
+
+  if (decision.kind === "adopt") {
+    settingsManager.setSystemPromptRecipe(agent.id, decision.recipe);
+    debugLog(
+      "startup",
+      `Recorded system prompt recipe ${decision.recipe.preset}@${decision.recipe.lettaCodeVersion}`,
+    );
+    return;
+  }
+
+  if (decision.kind === "custom") {
+    settingsManager.setSystemPromptCustom(agent.id);
+    debugLog("startup", `Marked system prompt custom: ${decision.reason}`);
+    return;
+  }
+
+  if (decision.kind === "clear") {
+    settingsManager.clearSystemPromptPreset(agent.id);
+    debugLog("startup", `Cleared system prompt recipe: ${decision.reason}`);
+    return;
+  }
+
+  void getBackend()
+    .updateAgent(agent.id, {
+      system: decision.nextSystemPrompt,
+    })
+    .then(async () => {
+      settingsManager.setSystemPromptRecipe(agent.id, decision.nextRecipe);
+      debugLog(
+        "startup",
+        `Updated managed system prompt ${decision.preset}@${decision.nextRecipe.lettaCodeVersion}: ${decision.reason}`,
+      );
+      if (onUpdated) {
+        const updatedAgent = await getBackend().retrieveAgent(agent.id, {
+          include: ["agent.secrets", "agent.tools", "agent.tags"],
+        });
+        onUpdated(updatedAgent);
+      }
+    })
+    .catch((error) => {
+      debugWarn(
+        "startup",
+        `Failed to update managed system prompt for ${agent.id}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
+}

--- a/src/agent/system-prompt-versioning.ts
+++ b/src/agent/system-prompt-versioning.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents";
 import { getBackend } from "@/backend";
-import { type SystemPromptRecipe, settingsManager } from "@/settings-manager";
+import { settingsManager } from "@/settings-manager";
 import { debugLog, debugWarn } from "@/utils/debug";
 import { getVersion } from "@/version";
 import {
@@ -13,16 +13,21 @@ import {
 
 const SYSTEM_PROMPT_HASH_PREFIX = "sha256:";
 
+type ManagedPrompt = {
+  preset: string;
+  hash: string;
+  version: string;
+};
+
 type SystemPromptUpdateDecision =
   | { kind: "noop"; reason: string }
-  | { kind: "adopt"; recipe: SystemPromptRecipe }
+  | { kind: "track"; prompt: ManagedPrompt }
   | { kind: "custom"; reason: string }
   | { kind: "clear"; reason: string }
   | {
       kind: "update";
-      preset: string;
       nextSystemPrompt: string;
-      nextRecipe: SystemPromptRecipe;
+      prompt: ManagedPrompt;
       reason: string;
     };
 
@@ -37,18 +42,31 @@ export function hashSystemPrompt(content: string): string {
   return `${SYSTEM_PROMPT_HASH_PREFIX}${digest}`;
 }
 
-export function createSystemPromptRecipe(
+function managedPrompt(
   preset: string,
   memoryMode: MemoryPromptMode,
   content: string = buildSystemPrompt(preset, memoryMode),
-): SystemPromptRecipe {
+): ManagedPrompt {
   return {
     preset,
-    lettaCodeVersion: getVersion(),
-    contentHash: hashSystemPrompt(content),
-    memoryMode,
-    updatedAt: new Date().toISOString(),
+    hash: hashSystemPrompt(content),
+    version: getVersion(),
   };
+}
+
+export function recordManagedSystemPrompt(
+  agentId: string,
+  preset: string,
+  memoryMode: MemoryPromptMode,
+  content?: string,
+): void {
+  if (!settingsManager.isReady) {
+    return;
+  }
+  settingsManager.setManagedSystemPrompt(
+    agentId,
+    managedPrompt(preset, memoryMode, content),
+  );
 }
 
 export function getMemoryPromptModeForAgent(agentId: string): MemoryPromptMode {
@@ -78,68 +96,24 @@ function findMatchingCurrentPreset(
   return undefined;
 }
 
-function isValidRecipe(recipe: SystemPromptRecipe | undefined): boolean {
-  return (
-    !!recipe &&
-    typeof recipe.preset === "string" &&
-    typeof recipe.contentHash === "string" &&
-    recipe.contentHash.startsWith(SYSTEM_PROMPT_HASH_PREFIX) &&
-    isKnownPreset(recipe.preset)
-  );
+function isValidHash(hash: string | undefined): hash is string {
+  return !!hash && hash.startsWith(SYSTEM_PROMPT_HASH_PREFIX);
 }
 
 export function decideManagedSystemPromptUpdate(input: {
   agent: AgentState;
   memoryMode: MemoryPromptMode;
   storedPreset?: string;
-  storedRecipe?: SystemPromptRecipe;
+  storedHash?: string;
+  storedVersion?: string;
 }): SystemPromptUpdateDecision {
-  const { agent, memoryMode, storedPreset, storedRecipe } = input;
+  const { agent, memoryMode, storedPreset, storedHash, storedVersion } = input;
   const currentSystemPrompt = agent.system ?? "";
   const currentHash = hashSystemPrompt(currentSystemPrompt);
+  const currentVersion = getVersion();
 
   if (storedPreset === "custom") {
     return { kind: "noop", reason: "system prompt is marked custom" };
-  }
-
-  if (storedRecipe) {
-    if (!isValidRecipe(storedRecipe)) {
-      return { kind: "clear", reason: "stored recipe is invalid or stale" };
-    }
-
-    if (currentHash !== storedRecipe.contentHash) {
-      return {
-        kind: "custom",
-        reason: "agent prompt differs from stored managed prompt hash",
-      };
-    }
-
-    const nextSystemPrompt = buildSystemPrompt(storedRecipe.preset, memoryMode);
-    const nextRecipe = createSystemPromptRecipe(
-      storedRecipe.preset,
-      memoryMode,
-      nextSystemPrompt,
-    );
-
-    if (
-      nextRecipe.contentHash === storedRecipe.contentHash &&
-      nextRecipe.memoryMode === storedRecipe.memoryMode &&
-      nextRecipe.lettaCodeVersion === storedRecipe.lettaCodeVersion
-    ) {
-      return { kind: "noop", reason: "managed prompt is current" };
-    }
-
-    if (nextRecipe.contentHash === storedRecipe.contentHash) {
-      return { kind: "adopt", recipe: nextRecipe };
-    }
-
-    return {
-      kind: "update",
-      preset: storedRecipe.preset,
-      nextSystemPrompt,
-      nextRecipe,
-      reason: "managed prompt content changed for current Letta Code version",
-    };
   }
 
   if (storedPreset) {
@@ -147,15 +121,49 @@ export function decideManagedSystemPromptUpdate(input: {
       return { kind: "clear", reason: "stored preset is no longer known" };
     }
 
+    if (storedHash) {
+      if (!isValidHash(storedHash)) {
+        return { kind: "clear", reason: "stored prompt hash is invalid" };
+      }
+
+      if (currentHash !== storedHash) {
+        return {
+          kind: "custom",
+          reason: "agent prompt differs from stored managed prompt hash",
+        };
+      }
+
+      const nextSystemPrompt = buildSystemPrompt(storedPreset, memoryMode);
+      const nextPrompt = managedPrompt(
+        storedPreset,
+        memoryMode,
+        nextSystemPrompt,
+      );
+
+      if (nextPrompt.hash !== storedHash) {
+        return {
+          kind: "update",
+          nextSystemPrompt,
+          prompt: nextPrompt,
+          reason:
+            "managed prompt content changed for current Letta Code version",
+        };
+      }
+
+      if (storedVersion !== currentVersion) {
+        return { kind: "track", prompt: nextPrompt };
+      }
+
+      return { kind: "noop", reason: "managed prompt is current" };
+    }
+
+    // Legacy preset-only settings cannot prove the prompt is still managed, so
+    // only start tracking them when they exactly match the current bundled text.
     const expectedCurrentPrompt = buildSystemPrompt(storedPreset, memoryMode);
     if (currentSystemPrompt === expectedCurrentPrompt) {
       return {
-        kind: "adopt",
-        recipe: createSystemPromptRecipe(
-          storedPreset,
-          memoryMode,
-          expectedCurrentPrompt,
-        ),
+        kind: "track",
+        prompt: managedPrompt(storedPreset, memoryMode, currentSystemPrompt),
       };
     }
 
@@ -181,12 +189,8 @@ export function decideManagedSystemPromptUpdate(input: {
   }
 
   return {
-    kind: "adopt",
-    recipe: createSystemPromptRecipe(
-      matchingPreset,
-      memoryMode,
-      currentSystemPrompt,
-    ),
+    kind: "track",
+    prompt: managedPrompt(matchingPreset, memoryMode, currentSystemPrompt),
   };
 }
 
@@ -203,7 +207,8 @@ export function scheduleManagedSystemPromptUpdate({
     agent,
     memoryMode,
     storedPreset: settingsManager.getSystemPromptPreset(agent.id),
-    storedRecipe: settingsManager.getSystemPromptRecipe(agent.id),
+    storedHash: settingsManager.getSystemPromptHash(agent.id),
+    storedVersion: settingsManager.getSystemPromptVersion(agent.id),
   });
 
   if (decision.kind === "noop") {
@@ -211,11 +216,11 @@ export function scheduleManagedSystemPromptUpdate({
     return;
   }
 
-  if (decision.kind === "adopt") {
-    settingsManager.setSystemPromptRecipe(agent.id, decision.recipe);
+  if (decision.kind === "track") {
+    settingsManager.setManagedSystemPrompt(agent.id, decision.prompt);
     debugLog(
       "startup",
-      `Recorded system prompt recipe ${decision.recipe.preset}@${decision.recipe.lettaCodeVersion}`,
+      `Tracking managed system prompt ${decision.prompt.preset}@${decision.prompt.version}`,
     );
     return;
   }
@@ -228,7 +233,7 @@ export function scheduleManagedSystemPromptUpdate({
 
   if (decision.kind === "clear") {
     settingsManager.clearSystemPromptPreset(agent.id);
-    debugLog("startup", `Cleared system prompt recipe: ${decision.reason}`);
+    debugLog("startup", `Cleared system prompt metadata: ${decision.reason}`);
     return;
   }
 
@@ -237,10 +242,10 @@ export function scheduleManagedSystemPromptUpdate({
       system: decision.nextSystemPrompt,
     })
     .then(async () => {
-      settingsManager.setSystemPromptRecipe(agent.id, decision.nextRecipe);
+      settingsManager.setManagedSystemPrompt(agent.id, decision.prompt);
       debugLog(
         "startup",
-        `Updated managed system prompt ${decision.preset}@${decision.nextRecipe.lettaCodeVersion}: ${decision.reason}`,
+        `Updated managed system prompt ${decision.prompt.preset}@${decision.prompt.version}: ${decision.reason}`,
       );
       if (onUpdated) {
         const updatedAgent = await getBackend().retrieveAgent(agent.id, {

--- a/src/headless-backend-lifecycle.test.ts
+++ b/src/headless-backend-lifecycle.test.ts
@@ -10,6 +10,18 @@ function readSource(relativePath: string): string {
   );
 }
 
+function expectManagedPromptUpdatesViaBackend(source: string): void {
+  const systemPromptVersioningSource = readSource(
+    "./agent/system-prompt-versioning.ts",
+  );
+
+  expect(source).toContain("scheduleManagedSystemPromptUpdate(");
+  expect(systemPromptVersioningSource).toMatch(
+    /getBackend\(\)\s*\.\s*updateAgent\(/,
+  );
+  expect(systemPromptVersioningSource).not.toContain("client.agents.");
+}
+
 describe("headless backend lifecycle wiring", () => {
   test("headless startup and approval recovery route lifecycle SDK calls through Backend", () => {
     const source = readSource("./headless.ts");
@@ -26,7 +38,7 @@ describe("headless backend lifecycle wiring", () => {
     expect(source).toContain("backend.retrieveAgent(");
     expect(source).toContain("backend.retrieveConversation(");
     expect(source).toContain("backend.createConversation(");
-    expect(source).toContain("backend.updateAgent(");
+    expectManagedPromptUpdatesViaBackend(source);
 
     expect(source).not.toContain("client.agents.");
     expect(source).not.toContain("client.conversations.");
@@ -52,7 +64,7 @@ describe("headless backend lifecycle wiring", () => {
     expect(source).toContain("backend.retrieveAgent(");
     expect(source).toContain("backend.retrieveConversation(");
     expect(source).toContain("backend.createConversation(");
-    expect(source).toContain("backend.updateAgent(");
+    expectManagedPromptUpdatesViaBackend(source);
     expect(source).toContain("getResumeDataFromBackend(");
 
     expect(source).not.toContain("getClient");

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1140,7 +1140,7 @@ export async function handleHeadlessCommand(
     // Mark imported agents as "custom" to prevent legacy auto-migration
     // from overwriting their system prompt on resume.
     if (settingsManager.isReady) {
-      settingsManager.setSystemPromptPreset(agent.id, "custom");
+      settingsManager.setSystemPromptCustom(agent.id);
     }
 
     // Display extracted skills summary
@@ -1497,40 +1497,16 @@ export async function handleHeadlessCommand(
     agent = result.agent;
   }
 
-  // Auto-heal system prompt drift (rebuild from stored recipe).
-  // Runs after memfs sync so isMemfsEnabled() reflects the final state.
+  // Maintain managed system prompt versions without blocking startup.
+  // This updates only agents whose current prompt still matches the stored
+  // managed prompt hash, so custom edits are preserved.
   if (isResumingAgent && !systemPromptPreset) {
-    let storedPreset = settingsManager.getSystemPromptPreset(agent.id);
-
-    // Adopt legacy agents (created before recipe tracking) as "custom"
-    // so their prompts are left untouched by auto-heal.
-    if (
-      !storedPreset &&
-      agent.tags?.includes("origin:letta-code") &&
-      !agent.tags?.includes("role:subagent")
-    ) {
-      storedPreset = "custom";
-      settingsManager.setSystemPromptPreset(agent.id, storedPreset);
-    }
-
-    if (storedPreset && storedPreset !== "custom") {
-      const { buildSystemPrompt: rebuildPrompt, isKnownPreset: isKnown } =
-        await import("@/agent/prompt-assets");
-      if (isKnown(storedPreset)) {
-        const memoryMode = settingsManager.isMemfsEnabled(agent.id)
-          ? "memfs"
-          : "standard";
-        const expected = rebuildPrompt(storedPreset, memoryMode);
-        if (agent.system !== expected) {
-          await backend.updateAgent(agent.id, { system: expected });
-          agent = await backend.retrieveAgent(agent.id, {
-            include: ["agent.secrets", "agent.tools", "agent.tags"],
-          });
-        }
-      } else {
-        settingsManager.clearSystemPromptPreset(agent.id);
-      }
-    }
+    const { getMemoryPromptModeForAgent, scheduleManagedSystemPromptUpdate } =
+      await import("@/agent/system-prompt-versioning");
+    scheduleManagedSystemPromptUpdate({
+      agent,
+      memoryMode: getMemoryPromptModeForAgent(agent.id),
+    });
   }
 
   const startupAgentId = agent.id;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2257,7 +2257,7 @@ async function main(): Promise<void> {
           // Mark imported agents as "custom" to prevent legacy auto-migration
           // from overwriting their system prompt on resume.
           if (settingsManager.isReady) {
-            settingsManager.setSystemPromptPreset(agent.id, "custom");
+            settingsManager.setSystemPromptCustom(agent.id);
           }
 
           // Display extracted skills summary
@@ -2346,6 +2346,7 @@ async function main(): Promise<void> {
             skillsDirectory,
             parallelToolCalls: true,
             systemPromptPreset,
+            systemPromptCustom: systemCustom,
             memoryPromptMode: effectiveMemoryMode,
             initBlocks,
             baseTools,
@@ -2674,41 +2675,6 @@ async function main(): Promise<void> {
           );
         }
 
-        // Auto-heal system prompt drift (rebuild from stored recipe).
-        // Runs after memfs flag reconciliation so isMemfsEnabled() reflects
-        // the target memory mode even if clone/pull is still in flight.
-        if (resuming && !systemPromptPreset) {
-          let storedPreset = settingsManager.getSystemPromptPreset(agent.id);
-
-          // Adopt legacy agents (created before recipe tracking) as "custom"
-          // so their prompts are left untouched by auto-heal.
-          if (
-            !storedPreset &&
-            agent.tags?.includes("origin:letta-code") &&
-            !agent.tags?.includes("role:subagent")
-          ) {
-            storedPreset = "custom";
-            settingsManager.setSystemPromptPreset(agent.id, storedPreset);
-          }
-
-          if (storedPreset && storedPreset !== "custom") {
-            const { buildSystemPrompt: rebuildPrompt, isKnownPreset: isKnown } =
-              await import("@/agent/prompt-assets");
-            if (isKnown(storedPreset)) {
-              const memoryMode = settingsManager.isMemfsEnabled(agent.id)
-                ? "memfs"
-                : "standard";
-              const expected = rebuildPrompt(storedPreset, memoryMode);
-              if (agent.system !== expected) {
-                await backend.updateAgent(agent.id, { system: expected });
-                agent = await backend.retrieveAgent(agent.id);
-              }
-            } else {
-              settingsManager.clearSystemPromptPreset(agent.id);
-            }
-          }
-        }
-
         // Save the session (agent + conversation) to settings
         // Skip for subagents - they shouldn't pollute the LRU settings
         if (shouldPersistSessionState()) {
@@ -2722,6 +2688,23 @@ async function main(): Promise<void> {
         setContextConversationId(conversationIdToUse);
         markMilestone("TUI_READY");
         setLoadingState("ready");
+
+        // Maintain managed system prompt versions without blocking startup.
+        // This updates only agents whose current prompt still matches the
+        // stored managed prompt hash, so custom edits are preserved.
+        if (resuming && !systemPromptPreset) {
+          const {
+            getMemoryPromptModeForAgent,
+            scheduleManagedSystemPromptUpdate,
+          } = await import("@/agent/system-prompt-versioning");
+          scheduleManagedSystemPromptUpdate({
+            agent,
+            memoryMode: getMemoryPromptModeForAgent(agent.id),
+            onUpdated: (updatedAgent) => {
+              setAgentState(updatedAgent);
+            },
+          });
+        }
       }
 
       init().catch((err) => {

--- a/src/integration-tests/local-system-prompt-parity.test.ts
+++ b/src/integration-tests/local-system-prompt-parity.test.ts
@@ -121,5 +121,5 @@ describe("local/API system prompt parity", () => {
       await rm(storageDir, { recursive: true, force: true });
       await client.agents.delete(apiAgent.id).catch(() => undefined);
     }
-  });
+  }, 60000);
 });

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -57,15 +57,8 @@ export interface AgentSettings {
     | "gemini_snake"
     | "none"; // toolset mode for this agent (manual override or auto)
   systemPromptPreset?: string; // known preset ID, "custom", or undefined (legacy/subagent)
-  systemPromptRecipe?: SystemPromptRecipe; // reproducible managed prompt provenance
-}
-
-export interface SystemPromptRecipe {
-  preset: string;
-  lettaCodeVersion: string;
-  contentHash: string;
-  memoryMode: "standard" | "memfs" | "local-memfs";
-  updatedAt: string;
+  systemPromptHash?: string; // hash of the managed prompt content last written by Letta Code
+  systemPromptVersion?: string; // Letta Code version that wrote systemPromptHash
 }
 
 export interface ConversationGoal {
@@ -2277,9 +2270,13 @@ class SettingsManager {
   private upsertAgentSettings(
     agentId: string,
     updates: Partial<
-      Omit<AgentSettings, "agentId" | "baseUrl" | "systemPromptRecipe">
+      Omit<
+        AgentSettings,
+        "agentId" | "baseUrl" | "systemPromptHash" | "systemPromptVersion"
+      >
     > & {
-      systemPromptRecipe?: SystemPromptRecipe | null;
+      systemPromptHash?: string | null;
+      systemPromptVersion?: string | null;
     },
     serverKeyOverride?: string,
   ): void {
@@ -2312,10 +2309,14 @@ class SettingsManager {
           updates.systemPromptPreset !== undefined
             ? updates.systemPromptPreset
             : existing.systemPromptPreset,
-        systemPromptRecipe:
-          updates.systemPromptRecipe !== undefined
-            ? (updates.systemPromptRecipe ?? undefined)
-            : existing.systemPromptRecipe,
+        systemPromptHash:
+          updates.systemPromptHash !== undefined
+            ? (updates.systemPromptHash ?? undefined)
+            : existing.systemPromptHash,
+        systemPromptVersion:
+          updates.systemPromptVersion !== undefined
+            ? (updates.systemPromptVersion ?? undefined)
+            : existing.systemPromptVersion,
       };
       // Clean up undefined/false values
       if (!updated.pinned) delete updated.pinned;
@@ -2323,7 +2324,8 @@ class SettingsManager {
       if (!updated.toolset || updated.toolset === "auto")
         delete updated.toolset;
       if (!updated.systemPromptPreset) delete updated.systemPromptPreset;
-      if (!updated.systemPromptRecipe) delete updated.systemPromptRecipe;
+      if (!updated.systemPromptHash) delete updated.systemPromptHash;
+      if (!updated.systemPromptVersion) delete updated.systemPromptVersion;
       if (!updated.baseUrl) delete updated.baseUrl;
       agents[idx] = updated;
     } else {
@@ -2332,7 +2334,8 @@ class SettingsManager {
         agentId,
         baseUrl: normalizedBaseUrl,
         ...updates,
-        systemPromptRecipe: updates.systemPromptRecipe ?? undefined,
+        systemPromptHash: updates.systemPromptHash ?? undefined,
+        systemPromptVersion: updates.systemPromptVersion ?? undefined,
       };
       // Clean up undefined/false values
       if (!newAgent.pinned) delete newAgent.pinned;
@@ -2340,7 +2343,8 @@ class SettingsManager {
       if (!newAgent.toolset || newAgent.toolset === "auto")
         delete newAgent.toolset;
       if (!newAgent.systemPromptPreset) delete newAgent.systemPromptPreset;
-      if (!newAgent.systemPromptRecipe) delete newAgent.systemPromptRecipe;
+      if (!newAgent.systemPromptHash) delete newAgent.systemPromptHash;
+      if (!newAgent.systemPromptVersion) delete newAgent.systemPromptVersion;
       if (!newAgent.baseUrl) delete newAgent.baseUrl;
       agents.push(newAgent);
     }
@@ -2408,10 +2412,17 @@ class SettingsManager {
   }
 
   /**
-   * Get the stored managed system prompt recipe for an agent on the current server.
+   * Get the stored hash for the managed system prompt on the current server.
    */
-  getSystemPromptRecipe(agentId: string): SystemPromptRecipe | undefined {
-    return this.getAgentSettings(agentId)?.systemPromptRecipe;
+  getSystemPromptHash(agentId: string): string | undefined {
+    return this.getAgentSettings(agentId)?.systemPromptHash;
+  }
+
+  /**
+   * Get the Letta Code version that last wrote the managed system prompt hash.
+   */
+  getSystemPromptVersion(agentId: string): string | undefined {
+    return this.getAgentSettings(agentId)?.systemPromptVersion;
   }
 
   /**
@@ -2420,27 +2431,37 @@ class SettingsManager {
   setSystemPromptPreset(agentId: string, preset: string): void {
     this.upsertAgentSettings(agentId, {
       systemPromptPreset: preset,
-      systemPromptRecipe: null,
+      systemPromptHash: null,
+      systemPromptVersion: null,
     });
   }
 
   /**
-   * Store the managed system prompt recipe for an agent on the current server.
+   * Store the managed system prompt metadata for an agent on the current server.
    */
-  setSystemPromptRecipe(agentId: string, recipe: SystemPromptRecipe): void {
+  setManagedSystemPrompt(
+    agentId: string,
+    prompt: {
+      preset: string;
+      hash: string;
+      version: string;
+    },
+  ): void {
     this.upsertAgentSettings(agentId, {
-      systemPromptPreset: recipe.preset,
-      systemPromptRecipe: recipe,
+      systemPromptPreset: prompt.preset,
+      systemPromptHash: prompt.hash,
+      systemPromptVersion: prompt.version,
     });
   }
 
   /**
-   * Mark an agent's system prompt as custom and clear any managed recipe.
+   * Mark an agent's system prompt as custom and clear managed prompt metadata.
    */
   setSystemPromptCustom(agentId: string): void {
     this.upsertAgentSettings(agentId, {
       systemPromptPreset: "custom",
-      systemPromptRecipe: null,
+      systemPromptHash: null,
+      systemPromptVersion: null,
     });
   }
 
@@ -2451,7 +2472,8 @@ class SettingsManager {
     // Setting to empty string triggers the cleanup `if (!updated.systemPromptPreset) delete ...`
     this.upsertAgentSettings(agentId, {
       systemPromptPreset: "",
-      systemPromptRecipe: null,
+      systemPromptHash: null,
+      systemPromptVersion: null,
     });
   }
 

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -57,6 +57,15 @@ export interface AgentSettings {
     | "gemini_snake"
     | "none"; // toolset mode for this agent (manual override or auto)
   systemPromptPreset?: string; // known preset ID, "custom", or undefined (legacy/subagent)
+  systemPromptRecipe?: SystemPromptRecipe; // reproducible managed prompt provenance
+}
+
+export interface SystemPromptRecipe {
+  preset: string;
+  lettaCodeVersion: string;
+  contentHash: string;
+  memoryMode: "standard" | "memfs" | "local-memfs";
+  updatedAt: string;
 }
 
 export interface ConversationGoal {
@@ -2267,7 +2276,11 @@ class SettingsManager {
    */
   private upsertAgentSettings(
     agentId: string,
-    updates: Partial<Omit<AgentSettings, "agentId" | "baseUrl">>,
+    updates: Partial<
+      Omit<AgentSettings, "agentId" | "baseUrl" | "systemPromptRecipe">
+    > & {
+      systemPromptRecipe?: SystemPromptRecipe | null;
+    },
     serverKeyOverride?: string,
   ): void {
     const settings = this.getSettings();
@@ -2299,6 +2312,10 @@ class SettingsManager {
           updates.systemPromptPreset !== undefined
             ? updates.systemPromptPreset
             : existing.systemPromptPreset,
+        systemPromptRecipe:
+          updates.systemPromptRecipe !== undefined
+            ? (updates.systemPromptRecipe ?? undefined)
+            : existing.systemPromptRecipe,
       };
       // Clean up undefined/false values
       if (!updated.pinned) delete updated.pinned;
@@ -2306,6 +2323,7 @@ class SettingsManager {
       if (!updated.toolset || updated.toolset === "auto")
         delete updated.toolset;
       if (!updated.systemPromptPreset) delete updated.systemPromptPreset;
+      if (!updated.systemPromptRecipe) delete updated.systemPromptRecipe;
       if (!updated.baseUrl) delete updated.baseUrl;
       agents[idx] = updated;
     } else {
@@ -2314,6 +2332,7 @@ class SettingsManager {
         agentId,
         baseUrl: normalizedBaseUrl,
         ...updates,
+        systemPromptRecipe: updates.systemPromptRecipe ?? undefined,
       };
       // Clean up undefined/false values
       if (!newAgent.pinned) delete newAgent.pinned;
@@ -2321,6 +2340,7 @@ class SettingsManager {
       if (!newAgent.toolset || newAgent.toolset === "auto")
         delete newAgent.toolset;
       if (!newAgent.systemPromptPreset) delete newAgent.systemPromptPreset;
+      if (!newAgent.systemPromptRecipe) delete newAgent.systemPromptRecipe;
       if (!newAgent.baseUrl) delete newAgent.baseUrl;
       agents.push(newAgent);
     }
@@ -2388,10 +2408,40 @@ class SettingsManager {
   }
 
   /**
+   * Get the stored managed system prompt recipe for an agent on the current server.
+   */
+  getSystemPromptRecipe(agentId: string): SystemPromptRecipe | undefined {
+    return this.getAgentSettings(agentId)?.systemPromptRecipe;
+  }
+
+  /**
    * Set the system prompt preset for an agent on the current server.
    */
   setSystemPromptPreset(agentId: string, preset: string): void {
-    this.upsertAgentSettings(agentId, { systemPromptPreset: preset });
+    this.upsertAgentSettings(agentId, {
+      systemPromptPreset: preset,
+      systemPromptRecipe: null,
+    });
+  }
+
+  /**
+   * Store the managed system prompt recipe for an agent on the current server.
+   */
+  setSystemPromptRecipe(agentId: string, recipe: SystemPromptRecipe): void {
+    this.upsertAgentSettings(agentId, {
+      systemPromptPreset: recipe.preset,
+      systemPromptRecipe: recipe,
+    });
+  }
+
+  /**
+   * Mark an agent's system prompt as custom and clear any managed recipe.
+   */
+  setSystemPromptCustom(agentId: string): void {
+    this.upsertAgentSettings(agentId, {
+      systemPromptPreset: "custom",
+      systemPromptRecipe: null,
+    });
   }
 
   /**
@@ -2399,7 +2449,10 @@ class SettingsManager {
    */
   clearSystemPromptPreset(agentId: string): void {
     // Setting to empty string triggers the cleanup `if (!updated.systemPromptPreset) delete ...`
-    this.upsertAgentSettings(agentId, { systemPromptPreset: "" });
+    this.upsertAgentSettings(agentId, {
+      systemPromptPreset: "",
+      systemPromptRecipe: null,
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary
- track managed built-in system prompts with only preset + hash + Letta Code version
- schedule safe non-blocking prompt updates on resume/startup when the current prompt still matches the stored hash
- preserve custom/imported prompts and cover update/custom/legacy-tracking behavior in tests

## Testing
- bun run check
- bun test src/agent/system-prompt-versioning.test.ts src/agent/prompt-assets.test.ts