### PR TITLE
feat(extensions): add diagnostics report files

### DIFF
--- a/src/extensions/extension-diagnostics-file.test.ts
+++ b/src/extensions/extension-diagnostics-file.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  createExtensionDiagnosticsFile,
+  getDefaultExtensionDiagnosticsRoot,
+  getExtensionDiagnosticsLatestFilePath,
+  readExtensionDiagnosticsLatestFile,
+  writeExtensionDiagnosticsLatestFile,
+} from "@/extensions/extension-diagnostics-file";
+import type { ExtensionDiagnostic, ExtensionOwner } from "@/extensions/types";
+
+function createTempDir(): string {
+  return mkdtempSync(path.join(tmpdir(), "letta-extension-diagnostics-"));
+}
+
+function createOwner(): ExtensionOwner {
+  return {
+    generation: 1,
+    id: "global:/tmp/example.ts",
+    path: "/tmp/example.ts",
+    scope: "global",
+  };
+}
+
+function createDiagnostic(): ExtensionDiagnostic {
+  const error = new Error("activation failed");
+  error.stack = "Error: activation failed\n    at extension.ts:1:1";
+  return {
+    error,
+    owner: createOwner(),
+    phase: "activate",
+    timestamp: 100,
+  };
+}
+
+describe("extension diagnostics file", () => {
+  test("resolves diagnostics under the extensions directory", () => {
+    expect(getDefaultExtensionDiagnosticsRoot("/home/test")).toBe(
+      path.join("/home/test", ".letta", "extensions", "diagnostics"),
+    );
+    expect(
+      getExtensionDiagnosticsLatestFilePath({
+        rootDirectory: "/tmp/root",
+        sessionId: "../conv/with/slash",
+      }),
+    ).toBe(
+      path.join(
+        "/tmp/root",
+        "sessions",
+        "%2E%2E%2Fconv%2Fwith%2Fslash",
+        "latest.json",
+      ),
+    );
+  });
+
+  test("rejects empty diagnostics session ids", () => {
+    expect(() =>
+      getExtensionDiagnosticsLatestFilePath({
+        rootDirectory: "/tmp/root",
+        sessionId: "",
+      }),
+    ).toThrow("Extension diagnostics session id must not be empty");
+  });
+
+  test("creates a latest diagnostics file payload", () => {
+    expect(
+      createExtensionDiagnosticsFile([createDiagnostic()], {
+        generatedAt: 200,
+        sessionId: "conv-1",
+      }),
+    ).toMatchObject({
+      generatedAt: 200,
+      report: {
+        diagnostics: [
+          {
+            extension: createOwner(),
+            message: "activation failed",
+            phase: "activate",
+            severity: "error",
+            source: "host",
+          },
+        ],
+        errorCount: 1,
+        warningCount: 0,
+      },
+      sessionId: "conv-1",
+      text: `Extension diagnostics: 1 error, 0 warnings
+- [error] activate /tmp/example.ts
+  message: activation failed`,
+      version: 1,
+    });
+  });
+
+  test("writes and reads latest diagnostics files", () => {
+    const rootDirectory = createTempDir();
+    try {
+      const options = {
+        generatedAt: 200,
+        rootDirectory,
+        sessionId: "conv-1",
+      };
+
+      const written = writeExtensionDiagnosticsLatestFile(
+        [createDiagnostic()],
+        options,
+      );
+      const filePath = getExtensionDiagnosticsLatestFilePath(options);
+
+      expect(readFileSync(filePath, "utf-8")).toBe(
+        `${JSON.stringify(written, null, 2)}\n`,
+      );
+      expect(readExtensionDiagnosticsLatestFile(options)).toEqual(written);
+    } finally {
+      rmSync(rootDirectory, { force: true, recursive: true });
+    }
+  });
+
+  test("writes empty latest diagnostics files to avoid stale results", () => {
+    const rootDirectory = createTempDir();
+    try {
+      const options = {
+        generatedAt: 200,
+        rootDirectory,
+        sessionId: "conv-1",
+      };
+
+      const written = writeExtensionDiagnosticsLatestFile([], options);
+
+      expect(written).toEqual({
+        generatedAt: 200,
+        report: { diagnostics: [], errorCount: 0, warningCount: 0 },
+        sessionId: "conv-1",
+        text: "No extension diagnostics recorded.",
+        version: 1,
+      });
+      expect(readExtensionDiagnosticsLatestFile(options)).toEqual(written);
+    } finally {
+      rmSync(rootDirectory, { force: true, recursive: true });
+    }
+  });
+
+  test("returns null when no latest diagnostics file exists", () => {
+    const rootDirectory = createTempDir();
+    try {
+      expect(
+        readExtensionDiagnosticsLatestFile({
+          rootDirectory,
+          sessionId: "conv-1",
+        }),
+      ).toBeNull();
+    } finally {
+      rmSync(rootDirectory, { force: true, recursive: true });
+    }
+  });
+});

