### PR TITLE
feat: add app-server external tool callbacks

### DIFF
--- a/src/app-server-client.test.ts
+++ b/src/app-server-client.test.ts
@@ -194,6 +194,69 @@ describe("app-server client", () => {
     expect(sent).toEqual(["sync", "abort_message", "input"]);
   });
 
+  test("registers external tools and responds to external tool calls", async () => {
+    const { client, control, stream } = createFakeClient();
+    control.open();
+    stream.open();
+    await client.connect();
+
+    const registerPromise = client.registerExternalTools({
+      scope_id: "council-1",
+      runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+      tools: [
+        {
+          name: "council-write",
+          description: "Write council opinion",
+          parameters: { type: "object", properties: {}, required: [] },
+        },
+      ],
+    });
+
+    expect(JSON.parse(control.sent[0] ?? "{}")).toMatchObject({
+      type: "external_tools_register",
+      request_id: "external-tools-register-1",
+      scope_id: "council-1",
+      tools: [{ name: "council-write" }],
+    });
+
+    control.receive({
+      type: "external_tools_register_response",
+      request_id: "external-tools-register-1",
+      success: true,
+      scope_id: "council-1",
+      tool_names: ["council-write"],
+    });
+    expect((await registerPromise).tool_names).toEqual(["council-write"]);
+
+    client.onExternalToolCall((request) => ({
+      content: [
+        {
+          type: "text",
+          text: `handled:${request.tool_name}:${request.scope_id}`,
+        },
+      ],
+    }));
+
+    control.receive({
+      type: "external_tool_call_request",
+      request_id: "tool-call-1",
+      runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+      scope_id: "council-1",
+      tool_call_id: "call-1",
+      tool_name: "council-write",
+      input: { side: "thesis" },
+    });
+
+    await Promise.resolve();
+    expect(JSON.parse(control.sent[1] ?? "{}")).toEqual({
+      type: "external_tool_call_response",
+      request_id: "tool-call-1",
+      result: {
+        content: [{ type: "text", text: "handled:council-write:council-1" }],
+      },
+    });
+  });
+
   test("runTurn injects client message ids and resolves on stop_reason", async () => {
     const { client, control, stream } = createFakeClient();
     control.open();

--- a/src/app-server-client.ts
+++ b/src/app-server-client.ts
@@ -1,6 +1,10 @@
 import type {
   AbortMessageCommand,
   AbortMessageResponseMessage,
+  ExternalToolCallRequestMessage,
+  ExternalToolCallResult,
+  ExternalToolsRegisterCommand,
+  ExternalToolsRegisterResponseMessage,
   InputCommand,
   LoopStatusUpdateMessage,
   RuntimeScope,
@@ -28,6 +32,10 @@ export type AppServerMessageHandler = (
 
 /** Called synchronously before a protocol command is written to the control socket. */
 export type AppServerSendHandler = (command: WsProtocolCommand) => void;
+
+export type AppServerExternalToolCallHandler = (
+  request: ExternalToolCallRequestMessage,
+) => ExternalToolCallResult | Promise<ExternalToolCallResult>;
 
 export interface AppServerSocketLike {
   readyState: number;
@@ -456,6 +464,57 @@ export class AppServerClient {
           message.type === "abort_message_response",
       },
     );
+  }
+
+  registerExternalTools(
+    command: Omit<ExternalToolsRegisterCommand, "type" | "request_id"> & {
+      request_id?: string;
+    },
+    options: Omit<
+      AppServerRequestOptions<ExternalToolsRegisterResponseMessage>,
+      "predicate"
+    > = {},
+  ): Promise<ExternalToolsRegisterResponseMessage> {
+    return this.request(
+      {
+        type: "external_tools_register",
+        request_id:
+          command.request_id ?? this.nextRequestId("external-tools-register"),
+        ...command,
+      },
+      {
+        ...options,
+        predicate: (message): message is ExternalToolsRegisterResponseMessage =>
+          message.type === "external_tools_register_response",
+      },
+    );
+  }
+
+  onExternalToolCall(handler: AppServerExternalToolCallHandler): () => void {
+    return this.onMessage((message, channel) => {
+      if (
+        channel !== "control" ||
+        message.type !== "external_tool_call_request"
+      ) {
+        return;
+      }
+
+      void Promise.resolve(handler(message))
+        .then((result) => {
+          this.send({
+            type: "external_tool_call_response",
+            request_id: message.request_id,
+            result,
+          });
+        })
+        .catch((error) => {
+          this.send({
+            type: "external_tool_call_response",
+            request_id: message.request_id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+    });
   }
 
   input(command: Omit<InputCommand, "type">): void {

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -327,16 +327,28 @@ function filterWorktreeTools(toolNames: ToolName[]): ToolName[] {
 function filterExternalToolsByClientAllowlist(
   externalTools: Map<string, ExternalToolDefinition>,
   clientToolAllowlist?: string[],
+  externalToolScopeIds?: string[],
 ): Map<string, ExternalToolDefinition> {
+  const scopeSet =
+    externalToolScopeIds === undefined
+      ? undefined
+      : new Set(externalToolScopeIds);
+  const scopeFiltered = Array.from(externalTools.values()).filter((tool) => {
+    if (tool.scopeId === undefined) {
+      return true;
+    }
+    return scopeSet?.has(tool.scopeId) ?? false;
+  });
+
   if (clientToolAllowlist === undefined) {
-    return new Map(externalTools);
+    return new Map(scopeFiltered.map((tool) => [tool.name, tool]));
   }
 
   const allowSet = new Set(clientToolAllowlist);
   return new Map(
-    Array.from(externalTools.entries()).filter(([internalName, tool]) =>
-      matchesClientToolAllowlistEntry(allowSet, tool.name, internalName),
-    ),
+    scopeFiltered
+      .filter((tool) => matchesClientToolAllowlistEntry(allowSet, tool.name))
+      .map((tool) => [tool.name, tool]),
   );
 }
 
@@ -821,6 +833,14 @@ export interface ExternalToolDefinition {
   label?: string;
   description: string;
   parameters: Record<string, unknown>; // JSON Schema
+  /** Hidden registration scope used by app-server dynamic external tools. */
+  scopeId?: string;
+  /** Optional runtime metadata for app-server callbacks and diagnostics. */
+  runtime?: { agent_id: string; conversation_id: string };
+}
+
+export interface ExternalToolExecutionContext {
+  tool: ExternalToolDefinition;
 }
 
 /**
@@ -830,6 +850,7 @@ export type ExternalToolExecutor = (
   toolCallId: string,
   toolName: string,
   input: Record<string, unknown>,
+  context?: ExternalToolExecutionContext,
 ) => Promise<{
   content: Array<{
     type: string;
@@ -857,13 +878,35 @@ function getExternalToolsRegistry(): Map<string, ExternalToolDefinition> {
   return global[EXTERNAL_TOOLS_KEY];
 }
 
+function getExternalToolRegistryKey(tool: ExternalToolDefinition): string {
+  return tool.scopeId === undefined
+    ? tool.name
+    : `scope:${tool.scopeId}:tool:${tool.name}`;
+}
+
 /**
  * Register external tools from SDK
  */
 export function registerExternalTools(tools: ExternalToolDefinition[]): void {
   const registry = getExternalToolsRegistry();
   for (const tool of tools) {
-    registry.set(tool.name, tool);
+    registry.set(getExternalToolRegistryKey(tool), tool);
+  }
+}
+
+export function unregisterExternalToolsForScope(scopeId: string): void {
+  const registry = getExternalToolsRegistry();
+  for (const [key, tool] of registry.entries()) {
+    if (tool.scopeId === scopeId) {
+      registry.delete(key);
+    }
+  }
+}
+
+export function unregisterExternalTools(tools: ExternalToolDefinition[]): void {
+  const registry = getExternalToolsRegistry();
+  for (const tool of tools) {
+    registry.delete(getExternalToolRegistryKey(tool));
   }
 }
 
@@ -906,11 +949,13 @@ export function getExternalToolDefinition(
  * Get all external tools as ClientTool format
  */
 export function getExternalToolsAsClientTools(): ClientTool[] {
-  return Array.from(getExternalToolsRegistry().values()).map((tool) => ({
-    name: tool.name,
-    description: tool.description,
-    parameters: tool.parameters,
-  }));
+  return Array.from(getExternalToolsRegistry().values())
+    .filter((tool) => tool.scopeId === undefined)
+    .map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.parameters,
+    }));
 }
 
 /**
@@ -921,6 +966,7 @@ export async function executeExternalTool(
   toolName: string,
   input: Record<string, unknown>,
   executorOverride?: ExternalToolExecutor,
+  context?: ExternalToolExecutionContext,
 ): Promise<ToolExecutionResult> {
   const executor = executorOverride ?? getExternalToolExecutor();
   if (!executor) {
@@ -931,7 +977,7 @@ export async function executeExternalTool(
   }
 
   try {
-    const result = await executor(toolCallId, toolName, input);
+    const result = await executor(toolCallId, toolName, input, context);
 
     // Convert external tool result to ToolExecutionResult format
     const textContent = result.content
@@ -1026,6 +1072,7 @@ function capturePreparedToolExecutionContext(
   },
   options?: {
     clientToolAllowlist?: string[];
+    externalToolScopeIds?: string[];
     workingDirectory?: string;
     permissionModeState?: PermissionModeState;
     modEvents?: ModEvents;
@@ -1046,6 +1093,7 @@ function capturePreparedToolExecutionContext(
     externalTools: filterExternalToolsByClientAllowlist(
       snapshot.externalTools,
       options?.clientToolAllowlist,
+      options?.externalToolScopeIds,
     ),
     externalExecutor: snapshot.externalExecutor,
     modEvents: options?.modEvents ?? snapshot.modEvents,
@@ -1130,6 +1178,7 @@ export async function prepareToolExecutionContextForSpecificTools(
   toolNames: string[],
   options?: {
     clientToolAllowlist?: string[];
+    externalToolScopeIds?: string[];
     workingDirectory?: string;
     permissionModeState?: PermissionModeState;
     channelToolScope?: MessageChannelToolDiscoveryScope | null;
@@ -1161,6 +1210,7 @@ export async function prepareToolExecutionContextForModel(
     exclude?: ToolName[];
     include?: ToolName[];
     clientToolAllowlist?: string[];
+    externalToolScopeIds?: string[];
     workingDirectory?: string;
     permissionModeState?: PermissionModeState;
     channelToolScope?: MessageChannelToolDiscoveryScope | null;
@@ -2344,6 +2394,13 @@ export async function executeTool(
       name,
       eventArgs as Record<string, unknown>,
       activeExternalExecutor,
+      {
+        tool: activeExternalTools.get(name) ?? {
+          name,
+          description: "",
+          parameters: {},
+        },
+      },
     );
   }
 

--- a/src/tools/tool-execution-context.test.ts
+++ b/src/tools/tool-execution-context.test.ts
@@ -52,6 +52,7 @@ import {
   prepareToolExecutionContextForSpecificTools,
   refreshDynamicChannelToolsInLoadedRegistry,
   registerExternalTools,
+  setExternalToolExecutor,
 } from "@/tools/manager";
 import {
   prepareToolExecutionContextForScope,
@@ -407,6 +408,71 @@ describe("tool execution context snapshot", () => {
 
     expect(prepared.loadedToolNames).toEqual([]);
     expect(prepared.clientTools).toEqual([]);
+  });
+
+  test("scoped external tools stay hidden unless their scope is selected", async () => {
+    registerExternalTools([
+      {
+        name: "RemoteFoo",
+        description: "Unscoped external tool",
+        parameters: { type: "object", properties: {}, required: [] },
+      },
+      {
+        name: "CouncilWrite",
+        description: "Council tool for scope a",
+        parameters: { type: "object", properties: {}, required: [] },
+        scopeId: "council-a",
+      },
+      {
+        name: "CouncilWrite",
+        description: "Council tool for scope b",
+        parameters: { type: "object", properties: {}, required: [] },
+        scopeId: "council-b",
+      },
+    ]);
+
+    const withoutScope = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      { clientToolAllowlist: ["RemoteFoo", "CouncilWrite"] },
+    );
+    expect(withoutScope.clientTools.map((tool) => tool.name)).toEqual([
+      "RemoteFoo",
+    ]);
+
+    const withScope = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      {
+        clientToolAllowlist: ["CouncilWrite"],
+        externalToolScopeIds: ["council-b"],
+      },
+    );
+    expect(withScope.clientTools).toEqual([
+      {
+        name: "CouncilWrite",
+        description: "Council tool for scope b",
+        parameters: { type: "object", properties: {}, required: [] },
+      },
+    ]);
+
+    setExternalToolExecutor(
+      async (_toolCallId, _toolName, _input, context) => ({
+        content: [
+          {
+            type: "text",
+            text: `scope:${context?.tool.scopeId ?? "none"}`,
+          },
+        ],
+        isError: false,
+      }),
+    );
+
+    const result = await executeTool(
+      "CouncilWrite",
+      {},
+      { toolContextId: withScope.contextId },
+    );
+    expect(result.status).toBe("success");
+    expect(asText(result.toolReturn)).toBe("scope:council-b");
   });
 
   test("prepares and executes mod tools from turn snapshots", async () => {

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -193,6 +193,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
   toolsetPreference: ToolsetPreference;
   exclude?: ToolName[];
   clientToolAllowlist?: string[];
+  externalToolScopeIds?: string[];
   workingDirectory?: string;
   permissionModeState?: PermissionModeState;
   channelToolScope?: MessageChannelToolDiscoveryScope | null;
@@ -205,6 +206,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
     toolsetPreference,
     exclude,
     clientToolAllowlist,
+    externalToolScopeIds,
     workingDirectory,
     permissionModeState,
     channelToolScope,
@@ -231,6 +233,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
           ? getGoalToolNamesForToolset(derivedToolset)
           : undefined,
         clientToolAllowlist,
+        externalToolScopeIds,
         workingDirectory,
         permissionModeState,
         channelToolScope,
@@ -262,6 +265,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
     ),
     {
       clientToolAllowlist,
+      externalToolScopeIds,
       workingDirectory,
       permissionModeState,
       channelToolScope,
@@ -430,6 +434,7 @@ export async function prepareToolExecutionContextForScope(params: {
   cachedEffectiveModel?: string | null;
   exclude?: ToolName[];
   clientToolAllowlist?: string[];
+  externalToolScopeIds?: string[];
   workingDirectory?: string;
   permissionModeState?: PermissionModeState;
   cachedAgent?: AgentState | null;
@@ -443,6 +448,7 @@ export async function prepareToolExecutionContextForScope(params: {
     cachedEffectiveModel,
     exclude,
     clientToolAllowlist,
+    externalToolScopeIds,
     workingDirectory,
     permissionModeState,
     cachedAgent,
@@ -505,6 +511,7 @@ export async function prepareToolExecutionContextForScope(params: {
     toolsetPreference,
     exclude,
     clientToolAllowlist,
+    externalToolScopeIds,
     workingDirectory,
     permissionModeState,
     modEvents,

--- a/src/types/app-server-protocol.test.ts
+++ b/src/types/app-server-protocol.test.ts
@@ -113,6 +113,19 @@ describe("app-server protocol export", () => {
         conversation: null,
         created: { agent: false, conversation: false },
       },
+      {
+        type: "external_tools_register_response",
+        request_id: "req",
+        success: true,
+        tool_names: ["council-write"],
+      },
+      {
+        type: "external_tool_call_request",
+        request_id: "req",
+        tool_call_id: "call-1",
+        tool_name: "council-write",
+        input: {},
+      },
     ] satisfies WsProtocolMessage[];
 
     expect(messages.map((message) => message.type)).toEqual([
@@ -134,6 +147,8 @@ describe("app-server protocol export", () => {
       "conversation_messages_list_response",
       "conversation_compact_response",
       "runtime_start_response",
+      "external_tools_register_response",
+      "external_tool_call_request",
     ]);
   });
 });

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -700,6 +700,12 @@ export interface InputCreateMessagePayload {
    * client tools for this turn.
    */
   client_tool_allowlist?: string[];
+  /**
+   * Optional scoped external-tool registrations to expose for this turn.
+   * Scoped registrations stay hidden unless selected here; unscoped external
+   * tools preserve the existing SDK behavior and remain available normally.
+   */
+  external_tool_scope_ids?: string[];
 }
 
 export type InputApprovalResponsePayload = {
@@ -795,6 +801,62 @@ export interface RuntimeStartCommand {
   recover_approvals?: boolean;
   /** Force the initial state replay to include update_device_status. Defaults to true. */
   force_device_status?: boolean;
+}
+
+export interface ExternalToolDefinitionPayload {
+  name: string;
+  label?: string;
+  description: string;
+  parameters: Record<string, unknown>;
+}
+
+export interface ExternalToolsRegisterCommand {
+  type: "external_tools_register";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  /** Hidden controller-defined scope used to select these tools on input turns. */
+  scope_id?: string;
+  /** Optional runtime this registration is intended for. Used for diagnostics/callbacks. */
+  runtime?: RuntimeScope;
+  tools: ExternalToolDefinitionPayload[];
+}
+
+export interface ExternalToolsRegisterResponseMessage {
+  type: "external_tools_register_response";
+  request_id: string;
+  success: boolean;
+  scope_id?: string;
+  tool_names: string[];
+  error?: string;
+}
+
+export interface ExternalToolCallRequestMessage {
+  type: "external_tool_call_request";
+  request_id: string;
+  runtime?: RuntimeScope;
+  scope_id?: string;
+  tool_call_id: string;
+  tool_name: string;
+  input: Record<string, unknown>;
+}
+
+export interface ExternalToolCallResultContent {
+  type: string;
+  text?: string;
+  data?: string;
+  mimeType?: string;
+}
+
+export interface ExternalToolCallResult {
+  content: ExternalToolCallResultContent[];
+  is_error?: boolean;
+}
+
+export interface ExternalToolCallResponseCommand {
+  type: "external_tool_call_response";
+  request_id: string;
+  result?: ExternalToolCallResult;
+  error?: string;
 }
 
 export interface TerminalSpawnCommand {
@@ -2600,6 +2662,8 @@ export type WsProtocolCommand =
   | AbortMessageCommand
   | SyncCommand
   | RuntimeStartCommand
+  | ExternalToolsRegisterCommand
+  | ExternalToolCallResponseCommand
   | TerminalSpawnCommand
   | TerminalInputCommand
   | TerminalResizeCommand
@@ -2750,6 +2814,8 @@ export type WsProtocolMessage =
   | ConversationMessagesListResponseMessage
   | ConversationCompactResponseMessage
   | RuntimeStartResponseMessage
+  | ExternalToolsRegisterResponseMessage
+  | ExternalToolCallRequestMessage
   | GetExperimentsResponseMessage
   | SetExperimentResponseMessage
   | ListConversationPinsResponseMessage

--- a/src/websocket/app-server.ts
+++ b/src/websocket/app-server.ts
@@ -6,6 +6,7 @@ import WebSocket, { WebSocketServer } from "ws";
 import { settingsManager } from "@/settings-manager";
 import { getListenerTelemetrySurface, telemetry } from "@/telemetry";
 import { loadTools } from "@/tools/manager";
+import { installExternalToolBridge } from "@/websocket/listener/external-tools";
 import {
   attachOpenListenerSocket,
   createRuntime,
@@ -203,6 +204,7 @@ async function startControlSession(params: {
   runtime.onWsEvent = undefined;
   runtime.connectionId = `app-server-${crypto.randomUUID()}`;
   runtime.connectionName = params.connectionName;
+  installExternalToolBridge(runtime);
   setActiveRuntime(runtime);
   telemetry.setSurface(getListenerTelemetrySurface());
   telemetry.init();

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -842,6 +842,7 @@ describe("listen-client parseServerMessage", () => {
             kind: "create_message",
             messages: [],
             client_tool_allowlist: ["Read", "Grep"],
+            external_tool_scope_ids: ["council-1"],
           },
         }),
       ),
@@ -858,6 +859,7 @@ describe("listen-client parseServerMessage", () => {
     expect(msg?.type).toBe("input");
     if (msg?.type === "input" && msg.payload.kind === "create_message") {
       expect(msg.payload.client_tool_allowlist).toEqual(["Read", "Grep"]);
+      expect(msg.payload.external_tool_scope_ids).toEqual(["council-1"]);
     }
     expect(changeDeviceState?.type).toBe("change_device_state");
   });
@@ -881,6 +883,30 @@ describe("listen-client parseServerMessage", () => {
     expect(parsed?.type).toBe("__invalid_input");
     if (parsed?.type === "__invalid_input") {
       expect(parsed.reason).toContain("client_tool_allowlist must be string[]");
+    }
+  });
+
+  test("rejects input create_message with invalid external tool scope ids", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "input",
+          runtime: { agent_id: "agent-1", conversation_id: "default" },
+          payload: {
+            kind: "create_message",
+            messages: [],
+            external_tool_scope_ids: ["scope-1", 42],
+          },
+        }),
+      ),
+    );
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.type).toBe("__invalid_input");
+    if (parsed?.type === "__invalid_input") {
+      expect(parsed.reason).toContain(
+        "external_tool_scope_ids must be string[]",
+      );
     }
   });
 

--- a/src/websocket/listener/external-tools.test.ts
+++ b/src/websocket/listener/external-tools.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { clearExternalTools, executeExternalTool } from "@/tools/manager";
+import {
+  handleExternalToolCallResponseCommand,
+  handleExternalToolsRegisterCommand,
+  installExternalToolBridge,
+} from "@/websocket/listener/external-tools";
+import type { ListenerRuntime } from "@/websocket/listener/types";
+
+class FakeSocket {
+  readyState = 1;
+  readonly sent: unknown[] = [];
+
+  send(data: string): void {
+    this.sent.push(JSON.parse(data));
+  }
+}
+
+function createRuntime(socket: FakeSocket): ListenerRuntime {
+  return {
+    socket,
+    intentionallyClosed: false,
+    pendingExternalToolCalls: new Map(),
+  } as unknown as ListenerRuntime;
+}
+
+describe("app-server external tool bridge", () => {
+  afterEach(() => {
+    clearExternalTools();
+  });
+
+  test("registers scoped tools and acknowledges registration", () => {
+    const socket = new FakeSocket();
+    const runtime = createRuntime(socket);
+    handleExternalToolsRegisterCommand(
+      runtime,
+      {
+        type: "external_tools_register",
+        request_id: "register-1",
+        scope_id: "council-1",
+        runtime: { agent_id: "agent-1", conversation_id: "default" },
+        tools: [
+          {
+            name: "council-write",
+            description: "Write council opinion",
+            parameters: { type: "object", properties: {}, required: [] },
+          },
+        ],
+      },
+      socket as never,
+    );
+
+    expect(socket.sent).toEqual([
+      {
+        type: "external_tools_register_response",
+        request_id: "register-1",
+        success: true,
+        scope_id: "council-1",
+        tool_names: ["council-write"],
+      },
+    ]);
+  });
+
+  test("executes external tools through request/response frames", async () => {
+    const socket = new FakeSocket();
+    const runtime = createRuntime(socket);
+    installExternalToolBridge(runtime);
+
+    const resultPromise = executeExternalTool(
+      "tool-call-1",
+      "council-write",
+      { side: "thesis" },
+      undefined,
+      {
+        tool: {
+          name: "council-write",
+          description: "Write council opinion",
+          parameters: { type: "object", properties: {}, required: [] },
+          scopeId: "council-1",
+          runtime: { agent_id: "agent-1", conversation_id: "default" },
+        },
+      },
+    );
+
+    expect(socket.sent).toEqual([
+      {
+        type: "external_tool_call_request",
+        request_id: expect.stringMatching(/^external-tool-/),
+        runtime: { agent_id: "agent-1", conversation_id: "default" },
+        scope_id: "council-1",
+        tool_call_id: "tool-call-1",
+        tool_name: "council-write",
+        input: { side: "thesis" },
+      },
+    ]);
+
+    const request = socket.sent[0] as { request_id: string };
+    expect(
+      handleExternalToolCallResponseCommand(runtime, {
+        type: "external_tool_call_response",
+        request_id: request.request_id,
+        result: { content: [{ type: "text", text: "ok" }] },
+      }),
+    ).toBe(true);
+
+    await expect(resultPromise).resolves.toEqual({
+      toolReturn: "ok",
+      status: "success",
+    });
+  });
+});

--- a/src/websocket/listener/external-tools.ts
+++ b/src/websocket/listener/external-tools.ts
@@ -1,0 +1,186 @@
+import type WebSocket from "ws";
+import {
+  type ExternalToolDefinition,
+  registerExternalTools,
+  setExternalToolExecutor,
+  unregisterExternalTools,
+  unregisterExternalToolsForScope,
+} from "@/tools/manager";
+import type {
+  ExternalToolCallRequestMessage,
+  ExternalToolCallResponseCommand,
+  ExternalToolDefinitionPayload,
+  ExternalToolsRegisterCommand,
+  ExternalToolsRegisterResponseMessage,
+} from "@/types/protocol_v2";
+import type { ListenerRuntime } from "@/websocket/listener/types";
+
+const EXTERNAL_TOOL_CALL_TIMEOUT_MS = 5 * 60 * 1000;
+const WEBSOCKET_OPEN = 1;
+const registeredToolsByRuntime = new WeakMap<
+  ListenerRuntime,
+  ExternalToolDefinition[]
+>();
+
+function isSocketOpen(socket: WebSocket | null): socket is WebSocket {
+  return socket?.readyState === WEBSOCKET_OPEN;
+}
+
+function getPendingExternalToolCalls(runtime: ListenerRuntime) {
+  runtime.pendingExternalToolCalls ??= new Map();
+  return runtime.pendingExternalToolCalls;
+}
+
+function toExternalToolDefinition(
+  tool: ExternalToolDefinitionPayload,
+  command: ExternalToolsRegisterCommand,
+): ExternalToolDefinition {
+  return {
+    name: tool.name,
+    ...(tool.label !== undefined ? { label: tool.label } : {}),
+    description: tool.description,
+    parameters: tool.parameters,
+    ...(command.scope_id !== undefined ? { scopeId: command.scope_id } : {}),
+    ...(command.runtime !== undefined ? { runtime: command.runtime } : {}),
+  };
+}
+
+function sendJson(socket: WebSocket, payload: unknown): void {
+  socket.send(JSON.stringify(payload));
+}
+
+export function installExternalToolBridge(runtime: ListenerRuntime): void {
+  setExternalToolExecutor(async (toolCallId, toolName, input, context) => {
+    const socket = runtime.socket;
+    if (!isSocketOpen(socket) || runtime.intentionallyClosed) {
+      throw new Error("External tool controller is not connected");
+    }
+
+    const requestId = `external-tool-${crypto.randomUUID()}`;
+    const request: ExternalToolCallRequestMessage = {
+      type: "external_tool_call_request",
+      request_id: requestId,
+      ...(context?.tool.runtime !== undefined
+        ? { runtime: context.tool.runtime }
+        : {}),
+      ...(context?.tool.scopeId !== undefined
+        ? { scope_id: context.tool.scopeId }
+        : {}),
+      tool_call_id: toolCallId,
+      tool_name: toolName,
+      input,
+    };
+
+    const result = await new Promise<{
+      content: Array<{
+        type: string;
+        text?: string;
+        data?: string;
+        mimeType?: string;
+      }>;
+      isError: boolean;
+    }>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        getPendingExternalToolCalls(runtime).delete(requestId);
+        reject(new Error(`External tool call timed out: ${toolName}`));
+      }, EXTERNAL_TOOL_CALL_TIMEOUT_MS);
+
+      getPendingExternalToolCalls(runtime).set(requestId, {
+        resolve: (response) => {
+          resolve({
+            content: response.content,
+            isError: response.is_error === true,
+          });
+        },
+        reject,
+        timeout,
+      });
+
+      try {
+        sendJson(socket, request);
+      } catch (error) {
+        clearTimeout(timeout);
+        getPendingExternalToolCalls(runtime).delete(requestId);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+
+    return result;
+  });
+}
+
+export function handleExternalToolsRegisterCommand(
+  runtime: ListenerRuntime,
+  command: ExternalToolsRegisterCommand,
+  socket: WebSocket,
+): void {
+  const tools = command.tools.map((tool) =>
+    toExternalToolDefinition(tool, command),
+  );
+  if (command.scope_id !== undefined) {
+    unregisterExternalToolsForScope(command.scope_id);
+  }
+  registerExternalTools(tools);
+  const previousTools = registeredToolsByRuntime.get(runtime) ?? [];
+  const nextTools =
+    command.scope_id === undefined
+      ? [...previousTools, ...tools]
+      : [
+          ...previousTools.filter((tool) => tool.scopeId !== command.scope_id),
+          ...tools,
+        ];
+  registeredToolsByRuntime.set(runtime, nextTools);
+
+  const response: ExternalToolsRegisterResponseMessage = {
+    type: "external_tools_register_response",
+    request_id: command.request_id,
+    success: true,
+    ...(command.scope_id !== undefined ? { scope_id: command.scope_id } : {}),
+    tool_names: tools.map((tool) => tool.name),
+  };
+  sendJson(socket, response);
+}
+
+export function handleExternalToolCallResponseCommand(
+  runtime: ListenerRuntime,
+  command: ExternalToolCallResponseCommand,
+): boolean {
+  const pending = getPendingExternalToolCalls(runtime).get(command.request_id);
+  if (!pending) {
+    return false;
+  }
+
+  clearTimeout(pending.timeout);
+  getPendingExternalToolCalls(runtime).delete(command.request_id);
+
+  if (command.error !== undefined) {
+    pending.reject(new Error(command.error));
+    return true;
+  }
+
+  if (command.result === undefined) {
+    pending.reject(new Error("External tool response missing result"));
+    return true;
+  }
+
+  pending.resolve(command.result);
+  return true;
+}
+
+export function rejectPendingExternalToolCalls(
+  runtime: ListenerRuntime,
+  reason: string,
+): void {
+  const pendingExternalToolCalls = getPendingExternalToolCalls(runtime);
+  for (const [requestId, pending] of pendingExternalToolCalls) {
+    clearTimeout(pending.timeout);
+    pendingExternalToolCalls.delete(requestId);
+    pending.reject(new Error(reason));
+  }
+
+  const registeredTools = registeredToolsByRuntime.get(runtime);
+  if (registeredTools) {
+    unregisterExternalTools(registeredTools);
+    registeredToolsByRuntime.delete(runtime);
+  }
+}

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -55,6 +55,7 @@ import {
   getOrCreateScopedRuntime,
 } from "./conversation-runtime";
 import { loadPersistedCwdMap } from "./cwd";
+import { rejectPendingExternalToolCalls } from "./external-tools";
 import { createFileCommandSession } from "./file-commands";
 import { createListenerMessageHandler } from "./message-router";
 import {
@@ -782,6 +783,7 @@ export function createRuntime(): ListenerRuntime {
     connectionName: null,
     conversationRuntimes: new Map(),
     approvalRuntimeKeyByRequestId: new Map(),
+    pendingExternalToolCalls: new Map(),
     memfsSyncedAgents: new Map(),
     secretsHydrationByAgent: new Map(),
     secretsHydrationFreshnessByAgent: new Map(),
@@ -812,6 +814,7 @@ export function stopRuntime(
   }
   runtime.conversationRuntimes.clear();
   runtime.approvalRuntimeKeyByRequestId.clear();
+  rejectPendingExternalToolCalls(runtime, "Listener runtime stopped");
   clearListenerWarmState(runtime);
   runtime.reminderStateByConversation.clear();
   runtime.contextTrackerByConversation.clear();

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -35,6 +35,10 @@ import { handleSecretsCommand } from "./commands/secrets";
 import { handleSettingsProtocolCommand } from "./commands/settings";
 import { handleSkillAgentProtocolCommand } from "./commands/skills-agents";
 import {
+  handleExternalToolCallResponseCommand,
+  handleExternalToolsRegisterCommand,
+} from "./external-tools";
+import {
   isExecuteCommandCommand,
   parseServerLifecycleMessage,
   parseServerMessage,
@@ -243,6 +247,16 @@ export function createListenerMessageHandler(
         return;
       }
 
+      if (parsed.type === "external_tools_register") {
+        handleExternalToolsRegisterCommand(runtime, parsed, socket);
+        return;
+      }
+
+      if (parsed.type === "external_tool_call_response") {
+        handleExternalToolCallResponseCommand(runtime, parsed);
+        return;
+      }
+
       if (parsed.type === "sync") {
         console.log(
           `[Listen V2] Received sync command for runtime=${parsed.runtime.agent_id}/${parsed.runtime.conversation_id}`,
@@ -348,6 +362,7 @@ export function createListenerMessageHandler(
           agentId: parsed.runtime.agent_id,
           conversationId: parsed.runtime.conversation_id,
           clientToolAllowlist: inputPayload.client_tool_allowlist,
+          externalToolScopeIds: inputPayload.external_tool_scope_ids,
           messages: inputPayload.messages,
         };
         const hasApprovalPayload = incoming.messages.some(

--- a/src/websocket/listener/protocol-inbound.test.ts
+++ b/src/websocket/listener/protocol-inbound.test.ts
@@ -20,6 +20,59 @@ describe("app-server protocol hard cut", () => {
   });
 });
 
+describe("app-server external tool protocol", () => {
+  test("accepts external tool registration and call responses", () => {
+    const registration = {
+      type: "external_tools_register" as const,
+      request_id: "register-1",
+      scope_id: "council-1",
+      runtime: { agent_id: "agent-1", conversation_id: "default" },
+      tools: [
+        {
+          name: "council-write",
+          label: "Council Write",
+          description: "Write council opinion",
+          parameters: { type: "object", properties: {}, required: [] },
+        },
+      ],
+    };
+    const response = {
+      type: "external_tool_call_response" as const,
+      request_id: "tool-call-1",
+      result: {
+        content: [{ type: "text", text: "ok" }],
+        is_error: false,
+      },
+    };
+
+    expect(
+      parseServerMessage(Buffer.from(JSON.stringify(registration))),
+    ).toEqual(registration);
+    expect(parseServerMessage(Buffer.from(JSON.stringify(response)))).toEqual(
+      response,
+    );
+  });
+
+  test("rejects malformed external tool registration and call responses", () => {
+    const invalidRegistration = {
+      type: "external_tools_register",
+      request_id: "register-1",
+      tools: [{ name: "missing-description", parameters: {} }],
+    };
+    const invalidResponse = {
+      type: "external_tool_call_response",
+      request_id: "tool-call-1",
+    };
+
+    expect(
+      parseServerMessage(Buffer.from(JSON.stringify(invalidRegistration))),
+    ).toBeNull();
+    expect(
+      parseServerMessage(Buffer.from(JSON.stringify(invalidResponse))),
+    ).toBeNull();
+  });
+});
+
 describe("agent/conversation management protocol-inbound validators", () => {
   test.each([
     {

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -54,6 +54,8 @@ import type {
   EditFileCommand,
   EnableMemfsCommand,
   ExecuteCommandCommand,
+  ExternalToolCallResponseCommand,
+  ExternalToolsRegisterCommand,
   FileOpsCommand,
   GetCwdMapCommand,
   GetExperimentsCommand,
@@ -167,6 +169,7 @@ function isInputCommand(value: unknown): value is InputCommand {
     kind?: unknown;
     messages?: unknown;
     client_tool_allowlist?: unknown;
+    external_tool_scope_ids?: unknown;
     request_id?: unknown;
     decision?: unknown;
     error?: unknown;
@@ -175,7 +178,9 @@ function isInputCommand(value: unknown): value is InputCommand {
     return (
       Array.isArray(payload.messages) &&
       (payload.client_tool_allowlist === undefined ||
-        isStringArray(payload.client_tool_allowlist))
+        isStringArray(payload.client_tool_allowlist)) &&
+      (payload.external_tool_scope_ids === undefined ||
+        isStringArray(payload.external_tool_scope_ids))
     );
   }
   if (payload.kind === "approval_response") {
@@ -209,6 +214,7 @@ function getInvalidInputReason(value: unknown): {
     kind?: unknown;
     messages?: unknown;
     client_tool_allowlist?: unknown;
+    external_tool_scope_ids?: unknown;
     request_id?: unknown;
     decision?: unknown;
     error?: unknown;
@@ -229,6 +235,16 @@ function getInvalidInputReason(value: unknown): {
         runtime: candidate.runtime,
         reason:
           "Protocol violation: input.payload.client_tool_allowlist must be string[]",
+      };
+    }
+    if (
+      payload.external_tool_scope_ids !== undefined &&
+      !isStringArray(payload.external_tool_scope_ids)
+    ) {
+      return {
+        runtime: candidate.runtime,
+        reason:
+          "Protocol violation: input.payload.external_tool_scope_ids must be string[]",
       };
     }
     return null;
@@ -403,6 +419,61 @@ export function isRuntimeStartCommand(
       typeof c.recover_approvals === "boolean") &&
     (c.force_device_status === undefined ||
       typeof c.force_device_status === "boolean")
+  );
+}
+
+function isExternalToolDefinitionPayload(value: unknown): boolean {
+  if (!isObjectRecord(value)) return false;
+  return (
+    typeof value.name === "string" &&
+    value.name.length > 0 &&
+    (value.label === undefined || typeof value.label === "string") &&
+    typeof value.description === "string" &&
+    isObjectRecord(value.parameters)
+  );
+}
+
+export function isExternalToolsRegisterCommand(
+  value: unknown,
+): value is ExternalToolsRegisterCommand {
+  if (!isObjectRecord(value)) return false;
+  return (
+    value.type === "external_tools_register" &&
+    typeof value.request_id === "string" &&
+    (value.scope_id === undefined || typeof value.scope_id === "string") &&
+    (value.runtime === undefined || isRuntimeScope(value.runtime)) &&
+    Array.isArray(value.tools) &&
+    value.tools.every(isExternalToolDefinitionPayload)
+  );
+}
+
+function isExternalToolCallResult(value: unknown): boolean {
+  if (!isObjectRecord(value) || !Array.isArray(value.content)) {
+    return false;
+  }
+  return (
+    value.content.every(
+      (entry) =>
+        isObjectRecord(entry) &&
+        typeof entry.type === "string" &&
+        (entry.text === undefined || typeof entry.text === "string") &&
+        (entry.data === undefined || typeof entry.data === "string") &&
+        (entry.mimeType === undefined || typeof entry.mimeType === "string"),
+    ) &&
+    (value.is_error === undefined || typeof value.is_error === "boolean")
+  );
+}
+
+export function isExternalToolCallResponseCommand(
+  value: unknown,
+): value is ExternalToolCallResponseCommand {
+  if (!isObjectRecord(value)) return false;
+  return (
+    value.type === "external_tool_call_response" &&
+    typeof value.request_id === "string" &&
+    (value.result === undefined || isExternalToolCallResult(value.result)) &&
+    (value.error === undefined || typeof value.error === "string") &&
+    (value.result !== undefined || value.error !== undefined)
   );
 }
 
@@ -2075,6 +2146,8 @@ export function parseServerMessage(
       isAbortMessageCommand(parsed) ||
       isSyncCommand(parsed) ||
       isRuntimeStartCommand(parsed) ||
+      isExternalToolsRegisterCommand(parsed) ||
+      isExternalToolCallResponseCommand(parsed) ||
       isTerminalSpawnCommand(parsed) ||
       isTerminalInputCommand(parsed) ||
       isTerminalResizeCommand(parsed) ||

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -624,6 +624,7 @@ export async function handleIncomingMessage(
       agentId,
       conversationId,
       clientToolAllowlist: msg.clientToolAllowlist,
+      externalToolScopeIds: msg.externalToolScopeIds,
       workingDirectory: turnWorkingDirectory,
       permissionModeState: turnPermissionModeState,
       cachedAgent,

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -21,6 +21,7 @@ import type { ToolsetName, ToolsetPreference } from "@/tools/toolset";
 import type {
   ApprovalResponseBody,
   ControlRequest,
+  ExternalToolCallResult,
   LoopStatus,
   RuntimeScope,
   WsProtocolCommand,
@@ -61,6 +62,7 @@ export interface IncomingMessage {
   conversationId?: string;
   channelTurnSources?: ChannelTurnSource[];
   clientToolAllowlist?: string[];
+  externalToolScopeIds?: string[];
   messages: Array<
     (MessageCreate & { client_message_id?: string }) | ApprovalCreate
   >;
@@ -108,6 +110,12 @@ export type PendingApprovalResolver = {
   resolve: (response: ApprovalResponseBody) => void;
   reject: (reason: Error) => void;
   controlRequest?: ControlRequest;
+};
+
+export type PendingExternalToolCall = {
+  resolve: (result: ExternalToolCallResult) => void;
+  reject: (reason: Error) => void;
+  timeout: NodeJS.Timeout;
 };
 
 export type RecoveredPendingApproval = {
@@ -212,6 +220,7 @@ export type ListenerRuntime = {
   connectionName: string | null;
   conversationRuntimes: Map<string, ConversationRuntime>;
   approvalRuntimeKeyByRequestId: Map<string, string>;
+  pendingExternalToolCalls?: Map<string, PendingExternalToolCall>;
   /** Per-conversation worktree directory watchers for CWD auto-detection fallback. */
   worktreeWatcherByConversation: Map<
     string,


### PR DESCRIPTION
## Summary
- add app-server protocol frames for external tool registration and callback execution
- expose scoped external tools per input turn via external_tool_scope_ids
- add listener-side request/response bridge and app-server client helpers

## Tests
- bun run check
- bun test src/websocket/listener/external-tools.test.ts src/tools/tool-execution-context.test.ts
- bun test src/app-server-client.test.ts src/websocket/listener/protocol-inbound.test.ts src/websocket/listen-client-protocol.test.ts src/types/app-server-protocol.test.ts