### PR TITLE
feat(mods): expose tool metadata to permission overlays

### DIFF
--- a/src/cli/approval-classification.test.ts
+++ b/src/cli/approval-classification.test.ts
@@ -103,6 +103,55 @@ describe("classifyApprovals", () => {
     });
   });
 
+  test("passes tool metadata to mod permission overlays", async () => {
+    const seen: Array<{ toolName: string; tool: unknown }> = [];
+    registerModPermission({
+      id: "capture-tool-metadata",
+      description: "Capture tool metadata",
+      path: "/tmp/capture-tool-metadata.ts",
+      owner: {
+        id: "global:/tmp/capture-tool-metadata.ts",
+        path: "/tmp/capture-tool-metadata.ts",
+        scope: "global",
+        generation: 1,
+      },
+      activationSignal: new AbortController().signal,
+      getContext: () => {
+        throw new Error("unused");
+      },
+      isAvailable: () => true,
+      check(event) {
+        seen.push({ toolName: event.toolName, tool: event.tool });
+        return undefined;
+      },
+    });
+
+    await classifyApprovals(
+      [
+        {
+          toolCallId: "call-read",
+          toolName: "Read",
+          toolArgs: JSON.stringify({ file_path: "README.md" }),
+        },
+        {
+          toolCallId: "call-write",
+          toolName: "Write",
+          toolArgs: JSON.stringify({ file_path: "README.md", content: "x" }),
+        },
+      ],
+      { workingDirectory: "/tmp/project" },
+    );
+
+    expect(seen).toContainEqual({
+      toolName: "Read",
+      tool: { name: "Read", permissionEffect: "read" },
+    });
+    expect(seen).toContainEqual({
+      toolName: "Write",
+      tool: { name: "Write", permissionEffect: "write" },
+    });
+  });
+
   test("mod permission overlays allow scoped tools before default ask", async () => {
     registerModPermission({
       id: "allow-plan-file",

--- a/src/mods/types.ts
+++ b/src/mods/types.ts
@@ -455,11 +455,19 @@ export type ModPermissionDecision = "allow" | "ask" | "deny";
 
 export type ModPermissionCheckPhase = "approval" | "execution";
 
+export type ModPermissionToolEffect = "read" | "write" | "shell" | "unknown";
+
+export interface ModPermissionToolMetadata {
+  name: string;
+  permissionEffect: ModPermissionToolEffect;
+}
+
 export interface ModPermissionCheckEvent {
   agentId: string | null;
   conversationId: string | null;
   toolCallId: string | null;
   toolName: string;
+  tool?: ModPermissionToolMetadata;
   args: Record<string, unknown>;
   cwd: string;
   workingDirectory: string;

--- a/src/permissions/checker.ts
+++ b/src/permissions/checker.ts
@@ -11,6 +11,7 @@ import {
 } from "@/mods/permission-registry";
 import { modToolRequiresApproval } from "@/mods/tool-registry";
 import type { PermissionModeState } from "@/tools/manager";
+import { getToolPermissionMetadata } from "@/tools/tool-metadata";
 import { canonicalToolName, isShellToolName } from "./canonical";
 import { cliPermissions } from "./cli-permissions-instance";
 import { evaluateCrossAgentGuard, extractFilePath } from "./cross-agent-guard";
@@ -852,6 +853,7 @@ export async function checkPermissionWithHooks(
         conversationId: modPermissionOptions.conversationId ?? null,
         toolCallId: modPermissionOptions.toolCallId ?? null,
         toolName,
+        tool: getToolPermissionMetadata(toolName, toolArgs),
         args: toolArgs,
         cwd: workingDirectory,
         workingDirectory,

--- a/src/skills/builtin/creating-mods/references/permissions.md
+++ b/src/skills/builtin/creating-mods/references/permissions.md
@@ -20,7 +20,7 @@ export default function activate(letta) {
     check(event) {
       if (!isPlanModeActive(event.conversationId)) return;
 
-      if (isReadOnlyTool(event.toolName, event.args)) {
+      if (event.tool?.permissionEffect === "read") {
         return { decision: "allow" };
       }
 
@@ -45,6 +45,10 @@ export default function activate(letta) {
   conversationId: string | null;
   toolCallId: string | null;
   toolName: string;
+  tool?: {
+    name: string;
+    permissionEffect: "read" | "write" | "shell" | "unknown";
+  };
   args: Record<string, unknown>;
   cwd: string;
   workingDirectory: string;
@@ -52,6 +56,10 @@ export default function activate(letta) {
   phase: "approval" | "execution";
 }
 ```
+
+Use `event.tool?.permissionEffect` for broad tool-family policy. It is the
+harness-provided tool metadata and avoids duplicating every provider-specific
+read tool alias in local mod code.
 
 ## Return values
 

--- a/src/skills/builtin/creating-mods/references/plan-mode.md
+++ b/src/skills/builtin/creating-mods/references/plan-mode.md
@@ -180,32 +180,14 @@ if (letta.capabilities.events.turns) {
 
 ## Permission overlay
 
-Use a permission overlay, not `tool_start`, for policy. Normalize tool names by family; UI display names and provider-specific tool names drift (`Read`, `read`, `read_file`, `ReadFile`, `SearchFileContent`, etc.). Keep pure read-only tools separate from planning coordination tools like `AskUserQuestion` and todo/plan updates so the policy stays honest.
+Use a permission overlay, not `tool_start`, for policy. Use the
+harness-provided `event.tool?.permissionEffect` for broad tool families; it
+classifies tools as `read`, `write`, `shell`, or `unknown` and avoids duplicating
+provider-specific read aliases. Keep only narrow name-based allowlists for
+tools that are not read-only but are intentionally part of the planning flow,
+like `AskUserQuestion` and todo/plan updates.
 
 ```ts
-const readOnlyToolNames = new Set([
-  "glob",
-  "globgemini",
-  "grep",
-  "grepfiles",
-  "list",
-  "listdir",
-  "listdirectory",
-  "ls",
-  "notebookread",
-  "read",
-  "readfile",
-  "readfilegemini",
-  "readlsp",
-  "readmanyfiles",
-  "search",
-  "searchfilecontent",
-  "searchfiles",
-  "skill",
-  "taskoutput",
-  "viewimage",
-]);
-
 const planningToolNames = new Set([
   "askuserquestion",
   "enterplanmode",
@@ -219,10 +201,6 @@ const readOnlySubagentTypes = new Set(["recall"]);
 
 function normalizedToolName(toolName) {
   return toolName.replace(/[^a-z0-9]/gi, "").toLowerCase();
-}
-
-function isReadOnlyToolName(toolName) {
-  return readOnlyToolNames.has(normalizedToolName(toolName));
 }
 
 function isPlanningToolName(toolName) {
@@ -250,7 +228,9 @@ if (letta.capabilities.permissions) {
       const toolName = String(event.toolName);
       const args = event.args ?? {};
 
-      if (isReadOnlyToolName(toolName)) return { decision: "allow" };
+      if (event.tool?.permissionEffect === "read") {
+        return { decision: "allow" };
+      }
       if (isPlanningToolName(toolName)) return { decision: "allow", reason: "planning" };
 
       const normalized = normalizedToolName(toolName);

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -67,6 +67,7 @@ import {
   scrubSecretsFromString,
 } from "./secret-substitution";
 import { TOOL_DEFINITIONS, type ToolName } from "./tool-definitions";
+import { getToolPermissionMetadata } from "./tool-metadata";
 
 export const TOOL_NAMES = Object.keys(TOOL_DEFINITIONS) as ToolName[];
 
@@ -1219,6 +1220,7 @@ async function checkModPermissionForContext(options: {
       conversationId: runtimeContext?.conversationId ?? null,
       toolCallId: options.toolCallId ?? null,
       toolName: options.toolName,
+      tool: getToolPermissionMetadata(options.toolName, options.args),
       args: options.args,
       cwd: options.workingDirectory,
       workingDirectory: options.workingDirectory,

--- a/src/tools/tool-execution-context.test.ts
+++ b/src/tools/tool-execution-context.test.ts
@@ -197,6 +197,7 @@ describe("tool execution context snapshot", () => {
 
   test("rechecks mod permission overlays after tool_start arg transforms", async () => {
     await loadSpecificTools(["Read"]);
+    let observedToolMetadata: unknown;
     registerModPermission({
       id: "execution-gate",
       description: "Deny mutated reads",
@@ -213,6 +214,9 @@ describe("tool execution context snapshot", () => {
       },
       isAvailable: () => true,
       check(event) {
+        if (event.phase === "execution" && event.toolName === "Read") {
+          observedToolMetadata = event.tool;
+        }
         if (
           event.phase === "execution" &&
           event.toolName === "Read" &&
@@ -250,6 +254,10 @@ describe("tool execution context snapshot", () => {
       "mod permission:execution-gate",
     );
     expect(asText(result.toolReturn)).toContain("mutated path blocked");
+    expect(observedToolMetadata).toEqual({
+      name: "Read",
+      permissionEffect: "read",
+    });
   });
 
   test("reports execution-phase ask decisions as blocked approval requests", async () => {

--- a/src/tools/tool-metadata.ts
+++ b/src/tools/tool-metadata.ts
@@ -1,0 +1,82 @@
+import type { ModPermissionToolMetadata } from "@/mods/types";
+
+const READ_ONLY_TOOL_NAMES = new Set([
+  "glob",
+  "globgemini",
+  "grep",
+  "grepfiles",
+  "list",
+  "listdir",
+  "listdirectory",
+  "ls",
+  "notebookread",
+  "read",
+  "readfile",
+  "readfilegemini",
+  "readlsp",
+  "readmanyfiles",
+  "search",
+  "searchfilecontent",
+  "searchfiles",
+  "skill",
+  "taskoutput",
+  "viewimage",
+]);
+
+const WRITE_TOOL_NAMES = new Set([
+  "applypatch",
+  "createworktree",
+  "edit",
+  "memory",
+  "memoryapplypatch",
+  "multiedit",
+  "notebookedit",
+  "replace",
+  "write",
+  "writefile",
+  "writefilegemini",
+]);
+
+const SHELL_TOOL_NAMES = new Set([
+  "bash",
+  "execcommand",
+  "runshellcommand",
+  "runshellcommandgemini",
+  "shell",
+  "shellcommand",
+]);
+
+function normalizedToolName(toolName: string): string {
+  return toolName.replace(/[^a-z0-9]/gi, "").toLowerCase();
+}
+
+export function getToolPermissionMetadata(
+  toolName: string,
+  args: Record<string, unknown> = {},
+): ModPermissionToolMetadata {
+  const normalized = normalizedToolName(toolName);
+
+  if (normalized === "writestdin") {
+    return {
+      name: toolName,
+      permissionEffect:
+        typeof args.chars === "string" && args.chars.length > 0
+          ? "write"
+          : "read",
+    };
+  }
+
+  if (READ_ONLY_TOOL_NAMES.has(normalized)) {
+    return { name: toolName, permissionEffect: "read" };
+  }
+
+  if (WRITE_TOOL_NAMES.has(normalized)) {
+    return { name: toolName, permissionEffect: "write" };
+  }
+
+  if (SHELL_TOOL_NAMES.has(normalized)) {
+    return { name: toolName, permissionEffect: "shell" };
+  }
+
+  return { name: toolName, permissionEffect: "unknown" };
+}


### PR DESCRIPTION
## Summary
- add centralized tool permission-effect metadata for mod permission checks
- pass tool metadata during approval and execution permission overlay phases
- update creating-mods permission docs and plan-mode example to use `event.tool?.permissionEffect` instead of local read-tool alias lists

## Validation
- `bun test src/cli/approval-classification.test.ts src/tools/tool-execution-context.test.ts`
- `bun run typecheck`