### PR TITLE
fix(tui): remove orphaned tool calls at end_turn instead of showing "Cancelled"

### DIFF
--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -556,6 +556,10 @@ export function markIncompleteToolsAsCancelled(
   let anyToolsCancelled = false;
   for (const [id, line] of b.byId.entries()) {
     if (line.kind === "tool_call" && line.phase !== "finished") {
+      debugLog(
+        "accumulator",
+        `[ORPHANED_TOOL] name=${line.name ?? "?"} phase=${line.phase} diagnosis=${diagnoseOrphanedTool(line, b)} reason=${reason}`,
+      );
       const updatedLine = {
         ...line,
         phase: "finished" as const,
@@ -573,6 +577,48 @@ export function markIncompleteToolsAsCancelled(
     markCurrentLineAsFinished(b);
   }
   return anyToolsCancelled;
+}
+
+/**
+ * Remove incomplete tool calls from the buffer entirely.
+ * Used at end_turn to clean up orphaned tool calls without showing "Cancelled".
+ * Returns true if any tools were removed.
+ */
+export function removeIncompleteTools(b: Buffers): boolean {
+  let anyToolsRemoved = false;
+  for (const [id, line] of b.byId.entries()) {
+    if (line.kind === "tool_call" && line.phase !== "finished") {
+      debugLog(
+        "accumulator",
+        `[REMOVED_ORPHANED_TOOL] name=${line.name ?? "?"} phase=${line.phase} diagnosis=${diagnoseOrphanedTool(line, b)} toolCallId=${line.toolCallId ?? "?"}`,
+      );
+      b.byId.delete(id);
+      b.order = b.order.filter((oid) => oid !== id);
+      if (line.toolCallId) {
+        b.toolCallIdToLineId.delete(line.toolCallId);
+        b.serverToolCalls.delete(line.toolCallId);
+      }
+      anyToolsRemoved = true;
+    }
+  }
+  return anyToolsRemoved;
+}
+
+function diagnoseOrphanedTool(
+  line: Extract<Line, { kind: "tool_call" }>,
+  b: Buffers,
+): string {
+  const isTrackedAsServerTool = line.toolCallId
+    ? b.serverToolCalls.has(line.toolCallId)
+    : false;
+  if (line.phase === "streaming") {
+    return isTrackedAsServerTool
+      ? "server_tool_missing_return"
+      : "client_tool_missing_approval_request";
+  }
+  if (line.phase === "ready") return "approval_pending_at_stream_end";
+  if (line.phase === "running") return "execution_incomplete_at_stream_end";
+  return "unknown_phase";
 }
 
 type ToolCallLine = Extract<Line, { kind: "tool_call" }>;

--- a/src/cli/helpers/stream-stop-reason.test.ts
+++ b/src/cli/helpers/stream-stop-reason.test.ts
@@ -87,6 +87,41 @@ describe("drainStream stop reason", () => {
     ]);
   });
 
+  test("end_turn removes orphaned tool calls entirely (tool_call_message without approval_request or tool_return)", async () => {
+    // Simulate: server sends tool_call_message, then decides to end turn without
+    // sending approval_request_message or tool_return_message. This can happen if
+    // the model hits token limits or decides to stop mid-tool-call.
+    const fakeStream = {
+      controller: new AbortController(),
+      async *[Symbol.asyncIterator]() {
+        yield {
+          message_type: "tool_call_message",
+          id: "msg-orphan",
+          tool_call: {
+            tool_call_id: "tc-orphan",
+            name: "Bash",
+            arguments: '{"command":"ls"',
+          },
+        } as LettaStreamingResponse;
+        // Args incomplete, no approval_request, no tool_return — just end_turn
+        yield {
+          message_type: "stop_reason",
+          stop_reason: "end_turn",
+        } as LettaStreamingResponse;
+      },
+    } as unknown as Stream<LettaStreamingResponse>;
+
+    const buffers = createBuffers("agent-test");
+    const result = await drainStream(fakeStream, buffers, () => {});
+
+    expect(result.stopReason).toBe("end_turn");
+    expect(result.sawStopReasonChunk).toBe(true);
+
+    // Tool call should be removed entirely, not shown as cancelled
+    expect(buffers.byId.has("tc-orphan")).toBe(false);
+    expect(buffers.order).not.toContain("tc-orphan");
+  });
+
   test("stream error cancels in-progress tool calls by default (skipCancelToolsOnError=false)", async () => {
     const buffers = createBuffers("agent-test");
     await drainStream(makeStreamWithToolCall("tc-1"), buffers, () => {});

--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -34,6 +34,7 @@ import {
   markCurrentLineAsFinished,
   markIncompleteToolsAsCancelled,
   onChunk,
+  removeIncompleteTools,
 } from "./accumulator";
 import { chunkLog } from "./chunk-log";
 import type { ContextTracker } from "./context-tracker";
@@ -559,9 +560,29 @@ export async function drainStream(
     stopReason = "error";
   }
 
-  // Mark incomplete tool calls as cancelled if stream was cancelled
+  // Clean up incomplete tool calls:
+  // - cancelled: user interrupted, show "Interrupted by user"
+  // - end_turn: server ended without completing, remove entirely (don't show anything)
   if (stopReason === "cancelled") {
-    markIncompleteToolsAsCancelled(buffers, true, "user_interrupt");
+    const hadOrphanedTools = markIncompleteToolsAsCancelled(
+      buffers,
+      true,
+      "user_interrupt",
+    );
+    if (hadOrphanedTools) {
+      debugWarn(
+        "drainStream",
+        "cancelled had orphaned tool calls (see [ORPHANED_TOOL] logs for diagnosis)",
+      );
+    }
+  } else if (stopReason === "end_turn") {
+    const hadOrphanedTools = removeIncompleteTools(buffers);
+    if (hadOrphanedTools) {
+      debugWarn(
+        "drainStream",
+        "end_turn had orphaned tool calls (see [REMOVED_ORPHANED_TOOL] logs)",
+      );
+    }
   }
 
   // Mark the final line as finished now that stream has ended.


### PR DESCRIPTION
## Summary
- Orphaned tool calls at `end_turn` are now removed from the buffer entirely instead of showing "Cancelled"
- Adds diagnostic logging with `LETTA_DEBUG=1` to identify why tools were orphaned
- Adds test coverage for orphaned tool removal at `end_turn`

## Context
When the server sends `tool_call_message` but ends the turn (`end_turn`) before sending `approval_request_message` or `tool_return_message`, the tool call was left stuck in `phase: "streaming"`. This showed a persistent "Bash …" indicator that only resolved to "Cancelled" on the next user message.

## Behavior change
- **Before**: Orphaned tools showed "Cancelled" after the turn ended
- **After**: Orphaned tools are removed entirely — nothing shown

For `cancelled` (user interrupt), tools still show "Interrupted by user" as before.

## Test plan
- [x] Unit test verifies orphaned tool call is removed from buffer at `end_turn`
- [x] Existing tests for `cancelled` path still pass

👾 Generated with [Letta Code](https://letta.com)