### PR TITLE
fix(settings): default conversation titles on

### DIFF
--- a/src/cli/conversation-title.test.ts
+++ b/src/cli/conversation-title.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -79,19 +79,19 @@ describe("normalizeConversationTitle", () => {
 });
 
 describe("conversation title settings", () => {
-  test("defaults off and persists explicit opt-in", async () => {
-    expect(getConversationTitleSettings()).toEqual({ enabled: false });
+  test("defaults on and persists explicit opt-out", async () => {
+    expect(getConversationTitleSettings()).toEqual({ enabled: true });
 
-    expect(setConversationTitleSettings(true)).toEqual({ enabled: true });
+    expect(setConversationTitleSettings(false)).toEqual({ enabled: false });
     await settingsManager.flush();
 
     await settingsManager.reset();
     await settingsManager.initialize();
 
-    expect(getConversationTitleSettings()).toEqual({ enabled: true });
+    expect(getConversationTitleSettings()).toEqual({ enabled: false });
   });
 
-  test("rolls back legacy opt-ins once before allowing re-enable", async () => {
+  test("preserves legacy explicit opt-ins", async () => {
     await settingsManager.reset();
     const settingsDir = join(testHomeDir, ".letta");
     const settingsPath = join(settingsDir, "settings.json");
@@ -101,22 +101,6 @@ describe("conversation title settings", () => {
       JSON.stringify({ autoConversationTitles: true }, null, 2),
     );
 
-    await settingsManager.initialize();
-
-    expect(getConversationTitleSettings()).toEqual({ enabled: false });
-    await settingsManager.flush();
-
-    const migrated = JSON.parse(await readFile(settingsPath, "utf-8")) as {
-      autoConversationTitles?: boolean;
-      autoConversationTitlesRollbackApplied?: boolean;
-    };
-    expect(migrated.autoConversationTitles).toBe(false);
-    expect(migrated.autoConversationTitlesRollbackApplied).toBe(true);
-
-    expect(setConversationTitleSettings(true)).toEqual({ enabled: true });
-    await settingsManager.flush();
-
-    await settingsManager.reset();
     await settingsManager.initialize();
 
     expect(getConversationTitleSettings()).toEqual({ enabled: true });

--- a/src/experiments/manager.test.ts
+++ b/src/experiments/manager.test.ts
@@ -78,12 +78,12 @@ describe("experimentManager", () => {
   test("maps conversation title experiment controls to the persistent setting", async () => {
     expect(experimentManager.getSnapshot("conversation_titles")).toMatchObject({
       id: "conversation_titles",
-      enabled: false,
+      enabled: true,
     });
 
-    expect(experimentManager.set("conversation_titles", true)).toMatchObject({
+    expect(experimentManager.set("conversation_titles", false)).toMatchObject({
       id: "conversation_titles",
-      enabled: true,
+      enabled: false,
     });
     await settingsManager.flush();
 
@@ -92,7 +92,7 @@ describe("experimentManager", () => {
 
     expect(experimentManager.getSnapshot("conversation_titles")).toMatchObject({
       id: "conversation_titles",
-      enabled: true,
+      enabled: false,
     });
   });
 });

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -81,7 +81,6 @@ export interface Settings {
   enableSleeptime: boolean;
   sessionContextEnabled: boolean; // Send device/agent context on first message of each session
   autoConversationTitles: boolean; // Generate AI conversation titles when possible
-  autoConversationTitlesRollbackApplied?: boolean; // One-time rollback marker for the default-on title experiment
   autoSwapOnQuotaLimit: boolean; // Auto-switch to temporary Auto model override on quota-limit errors
   includeWorktreeTool: boolean; // Include CreateWorktree in toolsets when true
   preferredBackendMode?: "api" | "local"; // Startup backend preference when no explicit --backend is provided
@@ -173,8 +172,7 @@ const DEFAULT_SETTINGS: Settings = {
   enableSleeptime: false,
   conversationSwitchAlertEnabled: false,
   sessionContextEnabled: true,
-  autoConversationTitles: false,
-  autoConversationTitlesRollbackApplied: true,
+  autoConversationTitles: true,
   autoSwapOnQuotaLimit: true,
   includeWorktreeTool: true,
   recentModels: [],
@@ -426,7 +424,6 @@ class SettingsManager {
     if (this.initialized) return;
 
     const settingsPath = this.getSettingsPath();
-    let shouldRollbackAutoConversationTitles = false;
 
     try {
       // Check if settings file exists
@@ -453,16 +450,6 @@ class SettingsManager {
           // Mark for deletion on next persist; keep startup backward-compatible.
           this.markDirty("reflectionBehavior");
         }
-        shouldRollbackAutoConversationTitles =
-          loadedSettingsRaw.autoConversationTitlesRollbackApplied !== true;
-        if (shouldRollbackAutoConversationTitles) {
-          loadedSettingsRaw.autoConversationTitles = false;
-          loadedSettingsRaw.autoConversationTitlesRollbackApplied = true;
-          this.markDirty(
-            "autoConversationTitles",
-            "autoConversationTitlesRollbackApplied",
-          );
-        }
         // Merge with defaults in case new fields were added
         this.settings = {
           ...DEFAULT_SETTINGS,
@@ -474,14 +461,6 @@ class SettingsManager {
       }
 
       this.initialized = true;
-
-      if (shouldRollbackAutoConversationTitles) {
-        try {
-          await this.persistSettings();
-        } catch {
-          // Best-effort cleanup only; do not fail the load path.
-        }
-      }
 
       // Check secrets availability and warn if not available
       await this.checkSecretsSupport();

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -2758,7 +2758,7 @@ describe("listen-client experiment command handling", () => {
     const originalGetSettings = settingsManager.getSettings;
     const originalUpdateSettings = settingsManager.updateSettings;
     const originalNodeFlag = process.env.LETTA_NODE;
-    const globalSettings = { autoConversationTitles: false } as Settings;
+    const globalSettings = { autoConversationTitles: true } as Settings;
 
     try {
       delete process.env.LETTA_NODE;
@@ -2803,7 +2803,7 @@ describe("listen-client experiment command handling", () => {
           }),
           expect.objectContaining({
             id: "conversation_titles",
-            enabled: false,
+            enabled: true,
           }),
         ]),
       });


### PR DESCRIPTION
## Summary
- Re-enable automatic conversation titles by default for TUI and desktop-backed settings.
- Remove the one-time rollback migration that forced legacy title settings off.
- Update experiment and websocket tests for the default-on title setting while preserving explicit opt-out behavior.

## Test plan
- [x] bun test src/cli/conversation-title.test.ts src/experiments/manager.test.ts src/websocket/listen-client-protocol.test.ts
- [x] bun run check