### PR TITLE
fix(permissions): honor settings permission mode

### DIFF
--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/auth/oauth";
 import { isLocalBackendEnvEnabled } from "@/backend/local/paths";
 import { ListenerStatusUI } from "@/cli/components/ListenerStatusUI";
+import { applyStartupPermissionMode } from "@/permissions/startup";
 import { settingsManager } from "@/settings-manager";
 import { getListenerTelemetrySurface, telemetry } from "@/telemetry";
 import { RemoteSessionLog } from "@/websocket/listen-log";
@@ -370,6 +371,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
   }
 
   await settingsManager.initialize();
+  await applyStartupPermissionMode({});
   telemetry.setSurface(getListenerTelemetrySurface());
   telemetry.init();
 

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -114,6 +114,7 @@ import {
 } from "./headless-extension-adapter";
 import { computeDiffPreviews } from "./helpers/diff-preview";
 import { formatPermissionDenial } from "./permissions/format-denial";
+import { applyStartupPermissionMode } from "./permissions/startup";
 import { QueueRuntime } from "./queue/queue-runtime";
 import {
   mergeQueuedTurnInput,
@@ -564,19 +565,18 @@ export async function handleHeadlessCommand(
   cliPermissions.setMemoryGuardDisabled(false);
 
   // Set permission mode if provided (or via --yolo alias)
-  const permissionModeValue = values["permission-mode"];
+  const permissionModeValue =
+    typeof values["permission-mode"] === "string"
+      ? values["permission-mode"]
+      : undefined;
   const yoloMode = values.yolo;
-  if (yoloMode || permissionModeValue) {
-    const { permissionMode } = await import("@/permissions/mode");
-    if (yoloMode) {
-      permissionMode.setMode("unrestricted");
-    } else if (permissionModeValue) {
-      const { migratePermissionMode } = await import("@/permissions/mode");
-      const migrated = migratePermissionMode(permissionModeValue);
-      if (migrated) {
-        permissionMode.setMode(migrated);
-      }
-    }
+  const startupPermissionMode = await applyStartupPermissionMode({
+    permissionModeValue,
+    yoloMode,
+  });
+  if (!startupPermissionMode.ok) {
+    console.error(startupPermissionMode.message);
+    process.exit(1);
   }
 
   // Set CLI permission overrides if provided
@@ -1658,11 +1658,7 @@ export async function handleHeadlessCommand(
   }
 
   const sessionStats = new SessionStats();
-  const headlessPermissionMode = yoloMode
-    ? "unrestricted"
-    : typeof permissionModeValue === "string"
-      ? permissionModeValue
-      : null;
+  const headlessPermissionMode = startupPermissionMode.mode;
   const headlessExtensionAdapter = createHeadlessExtensionAdapter({
     agent,
     backend,

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,11 +77,7 @@ import {
   disableExtensionsForProcess,
   shouldDisableExtensions,
 } from "./extensions/disable";
-import {
-  migratePermissionMode,
-  permissionMode,
-  VALID_PERMISSION_MODES,
-} from "./permissions/mode";
+import { applyStartupPermissionMode } from "./permissions/startup";
 import {
   type Settings,
   settingsManager,
@@ -1504,24 +1500,18 @@ async function main(): Promise<void> {
   }
 
   // Set permission mode if provided (or via --yolo alias)
-  const permissionModeValue = values["permission-mode"];
+  const permissionModeValue =
+    typeof values["permission-mode"] === "string"
+      ? values["permission-mode"]
+      : undefined;
   const yoloMode = values.yolo;
-
-  if (yoloMode || permissionModeValue) {
-    if (yoloMode) {
-      // --yolo is an alias for --permission-mode unrestricted
-      permissionMode.setMode("unrestricted");
-    } else if (permissionModeValue) {
-      const migrated = migratePermissionMode(permissionModeValue);
-      if (migrated) {
-        permissionMode.setMode(migrated);
-      } else {
-        console.error(
-          `Invalid permission mode: ${permissionModeValue}. Valid modes: ${VALID_PERMISSION_MODES.join(", ")}`,
-        );
-        process.exit(1);
-      }
-    }
+  const startupPermissionMode = await applyStartupPermissionMode({
+    permissionModeValue,
+    yoloMode,
+  });
+  if (!startupPermissionMode.ok) {
+    console.error(startupPermissionMode.message);
+    process.exit(1);
   }
 
   if (isHeadless) {

--- a/src/permissions/loader.ts
+++ b/src/permissions/loader.ts
@@ -6,14 +6,19 @@ import { type FSWatcher, readFileSync, statSync, watch } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { exists, readFile, writeFile } from "@/utils/fs.js";
+import { migratePermissionMode } from "./mode";
 import {
   normalizePermissionRule,
   permissionRulesEquivalent,
 } from "./rule-normalization";
 import type { PermissionRules } from "./types";
 
+type SettingsPermissions = Omit<PermissionRules, "mode"> & {
+  mode?: string;
+};
+
 type SettingsFile = {
-  permissions?: Record<string, string[]>;
+  permissions?: SettingsPermissions;
   [key: string]: unknown;
 };
 
@@ -125,12 +130,16 @@ function cachedEntryMatchesSources(
 }
 
 function clonePermissions(permissions: PermissionRules): PermissionRules {
-  return {
+  const cloned: PermissionRules = {
     allow: [...(permissions.allow || [])],
     deny: [...(permissions.deny || [])],
     ask: [...(permissions.ask || [])],
     additionalDirectories: [...(permissions.additionalDirectories || [])],
   };
+  if (permissions.mode) {
+    cloned.mode = permissions.mode;
+  }
+  return cloned;
 }
 
 function invalidatePermissionSource(sourcePath: string): void {
@@ -225,7 +234,7 @@ export async function loadPermissions(
         const content = await readFile(settingsPath);
         const settings = JSON.parse(content) as SettingsFile;
         if (settings.permissions) {
-          mergePermissions(merged, settings.permissions as PermissionRules);
+          mergePermissions(merged, settings.permissions);
         }
       }
     } catch (_error) {
@@ -244,13 +253,26 @@ export async function loadPermissions(
   return clonePermissions(merged);
 }
 
+export async function loadPermissionMode(
+  workingDirectory: string = process.cwd(),
+): Promise<PermissionRules["mode"] | null> {
+  const permissions = await loadPermissions(workingDirectory);
+  return permissions.mode ?? null;
+}
+
 /**
  * Merge permission rules by concatenating arrays
  */
 function mergePermissions(
   target: PermissionRules,
-  source: PermissionRules,
+  source: SettingsPermissions,
 ): void {
+  if (typeof source.mode === "string") {
+    const mode = migratePermissionMode(source.mode);
+    if (mode) {
+      target.mode = mode;
+    }
+  }
   if (source.allow) {
     target.allow = mergeRuleList(target.allow, source.allow);
   }

--- a/src/permissions/permissions-loader.test.ts
+++ b/src/permissions/permissions-loader.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   getUserSettingsPaths,
+  loadPermissionMode,
   loadPermissions,
   resetPermissionLoaderCacheForTests,
   savePermissionRule,
@@ -74,6 +75,52 @@ test("Load permissions from local settings", async () => {
 
   // Should include local rule (may also include user settings from real home dir)
   expect(permissions.allow).toContain("Bash(git push:*)");
+});
+
+test("Load permissions migrates legacy permission mode", async () => {
+  const projectDir = join(testDir, "project-mode-legacy");
+  await Bun.write(
+    join(projectDir, ".letta", "settings.json"),
+    JSON.stringify({
+      permissions: {
+        mode: "bypassPermissions",
+        allow: ["Bash"],
+      },
+    }),
+  );
+
+  const permissions = await loadPermissions(projectDir);
+  const mode = await loadPermissionMode(projectDir);
+
+  expect(permissions.mode).toBe("unrestricted");
+  expect(mode).toBe("unrestricted");
+  expect(permissions.allow).toContain("Bash");
+});
+
+test("Load permissions uses highest-precedence permission mode", async () => {
+  const projectDir = join(testDir, "project-mode-precedence");
+  await Bun.write(
+    join(projectDir, ".letta", "settings.json"),
+    JSON.stringify({
+      permissions: {
+        mode: "standard",
+      },
+    }),
+  );
+  await Bun.write(
+    join(projectDir, ".letta", "settings.local.json"),
+    JSON.stringify({
+      permissions: {
+        mode: "acceptEdits",
+      },
+    }),
+  );
+
+  const permissions = await loadPermissions(projectDir);
+  const mode = await loadPermissionMode(projectDir);
+
+  expect(permissions.mode).toBe("acceptEdits");
+  expect(mode).toBe("acceptEdits");
 });
 
 test("Load permissions picks up external project settings edits without restart", async () => {

--- a/src/permissions/startup.test.ts
+++ b/src/permissions/startup.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { checkPermission } from "@/permissions/checker";
+import { resetPermissionLoaderCacheForTests } from "@/permissions/loader";
+import { permissionMode } from "@/permissions/mode";
+import { applyStartupPermissionMode } from "@/permissions/startup";
+
+let testDir: string;
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "letta-permission-startup-"));
+  permissionMode.setMode("standard");
+});
+
+afterEach(async () => {
+  resetPermissionLoaderCacheForTests();
+  permissionMode.reset();
+  await rm(testDir, { recursive: true, force: true });
+});
+
+test("startup applies permissions.mode from settings", async () => {
+  const projectDir = join(testDir, "project-settings-mode");
+  await Bun.write(
+    join(projectDir, ".letta", "settings.json"),
+    JSON.stringify({
+      permissions: {
+        mode: "bypassPermissions",
+      },
+    }),
+  );
+
+  const result = await applyStartupPermissionMode({
+    workingDirectory: projectDir,
+  });
+
+  expect(result).toEqual({
+    ok: true,
+    mode: "unrestricted",
+    source: "settings",
+  });
+  expect(permissionMode.getMode()).toBe("unrestricted");
+
+  const permission = checkPermission(
+    "Bash",
+    { command: "python cache_update.py" },
+    { allow: [], deny: [], ask: [] },
+    projectDir,
+  );
+  expect(permission.decision).toBe("allow");
+  expect(permission.matchedRule).toBe("unrestricted mode");
+});
+
+test("startup CLI permission mode overrides settings", async () => {
+  const projectDir = join(testDir, "project-cli-mode");
+  await Bun.write(
+    join(projectDir, ".letta", "settings.json"),
+    JSON.stringify({
+      permissions: {
+        mode: "standard",
+      },
+    }),
+  );
+
+  const result = await applyStartupPermissionMode({
+    permissionModeValue: "acceptEdits",
+    workingDirectory: projectDir,
+  });
+
+  expect(result).toEqual({ ok: true, mode: "acceptEdits", source: "cli" });
+  expect(permissionMode.getMode()).toBe("acceptEdits");
+});
+
+test("startup yolo mode overrides explicit permission mode", async () => {
+  const result = await applyStartupPermissionMode({
+    permissionModeValue: "standard",
+    yoloMode: true,
+    workingDirectory: testDir,
+  });
+
+  expect(result).toEqual({
+    ok: true,
+    mode: "unrestricted",
+    source: "cli",
+  });
+  expect(permissionMode.getMode()).toBe("unrestricted");
+});
+
+test("startup rejects invalid CLI permission mode", async () => {
+  const result = await applyStartupPermissionMode({
+    permissionModeValue: "banana",
+    workingDirectory: testDir,
+  });
+
+  expect(result.ok).toBe(false);
+  if (!result.ok) {
+    expect(result.message).toContain("Invalid permission mode: banana");
+  }
+  expect(permissionMode.getMode()).toBe("standard");
+});

--- a/src/permissions/startup.ts
+++ b/src/permissions/startup.ts
@@ -1,0 +1,59 @@
+import { loadPermissionMode } from "./loader";
+import {
+  migratePermissionMode,
+  type PermissionMode,
+  permissionMode,
+  VALID_PERMISSION_MODES,
+} from "./mode";
+
+export type StartupPermissionModeResult =
+  | {
+      ok: true;
+      mode: PermissionMode;
+      source: "cli" | "settings" | "default";
+    }
+  | {
+      ok: false;
+      value: string;
+      message: string;
+    };
+
+export function formatInvalidPermissionModeMessage(value: string): string {
+  return `Invalid permission mode: ${value}. Valid modes: ${VALID_PERMISSION_MODES.join(", ")}`;
+}
+
+export async function applyStartupPermissionMode(options: {
+  permissionModeValue?: string;
+  yoloMode?: boolean;
+  workingDirectory?: string;
+}): Promise<StartupPermissionModeResult> {
+  const { permissionModeValue, yoloMode = false } = options;
+
+  if (yoloMode) {
+    permissionMode.setMode("unrestricted");
+    return { ok: true, mode: "unrestricted", source: "cli" };
+  }
+
+  if (permissionModeValue) {
+    const migrated = migratePermissionMode(permissionModeValue);
+    if (!migrated) {
+      return {
+        ok: false,
+        value: permissionModeValue,
+        message: formatInvalidPermissionModeMessage(permissionModeValue),
+      };
+    }
+    permissionMode.setMode(migrated);
+    return { ok: true, mode: migrated, source: "cli" };
+  }
+
+  const configuredMode = await loadPermissionMode(
+    options.workingDirectory ?? process.cwd(),
+  );
+  if (configuredMode) {
+    permissionMode.setMode(configuredMode);
+    return { ok: true, mode: configuredMode, source: "settings" };
+  }
+
+  return { ok: true, mode: permissionMode.getMode(), source: "default" };
+}

--- a/src/permissions/types.ts
+++ b/src/permissions/types.ts
@@ -1,10 +1,13 @@
 // src/permissions/types.ts
 // Types for Claude Code-compatible permission system
 
+import type { PermissionMode } from "./mode";
+
 /**
  * Permission rules following Claude Code's format
  */
 export interface PermissionRules {
+  mode?: PermissionMode;
   allow?: string[];
   deny?: string[];
   ask?: string[];


### PR DESCRIPTION
## Summary

- Reads `permissions.mode` from settings during startup so legacy `bypassPermissions` configs migrate to the current `unrestricted` mode instead of falling back to approval prompts.
- Centralizes startup precedence for `--yolo`, `--permission-mode`, settings, and the default mode across interactive, headless, and listener startup.
- Preserves listener-scoped permission-mode state while using settings only as the global fallback/default.
- Adds regression coverage for settings mode migration, precedence, startup application, and listener scoped-mode helpers.
- Validated with `bun test src/permissions/permissions-loader.test.ts src/permissions/startup.test.ts src/websocket/listener-permission-mode.test.ts` and `bun run check`.

Fixes #2709.
