### PR TITLE
fix(listener): refresh secret reminders after updates

### DIFF
--- a/src/reminders/engine.test.ts
+++ b/src/reminders/engine.test.ts
@@ -1,6 +1,50 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
-import { prependReminderPartsToContent } from "@/reminders/engine";
+import { setCurrentAgentId } from "@/agent/context";
+import { permissionMode } from "@/permissions/mode";
+import {
+  buildSharedReminderParts,
+  prependReminderPartsToContent,
+  sharedReminderProviders,
+} from "@/reminders/engine";
+import {
+  createSharedReminderState,
+  markSecretsInfoReminderPending,
+} from "@/reminders/state";
+import {
+  clearSecretsCache,
+  initSecretsFromServer,
+} from "@/utils/secrets-store";
+
+const SECRETS_AGENT_ID = "agent-reminder-secrets";
+
+async function buildSecretsTestReminderParts(
+  state: ReturnType<typeof createSharedReminderState>,
+) {
+  const origReflectionStep = sharedReminderProviders["reflection-step-count"];
+  const origReflectionCompaction =
+    sharedReminderProviders["reflection-compaction"];
+  sharedReminderProviders["reflection-step-count"] = async () => null;
+  sharedReminderProviders["reflection-compaction"] = async () => null;
+  try {
+    return await buildSharedReminderParts({
+      mode: "listen",
+      agent: { id: SECRETS_AGENT_ID, name: null },
+      state,
+      systemInfoReminderEnabled: false,
+      reflectionSettings: { trigger: "off", stepCount: 25 },
+      skillSources: [],
+    });
+  } finally {
+    sharedReminderProviders["reflection-step-count"] = origReflectionStep;
+    sharedReminderProviders["reflection-compaction"] = origReflectionCompaction;
+  }
+}
+
+afterEach(() => {
+  clearSecretsCache(SECRETS_AGENT_ID);
+  setCurrentAgentId(null);
+});
 
 describe("headless shared reminder content helpers", () => {
   test("prepends reminder text to string user content as parts array", () => {
@@ -64,5 +108,47 @@ describe("headless shared reminder content helpers", () => {
       { type: "text", text: "<skills>demo</skills>" },
       { type: "text", text: '{"ref":"abc"}' },
     ]);
+  });
+});
+
+describe("secrets info reminders", () => {
+  test("emits secret names when the cached name list changes", async () => {
+    const state = createSharedReminderState();
+    state.lastNotifiedPermissionMode = permissionMode.getMode();
+
+    const initial = await buildSecretsTestReminderParts(state);
+    expect(initial.appliedReminderIds).not.toContain("secrets-info");
+
+    await initSecretsFromServer(SECRETS_AGENT_ID, {
+      secrets: [{ key: "PLAYGROUND_AGENT_ID", value: "agent-123" }],
+    });
+
+    const updated = await buildSecretsTestReminderParts(state);
+
+    const text = updated.parts.map((part) => part.text).join("\n");
+    expect(updated.appliedReminderIds).toContain("secrets-info");
+    expect(text).toContain("The agent secrets were updated");
+    expect(text).toContain("$PLAYGROUND_AGENT_ID");
+  });
+
+  test("re-emits secret names after a secrets refresh", async () => {
+    await initSecretsFromServer(SECRETS_AGENT_ID, {
+      secrets: [{ key: "PLAYGROUND_AGENT_ID", value: "agent-123" }],
+    });
+    setCurrentAgentId(SECRETS_AGENT_ID);
+    const state = createSharedReminderState();
+    state.hasSentSecretsInfo = true;
+    state.lastNotifiedPermissionMode = permissionMode.getMode();
+
+    markSecretsInfoReminderPending(state);
+
+    const result = await buildSecretsTestReminderParts(state);
+
+    const text = result.parts.map((part) => part.text).join("\n");
+    expect(result.appliedReminderIds).toContain("secrets-info");
+    expect(text).toContain("The agent secrets were updated");
+    expect(text).toContain("$PLAYGROUND_AGENT_ID");
+    expect(state.hasSentSecretsInfo).toBe(true);
+    expect(state.pendingSecretsInfoRefresh).toBe(false);
   });
 });

