### PR TITLE
fix(resume): preserve selection when toggling pins

### DIFF
--- a/src/cli/components/ConversationSelector.tsx
+++ b/src/cli/components/ConversationSelector.tsx
@@ -54,7 +54,7 @@ interface EnrichedConversation {
   isPinnedLocal: boolean;
 }
 
-function isPinShortcut(
+export function isPinShortcut(
   input: string,
   key: { ctrl?: boolean; meta?: boolean },
 ): boolean {
@@ -96,6 +96,26 @@ export function buildConversationSelectorHints(params: {
   return params.isSelectedDefaultConversation
     ? "Enter select · ↑↓ navigate · Esc clear/cancel"
     : "Enter select · ↑↓ navigate · Alt+P pin/unpin · Esc clear/cancel";
+}
+
+export function normalizeConversationSearchInput(value: string): string {
+  return value.replace(/[π∏]/g, "");
+}
+
+export function findConversationIndexById<
+  T extends { conversation: { id: string } },
+>(items: T[], conversationId: string): number {
+  return items.findIndex((item) => item.conversation.id === conversationId);
+}
+
+export function sortPinnedConversations<
+  T extends { conversation: { id: string }; isPinned: boolean },
+>(items: T[]): T[] {
+  return [...items].sort((a, b) => {
+    if (a.conversation.id === "default") return -1;
+    if (b.conversation.id === "default") return 1;
+    return Number(b.isPinned) - Number(a.isPinned);
+  });
 }
 
 function paginatedItems<T>(value: T[] | { getPaginatedItems(): T[] }): T[] {
@@ -365,6 +385,7 @@ export function ConversationSelector({
   const [searching, setSearching] = useState(false);
   const [pinNotice, setPinNotice] = useState<string | null>(null);
   const pinNoticeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const preserveSelectionIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     return () => {
@@ -770,6 +791,20 @@ export function ConversationSelector({
       })()
     : conversations;
 
+  useEffect(() => {
+    const conversationId = preserveSelectionIdRef.current;
+    if (!conversationId) return;
+
+    preserveSelectionIdRef.current = null;
+    const nextSelectedIndex = findConversationIndexById(
+      filteredConversations,
+      conversationId,
+    );
+    if (nextSelectedIndex >= 0) {
+      setSelectedIndex(nextSelectedIndex);
+    }
+  }, [filteredConversations]);
+
   // Sliding window calculations (same interaction model as /search).
   const startIndex = Math.max(
     0,
@@ -823,6 +858,7 @@ export function ConversationSelector({
       } else {
         settingsManager.pinConversationGlobal(agentId, conversationId);
       }
+      preserveSelectionIdRef.current = conversationId;
       const updatePinState = (item: EnrichedConversation) =>
         item.conversation.id === conversationId
           ? {
@@ -831,16 +867,8 @@ export function ConversationSelector({
               isPinnedLocal: false,
             }
           : item;
-      const sortPinnedFirst = (
-        a: EnrichedConversation,
-        b: EnrichedConversation,
-      ) => {
-        if (a.conversation.id === "default") return -1;
-        if (b.conversation.id === "default") return 1;
-        return Number(b.isPinned) - Number(a.isPinned);
-      };
       setConversations((prev) =>
-        prev.map(updatePinState).sort(sortPinnedFirst),
+        sortPinnedConversations(prev.map(updatePinState)),
       );
       setSearchResults((prev) => prev?.map(updatePinState) ?? null);
     },
@@ -1049,7 +1077,9 @@ export function ConversationSelector({
         <PasteAwareTextInput
           value={searchInput}
           onChange={(value) => {
-            setSearchInput(value.replace(/[π∏]/g, ""));
+            const nextSearchInput = normalizeConversationSearchInput(value);
+            if (nextSearchInput === searchInput) return;
+            setSearchInput(nextSearchInput);
             setSelectedIndex(0);
           }}
           placeholder="search conversation titles"

--- a/src/cli/conversation-selector.test.ts
+++ b/src/cli/conversation-selector.test.ts
@@ -3,9 +3,13 @@ import type { Conversation } from "@letta-ai/letta-client/resources/conversation
 import {
   buildConversationSelectorHints,
   buildDefaultConversationEntry,
+  findConversationIndexById,
   formatConversationTimestampText,
   isConversationPinned,
+  isPinShortcut,
   mergePinnedConversationRecords,
+  normalizeConversationSearchInput,
+  sortPinnedConversations,
 } from "@/cli/components/ConversationSelector";
 
 describe("ConversationSelector timestamps", () => {
@@ -76,6 +80,41 @@ describe("ConversationSelector timestamps", () => {
 });
 
 describe("ConversationSelector pinned conversations", () => {
+  test("treats macOS Option+P glyphs as pin shortcuts", () => {
+    expect(isPinShortcut("π", {})).toBe(true);
+    expect(isPinShortcut("∏", {})).toBe(true);
+    expect(isPinShortcut("p", { meta: true })).toBe(true);
+    expect(isPinShortcut("p", { ctrl: true, meta: true })).toBe(false);
+  });
+
+  test("strips macOS Option+P glyphs from search input", () => {
+    expect(normalizeConversationSearchInput("π")).toBe("");
+    expect(normalizeConversationSearchInput("foo∏bar")).toBe("foobar");
+  });
+
+  test("keeps the toggled conversation selectable after pin sorting", () => {
+    const conversations = [
+      { conversation: { id: "default" }, isPinned: true },
+      { conversation: { id: "conv-a" }, isPinned: false },
+      { conversation: { id: "conv-b" }, isPinned: true },
+      { conversation: { id: "conv-c" }, isPinned: false },
+    ];
+
+    const sorted = sortPinnedConversations(
+      conversations.map((item) =>
+        item.conversation.id === "conv-a" ? { ...item, isPinned: true } : item,
+      ),
+    );
+
+    expect(sorted.map((item) => item.conversation.id)).toEqual([
+      "default",
+      "conv-a",
+      "conv-b",
+      "conv-c",
+    ]);
+    expect(findConversationIndexById(sorted, "conv-a")).toBe(1);
+  });
+
   test("hides the pin shortcut hint when default conversation is selected", () => {
     expect(
       buildConversationSelectorHints({ isSelectedDefaultConversation: true }),

--- a/src/cli/text-input-cursor-rendering.test.ts
+++ b/src/cli/text-input-cursor-rendering.test.ts
@@ -7,6 +7,15 @@ const vendorPath = fileURLToPath(
 );
 
 describe("vendored ink-text-input cursor rendering", () => {
+  test("treats meta letter shortcuts as control sequences", async () => {
+    const { isControlSequence } = await import(
+      "../../vendor/ink-text-input/build/index.js"
+    );
+
+    expect(isControlSequence("p", { meta: true })).toBe(true);
+    expect(isControlSequence("p", { meta: false })).toBe(false);
+  });
+
   test("uses an internal sentinel instead of rendering NBSP cursor cells", () => {
     const source = readFileSync(vendorPath, "utf8");
 

--- a/vendor/ink-text-input/build/index.js
+++ b/vendor/ink-text-input/build/index.js
@@ -13,7 +13,7 @@ const CURSOR_SENTINEL = '\u{10FFFD}';
  * Determines if the input should be treated as a control sequence (not inserted as text).
  * This centralizes escape sequence filtering to prevent garbage characters from being inserted.
  */
-function isControlSequence(input, key) {
+export function isControlSequence(input, key) {
     // Pasted content is handled separately
     if (key?.isPasted) return true;
 
@@ -31,8 +31,10 @@ function isControlSequence(input, key) {
     // The handled ones are: ctrl+a, ctrl+e, ctrl+k, ctrl+u, ctrl+y (see useInput below)
     if (key.ctrl && input && /^[a-z]$/i.test(input) && !['a', 'e', 'k', 'u', 'y'].includes(input.toLowerCase())) return true;
 
-    // Option+Arrow escape sequences: Ink parses \x1bb as meta=true, input='b'
-    if (key.meta && (input === 'b' || input === 'B' || input === 'f' || input === 'F')) return true;
+    // Meta/Option shortcuts are handled by parent components and should not
+    // also mutate focused text inputs. This covers terminal-specific encodings
+    // like Ghostty CSI-u (input='p', meta=true) and WezTerm ESC+p.
+    if (key.meta && input) return true;
 
     // Filter specific escape sequences that would insert garbage, but allow plain ESC through
     // CSI sequences (ESC[...), Option+Delete (ESC + DEL), and other multi-char escape sequences


### PR DESCRIPTION
## Summary
- preserve the selected conversation after pin/unpin resorting
- strip macOS Option+P glyphs from the resume search input without resetting selection on no-op cleanup
- keep meta/Option shortcuts from mutating focused text fields, fixing Ghostty CSI-u Option+P typing `p` into search after toggling pins
- add focused tests for Option+P glyph handling, pin sorting selection, and meta text-input filtering

## Validation
- bun test src/cli/text-input-cursor-rendering.test.ts src/cli/conversation-selector.test.ts
- bun run lint vendor/ink-text-input/build/index.js src/cli/text-input-cursor-rendering.test.ts src/cli/components/ConversationSelector.tsx src/cli/conversation-selector.test.ts
- bun run typecheck
- bun run check