### PR TITLE
fix(tools): clarify Bash execution on Windows

### DIFF
--- a/src/tools/bash-windows-description.test.ts
+++ b/src/tools/bash-windows-description.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import BashDescription from "@/tools/descriptions/Bash.md";
+import {
+  buildBashDescriptionForPlatform,
+  TOOL_DEFINITIONS,
+} from "@/tools/tool-definitions";
+
+describe("Bash Windows tool description", () => {
+  test("keeps the base Bash description unchanged on non-Windows platforms", () => {
+    const baseDescription = BashDescription.trim();
+
+    expect(buildBashDescriptionForPlatform("darwin")).toBe(baseDescription);
+    expect(buildBashDescriptionForPlatform("linux")).toBe(baseDescription);
+  });
+
+  test("appends Windows shell semantics and safety guidance on Windows", () => {
+    const description = buildBashDescriptionForPlatform("win32");
+
+    expect(description.startsWith(BashDescription.trim())).toBe(true);
+    expect(description).toContain("Windows execution:");
+    expect(description).toContain("does not run commands through bash");
+    expect(description).toContain("PowerShell Core (`pwsh`)");
+    expect(description).toContain("Windows PowerShell");
+    expect(description).toContain("`cmd.exe` as fallback");
+    expect(description).toContain("PowerShell-compatible syntax");
+    expect(description).toContain("heredocs");
+    expect(description).toContain("`export VAR=...`");
+    expect(description).toContain("Windows safety rules:");
+    expect(description).toContain("`Remove-Item` / `Move-Item`");
+    expect(description).toContain("`Start-Process`");
+  });
+
+  test("tool definition uses the platform-aware Bash description", () => {
+    expect(TOOL_DEFINITIONS.Bash.description).toBe(
+      buildBashDescriptionForPlatform(process.platform),
+    );
+  });
+});

--- a/src/tools/tool-definitions.ts
+++ b/src/tools/tool-definitions.ts
@@ -149,6 +149,21 @@ const WINDOWS_UNIFIED_EXEC_GUIDANCE = `Windows safety rules:
 - Before any recursive delete or move on Windows, verify the resolved absolute target paths stay within the intended workspace or explicitly named target directory. Never issue a recursive delete or move against a computed path if the final target has not been checked.
 - When using \`Start-Process\` to launch a background helper or service, pass \`-WindowStyle Hidden\` unless the user explicitly asked for a visible interactive window. Use visible windows only for interactive tools the user needs to see or control.`;
 
+const WINDOWS_BASH_EXECUTION_GUIDANCE = `Windows execution:
+- Despite the tool name, on Windows this tool does not run commands through bash by default. It uses the native Windows shell launcher: PowerShell Core (\`pwsh\`) when available, then Windows PowerShell, then \`cmd.exe\` as fallback.
+- Write commands using PowerShell-compatible syntax by default. POSIX/bash constructs such as heredocs, \`export VAR=...\`, and Unix-style shell quoting may not work unless you explicitly invoke a POSIX shell.
+
+${WINDOWS_UNIFIED_EXEC_GUIDANCE}`;
+
+export function buildBashDescriptionForPlatform(
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const baseDescription = BashDescription.trim();
+  return platform === "win32"
+    ? `${baseDescription}\n\n${WINDOWS_BASH_EXECUTION_GUIDANCE}`
+    : baseDescription;
+}
+
 function execCommandDescription(): string {
   const baseDescription = ExecCommandDescription.trim();
   return process.platform === "win32"
@@ -164,7 +179,7 @@ const toolDefinitions = {
   }),
   Bash: defineTool({
     schema: BashSchema,
-    description: BashDescription.trim(),
+    description: buildBashDescriptionForPlatform(),
     impl: bash,
   }),
   BashOutput: defineTool({


### PR DESCRIPTION
## Summary
- append Windows-specific model-facing guidance to the `Bash` tool description, explaining that the Windows launcher is PowerShell-first with `cmd.exe` fallback despite the tool name
- reuse the existing `exec_command` Windows safety guidance for destructive filesystem commands and visible `Start-Process` windows
- add deterministic tests for Windows and non-Windows Bash descriptions

Verified with `bun test src/tools/bash-windows-description.test.ts src/tools/codex-unified-exec-toolset.test.ts` and `bun run check`.

👾 Generated with [Letta Code](https://letta.com)