### PR TITLE
fix(tools): manage ripgrep resolution

### DIFF
--- a/src/tools/impl/glob.ts
+++ b/src/tools/impl/glob.ts
@@ -1,26 +1,12 @@
 import { execFile } from "node:child_process";
-import { createRequire } from "node:module";
 import * as path from "node:path";
-import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
+import { ensureRipgrep } from "./ripgrep-manager.js";
 import { LIMITS, truncateArray } from "./truncation.js";
 import { validateRequiredParams } from "./validation.js";
 
 const execFileAsync = promisify(execFile);
-
-function getRipgrepPath(): string {
-  try {
-    const __filename = fileURLToPath(import.meta.url);
-    const require = createRequire(__filename);
-    const rgPackage = require("@vscode/ripgrep");
-    return rgPackage.rgPath;
-  } catch (_error) {
-    return "rg";
-  }
-}
-
-const rgPath = getRipgrepPath();
 
 interface GlobArgs {
   pattern: string;
@@ -67,6 +53,12 @@ export async function glob(args: GlobArgs): Promise<GlobResult> {
     throw new Error("Glob tool missing required parameter: pattern");
   }
   const userCwd = getCurrentWorkingDirectory();
+  const rgPath = await ensureRipgrep(true);
+  if (!rgPath) {
+    throw new Error(
+      "Glob failed: ripgrep (rg) is not available and could not be downloaded",
+    );
+  }
 
   const baseDir = searchPath
     ? path.isAbsolute(searchPath)

--- a/src/tools/impl/grep.ts
+++ b/src/tools/impl/grep.ts
@@ -1,26 +1,12 @@
 import { execFile } from "node:child_process";
-import { createRequire } from "node:module";
 import * as path from "node:path";
-import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
+import { ensureRipgrep } from "./ripgrep-manager.js";
 import { LIMITS, truncateByChars } from "./truncation.js";
 import { validateRequiredParams } from "./validation.js";
 
 const execFileAsync = promisify(execFile);
-
-function getRipgrepPath(): string {
-  try {
-    const __filename = fileURLToPath(import.meta.url);
-    const require = createRequire(__filename);
-    const rgPackage = require("@vscode/ripgrep");
-    return rgPackage.rgPath;
-  } catch (_error) {
-    return "rg";
-  }
-}
-
-const rgPath = getRipgrepPath();
 
 function applyOffsetAndLimit<T>(
   items: T[],
@@ -75,6 +61,13 @@ export async function grep(args: GrepArgs): Promise<GrepResult> {
   } = args;
 
   const userCwd = getCurrentWorkingDirectory();
+  const rgPath = await ensureRipgrep(true);
+  if (!rgPath) {
+    throw new Error(
+      "Grep failed: ripgrep (rg) is not available and could not be downloaded",
+    );
+  }
+
   const rgArgs: string[] = [];
   if (output_mode === "files_with_matches") rgArgs.push("-l");
   else if (output_mode === "count") rgArgs.push("-c");

--- a/src/tools/impl/ripgrep-manager.ts
+++ b/src/tools/impl/ripgrep-manager.ts
@@ -10,7 +10,7 @@ import {
 } from "node:fs";
 import { createRequire } from "node:module";
 import { arch, homedir, platform } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
@@ -58,8 +58,8 @@ const RIPGREP_CONFIG: ToolConfig = {
   },
 };
 
-function isOfflineModeEnabled(): boolean {
-  const value = process.env[OFFLINE_ENV];
+function isOfflineModeEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const value = env[OFFLINE_ENV];
   if (!value) return false;
   return (
     value === "1" ||
@@ -68,17 +68,22 @@ function isOfflineModeEnabled(): boolean {
   );
 }
 
-export function getManagedToolsDir(): string {
-  return process.env[TOOLS_DIR_ENV] || join(homedir(), ".letta", "bin");
+export function getManagedToolsDir(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return env[TOOLS_DIR_ENV] || join(homedir(), ".letta", "bin");
 }
 
 function binaryName(config: ToolConfig): string {
   return config.binaryName + (platform() === "win32" ? ".exe" : "");
 }
 
-function commandWorks(command: string): boolean {
+function commandWorks(
+  command: string,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
   try {
-    const result = spawnSync(command, ["--version"], { stdio: "pipe" });
+    const result = spawnSync(command, ["--version"], { env, stdio: "pipe" });
     return !result.error && result.status === 0;
   } catch {
     return false;
@@ -96,22 +101,33 @@ function getBundledRipgrepPath(): string | null {
   }
 }
 
-export function getRipgrepPath(): string | null {
+interface RipgrepPathOptions {
+  env?: NodeJS.ProcessEnv;
+}
+
+export function getRipgrepPath(
+  options: RipgrepPathOptions = {},
+): string | null {
+  const env = options.env ?? process.env;
   const config = RIPGREP_CONFIG;
-  const managedPath = join(getManagedToolsDir(), binaryName(config));
-  if (existsSync(managedPath) && commandWorks(managedPath)) {
+  const managedPath = join(getManagedToolsDir(env), binaryName(config));
+  if (existsSync(managedPath) && commandWorks(managedPath, env)) {
     return managedPath;
   }
 
   const systemBinaryNames = config.systemBinaryNames ?? [config.binaryName];
   for (const systemBinaryName of systemBinaryNames) {
-    if (commandWorks(systemBinaryName)) {
+    if (commandWorks(systemBinaryName, env)) {
       return systemBinaryName;
     }
   }
 
   const bundledPath = getBundledRipgrepPath();
-  if (bundledPath && existsSync(bundledPath) && commandWorks(bundledPath)) {
+  if (
+    bundledPath &&
+    existsSync(bundledPath) &&
+    commandWorks(bundledPath, env)
+  ) {
     return bundledPath;
   }
 
@@ -401,7 +417,10 @@ export async function ensureRipgrep(
   }
 }
 
-export function getRipgrepBinDir(): string | undefined {
-  const rgPath = getRipgrepPath();
-  return rgPath ? dirname(rgPath) : undefined;
+export function getRipgrepBinDir(
+  options: RipgrepPathOptions = {},
+): string | undefined {
+  const rgPath = getRipgrepPath(options);
+  if (!rgPath || !isAbsolute(rgPath)) return undefined;
+  return dirname(rgPath);
 }

--- a/src/tools/impl/ripgrep-manager.ts
+++ b/src/tools/impl/ripgrep-manager.ts
@@ -1,0 +1,407 @@
+import { type SpawnSyncReturns, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+} from "node:fs";
+import { createRequire } from "node:module";
+import { arch, homedir, platform } from "node:os";
+import { dirname, join } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { fileURLToPath } from "node:url";
+
+const TOOLS_DIR_ENV = "LETTA_CODE_TOOLS_DIR";
+const OFFLINE_ENV = "LETTA_CODE_OFFLINE";
+const NETWORK_TIMEOUT_MS = 10_000;
+const DOWNLOAD_TIMEOUT_MS = 120_000;
+const APP_USER_AGENT = "letta-code";
+
+interface ToolConfig {
+  name: string;
+  repo: string;
+  binaryName: string;
+  systemBinaryNames?: string[];
+  tagPrefix: string;
+  getAssetName: (
+    version: string,
+    plat: NodeJS.Platform,
+    architecture: string,
+  ) => string | null;
+}
+
+const RIPGREP_CONFIG: ToolConfig = {
+  name: "ripgrep",
+  repo: "BurntSushi/ripgrep",
+  binaryName: "rg",
+  tagPrefix: "",
+  getAssetName: (version, plat, architecture) => {
+    if (plat === "darwin") {
+      const archStr = architecture === "arm64" ? "aarch64" : "x86_64";
+      return `ripgrep-${version}-${archStr}-apple-darwin.tar.gz`;
+    }
+    if (plat === "linux") {
+      if (architecture === "arm64") {
+        return `ripgrep-${version}-aarch64-unknown-linux-gnu.tar.gz`;
+      }
+      return `ripgrep-${version}-x86_64-unknown-linux-musl.tar.gz`;
+    }
+    if (plat === "win32") {
+      const archStr = architecture === "arm64" ? "aarch64" : "x86_64";
+      return `ripgrep-${version}-${archStr}-pc-windows-msvc.zip`;
+    }
+    return null;
+  },
+};
+
+function isOfflineModeEnabled(): boolean {
+  const value = process.env[OFFLINE_ENV];
+  if (!value) return false;
+  return (
+    value === "1" ||
+    value.toLowerCase() === "true" ||
+    value.toLowerCase() === "yes"
+  );
+}
+
+export function getManagedToolsDir(): string {
+  return process.env[TOOLS_DIR_ENV] || join(homedir(), ".letta", "bin");
+}
+
+function binaryName(config: ToolConfig): string {
+  return config.binaryName + (platform() === "win32" ? ".exe" : "");
+}
+
+function commandWorks(command: string): boolean {
+  try {
+    const result = spawnSync(command, ["--version"], { stdio: "pipe" });
+    return !result.error && result.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+function getBundledRipgrepPath(): string | null {
+  try {
+    const __filename = fileURLToPath(import.meta.url);
+    const require = createRequire(__filename);
+    const rgPackage = require("@vscode/ripgrep") as { rgPath?: unknown };
+    return typeof rgPackage.rgPath === "string" ? rgPackage.rgPath : null;
+  } catch {
+    return null;
+  }
+}
+
+export function getRipgrepPath(): string | null {
+  const config = RIPGREP_CONFIG;
+  const managedPath = join(getManagedToolsDir(), binaryName(config));
+  if (existsSync(managedPath) && commandWorks(managedPath)) {
+    return managedPath;
+  }
+
+  const systemBinaryNames = config.systemBinaryNames ?? [config.binaryName];
+  for (const systemBinaryName of systemBinaryNames) {
+    if (commandWorks(systemBinaryName)) {
+      return systemBinaryName;
+    }
+  }
+
+  const bundledPath = getBundledRipgrepPath();
+  if (bundledPath && existsSync(bundledPath) && commandWorks(bundledPath)) {
+    return bundledPath;
+  }
+
+  return null;
+}
+
+async function getLatestVersion(repo: string): Promise<string> {
+  const response = await fetch(
+    `https://api.github.com/repos/${repo}/releases/latest`,
+    {
+      headers: { "User-Agent": APP_USER_AGENT },
+      signal: AbortSignal.timeout(NETWORK_TIMEOUT_MS),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`GitHub API error: ${response.status}`);
+  }
+
+  const data = (await response.json()) as { tag_name: string };
+  return data.tag_name.replace(/^v/, "");
+}
+
+async function downloadFile(url: string, dest: string): Promise<void> {
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to download: ${response.status}`);
+  }
+
+  if (!response.body) {
+    throw new Error("No response body");
+  }
+
+  const fileStream = createWriteStream(dest);
+  await pipeline(Readable.fromWeb(response.body as never), fileStream);
+}
+
+function findBinaryRecursively(
+  rootDir: string,
+  binaryFileName: string,
+): string | null {
+  const stack: string[] = [rootDir];
+
+  while (stack.length > 0) {
+    const currentDir = stack.pop();
+    if (!currentDir) continue;
+
+    const entries = readdirSync(currentDir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = join(currentDir, entry.name);
+      if (entry.isFile() && entry.name === binaryFileName) {
+        return fullPath;
+      }
+      if (entry.isDirectory()) {
+        stack.push(fullPath);
+      }
+    }
+  }
+
+  return null;
+}
+
+function formatSpawnFailure(result: SpawnSyncReturns<Buffer>): string {
+  if (result.error?.message) {
+    return result.error.message;
+  }
+  const stderr = result.stderr?.toString().trim();
+  if (stderr) {
+    return stderr;
+  }
+  const stdout = result.stdout?.toString().trim();
+  if (stdout) {
+    return stdout;
+  }
+  return `exit status ${result.status ?? "unknown"}`;
+}
+
+function runExtractionCommand(command: string, args: string[]): string | null {
+  const result = spawnSync(command, args, { stdio: "pipe" });
+  if (!result.error && result.status === 0) {
+    return null;
+  }
+  return `${command}: ${formatSpawnFailure(result)}`;
+}
+
+function extractTarGzArchive(
+  archivePath: string,
+  extractDir: string,
+  assetName: string,
+): void {
+  const failure = runExtractionCommand("tar", [
+    "xzf",
+    archivePath,
+    "-C",
+    extractDir,
+  ]);
+  if (failure) {
+    throw new Error(`Failed to extract ${assetName}: ${failure}`);
+  }
+}
+
+function getWindowsTarCommand(): string {
+  const systemRoot = process.env.SystemRoot ?? process.env.WINDIR;
+  if (systemRoot) {
+    const systemTar = join(systemRoot, "System32", "tar.exe");
+    if (existsSync(systemTar)) {
+      return systemTar;
+    }
+  }
+  return "tar.exe";
+}
+
+function extractZipArchive(
+  archivePath: string,
+  extractDir: string,
+  assetName: string,
+): void {
+  const failures: string[] = [];
+
+  if (platform() === "win32") {
+    const tarFailure = runExtractionCommand(getWindowsTarCommand(), [
+      "xf",
+      archivePath,
+      "-C",
+      extractDir,
+    ]);
+    if (!tarFailure) return;
+    failures.push(tarFailure);
+
+    const script =
+      "& { param($archive, $destination) $ErrorActionPreference = 'Stop'; Expand-Archive -LiteralPath $archive -DestinationPath $destination -Force }";
+    const powershellFailure = runExtractionCommand("powershell.exe", [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-Command",
+      script,
+      archivePath,
+      extractDir,
+    ]);
+    if (!powershellFailure) return;
+    failures.push(powershellFailure);
+  } else {
+    const unzipFailure = runExtractionCommand("unzip", [
+      "-q",
+      archivePath,
+      "-d",
+      extractDir,
+    ]);
+    if (!unzipFailure) return;
+    failures.push(unzipFailure);
+
+    const tarFailure = runExtractionCommand("tar", [
+      "xf",
+      archivePath,
+      "-C",
+      extractDir,
+    ]);
+    if (!tarFailure) return;
+    failures.push(tarFailure);
+  }
+
+  throw new Error(`Failed to extract ${assetName}: ${failures.join("; ")}`);
+}
+
+async function downloadRipgrep(): Promise<string> {
+  const config = RIPGREP_CONFIG;
+  const plat = platform();
+  const architecture = arch();
+  const version = await getLatestVersion(config.repo);
+  const assetName = config.getAssetName(version, plat, architecture);
+  if (!assetName) {
+    throw new Error(`Unsupported platform: ${plat}/${architecture}`);
+  }
+
+  const toolsDir = getManagedToolsDir();
+  mkdirSync(toolsDir, { recursive: true });
+
+  const downloadUrl = `https://github.com/${config.repo}/releases/download/${config.tagPrefix}${version}/${assetName}`;
+  const archivePath = join(toolsDir, assetName);
+  const binaryFileName = binaryName(config);
+  const binaryPath = join(toolsDir, binaryFileName);
+
+  await downloadFile(downloadUrl, archivePath);
+
+  const extractDir = join(
+    toolsDir,
+    `extract_tmp_${config.binaryName}_${process.pid}_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`,
+  );
+  mkdirSync(extractDir, { recursive: true });
+
+  try {
+    if (assetName.endsWith(".tar.gz")) {
+      extractTarGzArchive(archivePath, extractDir, assetName);
+    } else if (assetName.endsWith(".zip")) {
+      extractZipArchive(archivePath, extractDir, assetName);
+    } else {
+      throw new Error(`Unsupported archive format: ${assetName}`);
+    }
+
+    const extractedDir = join(
+      extractDir,
+      assetName.replace(/\.(tar\.gz|zip)$/, ""),
+    );
+    const extractedBinaryCandidates = [
+      join(extractedDir, binaryFileName),
+      join(extractDir, binaryFileName),
+    ];
+    let extractedBinary = extractedBinaryCandidates.find((candidate) =>
+      existsSync(candidate),
+    );
+    if (!extractedBinary) {
+      extractedBinary =
+        findBinaryRecursively(extractDir, binaryFileName) ?? undefined;
+    }
+
+    if (!extractedBinary) {
+      throw new Error(
+        `Binary not found in archive: expected ${binaryFileName} under ${extractDir}`,
+      );
+    }
+
+    renameSync(extractedBinary, binaryPath);
+    if (plat !== "win32") {
+      chmodSync(binaryPath, 0o755);
+    }
+  } finally {
+    rmSync(archivePath, { force: true });
+    rmSync(extractDir, { recursive: true, force: true });
+  }
+
+  if (!commandWorks(binaryPath)) {
+    throw new Error(
+      `${config.name} installed to ${binaryPath} but failed --version validation`,
+    );
+  }
+
+  return binaryPath;
+}
+
+export async function ensureRipgrep(
+  silent = false,
+): Promise<string | undefined> {
+  const existingPath = getRipgrepPath();
+  if (existingPath) {
+    return existingPath;
+  }
+
+  if (isOfflineModeEnabled()) {
+    if (!silent) {
+      console.warn(
+        "ripgrep not found. Offline mode enabled, skipping download.",
+      );
+    }
+    return undefined;
+  }
+
+  if (platform() === "android") {
+    if (!silent) {
+      console.warn("ripgrep not found. Install with: pkg install ripgrep");
+    }
+    return undefined;
+  }
+
+  if (!silent) {
+    console.log("ripgrep not found. Downloading...");
+  }
+
+  try {
+    const path = await downloadRipgrep();
+    if (!silent) {
+      console.log(`ripgrep installed to ${path}`);
+    }
+    return path;
+  } catch (error) {
+    if (!silent) {
+      console.warn(
+        `Failed to download ripgrep: ${error instanceof Error ? error.message : error}`,
+      );
+    }
+    return undefined;
+  }
+}
+
+export function getRipgrepBinDir(): string | undefined {
+  const rgPath = getRipgrepPath();
+  return rgPath ? dirname(rgPath) : undefined;
+}

--- a/src/tools/impl/shell-env.ts
+++ b/src/tools/impl/shell-env.ts
@@ -18,22 +18,7 @@ import { getServerUrl } from "@/backend/api/client";
 import { isLocalBackendNoMemfsEnvEnabled } from "@/backend/local/paths";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
 import { settingsManager } from "@/settings-manager";
-
-/**
- * Get the directory containing the bundled ripgrep binary.
- * Returns undefined if @vscode/ripgrep is not installed.
- */
-function getRipgrepBinDir(): string | undefined {
-  try {
-    const __filename = fileURLToPath(import.meta.url);
-    const require = createRequire(__filename);
-    const rgPackage = require("@vscode/ripgrep");
-    // rgPath is the full path to the binary, we want the directory
-    return path.dirname(rgPackage.rgPath);
-  } catch (_error) {
-    return undefined;
-  }
-}
+import { getRipgrepBinDir } from "./ripgrep-manager.js";
 
 /**
  * Get the node_modules directory containing this package's dependencies.

--- a/src/tools/ripgrep-manager.test.ts
+++ b/src/tools/ripgrep-manager.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getRipgrepPath } from "@/tools/impl/ripgrep-manager";
+
+const TOOLS_DIR_ENV = "LETTA_CODE_TOOLS_DIR";
+
+function withTemporaryEnv<T>(
+  updates: Record<string, string | undefined>,
+  fn: () => T,
+): T {
+  const original = Object.fromEntries(
+    Object.keys(updates).map((key) => [key, process.env[key]]),
+  ) as Record<string, string | undefined>;
+
+  for (const [key, value] of Object.entries(updates)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return fn();
+  } finally {
+    for (const [key, value] of Object.entries(original)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+function writeFakeRg(dir: string, name: string, body: string): string {
+  const filePath = join(dir, name);
+  if (process.platform === "win32") {
+    writeFileSync(filePath, body, "utf-8");
+  } else {
+    writeFileSync(filePath, `#!/bin/sh\n${body}\n`, "utf-8");
+    chmodSync(filePath, 0o755);
+  }
+  return filePath;
+}
+
+describe("ripgrep manager", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function makeTempDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), "letta-rg-test-"));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  test.skipIf(process.platform === "win32")(
+    "prefers a managed rg binary that passes --version",
+    () => {
+      const toolsDir = makeTempDir();
+      const systemDir = makeTempDir();
+      const binaryName = process.platform === "win32" ? "rg.exe" : "rg";
+      const managedRg = writeFakeRg(
+        toolsDir,
+        binaryName,
+        "echo ripgrep managed",
+      );
+      writeFakeRg(systemDir, binaryName, "echo ripgrep system");
+
+      withTemporaryEnv(
+        {
+          [TOOLS_DIR_ENV]: toolsDir,
+          PATH: systemDir,
+        },
+        () => {
+          expect(getRipgrepPath()).toBe(managedRg);
+        },
+      );
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "skips a stale managed rg binary when --version fails",
+    () => {
+      const toolsDir = makeTempDir();
+      const systemDir = makeTempDir();
+      const binaryName = process.platform === "win32" ? "rg.exe" : "rg";
+      writeFakeRg(toolsDir, binaryName, "exit 1");
+      writeFakeRg(systemDir, binaryName, "echo ripgrep system");
+
+      withTemporaryEnv(
+        {
+          [TOOLS_DIR_ENV]: toolsDir,
+          PATH: systemDir,
+        },
+        () => {
+          expect(getRipgrepPath()).toBe(binaryName);
+        },
+      );
+    },
+  );
+});

--- a/src/tools/ripgrep-manager.test.ts
+++ b/src/tools/ripgrep-manager.test.ts
@@ -2,38 +2,9 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getRipgrepPath } from "@/tools/impl/ripgrep-manager";
+import { getRipgrepBinDir, getRipgrepPath } from "@/tools/impl/ripgrep-manager";
 
 const TOOLS_DIR_ENV = "LETTA_CODE_TOOLS_DIR";
-
-function withTemporaryEnv<T>(
-  updates: Record<string, string | undefined>,
-  fn: () => T,
-): T {
-  const original = Object.fromEntries(
-    Object.keys(updates).map((key) => [key, process.env[key]]),
-  ) as Record<string, string | undefined>;
-
-  for (const [key, value] of Object.entries(updates)) {
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
-    }
-  }
-
-  try {
-    return fn();
-  } finally {
-    for (const [key, value] of Object.entries(original)) {
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
-    }
-  }
-}
 
 function writeFakeRg(dir: string, name: string, body: string): string {
   const filePath = join(dir, name);
@@ -74,15 +45,15 @@ describe("ripgrep manager", () => {
       );
       writeFakeRg(systemDir, binaryName, "echo ripgrep system");
 
-      withTemporaryEnv(
-        {
-          [TOOLS_DIR_ENV]: toolsDir,
-          PATH: systemDir,
-        },
-        () => {
-          expect(getRipgrepPath()).toBe(managedRg);
-        },
-      );
+      expect(
+        getRipgrepPath({
+          env: {
+            ...process.env,
+            [TOOLS_DIR_ENV]: toolsDir,
+            PATH: systemDir,
+          },
+        }),
+      ).toBe(managedRg);
     },
   );
 
@@ -95,15 +66,35 @@ describe("ripgrep manager", () => {
       writeFakeRg(toolsDir, binaryName, "exit 1");
       writeFakeRg(systemDir, binaryName, "echo ripgrep system");
 
-      withTemporaryEnv(
-        {
-          [TOOLS_DIR_ENV]: toolsDir,
-          PATH: systemDir,
-        },
-        () => {
-          expect(getRipgrepPath()).toBe(binaryName);
-        },
-      );
+      expect(
+        getRipgrepPath({
+          env: {
+            ...process.env,
+            [TOOLS_DIR_ENV]: toolsDir,
+            PATH: systemDir,
+          },
+        }),
+      ).toBe(binaryName);
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "does not expose current directory when rg is resolved from PATH",
+    () => {
+      const toolsDir = makeTempDir();
+      const systemDir = makeTempDir();
+      const binaryName = process.platform === "win32" ? "rg.exe" : "rg";
+      writeFakeRg(systemDir, binaryName, "echo ripgrep system");
+
+      expect(
+        getRipgrepBinDir({
+          env: {
+            ...process.env,
+            [TOOLS_DIR_ENV]: toolsDir,
+            PATH: systemDir,
+          },
+        }),
+      ).toBeUndefined();
     },
   );
 });


### PR DESCRIPTION
## Summary

- Replace direct `@vscode/ripgrep` usage in Grep/Glob with a Pi-style resolver that validates `rg --version` before using a binary.
- Prefer a Letta-managed `~/.letta/bin/rg` cache, then system `rg`, then a validated bundled fallback; download the correct BurntSushi/ripgrep asset when no valid binary exists.
- Use the same validated resolver for shell PATH injection so stale platform-mismatched bundled binaries are not prepended.
- Add regression coverage for preferring valid managed ripgrep and skipping stale managed binaries.