### PR TITLE
feat(extensions): coalesce runtime diagnostics writes

### DIFF
--- a/src/extensions/extension-adapter.test.ts
+++ b/src/extensions/extension-adapter.test.ts
@@ -73,6 +73,10 @@ function readJsonFile(filePath: string): unknown {
   return JSON.parse(readFileSync(filePath, "utf-8")) as unknown;
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 describe("extension adapter", () => {
   test("LETTA_DISABLE_EXTENSIONS disables the adapter", () => {
     const original = process.env[LETTA_DISABLE_EXTENSIONS_ENV];
@@ -198,6 +202,129 @@ describe("extension adapter", () => {
       ).toBe(false);
 
       adapter.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("runtime diagnostics writes are debounced", async () => {
+    const root = createTempDir();
+
+    try {
+      const extensionDir = path.join(root, "global-extensions");
+      const diagnosticsRoot = path.join(root, "diagnostics");
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        path.join(extensionDir, "events.ts"),
+        `export default function(letta) {
+          letta.events.on("conversation_open", () => {
+            throw new Error("runtime failed");
+          });
+        }`,
+      );
+
+      const adapter = createExtensionAdapter({
+        cacheDirectory: path.join(root, "extension-cache"),
+        diagnosticsRootDirectory: diagnosticsRoot,
+        diagnosticsWriteDelayMs: 5,
+        getClient: async () => ({}) as unknown as Letta,
+        globalExtensionsDirectory: extensionDir,
+        initialContext: createExtensionContext(),
+      });
+
+      await adapter.reload();
+      const diagnosticsPath =
+        getExtensionDiagnosticsLatestFilePath(diagnosticsRoot);
+      expect(readJsonFile(diagnosticsPath)).toMatchObject({
+        report: { diagnostics: [], errorCount: 0, warningCount: 0 },
+      });
+
+      await adapter.events.emit("conversation_open", {
+        agentId: "agent-1",
+        agentName: "Amelia",
+        conversationId: "conversation-1",
+        reason: "startup",
+      });
+      await adapter.events.emit("conversation_open", {
+        agentId: "agent-1",
+        agentName: "Amelia",
+        conversationId: "conversation-1",
+        reason: "resume",
+      });
+
+      expect(readJsonFile(diagnosticsPath)).toMatchObject({
+        report: { diagnostics: [], errorCount: 0, warningCount: 0 },
+      });
+
+      await sleep(20);
+
+      expect(readJsonFile(diagnosticsPath)).toMatchObject({
+        report: {
+          diagnostics: [
+            { message: "runtime failed", phase: "event", severity: "error" },
+            { message: "runtime failed", phase: "event", severity: "error" },
+          ],
+          errorCount: 2,
+          warningCount: 0,
+        },
+      });
+
+      adapter.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("dispose flushes pending runtime diagnostics writes", async () => {
+    const root = createTempDir();
+
+    try {
+      const extensionDir = path.join(root, "global-extensions");
+      const diagnosticsRoot = path.join(root, "diagnostics");
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        path.join(extensionDir, "events.ts"),
+        `export default function(letta) {
+          letta.events.on("conversation_open", () => {
+            throw new Error("runtime failed");
+          });
+        }`,
+      );
+
+      const adapter = createExtensionAdapter({
+        cacheDirectory: path.join(root, "extension-cache"),
+        diagnosticsRootDirectory: diagnosticsRoot,
+        diagnosticsWriteDelayMs: 30_000,
+        getClient: async () => ({}) as unknown as Letta,
+        globalExtensionsDirectory: extensionDir,
+        initialContext: createExtensionContext(),
+      });
+
+      await adapter.reload();
+      await adapter.events.emit("conversation_open", {
+        agentId: "agent-1",
+        agentName: "Amelia",
+        conversationId: "conversation-1",
+        reason: "startup",
+      });
+
+      const diagnosticsPath =
+        getExtensionDiagnosticsLatestFilePath(diagnosticsRoot);
+      expect(readJsonFile(diagnosticsPath)).toMatchObject({
+        report: { diagnostics: [], errorCount: 0, warningCount: 0 },
+      });
+
+      adapter.dispose();
+
+      expect(readJsonFile(diagnosticsPath)).toMatchObject({
+        report: {
+          diagnostics: [
+            { message: "runtime failed", phase: "event", severity: "error" },
+          ],
+          errorCount: 1,
+          warningCount: 0,
+        },
+      });
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/src/extensions/extension-adapter.test.ts
+++ b/src/extensions/extension-adapter.test.ts
@@ -207,7 +207,7 @@ describe("extension adapter", () => {
     }
   });
 
-  test("runtime diagnostics writes are debounced", async () => {
+  test("runtime diagnostics writes are coalesced", async () => {
     const root = createTempDir();
 
     try {
@@ -263,6 +263,76 @@ describe("extension adapter", () => {
           diagnostics: [
             { message: "runtime failed", phase: "event", severity: "error" },
             { message: "runtime failed", phase: "event", severity: "error" },
+          ],
+          errorCount: 2,
+          warningCount: 0,
+        },
+      });
+
+      adapter.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("runtime diagnostics writes are not starved by continuous diagnostics", async () => {
+    const root = createTempDir();
+
+    try {
+      const extensionDir = path.join(root, "global-extensions");
+      const diagnosticsRoot = path.join(root, "diagnostics");
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        path.join(extensionDir, "events.ts"),
+        `export default function(letta) {
+          letta.events.on("conversation_open", (event) => {
+            throw new Error("runtime failed " + event.reason);
+          });
+        }`,
+      );
+
+      const adapter = createExtensionAdapter({
+        cacheDirectory: path.join(root, "extension-cache"),
+        diagnosticsRootDirectory: diagnosticsRoot,
+        diagnosticsWriteDelayMs: 20,
+        getClient: async () => ({}) as unknown as Letta,
+        globalExtensionsDirectory: extensionDir,
+        initialContext: createExtensionContext(),
+      });
+
+      await adapter.reload();
+      const diagnosticsPath =
+        getExtensionDiagnosticsLatestFilePath(diagnosticsRoot);
+
+      await adapter.events.emit("conversation_open", {
+        agentId: "agent-1",
+        agentName: "Amelia",
+        conversationId: "conversation-1",
+        reason: "startup",
+      });
+      await sleep(10);
+      await adapter.events.emit("conversation_open", {
+        agentId: "agent-1",
+        agentName: "Amelia",
+        conversationId: "conversation-1",
+        reason: "resume",
+      });
+
+      await sleep(15);
+
+      expect(readJsonFile(diagnosticsPath)).toMatchObject({
+        report: {
+          diagnostics: [
+            {
+              message: "runtime failed startup",
+              phase: "event",
+              severity: "error",
+            },
+            {
+              message: "runtime failed resume",
+              phase: "event",
+              severity: "error",
+            },
           ],
           errorCount: 2,
           warningCount: 0,

--- a/src/extensions/extension-adapter.ts
+++ b/src/extensions/extension-adapter.ts
@@ -133,8 +133,8 @@ export function createExtensionAdapter(
   function scheduleDiagnosticsWrite(): void {
     if (disposed || loadState.isLoading || !loadState.hasExtensionSources)
       return;
+    if (diagnosticsWriteTimer) return;
 
-    clearPendingDiagnosticsWrite();
     diagnosticsWriteTimer = setTimeout(() => {
       diagnosticsWriteTimer = null;
       writeLatestDiagnostics();

--- a/src/extensions/extension-adapter.ts
+++ b/src/extensions/extension-adapter.ts
@@ -20,6 +20,8 @@ import {
 import type { ExtensionContext } from "@/extensions/types";
 import { debugLog } from "@/utils/debug";
 
+const RUNTIME_DIAGNOSTICS_WRITE_DELAY_MS = 30_000;
+
 export interface ExtensionAdapterLoadState {
   hadStatuslineRenderer: boolean;
   hasExtensionSources: boolean;
@@ -33,6 +35,7 @@ export interface ExtensionAdapterSnapshot extends ExtensionAdapterLoadState {
 export interface CreateExtensionAdapterOptions
   extends Omit<CreateExtensionEngineOptions, "getContext"> {
   diagnosticsRootDirectory?: string;
+  diagnosticsWriteDelayMs?: number;
   disabled?: boolean;
   initialContext: ExtensionContext;
 }
@@ -62,6 +65,7 @@ export function createExtensionAdapter(
 ): ExtensionAdapter {
   const {
     diagnosticsRootDirectory,
+    diagnosticsWriteDelayMs = RUNTIME_DIAGNOSTICS_WRITE_DELAY_MS,
     disabled,
     getBackend: resolveBackend,
     initialContext,
@@ -85,6 +89,7 @@ export function createExtensionAdapter(
     isLoading: initialHasExtensionSources,
   };
   const listeners = new Set<() => void>();
+  let diagnosticsWriteTimer: ReturnType<typeof setTimeout> | null = null;
 
   const getBackend = () => resolveBackend?.();
   const getContext = () => context;
@@ -93,16 +98,62 @@ export function createExtensionAdapter(
     ...engineOptions,
     getBackend,
     getContext,
+    onDiagnostic: () => scheduleDiagnosticsWrite(),
   });
 
+  function clearPendingDiagnosticsWrite(): void {
+    if (!diagnosticsWriteTimer) return;
+    clearTimeout(diagnosticsWriteTimer);
+    diagnosticsWriteTimer = null;
+  }
+
+  function writeLatestDiagnostics(): void {
+    const registry = engine.getSnapshot();
+    if (!registry.sources.some((source) => source.files.length > 0)) return;
+
+    try {
+      writeExtensionDiagnosticsLatestFile(registry.diagnostics, {
+        rootDirectory: diagnosticsRootDirectory,
+      });
+    } catch (error) {
+      debugLog(
+        "extensions",
+        "failed to write extension diagnostics: %s",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  function flushPendingDiagnosticsWrite(): void {
+    if (!diagnosticsWriteTimer) return;
+    clearPendingDiagnosticsWrite();
+    writeLatestDiagnostics();
+  }
+
+  function scheduleDiagnosticsWrite(): void {
+    if (disposed || loadState.isLoading || !loadState.hasExtensionSources)
+      return;
+
+    clearPendingDiagnosticsWrite();
+    diagnosticsWriteTimer = setTimeout(() => {
+      diagnosticsWriteTimer = null;
+      writeLatestDiagnostics();
+    }, diagnosticsWriteDelayMs);
+    const timerWithUnref = diagnosticsWriteTimer as ReturnType<
+      typeof setTimeout
+    > & { unref?: () => void };
+    timerWithUnref.unref?.();
+  }
+
   const events: ExtensionEvents = {
-    emit(name, event) {
+    async emit(name, event) {
       if (loadState.isLoading || !loadState.hasExtensionSources) {
         // Events are best-effort hooks; do not deliver them while the extension
         // registry is unavailable or in flux.
-        return Promise.resolve(emptyEventEmissionResult(name));
+        return emptyEventEmissionResult(name);
       }
-      return engine.emitEvent(name, event);
+      const result = await engine.emitEvent(name, event);
+      return result;
     },
   };
 
@@ -124,6 +175,7 @@ export function createExtensionAdapter(
 
   const reload = async () => {
     if (disposed) return;
+    clearPendingDiagnosticsWrite();
 
     const previousSnapshot = engine.getSnapshot();
     const previousHadStatuslineRenderer =
@@ -140,19 +192,7 @@ export function createExtensionAdapter(
     if (disposed) return;
 
     const nextRegistry = engine.getSnapshot();
-    if (nextRegistry.sources.some((source) => source.files.length > 0)) {
-      try {
-        writeExtensionDiagnosticsLatestFile(nextRegistry.diagnostics, {
-          rootDirectory: diagnosticsRootDirectory,
-        });
-      } catch (error) {
-        debugLog(
-          "extensions",
-          "failed to write extension diagnostics: %s",
-          error instanceof Error ? error.message : String(error),
-        );
-      }
-    }
+    writeLatestDiagnostics();
 
     debugLog(
       "extensions",
@@ -192,6 +232,7 @@ export function createExtensionAdapter(
   return {
     dispose() {
       if (disposed) return;
+      flushPendingDiagnosticsWrite();
       disposed = true;
       engine.dispose();
       unsubscribeEngine();

--- a/src/extensions/extension-engine.ts
+++ b/src/extensions/extension-engine.ts
@@ -230,6 +230,7 @@ export interface CreateExtensionEngineOptions
   getBackend?: () => Backend | undefined;
   builtinCommandIds?: Iterable<string>;
   capabilities?: ExtensionCapabilities;
+  onDiagnostic?: (diagnostic: ExtensionDiagnostic) => void;
   reservedToolNames?: Iterable<string>;
 }
 
@@ -1339,7 +1340,7 @@ export function disposeLocalExtensions(registry: LocalExtensionRegistry): void {
 export function createExtensionEngine(
   options: CreateExtensionEngineOptions,
 ): ExtensionEngine {
-  const { getBackend, ...extensionOptions } = options;
+  const { getBackend, onDiagnostic, ...extensionOptions } = options;
   let generation = 0;
   let disposed = false;
   const capabilities = resolveExtensionCapabilities(
@@ -1394,6 +1395,7 @@ export function createExtensionEngine(
         if (loadingRegistry && loadGeneration === generation) {
           activeRegistry = loadingRegistry;
           publish();
+          onDiagnostic?.(diagnostic);
           return;
         }
         // Stale handles from a prior generation report through their old
@@ -1401,6 +1403,7 @@ export function createExtensionEngine(
         // snapshot without reviving the old registry.
         appendExtensionDiagnostic(activeRegistry, diagnostic);
         publish();
+        onDiagnostic?.(diagnostic);
       },
     });
     loadingRegistry = nextRegistry;
@@ -1438,6 +1441,7 @@ export function createExtensionEngine(
         payload,
         getContext,
         invocationBackend,
+        onDiagnostic,
       );
       if (result.diagnostics.length > 0) {
         publish();


### PR DESCRIPTION
## Summary
- schedule latest-file writes for runtime extension diagnostics
- default runtime diagnostics write window to 30s
- coalesce diagnostics into the pending write without resetting the timer, so continuous failures cannot starve writes
- keep reload writes immediate and cancel pending runtime writes before reload
- flush a pending runtime diagnostics write on adapter dispose
- expose engine `onDiagnostic` so event and stale-handle diagnostics can share the same scheduling path

## Notes
- no agent/system-reminder notification yet
- `diagnosticsWriteDelayMs` is a test seam so tests do not wait 30s
- writes still no-op when no extension sources exist

## Tests
- `bun test src/extensions/extension-adapter.test.ts src/extensions/extension-engine.test.ts`
- `bun run typecheck`
- `bun run check`
- `git diff --check`