### PR TITLE
refactor: remove dead block-label plumbing (ISOLATED_BLOCK_LABELS + global/project split)

### DIFF
--- a/src/agent/memory.ts
+++ b/src/agent/memory.ts
@@ -8,35 +8,17 @@ import { READ_ONLY_BLOCK_LABELS } from "./memory-constants";
 import { MEMORY_PROMPTS } from "./prompt-assets";
 
 /**
- * Block labels that are stored globally (shared across all projects).
+ * The memory block labels every standard (non-MemFS) agent is created with.
+ * Each maps to a `<label>.mdx` file in src/agent/prompts. Per-project blocks
+ * (skills/loaded_skills) were removed in LET-7353 — skills are now injected
+ * via system reminders, leaving only these defaults.
  */
-export const GLOBAL_BLOCK_LABELS = ["persona", "human"] as const;
-
-/**
- * Block labels that are stored per-project (local to the current directory).
- * Note: skills/loaded_skills removed in LET-7353 - skills are now injected via system reminders.
- */
-export const PROJECT_BLOCK_LABELS = [] as const;
-
-/**
- * All available memory block labels (derived from global + project blocks)
- */
-export const MEMORY_BLOCK_LABELS = [
-  ...GLOBAL_BLOCK_LABELS,
-  ...PROJECT_BLOCK_LABELS,
-] as const;
+export const MEMORY_BLOCK_LABELS = ["persona", "human"] as const;
 
 /**
  * Block labels that should be read-only (agent cannot modify via memory tools).
  */
 export { READ_ONLY_BLOCK_LABELS };
