### PR TITLE
fix(local): inherit conversation model for subagents

### DIFF
--- a/src/agent/subagent-model-resolution.test.ts
+++ b/src/agent/subagent-model-resolution.test.ts
@@ -494,6 +494,15 @@ describe("getModelHandleFromAgent", () => {
     ).toBe("ollama/llama3.1:8b");
   });
 
+  test("reconstructs provider-qualified handles from model settings", () => {
+    expect(
+      getModelHandleFromAgent({
+        model: "llama3.1:8b",
+        model_settings: { provider_type: "ollama" },
+      }),
+    ).toBe("ollama/llama3.1:8b");
+  });
+
   test("falls back to llm_config endpoint and model for server agents", () => {
     expect(
       getModelHandleFromAgent({

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -9,7 +9,7 @@
 
 import { spawn } from "node:child_process";
 import { getAvailableModelHandles } from "@/agent/available-models";
-import { getCurrentAgentId } from "@/agent/context";
+import { getConversationId, getCurrentAgentId } from "@/agent/context";
 import { getDefaultModelForTier, resolveModel } from "@/agent/model";
 import recallSubagentPrompt from "@/agent/prompts/recall_subagent.md";
 import recallSubagentLocalPrompt from "@/agent/prompts/recall_subagent_local.md";
@@ -121,11 +121,16 @@ interface ExecutionState {
  */
 export function getModelHandleFromAgent(agent: {
   model?: string | null;
+  model_settings?: { provider_type?: unknown } | null;
   llm_config?: { model_endpoint_type?: string | null; model?: string | null };
 }): string | null {
   const directModel = agent.model;
   if (directModel?.includes("/")) {
     return directModel;
+  }
+  const settingsProvider = agent.model_settings?.provider_type;
+  if (typeof settingsProvider === "string" && directModel) {
+    return `${settingsProvider}/${directModel}`;
   }
   const endpoint = agent.llm_config?.model_endpoint_type;
   const model = agent.llm_config?.model;
@@ -135,17 +140,33 @@ export function getModelHandleFromAgent(agent: {
   return directModel || model || null;
 }
 
-async function getPrimaryAgentModelHandle(): Promise<{
+async function getPrimaryAgentModelHandle(
+  scope: { agentId?: string | null; conversationId?: string | null } = {},
+): Promise<{
   handle: string | null;
   agent: {
     model?: string | null;
     name?: string | null;
+    model_settings?: { provider_type?: unknown } | null;
     llm_config?: { model_endpoint_type?: string | null; model?: string | null };
   } | null;
 }> {
   try {
-    const agentId = getCurrentAgentId();
+    const agentId = scope.agentId ?? getCurrentAgentId();
     const agent = await getBackend().retrieveAgent(agentId);
+    const conversationId = scope.conversationId;
+    if (conversationId && conversationId !== "default") {
+      try {
+        const conversation =
+          await getBackend().retrieveConversation(conversationId);
+        const conversationHandle = getModelHandleFromAgent(conversation);
+        if (conversationHandle) {
+          return { handle: conversationHandle, agent };
+        }
+      } catch {
+        // Fall back to the agent default if the conversation is not available.
+      }
+    }
     return { handle: getModelHandleFromAgent(agent), agent };
   } catch {
     return { handle: null, agent: null };
@@ -1229,7 +1250,9 @@ async function executeSubagent(
     if (exitCode !== 0) {
       // Check if this is a provider-not-supported error and we haven't retried yet
       if (!isRetry && isProviderNotSupportedError(stderr)) {
-        const { handle: primaryModel } = await getPrimaryAgentModelHandle();
+        const { handle: primaryModel } = await getPrimaryAgentModelHandle({
+          agentId: parentAgentIdOverride,
+        });
         if (primaryModel) {
           // Retry with the primary agent's model
           return executeSubagent(
@@ -1433,6 +1456,7 @@ export async function spawnSubagent(
   forkedContext?: boolean,
   parentAgentId?: string,
   transcriptPath?: string,
+  parentConversationId?: string,
 ): Promise<SubagentResult> {
   const allConfigs = await getAllSubagentConfigs();
   const config = allConfigs[type];
@@ -1454,8 +1478,29 @@ export async function spawnSubagent(
   const backendMode: BackendMode = activeBackend.capabilities.localMemfs
     ? "local"
     : "api";
+  // Resolve parent scope before model selection so local subagents inherit the
+  // active conversation's model override, not just the agent default.
+  let resolvedParentAgentId = parentAgentId;
+  if (!resolvedParentAgentId) {
+    try {
+      resolvedParentAgentId = getCurrentAgentId();
+    } catch {
+      // Context unavailable — carry forward undefined.
+    }
+  }
+  let resolvedParentConversationId = parentConversationId;
+  if (!resolvedParentConversationId) {
+    try {
+      resolvedParentConversationId = getConversationId() ?? undefined;
+    } catch {
+      // Context unavailable — carry forward undefined.
+    }
+  }
   const { handle: parentModelHandle, agent: parentAgent } =
-    await getPrimaryAgentModelHandle();
+    await getPrimaryAgentModelHandle({
+      agentId: resolvedParentAgentId,
+      conversationId: resolvedParentConversationId,
+    });
   const billingTier = await getCurrentBillingTier();
 
   // For existing agents, don't override model; for new agents, use provided or config default
@@ -1470,18 +1515,6 @@ export async function spawnSubagent(
         backendMode,
       });
   const baseURL = getBaseURL();
-
-  // Resolve parent agent ID: prefer the explicit value captured at the
-  // synchronous call site; fall back to the in-process context only when
-  // the caller didn't provide one.
-  let resolvedParentAgentId = parentAgentId;
-  if (!resolvedParentAgentId) {
-    try {
-      resolvedParentAgentId = getCurrentAgentId();
-    } catch {
-      // Context unavailable — carry forward undefined.
-    }
-  }
 
   // Build the prompt with system reminder for deployed agents
   let finalPrompt = prompt;

--- a/src/tools/impl/task.ts
+++ b/src/tools/impl/task.ts
@@ -399,6 +399,7 @@ export function spawnBackgroundSubagentTask(
     forkedContext,
     parentAgentIdForSpawn,
     transcriptPath,
+    resolvedParentScope?.conversationId,
   )
     .then(async (result) => {
       bgTask.status = result.success ? "completed" : "failed";
@@ -752,6 +753,8 @@ export async function task(args: TaskArgs): Promise<string> {
       args.max_turns,
       config.fork,
       parentAgentIdForSpawn,
+      undefined,
+      resolvedParentScope?.conversationId,
     );
 
     // Mark subagent as completed in state store

--- a/src/tools/subagent-parent-id-propagation.test.ts
+++ b/src/tools/subagent-parent-id-propagation.test.ts
@@ -13,12 +13,12 @@ import { spawnBackgroundSubagentTask } from "@/tools/impl/task";
  * `spawnSubagent` re-derives parentAgentId from getCurrentAgentId() after
  * multiple async yields — by which point the listener's in-process agent
  * context may have changed. The fix is to capture parentAgentId
- * synchronously at the call site (from parentScope.agentId) and plumb it
- * through as the 10th positional arg to spawnSubagent.
+ * synchronously at the call site (from parentScope) and plumb it through to
+ * spawnSubagent.
  *
  * Verifying at the spawnBackgroundSubagentTask boundary: whatever
- * parentScope.agentId callers pass in MUST reach the spawnSubagentImpl
- * as its parentAgentId argument — not re-read from a global context.
+ * parentScope callers pass in MUST reach the spawnSubagentImpl as explicit
+ * parent scope arguments — not be re-read from a global context.
  */
 
 describe("parentScope.agentId propagation to spawnSubagent", () => {
@@ -78,8 +78,10 @@ describe("parentScope.agentId propagation to spawnSubagent", () => {
   // Positional args of spawnSubagent:
   //   0: type, 1: prompt, 2: userModel, 3: subagentId, 4: signal,
   //   5: existingAgentId, 6: existingConversationId, 7: maxTurns,
-  //   8: forkedContext, 9: parentAgentId   ← the one we care about
+  //   8: forkedContext, 9: parentAgentId, 10: transcriptPath,
+  //   11: parentConversationId
   const PARENT_ID_ARG_INDEX = 9;
+  const PARENT_CONVERSATION_ID_ARG_INDEX = 11;
 
   // Typed stub matching spawnSubagent's shape so mock.calls is inferred
   // as a tuple with the 10th element addressable.
@@ -94,6 +96,8 @@ describe("parentScope.agentId propagation to spawnSubagent", () => {
     maxTurns?: number,
     forkedContext?: boolean,
     parentAgentId?: string,
+    transcriptPath?: string,
+    parentConversationId?: string,
   ];
 
   const makeSpawnStub = () =>
@@ -115,7 +119,7 @@ describe("parentScope.agentId propagation to spawnSubagent", () => {
       }),
     );
 
-  test("forwards parentScope.agentId as 10th positional arg to spawnSubagent", async () => {
+  test("forwards parentScope as explicit positional args to spawnSubagent", async () => {
     const spawnSubagentImpl = makeSpawnStub();
 
     spawnBackgroundSubagentTask({
@@ -142,6 +146,7 @@ describe("parentScope.agentId propagation to spawnSubagent", () => {
     const call = spawnSubagentImpl.mock.calls[0] as SpawnArgs | undefined;
     expect(call).toBeDefined();
     expect(call?.[PARENT_ID_ARG_INDEX]).toBe(PARENT_AGENT_ID);
+    expect(call?.[PARENT_CONVERSATION_ID_ARG_INDEX]).toBe("conv-xyz");
   });
 
   test("forwards undefined parentAgentId when parentScope is omitted", async () => {
@@ -173,5 +178,6 @@ describe("parentScope.agentId propagation to spawnSubagent", () => {
     // this layer we just confirm that without parentScope, nothing is
     // forwarded (so fallback will be exercised).
     expect(call?.[PARENT_ID_ARG_INDEX]).toBeUndefined();
+    expect(call?.[PARENT_CONVERSATION_ID_ARG_INDEX]).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- Thread parent conversation scope into Task subagent launches so local helpers resolve the active conversation override instead of the agent default.
- Resolve helper parent model handles from conversation model/model_settings before falling back to agent llm_config.
- Cover the propagation path with regression tests for local subagent inheritance.