### PR TITLE
fix(listener): apply the per-agent default working directory to new chats

### DIFF
--- a/src/websocket/listener/cwd.test.ts
+++ b/src/websocket/listener/cwd.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  getConversationWorkingDirectory,
+  getWorkingDirectoryScopeKey,
+  setConversationWorkingDirectory,
+} from "./cwd";
+import type { ListenerRuntime } from "./types";
+
+const BOOT = "/boot/dir";
+const AGENT = "agent-local-test";
+const AGENT_DEFAULT = "/agent/default/dir";
+const CONV = "local-conv-abc";
+
+function makeRuntime(entries: Record<string, string> = {}): ListenerRuntime {
+  return {
+    bootWorkingDirectory: BOOT,
+    workingDirectoryByConversation: new Map(Object.entries(entries)),
+  } as unknown as ListenerRuntime;
+}
+
+const agentDefaultKey = getWorkingDirectoryScopeKey(AGENT, "default");
+const convKey = getWorkingDirectoryScopeKey(AGENT, CONV);
+
+describe("getConversationWorkingDirectory", () => {
+  test("returns the explicit per-conversation override when present", () => {
+    const runtime = makeRuntime({
+      [convKey]: "/explicit/dir",
+      [agentDefaultKey]: AGENT_DEFAULT,
+    });
+    expect(getConversationWorkingDirectory(runtime, AGENT, CONV)).toBe(
+      "/explicit/dir",
+    );
+  });
+
+  // Regression: a real conversation with no explicit override must inherit the
+  // agent's saved default working directory, not silently fall back to boot.
+  test("falls back to the per-agent default for a new conversation", () => {
+    const runtime = makeRuntime({ [agentDefaultKey]: AGENT_DEFAULT });
+    expect(getConversationWorkingDirectory(runtime, AGENT, CONV)).toBe(
+      AGENT_DEFAULT,
+    );
+  });
+
+  test("falls back to boot when no per-agent default is set", () => {
+    const runtime = makeRuntime();
+    expect(getConversationWorkingDirectory(runtime, AGENT, CONV)).toBe(BOOT);
+  });
+
+  test("resolves the agent-default scope to its stored value", () => {
+    const runtime = makeRuntime({ [agentDefaultKey]: AGENT_DEFAULT });
+    expect(getConversationWorkingDirectory(runtime, AGENT, "default")).toBe(
+      AGENT_DEFAULT,
+    );
+  });
+
+  test("agent-default scope inherits boot (no higher tier)", () => {
+    const runtime = makeRuntime();
+    expect(getConversationWorkingDirectory(runtime, AGENT, "default")).toBe(
+      BOOT,
+    );
+  });
+});
+
+describe("setConversationWorkingDirectory", () => {
+  let prevHome: string | undefined;
+
+  beforeEach(() => {
+    prevHome = process.env.HOME;
+    process.env.HOME = mkdtempSync(join(tmpdir(), "cwd-test-home-"));
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+  });
+
+  test("stores an override that differs from the inherited default", () => {
+    const runtime = makeRuntime({ [agentDefaultKey]: AGENT_DEFAULT });
+    setConversationWorkingDirectory(runtime, AGENT, CONV, "/picked/dir");
+    expect(runtime.workingDirectoryByConversation.get(convKey)).toBe(
+      "/picked/dir",
+    );
+  });
+
+  test("drops a redundant override equal to the per-agent default", () => {
+    const runtime = makeRuntime({
+      [agentDefaultKey]: AGENT_DEFAULT,
+      [convKey]: "/stale/dir",
+    });
+    setConversationWorkingDirectory(runtime, AGENT, CONV, AGENT_DEFAULT);
+    expect(runtime.workingDirectoryByConversation.has(convKey)).toBe(false);
+    // Resolution still yields the agent default after the redundant entry is dropped.
+    expect(getConversationWorkingDirectory(runtime, AGENT, CONV)).toBe(
+      AGENT_DEFAULT,
+    );
+  });
+
+  test("preserves an explicit boot-dir choice when a different agent default exists", () => {
+    const runtime = makeRuntime({ [agentDefaultKey]: AGENT_DEFAULT });
+    setConversationWorkingDirectory(runtime, AGENT, CONV, BOOT);
+    // Boot differs from the agent default, so the explicit choice is kept.
+    expect(runtime.workingDirectoryByConversation.get(convKey)).toBe(BOOT);
+    expect(getConversationWorkingDirectory(runtime, AGENT, CONV)).toBe(BOOT);
+  });
+
+  test("drops an override equal to boot when no agent default exists", () => {
+    const runtime = makeRuntime({ [convKey]: "/stale/dir" });
+    setConversationWorkingDirectory(runtime, AGENT, CONV, BOOT);
+    expect(runtime.workingDirectoryByConversation.has(convKey)).toBe(false);
+  });
+});

