### PR TITLE
fix(memfs): push immediately after non-turn memory writes

### DIFF
--- a/src/websocket/listener/commands/memory.ts
+++ b/src/websocket/listener/commands/memory.ts
@@ -743,6 +743,21 @@ export function handleMemoryProtocolCommand(
           ...(memorySyncMode ? { syncMode: memorySyncMode } : {}),
         });
 
+        // ── Push immediately (non-turn writes don't get post-turn sync) ─
+        if (commitResult.committed && !memorySyncMode) {
+          const { syncPendingMemoryCommitsAfterTurn } = await import(
+            "@/agent/memory-git"
+          );
+          syncPendingMemoryCommitsAfterTurn(parsed.agent_id, {
+            memoryDir: memoryRoot,
+          }).catch((err) => {
+            console.warn(
+              `[write_memory_file] background push failed for ${parsed.agent_id}:`,
+              err instanceof Error ? err.message : err,
+            );
+          });
+        }
+
         // ── Notify UI so the memory view auto-refreshes ────────────────
         if (commitResult.committed) {
           safeSocketSend(
@@ -918,6 +933,21 @@ export function handleMemoryProtocolCommand(
           },
           ...(memorySyncMode ? { syncMode: memorySyncMode } : {}),
         });
+
+        // ── Push immediately (non-turn writes don't get post-turn sync) ─
+        if (commitResult.committed && !memorySyncMode) {
+          const { syncPendingMemoryCommitsAfterTurn } = await import(
+            "@/agent/memory-git"
+          );
+          syncPendingMemoryCommitsAfterTurn(parsed.agent_id, {
+            memoryDir: memoryRoot,
+          }).catch((err) => {
+            console.warn(
+              `[delete_memory_file] background push failed for ${parsed.agent_id}:`,
+              err instanceof Error ? err.message : err,
+            );
+          });
+        }
 
         if (commitResult.committed) {
           safeSocketSend(


### PR DESCRIPTION
Companion fix to #2819.

## Problem

The June 4 refactor (`4f851eff`) moved the push out of `commitMemoryWrite` and into `syncPendingMemoryCommitsAfterTurn`, which only fires after a turn. Non-turn writes like **profile picture uploads** (direct WS command) never trigger post-turn sync, so commits sit locally indefinitely.

This caused profile pictures to appear briefly (optimistic UI) then disappear on refetch — the commit existed locally but was never pushed to the server.

## Fix

Fire `syncPendingMemoryCommitsAfterTurn` in the background immediately after a successful commit in the `write_memory_file` WS handler. The response is sent to the client immediately (non-blocking); the push happens async.

Skipped for local-only backends (`syncMode: "local"`).

## Also

Added `console.log`/`console.warn` across the write path (checkout, commit, push) so failures are visible in desktop debug logs.