### PR TITLE
fix(app-server): let a reconnecting control socket take over instead of rejecting it

### DIFF
--- a/src/websocket/app-server-control-reconnect.test.ts
+++ b/src/websocket/app-server-control-reconnect.test.ts
@@ -1,0 +1,319 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import { join } from "node:path";
+import WebSocket from "ws";
+import type { AgentCreateBody } from "@/backend";
+import { __testSetBackend } from "@/backend";
+import { LocalBackend } from "@/backend/local";
+import { type AppServerHandle, startAppServer } from "@/websocket/app-server";
+
+const TEST_TIMEOUT_MS = 8000;
+
+function waitForOpen(socket: WebSocket): Promise<void> {
+  if (socket.readyState === WebSocket.OPEN) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error("Timed out waiting for websocket open"));
+    }, TEST_TIMEOUT_MS);
+    const cleanup = () => {
+      clearTimeout(timeout);
+      socket.off("open", handleOpen);
+      socket.off("error", handleError);
+    };
+    const handleOpen = () => {
+      cleanup();
+      resolve();
+    };
+    const handleError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    socket.once("open", handleOpen);
+    socket.once("error", handleError);
+  });
+}
+
+function waitForJsonMessage(
+  socket: WebSocket,
+  predicate: (message: Record<string, unknown>) => boolean,
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const seen: Record<string, unknown>[] = [];
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(
+        new Error(
+          `Timed out waiting for websocket message; saw ${JSON.stringify(seen)}`,
+        ),
+      );
+    }, TEST_TIMEOUT_MS);
+    const cleanup = () => {
+      clearTimeout(timeout);
+      socket.off("message", handleMessage);
+      socket.off("error", handleError);
+    };
+    const handleMessage = (raw: WebSocket.RawData) => {
+      const parsed = JSON.parse(String(raw)) as Record<string, unknown>;
+      seen.push(parsed);
+      if (!predicate(parsed)) {
+        return;
+      }
+      cleanup();
+      resolve(parsed);
+    };
+    const handleError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    socket.on("message", handleMessage);
+    socket.once("error", handleError);
+  });
+}
+
+function closeClient(socket: WebSocket | null): void {
+  if (!socket) return;
+  if (
+    socket.readyState === WebSocket.OPEN ||
+    socket.readyState === WebSocket.CONNECTING
+  ) {
+    socket.close();
+  }
+}
+
+function pageItems(page: unknown): unknown[] {
+  if (Array.isArray(page)) return page;
+  if (page && typeof page === "object") {
+    const candidate = page as {
+      getPaginatedItems?: () => unknown[];
+      items?: unknown[];
+    };
+    if (typeof candidate.getPaginatedItems === "function") {
+      return candidate.getPaginatedItems();
+    }
+    if (Array.isArray(candidate.items)) return candidate.items;
+  }
+  return [];
+}
+
+type RuntimeScope = { agent_id: string; conversation_id: string };
+
+function startCreateAgentChat(control: WebSocket, requestId: string): void {
+  control.send(
+    JSON.stringify({
+      type: "runtime_start",
+      request_id: requestId,
+      create_agent: {
+        body: {
+          name: "Reconnect Repro Agent",
+          model: "anthropic/claude-sonnet-4-6",
+        } as AgentCreateBody,
+        pin_global: false,
+      },
+      create_conversation: { body: {} },
+      recover_approvals: false,
+    }),
+  );
+}
+
+function startNewChat(
+  control: WebSocket,
+  requestId: string,
+  agentId: string,
+): void {
+  control.send(
+    JSON.stringify({
+      type: "runtime_start",
+      request_id: requestId,
+      agent_id: agentId,
+      create_conversation: { body: {} },
+      recover_approvals: false,
+    }),
+  );
+}
+
+function sendFirstUserMessage(
+  control: WebSocket,
+  runtime: RuntimeScope,
+  text: string,
+): void {
+  control.send(
+    JSON.stringify({
+      type: "input",
+      runtime,
+      payload: {
+        kind: "create_message",
+        messages: [
+          {
+            role: "user",
+            content: text,
+            client_message_id: `cm-${runtime.conversation_id}`,
+          },
+        ],
+      },
+    }),
+  );
+}
+
+async function waitForConversationMessages(
+  backend: LocalBackend,
+  conversationId: string,
+  agentId: string,
+): Promise<unknown[]> {
+  const deadline = Date.now() + TEST_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const items = pageItems(
+      await backend.listConversationMessages(conversationId, {
+        agent_id: agentId,
+        order: "asc",
+      } as never),
+    );
+    if (items.length > 0) return items;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return [];
+}
+
+afterEach(() => {
+  __testSetBackend(null);
+});
+
+describe("app-server control reconnect", () => {
+  // Regression: when the desktop reconnects its control socket while the
+  // previous one is still registered (half-open after sleep/wake, or the
+  // server has not yet observed the close), the new control socket must be
+  // able to take over and drive a turn. Previously the second control
+  // connection was hard-rejected, so every new chat after the reconnect
+  // silently did nothing.
+  test(
+    "a reconnecting control socket takes over and runs a first-message turn",
+    async () => {
+      const storageDir = await mkdtemp(join(os.tmpdir(), "letta-reconnect-"));
+      let handle: AppServerHandle | null = null;
+      let control1: WebSocket | null = null;
+      let control2: WebSocket | null = null;
+      let stream1: WebSocket | null = null;
+      let stream2: WebSocket | null = null;
+      try {
+        const backend = new LocalBackend({
+          storageDir,
+          executionMode: "deterministic",
+        });
+        __testSetBackend(backend);
+        handle = await startAppServer({ listen: "ws://127.0.0.1:0" });
+        stream1 = new WebSocket(handle.streamUrl);
+        control1 = new WebSocket(handle.controlUrl);
+        await Promise.all([waitForOpen(stream1), waitForOpen(control1)]);
+
+        startCreateAgentChat(control1, "rs-1");
+        const start1 = await waitForJsonMessage(
+          control1,
+          (m) => m.type === "runtime_start_response" && m.request_id === "rs-1",
+        );
+        expect(start1.success).toBe(true);
+        const agentId = (start1.runtime as RuntimeScope).agent_id;
+
+        // Reconnect WITHOUT the server having torn down control1 (control1 is
+        // intentionally left open to model a half-open socket after sleep).
+        stream2 = new WebSocket(handle.streamUrl);
+        control2 = new WebSocket(handle.controlUrl);
+        await Promise.all([waitForOpen(stream2), waitForOpen(control2)]);
+
+        startNewChat(control2, "rs-2", agentId);
+        const start2 = await waitForJsonMessage(
+          control2,
+          (m) => m.type === "runtime_start_response" && m.request_id === "rs-2",
+        );
+        expect(start2.success).toBe(true);
+        const rt2 = start2.runtime as RuntimeScope;
+
+        sendFirstUserMessage(control2, rt2, "hello after reconnect");
+        const conv2 = await waitForConversationMessages(
+          backend,
+          rt2.conversation_id,
+          agentId,
+        );
+        expect(conv2.length).toBeGreaterThan(0);
+      } finally {
+        closeClient(control1);
+        closeClient(control2);
+        closeClient(stream1);
+        closeClient(stream2);
+        await handle?.close();
+        await rm(storageDir, { recursive: true, force: true });
+      }
+    },
+    TEST_TIMEOUT_MS + 4000,
+  );
+
+  // A graceful reconnect (old control socket fully closed first) must keep
+  // working as before.
+  test(
+    "a new chat works after a graceful control reconnect (close then reopen)",
+    async () => {
+      const storageDir = await mkdtemp(join(os.tmpdir(), "letta-reconnect-g-"));
+      let handle: AppServerHandle | null = null;
+      let control1: WebSocket | null = null;
+      let control2: WebSocket | null = null;
+      let stream1: WebSocket | null = null;
+      let stream2: WebSocket | null = null;
+      try {
+        const backend = new LocalBackend({
+          storageDir,
+          executionMode: "deterministic",
+        });
+        __testSetBackend(backend);
+        handle = await startAppServer({ listen: "ws://127.0.0.1:0" });
+        stream1 = new WebSocket(handle.streamUrl);
+        control1 = new WebSocket(handle.controlUrl);
+        await Promise.all([waitForOpen(stream1), waitForOpen(control1)]);
+
+        startCreateAgentChat(control1, "rs-1");
+        const start1 = await waitForJsonMessage(
+          control1,
+          (m) => m.type === "runtime_start_response" && m.request_id === "rs-1",
+        );
+        const agentId = (start1.runtime as RuntimeScope).agent_id;
+
+        const control1Closed = new Promise<void>((resolve) => {
+          control1?.once("close", () => resolve());
+        });
+        control1.close();
+        stream1.close();
+        await control1Closed;
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        stream2 = new WebSocket(handle.streamUrl);
+        control2 = new WebSocket(handle.controlUrl);
+        await Promise.all([waitForOpen(stream2), waitForOpen(control2)]);
+
+        startNewChat(control2, "rs-2", agentId);
+        const start2 = await waitForJsonMessage(
+          control2,
+          (m) => m.type === "runtime_start_response" && m.request_id === "rs-2",
+        );
+        expect(start2.success).toBe(true);
+        const rt2 = start2.runtime as RuntimeScope;
+
+        sendFirstUserMessage(control2, rt2, "hello after graceful reconnect");
+        const conv2 = await waitForConversationMessages(
+          backend,
+          rt2.conversation_id,
+          agentId,
+        );
+        expect(conv2.length).toBeGreaterThan(0);
+      } finally {
+        closeClient(control1);
+        closeClient(control2);
+        closeClient(stream1);
+        closeClient(stream2);
+        await handle?.close();
+        await rm(storageDir, { recursive: true, force: true });
+      }
+    },
+    TEST_TIMEOUT_MS + 4000,
+  );
+});

