### PR TITLE
feat(models): add Kimi K2.7 Code

### DIFF
--- a/src/agent/model-tier-selection.test.ts
+++ b/src/agent/model-tier-selection.test.ts
@@ -53,6 +53,17 @@ describe("getModelInfo", () => {
       parallel_tool_calls: true,
     });
   });
+
+  test("resolves Kimi K2.7 Code registry metadata", () => {
+    const info = getModelInfo("kimi-k2.7-code");
+    expect(info?.handle).toBe("moonshot/kimi-k2.7-code");
+    expect(info?.label).toBe("Kimi K2.7 Code");
+    expect(info?.updateArgs).toMatchObject({
+      context_window: 200000,
+      max_output_tokens: 32768,
+      parallel_tool_calls: true,
+    });
+  });
 });
 
 describe("getModelInfoForLlmConfig", () => {

--- a/src/models.json
+++ b/src/models.json
@@ -1659,6 +1659,18 @@
       }
     },
     {
+      "id": "kimi-k2.7-code",
+      "handle": "moonshot/kimi-k2.7-code",
+      "label": "Kimi K2.7 Code",
+      "description": "Moonshot AI's long-context coding and agent model",
+      "isFeatured": true,
+      "updateArgs": {
+        "context_window": 200000,
+        "max_output_tokens": 32768,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "deepseek-chat-v3.1",
       "handle": "openrouter/deepseek/deepseek-chat-v3.1",
       "label": "DeepSeek Chat V3.1",


### PR DESCRIPTION
## Summary

- Adds Kimi K2.7 Code to the Letta Code model registry with the Moonshot handle moonshot/kimi-k2.7-code.
- Uses the same conservative 200k Letta Code context cap as Kimi K2.6 and sets the official 32768 output-token default.
- Adds registry coverage so the new preset stays resolvable by id and handle metadata.

## Why

The companion Cloud/Core PR adds direct Moonshot provider metadata, pricing, and tool-choice handling for Kimi K2.7 Code. This PR makes the model selectable from Letta Code once a Moonshot provider is connected.

Cloud/Core companion: https://github.com/letta-ai/letta-cloud/pull/12280

## Validation

- bun test src/agent/model-tier-selection.test.ts src/tools/model-provider-detection.test.ts
- Pre-commit hook ran Biome and tsc --noEmit during commit
- git diff --check
