### PR TITLE
fix: seed context window on conversation carryover

### DIFF
--- a/src/agent/conversation-model-carryover.test.ts
+++ b/src/agent/conversation-model-carryover.test.ts
@@ -42,6 +42,24 @@ describe("conversation model carryover", () => {
     });
   });
 
+  test("uses centralized normalization for ChatGPT fast handles", () => {
+    const carryover = buildConversationModelCarryoverUpdate({
+      rawModelHandle: "chatgpt_oauth/gpt-5.5-fast",
+      currentLlmConfig: {
+        model: "gpt-5.5-fast",
+        model_endpoint_type: "chatgpt_oauth",
+        reasoning_effort: "high",
+      } as LlmConfig,
+      activeConversationContextWindowLimit: null,
+    });
+
+    expect(carryover?.modelHandle).toBe("chatgpt-plus-pro/gpt-5.5-fast");
+    expect(carryover?.updateArgs).toMatchObject({
+      reasoning_effort: "high",
+      context_window: 272000,
+    });
+  });
+
   test("does not copy stale llm_config context when the model preset is unknown", () => {
     const carryover = buildConversationModelCarryoverUpdate({
       rawModelHandle: "openai/custom-model",

--- a/src/agent/conversation-model-carryover.test.ts
+++ b/src/agent/conversation-model-carryover.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import type { LlmConfig } from "@letta-ai/letta-client/resources/models/models";
+import { buildConversationModelCarryoverUpdate } from "@/agent/conversation-model-carryover";
+
+describe("conversation model carryover", () => {
+  test("seeds new conversations with the model preset context window before stale llm_config", () => {
+    const carryover = buildConversationModelCarryoverUpdate({
+      rawModelHandle: "chatgpt_oauth/gpt-5.5",
+      currentLlmConfig: {
+        model: "gpt-5.5",
+        model_endpoint_type: "chatgpt_oauth",
+        reasoning_effort: "xhigh",
+        context_window: 128000,
+      } as LlmConfig,
+      activeConversationContextWindowLimit: null,
+    });
+
+    expect(carryover?.modelHandle).toBe("chatgpt-plus-pro/gpt-5.5");
+    expect(carryover?.updateArgs).toMatchObject({
+      reasoning_effort: "xhigh",
+      context_window: 272000,
+      max_output_tokens: 128000,
+      parallel_tool_calls: true,
+    });
+  });
+
+  test("preserves an explicit active conversation context window", () => {
+    const carryover = buildConversationModelCarryoverUpdate({
+      rawModelHandle: "chatgpt_oauth/gpt-5.5",
+      currentLlmConfig: {
+        model: "gpt-5.5",
+        model_endpoint_type: "chatgpt_oauth",
+        reasoning_effort: "xhigh",
+        context_window: 128000,
+      } as LlmConfig,
+      activeConversationContextWindowLimit: 100000,
+    });
+
+    expect(carryover?.updateArgs).toMatchObject({
+      reasoning_effort: "xhigh",
+      context_window: 100000,
+    });
+  });
+});

--- a/src/agent/conversation-model-carryover.test.ts
+++ b/src/agent/conversation-model-carryover.test.ts
@@ -41,4 +41,19 @@ describe("conversation model carryover", () => {
       context_window: 100000,
     });
   });
+
+  test("does not copy stale llm_config context when the model preset is unknown", () => {
+    const carryover = buildConversationModelCarryoverUpdate({
+      rawModelHandle: "openai/custom-model",
+      currentLlmConfig: {
+        model: "custom-model",
+        model_endpoint_type: "openai",
+        context_window: 128000,
+      } as LlmConfig,
+      activeConversationContextWindowLimit: null,
+    });
+
+    expect(carryover?.modelHandle).toBe("openai/custom-model");
+    expect(carryover?.updateArgs).toBeUndefined();
+  });
 });

