### PR TITLE
fix(local): align provider defaults with Pi TUI

### DIFF
--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -49,7 +49,6 @@ interface PiProviderOverride {
   providerTypes?: readonly string[];
   handlePrefixes?: readonly string[];
   localProviderNames?: readonly string[];
-  defaultModel?: string;
   defaultBaseURL?: string;
   apiKeyEnv?: () => string | undefined;
   baseUrlEnv?: () => string | undefined;
@@ -81,6 +80,46 @@ const PI_PROVIDER_ALIASES: Record<string, PiProvider> = {
   "kimi-code": "kimi-coding",
 };
 
+// Keep LC's built-in provider defaults aligned with Pi TUI's
+// `defaultModelPerProvider` until Pi exposes this through a narrow runtime
+// package/API. Local endpoint providers intentionally have no default here;
+// they must resolve to explicit or discovered local models.
+export const PI_TUI_DEFAULT_MODEL_IDS: Partial<Record<KnownProvider, string>> =
+  {
+    "amazon-bedrock": "us.anthropic.claude-opus-4-6-v1",
+    anthropic: "claude-opus-4-7",
+    openai: "gpt-5.4",
+    "azure-openai-responses": "gpt-5.4",
+    "openai-codex": "gpt-5.5",
+    deepseek: "deepseek-v4-pro",
+    google: "gemini-3.1-pro-preview",
+    "google-vertex": "gemini-3.1-pro-preview",
+    "github-copilot": "gpt-5.4",
+    openrouter: "moonshotai/kimi-k2.6",
+    "vercel-ai-gateway": "zai/glm-5.1",
+    xai: "grok-4.20-0309-reasoning",
+    groq: "openai/gpt-oss-120b",
+    cerebras: "zai-glm-4.7",
+    zai: "glm-5.1",
+    mistral: "devstral-medium-latest",
+    minimax: "MiniMax-M2.7",
+    "minimax-cn": "MiniMax-M2.7",
+    moonshotai: "kimi-k2.6",
+    "moonshotai-cn": "kimi-k2.6",
+    huggingface: "moonshotai/Kimi-K2.6",
+    fireworks: "accounts/fireworks/models/kimi-k2p6",
+    together: "moonshotai/Kimi-K2.6",
+    opencode: "kimi-k2.6",
+    "opencode-go": "kimi-k2.6",
+    "kimi-coding": "kimi-for-coding",
+    "cloudflare-workers-ai": "@cf/moonshotai/kimi-k2.6",
+    "cloudflare-ai-gateway": "workers-ai/@cf/moonshotai/kimi-k2.6",
+    xiaomi: "mimo-v2.5-pro",
+    "xiaomi-token-plan-cn": "mimo-v2.5-pro",
+    "xiaomi-token-plan-ams": "mimo-v2.5-pro",
+    "xiaomi-token-plan-sgp": "mimo-v2.5-pro",
+  };
+
 const PI_PROVIDER_OVERRIDES: Partial<
   Record<KnownProvider, PiProviderOverride>
 > = {
@@ -88,15 +127,12 @@ const PI_PROVIDER_OVERRIDES: Partial<
     providerTypes: ["openai", "openai-responses"],
     handlePrefixes: ["openai/", "openai-responses/"],
     localProviderNames: ["openai", LOCAL_OPENAI_PROVIDER_NAME],
-    defaultModel: "openai/gpt-5.5",
   },
   anthropic: {
     localProviderNames: ["anthropic", LOCAL_ANTHROPIC_PROVIDER_NAME],
-    defaultModel: "anthropic/claude-sonnet-4-6",
   },
   openrouter: {
     localProviderNames: ["openrouter", LOCAL_OPENROUTER_PROVIDER_NAME],
-    defaultModel: "openrouter/deepseek/deepseek-v4-pro",
     baseUrlEnv: () => process.env.OPENROUTER_BASE_URL,
     headers: () => ({ "X-Title": "Letta Code" }),
   },
@@ -108,7 +144,6 @@ const PI_PROVIDER_OVERRIDES: Partial<
       LOCAL_ZAI_PROVIDER_NAME,
       LOCAL_ZAI_CODING_PROVIDER_NAME,
     ],
-    defaultModel: "zai/glm-5.1",
     envConfigured: () =>
       getEnvApiKey("zai") !== undefined ||
       hasEnvValue(process.env.ZHIPU_API_KEY) ||