--- a/src/websocket/app-server.ts
+++ b/src/websocket/app-server.ts
@@ -295,8 +295,21 @@ export async function startAppServer(
     }
 
     if (activeSession) {
-      closeSocket(socket, 1008, "control channel already connected");
-      return;
+      // A new control connection supersedes the previous session rather than
+      // being rejected. This is the desktop reconnecting (e.g. after sleep/
+      // wake or a network change) while the previous control socket is still
+      // half-open and the server has not yet observed its close. Rejecting the
+      // reconnect would leave the client unable to start runtimes or send
+      // messages, so every new chat would silently do nothing until the stale
+      // socket was finally detected as closed. Tear the old session down and
+      // let the new socket take over ("newest control wins"), mirroring the
+      // takeover that startControlSession already performs for the runtime.
+      const superseded = activeSession;
+      activeSession = null;
+      stopRuntime(superseded.runtime, true);
+      if (getActiveRuntime() === superseded.runtime) {
+        setActiveRuntime(null);
+      }
     }
 
     const streamSocket = clearPendingStream();


### PR DESCRIPTION
## Summary
- A new chat (and any message) **silently does nothing** after the desktop reconnects its control socket. The conversation is created but its first message never runs a turn, and no error is surfaced.
- Root cause: `startAppServer`’s control-channel handler **hard-rejected** a second control connection (`closeSocket(1008, "control channel already connected")`). When the desktop reconnects while the previous control socket is still registered (half-open after sleep/wake, or the close not yet observed by the server), the new socket cannot start runtimes or send messages.
- Notably, `startControlSession` **already** performs runtime takeover for this case, but that path was unreachable because the connection was rejected first.

