### PR TITLE
fix(desktop): keep project chat grouping after first message

### DIFF
--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -644,6 +644,9 @@ describe("listen-client parseServerMessage", () => {
               device_status: expect.objectContaining({
                 current_working_directory: cwdDir,
                 current_permission_mode: "acceptEdits",
+                cwd_map: expect.objectContaining({
+                  [`conversation:${runtimeScope.conversation_id}`]: cwdDir,
+                }),
               }),
             }),
             expect.objectContaining({
@@ -4617,12 +4620,20 @@ describe("listen-client v2 status builders", () => {
       conversation_id: "conv-a",
     });
     expect(activeStatus.current_working_directory).toBe("/repo/a");
+    expect(activeStatus.cwd_map).toMatchObject({
+      "conversation:conv-a": "/repo/a",
+      "agent:agent-b::conversation:default": "/repo/b",
+    });
 
     const defaultStatus = __listenClientTestUtils.buildDeviceStatus(runtime, {
       agent_id: "agent-b",
       conversation_id: "default",
     });
     expect(defaultStatus.current_working_directory).toBe("/repo/b");
+    expect(defaultStatus.cwd_map).toMatchObject({
+      "conversation:conv-a": "/repo/a",
+      "agent:agent-b::conversation:default": "/repo/b",
+    });
   });
 
   test("scoped loop status is not suppressed just because another conversation is processing", () => {

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -477,12 +477,8 @@ export function buildDeviceStatus(
     memory_directory: scopedAgentId
       ? getScopedMemoryFilesystemRoot(scopedAgentId)
       : null,
-    ...(!scope
-      ? {
-          cwd_map: Object.fromEntries(listener.workingDirectoryByConversation),
-          boot_working_directory: listener.bootWorkingDirectory,
-        }
-      : {}),
+    cwd_map: Object.fromEntries(listener.workingDirectoryByConversation),
+    boot_working_directory: listener.bootWorkingDirectory,
     should_doctor: systemPromptDoctorState?.should_doctor ?? false,
     supported_commands: FROZEN_SUPPORTED_COMMANDS,
     reflection_settings: scopedAgentId


### PR DESCRIPTION
## Summary
- Always include the listener `cwd_map` and boot working directory in device status updates, including scoped runtime updates
- Ensures Desktop can immediately retain project-folder grouping for newly-created project chats after the first message
- Adds coverage for runtime-start replay and scoped device status snapshots

## Why
Creating a new chat from a project folder can briefly show the chat under that project, but after the first message it falls back to the default/Documents bucket even though the bottom bar still shows the correct cwd. The listener has the mapping persisted, but scoped device status omitted `cwd_map`, so the client did not receive the map during scoped updates.

## Test plan
- `bun test src/websocket/listen-client-protocol.test.ts`
- `bun run typecheck`
- `bun run check`
