### PR TITLE
fix(extensions): cap retained diagnostics

### DIFF
--- a/src/extensions/extension-diagnostics.test.ts
+++ b/src/extensions/extension-diagnostics.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
+  appendExtensionDiagnostic,
   createExtensionDiagnosticsReport,
+  EXTENSION_DIAGNOSTICS_MAX_COUNT,
+  EXTENSION_DIAGNOSTICS_RESET_COUNT,
   type ExtensionDiagnosticCollector,
   getExtensionDiagnosticSeverity,
   getExtensionErrorDiagnostics,
@@ -61,6 +64,40 @@ describe("extension diagnostics", () => {
     expect(seen).toEqual([warning]);
     expect(warning.timestamp).toEqual(expect.any(Number));
     expect(error.timestamp).toEqual(expect.any(Number));
+  });
+
+  test("caps diagnostics on append with hysteresis", () => {
+    const registry: ExtensionDiagnosticCollector = {
+      diagnostics: [],
+    };
+    const owner = createOwner();
+
+    for (let index = 0; index <= EXTENSION_DIAGNOSTICS_MAX_COUNT; index += 1) {
+      appendExtensionDiagnostic(registry, {
+        error: new Error(`diagnostic ${index}`),
+        owner,
+        phase: "event",
+        timestamp: index,
+      });
+    }
+
+    expect(registry.diagnostics).toHaveLength(
+      EXTENSION_DIAGNOSTICS_RESET_COUNT,
+    );
+    expect(registry.diagnostics[0]?.error.message).toBe("diagnostic 151");
+    expect(registry.diagnostics.at(-1)?.error.message).toBe("diagnostic 200");
+
+    appendExtensionDiagnostic(registry, {
+      error: new Error("diagnostic 201"),
+      owner,
+      phase: "event",
+      timestamp: 201,
+    });
+
+    expect(registry.diagnostics).toHaveLength(
+      EXTENSION_DIAGNOSTICS_RESET_COUNT + 1,
+    );
+    expect(registry.diagnostics.at(-1)?.error.message).toBe("diagnostic 201");
   });
 
   test("creates compact agent reports from diagnostics", () => {

--- a/src/extensions/extension-diagnostics.ts
+++ b/src/extensions/extension-diagnostics.ts
@@ -7,6 +7,9 @@ import type {
 
 export type { ExtensionDiagnosticSeverity } from "@/extensions/types";
 
+export const EXTENSION_DIAGNOSTICS_MAX_COUNT = 200;
+export const EXTENSION_DIAGNOSTICS_RESET_COUNT = 50;
+
 export interface ExtensionDiagnosticCollector {
   diagnostics: ExtensionDiagnostic[];
 }
@@ -106,6 +109,12 @@ export function appendExtensionDiagnostic(
   diagnostic: ExtensionDiagnostic,
 ): void {
   collector.diagnostics.push(diagnostic);
+  if (collector.diagnostics.length > EXTENSION_DIAGNOSTICS_MAX_COUNT) {
+    collector.diagnostics.splice(
+      0,
+      collector.diagnostics.length - EXTENSION_DIAGNOSTICS_RESET_COUNT,
+    );
+  }
 }
 
 export function recordExtensionDiagnostic(


### PR DESCRIPTION
## Summary
- cap retained extension diagnostics at 200 entries
- when the cap is exceeded, trim to the latest 50 diagnostics
- apply the cap on append so both memory and latest-file writes stay bounded

## Tests
- `bun test src/extensions/extension-diagnostics.test.ts src/extensions/extension-engine.test.ts src/extensions/extension-adapter.test.ts src/extensions/extension-diagnostics-file.test.ts`
- `bun run typecheck`
- `bun run check`
- `git diff --check`