## Fix
- On a new control connection, **supersede** the stale session ("newest control wins") instead of rejecting: tear down the previous runtime/sockets and let the new socket take over. This mirrors the takeover `startControlSession` already does.
- Safe against stale-close races: the superseded control socket’s `close` handler is already guarded by an active-runtime check, so it cannot clobber the new session.

## How it was found
Built a ground-truth repro driving the real `startAppServer` + `LocalBackend` over real control/stream WebSockets:
- ✅ single-socket new chats, ✅ conversation-create-without-runtime_start, ✅ graceful reconnect (close→reopen) — all already worked.
- ❌ **overlap reconnect** (old control still registered) — `runtime_start` on the new socket got **no response**, matching the symptom (conversation created on disk, empty `messages.jsonl`, no error). Fixed by this change.

## Test plan
- [x] `bun test src/websocket/app-server-control-reconnect.test.ts` (new): overlap + graceful reconnect both run a first-message turn
- [x] `bun test src/websocket/app-server.test.ts` (existing) green
- [x] `bun run typecheck`, `biome check`, `check-layer-boundaries`, `check-exported-functions`, `check-filename-casing`, `madge --circular` all clean
- [ ] Manual: on Desktop, reconnect (sleep/wake) then open a new chat and send a message — should respond

Note: `src/websocket/listen-client-concurrency.test.ts` has 19 pre-existing failures on `main` (reproduce with this change stashed); unrelated to this fix.

👾 Generated with [Letta Code](https://letta.com)