### PR TITLE
feat(app-server): add agent conversation management commands

### DIFF
--- a/src/types/app-server-protocol.test.ts
+++ b/src/types/app-server-protocol.test.ts
@@ -50,6 +50,18 @@ describe("app-server protocol export", () => {
         success: true,
         reflection_settings: null,
       },
+      {
+        type: "agent_list_response",
+        request_id: "req",
+        success: true,
+        agents: [],
+      },
+      {
+        type: "conversation_list_response",
+        request_id: "req",
+        success: true,
+        conversations: [],
+      },
     ] satisfies WsProtocolMessage[];
 
     expect(messages.map((message) => message.type)).toEqual([
@@ -61,6 +73,8 @@ describe("app-server protocol export", () => {
       "terminal_output",
       "search_branches_response",
       "get_reflection_settings_response",
+      "agent_list_response",
+      "conversation_list_response",
     ]);
   });
 });

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -6,8 +6,18 @@
  * from the legacy protocol.ts surface.
  */
 
-import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
+import type {
+  AgentCreateParams,
+  AgentListParams,
+  AgentState,
+  MessageCreate,
+} from "@letta-ai/letta-client/resources/agents/agents";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
+import type {
+  Conversation,
+  ConversationCreateParams,
+  ConversationListParams,
+} from "@letta-ai/letta-client/resources/conversations/conversations";
 import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs";
 
 export type DmPolicy = "pairing" | "allowlist" | "open";
@@ -1541,6 +1551,52 @@ export interface CreateAgentCommand {
   pin_global?: boolean;
 }
 
+export interface AgentListCommand {
+  type: "agent_list";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  /** Query params forwarded to the Letta agents list API. */
+  query?: AgentListParams;
+}
+
+export interface AgentRetrieveCommand {
+  type: "agent_retrieve";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  agent_id: string;
+}
+
+export interface AgentCreateCommand {
+  type: "agent_create";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  /** Body forwarded to the Letta agents create API. */
+  body: AgentCreateParams;
+}
+
+export interface ConversationListCommand {
+  type: "conversation_list";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  /** Query params forwarded to the Letta conversations list API. */
+  query?: ConversationListParams;
+}
+
+export interface ConversationRetrieveCommand {
+  type: "conversation_retrieve";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  conversation_id: string;
+}
+
+export interface ConversationCreateCommand {
+  type: "conversation_create";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  /** Body forwarded to the Letta conversations create API. */
+  body: ConversationCreateParams;
+}
+
 export interface GetCwdMapCommand {
   type: "get_cwd_map";
   /** Echoed back in the response for request correlation. */
@@ -1870,6 +1926,54 @@ export interface CreateAgentResponseMessage {
   agent_id?: string;
   name?: string;
   model?: string;
+  error?: string;
+}
+
+export interface AgentListResponseMessage {
+  type: "agent_list_response";
+  request_id: string;
+  success: boolean;
+  agents: AgentState[];
+  error?: string;
+}
+
+export interface AgentRetrieveResponseMessage {
+  type: "agent_retrieve_response";
+  request_id: string;
+  success: boolean;
+  agent: AgentState | null;
+  error?: string;
+}
+
+export interface AgentCreateResponseMessage {
+  type: "agent_create_response";
+  request_id: string;
+  success: boolean;
+  agent: AgentState | null;
+  error?: string;
+}
+
+export interface ConversationListResponseMessage {
+  type: "conversation_list_response";
+  request_id: string;
+  success: boolean;
+  conversations: Conversation[];
+  error?: string;
+}
+
+export interface ConversationRetrieveResponseMessage {
+  type: "conversation_retrieve_response";
+  request_id: string;
+  success: boolean;
+  conversation: Conversation | null;
+  error?: string;
+}
+
+export interface ConversationCreateResponseMessage {
+  type: "conversation_create_response";
+  request_id: string;
+  success: boolean;
+  conversation: Conversation | null;
   error?: string;
 }
 
@@ -2318,6 +2422,12 @@ export type WsProtocolCommand =
   | SkillEnableCommand
   | SkillDisableCommand
   | CreateAgentCommand
+  | AgentListCommand
+  | AgentRetrieveCommand
+  | AgentCreateCommand
+  | ConversationListCommand
+  | ConversationRetrieveCommand
+  | ConversationCreateCommand
   | GetCwdMapCommand
   | ListConversationPinsCommand
   | SetConversationPinCommand
@@ -2400,6 +2510,12 @@ export type WsProtocolMessage =
   | SkillDisableResponseMessage
   | SkillsUpdatedMessage
   | CreateAgentResponseMessage
+  | AgentListResponseMessage
+  | AgentRetrieveResponseMessage
+  | AgentCreateResponseMessage
+  | ConversationListResponseMessage
+  | ConversationRetrieveResponseMessage
+  | ConversationCreateResponseMessage
   | GetExperimentsResponseMessage
   | SetExperimentResponseMessage
   | ListConversationPinsResponseMessage

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -289,6 +289,157 @@ describe("listen-client parseServerMessage", () => {
     });
   });
 
