### PR TITLE
fix(local-backend): fork conversations in-process instead of via the proxy

### DIFF
--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -233,6 +233,38 @@ describe("local backend pi transcript", () => {
     }
   });
 
+  // Regression: forking must run in-process via the local store. The default
+  // Backend.forkConversation posts to /v1/conversations/{id}/fork, which the
+  // desktop local-backend proxy returns 501 for, so without the override every
+  // fork attempt failed with LOCAL_BACKEND_UNSUPPORTED_ENDPOINT.
+  test("forks a conversation locally without hitting the HTTP proxy", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-backend-fork-"));
+    try {
+      const backend = new LocalBackend({ storageDir, memfsEnabled: false });
+      const agent = await backend.createAgent({ name: "Local" } as never);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+        summary: "Source conversation",
+      } as never);
+
+      const forked = await backend.forkConversation(conversation.id, {
+        agentId: agent.id,
+      });
+
+      expect(forked.id).toBeTruthy();
+      expect(forked.id).not.toBe(conversation.id);
+
+      const conversations = (await backend.listConversations({
+        agent_id: agent.id,
+      } as never)) as Array<{ id: string; summary?: string | null }>;
+      const forkedRecord = conversations.find((c) => c.id === forked.id);
+      expect(forkedRecord).toBeDefined();
+      expect(forkedRecord?.summary).toBe("Source conversation");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
   test("repairs legacy synthetic transcript timestamps from manifest and file mtime", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "local-backend-time-"));
     const agentId = "agent-local-default";

--- a/src/backend/local/local-backend.ts
+++ b/src/backend/local/local-backend.ts
@@ -389,6 +389,17 @@ export class LocalBackend extends HeadlessBackend {
     return conversation;
   }
 
+  // The default Backend.forkConversation issues an HTTP POST to
+  // /v1/conversations/{id}/fork, which the desktop local-backend proxy does
+  // not implement (returns 501 LOCAL_BACKEND_UNSUPPORTED_ENDPOINT). The local
+  // store already supports forking in-process, so delegate to it directly.
+  override async forkConversation(
+    conversationId: string,
+    options?: Parameters<Backend["forkConversation"]>[1],
+  ): ReturnType<Backend["forkConversation"]> {
+    return this.store.forkConversation(conversationId, options ?? {});
+  }
+
   override async recompileConversation(
     conversationId: string,
     body?: ConversationRecompileBody,


### PR DESCRIPTION
## Summary
- Forking a conversation on a **local agent** fails with `501 LOCAL_BACKEND_UNSUPPORTED_ENDPOINT` ("This local backend endpoint is not implemented in the Desktop proxy yet"), including forking the `default` conversation.
- Root cause: `LocalBackend` never overrode `forkConversation`, so it inherited the default `Backend` implementation that issues `POST /v1/conversations/{id}/fork`. The desktop local-backend proxy does not implement that route, so every local fork 501s — even though the local store already supports forking in-process.

## Fix
- Override `forkConversation` on `LocalBackend` to delegate to `this.store.forkConversation(...)` directly (mirroring the dev fake-headless backend), so it never touches the HTTP proxy. Option types already match (`{ agentId?, hidden? }`).

## Test plan
- [x] `bun test src/backend/local-backend.test.ts` (32) green, incl. new regression: a local fork returns a new **listed** conversation that carries the source summary
- [x] `bun run typecheck`, `biome check`, layer-boundaries, exported-functions, filename-casing all clean
- [ ] Manual: on a local agent, fork a conversation from the desktop sidebar — should create a forked chat instead of erroring

👾 Generated with [Letta Code](https://letta.com)