### PR TITLE
fix: render markdown in question prompts

### DIFF
--- a/src/cli/components/InlineQuestionApproval.test.tsx
+++ b/src/cli/components/InlineQuestionApproval.test.tsx
@@ -1,0 +1,88 @@
+import { expect, test } from "bun:test";
+import { Readable, Writable } from "node:stream";
+import { render } from "ink";
+import stripAnsi from "strip-ansi";
+import { InlineQuestionApproval } from "./InlineQuestionApproval";
+
+class CaptureStream extends Writable {
+  columns = 100;
+  rows = 24;
+  isTTY = true;
+  chunks: string[] = [];
+
+  override _write(
+    chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ) {
+    this.chunks.push(String(chunk));
+    callback();
+  }
+}
+
+function createInputStream(): NodeJS.ReadStream {
+  const input = new Readable({ read() {} }) as NodeJS.ReadStream;
+  input.isTTY = true;
+  input.setRawMode = () => input;
+  input.ref = () => input;
+  input.unref = () => input;
+  return input;
+}
+
+async function renderQuestion(question: string): Promise<string> {
+  const stdout = new CaptureStream() as CaptureStream & NodeJS.WriteStream;
+  const originalWrite = process.stdout.write;
+  process.stdout.write = (() => true) as typeof process.stdout.write;
+
+  try {
+    const instance = render(
+      <InlineQuestionApproval
+        questions={[
+          {
+            header: "Review plan",
+            question,
+            options: [
+              { label: "Approve", description: "Proceed" },
+              { label: "Revise", description: "Keep planning" },
+            ],
+            multiSelect: false,
+            allowOther: false,
+          },
+        ]}
+        onSubmit={() => {}}
+        isFocused={false}
+      />,
+      {
+        stdout,
+        stdin: createInputStream(),
+        debug: false,
+        patchConsole: false,
+        exitOnCtrlC: false,
+      },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    instance.unmount();
+    instance.cleanup();
+    return stripAnsi(stdout.chunks.join(""));
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+}
+
+test("InlineQuestionApproval renders multiline markdown question text", async () => {
+  const output = await renderQuestion(
+    [
+      "# Plan",
+      "",
+      "- Update `InlineQuestionApproval`",
+      "- Keep options unchanged",
+    ].join("\n"),
+  );
+
+  expect(output).toContain("Plan");
+  expect(output).not.toContain("# Plan");
+  expect(output).toContain("- Update InlineQuestionApproval");
+  expect(output).toContain("Approve");
+  expect(output).toContain("Revise");
+});

--- a/src/cli/components/InlineQuestionApproval.tsx
+++ b/src/cli/components/InlineQuestionApproval.tsx
@@ -4,6 +4,7 @@ import { useProgressIndicator } from "@/cli/hooks/use-progress-indicator";
 import { useTerminalWidth } from "@/cli/hooks/use-terminal-width";
 import { useTextInputCursor } from "@/cli/hooks/use-text-input-cursor";
 import { colors } from "./colors";
+import { MarkdownDisplay } from "./MarkdownDisplay";
 import { Text } from "./Text";
 
 interface QuestionOption {
@@ -28,6 +29,24 @@ type Props = {
 
 // Horizontal line character for Claude Code style
 const SOLID_LINE = "─";
+
+const MARKDOWN_QUESTION_PATTERNS = [
+  /^#{1,6}\s+/m,
+  /^\s*[-*+]\s+/m,
+  /^\s*\d+\.\s+/m,
+  /^>\s+/m,
+  /^```/m,
+  /\|.+\|\n\|[\s:]*-+/m,
+  /\*\*[^*]+\*\*/,
+  /`[^`]+`/,
+];
+
+function shouldRenderQuestionAsMarkdown(question: string): boolean {
+  return (
+    question.includes("\n") ||
+    MARKDOWN_QUESTION_PATTERNS.some((pattern) => pattern.test(question))
+  );
+}
 
 export const InlineQuestionApproval = memo(
   ({ questions, onSubmit, onCancel, isFocused = true }: Props) => {
@@ -260,6 +279,9 @@ export const InlineQuestionApproval = memo(
 
     // Generate horizontal line
     const solidLine = SOLID_LINE.repeat(Math.max(columns, 10));
+    const questionText = currentQuestion?.question ?? "";
+    const renderQuestionAsMarkdown =
+      shouldRenderQuestionAsMarkdown(questionText);
 
     // Memoize the static header content so it doesn't re-render on keystroke
     // This prevents flicker when typing in the custom input field
@@ -275,7 +297,11 @@ export const InlineQuestionApproval = memo(
           <Box height={1} />
 
           {/* Question */}
-          <Text bold>{currentQuestion?.question}</Text>
+          {renderQuestionAsMarkdown ? (
+            <MarkdownDisplay text={questionText} />
+          ) : (
+            <Text bold>{questionText}</Text>
+          )}
 
           <Box height={1} />
 
@@ -291,9 +317,10 @@ export const InlineQuestionApproval = memo(
       ),
       [
         currentQuestion?.header,
-        currentQuestion?.question,
         currentQuestionIndex,
         questions.length,
+        questionText,
+        renderQuestionAsMarkdown,
         solidLine,
       ],
     );


### PR DESCRIPTION
## Summary
- render AskUserQuestion prompt text with MarkdownDisplay when it is multiline or markdown-looking
- keep short plain questions rendered as the existing bold Text
- add a focused InlineQuestionApproval render test for multiline markdown question text

## Test
- bun test src/cli/components/InlineQuestionApproval.test.tsx
- bun run check