### PR TITLE
fix(startup): harden setup and version entrypoints

### DIFF
--- a/src/cli/local-first-setup-wiring.test.ts
+++ b/src/cli/local-first-setup-wiring.test.ts
@@ -80,6 +80,18 @@ describe("local-first setup wiring", () => {
     );
   });
 
+  test("startup completes terminal preflight before rendering setup UI", () => {
+    const source = readSource("../index.ts");
+    const setupCalls = [...source.matchAll(/runSetup\(/g)];
+
+    expect(source).toContain("const ensureTerminalPreflightComplete");
+    expect(setupCalls.length).toBeGreaterThanOrEqual(3);
+    for (const match of setupCalls) {
+      const prefix = source.slice(Math.max(0, match.index - 220), match.index);
+      expect(prefix).toContain("await ensureTerminalPreflightComplete();");
+    }
+  });
+
   test("startup auto-enters local mode for credentialless new users while honoring saved local preference", () => {
     const source = readSource("../index.ts");
     const start = source.indexOf('settings.preferredBackendMode === "local"');

--- a/src/cli/local-first-setup-wiring.test.ts
+++ b/src/cli/local-first-setup-wiring.test.ts
@@ -95,7 +95,10 @@ describe("local-first setup wiring", () => {
   test("startup auto-enters local mode for credentialless new users while honoring saved local preference", () => {
     const source = readSource("../index.ts");
     const start = source.indexOf('settings.preferredBackendMode === "local"');
-    const end = source.indexOf('configureBackendMode("local")', start);
+    const end = source.indexOf(
+      "await tryConfigureStartupLocalBackend()",
+      start,
+    );
 
     expect(start).toBeGreaterThan(-1);
     expect(end).toBeGreaterThan(start);
@@ -111,7 +114,7 @@ describe("local-first setup wiring", () => {
       "Local-first new-user flow: if the user has no Letta Cloud credentials",
     );
     const setupEnd = source.indexOf(
-      "await settingsManager.flush();",
+      "const startupTargetLookupOrder",
       setupStart,
     );
     expect(setupStart).toBeGreaterThan(-1);
@@ -124,13 +127,25 @@ describe("local-first setup wiring", () => {
     expect(setupSegment).toContain("!isHeadless");
     expect(setupSegment).toContain("!settings.refreshToken");
     expect(setupSegment).toContain("!apiKey");
-    expect(setupSegment).toContain('configureBackendMode("local")');
+    expect(setupSegment).toContain("await tryConfigureStartupLocalBackend()");
     expect(setupSegment).toContain(
       'settingsManager.updateSettings({ preferredBackendMode: "local" })',
     );
     expect(setupSegment).toContain("await settingsManager.flush();");
     expect(source).toContain("isCredentiallessLocalStartup");
     expect(source).toContain(".filter((entry) => entry.isLocal)");
+  });
+
+  test("local transcript migration errors do not block setup login fallback", () => {
+    const source = readSource("../index.ts");
+
+    expect(source).toContain("isLocalBackendTranscriptStartupError");
+    expect(source).toContain("LocalTranscriptMigrationRequiredError");
+    expect(source).toContain("Unsupported local transcript format");
+    expect(source).toContain("const tryConfigureStartupLocalBackend");
+    expect(source).toContain("Continuing to setup/login");
+    expect(source).toContain('configureBackendMode("api")');
+    expect(source).toContain('preferredBackendMode: "api"');
   });
 
   test("backend and setup subcommands expose default backend controls", () => {

--- a/src/cli/subcommands/router.test.ts
+++ b/src/cli/subcommands/router.test.ts
@@ -2,6 +2,24 @@ import { describe, expect, test } from "bun:test";
 import { runSubcommand } from "@/cli/subcommands/router";
 
 describe("subcommand router", () => {
+  test("routes version subcommand before TUI startup", async () => {
+    const messages: string[] = [];
+    const originalLog = console.log;
+    console.log = (message?: unknown) => {
+      messages.push(String(message));
+    };
+
+    try {
+      const exitCode = await runSubcommand(["version"]);
+
+      expect(exitCode).toBe(0);
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toMatch(/^\d+\.\d+\.\d+ .*\(Letta Code\)$/);
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
   test("routes connect subcommand", async () => {
     const exitCode = await runSubcommand(["connect", "help"]);
     expect(exitCode).toBe(0);

--- a/src/cli/subcommands/router.ts
+++ b/src/cli/subcommands/router.ts
@@ -17,6 +17,12 @@ async function runUpdateSubcommand(): Promise<number> {
   return result.success ? 0 : 1;
 }
 
+async function runVersionSubcommand(): Promise<number> {
+  const { getVersion } = await import("@/version");
+  console.log(`${getVersion()} (Letta Code)`);
+  return 0;
+}
+
 export async function runSubcommand(argv: string[]): Promise<number | null> {
   const [command, ...rest] = argv;
 
@@ -25,6 +31,8 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
   }
 
   switch (command) {
+    case "version":
+      return runVersionSubcommand();
     case "update":
     case "upgrade":
       return runUpdateSubcommand();

--- a/src/index.ts
+++ b/src/index.ts
@@ -582,6 +582,15 @@ function isBackendNotFoundError(error: unknown): boolean {
   );
 }
 
+function isLocalBackendTranscriptStartupError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.name === "LocalTranscriptMigrationRequiredError" ||
+    error.name === "LocalTranscriptRepairRequiredError" ||
+    error.message.includes("Unsupported local transcript format")
+  );
+}
+
 async function getLocalBackendStartupFallbackSession(
   backend: Backend,
 ): Promise<LocalStartupFallbackSession | null> {
@@ -902,6 +911,26 @@ async function main(): Promise<void> {
     process.env.LETTA_BASE_URL ||
     settings.env?.LETTA_BASE_URL ||
     LETTA_CLOUD_API_URL;
+  const tryConfigureStartupLocalBackend = async (): Promise<boolean> => {
+    try {
+      configureBackendMode("local");
+      return true;
+    } catch (error) {
+      if (!isLocalBackendTranscriptStartupError(error)) {
+        throw error;
+      }
+      console.warn(
+        `Local backend data needs migration before it can be used: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      console.warn(
+        "Continuing to setup/login so local transcript migration does not block account access.",
+      );
+      configureBackendMode("api");
+      settingsManager.updateSettings({ preferredBackendMode: "api" });
+      await settingsManager.flush();
+      return false;
+    }
+  };
 
   if (
     !explicitBackendMode &&
@@ -909,7 +938,7 @@ async function main(): Promise<void> {
     settings.preferredBackendMode === "local" &&
     baseURL === LETTA_CLOUD_API_URL
   ) {
-    configureBackendMode("local");
+    await tryConfigureStartupLocalBackend();
   }
 
   // Local-first new-user flow: if the user has no Letta Cloud credentials and
@@ -924,9 +953,10 @@ async function main(): Promise<void> {
     !settings.refreshToken &&
     !apiKey
   ) {
-    configureBackendMode("local");
-    settingsManager.updateSettings({ preferredBackendMode: "local" });
-    await settingsManager.flush();
+    if (await tryConfigureStartupLocalBackend()) {
+      settingsManager.updateSettings({ preferredBackendMode: "local" });
+      await settingsManager.flush();
+    }
   }
 
   const startupTargetLookupOrder = getStartupTargetLookupOrderForCredentials({

--- a/src/index.ts
+++ b/src/index.ts
@@ -893,6 +893,9 @@ async function main(): Promise<void> {
         }
       })()
     : Promise.resolve(undefined);
+  const ensureTerminalPreflightComplete = async () => {
+    await terminalPreflightPromise;
+  };
 
   let apiKey = process.env.LETTA_API_KEY || settings.env?.LETTA_API_KEY;
   const baseURL =
@@ -1244,6 +1247,7 @@ async function main(): Promise<void> {
       !apiKey
     ) {
       // For interactive mode, show setup flow
+      await ensureTerminalPreflightComplete();
       const { runSetup } = await import("@/auth/setup");
       const setupResult = await runSetup();
       if (setupResult.kind === "cancelled") {
@@ -1266,6 +1270,7 @@ async function main(): Promise<void> {
     if (!apiKey && baseURL === LETTA_CLOUD_API_URL) {
       // For interactive mode, show setup flow
       console.log("No credentials found. Let's get you set up!\n");
+      await ensureTerminalPreflightComplete();
       const { runSetup } = await import("@/auth/setup");
       const setupResult = await runSetup();
       if (setupResult.kind === "cancelled") {
@@ -1392,6 +1397,7 @@ async function main(): Promise<void> {
         }
 
         console.log("Let's reauthenticate your setup.\n");
+        await ensureTerminalPreflightComplete();
         const { runSetup } = await import("@/auth/setup");
         const setupResult = await runSetup({
           initialMode: baseURL === LETTA_CLOUD_API_URL ? "device-code" : "menu",


### PR DESCRIPTION
## Summary

- Treat `letta version` as an early subcommand so it exits before backend startup, matching `--version` behavior.
- Await terminal preflight before rendering any setup/login Ink UI so Kitty detection cannot restore cooked stdin while the menu is mounted.
- If non-explicit local startup hits local transcript migration/format errors, reset to API mode and continue to setup/login instead of bricking account access.

## Testing

- `bun test src/cli/subcommands/router.test.ts src/cli/local-first-setup-wiring.test.ts`
- `bun run check`

The added tests guard the exact regression surfaces: early command routing before TUI/backend init, setup rendering only after terminal preflight completes, and local transcript migration errors falling back to setup/login instead of blocking startup.