### PR TITLE
fix: hide shell tool placeholder flash

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -4522,6 +4522,13 @@ export function App({
           // Only show Task tools that are awaiting approval (not running/finished)
           return ln.phase === "ready" || ln.phase === "streaming";
         }
+        // Shell tools: don't show during streaming phase — wait until running
+        // so the header and streaming output appear together instead of the
+        // bare "• Run cd ..." header flashing before output starts.
+        // Still show during "ready" phase for approval requests.
+        if (ln.name && isShellTool(ln.name) && ln.phase === "streaming") {
+          return false;
+        }
         // Always show other tool calls in progress
         return (
           ln.phase !== "finished" ||

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -4522,13 +4522,6 @@ export function App({
           // Only show Task tools that are awaiting approval (not running/finished)
           return ln.phase === "ready" || ln.phase === "streaming";
         }
-        // Shell tools: don't show during streaming phase — wait until running
-        // so the header and streaming output appear together instead of the
-        // bare "• Run cd ..." header flashing before output starts.
-        // Still show during "ready" phase for approval requests.
-        if (ln.name && isShellTool(ln.name) && ln.phase === "streaming") {
-          return false;
-        }
         // Always show other tool calls in progress
         return (
           ln.phase !== "finished" ||

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -78,6 +78,7 @@ import {
   isFileEditTool,
   isFileWriteTool,
   isPatchTool,
+  isShellTool,
 } from "@/cli/helpers/tool-name-mapping";
 import { isTaskTool } from "@/cli/helpers/tool-name-mapping.js";
 import type { WindowTitleData } from "@/cli/helpers/window-title-config";
@@ -526,6 +527,15 @@ export function AppView(props: AppViewProps) {
                       (ln.toolCallId === currentApproval?.toolCallId ||
                         pendingIds.has(ln.toolCallId) ||
                         queuedIds.has(ln.toolCallId));
+                    if (
+                      ln.kind === "tool_call" &&
+                      ln.name &&
+                      isShellTool(ln.name) &&
+                      !isApprovalTracked &&
+                      (ln.phase === "streaming" || ln.phase === "ready")
+                    ) {
+                      return null;
+                    }
                     if (isFileTool && !isApprovalTracked) {
                       return null;
                     }


### PR DESCRIPTION
## Summary
- hide untracked shell tool calls while they are pre-execution placeholders
- keep approval-tracked shell calls visible so approval UI still works
- remove the earlier liveItems-level suppression in favor of the AppView render layer where approval state is available

## Tests
- npx tsc --noEmit
- npx @biomejs/biome@2.2.5 check src/cli/app/AppCoordinator.tsx src/cli/app/AppView.tsx
- manually tested a shell command from the worktree, no Bash placeholder flash