### PR TITLE
test: fix headless reflection state assertions

### DIFF
--- a/src/headless-bidirectional-reflection.test.ts
+++ b/src/headless-bidirectional-reflection.test.ts
@@ -10,9 +10,9 @@ import { createIsolatedCliTestEnv } from "@/test-utils/test-process-env";
 type JsonObject = Record<string, unknown>;
 
 interface ReflectionTranscriptState {
-  total_completed_turns?: number;
-  reflected_completed_turns?: number;
-  turns_since_last_successful_reflection?: number;
+  total_completed_steps?: number;
+  reflected_completed_steps?: number;
+  steps_since_last_successful_reflection?: number;
   last_reflection_started_at?: string;
   last_reflection_succeeded_at?: string;
   reflected_through_message_id?: string;
@@ -81,15 +81,15 @@ describe("headless bidirectional auto-reflection", () => {
       summary.payloadFiles.length,
       formatSummary(summary),
     ).toBeGreaterThanOrEqual(2);
-    expect(summary.state?.total_completed_turns, formatSummary(summary)).toBe(
+    expect(summary.state?.total_completed_steps, formatSummary(summary)).toBe(
       3,
     );
     expect(
-      summary.state?.reflected_completed_turns,
+      summary.state?.reflected_completed_steps,
       formatSummary(summary),
     ).toBe(2);
     expect(
-      summary.state?.turns_since_last_successful_reflection,
+      summary.state?.steps_since_last_successful_reflection,
       formatSummary(summary),
     ).toBe(1);
     expect(
@@ -195,7 +195,7 @@ async function runBidirectionalReflectionScenario(): Promise<BidirectionalReflec
     if (closeScheduled) return;
     closeScheduled = true;
     void waitForReflectionProgress(transcriptDir, {
-      reflectedCompletedTurns: 2,
+      reflectedCompletedSteps: 2,
       payloadCount: 2,
       timeoutMs: 10_000,
     }).finally(() => {
@@ -252,7 +252,7 @@ async function runBidirectionalReflectionScenario(): Promise<BidirectionalReflec
           // reflection finishes; otherwise the active-reflection guard correctly
           // skips duplicate launches and this test would only verify one cycle.
           void waitForReflectionProgress(transcriptDir, {
-            reflectedCompletedTurns: 1,
+            reflectedCompletedSteps: 1,
             payloadCount: 1,
             timeoutMs: 10_000,
           }).finally(() => sendUser("hello three"));
@@ -317,7 +317,7 @@ async function runBidirectionalReflectionScenario(): Promise<BidirectionalReflec
 async function waitForReflectionProgress(
   getTranscriptDir: () => string | null,
   options: {
-    reflectedCompletedTurns: number;
+    reflectedCompletedSteps: number;
     payloadCount: number;
     timeoutMs: number;
   },
@@ -328,8 +328,8 @@ async function waitForReflectionProgress(
     const state = dir ? readReflectionState(dir) : null;
     const payloadCount = dir ? readPayloadFiles(dir).length : 0;
     if (
-      (state?.reflected_completed_turns ?? 0) >=
-        options.reflectedCompletedTurns &&
+      (state?.reflected_completed_steps ?? 0) >=
+        options.reflectedCompletedSteps &&
       payloadCount >= options.payloadCount
     ) {
       return;

--- a/src/test-utils/headless-reflection-scenario.ts
+++ b/src/test-utils/headless-reflection-scenario.ts
@@ -29,9 +29,9 @@ interface Args {
 interface ReflectionTranscriptState {
   schema_version?: string;
   reflected_through_message_id?: string;
-  total_completed_turns?: number;
-  reflected_completed_turns?: number;
-  turns_since_last_successful_reflection?: number;
+  total_completed_steps?: number;
+  reflected_completed_steps?: number;
+  steps_since_last_successful_reflection?: number;
   last_reflection_started_at?: string;
   last_reflection_succeeded_at?: string;
 }
@@ -288,7 +288,7 @@ async function waitForLaunchArtifacts(
     const state = dir ? await readReflectionState(dir) : null;
     const payloadFiles = dir ? await readPayloadFiles(dir) : [];
     if (
-      (state?.total_completed_turns ?? 0) >= 2 &&
+      (state?.total_completed_steps ?? 0) >= 2 &&
       state?.last_reflection_started_at &&
       payloadFiles.length >= 1
     ) {
@@ -449,7 +449,7 @@ function assertScenario(summary: LiveReflectionSummary): void {
   assertTrue(summary.conversationId, `Missing conversation id.\n${details}`);
   assertTrue(
     summary.resultCount >= 2,
-    `Expected at least two completed turns.\n${details}`,
+    `Expected at least two completed steps.\n${details}`,
   );
   assertTrue(
     summary.reflectionLaunchCount >= 1,
@@ -472,12 +472,12 @@ function assertScenario(summary: LiveReflectionSummary): void {
     `Expected at least one auto reflection payload.\n${details}`,
   );
   assertTrue(
-    summary.state?.schema_version === "v2_message_id",
+    summary.state?.schema_version === "v3_assistant_steps",
     `Unexpected reflection state schema.\n${details}`,
   );
   assertTrue(
-    (summary.state?.total_completed_turns ?? 0) >= 2,
-    `Reflection state did not record completed turns.\n${details}`,
+    (summary.state?.total_completed_steps ?? 0) >= 2,
+    `Reflection state did not record completed steps.\n${details}`,
   );
   assertTrue(
     summary.state?.last_reflection_started_at,


### PR DESCRIPTION
## Summary
- update headless reflection test assertions for the current v3 assistant-step state schema
- update the dedicated CI reflection scenario to check `total_completed_steps` and `v3_assistant_steps`

## Tests
- bun test src/headless-bidirectional-reflection.test.ts
- bunx --bun @biomejs/biome@2.2.5 check src/headless-bidirectional-reflection.test.ts src/test-utils/headless-reflection-scenario.ts
- bun run typecheck