@@ -116,27 +151,23 @@ const PI_PROVIDER_OVERRIDES: Partial<
   },
   minimax: {
     localProviderNames: ["minimax", LOCAL_MINIMAX_PROVIDER_NAME],
-    defaultModel: "minimax/MiniMax-M2.7",
     baseUrlEnv: () => process.env.MINIMAX_BASE_URL,
   },
   moonshotai: {
     providerTypes: ["moonshotai", "moonshot"],
     handlePrefixes: ["moonshotai/", "moonshot/"],
     localProviderNames: ["moonshotai", LOCAL_MOONSHOT_PROVIDER_NAME],
-    defaultModel: "moonshotai/kimi-k2.5",
     baseUrlEnv: () => process.env.MOONSHOT_BASE_URL,
   },
   "kimi-coding": {
     providerTypes: ["kimi-coding", "moonshot_coding"],
     handlePrefixes: ["kimi-coding/", "moonshot_coding/"],
     localProviderNames: ["kimi-coding", LOCAL_KIMI_CODE_PROVIDER_NAME],
-    defaultModel: "kimi-coding/kimi-for-coding",
   },
   google: {
     providerTypes: ["google", "google_ai"],
     handlePrefixes: ["google/", "google_ai/"],
     localProviderNames: ["google", LOCAL_GOOGLE_AI_PROVIDER_NAME],
-    defaultModel: "google/gemini-3.1-pro-preview",
     apiKeyEnv: () =>
       process.env.GOOGLE_GENERATIVE_AI_API_KEY ?? getEnvApiKey("google"),
     baseUrlEnv: () => process.env.GOOGLE_GENERATIVE_AI_BASE_URL,
@@ -148,13 +179,11 @@ const PI_PROVIDER_OVERRIDES: Partial<
     providerTypes: ["amazon-bedrock", "bedrock"],
     handlePrefixes: ["amazon-bedrock/", "bedrock/"],
     localProviderNames: ["amazon-bedrock", LOCAL_BEDROCK_PROVIDER_NAME],
-    defaultModel: "amazon-bedrock/us.anthropic.claude-sonnet-4-6",
   },
   "openai-codex": {
     providerTypes: ["openai-codex", "chatgpt_oauth"],
     handlePrefixes: ["openai-codex/", "chatgpt-plus-pro/"],
     localProviderNames: ["openai-codex", LOCAL_CHATGPT_PROVIDER_NAME],
-    defaultModel: "openai-codex/gpt-5.5",
   },
 };
 
@@ -162,6 +191,8 @@ function defaultModelForProvider(
   provider: KnownProvider,
   handlePrefix: string,
 ): string {
+  const piTuiDefault = PI_TUI_DEFAULT_MODEL_IDS[provider];
+  if (piTuiDefault) return `${handlePrefix}${piTuiDefault}`;
   const model = getModels(provider)[0] as Model<Api> | undefined;
   return model ? `${handlePrefix}${model.id}` : `${handlePrefix}model`;
 }
@@ -178,9 +209,7 @@ function makePiProviderSpec(provider: KnownProvider): PiProviderSpec {
     providerTypes,
     handlePrefixes,
     localProviderNames,
-    defaultModel:
-      override.defaultModel ??
-      defaultModelForProvider(provider, primaryHandlePrefix),
+    defaultModel: defaultModelForProvider(provider, primaryHandlePrefix),
     ...(override.defaultBaseURL
       ? { defaultBaseURL: override.defaultBaseURL }
       : {}),

--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -120,6 +120,12 @@ export const PI_TUI_DEFAULT_MODEL_IDS: Partial<Record<KnownProvider, string>> =
     "xiaomi-token-plan-sgp": "mimo-v2.5-pro",
   };
 
