### PR TITLE
fix: hang local agent creation

### DIFF
--- a/src/agent/create.ts
+++ b/src/agent/create.ts
@@ -13,6 +13,7 @@ import { DEFAULT_AGENT_NAME, DEFAULT_SUMMARIZATION_MODEL } from "@/constants";
 import { settingsManager } from "@/settings-manager";
 import { getModelContextWindow } from "./available-models";
 import { getDefaultMemoryBlocks } from "./memory";
+import { GIT_MEMORY_ENABLED_TAG } from "./memory-git";
 import {
   formatAvailableModels,
   getDefaultModel,
@@ -82,6 +83,34 @@ export async function addBaseToolsToServer(): Promise<boolean> {
       `Failed to call /v1/tools/add-base-tools: ${err instanceof Error ? err.message : String(err)}`,
     );
     return false;
+  }
+}
+
+export async function enableMemfsForCreatedAgent(params: {
+  agentId: string;
+  agentTags?: string[] | null;
+}): Promise<void> {
+  const { agentId, agentTags } = params;
+
+  try {
+    // Only sync memfs to Letta API if backend is set to 'api'
+    // Otherwise this will cause a hang on terminal if we create
+    // the agent with '--backend local' flag due to an attempt
+    // to call Letta API which is not intended behavior for local
+    // backend.
+    if (getBackend().capabilities.remoteMemfs) {
+      const { getClient } = await import("@/backend/api/client");
+      const client = await getClient();
+      const tags = agentTags || [];
+      if (!tags.includes(GIT_MEMORY_ENABLED_TAG)) {
+        await client.agents.update(agentId, {
+          tags: [...tags, GIT_MEMORY_ENABLED_TAG],
+        });
+      }
+    }
+    settingsManager.setMemfsEnabled(agentId, true);
+  } catch {
+    // Self-hosted or memfs not available - skip silently
   }
 }
 
@@ -426,6 +455,11 @@ export async function createAgent(
     }
     // Subagent names: don't persist (no stable managed prompt metadata)
   }
