### PR TITLE
fix(agent): enable MemFS by default for created agents

### DIFF
--- a/src/agent/create.test.ts
+++ b/src/agent/create.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildCreatedAgentTags,
+  resolveCreatedAgentMemfsConfig,
+} from "@/agent/create";
+import { GIT_MEMORY_ENABLED_TAG } from "@/agent/memory-git";
+import {
+  LETTA_CODE_ORIGIN_TAG,
+  LETTA_CODE_SUBAGENT_TAG,
+} from "@/agent/system-prompt-versioning";
+
+const remoteMemfsBackend = { localMemfs: false, remoteMemfs: true } as const;
+const localMemfsBackend = { localMemfs: true, remoteMemfs: false } as const;
+
+function countTags(tags: string[], tag: string): number {
+  return tags.filter((candidate) => candidate === tag).length;
+}
+
+describe("created agent MemFS defaults", () => {
+  test("defaults to remote MemFS on Letta Cloud", () => {
+    expect(
+      resolveCreatedAgentMemfsConfig({
+        capabilities: remoteMemfsBackend,
+        isLettaCloud: true,
+      }),
+    ).toEqual({ enableMemfs: true, memoryPromptMode: "memfs" });
+  });
+
+  test("defaults to local MemFS on the local backend", () => {
+    expect(
+      resolveCreatedAgentMemfsConfig({
+        capabilities: localMemfsBackend,
+        isLettaCloud: false,
+      }),
+    ).toEqual({ enableMemfs: true, memoryPromptMode: "local-memfs" });
+  });
+
+  test("keeps explicit MemFS disable on created agents", () => {
+    expect(
+      resolveCreatedAgentMemfsConfig({
+        capabilities: remoteMemfsBackend,
+        enableMemfs: false,
+        isLettaCloud: true,
+      }),
+    ).toEqual({ enableMemfs: false, memoryPromptMode: "standard" });
+  });
+
+  test("treats standard memory prompt mode as an opt-out", () => {
+    expect(
+      resolveCreatedAgentMemfsConfig({
+        capabilities: remoteMemfsBackend,
+        requestedMemoryPromptMode: "standard",
+        isLettaCloud: true,
+      }),
+    ).toEqual({ enableMemfs: false, memoryPromptMode: "standard" });
+  });
+});
+
+describe("created agent tags", () => {
+  test("adds Letta Code origin and MemFS tags without dropping user tags", () => {
+    const tags = buildCreatedAgentTags({
+      tags: ["project:alpha", LETTA_CODE_ORIGIN_TAG, GIT_MEMORY_ENABLED_TAG],
+      enableMemfs: true,
+    });
+
+    expect(tags).toEqual([
+      LETTA_CODE_ORIGIN_TAG,
+      GIT_MEMORY_ENABLED_TAG,
+      "project:alpha",
+    ]);
+    expect(countTags(tags, LETTA_CODE_ORIGIN_TAG)).toBe(1);
+    expect(countTags(tags, GIT_MEMORY_ENABLED_TAG)).toBe(1);
+  });
+
+  test("adds the subagent tag once", () => {
+    const tags = buildCreatedAgentTags({
+      tags: [LETTA_CODE_SUBAGENT_TAG, "purpose:review"],
+      isSubagent: true,
+      enableMemfs: true,
+    });
+
+    expect(tags).toEqual([
+      LETTA_CODE_ORIGIN_TAG,
+      LETTA_CODE_SUBAGENT_TAG,
+      GIT_MEMORY_ENABLED_TAG,
+      "purpose:review",
+    ]);
+    expect(countTags(tags, LETTA_CODE_SUBAGENT_TAG)).toBe(1);
+  });
+
+  test("does not add the MemFS tag when explicitly disabled", () => {
+    const tags = buildCreatedAgentTags({
+      tags: ["project:alpha"],
+      enableMemfs: false,
+    });
+
+    expect(tags).toEqual([LETTA_CODE_ORIGIN_TAG, "project:alpha"]);
+    expect(tags).not.toContain(GIT_MEMORY_ENABLED_TAG);
+  });
+});

--- a/src/agent/create.ts
+++ b/src/agent/create.ts
@@ -6,13 +6,14 @@ import type {
   AgentState,
   AgentType,
 } from "@letta-ai/letta-client/resources/agents/agents";
