### PR TITLE
feat: generate conversation titles via summary endpoint

### DIFF
--- a/src/backend/api/conversations.ts
+++ b/src/backend/api/conversations.ts
@@ -9,6 +9,15 @@ export type ConversationDescriptionUpdateBody = Record<string, unknown> & {
   description: string | null;
 };
 
+export type SummarizeConversationBody = Record<string, unknown> & {
+  prompt: string;
+  messages: Array<{
+    role: "user" | "assistant" | "system";
+    content: string;
+  }>;
+  model?: string;
+};
+
 export async function forkConversation(
   conversationId: string,
   options: ForkConversationOptions = {},
@@ -34,5 +43,18 @@ export async function updateConversationDescription(
     "PATCH",
     `/v1/conversations/${encodeURIComponent(conversationId)}`,
     body,
+  );
+}
+
+export async function summarizeConversation(
+  conversationId: string,
+  body: SummarizeConversationBody,
+  options: { signal?: AbortSignal } = {},
+): Promise<{ summary: string }> {
+  return apiRequest<{ summary: string }>(
+    "POST",
+    `/v1/conversations/${encodeURIComponent(conversationId)}/summarize`,
+    body,
+    options,
   );
 }

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -77,7 +77,8 @@ import {
   resetContextHistory,
 } from "@/cli/helpers/context-tracker";
 import {
-  generateConversationTitleFromFork,
+  type ConversationTitleMessage,
+  generateConversationTitleFromSummary,
   getConversationTitleSettings,
   normalizeConversationTitle,
 } from "@/cli/helpers/conversation-title";