--- a/src/extensions/extension-diagnostics-file.test.ts
+++ b/src/extensions/extension-diagnostics-file.test.ts
@@ -42,32 +42,14 @@ describe("extension diagnostics file", () => {
     expect(
       getExtensionDiagnosticsLatestFilePath({
         rootDirectory: "/tmp/root",
-        sessionId: "../conv/with/slash",
       }),
-    ).toBe(
-      path.join(
-        "/tmp/root",
-        "sessions",
-        "%2E%2E%2Fconv%2Fwith%2Fslash",
-        "latest.json",
-      ),
-    );
-  });
-
-  test("rejects empty diagnostics session ids", () => {
-    expect(() =>
-      getExtensionDiagnosticsLatestFilePath({
-        rootDirectory: "/tmp/root",
-        sessionId: "",
-      }),
-    ).toThrow("Extension diagnostics session id must not be empty");
+    ).toBe(path.join("/tmp/root", "latest.json"));
   });
 
   test("creates a latest diagnostics file payload", () => {
     expect(
       createExtensionDiagnosticsFile([createDiagnostic()], {
         generatedAt: 200,
-        sessionId: "conv-1",
       }),
     ).toMatchObject({
       generatedAt: 200,
@@ -84,7 +66,6 @@ describe("extension diagnostics file", () => {
         errorCount: 1,
         warningCount: 0,
       },
-      sessionId: "conv-1",
       text: `Extension diagnostics: 1 error, 0 warnings
 - [error] activate /tmp/example.ts
   message: activation failed`,
@@ -97,7 +78,6 @@ describe("extension diagnostics file", () => {
       const options = {
         generatedAt: 200,
         rootDirectory,
-        sessionId: "conv-1",
       };
 
       const written = writeExtensionDiagnosticsLatestFile(
@@ -120,7 +100,6 @@ describe("extension diagnostics file", () => {
       const options = {
         generatedAt: 200,
         rootDirectory,
-        sessionId: "conv-1",
       };
 
       const written = writeExtensionDiagnosticsLatestFile([], options);
@@ -128,7 +107,6 @@ describe("extension diagnostics file", () => {
       expect(written).toEqual({
         generatedAt: 200,
         report: { diagnostics: [], errorCount: 0, warningCount: 0 },
-        sessionId: "conv-1",
         text: "No extension diagnostics recorded.",
       });
     } finally {

--- a/src/extensions/extension-diagnostics-file.test.ts
+++ b/src/extensions/extension-diagnostics-file.test.ts
@@ -6,7 +6,6 @@ import {
   createExtensionDiagnosticsFile,
   getDefaultExtensionDiagnosticsRoot,
   getExtensionDiagnosticsLatestFilePath,
-  readExtensionDiagnosticsLatestFile,
   writeExtensionDiagnosticsLatestFile,
 } from "@/extensions/extension-diagnostics-file";
 import type { ExtensionDiagnostic, ExtensionOwner } from "@/extensions/types";
@@ -89,11 +88,10 @@ describe("extension diagnostics file", () => {
       text: `Extension diagnostics: 1 error, 0 warnings
 - [error] activate /tmp/example.ts
   message: activation failed`,
-      version: 1,
     });
   });
 
-  test("writes and reads latest diagnostics files", () => {
+  test("writes latest diagnostics files", () => {
     const rootDirectory = createTempDir();
     try {
       const options = {
@@ -111,7 +109,6 @@ describe("extension diagnostics file", () => {
       expect(readFileSync(filePath, "utf-8")).toBe(
         `${JSON.stringify(written, null, 2)}\n`,
       );
-      expect(readExtensionDiagnosticsLatestFile(options)).toEqual(written);
     } finally {
       rmSync(rootDirectory, { force: true, recursive: true });
     }
@@ -133,23 +130,7 @@ describe("extension diagnostics file", () => {
         report: { diagnostics: [], errorCount: 0, warningCount: 0 },
         sessionId: "conv-1",
         text: "No extension diagnostics recorded.",
-        version: 1,
       });
-      expect(readExtensionDiagnosticsLatestFile(options)).toEqual(written);
-    } finally {
-      rmSync(rootDirectory, { force: true, recursive: true });
-    }
-  });
-
-  test("returns null when no latest diagnostics file exists", () => {
-    const rootDirectory = createTempDir();
-    try {
-      expect(
-        readExtensionDiagnosticsLatestFile({
-          rootDirectory,
-          sessionId: "conv-1",
-        }),
-      ).toBeNull();
     } finally {
       rmSync(rootDirectory, { force: true, recursive: true });
     }

--- a/src/extensions/extension-diagnostics-file.test.ts
+++ b/src/extensions/extension-diagnostics-file.test.ts
@@ -3,7 +3,6 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
-  createExtensionDiagnosticsFile,
   getDefaultExtensionDiagnosticsRoot,
   getExtensionDiagnosticsLatestFilePath,
   writeExtensionDiagnosticsLatestFile,
@@ -39,40 +38,12 @@ describe("extension diagnostics file", () => {
     expect(getDefaultExtensionDiagnosticsRoot("/home/test")).toBe(
       path.join("/home/test", ".letta", "extensions", "diagnostics"),
     );
-    expect(
-      getExtensionDiagnosticsLatestFilePath({
-        rootDirectory: "/tmp/root",
-      }),
-    ).toBe(path.join("/tmp/root", "latest.json"));
+    expect(getExtensionDiagnosticsLatestFilePath("/tmp/root")).toBe(
+      path.join("/tmp/root", "latest.json"),
+    );
   });
 
-  test("creates a latest diagnostics file payload", () => {
-    expect(
-      createExtensionDiagnosticsFile([createDiagnostic()], {
-        generatedAt: 200,
-      }),
-    ).toMatchObject({
-      generatedAt: 200,
-      report: {
-        diagnostics: [
-          {
-            extension: createOwner(),
-            message: "activation failed",
-            phase: "activate",
-            severity: "error",
-            source: "host",
-          },
-        ],
-        errorCount: 1,
-        warningCount: 0,
-      },
-      text: `Extension diagnostics: 1 error, 0 warnings
-- [error] activate /tmp/example.ts
-  message: activation failed`,
-    });
-  });
-
-  test("writes latest diagnostics files", () => {
+  test("writes latest diagnostics files and overwrites stale results", () => {
     const rootDirectory = createTempDir();
     try {
       const options = {
@@ -80,35 +51,40 @@ describe("extension diagnostics file", () => {
         rootDirectory,
       };
 
-      const written = writeExtensionDiagnosticsLatestFile(
+      const firstWritten = writeExtensionDiagnosticsLatestFile(
         [createDiagnostic()],
         options,
       );
-      const filePath = getExtensionDiagnosticsLatestFilePath(options);
+      const filePath = getExtensionDiagnosticsLatestFilePath(rootDirectory);
 
-      expect(readFileSync(filePath, "utf-8")).toBe(
-        `${JSON.stringify(written, null, 2)}\n`,
-      );
-    } finally {
-      rmSync(rootDirectory, { force: true, recursive: true });
-    }
-  });
-
-  test("writes empty latest diagnostics files to avoid stale results", () => {
-    const rootDirectory = createTempDir();
-    try {
-      const options = {
+      expect(firstWritten).toMatchObject({
         generatedAt: 200,
-        rootDirectory,
-      };
+        report: {
+          diagnostics: [
+            {
+              extension: createOwner(),
+              message: "activation failed",
+              phase: "activate",
+              severity: "error",
+            },
+          ],
+          errorCount: 1,
+          warningCount: 0,
+        },
+      });
+      expect(readFileSync(filePath, "utf-8")).toBe(
+        `${JSON.stringify(firstWritten, null, 2)}\n`,
+      );
 
-      const written = writeExtensionDiagnosticsLatestFile([], options);
+      const emptyWritten = writeExtensionDiagnosticsLatestFile([], options);
 
-      expect(written).toEqual({
+      expect(emptyWritten).toEqual({
         generatedAt: 200,
         report: { diagnostics: [], errorCount: 0, warningCount: 0 },
-        text: "No extension diagnostics recorded.",
       });
+      expect(readFileSync(filePath, "utf-8")).toBe(
+        `${JSON.stringify(emptyWritten, null, 2)}\n`,
+      );
     } finally {
       rmSync(rootDirectory, { force: true, recursive: true });
     }

--- a/src/extensions/extension-diagnostics-file.ts
+++ b/src/extensions/extension-diagnostics-file.ts
@@ -11,13 +11,11 @@ import type { ExtensionDiagnostic } from "@/extensions/types";
 
 export interface ExtensionDiagnosticsFileOptions {
   rootDirectory?: string;
-  sessionId: string;
 }
 
 export interface ExtensionDiagnosticsFile {
   generatedAt: number;
   report: ExtensionDiagnosticsReport;
-  sessionId: string;
   text: string;
 }
 
@@ -33,24 +31,12 @@ export function getDefaultExtensionDiagnosticsRoot(
   return path.join(homeDirectory, ".letta", "extensions", "diagnostics");
 }
 
-function encodeExtensionDiagnosticsPathSegment(segment: string): string {
-  if (!segment.trim()) {
-    throw new Error("Extension diagnostics session id must not be empty");
-  }
-  return encodeURIComponent(segment).replace(/\./g, "%2E");
-}
-
 export function getExtensionDiagnosticsLatestFilePath(
-  options: ExtensionDiagnosticsFileOptions,
+  options: ExtensionDiagnosticsFileOptions = {},
 ): string {
   const rootDirectory =
     options.rootDirectory ?? getDefaultExtensionDiagnosticsRoot();
-  return path.join(
-    rootDirectory,
-    "sessions",
-    encodeExtensionDiagnosticsPathSegment(options.sessionId),
-    "latest.json",
-  );
+  return path.join(rootDirectory, "latest.json");
 }
 
 export function createExtensionDiagnosticsFile(
@@ -60,7 +46,6 @@ export function createExtensionDiagnosticsFile(
   return {
     generatedAt: options.generatedAt ?? Date.now(),
     report: createExtensionDiagnosticsReport(diagnostics, options),
-    sessionId: options.sessionId,
     text: formatExtensionDiagnosticsForAgent(diagnostics, options),
   };
 }

--- a/src/extensions/extension-diagnostics-file.ts
+++ b/src/extensions/extension-diagnostics-file.ts
@@ -4,25 +4,12 @@ import path from "node:path";
 import {
   createExtensionDiagnosticsReport,
   type ExtensionDiagnosticsReport,
-  type ExtensionDiagnosticsReportOptions,
-  formatExtensionDiagnosticsForAgent,
 } from "@/extensions/extension-diagnostics";
 import type { ExtensionDiagnostic } from "@/extensions/types";
-
-export interface ExtensionDiagnosticsFileOptions {
-  rootDirectory?: string;
-}
 
 export interface ExtensionDiagnosticsFile {
   generatedAt: number;
   report: ExtensionDiagnosticsReport;
-  text: string;
-}
-
-export interface WriteExtensionDiagnosticsFileOptions
-  extends ExtensionDiagnosticsFileOptions,
-    ExtensionDiagnosticsReportOptions {
-  generatedAt?: number;
 }
 
 export function getDefaultExtensionDiagnosticsRoot(
@@ -32,30 +19,27 @@ export function getDefaultExtensionDiagnosticsRoot(
 }
 
 export function getExtensionDiagnosticsLatestFilePath(
-  options: ExtensionDiagnosticsFileOptions = {},
+  rootDirectory = getDefaultExtensionDiagnosticsRoot(),
 ): string {
-  const rootDirectory =
-    options.rootDirectory ?? getDefaultExtensionDiagnosticsRoot();
   return path.join(rootDirectory, "latest.json");
 }
 
-export function createExtensionDiagnosticsFile(
+function createExtensionDiagnosticsFile(
   diagnostics: readonly ExtensionDiagnostic[],
-  options: WriteExtensionDiagnosticsFileOptions,
+  generatedAt = Date.now(),
 ): ExtensionDiagnosticsFile {
   return {
-    generatedAt: options.generatedAt ?? Date.now(),
-    report: createExtensionDiagnosticsReport(diagnostics, options),
-    text: formatExtensionDiagnosticsForAgent(diagnostics, options),
+    generatedAt,
+    report: createExtensionDiagnosticsReport(diagnostics),
   };
 }
 
 export function writeExtensionDiagnosticsLatestFile(
   diagnostics: readonly ExtensionDiagnostic[],
-  options: WriteExtensionDiagnosticsFileOptions,
+  options: { generatedAt?: number; rootDirectory?: string } = {},
 ): ExtensionDiagnosticsFile {
-  const file = createExtensionDiagnosticsFile(diagnostics, options);
-  const filePath = getExtensionDiagnosticsLatestFilePath(options);
+  const file = createExtensionDiagnosticsFile(diagnostics, options.generatedAt);
+  const filePath = getExtensionDiagnosticsLatestFilePath(options.rootDirectory);
   mkdirSync(path.dirname(filePath), { recursive: true });
   writeFileSync(filePath, `${JSON.stringify(file, null, 2)}\n`, "utf-8");
   return file;

--- a/src/extensions/extension-diagnostics-file.ts
+++ b/src/extensions/extension-diagnostics-file.ts
@@ -1,0 +1,113 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import {
+  createExtensionDiagnosticsAgentReport,
+  type ExtensionDiagnosticsAgentReport,
+  type ExtensionDiagnosticsAgentReportOptions,
+  formatExtensionDiagnosticsForAgent,
+} from "@/extensions/extension-diagnostics";
+import type { ExtensionDiagnostic } from "@/extensions/types";
+
+export const EXTENSION_DIAGNOSTICS_FILE_VERSION = 1;
+
+export interface ExtensionDiagnosticsFileOptions {
+  rootDirectory?: string;
+  sessionId: string;
+}
+
+export interface ExtensionDiagnosticsFile {
+  generatedAt: number;
+  report: ExtensionDiagnosticsAgentReport;
+  sessionId: string;
+  text: string;
+  version: typeof EXTENSION_DIAGNOSTICS_FILE_VERSION;
+}
+
+export interface WriteExtensionDiagnosticsFileOptions
+  extends ExtensionDiagnosticsFileOptions,
+    ExtensionDiagnosticsAgentReportOptions {
+  generatedAt?: number;
+}
+
+export function getDefaultExtensionDiagnosticsRoot(
+  homeDirectory = homedir(),
+): string {
+  return path.join(homeDirectory, ".letta", "extensions", "diagnostics");
+}
+
+function encodeExtensionDiagnosticsPathSegment(segment: string): string {
+  if (!segment.trim()) {
+    throw new Error("Extension diagnostics session id must not be empty");
+  }
+  return encodeURIComponent(segment).replace(/\./g, "%2E");
+}
+
+export function getExtensionDiagnosticsLatestFilePath(
+  options: ExtensionDiagnosticsFileOptions,
+): string {
+  const rootDirectory =
+    options.rootDirectory ?? getDefaultExtensionDiagnosticsRoot();
+  return path.join(
+    rootDirectory,
+    "sessions",
+    encodeExtensionDiagnosticsPathSegment(options.sessionId),
+    "latest.json",
+  );
+}
+
+export function createExtensionDiagnosticsFile(
+  diagnostics: readonly ExtensionDiagnostic[],
+  options: WriteExtensionDiagnosticsFileOptions,
+): ExtensionDiagnosticsFile {
+  return {
+    generatedAt: options.generatedAt ?? Date.now(),
+    report: createExtensionDiagnosticsAgentReport(diagnostics, options),
+    sessionId: options.sessionId,
+    text: formatExtensionDiagnosticsForAgent(diagnostics, options),
+    version: EXTENSION_DIAGNOSTICS_FILE_VERSION,
+  };
+}
+
+export function writeExtensionDiagnosticsLatestFile(
+  diagnostics: readonly ExtensionDiagnostic[],
+  options: WriteExtensionDiagnosticsFileOptions,
+): ExtensionDiagnosticsFile {
+  const file = createExtensionDiagnosticsFile(diagnostics, options);
+  const filePath = getExtensionDiagnosticsLatestFilePath(options);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(file, null, 2)}\n`, "utf-8");
+  return file;
+}
+
+function isExtensionDiagnosticsFile(
+  value: unknown,
+): value is ExtensionDiagnosticsFile {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<ExtensionDiagnosticsFile>;
+  return (
+    candidate.version === EXTENSION_DIAGNOSTICS_FILE_VERSION &&
+    typeof candidate.generatedAt === "number" &&
+    typeof candidate.sessionId === "string" &&
+    typeof candidate.text === "string" &&
+    typeof candidate.report === "object" &&
+    candidate.report !== null &&
+    typeof candidate.report.errorCount === "number" &&
+    typeof candidate.report.warningCount === "number" &&
+    Array.isArray(candidate.report.diagnostics)
+  );
+}
+
+export function readExtensionDiagnosticsLatestFile(
+  options: ExtensionDiagnosticsFileOptions,
+): ExtensionDiagnosticsFile | null {
+  const filePath = getExtensionDiagnosticsLatestFilePath(options);
+  if (!existsSync(filePath)) return null;
+
+  const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as unknown;
+  if (!isExtensionDiagnosticsFile(parsed)) {
+    throw new Error(`Invalid extension diagnostics file at ${filePath}`);
+  }
+
+  return parsed;
+}

--- a/src/extensions/extension-diagnostics-file.ts
+++ b/src/extensions/extension-diagnostics-file.ts
@@ -1,15 +1,13 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import {
-  createExtensionDiagnosticsAgentReport,
-  type ExtensionDiagnosticsAgentReport,
-  type ExtensionDiagnosticsAgentReportOptions,
+  createExtensionDiagnosticsReport,
+  type ExtensionDiagnosticsReport,
+  type ExtensionDiagnosticsReportOptions,
   formatExtensionDiagnosticsForAgent,
 } from "@/extensions/extension-diagnostics";
 import type { ExtensionDiagnostic } from "@/extensions/types";
-
-export const EXTENSION_DIAGNOSTICS_FILE_VERSION = 1;
 
 export interface ExtensionDiagnosticsFileOptions {
   rootDirectory?: string;
@@ -18,15 +16,14 @@ export interface ExtensionDiagnosticsFileOptions {
 
 export interface ExtensionDiagnosticsFile {
   generatedAt: number;
-  report: ExtensionDiagnosticsAgentReport;
+  report: ExtensionDiagnosticsReport;
   sessionId: string;
   text: string;
-  version: typeof EXTENSION_DIAGNOSTICS_FILE_VERSION;
 }
 
 export interface WriteExtensionDiagnosticsFileOptions
   extends ExtensionDiagnosticsFileOptions,
-    ExtensionDiagnosticsAgentReportOptions {
+    ExtensionDiagnosticsReportOptions {
   generatedAt?: number;
 }
 
@@ -62,10 +59,9 @@ export function createExtensionDiagnosticsFile(
 ): ExtensionDiagnosticsFile {
   return {
     generatedAt: options.generatedAt ?? Date.now(),
-    report: createExtensionDiagnosticsAgentReport(diagnostics, options),
+    report: createExtensionDiagnosticsReport(diagnostics, options),
     sessionId: options.sessionId,
     text: formatExtensionDiagnosticsForAgent(diagnostics, options),
-    version: EXTENSION_DIAGNOSTICS_FILE_VERSION,
   };
 }
 
@@ -78,36 +74,4 @@ export function writeExtensionDiagnosticsLatestFile(
   mkdirSync(path.dirname(filePath), { recursive: true });
   writeFileSync(filePath, `${JSON.stringify(file, null, 2)}\n`, "utf-8");
   return file;
-}
-
-function isExtensionDiagnosticsFile(
-  value: unknown,
-): value is ExtensionDiagnosticsFile {
-  if (!value || typeof value !== "object") return false;
-  const candidate = value as Partial<ExtensionDiagnosticsFile>;
-  return (
-    candidate.version === EXTENSION_DIAGNOSTICS_FILE_VERSION &&
-    typeof candidate.generatedAt === "number" &&
-    typeof candidate.sessionId === "string" &&
-    typeof candidate.text === "string" &&
-    typeof candidate.report === "object" &&
-    candidate.report !== null &&
-    typeof candidate.report.errorCount === "number" &&
-    typeof candidate.report.warningCount === "number" &&
-    Array.isArray(candidate.report.diagnostics)
-  );
-}
-
-export function readExtensionDiagnosticsLatestFile(
-  options: ExtensionDiagnosticsFileOptions,
-): ExtensionDiagnosticsFile | null {
-  const filePath = getExtensionDiagnosticsLatestFilePath(options);
-  if (!existsSync(filePath)) return null;
-
-  const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as unknown;
-  if (!isExtensionDiagnosticsFile(parsed)) {
-    throw new Error(`Invalid extension diagnostics file at ${filePath}`);
-  }
-
-  return parsed;
 }

--- a/src/extensions/extension-diagnostics.test.ts
+++ b/src/extensions/extension-diagnostics.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
-  createExtensionDiagnosticsAgentReport,
+  createExtensionDiagnosticsReport,
   type ExtensionDiagnosticCollector,
   formatExtensionDiagnosticsForAgent,
   getExtensionDiagnosticSeverity,
@@ -77,7 +77,7 @@ describe("extension diagnostics", () => {
       timestamp: 200,
     };
 
-    expect(createExtensionDiagnosticsAgentReport([warning, error])).toEqual({
+    expect(createExtensionDiagnosticsReport([warning, error])).toEqual({
       diagnostics: [
         {
           capability: { id: "reload", kind: "command" },
@@ -113,10 +113,10 @@ describe("extension diagnostics", () => {
     };
 
     expect(
-      createExtensionDiagnosticsAgentReport([diagnostic]).diagnostics[0],
+      createExtensionDiagnosticsReport([diagnostic]).diagnostics[0],
     ).not.toHaveProperty("stack");
     expect(
-      createExtensionDiagnosticsAgentReport([diagnostic], {
+      createExtensionDiagnosticsReport([diagnostic], {
         includeStack: true,
       }).diagnostics[0],
     ).toMatchObject({

--- a/src/extensions/extension-diagnostics.test.ts
+++ b/src/extensions/extension-diagnostics.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
+  createExtensionDiagnosticsAgentReport,
   type ExtensionDiagnosticCollector,
+  formatExtensionDiagnosticsForAgent,
   getExtensionDiagnosticSeverity,
   getExtensionErrorDiagnostics,
   recordExtensionDiagnostic,
@@ -14,6 +16,12 @@ function createOwner(): ExtensionOwner {
     path: "/tmp/example.ts",
     scope: "global",
   };
+}
+
+function createError(message: string): Error {
+  const error = new Error(message);
+  error.stack = `Error: ${message}\n    at extension.ts:1:1`;
+  return error;
 }
 
 describe("extension diagnostics", () => {
@@ -51,5 +59,114 @@ describe("extension diagnostics", () => {
     expect(seen).toEqual([warning]);
     expect(warning.timestamp).toEqual(expect.any(Number));
     expect(error.timestamp).toEqual(expect.any(Number));
+  });
+
+  test("creates compact agent reports from diagnostics", () => {
+    const owner = createOwner();
+    const warning: ExtensionDiagnostic = {
+      capability: { id: "reload", kind: "command" },
+      error: createError("command override"),
+      owner,
+      phase: "command_override",
+      timestamp: 100,
+    };
+    const error: ExtensionDiagnostic = {
+      error: createError("activation failed"),
+      owner,
+      phase: "activate",
+      timestamp: 200,
+    };
+
+    expect(createExtensionDiagnosticsAgentReport([warning, error])).toEqual({
+      diagnostics: [
+        {
+          capability: { id: "reload", kind: "command" },
+          errorName: "Error",
+          extension: owner,
+          message: "command override",
+          phase: "command_override",
+          severity: "warning",
+          source: "host",
+          timestamp: 100,
+        },
+        {
+          errorName: "Error",
+          extension: owner,
+          message: "activation failed",
+          phase: "activate",
+          severity: "error",
+          source: "host",
+          timestamp: 200,
+        },
+      ],
+      errorCount: 1,
+      warningCount: 1,
+    });
+  });
+
+  test("includes stacks in agent reports only when requested", () => {
+    const diagnostic: ExtensionDiagnostic = {
+      error: createError("activation failed"),
+      owner: createOwner(),
+      phase: "activate",
+      timestamp: 100,
+    };
+
+    expect(
+      createExtensionDiagnosticsAgentReport([diagnostic]).diagnostics[0],
+    ).not.toHaveProperty("stack");
+    expect(
+      createExtensionDiagnosticsAgentReport([diagnostic], {
+        includeStack: true,
+      }).diagnostics[0],
+    ).toMatchObject({
+      stack: "Error: activation failed\n    at extension.ts:1:1",
+    });
+  });
+
+  test("formats diagnostics for agent context", () => {
+    const owner = createOwner();
+    const warning: ExtensionDiagnostic = {
+      capability: { id: "reload", kind: "command" },
+      error: createError("command override"),
+      owner,
+      phase: "command_override",
+      timestamp: 100,
+    };
+    const error: ExtensionDiagnostic = {
+      error: createError("activation failed\ncheck default export"),
+      owner,
+      phase: "activate",
+      timestamp: 200,
+    };
+
+    expect(formatExtensionDiagnosticsForAgent([])).toBe(
+      "No extension diagnostics recorded.",
+    );
+    expect(formatExtensionDiagnosticsForAgent([warning, error])).toBe(
+      `Extension diagnostics: 1 error, 1 warning
+- [warning] command_override command:reload /tmp/example.ts
+  message: command override
+- [error] activate /tmp/example.ts
+  message: activation failed check default export`,
+    );
+  });
+
+  test("formats stacks for agent context when requested", () => {
+    const diagnostic: ExtensionDiagnostic = {
+      error: createError("activation failed"),
+      owner: createOwner(),
+      phase: "activate",
+      timestamp: 100,
+    };
+
+    expect(
+      formatExtensionDiagnosticsForAgent([diagnostic], { includeStack: true }),
+    ).toBe(`Extension diagnostics: 1 error, 0 warnings
+- [error] activate /tmp/example.ts
+  message: activation failed
+  stack:
+    Error: activation failed
+        at extension.ts:1:1`);
   });
 });

--- a/src/extensions/extension-diagnostics.test.ts
+++ b/src/extensions/extension-diagnostics.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 import {
   createExtensionDiagnosticsReport,
   type ExtensionDiagnosticCollector,
-  formatExtensionDiagnosticsForAgent,
   getExtensionDiagnosticSeverity,
   getExtensionErrorDiagnostics,
   recordExtensionDiagnostic,
@@ -86,7 +85,7 @@ describe("extension diagnostics", () => {
           message: "command override",
           phase: "command_override",
           severity: "warning",
-          source: "host",
+          stack: "Error: command override\n    at extension.ts:1:1",
           timestamp: 100,
         },
         {
@@ -95,78 +94,12 @@ describe("extension diagnostics", () => {
           message: "activation failed",
           phase: "activate",
           severity: "error",
-          source: "host",
+          stack: "Error: activation failed\n    at extension.ts:1:1",
           timestamp: 200,
         },
       ],
       errorCount: 1,
       warningCount: 1,
     });
-  });
-
-  test("includes stacks in agent reports only when requested", () => {
-    const diagnostic: ExtensionDiagnostic = {
-      error: createError("activation failed"),
-      owner: createOwner(),
-      phase: "activate",
-      timestamp: 100,
-    };
-
-    expect(
-      createExtensionDiagnosticsReport([diagnostic]).diagnostics[0],
-    ).not.toHaveProperty("stack");
-    expect(
-      createExtensionDiagnosticsReport([diagnostic], {
-        includeStack: true,
-      }).diagnostics[0],
-    ).toMatchObject({
-      stack: "Error: activation failed\n    at extension.ts:1:1",
-    });
-  });
-
-  test("formats diagnostics for agent context", () => {
-    const owner = createOwner();
-    const warning: ExtensionDiagnostic = {
-      capability: { id: "reload", kind: "command" },
-      error: createError("command override"),
-      owner,
-      phase: "command_override",
-      timestamp: 100,
-    };
-    const error: ExtensionDiagnostic = {
-      error: createError("activation failed\ncheck default export"),
-      owner,
-      phase: "activate",
-      timestamp: 200,
-    };
-
-    expect(formatExtensionDiagnosticsForAgent([])).toBe(
-      "No extension diagnostics recorded.",
-    );
-    expect(formatExtensionDiagnosticsForAgent([warning, error])).toBe(
-      `Extension diagnostics: 1 error, 1 warning
-- [warning] command_override command:reload /tmp/example.ts
-  message: command override
-- [error] activate /tmp/example.ts
-  message: activation failed check default export`,
-    );
-  });
-
-  test("formats stacks for agent context when requested", () => {
-    const diagnostic: ExtensionDiagnostic = {
-      error: createError("activation failed"),
-      owner: createOwner(),
-      phase: "activate",
-      timestamp: 100,
-    };
-
-    expect(
-      formatExtensionDiagnosticsForAgent([diagnostic], { includeStack: true }),
-    ).toBe(`Extension diagnostics: 1 error, 0 warnings
-- [error] activate /tmp/example.ts
-  message: activation failed
-  stack:
-    Error: activation failed
-        at extension.ts:1:1`);
   });
 });

--- a/src/extensions/extension-diagnostics.ts
+++ b/src/extensions/extension-diagnostics.ts
@@ -10,7 +10,7 @@ export interface ExtensionDiagnosticCollector {
   diagnostics: ExtensionDiagnostic[];
 }
 
-export interface ExtensionDiagnosticAgentEntry {
+export interface ExtensionDiagnosticReportEntry {
   capability?: ExtensionDiagnostic["capability"];
   errorName: string;
   extension: ExtensionOwner;
@@ -22,13 +22,13 @@ export interface ExtensionDiagnosticAgentEntry {
   timestamp: number;
 }
 
-export interface ExtensionDiagnosticsAgentReport {
-  diagnostics: ExtensionDiagnosticAgentEntry[];
+export interface ExtensionDiagnosticsReport {
+  diagnostics: ExtensionDiagnosticReportEntry[];
   errorCount: number;
   warningCount: number;
 }
 
-export interface ExtensionDiagnosticsAgentReportOptions {
+export interface ExtensionDiagnosticsReportOptions {
   includeStack?: boolean;
 }
 
@@ -61,10 +61,10 @@ export function getExtensionErrorDiagnostics(
   return diagnostics.filter(isExtensionDiagnosticError);
 }
 
-export function createExtensionDiagnosticsAgentReport(
+export function createExtensionDiagnosticsReport(
   diagnostics: readonly ExtensionDiagnostic[],
-  options: ExtensionDiagnosticsAgentReportOptions = {},
-): ExtensionDiagnosticsAgentReport {
+  options: ExtensionDiagnosticsReportOptions = {},
+): ExtensionDiagnosticsReport {
   let errorCount = 0;
   let warningCount = 0;
 
@@ -90,7 +90,7 @@ export function createExtensionDiagnosticsAgentReport(
         ? { stack: diagnostic.error.stack }
         : {}),
       timestamp: diagnostic.timestamp,
-    } satisfies ExtensionDiagnosticAgentEntry;
+    } satisfies ExtensionDiagnosticReportEntry;
   });
 
   return {
@@ -110,9 +110,9 @@ function formatDiagnosticMessage(message: string): string {
 
 export function formatExtensionDiagnosticsForAgent(
   diagnostics: readonly ExtensionDiagnostic[],
-  options: ExtensionDiagnosticsAgentReportOptions = {},
+  options: ExtensionDiagnosticsReportOptions = {},
 ): string {
-  const report = createExtensionDiagnosticsAgentReport(diagnostics, options);
+  const report = createExtensionDiagnosticsReport(diagnostics, options);
   if (report.diagnostics.length === 0) {
     return "No extension diagnostics recorded.";
   }

--- a/src/extensions/extension-diagnostics.ts
+++ b/src/extensions/extension-diagnostics.ts
@@ -10,6 +10,28 @@ export interface ExtensionDiagnosticCollector {
   diagnostics: ExtensionDiagnostic[];
 }
 
+export interface ExtensionDiagnosticAgentEntry {
+  capability?: ExtensionDiagnostic["capability"];
+  errorName: string;
+  extension: ExtensionOwner;
+  message: string;
+  phase: ExtensionDiagnosticPhase;
+  severity: ExtensionDiagnosticSeverity;
+  source: "host";
+  stack?: string;
+  timestamp: number;
+}
+
+export interface ExtensionDiagnosticsAgentReport {
+  diagnostics: ExtensionDiagnosticAgentEntry[];
+  errorCount: number;
+  warningCount: number;
+}
+
+export interface ExtensionDiagnosticsAgentReportOptions {
+  includeStack?: boolean;
+}
+
 export function getExtensionDiagnosticSeverity(
   phase: ExtensionDiagnosticPhase,
 ): ExtensionDiagnosticSeverity {
@@ -37,6 +59,85 @@ export function getExtensionErrorDiagnostics(
   diagnostics: readonly ExtensionDiagnostic[],
 ): ExtensionDiagnostic[] {
   return diagnostics.filter(isExtensionDiagnosticError);
+}
+
+export function createExtensionDiagnosticsAgentReport(
+  diagnostics: readonly ExtensionDiagnostic[],
+  options: ExtensionDiagnosticsAgentReportOptions = {},
+): ExtensionDiagnosticsAgentReport {
+  let errorCount = 0;
+  let warningCount = 0;
+
+  const entries = diagnostics.map((diagnostic) => {
+    const severity = getExtensionDiagnosticSeverity(diagnostic.phase);
+    if (severity === "error") {
+      errorCount += 1;
+    } else {
+      warningCount += 1;
+    }
+
+    return {
+      ...(diagnostic.capability
+        ? { capability: { ...diagnostic.capability } }
+        : {}),
+      errorName: diagnostic.error.name,
+      extension: { ...diagnostic.owner },
+      message: diagnostic.error.message,
+      phase: diagnostic.phase,
+      severity,
+      source: "host",
+      ...(options.includeStack && diagnostic.error.stack
+        ? { stack: diagnostic.error.stack }
+        : {}),
+      timestamp: diagnostic.timestamp,
+    } satisfies ExtensionDiagnosticAgentEntry;
+  });
+
+  return {
+    diagnostics: entries,
+    errorCount,
+    warningCount,
+  };
+}
+
+function formatDiagnosticCount(count: number, label: string): string {
+  return `${count} ${label}${count === 1 ? "" : "s"}`;
+}
+
+function formatDiagnosticMessage(message: string): string {
+  return message.replace(/\s+/g, " ").trim();
+}
+
+export function formatExtensionDiagnosticsForAgent(
+  diagnostics: readonly ExtensionDiagnostic[],
+  options: ExtensionDiagnosticsAgentReportOptions = {},
+): string {
+  const report = createExtensionDiagnosticsAgentReport(diagnostics, options);
+  if (report.diagnostics.length === 0) {
+    return "No extension diagnostics recorded.";
+  }
+
+  const lines = [
+    `Extension diagnostics: ${formatDiagnosticCount(report.errorCount, "error")}, ${formatDiagnosticCount(report.warningCount, "warning")}`,
+  ];
+
+  for (const diagnostic of report.diagnostics) {
+    const capability = diagnostic.capability
+      ? ` ${diagnostic.capability.kind}:${diagnostic.capability.id}`
+      : "";
+    lines.push(
+      `- [${diagnostic.severity}] ${diagnostic.phase}${capability} ${diagnostic.extension.path}`,
+      `  message: ${formatDiagnosticMessage(diagnostic.message)}`,
+    );
+    if (diagnostic.stack) {
+      lines.push(
+        "  stack:",
+        ...diagnostic.stack.split("\n").map((line) => `    ${line}`),
+      );
+    }
+  }
+
+  return lines.join("\n");
 }
 
 export function appendExtensionDiagnostic(

--- a/src/extensions/extension-diagnostics.ts
+++ b/src/extensions/extension-diagnostics.ts
@@ -17,7 +17,6 @@ export interface ExtensionDiagnosticReportEntry {
   message: string;
   phase: ExtensionDiagnosticPhase;
   severity: ExtensionDiagnosticSeverity;
-  source: "host";
   stack?: string;
   timestamp: number;
 }
@@ -26,10 +25,6 @@ export interface ExtensionDiagnosticsReport {
   diagnostics: ExtensionDiagnosticReportEntry[];
   errorCount: number;
   warningCount: number;
-}
-
-export interface ExtensionDiagnosticsReportOptions {
-  includeStack?: boolean;
 }
 
 export function getExtensionDiagnosticSeverity(
@@ -63,7 +58,6 @@ export function getExtensionErrorDiagnostics(
 
 export function createExtensionDiagnosticsReport(
   diagnostics: readonly ExtensionDiagnostic[],
-  options: ExtensionDiagnosticsReportOptions = {},
 ): ExtensionDiagnosticsReport {
   let errorCount = 0;
   let warningCount = 0;
@@ -85,10 +79,7 @@ export function createExtensionDiagnosticsReport(
       message: diagnostic.error.message,
       phase: diagnostic.phase,
       severity,
-      source: "host",
-      ...(options.includeStack && diagnostic.error.stack
-        ? { stack: diagnostic.error.stack }
-        : {}),
+      ...(diagnostic.error.stack ? { stack: diagnostic.error.stack } : {}),
       timestamp: diagnostic.timestamp,
     } satisfies ExtensionDiagnosticReportEntry;
   });
@@ -98,46 +89,6 @@ export function createExtensionDiagnosticsReport(
     errorCount,
     warningCount,
   };
-}
-
-function formatDiagnosticCount(count: number, label: string): string {
-  return `${count} ${label}${count === 1 ? "" : "s"}`;
-}
-
-function formatDiagnosticMessage(message: string): string {
-  return message.replace(/\s+/g, " ").trim();
-}
-
-export function formatExtensionDiagnosticsForAgent(
-  diagnostics: readonly ExtensionDiagnostic[],
-  options: ExtensionDiagnosticsReportOptions = {},
-): string {
-  const report = createExtensionDiagnosticsReport(diagnostics, options);
-  if (report.diagnostics.length === 0) {
-    return "No extension diagnostics recorded.";
-  }
-
-  const lines = [
-    `Extension diagnostics: ${formatDiagnosticCount(report.errorCount, "error")}, ${formatDiagnosticCount(report.warningCount, "warning")}`,
-  ];
-
-  for (const diagnostic of report.diagnostics) {
-    const capability = diagnostic.capability
-      ? ` ${diagnostic.capability.kind}:${diagnostic.capability.id}`
-      : "";
-    lines.push(
-      `- [${diagnostic.severity}] ${diagnostic.phase}${capability} ${diagnostic.extension.path}`,
-      `  message: ${formatDiagnosticMessage(diagnostic.message)}`,
-    );
-    if (diagnostic.stack) {
-      lines.push(
-        "  stack:",
-        ...diagnostic.stack.split("\n").map((line) => `    ${line}`),
-      );
-    }
-  }
-
-  return lines.join("\n");
 }
 
 export function appendExtensionDiagnostic(


### PR DESCRIPTION
## Summary
- add structured extension diagnostics report serialization
- add latest-file write helpers under `~/.letta/extensions/diagnostics/latest.json`
- include empty latest-file writes so future reload wiring can clear stale diagnostics

## Notes
- no runtime writes yet
- no `/reload` wiring yet
- no agent notification/system reminder behavior yet
- no read/validation/versioning layer; this latest file is a generated agent-readable artifact, not a backwards-compatible storage API
- intentionally minimal: future fields/formatting can be added when there is a real callsite

## Tests
- `bun test src/extensions/extension-diagnostics.test.ts src/extensions/extension-diagnostics-file.test.ts`
- `bun run typecheck`
- `bun run check`
- `git diff --check`