### PR TITLE
fix(memfs): memory write push missing remote origin

### DIFF
--- a/src/agent/memory-git.ts
+++ b/src/agent/memory-git.ts
@@ -248,11 +248,30 @@ export async function maybeUpdateMemoryRemoteOrigin(
     const { stdout } = await runGit(repoDir, ["remote", "get-url", "origin"]);
     currentOrigin = stdout.trim();
   } catch {
-    // No origin remote configured — leave as-is.
+    // No origin remote configured — create one so pushes have a destination.
+    const expectedOrigin = normalizeRemoteUrl(getGitRemoteUrl(agentId));
+    await runGit(repoDir, ["remote", "add", "origin", expectedOrigin]);
+    console.warn(
+      `[memfs-git] Created missing origin remote for agent ${agentId}: ${expectedOrigin}`,
+    );
+    debugLog(
+      "memfs-git",
+      `Created missing origin remote for ${agentId}: ${expectedOrigin}`,
+    );
     return;
   }
 
   if (!currentOrigin) {
+    // origin key exists but value is empty — set it.
+    const expectedOrigin = normalizeRemoteUrl(getGitRemoteUrl(agentId));
+    await runGit(repoDir, ["remote", "set-url", "origin", expectedOrigin]);
+    console.warn(
+      `[memfs-git] Set empty origin remote for agent ${agentId}: ${expectedOrigin}`,
+    );
+    debugLog(
+      "memfs-git",
+      `Set empty origin remote for ${agentId}: ${expectedOrigin}`,
+    );
     return;
   }
 
@@ -1658,7 +1677,7 @@ export async function pushMemory(agentId: string): Promise<void> {
   const dir = getMemoryRepoDir(agentId);
 
   await prepareMemoryRepoForGitOps(dir, agentId, token);
-  await runGit(dir, ["push"], token);
+  await runGit(dir, ["push", "-u", "origin", "main"], token);
 }
 
 export interface MemoryGitStatus {
@@ -1881,7 +1900,7 @@ export async function syncPendingMemoryCommitsAfterTurn(
   }
 
   try {
-    await runGitWithRetry(memoryDir, ["push"], token, {
+    await runGitWithRetry(memoryDir, ["push", "-u", "origin", "main"], token, {
       operation: "post-turn push pending memory commits",
     });
     return {
@@ -1915,9 +1934,14 @@ export async function syncPendingMemoryCommitsAfterTurn(
           localOnly,
         };
       }
-      await runGitWithRetry(memoryDir, ["push"], token, {
-        operation: "post-turn push rebased memory commits",
-      });
+      await runGitWithRetry(
+        memoryDir,
+        ["push", "-u", "origin", "main"],
+        token,
+        {
+          operation: "post-turn push rebased memory commits",
+        },
+      );
       return {
         status: "pushed",
         summary: `Rebased and pushed ${divergence.ahead} pending memory commit(s).`,


### PR DESCRIPTION
Two bugs causing memory writes (including profile picture uploads) to silently stay local and never reach the server.

### Bare `git push` fails when branch has no upstream tracking ref

The June 4 refactor (`4f851eff`) introduced new push calls in `syncPendingMemoryCommitsAfterTurn` and `pushMemory` using bare `["push"]` with no explicit remote/branch. This fails with:

```
fatal: The current branch main has no upstream branch.
```

for any repo where `main` has no upstream tracking ref configured — which happens when the repo is bootstrapped via `git init` rather than `git clone` (e.g. Pierre repos where the remote was empty at clone time, or repos initialized locally first).

Fix: use `["push", "-u", "origin", "main"]` on all push call sites.

### Missing origin remote never gets created

`maybeUpdateMemoryRemoteOrigin` silently no-ops when no `origin` remote exists at all — the catch block just returns. Push then fails with:

```
fatal: No configured push destination.
```

Fix: create the origin remote using `getGitRemoteUrl(agentId)` when none is configured.
