### PR TITLE
feat(goal): cap autonomous goal-loop continuation with a max-step limit

### DIFF
--- a/src/cli/app/goal-loop.ts
+++ b/src/cli/app/goal-loop.ts
@@ -24,5 +24,7 @@ export function buildGoalPrompt(
     tokensUsed: storedGoal?.tokensUsed ?? 0,
     tokenBudget: storedGoal?.tokenBudget ?? state.tokenBudget,
     timeUsedSeconds: (storedGoal?.activeTimeSeconds ?? 0) + liveActiveSeconds,
+    currentStep: state.currentIteration,
+    maxSteps: state.maxSteps,
   });
 }

--- a/src/cli/app/use-conversation-loop.ts
+++ b/src/cli/app/use-conversation-loop.ts
@@ -582,6 +582,32 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
           return;
         }
 
+        // Stop cleanly when the autonomous step cap is reached. The goal is
+        // paused (not failed) so the user can /goal resume or raise the cap.
+        if (goalLoopMode.hasReachedStepLimit()) {
+          const reachedMaxSteps = goalState.maxSteps;
+          goalLoopMode.deactivate();
+          setUiGoalLoopActive(false);
+          settingsManager.updateConversationGoalStatus(
+            conversationIdRef.current,
+            "paused",
+          );
+          permissionMode.setMode("standard");
+          setUiPermissionMode("standard");
+
+          const statusId = uid("status");
+          buffersRef.current.byId.set(statusId, {
+            kind: "status",
+            id: statusId,
+            lines: [
+              `⏹️ Goal loop reached its step cap (${goalState.currentIteration}/${reachedMaxSteps}). Paused — run /goal resume to keep going or /goal --max-steps N to raise the cap.`,
+            ],
+          });
+          buffersRef.current.order.push(statusId);
+          refreshDerived();
+          return;
+        }
+
         if (!goalLoopMode.shouldContinue()) {
           return;
         }

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -58,6 +58,7 @@ import { formatErrorDetails } from "@/cli/helpers/error-formatter";
 import {
   buildGoalReminder,
   formatGoalSummary,
+  GOAL_DEFAULT_MAX_STEPS,
   GOAL_USAGE,
   GOAL_USAGE_HINT,
   goalStatusLabel,
@@ -1948,7 +1949,11 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
                 currentConversationId,
                 true,
               );
-              goalLoopMode.activateGoal(goal.objective, goal.tokenBudget);
+              goalLoopMode.activateGoal(
+                goal.objective,
+                goal.tokenBudget,
+                goal.maxSteps ?? GOAL_DEFAULT_MAX_STEPS,
+              );
               setUiGoalLoopActive(true);
               permissionMode.setMode("unrestricted");
               setUiPermissionMode("unrestricted");
@@ -2004,17 +2009,20 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             process.cwd(),
             parsedGoal.tokenBudget,
             true,
+            parsedGoal.maxSteps,
           );
           goalLoopMode.activateGoal(
             parsedGoal.objective,
             parsedGoal.tokenBudget,
+            parsedGoal.maxSteps,
           );
           setUiGoalLoopActive(true);
           permissionMode.setMode("unrestricted");
           setUiPermissionMode("unrestricted");
           const replaced = previousGoal ? " replaced" : " active";
+          const stepCapLabel = parsedGoal.maxSteps ?? "∞";
           cmd.finish(
-            `Goal${replaced} (iter 1/∞)\n${formatGoalSummary(goal)}`,
+            `Goal${replaced} (iter 1/${stepCapLabel})\n${formatGoalSummary(goal)}`,
             true,
           );
           const goalState = goalLoopMode.getState();

