### PR TITLE
fix(local-backend): align empty provider responses with pi loop

### DIFF
--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -95,29 +95,6 @@ class PiProviderError extends Error {
   }
 }
 
-class EmptyPiResponseError extends Error {
-  readonly isRetryable = true;
-
-  constructor() {
-    super("Received empty content in local provider response.");
-    this.name = "EmptyPiResponseError";
-  }
-}
-
-function hasAssistantOutputContent(message: AssistantMessage): boolean {
-  return message.content.some((block) => {
-    if (block.type === "toolCall") return true;
-    if (block.type === "text") return block.text.trim().length > 0;
-    return false;
-  });
-}
-
-function assertAssistantHasOutputContent(message: AssistantMessage): void {
-  if (!hasAssistantOutputContent(message)) {
-    throw new EmptyPiResponseError();
-  }
-}
-
 async function sleepWithAbort(
   delayMs: number,
   abortSignal: AbortSignal | undefined,
@@ -567,7 +544,6 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
           }
         }
         if (part.type === "done") {
-          assertAssistantHasOutputContent(part.message);
           finalMessage = part.message;
           yield providerLocalMessage(
             toLocalAssistantMessage(part.message, input),
@@ -578,7 +554,6 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
 
       if (streamError) throw streamError;
       finalMessage ??= await result.result();
-      assertAssistantHasOutputContent(finalMessage);
       if (
         finalMessage.stopReason === "error" ||
         finalMessage.stopReason === "aborted"

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -1164,15 +1164,12 @@ describe("local backend pi transcript", () => {
     );
 
     expect(
-      continuationChunks.some((chunk) => {
-        const event = chunk as { message_type?: string; event_type?: string };
-        return (
-          event.message_type === "event_message" && event.event_type === "retry"
-        );
-      }),
-    ).toBe(true);
+      continuationChunks.map(
+        (chunk) => (chunk as { message_type?: string }).message_type,
+      ),
+    ).toEqual(["usage_statistics", "stop_reason"]);
 
-    expect(contexts).toHaveLength(3);
+    expect(contexts).toHaveLength(2);
     const secondContextMessages = contexts[1]?.messages ?? [];
     expect(secondContextMessages.at(-1)).toMatchObject({
       role: "toolResult",
@@ -1198,9 +1195,7 @@ describe("local backend pi transcript", () => {
       "assistant",
     ]);
     const finalAssistant = messages.at(-1) as { content?: unknown[] };
-    expect(finalAssistant.content).toEqual([
-      { type: "text", text: "Tool result received." },
-    ]);
+    expect(finalAssistant.content).toEqual([]);
 
     const reloadedBackend = new LocalBackend({
       storageDir,
@@ -1219,7 +1214,6 @@ describe("local backend pi transcript", () => {
       "reasoning_message",
       "approval_request_message",
       "tool_return_message",
-      "assistant_message",
     ]);
   });
 

--- a/src/backend/pi-stream-adapter.test.ts
+++ b/src/backend/pi-stream-adapter.test.ts
@@ -544,19 +544,11 @@ describe("PiStreamAdapter", () => {
     expect(events.some((event) => event.type === "local-message")).toBe(true);
   });
 
-  test("retries empty local provider responses before persisting model output", async () => {
+  test("accepts empty successful local provider responses like pi agent loop", async () => {
     let calls = 0;
     const stream: PiStreamFunction = () => {
       calls += 1;
-      if (calls === 1) {
-        const empty = { ...assistantMessage(), content: [] };
-        return streamFromEvents(
-          [{ type: "done", reason: "stop", message: empty }],
-          empty,
-        );
-      }
-
-      const finalMessage = assistantMessage();
+      const finalMessage = { ...assistantMessage(), content: [] };
       return streamFromEvents(
         [{ type: "done", reason: "stop", message: finalMessage }],
         finalMessage,
@@ -569,7 +561,7 @@ describe("PiStreamAdapter", () => {
       events.push(event);
     }
 
-    expect(calls).toBe(2);
+    expect(calls).toBe(1);
     expect(
       events.some((event) => {
         if (event.type !== "letta-chunk") return false;
@@ -581,12 +573,36 @@ describe("PiStreamAdapter", () => {
           chunk.message_type === "event_message" && chunk.event_type === "retry"
         );
       }),
-    ).toBe(true);
+    ).toBe(false);
     const localMessages = events.filter(
       (event) => event.type === "local-message",
     );
     expect(localMessages).toHaveLength(1);
-    expect(JSON.stringify(localMessages[0])).toContain("ok");
+    expect(JSON.stringify(localMessages[0])).toContain('"content":[]');
+  });
+
+  test("accepts reasoning-only successful local provider responses like pi agent loop", async () => {
+    const finalMessage = {
+      ...assistantMessage(),
+      content: [{ type: "thinking", thinking: "done thinking" }],
+    } satisfies AssistantMessage;
+    const stream: PiStreamFunction = () =>
+      streamFromEvents(
+        [{ type: "done", reason: "stop", message: finalMessage }],
+        finalMessage,
+      );
+
+    const adapter = new PiStreamAdapter({ stream });
+    const events: ProviderStreamEvent[] = [];
+    for await (const event of adapter.stream(input())) {
+      events.push(event);
+    }
+
+    const localMessages = events.filter(
+      (event) => event.type === "local-message",
+    );
+    expect(localMessages).toHaveLength(1);
+    expect(JSON.stringify(localMessages[0])).toContain("done thinking");
   });
 
   test("maps local ChatGPT priority service tier to pi-ai serviceTier", async () => {

--- a/src/channels/discord-service.test.ts
+++ b/src/channels/discord-service.test.ts
@@ -62,6 +62,7 @@ describe("discord channel service", () => {
     __testOverrideSaveRoutes(() => {});
     __testOverrideLoadPairingStore(() => null);
     __testOverrideSavePairingStore(() => {});
+    __testOverrideResolveChannelAccountDisplayName(async () => undefined);
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- Remove the local-only PiStreamAdapter assertion that required visible text or tool calls on successful provider responses.
- Match Pi agent loop semantics: only `error` / `aborted` stop reasons fail; empty or reasoning-only `stop` responses complete normally.
- Update local adapter coverage for empty and reasoning-only successful responses.
- Validated with `bun test src/backend/pi-stream-adapter.test.ts` and `bun run check`.