### PR TITLE
fix(local): elide image payloads after oversized transport failures

### DIFF
--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -61,6 +61,7 @@ const LOCAL_CONTEXT_OVERFLOW_MAX_COMPACTIONS = 3;
 // 8MB keeps headroom under Anthropic's documented 32MB cap while staying
 // above known-good payloads.
 const LOCAL_PROVIDER_REQUEST_BYTE_LIMIT = 8_000_000;
+const LOCAL_PROVIDER_REQUEST_BYTE_TARGET = 6_000_000;
 
 export type PiStreamFunction = (
   model: Model<string>,
@@ -463,6 +464,122 @@ function isOversizedPayloadTransportFailure(input: ProviderTurnInput): boolean {
   );
 }
 
+interface ImageElisionCandidate {
+  messageIndex: number;
+  blockIndex: number;
+  mimeType?: string;
+  bytes: number;
+}
+
+interface ImagePayloadElision {
+  input: ProviderTurnInput;
+  beforeBytes: number;
+  afterBytes: number;
+  elidedImages: number;
+  elidedBytes: number;
+}
+
+function imagePayloadBytes(data: unknown): number {
+  return typeof data === "string" ? data.length : 0;
+}
+
+function imageElisionPlaceholder(mimeType: string | undefined, bytes: number) {
+  const mb = (bytes / 1_000_000).toFixed(1);
+  return `[Image omitted from this provider retry to reduce local request size: ${
+    mimeType ?? "image"
+  }, ~${mb}MB. The original image remains stored in conversation history.]`;
+}
+
+function imageElisionCandidates(
+  messages: readonly LocalMessage[],
+): ImageElisionCandidate[] {
+  const candidates: ImageElisionCandidate[] = [];
+  messages.forEach((message, messageIndex) => {
+    if (message.role !== "user" && message.role !== "toolResult") return;
+    if (!Array.isArray(message.content)) return;
+    message.content.forEach((block, blockIndex) => {
+      if (block.type !== "image") return;
+      const bytes = imagePayloadBytes(block.data);
+      if (bytes <= 0) return;
+      candidates.push({
+        messageIndex,
+        blockIndex,
+        mimeType: block.mimeType,
+        bytes,
+      });
+    });
+  });
+  // Prefer removing older images first; within a single message, remove larger
+  // blobs first. If the request is still too large, this naturally proceeds to
+  // newer images as needed.
+  return candidates.sort(
+    (a, b) =>
+      a.messageIndex - b.messageIndex ||
+      b.bytes - a.bytes ||
+      a.blockIndex - b.blockIndex,
+  );
+}
+
+function elideImagePayload(
+  messages: readonly LocalMessage[],
+  candidate: ImageElisionCandidate,
+): LocalMessage[] {
+  const message = messages[candidate.messageIndex];
+  if (!message) return [...messages];
+  if (message.role !== "user" && message.role !== "toolResult") {
+    return [...messages];
+  }
+  if (!Array.isArray(message.content)) return [...messages];
+  const block = message.content[candidate.blockIndex];
+  if (block?.type !== "image") return [...messages];
+
+  const content = [...message.content];
+  content[candidate.blockIndex] = {
+    type: "text",
+    text: imageElisionPlaceholder(candidate.mimeType, candidate.bytes),
+  };
+  const next = [...messages];
+  next[candidate.messageIndex] = { ...message, content } as LocalMessage;
+  return next;
+}
+
+function elideImagePayloadsForProviderRetry(
+  input: ProviderTurnInput,
+): ImagePayloadElision | null {
+  const beforeBytes = estimateProviderRequestBytes(input);
+  if (
+    beforeBytes === undefined ||
+    beforeBytes <= LOCAL_PROVIDER_REQUEST_BYTE_LIMIT
+  ) {
+    return null;
+  }
+
+  const candidates = imageElisionCandidates(input.uiMessages);
+  if (candidates.length === 0) return null;
+
+  let uiMessages = input.uiMessages;
+  let afterBytes = beforeBytes;
+  let elidedImages = 0;
+  let elidedBytes = 0;
+  for (const candidate of candidates) {
+    if (afterBytes <= LOCAL_PROVIDER_REQUEST_BYTE_TARGET) break;
+    uiMessages = elideImagePayload(uiMessages, candidate);
+    elidedImages += 1;
+    elidedBytes += candidate.bytes;
+    afterBytes =
+      estimateProviderRequestBytes({ ...input, uiMessages }) ?? afterBytes;
+  }
+
+  if (elidedImages === 0 || afterBytes >= beforeBytes) return null;
+  return {
+    input: { ...input, uiMessages },
+    beforeBytes,
+    afterBytes,
+    elidedImages,
+    elidedBytes,
+  };
+}
+
 function defaultStream(
   model: Model<string>,
   context: Context,
@@ -503,6 +620,23 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
       message_type: "summary_message",
       summary: compaction.summary,
       ...(compaction.stats ? { compaction_stats: compaction.stats } : {}),
+    } as never);
+  }
+
+  private async *emitImageElisionChunks(
+    elision: ImagePayloadElision,
+  ): AsyncIterable<ProviderStreamEvent> {
+    yield providerLettaChunk({
+      message_type: "event_message",
+      event_type: "context_image_elision",
+      event_data: {
+        trigger: "oversized_payload_transport_failure",
+        images_elided: elision.elidedImages,
+        image_bytes_elided: elision.elidedBytes,
+        request_bytes_before: elision.beforeBytes,
+        request_bytes_after: elision.afterBytes,
+        request_byte_target: LOCAL_PROVIDER_REQUEST_BYTE_TARGET,
+      },
     } as never);
   }
 
