### PR TITLE
fix(tui): add right padding to tool output cards

### DIFF
--- a/src/cli/components/CollapsedOutputDisplay.tsx
+++ b/src/cli/components/CollapsedOutputDisplay.tsx
@@ -7,6 +7,7 @@ import { Text } from "./Text";
 
 const DEFAULT_COLLAPSED_LINES = 3;
 const PREFIX_WIDTH = 5; // `  └  ` or `     `
+const RIGHT_PADDING = 1;
 
 interface CollapsedOutputDisplayProps {
   output: string; // Full output from completion
@@ -31,7 +32,7 @@ export const CollapsedOutputDisplay = memo(
     isLast = false,
   }: CollapsedOutputDisplayProps) => {
     const columns = useTerminalWidth();
-    const contentWidth = Math.max(0, columns - PREFIX_WIDTH);
+    const contentWidth = Math.max(0, columns - PREFIX_WIDTH - RIGHT_PADDING);
 
     let displayOutput = output;
     let clippedByChars = false;
@@ -68,7 +69,7 @@ export const CollapsedOutputDisplay = memo(
           <Box width={PREFIX_WIDTH} flexShrink={0}>
             <Text>{`  ${CLI_GLYPHS.result}  `}</Text>
           </Box>
-          <Box flexGrow={1} width={contentWidth}>
+          <Box flexGrow={1} width={contentWidth} paddingRight={RIGHT_PADDING}>
             <MarkdownDisplay text={visibleLines[0] ?? ""} />
           </Box>
         </Box>
@@ -79,7 +80,7 @@ export const CollapsedOutputDisplay = memo(
             <Box width={PREFIX_WIDTH} flexShrink={0}>
               <Text>{"     "}</Text>
             </Box>
-            <Box flexGrow={1} width={contentWidth}>
+            <Box flexGrow={1} width={contentWidth} paddingRight={RIGHT_PADDING}>
               <MarkdownDisplay text={line} />
             </Box>
           </Box>
@@ -90,7 +91,7 @@ export const CollapsedOutputDisplay = memo(
             <Box width={PREFIX_WIDTH} flexShrink={0}>
               <Text>{"     "}</Text>
             </Box>
-            <Box flexGrow={1} width={contentWidth}>
+            <Box flexGrow={1} width={contentWidth} paddingRight={RIGHT_PADDING}>
               <Text dimColor>
                 … +{hiddenCount} lines{isLast ? " (ctrl+o to expand)" : ""}
               </Text>
@@ -103,7 +104,7 @@ export const CollapsedOutputDisplay = memo(
             <Box width={PREFIX_WIDTH} flexShrink={0}>
               <Text>{"     "}</Text>
             </Box>
-            <Box flexGrow={1} width={contentWidth}>
+            <Box flexGrow={1} width={contentWidth} paddingRight={RIGHT_PADDING}>
               <Text dimColor>(ctrl+o to collapse)</Text>
             </Box>
           </Box>
@@ -114,7 +115,7 @@ export const CollapsedOutputDisplay = memo(
             <Box width={PREFIX_WIDTH} flexShrink={0}>
               <Text>{"     "}</Text>
             </Box>
-            <Box flexGrow={1} width={contentWidth}>
+            <Box flexGrow={1} width={contentWidth} paddingRight={RIGHT_PADDING}>
               <Text dimColor>
                 … output clipped{isLast ? " (ctrl+o to expand)" : ""}
               </Text>

--- a/src/cli/components/StreamingOutputDisplay.tsx
+++ b/src/cli/components/StreamingOutputDisplay.tsx
@@ -5,6 +5,8 @@ import { CLI_GLYPHS } from "@/cli/helpers/glyphs";
 import { useTerminalWidth } from "@/cli/hooks/use-terminal-width";
 import { Text } from "./Text";
 
+const RIGHT_PADDING = 1;
+
 interface StreamingOutputDisplayProps {
   streaming: StreamingState;
   /** Show "(esc to interrupt)" hint - used by bash mode (LET-7199) */
@@ -28,7 +30,7 @@ export const StreamingOutputDisplay = memo(
     const elapsed = Math.floor((Date.now() - streaming.startTime) / 1000);
     const { tailLines, totalLineCount } = streaming;
     const hiddenCount = Math.max(0, totalLineCount - tailLines.length);
-    const contentWidth = Math.max(10, columns - 5);
+    const contentWidth = Math.max(10, columns - 5 - RIGHT_PADDING);
 
     const clipToWidth = (text: string): string => {
       if (text.length <= contentWidth) {

--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -114,6 +114,7 @@ import {
 import { TodoRenderer } from "./TodoRenderer.js";
 
 const LIVE_SHELL_ARGS_MAX_LINES = 2;
+const RESULT_RIGHT_PADDING = 1;
 
 /** Render an array of StyledSpans as inline <Text> elements */
 function renderSpans(spans: StyledSpan[]): ReactNode {
@@ -384,7 +385,10 @@ export const ToolCallMessage = memo(
         const extractedText = extractMessageFromResult(line.resultText);
         const prefix = `  ${CLI_GLYPHS.result}  `; // 2 spaces, glyph, 2 spaces
         const prefixWidth = 5; // Total width of prefix
-        const contentWidth = Math.max(0, columns - prefixWidth);
+        const contentWidth = Math.max(
+          0,
+          columns - prefixWidth - RESULT_RIGHT_PADDING,
+        );
 
         // Special cases from old ToolReturnBlock (check before truncation)
         if (line.resultText === "Running...") {
@@ -393,7 +397,11 @@ export const ToolCallMessage = memo(
               <Box width={prefixWidth} flexShrink={0}>
                 <Text>{prefix}</Text>
               </Box>
-              <Box flexGrow={1} width={contentWidth}>
+              <Box
+                flexGrow={1}
+                width={contentWidth}
+                paddingRight={RESULT_RIGHT_PADDING}
+              >
                 <Text dimColor>Running...</Text>
               </Box>
             </Box>
@@ -406,7 +414,11 @@ export const ToolCallMessage = memo(
               <Box width={prefixWidth} flexShrink={0}>
                 <Text>{prefix}</Text>
               </Box>
-              <Box flexGrow={1} width={contentWidth}>
+              <Box
+                flexGrow={1}
+                width={contentWidth}
+                paddingRight={RESULT_RIGHT_PADDING}
+              >
                 <Text color={colors.status.interrupt}>
                   {INTERRUPTED_BY_USER}
                 </Text>
@@ -563,7 +575,11 @@ export const ToolCallMessage = memo(
                     <Box width={prefixWidth} flexShrink={0}>
                       <Text>{prefix}</Text>
                     </Box>
-                    <Box flexGrow={1} width={contentWidth}>
+                    <Box
+                      flexGrow={1}
+                      width={contentWidth}
+                      paddingRight={RESULT_RIGHT_PADDING}
+                    >
                       <Text wrap="wrap">
                         <Text dimColor>·</Text> {qa.question}{" "}
                         <Text dimColor>→</Text> {qa.answer}
@@ -802,7 +818,11 @@ export const ToolCallMessage = memo(
                 <Box width={prefixWidth} flexShrink={0}>
                   <Text>{prefix}</Text>
                 </Box>
-                <Box flexGrow={1} width={contentWidth}>
+                <Box
+                  flexGrow={1}
+                  width={contentWidth}
+                  paddingRight={RESULT_RIGHT_PADDING}
+                >
                   <Text>
                     Read <Text bold>1</Text> image
                   </Text>
@@ -818,7 +838,11 @@ export const ToolCallMessage = memo(
               <Box width={prefixWidth} flexShrink={0}>
                 <Text>{prefix}</Text>
               </Box>
-              <Box flexGrow={1} width={contentWidth}>
+              <Box
+                flexGrow={1}
+                width={contentWidth}
+                paddingRight={RESULT_RIGHT_PADDING}
+              >
                 <Text>
                   Read <Text bold>{lineCount}</Text> line
                   {lineCount !== 1 ? "s" : ""}
@@ -847,7 +871,11 @@ export const ToolCallMessage = memo(
                 <Box width={prefixWidth} flexShrink={0}>
                   <Text>{prefix}</Text>
                 </Box>
-                <Box flexGrow={1} width={contentWidth}>
+                <Box
+                  flexGrow={1}
+                  width={contentWidth}
+                  paddingRight={RESULT_RIGHT_PADDING}
+                >
                   <Text>
                     Found <Text bold>{count}</Text> file{count !== 1 ? "s" : ""}
                   </Text>
@@ -860,7 +888,11 @@ export const ToolCallMessage = memo(
                 <Box width={prefixWidth} flexShrink={0}>
                   <Text>{prefix}</Text>
                 </Box>
-                <Box flexGrow={1} width={contentWidth}>
+                <Box
+                  flexGrow={1}
+                  width={contentWidth}
+                  paddingRight={RESULT_RIGHT_PADDING}
+                >
                   <Text>
                     Found <Text bold>0</Text>{" "}
                     {noFilesMatch ? "files" : "matches"}
@@ -876,7 +908,11 @@ export const ToolCallMessage = memo(
                 <Box width={prefixWidth} flexShrink={0}>
                   <Text>{prefix}</Text>
                 </Box>
-                <Box flexGrow={1} width={contentWidth}>
+                <Box
+                  flexGrow={1}
+                  width={contentWidth}
+                  paddingRight={RESULT_RIGHT_PADDING}
+                >
                   <Text>
                     Found <Text bold>{lineCount}</Text> line
                     {lineCount !== 1 ? "s" : ""}
@@ -900,7 +936,11 @@ export const ToolCallMessage = memo(
                 <Box width={prefixWidth} flexShrink={0}>
                   <Text>{prefix}</Text>
                 </Box>
-                <Box flexGrow={1} width={contentWidth}>
+                <Box
+                  flexGrow={1}
+                  width={contentWidth}
+                  paddingRight={RESULT_RIGHT_PADDING}
+                >
                   <Text>
                     Found <Text bold>{count}</Text> file{count !== 1 ? "s" : ""}
                   </Text>
@@ -913,7 +953,11 @@ export const ToolCallMessage = memo(
                 <Box width={prefixWidth} flexShrink={0}>
                   <Text>{prefix}</Text>
                 </Box>
-                <Box flexGrow={1} width={contentWidth}>
+                <Box
+                  flexGrow={1}
+                  width={contentWidth}
+                  paddingRight={RESULT_RIGHT_PADDING}
+                >
                   <Text>
                     Found <Text bold>0</Text> files
                   </Text>
@@ -951,7 +995,11 @@ export const ToolCallMessage = memo(
             <Box width={prefixWidth} flexShrink={0}>
               <Text>{prefix}</Text>
             </Box>
-            <Box flexGrow={1} width={contentWidth}>
+            <Box
+              flexGrow={1}
+              width={contentWidth}
+              paddingRight={RESULT_RIGHT_PADDING}
+            >
               {isError ? (
                 <Text color={colors.status.error}>{displayText}</Text>
               ) : (


### PR DESCRIPTION
## Summary
- reserve a right-padding column for tool result text content
- apply the same width budget to collapsed and streaming shell output

## Tests
- bun test src/cli/create-worktree-result-renderer.test.tsx src/cli/markdown-display-code-highlighting.test.tsx
- git diff --check

Note: `bun run typecheck` is currently blocked by an unrelated `src/backend/dev/pi-provider-registry.ts` KnownProvider type error on main.