### PR TITLE
fix(local): compact before context overflow

### DIFF
--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -39,6 +39,8 @@ import type {
   ProviderTurnInput,
 } from "./provider-turn-executor";
 import {
+  contextCompactionThreshold,
+  estimateProviderContextTokens,
   providerLettaChunk,
   providerLocalMessage,
   providerStreamPart,
@@ -437,9 +439,24 @@ function isModelOutputEvent(event: ProviderStreamEvent): boolean {
 
 function isOverflowError(error: unknown, contextWindow?: number): boolean {
   if (error instanceof PiProviderError) {
-    return isContextOverflow(error.assistant, contextWindow);
+    return (
+      isContextOverflow(error.assistant, contextWindow) ||
+      isContextWindowOverflowError(error) ||
+      isContextWindowOverflowError(error.assistant)
+    );
   }
   return isContextWindowOverflowError(error);
+}
+
+function usageFromContextEstimate(contextTokens: number): Usage {
+  return {
+    input: contextTokens,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: contextTokens,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
 }
 
 function defaultStream(
@@ -483,6 +500,31 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
       summary: compaction.summary,
       ...(compaction.stats ? { compaction_stats: compaction.stats } : {}),
     } as never);
+  }
+
+  private async compactBeforeProviderCall(input: ProviderTurnInput): Promise<{
+    uiMessages: LocalMessage[];
+    summary: string;
+    stats?: LocalCompactionStats;
+  } | null> {
+    if (!this.onContextUsage) return null;
+
+    const contextTokens = estimateProviderContextTokens(input);
+    const resolved = await resolvePiModelForAgent(
+      input.agent.model,
+      input.agent.model_settings,
+      { localProviderAuthStorageDir: this.localProviderAuthStorageDir },
+    );
+    const threshold = contextCompactionThreshold(resolved.model.contextWindow);
+    if (
+      contextTokens === undefined ||
+      threshold === undefined ||
+      contextTokens <= threshold
+    ) {
+      return null;
+    }
+
+    return this.onContextUsage(input, usageFromContextEstimate(contextTokens));
   }
 
   private async *streamOnce(
@@ -567,6 +609,10 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
           }
         }
         if (part.type === "done") {
+          if (isContextOverflow(part.message, resolved.model.contextWindow)) {
+            streamError = new PiProviderError(part.message);
+            break;
+          }
           assertAssistantHasOutputContent(part.message);
           finalMessage = part.message;
           yield providerLocalMessage(
@@ -578,6 +624,9 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
 
       if (streamError) throw streamError;
       finalMessage ??= await result.result();
+      if (isContextOverflow(finalMessage, resolved.model.contextWindow)) {
+        throw new PiProviderError(finalMessage);
+      }
       assertAssistantHasOutputContent(finalMessage);
       if (
         finalMessage.stopReason === "error" ||
@@ -598,10 +647,21 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
 
   async *stream(input: ProviderTurnInput): AsyncIterable<ProviderStreamEvent> {
     let activeInput = input;
+    let preflightCompactionChecked = false;
     let contextOverflowCompactions = 0;
     let transientRetries = 0;
 
     while (true) {
+      if (!preflightCompactionChecked) {
+        preflightCompactionChecked = true;
+        const compaction = await this.compactBeforeProviderCall(activeInput);
+        if (compaction) {
+          activeInput = { ...activeInput, uiMessages: compaction.uiMessages };
+          yield* this.emitCompactionChunks(compaction, "context_window_limit");
+          continue;
+        }
+      }
+
       let emittedModelOutput = false;
       try {
         for await (const event of this.streamOnce(activeInput)) {

--- a/src/backend/dev/provider-turn-executor.ts
+++ b/src/backend/dev/provider-turn-executor.ts
@@ -38,6 +38,8 @@ export type ProviderStreamEvent =
   | { type: "letta-chunk"; chunk: LettaStreamingResponse }
   | { type: "error"; error: unknown };
 
+const LOCAL_CONTEXT_COMPACTION_RESERVE_TOKENS = 16_384;
+
 export function providerStreamPart(
   part: ProviderStreamPart,
 ): ProviderStreamEvent {
@@ -181,6 +183,38 @@ export function estimateProviderContextTokens(
   const toolTokens = estimateSerializedTokens(input.clientTools);
   const total = systemPromptTokens + messageTokens + toolTokens;
   return total > 0 ? total : undefined;
+}
+
+export function contextCompactionThreshold(
+  contextWindow: number | undefined,
+): number | undefined {
+  if (
+    typeof contextWindow !== "number" ||
+    !Number.isFinite(contextWindow) ||
+    contextWindow <= 0
+  ) {
+    return undefined;
+  }
+
+  // Match pi-tui's default 16k generation reserve for large-context models,
+  // but cap the reserve on small local models so they do not compact every turn.
+  const reserveTokens = Math.min(
+    LOCAL_CONTEXT_COMPACTION_RESERVE_TOKENS,
+    Math.max(1, Math.floor(contextWindow * 0.2)),
+  );
+  return Math.max(0, contextWindow - reserveTokens);
+}
+
+export function shouldCompactForContextUsage(input: {
+  contextTokens: number | undefined;
+  contextWindow: number | undefined;
+}): boolean {
+  const threshold = contextCompactionThreshold(input.contextWindow);
+  return (
+    input.contextTokens !== undefined &&
+    threshold !== undefined &&
+    input.contextTokens > threshold
+  );
 }
 
 function createUsageStatisticsChunk(

--- a/src/backend/local/local-backend.ts
+++ b/src/backend/local/local-backend.ts
@@ -28,6 +28,7 @@ import {
   contextTokensFromUsage,
   estimateProviderContextTokens,
   ProviderTurnExecutor,
+  shouldCompactForContextUsage,
 } from "@/backend/dev/provider-turn-executor";
 import { isRecord } from "@/utils/type-guards";
 import {
@@ -516,11 +517,7 @@ export class LocalBackend extends HeadlessBackend {
       input.conversationId,
       input.agentId,
     );
-    if (
-      contextTokens === undefined ||
-      contextWindow === undefined ||
-      contextTokens <= contextWindow
-    ) {
+    if (!shouldCompactForContextUsage({ contextTokens, contextWindow })) {
       return null;
     }
 

--- a/src/backend/pi-stream-adapter.test.ts
+++ b/src/backend/pi-stream-adapter.test.ts
@@ -544,6 +544,132 @@ describe("PiStreamAdapter", () => {
     expect(events.some((event) => event.type === "local-message")).toBe(true);
   });
 
+  test("compacts before provider call when estimated context enters reserve", async () => {
+    let calls = 0;
+    let compactionCalls = 0;
+    let capturedContext: Context | undefined;
+    const stream: PiStreamFunction = (
+      _model: Model<string>,
+      context: Context,
+    ) => {
+      calls += 1;
+      capturedContext = context;
+      const finalMessage = assistantMessage();
+      return streamFromEvents(
+        [{ type: "done", reason: "stop", message: finalMessage }],
+        finalMessage,
+      );
+    };
+
+    const adapter = new PiStreamAdapter({
+      stream,
+      onContextUsage: async (_input, usage) => {
+        if (usage.totalTokens === 0) return null;
+        compactionCalls += 1;
+        expect(usage.totalTokens).toBeGreaterThan(900);
+        return {
+          uiMessages: [
+            {
+              id: "ui-msg-summary",
+              role: "user",
+              content: "compacted summary",
+              timestamp: Date.now(),
+            },
+          ],
+          summary: "compacted summary",
+          stats: { trigger: "context_window_limit" },
+        };
+      },
+    });
+
+    const baseInput = input();
+    const events: ProviderStreamEvent[] = [];
+    for await (const event of adapter.stream({
+      ...baseInput,
+      agent: {
+        ...baseInput.agent,
+        model_settings: {
+          ...baseInput.agent.model_settings,
+          context_window_limit: 1000,
+        },
+      },
+      uiMessages: [
+        {
+          id: "ui-msg-large",
+          role: "user",
+          content: "x".repeat(6000),
+          timestamp: Date.now(),
+        },
+      ],
+    })) {
+      events.push(event);
+    }
+
+    expect(compactionCalls).toBe(1);
+    expect(calls).toBe(1);
+    expect(capturedContext?.messages).toEqual([
+      {
+        role: "user",
+        content: "compacted summary",
+        timestamp: expect.any(Number),
+      },
+    ]);
+    expect(events[0]).toMatchObject({
+      type: "letta-chunk",
+      chunk: { message_type: "event_message", event_type: "compaction" },
+    });
+    expect(events.some((event) => event.type === "local-message")).toBe(true);
+  });
+
+  test("compacts and retries exact Codex context_length_exceeded errors", async () => {
+    let calls = 0;
+    let overflowCompactions = 0;
+    const codexOverflow = assistantErrorMessage(
+      'Codex error:\n{"type":"error","error":{"type":"invalid_request_error","code":"context_length_exceeded","message":"Your input exceeds\nthe context window of this model. Please adjust your input and try again.","param":"input"},"sequence_number":2}',
+    );
+
+    const stream: PiStreamFunction = () => {
+      calls += 1;
+      if (calls === 1) {
+        return streamFromEvents(
+          [{ type: "error", reason: "error", error: codexOverflow }],
+          codexOverflow,
+        );
+      }
+
+      const finalMessage = assistantMessage();
+      return streamFromEvents(
+        [{ type: "done", reason: "stop", message: finalMessage }],
+        finalMessage,
+      );
+    };
+
+    const adapter = new PiStreamAdapter({
+      stream,
+      onContextWindowOverflow: async (turnInput) => {
+        overflowCompactions += 1;
+        return {
+          uiMessages: turnInput.uiMessages,
+          summary: "compacted after overflow",
+          stats: { trigger: "context_window_overflow" },
+        };
+      },
+    });
+
+    const events: ProviderStreamEvent[] = [];
+    for await (const event of adapter.stream(input())) {
+      events.push(event);
+    }
+
+    expect(calls).toBe(2);
+    expect(overflowCompactions).toBe(1);
+    expect(events[0]).toMatchObject({
+      type: "letta-chunk",
+      chunk: { message_type: "event_message", event_type: "compaction" },
+    });
+    expect(events.some((event) => event.type === "local-message")).toBe(true);
+  });
+
   test("retries empty local provider responses before persisting model output", async () => {
     let calls = 0;
     const stream: PiStreamFunction = () => {


### PR DESCRIPTION
## Summary
- add a Pi-style reserved-context threshold for local compaction instead of waiting for the full context window
- run a preflight compaction before provider calls when estimated context enters that reserve
- harden Codex overflow detection/retry for nested `context_length_exceeded` errors and silent overflow messages

## Why
Letta was only compacting after provider usage exceeded the entire context window. For Codex/ChatGPT, that means the next request could already be over the provider limit before Letta ever compacted. Pi TUI keeps a generation reserve and compacts before sending the over-limit request, so it avoids surfacing `context_length_exceeded`.

## Test plan
- `bun test src/backend/pi-stream-adapter.test.ts src/backend/provider-turn-executor.test.ts`
- `bun test src/backend/local-backend.test.ts`
- `bun run typecheck`
- `bunx --bun @biomejs/biome@2.2.5 check src/backend/dev/pi-stream-adapter.ts src/backend/dev/provider-turn-executor.ts src/backend/local/local-backend.ts src/backend/pi-stream-adapter.test.ts`
