### PR TITLE
feat: Add session-scoped approval option to permission dialogs

### DIFF
--- a/src/cli/components/InlineBashApproval.tsx
+++ b/src/cli/components/InlineBashApproval.tsx
@@ -59,8 +59,10 @@ export const InlineBashApproval = memo(
     const columns = useTerminalWidth();
     useProgressIndicator();
 
-    // Custom option index depends on whether "always" option is shown
-    const customOptionIndex = allowPersistence ? 2 : 1;
+    // Show session-only option when defaultScope is "project" and persistence is allowed
+    const showSessionOption = allowPersistence && defaultScope === "project";
+    // Custom option index depends on how many fixed options are shown
+    const customOptionIndex = showSessionOption ? 3 : allowPersistence ? 2 : 1;
     const maxOptionIndex = customOptionIndex;
     const isOnCustomOption = selectedOption === customOptionIndex;
     const customOptionPlaceholder =
@@ -112,6 +114,8 @@ export const InlineBashApproval = memo(
             onApprove();
           } else if (selectedOption === 1 && allowPersistence) {
             onApproveAlways(defaultScope);
+          } else if (selectedOption === 2 && showSessionOption) {
+            onApproveAlways("session");
           }
           return;
         }
@@ -128,6 +132,10 @@ export const InlineBashApproval = memo(
         }
         if (input === "2" && allowPersistence) {
           onApproveAlways(defaultScope);
+          return;
+        }
+        if (input === "3" && showSessionOption) {
+          onApproveAlways("session");
           return;
         }
       },
@@ -229,13 +237,40 @@ export const InlineBashApproval = memo(
                   }
                 >
                   {approveAlwaysText ||
-                    "Yes, and don't ask again for this project"}
+                    (defaultScope === "session"
+                      ? "Yes, and don't ask again for this session"
+                      : "Yes, and don't ask again for this project")}
                 </Text>
               </Box>
             </Box>
           )}
 
-          {/* Custom input option (3 if persistence, 2 if not) */}
+          {/* Option 3: Yes, allow for this session only (only when defaultScope is project) */}
+          {showSessionOption && (
+            <Box flexDirection="row">
+              <Box width={5} flexShrink={0}>
+                <Text
+                  color={
+                    selectedOption === 2 ? colors.approval.header : undefined
+                  }
+                >
+                  {selectedOption === 2 ? "❯" : " "} 3.
+                </Text>
+              </Box>
+              <Box flexGrow={1} width={Math.max(0, columns - 5)}>
+                <Text
+                  wrap="wrap"
+                  color={
+                    selectedOption === 2 ? colors.approval.header : undefined
+                  }
+                >
+                  Yes, allow for this session only
+                </Text>
+              </Box>
+            </Box>
+          )}
+
+          {/* Custom input option (4 if session option shown, 3 if persistence, 2 if not) */}
           <Box flexDirection="row">
             <Box width={5} flexShrink={0}>
               <Text

--- a/src/cli/components/InlineFileEditApproval.tsx
+++ b/src/cli/components/InlineFileEditApproval.tsx
@@ -176,8 +176,10 @@ export const InlineFileEditApproval = memo(
     const columns = useTerminalWidth();
     useProgressIndicator();
 
-    // Custom option index depends on whether "always" option is shown
-    const customOptionIndex = allowPersistence ? 2 : 1;
+    // Show session-only option when defaultScope is "project" and persistence is allowed
+    const showSessionOption = allowPersistence && defaultScope === "project";
+    // Custom option index depends on how many fixed options are shown
+    const customOptionIndex = showSessionOption ? 3 : allowPersistence ? 2 : 1;
     const maxOptionIndex = customOptionIndex;
     const isOnCustomOption = selectedOption === customOptionIndex;
 
@@ -276,6 +278,11 @@ export const InlineFileEditApproval = memo(
               defaultScope,
               diffsToPass.size > 0 ? diffsToPass : undefined,
             );
+          } else if (selectedOption === 2 && showSessionOption) {
+            onApproveAlways(
+              "session",
+              diffsToPass.size > 0 ? diffsToPass : undefined,
+            );
           }
           return;
         }
