### PR TITLE
fix(reminders): warn shell callers to use Letta base URL

### DIFF
--- a/src/reminders/engine.test.ts
+++ b/src/reminders/engine.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import { setCurrentAgentId } from "@/agent/context";
 import { permissionMode } from "@/permissions/mode";
@@ -17,6 +17,8 @@ import {
 } from "@/utils/secrets-store";
 
 const SECRETS_AGENT_ID = "agent-reminder-secrets";
+const ORIGINAL_LETTA_API_KEY = process.env.LETTA_API_KEY;
+const ORIGINAL_LETTA_BASE_URL = process.env.LETTA_BASE_URL;
 
 async function buildSecretsTestReminderParts(
   state: ReturnType<typeof createSharedReminderState>,
@@ -41,7 +43,22 @@ async function buildSecretsTestReminderParts(
   }
 }
 
+beforeEach(() => {
+  delete process.env.LETTA_API_KEY;
+  delete process.env.LETTA_BASE_URL;
+});
+
 afterEach(() => {
+  if (ORIGINAL_LETTA_API_KEY === undefined) {
+    delete process.env.LETTA_API_KEY;
+  } else {
+    process.env.LETTA_API_KEY = ORIGINAL_LETTA_API_KEY;
+  }
+  if (ORIGINAL_LETTA_BASE_URL === undefined) {
+    delete process.env.LETTA_BASE_URL;
+  } else {
+    process.env.LETTA_BASE_URL = ORIGINAL_LETTA_BASE_URL;
+  }
   clearSecretsCache(SECRETS_AGENT_ID);
   setCurrentAgentId(null);
 });
@@ -150,5 +167,21 @@ describe("secrets info reminders", () => {
     expect(text).toContain("$PLAYGROUND_AGENT_ID");
     expect(state.hasSentSecretsInfo).toBe(true);
     expect(state.pendingSecretsInfoRefresh).toBe(false);
+  });
+
+  test("reminds shell callers to pair LETTA_API_KEY with LETTA_BASE_URL", async () => {
+    process.env.LETTA_API_KEY = "proxy-session-token";
+    process.env.LETTA_BASE_URL = "http://localhost:57294";
+
+    const state = createSharedReminderState();
+    state.lastNotifiedPermissionMode = permissionMode.getMode();
+
+    const result = await buildSecretsTestReminderParts(state);
+
+    const text = result.parts.map((part) => part.text).join("\n");
+    expect(result.appliedReminderIds).toContain("secrets-info");
+    expect(text).toContain("use `$LETTA_BASE_URL` as the API host");
+    expect(text).toContain("Do not hardcode `https://api.letta.com`");
+    expect(text).toContain("$LETTA_BASE_URL/v1/...");
   });
 });

--- a/src/reminders/engine.ts
+++ b/src/reminders/engine.ts
@@ -92,7 +92,10 @@ async function buildSecretsInfoReminder(
   try {
     const { listSecretNames } = await import("@/utils/secrets-store");
     const names = listSecretNames(context.agent.id);
-    const namesKey = names.join("\0");
+    const hasLettaApiShellAuth = Boolean(
+      process.env.LETTA_API_KEY && process.env.LETTA_BASE_URL,
+    );
+    const namesKey = `${names.join("\0")}|letta-api:${hasLettaApiShellAuth ? "1" : "0"}`;
     const isRefresh = context.state.pendingSecretsInfoRefresh;
     const namesChanged =
       context.state.lastSentSecretNamesKey !== null &&
@@ -106,7 +109,18 @@ async function buildSecretsInfoReminder(
     context.state.pendingSecretsInfoRefresh = false;
     context.state.lastSentSecretNamesKey = namesKey;
 
+    const lettaApiRoutingNote = hasLettaApiShellAuth
+      ? "For Letta API calls from shell commands, use `$LETTA_BASE_URL` as the API host with `$LETTA_API_KEY`, for example `$LETTA_BASE_URL/v1/...` (strip a trailing slash first if needed). Do not hardcode `https://api.letta.com`: Desktop OAuth and some remote runtimes route `$LETTA_API_KEY` through a local/proxied base URL, and bypassing that URL can make valid auth look unauthorized."
+      : null;
+
     if (names.length === 0) {
+      if (lettaApiRoutingNote) {
+        const prefix =
+          isRefresh || namesChanged
+            ? "The agent secrets were updated. No secrets are currently set.\n\n"
+            : "";
+        return `${SYSTEM_REMINDER_OPEN}\n${prefix}${lettaApiRoutingNote}\n${SYSTEM_REMINDER_CLOSE}`;
+      }
       if (isRefresh || namesChanged) {
         return `${SYSTEM_REMINDER_OPEN}\nThe agent secrets were updated. No secrets are currently set.\n${SYSTEM_REMINDER_CLOSE}`;
       }
@@ -118,7 +132,8 @@ async function buildSecretsInfoReminder(
       isRefresh || namesChanged
         ? "The agent secrets were updated. The following secrets are now available for use."
         : "The following secrets are set on your agent and available for use.";
-    return `${SYSTEM_REMINDER_OPEN}\n${intro}\nReference them with \`$SECRET_NAME\` in shell commands — substitution happens automatically at exec time:\n${list}\n\nYou cannot read the raw values. If a value would appear in tool output, you will see \`NAME=<REDACTED>\` instead. This means the secret IS set and working — the bytes are just hidden from your context. Keep using \`$NAME\`; it will resolve correctly.\n${SYSTEM_REMINDER_CLOSE}`;
+    const suffix = lettaApiRoutingNote ? `\n\n${lettaApiRoutingNote}` : "";
+    return `${SYSTEM_REMINDER_OPEN}\n${intro}\nReference them with \`$SECRET_NAME\` in shell commands — substitution happens automatically at exec time:\n${list}\n\nYou cannot read the raw values. If a value would appear in tool output, you will see \`NAME=<REDACTED>\` instead. This means the secret IS set and working — the bytes are just hidden from your context. Keep using \`$NAME\`; it will resolve correctly.${suffix}\n${SYSTEM_REMINDER_CLOSE}`;
   } catch (error) {
     debugLog(
       "secrets",


### PR DESCRIPTION
## Summary

Desktop OAuth gives the listener a local proxy token plus a matching local base URL. Shell snippets that hardcode the production API host bypass that proxy, so the token reaches Cloud directly and gets rejected even though the user is signed in.

This adds a short secrets reminder note when both Letta API shell auth variables are present. The reminder tells agents to pair the base URL with the API key for Letta API calls instead of hardcoding the production host. It also emits the note even when there are no user-defined secrets, so the proxy-token case is covered.

## Behavior

Before: an agent could see a valid API key environment variable, hardcode the production host, and get a confusing 401.

After: the initial/remitted secrets reminder explicitly describes the base URL/API key pairing, including the Desktop OAuth proxy case.

## Risk

Low. This only changes agent-facing reminder text and the reminder cache key used to decide whether the note needs to be re-emitted.

## Validation

- bun test src/reminders/engine.test.ts
- bunx --bun @biomejs/biome@2.2.5 check src/reminders/engine.ts src/reminders/engine.test.ts
- bun run check

👾 Generated with [Letta Code](https://letta.com)
