### PR TITLE
fix(agent): avoid empty backfill assistant warning

### DIFF
--- a/src/agent/check-approval-resume-data.test.ts
+++ b/src/agent/check-approval-resume-data.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import type {
   Message,
@@ -120,6 +123,38 @@ function datedMessage(
     message_type: messageType,
     ...extras,
   } as unknown as Message;
+}
+
+async function captureDebugOutput<T>(
+  run: () => Promise<T>,
+): Promise<{ output: string; result: T }> {
+  const previousDebug = process.env.LETTA_DEBUG;
+  const previousDebugFile = process.env.LETTA_DEBUG_FILE;
+  const debugDir = mkdtempSync(join(tmpdir(), "letta-debug-"));
+  const debugFile = join(debugDir, "debug.log");
+
+  process.env.LETTA_DEBUG = "1";
+  process.env.LETTA_DEBUG_FILE = debugFile;
+
+  try {
+    const result = await run();
+    const output = existsSync(debugFile) ? readFileSync(debugFile, "utf8") : "";
+    return { output, result };
+  } finally {
+    if (previousDebug === undefined) {
+      delete process.env.LETTA_DEBUG;
+    } else {
+      process.env.LETTA_DEBUG = previousDebug;
+    }
+
+    if (previousDebugFile === undefined) {
+      delete process.env.LETTA_DEBUG_FILE;
+    } else {
+      process.env.LETTA_DEBUG_FILE = previousDebugFile;
+    }
+
+    rmSync(debugDir, { recursive: true, force: true });
+  }
 }
 
 describe("getResumeData", () => {
@@ -308,6 +343,53 @@ describe("getResumeData", () => {
     });
     expect(resume.pendingApprovals).toHaveLength(0);
     expect(resume.messageHistory.length).toBeGreaterThan(0);
+  });
+
+  test("does not warn about missing assistant messages for an empty new conversation", async () => {
+    const conversationsRetrieve = mock(async () => ({
+      in_context_message_ids: [],
+    }));
+    const conversationsList = mock(async () => ({
+      getPaginatedItems: () => [],
+    }));
+
+    installBackend({
+      retrieveConversation: conversationsRetrieve,
+      listConversationMessages: conversationsList,
+    });
+
+    const { output, result } = await captureDebugOutput(() =>
+      getResumeDataFromBackend(makeAgent(), "conv-new"),
+    );
+
+    expect(result.pendingApprovals).toEqual([]);
+    expect(result.messageHistory).toEqual([]);
+    expect(output).not.toContain("Backfill scan found 0 assistant messages");
+  });
+
+  test("warns about missing assistant messages after a full backfill scan", async () => {
+    const conversationsRetrieve = mock(async () => ({
+      in_context_message_ids: ["msg-49"],
+    }));
+    const conversationsList = mock(async () => ({
+      getPaginatedItems: () =>
+        Array.from({ length: 50 }, (_, index) =>
+          makeUserMessage(`msg-${index}`),
+        ),
+    }));
+
+    installBackend({
+      retrieveConversation: conversationsRetrieve,
+      listConversationMessages: conversationsList,
+    });
+
+    const { output } = await captureDebugOutput(() =>
+      getResumeDataFromBackend(makeAgent(), "conv-full"),
+    );
+
+    expect(output).toContain(
+      "Backfill scan found 0 assistant messages in last 50 messages",
+    );
   });
 
   test("uses resume tail for pending approval without retrieving last message when source variants are complete", async () => {

--- a/src/agent/check-approval.ts
+++ b/src/agent/check-approval.ts
@@ -364,7 +364,10 @@ function sortChronological(messages: Message[]): Message[] {
   });
 }
 
-function collectResumeTailMessages(tailMessages: Message[]): Message[] {
+function collectResumeTailMessages(
+  tailMessages: Message[],
+  options: { warnIfMissingAssistant?: boolean } = {},
+): Message[] {
   const seen = new Set<string>();
   let assistantCount = 0;
   const collected: Message[] = [];
@@ -386,7 +389,10 @@ function collectResumeTailMessages(tailMessages: Message[]): Message[] {
     if (m.message_type === "assistant_message") assistantCount += 1;
   }
 
-  if (assistantCount < BACKFILL_MIN_ASSISTANT) {
+  if (
+    options.warnIfMissingAssistant &&
+    assistantCount < BACKFILL_MIN_ASSISTANT
+  ) {
     debugWarn(
       "check-approval",
       `Backfill scan found 0 assistant messages in last ${collected.length} messages (tool-heavy conversation?)`,
@@ -412,9 +418,14 @@ async function fetchResumeTail(
       includeReturnMessageTypes: RESUME_BACKFILL_MESSAGE_TYPES,
     },
   );
+  const warnIfMissingAssistant =
+    limit >= BACKFILL_PAGE_LIMIT && tail.messages.length >= limit;
+
   return {
     conversation: tail.conversation,
-    messages: collectResumeTailMessages(tail.messages),
+    messages: collectResumeTailMessages(tail.messages, {
+      warnIfMissingAssistant,
+    }),
   };
 }
 


### PR DESCRIPTION
## Summary
- only emit the missing-assistant backfill warning when the backfill fetch filled the page limit
- keep the tool-heavy/truncated-tail diagnostic for full scans
- add regression coverage for empty new conversations and full no-assistant scans

## Tests
- bun test src/agent/check-approval-resume-data.test.ts
- git diff --check
- bun run typecheck (fails on existing provider/model typing errors in src/backend/dev/pi-provider-registry.ts and src/backend/local-backend.test.ts)