### PR TITLE
fix(stream): prevent pending approvals from orphaning tools LET-9142

### DIFF
--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -581,16 +581,19 @@ export function markIncompleteToolsAsCancelled(
 
 /**
  * Remove incomplete tool calls from the buffer entirely.
- * Used at end_turn to clean up orphaned tool calls without showing "Cancelled".
+ * Used to clean up orphaned/failed-run tool calls without showing "Cancelled".
  * Returns true if any tools were removed.
  */
-export function removeIncompleteTools(b: Buffers): boolean {
+export function removeIncompleteTools(
+  b: Buffers,
+  reason = "end_turn",
+): boolean {
   let anyToolsRemoved = false;
   for (const [id, line] of b.byId.entries()) {
     if (line.kind === "tool_call" && line.phase !== "finished") {
       debugLog(
         "accumulator",
-        `[REMOVED_ORPHANED_TOOL] name=${line.name ?? "?"} phase=${line.phase} diagnosis=${diagnoseOrphanedTool(line, b)} toolCallId=${line.toolCallId ?? "?"}`,
+        `[REMOVED_ORPHANED_TOOL] name=${line.name ?? "?"} phase=${line.phase} diagnosis=${diagnoseOrphanedTool(line, b)} reason=${reason} toolCallId=${line.toolCallId ?? "?"}`,
       );
       b.byId.delete(id);
       b.order = b.order.filter((oid) => oid !== id);

--- a/src/cli/helpers/stream-stop-reason.test.ts
+++ b/src/cli/helpers/stream-stop-reason.test.ts
@@ -51,6 +51,49 @@ describe("drainStream stop reason", () => {
     expect(result.sawStopReasonChunk).toBe(true);
   });
 
+  test("removes incomplete tools from terminal llm_api_error streams", async () => {
+    const fakeStream = {
+      controller: new AbortController(),
+      async *[Symbol.asyncIterator]() {
+        yield {
+          message_type: "approval_request_message",
+          tool_call: {
+            tool_call_id: "tc-failed-run",
+            name: "exec_command",
+            arguments: '{"cmd":"git status"}',
+          },
+        } as LettaStreamingResponse;
+        yield {
+          message_type: "stop_reason",
+          stop_reason: "llm_api_error",
+        } as LettaStreamingResponse;
+        throw new Error("peer closed connection");
+      },
+    } as unknown as Stream<LettaStreamingResponse>;
+
+    const buffers = createBuffers("agent-test");
+    const result = await drainStream(
+      fakeStream,
+      buffers,
+      () => {},
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      false,
+      true,
+    );
+
+    expect(result.stopReason).toBe("llm_api_error");
+    expect(
+      Array.from(buffers.byId.values()).some(
+        (line) => line.kind === "tool_call" && line.phase !== "finished",
+      ),
+    ).toBe(false);
+    expect(buffers.interrupted).toBe(false);
+  });
+
   test("coerces end_turn with pending approvals into requires_approval", async () => {
     const fakeStream = {
       controller: new AbortController(),
@@ -70,11 +113,8 @@ describe("drainStream stop reason", () => {
       },
     } as unknown as Stream<LettaStreamingResponse>;
 
-    const result = await drainStream(
-      fakeStream,
-      createBuffers("agent-test"),
-      () => {},
-    );
+    const buffers = createBuffers("agent-test");
+    const result = await drainStream(fakeStream, buffers, () => {});
 
     expect(result.stopReason).toBe("requires_approval");
     expect(result.sawStopReasonChunk).toBe(true);
@@ -85,6 +125,11 @@ describe("drainStream stop reason", () => {
         toolArgs: '{"command":"pwd"}',
       },
     ]);
+    const line = buffers.byId.get("tc-end-turn");
+    expect(line?.kind).toBe("tool_call");
+    if (line?.kind === "tool_call") {
+      expect(line.phase).toBe("ready");
+    }
   });
 
   test("end_turn removes orphaned tool calls entirely (tool_call_message without approval_request or tool_return)", async () => {

--- a/src/cli/helpers/stream.ts
+++ b/src/cli/helpers/stream.ts
@@ -512,12 +512,19 @@ export async function drainStream(
     // commit truncated content to static (emittedIdsRef) before resume can append.
     // drainStreamWithResume calls markCurrentLineAsFinished if no resume happens.
     //
-    // skipCancelToolsOnError: when drainStreamWithResume will attempt a resume,
-    // don't cancel tool calls yet — the resume stream replays tool_return_message
-    // chunks that overwrite any cancelled state. drainStreamWithResume cancels
-    // tools itself in the failure/no-resume paths.
+    // skipCancelToolsOnError: when drainStreamWithResume may attempt a resume,
+    // don't cancel tool calls for resumable stream drops yet — the resume stream
+    // replays tool_return_message chunks that overwrite any cancelled state.
+    // If the server already emitted a terminal provider error, though, the run
+    // is not resumable; any incomplete tools from that failed run are artifacts
+    // and should not survive into the next retry run.
     if (skipCancelToolsOnError) {
-      buffers.interrupted = true;
+      if (stopReason === "error") {
+        buffers.interrupted = true;
+      } else if (stopReason === "llm_api_error") {
+        buffers.interrupted = false;
+        removeIncompleteTools(buffers, "terminal_stream_error");
+      }
     } else {
       markIncompleteToolsAsCancelled(buffers, true, "stream_error", true);
     }
@@ -560,40 +567,7 @@ export async function drainStream(
     stopReason = "error";
   }
 
-  // Clean up incomplete tool calls:
-  // - cancelled: user interrupted, show "Interrupted by user"
-  // - end_turn: server ended without completing, remove entirely (don't show anything)
-  if (stopReason === "cancelled") {
-    const hadOrphanedTools = markIncompleteToolsAsCancelled(
-      buffers,
-      true,
-      "user_interrupt",
-    );
-    if (hadOrphanedTools) {
-      debugWarn(
-        "drainStream",
-        "cancelled had orphaned tool calls (see [ORPHANED_TOOL] logs for diagnosis)",
-      );
-    }
-  } else if (stopReason === "end_turn") {
-    const hadOrphanedTools = removeIncompleteTools(buffers);
-    if (hadOrphanedTools) {
-      debugWarn(
-        "drainStream",
-        "end_turn had orphaned tool calls (see [REMOVED_ORPHANED_TOOL] logs)",
-      );
-    }
-  }
-
-  // Mark the final line as finished now that stream has ended.
-  // Skip for error stop reason — drainStreamWithResume will finalize after
-  // resume succeeds (or in its catch/else path if no resume is attempted).
-  if (stopReason !== "error") {
-    markCurrentLineAsFinished(buffers);
-  }
-  queueMicrotask(refresh);
-
-  // Package the approval request(s) at the end.
+  // Package the approval request(s) before cleanup.
   // Always extract from streamProcessor regardless of stopReason so that
   // drainStreamWithResume can carry them across a resume boundary (the
   // resumed stream uses a fresh streamProcessor that won't have them).
@@ -621,6 +595,41 @@ export async function drainStream(
     );
     stopReason = "requires_approval";
   }
+
+  // Clean up incomplete tool calls:
+  // - cancelled: user interrupted, show "Interrupted by user"
+  // - end_turn: server ended without completing, remove entirely (don't show anything)
+  if (stopReason === "cancelled") {
+    const hadOrphanedTools = markIncompleteToolsAsCancelled(
+      buffers,
+      true,
+      "user_interrupt",
+    );
+    if (hadOrphanedTools) {
+      debugWarn(
+        "drainStream",
+        "cancelled had orphaned tool calls (see [ORPHANED_TOOL] logs for diagnosis)",
+      );
+    }
+  } else if (stopReason === "end_turn") {
+    const hadOrphanedTools = removeIncompleteTools(buffers);
+    if (hadOrphanedTools) {
+      debugWarn(
+        "drainStream",
+        "end_turn had orphaned tool calls (see [REMOVED_ORPHANED_TOOL] logs)",
+      );
+    }
+  } else if (stopReason === "llm_api_error") {
+    removeIncompleteTools(buffers, "terminal_stream_error");
+  }
+
+  // Mark the final line as finished now that stream has ended.
+  // Skip for error stop reason — drainStreamWithResume will finalize after
+  // resume succeeds (or in its catch/else path if no resume is attempted).
+  if (stopReason !== "error") {
+    markCurrentLineAsFinished(buffers);
+  }
+  queueMicrotask(refresh);
 
   if (
     stopReason === "requires_approval" &&


### PR DESCRIPTION
## Summary
- remove incomplete tool calls from terminal `llm_api_error` streams so failed-run artifacts do not survive into retry runs
- package/coerce pending approvals before `end_turn` cleanup so valid approval requests are not removed as orphans
- include a cleanup reason in `[REMOVED_ORPHANED_TOOL]` diagnostics

## Testing
- `bun test src/cli/helpers/stream-stop-reason.test.ts`
- `bun test src/cli/helpers/stream-stop-reason.test.ts src/cli/stream-resume-fallback.test.ts src/cli/helpers/unified-exec-accumulator.test.ts`
- `bunx --bun @biomejs/biome@2.2.5 check src/cli/helpers/stream.ts src/cli/helpers/accumulator.ts src/cli/helpers/stream-stop-reason.test.ts`
- `bun run check` (fails on existing unrelated type errors in `src/backend/dev/pi-provider-registry.ts` and `src/backend/local-backend.test.ts`)

## Notes
The local debug sequence that motivated this showed a terminal `llm_api_error` (`WebSocket closed unexpectedly: 1006`) followed by a normal later `end_turn` removing a stale `exec_command` approval line. This PR discards those failed-run tool artifacts at the terminal error boundary instead of letting them survive until a later turn.
