### PR TITLE
feat(mods): add web search examples for local agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ letta --backend local --new-agent
 
 Local agents do not appear in the Constellation, but their memory is still a normal git repository under `~/.letta/lc-local-backend/memfs/<agent-id>/memory`.
 
+Local agents can add model-callable web search through trusted local mods in `~/.letta/mods/`. The bundled [`web-search-mods` skill](src/skills/builtin/web-search-mods/SKILL.md) includes Perplexity, Exa, and Parallel examples.
+
 ## 🌌 Constellation
 
 Agents hosted on Constellation can be accessed from any machine: your laptop, [GitHub Actions](https://github.com/letta-ai/letta-code-action), a sandbox, remote VM, or a Mac Mini. You can also chat with agents through [chat.letta.com](https://chat.letta.com/) or through the desktop app.

--- a/src/agent/skills-discovery.test.ts
+++ b/src/agent/skills-discovery.test.ts
@@ -6,8 +6,25 @@ import {
   symlinkSync,
   writeFileSync,
 } from "node:fs";
-import { join } from "node:path";
-import { discoverSkills } from "@/agent/skills";
+import { dirname, join } from "node:path";
+import { discoverSkills, getBundledSkills } from "@/agent/skills";
+
+describe("bundled web search mod skill", () => {
+  test("includes Perplexity, Exa, and Parallel provider references", async () => {
+    const bundledSkills = await getBundledSkills();
+    const skill = bundledSkills.find((item) => item.id === "web-search-mods");
+
+    expect(skill).toBeDefined();
+    expect(skill?.description).toContain("Perplexity");
+    expect(skill?.description).toContain("Exa");
+    expect(skill?.description).toContain("Parallel");
+
+    const skillRoot = dirname(skill?.path ?? "");
+    for (const fileName of ["perplexity.md", "exa.md", "parallel.md"]) {
+      expect(existsSync(join(skillRoot, "references", fileName))).toBe(true);
+    }
+  });
+});
 
 describe.skipIf(process.platform === "win32")(
   "skills discovery with symlinks",

--- a/src/skills/builtin/creating-mods/SKILL.md
+++ b/src/skills/builtin/creating-mods/SKILL.md
@@ -140,6 +140,7 @@ Before finishing, verify:
 | Reference | Load when |
 | --- | --- |
 | `references/tools.md` | The model should autonomously call a local capability |
+| `../web-search-mods/SKILL.md` | The requested tool is web search, Perplexity, Exa, or Parallel |
 | `references/commands.md` | The human should invoke `/foo` |
 | `references/providers.md` | Adding a custom model/API provider for local agents |
 | `references/events.md` | Reacting to lifecycle/tool/turn events or transforming turns/tools |

--- a/src/skills/builtin/web-search-mods/SKILL.md
+++ b/src/skills/builtin/web-search-mods/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: web-search-mods
+description: Create trusted local Letta Code mods that add model-callable web search tools for local agents using Perplexity, Exa, or Parallel APIs.
+when_to_use: Use when a local Letta Code agent needs web search, or when asked to add Perplexity, Exa, Parallel, live web, search, or research capability through a mod or extension.
+category: integrations
+tags: web search mods local-agent perplexity exa parallel
+---
+
+# Web search mods for local agents
+
+Use this skill when a local agent needs web search. The implementation path is a trusted local mod that registers a model-callable search tool.
+
+## Rules
+
+- Current naming is **mod**, not extension. Prefer `~/.letta/mods/`. Legacy `~/.letta/extensions/` is only for backwards compatibility.
+- Do not add provider SDK dependencies. Use `fetch` and standard runtime APIs so the mod works in a stock Letta Code install.
+- Do not hard-code API keys. Read from environment variables:
+  - `PERPLEXITY_API_KEY`
+  - `EXA_API_KEY`
+  - `PARALLEL_API_KEY`
+- Web search sends query text to a third-party provider. Tell the user which provider/env var the mod uses.
+- A search tool is read-only and may be marked `parallelSafe: true`. If the user wants approval before network calls, set `requiresApproval: true`; otherwise use `false` for normal web-search behavior.
+- After writing or editing a mod, tell the user to run `/reload` or restart Letta Code.
+- If a mod breaks startup, recover with `letta --no-mods` or `LETTA_DISABLE_MODS=1 letta`.
+
+## Workflow
+
+1. Ask which provider to use if the user did not specify one.
+2. Create `~/.letta/mods/` if needed.
+3. Write one focused mod file, for example:
+   - `~/.letta/mods/perplexity-search.ts`
+   - `~/.letta/mods/exa-search.ts`
+   - `~/.letta/mods/parallel-search.ts`
+4. Use the matching reference file below.
+5. Confirm the required environment variable and reload step.
+
+## Provider examples
+
+Load only the reference you need:
+
+| Provider | Tool name | Required env var | Reference |
+| --- | --- | --- | --- |
+| Perplexity | `perplexity_search` | `PERPLEXITY_API_KEY` | `references/perplexity.md` |
+| Exa | `exa_search` | `EXA_API_KEY` | `references/exa.md` |
+| Parallel | `parallel_search` | `PARALLEL_API_KEY` | `references/parallel.md` |
+
+If the user asks for all three, install all three files. The tool names are provider-scoped so they can coexist.

--- a/src/skills/builtin/web-search-mods/SKILL.md
+++ b/src/skills/builtin/web-search-mods/SKILL.md
@@ -14,13 +14,16 @@ Use this skill when a local agent needs web search. The implementation path is a
 
 - Current naming is **mod**, not extension. Prefer `~/.letta/mods/`. Legacy `~/.letta/extensions/` is only for backwards compatibility.
 - Do not add provider SDK dependencies. Use `fetch` and standard runtime APIs so the mod works in a stock Letta Code install.
-- Do not hard-code API keys. Read from environment variables:
+- Current mod APIs do not expose `letta.runtime.backend`, `ctx.runtime`, `ctx.cloud`, `ctx.secrets`, or `requiresSecrets`. Do not invent those fields in examples.
+- Do not hard-code API keys. Until mod-owned or local-agent `/secret` support exists, read provider keys from environment variables available to the Letta Code process:
   - `PERPLEXITY_API_KEY`
   - `EXA_API_KEY`
   - `PARALLEL_API_KEY`
+- If the user changes an environment variable, they must restart Letta Code with the variable set. `/reload` reloads mod files, not the parent process environment.
 - Web search sends query text to a third-party provider. Tell the user which provider/env var the mod uses.
+- Use provider-scoped tool names such as `perplexity_search`, `exa_search`, and `parallel_search`. Do not register a generic `web_search` mod until the mod runtime has a supported cloud/local routing and secret API.
 - A search tool is read-only and may be marked `parallelSafe: true`. If the user wants approval before network calls, set `requiresApproval: true`; otherwise use `false` for normal web-search behavior.
-- After writing or editing a mod, tell the user to run `/reload` or restart Letta Code.
+- After writing or editing a mod file, tell the user to run `/reload` or restart Letta Code.
 - If a mod breaks startup, recover with `letta --no-mods` or `LETTA_DISABLE_MODS=1 letta`.
 
 ## Workflow
@@ -32,7 +35,7 @@ Use this skill when a local agent needs web search. The implementation path is a
    - `~/.letta/mods/exa-search.ts`
    - `~/.letta/mods/parallel-search.ts`
 4. Use the matching reference file below.
-5. Confirm the required environment variable and reload step.
+5. Confirm the required environment variable. If the variable was not set before Letta Code started, tell the user to restart Letta Code with it set.
 
 ## Provider examples
 

--- a/src/skills/builtin/web-search-mods/references/exa.md
+++ b/src/skills/builtin/web-search-mods/references/exa.md
@@ -117,7 +117,8 @@ export default function activate(letta) {
       if (!apiKey) {
         return {
           status: "error",
-          content: "EXA_API_KEY is not set. Export it, then run /reload.",
+          content:
+            "EXA_API_KEY is not set in the Letta Code process environment. Restart Letta Code with EXA_API_KEY set.",
         };
       }
 

--- a/src/skills/builtin/web-search-mods/references/exa.md
+++ b/src/skills/builtin/web-search-mods/references/exa.md
@@ -1,0 +1,188 @@
+# Exa web search mod
+
+Create this file at `~/.letta/mods/exa-search.ts`.
+
+It registers `exa_search`, a model-callable tool backed by the Exa Search API. It reads `EXA_API_KEY` from the environment.
+
+```ts
+const EXA_API_URL = "https://api.exa.ai/search";
+
+function stringArg(value, fallback = "") {
+  return typeof value === "string" ? value.trim() : fallback;
+}
+
+function stringArrayArg(value) {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => stringArg(item)).filter(Boolean);
+}
+
+function clampInteger(value, fallback, min, max) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(max, Math.max(min, Math.trunc(parsed)));
+}
+
+function pickEnum(value, allowed, fallback) {
+  return allowed.includes(value) ? value : fallback;
+}
+
+async function readResponseBody(response) {
+  const text = await response.text();
+  if (!text) return "";
+  try {
+    return JSON.stringify(JSON.parse(text), null, 2);
+  } catch {
+    return text;
+  }
+}
+
+function formatResult(result, index) {
+  const title = stringArg(result?.title, "Untitled");
+  const url = stringArg(result?.url);
+  const date = stringArg(result?.publishedDate);
+  const author = stringArg(result?.author);
+  const text = stringArg(result?.text);
+  const highlights = Array.isArray(result?.highlights)
+    ? result.highlights.map((item) => stringArg(item)).filter(Boolean)
+    : [];
+  const summary = stringArg(result?.summary);
+
+  return [
+    `### ${index + 1}. ${title}`,
+    url,
+    date ? `Published: ${date}` : "",
+    author ? `Author: ${author}` : "",
+    summary ? `Summary: ${summary}` : "",
+    highlights.length ? `Highlights:\n${highlights.map((item) => `- ${item}`).join("\n")}` : "",
+    text ? `Text:\n${text.slice(0, 1600)}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export default function activate(letta) {
+  if (!letta.capabilities.tools) return;
+
+  return letta.tools.register({
+    name: "exa_search",
+    description:
+      "Search the live web with Exa and return ranked results with text/highlights. Use for current facts, source discovery, research papers, companies, news, or web pages.",
+    parameters: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "The web-search query.",
+        },
+        type: {
+          type: "string",
+          enum: ["auto", "instant", "fast", "deep-lite", "deep"],
+          description: "Search type. Defaults to auto.",
+        },
+        category: {
+          type: "string",
+          enum: ["company", "research paper", "news", "personal site", "financial report", "people"],
+          description: "Optional result category to focus the search.",
+        },
+        num_results: {
+          type: "number",
+          description: "Number of results to return, 1-10. Defaults to 5.",
+        },
+        include_domains: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional domains to restrict results to.",
+        },
+        exclude_domains: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional domains to exclude from results.",
+        },
+        start_published_date: {
+          type: "string",
+          description: "Optional ISO date/time. Only results published after this date.",
+        },
+        end_published_date: {
+          type: "string",
+          description: "Optional ISO date/time. Only results published before this date.",
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    requiresApproval: false,
+    parallelSafe: true,
+    async run(ctx) {
+      const apiKey = process.env.EXA_API_KEY;
+      if (!apiKey) {
+        return {
+          status: "error",
+          content: "EXA_API_KEY is not set. Export it, then run /reload.",
+        };
+      }
+
+      const query = stringArg(ctx.args.query);
+      if (!query) return { status: "error", content: "query is required" };
+
+      const body = {
+        query,
+        type: pickEnum(
+          ctx.args.type,
+          ["auto", "instant", "fast", "deep-lite", "deep"],
+          "auto",
+        ),
+        numResults: clampInteger(ctx.args.num_results, 5, 1, 10),
+        contents: {
+          text: { maxCharacters: 1600 },
+          highlights: true,
+          summary: { query: "Main relevant facts for the user's question" },
+        },
+        moderation: true,
+      };
+
+      const category = pickEnum(
+        ctx.args.category,
+        ["company", "research paper", "news", "personal site", "financial report", "people"],
+        "",
+      );
+      if (category) body.category = category;
+
+      const includeDomains = stringArrayArg(ctx.args.include_domains);
+      if (includeDomains.length > 0) body.includeDomains = includeDomains;
+
+      const excludeDomains = stringArrayArg(ctx.args.exclude_domains);
+      if (excludeDomains.length > 0) body.excludeDomains = excludeDomains;
+
+      const startPublishedDate = stringArg(ctx.args.start_published_date);
+      if (startPublishedDate) body.startPublishedDate = startPublishedDate;
+
+      const endPublishedDate = stringArg(ctx.args.end_published_date);
+      if (endPublishedDate) body.endPublishedDate = endPublishedDate;
+
+      const response = await fetch(EXA_API_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": apiKey,
+        },
+        body: JSON.stringify(body),
+        signal: ctx.signal,
+      });
+
+      if (!response.ok) {
+        const detail = await readResponseBody(response);
+        return {
+          status: "error",
+          content: `Exa API error ${response.status}: ${detail.slice(0, 2000)}`,
+        };
+      }
+
+      const data = await response.json();
+      const results = Array.isArray(data?.results) ? data.results : [];
+      if (results.length === 0) return "No Exa results.";
+
+      return ["## Exa results", ...results.map(formatResult)].join("\n\n");
+    },
+  });
+}
+```

--- a/src/skills/builtin/web-search-mods/references/parallel.md
+++ b/src/skills/builtin/web-search-mods/references/parallel.md
@@ -1,0 +1,193 @@
+# Parallel web search mod
+
+Create this file at `~/.letta/mods/parallel-search.ts`.
+
+It registers `parallel_search`, a model-callable tool backed by the Parallel Search API. It reads `PARALLEL_API_KEY` from the environment.
+
+```ts
+const PARALLEL_SEARCH_API_URL = "https://api.parallel.ai/v1/search";
+
+function stringArg(value, fallback = "") {
+  return typeof value === "string" ? value.trim() : fallback;
+}
+
+function stringArrayArg(value) {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => stringArg(item)).filter(Boolean);
+}
+
+function clampInteger(value, fallback, min, max) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(max, Math.max(min, Math.trunc(parsed)));
+}
+
+function pickEnum(value, allowed, fallback) {
+  return allowed.includes(value) ? value : fallback;
+}
+
+async function readResponseBody(response) {
+  const text = await response.text();
+  if (!text) return "";
+  try {
+    return JSON.stringify(JSON.parse(text), null, 2);
+  } catch {
+    return text;
+  }
+}
+
+function formatResult(result, index) {
+  const title = stringArg(result?.title, "Untitled");
+  const url = stringArg(result?.url);
+  const publishDate = stringArg(result?.publish_date);
+  const excerpts = Array.isArray(result?.excerpts)
+    ? result.excerpts.map((item) => stringArg(item)).filter(Boolean)
+    : [];
+
+  return [
+    `### ${index + 1}. ${title}`,
+    url,
+    publishDate ? `Published: ${publishDate}` : "",
+    excerpts.length ? excerpts.map((excerpt) => `- ${excerpt}`).join("\n") : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export default function activate(letta) {
+  if (!letta.capabilities.tools) return;
+
+  return letta.tools.register({
+    name: "parallel_search",
+    description:
+      "Search the live web with Parallel and return LLM-optimized excerpts. Use for current facts, specific entities, recent events, or web data that should ground a response.",
+    parameters: {
+      type: "object",
+      properties: {
+        objective: {
+          type: "string",
+          description:
+            "Natural-language research goal. Include the key entity/topic and what you need to learn.",
+        },
+        search_queries: {
+          type: "array",
+          description:
+            "2-3 diverse keyword queries, each 3-6 words. Vary entities, synonyms, and angles. Do not use sentences or site: operators.",
+          items: { type: "string" },
+          minItems: 2,
+          maxItems: 3,
+        },
+        mode: {
+          type: "string",
+          enum: ["basic", "advanced"],
+          description: "Search mode. basic is lower latency; advanced is higher quality. Defaults to advanced.",
+        },
+        max_results: {
+          type: "number",
+          description: "Maximum number of results, 1-10. Defaults to 6.",
+        },
+        max_chars_total: {
+          type: "number",
+          description: "Maximum characters across all excerpts. Defaults to 6000.",
+        },
+        include_domains: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional domains to restrict results to.",
+        },
+        exclude_domains: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional domains to exclude from results.",
+        },
+        after_date: {
+          type: "string",
+          description: "Optional YYYY-MM-DD start date for filtering results.",
+        },
+      },
+      required: ["objective", "search_queries"],
+      additionalProperties: false,
+    },
+    requiresApproval: false,
+    parallelSafe: true,
+    async run(ctx) {
+      const apiKey = process.env.PARALLEL_API_KEY;
+      if (!apiKey) {
+        return {
+          status: "error",
+          content: "PARALLEL_API_KEY is not set. Export it, then run /reload.",
+        };
+      }
+
+      const objective = stringArg(ctx.args.objective);
+      if (!objective) return { status: "error", content: "objective is required" };
+
+      const searchQueries = stringArrayArg(ctx.args.search_queries).slice(0, 3);
+      if (searchQueries.length === 0) {
+        return { status: "error", content: "search_queries must include at least one query" };
+      }
+
+      const sourcePolicy = {};
+      const includeDomains = stringArrayArg(ctx.args.include_domains);
+      if (includeDomains.length > 0) sourcePolicy.include_domains = includeDomains;
+      const excludeDomains = stringArrayArg(ctx.args.exclude_domains);
+      if (excludeDomains.length > 0) sourcePolicy.exclude_domains = excludeDomains;
+      const afterDate = stringArg(ctx.args.after_date);
+      if (afterDate) sourcePolicy.after_date = afterDate;
+
+      const advancedSettings = {
+        max_results: clampInteger(ctx.args.max_results, 6, 1, 10),
+        excerpt_settings: {
+          max_chars_per_result: 1200,
+        },
+      };
+      if (Object.keys(sourcePolicy).length > 0) {
+        advancedSettings.source_policy = sourcePolicy;
+      }
+
+      const body = {
+        objective,
+        search_queries: searchQueries,
+        mode: pickEnum(ctx.args.mode, ["basic", "advanced"], "advanced"),
+        max_chars_total: clampInteger(ctx.args.max_chars_total, 6000, 1000, 12000),
+        advanced_settings: advancedSettings,
+      };
+
+      const response = await fetch(PARALLEL_SEARCH_API_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": apiKey,
+        },
+        body: JSON.stringify(body),
+        signal: ctx.signal,
+      });
+
+      if (!response.ok) {
+        const detail = await readResponseBody(response);
+        return {
+          status: "error",
+          content: `Parallel API error ${response.status}: ${detail.slice(0, 2000)}`,
+        };
+      }
+
+      const data = await response.json();
+      const results = Array.isArray(data?.results) ? data.results : [];
+      if (results.length === 0) return "No Parallel results.";
+
+      const warnings = Array.isArray(data?.warnings)
+        ? data.warnings
+            .map((warning) => stringArg(warning?.message))
+            .filter(Boolean)
+        : [];
+      const warningText = warnings.length
+        ? ["## Warnings", ...warnings.map((warning) => `- ${warning}`)].join("\n")
+        : "";
+
+      return ["## Parallel results", ...results.map(formatResult), warningText]
+        .filter(Boolean)
+        .join("\n\n");
+    },
+  });
+}
+```

--- a/src/skills/builtin/web-search-mods/references/parallel.md
+++ b/src/skills/builtin/web-search-mods/references/parallel.md
@@ -115,7 +115,8 @@ export default function activate(letta) {
       if (!apiKey) {
         return {
           status: "error",
-          content: "PARALLEL_API_KEY is not set. Export it, then run /reload.",
+          content:
+            "PARALLEL_API_KEY is not set in the Letta Code process environment. Restart Letta Code with PARALLEL_API_KEY set.",
         };
       }
 

--- a/src/skills/builtin/web-search-mods/references/perplexity.md
+++ b/src/skills/builtin/web-search-mods/references/perplexity.md
@@ -92,7 +92,8 @@ export default function activate(letta) {
       if (!apiKey) {
         return {
           status: "error",
-          content: "PERPLEXITY_API_KEY is not set. Export it, then run /reload.",
+          content:
+            "PERPLEXITY_API_KEY is not set in the Letta Code process environment. Restart Letta Code with PERPLEXITY_API_KEY set.",
         };
       }
 

--- a/src/skills/builtin/web-search-mods/references/perplexity.md
+++ b/src/skills/builtin/web-search-mods/references/perplexity.md
@@ -1,0 +1,159 @@
+# Perplexity web search mod
+
+Create this file at `~/.letta/mods/perplexity-search.ts`.
+
+It registers `perplexity_search`, a model-callable tool backed by the Perplexity Sonar API. It reads `PERPLEXITY_API_KEY` from the environment.
+
+```ts
+const PERPLEXITY_API_URL = "https://api.perplexity.ai/v1/sonar";
+
+function stringArg(value, fallback = "") {
+  return typeof value === "string" ? value.trim() : fallback;
+}
+
+function clampInteger(value, fallback, min, max) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(max, Math.max(min, Math.trunc(parsed)));
+}
+
+function pickEnum(value, allowed, fallback) {
+  return allowed.includes(value) ? value : fallback;
+}
+
+async function readResponseBody(response) {
+  const text = await response.text();
+  if (!text) return "";
+  try {
+    return JSON.stringify(JSON.parse(text), null, 2);
+  } catch {
+    return text;
+  }
+}
+
+function formatSearchResults(results) {
+  if (!Array.isArray(results) || results.length === 0) return "";
+
+  return [
+    "## Search results",
+    ...results.map((result, index) => {
+      const title = stringArg(result?.title, "Untitled");
+      const url = stringArg(result?.url);
+      const date = stringArg(result?.date) || stringArg(result?.last_updated);
+      const snippet = stringArg(result?.snippet);
+      return [
+        `### ${index + 1}. ${title}`,
+        url,
+        date ? `Date: ${date}` : "",
+        snippet,
+      ]
+        .filter(Boolean)
+        .join("\n");
+    }),
+  ].join("\n\n");
+}
+
+export default function activate(letta) {
+  if (!letta.capabilities.tools) return;
+
+  return letta.tools.register({
+    name: "perplexity_search",
+    description:
+      "Search the live web with Perplexity Sonar and return an answer with citations. Use for current facts, news, and web-grounded research.",
+    parameters: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "The web-search question or research objective.",
+        },
+        search_mode: {
+          type: "string",
+          enum: ["web", "academic", "sec"],
+          description: "Search corpus to use. Defaults to web.",
+        },
+        recency: {
+          type: "string",
+          enum: ["hour", "day", "week", "month", "year"],
+          description: "Optional publication recency filter.",
+        },
+        max_tokens: {
+          type: "number",
+          description: "Maximum answer tokens. Defaults to 1200.",
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    requiresApproval: false,
+    parallelSafe: true,
+    async run(ctx) {
+      const apiKey = process.env.PERPLEXITY_API_KEY;
+      if (!apiKey) {
+        return {
+          status: "error",
+          content: "PERPLEXITY_API_KEY is not set. Export it, then run /reload.",
+        };
+      }
+
+      const query = stringArg(ctx.args.query);
+      if (!query) return { status: "error", content: "query is required" };
+
+      const body = {
+        model: "sonar",
+        messages: [
+          {
+            role: "system",
+            content:
+              "Answer with concise, factual web-grounded information. Include citations when available.",
+          },
+          { role: "user", content: query },
+        ],
+        max_tokens: clampInteger(ctx.args.max_tokens, 1200, 100, 4000),
+        search_mode: pickEnum(ctx.args.search_mode, ["web", "academic", "sec"], "web"),
+        stream: false,
+      };
+
+      const recency = pickEnum(
+        ctx.args.recency,
+        ["hour", "day", "week", "month", "year"],
+        "",
+      );
+      if (recency) body.search_recency_filter = recency;
+
+      const response = await fetch(PERPLEXITY_API_URL, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+        signal: ctx.signal,
+      });
+
+      if (!response.ok) {
+        const detail = await readResponseBody(response);
+        return {
+          status: "error",
+          content: `Perplexity API error ${response.status}: ${detail.slice(0, 2000)}`,
+        };
+      }
+
+      const data = await response.json();
+      const answer = stringArg(data?.choices?.[0]?.message?.content);
+      const citations = Array.isArray(data?.citations) ? data.citations : [];
+      const citationText = citations.length
+        ? [
+            "## Citations",
+            ...citations.map((url, index) => `${index + 1}. ${url}`),
+          ].join("\n")
+        : "";
+      const searchResults = formatSearchResults(data?.search_results);
+
+      return ["## Perplexity answer", answer, citationText, searchResults]
+        .filter(Boolean)
+        .join("\n\n");
+    },
+  });
+}
+```


### PR DESCRIPTION
## Summary
- Add a bundled `web-search-mods` skill with local mod examples for Perplexity, Exa, and Parallel.
- Link the skill from the existing mod-writing guidance and README local-mode section so local agents can discover the path when they need web search.
- Cover the bundled skill references in the existing skill-discovery test.

## Why
Local agents do not get hosted web-search tools automatically. The current extension surface is called mods, and model-callable mod tools are already the right local mechanism. This PR adds copy-pasteable provider examples instead of adding a new first-class built-in search tool or taking a dependency on provider SDKs.

## Behavior
After this change, a user can ask Letta Code for web-search mods and get provider-specific templates for:
- Perplexity via `PERPLEXITY_API_KEY`
- Exa via `EXA_API_KEY`
- Parallel via `PARALLEL_API_KEY`

Each template registers one local tool and uses `fetch`, so the examples stay dependency-free.

## Limits
I did not make live provider calls because provider API keys are not available in this environment. The validation here proves discovery and packaging, not external provider connectivity.

## Test plan
- [x] `bun test ./src/agent/skills-discovery.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)