--- a/src/cli/goal-command.test.ts
+++ b/src/cli/goal-command.test.ts
@@ -6,6 +6,7 @@ import {
   formatGoalElapsedSeconds,
   formatGoalStatusIndicator,
   formatGoalSummary,
+  GOAL_DEFAULT_MAX_STEPS,
   goalStatusLabel,
   parseGoalArgs,
   validateGoalObjective,
@@ -119,6 +120,40 @@ describe("goalCommand - parseGoalArgs", () => {
     const result = parseGoalArgs("--token-budget 50000");
     expect(result.objective).toBe("");
     expect(result.tokenBudget).toBe(50000);
+  });
+
+  test("applies the default max-steps cap when no flag is provided", () => {
+    const result = parseGoalArgs("ship the feature");
+    expect(result.maxSteps).toBe(GOAL_DEFAULT_MAX_STEPS);
+  });
+
+  test("parses --max-steps flag", () => {
+    const result = parseGoalArgs("--max-steps 12 improve coverage");
+    expect(result.objective).toBe("improve coverage");
+    expect(result.maxSteps).toBe(12);
+    expect(result.error).toBeUndefined();
+  });
+
+  test("treats --max-steps 0/unlimited as no cap", () => {
+    expect(parseGoalArgs("--max-steps 0 keep going").maxSteps).toBeNull();
+    expect(
+      parseGoalArgs("--max-steps unlimited keep going").maxSteps,
+    ).toBeNull();
+  });
+
+  test("returns error for negative-ish / invalid max-steps is treated as text", () => {
+    // The regex only matches \d+|unlimited|none|off, so "-5" is not captured;
+    // the cap falls back to the default and the text becomes the objective.
+    const result = parseGoalArgs("--max-steps -5 do something");
+    expect(result.maxSteps).toBe(GOAL_DEFAULT_MAX_STEPS);
+    expect(result.error).toBeUndefined();
+  });
+
+  test("parses --token-budget and --max-steps together", () => {
+    const result = parseGoalArgs("--token-budget 1000 --max-steps 8 redo this");
+    expect(result.objective).toBe("redo this");
+    expect(result.tokenBudget).toBe(1000);
+    expect(result.maxSteps).toBe(8);
   });
 });
 
@@ -304,6 +339,31 @@ describe("goalCommand - buildGoalContinuationPrompt", () => {
     });
     expect(prompt).toContain('status "blocked"');
     expect(prompt).toContain("three consecutive goal turns");
+  });
+
+  test("surfaces the autonomous step cap when one is configured", () => {
+    const prompt = buildGoalContinuationPrompt({
+      objective: "do the thing",
+      status: "active",
+      tokensUsed: 100,
+      tokenBudget: null,
+      timeUsedSeconds: 30,
+      currentStep: 4,
+      maxSteps: 10,
+    });
+    expect(prompt).toContain("Autonomous step: 4 of 10");
+  });
+
+  test("omits the step line when no cap is configured", () => {
+    const prompt = buildGoalContinuationPrompt({
+      objective: "do the thing",
+      status: "active",
+      tokensUsed: 100,
+      tokenBudget: null,
+      timeUsedSeconds: 30,
+      maxSteps: null,
+    });
+    expect(prompt).not.toContain("Autonomous step:");
   });
 });
 

--- a/src/cli/helpers/goal-command.ts
+++ b/src/cli/helpers/goal-command.ts
@@ -3,11 +3,18 @@ import type { ConversationGoal } from "@/settings-manager";
 import { formatCompact } from "./format";
 
 export const GOAL_USAGE =
-  "Usage: /goal [status|pause|resume|complete|clear|disable|--replace|--token-budget N <objective>]";
+  "Usage: /goal [status|pause|resume|complete|clear|disable|--replace|--token-budget N|--max-steps N <objective>]";
 export const GOAL_USAGE_HINT =
-  "Example: /goal --token-budget 50000 improve benchmark coverage";
+  "Example: /goal --token-budget 50000 --max-steps 30 improve benchmark coverage";
 
 const MAX_GOAL_OBJECTIVE_CHARS = 4000;
