### PR TITLE
test: add reflection CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,6 +419,31 @@ jobs:
           bun run src/test-utils/headless-scenario.ts --backend local --model "${{ matrix.model }}" --output json --parallel on
           bun run src/test-utils/headless-scenario.ts --backend local --model "${{ matrix.model }}" --output stream-json --parallel on
 
+  reflection-headless:
+    needs: [classify, check]
+    if: ${{ needs.classify.outputs.run_heavy_ci == 'true' && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository)) }}
+    name: Reflection / Headless
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.0
+
+      - name: Install dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun install --frozen-lockfile
+
+      - name: Run headless reflection scenario
+        env:
+          LETTA_API_KEY: ${{ secrets.LETTA_API_KEY }}
+        run: bun run src/test-utils/headless-reflection-scenario.ts --model auto
+
   docker:
     needs: [classify, check]
     name: Docker Integration

--- a/src/cli/app/reflection-transcript-wiring.test.ts
+++ b/src/cli/app/reflection-transcript-wiring.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+describe("interactive reflection transcript wiring", () => {
+  test("submit handler launches step-count reflection through shared reminders", () => {
+    const submitHandlerPath = fileURLToPath(
+      new URL("./use-submit-handler.ts", import.meta.url),
+    );
+    const source = readFileSync(submitHandlerPath, "utf-8");
+
+    expect(source).toContain("const maybeLaunchReflectionSubagent = async (");
+    expect(source).toContain("launchReflectionSubagent({");
+    expect(source).toContain("description: AUTO_REFLECTION_DESCRIPTION");
+    expect(source).toContain('mode: "interactive"');
+    expect(source).toContain("maybeLaunchReflectionSubagent,");
+  });
+
+  test("successful TUI turns append user and assistant rows to the reflection transcript", () => {
+    const submitHandlerPath = fileURLToPath(
+      new URL("./use-submit-handler.ts", import.meta.url),
+    );
+    const conversationLoopPath = fileURLToPath(
+      new URL("./use-conversation-loop.ts", import.meta.url),
+    );
+    const submitSource = readFileSync(submitHandlerPath, "utf-8");
+    const loopSource = readFileSync(conversationLoopPath, "utf-8");
+
+    expect(submitSource).toContain(
+      "const transcriptStartLineIndex = userTextForInput",
+    );
+    expect(submitSource).toContain("transcriptStartLineIndex,");
+    expect(loopSource).toContain("const transcriptTurnStartLineIndex =");
+    expect(loopSource).toContain('if (stopReasonToHandle === "end_turn")');
+    expect(loopSource).toContain("toLines(buffersRef.current).slice(");
+    expect(loopSource).toContain("appendTranscriptDeltaJsonl(");
+
+    expect(
+      loopSource.indexOf('if (stopReasonToHandle === "end_turn")'),
+    ).toBeLessThan(loopSource.indexOf("appendTranscriptDeltaJsonl("));
+  });
+});

