### PR TITLE
fix(local): avoid Fable for compaction summaries

### DIFF
--- a/src/backend/local/compaction.test.ts
+++ b/src/backend/local/compaction.test.ts
@@ -24,7 +24,7 @@ function summaryAssistantMessage(): AssistantMessage {
 }
 
 describe("local compaction summarizer options", () => {
-  test("passes settings-derived reasoning to the summarization request", async () => {
+  test("uses Opus for Fable compaction summaries while preserving reasoning", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "local-compaction-"));
     try {
       await createOrUpdateLocalProvider({
@@ -46,6 +46,7 @@ describe("local compaction summarizer options", () => {
       let capturedOptions:
         | (SimpleStreamOptions & Record<string, unknown>)
         | undefined;
+      let capturedModelId: string | undefined;
       const summary = await summarizeLocalMessagesAll({
         agent: {
           id: "agent-local-1",
@@ -62,13 +63,18 @@ describe("local compaction summarizer options", () => {
         },
         messages,
         localProviderAuthStorageDir: storageDir,
-        complete: async (_model, _context, options) => {
+        complete: async (model, _context, options) => {
+          capturedModelId = model.id;
           capturedOptions = options;
           return summaryAssistantMessage();
         },
       });
 
       expect(summary).toBe("summary of prior work");
+      // Fable 5 can refuse compaction-summarizer prompts and pi-ai currently
+      // masks that refusal as "An unknown error occurred". Use Opus for the
+      // auxiliary summary call while preserving the session reasoning level.
+      expect(capturedModelId).toBe("claude-opus-4-8");
       // Pi parity (createSummarizationOptions): summarization requests carry
       // the session thinking level. Without options.reasoning, pi-ai sends
       // `thinking: {type: "disabled"}`, which adaptive-thinking Anthropic
@@ -92,6 +98,7 @@ describe("local compaction summarizer options", () => {
       let capturedOptions:
         | (SimpleStreamOptions & Record<string, unknown>)
         | undefined;
+      let capturedModelId: string | undefined;
       await summarizeLocalMessagesAll({
         agent: {
           id: "agent-local-1",
@@ -114,12 +121,14 @@ describe("local compaction summarizer options", () => {
           },
         ],
         localProviderAuthStorageDir: storageDir,
-        complete: async (_model, _context, options) => {
+        complete: async (model, _context, options) => {
+          capturedModelId = model.id;
           capturedOptions = options;
           return summaryAssistantMessage();
         },
       });
 
+      expect(capturedModelId).toBe("claude-sonnet-4-6");
       expect(capturedOptions?.reasoning).toBeUndefined();
     } finally {
       await rm(storageDir, { recursive: true, force: true });

--- a/src/backend/local/compaction.ts
+++ b/src/backend/local/compaction.ts
@@ -23,6 +23,10 @@ const ALL_WORD_LIMIT = 500;
 const SLIDING_WORD_LIMIT = 300;
 const SUMMARY_TRUNCATION_SUFFIX = "... [summary truncated to fit]";
 export const LOCAL_SUMMARY_TOOL_RETURN_TRUNCATION_CHARS = 2_000;
+const FABLE_5_MODEL_ID = "claude-fable-5";
+const FABLE_COMPACTION_SUMMARY_FALLBACK_MODEL = "anthropic/claude-opus-4-8";
+const FABLE_COMPACTION_SUMMARY_FALLBACK_CONTEXT_WINDOW = 1_000_000;
+const FABLE_COMPACTION_SUMMARY_FALLBACK_MAX_TOKENS = 128_000;
 const TRANSCRIPT_FALLBACK_MAX_CHARS = 120000;
 const TRANSCRIPT_FALLBACK_MAX_CHAR_STEPS = [
   TRANSCRIPT_FALLBACK_MAX_CHARS,
@@ -366,22 +370,69 @@ async function defaultComplete(
   return completeSimple(model, context, options);
 }
 
+function isFableModel(model: Model<string>): boolean {
+  return model.id.includes(FABLE_5_MODEL_ID);
+}
+
+function fableCompactionSummaryFallbackSettings(
+  modelSettings: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    ...modelSettings,
+    provider_type: "anthropic",
+    parallel_tool_calls:
+      typeof modelSettings.parallel_tool_calls === "boolean"
+        ? modelSettings.parallel_tool_calls
+        : true,
+    context_window_limit:
+      typeof modelSettings.context_window_limit === "number"
+        ? modelSettings.context_window_limit
+        : FABLE_COMPACTION_SUMMARY_FALLBACK_CONTEXT_WINDOW,
+    max_tokens:
+      typeof modelSettings.max_tokens === "number"
+        ? modelSettings.max_tokens
+        : FABLE_COMPACTION_SUMMARY_FALLBACK_MAX_TOKENS,
+  };
+}
+
 async function runGenerateText(
   input: LocalAllCompactionInput,
   transcript: string,
   defaultPrompt: string,
 ): Promise<{ text: string }> {
   const systemPrompt = input.prompt ?? defaultPrompt;
-  const localModel = await resolveAvailableLocalModelForTurn({
+  let localModel = await resolveAvailableLocalModelForTurn({
     model: input.agent.model,
     modelSettings: input.agent.model_settings,
     storageDir: input.localProviderAuthStorageDir,
   });
-  const resolved = await resolvePiModelForAgent(
+  let resolved = await resolvePiModelForAgent(
     localModel.model,
     localModel.modelSettings,
     { localProviderAuthStorageDir: input.localProviderAuthStorageDir },
   );
+  if (
+    resolved.model.api === "anthropic-messages" &&
+    isFableModel(resolved.model)
+  ) {
+    // Fable 5 is a strong turn model, but compaction summaries can trip
+    // Anthropic's refusal path and pi-ai currently surfaces that as the opaque
+    // "An unknown error occurred". The summary model is an implementation
+    // detail of compaction, so avoid Fable for this auxiliary call while
+    // preserving the original Anthropic reasoning/settings shape.
+    localModel = await resolveAvailableLocalModelForTurn({
+      model: FABLE_COMPACTION_SUMMARY_FALLBACK_MODEL,
+      modelSettings: fableCompactionSummaryFallbackSettings(
+        localModel.modelSettings,
+      ),
+      storageDir: input.localProviderAuthStorageDir,
+    });
+    resolved = await resolvePiModelForAgent(
+      localModel.model,
+      localModel.modelSettings,
+      { localProviderAuthStorageDir: input.localProviderAuthStorageDir },
+    );
+  }
   const run = input.complete ?? defaultComplete;
   const context: Context = {
     systemPrompt,


### PR DESCRIPTION
## Summary

- Avoid using Fable 5 for local compaction summarizer calls.
- When the effective summary model resolves to `claude-fable-5`, substitute `anthropic/claude-opus-4-8` for the auxiliary summary call while preserving the session's Anthropic reasoning/settings shape.
- Leaves normal Fable turns unchanged and does not add placeholder/fake summaries; if the Opus summary fails, compaction still fails normally.

## Why

After #2827 fixed the disabled-thinking 400, Fable compaction summaries can still fail through Anthropic's refusal path. pi-ai currently collapses `stop_reason: "refusal"` into the opaque `"An unknown error occurred"`, so Letta Code cannot reliably distinguish a refusal from other terminal stream errors at this layer.

Compaction summary generation is an implementation detail, not the user's conversational model choice. Using Opus 4.8 for that auxiliary call avoids the known Fable-specific refusal surface without changing normal turns.

## Notes

- This is intentionally separate from byte-aware image eviction. A fallback summary model helps refusal-only compaction failures, but image-heavy sessions can still remain oversized if recent kept image blobs exceed the local provider request byte budget.
- This is also separate from upstream pi-ai refusal propagation. #2840 tracks surfacing refusals distinctly instead of receiving only `"An unknown error occurred"`.

Fixes/addresses #2840.

## Validation

- `bun test src/backend/local/compaction.test.ts`
- Commit hooks ran Biome, layer checks, filename casing, and `tsc --noEmit`.

👾 Generated with [Letta Code](https://letta.com)
