### PR TITLE
refactor(extensions): simplify adapter options type

### DIFF
--- a/src/extensions/extension-adapter.ts
+++ b/src/extensions/extension-adapter.ts
@@ -1,4 +1,3 @@
-import type Letta from "@letta-ai/letta-client";
 import type { Backend } from "@/backend";
 import {
   areExtensionsDisabled,
@@ -29,10 +28,8 @@ export interface ExtensionAdapterSnapshot extends ExtensionAdapterLoadState {
 }
 
 export interface CreateExtensionAdapterOptions
-  extends Omit<CreateExtensionEngineOptions, "getBackend" | "getContext"> {
+  extends Omit<CreateExtensionEngineOptions, "getContext"> {
   disabled?: boolean;
-  getBackend?: () => Backend | undefined;
-  getClient: () => Promise<Letta>;
   initialContext: ExtensionContext;
 }
 


### PR DESCRIPTION
## Summary
- remove redundant `getBackend` and `getClient` redeclarations from `CreateExtensionAdapterOptions`
- let adapter options inherit shared engine dependencies directly
- keep only `getContext` omitted because the adapter owns context via `initialContext`/`updateContext`
- remove the now-unused Letta type import

## Tests
- `bun test src/extensions/extension-adapter.test.ts src/headless-extension-lifecycle.test.ts`
- `bun run typecheck`
- `bun run check`
- `git diff --check`