### PR TITLE
feat: expose extension permission overlays

### DIFF
--- a/src/cli/app/use-approval-flow.ts
+++ b/src/cli/app/use-approval-flow.ts
@@ -804,6 +804,11 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
             const permission = await checkToolPermission(
               approval.toolName,
               parsedArgs,
+              undefined,
+              undefined,
+              undefined,
+              approvalToolContextIdRef.current,
+              approval.toolCallId,
             );
             return { approval, permission };
           }),
@@ -976,6 +981,7 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
       setIsExecutingTool,
       setPendingApprovals,
       setThinkingMessage,
+      approvalToolContextIdRef,
     ],
   );
 

--- a/src/cli/app/use-conversation-loop.ts
+++ b/src/cli/app/use-conversation-loop.ts
@@ -1918,6 +1918,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
                 alwaysRequiresUserInput,
                 missingNameReason:
                   "Tool call incomplete - missing name or arguments",
+                toolContextId: approvalToolContextIdRef.current,
               });
 
             // Precompute diffs for file edit tools before execution (both auto-allowed and needs-user-input)

--- a/src/cli/approval-classification.test.ts
+++ b/src/cli/approval-classification.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { classifyApprovals } from "@/cli/helpers/approval-classification";
+import {
+  clearExtensionPermissions,
+  registerExtensionPermission,
+} from "@/extensions/permission-registry";
 import { permissionMode } from "@/permissions/mode";
 import { loadTools } from "@/tools/manager";
 
