### PR TITLE
fix(connect): handle OAuth login-method selection in local backend connect

### DIFF
--- a/src/cli/commands/connect-local-oauth.test.ts
+++ b/src/cli/commands/connect-local-oauth.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { OAuthSelectPrompt } from "@earendil-works/pi-ai/oauth";
+import {
+  clearRegisteredPiProviders,
+  type PiProviderOAuthLoginCallbacks,
+  registerPiProvider,
+} from "@/backend/dev/pi-provider-mod-registry";
+import { runLocalOAuthConnectFlow } from "@/cli/commands/connect-local-oauth";
+import type { ByokProvider } from "@/providers/byok-providers";
+
+const FAKE_PROVIDER_ID = "fake-select-oauth";
+
+const FAKE_BYOK_PROVIDER: ByokProvider = {
+  id: FAKE_PROVIDER_ID,
+  displayName: "Fake Select OAuth",
+  description: "Fake OAuth provider for tests",
+  providerType: FAKE_PROVIDER_ID,
+  providerName: FAKE_PROVIDER_ID,
+  isOAuth: true,
+  oauthProviderId: FAKE_PROVIDER_ID,
+};
+
+const SELECT_PROMPT: OAuthSelectPrompt = {
+  message: "Select login method:",
+  options: [
+    { id: "browser", label: "Browser login (default)" },
+    { id: "device_code", label: "Device code login (headless)" },
+  ],
+};
+
+describe("runLocalOAuthConnectFlow select prompts", () => {
+  let storageDir: string;
+  let previousStorageDir: string | undefined;
+  let selectedMethod: string | undefined;
+
+  beforeEach(async () => {
+    storageDir = await mkdtemp(join(tmpdir(), "letta-local-oauth-test-"));
+    previousStorageDir = process.env.LETTA_LOCAL_BACKEND_DIR;
+    process.env.LETTA_LOCAL_BACKEND_DIR = storageDir;
+    selectedMethod = undefined;
+
+    registerPiProvider(FAKE_PROVIDER_ID, {
+      name: "Fake Select OAuth",
+      description: "Fake OAuth provider for tests",
+      baseUrl: "https://fake-select-oauth.test/v1",
+      api: "openai-completions",
+      oauth: {
+        name: "Fake Select OAuth",
+        login: async (callbacks: PiProviderOAuthLoginCallbacks) => {
+          const method = await callbacks.onSelect(SELECT_PROMPT);
+          if (!method) throw new Error("Login cancelled");
+          selectedMethod = method;
+          return {
+            access: "fake-access",
+            refresh: "fake-refresh",
+            expires: Date.now() + 60_000,
+          };
+        },
+        refreshToken: async (credentials) => credentials,
+        getApiKey: (credentials) => String(credentials.access),
+      },
+      models: [
+        {
+          id: "fake-model",
+          name: "Fake Model",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 128000,
+          maxTokens: 8192,
+        },
+      ],
+    });
+  });
+
+  afterEach(async () => {
+    clearRegisteredPiProviders();
+    if (previousStorageDir === undefined) {
+      delete process.env.LETTA_LOCAL_BACKEND_DIR;
+    } else {
+      process.env.LETTA_LOCAL_BACKEND_DIR = previousStorageDir;
+    }
+    await rm(storageDir, { recursive: true, force: true });
+  });
+
+  test("auto-selects the first (default) option when no onSelect is provided", async () => {
+    const result = await runLocalOAuthConnectFlow(FAKE_BYOK_PROVIDER, {
+      onStatus: () => {},
+      openBrowser: async () => {},
+    });
+
+    expect(selectedMethod).toBe("browser");
+    expect(result.providerName).toBe(FAKE_PROVIDER_ID);
+  });
+
+  test("uses the caller-provided onSelect when available", async () => {
+    const result = await runLocalOAuthConnectFlow(FAKE_BYOK_PROVIDER, {
+      onStatus: () => {},
+      openBrowser: async () => {},
+      onSelect: async (prompt) => {
+        expect(prompt.message).toBe("Select login method:");
+        return "device_code";
+      },
+    });
+
+    expect(selectedMethod).toBe("device_code");
+    expect(result.providerName).toBe(FAKE_PROVIDER_ID);
+  });
+});