@@ -1227,10 +1228,20 @@ export function App({
     }
 
     try {
-      const client = await getClient();
-      const aiTitle = await generateConversationTitleFromFork(
-        client,
+      const messages: ConversationTitleMessage[] = [];
+      for (const lineId of buffersRef.current.order) {
+        const line = buffersRef.current.byId.get(lineId);
+        if (line?.kind === "user" || line?.kind === "assistant") {
+          const content = line.text.trim();
+          if (content) {
+            messages.push({ role: line.kind, content });
+          }
+        }
+      }
+
+      const aiTitle = await generateConversationTitleFromSummary(
         conversationId,
+        messages,
       );
       return aiTitle ?? fallback;
     } catch (err) {

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -1182,6 +1182,9 @@ export function App({
     !resumedExistingConversation,
   );
   const isAutoConversationTitleInFlightRef = useRef(false);
+  const autoConversationTitleStartIndexRef = useRef<number | null>(
+    !resumedExistingConversation ? 0 : null,
+  );
   const shouldAutoGenerateConversationDescriptionRef = useRef(
     !resumedExistingConversation,
   );
@@ -1191,6 +1194,9 @@ export function App({
     (enabled: boolean) => {
       shouldAutoGenerateConversationTitleRef.current = enabled;
       isAutoConversationTitleInFlightRef.current = false;
+      autoConversationTitleStartIndexRef.current = enabled
+        ? buffersRef.current.order.length
+        : null;
       shouldAutoGenerateConversationDescriptionRef.current = enabled;
       isAutoConversationDescriptionInFlightRef.current = false;
       firstUserQueryRef.current = null;
@@ -1234,7 +1240,11 @@ export function App({
 
     try {
       const messages: ConversationTitleMessage[] = [];
-      for (const lineId of buffersRef.current.order) {
+      const startIndex = autoConversationTitleStartIndexRef.current ?? 0;
+      const titleLineIds = buffersRef.current.order.slice(
+        Math.min(startIndex, buffersRef.current.order.length),
+      );
+      for (const lineId of titleLineIds) {
         const line = buffersRef.current.byId.get(lineId);
         if (line?.kind === "user" || line?.kind === "assistant") {
           const content = line.text.trim();

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -1239,9 +1239,14 @@ export function App({
         }
       }
 
+      const summaryModel =
+        currentModelLabel && !currentModelLabel.startsWith("letta/auto")
+          ? currentModelLabel
+          : undefined;
       const aiTitle = await generateConversationTitleFromSummary(
         conversationId,
         messages,
+        summaryModel,
       );
       return aiTitle ?? fallback;
     } catch (err) {
@@ -1250,7 +1255,7 @@ export function App({
       }
       return fallback;
     }
-  }, [deriveAutoConversationTitle]);
+  }, [deriveAutoConversationTitle, currentModelLabel]);
   const generateConversationDescription = useCallback(
     async (options?: { force?: boolean }) => {
       if (!experimentManager.isEnabled("desktop_conversation_bootstrap")) {

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -133,6 +133,11 @@ import { goalLoopMode } from "@/goal-loop-mode";
 import { runSessionEndHooks, runSessionStartHooks } from "@/hooks";
 import type { ApprovalContext } from "@/permissions/analyzer";
 import { type PermissionMode, permissionMode } from "@/permissions/mode";
+import {
+  buildByokProviderAliases,
+  isByokHandleForSelector,
+  listProviders,
+} from "@/providers/byok-providers";
 import { OPENAI_CODEX_PROVIDER_NAME } from "@/providers/openai-codex-provider";
 import {
   type MessageQueueItem,
@@ -1239,10 +1244,27 @@ export function App({
         }
       }
 
-      const summaryModel =
-        currentModelLabel && !currentModelLabel.startsWith("letta/auto")
-          ? currentModelLabel
-          : undefined;
+      let summaryModel: string | undefined;
+      if (currentModelLabel) {
+        try {
+          const providers = await listProviders();
+          const byokProviderAliases = buildByokProviderAliases(providers);
+          summaryModel = isByokHandleForSelector(
+            currentModelLabel,
+            byokProviderAliases,
+          )
+            ? currentModelLabel
+            : undefined;
+        } catch {
+          const byokProviderAliases = buildByokProviderAliases([]);
+          summaryModel = isByokHandleForSelector(
+            currentModelLabel,
+            byokProviderAliases,
+          )
+            ? currentModelLabel
+            : undefined;
+        }
+      }
       const aiTitle = await generateConversationTitleFromSummary(
         conversationId,
         messages,

--- a/src/cli/app/use-conversation-loop.ts
+++ b/src/cli/app/use-conversation-loop.ts
@@ -1656,12 +1656,18 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
               conversationIdRef.current !== "default"
             ) {
               isAutoConversationTitleInFlightRef.current = true;
+              const titleConversationId = conversationIdRef.current;
               const conversationTitle = await generateConversationTitle();
               if (!conversationTitle) {
                 isAutoConversationTitleInFlightRef.current = false;
+              } else if (
+                !shouldAutoGenerateConversationTitleRef.current ||
+                conversationIdRef.current !== titleConversationId
+              ) {
+                isAutoConversationTitleInFlightRef.current = false;
               } else {
                 void getBackend()
-                  .updateConversation(conversationIdRef.current, {
+                  .updateConversation(titleConversationId, {
                     summary: conversationTitle,
                   })
                   .then(() => {

--- a/src/cli/helpers/conversation-title.ts
+++ b/src/cli/helpers/conversation-title.ts
@@ -1,5 +1,4 @@
-import type Letta from "@letta-ai/letta-client";
-import { forkConversation } from "@/backend/api/conversations";
+import { summarizeConversation } from "@/backend/api/conversations";
 import { DEFAULT_SUMMARIZATION_MODEL } from "@/constants";
 import { settingsManager } from "@/settings-manager";
 import { isDebugEnabled } from "@/utils/debug";
@@ -8,6 +7,11 @@ import { isDebugEnabled } from "@/utils/debug";
  * Maximum characters allowed for an auto-generated conversation title.
  */
 export const CONVERSATION_TITLE_MAX_LENGTH = 100;
+
+export type ConversationTitleMessage = {
+  role: "user" | "assistant" | "system";
+  content: string;
+};
 
 export interface ConversationTitleSettingsSnapshot {
   enabled: boolean;
@@ -31,15 +35,13 @@ export function setConversationTitleSettings(
 }
 
 /**
- * Hard timeout on the fork-and-generate flow. Title generation is best-effort
- * and we fall back to a heuristic on timeout.
+ * Hard timeout on title generation. Title generation is best-effort and we
+ * fall back to a heuristic on timeout.
  */
 const CONVERSATION_TITLE_TIMEOUT_MS = 30_000;
 
 /**
- * System prompt installed via `override_system` for the title-generation turn.
- * Bypasses the agent's persisted system prompt so the model focuses on producing
- * a single short title rather than its normal task behavior.
+ * System prompt for server-side title summarization.
  */
 const CONVERSATION_TITLE_SYSTEM_PROMPT = `You are a conversation title generator.
 
@@ -50,14 +52,6 @@ Rules:
 - no quotes, markdown, prefixes, or trailing punctuation
 - never call any tools — reply with plain text only
 - avoid generic titles like "New conversation" or "Help request"`;
-
-/**
- * Final user-turn prompt sent to the forked conversation. The agent already
- * has the original conversation's in-context messages (copied by fork), so
- * this just nudges it to emit the title.
- */
-const CONVERSATION_TITLE_USER_PROMPT =
-  "Based on the conversation above, output a short title (2-7 words) describing the topic. Reply with ONLY the title text — no quotes, no tools, no preamble.";
 
 /**
  * Strip whitespace, surrounding quotes, and clamp to {@link CONVERSATION_TITLE_MAX_LENGTH}.
@@ -81,49 +75,14 @@ export function normalizeConversationTitle(value: string): string | null {
   return normalized.slice(0, CONVERSATION_TITLE_MAX_LENGTH);
 }
 
-/**
- * Extract plain-text content from an assistant_message chunk's `content`
- * field, which may be a raw string or an array of structured content parts.
- */
-function extractAssistantText(content: unknown): string {
-  if (typeof content === "string") {
-    return content;
-  }
-  if (Array.isArray(content)) {
-    let collected = "";
-    for (const part of content) {
-      if (
-        part &&
-        typeof part === "object" &&
-        "text" in part &&
-        typeof (part as { text?: unknown }).text === "string"
-      ) {
-        collected += (part as { text: string }).text;
-      }
-    }
-    return collected;
-  }
-  return "";
-}
-
-/**
- * Generate a conversation title by:
- * 1. Forking the conversation as a hidden side conversation.
- * 2. Sending a single one-step message to the fork with `override_model`
- *    (DEFAULT_SUMMARIZATION_MODEL) and `override_system` so the agent only
- *    emits a short title rather than running its full task loop.
- * 3. Reading the assistant message text out of the stream.
- * 4. Best-effort deleting the forked conversation so it doesn't pollute
- *    the user's conversation list.
- *
- * Returns null on any failure or when the model produced empty output —
- * the caller should fall back to a heuristic title.
- */
-export async function generateConversationTitleFromFork(
-  client: Letta,
+export async function generateConversationTitleFromSummary(
   conversationId: string,
+  messages: ConversationTitleMessage[],
 ): Promise<string | null> {
-  let forkId: string | null = null;
+  if (messages.length === 0) {
+    return null;
+  }
+
   const abortController = new AbortController();
   const timeoutId = setTimeout(
     () => abortController.abort(),
@@ -131,64 +90,27 @@ export async function generateConversationTitleFromFork(
   );
 
   try {
-    const fork = await forkConversation(conversationId, { hidden: true });
-    forkId = fork.id;
-
-    const stream = await client.conversations.messages.create(
-      forkId,
+    const response = await summarizeConversation(
+      conversationId,
       {
-        messages: [
-          {
-            role: "user",
-            content: CONVERSATION_TITLE_USER_PROMPT,
-          },
-        ],
-        override_model: DEFAULT_SUMMARIZATION_MODEL,
-        override_system: CONVERSATION_TITLE_SYSTEM_PROMPT,
-        max_steps: 1,
-        streaming: true,
-        stream_tokens: false,
-        include_pings: false,
+        prompt: CONVERSATION_TITLE_SYSTEM_PROMPT,
+        messages,
+        model: DEFAULT_SUMMARIZATION_MODEL,
       },
-      { signal: abortController.signal },
+      {
+        signal: abortController.signal,
+      },
     );
-
-    let titleText = "";
-    for await (const chunk of stream) {
-      // Only collect assistant_message text. Tool calls / reasoning are ignored
-      // so a model that misbehaves and tries a tool call still falls back cleanly.
-      if (
-        chunk &&
-        typeof chunk === "object" &&
-        "message_type" in chunk &&
-        (chunk as { message_type?: string }).message_type ===
-          "assistant_message"
-      ) {
-        titleText += extractAssistantText(
-          (chunk as { content?: unknown }).content,
-        );
-      }
-    }
-
-    return normalizeConversationTitle(titleText);
+    return normalizeConversationTitle(response.summary);
   } catch (err) {
     if (isDebugEnabled()) {
-      console.error("[DEBUG] generateConversationTitleFromFork failed:", err);
+      console.error(
+        "[DEBUG] generateConversationTitleFromSummary failed:",
+        err,
+      );
     }
     return null;
   } finally {
     clearTimeout(timeoutId);
-    // Best-effort cleanup of the hidden fork. We don't await this on the
-    // hot path; if it errors we just leave the hidden convo and move on.
-    if (forkId) {
-      void client.conversations.delete(forkId).catch((err) => {
-        if (isDebugEnabled()) {
-          console.error(
-            "[DEBUG] failed to delete title-fork conversation:",
-            err,
-          );
-        }
-      });
-    }
   }
 }

--- a/src/cli/helpers/conversation-title.ts
+++ b/src/cli/helpers/conversation-title.ts
@@ -1,5 +1,5 @@
 import { summarizeConversation } from "@/backend/api/conversations";
-import { DEFAULT_SUMMARIZATION_MODEL } from "@/constants";
+import { DEFAULT_TITLE_SUMMARIZATION_MODEL } from "@/constants";
 import { settingsManager } from "@/settings-manager";
 import { isDebugEnabled } from "@/utils/debug";
 
@@ -78,6 +78,7 @@ export function normalizeConversationTitle(value: string): string | null {
 export async function generateConversationTitleFromSummary(
   conversationId: string,
   messages: ConversationTitleMessage[],
+  model: string = DEFAULT_TITLE_SUMMARIZATION_MODEL,
 ): Promise<string | null> {
   if (messages.length === 0) {
     return null;
@@ -95,7 +96,7 @@ export async function generateConversationTitleFromSummary(
       {
         prompt: CONVERSATION_TITLE_SYSTEM_PROMPT,
         messages,
-        model: DEFAULT_SUMMARIZATION_MODEL,
+        model,
       },
       {
         signal: abortController.signal,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,6 +13,11 @@ export const DEFAULT_MODEL_ID = "auto";
 export const DEFAULT_SUMMARIZATION_MODEL = "letta/auto";
 
 /**
+ * Default model handle for lightweight conversation title generation.
+ */
+export const DEFAULT_TITLE_SUMMARIZATION_MODEL = "letta/auto-fast";
+
+/**
  * Default agent name when creating a new agent
  */
 export const DEFAULT_AGENT_NAME = "Letta Code";


### PR DESCRIPTION
## Summary
- Replace hidden fork-based conversation title generation with the new summarize endpoint
- Send the current rendered user/assistant transcript as request messages
- Keep fallback behavior when title generation fails or has no messages

## Validation
- `bun run typecheck`
- pre-commit hook stack during commit

## Notes
- Depends on letta-cloud PR: https://github.com/letta-ai/letta-cloud/pull/12104