### PR TITLE
feat(app-server): add turn helper to client

### DIFF
--- a/src/app-server-client.test.ts
+++ b/src/app-server-client.test.ts
@@ -194,6 +194,177 @@ describe("app-server client", () => {
     expect(sent).toEqual(["sync", "abort_message", "input"]);
   });
 
+  test("runTurn injects client message ids and resolves on stop_reason", async () => {
+    const { client, control, stream } = createFakeClient();
+    control.open();
+    stream.open();
+    await client.connect();
+
+    const runtime = { agent_id: "agent-1", conversation_id: "conv-1" };
+    const turn = client.runTurn({
+      runtime,
+      payload: {
+        kind: "create_message",
+        messages: [{ role: "user", content: "hello" }],
+      },
+    });
+
+    const sent = JSON.parse(control.sent[0] ?? "{}");
+    expect(sent).toMatchObject({
+      type: "input",
+      runtime,
+      payload: { kind: "create_message" },
+    });
+    expect(sent.payload.messages[0].client_message_id).toStartWith(
+      "client-message-",
+    );
+
+    stream.receive({
+      type: "stream_delta",
+      runtime,
+      event_seq: 1,
+      emitted_at: "2026-06-11T00:00:00.000Z",
+      idempotency_key: "stream-1",
+      delta: {
+        type: "message",
+        message_type: "assistant_message",
+        run_id: "run-1",
+        content: [{ type: "text", text: "pong" }],
+      },
+    });
+    stream.receive({
+      type: "stream_delta",
+      runtime,
+      event_seq: 2,
+      emitted_at: "2026-06-11T00:00:00.001Z",
+      idempotency_key: "stream-2",
+      delta: {
+        type: "message",
+        message_type: "stop_reason",
+        run_id: "run-1",
+        stop_reason: "end_turn",
+      },
+    });
+
+    expect(await turn).toMatchObject({
+      runtime,
+      stopReason: "end_turn",
+      runIds: ["run-1"],
+      completedBy: "stop_reason",
+    });
+  });
+
+  test("runTurn does not treat idle status alone as terminal", async () => {
+    const { client, control, stream } = createFakeClient();
+    control.open();
+    stream.open();
+    await client.connect();
+
+    const runtime = { agent_id: "agent-1", conversation_id: "conv-1" };
+    const turn = client.runTurn(
+      {
+        runtime,
+        payload: {
+          kind: "create_message",
+          messages: [{ role: "user", content: "hello" }],
+        },
+      },
+      { timeoutMs: 25, allowLoopStatusFallback: true },
+    );
+
+    stream.receive({
+      type: "update_loop_status",
+      runtime,
+      event_seq: 1,
+      emitted_at: "2026-06-11T00:00:00.000Z",
+      idempotency_key: "loop-1",
+      loop_status: { status: "WAITING_ON_INPUT", active_run_ids: [] },
+    });
+
+    await expect(turn).rejects.toThrow("Timed out waiting for app-server turn");
+  });
+
+  test("runTurn can use guarded loop-status fallback after run evidence", async () => {
+    const { client, control, stream } = createFakeClient();
+    control.open();
+    stream.open();
+    await client.connect();
+
+    const runtime = { agent_id: "agent-1", conversation_id: "conv-1" };
+    const turn = client.runTurn(
+      {
+        runtime,
+        payload: {
+          kind: "create_message",
+          messages: [{ role: "user", content: "hello" }],
+        },
+      },
+      { allowLoopStatusFallback: true },
+    );
+
+    stream.receive({
+      type: "update_loop_status",
+      runtime,
+      event_seq: 1,
+      emitted_at: "2026-06-11T00:00:00.000Z",
+      idempotency_key: "loop-1",
+      loop_status: {
+        status: "PROCESSING_API_RESPONSE",
+        active_run_ids: ["run-1"],
+      },
+    });
+    stream.receive({
+      type: "update_loop_status",
+      runtime,
+      event_seq: 2,
+      emitted_at: "2026-06-11T00:00:00.001Z",
+      idempotency_key: "loop-2",
+      loop_status: { status: "WAITING_ON_INPUT", active_run_ids: [] },
+    });
+
+    expect(await turn).toMatchObject({
+      runtime,
+      stopReason: null,
+      runIds: ["run-1"],
+      completedBy: "loop_status_waiting_fallback",
+    });
+  });
+
+  test("runTurn rejects on loop_error stream delta", async () => {
+    const { client, control, stream } = createFakeClient();
+    control.open();
+    stream.open();
+    await client.connect();
+
+    const runtime = { agent_id: "agent-1", conversation_id: "conv-1" };
+    const turn = client.runTurn({
+      runtime,
+      payload: {
+        kind: "create_message",
+        messages: [{ role: "user", content: "hello" }],
+      },
+    });
+
+    stream.receive({
+      type: "stream_delta",
+      runtime,
+      event_seq: 1,
+      emitted_at: "2026-06-11T00:00:00.000Z",
+      idempotency_key: "stream-1",
+      delta: {
+        id: "message-1",
+        date: "2026-06-11T00:00:00.000Z",
+        message_type: "loop_error",
+        run_id: "run-1",
+        message: "No API key for provider",
+        stop_reason: "llm_api_error",
+        is_terminal: false,
+      },
+    });
+
+    await expect(turn).rejects.toThrow("No API key for provider");
+  });
+
   test("supports ergonomic request construction", async () => {
     const { client, control, stream } = createFakeClient();
     control.open();

--- a/src/app-server-client.test.ts
+++ b/src/app-server-client.test.ts
@@ -284,6 +284,39 @@ describe("app-server client", () => {
     await expect(turn).rejects.toThrow("Timed out waiting for app-server turn");
   });
 
+  test("runTurn rejects concurrent turns for the same runtime", async () => {
+    const { client, control, stream } = createFakeClient();
+    control.open();
+    stream.open();
+    await client.connect();
+
+    const runtime = { agent_id: "agent-1", conversation_id: "conv-1" };
+    const first = client.runTurn(
+      {
+        runtime,
+        payload: {
+          kind: "create_message",
+          messages: [{ role: "user", content: "hello" }],
+        },
+      },
+      { timeoutMs: 25 },
+    );
+
+    await expect(
+      client.runTurn({
+        runtime,
+        payload: {
+          kind: "create_message",
+          messages: [{ role: "user", content: "again" }],
+        },
+      }),
+    ).rejects.toThrow("A turn is already in flight for agent-1/conv-1");
+
+    await expect(first).rejects.toThrow(
+      "Timed out waiting for app-server turn",
+    );
+  });
+
   test("runTurn can use guarded loop-status fallback after run evidence", async () => {
     const { client, control, stream } = createFakeClient();
     control.open();

--- a/src/app-server-client.ts
+++ b/src/app-server-client.ts
@@ -2,8 +2,11 @@ import type {
   AbortMessageCommand,
   AbortMessageResponseMessage,
   InputCommand,
+  LoopStatusUpdateMessage,
+  RuntimeScope,
   RuntimeStartCommand,
   RuntimeStartResponseMessage,
+  StreamDeltaMessage,
   SyncCommand,
   SyncResponseMessage,
   WsProtocolCommand,
@@ -74,6 +77,29 @@ type PendingRequest = {
   predicate?: (message: WsProtocolMessage) => boolean;
   timeout: ReturnType<typeof setTimeout>;
 };
+
+export type AppServerTurnCompletionSource =
+  | "stop_reason"
+  | "loop_status_waiting_fallback";
+
+export interface AppServerTurnResult {
+  runtime: RuntimeScope;
+  stopReason: string | null;
+  runIds: string[];
+  clientMessageIds: string[];
+  completedBy: AppServerTurnCompletionSource;
+  terminalMessage: WsProtocolMessage;
+}
+
+export interface AppServerRunTurnOptions {
+  timeoutMs?: number;
+  /**
+   * Prefer explicit stream terminal events. This fallback is only used after
+   * the client has seen stream/run evidence for this runtime, never from idle
+   * loop status alone.
+   */
+  allowLoopStatusFallback?: boolean;
+}
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const WEBSOCKET_OPEN_STATE = 1;
@@ -191,6 +217,43 @@ function messageDataToString(data: unknown): string {
 
 function parseProtocolMessage(event: unknown): WsProtocolMessage {
   return JSON.parse(messageDataToString(event)) as WsProtocolMessage;
+}
+
+function sameRuntime(a: RuntimeScope | undefined, b: RuntimeScope): boolean {
+  return a?.agent_id === b.agent_id && a?.conversation_id === b.conversation_id;
+}
+
+function isWaitingLoopStatus(message: LoopStatusUpdateMessage): boolean {
+  return message.loop_status.status === "WAITING_ON_INPUT";
+}
+
+function streamDeltaRunId(message: StreamDeltaMessage): string | null {
+  const runId = (message.delta as { run_id?: unknown }).run_id;
+  return typeof runId === "string" ? runId : null;
+}
+
+function streamDeltaMessageType(message: StreamDeltaMessage): string | null {
+  const messageType = (message.delta as { message_type?: unknown })
+    .message_type;
+  return typeof messageType === "string" ? messageType : null;
+}
+
+function streamDeltaStopReason(message: StreamDeltaMessage): string | null {
+  const stopReason = (message.delta as { stop_reason?: unknown }).stop_reason;
+  return typeof stopReason === "string" ? stopReason : null;
+}
+
+function streamDeltaErrorMessage(message: StreamDeltaMessage): string {
+  const delta = message.delta as {
+    message?: unknown;
+    api_error?: { message?: unknown; detail?: unknown };
+  };
+  const apiMessage = delta.api_error?.message ?? delta.api_error?.detail;
+  if (typeof apiMessage === "string" && apiMessage.length > 0)
+    return apiMessage;
+  if (typeof delta.message === "string" && delta.message.length > 0)
+    return delta.message;
+  return "App-server turn failed";
 }
 
 export class AppServerClient {
@@ -396,6 +459,130 @@ export class AppServerClient {
 
   input(command: Omit<InputCommand, "type">): void {
     this.send({ type: "input", ...command });
+  }
+
+  runTurn(
+    command: Omit<InputCommand, "type">,
+    options: AppServerRunTurnOptions = {},
+  ): Promise<AppServerTurnResult> {
+    const timeoutMs = options.timeoutMs ?? this.requestTimeoutMs;
+    const commandWithIds = this.withClientMessageIds(command);
+    const runIds = new Set<string>();
+    let observedTurnEvidence = false;
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        cleanup();
+        reject(
+          new Error(
+            `Timed out waiting for app-server turn on ${command.runtime.agent_id}/${command.runtime.conversation_id}`,
+          ),
+        );
+      }, timeoutMs);
+
+      const cleanup = () => {
+        clearTimeout(timeout);
+        offMessage();
+      };
+
+      const finish = (
+        completedBy: AppServerTurnCompletionSource,
+        terminalMessage: WsProtocolMessage,
+        stopReason: string | null,
+      ) => {
+        cleanup();
+        resolve({
+          runtime: command.runtime,
+          stopReason,
+          runIds: [...runIds],
+          clientMessageIds: commandWithIds.clientMessageIds,
+          completedBy,
+          terminalMessage,
+        });
+      };
+
+      const fail = (error: Error) => {
+        cleanup();
+        reject(error);
+      };
+
+      const offMessage = this.onMessage((message) => {
+        if (
+          !sameRuntime(
+            (message as { runtime?: RuntimeScope }).runtime,
+            command.runtime,
+          )
+        ) {
+          return;
+        }
+
+        if (message.type === "stream_delta") {
+          observedTurnEvidence = true;
+          const runId = streamDeltaRunId(message);
+          if (runId) runIds.add(runId);
+
+          const messageType = streamDeltaMessageType(message);
+          if (messageType === "loop_error" || messageType === "error_message") {
+            fail(new Error(streamDeltaErrorMessage(message)));
+            return;
+          }
+          if (messageType === "stop_reason") {
+            finish("stop_reason", message, streamDeltaStopReason(message));
+          }
+          return;
+        }
+
+        if (message.type === "update_loop_status") {
+          for (const runId of message.loop_status.active_run_ids) {
+            observedTurnEvidence = true;
+            runIds.add(runId);
+          }
+          if (
+            options.allowLoopStatusFallback === true &&
+            observedTurnEvidence &&
+            isWaitingLoopStatus(message)
+          ) {
+            finish("loop_status_waiting_fallback", message, null);
+          }
+        }
+      });
+
+      try {
+        this.input(commandWithIds.command);
+      } catch (error) {
+        fail(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  }
+
+  private withClientMessageIds(command: Omit<InputCommand, "type">): {
+    command: Omit<InputCommand, "type">;
+    clientMessageIds: string[];
+  } {
+    if (command.payload.kind !== "create_message") {
+      return { command, clientMessageIds: [] };
+    }
+
+    const clientMessageIds: string[] = [];
+    const messages = command.payload.messages.map((message) => {
+      if (message.role !== "user") return message;
+      const existing = (message as { client_message_id?: unknown })
+        .client_message_id;
+      const clientMessageId =
+        typeof existing === "string" && existing.length > 0
+          ? existing
+          : this.nextRequestId("client-message");
+      clientMessageIds.push(clientMessageId);
+      return { ...message, client_message_id: clientMessageId };
+    });
+
+    return {
+      command: {
+        ...command,
+        payload: { ...command.payload, messages },
+      },
+      clientMessageIds,
+    };
   }
 
   private handleMessage(event: unknown, channel: AppServerChannel): void {

--- a/src/app-server-client.ts
+++ b/src/app-server-client.ts
@@ -264,6 +264,7 @@ export class AppServerClient {
   private readonly pending = new Map<string, PendingRequest>();
   private readonly messageHandlers = new Set<AppServerMessageHandler>();
   private readonly sendHandlers = new Set<AppServerSendHandler>();
+  private readonly activeTurnRuntimes = new Set<string>();
   private nextRequestNumber = 0;
 
   constructor(options: AppServerClientOptions) {
@@ -465,6 +466,13 @@ export class AppServerClient {
     command: Omit<InputCommand, "type">,
     options: AppServerRunTurnOptions = {},
   ): Promise<AppServerTurnResult> {
+    const runtimeKey = `${command.runtime.agent_id}/${command.runtime.conversation_id}`;
+    if (this.activeTurnRuntimes.has(runtimeKey)) {
+      return Promise.reject(
+        new Error(`A turn is already in flight for ${runtimeKey}`),
+      );
+    }
+    this.activeTurnRuntimes.add(runtimeKey);
     const timeoutMs = options.timeoutMs ?? this.requestTimeoutMs;
     const commandWithIds = this.withClientMessageIds(command);
     const runIds = new Set<string>();
@@ -482,6 +490,7 @@ export class AppServerClient {
 
       const cleanup = () => {
         clearTimeout(timeout);
+        this.activeTurnRuntimes.delete(runtimeKey);
         offMessage();
       };
 


### PR DESCRIPTION
## Summary
- add `AppServerClient.runTurn(...)` for input + terminal turn waiting
- resolve on `stream_delta` `stop_reason`, reject on `loop_error` / `error_message`
- inject `client_message_id` for user messages when callers do not provide one
- guard loop-status fallback so `WAITING_ON_INPUT` alone cannot complete a turn without prior stream/run evidence

## Why
The ACP prototype showed that app-server loop status can return to `WAITING_ON_INPUT` before terminal stream evidence arrives. Treating idle status alone as completion can produce false success and kill the runtime before the backend result/error is surfaced. The client helper centralizes the safer semantics for app-server consumers.

## Validation
- `bun test src/app-server-client.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun run check`
- ACP prototype smoke against this built client: `env -u LETTA_AGENT_ID -u LETTA_CONVERSATION_ID LETTA_APP_SERVER_BACKEND=local LETTA_LOCAL_BACKEND_EXECUTOR=deterministic LETTA_BIN=/Users/caren/Dev/letta-code/.letta/worktrees/app-server-turn-helper/letta.js LETTA_APP_SERVER_CLIENT_MODULE=/Users/caren/Dev/letta-code/.letta/worktrees/app-server-turn-helper/dist/app-server-client.js npm run smoke:app-server-turn -- two-turn`
