### PR TITLE
fix(cli): reload runtime surfaces in place

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -2545,9 +2545,15 @@ export function App({
     }
 
     await extensionAdapter.reload();
+    await extensionAdapter.events.emit("conversation_open", {
+      agentId,
+      agentName: agentName ?? null,
+      conversationId: conversationIdRef.current ?? null,
+      reason: "reload",
+    });
     setTerminalTitleConfigRefreshEpoch((epoch) => epoch + 1);
     refreshDerived();
-  }, [extensionAdapter, refreshDerived]);
+  }, [agentId, agentName, extensionAdapter, refreshDerived]);
 
   const recordCommandReminder = useCallback((event: CommandFinishedEvent) => {
     let input = event.input.trim();

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -48,6 +48,7 @@ import {
   cancelActiveConnectOperation,
   isActiveConnectOperationCancellable,
 } from "@/cli/commands/connect-command-state";
+import { refreshCustomCommands } from "@/cli/commands/custom";
 import {
   type CommandFinishedEvent,
   type CommandHandle,
@@ -335,7 +336,6 @@ export function App({
   updateNotification = null,
   systemInfoReminderEnabled = true,
   extensionsDisabled = false,
-  onReload,
 }: AppProps) {
   // Warm the model-access cache in the background so /model is fast on first open.
   useEffect(() => {
@@ -988,6 +988,8 @@ export function App({
   // Show compaction messages preference (can be toggled at runtime)
   const [showCompactionsEnabled, _setShowCompactionsEnabled] =
     useState(showCompactions);
+  const [terminalTitleConfigRefreshEpoch, setTerminalTitleConfigRefreshEpoch] =
+    useState(0);
 
   // Live, approximate token counter (resets each turn)
   const [tokenCount, setTokenCount] = useState(0);
@@ -2521,6 +2523,31 @@ export function App({
     commitEligibleLines(b);
   }, [commitEligibleLines]);
   refreshDerivedRef.current = refreshDerived;
+
+  const handleReload = useCallback(async () => {
+    settingsManager.clearCaches();
+    await settingsManager.loadProjectSettings();
+    await settingsManager.loadLocalProjectSettings();
+
+    const settings = settingsManager.getSettings();
+    setTokenStreamingEnabled(settings.tokenStreaming);
+    _setReasoningTabCycleEnabled(settings.reasoningTabCycleEnabled === true);
+    _setShowCompactionsEnabled(settings.showCompactions === true);
+
+    try {
+      refreshCustomCommands();
+    } catch (error) {
+      debugLog(
+        "commands",
+        "refreshCustomCommands failed during /reload: %s",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+
+    await extensionAdapter.reload();
+    setTerminalTitleConfigRefreshEpoch((epoch) => epoch + 1);
+    refreshDerived();
+  }, [extensionAdapter, refreshDerived]);
 
   const recordCommandReminder = useCallback((event: CommandFinishedEvent) => {
     let input = event.input.trim();
@@ -4103,7 +4130,7 @@ export function App({
     updateAgentName,
     updateMemorySyncCommand,
     userCancelledRef,
-    onReload,
+    onReload: handleReload,
   });
 
   const onSubmitRef = useRef(onSubmit);
@@ -4814,7 +4841,7 @@ export function App({
     <>
       <TerminalTitleWriter
         projectDirectory={projectDirectory}
-        configRefreshKey={activeOverlay}
+        configRefreshKey={`${activeOverlay ?? ""}:${terminalTitleConfigRefreshEpoch}`}
         titleData={terminalTitleData}
         shouldAnimate={shouldAnimate}
         hasActiveProgress={terminalTitleTaskRunning}

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -2545,7 +2545,7 @@ export function App({
     }
 
     const durationMs = Date.now() - sessionStartTimeRef.current;
-    await extensionAdapter.events.emit("conversation_close", {
+    void extensionAdapter.events.emit("conversation_close", {
       agentId,
       conversationId: conversationIdRef.current ?? null,
       durationMs,
@@ -2554,7 +2554,7 @@ export function App({
       toolCallCount: telemetry.getToolCallCount(),
     });
     await extensionAdapter.reload();
-    await extensionAdapter.events.emit("conversation_open", {
+    void extensionAdapter.events.emit("conversation_open", {
       agentId,
       agentName: agentName ?? null,
       conversationId: conversationIdRef.current ?? null,

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -2544,6 +2544,15 @@ export function App({
       );
     }
 
+    const durationMs = Date.now() - sessionStartTimeRef.current;
+    await extensionAdapter.events.emit("conversation_close", {
+      agentId,
+      conversationId: conversationIdRef.current ?? null,
+      durationMs,
+      messageCount: telemetry.getMessageCount(),
+      reason: "reload",
+      toolCallCount: telemetry.getToolCallCount(),
+    });
     await extensionAdapter.reload();
     await extensionAdapter.events.emit("conversation_open", {
       agentId,

--- a/src/cli/app/command-routing.ts
+++ b/src/cli/app/command-routing.ts
@@ -46,7 +46,7 @@ const NON_STATE_COMMANDS = new Set([
   "/exit", // session exit
   "/rename", // agent/convo rename
   "/btw",
-  "/reload", // soft TUI restart (has its own busy guard)
+  "/reload", // runtime surface reload (has its own busy guard)
 ]);
 
 // Check if a command is interactive (opens overlay, should not be queued)

--- a/src/cli/app/types.ts
+++ b/src/cli/app/types.ts
@@ -50,8 +50,6 @@ export type AppProps = {
   updateNotification?: string | null; // Latest version when a significant auto-update was applied
   systemInfoReminderEnabled?: boolean;
   extensionsDisabled?: boolean;
-  /** Callback to soft-restart the TUI (re-runs startup path, remounts App). */
-  onReload?: (agentId: string, conversationId: string) => Promise<void>;
 };
 
 export type ActiveOverlay =

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -322,7 +322,7 @@ type SubmitHandlerContext = {
     keepRunning?: boolean,
   ) => void;
   userCancelledRef: MutableRefObject<boolean>;
-  onReload?: (agentId: string, conversationId: string) => Promise<void>;
+  onReload?: () => Promise<void>;
 };
 
 export function useSubmitHandler(ctx: SubmitHandlerContext) {
@@ -978,30 +978,11 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           if (onReload) {
             const cmd = commandRunner.start(
               "/reload",
-              "Reloading settings and restarting TUI effects...",
+              "Reloading settings and local extensions...",
             );
             cmd.finish("Reloading...", true);
-            try {
-              const { refreshCustomCommands } = await import(
-                "@/cli/commands/custom.js"
-              );
-              refreshCustomCommands();
-            } catch (error) {
-              debugLog(
-                "commands",
-                "refreshCustomCommands failed during /reload: %s",
-                error instanceof Error ? error.message : String(error),
-              );
-            }
             // Defer the reload to let the command UI render first
-            setTimeout(
-              () =>
-                onReload(
-                  agentIdRef.current,
-                  conversationIdRef.current ?? "default",
-                ),
-              0,
-            );
+            setTimeout(() => void onReload(), 0);
           } else {
             const cmd = commandRunner.start("/reload", "Reload not available");
             cmd.fail("Reload is not available in this context");

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -980,9 +980,21 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               "/reload",
               "Reloading settings and local extensions...",
             );
-            cmd.finish("Reloading...", true);
+            setCommandRunning(true);
             // Defer the reload to let the command UI render first
-            setTimeout(() => void onReload(), 0);
+            setTimeout(() => {
+              void (async () => {
+                try {
+                  await onReload();
+                  cmd.finish("Reloaded settings and local extensions", true);
+                } catch (error) {
+                  const errorDetails = formatErrorDetails(error, agentId);
+                  cmd.fail(`Failed: ${errorDetails}`);
+                } finally {
+                  setCommandRunning(false);
+                }
+              })();
+            }, 0);
           } else {
             const cmd = commandRunner.start("/reload", "Reload not available");
             cmd.fail("Reload is not available in this context");

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -289,11 +289,11 @@ export const commands: Record<string, Command> = {
     },
   },
   "/reload": {
-    desc: "Reload settings and restart TUI effects",
+    desc: "Reload settings and local extensions",
     order: 27.2,
     noArgs: true,
     handler: () => {
-      // Handled specially in AppCoordinator to trigger a soft restart
+      // Handled specially in AppCoordinator to reload runtime surfaces in-place
       return "Reloading...";
     },
   },

--- a/src/cli/reload-command.test.ts
+++ b/src/cli/reload-command.test.ts
@@ -26,6 +26,9 @@ describe("/reload command", () => {
       "await settingsManager.loadLocalProjectSettings()",
     );
     expect(source).toContain("refreshCustomCommands()");
+    expect(source).toContain(
+      'await extensionAdapter.events.emit("conversation_close"',
+    );
     expect(source).toContain("await extensionAdapter.reload()");
     expect(source).toContain(
       'await extensionAdapter.events.emit("conversation_open"',

--- a/src/cli/reload-command.test.ts
+++ b/src/cli/reload-command.test.ts
@@ -10,18 +10,23 @@ describe("/reload command", () => {
     const source = readFileSync(registryPath, "utf-8");
 
     expect(source).toContain('"/reload"');
-    expect(source).toContain("Reload settings and restart TUI effects");
+    expect(source).toContain("Reload settings and local extensions");
   });
 
-  test("AppProps includes onReload callback", () => {
-    const typesPath = fileURLToPath(
-      new URL("../cli/app/types.ts", import.meta.url),
+  test("AppCoordinator owns the in-place reload callback", () => {
+    const appCoordinatorPath = fileURLToPath(
+      new URL("../cli/app/AppCoordinator.tsx", import.meta.url),
     );
-    const source = readFileSync(typesPath, "utf-8");
+    const source = readFileSync(appCoordinatorPath, "utf-8");
 
+    expect(source).toContain("const handleReload = useCallback(async () =>");
+    expect(source).toContain("settingsManager.clearCaches()");
+    expect(source).toContain("await settingsManager.loadProjectSettings()");
     expect(source).toContain(
-      "onReload?: (agentId: string, conversationId: string) => Promise<void>",
+      "await settingsManager.loadLocalProjectSettings()",
     );
+    expect(source).toContain("refreshCustomCommands()");
+    expect(source).toContain("await extensionAdapter.reload()");
   });
 
   test("useSubmitHandler handles /reload command", () => {
@@ -31,7 +36,7 @@ describe("/reload command", () => {
     const source = readFileSync(submitHandlerPath, "utf-8");
 
     expect(source).toContain('trimmed === "/reload"');
-    expect(source).toContain("onReload(");
+    expect(source).toContain("void onReload()");
   });
 
   test("/reload has a busy guard", () => {
@@ -52,13 +57,16 @@ describe("/reload command", () => {
     expect(source).toContain('"/reload"');
   });
 
-  test("LoadingApp passes onReload and key to App", () => {
+  test("/reload does not remount App through startup state", () => {
     const indexPath = fileURLToPath(new URL("../index.ts", import.meta.url));
     const source = readFileSync(indexPath, "utf-8");
-    expect(source).toContain("onReload: handleReload");
+    expect(source).not.toContain("appReloadEpoch");
+    expect(source).not.toContain("setAppReloadEpoch");
+    expect(source).not.toContain("onReload: handleReload");
+    expect(source).not.toContain("setResumeData(null)");
     expect(source).toContain(
       // biome-ignore lint/suspicious/noTemplateCurlyInString: asserting source contains literal template string syntax
-      "key: `${agentId}:${conversationId}:${appReloadEpoch}`",
+      "key: `${agentId}:${conversationId}`",
     );
   });
 });

--- a/src/cli/reload-command.test.ts
+++ b/src/cli/reload-command.test.ts
@@ -27,11 +27,11 @@ describe("/reload command", () => {
     );
     expect(source).toContain("refreshCustomCommands()");
     expect(source).toContain(
-      'await extensionAdapter.events.emit("conversation_close"',
+      'void extensionAdapter.events.emit("conversation_close"',
     );
     expect(source).toContain("await extensionAdapter.reload()");
     expect(source).toContain(
-      'await extensionAdapter.events.emit("conversation_open"',
+      'void extensionAdapter.events.emit("conversation_open"',
     );
     expect(source).toContain('reason: "reload"');
   });

--- a/src/cli/reload-command.test.ts
+++ b/src/cli/reload-command.test.ts
@@ -27,6 +27,10 @@ describe("/reload command", () => {
     );
     expect(source).toContain("refreshCustomCommands()");
     expect(source).toContain("await extensionAdapter.reload()");
+    expect(source).toContain(
+      'await extensionAdapter.events.emit("conversation_open"',
+    );
+    expect(source).toContain('reason: "reload"');
   });
 
   test("useSubmitHandler handles /reload command", () => {

--- a/src/cli/reload-command.test.ts
+++ b/src/cli/reload-command.test.ts
@@ -36,7 +36,8 @@ describe("/reload command", () => {
     const source = readFileSync(submitHandlerPath, "utf-8");
 
     expect(source).toContain('trimmed === "/reload"');
-    expect(source).toContain("void onReload()");
+    expect(source).toContain("await onReload()");
+    expect(source).toContain("Reloaded settings and local extensions");
   });
 
   test("/reload has a busy guard", () => {

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -153,7 +153,8 @@ export type ExtensionConversationCloseReason =
   | "quit"
   | "new"
   | "resume"
-  | "fork";
+  | "fork"
+  | "reload";
 
 export interface ExtensionConversationOpenEvent {
   agentId: string | null;

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -146,7 +146,8 @@ export type ExtensionConversationOpenReason =
   | "startup"
   | "new"
   | "resume"
-  | "fork";
+  | "fork"
+  | "reload";
 
 export type ExtensionConversationCloseReason =
   | "quit"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1530,7 +1530,7 @@ async function main(): Promise<void> {
   markMilestone("REACT_IMPORT_DONE");
   await terminalPreflightPromise;
   markMilestone("TERMINAL_PREFLIGHT_DONE");
-  const { useState, useEffect, useCallback, useRef } = React;
+  const { useState, useEffect, useRef } = React;
   const App = AppModule.App;
 
   function LoadingApp({
@@ -1578,8 +1578,6 @@ async function main(): Promise<void> {
     const [isResumingSession, setIsResumingSession] = useState(false);
     const [resumedExistingConversation, setResumedExistingConversation] =
       useState(false);
-    // Epoch counter: incrementing forces App to remount via React key
-    const [appReloadEpoch, setAppReloadEpoch] = useState(0);
     const [agentProvenance, setAgentProvenance] =
       useState<AgentProvenance | null>(null);
     const [selectedGlobalAgentId, setSelectedGlobalAgentId] = useState<
@@ -2073,29 +2071,6 @@ async function main(): Promise<void> {
 
     // Main initialization effect - runs after profile selection
     const initStartedRef = React.useRef(false);
-
-    // Reload handler: re-triggers the startup path for the current agent/conversation,
-    // then remounts AppCoordinator via key change so all effects re-fire.
-    const handleReload = useCallback(
-      async (currentAgentId: string, currentConversationId: string) => {
-        // Clear cached settings and re-populate local project settings
-        // BEFORE triggering state updates. React components read local
-        // project settings synchronously during render (e.g. getConversationGoal),
-        // so the cache must be warm before the re-render cycle starts.
-        settingsManager.clearCaches();
-        await settingsManager.loadLocalProjectSettings();
-        initStartedRef.current = false;
-        setResumeData(null);
-        setAgentState(null);
-        setValidatedAgent(null);
-        setSelectedGlobalAgentId(currentAgentId);
-        setSelectedConversationId(currentConversationId);
-        setResumedExistingConversation(true);
-        setLoadingState("assembling");
-        setAppReloadEpoch((x) => x + 1);
-      },
-      [],
-    );
 
     useEffect(() => {
       if (loadingState !== "assembling") {
@@ -2839,7 +2814,7 @@ async function main(): Promise<void> {
     }
 
     return React.createElement(App, {
-      key: `${agentId}:${conversationId}:${appReloadEpoch}`,
+      key: `${agentId}:${conversationId}`,
       agentId,
       agentState,
       conversationId,
@@ -2860,7 +2835,6 @@ async function main(): Promise<void> {
       systemInfoReminderEnabled: !noSystemInfoReminderFlag,
       extensionsDisabled,
       fileAutocompleteFdPath,
-      onReload: handleReload,
     });
   }
 


### PR DESCRIPTION
## Summary
- make `/reload` refresh runtime surfaces in-place instead of remounting the startup wrapper
- reload project/local settings, custom slash command cache, local extensions, terminal title config, and derived UI state
- remove the App remount epoch that caused startup resume data/message history to be replayed

## Testing
- `bun test src/cli/reload-command.test.ts`
- `bun run typecheck`
- `bun run check`
