### PR TITLE
fix(local): skip remote memfs enablement for local agent creation

### DIFF
--- a/src/agent/personality.test.ts
+++ b/src/agent/personality.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import {
   buildCreateAgentOptionsForPersonality,
   DEFAULT_CREATE_AGENT_PERSONALITIES,
   detectPersonalityFromPersonaFile,
+  enableMemfsForCreatedAgent,
   getDefaultHumanContent,
   getPersonalityBlockDefinitions,
   getPersonalityBlockValues,
@@ -13,8 +14,19 @@ import {
   replaceBodyPreservingFrontmatter,
   resolvePersonalityId,
 } from "@/agent/personality";
+import { configureBackendMode } from "@/backend";
+import { __testOverrideGetClient } from "@/backend/api/client";
+import { settingsManager } from "@/settings-manager";
 
 const VALID_FRONTMATTER = "---\ndescription: Persona\nlimit: 20000\n---\n\n";
+const originalSetMemfsEnabled =
+  settingsManager.setMemfsEnabled.bind(settingsManager);
+
+afterEach(() => {
+  __testOverrideGetClient(null);
+  settingsManager.setMemfsEnabled = originalSetMemfsEnabled;
+  configureBackendMode("api");
+});
 
 describe("personality helpers", () => {
   test("replaceBodyPreservingFrontmatter swaps body and keeps frontmatter", () => {
@@ -176,6 +188,33 @@ describe("personality helpers", () => {
     });
 
     expect(options.tags).toEqual(["desktop", "favorite"]);
+  });
+
+  test("enableMemfsForCreatedAgent skips remote API calls on local backend", async () => {
+    configureBackendMode("local");
+    let getClientCalls = 0;
+    let enabledAgentId: string | undefined;
+    __testOverrideGetClient(async () => {
+      getClientCalls += 1;
+      return {
+        agents: {
+          update: async () => undefined,
+        },
+      };
+    });
+    settingsManager.setMemfsEnabled = (agentId, enabled) => {
+      if (enabled) {
+        enabledAgentId = agentId;
+      }
+    };
+
+    await enableMemfsForCreatedAgent({
+      agentId: "agent-local-test",
+      agentTags: [],
+    });
+
+    expect(getClientCalls).toBe(0);
+    expect(enabledAgentId).toBe("agent-local-test");
   });
 
   test("kawaii block definitions carry personality-specific descriptions", () => {

--- a/src/agent/personality.ts
+++ b/src/agent/personality.ts
@@ -469,6 +469,14 @@ export async function enableMemfsForCreatedAgent(params: {
   const { agentId, agentTags } = params;
 
   try {
+    const backend = getBackend();
+    if (!backend.capabilities.remoteMemfs) {
+      if (backend.capabilities.localMemfs) {
+        settingsManager.setMemfsEnabled(agentId, true);
+      }
+      return;
+    }
+
     const { getClient } = await import("@/backend/api/client");
     const client = await getClient();
     let currentTags = agentTags;


### PR DESCRIPTION
## Summary

- Fixes `letta --backend local agents create` hanging after login by returning before the remote MemFS tag/update path when the active backend does not support remote MemFS.
- Preserves local MemFS state for local backends without importing or calling the Letta API client.
- Adds a regression test that verifies local backend MemFS enablement does not call `getClient()`.

Based on the issue and original fix direction from #2723 / #2713.