### PR TITLE
refactor(extensions): consolidate event emission capability

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -1136,13 +1136,9 @@ export function App({
       }
 
       const extensionAdapter = extensionAdapterRef.current;
-      if (
-        extensionAdapter &&
-        !extensionAdapter.isLoading &&
-        extensionAdapter.hasExtensionSources
-      ) {
+      if (extensionAdapter) {
         try {
-          await extensionAdapter.emitEvent("conversation_close", {
+          await extensionAdapter.events.emit("conversation_close", {
             agentId: agentIdRef.current ?? null,
             conversationId: conversationIdRef.current ?? null,
             durationMs,
@@ -1583,7 +1579,7 @@ export function App({
           conversationId: conversationIdRef.current,
           overrideModel: desiredModel,
           workingDirectory,
-          extensionEventEmitter: extensionAdapterRef.current?.eventEmitter,
+          extensionEvents: extensionAdapterRef.current?.events,
         });
       }
 
@@ -1591,7 +1587,7 @@ export function App({
         return prepareToolExecutionContextForResolvedTarget({
           modelIdentifier: desiredModel,
           conversationId: conversationIdRef.current,
-          extensionEventEmitter: extensionAdapterRef.current?.eventEmitter,
+          extensionEvents: extensionAdapterRef.current?.events,
           toolsetPreference: currentToolsetPreference,
           workingDirectory,
         });
@@ -1600,7 +1596,7 @@ export function App({
       return prepareToolExecutionContextForResolvedTarget({
         modelIdentifier: null,
         conversationId: conversationIdRef.current,
-        extensionEventEmitter: extensionAdapterRef.current?.eventEmitter,
+        extensionEvents: extensionAdapterRef.current?.events,
         toolsetPreference: currentToolsetPreference,
         workingDirectory,
       });
@@ -2320,7 +2316,7 @@ export function App({
     if (!extensionAdapter.hasExtensionSources) return;
 
     sessionExtensionStartAttemptedRef.current = true;
-    void extensionAdapter.emitEvent("conversation_open", {
+    void extensionAdapter.events.emit("conversation_open", {
       agentId,
       agentName: agentName ?? null,
       conversationId: conversationIdRef.current ?? null,

--- a/src/cli/app/use-conversation-loop.ts
+++ b/src/cli/app/use-conversation-loop.ts
@@ -630,11 +630,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
       }
       processingConversationRef.current += 1;
 
-      if (
-        hasUserMessageInput(currentInput) &&
-        extensionAdapter.hasExtensionSources &&
-        !extensionAdapter.isLoading
-      ) {
+      if (hasUserMessageInput(currentInput)) {
         const originalInput = currentInput;
         try {
           const turnStartEvent = {
@@ -642,7 +638,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
             conversationId: conversationIdRef.current ?? null,
             input: currentInput,
           };
-          await extensionAdapter.emitEvent("turn_start", turnStartEvent);
+          await extensionAdapter.events.emit("turn_start", turnStartEvent);
           currentInput = isTurnInputArray(turnStartEvent.input)
             ? turnStartEvent.input
             : originalInput;

--- a/src/cli/app/use-conversation-switching.ts
+++ b/src/cli/app/use-conversation-switching.ts
@@ -434,7 +434,7 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
           })
           .catch(() => {});
         sessionHooksRanRef.current = true;
-        void extensionAdapter.emitEvent("conversation_open", {
+        void extensionAdapter.events.emit("conversation_open", {
           agentId,
           agentName: agentName ?? null,
           conversationId,

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -1635,7 +1635,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               })
               .catch(() => {});
             sessionHooksRanRef.current = true;
-            void extensionAdapter.emitEvent("conversation_open", {
+            void extensionAdapter.events.emit("conversation_open", {
               agentId,
               agentName: agentName ?? null,
               conversationId: conversation.id,
@@ -1733,7 +1733,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               })
               .catch(() => {});
             sessionHooksRanRef.current = true;
-            void extensionAdapter.emitEvent("conversation_open", {
+            void extensionAdapter.events.emit("conversation_open", {
               agentId,
               agentName: agentName ?? null,
               conversationId: forked.id,
@@ -1849,7 +1849,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               })
               .catch(() => {});
             sessionHooksRanRef.current = true;
-            void extensionAdapter.emitEvent("conversation_open", {
+            void extensionAdapter.events.emit("conversation_open", {
               agentId,
               agentName: agentName ?? null,
               conversationId: conversation.id,

--- a/src/cli/extensions/use-local-extension-adapter.ts
+++ b/src/cli/extensions/use-local-extension-adapter.ts
@@ -9,19 +9,10 @@ import {
   type ExtensionAdapter,
   type ExtensionAdapterSnapshot,
 } from "./local-extension-loader";
-import type {
-  ExtensionContext,
-  ExtensionEventEmissionResult,
-  ExtensionEventMap,
-  ExtensionEventName,
-} from "./types";
+import type { ExtensionContext } from "./types";
 
 export interface LocalExtensionAdapter {
-  emitEvent: <TName extends ExtensionEventName>(
-    name: TName,
-    event: ExtensionEventMap[TName],
-  ) => Promise<ExtensionEventEmissionResult<TName>>;
-  eventEmitter: ExtensionAdapter["eventEmitter"];
+  events: ExtensionAdapter["events"];
   getBackendApi: () => ExtensionAdapterBackendApi | undefined;
   getContext: () => ExtensionContext;
   hadStatuslineRenderer: boolean; // Used to prevent flicker on reload
@@ -98,8 +89,7 @@ export function useLocalExtensionAdapter(
 
   return useMemo(
     () => ({
-      emitEvent: adapter.emitEvent,
-      eventEmitter: adapter.eventEmitter,
+      events: adapter.events,
       getBackendApi: adapter.getBackendApi,
       getContext: adapter.getContext,
       hadStatuslineRenderer: snapshot.hadStatuslineRenderer,

--- a/src/extensions/event-emitter.ts
+++ b/src/extensions/event-emitter.ts
@@ -4,17 +4,14 @@ import type {
   ExtensionEventName,
 } from "@/extensions/types";
 
-export type ExtensionAdapterEventSnapshot = {
-  hasExtensionSources: boolean;
-  isLoading: boolean;
-};
-
-export type ExtensionEventEmitter = {
-  emitEvent: <TName extends ExtensionEventName>(
+// Narrow event capability exposed by the extension adapter. Adapter-owned
+// implementations are guarded, so lower layers can emit events without
+// depending on adapter lifecycle or registry APIs.
+export type ExtensionEvents = {
+  emit: <TName extends ExtensionEventName>(
     name: TName,
     event: ExtensionEventMap[TName],
   ) => Promise<ExtensionEventEmissionResult<TName>>;
-  getSnapshot: () => ExtensionAdapterEventSnapshot;
 };
 
 export function emptyEventEmissionResult<TName extends ExtensionEventName>(
@@ -24,18 +21,13 @@ export function emptyEventEmissionResult<TName extends ExtensionEventName>(
 }
 
 export async function emitExtensionEvent<TName extends ExtensionEventName>(
-  emitter: ExtensionEventEmitter | undefined,
+  events: ExtensionEvents | undefined,
   name: TName,
   event: ExtensionEventMap[TName],
 ): Promise<ExtensionEventEmissionResult<TName>> {
-  if (!emitter) {
+  if (!events) {
     return emptyEventEmissionResult(name);
   }
 
-  const snapshot = emitter.getSnapshot();
-  if (snapshot.isLoading || !snapshot.hasExtensionSources) {
-    return emptyEventEmissionResult(name);
-  }
-
-  return emitter.emitEvent(name, event);
+  return events.emit(name, event);
 }

--- a/src/extensions/extension-adapter.test.ts
+++ b/src/extensions/extension-adapter.test.ts
@@ -210,7 +210,7 @@ describe("extension adapter", () => {
       expect(adapter.getSnapshot().registry.sources).toEqual([]);
 
       await adapter.reload();
-      const result = await adapter.emitEvent("conversation_open", {
+      const result = await adapter.events.emit("conversation_open", {
         agentId: "agent-1",
         agentName: "Amelia",
         conversationId: "conversation-1",
@@ -284,6 +284,15 @@ describe("extension adapter", () => {
       });
       expect(adapter.getSnapshot()).toBe(adapter.getSnapshot());
 
+      const loadingResult = await adapter.events.emit("conversation_open", {
+        agentId: "agent-1",
+        agentName: "Amelia",
+        conversationId: "conversation-1",
+        reason: "startup",
+      });
+      expect(loadingResult.handlerCount).toBe(0);
+      expect(testGlobal.__lettaAdapterEvents).toEqual([]);
+
       await adapter.reload();
       adapter.updateContext(createExtensionContext("Updated Agent"));
 
@@ -293,7 +302,7 @@ describe("extension adapter", () => {
       });
       expect(adapter.getSnapshot().registry.loadedPaths).toHaveLength(1);
 
-      await adapter.emitEvent("conversation_open", {
+      await adapter.events.emit("conversation_open", {
         agentId: "agent-1",
         agentName: "Updated Agent",
         conversationId: "conversation-1",

--- a/src/extensions/extension-adapter.ts
+++ b/src/extensions/extension-adapter.ts
@@ -9,7 +9,7 @@ import {
   disableExtensionsForProcess,
 } from "@/extensions/disable";
 import {
-  type ExtensionEventEmitter,
+  type ExtensionEvents,
   emptyEventEmissionResult,
 } from "@/extensions/event-emitter";
 import {
@@ -23,9 +23,6 @@ import { clearExtensionTools } from "@/extensions/tool-registry";
 import type {
   ExtensionAdapterBackendApi,
   ExtensionContext,
-  ExtensionEventEmissionResult,
-  ExtensionEventMap,
-  ExtensionEventName,
 } from "@/extensions/types";
 import { debugLog } from "@/utils/debug";
 
@@ -105,21 +102,15 @@ function createDisabledExtensionAdapter(
     isLoading: false,
     registry,
   };
-  const eventEmitter: ExtensionEventEmitter = {
-    emitEvent(name) {
+  const events: ExtensionEvents = {
+    emit(name) {
       return Promise.resolve(emptyEventEmissionResult(name));
-    },
-    getSnapshot() {
-      return snapshot;
     },
   };
 
   return {
     dispose() {},
-    emitEvent(name) {
-      return Promise.resolve(emptyEventEmissionResult(name));
-    },
-    eventEmitter,
+    events,
     getBackendApi() {
       return undefined;
     },
@@ -144,11 +135,7 @@ function createDisabledExtensionAdapter(
 
 export interface ExtensionAdapter {
   dispose: () => void;
-  emitEvent: <TName extends ExtensionEventName>(
-    name: TName,
-    event: ExtensionEventMap[TName],
-  ) => Promise<ExtensionEventEmissionResult<TName>>;
-  eventEmitter: ExtensionEventEmitter;
+  events: ExtensionEvents;
   getBackendApi: () => ExtensionAdapterBackendApi | undefined;
   getContext: () => ExtensionContext;
   getSnapshot: () => ExtensionAdapterSnapshot;
@@ -236,12 +223,12 @@ export function createExtensionAdapter(
     getContext,
   });
 
-  const eventEmitter: ExtensionEventEmitter = {
-    emitEvent(name, event) {
+  const events: ExtensionEvents = {
+    emit(name, event) {
+      if (loadState.isLoading || !loadState.hasExtensionSources) {
+        return Promise.resolve(emptyEventEmissionResult(name));
+      }
       return engine.emitEvent(name, event, getBackendApi());
-    },
-    getSnapshot() {
-      return loadState;
     },
   };
 
@@ -319,10 +306,7 @@ export function createExtensionAdapter(
       unsubscribeEngine();
       listeners.clear();
     },
-    emitEvent(name, event) {
-      return engine.emitEvent(name, event, getBackendApi());
-    },
-    eventEmitter,
+    events,
     getBackendApi,
     getContext,
     getSnapshot,

--- a/src/headless-extension-adapter.ts
+++ b/src/headless-extension-adapter.ts
@@ -191,9 +191,7 @@ export async function emitHeadlessConversationOpen(options: {
   reason: ExtensionConversationOpenReason;
   adapter: ExtensionAdapter;
 }): Promise<void> {
-  if (!options.adapter.getSnapshot().hasExtensionSources) return;
-
-  await options.adapter.emitEvent("conversation_open", {
+  await options.adapter.events.emit("conversation_open", {
     agentId: options.agent.id,
     agentName: options.agent.name ?? null,
     conversationId: options.conversationId,
@@ -207,9 +205,7 @@ export async function emitHeadlessConversationClose(options: {
   durationMs: number | null;
   adapter: ExtensionAdapter;
 }): Promise<void> {
-  if (!options.adapter.getSnapshot().hasExtensionSources) return;
-
-  await options.adapter.emitEvent("conversation_close", {
+  await options.adapter.events.emit("conversation_close", {
     agentId: options.agent.id,
     conversationId: options.conversationId,
     durationMs: options.durationMs,

--- a/src/headless-extension-lifecycle.test.ts
+++ b/src/headless-extension-lifecycle.test.ts
@@ -173,7 +173,7 @@ describe("headless extension adapter", () => {
           agentId: agent.id,
           cachedAgent: agent,
           conversationId: "default",
-          extensionEventEmitter: adapter.eventEmitter,
+          extensionEvents: adapter.events,
         });
       const clientToolNames =
         prepared.preparedToolContext.preparedToolContext.clientTools.map(
@@ -313,7 +313,7 @@ describe("headless extension adapter", () => {
           agentId: agent.id,
           cachedAgent: agent,
           conversationId: "default",
-          extensionEventEmitter: adapter.eventEmitter,
+          extensionEvents: adapter.events,
         });
 
       const result = await executeTool(
@@ -335,7 +335,7 @@ describe("headless extension adapter", () => {
     }
   });
 
-  test("uses the captured adapter emitter for tool_start", async () => {
+  test("uses the captured adapter events for tool_start", async () => {
     const root = mkdtempSync(
       path.join(tmpdir(), "letta-headless-tool-start-captured-"),
     );
@@ -397,7 +397,7 @@ describe("headless extension adapter", () => {
           agentId: agent.id,
           cachedAgent: agent,
           conversationId: "default",
-          extensionEventEmitter: firstAdapter.eventEmitter,
+          extensionEvents: firstAdapter.events,
         });
 
       secondAdapter = createHeadlessExtensionAdapter({

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -426,7 +426,7 @@ async function prepareHeadlessToolExecutionContext(params: {
   conversationId: string;
   overrideModel?: string | null;
   cachedAgent?: AgentState | null;
-  extensionEventEmitter?: ExtensionAdapter["eventEmitter"];
+  extensionEvents?: ExtensionAdapter["events"];
 }): Promise<{
   preparedToolContext: Awaited<
     ReturnType<typeof prepareToolExecutionContextForScope>
@@ -440,7 +440,7 @@ async function prepareHeadlessToolExecutionContext(params: {
     workingDirectory: getCurrentWorkingDirectory(),
     exclude: ["AskUserQuestion"],
     cachedAgent: params.cachedAgent,
-    extensionEventEmitter: params.extensionEventEmitter,
+    extensionEvents: params.extensionEvents,
   });
 
   return {
@@ -466,15 +466,13 @@ async function emitHeadlessTurnStart(options: {
   input: Array<MessageCreate | ApprovalCreate>;
   adapter: ExtensionAdapter;
 }): Promise<Array<MessageCreate | ApprovalCreate>> {
-  if (!options.adapter.getSnapshot().hasExtensionSources) return options.input;
-
   try {
     const event = {
       agentId: options.agent.id,
       conversationId: options.conversationId,
       input: options.input,
     };
-    await options.adapter.emitEvent("turn_start", event);
+    await options.adapter.events.emit("turn_start", event);
     return isTurnInputArray(event.input) ? event.input : options.input;
   } catch {
     // Extension turn_start handlers should not block sending the turn.
@@ -486,12 +484,12 @@ async function sendScopedApprovalMessages(params: {
   agentId: string;
   conversationId: string;
   approvalMessages: Array<MessageCreate | ApprovalCreate>;
-  extensionEventEmitter?: ExtensionAdapter["eventEmitter"];
+  extensionEvents?: ExtensionAdapter["events"];
 }): Promise<Awaited<ReturnType<typeof sendMessageStream>>> {
   const approvalToolContext = await prepareHeadlessToolExecutionContext({
     agentId: params.agentId,
     conversationId: params.conversationId,
-    extensionEventEmitter: params.extensionEventEmitter,
+    extensionEvents: params.extensionEvents,
   });
 
   return await sendMessageStream(
@@ -1709,7 +1707,7 @@ export async function handleHeadlessCommand(
       agentId: agent.id,
       conversationId,
       cachedAgent: agent as AgentState,
-      extensionEventEmitter: headlessExtensionAdapter.eventEmitter,
+      extensionEvents: headlessExtensionAdapter.events,
     });
     availableTools = initialToolContext.availableTools;
     cachedAgent = initialToolContext.preparedToolContext.agent;
@@ -1881,7 +1879,7 @@ export async function handleHeadlessCommand(
         agentId: agent.id,
         conversationId,
         approvalMessages,
-        extensionEventEmitter: headlessExtensionAdapter.eventEmitter,
+        extensionEvents: headlessExtensionAdapter.events,
       });
       const drainResult = await drainStreamWithResume(
         approvalStream,
@@ -2131,7 +2129,7 @@ ${SYSTEM_REMINDER_CLOSE}
           conversationId,
           overrideModel: overrideModelHandle ?? preparedEffectiveModel,
           cachedAgent,
-          extensionEventEmitter: headlessExtensionAdapter.eventEmitter,
+          extensionEvents: headlessExtensionAdapter.events,
         });
         availableTools = turnToolContext.availableTools;
         stream = await sendMessageStream(conversationId, currentInput, {
@@ -3257,7 +3255,7 @@ async function runBidirectionalMode(
         agentId: agent.id,
         conversationId,
         approvalMessages,
-        extensionEventEmitter: headlessExtensionAdapter.eventEmitter,
+        extensionEvents: headlessExtensionAdapter.events,
       });
       const drainResult = await drainStreamWithResume(
         approvalStream,
@@ -3637,7 +3635,7 @@ async function runBidirectionalMode(
         agentId: agent.id,
         conversationId: targetConversationId,
         approvalMessages: [approvalInput],
-        extensionEventEmitter: headlessExtensionAdapter.eventEmitter,
+        extensionEvents: headlessExtensionAdapter.events,
       });
 
       const drainResult = await drainStreamWithResume(
@@ -4092,7 +4090,7 @@ async function runBidirectionalMode(
             const turnToolContext = await prepareHeadlessToolExecutionContext({
               agentId: agent.id,
               conversationId,
-              extensionEventEmitter: headlessExtensionAdapter.eventEmitter,
+              extensionEvents: headlessExtensionAdapter.events,
             });
             availableTools = turnToolContext.availableTools;
             stream = await sendMessageStream(conversationId, currentInput, {

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -20,7 +20,7 @@ import type { ChannelTurnSource } from "@/channels/types";
 import { INTERRUPTED_BY_USER } from "@/constants";
 import { loadExtensionConversationHistoryFromBackend } from "@/extensions/conversation-history";
 import {
-  type ExtensionEventEmitter,
+  type ExtensionEvents,
   emitExtensionEvent,
 } from "@/extensions/event-emitter";
 import {
@@ -589,7 +589,7 @@ type ToolExecutionContextSnapshot = {
   toolRegistry: ToolRegistry;
   externalTools: Map<string, ExternalToolDefinition>;
   externalExecutor?: ExternalToolExecutor;
-  extensionEventEmitter?: ExtensionEventEmitter;
+  extensionEvents?: ExtensionEvents;
   extensionTools: Map<string, ExtensionToolDefinition>;
   workingDirectory: string;
   runtimeContext: RuntimeContextSnapshot;
@@ -1012,14 +1012,14 @@ function capturePreparedToolExecutionContext(
     toolRegistry: ToolRegistry;
     externalTools: Map<string, ExternalToolDefinition>;
     externalExecutor?: ExternalToolExecutor;
-    extensionEventEmitter?: ExtensionEventEmitter;
+    extensionEvents?: ExtensionEvents;
     extensionTools: Map<string, ExtensionToolDefinition>;
   },
   options?: {
     clientToolAllowlist?: string[];
     workingDirectory?: string;
     permissionModeState?: PermissionModeState;
-    extensionEventEmitter?: ExtensionEventEmitter;
+    extensionEvents?: ExtensionEvents;
     runtimeContext?: Partial<RuntimeContextSnapshot>;
     channelToolScope?: MessageChannelToolDiscoveryScope | null;
     channelTurnSources?: ChannelTurnSource[];
@@ -1039,8 +1039,7 @@ function capturePreparedToolExecutionContext(
       options?.clientToolAllowlist,
     ),
     externalExecutor: snapshot.externalExecutor,
-    extensionEventEmitter:
-      options?.extensionEventEmitter ?? snapshot.extensionEventEmitter,
+    extensionEvents: options?.extensionEvents ?? snapshot.extensionEvents,
     extensionTools: filterExtensionToolsByClientAllowlist(
       snapshot.extensionTools,
       options?.clientToolAllowlist,
@@ -1095,7 +1094,7 @@ export async function prepareCurrentToolExecutionContext(options?: {
   runtimeContext?: Partial<RuntimeContextSnapshot>;
   channelToolScope?: MessageChannelToolDiscoveryScope | null;
   channelTurnSources?: ChannelTurnSource[];
-  extensionEventEmitter?: ExtensionEventEmitter;
+  extensionEvents?: ExtensionEvents;
 }): Promise<PreparedToolExecutionContext> {
   await waitForToolsetReady();
   const currentToolNames = maybeAppendChannelTools(
@@ -1108,7 +1107,7 @@ export async function prepareCurrentToolExecutionContext(options?: {
       toolRegistry: toolRegistrySnapshot,
       externalTools: new Map(getExternalToolsRegistry()),
       externalExecutor: getExternalToolExecutor(),
-      extensionEventEmitter: options?.extensionEventEmitter,
+      extensionEvents: options?.extensionEvents,
       extensionTools: getAvailableExtensionToolsRegistry(),
     },
     options,
@@ -1123,7 +1122,7 @@ export async function prepareToolExecutionContextForSpecificTools(
     permissionModeState?: PermissionModeState;
     channelToolScope?: MessageChannelToolDiscoveryScope | null;
     channelTurnSources?: ChannelTurnSource[];
-    extensionEventEmitter?: ExtensionEventEmitter;
+    extensionEvents?: ExtensionEvents;
     runtimeContext?: Partial<RuntimeContextSnapshot>;
   },
 ): Promise<PreparedToolExecutionContext> {
@@ -1136,7 +1135,7 @@ export async function prepareToolExecutionContextForSpecificTools(
       toolRegistry: toolRegistrySnapshot,
       externalTools: new Map(getExternalToolsRegistry()),
       externalExecutor: getExternalToolExecutor(),
-      extensionEventEmitter: options?.extensionEventEmitter,
+      extensionEvents: options?.extensionEvents,
       extensionTools: getAvailableExtensionToolsRegistry(),
     },
     options,
@@ -1153,7 +1152,7 @@ export async function prepareToolExecutionContextForModel(
     permissionModeState?: PermissionModeState;
     channelToolScope?: MessageChannelToolDiscoveryScope | null;
     channelTurnSources?: ChannelTurnSource[];
-    extensionEventEmitter?: ExtensionEventEmitter;
+    extensionEvents?: ExtensionEvents;
     runtimeContext?: Partial<RuntimeContextSnapshot>;
   },
 ): Promise<PreparedToolExecutionContext> {
@@ -1166,7 +1165,7 @@ export async function prepareToolExecutionContextForModel(
       toolRegistry: toolRegistrySnapshot,
       externalTools: new Map(getExternalToolsRegistry()),
       externalExecutor: getExternalToolExecutor(),
-      extensionEventEmitter: options?.extensionEventEmitter,
+      extensionEvents: options?.extensionEvents,
       extensionTools: getAvailableExtensionToolsRegistry(),
     },
     options,
@@ -1926,7 +1925,7 @@ function isToolStartArgs(value: unknown): value is ToolArgs {
 
 async function emitToolStartEvent(options: {
   args: ToolArgs;
-  eventEmitter?: ExtensionEventEmitter;
+  events?: ExtensionEvents;
   executionScope: RuntimeContextSnapshot;
   toolCallId?: string;
   toolName: string;
@@ -1940,7 +1939,7 @@ async function emitToolStartEvent(options: {
   };
 
   try {
-    await emitExtensionEvent(options.eventEmitter, "tool_start", event);
+    await emitExtensionEvent(options.events, "tool_start", event);
   } catch (error) {
     debugLog("extensions", "tool_start event failed", error);
     return options.args;
@@ -2179,7 +2178,7 @@ export async function executeTool(
     context?.externalExecutor ?? getExternalToolExecutor();
   const activeExtensionTools =
     context?.extensionTools ?? getAvailableExtensionToolsRegistry();
-  const extensionEventEmitter = context?.extensionEventEmitter;
+  const extensionEvents = context?.extensionEvents;
   const executionScope = context?.runtimeContext
     ? buildExecutionRuntimeContextSnapshot({
         workingDirectory: context.runtimeContext.workingDirectory ?? undefined,
@@ -2204,7 +2203,7 @@ export async function executeTool(
     }
     const eventArgs = await emitToolStartEvent({
       args,
-      eventEmitter: extensionEventEmitter,
+      events: extensionEvents,
       executionScope,
       toolCallId: options?.toolCallId,
       toolName: name,
@@ -2228,7 +2227,7 @@ export async function executeTool(
   if (activeExternalTools.has(name)) {
     const eventArgs = await emitToolStartEvent({
       args,
-      eventEmitter: extensionEventEmitter,
+      events: extensionEvents,
       executionScope,
       toolCallId: options?.toolCallId,
       toolName: name,
@@ -2269,7 +2268,7 @@ export async function executeTool(
 
   args = await emitToolStartEvent({
     args,
-    eventEmitter: extensionEventEmitter,
+    events: extensionEvents,
     executionScope,
     toolCallId: options?.toolCallId,
     toolName: internalName,

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -7,7 +7,7 @@ import { getSupportedChannelIds } from "@/channels/plugin-registry";
 import { getChannelRegistry } from "@/channels/registry";
 import { getRoutesForChannel, loadRoutes } from "@/channels/routing";
 import type { ChannelTurnSource, SupportedChannelId } from "@/channels/types";
-import type { ExtensionEventEmitter } from "@/extensions/event-emitter";
+import type { ExtensionEvents } from "@/extensions/event-emitter";
 import {
   type InheritedChannelContextPayload,
   LETTA_INHERITED_CHANNEL_CONTEXT_ENV,
@@ -196,7 +196,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
   workingDirectory?: string;
   permissionModeState?: PermissionModeState;
   channelToolScope?: MessageChannelToolDiscoveryScope | null;
-  extensionEventEmitter?: ExtensionEventEmitter;
+  extensionEvents?: ExtensionEvents;
   runtimeContext?: Partial<RuntimeContextSnapshot>;
 }): Promise<PreparedScopeToolContext> {
   const {
@@ -208,7 +208,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
     workingDirectory,
     permissionModeState,
     channelToolScope,
-    extensionEventEmitter,
+    extensionEvents,
     runtimeContext,
   } = params;
   const effectiveModel =
@@ -234,7 +234,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
         workingDirectory,
         permissionModeState,
         channelToolScope,
-        extensionEventEmitter,
+        extensionEvents,
         runtimeContext,
       },
     );
@@ -265,7 +265,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
       workingDirectory,
       permissionModeState,
       channelToolScope,
-      extensionEventEmitter,
+      extensionEvents,
       runtimeContext,
     },
   );
@@ -434,7 +434,7 @@ export async function prepareToolExecutionContextForScope(params: {
   permissionModeState?: PermissionModeState;
   cachedAgent?: AgentState | null;
   channelTurnSources?: import("@/channels/types").ChannelTurnSource[];
-  extensionEventEmitter?: ExtensionEventEmitter;
+  extensionEvents?: ExtensionEvents;
 }): Promise<PreparedScopeToolContext> {
   const {
     agentId,
@@ -447,7 +447,7 @@ export async function prepareToolExecutionContextForScope(params: {
     permissionModeState,
     cachedAgent,
     channelTurnSources: explicitChannelTurnSources,
-    extensionEventEmitter,
+    extensionEvents,
   } = params;
 
   const backend = getBackend();
@@ -507,7 +507,7 @@ export async function prepareToolExecutionContextForScope(params: {
     clientToolAllowlist,
     workingDirectory,
     permissionModeState,
-    extensionEventEmitter,
+    extensionEvents,
     runtimeContext: {
       agentId,
       conversationId: scopedConversationId,


### PR DESCRIPTION
## Summary
- replace adapter-level `emitEvent` / `eventEmitter` surfaces with a single narrow `events.emit` capability
- move extension loading/no-source guards into the adapter-owned events capability
- pass `extensionEvents` through tool/headless execution contexts instead of adapter-shaped event emitters
- remove redundant caller-side availability checks now handled by the guarded event capability

## Tests
- `bun test src/extensions/extension-adapter.test.ts src/extensions/extension-engine.test.ts src/tools/tool-execution-context.test.ts src/headless-extension-lifecycle.test.ts`
- `bun run check`
- `git diff --check`