### PR TITLE
feat(skills): add image generation builtin

### DIFF
--- a/src/agent/client-skills.test.ts
+++ b/src/agent/client-skills.test.ts
@@ -109,6 +109,80 @@ describe("buildClientSkillsPayload", () => {
     expect(result.skills.map((skill) => skill.id)).toEqual(["manual-only"]);
   });
 
+  test("excludes bundled image generation skill for local agents", async () => {
+    const { buildClientSkillsPayload, discoverClientSideSkills } = await import(
+      "@/agent/client-skills"
+    );
+
+    const discoverSkillsFn = async (): Promise<SkillDiscoveryResult> => ({
+      skills: [
+        {
+          ...baseSkill,
+          id: "image-generation",
+          description: "Generate images",
+          path: "/tmp/bundled/image-generation/SKILL.md",
+          source: "bundled",
+        },
+        {
+          ...baseSkill,
+          id: "safe-bundled",
+          description: "Safe bundled skill",
+          path: "/tmp/bundled/safe/SKILL.md",
+          source: "bundled",
+        },
+      ],
+      errors: [],
+    });
+
+    const discovery = await discoverClientSideSkills({
+      agentId: "agent-local-123",
+      skillsDirectory: "/tmp/.skills",
+      skillSources: ["bundled"],
+      discoverSkillsFn,
+    });
+
+    expect(discovery.skills.map((skill) => skill.id)).toEqual(["safe-bundled"]);
+
+    const payload = await buildClientSkillsPayload({
+      agentId: "agent-local-123",
+      skillsDirectory: "/tmp/.skills",
+      skillSources: ["bundled"],
+      discoverSkillsFn,
+    });
+
+    expect(payload.clientSkills.map((skill) => skill.name)).toEqual([
+      "safe-bundled",
+    ]);
+  });
+
+  test("keeps project image generation skills for local agents", async () => {
+    const { discoverClientSideSkills } = await import("@/agent/client-skills");
+
+    const discoverSkillsFn = async (): Promise<SkillDiscoveryResult> => ({
+      skills: [
+        {
+          ...baseSkill,
+          id: "image-generation",
+          description: "Project override",
+          path: "/tmp/project/image-generation/SKILL.md",
+          source: "project",
+        },
+      ],
+      errors: [],
+    });
+
+    const result = await discoverClientSideSkills({
+      agentId: "agent-local-123",
+      skillsDirectory: "/tmp/.skills",
+      skillSources: ["project"],
+      discoverSkillsFn,
+    });
+
+    expect(result.skills.map((skill) => skill.id)).toEqual([
+      "image-generation",
+    ]);
+  });
+
   test("excludes skills marked disable-model-invocation from client_skills", async () => {
     const { buildClientSkillsPayload } = await import("@/agent/client-skills");
 

--- a/src/agent/client-skills.ts
+++ b/src/agent/client-skills.ts
@@ -9,6 +9,7 @@ import {
   GLOBAL_SKILLS_DIR,
   getAgentSkillsDir,
   isModelInvocableSkill,
+  isSkillAvailableForAgent,
   SKILLS_DIR,
   type Skill,
   type SkillDiscoveryError,
@@ -403,7 +404,9 @@ async function collectClientSideSkills(
       });
       errors.push(...discovery.errors);
       for (const skill of discovery.skills) {
-        skillsById.set(skill.id, skill);
+        if (isSkillAvailableForAgent(skill, options.agentId)) {
+          skillsById.set(skill.id, skill);
+        }
       }
     } catch (error) {
       const message =
@@ -418,6 +421,9 @@ async function collectClientSideSkills(
     const memoryDiscovery = await discoverMemorySkills(options.agentId);
     errors.push(...memoryDiscovery.errors);
     for (const skill of memoryDiscovery.skills) {
+      if (!isSkillAvailableForAgent(skill, options.agentId)) {
+        continue;
+      }
       const existing = skillsById.get(skill.id);
       if (existing?.source === "project" || existing?.source === "agent") {
         continue;

--- a/src/agent/skills.ts
+++ b/src/agent/skills.ts
@@ -13,6 +13,7 @@ import { readdir, readFile, realpath, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseFrontmatter } from "@/utils/frontmatter";
+import { isLocalAgentId } from "./agent-id";
 import { ALL_SKILL_SOURCES, type SkillSource } from "./skill-sources";
 
 /**
@@ -152,6 +153,23 @@ export function isModelInvocableSkill(skill: Skill): boolean {
 
 export function isUserInvocableSkill(skill: Skill): boolean {
   return skill.userInvocable !== false;
+}
+
+const LOCAL_AGENT_EXCLUDED_BUNDLED_SKILLS = new Set(["image-generation"]);
+
+export function isSkillAvailableForAgent(
+  skill: Skill,
+  agentId?: string,
+): boolean {
+  if (
+    skill.source === "bundled" &&
+    agentId &&
+    isLocalAgentId(agentId) &&
+    LOCAL_AGENT_EXCLUDED_BUNDLED_SKILLS.has(skill.id)
+  ) {
+    return false;
+  }
+  return true;
 }
 
 /**

--- a/src/skills/builtin/image-generation/SKILL.md
+++ b/src/skills/builtin/image-generation/SKILL.md
@@ -11,14 +11,26 @@ before replying.
 
 ## Example
 
-Generate an image and save it to a file:
+Generate the image, save it locally, then show it inline:
 
 ```bash
 curl -sS -X POST "https://api.letta.com/v1/images/generations" \
   -H "Authorization: Bearer $LETTA_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"provider":"gemini","prompt":"a friendly robot mascot waving, flat vector logo, mint green background","n":1}' \
-  | python3 -c "import sys,json,base64,urllib.request; d=json.load(sys.stdin); img=d['images'][0]; data=base64.b64decode(img['b64_json']) if img.get('b64_json') else urllib.request.urlopen(img['url']).read(); open('robot-mascot.png','wb').write(data); print('saved robot-mascot.png; credits:', d['billing']['credits_charged'])"
+  > image-response.json
+
+python3 - <<'PY'
+import base64, json
+
+with open("image-response.json") as f:
+    response = json.load(f)
+
+with open("robot-mascot.png", "wb") as f:
+    f.write(base64.b64decode(response["images"][0]["b64_json"]))
+
+print("saved robot-mascot.png; credits:", response["billing"]["credits_charged"])
+PY
 ```
 
 In Bash tools launched by Letta Code, the current Letta credential is available
@@ -76,7 +88,8 @@ Default to `gemini` unless the user wants photoreal or a specific size/quality.
 ```
 
 Each `images[]` entry has either `b64_json` or `url`, plus `mime_type`. Gemini
-always returns `b64_json`; OpenAI may return either — handle both.
+always returns `b64_json`. If OpenAI returns a `url`, download that URL to your
+local image file instead of base64-decoding.
 
 ## Editing / remixing images
 

--- a/src/skills/builtin/image-generation/SKILL.md
+++ b/src/skills/builtin/image-generation/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: image-generation
+description: Generate images from text prompts (and optionally edit/remix input images). Use when the user asks to create, generate, draw, render, or edit an image, illustration, logo, icon, diagram, or photo.
+---
+
+# Image Generation
+
+Generate images via Letta's hosted endpoint `POST /v1/images/generations`. The API
+usually returns base64 image bytes, so save the response to a local image file
+before replying.
+
+## Example
+
+Generate an image and save it to a file:
+
+```bash
+curl -sS -X POST "https://api.letta.com/v1/images/generations" \
+  -H "Authorization: Bearer $LETTA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"provider":"gemini","prompt":"a friendly robot mascot waving, flat vector logo, mint green background","n":1}' \
+  | python3 -c "import sys,json,base64,urllib.request; d=json.load(sys.stdin); img=d['images'][0]; data=base64.b64decode(img['b64_json']) if img.get('b64_json') else urllib.request.urlopen(img['url']).read(); open('robot-mascot.png','wb').write(data); print('saved robot-mascot.png; credits:', d['billing']['credits_charged'])"
+```
+
+In Bash tools launched by Letta Code, the current Letta credential is available
+as `$LETTA_API_KEY`. This works for both Letta auth modes: it may be a normal
+Letta API key, or the OAuth access token from a Letta Cloud OAuth login. Reference
+it directly. If it is missing, the user needs to authenticate with Letta Cloud (or
+provide a Letta API key); do **not** ask for an OpenAI/Gemini provider key. This
+endpoint also does not use `/connect` BYOK providers — the only `provider` values
+supported here are `gemini` and `openai`.
+
+Then **show the image to the user** by embedding the saved file in your reply:
+
+```markdown
+Here's the mascot:
+
+![a friendly robot mascot waving, flat vector logo](./robot-mascot.png)
+```
+
+The Letta Code UI renders local file paths in markdown image tags, so the image
+appears inline. **Always display generated images this way** — don't just report
+the path, and never paste the raw base64 / a `data:` URI. The markdown path must
+match where you saved the file. For `n > 1`, save each image to its own file and
+embed each on its own line. Also tell the user the `credits_charged`.
+
+## Request body
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `provider` | `"gemini"` \| `"openai"` | Required. |
+| `prompt` | string | Required, 1–32000 chars. |
+| `model` | string | Optional; defaults per provider (below). |
+| `n` | int 1–4 | Optional, default 1. Request variations in one call. |
+| `size` | string | Optional, e.g. `"1024x1024"` (OpenAI). |
+| `quality` | `low`\|`medium`\|`high`\|`auto` | Optional (OpenAI; higher = more credits). |
+| `output_format` | `png`\|`jpeg`\|`webp` | Optional (OpenAI). |
+| `input_images` | string[] (max 14) | Optional. Base64 **data URLs** for edit/remix. |
+| `seed` | int | Optional. |
+
+| Provider | Default model | Use for |
+|----------|---------------|---------|
+| `gemini` | `gemini-3-pro-image` | Default. Strong prompt adherence, image editing/remix. |
+| `openai` | `gpt-image-2` | Photoreal output, explicit `size`/`quality`/`output_format`. |
+
+Default to `gemini` unless the user wants photoreal or a specific size/quality.
+
+## Response
+
+```json
+{
+  "provider": "gemini",
+  "model": "gemini-3-pro-image",
+  "images": [{ "b64_json": "<base64>", "mime_type": "image/png" }],
+  "billing": { "credits_charged": 12, "...": "..." }
+}
+```
+
+Each `images[]` entry has either `b64_json` or `url`, plus `mime_type`. Gemini
+always returns `b64_json`; OpenAI may return either — handle both.
+
+## Editing / remixing images
+
+Pass source images in `input_images` as base64 **data URLs**
+(`data:<mime>;base64,<data>`) and describe the edit in `prompt`. Gemini handles
+multi-image edits well. To build a data URL from a local file:
+
+```bash
+DATA_URL="data:image/png;base64,$(base64 < input.png | tr -d '\n')"
+```
+
+## Notes
+
+- **Billing**: every success charges credits; don't loop needlessly, and report
+  `credits_charged`.
+- **Errors**: `402` = insufficient credits (`credits_required` in body); `400`/`500`
+  return `{ "message": "..." }` — surface it to the user.
+- Only `gemini` and `openai` are supported here.

--- a/src/tools/impl/skill.ts
+++ b/src/tools/impl/skill.ts
@@ -9,6 +9,7 @@ import {
   getBundledSkills,
   getFrontmatterBoolean,
   getFrontmatterStringList,
+  isSkillAvailableForAgent,
   SKILLS_DIR,
 } from "@/agent/skills";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
@@ -129,7 +130,7 @@ export async function readSkillContent(
   // 5. Try bundled skills (lowest priority)
   const bundledSkills = await getBundledSkills();
   const bundledSkill = bundledSkills.find((s) => s.id === skillId);
-  if (bundledSkill?.path) {
+  if (bundledSkill?.path && isSkillAvailableForAgent(bundledSkill, agentId)) {
     try {
       const content = await readFile(bundledSkill.path, "utf-8");
       return { content, path: bundledSkill.path };

--- a/src/tools/skill-tool.test.ts
+++ b/src/tools/skill-tool.test.ts
@@ -9,9 +9,8 @@ import { clearTools, executeTool, loadSpecificTools } from "@/tools/manager";
 const TEST_AGENT_ID = "agent-skill-memfs-test";
 let currentSkillsDirectory: string | null = null;
 
-const { renderSkillContent, skill, wrapSkillContent } = await import(
-  "@/tools/impl/skill"
-);
+const { readSkillContent, renderSkillContent, skill, wrapSkillContent } =
+  await import("@/tools/impl/skill");
 
 function withSkillContext<T>(fn: () => Promise<T>) {
   return runWithRuntimeContext(
@@ -80,6 +79,20 @@ describe("Skill tool memory filesystem lookup", () => {
     }
 
     rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  test("does not load bundled image generation skill for local agents", async () => {
+    process.env.MEMORY_DIR = join(tempRoot, "empty-memory");
+    process.env.LETTA_MEMORY_DIR = join(tempRoot, "empty-letta-memory");
+    process.env.HOME = tempRoot;
+
+    await expect(
+      readSkillContent(
+        "image-generation",
+        currentSkillsDirectory ?? join(tempRoot, ".skills"),
+        "agent-local-skill-test",
+      ),
+    ).rejects.toThrow('Skill "image-generation" not found');
   });
 
   test("loads skills from MEMORY_DIR/skills", async () => {


### PR DESCRIPTION
## Summary
- add a bundled `image-generation` skill for the new Letta Cloud image generation endpoint
- document Gemini/OpenAI usage only, including Letta API key and Letta Cloud OAuth auth via `$LETTA_API_KEY`
- include a verified example that saves generated output and instructs agents to render local images inline with markdown
- hide the bundled cloud-only image generation skill from local agents while preserving project/user overrides

## Validation
- Ran the documented Gemini example successfully against `https://api.letta.com/v1/images/generations` and saved/rendered the generated image
- Asked fresh Codex and Claude Code agents to review the skill for clarity; incorporated feedback on OAuth auth, `b64_json`/`url` handling, portable base64, and BYOK-provider scope
- `bun test src/agent/client-skills.test.ts src/tools/skill-tool.test.ts`
- `bun run check` passes through biome and fails only on pre-existing TypeScript errors in `src/web/generate-diff-viewer.ts` for missing `@pierre/diffs` types

👾 Generated with [Letta Code](https://letta.com)

See [trace](https://app.letta.com/chat/agent-4140c4b5-f32e-475c-9573-bcfd9446ca7b?conversation=conv-8e27c24a-c271-4643-8b4b-63d61e21bd3a). Resume conversation with `letta --conv conv-8e27c24a-c271-4643-8b4b-63d61e21bd3a`