### PR TITLE
docs(skills): document local provider extensions

### DIFF
--- a/src/skills/builtin/creating-extensions/SKILL.md
+++ b/src/skills/builtin/creating-extensions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: creating-extensions
-description: Creates and edits trusted local Letta Code extensions, including extension tools, slash commands, lifecycle/turn events, scoped conversation helpers, panels, status values, and capability-gated behavior. Use when the user asks to make an extension, add a tool the agent can call, add a slash command, transform turns, react to app events, or add lightweight extension UI outside the dedicated /statusline flow.
+description: Creates and edits trusted local Letta Code extensions, including tools, slash commands, local-only model providers, lifecycle/turn events, scoped conversation helpers, panels, status values, and capability-gated behavior. Use when asked to make an extension, add an agent-callable tool, add a slash command, add a local provider/model adapter, transform turns, react to app events, or add lightweight extension UI outside the dedicated /statusline flow.
 ---
 
 # Creating Extensions
@@ -13,6 +13,8 @@ Use this skill to create or update trusted global Letta Code extensions in:
 
 Extensions are trusted local apps for Letta Code. They add small composable capabilities through extension APIs, not by importing app internals. Prefer scoped handles (`ctx.conversation`, `ctx.cwd`, `ctx.agent`, `letta.getContext()`) and guard optional UI with `letta.capabilities`.
 
+Capabilities vary by surface. TUI/headless may load tools, commands, events, UI, and providers; the desktop listener loads provider-only extensions for local provider discovery. Always guard optional capabilities.
+
 ## Choose the right capability
 
 | User wants | Build |
@@ -24,6 +26,7 @@ Extensions are trusted local apps for Letta Code. They add small composable capa
 | Show transient output above input | Panel, usually from a command |
 | Show small persistent state | Status value |
 | React to app/session lifecycle or transform outbound turns | Event |
+| Add a custom model/API provider for local agents | Provider extension (local agents only) |
 | Change the bottom statusline appearance | Use `customizing-statusline`, not this skill |
 
 Default to a **tool** when the model should decide when to use the capability. Default to a **command** when the human explicitly invokes it. Compose capabilities when the UX needs it, e.g. command + panel + scoped conversation fork.
@@ -32,17 +35,16 @@ Default to a **tool** when the model should decide when to use the capability. D
 
 1. Inspect `~/.letta/extensions/` for related files.
 2. Preserve unrelated extension code. Prefer a focused new file if merging would be messy.
-3. Choose the extension shape:
-   - simple tool/command/event: read the specific recipe below
-   - multi-capability or stateful extension: also read `references/architecture.md`
-4. Load only the needed recipe:
+3. Choose the extension shape and load only the needed recipe:
    - tools: `references/tools.md`
    - commands: `references/commands.md`
+   - local custom providers: `references/providers.md`
    - events: `references/events.md`
    - panels/status/capabilities: `references/ui.md`
    - busy side-question pattern: `references/btw-command.md`
+4. For multi-capability or stateful extensions, also read `references/architecture.md`.
 5. Write a single-file extension unless the user asks for something larger.
-6. Return disposers for registered commands/tools/events, timers, subscriptions, and panels that should close on reload.
+6. Return disposers for registered providers/commands/tools/events, timers, subscriptions, and panels that should close on reload.
 7. Do a basic review: valid names, descriptions present, schemas are object schemas, optional capabilities guarded, scoped APIs used, cleanup returned.
 8. Tell the user the absolute file path changed and to run `/reload`. If an extension breaks startup or command handling, recover with `letta --no-extensions` or `LETTA_DISABLE_EXTENSIONS=1 letta`.
 
@@ -74,6 +76,7 @@ letta.capabilities.commands
 letta.capabilities.events.lifecycle
 letta.capabilities.events.tools
 letta.capabilities.events.turns
+letta.capabilities.providers
 letta.capabilities.ui.panels
 letta.capabilities.ui.statusValues
 letta.capabilities.ui.customStatuslineRenderer
@@ -102,6 +105,8 @@ Agents can inspect local extension diagnostics at:
 ## Rules
 
 - Global trusted code only for now. Do not create project extensions.
