### PR TITLE
feat(permissions): add always-ask rules

### DIFF
--- a/src/cli/app/use-approval-flow.ts
+++ b/src/cli/app/use-approval-flow.ts
@@ -818,7 +818,9 @@ export function useApprovalFlow(ctx: ApprovalFlowContext) {
           (r) => r.permission.decision === "allow",
         );
         const stillNeedAsking = recheckResults.filter(
-          (r) => r.permission.decision === "ask",
+          (r) =>
+            r.permission.decision === "ask" ||
+            r.permission.decision === "alwaysAsk",
         );
 
         // Only auto-handle if ALL remaining are now allowed

--- a/src/cli/approval-classification.test.ts
+++ b/src/cli/approval-classification.test.ts
@@ -1,18 +1,44 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { classifyApprovals } from "@/cli/helpers/approval-classification";
 import {
   clearModPermissions,
   registerModPermission,
 } from "@/mods/permission-registry";
+import {
+  resetPermissionLoaderCacheForTests,
+  savePermissionRule,
+} from "@/permissions/loader";
 import { permissionMode } from "@/permissions/mode";
 import { loadTools } from "@/tools/manager";
 
 describe("classifyApprovals", () => {
   const originalMemoryDir = process.env.MEMORY_DIR;
+  const tempDirs: string[] = [];
 
-  afterEach(() => {
+  async function createTempProjectWithAlwaysAskRule(): Promise<string> {
+    const projectDir = await mkdtemp(join(tmpdir(), "letta-always-ask-"));
+    tempDirs.push(projectDir);
+    await savePermissionRule(
+      "Bash(git push:*)",
+      "alwaysAsk",
+      "local",
+      projectDir,
+    );
+    return projectDir;
+  }
+
+  afterEach(async () => {
     clearModPermissions();
+    resetPermissionLoaderCacheForTests();
     permissionMode.reset();
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => rm(dir, { recursive: true, force: true })),
+    );
     if (originalMemoryDir === undefined) {
       delete process.env.MEMORY_DIR;
     } else {
@@ -152,5 +178,54 @@ describe("classifyApprovals", () => {
       matchedRule: "mod permission:allow-plan-file",
       reason: "active plan file",
     });
+  });
+
+  test("alwaysAsk rules require user input in unrestricted mode", async () => {
+    permissionMode.setMode("unrestricted");
+    const projectDir = await createTempProjectWithAlwaysAskRule();
+
+    const result = await classifyApprovals(
+      [
+        {
+          toolCallId: "call-git-push",
+          toolName: "Bash",
+          toolArgs: JSON.stringify({ command: "git push origin main" }),
+        },
+      ],
+      { workingDirectory: projectDir },
+    );
+
+    expect(result.autoAllowed).toHaveLength(0);
+    expect(result.autoDenied).toHaveLength(0);
+    expect(result.needsUserInput).toHaveLength(1);
+    expect(result.needsUserInput[0]?.permission).toMatchObject({
+      decision: "alwaysAsk",
+      matchedRule: "Bash(git push:*)",
+      reason: "Matched alwaysAsk rule",
+    });
+  });
+
+  test("treatAskAsDeny also denies alwaysAsk rules", async () => {
+    permissionMode.setMode("unrestricted");
+    const projectDir = await createTempProjectWithAlwaysAskRule();
+
+    const result = await classifyApprovals(
+      [
+        {
+          toolCallId: "call-git-push",
+          toolName: "Bash",
+          toolArgs: JSON.stringify({ command: "git push origin main" }),
+        },
+      ],
+      { workingDirectory: projectDir, treatAskAsDeny: true },
+    );
+
+    expect(result.autoAllowed).toHaveLength(0);
+    expect(result.needsUserInput).toHaveLength(0);
+    expect(result.autoDenied).toHaveLength(1);
+    expect(result.autoDenied[0]?.permission.decision).toBe("alwaysAsk");
+    expect(result.autoDenied[0]?.denyReason).toBe(
+      "Tool requires approval (headless mode)",
+    );
   });
 });

--- a/src/cli/helpers/approval-classification.ts
+++ b/src/cli/helpers/approval-classification.ts
@@ -139,7 +139,9 @@ export async function classifyApprovals<TContext = ApprovalContext | null>(
       decision = "ask";
     }
 
-    if (decision === "ask" && opts.treatAskAsDeny) {
+    const needsHumanApproval = decision === "ask" || decision === "alwaysAsk";
+
+    if (needsHumanApproval && opts.treatAskAsDeny) {
       autoDenied.push({
         approval,
         permission,
@@ -157,7 +159,7 @@ export async function classifyApprovals<TContext = ApprovalContext | null>(
       parsedArgs,
     };
 
-    if (decision === "ask") {
+    if (needsHumanApproval) {
       needsUserInput.push(entry);
     } else if (decision === "deny") {
       autoDenied.push(entry);

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -4321,7 +4321,7 @@ async function runBidirectionalMode(
             }
 
             for (const ac of needsUserInput) {
-              // permission.decision === "ask" - request permission from SDK
+              // permission.decision is ask/alwaysAsk - request permission from SDK
               const permResponse = await requestPermission(
                 ac.approval.toolCallId,
                 ac.approval.toolName,

--- a/src/permissions/checker.ts
+++ b/src/permissions/checker.ts
@@ -122,7 +122,11 @@ function shouldAttachTrace(result: PermissionCheckResult): boolean {
   if (!envFlagEnabled("LETTA_PERMISSION_TRACE")) {
     return false;
   }
-  return result.decision === "ask" || result.decision === "deny";
+  return (
+    result.decision === "ask" ||
+    result.decision === "alwaysAsk" ||
+    result.decision === "deny"
+  );
 }
 
 /**
@@ -345,6 +349,52 @@ function checkPermissionForEngine(
         },
         trace,
       };
+    }
+  }
+
+  if (sessionRules.alwaysAsk) {
+    for (const pattern of sessionRules.alwaysAsk) {
+      const matched = matchesPattern(
+        toolName,
+        query,
+        pattern,
+        workingDirectory,
+        engine,
+      );
+      traceEvent(trace, "session-always-ask-rule", undefined, pattern, matched);
+      if (matched) {
+        return {
+          result: {
+            decision: "alwaysAsk",
+            matchedRule: `${pattern} (session)`,
+            reason: "Matched alwaysAsk rule",
+          },
+          trace,
+        };
+      }
+    }
+  }
+
+  if (permissions.alwaysAsk) {
+    for (const pattern of permissions.alwaysAsk) {
+      const matched = matchesPattern(
+        toolName,
+        query,
+        pattern,
+        workingDirectory,
+        engine,
+      );
+      traceEvent(trace, "always-ask-rule", undefined, pattern, matched);
+      if (matched) {
+        return {
+          result: {
+            decision: "alwaysAsk",
+            matchedRule: pattern,
+            reason: "Matched alwaysAsk rule",
+          },
+          trace,
+        };
+      }
     }
   }
 
@@ -861,11 +911,13 @@ export async function checkPermissionWithHooks(
       modPermissions,
     );
     if (modDecision) {
-      result = {
-        decision: modDecision.decision,
-        matchedRule: modDecision.matchedRule,
-        reason: modDecision.reason ?? `Matched ${modDecision.matchedRule}`,
-      };
+      if (result.decision !== "alwaysAsk" || modDecision.decision === "deny") {
+        result = {
+          decision: modDecision.decision,
+          matchedRule: modDecision.matchedRule,
+          reason: modDecision.reason ?? `Matched ${modDecision.matchedRule}`,
+        };
+      }
     }
   }
 

--- a/src/permissions/loader.ts
+++ b/src/permissions/loader.ts
@@ -11,7 +11,7 @@ import {
   normalizePermissionRule,
   permissionRulesEquivalent,
 } from "./rule-normalization";
-import type { PermissionRules } from "./types";
+import type { PermissionRules, PermissionRuleType } from "./types";
 
 type SettingsPermissions = Omit<PermissionRules, "mode"> & {
   mode?: string;
@@ -134,6 +134,7 @@ function clonePermissions(permissions: PermissionRules): PermissionRules {
     allow: [...(permissions.allow || [])],
     deny: [...(permissions.deny || [])],
     ask: [...(permissions.ask || [])],
+    alwaysAsk: [...(permissions.alwaysAsk || [])],
     additionalDirectories: [...(permissions.additionalDirectories || [])],
   };
   if (permissions.mode) {
@@ -225,6 +226,7 @@ export async function loadPermissions(
     allow: [],
     deny: [],
     ask: [],
+    alwaysAsk: [],
     additionalDirectories: [],
   };
 
@@ -282,6 +284,9 @@ function mergePermissions(
   if (source.ask) {
     target.ask = mergeRuleList(target.ask, source.ask);
   }
+  if (source.alwaysAsk) {
+    target.alwaysAsk = mergeRuleList(target.alwaysAsk, source.alwaysAsk);
+  }
   if (source.additionalDirectories) {
     target.additionalDirectories = [
       ...(target.additionalDirectories || []),
@@ -308,7 +313,7 @@ function mergeRuleList(
  */
 export async function savePermissionRule(
   rule: string,
-  ruleType: "allow" | "deny" | "ask",
+  ruleType: PermissionRuleType,
   scope: "project" | "local" | "user",
   workingDirectory: string = process.cwd(),
 ): Promise<void> {

--- a/src/permissions/permissions-loader.test.ts
+++ b/src/permissions/permissions-loader.test.ts
@@ -36,6 +36,7 @@ test("Load permissions from empty directory returns rules from user settings", a
   expect(Array.isArray(permissions.allow)).toBe(true);
   expect(Array.isArray(permissions.deny)).toBe(true);
   expect(Array.isArray(permissions.ask)).toBe(true);
+  expect(Array.isArray(permissions.alwaysAsk)).toBe(true);
   expect(Array.isArray(permissions.additionalDirectories)).toBe(true);
 });
 
@@ -75,6 +76,22 @@ test("Load permissions from local settings", async () => {
 
   // Should include local rule (may also include user settings from real home dir)
   expect(permissions.allow).toContain("Bash(git push:*)");
+});
+
+test("Load permissions from alwaysAsk settings", async () => {
+  const projectDir = join(testDir, "project-always-ask");
+  await Bun.write(
+    join(projectDir, ".letta", "settings.json"),
+    JSON.stringify({
+      permissions: {
+        alwaysAsk: ["Bash(git push:*)"],
+      },
+    }),
+  );
+
+  const permissions = await loadPermissions(projectDir);
+
+  expect(permissions.alwaysAsk).toContain("Bash(git push:*)");
 });
 
 test("Load permissions migrates legacy permission mode", async () => {
@@ -333,6 +350,22 @@ test("Save permission to deny list", async () => {
   const settings = await file.json();
 
   expect(settings.permissions.deny).toContain("Read(.env)");
+});
+
+test("Save permission to alwaysAsk list", async () => {
+  const projectDir = join(testDir, "project");
+  await savePermissionRule(
+    "Bash(git push:*)",
+    "alwaysAsk",
+    "project",
+    projectDir,
+  );
+
+  const settingsPath = join(projectDir, ".letta", "settings.json");
+  const file = Bun.file(settingsPath);
+  const settings = await file.json();
+
+  expect(settings.permissions.alwaysAsk).toContain("Bash(git push:*)");
 });
 
 test("Save permission doesn't create duplicates", async () => {

--- a/src/permissions/permissions-mode.test.ts
+++ b/src/permissions/permissions-mode.test.ts
@@ -163,6 +163,69 @@ test("unrestricted mode - does NOT override deny rules", () => {
   expect(result.reason).toBe("Matched deny rule");
 });
 
+test("unrestricted mode - does NOT override alwaysAsk rules", () => {
+  permissionMode.setMode("unrestricted");
+
+  const permissions: PermissionRules = {
+    allow: [],
+    deny: [],
+    ask: [],
+    alwaysAsk: ["Bash(git push:*)"],
+  };
+
+  const result = checkPermission(
+    "Bash",
+    { command: "git push origin main" },
+    permissions,
+    "/Users/test/project",
+  );
+
+  expect(result.decision).toBe("alwaysAsk");
+  expect(result.matchedRule).toBe("Bash(git push:*)");
+  expect(result.reason).toBe("Matched alwaysAsk rule");
+});
+
+test("unrestricted mode - deny rules override alwaysAsk rules", () => {
+  permissionMode.setMode("unrestricted");
+
+  const permissions: PermissionRules = {
+    allow: [],
+    deny: ["Bash(git push:*)"],
+    ask: [],
+    alwaysAsk: ["Bash(git push:*)"],
+  };
+
+  const result = checkPermission(
+    "Bash",
+    { command: "git push origin main" },
+    permissions,
+    "/Users/test/project",
+  );
+
+  expect(result.decision).toBe("deny");
+  expect(result.reason).toBe("Matched deny rule");
+});
+
+test("unrestricted mode - regular ask rules still auto-allow", () => {
+  permissionMode.setMode("unrestricted");
+
+  const permissions: PermissionRules = {
+    allow: [],
+    deny: [],
+    ask: ["Bash(git push:*)"],
+  };
+
+  const result = checkPermission(
+    "Bash",
+    { command: "git push origin main" },
+    permissions,
+    "/Users/test/project",
+  );
+
+  expect(result.decision).toBe("allow");
+  expect(result.reason).toBe("Permission mode: unrestricted");
+});
+
 // ============================================================================
 // Permission Mode: acceptEdits
 // ============================================================================

--- a/src/permissions/session.ts
+++ b/src/permissions/session.ts
@@ -1,7 +1,7 @@
 // src/permissions/session.ts
 // In-memory permission store for session-only rules
 
-import type { PermissionRules } from "./types";
+import type { PermissionRules, PermissionRuleType } from "./types";
 
 /**
  * Session-only permissions that are not persisted to disk.
@@ -12,12 +12,13 @@ class SessionPermissions {
     allow: [],
     deny: [],
     ask: [],
+    alwaysAsk: [],
   };
 
   /**
    * Add a permission rule for this session only
    */
-  addRule(rule: string, type: "allow" | "deny" | "ask"): void {
+  addRule(rule: string, type: PermissionRuleType): void {
     const rules = this.sessionRules[type];
     if (rules && !rules.includes(rule)) {
       rules.push(rule);
@@ -32,6 +33,7 @@ class SessionPermissions {
       allow: [...(this.sessionRules.allow || [])],
       deny: [...(this.sessionRules.deny || [])],
       ask: [...(this.sessionRules.ask || [])],
+      alwaysAsk: [...(this.sessionRules.alwaysAsk || [])],
     };
   }
 
@@ -43,13 +45,14 @@ class SessionPermissions {
       allow: [],
       deny: [],
       ask: [],
+      alwaysAsk: [],
     };
   }
 
   /**
    * Check if a rule exists in session permissions
    */
-  hasRule(rule: string, type: "allow" | "deny" | "ask"): boolean {
+  hasRule(rule: string, type: PermissionRuleType): boolean {
     return this.sessionRules[type]?.includes(rule) || false;
   }
 }

--- a/src/permissions/types.ts
+++ b/src/permissions/types.ts
@@ -11,13 +11,16 @@ export interface PermissionRules {
   allow?: string[];
   deny?: string[];
   ask?: string[];
+  alwaysAsk?: string[];
   additionalDirectories?: string[];
 }
 
 /**
  * Permission decision for a tool execution
  */
-export type PermissionDecision = "allow" | "deny" | "ask";
+export type PermissionDecision = "allow" | "deny" | "ask" | "alwaysAsk";
+
+export type PermissionRuleType = PermissionDecision;
 
 /**
  * Scope for saving permission rules

--- a/src/skills/builtin/modifying-the-harness/SKILL.md
+++ b/src/skills/builtin/modifying-the-harness/SKILL.md
@@ -75,6 +75,8 @@ Load the `letta-api-client` skill for richer SDK examples.
 ## 1. Change permissions
 
 Permissions decide which tool calls are allowed, denied, or require approval.
+Use `alwaysAsk` when a rule should request human approval even in
+`unrestricted`/yolo mode.
 
 ### Rule syntax
 
@@ -91,6 +93,15 @@ python3 <skill-dir>/scripts/add_permission.py \
   --scope user
 ```
 
+Force approval even in yolo mode:
+
+```bash
+python3 <skill-dir>/scripts/add_permission.py \
+  --rule "Bash(git push:*)" \
+  --type alwaysAsk \
+  --scope user
+```
+
 ### Edit directly
 
 ```json
@@ -98,7 +109,8 @@ python3 <skill-dir>/scripts/add_permission.py \
   "permissions": {
     "allow": ["Bash(npm:*)", "Read(src/**)"],
     "deny": ["Bash(rm -rf:*)"],
-    "ask": []
+    "ask": [],
+    "alwaysAsk": ["Bash(git push:*)"]
   }
 }
 ```
@@ -215,6 +227,7 @@ Find your own entry by matching `agentId === $LETTA_AGENT_ID`, then edit the fie
 |------|----------------|
 | Auto-approve curl | `add_permission.py --rule "Bash(curl:*)" --type allow --scope user` |
 | Block `rm -rf` | Add `"Bash(rm -rf:*)"` to `permissions.deny`, or add a `PreToolUse` hook |
+| Always ask before git push | `add_permission.py --rule "Bash(git push:*)" --type alwaysAsk --scope user` |
 | Log all Bash calls | `add_hook.py --event PreToolUse --matcher Bash --type command --command '...' --scope user` |
 | Auto-format after edits | `add_hook.py --event PostToolUse --matcher "Edit|Write" --type command --command '...' --scope project` |
 | Gate edits with LLM | `add_hook.py --event PreToolUse --matcher "Edit|Write" --type prompt --prompt '...' --scope user` |
@@ -237,7 +250,7 @@ Find your own entry by matching `agentId === $LETTA_AGENT_ID`, then edit the fie
 
 | Script | Purpose |
 |--------|---------|
-| `scripts/add_permission.py` | Add an allow/deny/ask rule to any scope |
+| `scripts/add_permission.py` | Add an allow/deny/ask/alwaysAsk rule to any scope |
 | `scripts/add_hook.py` | Add a command or prompt hook to any event |
 | `scripts/show_config.py` | Show merged permissions, hooks, and per-agent settings across all scopes |
 

--- a/src/skills/builtin/modifying-the-harness/scripts/add_permission.py
+++ b/src/skills/builtin/modifying-the-harness/scripts/add_permission.py
@@ -5,6 +5,7 @@ Add a permission rule to Letta Code settings.
 Usage:
     python3 add_permission.py --rule "Bash(npm run:*)" --type allow --scope user
     python3 add_permission.py --rule "Read(src/**)" --type allow --scope project
+    python3 add_permission.py --rule "Bash(git push:*)" --type alwaysAsk --scope user
 """
 
 import argparse
@@ -99,7 +100,7 @@ def main():
     parser.add_argument(
         "--type",
         required=True,
-        choices=["allow", "deny", "ask"],
+        choices=["allow", "deny", "ask", "alwaysAsk"],
         help="Type of permission rule",
     )
     parser.add_argument(

--- a/src/skills/builtin/modifying-the-harness/scripts/show_config.py
+++ b/src/skills/builtin/modifying-the-harness/scripts/show_config.py
@@ -40,10 +40,11 @@ def format_permissions(
     all_settings: list[tuple[str, dict]], as_json: bool
 ) -> dict | None:
     """Collect permissions from all scopes with sources."""
-    rules: dict[str, list[tuple[str, str]]] = {"allow": [], "deny": [], "ask": []}
+    rule_types = ["allow", "deny", "ask", "alwaysAsk"]
+    rules: dict[str, list[tuple[str, str]]] = {rule_type: [] for rule_type in rule_types}
     for scope, settings in all_settings:
         perms = settings.get("permissions", {})
-        for rule_type in ["allow", "deny", "ask"]:
+        for rule_type in rule_types:
             for rule in perms.get(rule_type, []):
                 rules[rule_type].append((rule, scope))
 
@@ -59,7 +60,7 @@ def format_permissions(
     if total == 0:
         print("  (none)")
     else:
-        for rule_type in ["allow", "deny", "ask"]:
+        for rule_type in rule_types:
             if rules[rule_type]:
                 print(f"\n  {rule_type.upper()}:")
                 for rule, scope in rules[rule_type]:

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -45,6 +45,10 @@ import {
   permissionMode as globalPermissionMode,
   type PermissionMode,
 } from "@/permissions/mode";
+import type {
+  PermissionDecision,
+  PermissionRuleType,
+} from "@/permissions/types";
 import { OPENAI_CODEX_PROVIDER_NAME } from "@/providers/openai-codex-provider";
 import {
   getCurrentWorkingDirectory,
@@ -1235,7 +1239,7 @@ async function checkModPermissionForContext(options: {
  * @param toolName - Name of the tool
  * @param toolArgs - Tool arguments
  * @param workingDirectory - Current working directory (defaults to process.cwd())
- * @returns Permission decision: "allow", "deny", or "ask"
+ * @returns Permission decision: "allow", "deny", "ask", or "alwaysAsk"
  */
 export async function checkToolPermission(
   toolName: string,
@@ -1246,7 +1250,7 @@ export async function checkToolPermission(
   toolContextIdArg?: string | null,
   toolCallIdArg?: string | null,
 ): Promise<{
-  decision: "allow" | "deny" | "ask";
+  decision: PermissionDecision;
   matchedRule?: string;
   reason?: string;
 }> {
@@ -1291,13 +1295,13 @@ export async function checkToolPermission(
 /**
  * Save a permission rule to settings
  * @param rule - Permission rule (e.g., "Read(src/**)")
- * @param ruleType - Type of rule ("allow", "deny", or "ask")
+ * @param ruleType - Type of rule ("allow", "deny", "ask", or "alwaysAsk")
  * @param scope - Where to save ("project", "local", "user", or "session")
  * @param workingDirectory - Current working directory
  */
 export async function savePermissionRule(
   rule: string,
-  ruleType: "allow" | "deny" | "ask",
+  ruleType: PermissionRuleType,
   scope: "project" | "local" | "user" | "session",
   workingDirectory: string = process.cwd(),
 ): Promise<void> {


### PR DESCRIPTION
## Summary
- add `alwaysAsk` as a permission decision/rule list in settings
- evaluate `permissions.alwaysAsk` before permission-mode overrides so it still asks in unrestricted/yolo mode
- classify `alwaysAsk` alongside `ask` for approval UI/headless handling while keeping regular `ask` behavior unchanged
- update modifying-the-harness docs/scripts for `--type alwaysAsk`

## Notes
- `deny` and CLI disallow still win before `alwaysAsk`
- regular `ask` rules continue to be auto-approved by unrestricted/yolo mode
- scope intentionally does not add any mod tool API

## Validation
- `bun test src/permissions/permissions-mode.test.ts src/permissions/permissions-loader.test.ts src/cli/approval-classification.test.ts`
- `bun run typecheck`