### PR TITLE
Tag chat summary generation calls

### DIFF
--- a/src/agent/conversation-description.ts
+++ b/src/agent/conversation-description.ts
@@ -9,6 +9,10 @@ import { DEFAULT_SUMMARIZATION_MODEL } from "@/constants";
 import { experimentManager } from "@/experiments/manager";
 import { isDebugEnabled } from "@/utils/debug";
 
+type ConversationDescriptionCreateBody = Parameters<
+  Letta["conversations"]["messages"]["create"]
+>[1] & { llm_call_type: "chat_summary" };
+
 const CONVERSATION_DESCRIPTION_MAX_WORDS = 40;
 
 /**
@@ -110,7 +114,8 @@ export async function generateConversationDescriptionFromFork(
         streaming: true,
         stream_tokens: false,
         include_pings: false,
-      },
+        llm_call_type: "chat_summary",
+      } as ConversationDescriptionCreateBody,
       { signal: abortController.signal },
     );
 

--- a/src/cli/helpers/conversation-title.ts
+++ b/src/cli/helpers/conversation-title.ts
@@ -4,6 +4,10 @@ import { DEFAULT_SUMMARIZATION_MODEL } from "@/constants";
 import { settingsManager } from "@/settings-manager";
 import { isDebugEnabled } from "@/utils/debug";
 
+type ConversationTitleCreateBody = Parameters<
+  Letta["conversations"]["messages"]["create"]
+>[1] & { llm_call_type: "chat_summary" };
+
 /**
  * Maximum characters allowed for an auto-generated conversation title.
  */
@@ -149,7 +153,8 @@ export async function generateConversationTitleFromFork(
         streaming: true,
         stream_tokens: false,
         include_pings: false,
-      },
+        llm_call_type: "chat_summary",
+      } as ConversationTitleCreateBody,
       { signal: abortController.signal },
     );
 


### PR DESCRIPTION
## Summary
- mark hidden-fork conversation title generation requests as `chat_summary`
- mark hidden-fork conversation description generation requests as `chat_summary`
- use local request body type intersections until the generated SDK includes the new field

Depends on letta-cloud PR: https://github.com/letta-ai/letta-cloud/pull/12085

## Tests
- `bun run check`