### PR TITLE
feat(app-server): add runtime-start external tool callbacks

### DIFF
--- a/src/app-server-client.test.ts
+++ b/src/app-server-client.test.ts
@@ -194,6 +194,70 @@ describe("app-server client", () => {
     expect(sent).toEqual(["sync", "abort_message", "input"]);
   });
 
+  test("starts runtimes with external tools and responds to external tool calls", async () => {
+    const { client, control, stream } = createFakeClient();
+    control.open();
+    stream.open();
+    await client.connect();
+
+    const runtimeStart = client.runtimeStart({
+      create_agent: { body: { name: "SDK test" } },
+      create_conversation: { body: {} },
+      external_tools: [
+        {
+          scope_id: "scope-1",
+          tools: [
+            {
+              name: "lookup_ticket",
+              description: "Lookup a ticket",
+              parameters: { type: "object", properties: {} },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(JSON.parse(control.sent[0] ?? "{}")).toMatchObject({
+      type: "runtime_start",
+      external_tools: [
+        {
+          scope_id: "scope-1",
+          tools: [{ name: "lookup_ticket" }],
+        },
+      ],
+    });
+    control.receive({
+      type: "runtime_start_response",
+      request_id: "runtime-start-1",
+      success: true,
+      runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+      agent: { id: "agent-1" },
+      conversation: { id: "conv-1" },
+      created: { agent: true, conversation: true },
+    });
+    await runtimeStart;
+
+    client.onExternalToolCall((request) => ({
+      content: [{ type: "text", text: `ticket:${request.input.id}` }],
+    }));
+    control.receive({
+      type: "external_tool_call_request",
+      request_id: "external-tool-1",
+      runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+      scope_id: "scope-1",
+      tool_call_id: "call-1",
+      tool_name: "lookup_ticket",
+      input: { id: "ABC-123" },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(JSON.parse(control.sent.at(-1) ?? "{}")).toEqual({
+      type: "external_tool_call_response",
+      request_id: "external-tool-1",
+      result: { content: [{ type: "text", text: "ticket:ABC-123" }] },
+    });
+  });
+
   test("runTurn injects client message ids and resolves on stop_reason", async () => {
     const { client, control, stream } = createFakeClient();
     control.open();

--- a/src/app-server-client.ts
+++ b/src/app-server-client.ts
@@ -1,6 +1,8 @@
 import type {
   AbortMessageCommand,
   AbortMessageResponseMessage,
+  ExternalToolCallRequestMessage,
+  ExternalToolCallResult,
   InputCommand,
   LoopStatusUpdateMessage,
   RuntimeScope,
@@ -28,6 +30,10 @@ export type AppServerMessageHandler = (
 
 /** Called synchronously before a protocol command is written to the control socket. */
 export type AppServerSendHandler = (command: WsProtocolCommand) => void;
+
+export type AppServerExternalToolCallHandler = (
+  request: ExternalToolCallRequestMessage,
+) => Promise<ExternalToolCallResult> | ExternalToolCallResult;
 
 export interface AppServerSocketLike {
   readyState: number;
@@ -456,6 +462,33 @@ export class AppServerClient {
           message.type === "abort_message_response",
       },
     );
+  }
+
+  onExternalToolCall(handler: AppServerExternalToolCallHandler): () => void {
+    return this.onMessage((message, channel) => {
+      if (
+        channel !== "control" ||
+        message.type !== "external_tool_call_request"
+      ) {
+        return;
+      }
+
+      void Promise.resolve(handler(message))
+        .then((result) => {
+          this.send({
+            type: "external_tool_call_response",
+            request_id: message.request_id,
+            result,
+          });
+        })
+        .catch((error) => {
+          this.send({
+            type: "external_tool_call_response",
+            request_id: message.request_id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+    });
   }
 
   input(command: Omit<InputCommand, "type">): void {

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -340,6 +340,38 @@ function filterExternalToolsByClientAllowlist(
   );
 }
 
+function filterExternalToolsByRuntimeContext(
+  externalTools: Map<string, ExternalToolDefinition>,
+  runtimeContext: RuntimeContextSnapshot,
+): Map<string, ExternalToolDefinition> {
+  return new Map(
+    Array.from(externalTools.entries()).filter(([, tool]) => {
+      if (!tool.runtime) {
+        return true;
+      }
+      return (
+        tool.runtime.agentId === runtimeContext.agentId &&
+        tool.runtime.conversationId === runtimeContext.conversationId
+      );
+    }),
+  );
+}
+
+function filterExternalToolsByScopeIds(
+  externalTools: Map<string, ExternalToolDefinition>,
+  externalToolScopeIds?: string[],
+): Map<string, ExternalToolDefinition> {
+  const selectedScopes = new Set(externalToolScopeIds ?? []);
+  return new Map(
+    Array.from(externalTools.entries()).filter(([, tool]) => {
+      if (tool.scopeId === undefined) {
+        return true;
+      }
+      return selectedScopes.has(tool.scopeId);
+    }),
+  );
+}
+
 function filterModToolsByClientAllowlist(
   modTools: Map<string, ModToolDefinition>,
   clientToolAllowlist?: string[],
@@ -821,6 +853,13 @@ export interface ExternalToolDefinition {
   label?: string;
   description: string;
   parameters: Record<string, unknown>; // JSON Schema
+  /** Optional visibility scope; scoped tools are hidden unless selected for a turn. */
+  scopeId?: string;
+  /** Optional runtime owner; runtime-owned tools are visible only in that runtime. */
+  runtime?: {
+    agentId?: string;
+    conversationId?: string;
+  };
 }
 
 /**
@@ -830,6 +869,7 @@ export type ExternalToolExecutor = (
   toolCallId: string,
   toolName: string,
   input: Record<string, unknown>,
+  context?: { tool: ExternalToolDefinition },
 ) => Promise<{
   content: Array<{
     type: string;
@@ -864,6 +904,15 @@ export function registerExternalTools(tools: ExternalToolDefinition[]): void {
   const registry = getExternalToolsRegistry();
   for (const tool of tools) {
     registry.set(tool.name, tool);
+  }
+}
+
+export function unregisterExternalTools(tools: ExternalToolDefinition[]): void {
+  const registry = getExternalToolsRegistry();
+  for (const tool of tools) {
+    if (registry.get(tool.name) === tool) {
+      registry.delete(tool.name);
+    }
   }
 }
 
@@ -921,6 +970,7 @@ export async function executeExternalTool(
   toolName: string,
   input: Record<string, unknown>,
   executorOverride?: ExternalToolExecutor,
+  toolDefinition?: ExternalToolDefinition,
 ): Promise<ToolExecutionResult> {
   const executor = executorOverride ?? getExternalToolExecutor();
   if (!executor) {
@@ -931,7 +981,13 @@ export async function executeExternalTool(
   }
 
   try {
-    const result = await executor(toolCallId, toolName, input);
+    const tool = toolDefinition ?? getExternalToolDefinition(toolName);
+    const result = await executor(
+      toolCallId,
+      toolName,
+      input,
+      tool ? { tool } : undefined,
+    );
 
     // Convert external tool result to ToolExecutionResult format
     const textContent = result.content
@@ -1026,6 +1082,7 @@ function capturePreparedToolExecutionContext(
   },
   options?: {
     clientToolAllowlist?: string[];
+    externalToolScopeIds?: string[];
     workingDirectory?: string;
     permissionModeState?: PermissionModeState;
     modEvents?: ModEvents;
@@ -1044,7 +1101,13 @@ function capturePreparedToolExecutionContext(
   const executionSnapshot: ToolExecutionContextSnapshot = {
     toolRegistry: withDynamicMessageChannelCache(snapshot.toolRegistry),
     externalTools: filterExternalToolsByClientAllowlist(
-      snapshot.externalTools,
+      filterExternalToolsByScopeIds(
+        filterExternalToolsByRuntimeContext(
+          snapshot.externalTools,
+          runtimeContext,
+        ),
+        options?.externalToolScopeIds,
+      ),
       options?.clientToolAllowlist,
     ),
     externalExecutor: snapshot.externalExecutor,
@@ -1130,6 +1193,7 @@ export async function prepareToolExecutionContextForSpecificTools(
   toolNames: string[],
   options?: {
     clientToolAllowlist?: string[];
+    externalToolScopeIds?: string[];
     workingDirectory?: string;
     permissionModeState?: PermissionModeState;
     channelToolScope?: MessageChannelToolDiscoveryScope | null;
@@ -1161,6 +1225,7 @@ export async function prepareToolExecutionContextForModel(
     exclude?: ToolName[];
     include?: ToolName[];
     clientToolAllowlist?: string[];
+    externalToolScopeIds?: string[];
     workingDirectory?: string;
     permissionModeState?: PermissionModeState;
     channelToolScope?: MessageChannelToolDiscoveryScope | null;
@@ -2319,6 +2384,7 @@ export async function executeTool(
 
   // Check if this is an external tool (SDK-executed)
   if (activeExternalTools.has(name)) {
+    const externalTool = activeExternalTools.get(name);
     const { args: eventArgs } = await emitToolStartEvent({
       args,
       events: modEvents,
@@ -2344,6 +2410,7 @@ export async function executeTool(
       name,
       eventArgs as Record<string, unknown>,
       activeExternalExecutor,
+      externalTool,
     );
   }
 

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -372,6 +372,19 @@ function filterExternalToolsByScopeIds(
   );
 }
 
+function toModelFacingExternalToolMap(
+  externalTools: Map<string, ExternalToolDefinition>,
+): Map<string, ExternalToolDefinition> {
+  const modelFacingTools = new Map<string, ExternalToolDefinition>();
+  for (const tool of externalTools.values()) {
+    // MVP: if one runtime exposes duplicate model-facing names, the later
+    // registration wins. We keep cross-runtime registrations isolated by using
+    // namespaced internal keys before this final model-facing collapse.
+    modelFacingTools.set(tool.name, tool);
+  }
+  return modelFacingTools;
+}
+
 function filterModToolsByClientAllowlist(
   modTools: Map<string, ModToolDefinition>,
   clientToolAllowlist?: string[],
@@ -853,6 +866,8 @@ export interface ExternalToolDefinition {
   label?: string;
   description: string;
   parameters: Record<string, unknown>; // JSON Schema
+  /** Internal registration key; model-facing calls still use name. */
+  registrationKey?: string;
   /** Optional visibility scope; scoped tools are hidden unless selected for a turn. */
   scopeId?: string;
   /** Optional runtime owner; runtime-owned tools are visible only in that runtime. */
@@ -903,15 +918,16 @@ function getExternalToolsRegistry(): Map<string, ExternalToolDefinition> {
 export function registerExternalTools(tools: ExternalToolDefinition[]): void {
   const registry = getExternalToolsRegistry();
   for (const tool of tools) {
-    registry.set(tool.name, tool);
+    registry.set(tool.registrationKey ?? tool.name, tool);
   }
 }
 
 export function unregisterExternalTools(tools: ExternalToolDefinition[]): void {
   const registry = getExternalToolsRegistry();
   for (const tool of tools) {
-    if (registry.get(tool.name) === tool) {
-      registry.delete(tool.name);
+    const registrationKey = tool.registrationKey ?? tool.name;
+    if (registry.get(registrationKey) === tool) {
+      registry.delete(registrationKey);
     }
   }
 }
@@ -955,7 +971,11 @@ export function getExternalToolDefinition(
  * Get all external tools as ClientTool format
  */
 export function getExternalToolsAsClientTools(): ClientTool[] {
-  return Array.from(getExternalToolsRegistry().values()).map((tool) => ({
+  return Array.from(
+    toModelFacingExternalToolMap(
+      filterExternalToolsByRuntimeContext(getExternalToolsRegistry(), {}),
+    ).values(),
+  ).map((tool) => ({
     name: tool.name,
     description: tool.description,
     parameters: tool.parameters,
@@ -1016,7 +1036,9 @@ export async function executeExternalTool(
 export function getClientToolsFromRegistry(): ClientTool[] {
   return buildClientToolsFromSnapshot(
     withDynamicMessageChannelCache(toolRegistry),
-    getExternalToolsRegistry(),
+    toModelFacingExternalToolMap(
+      filterExternalToolsByRuntimeContext(getExternalToolsRegistry(), {}),
+    ),
     getAvailableModToolsRegistry(),
   );
 }
@@ -1100,15 +1122,17 @@ function capturePreparedToolExecutionContext(
   }
   const executionSnapshot: ToolExecutionContextSnapshot = {
     toolRegistry: withDynamicMessageChannelCache(snapshot.toolRegistry),
-    externalTools: filterExternalToolsByClientAllowlist(
-      filterExternalToolsByScopeIds(
-        filterExternalToolsByRuntimeContext(
-          snapshot.externalTools,
-          runtimeContext,
+    externalTools: toModelFacingExternalToolMap(
+      filterExternalToolsByClientAllowlist(
+        filterExternalToolsByScopeIds(
+          filterExternalToolsByRuntimeContext(
+            snapshot.externalTools,
+            runtimeContext,
+          ),
+          options?.externalToolScopeIds,
         ),
-        options?.externalToolScopeIds,
+        options?.clientToolAllowlist,
       ),
-      options?.clientToolAllowlist,
     ),
     externalExecutor: snapshot.externalExecutor,
     modEvents: options?.modEvents ?? snapshot.modEvents,

--- a/src/tools/tool-execution-context.test.ts
+++ b/src/tools/tool-execution-context.test.ts
@@ -409,6 +409,78 @@ describe("tool execution context snapshot", () => {
     expect(prepared.clientTools).toEqual([]);
   });
 
+  test("runtime-owned external tools stay scoped to their runtime", async () => {
+    registerExternalTools([
+      {
+        name: "RemoteFoo",
+        description: "External tool for first runtime",
+        parameters: { type: "object", properties: {}, required: [] },
+        runtime: { agentId: "agent-1", conversationId: "conv-1" },
+      },
+      {
+        name: "RemoteBar",
+        description: "External tool for second runtime",
+        parameters: { type: "object", properties: {}, required: [] },
+        runtime: { agentId: "agent-1", conversationId: "conv-2" },
+      },
+    ]);
+
+    const prepared = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      {
+        clientToolAllowlist: ["RemoteFoo", "RemoteBar"],
+        runtimeContext: { agentId: "agent-1", conversationId: "conv-1" },
+      },
+    );
+
+    expect(prepared.loadedToolNames).toEqual([]);
+    expect(prepared.clientTools.map((tool) => tool.name)).toEqual([
+      "RemoteFoo",
+    ]);
+  });
+
+  test("scoped runtime external tools stay hidden unless selected", async () => {
+    registerExternalTools([
+      {
+        name: "AlwaysOnRemote",
+        description: "Unscoped runtime tool",
+        parameters: { type: "object", properties: {}, required: [] },
+        runtime: { agentId: "agent-1", conversationId: "conv-1" },
+      },
+      {
+        name: "ScopedRemote",
+        description: "Scoped runtime tool",
+        parameters: { type: "object", properties: {}, required: [] },
+        runtime: { agentId: "agent-1", conversationId: "conv-1" },
+        scopeId: "scope-1",
+      },
+    ]);
+
+    const base = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      {
+        clientToolAllowlist: ["AlwaysOnRemote", "ScopedRemote"],
+        runtimeContext: { agentId: "agent-1", conversationId: "conv-1" },
+      },
+    );
+    expect(base.clientTools.map((tool) => tool.name)).toEqual([
+      "AlwaysOnRemote",
+    ]);
+
+    const selected = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      {
+        clientToolAllowlist: ["AlwaysOnRemote", "ScopedRemote"],
+        externalToolScopeIds: ["scope-1"],
+        runtimeContext: { agentId: "agent-1", conversationId: "conv-1" },
+      },
+    );
+    expect(selected.clientTools.map((tool) => tool.name)).toEqual([
+      "AlwaysOnRemote",
+      "ScopedRemote",
+    ]);
+  });
+
   test("prepares and executes mod tools from turn snapshots", async () => {
     const controller = new AbortController();
     registerEchoModTool(controller.signal);

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -193,6 +193,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
   toolsetPreference: ToolsetPreference;
   exclude?: ToolName[];
   clientToolAllowlist?: string[];
+  externalToolScopeIds?: string[];
   workingDirectory?: string;
   permissionModeState?: PermissionModeState;
   channelToolScope?: MessageChannelToolDiscoveryScope | null;
@@ -205,6 +206,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
     toolsetPreference,
     exclude,
     clientToolAllowlist,
+    externalToolScopeIds,
     workingDirectory,
     permissionModeState,
     channelToolScope,
@@ -231,6 +233,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
           ? getGoalToolNamesForToolset(derivedToolset)
           : undefined,
         clientToolAllowlist,
+        externalToolScopeIds,
         workingDirectory,
         permissionModeState,
         channelToolScope,
@@ -262,6 +265,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
     ),
     {
       clientToolAllowlist,
+      externalToolScopeIds,
       workingDirectory,
       permissionModeState,
       channelToolScope,
@@ -430,6 +434,7 @@ export async function prepareToolExecutionContextForScope(params: {
   cachedEffectiveModel?: string | null;
   exclude?: ToolName[];
   clientToolAllowlist?: string[];
+  externalToolScopeIds?: string[];
   workingDirectory?: string;
   permissionModeState?: PermissionModeState;
   cachedAgent?: AgentState | null;
@@ -443,6 +448,7 @@ export async function prepareToolExecutionContextForScope(params: {
     cachedEffectiveModel,
     exclude,
     clientToolAllowlist,
+    externalToolScopeIds,
     workingDirectory,
     permissionModeState,
     cachedAgent,
@@ -505,6 +511,7 @@ export async function prepareToolExecutionContextForScope(params: {
     toolsetPreference,
     exclude,
     clientToolAllowlist,
+    externalToolScopeIds,
     workingDirectory,
     permissionModeState,
     modEvents,

--- a/src/types/app-server-protocol.test.ts
+++ b/src/types/app-server-protocol.test.ts
@@ -113,6 +113,15 @@ describe("app-server protocol export", () => {
         conversation: null,
         created: { agent: false, conversation: false },
       },
+      {
+        type: "external_tool_call_request",
+        request_id: "req",
+        runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+        scope_id: "scope-1",
+        tool_call_id: "call-1",
+        tool_name: "lookup_ticket",
+        input: { id: "ABC-123" },
+      },
     ] satisfies WsProtocolMessage[];
 
     expect(messages.map((message) => message.type)).toEqual([
@@ -134,6 +143,7 @@ describe("app-server protocol export", () => {
       "conversation_messages_list_response",
       "conversation_compact_response",
       "runtime_start_response",
+      "external_tool_call_request",
     ]);
   });
 });

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -700,6 +700,12 @@ export interface InputCreateMessagePayload {
    * client tools for this turn.
    */
   client_tool_allowlist?: string[];
+  /**
+   * Optional scoped external tools to expose for this turn. Runtime-start
+   * external tools with a scope_id stay hidden unless selected here; unscoped
+   * external tools for the runtime remain available normally.
+   */
+  external_tool_scope_ids?: string[];
 }
 
 export type InputApprovalResponsePayload = {
@@ -773,6 +779,19 @@ export interface RuntimeStartClientInfo {
   version?: string;
 }
 
+export interface ExternalToolDefinitionPayload {
+  name: string;
+  label?: string;
+  description: string;
+  parameters: Record<string, unknown>;
+}
+
+export interface RuntimeStartExternalToolsGroup {
+  /** Hidden controller-defined scope used to select these tools on input turns. */
+  scope_id?: string;
+  tools: readonly ExternalToolDefinitionPayload[];
+}
+
 export interface RuntimeStartCommand {
   type: "runtime_start";
   /** Echoed back in the response for request correlation. */
@@ -795,6 +814,37 @@ export interface RuntimeStartCommand {
   recover_approvals?: boolean;
   /** Force the initial state replay to include update_device_status. Defaults to true. */
   force_device_status?: boolean;
+  /** Controller-owned tools registered atomically with the resolved runtime. */
+  external_tools?: readonly RuntimeStartExternalToolsGroup[];
+}
+
+export interface ExternalToolCallRequestMessage {
+  type: "external_tool_call_request";
+  request_id: string;
+  runtime?: RuntimeScope;
+  scope_id?: string;
+  tool_call_id: string;
+  tool_name: string;
+  input: Record<string, unknown>;
+}
+
+export interface ExternalToolCallResultContent {
+  type: string;
+  text?: string;
+  data?: string;
+  mimeType?: string;
+}
+
+export interface ExternalToolCallResult {
+  content: readonly ExternalToolCallResultContent[];
+  is_error?: boolean;
+}
+
+export interface ExternalToolCallResponseCommand {
+  type: "external_tool_call_response";
+  request_id: string;
+  result?: ExternalToolCallResult;
+  error?: string;
 }
 
 export interface TerminalSpawnCommand {
@@ -2600,6 +2650,7 @@ export type WsProtocolCommand =
   | AbortMessageCommand
   | SyncCommand
   | RuntimeStartCommand
+  | ExternalToolCallResponseCommand
   | TerminalSpawnCommand
   | TerminalInputCommand
   | TerminalResizeCommand
@@ -2694,6 +2745,7 @@ export type WsProtocolMessage =
   | QueueUpdateMessage
   | StreamDeltaMessage
   | SubagentStateUpdateMessage
+  | ExternalToolCallRequestMessage
   | AbortMessageResponseMessage
   | SyncResponseMessage
   | TerminalOutputMessage

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -32,6 +32,10 @@ import {
   backgroundTasks,
 } from "@/tools/impl/process_manager";
 import { LIMITS } from "@/tools/impl/truncation";
+import {
+  clearExternalTools,
+  prepareToolExecutionContextForModel,
+} from "@/tools/manager";
 import type { ApprovalResponseBody, ControlRequest } from "@/types/protocol_v2";
 import {
   __listenClientTestUtils,
@@ -88,6 +92,7 @@ const actualChannelsService = await import("@/channels/service");
 
 afterEach(() => {
   __testSetBackend(null);
+  clearExternalTools();
   __listenClientTestUtils.setChannelsServiceLoaderForTests(null);
   mock.restore();
 });
@@ -684,6 +689,18 @@ describe("listen-client parseServerMessage", () => {
             request_id: "runtime-start-resume",
             agent_id: agent.id,
             conversation_id: conversation.id,
+            external_tools: [
+              {
+                scope_id: "scope-1",
+                tools: [
+                  {
+                    name: "RemoteLookup",
+                    description: "Lookup a remote resource",
+                    parameters: { type: "object", properties: {} },
+                  },
+                ],
+              },
+            ],
             recover_approvals: false,
           },
           socket as unknown as WebSocket,
@@ -702,6 +719,21 @@ describe("listen-client parseServerMessage", () => {
           conversation: { id: conversation.id },
           created: { agent: false, conversation: false },
         });
+
+        const prepared = await prepareToolExecutionContextForModel(
+          "anthropic/claude-sonnet-4",
+          {
+            clientToolAllowlist: ["RemoteLookup"],
+            externalToolScopeIds: ["scope-1"],
+            runtimeContext: {
+              agentId: agent.id,
+              conversationId: conversation.id,
+            },
+          },
+        );
+        expect(prepared.clientTools.map((tool) => tool.name)).toEqual([
+          "RemoteLookup",
+        ]);
       } finally {
         await rm(storageDir, { recursive: true, force: true });
       }
@@ -842,6 +874,7 @@ describe("listen-client parseServerMessage", () => {
             kind: "create_message",
             messages: [],
             client_tool_allowlist: ["Read", "Grep"],
+            external_tool_scope_ids: ["scope-1"],
           },
         }),
       ),
@@ -858,6 +891,7 @@ describe("listen-client parseServerMessage", () => {
     expect(msg?.type).toBe("input");
     if (msg?.type === "input" && msg.payload.kind === "create_message") {
       expect(msg.payload.client_tool_allowlist).toEqual(["Read", "Grep"]);
+      expect(msg.payload.external_tool_scope_ids).toEqual(["scope-1"]);
     }
     expect(changeDeviceState?.type).toBe("change_device_state");
   });
@@ -881,6 +915,30 @@ describe("listen-client parseServerMessage", () => {
     expect(parsed?.type).toBe("__invalid_input");
     if (parsed?.type === "__invalid_input") {
       expect(parsed.reason).toContain("client_tool_allowlist must be string[]");
+    }
+  });
+
+  test("rejects input create_message with invalid external tool scope ids", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "input",
+          runtime: { agent_id: "agent-1", conversation_id: "default" },
+          payload: {
+            kind: "create_message",
+            messages: [],
+            external_tool_scope_ids: ["scope-1", 42],
+          },
+        }),
+      ),
+    );
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.type).toBe("__invalid_input");
+    if (parsed?.type === "__invalid_input") {
+      expect(parsed.reason).toContain(
+        "external_tool_scope_ids must be string[]",
+      );
     }
   });
 

--- a/src/websocket/listener/commands/runtime-start.ts
+++ b/src/websocket/listener/commands/runtime-start.ts
@@ -18,6 +18,7 @@ import type {
   ConversationRuntime,
   ListenerRuntime,
 } from "@/websocket/listener/types";
+import { registerRuntimeExternalTools } from "../external-tools";
 import type {
   GetOrCreateScopedRuntime,
   RunDetachedListenerTask,
@@ -232,6 +233,11 @@ export async function handleRuntimeStartCommand(
       runtimeScope.conversation_id,
     );
     await applyRuntimeStartState(parsed, context, runtimeScope, scopedRuntime);
+    registerRuntimeExternalTools(
+      context.runtime,
+      runtimeScope,
+      parsed.external_tools ?? [],
+    );
 
     const sent = sendRuntimeStartResponse(context, parsed, {
       success: true,

--- a/src/websocket/listener/external-tools.test.ts
+++ b/src/websocket/listener/external-tools.test.ts
@@ -10,6 +10,7 @@ import {
   handleExternalToolCallResponseCommand,
   installExternalToolBridge,
   registerRuntimeExternalTools,
+  rejectPendingExternalToolCalls,
 } from "@/websocket/listener/external-tools";
 import type { ListenerRuntime } from "@/websocket/listener/types";
 
@@ -96,5 +97,139 @@ describe("app-server runtime_start external tool bridge", () => {
       tool_name: "RemoteLookup",
       input: { id: "ABC-123" },
     });
+  });
+
+  test("keeps same tool name and scope id isolated across runtimes", async () => {
+    const { runtime } = createMockRuntime();
+    registerRuntimeExternalTools(
+      runtime,
+      { agent_id: "agent-1", conversation_id: "conv-a" },
+      [
+        {
+          scope_id: "search",
+          tools: [
+            {
+              name: "lookup_ticket",
+              description: "Lookup ticket for conversation A",
+              parameters: { type: "object", properties: {} },
+            },
+          ],
+        },
+      ],
+    );
+    registerRuntimeExternalTools(
+      runtime,
+      { agent_id: "agent-1", conversation_id: "conv-b" },
+      [
+        {
+          scope_id: "search",
+          tools: [
+            {
+              name: "lookup_ticket",
+              description: "Lookup ticket for conversation B",
+              parameters: { type: "object", properties: {} },
+            },
+          ],
+        },
+      ],
+    );
+
+    const preparedA = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      {
+        clientToolAllowlist: ["lookup_ticket"],
+        externalToolScopeIds: ["search"],
+        runtimeContext: { agentId: "agent-1", conversationId: "conv-a" },
+      },
+    );
+    const preparedB = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      {
+        clientToolAllowlist: ["lookup_ticket"],
+        externalToolScopeIds: ["search"],
+        runtimeContext: { agentId: "agent-1", conversationId: "conv-b" },
+      },
+    );
+
+    expect(preparedA.clientTools).toEqual([
+      expect.objectContaining({
+        name: "lookup_ticket",
+        description: "Lookup ticket for conversation A",
+      }),
+    ]);
+    expect(preparedB.clientTools).toEqual([
+      expect.objectContaining({
+        name: "lookup_ticket",
+        description: "Lookup ticket for conversation B",
+      }),
+    ]);
+  });
+
+  test("repeated runtime_start registration replaces tools for that runtime", async () => {
+    const { runtime } = createMockRuntime();
+    const runtimeScope = { agent_id: "agent-1", conversation_id: "conv-1" };
+    registerRuntimeExternalTools(runtime, runtimeScope, [
+      {
+        tools: [
+          {
+            name: "old_tool",
+            description: "Old tool",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+      },
+    ]);
+    registerRuntimeExternalTools(runtime, runtimeScope, [
+      {
+        tools: [
+          {
+            name: "new_tool",
+            description: "New tool",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+      },
+    ]);
+
+    const prepared = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      {
+        clientToolAllowlist: ["old_tool", "new_tool"],
+        runtimeContext: { agentId: "agent-1", conversationId: "conv-1" },
+      },
+    );
+
+    expect(prepared.clientTools.map((tool) => tool.name)).toEqual(["new_tool"]);
+  });
+
+  test("runtime-owned external tools unregister when listener runtime stops", async () => {
+    const { runtime } = createMockRuntime();
+    registerRuntimeExternalTools(
+      runtime,
+      { agent_id: "agent-1", conversation_id: "conv-1" },
+      [
+        {
+          tools: [
+            {
+              name: "runtime_only",
+              description: "Runtime owned tool",
+              parameters: { type: "object", properties: {} },
+            },
+          ],
+        },
+      ],
+    );
+
+    rejectPendingExternalToolCalls(runtime, "stop");
+
+    const prepared = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      {
+        clientToolAllowlist: ["runtime_only"],
+        runtimeContext: { agentId: "agent-1", conversationId: "conv-1" },
+      },
+    );
+
+    expect(prepared.clientTools).toEqual([]);
   });
 });

--- a/src/websocket/listener/external-tools.test.ts
+++ b/src/websocket/listener/external-tools.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type WebSocket from "ws";
+import {
+  clearExternalTools,
+  executeTool,
+  prepareToolExecutionContextForModel,
+} from "@/tools/manager";
+import type { ExternalToolCallRequestMessage } from "@/types/protocol_v2";
+import {
+  handleExternalToolCallResponseCommand,
+  installExternalToolBridge,
+  registerRuntimeExternalTools,
+} from "@/websocket/listener/external-tools";
+import type { ListenerRuntime } from "@/websocket/listener/types";
+
+function createMockRuntime(): {
+  runtime: ListenerRuntime;
+  sent: ExternalToolCallRequestMessage[];
+} {
+  const sent: ExternalToolCallRequestMessage[] = [];
+  const runtime = {
+    intentionallyClosed: false,
+    pendingExternalToolCalls: new Map(),
+  } as unknown as ListenerRuntime;
+  runtime.socket = {
+    readyState: 1,
+    send(data: string) {
+      const request = JSON.parse(data) as ExternalToolCallRequestMessage;
+      sent.push(request);
+      queueMicrotask(() => {
+        handleExternalToolCallResponseCommand(runtime, {
+          type: "external_tool_call_response",
+          request_id: request.request_id,
+          result: {
+            content: [{ type: "text", text: `lookup:${request.input.id}` }],
+          },
+        });
+      });
+    },
+  } as unknown as WebSocket;
+  return { runtime, sent };
+}
+
+describe("app-server runtime_start external tool bridge", () => {
+  afterEach(() => {
+    clearExternalTools();
+  });
+
+  test("registers runtime-scoped tools and executes calls over the control socket", async () => {
+    const { runtime, sent } = createMockRuntime();
+    installExternalToolBridge(runtime);
+    registerRuntimeExternalTools(
+      runtime,
+      { agent_id: "agent-1", conversation_id: "conv-1" },
+      [
+        {
+          scope_id: "scope-1",
+          tools: [
+            {
+              name: "RemoteLookup",
+              description: "Lookup a remote resource",
+              parameters: {
+                type: "object",
+                properties: { id: { type: "string" } },
+                required: ["id"],
+              },
+            },
+          ],
+        },
+      ],
+    );
+
+    const prepared = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      {
+        clientToolAllowlist: ["RemoteLookup"],
+        externalToolScopeIds: ["scope-1"],
+        runtimeContext: { agentId: "agent-1", conversationId: "conv-1" },
+      },
+    );
+
+    const result = await executeTool(
+      "RemoteLookup",
+      { id: "ABC-123" },
+      { toolContextId: prepared.contextId, toolCallId: "call-1" },
+    );
+
+    expect(result.status).toBe("success");
+    expect(result.toolReturn).toBe("lookup:ABC-123");
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      type: "external_tool_call_request",
+      runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+      scope_id: "scope-1",
+      tool_call_id: "call-1",
+      tool_name: "RemoteLookup",
+      input: { id: "ABC-123" },
+    });
+  });
+});

--- a/src/websocket/listener/external-tools.ts
+++ b/src/websocket/listener/external-tools.ts
@@ -1,0 +1,202 @@
+import type WebSocket from "ws";
+import {
+  type ExternalToolDefinition,
+  registerExternalTools,
+  setExternalToolExecutor,
+  unregisterExternalTools,
+} from "@/tools/manager";
+import type {
+  ExternalToolCallRequestMessage,
+  ExternalToolCallResponseCommand,
+  ExternalToolDefinitionPayload,
+  RuntimeScope,
+  RuntimeStartExternalToolsGroup,
+} from "@/types/protocol_v2";
+import type { ListenerRuntime } from "@/websocket/listener/types";
+
+const EXTERNAL_TOOL_CALL_TIMEOUT_MS = 5 * 60 * 1000;
+const WEBSOCKET_OPEN = 1;
+
+const registeredToolsByRuntime = new WeakMap<
+  ListenerRuntime,
+  Map<string, ExternalToolDefinition[]>
+>();
+
+function isSocketOpen(socket: WebSocket | null): socket is WebSocket {
+  return socket?.readyState === WEBSOCKET_OPEN;
+}
+
+function getPendingExternalToolCalls(runtime: ListenerRuntime) {
+  runtime.pendingExternalToolCalls ??= new Map();
+  return runtime.pendingExternalToolCalls;
+}
+
+function getRegisteredTools(runtime: ListenerRuntime) {
+  let registeredTools = registeredToolsByRuntime.get(runtime);
+  if (!registeredTools) {
+    registeredTools = new Map();
+    registeredToolsByRuntime.set(runtime, registeredTools);
+  }
+  return registeredTools;
+}
+
+function getRuntimeKey(runtime: RuntimeScope): string {
+  return `${runtime.agent_id}:${runtime.conversation_id}`;
+}
+
+function toExternalToolDefinition(
+  tool: ExternalToolDefinitionPayload,
+  runtime: RuntimeScope,
+  scopeId?: string,
+): ExternalToolDefinition {
+  return {
+    name: tool.name,
+    ...(tool.label !== undefined ? { label: tool.label } : {}),
+    description: tool.description,
+    parameters: tool.parameters,
+    ...(scopeId !== undefined ? { scopeId } : {}),
+    runtime: {
+      agentId: runtime.agent_id,
+      conversationId: runtime.conversation_id,
+    },
+  };
+}
+
+function sendJson(socket: WebSocket, payload: unknown): void {
+  socket.send(JSON.stringify(payload));
+}
+
+export function installExternalToolBridge(runtime: ListenerRuntime): void {
+  setExternalToolExecutor(async (toolCallId, toolName, input, context) => {
+    const socket = runtime.socket;
+    if (!isSocketOpen(socket) || runtime.intentionallyClosed) {
+      throw new Error("External tool controller is not connected");
+    }
+
+    const requestId = `external-tool-${crypto.randomUUID()}`;
+    const toolRuntime = context?.tool.runtime;
+    const request: ExternalToolCallRequestMessage = {
+      type: "external_tool_call_request",
+      request_id: requestId,
+      ...(toolRuntime
+        ? {
+            runtime: {
+              agent_id: toolRuntime.agentId ?? "",
+              conversation_id: toolRuntime.conversationId ?? "default",
+            },
+          }
+        : {}),
+      ...(context?.tool.scopeId !== undefined
+        ? { scope_id: context.tool.scopeId }
+        : {}),
+      tool_call_id: toolCallId,
+      tool_name: toolName,
+      input,
+    };
+
+    const result = await new Promise<{
+      content: Array<{
+        type: string;
+        text?: string;
+        data?: string;
+        mimeType?: string;
+      }>;
+      isError: boolean;
+    }>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        getPendingExternalToolCalls(runtime).delete(requestId);
+        reject(new Error(`External tool call timed out: ${toolName}`));
+      }, EXTERNAL_TOOL_CALL_TIMEOUT_MS);
+
+      getPendingExternalToolCalls(runtime).set(requestId, {
+        resolve: (response) => {
+          resolve({
+            content: [...response.content],
+            isError: response.is_error === true,
+          });
+        },
+        reject,
+        timeout,
+      });
+
+      try {
+        sendJson(socket, request);
+      } catch (error) {
+        clearTimeout(timeout);
+        getPendingExternalToolCalls(runtime).delete(requestId);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+
+    return result;
+  });
+}
+
+export function registerRuntimeExternalTools(
+  runtime: ListenerRuntime,
+  runtimeScope: RuntimeScope,
+  groups: readonly RuntimeStartExternalToolsGroup[] = [],
+): void {
+  const registeredTools = getRegisteredTools(runtime);
+  const runtimeKey = getRuntimeKey(runtimeScope);
+  const previousTools = registeredTools.get(runtimeKey) ?? [];
+  unregisterExternalTools(previousTools);
+
+  const tools = groups.flatMap((group) =>
+    group.tools.map((tool) =>
+      toExternalToolDefinition(tool, runtimeScope, group.scope_id),
+    ),
+  );
+  if (tools.length > 0) {
+    registerExternalTools(tools);
+    registeredTools.set(runtimeKey, tools);
+  } else {
+    registeredTools.delete(runtimeKey);
+  }
+}
+
+export function handleExternalToolCallResponseCommand(
+  runtime: ListenerRuntime,
+  command: ExternalToolCallResponseCommand,
+): boolean {
+  const pending = getPendingExternalToolCalls(runtime).get(command.request_id);
+  if (!pending) {
+    return false;
+  }
+
+  clearTimeout(pending.timeout);
+  getPendingExternalToolCalls(runtime).delete(command.request_id);
+
+  if (command.error !== undefined) {
+    pending.reject(new Error(command.error));
+    return true;
+  }
+
+  if (command.result === undefined) {
+    pending.reject(new Error("External tool response missing result"));
+    return true;
+  }
+
+  pending.resolve(command.result);
+  return true;
+}
+
+export function rejectPendingExternalToolCalls(
+  runtime: ListenerRuntime,
+  reason: string,
+): void {
+  const pendingExternalToolCalls = getPendingExternalToolCalls(runtime);
+  for (const [requestId, pending] of pendingExternalToolCalls) {
+    clearTimeout(pending.timeout);
+    pendingExternalToolCalls.delete(requestId);
+    pending.reject(new Error(reason));
+  }
+
+  const registeredTools = registeredToolsByRuntime.get(runtime);
+  if (registeredTools) {
+    for (const tools of registeredTools.values()) {
+      unregisterExternalTools(tools);
+    }
+    registeredToolsByRuntime.delete(runtime);
+  }
+}

--- a/src/websocket/listener/external-tools.ts
+++ b/src/websocket/listener/external-tools.ts
@@ -44,6 +44,20 @@ function getRuntimeKey(runtime: RuntimeScope): string {
   return `${runtime.agent_id}:${runtime.conversation_id}`;
 }
 
+function getToolRegistrationKey(
+  runtime: RuntimeScope,
+  scopeId: string | undefined,
+  toolName: string,
+): string {
+  return JSON.stringify([
+    "runtime",
+    runtime.agent_id,
+    runtime.conversation_id,
+    scopeId ?? null,
+    toolName,
+  ]);
+}
+
 function toExternalToolDefinition(
   tool: ExternalToolDefinitionPayload,
   runtime: RuntimeScope,
@@ -54,6 +68,7 @@ function toExternalToolDefinition(
     ...(tool.label !== undefined ? { label: tool.label } : {}),
     description: tool.description,
     parameters: tool.parameters,
+    registrationKey: getToolRegistrationKey(runtime, scopeId, tool.name),
     ...(scopeId !== undefined ? { scopeId } : {}),
     runtime: {
       agentId: runtime.agent_id,
@@ -75,17 +90,17 @@ export function installExternalToolBridge(runtime: ListenerRuntime): void {
 
     const requestId = `external-tool-${crypto.randomUUID()}`;
     const toolRuntime = context?.tool.runtime;
+    const requestRuntime =
+      toolRuntime?.agentId && toolRuntime.conversationId
+        ? {
+            agent_id: toolRuntime.agentId,
+            conversation_id: toolRuntime.conversationId,
+          }
+        : undefined;
     const request: ExternalToolCallRequestMessage = {
       type: "external_tool_call_request",
       request_id: requestId,
-      ...(toolRuntime
-        ? {
-            runtime: {
-              agent_id: toolRuntime.agentId ?? "",
-              conversation_id: toolRuntime.conversationId ?? "default",
-            },
-          }
-        : {}),
+      ...(requestRuntime ? { runtime: requestRuntime } : {}),
       ...(context?.tool.scopeId !== undefined
         ? { scope_id: context.tool.scopeId }
         : {}),

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -55,6 +55,10 @@ import {
   getOrCreateScopedRuntime,
 } from "./conversation-runtime";
 import { loadPersistedCwdMap } from "./cwd";
+import {
+  installExternalToolBridge,
+  rejectPendingExternalToolCalls,
+} from "./external-tools";
 import { createFileCommandSession } from "./file-commands";
 import { createListenerMessageHandler } from "./message-router";
 import {
@@ -786,6 +790,7 @@ export function createRuntime(): ListenerRuntime {
     secretsHydrationByAgent: new Map(),
     secretsHydrationFreshnessByAgent: new Map(),
     secretsDirtyAgents: new Set(),
+    pendingExternalToolCalls: new Map(),
     agentMetadataByAgent: new Map(),
     lastEmittedStatus: null,
   };
@@ -796,6 +801,7 @@ export function stopRuntime(
   suppressCallbacks: boolean,
 ): void {
   disposeListenerModAdapter(runtime);
+  rejectPendingExternalToolCalls(runtime, "Listener runtime stopped");
   setMessageQueueAdder(null); // Clear bridge for ALL stop paths
   runtime.intentionallyClosed = true;
   clearRuntimeTimers(runtime);
@@ -1067,6 +1073,7 @@ export async function attachOpenListenerSocket(
 
   runtime.socket = socket;
   runtime.streamSocket = streamSocket;
+  installExternalToolBridge(runtime);
   const transport = socket;
   const processQueuedTurn: ProcessQueuedTurn = async (
     queuedTurn: IncomingMessage,

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -34,6 +34,7 @@ import { handleRuntimeStartProtocolCommand } from "./commands/runtime-start";
 import { handleSecretsCommand } from "./commands/secrets";
 import { handleSettingsProtocolCommand } from "./commands/settings";
 import { handleSkillAgentProtocolCommand } from "./commands/skills-agents";
+import { handleExternalToolCallResponseCommand } from "./external-tools";
 import {
   isExecuteCommandCommand,
   parseServerLifecycleMessage,
@@ -243,6 +244,11 @@ export function createListenerMessageHandler(
         return;
       }
 
+      if (parsed.type === "external_tool_call_response") {
+        handleExternalToolCallResponseCommand(runtime, parsed);
+        return;
+      }
+
       if (parsed.type === "sync") {
         console.log(
           `[Listen V2] Received sync command for runtime=${parsed.runtime.agent_id}/${parsed.runtime.conversation_id}`,
@@ -348,6 +354,7 @@ export function createListenerMessageHandler(
           agentId: parsed.runtime.agent_id,
           conversationId: parsed.runtime.conversation_id,
           clientToolAllowlist: inputPayload.client_tool_allowlist,
+          externalToolScopeIds: inputPayload.external_tool_scope_ids,
           messages: inputPayload.messages,
         };
         const hasApprovalPayload = incoming.messages.some(

--- a/src/websocket/listener/protocol-inbound.test.ts
+++ b/src/websocket/listener/protocol-inbound.test.ts
@@ -30,6 +30,23 @@ describe("agent/conversation management protocol-inbound validators", () => {
       cwd: "/tmp/project",
       mode: "acceptEdits",
       client_info: { name: "test", title: "Test", version: "1.0.0" },
+      external_tools: [
+        {
+          scope_id: "scope-1",
+          tools: [
+            {
+              name: "lookup_ticket",
+              description: "Lookup a ticket",
+              parameters: { type: "object", properties: {} },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: "external_tool_call_response",
+      request_id: "ext-1",
+      result: { content: [{ type: "text", text: "ok" }] },
     },
     { type: "agent_list", request_id: "r1", query: { limit: 10 } },
     { type: "agent_retrieve", request_id: "r2", agent_id: "agent-1" },
@@ -110,6 +127,17 @@ describe("agent/conversation management protocol-inbound validators", () => {
       request_id: "r0",
       agent_id: "agent-1",
       client_info: { title: "missing name" },
+    },
+    {
+      type: "runtime_start",
+      request_id: "r0",
+      agent_id: "agent-1",
+      external_tools: [{ tools: [{ name: "bad" }] }],
+    },
+    {
+      type: "external_tool_call_response",
+      request_id: "ext-1",
+      result: { content: "not-array" },
     },
     { type: "agent_list", request_id: "r1", query: "bad" },
     { type: "agent_retrieve", request_id: "r2" },

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -54,6 +54,7 @@ import type {
   EditFileCommand,
   EnableMemfsCommand,
   ExecuteCommandCommand,
+  ExternalToolCallResponseCommand,
   FileOpsCommand,
   GetCwdMapCommand,
   GetExperimentsCommand,
@@ -167,6 +168,7 @@ function isInputCommand(value: unknown): value is InputCommand {
     kind?: unknown;
     messages?: unknown;
     client_tool_allowlist?: unknown;
+    external_tool_scope_ids?: unknown;
     request_id?: unknown;
     decision?: unknown;
     error?: unknown;
@@ -175,7 +177,9 @@ function isInputCommand(value: unknown): value is InputCommand {
     return (
       Array.isArray(payload.messages) &&
       (payload.client_tool_allowlist === undefined ||
-        isStringArray(payload.client_tool_allowlist))
+        isStringArray(payload.client_tool_allowlist)) &&
+      (payload.external_tool_scope_ids === undefined ||
+        isStringArray(payload.external_tool_scope_ids))
     );
   }
   if (payload.kind === "approval_response") {
@@ -209,6 +213,7 @@ function getInvalidInputReason(value: unknown): {
     kind?: unknown;
     messages?: unknown;
     client_tool_allowlist?: unknown;
+    external_tool_scope_ids?: unknown;
     request_id?: unknown;
     decision?: unknown;
     error?: unknown;
@@ -229,6 +234,16 @@ function getInvalidInputReason(value: unknown): {
         runtime: candidate.runtime,
         reason:
           "Protocol violation: input.payload.client_tool_allowlist must be string[]",
+      };
+    }
+    if (
+      payload.external_tool_scope_ids !== undefined &&
+      !isStringArray(payload.external_tool_scope_ids)
+    ) {
+      return {
+        runtime: candidate.runtime,
+        reason:
+          "Protocol violation: input.payload.external_tool_scope_ids must be string[]",
       };
     }
     return null;
@@ -369,6 +384,25 @@ function isRuntimeStartClientInfo(value: unknown): boolean {
   );
 }
 
+function isExternalToolDefinitionPayload(value: unknown): boolean {
+  if (!isObjectRecord(value)) return false;
+  return (
+    typeof value.name === "string" &&
+    (value.label === undefined || typeof value.label === "string") &&
+    typeof value.description === "string" &&
+    isObjectRecord(value.parameters)
+  );
+}
+
+function isRuntimeStartExternalToolsGroup(value: unknown): boolean {
+  if (!isObjectRecord(value)) return false;
+  return (
+    (value.scope_id === undefined || typeof value.scope_id === "string") &&
+    Array.isArray(value.tools) &&
+    value.tools.every(isExternalToolDefinitionPayload)
+  );
+}
+
 export function isRuntimeStartCommand(
   value: unknown,
 ): value is RuntimeStartCommand {
@@ -385,6 +419,7 @@ export function isRuntimeStartCommand(
     client_info?: unknown;
     recover_approvals?: unknown;
     force_device_status?: unknown;
+    external_tools?: unknown;
   };
   return (
     c.type === "runtime_start" &&
@@ -402,7 +437,37 @@ export function isRuntimeStartCommand(
     (c.recover_approvals === undefined ||
       typeof c.recover_approvals === "boolean") &&
     (c.force_device_status === undefined ||
-      typeof c.force_device_status === "boolean")
+      typeof c.force_device_status === "boolean") &&
+    (c.external_tools === undefined ||
+      (Array.isArray(c.external_tools) &&
+        c.external_tools.every(isRuntimeStartExternalToolsGroup)))
+  );
+}
+
+export function isExternalToolCallResponseCommand(
+  value: unknown,
+): value is ExternalToolCallResponseCommand {
+  if (!isObjectRecord(value)) return false;
+  if (
+    value.type !== "external_tool_call_response" ||
+    typeof value.request_id !== "string"
+  ) {
+    return false;
+  }
+  if (value.error !== undefined && typeof value.error !== "string") {
+    return false;
+  }
+  if (value.result === undefined) {
+    return typeof value.error === "string";
+  }
+  if (!isObjectRecord(value.result)) {
+    return false;
+  }
+  return (
+    Array.isArray(value.result.content) &&
+    value.result.content.every(isObjectRecord) &&
+    (value.result.is_error === undefined ||
+      typeof value.result.is_error === "boolean")
   );
 }
 
@@ -2075,6 +2140,7 @@ export function parseServerMessage(
       isAbortMessageCommand(parsed) ||
       isSyncCommand(parsed) ||
       isRuntimeStartCommand(parsed) ||
+      isExternalToolCallResponseCommand(parsed) ||
       isTerminalSpawnCommand(parsed) ||
       isTerminalInputCommand(parsed) ||
       isTerminalResizeCommand(parsed) ||

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -624,6 +624,7 @@ export async function handleIncomingMessage(
       agentId,
       conversationId,
       clientToolAllowlist: msg.clientToolAllowlist,
+      externalToolScopeIds: msg.externalToolScopeIds,
       workingDirectory: turnWorkingDirectory,
       permissionModeState: turnPermissionModeState,
       cachedAgent,

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -21,6 +21,7 @@ import type { ToolsetName, ToolsetPreference } from "@/tools/toolset";
 import type {
   ApprovalResponseBody,
   ControlRequest,
+  ExternalToolCallResult,
   LoopStatus,
   RuntimeScope,
   WsProtocolCommand,
@@ -61,6 +62,7 @@ export interface IncomingMessage {
   conversationId?: string;
   channelTurnSources?: ChannelTurnSource[];
   clientToolAllowlist?: string[];
+  externalToolScopeIds?: string[];
   messages: Array<
     (MessageCreate & { client_message_id?: string }) | ApprovalCreate
   >;
@@ -79,6 +81,12 @@ export type ProcessQueuedTurn = (
   queuedTurn: IncomingMessage,
   dequeuedBatch: DequeuedBatch,
 ) => Promise<void>;
+
+export interface PendingExternalToolCall {
+  resolve: (result: ExternalToolCallResult) => void;
+  reject: (error: Error) => void;
+  timeout: ReturnType<typeof setTimeout>;
+}
 
 export interface ModeChangePayload {
   mode: "standard" | "acceptEdits" | "memory" | "unrestricted";
@@ -225,6 +233,7 @@ export type ListenerRuntime = {
   secretsHydrationFreshnessByAgent: Map<string, number>;
   /** Agent IDs whose cached secrets are stale and must re-fetch on the next hydration call. */
   secretsDirtyAgents: Set<string>;
+  pendingExternalToolCalls?: Map<string, PendingExternalToolCall>;
   /**
    * Agent metadata warmups for listen-mode reminders. The cached promise is
    * reused while the listener stays connected so first-turn reminders can join


### PR DESCRIPTION
## Summary
- add `runtime_start.external_tools` so app-server controllers can register external tools atomically with runtime startup
- keep `external_tool_scope_ids` for per-turn scoped exposure
- add control-channel `external_tool_call_request` / `external_tool_call_response` callback flow
- bind runtime-start tools to the resolved runtime scope so they do not leak across conversations
- store runtime-owned tools under namespaced internal registration keys, then collapse to model-facing tool names after runtime/scope filtering

## Comparison with #2857
This is the runtime_start-shaped alternative to #2857. It intentionally does not add `external_tools_register` / `external_tools_register_response`; tools are registered during `runtime_start` after agent/conversation resolution.

## MVP note
Duplicate model-facing tool names inside the same resolved runtime are not validated yet. If a runtime exposes the same tool name more than once, the later visible registration wins when building the model-facing tool map. Cross-runtime duplicate names are isolated by namespaced internal registration keys.

## Tests
- bun run check
- bun test src/websocket/listener/external-tools.test.ts src/tools/tool-execution-context.test.ts src/websocket/listener/protocol-inbound.test.ts src/websocket/listen-client-protocol.test.ts src/app-server-client.test.ts src/types/app-server-protocol.test.ts