### PR TITLE
feat: add local connect providers WS command

### DIFF
--- a/src/providers/connect-provider-service.test.ts
+++ b/src/providers/connect-provider-service.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import type { ProviderResponse } from "@/backend/api/providers";
+import type { ByokProvider } from "@/providers/byok-providers";
+import { buildConnectProviderEntries } from "@/providers/connect-provider-service";
+
+describe("connect provider service", () => {
+  test("serializes simple providers with safe default API key fields", () => {
+    const providers: ByokProvider[] = [
+      {
+        id: "anthropic",
+        displayName: "Claude API",
+        description: "Connect an Anthropic API key",
+        providerType: "anthropic",
+        providerName: "lc-anthropic",
+        defaultApiKey: "secret-value",
+      },
+    ];
+
+    const entries = buildConnectProviderEntries(providers, new Map(), "local");
+
+    expect(entries).toEqual([
+      {
+        id: "anthropic",
+        display_name: "Claude API",
+        description: "Connect an Anthropic API key",
+        provider_type: "anthropic",
+        provider_name: "lc-anthropic",
+        provider_names: ["lc-anthropic"],
+        requires_api_key: true,
+        fields: [
+          {
+            key: "apiKey",
+            label: "API Key",
+            secret: true,
+            required: true,
+          },
+        ],
+        connected: { is_connected: false },
+      },
+    ]);
+    expect(JSON.stringify(entries)).not.toContain("secret-value");
+  });
+
+  test("uses provider aliases and auth type to resolve connected local providers", () => {
+    const providers: ByokProvider[] = [
+      {
+        id: "anthropic-oauth",
+        displayName: "Claude OAuth",
+        description: "Connect Claude OAuth",
+        providerType: "anthropic",
+        providerName: "anthropic",
+        providerNames: ["anthropic", "lc-anthropic"],
+        isOAuth: true,
+        oauthProviderId: "anthropic",
+      },
+      {
+        id: "anthropic-api",
+        displayName: "Claude API",
+        description: "Connect Claude API",
+        providerType: "anthropic",
+        providerName: "lc-anthropic",
+        providerNames: ["anthropic", "lc-anthropic"],
+      },
+    ];
+    const connected = new Map<string, ProviderResponse>([
+      [
+        "lc-anthropic",
+        {
+          id: "local-provider-lc-anthropic",
+          name: "lc-anthropic",
+          provider_type: "anthropic",
+          provider_category: "byok",
+          auth_type: "api",
+          api_key: "secret-value",
+          access_key: "secret-access-key",
+          base_url: "https://example.test",
+          region: "us-east-1",
+        },
+      ],
+    ]);
+
+    const entries = buildConnectProviderEntries(providers, connected, "local");
+
+    expect(entries[0]?.connected).toEqual({ is_connected: false });
+    expect(entries[1]?.connected).toEqual({
+      is_connected: true,
+      id: "local-provider-lc-anthropic",
+      provider_name: "lc-anthropic",
+      provider_type: "anthropic",
+      auth_type: "api",
+      base_url: "https://example.test",
+      region: "us-east-1",
+    });
+    expect(JSON.stringify(entries)).not.toContain("secret-value");
+    expect(JSON.stringify(entries)).not.toContain("secret-access-key");
+  });
+
+  test("serializes auth methods instead of default fields", () => {
+    const providers: ByokProvider[] = [
+      {
+        id: "bedrock",
+        displayName: "AWS Bedrock",
+        description: "Connect Bedrock",
+        providerType: "bedrock",
+        providerName: "lc-bedrock",
+        authMethods: [
+          {
+            id: "iam",
+            label: "AWS Access Keys",
+            description: "Enter access keys manually",
+            fields: [
+              { key: "accessKey", label: "Access key" },
+              { key: "apiKey", label: "Secret key", secret: true },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const entries = buildConnectProviderEntries(providers, new Map(), "local");
+
+    expect(entries[0]?.fields).toBeUndefined();
+    expect(entries[0]?.auth_methods).toEqual([
+      {
+        id: "iam",
+        label: "AWS Access Keys",
+        description: "Enter access keys manually",
+        fields: [
+          { key: "accessKey", label: "Access key" },
+          { key: "apiKey", label: "Secret key", secret: true },
+        ],
+      },
+    ]);
+  });
+});

--- a/src/providers/connect-provider-service.ts
+++ b/src/providers/connect-provider-service.ts
@@ -1,0 +1,197 @@
+import type { ProviderResponse } from "@/backend/api/providers";
+import type { LocalProviderTimeout } from "@/backend/local/local-provider-timeout";
+import {
+  type AuthMethod,
+  type ByokProvider,
+  getConnectedProviders,
+  getProviderConfigs,
+  type ProviderField,
+  type ProviderStorageTarget,
+} from "@/providers/byok-providers";
+
+export interface ConnectProviderField {
+  key: string;
+  label: string;
+  placeholder?: string;
+  secret?: boolean;
+  required?: boolean;
+}
+
+export interface ConnectProviderAuthMethod {
+  id: string;
+  label: string;
+  description: string;
+  fields: ConnectProviderField[];
+}
+
+export interface ConnectProviderConnectionState {
+  is_connected: boolean;
+  id?: string;
+  provider_name?: string;
+  provider_type?: string;
+  auth_type?: "api" | "oauth";
+  base_url?: string;
+  timeout?: LocalProviderTimeout;
+  region?: string;
+}
+
+export interface ConnectProviderEntry {
+  id: string;
+  display_name: string;
+  description: string;
+  provider_type: string;
+  provider_name: string;
+  provider_names: string[];
+  is_oauth?: boolean;
+  oauth_provider_id?: string;
+  requires_api_key: boolean;
+  fields?: ConnectProviderField[];
+  auth_methods?: ConnectProviderAuthMethod[];
+  connected: ConnectProviderConnectionState;
+}
+
+export interface ListConnectProvidersResult<
+  TTarget extends ProviderStorageTarget = ProviderStorageTarget,
+> {
+  target: TTarget;
+  providers: ConnectProviderEntry[];
+}
+
+function uniqueProviderNames(provider: ByokProvider): string[] {
+  return [
+    ...new Set([provider.providerName, ...(provider.providerNames ?? [])]),
+  ];
+}
+
+function providerIsConnectedToRecord(
+  provider: ByokProvider,
+  record: ProviderResponse | undefined,
+  target: ProviderStorageTarget,
+): record is ProviderResponse {
+  if (!record) return false;
+  if (target !== "local" || !record.auth_type) return true;
+  return provider.isOAuth === true
+    ? record.auth_type === "oauth"
+    : record.auth_type !== "oauth";
+}
+
+function connectedRecordForProvider(
+  provider: ByokProvider,
+  connectedProviders: ReadonlyMap<string, ProviderResponse>,
+  target: ProviderStorageTarget,
+): ProviderResponse | undefined {
+  for (const providerName of uniqueProviderNames(provider)) {
+    const record = connectedProviders.get(providerName);
+    if (providerIsConnectedToRecord(provider, record, target)) {
+      return record;
+    }
+  }
+  return undefined;
+}
+
+function serializeConnectedProvider(
+  record: ProviderResponse | undefined,
+): ConnectProviderConnectionState {
+  if (!record) return { is_connected: false };
+  return {
+    is_connected: true,
+    id: record.id,
+    provider_name: record.name,
+    provider_type: record.provider_type,
+    ...(record.auth_type ? { auth_type: record.auth_type } : {}),
+    ...(record.base_url ? { base_url: record.base_url } : {}),
+    ...(record.timeout !== undefined ? { timeout: record.timeout } : {}),
+    ...(record.region ? { region: record.region } : {}),
+  };
+}
+
+function serializeFields(
+  fields: readonly ProviderField[],
+): ConnectProviderField[] {
+  return fields.map((field) => ({
+    key: field.key,
+    label: field.label,
+    ...(field.placeholder ? { placeholder: field.placeholder } : {}),
+    ...(field.secret !== undefined ? { secret: field.secret } : {}),
+  }));
+}
+
+function defaultApiKeyFields(provider: ByokProvider): ConnectProviderField[] {
+  return [
+    {
+      key: "apiKey",
+      label: "API Key",
+      secret: true,
+      required: provider.requiresApiKey !== false,
+    },
+  ];
+}
+
+function serializeAuthMethods(
+  authMethods: readonly AuthMethod[],
+): ConnectProviderAuthMethod[] {
+  return authMethods.map((method) => ({
+    id: method.id,
+    label: method.label,
+    description: method.description,
+    fields: serializeFields(method.fields),
+  }));
+}
+
+function fieldsForProvider(
+  provider: ByokProvider,
+): ConnectProviderField[] | undefined {
+  if (provider.isOAuth || provider.authMethods) return undefined;
+  if (provider.fields) return serializeFields(provider.fields);
+  return defaultApiKeyFields(provider);
+}
+
+export function buildConnectProviderEntries(
+  providers: readonly ByokProvider[],
+  connectedProviders: ReadonlyMap<string, ProviderResponse>,
+  target: ProviderStorageTarget,
+): ConnectProviderEntry[] {
+  return providers.map((provider) => {
+    const connected = connectedRecordForProvider(
+      provider,
+      connectedProviders,
+      target,
+    );
+    const fields = fieldsForProvider(provider);
+    return {
+      id: provider.id,
+      display_name: provider.displayName,
+      description: provider.description,
+      provider_type: provider.providerType,
+      provider_name: provider.providerName,
+      provider_names: uniqueProviderNames(provider),
+      ...(provider.isOAuth ? { is_oauth: true } : {}),
+      ...(provider.oauthProviderId
+        ? { oauth_provider_id: provider.oauthProviderId }
+        : {}),
+      requires_api_key: provider.requiresApiKey !== false,
+      ...(fields ? { fields } : {}),
+      ...(provider.authMethods
+        ? { auth_methods: serializeAuthMethods(provider.authMethods) }
+        : {}),
+      connected: serializeConnectedProvider(connected),
+    };
+  });
+}
+
+export async function listConnectProviders<
+  TTarget extends ProviderStorageTarget,
+>(target: TTarget): Promise<ListConnectProvidersResult<TTarget>> {
+  const [providers, connectedProviders] = await Promise.all([
+    Promise.resolve(getProviderConfigs(target)),
+    getConnectedProviders({ target }),
+  ]);
+  return {
+    target,
+    providers: buildConnectProviderEntries(
+      providers,
+      connectedProviders,
+      target,
+    ),
+  };
+}

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -933,6 +933,66 @@ export interface ListModelsCommand {
   request_id: string;
 }
 
+export type ConnectProviderStorageTarget = "local";
+
+export interface ListConnectProvidersCommand {
+  type: "list_connect_providers";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  /** Provider store to inspect. MVP supports local provider storage. */
+  target: ConnectProviderStorageTarget;
+}
+
+export interface ConnectProviderField {
+  key: string;
+  label: string;
+  placeholder?: string;
+  secret?: boolean;
+  required?: boolean;
+}
+
+export interface ConnectProviderAuthMethod {
+  id: string;
+  label: string;
+  description: string;
+  fields: ConnectProviderField[];
+}
+
+export interface ConnectProviderConnectionState {
+  is_connected: boolean;
+  id?: string;
+  provider_name?: string;
+  provider_type?: string;
+  auth_type?: "api" | "oauth";
+  base_url?: string;
+  timeout?: number | false;
+  region?: string;
+}
+
+export interface ConnectProviderEntry {
+  id: string;
+  display_name: string;
+  description: string;
+  provider_type: string;
+  provider_name: string;
+  provider_names: string[];
+  is_oauth?: boolean;
+  oauth_provider_id?: string;
+  requires_api_key: boolean;
+  fields?: ConnectProviderField[];
+  auth_methods?: ConnectProviderAuthMethod[];
+  connected: ConnectProviderConnectionState;
+}
+
+export interface ListConnectProvidersResponseMessage {
+  type: "list_connect_providers_response";
+  request_id: string;
+  success: boolean;
+  target: ConnectProviderStorageTarget;
+  providers: ConnectProviderEntry[];
+  error?: string;
+}
+
 export interface UpdateModelPayload {
   /** Preferred model identifier from models.json (e.g. "sonnet") */
   model_id?: string;
@@ -1858,6 +1918,7 @@ export type WsProtocolCommand =
   | DeleteMemoryFileCommand
   | EnableMemfsCommand
   | ListModelsCommand
+  | ListConnectProvidersCommand
   | UpdateModelCommand
   | UpdateToolsetCommand
   | CronListCommand
@@ -1911,6 +1972,7 @@ export type WsProtocolMessage =
   | StreamDeltaMessage
   | SubagentStateUpdateMessage
   | ListModelsResponseMessage
+  | ListConnectProvidersResponseMessage
   | UpdateModelResponseMessage
   | UpdateToolsetResponseMessage
   | GetExperimentsResponseMessage

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -734,6 +734,35 @@ describe("listen-client parseServerMessage", () => {
     expect(parsed?.type).toBe("list_models");
   });
 
+  test("parses list_connect_providers command", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "list_connect_providers",
+          request_id: "connect-providers-1",
+          target: "local",
+        }),
+      ),
+    );
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.type).toBe("list_connect_providers");
+  });
+
+  test("rejects list_connect_providers command for non-local target", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "list_connect_providers",
+          request_id: "connect-providers-2",
+          target: "api",
+        }),
+      ),
+    );
+
+    expect(parsed).toBeNull();
+  });
+
   test("parses update_model command with model_id", () => {
     const parsed = parseServerMessage(
       Buffer.from(

--- a/src/websocket/listener/commands/connect-providers.ts
+++ b/src/websocket/listener/commands/connect-providers.ts
@@ -1,0 +1,68 @@
+import type WebSocket from "ws";
+import { listConnectProviders } from "@/providers/connect-provider-service";
+import type {
+  ListConnectProvidersCommand,
+  ListConnectProvidersResponseMessage,
+} from "@/types/protocol_v2";
+import { isListConnectProvidersCommand } from "@/websocket/listener/protocol-inbound";
+import type { RunDetachedListenerTask, SafeSocketSend } from "./types";
+
+type ConnectProvidersCommandContext = {
+  socket: WebSocket;
+  safeSocketSend: SafeSocketSend;
+  runDetachedListenerTask: RunDetachedListenerTask;
+};
+
+export async function buildListConnectProvidersResponse(
+  command: ListConnectProvidersCommand,
+): Promise<ListConnectProvidersResponseMessage> {
+  const result = await listConnectProviders(command.target);
+  return {
+    type: "list_connect_providers_response",
+    request_id: command.request_id,
+    success: true,
+    target: result.target,
+    providers: result.providers,
+  };
+}
+
+export function handleConnectProvidersCommand(
+  parsed: unknown,
+  context: ConnectProvidersCommandContext,
+): boolean {
+  const { socket, safeSocketSend, runDetachedListenerTask } = context;
+
+  if (isListConnectProvidersCommand(parsed)) {
+    runDetachedListenerTask("list_connect_providers", async () => {
+      try {
+        const response = await buildListConnectProvidersResponse(parsed);
+        safeSocketSend(
+          socket,
+          response,
+          "listener_list_connect_providers_send_failed",
+          "listener_list_connect_providers",
+        );
+      } catch (error) {
+        safeSocketSend(
+          socket,
+          {
+            type: "list_connect_providers_response",
+            request_id: parsed.request_id,
+            success: false,
+            target: parsed.target,
+            providers: [],
+            error:
+              error instanceof Error
+                ? error.message
+                : "Failed to list connect providers",
+          },
+          "listener_list_connect_providers_send_failed",
+          "listener_list_connect_providers",
+        );
+      }
+    });
+    return true;
+  }
+
+  return false;
+}

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -23,6 +23,7 @@ import {
   handleChannelsProtocolCommand,
   isDetachedChannelsCommand,
 } from "./commands/channels";
+import { handleConnectProvidersCommand } from "./commands/connect-providers";
 import { handleCronProtocolCommand } from "./commands/cron";
 import { handleGitBranchCommand } from "./commands/git-branches";
 import { handleMemoryProtocolCommand } from "./commands/memory";
@@ -489,6 +490,16 @@ export function createListenerMessageHandler(
           safeSocketSend,
           runDetachedListenerTask,
           getOrCreateScopedRuntime,
+        })
+      ) {
+        return;
+      }
+
+      if (
+        handleConnectProvidersCommand(parsed, {
+          socket,
+          safeSocketSend,
+          runDetachedListenerTask,
         })
       ) {
         return;

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -45,6 +45,7 @@ import type {
   GetTreeCommand,
   GrepInFilesCommand,
   InputCommand,
+  ListConnectProvidersCommand,
   ListConversationPinsCommand,
   ListInDirectoryCommand,
   ListMemoryCommand,
@@ -667,6 +668,22 @@ export function isListModelsCommand(
     request_id?: unknown;
   };
   return c.type === "list_models" && typeof c.request_id === "string";
+}
+
+export function isListConnectProvidersCommand(
+  value: unknown,
+): value is ListConnectProvidersCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    target?: unknown;
+  };
+  return (
+    c.type === "list_connect_providers" &&
+    typeof c.request_id === "string" &&
+    c.target === "local"
+  );
 }
 
 export function isUpdateModelCommand(
@@ -1686,6 +1703,7 @@ export function parseServerMessage(
       isDeleteMemoryFileCommand(parsed) ||
       isEnableMemfsCommand(parsed) ||
       isListModelsCommand(parsed) ||
+      isListConnectProvidersCommand(parsed) ||
       isUpdateModelCommand(parsed) ||
       isUpdateToolsetCommand(parsed) ||
       isCronListCommand(parsed) ||


### PR DESCRIPTION
## Summary
- add `list_connect_providers` / `list_connect_providers_response` protocol types and parser support
- add a listener command handler for local connect provider metadata
- add a provider connect service that serializes local provider configs plus connected state without leaking secrets

## Testing
- `bun test src/providers/connect-provider-service.test.ts`
- `bun test src/providers/connect-provider-service.test.ts src/websocket/listen-client-protocol.test.ts`
- `bun run typecheck`
- `bun run check`

## Notes
- MVP supports `target: "local"` only
- response uses `getProviderConfigs("local")`, so provider extensions can flow through this endpoint once the listener loads provider-capable extensions