### PR TITLE
fix(tui): scroll help dialog with arrows

### DIFF
--- a/src/cli/components/HelpDialog.test.tsx
+++ b/src/cli/components/HelpDialog.test.tsx
@@ -29,16 +29,21 @@ function createInputStream(): NodeJS.ReadStream {
   return input;
 }
 
-async function renderHelpDialog(): Promise<string> {
+async function renderHelpDialog(
+  interact?: (stdin: NodeJS.ReadStream) => void | Promise<void>,
+): Promise<string> {
   const stdout = new CaptureStream() as CaptureStream & NodeJS.WriteStream;
+  const stdin = createInputStream();
   const instance = render(<HelpDialog onClose={() => {}} />, {
     stdout,
-    stdin: createInputStream(),
+    stdin,
     debug: false,
     patchConsole: false,
     exitOnCtrlC: false,
   });
 
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  await interact?.(stdin);
   await new Promise((resolve) => setTimeout(resolve, 20));
   instance.unmount();
   instance.cleanup();
@@ -50,7 +55,22 @@ test("HelpDialog renders its footer without raw Ink text", async () => {
   const output = await renderHelpDialog();
 
   expect(output).toContain("Letta Code v");
-  expect(output).toContain(
-    "Enter select · ↑↓ navigate · ←→/Tab switch · Esc cancel",
-  );
+  expect(output).toContain("↑↓ scroll · ←→ page · Tab switch · Esc cancel");
+});
+
+test("HelpDialog keeps spacing between commands and descriptions", async () => {
+  const output = await renderHelpDialog();
+
+  expect(output).toContain("/goal Manage goal");
+});
+
+test("HelpDialog scrolls commands with down arrow", async () => {
+  const output = await renderHelpDialog(async (stdin) => {
+    for (let i = 0; i < 10; i += 1) {
+      stdin.push("\x1b[B");
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+  });
+
+  expect(output).toContain("Page 2/");
 });

--- a/src/cli/components/HelpDialog.tsx
+++ b/src/cli/components/HelpDialog.tsx
@@ -114,11 +114,28 @@ export function HelpDialog({ onClose }: HelpDialogProps) {
         } else if (key.tab) {
           cycleTab();
         } else if (key.upArrow) {
-          setSelectedIndex((prev) => Math.max(0, prev - 1));
+          setSelectedIndex((prev) => {
+            if (prev > 0) return prev - 1;
+            if (currentPage > 0) {
+              const previousPageStart = (currentPage - 1) * PAGE_SIZE;
+              const previousPageLength = Math.min(
+                PAGE_SIZE,
+                visibleItems.length - previousPageStart,
+              );
+              setCurrentPage((page) => page - 1);
+              return Math.max(0, previousPageLength - 1);
+            }
+            return prev;
+          });
         } else if (key.downArrow) {
-          setSelectedIndex((prev) =>
-            Math.min(visiblePageItems.length - 1, prev + 1),
-          );
+          setSelectedIndex((prev) => {
+            if (prev < visiblePageItems.length - 1) return prev + 1;
+            if (currentPage < totalPages - 1) {
+              setCurrentPage((page) => page + 1);
+              return 0;
+            }
+            return prev;
+          });
         } else if (input === "j" || input === "J") {
           // Previous page
           if (currentPage > 0) {
@@ -139,7 +156,14 @@ export function HelpDialog({ onClose }: HelpDialogProps) {
           setSelectedIndex(0);
         }
       },
-      [currentPage, totalPages, visiblePageItems.length, onClose, cycleTab],
+      [
+        currentPage,
+        totalPages,
+        visibleItems.length,
+        visiblePageItems.length,
+        onClose,
+        cycleTab,
+      ],
     ),
     { isActive: true },
   );
@@ -155,7 +179,7 @@ export function HelpDialog({ onClose }: HelpDialogProps) {
     <OverlayShell
       command="/help"
       title={`Letta Code v${version}`}
-      footer={`Enter select · ↑↓ navigate · ←→/Tab switch · Esc cancel`}
+      footer={`↑↓ scroll · ←→ page · Tab switch · Esc cancel`}
     >
       <Box flexDirection="column" paddingLeft={1}>
         <TabBar tabs={HELP_TABS} activeTab={activeTab} getLabel={getTabLabel} />
@@ -189,7 +213,9 @@ export function HelpDialog({ onClose }: HelpDialogProps) {
                     >
                       {command.name}
                     </Text>
-                    <Text dimColor> {command.description}</Text>
+                    <Box marginLeft={1}>
+                      <Text dimColor>{command.description}</Text>
+                    </Box>
                   </Box>
                 </Box>
               </Box>
@@ -219,7 +245,9 @@ export function HelpDialog({ onClose }: HelpDialogProps) {
                     >
                       {shortcut.keys}
                     </Text>
-                    <Text dimColor> {shortcut.description}</Text>
+                    <Box marginLeft={1}>
+                      <Text dimColor>{shortcut.description}</Text>
+                    </Box>
                   </Box>
                 </Box>
               </Box>


### PR DESCRIPTION
## Summary
- Let ↑/↓ navigation move across `/help` pages instead of stopping at the current page boundary
- Update the help footer to describe arrow scrolling
- Preserve spacing between command names and wrapped descriptions, including `/goal Manage goal`

## Testing
- `bun test src/cli/components/HelpDialog.test.tsx`
- `bunx --bun @biomejs/biome@2.2.5 check src/cli/components/HelpDialog.tsx src/cli/components/HelpDialog.test.tsx`
- `bun run check` (fails on existing unrelated type error in `src/backend/dev/pi-provider-registry.ts`)

Based on latest `origin/main` at `7105d8e7`.
