### PR TITLE
feat(commands): add /copy to export the conversation as Markdown

### DIFF
--- a/src/cli/app/command-routing.ts
+++ b/src/cli/app/command-routing.ts
@@ -40,6 +40,7 @@ const NON_STATE_COMMANDS = new Set([
   "/feedback",
   "/export",
   "/download",
+  "/copy", // read-only conversation snapshot
   "/reasoning-tab",
   "/secret",
   "/palace", // read-only memory viewer

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -44,13 +44,19 @@ import { getClient } from "@/backend/api/client";
 import type { CustomCommand } from "@/cli/commands/custom";
 import type { CommandHandle } from "@/cli/commands/runner";
 import { validateAgentName } from "@/cli/components/PinDialog";
-import { type Buffers, type Line, toLines } from "@/cli/helpers/accumulator";
+import {
+  type Buffers,
+  type Line,
+  linesToMarkdown,
+  toLines,
+} from "@/cli/helpers/accumulator";
 import { buildChatUrl, isLocalAgentId } from "@/cli/helpers/app-urls";
 import {
   CHDIR_USAGE,
   parseChdirCommand,
   resolveChdirTarget,
 } from "@/cli/helpers/chdir-command";
+import { copyToClipboard } from "@/cli/helpers/clipboard";
 import type { ContextTracker } from "@/cli/helpers/context-tracker";
 import { resetContextHistory } from "@/cli/helpers/context-tracker";
 import type { ConversationSwitchContext } from "@/cli/helpers/conversation-switch-alert";
@@ -2515,6 +2521,76 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             cmd.fail(`Failed: ${errorDetails}`);
           } finally {
             setCommandRunning(false);
+          }
+          return { submitted: true };
+        }
+
+        // Special handling for /copy command - copy the conversation as Markdown
+        if (trimmed === "/copy" || trimmed.startsWith("/copy ")) {
+          const arg = trimmed.slice("/copy".length).trim().toLowerCase();
+          const forceFile = arg === "file" || arg === "--file";
+          const cmd = commandRunner.start(
+            msg.trim(),
+            "Copying conversation...",
+          );
+
+          const lines = toLines(buffersRef.current);
+          const body = linesToMarkdown(lines);
+          if (!body.trim()) {
+            cmd.fail("No conversation to copy yet.");
+            return { submitted: true };
+          }
+
+          const messageCount = lines.filter(
+            (line) => line.kind === "user" || line.kind === "assistant",
+          ).length;
+          const header = [
+            `# Conversation${agentName ? ` — ${agentName}` : ""}`,
+            "",
+            `_Exported from Letta Code on ${new Date().toISOString()}_`,
+          ].join("\n");
+          const markdown = `${header}\n\n${body}\n`;
+
+          const writeMarkdownFile = (): string => {
+            const fileName = `letta-conversation-${Date.now()}.md`;
+            writeFileSync(fileName, markdown);
+            return fileName;
+          };
+
+          if (forceFile) {
+            try {
+              const fileName = writeMarkdownFile();
+              cmd.finish(
+                `Saved conversation to ${fileName} (${messageCount} messages)`,
+                true,
+              );
+            } catch (error) {
+              cmd.fail(
+                `Failed to write file: ${error instanceof Error ? error.message : String(error)}`,
+              );
+            }
+            return { submitted: true };
+          }
+
+          if (copyToClipboard(markdown)) {
+            cmd.finish(
+              `Copied conversation to clipboard as Markdown (${messageCount} messages)`,
+              true,
+            );
+          } else {
+            // Clipboard unavailable (e.g. headless or Linux without xclip/xsel):
+            // fall back to writing a Markdown file so the command still works.
+            try {
+              const fileName = writeMarkdownFile();
+              cmd.finish(
+                `Clipboard unavailable — saved conversation to ${fileName} (${messageCount} messages)`,
+                true,
+              );
+            } catch (error) {
+              cmd.fail(
+                `Could not copy to clipboard or write file: ${error instanceof Error ? error.message : String(error)}`,
+              );
+            }
           }
           return { submitted: true };
         }

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -271,6 +271,15 @@ export const commands: Record<string, Command> = {
       return "Exporting agent file...";
     },
   },
