### PR TITLE
fix(tools): support worktree creation from explicit repo path

### DIFF
--- a/src/tools/create-worktree.test.ts
+++ b/src/tools/create-worktree.test.ts
@@ -320,6 +320,36 @@ describe("CreateWorktree tool", () => {
     expect(remoteFile.replace(/\r\n/g, "\n")).toBe("latest remote\n");
   });
 
+  test("creates a worktree from repo_path when current cwd is outside a git repository", async () => {
+    const repo = await trackRepo();
+    const dir = await mkdtemp(
+      path.join(tmpdir(), "letta-create-worktree-empty-"),
+    );
+    tempDirs.push(dir);
+
+    const result = await runWithRuntimeContext({ workingDirectory: dir }, () =>
+      create_worktree({
+        name: "Repo Path Feature",
+        repo_path: repo,
+        refresh_base: false,
+        switch_cwd: false,
+      }),
+    );
+
+    expect(result.status).toBe("success");
+    expect(result.worktree_path).toBe(
+      path.join(repo, ".letta", "worktrees", "repo-path-feature"),
+    );
+    if (!result.worktree_path) {
+      throw new Error("Expected CreateWorktree to return a worktree path");
+    }
+    expect(
+      path.normalize(
+        git(["rev-parse", "--show-toplevel"], result.worktree_path),
+      ),
+    ).toBe(result.worktree_path);
+  });
+
   test("returns an error outside a git repository", async () => {
     const dir = await mkdtemp(
       path.join(tmpdir(), "letta-create-worktree-empty-"),
@@ -331,6 +361,9 @@ describe("CreateWorktree tool", () => {
     );
 
     expect(result.status).toBe("error");
-    expect(result.content[0]?.text).toContain("rev-parse");
+    expect(result.content[0]?.text).toContain(
+      "Current working directory is not inside a git repository",
+    );
+    expect(result.content[0]?.text).toContain("repo_path");
   });
 });

--- a/src/tools/descriptions/CreateWorktree.md
+++ b/src/tools/descriptions/CreateWorktree.md
@@ -9,8 +9,9 @@ Prefer this tool over manually running `git worktree add` with Bash because it c
 Do not use this tool for read-only tasks, code review, answering questions, continuing work already in the correct checkout, or when the user explicitly asks not to use worktrees.
 
 Behavior:
-- Verifies the current cwd is inside a git repository.
-- Creates the worktree under `.letta/worktrees/` for the repository.
+- Uses the current cwd as the target git repository by default, or `repo_path` when provided.
+- If the current cwd is not inside a git repository, pass `repo_path` instead of falling back to manual `git worktree` commands.
+- Creates the worktree under `.letta/worktrees/` for the target repository.
 - Creates a new branch from the default base ref unless `branch_name` or `base_ref` is provided.
 - By default, switches the active conversation/session cwd to the new worktree.
 - Does not copy uncommitted changes from the current checkout.

--- a/src/tools/impl/create-worktree.ts
+++ b/src/tools/impl/create-worktree.ts
@@ -16,6 +16,7 @@ interface CreateWorktreeArgs {
   name: string;
   branch_name?: string;
   base_ref?: string;
+  repo_path?: string;
   refresh_base?: boolean;
   switch_cwd?: boolean;
   _executionContextId?: string;
@@ -200,6 +201,30 @@ async function resolveRepoRoot(cwd: string): Promise<string> {
   return await gitStdout(["rev-parse", "--show-toplevel"], cwd);
 }
 
+async function resolveWorktreeSourceRoot(params: {
+  currentCwd: string;
+  requestedRepoPath?: string;
+}): Promise<string> {
+  const sourcePath = params.requestedRepoPath
+    ? path.resolve(params.currentCwd, params.requestedRepoPath)
+    : params.currentCwd;
+
+  try {
+    return await resolveRepoRoot(sourcePath);
+  } catch (error) {
+    if (params.requestedRepoPath) {
+      throw error;
+    }
+    throw new Error(
+      [
+        `Current working directory is not inside a git repository: ${params.currentCwd}`,
+        "Pass `repo_path` to CreateWorktree or start the session from inside the target repo.",
+        formatGitFailure(error),
+      ].join("\n"),
+    );
+  }
+}
+
 async function resolvePrimaryWorktreeRoot(repoRoot: string): Promise<string> {
   const commonDir = await gitStdout(
     ["rev-parse", "--path-format=absolute", "--git-common-dir"],
@@ -361,7 +386,10 @@ export async function create_worktree(
     const runtimeContext = getRuntimeContext();
     const currentCwd =
       runtimeContext?.workingDirectory || process.env.USER_CWD || process.cwd();
-    const repoRoot = await resolveRepoRoot(currentCwd);
+    const repoRoot = await resolveWorktreeSourceRoot({
+      currentCwd,
+      requestedRepoPath: getStringArg(args, "repo_path"),
+    });
     const primaryRoot = await resolvePrimaryWorktreeRoot(repoRoot);
     const worktreesDir = path.join(primaryRoot, ".letta", "worktrees");
     const slug = slugifyName(name);

--- a/src/tools/schemas/CreateWorktree.json
+++ b/src/tools/schemas/CreateWorktree.json
@@ -13,6 +13,10 @@
       "type": "string",
       "description": "Optional git ref to base the worktree on. Defaults to the latest remote default branch, usually origin/main."
     },
+    "repo_path": {
+      "type": "string",
+      "description": "Optional path to the git repository to create the worktree from. Use this when the current conversation cwd is not inside the target repo."
+    },
     "refresh_base": {
       "type": "boolean",
       "description": "Whether to fetch the remote base branch before creating the worktree. Defaults to true."


### PR DESCRIPTION
## Summary
- Add `repo_path` to CreateWorktree so sessions started outside a git repo can still target the intended repository.
- Return an actionable outside-repo error instead of raw `git rev-parse` failure output.
- Cover the new repo_path behavior in the existing CreateWorktree test suite.

## Test plan
- [x] `bun test src/tools/create-worktree.test.ts`
- [x] `bun run check`