+
+  await enableMemfsForCreatedAgent({
+    agentId: agent.id,
+    agentTags: agent.tags,
+  });
 
   // Build provenance info
   const provenance: AgentProvenance = {

--- a/src/agent/personality.test.ts
+++ b/src/agent/personality.test.ts
@@ -3,7 +3,6 @@ import {
   buildCreateAgentOptionsForPersonality,
   DEFAULT_CREATE_AGENT_PERSONALITIES,
   detectPersonalityFromPersonaFile,
-  enableMemfsForCreatedAgent,
   getDefaultHumanContent,
   getPersonalityBlockDefinitions,
   getPersonalityBlockValues,
@@ -16,6 +15,7 @@ import {
 } from "@/agent/personality";
 import { configureBackendMode } from "@/backend";
 import { __testOverrideGetClient } from "@/backend/api/client";
+import { enableMemfsForCreatedAgent } from "./create";
 
 const VALID_FRONTMATTER = "---\ndescription: Persona\nlimit: 20000\n---\n\n";
 

--- a/src/agent/personality.test.ts
+++ b/src/agent/personality.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import {
   buildCreateAgentOptionsForPersonality,
   DEFAULT_CREATE_AGENT_PERSONALITIES,
   detectPersonalityFromPersonaFile,
+  enableMemfsForCreatedAgent,
   getDefaultHumanContent,
   getPersonalityBlockDefinitions,
   getPersonalityBlockValues,
@@ -13,8 +14,15 @@ import {
   replaceBodyPreservingFrontmatter,
   resolvePersonalityId,
 } from "@/agent/personality";
+import { configureBackendMode } from "@/backend";
+import { __testOverrideGetClient } from "@/backend/api/client";
 
 const VALID_FRONTMATTER = "---\ndescription: Persona\nlimit: 20000\n---\n\n";
+
+afterEach(() => {
+  __testOverrideGetClient(null);
+  configureBackendMode("api");
+});
 
 describe("personality helpers", () => {
   test("replaceBodyPreservingFrontmatter swaps body and keeps frontmatter", () => {
@@ -176,6 +184,26 @@ describe("personality helpers", () => {
     });
 
     expect(options.tags).toEqual(["desktop", "favorite"]);
+  });
+
+  test("enableMemfsForCreatedAgent skips remote API calls on local backend", async () => {
+    configureBackendMode("local");
+    let getClientCalls = 0;
+    __testOverrideGetClient(async () => {
+      getClientCalls += 1;
+      return {
+        agents: {
+          update: async () => undefined,
+        },
+      };
+    });
+
+    await enableMemfsForCreatedAgent({
+      agentId: "agent-local-test",
+      agentTags: [],
+    });
+
+    expect(getClientCalls).toBe(0);
   });
 
   test("kawaii block definitions carry personality-specific descriptions", () => {

--- a/src/agent/personality.ts
+++ b/src/agent/personality.ts
@@ -466,6 +466,11 @@ export async function enableMemfsForCreatedAgent(params: {
   agentTags?: string[] | null;
 }): Promise<void> {
   const { agentId, agentTags } = params;
+  const backend = getBackend();
+
+  if (!backend.capabilities.remoteMemfs) {
+    return;
+  }
 
   try {
     const { getClient } = await import("@/backend/api/client");

--- a/src/agent/personality.ts
+++ b/src/agent/personality.ts
@@ -3,13 +3,11 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import { getBackend } from "@/backend";
-import { settingsManager } from "@/settings-manager";
 import type { CreateAgentOptions } from "./create";
 import { getDefaultMemoryBlocks, parseMdxFrontmatter } from "./memory";
 import { getScopedMemoryFilesystemRoot } from "./memory-filesystem";
 import {
   commitAndSyncMemoryWrite,
-  GIT_MEMORY_ENABLED_TAG,
   getMemoryRepoDir,
   pullMemory,
 } from "./memory-git";
@@ -461,32 +459,6 @@ export async function buildCreateAgentOptionsForPersonality(params: {
   };
 }
 
-export async function enableMemfsForCreatedAgent(params: {
-  agentId: string;
-  agentTags?: string[] | null;
-}): Promise<void> {
-  const { agentId, agentTags } = params;
-  const backend = getBackend();
-
-  if (!backend.capabilities.remoteMemfs) {
-    return;
-  }
-
-  try {
-    const { getClient } = await import("@/backend/api/client");
-    const client = await getClient();
-    const tags = agentTags || [];
-    if (!tags.includes(GIT_MEMORY_ENABLED_TAG)) {
-      await client.agents.update(agentId, {
-        tags: [...tags, GIT_MEMORY_ENABLED_TAG],
-      });
-    }
-    settingsManager.setMemfsEnabled(agentId, true);
-  } catch {
-    // Self-hosted or memfs not available - skip silently
-  }
-}
-
 export async function createAgentForPersonality(params: {
   personalityId: PersonalityId;
   name?: string;
@@ -500,11 +472,6 @@ export async function createAgentForPersonality(params: {
   const result = await createAgent(
     await buildCreateAgentOptionsForPersonality(params),
   );
-
-  await enableMemfsForCreatedAgent({
-    agentId: result.agent.id,
-    agentTags: result.agent.tags,
-  });
 
   return result;
 }

--- a/src/cli/subcommands/agents.ts
+++ b/src/cli/subcommands/agents.ts
@@ -4,7 +4,6 @@ import { type CreateAgentOptions, createAgent } from "@/agent/create";
 import {
   buildCreateAgentOptionsForPersonality,
   createAgentForPersonality,
-  enableMemfsForCreatedAgent,
   resolvePersonalityId,
 } from "@/agent/personality";
 import { getBackend } from "@/backend";
@@ -164,13 +163,6 @@ async function runCreateAction(
         })
       : await createAgent(options);
     const agentId = result.agent.id;
-
-    if (!personality) {
-      await enableMemfsForCreatedAgent({
-        agentId,
-        agentTags: result.agent.tags,
-      });
-    }
 
     if (values.pinned) {
       settingsManager.pinGlobal(agentId);


### PR DESCRIPTION
### Summary

This PR will solve issue https://github.com/letta-ai/letta-code/issues/2713 by ignoring memFS sync to Letta Cloud API when the backend mode is set to `local`.

### Changes

- Add check of `getBackend().capabilities.remoteMemfs` in `enableMemfsForCreatedAgent` before executing memFS cloud API sync
- Move `enableMemfsForCreatedAgent` from `src/agent/personality.ts` to `src/agent/create.ts` to prevent circular dependency
- Removing check of `personality` in `src/cli/subcommands/agents.ts` which is used to determine whether to call `enableMemfsForCreatedAgent`
- Add test on `src/agent/personality.test.ts` to ensure the cloud sync is skipped when backend mode is `local`