### PR TITLE
test(cli): wait for setup menu raw input readiness

### DIFF
--- a/src/test-utils/startup-setup-pty-runner.cjs
+++ b/src/test-utils/startup-setup-pty-runner.cjs
@@ -4,6 +4,7 @@ const path = require("node:path");
 const pty = require("node-pty");
 
 const [, , cliPath, projectRoot] = process.argv;
+const INK_BRACKETED_PASTE_ENABLE = "\x1b[?2004h";
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -116,6 +117,12 @@ async function main() {
         `Local transcript error leaked into setup. Output:\n${initialOutput}`,
       );
     }
+
+    await waitForOutput(
+      () => output,
+      (current) => current.includes(INK_BRACKETED_PASTE_ENABLE),
+      "setup menu raw input mode",
+    );
 
     const beforeInputLength = output.length;
     terminal.write("\x1b[A");


### PR DESCRIPTION
## Summary
- Wait for Ink to enable raw input/bracketed paste before sending synthetic arrow keys in the setup PTY test runner
- Avoid racing first menu render vs `useInput` raw-mode setup

## Testing
- `bun test src/startup-setup-pty.test.ts`
- `for i in {1..10}; do bun test src/startup-setup-pty.test.ts || exit 1; done`
- `bunx --bun @biomejs/biome@2.2.5 check src/test-utils/startup-setup-pty-runner.cjs`
- `bun run check` (fails on existing unrelated type errors in `src/backend/dev/pi-provider-registry.ts` and `src/backend/local-backend.test.ts`)

Context: this is separate from #2821; that PR's rerun is now green.
