### PR TITLE
fix(tui): render overlay string footers safely

### DIFF
--- a/src/cli/components/HelpDialog.test.tsx
+++ b/src/cli/components/HelpDialog.test.tsx
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test";
+import { Readable, Writable } from "node:stream";
+import { render } from "ink";
+import stripAnsi from "strip-ansi";
+import { HelpDialog } from "./HelpDialog";
+
+class CaptureStream extends Writable {
+  columns = 100;
+  rows = 24;
+  isTTY = true;
+  chunks: string[] = [];
+
+  override _write(
+    chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ) {
+    this.chunks.push(String(chunk));
+    callback();
+  }
+}
+
+function createInputStream(): NodeJS.ReadStream {
+  const input = new Readable({ read() {} }) as NodeJS.ReadStream;
+  input.isTTY = true;
+  input.setRawMode = () => input;
+  input.ref = () => input;
+  input.unref = () => input;
+  return input;
+}
+
+async function renderHelpDialog(): Promise<string> {
+  const stdout = new CaptureStream() as CaptureStream & NodeJS.WriteStream;
+  const instance = render(<HelpDialog onClose={() => {}} />, {
+    stdout,
+    stdin: createInputStream(),
+    debug: false,
+    patchConsole: false,
+    exitOnCtrlC: false,
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  instance.unmount();
+  instance.cleanup();
+
+  return stripAnsi(stdout.chunks.join(""));
+}
+
+test("HelpDialog renders its footer without raw Ink text", async () => {
+  const output = await renderHelpDialog();
+
+  expect(output).toContain("Letta Code v");
+  expect(output).toContain(
+    "Enter select · ↑↓ navigate · ←→/Tab switch · Esc cancel",
+  );
+});

--- a/src/cli/components/OverlayShell.tsx
+++ b/src/cli/components/OverlayShell.tsx
@@ -28,6 +28,12 @@ export function OverlayShell({
 }: OverlayShellProps) {
   const terminalWidth = useTerminalWidth();
   const solidLine = SOLID_LINE.repeat(Math.max(terminalWidth, 10));
+  const renderedFooter =
+    typeof footer === "string" || typeof footer === "number" ? (
+      <Text dimColor>{footer}</Text>
+    ) : (
+      footer
+    );
 
   return (
     <Box flexDirection="column">
@@ -44,7 +50,7 @@ export function OverlayShell({
 
       {children}
 
-      {footer && <Box marginTop={1}>{footer}</Box>}
+      {footer && <Box marginTop={1}>{renderedFooter}</Box>}
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- Wrap primitive `OverlayShell` footers in `Text` so Ink never receives raw text inside a `Box`
- Add a `/help` render regression test covering the footer

## Testing
- `bun test src/cli/components/HelpDialog.test.tsx`
- `bunx --bun @biomejs/biome@2.2.5 check src/cli/components/OverlayShell.tsx src/cli/components/HelpDialog.test.tsx`
- Caren manually E2E tested `/help`

Note: `bun run typecheck` still fails on existing unrelated provider/model type errors in `src/backend/dev/pi-provider-registry.ts` and `src/backend/local-backend.test.ts`.