--- a/src/cli/commands/connect-local-oauth.ts
+++ b/src/cli/commands/connect-local-oauth.ts
@@ -1,6 +1,7 @@
 import {
   getOAuthProvider,
   type OAuthPrompt,
+  type OAuthSelectPrompt,
 } from "@earendil-works/pi-ai/oauth";
 import {
   localOAuthAuthFromCredentials,
@@ -12,6 +13,8 @@ import { openOAuthBrowser } from "./connect-oauth-core";
 export interface LocalOAuthConnectCallbacks {
   onStatus: (message: string) => void | Promise<void>;
   onPrompt?: (prompt: OAuthPrompt) => Promise<string>;
+  /** Answer a selection prompt (e.g. OpenAI Codex login method) with an option id. */
+  onSelect?: (prompt: OAuthSelectPrompt) => Promise<string | undefined>;
   openBrowser?: (authorizationUrl: string) => Promise<void>;
   signal?: AbortSignal;
 }
@@ -35,6 +38,14 @@ async function defaultPrompt(
 ): Promise<string> {
   if (prompt.allowEmpty) return "";
   throw new Error(`${providerName} requires input: ${prompt.message}`);
+}
+
+async function defaultSelect(
+  prompt: OAuthSelectPrompt,
+): Promise<string | undefined> {
+  // pi-ai providers list their default option first (e.g. OpenAI Codex
+  // browser login), so auto-select it when the caller has no selection UI.
+  return prompt.options[0]?.id;
 }
 
 export async function runLocalOAuthConnectFlow(
@@ -67,12 +78,7 @@ export async function runLocalOAuthConnectFlow(
     onProgress: (message) => {
       void Promise.resolve(callbacks.onStatus(message));
     },
-    onSelect: async (prompt) => {
-      if (prompt.options.length === 1) return prompt.options[0]?.id;
-      throw new Error(
-        `${oauthProvider.name} requires selection: ${prompt.message}`,
-      );
-    },
+    onSelect: (prompt) => callbacks.onSelect?.(prompt) ?? defaultSelect(prompt),
   } as Parameters<typeof oauthProvider.login>[0] & {
     onDeviceCode?: (info: OAuthDeviceCodeInfo) => void;
   };

--- a/src/cli/subcommands/connect.test.ts
+++ b/src/cli/subcommands/connect.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { OAuthSelectPrompt } from "@earendil-works/pi-ai/oauth";
 import { __testSetBackend, type Backend } from "@/backend";
+import type { LocalOAuthConnectCallbacks } from "@/cli/commands/connect-local-oauth";
 import { runConnectSubcommand } from "@/cli/subcommands/connect";
 
 function setProviderTarget(target: "api" | "local") {
@@ -288,6 +290,72 @@ describe("connect subcommand", () => {
       undefined,
       { baseURL: "http://localhost:8000/v1" },
     );
+  });
+
+  const CODEX_LOGIN_SELECT_PROMPT: OAuthSelectPrompt = {
+    message: "Select OpenAI Codex login method:",
+    options: [
+      { id: "browser", label: "Browser login (default)" },
+      { id: "device_code", label: "Device code login (headless)" },
+    ],
+  };
+
+  function createLocalOAuthFlowMock() {
+    const selections: (string | undefined)[] = [];
+    const runLocalOAuthConnectFlow = mock(
+      async (_provider: unknown, callbacks: LocalOAuthConnectCallbacks) => {
+        selections.push(await callbacks.onSelect?.(CODEX_LOGIN_SELECT_PROMPT));
+        return { providerName: "chatgpt-plus-pro" };
+      },
+    );
+    return { selections, runLocalOAuthConnectFlow };
+  }
+
+  test("local codex connect defaults to the first login method option", async () => {
+    const { stdout, deps } = createIoDeps();
+    setProviderTarget("local");
+    const { selections, runLocalOAuthConnectFlow } = createLocalOAuthFlowMock();
+
+    const exitCode = await runConnectSubcommand(["codex"], {
+      ...deps,
+      runLocalOAuthConnectFlow,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(runLocalOAuthConnectFlow).toHaveBeenCalledTimes(1);
+    expect(selections).toEqual(["browser"]);
+    expect(stdout.join("\n")).toContain("Successfully connected");
+  });
+
+  test("local codex connect honors --method device-code", async () => {
+    const { deps } = createIoDeps();
+    setProviderTarget("local");
+    const { selections, runLocalOAuthConnectFlow } = createLocalOAuthFlowMock();
+
+    const exitCode = await runConnectSubcommand(
+      ["codex", "--method", "device-code"],
+      { ...deps, runLocalOAuthConnectFlow },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(selections).toEqual(["device_code"]);
+  });
+
+  test("local codex connect rejects unknown --method values", async () => {
+    const { stderr, deps } = createIoDeps();
+    setProviderTarget("local");
+    const { runLocalOAuthConnectFlow } = createLocalOAuthFlowMock();
+
+    const exitCode = await runConnectSubcommand(
+      ["codex", "--method", "carrier-pigeon"],
+      { ...deps, runLocalOAuthConnectFlow },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stderr.join("\n")).toContain(
+      "Unknown ChatGPT Plus/Pro (Codex Subscription) login method: carrier-pigeon",
+    );
+    expect(stderr.join("\n")).toContain("Available: browser, device_code");
   });
 
   test("validates bedrock iam required flags", async () => {

--- a/src/cli/subcommands/connect.ts
+++ b/src/cli/subcommands/connect.ts
@@ -110,6 +110,7 @@ function formatUsage(): string {
     "Examples:",
     "  letta connect chatgpt",
     "  letta connect codex",
+    "  letta connect codex --method device-code",
     "  letta connect anthropic <api_key>",
     "  letta connect openai --api-key <api_key>",
     "  letta connect lmstudio --base-url http://127.0.0.1:1234/v1 --timeout 600s",
@@ -137,6 +138,10 @@ function connectionOptionsFromArgs(
 
 function hasConnectionOptions(options: ProviderConnectionOptions): boolean {
   return options.baseURL !== undefined || options.timeout !== undefined;
+}
+
+function normalizeOAuthLoginMethod(value: string): string {
+  return value.trim().toLowerCase().replace(/-/g, "_");
 }
 
 function formatBedrockUsage(): string {
@@ -241,6 +246,7 @@ export async function runConnectSubcommand(
         return 0;
       }
 
+      const loginMethod = readStringOption(parsed.values.method);
       await io.runLocalOAuthConnectFlow(provider.byokProvider, {
         onStatus: (status) => io.stdout(status),
         onPrompt: async (prompt) => {
@@ -253,6 +259,22 @@ export async function runConnectSubcommand(
           return io.promptSecret(
             `${prompt.message}${prompt.placeholder ? ` (${prompt.placeholder})` : ""}: `,
           );
+        },
+        onSelect: async (prompt) => {
+          if (loginMethod) {
+            const normalized = normalizeOAuthLoginMethod(loginMethod);
+            const match = prompt.options.find(
+              (option) => normalizeOAuthLoginMethod(option.id) === normalized,
+            );
+            if (!match) {
+              throw new Error(
+                `Unknown ${provider.byokProvider.displayName} login method: ${loginMethod}. Available: ${prompt.options.map((option) => option.id).join(", ")}`,
+              );
+            }
+            return match.id;
+          }
+          // Default to the provider's first (default) option, e.g. browser login.
+          return prompt.options[0]?.id;
         },
       });
 


### PR DESCRIPTION
## Summary

pi-ai 0.79.1 added a login-method selection prompt (browser vs device code) to the `openai-codex` OAuth provider, but `runLocalOAuthConnectFlow` threw on any multi-option `onSelect` prompt, so local `/connect chatgpt` and `letta connect codex` failed with "requires selection" before OAuth could start.

- Default to the provider's first (default) option — browser login for Codex — restoring pre-0.79 behavior for the TUI flow
- Add optional `onSelect` to `LocalOAuthConnectCallbacks` for callers with selection UI
- `letta connect codex --method device-code` selects the headless device-code login explicitly (reuses the existing `--method` flag); unknown methods fail with the available options listed

Verified live: `letta connect codex --method device-code --backend local` against a temp storage dir got past the selection and received a real device code from OpenAI before being cancelled.

Fixes #2818

👾 Generated with [Letta Code](https://letta.com)