### PR TITLE
fix(slack): keep channel replies in active thread

### DIFF
--- a/src/channels/message-channel.test.ts
+++ b/src/channels/message-channel.test.ts
@@ -144,6 +144,72 @@ describe("MessageChannel", () => {
     });
   });
 
+  test("inherits active Slack turn thread when route is channel-scoped", async () => {
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({ messageId: "slack-msg-3" }));
+
+    const adapter: ChannelAdapter = {
+      id: "slack:account-1",
+      channelId: "slack",
+      accountId: "account-1",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+
+    setRouteInMemory("slack", {
+      accountId: "account-1",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: null,
+      agentId: "agent-1",
+      conversationId: "conv-channel",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const result = await message_channel({
+      action: "send",
+      channel: "slack",
+      chat_id: "C123",
+      message: "hello from active turn",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "conv-channel",
+      },
+      channelTurnSources: [
+        {
+          channel: "slack",
+          accountId: "account-1",
+          chatId: "C123",
+          chatType: "channel",
+          messageId: "1712790000.000050",
+          threadId: "1712790000.000050",
+          agentId: "agent-1",
+          conversationId: "conv-channel",
+        },
+      ],
+    });
+
+    expect(result).toContain("Message sent to slack");
+    expect(sendMessage).toHaveBeenCalledWith({
+      channel: "slack",
+      accountId: "account-1",
+      chatId: "C123",
+      text: "hello from active turn",
+      replyToMessageId: undefined,
+      threadId: "1712790000.000050",
+      parseMode: undefined,
+    });
+  });
+
   test("passes Slack reactions through MessageChannel with the routed account", async () => {
     const registry = new ChannelRegistry();
 

--- a/src/tools/impl/message-channel.ts
+++ b/src/tools/impl/message-channel.ts
@@ -728,6 +728,36 @@ function inferAccountIdFromChannelTurnSources(params: {
   return accountIds.size === 1 ? [...accountIds][0] : undefined;
 }
 
+function inferThreadIdFromChannelTurnSources(params: {
+  input: NormalizedMessageChannelInput;
+  scope: { agentId: string; conversationId: string };
+  accountId?: string;
+  channelTurnSources?: ChannelTurnSource[];
+}): string | null | undefined {
+  if (!params.input.chatId || params.input.threadId !== null) {
+    return undefined;
+  }
+
+  const threadIds = new Set<string | null>();
+  for (const source of params.channelTurnSources ?? []) {
+    if (
+      source.channel !== params.input.channel ||
+      source.chatId !== params.input.chatId ||
+      source.agentId !== params.scope.agentId ||
+      source.conversationId !== params.scope.conversationId
+    ) {
+      continue;
+    }
+    if (params.accountId && source.accountId !== params.accountId) {
+      continue;
+    }
+
+    threadIds.add(source.threadId ?? source.messageId ?? null);
+  }
+
+  return threadIds.size === 1 ? [...threadIds][0] : undefined;
+}
+
 async function resolveExplicitMessageChannelContext(params: {
   input: NormalizedMessageChannelInput;
   scope: { agentId: string; conversationId: string };
@@ -828,11 +858,17 @@ export async function message_channel(
       }
 
       const plugin = await loadChannelPlugin(input.channel);
+      const inferredThreadId = inferThreadIdFromChannelTurnSources({
+        input,
+        scope,
+        accountId: resolvedAccountId,
+        channelTurnSources: args.channelTurnSources,
+      });
       executionContext = {
         request: buildMessageChannelRequest(
           input,
           input.chatId,
-          input.threadId,
+          inferredThreadId ?? input.threadId,
         ),
         route,
         adapter,


### PR DESCRIPTION
## Summary
- Inherit the active channel turn thread when MessageChannel replies through a channel-scoped route
- Keep Slack channel replies in the originating thread instead of posting at the channel root
- Add a focused regression test for channel-scoped Slack routes

## Tests
- `bun test src/channels/message-channel.test.ts src/tools/impl/message-channel.test.ts`
- `bunx --bun @biomejs/biome@2.2.5 check src/tools/impl/message-channel.ts src/channels/message-channel.test.ts`

## Notes
- `bun run typecheck` currently fails on unrelated existing errors in `src/backend/dev/pi-provider-registry.ts` and `src/web/generate-diff-viewer.ts`.