+
+/**
+ * Default cap on autonomous goal-loop continuation turns. Prevents an
+ * unattended `/goal` from looping indefinitely in unrestricted mode. Users can
+ * override with `--max-steps N`, or disable with `--max-steps 0|unlimited`.
+ */
+export const GOAL_DEFAULT_MAX_STEPS = 50;
 
 export function validateGoalObjective(objective: string): string | null {
   if (!objective.trim()) return "Goal objective must not be empty.";
@@ -35,11 +42,14 @@ export function goalStatusLabel(status: ConversationGoal["status"]): string {
 export function parseGoalArgs(input: string): {
   objective: string;
   tokenBudget: number | null;
+  maxSteps: number | null;
   replace: boolean;
   error?: string;
 } {
   let rest = input.trim();
   let tokenBudget: number | null = null;
+  // Absent flag → default cap; explicit `0`/`unlimited`/`none`/`off` → no cap.
+  let maxSteps: number | null = GOAL_DEFAULT_MAX_STEPS;
   let replace = false;
 
   const budgetMatch = rest.match(/--token-budget\s+(\d+)/);
@@ -49,11 +59,34 @@ export function parseGoalArgs(input: string): {
       return {
         objective: "",
         tokenBudget: null,
+        maxSteps,
         replace,
         error: "Token budget must be a positive integer.",
       };
     }
     rest = rest.replace(/--token-budget\s+\d+\s*/, "");
+  }
+
+  const stepsMatch = rest.match(/--max-steps\s+(\d+|unlimited|none|off)/i);
+  if (stepsMatch?.[1]) {
+    const raw = stepsMatch[1].toLowerCase();
+    if (raw === "unlimited" || raw === "none" || raw === "off" || raw === "0") {
+      maxSteps = null;
+    } else {
+      const parsed = Number.parseInt(raw, 10);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        return {
+          objective: "",
+          tokenBudget,
+          maxSteps,
+          replace,
+          error:
+            "Max steps must be a positive integer, or 0/unlimited to disable the cap.",
+        };
+      }
+      maxSteps = parsed;
+    }
+    rest = rest.replace(/--max-steps\s+(?:\d+|unlimited|none|off)\s*/i, "");
   }
 
   if (/--replace\b/.test(rest)) {
@@ -64,6 +97,7 @@ export function parseGoalArgs(input: string): {
   return {
     objective: rest.trim().replace(/^["']|["']$/g, ""),
     tokenBudget,
+    maxSteps,
     replace,
   };
 }
@@ -147,12 +181,18 @@ export function buildGoalContinuationPrompt(input: {
   tokensUsed: number;
   tokenBudget: number | null;
   timeUsedSeconds: number;
+  currentStep?: number;
+  maxSteps?: number | null;
 }): string {
   const tokenBudget = input.tokenBudget?.toString() ?? "none";
   const remainingTokens = input.tokenBudget
     ? Math.max(0, input.tokenBudget - input.tokensUsed).toString()
     : "unbounded";
   const objective = escapeXmlText(input.objective);
+  const stepLine =
+    input.maxSteps != null
+      ? `\n- Autonomous step: ${input.currentStep ?? 1} of ${input.maxSteps} (the loop stops automatically at the cap)`
+      : "";
 
   return `Continue working toward the active thread goal.
 
@@ -166,7 +206,7 @@ Budget:
 - Time spent pursuing goal: ${input.timeUsedSeconds} seconds
 - Tokens used: ${input.tokensUsed}
 - Token budget: ${tokenBudget}
-- Tokens remaining: ${remainingTokens}
+- Tokens remaining: ${remainingTokens}${stepLine}
 
 Avoid repeating work that is already done. Choose the next concrete action toward the objective.
 

--- a/src/goal-loop-mode.test.ts
+++ b/src/goal-loop-mode.test.ts
@@ -57,5 +57,38 @@ describe("goal loop mode", () => {
     expect(state.originalPrompt).toBe("");
     expect(state.currentIteration).toBe(0);
     expect(state.tokenBudget).toBeNull();
+    expect(state.maxSteps).toBeNull();
+  });
+
+  test("stores the max-steps cap when provided", () => {
+    goalLoopMode.activateGoal("fix the bug", null, 3);
+    expect(goalLoopMode.getState().maxSteps).toBe(3);
+  });
+
+  test("defaults max steps to null (unbounded)", () => {
+    goalLoopMode.activateGoal("fix the bug");
+    expect(goalLoopMode.getState().maxSteps).toBeNull();
+  });
+
+  test("hasReachedStepLimit is false when no cap is set", () => {
+    goalLoopMode.activateGoal("fix the bug");
+    for (let i = 0; i < 5; i++) goalLoopMode.incrementIteration();
+    expect(goalLoopMode.hasReachedStepLimit()).toBe(false);
+    expect(goalLoopMode.shouldContinue()).toBe(true);
+  });
+
+  test("hasReachedStepLimit trips once the cap is reached", () => {
+    goalLoopMode.activateGoal("fix the bug", null, 3); // starts at iteration 1
+    expect(goalLoopMode.hasReachedStepLimit()).toBe(false);
+    goalLoopMode.incrementIteration(); // 2
+    expect(goalLoopMode.hasReachedStepLimit()).toBe(false);
+    expect(goalLoopMode.shouldContinue()).toBe(true);
+    goalLoopMode.incrementIteration(); // 3 == cap
+    expect(goalLoopMode.hasReachedStepLimit()).toBe(true);
+    expect(goalLoopMode.shouldContinue()).toBe(false);
+  });
+
+  test("shouldContinue is false when the loop is inactive", () => {
+    expect(goalLoopMode.shouldContinue()).toBe(false);
   });
 });

--- a/src/goal-loop-mode.ts
+++ b/src/goal-loop-mode.ts
@@ -6,6 +6,9 @@ export type GoalLoopState = {
   originalPrompt: string;
   currentIteration: number;
   tokenBudget: number | null;
+  // Max number of autonomous continuation turns before the loop stops itself.
+  // `null` means unbounded (the legacy behavior).
+  maxSteps: number | null;
 };
 
 // Use globalThis to ensure singleton across bundle.
@@ -21,6 +24,7 @@ function getDefaultState(): GoalLoopState {
     originalPrompt: "",
     currentIteration: 0,
     tokenBudget: null,
+    maxSteps: null,
   };
 }
 
@@ -38,12 +42,17 @@ function setGlobalState(state: GoalLoopState): void {
 }
 
 class GoalLoopModeManager {
-  activateGoal(objective: string, tokenBudget: number | null = null): void {
+  activateGoal(
+    objective: string,
+    tokenBudget: number | null = null,
+    maxSteps: number | null = null,
+  ): void {
     setGlobalState({
       isActive: true,
       originalPrompt: objective,
       currentIteration: 1,
       tokenBudget,
+      maxSteps,
     });
   }
 
@@ -69,8 +78,20 @@ class GoalLoopModeManager {
     return /<goal_status>\s*complete\s*<\/goal_status>/i.test(text);
   }
 
+  /**
+   * True once the loop has run at least `maxSteps` autonomous turns. Returns
+   * false when no cap is configured (`maxSteps === null`).
+   */
+  hasReachedStepLimit(): boolean {
+    const state = getGlobalState();
+    return state.maxSteps !== null && state.currentIteration >= state.maxSteps;
+  }
+
   shouldContinue(): boolean {
-    return getGlobalState().isActive;
+    const state = getGlobalState();
+    // Defense in depth: even if a caller forgets the explicit step-limit
+    // check, never continue past the configured cap.
+    return state.isActive && !this.hasReachedStepLimit();
   }
 }
 

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -70,6 +70,9 @@ export interface ConversationGoal {
   activeTimeSeconds: number;
   tokensUsed: number;
   tokenBudget?: number | null;
+  // Max autonomous continuation turns before the goal loop stops itself.
+  // `null`/undefined means unbounded.
+  maxSteps?: number | null;
 }
 
 export interface Settings {
@@ -1610,6 +1613,7 @@ class SettingsManager {
     workingDirectory: string = process.cwd(),
     tokenBudget: number | null = null,
     resetUsage: boolean = true,
+    maxSteps: number | null = null,
   ): ConversationGoal {
     const globalSettings = this.getSettings();
     const serverKey = getCurrentServerKey(globalSettings);
@@ -1626,6 +1630,7 @@ class SettingsManager {
       activeTimeSeconds: resetUsage ? 0 : (previous?.activeTimeSeconds ?? 0),
       tokensUsed: resetUsage ? 0 : (previous?.tokensUsed ?? 0),
       tokenBudget,
+      maxSteps,
     };
     this.updateLocalProjectSettings(
       {

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -15,6 +15,7 @@ import { formatErrorDetails } from "@/cli/helpers/error-formatter";
 import {
   buildGoalContinuationPrompt,
   formatGoalSummary,
+  GOAL_DEFAULT_MAX_STEPS,
   GOAL_USAGE,
   GOAL_USAGE_HINT,
   goalStatusLabel,
@@ -795,7 +796,11 @@ async function handleGoalCommand(
       }
     } else if (lowerGoalArg === "resume") {
       settingsManager.setConversationGoalToolsEnabled(conversationId, true);
-      goalLoopMode.activateGoal(goal.objective, goal.tokenBudget);
+      goalLoopMode.activateGoal(
+        goal.objective,
+        goal.tokenBudget,
+        goal.maxSteps ?? GOAL_DEFAULT_MAX_STEPS,
+      );
       permState.mode = "unrestricted";
       persistPermissionModeMapForRuntime(conversationRuntime.listener);
 
@@ -818,6 +823,8 @@ async function handleGoalCommand(
         tokenBudget: storedGoal?.tokenBudget ?? goalState.tokenBudget,
         timeUsedSeconds:
           (storedGoal?.activeTimeSeconds ?? 0) + liveActiveSeconds,
+        currentStep: goalState.currentIteration,
+        maxSteps: goalState.maxSteps,
       });
 
       await handleIncomingMessage(
@@ -866,8 +873,13 @@ async function handleGoalCommand(
     conversationRuntime.activeWorkingDirectory ?? process.cwd(),
     parsedGoal.tokenBudget,
     true,
+    parsedGoal.maxSteps,
   );
-  goalLoopMode.activateGoal(parsedGoal.objective, parsedGoal.tokenBudget);
+  goalLoopMode.activateGoal(
+    parsedGoal.objective,
+    parsedGoal.tokenBudget,
+    parsedGoal.maxSteps,
+  );
 
   const permState = getOrCreateConversationPermissionModeStateRef(
     conversationRuntime.listener,
@@ -878,7 +890,8 @@ async function handleGoalCommand(
   persistPermissionModeMapForRuntime(conversationRuntime.listener);
 
   const replaced = previousGoal ? " replaced" : " active";
-  const resultPrefix = `Goal${replaced} (iter 1/∞)\n${formatGoalSummary(goal)}`;
+  const stepCapLabel = parsedGoal.maxSteps ?? "∞";
+  const resultPrefix = `Goal${replaced} (iter 1/${stepCapLabel})\n${formatGoalSummary(goal)}`;
 
   // Send initial goal continuation prompt through the turn pipeline
   const goalState = goalLoopMode.getState();
@@ -898,6 +911,8 @@ async function handleGoalCommand(
     tokensUsed: storedGoal?.tokensUsed ?? 0,
     tokenBudget: storedGoal?.tokenBudget ?? goalState.tokenBudget,
     timeUsedSeconds: (storedGoal?.activeTimeSeconds ?? 0) + liveActiveSeconds,
+    currentStep: goalState.currentIteration,
+    maxSteps: goalState.maxSteps,
   });
 
   await handleIncomingMessage(


### PR DESCRIPTION
## Summary

The `/goal` autonomous loop already continues turn-after-turn until the goal is **complete**, **blocked**, an **approval** is needed, or the **token budget** is exhausted. The one missing safety stop from the goal-mode mental model (Codex `follow-goals`) was a **max-step cap** — the loop ran `iter 1/∞` in **unrestricted** permission mode, so an unattended `/goal` could loop indefinitely.

This adds an enforced step cap:

- `/goal --max-steps N <objective>` sets the cap.
- `--max-steps 0` / `--max-steps unlimited` disables it.
- Defaults to `GOAL_DEFAULT_MAX_STEPS` (50) when no flag is given.
- On reaching the cap the loop **stops cleanly and pauses** the goal (not failed), so the user can `/goal resume` or raise the cap with `/goal --max-steps N`. A status line explains exactly what happened.
- `shouldContinue()` now respects the cap as defense-in-depth, and the continuation prompt surfaces `Autonomous step: X of N` to the model so it can prioritize.

`maxSteps` is parsed, persisted on the conversation goal, threaded through activation/resume, and displayed as `iter 1/N` in both the TUI and the websocket listener.

## Why this matters

The goal loop runs in unrestricted permission mode. Without a step cap, a goal the model never marks complete (or a subtly looping plan) keeps spending tokens and taking actions unattended. A default cap makes "goal mode" safe-by-default while staying fully overridable, and directly implements the tickets "Max step count" safety requirement and the "stop on step cap" acceptance test. Design reference: OpenAI Codex `follow-goals` (loop until done / blocked / budget / approval / cap).

## Behavior matrix (unchanged stops + new one)

| Condition | Result |
| --- | --- |
| Model marks `complete` / `blocked` | loop stops (existing) |
| Approval required | loop pauses for approval (existing) |
| Token budget reached | `budget_limited` wrap-up (existing) |
| **Step cap reached** | **loop pauses, resumable (new)** |
| User ESC | loop pauses, resumable (existing) |

## Files changed

- `src/goal-loop-mode.ts` — `maxSteps` in loop state, `hasReachedStepLimit()`, cap-aware `shouldContinue()`
- `src/cli/helpers/goal-command.ts` — `GOAL_DEFAULT_MAX_STEPS`, parse `--max-steps`, usage text, step line in continuation prompt
- `src/cli/app/goal-loop.ts` — pass current step / cap into the prompt
- `src/cli/app/use-conversation-loop.ts` — clean resumable stop + status line when the cap is hit
- `src/cli/app/use-submit-handler.ts` — thread `maxSteps` through `/goal` create + resume; show `iter 1/N`
- `src/settings-manager.ts` — persist `maxSteps` on `ConversationGoal`
- `src/websocket/listener/commands.ts` — same threading for the listener surface
- `src/goal-loop-mode.test.ts`, `src/cli/goal-command.test.ts` — new unit tests

## Test plan

- [x] `bun test src/goal-loop-mode.test.ts src/cli/goal-command.test.ts` (56 pass) — covers: cap stored, `hasReachedStepLimit` trips at cap, `shouldContinue` stops at cap and when inactive, default cap applied, `--max-steps` parsing incl. `0`/`unlimited`/invalid, combined flags, and step line present/absent in the prompt
- [x] `bun run typecheck`
- [x] `biome check` on changed files
- [x] `check:boundaries`, `check:exported-functions`, circular-deps — clean
- [x] Confirmed the only failing repo tests (`Settings Manager - Conversation Pins`, x3) also fail on a clean base branch — pre-existing, unrelated
- [ ] Manual: `/goal --max-steps 3 <objective>` and watch it pause at 3/3; `/goal resume` continues; `/goal --max-steps 0` runs unbounded

## Notes / follow-ups (out of scope)

- Wall-clock cap is tracked but still not enforced (could mirror this cap next).
- Agent-created goals via the `create_goal` tool remain uncapped (unchanged behavior); could adopt the default cap in a follow-up.

👾 Generated with [Letta Code](https://letta.com)