### PR TITLE
feat: add local connect provider write commands

### DIFF
--- a/src/providers/connect-provider-service.test.ts
+++ b/src/providers/connect-provider-service.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type { ProviderResponse } from "@/backend/api/providers";
 import type { ByokProvider } from "@/providers/byok-providers";
-import { buildConnectProviderEntries } from "@/providers/connect-provider-service";
+import {
+  buildConnectProviderEntries,
+  resolveProviderConnectionFields,
+} from "@/providers/connect-provider-service";
 
 describe("connect provider service", () => {
   test("serializes simple providers with safe default API key fields", () => {
@@ -131,5 +134,117 @@ describe("connect provider service", () => {
         ],
       },
     ]);
+  });
+
+  test("resolves simple API key fields for saving", () => {
+    const provider: ByokProvider = {
+      id: "anthropic",
+      displayName: "Claude API",
+      description: "Connect Claude API",
+      providerType: "anthropic",
+      providerName: "lc-anthropic",
+    };
+
+    expect(
+      resolveProviderConnectionFields(provider, {
+        fields: { apiKey: " sk-test ", baseUrl: " https://example.test " },
+      }),
+    ).toEqual({
+      apiKey: "sk-test",
+      options: { baseURL: "https://example.test" },
+    });
+  });
+
+  test("uses provider defaults for API-key-optional providers", () => {
+    const provider: ByokProvider = {
+      id: "ollama",
+      displayName: "Ollama",
+      description: "Connect Ollama",
+      providerType: "ollama",
+      providerName: "ollama",
+      requiresApiKey: false,
+      defaultApiKey: "not-needed",
+    };
+
+    expect(resolveProviderConnectionFields(provider, { fields: {} })).toEqual({
+      apiKey: "not-needed",
+      options: {},
+    });
+  });
+
+  test("resolves selected auth method fields", () => {
+    const provider: ByokProvider = {
+      id: "bedrock",
+      displayName: "AWS Bedrock",
+      description: "Connect Bedrock",
+      providerType: "bedrock",
+      providerName: "lc-bedrock",
+      authMethods: [
+        {
+          id: "profile",
+          label: "AWS Profile",
+          description: "Use an AWS profile",
+          fields: [
+            { key: "profile", label: "Profile Name" },
+            { key: "region", label: "AWS Region" },
+          ],
+        },
+      ],
+    };
+
+    expect(
+      resolveProviderConnectionFields(provider, {
+        authMethodId: "profile",
+        fields: { profile: " default ", region: " us-east-1 " },
+      }),
+    ).toEqual({
+      apiKey: "",
+      profile: "default",
+      region: "us-east-1",
+      options: {},
+    });
+  });
+
+  test("rejects unsupported OAuth save path", () => {
+    const provider: ByokProvider = {
+      id: "codex",
+      displayName: "ChatGPT / Codex plan",
+      description: "Connect ChatGPT",
+      providerType: "chatgpt_oauth",
+      providerName: "chatgpt-plus-pro",
+      isOAuth: true,
+    };
+
+    expect(() =>
+      resolveProviderConnectionFields(provider, { fields: {} }),
+    ).toThrow("uses OAuth");
+  });
+
+  test("requires all selected auth method fields", () => {
+    const provider: ByokProvider = {
+      id: "bedrock",
+      displayName: "AWS Bedrock",
+      description: "Connect Bedrock",
+      providerType: "bedrock",
+      providerName: "lc-bedrock",
+      authMethods: [
+        {
+          id: "profile",
+          label: "AWS Profile",
+          description: "Use an AWS profile",
+          fields: [
+            { key: "profile", label: "Profile Name" },
+            { key: "region", label: "AWS Region" },
+          ],
+        },
+      ],
+    };
+
+    expect(() =>
+      resolveProviderConnectionFields(provider, {
+        authMethodId: "profile",
+        fields: { profile: "default" },
+      }),
+    ).toThrow("Missing AWS Region");
   });
 });

