### PR TITLE
fix: isolate background log files in private temp dirs

### DIFF
--- a/src/tools/impl/process-manager-output.test.ts
+++ b/src/tools/impl/process-manager-output.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import {
+  __resetBackgroundOutputDirForTests,
+  createBackgroundOutputFile,
+  getBackgroundOutputDir,
+} from "@/tools/impl/process_manager";
+
+const originalScratchpad = process.env.LETTA_SCRATCHPAD;
+const originalTmpdir = process.env.TMPDIR;
+const originalTmp = process.env.TMP;
+const originalTemp = process.env.TEMP;
+const isWindows = process.platform === "win32";
+let tempRoots: string[] = [];
+
+function restoreBackgroundOutputEnv(): void {
+  if (originalScratchpad === undefined) {
+    delete process.env.LETTA_SCRATCHPAD;
+  } else {
+    process.env.LETTA_SCRATCHPAD = originalScratchpad;
+  }
+
+  if (originalTmpdir === undefined) {
+    delete process.env.TMPDIR;
+  } else {
+    process.env.TMPDIR = originalTmpdir;
+  }
+
+  if (originalTmp === undefined) {
+    delete process.env.TMP;
+  } else {
+    process.env.TMP = originalTmp;
+  }
+
+  if (originalTemp === undefined) {
+    delete process.env.TEMP;
+  } else {
+    process.env.TEMP = originalTemp;
+  }
+}
+
+function makeTempRoot(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  tempRoots.push(root);
+  return root;
+}
+
+function useTempRootForTmpdir(): string {
+  const root = makeTempRoot("letta-bg-tmp-");
+  process.env.TMPDIR = root;
+  process.env.TMP = root;
+  process.env.TEMP = root;
+  return root;
+}
+
+function expectPosixMode(path: string, mode: number): void {
+  if (isWindows) {
+    return;
+  }
+
+  expect(statSync(path).mode & 0o777).toBe(mode);
+}
+
+describe("background output files", () => {
+  afterEach(() => {
+    __resetBackgroundOutputDirForTests();
+    restoreBackgroundOutputEnv();
+
+    for (const root of tempRoots) {
+      rmSync(root, { recursive: true, force: true });
+    }
+    tempRoots = [];
+  });
+
+  test("uses LETTA_SCRATCHPAD when explicitly configured", () => {
+    const scratchpad = makeTempRoot("letta-bg-scratch-");
+    process.env.LETTA_SCRATCHPAD = scratchpad;
+
+    const outputFile = createBackgroundOutputFile("task_scratchpad");
+
+    expect(getBackgroundOutputDir()).toBe(scratchpad);
+    expect(dirname(outputFile)).toBe(scratchpad);
+    expect(basename(outputFile)).toBe("task_scratchpad.log");
+    expect(existsSync(outputFile)).toBe(true);
+    expectPosixMode(outputFile, 0o600);
+  });
+
+  test("creates one private temp directory for the current process", () => {
+    const tempRoot = useTempRootForTmpdir();
+    delete process.env.LETTA_SCRATCHPAD;
+
+    const outputDir = getBackgroundOutputDir();
+    const outputFile = createBackgroundOutputFile("exec_1");
+
+    expect(outputDir.startsWith(join(tempRoot, "letta-background-"))).toBe(
+      true,
+    );
+    expect(getBackgroundOutputDir()).toBe(outputDir);
+    expect(dirname(outputFile)).toBe(outputDir);
+    expect(basename(outputFile)).toBe("exec_1.log");
+    expect(existsSync(outputFile)).toBe(true);
+    expectPosixMode(outputDir, 0o700);
+    expectPosixMode(outputFile, 0o600);
+  });
+
+  test("separates reused filenames across independent temp directories", () => {
+    const tempRoot = useTempRootForTmpdir();
+    delete process.env.LETTA_SCRATCHPAD;
+
+    const firstOutputFile = createBackgroundOutputFile("exec_1");
+    const firstOutputDir = dirname(firstOutputFile);
+
+    __resetBackgroundOutputDirForTests();
+
+    const secondOutputFile = createBackgroundOutputFile("exec_1");
+    const secondOutputDir = dirname(secondOutputFile);
+
+    expect(firstOutputDir.startsWith(join(tempRoot, "letta-background-"))).toBe(
+      true,
+    );
+    expect(
+      secondOutputDir.startsWith(join(tempRoot, "letta-background-")),
+    ).toBe(true);
+    expect(firstOutputDir).not.toBe(secondOutputDir);
+    expect(basename(firstOutputFile)).toBe("exec_1.log");
+    expect(basename(secondOutputFile)).toBe("exec_1.log");
+    expect(existsSync(firstOutputFile)).toBe(true);
+    expect(existsSync(secondOutputFile)).toBe(true);
+  });
+});

