### PR TITLE
feat: export app-server protocol contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   ],
   "exports": {
     ".": "./letta.js",
+    "./app-server-protocol": {
+      "types": "./dist/types/app-server-protocol.d.ts"
+    },
     "./protocol": {
       "types": "./dist/types/protocol.d.ts"
     }

--- a/src/cli/subcommands/listen-auth.test.ts
+++ b/src/cli/subcommands/listen-auth.test.ts
@@ -285,6 +285,27 @@ describe("listen subcommand auth resolution", () => {
     expect(pollForTokenMock).not.toHaveBeenCalled();
   });
 
+  test("uses remote registration for desktop local backend listeners with channels", async () => {
+    process.env.LETTA_BASE_URL = "http://localhost:61677";
+    process.env.LETTA_DESKTOP_DEBUG_PANEL = "1";
+    process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL = "1";
+
+    settingsManager.getSettingsWithSecureTokens = mock(async () => ({
+      env: {},
+    })) as unknown as typeof settingsManager.getSettingsWithSecureTokens;
+
+    const result = await __listenSubcommandTestUtils.resolveListenerStartupMode(
+      ["slack"],
+    );
+
+    expect(result).toEqual({
+      kind: "remote",
+      serverUrl: "http://localhost:61677",
+    });
+    expect(requestDeviceCodeMock).not.toHaveBeenCalled();
+    expect(pollForTokenMock).not.toHaveBeenCalled();
+  });
+
   test("rejects self-hosted listener startup without channels", async () => {
     process.env.LETTA_BASE_URL = "http://localhost:8283";
 

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -133,6 +133,14 @@ async function resolveListenerStartupMode(
   const settings = await settingsManager.getSettingsWithSecureTokens();
   const serverUrl = getListenerServerUrl(settings);
 
+  // When running under the desktop app (which sets LETTA_DESKTOP_DEBUG_PANEL),
+  // the local proxy has a full environment server that expects device
+  // registration. Treat it as "remote" so the listener registers and connects
+  // via WebSocket, even when channels are active.
+  if (process.env.LETTA_DESKTOP_DEBUG_PANEL === "1") {
+    return { kind: "remote", serverUrl };
+  }
+
   if (isLocalBackendEnvEnabled() && channelNames.length > 0) {
     return {
       kind: "local-channels",
@@ -142,14 +150,6 @@ async function resolveListenerStartupMode(
   }
 
   if (isCloudListenerServerUrl(serverUrl)) {
-    return { kind: "remote", serverUrl };
-  }
-
-  // When running under the desktop app (which sets LETTA_DESKTOP_DEBUG_PANEL),
-  // the local proxy has a full environment server that expects device
-  // registration. Treat it as "remote" so the listener registers and connects
-  // via WebSocket, even when channels are active.
-  if (process.env.LETTA_DESKTOP_DEBUG_PANEL === "1") {
     return { kind: "remote", serverUrl };
   }
 

--- a/src/types/app-server-protocol.test.ts
+++ b/src/types/app-server-protocol.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import type { WsProtocolMessage } from "@/types/app-server-protocol";
+
+describe("app-server protocol export", () => {
+  test("covers command response messages emitted by the listener", () => {
+    const messages = [
+      {
+        type: "cron_list_response",
+        request_id: "req",
+        tasks: [],
+        success: true,
+      },
+      {
+        type: "cron_update_response",
+        request_id: "req",
+        success: true,
+      },
+      {
+        type: "skills_updated",
+        timestamp: 1,
+      },
+      {
+        type: "list_memory_response",
+        request_id: "req",
+        entries: [],
+        done: true,
+        total: 0,
+        success: true,
+      },
+      {
+        type: "search_files_response",
+        request_id: "req",
+        files: [],
+        success: true,
+      },
+      {
+        type: "terminal_output",
+        terminal_id: "term",
+        data: "hello",
+      },
+      {
+        type: "search_branches_response",
+        request_id: "req",
+        branches: [],
+        success: true,
+      },
+      {
+        type: "get_reflection_settings_response",
+        request_id: "req",
+        success: true,
+        reflection_settings: null,
+      },
+    ] satisfies WsProtocolMessage[];
+
+    expect(messages.map((message) => message.type)).toEqual([
+      "cron_list_response",
+      "cron_update_response",
+      "skills_updated",
+      "list_memory_response",
+      "search_files_response",
+      "terminal_output",
+      "search_branches_response",
+      "get_reflection_settings_response",
+    ]);
+  });
+});

--- a/src/types/app-server-protocol.ts
+++ b/src/types/app-server-protocol.ts
@@ -1,0 +1,2 @@
+/** Public app-server websocket protocol export. */
+export * from "./protocol_v2";

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -9,9 +9,98 @@
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs";
-import type { DmPolicy } from "@/channels/types";
-import type { CronRunLogPage, CronTask } from "@/cron";
-import type { ExperimentId, ExperimentSnapshot } from "@/experiments/types";
+
+export type DmPolicy = "pairing" | "allowlist" | "open";
+
+export type ExperimentId =
+  | "conversation_titles"
+  | "desktop_conversation_bootstrap"
+  | "diffs"
+  | "node"
+  | "tui_cron";
+
+export type ExperimentSource = "override" | "env" | "default";
+
+export interface ExperimentSnapshot {
+  id: ExperimentId;
+  label: string;
+  description: string;
+  envVar?: string;
+  enabled: boolean;
+  source: ExperimentSource;
+  override: boolean | null;
+}
+
+export type CronTaskStatus = "active" | "fired" | "missed" | "cancelled";
+export type CronCancelReason = "conversation_not_found" | "expired";
+export type CronRunOutcome = "queued" | "missed" | "failed" | "skipped";
+export type CronRunReason =
+  | "scheduled_time_matched"
+  | "one_off_due"
+  | "scheduler_inactive"
+  | "started_too_late"
+  | "queue_full"
+  | "runtime_unavailable"
+  | "task_cancelled"
+  | "scheduler_error";
+
+export interface CronTask {
+  id: string;
+  agent_id: string;
+  conversation_id: string;
+  name: string;
+  description: string;
+  cron: string;
+  timezone: string;
+  recurring: boolean;
+  prompt: string;
+  status: CronTaskStatus;
+  created_at: string;
+  expires_at: string | null;
+  last_fired_at: string | null;
+  fire_count: number;
+  cancel_reason: CronCancelReason | null;
+  jitter_offset_ms: number;
+  last_run_at: string | null;
+  last_run_outcome: CronRunOutcome | null;
+  last_run_reason: CronRunReason | null;
+  last_run_error: string | null;
+  last_missed_at: string | null;
+  missed_count: number;
+  failed_count: number;
+  scheduled_for: string | null;
+  fired_at: string | null;
+  missed_at: string | null;
+}
+
+export type CronRunLogStatus = "ok" | "error" | "skipped";
+
+export interface CronRunLogEntry {
+  ts: number;
+  jobId: string;
+  action: "finished";
+  status?: CronRunLogStatus;
+  outcome?: CronRunOutcome;
+  reason?: CronRunReason;
+  error?: string;
+  summary?: string;
+  agentId?: string;
+  conversationId?: string;
+  runId?: string;
+  runAtMs?: number;
+  queueItemId?: string;
+  scheduledFor?: string | null;
+  firedAt?: string;
+}
+
+export interface CronRunLogPage {
+  entries: CronRunLogEntry[];
+  total: number;
+  offset: number;
+  limit: number;
+  hasMore: boolean;
+  nextOffset: number | null;
+}
 
 /**
  * Runtime identity for all state and delta events.
@@ -669,6 +758,24 @@ export interface TerminalKillCommand {
   terminal_id: string;
 }
 
+export interface TerminalOutputMessage {
+  type: "terminal_output";
+  terminal_id: string;
+  data: string;
+}
+
+export interface TerminalSpawnedMessage {
+  type: "terminal_spawned";
+  terminal_id: string;
+  pid: number;
+}
+
+export interface TerminalExitedMessage {
+  type: "terminal_exited";
+  terminal_id: string;
+  exitCode: number;
+}
+
 export interface SearchFilesCommand {
   type: "search_files";
   /** Substring to match against file paths. Empty string returns top files by mtime. */
@@ -727,6 +834,30 @@ export interface GrepInFilesMatch {
   after?: string[];
 }
 
+export interface SearchFilesEntry {
+  path: string;
+  type: "file";
+}
+
+export interface SearchFilesResponseMessage {
+  type: "search_files_response";
+  request_id: string;
+  files: SearchFilesEntry[];
+  success: boolean;
+  error?: string;
+}
+
+export interface GrepInFilesResponseMessage {
+  type: "grep_in_files_response";
+  request_id: string;
+  success: boolean;
+  matches: GrepInFilesMatch[];
+  total_matches: number;
+  total_files: number;
+  truncated: boolean;
+  error?: string;
+}
+
 export interface ListInDirectoryCommand {
   type: "list_in_directory";
   /** Absolute path to list entries in. */
@@ -741,6 +872,18 @@ export interface ListInDirectoryCommand {
   request_id?: string;
 }
 
+export interface ListInDirectoryResponseMessage {
+  type: "list_in_directory_response";
+  path: string;
+  folders: string[];
+  files?: string[];
+  hasMore: boolean;
+  total?: number;
+  success: boolean;
+  error?: string;
+  request_id?: string;
+}
+
 export interface GetTreeCommand {
   type: "get_tree";
   /** Absolute path to the root of the subtree to fetch. */
@@ -751,12 +894,36 @@ export interface GetTreeCommand {
   request_id: string;
 }
 
+export interface TreeEntry {
+  path: string;
+  type: "file" | "dir";
+}
+
+export interface GetTreeResponseMessage {
+  type: "get_tree_response";
+  path: string;
+  request_id: string;
+  entries: TreeEntry[];
+  has_more_depth: boolean;
+  success: boolean;
+  error?: string;
+}
+
 export interface ReadFileCommand {
   type: "read_file";
   /** Absolute path to the file to read. */
   path: string;
   /** Echoed back in the response for request correlation. */
   request_id: string;
+}
+
+export interface ReadFileResponseMessage {
+  type: "read_file_response";
+  request_id: string;
+  path: string;
+  content: string | null;
+  success: boolean;
+  error?: string;
 }
 
 export interface WriteFileCommand {
@@ -767,6 +934,14 @@ export interface WriteFileCommand {
   content: string;
   /** Echoed back in the response for request correlation. */
   request_id: string;
+}
+
+export interface WriteFileResponseMessage {
+  type: "write_file_response";
+  request_id: string;
+  path: string;
+  success: boolean;
+  error?: string;
 }
 
 export interface WatchFileCommand {
@@ -821,6 +996,23 @@ export interface EditFileCommand {
   expected_replacements?: number;
   /** Echoed back in the response for request correlation. */
   request_id: string;
+}
+
+export interface EditFileResponseMessage {
+  type: "edit_file_response";
+  request_id: string;
+  file_path: string;
+  message: string | null;
+  replacements: number;
+  start_line?: number;
+  success: boolean;
+  error?: string;
+}
+
+export interface FileChangedMessage {
+  type: "file_changed";
+  path: string;
+  lastModified: number;
 }
 
 export interface ListMemoryCommand {
@@ -925,6 +1117,109 @@ export interface EnableMemfsCommand {
   request_id: string;
   /** The agent to enable memfs for. */
   agent_id: string;
+}
+
+export interface MemoryFileEntry {
+  relative_path: string;
+  is_system: boolean;
+  description: string | null;
+  content: string;
+  size: number;
+  references?: string[];
+}
+
+export interface ListMemoryResponseMessage {
+  type: "list_memory_response";
+  request_id: string;
+  entries: MemoryFileEntry[];
+  done: boolean;
+  total: number;
+  success: boolean;
+  error?: string;
+  memfs_enabled?: boolean;
+  memfs_initialized?: boolean;
+}
+
+export interface MemoryHistoryCommitEntry {
+  sha: string;
+  message: string;
+  timestamp: string;
+  author_name: string | null;
+}
+
+export interface MemoryHistoryResponseMessage {
+  type: "memory_history_response";
+  request_id: string;
+  file_path: string;
+  commits: MemoryHistoryCommitEntry[];
+  success: boolean;
+  error?: string;
+}
+
+export interface MemoryFileAtRefResponseMessage {
+  type: "memory_file_at_ref_response";
+  request_id: string;
+  file_path: string;
+  ref: string;
+  content: string | null;
+  success: boolean;
+  error?: string;
+}
+
+export interface ReadMemoryFileResponseMessage {
+  type: "read_memory_file_response";
+  request_id: string;
+  agent_id: string;
+  path: string;
+  content: string | null;
+  encoding: "utf8" | "base64";
+  success: boolean;
+  error?: string;
+}
+
+export interface WriteMemoryFileResponseMessage {
+  type: "write_memory_file_response";
+  request_id: string;
+  agent_id: string;
+  path: string;
+  success: boolean;
+  committed?: boolean;
+  commit_sha?: string;
+  error?: string;
+}
+
+export interface DeleteMemoryFileResponseMessage {
+  type: "delete_memory_file_response";
+  request_id: string;
+  agent_id: string;
+  path: string;
+  success: boolean;
+  committed?: boolean;
+  commit_sha?: string;
+  error?: string;
+}
+
+export interface MemoryCommitDiffResponseMessage {
+  type: "memory_commit_diff_response";
+  request_id: string;
+  sha: string;
+  diff: string | null;
+  success: boolean;
+  error?: string;
+}
+
+export interface EnableMemfsResponseMessage {
+  type: "enable_memfs_response";
+  request_id: string;
+  success: boolean;
+  memory_directory?: string;
+  error?: string;
+}
+
+export interface MemoryUpdatedMessage {
+  type: "memory_updated";
+  affected_paths: string[];
+  timestamp: number;
 }
 
 export interface ListModelsCommand {
@@ -1167,6 +1462,22 @@ export interface CronTriggerCommand {
   task_id: string;
 }
 
+export interface CronUpdateCommand {
+  type: "cron_update";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  task_id: string;
+  name?: string;
+  description?: string;
+  conversation_id?: string;
+  cron?: string;
+  timezone?: string;
+  recurring?: boolean;
+  prompt?: string;
+  /** Optional ISO timestamp for one-shot tasks. */
+  scheduled_for?: string | null;
+}
+
 export interface CronDeleteCommand {
   type: "cron_delete";
   /** Echoed back in the response for request correlation. */
@@ -1189,12 +1500,33 @@ export interface SkillEnableCommand {
   skill_path: string;
 }
 
+export interface SkillEnableResponseMessage {
+  type: "skill_enable_response";
+  request_id: string;
+  success: boolean;
+  skill_name?: string;
+  error?: string;
+}
+
 export interface SkillDisableCommand {
   type: "skill_disable";
   /** Echoed back in the response for request correlation. */
   request_id: string;
   /** Skill name (symlink name in ~/.letta/skills/). */
   name: string;
+}
+
+export interface SkillDisableResponseMessage {
+  type: "skill_disable_response";
+  request_id: string;
+  success: boolean;
+  skill_name?: string;
+  error?: string;
+}
+
+export interface SkillsUpdatedMessage {
+  type: "skills_updated";
+  timestamp: number;
 }
 
 export interface CreateAgentCommand {
@@ -1495,6 +1827,14 @@ export interface CronTriggerResponseMessage {
   request_id: string;
   success: boolean;
   found: boolean;
+  task?: CronTask;
+  error?: string;
+}
+
+export interface CronUpdateResponseMessage {
+  type: "cron_update_response";
+  request_id: string;
+  success: boolean;
   task?: CronTask;
   error?: string;
 }
@@ -1972,6 +2312,7 @@ export type WsProtocolCommand =
   | CronGetCommand
   | CronRunsCommand
   | CronTriggerCommand
+  | CronUpdateCommand
   | CronDeleteCommand
   | CronDeleteAllCommand
   | SkillEnableCommand
@@ -2011,22 +2352,60 @@ export type WsProtocolCommand =
   | SecretListCommand
   | SecretApplyCommand;
 
+export type WsProtocolCommandType = WsProtocolCommand["type"];
+
 export type WsProtocolMessage =
   | DeviceStatusUpdateMessage
   | LoopStatusUpdateMessage
   | QueueUpdateMessage
   | StreamDeltaMessage
   | SubagentStateUpdateMessage
+  | TerminalOutputMessage
+  | TerminalSpawnedMessage
+  | TerminalExitedMessage
+  | SearchFilesResponseMessage
+  | GrepInFilesResponseMessage
+  | ListInDirectoryResponseMessage
+  | GetTreeResponseMessage
+  | ReadFileResponseMessage
+  | WriteFileResponseMessage
+  | FileOpsCommand
+  | EditFileResponseMessage
+  | FileChangedMessage
+  | ListMemoryResponseMessage
+  | MemoryHistoryResponseMessage
+  | MemoryFileAtRefResponseMessage
+  | MemoryCommitDiffResponseMessage
+  | ReadMemoryFileResponseMessage
+  | WriteMemoryFileResponseMessage
+  | DeleteMemoryFileResponseMessage
+  | EnableMemfsResponseMessage
+  | MemoryUpdatedMessage
   | ListModelsResponseMessage
   | ListConnectProvidersResponseMessage
   | ConnectProviderResponseMessage
   | DisconnectProviderResponseMessage
   | UpdateModelResponseMessage
   | UpdateToolsetResponseMessage
+  | CronListResponseMessage
+  | CronAddResponseMessage
+  | CronGetResponseMessage
+  | CronRunsResponseMessage
+  | CronTriggerResponseMessage
+  | CronUpdateResponseMessage
+  | CronDeleteResponseMessage
+  | CronDeleteAllResponseMessage
+  | CronsUpdatedMessage
+  | SkillEnableResponseMessage
+  | SkillDisableResponseMessage
+  | SkillsUpdatedMessage
+  | CreateAgentResponseMessage
   | GetExperimentsResponseMessage
   | SetExperimentResponseMessage
   | ListConversationPinsResponseMessage
   | SetConversationPinResponseMessage
+  | GetReflectionSettingsResponseMessage
+  | SetReflectionSettingsResponseMessage
   | ChannelsListResponseMessage
   | ChannelAccountsListResponseMessage
   | ChannelAccountCreateResponseMessage
@@ -2053,8 +2432,12 @@ export type WsProtocolMessage =
   | ChannelRoutesUpdatedMessage
   | ChannelTargetsUpdatedMessage
   | GetCwdMapResponseMessage
+  | SearchBranchesResponse
+  | CheckoutBranchResponse
   | SecretListResponse
   | SecretApplyResponse
   | RemoveQueueItemResponse;
+
+export type WsProtocolMessageType = WsProtocolMessage["type"];
 
 export type { StopReasonType };

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -461,6 +461,26 @@ describe("listen-client parseServerMessage", () => {
         }),
       ),
     );
+    const cronTrigger = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "cron_trigger",
+          request_id: "cron-trigger-1",
+          task_id: "cron-1",
+        }),
+      ),
+    );
+    const cronUpdate = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "cron_update",
+          request_id: "cron-update-1",
+          task_id: "cron-1",
+          name: "Updated task",
+          scheduled_for: null,
+        }),
+      ),
+    );
     const cronDelete = parseServerMessage(
       Buffer.from(
         JSON.stringify({
@@ -484,6 +504,8 @@ describe("listen-client parseServerMessage", () => {
     expect(cronAdd?.type).toBe("cron_add");
     expect(cronGet?.type).toBe("cron_get");
     expect(cronRuns?.type).toBe("cron_runs");
+    expect(cronTrigger?.type).toBe("cron_trigger");
+    expect(cronUpdate?.type).toBe("cron_update");
     expect(cronDelete?.type).toBe("cron_delete");
     expect(cronDeleteAll?.type).toBe("cron_delete_all");
   });
@@ -1544,6 +1566,37 @@ describe("listen-client cron command handling", () => {
         success: true,
         found: true,
         task: { id: taskId },
+      });
+
+      socket.sentPayloads.length = 0;
+      await __listenClientTestUtils.handleCronCommand(
+        {
+          type: "cron_update",
+          request_id: "cron-update-1",
+          task_id: taskId,
+          name: "Updated cron",
+          prompt: "run the updated cron task",
+          scheduled_for: null,
+        },
+        socket as unknown as WebSocket,
+      );
+      const updateMessages = socket.sentPayloads.map((payload) =>
+        JSON.parse(payload as string),
+      );
+      expect(updateMessages[0]).toMatchObject({
+        type: "cron_update_response",
+        request_id: "cron-update-1",
+        success: true,
+        task: {
+          id: taskId,
+          name: "Updated cron",
+          prompt: "run the updated cron task",
+        },
+      });
+      expect(updateMessages[1]).toMatchObject({
+        type: "crons_updated",
+        agent_id: "agent-1",
+        conversation_id: "conv-1",
       });
 
       socket.sentPayloads.length = 0;

--- a/src/websocket/listener/commands/cron.ts
+++ b/src/websocket/listener/commands/cron.ts
@@ -7,6 +7,7 @@ import {
   getTask as getCronTask,
   listTasks as listCronTasks,
   readCronRunLogEntriesPage,
+  updateTask as updateCronTask,
 } from "@/cron";
 import { runCronTaskNow } from "@/cron/scheduler";
 import type {
@@ -17,6 +18,7 @@ import type {
   CronListCommand,
   CronRunsCommand,
   CronTriggerCommand,
+  CronUpdateCommand,
 } from "@/types/protocol_v2";
 import {
   isCronAddCommand,
@@ -26,6 +28,7 @@ import {
   isCronListCommand,
   isCronRunsCommand,
   isCronTriggerCommand,
+  isCronUpdateCommand,
 } from "@/websocket/listener/protocol-inbound";
 import type { RunDetachedListenerTask, SafeSocketSend } from "./types";
 
@@ -35,6 +38,7 @@ export type CronCommand =
   | CronGetCommand
   | CronRunsCommand
   | CronTriggerCommand
+  | CronUpdateCommand
   | CronDeleteCommand
   | CronDeleteAllCommand;
 
@@ -261,6 +265,68 @@ export async function handleCronCommand(
     return true;
   }
 
+  if (parsed.type === "cron_update") {
+    try {
+      let scheduledForIso: string | null | undefined;
+      if (parsed.scheduled_for === null) {
+        scheduledForIso = null;
+      } else if (parsed.scheduled_for !== undefined) {
+        const scheduledFor = new Date(parsed.scheduled_for);
+        if (Number.isNaN(scheduledFor.getTime())) {
+          throw new Error("Invalid scheduled_for timestamp");
+        }
+        scheduledForIso = scheduledFor.toISOString();
+      }
+      const task = updateCronTask(parsed.task_id, (current) => {
+        if (parsed.name !== undefined) current.name = parsed.name;
+        if (parsed.description !== undefined) {
+          current.description = parsed.description;
+        }
+        if (parsed.conversation_id !== undefined) {
+          current.conversation_id = parsed.conversation_id;
+        }
+        if (parsed.cron !== undefined) current.cron = parsed.cron;
+        if (parsed.timezone !== undefined) current.timezone = parsed.timezone;
+        if (parsed.recurring !== undefined)
+          current.recurring = parsed.recurring;
+        if (parsed.prompt !== undefined) current.prompt = parsed.prompt;
+        if (parsed.scheduled_for !== undefined) {
+          current.scheduled_for = scheduledForIso ?? null;
+        }
+      });
+      safeSocketSend(
+        socket,
+        {
+          type: "cron_update_response",
+          request_id: parsed.request_id,
+          success: task !== null,
+          ...(task ? { task } : { error: "Cron task not found" }),
+        },
+        "listener_cron_send_failed",
+        "listener_cron_command",
+      );
+      if (task) {
+        emitCronsUpdated(socket, safeSocketSend, {
+          agent_id: task.agent_id,
+          conversation_id: task.conversation_id,
+        });
+      }
+    } catch (err) {
+      safeSocketSend(
+        socket,
+        {
+          type: "cron_update_response",
+          request_id: parsed.request_id,
+          success: false,
+          error: err instanceof Error ? err.message : "Failed to update cron",
+        },
+        "listener_cron_send_failed",
+        "listener_cron_command",
+      );
+    }
+    return true;
+  }
+
   if (parsed.type === "cron_delete") {
     try {
       const existingTask = getCronTask(parsed.task_id);
@@ -348,6 +414,7 @@ export function handleCronProtocolCommand(
     isCronGetCommand(parsed) ||
     isCronRunsCommand(parsed) ||
     isCronTriggerCommand(parsed) ||
+    isCronUpdateCommand(parsed) ||
     isCronDeleteCommand(parsed) ||
     isCronDeleteAllCommand(parsed)
   ) {

--- a/src/websocket/listener/protocol-inbound.test.ts
+++ b/src/websocket/listener/protocol-inbound.test.ts
@@ -3,7 +3,22 @@ import {
   isChannelAccountCreateCommand,
   isChannelAccountUpdateCommand,
   isChannelSetConfigCommand,
+  parseServerMessage,
 } from "@/websocket/listener/protocol-inbound";
+
+describe("app-server protocol hard cut", () => {
+  test.each([
+    "request_state",
+    "change_cwd",
+    "cancel_run",
+    "recover_pending_approvals",
+    "change_mode",
+    "message",
+  ])("rejects legacy command %s", (type) => {
+    const parsed = parseServerMessage(Buffer.from(JSON.stringify({ type })));
+    expect(parsed).toBeNull();
+  });
+});
 
 describe("discord protocol-inbound validators", () => {
   test("valid discord account create passes", () => {

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -35,6 +35,7 @@ import type {
   CronListCommand,
   CronRunsCommand,
   CronTriggerCommand,
+  CronUpdateCommand,
   DeleteMemoryFileCommand,
   DisconnectProviderCommand,
   EditFileCommand,
@@ -888,6 +889,41 @@ export function isCronTriggerCommand(
     c.type === "cron_trigger" &&
     typeof c.request_id === "string" &&
     typeof c.task_id === "string"
+  );
+}
+
+export function isCronUpdateCommand(
+  value: unknown,
+): value is CronUpdateCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    task_id?: unknown;
+    name?: unknown;
+    description?: unknown;
+    conversation_id?: unknown;
+    cron?: unknown;
+    timezone?: unknown;
+    recurring?: unknown;
+    prompt?: unknown;
+    scheduled_for?: unknown;
+  };
+  return (
+    c.type === "cron_update" &&
+    typeof c.request_id === "string" &&
+    typeof c.task_id === "string" &&
+    (c.name === undefined || typeof c.name === "string") &&
+    (c.description === undefined || typeof c.description === "string") &&
+    (c.conversation_id === undefined ||
+      typeof c.conversation_id === "string") &&
+    (c.cron === undefined || typeof c.cron === "string") &&
+    (c.timezone === undefined || typeof c.timezone === "string") &&
+    (c.recurring === undefined || typeof c.recurring === "boolean") &&
+    (c.prompt === undefined || typeof c.prompt === "string") &&
+    (c.scheduled_for === undefined ||
+      c.scheduled_for === null ||
+      typeof c.scheduled_for === "string")
   );
 }
 
@@ -1764,6 +1800,7 @@ export function parseServerMessage(
       isCronGetCommand(parsed) ||
       isCronRunsCommand(parsed) ||
       isCronTriggerCommand(parsed) ||
+      isCronUpdateCommand(parsed) ||
       isCronDeleteCommand(parsed) ||
       isCronDeleteAllCommand(parsed) ||
       isSkillEnableCommand(parsed) ||

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -7,5 +7,5 @@
     "declarationMap": true,
     "outDir": "./dist/types"
   },
-  "include": ["src/types/protocol.ts"]
+  "include": ["src/types/protocol.ts", "src/types/app-server-protocol.ts"]
 }


### PR DESCRIPTION
## Summary
- export `@letta-ai/letta-code/app-server-protocol` as the public v2 app-server type surface
- complete the v2 command/message contract for Desktop-side protocol coverage, including cron/settings/channel/model/skill/filesystem/terminal responses
- add `cron_update` handling and hard-cut parser tests for legacy websocket commands
- ensure Desktop local-backend listeners with restored channels still register with the Desktop environment server

## Testing
- `bun run typecheck`
- `bun run lint`
- `bunx tsc -p tsconfig.types.json --pretty false`
- `bun test src/types/app-server-protocol.test.ts src/websocket/listener/protocol-inbound.test.ts src/websocket/listen-client-protocol.test.ts src/cli/subcommands/listen-auth.test.ts`

## Manual validation
Paired with the Desktop relay branch:
- local Desktop listener registered and connected on split control/stream channels
- message send/streaming worked
- stop/interrupt worked
- approval flow worked
- cron edit worked via `cron_update`
- no Desktop `Dropping unsupported device message type` logs observed

Paired Desktop PR: letta-ai/letta-cloud#12209 (draft until this package is released).