--- a/src/providers/connect-provider-service.ts
+++ b/src/providers/connect-provider-service.ts
@@ -3,10 +3,15 @@ import type { LocalProviderTimeout } from "@/backend/local/local-provider-timeou
 import {
   type AuthMethod,
   type ByokProvider,
+  checkProviderApiKey,
+  createOrUpdateProvider,
+  defaultProviderApiKey,
   getConnectedProviders,
   getProviderConfigs,
+  type ProviderConnectionOptions,
   type ProviderField,
   type ProviderStorageTarget,
+  removeProviderByName,
 } from "@/providers/byok-providers";
 
 export interface ConnectProviderField {
@@ -55,6 +60,30 @@ export interface ListConnectProvidersResult<
 > {
   target: TTarget;
   providers: ConnectProviderEntry[];
+}
+
+export interface ConnectProviderInput<
+  TTarget extends ProviderStorageTarget = ProviderStorageTarget,
+> {
+  target: TTarget;
+  providerId: string;
+  authMethodId?: string;
+  fields: Record<string, string>;
+}
+
+export interface DisconnectProviderInput<
+  TTarget extends ProviderStorageTarget = ProviderStorageTarget,
+> {
+  target: TTarget;
+  providerId: string;
+}
+
+export interface ResolvedProviderConnectionFields {
+  apiKey: string;
+  accessKey?: string;
+  region?: string;
+  profile?: string;
+  options: ProviderConnectionOptions;
 }
 
 function uniqueProviderNames(provider: ByokProvider): string[] {
@@ -146,6 +175,97 @@ function fieldsForProvider(
   return defaultApiKeyFields(provider);
 }
 
+function requiredFieldsForProvider(
+  provider: ByokProvider,
+  authMethodId: string | undefined,
+): readonly ProviderField[] {
+  if (provider.isOAuth) {
+    throw new Error(
+      `${provider.displayName} uses OAuth. Use the OAuth connection flow instead.`,
+    );
+  }
+
+  if (provider.authMethods) {
+    if (!authMethodId) {
+      throw new Error(`Select an auth method for ${provider.displayName}.`);
+    }
+    const authMethod = provider.authMethods.find(
+      (method) => method.id === authMethodId,
+    );
+    if (!authMethod) {
+      throw new Error(
+        `Unknown auth method "${authMethodId}" for ${provider.displayName}.`,
+      );
+    }
+    return authMethod.fields;
+  }
+
+  if (authMethodId) {
+    throw new Error(`${provider.displayName} does not use auth methods.`);
+  }
+
+  if (provider.fields) return provider.fields;
+  if (provider.requiresApiKey === false) return [];
+  return [{ key: "apiKey", label: "API Key", secret: true }];
+}
+
+function fieldValue(
+  fields: Record<string, string>,
+  key: string,
+): string | undefined {
+  const value = fields[key]?.trim();
+  return value && value.length > 0 ? value : undefined;
+}
+
+export function resolveProviderConnectionFields(
+  provider: ByokProvider,
+  input: { authMethodId?: string; fields: Record<string, string> },
+): ResolvedProviderConnectionFields {
+  const requiredFields = requiredFieldsForProvider(
+    provider,
+    input.authMethodId,
+  );
+  const missingField = requiredFields.find(
+    (field) => !fieldValue(input.fields, field.key),
+  );
+  if (missingField) {
+    throw new Error(`Missing ${missingField.label}.`);
+  }
+
+  const apiKey =
+    fieldValue(input.fields, "apiKey") ?? defaultProviderApiKey(provider);
+  const apiKeyRequired = requiredFields.some((field) => field.key === "apiKey");
+  if (!apiKey && apiKeyRequired) {
+    throw new Error(`Missing ${provider.displayName} API key.`);
+  }
+
+  const accessKey = fieldValue(input.fields, "accessKey");
+  const region = fieldValue(input.fields, "region");
+  const profile = fieldValue(input.fields, "profile");
+  const baseURL = fieldValue(input.fields, "baseUrl");
+
+  return {
+    apiKey: apiKey ?? "",
+    ...(accessKey ? { accessKey } : {}),
+    ...(region ? { region } : {}),
+    ...(profile ? { profile } : {}),
+    options: {
+      ...(baseURL ? { baseURL } : {}),
+    },
+  };
+}
+
+function resolveProvider(
+  providers: readonly ByokProvider[],
+  providerId: string,
+): ByokProvider {
+  const provider = providers.find((candidate) => candidate.id === providerId);
+  if (!provider) {
+    throw new Error(`Unknown provider: ${providerId}`);
+  }
+  return provider;
+}
+
 export function buildConnectProviderEntries(
   providers: readonly ByokProvider[],
   connectedProviders: ReadonlyMap<string, ProviderResponse>,
@@ -194,4 +314,58 @@ export async function listConnectProviders<
       target,
     ),
   };
+}
+
+export async function connectProvider<TTarget extends ProviderStorageTarget>(
+  input: ConnectProviderInput<TTarget>,
+): Promise<ListConnectProvidersResult<TTarget>> {
+  const provider = resolveProvider(
+    getProviderConfigs(input.target),
+    input.providerId,
+  );
+  const resolved = resolveProviderConnectionFields(provider, {
+    authMethodId: input.authMethodId,
+    fields: input.fields,
+  });
+
+  await checkProviderApiKey(
+    provider.providerType,
+    resolved.apiKey,
+    resolved.accessKey,
+    resolved.region,
+    resolved.profile,
+    { target: input.target },
+  );
+  await createOrUpdateProvider(
+    provider.providerType,
+    provider.providerName,
+    resolved.apiKey,
+    resolved.accessKey,
+    resolved.region,
+    resolved.profile,
+    resolved.options,
+    { target: input.target },
+  );
+
+  return listConnectProviders(input.target);
+}
+
+export async function disconnectProvider<TTarget extends ProviderStorageTarget>(
+  input: DisconnectProviderInput<TTarget>,
+): Promise<ListConnectProvidersResult<TTarget>> {
+  const providers = getProviderConfigs(input.target);
+  const provider = resolveProvider(providers, input.providerId);
+  const connectedProviders = await getConnectedProviders({
+    target: input.target,
+  });
+  const connected = connectedRecordForProvider(
+    provider,
+    connectedProviders,
+    input.target,
+  );
+  if (connected) {
+    await removeProviderByName(connected.name, { target: input.target });
+  }
+
+  return listConnectProviders(input.target);
 }

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -943,6 +943,30 @@ export interface ListConnectProvidersCommand {
   target: ConnectProviderStorageTarget;
 }
 
