### PR TITLE
refactor(extensions): extract diagnostics helpers

### DIFF
--- a/src/cli/extensions/local-extension-loader.test.ts
+++ b/src/cli/extensions/local-extension-loader.test.ts
@@ -18,6 +18,10 @@ import {
   resolveLocalExtensionSources,
 } from "@/cli/extensions/local-extension-loader";
 import { buildStatusLinePayload } from "@/cli/helpers/status-line-payload";
+import {
+  getExtensionDiagnosticPath,
+  getExtensionErrorDiagnostics,
+} from "@/extensions/extension-diagnostics";
 import { clearExtensionTools } from "@/extensions/tool-registry";
 
 function createTempDir(): string {
@@ -109,7 +113,7 @@ describe("local extension loader", () => {
       const registry = await loadLocalExtensions(options);
 
       expect(registry.loadedPaths).toEqual([]);
-      expect(registry.errors).toEqual([]);
+      expect(getExtensionErrorDiagnostics(registry.diagnostics)).toEqual([]);
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
@@ -135,7 +139,7 @@ describe("local extension loader", () => {
 
       const registry = await loadLocalExtensions(options);
 
-      expect(registry.errors).toEqual([]);
+      expect(getExtensionErrorDiagnostics(registry.diagnostics)).toEqual([]);
       expect(
         evaluateLocalExtensionStatuses(registry, createStatuslineContext()),
       ).toEqual({ mode: "fast" });
@@ -161,7 +165,9 @@ describe("local extension loader", () => {
       );
 
       const firstRegistry = await loadLocalExtensions(options);
-      expect(firstRegistry.errors).toEqual([]);
+      expect(getExtensionErrorDiagnostics(firstRegistry.diagnostics)).toEqual(
+        [],
+      );
       expect(firstRegistry.loadedPaths).toEqual([extensionPath]);
       expect(
         evaluateLocalExtensionStatuses(
@@ -188,7 +194,9 @@ describe("local extension loader", () => {
       );
 
       const secondRegistry = await loadLocalExtensions(options);
-      expect(secondRegistry.errors).toEqual([]);
+      expect(getExtensionErrorDiagnostics(secondRegistry.diagnostics)).toEqual(
+        [],
+      );
       expect(
         evaluateLocalExtensionStatuses(
           secondRegistry,
@@ -226,7 +234,7 @@ describe("local extension loader", () => {
 
       const registry = await loadLocalExtensions(options);
 
-      expect(registry.errors).toEqual([]);
+      expect(getExtensionErrorDiagnostics(registry.diagnostics)).toEqual([]);
       expect(registry.loadedPaths).toEqual([extensionPath]);
       const cacheFiles = readdirSync(options.cacheDirectory).filter((entry) =>
         entry.startsWith(".letta-extension-statusline-"),
@@ -267,13 +275,16 @@ describe("local extension loader", () => {
       expect(
         evaluateLocalExtensionStatuses(registry, createStatuslineContext()),
       ).toEqual({ ok: "true" });
-      expect(registry.errors).toHaveLength(1);
-      expect(registry.errors[0]?.path).toBe(
+      const errorDiagnostics = getExtensionErrorDiagnostics(
+        registry.diagnostics,
+      );
+      expect(errorDiagnostics).toHaveLength(1);
+      const [errorDiagnostic] = errorDiagnostics;
+      if (!errorDiagnostic) throw new Error("Expected extension diagnostic");
+      expect(getExtensionDiagnosticPath(errorDiagnostic)).toBe(
         path.join(extensionDir, "broken.ts"),
       );
-      expect(registry.errors[0]?.error.message).toContain(
-        "Extension must export",
-      );
+      expect(errorDiagnostic.error.message).toContain("Extension must export");
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
@@ -305,7 +316,7 @@ describe("local extension loader", () => {
 
       const registry = await loadLocalExtensions(options);
 
-      expect(registry.errors).toEqual([]);
+      expect(getExtensionErrorDiagnostics(registry.diagnostics)).toEqual([]);
       expect(registry.commands["review-pr"]?.description).toBe(
         "Review a GitHub PR",
       );
@@ -365,7 +376,7 @@ describe("local extension loader", () => {
 
       const registry = await loadLocalExtensions(options);
 
-      expect(registry.errors).toEqual([]);
+      expect(getExtensionErrorDiagnostics(registry.diagnostics)).toEqual([]);
       await expect(
         Promise.resolve(
           registry.commands["client-check"]?.run({
@@ -414,7 +425,7 @@ describe("local extension loader", () => {
 
       const registry = await loadLocalExtensions(options);
 
-      expect(registry.errors).toEqual([]);
+      expect(getExtensionErrorDiagnostics(registry.diagnostics)).toEqual([]);
       expect(Object.values(registry.ui.panels)[0]).toMatchObject({
         content: ["answer"],
         id: "btw",
@@ -448,7 +459,7 @@ describe("local extension loader", () => {
 
       const registry = await loadLocalExtensions(options);
 
-      expect(registry.errors).toEqual([]);
+      expect(getExtensionErrorDiagnostics(registry.diagnostics)).toEqual([]);
       expect(
         Object.values(registry.ui.panels).map((panel) => panel.content),
       ).toEqual([["from a"], ["from b"]]);
@@ -508,11 +519,14 @@ describe("local extension loader", () => {
 
       expect(Object.keys(registry.commands)).toEqual(["dupe", "reload"]);
       expect(registry.commands.reload?.description).toBe("Built-in conflict");
-      expect(registry.errors.map((entry) => entry.path).sort()).toEqual([
+      const errorDiagnostics = getExtensionErrorDiagnostics(
+        registry.diagnostics,
+      );
+      expect(errorDiagnostics.map(getExtensionDiagnosticPath).sort()).toEqual([
         path.join(extensionDir, "b.ts"),
         path.join(extensionDir, "d.ts"),
       ]);
-      expect(registry.errors.map((entry) => entry.error.message)).toEqual([
+      expect(errorDiagnostics.map((entry) => entry.error.message)).toEqual([
         expect.stringContaining("already registered"),
         expect.stringContaining("must not start"),
       ]);
@@ -524,7 +538,7 @@ describe("local extension loader", () => {
               message: expect.stringContaining("overrides a built-in command"),
             }),
             path: path.join(extensionDir, "c.ts"),
-            phase: "command.override",
+            phase: "command_override",
           }),
         ]),
       );
@@ -553,8 +567,11 @@ describe("local extension loader", () => {
       const registry = await loadLocalExtensions(options);
 
       expect(registry.tools).toEqual({});
-      expect(registry.errors).toHaveLength(1);
-      expect(registry.errors[0]?.error.message).toContain("built-in tool");
+      const errorDiagnostics = getExtensionErrorDiagnostics(
+        registry.diagnostics,
+      );
+      expect(errorDiagnostics).toHaveLength(1);
+      expect(errorDiagnostics[0]?.error.message).toContain("built-in tool");
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/src/cli/extensions/local-extension-loader.test.ts
+++ b/src/cli/extensions/local-extension-loader.test.ts
@@ -18,10 +18,7 @@ import {
   resolveLocalExtensionSources,
 } from "@/cli/extensions/local-extension-loader";
 import { buildStatusLinePayload } from "@/cli/helpers/status-line-payload";
-import {
-  getExtensionDiagnosticPath,
-  getExtensionErrorDiagnostics,
-} from "@/extensions/extension-diagnostics";
+import { getExtensionErrorDiagnostics } from "@/extensions/extension-diagnostics";
 import { clearExtensionTools } from "@/extensions/tool-registry";
 
 function createTempDir(): string {
@@ -281,7 +278,7 @@ describe("local extension loader", () => {
       expect(errorDiagnostics).toHaveLength(1);
       const [errorDiagnostic] = errorDiagnostics;
       if (!errorDiagnostic) throw new Error("Expected extension diagnostic");
-      expect(getExtensionDiagnosticPath(errorDiagnostic)).toBe(
+      expect(errorDiagnostic.owner.path).toBe(
         path.join(extensionDir, "broken.ts"),
       );
       expect(errorDiagnostic.error.message).toContain("Extension must export");
@@ -522,7 +519,7 @@ describe("local extension loader", () => {
       const errorDiagnostics = getExtensionErrorDiagnostics(
         registry.diagnostics,
       );
-      expect(errorDiagnostics.map(getExtensionDiagnosticPath).sort()).toEqual([
+      expect(errorDiagnostics.map((entry) => entry.owner.path).sort()).toEqual([
         path.join(extensionDir, "b.ts"),
         path.join(extensionDir, "d.ts"),
       ]);
@@ -537,7 +534,9 @@ describe("local extension loader", () => {
             error: expect.objectContaining({
               message: expect.stringContaining("overrides a built-in command"),
             }),
-            path: path.join(extensionDir, "c.ts"),
+            owner: expect.objectContaining({
+              path: path.join(extensionDir, "c.ts"),
+            }),
             phase: "command_override",
           }),
         ]),

--- a/src/cli/extensions/local-extension-loader.ts
+++ b/src/cli/extensions/local-extension-loader.ts
@@ -93,7 +93,6 @@ export type {
   LettaExtensionFactory,
   LoadLocalExtensionsOptions,
   LocalExtensionDisposer,
-  LocalExtensionLoadError,
   LocalExtensionRegistry,
   LocalExtensionSource,
   LocalExtensionUiRegistry,

--- a/src/extensions/disabled-extension-adapter.ts
+++ b/src/extensions/disabled-extension-adapter.ts
@@ -24,7 +24,6 @@ function createDisabledExtensionRegistry(): LocalExtensionRegistry {
     commands: {},
     diagnostics: [],
     disposers: [],
-    errors: [],
     events: {},
     generation: 0,
     loadedPaths: [],

--- a/src/extensions/extension-adapter.ts
+++ b/src/extensions/extension-adapter.ts
@@ -8,10 +8,7 @@ import {
   type ExtensionEvents,
   emptyEventEmissionResult,
 } from "@/extensions/event-emitter";
-import {
-  getExtensionDiagnosticPath,
-  getExtensionErrorDiagnostics,
-} from "@/extensions/extension-diagnostics";
+import { getExtensionErrorDiagnostics } from "@/extensions/extension-diagnostics";
 import {
   type CreateExtensionEngineOptions,
   createExtensionEngine,
@@ -154,7 +151,7 @@ export function createExtensionAdapter(
       debugLog(
         "extensions",
         "failed to load %s: %s",
-        getExtensionDiagnosticPath(diagnostic),
+        diagnostic.owner.path,
         diagnostic.error.message,
       );
     }

--- a/src/extensions/extension-adapter.ts
+++ b/src/extensions/extension-adapter.ts
@@ -9,6 +9,10 @@ import {
   emptyEventEmissionResult,
 } from "@/extensions/event-emitter";
 import {
+  getExtensionDiagnosticPath,
+  getExtensionErrorDiagnostics,
+} from "@/extensions/extension-diagnostics";
+import {
   type CreateExtensionEngineOptions,
   createExtensionEngine,
   type ExtensionEngine,
@@ -144,17 +148,19 @@ export function createExtensionAdapter(
       nextRegistry.ui.statuslineRenderer?.id ?? "(none)",
     );
 
-    for (const loadError of nextRegistry.errors) {
+    for (const diagnostic of getExtensionErrorDiagnostics(
+      nextRegistry.diagnostics,
+    )) {
       debugLog(
         "extensions",
         "failed to load %s: %s",
-        loadError.path,
-        loadError.error.message,
+        getExtensionDiagnosticPath(diagnostic),
+        diagnostic.error.message,
       );
     }
 
     for (const diagnostic of nextRegistry.diagnostics) {
-      if (diagnostic.phase === "command.override") {
+      if (diagnostic.phase === "command_override") {
         debugLog("extensions", "%s", diagnostic.error.message);
       }
     }

--- a/src/extensions/extension-diagnostics.test.ts
+++ b/src/extensions/extension-diagnostics.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type ExtensionDiagnosticSink,
+  getExtensionDiagnosticSeverity,
+  recordExtensionDiagnostic,
+} from "@/extensions/extension-diagnostics";
+import type { ExtensionDiagnostic, ExtensionOwner } from "@/extensions/types";
+
+function createOwner(): ExtensionOwner {
+  return {
+    generation: 1,
+    id: "global:/tmp/example.ts",
+    path: "/tmp/example.ts",
+    scope: "global",
+  };
+}
+
+describe("extension diagnostics", () => {
+  test("classifies diagnostic phases for future surfacing", () => {
+    expect(getExtensionDiagnosticSeverity("command.override")).toBe("warning");
+    expect(getExtensionDiagnosticSeverity("status.evaluate")).toBe("warning");
+    expect(getExtensionDiagnosticSeverity("activate")).toBe("error");
+    expect(getExtensionDiagnosticSeverity("event")).toBe("error");
+  });
+
+  test("records diagnostics and only mirrors error phases into errors", () => {
+    const registry: ExtensionDiagnosticSink = { diagnostics: [], errors: [] };
+    const owner = createOwner();
+    const seen: ExtensionDiagnostic[] = [];
+
+    const warning = recordExtensionDiagnostic(
+      registry,
+      {
+        capability: { id: "reload", kind: "command" },
+        error: new Error("command override"),
+        owner,
+        path: owner.path,
+        phase: "command.override",
+      },
+      (diagnostic) => seen.push(diagnostic),
+    );
+    const error = recordExtensionDiagnostic(registry, {
+      error: new Error("activation failed"),
+      owner,
+      path: owner.path,
+      phase: "activate",
+    });
+
+    expect(registry.diagnostics).toEqual([warning, error]);
+    expect(registry.errors).toEqual([
+      {
+        error: error.error,
+        owner,
+        path: owner.path,
+        phase: "activate",
+      },
+    ]);
+    expect(seen).toEqual([warning]);
+    expect(warning.timestamp).toEqual(expect.any(Number));
+    expect(error.timestamp).toEqual(expect.any(Number));
+  });
+});

--- a/src/extensions/extension-diagnostics.test.ts
+++ b/src/extensions/extension-diagnostics.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
-  type ExtensionDiagnosticSink,
+  type ExtensionDiagnosticCollector,
   getExtensionDiagnosticSeverity,
+  getExtensionErrorDiagnostics,
   recordExtensionDiagnostic,
 } from "@/extensions/extension-diagnostics";
 import type { ExtensionDiagnostic, ExtensionOwner } from "@/extensions/types";
@@ -17,14 +18,15 @@ function createOwner(): ExtensionOwner {
 
 describe("extension diagnostics", () => {
   test("classifies diagnostic phases for future surfacing", () => {
-    expect(getExtensionDiagnosticSeverity("command.override")).toBe("warning");
-    expect(getExtensionDiagnosticSeverity("status.evaluate")).toBe("warning");
+    expect(getExtensionDiagnosticSeverity("command_override")).toBe("warning");
     expect(getExtensionDiagnosticSeverity("activate")).toBe("error");
     expect(getExtensionDiagnosticSeverity("event")).toBe("error");
   });
 
-  test("records diagnostics and only mirrors error phases into errors", () => {
-    const registry: ExtensionDiagnosticSink = { diagnostics: [], errors: [] };
+  test("records diagnostics and derives error diagnostics", () => {
+    const registry: ExtensionDiagnosticCollector = {
+      diagnostics: [],
+    };
     const owner = createOwner();
     const seen: ExtensionDiagnostic[] = [];
 
@@ -35,7 +37,7 @@ describe("extension diagnostics", () => {
         error: new Error("command override"),
         owner,
         path: owner.path,
-        phase: "command.override",
+        phase: "command_override",
       },
       (diagnostic) => seen.push(diagnostic),
     );
@@ -47,14 +49,7 @@ describe("extension diagnostics", () => {
     });
 
     expect(registry.diagnostics).toEqual([warning, error]);
-    expect(registry.errors).toEqual([
-      {
-        error: error.error,
-        owner,
-        path: owner.path,
-        phase: "activate",
-      },
-    ]);
+    expect(getExtensionErrorDiagnostics(registry.diagnostics)).toEqual([error]);
     expect(seen).toEqual([warning]);
     expect(warning.timestamp).toEqual(expect.any(Number));
     expect(error.timestamp).toEqual(expect.any(Number));

--- a/src/extensions/extension-diagnostics.test.ts
+++ b/src/extensions/extension-diagnostics.test.ts
@@ -36,7 +36,6 @@ describe("extension diagnostics", () => {
         capability: { id: "reload", kind: "command" },
         error: new Error("command override"),
         owner,
-        path: owner.path,
         phase: "command_override",
       },
       (diagnostic) => seen.push(diagnostic),
@@ -44,7 +43,6 @@ describe("extension diagnostics", () => {
     const error = recordExtensionDiagnostic(registry, {
       error: new Error("activation failed"),
       owner,
-      path: owner.path,
       phase: "activate",
     });
 

--- a/src/extensions/extension-diagnostics.ts
+++ b/src/extensions/extension-diagnostics.ts
@@ -1,0 +1,85 @@
+import type {
+  ExtensionDiagnostic,
+  ExtensionDiagnosticPhase,
+  ExtensionOwner,
+} from "@/extensions/types";
+
+export type ExtensionDiagnosticSeverity = "error" | "warning";
+
+export interface ExtensionDiagnosticSink {
+  diagnostics: ExtensionDiagnostic[];
+  errors: Array<{
+    error: Error;
+    owner?: ExtensionOwner;
+    path: string;
+    phase?: ExtensionDiagnosticPhase;
+  }>;
+}
+
+export function getExtensionDiagnosticSeverity(
+  phase: ExtensionDiagnosticPhase,
+): ExtensionDiagnosticSeverity {
+  switch (phase) {
+    case "command.override":
+    case "status.evaluate":
+      return "warning";
+    default:
+      return "error";
+  }
+}
+
+export function isExtensionDiagnosticErrorPhase(
+  phase: ExtensionDiagnosticPhase,
+): boolean {
+  return getExtensionDiagnosticSeverity(phase) === "error";
+}
+
+export function appendExtensionDiagnostic(
+  registry: ExtensionDiagnosticSink,
+  diagnostic: ExtensionDiagnostic,
+): void {
+  registry.diagnostics.push(diagnostic);
+  if (isExtensionDiagnosticErrorPhase(diagnostic.phase)) {
+    registry.errors.push({
+      error: diagnostic.error,
+      ...(diagnostic.owner ? { owner: diagnostic.owner } : {}),
+      path: diagnostic.path ?? diagnostic.owner?.path ?? "",
+      phase: diagnostic.phase,
+    });
+  }
+}
+
+export function recordExtensionDiagnostic(
+  registry: ExtensionDiagnosticSink,
+  diagnostic: Omit<ExtensionDiagnostic, "timestamp">,
+  onDiagnostic?: (diagnostic: ExtensionDiagnostic) => void,
+): ExtensionDiagnostic {
+  const completeDiagnostic: ExtensionDiagnostic = {
+    ...diagnostic,
+    timestamp: Date.now(),
+  };
+  appendExtensionDiagnostic(registry, completeDiagnostic);
+  onDiagnostic?.(completeDiagnostic);
+  return completeDiagnostic;
+}
+
+export function recordStaleHandleUse(
+  registry: ExtensionDiagnosticSink,
+  owner: ExtensionOwner,
+  capability: ExtensionDiagnostic["capability"],
+  onDiagnostic?: (diagnostic: ExtensionDiagnostic) => void,
+): ExtensionDiagnostic {
+  return recordExtensionDiagnostic(
+    registry,
+    {
+      capability,
+      error: new Error(
+        `Ignored stale extension handle for ${capability?.kind ?? "capability"}${capability?.id ? ` '${capability.id}'` : ""}`,
+      ),
+      owner,
+      path: owner.path,
+      phase: "stale_handle",
+    },
+    onDiagnostic,
+  );
+}

--- a/src/extensions/extension-diagnostics.ts
+++ b/src/extensions/extension-diagnostics.ts
@@ -6,22 +6,15 @@ import type {
 
 export type ExtensionDiagnosticSeverity = "error" | "warning";
 
-export interface ExtensionDiagnosticSink {
+export interface ExtensionDiagnosticCollector {
   diagnostics: ExtensionDiagnostic[];
-  errors: Array<{
-    error: Error;
-    owner?: ExtensionOwner;
-    path: string;
-    phase?: ExtensionDiagnosticPhase;
-  }>;
 }
 
 export function getExtensionDiagnosticSeverity(
   phase: ExtensionDiagnosticPhase,
 ): ExtensionDiagnosticSeverity {
   switch (phase) {
-    case "command.override":
-    case "status.evaluate":
+    case "command_override":
       return "warning";
     default:
       return "error";
@@ -34,23 +27,33 @@ export function isExtensionDiagnosticErrorPhase(
   return getExtensionDiagnosticSeverity(phase) === "error";
 }
 
+export function isExtensionDiagnosticError(
+  diagnostic: Pick<ExtensionDiagnostic, "phase">,
+): boolean {
+  return isExtensionDiagnosticErrorPhase(diagnostic.phase);
+}
+
+export function getExtensionErrorDiagnostics(
+  diagnostics: readonly ExtensionDiagnostic[],
+): ExtensionDiagnostic[] {
+  return diagnostics.filter(isExtensionDiagnosticError);
+}
+
+export function getExtensionDiagnosticPath(
+  diagnostic: Pick<ExtensionDiagnostic, "owner" | "path">,
+): string {
+  return diagnostic.path ?? diagnostic.owner?.path ?? "";
+}
+
 export function appendExtensionDiagnostic(
-  registry: ExtensionDiagnosticSink,
+  collector: ExtensionDiagnosticCollector,
   diagnostic: ExtensionDiagnostic,
 ): void {
-  registry.diagnostics.push(diagnostic);
-  if (isExtensionDiagnosticErrorPhase(diagnostic.phase)) {
-    registry.errors.push({
-      error: diagnostic.error,
-      ...(diagnostic.owner ? { owner: diagnostic.owner } : {}),
-      path: diagnostic.path ?? diagnostic.owner?.path ?? "",
-      phase: diagnostic.phase,
-    });
-  }
+  collector.diagnostics.push(diagnostic);
 }
 
 export function recordExtensionDiagnostic(
-  registry: ExtensionDiagnosticSink,
+  collector: ExtensionDiagnosticCollector,
   diagnostic: Omit<ExtensionDiagnostic, "timestamp">,
   onDiagnostic?: (diagnostic: ExtensionDiagnostic) => void,
 ): ExtensionDiagnostic {
@@ -58,19 +61,19 @@ export function recordExtensionDiagnostic(
     ...diagnostic,
     timestamp: Date.now(),
   };
-  appendExtensionDiagnostic(registry, completeDiagnostic);
+  appendExtensionDiagnostic(collector, completeDiagnostic);
   onDiagnostic?.(completeDiagnostic);
   return completeDiagnostic;
 }
 
 export function recordStaleHandleUse(
-  registry: ExtensionDiagnosticSink,
+  collector: ExtensionDiagnosticCollector,
   owner: ExtensionOwner,
   capability: ExtensionDiagnostic["capability"],
   onDiagnostic?: (diagnostic: ExtensionDiagnostic) => void,
 ): ExtensionDiagnostic {
   return recordExtensionDiagnostic(
-    registry,
+    collector,
     {
       capability,
       error: new Error(

--- a/src/extensions/extension-diagnostics.ts
+++ b/src/extensions/extension-diagnostics.ts
@@ -39,12 +39,6 @@ export function getExtensionErrorDiagnostics(
   return diagnostics.filter(isExtensionDiagnosticError);
 }
 
-export function getExtensionDiagnosticPath(
-  diagnostic: Pick<ExtensionDiagnostic, "owner" | "path">,
-): string {
-  return diagnostic.path ?? diagnostic.owner?.path ?? "";
-}
-
 export function appendExtensionDiagnostic(
   collector: ExtensionDiagnosticCollector,
   diagnostic: ExtensionDiagnostic,
@@ -80,7 +74,6 @@ export function recordStaleHandleUse(
         `Ignored stale extension handle for ${capability?.kind ?? "capability"}${capability?.id ? ` '${capability.id}'` : ""}`,
       ),
       owner,
-      path: owner.path,
       phase: "stale_handle",
     },
     onDiagnostic,

--- a/src/extensions/extension-engine.test.ts
+++ b/src/extensions/extension-engine.test.ts
@@ -9,6 +9,10 @@ import {
   getRegisteredPiProvider,
 } from "@/backend/dev/pi-provider-extension-registry";
 import {
+  getExtensionDiagnosticPath,
+  getExtensionErrorDiagnostics,
+} from "@/extensions/extension-diagnostics";
+import {
   createExtensionEngine,
   type ExtensionEngine,
 } from "@/extensions/extension-engine";
@@ -255,7 +259,9 @@ describe("extension engine", () => {
       expect(forkResult).toMatchObject({
         id: "conv-1:agent-1:hidden",
       });
-      expect(engine.getSnapshot().errors).toEqual([]);
+      expect(
+        getExtensionErrorDiagnostics(engine.getSnapshot().diagnostics),
+      ).toEqual([]);
     } finally {
       delete testGlobal.__lettaExtensionBackend;
       delete testGlobal.__lettaExtensionForkResult;
@@ -422,7 +428,7 @@ describe("extension engine", () => {
       await engine.reload();
       const snapshot = engine.getSnapshot();
 
-      expect(snapshot.errors).toEqual([]);
+      expect(getExtensionErrorDiagnostics(snapshot.diagnostics)).toEqual([]);
       expect(snapshot.commands).toEqual({});
       expect(snapshot.events).toEqual({});
       expect(snapshot.ui.panels).toEqual({});
@@ -481,7 +487,9 @@ describe("extension engine", () => {
         "startup:agent-1:Amelia:conversation-1",
       ]);
       expect(snapshot.ui.statusValues.lifecycle).toBe("startup");
-      expect(snapshot.errors.at(-1)).toMatchObject({
+      expect(
+        getExtensionErrorDiagnostics(snapshot.diagnostics).at(-1),
+      ).toMatchObject({
         phase: "event",
         error: expect.objectContaining({ message: "event failed" }),
       });
@@ -834,9 +842,12 @@ describe("extension engine", () => {
 
       expect(
         Object.fromEntries(
-          engine
-            .getSnapshot()
-            .errors.map((entry) => [path.basename(entry.path), entry.phase]),
+          getExtensionErrorDiagnostics(engine.getSnapshot().diagnostics).map(
+            (entry) => [
+              path.basename(getExtensionDiagnosticPath(entry)),
+              entry.phase,
+            ],
+          ),
         ),
       ).toEqual({
         "phase-activate.js": "activate",
@@ -878,7 +889,7 @@ describe("extension engine", () => {
       await engine.reload();
       const snapshot = engine.getSnapshot();
 
-      expect(snapshot.errors).toEqual([]);
+      expect(getExtensionErrorDiagnostics(snapshot.diagnostics)).toEqual([]);
       expect(snapshot.tools.local_weather).toMatchObject({
         description: "Get local weather",
         owner: {

--- a/src/extensions/extension-engine.test.ts
+++ b/src/extensions/extension-engine.test.ts
@@ -8,10 +8,7 @@ import {
   clearRegisteredPiProviders,
   getRegisteredPiProvider,
 } from "@/backend/dev/pi-provider-extension-registry";
-import {
-  getExtensionDiagnosticPath,
-  getExtensionErrorDiagnostics,
-} from "@/extensions/extension-diagnostics";
+import { getExtensionErrorDiagnostics } from "@/extensions/extension-diagnostics";
 import {
   createExtensionEngine,
   type ExtensionEngine,
@@ -843,10 +840,7 @@ describe("extension engine", () => {
       expect(
         Object.fromEntries(
           getExtensionErrorDiagnostics(engine.getSnapshot().diagnostics).map(
-            (entry) => [
-              path.basename(getExtensionDiagnosticPath(entry)),
-              entry.phase,
-            ],
+            (entry) => [path.basename(entry.owner.path), entry.phase],
           ),
         ),
       ).toEqual({

--- a/src/extensions/extension-engine.ts
+++ b/src/extensions/extension-engine.ts
@@ -153,8 +153,7 @@ export interface LettaExtensionApi {
 export interface LocalExtensionDisposer {
   abortController?: AbortController;
   dispose: LettaExtensionDisposer;
-  owner?: ExtensionOwner;
-  path: string;
+  owner: ExtensionOwner;
 }
 
 export interface LocalExtensionUiRegistry {
@@ -901,7 +900,6 @@ function createLettaExtensionApi(
         handler: handler as unknown as ExtensionEventHandler,
         name,
         owner,
-        path: owner.path,
       },
     ];
     onChange();
@@ -936,7 +934,6 @@ function createLettaExtensionApi(
                 `Extension command '${normalized.id}' overrides a built-in command`,
               ),
               owner,
-              path: owner.path,
               phase: "command_override",
             },
             onDiagnostic,
@@ -1153,7 +1150,6 @@ export async function loadLocalExtensions(
             abortController,
             dispose,
             owner,
-            path: extensionPath,
           });
         }
         registry.loadedPaths.push(extensionPath);
@@ -1166,7 +1162,6 @@ export async function loadLocalExtensions(
           {
             error: error instanceof Error ? error : new Error(String(error)),
             owner,
-            path: extensionPath,
             phase: failurePhase,
           },
           options.onDiagnostic,
@@ -1291,8 +1286,7 @@ export async function emitLocalExtensionEvent<TName extends ExtensionEventName>(
         {
           capability: { id: name, kind: "event" },
           error: error instanceof Error ? error : new Error(String(error)),
-          ...(registration.owner ? { owner: registration.owner } : {}),
-          path: registration.path,
+          owner: registration.owner,
           phase: "event",
         },
         onDiagnostic,
@@ -1312,14 +1306,13 @@ export function disposeLocalExtensions(registry: LocalExtensionRegistry): void {
   const disposers = [...registry.disposers].reverse();
   registry.disposers = [];
 
-  for (const { dispose, owner, path: extensionPath } of disposers) {
+  for (const { dispose, owner } of disposers) {
     try {
       dispose();
     } catch (error) {
       recordExtensionDiagnostic(registry, {
         error: error instanceof Error ? error : new Error(String(error)),
-        ...(owner ? { owner } : {}),
-        path: extensionPath,
+        owner,
         phase: "dispose",
       });
     }

--- a/src/extensions/extension-engine.ts
+++ b/src/extensions/extension-engine.ts
@@ -35,6 +35,11 @@ import {
 } from "@/extensions/capabilities";
 import { createExtensionConversationHandle } from "@/extensions/conversation-handle";
 import {
+  appendExtensionDiagnostic,
+  recordExtensionDiagnostic,
+  recordStaleHandleUse,
+} from "@/extensions/extension-diagnostics";
+import {
   getExtensionToolDefinition,
   registerExtensionTool,
   unregisterExtensionTool,
@@ -311,51 +316,6 @@ function isOwnerLive(
   owner: ExtensionOwner,
 ): boolean {
   return registry.owners[owner.id]?.generation === owner.generation;
-}
-
-function recordExtensionDiagnostic(
-  registry: LocalExtensionRegistry,
-  diagnostic: Omit<ExtensionDiagnostic, "timestamp">,
-  onDiagnostic?: (diagnostic: ExtensionDiagnostic) => void,
-): void {
-  const completeDiagnostic: ExtensionDiagnostic = {
-    ...diagnostic,
-    timestamp: Date.now(),
-  };
-  registry.diagnostics.push(completeDiagnostic);
-  if (
-    completeDiagnostic.phase !== "status.evaluate" &&
-    completeDiagnostic.phase !== "command.override"
-  ) {
-    registry.errors.push({
-      error: completeDiagnostic.error,
-      ...(completeDiagnostic.owner ? { owner: completeDiagnostic.owner } : {}),
-      path: completeDiagnostic.path ?? completeDiagnostic.owner?.path ?? "",
-      phase: completeDiagnostic.phase,
-    });
-  }
-  onDiagnostic?.(completeDiagnostic);
-}
-
-function recordStaleHandleUse(
-  registry: LocalExtensionRegistry,
-  owner: ExtensionOwner,
-  capability: ExtensionDiagnostic["capability"],
-  onDiagnostic?: (diagnostic: ExtensionDiagnostic) => void,
-): void {
-  recordExtensionDiagnostic(
-    registry,
-    {
-      capability,
-      error: new Error(
-        `Ignored stale extension handle for ${capability?.kind ?? "capability"}${capability?.id ? ` '${capability.id}'` : ""}`,
-      ),
-      owner,
-      path: owner.path,
-      phase: "stale_handle",
-    },
-    onDiagnostic,
-  );
 }
 
 function snapshotRegistryForReaders(
@@ -1336,7 +1296,7 @@ export async function emitLocalExtensionEvent<TName extends ExtensionEventName>(
       if (toolStartEvent && toolStartArgsBeforeHandler) {
         toolStartEvent.args = toolStartArgsBeforeHandler;
       }
-      recordExtensionDiagnostic(
+      const diagnostic = recordExtensionDiagnostic(
         registry,
         {
           capability: { id: name, kind: "event" },
@@ -1347,8 +1307,7 @@ export async function emitLocalExtensionEvent<TName extends ExtensionEventName>(
         },
         onDiagnostic,
       );
-      const diagnostic = registry.diagnostics.at(-1);
-      if (diagnostic) diagnostics.push(diagnostic);
+      diagnostics.push(diagnostic);
     }
   }
 
@@ -1457,18 +1416,7 @@ export function createExtensionEngine(
         // Stale handles from a prior generation report through their old
         // activation callback. Preserve the diagnostic on the current engine
         // snapshot without reviving the old registry.
-        activeRegistry.diagnostics.push(diagnostic);
-        if (
-          diagnostic.phase !== "status.evaluate" &&
-          diagnostic.phase !== "command.override"
-        ) {
-          activeRegistry.errors.push({
-            error: diagnostic.error,
-            ...(diagnostic.owner ? { owner: diagnostic.owner } : {}),
-            path: diagnostic.path ?? diagnostic.owner?.path ?? "",
-            phase: diagnostic.phase,
-          });
-        }
+        appendExtensionDiagnostic(activeRegistry, diagnostic);
         publish();
       },
     });

--- a/src/extensions/extension-engine.ts
+++ b/src/extensions/extension-engine.ts
@@ -157,13 +157,6 @@ export interface LocalExtensionDisposer {
   path: string;
 }
 
-export interface LocalExtensionLoadError {
-  error: Error;
-  owner?: ExtensionOwner;
-  path: string;
-  phase?: ExtensionDiagnostic["phase"];
-}
-
 export interface LocalExtensionUiRegistry {
   panels: Record<string, ExtensionPanel>;
   statuslineRenderer: StatuslineRenderer | null;
@@ -181,7 +174,6 @@ export interface LocalExtensionRegistry {
   commands: Record<string, ExtensionCommand>;
   diagnostics: ExtensionDiagnostic[];
   disposers: LocalExtensionDisposer[];
-  errors: LocalExtensionLoadError[];
   events: LocalExtensionEventsRegistry;
   generation: number;
   loadedPaths: string[];
@@ -281,7 +273,6 @@ function createEmptyExtensionRegistry(
     commands: {},
     diagnostics: [],
     disposers: [],
-    errors: [],
     events: {},
     generation,
     loadedPaths: [],
@@ -327,7 +318,6 @@ function snapshotRegistryForReaders(
     capabilities: cloneExtensionCapabilities(registry.capabilities),
     diagnostics: [...registry.diagnostics],
     disposers: [...registry.disposers],
-    errors: [...registry.errors],
     events: Object.fromEntries(
       Object.entries(registry.events).map(([name, handlers]) => [
         name,
@@ -947,7 +937,7 @@ function createLettaExtensionApi(
               ),
               owner,
               path: owner.path,
-              phase: "command.override",
+              phase: "command_override",
             },
             onDiagnostic,
           );

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -226,8 +226,7 @@ export interface ExtensionEventRegistration<
 > {
   handler: ExtensionEventHandler<TName>;
   name: TName;
-  owner?: ExtensionOwner;
-  path: string;
+  owner: ExtensionOwner;
 }
 
 export interface ExtensionEventEmissionResult<
@@ -271,8 +270,7 @@ export interface ExtensionDiagnostic {
     kind: ExtensionCapabilityKind;
   };
   error: Error;
-  owner?: ExtensionOwner;
-  path?: string;
+  owner: ExtensionOwner;
   phase: ExtensionDiagnosticPhase;
   timestamp: number;
 }

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -260,11 +260,10 @@ export type ExtensionDiagnosticPhase =
   | "transpile"
   | "import"
   | "activate"
-  | "command.override"
+  | "command_override"
   | "dispose"
   | "event"
-  | "stale_handle"
-  | "status.evaluate";
+  | "stale_handle";
 
 export interface ExtensionDiagnostic {
   capability?: {


### PR DESCRIPTION
## Summary
- move extension diagnostic recording into `extension-diagnostics.ts`
- make `diagnostics` the single registry source of truth and derive error-only views with `getExtensionErrorDiagnostics`
- remove the stored `errors` array and `LocalExtensionLoadError` type
- require diagnostic owners and use `diagnostic.owner.path` as the path source instead of duplicating `path`
- centralize diagnostic severity helpers for future agent-facing diagnostics
- normalize diagnostic phase naming (`command_override`) and remove unused `status.evaluate`
- return the recorded diagnostic directly instead of reading it back from the registry

## Notes
- no user-facing or agent-facing diagnostics surfacing yet
- this intentionally changes the registry snapshot shape by removing `errors`; consumers should filter `diagnostics` instead
- diagnostic path data now comes from `owner.path`

## Tests
- `bun test src/extensions/extension-diagnostics.test.ts src/extensions/extension-engine.test.ts src/cli/extensions/local-extension-loader.test.ts src/extensions/extension-adapter.test.ts src/extensions/disabled-extension-adapter.test.ts`
- `bun run check`
- `git diff --check`