### PR TITLE
feat(app-server): add runtime_start command

### DIFF
--- a/src/types/app-server-protocol.test.ts
+++ b/src/types/app-server-protocol.test.ts
@@ -104,6 +104,15 @@ describe("app-server protocol export", () => {
         success: true,
         compaction: null,
       },
+      {
+        type: "runtime_start_response",
+        request_id: "req",
+        success: true,
+        runtime: null,
+        agent: null,
+        conversation: null,
+        created: { agent: false, conversation: false },
+      },
     ] satisfies WsProtocolMessage[];
 
     expect(messages.map((message) => message.type)).toEqual([
@@ -124,6 +133,7 @@ describe("app-server protocol export", () => {
       "conversation_fork_response",
       "conversation_messages_list_response",
       "conversation_compact_response",
+      "runtime_start_response",
     ]);
   });
 });

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -752,6 +752,48 @@ export interface SyncCommand {
   force_device_status?: boolean;
 }
 
+export interface RuntimeStartCreateAgentOptions {
+  /** Body forwarded to the Letta agents create API. */
+  body: AgentCreateParams;
+  /** Whether to pin the created agent globally. Defaults to true. */
+  pin_global?: boolean;
+}
+
+export interface RuntimeStartCreateConversationOptions {
+  /** Body forwarded to the Letta conversations create API. */
+  body?: Omit<ConversationCreateParams, "agent_id">;
+}
+
+export interface RuntimeStartClientInfo {
+  name: string;
+  title?: string;
+  version?: string;
+}
+
+export interface RuntimeStartCommand {
+  type: "runtime_start";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  /** Existing agent to start/resume a runtime for. Mutually exclusive with create_agent. */
+  agent_id?: string;
+  /** Create a new agent before starting the runtime. Mutually exclusive with agent_id. */
+  create_agent?: RuntimeStartCreateAgentOptions;
+  /** Existing conversation to start/resume. Mutually exclusive with create_conversation. */
+  conversation_id?: string;
+  /** Create a new conversation for the resolved agent before starting the runtime. */
+  create_conversation?: RuntimeStartCreateConversationOptions;
+  /** Initial working directory for this runtime scope. Null resets to listener boot CWD. */
+  cwd?: string | null;
+  /** Initial permission mode for this runtime scope. */
+  mode?: DevicePermissionMode;
+  /** Optional client metadata for diagnostics/future protocol negotiation. */
+  client_info?: RuntimeStartClientInfo;
+  /** Whether to probe backend state for stale pending approvals before replaying state. Defaults to true. */
+  recover_approvals?: boolean;
+  /** Force the initial state replay to include update_device_status. Defaults to true. */
+  force_device_status?: boolean;
+}
+
 export interface TerminalSpawnCommand {
   type: "terminal_spawn";
   terminal_id: string;
@@ -2115,6 +2157,20 @@ export interface ConversationCompactResponseMessage {
   error?: string;
 }
 
+export interface RuntimeStartResponseMessage {
+  type: "runtime_start_response";
+  request_id: string;
+  success: boolean;
+  runtime: RuntimeScope | null;
+  agent: AgentState | null;
+  conversation: Conversation | null;
+  created: {
+    agent: boolean;
+    conversation: boolean;
+  };
+  error?: string;
+}
+
 export interface GetReflectionSettingsResponseMessage {
   type: "get_reflection_settings_response";
   request_id: string;
@@ -2521,6 +2577,7 @@ export type WsProtocolCommand =
   | ChangeDeviceStateCommand
   | AbortMessageCommand
   | SyncCommand
+  | RuntimeStartCommand
   | TerminalSpawnCommand
   | TerminalInputCommand
   | TerminalResizeCommand
@@ -2668,6 +2725,7 @@ export type WsProtocolMessage =
   | ConversationForkResponseMessage
   | ConversationMessagesListResponseMessage
   | ConversationCompactResponseMessage
+  | RuntimeStartResponseMessage
   | GetExperimentsResponseMessage
   | SetExperimentResponseMessage
   | ListConversationPinsResponseMessage

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -571,6 +571,178 @@ describe("listen-client parseServerMessage", () => {
     });
   });
 