+  describe("listen-client agent/conversation management command handling", () => {
+    test("lists, retrieves, and creates agents and conversations", async () => {
+      const storageDir = await mkdtemp(join(os.tmpdir(), "ws-management-"));
+      try {
+        const backend = new LocalBackend({
+          storageDir,
+          executionMode: "deterministic",
+        });
+        __testSetBackend(backend);
+        const socket = new MockSocket(WebSocket.OPEN);
+
+        await __listenClientTestUtils.handleAgentConversationManagementCommand(
+          {
+            type: "agent_create",
+            request_id: "agent-create-1",
+            body: {
+              name: "WS Managed Agent",
+              model: "anthropic/claude-sonnet-4-6",
+            } as AgentCreateBody,
+          },
+          socket as unknown as WebSocket,
+        );
+
+        const agentCreateResponse = JSON.parse(
+          socket.sentPayloads.at(-1) ?? "{}",
+        );
+        expect(agentCreateResponse).toMatchObject({
+          type: "agent_create_response",
+          request_id: "agent-create-1",
+          success: true,
+          agent: {
+            name: "WS Managed Agent",
+          },
+        });
+        const agentId = agentCreateResponse.agent.id as string;
+
+        await __listenClientTestUtils.handleAgentConversationManagementCommand(
+          {
+            type: "agent_list",
+            request_id: "agent-list-1",
+            query: { limit: 10 },
+          },
+          socket as unknown as WebSocket,
+        );
+        expect(JSON.parse(socket.sentPayloads.at(-1) ?? "{}")).toMatchObject({
+          type: "agent_list_response",
+          request_id: "agent-list-1",
+          success: true,
+          agents: [expect.objectContaining({ id: agentId })],
+        });
+
+        await __listenClientTestUtils.handleAgentConversationManagementCommand(
+          {
+            type: "agent_retrieve",
+            request_id: "agent-retrieve-1",
+            agent_id: agentId,
+          },
+          socket as unknown as WebSocket,
+        );
+        expect(JSON.parse(socket.sentPayloads.at(-1) ?? "{}")).toMatchObject({
+          type: "agent_retrieve_response",
+          request_id: "agent-retrieve-1",
+          success: true,
+          agent: { id: agentId },
+        });
+
+        await __listenClientTestUtils.handleAgentConversationManagementCommand(
+          {
+            type: "conversation_create",
+            request_id: "conversation-create-1",
+            body: { agent_id: agentId },
+          },
+          socket as unknown as WebSocket,
+        );
+        const conversationCreateResponse = JSON.parse(
+          socket.sentPayloads.at(-1) ?? "{}",
+        );
+        expect(conversationCreateResponse).toMatchObject({
+          type: "conversation_create_response",
+          request_id: "conversation-create-1",
+          success: true,
+          conversation: { agent_id: agentId },
+        });
+        const conversationId = conversationCreateResponse.conversation
+          .id as string;
+
+        await __listenClientTestUtils.handleAgentConversationManagementCommand(
+          {
+            type: "conversation_list",
+            request_id: "conversation-list-1",
+            query: { agent_id: agentId, limit: 10 },
+          },
+          socket as unknown as WebSocket,
+        );
+        expect(JSON.parse(socket.sentPayloads.at(-1) ?? "{}")).toMatchObject({
+          type: "conversation_list_response",
+          request_id: "conversation-list-1",
+          success: true,
+          conversations: [expect.objectContaining({ id: conversationId })],
+        });
+
+        await __listenClientTestUtils.handleAgentConversationManagementCommand(
+          {
+            type: "conversation_retrieve",
+            request_id: "conversation-retrieve-1",
+            conversation_id: conversationId,
+          },
+          socket as unknown as WebSocket,
+        );
+        expect(JSON.parse(socket.sentPayloads.at(-1) ?? "{}")).toMatchObject({
+          type: "conversation_retrieve_response",
+          request_id: "conversation-retrieve-1",
+          success: true,
+          conversation: { id: conversationId },
+        });
+      } finally {
+        await rm(storageDir, { recursive: true, force: true });
+      }
+    });
+
+    test("soft-fails management command backend errors", async () => {
+      const storageDir = await mkdtemp(
+        join(os.tmpdir(), "ws-management-error-"),
+      );
+      try {
+        __testSetBackend(
+          new LocalBackend({ storageDir, executionMode: "deterministic" }),
+        );
+        const socket = new MockSocket(WebSocket.OPEN);
+
+        await __listenClientTestUtils.handleAgentConversationManagementCommand(
+          {
+            type: "agent_retrieve",
+            request_id: "agent-retrieve-missing",
+            agent_id: "agent-missing",
+          },
+          socket as unknown as WebSocket,
+        );
+
+        expect(JSON.parse(socket.sentPayloads.at(-1) ?? "{}")).toMatchObject({
+          type: "agent_retrieve_response",
+          request_id: "agent-retrieve-missing",
+          success: false,
+          agent: null,
+        });
+      } finally {
+        await rm(storageDir, { recursive: true, force: true });
+      }
+    });
+  });
+
   test("classifies invalid input approval_response payloads", () => {
     const missingResponse = parseServerMessage(
       Buffer.from(

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -11,6 +11,10 @@ import {
   resolveRecoveryBatchId,
 } from "./approval";
 import {
+  handleAgentConversationManagementCommand,
+  handleAgentConversationManagementProtocolCommand,
+} from "./commands/agents-conversations";
+import {
   handleChannelRegistryEvent,
   handleChannelsProtocolCommand,
   isDetachedChannelsCommand,
@@ -506,6 +510,21 @@ export const __listenClientTestUtils = {
     socket: Parameters<typeof handleChannelRegistryEvent>[1],
     runtime: ListenerRuntime,
   ) => handleChannelRegistryEvent(event, socket, runtime, safeSocketSend),
+  handleAgentConversationManagementCommand: (
+    parsed: Parameters<typeof handleAgentConversationManagementCommand>[0],
+    socket: WebSocket,
+  ) => handleAgentConversationManagementCommand(parsed, socket, safeSocketSend),
+  handleAgentConversationManagementProtocolCommand: (
+    parsed: Parameters<
+      typeof handleAgentConversationManagementProtocolCommand
+    >[0],
+    socket: WebSocket,
+  ) =>
+    handleAgentConversationManagementProtocolCommand(parsed, {
+      socket,
+      safeSocketSend,
+      runDetachedListenerTask,
+    }),
   handleSkillCommand: (
     parsed: Parameters<typeof handleSkillCommand>[0],
     socket: WebSocket,

--- a/src/websocket/listener/commands/agents-conversations.ts
+++ b/src/websocket/listener/commands/agents-conversations.ts
@@ -1,0 +1,282 @@
+import type WebSocket from "ws";
+import { getBackend } from "@/backend";
+import type {
+  AgentCreateCommand,
+  AgentListCommand,
+  AgentRetrieveCommand,
+  ConversationCreateCommand,
+  ConversationListCommand,
+  ConversationRetrieveCommand,
+} from "@/types/protocol_v2";
+import {
+  isAgentCreateCommand,
+  isAgentListCommand,
+  isAgentRetrieveCommand,
+  isConversationCreateCommand,
+  isConversationListCommand,
+  isConversationRetrieveCommand,
+} from "@/websocket/listener/protocol-inbound";
+import type { RunDetachedListenerTask, SafeSocketSend } from "./types";
+
+export type AgentConversationManagementCommand =
+  | AgentListCommand
+  | AgentRetrieveCommand
+  | AgentCreateCommand
+  | ConversationListCommand
+  | ConversationRetrieveCommand
+  | ConversationCreateCommand;
+
+type AgentConversationManagementCommandContext = {
+  socket: WebSocket;
+  safeSocketSend: SafeSocketSend;
+  runDetachedListenerTask: RunDetachedListenerTask;
+};
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+function getPageItems<T>(page: unknown): T[] {
+  if (Array.isArray(page)) return page as T[];
+  if (page && typeof page === "object") {
+    const candidate = page as {
+      getPaginatedItems?: () => T[];
+      items?: T[];
+    };
+    if (typeof candidate.getPaginatedItems === "function") {
+      return candidate.getPaginatedItems();
+    }
+    if (Array.isArray(candidate.items)) {
+      return candidate.items;
+    }
+  }
+  return [];
+}
+
+export async function handleAgentConversationManagementCommand(
+  parsed: AgentConversationManagementCommand,
+  socket: WebSocket,
+  safeSocketSend: SafeSocketSend,
+): Promise<boolean> {
+  const backend = getBackend();
+
+  if (parsed.type === "agent_list") {
+    try {
+      const page = await backend.listAgents(parsed.query);
+      safeSocketSend(
+        socket,
+        {
+          type: "agent_list_response",
+          request_id: parsed.request_id,
+          success: true,
+          agents: getPageItems(page),
+        },
+        "listener_agent_management_send_failed",
+        "listener_agent_management",
+      );
+    } catch (error) {
+      safeSocketSend(
+        socket,
+        {
+          type: "agent_list_response",
+          request_id: parsed.request_id,
+          success: false,
+          agents: [],
+          error: getErrorMessage(error, "Failed to list agents"),
+        },
+        "listener_agent_management_send_failed",
+        "listener_agent_management",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "agent_retrieve") {
+    try {
+      const agent = await backend.retrieveAgent(parsed.agent_id);
+      safeSocketSend(
+        socket,
+        {
+          type: "agent_retrieve_response",
+          request_id: parsed.request_id,
+          success: true,
+          agent,
+        },
+        "listener_agent_management_send_failed",
+        "listener_agent_management",
+      );
+    } catch (error) {
+      safeSocketSend(
+        socket,
+        {
+          type: "agent_retrieve_response",
+          request_id: parsed.request_id,
+          success: false,
+          agent: null,
+          error: getErrorMessage(error, "Failed to retrieve agent"),
+        },
+        "listener_agent_management_send_failed",
+        "listener_agent_management",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "agent_create") {
+    try {
+      const agent = await backend.createAgent(parsed.body);
+      safeSocketSend(
+        socket,
+        {
+          type: "agent_create_response",
+          request_id: parsed.request_id,
+          success: true,
+          agent,
+        },
+        "listener_agent_management_send_failed",
+        "listener_agent_management",
+      );
+    } catch (error) {
+      safeSocketSend(
+        socket,
+        {
+          type: "agent_create_response",
+          request_id: parsed.request_id,
+          success: false,
+          agent: null,
+          error: getErrorMessage(error, "Failed to create agent"),
+        },
+        "listener_agent_management_send_failed",
+        "listener_agent_management",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "conversation_list") {
+    try {
+      const page = await backend.listConversations(parsed.query);
+      safeSocketSend(
+        socket,
+        {
+          type: "conversation_list_response",
+          request_id: parsed.request_id,
+          success: true,
+          conversations: getPageItems(page),
+        },
+        "listener_conversation_management_send_failed",
+        "listener_conversation_management",
+      );
+    } catch (error) {
+      safeSocketSend(
+        socket,
+        {
+          type: "conversation_list_response",
+          request_id: parsed.request_id,
+          success: false,
+          conversations: [],
+          error: getErrorMessage(error, "Failed to list conversations"),
+        },
+        "listener_conversation_management_send_failed",
+        "listener_conversation_management",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "conversation_retrieve") {
+    try {
+      const conversation = await backend.retrieveConversation(
+        parsed.conversation_id,
+      );
+      safeSocketSend(
+        socket,
+        {
+          type: "conversation_retrieve_response",
+          request_id: parsed.request_id,
+          success: true,
+          conversation,
+        },
+        "listener_conversation_management_send_failed",
+        "listener_conversation_management",
+      );
+    } catch (error) {
+      safeSocketSend(
+        socket,
+        {
+          type: "conversation_retrieve_response",
+          request_id: parsed.request_id,
+          success: false,
+          conversation: null,
+          error: getErrorMessage(error, "Failed to retrieve conversation"),
+        },
+        "listener_conversation_management_send_failed",
+        "listener_conversation_management",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "conversation_create") {
+    try {
+      const conversation = await backend.createConversation(parsed.body);
+      safeSocketSend(
+        socket,
+        {
+          type: "conversation_create_response",
+          request_id: parsed.request_id,
+          success: true,
+          conversation,
+        },
+        "listener_conversation_management_send_failed",
+        "listener_conversation_management",
+      );
+    } catch (error) {
+      safeSocketSend(
+        socket,
+        {
+          type: "conversation_create_response",
+          request_id: parsed.request_id,
+          success: false,
+          conversation: null,
+          error: getErrorMessage(error, "Failed to create conversation"),
+        },
+        "listener_conversation_management_send_failed",
+        "listener_conversation_management",
+      );
+    }
+    return true;
+  }
+
+  return false;
+}
+
+export function handleAgentConversationManagementProtocolCommand(
+  parsed: unknown,
+  context: AgentConversationManagementCommandContext,
+): boolean {
+  const { socket, safeSocketSend, runDetachedListenerTask } = context;
+
+  if (
+    isAgentListCommand(parsed) ||
+    isAgentRetrieveCommand(parsed) ||
+    isAgentCreateCommand(parsed) ||
+    isConversationListCommand(parsed) ||
+    isConversationRetrieveCommand(parsed) ||
+    isConversationCreateCommand(parsed)
+  ) {
+    runDetachedListenerTask(
+      "agent_conversation_management_command",
+      async () => {
+        await handleAgentConversationManagementCommand(
+          parsed,
+          socket,
+          safeSocketSend,
+        );
+      },
+    );
+    return true;
+  }
+
+  return false;
+}

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -19,6 +19,7 @@ import {
   handleTerminalSpawn,
 } from "@/websocket/terminal-handler";
 import { handleExecuteCommand } from "./commands";
+import { handleAgentConversationManagementProtocolCommand } from "./commands/agents-conversations";
 import {
   handleChannelsProtocolCommand,
   isDetachedChannelsCommand,
@@ -507,6 +508,16 @@ export function createListenerMessageHandler(
 
       if (
         handleCronProtocolCommand(parsed, {
+          socket,
+          safeSocketSend,
+          runDetachedListenerTask,
+        })
+      ) {
+        return;
+      }
+
+      if (
+        handleAgentConversationManagementProtocolCommand(parsed, {
           socket,
           safeSocketSend,
           runDetachedListenerTask,

--- a/src/websocket/listener/protocol-inbound.test.ts
+++ b/src/websocket/listener/protocol-inbound.test.ts
@@ -20,6 +20,44 @@ describe("app-server protocol hard cut", () => {
   });
 });
 
+describe("agent/conversation management protocol-inbound validators", () => {
+  test.each([
+    { type: "agent_list", request_id: "r1", query: { limit: 10 } },
+    { type: "agent_retrieve", request_id: "r2", agent_id: "agent-1" },
+    { type: "agent_create", request_id: "r3", body: { name: "Agent" } },
+    {
+      type: "conversation_list",
+      request_id: "r4",
+      query: { agent_id: "agent-1", limit: 10 },
+    },
+    {
+      type: "conversation_retrieve",
+      request_id: "r5",
+      conversation_id: "conv-1",
+    },
+    {
+      type: "conversation_create",
+      request_id: "r6",
+      body: { agent_id: "agent-1" },
+    },
+  ])("accepts $type", (message) => {
+    const parsed = parseServerMessage(Buffer.from(JSON.stringify(message)));
+    expect(parsed).toEqual(message);
+  });
+
+  test.each([
+    { type: "agent_list", request_id: "r1", query: "bad" },
+    { type: "agent_retrieve", request_id: "r2" },
+    { type: "agent_create", request_id: "r3", body: null },
+    { type: "conversation_list", request_id: "r4", query: [] },
+    { type: "conversation_retrieve", request_id: "r5" },
+    { type: "conversation_create", request_id: "r6", body: "bad" },
+  ])("rejects invalid $type", (message) => {
+    const parsed = parseServerMessage(Buffer.from(JSON.stringify(message)));
+    expect(parsed).toBeNull();
+  });
+});
+
 describe("discord protocol-inbound validators", () => {
   test("valid discord account create passes", () => {
     const msg = {

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -4,6 +4,9 @@ import { isSupportedChannelId } from "@/channels/plugin-registry";
 import type { ExperimentId } from "@/experiments/types";
 import type {
   AbortMessageCommand,
+  AgentCreateCommand,
+  AgentListCommand,
+  AgentRetrieveCommand,
   ChangeDeviceStateCommand,
   ChannelAccountBindCommand,
   ChannelAccountCreateCommand,
@@ -27,6 +30,9 @@ import type {
   ChannelTargetsListCommand,
   CheckoutBranchCommand,
   ConnectProviderCommand,
+  ConversationCreateCommand,
+  ConversationListCommand,
+  ConversationRetrieveCommand,
   CreateAgentCommand,
   CronAddCommand,
   CronDeleteAllCommand,
@@ -114,6 +120,10 @@ function isStringRecord(value: unknown): value is Record<string, string> {
     !Array.isArray(value) &&
     Object.values(value).every((item) => typeof item === "string")
   );
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
 function isRuntimeScope(value: unknown): value is RuntimeScope {
@@ -1015,6 +1025,100 @@ export function isCreateAgentCommand(
   );
 }
 
+export function isAgentListCommand(value: unknown): value is AgentListCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    query?: unknown;
+  };
+  return (
+    c.type === "agent_list" &&
+    typeof c.request_id === "string" &&
+    (c.query === undefined || isObjectRecord(c.query))
+  );
+}
+
+export function isAgentRetrieveCommand(
+  value: unknown,
+): value is AgentRetrieveCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    agent_id?: unknown;
+  };
+  return (
+    c.type === "agent_retrieve" &&
+    typeof c.request_id === "string" &&
+    typeof c.agent_id === "string"
+  );
+}
+
+export function isAgentCreateCommand(
+  value: unknown,
+): value is AgentCreateCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    body?: unknown;
+  };
+  return (
+    c.type === "agent_create" &&
+    typeof c.request_id === "string" &&
+    isObjectRecord(c.body)
+  );
+}
+
+export function isConversationListCommand(
+  value: unknown,
+): value is ConversationListCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    query?: unknown;
+  };
+  return (
+    c.type === "conversation_list" &&
+    typeof c.request_id === "string" &&
+    (c.query === undefined || isObjectRecord(c.query))
+  );
+}
+
+export function isConversationRetrieveCommand(
+  value: unknown,
+): value is ConversationRetrieveCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    conversation_id?: unknown;
+  };
+  return (
+    c.type === "conversation_retrieve" &&
+    typeof c.request_id === "string" &&
+    typeof c.conversation_id === "string"
+  );
+}
+
+export function isConversationCreateCommand(
+  value: unknown,
+): value is ConversationCreateCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    body?: unknown;
+  };
+  return (
+    c.type === "conversation_create" &&
+    typeof c.request_id === "string" &&
+    isObjectRecord(c.body)
+  );
+}
+
 export function isListConversationPinsCommand(
   value: unknown,
 ): value is ListConversationPinsCommand {
@@ -1806,6 +1910,12 @@ export function parseServerMessage(
       isSkillEnableCommand(parsed) ||
       isSkillDisableCommand(parsed) ||
       isCreateAgentCommand(parsed) ||
+      isAgentListCommand(parsed) ||
+      isAgentRetrieveCommand(parsed) ||
+      isAgentCreateCommand(parsed) ||
+      isConversationListCommand(parsed) ||
+      isConversationRetrieveCommand(parsed) ||
+      isConversationCreateCommand(parsed) ||
       isGetCwdMapCommand(parsed) ||
       isGetExperimentsCommand(parsed) ||
       isSetExperimentCommand(parsed) ||


### PR DESCRIPTION
## Summary
- add v2 websocket commands for agent list/retrieve/create and conversation list/retrieve/create
- route the new commands through a backend-backed listener handler with soft-fail responses
- add parser, handler, and app-server protocol export coverage

## Testing
- `bun test src/types/app-server-protocol.test.ts src/websocket/listener/protocol-inbound.test.ts src/websocket/listen-client-protocol.test.ts --timeout 30000`
- `bun run lint`
- `bun run typecheck`

Note: this intentionally leaves `runtime_start` for a follow-up PR.