### PR TITLE
fix(discord): explain how to fix the "Used disallowed intents" connect error

### DIFF
--- a/src/channels/discord-adapter.test.ts
+++ b/src/channels/discord-adapter.test.ts
@@ -49,6 +49,9 @@ interface DiscordTestMessage {
 
 class FakeDiscordClient {
   static instances: FakeDiscordClient[] = [];
+  // When set, the next login() call rejects with this error (simulates the
+  // gateway refusing the connection, e.g. disallowed intents).
+  static loginError: unknown = null;
 
   readonly user = {
     id: "bot-user",
@@ -61,7 +64,12 @@ class FakeDiscordClient {
     fetch: mock(async () => null),
   };
 
-  readonly login = mock(async (_token: string) => undefined);
+  readonly login = mock(async (_token: string) => {
+    if (FakeDiscordClient.loginError) {
+      throw FakeDiscordClient.loginError;
+    }
+    return undefined;
+  });
   readonly destroy = mock(() => {});
   private readonly handlers = new Map<
     string,
@@ -191,6 +199,7 @@ async function startAdapterWithDeliveries(
 
 beforeEach(() => {
   FakeDiscordClient.instances.length = 0;
+  FakeDiscordClient.loginError = null;
   __testOverrideLoadDiscordModule(async () => createFakeDiscordRuntime());
 });
 
@@ -200,6 +209,31 @@ afterEach(() => {
 
 afterAll(() => {
   mock.restore();
+});
+
+// ── Discord adapter connection errors ──────────────────────────────────
+
+describe("Discord adapter start()", () => {
+  test("translates a disallowed-intents login failure into an actionable error", async () => {
+    FakeDiscordClient.loginError = new Error("Used disallowed intents");
+    const adapter = createDiscordAdapter({
+      ...discordAccountDefaults,
+      allowedChannels: {},
+    });
+
+    await expect(adapter.start()).rejects.toThrow(/Message Content Intent/);
+    expect(adapter.isRunning()).toBe(false);
+  });
+
+  test("preserves unrelated login failures", async () => {
+    FakeDiscordClient.loginError = new Error("An invalid token was provided.");
+    const adapter = createDiscordAdapter({
+      ...discordAccountDefaults,
+      allowedChannels: {},
+    });
+
+    await expect(adapter.start()).rejects.toThrow(/invalid token/i);
+  });
 });
 
 // ── Discord adapter open-channel ingress ───────────────────────────────

--- a/src/channels/discord/adapter.ts
+++ b/src/channels/discord/adapter.ts
@@ -12,6 +12,7 @@ import {
   isDiscordGuildChannelAllowed,
   resolveDiscordChannelMode,
 } from "./channel-gating";
+import { describeDiscordConnectionError } from "./connection-error";
 import { formatDiscordDeliveryError } from "./error-reply";
 import {
   resolveDiscordInboundAttachments,
@@ -893,7 +894,18 @@ export function createDiscordAdapter(
         console.error("[Discord] Client error:", err);
       });
 
-      await client.login(config.token);
+      try {
+        await client.login(config.token);
+      } catch (error) {
+        // Surface an actionable message when the gateway rejects the
+        // connection for missing privileged intents instead of the opaque
+        // "Used disallowed intents" close reason.
+        const friendly = describeDiscordConnectionError(error);
+        if (friendly) {
+          throw new Error(friendly);
+        }
+        throw error;
+      }
     },
 
     async stop(): Promise<void> {

--- a/src/channels/discord/connection-error.test.ts
+++ b/src/channels/discord/connection-error.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DISCORD_DISALLOWED_INTENTS_MESSAGE,
+  describeDiscordConnectionError,
+  isDiscordDisallowedIntentsError,
+} from "@/channels/discord/connection-error";
+
+describe("isDiscordDisallowedIntentsError", () => {
+  test("matches the raw gateway close reason", () => {
+    expect(
+      isDiscordDisallowedIntentsError(new Error("Used disallowed intents")),
+    ).toBe(true);
+  });
+
+  test("matches the discord.js error code", () => {
+    const error = Object.assign(new Error("nope"), {
+      code: "DisallowedIntents",
+    });
+    expect(isDiscordDisallowedIntentsError(error)).toBe(true);
+  });
+
+  test("matches the numeric gateway close code 4014", () => {
+    const error = Object.assign(new Error("Connection closed"), {
+      code: 4014,
+    });
+    expect(isDiscordDisallowedIntentsError(error)).toBe(true);
+  });
+
+  test("matches a 'Privileged intent' phrasing", () => {
+    expect(
+      isDiscordDisallowedIntentsError(
+        new Error("Privileged intent provided is not enabled or whitelisted."),
+      ),
+    ).toBe(true);
+  });
+
+  test("matches plain string errors", () => {
+    expect(isDiscordDisallowedIntentsError("used Disallowed Intent(s)")).toBe(
+      true,
+    );
+  });
+
+  test("ignores unrelated errors", () => {
+    expect(
+      isDiscordDisallowedIntentsError(new Error("Invalid token provided")),
+    ).toBe(false);
+    expect(isDiscordDisallowedIntentsError(undefined)).toBe(false);
+    expect(isDiscordDisallowedIntentsError(null)).toBe(false);
+    expect(isDiscordDisallowedIntentsError({})).toBe(false);
+  });
+});
+
+describe("describeDiscordConnectionError", () => {
+  test("returns the actionable message for disallowed-intents errors", () => {
+    const message = describeDiscordConnectionError(
+      new Error("Used disallowed intents"),
+    );
+    expect(message).toBe(DISCORD_DISALLOWED_INTENTS_MESSAGE);
+    expect(message).toContain("Message Content Intent");
+    expect(message).toContain("Privileged Gateway Intents");
+  });
+
+  test("returns null for unrecognized errors", () => {
+    expect(
+      describeDiscordConnectionError(new Error("Invalid token provided")),
+    ).toBeNull();
+  });
+});

--- a/src/channels/discord/connection-error.ts
+++ b/src/channels/discord/connection-error.ts
@@ -1,0 +1,71 @@
+// Translates low-level Discord gateway connection failures into clear,
+// actionable messages for the bot setup UI. Kept dependency-free so the
+// detection logic can be unit-tested without the discord.js runtime.
+
+/**
+ * Shown when Discord rejects the gateway connection because a privileged
+ * intent (here: Message Content) is not enabled for the application. Discord
+ * surfaces this as the opaque close reason "Used disallowed intents"
+ * (gateway close code 4014), which gives the user no idea how to fix it.
+ */
+export const DISCORD_DISALLOWED_INTENTS_MESSAGE =
+  'Discord rejected the connection because this bot needs the privileged "Message Content" intent, which is not enabled for its application.\n\n' +
+  "Enable it in the Discord Developer Portal:\n" +
+  "1. Open https://discord.com/developers/applications and select this bot's application.\n" +
+  "2. Go to Bot → Privileged Gateway Intents.\n" +
+  '3. Turn on "Message Content Intent" and save.\n' +
+  "4. Reconnect the bot here.\n\n" +
+  "Letta Code uses the Message Content intent to read message text in open channels. (Replying to @mentions and direct messages works without it.)";
+
+function extractErrorText(error: unknown): string {
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === "object" && "message" in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  return "";
+}
+
+function extractErrorCode(error: unknown): string {
+  if (error && typeof error === "object" && "code" in error) {
+    const code = (error as { code?: unknown }).code;
+    if (typeof code === "string" || typeof code === "number") {
+      return String(code);
+    }
+  }
+  return "";
+}
+
+/**
+ * Returns true when an error raised while connecting a Discord bot indicates
+ * that the requested privileged gateway intents are not enabled.
+ *
+ * Matches the several shapes discord.js / the gateway can use:
+ * - close code `4014`
+ * - discord.js error code `"DisallowedIntents"`
+ * - messages mentioning "disallowed intent(s)" or "privileged intent".
+ */
+export function isDiscordDisallowedIntentsError(error: unknown): boolean {
+  const haystack =
+    `${extractErrorCode(error)} ${extractErrorText(error)}`.toLowerCase();
+  if (!haystack.trim()) return false;
+  return (
+    haystack.includes("4014") ||
+    haystack.includes("disallowedintents") ||
+    haystack.includes("disallowed intent") ||
+    haystack.includes("privileged intent")
+  );
+}
+
+/**
+ * Map a Discord connection error to a user-facing message when it is a known,
+ * actionable failure. Returns `null` for unrecognized errors so callers can
+ * fall back to the original error.
+ */
+export function describeDiscordConnectionError(error: unknown): string | null {
+  if (isDiscordDisallowedIntentsError(error)) {
+    return DISCORD_DISALLOWED_INTENTS_MESSAGE;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

Connecting a Discord bot fails with the opaque error **"Used disallowed intents"** when the application does not have the **Message Content** privileged gateway intent enabled.

Root cause: the Discord adapter requests `GatewayIntentBits.MessageContent` (a privileged intent) in `start()`. If it is not toggled on in the Discord Developer Portal, Discord refuses the gateway connection with close code **4014** / reason *"Used disallowed intents"*, which surfaces verbatim in the bot setup UI and tells the user nothing about how to fix it.

This PR detects that specific failure on login and rethrows an **actionable** message:

```
Discord rejected the connection because this bot needs the privileged "Message Content" intent, which is not enabled for its application.

Enable it in the Discord Developer Portal:
1. Open https://discord.com/developers/applications and select this bot's application.
2. Go to Bot → Privileged Gateway Intents.
3. Turn on "Message Content Intent" and save.
4. Reconnect the bot here.

Letta Code uses the Message Content intent to read message text in open channels. (Replying to @mentions and direct messages works without it.)
```

Because `adapter.start()` errors propagate up through the channel registry and are surfaced via `error.message`, the friendly text replaces the cryptic one everywhere the connection error is shown.

## Why a clear message (not silently dropping the intent)

The Message Content intent is genuinely required for open-channel mode (reading the text of non-mention messages). Dropping it would silently break that feature, so the right fix is to keep requesting it and tell the user how to enable it. Mentions and DMs already work without it, noted in the message.

## Implementation

- `src/channels/discord/connection-error.ts` — dependency-free `isDiscordDisallowedIntentsError()` / `describeDiscordConnectionError()`. Detection matches the several shapes the failure takes: gateway close code `4014`, discord.js error code `"DisallowedIntents"`, and messages mentioning "disallowed intent(s)" / "privileged intent".
- `src/channels/discord/adapter.ts` — wrap `client.login()`; translate a disallowed-intents failure, pass through everything else unchanged.

## Test plan

- [x] `bun test src/channels/discord/connection-error.test.ts src/channels/discord-adapter.test.ts` — 49 pass (8 new). Covers: each error shape detected, unrelated errors ignored, the actionable message content, `start()` rethrows the friendly message on a disallowed-intents login failure, and `start()` preserves unrelated login failures (e.g. invalid token).
- [x] `bun run typecheck`
- [x] `biome check` on changed files
- [x] `check:boundaries`, `check:exported-functions`, `check:filename-casing`, circular-deps — clean

## Out of scope / possible follow-up

- Graceful degradation: on a disallowed-intents failure, optionally retry the connection **without** `MessageContent` so mention/DM-only bots can still run (with a warning that open-channel mode is disabled). Left out to keep this change minimal and behavior-preserving.

👾 Generated with [Letta Code](https://letta.com)