### PR TITLE
fix(telegram): do not infer messageId as threadId in direct chats

### DIFF
--- a/src/channels/message-channel.test.ts
+++ b/src/channels/message-channel.test.ts
@@ -210,6 +210,68 @@ describe("MessageChannel", () => {
     });
   });
 
+  test("does not infer messageId as threadId for Telegram direct chats", async () => {
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({ messageId: "42" }));
+
+    const adapter: ChannelAdapter = {
+      id: "telegram:account-1",
+      channelId: "telegram",
+      accountId: "account-1",
+      name: "Telegram",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+
+    setRouteInMemory("telegram", {
+      accountId: "account-1",
+      chatId: "8150361784",
+      chatType: "direct",
+      threadId: null,
+      agentId: "agent-1",
+      conversationId: "conv-dm",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const result = await message_channel({
+      action: "send",
+      channel: "telegram",
+      chat_id: "8150361784",
+      message: "hello from DM",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "conv-dm",
+      },
+      channelTurnSources: [
+        {
+          channel: "telegram",
+          accountId: "account-1",
+          chatId: "8150361784",
+          chatType: "direct",
+          messageId: "23",
+          threadId: null,
+          agentId: "agent-1",
+          conversationId: "conv-dm",
+        },
+      ],
+    });
+
+    expect(result).toContain("Message sent to telegram");
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: null,
+      }),
+    );
+  });
+
   test("passes Slack reactions through MessageChannel with the routed account", async () => {
     const registry = new ChannelRegistry();
 

--- a/src/tools/impl/message-channel.ts
+++ b/src/tools/impl/message-channel.ts
@@ -37,6 +37,13 @@ const SLACK_PLACEHOLDER_SUFFIX = "X";
 const SLACK_PLACEHOLDER_PATTERN = /LCSLACKMRKDWNPLACEHOLDER(\d+)X/g;
 const SLACK_ANGLE_TOKEN_RE = /<[^>\n]+>/g;
 
+// Channels where a thread identifier is equivalent to a message identifier
+// (e.g. Slack's thread_ts). For these, if threadId is absent we can fall
+// back to messageId. Other channels must not use messageId as a threadId.
+const CHANNELS_USING_MESSAGE_ID_AS_THREAD_ID = new Set<SupportedChannelId>([
+  "slack",
+]);
+
 type OutboundChannelFormatter = (
   text: string,
 ) => Pick<OutboundChannelMessage, "text" | "parseMode">;
@@ -752,7 +759,17 @@ function inferThreadIdFromChannelTurnSources(params: {
       continue;
     }
 
-    threadIds.add(source.threadId ?? source.messageId ?? null);
+    // Only fall through to messageId for channels where thread identifiers
+    // double as message identifiers (e.g. Slack thread_ts). For Telegram
+    // direct chats, messageId is never a valid thread ID and would cause
+    // "message thread not found" errors if forwarded as message_thread_id.
+    if (source.threadId != null) {
+      threadIds.add(source.threadId);
+    } else if (CHANNELS_USING_MESSAGE_ID_AS_THREAD_ID.has(source.channel)) {
+      threadIds.add(source.messageId ?? null);
+    } else {
+      threadIds.add(null);
+    }
   }
 
   return threadIds.size === 1 ? [...threadIds][0] : undefined;


### PR DESCRIPTION
## Summary

Commit 2fe98dcd ("fix(slack): keep channel replies in active thread", #2838) introduced `inferThreadIdFromChannelTurnSources` to keep Slack channel replies in their active thread. Its fallback used `source.threadId ?? source.messageId ?? null`, which is correct for Slack (where `thread_ts` can equal the message timestamp) but wrong for Telegram direct chats.

In a private Telegram chat, `threadId` is `null` and `messageId` is the numeric message ID. The previous logic inferred that message ID as a thread ID, which was then passed as `message_thread_id` to the Telegram Bot API, causing `Bad Request: message thread not found` errors.

## Change

- `src/tools/impl/message-channel.ts`: only fall back to `messageId` for Slack. For all other channels, treat a missing `threadId` as `null`.
- `src/channels/message-channel.test.ts`: add a test covering a Telegram direct chat with `threadId: null` to ensure `messageId` is not inferred as `threadId`.

## Test plan

- [ ] Run `bun test src/channels/message-channel.test.ts` (I was unable to run tests locally because `node_modules` / `bun` are not installed in this environment).

👾 Generated with [Letta Code](https://letta.com)