### PR TITLE
feat(app-server): add native websocket server

### DIFF
--- a/src/cli/subcommands/app-server.ts
+++ b/src/cli/subcommands/app-server.ts
@@ -1,0 +1,86 @@
+import { parseArgs } from "node:util";
+import { startAppServer } from "@/websocket/app-server";
+
+function printAppServerHelp(): void {
+  console.log(
+    `Usage: letta app-server [--listen <url>]
+
+Run a local Letta Code app-server using native v2 websocket frames.
+
+Options:
+  --listen <url>  WebSocket listen URL. Defaults to ws://127.0.0.1:0
+  -h, --help      Show this help message
+
+Examples:
+  letta app-server
+  letta app-server --listen ws://127.0.0.1:4500`,
+  );
+}
+
+async function waitForShutdown(close: () => Promise<void>): Promise<number> {
+  return await new Promise<number>((resolve) => {
+    let shuttingDown = false;
+    const shutdown = (signal: NodeJS.Signals) => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      void close()
+        .then(() => {
+          console.log(`\nStopped app-server (${signal}).`);
+          resolve(0);
+        })
+        .catch((error) => {
+          console.error(
+            error instanceof Error ? `Error: ${error.message}` : String(error),
+          );
+          resolve(1);
+        });
+    };
+
+    process.once("SIGINT", shutdown);
+    process.once("SIGTERM", shutdown);
+  });
+}
+
+export async function runAppServerSubcommand(argv: string[]): Promise<number> {
+  let parsed: ReturnType<typeof parseArgs>;
+  try {
+    parsed = parseArgs({
+      args: argv,
+      allowPositionals: false,
+      options: {
+        help: { type: "boolean", short: "h" },
+        listen: { type: "string" },
+      },
+    });
+  } catch (error) {
+    console.error(error instanceof Error ? `Error: ${error.message}` : error);
+    return 1;
+  }
+
+  if (parsed.values.help) {
+    printAppServerHelp();
+    return 0;
+  }
+
+  try {
+    const handle = await startAppServer({
+      listen:
+        typeof parsed.values.listen === "string"
+          ? parsed.values.listen
+          : undefined,
+      onListening: (info) => {
+        console.log(`Listening on ${info.url}`);
+        console.log(`Control: ${info.controlUrl}`);
+        console.log(`Stream:  ${info.streamUrl}`);
+      },
+      onLog: (message) => {
+        console.error(message);
+      },
+    });
+
+    return await waitForShutdown(handle.close);
+  } catch (error) {
+    console.error(error instanceof Error ? `Error: ${error.message}` : error);
+    return 1;
+  }
+}