--- a/src/websocket/listener/cwd.ts
+++ b/src/websocket/listener/cwd.ts
@@ -16,6 +16,37 @@ export function getWorkingDirectoryScopeKey(
   return `conversation:${normalizedConversationId}`;
 }
 
+/**
+ * The directory a scope inherits when it has no explicit per-scope override.
+ *
+ * For a concrete conversation this is the agent's saved "default working
+ * directory" (the folder chosen via the desktop "Default working directory"
+ * dialog, stored under the `agent:<id>::conversation:default` scope key), and
+ * only the boot directory when no such default exists. For the agent-default
+ * scope itself (conversationId === "default") there is no higher tier, so it
+ * inherits the boot directory directly.
+ *
+ * Without this, a saved per-agent default only ever applied to the pre-send
+ * "default" conversation preview: once a real conversation id was created its
+ * scope key had no entry and resolution fell straight back to the boot cwd, so
+ * every new chat silently ignored the saved default.
+ */
+function getInheritedWorkingDirectory(
+  runtime: ListenerRuntime,
+  agentId?: string | null,
+  conversationId?: string | null,
+): string {
+  if (normalizeConversationId(conversationId) !== "default") {
+    const agentDefault = runtime.workingDirectoryByConversation.get(
+      getWorkingDirectoryScopeKey(agentId, "default"),
+    );
+    if (agentDefault !== undefined) {
+      return agentDefault;
+    }
+  }
+  return runtime.bootWorkingDirectory;
+}
+
 export function getConversationWorkingDirectory(
   runtime: ListenerRuntime,
   agentId?: string | null,
@@ -24,7 +55,7 @@ export function getConversationWorkingDirectory(
   const scopeKey = getWorkingDirectoryScopeKey(agentId, conversationId);
   return (
     runtime.workingDirectoryByConversation.get(scopeKey) ??
-    runtime.bootWorkingDirectory
+    getInheritedWorkingDirectory(runtime, agentId, conversationId)
   );
 }
 
@@ -65,7 +96,16 @@ export function setConversationWorkingDirectory(
   workingDirectory: string,
 ): void {
   const scopeKey = getWorkingDirectoryScopeKey(agentId, conversationId);
-  if (workingDirectory === runtime.bootWorkingDirectory) {
+  // Only persist an explicit override when it differs from what the scope
+  // would already inherit (the per-agent default, else the boot directory).
+  // This keeps the map free of redundant entries while ensuring an explicit
+  // choice that differs from the inherited default is preserved.
+  const inherited = getInheritedWorkingDirectory(
+    runtime,
+    agentId,
+    conversationId,
+  );
+  if (workingDirectory === inherited) {
     runtime.workingDirectoryByConversation.delete(scopeKey);
   } else {
     runtime.workingDirectoryByConversation.set(scopeKey, workingDirectory);


### PR DESCRIPTION
## Summary
- The desktop **"Default working directory"** setting (per agent, per device) is silently ignored by new chats: a new conversation starts in whatever directory the listener booted in (e.g. `Documents`/`Stack`) regardless of the saved default.
- Root cause: the default is stored under the `agent:<id>::conversation:default` scope key, but `getConversationWorkingDirectory` only consulted that key when the conversation id was literally `"default"` (the pre-send "New conversation" preview). Once a real conversation id is created, its scope key has no entry, so resolution fell straight back to `bootWorkingDirectory` — skipping the per-agent default entirely.

## Fix
- Add a `getInheritedWorkingDirectory` tier: a concrete conversation with no explicit per-conversation override now inherits the **per-agent default** (when set) before `bootWorkingDirectory`. The agent-default scope itself still inherits boot (no higher tier).
- Apply the same inheritance in `setConversationWorkingDirectory` when deciding whether to persist or drop an override, so explicit per-conversation choices that differ from the inherited default are preserved (and redundant entries are still pruned).

Resolution precedence is now: `conversation:<id>` override → `agent:<id>::conversation:default` → boot cwd.

## Repro (before)
1. Set a per-agent **Default working directory** (e.g. `/Users/me/Code/foo`).
2. Start a **new chat** and ask the agent what folder it is in.
3. It reports the listener boot dir (e.g. `~/Documents`), not the saved default.

## Test plan
- [x] `bun test src/websocket/listener/cwd.test.ts` (new): override / per-agent-default / boot tiers + persist-vs-drop logic
- [x] `bun test src/websocket/listen-client-protocol.test.ts` (161) green
- [x] `bun run typecheck`, `biome check`, layer-boundaries, exported-functions, filename-casing, `madge --circular` all clean
- [ ] Manual: set a default working dir, open a new chat, confirm the agent runs in that dir

👾 Generated with [Letta Code](https://letta.com)