### PR TITLE
fix(listener): re-enter the goal loop on the Desktop/API surface

### DIFF
--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -45,6 +45,7 @@ import type {
 import { debugLog } from "@/utils/debug";
 import { markSecretsReminderRefreshPending } from "./commands/secrets";
 import { getConversationWorkingDirectory } from "./cwd";
+import { MAX_AUTONOMOUS_GOAL_ITERATIONS } from "./goal-continuation";
 import { reloadListenerModAdapter } from "./mod-adapter";
 import {
   getOrCreateConversationPermissionModeStateRef,
@@ -63,7 +64,11 @@ import {
   buildMaybeLaunchReflectionSubagent,
   handleIncomingMessage,
 } from "./turn";
-import type { ConversationRuntime, StartListenerOptions } from "./types";
+import type {
+  ConversationRuntime,
+  IncomingMessage,
+  StartListenerOptions,
+} from "./types";
 
 export { SUPPORTED_REMOTE_COMMANDS } from "./listener-constants";
 
@@ -694,6 +699,41 @@ async function handleRememberCommand(
 }
 
 /**
+ * Kick off an autonomous goal turn without blocking the /goal command result.
+ *
+ * The turn (and its full continuation loop in handleIncomingMessage) is chained
+ * onto the conversation message queue so it stays serialized with other turns
+ * and runs in the background — the command can return its confirmation
+ * immediately while the agent grinds on the goal.
+ */
+function startGoalLoopTurnInBackground(
+  socket: WebSocket,
+  conversationRuntime: ConversationRuntime,
+  message: IncomingMessage,
+  opts: {
+    onStatusChange?: StartListenerOptions["onStatusChange"];
+    connectionId?: string;
+  },
+): void {
+  conversationRuntime.messageQueue = conversationRuntime.messageQueue
+    .then(() =>
+      handleIncomingMessage(
+        message,
+        socket,
+        conversationRuntime,
+        opts.onStatusChange,
+        opts.connectionId,
+      ),
+    )
+    .catch((error: unknown) => {
+      console.error(
+        "[Goal] Autonomous goal loop failed:",
+        error instanceof Error ? error.message : error,
+      );
+    });
+}
+
+/**
  * /goal — Manage conversation goals with auto-continuation.
  *
  * Subcommands:
@@ -820,7 +860,9 @@ async function handleGoalCommand(
           (storedGoal?.activeTimeSeconds ?? 0) + liveActiveSeconds,
       });
 
-      await handleIncomingMessage(
+      startGoalLoopTurnInBackground(
+        socket,
+        conversationRuntime,
         {
           type: "message",
           agentId,
@@ -833,10 +875,7 @@ async function handleGoalCommand(
             },
           ],
         },
-        socket,
-        conversationRuntime,
-        opts.onStatusChange,
-        opts.connectionId,
+        opts,
       );
     }
 
@@ -878,7 +917,7 @@ async function handleGoalCommand(
   persistPermissionModeMapForRuntime(conversationRuntime.listener);
 
   const replaced = previousGoal ? " replaced" : " active";
-  const resultPrefix = `Goal${replaced} (iter 1/∞)\n${formatGoalSummary(goal)}`;
+  const resultPrefix = `Goal${replaced} (iter 1/${MAX_AUTONOMOUS_GOAL_ITERATIONS})\n${formatGoalSummary(goal)}`;
 
   // Send initial goal continuation prompt through the turn pipeline
   const goalState = goalLoopMode.getState();
@@ -900,7 +939,9 @@ async function handleGoalCommand(
     timeUsedSeconds: (storedGoal?.activeTimeSeconds ?? 0) + liveActiveSeconds,
   });
 
-  await handleIncomingMessage(
+  startGoalLoopTurnInBackground(
+    socket,
+    conversationRuntime,
     {
       type: "message",
       agentId,
@@ -913,10 +954,7 @@ async function handleGoalCommand(
         },
       ],
     },
-    socket,
-    conversationRuntime,
-    opts.onStatusChange,
-    opts.connectionId,
+    opts,
   );
 
   return resultPrefix;

--- a/src/websocket/listener/goal-continuation.test.ts
+++ b/src/websocket/listener/goal-continuation.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import {
+  decideGoalContinuation,
+  MAX_AUTONOMOUS_GOAL_ITERATIONS,
+} from "@/websocket/listener/goal-continuation";
+
+const base = {
+  goalActive: true,
+  lastStopReason: "end_turn" as string | null,
+  goalStatus: "active" as string | null,
+  iteration: 1,
+  maxIterations: MAX_AUTONOMOUS_GOAL_ITERATIONS,
+  tokensUsed: 0,
+  tokenBudget: null as number | null,
+};
+
+describe("decideGoalContinuation", () => {
+  test("continues a clean, active goal turn under all limits", () => {
+    expect(decideGoalContinuation(base)).toBe("continue");
+  });
+
+  test("stops when the goal loop is not active", () => {
+    expect(decideGoalContinuation({ ...base, goalActive: false })).toBe(
+      "stop_inactive",
+    );
+  });
+
+  test("stops when the turn did not end cleanly", () => {
+    expect(decideGoalContinuation({ ...base, lastStopReason: null })).toBe(
+      "stop_unclean",
+    );
+    expect(
+      decideGoalContinuation({ ...base, lastStopReason: "cancelled" }),
+    ).toBe("stop_unclean");
+    expect(decideGoalContinuation({ ...base, lastStopReason: "error" })).toBe(
+      "stop_unclean",
+    );
+  });
+
+  test("stops when the goal is no longer active (complete/blocked/paused)", () => {
+    for (const goalStatus of ["complete", "blocked", "paused", null]) {
+      expect(decideGoalContinuation({ ...base, goalStatus })).toBe(
+        "stop_status",
+      );
+    }
+  });
+
+  test("stops when the iteration cap is reached", () => {
+    expect(
+      decideGoalContinuation({
+        ...base,
+        iteration: MAX_AUTONOMOUS_GOAL_ITERATIONS,
+      }),
+    ).toBe("stop_cap");
+    expect(
+      decideGoalContinuation({
+        ...base,
+        iteration: MAX_AUTONOMOUS_GOAL_ITERATIONS + 5,
+      }),
+    ).toBe("stop_cap");
+  });
+
+  test("stops when the token budget is exhausted", () => {
+    expect(
+      decideGoalContinuation({ ...base, tokenBudget: 1000, tokensUsed: 1000 }),
+    ).toBe("stop_budget");
+    expect(
+      decideGoalContinuation({ ...base, tokenBudget: 1000, tokensUsed: 1500 }),
+    ).toBe("stop_budget");
+  });
+
+  test("continues when under the token budget", () => {
+    expect(
+      decideGoalContinuation({ ...base, tokenBudget: 1000, tokensUsed: 999 }),
+    ).toBe("continue");
+  });
+
+  test("prioritizes an unclean stop over the active-goal check", () => {
+    // A cancelled turn on an otherwise-continuable goal still stops.
+    expect(
+      decideGoalContinuation({
+        ...base,
+        lastStopReason: "cancelled",
+        goalStatus: "active",
+      }),
+    ).toBe("stop_unclean");
+  });
+});

--- a/src/websocket/listener/goal-continuation.ts
+++ b/src/websocket/listener/goal-continuation.ts
@@ -1,0 +1,155 @@
+// Autonomous goal-loop re-entry for the websocket listener (Desktop/API
+// surface). The TUI re-enters the goal loop at end_turn via
+// use-conversation-loop.ts; the listener historically injected a single
+// continuation prompt and stopped. This module mirrors the TUI stop/continue
+// logic so a /goal keeps taking autonomous turns on the listener too, with a
+// hard safety cap to guarantee the loop can never run away unattended.
+
+import { buildGoalContinuationPrompt } from "@/cli/helpers/goal-command";
+import { goalLoopMode } from "@/goal-loop-mode";
+import { settingsManager } from "@/settings-manager";
+import {
+  getOrCreateConversationPermissionModeStateRef,
+  persistPermissionModeMapForRuntime,
+} from "./permission-mode";
+import type { ConversationRuntime, IncomingMessage } from "./types";
+
+/**
+ * Hard upper bound on the number of autonomous continuation turns a single
+ * goal run may take on the listener, independent of any user-facing step cap.
+ * This is a safety net against a goal the model never marks complete/blocked:
+ * the loop stops itself and the goal can be resumed with /goal resume.
+ */
+export const MAX_AUTONOMOUS_GOAL_ITERATIONS = 50;
+
+export type GoalContinuationAction =
+  | "stop_inactive"
+  | "stop_unclean"
+  | "stop_status"
+  | "stop_cap"
+  | "stop_budget"
+  | "continue";
+
+/**
+ * Pure decision: given the loop/turn/goal state after a turn completes, decide
+ * whether the listener should take another autonomous goal turn.
+ *
+ * Continuation only happens after a clean `end_turn`. A cancelled or errored
+ * turn (`lastStopReason !== "end_turn"`) stops the loop, as does the goal being
+ * marked complete/blocked/paused (status !== "active"), reaching the iteration
+ * cap, or exhausting the token budget.
+ */
+export function decideGoalContinuation(input: {
+  goalActive: boolean;
+  lastStopReason: string | null;
+  goalStatus: string | null;
+  iteration: number;
+  maxIterations: number;
+  tokensUsed: number;
+  tokenBudget: number | null;
+}): GoalContinuationAction {
+  if (!input.goalActive) return "stop_inactive";
+  if (input.lastStopReason !== "end_turn") return "stop_unclean";
+  if (input.goalStatus !== "active") return "stop_status";
+  if (input.iteration >= input.maxIterations) return "stop_cap";
+  if (input.tokenBudget !== null && input.tokensUsed >= input.tokenBudget) {
+    return "stop_budget";
+  }
+  return "continue";
+}
+
+/**
+ * End the autonomous goal loop: deactivate the in-process loop mode and restore
+ * the standard permission mode for the conversation (the loop runs in
+ * unrestricted mode). Safe to call when the loop is already inactive.
+ */
+function stopGoalLoop(
+  runtime: ConversationRuntime,
+  agentId: string | undefined,
+  conversationId: string,
+): void {
+  if (goalLoopMode.getState().isActive) {
+    goalLoopMode.deactivate();
+  }
+  if (!agentId) return;
+  const permState = getOrCreateConversationPermissionModeStateRef(
+    runtime.listener,
+    agentId,
+    conversationId,
+  );
+  if (permState.mode === "unrestricted") {
+    permState.mode = "standard";
+    persistPermissionModeMapForRuntime(runtime.listener);
+  }
+}
+
+/**
+ * After a turn completes, decide whether to continue the active goal and, if
+ * so, build the next continuation turn. Applies the required side effects
+ * (iteration bump, or loop teardown + permission restore) and returns the next
+ * message to feed back through the turn pipeline, or `null` to stop.
+ */
+export function buildGoalContinuationTurn(
+  previousMessage: IncomingMessage,
+  runtime: ConversationRuntime,
+): IncomingMessage | null {
+  const agentId = previousMessage.agentId;
+  const conversationId = previousMessage.conversationId ?? "default";
+  const goalState = goalLoopMode.getState();
+  const storedGoal = settingsManager.getConversationGoal(conversationId);
+
+  const action = decideGoalContinuation({
+    goalActive: goalState.isActive,
+    lastStopReason: runtime.lastStopReason,
+    goalStatus: storedGoal?.status ?? null,
+    iteration: goalState.currentIteration,
+    maxIterations: MAX_AUTONOMOUS_GOAL_ITERATIONS,
+    tokensUsed: storedGoal?.tokensUsed ?? 0,
+    tokenBudget: storedGoal?.tokenBudget ?? goalState.tokenBudget,
+  });
+
+  if (action === "stop_inactive") {
+    // Not a goal turn (or already torn down) — nothing to do.
+    return null;
+  }
+
+  if (action !== "continue") {
+    stopGoalLoop(runtime, agentId, conversationId);
+    return null;
+  }
+
+  goalLoopMode.incrementIteration();
+  const nextState = goalLoopMode.getState();
+  const liveActiveSeconds =
+    storedGoal?.activeStartedAt && storedGoal.status === "active"
+      ? Math.max(
+          0,
+          Math.floor(
+            (Date.now() - Date.parse(storedGoal.activeStartedAt)) / 1000,
+          ),
+        )
+      : 0;
+  const text = buildGoalContinuationPrompt({
+    objective: nextState.originalPrompt,
+    status: "active",
+    tokensUsed: storedGoal?.tokensUsed ?? 0,
+    tokenBudget: storedGoal?.tokenBudget ?? nextState.tokenBudget,
+    timeUsedSeconds: (storedGoal?.activeTimeSeconds ?? 0) + liveActiveSeconds,
+  });
+
+  return {
+    type: "message",
+    agentId,
+    conversationId,
+    messages: [
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "text", text }],
+      },
+    ],
+    ...(previousMessage.actingUserId
+      ? { actingUserId: previousMessage.actingUserId }
+      : {}),
+  };
+}

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -67,6 +67,7 @@ import {
   PROVIDER_FALLBACK_NOTICE,
 } from "./constants";
 import { getConversationWorkingDirectory } from "./cwd";