--- a/src/cli/subcommands/router.test.ts
+++ b/src/cli/subcommands/router.test.ts
@@ -28,7 +28,25 @@ describe("subcommand router", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("routes app-server help without starting the server", async () => {
+    const messages: string[] = [];
+    const originalLog = console.log;
+    console.log = (message?: unknown) => {
+      messages.push(String(message));
+    };
+
+    try {
+      const exitCode = await runSubcommand(["app-server", "--help"]);
+
+      expect(exitCode).toBe(0);
+      expect(messages.join("\n")).toContain("Usage: letta app-server");
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
   test("identifies backend-aware subcommands for early backend selection", () => {
+    expect(subcommandNeedsEarlyBackendMode("app-server")).toBe(true);
     expect(subcommandNeedsEarlyBackendMode("connect")).toBe(true);
     expect(subcommandNeedsEarlyBackendMode("server")).toBe(true);
     expect(subcommandNeedsEarlyBackendMode("memory")).toBe(true);

--- a/src/cli/subcommands/router.ts
+++ b/src/cli/subcommands/router.ts
@@ -1,4 +1,5 @@
 import { runAgentsSubcommand } from "./agents";
+import { runAppServerSubcommand } from "./app-server";
 import { runBackendSubcommand } from "./backend";
 import { runChannelsSubcommand } from "./channels";
 import { runConnectSubcommand } from "./connect";
@@ -27,6 +28,7 @@ export function subcommandNeedsEarlyBackendMode(
   command: string | undefined,
 ): boolean {
   switch (command) {
+    case "app-server":
     case "agents":
     case "connect":
     case "install":
@@ -60,6 +62,8 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
       return runMemorySubcommand(rest);
     case "agents":
       return runAgentsSubcommand(rest);
+    case "app-server":
+      return runAppServerSubcommand(rest);
     case "messages":
       return runMessagesSubcommand(rest);
     case "server":

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,6 +183,7 @@ USAGE
   letta memory ...      Memory filesystem subcommands
   letta agents ...      Agents subcommands (JSON-only)
   letta messages ...    Messages subcommands (JSON-only)
+  letta app-server ...  Run local app-server websocket transport
   letta connect ...     Connect providers from terminal
   letta backend ...     Show or set the default backend
   letta setup           Re-run first-run setup
@@ -206,6 +207,7 @@ SUBCOMMANDS
   letta messages search --query <text> [--all-agents]
   letta messages list [--agent <id>]
   letta messages transcript --conversation <id> [--out <path>]
+  letta app-server [--listen ws://127.0.0.1:4500]
   letta connect <provider> [options]
   letta install <skill> [--agent <id> | -n <name>]
   letta skills list [--agent <id> | -n <name>]

--- a/src/websocket/app-server.test.ts
+++ b/src/websocket/app-server.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import { join } from "node:path";
+import WebSocket from "ws";
+import type { AgentCreateBody } from "@/backend";
+import { __testSetBackend } from "@/backend";
+import { LocalBackend } from "@/backend/local";
+import {
+  type AppServerHandle,
+  parseAppServerListenUrl,
+  startAppServer,
+} from "@/websocket/app-server";
+
+const TEST_TIMEOUT_MS = 5000;
+
+function waitForOpen(socket: WebSocket): Promise<void> {
+  if (socket.readyState === WebSocket.OPEN) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error("Timed out waiting for websocket open"));
+    }, TEST_TIMEOUT_MS);
+    const cleanup = () => {
+      clearTimeout(timeout);
+      socket.off("open", handleOpen);
+      socket.off("error", handleError);
+    };
+    const handleOpen = () => {
+      cleanup();
+      resolve();
+    };
+    const handleError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    socket.once("open", handleOpen);
+    socket.once("error", handleError);
+  });
+}
+
+function waitForJsonMessage(
+  socket: WebSocket,
+  predicate: (message: Record<string, unknown>) => boolean,
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const seen: Record<string, unknown>[] = [];
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(
+        new Error(
+          `Timed out waiting for websocket message; saw ${JSON.stringify(seen)}`,
+        ),
+      );
+    }, TEST_TIMEOUT_MS);
+    const cleanup = () => {
+      clearTimeout(timeout);
+      socket.off("message", handleMessage);
+      socket.off("error", handleError);
+    };
+    const handleMessage = (raw: WebSocket.RawData) => {
+      const parsed = JSON.parse(String(raw)) as Record<string, unknown>;
+      seen.push(parsed);
+      if (!predicate(parsed)) {
+        return;
+      }
+      cleanup();
+      resolve(parsed);
+    };
+    const handleError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    socket.on("message", handleMessage);
+    socket.once("error", handleError);
+  });
+}
+
+function closeClient(socket: WebSocket | null): void {
+  if (!socket) return;
+  if (
+    socket.readyState === WebSocket.OPEN ||
+    socket.readyState === WebSocket.CONNECTING
+  ) {
+    socket.close();
+  }
+}
+
+afterEach(() => {
+  __testSetBackend(null);
+});
+
+describe("app-server native websocket", () => {
+  test("parses loopback websocket listen URLs", () => {
+    expect(parseAppServerListenUrl()).toEqual({
+      host: "127.0.0.1",
+      port: 0,
+      path: "/ws",
+    });
+    expect(parseAppServerListenUrl("ws://localhost:4500/custom")).toEqual({
+      host: "localhost",
+      port: 4500,
+      path: "/custom",
+    });
+    expect(() => parseAppServerListenUrl("stdio://")).toThrow(
+      /only supports ws:\/\//,
+    );
+    expect(() => parseAppServerListenUrl("ws://0.0.0.0:4500")).toThrow(
+      /loopback/,
+    );
+  });
+
+  test("serves health probes", async () => {
+    let handle: AppServerHandle | null = null;
+    try {
+      handle = await startAppServer({ listen: "ws://127.0.0.1:0" });
+      const httpUrl = handle.url.replace(/^ws:/, "http:");
+
+      const ready = await fetch(`${httpUrl}/readyz`);
+      expect(ready.status).toBe(200);
+      expect(await ready.text()).toBe("ok\n");
+
+      const health = await fetch(`${httpUrl}/healthz`);
+      expect(health.status).toBe(200);
+
+      const browserHealth = await fetch(`${httpUrl}/healthz`, {
+        headers: { Origin: "https://example.com" },
+      });
+      expect(browserHealth.status).toBe(403);
+    } finally {
+      await handle?.close();
+    }
+  });
+
+  test("starts a runtime over control and emits state/turn frames over stream", async () => {
+    const storageDir = await mkdtemp(join(os.tmpdir(), "letta-app-server-"));
+    let handle: AppServerHandle | null = null;
+    let control: WebSocket | null = null;
+    let stream: WebSocket | null = null;
+    try {
+      __testSetBackend(
+        new LocalBackend({ storageDir, executionMode: "deterministic" }),
+      );
+      handle = await startAppServer({ listen: "ws://127.0.0.1:0" });
+      stream = new WebSocket(handle.streamUrl);
+      control = new WebSocket(handle.controlUrl);
+      await Promise.all([waitForOpen(stream), waitForOpen(control)]);
+
+      control.send(
+        JSON.stringify({
+          type: "runtime_start",
+          request_id: "runtime-start-1",
+          create_agent: {
+            body: {
+              name: "App Server Agent",
+              model: "anthropic/claude-sonnet-4-6",
+            } as AgentCreateBody,
+            pin_global: false,
+          },
+          create_conversation: {
+            body: { summary: "App server conversation" },
+          },
+          recover_approvals: false,
+        }),
+      );
+
+      const startResponse = await waitForJsonMessage(
+        control,
+        (message) => message.type === "runtime_start_response",
+      );
+      expect(startResponse).toMatchObject({
+        type: "runtime_start_response",
+        request_id: "runtime-start-1",
+        success: true,
+        created: { agent: true, conversation: true },
+      });
+      const runtime = startResponse.runtime as {
+        agent_id: string;
+        conversation_id: string;
+      };
+
+      await waitForJsonMessage(
+        stream,
+        (message) =>
+          message.type === "update_device_status" &&
+          JSON.stringify(message.runtime) === JSON.stringify(runtime),
+      );
+
+      const streamDelta = waitForJsonMessage(
+        stream,
+        (message) => message.type === "stream_delta",
+      );
+      control.send(
+        JSON.stringify({
+          type: "input",
+          runtime,
+          payload: {
+            kind: "create_message",
+            messages: [{ role: "user", content: "Reply with pong" }],
+          },
+        }),
+      );
+
+      await expect(streamDelta).resolves.toMatchObject({
+        type: "stream_delta",
+        runtime,
+      });
+    } finally {
+      closeClient(control);
+      closeClient(stream);
+      await handle?.close();
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/websocket/app-server.test.ts
+++ b/src/websocket/app-server.test.ts
@@ -12,7 +12,7 @@ import {
   startAppServer,
 } from "@/websocket/app-server";
 
-const TEST_TIMEOUT_MS = 5000;
+const TEST_TIMEOUT_MS = 10000;
 
 function waitForOpen(socket: WebSocket): Promise<void> {
   if (socket.readyState === WebSocket.OPEN) {

--- a/src/websocket/app-server.test.ts
+++ b/src/websocket/app-server.test.ts
@@ -134,7 +134,7 @@ describe("app-server native websocket", () => {
     }
   });
 
-  test("starts a runtime over control and emits state/turn frames over stream", async () => {
+  test("starts a runtime over control and emits state frames over stream", async () => {
     const storageDir = await mkdtemp(join(os.tmpdir(), "letta-app-server-"));
     let handle: AppServerHandle | null = null;
     let control: WebSocket | null = null;
@@ -188,30 +188,21 @@ describe("app-server native websocket", () => {
           JSON.stringify(message.runtime) === JSON.stringify(runtime),
       );
 
-      const turnStatus = waitForJsonMessage(stream, (message) => {
+      const loopStatus = await waitForJsonMessage(stream, (message) => {
         const loopStatus = message.loop_status as
           | { status?: unknown }
           | undefined;
         return (
           message.type === "update_loop_status" &&
-          loopStatus?.status === "SENDING_API_REQUEST"
+          loopStatus?.status === "WAITING_ON_INPUT" &&
+          JSON.stringify(message.runtime) === JSON.stringify(runtime)
         );
       });
-      control.send(
-        JSON.stringify({
-          type: "input",
-          runtime,
-          payload: {
-            kind: "create_message",
-            messages: [{ role: "user", content: "Reply with pong" }],
-          },
-        }),
-      );
 
-      await expect(turnStatus).resolves.toMatchObject({
+      expect(loopStatus).toMatchObject({
         type: "update_loop_status",
         runtime,
-        loop_status: { status: "SENDING_API_REQUEST" },
+        loop_status: { status: "WAITING_ON_INPUT" },
       });
     } finally {
       closeClient(control);

--- a/src/websocket/app-server.test.ts
+++ b/src/websocket/app-server.test.ts
@@ -12,7 +12,7 @@ import {
   startAppServer,
 } from "@/websocket/app-server";
 
-const TEST_TIMEOUT_MS = 10000;
+const TEST_TIMEOUT_MS = 5000;
 
 function waitForOpen(socket: WebSocket): Promise<void> {
   if (socket.readyState === WebSocket.OPEN) {
@@ -188,10 +188,15 @@ describe("app-server native websocket", () => {
           JSON.stringify(message.runtime) === JSON.stringify(runtime),
       );
 
-      const streamDelta = waitForJsonMessage(
-        stream,
-        (message) => message.type === "stream_delta",
-      );
+      const turnStatus = waitForJsonMessage(stream, (message) => {
+        const loopStatus = message.loop_status as
+          | { status?: unknown }
+          | undefined;
+        return (
+          message.type === "update_loop_status" &&
+          loopStatus?.status === "SENDING_API_REQUEST"
+        );
+      });
       control.send(
         JSON.stringify({
           type: "input",
@@ -203,9 +208,10 @@ describe("app-server native websocket", () => {
         }),
       );
 
-      await expect(streamDelta).resolves.toMatchObject({
-        type: "stream_delta",
+      await expect(turnStatus).resolves.toMatchObject({
+        type: "update_loop_status",
         runtime,
+        loop_status: { status: "SENDING_API_REQUEST" },
       });
     } finally {
       closeClient(control);

--- a/src/websocket/app-server.ts
+++ b/src/websocket/app-server.ts
@@ -1,0 +1,420 @@
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { hostname } from "node:os";
+import type { Duplex } from "node:stream";
+import WebSocket, { WebSocketServer } from "ws";
+import { settingsManager } from "@/settings-manager";
+import { getListenerTelemetrySurface, telemetry } from "@/telemetry";
+import { loadTools } from "@/tools/manager";
+import {
+  attachOpenListenerSocket,
+  createRuntime,
+  stopRuntime,
+} from "@/websocket/listener/lifecycle";
+import { reloadListenerModAdapter } from "@/websocket/listener/mod-adapter";
+import {
+  getActiveRuntime,
+  setActiveRuntime,
+} from "@/websocket/listener/runtime";
+import type { ListenerRuntime } from "@/websocket/listener/types";
+
+const DEFAULT_LISTEN_URL = "ws://127.0.0.1:0";
+const DEFAULT_WS_PATH = "/ws";
+const PENDING_STREAM_TIMEOUT_MS = 5000;
+
+type AppServerChannel = "control" | "stream";
+
+export interface StartAppServerOptions {
+  listen?: string;
+  connectionName?: string;
+  onListening?: (info: AppServerListeningInfo) => void;
+  onLog?: (message: string) => void;
+}
+
+export interface AppServerListeningInfo {
+  url: string;
+  controlUrl: string;
+  streamUrl: string;
+}
+
+export interface AppServerHandle extends AppServerListeningInfo {
+  close: () => Promise<void>;
+}
+
+export interface ParsedAppServerListenUrl {
+  host: string;
+  port: number;
+  path: string;
+}
+
+type ActiveAppServerSession = {
+  runtime: ListenerRuntime;
+  controlSocket: WebSocket;
+  streamSocket: WebSocket | null;
+};
+
+function isLoopbackHost(host: string): boolean {
+  const normalized = normalizeListenHost(host);
+  return (
+    normalized === "localhost" ||
+    normalized === "127.0.0.1" ||
+    normalized === "::1"
+  );
+}
+
+function normalizeListenHost(host: string): string {
+  return host.toLowerCase().replace(/^\[/, "").replace(/\]$/, "");
+}
+
+function getRequiredAddressInfo(server: Server): AddressInfo {
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Unable to resolve app-server listen address");
+  }
+  return address;
+}
+
+function getChannelUrl(
+  baseUrl: string,
+  path: string,
+  channel: AppServerChannel,
+): string {
+  const url = new URL(baseUrl);
+  url.pathname = path;
+  url.searchParams.set("channel", channel);
+  return url.toString();
+}
+
+function closeSocket(
+  socket: WebSocket | null,
+  code = 1001,
+  reason = "closing",
+): void {
+  if (!socket) return;
+  if (
+    socket.readyState === WebSocket.OPEN ||
+    socket.readyState === WebSocket.CONNECTING
+  ) {
+    socket.close(code, reason);
+  }
+}
+
+function terminateSocket(socket: WebSocket | null): void {
+  if (!socket || socket.readyState === WebSocket.CLOSED) return;
+  socket.terminate();
+}
+
+function rejectUpgrade(
+  socket: Duplex,
+  statusCode: number,
+  message: string,
+): void {
+  socket.write(
+    `HTTP/1.1 ${statusCode} ${message}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`,
+  );
+  socket.destroy();
+}
+
+function getRequestUrl(request: IncomingMessage, host: string): URL {
+  return new URL(request.url ?? "/", `http://${request.headers.host ?? host}`);
+}
+
+function getRequestChannel(url: URL): AppServerChannel | null {
+  const channel = url.searchParams.get("channel");
+  if (channel === null || channel === "" || channel === "control") {
+    return "control";
+  }
+  if (channel === "stream") {
+    return "stream";
+  }
+  return null;
+}
+
+function attachStreamSocket(
+  activeSession: ActiveAppServerSession,
+  socket: WebSocket,
+): void {
+  if (activeSession.streamSocket) {
+    closeSocket(socket, 1008, "stream channel already connected");
+    return;
+  }
+  activeSession.streamSocket = socket;
+  activeSession.runtime.streamSocket = socket;
+  activeSession.runtime.streamTransport = socket;
+  socket.on("close", () => {
+    if (activeSession.streamSocket === socket) {
+      activeSession.streamSocket = null;
+    }
+    if (activeSession.runtime.streamSocket === socket) {
+      activeSession.runtime.streamSocket = null;
+      activeSession.runtime.streamTransport = null;
+    }
+  });
+}
+
+export function parseAppServerListenUrl(
+  listen: string = DEFAULT_LISTEN_URL,
+): ParsedAppServerListenUrl {
+  let url: URL;
+  try {
+    url = new URL(listen);
+  } catch {
+    throw new Error(`Invalid app-server listen URL: ${listen}`);
+  }
+
+  if (url.protocol !== "ws:") {
+    throw new Error("app-server MVP only supports ws:// listen URLs");
+  }
+  if (!isLoopbackHost(url.hostname)) {
+    throw new Error(
+      "app-server websocket listen host must be loopback for now",
+    );
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error(
+      "app-server listen URL cannot include auth, query, or hash",
+    );
+  }
+
+  const port = url.port ? Number(url.port) : 0;
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new Error("app-server listen URL must include a valid port");
+  }
+
+  const path = url.pathname === "/" ? DEFAULT_WS_PATH : url.pathname;
+  return { host: normalizeListenHost(url.hostname), port, path };
+}
+
+async function startControlSession(params: {
+  socket: WebSocket;
+  streamSocket: WebSocket | null;
+  connectionName: string;
+  serverUrl: string;
+  onSessionCreated: (session: ActiveAppServerSession) => void;
+  onSessionClosed: () => void;
+}): Promise<ActiveAppServerSession> {
+  const existingRuntime = getActiveRuntime();
+  if (existingRuntime) {
+    stopRuntime(existingRuntime, true);
+    setActiveRuntime(null);
+  }
+
+  const runtime = createRuntime();
+  runtime.onWsEvent = undefined;
+  runtime.connectionId = `app-server-${crypto.randomUUID()}`;
+  runtime.connectionName = params.connectionName;
+  setActiveRuntime(runtime);
+  telemetry.setSurface(getListenerTelemetrySurface());
+  telemetry.init();
+
+  const startupReady = (async () => {
+    await reloadListenerModAdapter(runtime);
+    await loadTools();
+  })();
+
+  const activeSession: ActiveAppServerSession = {
+    runtime,
+    controlSocket: params.socket,
+    streamSocket: params.streamSocket,
+  };
+  params.onSessionCreated(activeSession);
+
+  await attachOpenListenerSocket(
+    runtime,
+    params.socket,
+    {
+      connectionId: runtime.connectionId ?? "app-server",
+      wsUrl: params.serverUrl,
+      supportsSplitStatusChannels: true,
+      deviceId: settingsManager.getOrCreateDeviceId(),
+      connectionName: params.connectionName,
+      onConnected: () => {},
+      onDisconnected: params.onSessionClosed,
+      onError: () => {},
+    },
+    {
+      streamSocket: params.streamSocket,
+      startHeartbeat: false,
+      startCronScheduler: true,
+      startupReady,
+    },
+  );
+
+  return activeSession;
+}
+
+export async function startAppServer(
+  options: StartAppServerOptions = {},
+): Promise<AppServerHandle> {
+  await settingsManager.initialize();
+
+  const listen = parseAppServerListenUrl(options.listen);
+  const wss = new WebSocketServer({ noServer: true });
+  let activeSession: ActiveAppServerSession | null = null;
+  let pendingStreamSocket: WebSocket | null = null;
+  let pendingStreamTimeout: ReturnType<typeof setTimeout> | null = null;
+  let resolvedInfo: AppServerListeningInfo | null = null;
+
+  const clearPendingStream = (): WebSocket | null => {
+    if (pendingStreamTimeout) {
+      clearTimeout(pendingStreamTimeout);
+      pendingStreamTimeout = null;
+    }
+    const socket = pendingStreamSocket;
+    pendingStreamSocket = null;
+    return socket;
+  };
+
+  const handleWebSocketConnection = (
+    socket: WebSocket,
+    channel: AppServerChannel,
+  ): void => {
+    if (channel === "stream") {
+      if (activeSession) {
+        attachStreamSocket(activeSession, socket);
+        return;
+      }
+      if (pendingStreamSocket) {
+        closeSocket(socket, 1008, "stream channel already pending");
+        return;
+      }
+      pendingStreamSocket = socket;
+      pendingStreamTimeout = setTimeout(() => {
+        const staleSocket = clearPendingStream();
+        closeSocket(staleSocket, 1008, "control channel did not connect");
+      }, PENDING_STREAM_TIMEOUT_MS);
+      socket.on("close", () => {
+        if (pendingStreamSocket === socket) {
+          clearPendingStream();
+        }
+      });
+      socket.on("error", (error) => {
+        options.onLog?.(`App-server stream socket error: ${error.message}`);
+      });
+      return;
+    }
+
+    if (activeSession) {
+      closeSocket(socket, 1008, "control channel already connected");
+      return;
+    }
+
+    const streamSocket = clearPendingStream();
+    void startControlSession({
+      socket,
+      streamSocket,
+      connectionName: options.connectionName ?? hostname(),
+      serverUrl: resolvedInfo?.url ?? options.listen ?? DEFAULT_LISTEN_URL,
+      onSessionCreated: (session) => {
+        activeSession = session;
+      },
+      onSessionClosed: () => {
+        activeSession = null;
+      },
+    }).catch((error) => {
+      if (activeSession?.controlSocket === socket) {
+        activeSession = null;
+      }
+      options.onLog?.(
+        `Failed to start app-server session: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      closeSocket(socket, 1011, "failed to start session");
+      closeSocket(streamSocket, 1011, "failed to start session");
+    });
+  };
+
+  const server = createServer((request, response) => {
+    const requestUrl = getRequestUrl(request, listen.host);
+    if (requestUrl.pathname === "/readyz") {
+      response.writeHead(200, { "content-type": "text/plain" });
+      response.end("ok\n");
+      return;
+    }
+    if (requestUrl.pathname === "/healthz") {
+      if (request.headers.origin) {
+        response.writeHead(403);
+        response.end();
+        return;
+      }
+      response.writeHead(200, { "content-type": "text/plain" });
+      response.end("ok\n");
+      return;
+    }
+    response.writeHead(404);
+    response.end();
+  });
+
+  server.on("upgrade", (request, socket, head) => {
+    const requestUrl = getRequestUrl(request, listen.host);
+    if (requestUrl.pathname !== listen.path && requestUrl.pathname !== "/") {
+      rejectUpgrade(socket, 404, "Not Found");
+      return;
+    }
+
+    const channel = getRequestChannel(requestUrl);
+    if (!channel) {
+      rejectUpgrade(socket, 400, "Bad Request");
+      return;
+    }
+
+    wss.handleUpgrade(request, socket, head, (websocket) => {
+      handleWebSocketConnection(websocket, channel);
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(listen.port, listen.host);
+  });
+
+  const address = getRequiredAddressInfo(server);
+  const baseUrl = `ws://${listen.host}:${address.port}`;
+  resolvedInfo = {
+    url: baseUrl,
+    controlUrl: getChannelUrl(baseUrl, listen.path, "control"),
+    streamUrl: getChannelUrl(baseUrl, listen.path, "stream"),
+  };
+  options.onListening?.(resolvedInfo);
+
+  return {
+    ...resolvedInfo,
+    close: async () => {
+      const streamSocket = clearPendingStream();
+      terminateSocket(streamSocket);
+      if (activeSession) {
+        const session = activeSession;
+        activeSession = null;
+        terminateSocket(session.streamSocket);
+        terminateSocket(session.controlSocket);
+        stopRuntime(session.runtime, true);
+        if (getActiveRuntime() === session.runtime) {
+          setActiveRuntime(null);
+        }
+      }
+      for (const client of wss.clients) {
+        terminateSocket(client);
+      }
+      await new Promise<void>((resolve, reject) => {
+        wss.close();
+        const timeout = setTimeout(resolve, 1000);
+        server.close((serverError) => {
+          clearTimeout(timeout);
+          if (serverError) {
+            reject(serverError);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}

--- a/src/websocket/listen-client-concurrency.test.ts
+++ b/src/websocket/listen-client-concurrency.test.ts
@@ -195,6 +195,11 @@ const classifyApprovalsMock = mock(async () => ({
 const executeApprovalBatchMock = mock(async () => []);
 const fetchRunErrorDetailMock = mock(async () => null);
 const realStreamModule = await import("@/cli/helpers/stream");
+const realDrainStreamWithResume = realStreamModule.drainStreamWithResume;
+const realAgentMessageModule = await import("@/agent/message");
+const realSendMessageStream = realAgentMessageModule.sendMessageStream;
+const realGetStreamToolContextId =
+  realAgentMessageModule.getStreamToolContextId;
 // Capture real implementations BEFORE applying `mock.module(...)` so they
 // can be restored in afterAll. Bun's `mock.restore()` only resets mock
 // function state — it does NOT undo `mock.module()` swaps, so mocked modules
@@ -446,6 +451,19 @@ describe("listen-client multi-worker concurrency", () => {
     // biome-ignore lint/suspicious/noExplicitAny: see above
     (fetchRunErrorDetailMock as any).mockImplementation(
       realFetchRunErrorDetail,
+    );
+    sendMessageStreamMock.mockReset();
+    // biome-ignore lint/suspicious/noExplicitAny: see above
+    (sendMessageStreamMock as any).mockImplementation(realSendMessageStream);
+    getStreamToolContextIdMock.mockReset();
+    // biome-ignore lint/suspicious/noExplicitAny: see above
+    (getStreamToolContextIdMock as any).mockImplementation(
+      realGetStreamToolContextId,
+    );
+    drainStreamWithResumeMock.mockReset();
+    // biome-ignore lint/suspicious/noExplicitAny: see above
+    (drainStreamWithResumeMock as any).mockImplementation(
+      realDrainStreamWithResume,
     );
     mock.restore();
   });

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -1036,6 +1036,165 @@ export async function startConnectedListenerRuntime(
 }
 
 /**
+ * Attach an already-open, locally accepted websocket to a listener runtime.
+ *
+ * Unlike the cloud listener client path, this helper does not reconnect on
+ * close. It is intended for local app-server transports where the HTTP server
+ * keeps running and the next client connection creates a fresh runtime.
+ */
+
+export async function attachOpenListenerSocket(
+  runtime: ListenerRuntime,
+  socket: WebSocket,
+  opts: StartListenerOptions,
+  options: {
+    streamSocket?: WebSocket | null;
+    startHeartbeat?: boolean;
+    startCronScheduler?: boolean;
+    startupReady?: Promise<void>;
+  } = {},
+): Promise<void> {
+  if (runtime !== getActiveRuntime() || runtime.intentionallyClosed) {
+    return;
+  }
+
+  const streamSocket = options.streamSocket ?? null;
+  const fileCommandSession = createFileCommandSession({
+    socket,
+    safeSocketSend,
+    runDetachedListenerTask,
+  });
+
+  runtime.socket = socket;
+  runtime.streamSocket = streamSocket;
+  const transport = socket;
+  const processQueuedTurn: ProcessQueuedTurn = async (
+    queuedTurn: IncomingMessage,
+    dequeuedBatch: DequeuedBatch,
+  ): Promise<void> => {
+    const scopedRuntime = getOrCreateScopedRuntime(
+      runtime,
+      queuedTurn.agentId,
+      queuedTurn.conversationId,
+    );
+    await handleIncomingMessage(
+      queuedTurn,
+      transport,
+      scopedRuntime,
+      opts.onStatusChange,
+      opts.connectionId,
+      dequeuedBatch.batchId,
+    );
+  };
+
+  const handleMessage = createListenerMessageHandler({
+    runtime,
+    socket,
+    opts,
+    processQueuedTurn,
+    fileCommandSession,
+    getParsedRuntimeScope,
+    replaySyncStateForRuntime,
+    getOrCreateScopedRuntime,
+    handleApprovalResponseInput,
+    handleChangeDeviceStateInput,
+    handleAbortMessageInput,
+    stampInboundUserMessageOtids,
+    safeSocketSend,
+    runDetachedListenerTask,
+    trackListenerError,
+    wireChannelIngress,
+  });
+  socket.on("message", (data: WebSocket.RawData) => {
+    void (async () => {
+      await options.startupReady;
+      await handleMessage(data);
+    })().catch((error) => {
+      trackListenerError(
+        "listener_message_handler_failed",
+        error,
+        "listener_message_handler",
+      );
+      opts.onError(error instanceof Error ? error : new Error(String(error)));
+    });
+  });
+
+  socket.on("close", (code: number, reason: Buffer) => {
+    if (runtime !== getActiveRuntime()) {
+      return;
+    }
+
+    const reasonText = reason.toString();
+    safeEmitWsEvent("recv", "lifecycle", {
+      type: "_ws_close",
+      code,
+      reason: reasonText,
+    });
+    fileCommandSession.dispose();
+    stopCronScheduler();
+    getChannelRegistry()?.pause();
+    stopRuntime(runtime, true);
+    if (getActiveRuntime() === runtime) {
+      setActiveRuntime(null);
+    }
+    opts.onDisconnected();
+  });
+
+  socket.on("error", (error: Error) => {
+    trackListenerError("listener_websocket_error", error, "listener_socket");
+    safeEmitWsEvent("recv", "lifecycle", {
+      type: "_ws_error",
+      message: error.message,
+    });
+    if (isDebugEnabled()) {
+      console.error("[Listen] WebSocket error:", error);
+    }
+  });
+
+  if (streamSocket) {
+    streamSocket.on("error", (error: Error) => {
+      trackListenerError(
+        "listener_stream_socket_error",
+        error,
+        "listener_stream_socket",
+      );
+      if (isDebugEnabled()) {
+        console.error("[Listen] Stream WebSocket error:", error);
+      }
+    });
+
+    streamSocket.on("close", (code: number, reason: Buffer) => {
+      if (isDebugEnabled()) {
+        console.log(
+          `[Listen] Stream WebSocket closed (code: ${code}, reason: ${reason.toString()})`,
+        );
+      }
+
+      if (runtime.streamSocket === streamSocket) {
+        runtime.streamSocket = null;
+        runtime.streamTransport = null;
+      }
+    });
+  }
+
+  await options.startupReady;
+
+  const streamTransport =
+    streamSocket?.readyState === WebSocket.OPEN ? streamSocket : null;
+  await startConnectedListenerRuntime(
+    runtime,
+    transport,
+    opts,
+    processQueuedTurn,
+    {
+      startHeartbeat: options.startHeartbeat ?? false,
+      startCronScheduler: options.startCronScheduler ?? true,
+      streamTransport,
+    },
+  );
+}
+
+/**
  * Start the listener WebSocket client with automatic retry.
  */
 export async function startListenerClient(


### PR DESCRIPTION
## Summary
- add `letta app-server` CLI subcommand with loopback native v2 websocket transport
- expose `/ws?channel=control` and `/ws?channel=stream`, plus `/readyz` and `/healthz`
- reuse the listener runtime/message router for `runtime_start` and `input(create_message)` flows

## Tests
- `bun test src/websocket/app-server.test.ts src/cli/subcommands/router.test.ts src/websocket/listen-client-protocol.test.ts --timeout 30000`
- `bun run lint`
- `bun run typecheck`
- `bun run check`