### PR TITLE
fix(app-server): support default runtime conversations

### DIFF
--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -707,6 +707,52 @@ describe("listen-client parseServerMessage", () => {
       }
     });
 
+    test("starts an agent default conversation", async () => {
+      const storageDir = await mkdtemp(
+        join(os.tmpdir(), "ws-runtime-start-default-"),
+      );
+      try {
+        const backend = new LocalBackend({
+          storageDir,
+          executionMode: "deterministic",
+        });
+        __testSetBackend(backend);
+        const agent = await backend.createAgent({
+          name: "Runtime Default Agent",
+          model: "anthropic/claude-sonnet-4-6",
+        } as AgentCreateBody);
+        const listener = __listenClientTestUtils.createListenerRuntime();
+        const socket = new MockSocket(WebSocket.OPEN);
+
+        await __listenClientTestUtils.handleRuntimeStartCommand(
+          {
+            type: "runtime_start",
+            request_id: "runtime-start-default",
+            agent_id: agent.id,
+            conversation_id: "default",
+            recover_approvals: false,
+          },
+          socket as unknown as WebSocket,
+          listener,
+        );
+
+        expect(JSON.parse(socket.sentPayloads[0] ?? "{}")).toMatchObject({
+          type: "runtime_start_response",
+          request_id: "runtime-start-default",
+          success: true,
+          runtime: {
+            agent_id: agent.id,
+            conversation_id: "default",
+          },
+          agent: { id: agent.id },
+          conversation: { id: "default", agent_id: agent.id },
+          created: { agent: false, conversation: false },
+        });
+      } finally {
+        await rm(storageDir, { recursive: true, force: true });
+      }
+    });
+
     test("soft-fails invalid runtime_start combinations", async () => {
       const storageDir = await mkdtemp(
         join(os.tmpdir(), "ws-runtime-start-error-"),

--- a/src/websocket/listener/commands/runtime-start.ts
+++ b/src/websocket/listener/commands/runtime-start.ts
@@ -45,6 +45,21 @@ type CreatedResources = {
   conversation: boolean;
 };
 
+function buildDefaultConversation(agent: AgentState): Conversation {
+  const now = new Date().toISOString();
+  return {
+    id: "default",
+    agent_id: agent.id,
+    archived: false,
+    archived_at: null,
+    created_at: now,
+    updated_at: now,
+    last_message_at: null,
+    summary: null,
+    in_context_message_ids: [],
+  } as Conversation;
+}
+
 function getErrorMessage(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
 }
@@ -136,6 +151,9 @@ async function resolveRuntimeStartConversation(
 ): Promise<Conversation> {
   const backend = getBackend();
   if (hasString(parsed.conversation_id)) {
+    if (parsed.conversation_id === "default") {
+      return buildDefaultConversation(agent);
+    }
     const conversation = await backend.retrieveConversation(
       parsed.conversation_id,
     );


### PR DESCRIPTION
## Summary
- allow `runtime_start` with `agent_id` + `conversation_id: "default"`
- return a virtual default conversation object in the runtime_start response
- cover the default conversation path in websocket protocol tests

## Why
ACP main-chat mode maps to Letta Code's virtual default conversation. The app-server client prototype needs native v2 to support that same scope instead of forcing all ACP sessions into newly-created isolated conversations.

## Validation
- `bun test src/websocket/listen-client-protocol.test.ts --test-name-pattern "runtime_start"`
- `bun run typecheck`
- `bun run build`
- `bun run check`
- ACP prototype smoke: `env -u LETTA_AGENT_ID -u LETTA_CONVERSATION_ID LETTA_ACP_TRANSPORT=app-server LETTA_APP_SERVER_BACKEND=local LETTA_LOCAL_BACKEND_EXECUTOR=deterministic LETTA_BIN=/Users/caren/Dev/letta-code/.letta/worktrees/acp-app-server-fixes/letta.js LETTA_APP_SERVER_CLIENT_MODULE=/Users/caren/Dev/letta-code/.letta/worktrees/acp-app-server-fixes/dist/app-server-client.js npm run smoke -- "Reply with exactly: pong"`
