### PR TITLE
feat(app-server): add app-server client

### DIFF
--- a/build.js
+++ b/build.js
@@ -77,6 +77,18 @@ await Bun.write(outputPath, withShebang);
 // Make executable
 await Bun.$`chmod +x letta.js`;
 
+await Bun.build({
+  entrypoints: ["./src/app-server-client.ts"],
+  outdir: "./dist",
+  target: "browser",
+  format: "esm",
+  minify: false,
+  sourcemap: "external",
+  naming: {
+    entry: "app-server-client.js",
+  },
+});
+
 // Copy bundled skills to skills/ directory for shipping
 const bundledSkillsSrc = join(__dirname, "src/skills/builtin");
 const bundledSkillsDst = join(__dirname, "skills");
@@ -97,4 +109,5 @@ console.log("   Output: dist/types/protocol.d.ts");
 
 console.log("✅ Build complete!");
 console.log(`   Output: letta.js`);
+console.log("   Output: dist/app-server-client.js");
 console.log(`   Size: ${(Bun.file(outputPath).size / 1024).toFixed(0)}KB`);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "scripts",
     "skills",
     "vendor",
+    "dist/app-server-client.js",
+    "dist/app-server-client.js.map",
     "dist/types",
     "docs"
   ],
@@ -21,6 +23,10 @@
     ".": "./letta.js",
     "./app-server-protocol": {
       "types": "./dist/types/app-server-protocol.d.ts"
+    },
+    "./app-server-client": {
+      "types": "./dist/types/app-server-client.d.ts",
+      "import": "./dist/app-server-client.js"
     },
     "./protocol": {
       "types": "./dist/types/protocol.d.ts"

--- a/src/app-server-client.test.ts
+++ b/src/app-server-client.test.ts
@@ -64,7 +64,7 @@ function createFakeClient() {
   return { client, control, stream };
 }
 
-describe("app-server client helper", () => {
+describe("app-server client", () => {
   afterEach(() => {
     FakeSocket.instances = [];
   });
@@ -140,6 +140,11 @@ describe("app-server client helper", () => {
     stream.open();
     await client.connect();
 
+    const sent: string[] = [];
+    client.onSend((command) => {
+      sent.push(command.type);
+    });
+
     const runtime = { agent_id: "agent-1", conversation_id: "conv-1" };
     const syncPromise = client.sync({
       runtime,
@@ -185,6 +190,35 @@ describe("app-server client helper", () => {
       type: "input",
       runtime,
       payload: { kind: "create_message" },
+    });
+    expect(sent).toEqual(["sync", "abort_message", "input"]);
+  });
+
+  test("supports ergonomic request construction", async () => {
+    const { client, control, stream } = createFakeClient();
+    control.open();
+    stream.open();
+    await client.connect();
+
+    const responsePromise = client.request("agent_list", {
+      query: { limit: 10 },
+    });
+    expect(JSON.parse(control.sent[0] ?? "{}")).toMatchObject({
+      type: "agent_list",
+      request_id: "agent_list-1",
+      query: { limit: 10 },
+    });
+
+    control.receive({
+      type: "agent_list_response",
+      request_id: "agent_list-1",
+      success: true,
+      agents: [],
+    });
+
+    expect(await responsePromise).toMatchObject({
+      type: "agent_list_response",
+      success: true,
     });
   });
 

--- a/src/app-server-client.test.ts
+++ b/src/app-server-client.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  type AppServerSocketLike,
+  createAppServerClient,
+  resolveAppServerChannelUrl,
+} from "./app-server-client";
+
+type Listener = (event: unknown) => void;
+
+class FakeSocket implements AppServerSocketLike {
+  static instances: FakeSocket[] = [];
+
+  readyState = 0;
+  readonly sent: string[] = [];
+  private readonly listeners = new Map<string, Set<Listener>>();
+
+  constructor(readonly url: string) {
+    FakeSocket.instances.push(this);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.readyState = 3;
+    this.emit("close", {});
+  }
+
+  addEventListener(type: string, listener: Listener): void {
+    const listeners = this.listeners.get(type) ?? new Set<Listener>();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: Listener): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  open(): void {
+    this.readyState = 1;
+    this.emit("open", {});
+  }
+
+  receive(message: unknown): void {
+    this.emit("message", { data: JSON.stringify(message) });
+  }
+
+  private emit(type: string, event: unknown): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+function createFakeClient() {
+  const client = createAppServerClient({
+    url: "http://127.0.0.1:4500",
+    WebSocket: FakeSocket,
+    requestTimeoutMs: 25,
+  });
+  const [control, stream] = FakeSocket.instances;
+  if (!control || !stream) throw new Error("expected two sockets");
+  return { client, control, stream };
+}
+
+describe("app-server client helper", () => {
+  afterEach(() => {
+    FakeSocket.instances = [];
+  });
+
+  test("resolves control and stream websocket URLs", () => {
+    expect(resolveAppServerChannelUrl("http://127.0.0.1:4500", "control")).toBe(
+      "ws://127.0.0.1:4500/ws?channel=control",
+    );
+    expect(
+      resolveAppServerChannelUrl(
+        "wss://example.test/ws?channel=control&token=abc",
+        "stream",
+      ),
+    ).toBe("wss://example.test/ws?channel=stream&token=abc");
+  });
+
+  test("connects both sockets and resolves request_id responses", async () => {
+    const { client, control, stream } = createFakeClient();
+    const opened = client.connect();
+    control.open();
+    stream.open();
+    await opened;
+
+    const seen: string[] = [];
+    client.onMessage((message, channel) => {
+      seen.push(`${channel}:${message.type}`);
+    });
+
+    const responsePromise = client.runtimeStart({
+      create_agent: { body: { name: "SDK test" } },
+      create_conversation: { body: {} },
+    });
+
+    expect(JSON.parse(control.sent[0] ?? "{}")).toMatchObject({
+      type: "runtime_start",
+      request_id: "runtime-start-1",
+      create_agent: { body: { name: "SDK test" } },
+    });
+
+    control.receive({
+      type: "runtime_start_response",
+      request_id: "runtime-start-1",
+      success: true,
+      runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+      agent: { id: "agent-1" },
+      conversation: { id: "conv-1" },
+      created: { agent: true, conversation: true },
+    });
+
+    const response = await responsePromise;
+    expect(response.runtime).toEqual({
+      agent_id: "agent-1",
+      conversation_id: "conv-1",
+    });
+
+    stream.receive({
+      type: "update_loop_status",
+      runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+      event_seq: 1,
+      emitted_at: "2026-06-11T00:00:00.000Z",
+      idempotency_key: "evt-1",
+      loop_status: { status: "WAITING_ON_INPUT", active_run_ids: [] },
+    });
+    expect(seen).toEqual([
+      "control:runtime_start_response",
+      "stream:update_loop_status",
+    ]);
+  });
+
+  test("wraps sync, abort, and input commands", async () => {
+    const { client, control, stream } = createFakeClient();
+    control.open();
+    stream.open();
+    await client.connect();
+
+    const runtime = { agent_id: "agent-1", conversation_id: "conv-1" };
+    const syncPromise = client.sync({
+      runtime,
+      recover_approvals: false,
+      force_device_status: true,
+    });
+    expect(JSON.parse(control.sent[0] ?? "{}")).toMatchObject({
+      type: "sync",
+      request_id: "sync-1",
+      runtime,
+    });
+    control.receive({
+      type: "sync_response",
+      request_id: "sync-1",
+      runtime,
+      success: true,
+    });
+    expect((await syncPromise).success).toBe(true);
+
+    const abortPromise = client.abort({ runtime });
+    expect(JSON.parse(control.sent[1] ?? "{}")).toMatchObject({
+      type: "abort_message",
+      request_id: "abort-2",
+      runtime,
+    });
+    control.receive({
+      type: "abort_message_response",
+      request_id: "abort-2",
+      runtime,
+      aborted: false,
+      success: true,
+    });
+    expect((await abortPromise).aborted).toBe(false);
+
+    client.input({
+      runtime,
+      payload: {
+        kind: "create_message",
+        messages: [{ role: "user", content: "hello" }],
+      },
+    });
+    expect(JSON.parse(control.sent[2] ?? "{}")).toMatchObject({
+      type: "input",
+      runtime,
+      payload: { kind: "create_message" },
+    });
+  });
+
+  test("times out unanswered requests", async () => {
+    const { client, control, stream } = createFakeClient();
+    control.open();
+    stream.open();
+    await client.connect();
+
+    await expect(
+      client.sync({
+        runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+      }),
+    ).rejects.toThrow("Timed out waiting for sync-1");
+  });
+});

--- a/src/app-server-client.ts
+++ b/src/app-server-client.ts
@@ -12,10 +12,19 @@ import type {
 
 export type AppServerChannel = "control" | "stream";
 
+/**
+ * Receives every parsed protocol frame from both app-server websocket channels.
+ * Treat this as the primary event stream: app-server may emit replay or turn
+ * updates on the same channel that sent the triggering command, not only on the
+ * stream channel. The channel argument is diagnostic/routing context.
+ */
 export type AppServerMessageHandler = (
   message: WsProtocolMessage,
   channel: AppServerChannel,
 ) => void;
+
+/** Called synchronously before a protocol command is written to the control socket. */
+export type AppServerSendHandler = (command: WsProtocolCommand) => void;
 
 export interface AppServerSocketLike {
   readyState: number;
@@ -45,6 +54,19 @@ export interface AppServerRequestOptions<TMessage extends WsProtocolMessage> {
   timeoutMs?: number;
   predicate?: (message: WsProtocolMessage) => message is TMessage;
 }
+
+export type AppServerRequestCommand = Extract<
+  WsProtocolCommand,
+  { request_id?: string }
+>;
+
+export type AppServerRequestCommandWithId = AppServerRequestCommand & {
+  request_id: string;
+};
+
+export type AppServerRequestBody = Record<string, unknown> & {
+  request_id?: string;
+};
 
 type PendingRequest = {
   resolve: (message: WsProtocolMessage) => void;
@@ -178,6 +200,7 @@ export class AppServerClient {
   private readonly requestTimeoutMs: number;
   private readonly pending = new Map<string, PendingRequest>();
   private readonly messageHandlers = new Set<AppServerMessageHandler>();
+  private readonly sendHandlers = new Set<AppServerSendHandler>();
   private nextRequestNumber = 0;
 
   constructor(options: AppServerClientOptions) {
@@ -226,19 +249,59 @@ export class AppServerClient {
     return () => this.messageHandlers.delete(handler);
   }
 
+  onSend(handler: AppServerSendHandler): () => void {
+    this.sendHandlers.add(handler);
+    return () => this.sendHandlers.delete(handler);
+  }
+
   nextRequestId(prefix = "req"): string {
     this.nextRequestNumber += 1;
     return `${prefix}-${this.nextRequestNumber}`;
   }
 
   send(command: WsProtocolCommand): void {
+    for (const handler of this.sendHandlers) {
+      handler(command);
+    }
     this.control.send(JSON.stringify(command));
   }
 
   request<TMessage extends WsProtocolMessage = WsProtocolMessage>(
-    command: WsProtocolCommand & { request_id: string },
-    options: AppServerRequestOptions<TMessage> = {},
+    command: AppServerRequestCommandWithId,
+    options?: AppServerRequestOptions<TMessage>,
+  ): Promise<TMessage>;
+
+  request<
+    TType extends AppServerRequestCommand["type"],
+    TMessage extends WsProtocolMessage = WsProtocolMessage,
+  >(
+    type: TType,
+    body?: AppServerRequestBody,
+    options?: AppServerRequestOptions<TMessage>,
+  ): Promise<TMessage>;
+
+  request<TMessage extends WsProtocolMessage = WsProtocolMessage>(
+    commandOrType:
+      | AppServerRequestCommandWithId
+      | AppServerRequestCommand["type"],
+    bodyOrOptions:
+      | AppServerRequestBody
+      | AppServerRequestOptions<TMessage> = {},
+    maybeOptions: AppServerRequestOptions<TMessage> = {},
   ): Promise<TMessage> {
+    const isTypeRequest = typeof commandOrType === "string";
+    const command = isTypeRequest
+      ? ({
+          type: commandOrType,
+          request_id:
+            (bodyOrOptions as { request_id?: string }).request_id ??
+            this.nextRequestId(commandOrType),
+          ...(bodyOrOptions as object),
+        } as AppServerRequestCommandWithId)
+      : commandOrType;
+    const options = isTypeRequest
+      ? maybeOptions
+      : (bodyOrOptions as AppServerRequestOptions<TMessage>);
     const timeoutMs = options.timeoutMs ?? this.requestTimeoutMs;
 
     return new Promise((resolve, reject) => {

--- a/src/app-server-client.ts
+++ b/src/app-server-client.ts
@@ -1,0 +1,376 @@
+import type {
+  AbortMessageCommand,
+  AbortMessageResponseMessage,
+  InputCommand,
+  RuntimeStartCommand,
+  RuntimeStartResponseMessage,
+  SyncCommand,
+  SyncResponseMessage,
+  WsProtocolCommand,
+  WsProtocolMessage,
+} from "./types/app-server-protocol";
+
+export type AppServerChannel = "control" | "stream";
+
+export type AppServerMessageHandler = (
+  message: WsProtocolMessage,
+  channel: AppServerChannel,
+) => void;
+
+export interface AppServerSocketLike {
+  readyState: number;
+  send(data: string): void;
+  close(): void;
+  addEventListener?(type: string, listener: (event: unknown) => void): void;
+  removeEventListener?(type: string, listener: (event: unknown) => void): void;
+  on?(type: string, listener: (event: unknown) => void): void;
+  off?(type: string, listener: (event: unknown) => void): void;
+  once?(type: string, listener: (event: unknown) => void): void;
+}
+
+export type AppServerSocketConstructor = new (
+  url: string,
+) => AppServerSocketLike;
+
+export interface AppServerClientOptions {
+  /** Base app-server URL, e.g. ws://127.0.0.1:4500 or http://127.0.0.1:4500. */
+  url: string;
+  /** Optional WebSocket constructor for Node/tests. Browsers use globalThis.WebSocket. */
+  WebSocket?: AppServerSocketConstructor;
+  /** Default timeout for request_id-correlated control requests. */
+  requestTimeoutMs?: number;
+}
+
+export interface AppServerRequestOptions<TMessage extends WsProtocolMessage> {
+  timeoutMs?: number;
+  predicate?: (message: WsProtocolMessage) => message is TMessage;
+}
+
+type PendingRequest = {
+  resolve: (message: WsProtocolMessage) => void;
+  reject: (error: Error) => void;
+  predicate?: (message: WsProtocolMessage) => boolean;
+  timeout: ReturnType<typeof setTimeout>;
+};
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const WEBSOCKET_OPEN_STATE = 1;
+
+function getGlobalWebSocket(): AppServerSocketConstructor | undefined {
+  return (globalThis as { WebSocket?: AppServerSocketConstructor }).WebSocket;
+}
+
+function normalizeBaseUrl(url: string): URL {
+  const parsed = new URL(url);
+  if (parsed.protocol === "http:") parsed.protocol = "ws:";
+  if (parsed.protocol === "https:") parsed.protocol = "wss:";
+  if (parsed.protocol !== "ws:" && parsed.protocol !== "wss:") {
+    throw new Error(`Unsupported app-server URL protocol: ${parsed.protocol}`);
+  }
+  if (!parsed.pathname || parsed.pathname === "/") {
+    parsed.pathname = "/ws";
+  }
+  return parsed;
+}
+
+export function resolveAppServerChannelUrl(
+  url: string,
+  channel: AppServerChannel,
+): string {
+  const parsed = normalizeBaseUrl(url);
+  parsed.searchParams.set("channel", channel);
+  return parsed.toString();
+}
+
+function attachSocketListener(
+  socket: AppServerSocketLike,
+  type: string,
+  listener: (event: unknown) => void,
+): () => void {
+  if (socket.addEventListener && socket.removeEventListener) {
+    socket.addEventListener(type, listener);
+    return () => socket.removeEventListener?.(type, listener);
+  }
+
+  if (socket.on) {
+    socket.on(type, listener);
+    return () => socket.off?.(type, listener);
+  }
+
+  throw new Error("WebSocket implementation does not support event listeners");
+}
+
+function onceSocketEvent(
+  socket: AppServerSocketLike,
+  type: string,
+  listener: (event: unknown) => void,
+): () => void {
+  if (socket.once) {
+    socket.once(type, listener);
+    return () => socket.off?.(type, listener);
+  }
+
+  let detach = () => {};
+  detach = attachSocketListener(socket, type, (event) => {
+    detach();
+    listener(event);
+  });
+  return detach;
+}
+
+function waitForSocketOpen(socket: AppServerSocketLike): Promise<void> {
+  if (socket.readyState === WEBSOCKET_OPEN_STATE) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    let detachOpen = () => {};
+    let detachError = () => {};
+    const cleanup = () => {
+      detachOpen();
+      detachError();
+    };
+    detachOpen = onceSocketEvent(socket, "open", () => {
+      cleanup();
+      resolve();
+    });
+    detachError = onceSocketEvent(socket, "error", (event) => {
+      cleanup();
+      reject(
+        new Error(`App-server WebSocket failed to open: ${String(event)}`),
+      );
+    });
+  });
+}
+
+function rawEventData(event: unknown): unknown {
+  if (event && typeof event === "object" && "data" in event) {
+    return (event as { data: unknown }).data;
+  }
+  return event;
+}
+
+function messageDataToString(data: unknown): string {
+  const raw = rawEventData(data);
+  if (typeof raw === "string") return raw;
+  if (raw instanceof ArrayBuffer) {
+    return new TextDecoder().decode(raw);
+  }
+  if (raw instanceof Uint8Array) {
+    return new TextDecoder().decode(raw);
+  }
+  if (ArrayBuffer.isView(raw)) {
+    return new TextDecoder().decode(
+      new Uint8Array(raw.buffer as ArrayBuffer, raw.byteOffset, raw.byteLength),
+    );
+  }
+  return String(raw);
+}
+
+function parseProtocolMessage(event: unknown): WsProtocolMessage {
+  return JSON.parse(messageDataToString(event)) as WsProtocolMessage;
+}
+
+export class AppServerClient {
+  readonly control: AppServerSocketLike;
+  readonly stream: AppServerSocketLike;
+
+  private readonly requestTimeoutMs: number;
+  private readonly pending = new Map<string, PendingRequest>();
+  private readonly messageHandlers = new Set<AppServerMessageHandler>();
+  private nextRequestNumber = 0;
+
+  constructor(options: AppServerClientOptions) {
+    const WebSocket = options.WebSocket ?? getGlobalWebSocket();
+    if (!WebSocket) {
+      throw new Error("No WebSocket implementation available");
+    }
+
+    this.requestTimeoutMs =
+      options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.control = new WebSocket(
+      resolveAppServerChannelUrl(options.url, "control"),
+    );
+    this.stream = new WebSocket(
+      resolveAppServerChannelUrl(options.url, "stream"),
+    );
+
+    attachSocketListener(this.control, "message", (event) => {
+      this.handleMessage(event, "control");
+    });
+    attachSocketListener(this.stream, "message", (event) => {
+      this.handleMessage(event, "stream");
+    });
+    const rejectPending = () =>
+      this.rejectAllPending("App-server socket closed");
+    attachSocketListener(this.control, "close", rejectPending);
+    attachSocketListener(this.stream, "close", rejectPending);
+  }
+
+  async connect(): Promise<this> {
+    await Promise.all([
+      waitForSocketOpen(this.control),
+      waitForSocketOpen(this.stream),
+    ]);
+    return this;
+  }
+
+  close(): void {
+    this.rejectAllPending("App-server client closed");
+    this.control.close();
+    this.stream.close();
+  }
+
+  onMessage(handler: AppServerMessageHandler): () => void {
+    this.messageHandlers.add(handler);
+    return () => this.messageHandlers.delete(handler);
+  }
+
+  nextRequestId(prefix = "req"): string {
+    this.nextRequestNumber += 1;
+    return `${prefix}-${this.nextRequestNumber}`;
+  }
+
+  send(command: WsProtocolCommand): void {
+    this.control.send(JSON.stringify(command));
+  }
+
+  request<TMessage extends WsProtocolMessage = WsProtocolMessage>(
+    command: WsProtocolCommand & { request_id: string },
+    options: AppServerRequestOptions<TMessage> = {},
+  ): Promise<TMessage> {
+    const timeoutMs = options.timeoutMs ?? this.requestTimeoutMs;
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(command.request_id);
+        reject(new Error(`Timed out waiting for ${command.request_id}`));
+      }, timeoutMs);
+
+      this.pending.set(command.request_id, {
+        resolve: (message) => resolve(message as TMessage),
+        reject,
+        predicate: options.predicate,
+        timeout,
+      });
+
+      try {
+        this.send(command);
+      } catch (error) {
+        clearTimeout(timeout);
+        this.pending.delete(command.request_id);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  }
+
+  runtimeStart(
+    command: Omit<RuntimeStartCommand, "type" | "request_id"> & {
+      request_id?: string;
+    },
+    options: Omit<
+      AppServerRequestOptions<RuntimeStartResponseMessage>,
+      "predicate"
+    > = {},
+  ): Promise<RuntimeStartResponseMessage> {
+    return this.request(
+      {
+        type: "runtime_start",
+        request_id: command.request_id ?? this.nextRequestId("runtime-start"),
+        ...command,
+      },
+      {
+        ...options,
+        predicate: (message): message is RuntimeStartResponseMessage =>
+          message.type === "runtime_start_response",
+      },
+    );
+  }
+
+  sync(
+    command: Omit<SyncCommand, "type" | "request_id"> & { request_id?: string },
+    options: Omit<
+      AppServerRequestOptions<SyncResponseMessage>,
+      "predicate"
+    > = {},
+  ): Promise<SyncResponseMessage> {
+    return this.request(
+      {
+        type: "sync",
+        request_id: command.request_id ?? this.nextRequestId("sync"),
+        ...command,
+      },
+      {
+        ...options,
+        predicate: (message): message is SyncResponseMessage =>
+          message.type === "sync_response",
+      },
+    );
+  }
+
+  abort(
+    command: Omit<AbortMessageCommand, "type" | "request_id"> & {
+      request_id?: string;
+    },
+    options: Omit<
+      AppServerRequestOptions<AbortMessageResponseMessage>,
+      "predicate"
+    > = {},
+  ): Promise<AbortMessageResponseMessage> {
+    return this.request(
+      {
+        type: "abort_message",
+        request_id: command.request_id ?? this.nextRequestId("abort"),
+        ...command,
+      },
+      {
+        ...options,
+        predicate: (message): message is AbortMessageResponseMessage =>
+          message.type === "abort_message_response",
+      },
+    );
+  }
+
+  input(command: Omit<InputCommand, "type">): void {
+    this.send({ type: "input", ...command });
+  }
+
+  private handleMessage(event: unknown, channel: AppServerChannel): void {
+    const message = parseProtocolMessage(event);
+
+    for (const handler of this.messageHandlers) {
+      handler(message, channel);
+    }
+
+    const requestId =
+      message && typeof message === "object" && "request_id" in message
+        ? (message as { request_id?: unknown }).request_id
+        : undefined;
+    if (channel !== "control" || typeof requestId !== "string") {
+      return;
+    }
+
+    const pending = this.pending.get(requestId);
+    if (!pending || (pending.predicate && !pending.predicate(message))) {
+      return;
+    }
+
+    clearTimeout(pending.timeout);
+    this.pending.delete(requestId);
+    pending.resolve(message);
+  }
+
+  private rejectAllPending(reason: string): void {
+    for (const [requestId, pending] of this.pending) {
+      clearTimeout(pending.timeout);
+      this.pending.delete(requestId);
+      pending.reject(new Error(reason));
+    }
+  }
+}
+
+export function createAppServerClient(
+  options: AppServerClientOptions,
+): AppServerClient {
+  return new AppServerClient(options);
+}

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -7,5 +7,9 @@
     "declarationMap": true,
     "outDir": "./dist/types"
   },
-  "include": ["src/types/protocol.ts", "src/types/app-server-protocol.ts"]
+  "include": [
+    "src/types/protocol.ts",
+    "src/types/app-server-protocol.ts",
+    "src/app-server-client.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- add `./app-server-client` as the minimal SDK/client for native app-server v2
- support dual control/stream websocket connections, request_id correlation, `runtimeStart`, `sync`, `abort`, `input`, and raw message hooks
- add ergonomic generic requests via `client.request(type, body)` while preserving raw command-object requests
- add `client.onSend(...)` for traces/devtools/tests without monkey-patching `send`
- document `client.onMessage(...)` as the global protocol event surface because replay/turn frames may arrive on either websocket channel
- emit runtime JS and declaration files during build

## Positioning
This is the first slice of the app-server client SDK from the app-server vision: Desktop and other clients dogfood native v2, and the SDK wraps v2 for developers without hiding the protocol or overbuilding higher-level message abstractions too early. We are shipping it inside `@letta-ai/letta-code` for now and can revisit standalone SDK packaging later.

## Validation
- `bun test src/app-server-client.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun run check`
- copied POC: `bun run check`
- copied POC: `LETTA_CODE_REPO=/Users/caren/Dev/letta-code/.letta/worktrees/app-server-sdk-helper bun run test:app-server`
- copied POC: `LETTA_CODE_REPO=/Users/caren/Dev/letta-code/.letta/worktrees/app-server-sdk-helper bun run test:browser`