### PR TITLE
fix(agent): preserve Letta Code origin tags

### DIFF
--- a/src/agent/create.ts
+++ b/src/agent/create.ts
@@ -382,7 +382,7 @@ export async function createAgent(
 
   // Always retrieve the agent to ensure we get the full state with populated memory blocks
   const fullAgent = await backend.retrieveAgent(agent.id, {
-    include: ["agent.managed_group"],
+    include: ["agent.managed_group", "agent.tags"],
   });
 
   // Update persona block for sleeptime agent

--- a/src/agent/personality.ts
+++ b/src/agent/personality.ts
@@ -483,9 +483,12 @@ export async function enableMemfsForCreatedAgent(params: {
       }
     }
     const tags = Array.from(new Set([...currentTags, LETTA_CODE_ORIGIN_TAG]));
-    if (!tags.includes(GIT_MEMORY_ENABLED_TAG)) {
+    if (
+      !tags.includes(GIT_MEMORY_ENABLED_TAG) ||
+      !currentTags.includes(LETTA_CODE_ORIGIN_TAG)
+    ) {
       await client.agents.update(agentId, {
-        tags: [...tags, GIT_MEMORY_ENABLED_TAG],
+        tags: Array.from(new Set([...tags, GIT_MEMORY_ENABLED_TAG])),
       });
     }
     settingsManager.setMemfsEnabled(agentId, true);

--- a/src/agent/personality.ts
+++ b/src/agent/personality.ts
@@ -2,8 +2,8 @@ import { execFile as execFileCb } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
-import { getBackend } from "@/backend";
 import { LETTA_CODE_ORIGIN_TAG } from "@/agent/system-prompt-versioning";
+import { getBackend } from "@/backend";
 import { settingsManager } from "@/settings-manager";
 import type { CreateAgentOptions } from "./create";
 import { getDefaultMemoryBlocks, parseMdxFrontmatter } from "./memory";
@@ -482,9 +482,7 @@ export async function enableMemfsForCreatedAgent(params: {
         currentTags = [];
       }
     }
-    const tags = Array.from(
-      new Set([...currentTags, LETTA_CODE_ORIGIN_TAG]),
-    );
+    const tags = Array.from(new Set([...currentTags, LETTA_CODE_ORIGIN_TAG]));
     if (!tags.includes(GIT_MEMORY_ENABLED_TAG)) {
       await client.agents.update(agentId, {
         tags: [...tags, GIT_MEMORY_ENABLED_TAG],

--- a/src/agent/personality.ts
+++ b/src/agent/personality.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import { getBackend } from "@/backend";
+import { LETTA_CODE_ORIGIN_TAG } from "@/agent/system-prompt-versioning";
 import { settingsManager } from "@/settings-manager";
 import type { CreateAgentOptions } from "./create";
 import { getDefaultMemoryBlocks, parseMdxFrontmatter } from "./memory";
@@ -470,7 +471,20 @@ export async function enableMemfsForCreatedAgent(params: {
   try {
     const { getClient } = await import("@/backend/api/client");
     const client = await getClient();
-    const tags = agentTags || [];
+    let currentTags = agentTags;
+    if (!currentTags) {
+      try {
+        const agent = await client.agents.retrieve(agentId, {
+          include: ["agent.tags"],
+        });
+        currentTags = agent.tags ?? [];
+      } catch {
+        currentTags = [];
+      }
+    }
+    const tags = Array.from(
+      new Set([...currentTags, LETTA_CODE_ORIGIN_TAG]),
+    );
     if (!tags.includes(GIT_MEMORY_ENABLED_TAG)) {
       await client.agents.update(agentId, {
         tags: [...tags, GIT_MEMORY_ENABLED_TAG],

--- a/src/agent/system-prompt-versioning.ts
+++ b/src/agent/system-prompt-versioning.ts
@@ -12,6 +12,8 @@ import {
 } from "./prompt-assets";
 
 const SYSTEM_PROMPT_HASH_PREFIX = "sha256:";
+export const LETTA_CODE_ORIGIN_TAG = "origin:letta-code";
+export const LETTA_CODE_SUBAGENT_TAG = "role:subagent";
 
 type ManagedPrompt = {
   preset: string;
@@ -81,7 +83,10 @@ export function getMemoryPromptModeForAgent(agentId: string): MemoryPromptMode {
 
 function isLettaCodePrimaryAgent(agent: AgentState): boolean {
   const tags = agent.tags ?? [];
-  return tags.includes("origin:letta-code") && !tags.includes("role:subagent");
+  return (
+    tags.includes(LETTA_CODE_ORIGIN_TAG) &&
+    !tags.includes(LETTA_CODE_SUBAGENT_TAG)
+  );
 }
 
 function findMatchingCurrentPreset(
@@ -192,6 +197,29 @@ export function decideManagedSystemPromptUpdate(input: {
     kind: "track",
     prompt: managedPrompt(matchingPreset, memoryMode, currentSystemPrompt),
   };
+}
+
+export async function ensureLettaCodeOriginTag(
+  agent: AgentState,
+): Promise<AgentState> {
+  const backend = getBackend();
+  const agentWithTags = agent.tags
+    ? agent
+    : await backend.retrieveAgent(agent.id, { include: ["agent.tags"] });
+  const tags = agentWithTags.tags ?? [];
+
+  if (tags.includes(LETTA_CODE_ORIGIN_TAG)) {
+    return agentWithTags;
+  }
+
+  const nextTags = [...tags, LETTA_CODE_ORIGIN_TAG];
+  const updatedAgent = await backend.updateAgent(agent.id, { tags: nextTags });
+
+  return {
+    ...agentWithTags,
+    ...updatedAgent,
+    tags: updatedAgent.tags ?? nextTags,
+  } as AgentState;
 }
 
 export function scheduleManagedSystemPromptUpdate({

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1499,8 +1499,21 @@ export async function handleHeadlessCommand(
   // This updates only agents whose current prompt still matches the stored
   // managed prompt hash, so custom edits are preserved.
   if (isResumingAgent && !systemPromptPreset) {
-    const { getMemoryPromptModeForAgent, scheduleManagedSystemPromptUpdate } =
-      await import("@/agent/system-prompt-versioning");
+    const {
+      ensureLettaCodeOriginTag,
+      getMemoryPromptModeForAgent,
+      scheduleManagedSystemPromptUpdate,
+    } = await import("@/agent/system-prompt-versioning");
+    try {
+      agent = await ensureLettaCodeOriginTag(agent);
+    } catch (error) {
+      debugWarn(
+        "headless startup",
+        `Failed to ensure Letta Code origin tag for ${agent.id}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
     scheduleManagedSystemPromptUpdate({
       agent,
       memoryMode: getMemoryPromptModeForAgent(agent.id),

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1504,8 +1504,9 @@ export async function handleHeadlessCommand(
       getMemoryPromptModeForAgent,
       scheduleManagedSystemPromptUpdate,
     } = await import("@/agent/system-prompt-versioning");
+    let taggedAgent = agent;
     try {
-      agent = await ensureLettaCodeOriginTag(agent);
+      taggedAgent = await ensureLettaCodeOriginTag(agent);
     } catch (error) {
       debugWarn(
         "headless startup",
@@ -1515,8 +1516,8 @@ export async function handleHeadlessCommand(
       );
     }
     scheduleManagedSystemPromptUpdate({
-      agent,
-      memoryMode: getMemoryPromptModeForAgent(agent.id),
+      agent: taggedAgent,
+      memoryMode: getMemoryPromptModeForAgent(taggedAgent.id),
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2694,16 +2694,32 @@ async function main(): Promise<void> {
         // stored managed prompt hash, so custom edits are preserved.
         if (resuming && !systemPromptPreset) {
           const {
+            ensureLettaCodeOriginTag,
             getMemoryPromptModeForAgent,
             scheduleManagedSystemPromptUpdate,
           } = await import("@/agent/system-prompt-versioning");
-          scheduleManagedSystemPromptUpdate({
-            agent,
-            memoryMode: getMemoryPromptModeForAgent(agent.id),
-            onUpdated: (updatedAgent) => {
-              setAgentState(updatedAgent);
-            },
-          });
+          void ensureLettaCodeOriginTag(agent)
+            .catch((error) => {
+              import("@/utils/debug").then(({ debugWarn }) =>
+                debugWarn(
+                  "startup",
+                  `Failed to ensure Letta Code origin tag for ${agent.id}: ${
+                    error instanceof Error ? error.message : String(error)
+                  }`,
+                ),
+              );
+              return agent;
+            })
+            .then((taggedAgent) => {
+              setAgentState(taggedAgent);
+              scheduleManagedSystemPromptUpdate({
+                agent: taggedAgent,
+                memoryMode: getMemoryPromptModeForAgent(taggedAgent.id),
+                onUpdated: (updatedAgent) => {
+                  setAgentState(updatedAgent);
+                },
+              });
+            });
         }
       }
 

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -792,7 +792,7 @@ class TelemetryManager {
         },
         { signal: AbortSignal.timeout(5000) },
       );
-    } catch (error) {
+    } catch (_error) {
       // If flush fails, put events back in queue, but don't throw error
       this.events.unshift(...eventsToSend);
     }

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -524,10 +524,30 @@ export async function handleIncomingMessage(
         );
         if (agentId) {
           try {
-            cachedAgent = (await getBackend().retrieveAgent(
-              agentId,
-            )) as AgentState;
-          } catch {
+            cachedAgent = (await getBackend().retrieveAgent(agentId, {
+              include: ["agent.tags"],
+            })) as AgentState;
+
+            const {
+              ensureLettaCodeOriginTag,
+              getMemoryPromptModeForAgent,
+              scheduleManagedSystemPromptUpdate,
+            } = await import("@/agent/system-prompt-versioning");
+            cachedAgent = await ensureLettaCodeOriginTag(cachedAgent);
+            scheduleManagedSystemPromptUpdate({
+              agent: cachedAgent,
+              memoryMode: getMemoryPromptModeForAgent(cachedAgent.id),
+              onUpdated: (updatedAgent) => {
+                cachedAgent = updatedAgent;
+              },
+            });
+          } catch (error) {
+            debugWarn(
+              "listen",
+              `Failed to ensure Letta Code agent metadata for ${agentId}: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            );
             // Best-effort only. If the fetch fails, reminder and tool prep
             // will fall back to the existing null/placeholder behavior.
           }


### PR DESCRIPTION
## Summary
- keep `origin:letta-code` when desktop/personality-created agents enable git memory
- ensure resumed TUI/headless agents are tagged before managed system prompt version checks
- ensure websocket/listener turns tag agents as Letta Code agents and run managed prompt updates

## Testing
- `bun test src/agent/system-prompt-versioning.test.ts src/agent/personality.test.ts`
- `bunx biome check src/agent/system-prompt-versioning.ts src/agent/personality.ts src/agent/create.ts src/index.ts src/headless.ts src/websocket/listener/turn.ts`

Note: `bun run typecheck` currently fails on unrelated existing missing `@pierre/diffs` types in `src/web/generate-diff-viewer.ts`.