--- a/src/agent/conversation-model-carryover.ts
+++ b/src/agent/conversation-model-carryover.ts
@@ -1,0 +1,81 @@
+import type { LlmConfig } from "@letta-ai/letta-client/resources/models/models";
+import {
+  getModelInfoForLlmConfig,
+  normalizeModelHandleForRegistry,
+} from "@/agent/model";
+import { OPENAI_CODEX_PROVIDER_NAME } from "@/providers/openai-codex-provider";
+
+type CarryoverLlmConfig = LlmConfig & {
+  enable_reasoner?: boolean | null;
+  service_tier?: string | null;
+};
+
+export function normalizeConversationModelCarryoverHandle(
+  rawModelHandle: string,
+): string {
+  const [provider, ...modelParts] = rawModelHandle.split("/");
+  if (provider === "chatgpt_oauth" && modelParts.length > 0) {
+    return `${OPENAI_CODEX_PROVIDER_NAME}/${modelParts.join("/")}`;
+  }
+  return normalizeModelHandleForRegistry(rawModelHandle) ?? rawModelHandle;
+}
+
+export function buildConversationModelCarryoverUpdate(params: {
+  rawModelHandle: string | null;
+  currentLlmConfig: LlmConfig | null;
+  activeConversationContextWindowLimit?: number | null;
+}): { modelHandle: string; updateArgs?: Record<string, unknown> } | null {
+  const { rawModelHandle, currentLlmConfig } = params;
+  if (!rawModelHandle) return null;
+
+  const modelHandle = normalizeConversationModelCarryoverHandle(rawModelHandle);
+  const carryoverLlmConfig = currentLlmConfig as CarryoverLlmConfig | null;
+  const activeConversationContextWindowLimit =
+    params.activeConversationContextWindowLimit;
+  const modelInfo = getModelInfoForLlmConfig(modelHandle, {
+    reasoning_effort: carryoverLlmConfig?.reasoning_effort ?? null,
+    enable_reasoner: carryoverLlmConfig?.enable_reasoner ?? null,
+    context_window:
+      typeof activeConversationContextWindowLimit === "number"
+        ? activeConversationContextWindowLimit
+        : null,
+    service_tier: carryoverLlmConfig?.service_tier ?? null,
+  });
+
+  const updateArgs: Record<string, unknown> = {
+    ...((modelInfo?.updateArgs as Record<string, unknown> | undefined) ?? {}),
+  };
+  const reasoningEffort = carryoverLlmConfig?.reasoning_effort;
+  if (
+    typeof reasoningEffort === "string" &&
+    updateArgs.reasoning_effort === undefined
+  ) {
+    updateArgs.reasoning_effort = reasoningEffort;
+  }
+  const enableReasoner = carryoverLlmConfig?.enable_reasoner;
+  if (
+    typeof enableReasoner === "boolean" &&
+    updateArgs.enable_reasoner === undefined
+  ) {
+    updateArgs.enable_reasoner = enableReasoner;
+  }
+
+  const modelPresetContextWindow = updateArgs.context_window;
+  const currentConfigContextWindow = carryoverLlmConfig?.context_window;
+  const contextWindow =
+    typeof activeConversationContextWindowLimit === "number"
+      ? activeConversationContextWindowLimit
+      : typeof modelPresetContextWindow === "number"
+        ? modelPresetContextWindow
+        : typeof currentConfigContextWindow === "number"
+          ? currentConfigContextWindow
+          : undefined;
+  if (typeof contextWindow === "number") {
+    updateArgs.context_window = contextWindow;
+  }
+
+  return {
+    modelHandle,
+    updateArgs: Object.keys(updateArgs).length > 0 ? updateArgs : undefined,
+  };
+}

--- a/src/agent/conversation-model-carryover.ts
+++ b/src/agent/conversation-model-carryover.ts
@@ -3,7 +3,6 @@ import {
   getModelInfoForLlmConfig,
   normalizeModelHandleForRegistry,
 } from "@/agent/model";
