### PR TITLE
fix(local): pass reasoning to compaction summarizer for adaptive-thinking models

### DIFF
--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -1,4 +1,4 @@
-import type { Api, Model } from "@earendil-works/pi-ai";
+import type { Api, Model, ThinkingLevel } from "@earendil-works/pi-ai";
 import { getModel, getModels } from "@earendil-works/pi-ai";
 import {
   getOAuthProvider,
@@ -14,6 +14,7 @@ import {
   type LocalProviderTimeout,
   resolveLocalProviderTimeout,
 } from "@/backend/local/local-provider-timeout";
+import { isRecord } from "@/utils/type-guards";
 import {
   getRegisteredPiProvider,
   type PiProviderModelRegistration,
@@ -49,6 +50,44 @@ export function isUnselectedLocalModelHandle(model: unknown): boolean {
     model === "auto" ||
     model === UNSELECTED_LOCAL_MODEL_HANDLE ||
     model.startsWith("letta/")
+  );
+}
+
+function settingString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function thinkingLevelSetting(value: unknown): ThinkingLevel | undefined {
+  const effort = settingString(value);
+  if (effort === "max") return "xhigh";
+  return effort === "minimal" ||
+    effort === "low" ||
+    effort === "medium" ||
+    effort === "high" ||
+    effort === "xhigh"
+    ? effort
+    : undefined;
+}
+
+// Maps Letta model settings to a pi-ai ThinkingLevel. Every pi-ai Anthropic
+// call against a reasoning-capable model must pass this when available:
+// pi-ai sends `thinking: {type: "disabled"}` for reasoning models when
+// `options.reasoning` is absent, and adaptive-thinking models (for example
+// claude-fable-5) reject that with a 400 invalid_request_error.
+export function reasoningForSettings(
+  modelSettings: Record<string, unknown>,
+): ThinkingLevel | undefined {
+  const thinking = isRecord(modelSettings.thinking)
+    ? modelSettings.thinking
+    : undefined;
+  if (thinking?.type === "disabled") return undefined;
+  const nestedReasoning = isRecord(modelSettings.reasoning)
+    ? modelSettings.reasoning
+    : undefined;
+  return (
+    thinkingLevelSetting(nestedReasoning?.reasoning_effort) ??
+    thinkingLevelSetting(modelSettings.effort) ??
+    thinkingLevelSetting(modelSettings.reasoning_effort)
   );
 }
 

--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -8,7 +8,6 @@ import {
   type SimpleStreamOptions,
   stream,
   streamSimple,
-  type ThinkingLevel,
   type Tool,
   type TSchema,
   Type,
@@ -32,6 +31,7 @@ import {
 } from "./local-provider-errors";
 import {
   applyPiEnvOverrides,
+  reasoningForSettings,
   resolvePiModelForAgent,
 } from "./pi-model-factory";
 import type {
@@ -363,35 +363,6 @@ function boolValue(value: unknown): boolean | undefined {
   return typeof value === "boolean" ? value : undefined;
 }
 
-function thinkingLevel(value: unknown): ThinkingLevel | undefined {
-  const effort = stringValue(value);
-  if (effort === "max") return "xhigh";
-  return effort === "minimal" ||
-    effort === "low" ||
-    effort === "medium" ||
-    effort === "high" ||
-    effort === "xhigh"
-    ? effort
-    : undefined;
-}
-
-function reasoningForSettings(
-  modelSettings: Record<string, unknown>,
-): ThinkingLevel | undefined {
-  const thinking = isRecord(modelSettings.thinking)
-    ? modelSettings.thinking
-    : undefined;
-  if (thinking?.type === "disabled") return undefined;
-  const nestedReasoning = isRecord(modelSettings.reasoning)
-    ? modelSettings.reasoning
-    : undefined;
-  return (
-    thinkingLevel(nestedReasoning?.reasoning_effort) ??
-    thinkingLevel(modelSettings.effort) ??
-    thinkingLevel(modelSettings.reasoning_effort)
-  );
-}
-
 function anthropicEffortForSettings(
   modelSettings: Record<string, unknown>,
 ): string | undefined {
@@ -706,10 +677,19 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
           contextOverflowCompactions < LOCAL_CONTEXT_OVERFLOW_MAX_COMPACTIONS &&
           isOversizedPayloadTransportFailure(activeInput)
         ) {
-          const compaction = await this.onContextWindowOverflow(
-            activeInput,
-            error,
-          );
+          // Unlike the provider-reported overflow branch above, the original
+          // error here is retryable. If compaction itself fails (for example
+          // the summarizer model call errors), fall back to the normal
+          // transient retry path instead of replacing a retryable transport
+          // error with a non-retryable compaction error.
+          let compaction: Awaited<
+            ReturnType<NonNullable<typeof this.onContextWindowOverflow>>
+          > = null;
+          try {
+            compaction = await this.onContextWindowOverflow(activeInput, error);
+          } catch {
+            compaction = null;
+          }
           if (compaction) {
             contextOverflowCompactions += 1;
             activeInput = { ...activeInput, uiMessages: compaction.uiMessages };

--- a/src/backend/local/compaction.test.ts
+++ b/src/backend/local/compaction.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  AssistantMessage,
+  SimpleStreamOptions,
+} from "@earendil-works/pi-ai";
+import { createOrUpdateLocalProvider } from "@/backend/local/local-provider-auth-store";
+import { summarizeLocalMessagesAll } from "./compaction";
+import { emptyLocalUsage, type LocalMessage } from "./local-message";
+
+function summaryAssistantMessage(): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text: "summary of prior work" }],
+    api: "anthropic-messages",
+    provider: "anthropic",
+    model: "claude-fable-5",
+    usage: emptyLocalUsage(),
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+}
+
+describe("local compaction summarizer options", () => {
+  test("passes settings-derived reasoning to the summarization request", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-compaction-"));
+    try {
+      await createOrUpdateLocalProvider({
+        storageDir,
+        providerType: "anthropic",
+        providerName: "lc-anthropic",
+        apiKey: "secret-key",
+      });
+
+      const messages: LocalMessage[] = [
+        {
+          id: "ui-msg-1",
+          role: "user",
+          content: "please summarize this conversation",
+          timestamp: Date.now(),
+        },
+      ];
+
+      let capturedOptions:
+        | (SimpleStreamOptions & Record<string, unknown>)
+        | undefined;
+      const summary = await summarizeLocalMessagesAll({
+        agent: {
+          id: "agent-local-1",
+          name: "Local",
+          description: null,
+          system: "",
+          tags: [],
+          model: "anthropic/claude-fable-5",
+          model_settings: {
+            provider_type: "anthropic",
+            effort: "max",
+            thinking: { type: "enabled" },
+          },
+        },
+        messages,
+        localProviderAuthStorageDir: storageDir,
+        complete: async (_model, _context, options) => {
+          capturedOptions = options;
+          return summaryAssistantMessage();
+        },
+      });
+
+      expect(summary).toBe("summary of prior work");
+      // Pi parity (createSummarizationOptions): summarization requests carry
+      // the session thinking level. Without options.reasoning, pi-ai sends
+      // `thinking: {type: "disabled"}`, which adaptive-thinking Anthropic
+      // models (claude-fable-5) reject with a 400 invalid_request_error.
+      expect(capturedOptions?.reasoning).toBe("xhigh");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("omits reasoning when model settings disable thinking", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-compaction-"));
+    try {
+      await createOrUpdateLocalProvider({
+        storageDir,
+        providerType: "anthropic",
+        providerName: "lc-anthropic",
+        apiKey: "secret-key",
+      });
+
+      let capturedOptions:
+        | (SimpleStreamOptions & Record<string, unknown>)
+        | undefined;
+      await summarizeLocalMessagesAll({
+        agent: {
+          id: "agent-local-1",
+          name: "Local",
+          description: null,
+          system: "",
+          tags: [],
+          model: "anthropic/claude-sonnet-4-6",
+          model_settings: {
+            provider_type: "anthropic",
+            thinking: { type: "disabled" },
+          },
+        },
+        messages: [
+          {
+            id: "ui-msg-1",
+            role: "user",
+            content: "please summarize this conversation",
+            timestamp: Date.now(),
+          },
+        ],
+        localProviderAuthStorageDir: storageDir,
+        complete: async (_model, _context, options) => {
+          capturedOptions = options;
+          return summaryAssistantMessage();
+        },
+      });
+
+      expect(capturedOptions?.reasoning).toBeUndefined();
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/backend/local/compaction.ts
+++ b/src/backend/local/compaction.ts
@@ -10,6 +10,7 @@ import {
 import { isContextWindowOverflowError } from "@/backend/dev/context-window-overflow";
 import {
   applyPiEnvOverrides,
+  reasoningForSettings,
   resolvePiModelForAgent,
 } from "@/backend/dev/pi-model-factory";
 import { estimateLocalMessagesTokens } from "@/backend/local/local-context-estimate";
@@ -386,12 +387,20 @@ async function runGenerateText(
     systemPrompt,
     messages: [{ role: "user", content: transcript, timestamp: Date.now() }],
   };
+  const reasoning = reasoningForSettings(localModel.modelSettings);
   const options: SimpleStreamOptions & Record<string, unknown> = {
     ...resolved.providerOptions,
     ...(resolved.apiKey ? { apiKey: resolved.apiKey } : {}),
     ...(resolved.timeout !== false ? { timeoutMs: resolved.timeout } : {}),
     ...(resolved.headers ? { headers: resolved.headers } : {}),
     ...(input.abortSignal ? { signal: input.abortSignal } : {}),
+    // Mirrors Pi's createSummarizationOptions, which passes the session
+    // thinking level into summarization requests. Required for adaptive
+    // thinking Anthropic models (for example claude-fable-5): without
+    // options.reasoning, pi-ai sends `thinking: {type: "disabled"}`, which
+    // those models reject with a 400 invalid_request_error — breaking every
+    // compaction (automatic and manual /compact).
+    ...(reasoning ? { reasoning } : {}),
     maxRetries: 0,
   };
   const restoreEnv = applyPiEnvOverrides(resolved.envOverrides);

--- a/src/backend/pi-stream-adapter.test.ts
+++ b/src/backend/pi-stream-adapter.test.ts
@@ -245,6 +245,71 @@ describe("PiStreamAdapter", () => {
     expect(events.some((event) => event.type === "local-message")).toBe(true);
   });
 
+  test("falls back to transient retry when oversized-payload compaction fails", async () => {
+    let providerCalls = 0;
+    const stream: PiStreamFunction = () => {
+      providerCalls += 1;
+      if (providerCalls === 1) {
+        const error = assistantErrorMessage(
+          "WebSocket closed 1006 Connection ended\nretry-after-ms: 0",
+        );
+        return streamFromEvents(
+          [{ type: "error", reason: "error", error }],
+          error,
+        );
+      }
+      const finalMessage = assistantMessage();
+      return streamFromEvents(
+        [{ type: "done", reason: "stop", message: finalMessage }],
+        finalMessage,
+      );
+    };
+
+    const adapter = new PiStreamAdapter({
+      stream,
+      onContextWindowOverflow: async () => {
+        // Simulates a summarizer failure (for example the summarization model
+        // call being rejected by the provider).
+        throw new Error("Local compaction failed");
+      },
+    });
+    const baseInput = input();
+    const events = await collectEvents(
+      adapter.stream({
+        ...baseInput,
+        uiMessages: [
+          {
+            id: "ui-msg-large-image",
+            role: "user",
+            content: [
+              {
+                type: "image",
+                mimeType: "image/png",
+                data: "a".repeat(8_000_001),
+              },
+            ],
+            timestamp: Date.now(),
+          },
+        ],
+      }),
+    );
+
+    // The retryable transport error must win over the compaction failure:
+    // the turn retries and completes instead of surfacing the summarizer
+    // error as a non-retryable run failure.
+    expect(providerCalls).toBe(2);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "letta-chunk",
+        chunk: expect.objectContaining({
+          message_type: "event_message",
+          event_type: "retry",
+        }),
+      }),
+    );
+    expect(events.some((event) => event.type === "local-message")).toBe(true);
+  });
+
   test("removes OpenAI Responses replay item IDs before provider submission", async () => {
     let sanitizedPayload: unknown;
     const stream: PiStreamFunction = (


### PR DESCRIPTION
## Summary

- The local compaction summarizer (`runGenerateText` in `compaction.ts`) called pi-ai without `options.reasoning`. pi-ai's Anthropic provider sends `thinking: {type: "disabled"}` for reasoning-capable models when `options.reasoning` is absent, and adaptive-thinking models (`claude-fable-5`, `compat.forceAdaptiveThinking`) reject that with `400 invalid_request_error: "thinking.type.disabled" is not supported for this model`. This broke **every** local compaction on those models — automatic (overflow / oversized-payload recovery from #2824) and manual `/compact` alike.
- Fix mirrors Pi's `createSummarizationOptions`, which passes the session thinking level into summarization requests: `reasoningForSettings` moves to `pi-model-factory` and the summarizer now passes settings-derived reasoning (e.g. `effort: "high"` → adaptive thinking + effort, which the same models already accept on normal turns).
- Resilience: when oversized-payload compaction (#2824) fails, fall back to the normal transient retry path instead of replacing a *retryable* transport error with a *non-retryable* compaction error.

## Field report (how this surfaced)

On an image-heavy local conversation (11.8MB payload, ~412k context tokens on a 1M-window model):

1. Turn upload failed with a generic transport error (`Connection error.`) — same class as the incident in #2824 (an identical request had succeeded two turns earlier; transport at this payload size is flaky, not deterministic).
2. The #2824 oversized-payload classifier correctly routed the failure into compaction.
3. The summarizer called Fable 5 without `reasoning` → pi-ai sent `thinking: {type: "disabled"}` → Anthropic 400.
4. The summarizer error propagated out of `onContextWindowOverflow`, replacing the retryable transport error, and the run died as a non-retryable `local_backend_error` showing the confusing thinking-config message.

Normal turns were never affected (the stream adapter already passes `reasoningForSettings(...)`); the bug was latent in the summarizer and only reachable once compaction actually ran on an adaptive-thinking model.

## Notes

- Pi parity: Pi's summarizer passes `options.reasoning = thinkingLevel` when the model supports reasoning (`createSummarizationOptions` in `packages/coding-agent/src/core/compaction/compaction.ts`), so passing reasoning here is parity, not divergence. The underlying pi-ai behavior (explicit `disabled` for adaptive models) also exists upstream; Pi avoids it the same way.
- `thinking: {type: "disabled"}` in model settings still correctly omits reasoning (covered by a test); that combination is rejected by adaptive-only models at the provider level regardless of client.

## Validation

- New tests: summarizer passes settings-derived reasoning (`effort: "max"` → `"xhigh"`); summarizer omits reasoning when settings disable thinking; oversized-payload compaction failure falls back to transient retry and the turn completes
- `bun run check` (9/9); suites for `pi-stream-adapter`, `compaction`, `local-context-estimate`, `local-backend`, `pi-model-factory`, `provider-turn-executor`, `message-search`, `local-compaction-parity` all green

👾 Generated with [Letta Code](https://letta.com)