### PR TITLE
fix(cli): toggle memory viewer with Cmd+M

### DIFF
--- a/src/cli/components/MemfsTreeViewer.tsx
+++ b/src/cli/components/MemfsTreeViewer.tsx
@@ -113,6 +113,12 @@ export function MemfsTreeViewer({
 
   // Handle input
   useInput((input, key) => {
+    // Cmd+M: toggle memory viewer closed (desktop shortcut parity)
+    if (key.meta && input.toLowerCase() === "m") {
+      onClose();
+      return;
+    }
+
     // CTRL-C: immediately close
     if (key.ctrl && input === "c") {
       onClose();

--- a/src/cli/components/MemoryTabViewer.tsx
+++ b/src/cli/components/MemoryTabViewer.tsx
@@ -86,6 +86,12 @@ export function MemoryTabViewer({
   };
 
   useInput((input, key) => {
+    // Cmd+M: toggle memory viewer closed (desktop shortcut parity)
+    if (key.meta && input.toLowerCase() === "m") {
+      onClose();
+      return;
+    }
+
     // CTRL-C: immediately close
     if (key.ctrl && input === "c") {
       onClose();


### PR DESCRIPTION
## Summary
- close the memfs memory viewer when Cmd+M is pressed while open
- close the block-tab memory viewer on the same shortcut

## Test Plan
- bunx --bun @biomejs/biome@2.2.5 check src/cli/components/MemfsTreeViewer.tsx src/cli/components/MemoryTabViewer.tsx