@@ -292,6 +299,13 @@ export const InlineFileEditApproval = memo(
         if (input === "2" && allowPersistence) {
           onApproveAlways(
             defaultScope,
+            diffsToPass.size > 0 ? diffsToPass : undefined,
+          );
+          return;
+        }
+        if (input === "3" && showSessionOption) {
+          onApproveAlways(
+            "session",
             diffsToPass.size > 0 ? diffsToPass : undefined,
           );
           return;
@@ -503,7 +517,34 @@ export const InlineFileEditApproval = memo(
                   }
                 >
                   {approveAlwaysText ||
-                    "Yes, and don't ask again for this project"}
+                    (defaultScope === "session"
+                      ? "Yes, and don't ask again for this session"
+                      : "Yes, and don't ask again for this project")}
+                </Text>
+              </Box>
+            </Box>
+          )}
+
+          {/* Option 3: Yes, allow for this session only (only when defaultScope is project) */}
+          {showSessionOption && (
+            <Box flexDirection="row">
+              <Box width={5} flexShrink={0}>
+                <Text
+                  color={
+                    selectedOption === 2 ? colors.approval.header : undefined
+                  }
+                >
+                  {selectedOption === 2 ? "❯" : " "} 3.
+                </Text>
+              </Box>
+              <Box flexGrow={1} width={Math.max(0, columns - 5)}>
+                <Text
+                  wrap="wrap"
+                  color={
+                    selectedOption === 2 ? colors.approval.header : undefined
+                  }
+                >
+                  Yes, allow for this session only
                 </Text>
               </Box>
             </Box>

--- a/src/cli/components/InlineGenericApproval.tsx
+++ b/src/cli/components/InlineGenericApproval.tsx
@@ -71,8 +71,10 @@ export const InlineGenericApproval = memo(
     const columns = useTerminalWidth();
     useProgressIndicator();
 
-    // Custom option index depends on whether "always" option is shown
-    const customOptionIndex = allowPersistence ? 2 : 1;
+    // Show session-only option when defaultScope is "project" and persistence is allowed
+    const showSessionOption = allowPersistence && defaultScope === "project";
+    // Custom option index depends on how many fixed options are shown
+    const customOptionIndex = showSessionOption ? 3 : allowPersistence ? 2 : 1;
     const maxOptionIndex = customOptionIndex;
     const isOnCustomOption = selectedOption === customOptionIndex;
     const customOptionPlaceholder =
@@ -124,6 +126,8 @@ export const InlineGenericApproval = memo(
             onApprove();
           } else if (selectedOption === 1 && allowPersistence) {
             onApproveAlways(defaultScope);
+          } else if (selectedOption === 2 && showSessionOption) {
+            onApproveAlways("session");
           }
           return;
         }
@@ -139,6 +143,10 @@ export const InlineGenericApproval = memo(
         }
         if (input === "2" && allowPersistence) {
           onApproveAlways(defaultScope);
+          return;
+        }
+        if (input === "3" && showSessionOption) {
+          onApproveAlways("session");
           return;
         }
       },
@@ -232,7 +240,34 @@ export const InlineGenericApproval = memo(
                   }
                 >
                   {approveAlwaysText ||
-                    "Yes, and don't ask again for this project"}
+                    (defaultScope === "session"
+                      ? "Yes, and don't ask again for this session"
+                      : "Yes, and don't ask again for this project")}
+                </Text>
+              </Box>
+            </Box>
+          )}
+
+          {/* Option 3: Yes, allow for this session only (only when defaultScope is project) */}
+          {showSessionOption && (
+            <Box flexDirection="row">
+              <Box width={5} flexShrink={0}>
+                <Text
+                  color={
+                    selectedOption === 2 ? colors.approval.header : undefined
+                  }
+                >
+                  {selectedOption === 2 ? "❯" : " "} 3.
+                </Text>
+              </Box>
+              <Box flexGrow={1} width={Math.max(0, columns - 5)}>
+                <Text
+                  wrap="wrap"
+                  color={
+                    selectedOption === 2 ? colors.approval.header : undefined
+                  }
+                >
+                  Yes, allow for this session only
                 </Text>
               </Box>
             </Box>


### PR DESCRIPTION
## Summary

- Adds a "Yes, allow for this session only" option (option 3) to inline approval dialogs when the analyzer defaultScope is "project"
- Fixes fallback text for option 2 to correctly show "session" vs "project" based on the analyzer-provided defaultScope
- Gives users an explicit choice between project-persistent and session-only permission rules

## Problem

When users approve a tool "always", the approval is saved with the scope determined by the analyzer. For bash commands (git, gh, npm, etc.), the default scope is "project", which persists the rule to `.letta/settings.json`. This means a one-time approval decision becomes permanent, leading to permission bloat and potential security concerns.

Meanwhile, the analyzer already sets `defaultScope: "session"` for many safe operations (Read within project, Write, Glob/Grep, Task, Edit at project root). But the UI always showed "Yes, and don't ask again for this project" regardless of the actual scope.

## Changes

### UI Components (3 files)

**InlineBashApproval.tsx**, **InlineFileEditApproval.tsx**, **InlineGenericApproval.tsx**:
- When `defaultScope === "project"` and `allowPersistence === true`, show a 3rd option: "Yes, allow for this session only"
- This option calls `onApproveAlways("session")` — saving the rule to in-memory `SessionPermissions` instead of disk
- Option 2 text now reflects the actual scope: "Yes, and don't ask again for this session" when `defaultScope === "session"`, or "this project" when `defaultScope === "project"`
- Custom input option (deny with feedback) shifts to option 4 when session option is shown

**Not modified** (already correct):
- `InlineTaskApproval` — already hardcodes `scope: "session"` and says "during this session"
- `InlineMemoryApproval` — already defaults to session scope and says "during this session"

### Backend (no changes needed)

The backend already fully supports session-scoped permissions:
- `SessionPermissions` class stores in-memory rules
- `checkPermission()` checks session rules at step 7 (session allow) and step 3.5 (session alwaysAsk)
- `savePermissionRule2()` already handles `scope === "session"` → `sessionPermissions.addRule()`
- `analyzeApprovalContext()` already sets appropriate `defaultScope` per tool type

## UX Flow

Before (project-scoped bash command):
```
1. Yes
2. Yes, and don't ask again for this project  ← permanent!
3. No, and tell Letta Code what to do differently
```

After:
```
1. Yes
2. Yes, and don't ask again for this project  ← permanent
3. Yes, allow for this session only               ← NEW: temporary
4. No, and tell Letta Code what to do differently
```

For session-scoped operations (Read, Write, Glob/Grep, Task, Edit at root):
```
1. Yes
2. Yes, and don't ask again for this session   ← correctly scoped
3. No, and tell Letta Code what to do differently
```
(No extra option since option 2 already does session scope)

## Test plan

- [ ] Verify option 3 appears for bash commands (git, gh, npm, etc.) and saves session-scoped rules
- [ ] Verify option 3 does NOT appear for session-scoped tools (Read, Write, Glob/Grep, Task)
- [ ] Verify option 2 text says "this session" for session-scoped tools
- [ ] Verify option 2 text says "this project" for project-scoped tools
- [ ] Verify session rules are cleared on exit (not persisted to disk)
- [ ] Verify number key "3" works for quick selection
- [ ] Verify arrow navigation works with the new option count
- [ ] Verify existing tests still pass (`bun test`)

👾 Generated with [Letta Code](https://letta.com)