+export interface ConnectProviderCommand {
+  type: "connect_provider";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  /** Provider store to write. MVP supports local provider storage. */
+  target: ConnectProviderStorageTarget;
+  /** Provider id from list_connect_providers. */
+  provider_id: string;
+  /** Optional auth method id for providers with multiple auth methods. */
+  auth_method_id?: string;
+  /** User-provided connection fields keyed by field id. */
+  fields: Record<string, string>;
+}
+
+export interface DisconnectProviderCommand {
+  type: "disconnect_provider";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  /** Provider store to write. MVP supports local provider storage. */
+  target: ConnectProviderStorageTarget;
+  /** Provider id from list_connect_providers. */
+  provider_id: string;
+}
+
 export interface ConnectProviderField {
   key: string;
   label: string;
@@ -990,6 +1014,26 @@ export interface ListConnectProvidersResponseMessage {
   success: boolean;
   target: ConnectProviderStorageTarget;
   providers: ConnectProviderEntry[];
+  error?: string;
+}
+
+export interface ConnectProviderResponseMessage {
+  type: "connect_provider_response";
+  request_id: string;
+  success: boolean;
+  target: ConnectProviderStorageTarget;
+  providers: ConnectProviderEntry[];
+  models_may_have_changed: boolean;
+  error?: string;
+}
+
+export interface DisconnectProviderResponseMessage {
+  type: "disconnect_provider_response";
+  request_id: string;
+  success: boolean;
+  target: ConnectProviderStorageTarget;
+  providers: ConnectProviderEntry[];
+  models_may_have_changed: boolean;
   error?: string;
 }
 
@@ -1919,6 +1963,8 @@ export type WsProtocolCommand =
   | EnableMemfsCommand
   | ListModelsCommand
   | ListConnectProvidersCommand
+  | ConnectProviderCommand
+  | DisconnectProviderCommand
   | UpdateModelCommand
   | UpdateToolsetCommand
   | CronListCommand
@@ -1973,6 +2019,8 @@ export type WsProtocolMessage =
   | SubagentStateUpdateMessage
   | ListModelsResponseMessage
   | ListConnectProvidersResponseMessage
+  | ConnectProviderResponseMessage
+  | DisconnectProviderResponseMessage
   | UpdateModelResponseMessage
   | UpdateToolsetResponseMessage
   | GetExperimentsResponseMessage

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -763,6 +763,73 @@ describe("listen-client parseServerMessage", () => {
     expect(parsed).toBeNull();
   });
 
+  test("parses connect_provider command", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "connect_provider",
+          request_id: "connect-provider-1",
+          target: "local",
+          provider_id: "anthropic",
+          fields: { apiKey: "sk-test" },
+        }),
+      ),
+    );
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.type).toBe("connect_provider");
+  });
+
+  test("parses connect_provider command with auth method", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "connect_provider",
+          request_id: "connect-provider-2",
+          target: "local",
+          provider_id: "amazon-bedrock",
+          auth_method_id: "profile",
+          fields: { profile: "default", region: "us-east-1" },
+        }),
+      ),
+    );
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.type).toBe("connect_provider");
+  });
+
+  test("rejects connect_provider command with non-string fields", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "connect_provider",
+          request_id: "connect-provider-3",
+          target: "local",
+          provider_id: "anthropic",
+          fields: { apiKey: 123 },
+        }),
+      ),
+    );
+
+    expect(parsed).toBeNull();
+  });
+
+  test("parses disconnect_provider command", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "disconnect_provider",
+          request_id: "disconnect-provider-1",
+          target: "local",
+          provider_id: "anthropic",
+        }),
+      ),
+    );
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.type).toBe("disconnect_provider");
+  });
+
   test("parses update_model command with model_id", () => {
     const parsed = parseServerMessage(
       Buffer.from(

--- a/src/websocket/listener/commands/connect-providers.ts
+++ b/src/websocket/listener/commands/connect-providers.ts
@@ -1,10 +1,23 @@
 import type WebSocket from "ws";
-import { listConnectProviders } from "@/providers/connect-provider-service";
+import { clearAvailableModelsCache } from "@/agent/available-models";
+import {
+  connectProvider,
+  disconnectProvider,
+  listConnectProviders,
+} from "@/providers/connect-provider-service";
 import type {
+  ConnectProviderCommand,
+  ConnectProviderResponseMessage,
+  DisconnectProviderCommand,
+  DisconnectProviderResponseMessage,
   ListConnectProvidersCommand,
   ListConnectProvidersResponseMessage,
 } from "@/types/protocol_v2";
-import { isListConnectProvidersCommand } from "@/websocket/listener/protocol-inbound";
+import {
+  isConnectProviderCommand,
+  isDisconnectProviderCommand,
+  isListConnectProvidersCommand,
+} from "@/websocket/listener/protocol-inbound";
 import type { RunDetachedListenerTask, SafeSocketSend } from "./types";
 
 type ConnectProvidersCommandContext = {
@@ -23,6 +36,44 @@ export async function buildListConnectProvidersResponse(
     success: true,
     target: result.target,
     providers: result.providers,
+  };
+}
+
+export async function buildConnectProviderResponse(
+  command: ConnectProviderCommand,
+): Promise<ConnectProviderResponseMessage> {
+  const result = await connectProvider({
+    target: command.target,
+    providerId: command.provider_id,
+    ...(command.auth_method_id ? { authMethodId: command.auth_method_id } : {}),
+    fields: command.fields,
+  });
+  clearAvailableModelsCache();
+  return {
+    type: "connect_provider_response",
+    request_id: command.request_id,
+    success: true,
+    target: result.target,
+    providers: result.providers,
+    models_may_have_changed: true,
+  };
+}
+
+export async function buildDisconnectProviderResponse(
+  command: DisconnectProviderCommand,
+): Promise<DisconnectProviderResponseMessage> {
+  const result = await disconnectProvider({
+    target: command.target,
+    providerId: command.provider_id,
+  });
+  clearAvailableModelsCache();
+  return {
+    type: "disconnect_provider_response",
+    request_id: command.request_id,
+    success: true,
+    target: result.target,
+    providers: result.providers,
+    models_may_have_changed: true,
   };
 }
 
@@ -58,6 +109,72 @@ export function handleConnectProvidersCommand(
           },
           "listener_list_connect_providers_send_failed",
           "listener_list_connect_providers",
+        );
+      }
+    });
+    return true;
+  }
+
+  if (isConnectProviderCommand(parsed)) {
+    runDetachedListenerTask("connect_provider", async () => {
+      try {
+        const response = await buildConnectProviderResponse(parsed);
+        safeSocketSend(
+          socket,
+          response,
+          "listener_connect_provider_send_failed",
+          "listener_connect_provider",
+        );
+      } catch (error) {
+        safeSocketSend(
+          socket,
+          {
+            type: "connect_provider_response",
+            request_id: parsed.request_id,
+            success: false,
+            target: parsed.target,
+            providers: [],
+            models_may_have_changed: false,
+            error:
+              error instanceof Error
+                ? error.message
+                : "Failed to connect provider",
+          },
+          "listener_connect_provider_send_failed",
+          "listener_connect_provider",
+        );
+      }
+    });
+    return true;
+  }
+
+  if (isDisconnectProviderCommand(parsed)) {
+    runDetachedListenerTask("disconnect_provider", async () => {
+      try {
+        const response = await buildDisconnectProviderResponse(parsed);
+        safeSocketSend(
+          socket,
+          response,
+          "listener_disconnect_provider_send_failed",
+          "listener_disconnect_provider",
+        );
+      } catch (error) {
+        safeSocketSend(
+          socket,
+          {
+            type: "disconnect_provider_response",
+            request_id: parsed.request_id,
+            success: false,
+            target: parsed.target,
+            providers: [],
+            models_may_have_changed: false,
+            error:
+              error instanceof Error
+                ? error.message
+                : "Failed to disconnect provider",
+          },
+          "listener_disconnect_provider_send_failed",
+          "listener_disconnect_provider",
         );
       }
     });

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -26,6 +26,7 @@ import type {
   ChannelTargetBindCommand,
   ChannelTargetsListCommand,
   CheckoutBranchCommand,
+  ConnectProviderCommand,
   CreateAgentCommand,
   CronAddCommand,
   CronDeleteAllCommand,
@@ -35,6 +36,7 @@ import type {
   CronRunsCommand,
   CronTriggerCommand,
   DeleteMemoryFileCommand,
+  DisconnectProviderCommand,
   EditFileCommand,
   EnableMemfsCommand,
   ExecuteCommandCommand,
@@ -101,6 +103,15 @@ export type ServerLifecycleMessage = {
 function isStringArray(value: unknown): value is string[] {
   return (
     Array.isArray(value) && value.every((item) => typeof item === "string")
+  );
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.values(value).every((item) => typeof item === "string")
   );
 }
 
@@ -683,6 +694,46 @@ export function isListConnectProvidersCommand(
     c.type === "list_connect_providers" &&
     typeof c.request_id === "string" &&
     c.target === "local"
+  );
+}
+
+export function isConnectProviderCommand(
+  value: unknown,
+): value is ConnectProviderCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    target?: unknown;
+    provider_id?: unknown;
+    auth_method_id?: unknown;
+    fields?: unknown;
+  };
+  return (
+    c.type === "connect_provider" &&
+    typeof c.request_id === "string" &&
+    c.target === "local" &&
+    typeof c.provider_id === "string" &&
+    (c.auth_method_id === undefined || typeof c.auth_method_id === "string") &&
+    isStringRecord(c.fields)
+  );
+}
+
+export function isDisconnectProviderCommand(
+  value: unknown,
+): value is DisconnectProviderCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    target?: unknown;
+    provider_id?: unknown;
+  };
+  return (
+    c.type === "disconnect_provider" &&
+    typeof c.request_id === "string" &&
+    c.target === "local" &&
+    typeof c.provider_id === "string"
   );
 }
 
@@ -1704,6 +1755,8 @@ export function parseServerMessage(
       isEnableMemfsCommand(parsed) ||
       isListModelsCommand(parsed) ||
       isListConnectProvidersCommand(parsed) ||
+      isConnectProviderCommand(parsed) ||
+      isDisconnectProviderCommand(parsed) ||
       isUpdateModelCommand(parsed) ||
       isUpdateToolsetCommand(parsed) ||
       isCronListCommand(parsed) ||


### PR DESCRIPTION
## Summary
- add `connect_provider` and `disconnect_provider` listener protocol commands for local provider storage
- resolve writes through the shared connect provider catalog using `provider_id`
- return refreshed provider snapshots after writes and clear available-model cache on success
- keep OAuth providers out of this write path for now with a clear error

## Testing
- `bun test src/providers/connect-provider-service.test.ts src/websocket/listen-client-protocol.test.ts`
- `bun run check`

## Notes
- built on top of merged #2717
- MVP supports `target: "local"` only