### PR TITLE
refactor(extensions): pass backend directly through adapter

### DIFF
--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -713,7 +713,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             const cwd = getCurrentWorkingDirectory();
             const conversation = createExtensionConversationHandle({
               agentId,
-              backend: extensionAdapter.getBackendApi(),
+              backend: extensionAdapter.getBackend(),
               conversationId: conversationIdRef.current,
               workingDirectory: cwd,
             });

--- a/src/cli/extensions/use-local-extension-adapter.ts
+++ b/src/cli/extensions/use-local-extension-adapter.ts
@@ -1,9 +1,6 @@
 import { useEffect, useMemo, useSyncExternalStore } from "react";
-import { sendMessageStreamWithBackend } from "@/agent/message";
-import { type Backend, getBackend } from "@/backend";
+import { getBackend } from "@/backend";
 import { getClient } from "@/backend/api/client";
-import { loadExtensionConversationHistoryFromBackend } from "@/extensions/conversation-history";
-import type { ExtensionAdapterBackendApi } from "@/extensions/types";
 import {
   createExtensionAdapter,
   type ExtensionAdapter,
@@ -13,7 +10,7 @@ import type { ExtensionContext } from "./types";
 
 export interface LocalExtensionAdapter {
   events: ExtensionAdapter["events"];
-  getBackendApi: () => ExtensionAdapterBackendApi | undefined;
+  getBackend: ExtensionAdapter["getBackend"];
   getContext: () => ExtensionContext;
   hadStatuslineRenderer: boolean; // Used to prevent flicker on reload
   hasExtensionSources: boolean;
@@ -22,35 +19,6 @@ export interface LocalExtensionAdapter {
   registry: ExtensionAdapterSnapshot["registry"];
   reload: () => Promise<void>;
   updateContext: (context: ExtensionContext) => void;
-}
-
-function createExtensionBackendApi(
-  backend: Backend,
-): ExtensionAdapterBackendApi {
-  return {
-    forkConversation(conversationId, options) {
-      return backend.forkConversation(conversationId, options);
-    },
-    getConversationHistory(conversationId, options) {
-      return loadExtensionConversationHistoryFromBackend(
-        backend,
-        {
-          agentId: options?.agentId,
-          conversationId,
-        },
-        options,
-      );
-    },
-    sendMessageStream(conversationId, messages, options, requestOptions) {
-      return sendMessageStreamWithBackend(
-        backend,
-        conversationId,
-        messages,
-        options,
-        requestOptions,
-      );
-    },
-  };
 }
 
 export function useLocalExtensionAdapter(
@@ -62,7 +30,7 @@ export function useLocalExtensionAdapter(
     () =>
       createExtensionAdapter({
         disabled: options.disabled,
-        getBackendApi: () => createExtensionBackendApi(getBackend()),
+        getBackend,
         getClient,
         initialContext,
       }),
@@ -90,7 +58,7 @@ export function useLocalExtensionAdapter(
   return useMemo(
     () => ({
       events: adapter.events,
-      getBackendApi: adapter.getBackendApi,
+      getBackend: adapter.getBackend,
       getContext: adapter.getContext,
       hadStatuslineRenderer: snapshot.hadStatuslineRenderer,
       hasExtensionSources: snapshot.hasExtensionSources,

--- a/src/extensions/conversation-handle.test.ts
+++ b/src/extensions/conversation-handle.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
+import type { Backend, ConversationMessageListBody } from "@/backend";
+import { createExtensionConversationHandle } from "@/extensions/conversation-handle";
+
+describe("extension conversation handle", () => {
+  test("uses the internal backend directly for scoped fork and history", async () => {
+    const calls: string[] = [];
+    const newestFirstMessages = [
+      { id: "message-2" },
+      { id: "message-1" },
+    ] as unknown as Message[];
+    const backend = {
+      forkConversation: async (
+        ...[conversationId, options]: Parameters<Backend["forkConversation"]>
+      ) => {
+        calls.push(
+          `fork:${conversationId}:${options?.agentId}:${options?.hidden}`,
+        );
+        return { id: "forked-conversation" };
+      },
+      listConversationMessages: async (
+        conversationId: string,
+        body?: ConversationMessageListBody,
+      ) => {
+        calls.push(
+          `history:${conversationId}:${body?.agent_id}:${body?.limit}:${body?.order}:${body?.include_err}`,
+        );
+        return {
+          getPaginatedItems: () => newestFirstMessages,
+        };
+      },
+    } as unknown as Backend;
+
+    const handle = createExtensionConversationHandle({
+      agentId: "agent-1",
+      backend,
+      conversationId: null,
+      workingDirectory: "/tmp/project",
+    });
+
+    const forked = await handle.fork({ hidden: true });
+    const history = await handle.getHistory({ limit: 2 });
+
+    expect(forked.id).toBe("forked-conversation");
+    expect(history.map((message) => message.id)).toEqual([
+      "message-1",
+      "message-2",
+    ]);
+    expect(calls).toEqual([
+      "fork:default:agent-1:true",
+      "history:default:agent-1:2:desc:true",
+    ]);
+  });
+
+  test("throws a scoped error when no backend is available", () => {
+    const handle = createExtensionConversationHandle({
+      conversationId: "conversation-1",
+    });
+
+    expect(() => handle.getHistory()).toThrow(
+      "Extension conversation backend is not available",
+    );
+  });
+});

--- a/src/extensions/conversation-handle.ts
+++ b/src/extensions/conversation-handle.ts
@@ -1,11 +1,11 @@
-import type {
-  ExtensionAdapterBackendApi,
-  ExtensionConversationHandle,
-} from "@/extensions/types";
+import { sendMessageStreamWithBackend } from "@/agent/message";
+import type { Backend } from "@/backend";
+import { loadExtensionConversationHistoryFromBackend } from "@/extensions/conversation-history";
+import type { ExtensionConversationHandle } from "@/extensions/types";
 
 export function createExtensionConversationHandle(options: {
   agentId?: string | null;
-  backend?: ExtensionAdapterBackendApi;
+  backend?: Backend;
   conversationId?: string | null;
   workingDirectory?: string | null;
 }): ExtensionConversationHandle {
@@ -30,13 +30,18 @@ export function createExtensionConversationHandle(options: {
       });
     },
     getHistory(historyOptions) {
-      return requireBackend().getConversationHistory(conversationId, {
-        ...(options.agentId ? { agentId: options.agentId } : {}),
-        ...historyOptions,
-      });
+      return loadExtensionConversationHistoryFromBackend(
+        requireBackend(),
+        {
+          agentId: options.agentId,
+          conversationId,
+        },
+        historyOptions,
+      );
     },
     sendMessageStream(messages, sendOptions, requestOptions) {
-      return requireBackend().sendMessageStream(
+      return sendMessageStreamWithBackend(
+        requireBackend(),
         conversationId,
         messages,
         {

--- a/src/extensions/extension-adapter.test.ts
+++ b/src/extensions/extension-adapter.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type Letta from "@letta-ai/letta-client";
+import type { Backend } from "@/backend";
 import {
   clearRegisteredPiProviders,
   listRegisteredPiProviders,
@@ -16,10 +17,7 @@ import {
   getExtensionToolDefinition,
   registerExtensionTool,
 } from "@/extensions/tool-registry";
-import type {
-  ExtensionAdapterBackendApi,
-  ExtensionContext,
-} from "@/extensions/types";
+import type { ExtensionContext } from "@/extensions/types";
 
 type ExtensionAdapterTestGlobal = typeof globalThis & {
   __lettaAdapterEvents?: string[];
@@ -265,14 +263,12 @@ describe("extension adapter", () => {
         }`,
       );
 
-      const backend: ExtensionAdapterBackendApi = {
+      const backend = {
         forkConversation: async () => ({ id: "forked-conversation" }),
-        getConversationHistory: async () => [],
-        sendMessageStream: async () => (async function* () {})(),
-      };
+      } as unknown as Backend;
       const adapter = createExtensionAdapter({
         cacheDirectory: path.join(root, "extension-cache"),
-        getBackendApi: () => backend,
+        getBackend: () => backend,
         getClient: async () => ({}) as unknown as Letta,
         globalExtensionsDirectory: extensionDir,
         initialContext: createExtensionContext(),

--- a/src/extensions/extension-adapter.ts
+++ b/src/extensions/extension-adapter.ts
@@ -1,4 +1,5 @@
 import type Letta from "@letta-ai/letta-client";
+import type { Backend } from "@/backend";
 import { clearRegisteredPiProviders } from "@/backend/dev/pi-provider-extension-registry";
 import {
   cloneExtensionCapabilities,
@@ -20,10 +21,7 @@ import {
   resolveLocalExtensionSources,
 } from "@/extensions/extension-engine";
 import { clearExtensionTools } from "@/extensions/tool-registry";
-import type {
-  ExtensionAdapterBackendApi,
-  ExtensionContext,
-} from "@/extensions/types";
+import type { ExtensionContext } from "@/extensions/types";
 import { debugLog } from "@/utils/debug";
 
 export interface ExtensionAdapterLoadState {
@@ -37,9 +35,9 @@ export interface ExtensionAdapterSnapshot extends ExtensionAdapterLoadState {
 }
 
 export interface CreateExtensionAdapterOptions
-  extends Omit<CreateExtensionEngineOptions, "backend" | "getContext"> {
+  extends Omit<CreateExtensionEngineOptions, "getBackend" | "getContext"> {
   disabled?: boolean;
-  getBackendApi?: () => ExtensionAdapterBackendApi | undefined;
+  getBackend?: () => Backend | undefined;
   getClient: () => Promise<Letta>;
   initialContext: ExtensionContext;
 }
@@ -111,7 +109,7 @@ function createDisabledExtensionAdapter(
   return {
     dispose() {},
     events,
-    getBackendApi() {
+    getBackend() {
       return undefined;
     },
     getContext() {
@@ -136,7 +134,7 @@ function createDisabledExtensionAdapter(
 export interface ExtensionAdapter {
   dispose: () => void;
   events: ExtensionEvents;
-  getBackendApi: () => ExtensionAdapterBackendApi | undefined;
+  getBackend: () => Backend | undefined;
   getContext: () => ExtensionContext;
   getSnapshot: () => ExtensionAdapterSnapshot;
   engine: ExtensionEngine;
@@ -156,35 +154,6 @@ function hasExtensionSources(
   );
 }
 
-function createLazyAdapterBackendApi(
-  getBackendApi: () => ExtensionAdapterBackendApi | undefined,
-): ExtensionAdapterBackendApi {
-  const requireBackend = () => {
-    const backend = getBackendApi();
-    if (!backend) {
-      throw new Error("Extension backend is not available");
-    }
-    return backend;
-  };
-
-  return {
-    forkConversation(conversationId, options) {
-      return requireBackend().forkConversation(conversationId, options);
-    },
-    getConversationHistory(conversationId, options) {
-      return requireBackend().getConversationHistory(conversationId, options);
-    },
-    sendMessageStream(conversationId, messages, options, requestOptions) {
-      return requireBackend().sendMessageStream(
-        conversationId,
-        messages,
-        options,
-        requestOptions,
-      );
-    },
-  };
-}
-
 export function createExtensionAdapter(
   options: CreateExtensionAdapterOptions,
 ): ExtensionAdapter {
@@ -197,7 +166,7 @@ export function createExtensionAdapter(
   }
 
   const {
-    getBackendApi: resolveBackendApi,
+    getBackend: resolveBackend,
     initialContext,
     ...engineOptions
   } = options;
@@ -211,15 +180,12 @@ export function createExtensionAdapter(
   };
   const listeners = new Set<() => void>();
 
-  const getBackendApi = () => resolveBackendApi?.();
+  const getBackend = () => resolveBackend?.();
   const getContext = () => context;
-  const backend = resolveBackendApi
-    ? createLazyAdapterBackendApi(getBackendApi)
-    : undefined;
 
   const engine = createExtensionEngine({
     ...engineOptions,
-    ...(backend ? { backend } : {}),
+    ...(resolveBackend ? { getBackend } : {}),
     getContext,
   });
 
@@ -228,7 +194,7 @@ export function createExtensionAdapter(
       if (loadState.isLoading || !loadState.hasExtensionSources) {
         return Promise.resolve(emptyEventEmissionResult(name));
       }
-      return engine.emitEvent(name, event, getBackendApi());
+      return engine.emitEvent(name, event);
     },
   };
 
@@ -307,7 +273,7 @@ export function createExtensionAdapter(
       listeners.clear();
     },
     events,
-    getBackendApi,
+    getBackend,
     getContext,
     getSnapshot,
     engine,

--- a/src/extensions/extension-engine.test.ts
+++ b/src/extensions/extension-engine.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type Letta from "@letta-ai/letta-client";
+import type { Backend } from "@/backend";
 import {
   clearRegisteredPiProviders,
   getRegisteredPiProvider,
@@ -16,7 +17,6 @@ import {
   getExtensionToolDefinition,
 } from "@/extensions/tool-registry";
 import type {
-  ExtensionAdapterBackendApi,
   ExtensionCapabilities,
   ExtensionContext,
   ExtensionPanelHandle,
@@ -24,13 +24,16 @@ import type {
 
 type ExtensionTestGlobal = typeof globalThis & {
   __lettaExtensionBackend?: unknown;
+  __lettaExtensionBackendCalls?: string[];
   __lettaExtensionForkResult?: { id: string };
+  __lettaExtensionHistoryResult?: string[];
   __lettaExtensionCapabilities?: ExtensionCapabilities;
   __lettaExtensionEvents?: string[];
   __lettaExtensionGate?: Promise<void>;
   __lettaExtensionPanel?: ExtensionPanelHandle;
   __lettaExtensionSignal?: AbortSignal;
   __lettaExtensionStarted?: () => void;
+  __lettaSwapBackend?: () => void;
 };
 
 function createTempDir(): string {
@@ -84,11 +87,11 @@ function createExtensionContext(): ExtensionContext {
 function createEngine(
   root: string,
   capabilities?: ExtensionCapabilities,
-  backend?: ExtensionAdapterBackendApi,
+  backend?: Backend,
 ): ExtensionEngine {
   return createExtensionEngine({
     cacheDirectory: path.join(root, "extension-cache"),
-    ...(backend ? { backend } : {}),
+    ...(backend ? { getBackend: () => backend } : {}),
     ...(capabilities ? { capabilities } : {}),
     getClient: async () => ({}) as unknown as Letta,
     getContext: createExtensionContext,
@@ -214,16 +217,13 @@ describe("extension engine", () => {
     delete testGlobal.__lettaExtensionBackend;
     delete testGlobal.__lettaExtensionForkResult;
 
-    const backend: ExtensionAdapterBackendApi = {
-      forkConversation: async (conversationId, options) => ({
+    const backend = {
+      forkConversation: async (
+        ...[conversationId, options]: Parameters<Backend["forkConversation"]>
+      ) => ({
         id: `${conversationId}:${options?.agentId}:${options?.hidden ? "hidden" : "visible"}`,
       }),
-      getConversationHistory: async () => [],
-      sendMessageStream: async () =>
-        (async function* () {
-          // Empty stream for engine plumbing tests.
-        })(),
-    };
+    } as unknown as Backend;
 
     try {
       const extensionDir = path.join(root, "global-extensions");
@@ -259,6 +259,90 @@ describe("extension engine", () => {
     } finally {
       delete testGlobal.__lettaExtensionBackend;
       delete testGlobal.__lettaExtensionForkResult;
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("captures backend once per event invocation for composed conversation helpers", async () => {
+    const root = createTempDir();
+    const testGlobal = globalThis as ExtensionTestGlobal;
+    testGlobal.__lettaExtensionBackendCalls = [];
+    delete testGlobal.__lettaExtensionHistoryResult;
+    delete testGlobal.__lettaSwapBackend;
+
+    const createBackend = (label: string) =>
+      ({
+        forkConversation: async (
+          ...[conversationId, options]: Parameters<Backend["forkConversation"]>
+        ) => {
+          testGlobal.__lettaExtensionBackendCalls?.push(
+            `${label}:fork:${conversationId}:${options?.agentId}:${options?.hidden}`,
+          );
+          return { id: `${label}-forked-conversation` };
+        },
+        listConversationMessages: async (
+          ...[conversationId, body]: Parameters<
+            Backend["listConversationMessages"]
+          >
+        ) => {
+          testGlobal.__lettaExtensionBackendCalls?.push(
+            `${label}:history:${conversationId}:${body?.limit}`,
+          );
+          return {
+            getPaginatedItems: () => [{ id: `${label}-message` }],
+          };
+        },
+      }) as unknown as Backend;
+
+    const backendA = createBackend("a");
+    const backendB = createBackend("b");
+    let activeBackend = backendA;
+    testGlobal.__lettaSwapBackend = () => {
+      activeBackend = backendB;
+    };
+
+    try {
+      const extensionDir = path.join(root, "global-extensions");
+      const extensionPath = path.join(extensionDir, "scoped-backend.ts");
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        extensionPath,
+        `export default function(letta) {
+          letta.events.on("conversation_open", async (_event, ctx) => {
+            const fork = await ctx.conversation.fork({ hidden: true });
+            globalThis.__lettaSwapBackend();
+            const history = await fork.getHistory({ limit: 1 });
+            globalThis.__lettaExtensionHistoryResult = history.map((message) => message.id);
+          });
+        }`,
+      );
+
+      const engine = createExtensionEngine({
+        cacheDirectory: path.join(root, "extension-cache"),
+        getBackend: () => activeBackend,
+        getClient: async () => ({}) as unknown as Letta,
+        getContext: createExtensionContext,
+        globalExtensionsDirectory: extensionDir,
+      });
+      await engine.reload();
+      await engine.emitEvent("conversation_open", {
+        agentId: "agent-1",
+        agentName: "Amelia",
+        conversationId: "conv-1",
+        reason: "startup",
+      });
+
+      expect(testGlobal.__lettaExtensionBackendCalls).toEqual([
+        "a:fork:conv-1:agent-1:true",
+        "a:history:a-forked-conversation:1",
+      ]);
+      const historyResult = (globalThis as ExtensionTestGlobal)
+        .__lettaExtensionHistoryResult;
+      expect(historyResult).toEqual(["a-message"]);
+    } finally {
+      delete testGlobal.__lettaExtensionBackendCalls;
+      delete testGlobal.__lettaExtensionHistoryResult;
+      delete testGlobal.__lettaSwapBackend;
       rmSync(root, { force: true, recursive: true });
     }
   });
@@ -373,11 +457,9 @@ describe("extension engine", () => {
         }`,
       );
 
-      const backend: ExtensionAdapterBackendApi = {
+      const backend = {
         forkConversation: async () => ({ id: "forked" }),
-        getConversationHistory: async () => [],
-        sendMessageStream: async () => (async function* () {})(),
-      };
+      } as unknown as Backend;
       const engine = createEngine(root, undefined, backend);
       await engine.reload();
       expect(engine.getSnapshot().events.conversation_open).toHaveLength(2);

--- a/src/extensions/extension-engine.ts
+++ b/src/extensions/extension-engine.ts
@@ -16,6 +16,7 @@ import { pathToFileURL } from "node:url";
 import type Letta from "@letta-ai/letta-client";
 import * as ts from "typescript";
 import { clearAvailableModelsCache } from "@/agent/available-models";
+import type { Backend } from "@/backend";
 import type { PiProviderRegistration } from "@/backend/dev/pi-provider-extension-registry";
 import {
   registerPiProvider,
@@ -39,7 +40,6 @@ import {
   unregisterExtensionToolsForOwner,
 } from "@/extensions/tool-registry";
 import type {
-  ExtensionAdapterBackendApi,
   ExtensionCapabilities,
   ExtensionCommand,
   ExtensionCommandRegistration,
@@ -207,7 +207,6 @@ export interface LoadLocalExtensionsOptions
   extends ResolveLocalExtensionSourcesOptions {
   getContext?: () => ExtensionContext;
   getClient: () => Promise<Letta>;
-  backend?: ExtensionAdapterBackendApi;
   capabilities?: ExtensionCapabilities;
   builtinCommandIds?: Iterable<string>;
   generation?: number;
@@ -221,7 +220,6 @@ export interface ExtensionEngine {
   emitEvent: <TName extends ExtensionEventName>(
     name: TName,
     event: ExtensionEventMap[TName],
-    backend?: ExtensionAdapterBackendApi,
   ) => Promise<ExtensionEventEmissionResult<TName>>;
   getSnapshot: () => LocalExtensionRegistry;
   reload: () => Promise<void>;
@@ -232,7 +230,7 @@ export interface CreateExtensionEngineOptions
   extends ResolveLocalExtensionSourcesOptions {
   getContext?: () => ExtensionContext;
   getClient: () => Promise<Letta>;
-  backend?: ExtensionAdapterBackendApi;
+  getBackend?: () => Backend | undefined;
   builtinCommandIds?: Iterable<string>;
   capabilities?: ExtensionCapabilities;
   reservedToolNames?: Iterable<string>;
@@ -1256,7 +1254,7 @@ export async function emitLocalExtensionEvent<TName extends ExtensionEventName>(
   name: TName,
   event: ExtensionEventMap[TName],
   getContext: () => ExtensionContext,
-  backend?: ExtensionAdapterBackendApi,
+  backend?: Backend,
   onDiagnostic?: (diagnostic: ExtensionDiagnostic) => void,
 ): Promise<ExtensionEventEmissionResult<TName>> {
   if (!registry) {
@@ -1397,16 +1395,19 @@ export function disposeLocalExtensions(registry: LocalExtensionRegistry): void {
 export function createExtensionEngine(
   options: CreateExtensionEngineOptions,
 ): ExtensionEngine {
+  const { getBackend, ...extensionOptions } = options;
   let generation = 0;
   let disposed = false;
-  const capabilities = resolveExtensionCapabilities(options.capabilities);
+  const capabilities = resolveExtensionCapabilities(
+    extensionOptions.capabilities,
+  );
   const getContext =
-    options.getContext ??
+    extensionOptions.getContext ??
     (() => {
       throw new Error("Extension context is not available yet");
     });
   let activeRegistry = createEmptyExtensionRegistry(
-    resolveLocalExtensionSources(options),
+    resolveLocalExtensionSources(extensionOptions),
     generation,
     capabilities,
   );
@@ -1427,7 +1428,7 @@ export function createExtensionEngine(
     generation += 1;
     const loadGeneration = generation;
     activeRegistry = createEmptyExtensionRegistry(
-      resolveLocalExtensionSources(options),
+      resolveLocalExtensionSources(extensionOptions),
       loadGeneration,
       capabilities,
     );
@@ -1435,7 +1436,7 @@ export function createExtensionEngine(
 
     let loadingRegistry: LocalExtensionRegistry | null = null;
     const nextRegistry = await loadLocalExtensions({
-      ...options,
+      ...extensionOptions,
       generation: loadGeneration,
       onChange: () => {
         if (!disposed && loadingRegistry && loadGeneration === generation) {
@@ -1486,23 +1487,24 @@ export function createExtensionEngine(
       generation += 1;
       disposeLocalExtensions(activeRegistry);
       activeRegistry = createEmptyExtensionRegistry(
-        resolveLocalExtensionSources(options),
+        resolveLocalExtensionSources(extensionOptions),
         generation,
         capabilities,
       );
       publish();
       listeners.clear();
     },
-    async emitEvent(name, payload, backend) {
+    async emitEvent(name, payload) {
       if (disposed) {
         return { diagnostics: [], handlerCount: 0, name, results: [] };
       }
+      const invocationBackend = getBackend?.();
       const result = await emitLocalExtensionEvent(
         activeRegistry,
         name,
         payload,
         getContext,
-        backend ?? options.backend,
+        invocationBackend,
       );
       if (result.diagnostics.length > 0) {
         publish();

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -127,38 +127,6 @@ export interface ExtensionConversationHandle {
   ) => Promise<AsyncIterable<LettaStreamingResponse>>;
 }
 
-export interface ExtensionAdapterBackendForkConversationOptions
-  extends ExtensionConversationForkOptions {
-  agentId?: string;
-}
-
-export interface ExtensionAdapterBackendSendMessageOptions
-  extends ExtensionConversationSendMessageOptions {
-  agentId?: string;
-}
-
-export interface ExtensionAdapterBackendHistoryOptions
-  extends ExtensionConversationHistoryOptions {
-  agentId?: string | null;
-}
-
-export interface ExtensionAdapterBackendApi {
-  forkConversation: (
-    conversationId: string,
-    options?: ExtensionAdapterBackendForkConversationOptions,
-  ) => Promise<{ id: string }>;
-  getConversationHistory: (
-    conversationId: string,
-    options?: ExtensionAdapterBackendHistoryOptions,
-  ) => Promise<Message[]>;
-  sendMessageStream: (
-    conversationId: string,
-    messages: ExtensionConversationMessage[],
-    options?: ExtensionAdapterBackendSendMessageOptions,
-    requestOptions?: ExtensionConversationSendMessageRequestOptions,
-  ) => Promise<AsyncIterable<LettaStreamingResponse>>;
-}
-
 export type ExtensionSourceScope = "global" | "project" | "bundled";
 
 export interface ExtensionOwner {

--- a/src/headless-extension-adapter.ts
+++ b/src/headless-extension-adapter.ts
@@ -1,18 +1,15 @@
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import { getScopedMemoryFilesystemRoot } from "@/agent/memory-filesystem";
-import { sendMessageStreamWithBackend } from "@/agent/message";
 import { getModelInfo } from "@/agent/model";
 import type { SessionStats } from "@/agent/stats";
 import type { Backend } from "@/backend";
 import { getClient } from "@/backend/api/client";
 import type { ReflectionSettings } from "@/cli/helpers/memory-reminder";
-import { loadExtensionConversationHistoryFromBackend } from "@/extensions/conversation-history";
 import {
   createExtensionAdapter,
   type ExtensionAdapter,
 } from "@/extensions/extension-adapter";
 import type {
-  ExtensionAdapterBackendApi,
   ExtensionCapabilities,
   ExtensionContext,
   ExtensionConversationOpenReason,
@@ -37,35 +34,6 @@ export const HEADLESS_EXTENSION_CAPABILITIES: ExtensionCapabilities = {
     customStatuslineRenderer: false,
   },
 };
-
-function createHeadlessExtensionBackendApi(
-  backend: Backend,
-): ExtensionAdapterBackendApi {
-  return {
-    forkConversation(conversationId, options) {
-      return backend.forkConversation(conversationId, options);
-    },
-    getConversationHistory(conversationId, options) {
-      return loadExtensionConversationHistoryFromBackend(
-        backend,
-        {
-          agentId: options?.agentId,
-          conversationId,
-        },
-        options,
-      );
-    },
-    sendMessageStream(conversationId, messages, options, requestOptions) {
-      return sendMessageStreamWithBackend(
-        backend,
-        conversationId,
-        messages,
-        options,
-        requestOptions,
-      );
-    },
-  };
-}
 
 function isHeadlessMemfsEnabled(agentId: string): boolean {
   try {
@@ -176,7 +144,7 @@ export function createHeadlessExtensionAdapter(options: {
       : {}),
     capabilities: HEADLESS_EXTENSION_CAPABILITIES,
     disabled: options.disabled,
-    getBackendApi: () => createHeadlessExtensionBackendApi(options.backend),
+    getBackend: () => options.backend,
     getClient,
     ...(options.globalExtensionsDirectory
       ? { globalExtensionsDirectory: options.globalExtensionsDirectory }


### PR DESCRIPTION
## Summary
- remove the adapter-specific `ExtensionAdapterBackendApi` bridge and lazy proxy
- pass internal `Backend` through adapter/engine dependencies instead of rebuilding method wrappers in TUI/headless
- centralize scoped extension conversation operations in `createExtensionConversationHandle`
- add regression coverage for invocation-scoped backend capture across composed `ctx.conversation` calls

## Tests
- `bun test src/extensions/conversation-handle.test.ts src/extensions/extension-adapter.test.ts src/extensions/extension-engine.test.ts src/headless-extension-lifecycle.test.ts`
- `bun run typecheck`
- `bun run check`
- `git diff --check`

## Follow-up
- extension tools still expose a smaller read-only conversation shape; aligning tool contexts with the shared conversation handle should be a separate PR because it changes tool execution semantics.