### PR TITLE
feat(app-server): add remaining management commands

### DIFF
--- a/src/types/app-server-protocol.test.ts
+++ b/src/types/app-server-protocol.test.ts
@@ -57,10 +57,52 @@ describe("app-server protocol export", () => {
         agents: [],
       },
       {
+        type: "agent_update_response",
+        request_id: "req",
+        success: true,
+        agent: null,
+      },
+      {
+        type: "agent_delete_response",
+        request_id: "req",
+        success: true,
+        agent_id: "agent-1",
+      },
+      {
         type: "conversation_list_response",
         request_id: "req",
         success: true,
         conversations: [],
+      },
+      {
+        type: "conversation_update_response",
+        request_id: "req",
+        success: true,
+        conversation: null,
+      },
+      {
+        type: "conversation_recompile_response",
+        request_id: "req",
+        success: true,
+        result: null,
+      },
+      {
+        type: "conversation_fork_response",
+        request_id: "req",
+        success: true,
+        conversation: null,
+      },
+      {
+        type: "conversation_messages_list_response",
+        request_id: "req",
+        success: true,
+        messages: [],
+      },
+      {
+        type: "conversation_compact_response",
+        request_id: "req",
+        success: true,
+        compaction: null,
       },
     ] satisfies WsProtocolMessage[];
 
@@ -74,7 +116,14 @@ describe("app-server protocol export", () => {
       "search_branches_response",
       "get_reflection_settings_response",
       "agent_list_response",
+      "agent_update_response",
+      "agent_delete_response",
       "conversation_list_response",
+      "conversation_update_response",
+      "conversation_recompile_response",
+      "conversation_fork_response",
+      "conversation_messages_list_response",
+      "conversation_compact_response",
     ]);
   });
 });

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -10,14 +10,25 @@ import type {
   AgentCreateParams,
   AgentListParams,
   AgentState,
+  AgentUpdateParams,
   MessageCreate,
 } from "@letta-ai/letta-client/resources/agents/agents";
-import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
+import type {
+  Message as LettaMessage,
+  LettaStreamingResponse,
+} from "@letta-ai/letta-client/resources/agents/messages";
 import type {
   Conversation,
   ConversationCreateParams,
   ConversationListParams,
+  ConversationRecompileParams,
+  ConversationUpdateParams,
 } from "@letta-ai/letta-client/resources/conversations/conversations";
+import type {
+  CompactionResponse,
+  MessageCompactParams,
+  MessageListParams,
+} from "@letta-ai/letta-client/resources/conversations/messages";
 import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs";
 
 export type DmPolicy = "pairing" | "allowlist" | "open";
@@ -1574,6 +1585,22 @@ export interface AgentCreateCommand {
   body: AgentCreateParams;
 }
 
