### PR TITLE
fix(local): sync model token limits from pi catalog

### DIFF
--- a/src/agent/modify-local.test.ts
+++ b/src/agent/modify-local.test.ts
@@ -83,6 +83,27 @@ describe("local model updates", () => {
         expect(conversationModelSettings?.max_tokens).toBe(kimi?.maxTokens);
         expect(conversationModelSettings?.max_output_tokens).toBeUndefined();
 
+        const customizedConversation = await backend.updateConversation(
+          conversation.id,
+          {
+            model: "openrouter/moonshotai/kimi-k2.6",
+            model_settings: {
+              provider_type: "openrouter",
+              context_window_limit: 12345,
+              max_tokens: 1234,
+              parallel_tool_calls: false,
+            },
+          } as never,
+        );
+        const customizedConversationModelSettings =
+          customizedConversation.model_settings as
+            | Record<string, unknown>
+            | undefined;
+        expect(customizedConversationModelSettings?.context_window_limit).toBe(
+          12345,
+        );
+        expect(customizedConversationModelSettings?.max_tokens).toBe(1234);
+
         const updated = await updateAgentLLMConfig(
           agent.id,
           "openrouter/moonshotai/kimi-k2.6",

--- a/src/agent/modify-local.test.ts
+++ b/src/agent/modify-local.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getModel } from "@earendil-works/pi-ai";
+import { configureBackendMode, getBackend } from "@/backend/backend";
+import { createOrUpdateLocalProvider } from "@/backend/local";
+import { LOCAL_BACKEND_DIR_ENV } from "@/backend/local/paths";
+import { clearAvailableModelsCache } from "./available-models";
+import { updateAgentLLMConfig, updateConversationLLMConfig } from "./modify";
+
+async function withLocalBackendStorage<T>(
+  storageDir: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  const previousStorageDir = process.env[LOCAL_BACKEND_DIR_ENV];
+  try {
+    process.env[LOCAL_BACKEND_DIR_ENV] = storageDir;
+    configureBackendMode("local");
+    return await run();
+  } finally {
+    configureBackendMode("api");
+    clearAvailableModelsCache();
+    if (previousStorageDir === undefined) {
+      delete process.env[LOCAL_BACKEND_DIR_ENV];
+    } else {
+      process.env[LOCAL_BACKEND_DIR_ENV] = previousStorageDir;
+    }
+  }
+}
+
+describe("local model updates", () => {
+  afterEach(() => {
+    configureBackendMode("api");
+    clearAvailableModelsCache();
+  });
+
+  test("uses pi catalog token settings instead of static Letta model presets", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-model-update-pi-catalog-"),
+    );
+    try {
+      await createOrUpdateLocalProvider({
+        providerType: "openrouter",
+        providerName: "lc-openrouter",
+        apiKey: "dummy",
+        storageDir,
+      });
+
+      await withLocalBackendStorage(storageDir, async () => {
+        const backend = getBackend();
+        const agent = await backend.createAgent({
+          name: "Local",
+          model: "openrouter/deepseek/deepseek-v4-pro",
+          model_settings: {
+            provider_type: "openrouter",
+            max_output_tokens: 384000,
+          },
+          max_tokens: 384000,
+          context_window_limit: 1048576,
+        } as never);
+        const conversation = await backend.createConversation({
+          agent_id: agent.id,
+        } as never);
+
+        const updatedConversation = await updateConversationLLMConfig(
+          conversation.id,
+          "openrouter/moonshotai/kimi-k2.6",
+          {
+            context_window: 200000,
+            max_output_tokens: 64000,
+            parallel_tool_calls: true,
+          },
+        );
+
+        const kimi = getModel("openrouter", "moonshotai/kimi-k2.6");
+        const conversationModelSettings = updatedConversation.model_settings as
+          | Record<string, unknown>
+          | undefined;
+        expect(conversationModelSettings?.context_window_limit).toBe(
+          kimi?.contextWindow,
+        );
+        expect(conversationModelSettings?.max_tokens).toBe(kimi?.maxTokens);
+        expect(conversationModelSettings?.max_output_tokens).toBeUndefined();
+
+        const updated = await updateAgentLLMConfig(
+          agent.id,
+          "openrouter/moonshotai/kimi-k2.6",
+          {
+            context_window: 200000,
+            max_output_tokens: 64000,
+            parallel_tool_calls: true,
+          },
+        );
+
+        expect(updated.model).toBe("openrouter/moonshotai/kimi-k2.6");
+        expect(updated.llm_config?.context_window).toBe(kimi?.contextWindow);
+        expect(updated.llm_config?.max_tokens).toBe(kimi?.maxTokens);
+        expect(updated.llm_config?.max_tokens).not.toBe(384000);
+        expect(updated.llm_config?.max_tokens).not.toBe(64000);
+        expect(
+          (updated.model_settings as Record<string, unknown>).max_output_tokens,
+        ).toBeUndefined();
+      });
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -241,6 +241,27 @@ function buildModelSettings(
   return settings;
 }
 
+function updateArgsForModelSettings(
+  updateArgs: Record<string, unknown> | undefined,
+  options: { useBackendModelCatalog: boolean },
+): Record<string, unknown> | undefined {
+  if (!options.useBackendModelCatalog || !updateArgs) return updateArgs;
+  return Object.fromEntries(
+    Object.entries(updateArgs).filter(([key]) => key !== "max_output_tokens"),
+  );
+}
+
+function maxTokensForUpdatePayload(
+  updateArgs: Record<string, unknown> | undefined,
+  options: { useBackendModelCatalog: boolean },
+): number | null | undefined {
+  if (options.useBackendModelCatalog) return undefined;
+  const maxTokens = updateArgs?.max_output_tokens;
+  return typeof maxTokens === "number" || maxTokens === null
+    ? maxTokens
+    : undefined;
+}
+
 /**
  * Updates an agent's model and model settings.
  *
@@ -263,11 +284,15 @@ export async function updateAgentLLMConfig(
   options?: UpdateAgentLLMConfigOptions,
 ): Promise<AgentState> {
   const backend = getBackend();
+  const useBackendModelCatalog = backend.capabilities.localModelCatalog;
 
-  const modelSettings = buildModelSettings(modelHandle, updateArgs);
-  const explicitContextWindow = updateArgs?.context_window as
-    | number
-    | undefined;
+  const modelSettings = buildModelSettings(
+    modelHandle,
+    updateArgsForModelSettings(updateArgs, { useBackendModelCatalog }),
+  );
+  const explicitContextWindow = useBackendModelCatalog
+    ? undefined
+    : (updateArgs?.context_window as number | undefined);
   const shouldPreserveContextWindow = options?.preserveContextWindow === true;
   // Resume refresh updates should not implicitly reset context window.
   const contextWindow =
@@ -276,15 +301,15 @@ export async function updateAgentLLMConfig(
       ? await getModelContextWindow(modelHandle)
       : undefined);
   const hasModelSettings = Object.keys(modelSettings).length > 0;
+  const maxTokens = maxTokensForUpdatePayload(updateArgs, {
+    useBackendModelCatalog,
+  });
 
   await backend.updateAgent(agentId, {
     model: modelHandle,
     ...(hasModelSettings && { model_settings: modelSettings }),
     ...(contextWindow && { context_window_limit: contextWindow }),
-    ...((typeof updateArgs?.max_output_tokens === "number" ||
-      updateArgs?.max_output_tokens === null) && {
-      max_tokens: updateArgs.max_output_tokens,
-    }),
+    ...(maxTokens !== undefined && { max_tokens: maxTokens }),
   });
 
   const finalAgent = await backend.retrieveAgent(agentId, {
@@ -311,11 +336,15 @@ export async function updateConversationLLMConfig(
   options?: UpdateAgentLLMConfigOptions,
 ): Promise<Conversation> {
   const backend = getBackend();
+  const useBackendModelCatalog = backend.capabilities.localModelCatalog;
 
-  const modelSettings = buildModelSettings(modelHandle, updateArgs);
-  const explicitContextWindow = updateArgs?.context_window as
-    | number
-    | undefined;
+  const modelSettings = buildModelSettings(
+    modelHandle,
+    updateArgsForModelSettings(updateArgs, { useBackendModelCatalog }),
+  );
+  const explicitContextWindow = useBackendModelCatalog
+    ? undefined
+    : (updateArgs?.context_window as number | undefined);
   const shouldPreserveContextWindow = options?.preserveContextWindow === true;
   const contextWindow =
     explicitContextWindow ??
@@ -323,10 +352,14 @@ export async function updateConversationLLMConfig(
       ? await getModelContextWindow(modelHandle)
       : undefined);
   const hasModelSettings = Object.keys(modelSettings).length > 0;
+  const maxTokens = maxTokensForUpdatePayload(updateArgs, {
+    useBackendModelCatalog,
+  });
   const payload = {
     model: modelHandle,
     ...(hasModelSettings && { model_settings: modelSettings }),
     ...(contextWindow && { context_window_limit: contextWindow }),
+    ...(maxTokens !== undefined && { max_tokens: maxTokens }),
   } as Parameters<typeof backend.updateConversation>[1];
 
   return backend.updateConversation(conversationId, payload);

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -19,6 +19,7 @@ import type {
   Model,
   SimpleStreamOptions,
 } from "@earendil-works/pi-ai";
+import { getModel } from "@earendil-works/pi-ai";
 import type { Stream } from "@letta-ai/letta-client/core/streaming";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import type { ConversationMessageCreateBody } from "@/backend";
@@ -685,6 +686,25 @@ describe("local backend pi transcript", () => {
     expect(handles).toContain("zai/glm-5.1");
   });
 
+  test("lists pi catalog context windows for configured OpenRouter models", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-pi-openrouter-context-"),
+    );
+    await createOrUpdateLocalProvider({
+      providerType: "openrouter",
+      providerName: "lc-openrouter",
+      apiKey: "dummy",
+      storageDir,
+    });
+
+    const kimi = (await listLocalModels(storageDir)).find(
+      (model) => model.handle === "openrouter/moonshotai/kimi-k2.6",
+    );
+    expect(kimi?.max_context_window).toBe(
+      getModel("openrouter", "moonshotai/kimi-k2.6")?.contextWindow,
+    );
+  });
+
   test("does not list unconfigured local provider model guesses", async () => {
     const storageDir = await mkdtemp(
       join(tmpdir(), "local-backend-pi-unconfigured-local-"),
@@ -822,6 +842,52 @@ describe("local backend pi transcript", () => {
       (agent as { llm_config?: { max_tokens?: number } }).llm_config
         ?.max_tokens,
     ).toBe(8192);
+  });
+
+  test("resets persisted output-token settings when switching local models", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-pi-model-token-reset-"),
+    );
+    await createOrUpdateLocalProvider({
+      providerType: "openrouter",
+      providerName: "lc-openrouter",
+      apiKey: "dummy",
+      storageDir,
+    });
+
+    const backend = new LocalBackend({ storageDir, memfsEnabled: false });
+    const agent = await backend.createAgent({
+      name: "Local",
+      model: "openrouter/deepseek/deepseek-v4-pro",
+      model_settings: {
+        provider_type: "openrouter",
+        max_output_tokens: 384000,
+      },
+      max_tokens: 384000,
+      context_window_limit: 1048576,
+    } as never);
+
+    const updated = await backend.updateAgent(agent.id, {
+      model: "openrouter/moonshotai/kimi-k2.6",
+      model_settings: {
+        provider_type: "openrouter",
+        parallel_tool_calls: true,
+      },
+    } as never);
+
+    const kimi = getModel("openrouter", "moonshotai/kimi-k2.6");
+    expect(updated.model).toBe("openrouter/moonshotai/kimi-k2.6");
+    expect(
+      (updated as { llm_config?: { max_tokens?: number } }).llm_config
+        ?.max_tokens,
+    ).toBe(kimi?.maxTokens);
+    expect(
+      (updated as { llm_config?: { context_window?: number } }).llm_config
+        ?.context_window,
+    ).toBe(kimi?.contextWindow);
+    expect(
+      (updated.model_settings as Record<string, unknown>).max_output_tokens,
+    ).toBeUndefined();
   });
 
   test("projects legacy local 128k defaults through registered model metadata", async () => {

--- a/src/backend/local/local-model-config.ts
+++ b/src/backend/local/local-model-config.ts
@@ -1,3 +1,4 @@
+import { type Api, getModels, type Model } from "@earendil-works/pi-ai";
 import {
   DEFAULT_PI_PROVIDER,
   type PiProvider,
@@ -275,6 +276,24 @@ function registeredModelSettingsForProviderModel(
   };
 }
 
+function catalogModelSettingsForProviderModel(
+  provider: PiProvider,
+  modelId: string | undefined,
+): Record<string, unknown> | undefined {
+  if (!modelId || !isPiProvider(provider)) return undefined;
+  const spec = getPiProviderSpec(provider);
+  if (!spec.piProvider) return undefined;
+  const model = (getModels(spec.piProvider) as Model<Api>[]).find(
+    (entry) => entry.id === modelId,
+  );
+  if (!model) return undefined;
+  return {
+    provider_type: localProviderTypeForModelConfig(provider),
+    context_window_limit: model.contextWindow,
+    max_tokens: model.maxTokens,
+  };
+}
+
 export function localModelSettingsForHandle(
   handle: string | undefined,
 ): Record<string, unknown> | undefined {
@@ -289,9 +308,10 @@ export function localModelSettingsForHandle(
 
   const provider = resolveProviderFromModelHandle(handle);
   if (!provider) return undefined;
-  return registeredModelSettingsForProviderModel(
-    provider,
-    stripProviderHandlePrefix(handle, provider),
+  const modelId = stripProviderHandlePrefix(handle, provider);
+  return (
+    registeredModelSettingsForProviderModel(provider, modelId) ??
+    catalogModelSettingsForProviderModel(provider, modelId)
   );
 }
 
@@ -305,17 +325,14 @@ export function resolveLocalModelConfig(storageDir?: string): LocalModelConfig {
   const handle = registeredProvider
     ? `${provider}/${model}`
     : localModelHandle(provider, model);
-  const registeredModelSettings = registeredModelSettingsForProviderModel(
-    provider,
-    registeredModel?.id,
-  );
+  const modelSettings = localModelSettingsForHandle(handle);
   return {
     provider,
     model,
     handle,
     modelSettings: {
       provider_type: localProviderTypeForModelConfig(provider),
-      ...(registeredModelSettings ?? {}),
+      ...(modelSettings ?? {}),
     },
   };
 }
@@ -350,11 +367,15 @@ export async function listLocalModels(
         ? `${provider}/${model}`
         : localModelHandle(provider as PiProvider, model));
     if (models.some((entry) => entry.handle === handle)) return;
+    const modelSettings = localModelSettingsForHandle(handle);
+    const maxContextWindow =
+      options.maxContextWindow ??
+      (typeof modelSettings?.context_window_limit === "number"
+        ? modelSettings.context_window_limit
+        : undefined);
     models.push({
       handle,
-      ...(options.maxContextWindow
-        ? { max_context_window: options.maxContextWindow }
-        : {}),
+      ...(maxContextWindow ? { max_context_window: maxContextWindow } : {}),
       model: handle,
       model_endpoint_type:
         options.modelEndpointType ?? localProviderTypeForModelConfig(provider),

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -191,9 +191,6 @@ function supportedConversationModelSettingsFromBody(
   if (modelSettings === null) return null;
 
   const next = modelSettings ?? {};
-  if (typeof bodyRecord.context_window_limit === "number") {
-    next.context_window_limit = bodyRecord.context_window_limit;
-  }
   if (
     typeof bodyRecord.max_tokens === "number" ||
     bodyRecord.max_tokens === null

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -1518,7 +1518,11 @@ export class LocalStore {
         body,
         currentIsoTimestamp(),
       );
-      const projected = this.applyConversationModelDefaults(updated, body);
+      const projected = this.applyConversationModelDefaults(
+        updated,
+        body,
+        created,
+      );
       this.conversations.set(
         this.conversationKey(conversationId, created.agent_id),
         projected,
@@ -1529,6 +1533,7 @@ export class LocalStore {
     const updated = this.applyConversationModelDefaults(
       updateLocalConversationRecord(current, body, currentIsoTimestamp()),
       body,
+      current,
     );
     this.conversations.set(
       this.conversationKey(conversationId, current.agent_id),
@@ -1541,9 +1546,11 @@ export class LocalStore {
   private applyConversationModelDefaults(
     conversation: StoredConversation,
     body: ConversationUpdateBody,
+    previousConversation: StoredConversation,
   ): StoredConversation {
     const requestedModel = (body as Record<string, unknown>).model;
     if (typeof requestedModel !== "string") return conversation;
+    if (previousConversation.model === requestedModel) return conversation;
     const defaults = this.modelSettingsDefaultsForModel(requestedModel);
     if (!defaults || Object.keys(defaults).length === 0) return conversation;
     const existingSettings = isRecord(conversation.model_settings)

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -184,6 +184,26 @@ function conversationModelSettings(
   return optionalRecordOrNull(value);
 }
 
+function supportedConversationModelSettingsFromBody(
+  bodyRecord: Record<string, unknown>,
+): Record<string, unknown> | null | undefined {
+  const modelSettings = conversationModelSettings(bodyRecord.model_settings);
+  if (modelSettings === null) return null;
+
+  const next = modelSettings ?? {};
+  if (typeof bodyRecord.context_window_limit === "number") {
+    next.context_window_limit = bodyRecord.context_window_limit;
+  }
+  if (
+    typeof bodyRecord.max_tokens === "number" ||
+    bodyRecord.max_tokens === null
+  ) {
+    next.max_tokens = bodyRecord.max_tokens;
+  }
+
+  return Object.keys(next).length > 0 ? next : modelSettings;
+}
+
 function createLocalConversationRecord(
   conversationId: string,
   agentId: string,
@@ -192,7 +212,7 @@ function createLocalConversationRecord(
 ): StoredConversation {
   const bodyRecord = body as Record<string, unknown>;
   const now = currentIsoTimestamp();
-  const modelSettings = conversationModelSettings(bodyRecord.model_settings);
+  const modelSettings = supportedConversationModelSettingsFromBody(bodyRecord);
   return {
     id: conversationId,
     agent_id: agentId,
@@ -245,7 +265,7 @@ function updateLocalConversationRecord(
   if (typeof bodyRecord.model === "string" || bodyRecord.model === null) {
     next.model = bodyRecord.model;
   }
-  const modelSettings = conversationModelSettings(bodyRecord.model_settings);
+  const modelSettings = supportedConversationModelSettingsFromBody(bodyRecord);
   if (modelSettings !== undefined) {
     next.model_settings = modelSettings as StoredConversation["model_settings"];
   }
@@ -1288,13 +1308,6 @@ export class LocalStore {
     const systemChanged =
       nextSystem !== undefined && nextSystem !== existingRecord.system;
     const requestedModel = bodyRecord.model;
-    const nextModelSettings = {
-      ...existingRecord.model_settings,
-      ...(shouldUseDefaultLocalModel(requestedModel)
-        ? this.defaultAgentModelSettings
-        : {}),
-      ...supportedModelSettingsFromBody(bodyRecord),
-    };
     const nextModel =
       typeof requestedModel === "string" &&
       !shouldUseDefaultLocalModel(requestedModel)
@@ -1302,6 +1315,16 @@ export class LocalStore {
         : typeof requestedModel === "string" && this.defaultAgentModel
           ? this.defaultAgentModel
           : undefined;
+    const modelChanged =
+      nextModel !== undefined && nextModel !== existingRecord.model;
+    const nextModelDefaults = nextModel
+      ? this.modelSettingsDefaultsForModel(nextModel)
+      : undefined;
+    const nextModelSettings = {
+      ...(modelChanged ? {} : existingRecord.model_settings),
+      ...supportedModelSettingsFromBody(bodyRecord),
+      ...(modelChanged ? (nextModelDefaults ?? {}) : {}),
+    };
     const updated = {
       ...existingRecord,
       ...(typeof bodyRecord.name === "string" && { name: bodyRecord.name }),
@@ -1495,17 +1518,17 @@ export class LocalStore {
         body,
         currentIsoTimestamp(),
       );
+      const projected = this.applyConversationModelDefaults(updated, body);
       this.conversations.set(
         this.conversationKey(conversationId, created.agent_id),
-        updated,
+        projected,
       );
       this.persistConversationState(conversationId, created.agent_id);
-      return updated;
+      return projected;
     }
-    const updated = updateLocalConversationRecord(
-      current,
+    const updated = this.applyConversationModelDefaults(
+      updateLocalConversationRecord(current, body, currentIsoTimestamp()),
       body,
-      currentIsoTimestamp(),
     );
     this.conversations.set(
       this.conversationKey(conversationId, current.agent_id),
@@ -1513,6 +1536,26 @@ export class LocalStore {
     );
     this.persistConversationState(conversationId, current.agent_id);
     return updated;
+  }
+
+  private applyConversationModelDefaults(
+    conversation: StoredConversation,
+    body: ConversationUpdateBody,
+  ): StoredConversation {
+    const requestedModel = (body as Record<string, unknown>).model;
+    if (typeof requestedModel !== "string") return conversation;
+    const defaults = this.modelSettingsDefaultsForModel(requestedModel);
+    if (!defaults || Object.keys(defaults).length === 0) return conversation;
+    const existingSettings = isRecord(conversation.model_settings)
+      ? conversation.model_settings
+      : {};
+    return {
+      ...conversation,
+      model_settings: {
+        ...existingSettings,
+        ...defaults,
+      },
+    };
   }
 
   forkConversation(


### PR DESCRIPTION
## Summary

- Derive local model context/output-token settings from the pi-ai catalog for configured local providers.
- Reset model-specific local settings on model switches so stale output-token caps cannot persist across DeepSeek → Kimi-style changes.
- Cover agent and conversation-scoped local model updates with regressions for pi catalog token limits.

## Verification

- `bun test src/backend/local-backend.test.ts src/agent/modify-local.test.ts`
- `bun run check`

👾 Generated with [Letta Code](https://letta.com)