@@ -7,6 +11,7 @@ describe("classifyApprovals", () => {
   const originalMemoryDir = process.env.MEMORY_DIR;
 
   afterEach(() => {
+    clearExtensionPermissions();
     permissionMode.reset();
     if (originalMemoryDir === undefined) {
       delete process.env.MEMORY_DIR;
@@ -46,5 +51,106 @@ describe("classifyApprovals", () => {
       "Bash tool missing required parameter: command. Received parameters: description",
     );
     expect(denied?.permission.reason).toBe(denied?.denyReason);
+  });
+
+  test("extension permission overlays deny before unrestricted auto-allow", async () => {
+    permissionMode.setMode("unrestricted");
+    registerExtensionPermission({
+      id: "block-dangerous-shell",
+      description: "Block dangerous shell commands",
+      path: "/tmp/block-dangerous-shell.ts",
+      owner: {
+        id: "global:/tmp/block-dangerous-shell.ts",
+        path: "/tmp/block-dangerous-shell.ts",
+        scope: "global",
+        generation: 1,
+      },
+      activationSignal: new AbortController().signal,
+      getContext: () => {
+        throw new Error("unused");
+      },
+      isAvailable: () => true,
+      check(event) {
+        if (
+          event.toolName === "Bash" &&
+          typeof event.args.command === "string" &&
+          event.args.command.includes("rm -rf")
+        ) {
+          return { decision: "deny", reason: "rm is blocked" };
+        }
+        return undefined;
+      },
+    });
+
+    const result = await classifyApprovals(
+      [
+        {
+          toolCallId: "call-dangerous",
+          toolName: "Bash",
+          toolArgs: JSON.stringify({ command: "rm -rf /tmp/nope" }),
+        },
+      ],
+      { workingDirectory: "/tmp/project" },
+    );
+
+    expect(result.autoAllowed).toHaveLength(0);
+    expect(result.needsUserInput).toHaveLength(0);
+    expect(result.autoDenied).toHaveLength(1);
+    expect(result.autoDenied[0]?.permission).toMatchObject({
+      decision: "deny",
+      matchedRule: "extension permission:block-dangerous-shell",
+      reason: "rm is blocked",
+    });
+  });
+
+  test("extension permission overlays allow scoped tools before default ask", async () => {
+    registerExtensionPermission({
+      id: "allow-plan-file",
+      description: "Allow writes to the active plan file",
+      path: "/tmp/allow-plan-file.ts",
+      owner: {
+        id: "global:/tmp/allow-plan-file.ts",
+        path: "/tmp/allow-plan-file.ts",
+        scope: "global",
+        generation: 1,
+      },
+      activationSignal: new AbortController().signal,
+      getContext: () => {
+        throw new Error("unused");
+      },
+      isAvailable: () => true,
+      check(event) {
+        if (
+          event.toolName === "Write" &&
+          event.args.file_path === "/tmp/plan.md"
+        ) {
+          return { decision: "allow", reason: "active plan file" };
+        }
+        return undefined;
+      },
+    });
+
+    const result = await classifyApprovals(
+      [
+        {
+          toolCallId: "call-plan-file",
+          toolName: "Write",
+          toolArgs: JSON.stringify({
+            file_path: "/tmp/plan.md",
+            content: "# Plan",
+          }),
+        },
+      ],
+      { workingDirectory: "/tmp/project" },
+    );
+
+    expect(result.autoDenied).toHaveLength(0);
+    expect(result.needsUserInput).toHaveLength(0);
+    expect(result.autoAllowed).toHaveLength(1);
+    expect(result.autoAllowed[0]?.permission).toMatchObject({
+      decision: "allow",
+      matchedRule: "extension permission:allow-plan-file",
+      reason: "active plan file",
+    });
   });
 });

--- a/src/cli/extensions/capabilities.ts
+++ b/src/cli/extensions/capabilities.ts
@@ -8,6 +8,7 @@ export const TUI_EXTENSION_CAPABILITIES: ExtensionCapabilities = {
     tools: true,
     turns: true,
   },
+  permissions: true,
   providers: true,
   ui: {
     panels: true,

--- a/src/cli/helpers/approval-classification.ts
+++ b/src/cli/helpers/approval-classification.ts
@@ -39,6 +39,7 @@ export type ClassifyApprovalsOptions<TContext = ApprovalContext | null> = {
   workingDirectory?: string;
   permissionModeState?: PermissionModeState;
   agentId?: string;
+  toolContextId?: string | null;
 };
 
 export async function getMissingRequiredArgs(
@@ -126,6 +127,8 @@ export async function classifyApprovals<TContext = ApprovalContext | null>(
       opts.workingDirectory,
       opts.permissionModeState,
       opts.agentId,
+      opts.toolContextId,
+      approval.toolCallId,
     );
     const context = opts.getContext
       ? await opts.getContext(toolName, parsedArgs, opts.workingDirectory)

--- a/src/extensions/capabilities.ts
+++ b/src/extensions/capabilities.ts
@@ -8,6 +8,7 @@ export const DEFAULT_EXTENSION_CAPABILITIES: ExtensionCapabilities = {
     tools: true,
     turns: true,
   },
+  permissions: true,
   providers: true,
   ui: {
     panels: true,
@@ -24,6 +25,7 @@ export const DISABLED_EXTENSION_CAPABILITIES: ExtensionCapabilities = {
     tools: false,
     turns: false,
   },
+  permissions: false,
   providers: false,
   ui: {
     panels: false,
@@ -43,6 +45,7 @@ export function cloneExtensionCapabilities(
       tools: capabilities.events.tools,
       turns: capabilities.events.turns,
     },
+    permissions: capabilities.permissions,
     providers: capabilities.providers,
     ui: {
       panels: capabilities.ui.panels,

--- a/src/extensions/disabled-extension-adapter.test.ts
+++ b/src/extensions/disabled-extension-adapter.test.ts
@@ -8,6 +8,11 @@ import { DISABLED_EXTENSION_CAPABILITIES } from "@/extensions/capabilities";
 import { LETTA_DISABLE_EXTENSIONS_ENV } from "@/extensions/disable";
 import { createDisabledExtensionAdapter } from "@/extensions/disabled-extension-adapter";
 import {
+  clearExtensionPermissions,
+  getExtensionPermissionDefinition,
+  registerExtensionPermission,
+} from "@/extensions/permission-registry";
+import {
   clearExtensionTools,
   getExtensionToolDefinition,
   registerExtensionTool,
@@ -43,6 +48,23 @@ function registerTestExtensionTool(name: string): void {
   });
 }
 
+function registerTestExtensionPermission(id: string): void {
+  registerExtensionPermission({
+    activationSignal: new AbortController().signal,
+    check: () => undefined,
+    getContext: () => createExtensionContext(),
+    id,
+    isAvailable: () => true,
+    owner: {
+      generation: 0,
+      id: `test:${id}`,
+      path: `${id}.ts`,
+      scope: "global",
+    },
+    path: `${id}.ts`,
+  });
+}
+
 function registerTestPiProvider(name: string): void {
   registerPiProvider(name, {
     api: "openai-completions",
@@ -68,9 +90,13 @@ describe("disabled extension adapter", () => {
 
     try {
       delete process.env[LETTA_DISABLE_EXTENSIONS_ENV];
+      registerTestExtensionPermission("stale-permission");
       registerTestExtensionTool("stale_extension_tool");
       registerTestPiProvider("stale-provider");
 
+      expect(
+        getExtensionPermissionDefinition("stale-permission"),
+      ).toBeDefined();
       expect(getExtensionToolDefinition("stale_extension_tool")).toBeDefined();
       expect(listRegisteredPiProviders()).toHaveLength(1);
 
@@ -89,10 +115,14 @@ describe("disabled extension adapter", () => {
       expect(adapter.getSnapshot().registry.sources).toEqual([]);
       expect(adapter.getSnapshot().registry.loadedPaths).toEqual([]);
       expect(adapter.getSnapshot().registry.commands).toEqual({});
+      expect(adapter.getSnapshot().registry.permissions).toEqual({});
       expect(adapter.getSnapshot().registry.tools).toEqual({});
       expect(adapter.getSnapshot().registry.ui.panels).toEqual({});
       expect(adapter.getSnapshot().registry.ui.statuslineRenderer).toBeNull();
       expect(adapter.getBackend()).toBeUndefined();
+      expect(
+        getExtensionPermissionDefinition("stale-permission"),
+      ).toBeUndefined();
       expect(
         getExtensionToolDefinition("stale_extension_tool"),
       ).toBeUndefined();
@@ -120,6 +150,7 @@ describe("disabled extension adapter", () => {
 
       adapter.dispose();
     } finally {
+      clearExtensionPermissions();
       clearExtensionTools();
       clearRegisteredPiProviders();
       if (originalDisableEnv === undefined) {

--- a/src/extensions/disabled-extension-adapter.ts
+++ b/src/extensions/disabled-extension-adapter.ts
@@ -11,6 +11,7 @@ import type {
   ExtensionEngine,
   LocalExtensionRegistry,
 } from "@/extensions/extension-engine";
+import { clearExtensionPermissions } from "@/extensions/permission-registry";
 import { clearExtensionTools } from "@/extensions/tool-registry";
 import type { ExtensionContext } from "@/extensions/types";
 
@@ -29,6 +30,7 @@ function createDisabledExtensionRegistry(): LocalExtensionRegistry {
     loadedPaths: [],
     ownerAbortControllers: {},
     owners: {},
+    permissions: {},
     sources: [],
     tools: {},
     ui: {
@@ -63,6 +65,7 @@ function createDisabledExtensionEngine(
 export function createDisabledExtensionAdapter(
   options: CreateDisabledExtensionAdapterOptions,
 ) {
+  clearExtensionPermissions();
   clearExtensionTools();
   clearRegisteredPiProviders();
 

--- a/src/extensions/extension-engine.test.ts
+++ b/src/extensions/extension-engine.test.ts
@@ -14,6 +14,10 @@ import {
   type ExtensionEngine,
 } from "@/extensions/extension-engine";
 import {
+  clearExtensionPermissions,
+  getExtensionPermissionDefinition,
+} from "@/extensions/permission-registry";
+import {
   clearExtensionTools,
   getExtensionToolDefinition,
 } from "@/extensions/tool-registry";
@@ -104,6 +108,7 @@ const TOOL_ONLY_EXTENSION_CAPABILITIES: ExtensionCapabilities = {
   tools: true,
   commands: false,
   events: { lifecycle: false, tools: false, turns: false },
+  permissions: false,
   providers: false,
   ui: {
     panels: false,
@@ -114,6 +119,7 @@ const TOOL_ONLY_EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 
 describe("extension engine", () => {
   afterEach(() => {
+    clearExtensionPermissions();
     clearExtensionTools();
     clearRegisteredPiProviders();
   });
@@ -1035,6 +1041,49 @@ describe("extension engine", () => {
 
       engine.dispose();
       expect(getExtensionToolDefinition("local_weather")).toBeUndefined();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("loads extension-provided permission overlays with owner metadata", async () => {
+    const root = createTempDir();
+    try {
+      const extensionDir = path.join(root, "global-extensions");
+      const extensionPath = path.join(extensionDir, "permissions.ts");
+      mkdirSync(extensionDir, { recursive: true });
+      writeFileSync(
+        extensionPath,
+        `export default function(letta) {
+          return letta.permissions.register({
+            id: "plan-mode",
+            description: "Allow reads and plan-file writes while planning",
+            check(event) {
+              if (event.toolName === "Write") {
+                return { decision: "deny", reason: "write blocked while planning" };
+              }
+            },
+          });
+        }`,
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+      const snapshot = engine.getSnapshot();
+
+      expect(getExtensionErrorDiagnostics(snapshot.diagnostics)).toEqual([]);
+      expect(snapshot.permissions["plan-mode"]).toMatchObject({
+        description: "Allow reads and plan-file writes while planning",
+        owner: {
+          generation: 1,
+          id: `global:${extensionPath}`,
+          path: extensionPath,
+        },
+      });
+      expect(getExtensionPermissionDefinition("plan-mode")).toBeDefined();
+
+      engine.dispose();
+      expect(getExtensionPermissionDefinition("plan-mode")).toBeUndefined();
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/src/extensions/extension-engine.ts
+++ b/src/extensions/extension-engine.ts
@@ -40,6 +40,12 @@ import {
   recordStaleHandleUse,
 } from "@/extensions/extension-diagnostics";
 import {
+  getExtensionPermissionDefinition,
+  registerExtensionPermission,
+  unregisterExtensionPermission,
+  unregisterExtensionPermissionsForOwner,
+} from "@/extensions/permission-registry";
+import {
   getExtensionToolDefinition,
   registerExtensionTool,
   unregisterExtensionTool,
@@ -66,6 +72,8 @@ import type {
   ExtensionPanelHandle,
   ExtensionPanelOptions,
   ExtensionPanelUpdate,
+  ExtensionPermission,
+  ExtensionPermissionRegistration,
   ExtensionTool,
   ExtensionToolRegistration,
   ExtensionToolStartEvent,
@@ -141,6 +149,12 @@ export interface LettaExtensionApi {
       handler: ExtensionEventHandler<TName>,
     ) => LettaExtensionDisposer;
   };
+  permissions: {
+    register: (
+      permission: ExtensionPermissionRegistration,
+    ) => LettaExtensionDisposer;
+    unregister: (id: string) => void;
+  };
   diagnostics: {
     report: (diagnostic: ExtensionDiagnosticReportOptions) => void;
   };
@@ -183,6 +197,7 @@ export interface LocalExtensionRegistry {
   loadedPaths: string[];
   ownerAbortControllers: Record<string, AbortController>;
   owners: Record<string, ExtensionOwner>;
+  permissions: Record<string, ExtensionPermission>;
   sources: LocalExtensionSource[];
   tools: Record<string, ExtensionTool>;
   ui: LocalExtensionUiRegistry;
@@ -283,6 +298,7 @@ function createEmptyExtensionRegistry(
     loadedPaths: [],
     ownerAbortControllers: {},
     owners: {},
+    permissions: {},
     sources,
     tools: {},
     ui: {
@@ -332,6 +348,7 @@ function snapshotRegistryForReaders(
     loadedPaths: [...registry.loadedPaths],
     ownerAbortControllers: { ...registry.ownerAbortControllers },
     owners: { ...registry.owners },
+    permissions: { ...registry.permissions },
     sources: registry.sources.map((source) => ({
       ...source,
       files: [...source.files],
@@ -681,6 +698,35 @@ function normalizeExtensionCommand(
   };
 }
 
+function validateExtensionPermissionId(id: string): void {
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(id)) {
+    throw new Error(
+      "Extension permission id must be a lowercase slug using letters, numbers, and hyphens",
+    );
+  }
+}
+
+function normalizeExtensionPermission(
+  permission: ExtensionPermissionRegistration,
+  owner: ExtensionOwner,
+): ExtensionPermission {
+  validateExtensionPermissionId(permission.id);
+  if (typeof permission.check !== "function") {
+    throw new Error(
+      `Extension permission '${permission.id}' must include check()`,
+    );
+  }
+
+  return {
+    id: permission.id,
+    ...(permission.description ? { description: permission.description } : {}),
+    owner,
+    path: owner.path,
+    ...(permission.isEnabled ? { isEnabled: permission.isEnabled } : {}),
+    check: permission.check,
+  };
+}
+
 function validateExtensionToolName(name: string): void {
   if (!/^[a-zA-Z0-9_-]{1,64}$/.test(name)) {
     throw new Error(
@@ -830,6 +876,18 @@ function createLettaExtensionApi(
     const existing = registry.commands[id];
     if (existing?.owner?.id === owner.id) {
       delete registry.commands[id];
+      onChange();
+    }
+  };
+
+  const unregisterPermission = (id: string) => {
+    if (!capabilities.permissions) return;
+    validateExtensionPermissionId(id);
+    if (!guardLive({ id, kind: "permission" })) return;
+    const existing = registry.permissions[id];
+    if (existing?.owner?.id === owner.id) {
+      delete registry.permissions[id];
+      unregisterExtensionPermission(id, owner);
       onChange();
     }
   };
@@ -1052,6 +1110,40 @@ function createLettaExtensionApi(
     events: {
       off: unregisterEvent,
       on: onEvent,
+    },
+    permissions: {
+      register(permission) {
+        if (!capabilities.permissions) {
+          return () => undefined;
+        }
+        if (!guardLive({ id: permission.id, kind: "permission" })) {
+          return () => undefined;
+        }
+
+        const normalized = normalizeExtensionPermission(permission, owner);
+        const existing = registry.permissions[normalized.id];
+        const existingGlobal = getExtensionPermissionDefinition(normalized.id);
+        if (existing || existingGlobal) {
+          throw new Error(
+            `Extension permission '${normalized.id}' is already registered by ${existing?.path ?? existingGlobal?.path}`,
+          );
+        }
+
+        registry.permissions[normalized.id] = normalized;
+        registerExtensionPermission({
+          ...normalized,
+          activationSignal: signal,
+          getContext,
+          isAvailable: () => {
+            if (signal.aborted) return false;
+            return normalized.isEnabled?.(getContext()) ?? true;
+          },
+        });
+        onChange();
+
+        return () => unregisterPermission(normalized.id);
+      },
+      unregister: unregisterPermission,
     },
     diagnostics: {
       report: reportDiagnostic,
@@ -1372,6 +1464,7 @@ export function disposeLocalExtensions(registry: LocalExtensionRegistry): void {
 
   for (const owner of Object.values(registry.owners)) {
     unregisterPiProvidersForOwner(owner.id);
+    unregisterExtensionPermissionsForOwner(owner);
     unregisterExtensionToolsForOwner(owner);
   }
   clearAvailableModelsCache();
@@ -1380,6 +1473,7 @@ export function disposeLocalExtensions(registry: LocalExtensionRegistry): void {
   registry.events = {};
   registry.ownerAbortControllers = {};
   registry.owners = {};
+  registry.permissions = {};
   registry.tools = {};
   registry.ui.panels = {};
   registry.ui.statusOwners = {};

--- a/src/extensions/permission-registry.ts
+++ b/src/extensions/permission-registry.ts
@@ -1,0 +1,165 @@
+import type {
+  ExtensionContext,
+  ExtensionOwner,
+  ExtensionPermission,
+  ExtensionPermissionCheckEvent,
+  ExtensionPermissionCheckResult,
+} from "@/extensions/types";
+import { areExtensionsDisabled } from "./disable";
+
+const EXTENSION_PERMISSIONS_KEY = Symbol.for("@letta/extensionPermissions");
+
+type GlobalWithExtensionPermissions = typeof globalThis & {
+  [EXTENSION_PERMISSIONS_KEY]?: Map<string, ExtensionPermissionDefinition>;
+};
+
+export interface ExtensionPermissionDefinition extends ExtensionPermission {
+  activationSignal: AbortSignal;
+  getContext: () => ExtensionContext;
+  isAvailable: () => boolean;
+}
+
+export interface ExtensionPermissionDecisionResult {
+  decision: "allow" | "ask" | "deny";
+  matchedRule: string;
+  reason?: string;
+}
+
+function getMutableExtensionPermissionsRegistry(): Map<
+  string,
+  ExtensionPermissionDefinition
+> {
+  const global = globalThis as GlobalWithExtensionPermissions;
+  if (!global[EXTENSION_PERMISSIONS_KEY]) {
+    global[EXTENSION_PERMISSIONS_KEY] = new Map();
+  }
+  return global[EXTENSION_PERMISSIONS_KEY];
+}
+
+export function getAvailableExtensionPermissionsRegistry(): Map<
+  string,
+  ExtensionPermissionDefinition
+> {
+  if (areExtensionsDisabled()) return new Map();
+
+  return new Map(
+    Array.from(getMutableExtensionPermissionsRegistry().entries()).filter(
+      ([, permission]) => {
+        if (permission.activationSignal.aborted) return false;
+        try {
+          return permission.isAvailable();
+        } catch {
+          return false;
+        }
+      },
+    ),
+  );
+}
+
+export function registerExtensionPermission(
+  permission: ExtensionPermissionDefinition,
+): void {
+  if (areExtensionsDisabled()) return;
+  getMutableExtensionPermissionsRegistry().set(permission.id, permission);
+}
+
+export function unregisterExtensionPermission(
+  id: string,
+  owner: ExtensionOwner,
+): void {
+  const registry = getMutableExtensionPermissionsRegistry();
+  const existing = registry.get(id);
+  if (existing?.owner?.id === owner.id) {
+    registry.delete(id);
+  }
+}
+
+export function unregisterExtensionPermissionsForOwner(
+  owner: ExtensionOwner,
+): void {
+  const registry = getMutableExtensionPermissionsRegistry();
+  for (const [id, permission] of registry.entries()) {
+    if (permission.owner?.id === owner.id) {
+      registry.delete(id);
+    }
+  }
+}
+
+export function clearExtensionPermissions(): void {
+  getMutableExtensionPermissionsRegistry().clear();
+}
+
+export function getExtensionPermissionDefinition(
+  id: string,
+  registry: Map<
+    string,
+    ExtensionPermissionDefinition
+  > = getMutableExtensionPermissionsRegistry(),
+): ExtensionPermissionDefinition | undefined {
+  if (areExtensionsDisabled()) return undefined;
+  return registry.get(id);
+}
+
+function normalizePermissionResult(
+  result: ExtensionPermissionCheckResult,
+): ExtensionPermissionCheckResult {
+  if (result === undefined) return undefined;
+  if (
+    result.decision === "allow" ||
+    result.decision === "ask" ||
+    result.decision === "deny"
+  ) {
+    return result;
+  }
+  return undefined;
+}
+
+function composePermissionDecision(
+  decisions: ExtensionPermissionDecisionResult[],
+): ExtensionPermissionDecisionResult | undefined {
+  return (
+    decisions.find((result) => result.decision === "deny") ??
+    decisions.find((result) => result.decision === "ask") ??
+    decisions.find((result) => result.decision === "allow")
+  );
+}
+
+export async function checkExtensionPermissions(
+  event: ExtensionPermissionCheckEvent,
+  registry: Map<
+    string,
+    ExtensionPermissionDefinition
+  > = getAvailableExtensionPermissionsRegistry(),
+): Promise<ExtensionPermissionDecisionResult | undefined> {
+  if (areExtensionsDisabled()) return undefined;
+
+  const decisions: ExtensionPermissionDecisionResult[] = [];
+  for (const permission of registry.values()) {
+    if (permission.activationSignal.aborted) continue;
+
+    let rawResult: ExtensionPermissionCheckResult;
+    try {
+      if (!permission.isAvailable()) continue;
+      rawResult = await permission.check(event, {
+        getContext: permission.getContext,
+        signal: permission.activationSignal,
+      });
+    } catch (error) {
+      return {
+        decision: "deny",
+        matchedRule: `extension permission:${permission.id}`,
+        reason: `Extension permission '${permission.id}' failed: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+
+    const result = normalizePermissionResult(rawResult);
+    if (!result) continue;
+    decisions.push({
+      decision: result.decision,
+      matchedRule: `extension permission:${permission.id}`,
+      reason: result.reason,
+    });
+  }
+
+  return composePermissionDecision(decisions);
+}

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -79,6 +79,7 @@ export interface ExtensionCapabilities {
   tools: boolean;
   commands: boolean;
   events: ExtensionEventCapabilities;
+  permissions: boolean;
   providers: boolean;
   ui: ExtensionUiCapabilities;
 }
@@ -247,6 +248,7 @@ export interface ExtensionEventEmissionResult<
 export type ExtensionCapabilityKind =
   | "command"
   | "event"
+  | "permission"
   | "provider"
   | "tool"
   | "panel"
@@ -457,4 +459,51 @@ export interface ExtensionTool {
   parallelSafe: boolean;
   isEnabled?: ExtensionToolRegistration["isEnabled"];
   run: ExtensionToolRegistration["run"];
+}
+
+export type ExtensionPermissionDecision = "allow" | "ask" | "deny";
+
+export type ExtensionPermissionCheckPhase = "approval" | "execution";
+
+export interface ExtensionPermissionCheckEvent {
+  agentId: string | null;
+  conversationId: string | null;
+  toolCallId: string | null;
+  toolName: string;
+  args: Record<string, unknown>;
+  cwd: string;
+  workingDirectory: string;
+  permissionMode: string | null;
+  phase: ExtensionPermissionCheckPhase;
+}
+
+export type ExtensionPermissionCheckResult =
+  | {
+      decision: ExtensionPermissionDecision;
+      reason?: string;
+    }
+  | undefined;
+
+export interface ExtensionPermissionCheckContext {
+  getContext: () => ExtensionContext;
+  signal: AbortSignal;
+}
+
+export interface ExtensionPermissionRegistration {
+  id: string;
+  description?: string;
+  isEnabled?: (context: ExtensionContext) => boolean;
+  check: (
+    event: ExtensionPermissionCheckEvent,
+    context: ExtensionPermissionCheckContext,
+  ) => ExtensionPermissionCheckResult | Promise<ExtensionPermissionCheckResult>;
+}
+
+export interface ExtensionPermission {
+  id: string;
+  description?: string;
+  owner?: ExtensionOwner;
+  path: string;
+  isEnabled?: ExtensionPermissionRegistration["isEnabled"];
+  check: ExtensionPermissionRegistration["check"];
 }

--- a/src/headless-extension-adapter.ts
+++ b/src/headless-extension-adapter.ts
@@ -27,6 +27,7 @@ export const HEADLESS_EXTENSION_CAPABILITIES: ExtensionCapabilities = {
     tools: true,
     turns: true,
   },
+  permissions: true,
   providers: true,
   ui: {
     panels: false,

--- a/src/headless-extension-lifecycle.test.ts
+++ b/src/headless-extension-lifecycle.test.ts
@@ -45,6 +45,7 @@ describe("headless extension adapter", () => {
         tools: true,
         turns: true,
       },
+      permissions: true,
       providers: true,
       ui: {
         panels: false,

--- a/src/permissions/checker.ts
+++ b/src/permissions/checker.ts
@@ -3,6 +3,11 @@
 
 import { resolve } from "node:path";
 import { getCurrentAgentId } from "@/agent/context";
+import {
+  checkExtensionPermissions,
+  type ExtensionPermissionDefinition,
+  getAvailableExtensionPermissionsRegistry,
+} from "@/extensions/permission-registry";
 import { extensionToolRequiresApproval } from "@/extensions/tool-registry";
 import { runPermissionRequestHooks } from "@/hooks";
 import type { PermissionModeState } from "@/tools/manager";
@@ -91,6 +96,12 @@ const FILE_TOOLS_V1 = [
 ];
 
 type ToolArgs = Record<string, unknown>;
+
+interface ExtensionPermissionCheckOptions {
+  conversationId?: string | null;
+  phase?: "approval" | "execution";
+  toolCallId?: string | null;
+}
 
 function envFlagEnabled(name: string): boolean {
   const value = process.env[name];
@@ -818,9 +829,14 @@ export async function checkPermissionWithHooks(
   workingDirectory: string = process.cwd(),
   modeState?: PermissionModeState,
   agentId?: string,
+  extensionPermissions: Map<
+    string,
+    ExtensionPermissionDefinition
+  > = getAvailableExtensionPermissionsRegistry(),
+  extensionPermissionOptions: ExtensionPermissionCheckOptions = {},
 ): Promise<PermissionCheckResult> {
   // First, check permission using normal rules
-  const result = checkPermission(
+  let result = checkPermission(
     toolName,
     toolArgs,
     permissions,
@@ -828,6 +844,32 @@ export async function checkPermissionWithHooks(
     modeState,
     agentId,
   );
+
+  if (result.decision !== "deny") {
+    const extensionDecision = await checkExtensionPermissions(
+      {
+        agentId: agentId ?? null,
+        conversationId: extensionPermissionOptions.conversationId ?? null,
+        toolCallId: extensionPermissionOptions.toolCallId ?? null,
+        toolName,
+        args: toolArgs,
+        cwd: workingDirectory,
+        workingDirectory,
+        permissionMode: modeState?.mode ?? permissionMode.getMode(),
+        phase: extensionPermissionOptions.phase ?? "approval",
+      },
+      extensionPermissions,
+    );
+    if (extensionDecision) {
+      result = {
+        decision: extensionDecision.decision,
+        matchedRule: extensionDecision.matchedRule,
+        reason:
+          extensionDecision.reason ??
+          `Matched ${extensionDecision.matchedRule}`,
+      };
+    }
+  }
 
   // If decision is "ask", run PermissionRequest hooks to see if they auto-allow/deny
   if (result.decision === "ask") {

--- a/src/skills/builtin/creating-extensions/SKILL.md
+++ b/src/skills/builtin/creating-extensions/SKILL.md
@@ -26,6 +26,7 @@ Capabilities vary by surface. TUI/headless may load tools, commands, events, UI,
 | Show transient output above input | Panel, usually from a command |
 | Show small persistent state | Status value |
 | React to app/session lifecycle or transform outbound turns | Event |
+| Enforce dynamic allow/ask/deny policy for tool calls | Permission overlay |
 | Add a custom model/API provider for local agents | Provider extension (local agents only) |
 | Change the bottom statusline appearance | Use `customizing-statusline`, not this skill |
 
@@ -40,6 +41,7 @@ Default to a **tool** when the model should decide when to use the capability. D
    - commands: `references/commands.md`
    - local custom providers: `references/providers.md`
    - events: `references/events.md`
+   - permissions: `references/permissions.md`
    - panels/status/capabilities: `references/ui.md`
    - busy side-question pattern: `references/btw-command.md`
 4. For multi-capability or stateful extensions, also read `references/architecture.md`.
@@ -76,6 +78,7 @@ letta.capabilities.commands
 letta.capabilities.events.lifecycle
 letta.capabilities.events.tools
 letta.capabilities.events.turns
+letta.capabilities.permissions
 letta.capabilities.providers
 letta.capabilities.ui.panels
 letta.capabilities.ui.statusValues
@@ -140,6 +143,7 @@ Before finishing, verify:
 | `references/commands.md` | The human should invoke `/foo` |
 | `references/providers.md` | Adding a custom model/API provider for local agents |
 | `references/events.md` | Reacting to lifecycle/tool/turn events or transforming turns/tools |
+| `references/permissions.md` | Enforcing dynamic tool allow/ask/deny policy before approval/execution |
 | `references/ui.md` | Panels, status values, or statusline capability guards are involved |
 | `references/btw-command.md` | Building a busy-safe side-question command with a forked conversation |
 | `references/architecture.md` | Multiple capabilities, local state, cleanup, background model work, or non-trivial composition |

--- a/src/skills/builtin/creating-extensions/references/events.md
+++ b/src/skills/builtin/creating-extensions/references/events.md
@@ -6,7 +6,7 @@ Use events when trusted local code should react to app/session changes or transf
 
 - Capabilities
 - Supported events
-- Tool argument transforms and denial
+- Tool argument transforms
 - Turn input transforms
 - Event handler context
 - Conversation status example
@@ -44,7 +44,7 @@ letta.events.on("event_name", (event, ctx) => {
 });
 ```
 
-Tool events use this same API. Existing settings-based hooks still own blocking decisions and model feedback injection until those contracts are explicitly added to extension events.
+Tool events use this same API. Use `letta.permissions.register` for allow/ask/deny policy; use `tool_start` for last-mile argument transforms and lifecycle reactions.
 
 ```ts
 letta.events.on("tool_start", (event, ctx) => {
@@ -115,7 +115,7 @@ Lifecycle handlers are notification-only and should not return values. `turn_sta
 }
 ```
 
-`tool_start` fires immediately before a client-side tool executes. This includes built-in tools, extension tools, and external tools executed through the local tool manager. It runs after permission/approval classification and before `PreToolUse` hooks, so trusted local extensions can change the actual executed arguments after the approval UI has already classified the original request.
+`tool_start` fires immediately before a client-side tool executes. This includes built-in tools, extension tools, and external tools executed through the local tool manager. It runs after permission/approval classification and before `PreToolUse` hooks, so trusted local extensions can change the actual executed arguments after the approval UI has already classified the original request. Extension permission overlays are rechecked after `tool_start` on the final args.
 
 Handlers can inspect `event.args`, mutate it directly, or return replacement args:
 

--- a/src/skills/builtin/creating-extensions/references/permissions.md
+++ b/src/skills/builtin/creating-extensions/references/permissions.md
@@ -1,0 +1,88 @@
+# Extension permission recipes
+
+Use permission overlays when trusted local code should participate in tool approval decisions. Prefer permissions over `tool_start` denial for policy: permissions run before approval UI and again before execution on final tool arguments.
+
+## Capability
+
+```ts
+letta.capabilities.permissions
+```
+
+Guard registrations when writing portable extensions:
+
+```ts
+export default function activate(letta) {
+  if (!letta.capabilities.permissions) return;
+
+  return letta.permissions.register({
+    id: "plan-mode",
+    description: "Allow read-only tools and writes only to the active plan file.",
+    check(event) {
+      if (!isPlanModeActive(event.conversationId)) return;
+
+      if (isReadOnlyTool(event.toolName, event.args)) {
+        return { decision: "allow" };
+      }
+
+      if (isActivePlanFileWrite(event.toolName, event.args)) {
+        return { decision: "allow", reason: "active plan file" };
+      }
+
+      return {
+        decision: "deny",
+        reason: "Plan mode is active. You can only read files or update the plan file.",
+      };
+    },
+  });
+}
+```
+
+## Event shape
+
+```ts
+{
+  agentId: string | null;
+  conversationId: string | null;
+  toolCallId: string | null;
+  toolName: string;
+  args: Record<string, unknown>;
+  cwd: string;
+  workingDirectory: string;
+  permissionMode: string | null;
+  phase: "approval" | "execution";
+}
+```
+
+## Return values
+
+Return one of:
+
+```ts
+{ decision: "allow", reason?: string }
+{ decision: "ask", reason?: string }
+{ decision: "deny", reason?: string }
+undefined // no opinion
+```
+
+Composition rules across overlays:
+
+- `deny` wins
+- then `ask`
+- then `allow`
+- `undefined` means no opinion
+
+User/configured hard denials still win before extension overlays. Extension overlays can override normal auto-allow/default approval behavior, including unrestricted/yolo mode.
+
+## Two phases
+
+Permission overlays run during approval classification (`phase: "approval"`) and again immediately before execution (`phase: "execution"`) after any `tool_start` argument transforms.
+
+During execution, `ask` cannot reopen approval yet, so use `deny` for execution-time blocking behavior.
+
+## Rules
+
+- Keep checks fast and deterministic.
+- Return `undefined` when the overlay is not active for the current conversation/state.
+- Prefer path-scoped allow rules over broad allow rules.
+- Do not mutate `event.args`; use `tool_start` for argument transforms.
+- For policy decisions, prefer this API over `tool_start` denial.

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -1993,8 +1993,13 @@ function createExtensionDenialToolResult(denial: {
 function createExtensionPermissionToolResult(
   decision: ExtensionPermissionDecisionResult,
 ): ToolExecutionResult {
+  const isApprovalRequest = decision.decision === "ask";
+  const action = isApprovalRequest ? "blocked" : "denied";
+  const fallbackReason = isApprovalRequest
+    ? "Approval requested but cannot reopen during execution."
+    : "No reason given.";
   return {
-    toolReturn: `Error: Tool execution denied by ${decision.matchedRule}. ${decision.reason ?? "No reason given."}`,
+    toolReturn: `Error: Tool execution ${action} by ${decision.matchedRule}. ${decision.reason ?? fallbackReason}`,
     status: "error",
   };
 }

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -25,6 +25,12 @@ import {
   emitExtensionEvent,
 } from "@/extensions/event-emitter";
 import {
+  checkExtensionPermissions,
+  type ExtensionPermissionDecisionResult,
+  type ExtensionPermissionDefinition,
+  getAvailableExtensionPermissionsRegistry,
+} from "@/extensions/permission-registry";
+import {
   type ExtensionToolDefinition,
   extensionToolRequiresApproval,
   getAvailableExtensionToolsRegistry,
@@ -592,6 +598,7 @@ type ToolExecutionContextSnapshot = {
   externalTools: Map<string, ExternalToolDefinition>;
   externalExecutor?: ExternalToolExecutor;
   extensionEvents?: ExtensionEvents;
+  extensionPermissions: Map<string, ExtensionPermissionDefinition>;
   extensionTools: Map<string, ExtensionToolDefinition>;
   workingDirectory: string;
   runtimeContext: RuntimeContextSnapshot;
@@ -1015,6 +1022,7 @@ function capturePreparedToolExecutionContext(
     externalTools: Map<string, ExternalToolDefinition>;
     externalExecutor?: ExternalToolExecutor;
     extensionEvents?: ExtensionEvents;
+    extensionPermissions: Map<string, ExtensionPermissionDefinition>;
     extensionTools: Map<string, ExtensionToolDefinition>;
   },
   options?: {
@@ -1042,6 +1050,7 @@ function capturePreparedToolExecutionContext(
     ),
     externalExecutor: snapshot.externalExecutor,
     extensionEvents: options?.extensionEvents ?? snapshot.extensionEvents,
+    extensionPermissions: snapshot.extensionPermissions,
     extensionTools: filterExtensionToolsByClientAllowlist(
       snapshot.extensionTools,
       options?.clientToolAllowlist,
@@ -1081,6 +1090,7 @@ export function captureToolExecutionContext(
       toolRegistry: new Map(toolRegistry),
       externalTools: new Map(getExternalToolsRegistry()),
       externalExecutor: getExternalToolExecutor(),
+      extensionPermissions: getAvailableExtensionPermissionsRegistry(),
       extensionTools: getAvailableExtensionToolsRegistry(),
     },
     {
@@ -1110,6 +1120,7 @@ export async function prepareCurrentToolExecutionContext(options?: {
       externalTools: new Map(getExternalToolsRegistry()),
       externalExecutor: getExternalToolExecutor(),
       extensionEvents: options?.extensionEvents,
+      extensionPermissions: getAvailableExtensionPermissionsRegistry(),
       extensionTools: getAvailableExtensionToolsRegistry(),
     },
     options,
@@ -1138,6 +1149,7 @@ export async function prepareToolExecutionContextForSpecificTools(
       externalTools: new Map(getExternalToolsRegistry()),
       externalExecutor: getExternalToolExecutor(),
       extensionEvents: options?.extensionEvents,
+      extensionPermissions: getAvailableExtensionPermissionsRegistry(),
       extensionTools: getAvailableExtensionToolsRegistry(),
     },
     options,
@@ -1168,6 +1180,7 @@ export async function prepareToolExecutionContextForModel(
       externalTools: new Map(getExternalToolsRegistry()),
       externalExecutor: getExternalToolExecutor(),
       extensionEvents: options?.extensionEvents,
+      extensionPermissions: getAvailableExtensionPermissionsRegistry(),
       extensionTools: getAvailableExtensionToolsRegistry(),
     },
     options,
@@ -1198,6 +1211,34 @@ export function isExtensionToolParallelSafeForContext(
   );
 }
 
+async function checkExtensionPermissionForContext(options: {
+  args: ToolArgs;
+  context?: ToolExecutionContextSnapshot;
+  phase: "approval" | "execution";
+  toolCallId?: string | null;
+  toolName: string;
+  workingDirectory: string;
+}): Promise<ExtensionPermissionDecisionResult | undefined> {
+  const runtimeContext = options.context?.runtimeContext;
+  const permissionModeState = options.context?.permissionModeState;
+  return checkExtensionPermissions(
+    {
+      agentId: runtimeContext?.agentId ?? null,
+      conversationId: runtimeContext?.conversationId ?? null,
+      toolCallId: options.toolCallId ?? null,
+      toolName: options.toolName,
+      args: options.args,
+      cwd: options.workingDirectory,
+      workingDirectory: options.workingDirectory,
+      permissionMode:
+        permissionModeState?.mode ?? runtimeContext?.permissionMode ?? null,
+      phase: options.phase,
+    },
+    options.context?.extensionPermissions ??
+      getAvailableExtensionPermissionsRegistry(),
+  );
+}
+
 /**
  * Check permission for a tool execution using the full permission system.
  * @param toolName - Name of the tool
@@ -1208,9 +1249,11 @@ export function isExtensionToolParallelSafeForContext(
 export async function checkToolPermission(
   toolName: string,
   toolArgs: ToolArgs,
-  workingDirectory: string = process.cwd(),
+  workingDirectory?: string,
   permissionModeStateArg?: PermissionModeState,
   agentIdArg?: string,
+  toolContextIdArg?: string | null,
+  toolCallIdArg?: string | null,
 ): Promise<{
   decision: "allow" | "deny" | "ask";
   matchedRule?: string;
@@ -1219,21 +1262,38 @@ export async function checkToolPermission(
   const { checkPermissionWithHooks } = await import("@/permissions/checker");
   const { loadPermissions } = await import("@/permissions/loader");
 
-  const permissions = await loadPermissions(workingDirectory);
+  const context = toolContextIdArg
+    ? getExecutionContextById(toolContextIdArg)
+    : undefined;
+  const effectiveWorkingDirectory =
+    workingDirectory ?? context?.workingDirectory ?? process.cwd();
+  const effectivePermissionModeState =
+    permissionModeStateArg ?? context?.permissionModeState;
+  const effectiveAgentId =
+    agentIdArg ?? context?.runtimeContext.agentId ?? undefined;
+
+  const permissions = await loadPermissions(effectiveWorkingDirectory);
   return runWithRuntimeContext(
     {
-      ...(agentIdArg ? { agentId: agentIdArg } : {}),
-      workingDirectory,
-      permissionMode: permissionModeStateArg?.mode,
+      ...(effectiveAgentId ? { agentId: effectiveAgentId } : {}),
+      workingDirectory: effectiveWorkingDirectory,
+      permissionMode: effectivePermissionModeState?.mode,
     },
     () =>
       checkPermissionWithHooks(
         toolName,
         toolArgs,
         permissions,
-        workingDirectory,
-        permissionModeStateArg,
-        agentIdArg,
+        effectiveWorkingDirectory,
+        effectivePermissionModeState,
+        effectiveAgentId,
+        context?.extensionPermissions ??
+          getAvailableExtensionPermissionsRegistry(),
+        {
+          conversationId: context?.runtimeContext.conversationId ?? null,
+          phase: "approval",
+          toolCallId: toolCallIdArg ?? null,
+        },
       ),
   );
 }
@@ -1930,6 +1990,15 @@ function createExtensionDenialToolResult(denial: {
   };
 }
 
+function createExtensionPermissionToolResult(
+  decision: ExtensionPermissionDecisionResult,
+): ToolExecutionResult {
+  return {
+    toolReturn: `Error: Tool execution denied by ${decision.matchedRule}. ${decision.reason ?? "No reason given."}`,
+    status: "error",
+  };
+}
+
 function isToolStartArgs(value: unknown): value is ToolArgs {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -2238,6 +2307,19 @@ export async function executeTool(
     if (extDenial) {
       return createExtensionDenialToolResult(extDenial);
     }
+    const permissionDecision = await checkExtensionPermissionForContext({
+      args: eventArgs,
+      context,
+      phase: "execution",
+      toolCallId: options?.toolCallId,
+      toolName: name,
+      workingDirectory,
+    });
+    if (permissionDecision?.decision !== undefined) {
+      if (permissionDecision.decision !== "allow") {
+        return createExtensionPermissionToolResult(permissionDecision);
+      }
+    }
     return executeExtensionTool(
       name,
       extensionTool,
@@ -2264,6 +2346,19 @@ export async function executeTool(
     });
     if (extDenial) {
       return createExtensionDenialToolResult(extDenial);
+    }
+    const permissionDecision = await checkExtensionPermissionForContext({
+      args: eventArgs,
+      context,
+      phase: "execution",
+      toolCallId: options?.toolCallId,
+      toolName: name,
+      workingDirectory,
+    });
+    if (permissionDecision?.decision !== undefined) {
+      if (permissionDecision.decision !== "allow") {
+        return createExtensionPermissionToolResult(permissionDecision);
+      }
     }
     return executeExternalTool(
       options?.toolCallId ?? `ext-${Date.now()}`,
@@ -2309,6 +2404,19 @@ export async function executeTool(
   args = eventArgs;
   if (extDenial) {
     return createExtensionDenialToolResult(extDenial);
+  }
+  const permissionDecision = await checkExtensionPermissionForContext({
+    args,
+    context,
+    phase: "execution",
+    toolCallId: options?.toolCallId,
+    toolName: internalName,
+    workingDirectory,
+  });
+  if (permissionDecision?.decision !== undefined) {
+    if (permissionDecision.decision !== "allow") {
+      return createExtensionPermissionToolResult(permissionDecision);
+    }
   }
   const startTime = Date.now();
 

--- a/src/tools/tool-execution-context.test.ts
+++ b/src/tools/tool-execution-context.test.ts
@@ -255,6 +255,47 @@ describe("tool execution context snapshot", () => {
     expect(asText(result.toolReturn)).toContain("mutated path blocked");
   });
 
+  test("reports execution-phase ask decisions as blocked approval requests", async () => {
+    await loadSpecificTools(["Read"]);
+    registerExtensionPermission({
+      id: "execution-ask",
+      description: "Ask before execution",
+      path: "/tmp/execution-ask.ts",
+      owner: {
+        id: "global:/tmp/execution-ask.ts",
+        path: "/tmp/execution-ask.ts",
+        scope: "global",
+        generation: 1,
+      },
+      activationSignal: new AbortController().signal,
+      getContext: () => {
+        throw new Error("unused");
+      },
+      isAvailable: () => true,
+      check(event) {
+        if (event.phase === "execution" && event.toolName === "Read") {
+          return { decision: "ask" };
+        }
+        return undefined;
+      },
+    });
+
+    const prepared = await prepareCurrentToolExecutionContext();
+    const result = await executeTool(
+      "Read",
+      { file_path: "README.md" },
+      { toolContextId: prepared.contextId },
+    );
+
+    const text = asText(result.toolReturn);
+    expect(result.status).toBe("error");
+    expect(text).toContain("blocked by extension permission:execution-ask");
+    expect(text).toContain(
+      "Approval requested but cannot reopen during execution.",
+    );
+    expect(text).not.toContain("denied by extension permission:execution-ask");
+  });
+
   test("prepares explicit tool snapshots without reading the global registry", async () => {
     await loadSpecificTools(["Edit"]);
 

--- a/src/tools/tool-execution-context.test.ts
+++ b/src/tools/tool-execution-context.test.ts
@@ -28,9 +28,14 @@ import {
 } from "@/channels/routing";
 import type { ChannelAdapter } from "@/channels/types";
 import {
+  clearExtensionPermissions,
+  registerExtensionPermission,
+} from "@/extensions/permission-registry";
+import {
   clearExtensionTools,
   registerExtensionTool,
 } from "@/extensions/tool-registry";
+import type { ExtensionToolStartEvent } from "@/extensions/types";
 import {
   LETTA_INHERITED_CHANNEL_CONTEXT_ENV,
   runWithRuntimeContext,
@@ -123,6 +128,7 @@ describe("tool execution context snapshot", () => {
     clearDynamicMessageChannelToolCache();
     clearCapturedToolExecutionContexts();
     clearExternalTools();
+    clearExtensionPermissions();
     clearExtensionTools();
     clearAllRoutes();
     __testOverrideLoadRoutes(null);
@@ -141,6 +147,7 @@ describe("tool execution context snapshot", () => {
 
   afterAll(async () => {
     clearExternalTools();
+    clearExtensionPermissions();
     clearExtensionTools();
     if (initialTools.length > 0) {
       await loadSpecificTools(initialTools);
@@ -189,6 +196,63 @@ describe("tool execution context snapshot", () => {
       { toolContextId: contextId },
     );
     expect(withContext.status).toBe("success");
+  });
+
+  test("rechecks extension permission overlays after tool_start arg transforms", async () => {
+    await loadSpecificTools(["Read"]);
+    registerExtensionPermission({
+      id: "execution-gate",
+      description: "Deny mutated reads",
+      path: "/tmp/execution-gate.ts",
+      owner: {
+        id: "global:/tmp/execution-gate.ts",
+        path: "/tmp/execution-gate.ts",
+        scope: "global",
+        generation: 1,
+      },
+      activationSignal: new AbortController().signal,
+      getContext: () => {
+        throw new Error("unused");
+      },
+      isAvailable: () => true,
+      check(event) {
+        if (
+          event.phase === "execution" &&
+          event.toolName === "Read" &&
+          event.args.file_path === "package.json"
+        ) {
+          return { decision: "deny", reason: "mutated path blocked" };
+        }
+        return undefined;
+      },
+    });
+
+    const prepared = await prepareCurrentToolExecutionContext({
+      extensionEvents: {
+        async emit(name, event) {
+          if (name === "tool_start") {
+            const toolStartEvent = event as ExtensionToolStartEvent;
+            toolStartEvent.args = {
+              ...toolStartEvent.args,
+              file_path: "package.json",
+            };
+          }
+          return { diagnostics: [], handlerCount: 0, name, results: [] };
+        },
+      },
+    });
+
+    const result = await executeTool(
+      "Read",
+      { file_path: "README.md" },
+      { toolContextId: prepared.contextId },
+    );
+
+    expect(result.status).toBe("error");
+    expect(asText(result.toolReturn)).toContain(
+      "extension permission:execution-gate",
+    );
+    expect(asText(result.toolReturn)).toContain("mutated path blocked");
   });
 
   test("prepares explicit tool snapshots without reading the global registry", async () => {

--- a/src/websocket/listener/extension-adapter.test.ts
+++ b/src/websocket/listener/extension-adapter.test.ts
@@ -37,6 +37,7 @@ describe("listener extension adapter", () => {
         tools: false,
         turns: false,
       },
+      permissions: false,
       providers: true,
       ui: {
         panels: false,

--- a/src/websocket/listener/extension-adapter.ts
+++ b/src/websocket/listener/extension-adapter.ts
@@ -20,6 +20,7 @@ export const LISTENER_EXTENSION_CAPABILITIES: ExtensionCapabilities = {
     tools: false,
     turns: false,
   },
+  permissions: false,
   providers: true,
   ui: {
     panels: false,


### PR DESCRIPTION
## Summary
- add `letta.permissions.register(...)` for extension-provided allow/ask/deny overlays
- run overlays during approval classification and recheck them after `tool_start` arg transforms before execution
- snapshot permission overlays in prepared tool contexts and clean them up on reload/disable
- document the new extension permission recipe

## Test Plan
- `bun run check`
- `bun test src/cli/approval-classification.test.ts src/extensions/extension-engine.test.ts src/extensions/disabled-extension-adapter.test.ts src/tools/tool-execution-context.test.ts`