+- Custom provider extensions are local-backend/local-agent only. They do not add providers for Constellation/cloud agents.
+- Provider extensions may run in a provider-only listener context; keep provider registration independent from commands/tools/UI and guard everything else.
 - Do not assume extra npm packages are available.
 - Do not do surprising side effects on startup; extensions activate on app start and `/reload`.
 - Keep user-facing output short and intentional.
@@ -120,6 +125,7 @@ Before finishing, verify:
 - Tool descriptions explain when the model should call them.
 - JSON schemas are object schemas with useful descriptions.
 - Optional UI/event/statusline APIs are capability-guarded.
+- Provider extensions are capability-guarded and clearly documented as local-agent only.
 - Timers, intervals, event registrations, and panels are cleaned up in a disposer.
 - Busy commands return `{ type: "handled" }` quickly and avoid main-conversation sends.
 - Conversation work uses `ctx.conversation` or forked handles, not app internals.
@@ -128,9 +134,12 @@ Before finishing, verify:
 
 ## References
 
-- `references/architecture.md` - composition, state, cleanup, scoped conversation, and review checklist for complex extensions
-- `references/tools.md` - extension tools the model can call
-- `references/commands.md` - slash commands, command results, and skill-backed commands
-- `references/events.md` - lifecycle and turn event handlers
-- `references/ui.md` - panels, status values, capability guards
-- `references/btw-command.md` - advanced busy-safe side-question command using scoped conversation helpers
+| Reference | Load when |
+| --- | --- |
+| `references/tools.md` | The model should autonomously call a local capability |
+| `references/commands.md` | The human should invoke `/foo` |
+| `references/providers.md` | Adding a custom model/API provider for local agents |
+| `references/events.md` | Reacting to lifecycle/tool/turn events or transforming turns/tools |
+| `references/ui.md` | Panels, status values, or statusline capability guards are involved |
+| `references/btw-command.md` | Building a busy-safe side-question command with a forked conversation |
+| `references/architecture.md` | Multiple capabilities, local state, cleanup, background model work, or non-trivial composition |

--- a/src/skills/builtin/creating-extensions/references/architecture.md
+++ b/src/skills/builtin/creating-extensions/references/architecture.md
@@ -2,6 +2,16 @@
 
 Use this reference for non-trivial extensions: multiple capabilities, local state, timers, background model work, or UI.
 
+## Contents
+
+- Mental model
+- Capability composition patterns
+- Local state
+- Timers and subscriptions
+- Scoped conversation handles
+- Error handling
+- Final review checklist
+
 ## Mental model
 
 An extension is trusted local code that registers capabilities during activation and cleans them up on reload/shutdown. Keep the public surface small:
@@ -12,6 +22,8 @@ An extension is trusted local code that registers capabilities during activation
 - cleanup is returned from activation
 
 Do not import Letta Code internals. If the extension API does not expose a capability yet, avoid reaching around it.
+
+Capabilities vary by host surface. Keep each registration behind the matching `letta.capabilities` guard so one file can run in TUI, headless, and provider-only listener contexts.
 
 ## Capability composition patterns
 

--- a/src/skills/builtin/creating-extensions/references/commands.md
+++ b/src/skills/builtin/creating-extensions/references/commands.md
@@ -4,6 +4,15 @@ Use commands when the human explicitly invokes `/foo`.
 
 For complex command-driven extensions with panels, timers, local state, or background model work, also read `architecture.md`.
 
+## Contents
+
+- Decide command vs skill vs tool
+- Command IDs
+- Prompt command
+- Output-only command
+- Panel command
+- Busy-safe conversation command
+
 ## Decide command vs skill vs tool
 
 | Need | Use |

--- a/src/skills/builtin/creating-extensions/references/events.md
+++ b/src/skills/builtin/creating-extensions/references/events.md
@@ -2,6 +2,16 @@
 
 Use events when trusted local code should react to app/session changes or transform outbound turns without the human explicitly invoking a command. For event-driven extensions with state, timers, panels, or background model work, also read `architecture.md`.
 
+## Contents
+
+- Capabilities
+- Supported events
+- Tool argument transforms and denial
+- Turn input transforms
+- Event handler context
+- Conversation status example
+- Rules
+
 This is the first slice of the hooks-v2 direction. The long-term goal is for typed extension events to replace settings-based hooks. Existing hooks still own blocking decisions and model feedback injection until each event has a typed return contract.
 
 ## Capabilities

