### PR TITLE
fix(startup): disable local setup for explicit cloud agents

### DIFF
--- a/src/auth/setup-ui.tsx
+++ b/src/auth/setup-ui.tsx
@@ -26,32 +26,45 @@ interface SetupUIProps {
   onComplete: (result: SetupResult) => void;
   onCancel: () => void;
   initialMode?: SetupInitialMode;
+  localModeDisabledReason?: string;
 }
 
 export function SetupUI({
   onComplete,
   onCancel,
   initialMode = "menu",
+  localModeDisabledReason,
 }: SetupUIProps) {
+  const localModeDisabled = Boolean(localModeDisabledReason);
   const [mode, setMode] = useState<SetupMode>(initialMode);
   const [selectedOption, setSelectedOption] = useState(
-    initialMode === "device-code" ? 0 : 1,
+    initialMode === "device-code" || localModeDisabled ? 0 : 1,
   );
   const [error, setError] = useState<string | null>(null);
   const [doneMessage, setDoneMessage] = useState("Starting Letta Code...");
+  const selectNextOption = (current: number, delta: 1 | -1): number => {
+    const options = localModeDisabled ? [0, 2] : [0, 1, 2];
+    const currentIndex = options.indexOf(current);
+    const nextIndex = Math.min(
+      options.length - 1,
+      Math.max(0, currentIndex + delta),
+    );
+    return options[nextIndex] ?? current;
+  };
+
   // Handle menu navigation
   useInput(
     (_input, key) => {
       if (mode === "menu") {
         if (key.upArrow) {
-          setSelectedOption((prev) => Math.max(0, prev - 1));
+          setSelectedOption((prev) => selectNextOption(prev, -1));
         } else if (key.downArrow) {
-          setSelectedOption((prev) => Math.min(2, prev + 1));
+          setSelectedOption((prev) => selectNextOption(prev, 1));
         } else if (key.return) {
           if (selectedOption === 0) {
             // Login to Constellation - start device code flow
             setMode("device-code");
-          } else if (selectedOption === 1) {
+          } else if (selectedOption === 1 && !localModeDisabled) {
             proceedLocally();
           } else if (selectedOption === 2) {
             onCancel();
@@ -144,18 +157,25 @@ export function SetupUI({
       <Box>
         <Text
           color={
-            selectedOption === 1 ? colors.selector.itemHighlighted : undefined
+            selectedOption === 1 && !localModeDisabled
+              ? colors.selector.itemHighlighted
+              : undefined
           }
+          dimColor={localModeDisabled}
         >
           {selectedOption === 1 ? "> " : "  "}
-          {LOCAL_MODE_LABEL} (default)
+          {LOCAL_MODE_LABEL} {localModeDisabled ? "(unavailable)" : "(default)"}
         </Text>
       </Box>
       <Box paddingLeft={2}>
-        <Text dimColor>
-          Store agent state on this device. Agents you create are local to this
-          machine.
-        </Text>
+        {localModeDisabledReason ? (
+          <Text dimColor>{localModeDisabledReason}</Text>
+        ) : (
+          <Text dimColor>
+            Store agent state on this device. Agents you create are local to
+            this machine.
+          </Text>
+        )}
       </Box>
       <Box>
         <Text

--- a/src/auth/setup.ts
+++ b/src/auth/setup.ts
@@ -8,6 +8,7 @@ import { type SetupInitialMode, type SetupResult, SetupUI } from "./setup-ui";
 
 interface RunSetupOptions {
   initialMode?: SetupInitialMode;
+  localModeDisabledReason?: string;
 }
 
 /**
@@ -32,6 +33,7 @@ export async function runSetup(
     instance = render(
       React.createElement(SetupUI, {
         initialMode: options.initialMode,
+        localModeDisabledReason: options.localModeDisabledReason,
         onComplete: settle,
         onCancel: () => settle({ kind: "cancelled" }),
       }),

--- a/src/cli/local-first-setup-wiring.test.ts
+++ b/src/cli/local-first-setup-wiring.test.ts
@@ -13,14 +13,16 @@ describe("local-first setup wiring", () => {
     expect(source).toContain(
       'const AUTH_LOGIN_LABEL = "Login to Constellation"',
     );
-    expect(source).toContain('initialMode === "device-code" ? 0 : 1');
+    expect(source).toContain(
+      'initialMode === "device-code" || localModeDisabled ? 0 : 1',
+    );
     expect(source).toContain('configureBackendMode("local")');
     expect(source).toContain(
       'settingsManager.updateSettings({ preferredBackendMode: "local" })',
     );
     expect(source).toContain("letta setup");
     expect(source).toContain("letta backend api");
-    expect(source).toContain("Agents you create are local to this");
+    expect(source).toContain("Agents you create are local to");
     expect(source).toContain("chat.letta.com");
     expect(source).toContain("Welcome to Letta Code");
     expect(source).not.toContain("Welcome to Letta Code.");
@@ -55,7 +57,9 @@ describe("local-first setup wiring", () => {
       "LETTA_API_KEY is set in your environment, so OAuth login cannot replace the credential Letta Code is using.",
     );
 
-    expect(setupSource).toContain('initialMode === "device-code" ? 0 : 1');
+    expect(setupSource).toContain(
+      'initialMode === "device-code" || localModeDisabled ? 0 : 1',
+    );
     expect(setupSource).toContain('onCancel={() => setMode("menu")}');
     expect(setupRunnerSource).toContain("initialMode?: SetupInitialMode");
     expect(setupRunnerSource).toContain("Promise<SetupResult>");
@@ -77,6 +81,33 @@ describe("local-first setup wiring", () => {
     expect(indexSource).toContain("const shouldValidateCredentials =");
     expect(indexSource).toContain(
       "baseURL === LETTA_CLOUD_API_URL || Boolean(apiKey)",
+    );
+  });
+
+  test("explicit cloud agent setup disables local mode to avoid restart loops", () => {
+    const setupSource = readSource("../auth/setup-ui.tsx");
+    const setupRunnerSource = readSource("../auth/setup.ts");
+    const indexSource = readSource("../index.ts");
+
+    expect(setupSource).toContain("localModeDisabledReason?: string");
+    expect(setupSource).toContain(
+      "const localModeDisabled = Boolean(localModeDisabledReason)",
+    );
+    expect(setupSource).toContain("localModeDisabled ? [0, 2] : [0, 1, 2]");
+    expect(setupSource).toContain("Proceed locally");
+    expect(setupSource).toContain("(unavailable)");
+    expect(setupSource).toContain("selectedOption === 1 && !localModeDisabled");
+    expect(setupRunnerSource).toContain("localModeDisabledReason?: string");
+    expect(setupRunnerSource).toContain(
+      "localModeDisabledReason: options.localModeDisabledReason",
+    );
+
+    expect(indexSource).toContain("const setupLocalModeDisabledReason =");
+    expect(indexSource).toContain('inferredBackendModeFromAgentId === "api"');
+    expect(indexSource).toContain("is a Constellation agent");
+    expect(indexSource).toContain("rerun without --agent to start locally");
+    expect(indexSource).toContain(
+      "localModeDisabledReason: setupLocalModeDisabledReason",
     );
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -844,6 +844,12 @@ async function main(): Promise<void> {
   if (!explicitBackendMode && inferredBackendModeFromAgentId) {
     configureBackendMode(inferredBackendModeFromAgentId);
   }
+  const setupLocalModeDisabledReason =
+    !explicitBackendMode &&
+    specifiedAgentId &&
+    inferredBackendModeFromAgentId === "api"
+      ? `Agent ${specifiedAgentId} is a Constellation agent. Sign in to access it, or rerun without --agent to start locally.`
+      : undefined;
   const specifiedModel = values.model ?? undefined;
   const systemPromptPreset = values.system ?? undefined;
   const systemCustom = values["system-custom"] ?? undefined;
@@ -1279,7 +1285,9 @@ async function main(): Promise<void> {
       // For interactive mode, show setup flow
       await ensureTerminalPreflightComplete();
       const { runSetup } = await import("@/auth/setup");
-      const setupResult = await runSetup();
+      const setupResult = await runSetup({
+        localModeDisabledReason: setupLocalModeDisabledReason,
+      });
       if (setupResult.kind === "cancelled") {
         process.exit(0);
       }
@@ -1302,7 +1310,9 @@ async function main(): Promise<void> {
       console.log("No credentials found. Let's get you set up!\n");
       await ensureTerminalPreflightComplete();
       const { runSetup } = await import("@/auth/setup");
-      const setupResult = await runSetup();
+      const setupResult = await runSetup({
+        localModeDisabledReason: setupLocalModeDisabledReason,
+      });
       if (setupResult.kind === "cancelled") {
         process.exit(0);
       }
@@ -1431,6 +1441,7 @@ async function main(): Promise<void> {
         const { runSetup } = await import("@/auth/setup");
         const setupResult = await runSetup({
           initialMode: baseURL === LETTA_CLOUD_API_URL ? "device-code" : "menu",
+          localModeDisabledReason: setupLocalModeDisabledReason,
         });
         if (setupResult.kind === "cancelled") {
           process.exit(0);


### PR DESCRIPTION
## Summary

- Detect explicit cloud/Constellation agent ids during startup setup flows.
- Disable `Proceed locally` in the setup menu for that case so users do not enter a restart loop where `--agent agent-...` keeps forcing API mode.
- Show targeted copy explaining that the requested agent requires sign-in, or rerunning without `--agent` to start locally.

## Testing

- `bun test src/cli/local-first-setup-wiring.test.ts`
- `bun run check`