### PR TITLE
fix(cron): fix "Send now" failing when scheduler lease is held by another process

### DIFF
--- a/src/cron/cron-file.ts
+++ b/src/cron/cron-file.ts
@@ -634,12 +634,12 @@ export function claimSchedulerLease(): string {
     if (data.scheduler_owner) {
       const existingOwner = data.scheduler_owner;
       const { pid, token: existingToken } = existingOwner;
-      if (isProcessAlive(pid, existingOwner)) {
+      if (pid !== process.pid && isProcessAlive(pid, existingOwner)) {
         throw new Error(
           `Scheduler lease held by PID ${pid} (token ${existingToken}). Cannot claim.`,
         );
       }
-      // Stale lease from dead process — take over
+      // Stale lease from dead process or self-reclaim — take over
     }
 
     data.scheduler_owner = {

--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -74,6 +74,18 @@ interface SchedulerState {
 
 let schedulerState: SchedulerState | null = null;
 
+/**
+ * Listener context stored independently of the scheduler lease.
+ * runCronTaskNow ("Send now") only needs an active listener — it doesn't
+ * need the tick loop or the lease. This lets it work even when another
+ * process holds the scheduler lease (e.g. desktop app vs local dev server).
+ */
+let listenerFireContext: {
+  socket: ListenerTransport;
+  opts: StartListenerOptions;
+  processQueuedTurn: ProcessQueuedTurn;
+} | null = null;
+
 // ── Constants ───────────────────────────────────────────────────────
 
 const TICK_INTERVAL_MS = 60_000;
@@ -399,7 +411,10 @@ export async function runCronTaskNow(taskId: string): Promise<{
     };
   }
 
-  if (!schedulerState) {
+  // Prefer the full scheduler state, but fall back to the listener context.
+  // "Send now" only needs the active listener — not the tick loop or the lease.
+  const ctx = schedulerState ?? listenerFireContext;
+  if (!ctx) {
     return {
       success: false,
       found: true,
@@ -412,9 +427,9 @@ export async function runCronTaskNow(taskId: string): Promise<{
   const fired = await fireCronTask(
     task,
     now,
-    schedulerState.socket,
-    schedulerState.opts,
-    schedulerState.processQueuedTurn,
+    ctx.socket,
+    ctx.opts,
+    ctx.processQueuedTurn,
   );
 
   if (!fired) {
@@ -426,7 +441,9 @@ export async function runCronTaskNow(taskId: string): Promise<{
     };
   }
 
-  refreshTaskCache(schedulerState);
+  if (schedulerState) {
+    refreshTaskCache(schedulerState);
+  }
   return { success: true, found: true, task: getTask(taskId) ?? task };
 }
 
@@ -533,6 +550,10 @@ export function startScheduler(
   processQueuedTurn: ProcessQueuedTurn,
   _retryCount = 0,
 ): void {
+  // Always store the listener context so runCronTaskNow ("Send now") works
+  // even when this process doesn't hold the scheduler lease.
+  listenerFireContext = { socket, opts, processQueuedTurn };
+
   if (schedulerState) return;
 
   let token: string;
@@ -601,6 +622,7 @@ export function startScheduler(
  * Stop the cron scheduler. Should be called when the WS listener disconnects.
  */
 export function stopScheduler(): void {
+  listenerFireContext = null;
   if (!schedulerState) return;
 
   clearInterval(schedulerState.tickInterval);


### PR DESCRIPTION
## Summary
- Store listener context (`listenerFireContext`) independently of the scheduler lease so `runCronTaskNow` ("Send now") works even when this process does not hold the scheduler lease — e.g. when the desktop app has both REMOTE and MAIN listener processes, or a stale lease from a previous session blocks claim
- Allow same-PID lease reclaim in `claimSchedulerLease` so the scheduler tick loop restarts after WS reconnects where `releaseSchedulerLease` silently failed

## Test plan
- [ ] Fresh app launch with stale `crons.json` lease from previous session → "Send now" works
- [ ] Local dev: bun dev server + desktop app running simultaneously → "Send now" works on dev server
- [ ] WS reconnect (laptop sleep/wake) → scheduler restarts, both "Send now" and normal ticks work
- [ ] Existing cron tests pass (`bun test src/cron/cron-file.test.ts src/cron/scheduler.test.ts` — 44/44)

🤖 Generated with [Letta Code](https://letta.com)