### PR TITLE
fix: bump pi-ai for Fable local backend support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,10 +1,11 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@letta-ai/letta-code",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.78.1",
+        "@earendil-works/pi-ai": "^0.79.1",
         "@letta-ai/letta-client": "^1.10.2",
         "@pierre/diffs": "1.2.2",
         "glob": "^13.0.0",
@@ -110,7 +111,7 @@
 
     "@discoveryjs/json-ext": ["@discoveryjs/json-ext@1.1.0", "", {}, "sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.78.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-CM2pkTs1iupG/maw381lC9Q/Y/aQaMGK7GILc28ttImD0ci3LDwKroDsGkWbly5JIy3iqxdRxB9JlG7vvzCzTg=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.79.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-UnORwrcsTNLm4StEvoM8iEom0u87Te7BXEWxhec3iNXygWD6eEBosUoq9ddcveqtj/QpUZBMPWUu81cCtZxzkQ=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "access": "public"
   },
   "dependencies": {
+    "@earendil-works/pi-ai": "^0.79.1",
     "@letta-ai/letta-client": "^1.10.2",
-    "@earendil-works/pi-ai": "^0.78.1",
     "@pierre/diffs": "1.2.2",
     "glob": "^13.0.0",
     "ink-link": "^5.0.0",

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -686,6 +686,25 @@ describe("local backend pi transcript", () => {
     expect(handles).toContain("zai/glm-5.1");
   });
 
+  test("lists Fable 5 from the configured Anthropic pi catalog", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-pi-anthropic-fable-"),
+    );
+    await createOrUpdateLocalProvider({
+      providerType: "anthropic",
+      providerName: "lc-anthropic",
+      apiKey: "dummy",
+      storageDir,
+    });
+
+    const fable = (await listLocalModels(storageDir)).find(
+      (model) => model.handle === "anthropic/claude-fable-5",
+    );
+    expect(fable?.max_context_window).toBe(
+      getModel("anthropic", "claude-fable-5")?.contextWindow,
+    );
+  });
+
   test("lists pi catalog context windows for configured OpenRouter models", async () => {
     const storageDir = await mkdtemp(
       join(tmpdir(), "local-backend-pi-openrouter-context-"),


### PR DESCRIPTION
## Summary
- Bumps `@earendil-works/pi-ai` from `0.78.1` to `0.79.1` so local backend mode can resolve Claude Fable 5 from the upstream pi-ai Anthropic catalog.
- Adds a local backend catalog test that configures Anthropic locally and verifies `anthropic/claude-fable-5` is listed with the pi-ai context window.

## Why
The Letta Code registry already has the Fable preset for cloud/API-backed runs, but `letta --backend local` builds its local model catalog from pi-ai. Upstream pi-ai added Fable in `0.79.1`; `0.78.1` returns no Fable model.

## Validation
- `bun test src/backend/local-backend.test.ts -t "lists Fable 5 from the configured Anthropic pi catalog"`
- `bun test src/agent/model-tier-selection.test.ts`
- `bun run check`

👾 Generated with [Letta Code](https://letta.com)
