### PR TITLE
fix(channels): clarify Slack acknowledgement routing

### DIFF
--- a/src/channels/message-tool-schema.test.ts
+++ b/src/channels/message-tool-schema.test.ts
@@ -144,6 +144,12 @@ describe("buildDynamicMessageChannelSchema", () => {
     expect(resolved.description).toContain(
       "If no user-visible response is appropriate, do not call MessageChannel and do not send an empty acknowledgement.",
     );
+    expect(resolved.description).toContain(
+      'For lightweight acknowledgement, prefer action="react" when supported.',
+    );
+    expect(resolved.description).toContain(
+      "If the useful response belongs later, schedule the follow-up instead of sending a placeholder.",
+    );
     expect(resolved.description).not.toContain("Telegram");
     expect(properties.channel?.enum).toEqual(["slack"]);
     expect(properties.action?.enum).toEqual(["send", "react", "upload-file"]);

--- a/src/channels/message-tool.ts
+++ b/src/channels/message-tool.ts
@@ -132,7 +132,7 @@ function buildDynamicMessageChannelDescriptionFromDiscovery(
 
   const scopedReplyContract =
     scope && scope.channels.length > 0
-      ? '\n\nThis tool is currently scoped to a routed external channel turn. Plain assistant text is not delivered to that external user. If a user-visible reply is appropriate, your final action for the turn must be one MessageChannel call with action="send", channel from the notification, chat_id from the notification, and message containing the reply. If no user-visible response is appropriate, do not call MessageChannel and do not send an empty acknowledgement.'
+      ? '\n\nThis tool is currently scoped to a routed external channel turn. Plain assistant text is not delivered to that external user. If a user-visible reply is appropriate, your final action for the turn must be one MessageChannel call with action="send", channel from the notification, chat_id from the notification, and message containing the reply. If no user-visible response is appropriate, do not call MessageChannel and do not send an empty acknowledgement. For lightweight acknowledgement, prefer action="react" when supported. If the useful response belongs later, schedule the follow-up instead of sending a placeholder.'
       : "";
 
   return `${description}${scopedReplyContract}\n\nCurrently active channels: ${channelList}. Available actions across the active channels: ${actionList}. The JSON schema reflects the currently active channel plugins.`;

--- a/src/channels/xml.test.ts
+++ b/src/channels/xml.test.ts
@@ -70,6 +70,12 @@ describe("formatChannelNotification", () => {
       "If no user-visible response is appropriate, do not call MessageChannel. Do not send an empty acknowledgement.",
     );
     expect(reminder).toContain(
+      'For lightweight acknowledgement, prefer MessageChannel action="react" when supported.',
+    );
+    expect(reminder).toContain(
+      "If the useful response belongs later, schedule the follow-up instead of sending a placeholder.",
+    );
+    expect(reminder).toContain(
       "Do not produce a plain text assistant response as the user-visible reply.",
     );
     expect(reminder).toContain('action="react"');

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -51,6 +51,7 @@ export function buildChannelReminderText(msg: InboundChannelMessage): string {
     `This is an external ${escapedChannel} turn. Plain assistant text is not delivered to the user.`,
     `If you should reply to the external user, use MessageChannel with action="send", channel="${escapedChannel}", and chat_id="${escapedChatId}". Put the user-visible reply in message.`,
     "If no user-visible response is appropriate, do not call MessageChannel. Do not send an empty acknowledgement.",
+    'For lightweight acknowledgement, prefer MessageChannel action="react" when supported. If the useful response belongs later, schedule the follow-up instead of sending a placeholder.',
     "Do not produce a plain text assistant response as the user-visible reply.",
     "On supported channels, MessageChannel can also send proactively using channel + target (and accountId when needed).",
     "Only pass replyTo if you intentionally want the platform's quote/reply UI.",


### PR DESCRIPTION
## Summary
- Extends the routed channel reminder and scoped MessageChannel description so lightweight acknowledgements prefer reactions when available.
- Clarifies that delayed follow-up should be scheduled instead of sending placeholder Slack text, while keeping the delivery guard for visible replies.

## Test plan
- bun test src/channels/xml.test.ts src/channels/message-tool-schema.test.ts
- bun run lint
- bun run check

👾 Generated with [Letta Code](https://letta.com)
