### PR TITLE
feat(cli): search conversation titles from resume selector

### DIFF
--- a/src/cli/components/ConversationSelector.tsx
+++ b/src/cli/components/ConversationSelector.tsx
@@ -6,6 +6,7 @@ import type { Conversation } from "@letta-ai/letta-client/resources/conversation
 import { Box, useInput } from "ink";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { type Backend, getBackend } from "@/backend";
+import { searchConversationsForBackend } from "@/backend/conversation-search";
 import { CLI_GLYPHS } from "@/cli/helpers/glyphs";
 import {
   useTerminalRows,
@@ -308,6 +309,37 @@ export function mergePinnedConversationRecords(
     ),
     ...listedConversations,
   ];
+}
+
+export async function searchConversationTitlesForSelector(params: {
+  agentId: string;
+  query: string;
+  backend: Backend;
+  limit?: number;
+}): Promise<Conversation[]> {
+  const query = params.query.trim();
+  if (!query) return [];
+
+  const results = await searchConversationsForBackend(
+    {
+      agent_id: params.agentId,
+      query,
+      search_mode: "hybrid",
+      search_target: "summary",
+      limit: params.limit ?? 20,
+    },
+    params.backend,
+  );
+
+  const conversations: Conversation[] = [];
+  const seenConversationIds = new Set<string>();
+  for (const result of results) {
+    const conversation = result.conversation;
+    if (seenConversationIds.has(conversation.id)) continue;
+    seenConversationIds.add(conversation.id);
+    conversations.push(conversation);
+  }
+  return conversations;
 }
 
 export function ConversationSelector({
@@ -649,20 +681,11 @@ export function ConversationSelector({
         backendRef.current = backend;
         setSearching(true);
         try {
-          const page = await backend.listConversations({
-            agent_id: agentId,
+          const dedupedResults = await searchConversationTitlesForSelector({
+            agentId,
+            query,
+            backend,
             limit: 20,
-            order: "desc",
-            order_by: "last_run_completion",
-            summary_search: query,
-          });
-          const results = paginatedItems<Conversation>(page);
-          const seenConversationIds = new Set<string>();
-          const dedupedResults = results.filter((conversation) => {
-            const conversationId = conversation.id;
-            if (seenConversationIds.has(conversationId)) return false;
-            seenConversationIds.add(conversationId);
-            return true;
           });
           if (cancelled) return;
           setSearchResults(

--- a/src/cli/conversation-selector.test.ts
+++ b/src/cli/conversation-selector.test.ts
@@ -4,6 +4,7 @@ import {
   buildDefaultConversationEntry,
   formatConversationTimestampText,
   mergePinnedConversationRecords,
+  searchConversationTitlesForSelector,
 } from "@/cli/components/ConversationSelector";
 
 describe("ConversationSelector timestamps", () => {
@@ -90,5 +91,56 @@ describe("ConversationSelector pinned conversations", () => {
     expect(
       mergePinnedConversationRecords(listed, pinned).map((c) => c.id),
     ).toEqual(["recent-1", "old-pinned"]);
+  });
+});
+
+describe("ConversationSelector title search", () => {
+  test("uses backend conversation search and dedupes title matches", async () => {
+    const listCalls: unknown[] = [];
+    const backend = {
+      capabilities: { localModelCatalog: true },
+      listConversations: async (body: unknown) => {
+        listCalls.push(body);
+        return [
+          { id: "conv-1", summary: "TUI title search" },
+          { id: "conv-1", summary: "TUI title search" },
+          { id: "conv-2", summary: "Unrelated" },
+        ] as Conversation[];
+      },
+    };
+
+    const results = await searchConversationTitlesForSelector({
+      agentId: "agent-1",
+      query: "title search",
+      backend: backend as never,
+      limit: 10,
+    });
+
+    expect(results.map((conversation) => conversation.id)).toEqual(["conv-1"]);
+    expect(listCalls).toEqual([
+      {
+        agent_id: "agent-1",
+        limit: 10,
+        order: "desc",
+        order_by: "last_message_at",
+      },
+    ]);
+  });
+
+  test("does not search blank queries", async () => {
+    const backend = {
+      capabilities: { localModelCatalog: true },
+      listConversations: async () => {
+        throw new Error("should not list conversations");
+      },
+    };
+
+    await expect(
+      searchConversationTitlesForSelector({
+        agentId: "agent-1",
+        query: "   ",
+        backend: backend as never,
+      }),
+    ).resolves.toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- route `/resume` selector search through backend conversation search with `search_target: summary`
- keep local loaded-list fallback/merge behavior for visible conversations
- add selector helper tests for title-search routing, dedupe, and blank queries

## Tests
- `bun test src/cli/conversation-selector.test.ts`
- `bun run typecheck`
- `bunx --bun @biomejs/biome@2.2.5 check src/cli/components/ConversationSelector.tsx src/cli/conversation-selector.test.ts`