### PR TITLE
fix(subagents): honor explicit inherit model override

### DIFF
--- a/src/agent/subagent-model-resolution.test.ts
+++ b/src/agent/subagent-model-resolution.test.ts
@@ -585,6 +585,39 @@ describe("resolveSubagentModel", () => {
     expect(result).toBe("lc-openrouter/custom-model");
   });
 
+  test("explicit user inherit follows subagent inherit instead of literal model", async () => {
+    const result = await resolveSubagentModel({
+      userModel: "inherit",
+      recommendedModel: "inherit",
+      parentModelHandle: "lc-anthropic/parent-model",
+      availableHandles: new Set(["lc-anthropic/parent-model"]),
+    });
+
+    expect(result).toBe("lc-anthropic/parent-model");
+    expect(result).not.toBe("inherit");
+  });
+
+  test("explicit user inherit overrides subagent recommended model", async () => {
+    const result = await resolveSubagentModel({
+      userModel: "inherit",
+      recommendedModel: "anthropic/test-model",
+      parentModelHandle: "openai/parent-model",
+      availableHandles: new Set(["anthropic/test-model"]),
+    });
+
+    expect(result).toBe("openai/parent-model");
+  });
+
+  test("explicit user inherit still allows default fallback without a parent model", async () => {
+    const result = await resolveSubagentModel({
+      userModel: "inherit",
+      recommendedModel: "inherit",
+      availableHandles: new Set(["letta/auto"]),
+    });
+
+    expect(result).toBe("letta/auto");
+  });
+
   test("inherits parent when recommended is inherit", async () => {
     const result = await resolveSubagentModel({
       recommendedModel: "inherit",

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -201,6 +201,10 @@ function swapProviderPrefix(
   return `${parentProvider}/${modelPortion}`;
 }
 
+function isInheritModel(model: string | null | undefined): boolean {
+  return model?.trim().toLowerCase() === "inherit";
+}
+
 export async function resolveSubagentModel(options: {
   userModel?: string;
   recommendedModel?: string;
@@ -213,8 +217,12 @@ export async function resolveSubagentModel(options: {
   const { userModel, recommendedModel, parentModelHandle, billingTier } =
     options;
   const isFreeTier = billingTier?.toLowerCase() === "free";
+  const userRequestedInheritance = isInheritModel(userModel);
+  const effectiveRecommendedModel = userRequestedInheritance
+    ? "inherit"
+    : recommendedModel;
 
-  if (userModel) return userModel;
+  if (userModel && !userRequestedInheritance) return userModel;
 
   // Local backend has no server-side auto router. If the parent agent is
   // already running successfully on a local model, spawned subagents should use
@@ -225,8 +233,11 @@ export async function resolveSubagentModel(options: {
   }
 
   if (options.subagentType === "reflection") {
-    if (recommendedModel && recommendedModel !== "inherit") {
-      const recommendedHandle = resolveModel(recommendedModel);
+    if (
+      effectiveRecommendedModel &&
+      !isInheritModel(effectiveRecommendedModel)
+    ) {
+      const recommendedHandle = resolveModel(effectiveRecommendedModel);
       if (recommendedHandle) {
         return recommendedHandle;
       }
@@ -236,8 +247,8 @@ export async function resolveSubagentModel(options: {
   }
 
   let recommendedHandle: string | null = null;
-  if (recommendedModel && recommendedModel !== "inherit") {
-    recommendedHandle = resolveModel(recommendedModel);
+  if (effectiveRecommendedModel && !isInheritModel(effectiveRecommendedModel)) {
+    recommendedHandle = resolveModel(effectiveRecommendedModel);
   }
 
   let availableHandles: Set<string> | null = options.availableHandles ?? null;


### PR DESCRIPTION
## Summary
- Treat Agent tool `model: "inherit"` as the inherit sentinel during subagent model resolution instead of returning it as a literal override.
- Preserve explicit model overrides while making inherit resolve through parent/default selection semantics.
- Add focused regression coverage for parent inheritance, recommended-model override, and default fallback.

## Test plan
- [x] `bun test ./src/agent/subagent-model-resolution.test.ts`
- [x] `bun run typecheck`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)