### PR TITLE
feat: add denial support to tool_start extension event

### DIFF
--- a/src/extensions/extension-engine.test.ts
+++ b/src/extensions/extension-engine.test.ts
@@ -613,7 +613,7 @@ describe("extension engine", () => {
     }
   });
 
-  test("tool_start denial: all handlers run, first denial wins", async () => {
+  test("tool_start denial: all handlers run, first denial reason wins", async () => {
     const root = createTempDir();
     try {
       const extensionDir = path.join(root, "global-extensions");
@@ -623,11 +623,17 @@ describe("extension engine", () => {
         `export default function(letta) {
           letta.events.on("tool_start", (event) => {
             if (event.toolName === "Bash" && String(event.args.command).includes("rm -rf")) {
-              return { deny: true, reason: "Destructive command blocked." };
+              return { deny: true, reason: "First denial reason." };
             }
           });
           letta.events.on("tool_start", (event) => {
-            // This handler still runs even when another handler denies
+            // Second denial handler — reason should not override first
+            if (event.toolName === "Bash") {
+              return { deny: true, reason: "Second denial reason." };
+            }
+          });
+          letta.events.on("tool_start", (event) => {
+            // Non-denial handler still runs for side effects
             event.args = { ...event.args, _sideEffect: true };
           });
         }`,
@@ -645,12 +651,16 @@ describe("extension engine", () => {
 
       const result = await engine.emitEvent("tool_start", event);
 
-      // Both handlers ran
-      expect(result.handlerCount).toBe(2);
-      // Denial result is collected
+      // All three handlers ran
+      expect(result.handlerCount).toBe(3);
+      // Both denial results are collected
       expect(result.results).toContainEqual({
         deny: true,
-        reason: "Destructive command blocked.",
+        reason: "First denial reason.",
+      });
+      expect(result.results).toContainEqual({
+        deny: true,
+        reason: "Second denial reason.",
       });
       // Side-effect handler still ran (args were mutated)
       expect(event.args).toMatchObject({ _sideEffect: true });

--- a/src/extensions/extension-engine.test.ts
+++ b/src/extensions/extension-engine.test.ts
@@ -613,6 +613,87 @@ describe("extension engine", () => {
     }
   });
 
+  test("tool_start denial: all handlers run, first denial wins", async () => {
+    const root = createTempDir();
+    try {
+      const extensionDir = path.join(root, "global-extensions");
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        path.join(extensionDir, "deny.ts"),
+        `export default function(letta) {
+          letta.events.on("tool_start", (event) => {
+            if (event.toolName === "Bash" && String(event.args.command).includes("rm -rf")) {
+              return { deny: true, reason: "Destructive command blocked." };
+            }
+          });
+          letta.events.on("tool_start", (event) => {
+            // This handler still runs even when another handler denies
+            event.args = { ...event.args, _sideEffect: true };
+          });
+        }`,
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+      const event = {
+        agentId: "agent-1",
+        conversationId: "conversation-1",
+        toolCallId: "toolu-1",
+        toolName: "Bash",
+        args: { command: "rm -rf /" },
+      };
+
+      const result = await engine.emitEvent("tool_start", event);
+
+      // Both handlers ran
+      expect(result.handlerCount).toBe(2);
+      // Denial result is collected
+      expect(result.results).toContainEqual({ deny: true, reason: "Destructive command blocked." });
+      // Side-effect handler still ran (args were mutated)
+      expect(event.args).toMatchObject({ _sideEffect: true });
+
+      engine.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("tool_start denial: no denial when handler returns undefined", async () => {
+    const root = createTempDir();
+    try {
+      const extensionDir = path.join(root, "global-extensions");
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        path.join(extensionDir, "no-deny.ts"),
+        `export default function(letta) {
+          letta.events.on("tool_start", (event) => {
+            // Only deny Bash, let everything else through
+            if (event.toolName !== "Bash") return;
+            return { deny: true, reason: "Bash blocked." };
+          });
+        }`,
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+
+      // Edit should not be denied
+      const editEvent = {
+        agentId: "agent-1",
+        conversationId: "conversation-1",
+        toolCallId: "toolu-2",
+        toolName: "Edit",
+        args: { file_path: "/tmp/test.txt" },
+      };
+      const editResult = await engine.emitEvent("tool_start", editEvent);
+      expect(editResult.results).toHaveLength(0);
+
+      engine.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("reload aborts old activations and ignores stale handles", async () => {
     const root = createTempDir();
     const testGlobal = globalThis as ExtensionTestGlobal;

--- a/src/extensions/extension-engine.test.ts
+++ b/src/extensions/extension-engine.test.ts
@@ -648,7 +648,10 @@ describe("extension engine", () => {
       // Both handlers ran
       expect(result.handlerCount).toBe(2);
       // Denial result is collected
-      expect(result.results).toContainEqual({ deny: true, reason: "Destructive command blocked." });
+      expect(result.results).toContainEqual({
+        deny: true,
+        reason: "Destructive command blocked.",
+      });
       // Side-effect handler still ran (args were mutated)
       expect(event.args).toMatchObject({ _sideEffect: true });
 

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -191,6 +191,10 @@ export interface ExtensionToolStartEvent {
 
 export interface ExtensionToolStartResult {
   args?: Record<string, unknown>;
+  /** If true, the tool execution is denied. All handlers still run, but any denial blocks the tool. */
+  deny?: boolean;
+  /** Human-readable reason for the denial. Shown to the model as the tool error message. */
+  reason?: string;
 }
 
 export interface ExtensionEventMap {

--- a/src/headless-extension-lifecycle.test.ts
+++ b/src/headless-extension-lifecycle.test.ts
@@ -428,4 +428,145 @@ describe("headless extension adapter", () => {
       rmSync(root, { force: true, recursive: true });
     }
   });
+
+  test("tool_start denial blocks executeTool and skips PreToolUse hooks", async () => {
+    const root = mkdtempSync(
+      path.join(tmpdir(), "letta-headless-tool-start-deny-"),
+    );
+    const extensionDir = path.join(root, "global-extensions");
+    const targetFile = path.join(root, "target.txt");
+    const agent = {
+      id: "agent-1",
+      name: "Amelia",
+      llm_config: { model: "anthropic/claude-sonnet-4" },
+    } as AgentState;
+    const backend = {
+      forkConversation: async () => ({ id: "forked" }),
+      sendMessageStream: async () => (async function* () {})(),
+    } as unknown as Backend;
+
+    try {
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(targetFile, "secret content");
+      writeFileSync(
+        path.join(extensionDir, "deny-read.ts"),
+        `export default function activate(letta) {
+          letta.events.on("tool_start", (event) => {
+            if (event.toolName === "Read") {
+              return { deny: true, reason: "Read is blocked by extension." };
+            }
+          });
+        }`,
+      );
+
+      const adapter = createHeadlessExtensionAdapter({
+        agent,
+        backend,
+        cacheDirectory: path.join(root, "extension-cache"),
+        conversationId: "default",
+        globalExtensionsDirectory: extensionDir,
+      });
+
+      await adapter.reload();
+      const prepared =
+        await __headlessTestUtils.prepareHeadlessToolExecutionContext({
+          agentId: agent.id,
+          cachedAgent: agent,
+          conversationId: "default",
+          extensionEvents: adapter.events,
+        });
+
+      const result = await executeTool(
+        "Read",
+        { file_path: targetFile },
+        {
+          toolContextId:
+            prepared.preparedToolContext.preparedToolContext.contextId,
+        },
+      );
+
+      // Tool was denied — status is error, output contains the denial reason
+      expect(result.status).toBe("error");
+      expect(result.toolReturn).toContain("denied by extension");
+      expect(result.toolReturn).toContain("Read is blocked by extension.");
+      // File content was NOT read
+      expect(result.toolReturn).not.toContain("secret content");
+
+      adapter.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("tool_start denial: first denial reason is used when multiple handlers deny", async () => {
+    const root = mkdtempSync(
+      path.join(tmpdir(), "letta-headless-tool-start-deny-order-"),
+    );
+    const extensionDir = path.join(root, "global-extensions");
+    const targetFile = path.join(root, "target.txt");
+    const agent = {
+      id: "agent-1",
+      name: "Amelia",
+      llm_config: { model: "anthropic/claude-sonnet-4" },
+    } as AgentState;
+    const backend = {
+      forkConversation: async () => ({ id: "forked" }),
+      sendMessageStream: async () => (async function* () {})(),
+    } as unknown as Backend;
+
+    try {
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(targetFile, "secret content");
+      writeFileSync(
+        path.join(extensionDir, "multi-deny.ts"),
+        `export default function activate(letta) {
+          letta.events.on("tool_start", (event) => {
+            if (event.toolName === "Read") {
+              return { deny: true, reason: "First denial reason." };
+            }
+          });
+          letta.events.on("tool_start", (event) => {
+            if (event.toolName === "Read") {
+              return { deny: true, reason: "Second denial reason." };
+            }
+          });
+        }`,
+      );
+
+      const adapter = createHeadlessExtensionAdapter({
+        agent,
+        backend,
+        cacheDirectory: path.join(root, "extension-cache"),
+        conversationId: "default",
+        globalExtensionsDirectory: extensionDir,
+      });
+
+      await adapter.reload();
+      const prepared =
+        await __headlessTestUtils.prepareHeadlessToolExecutionContext({
+          agentId: agent.id,
+          cachedAgent: agent,
+          conversationId: "default",
+          extensionEvents: adapter.events,
+        });
+
+      const result = await executeTool(
+        "Read",
+        { file_path: targetFile },
+        {
+          toolContextId:
+            prepared.preparedToolContext.preparedToolContext.contextId,
+        },
+      );
+
+      expect(result.status).toBe("error");
+      // First denial reason is used
+      expect(result.toolReturn).toContain("First denial reason.");
+      expect(result.toolReturn).not.toContain("Second denial reason.");
+
+      adapter.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
 });

--- a/src/skills/builtin/creating-extensions/references/events.md
+++ b/src/skills/builtin/creating-extensions/references/events.md
@@ -126,7 +126,21 @@ letta.events.on("tool_start", (event) => {
 
 Handlers run in registration order. Later handlers see the current args after earlier mutations/returns. If a handler throws, its partial `event.args` mutation is rolled back and the error is recorded as an extension diagnostic.
 
-`tool_start` is intentionally a trusted local extension point: it can rewrite commands, file paths, and other tool inputs before execution. Keep transforms focused and unsurprising. It does not support blocking; use existing hooks for blocking safety decisions.
+`tool_start` is intentionally a trusted local extension point: it can rewrite commands, file paths, and other tool inputs before execution. Keep transforms focused and unsurprising.
+
+### Denying tool execution
+
+Handlers can deny a tool by returning `{ deny: true, reason?: "..." }`. All handlers still run (for side effects like logging or state updates), but if any handler denies, the tool is blocked. The first denial reason is shown to the model as the tool error message.
+
+```ts
+letta.events.on("tool_start", (event) => {
+  if (event.toolName === "Bash" && String(event.args.command).includes("rm -rf")) {
+    return { deny: true, reason: "Destructive command blocked." };
+  }
+});
+```
+
+Denial runs before `PreToolUse` hooks. If an extension denies a tool, hooks are not invoked for that tool call.
 
 `turn_start` fires before outbound turns that include a user message. In the TUI this includes normal submits and prompt-style command turns. In headless it includes one-shot prompts and bidirectional user turns.
 

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -33,6 +33,7 @@ import {
   runExtensionTool,
 } from "@/extensions/tool-registry";
 import type { ExtensionToolRunContext } from "@/extensions/types";
+import type { ExtensionEventEmissionResult } from "@/extensions/types";
 import {
   runPostToolUseFailureHooks,
   runPostToolUseHooks,
@@ -1930,7 +1931,7 @@ async function emitToolStartEvent(options: {
   executionScope: RuntimeContextSnapshot;
   toolCallId?: string;
   toolName: string;
-}): Promise<ToolArgs> {
+}): Promise<{ args: ToolArgs; denied?: { reason?: string } }> {
   const event = {
     agentId: options.executionScope.agentId ?? null,
     conversationId: options.executionScope.conversationId ?? null,
@@ -1939,14 +1940,25 @@ async function emitToolStartEvent(options: {
     args: cloneToolArgsForExtensionEvent(options.args),
   };
 
+  let emitResult: ExtensionEventEmissionResult<"tool_start"> | undefined;
   try {
-    await emitExtensionEvent(options.events, "tool_start", event);
+    emitResult = await emitExtensionEvent(options.events, "tool_start", event);
   } catch (error) {
     debugLog("extensions", "tool_start event failed", error);
-    return options.args;
+    return { args: options.args };
   }
 
-  return isToolStartArgs(event.args) ? event.args : options.args;
+  // Check for denial from any handler. First denial wins.
+  const firstDenial = emitResult?.results?.find(
+    (r): r is { deny: true; reason?: string } =>
+      typeof r === "object" && r !== null && r.deny === true,
+  );
+  if (firstDenial) {
+    debugLog("extensions", `tool_start denied: ${firstDenial.reason ?? "no reason given"}`);
+    return { args: isToolStartArgs(event.args) ? event.args : options.args, denied: { reason: firstDenial.reason } };
+  }
+
+  return { args: isToolStartArgs(event.args) ? event.args : options.args };
 }
 
 async function executeExtensionTool(
@@ -2201,13 +2213,19 @@ export async function executeTool(
         status: "error",
       };
     }
-    const eventArgs = await emitToolStartEvent({
+    const { args: eventArgs, denied: extDenial } = await emitToolStartEvent({
       args,
       events: extensionEvents,
       executionScope,
       toolCallId: options?.toolCallId,
       toolName: name,
     });
+    if (extDenial) {
+      return {
+        toolReturn: `Error: Tool execution denied by extension. ${extDenial.reason ?? "No reason given."}`,
+        status: "error",
+      };
+    }
     return executeExtensionTool(
       name,
       extensionTool,
@@ -2225,13 +2243,19 @@ export async function executeTool(
 
   // Check if this is an external tool (SDK-executed)
   if (activeExternalTools.has(name)) {
-    const eventArgs = await emitToolStartEvent({
+    const { args: eventArgs, denied: extDenial } = await emitToolStartEvent({
       args,
       events: extensionEvents,
       executionScope,
       toolCallId: options?.toolCallId,
       toolName: name,
     });
+    if (extDenial) {
+      return {
+        toolReturn: `Error: Tool execution denied by extension. ${extDenial.reason ?? "No reason given."}`,
+        status: "error",
+      };
+    }
     return executeExternalTool(
       options?.toolCallId ?? `ext-${Date.now()}`,
       name,
@@ -2266,13 +2290,20 @@ export async function executeTool(
     };
   }
 
-  args = await emitToolStartEvent({
+  const { args: eventArgs, denied: extDenial } = await emitToolStartEvent({
     args,
     events: extensionEvents,
     executionScope,
     toolCallId: options?.toolCallId,
     toolName: internalName,
   });
+  args = eventArgs;
+  if (extDenial) {
+    return {
+      toolReturn: `Error: Tool execution denied by extension. ${extDenial.reason ?? "No reason given."}`,
+      status: "error",
+    };
+  }
   const startTime = Date.now();
 
   const run = async (): Promise<ToolExecutionResult> => {

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -1923,6 +1923,15 @@ function cloneToolArgsForExtensionEvent(args: ToolArgs): ToolArgs {
   }
 }
 
+function createExtensionDenialToolResult(denial: {
+  reason?: string;
+}): ToolExecutionResult {
+  return {
+    toolReturn: `Error: Tool execution denied by extension. ${denial.reason ?? "No reason given."}`,
+    status: "error",
+  };
+}
+
 function isToolStartArgs(value: unknown): value is ToolArgs {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -2229,10 +2238,7 @@ export async function executeTool(
       toolName: name,
     });
     if (extDenial) {
-      return {
-        toolReturn: `Error: Tool execution denied by extension. ${extDenial.reason ?? "No reason given."}`,
-        status: "error",
-      };
+      return createExtensionDenialToolResult(extDenial);
     }
     return executeExtensionTool(
       name,
@@ -2259,10 +2265,7 @@ export async function executeTool(
       toolName: name,
     });
     if (extDenial) {
-      return {
-        toolReturn: `Error: Tool execution denied by extension. ${extDenial.reason ?? "No reason given."}`,
-        status: "error",
-      };
+      return createExtensionDenialToolResult(extDenial);
     }
     return executeExternalTool(
       options?.toolCallId ?? `ext-${Date.now()}`,
@@ -2307,10 +2310,7 @@ export async function executeTool(
   });
   args = eventArgs;
   if (extDenial) {
-    return {
-      toolReturn: `Error: Tool execution denied by extension. ${extDenial.reason ?? "No reason given."}`,
-      status: "error",
-    };
+    return createExtensionDenialToolResult(extDenial);
   }
   const startTime = Date.now();
 

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -32,8 +32,10 @@ import {
   isExtensionToolParallelSafe,
   runExtensionTool,
 } from "@/extensions/tool-registry";
-import type { ExtensionToolRunContext } from "@/extensions/types";
-import type { ExtensionEventEmissionResult } from "@/extensions/types";
+import type {
+  ExtensionEventEmissionResult,
+  ExtensionToolRunContext,
+} from "@/extensions/types";
 import {
   runPostToolUseFailureHooks,
   runPostToolUseHooks,
@@ -1954,8 +1956,14 @@ async function emitToolStartEvent(options: {
       typeof r === "object" && r !== null && r.deny === true,
   );
   if (firstDenial) {
-    debugLog("extensions", `tool_start denied: ${firstDenial.reason ?? "no reason given"}`);
-    return { args: isToolStartArgs(event.args) ? event.args : options.args, denied: { reason: firstDenial.reason } };
+    debugLog(
+      "extensions",
+      `tool_start denied: ${firstDenial.reason ?? "no reason given"}`,
+    );
+    return {
+      args: isToolStartArgs(event.args) ? event.args : options.args,
+      denied: { reason: firstDenial.reason },
+    };
   }
 
   return { args: isToolStartArgs(event.args) ? event.args : options.args };


### PR DESCRIPTION
## Summary
- Extension handlers can return `{ deny: true, reason?: "..." }` to block tool execution
- All handlers still run (for side effects), but any denial blocks the tool
- First denial reason is shown to the model as the tool error message
- Denial runs before `PreToolUse` hooks — if an extension denies, hooks are not invoked

## Why
This enables extensions to implement safety gates like plan mode, where action tools (Edit, Write, Bash) are blocked until the user approves a plan. Unlike `requiresApproval`, denial works even in unrestricted/yolo mode because it is enforced by the extension, not the approval system.

## Changes
- `ExtensionToolStartResult`: add `deny` and `reason` fields
- `emitToolStartEvent`: return `{ args, denied? }` instead of just args
- All three call sites in `manager.ts`: check for denial, return error tool result
- Extension engine: no changes needed (already runs all handlers)
- Skill docs: document denial behavior with examples

## Test plan
- [x] `tool_start denial: all handlers run, first denial wins` — verifies both handlers execute, denial is collected, side effects still apply
- [x] `tool_start denial: no denial when handler returns undefined` — verifies non-matching tools pass through
- [x] Type check passes (`tsc --noEmit`)
- [x] Existing extension engine tests still pass

👾 Generated with [Letta Code](https://letta.com)