### PR TITLE
feat(cli): add statusline to include help command and newline keybind

### DIFF
--- a/src/cli/components/HelpDialog.tsx
+++ b/src/cli/components/HelpDialog.tsx
@@ -1,6 +1,7 @@
 import { Box, useInput } from "ink";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { commands } from "@/cli/commands/registry";
+import { INPUT_NEWLINE_MODIFIER_LABEL } from "@/constants";
 import { getVersion } from "@/version";
 import { colors } from "./colors";
 import { OverlayShell } from "./OverlayShell";
@@ -73,7 +74,10 @@ export function HelpDialog({ onClose }: HelpDialogProps) {
       { keys: "↓", description: "Navigate down / next command in history" },
       { keys: "↑", description: "Navigate up / previous command in history" },
       { keys: "Shift+Enter", description: "Insert newline (multi-line input)" },
-      { keys: "Opt+Enter", description: "Insert newline (alternative)" },
+      {
+        keys: INPUT_NEWLINE_MODIFIER_LABEL,
+        description: "Insert newline (alternative)",
+      },
       {
         keys: "Ctrl+C",
         description: "Interrupt operation / exit (double press)",

--- a/src/cli/components/PasteAwareTextInput.tsx
+++ b/src/cli/components/PasteAwareTextInput.tsx
@@ -192,6 +192,7 @@ export function PasteAwareTextInput({
   useInput(
     (input, key) => {
       // Handle Shift/Option/Ctrl + Enter to insert newline
+      // Display label for this shortcut: INPUT_NEWLINE_MODIFIER_LABEL in @/constants
       if (key.return && (key.shift || key.meta || key.ctrl)) {
         const at = Math.max(
           0,

--- a/src/cli/display/statusline/renderers/Default.tsx
+++ b/src/cli/display/statusline/renderers/Default.tsx
@@ -7,6 +7,7 @@ import type {
   StatuslineRenderContext,
   StatuslineRenderer,
 } from "@/cli/display/statusline/types";
+import { INPUT_NEWLINE_MODIFIER_LABEL } from "@/constants";
 
 interface DefaultStatuslineParts {
   left: ReactNode;
@@ -77,8 +78,15 @@ export function buildDefaultStatuslineParts(
     ? chalk.magenta(context.ui.goalStatusText)
     : " ".repeat(rightPrefixSpaces) + rightCore;
 
+  const left = (
+    <Text dimColor wrap="truncate-end">
+      /help for commands & shortcuts · {INPUT_NEWLINE_MODIFIER_LABEL} for
+      newline
+    </Text>
+  );
+
   return {
-    left: <Text> </Text>,
+    left,
     right,
     rightCore,
     rightWidth,
@@ -86,7 +94,10 @@ export function buildDefaultStatuslineParts(
 }
 
 export function renderDefaultStatusline(context: StatuslineRenderContext) {
-  const rightColumnWidth = getDefaultStatuslineRightColumnWidth(context);
+  // Use the capped rightColumnWidth from InputRich (max 72, 45% of terminal)
+  // rather than getDefaultStatuslineRightColumnWidth which returns terminalWidth-4
+  // and leaves no room for left-side content.
+  const rightColumnWidth = context.ui.rightColumnWidth;
   const parts = buildDefaultStatuslineParts(context, rightColumnWidth);
 
   return (

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -64,3 +64,12 @@ export const COMPACTION_SUMMARY_HEADER =
 export const TOKEN_DISPLAY_THRESHOLD = 100;
 // Show elapsed time after 2 minutes (in ms)
 export const ELAPSED_DISPLAY_THRESHOLD_MS = 60 * 1000;
+
+/**
+ * Display label for the modifier key that inserts a newline in the input
+ * (Shift/Option/Ctrl + Enter in PasteAwareTextInput). Platform-aware so
+ * the statusline hint matches the user's actual keybinding.
+ * Single source of truth — update here if the keybinding changes.
+ */
+export const INPUT_NEWLINE_MODIFIER_LABEL =
+  process.platform === "darwin" ? "Opt+Enter" : "Alt+Enter";


### PR DESCRIPTION
### Summary

This PR will only change TUI appearance to add simple text below input text box.

<img width="946" height="99" alt="Screenshot_2026-06-13_11-58-05" src="https://github.com/user-attachments/assets/ed55685b-8aba-44ee-a122-03d45741086c" />

I added this because `/help` seems also contain many shortcuts which TUI user may not aware.

For the newline, I tried Shift+Enter yet it sends the input, CTRL+Enter also send the input then realised it was using ALT+Enter to create newline. So I think putting below textbox would be helpful since user may need to make some bullet points to explain something or answer multiple questions from the models.

Also `/help` seems not a valid command but it works if I press enter afterward, tested this with latest commit https://github.com/letta-ai/letta-code/commit/bdd0e56ed6111d6f23150007170a898a6961fe68

<img width="652" height="85" alt="image" src="https://github.com/user-attachments/assets/8b17c3ac-3bf4-41f4-bd6d-fff3655c04e9" />

### Concern

- I don't have Apple device on my end so I can't test, but I added the shortcut to be platform aware so for Mac it should be `Opt+Enter` but others would be `Alt+Enter`
- I changed the size of right column width under the input text box to give space for the text on the left column. Not sure what is the consequence, so far I test by writing prompt and input command.

### Changes

- **src/cli/components/HelpDialog.tsx**: Update newline shortcut to be platform aware
- **src/constants.ts**: Added constant for the shortcut text
- **src/cli/display/statusline/renderers/Default.tsx**: Added text below input text box
