### PR TITLE
refactor(extensions): share conversation handle with tools

### DIFF
--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -32,6 +32,7 @@ import {
   isActiveMemfsEnabled,
   isLocalMemfsActive,
 } from "@/agent/memory-runtime";
+import { sendMessageStreamWithBackend } from "@/agent/message";
 import {
   detectPersonalityFromPersonaFile,
   type PersonalityId,
@@ -715,6 +716,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               agentId,
               backend: extensionAdapter.getBackend(),
               conversationId: conversationIdRef.current,
+              sendMessageStream: sendMessageStreamWithBackend,
               workingDirectory: cwd,
             });
             const commandContext: ExtensionCommandContext = {

--- a/src/extensions/conversation-handle.test.ts
+++ b/src/extensions/conversation-handle.test.ts
@@ -3,6 +3,8 @@ import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
 import type { Backend, ConversationMessageListBody } from "@/backend";
 import { createExtensionConversationHandle } from "@/extensions/conversation-handle";
 
+const sendMessageStream = async () => (async function* () {})();
+
 describe("extension conversation handle", () => {
   test("uses the internal backend directly for scoped fork and history", async () => {
     const calls: string[] = [];
@@ -36,6 +38,7 @@ describe("extension conversation handle", () => {
       agentId: "agent-1",
       backend,
       conversationId: null,
+      sendMessageStream,
       workingDirectory: "/tmp/project",
     });
 
@@ -56,6 +59,7 @@ describe("extension conversation handle", () => {
   test("throws a scoped error when no backend is available", () => {
     const handle = createExtensionConversationHandle({
       conversationId: "conversation-1",
+      sendMessageStream,
     });
 
     expect(() => handle.getHistory()).toThrow(

--- a/src/extensions/conversation-handle.ts
+++ b/src/extensions/conversation-handle.ts
@@ -1,12 +1,25 @@
-import { sendMessageStreamWithBackend } from "@/agent/message";
 import type { Backend } from "@/backend";
 import { loadExtensionConversationHistoryFromBackend } from "@/extensions/conversation-history";
-import type { ExtensionConversationHandle } from "@/extensions/types";
+import type {
+  ExtensionConversationHandle,
+  ExtensionConversationMessage,
+  ExtensionConversationSendMessageOptions,
+  ExtensionConversationSendMessageRequestOptions,
+} from "@/extensions/types";
+
+type SendExtensionConversationMessageStream = (
+  backend: Backend,
+  conversationId: string,
+  messages: ExtensionConversationMessage[],
+  options?: ExtensionConversationSendMessageOptions & { agentId?: string },
+  requestOptions?: ExtensionConversationSendMessageRequestOptions,
+) => ReturnType<ExtensionConversationHandle["sendMessageStream"]>;
 
 export function createExtensionConversationHandle(options: {
   agentId?: string | null;
   backend?: Backend;
   conversationId?: string | null;
+  sendMessageStream: SendExtensionConversationMessageStream;
   workingDirectory?: string | null;
 }): ExtensionConversationHandle {
   const conversationId = options.conversationId ?? "default";
@@ -40,7 +53,7 @@ export function createExtensionConversationHandle(options: {
       );
     },
     sendMessageStream(messages, sendOptions, requestOptions) {
-      return sendMessageStreamWithBackend(
+      return options.sendMessageStream(
         requireBackend(),
         conversationId,
         messages,

--- a/src/extensions/extension-engine.ts
+++ b/src/extensions/extension-engine.ts
@@ -16,6 +16,7 @@ import { pathToFileURL } from "node:url";
 import type Letta from "@letta-ai/letta-client";
 import * as ts from "typescript";
 import { clearAvailableModelsCache } from "@/agent/available-models";
+import { sendMessageStreamWithBackend } from "@/agent/message";
 import type { Backend } from "@/backend";
 import type { PiProviderRegistration } from "@/backend/dev/pi-provider-extension-registry";
 import {
@@ -1297,6 +1298,7 @@ export async function emitLocalExtensionEvent<TName extends ExtensionEventName>(
             typeof event.conversationId === "string"
               ? event.conversationId
               : context.sessionId,
+          sendMessageStream: sendMessageStreamWithBackend,
           workingDirectory: context.cwd,
         }),
         context,

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -418,12 +418,7 @@ export interface ExtensionToolRunContext {
   agent: {
     id: string | null;
   };
-  conversation: {
-    id: string | null;
-    getHistory: (
-      options?: ExtensionConversationHistoryOptions,
-    ) => Promise<Message[]>;
-  };
+  conversation: ExtensionConversationHandle;
   getContext: () => ExtensionContext;
 }
 

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -10,6 +10,7 @@ import {
 } from "@/agent/context";
 import { getModelInfo } from "@/agent/model";
 import { getAllSubagentConfigs } from "@/agent/subagents";
+import { getBackend } from "@/backend";
 import {
   buildDynamicMessageChannelToolDefinition,
   getCachedDynamicMessageChannelToolDefinition,
@@ -18,7 +19,7 @@ import {
 import { getActiveChannelIds } from "@/channels/registry";
 import type { ChannelTurnSource } from "@/channels/types";
 import { INTERRUPTED_BY_USER } from "@/constants";
-import { loadExtensionConversationHistoryFromBackend } from "@/extensions/conversation-history";
+import { createExtensionConversationHandle } from "@/extensions/conversation-handle";
 import {
   type ExtensionEvents,
   emitExtensionEvent,
@@ -1985,6 +1986,7 @@ async function executeExtensionTool(
     }
 
     try {
+      const backend = getBackend();
       const context: ExtensionToolRunContext = {
         args: args as Record<string, unknown>,
         cwd: options.workingDirectory,
@@ -2005,20 +2007,18 @@ async function executeExtensionTool(
           : {}),
         permissionMode: executionScope.permissionMode ?? null,
         agent: { id: executionScope.agentId ?? null },
-        conversation: {
-          id: executionScope.conversationId ?? null,
-          getHistory: async (historyOptions) => {
-            const { getBackend } = await import("@/backend");
-            return loadExtensionConversationHistoryFromBackend(
-              getBackend(),
-              {
-                agentId: executionScope.agentId,
-                conversationId: executionScope.conversationId,
-              },
-              historyOptions,
+        conversation: createExtensionConversationHandle({
+          agentId: executionScope.agentId,
+          backend,
+          conversationId: executionScope.conversationId,
+          sendMessageStream: async (...sendArgs) => {
+            const { sendMessageStreamWithBackend } = await import(
+              "@/agent/message"
             );
+            return sendMessageStreamWithBackend(...sendArgs);
           },
-        },
+          workingDirectory: options.workingDirectory,
+        }),
         getContext: tool.getContext,
       };
       const result = await runExtensionTool(tool, context);

--- a/src/tools/tool-execution-context.test.ts
+++ b/src/tools/tool-execution-context.test.ts
@@ -405,6 +405,89 @@ describe("tool execution context snapshot", () => {
     ]);
   });
 
+  test("captures backend once for extension tool conversation handles", async () => {
+    const calls: string[] = [];
+    const backendA = {
+      forkConversation: async (
+        ...[conversationId, options]: Parameters<Backend["forkConversation"]>
+      ) => {
+        calls.push(
+          `a:fork:${conversationId}:${options?.agentId}:${options?.hidden}`,
+        );
+        return { id: "forked-conversation" };
+      },
+      listConversationMessages: async (
+        ...[conversationId, body]: Parameters<
+          Backend["listConversationMessages"]
+        >
+      ) => {
+        calls.push(`a:history:${conversationId}:${body?.limit}`);
+        return {
+          getPaginatedItems: () => [{ id: "forked-message" }],
+        };
+      },
+    } as unknown as Backend;
+    const backendB = {
+      listConversationMessages: async (
+        ...[conversationId, body]: Parameters<
+          Backend["listConversationMessages"]
+        >
+      ) => {
+        calls.push(`b:history:${conversationId}:${body?.limit}`);
+        return {
+          getPaginatedItems: () => [{ id: "wrong-backend-message" }],
+        };
+      },
+    } as unknown as Backend;
+    __testSetBackend(backendA);
+
+    const controller = new AbortController();
+    registerExtensionTool({
+      name: "fork_history",
+      description: "Fork conversation and read fork history",
+      parameters: { type: "object", properties: {}, required: [] },
+      owner: {
+        id: "global:/tmp/fork-history.ts",
+        path: "/tmp/fork-history.ts",
+        scope: "global",
+        generation: 1,
+      },
+      path: "/tmp/fork-history.ts",
+      requiresApproval: false,
+      parallelSafe: true,
+      activationSignal: controller.signal,
+      getContext: () => {
+        throw new Error("context should not be needed for this test");
+      },
+      isAvailable: () => true,
+      run: async (ctx) => {
+        const fork = await ctx.conversation.fork({ hidden: true });
+        __testSetBackend(backendB);
+        const history = await fork.getHistory({ limit: 1 });
+        return [
+          ctx.conversation.id,
+          fork.id,
+          typeof ctx.conversation.sendMessageStream,
+          history.map((message) => message.id).join(","),
+        ].join(":");
+      },
+    });
+
+    const result = await runWithRuntimeContext(
+      { agentId: "agent-1", conversationId: "conversation-1" },
+      () => executeTool("fork_history", {}),
+    );
+
+    expect(result.status).toBe("success");
+    expect(asText(result.toolReturn)).toBe(
+      "conversation-1:forked-conversation:function:forked-message",
+    );
+    expect(calls).toEqual([
+      "a:fork:conversation-1:agent-1:true",
+      "a:history:forked-conversation:1",
+    ]);
+  });
+
   test("extension tools take precedence over external tools with the same name", async () => {
     registerExternalTools([
       {


### PR DESCRIPTION
## Summary
- make extension tool contexts use the shared `ExtensionConversationHandle`
- capture backend once per extension tool execution before constructing the conversation handle
- inject the send-message helper into the handle builder to avoid a static tools/agent-message import cycle
- add regression coverage for tool conversation handles preserving invocation-scoped backend binding across fork + history

## Tests
- `bun test src/extensions/conversation-handle.test.ts src/extensions/extension-engine.test.ts src/extensions/extension-adapter.test.ts src/tools/tool-execution-context.test.ts src/headless-extension-lifecycle.test.ts`
- `bun run typecheck`
- `bun run check`
- `git diff --check`