### PR TITLE
fix(settings): disable automatic conversation titles by default

### DIFF
--- a/src/cli/conversation-title.test.ts
+++ b/src/cli/conversation-title.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -79,15 +79,46 @@ describe("normalizeConversationTitle", () => {
 });
 
 describe("conversation title settings", () => {
-  test("defaults on and persists explicit opt-out", async () => {
-    expect(getConversationTitleSettings()).toEqual({ enabled: true });
+  test("defaults off and persists explicit opt-in", async () => {
+    expect(getConversationTitleSettings()).toEqual({ enabled: false });
 
-    expect(setConversationTitleSettings(false)).toEqual({ enabled: false });
+    expect(setConversationTitleSettings(true)).toEqual({ enabled: true });
     await settingsManager.flush();
 
     await settingsManager.reset();
     await settingsManager.initialize();
 
+    expect(getConversationTitleSettings()).toEqual({ enabled: true });
+  });
+
+  test("rolls back legacy opt-ins once before allowing re-enable", async () => {
+    await settingsManager.reset();
+    const settingsDir = join(testHomeDir, ".letta");
+    const settingsPath = join(settingsDir, "settings.json");
+    await mkdir(settingsDir, { recursive: true });
+    await writeFile(
+      settingsPath,
+      JSON.stringify({ autoConversationTitles: true }, null, 2),
+    );
+
+    await settingsManager.initialize();
+
     expect(getConversationTitleSettings()).toEqual({ enabled: false });
+    await settingsManager.flush();
+
+    const migrated = JSON.parse(await readFile(settingsPath, "utf-8")) as {
+      autoConversationTitles?: boolean;
+      autoConversationTitlesRollbackApplied?: boolean;
+    };
+    expect(migrated.autoConversationTitles).toBe(false);
+    expect(migrated.autoConversationTitlesRollbackApplied).toBe(true);
+
+    expect(setConversationTitleSettings(true)).toEqual({ enabled: true });
+    await settingsManager.flush();
+
+    await settingsManager.reset();
+    await settingsManager.initialize();
+
+    expect(getConversationTitleSettings()).toEqual({ enabled: true });
   });
 });

--- a/src/cli/helpers/conversation-title.ts
+++ b/src/cli/helpers/conversation-title.ts
@@ -16,10 +16,10 @@ export interface ConversationTitleSettingsSnapshot {
 export function getConversationTitleSettings(): ConversationTitleSettingsSnapshot {
   try {
     return {
-      enabled: settingsManager.getSettings().autoConversationTitles !== false,
+      enabled: settingsManager.getSettings().autoConversationTitles === true,
     };
   } catch {
-    return { enabled: true };
+    return { enabled: false };
   }
 }
 

--- a/src/experiments/manager.test.ts
+++ b/src/experiments/manager.test.ts
@@ -78,12 +78,12 @@ describe("experimentManager", () => {
   test("maps conversation title experiment controls to the persistent setting", async () => {
     expect(experimentManager.getSnapshot("conversation_titles")).toMatchObject({
       id: "conversation_titles",
-      enabled: true,
+      enabled: false,
     });
 
-    expect(experimentManager.set("conversation_titles", false)).toMatchObject({
+    expect(experimentManager.set("conversation_titles", true)).toMatchObject({
       id: "conversation_titles",
-      enabled: false,
+      enabled: true,
     });
     await settingsManager.flush();
 
@@ -92,7 +92,7 @@ describe("experimentManager", () => {
 
     expect(experimentManager.getSnapshot("conversation_titles")).toMatchObject({
       id: "conversation_titles",
-      enabled: false,
+      enabled: true,
     });
   });
 });

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -81,6 +81,7 @@ export interface Settings {
   enableSleeptime: boolean;
   sessionContextEnabled: boolean; // Send device/agent context on first message of each session
   autoConversationTitles: boolean; // Generate AI conversation titles when possible
+  autoConversationTitlesRollbackApplied?: boolean; // One-time rollback marker for the default-on title experiment
   autoSwapOnQuotaLimit: boolean; // Auto-switch to temporary Auto model override on quota-limit errors
   includeWorktreeTool: boolean; // Include CreateWorktree in toolsets when true
   preferredBackendMode?: "api" | "local"; // Startup backend preference when no explicit --backend is provided
@@ -167,7 +168,8 @@ const DEFAULT_SETTINGS: Settings = {
   enableSleeptime: false,
   conversationSwitchAlertEnabled: false,
   sessionContextEnabled: true,
-  autoConversationTitles: true,
+  autoConversationTitles: false,
+  autoConversationTitlesRollbackApplied: true,
   autoSwapOnQuotaLimit: true,
   includeWorktreeTool: true,
   recentModels: [],
@@ -419,6 +421,7 @@ class SettingsManager {
     if (this.initialized) return;
 
     const settingsPath = this.getSettingsPath();
+    let shouldRollbackAutoConversationTitles = false;
 
     try {
       // Check if settings file exists
@@ -445,6 +448,16 @@ class SettingsManager {
           // Mark for deletion on next persist; keep startup backward-compatible.
           this.markDirty("reflectionBehavior");
         }
+        shouldRollbackAutoConversationTitles =
+          loadedSettingsRaw.autoConversationTitlesRollbackApplied !== true;
+        if (shouldRollbackAutoConversationTitles) {
+          loadedSettingsRaw.autoConversationTitles = false;
+          loadedSettingsRaw.autoConversationTitlesRollbackApplied = true;
+          this.markDirty(
+            "autoConversationTitles",
+            "autoConversationTitlesRollbackApplied",
+          );
+        }
         // Merge with defaults in case new fields were added
         this.settings = {
           ...DEFAULT_SETTINGS,
@@ -456,6 +469,14 @@ class SettingsManager {
       }
 
       this.initialized = true;
+
+      if (shouldRollbackAutoConversationTitles) {
+        try {
+          await this.persistSettings();
+        } catch {
+          // Best-effort cleanup only; do not fail the load path.
+        }
+      }
 
       // Check secrets availability and warn if not available
       await this.checkSecretsSupport();

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -2621,7 +2621,7 @@ describe("listen-client experiment command handling", () => {
     const originalGetSettings = settingsManager.getSettings;
     const originalUpdateSettings = settingsManager.updateSettings;
     const originalNodeFlag = process.env.LETTA_NODE;
-    const globalSettings = { autoConversationTitles: true } as Settings;
+    const globalSettings = { autoConversationTitles: false } as Settings;
 
     try {
       delete process.env.LETTA_NODE;
@@ -2666,7 +2666,7 @@ describe("listen-client experiment command handling", () => {
           }),
           expect.objectContaining({
             id: "conversation_titles",
-            enabled: true,
+            enabled: false,
           }),
         ]),
       });
@@ -2718,7 +2718,7 @@ describe("listen-client experiment command handling", () => {
           type: "set_experiment",
           request_id: "conversation-titles-set-1",
           experiment_id: "conversation_titles",
-          enabled: false,
+          enabled: true,
         },
         socket as unknown as WebSocket,
         listener,
@@ -2732,11 +2732,11 @@ describe("listen-client experiment command handling", () => {
         experiments: expect.arrayContaining([
           expect.objectContaining({
             id: "conversation_titles",
-            enabled: false,
+            enabled: true,
           }),
         ]),
       });
-      expect(globalSettings.autoConversationTitles).toBe(false);
+      expect(globalSettings.autoConversationTitles).toBe(true);
     } finally {
       if (originalNodeFlag === undefined) {
         delete process.env.LETTA_NODE;


### PR DESCRIPTION
## Summary
- disable automatic conversation title generation by default and make the helper treat titles as opt-in only
- add a one-time settings rollback marker so existing installs with the default-on experiment are opted back out until they explicitly re-enable it
- update experiment, title-settings, and websocket protocol coverage for default-off behavior and re-enable persistence

Verified with `bun test src/cli/conversation-title.test.ts src/experiments/manager.test.ts src/websocket/listen-client-protocol.test.ts` and `bun run check`.

👾 Generated with [Letta Code](https://letta.com)