### PR TITLE
refactor(providers): split registered provider runtime helpers

### DIFF
--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -18,10 +18,7 @@ import {
   getRegisteredPiProvider,
   type PiProviderModelRegistration,
   type PiProviderRegistration,
-  type RegisteredPiProvider,
-  resolveRegisteredPiProviderApiKey,
   resolveRegisteredPiProviderFromModelHandle,
-  resolveRegisteredPiProviderHeaders,
   stripRegisteredProviderHandlePrefix,
 } from "./pi-provider-extension-registry";
 import {
@@ -35,6 +32,11 @@ import {
   resolveProviderFromProviderType,
   stripProviderHandlePrefix,
 } from "./pi-provider-registry";
+import {
+  getRegisteredPiProviderLocalNames,
+  listRegisteredPiProviderModels,
+  resolveRegisteredPiProviderRuntimeConnection,
+} from "./registered-pi-provider-runtime";
 
 export const DEFAULT_PI_PROVIDER = "openai" satisfies PiProvider;
 export type { PiProvider } from "./pi-provider-registry";
@@ -178,58 +180,6 @@ function localProviderConnection(
     }),
     ...(record ? { record } : {}),
   };
-}
-
-function registeredProviderLocalNames(
-  provider: RegisteredPiProvider,
-): readonly string[] {
-  return isPiProvider(provider.providerName)
-    ? getPiProviderSpec(provider.providerName).localProviderNames
-    : [provider.providerName];
-}
-
-function registeredProviderConnection(
-  provider: RegisteredPiProvider,
-  storageDir?: string,
-): {
-  apiKey?: string;
-  baseURL?: string;
-  timeout: LocalProviderTimeout;
-  headers?: Record<string, string>;
-  record?: LocalProviderRecord;
-} {
-  const providerNames = registeredProviderLocalNames(provider);
-  const record = localProviderRecord(providerNames, storageDir);
-  return {
-    apiKey:
-      localProviderApiKeyFromRecord(record) ??
-      resolveRegisteredPiProviderApiKey(provider.config.apiKey),
-    baseURL: record?.base_url ?? provider.config.baseUrl,
-    timeout: resolveLocalProviderTimeout({
-      configuredTimeout: record?.timeout,
-      providerIds: providerNames,
-    }),
-    headers: resolveRegisteredPiProviderHeaders(provider.config.headers),
-    ...(record ? { record } : {}),
-  };
-}
-
-async function registeredProviderModels(
-  provider: RegisteredPiProvider,
-  connection: {
-    apiKey?: string;
-    baseURL?: string;
-    headers?: Record<string, string>;
-  },
-): Promise<PiProviderModelRegistration[]> {
-  const listed = await provider.config.listModels?.({
-    id: provider.providerName,
-    providerName: provider.providerName,
-    baseUrl: connection.baseURL,
-    apiKey: connection.apiKey,
-    headers: connection.headers,
-  });
-  return listed ?? provider.config.models ?? [];
 }
 
 export interface ZaiConnection {
@@ -511,7 +461,10 @@ export async function resolvePiModelForAgent(
       : options.preferredProviderType;
 
   let connection = registeredProvider
-    ? registeredProviderConnection(registeredProvider, storageDir)
+    ? resolveRegisteredPiProviderRuntimeConnection(
+        registeredProvider,
+        storageDir,
+      )
     : spec
       ? localProviderConnection(
           spec.localProviderNames,
@@ -564,7 +517,7 @@ export async function resolvePiModelForAgent(
   ) {
     const oauth = await getLocalOAuthApiKey({
       providerId: registeredProvider.providerName,
-      providerNames: registeredProviderLocalNames(registeredProvider),
+      providerNames: getRegisteredPiProviderLocalNames(registeredProvider),
       storageDir,
     });
     connection = {
@@ -589,7 +542,7 @@ export async function resolvePiModelForAgent(
   );
 
   const registeredModels = registeredProvider
-    ? await registeredProviderModels(registeredProvider, connection)
+    ? await listRegisteredPiProviderModels(registeredProvider, connection)
     : undefined;
   const registeredModel = registeredModels?.find(
     (model) => model.id === modelId,

--- a/src/backend/dev/pi-provider-extension-registry.ts
+++ b/src/backend/dev/pi-provider-extension-registry.ts
@@ -1,99 +1,30 @@
-import type { Api, Model } from "@earendil-works/pi-ai";
 import {
-  type OAuthCredentials,
-  type OAuthLoginCallbacks,
   registerOAuthProvider,
   unregisterOAuthProvider,
 } from "@earendil-works/pi-ai/oauth";
+import type {
+  PiProviderOAuthLoginCallbacks,
+  PiProviderRegistration,
+  RegisteredPiProvider,
+} from "./pi-provider-extension-types";
+import {
+  clonePiProviderRegistration,
+  resolvePiProviderRegistrationHeaders,
+  validatePiProviderRegistration,
+} from "./pi-provider-extension-validation";
 
-export type PiProviderInputType = "text" | "image";
-
-export interface PiProviderModelRegistration {
-  id: string;
-  name: string;
-  api?: Api;
-  baseUrl?: string;
-  reasoning: boolean;
-  thinkingLevelMap?: Model<Api>["thinkingLevelMap"];
-  input: PiProviderInputType[];
-  cost: {
-    input: number;
-    output: number;
-    cacheRead: number;
-    cacheWrite: number;
-  };
-  contextWindow: number;
-  maxTokens: number;
-  headers?: Record<string, string>;
-  compat?: Model<Api>["compat"];
-}
-
-export interface PiProviderConnection {
-  id: string;
-  providerName: string;
-  baseUrl?: string;
-  apiKey?: string;
-  headers?: Record<string, string>;
-}
-
-export interface PiProviderConnectField {
-  key: string;
-  label: string;
-  placeholder?: string;
-  secret?: boolean;
-}
-
-export interface PiProviderConnectConfig {
-  fields?: PiProviderConnectField[];
-}
-
-export interface PiProviderOAuthDeviceCodeInfo {
-  verificationUri: string;
-  userCode: string;
-  intervalSeconds?: number;
-  expiresInSeconds?: number;
-}
-
-export interface PiProviderOAuthLoginCallbacks
-  extends Omit<OAuthLoginCallbacks, "onDeviceCode"> {
-  onDeviceCode?: (info: PiProviderOAuthDeviceCodeInfo) => void;
-}
-
-export interface PiProviderOAuthConfig {
-  name?: string;
-  login: (
-    callbacks: PiProviderOAuthLoginCallbacks,
-  ) => Promise<OAuthCredentials>;
-  refreshToken: (credentials: OAuthCredentials) => Promise<OAuthCredentials>;
-  getApiKey: (credentials: OAuthCredentials) => string;
-  modifyModels?: (
-    models: Model<Api>[],
-    credentials: OAuthCredentials,
-  ) => Model<Api>[];
-}
-
-export interface PiProviderRegistration {
-  name?: string;
-  description?: string;
-  baseUrl?: string;
-  apiKey?: string;
-  api?: Api;
-  headers?: Record<string, string>;
-  authHeader?: boolean;
-  models?: PiProviderModelRegistration[];
-  listModels?: (
-    connection: PiProviderConnection,
-  ) => Promise<PiProviderModelRegistration[]> | PiProviderModelRegistration[];
-  connect?: boolean | PiProviderConnectConfig;
-  oauth?: PiProviderOAuthConfig;
-}
-
-export interface RegisteredPiProvider {
-  providerName: string;
-  config: PiProviderRegistration;
-  ownerId?: string;
-  path?: string;
-}
+export type {
+  PiProviderConnectConfig,
+  PiProviderConnectField,
+  PiProviderConnection,
+  PiProviderInputType,
+  PiProviderModelRegistration,
+  PiProviderOAuthConfig,
+  PiProviderOAuthDeviceCodeInfo,
+  PiProviderOAuthLoginCallbacks,
+  PiProviderRegistration,
+  RegisteredPiProvider,
+} from "./pi-provider-extension-types";
 
 type PiProviderRegistryListener = () => void;
 
@@ -118,239 +49,6 @@ export function subscribePiProviderRegistry(
   return () => {
     registryListeners.delete(listener);
   };
-}
-
-function cloneHeaders(
-  headers: Record<string, string> | undefined,
-): Record<string, string> | undefined {
-  return headers ? { ...headers } : undefined;
-}
-
-function resolveHeaderValues(
-  headers: Record<string, string> | undefined,
-): Record<string, string> | undefined {
-  if (!headers) return undefined;
-  const resolved: Record<string, string> = {};
-  for (const [key, value] of Object.entries(headers)) {
-    resolved[key] = process.env[value] ?? value;
-  }
-  return resolved;
-}
-
-function cloneModel(
-  model: PiProviderModelRegistration,
-): PiProviderModelRegistration {
-  return {
-    ...model,
-    input: [...model.input],
-    cost: { ...model.cost },
-    ...(model.headers ? { headers: { ...model.headers } } : {}),
-    ...(model.compat ? { compat: { ...model.compat } } : {}),
-    ...(model.thinkingLevelMap
-      ? { thinkingLevelMap: { ...model.thinkingLevelMap } }
-      : {}),
-  };
-}
-
-function cloneConfig(config: PiProviderRegistration): PiProviderRegistration {
-  return {
-    ...config,
-    ...(config.headers ? { headers: cloneHeaders(config.headers) } : {}),
-    ...(config.models ? { models: config.models.map(cloneModel) } : {}),
-  };
-}
-
-function validateProviderName(providerName: string): void {
-  if (!/^[a-z0-9][a-z0-9._-]*$/.test(providerName)) {
-    throw new Error(
-      "Provider name must start with a lowercase letter or number and contain only lowercase letters, numbers, dots, underscores, or hyphens",
-    );
-  }
-}
-
-function validateFiniteNonNegative(value: unknown, label: string): void {
-  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
-    throw new Error(`${label} must be a finite non-negative number`);
-  }
-}
-
-function validatePositiveInteger(value: unknown, label: string): void {
-  if (
-    typeof value !== "number" ||
-    !Number.isFinite(value) ||
-    value <= 0 ||
-    !Number.isInteger(value)
-  ) {
-    throw new Error(`${label} must be a positive integer`);
-  }
-}
-
-function validateInput(input: unknown, label: string): void {
-  if (!Array.isArray(input) || input.length === 0) {
-    throw new Error(`${label}.input must be a non-empty array`);
-  }
-  for (const item of input) {
-    if (item !== "text" && item !== "image") {
-      throw new Error(`${label}.input can only contain "text" or "image"`);
-    }
-  }
-}
-
-function validateHeaders(headers: unknown, label: string): void {
-  if (headers === undefined) return;
-  if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
-    throw new Error(`${label} must be an object of string headers`);
-  }
-  for (const [key, value] of Object.entries(headers)) {
-    if (!key || typeof value !== "string") {
-      throw new Error(`${label} must be an object of string headers`);
-    }
-  }
-}
-
-function validateModel(
-  providerName: string,
-  config: PiProviderRegistration,
-  model: PiProviderModelRegistration,
-): void {
-  const label = `Provider ${providerName}, model ${model.id || "<unknown>"}`;
-  if (!model.id || typeof model.id !== "string") {
-    throw new Error(`${label}: id is required`);
-  }
-  if (model.id.includes("/")) {
-    throw new Error(`${label}: id must be unprefixed and cannot contain "/"`);
-  }
-  if (!model.name || typeof model.name !== "string") {
-    throw new Error(`${label}: name is required`);
-  }
-  if (!model.api && !config.api) {
-    throw new Error(`${label}: api is required at provider or model level`);
-  }
-  if (typeof model.reasoning !== "boolean") {
-    throw new Error(`${label}: reasoning must be boolean`);
-  }
-  validateInput(model.input, label);
-  validateFiniteNonNegative(model.cost?.input, `${label}.cost.input`);
-  validateFiniteNonNegative(model.cost?.output, `${label}.cost.output`);
-  validateFiniteNonNegative(model.cost?.cacheRead, `${label}.cost.cacheRead`);
-  validateFiniteNonNegative(model.cost?.cacheWrite, `${label}.cost.cacheWrite`);
-  validatePositiveInteger(model.contextWindow, `${label}.contextWindow`);
-  validatePositiveInteger(model.maxTokens, `${label}.maxTokens`);
-  validateHeaders(model.headers, `${label}.headers`);
-}
-
-function validateConnectConfig(
-  providerName: string,
-  connect: PiProviderRegistration["connect"],
-): void {
-  if (connect === undefined || connect === true || connect === false) return;
-  if (!connect || typeof connect !== "object" || Array.isArray(connect)) {
-    throw new Error(
-      `Provider ${providerName}.connect must be boolean or object`,
-    );
-  }
-  if (connect.fields !== undefined) {
-    if (!Array.isArray(connect.fields)) {
-      throw new Error(
-        `Provider ${providerName}.connect.fields must be an array`,
-      );
-    }
-    for (const field of connect.fields) {
-      if (!field || typeof field !== "object") {
-        throw new Error(
-          `Provider ${providerName}.connect.fields entries must be objects`,
-        );
-      }
-      if (typeof field.key !== "string" || field.key.length === 0) {
-        throw new Error(
-          `Provider ${providerName}.connect.fields entries need a key`,
-        );
-      }
-      if (typeof field.label !== "string" || field.label.length === 0) {
-        throw new Error(
-          `Provider ${providerName}.connect.fields entries need a label`,
-        );
-      }
-      if (
-        field.placeholder !== undefined &&
-        typeof field.placeholder !== "string"
-      ) {
-        throw new Error(
-          `Provider ${providerName}.connect.fields placeholder must be a string`,
-        );
-      }
-      if (field.secret !== undefined && typeof field.secret !== "boolean") {
-        throw new Error(
-          `Provider ${providerName}.connect.fields secret must be boolean`,
-        );
-      }
-    }
-  }
-}
-
-function validateOAuthConfig(
-  providerName: string,
-  oauth: PiProviderRegistration["oauth"],
-): void {
-  if (oauth === undefined) return;
-  if (!oauth || typeof oauth !== "object" || Array.isArray(oauth)) {
-    throw new Error(`Provider ${providerName}.oauth must be an object`);
-  }
-  if (oauth.name !== undefined && typeof oauth.name !== "string") {
-    throw new Error(`Provider ${providerName}.oauth.name must be a string`);
-  }
-  for (const key of ["login", "refreshToken", "getApiKey"] as const) {
-    if (typeof oauth[key] !== "function") {
-      throw new Error(
-        `Provider ${providerName}.oauth.${key} must be a function`,
-      );
-    }
-  }
-  if (
-    oauth.modifyModels !== undefined &&
-    typeof oauth.modifyModels !== "function"
-  ) {
-    throw new Error(
-      `Provider ${providerName}.oauth.modifyModels must be a function`,
-    );
-  }
-}
-
-function validateProviderConfig(
-  providerName: string,
-  config: PiProviderRegistration,
-): void {
-  validateProviderName(providerName);
-  validateHeaders(config.headers, `Provider ${providerName}.headers`);
-  validateConnectConfig(providerName, config.connect);
-  validateOAuthConfig(providerName, config.oauth);
-  if (
-    config.listModels !== undefined &&
-    typeof config.listModels !== "function"
-  ) {
-    throw new Error(`Provider ${providerName}.listModels must be a function`);
-  }
-  if (
-    config.authHeader !== undefined &&
-    typeof config.authHeader !== "boolean"
-  ) {
-    throw new Error(`Provider ${providerName}.authHeader must be boolean`);
-  }
-  if (config.models !== undefined) {
-    if (!Array.isArray(config.models)) {
-      throw new Error(`Provider ${providerName}.models must be an array`);
-    }
-    const ids = new Set<string>();
-    for (const model of config.models) {
-      validateModel(providerName, config, model);
-      if (ids.has(model.id)) {
-        throw new Error(
-          `Provider ${providerName}: duplicate model id "${model.id}"`,
-        );
-      }
-      ids.add(model.id);
-    }
-  }
 }
 
 function registerPiOAuthProvider(
@@ -397,10 +95,10 @@ export function registerPiProvider(
   config: PiProviderRegistration,
   owner?: { id?: string; path?: string },
 ): RegisteredPiProvider {
-  validateProviderConfig(providerName, config);
+  validatePiProviderRegistration(providerName, config);
   const registered: RegisteredPiProvider = {
     providerName,
-    config: cloneConfig(config),
+    config: clonePiProviderRegistration(config),
     ...(owner?.id ? { ownerId: owner.id } : {}),
     ...(owner?.path ? { path: owner.path } : {}),
   };
@@ -450,14 +148,14 @@ export function getRegisteredPiProvider(
   if (!provider) return undefined;
   return {
     ...provider,
-    config: cloneConfig(provider.config),
+    config: clonePiProviderRegistration(provider.config),
   };
 }
 
 export function listRegisteredPiProviders(): RegisteredPiProvider[] {
   return [...registeredProviders.values()].map((provider) => ({
     ...provider,
-    config: cloneConfig(provider.config),
+    config: clonePiProviderRegistration(provider.config),
   }));
 }
 
@@ -489,5 +187,5 @@ export function resolveRegisteredPiProviderApiKey(
 export function resolveRegisteredPiProviderHeaders(
   headers: PiProviderRegistration["headers"],
 ): Record<string, string> | undefined {
-  return resolveHeaderValues(headers);
+  return resolvePiProviderRegistrationHeaders(headers);
 }

--- a/src/backend/dev/pi-provider-extension-types.ts
+++ b/src/backend/dev/pi-provider-extension-types.ts
@@ -1,0 +1,94 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import type {
+  OAuthCredentials,
+  OAuthLoginCallbacks,
+} from "@earendil-works/pi-ai/oauth";
+
+export type PiProviderInputType = "text" | "image";
+
+export interface PiProviderModelRegistration {
+  id: string;
+  name: string;
+  api?: Api;
+  baseUrl?: string;
+  reasoning: boolean;
+  thinkingLevelMap?: Model<Api>["thinkingLevelMap"];
+  input: PiProviderInputType[];
+  cost: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+  };
+  contextWindow: number;
+  maxTokens: number;
+  headers?: Record<string, string>;
+  compat?: Model<Api>["compat"];
+}
+
+export interface PiProviderConnection {
+  id: string;
+  providerName: string;
+  baseUrl?: string;
+  apiKey?: string;
+  headers?: Record<string, string>;
+}
+
+export interface PiProviderConnectField {
+  key: string;
+  label: string;
+  placeholder?: string;
+  secret?: boolean;
+}
+
+export interface PiProviderConnectConfig {
+  fields?: PiProviderConnectField[];
+}
+
+export interface PiProviderOAuthDeviceCodeInfo {
+  verificationUri: string;
+  userCode: string;
+  intervalSeconds?: number;
+  expiresInSeconds?: number;
+}
+
+export interface PiProviderOAuthLoginCallbacks
+  extends Omit<OAuthLoginCallbacks, "onDeviceCode"> {
+  onDeviceCode?: (info: PiProviderOAuthDeviceCodeInfo) => void;
+}
+
+export interface PiProviderOAuthConfig {
+  name?: string;
+  login: (
+    callbacks: PiProviderOAuthLoginCallbacks,
+  ) => Promise<OAuthCredentials>;
+  refreshToken: (credentials: OAuthCredentials) => Promise<OAuthCredentials>;
+  getApiKey: (credentials: OAuthCredentials) => string;
+  modifyModels?: (
+    models: Model<Api>[],
+    credentials: OAuthCredentials,
+  ) => Model<Api>[];
+}
+
+export interface PiProviderRegistration {
+  name?: string;
+  description?: string;
+  baseUrl?: string;
+  apiKey?: string;
+  api?: Api;
+  headers?: Record<string, string>;
+  authHeader?: boolean;
+  models?: PiProviderModelRegistration[];
+  listModels?: (
+    connection: PiProviderConnection,
+  ) => Promise<PiProviderModelRegistration[]> | PiProviderModelRegistration[];
+  connect?: boolean | PiProviderConnectConfig;
+  oauth?: PiProviderOAuthConfig;
+}
+
+export interface RegisteredPiProvider {
+  providerName: string;
+  config: PiProviderRegistration;
+  ownerId?: string;
+  path?: string;
+}

--- a/src/backend/dev/pi-provider-extension-validation.ts
+++ b/src/backend/dev/pi-provider-extension-validation.ts
@@ -1,0 +1,239 @@
+import type {
+  PiProviderModelRegistration,
+  PiProviderRegistration,
+} from "./pi-provider-extension-types";
+
+function cloneHeaders(
+  headers: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  return headers ? { ...headers } : undefined;
+}
+
+export function resolvePiProviderRegistrationHeaders(
+  headers: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!headers) return undefined;
+  const resolved: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    resolved[key] = process.env[value] ?? value;
+  }
+  return resolved;
+}
+
+function cloneModel(
+  model: PiProviderModelRegistration,
+): PiProviderModelRegistration {
+  return {
+    ...model,
+    input: [...model.input],
+    cost: { ...model.cost },
+    ...(model.headers ? { headers: { ...model.headers } } : {}),
+    ...(model.compat ? { compat: { ...model.compat } } : {}),
+    ...(model.thinkingLevelMap
+      ? { thinkingLevelMap: { ...model.thinkingLevelMap } }
+      : {}),
+  };
+}
+
+export function clonePiProviderRegistration(
+  config: PiProviderRegistration,
+): PiProviderRegistration {
+  return {
+    ...config,
+    ...(config.headers ? { headers: cloneHeaders(config.headers) } : {}),
+    ...(config.models ? { models: config.models.map(cloneModel) } : {}),
+  };
+}
+
+function validateProviderName(providerName: string): void {
+  if (!/^[a-z0-9][a-z0-9._-]*$/.test(providerName)) {
+    throw new Error(
+      "Provider name must start with a lowercase letter or number and contain only lowercase letters, numbers, dots, underscores, or hyphens",
+    );
+  }
+}
+
+function validateFiniteNonNegative(value: unknown, label: string): void {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new Error(`${label} must be a finite non-negative number`);
+  }
+}
+
+function validatePositiveInteger(value: unknown, label: string): void {
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    value <= 0 ||
+    !Number.isInteger(value)
+  ) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+}
+
+function validateInput(input: unknown, label: string): void {
+  if (!Array.isArray(input) || input.length === 0) {
+    throw new Error(`${label}.input must be a non-empty array`);
+  }
+  for (const item of input) {
+    if (item !== "text" && item !== "image") {
+      throw new Error(`${label}.input can only contain "text" or "image"`);
+    }
+  }
+}
+
+function validateHeaders(headers: unknown, label: string): void {
+  if (headers === undefined) return;
+  if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
+    throw new Error(`${label} must be an object of string headers`);
+  }
+  for (const [key, value] of Object.entries(headers)) {
+    if (!key || typeof value !== "string") {
+      throw new Error(`${label} must be an object of string headers`);
+    }
+  }
+}
+
+function validateModel(
+  providerName: string,
+  config: PiProviderRegistration,
+  model: PiProviderModelRegistration,
+): void {
+  const label = `Provider ${providerName}, model ${model.id || "<unknown>"}`;
+  if (!model.id || typeof model.id !== "string") {
+    throw new Error(`${label}: id is required`);
+  }
+  if (model.id.includes("/")) {
+    throw new Error(`${label}: id must be unprefixed and cannot contain "/"`);
+  }
+  if (!model.name || typeof model.name !== "string") {
+    throw new Error(`${label}: name is required`);
+  }
+  if (!model.api && !config.api) {
+    throw new Error(`${label}: api is required at provider or model level`);
+  }
+  if (typeof model.reasoning !== "boolean") {
+    throw new Error(`${label}: reasoning must be boolean`);
+  }
+  validateInput(model.input, label);
+  validateFiniteNonNegative(model.cost?.input, `${label}.cost.input`);
+  validateFiniteNonNegative(model.cost?.output, `${label}.cost.output`);
+  validateFiniteNonNegative(model.cost?.cacheRead, `${label}.cost.cacheRead`);
+  validateFiniteNonNegative(model.cost?.cacheWrite, `${label}.cost.cacheWrite`);
+  validatePositiveInteger(model.contextWindow, `${label}.contextWindow`);
+  validatePositiveInteger(model.maxTokens, `${label}.maxTokens`);
+  validateHeaders(model.headers, `${label}.headers`);
+}
+
+function validateConnectConfig(
+  providerName: string,
+  connect: PiProviderRegistration["connect"],
+): void {
+  if (connect === undefined || connect === true || connect === false) return;
+  if (!connect || typeof connect !== "object" || Array.isArray(connect)) {
+    throw new Error(
+      `Provider ${providerName}.connect must be boolean or object`,
+    );
+  }
+  if (connect.fields !== undefined) {
+    if (!Array.isArray(connect.fields)) {
+      throw new Error(
+        `Provider ${providerName}.connect.fields must be an array`,
+      );
+    }
+    for (const field of connect.fields) {
+      if (!field || typeof field !== "object") {
+        throw new Error(
+          `Provider ${providerName}.connect.fields entries must be objects`,
+        );
+      }
+      if (typeof field.key !== "string" || field.key.length === 0) {
+        throw new Error(
+          `Provider ${providerName}.connect.fields entries need a key`,
+        );
+      }
+      if (typeof field.label !== "string" || field.label.length === 0) {
+        throw new Error(
+          `Provider ${providerName}.connect.fields entries need a label`,
+        );
+      }
+      if (
+        field.placeholder !== undefined &&
+        typeof field.placeholder !== "string"
+      ) {
+        throw new Error(
+          `Provider ${providerName}.connect.fields placeholder must be a string`,
+        );
+      }
+      if (field.secret !== undefined && typeof field.secret !== "boolean") {
+        throw new Error(
+          `Provider ${providerName}.connect.fields secret must be boolean`,
+        );
+      }
+    }
+  }
+}
+
+function validateOAuthConfig(
+  providerName: string,
+  oauth: PiProviderRegistration["oauth"],
+): void {
+  if (oauth === undefined) return;
+  if (!oauth || typeof oauth !== "object" || Array.isArray(oauth)) {
+    throw new Error(`Provider ${providerName}.oauth must be an object`);
+  }
+  if (oauth.name !== undefined && typeof oauth.name !== "string") {
+    throw new Error(`Provider ${providerName}.oauth.name must be a string`);
+  }
+  for (const key of ["login", "refreshToken", "getApiKey"] as const) {
+    if (typeof oauth[key] !== "function") {
+      throw new Error(
+        `Provider ${providerName}.oauth.${key} must be a function`,
+      );
+    }
+  }
+  if (
+    oauth.modifyModels !== undefined &&
+    typeof oauth.modifyModels !== "function"
+  ) {
+    throw new Error(
+      `Provider ${providerName}.oauth.modifyModels must be a function`,
+    );
+  }
+}
+
+export function validatePiProviderRegistration(
+  providerName: string,
+  config: PiProviderRegistration,
+): void {
+  validateProviderName(providerName);
+  validateHeaders(config.headers, `Provider ${providerName}.headers`);
+  validateConnectConfig(providerName, config.connect);
+  validateOAuthConfig(providerName, config.oauth);
+  if (
+    config.listModels !== undefined &&
+    typeof config.listModels !== "function"
+  ) {
+    throw new Error(`Provider ${providerName}.listModels must be a function`);
+  }
+  if (
+    config.authHeader !== undefined &&
+    typeof config.authHeader !== "boolean"
+  ) {
+    throw new Error(`Provider ${providerName}.authHeader must be boolean`);
+  }
+  if (config.models !== undefined) {
+    if (!Array.isArray(config.models)) {
+      throw new Error(`Provider ${providerName}.models must be an array`);
+    }
+    const ids = new Set<string>();
+    for (const model of config.models) {
+      validateModel(providerName, config, model);
+      if (ids.has(model.id)) {
+        throw new Error(
+          `Provider ${providerName}: duplicate model id "${model.id}"`,
+        );
+      }
+      ids.add(model.id);
+    }
+  }
+}

--- a/src/backend/dev/registered-pi-provider-runtime.ts
+++ b/src/backend/dev/registered-pi-provider-runtime.ts
@@ -1,0 +1,138 @@
+import {
+  getLocalOAuthApiKey,
+  getLocalProviderRecordByName,
+  type LocalProviderRecord,
+  localProviderApiKeyFromRecord,
+} from "@/backend/local/local-provider-auth-store";
+import {
+  type LocalProviderTimeout,
+  resolveLocalProviderTimeout,
+} from "@/backend/local/local-provider-timeout";
+import {
+  resolveRegisteredPiProviderApiKey,
+  resolveRegisteredPiProviderHeaders,
+} from "./pi-provider-extension-registry";
+import type {
+  PiProviderConnection,
+  PiProviderModelRegistration,
+  RegisteredPiProvider,
+} from "./pi-provider-extension-types";
+import { getPiProviderSpec, isPiProvider } from "./pi-provider-registry";
+
+export interface RegisteredPiProviderRuntimeConnection {
+  apiKey?: string;
+  baseURL?: string;
+  timeout: LocalProviderTimeout;
+  headers?: Record<string, string>;
+  record?: LocalProviderRecord;
+}
+
+interface RegisteredPiProviderModelListConnection {
+  apiKey?: string;
+  baseUrl?: string;
+  baseURL?: string;
+  headers?: Record<string, string>;
+}
+
+export function getRegisteredPiProviderLocalNames(
+  provider: RegisteredPiProvider,
+): readonly string[] {
+  return isPiProvider(provider.providerName)
+    ? getPiProviderSpec(provider.providerName).localProviderNames
+    : [provider.providerName];
+}
+
+export function findRegisteredPiProviderLocalRecord(
+  provider: RegisteredPiProvider,
+  records: readonly LocalProviderRecord[],
+): LocalProviderRecord | undefined {
+  const providerNames = getRegisteredPiProviderLocalNames(provider);
+  return records.find((record) => providerNames.includes(record.name));
+}
+
+export function getRegisteredPiProviderLocalRecord(
+  provider: RegisteredPiProvider,
+  storageDir?: string,
+): LocalProviderRecord | null {
+  for (const providerName of getRegisteredPiProviderLocalNames(provider)) {
+    const record = getLocalProviderRecordByName(providerName, storageDir);
+    if (record) return record;
+  }
+  return null;
+}
+
+export function isRegisteredPiProviderConfigured(
+  provider: RegisteredPiProvider,
+  records: readonly LocalProviderRecord[],
+): boolean {
+  return Boolean(
+    findRegisteredPiProviderLocalRecord(provider, records) ||
+      (provider.config.apiKey
+        ? process.env[provider.config.apiKey]
+        : undefined) ||
+      provider.config.connect === false,
+  );
+}
+
+export async function resolveRegisteredPiProviderListModelsConnection(
+  provider: RegisteredPiProvider,
+  options: {
+    records: readonly LocalProviderRecord[];
+    storageDir?: string;
+  },
+): Promise<PiProviderConnection> {
+  const providerNames = getRegisteredPiProviderLocalNames(provider);
+  const record = findRegisteredPiProviderLocalRecord(provider, options.records);
+  const oauth =
+    record?.auth.type === "oauth" && provider.config.oauth
+      ? await getLocalOAuthApiKey({
+          providerId: provider.providerName,
+          providerNames,
+          storageDir: options.storageDir,
+        })
+      : undefined;
+  return {
+    id: provider.providerName,
+    providerName: provider.providerName,
+    baseUrl: record?.base_url ?? provider.config.baseUrl,
+    apiKey:
+      oauth?.apiKey ??
+      localProviderApiKeyFromRecord(record) ??
+      resolveRegisteredPiProviderApiKey(provider.config.apiKey),
+    headers: resolveRegisteredPiProviderHeaders(provider.config.headers),
+  };
+}
+
+export function resolveRegisteredPiProviderRuntimeConnection(
+  provider: RegisteredPiProvider,
+  storageDir?: string,
+): RegisteredPiProviderRuntimeConnection {
+  const providerNames = getRegisteredPiProviderLocalNames(provider);
+  const record = getRegisteredPiProviderLocalRecord(provider, storageDir);
+  return {
+    apiKey:
+      localProviderApiKeyFromRecord(record) ??
+      resolveRegisteredPiProviderApiKey(provider.config.apiKey),
+    baseURL: record?.base_url ?? provider.config.baseUrl,
+    timeout: resolveLocalProviderTimeout({
+      configuredTimeout: record?.timeout,
+      providerIds: providerNames,
+    }),
+    headers: resolveRegisteredPiProviderHeaders(provider.config.headers),
+    ...(record ? { record } : {}),
+  };
+}
+
+export async function listRegisteredPiProviderModels(
+  provider: RegisteredPiProvider,
+  connection: RegisteredPiProviderModelListConnection,
+): Promise<PiProviderModelRegistration[]> {
+  const listed = await provider.config.listModels?.({
+    id: provider.providerName,
+    providerName: provider.providerName,
+    baseUrl: connection.baseUrl ?? connection.baseURL,
+    apiKey: connection.apiKey,
+    headers: connection.headers,
+  });
+  return listed ?? provider.config.models ?? [];
+}

--- a/src/backend/local/local-model-config.ts
+++ b/src/backend/local/local-model-config.ts
@@ -5,12 +5,7 @@ import {
 import {
   getRegisteredPiProvider,
   listRegisteredPiProviders,
-  type PiProviderConnection,
-  type PiProviderModelRegistration,
-  type RegisteredPiProvider,
-  resolveRegisteredPiProviderApiKey,
   resolveRegisteredPiProviderFromModelHandle,
-  resolveRegisteredPiProviderHeaders,
   stripRegisteredProviderHandlePrefix,
 } from "@/backend/dev/pi-provider-extension-registry";
 import {
@@ -25,7 +20,11 @@ import {
   stripProviderHandlePrefix,
 } from "@/backend/dev/pi-provider-registry";
 import {
-  getLocalOAuthApiKey,
+  isRegisteredPiProviderConfigured,
+  listRegisteredPiProviderModels,
+  resolveRegisteredPiProviderListModelsConnection,
+} from "@/backend/dev/registered-pi-provider-runtime";
+import {
   type LocalProviderRecord,
   listLocalProviderRecords,
   localProviderApiKeyFromRecord,
@@ -235,77 +234,11 @@ async function discoverModelIdsForProvider(
   }
 }
 
-function registeredProviderLocalNames(
-  provider: RegisteredPiProvider,
-): readonly string[] {
-  return isPiProviderForLocalModelHandle(provider.providerName)
-    ? getPiProviderSpec(provider.providerName).localProviderNames
-    : [provider.providerName];
-}
-
-function registeredProviderRecordFor(
-  provider: RegisteredPiProvider,
-  records: readonly LocalProviderRecord[],
-): LocalProviderRecord | undefined {
-  const providerNames = registeredProviderLocalNames(provider);
-  return records.find((record) => providerNames.includes(record.name));
-}
-
-async function registeredProviderConnection(
-  provider: RegisteredPiProvider,
-  records: readonly LocalProviderRecord[],
-  storageDir?: string,
-): Promise<PiProviderConnection> {
-  const record = registeredProviderRecordFor(provider, records);
-  const oauth =
-    record?.auth.type === "oauth" && provider.config.oauth
-      ? await getLocalOAuthApiKey({
-          providerId: provider.providerName,
-          providerNames: registeredProviderLocalNames(provider),
-          storageDir,
-        })
-      : undefined;
-  return {
-    id: provider.providerName,
-    providerName: provider.providerName,
-    baseUrl: record?.base_url ?? provider.config.baseUrl,
-    apiKey:
-      oauth?.apiKey ??
-      localProviderApiKeyFromRecord(record) ??
-      resolveRegisteredPiProviderApiKey(provider.config.apiKey),
-    headers: resolveRegisteredPiProviderHeaders(provider.config.headers),
-  };
-}
-
-function isRegisteredProviderConfigured(
-  provider: RegisteredPiProvider,
-  records: readonly LocalProviderRecord[],
-): boolean {
-  return Boolean(
-    registeredProviderRecordFor(provider, records) ||
-      (provider.config.apiKey
-        ? process.env[provider.config.apiKey]
-        : undefined) ||
-      provider.config.connect === false,
-  );
-}
-
-async function listRegisteredProviderModels(
-  provider: RegisteredPiProvider,
-  records: readonly LocalProviderRecord[],
-  storageDir?: string,
-): Promise<PiProviderModelRegistration[]> {
-  const listed = await provider.config.listModels?.(
-    await registeredProviderConnection(provider, records, storageDir),
-  );
-  return listed ?? provider.config.models ?? [];
-}
-
 export function resolveLocalProvider(storageDir?: string): PiProvider {
   const records = listLocalProviderRecords(storageDir);
   const registeredProvider = listRegisteredPiProviders().find(
     (provider) =>
-      isRegisteredProviderConfigured(provider, records) &&
+      isRegisteredPiProviderConfigured(provider, records) &&
       (provider.config.models?.length ?? 0) > 0,
   );
   if (registeredProvider) return registeredProvider.providerName as PiProvider;
@@ -429,12 +362,14 @@ export async function listLocalModels(
   };
 
   for (const provider of registeredProviders) {
-    if (!isRegisteredProviderConfigured(provider, records)) continue;
+    if (!isRegisteredPiProviderConfigured(provider, records)) continue;
     try {
-      for (const model of await listRegisteredProviderModels(
+      for (const model of await listRegisteredPiProviderModels(
         provider,
-        records,
-        storageDir,
+        await resolveRegisteredPiProviderListModelsConnection(provider, {
+          records,
+          storageDir,
+        }),
       )) {
         addModel(provider.providerName, model.id, {
           handle: `${provider.providerName}/${model.id}`,


### PR DESCRIPTION
## Summary
- extract registered provider runtime helpers shared by local model listing and turn-time model resolution
- split extension provider types and validation/cloning out of the mutable provider registry
- keep the registry focused on registration state, lookup, and OAuth provider wiring

## Tests
- `bun run check`
- `bun test src/backend/pi-model-factory.test.ts src/providers/local-pi-provider-catalog.test.ts src/providers/connect-provider-service.test.ts`