--- a/src/headless-bidirectional-reflection.test.ts
+++ b/src/headless-bidirectional-reflection.test.ts
@@ -1,0 +1,410 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createIsolatedCliTestEnv } from "@/test-utils/test-process-env";
+
+type JsonObject = Record<string, unknown>;
+
+interface ReflectionTranscriptState {
+  total_completed_turns?: number;
+  reflected_completed_turns?: number;
+  turns_since_last_successful_reflection?: number;
+  last_reflection_started_at?: string;
+  last_reflection_succeeded_at?: string;
+  reflected_through_message_id?: string;
+}
+
+interface BidirectionalReflectionSummary {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  tmpRoot: string;
+  agentId: string | null;
+  conversationId: string | null;
+  resultCount: number;
+  reflectionLaunchCount: number;
+  events: Array<{
+    type?: unknown;
+    subtype?: unknown;
+    result?: unknown;
+    conversationId?: unknown;
+  }>;
+  transcriptDir: string | null;
+  transcriptLines: string[];
+  payloadFiles: string[];
+  state: ReflectionTranscriptState | null;
+  stdoutTail: string;
+  stderrTail: string;
+}
+
+const cliProcesses = new Set<ChildProcessWithoutNullStreams>();
+const tempRoots: string[] = [];
+
+afterAll(async () => {
+  for (const child of cliProcesses) {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGTERM");
+    }
+  }
+  await Promise.all(
+    tempRoots.map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("headless bidirectional auto-reflection", () => {
+  test("records completed turns and launches step-count reflection from transcript state", async () => {
+    const summary = await runBidirectionalReflectionScenario();
+
+    expect(summary.code, formatSummary(summary)).toBe(0);
+    expect(summary.signal, formatSummary(summary)).toBeNull();
+    expect(summary.resultCount, formatSummary(summary)).toBe(3);
+    expect(summary.agentId, formatSummary(summary)).toBeTruthy();
+    expect(summary.conversationId, formatSummary(summary)).toBeTruthy();
+    expect(summary.transcriptDir, formatSummary(summary)).toBeTruthy();
+
+    expect(summary.transcriptLines, formatSummary(summary)).toHaveLength(6);
+    expect(summary.transcriptLines[0]).toContain('"kind":"user"');
+    expect(summary.transcriptLines[0]).toContain("hello one");
+    expect(summary.transcriptLines[1]).toContain('"kind":"assistant"');
+    expect(summary.transcriptLines[1]).toContain(
+      '"source_message_id":"letta-msg-1"',
+    );
+
+    expect(
+      summary.reflectionLaunchCount,
+      formatSummary(summary),
+    ).toBeGreaterThanOrEqual(2);
+    expect(
+      summary.payloadFiles.length,
+      formatSummary(summary),
+    ).toBeGreaterThanOrEqual(2);
+    expect(summary.state?.total_completed_turns, formatSummary(summary)).toBe(
+      3,
+    );
+    expect(
+      summary.state?.reflected_completed_turns,
+      formatSummary(summary),
+    ).toBe(2);
+    expect(
+      summary.state?.turns_since_last_successful_reflection,
+      formatSummary(summary),
+    ).toBe(1);
+    expect(
+      summary.state?.last_reflection_started_at,
+      formatSummary(summary),
+    ).toBeTruthy();
+    expect(
+      summary.state?.last_reflection_succeeded_at,
+      formatSummary(summary),
+    ).toBeTruthy();
+    expect(
+      summary.state?.reflected_through_message_id,
+      formatSummary(summary),
+    ).toBe("letta-msg-2");
+  }, 30_000);
+});
+
+async function runBidirectionalReflectionScenario(): Promise<BidirectionalReflectionSummary> {
+  const tmpRoot = await mkdtemp(join(tmpdir(), "letta-bidir-reflection-test-"));
+  tempRoots.push(tmpRoot);
+  const homeDir = join(tmpRoot, "home");
+  const projectDir = join(tmpRoot, "project");
+  const localBackendDir = join(tmpRoot, "local-backend");
+  const transcriptRoot = join(tmpRoot, "transcripts");
+  mkdirSync(join(homeDir, ".letta"), { recursive: true });
+  mkdirSync(projectDir, { recursive: true });
+  mkdirSync(localBackendDir, { recursive: true });
+  mkdirSync(transcriptRoot, { recursive: true });
+
+  writeFileSync(
+    join(homeDir, ".letta", "settings.json"),
+    JSON.stringify(
+      {
+        tokenStreaming: false,
+        sessionContextEnabled: true,
+        memoryReminderInterval: 1,
+        reflectionTrigger: "step-count",
+        reflectionStepCount: 1,
+        agents: [],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const cliEntry = join(repoRoot, "src", "index.ts");
+  const child = spawn(
+    process.execPath,
+    [
+      "--loader=.md:text",
+      "--loader=.mdx:text",
+      "--loader=.txt:text",
+      "run",
+      cliEntry,
+      "--backend",
+      "local",
+      "--new-agent",
+      "--input-format",
+      "stream-json",
+      "--output-format",
+      "stream-json",
+      "--no-system-info-reminder",
+    ],
+    {
+      cwd: projectDir,
+      env: createIsolatedCliTestEnv({
+        HOME: homeDir,
+        LETTA_LOCAL_BACKEND_DIR: localBackendDir,
+        LETTA_LOCAL_BACKEND_EXECUTOR: "deterministic",
+        LETTA_TRANSCRIPT_ROOT: transcriptRoot,
+        USER_CWD: projectDir,
+        LETTA_DEBUG: "1",
+        NO_COLOR: "1",
+      }),
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+  cliProcesses.add(child);
+
+  let stdout = "";
+  let stderr = "";
+  let pendingStdout = "";
+  let sentFirstMessage = false;
+  let resultCount = 0;
+  let closeScheduled = false;
+  let agentId: string | null = null;
+  let conversationId: string | null = null;
+  const events: BidirectionalReflectionSummary["events"] = [];
+
+  const sendUser = (content: string) => {
+    child.stdin.write(
+      `${JSON.stringify({ type: "user", message: { content } })}\n`,
+    );
+  };
+
+  const transcriptDir = () =>
+    agentId && conversationId
+      ? join(transcriptRoot, agentId, conversationId)
+      : null;
+
+  const scheduleCloseAfterReflection = () => {
+    if (closeScheduled) return;
+    closeScheduled = true;
+    void waitForReflectionProgress(transcriptDir, {
+      reflectedCompletedTurns: 2,
+      payloadCount: 2,
+      timeoutMs: 10_000,
+    }).finally(() => {
+      child.stdin.end();
+    });
+  };
+
+  child.stdout.on("data", (chunk) => {
+    const text = chunk.toString();
+    stdout += text;
+    pendingStdout += text;
+
+    while (true) {
+      const newlineIndex = pendingStdout.indexOf("\n");
+      if (newlineIndex < 0) break;
+      const line = pendingStdout.slice(0, newlineIndex).trim();
+      pendingStdout = pendingStdout.slice(newlineIndex + 1);
+      if (!line) continue;
+
+      let parsed: JsonObject;
+      try {
+        parsed = JSON.parse(line) as JsonObject;
+      } catch {
+        continue;
+      }
+
+      agentId = typeof parsed.agent_id === "string" ? parsed.agent_id : agentId;
+      conversationId =
+        typeof parsed.conversation_id === "string"
+          ? parsed.conversation_id
+          : conversationId;
+      events.push({
+        type: parsed.type,
+        subtype: parsed.subtype,
+        result: parsed.result,
+        conversationId: parsed.conversation_id,
+      });
+
+      if (
+        parsed.type === "system" &&
+        parsed.subtype === "init" &&
+        !sentFirstMessage
+      ) {
+        sentFirstMessage = true;
+        sendUser("hello one");
+      }
+
+      if (parsed.type === "result") {
+        resultCount += 1;
+        if (resultCount === 1) {
+          setTimeout(() => sendUser("hello two"), 1_200);
+        } else if (resultCount === 2) {
+          // The next turn is allowed to start only after the prior background
+          // reflection finishes; otherwise the active-reflection guard correctly
+          // skips duplicate launches and this test would only verify one cycle.
+          void waitForReflectionProgress(transcriptDir, {
+            reflectedCompletedTurns: 1,
+            payloadCount: 1,
+            timeoutMs: 10_000,
+          }).finally(() => sendUser("hello three"));
+        } else if (resultCount === 3) {
+          scheduleCloseAfterReflection();
+        }
+      }
+    }
+  });
+
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk.toString();
+  });
+
+  const timeout = setTimeout(() => {
+    child.kill("SIGTERM");
+  }, 25_000);
+
+  const { code, signal } = await new Promise<{
+    code: number | null;
+    signal: NodeJS.Signals | null;
+  }>((resolvePromise) => {
+    child.on("exit", (code, signal) => {
+      clearTimeout(timeout);
+      cliProcesses.delete(child);
+      resolvePromise({ code, signal });
+    });
+  });
+
+  const finalTranscriptDir = transcriptDir();
+  const state = finalTranscriptDir
+    ? readReflectionState(finalTranscriptDir)
+    : null;
+  const transcriptLines = finalTranscriptDir
+    ? readTranscriptLines(finalTranscriptDir)
+    : [];
+  const payloadFiles = finalTranscriptDir
+    ? readPayloadFiles(finalTranscriptDir)
+    : [];
+
+  return {
+    code,
+    signal,
+    tmpRoot,
+    agentId,
+    conversationId,
+    resultCount,
+    reflectionLaunchCount: countOccurrences(
+      stderr,
+      "Launched reflection subagent (step-count)",
+    ),
+    events,
+    transcriptDir: finalTranscriptDir,
+    transcriptLines,
+    payloadFiles,
+    state,
+    stdoutTail: tail(stdout),
+    stderrTail: tail(stderr),
+  };
+}
+
+async function waitForReflectionProgress(
+  getTranscriptDir: () => string | null,
+  options: {
+    reflectedCompletedTurns: number;
+    payloadCount: number;
+    timeoutMs: number;
+  },
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < options.timeoutMs) {
+    const dir = getTranscriptDir();
+    const state = dir ? readReflectionState(dir) : null;
+    const payloadCount = dir ? readPayloadFiles(dir).length : 0;
+    if (
+      (state?.reflected_completed_turns ?? 0) >=
+        options.reflectedCompletedTurns &&
+      payloadCount >= options.payloadCount
+    ) {
+      return;
+    }
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
+  }
+}
+
+function readReflectionState(dir: string): ReflectionTranscriptState | null {
+  try {
+    return JSON.parse(
+      readFileSync(join(dir, "state.json"), "utf-8"),
+    ) as ReflectionTranscriptState;
+  } catch {
+    return null;
+  }
+}
+
+function readTranscriptLines(dir: string): string[] {
+  try {
+    return readFileSync(join(dir, "transcript.jsonl"), "utf-8")
+      .trim()
+      .split("\n")
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function readPayloadFiles(dir: string): string[] {
+  try {
+    return readdirSync(dir)
+      .filter(
+        (name) => name.startsWith("payload-auto-") && name.endsWith(".json"),
+      )
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+function countOccurrences(text: string, needle: string): number {
+  let count = 0;
+  let index = 0;
+  while (true) {
+    index = text.indexOf(needle, index);
+    if (index === -1) return count;
+    count += 1;
+    index += needle.length;
+  }
+}
+
+function tail(text: string): string {
+  return text.split("\n").slice(-80).join("\n");
+}
+
+function formatSummary(summary: BidirectionalReflectionSummary): string {
+  return JSON.stringify(
+    {
+      code: summary.code,
+      signal: summary.signal,
+      tmpRoot: summary.tmpRoot,
+      agentId: summary.agentId,
+      conversationId: summary.conversationId,
+      resultCount: summary.resultCount,
+      reflectionLaunchCount: summary.reflectionLaunchCount,
+      transcriptDir: summary.transcriptDir,
+      payloadFiles: summary.payloadFiles,
+      state: summary.state,
+      transcriptLines: summary.transcriptLines,
+      events: summary.events,
+      stdoutTail: summary.stdoutTail,
+      stderrTail: summary.stderrTail,
+    },
+    null,
+    2,
+  );
+}

--- a/src/integration-tests/headless-bidirectional-reflection.integration.test.ts
+++ b/src/integration-tests/headless-bidirectional-reflection.integration.test.ts
@@ -182,7 +182,7 @@ async function runLiveBidirectionalCli(paths: {
         "--no-system-info-reminder",
         "--yolo",
         "-m",
-        "sonnet-4.6-low",
+        "auto",
       ],
       {
         cwd: process.cwd(),

--- a/src/integration-tests/headless-bidirectional-reflection.integration.test.ts
+++ b/src/integration-tests/headless-bidirectional-reflection.integration.test.ts
@@ -1,0 +1,472 @@
+import { describe, expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createAuthenticatedCliTestEnv } from "@/test-utils/test-process-env";
+import { formatCapturedOutput } from "./process-diagnostics";
+
+interface ReflectionTranscriptState {
+  schema_version?: string;
+  reflected_through_message_id?: string;
+  total_completed_turns?: number;
+  reflected_completed_turns?: number;
+  turns_since_last_successful_reflection?: number;
+  last_reflection_started_at?: string;
+  last_reflection_succeeded_at?: string;
+}
+
+interface PayloadFile {
+  name: string;
+  path: string;
+  mtimeMs: number;
+}
+
+interface LiveReflectionSummary {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  tmpRoot: string;
+  agentId: string | null;
+  conversationId: string | null;
+  resultCount: number;
+  reflectionLaunchCount: number;
+  transcriptDir: string | null;
+  transcriptLines: string[];
+  payloadFiles: PayloadFile[];
+  firstPayloadText: string;
+  state: ReflectionTranscriptState | null;
+  stdout: string;
+  stderr: string;
+}
+
+const TURN_ONE_MARKER = "LIVE_REFLECTION_TURN_ONE_MARKER";
+const TURN_TWO_MARKER = "LIVE_REFLECTION_TURN_TWO_MARKER";
+
+describe("headless bidirectional reflection integration", () => {
+  test(
+    "launches reflection with the newly recorded transcript payload",
+    async () => {
+      if (!process.env.LETTA_API_KEY) {
+        console.log("SKIP: Missing LETTA_API_KEY");
+        return;
+      }
+
+      const summary = await runLiveBidirectionalReflectionSmoke();
+
+      expect(summary.code, formatSummary(summary)).toBe(0);
+      expect(summary.signal, formatSummary(summary)).toBeNull();
+      expect(summary.agentId, formatSummary(summary)).toBeTruthy();
+      expect(summary.conversationId, formatSummary(summary)).toBeTruthy();
+      expect(
+        summary.resultCount,
+        formatSummary(summary),
+      ).toBeGreaterThanOrEqual(2);
+      expect(
+        summary.reflectionLaunchCount,
+        formatSummary(summary),
+      ).toBeGreaterThanOrEqual(1);
+
+      expect(
+        summary.transcriptLines.length,
+        formatSummary(summary),
+      ).toBeGreaterThanOrEqual(4);
+      expect(
+        summary.transcriptLines.join("\n"),
+        formatSummary(summary),
+      ).toContain(TURN_ONE_MARKER);
+      expect(
+        summary.transcriptLines.join("\n"),
+        formatSummary(summary),
+      ).toContain(TURN_TWO_MARKER);
+      expect(
+        summary.payloadFiles.length,
+        formatSummary(summary),
+      ).toBeGreaterThanOrEqual(1);
+
+      expect(summary.state?.schema_version, formatSummary(summary)).toBe(
+        "v2_message_id",
+      );
+      expect(
+        summary.state?.total_completed_turns,
+        formatSummary(summary),
+      ).toBeGreaterThanOrEqual(2);
+      expect(
+        summary.state?.last_reflection_started_at,
+        formatSummary(summary),
+      ).toBeTruthy();
+
+      const firstPayload = parsePayload(summary.firstPayloadText);
+      expect(firstPayload.roles, formatSummary(summary)).toContain("system");
+      expect(firstPayload.roles, formatSummary(summary)).toContain("user");
+      expect(firstPayload.roles, formatSummary(summary)).toContain("assistant");
+      expect(firstPayload.text, formatSummary(summary)).toContain(
+        TURN_ONE_MARKER,
+      );
+      expect(firstPayload.text, formatSummary(summary)).not.toContain(
+        TURN_TWO_MARKER,
+      );
+    },
+    { timeout: 180_000 },
+  );
+});
+
+async function runLiveBidirectionalReflectionSmoke(): Promise<LiveReflectionSummary> {
+  const tmpRoot = await mkdtemp(join(tmpdir(), "letta-live-bidir-reflection-"));
+  const homeDir = join(tmpRoot, "home");
+  const projectDir = join(tmpRoot, "project");
+  const transcriptRoot = join(tmpRoot, "transcripts");
+  await mkdir(join(homeDir, ".letta"), { recursive: true });
+  await mkdir(projectDir, { recursive: true });
+  await mkdir(transcriptRoot, { recursive: true });
+
+  await writeFile(
+    join(homeDir, ".letta", "settings.json"),
+    JSON.stringify(
+      {
+        tokenStreaming: false,
+        sessionContextEnabled: true,
+        memoryReminderInterval: 1,
+        reflectionTrigger: "step-count",
+        reflectionStepCount: 1,
+        agents: [],
+      },
+      null,
+      2,
+    ),
+  );
+
+  try {
+    return await runLiveBidirectionalCli({
+      tmpRoot,
+      homeDir,
+      projectDir,
+      transcriptRoot,
+    });
+  } finally {
+    await rm(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+async function runLiveBidirectionalCli(paths: {
+  tmpRoot: string;
+  homeDir: string;
+  projectDir: string;
+  transcriptRoot: string;
+}): Promise<LiveReflectionSummary> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(
+      "bun",
+      [
+        "run",
+        "dev",
+        "--new-agent",
+        "--memfs",
+        "--memfs-startup",
+        "skip",
+        "--input-format",
+        "stream-json",
+        "--output-format",
+        "stream-json",
+        "--reflection-trigger",
+        "step-count",
+        "--reflection-step-count",
+        "1",
+        "--no-system-info-reminder",
+        "--yolo",
+        "-m",
+        "sonnet-4.6-low",
+      ],
+      {
+        cwd: process.cwd(),
+        env: createAuthenticatedCliTestEnv({
+          HOME: paths.homeDir,
+          LETTA_TRANSCRIPT_ROOT: paths.transcriptRoot,
+          USER_CWD: paths.projectDir,
+          LETTA_DEBUG: "1",
+          NO_COLOR: "1",
+        }),
+      },
+    );
+
+    let stdout = "";
+    let stderr = "";
+    let pendingStdout = "";
+    let agentId: string | null = null;
+    let conversationId: string | null = null;
+    let resultCount = 0;
+    let closing = false;
+
+    const transcriptDir = () =>
+      agentId && conversationId
+        ? join(paths.transcriptRoot, agentId, conversationId)
+        : null;
+
+    const sendUser = (content: string) => {
+      proc.stdin.write(
+        `${JSON.stringify({ type: "user", message: { content } })}\n`,
+      );
+    };
+
+    const closeWhenReflectionPayloadExists = () => {
+      if (closing) return;
+      closing = true;
+      void waitForLaunchArtifacts(transcriptDir, 90_000).finally(() => {
+        proc.stdin.end();
+      });
+    };
+
+    proc.stdout.on("data", (chunk) => {
+      const text = chunk.toString();
+      stdout += text;
+      pendingStdout += text;
+
+      while (true) {
+        const newlineIndex = pendingStdout.indexOf("\n");
+        if (newlineIndex < 0) break;
+        const line = pendingStdout.slice(0, newlineIndex).trim();
+        pendingStdout = pendingStdout.slice(newlineIndex + 1);
+        if (!line) continue;
+
+        let parsed: Record<string, unknown>;
+        try {
+          parsed = JSON.parse(line) as Record<string, unknown>;
+        } catch {
+          continue;
+        }
+
+        agentId =
+          typeof parsed.agent_id === "string" ? parsed.agent_id : agentId;
+        conversationId =
+          typeof parsed.conversation_id === "string"
+            ? parsed.conversation_id
+            : conversationId;
+
+        if (parsed.type === "system" && parsed.subtype === "init") {
+          sendUser(`Reply with OK only. Do not use tools. ${TURN_ONE_MARKER}`);
+        }
+
+        if (parsed.type === "result") {
+          resultCount += 1;
+          if (resultCount === 1) {
+            setTimeout(
+              () =>
+                sendUser(
+                  `Reply with OK only. Do not use tools. ${TURN_TWO_MARKER}`,
+                ),
+              1_000,
+            );
+          } else if (resultCount === 2) {
+            closeWhenReflectionPayloadExists();
+          }
+        }
+      }
+    });
+
+    proc.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    const timeout = setTimeout(() => {
+      proc.kill("SIGTERM");
+      reject(
+        new Error(
+          `Timed out waiting for live bidirectional reflection smoke.\n${formatCapturedOutput(
+            {
+              stdout,
+              stderr,
+              extra: {
+                agent_id: agentId ?? "(unknown)",
+                conversation_id: conversationId ?? "(unknown)",
+                result_count: resultCount,
+              },
+            },
+          )}`,
+        ),
+      );
+    }, 180_000);
+
+    proc.on("close", (code, signal) => {
+      clearTimeout(timeout);
+      void buildSummary({
+        code,
+        signal,
+        tmpRoot: paths.tmpRoot,
+        transcriptRoot: paths.transcriptRoot,
+        transcriptDir: transcriptDir(),
+        agentId,
+        conversationId,
+        resultCount,
+        stdout,
+        stderr,
+      })
+        .then(resolve)
+        .catch(reject);
+    });
+  });
+}
+
+async function waitForLaunchArtifacts(
+  getTranscriptDir: () => string | null,
+  timeoutMs: number,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const dir = getTranscriptDir();
+    const state = dir ? await readReflectionState(dir) : null;
+    const payloadFiles = dir ? await readPayloadFiles(dir) : [];
+    if (
+      (state?.total_completed_turns ?? 0) >= 2 &&
+      state?.last_reflection_started_at &&
+      payloadFiles.length >= 1
+    ) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+}
+
+async function buildSummary(args: {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  tmpRoot: string;
+  transcriptRoot: string;
+  transcriptDir: string | null;
+  agentId: string | null;
+  conversationId: string | null;
+  resultCount: number;
+  stdout: string;
+  stderr: string;
+}): Promise<LiveReflectionSummary> {
+  const state = args.transcriptDir
+    ? await readReflectionState(args.transcriptDir)
+    : null;
+  const transcriptLines = args.transcriptDir
+    ? await readTranscriptLines(args.transcriptDir)
+    : [];
+  const payloadFiles = args.transcriptDir
+    ? await readPayloadFiles(args.transcriptDir)
+    : [];
+  const firstPayloadText = payloadFiles[0]
+    ? await readFile(payloadFiles[0].path, "utf-8")
+    : "";
+
+  return {
+    code: args.code,
+    signal: args.signal,
+    tmpRoot: args.tmpRoot,
+    agentId: args.agentId,
+    conversationId: args.conversationId,
+    resultCount: args.resultCount,
+    reflectionLaunchCount: countOccurrences(
+      args.stderr,
+      "Launched reflection subagent (step-count)",
+    ),
+    transcriptDir: args.transcriptDir,
+    transcriptLines,
+    payloadFiles,
+    firstPayloadText,
+    state,
+    stdout: tail(args.stdout),
+    stderr: tail(args.stderr),
+  };
+}
+
+async function readReflectionState(
+  dir: string,
+): Promise<ReflectionTranscriptState | null> {
+  try {
+    return JSON.parse(
+      await readFile(join(dir, "state.json"), "utf-8"),
+    ) as ReflectionTranscriptState;
+  } catch {
+    return null;
+  }
+}
+
+async function readTranscriptLines(dir: string): Promise<string[]> {
+  try {
+    return (await readFile(join(dir, "transcript.jsonl"), "utf-8"))
+      .trim()
+      .split("\n")
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+async function readPayloadFiles(dir: string): Promise<PayloadFile[]> {
+  try {
+    const names = await readdir(dir);
+    const payloads = names.filter(
+      (name) => name.startsWith("payload-auto-") && name.endsWith(".json"),
+    );
+    const withStats = await Promise.all(
+      payloads.map(async (name) => {
+        const path = join(dir, name);
+        return { name, path, mtimeMs: (await stat(path)).mtimeMs };
+      }),
+    );
+    return withStats.sort((a, b) => a.mtimeMs - b.mtimeMs);
+  } catch {
+    return [];
+  }
+}
+
+function parsePayload(payloadText: string): { roles: string[]; text: string } {
+  const parsed = JSON.parse(payloadText) as Array<{
+    role?: string;
+    content?: unknown;
+  }>;
+  return {
+    roles: parsed
+      .map((entry) => entry.role)
+      .filter((role): role is string => typeof role === "string"),
+    text: JSON.stringify(parsed),
+  };
+}
+
+function countOccurrences(text: string, needle: string): number {
+  let count = 0;
+  let index = 0;
+  while (true) {
+    index = text.indexOf(needle, index);
+    if (index === -1) return count;
+    count += 1;
+    index += needle.length;
+  }
+}
+
+function tail(text: string): string {
+  return text.split("\n").slice(-80).join("\n");
+}
+
+function formatSummary(summary: LiveReflectionSummary): string {
+  return JSON.stringify(
+    {
+      code: summary.code,
+      signal: summary.signal,
+      tmpRoot: summary.tmpRoot,
+      agentId: summary.agentId,
+      conversationId: summary.conversationId,
+      resultCount: summary.resultCount,
+      reflectionLaunchCount: summary.reflectionLaunchCount,
+      transcriptDir: summary.transcriptDir,
+      transcriptLines: summary.transcriptLines,
+      payloadFiles: summary.payloadFiles.map((file) => file.name),
+      state: summary.state,
+      firstPayloadText: summary.firstPayloadText.slice(0, 2_000),
+      stdout: summary.stdout,
+      stderr: summary.stderr,
+    },
+    null,
+    2,
+  );
+}

--- a/src/test-utils/headless-reflection-scenario.ts
+++ b/src/test-utils/headless-reflection-scenario.ts
@@ -1,4 +1,12 @@
-import { describe, expect, test } from "bun:test";
+#!/usr/bin/env bun
+/**
+ * Headless bidirectional reflection scenario.
+ *
+ * Intended for CI as a dedicated Reflection / Headless check. It exercises the
+ * authenticated API headless bidirectional path with MemFS enabled and verifies
+ * that auto-reflection creates the right transcript metadata and payload.
+ */
+
 import { spawn } from "node:child_process";
 import {
   mkdir,
@@ -11,8 +19,12 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createAuthenticatedCliTestEnv } from "@/test-utils/test-process-env";
-import { formatCapturedOutput } from "./process-diagnostics";
+import { formatCapturedOutput } from "@/integration-tests/process-diagnostics";
+import { createAuthenticatedCliTestEnv } from "./test-process-env";
+
+interface Args {
+  model: string;
+}
 
 interface ReflectionTranscriptState {
   schema_version?: string;
@@ -50,75 +62,27 @@ interface LiveReflectionSummary {
 const TURN_ONE_MARKER = "LIVE_REFLECTION_TURN_ONE_MARKER";
 const TURN_TWO_MARKER = "LIVE_REFLECTION_TURN_TWO_MARKER";
 
-describe("headless bidirectional reflection integration", () => {
-  test(
-    "launches reflection with the newly recorded transcript payload",
-    async () => {
-      if (!process.env.LETTA_API_KEY) {
-        console.log("SKIP: Missing LETTA_API_KEY");
-        return;
-      }
-
-      const summary = await runLiveBidirectionalReflectionSmoke();
-
-      expect(summary.code, formatSummary(summary)).toBe(0);
-      expect(summary.signal, formatSummary(summary)).toBeNull();
-      expect(summary.agentId, formatSummary(summary)).toBeTruthy();
-      expect(summary.conversationId, formatSummary(summary)).toBeTruthy();
-      expect(
-        summary.resultCount,
-        formatSummary(summary),
-      ).toBeGreaterThanOrEqual(2);
-      expect(
-        summary.reflectionLaunchCount,
-        formatSummary(summary),
-      ).toBeGreaterThanOrEqual(1);
-
-      expect(
-        summary.transcriptLines.length,
-        formatSummary(summary),
-      ).toBeGreaterThanOrEqual(4);
-      expect(
-        summary.transcriptLines.join("\n"),
-        formatSummary(summary),
-      ).toContain(TURN_ONE_MARKER);
-      expect(
-        summary.transcriptLines.join("\n"),
-        formatSummary(summary),
-      ).toContain(TURN_TWO_MARKER);
-      expect(
-        summary.payloadFiles.length,
-        formatSummary(summary),
-      ).toBeGreaterThanOrEqual(1);
-
-      expect(summary.state?.schema_version, formatSummary(summary)).toBe(
-        "v2_message_id",
+function parseArgs(argv: string[]): Args {
+  const args: Args = { model: "auto" };
+  for (let i = 0; i < argv.length; i += 1) {
+    const value = argv[i];
+    if (value === "--model") {
+      args.model = argv[++i] ?? args.model;
+    } else if (value === "--help" || value === "-h") {
+      console.log(
+        "Usage: bun run src/test-utils/headless-reflection-scenario.ts [--model auto]",
       );
-      expect(
-        summary.state?.total_completed_turns,
-        formatSummary(summary),
-      ).toBeGreaterThanOrEqual(2);
-      expect(
-        summary.state?.last_reflection_started_at,
-        formatSummary(summary),
-      ).toBeTruthy();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${value}`);
+    }
+  }
+  return args;
+}
 
-      const firstPayload = parsePayload(summary.firstPayloadText);
-      expect(firstPayload.roles, formatSummary(summary)).toContain("system");
-      expect(firstPayload.roles, formatSummary(summary)).toContain("user");
-      expect(firstPayload.roles, formatSummary(summary)).toContain("assistant");
-      expect(firstPayload.text, formatSummary(summary)).toContain(
-        TURN_ONE_MARKER,
-      );
-      expect(firstPayload.text, formatSummary(summary)).not.toContain(
-        TURN_TWO_MARKER,
-      );
-    },
-    { timeout: 180_000 },
-  );
-});
-
-async function runLiveBidirectionalReflectionSmoke(): Promise<LiveReflectionSummary> {
+async function runLiveBidirectionalReflectionSmoke(
+  args: Args,
+): Promise<LiveReflectionSummary> {
   const tmpRoot = await mkdtemp(join(tmpdir(), "letta-live-bidir-reflection-"));
   const homeDir = join(tmpRoot, "home");
   const projectDir = join(tmpRoot, "project");
@@ -149,6 +113,7 @@ async function runLiveBidirectionalReflectionSmoke(): Promise<LiveReflectionSumm
       homeDir,
       projectDir,
       transcriptRoot,
+      model: args.model,
     });
   } finally {
     await rm(tmpRoot, { recursive: true, force: true });
@@ -160,6 +125,7 @@ async function runLiveBidirectionalCli(paths: {
   homeDir: string;
   projectDir: string;
   transcriptRoot: string;
+  model: string;
 }): Promise<LiveReflectionSummary> {
   return new Promise((resolve, reject) => {
     const proc = spawn(
@@ -182,7 +148,7 @@ async function runLiveBidirectionalCli(paths: {
         "--no-system-info-reminder",
         "--yolo",
         "-m",
-        "auto",
+        paths.model,
       ],
       {
         cwd: process.cwd(),
@@ -299,7 +265,6 @@ async function runLiveBidirectionalCli(paths: {
         code,
         signal,
         tmpRoot: paths.tmpRoot,
-        transcriptRoot: paths.transcriptRoot,
         transcriptDir: transcriptDir(),
         agentId,
         conversationId,
@@ -337,7 +302,6 @@ async function buildSummary(args: {
   code: number | null;
   signal: NodeJS.Signals | null;
   tmpRoot: string;
-  transcriptRoot: string;
   transcriptDir: string | null;
   agentId: string | null;
   conversationId: string | null;
@@ -470,3 +434,92 @@ function formatSummary(summary: LiveReflectionSummary): string {
     2,
   );
 }
+
+function assertTrue(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function assertScenario(summary: LiveReflectionSummary): void {
+  const details = formatSummary(summary);
+  assertTrue(summary.code === 0, `Expected exit code 0.\n${details}`);
+  assertTrue(summary.signal === null, `Expected no signal.\n${details}`);
+  assertTrue(summary.agentId, `Missing agent id.\n${details}`);
+  assertTrue(summary.conversationId, `Missing conversation id.\n${details}`);
+  assertTrue(
+    summary.resultCount >= 2,
+    `Expected at least two completed turns.\n${details}`,
+  );
+  assertTrue(
+    summary.reflectionLaunchCount >= 1,
+    `Expected reflection launch log.\n${details}`,
+  );
+  assertTrue(
+    summary.transcriptLines.length >= 4,
+    `Expected user/assistant transcript rows.\n${details}`,
+  );
+  assertTrue(
+    summary.transcriptLines.join("\n").includes(TURN_ONE_MARKER),
+    `Transcript missing first marker.\n${details}`,
+  );
+  assertTrue(
+    summary.transcriptLines.join("\n").includes(TURN_TWO_MARKER),
+    `Transcript missing second marker.\n${details}`,
+  );
+  assertTrue(
+    summary.payloadFiles.length >= 1,
+    `Expected at least one auto reflection payload.\n${details}`,
+  );
+  assertTrue(
+    summary.state?.schema_version === "v2_message_id",
+    `Unexpected reflection state schema.\n${details}`,
+  );
+  assertTrue(
+    (summary.state?.total_completed_turns ?? 0) >= 2,
+    `Reflection state did not record completed turns.\n${details}`,
+  );
+  assertTrue(
+    summary.state?.last_reflection_started_at,
+    `Reflection state did not record launch timestamp.\n${details}`,
+  );
+
+  const firstPayload = parsePayload(summary.firstPayloadText);
+  assertTrue(
+    firstPayload.roles.includes("system"),
+    `Payload missing system message.\n${details}`,
+  );
+  assertTrue(
+    firstPayload.roles.includes("user"),
+    `Payload missing user message.\n${details}`,
+  );
+  assertTrue(
+    firstPayload.roles.includes("assistant"),
+    `Payload missing assistant message.\n${details}`,
+  );
+  assertTrue(
+    firstPayload.text.includes(TURN_ONE_MARKER),
+    `Payload missing first marker.\n${details}`,
+  );
+  assertTrue(
+    !firstPayload.text.includes(TURN_TWO_MARKER),
+    `Payload should not include second marker from after the launch snapshot.\n${details}`,
+  );
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (!process.env.LETTA_API_KEY) {
+    console.log("SKIP: Missing env LETTA_API_KEY");
+    return;
+  }
+
+  const summary = await runLiveBidirectionalReflectionSmoke(args);
+  assertScenario(summary);
+  console.log(`OK: reflection / headless / ${args.model}`);
+}
+
+main().catch((error) => {
+  console.error(String(error?.stack || error));
+  process.exit(1);
+});

--- a/src/websocket/listener/turn-reflection.test.ts
+++ b/src/websocket/listener/turn-reflection.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { createBuffers, toLines } from "@/cli/helpers/accumulator";
 import { createContextTracker } from "@/cli/helpers/context-tracker";
 import { REFLECTION_STATE_SCHEMA_VERSION } from "@/cli/helpers/reflection-transcript";
@@ -109,5 +111,23 @@ describe("post-turn channel reflection", () => {
 
     expect(didLaunch).toBe(false);
     expect(launch).not.toHaveBeenCalled();
+  });
+
+  test("records listener transcript rows before evaluating post-turn reflection", () => {
+    const turnPath = fileURLToPath(new URL("./turn.ts", import.meta.url));
+    const source = readFileSync(turnPath, "utf-8");
+    const endTurnIndex = source.indexOf('if (stopReason === "end_turn")');
+    const appendIndex = source.indexOf(
+      "appendTranscriptDeltaJsonl(",
+      endTurnIndex,
+    );
+    const launchIndex = source.indexOf(
+      "maybeLaunchPostTurnChannelReflection({",
+      endTurnIndex,
+    );
+
+    expect(endTurnIndex).toBeGreaterThanOrEqual(0);
+    expect(appendIndex).toBeGreaterThan(endTurnIndex);
+    expect(launchIndex).toBeGreaterThan(appendIndex);
   });
 });


### PR DESCRIPTION
## Summary
- add an isolated deterministic bidirectional headless unit/CI test that verifies auto-reflection launches, transcript rows are recorded, payloads are created, and reflection state advances
- add a dedicated GitHub CI job `Reflection / Headless` that runs a live API bidirectional headless reflection smoke with `-m auto`
- add TUI source-level guards for shared reminder reflection launch wiring and transcript append wiring
- add listener ordering coverage so post-turn reflection is evaluated only after transcript rows are appended

## Test plan
- bun run src/test-utils/headless-reflection-scenario.ts --model auto
- bun test src/headless-bidirectional-reflection.test.ts src/cli/app/reflection-transcript-wiring.test.ts src/websocket/listener/turn-reflection.test.ts src/websocket/listen-reflection-runtime.test.ts src/headless-reminder.test.ts src/cli/memory-reminder.test.ts src/cli/reflection-transcript.test.ts
- bun run check

## Local note
- node scripts/run-unit-tests.cjs: new reflection test passed; local run still hit existing src/hooks/e2e.test.ts marker assertion failures unrelated to this change