@@ -677,6 +811,13 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
           contextOverflowCompactions < LOCAL_CONTEXT_OVERFLOW_MAX_COMPACTIONS &&
           isOversizedPayloadTransportFailure(activeInput)
         ) {
+          const imageElision = elideImagePayloadsForProviderRetry(activeInput);
+          if (imageElision) {
+            activeInput = imageElision.input;
+            yield* this.emitImageElisionChunks(imageElision);
+            continue;
+          }
+
           // Unlike the provider-reported overflow branch above, the original
           // error here is retryable. If compaction itself fails (for example
           // the summarizer model call errors), fall back to the normal

--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -22,6 +22,7 @@ import {
 import { removeOrphanLocalToolResults } from "@/backend/local/local-message-projection";
 import { resolveAvailableLocalModelForTurn } from "@/backend/local/local-model-config";
 import type { ClientTool } from "@/tools/manager";
+import { debugLog } from "@/utils/debug";
 import { isRecord } from "@/utils/type-guards";
 import { isContextWindowOverflowError } from "./context-window-overflow";
 import {
@@ -813,6 +814,14 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
         ) {
           const imageElision = elideImagePayloadsForProviderRetry(activeInput);
           if (imageElision) {
+            debugLog(
+              "pi-stream",
+              "oversized payload transport failure: elided %d image(s) (%d -> %d bytes, target %d) from provider retry context",
+              imageElision.elidedImages,
+              imageElision.beforeBytes,
+              imageElision.afterBytes,
+              LOCAL_PROVIDER_REQUEST_BYTE_TARGET,
+            );
             activeInput = imageElision.input;
             yield* this.emitImageElisionChunks(imageElision);
             continue;

--- a/src/backend/pi-stream-adapter.test.ts
+++ b/src/backend/pi-stream-adapter.test.ts
@@ -163,7 +163,92 @@ describe("PiStreamAdapter", () => {
     expect(events.some((event) => event.type === "local-message")).toBe(true);
   });
 
-  test("classifies transport failures on oversized payloads as overflow instead of retrying", async () => {
+  test("elides image payloads in-memory before retrying oversized transport failures", async () => {
+    let providerCalls = 0;
+    const contexts: Context[] = [];
+    const stream: PiStreamFunction = (_model, context) => {
+      providerCalls += 1;
+      contexts.push(context);
+      if (providerCalls === 1) {
+        const error = assistantErrorMessage(
+          "WebSocket closed 1006 Connection ended\nretry-after-ms: 0",
+        );
+        return streamFromEvents(
+          [{ type: "error", reason: "error", error }],
+          error,
+        );
+      }
+      const finalMessage = assistantMessage();
+      return streamFromEvents(
+        [{ type: "done", reason: "stop", message: finalMessage }],
+        finalMessage,
+      );
+    };
+
+    const adapter = new PiStreamAdapter({
+      stream,
+      onContextWindowOverflow: async () => {
+        throw new Error("Compaction should not run before image elision");
+      },
+    });
+    const baseInput = input();
+    const events = await collectEvents(
+      adapter.stream({
+        ...baseInput,
+        // Semantic image cost is tiny (1200 tokens), but the raw base64 body is
+        // oversized. After a real transport failure, retry with provider-only
+        // image elision instead of persisting a compaction that may not shed the
+        // kept image bytes.
+        uiMessages: [
+          {
+            id: "ui-msg-large-image",
+            role: "user",
+            content: [
+              {
+                type: "image",
+                mimeType: "image/png",
+                data: "a".repeat(8_000_001),
+              },
+            ],
+            timestamp: Date.now(),
+          },
+        ],
+      }),
+    );
+
+    expect(providerCalls).toBe(2);
+    expect(contexts[0]?.messages[0]?.content).toEqual([
+      {
+        type: "image",
+        mimeType: "image/png",
+        data: "a".repeat(8_000_001),
+      },
+    ]);
+    expect(contexts[1]?.messages[0]?.content).toEqual([
+      expect.objectContaining({
+        type: "text",
+        text: expect.stringContaining("Image omitted"),
+      }),
+    ]);
+    const retryEvents = events.filter(
+      (event) =>
+        event.type === "letta-chunk" &&
+        (event.chunk as { event_type?: string }).event_type === "retry",
+    );
+    expect(retryEvents).toHaveLength(0);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "letta-chunk",
+        chunk: expect.objectContaining({
+          message_type: "event_message",
+          event_type: "context_image_elision",
+        }),
+      }),
+    );
+    expect(events.some((event) => event.type === "local-message")).toBe(true);
+  });
+
+  test("classifies non-image oversized transport failures as overflow instead of retrying", async () => {
     let providerCalls = 0;
     const stream: PiStreamFunction = () => {
       providerCalls += 1;
@@ -197,7 +282,7 @@ describe("PiStreamAdapter", () => {
               timestamp: Date.now(),
             },
           ],
-          summary: "compacted images",
+          summary: "compacted oversized text",
         };
       },
     });
@@ -205,20 +290,11 @@ describe("PiStreamAdapter", () => {
     const events = await collectEvents(
       adapter.stream({
         ...baseInput,
-        // Semantic image cost is tiny (1200 tokens) and there is no clean
-        // overflow error, so only the oversized-payload transport classifier
-        // can route this into compaction.
         uiMessages: [
           {
-            id: "ui-msg-large-image",
+            id: "ui-msg-large-text",
             role: "user",
-            content: [
-              {
-                type: "image",
-                mimeType: "image/png",
-                data: "a".repeat(8_000_001),
-              },
-            ],
+            content: "x".repeat(8_000_001),
             timestamp: Date.now(),
           },
         ],
@@ -279,15 +355,9 @@ describe("PiStreamAdapter", () => {
         ...baseInput,
         uiMessages: [
           {
-            id: "ui-msg-large-image",
+            id: "ui-msg-large-text",
             role: "user",
-            content: [
-              {
-                type: "image",
-                mimeType: "image/png",
-                data: "a".repeat(8_000_001),
-              },
-            ],
+            content: "x".repeat(8_000_001),
             timestamp: Date.now(),
           },
         ],


### PR DESCRIPTION
## Summary

- Adds a provider-context-only image elision step for local oversized-payload transport failures.
- When a retryable transport failure happens and the serialized request payload is >8MB, Letta Code now first retries with older image blobs replaced by text placeholders until the retry payload targets ~6MB.
- Original image blobs remain persisted in conversation history; only the provider retry payload is sanitized.
- Non-image oversized payloads still fall through to the existing #2824 compaction path.

## Why

#2824 routes oversized local transport failures into compaction, which works when token-based compaction also happens to reduce request bytes. But image-heavy sessions can keep recent multi-MB screenshots after compaction because images are cheap in tokens (~1200 each) while huge on the wire. In that case compaction can persist a summary but still leave the request above the local transport byte limit.

This change handles the byte-specific failure at the byte-specific layer: after an actual transport failure, shrink only the provider retry context by eliding image base64 payloads. No preflight rejection, no destructive transcript rewrite, and no fake summaries.

## Behavior

Trigger remains reactive:

```txt
retryable transport failure
+ no model output emitted
+ estimated serialized request bytes > 8MB
=> elide image blobs in provider retry context toward 6MB, then retry
```

If there are no image blobs to elide, the existing compaction path runs unchanged.

## Validation

- `bun test src/backend/pi-stream-adapter.test.ts`
- `bun test src/backend/pi-stream-adapter.test.ts src/backend/provider-turn-executor.test.ts src/backend/local/local-context-estimate.test.ts src/backend/local-backend.test.ts`
- `bun run check`

👾 Generated with [Letta Code](https://letta.com)
