### PR TITLE
fix(channels): refresh forced account display names

### DIFF
--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -271,6 +271,8 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
       ? { ...(next as CustomChannelAccount).config }
       : {};
   }
+  // Legacy placeholders from older channel-account migration paths. Current
+  // code does not generate these, but persisted accounts may still contain them.
   if (
     (isTelegramChannelAccount(next) &&
       (next.displayName === "Telegram bot" ||

--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -272,15 +272,9 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
       : {};
   }
   if (
-    (isTelegramChannelAccount(next) &&
-      (next.displayName === "Telegram bot" ||
-        next.displayName === "Migrated Telegram bot")) ||
-    (isSlackChannelAccount(next) &&
-      (next.displayName === "Slack app" ||
-        next.displayName === "Migrated Slack app")) ||
-    (isDiscordChannelAccount(next) &&
-      (next.displayName === "Discord bot" ||
-        next.displayName === "Migrated Discord bot")) ||
+    (isTelegramChannelAccount(next) && next.displayName === "Telegram bot") ||
+    (isSlackChannelAccount(next) && next.displayName === "Slack app") ||
+    (isDiscordChannelAccount(next) && next.displayName === "Discord bot") ||
     (isWhatsAppChannelAccount(next) && next.displayName === "WhatsApp")
   ) {
     next.displayName = undefined;

--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -272,9 +272,15 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
       : {};
   }
   if (
-    (isTelegramChannelAccount(next) && next.displayName === "Telegram bot") ||
-    (isSlackChannelAccount(next) && next.displayName === "Slack app") ||
-    (isDiscordChannelAccount(next) && next.displayName === "Discord bot") ||
+    (isTelegramChannelAccount(next) &&
+      (next.displayName === "Telegram bot" ||
+        next.displayName === "Migrated Telegram bot")) ||
+    (isSlackChannelAccount(next) &&
+      (next.displayName === "Slack app" ||
+        next.displayName === "Migrated Slack app")) ||
+    (isDiscordChannelAccount(next) &&
+      (next.displayName === "Discord bot" ||
+        next.displayName === "Migrated Discord bot")) ||
     (isWhatsAppChannelAccount(next) && next.displayName === "WhatsApp")
   ) {
     next.displayName = undefined;

--- a/src/channels/service.test.ts
+++ b/src/channels/service.test.ts
@@ -626,6 +626,55 @@ describe("channel service", () => {
     expect(refreshed.displayName).toBe("Old Slack Name");
   });
 
+  test("forced display-name refresh updates existing labels", async () => {
+    __testOverrideResolveChannelAccountDisplayName(
+      async () => "Fresh Slack Name",
+    );
+
+    createChannelAccountLive(
+      "slack",
+      {
+        displayName: "Old Slack Name",
+        botToken: "xoxb-test-token",
+        appToken: "xapp-test-token",
+      },
+      { accountId: "slack-bot" },
+    );
+
+    const refreshed = await refreshChannelAccountDisplayNameLive(
+      "slack",
+      "slack-bot",
+      { force: true },
+    );
+
+    expect(refreshed.displayName).toBe("Fresh Slack Name");
+  });
+
+  test("forced display-name refresh clears stale placeholders", async () => {
+    __testOverrideResolveChannelAccountDisplayName(async () => undefined);
+
+    createChannelAccountLive(
+      "slack",
+      {
+        displayName: "Slack app",
+        botToken: "xoxb-test-token",
+        appToken: "xapp-test-token",
+      },
+      { accountId: "slack-bot" },
+    );
+
+    const refreshed = await refreshChannelAccountDisplayNameLive(
+      "slack",
+      "slack-bot",
+      { force: true },
+    );
+
+    expect(refreshed.displayName).toBeUndefined();
+    expect(
+      getChannelAccountSnapshot("slack", "slack-bot")?.displayName,
+    ).toBeUndefined();
+  });
+
   test("config helpers resolve the sole account instead of assuming a default id", async () => {
     const snapshot = await setChannelConfigLive("telegram", {
       token: "telegram-token",

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -238,6 +238,27 @@ function normalizeDisplayName(value: string | undefined): string | undefined {
   return trimmed ? trimmed : undefined;
 }
 
+function isStalePlaceholderDisplayName(account: ChannelAccount): boolean {
+  const displayName = normalizeDisplayName(account.displayName);
+  if (!displayName) {
+    return false;
+  }
+  if (isTelegramChannelAccount(account)) {
+    return (
+      displayName === "Telegram bot" || displayName === "Migrated Telegram bot"
+    );
+  }
+  if (isSlackChannelAccount(account)) {
+    return displayName === "Slack app" || displayName === "Migrated Slack app";
+  }
+  if (isDiscordChannelAccount(account)) {
+    return (
+      displayName === "Discord bot" || displayName === "Migrated Discord bot"
+    );
+  }
+  return isWhatsAppChannelAccount(account) && displayName === "WhatsApp";
+}
+
 async function resolveChannelAccountDisplayName(
   account: ChannelAccount,
 ): Promise<string | undefined> {
@@ -1375,13 +1396,15 @@ export async function refreshChannelAccountDisplayNameLive(
   if (!isAccountConfigured(existing)) {
     return toAccountSnapshot(existing);
   }
-  if (existing.displayName) {
+  if (existing.displayName && !options?.force) {
     return toAccountSnapshot(existing);
   }
 
   const resolvedDisplayName = await resolveChannelAccountDisplayName(existing);
   const nextDisplayName =
-    options?.force && resolvedDisplayName === undefined
+    options?.force &&
+    resolvedDisplayName === undefined &&
+    isStalePlaceholderDisplayName(existing)
       ? undefined
       : (resolvedDisplayName ?? existing.displayName);
 

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -244,17 +244,13 @@ function isStalePlaceholderDisplayName(account: ChannelAccount): boolean {
     return false;
   }
   if (isTelegramChannelAccount(account)) {
-    return (
-      displayName === "Telegram bot" || displayName === "Migrated Telegram bot"
-    );
+    return displayName === "Telegram bot";
   }
   if (isSlackChannelAccount(account)) {
-    return displayName === "Slack app" || displayName === "Migrated Slack app";
+    return displayName === "Slack app";
   }
   if (isDiscordChannelAccount(account)) {
-    return (
-      displayName === "Discord bot" || displayName === "Migrated Discord bot"
-    );
+    return displayName === "Discord bot";
   }
   return isWhatsAppChannelAccount(account) && displayName === "WhatsApp";
 }

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -244,13 +244,17 @@ function isStalePlaceholderDisplayName(account: ChannelAccount): boolean {
     return false;
   }
   if (isTelegramChannelAccount(account)) {
-    return displayName === "Telegram bot";
+    return (
+      displayName === "Telegram bot" || displayName === "Migrated Telegram bot"
+    );
   }
   if (isSlackChannelAccount(account)) {
-    return displayName === "Slack app";
+    return displayName === "Slack app" || displayName === "Migrated Slack app";
   }
   if (isDiscordChannelAccount(account)) {
-    return displayName === "Discord bot";
+    return (
+      displayName === "Discord bot" || displayName === "Migrated Discord bot"
+    );
   }
   return isWhatsAppChannelAccount(account) && displayName === "WhatsApp";
 }

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -243,6 +243,8 @@ function isStalePlaceholderDisplayName(account: ChannelAccount): boolean {
   if (!displayName) {
     return false;
   }
+  // Legacy placeholders from older channel-account migration paths. Current
+  // code does not generate these, but persisted accounts may still contain them.
   if (isTelegramChannelAccount(account)) {
     return (
       displayName === "Telegram bot" || displayName === "Migrated Telegram bot"


### PR DESCRIPTION
Ensure forced channel account refreshes can replace stale persisted labels with current platform names while preserving user labels when resolution fails.

👾 Generated with [Letta Code](https://letta.com)