### PR TITLE
fix(local): avoid guessed endpoint model defaults

### DIFF
--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -39,7 +39,18 @@ import {
 } from "./registered-pi-provider-runtime";
 
 export const DEFAULT_PI_PROVIDER = "openai" satisfies PiProvider;
+export const UNSELECTED_LOCAL_MODEL_HANDLE = "local/default";
 export type { PiProvider } from "./pi-provider-registry";
+
+export function isUnselectedLocalModelHandle(model: unknown): boolean {
+  return (
+    typeof model !== "string" ||
+    model.length === 0 ||
+    model === "auto" ||
+    model === UNSELECTED_LOCAL_MODEL_HANDLE ||
+    model.startsWith("letta/")
+  );
+}
 
 export interface PiModelSettings {
   provider_type?: unknown;
@@ -129,7 +140,7 @@ export function resolvePiProviderFromAgent(
   );
   if (settingsProvider) return settingsProvider;
 
-  if (model) {
+  if (model && !isUnselectedLocalModelHandle(model)) {
     const slashIndex = model.indexOf("/");
     if (slashIndex > 0) {
       throw new Error(
@@ -439,19 +450,26 @@ export async function resolvePiModelForAgent(
   modelSettings: PiModelSettings = {},
   options: PiModelFactoryOptions = {},
 ): Promise<ResolvedPiModel> {
+  const concreteModelHandle = isUnselectedLocalModelHandle(modelHandle)
+    ? undefined
+    : modelHandle;
   const provider = options.provider
     ? resolvePiProvider(options.provider)
-    : resolvePiProviderFromAgent(modelHandle, modelSettings);
+    : resolvePiProviderFromAgent(concreteModelHandle, modelSettings);
   const registeredProvider = getRegisteredPiProvider(provider);
   const spec = isPiProvider(provider) ? getPiProviderSpec(provider) : undefined;
   const modelId =
     options.model ??
     (registeredProvider
-      ? stripRegisteredProviderHandlePrefix(modelHandle, provider)
+      ? stripRegisteredProviderHandlePrefix(concreteModelHandle, provider)
       : undefined) ??
-    (spec ? resolvePiModelFromAgent(modelHandle, spec.id) : undefined) ??
+    (spec
+      ? resolvePiModelFromAgent(concreteModelHandle, spec.id)
+      : undefined) ??
     registeredProvider?.config.models?.[0]?.id ??
-    (spec ? resolvePiModelFromAgent(spec.defaultModel, spec.id) : undefined) ??
+    (spec?.defaultModel
+      ? resolvePiModelFromAgent(spec.defaultModel, spec.id)
+      : undefined) ??
     process.env.LETTA_CODE_DEV_PI_MODEL ??
     "";
   const storageDir = options.localProviderAuthStorageDir;
@@ -582,6 +600,11 @@ export async function resolvePiModelForAgent(
         "Register the provider with models before using it.",
     );
   } else if (spec.createCustomModel) {
+    if (!modelId) {
+      throw new Error(
+        `No model selected for provider "${provider}". Choose an available model with /model.`,
+      );
+    }
     model = customOpenAICompatibleModel({
       provider: spec.id,
       modelId,

--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -33,7 +33,7 @@ export interface PiProviderSpec {
   providerTypes: readonly string[];
   handlePrefixes: readonly string[];
   localProviderNames: readonly string[];
-  defaultModel: string;
+  defaultModel?: string;
   defaultBaseURL?: string;
   apiKeyEnv?: () => string | undefined;
   baseUrlEnv?: () => string | undefined;
@@ -210,7 +210,6 @@ const LOCAL_ENDPOINT_PROVIDER_SPECS: readonly PiProviderSpec[] = [
     providerTypes: ["ollama"],
     handlePrefixes: ["ollama/"],
     localProviderNames: ["ollama", LOCAL_OLLAMA_PROVIDER_NAME],
-    defaultModel: "ollama/llama2",
     defaultBaseURL: "http://localhost:11434/v1",
     apiKeyEnv: () => process.env.OLLAMA_LOCAL_API_KEY,
     baseUrlEnv: () => process.env.OLLAMA_BASE_URL,
@@ -226,7 +225,6 @@ const LOCAL_ENDPOINT_PROVIDER_SPECS: readonly PiProviderSpec[] = [
     providerTypes: ["ollama_cloud"],
     handlePrefixes: ["ollama-cloud/"],
     localProviderNames: ["ollama-cloud", LOCAL_OLLAMA_CLOUD_PROVIDER_NAME],
-    defaultModel: "ollama-cloud/gpt-oss:20b",
     defaultBaseURL: "https://ollama.com/v1",
     apiKeyEnv: () => process.env.OLLAMA_API_KEY,
     baseUrlEnv: () => process.env.OLLAMA_CLOUD_BASE_URL,
@@ -242,7 +240,6 @@ const LOCAL_ENDPOINT_PROVIDER_SPECS: readonly PiProviderSpec[] = [
     ],
     handlePrefixes: ["lmstudio/"],
     localProviderNames: ["lmstudio", LOCAL_LMSTUDIO_PROVIDER_NAME],
-    defaultModel: "lmstudio/google/gemma-3n-e4b",
     defaultBaseURL: "http://127.0.0.1:1234/v1",
     apiKeyEnv: () => process.env.LMSTUDIO_API_KEY,
     baseUrlEnv: () => process.env.LMSTUDIO_BASE_URL,
@@ -258,7 +255,6 @@ const LOCAL_ENDPOINT_PROVIDER_SPECS: readonly PiProviderSpec[] = [
     providerTypes: ["llama_cpp", "llama.cpp"],
     handlePrefixes: ["llama.cpp/", "llama-cpp/"],
     localProviderNames: ["llama-cpp", LOCAL_LLAMA_CPP_PROVIDER_NAME],
-    defaultModel: "llama.cpp/model",
     defaultBaseURL: "http://localhost:8080/v1",
     apiKeyEnv: () => process.env.LLAMA_CPP_API_KEY,
     baseUrlEnv: () =>
@@ -360,7 +356,7 @@ export function localModelHandle(provider: PiProvider, model: string): string {
   return prefix ? `${prefix}${model}` : model;
 }
 
-export function resolveLocalModel(provider: PiProvider): string {
+export function resolveLocalModel(provider: PiProvider): string | undefined {
   return getPiProviderSpec(provider).defaultModel;
 }
 

--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -21,6 +21,7 @@ import {
   type LocalMessage,
 } from "@/backend/local/local-message";
 import { removeOrphanLocalToolResults } from "@/backend/local/local-message-projection";
+import { resolveAvailableLocalModelForTurn } from "@/backend/local/local-model-config";
 import type { ClientTool } from "@/tools/manager";
 import { isRecord } from "@/utils/type-guards";
 import { isContextWindowOverflowError } from "./context-window-overflow";
@@ -466,9 +467,14 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
     input: ProviderTurnInput,
   ): AsyncIterable<ProviderStreamEvent> {
     const tools = toPiTools(input.clientTools);
+    const localModel = await resolveAvailableLocalModelForTurn({
+      model: input.agent.model,
+      modelSettings: input.agent.model_settings,
+      storageDir: this.localProviderAuthStorageDir,
+    });
     const resolved = await resolvePiModelForAgent(
-      input.agent.model,
-      input.agent.model_settings,
+      localModel.model,
+      localModel.modelSettings,
       { localProviderAuthStorageDir: this.localProviderAuthStorageDir },
     );
     const context: Context = {

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -752,6 +752,42 @@ describe("local backend pi transcript", () => {
     expect(handles).not.toContain("lmstudio/google/gemma-3n-e4b");
   });
 
+  test("discovers configured Ollama models without adding guessed defaults", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-pi-ollama-discovery-"),
+    );
+    await createOrUpdateLocalProvider({
+      providerType: "ollama",
+      providerName: "lc-ollama",
+      apiKey: "not-needed",
+      baseURL: "http://localhost:11434/v1",
+      storageDir,
+    });
+    const calls: string[] = [];
+    const fetchImpl = (async (input: unknown) => {
+      const url = typeof input === "string" ? input : String(input);
+      calls.push(url);
+      if (url.endsWith("/v1/models")) {
+        return new Response("not found", { status: 404 });
+      }
+      return new Response(
+        JSON.stringify({ models: [{ name: "qwen2.5-coder:7b" }] }),
+        { headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const handles = (
+      await listLocalModels(storageDir, { fetch: fetchImpl })
+    ).map((model) => model.handle);
+
+    expect(calls).toEqual([
+      "http://localhost:11434/v1/models",
+      "http://localhost:11434/api/tags",
+    ]);
+    expect(handles).toContain("ollama/qwen2.5-coder:7b");
+    expect(handles).not.toContain("ollama/llama2");
+  });
+
   test("lists extension-registered local provider models with context windows", async () => {
     registerPiProvider("lmstudio", {
       baseUrl: "http://localhost:8000/v1",

--- a/src/backend/local/compaction.ts
+++ b/src/backend/local/compaction.ts
@@ -14,6 +14,7 @@ import {
 } from "@/backend/dev/pi-model-factory";
 import { isRecord } from "@/utils/type-guards";
 import type { LocalMessage } from "./local-message";
+import { resolveAvailableLocalModelForTurn } from "./local-model-config";
 import type { LocalAgentRecord } from "./local-types";
 
 const ALL_WORD_LIMIT = 500;
@@ -369,9 +370,14 @@ async function runGenerateText(
   defaultPrompt: string,
 ): Promise<{ text: string }> {
   const systemPrompt = input.prompt ?? defaultPrompt;
+  const localModel = await resolveAvailableLocalModelForTurn({
+    model: input.agent.model,
+    modelSettings: input.agent.model_settings,
+    storageDir: input.localProviderAuthStorageDir,
+  });
   const resolved = await resolvePiModelForAgent(
-    input.agent.model,
-    input.agent.model_settings,
+    localModel.model,
+    localModel.modelSettings,
     { localProviderAuthStorageDir: input.localProviderAuthStorageDir },
   );
   const run = input.complete ?? defaultComplete;

--- a/src/backend/local/local-model-config.ts
+++ b/src/backend/local/local-model-config.ts
@@ -1,7 +1,9 @@
 import { type Api, getModels, type Model } from "@earendil-works/pi-ai";
 import {
   DEFAULT_PI_PROVIDER,
+  isUnselectedLocalModelHandle,
   type PiProvider,
+  UNSELECTED_LOCAL_MODEL_HANDLE,
 } from "@/backend/dev/pi-model-factory";
 import {
   getRegisteredPiProvider,
@@ -18,6 +20,7 @@ import {
   localProviderType,
   resolveLocalModel,
   resolveProviderFromModelHandle,
+  resolveProviderFromProviderType,
   stripProviderHandlePrefix,
 } from "@/backend/dev/pi-provider-registry";
 import {
@@ -37,6 +40,8 @@ export interface LocalModelConfig {
   handle: string;
   modelSettings: Record<string, unknown>;
 }
+
+export { UNSELECTED_LOCAL_MODEL_HANDLE };
 
 interface LocalModelListEntry {
   handle: string;
@@ -319,12 +324,18 @@ export function resolveLocalModelConfig(storageDir?: string): LocalModelConfig {
   const provider = resolveLocalProvider(storageDir);
   const registeredProvider = getRegisteredPiProvider(provider);
   const registeredModel = registeredProvider?.config.models?.[0];
+  const defaultModel = registeredProvider
+    ? undefined
+    : resolveLocalModel(provider);
   const model =
     registeredModel?.id ??
-    (registeredProvider ? "default" : resolveLocalModel(provider));
+    (registeredProvider ? "default" : defaultModel) ??
+    UNSELECTED_LOCAL_MODEL_HANDLE;
   const handle = registeredProvider
     ? `${provider}/${model}`
-    : localModelHandle(provider, model);
+    : model === UNSELECTED_LOCAL_MODEL_HANDLE
+      ? UNSELECTED_LOCAL_MODEL_HANDLE
+      : localModelHandle(provider, model);
   const modelSettings = localModelSettingsForHandle(handle);
   return {
     provider,
@@ -333,6 +344,52 @@ export function resolveLocalModelConfig(storageDir?: string): LocalModelConfig {
     modelSettings: {
       provider_type: localProviderTypeForModelConfig(provider),
       ...(modelSettings ?? {}),
+    },
+  };
+}
+
+function providerForLocalModelListEntry(
+  entry: LocalModelListEntry,
+): PiProvider | undefined {
+  return (
+    resolveProviderFromModelHandle(entry.handle) ??
+    resolveProviderFromProviderType(entry.model_endpoint_type)
+  );
+}
+
+export async function resolveAvailableLocalModelForTurn(input: {
+  model?: string | null;
+  modelSettings?: Record<string, unknown> | null;
+  storageDir?: string;
+}): Promise<{ model?: string; modelSettings: Record<string, unknown> }> {
+  const baseSettings = { ...(input.modelSettings ?? {}) };
+  if (
+    typeof input.model === "string" &&
+    !isUnselectedLocalModelHandle(input.model)
+  ) {
+    return { model: input.model, modelSettings: baseSettings };
+  }
+
+  const preferredProvider = resolveProviderFromProviderType(
+    baseSettings.provider_type,
+  );
+  const models = await listLocalModels(input.storageDir);
+  const selected = preferredProvider
+    ? models.find(
+        (entry) => providerForLocalModelListEntry(entry) === preferredProvider,
+      )
+    : models[0];
+
+  if (!selected) {
+    return { model: undefined, modelSettings: baseSettings };
+  }
+
+  return {
+    model: selected.handle,
+    modelSettings: {
+      ...baseSettings,
+      ...localModelSettingsForHandle(selected.handle),
+      provider_type: selected.model_endpoint_type,
     },
   };
 }

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -311,14 +311,14 @@ describe("pi model factory", () => {
     }
   });
 
-  test("resolves server LM Studio provider type to local runtime provider", async () => {
-    const resolved = await resolvePiModelForAgent(undefined, {
-      provider_type: "lmstudio_openai",
-    });
-
-    expect(resolved.provider).toBe("lmstudio");
-    expect(resolved.model.provider).toBe("lmstudio");
-    expect(resolved.model.baseUrl).toBe("http://127.0.0.1:1234/v1");
+  test("requires a selected model for local endpoint providers", async () => {
+    await expect(
+      resolvePiModelForAgent(undefined, {
+        provider_type: "lmstudio_openai",
+      }),
+    ).rejects.toThrow(
+      'No model selected for provider "lmstudio". Choose an available model with /model.',
+    );
   });
 
   test("uses extension-registered provider capabilities for local OpenAI-compatible models", async () => {

--- a/src/providers/local-pi-provider-catalog.test.ts
+++ b/src/providers/local-pi-provider-catalog.test.ts
@@ -68,6 +68,8 @@ describe("local pi provider catalog", () => {
   test("local provider defaults point at current pi-ai catalog models", () => {
     for (const spec of PI_PROVIDER_SPECS) {
       if (!spec.piProvider) continue;
+      expect(spec.defaultModel).toBeDefined();
+      if (!spec.defaultModel) continue;
       const modelId = spec.defaultModel.split("/").slice(1).join("/");
       expect(
         getModels(spec.piProvider).some((model) => model.id === modelId),


### PR DESCRIPTION
## Summary
- Remove hardcoded executable defaults for discoverable local endpoint providers like Ollama, Ollama Cloud, LM Studio, and llama.cpp.
- Resolve unselected local turns and compactions from the actual local model catalog instead of guessed provider placeholders.
- Fail clearly when a local endpoint provider has no selected/discovered model instead of constructing stale custom model IDs.