-import { OPENAI_CODEX_PROVIDER_NAME } from "@/providers/openai-codex-provider";
 
 type CarryoverLlmConfig = LlmConfig & {
   enable_reasoner?: boolean | null;
@@ -13,10 +12,6 @@ type CarryoverLlmConfig = LlmConfig & {
 export function normalizeConversationModelCarryoverHandle(
   rawModelHandle: string,
 ): string {
-  const [provider, ...modelParts] = rawModelHandle.split("/");
-  if (provider === "chatgpt_oauth" && modelParts.length > 0) {
-    return `${OPENAI_CODEX_PROVIDER_NAME}/${modelParts.join("/")}`;
-  }
   return normalizeModelHandleForRegistry(rawModelHandle) ?? rawModelHandle;
 }
 

--- a/src/agent/conversation-model-carryover.ts
+++ b/src/agent/conversation-model-carryover.ts
@@ -61,15 +61,12 @@ export function buildConversationModelCarryoverUpdate(params: {
   }
 
   const modelPresetContextWindow = updateArgs.context_window;
-  const currentConfigContextWindow = carryoverLlmConfig?.context_window;
   const contextWindow =
     typeof activeConversationContextWindowLimit === "number"
       ? activeConversationContextWindowLimit
       : typeof modelPresetContextWindow === "number"
         ? modelPresetContextWindow
-        : typeof currentConfigContextWindow === "number"
-          ? currentConfigContextWindow
-          : undefined;
+        : undefined;
   if (typeof contextWindow === "number") {
     updateArgs.context_window = contextWindow;
   }

--- a/src/agent/model.ts
+++ b/src/agent/model.ts
@@ -81,9 +81,11 @@ export function normalizeModelHandleForRegistry(
   if (!modelHandle) return null;
   const [provider, ...modelParts] = modelHandle.split("/");
   const model = modelParts.join("/");
+  if (provider === CHATGPT_OAUTH_LLM_CONFIG_PROVIDER && model.length > 0) {
+    return `${OPENAI_CODEX_PROVIDER_NAME}/${model}`;
+  }
   if (
-    (provider === CHATGPT_OAUTH_LLM_CONFIG_PROVIDER ||
-      provider === LOCAL_CHATGPT_OAUTH_HANDLE_PREFIX.slice(0, -1)) &&
+    provider === LOCAL_CHATGPT_OAUTH_HANDLE_PREFIX.slice(0, -1) &&
     model.length > 0 &&
     !model.endsWith("-fast")
   ) {

--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -275,7 +275,13 @@ function maxTokensForUpdatePayload(
  * @returns The updated agent state from the server (includes llm_config and model_settings)
  */
 export interface UpdateAgentLLMConfigOptions {
-  preserveContextWindow?: boolean;
+  /**
+   * When true, do not derive and send a default context_window_limit unless the
+   * caller explicitly supplied updateArgs.context_window. This is for updates to
+   * existing agent/conversation model settings where omitting the field lets the
+   * backend keep its current value.
+   */
+  avoidOverwritingExistingContextWindow?: boolean;
 }
 
 export async function updateAgentLLMConfig(
@@ -294,11 +300,12 @@ export async function updateAgentLLMConfig(
   const explicitContextWindow = useBackendModelCatalog
     ? undefined
     : (updateArgs?.context_window as number | undefined);
-  const shouldPreserveContextWindow = options?.preserveContextWindow === true;
+  const shouldAvoidOverwritingExistingContextWindow =
+    options?.avoidOverwritingExistingContextWindow === true;
   // Resume refresh updates should not implicitly reset context window.
   const contextWindow =
     explicitContextWindow ??
-    (!shouldPreserveContextWindow
+    (!shouldAvoidOverwritingExistingContextWindow
       ? await getModelContextWindow(modelHandle)
       : undefined);
   const hasModelSettings = Object.keys(modelSettings).length > 0;
@@ -346,10 +353,11 @@ export async function updateConversationLLMConfig(
   const explicitContextWindow = useBackendModelCatalog
     ? undefined
     : (updateArgs?.context_window as number | undefined);
-  const shouldPreserveContextWindow = options?.preserveContextWindow === true;
+  const shouldAvoidOverwritingExistingContextWindow =
+    options?.avoidOverwritingExistingContextWindow === true;
   const contextWindow =
     explicitContextWindow ??
-    (!shouldPreserveContextWindow
+    (!shouldAvoidOverwritingExistingContextWindow
       ? await getModelContextWindow(modelHandle)
       : undefined);
   const hasModelSettings = Object.keys(modelSettings).length > 0;

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -20,6 +20,7 @@ import { prefetchAvailableModelHandles } from "@/agent/available-models";
 import { getResumeDataFromBackend } from "@/agent/check-approval";
 import { setCurrentAgentId } from "@/agent/context";
 import { regenerateConversationDescription } from "@/agent/conversation-description";
+import { buildConversationModelCarryoverUpdate } from "@/agent/conversation-model-carryover";
 import { getScopedMemoryFilesystemRoot } from "@/agent/memory-filesystem";
 import {
   CHATGPT_FAST_SERVICE_TIER,
@@ -821,6 +822,13 @@ export function App({
     conversationOverrideContextWindowLimit,
     setConversationOverrideContextWindowLimit,
   ] = useState<number | null>(null);
+  const conversationOverrideContextWindowLimitRef = useRef(
+    conversationOverrideContextWindowLimit,
+  );
+  useEffect(() => {
+    conversationOverrideContextWindowLimitRef.current =
+      conversationOverrideContextWindowLimit;
+  }, [conversationOverrideContextWindowLimit]);
   const agentStateRef = useRef(agentState);
   useEffect(() => {
     agentStateRef.current = agentState;
@@ -3421,51 +3429,21 @@ export function App({
         return;
       }
 
-      // Keep provider naming aligned with model handles used by /model.
-      const [provider, ...modelParts] = rawModelHandle.split("/");
-      const modelHandle =
-        provider === "chatgpt_oauth" && modelParts.length > 0
-          ? `${OPENAI_CODEX_PROVIDER_NAME}/${modelParts.join("/")}`
-          : rawModelHandle;
-
-      const modelInfo = getModelInfoForLlmConfig(modelHandle, {
-        reasoning_effort: currentLlmConfig?.reasoning_effort ?? null,
-        enable_reasoner:
-          (currentLlmConfig as { enable_reasoner?: boolean | null } | null)
-            ?.enable_reasoner ?? null,
+      const carryover = buildConversationModelCarryoverUpdate({
+        rawModelHandle,
+        currentLlmConfig,
+        activeConversationContextWindowLimit:
+          conversationOverrideContextWindowLimitRef.current,
       });
-
-      const updateArgs: Record<string, unknown> = {
-        ...((modelInfo?.updateArgs as Record<string, unknown> | undefined) ??
-          {}),
-      };
-      const reasoningEffort = currentLlmConfig?.reasoning_effort;
-      if (
-        typeof reasoningEffort === "string" &&
-        updateArgs.reasoning_effort === undefined
-      ) {
-        updateArgs.reasoning_effort = reasoningEffort;
-      }
-      const enableReasoner = (
-        currentLlmConfig as { enable_reasoner?: boolean | null } | null
-      )?.enable_reasoner;
-      if (
-        typeof enableReasoner === "boolean" &&
-        updateArgs.enable_reasoner === undefined
-      ) {
-        updateArgs.enable_reasoner = enableReasoner;
-      }
-      if (typeof currentLlmConfig?.context_window === "number") {
-        updateArgs.context_window = currentLlmConfig.context_window;
-      }
+      if (!carryover) return;
 
       try {
         const { updateConversationLLMConfig } = await import("@/agent/modify");
         await updateConversationLLMConfig(
           targetConversationId,
-          modelHandle,
-          Object.keys(updateArgs).length > 0 ? updateArgs : undefined,
-          { preserveContextWindow: true },
+          carryover.modelHandle,
+          carryover.updateArgs,
+          { avoidOverwritingExistingContextWindow: false },
         );
       } catch (error) {
         debugWarn(

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -3443,7 +3443,7 @@ export function App({
           targetConversationId,
           carryover.modelHandle,
           carryover.updateArgs,
-          { avoidOverwritingExistingContextWindow: false },
+          { avoidOverwritingExistingContextWindow: true },
         );
       } catch (error) {
         debugWarn(

--- a/src/cli/app/use-configuration-handlers.ts
+++ b/src/cli/app/use-configuration-handlers.ts
@@ -439,7 +439,10 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
               agentIdRef.current,
               modelHandle,
               modelUpdateArgsForRequest,
-              { preserveContextWindow: shouldPreserveContextWindow },
+              {
+                avoidOverwritingExistingContextWindow:
+                  shouldPreserveContextWindow,
+              },
             );
             conversationModelSettings = updatedAgent?.model_settings;
           } else {
@@ -450,7 +453,10 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
               conversationIdRef.current,
               modelHandle,
               modelUpdateArgsForRequest,
-              { preserveContextWindow: shouldPreserveContextWindow },
+              {
+                avoidOverwritingExistingContextWindow:
+                  shouldPreserveContextWindow,
+              },
             );
             conversationModelSettings = (
               updatedConversation as {

--- a/src/cli/app/use-reasoning-cycle.ts
+++ b/src/cli/app/use-reasoning-cycle.ts
@@ -199,7 +199,7 @@ export function useReasoningCycle(ctx: ReasoningCycleContext) {
                   ? { service_tier: desired.serviceTier }
                   : {}),
               },
-              { preserveContextWindow: true },
+              { avoidOverwritingExistingContextWindow: true },
             );
           } else {
             const { updateConversationLLMConfig } = await import(
@@ -214,7 +214,7 @@ export function useReasoningCycle(ctx: ReasoningCycleContext) {
                   ? { service_tier: desired.serviceTier }
                   : {}),
               },
-              { preserveContextWindow: true },
+              { avoidOverwritingExistingContextWindow: true },
             );
             conversationModelSettings = (
               updatedConversation as {

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1337,7 +1337,7 @@ export async function handleHeadlessCommand(
             agent.id,
             presetRefresh.modelHandle,
             resumeRefreshUpdateArgs,
-            { preserveContextWindow: true },
+            { avoidOverwritingExistingContextWindow: true },
           );
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2565,7 +2565,7 @@ async function main(): Promise<void> {
                   agent.id,
                   presetRefresh.modelHandle,
                   resumeRefreshUpdateArgs,
-                  { preserveContextWindow: true },
+                  { avoidOverwritingExistingContextWindow: true },
                 );
               }
             }

--- a/src/websocket/listen-model-update.test.ts
+++ b/src/websocket/listen-model-update.test.ts
@@ -233,7 +233,7 @@ describe("listen-client applyModelUpdateForRuntime wiring", () => {
     // Conversation-scoped update for non-default
     expect(source).toContain("updateConversationLLMConfig(");
     expect(source).toContain(
-      "preserveContextWindow: shouldPreserveContextWindow",
+      "avoidOverwritingExistingContextWindow: shouldPreserveContextWindow",
     );
     expect(source).toContain('appliedTo = "conversation"');
   });

--- a/src/websocket/listener/commands/model-toolset.ts
+++ b/src/websocket/listener/commands/model-toolset.ts
@@ -333,7 +333,7 @@ export async function applyModelUpdateForRuntime(params: {
       agentId,
       model.handle,
       updateArgsForRequest,
-      { preserveContextWindow: shouldPreserveContextWindow },
+      { avoidOverwritingExistingContextWindow: shouldPreserveContextWindow },
     );
     modelSettings =
       (updatedAgent.model_settings as
@@ -346,7 +346,7 @@ export async function applyModelUpdateForRuntime(params: {
       conversationId,
       model.handle,
       updateArgsForRequest,
-      { preserveContextWindow: shouldPreserveContextWindow },
+      { avoidOverwritingExistingContextWindow: shouldPreserveContextWindow },
     );
     modelSettings =
       ((


### PR DESCRIPTION
## Summary
- Seed new conversation model carryover with an explicit context window when it is already known from the active conversation override or selected static model preset.
- Prevent stale agent `llm_config.context_window` from winning over model preset metadata during carryover.
- Avoid adding backend model-catalog reads for carryover; unknown presets omit `context_window_limit` rather than fetching or copying stale UI state.
- Rename `preserveContextWindow` to `avoidOverwritingExistingContextWindow` to reflect that the option omits the field so existing server state is not overwritten.

## Test plan
- `bun test src/agent/conversation-model-carryover.test.ts`
- `bun test src/websocket/listen-model-update.test.ts`
- `bun run typecheck`
- `bun run fix`
- `bun run check`