### PR TITLE
fix(models): add OpenRouter MiniMax M3 registry entry

### DIFF
--- a/src/agent/model-tier-selection.test.ts
+++ b/src/agent/model-tier-selection.test.ts
@@ -40,6 +40,16 @@ describe("getModelInfo", () => {
       parallel_tool_calls: true,
     });
   });
+
+  test("resolves OpenRouter MiniMax M3 registry metadata", () => {
+    const info = getModelInfo("openrouter-minimax-m3");
+    expect(info?.handle).toBe("openrouter/minimax/minimax-m3");
+    expect(info?.label).toBe("MiniMax M3");
+    expect(info?.updateArgs).toMatchObject({
+      context_window: 500000,
+      parallel_tool_calls: true,
+    });
+  });
 });
 
 describe("getModelInfoForLlmConfig", () => {

--- a/src/models.json
+++ b/src/models.json
@@ -1491,6 +1491,16 @@
       }
     },
     {
+      "id": "openrouter-minimax-m3",
+      "handle": "openrouter/minimax/minimax-m3",
+      "label": "MiniMax M3",
+      "description": "MiniMax M3 through OpenRouter",
+      "updateArgs": {
+        "context_window": 500000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "minimax-m2.7",
       "handle": "minimax/MiniMax-M2.7",
       "label": "MiniMax 2.7",


### PR DESCRIPTION
## Summary

Add openrouter/minimax/minimax-m3 to the hardcoded model registry so OpenRouter BYOK handles can resolve to MiniMax M3 metadata in the model selector.

The direct MiniMax M3 entry already existed. This adds the OpenRouter handle variant that BYOK/OpenRouter model sync returns.

## Validation

- bun test src/agent/model-tier-selection.test.ts
- bun run lint

👾 Generated with [Letta Code](https://letta.com)