### PR TITLE
fix(startup): align PTY setup test with cloud-agent flow

### DIFF
--- a/src/startup-setup-pty.test.ts
+++ b/src/startup-setup-pty.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
@@ -43,9 +43,17 @@ describe("startup setup PTY", () => {
         },
       );
 
-      expect(result.status).toBe(0);
-      expect(result.signal).toBeNull();
-      expect(result.stderr).toBe("");
+      if (result.status !== 0 || result.signal !== null || result.stderr) {
+        throw new Error(
+          [
+            `PTY setup runner failed with status ${result.status} signal ${result.signal}`,
+            result.stdout ? `stdout:\n${result.stdout}` : null,
+            result.stderr ? `stderr:\n${result.stderr}` : null,
+          ]
+            .filter(Boolean)
+            .join("\n\n"),
+        );
+      }
     },
     { timeout: 35000 },
   );

--- a/src/test-utils/startup-setup-pty-runner.cjs
+++ b/src/test-utils/startup-setup-pty-runner.cjs
@@ -74,7 +74,10 @@ async function main() {
     let exited = false;
     terminal = pty.spawn(
       "node",
-      [cliPath, "--agent", "agent-4140c4b5-f32e-475c-9573-bcfd9446ca7b"],
+      // Force API startup so the no-credentials setup menu renders. The test
+      // is about PTY raw input after terminal preflight, not explicit cloud
+      // agent handling; cloud-agent setup intentionally disables local mode.
+      [cliPath, "--backend", "api"],
       {
         cols: 120,
         cwd: projectRoot,


### PR DESCRIPTION
## Summary

- Updates the startup setup PTY regression test to force API startup with `--backend api` instead of passing an explicit cloud agent ID.
- Keeps the test focused on raw keyboard handling after terminal preflight while respecting the newer behavior where explicit cloud-agent startup disables local mode.
- Improves the test failure output so runner stdout/stderr is visible when the PTY helper exits non-zero.

Fixes the current main CI failure from #2749/#2750 interaction.