### PR TITLE
feat(listener): support remote reload command

### DIFF
--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -1048,6 +1048,7 @@ describe("listen-client parseServerMessage", () => {
     expect(SUPPORTED_REMOTE_COMMANDS).not.toContain("set-max-context");
     expect(SUPPORTED_REMOTE_COMMANDS).toContain("goal");
     expect(SUPPORTED_REMOTE_COMMANDS).toContain("compact");
+    expect(SUPPORTED_REMOTE_COMMANDS).toContain("reload");
 
     const command = parseServerMessage(
       Buffer.from(
@@ -1320,6 +1321,32 @@ describe("listen-client parseServerMessage", () => {
     } finally {
       await rm(storageDir, { recursive: true, force: true });
     }
+  });
+
+  test("runs remote reload execute_command", async () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
+      listener,
+      "agent-reload",
+      "default",
+    );
+    const socket = new MockSocket(WebSocket.OPEN);
+
+    await handleExecuteCommand(
+      {
+        type: "execute_command",
+        command_id: "reload",
+        request_id: "reload-run-1",
+        runtime: { agent_id: "agent-reload", conversation_id: "default" },
+      },
+      socket as unknown as WebSocket,
+      runtime,
+      {},
+    );
+
+    expect(socket.sentPayloads.join("\n")).toContain(
+      "Reloaded settings and local extensions",
+    );
   });
 
   test("rejects legacy cancel_run in hard-cut v2 protocol", () => {

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -10,6 +10,7 @@ import { getMemoryFilesystemRoot } from "@/agent/memory-filesystem";
 import { REMEMBER_PROMPT } from "@/agent/prompt-assets";
 import type { ConversationMessageCompactBody } from "@/backend";
 import { getBackend } from "@/backend";
+import { refreshCustomCommands } from "@/cli/commands/custom";
 import { formatErrorDetails } from "@/cli/helpers/error-formatter";
 import {
   buildGoalContinuationPrompt,
@@ -40,6 +41,7 @@ import type {
   SlashCommandStartMessage,
   StreamDelta,
 } from "@/types/protocol_v2";
+import { debugLog } from "@/utils/debug";
 import {
   getOrCreateConversationPermissionModeStateRef,
   persistPermissionModeMapForRuntime,
@@ -133,6 +135,10 @@ export async function handleExecuteCommand(
         output = await handleCompactCommand(conversationRuntime, trimmedArgs);
         break;
 
+      case "reload":
+        output = await handleReloadCommand();
+        break;
+
       case "context-limit":
       case "set-max-context":
         output = await handleSetMaxContextCommand(
@@ -189,6 +195,24 @@ export async function handleExecuteCommand(
     // "interrupt_in_progress"). Reset it so subsequent user messages drain.
     conversationRuntime.cancelRequested = false;
   }
+}
+
+async function handleReloadCommand(): Promise<string> {
+  settingsManager.clearCaches();
+  await settingsManager.loadProjectSettings();
+  await settingsManager.loadLocalProjectSettings();
+
+  try {
+    refreshCustomCommands();
+  } catch (error) {
+    debugLog(
+      "commands",
+      "refreshCustomCommands failed during /reload:",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+
+  return "Reloaded settings and local extensions";
 }
 
 async function handleUpgradeLettaCodeCommand(opts: {

--- a/src/websocket/listener/listener-constants.ts
+++ b/src/websocket/listener/listener-constants.ts
@@ -12,6 +12,7 @@ export const SUPPORTED_REMOTE_COMMANDS: readonly string[] = [
   "remember",
   "goal",
   "compact",
+  "reload",
   "context-limit",
   "channels",
   "upgrade-letta-code",

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -5,7 +5,6 @@ import {
   estimateSystemPromptTokensFromMemoryDir,
   setSystemPromptDoctorState,
 } from "@/cli/helpers/system-prompt-warning";
-import { settingsManager } from "@/settings-manager";
 import type {
   AbortMessageCommand,
   ApprovalResponseBody,

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -5,6 +5,7 @@ import {
   estimateSystemPromptTokensFromMemoryDir,
   setSystemPromptDoctorState,
 } from "@/cli/helpers/system-prompt-warning";
+import { settingsManager } from "@/settings-manager";
 import type {
   AbortMessageCommand,
   ApprovalResponseBody,


### PR DESCRIPTION
## Summary
- add `/reload` to the listener `execute_command` handler
- advertise `reload` in `SUPPORTED_REMOTE_COMMANDS`
- reload listener settings/project settings/custom command caches

## Tests
- `bun test src/websocket/listen-client-protocol.test.ts src/cli/reload-command.test.ts`
- `bunx --bun @biomejs/biome@2.2.5 check src/websocket/listener/commands.ts src/websocket/listener/listener-constants.ts src/websocket/listener/message-router.ts src/websocket/listener/protocol-inbound.ts src/types/protocol_v2.ts src/websocket/listen-client-protocol.test.ts`