### PR TITLE
refactor: stop seeding memory blocks for subagents, remove --init-blocks

### DIFF
--- a/src/agent/create.ts
+++ b/src/agent/create.ts
@@ -206,8 +206,6 @@ export interface CreateAgentOptions {
   systemPromptCustom?: string;
   /** Which managed memory prompt mode to apply */
   memoryPromptMode?: MemoryPromptMode;
-  /** Block labels to initialize (from default blocks) */
-  initBlocks?: string[];
   /** Base tools to include */
   baseTools?: string[];
   /** Custom memory blocks (overrides default blocks) */
@@ -230,7 +228,6 @@ export async function createAgent(
   skillsDirectory?: string,
   parallelToolCalls = true,
   systemPromptPreset?: string,
-  initBlocks?: string[],
   baseTools?: string[],
 ) {
   // Support both old positional args and new options object
@@ -246,7 +243,6 @@ export async function createAgent(
       skillsDirectory,
       parallelToolCalls,
       systemPromptPreset,
-      initBlocks,
       baseTools,
     };
   }
@@ -254,6 +250,8 @@ export async function createAgent(
   const name = options.name ?? DEFAULT_AGENT_NAME;
   const embeddingModelVal = options.embeddingModel;
   const parallelToolCallsVal = options.parallelToolCalls ?? true;
+  // Subagents are ephemeral and don't carry memory blocks of their own.
+  const isSubagent = process.env.LETTA_CODE_AGENT_ROLE === "subagent";
 
   // Resolve model identifier to handle
   let modelHandle: string;
@@ -294,7 +292,8 @@ export async function createAgent(
 
   // Determine which memory blocks to use:
   // 1. If options.memoryBlocks is provided, use those (custom blocks and/or block references)
-  // 2. Otherwise, use default blocks filtered by options.initBlocks
+  // 2. Subagents are ephemeral and get no memory blocks.
+  // 3. Otherwise, use the default blocks.
 
   // Separate block references from blocks to create
   const referencedBlockIds: string[] = [];
@@ -317,35 +316,8 @@ export async function createAgent(
     }
     filteredMemoryBlocks = createBlocks;
   } else {
-    // Load memory blocks from .mdx files
-    const defaultMemoryBlocks =
-      options.initBlocks && options.initBlocks.length === 0
-        ? []
-        : await getDefaultMemoryBlocks();
-
-    // Optional filter: only initialize a subset of memory blocks on creation
-    const allowedBlockLabels = options.initBlocks
-      ? new Set(
-          options.initBlocks.map((n) => n.trim()).filter((n) => n.length > 0),
-        )
-      : undefined;
-
-    if (allowedBlockLabels && allowedBlockLabels.size > 0) {
-      const knownLabels = new Set(defaultMemoryBlocks.map((b) => b.label));
-      for (const label of Array.from(allowedBlockLabels)) {
-        if (!knownLabels.has(label)) {
-          console.warn(
-            `Ignoring unknown init block "${label}". Valid blocks: ${Array.from(knownLabels).join(", ")}`,
-          );
-          allowedBlockLabels.delete(label);
-        }
-      }
-    }
-
-    filteredMemoryBlocks =
-      allowedBlockLabels && allowedBlockLabels.size > 0
-        ? defaultMemoryBlocks.filter((b) => allowedBlockLabels.has(b.label))
-        : defaultMemoryBlocks;
+    // Subagents get no blocks; everyone else gets the default .mdx blocks.
+    filteredMemoryBlocks = isSubagent ? [] : await getDefaultMemoryBlocks();
   }
 
   // Apply blockValues overrides to preset blocks
@@ -397,7 +369,6 @@ export async function createAgent(
   // Create agent with inline memory blocks (LET-7101: single API call instead of N+1)
   // - memory_blocks: new blocks to create inline
   // - block_ids: references to existing blocks (for shared memory)
-  const isSubagent = process.env.LETTA_CODE_AGENT_ROLE === "subagent";
   const tags = buildCreatedAgentTags({
     tags: options.tags,
     isSubagent,

--- a/src/agent/defaults.ts
+++ b/src/agent/defaults.ts
@@ -48,7 +48,7 @@ export const DEFAULT_AGENT_CONFIGS: Record<string, CreateAgentOptions> = {
   incognito: {
     name: "Incognito",
     description: INCOGNITO_DESCRIPTION,
-    initBlocks: [], // No personal memory blocks
+    memoryBlocks: [], // No personal memory blocks
     baseTools: ["web_search", "fetch_webpage"], // No memory tool
     enableMemfs: false,
   },

--- a/src/agent/memory.ts
+++ b/src/agent/memory.ts
@@ -27,11 +27,6 @@ export const MEMORY_BLOCK_LABELS = [
 ] as const;
 
 /**
- * Type for memory block labels
- */
-export type MemoryBlockLabel = (typeof MEMORY_BLOCK_LABELS)[number];
-
-/**
  * Block labels that should be read-only (agent cannot modify via memory tools).
  */
 export { READ_ONLY_BLOCK_LABELS };

--- a/src/agent/subagent-builtins.test.ts
+++ b/src/agent/subagent-builtins.test.ts
@@ -116,7 +116,6 @@ describe("built-in subagents", () => {
         "description: Custom reflection override",
         "tools: Read",
         "model: zaisigno/glm-5",
-        "memoryBlocks: none",
         "---",
         "Custom prompt body",
       ].join("\r\n"),
@@ -138,7 +137,6 @@ name: reflection
 description: Custom reflection override
 tools: Read
 model:
-memoryBlocks: none
 ---
 Custom prompt body`,
     );
@@ -157,7 +155,6 @@ Custom prompt body`,
 name: reflection
 description: Custom reflection override from different filename
 tools: Read
-memoryBlocks: none
 ---
 Custom prompt body`,
     );

--- a/src/agent/subagent-model-resolution.test.ts
+++ b/src/agent/subagent-model-resolution.test.ts
@@ -245,7 +245,6 @@ describe("buildSubagentArgs", () => {
     allowedTools: "all",
     recommendedModel: "inherit",
     skills: [],
-    memoryBlocks: "none",
     mode: "stateful",
     fork: false,
     background: false,
@@ -254,8 +253,6 @@ describe("buildSubagentArgs", () => {
   test("adds --no-memfs for newly spawned subagents by default", () => {
     const args = buildSubagentArgs("test-subagent", baseConfig, null, "hello");
 
-    expect(args).toContain("--init-blocks");
-    expect(args).toContain("none");
     expect(args).toContain("--no-memfs");
   });
 

--- a/src/agent/subagents/builtin/fork.md
+++ b/src/agent/subagents/builtin/fork.md
@@ -3,7 +3,6 @@ name: fork
 description: Fork of the parent agent with full context and tools. Recommended to run in background (run_in_background: true).
 tools: Bash, TaskOutput, Edit, KillBash, LS, MultiEdit, Read, TodoWrite, Write
 model: inherit
-memoryBlocks: all
 mode: stateful
 fork: true
 background: true

--- a/src/agent/subagents/builtin/general-purpose.md
+++ b/src/agent/subagents/builtin/general-purpose.md
@@ -3,7 +3,6 @@ name: general-purpose
 description: Full-capability agent for research, planning, and implementation
 tools: Bash, TaskOutput, Edit, KillBash, LS, MultiEdit, Read, TodoWrite, Write
 model: auto
-memoryBlocks: all
 mode: stateful
 ---
 

--- a/src/agent/subagents/builtin/history-analyzer.md
+++ b/src/agent/subagents/builtin/history-analyzer.md
@@ -4,7 +4,6 @@ description: Analyze Claude Code or Codex conversation history and directly upda
 tools: Read, Write, Bash
 skills:
 model: auto
-memoryBlocks: none
 mode: stateless
 permissionMode: memory
 ---

--- a/src/agent/subagents/builtin/init.md
+++ b/src/agent/subagents/builtin/init.md
@@ -3,7 +3,6 @@ name: init
 description: Fast initialization of agent memory — reads key project files and creates a minimal memory hierarchy
 tools: Read, Write, Edit, Bash
 model: auto-fast
-memoryBlocks: none
 permissionMode: memory
 ---
 

--- a/src/agent/subagents/builtin/memory.md
+++ b/src/agent/subagents/builtin/memory.md
@@ -3,7 +3,6 @@ name: memory
 description: Decompose and reorganize memory files into focused, single-purpose files using `/` naming
 tools: Bash, TaskOutput
 model: auto
-memoryBlocks: none
 permissionMode: memory
 ---
 

--- a/src/agent/subagents/builtin/recall.md
+++ b/src/agent/subagents/builtin/recall.md
@@ -3,7 +3,6 @@ name: recall
 description: Recall past interactions and experience
 tools: Bash, Read, TaskOutput
 model: inherit
-memoryBlocks: all
 mode: stateful
 fork: true
 ---

--- a/src/agent/subagents/builtin/reflection.md
+++ b/src/agent/subagents/builtin/reflection.md
@@ -3,7 +3,6 @@ name: reflection
 description: Background agent that reflects on recent conversations and updates memory files
 tools: Bash
 model: inherit
-memoryBlocks: none
 mode: stateless
 permissionMode: memory
 ---

--- a/src/agent/subagents/index.ts
+++ b/src/agent/subagents/index.ts
@@ -9,7 +9,6 @@
 import { existsSync } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { MEMORY_BLOCK_LABELS, type MemoryBlockLabel } from "@/agent/memory";
 import { getBackend } from "@/backend";
 import { getErrorMessage } from "@/utils/error";
 import {
@@ -46,9 +45,6 @@ const LOCAL_MEMFS_BUILTIN_SOURCES = [
   reflectionAgentMd,
 ];
 
-// Re-export for convenience
-export type { MemoryBlockLabel };
-
 // ============================================================================
 // Types
 // ============================================================================
@@ -71,8 +67,6 @@ export interface SubagentConfig {
   recommendedModel: string;
   /** Skills to auto-load */
   skills: string[];
-  /** Memory blocks the subagent has access to - list of labels or "all" or "none" */
-  memoryBlocks: MemoryBlockLabel[] | "all" | "none";
   /** Stateless agents should not persist private working memory. */
   mode: SubagentMode;
   /** Whether this subagent should fork the parent conversation before launch. */
@@ -107,11 +101,6 @@ export const GLOBAL_AGENTS_DIR = join(
   process.env.HOME || process.env.USERPROFILE || "~",
   ".letta/agents",
 );
-
-/**
- * Valid memory block labels (derived from memory.ts)
- */
-const VALID_MEMORY_BLOCKS: Set<string> = new Set(MEMORY_BLOCK_LABELS);
 
 // ============================================================================
 // Cache
@@ -164,32 +153,6 @@ function parseTools(toolsStr: string | undefined): string[] | "all" {
  */
 function parseSkills(skillsStr: string | undefined): string[] {
   return parseCommaSeparatedList(skillsStr);
-}
-
-/**
- * Parse comma-separated memory blocks string into validated block labels
- */
-function parseMemoryBlocks(
-  blocksStr: string | undefined,
-): MemoryBlockLabel[] | "all" | "none" {
-  if (
-    !blocksStr ||
-    blocksStr.trim() === "" ||
-    blocksStr.trim().toLowerCase() === "all"
-  ) {
-    return "all";
-  }
-
-  if (blocksStr.trim().toLowerCase() === "none") {
-    return "none";
-  }
-
-  const parts = parseCommaSeparatedList(blocksStr).map((b) => b.toLowerCase());
-  const blocks = parts.filter((p) =>
-    VALID_MEMORY_BLOCKS.has(p),
-  ) as MemoryBlockLabel[];
-
-  return blocks.length > 0 ? blocks : "all";
 }
 
 function parseSubagentMode(modeStr: string | undefined): SubagentMode {
@@ -252,9 +215,6 @@ function parseSubagentContent(content: string): SubagentConfig {
     allowedTools: parseTools(getStringField(frontmatter, "tools")),
     recommendedModel: getStringField(frontmatter, "model") || "inherit",
     skills: parseSkills(getStringField(frontmatter, "skills")),
-    memoryBlocks: parseMemoryBlocks(
-      getStringField(frontmatter, "memoryBlocks"),
-    ),
     mode: parseSubagentMode(getStringField(frontmatter, "mode")),
     fork: getStringField(frontmatter, "fork")?.toLowerCase() === "true",
     background:

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -1008,18 +1008,6 @@ export function buildSubagentArgs(
     args.push("--disallowedTools", parentDisallowedTools.join(","));
   }
 
-  // Add memory block filtering if specified (only for new agents)
-  if (!isDeployingExisting) {
-    if (config.memoryBlocks === "none") {
-      args.push("--init-blocks", "none");
-    } else if (
-      Array.isArray(config.memoryBlocks) &&
-      config.memoryBlocks.length > 0
-    ) {
-      args.push("--init-blocks", config.memoryBlocks.join(","));
-    }
-  }
-
   // Add tool filtering if specified (applies to both new and existing agents)
   if (
     config.allowedTools !== "all" &&

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -53,15 +53,6 @@ export const CLI_FLAG_CATALOG = {
     mode: "both",
     help: { description: "Create new conversation (for concurrent sessions)" },
   },
-  "init-blocks": {
-    parser: { type: "string" },
-    mode: "both",
-    help: {
-      argLabel: "<list>",
-      description:
-        'Comma-separated memory blocks to initialize when using --new-agent (e.g., "persona,human")',
-    },
-  },
   "base-tools": {
     parser: { type: "string" },
     mode: "both",

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -661,7 +661,6 @@ export async function handleHeadlessCommand(
   const systemCustom = values["system-custom"];
   const personalityInput = values.personality;
   const embeddingModel = values.embedding;
-  const initBlocksRaw = values["init-blocks"];
   const baseToolsRaw = values["base-tools"];
   const skillsDirectory = values.skills ?? skillsDirectoryOverride;
   const noSkillsFlag = values["no-skills"];
@@ -938,15 +937,6 @@ export async function handleHeadlessCommand(
     }
   }
 
-  if (initBlocksRaw && !forceNew) {
-    console.error(
-      "Error: --init-blocks can only be used together with --new to control initial memory blocks.",
-    );
-    process.exit(1);
-  }
-
-  const initBlocks = parseCsvListFlag(initBlocksRaw);
-
   if (baseToolsRaw && !forceNew) {
     console.error(
       "Error: --base-tools can only be used together with --new to control initial base tools.",
@@ -967,10 +957,6 @@ export async function handleHeadlessCommand(
   }
   if (personalityInput && !forceNew) {
     console.error("Error: --personality can only be used with --new-agent");
-    process.exit(1);
-  }
-  if (personalityInput && initBlocksRaw) {
-    console.error("Error: --personality cannot be combined with --init-blocks");
     process.exit(1);
   }
 
@@ -1117,7 +1103,6 @@ export async function handleHeadlessCommand(
       systemPromptPreset,
       systemPromptCustom: systemCustom,
       memoryPromptMode: effectiveMemoryMode,
-      initBlocks,
       baseTools,
       memoryBlocks: personalityOptions?.memoryBlocks,
       tags: personalityOptions?.tags ?? tags,
@@ -1459,12 +1444,7 @@ export async function handleHeadlessCommand(
   }
 
   // Determine which blocks to isolate for the conversation
-  const isolatedBlockLabels: string[] =
-    initBlocks === undefined
-      ? [...ISOLATED_BLOCK_LABELS]
-      : ISOLATED_BLOCK_LABELS.filter((label) =>
-          initBlocks.includes(label as string),
-        );
+  const isolatedBlockLabels: string[] = [...ISOLATED_BLOCK_LABELS];
 
   if (specifiedConversationId) {
     if (specifiedConversationId === "default") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -820,7 +820,6 @@ async function main(): Promise<void> {
   // --new: Create a new conversation (for concurrent sessions)
   const forceNewConversation = values.new ?? false;
 
-  const initBlocksRaw = values["init-blocks"];
   const baseToolsRaw = values["base-tools"];
   let specifiedAgentId = values.agent ?? null;
   try {
@@ -1043,16 +1042,6 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // --init-blocks only makes sense when creating a brand new agent
-  if (initBlocksRaw && !forceNew) {
-    console.error(
-      "Error: --init-blocks can only be used together with --new to control initial memory blocks.",
-    );
-    process.exit(1);
-  }
-
-  const initBlocks = parseCsvListFlag(initBlocksRaw);
-
   // --base-tools only makes sense when creating a brand new agent
   if (baseToolsRaw && !forceNew) {
     console.error(
@@ -1074,10 +1063,6 @@ async function main(): Promise<void> {
   }
   if (personalityInput && !forceNew) {
     console.error("Error: --personality can only be used with --new-agent");
-    process.exit(1);
-  }
-  if (personalityInput && initBlocksRaw) {
-    console.error("Error: --personality cannot be combined with --init-blocks");
     process.exit(1);
   }
 
@@ -1569,7 +1554,6 @@ async function main(): Promise<void> {
 
   function LoadingApp({
     forceNew,
-    initBlocks,
     baseTools,
     agentIdArg,
     preResolvedAgent,
@@ -1581,7 +1565,6 @@ async function main(): Promise<void> {
     isRegistryImport,
   }: {
     forceNew: boolean;
-    initBlocks?: string[];
     baseTools?: string[];
     agentIdArg: string | null;
     preResolvedAgent?: AgentState | null;
@@ -2367,7 +2350,6 @@ async function main(): Promise<void> {
             systemPromptPreset,
             systemPromptCustom: systemCustom,
             memoryPromptMode: effectiveMemoryMode,
-            initBlocks,
             baseTools,
           });
           agent = result.agent;
@@ -2902,7 +2884,6 @@ async function main(): Promise<void> {
   render(
     React.createElement(LoadingApp, {
       forceNew: forceNew,
-      initBlocks: initBlocks,
       baseTools: baseTools,
       agentIdArg: specifiedAgentId,
       preResolvedAgent: nameResolvedAgent,

--- a/src/integration-tests/startup-flow.integration.test.ts
+++ b/src/integration-tests/startup-flow.integration.test.ts
@@ -385,29 +385,4 @@ describe("Startup Flow - Integration", () => {
     },
     { timeout: 190000 },
   );
-
-  test(
-    "--new-agent with --init-blocks none creates minimal agent",
-    async () => {
-      const result = await runCliJson(
-        [
-          "--new-agent",
-          "--init-blocks",
-          "none",
-          "-m",
-          "sonnet-4.6-low",
-          "-p",
-          "Say OK",
-          "--output-format",
-          "json",
-        ],
-        { timeoutMs: 180000 },
-      );
-
-      expect(result.exitCode).toBe(0);
-      const output = result.output;
-      expect(output.agent_id).toBeDefined();
-    },
-    { timeout: 190000 },
-  );
 });


### PR DESCRIPTION
Continues the legacy memory-block teardown. **Stacked on #2873** (base = `worktree-remove-legacy-sleeptime`) since both touch the block-flag region of `args.ts`/`headless.ts`/`index.ts` — retarget to `main` once #2873 merges.

## Subagents are memoryless by construction
A fresh subagent never carried real memory — `--init-blocks` only ever seeded the bundled default `persona.mdx`/`human.mdx` boilerplate ("I'm a coding assistant…"), never the parent's learned memory. The builtins were split `all`/`none` somewhat arbitrarily, and the `all` ones (`general-purpose`/`fork`/`recall`) just got two paragraphs of generic boilerplate per spawn. Fork/recall bypassed the mechanism entirely (they inherit the parent conversation and never pass `--init-blocks`).

This gates the default-block path in `createAgent` on `isSubagent` so **every** subagent gets zero blocks, and removes the per-subagent config that drove it.

## Changes (+8/−180)
- **`create.ts`** — hoist `isSubagent`; `filteredMemoryBlocks = isSubagent ? [] : await getDefaultMemoryBlocks()`. Remove the `initBlocks` option, positional param, and the label-filtering logic.
- **`subagents/`** — drop the `memoryBlocks` frontmatter field + parser (`parseMemoryBlocks`/`VALID_MEMORY_BLOCKS`) and the `--init-blocks` spawn args in `manager.ts`; remove the `memoryBlocks:` line from all 7 builtins.
- **`--init-blocks` flag** — removed end to end (`args.ts`, `headless.ts`, `index.ts`: parse, validation, `--personality` conflict, `LoadingApp` plumbing).
- **`defaults.ts`** — incognito agent `initBlocks: []` → `memoryBlocks: []` (same zero-blocks result).
- **`memory.ts`** — drop the now-orphaned `MemoryBlockLabel` type. `MEMORY_BLOCK_LABELS` stays (builds the default `.mdx` blocks).
- **Tests** — update `subagent-model-resolution` / `subagent-builtins`; remove the integration test that exercised `--init-blocks none`.

## Behavioral surface
Only observable change: new `general-purpose`/`fork`/`recall` subagents no longer get the default persona/human boilerplate in core memory (fewer wasted tokens per spawn). The reflection subagent was already `none`, so it's unaffected.

## Scope note
`ISOLATED_BLOCK_LABELS` plumbing (the empty-array per-conversation isolation) is intentionally left for a separate dead-code PR — it spans `cron`/`channels`/`websocket`/UI and is a different concept. `headless.ts` here just simplifies the now-`initBlocks`-free computation to `[...ISOLATED_BLOCK_LABELS]`.

## Verification
`bun run check` passes all 9 checks. Affected unit suites (subagents, create, defaults, personality, args — 114 tests) all pass.
