### PR TITLE
fix(cli): label Fable xhigh reasoning distinctly

### DIFF
--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -700,9 +700,7 @@ describe("local backend pi transcript", () => {
     const fable = (await listLocalModels(storageDir)).find(
       (model) => model.handle === "anthropic/claude-fable-5",
     );
-    expect(fable?.max_context_window).toBe(
-      getModel("anthropic", "claude-fable-5")?.contextWindow,
-    );
+    expect(fable?.max_context_window).toBe(1_000_000);
   });
 
   test("lists pi catalog context windows for configured OpenRouter models", async () => {

--- a/src/cli/app/use-configuration-handlers.ts
+++ b/src/cli/app/use-configuration-handlers.ts
@@ -299,7 +299,9 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
           | undefined;
         const rawReasoningEffort = modelUpdateArgs?.reasoning_effort;
         const usesDistinctXHighLabel =
-          model.label.includes("Opus 4.7") || model.label.includes("Opus 4.8");
+          model.label.includes("Fable 5") ||
+          model.label.includes("Opus 4.7") ||
+          model.label.includes("Opus 4.8");
         const reasoningLevel =
           typeof rawReasoningEffort === "string"
             ? rawReasoningEffort === "none"

--- a/src/websocket/listen-model-update.test.ts
+++ b/src/websocket/listen-model-update.test.ts
@@ -133,8 +133,8 @@ describe("listen-client model update status message", () => {
     expect(result.message).toBe("Model updated to Opus 4.6 (Max).");
   });
 
-  test("shows Extra-High for reasoning_effort xhigh on Opus 4.7+", () => {
-    for (const modelLabel of ["Opus 4.7", "Opus 4.8"]) {
+  test("shows Extra-High for reasoning_effort xhigh on Fable and Opus 4.7+", () => {
+    for (const modelLabel of ["Fable 5", "Opus 4.7", "Opus 4.8"]) {
       const result = __listenClientTestUtils.buildModelUpdateStatusMessage({
         modelLabel,
         toolsetChanged: false,

--- a/src/websocket/listener/commands/model-toolset.ts
+++ b/src/websocket/listener/commands/model-toolset.ts
@@ -233,7 +233,9 @@ function formatEffortSuffix(
   const effort = updateArgs.reasoning_effort;
   if (typeof effort !== "string" || effort.length === 0) return "";
   const xhighLabel =
-    modelLabel.includes("Opus 4.7") || modelLabel.includes("Opus 4.8")
+    modelLabel.includes("Fable 5") ||
+    modelLabel.includes("Opus 4.7") ||
+    modelLabel.includes("Opus 4.8")
       ? "Extra-High"
       : "Max";
   const labels: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Show Fable 5 `xhigh` reasoning as Extra-High instead of Max in model/status UI paths.
- Keep older Anthropic `xhigh` compatibility labeling as Max for models without a distinct max tier.
- Avoid stale pi-ai provider typings in the Fable local catalog context-window test.

## Test plan
- `bun test src/websocket/listen-model-update.test.ts`
- `bun run check`
