### PR TITLE
feat(app-server): add protocol command acknowledgements

### DIFF
--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -123,8 +123,11 @@ export const PI_TUI_DEFAULT_MODEL_IDS: Partial<Record<KnownProvider, string>> =
 // These pi-ai providers are intentionally absent from Pi TUI's
 // `defaultModelPerProvider`. Keep the omission explicit so newly added pi-ai
 // providers cannot silently inherit catalog-order defaults without review.
-export const PI_TUI_DEFAULTLESS_PROVIDER_IDS: ReadonlySet<KnownProvider> =
-  new Set(["ant-ling", "nvidia", "zai-coding-cn"]);
+export const PI_TUI_DEFAULTLESS_PROVIDER_IDS: ReadonlySet<string> = new Set([
+  "ant-ling",
+  "nvidia",
+  "zai-coding-cn",
+]);
 
 const PI_PROVIDER_OVERRIDES: Partial<
   Record<KnownProvider, PiProviderOverride>

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -732,6 +732,7 @@ export interface ChangeDeviceStateCommand {
 export interface AbortMessageCommand {
   type: "abort_message";
   runtime: RuntimeScope;
+  /** When provided, app-server sends abort_message_response on the control channel. */
   request_id?: string;
   run_id?: string | null;
 }
@@ -739,6 +740,8 @@ export interface AbortMessageCommand {
 export interface SyncCommand {
   type: "sync";
   runtime: RuntimeScope;
+  /** When provided, app-server sends sync_response after replaying state. */
+  request_id?: string;
   /**
    * Whether the device should probe backend state for stale pending approvals.
    * Defaults to true for older clients. Lightweight status/recovery syncs should
@@ -837,6 +840,25 @@ export interface TerminalExitedMessage {
   type: "terminal_exited";
   terminal_id: string;
   exitCode: number;
+  error?: string;
+}
+
+export interface AbortMessageResponseMessage {
+  type: "abort_message_response";
+  request_id: string;
+  runtime: RuntimeScope;
+  /** True when an active turn or pending approval was interrupted. */
+  aborted: boolean;
+  success: boolean;
+  error?: string;
+}
+
+export interface SyncResponseMessage {
+  type: "sync_response";
+  request_id: string;
+  runtime: RuntimeScope;
+  success: boolean;
+  error?: string;
 }
 
 export interface SearchFilesCommand {
@@ -2672,6 +2694,8 @@ export type WsProtocolMessage =
   | QueueUpdateMessage
   | StreamDeltaMessage
   | SubagentStateUpdateMessage
+  | AbortMessageResponseMessage
+  | SyncResponseMessage
   | TerminalOutputMessage
   | TerminalSpawnedMessage
   | TerminalExitedMessage

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -857,6 +857,7 @@ describe("listen-client parseServerMessage", () => {
       Buffer.from(
         JSON.stringify({
           type: "sync",
+          request_id: "sync-1",
           runtime: { agent_id: "agent-1", conversation_id: "default" },
           recover_approvals: false,
           force_device_status: true,
@@ -869,6 +870,7 @@ describe("listen-client parseServerMessage", () => {
     }
     expect(sync.recover_approvals).toBe(false);
     expect(sync.force_device_status).toBe(true);
+    expect(sync.request_id).toBe("sync-1");
   });
 
   test("parses cron CRUD commands", () => {

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -12,6 +12,7 @@ import type {
   ChangeDeviceStateCommand,
 } from "@/types/protocol_v2";
 import { isDebugEnabled } from "@/utils/debug";
+import { getErrorMessage } from "@/utils/error";
 import {
   handleTerminalInput,
   handleTerminalKill,
@@ -248,12 +249,58 @@ export function createListenerMessageHandler(
         );
         if (runtime !== getActiveRuntime() || runtime.intentionallyClosed) {
           console.log(`[Listen V2] Dropping sync: runtime mismatch or closed`);
+          if (parsed.request_id) {
+            safeSocketSend(
+              socket,
+              {
+                type: "sync_response",
+                request_id: parsed.request_id,
+                runtime: parsed.runtime,
+                success: false,
+                error: "Runtime is no longer active",
+              },
+              "sync_response",
+              "sync",
+            );
+          }
           return;
         }
-        await replaySyncStateForRuntime(runtime, socket, parsed.runtime, {
-          recoverApprovals: parsed.recover_approvals !== false,
-          forceDeviceStatus: parsed.force_device_status === true,
-        });
+        try {
+          await replaySyncStateForRuntime(runtime, socket, parsed.runtime, {
+            recoverApprovals: parsed.recover_approvals !== false,
+            forceDeviceStatus: parsed.force_device_status === true,
+          });
+          if (parsed.request_id) {
+            safeSocketSend(
+              socket,
+              {
+                type: "sync_response",
+                request_id: parsed.request_id,
+                runtime: parsed.runtime,
+                success: true,
+              },
+              "sync_response",
+              "sync",
+            );
+          }
+        } catch (error) {
+          if (parsed.request_id) {
+            safeSocketSend(
+              socket,
+              {
+                type: "sync_response",
+                request_id: parsed.request_id,
+                runtime: parsed.runtime,
+                success: false,
+                error: getErrorMessage(error),
+              },
+              "sync_response",
+              "sync",
+            );
+            return;
+          }
+          throw error;
+        }
         return;
       }
 
@@ -443,15 +490,67 @@ export function createListenerMessageHandler(
       }
 
       if (parsed.type === "abort_message") {
-        await handleAbortMessageInput(runtime, {
-          command: parsed,
-          socket,
-          opts: {
-            onStatusChange: opts.onStatusChange,
-            connectionId: opts.connectionId,
-          },
-          processQueuedTurn,
-        });
+        if (runtime !== getActiveRuntime() || runtime.intentionallyClosed) {
+          if (parsed.request_id) {
+            safeSocketSend(
+              socket,
+              {
+                type: "abort_message_response",
+                request_id: parsed.request_id,
+                runtime: parsed.runtime,
+                aborted: false,
+                success: false,
+                error: "Runtime is no longer active",
+              },
+              "abort_message_response",
+              "abort_message",
+            );
+          }
+          return;
+        }
+        try {
+          const aborted = await handleAbortMessageInput(runtime, {
+            command: parsed,
+            socket,
+            opts: {
+              onStatusChange: opts.onStatusChange,
+              connectionId: opts.connectionId,
+            },
+            processQueuedTurn,
+          });
+          if (parsed.request_id) {
+            safeSocketSend(
+              socket,
+              {
+                type: "abort_message_response",
+                request_id: parsed.request_id,
+                runtime: parsed.runtime,
+                aborted,
+                success: true,
+              },
+              "abort_message_response",
+              "abort_message",
+            );
+          }
+        } catch (error) {
+          if (parsed.request_id) {
+            safeSocketSend(
+              socket,
+              {
+                type: "abort_message_response",
+                request_id: parsed.request_id,
+                runtime: parsed.runtime,
+                aborted: false,
+                success: false,
+                error: getErrorMessage(error),
+              },
+              "abort_message_response",
+              "abort_message",
+            );
+            return;
+          }
+          throw error;
+        }
         return;
       }
 

--- a/src/websocket/listener/protocol-ergonomics.test.ts
+++ b/src/websocket/listener/protocol-ergonomics.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type WebSocket from "ws";
+import { __listenClientTestUtils } from "@/websocket/listen-client";
+import { createListenerMessageHandler } from "@/websocket/listener/message-router";
+import type {
+  IncomingMessage,
+  ListenerRuntime,
+  StartListenerOptions,
+} from "@/websocket/listener/types";
+
+function makeListenerOptions(): StartListenerOptions {
+  return {
+    connectionId: "conn-test",
+    wsUrl: "wss://example.test/ws",
+    deviceId: "device-test",
+    connectionName: "listener-test",
+    onConnected: () => {},
+    onDisconnected: () => {},
+    onError: () => {},
+  };
+}
+
+function makeHandler(
+  runtime: ListenerRuntime,
+  sent: unknown[],
+  overrides: Partial<Parameters<typeof createListenerMessageHandler>[0]> = {},
+) {
+  return createListenerMessageHandler({
+    runtime,
+    socket: {} as WebSocket,
+    opts: makeListenerOptions(),
+    processQueuedTurn: async () => {},
+    fileCommandSession: { handle: () => false },
+    getParsedRuntimeScope: () => null,
+    replaySyncStateForRuntime: async () => {},
+    getOrCreateScopedRuntime: () => {
+      throw new Error("unused in protocol ergonomics tests");
+    },
+    handleApprovalResponseInput: async () => false,
+    handleChangeDeviceStateInput: async () => false,
+    handleAbortMessageInput: async () => false,
+    stampInboundUserMessageOtids: (incoming: IncomingMessage) => incoming,
+    safeSocketSend: (_socket, payload) => {
+      sent.push(payload);
+      return true;
+    },
+    runDetachedListenerTask: () => {},
+    trackListenerError: () => {},
+    wireChannelIngress: async () => {},
+    ...overrides,
+  });
+}
+
+describe("listener protocol ergonomics", () => {
+  afterEach(() => {
+    __listenClientTestUtils.setActiveRuntime(null);
+  });
+
+  test("sync sends an ack response when request_id is provided", async () => {
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+    const sent: unknown[] = [];
+    const replaySyncStateForRuntime = mock(async () => {});
+    __listenClientTestUtils.setActiveRuntime(runtime);
+
+    await makeHandler(runtime, sent, { replaySyncStateForRuntime })(
+      Buffer.from(
+        JSON.stringify({
+          type: "sync",
+          request_id: "sync-1",
+          runtime: { agent_id: "agent-1", conversation_id: "default" },
+          recover_approvals: false,
+          force_device_status: true,
+        }),
+      ),
+    );
+
+    expect(replaySyncStateForRuntime).toHaveBeenCalledWith(
+      runtime,
+      expect.anything(),
+      { agent_id: "agent-1", conversation_id: "default" },
+      { recoverApprovals: false, forceDeviceStatus: true },
+    );
+    expect(sent).toContainEqual({
+      type: "sync_response",
+      request_id: "sync-1",
+      runtime: { agent_id: "agent-1", conversation_id: "default" },
+      success: true,
+    });
+  });
+
+  test("sync request_id gets a failure response when the listener is inactive", async () => {
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+    const sent: unknown[] = [];
+
+    await makeHandler(
+      runtime,
+      sent,
+    )(
+      Buffer.from(
+        JSON.stringify({
+          type: "sync",
+          request_id: "sync-closed",
+          runtime: { agent_id: "agent-1", conversation_id: "default" },
+        }),
+      ),
+    );
+
+    expect(sent).toContainEqual({
+      type: "sync_response",
+      request_id: "sync-closed",
+      runtime: { agent_id: "agent-1", conversation_id: "default" },
+      success: false,
+      error: "Runtime is no longer active",
+    });
+  });
+
+  test("abort_message sends an ack response when request_id is provided", async () => {
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+    const sent: unknown[] = [];
+    const handleAbortMessageInput = mock(async () => true);
+    __listenClientTestUtils.setActiveRuntime(runtime);
+
+    await makeHandler(runtime, sent, { handleAbortMessageInput })(
+      Buffer.from(
+        JSON.stringify({
+          type: "abort_message",
+          request_id: "abort-1",
+          runtime: { agent_id: "agent-1", conversation_id: "default" },
+        }),
+      ),
+    );
+
+    expect(handleAbortMessageInput).toHaveBeenCalled();
+    expect(sent).toContainEqual({
+      type: "abort_message_response",
+      request_id: "abort-1",
+      runtime: { agent_id: "agent-1", conversation_id: "default" },
+      aborted: true,
+      success: true,
+    });
+  });
+
+  test("abort_message request_id reports idle no-op without timing out", async () => {
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+    const sent: unknown[] = [];
+    const handleAbortMessageInput = mock(async () => false);
+    __listenClientTestUtils.setActiveRuntime(runtime);
+
+    await makeHandler(runtime, sent, { handleAbortMessageInput })(
+      Buffer.from(
+        JSON.stringify({
+          type: "abort_message",
+          request_id: "abort-idle",
+          runtime: { agent_id: "agent-1", conversation_id: "default" },
+        }),
+      ),
+    );
+
+    expect(sent).toContainEqual({
+      type: "abort_message_response",
+      request_id: "abort-idle",
+      runtime: { agent_id: "agent-1", conversation_id: "default" },
+      aborted: false,
+      success: true,
+    });
+  });
+});

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -322,12 +322,15 @@ function isSyncCommand(value: unknown): value is SyncCommand {
   const candidate = value as {
     type?: unknown;
     runtime?: unknown;
+    request_id?: unknown;
     recover_approvals?: unknown;
     force_device_status?: unknown;
   };
   return (
     candidate.type === "sync" &&
     isRuntimeScope(candidate.runtime) &&
+    (candidate.request_id === undefined ||
+      typeof candidate.request_id === "string") &&
     (candidate.recover_approvals === undefined ||
       typeof candidate.recover_approvals === "boolean") &&
     (candidate.force_device_status === undefined ||

--- a/src/websocket/terminal-handler.ts
+++ b/src/websocket/terminal-handler.ts
@@ -305,6 +305,7 @@ export function handleTerminalSpawn(
       type: "terminal_exited",
       terminal_id,
       exitCode: 1,
+      error: error instanceof Error ? error.message : String(error),
     });
   }
 }


### PR DESCRIPTION
## Summary
- add optional `sync_response` and `abort_message_response` frames when clients provide `request_id`
- include terminal spawn failure details on `terminal_exited.error`
- add protocol ergonomics coverage for sync/abort acknowledgements
- fix a current local type-check issue in the pi provider defaultless-id set by typing it as string membership

## Validation
- `bun test src/websocket --timeout 15000`
- `bun run check`
- `cd /Users/caren/Dev/letta-app-server-web-poc && bun run check`
- `cd /Users/caren/Dev/letta-app-server-web-poc && bun run test:app-server -- /Users/caren/Dev/letta-code/.letta/worktrees/app-server-protocol-ergonomics`
- `cd /Users/caren/Dev/letta-app-server-web-poc && bun run test:browser -- /Users/caren/Dev/letta-code/.letta/worktrees/app-server-protocol-ergonomics`