--- a/src/skills/builtin/creating-extensions/references/providers.md
+++ b/src/skills/builtin/creating-extensions/references/providers.md
@@ -1,0 +1,208 @@
+# Extension provider recipes
+
+Use provider extensions when the user wants Letta Code local agents to use a model provider that is not built into `/connect` and `/model`.
+
+**Important scope:** custom provider extensions are for **local agents only**. They register local provider metadata used by the local backend/TUI/desktop listener. They do not add providers for Constellation/cloud agents.
+
+For multi-capability extensions that combine a provider with commands, tools, UI, or state, also read `architecture.md`.
+
+## Contents
+
+- When to use
+- Surface behavior and limitations
+- Capability guard
+- Basic API-key provider
+- Config fields
+- Dynamic model discovery
+- Connect behavior
+- Review checklist
+
+## When to use
+
+Use a provider extension when:
+
+- the provider API is supported by the local pi-ai adapter stack; OpenAI-compatible providers usually use `api: "openai-completions"` or `api: "openai-responses"`
+- the user wants the provider to appear in local `/connect` / desktop Connect model providers
+- local `/model` should show static or dynamically listed models from that provider
+- local turns should resolve model handles like `kilo/kilo-code`
+
+Do **not** use a provider extension when the user is asking to configure a Constellation/cloud provider. For cloud agents, use the product's normal provider configuration path instead.
+
+## Surface behavior and limitations
+
+- TUI/headless local agents can load provider extensions along with other extension capabilities.
+- The desktop listener loads provider extensions so desktop's local provider UI can list and connect them.
+- Listener provider loading is provider-only. Do not rely on commands, tools, UI, events, or `letta.client` while registering a provider.
+- Provider extensions should use local data, environment variables, local provider connections, and direct `fetch`/Node APIs. They should not use Constellation-specific APIs to make a local provider work.
+
+## Capability guard
+
+Always guard provider registration:
+
+```ts
+export default function activate(letta) {
+  if (!letta.capabilities.providers) return;
+
+  return letta.providers.register("kilo", {
+    // provider config
+  });
+}
+```
+
+`letta.registerProvider(id, config)` is also supported, but prefer `letta.providers.register(...)` so the capability being used is explicit.
+
+## Basic API-key provider
+
+```ts
+// ~/.letta/extensions/kilo.ts
+export default function activate(letta) {
+  if (!letta.capabilities.providers) return;
+
+  return letta.providers.register("kilo", {
+    name: "Kilo",
+    description: "Connect to Kilo's OpenAI-compatible API",
+    api: "openai-completions",
+    baseUrl: "https://api.kilo.example/v1",
+    apiKey: "KILO_API_KEY",
+    models: [
+      {
+        id: "kilo-code",
+        name: "Kilo Code",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 8192,
+      },
+    ],
+    connect: {
+      fields: [
+        { key: "apiKey", label: "Kilo API Key", secret: true },
+      ],
+    },
+  });
+}
+```
+
+After `/reload`, this provider appears in local `/connect` and in the desktop local provider page. The model handle is `<provider-id>/<model-id>`, for example `kilo/kilo-code`.
+
+## Config fields
+
+Common provider config fields:
+
+```ts
+{
+  name?: string;
+  description?: string;
+  api?: string;             // common: "openai-completions", "openai-responses", "anthropic-messages", "bedrock-converse-stream"
+  baseUrl?: string;
+  apiKey?: string;          // env var name to resolve, e.g. "KILO_API_KEY"
+  headers?: Record<string, string>; // values resolve through process.env when present
+  authHeader?: boolean;     // add Authorization: Bearer <apiKey>
+  models?: Array<model>;
+  listModels?: (connection) => Promise<Array<model>> | Array<model>;
+  connect?: boolean | { fields?: Array<field> };
+}
+```
+
+Check `src/backend/dev/pi-provider-extension-types.ts` and pi-ai model types before documenting or using an uncommon `api` value.
+
+Model entries must include useful local runtime metadata:
+
+```ts
+{
+  id: "model-id-without-provider-prefix",
+  name: "Display Name",
+  api?: "openai-completions",
+  reasoning: false,
+  input: ["text"],          // or ["text", "image"]
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128000,
+  maxTokens: 8192,
+  headers?: {},
+}
+```
+
+Do not set `model.baseUrl` when all models use the provider-level URL. Model-level `baseUrl` overrides the connected provider base URL, so `/connect` base URL overrides will be ignored. Use it only when a specific model intentionally needs a different endpoint.
+
+## Dynamic model discovery
+
+Use `listModels(connection)` when the provider exposes a models endpoint or the model list depends on connected credentials:
+
+```ts
+export default function activate(letta) {
+  if (!letta.capabilities.providers) return;
+
+  return letta.providers.register("kilo", {
+    name: "Kilo",
+    api: "openai-completions",
+    baseUrl: "https://api.kilo.example/v1",
+    apiKey: "KILO_API_KEY",
+    async listModels(connection) {
+      const response = await fetch(`${connection.baseUrl}/models`, {
+        headers: {
+          Authorization: `Bearer ${connection.apiKey}`,
+          ...connection.headers,
+        },
+      });
+      if (!response.ok) {
+        throw new Error(`Kilo model list failed: ${response.status}`);
+      }
+      const body = await response.json();
+      return body.data.map((model) => ({
+        id: model.id,
+        name: model.id,
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 8192,
+      }));
+    },
+  });
+}
+```
+
+`connection` contains the provider id/name plus resolved local connection details:
+
+```ts
+{
+  id: string;
+  providerName: string;
+  baseUrl?: string;
+  apiKey?: string;
+  headers?: Record<string, string>;
+}
+```
+
+Keep dynamic listing lightweight and fail with short actionable errors. If listing is flaky, provide a static `models` fallback instead.
+
+## Connect behavior
+
+- `connect: undefined` or `connect: true` uses default API key + base URL fields.
+- `connect: { fields: [...] }` customizes local `/connect` / desktop fields.
+- `connect: false` hides the provider from `/connect`; use only when credentials come entirely from environment variables or local code.
+- `apiKey: "ENV_VAR_NAME"` resolves from `process.env.ENV_VAR_NAME` when available. Do not hardcode real secrets.
+- Custom fields are currently required. `placeholder` is display-only, not a default value.
+- If the provider has a normal fixed `baseUrl`, set provider-level `baseUrl` and omit `baseUrl` from `connect.fields`; the local runtime will use the provider-level URL after the API key is saved.
+- Include `{ key: "baseUrl", ... }` only when the user must enter or override the endpoint during connect.
+
+Default custom fields use these keys when possible because the local provider store understands them:
+
+```ts
+{ key: "apiKey", label: "API Key", secret: true }
+{ key: "baseUrl", label: "Base URL" }
+```
+
+## Review checklist
+
+- The extension says or implies the provider is local-agent only when reporting back to the user.
+- `letta.capabilities.providers` is checked before registration.
+- Provider id is stable, lowercase, and suitable as the model-handle prefix.
+- Model ids are unprefixed; Letta Code exposes them as `<provider-id>/<model-id>`.
+- `contextWindow`, `maxTokens`, `input`, and `reasoning` metadata are accurate enough for local selection and context display.
+- Model-level `baseUrl` is omitted unless the model intentionally needs a different endpoint from the provider/connection.
+- `connect.fields` contains only fields the user must type; placeholders are not treated as defaults.
+- Secrets are read from environment/local provider connections, not hardcoded.
+- Provider registration does not depend on commands/tools/UI/events or `letta.client`.
+- The user is told to run `/reload`, then configure the provider through local `/connect` or desktop Connect model providers.

--- a/src/skills/builtin/creating-extensions/references/tools.md
+++ b/src/skills/builtin/creating-extensions/references/tools.md
@@ -4,6 +4,13 @@ Use tools when the agent/model should call a local capability autonomously.
 
 For tools that are part of a larger extension with commands, UI, local state, or events, also read `architecture.md`.
 
+## Contents
+
+- Defaults
+- Read-only shell tool
+- Tool with arguments
+- Mutating or risky tool
+
 ## Defaults
 
 - Name: lowercase/underscore tool name, e.g. `branch_summary`.


### PR DESCRIPTION
## Summary
- add provider-extension guidance to the creating-extensions skill
- document that custom providers are local-agent/local-backend only, not Constellation
- add capability/surface caveats for provider-only listener loading
- call out connect-field behavior so agents do not require base URL input unless it is truly needed

## Tests
- `npx tsx src/skills/builtin/creating-skills/scripts/package-skill.ts src/skills/builtin/creating-extensions /tmp/letta-skill-validate`
- `bun run check`