### PR TITLE
feat(input): rotate conversation threads with Ctrl+PageUp/PageDown

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -75,6 +75,11 @@ import {
   resetContextHistory,
 } from "@/cli/helpers/context-tracker";
 import {
+  type ConversationRotationDirection,
+  computeRotatedConversationId,
+  withCurrentConversation,
+} from "@/cli/helpers/conversation-rotation";
+import {
   generateConversationTitleFromSummary,
   getConversationTitleSettings,
   listConversationTitleMessages,
@@ -4580,6 +4585,74 @@ export function App({
     }
   }, [lastShellToolCallId, handleToggleExpandedToolCall]);
 
+  // Ctrl+PageUp / Ctrl+PageDown rotate through the agent's recent conversation
+  // threads, like switching browser tabs. The switch is performed by running
+  // the existing `/resume <id>` command so the transcript backfill, goal
+  // pause, and switch-alert behavior are identical to a manual resume.
+  const handleRotateConversation = useCallback(
+    async (direction: ConversationRotationDirection) => {
+      const currentAgentId = agentIdRef.current ?? agentId;
+      const currentConversationId = conversationIdRef.current ?? conversationId;
+      if (!currentAgentId || !currentConversationId) return;
+
+      let orderedIds: string[];
+      try {
+        const backend = getBackend();
+        // Rotate across the most recently active threads (matches the
+        // ConversationSelector ordering); one page is plenty for tab cycling.
+        const rawPage: unknown = await backend.listConversations({
+          agent_id: currentAgentId,
+          limit: 25,
+          order: "desc",
+          order_by: "last_run_completion",
+        });
+        const items = (
+          Array.isArray(rawPage)
+            ? rawPage
+            : ((
+                rawPage as { getPaginatedItems?: () => unknown[] }
+              ).getPaginatedItems?.() ?? [])
+        ) as Array<{ id?: string }>;
+        orderedIds = items
+          .map((conversation) => conversation.id)
+          .filter((id): id is string => typeof id === "string");
+      } catch (error) {
+        commandRunner
+          .start(
+            direction === "next" ? "(next thread)" : "(previous thread)",
+            "Switching thread...",
+          )
+          .fail(
+            `Failed to list threads: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        return;
+      }
+
+      const rotatable = withCurrentConversation(
+        orderedIds,
+        currentConversationId,
+      );
+      const targetId = computeRotatedConversationId(
+        rotatable,
+        currentConversationId,
+        direction,
+      );
+      if (!targetId) {
+        commandRunner
+          .start(
+            direction === "next" ? "(next thread)" : "(previous thread)",
+            "Switching thread...",
+          )
+          .finish("No other threads to switch to", true);
+        return;
+      }
+
+      // Reuse the canonical direct-switch path (full transcript backfill).
+      void onSubmit(`/resume ${targetId}`);
+    },
+    [agentId, conversationId, commandRunner, onSubmit],
+  );
+
   // Handle permission mode changes from the Input component (e.g., shift+tab cycling)
   const handlePermissionModeChange = useCallback(
     (mode: PermissionMode) => {
@@ -4970,6 +5043,7 @@ export function App({
         expandedToolCallId={expandedToolCallId}
         lastShellToolCallId={lastShellToolCallId}
         handleCtrlO={handleCtrlO}
+        handleRotateConversation={handleRotateConversation}
         queueMode={queueMode}
         deferModeSupported={deferModeSupported}
         handleCtrlD={handleCtrlD}

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -161,6 +161,9 @@ type AppViewProps = {
   expandedToolCallId: string | null;
   lastShellToolCallId: string | null;
   handleCtrlO: () => void;
+  handleRotateConversation: (
+    direction: "next" | "prev",
+  ) => void | Promise<void>;
   queueMode: "immediate" | "defer";
   deferModeSupported: boolean;
   handleCtrlD: () => void;
@@ -375,6 +378,7 @@ export function AppView(props: AppViewProps) {
     expandedToolCallId,
     lastShellToolCallId,
     handleCtrlO,
+    handleRotateConversation,
     queueMode,
     deferModeSupported,
     handleCtrlD,
@@ -732,6 +736,7 @@ export function AppView(props: AppViewProps) {
                 onExit={handleExit}
                 onInterrupt={handleInterrupt}
                 onCtrlO={handleCtrlO}
+                onRotateConversation={handleRotateConversation}
                 onCtrlD={handleCtrlD}
                 queueMode={queueMode}
                 deferModeSupported={deferModeSupported}

--- a/src/cli/components/HelpDialog.tsx
+++ b/src/cli/components/HelpDialog.tsx
@@ -79,6 +79,10 @@ export function HelpDialog({ onClose }: HelpDialogProps) {
         description: "Interrupt operation / exit (double press)",
       },
       { keys: "Ctrl+V", description: "Paste content or image" },
+      {
+        keys: "Ctrl+PageUp / Ctrl+PageDown",
+        description: "Switch to previous / next conversation thread",
+      },
     ];
   }, []);
 

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -900,6 +900,7 @@ export function Input({
   onExit,
   onInterrupt,
   onCtrlO,
+  onRotateConversation,
   onCtrlD,
   queueMode = "immediate",
   deferModeSupported = false,
@@ -953,6 +954,7 @@ export function Input({
   onExit?: () => void;
   onInterrupt?: () => void;
   onCtrlO?: () => void;
+  onRotateConversation?: (direction: "next" | "prev") => void | Promise<void>;
   onCtrlD?: () => void;
   queueMode?: "immediate" | "defer";
   deferModeSupported?: boolean;
@@ -1389,6 +1391,13 @@ export function Input({
     // Handle CTRL-O to expand/collapse the last tool call output
     if (input === "o" && key.ctrl) {
       if (onCtrlO) onCtrlO();
+      return;
+    }
+
+    // Ctrl+PageUp / Ctrl+PageDown rotate through conversation threads (like
+    // switching browser tabs). PageUp = previous thread, PageDown = next.
+    if (onRotateConversation && key.ctrl && (key.pageUp || key.pageDown)) {
+      void onRotateConversation(key.pageUp ? "prev" : "next");
       return;
     }
 

--- a/src/cli/helpers/conversation-rotation.test.ts
+++ b/src/cli/helpers/conversation-rotation.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import {
+  computeRotatedConversationId,
+  withCurrentConversation,
+} from "@/cli/helpers/conversation-rotation";
+
+describe("computeRotatedConversationId", () => {
+  const ids = ["a", "b", "c"];
+
+  test("next advances to the following thread", () => {
+    expect(computeRotatedConversationId(ids, "a", "next")).toBe("b");
+    expect(computeRotatedConversationId(ids, "b", "next")).toBe("c");
+  });
+
+  test("prev moves to the preceding thread", () => {
+    expect(computeRotatedConversationId(ids, "c", "prev")).toBe("b");
+    expect(computeRotatedConversationId(ids, "b", "prev")).toBe("a");
+  });
+
+  test("next wraps from the last thread to the first", () => {
+    expect(computeRotatedConversationId(ids, "c", "next")).toBe("a");
+  });
+
+  test("prev wraps from the first thread to the last", () => {
+    expect(computeRotatedConversationId(ids, "a", "prev")).toBe("c");
+  });
+
+  test("returns null when there is only one thread", () => {
+    expect(computeRotatedConversationId(["only"], "only", "next")).toBeNull();
+  });
+
+  test("returns null for an empty list", () => {
+    expect(computeRotatedConversationId([], "a", "next")).toBeNull();
+  });
+
+  test("returns null when the current thread is not in the list", () => {
+    expect(computeRotatedConversationId(ids, "z", "next")).toBeNull();
+  });
+
+  test("ignores duplicate ids when rotating", () => {
+    // "a" appears twice (e.g. also pinned); rotating next from b should reach c,
+    // not stall on a duplicate.
+    expect(
+      computeRotatedConversationId(["a", "b", "a", "c"], "c", "next"),
+    ).toBe("a");
+    expect(
+      computeRotatedConversationId(["a", "b", "a", "c"], "a", "next"),
+    ).toBe("b");
+  });
+});
+
+describe("withCurrentConversation", () => {
+  test("prepends the current id when it is missing", () => {
+    expect(withCurrentConversation(["a", "b"], "default")).toEqual([
+      "default",
+      "a",
+      "b",
+    ]);
+  });
+
+  test("leaves the list untouched when the current id is present", () => {
+    const list = ["a", "b", "c"];
+    expect(withCurrentConversation(list, "b")).toBe(list);
+  });
+
+  test("rotation works after ensuring the current thread is included", () => {
+    const list = withCurrentConversation(["a", "b"], "default");
+    expect(computeRotatedConversationId(list, "default", "next")).toBe("a");
+    expect(computeRotatedConversationId(list, "default", "prev")).toBe("b");
+  });
+});

--- a/src/cli/helpers/conversation-rotation.ts
+++ b/src/cli/helpers/conversation-rotation.ts
@@ -1,0 +1,52 @@
+// Pure helpers for rotating ("tab cycling") through an agent's conversation
+// threads. Kept dependency-free so the logic can be unit-tested in isolation
+// from the TUI and backend.
+
+export type ConversationRotationDirection = "next" | "prev";
+
+/**
+ * Given an ordered list of conversation ids and the id of the current thread,
+ * return the id of the thread to switch to when rotating in `direction`.
+ *
+ * Conventions:
+ * - "next" advances toward later indices (Ctrl+PageDown); "prev" moves toward
+ *   earlier indices (Ctrl+PageUp). Both wrap around the ends.
+ * - Duplicate ids are ignored so a thread that also appears pinned/elsewhere
+ *   does not create a dead step.
+ * - Returns `null` when there is nowhere to rotate to: an empty list, a list
+ *   that only contains the current thread, or a current id that is absent from
+ *   the list (callers should make sure the current id is included first).
+ */
+export function computeRotatedConversationId(
+  orderedIds: string[],
+  currentId: string,
+  direction: ConversationRotationDirection,
+): string | null {
+  const ids: string[] = [];
+  for (const id of orderedIds) {
+    if (id && !ids.includes(id)) ids.push(id);
+  }
+
+  const index = ids.indexOf(currentId);
+  if (index === -1 || ids.length <= 1) return null;
+
+  const delta = direction === "next" ? 1 : -1;
+  const nextIndex = (index + delta + ids.length) % ids.length;
+  return ids[nextIndex] ?? null;
+}
+
+/**
+ * Ensure the current thread participates in rotation even if it is missing from
+ * the fetched page (e.g. an older thread beyond the first page, or the synthetic
+ * "default" conversation). The current id is prepended when absent so it has a
+ * stable position to rotate away from.
+ */
+export function withCurrentConversation(
+  orderedIds: string[],
+  currentId: string,
+): string[] {
+  if (!currentId) return orderedIds;
+  return orderedIds.includes(currentId)
+    ? orderedIds
+    : [currentId, ...orderedIds];
+}


### PR DESCRIPTION
## Summary

Adds browser-tab-style rotation through an agent's conversation threads, driven from the main input:

- **Ctrl+PageUp** → previous thread
- **Ctrl+PageDown** → next thread

Rotation cycles across the most recently active conversations (same ordering as the `/resume` selector) with wraparound, and always includes the current thread even if it is not on the first page. The switch is performed by running the existing `/resume <id>` command, so transcript backfill, goal pausing, and the conversation-switch alert behave **exactly** like a manual resume — no new switch path to keep in sync.

The target/order math lives in a small pure, unit-tested helper (`conversation-rotation.ts`).

## Why Ctrl+PageUp/PageDown (and not Cmd+Shift+[ / ])

The original request was Chrome-style `Cmd+Shift+[ / ]`. Terminals do **not** deliver the `Cmd` (super) modifier to TUI programs — the terminal/OS intercepts it — so a literal `Cmd`-based binding cannot be captured by a terminal app like letta-code. `Ctrl+PageUp/PageDown` is the terminal-deliverable equivalent and is the same shortcut many browsers use for tab switching. The vendored Ink keypress parser already decodes `\e[5;5~` / `\e[6;5~` into `key.pageUp/pageDown + key.ctrl`, so detection is reliable. A host application (e.g. Letta Desktop) can later map `Cmd+Shift+[/]` onto these.

## Behavior details

- Fires only while the input is interactive (idle), so it never interferes with a streaming turn.
- If there are no other threads, shows a brief "No other threads to switch to" status instead of switching.
- On a list-fetch error, surfaces a clear failure message.
- Listed in the Help dialog (Shortcuts tab).

## Files changed

- `src/cli/helpers/conversation-rotation.ts` — pure `computeRotatedConversationId` + `withCurrentConversation` helpers
- `src/cli/helpers/conversation-rotation.test.ts` — 11 unit tests
- `src/cli/app/AppCoordinator.tsx` — `handleRotateConversation` (fetch recent threads → compute target → run `/resume <id>`)
- `src/cli/app/AppView.tsx` — thread the handler to the input
- `src/cli/components/InputRich.tsx` — Ctrl+PageUp/PageDown key handling
- `src/cli/components/HelpDialog.tsx` — document the shortcut

## Test plan

- [x] `bun test src/cli/helpers/conversation-rotation.test.ts` (11 pass) — next/prev, wraparound both ends, single-thread/empty/missing-current → null, duplicate-id dedupe, and current-thread inclusion
- [x] `bun run typecheck`
- [x] `biome check` on changed files
- [x] `check:boundaries`, `check:exported-functions`, `check:filename-casing`, circular-deps — clean
- [ ] Manual: with 2+ threads, Ctrl+PageDown/PageUp cycles and the transcript backfills; wraps at both ends; single-thread shows the no-op status

👾 Generated with [Letta Code](https://letta.com)