### PR TITLE
fix(skills): use Letta base URL for image generation

### DIFF
--- a/src/skills/builtin/image-generation/SKILL.md
+++ b/src/skills/builtin/image-generation/SKILL.md
@@ -14,7 +14,9 @@ before replying.
 Generate the image, save it locally, then show it inline:
 
 ```bash
-curl -sS -X POST "https://api.letta.com/v1/images/generations" \
+base_url="${LETTA_BASE_URL%/}"
+
+curl -sS -X POST "$base_url/v1/images/generations" \
   -H "Authorization: Bearer $LETTA_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"provider":"gemini","prompt":"a friendly robot mascot waving, flat vector logo, mint green background","n":1}' \
@@ -33,13 +35,14 @@ print("saved robot-mascot.png; credits:", response["billing"]["credits_charged"]
 PY
 ```
 
-In Bash tools launched by Letta Code, the current Letta credential is available
-as `$LETTA_API_KEY`. This works for both Letta auth modes: it may be a normal
-Letta API key, or the OAuth access token from a Letta Cloud OAuth login. Reference
-it directly. If it is missing, the user needs to authenticate with Letta Cloud (or
-provide a Letta API key); do **not** ask for an OpenAI/Gemini provider key. This
-endpoint also does not use `/connect` BYOK providers — the only `provider` values
-supported here are `gemini` and `openai`.
+In Bash tools launched by Letta Code, the current Letta API host and credential
+are available as `$LETTA_BASE_URL` and `$LETTA_API_KEY`. Use them as a pair. Do
+not hardcode `https://api.letta.com`: Desktop OAuth and some remote runtimes route
+the token through a local/proxied base URL. If either variable is missing, the
+user needs to authenticate with Letta Cloud (or provide a Letta API key); do
+**not** ask for an OpenAI/Gemini provider key. This endpoint also does not use
+`/connect` BYOK providers — the only `provider` values supported here are
+`gemini` and `openai`.
 
 Then **show the image to the user** by embedding the saved file in your reply:
 

--- a/src/skills/builtin/image-generation/SKILL.md
+++ b/src/skills/builtin/image-generation/SKILL.md
@@ -35,14 +35,16 @@ print("saved robot-mascot.png; credits:", response["billing"]["credits_charged"]
 PY
 ```
 
-In Bash tools launched by Letta Code, the current Letta API host and credential
-are available as `$LETTA_BASE_URL` and `$LETTA_API_KEY`. Use them as a pair. Do
-not hardcode `https://api.letta.com`: Desktop OAuth and some remote runtimes route
-the token through a local/proxied base URL. If either variable is missing, the
-user needs to authenticate with Letta Cloud (or provide a Letta API key); do
-**not** ask for an OpenAI/Gemini provider key. This endpoint also does not use
-`/connect` BYOK providers — the only `provider` values supported here are
-`gemini` and `openai`.
+Letta Code commands such as `letta messages` build their client from the active
+runtime config: `LETTA_BASE_URL` selects the server, and `LETTA_API_KEY` is the
+bearer credential for that server. Raw `curl` calls from Bash tools should do the
+same. Use the two variables as a pair, and do not hardcode
+`https://api.letta.com`: in Desktop, `LETTA_BASE_URL` may be a local proxy and
+`LETTA_API_KEY` may be a local session token that only works through that proxy.
+If either variable is missing, the user needs to authenticate with Letta Cloud
+(or provide a Letta API key); do **not** ask for an OpenAI/Gemini provider key.
+This endpoint also does not use `/connect` BYOK providers — the only `provider`
+values supported here are `gemini` and `openai`.
 
 Then **show the image to the user** by embedding the saved file in your reply:
 

--- a/src/skills/builtin/image-generation/SKILL.md
+++ b/src/skills/builtin/image-generation/SKILL.md
@@ -35,16 +35,15 @@ print("saved robot-mascot.png; credits:", response["billing"]["credits_charged"]
 PY
 ```
 
-Letta Code commands such as `letta messages` build their client from the active
-runtime config: `LETTA_BASE_URL` selects the server, and `LETTA_API_KEY` is the
-bearer credential for that server. Raw `curl` calls from Bash tools should do the
-same. Use the two variables as a pair, and do not hardcode
-`https://api.letta.com`: in Desktop, `LETTA_BASE_URL` may be a local proxy and
-`LETTA_API_KEY` may be a local session token that only works through that proxy.
-If either variable is missing, the user needs to authenticate with Letta Cloud
-(or provide a Letta API key); do **not** ask for an OpenAI/Gemini provider key.
-This endpoint also does not use `/connect` BYOK providers — the only `provider`
-values supported here are `gemini` and `openai`.
+In Bash tools launched by Letta Code, use the runtime-provided
+`LETTA_BASE_URL` and `LETTA_API_KEY` together for Letta API calls. Build URLs
+relative to `${LETTA_BASE_URL%/}` and send `Authorization: Bearer $LETTA_API_KEY`.
+Do not hardcode `https://api.letta.com`: Desktop and remote runtimes may provide
+a proxy base URL, and the credential may only be valid through that URL. If
+either variable is missing, the user needs to authenticate with Letta Cloud (or
+provide a Letta API key); do **not** ask for an OpenAI/Gemini provider key. This
+endpoint also does not use `/connect` BYOK providers — the only `provider` values
+supported here are `gemini` and `openai`.
 
 Then **show the image to the user** by embedding the saved file in your reply:
 


### PR DESCRIPTION
## Summary

Update the built-in `image-generation` skill in `letta-code` so its example call uses the Letta Code runtime base URL instead of hardcoding the Cloud API host.

The skill now builds the image endpoint from `LETTA_BASE_URL` and uses it together with `LETTA_API_KEY`. That matches how Desktop OAuth and proxied runtime shells are configured: the token and base URL are a pair.

## Validation

- `bun src/skills/builtin/creating-skills/scripts/validate-skill.ts src/skills/builtin/image-generation`

👾 Generated with [Letta Code](https://letta.com)
