### PR TITLE
fix(listen): keep local channel listeners alive with process anchor

### DIFF
--- a/src/cli/subcommands/listen-auth.test.ts
+++ b/src/cli/subcommands/listen-auth.test.ts
@@ -285,20 +285,15 @@ describe("listen subcommand auth resolution", () => {
     expect(pollForTokenMock).not.toHaveBeenCalled();
   });
 
-  test("uses a ref'ed timer to keep local channel listeners alive", async () => {
-    const calls: Array<{
-      callback: () => void;
-      delay?: number;
-    }> = [];
-    const intervalHandle = {} as ReturnType<typeof setInterval>;
-    const setIntervalMock = mock(((callback: () => void, delay?: number) => {
-      calls.push({ callback, delay });
-      return intervalHandle;
-    }) as typeof setInterval);
+  test("uses a ref'ed process anchor to keep local channel listeners alive", async () => {
+    const anchor = {
+      close: mock(() => {}),
+    };
+    const createProcessAnchor = mock(() => anchor);
 
     const keepAlive =
-      __listenSubcommandTestUtils.createListenerKeepAlivePromise(
-        setIntervalMock,
+      __listenSubcommandTestUtils.createListenerProcessAnchorPromise(
+        createProcessAnchor,
       );
 
     let resolved = false;
@@ -307,11 +302,8 @@ describe("listen subcommand auth resolution", () => {
     });
     await Promise.resolve();
 
-    expect(setIntervalMock).toHaveBeenCalledTimes(1);
-    expect(calls[0]?.delay).toBe(
-      __listenSubcommandTestUtils.LISTENER_KEEPALIVE_INTERVAL_MS,
-    );
-    expect(typeof calls[0]?.callback).toBe("function");
+    expect(createProcessAnchor).toHaveBeenCalledTimes(1);
+    expect(anchor.close).not.toHaveBeenCalled();
     expect(resolved).toBe(false);
   });
 

--- a/src/cli/subcommands/listen-auth.test.ts
+++ b/src/cli/subcommands/listen-auth.test.ts
@@ -285,6 +285,36 @@ describe("listen subcommand auth resolution", () => {
     expect(pollForTokenMock).not.toHaveBeenCalled();
   });
 
+  test("uses a ref'ed timer to keep local channel listeners alive", async () => {
+    const calls: Array<{
+      callback: () => void;
+      delay?: number;
+    }> = [];
+    const intervalHandle = {} as ReturnType<typeof setInterval>;
+    const setIntervalMock = mock(((callback: () => void, delay?: number) => {
+      calls.push({ callback, delay });
+      return intervalHandle;
+    }) as typeof setInterval);
+
+    const keepAlive =
+      __listenSubcommandTestUtils.createListenerKeepAlivePromise(
+        setIntervalMock,
+      );
+
+    let resolved = false;
+    void keepAlive.then(() => {
+      resolved = true;
+    });
+    await Promise.resolve();
+
+    expect(setIntervalMock).toHaveBeenCalledTimes(1);
+    expect(calls[0]?.delay).toBe(
+      __listenSubcommandTestUtils.LISTENER_KEEPALIVE_INTERVAL_MS,
+    );
+    expect(typeof calls[0]?.callback).toBe("function");
+    expect(resolved).toBe(false);
+  });
+
   test("rejects self-hosted listener startup without channels", async () => {
     process.env.LETTA_BASE_URL = "http://localhost:8283";
 

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -35,6 +35,9 @@ type ListenerProcessAnchor = {
 
 type CreateListenerProcessAnchor = () => ListenerProcessAnchor;
 
+// Keep listener process anchors reachable for the lifetime of the CLI command.
+// Without a retained reference, the MessageChannel anchor could be garbage
+// collected even though it is intended to hold channel-only listeners open.
 const activeListenerProcessAnchors = new Set<ListenerProcessAnchor>();
 
 type ListenerOAuthDeps = {

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/websocket/listen-register";
 
 const LISTENER_TOKEN_REFRESH_WINDOW_MS = 5 * 60 * 1000;
+const LISTENER_KEEPALIVE_INTERVAL_MS = 60 * 60 * 1000;
 
 type ListenerOAuthDeps = {
   LETTA_CLOUD_API_URL: string;
@@ -85,6 +86,20 @@ function formatTimestamp(): string {
   const s = String(now.getSeconds()).padStart(2, "0");
   const ms = String(now.getMilliseconds()).padStart(3, "0");
   return `${h}:${m}:${s}.${ms}`;
+}
+
+function createListenerKeepAlivePromise(
+  setIntervalFn: typeof setInterval = setInterval,
+): Promise<number> {
+  const keepAlive = setIntervalFn(() => {
+    // Intentionally empty: this ref'ed timer keeps channel-only listeners
+    // alive when adapters have no other active Node handles.
+  }, LISTENER_KEEPALIVE_INTERVAL_MS);
+
+  return new Promise<number>(() => {
+    void keepAlive;
+    // Never resolves - runs until the process receives a shutdown signal.
+  });
 }
 
 async function flushListenerTelemetryEnd(exitReason: string): Promise<void> {
@@ -286,6 +301,8 @@ async function resolveListenerRegistrationOptions(
 }
 
 export const __listenSubcommandTestUtils = {
+  LISTENER_KEEPALIVE_INTERVAL_MS,
+  createListenerKeepAlivePromise,
   flushListenerTelemetryEnd,
   getListenerServerUrl,
   resolveListenerStartupMode,
@@ -551,9 +568,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
         },
       });
 
-      return new Promise<number>(() => {
-        // Never resolves - runs until Ctrl+C
-      });
+      return createListenerKeepAlivePromise();
     }
 
     let registerOptions: RegisterOptions;

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -5,6 +5,7 @@
 
 import { hostname } from "node:os";
 import { parseArgs } from "node:util";
+import { MessageChannel } from "node:worker_threads";
 import { Box, render, Text } from "ink";
 import TextInput from "ink-text-input";
 import type React from "react";
@@ -27,7 +28,14 @@ import {
 } from "@/websocket/listen-register";
 
 const LISTENER_TOKEN_REFRESH_WINDOW_MS = 5 * 60 * 1000;
-const LISTENER_KEEPALIVE_INTERVAL_MS = 60 * 60 * 1000;
+
+type ListenerProcessAnchor = {
+  close: () => void;
+};
+
+type CreateListenerProcessAnchor = () => ListenerProcessAnchor;
+
+const activeListenerProcessAnchors = new Set<ListenerProcessAnchor>();
 
 type ListenerOAuthDeps = {
   LETTA_CLOUD_API_URL: string;
@@ -88,17 +96,31 @@ function formatTimestamp(): string {
   return `${h}:${m}:${s}.${ms}`;
 }
 
-function createListenerKeepAlivePromise(
-  setIntervalFn: typeof setInterval = setInterval,
+function createMessageChannelProcessAnchor(): ListenerProcessAnchor {
+  const { port1, port2 } = new MessageChannel();
+
+  port1.ref();
+  port2.ref();
+
+  return {
+    close: () => {
+      port1.close();
+      port2.close();
+    },
+  };
+}
+
+function createListenerProcessAnchorPromise(
+  createProcessAnchor: CreateListenerProcessAnchor = createMessageChannelProcessAnchor,
 ): Promise<number> {
-  const keepAlive = setIntervalFn(() => {
-    // Intentionally empty: this ref'ed timer keeps channel-only listeners
-    // alive when adapters have no other active Node handles.
-  }, LISTENER_KEEPALIVE_INTERVAL_MS);
+  const anchor = createProcessAnchor();
+
+  activeListenerProcessAnchors.add(anchor);
 
   return new Promise<number>(() => {
-    void keepAlive;
     // Never resolves - runs until the process receives a shutdown signal.
+    // The ref'ed MessageChannel above is a zero-wakeup process anchor for
+    // channel-only listeners whose adapters may not own a persistent handle.
   });
 }
 
@@ -301,8 +323,7 @@ async function resolveListenerRegistrationOptions(
 }
 
 export const __listenSubcommandTestUtils = {
-  LISTENER_KEEPALIVE_INTERVAL_MS,
-  createListenerKeepAlivePromise,
+  createListenerProcessAnchorPromise,
   flushListenerTelemetryEnd,
   getListenerServerUrl,
   resolveListenerStartupMode,
@@ -568,7 +589,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
         },
       });
 
-      return createListenerKeepAlivePromise();
+      return createListenerProcessAnchorPromise();
     }
 
     let registerOptions: RegisterOptions;


### PR DESCRIPTION
## Summary

Fixes local channel listener lifetime by replacing the previous hourly no-op keepalive timer with an explicit process anchor.

Local channel adapters may not always own a persistent Node handle, which can let the listener process exit even though the channel listener has started successfully. This change keeps the process alive intentionally using a ref'ed `MessageChannel`, making the lifecycle behavior clearer and avoiding periodic wakeups.

## Changes

- Replace the local-channel listener keepalive interval with a `MessageChannel`-based process anchor.
- Rename the test utility from keepalive timer terminology to process-anchor terminology.
- Update the listener auth/lifecycle test to assert that a process anchor is created and the listener promise remains pending.

## Validation

- `bun test src/cli/subcommands/listen-auth.test.ts`
- `bunx --bun @biomejs/biome@2.2.5 check src/cli/subcommands/listen.tsx src/cli/subcommands/listen-auth.test.ts`
- `bun run typecheck`

## Risk

Low. The change is isolated to local-channel listener mode after startup succeeds. Cloud listener registration, OAuth, channel registry behavior, adapter startup, and shutdown logic are unchanged.