+  describe("listen-client runtime_start command handling", () => {
+    test("creates an agent and conversation, starts runtime, and replays state", async () => {
+      const storageDir = await mkdtemp(join(os.tmpdir(), "ws-runtime-start-"));
+      const cwdDir = await mkdtemp(join(os.tmpdir(), "ws-runtime-cwd-"));
+      try {
+        const backend = new LocalBackend({
+          storageDir,
+          executionMode: "deterministic",
+        });
+        __testSetBackend(backend);
+        const listener = __listenClientTestUtils.createListenerRuntime();
+        const socket = new MockSocket(WebSocket.OPEN);
+
+        await __listenClientTestUtils.handleRuntimeStartCommand(
+          {
+            type: "runtime_start",
+            request_id: "runtime-start-create",
+            create_agent: {
+              body: {
+                name: "Runtime Agent",
+                model: "anthropic/claude-sonnet-4-6",
+              } as AgentCreateBody,
+              pin_global: false,
+            },
+            create_conversation: {
+              body: { summary: "Runtime conversation" },
+            },
+            cwd: cwdDir,
+            mode: "acceptEdits",
+            recover_approvals: false,
+          },
+          socket as unknown as WebSocket,
+          listener,
+        );
+
+        const messages = socket.sentPayloads.map((payload) =>
+          JSON.parse(payload),
+        );
+        const runtimeScope = messages[0].runtime as {
+          agent_id: string;
+          conversation_id: string;
+        };
+        expect(runtimeScope.agent_id).toEqual(expect.any(String));
+        expect(runtimeScope.conversation_id).toEqual(expect.any(String));
+        expect(messages[0]).toMatchObject({
+          type: "runtime_start_response",
+          request_id: "runtime-start-create",
+          success: true,
+          runtime: runtimeScope,
+          agent: { name: "Runtime Agent" },
+          conversation: { summary: "Runtime conversation" },
+          created: { agent: true, conversation: true },
+        });
+        expect(
+          __listenClientTestUtils.getConversationWorkingDirectory(
+            listener,
+            runtimeScope.agent_id,
+            runtimeScope.conversation_id,
+          ),
+        ).toBe(cwdDir);
+        expect(messages).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              type: "update_device_status",
+              runtime: runtimeScope,
+              device_status: expect.objectContaining({
+                current_working_directory: cwdDir,
+                current_permission_mode: "acceptEdits",
+              }),
+            }),
+            expect.objectContaining({
+              type: "update_loop_status",
+              runtime: runtimeScope,
+            }),
+            expect.objectContaining({
+              type: "update_queue",
+              runtime: runtimeScope,
+            }),
+          ]),
+        );
+      } finally {
+        await rm(storageDir, { recursive: true, force: true });
+        await rm(cwdDir, { recursive: true, force: true });
+      }
+    });
+
+    test("resumes an existing agent and conversation", async () => {
+      const storageDir = await mkdtemp(
+        join(os.tmpdir(), "ws-runtime-start-resume-"),
+      );
+      try {
+        const backend = new LocalBackend({
+          storageDir,
+          executionMode: "deterministic",
+        });
+        __testSetBackend(backend);
+        const agent = await backend.createAgent({
+          name: "Runtime Existing Agent",
+          model: "anthropic/claude-sonnet-4-6",
+        } as AgentCreateBody);
+        const conversation = await backend.createConversation({
+          agent_id: agent.id,
+          summary: "Existing conversation",
+        });
+        const listener = __listenClientTestUtils.createListenerRuntime();
+        const socket = new MockSocket(WebSocket.OPEN);
+
+        await __listenClientTestUtils.handleRuntimeStartCommand(
+          {
+            type: "runtime_start",
+            request_id: "runtime-start-resume",
+            agent_id: agent.id,
+            conversation_id: conversation.id,
+            recover_approvals: false,
+          },
+          socket as unknown as WebSocket,
+          listener,
+        );
+
+        expect(JSON.parse(socket.sentPayloads[0] ?? "{}")).toMatchObject({
+          type: "runtime_start_response",
+          request_id: "runtime-start-resume",
+          success: true,
+          runtime: {
+            agent_id: agent.id,
+            conversation_id: conversation.id,
+          },
+          agent: { id: agent.id },
+          conversation: { id: conversation.id },
+          created: { agent: false, conversation: false },
+        });
+      } finally {
+        await rm(storageDir, { recursive: true, force: true });
+      }
+    });
+
+    test("soft-fails invalid runtime_start combinations", async () => {
+      const storageDir = await mkdtemp(
+        join(os.tmpdir(), "ws-runtime-start-error-"),
+      );
+      try {
+        __testSetBackend(
+          new LocalBackend({ storageDir, executionMode: "deterministic" }),
+        );
+        const listener = __listenClientTestUtils.createListenerRuntime();
+        const socket = new MockSocket(WebSocket.OPEN);
+
+        await __listenClientTestUtils.handleRuntimeStartCommand(
+          {
+            type: "runtime_start",
+            request_id: "runtime-start-invalid",
+            agent_id: "agent-1",
+            create_agent: { body: { name: "Bad" } as AgentCreateBody },
+            recover_approvals: false,
+          },
+          socket as unknown as WebSocket,
+          listener,
+        );
+
+        expect(JSON.parse(socket.sentPayloads.at(-1) ?? "{}")).toMatchObject({
+          type: "runtime_start_response",
+          request_id: "runtime-start-invalid",
+          success: false,
+          runtime: null,
+          created: { agent: false, conversation: false },
+        });
+      } finally {
+        await rm(storageDir, { recursive: true, force: true });
+      }
+    });
+  });
+
   test("classifies invalid input approval_response payloads", () => {
     const missingResponse = parseServerMessage(
       Buffer.from(

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -30,6 +30,10 @@ import {
   resolveModelForUpdate,
 } from "./commands/model-toolset";
 import {
+  handleRuntimeStartCommand,
+  handleRuntimeStartProtocolCommand,
+} from "./commands/runtime-start";
+import {
   handleExperimentCommand,
   handleReflectionSettingsCommand,
 } from "./commands/settings";
@@ -524,6 +528,50 @@ export const __listenClientTestUtils = {
       socket,
       safeSocketSend,
       runDetachedListenerTask,
+    }),
+  handleRuntimeStartCommand: (
+    parsed: Parameters<typeof handleRuntimeStartCommand>[0],
+    socket: WebSocket,
+    runtime: ListenerRuntime,
+  ) =>
+    handleRuntimeStartCommand(parsed, {
+      socket,
+      runtime,
+      safeSocketSend,
+      runDetachedListenerTask,
+      getOrCreateScopedRuntime,
+      replaySyncStateForRuntime: (
+        listenerRuntime,
+        runtimeSocket,
+        scope,
+        opts,
+      ) =>
+        replaySyncStateForRuntime(listenerRuntime, runtimeSocket, scope, {
+          ...opts,
+          scheduleWarmupsAfterSync: () => {},
+        }),
+    }),
+  handleRuntimeStartProtocolCommand: (
+    parsed: Parameters<typeof handleRuntimeStartProtocolCommand>[0],
+    socket: WebSocket,
+    runtime: ListenerRuntime,
+  ) =>
+    handleRuntimeStartProtocolCommand(parsed, {
+      socket,
+      runtime,
+      safeSocketSend,
+      runDetachedListenerTask,
+      getOrCreateScopedRuntime,
+      replaySyncStateForRuntime: (
+        listenerRuntime,
+        runtimeSocket,
+        scope,
+        opts,
+      ) =>
+        replaySyncStateForRuntime(listenerRuntime, runtimeSocket, scope, {
+          ...opts,
+          scheduleWarmupsAfterSync: () => {},
+        }),
     }),
   handleSkillCommand: (
     parsed: Parameters<typeof handleSkillCommand>[0],

--- a/src/websocket/listener/commands/runtime-start.ts
+++ b/src/websocket/listener/commands/runtime-start.ts
@@ -1,0 +1,264 @@
+import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import type {
+  Conversation,
+  ConversationCreateParams,
+} from "@letta-ai/letta-client/resources/conversations/conversations";
+import type WebSocket from "ws";
+import { getBackend } from "@/backend";
+import { migratePermissionMode } from "@/permissions/mode";
+import { settingsManager } from "@/settings-manager";
+import type { RuntimeScope, RuntimeStartCommand } from "@/types/protocol_v2";
+import { switchConversationWorkingDirectory } from "@/websocket/listener/cwd-change";
+import {
+  getOrCreateConversationPermissionModeStateRef,
+  persistPermissionModeMapForRuntime,
+} from "@/websocket/listener/permission-mode";
+import { isRuntimeStartCommand } from "@/websocket/listener/protocol-inbound";
+import type {
+  ConversationRuntime,
+  ListenerRuntime,
+} from "@/websocket/listener/types";
+import type {
+  GetOrCreateScopedRuntime,
+  RunDetachedListenerTask,
+  SafeSocketSend,
+} from "./types";
+
+type ReplaySyncStateForRuntime = (
+  listenerRuntime: ListenerRuntime,
+  socket: WebSocket,
+  scope: RuntimeScope,
+  opts?: { recoverApprovals?: boolean; forceDeviceStatus?: boolean },
+) => Promise<void>;
+
+type RuntimeStartCommandContext = {
+  socket: WebSocket;
+  runtime: ListenerRuntime;
+  safeSocketSend: SafeSocketSend;
+  runDetachedListenerTask: RunDetachedListenerTask;
+  getOrCreateScopedRuntime: GetOrCreateScopedRuntime;
+  replaySyncStateForRuntime: ReplaySyncStateForRuntime;
+};
+
+type CreatedResources = {
+  agent: boolean;
+  conversation: boolean;
+};
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+function hasString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function buildRuntimeScope(
+  agent: AgentState,
+  conversation: Conversation,
+): RuntimeScope {
+  return {
+    agent_id: agent.id,
+    conversation_id: conversation.id,
+  };
+}
+
+function sendRuntimeStartResponse(
+  context: RuntimeStartCommandContext,
+  parsed: RuntimeStartCommand,
+  response: {
+    success: boolean;
+    runtime: RuntimeScope | null;
+    agent: AgentState | null;
+    conversation: Conversation | null;
+    created: CreatedResources;
+    error?: string;
+  },
+): boolean {
+  return context.safeSocketSend(
+    context.socket,
+    {
+      type: "runtime_start_response",
+      request_id: parsed.request_id,
+      ...response,
+    },
+    "listener_runtime_start_send_failed",
+    "listener_runtime_start",
+  );
+}
+
+function validateRuntimeStartShape(parsed: RuntimeStartCommand): void {
+  const hasAgentId = hasString(parsed.agent_id);
+  const hasCreateAgent = parsed.create_agent !== undefined;
+  if (hasAgentId === hasCreateAgent) {
+    throw new Error(
+      "runtime_start requires exactly one of agent_id or create_agent",
+    );
+  }
+
+  if (parsed.agent_id !== undefined && !hasAgentId) {
+    throw new Error("runtime_start agent_id must be a non-empty string");
+  }
+
+  const hasConversationId = hasString(parsed.conversation_id);
+  if (parsed.conversation_id !== undefined && !hasConversationId) {
+    throw new Error("runtime_start conversation_id must be a non-empty string");
+  }
+
+  if (hasConversationId && parsed.create_conversation !== undefined) {
+    throw new Error(
+      "runtime_start conversation_id cannot be combined with create_conversation",
+    );
+  }
+}
+
+async function resolveRuntimeStartAgent(
+  parsed: RuntimeStartCommand,
+  created: CreatedResources,
+): Promise<AgentState> {
+  const backend = getBackend();
+  if (parsed.create_agent) {
+    const agent = await backend.createAgent(parsed.create_agent.body);
+    created.agent = true;
+    if (parsed.create_agent.pin_global !== false) {
+      settingsManager.pinGlobal(agent.id);
+    }
+    return agent;
+  }
+
+  return backend.retrieveAgent(parsed.agent_id as string);
+}
+
+async function resolveRuntimeStartConversation(
+  parsed: RuntimeStartCommand,
+  agent: AgentState,
+  created: CreatedResources,
+): Promise<Conversation> {
+  const backend = getBackend();
+  if (hasString(parsed.conversation_id)) {
+    const conversation = await backend.retrieveConversation(
+      parsed.conversation_id,
+    );
+    if (conversation.agent_id !== agent.id) {
+      throw new Error(
+        `Conversation ${conversation.id} belongs to ${conversation.agent_id}, not ${agent.id}`,
+      );
+    }
+    return conversation;
+  }
+
+  const body = {
+    ...(parsed.create_conversation?.body ?? {}),
+    agent_id: agent.id,
+  } satisfies ConversationCreateParams;
+  const conversation = await backend.createConversation(body);
+  created.conversation = true;
+  return conversation;
+}
+
+async function applyRuntimeStartState(
+  parsed: RuntimeStartCommand,
+  context: RuntimeStartCommandContext,
+  scope: RuntimeScope,
+  scopedRuntime: ConversationRuntime,
+): Promise<void> {
+  if (parsed.mode) {
+    const mode = migratePermissionMode(parsed.mode);
+    if (!mode) {
+      throw new Error(`Unsupported permission mode: ${parsed.mode}`);
+    }
+    const state = getOrCreateConversationPermissionModeStateRef(
+      context.runtime,
+      scope.agent_id,
+      scope.conversation_id,
+    );
+    state.mode = mode;
+    persistPermissionModeMapForRuntime(context.runtime);
+  }
+
+  if (parsed.cwd !== undefined) {
+    await switchConversationWorkingDirectory({
+      runtime: context.runtime,
+      agentId: scope.agent_id,
+      conversationId: scope.conversation_id,
+      workingDirectory: parsed.cwd ?? context.runtime.bootWorkingDirectory,
+      emitStatus: false,
+      statusRuntime: scopedRuntime,
+      statusSocket: context.socket,
+    });
+  }
+}
+
+export async function handleRuntimeStartCommand(
+  parsed: RuntimeStartCommand,
+  context: RuntimeStartCommandContext,
+): Promise<boolean> {
+  const created = { agent: false, conversation: false };
+  let agent: AgentState | null = null;
+  let conversation: Conversation | null = null;
+  let runtimeScope: RuntimeScope | null = null;
+  let shouldReplayState = false;
+
+  try {
+    validateRuntimeStartShape(parsed);
+    agent = await resolveRuntimeStartAgent(parsed, created);
+    conversation = await resolveRuntimeStartConversation(
+      parsed,
+      agent,
+      created,
+    );
+    runtimeScope = buildRuntimeScope(agent, conversation);
+    const scopedRuntime = context.getOrCreateScopedRuntime(
+      context.runtime,
+      runtimeScope.agent_id,
+      runtimeScope.conversation_id,
+    );
+    await applyRuntimeStartState(parsed, context, runtimeScope, scopedRuntime);
+
+    const sent = sendRuntimeStartResponse(context, parsed, {
+      success: true,
+      runtime: runtimeScope,
+      agent,
+      conversation,
+      created,
+    });
+    shouldReplayState = sent;
+  } catch (error) {
+    sendRuntimeStartResponse(context, parsed, {
+      success: false,
+      runtime: null,
+      agent,
+      conversation,
+      created,
+      error: getErrorMessage(error, "Failed to start runtime"),
+    });
+  }
+
+  if (shouldReplayState && runtimeScope) {
+    await context.replaySyncStateForRuntime(
+      context.runtime,
+      context.socket,
+      runtimeScope,
+      {
+        recoverApprovals: parsed.recover_approvals !== false,
+        forceDeviceStatus: parsed.force_device_status !== false,
+      },
+    );
+  }
+
+  return true;
+}
+
+export function handleRuntimeStartProtocolCommand(
+  parsed: unknown,
+  context: RuntimeStartCommandContext,
+): boolean {
+  if (!isRuntimeStartCommand(parsed)) {
+    return false;
+  }
+
+  context.runDetachedListenerTask("runtime_start", async () => {
+    await handleRuntimeStartCommand(parsed, context);
+  });
+  return true;
+}

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -29,6 +29,7 @@ import { handleCronProtocolCommand } from "./commands/cron";
 import { handleGitBranchCommand } from "./commands/git-branches";
 import { handleMemoryProtocolCommand } from "./commands/memory";
 import { handleModelToolsetCommand } from "./commands/model-toolset";
+import { handleRuntimeStartProtocolCommand } from "./commands/runtime-start";
 import { handleSecretsCommand } from "./commands/secrets";
 import { handleSettingsProtocolCommand } from "./commands/settings";
 import { handleSkillAgentProtocolCommand } from "./commands/skills-agents";
@@ -225,6 +226,19 @@ export function createListenerMessageHandler(
           agentId: parsed.runtime.agent_id,
           conversationId: parsed.runtime.conversation_id,
         });
+        return;
+      }
+
+      if (
+        handleRuntimeStartProtocolCommand(parsed, {
+          socket,
+          runtime,
+          safeSocketSend,
+          runDetachedListenerTask,
+          getOrCreateScopedRuntime,
+          replaySyncStateForRuntime,
+        })
+      ) {
         return;
       }
 

--- a/src/websocket/listener/protocol-inbound.test.ts
+++ b/src/websocket/listener/protocol-inbound.test.ts
@@ -22,6 +22,15 @@ describe("app-server protocol hard cut", () => {
 
 describe("agent/conversation management protocol-inbound validators", () => {
   test.each([
+    {
+      type: "runtime_start",
+      request_id: "r0",
+      create_agent: { body: { name: "Agent" }, pin_global: false },
+      create_conversation: { body: { summary: "New conversation" } },
+      cwd: "/tmp/project",
+      mode: "acceptEdits",
+      client_info: { name: "test", title: "Test", version: "1.0.0" },
+    },
     { type: "agent_list", request_id: "r1", query: { limit: 10 } },
     { type: "agent_retrieve", request_id: "r2", agent_id: "agent-1" },
     { type: "agent_create", request_id: "r3", body: { name: "Agent" } },
@@ -83,6 +92,25 @@ describe("agent/conversation management protocol-inbound validators", () => {
   });
 
   test.each([
+    { type: "runtime_start", request_id: "r0", create_agent: { body: [] } },
+    {
+      type: "runtime_start",
+      request_id: "r0",
+      agent_id: "agent-1",
+      create_conversation: [],
+    },
+    {
+      type: "runtime_start",
+      request_id: "r0",
+      agent_id: "agent-1",
+      mode: "bad",
+    },
+    {
+      type: "runtime_start",
+      request_id: "r0",
+      agent_id: "agent-1",
+      client_info: { title: "missing name" },
+    },
     { type: "agent_list", request_id: "r1", query: "bad" },
     { type: "agent_retrieve", request_id: "r2" },
     { type: "agent_create", request_id: "r3", body: null },

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -73,6 +73,7 @@ import type {
   ReadMemoryFileCommand,
   RemoveQueueItemCommand,
   RuntimeScope,
+  RuntimeStartCommand,
   SearchBranchesCommand,
   SearchFilesCommand,
   SecretApplyCommand,
@@ -331,6 +332,74 @@ function isSyncCommand(value: unknown): value is SyncCommand {
       typeof candidate.recover_approvals === "boolean") &&
     (candidate.force_device_status === undefined ||
       typeof candidate.force_device_status === "boolean")
+  );
+}
+
+function isDevicePermissionMode(value: unknown): boolean {
+  return (
+    value === "standard" ||
+    value === "acceptEdits" ||
+    value === "memory" ||
+    value === "unrestricted"
+  );
+}
+
+function isRuntimeStartCreateAgentOptions(value: unknown): boolean {
+  if (!isObjectRecord(value)) return false;
+  return (
+    isObjectRecord(value.body) &&
+    (value.pin_global === undefined || typeof value.pin_global === "boolean")
+  );
+}
+
+function isRuntimeStartCreateConversationOptions(value: unknown): boolean {
+  if (!isObjectRecord(value)) return false;
+  return value.body === undefined || isObjectRecord(value.body);
+}
+
+function isRuntimeStartClientInfo(value: unknown): boolean {
+  if (!isObjectRecord(value)) return false;
+  return (
+    typeof value.name === "string" &&
+    (value.title === undefined || typeof value.title === "string") &&
+    (value.version === undefined || typeof value.version === "string")
+  );
+}
+
+export function isRuntimeStartCommand(
+  value: unknown,
+): value is RuntimeStartCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    agent_id?: unknown;
+    create_agent?: unknown;
+    conversation_id?: unknown;
+    create_conversation?: unknown;
+    cwd?: unknown;
+    mode?: unknown;
+    client_info?: unknown;
+    recover_approvals?: unknown;
+    force_device_status?: unknown;
+  };
+  return (
+    c.type === "runtime_start" &&
+    typeof c.request_id === "string" &&
+    (c.agent_id === undefined || typeof c.agent_id === "string") &&
+    (c.create_agent === undefined ||
+      isRuntimeStartCreateAgentOptions(c.create_agent)) &&
+    (c.conversation_id === undefined ||
+      typeof c.conversation_id === "string") &&
+    (c.create_conversation === undefined ||
+      isRuntimeStartCreateConversationOptions(c.create_conversation)) &&
+    (c.cwd === undefined || c.cwd === null || typeof c.cwd === "string") &&
+    (c.mode === undefined || isDevicePermissionMode(c.mode)) &&
+    (c.client_info === undefined || isRuntimeStartClientInfo(c.client_info)) &&
+    (c.recover_approvals === undefined ||
+      typeof c.recover_approvals === "boolean") &&
+    (c.force_device_status === undefined ||
+      typeof c.force_device_status === "boolean")
   );
 }
 
@@ -2002,6 +2071,7 @@ export function parseServerMessage(
       isChangeDeviceStateCommand(parsed) ||
       isAbortMessageCommand(parsed) ||
       isSyncCommand(parsed) ||
+      isRuntimeStartCommand(parsed) ||
       isTerminalSpawnCommand(parsed) ||
       isTerminalInputCommand(parsed) ||
       isTerminalResizeCommand(parsed) ||


### PR DESCRIPTION
## Summary
- add typed `runtime_start` command/response to the v2 app-server protocol
- support creating or resuming agent/conversation runtime scopes with initial cwd/mode state
- replay canonical runtime state frames after the startup ack

## Testing
- `bun test src/types/app-server-protocol.test.ts src/websocket/listener/protocol-inbound.test.ts src/websocket/listen-client-protocol.test.ts --timeout 30000`
- `bun run lint`
- `bun run typecheck`
- `bun run check`