### PR TITLE
fix(cli): apply saved preferredBackendMode before routing subcommands

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,7 @@ import {
 } from "./permissions/mode";
 import {
   type Settings,
+  readPreferredBackendModeSync,
   settingsManager,
   shouldPersistSessionState,
 } from "./settings-manager";
@@ -690,6 +691,20 @@ async function main(): Promise<void> {
       error instanceof Error ? `Error: ${error.message}` : String(error),
     );
     process.exit(1);
+  }
+
+  // Configure backend from saved preference before routing subcommands.
+  // Without this, subcommands like `connect` that depend on
+  // defaultProviderStorageTarget() would always see "api" when no
+  // explicit --backend flag is given, even if the user previously ran
+  // `letta backend local`.  Uses a lightweight file read to avoid
+  // triggering full SettingsManager initialization (default creation,
+  // dirty-key tracking, rollback writes, etc.).
+  if (!explicitBackendMode) {
+    const saved = readPreferredBackendModeSync();
+    if (saved) {
+      configureBackendMode(saved);
+    }
   }
 
   // Early exit for CLI subcommands (e.g., `letta server`, `letta memory`).

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,6 @@ import {
 } from "./permissions/mode";
 import {
   type Settings,
-  readPreferredBackendModeSync,
   settingsManager,
   shouldPersistSessionState,
 } from "./settings-manager";
@@ -701,7 +700,7 @@ async function main(): Promise<void> {
   // triggering full SettingsManager initialization (default creation,
   // dirty-key tracking, rollback writes, etc.).
   if (!explicitBackendMode) {
-    const saved = readPreferredBackendModeSync();
+    const saved = settingsManager.readPreferredBackendModeSync();
     if (saved) {
       configureBackendMode(saved);
     }

--- a/src/settings-manager.test.ts
+++ b/src/settings-manager.test.ts
@@ -1,11 +1,15 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { CommandHookConfig, HookCommand } from "@/hooks/types";
 import { runWithRuntimeContext } from "@/runtime-context";
 import type { LocalProjectSettings, Settings } from "@/settings-manager";
-import { settingsManager } from "@/settings-manager";
+import {
+  readPreferredBackendModeSync,
+  settingsManager,
+} from "@/settings-manager";
 
 // Type-safe helper to extract command from a hook (tests only use command hooks)
 function asCommand(
@@ -2027,5 +2031,57 @@ describe("Settings Manager - Conversation Pins", () => {
     expect(
       settingsManager.getGlobalPinnedConversations("local-agent-1"),
     ).toEqual([]);
+  });
+});
+
+describe("readPreferredBackendModeSync", () => {
+  let tmpHome: string;
+  const savedHome = process.env.HOME;
+
+  beforeEach(async () => {
+    tmpHome = await mkdtemp(join(tmpdir(), "letta-read-backend-"));
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(async () => {
+    process.env.HOME = savedHome;
+    await rm(tmpHome, { recursive: true, force: true });
+  });
+
+  function writeSettings(data: Record<string, unknown>): void {
+    const dir = join(tmpHome, ".letta");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "settings.json"), JSON.stringify(data));
+  }
+
+  test("returns undefined when settings file does not exist", () => {
+    expect(readPreferredBackendModeSync()).toBeUndefined();
+  });
+
+  test("returns undefined when preferredBackendMode is not set", () => {
+    writeSettings({});
+    expect(readPreferredBackendModeSync()).toBeUndefined();
+  });
+
+  test("reads 'local' from settings file", () => {
+    writeSettings({ preferredBackendMode: "local" });
+    expect(readPreferredBackendModeSync()).toBe("local");
+  });
+
+  test("reads 'api' from settings file", () => {
+    writeSettings({ preferredBackendMode: "api" });
+    expect(readPreferredBackendModeSync()).toBe("api");
+  });
+
+  test("returns undefined for invalid preferredBackendMode value", () => {
+    writeSettings({ preferredBackendMode: "invalid" });
+    expect(readPreferredBackendModeSync()).toBeUndefined();
+  });
+
+  test("returns undefined for malformed JSON", () => {
+    const dir = join(tmpHome, ".letta");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "settings.json"), "not json{{{");
+    expect(readPreferredBackendModeSync()).toBeUndefined();
   });
 });

--- a/src/settings-manager.test.ts
+++ b/src/settings-manager.test.ts
@@ -6,10 +6,7 @@ import { join, resolve } from "node:path";
 import type { CommandHookConfig, HookCommand } from "@/hooks/types";
 import { runWithRuntimeContext } from "@/runtime-context";
 import type { LocalProjectSettings, Settings } from "@/settings-manager";
-import {
-  readPreferredBackendModeSync,
-  settingsManager,
-} from "@/settings-manager";
+import { settingsManager } from "@/settings-manager";
 
 // Type-safe helper to extract command from a hook (tests only use command hooks)
 function asCommand(
@@ -2055,33 +2052,33 @@ describe("readPreferredBackendModeSync", () => {
   }
 
   test("returns undefined when settings file does not exist", () => {
-    expect(readPreferredBackendModeSync()).toBeUndefined();
+    expect(settingsManager.readPreferredBackendModeSync()).toBeUndefined();
   });
 
   test("returns undefined when preferredBackendMode is not set", () => {
     writeSettings({});
-    expect(readPreferredBackendModeSync()).toBeUndefined();
+    expect(settingsManager.readPreferredBackendModeSync()).toBeUndefined();
   });
 
   test("reads 'local' from settings file", () => {
     writeSettings({ preferredBackendMode: "local" });
-    expect(readPreferredBackendModeSync()).toBe("local");
+    expect(settingsManager.readPreferredBackendModeSync()).toBe("local");
   });
 
   test("reads 'api' from settings file", () => {
     writeSettings({ preferredBackendMode: "api" });
-    expect(readPreferredBackendModeSync()).toBe("api");
+    expect(settingsManager.readPreferredBackendModeSync()).toBe("api");
   });
 
   test("returns undefined for invalid preferredBackendMode value", () => {
     writeSettings({ preferredBackendMode: "invalid" });
-    expect(readPreferredBackendModeSync()).toBeUndefined();
+    expect(settingsManager.readPreferredBackendModeSync()).toBeUndefined();
   });
 
   test("returns undefined for malformed JSON", () => {
     const dir = join(tmpHome, ".letta");
     mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, "settings.json"), "not json{{{");
-    expect(readPreferredBackendModeSync()).toBeUndefined();
+    expect(settingsManager.readPreferredBackendModeSync()).toBeUndefined();
   });
 });

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -2718,27 +2718,17 @@ class SettingsManager {
     this.dirtyKeys.clear();
     this.clearSecureTokensCache();
   }