--- a/src/reminders/engine.ts
+++ b/src/reminders/engine.ts
@@ -89,21 +89,36 @@ async function buildAgentInfoReminder(
 async function buildSecretsInfoReminder(
   context: SharedReminderContext,
 ): Promise<string | null> {
-  if (context.state.hasSentSecretsInfo) {
-    return null;
-  }
-
-  context.state.hasSentSecretsInfo = true;
-
   try {
     const { listSecretNames } = await import("@/utils/secrets-store");
-    const names = listSecretNames();
+    const names = listSecretNames(context.agent.id);
+    const namesKey = names.join("\0");
+    const isRefresh = context.state.pendingSecretsInfoRefresh;
+    const namesChanged =
+      context.state.lastSentSecretNamesKey !== null &&
+      context.state.lastSentSecretNamesKey !== namesKey;
+
+    if (context.state.hasSentSecretsInfo && !isRefresh && !namesChanged) {
+      return null;
+    }
+
+    context.state.hasSentSecretsInfo = true;
+    context.state.pendingSecretsInfoRefresh = false;
+    context.state.lastSentSecretNamesKey = namesKey;
+
     if (names.length === 0) {
+      if (isRefresh || namesChanged) {
+        return `${SYSTEM_REMINDER_OPEN}\nThe agent secrets were updated. No secrets are currently set.\n${SYSTEM_REMINDER_CLOSE}`;
+      }
       return null;
     }
 
     const list = names.map((n) => `- \`$${n}\``).join("\n");
-    return `${SYSTEM_REMINDER_OPEN}\nThe following secrets are set on your agent and available for use.\nReference them with \`$SECRET_NAME\` in shell commands — substitution happens automatically at exec time:\n${list}\n\nYou cannot read the raw values. If a value would appear in tool output, you will see \`NAME=<REDACTED>\` instead. This means the secret IS set and working — the bytes are just hidden from your context. Keep using \`$NAME\`; it will resolve correctly.\n${SYSTEM_REMINDER_CLOSE}`;
+    const intro =
+      isRefresh || namesChanged
+        ? "The agent secrets were updated. The following secrets are now available for use."
+        : "The following secrets are set on your agent and available for use.";
+    return `${SYSTEM_REMINDER_OPEN}\n${intro}\nReference them with \`$SECRET_NAME\` in shell commands — substitution happens automatically at exec time:\n${list}\n\nYou cannot read the raw values. If a value would appear in tool output, you will see \`NAME=<REDACTED>\` instead. This means the secret IS set and working — the bytes are just hidden from your context. Keep using \`$NAME\`; it will resolve correctly.\n${SYSTEM_REMINDER_CLOSE}`;
   } catch (error) {
     debugLog(
       "secrets",

--- a/src/reminders/state.ts
+++ b/src/reminders/state.ts
@@ -31,6 +31,8 @@ export interface SharedReminderState {
   hasSentConversationBootstrap: boolean;
   pendingConversationBootstrap: boolean;
   hasSentSecretsInfo: boolean;
+  pendingSecretsInfoRefresh: boolean;
+  lastSentSecretNamesKey: string | null;
   lastNotifiedPermissionMode: PermissionMode | null;
   turnCount: number;
   pendingReflectionTrigger: boolean;
@@ -48,6 +50,8 @@ export function createSharedReminderState(): SharedReminderState {
     hasSentConversationBootstrap: false,
     pendingConversationBootstrap: false,
     hasSentSecretsInfo: false,
+    pendingSecretsInfoRefresh: false,
+    lastSentSecretNamesKey: null,
     lastNotifiedPermissionMode: null,
     turnCount: 0,
     pendingReflectionTrigger: false,
@@ -98,4 +102,11 @@ export function enqueueToolsetChangeReminder(
   reminder: ToolsetChangeReminder,
 ): void {
   pushBounded(state.pendingToolsetChangeReminders, reminder);
+}
+
+export function markSecretsInfoReminderPending(
+  state: SharedReminderState,
+): void {
+  state.hasSentSecretsInfo = false;
+  state.pendingSecretsInfoRefresh = true;
 }

--- a/src/websocket/listen-client-concurrency.test.ts
+++ b/src/websocket/listen-client-concurrency.test.ts
@@ -25,8 +25,14 @@ import type {
   TaskNotificationQueueItem,
 } from "@/queue/queue-runtime";
 import { sharedReminderProviders } from "@/reminders/engine";
+import { settingsManager } from "@/settings-manager";
 import { queueSkillContent } from "@/tools/impl/skill-content-registry";
 import { clearTools, loadSpecificTools } from "@/tools/manager";
+import {
+  __testOverrideSecretsBackend,
+  clearSecretsCache,
+} from "@/utils/secrets-store";
+import { handleSecretsCommand } from "@/websocket/listener/commands/secrets";
 import { shouldProcessInboundMessageDirectly } from "@/websocket/listener/queue";
 import { resolveRecoveredApprovalResponse } from "@/websocket/listener/recovery";
 import { injectQueuedSkillContent } from "@/websocket/listener/skill-injection";
@@ -330,6 +336,8 @@ function makeIncomingMessage(
 // to avoid mock.module (which leaks into other test files in Bun).
 const origSessionContext = sharedReminderProviders["session-context"];
 const origAgentInfo = sharedReminderProviders["agent-info"];
+const originalGetLocalProjectSettings = settingsManager.getLocalProjectSettings;
+const originalGetSettings = settingsManager.getSettings;
 const originalTranscriptRoot = process.env.LETTA_TRANSCRIPT_ROOT;
 let testTranscriptRoot: string | null = null;
 
@@ -343,6 +351,14 @@ describe("listen-client multi-worker concurrency", () => {
     // No-op stubs for providers that need settingsManager / process.cwd
     sharedReminderProviders["session-context"] = async () => null;
     sharedReminderProviders["agent-info"] = async () => null;
+    (settingsManager as typeof settingsManager).getSettings = (() =>
+      ({
+        memoryReminderInterval: null,
+      }) as ReturnType<
+        typeof settingsManager.getSettings
+      >) as typeof settingsManager.getSettings;
+    (settingsManager as typeof settingsManager).getLocalProjectSettings = () =>
+      ({}) as ReturnType<typeof settingsManager.getLocalProjectSettings>;
 
     queueSkillContent("__test-cleanup__", "__test-cleanup__");
     injectQueuedSkillContent([]);
@@ -374,6 +390,12 @@ describe("listen-client multi-worker concurrency", () => {
   afterEach(() => {
     sharedReminderProviders["session-context"] = origSessionContext;
     sharedReminderProviders["agent-info"] = origAgentInfo;
+    (settingsManager as typeof settingsManager).getSettings =
+      originalGetSettings;
+    (settingsManager as typeof settingsManager).getLocalProjectSettings =
+      originalGetLocalProjectSettings;
+    __testOverrideSecretsBackend(null);
+    clearSecretsCache("agent-secret-payload");
     clearTools();
   });
 
@@ -2399,6 +2421,77 @@ describe("listen-client multi-worker concurrency", () => {
         otid: "cm-user-otid",
       }),
     ]);
+  });
+
+  test("secret_apply refreshes the next user payload for the same conversation", async () => {
+    const agentId = "agent-secret-payload";
+    const conversationId = "conv-secret-payload";
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
+      listener,
+      agentId,
+      conversationId,
+    );
+    const socket = new MockSocket();
+    let serverSecrets: Record<string, string> = {};
+    __testOverrideSecretsBackend({
+      capabilities: { serverSecrets: true },
+      retrieveAgent: async () => ({
+        secrets: Object.entries(serverSecrets).map(([key, value]) => ({
+          key,
+          value,
+        })),
+      }),
+      updateAgent: async (_agentId, body) => {
+        serverSecrets = { ...body.secrets };
+      },
+    });
+
+    await __listenClientTestUtils.handleIncomingMessage(
+      makeIncomingMessage(agentId, conversationId, "before secret"),
+      socket as unknown as WebSocket,
+      runtime,
+    );
+
+    const firstPayload = sendMessageStreamCalls[0]?.messages;
+    expect(JSON.stringify(firstPayload)).not.toContain("PLAYGROUND_AGENT_ID");
+
+    const tasks: Promise<void>[] = [];
+    handleSecretsCommand(
+      {
+        type: "secret_apply",
+        request_id: "secret-payload-apply",
+        agent_id: agentId,
+        set: { PLAYGROUND_AGENT_ID: "agent-playground" },
+        unset: [],
+      },
+      {
+        socket: socket as unknown as WebSocket,
+        runtime: listener,
+        safeSocketSend: () => true,
+        runDetachedListenerTask: (_name, task) => {
+          tasks.push(task());
+        },
+      },
+    );
+    await Promise.all(tasks);
+    expect(runtime.reminderState.pendingSecretsInfoRefresh).toBe(true);
+    expect(runtime.reminderState.hasSentSecretsInfo).toBe(false);
+
+    await __listenClientTestUtils.handleIncomingMessage(
+      makeIncomingMessage(agentId, conversationId, "after secret"),
+      socket as unknown as WebSocket,
+      runtime,
+    );
+    expect(runtime.reminderState.lastSentSecretNamesKey).toBe(
+      "PLAYGROUND_AGENT_ID",
+    );
+
+    const secondPayload = sendMessageStreamCalls[1]?.messages;
+    const payloadText = JSON.stringify(secondPayload);
+    expect(payloadText).toContain("The agent secrets were updated");
+    expect(payloadText).toContain("$PLAYGROUND_AGENT_ID");
+    expect(payloadText).toContain("after secret");
   });
 
   test("handleIncomingMessage records direct websocket user turns in the reflection transcript", async () => {

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -1359,7 +1359,7 @@ describe("listen-client parseServerMessage", () => {
 
     expect(reloadCalls).toBe(1);
     expect(socket.sentPayloads.join("\n")).toContain(
-      "Reloaded settings and local extensions",
+      "Reloaded settings, local extensions, and agent secrets",
     );
   });
 

--- a/src/websocket/listener-secrets-sync.test.ts
+++ b/src/websocket/listener-secrets-sync.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type WebSocket from "ws";
+import { createSharedReminderState } from "@/reminders/state";
 import {
+  __testOverrideSecretsBackend,
   clearSecretsCache,
   initSecretsFromServer,
   loadSecrets,
 } from "@/utils/secrets-store";
 import { __listenClientTestUtils } from "@/websocket/listen-client";
+import { handleSecretsCommand } from "@/websocket/listener/commands/secrets";
 import {
   __testOverrideRefreshSecretsForAgent,
   __testSetFreshnessMs,
@@ -32,8 +36,10 @@ describe("listener secrets sync", () => {
 
   afterEach(() => {
     __testOverrideRefreshSecretsForAgent(null);
+    __testOverrideSecretsBackend(null);
     __testSetFreshnessMs(null);
     clearSecretsCache("agent-listener-secret");
+    clearSecretsCache("agent-other-secret");
   });
 
   test("hydrates the agent-scoped secrets cache from the server", async () => {
@@ -197,6 +203,74 @@ describe("listener secrets sync", () => {
     expect(loadSecrets("agent-listener-secret")).toEqual({
       WS_SECRET_TOKEN: "updated",
     });
+  });
+
+  test("secret_apply schedules fresh secrets reminders for existing conversations", async () => {
+    await initSecretsFromServer("agent-listener-secret", {
+      secrets: [{ key: "WS_SECRET_TOKEN", value: "first" }],
+    });
+    const updateAgentMock = mock(() => Promise.resolve({}));
+    __testOverrideSecretsBackend({
+      capabilities: { serverSecrets: true },
+      retrieveAgent: retrieveMock,
+      updateAgent: updateAgentMock,
+    });
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const state = createSharedReminderState();
+    state.hasSentSecretsInfo = true;
+    const otherAgentState = createSharedReminderState();
+    otherAgentState.hasSentSecretsInfo = true;
+    listener.reminderStateByConversation.set(
+      "agent:agent-listener-secret::conversation:conv-a",
+      state,
+    );
+    listener.reminderStateByConversation.set(
+      "agent:agent-other-secret::conversation:conv-b",
+      otherAgentState,
+    );
+    const sent: unknown[] = [];
+    const tasks: Promise<void>[] = [];
+
+    const handled = handleSecretsCommand(
+      {
+        type: "secret_apply",
+        request_id: "req-secret-apply",
+        agent_id: "agent-listener-secret",
+        set: { WS_SECRET_TOKEN: "updated" },
+        unset: [],
+      },
+      {
+        socket: {} as WebSocket,
+        runtime: listener,
+        safeSocketSend: (_socket, message) => {
+          sent.push(message);
+          return true;
+        },
+        runDetachedListenerTask: (_name, task) => {
+          tasks.push(task());
+        },
+      },
+    );
+
+    expect(handled).toBe(true);
+    await Promise.all(tasks);
+
+    expect(updateAgentMock).toHaveBeenCalledWith("agent-listener-secret", {
+      secrets: { WS_SECRET_TOKEN: "updated" },
+    });
+    expect(listener.secretsDirtyAgents.has("agent-listener-secret")).toBe(true);
+    expect(state.hasSentSecretsInfo).toBe(false);
+    expect(state.pendingSecretsInfoRefresh).toBe(true);
+    expect(otherAgentState.hasSentSecretsInfo).toBe(true);
+    expect(otherAgentState.pendingSecretsInfoRefresh).toBe(false);
+    expect(sent).toEqual([
+      {
+        type: "secret_apply_response",
+        request_id: "req-secret-apply",
+        success: true,
+        names: ["WS_SECRET_TOKEN"],
+      },
+    ]);
   });
 
   test("approval reuse: same-turn call after preflight hits cache", async () => {

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -42,6 +42,7 @@ import type {
   StreamDelta,
 } from "@/types/protocol_v2";
 import { debugLog } from "@/utils/debug";
+import { markSecretsReminderRefreshPending } from "./commands/secrets";
 import { reloadListenerExtensionAdapter } from "./extension-adapter";
 import {
   getOrCreateConversationPermissionModeStateRef,
@@ -52,12 +53,12 @@ import {
   emitCanonicalMessageDelta,
 } from "./protocol-outbound";
 import { clearConversationRuntimeState, emitListenerStatus } from "./runtime";
+import {
+  ensureSecretsHydratedForAgent,
+  invalidateSecretsCacheForAgent,
+} from "./secrets-sync";
 import { handleIncomingMessage } from "./turn";
-import type {
-  ConversationRuntime,
-  ListenerRuntime,
-  StartListenerOptions,
-} from "./types";
+import type { ConversationRuntime, StartListenerOptions } from "./types";
 
 export { SUPPORTED_REMOTE_COMMANDS } from "./listener-constants";
 
@@ -141,7 +142,7 @@ export async function handleExecuteCommand(
         break;
 
       case "reload":
-        output = await handleReloadCommand(conversationRuntime.listener);
+        output = await handleReloadCommand(conversationRuntime);
         break;
 
       case "context-limit":
@@ -202,7 +203,10 @@ export async function handleExecuteCommand(
   }
 }
 
-async function handleReloadCommand(listener: ListenerRuntime): Promise<string> {
+async function handleReloadCommand(
+  conversationRuntime: ConversationRuntime,
+): Promise<string> {
+  const { listener } = conversationRuntime;
   settingsManager.clearCaches();
   await settingsManager.loadProjectSettings();
   await settingsManager.loadLocalProjectSettings();
@@ -219,7 +223,13 @@ async function handleReloadCommand(listener: ListenerRuntime): Promise<string> {
 
   await reloadListenerExtensionAdapter(listener);
 
-  return "Reloaded settings and local extensions";
+  if (conversationRuntime.agentId) {
+    invalidateSecretsCacheForAgent(listener, conversationRuntime.agentId);
+    markSecretsReminderRefreshPending(listener, conversationRuntime.agentId);
+    await ensureSecretsHydratedForAgent(listener, conversationRuntime.agentId);
+  }
+
+  return "Reloaded settings, local extensions, and agent secrets";
 }
 
 async function handleUpgradeLettaCodeCommand(opts: {

--- a/src/websocket/listener/commands/secrets.ts
+++ b/src/websocket/listener/commands/secrets.ts
@@ -1,4 +1,5 @@
 import type WebSocket from "ws";
+import { markSecretsInfoReminderPending } from "@/reminders/state";
 import {
   isSecretApplyCommand,
   isSecretListCommand,
@@ -13,6 +14,25 @@ type SecretsCommandContext = {
   safeSocketSend: SafeSocketSend;
   runDetachedListenerTask: RunDetachedListenerTask;
 };
+
+export function markSecretsReminderRefreshPending(
+  runtime: ListenerRuntime,
+  agentId: string,
+): void {
+  const prefix = `agent:${agentId}::conversation:`;
+
+  for (const [key, state] of runtime.reminderStateByConversation) {
+    if (key.startsWith(prefix)) {
+      markSecretsInfoReminderPending(state);
+    }
+  }
+
+  for (const conversationRuntime of runtime.conversationRuntimes.values()) {
+    if (conversationRuntime.agentId === agentId) {
+      markSecretsInfoReminderPending(conversationRuntime.reminderState);
+    }
+  }
+}
 
 export function handleSecretsCommand(
   parsed: unknown,
@@ -84,6 +104,7 @@ export function handleSecretsCommand(
 
         if (parsed.agent_id) {
           invalidateSecretsCacheForAgent(runtime, parsed.agent_id);
+          markSecretsReminderRefreshPending(runtime, parsed.agent_id);
         }
 
         safeSocketSend(


### PR DESCRIPTION
## Summary
- Re-emit the secrets system reminder when the listener sees a changed secret-name list, including after Desktop saves new secrets.
- Mark active reminder state dirty after `secret_apply`, and make remote `/reload` refresh the current agent's secrets instead of only reloading settings/extensions.
- Keep the initial no-secrets case quiet, but tell the agent when a previously populated secrets list becomes empty.

## Why
Desktop was persisting secrets, but existing conversations kept their one-shot `secrets-info` reminder state. A restart recreated that state, so newly added secret names only appeared after restarting or starting fresh.

One important boundary is unchanged: shell tools still inject secret values only for commands that reference a named secret such as `$SECRET_NAME`; this PR refreshes the agent-facing metadata and cache, not ambient env vars for every child process.

## Test plan
- [x] `bun test src/websocket/listen-client-concurrency.test.ts --grep "secret_apply refreshes|handleIncomingMessage reuses client_message_id"`
- [x] `bun test src/reminders/engine.test.ts src/websocket/listener-secrets-sync.test.ts src/websocket/listen-client-protocol.test.ts --grep "secrets|reload|headless shared reminder content helpers"`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)

