### PR TITLE
fix: declare yaml runtime dependency for skill scripts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "shiki": "^4.0.2",
         "strip-ansi": "^7.2.0",
         "ws": "^8.19.0",
+        "yaml": "^2.8.1",
       },
       "devDependencies": {
         "@slack/bolt": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "sharp": "^0.34.5",
     "shiki": "^4.0.2",
     "strip-ansi": "^7.2.0",
-    "ws": "^8.19.0"
+    "ws": "^8.19.0",
+    "yaml": "^2.8.1"
   },
   "optionalDependencies": {
     "@vscode/ripgrep": "^1.17.0"

--- a/src/skills/skill-creator-scripts.test.ts
+++ b/src/skills/skill-creator-scripts.test.ts
@@ -3,7 +3,14 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import {
   initSkill,
@@ -13,6 +20,45 @@ import { packageSkill } from "@/skills/builtin/creating-skills/scripts/package-s
 import { validateSkill } from "@/skills/builtin/creating-skills/scripts/validate-skill";
 
 const TEST_DIR = join(import.meta.dir, ".test-skill-creator");
+const CREATING_SKILLS_SCRIPTS_DIR = join(
+  import.meta.dir,
+  "builtin",
+  "creating-skills",
+  "scripts",
+);
+
+function packageDependencies(): Record<string, string> {
+  return JSON.parse(
+    readFileSync(join(import.meta.dir, "..", "..", "package.json"), "utf-8"),
+  ).dependencies;
+}
+
+function bundledScriptExternalImports(): string[] {
+  const bareImports = new Set<string>();
+  const importPattern = /\bfrom\s+["']([^"']+)["']|import\s*\(\s*["']([^"']+)["']\s*\)/g;
+
+  for (const file of readdirSync(CREATING_SKILLS_SCRIPTS_DIR)) {
+    if (!file.endsWith(".ts")) continue;
+
+    const contents = readFileSync(
+      join(CREATING_SKILLS_SCRIPTS_DIR, file),
+      "utf-8",
+    );
+
+    for (const match of contents.matchAll(importPattern)) {
+      const specifier = match[1] ?? match[2];
+      if (
+        specifier &&
+        !specifier.startsWith(".") &&
+        !specifier.startsWith("node:")
+      ) {
+        bareImports.add(specifier);
+      }
+    }
+  }
+
+  return [...bareImports].sort();
+}
 
 describe("validate-skill", () => {
   beforeEach(() => {
@@ -233,6 +279,17 @@ description: Name doesn't match directory
     expect(result.valid).toBe(true);
     expect(result.warnings).toBeDefined();
     expect(result.warnings?.[0]).toContain("doesn't match directory name");
+  });
+});
+
+describe("bundled skill scripts", () => {
+  test("declare external runtime imports as package dependencies", () => {
+    const dependencies = packageDependencies();
+    const missing = bundledScriptExternalImports().filter(
+      (specifier) => !(specifier in dependencies),
+    );
+
+    expect(missing).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary
- add yaml to the published package dependencies so bundled creating-skills scripts can resolve it from the desktop/app package
- sync the Bun lock root dependency entry
- add a regression guard that checks bundled skill scripts do not import undeclared external runtime packages

## Verification
- 
ode static dependency guard: bundled creating-skills scripts external imports = ["yaml"], missing dependencies = []

Note: I could not run the repository's Bun test suite in this Windows environment because un is not installed here.

Fixes #2775