### PR TITLE
feat(extensions): add diagnostic report API

### DIFF
--- a/src/extensions/extension-adapter.test.ts
+++ b/src/extensions/extension-adapter.test.ts
@@ -400,6 +400,63 @@ describe("extension adapter", () => {
     }
   });
 
+  test("runtime diagnostic reports are written", async () => {
+    const root = createTempDir();
+
+    try {
+      const extensionDir = path.join(root, "global-extensions");
+      const diagnosticsRoot = path.join(root, "diagnostics");
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        path.join(extensionDir, "events.ts"),
+        `export default function(letta) {
+          letta.events.on("conversation_open", () => {
+            letta.diagnostics.report({ message: "missing optional env" });
+          });
+        }`,
+      );
+
+      const adapter = createExtensionAdapter({
+        cacheDirectory: path.join(root, "extension-cache"),
+        diagnosticsRootDirectory: diagnosticsRoot,
+        diagnosticsWriteDelayMs: 5,
+        getClient: async () => ({}) as unknown as Letta,
+        globalExtensionsDirectory: extensionDir,
+        initialContext: createExtensionContext(),
+      });
+
+      await adapter.reload();
+      await adapter.events.emit("conversation_open", {
+        agentId: "agent-1",
+        agentName: "Amelia",
+        conversationId: "conversation-1",
+        reason: "startup",
+      });
+      await sleep(20);
+
+      expect(
+        readJsonFile(getExtensionDiagnosticsLatestFilePath(diagnosticsRoot)),
+      ).toMatchObject({
+        report: {
+          diagnostics: [
+            {
+              errorName: "ExtensionDiagnosticReport",
+              message: "missing optional env",
+              phase: "report",
+              severity: "error",
+            },
+          ],
+          errorCount: 1,
+          warningCount: 0,
+        },
+      });
+
+      adapter.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("loads extensions and dispatches events with fresh context and backend", async () => {
     const root = createTempDir();
     const testGlobal = globalThis as ExtensionAdapterTestGlobal;

--- a/src/extensions/extension-diagnostics.test.ts
+++ b/src/extensions/extension-diagnostics.test.ts
@@ -26,6 +26,9 @@ function createError(message: string): Error {
 describe("extension diagnostics", () => {
   test("classifies diagnostic phases for future surfacing", () => {
     expect(getExtensionDiagnosticSeverity("command_override")).toBe("warning");
+    expect(getExtensionDiagnosticSeverity("report")).toBe("error");
+    expect(getExtensionDiagnosticSeverity("report", "warning")).toBe("warning");
+    expect(getExtensionDiagnosticSeverity("report", "error")).toBe("error");
     expect(getExtensionDiagnosticSeverity("activate")).toBe("error");
     expect(getExtensionDiagnosticSeverity("event")).toBe("error");
   });
@@ -75,8 +78,16 @@ describe("extension diagnostics", () => {
       phase: "activate",
       timestamp: 200,
     };
+    const reportError = new Error("missing optional env");
+    reportError.stack = undefined;
+    const report: ExtensionDiagnostic = {
+      error: reportError,
+      owner,
+      phase: "report",
+      timestamp: 300,
+    };
 
-    expect(createExtensionDiagnosticsReport([warning, error])).toEqual({
+    expect(createExtensionDiagnosticsReport([warning, error, report])).toEqual({
       diagnostics: [
         {
           capability: { id: "reload", kind: "command" },
@@ -97,8 +108,16 @@ describe("extension diagnostics", () => {
           stack: "Error: activation failed\n    at extension.ts:1:1",
           timestamp: 200,
         },
+        {
+          errorName: "Error",
+          extension: owner,
+          message: "missing optional env",
+          phase: "report",
+          severity: "error",
+          timestamp: 300,
+        },
       ],
-      errorCount: 1,
+      errorCount: 2,
       warningCount: 1,
     });
   });

--- a/src/extensions/extension-diagnostics.ts
+++ b/src/extensions/extension-diagnostics.ts
@@ -1,10 +1,11 @@
 import type {
   ExtensionDiagnostic,
   ExtensionDiagnosticPhase,
+  ExtensionDiagnosticSeverity,
   ExtensionOwner,
 } from "@/extensions/types";
 
-export type ExtensionDiagnosticSeverity = "error" | "warning";
+export type { ExtensionDiagnosticSeverity } from "@/extensions/types";
 
 export interface ExtensionDiagnosticCollector {
   diagnostics: ExtensionDiagnostic[];
@@ -29,10 +30,13 @@ export interface ExtensionDiagnosticsReport {
 
 export function getExtensionDiagnosticSeverity(
   phase: ExtensionDiagnosticPhase,
+  severity?: ExtensionDiagnosticSeverity,
 ): ExtensionDiagnosticSeverity {
   switch (phase) {
     case "command_override":
       return "warning";
+    case "report":
+      return severity ?? "error";
     default:
       return "error";
   }
@@ -45,9 +49,12 @@ export function isExtensionDiagnosticErrorPhase(
 }
 
 export function isExtensionDiagnosticError(
-  diagnostic: Pick<ExtensionDiagnostic, "phase">,
+  diagnostic: Pick<ExtensionDiagnostic, "phase" | "severity">,
 ): boolean {
-  return isExtensionDiagnosticErrorPhase(diagnostic.phase);
+  return (
+    getExtensionDiagnosticSeverity(diagnostic.phase, diagnostic.severity) ===
+    "error"
+  );
 }
 
 export function getExtensionErrorDiagnostics(
@@ -63,7 +70,10 @@ export function createExtensionDiagnosticsReport(
   let warningCount = 0;
 
   const entries = diagnostics.map((diagnostic) => {
-    const severity = getExtensionDiagnosticSeverity(diagnostic.phase);
+    const severity = getExtensionDiagnosticSeverity(
+      diagnostic.phase,
+      diagnostic.severity,
+    );
     if (severity === "error") {
       errorCount += 1;
     } else {

--- a/src/extensions/extension-engine.test.ts
+++ b/src/extensions/extension-engine.test.ts
@@ -949,6 +949,49 @@ describe("extension engine", () => {
     }
   });
 
+  test("lets extensions report diagnostics intentionally", async () => {
+    const root = createTempDir();
+    try {
+      const extensionDir = path.join(root, "global-extensions");
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        path.join(extensionDir, "reports.ts"),
+        `export default function(letta) {
+          letta.diagnostics.report({ message: "missing optional env" });
+          letta.diagnostics.report({ message: "configuration failed", severity: "error" });
+        }`,
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+      const diagnostics = engine.getSnapshot().diagnostics;
+
+      expect(diagnostics).toMatchObject([
+        {
+          error: expect.objectContaining({
+            message: "missing optional env",
+            name: "ExtensionDiagnosticReport",
+          }),
+          phase: "report",
+          severity: "error",
+        },
+        {
+          error: expect.objectContaining({
+            message: "configuration failed",
+            name: "ExtensionDiagnosticReport",
+          }),
+          phase: "report",
+          severity: "error",
+        },
+      ]);
+      expect(getExtensionErrorDiagnostics(diagnostics)).toHaveLength(2);
+
+      engine.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("loads extension-provided tools with owner metadata", async () => {
     const root = createTempDir();
     try {

--- a/src/extensions/extension-engine.ts
+++ b/src/extensions/extension-engine.ts
@@ -51,6 +51,8 @@ import type {
   ExtensionCommandRegistration,
   ExtensionContext,
   ExtensionDiagnostic,
+  ExtensionDiagnosticReportOptions,
+  ExtensionDiagnosticSeverity,
   ExtensionEventContext,
   ExtensionEventEmissionResult,
   ExtensionEventHandler,
@@ -138,6 +140,9 @@ export interface LettaExtensionApi {
       name: TName,
       handler: ExtensionEventHandler<TName>,
     ) => LettaExtensionDisposer;
+  };
+  diagnostics: {
+    report: (diagnostic: ExtensionDiagnosticReportOptions) => void;
   };
   ui: {
     clearPanel: (id: string) => void;
@@ -880,6 +885,49 @@ function createLettaExtensionApi(
     return () => unregisterProvider(name);
   };
 
+  const normalizeReportedDiagnostic = (
+    diagnostic: ExtensionDiagnosticReportOptions,
+  ): { message: string; severity: ExtensionDiagnosticSeverity } => {
+    if (!diagnostic || typeof diagnostic !== "object") {
+      throw new Error("Extension diagnostic report must be an object");
+    }
+    if (typeof diagnostic.message !== "string") {
+      throw new Error("Extension diagnostic report must include a message");
+    }
+    const message = diagnostic.message.trim();
+    if (message.length === 0) {
+      throw new Error("Extension diagnostic report message cannot be empty");
+    }
+    if (
+      diagnostic.severity !== undefined &&
+      diagnostic.severity !== "error" &&
+      diagnostic.severity !== "warning"
+    ) {
+      throw new Error(
+        "Extension diagnostic severity must be 'error' or 'warning'",
+      );
+    }
+    return { message, severity: diagnostic.severity ?? "error" };
+  };
+
+  const reportDiagnostic = (diagnostic: ExtensionDiagnosticReportOptions) => {
+    if (!guardLive(undefined)) return;
+    const normalized = normalizeReportedDiagnostic(diagnostic);
+    const error = new Error(normalized.message);
+    error.name = "ExtensionDiagnosticReport";
+    error.stack = undefined;
+    recordExtensionDiagnostic(
+      registry,
+      {
+        error,
+        owner,
+        phase: "report",
+        severity: normalized.severity,
+      },
+      onDiagnostic,
+    );
+  };
+
   const onEvent = <TName extends ExtensionEventName>(
     name: TName,
     handler: ExtensionEventHandler<TName>,
@@ -1004,6 +1052,9 @@ function createLettaExtensionApi(
     events: {
       off: unregisterEvent,
       on: onEvent,
+    },
+    diagnostics: {
+      report: reportDiagnostic,
     },
     ui: {
       clearPanel,

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -268,7 +268,15 @@ export type ExtensionDiagnosticPhase =
   | "command_override"
   | "dispose"
   | "event"
+  | "report"
   | "stale_handle";
+
+export type ExtensionDiagnosticSeverity = "error" | "warning";
+
+export interface ExtensionDiagnosticReportOptions {
+  message: string;
+  severity?: ExtensionDiagnosticSeverity;
+}
 
 export interface ExtensionDiagnostic {
   capability?: {
@@ -278,6 +286,7 @@ export interface ExtensionDiagnostic {
   error: Error;
   owner: ExtensionOwner;
   phase: ExtensionDiagnosticPhase;
+  severity?: ExtensionDiagnosticSeverity;
   timestamp: number;
 }
 


### PR DESCRIPTION
## Summary
- add `letta.diagnostics.report({ message, severity })` for extension-authored diagnostics
- default reported diagnostics to `error`, with optional `severity: "warning"`
- serialize reported diagnostics through the existing latest diagnostics file pipeline
- keep reported diagnostics stackless since they are intentional reports, not thrown errors

## Notes
- no agent/system-reminder notification yet
- no read API yet
- no extra fields beyond message/severity

## Tests
- `bun test src/extensions/extension-diagnostics.test.ts src/extensions/extension-engine.test.ts src/extensions/extension-adapter.test.ts src/extensions/extension-diagnostics-file.test.ts`
- `bun run typecheck`
- `bun run check`
- `git diff --check`