### PR TITLE
feat(listener): load provider extensions for desktop

### DIFF
--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -45,6 +45,7 @@ import {
   handleExecuteCommand,
   SUPPORTED_REMOTE_COMMANDS,
 } from "@/websocket/listener/commands";
+import { ensureListenerExtensionAdapter } from "@/websocket/listener/extension-adapter";
 import { isEditFileCommand } from "@/websocket/listener/protocol-inbound";
 import {
   DESKTOP_DEBUG_PANEL_INFO_PREFIX,
@@ -1325,6 +1326,12 @@ describe("listen-client parseServerMessage", () => {
 
   test("runs remote reload execute_command", async () => {
     const listener = __listenClientTestUtils.createListenerRuntime();
+    const adapter = ensureListenerExtensionAdapter(listener);
+    const originalReload = adapter.reload;
+    let reloadCalls = 0;
+    adapter.reload = async () => {
+      reloadCalls += 1;
+    };
     const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
       listener,
       "agent-reload",
@@ -1332,18 +1339,25 @@ describe("listen-client parseServerMessage", () => {
     );
     const socket = new MockSocket(WebSocket.OPEN);
 
-    await handleExecuteCommand(
-      {
-        type: "execute_command",
-        command_id: "reload",
-        request_id: "reload-run-1",
-        runtime: { agent_id: "agent-reload", conversation_id: "default" },
-      },
-      socket as unknown as WebSocket,
-      runtime,
-      {},
-    );
+    try {
+      await handleExecuteCommand(
+        {
+          type: "execute_command",
+          command_id: "reload",
+          request_id: "reload-run-1",
+          runtime: { agent_id: "agent-reload", conversation_id: "default" },
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        {},
+      );
+    } finally {
+      adapter.reload = originalReload;
+      adapter.dispose();
+      listener.extensionAdapter = undefined;
+    }
 
+    expect(reloadCalls).toBe(1);
     expect(socket.sentPayloads.join("\n")).toContain(
       "Reloaded settings and local extensions",
     );

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -42,6 +42,7 @@ import type {
   StreamDelta,
 } from "@/types/protocol_v2";
 import { debugLog } from "@/utils/debug";
+import { reloadListenerExtensionAdapter } from "./extension-adapter";
 import {
   getOrCreateConversationPermissionModeStateRef,
   persistPermissionModeMapForRuntime,
@@ -52,7 +53,11 @@ import {
 } from "./protocol-outbound";
 import { clearConversationRuntimeState, emitListenerStatus } from "./runtime";
 import { handleIncomingMessage } from "./turn";
-import type { ConversationRuntime, StartListenerOptions } from "./types";
+import type {
+  ConversationRuntime,
+  ListenerRuntime,
+  StartListenerOptions,
+} from "./types";
 
 export { SUPPORTED_REMOTE_COMMANDS } from "./listener-constants";
 
@@ -136,7 +141,7 @@ export async function handleExecuteCommand(
         break;
 
       case "reload":
-        output = await handleReloadCommand();
+        output = await handleReloadCommand(conversationRuntime.listener);
         break;
 
       case "context-limit":
@@ -197,7 +202,7 @@ export async function handleExecuteCommand(
   }
 }
 
-async function handleReloadCommand(): Promise<string> {
+async function handleReloadCommand(listener: ListenerRuntime): Promise<string> {
   settingsManager.clearCaches();
   await settingsManager.loadProjectSettings();
   await settingsManager.loadLocalProjectSettings();
@@ -211,6 +216,8 @@ async function handleReloadCommand(): Promise<string> {
       error instanceof Error ? error.message : String(error),
     );
   }
+
+  await reloadListenerExtensionAdapter(listener);
 
   return "Reloaded settings and local extensions";
 }

--- a/src/websocket/listener/extension-adapter.test.ts
+++ b/src/websocket/listener/extension-adapter.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  clearRegisteredPiProviders,
+  getRegisteredPiProvider,
+} from "@/backend/dev/pi-provider-extension-registry";
+import {
+  createListenerExtensionAdapter,
+  createListenerExtensionContext,
+  LISTENER_EXTENSION_CAPABILITIES,
+} from "@/websocket/listener/extension-adapter";
+
+const tempRoots: string[] = [];
+
+function createTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "letta-listener-extension-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  clearRegisteredPiProviders();
+  for (const dir of tempRoots.splice(0)) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe("listener extension adapter", () => {
+  test("uses provider-only capabilities", () => {
+    expect(LISTENER_EXTENSION_CAPABILITIES).toEqual({
+      tools: false,
+      commands: false,
+      events: {
+        lifecycle: false,
+        tools: false,
+        turns: false,
+      },
+      providers: true,
+      ui: {
+        panels: false,
+        statusValues: false,
+        customStatuslineRenderer: false,
+      },
+    });
+  });
+
+  test("builds a listener-scoped extension context", () => {
+    const context = createListenerExtensionContext({
+      sessionId: "listen-test-session",
+      workingDirectory: "/tmp/listener-workspace",
+    });
+
+    expect(context.sessionId).toBe("listen-test-session");
+    expect(context.cwd).toBe("/tmp/listener-workspace");
+    expect(context.workspace).toEqual({
+      cwd: "/tmp/listener-workspace",
+      currentDir: "/tmp/listener-workspace",
+      projectDir: "/tmp/listener-workspace",
+    });
+    expect(context.agent).toEqual({ id: null, name: null });
+    expect(context.model).toEqual({
+      id: null,
+      displayName: null,
+      provider: null,
+      reasoningEffort: null,
+    });
+    expect(context.memfs).toEqual({ enabled: false, memoryDir: null });
+  });
+
+  test("loads provider registrations without exposing other listener capabilities", async () => {
+    const root = createTempDir();
+    const extensionsDir = join(root, "extensions");
+    const cacheDir = join(root, "cache");
+    const extensionPath = join(extensionsDir, "kilo.ts");
+    mkdirSync(extensionsDir, { recursive: true });
+    writeFileSync(
+      extensionPath,
+      `export default function activate(letta) {
+        letta.providers.register("kilo", {
+          name: "Kilo",
+          description: "Connect Kilo",
+          api: "openai-completions",
+          baseUrl: "https://api.kilo.test/v1",
+          apiKey: "KILO_API_KEY",
+          models: [{
+            id: "kilo-code",
+            name: "Kilo Code",
+            reasoning: true,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 128000,
+            maxTokens: 8192,
+          }],
+        });
+        letta.commands.register({
+          id: "ignored-command",
+          description: "Should not register on listener",
+          run() { return { type: "handled" }; },
+        });
+        letta.tools.register({
+          name: "ignored_tool",
+          description: "Should not register on listener",
+          parameters: { type: "object", properties: {} },
+          run() { return "ignored"; },
+        });
+        letta.events.on("conversation_open", () => undefined);
+        letta.ui.openPanel({ id: "ignored-panel", content: "ignored" });
+        letta.ui.setStatus("ignored-status", "ignored");
+      }`,
+    );
+
+    const adapter = createListenerExtensionAdapter({
+      cacheDirectory: cacheDir,
+      globalExtensionsDirectory: extensionsDir,
+      sessionId: "listen-provider-test",
+      workingDirectory: root,
+    });
+
+    await adapter.reload();
+
+    expect(getRegisteredPiProvider("kilo")?.config).toMatchObject({
+      name: "Kilo",
+      baseUrl: "https://api.kilo.test/v1",
+      models: [{ id: "kilo-code", contextWindow: 128000 }],
+    });
+
+    const snapshot = adapter.getSnapshot().registry;
+    expect(snapshot.capabilities).toEqual(LISTENER_EXTENSION_CAPABILITIES);
+    expect(snapshot.loadedPaths).toEqual([extensionPath]);
+    expect(snapshot.commands).toEqual({});
+    expect(snapshot.tools).toEqual({});
+    expect(snapshot.events).toEqual({});
+    expect(snapshot.ui.panels).toEqual({});
+    expect(snapshot.ui.statusValues).toEqual({});
+
+    adapter.dispose();
+    expect(getRegisteredPiProvider("kilo")).toBeUndefined();
+  });
+});

--- a/src/websocket/listener/extension-adapter.ts
+++ b/src/websocket/listener/extension-adapter.ts
@@ -1,0 +1,154 @@
+import type Letta from "@letta-ai/letta-client";
+import { getBackend } from "@/backend";
+import {
+  createExtensionAdapter,
+  type ExtensionAdapter,
+} from "@/extensions/extension-adapter";
+import type {
+  ExtensionCapabilities,
+  ExtensionContext,
+} from "@/extensions/types";
+import { getCurrentWorkingDirectory } from "@/runtime-context";
+import { getVersion } from "@/version";
+import type { ListenerRuntime } from "./types";
+
+export const LISTENER_EXTENSION_CAPABILITIES: ExtensionCapabilities = {
+  tools: false,
+  commands: false,
+  events: {
+    lifecycle: false,
+    tools: false,
+    turns: false,
+  },
+  providers: true,
+  ui: {
+    panels: false,
+    statusValues: false,
+    customStatuslineRenderer: false,
+  },
+};
+
+export interface CreateListenerExtensionAdapterOptions {
+  cacheDirectory?: string;
+  diagnosticsRootDirectory?: string;
+  disabled?: boolean;
+  globalExtensionsDirectory?: string;
+  sessionId?: string | null;
+  workingDirectory?: string | null;
+}
+
+async function getUnavailableListenerClient(): Promise<Letta> {
+  throw new Error(
+    "letta.client is not available in listener provider extensions",
+  );
+}
+
+export function createListenerExtensionContext(
+  options: Pick<
+    CreateListenerExtensionAdapterOptions,
+    "sessionId" | "workingDirectory"
+  > = {},
+): ExtensionContext {
+  const cwd = options.workingDirectory ?? getCurrentWorkingDirectory();
+  return {
+    app: { version: getVersion() },
+    workspace: {
+      cwd,
+      currentDir: cwd,
+      projectDir: cwd,
+    },
+    cwd,
+    sessionId: options.sessionId ?? null,
+    lastRunId: null,
+    agent: {
+      id: null,
+      name: null,
+    },
+    model: {
+      id: null,
+      displayName: null,
+      provider: null,
+      reasoningEffort: null,
+    },
+    toolset: null,
+    systemPromptId: null,
+    permissionMode: null,
+    networkPhase: null,
+    terminalWidth: process.stdout.columns ?? null,
+    contextWindow: {
+      size: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      usedPercentage: null,
+      remainingPercentage: null,
+      currentUsage: null,
+    },
+    cost: {
+      totalDurationMs: 0,
+      totalApiDurationMs: 0,
+      totalCostUsd: null,
+      totalLinesAdded: null,
+      totalLinesRemoved: null,
+    },
+    reflection: {
+      mode: null,
+      stepCount: 0,
+    },
+    memfs: {
+      enabled: false,
+      memoryDir: null,
+    },
+    backgroundAgents: [],
+  };
+}
+
+export function createListenerExtensionAdapter(
+  options: CreateListenerExtensionAdapterOptions = {},
+): ExtensionAdapter {
+  return createExtensionAdapter({
+    ...(options.cacheDirectory
+      ? { cacheDirectory: options.cacheDirectory }
+      : {}),
+    capabilities: LISTENER_EXTENSION_CAPABILITIES,
+    ...(options.diagnosticsRootDirectory
+      ? { diagnosticsRootDirectory: options.diagnosticsRootDirectory }
+      : {}),
+    disabled: options.disabled,
+    getBackend,
+    getClient: getUnavailableListenerClient,
+    ...(options.globalExtensionsDirectory
+      ? { globalExtensionsDirectory: options.globalExtensionsDirectory }
+      : {}),
+    initialContext: createListenerExtensionContext(options),
+  });
+}
+
+export function ensureListenerExtensionAdapter(
+  runtime: ListenerRuntime,
+): ExtensionAdapter {
+  runtime.extensionAdapter ??= createListenerExtensionAdapter({
+    sessionId: runtime.sessionId,
+    workingDirectory: runtime.bootWorkingDirectory,
+  });
+  return runtime.extensionAdapter;
+}
+
+export async function reloadListenerExtensionAdapter(
+  runtime: ListenerRuntime,
+): Promise<void> {
+  const adapter = ensureListenerExtensionAdapter(runtime);
+  adapter.updateContext(
+    createListenerExtensionContext({
+      sessionId: runtime.sessionId,
+      workingDirectory: runtime.bootWorkingDirectory,
+    }),
+  );
+  await adapter.reload();
+}
+
+export function disposeListenerExtensionAdapter(
+  runtime: ListenerRuntime,
+): void {
+  runtime.extensionAdapter?.dispose();
+  runtime.extensionAdapter = undefined;
+}

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -55,6 +55,10 @@ import {
   getOrCreateScopedRuntime,
 } from "./conversation-runtime";
 import { loadPersistedCwdMap } from "./cwd";
+import {
+  disposeListenerExtensionAdapter,
+  reloadListenerExtensionAdapter,
+} from "./extension-adapter";
 import { createFileCommandSession } from "./file-commands";
 import { createListenerMessageHandler } from "./message-router";
 import {
@@ -791,6 +795,7 @@ export function stopRuntime(
   runtime: ListenerRuntime,
   suppressCallbacks: boolean,
 ): void {
+  disposeListenerExtensionAdapter(runtime);
   setMessageQueueAdder(null); // Clear bridge for ALL stop paths
   runtime.intentionallyClosed = true;
   clearRuntimeTimers(runtime);
@@ -1050,6 +1055,7 @@ export async function startListenerClient(
   telemetry.setSurface(getListenerTelemetrySurface());
   telemetry.init();
 
+  await reloadListenerExtensionAdapter(runtime);
   await connectWithRetry(runtime, opts);
 }
 
@@ -1084,6 +1090,7 @@ export async function startLocalChannelListener(
   telemetry.init();
 
   try {
+    await reloadListenerExtensionAdapter(runtime);
     await loadTools();
     const transport = new LocalListenerTransport();
     const processQueuedTurn: ProcessQueuedTurn = async (

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -8,6 +8,7 @@ import type {
 import type { ChannelTurnSource } from "@/channels/types";
 import type { ContextTracker } from "@/cli/helpers/context-tracker";
 import type { ApprovalRequest } from "@/cli/helpers/stream";
+import type { ExtensionAdapter } from "@/extensions/extension-adapter";
 import type { ApprovalContext } from "@/permissions/analyzer";
 import type {
   DequeuedBatch,
@@ -181,6 +182,8 @@ export type ListenerRuntime = {
   hasSuccessfulConnection: boolean;
   /** True once the WS has connected at least once. Never reset to false. */
   everConnected: boolean;
+  /** Provider-only local extension adapter for desktop/listener surfaces. */
+  extensionAdapter?: ExtensionAdapter | undefined;
   sessionId: string;
   eventSeqCounter: number;
   lastStopReason: string | null;


### PR DESCRIPTION
## Summary
- add a listener-specific provider-only extension adapter for desktop/listener runtimes
- reload listener provider extensions on startup and remote `/reload`
- dispose listener extensions on runtime shutdown so provider registrations are cleaned up

## Tests
- `bun test src/websocket/listener/extension-adapter.test.ts`
- `bun test src/websocket/listen-client-protocol.test.ts --timeout 30000`
- `bun run check`