### PR TITLE
fix(skills): run creator scripts under ESM

### DIFF
--- a/src/skills/builtin/creating-skills/scripts/init-skill.ts
+++ b/src/skills/builtin/creating-skills/scripts/init-skill.ts
@@ -1,17 +1,18 @@
-#!/usr/bin/env npx ts-node
+#!/usr/bin/env -S npx tsx
 /**
  * Skill Initializer - Creates a new skill from template
  *
  * Usage:
- *   npx ts-node init-skill.ts <skill-name> --path <path>
+ *   npx tsx init-skill.ts <skill-name> --path <path>
  *
  * Examples:
- *   npx ts-node init-skill.ts my-new-skill --path .skills
- *   npx ts-node init-skill.ts my-api-helper --path ~/.letta/skills
+ *   npx tsx init-skill.ts my-new-skill --path .skills
+ *   npx tsx init-skill.ts my-api-helper --path ~/.letta/skills
  */
 
 import { chmodSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const SKILL_TEMPLATE = `---
 name: {skill_name}
@@ -86,7 +87,7 @@ Files not intended to be loaded into context, but rather used within the output 
 **Any unneeded directories can be deleted.** Not every skill requires all three types of resources.
 `;
 
-const EXAMPLE_SCRIPT = `#!/usr/bin/env npx ts-node
+const EXAMPLE_SCRIPT = `#!/usr/bin/env -S npx tsx
 /**
  * Example helper script for {skill_name}
  *
@@ -247,22 +248,27 @@ function initSkill(skillName: string, path: string): string | null {
   return skillDir;
 }
 
+function isMainModule(): boolean {
+  const entrypoint = process.argv[1];
+  return entrypoint
+    ? resolve(entrypoint) === fileURLToPath(import.meta.url)
+    : false;
+}
+
 // CLI entry point
-if (require.main === module) {
+if (isMainModule()) {
   const args = process.argv.slice(2);
 
   if (args.length < 3 || args[1] !== "--path") {
-    console.log("Usage: npx ts-node init-skill.ts <skill-name> --path <path>");
+    console.log("Usage: npx tsx init-skill.ts <skill-name> --path <path>");
     console.log("\nSkill name requirements:");
     console.log("  - Hyphen-case identifier (e.g., 'data-analyzer')");
     console.log("  - Lowercase letters, digits, and hyphens only");
     console.log("  - Max 64 characters");
     console.log("  - Must match directory name exactly");
     console.log("\nExamples:");
-    console.log("  npx ts-node init-skill.ts my-new-skill --path .skills");
-    console.log(
-      "  npx ts-node init-skill.ts my-api-helper --path ~/.letta/skills",
-    );
+    console.log("  npx tsx init-skill.ts my-new-skill --path .skills");
+    console.log("  npx tsx init-skill.ts my-api-helper --path ~/.letta/skills");
     process.exit(1);
   }
 

--- a/src/skills/builtin/creating-skills/scripts/package-skill.ts
+++ b/src/skills/builtin/creating-skills/scripts/package-skill.ts
@@ -1,13 +1,13 @@
-#!/usr/bin/env npx ts-node
+#!/usr/bin/env -S npx tsx
 /**
  * Skill Packager - Creates a distributable .skill file of a skill folder
  *
  * Usage:
- *   npx ts-node package-skill.ts <path/to/skill-folder> [output-directory]
+ *   npx tsx package-skill.ts <path/to/skill-folder> [output-directory]
  *
  * Example:
- *   npx ts-node package-skill.ts .skills/my-skill
- *   npx ts-node package-skill.ts .skills/my-skill ./dist
+ *   npx tsx package-skill.ts .skills/my-skill
+ *   npx tsx package-skill.ts .skills/my-skill ./dist
  */
 
 import {
@@ -19,6 +19,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { basename, dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 // Simple zip implementation using Node.js built-in zlib
 // For a proper zip file, we'll create the structure manually
 import { deflateSync } from "node:zlib";
@@ -238,17 +239,24 @@ function packageSkill(skillPath: string, outputDir?: string): string | null {
   }
 }
 
+function isMainModule(): boolean {
+  const entrypoint = process.argv[1];
+  return entrypoint
+    ? resolve(entrypoint) === fileURLToPath(import.meta.url)
+    : false;
+}
+
 // CLI entry point
-if (require.main === module) {
+if (isMainModule()) {
   const args = process.argv.slice(2);
 
   if (args.length < 1) {
     console.log(
-      "Usage: npx ts-node package-skill.ts <path/to/skill-folder> [output-directory]",
+      "Usage: npx tsx package-skill.ts <path/to/skill-folder> [output-directory]",
     );
     console.log("\nExample:");
-    console.log("  npx ts-node package-skill.ts .skills/my-skill");
-    console.log("  npx ts-node package-skill.ts .skills/my-skill ./dist");
+    console.log("  npx tsx package-skill.ts .skills/my-skill");
+    console.log("  npx tsx package-skill.ts .skills/my-skill ./dist");
     process.exit(1);
   }
 

--- a/src/skills/builtin/creating-skills/scripts/validate-skill.ts
+++ b/src/skills/builtin/creating-skills/scripts/validate-skill.ts
@@ -1,16 +1,17 @@
-#!/usr/bin/env npx ts-node
+#!/usr/bin/env -S npx tsx
 /**
  * Skill Validator - Validates skill structure and frontmatter
  *
  * Usage:
- *   npx ts-node validate-skill.ts <skill-directory>
+ *   npx tsx validate-skill.ts <skill-directory>
  *
  * Example:
- *   npx ts-node validate-skill.ts .skills/my-skill
+ *   npx tsx validate-skill.ts .skills/my-skill
  */
 
 import { existsSync, readFileSync } from "node:fs";
-import { basename, join } from "node:path";
+import { basename, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
 
 interface ValidationResult {
@@ -161,11 +162,18 @@ export function validateSkill(skillPath: string): ValidationResult {
   };
 }
 
+function isMainModule(): boolean {
+  const entrypoint = process.argv[1];
+  return entrypoint
+    ? resolve(entrypoint) === fileURLToPath(import.meta.url)
+    : false;
+}
+
 // CLI entry point
-if (require.main === module) {
+if (isMainModule()) {
   const args = process.argv.slice(2);
   if (args.length !== 1) {
-    console.log("Usage: npx ts-node validate-skill.ts <skill-directory>");
+    console.log("Usage: npx tsx validate-skill.ts <skill-directory>");
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary
- replace CommonJS `require.main` CLI guards in bundled skill creator scripts with ESM-safe `import.meta.url` entrypoint checks
- align init/validate/package script shebangs and usage text with the documented `npx tsx` runner
- update generated example script shebang to use `npx tsx`

## Testing
- `npx tsx src/skills/builtin/creating-skills/scripts/init-skill.ts esm-test-skill --path /tmp/letta-skill-fix-test`
- `npx tsx src/skills/builtin/creating-skills/scripts/validate-skill.ts /tmp/letta-skill-fix-test/esm-test-skill`
- `npx tsx src/skills/builtin/creating-skills/scripts/package-skill.ts /tmp/letta-skill-fix-test/esm-test-skill /tmp/letta-skill-fix-out`
- `bun test src/skills/skill-creator-scripts.test.ts`
- `bun run typecheck`
- `bun run check`

Written by Cameron ◯ Letta Code