-
-/**
- * Check if a block label is a project-level block
- */
-export function isProjectBlock(label: string): boolean {
-  return (PROJECT_BLOCK_LABELS as readonly string[]).includes(label);
-}
 
 /**
  * Parse frontmatter and content from an .mdx file

--- a/src/agent/memory.ts
+++ b/src/agent/memory.ts
@@ -32,12 +32,6 @@ export const MEMORY_BLOCK_LABELS = [
 export { READ_ONLY_BLOCK_LABELS };
 
 /**
- * Block labels that should be isolated per-conversation.
- * Note: skills/loaded_skills removed in LET-7353.
- */
-export const ISOLATED_BLOCK_LABELS = [] as const;
-
-/**
  * Check if a block label is a project-level block
  */
 export function isProjectBlock(label: string): boolean {

--- a/src/channels/discord-registry.test.ts
+++ b/src/channels/discord-registry.test.ts
@@ -273,7 +273,6 @@ describe("discord channel registry", () => {
     expect(createConversation).toHaveBeenCalledTimes(1);
     expect(createConversation).toHaveBeenCalledWith({
       agent_id: "agent-1",
-      isolated_block_labels: expect.any(Array),
       summary: "[Discord] DM with Cameron",
     });
     expect(getRoute("discord", "dm-1", "discord-bot")).toMatchObject({

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -10,7 +10,6 @@
  */
 
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
-import { ISOLATED_BLOCK_LABELS } from "@/agent/memory";
 import { getClient } from "@/backend/api/client";
 import { buildChatUrl, isLocalAgentId } from "@/cli/helpers/app-urls";
 import type { ApprovalResponseBody } from "@/types/protocol_v2";
@@ -1571,7 +1570,6 @@ export class ChannelRegistry {
     const client = await getClient();
     const conversation = await client.conversations.create({
       agent_id: agentId,
-      isolated_block_labels: [...ISOLATED_BLOCK_LABELS],
       ...(summary ? { summary } : {}),
     });
     return conversation.id;

--- a/src/channels/telegram-adapter.test.ts
+++ b/src/channels/telegram-adapter.test.ts
@@ -320,7 +320,6 @@ test("telegram channel starts through service and routes inbound topic messages 
   expect(createConversation).toHaveBeenCalledTimes(1);
   expect(createConversation).toHaveBeenCalledWith({
     agent_id: "agent-telegram",
-    isolated_block_labels: expect.any(Array),
     summary: "[Telegram] Topic in Void Cafe: Hello from a Telegram topic",
   });
   expect(getRoute("telegram", "-100123", "telegram-e2e", "42")).toMatchObject({

--- a/src/channels/telegram-registry.test.ts
+++ b/src/channels/telegram-registry.test.ts
@@ -231,7 +231,6 @@ describe("telegram channel registry", () => {
     expect(createConversation).toHaveBeenCalledTimes(1);
     expect(createConversation).toHaveBeenCalledWith({
       agent_id: "agent-1",
-      isolated_block_labels: expect.any(Array),
       summary: "[Telegram] Topic in Void Cafe: hello topic",
     });
     expect(getRoute("telegram", "-100123", "telegram-bot", "42")).toMatchObject(

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -5,7 +5,6 @@ import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents"
 import { Box } from "ink";
 import type { Dispatch, RefObject, SetStateAction } from "react";
 import { getResumeDataFromBackend } from "@/agent/check-approval";
-import { ISOLATED_BLOCK_LABELS } from "@/agent/memory";
 import { isActiveMemfsEnabled } from "@/agent/memory-runtime";
 import type { ModelReasoningEffort } from "@/agent/model";
 import type { PersonalityId } from "@/agent/personality";
@@ -1339,7 +1338,6 @@ export function AppView(props: AppViewProps) {
                     // Create a new conversation
                     const conversation = await getBackend().createConversation({
                       agent_id: agentId,
-                      isolated_block_labels: [...ISOLATED_BLOCK_LABELS],
                     });
 
                     await maybeCarryOverActiveConversationModel(

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -22,7 +22,6 @@ import {
   STALE_APPROVAL_RECOVERY_DENIAL_REASON,
 } from "@/agent/approval-recovery";
 import { getResumeDataFromBackend } from "@/agent/check-approval";
-import { ISOLATED_BLOCK_LABELS } from "@/agent/memory";
 import {
   ensureMemoryFilesystemDirs,
   getScopedMemoryFilesystemRoot,
@@ -1585,7 +1584,6 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             // Create a new conversation for the current agent
             const conversation = await backend.createConversation({
               agent_id: agentId,
-              isolated_block_labels: [...ISOLATED_BLOCK_LABELS],
               ...(conversationName && { summary: conversationName }),
             });
 
@@ -1804,7 +1802,6 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             // Create a new conversation
             const conversation = await backend.createConversation({
               agent_id: agentId,
-              isolated_block_labels: [...ISOLATED_BLOCK_LABELS],
             });
 
             setConversationAutoTitleEligibility(true);

--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -12,7 +12,6 @@
  * On stop: clears interval, releases lease.
  */
 
-import { ISOLATED_BLOCK_LABELS } from "@/agent/memory";
 import { getBackend } from "@/backend";
 import type { CronPromptQueueItem, DequeuedBatch } from "@/queue/queue-runtime";
 import { ensureConversationQueueRuntime } from "@/websocket/listener/conversation-runtime";
@@ -123,7 +122,6 @@ async function resolveCronFireConversationId(
   if (task.conversation_id === NEW_CONVERSATION_TARGET) {
     const conversation = await getBackend().createConversation({
       agent_id: task.agent_id,
-      isolated_block_labels: [...ISOLATED_BLOCK_LABELS],
       summary: getCronConversationSummary(task),
     });
     return conversation.id;

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -34,7 +34,6 @@ import { buildClientSkillsPayload } from "./agent/client-skills";
 import { setAgentContext, setConversationId } from "./agent/context";
 import { createAgent } from "./agent/create";
 import { handleListMessages } from "./agent/list-messages-handler";
-import { ISOLATED_BLOCK_LABELS } from "./agent/memory";
 import { getStreamToolContextId, sendMessageStream } from "./agent/message";
 import {
   getModelInfo,
@@ -1443,9 +1442,6 @@ export async function handleHeadlessCommand(
     process.exit(1);
   }
 
-  // Determine which blocks to isolate for the conversation
-  const isolatedBlockLabels: string[] = [...ISOLATED_BLOCK_LABELS];
-
   if (specifiedConversationId) {
     if (specifiedConversationId === "default") {
       // "default" is the agent's primary message history (no explicit conversation)
@@ -1479,7 +1475,6 @@ export async function handleHeadlessCommand(
     // body fields unchanged — remove the cast once the SDK is bumped.
     const createParams: ConversationCreateBody = {
       agent_id: agent.id,
-      isolated_block_labels: isolatedBlockLabels,
     };
     if (fromAgentId) {
       (createParams as { hidden?: boolean }).hidden = true;
@@ -1499,7 +1494,6 @@ export async function handleHeadlessCommand(
     // primary conversation.
     const conversation = await backend.createConversation({
       agent_id: agent.id,
-      isolated_block_labels: isolatedBlockLabels,
     });
     conversationId = conversation.id;
     conversationOpenReason = "new";

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,6 @@ import {
   setConversationId as setContextConversationId,
 } from "./agent/context";
 import type { AgentProvenance } from "./agent/create";
-import { ISOLATED_BLOCK_LABELS } from "./agent/memory";
 import {
   getModelPresetUpdateForAgent,
   getModelUpdateArgs,
@@ -2636,7 +2635,6 @@ async function main(): Promise<void> {
           // --new flag: create a new conversation (for concurrent sessions)
           const conversation = await backend.createConversation({
             agent_id: agent.id,
-            isolated_block_labels: [...ISOLATED_BLOCK_LABELS],
           });
           conversationIdToUse = conversation.id;
         } else {

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -5,7 +5,6 @@ import {
   applySetMaxContext,
   formatSetMaxContextResult,
 } from "@/agent/max-context";
-import { ISOLATED_BLOCK_LABELS } from "@/agent/memory";
 import { getScopedMemoryFilesystemRoot } from "@/agent/memory-filesystem";
 import { REMEMBER_PROMPT } from "@/agent/prompt-assets";
 import type { ConversationMessageCompactBody } from "@/backend";
@@ -515,7 +514,6 @@ async function handleClearCommand(
   // Create a new conversation
   const conversation = await backend.createConversation({
     agent_id: agentId,
-    isolated_block_labels: [...ISOLATED_BLOCK_LABELS],
   });
 
   // Clear runtime state for the current conversation


### PR DESCRIPTION
Two pure dead-code/clarity cleanups in the memory-block teardown, both confined to leftover block-label plumbing. **Stacked on #2874** (base = `worktree-remove-subagent-blocks`) — retarget to `main` once #2873 and #2874 merge.

## `ec09746e` — remove dead `ISOLATED_BLOCK_LABELS` plumbing (−28, 0 insertions)
`ISOLATED_BLOCK_LABELS` had been `[] as const` since per-conversation block isolation was retired (`skills`/`loaded_skills` removed in LET-7353). Every reference was `isolated_block_labels: [...ISOLATED_BLOCK_LABELS]` on a `createConversation` call — passing `[]`, a no-op.
- Remove the constant (`agent/memory.ts`) and all references across `cron/scheduler.ts`, `channels/registry.ts`, `index.ts`, `websocket/listener/commands.ts`, `cli/app/use-submit-handler.ts` (×2), `cli/app/AppView.tsx`, `headless.ts` (+ the now-unused imports).
- Drop the `isolated_block_labels: expect.any(Array)` assertions in the 3 channels tests that pinned the empty array.
- No runtime change: the field is optional on the SDK `ConversationCreateBody`; the API backend forwards it unchanged (absent ≡ `[]`) and the local store never reads it.

## `4ccae9c9` — collapse the global/project block-label split
The global-vs-project distinction no longer reflects reality: `PROJECT_BLOCK_LABELS` has been empty since `skills`/`loaded_skills` were removed (LET-7353), and "global" no longer means shared storage — each agent gets fresh `persona`/`human` blocks (`create.ts`: *"we no longer reuse shared blocks"*). `isProjectBlock()` had zero callers and always returned `false`.
- Collapse `GLOBAL_BLOCK_LABELS` + empty `PROJECT_BLOCK_LABELS` + the composed `MEMORY_BLOCK_LABELS` into one representative `MEMORY_BLOCK_LABELS = ["persona", "human"]` (the default blocks for standard non-MemFS agents), with a comment describing what it actually is.
- Drop the dead `isProjectBlock`.

## Verification
`bun run check` passes all 9 checks. Affected tests (channels ×3, memory/create/defaults) pass.