+import { buildGoalContinuationTurn } from "./goal-continuation";
 import {
   consumeInterruptQueue,
   emitInterruptToolReturnMessage,
@@ -295,7 +296,43 @@ function finalizeInterruptedTurn(
   }
 }
 
+/**
+ * Process a message and, when an autonomous goal loop is active, keep taking
+ * continuation turns until the goal completes/blocks/pauses, the turn ends
+ * uncleanly (cancel/error), the token budget is hit, or the hard iteration cap
+ * is reached. Each iteration is a full turn via {@link runSingleTurn}, mirroring
+ * the TUI's end_turn re-entry (use-conversation-loop.ts) on the listener path.
+ */
 export async function handleIncomingMessage(
+  msg: IncomingMessage,
+  socket: ListenerTransport,
+  runtime: ConversationRuntime,
+  onStatusChange?: (
+    status: "idle" | "receiving" | "processing",
+    connectionId: string,
+  ) => void,
+  connectionId?: string,
+  dequeuedBatchId: string = `batch-direct-${crypto.randomUUID()}`,
+): Promise<void> {
+  let currentMsg = msg;
+  let batchId = dequeuedBatchId;
+  while (true) {
+    await runSingleTurn(
+      currentMsg,
+      socket,
+      runtime,
+      onStatusChange,
+      connectionId,
+      batchId,
+    );
+    const continuation = buildGoalContinuationTurn(currentMsg, runtime);
+    if (!continuation) return;
+    currentMsg = continuation;
+    batchId = `batch-goal-${crypto.randomUUID()}`;
+  }
+}
+
+async function runSingleTurn(
   msg: IncomingMessage,
   socket: ListenerTransport,
   runtime: ConversationRuntime,


### PR DESCRIPTION
## Summary

The autonomous `/goal` continuation loop only re-entered in the **TUI** (`src/cli/app/use-conversation-loop.ts`, via `handleGoalContinuation` → `processConversation(allowReentry)`). The **websocket listener** (Desktop/API surface) activated durable goal state and injected a **single** continuation prompt, then stopped — so a goal never iterated autonomously outside the terminal.

This wires the same end-turn re-entry into the listener path.

## Approach

- `handleIncomingMessage` is now a thin **trampoline**: the existing turn body is `runSingleTurn`, and after each clean `end_turn` the wrapper asks `buildGoalContinuationTurn` whether to take another autonomous goal turn. No recursion (a `while` loop), so no stack growth; each iteration is a full, normal turn — exactly mirroring the TUI.
- Stop conditions (in `src/websocket/listener/goal-continuation.ts`, pure + unit-tested `decideGoalContinuation`):
  - turn did not end cleanly (`lastStopReason !== "end_turn"`, i.e. cancel/error) → stop
  - goal no longer `active` (complete / blocked / paused — the per-conversation stored status set by the `update_goal` tool) → stop + restore standard permission mode
  - **hard iteration cap** `MAX_AUTONOMOUS_GOAL_ITERATIONS = 50` → stop (runaway safety net, independent of any user-facing step cap)
  - token budget exhausted → stop
- `/goal` now starts the first turn on the conversation **message queue** (`startGoalLoopTurnInBackground`) instead of `await`ing it inline, so the command returns its confirmation immediately while the loop runs serialized in the background (also prevents concurrent turns on the same conversation).
- Honest label: `(iter 1/∞)` → `(iter 1/50)`.

## Why a hard cap

This adds an autonomous loop to a non-interactive surface, so a goal the model never marks complete/blocked must not run forever. The cap guarantees termination; `update_goal` (complete/blocked) is still the normal exit, and the goal can be resumed with `/goal resume`.

## Known limitation (follow-up)

`goalLoopMode` is a process-global singleton (pre-existing). On a single listener serving **multiple** conversations with concurrent goals, the global iteration/active state can interfere across conversations. The authoritative complete/blocked signal is the per-conversation stored goal status, so completion is correctly scoped; the global iteration counter is not. A per-conversation goal-loop state is the right follow-up (tracked in a separate issue). The common Desktop case (one active goal) is unaffected.

## Test plan

- [x] `bun test src/websocket/listener/goal-continuation.test.ts` — 8 pass (continue path; stop on inactive/unclean/complete/blocked/paused/cap/budget; unclean prioritized over status)
- [x] `bun test src/websocket/listener/` — 79 pass (no regressions from the `handleIncomingMessage` rename/wrapper)
- [x] `bun run typecheck`
- [x] `biome check`, `check:boundaries`, `check:exported-functions`, `check:filename-casing`, circular-deps — clean
- [ ] Manual (Desktop): set `/goal <objective>`; confirm the agent keeps taking turns until it calls `update_goal complete`/`blocked`, the cap is hit, or the turn is cancelled; confirm permission mode returns to standard on stop

## Repro (issue anchor)

On Desktop/API, set a `/goal`; observe the agent runs exactly one turn then idles. In the TUI the same goal iterates. Root cause: re-entry exists only in `use-conversation-loop.ts`; the listener (`src/websocket/listener/commands.ts`) injects one prompt with no end-turn continuation.

👾 Generated with [Letta Code](https://letta.com)