### PR TITLE
fix(resume): keep default conversation permanently pinned

### DIFF
--- a/src/cli/components/ConversationSelector.tsx
+++ b/src/cli/components/ConversationSelector.tsx
@@ -77,6 +77,19 @@ const RESUME_PREVIEW_MESSAGE_TYPES: MessageType[] = [
   "assistant_message",
 ];
 
+export function isDefaultConversationId(conversationId: string): boolean {
+  return conversationId === "default";
+}
+
+export function isConversationPinned(params: {
+  conversationId: string;
+  pinnedIds: Set<string>;
+}): boolean {
+  return isDefaultConversationId(params.conversationId)
+    ? true
+    : params.pinnedIds.has(params.conversationId);
+}
+
 function paginatedItems<T>(value: T[] | { getPaginatedItems(): T[] }): T[] {
   return Array.isArray(value) ? value : value.getPaginatedItems();
 }
@@ -516,7 +529,10 @@ export function ConversationSelector({
             lastActiveAt: conv.updated_at ?? conv.created_at ?? null,
             messageCount: -1, // Unknown until enriched
             enriched: false,
-            isPinned: pinnedIdSet.has(conv.id),
+            isPinned: isConversationPinned({
+              conversationId: conv.id,
+              pinnedIds: pinnedIdSet,
+            }),
             isPinnedLocal: localPinnedIdSet.has(conv.id),
           }),
         );
