### PR TITLE
fix(tools): guide Windows Bash usage

### DIFF
--- a/src/tools/bash.test.ts
+++ b/src/tools/bash.test.ts
@@ -3,8 +3,9 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { runWithRuntimeContext } from "@/runtime-context";
-import { bash } from "@/tools/impl/bash";
+import { appendWindowsShellFailureHint, bash } from "@/tools/impl/bash";
 import { backgroundProcesses } from "@/tools/impl/process_manager";
+import BashSchema from "@/tools/schemas/Bash.json";
 
 async function runBashInTemp(
   command: string,
@@ -25,6 +26,33 @@ async function runBashInTemp(
 }
 
 describe("Bash tool", () => {
+  test("command schema warns Windows agents that Bash is PowerShell", () => {
+    expect(BashSchema.properties.command.description).toContain(
+      "On Windows this tool runs through PowerShell",
+    );
+    expect(BashSchema.properties.command.description).toContain("&&");
+  });
+
+  test("adds Windows shell guidance for common PowerShell syntax failures", () => {
+    const output = appendWindowsShellFailureHint(
+      "Exit code: 1\nAt line:1 char:339\nThe token '&&' is not a valid statement separator in this version.",
+      "win32",
+    );
+
+    expect(output).toContain("Windows shell note");
+    expect(output).toContain("PowerShell-compatible syntax");
+    expect(output).toContain("instead of `&&` / `||`");
+  });
+
+  test("does not add Windows shell guidance on non-Windows platforms", () => {
+    const output = appendWindowsShellFailureHint(
+      "Exit code: 1\nThe token '&&' is not a valid statement separator",
+      "darwin",
+    );
+
+    expect(output).not.toContain("Windows shell note");
+  });
+
   test("executes simple command", async () => {
     const result = await bash({
       command: "echo 'Hello, World!'",

--- a/src/tools/descriptions/Bash.md
+++ b/src/tools/descriptions/Bash.md
@@ -36,7 +36,7 @@ Usage notes:
     - Communication: Output text directly (NOT echo/printf)
   - When issuing multiple commands:
     - If the commands are independent and can run in parallel, make multiple Bash tool calls in a single message. For example, if you need to run "git status" and "git diff", send a single message with two Bash tool calls in parallel.
-    - If the commands depend on each other and must run sequentially, use a single Bash call with '&&' to chain them together (e.g., `git add . && git commit -m "message" && git push`). For instance, if one operation must complete before another starts (like mkdir before cp, Write before Bash for git operations, or git add before git commit), run these operations sequentially instead.
+    - If the commands depend on each other and must run sequentially, use shell-appropriate sequencing. On Unix shells, a single Bash call with '&&' is usually appropriate (e.g., `git add . && git commit -m "message" && git push`). On Windows, this tool runs through PowerShell, so prefer separate tool calls or PowerShell-compatible sequencing with `;` and explicit `$LASTEXITCODE` checks instead of assuming `&&` / `||` work.
     - Use ';' only when you need to run commands sequentially but don't care if earlier commands fail
     - DO NOT use newlines to separate commands (newlines are ok in quoted strings)
   - Try to maintain your current working directory throughout the session by using absolute paths and avoiding usage of `cd`. You may use `cd` if the User explicitly requests it.

--- a/src/tools/impl/bash.ts
+++ b/src/tools/impl/bash.ts
@@ -25,6 +25,38 @@ import { validateRequiredParams } from "./validation.js";
 // Cache the working shell launcher after first successful spawn
 let cachedWorkingLauncher: string[] | null = null;
 
+const WINDOWS_SHELL_FAILURE_HINT = [
+  "",
+  "Windows shell note: Bash runs through PowerShell on Windows, not Unix bash.",
+  "Use PowerShell-compatible syntax or separate tool calls. Common fixes: use `;` plus explicit `$LASTEXITCODE` checks instead of `&&` / `||`, `Get-Content -TotalCount` instead of `head`, `Select-String` instead of `grep`, PowerShell hashtables for HTTP headers, and a temporary `.ps1` script for complex quoting.",
+].join("\n");
+
+const WINDOWS_SHELL_ERROR_PATTERNS = [
+  /The token '&&' is not a valid statement separator/i,
+  /The token '\|\|' is not a valid statement separator/i,
+  /\b(head|grep|sed|awk|cat) : The term '\1' is not recognized/i,
+  /The string is missing the terminator/i,
+  /Cannot bind parameter 'Headers'/i,
+  /Missing '\(' after 'if' in if statement/i,
+  /& was unexpected at this time/i,
+  /The '<' operator is reserved for future use/i,
+  /Missing property name after reference operator/i,
+  /Missing argument in parameter list/i,
+  /Unexpected token/i,
+];
+
+export function appendWindowsShellFailureHint(
+  text: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform !== "win32") return text;
+  if (text.includes("Windows shell note:")) return text;
+  if (!WINDOWS_SHELL_ERROR_PATTERNS.some((pattern) => pattern.test(text))) {
+    return text;
+  }
+  return `${text.trimEnd()}${WINDOWS_SHELL_FAILURE_HINT}`;
+}
+
 function rebuildCachedLauncher(
   command: string,
   secretEnv?: Record<string, string>,
@@ -344,7 +376,9 @@ export async function bash(args: BashArgs): Promise<BashResult> {
         content: [
           {
             type: "text",
-            text: `Exit code: ${exitCode}\n${truncatedOutput}`,
+            text: appendWindowsShellFailureHint(
+              `Exit code: ${exitCode}\n${truncatedOutput}`,
+            ),
           },
         ],
         status: "error",
@@ -392,7 +426,9 @@ export async function bash(args: BashArgs): Promise<BashResult> {
     );
 
     return {
-      content: [{ type: "text", text: truncatedError }],
+      content: [
+        { type: "text", text: appendWindowsShellFailureHint(truncatedError) },
+      ],
       status: "error",
     };
   }

--- a/src/tools/schemas/Bash.json
+++ b/src/tools/schemas/Bash.json
@@ -3,7 +3,7 @@
   "properties": {
     "command": {
       "type": "string",
-      "description": "The command to execute"
+      "description": "The command to execute. On Windows this tool runs through PowerShell, not Unix bash; use PowerShell-compatible syntax and avoid bash-only operators/utilities such as &&, ||, head, cat <<EOF, grep, sed, and awk unless you have verified they are available."
     },
     "timeout": {
       "type": "number",

--- a/src/tools/tool-definitions.ts
+++ b/src/tools/tool-definitions.ts
@@ -149,10 +149,24 @@ const WINDOWS_UNIFIED_EXEC_GUIDANCE = `Windows safety rules:
 - Before any recursive delete or move on Windows, verify the resolved absolute target paths stay within the intended workspace or explicitly named target directory. Never issue a recursive delete or move against a computed path if the final target has not been checked.
 - When using \`Start-Process\` to launch a background helper or service, pass \`-WindowStyle Hidden\` unless the user explicitly asked for a visible interactive window. Use visible windows only for interactive tools the user needs to see or control.`;
 
+const WINDOWS_BASH_GUIDANCE = `Windows shell rules:
+- On Windows, the Bash tool executes commands through PowerShell (preferring \`pwsh\`, then Windows PowerShell) and only falls back to \`cmd.exe\` if PowerShell is unavailable. It is not a Unix bash shell.
+- Write Windows-compatible PowerShell commands. Do not use Unix-only utilities or bash syntax such as \`head\`, \`cat <<EOF\`, \`grep\`, \`sed\`, \`awk\`, \`&&\`, \`||\`, or POSIX \`if\`/redirection patterns unless you first verify they are available in the current shell.
+- For sequential commands in Windows PowerShell, prefer separate Bash tool calls or PowerShell statements separated with semicolons and explicit checks, for example \`git status; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }; git diff\`.
+- Use PowerShell-native equivalents: \`Get-Content -TotalCount\` instead of \`head\`, \`Select-String\` instead of \`grep\`, \`Invoke-RestMethod\` / \`Invoke-WebRequest\` with hashtable headers instead of curl-style header strings, and \`Test-Path\` before reading files.
+- For complex multi-line logic on Windows, write a temporary \`.ps1\` script with the Write tool and run it, rather than embedding fragile quoting in a one-line command.`;
+
 function execCommandDescription(): string {
   const baseDescription = ExecCommandDescription.trim();
   return process.platform === "win32"
     ? `${baseDescription}\n\n${WINDOWS_UNIFIED_EXEC_GUIDANCE}`
+    : baseDescription;
+}
+
+function bashDescription(): string {
+  const baseDescription = BashDescription.trim();
+  return process.platform === "win32"
+    ? `${baseDescription}\n\n${WINDOWS_BASH_GUIDANCE}`
     : baseDescription;
 }
 
@@ -164,7 +178,7 @@ const toolDefinitions = {
   }),
   Bash: defineTool({
     schema: BashSchema,
-    description: BashDescription.trim(),
+    description: bashDescription(),
     impl: bash,
   }),
   BashOutput: defineTool({


### PR DESCRIPTION
## Summary
- Clarifies Bash tool guidance/schema so Windows agents know the tool executes through PowerShell, not Unix bash.
- Adds Windows-specific prompt guidance for common failures seen in D. Attridge payloads: `&&` / `||`, Unix utilities like `head`/`grep`, curl-style headers, and fragile one-line PowerShell quoting.
- Appends a recovery hint to Bash error output when common Windows shell syntax failures occur so the next model turn can adapt instead of repeating the same broken command style.

## Test plan
- [x] `bun test src/tools/bash.test.ts src/tools/codex-unified-exec-toolset.test.ts`
- [x] `bunx --bun @biomejs/biome@2.2.5 check src/tools/bash.test.ts src/tools/impl/bash.ts src/tools/tool-definitions.ts src/tools/schemas/Bash.json src/tools/descriptions/Bash.md`
- [ ] `bun run check` (fails in TypeScript on pre-existing missing `@pierre/diffs` / `@pierre/diffs/ssr` declarations in `src/web/generate-diff-viewer.ts`, unrelated to this PR)

Context: investigation of downloaded D. Attridge ClickHouse payloads showed GLM-5.1 tool calls were structurally valid, but many tool results failed at runtime because agents used Unix/bash idioms in Windows PowerShell sessions.

👾 Generated with [Letta Code](https://letta.com)