+// These pi-ai providers are intentionally absent from Pi TUI's
+// `defaultModelPerProvider`. Keep the omission explicit so newly added pi-ai
+// providers cannot silently inherit catalog-order defaults without review.
+export const PI_TUI_DEFAULTLESS_PROVIDER_IDS: ReadonlySet<KnownProvider> =
+  new Set(["ant-ling", "nvidia", "zai-coding-cn"]);
+
 const PI_PROVIDER_OVERRIDES: Partial<
   Record<KnownProvider, PiProviderOverride>
 > = {
@@ -193,6 +199,8 @@ function defaultModelForProvider(
 ): string {
   const piTuiDefault = PI_TUI_DEFAULT_MODEL_IDS[provider];
   if (piTuiDefault) return `${handlePrefix}${piTuiDefault}`;
+  // Match Pi TUI's no-explicit-default behavior for providers omitted from its
+  // default map: use catalog order as the generic fallback.
   const model = getModels(provider)[0] as Model<Api> | undefined;
   return model ? `${handlePrefix}${model.id}` : `${handlePrefix}model`;
 }

--- a/src/providers/local-pi-provider-catalog.test.ts
+++ b/src/providers/local-pi-provider-catalog.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   PI_PROVIDER_SPECS,
   PI_TUI_DEFAULT_MODEL_IDS,
+  PI_TUI_DEFAULTLESS_PROVIDER_IDS,
   resolveProviderFromProviderType,
 } from "@/backend/dev/pi-provider-registry";
 import { listLocalModels } from "@/backend/local/local-model-config";
@@ -89,6 +90,17 @@ describe("local pi provider catalog", () => {
         getModels(provider as Parameters<typeof getModels>[0]).some(
           (model) => model.id === modelId,
         ),
+      ).toBe(true);
+    }
+  });
+
+  test("pi-ai providers without Pi TUI defaults are explicit", () => {
+    const defaultedProviders = new Set(Object.keys(PI_TUI_DEFAULT_MODEL_IDS));
+
+    for (const provider of getProviders()) {
+      expect(
+        defaultedProviders.has(provider) ||
+          PI_TUI_DEFAULTLESS_PROVIDER_IDS.has(provider),
       ).toBe(true);
     }
   });

--- a/src/providers/local-pi-provider-catalog.test.ts
+++ b/src/providers/local-pi-provider-catalog.test.ts
@@ -13,6 +13,7 @@ import {
 } from "@/backend/dev/pi-provider-extension-registry";
 import {
   PI_PROVIDER_SPECS,
+  PI_TUI_DEFAULT_MODEL_IDS,
   resolveProviderFromProviderType,
 } from "@/backend/dev/pi-provider-registry";
 import { listLocalModels } from "@/backend/local/local-model-config";
@@ -74,6 +75,35 @@ describe("local pi provider catalog", () => {
       expect(
         getModels(spec.piProvider).some((model) => model.id === modelId),
       ).toBe(true);
+    }
+  });
+
+  test("built-in provider defaults mirror Pi TUI defaults", () => {
+    for (const [provider, modelId] of Object.entries(
+      PI_TUI_DEFAULT_MODEL_IDS,
+    )) {
+      const spec = PI_PROVIDER_SPECS.find((entry) => entry.id === provider);
+      expect(spec).toBeDefined();
+      expect(spec?.defaultModel).toBe(`${spec?.handlePrefixes[0]}${modelId}`);
+      expect(
+        getModels(provider as Parameters<typeof getModels>[0]).some(
+          (model) => model.id === modelId,
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("discoverable local endpoint providers do not have guessed defaults", () => {
+    const endpointProviders = new Set([
+      "ollama",
+      "ollama-cloud",
+      "lmstudio",
+      "llama-cpp",
+    ]);
+
+    for (const spec of PI_PROVIDER_SPECS) {
+      if (!endpointProviders.has(spec.id)) continue;
+      expect(spec.defaultModel).toBeUndefined();
     }
   });
 


### PR DESCRIPTION
## Summary
- Align local backend built-in provider defaults with Pi TUI’s `defaultModelPerProvider` values from `pi-mono/packages/coding-agent/src/core/model-resolver.ts`.
- Remove LC-specific default model overrides for providers like OpenAI, Anthropic, OpenRouter, Moonshot, Bedrock, and ChatGPT/Codex.
- Keep local endpoint providers (Ollama, Ollama Cloud, LM Studio, llama.cpp) relying on explicit or discovered models rather than guessed executable defaults.
- Make providers omitted from Pi TUI’s default map explicit so future `pi-ai` additions cannot silently inherit catalog-order defaults without review.

This is intentionally narrow: it does not import `pi-coding-agent` or add any broader Pi TUI runtime dependency. LC still keeps its provider alias/storage/UI adapter layer, but built-in default model IDs now mirror Pi TUI until Pi exposes a narrow defaults/resolver API that LC can consume directly.

## Validation
- `bun install`
- `bun run check`
- `bun test src/providers/local-pi-provider-catalog.test.ts src/backend/local-backend.test.ts src/backend/pi-model-factory.test.ts`