### PR TITLE
Add app-server tool policy support

### DIFF
--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -58,6 +58,7 @@ import {
 } from "@/runtime-context";
 import { settingsManager } from "@/settings-manager";
 import { telemetry } from "@/telemetry";
+import type { ClientToolPolicy } from "@/types/protocol_v2";
 import { debugLog } from "@/utils/debug";
 import { isRecord } from "@/utils/type-guards";
 import {
@@ -288,20 +289,86 @@ function matchesClientToolAllowlistEntry(
   );
 }
 
+function normalizeClientToolPolicies(options?: {
+  clientToolAllowlist?: string[];
+  clientToolPolicies?: ClientToolPolicy[];
+}): ClientToolPolicy[] {
+  const policies = [...(options?.clientToolPolicies ?? [])];
+  if (options?.clientToolAllowlist !== undefined) {
+    policies.push({ mode: "allow", tools: options.clientToolAllowlist });
+  }
+  return policies;
+}
+
+function matchesClientToolPolicyEntry(
+  tools: string[],
+  serverToolName: string,
+  internalToolName?: string,
+): boolean {
+  const toolSet = new Set(tools);
+  return matchesClientToolAllowlistEntry(
+    toolSet,
+    serverToolName,
+    internalToolName,
+  );
+}
+
+function isClientToolAllowedByPolicies(
+  serverToolName: string,
+  internalToolName: string | undefined,
+  policies: ClientToolPolicy[],
+): boolean {
+  for (const policy of policies) {
+    switch (policy.mode) {
+      case "all":
+        break;
+      case "none":
+        return false;
+      case "allow":
+        if (
+          !matchesClientToolPolicyEntry(
+            policy.tools,
+            serverToolName,
+            internalToolName,
+          )
+        ) {
+          return false;
+        }
+        break;
+      case "deny":
+        if (
+          matchesClientToolPolicyEntry(
+            policy.tools,
+            serverToolName,
+            internalToolName,
+          )
+        ) {
+          return false;
+        }
+        break;
+    }
+  }
+  return true;
+}
+
 export function filterBuiltInToolNamesByClientAllowlist(
   toolNames: ToolName[],
   clientToolAllowlist?: string[],
+  clientToolPolicies?: ClientToolPolicy[],
 ): ToolName[] {
-  if (clientToolAllowlist === undefined) {
+  const policies = normalizeClientToolPolicies({
+    clientToolAllowlist,
+    clientToolPolicies,
+  });
+  if (policies.length === 0) {
     return toolNames;
   }
 
-  const allowSet = new Set(clientToolAllowlist);
   return toolNames.filter((toolName) =>
-    matchesClientToolAllowlistEntry(
-      allowSet,
+    isClientToolAllowedByPolicies(
       getServerToolName(toolName),
       toolName,
+      policies,
     ),
   );
 }
@@ -328,6 +395,7 @@ function filterExternalToolsByClientAllowlist(
   externalTools: Map<string, ExternalToolDefinition>,
   clientToolAllowlist?: string[],
   externalToolScopeIds?: string[],
+  clientToolPolicies?: ClientToolPolicy[],
 ): Map<string, ExternalToolDefinition> {
   const scopeSet =
     externalToolScopeIds === undefined
@@ -340,14 +408,19 @@ function filterExternalToolsByClientAllowlist(
     return scopeSet?.has(tool.scopeId) ?? false;
   });
 
-  if (clientToolAllowlist === undefined) {
+  const policies = normalizeClientToolPolicies({
+    clientToolAllowlist,
+    clientToolPolicies,
+  });
+  if (policies.length === 0) {
     return new Map(scopeFiltered.map((tool) => [tool.name, tool]));
   }
 
-  const allowSet = new Set(clientToolAllowlist);
   return new Map(
     scopeFiltered
-      .filter((tool) => matchesClientToolAllowlistEntry(allowSet, tool.name))
+      .filter((tool) =>
+        isClientToolAllowedByPolicies(tool.name, undefined, policies),
+      )
       .map((tool) => [tool.name, tool]),
   );
 }
@@ -355,15 +428,19 @@ function filterExternalToolsByClientAllowlist(
 function filterModToolsByClientAllowlist(
   modTools: Map<string, ModToolDefinition>,
   clientToolAllowlist?: string[],
+  clientToolPolicies?: ClientToolPolicy[],
 ): Map<string, ModToolDefinition> {
-  if (clientToolAllowlist === undefined) {
+  const policies = normalizeClientToolPolicies({
+    clientToolAllowlist,
+    clientToolPolicies,
+  });
+  if (policies.length === 0) {
     return new Map(modTools);
   }
 
-  const allowSet = new Set(clientToolAllowlist);
   return new Map(
     Array.from(modTools.entries()).filter(([name, tool]) =>
-      matchesClientToolAllowlistEntry(allowSet, tool.name, name),
+      isClientToolAllowedByPolicies(tool.name, name, policies),
     ),
   );
 }
@@ -1072,6 +1149,7 @@ function capturePreparedToolExecutionContext(
   },
   options?: {
     clientToolAllowlist?: string[];
+    clientToolPolicies?: ClientToolPolicy[];
     externalToolScopeIds?: string[];
     workingDirectory?: string;
     permissionModeState?: PermissionModeState;
@@ -1094,6 +1172,7 @@ function capturePreparedToolExecutionContext(
       snapshot.externalTools,
       options?.clientToolAllowlist,
       options?.externalToolScopeIds,
+      options?.clientToolPolicies,
     ),
     externalExecutor: snapshot.externalExecutor,
     modEvents: options?.modEvents ?? snapshot.modEvents,
@@ -1101,6 +1180,7 @@ function capturePreparedToolExecutionContext(
     modTools: filterModToolsByClientAllowlist(
       snapshot.modTools,
       options?.clientToolAllowlist,
+      options?.clientToolPolicies,
     ),
     workingDirectory:
       runtimeContext.workingDirectory ?? getCurrentWorkingDirectory(),
@@ -1178,6 +1258,7 @@ export async function prepareToolExecutionContextForSpecificTools(
   toolNames: string[],
   options?: {
     clientToolAllowlist?: string[];
+    clientToolPolicies?: ClientToolPolicy[];
     externalToolScopeIds?: string[];
     workingDirectory?: string;
     permissionModeState?: PermissionModeState;
@@ -1210,6 +1291,7 @@ export async function prepareToolExecutionContextForModel(
     exclude?: ToolName[];
     include?: ToolName[];
     clientToolAllowlist?: string[];
+    clientToolPolicies?: ClientToolPolicy[];
     externalToolScopeIds?: string[];
     workingDirectory?: string;
     permissionModeState?: PermissionModeState;
@@ -1506,6 +1588,7 @@ async function resolveBaseToolNamesForModel(
     exclude?: ToolName[];
     include?: ToolName[];
     clientToolAllowlist?: string[];
+    clientToolPolicies?: ClientToolPolicy[];
     channelToolScope?: MessageChannelToolDiscoveryScope | null;
   },
 ): Promise<ToolName[]> {
@@ -1551,6 +1634,7 @@ async function resolveBaseToolNamesForModel(
   baseToolNames = filterBuiltInToolNamesByClientAllowlist(
     baseToolNames,
     options?.clientToolAllowlist,
+    options?.clientToolPolicies,
   );
 
   return baseToolNames;
@@ -1562,6 +1646,7 @@ async function buildRegistryForModel(
     exclude?: ToolName[];
     include?: ToolName[];
     clientToolAllowlist?: string[];
+    clientToolPolicies?: ClientToolPolicy[];
     channelToolScope?: MessageChannelToolDiscoveryScope | null;
   },
 ): Promise<ToolRegistry> {

--- a/src/tools/tool-execution-context.test.ts
+++ b/src/tools/tool-execution-context.test.ts
@@ -366,6 +366,42 @@ describe("tool execution context snapshot", () => {
     expect(prepared.clientTools.map((tool) => tool.name)).toEqual(["Agent"]);
   });
 
+  test("client tool policies can deny tools by server-facing aliases", async () => {
+    const prepared = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      {
+        clientToolPolicies: [
+          { mode: "deny", tools: ["AskUserQuestion", "Agent"] },
+        ],
+      },
+    );
+
+    expect(prepared.loadedToolNames).not.toContain("AskUserQuestion");
+    expect(prepared.loadedToolNames).not.toContain("Task");
+    expect(prepared.clientTools.map((tool) => tool.name)).not.toContain(
+      "AskUserQuestion",
+    );
+    expect(prepared.clientTools.map((tool) => tool.name)).not.toContain(
+      "Agent",
+    );
+    expect(prepared.loadedToolNames).toContain("Read");
+  });
+
+  test("runtime policies cannot be widened by input policies", async () => {
+    const prepared = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      {
+        clientToolPolicies: [
+          { mode: "deny", tools: ["AskUserQuestion"] },
+          { mode: "allow", tools: ["AskUserQuestion"] },
+        ],
+      },
+    );
+
+    expect(prepared.loadedToolNames).toEqual([]);
+    expect(prepared.clientTools).toEqual([]);
+  });
+
   test("request-scoped allowlist filters external tools by name", async () => {
     registerExternalTools([
       {
@@ -408,6 +444,34 @@ describe("tool execution context snapshot", () => {
 
     expect(prepared.loadedToolNames).toEqual([]);
     expect(prepared.clientTools).toEqual([]);
+  });
+
+  test("client tool policies filter external and mod tools", async () => {
+    registerExternalTools([
+      {
+        name: "RemoteFoo",
+        description: "External tool",
+        parameters: { type: "object", properties: {}, required: [] },
+      },
+    ]);
+    const controller = new AbortController();
+    registerEchoModTool(controller.signal);
+
+    const prepared = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      {
+        clientToolPolicies: [
+          { mode: "deny", tools: ["RemoteFoo", "local_echo"] },
+        ],
+      },
+    );
+
+    expect(prepared.clientTools.map((tool) => tool.name)).not.toContain(
+      "RemoteFoo",
+    );
+    expect(prepared.clientTools.map((tool) => tool.name)).not.toContain(
+      "local_echo",
+    );
   });
 
   test("scoped external tools stay hidden unless their scope is selected", async () => {

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -14,6 +14,7 @@ import {
   type RuntimeContextSnapshot,
 } from "@/runtime-context";
 import { settingsManager } from "@/settings-manager";
+import type { ClientToolPolicy } from "@/types/protocol_v2";
 import { isRecord } from "@/utils/type-guards";
 import { toolFilter } from "./filter";
 import {
@@ -193,6 +194,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
   toolsetPreference: ToolsetPreference;
   exclude?: ToolName[];
   clientToolAllowlist?: string[];
+  clientToolPolicies?: ClientToolPolicy[];
   externalToolScopeIds?: string[];
   workingDirectory?: string;
   permissionModeState?: PermissionModeState;
@@ -206,6 +208,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
     toolsetPreference,
     exclude,
     clientToolAllowlist,
+    clientToolPolicies,
     externalToolScopeIds,
     workingDirectory,
     permissionModeState,
@@ -233,6 +236,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
           ? getGoalToolNamesForToolset(derivedToolset)
           : undefined,
         clientToolAllowlist,
+        clientToolPolicies,
         externalToolScopeIds,
         workingDirectory,
         permissionModeState,
@@ -262,9 +266,11 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
           : [],
       ),
       clientToolAllowlist,
+      clientToolPolicies,
     ),
     {
       clientToolAllowlist,
+      clientToolPolicies,
       externalToolScopeIds,
       workingDirectory,
       permissionModeState,
@@ -434,6 +440,7 @@ export async function prepareToolExecutionContextForScope(params: {
   cachedEffectiveModel?: string | null;
   exclude?: ToolName[];
   clientToolAllowlist?: string[];
+  clientToolPolicies?: ClientToolPolicy[];
   externalToolScopeIds?: string[];
   workingDirectory?: string;
   permissionModeState?: PermissionModeState;
@@ -448,6 +455,7 @@ export async function prepareToolExecutionContextForScope(params: {
     cachedEffectiveModel,
     exclude,
     clientToolAllowlist,
+    clientToolPolicies,
     externalToolScopeIds,
     workingDirectory,
     permissionModeState,
@@ -511,6 +519,7 @@ export async function prepareToolExecutionContextForScope(params: {
     toolsetPreference,
     exclude,
     clientToolAllowlist,
+    clientToolPolicies,
     externalToolScopeIds,
     workingDirectory,
     permissionModeState,

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -695,6 +695,11 @@ export interface InputCreateMessagePayload {
   kind: "create_message";
   messages: Array<MessageCreate & { client_message_id?: string }>;
   /**
+   * Optional request-scoped tool policy. This can only narrow any runtime-level
+   * tool_policy established by runtime_start.
+   */
+  tool_policy?: ClientToolPolicy;
+  /**
    * Optional request-scoped allowlist for locally executed client tools.
    * Undefined preserves the listener's normal toolset; an empty array means no
    * client tools for this turn.
@@ -779,6 +784,12 @@ export interface RuntimeStartClientInfo {
   version?: string;
 }
 
+export type ClientToolPolicy =
+  | { mode: "all" }
+  | { mode: "none" }
+  | { mode: "allow"; tools: string[] }
+  | { mode: "deny"; tools: string[] };
+
 export interface RuntimeStartCommand {
   type: "runtime_start";
   /** Echoed back in the response for request correlation. */
@@ -795,6 +806,8 @@ export interface RuntimeStartCommand {
   cwd?: string | null;
   /** Initial permission mode for this runtime scope. */
   mode?: DevicePermissionMode;
+  /** Default client-tool policy for this runtime scope. Input policies only narrow this. */
+  tool_policy?: ClientToolPolicy;
   /** Optional client metadata for diagnostics/future protocol negotiation. */
   client_info?: RuntimeStartClientInfo;
   /** Whether to probe backend state for stale pending approvals before replaying state. Defaults to true. */

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -56,6 +56,7 @@ import {
   getRecoverableRetryNoticeVisibility,
   getRecoverableStatusNoticeVisibility,
 } from "@/websocket/listener/recoverable-notices";
+import { getConversationToolPolicy } from "@/websocket/listener/tool-policy";
 
 class MockSocket {
   readyState: number;
@@ -600,6 +601,7 @@ describe("listen-client parseServerMessage", () => {
             },
             cwd: cwdDir,
             mode: "acceptEdits",
+            tool_policy: { mode: "deny", tools: ["AskUserQuestion"] },
             recover_approvals: false,
           },
           socket as unknown as WebSocket,
@@ -631,6 +633,13 @@ describe("listen-client parseServerMessage", () => {
             runtimeScope.conversation_id,
           ),
         ).toBe(cwdDir);
+        expect(
+          getConversationToolPolicy(
+            listener,
+            runtimeScope.agent_id,
+            runtimeScope.conversation_id,
+          ),
+        ).toEqual({ mode: "deny", tools: ["AskUserQuestion"] });
         expect(messages).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
@@ -841,6 +850,7 @@ describe("listen-client parseServerMessage", () => {
           payload: {
             kind: "create_message",
             messages: [],
+            tool_policy: { mode: "deny", tools: ["AskUserQuestion"] },
             client_tool_allowlist: ["Read", "Grep"],
             external_tool_scope_ids: ["council-1"],
           },
@@ -858,6 +868,10 @@ describe("listen-client parseServerMessage", () => {
     );
     expect(msg?.type).toBe("input");
     if (msg?.type === "input" && msg.payload.kind === "create_message") {
+      expect(msg.payload.tool_policy).toEqual({
+        mode: "deny",
+        tools: ["AskUserQuestion"],
+      });
       expect(msg.payload.client_tool_allowlist).toEqual(["Read", "Grep"]);
       expect(msg.payload.external_tool_scope_ids).toEqual(["council-1"]);
     }
@@ -883,6 +897,28 @@ describe("listen-client parseServerMessage", () => {
     expect(parsed?.type).toBe("__invalid_input");
     if (parsed?.type === "__invalid_input") {
       expect(parsed.reason).toContain("client_tool_allowlist must be string[]");
+    }
+  });
+
+  test("rejects input create_message with invalid tool policy", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "input",
+          runtime: { agent_id: "agent-1", conversation_id: "default" },
+          payload: {
+            kind: "create_message",
+            messages: [],
+            tool_policy: { mode: "deny" },
+          },
+        }),
+      ),
+    );
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.type).toBe("__invalid_input");
+    if (parsed?.type === "__invalid_input") {
+      expect(parsed.reason).toContain("tool_policy must be a valid");
     }
   });
 

--- a/src/websocket/listener/commands/runtime-start.ts
+++ b/src/websocket/listener/commands/runtime-start.ts
@@ -14,6 +14,7 @@ import {
   persistPermissionModeMapForRuntime,
 } from "@/websocket/listener/permission-mode";
 import { isRuntimeStartCommand } from "@/websocket/listener/protocol-inbound";
+import { setConversationToolPolicy } from "@/websocket/listener/tool-policy";
 import type {
   ConversationRuntime,
   ListenerRuntime,
@@ -205,6 +206,13 @@ async function applyRuntimeStartState(
       statusSocket: context.socket,
     });
   }
+
+  setConversationToolPolicy(
+    context.runtime,
+    scope.agent_id,
+    scope.conversation_id,
+    parsed.tool_policy,
+  );
 }
 
 export async function handleRuntimeStartCommand(

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -775,6 +775,7 @@ export function createRuntime(): ListenerRuntime {
     workingDirectoryByConversation: loadPersistedCwdMap(),
     worktreeWatcherByConversation: new Map(),
     permissionModeByConversation: loadPersistedPermissionModeMap(),
+    toolPolicyByConversation: new Map(),
     reminderStateByConversation: new Map(),
     contextTrackerByConversation: new Map(),
     systemPromptRecompileByConversation: new Map(),
@@ -817,6 +818,7 @@ export function stopRuntime(
   rejectPendingExternalToolCalls(runtime, "Listener runtime stopped");
   clearListenerWarmState(runtime);
   runtime.reminderStateByConversation.clear();
+  runtime.toolPolicyByConversation?.clear();
   runtime.contextTrackerByConversation.clear();
   runtime.systemPromptRecompileByConversation.clear();
   runtime.queuedSystemPromptRecompileByConversation.clear();

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -361,6 +361,7 @@ export function createListenerMessageHandler(
           type: "message",
           agentId: parsed.runtime.agent_id,
           conversationId: parsed.runtime.conversation_id,
+          toolPolicy: inputPayload.tool_policy,
           clientToolAllowlist: inputPayload.client_tool_allowlist,
           externalToolScopeIds: inputPayload.external_tool_scope_ids,
           messages: inputPayload.messages,

--- a/src/websocket/listener/protocol-inbound.test.ts
+++ b/src/websocket/listener/protocol-inbound.test.ts
@@ -82,6 +82,7 @@ describe("agent/conversation management protocol-inbound validators", () => {
       create_conversation: { body: { summary: "New conversation" } },
       cwd: "/tmp/project",
       mode: "acceptEdits",
+      tool_policy: { mode: "deny", tools: ["AskUserQuestion"] },
       client_info: { name: "test", title: "Test", version: "1.0.0" },
     },
     { type: "agent_list", request_id: "r1", query: { limit: 10 } },
@@ -141,7 +142,7 @@ describe("agent/conversation management protocol-inbound validators", () => {
     },
   ])("accepts $type", (message) => {
     const parsed = parseServerMessage(Buffer.from(JSON.stringify(message)));
-    expect(parsed).toEqual(message);
+    expect(parsed as unknown).toEqual(message);
   });
 
   test.each([
@@ -157,6 +158,12 @@ describe("agent/conversation management protocol-inbound validators", () => {
       request_id: "r0",
       agent_id: "agent-1",
       mode: "bad",
+    },
+    {
+      type: "runtime_start",
+      request_id: "r0",
+      agent_id: "agent-1",
+      tool_policy: { mode: "deny" },
     },
     {
       type: "runtime_start",

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -168,6 +168,7 @@ function isInputCommand(value: unknown): value is InputCommand {
   const payload = candidate.payload as {
     kind?: unknown;
     messages?: unknown;
+    tool_policy?: unknown;
     client_tool_allowlist?: unknown;
     external_tool_scope_ids?: unknown;
     request_id?: unknown;
@@ -177,6 +178,8 @@ function isInputCommand(value: unknown): value is InputCommand {
   if (payload.kind === "create_message") {
     return (
       Array.isArray(payload.messages) &&
+      (payload.tool_policy === undefined ||
+        isClientToolPolicy(payload.tool_policy)) &&
       (payload.client_tool_allowlist === undefined ||
         isStringArray(payload.client_tool_allowlist)) &&
       (payload.external_tool_scope_ids === undefined ||
@@ -213,6 +216,7 @@ function getInvalidInputReason(value: unknown): {
   const payload = candidate.payload as {
     kind?: unknown;
     messages?: unknown;
+    tool_policy?: unknown;
     client_tool_allowlist?: unknown;
     external_tool_scope_ids?: unknown;
     request_id?: unknown;
@@ -225,6 +229,16 @@ function getInvalidInputReason(value: unknown): {
         runtime: candidate.runtime,
         reason:
           "Protocol violation: input.kind=create_message requires payload.messages[]",
+      };
+    }
+    if (
+      payload.tool_policy !== undefined &&
+      !isClientToolPolicy(payload.tool_policy)
+    ) {
+      return {
+        runtime: candidate.runtime,
+        reason:
+          "Protocol violation: input.payload.tool_policy must be a valid client tool policy",
       };
     }
     if (
@@ -398,6 +412,7 @@ export function isRuntimeStartCommand(
     create_conversation?: unknown;
     cwd?: unknown;
     mode?: unknown;
+    tool_policy?: unknown;
     client_info?: unknown;
     recover_approvals?: unknown;
     force_device_status?: unknown;
@@ -414,12 +429,25 @@ export function isRuntimeStartCommand(
       isRuntimeStartCreateConversationOptions(c.create_conversation)) &&
     (c.cwd === undefined || c.cwd === null || typeof c.cwd === "string") &&
     (c.mode === undefined || isDevicePermissionMode(c.mode)) &&
+    (c.tool_policy === undefined || isClientToolPolicy(c.tool_policy)) &&
     (c.client_info === undefined || isRuntimeStartClientInfo(c.client_info)) &&
     (c.recover_approvals === undefined ||
       typeof c.recover_approvals === "boolean") &&
     (c.force_device_status === undefined ||
       typeof c.force_device_status === "boolean")
   );
+}
+
+function isClientToolPolicy(value: unknown): boolean {
+  if (!isObjectRecord(value)) return false;
+  const mode = value.mode;
+  if (mode === "all" || mode === "none") {
+    return value.tools === undefined;
+  }
+  if (mode === "allow" || mode === "deny") {
+    return Array.isArray(value.tools) && isStringArray(value.tools);
+  }
+  return false;
 }
 
 function isExternalToolDefinitionPayload(value: unknown): boolean {

--- a/src/websocket/listener/tool-policy.ts
+++ b/src/websocket/listener/tool-policy.ts
@@ -1,0 +1,35 @@
+import type { ClientToolPolicy } from "@/types/protocol_v2";
+import { getPermissionModeScopeKey } from "./permission-mode";
+import type { ListenerRuntime } from "./types";
+
+function getToolPolicyMap(
+  runtime: ListenerRuntime,
+): Map<string, ClientToolPolicy> {
+  runtime.toolPolicyByConversation ??= new Map();
+  return runtime.toolPolicyByConversation;
+}
+
+export function setConversationToolPolicy(
+  runtime: ListenerRuntime,
+  agentId?: string | null,
+  conversationId?: string | null,
+  policy?: ClientToolPolicy,
+): void {
+  const scopeKey = getPermissionModeScopeKey(agentId, conversationId);
+  const toolPolicyMap = getToolPolicyMap(runtime);
+  if (policy === undefined) {
+    toolPolicyMap.delete(scopeKey);
+    return;
+  }
+  toolPolicyMap.set(scopeKey, policy);
+}
+
+export function getConversationToolPolicy(
+  runtime: ListenerRuntime,
+  agentId?: string | null,
+  conversationId?: string | null,
+): ClientToolPolicy | undefined {
+  return getToolPolicyMap(runtime).get(
+    getPermissionModeScopeKey(agentId, conversationId),
+  );
+}

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -125,6 +125,7 @@ import {
   sendMessageStreamWithRetry,
 } from "./send";
 import { injectQueuedSkillContent } from "./skill-injection";
+import { getConversationToolPolicy } from "./tool-policy";
 import type { ListenerTransport } from "./transport";
 import { handleApprovalStop } from "./turn-approval";
 import type {
@@ -620,10 +621,19 @@ export async function handleIncomingMessage(
     let pendingNormalizationInterruptedToolCallIds = [
       ...queuedInterruptedToolCallIds,
     ];
+    const runtimeToolPolicy = getConversationToolPolicy(
+      runtime.listener,
+      normalizedAgentId,
+      conversationId,
+    );
+    const clientToolPolicies = [runtimeToolPolicy, msg.toolPolicy].filter(
+      (policy): policy is NonNullable<typeof policy> => policy !== undefined,
+    );
     const preparedToolContext = await prepareToolExecutionContextForScope({
       agentId,
       conversationId,
       clientToolAllowlist: msg.clientToolAllowlist,
+      clientToolPolicies,
       externalToolScopeIds: msg.externalToolScopeIds,
       workingDirectory: turnWorkingDirectory,
       permissionModeState: turnPermissionModeState,

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -20,6 +20,7 @@ import type { SharedReminderState } from "@/reminders/state";
 import type { ToolsetName, ToolsetPreference } from "@/tools/toolset";
 import type {
   ApprovalResponseBody,
+  ClientToolPolicy,
   ControlRequest,
   ExternalToolCallResult,
   LoopStatus,
@@ -61,6 +62,7 @@ export interface IncomingMessage {
   agentId?: string;
   conversationId?: string;
   channelTurnSources?: ChannelTurnSource[];
+  toolPolicy?: ClientToolPolicy;
   clientToolAllowlist?: string[];
   externalToolScopeIds?: string[];
   messages: Array<
@@ -209,6 +211,8 @@ export type ListenerRuntime = {
     string,
     import("@/websocket/listener/permission-mode").ConversationPermissionModeState
   >;
+  /** Per-conversation default client-tool policy supplied by app-server runtime_start. */
+  toolPolicyByConversation?: Map<string, ClientToolPolicy>;
   /** Per-conversation reminder state survives ConversationRuntime eviction. */
   reminderStateByConversation: Map<string, SharedReminderState>;
   /** Per-conversation context tracker survives ConversationRuntime eviction. */


### PR DESCRIPTION
## Summary
- add runtime/input `tool_policy` with all/none/allow/deny modes
- apply runtime policy as the baseline and input policy / legacy allowlist as narrowing filters
- store runtime default policy per conversation and apply it during tool preparation

Stacked on #2857.

## Tests
- bun run check
- bun test src/tools/tool-execution-context.test.ts
- bun test src/websocket/listener/protocol-inbound.test.ts src/websocket/listen-client-protocol.test.ts