-}
 
-/**
- * Read `preferredBackendMode` directly from the settings file without
- * initializing the SettingsManager.  Used by the CLI subcommand path where
- * full initialization (default creation, dirty-key tracking, rollback
- * writes, etc.) is unnecessary and potentially unwanted.
- */
-export function readPreferredBackendModeSync(): Settings["preferredBackendMode"] {
-  const home = process.env.HOME || homedir();
-  const settingsPath = join(home, ".letta", "settings.json");
-  try {
-    if (!exists(settingsPath)) return undefined;
-    const raw = JSON.parse(readFileSync(settingsPath, "utf-8")) as Record<
-      string,
-      unknown
-    >;
+  /**
+   * Read `preferredBackendMode` directly from the settings file without
+   * initializing the SettingsManager.  Used by the CLI subcommand path
+   * where full initialization (default creation, dirty-key tracking,
+   * rollback writes, etc.) is unnecessary and potentially unwanted.
+   */
+  readPreferredBackendModeSync(): Settings["preferredBackendMode"] {
+    const raw = this.readJsonObjectSync(this.getSettingsPath());
     const mode = raw.preferredBackendMode;
     return mode === "api" || mode === "local" ? mode : undefined;
-  } catch {
-    return undefined;
   }
 }
 

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -2720,6 +2720,28 @@ class SettingsManager {
   }
 }
 
+/**
+ * Read `preferredBackendMode` directly from the settings file without
+ * initializing the SettingsManager.  Used by the CLI subcommand path where
+ * full initialization (default creation, dirty-key tracking, rollback
+ * writes, etc.) is unnecessary and potentially unwanted.
+ */
+export function readPreferredBackendModeSync(): Settings["preferredBackendMode"] {
+  const home = process.env.HOME || homedir();
+  const settingsPath = join(home, ".letta", "settings.json");
+  try {
+    if (!exists(settingsPath)) return undefined;
+    const raw = JSON.parse(readFileSync(settingsPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    const mode = raw.preferredBackendMode;
+    return mode === "api" || mode === "local" ? mode : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 // Singleton instance - use globalThis to ensure only one instance across the entire bundle
 declare global {
   var __lettaSettingsManager: SettingsManager | undefined;


### PR DESCRIPTION
## Summary
 
This PR fixes issue https://github.com/letta-ai/letta-code/issues/2764 where `letta connect` ignores the saved backend preference. Running `letta backend local;
letta connect xiaomi` would resolve providers to the API storage target instead of local, while `letta --backend
local connect xiaomi` worked correctly.
 
The root cause: the subcommand early-exit in `main()` happened before `settingsManager.initialize()`, so
`defaultProviderStorageTarget()` always saw the API backend — the saved `preferredBackendMode` was never applied. This causes 2 issues:

1. The list of provider will always take from `api` backend even if the preference is `local`, so if user tries to connect provider that is not supported on `api`, it will fail.
2. The PR https://github.com/letta-ai/letta-code/pull/2762 solve the initialization issue, and if the PR is merged, there is a subtle inconsistent behavior. Which is the `connect` subcommand still not respecting the user preferred backend settings. If user runs `letta connect openai`, the command will succeed regardless the preference because `openai` exist on both `api` and `local`. However, *where* the credential stored is not like what we expect. When the preferred settings is `local`, the credential is still stored in the cloud since the connection option is still set as empty if user does not pass `--backend` flag. We can see from this line

https://github.com/letta-ai/letta-code/blob/33a21140af0c854597636eb24f29a7a2756f848e/src/cli/subcommands/connect.ts#L392-L408

which I assume it will use the byok-provider that checks if the connection options is empty, it will not store in local auth storage.

https://github.com/letta-ai/letta-code/blob/33a21140af0c854597636eb24f29a7a2756f848e/src/providers/byok-providers.ts#L725-L745

 
## Changes
 
- **src/settings-manager.ts** Added `readPreferredBackendModeSync()` method to `SettingsManager` — reads
`preferredBackendMode` directly from `~/.letta/settings.json` via `readJsonObjectSync()` and `getSettingsPath()`
without triggering full initialization (default creation, dirty-key tracking, rollback writes, etc.)
- **src/index.ts** Before routing subcommands, if no explicit `--backend` flag is given, call
`settingsManager.readPreferredBackendModeSync()` and `configureBackendMode()` with the result
- **src/settings-manager.test.ts** Added 6 tests for `readPreferredBackendModeSync`: missing file, no preference
set, reads `"local"`, reads `"api"`, invalid value, malformed JSON

## Concern

This fix may be simple but I also got feedback from Letta to consider the backward compatibility with `letta local-backend migrate-transcripts` since it may cause error. I need feedback on how best to approach this since this tool also in beta I guess (not yet 1.0) so breaking change is expected.