--- a/src/tools/impl/process_manager.ts
+++ b/src/tools/impl/process_manager.ts
@@ -1,3 +1,13 @@
+import {
+  appendFileSync,
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 type TimerHandle = ReturnType<typeof setTimeout>;
 
 export interface BackgroundProcessHandle {
@@ -34,6 +44,7 @@ export interface BackgroundTask {
 
 export const backgroundProcesses = new Map<string, BackgroundProcess>();
 export const backgroundTasks = new Map<string, BackgroundTask>();
+let backgroundOutputDir: string | undefined;
 let bashIdCounter = 1;
 export function getNextBashId() {
   return `bash_${bashIdCounter++}`;
@@ -257,33 +268,46 @@ export function setBackgroundTaskOutput(
 
 /**
  * Get a temp directory for background task output files.
- * Uses LETTA_SCRATCHPAD if set, otherwise falls back to os.tmpdir().
+ * Uses LETTA_SCRATCHPAD if set. Otherwise creates one private temp directory
+ * for this process so fixed log filenames do not collide across users or runs.
  */
 export function getBackgroundOutputDir(): string {
   const scratchpad = process.env.LETTA_SCRATCHPAD;
   if (scratchpad) {
     return scratchpad;
   }
-  // Fall back to system temp with a letta-specific subdirectory
-  const os = require("node:os");
-  const path = require("node:path");
-  return path.join(os.tmpdir(), "letta-background");
+
+  if (!backgroundOutputDir) {
+    backgroundOutputDir = mkdtempSync(join(tmpdir(), "letta-background-"));
+    chmodSync(backgroundOutputDir, 0o700);
+  }
+
+  return backgroundOutputDir;
+}
+
+export function __resetBackgroundOutputDirForTests(): void {
+  backgroundOutputDir = undefined;
+}
+
+function ensureBackgroundOutputDir(dir: string): void {
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+
+  if (!process.env.LETTA_SCRATCHPAD) {
+    chmodSync(dir, 0o700);
+  }
 }
 
 /**
  * Create a unique output file path for a background process/task.
  */
 export function createBackgroundOutputFile(id: string): string {
-  const fs = require("node:fs");
-  const path = require("node:path");
   const dir = getBackgroundOutputDir();
 
-  // Ensure directory exists
-  fs.mkdirSync(dir, { recursive: true });
+  ensureBackgroundOutputDir(dir);
 
-  const filePath = path.join(dir, `${id}.log`);
-  // Create empty file
-  fs.writeFileSync(filePath, "");
+  const filePath = join(dir, `${id}.log`);
+  writeFileSync(filePath, "", { mode: 0o600 });
+  chmodSync(filePath, 0o600);
   return filePath;
 }
 
@@ -291,6 +315,5 @@ export function createBackgroundOutputFile(id: string): string {
  * Append content to a background output file.
  */
 export function appendToOutputFile(filePath: string, content: string): void {
-  const fs = require("node:fs");
-  fs.appendFileSync(filePath, content);
+  appendFileSync(filePath, content);
 }


### PR DESCRIPTION
## Summary
- replace the shared `/tmp/letta-background` default with a process-private temp dir from `os.tmpdir()` + `fs.mkdtempSync()`
- keep fixed background log filenames inside the private dir while setting dirs to `0700` and files to `0600`
- add regression coverage for scratchpad override, private temp-dir reuse, and fixed-filename isolation

Closes #2810.

## Testing
- `bun test src/tools/impl/process-manager-output.test.ts src/tools/task-background.test.ts`
- `bun run typecheck`
- `bun run check`
- live smoke: two separate Bun processes with the same `TMPDIR` created separate `letta-background-*` dirs for `exec_1.log`; poisoned old shared `letta-background/exec_1.log` path was ignored