### PR TITLE
fix(startup): prefer local pinned agent over stale LRU

### DIFF
--- a/src/agent/resolve-startup-agent-files.test.ts
+++ b/src/agent/resolve-startup-agent-files.test.ts
@@ -45,13 +45,23 @@ async function resolveFromSettings(options?: {
   const localAgentId = settingsManager.getLocalLastAgentId(testProjectDir);
   const localSession = settingsManager.getLocalLastSession(testProjectDir);
   const globalAgentId = settingsManager.getGlobalLastAgentId();
+  const localPinnedAgents =
+    settingsManager.getLocalPinnedAgents(testProjectDir);
+  const localPinnedAgentId =
+    localPinnedAgents.length === 1 ? (localPinnedAgents[0] ?? null) : null;
 
+  const localPinnedAgentExists = localPinnedAgentId
+    ? existing.has(localPinnedAgentId)
+    : false;
   const localAgentExists = localAgentId ? existing.has(localAgentId) : false;
   const globalAgentExists = globalAgentId ? existing.has(globalAgentId) : false;
   const mergedPinnedCount =
     settingsManager.getMergedPinnedAgents(testProjectDir).length;
 
   return resolveStartupTarget({
+    localPinnedAgentId,
+    localPinnedAgentExists,
+    localPinnedCount: localPinnedAgents.length,
     localAgentId,
     localConversationId: options?.includeLocalConversation
       ? (localSession?.conversationId ?? null)
@@ -189,6 +199,29 @@ describe("startup resolution from settings files", () => {
       action: "resume",
       agentId: "agent-local",
       conversationId: "conv-local",
+    });
+  });
+
+  test("local pinned agent takes precedence over stale local last session", async () => {
+    await writeLocalSettings({
+      lastAgent: "agent-last-used",
+      lastSession: {
+        agentId: "agent-last-used",
+        conversationId: "conv-stale",
+      },
+      pinnedAgentsByServer: {
+        "api.letta.com": ["agent-pinned"],
+      },
+    });
+
+    const target = await resolveFromSettings({
+      existingAgentIds: ["agent-pinned", "agent-last-used"],
+      includeLocalConversation: true,
+    });
+
+    expect(target).toEqual({
+      action: "resume",
+      agentId: "agent-pinned",
     });
   });
 

--- a/src/agent/resolve-startup-agent.test.ts
+++ b/src/agent/resolve-startup-agent.test.ts
@@ -15,6 +15,9 @@ function makeInput(
   overrides: Partial<StartupResolutionInput> = {},
 ): StartupResolutionInput {
   return {
+    localPinnedAgentId: null,
+    localPinnedAgentExists: false,
+    localPinnedCount: 0,
     localAgentId: null,
     localConversationId: null,
     localAgentExists: false,
@@ -80,6 +83,53 @@ describe("resolveStartupTarget", () => {
       agentId: "agent-local-456",
       conversationId: "conv-local-789",
     });
+  });
+
+  test("valid local pinned agent takes priority over stale local LRU", () => {
+    const result = resolveStartupTarget(
+      makeInput({
+        localPinnedAgentId: "agent-pinned-123",
+        localPinnedAgentExists: true,
+        localPinnedCount: 1,
+        localAgentId: "agent-last-used-456",
+        localConversationId: "conv-stale-789",
+        localAgentExists: true,
+      }),
+    );
+    expect(result).toEqual({
+      action: "resume",
+      agentId: "agent-pinned-123",
+    });
+  });
+
+  test("valid local pinned agent preserves conversation when it matches local LRU", () => {
+    const result = resolveStartupTarget(
+      makeInput({
+        localPinnedAgentId: "agent-pinned-123",
+        localPinnedAgentExists: true,
+        localPinnedCount: 1,
+        localAgentId: "agent-pinned-123",
+        localConversationId: "conv-local-789",
+        localAgentExists: true,
+      }),
+    );
+    expect(result).toEqual({
+      action: "resume",
+      agentId: "agent-pinned-123",
+      conversationId: "conv-local-789",
+    });
+  });
+
+  test("multiple local pinned agents open selector before stale local LRU", () => {
+    const result = resolveStartupTarget(
+      makeInput({
+        localPinnedCount: 2,
+        localAgentId: "agent-last-used-456",
+        localConversationId: "conv-stale-789",
+        localAgentExists: true,
+      }),
+    );
+    expect(result).toEqual({ action: "select" });
   });
 
   test("dir with local LRU + invalid agent + valid global → resumes global (no conv)", () => {

--- a/src/agent/resolve-startup-agent.ts
+++ b/src/agent/resolve-startup-agent.ts
@@ -2,7 +2,7 @@
  * Pure startup agent resolution logic.
  *
  * Encodes the decision tree for which agent to use when `letta` starts:
- *   local LRU → global LRU → selector → create default
+ *   local pinned → local LRU → global LRU → selector → create default
  *
  * Extracted from index.ts/headless.ts so it can be unit-tested without
  * React effects or real network calls.
@@ -14,6 +14,13 @@ export type StartupTarget =
   | { action: "create" };
 
 export interface StartupResolutionInput {
+  /** Agent ID from local project pins (via getLocalPinnedAgents) */
+  localPinnedAgentId: string | null;
+  /** Whether the local pinned agent still exists on the server */
+  localPinnedAgentExists: boolean;
+  /** Number of local project pins for the active backend */
+  localPinnedCount: number;
+
   /** Agent ID from local project LRU (via getLocalLastAgentId) */
   localAgentId: string | null;
   /** Conversation ID from local project LRU */
@@ -45,12 +52,14 @@ export interface StartupResolutionInput {
  *
  * Decision tree:
  * 1. forceNew → create
- * 2. local LRU valid → resume (with local conversation)
- * 3. global LRU valid → resume (no conversation — project-scoped)
- * 4. backend-store fallback → resume
- * 5. needsModelPicker → select
- * 6. pinned agents exist → select
- * 7. nothing → create
+ * 2. local pinned valid → resume (with local conversation only if it matches LRU)
+ * 3. multiple local pins → select
+ * 4. local LRU valid → resume (with local conversation)
+ * 5. global LRU valid → resume (no conversation — project-scoped)
+ * 6. backend-store fallback → resume
+ * 7. needsModelPicker → select
+ * 8. pinned agents exist → select
+ * 9. nothing → create
  */
 export function resolveStartupTarget(
   input: StartupResolutionInput,
@@ -60,7 +69,25 @@ export function resolveStartupTarget(
     return { action: "create" };
   }
 
-  // Step 1: Local project LRU
+  // Step 1: Local project pin
+  if (input.localPinnedAgentId && input.localPinnedAgentExists) {
+    const conversationId =
+      input.localPinnedAgentId === input.localAgentId
+        ? (input.localConversationId ?? undefined)
+        : undefined;
+    return {
+      action: "resume",
+      agentId: input.localPinnedAgentId,
+      ...(conversationId ? { conversationId } : {}),
+    };
+  }
+
+  // Step 2: Multiple local pins should ask instead of picking implicitly.
+  if (input.localPinnedCount > 1) {
+    return { action: "select" };
+  }
+
+  // Step 3: Local project LRU
   if (input.localAgentId && input.localAgentExists) {
     return {
       action: "resume",
@@ -69,7 +96,7 @@ export function resolveStartupTarget(
     };
   }
 
-  // Step 2: Global LRU (directory-switching fallback)
+  // Step 4: Global LRU (directory-switching fallback)
   // Do NOT restore global conversation — keep conversations project-scoped
   if (input.globalAgentId && input.globalAgentExists) {
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1963,6 +1963,15 @@ async function main(): Promise<void> {
           process.cwd(),
         );
         const rawGlobalAgentId = settingsManager.getGlobalLastAgentId();
+        const localPinnedAgentIds = settingsManager
+          .getLocalPinnedAgents(process.cwd())
+          .filter((agentId) =>
+            isAgentIdCompatibleWithBackend(agentId, startupBackendMode),
+          );
+        const localPinnedAgentId =
+          localPinnedAgentIds.length === 1
+            ? (localPinnedAgentIds[0] ?? null)
+            : null;
         const localAgentId =
           startupBackendMode === "local" &&
           rawLocalAgentId &&
@@ -1976,52 +1985,44 @@ async function main(): Promise<void> {
             ? rawGlobalAgentId
             : null;
 
-        // Fetch local + global LRU agents in parallel
+        // Fetch local pin + LRU agents in parallel, de-duping shared IDs.
+        const agentIdsToValidate = [
+          ...new Set(
+            [localPinnedAgentId, localAgentId, globalAgentId].filter(
+              (agentId): agentId is string => Boolean(agentId),
+            ),
+          ),
+        ];
+        const validationResults = await Promise.allSettled(
+          agentIdsToValidate.map(async (agentId) => ({
+            agentId,
+            agent: await backend.retrieveAgent(agentId, {
+              include: ["agent.tags"],
+            }),
+          })),
+        );
+        const cachedAgents = new Map<string, AgentState>();
+        for (const result of validationResults) {
+          if (result.status === "fulfilled") {
+            cachedAgents.set(result.value.agentId, result.value.agent);
+          }
+        }
+
+        const localPinnedAgentExists = localPinnedAgentId
+          ? cachedAgents.has(localPinnedAgentId)
+          : false;
         let localAgentExists = false;
         let globalAgentExists = false;
-        let cachedAgent: AgentState | null = null;
-
-        if (globalAgentId && globalAgentId === localAgentId) {
-          // Same agent — only need one fetch
-          if (localAgentId) {
-            try {
-              cachedAgent = await backend.retrieveAgent(localAgentId, {
-                include: ["agent.tags"],
-              });
-              localAgentExists = true;
-            } catch {
-              setFailedAgentMessage(
-                `Unable to locate recently used agent ${localAgentId}`,
-              );
-            }
-          }
-          globalAgentExists = localAgentExists;
-        } else {
-          // Different agents — fetch in parallel
-          const [localResult, globalResult] = await Promise.allSettled([
-            localAgentId
-              ? backend.retrieveAgent(localAgentId, { include: ["agent.tags"] })
-              : Promise.reject(new Error("no local")),
-            globalAgentId
-              ? backend.retrieveAgent(globalAgentId, {
-                  include: ["agent.tags"],
-                })
-              : Promise.reject(new Error("no global")),
-          ]);
-
-          if (localResult.status === "fulfilled") {
-            localAgentExists = true;
-            cachedAgent = localResult.value;
-          } else if (localAgentId) {
+        if (localAgentId) {
+          localAgentExists = cachedAgents.has(localAgentId);
+          if (!localAgentExists) {
             setFailedAgentMessage(
               `Unable to locate recently used agent ${localAgentId}`,
             );
           }
-
-          if (globalResult.status === "fulfilled") {
-            globalAgentExists = true;
-            cachedAgent = globalResult.value;
-          }
+        }
+        if (globalAgentId) {
+          globalAgentExists = cachedAgents.has(globalAgentId);
         }
         markMilestone("STARTUP_LRU_FETCH_DONE");
 
@@ -2042,6 +2043,9 @@ async function main(): Promise<void> {
         );
         const localSession = settingsManager.getLocalLastSession(process.cwd());
         const target = resolveStartupTarget({
+          localPinnedAgentId,
+          localPinnedAgentExists,
+          localPinnedCount: localPinnedAgentIds.length,
           localAgentId,
           localConversationId: localSession?.conversationId ?? null,
           localAgentExists,
@@ -2056,9 +2060,10 @@ async function main(): Promise<void> {
         markMilestone(`STARTUP_TARGET_${target.action.toUpperCase()}`);
 
         switch (target.action) {
-          case "resume":
+          case "resume": {
             setSelectedGlobalAgentId(target.agentId);
-            if (cachedAgent && cachedAgent.id === target.agentId) {
+            const cachedAgent = cachedAgents.get(target.agentId);
+            if (cachedAgent) {
               setValidatedAgent(cachedAgent);
             }
             if (target.conversationId && !forceNewConversation) {
@@ -2066,6 +2071,7 @@ async function main(): Promise<void> {
             }
             setLoadingState("assembling");
             return;
+          }
           case "select":
             setLoadingState("selecting_global");
             return;


### PR DESCRIPTION
 ## Summary

 Fixes #2760.

This updates startup resolution so a valid local pinned agent for the current working directory takes precedence over stale `lastAgent` / `lastSession` state.

The change also avoids carrying a stale conversation ID across agents: if the pinned agent differs from the local LRU agent, startup resumes the pinned agent without the stale LRU conversation. If multiple local pinned agents exist, startup opens the selector instead of silently choosing one.

## Testing
- `bun test src/agent/resolve-startup-agent.test.ts src/agent/resolve-startup-agent-files.test.ts`
- `bun run check`