-import { getBackend } from "@/backend";
+import { type BackendCapabilities, getBackend } from "@/backend";
 import { getClient } from "@/backend/api/client";
 import { apiRequest, getApiRequestConfig } from "@/backend/api/request";
 import { DEFAULT_AGENT_NAME, DEFAULT_SUMMARIZATION_MODEL } from "@/constants";
 import { settingsManager } from "@/settings-manager";
 import { getModelContextWindow } from "./available-models";
 import { getDefaultMemoryBlocks } from "./memory";
+import { GIT_MEMORY_ENABLED_TAG } from "./memory-git";
 import {
   formatAvailableModels,
   getDefaultModel,
@@ -26,7 +27,11 @@ import {
   resolveAndBuildSystemPrompt,
   SLEEPTIME_MEMORY_PERSONA,
 } from "./prompt-assets";
-import { recordManagedSystemPrompt } from "./system-prompt-versioning";
+import {
+  LETTA_CODE_ORIGIN_TAG,
+  LETTA_CODE_SUBAGENT_TAG,
+  recordManagedSystemPrompt,
+} from "./system-prompt-versioning";
 
 /**
  * Describes where a memory block came from
@@ -121,6 +126,73 @@ export async function createAgentWithBaseToolsRecovery(
   }
 }
 
+type MemfsCreateCapabilities = Pick<
+  BackendCapabilities,
+  "localMemfs" | "remoteMemfs"
+>;
+
+export interface CreatedAgentMemfsConfigOptions {
+  capabilities: MemfsCreateCapabilities;
+  requestedMemoryPromptMode?: MemoryPromptMode;
+  enableMemfs?: boolean;
+  isLettaCloud: boolean;
+}
+
+export interface CreatedAgentMemfsConfig {
+  enableMemfs: boolean;
+  memoryPromptMode: MemoryPromptMode;
+}
+
+export function resolveCreatedAgentMemfsConfig(
+  options: CreatedAgentMemfsConfigOptions,
+): CreatedAgentMemfsConfig {
+  const explicitDisable =
+    options.enableMemfs === false ||
+    (options.enableMemfs === undefined &&
+      options.requestedMemoryPromptMode === "standard");
+  const explicitEnable =
+    options.enableMemfs === true ||
+    options.requestedMemoryPromptMode === "memfs" ||
+    options.requestedMemoryPromptMode === "local-memfs";
+  const supportedByDefault =
+    options.capabilities.localMemfs ||
+    (options.capabilities.remoteMemfs && options.isLettaCloud);
+  const enableMemfs = explicitDisable
+    ? false
+    : explicitEnable || supportedByDefault;
+  const memoryPromptMode =
+    options.requestedMemoryPromptMode ??
+    (enableMemfs
+      ? options.capabilities.localMemfs
+        ? "local-memfs"
+        : "memfs"
+      : "standard");
+
+  return { enableMemfs, memoryPromptMode };
+}
+
+export interface BuildCreatedAgentTagsOptions {
+  tags?: string[] | null;
+  isSubagent?: boolean;
+  enableMemfs?: boolean;
+}
+
+export function buildCreatedAgentTags(
+  options: BuildCreatedAgentTagsOptions = {},
+): string[] {
+  const tags = [LETTA_CODE_ORIGIN_TAG];
+  if (options.isSubagent) {
+    tags.push(LETTA_CODE_SUBAGENT_TAG);
+  }
+  if (options.enableMemfs) {
+    tags.push(GIT_MEMORY_ENABLED_TAG);
+  }
+  if (options.tags && Array.isArray(options.tags)) {
+    tags.push(...options.tags);
+  }
+  return Array.from(new Set(tags));
+}
+
 export interface CreateAgentOptions {
   name?: string;
   /** Agent description shown in /agents selector */
@@ -149,6 +221,8 @@ export interface CreateAgentOptions {
   blockValues?: Record<string, string>;
   /** Tags to organize and categorize the agent */
   tags?: string[];
+  /** Whether to enable git-backed MemFS for the created agent (defaults to true when supported). */
+  enableMemfs?: boolean;
 }
 
 export async function createAgent(
@@ -205,6 +279,18 @@ export async function createAgent(
   }
 
   const backend = getBackend();
+  const isLettaCloud =
+    backend.capabilities.remoteMemfs && !backend.capabilities.localMemfs
+      ? await import("./memory-filesystem").then((module) =>
+          module.isLettaCloud(),
+        )
+      : false;
+  const memfsConfig = resolveCreatedAgentMemfsConfig({
+    capabilities: backend.capabilities,
+    requestedMemoryPromptMode: options.memoryPromptMode,
+    enableMemfs: options.enableMemfs,
+    isLettaCloud,
+  });
 
   // Only attach server-side tools to the agent.
   // Client-side tools (Read, Write, Bash, etc.) are passed via client_tools at runtime,
@@ -309,7 +395,7 @@ export async function createAgent(
     (await getModelContextWindow(modelHandle));
 
   // Resolve system prompt content
-  const memMode: MemoryPromptMode = options.memoryPromptMode ?? "standard";
+  const memMode: MemoryPromptMode = memfsConfig.memoryPromptMode;
   const systemPromptContent = options.systemPromptCustom
     ? options.systemPromptCustom
     : await resolveAndBuildSystemPrompt(options.systemPromptPreset, memMode);
@@ -318,13 +404,11 @@ export async function createAgent(
   // - memory_blocks: new blocks to create inline
   // - block_ids: references to existing blocks (for shared memory)
   const isSubagent = process.env.LETTA_CODE_AGENT_ROLE === "subagent";
-  const tags = ["origin:letta-code"];
-  if (isSubagent) {
-    tags.push("role:subagent");
-  }
-  if (options.tags && Array.isArray(options.tags)) {
-    tags.push(...options.tags);
-  }
+  const tags = buildCreatedAgentTags({
+    tags: options.tags,
+    isSubagent,
+    enableMemfs: memfsConfig.enableMemfs,
+  });
 
   const agentDescription =
     options.description ?? `Letta Code agent created in ${process.cwd()}`;

--- a/src/agent/defaults.test.ts
+++ b/src/agent/defaults.test.ts
@@ -68,4 +68,8 @@ describe("default agent configs", () => {
       getPersonalityHumanContent("memo").trim(),
     );
   });
+
+  test("incognito explicitly opts out of MemFS", () => {
+    expect(DEFAULT_AGENT_CONFIGS.incognito?.enableMemfs).toBe(false);
+  });
 });

--- a/src/agent/defaults.ts
+++ b/src/agent/defaults.ts
@@ -50,6 +50,7 @@ export const DEFAULT_AGENT_CONFIGS: Record<string, CreateAgentOptions> = {
     description: INCOGNITO_DESCRIPTION,
     initBlocks: [], // No personal memory blocks
     baseTools: ["web_search", "fetch_webpage"], // No memory tool
+    enableMemfs: false,
   },
 };
 