+  "/copy": {
+    desc: "Copy the conversation to the clipboard as Markdown",
+    args: "[file]",
+    order: 26.5,
+    handler: () => {
+      // Handled specially in use-submit-handler.ts to access conversation buffers
+      return "Copying conversation...";
+    },
+  },
   "/toolset": {
     desc: "Switch toolset (replaces /link and /unlink)",
     order: 27,

--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -1574,3 +1574,139 @@ export function linesToTranscript(lines: Line[]): string {
   }
   return parts.join("\n");
 }
+
+export interface LinesToMarkdownOptions {
+  /** Include assistant reasoning blocks (default: false). */
+  includeReasoning?: boolean;
+  /** Include tool calls and their results (default: true). */
+  includeToolCalls?: boolean;
+}
+
+/**
+ * Pick a backtick fence long enough to safely wrap `content` so that any
+ * embedded backtick runs don't prematurely close the code block.
+ */
+function markdownFence(content: string): string {
+  let longest = 0;
+  const runs = content.match(/`+/g);
+  if (runs) {
+    for (const run of runs) longest = Math.max(longest, run.length);
+  }
+  return "`".repeat(Math.max(3, longest + 1));
+}
+
+/** Wrap `content` in a fenced code block with an optional language hint. */
+function markdownCodeBlock(content: string, lang = ""): string {
+  const fence = markdownFence(content);
+  return `${fence}${lang}\n${content.replace(/\n+$/, "")}\n${fence}`;
+}
+
+/** Pretty-print tool arguments as JSON when possible, else return raw text. */
+function formatToolArgs(argsText: string | undefined): {
+  text: string;
+  lang: string;
+} {
+  const raw = (argsText ?? "").trim();
+  if (!raw) return { text: "{}", lang: "json" };
+  try {
+    return { text: JSON.stringify(JSON.parse(raw), null, 2), lang: "json" };
+  } catch {
+    return { text: raw, lang: "" };
+  }
+}
+
+/**
+ * Serialize display lines into a clean, human-readable Markdown transcript.
+ *
+ * Unlike {@link linesToTranscript} (XML-tagged output tuned for the reflection
+ * subagent), this produces GitHub-flavored Markdown with `##` role headers and
+ * fenced code blocks for tool calls — suitable for sharing or pasting into
+ * docs, issues, or chats (used by the `/copy` command).
+ */
+export function linesToMarkdown(
+  lines: Line[],
+  options: LinesToMarkdownOptions = {},
+): string {
+  const includeReasoning = options.includeReasoning ?? false;
+  const includeToolCalls = options.includeToolCalls ?? true;
+  const blocks: string[] = [];
+  // Track the last role block so streaming continuation lines (split at
+  // paragraph boundaries) merge back into a single section instead of
+  // emitting a fresh header per fragment.
+  let lastMergeKind: "assistant" | "reasoning" | null = null;
+
+  for (const line of lines) {
+    switch (line.kind) {
+      case "user": {
+        const text = line.text.trim();
+        if (text) blocks.push(`## User\n\n${text}`);
+        lastMergeKind = null;
+        break;
+      }
+      case "assistant": {
+        const text = line.text.trim();
+        if (!text) break;
+        if (
+          line.isContinuation &&
+          lastMergeKind === "assistant" &&
+          blocks.length > 0
+        ) {
+          blocks[blocks.length - 1] += `\n\n${text}`;
+        } else {
+          blocks.push(`## Assistant\n\n${text}`);
+        }
+        lastMergeKind = "assistant";
+        break;
+      }
+      case "reasoning": {
+        if (!includeReasoning) {
+          lastMergeKind = null;
+          break;
+        }
+        const text = line.text.trim();
+        if (!text) break;
+        if (
+          line.isContinuation &&
+          lastMergeKind === "reasoning" &&
+          blocks.length > 0
+        ) {
+          blocks[blocks.length - 1] += `\n\n${text}`;
+        } else {
+          blocks.push(`### Reasoning\n\n${text}`);
+        }
+        lastMergeKind = "reasoning";
+        break;
+      }
+      case "tool_call": {
+        lastMergeKind = null;
+        if (!includeToolCalls || !line.name) break;
+        const parts = [`### Tool: \`${line.name}\``];
+        const { text: argsBody, lang } = formatToolArgs(line.argsText);
+        parts.push(markdownCodeBlock(argsBody, lang));
+        if (line.resultText) {
+          const label = line.resultOk === false ? "Result (error)" : "Result";
+          parts.push(
+            `<details>\n<summary>${label}</summary>\n\n${markdownCodeBlock(
+              line.resultText,
+            )}\n\n</details>`,
+          );
+        }
+        blocks.push(parts.join("\n\n"));
+        break;
+      }
+      case "error": {
+        const text = line.text.trim();
+        if (text) blocks.push(`## Error\n\n${text}`);
+        lastMergeKind = null;
+        break;
+      }
+      default:
+        // Skip status, separator, command, event, trajectory_summary,
+        // bash_command lines — they aren't part of the conversation content.
+        lastMergeKind = null;
+        break;
+    }
+  }
+
+  return blocks.join("\n\n");
+}

--- a/src/cli/helpers/lines-to-markdown.test.ts
+++ b/src/cli/helpers/lines-to-markdown.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test";
+import { type Line, linesToMarkdown } from "@/cli/helpers/accumulator";
+
+describe("linesToMarkdown", () => {
+  test("renders user and assistant turns with role headers", () => {
+    const lines: Line[] = [
+      { kind: "user", id: "u1", text: "Hello there" },
+      {
+        kind: "assistant",
+        id: "a1",
+        text: "Hi! How can I help?",
+        phase: "finished",
+      },
+    ];
+    expect(linesToMarkdown(lines)).toBe(
+      "## User\n\nHello there\n\n## Assistant\n\nHi! How can I help?",
+    );
+  });
+
+  test("returns an empty string for an empty or content-free conversation", () => {
+    expect(linesToMarkdown([])).toBe("");
+    expect(
+      linesToMarkdown([
+        { kind: "separator", id: "s1" },
+        { kind: "status", id: "st1", lines: ["working..."] },
+      ]),
+    ).toBe("");
+  });
+
+  test("excludes reasoning by default and includes it when requested", () => {
+    const lines: Line[] = [
+      { kind: "reasoning", id: "r1", text: "thinking hard", phase: "finished" },
+      { kind: "assistant", id: "a1", text: "Done", phase: "finished" },
+    ];
+    expect(linesToMarkdown(lines)).toBe("## Assistant\n\nDone");
+    expect(linesToMarkdown(lines, { includeReasoning: true })).toBe(
+      "### Reasoning\n\nthinking hard\n\n## Assistant\n\nDone",
+    );
+  });
+
+  test("renders tool calls with pretty-printed JSON args and a result block", () => {
+    const lines: Line[] = [
+      {
+        kind: "tool_call",
+        id: "t1",
+        name: "bash",
+        argsText: '{"command":"ls"}',
+        resultText: "file.txt",
+        resultOk: true,
+        phase: "finished",
+      },
+    ];
+    const md = linesToMarkdown(lines);
+    expect(md).toContain("### Tool: `bash`");
+    expect(md).toContain('```json\n{\n  "command": "ls"\n}\n```');
+    expect(md).toContain("<details>\n<summary>Result</summary>");
+    expect(md).toContain("```\nfile.txt\n```");
+  });
+
+  test("labels failed tool results as errors", () => {
+    const lines: Line[] = [
+      {
+        kind: "tool_call",
+        id: "t1",
+        name: "bash",
+        argsText: "{}",
+        resultText: "boom",
+        resultOk: false,
+        phase: "finished",
+      },
+    ];
+    expect(linesToMarkdown(lines)).toContain(
+      "<summary>Result (error)</summary>",
+    );
+  });
+
+  test("keeps non-JSON tool args as raw text without a language hint", () => {
+    const lines: Line[] = [
+      {
+        kind: "tool_call",
+        id: "t1",
+        name: "shell",
+        argsText: "not json",
+        phase: "finished",
+      },
+    ];
+    const md = linesToMarkdown(lines);
+    expect(md).toContain("### Tool: `shell`");
+    expect(md).toContain("```\nnot json\n```");
+  });
+
+  test("can omit tool calls entirely", () => {
+    const lines: Line[] = [
+      { kind: "user", id: "u1", text: "run it" },
+      {
+        kind: "tool_call",
+        id: "t1",
+        name: "bash",
+        argsText: "{}",
+        phase: "finished",
+      },
+    ];
+    expect(linesToMarkdown(lines, { includeToolCalls: false })).toBe(
+      "## User\n\nrun it",
+    );
+  });
+
+  test("escapes code fences when content contains backticks", () => {
+    const lines: Line[] = [
+      {
+        kind: "tool_call",
+        id: "t1",
+        name: "shell",
+        argsText: "echo ```nested```",
+        phase: "finished",
+      },
+    ];
+    const md = linesToMarkdown(lines);
+    // A run of 3 backticks in the content forces a 4-backtick fence.
+    expect(md).toContain("````\necho ```nested```\n````");
+  });
+
+  test("merges streaming continuation lines into a single assistant section", () => {
+    const lines: Line[] = [
+      {
+        kind: "assistant",
+        id: "a1",
+        text: "First paragraph.\n\n",
+        phase: "finished",
+      },
+      {
+        kind: "assistant",
+        id: "a1-split-0",
+        text: "Second paragraph.",
+        phase: "finished",
+        isContinuation: true,
+      },
+    ];
+    expect(linesToMarkdown(lines)).toBe(
+      "## Assistant\n\nFirst paragraph.\n\nSecond paragraph.",
+    );
+    // A single merged section means exactly one assistant header.
+    expect(linesToMarkdown(lines).match(/## Assistant/g)?.length).toBe(1);
+  });
+
+  test("renders errors and skips non-conversation line kinds", () => {
+    const lines: Line[] = [
+      { kind: "user", id: "u1", text: "hi" },
+      { kind: "command", id: "c1", input: "/help", output: "..." },
+      { kind: "error", id: "e1", text: "Something failed" },
+    ];
+    expect(linesToMarkdown(lines)).toBe(
+      "## User\n\nhi\n\n## Error\n\nSomething failed",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `/copy` slash command that serializes the **current in-context conversation** to clean, GitHub-flavored Markdown and copies it to the system clipboard.

- `/copy` → copy the conversation to the clipboard as Markdown
- `/copy file` → always save to a `letta-conversation-<ts>.md` file in the cwd
- If the clipboard is unavailable (headless, or Linux without `xclip`/`xsel`), `/copy` automatically falls back to writing the same Markdown file, so it never silently fails.

The rendering logic lives in a new pure helper, `linesToMarkdown`, that sits next to the existing `linesToTranscript` in `accumulator.ts`:
- user/assistant turns become `##` headers
- tool calls render as fenced code blocks with pretty-printed JSON args and a collapsible `<details>` result block (labelled `Result (error)` on failure)
- assistant reasoning is excluded by default (opt-in via `includeReasoning`)
- streaming continuation lines (split at paragraph boundaries) merge back into a single section
- code fences are widened when content contains backtick runs, so embedded code never breaks the block

## Why this matters

Sharing a Letta Code session today means manually scrolling and copy-pasting terminal output, which loses structure (tool calls, code blocks) and drags in ANSI noise. `/copy` makes it one keystroke to drop a faithful, readable transcript into a PR description, issue, bug report, doc, or chat. It reuses the same display buffers the TUI already renders, so what you copy is what you saw. `/export` already covers the AgentFile (`.af`) case; this fills the everyday "share this conversation with a human" gap.

## Files changed

- `src/cli/helpers/accumulator.ts` — new pure `linesToMarkdown` helper + options
- `src/cli/helpers/lines-to-markdown.test.ts` — 10 unit tests for the helper
- `src/cli/commands/registry.ts` — register `/copy` (autocomplete + description)
- `src/cli/app/use-submit-handler.ts` — wire `/copy` handler (clipboard + file fallback)
- `src/cli/app/command-routing.ts` — mark `/copy` as a read-only, non-state command

## Test plan

- [x] `bun test src/cli/helpers/lines-to-markdown.test.ts` (10 pass)
- [x] `bun run typecheck`
- [x] `biome check` on changed files
- [x] `check:exported-functions`, `check:filename-casing`, `check:boundaries`, circular-deps — all clean
- [ ] Manual: run `/copy` in a live session, paste from clipboard; run `/copy file` and open the saved `.md`; verify the clipboard-unavailable fallback on Linux

👾 Generated with [Letta Code](https://letta.com)