### PR TITLE
fix(cli): apply saved backend preference to subcommands

### DIFF
--- a/src/cli/startup-backend-mode.test.ts
+++ b/src/cli/startup-backend-mode.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   getStartupBackendLookupOrder,
   inferBackendModeFromAgentId,
+  resolveSubcommandBackendMode,
 } from "@/cli/startup-backend-mode";
 
 describe("startup backend mode inference", () => {
@@ -26,5 +27,54 @@ describe("startup backend mode inference", () => {
   test("explicit backend mode disables fallback", () => {
     expect(getStartupBackendLookupOrder("local", "api")).toEqual(["api"]);
     expect(getStartupBackendLookupOrder("api", "local")).toEqual(["local"]);
+  });
+
+  test("subcommands use saved backend mode when no stronger selector exists", () => {
+    expect(
+      resolveSubcommandBackendMode({
+        savedBackendMode: "local",
+        baseURL: "https://api.letta.com",
+        cloudBaseURL: "https://api.letta.com",
+      }),
+    ).toBe("local");
+    expect(
+      resolveSubcommandBackendMode({
+        savedBackendMode: "api",
+        baseURL: "https://api.letta.com",
+        cloudBaseURL: "https://api.letta.com",
+      }),
+    ).toBe("api");
+  });
+
+  test("explicit backend flag takes precedence over saved subcommand mode", () => {
+    expect(
+      resolveSubcommandBackendMode({
+        explicitBackendMode: "api",
+        savedBackendMode: "local",
+        baseURL: "https://api.letta.com",
+        cloudBaseURL: "https://api.letta.com",
+      }),
+    ).toBeUndefined();
+  });
+
+  test("local backend env takes precedence over saved API subcommand mode", () => {
+    expect(
+      resolveSubcommandBackendMode({
+        envBackendMode: "local",
+        savedBackendMode: "api",
+        baseURL: "https://api.letta.com",
+        cloudBaseURL: "https://api.letta.com",
+      }),
+    ).toBe("local");
+  });
+
+  test("custom API base URL blocks saved local subcommand mode", () => {
+    expect(
+      resolveSubcommandBackendMode({
+        savedBackendMode: "local",
+        baseURL: "http://localhost:8283",
+        cloudBaseURL: "https://api.letta.com",
+      }),
+    ).toBeUndefined();
   });
 });

--- a/src/cli/startup-backend-mode.ts
+++ b/src/cli/startup-backend-mode.ts
@@ -16,3 +16,27 @@ export function getStartupBackendLookupOrder(
   if (explicitMode) return [explicitMode];
   return activeMode === "local" ? ["local", "api"] : ["api", "local"];
 }
+
+export interface SubcommandBackendModeInput {
+  explicitBackendMode?: StartupBackendMode;
+  envBackendMode?: StartupBackendMode;
+  savedBackendMode?: StartupBackendMode;
+  baseURL: string;
+  cloudBaseURL: string;
+}
+
+export function resolveSubcommandBackendMode({
+  explicitBackendMode,
+  envBackendMode,
+  savedBackendMode,
+  baseURL,
+  cloudBaseURL,
+}: SubcommandBackendModeInput): StartupBackendMode | undefined {
+  if (explicitBackendMode) return undefined;
+  if (envBackendMode) return envBackendMode;
+  if (!savedBackendMode) return undefined;
+  if (savedBackendMode === "local" && baseURL !== cloudBaseURL) {
+    return undefined;
+  }
+  return savedBackendMode;
+}

--- a/src/cli/subcommands/router.test.ts
+++ b/src/cli/subcommands/router.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { runSubcommand } from "@/cli/subcommands/router";
+import {
+  runSubcommand,
+  subcommandNeedsEarlyBackendMode,
+} from "@/cli/subcommands/router";
 
 describe("subcommand router", () => {
   test("routes version subcommand before TUI startup", async () => {
@@ -23,5 +26,14 @@ describe("subcommand router", () => {
   test("routes connect subcommand", async () => {
     const exitCode = await runSubcommand(["connect", "help"]);
     expect(exitCode).toBe(0);
+  });
+
+  test("identifies backend-aware subcommands for early backend selection", () => {
+    expect(subcommandNeedsEarlyBackendMode("connect")).toBe(true);
+    expect(subcommandNeedsEarlyBackendMode("server")).toBe(true);
+    expect(subcommandNeedsEarlyBackendMode("memory")).toBe(true);
+    expect(subcommandNeedsEarlyBackendMode("version")).toBe(false);
+    expect(subcommandNeedsEarlyBackendMode("backend")).toBe(false);
+    expect(subcommandNeedsEarlyBackendMode(undefined)).toBe(false);
   });
 });

--- a/src/cli/subcommands/router.ts
+++ b/src/cli/subcommands/router.ts
@@ -23,6 +23,25 @@ async function runVersionSubcommand(): Promise<number> {
   return 0;
 }
 
+export function subcommandNeedsEarlyBackendMode(
+  command: string | undefined,
+): boolean {
+  switch (command) {
+    case "agents":
+    case "connect":
+    case "install":
+    case "memfs":
+    case "memory":
+    case "messages":
+    case "remote":
+    case "server":
+    case "skills":
+      return true;
+    default:
+      return false;
+  }
+}
+
 export async function runSubcommand(argv: string[]): Promise<number | null> {
   const [command, ...rest] = argv;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import {
 import { getBillingTier } from "./backend/api/metadata";
 import {
   isLocalBackendNoMemfsEnvEnabled,
+  LOCAL_BACKEND_EXPERIMENTAL_ENV,
   LOCAL_BACKEND_NO_MEMFS_ENV,
 } from "./backend/local/paths";
 import {
@@ -66,13 +67,17 @@ import { ProfileSelectionInline } from "./cli/profile-selection";
 import {
   getStartupBackendLookupOrder,
   inferBackendModeFromAgentId,
+  resolveSubcommandBackendMode,
 } from "./cli/startup-backend-mode";
 import {
   validateConversationDefaultRequiresAgent,
   validateFlagConflicts,
   validateRegistryHandleOrThrow,
 } from "./cli/startup-flag-validation";
-import { runSubcommand } from "./cli/subcommands/router";
+import {
+  runSubcommand,
+  subcommandNeedsEarlyBackendMode,
+} from "./cli/subcommands/router";
 import {
   disableExtensionsForProcess,
   shouldDisableExtensions,
@@ -686,6 +691,32 @@ async function main(): Promise<void> {
       error instanceof Error ? `Error: ${error.message}` : String(error),
     );
     process.exit(1);
+  }
+
+  if (subcommandNeedsEarlyBackendMode(subcommandArgs[0])) {
+    const savedBackendSettings =
+      settingsManager.readStartupBackendSettingsSync();
+    const localBackendEnvValue = process.env[LOCAL_BACKEND_EXPERIMENTAL_ENV];
+    const envBackendMode =
+      localBackendEnvValue === undefined
+        ? undefined
+        : localBackendEnvValue === "1" ||
+            localBackendEnvValue.toLowerCase() === "true"
+          ? "local"
+          : "api";
+    const backendMode = resolveSubcommandBackendMode({
+      explicitBackendMode,
+      envBackendMode,
+      savedBackendMode: savedBackendSettings.preferredBackendMode,
+      baseURL:
+        process.env.LETTA_BASE_URL ||
+        savedBackendSettings.envBaseUrl ||
+        LETTA_CLOUD_API_URL,
+      cloudBaseURL: LETTA_CLOUD_API_URL,
+    });
+    if (backendMode) {
+      configureBackendMode(backendMode);
+    }
   }
 
   // Early exit for CLI subcommands (e.g., `letta server`, `letta memory`).

--- a/src/settings-manager.test.ts
+++ b/src/settings-manager.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -2027,5 +2028,69 @@ describe("Settings Manager - Conversation Pins", () => {
     expect(
       settingsManager.getGlobalPinnedConversations("local-agent-1"),
     ).toEqual([]);
+  });
+});
+
+describe("readStartupBackendSettingsSync", () => {
+  let tmpHome: string;
+  const savedHome = process.env.HOME;
+
+  beforeEach(async () => {
+    tmpHome = await mkdtemp(join(tmpdir(), "letta-startup-backend-"));
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(async () => {
+    if (savedHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = savedHome;
+    }
+    await rm(tmpHome, { recursive: true, force: true });
+  });
+
+  function writeSettings(data: Record<string, unknown>): void {
+    const dir = join(tmpHome, ".letta");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "settings.json"), JSON.stringify(data));
+  }
+
+  test("returns empty settings when settings file does not exist", () => {
+    expect(settingsManager.readStartupBackendSettingsSync()).toEqual({
+      preferredBackendMode: undefined,
+      envBaseUrl: undefined,
+    });
+  });
+
+  test("reads valid backend preference and configured base URL", () => {
+    writeSettings({
+      preferredBackendMode: "local",
+      env: { LETTA_BASE_URL: "http://localhost:8283" },
+    });
+
+    expect(settingsManager.readStartupBackendSettingsSync()).toEqual({
+      preferredBackendMode: "local",
+      envBaseUrl: "http://localhost:8283",
+    });
+  });
+
+  test("ignores invalid backend preference and malformed env", () => {
+    writeSettings({ preferredBackendMode: "other", env: "not-an-object" });
+
+    expect(settingsManager.readStartupBackendSettingsSync()).toEqual({
+      preferredBackendMode: undefined,
+      envBaseUrl: undefined,
+    });
+  });
+
+  test("returns empty settings for malformed JSON", () => {
+    const dir = join(tmpHome, ".letta");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "settings.json"), "not json{{{");
+
+    expect(settingsManager.readStartupBackendSettingsSync()).toEqual({
+      preferredBackendMode: undefined,
+      envBaseUrl: undefined,
+    });
   });
 });

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -128,6 +128,11 @@ export interface Settings {
   };
 }
 
+export interface StartupBackendSettings {
+  preferredBackendMode?: Settings["preferredBackendMode"];
+  envBaseUrl?: string;
+}
+
 export interface ProjectSettings {
   hooks?: HooksConfig; // Project-specific hook commands (checked in)
   windowTitle?: WindowTitleConfig; // Project-specific terminal window title
@@ -2717,6 +2722,26 @@ class SettingsManager {
     this.managedKeys.clear();
     this.dirtyKeys.clear();
     this.clearSecureTokensCache();
+  }
+
+  /**
+   * Read the small subset of settings needed before CLI subcommand routing.
+   * This intentionally avoids full SettingsManager initialization, which can
+   * create defaults, mark dirty keys, and perform migrations/writes.
+   */
+  readStartupBackendSettingsSync(): StartupBackendSettings {
+    const raw = this.readJsonObjectSync(this.getSettingsPath());
+    const mode = raw.preferredBackendMode;
+    const env = raw.env;
+    const envBaseUrl =
+      env && typeof env === "object" && !Array.isArray(env)
+        ? (env as Record<string, unknown>).LETTA_BASE_URL
+        : undefined;
+    return {
+      preferredBackendMode:
+        mode === "api" || mode === "local" ? mode : undefined,
+      envBaseUrl: typeof envBaseUrl === "string" ? envBaseUrl : undefined,
+    };
   }
 }
 


### PR DESCRIPTION
## Summary

- Applies the saved backend preference before backend-aware CLI subcommands run, so `letta backend local` makes `letta connect ...` use local provider storage by default.
- Preserves stronger selectors: explicit `--backend`, `LETTA_LOCAL_BACKEND_EXPERIMENTAL`, and custom `LETTA_BASE_URL` continue to take precedence over the saved preference.
- Adds coverage for subcommand backend resolution and lightweight startup settings reads.

Fixes #2764
Replaces #2766