### PR TITLE
test(startup): cover setup keyboard input in PTY

### DIFF
--- a/src/startup-setup-pty.test.ts
+++ b/src/startup-setup-pty.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const projectRoot = process.cwd();
+
+function ensureBuiltCli(): string {
+  const cliPath = join(projectRoot, "letta.js");
+  if (existsSync(cliPath)) {
+    return cliPath;
+  }
+
+  const result = spawnSync("bun", ["run", "build"], {
+    cwd: projectRoot,
+    encoding: "utf-8",
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `Failed to build letta.js\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+  }
+  return cliPath;
+}
+
+const ptyTest = process.platform === "win32" ? test.skip : test;
+
+describe("startup setup PTY", () => {
+  ptyTest(
+    "setup menu keeps raw keyboard input after terminal preflight",
+    () => {
+      const runnerPath = join(
+        projectRoot,
+        "src/test-utils/startup-setup-pty-runner.cjs",
+      );
+      const result = spawnSync(
+        "node",
+        [runnerPath, ensureBuiltCli(), projectRoot],
+        {
+          cwd: projectRoot,
+          encoding: "utf-8",
+          timeout: 30000,
+        },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.signal).toBeNull();
+      expect(result.stderr).toBe("");
+    },
+    { timeout: 35000 },
+  );
+});

--- a/src/test-utils/startup-setup-pty-runner.cjs
+++ b/src/test-utils/startup-setup-pty-runner.cjs
@@ -1,0 +1,151 @@
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const pty = require("node-pty");
+
+const [, , cliPath, projectRoot] = process.argv;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForOutput(getOutput, predicate, label, timeoutMs = 10000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const output = getOutput();
+    if (predicate(output)) return output;
+    await sleep(25);
+  }
+  throw new Error(
+    `Timed out waiting for ${label}. Output:\n${globalThis.stripAnsi(getOutput()).slice(-4000)}`,
+  );
+}
+
+function writeBrokenLocalTranscriptStore(homeDir) {
+  const lettaDir = path.join(homeDir, ".letta");
+  const conversationDir = path.join(
+    lettaDir,
+    "lc-local-backend",
+    "conversations",
+    "broken",
+  );
+  fs.mkdirSync(conversationDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(lettaDir, "settings.json"),
+    `${JSON.stringify({ preferredBackendMode: "local" }, null, 2)}\n`,
+  );
+  fs.writeFileSync(
+    path.join(conversationDir, "conversation.json"),
+    `${JSON.stringify({
+      id: "local-conv-broken",
+      agent_id: "agent-local-broken",
+      in_context_message_ids: [],
+    })}\n`,
+  );
+  fs.writeFileSync(
+    path.join(conversationDir, "manifest.json"),
+    `${JSON.stringify({
+      schema_version: 999,
+      message_format: "future-jsonl",
+      provider_stack: "pi-ai",
+      created_at: new Date().toISOString(),
+    })}\n`,
+  );
+  fs.writeFileSync(path.join(conversationDir, "messages.jsonl"), "");
+}
+
+async function main() {
+  if (!cliPath || !projectRoot) {
+    throw new Error(
+      "Usage: startup-setup-pty-runner.cjs <cliPath> <projectRoot>",
+    );
+  }
+
+  globalThis.stripAnsi = (await import("strip-ansi")).default;
+
+  const homeDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "letta-setup-pty-home-"),
+  );
+  let terminal;
+  try {
+    writeBrokenLocalTranscriptStore(homeDir);
+
+    let output = "";
+    let exited = false;
+    terminal = pty.spawn(
+      "node",
+      [cliPath, "--agent", "agent-4140c4b5-f32e-475c-9573-bcfd9446ca7b"],
+      {
+        cols: 120,
+        cwd: projectRoot,
+        env: {
+          PATH: process.env.PATH,
+          HOME: homeDir,
+          TERM: "xterm-256color",
+          DISABLE_AUTOUPDATER: "1",
+          LETTA_DISABLE_SESSION_PERSIST: "1",
+        },
+        name: "xterm-256color",
+        rows: 30,
+      },
+    );
+    terminal.onData((data) => {
+      output += data;
+    });
+    terminal.onExit(() => {
+      exited = true;
+    });
+
+    await waitForOutput(
+      () => output,
+      (current) =>
+        globalThis.stripAnsi(current).includes("Welcome to Letta Code"),
+      "setup menu",
+    );
+    const initialOutput = globalThis.stripAnsi(output);
+    if (!initialOutput.includes("> Proceed locally (default)")) {
+      throw new Error(
+        `Setup menu did not default to local. Output:\n${initialOutput}`,
+      );
+    }
+    if (initialOutput.includes("Unsupported local transcript format")) {
+      throw new Error(
+        `Local transcript error leaked into setup. Output:\n${initialOutput}`,
+      );
+    }
+
+    const beforeInputLength = output.length;
+    terminal.write("\x1b[A");
+    await waitForOutput(
+      () => output,
+      (current) =>
+        globalThis.stripAnsi(current).includes("> Login to Constellation"),
+      "up-arrow selection change",
+    );
+
+    const afterInputOutput = globalThis.stripAnsi(
+      output.slice(beforeInputLength),
+    );
+    if (afterInputOutput.includes("^[[A")) {
+      throw new Error(
+        `Arrow key was echoed instead of handled. Output:\n${afterInputOutput}`,
+      );
+    }
+    if (exited) {
+      throw new Error("CLI exited while setup menu should still be active");
+    }
+  } finally {
+    if (terminal) {
+      terminal.write("\x03");
+      terminal.kill();
+    }
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(
+    error instanceof Error ? error.stack || error.message : String(error),
+  );
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds a PTY smoke test for the bundled `letta.js` setup/login screen.
- Seeds an isolated HOME with preferred local mode and a stale/unsupported local transcript manifest, then launches `letta.js --agent <cloud-agent-id>` with no credentials.
- Verifies the setup menu renders, local transcript errors do not leak into the login path, Up arrow moves selection, and the arrow escape sequence is not echoed as `^[[A`.

This follows #2747 and catches the raw-mode/login-bricking regression end-to-end.

## Testing

- `bun test src/startup-setup-pty.test.ts`
- `bun run check`