### PR TITLE
chore(codeowners): add Kevin to runtime ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 /src/agent/memoryGit.ts @letta-ai/system-prompt-owners
 
 # WebSocket listener and protocol code
-/src/websocket/ @cpacker @4shub @carenthomas
+/src/websocket/ @cpacker @4shub @kl2806 @carenthomas
 
 # Headless mode runtime
 /src/headless.ts @cpacker @4shub @kl2806 @devanshrj @sarahwooders @jnjpng @carenthomas
@@ -15,4 +15,4 @@
 /src/agent/prompts/source_codex.md @kl2806
 
 # TUI/CLI runtime and UI
-/src/cli/ @cpacker @4shub @sarahwooders @jnjpng @carenthomas
+/src/cli/ @cpacker @4shub @kl2806 @sarahwooders @jnjpng @carenthomas


### PR DESCRIPTION
## Summary

- Add @kl2806 to the existing websocket listener/protocol owner group.
- Add @kl2806 to the existing TUI/CLI runtime owner group.

## Why

Kevin already owns adjacent Letta Code runtime areas, but approvals from @kl2806 do not currently satisfy code-owner review on PRs that touch `src/websocket/` or `src/cli/`. This makes runtime/reflection PRs wait on a narrower owner set than intended.

## Validation

- `git diff --check -- .github/CODEOWNERS`