--- a/src/agent/import.ts
+++ b/src/agent/import.ts
@@ -7,6 +7,10 @@ import { dirname, resolve } from "node:path";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import { getBackend } from "@/backend";
 import { getClient } from "@/backend/api/client";
+import {
+  buildCreatedAgentTags,
+  resolveCreatedAgentMemfsConfig,
+} from "./create";
 import { getModelUpdateArgs } from "./model";
 import { updateAgentLLMConfig } from "./modify";
 
@@ -15,6 +19,7 @@ export interface ImportAgentOptions {
   modelOverride?: string;
   stripMessages?: boolean;
   stripSkills?: boolean;
+  enableMemfs?: boolean;
 }
 
 export interface ImportFromRegistryOptions {
@@ -22,11 +27,57 @@ export interface ImportFromRegistryOptions {
   modelOverride?: string;
   stripMessages?: boolean;
   stripSkills?: boolean;
+  enableMemfs?: boolean;
 }
 
 export interface ImportAgentResult {
   agent: AgentState;
   skills?: string[];
+}
+
+function tagsEqual(left: string[], right: string[]): boolean {
+  return (
+    left.length === right.length && left.every((tag, i) => tag === right[i])
+  );
+}
+
+async function resolveImportedAgentMemfsEnabled(
+  requestedEnableMemfs: boolean | undefined,
+): Promise<boolean> {
+  const backend = getBackend();
+  const isLettaCloud =
+    backend.capabilities.remoteMemfs && !backend.capabilities.localMemfs
+      ? await import("./memory-filesystem").then((module) =>
+          module.isLettaCloud(),
+        )
+      : false;
+  return resolveCreatedAgentMemfsConfig({
+    capabilities: backend.capabilities,
+    enableMemfs: requestedEnableMemfs,
+    requestedMemoryPromptMode:
+      requestedEnableMemfs === false ? "standard" : undefined,
+    isLettaCloud,
+  }).enableMemfs;
+}
+
+async function ensureImportedAgentCreationTags(
+  agent: AgentState,
+  enableMemfs: boolean,
+): Promise<AgentState> {
+  const tags = buildCreatedAgentTags({
+    tags: agent.tags,
+    enableMemfs,
+  });
+  if (tagsEqual(agent.tags ?? [], tags)) {
+    return agent;
+  }
+
+  const updatedAgent = await getBackend().updateAgent(agent.id, { tags });
+  return {
+    ...agent,
+    ...updatedAgent,
+    tags: updatedAgent.tags ?? tags,
+  } as AgentState;
 }
 
 export async function importAgentFromFile(
@@ -59,7 +110,9 @@ export async function importAgentFromFile(
   }
 
   const agentId = importResponse.agent_ids[0] as string;
-  let agent = await client.agents.retrieve(agentId);
+  let agent = await client.agents.retrieve(agentId, {
+    include: ["agent.tags"],
+  });
 
   // Override model if specified
   if (options.modelOverride) {
@@ -68,8 +121,13 @@ export async function importAgentFromFile(
     // Ensure the correct memory tool is attached for the new model
     const { ensureCorrectMemoryTool } = await import("@/tools/toolset");
     await ensureCorrectMemoryTool(agentId, options.modelOverride);
-    agent = await client.agents.retrieve(agentId);
+    agent = await client.agents.retrieve(agentId, { include: ["agent.tags"] });
   }
+
+  agent = await ensureImportedAgentCreationTags(
+    agent,
+    await resolveImportedAgentMemfsEnabled(options.enableMemfs),
+  );
 
   // Extract skills from .af file if present (unless stripSkills=true)
   let skills: string[] | undefined;
@@ -308,6 +366,7 @@ export async function importAgentFromRegistry(
       modelOverride: options.modelOverride,
       stripMessages: options.stripMessages ?? true,
       stripSkills: options.stripSkills ?? false,
+      enableMemfs: options.enableMemfs,
     });
 
     return result;

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1123,6 +1123,7 @@ export async function handleHeadlessCommand(
         modelOverride: model,
         stripMessages: true,
         stripSkills: false,
+        enableMemfs: noMemfsFlag || localNoMemfsRequested ? false : memfsFlag,
       });
     } else {
       // Import from local file
@@ -1132,6 +1133,7 @@ export async function handleHeadlessCommand(
         modelOverride: model,
         stripMessages: true,
         stripSkills: false,
+        enableMemfs: noMemfsFlag || localNoMemfsRequested ? false : memfsFlag,
       });
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2211,6 +2211,8 @@ async function main(): Promise<void> {
               modelOverride: model,
               stripMessages: true,
               stripSkills: false,
+              enableMemfs:
+                noMemfsFlag || localNoMemfsRequested ? false : memfsFlag,
             });
           } else {
             // Import from local file
@@ -2220,6 +2222,8 @@ async function main(): Promise<void> {
               modelOverride: model,
               stripMessages: true,
               stripSkills: false,
+              enableMemfs:
+                noMemfsFlag || localNoMemfsRequested ? false : memfsFlag,
             });
           }
 


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Summary
- Default `createAgent` to MemFS-enabled creation when the active backend supports it, adding `git-memory-enabled` and using the matching MemFS prompt while keeping `enableMemfs: false` and standard prompt requests as opt-outs.
- Centralize created-agent tag merging so `origin:letta-code`, `role:subagent`, the MemFS tag, and user-provided tags are deduplicated instead of overwritten.
- Reconcile imported AgentFile-created agents through the same origin/MemFS tag path and forward explicit `--no-memfs` from interactive/headless import flows.

## Test plan
- [x] `bun test src/agent/create.test.ts src/agent/defaults.test.ts`
- [x] `bun test src/agent/create.test.ts src/agent/create-base-tools-recovery.test.ts src/agent/create-soft-fail.test.ts src/agent/defaults.test.ts src/agent/personality.test.ts src/agent/import-skills.test.ts`
- [x] `bun run typecheck`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)