+export interface AgentUpdateCommand {
+  type: "agent_update";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  agent_id: string;
+  /** Body forwarded to the Letta agents update API. */
+  body: AgentUpdateParams;
+}
+
+export interface AgentDeleteCommand {
+  type: "agent_delete";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  agent_id: string;
+}
+
 export interface ConversationListCommand {
   type: "conversation_list";
   /** Echoed back in the response for request correlation. */
@@ -1595,6 +1622,57 @@ export interface ConversationCreateCommand {
   request_id: string;
   /** Body forwarded to the Letta conversations create API. */
   body: ConversationCreateParams;
+}
+
+export interface ConversationUpdateCommand {
+  type: "conversation_update";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  conversation_id: string;
+  /** Body forwarded to the Letta conversations update API. */
+  body: ConversationUpdateParams;
+}
+
+export interface ConversationRecompileCommand {
+  type: "conversation_recompile";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  conversation_id: string;
+  /** Body/query forwarded to the Letta conversations recompile API. */
+  body?: ConversationRecompileParams;
+}
+
+export interface ConversationForkBody {
+  /** Agent ID for agent-direct mode with the default conversation. */
+  agent_id?: string | null;
+  /** Whether the forked conversation should be hidden. */
+  hidden?: boolean;
+}
+
+export interface ConversationForkCommand {
+  type: "conversation_fork";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  conversation_id: string;
+  body?: ConversationForkBody;
+}
+
+export interface ConversationMessagesListCommand {
+  type: "conversation_messages_list";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  conversation_id: string;
+  /** Query params forwarded to the Letta conversation messages list API. */
+  query?: MessageListParams;
+}
+
+export interface ConversationCompactCommand {
+  type: "conversation_compact";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  conversation_id: string;
+  /** Body forwarded to the Letta conversation messages compact API. */
+  body?: MessageCompactParams;
 }
 
 export interface GetCwdMapCommand {
@@ -1953,6 +2031,22 @@ export interface AgentCreateResponseMessage {
   error?: string;
 }
 
+export interface AgentUpdateResponseMessage {
+  type: "agent_update_response";
+  request_id: string;
+  success: boolean;
+  agent: AgentState | null;
+  error?: string;
+}
+
+export interface AgentDeleteResponseMessage {
+  type: "agent_delete_response";
+  request_id: string;
+  success: boolean;
+  agent_id: string;
+  error?: string;
+}
+
 export interface ConversationListResponseMessage {
   type: "conversation_list_response";
   request_id: string;
@@ -1974,6 +2068,50 @@ export interface ConversationCreateResponseMessage {
   request_id: string;
   success: boolean;
   conversation: Conversation | null;
+  error?: string;
+}
+
+export interface ConversationUpdateResponseMessage {
+  type: "conversation_update_response";
+  request_id: string;
+  success: boolean;
+  conversation: Conversation | null;
+  error?: string;
+}
+
+export interface ConversationRecompileResponseMessage {
+  type: "conversation_recompile_response";
+  request_id: string;
+  success: boolean;
+  result: string | null;
+  error?: string;
+}
+
+export interface ForkedConversationReference {
+  id: string;
+}
+
+export interface ConversationForkResponseMessage {
+  type: "conversation_fork_response";
+  request_id: string;
+  success: boolean;
+  conversation: ForkedConversationReference | null;
+  error?: string;
+}
+
+export interface ConversationMessagesListResponseMessage {
+  type: "conversation_messages_list_response";
+  request_id: string;
+  success: boolean;
+  messages: LettaMessage[];
+  error?: string;
+}
+
+export interface ConversationCompactResponseMessage {
+  type: "conversation_compact_response";
+  request_id: string;
+  success: boolean;
+  compaction: CompactionResponse | null;
   error?: string;
 }
 
@@ -2425,9 +2563,16 @@ export type WsProtocolCommand =
   | AgentListCommand
   | AgentRetrieveCommand
   | AgentCreateCommand
+  | AgentUpdateCommand
+  | AgentDeleteCommand
   | ConversationListCommand
   | ConversationRetrieveCommand
   | ConversationCreateCommand
+  | ConversationUpdateCommand
+  | ConversationRecompileCommand
+  | ConversationForkCommand
+  | ConversationMessagesListCommand
+  | ConversationCompactCommand
   | GetCwdMapCommand
   | ListConversationPinsCommand
   | SetConversationPinCommand
@@ -2513,9 +2658,16 @@ export type WsProtocolMessage =
   | AgentListResponseMessage
   | AgentRetrieveResponseMessage
   | AgentCreateResponseMessage
+  | AgentUpdateResponseMessage
+  | AgentDeleteResponseMessage
   | ConversationListResponseMessage
   | ConversationRetrieveResponseMessage
   | ConversationCreateResponseMessage
+  | ConversationUpdateResponseMessage
+  | ConversationRecompileResponseMessage
+  | ConversationForkResponseMessage
+  | ConversationMessagesListResponseMessage
+  | ConversationCompactResponseMessage
   | GetExperimentsResponseMessage
   | SetExperimentResponseMessage
   | ListConversationPinsResponseMessage

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -293,7 +293,21 @@ describe("listen-client parseServerMessage", () => {
     test("lists, retrieves, and creates agents and conversations", async () => {
       const storageDir = await mkdtemp(join(os.tmpdir(), "ws-management-"));
       try {
-        const backend = new LocalBackend({
+        class ManagementBackend extends LocalBackend {
+          override async compactConversationMessages(
+            ..._args: Parameters<LocalBackend["compactConversationMessages"]>
+          ): ReturnType<LocalBackend["compactConversationMessages"]> {
+            return {
+              num_messages_before: 4,
+              num_messages_after: 2,
+              summary: "compacted summary",
+            } as Awaited<
+              ReturnType<LocalBackend["compactConversationMessages"]>
+            >;
+          }
+        }
+
+        const backend = new ManagementBackend({
           storageDir,
           executionMode: "deterministic",
         });
@@ -357,6 +371,22 @@ describe("listen-client parseServerMessage", () => {
 
         await __listenClientTestUtils.handleAgentConversationManagementCommand(
           {
+            type: "agent_update",
+            request_id: "agent-update-1",
+            agent_id: agentId,
+            body: { name: "WS Managed Agent Updated" },
+          },
+          socket as unknown as WebSocket,
+        );
+        expect(JSON.parse(socket.sentPayloads.at(-1) ?? "{}")).toMatchObject({
+          type: "agent_update_response",
+          request_id: "agent-update-1",
+          success: true,
+          agent: { id: agentId, name: "WS Managed Agent Updated" },
+        });
+
+        await __listenClientTestUtils.handleAgentConversationManagementCommand(
+          {
             type: "conversation_create",
             request_id: "conversation-create-1",
             body: { agent_id: agentId },
@@ -403,6 +433,107 @@ describe("listen-client parseServerMessage", () => {
           request_id: "conversation-retrieve-1",
           success: true,
           conversation: { id: conversationId },
+        });
+
+        await __listenClientTestUtils.handleAgentConversationManagementCommand(
+          {
+            type: "conversation_update",
+            request_id: "conversation-update-1",
+            conversation_id: conversationId,
+            body: { summary: "Updated conversation summary" },
+          },
+          socket as unknown as WebSocket,
+        );
+        expect(JSON.parse(socket.sentPayloads.at(-1) ?? "{}")).toMatchObject({
+          type: "conversation_update_response",
+          request_id: "conversation-update-1",
+          success: true,
+          conversation: {
+            id: conversationId,
+            summary: "Updated conversation summary",
+          },
+        });
+
+        await __listenClientTestUtils.handleAgentConversationManagementCommand(
+          {
+            type: "conversation_recompile",
+            request_id: "conversation-recompile-1",
+            conversation_id: conversationId,
+            body: { dry_run: true },
+          },
+          socket as unknown as WebSocket,
+        );
+        expect(JSON.parse(socket.sentPayloads.at(-1) ?? "{}")).toMatchObject({
+          type: "conversation_recompile_response",
+          request_id: "conversation-recompile-1",
+          success: true,
+          result: expect.any(String),
+        });
+
+        await __listenClientTestUtils.handleAgentConversationManagementCommand(
+          {
+            type: "conversation_fork",
+            request_id: "conversation-fork-1",
+            conversation_id: conversationId,
+            body: { hidden: true },
+          },
+          socket as unknown as WebSocket,
+        );
+        expect(JSON.parse(socket.sentPayloads.at(-1) ?? "{}")).toMatchObject({
+          type: "conversation_fork_response",
+          request_id: "conversation-fork-1",
+          success: true,
+          conversation: { id: expect.any(String) },
+        });
+
+        await __listenClientTestUtils.handleAgentConversationManagementCommand(
+          {
+            type: "conversation_messages_list",
+            request_id: "conversation-messages-list-1",
+            conversation_id: conversationId,
+            query: { limit: 10 },
+          },
+          socket as unknown as WebSocket,
+        );
+        expect(JSON.parse(socket.sentPayloads.at(-1) ?? "{}")).toMatchObject({
+          type: "conversation_messages_list_response",
+          request_id: "conversation-messages-list-1",
+          success: true,
+          messages: expect.any(Array),
+        });
+
+        await __listenClientTestUtils.handleAgentConversationManagementCommand(
+          {
+            type: "conversation_compact",
+            request_id: "conversation-compact-1",
+            conversation_id: conversationId,
+          },
+          socket as unknown as WebSocket,
+        );
+        expect(JSON.parse(socket.sentPayloads.at(-1) ?? "{}")).toMatchObject({
+          type: "conversation_compact_response",
+          request_id: "conversation-compact-1",
+          success: true,
+          compaction: {
+            num_messages_before: 4,
+            num_messages_after: 2,
+            summary: "compacted summary",
+          },
+        });
+
+        await __listenClientTestUtils.handleAgentConversationManagementCommand(
+          {
+            type: "agent_delete",
+            request_id: "agent-delete-1",
+            agent_id: agentId,
+          },
+          socket as unknown as WebSocket,
+        );
+        expect(JSON.parse(socket.sentPayloads.at(-1) ?? "{}")).toMatchObject({
+          type: "agent_delete_response",
+          request_id: "agent-delete-1",
+          success: true,
+          agent_id: agentId,
         });
       } finally {
         await rm(storageDir, { recursive: true, force: true });

--- a/src/websocket/listener/commands/agents-conversations.ts
+++ b/src/websocket/listener/commands/agents-conversations.ts
@@ -2,19 +2,33 @@ import type WebSocket from "ws";
 import { getBackend } from "@/backend";
 import type {
   AgentCreateCommand,
+  AgentDeleteCommand,
   AgentListCommand,
   AgentRetrieveCommand,
+  AgentUpdateCommand,
+  ConversationCompactCommand,
   ConversationCreateCommand,
+  ConversationForkCommand,
   ConversationListCommand,
+  ConversationMessagesListCommand,
+  ConversationRecompileCommand,
   ConversationRetrieveCommand,
+  ConversationUpdateCommand,
 } from "@/types/protocol_v2";
 import {
   isAgentCreateCommand,
+  isAgentDeleteCommand,
   isAgentListCommand,
   isAgentRetrieveCommand,
+  isAgentUpdateCommand,
+  isConversationCompactCommand,
   isConversationCreateCommand,
+  isConversationForkCommand,
   isConversationListCommand,
+  isConversationMessagesListCommand,
+  isConversationRecompileCommand,
   isConversationRetrieveCommand,
+  isConversationUpdateCommand,
 } from "@/websocket/listener/protocol-inbound";
 import type { RunDetachedListenerTask, SafeSocketSend } from "./types";
 
@@ -22,9 +36,16 @@ export type AgentConversationManagementCommand =
   | AgentListCommand
   | AgentRetrieveCommand
   | AgentCreateCommand
+  | AgentUpdateCommand
+  | AgentDeleteCommand
   | ConversationListCommand
   | ConversationRetrieveCommand
-  | ConversationCreateCommand;
+  | ConversationCreateCommand
+  | ConversationUpdateCommand
+  | ConversationRecompileCommand
+  | ConversationForkCommand
+  | ConversationMessagesListCommand
+  | ConversationCompactCommand;
 
 type AgentConversationManagementCommandContext = {
   socket: WebSocket;
@@ -153,6 +174,68 @@ export async function handleAgentConversationManagementCommand(
     return true;
   }
 
+  if (parsed.type === "agent_update") {
+    try {
+      const agent = await backend.updateAgent(parsed.agent_id, parsed.body);
+      safeSocketSend(
+        socket,
+        {
+          type: "agent_update_response",
+          request_id: parsed.request_id,
+          success: true,
+          agent,
+        },
+        "listener_agent_management_send_failed",
+        "listener_agent_management",
+      );
+    } catch (error) {
+      safeSocketSend(
+        socket,
+        {
+          type: "agent_update_response",
+          request_id: parsed.request_id,
+          success: false,
+          agent: null,
+          error: getErrorMessage(error, "Failed to update agent"),
+        },
+        "listener_agent_management_send_failed",
+        "listener_agent_management",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "agent_delete") {
+    try {
+      await backend.deleteAgent(parsed.agent_id);
+      safeSocketSend(
+        socket,
+        {
+          type: "agent_delete_response",
+          request_id: parsed.request_id,
+          success: true,
+          agent_id: parsed.agent_id,
+        },
+        "listener_agent_management_send_failed",
+        "listener_agent_management",
+      );
+    } catch (error) {
+      safeSocketSend(
+        socket,
+        {
+          type: "agent_delete_response",
+          request_id: parsed.request_id,
+          success: false,
+          agent_id: parsed.agent_id,
+          error: getErrorMessage(error, "Failed to delete agent"),
+        },
+        "listener_agent_management_send_failed",
+        "listener_agent_management",
+      );
+    }
+    return true;
+  }
+
   if (parsed.type === "conversation_list") {
     try {
       const page = await backend.listConversations(parsed.query);
@@ -248,6 +331,183 @@ export async function handleAgentConversationManagementCommand(
     return true;
   }
 
+  if (parsed.type === "conversation_update") {
+    try {
+      const conversation = await backend.updateConversation(
+        parsed.conversation_id,
+        parsed.body,
+      );
+      safeSocketSend(
+        socket,
+        {
+          type: "conversation_update_response",
+          request_id: parsed.request_id,
+          success: true,
+          conversation,
+        },
+        "listener_conversation_management_send_failed",
+        "listener_conversation_management",
+      );
+    } catch (error) {
+      safeSocketSend(
+        socket,
+        {
+          type: "conversation_update_response",
+          request_id: parsed.request_id,
+          success: false,
+          conversation: null,
+          error: getErrorMessage(error, "Failed to update conversation"),
+        },
+        "listener_conversation_management_send_failed",
+        "listener_conversation_management",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "conversation_recompile") {
+    try {
+      const result = await backend.recompileConversation(
+        parsed.conversation_id,
+        parsed.body,
+      );
+      safeSocketSend(
+        socket,
+        {
+          type: "conversation_recompile_response",
+          request_id: parsed.request_id,
+          success: true,
+          result,
+        },
+        "listener_conversation_management_send_failed",
+        "listener_conversation_management",
+      );
+    } catch (error) {
+      safeSocketSend(
+        socket,
+        {
+          type: "conversation_recompile_response",
+          request_id: parsed.request_id,
+          success: false,
+          result: null,
+          error: getErrorMessage(error, "Failed to recompile conversation"),
+        },
+        "listener_conversation_management_send_failed",
+        "listener_conversation_management",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "conversation_fork") {
+    try {
+      const conversation = await backend.forkConversation(
+        parsed.conversation_id,
+        {
+          ...(typeof parsed.body?.agent_id === "string"
+            ? { agentId: parsed.body.agent_id }
+            : {}),
+          ...(typeof parsed.body?.hidden === "boolean"
+            ? { hidden: parsed.body.hidden }
+            : {}),
+        },
+      );
+      safeSocketSend(
+        socket,
+        {
+          type: "conversation_fork_response",
+          request_id: parsed.request_id,
+          success: true,
+          conversation,
+        },
+        "listener_conversation_management_send_failed",
+        "listener_conversation_management",
+      );
+    } catch (error) {
+      safeSocketSend(
+        socket,
+        {
+          type: "conversation_fork_response",
+          request_id: parsed.request_id,
+          success: false,
+          conversation: null,
+          error: getErrorMessage(error, "Failed to fork conversation"),
+        },
+        "listener_conversation_management_send_failed",
+        "listener_conversation_management",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "conversation_messages_list") {
+    try {
+      const page = await backend.listConversationMessages(
+        parsed.conversation_id,
+        parsed.query,
+      );
+      safeSocketSend(
+        socket,
+        {
+          type: "conversation_messages_list_response",
+          request_id: parsed.request_id,
+          success: true,
+          messages: getPageItems(page),
+        },
+        "listener_conversation_management_send_failed",
+        "listener_conversation_management",
+      );
+    } catch (error) {
+      safeSocketSend(
+        socket,
+        {
+          type: "conversation_messages_list_response",
+          request_id: parsed.request_id,
+          success: false,
+          messages: [],
+          error: getErrorMessage(error, "Failed to list conversation messages"),
+        },
+        "listener_conversation_management_send_failed",
+        "listener_conversation_management",
+      );
+    }
+    return true;
+  }
+
+  if (parsed.type === "conversation_compact") {
+    try {
+      const compaction = await backend.compactConversationMessages(
+        parsed.conversation_id,
+        parsed.body,
+      );
+      safeSocketSend(
+        socket,
+        {
+          type: "conversation_compact_response",
+          request_id: parsed.request_id,
+          success: true,
+          compaction,
+        },
+        "listener_conversation_management_send_failed",
+        "listener_conversation_management",
+      );
+    } catch (error) {
+      safeSocketSend(
+        socket,
+        {
+          type: "conversation_compact_response",
+          request_id: parsed.request_id,
+          success: false,
+          compaction: null,
+          error: getErrorMessage(error, "Failed to compact conversation"),
+        },
+        "listener_conversation_management_send_failed",
+        "listener_conversation_management",
+      );
+    }
+    return true;
+  }
+
   return false;
 }
 
@@ -261,9 +521,16 @@ export function handleAgentConversationManagementProtocolCommand(
     isAgentListCommand(parsed) ||
     isAgentRetrieveCommand(parsed) ||
     isAgentCreateCommand(parsed) ||
+    isAgentUpdateCommand(parsed) ||
+    isAgentDeleteCommand(parsed) ||
     isConversationListCommand(parsed) ||
     isConversationRetrieveCommand(parsed) ||
-    isConversationCreateCommand(parsed)
+    isConversationCreateCommand(parsed) ||
+    isConversationUpdateCommand(parsed) ||
+    isConversationRecompileCommand(parsed) ||
+    isConversationForkCommand(parsed) ||
+    isConversationMessagesListCommand(parsed) ||
+    isConversationCompactCommand(parsed)
   ) {
     runDetachedListenerTask(
       "agent_conversation_management_command",

--- a/src/websocket/listener/protocol-inbound.test.ts
+++ b/src/websocket/listener/protocol-inbound.test.ts
@@ -26,18 +26,55 @@ describe("agent/conversation management protocol-inbound validators", () => {
     { type: "agent_retrieve", request_id: "r2", agent_id: "agent-1" },
     { type: "agent_create", request_id: "r3", body: { name: "Agent" } },
     {
-      type: "conversation_list",
+      type: "agent_update",
       request_id: "r4",
+      agent_id: "agent-1",
+      body: { name: "Updated" },
+    },
+    { type: "agent_delete", request_id: "r5", agent_id: "agent-1" },
+    {
+      type: "conversation_list",
+      request_id: "r6",
       query: { agent_id: "agent-1", limit: 10 },
     },
     {
       type: "conversation_retrieve",
-      request_id: "r5",
+      request_id: "r7",
       conversation_id: "conv-1",
     },
     {
       type: "conversation_create",
-      request_id: "r6",
+      request_id: "r8",
+      body: { agent_id: "agent-1" },
+    },
+    {
+      type: "conversation_update",
+      request_id: "r9",
+      conversation_id: "conv-1",
+      body: { summary: "Updated" },
+    },
+    {
+      type: "conversation_recompile",
+      request_id: "r10",
+      conversation_id: "conv-1",
+      body: { dry_run: true },
+    },
+    {
+      type: "conversation_fork",
+      request_id: "r11",
+      conversation_id: "conv-1",
+      body: { hidden: true },
+    },
+    {
+      type: "conversation_messages_list",
+      request_id: "r12",
+      conversation_id: "conv-1",
+      query: { limit: 10 },
+    },
+    {
+      type: "conversation_compact",
+      request_id: "r13",
+      conversation_id: "conv-1",
       body: { agent_id: "agent-1" },
     },
   ])("accepts $type", (message) => {
@@ -49,9 +86,36 @@ describe("agent/conversation management protocol-inbound validators", () => {
     { type: "agent_list", request_id: "r1", query: "bad" },
     { type: "agent_retrieve", request_id: "r2" },
     { type: "agent_create", request_id: "r3", body: null },
+    { type: "agent_update", request_id: "r4", agent_id: "agent-1" },
+    { type: "agent_delete", request_id: "r5" },
     { type: "conversation_list", request_id: "r4", query: [] },
     { type: "conversation_retrieve", request_id: "r5" },
     { type: "conversation_create", request_id: "r6", body: "bad" },
+    { type: "conversation_update", request_id: "r7", body: {} },
+    {
+      type: "conversation_recompile",
+      request_id: "r8",
+      conversation_id: "conv-1",
+      body: [],
+    },
+    {
+      type: "conversation_fork",
+      request_id: "r9",
+      conversation_id: "conv-1",
+      body: [],
+    },
+    {
+      type: "conversation_messages_list",
+      request_id: "r10",
+      conversation_id: "conv-1",
+      query: "bad",
+    },
+    {
+      type: "conversation_compact",
+      request_id: "r11",
+      conversation_id: "conv-1",
+      body: [],
+    },
   ])("rejects invalid $type", (message) => {
     const parsed = parseServerMessage(Buffer.from(JSON.stringify(message)));
     expect(parsed).toBeNull();

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -5,8 +5,10 @@ import type { ExperimentId } from "@/experiments/types";
 import type {
   AbortMessageCommand,
   AgentCreateCommand,
+  AgentDeleteCommand,
   AgentListCommand,
   AgentRetrieveCommand,
+  AgentUpdateCommand,
   ChangeDeviceStateCommand,
   ChannelAccountBindCommand,
   ChannelAccountCreateCommand,
@@ -30,9 +32,14 @@ import type {
   ChannelTargetsListCommand,
   CheckoutBranchCommand,
   ConnectProviderCommand,
+  ConversationCompactCommand,
   ConversationCreateCommand,
+  ConversationForkCommand,
   ConversationListCommand,
+  ConversationMessagesListCommand,
+  ConversationRecompileCommand,
   ConversationRetrieveCommand,
+  ConversationUpdateCommand,
   CreateAgentCommand,
   CronAddCommand,
   CronDeleteAllCommand,
@@ -1071,6 +1078,40 @@ export function isAgentCreateCommand(
   );
 }
 
+export function isAgentUpdateCommand(
+  value: unknown,
+): value is AgentUpdateCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    agent_id?: unknown;
+    body?: unknown;
+  };
+  return (
+    c.type === "agent_update" &&
+    typeof c.request_id === "string" &&
+    typeof c.agent_id === "string" &&
+    isObjectRecord(c.body)
+  );
+}
+
+export function isAgentDeleteCommand(
+  value: unknown,
+): value is AgentDeleteCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    agent_id?: unknown;
+  };
+  return (
+    c.type === "agent_delete" &&
+    typeof c.request_id === "string" &&
+    typeof c.agent_id === "string"
+  );
+}
+
 export function isConversationListCommand(
   value: unknown,
 ): value is ConversationListCommand {
@@ -1116,6 +1157,96 @@ export function isConversationCreateCommand(
     c.type === "conversation_create" &&
     typeof c.request_id === "string" &&
     isObjectRecord(c.body)
+  );
+}
+
+export function isConversationUpdateCommand(
+  value: unknown,
+): value is ConversationUpdateCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    conversation_id?: unknown;
+    body?: unknown;
+  };
+  return (
+    c.type === "conversation_update" &&
+    typeof c.request_id === "string" &&
+    typeof c.conversation_id === "string" &&
+    isObjectRecord(c.body)
+  );
+}
+
+export function isConversationRecompileCommand(
+  value: unknown,
+): value is ConversationRecompileCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    conversation_id?: unknown;
+    body?: unknown;
+  };
+  return (
+    c.type === "conversation_recompile" &&
+    typeof c.request_id === "string" &&
+    typeof c.conversation_id === "string" &&
+    (c.body === undefined || isObjectRecord(c.body))
+  );
+}
+
+export function isConversationForkCommand(
+  value: unknown,
+): value is ConversationForkCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    conversation_id?: unknown;
+    body?: unknown;
+  };
+  return (
+    c.type === "conversation_fork" &&
+    typeof c.request_id === "string" &&
+    typeof c.conversation_id === "string" &&
+    (c.body === undefined || isObjectRecord(c.body))
+  );
+}
+
+export function isConversationMessagesListCommand(
+  value: unknown,
+): value is ConversationMessagesListCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    conversation_id?: unknown;
+    query?: unknown;
+  };
+  return (
+    c.type === "conversation_messages_list" &&
+    typeof c.request_id === "string" &&
+    typeof c.conversation_id === "string" &&
+    (c.query === undefined || isObjectRecord(c.query))
+  );
+}
+
+export function isConversationCompactCommand(
+  value: unknown,
+): value is ConversationCompactCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    conversation_id?: unknown;
+    body?: unknown;
+  };
+  return (
+    c.type === "conversation_compact" &&
+    typeof c.request_id === "string" &&
+    typeof c.conversation_id === "string" &&
+    (c.body === undefined || isObjectRecord(c.body))
   );
 }
 
@@ -1913,9 +2044,16 @@ export function parseServerMessage(
       isAgentListCommand(parsed) ||
       isAgentRetrieveCommand(parsed) ||
       isAgentCreateCommand(parsed) ||
+      isAgentUpdateCommand(parsed) ||
+      isAgentDeleteCommand(parsed) ||
       isConversationListCommand(parsed) ||
       isConversationRetrieveCommand(parsed) ||
       isConversationCreateCommand(parsed) ||
+      isConversationUpdateCommand(parsed) ||
+      isConversationRecompileCommand(parsed) ||
+      isConversationForkCommand(parsed) ||
+      isConversationMessagesListCommand(parsed) ||
+      isConversationCompactCommand(parsed) ||
       isGetCwdMapCommand(parsed) ||
       isGetExperimentsCommand(parsed) ||
       isSetExperimentCommand(parsed) ||


### PR DESCRIPTION
## Summary
- add typed app-server commands for agent update/delete
- add typed app-server commands for conversation update, recompile, fork, message listing, and compact
- extend parser, command handling, and protocol export coverage

## Testing
- `bun test src/types/app-server-protocol.test.ts src/websocket/listener/protocol-inbound.test.ts src/websocket/listen-client-protocol.test.ts --timeout 30000`
- `bun run lint`
- `bun run typecheck`
- `bun run check`