@@ -537,7 +553,7 @@ export function ConversationSelector({
             ? [
                 {
                   ...defaultConversation,
-                  isPinned: pinnedIdSet.has("default"),
+                  isPinned: true,
                   isPinnedLocal: localPinnedIdSet.has("default"),
                 },
                 ...nonEmptyList,
@@ -675,9 +691,14 @@ export function ConversationSelector({
                 conversation.updated_at ?? conversation.created_at ?? null,
               messageCount: -1,
               enriched: false,
-              isPinned: settingsManager
-                .getMergedPinnedConversations(agentId)
-                .some((pinned) => pinned.conversationId === conversation.id),
+              isPinned: isConversationPinned({
+                conversationId: conversation.id,
+                pinnedIds: new Set(
+                  settingsManager
+                    .getMergedPinnedConversations(agentId)
+                    .map((pinned) => pinned.conversationId),
+                ),
+              }),
               isPinnedLocal: settingsManager
                 .getLocalPinnedConversations(agentId)
                 .includes(conversation.id),
@@ -767,6 +788,7 @@ export function ConversationSelector({
     (selected: EnrichedConversation | undefined) => {
       if (!selected?.conversation.id) return;
       const conversationId = selected.conversation.id;
+      if (isDefaultConversationId(conversationId)) return;
       if (selected.isPinned) {
         settingsManager.unpinConversationBoth(agentId, conversationId);
       } else {

--- a/src/cli/components/ConversationSelector.tsx
+++ b/src/cli/components/ConversationSelector.tsx
@@ -90,6 +90,14 @@ export function isConversationPinned(params: {
     : params.pinnedIds.has(params.conversationId);
 }
 
+export function buildConversationSelectorHints(params: {
+  isSelectedDefaultConversation: boolean;
+}): string {
+  return params.isSelectedDefaultConversation
+    ? "Enter select · ↑↓ navigate · Esc clear/cancel"
+    : "Enter select · ↑↓ navigate · Alt+P pin/unpin · Esc clear/cancel";
+}
+
 function paginatedItems<T>(value: T[] | { getPaginatedItems(): T[] }): T[] {
   return Array.isArray(value) ? value : value.getPaginatedItems();
 }
@@ -355,6 +363,16 @@ export function ConversationSelector({
     EnrichedConversation[] | null
   >(null);
   const [searching, setSearching] = useState(false);
+  const [pinNotice, setPinNotice] = useState<string | null>(null);
+  const pinNoticeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (pinNoticeTimerRef.current) {
+        clearTimeout(pinNoticeTimerRef.current);
+      }
+    };
+  }, []);
 
   // Enrich a single conversation with message data, updating state in-place
   const enrichConversation = useCallback(
@@ -788,7 +806,18 @@ export function ConversationSelector({
     (selected: EnrichedConversation | undefined) => {
       if (!selected?.conversation.id) return;
       const conversationId = selected.conversation.id;
-      if (isDefaultConversationId(conversationId)) return;
+      if (isDefaultConversationId(conversationId)) {
+        if (pinNoticeTimerRef.current) {
+          clearTimeout(pinNoticeTimerRef.current);
+        }
+        setPinNotice("Default conversation is always pinned.");
+        pinNoticeTimerRef.current = setTimeout(() => {
+          pinNoticeTimerRef.current = null;
+          setPinNotice(null);
+        }, 2000);
+        return;
+      }
+      setPinNotice(null);
       if (selected.isPinned) {
         settingsManager.unpinConversationBoth(agentId, conversationId);
       } else {
@@ -995,6 +1024,10 @@ export function ConversationSelector({
 
   const terminalWidth = useTerminalWidth();
   const solidLine = SOLID_LINE.repeat(Math.max(terminalWidth, 10));
+  const selectedConversation = filteredConversations[selectedIndex];
+  const isSelectedDefaultConversation = selectedConversation
+    ? isDefaultConversationId(selectedConversation.conversation.id)
+    : false;
 
   return (
     <Box flexDirection="column">
@@ -1079,8 +1112,9 @@ export function ConversationSelector({
         (() => {
           const footerWidth = Math.max(0, terminalWidth - 2);
           const pageText = `Showing ${startIndex + 1}-${Math.min(startIndex + visibleConversations.length, filteredConversations.length)} of ${filteredConversations.length}${!normalizedSearch && hasMore ? "+" : ""}${loadingMore ? " (loading...)" : ""}`;
-          const hintsText =
-            "Enter select · ↑↓ navigate · Alt+P pin/unpin · Esc clear/cancel";
+          const hintsText = buildConversationSelectorHints({
+            isSelectedDefaultConversation,
+          });
 
           return (
             <Box flexDirection="column">
@@ -1096,6 +1130,14 @@ export function ConversationSelector({
                   <MarkdownDisplay text={hintsText} dimColor />
                 </Box>
               </Box>
+              {pinNotice && (
+                <Box flexDirection="row">
+                  <Box width={2} flexShrink={0} />
+                  <Box flexGrow={1} width={footerWidth}>
+                    <Text color="yellow">{pinNotice}</Text>
+                  </Box>
+                </Box>
+              )}
             </Box>
           );
         })()}

--- a/src/cli/conversation-selector.test.ts
+++ b/src/cli/conversation-selector.test.ts
@@ -3,6 +3,7 @@ import type { Conversation } from "@letta-ai/letta-client/resources/conversation
 import {
   buildDefaultConversationEntry,
   formatConversationTimestampText,
+  isConversationPinned,
   mergePinnedConversationRecords,
 } from "@/cli/components/ConversationSelector";
 
@@ -74,6 +75,26 @@ describe("ConversationSelector timestamps", () => {
 });
 
 describe("ConversationSelector pinned conversations", () => {
+  test("treats the default conversation as permanently pinned", () => {
+    expect(
+      isConversationPinned({
+        conversationId: "default",
+        pinnedIds: new Set(),
+      }),
+    ).toBe(true);
+  });
+
+  test("uses stored pin state for non-default conversations", () => {
+    const pinnedIds = new Set(["conv-pinned"]);
+
+    expect(
+      isConversationPinned({ conversationId: "conv-pinned", pinnedIds }),
+    ).toBe(true);
+    expect(
+      isConversationPinned({ conversationId: "conv-unpinned", pinnedIds }),
+    ).toBe(false);
+  });
+
   test("includes pinned conversations missing from the recent page", () => {
     const listed = [{ id: "recent-1" }, { id: "recent-2" }] as Conversation[];
     const pinned = [{ id: "old-pinned" }] as Conversation[];

--- a/src/cli/conversation-selector.test.ts
+++ b/src/cli/conversation-selector.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { Conversation } from "@letta-ai/letta-client/resources/conversations/conversations";
 import {
+  buildConversationSelectorHints,
   buildDefaultConversationEntry,
   formatConversationTimestampText,
   isConversationPinned,
@@ -75,6 +76,15 @@ describe("ConversationSelector timestamps", () => {
 });
 
 describe("ConversationSelector pinned conversations", () => {
+  test("hides the pin shortcut hint when default conversation is selected", () => {
+    expect(
+      buildConversationSelectorHints({ isSelectedDefaultConversation: true }),
+    ).not.toContain("Alt+P");
+    expect(
+      buildConversationSelectorHints({ isSelectedDefaultConversation: false }),
+    ).toContain("Alt+P pin/unpin");
+  });
+
   test("treats the default conversation as permanently pinned", () => {
     expect(
       isConversationPinned({


### PR DESCRIPTION
## Summary
- treat the default conversation as always pinned in the TUI resume selector
- prevent Alt+P from unpinning the default conversation
- hide the Alt+P pin/unpin footer hint while default is selected
- show a short notice if Alt+P is pressed on default
- preserve stored pin behavior for non-default conversations

## Testing
- bun test src/cli/conversation-selector.test.ts
- bunx --bun @biomejs/biome@2.2.5 check src/cli/components/ConversationSelector.tsx src/cli/conversation-selector.test.ts
- bun run check