### PR TITLE
fix(telegram): avoid inlining SVG attachments as images

### DIFF
--- a/src/channels/telegram-adapter.test.ts
+++ b/src/channels/telegram-adapter.test.ts
@@ -2045,6 +2045,84 @@ test("telegram adapter preserves photo mime type when Telegram download responds
   }
 });
 
+test("telegram adapter does not inline SVG documents as model images", async () => {
+  const svgBytes = Buffer.from(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10" fill="#ff6600" /></svg>',
+  );
+  globalThis.fetch = mock(
+    async () =>
+      new Response(svgBytes, {
+        status: 200,
+        headers: { "content-type": "image/svg+xml" },
+      }),
+  ) as unknown as typeof fetch;
+
+  FakeBot.nextGetFileImpl = async () => ({
+    file_path: "documents/void-final.svg",
+  });
+
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  const onMessage = mock(async () => {});
+  adapter.onMessage = onMessage;
+
+  await adapter.start();
+
+  const bot = FakeBot.instances[0];
+  try {
+    await bot?.emit("message", {
+      message: {
+        chat: { id: 123 },
+        from: { id: 456, username: "alice", first_name: "Alice" },
+        caption: "Extract the colors",
+        date: 1_736_380_800,
+        message_id: 10,
+        document: {
+          file_id: "svg1",
+          file_name: "void-final.svg",
+          mime_type: "image/svg+xml",
+          file_size: svgBytes.byteLength,
+        },
+      },
+    });
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    const firstCall = onMessage.mock.calls[0] as unknown as
+      | [InboundChannelMessage]
+      | undefined;
+    expect(firstCall).toBeDefined();
+    if (!firstCall) {
+      throw new Error("Expected inbound Telegram SVG to emit a message");
+    }
+
+    const [inbound] = firstCall;
+    expect(inbound.attachments).toHaveLength(1);
+    const attachment = inbound.attachments?.[0];
+    expect(attachment).toMatchObject({
+      kind: "image",
+      name: "void-final.svg",
+      mimeType: "image/svg+xml",
+      sizeBytes: svgBytes.byteLength,
+    });
+    expect(attachment?.imageDataBase64).toBeUndefined();
+    expect(attachment?.localPath).toBeDefined();
+    if (!attachment?.localPath) {
+      throw new Error("Expected inbound Telegram SVG to be saved locally");
+    }
+    expect(readFileSync(attachment.localPath)).toEqual(svgBytes);
+  } finally {
+    rmSync(channelRoot, { recursive: true, force: true });
+    channelRoot = mkdtempSync(join(tmpdir(), "letta-telegram-root-"));
+  }
+});
+
 test("telegram adapter downloads inbound wav documents as audio", async () => {
   const wavBytes = Buffer.from("wav-bytes");
   globalThis.fetch = mock(

--- a/src/channels/telegram/media.ts
+++ b/src/channels/telegram/media.ts
@@ -143,6 +143,15 @@ function isImageMimeType(mimeType?: string): boolean {
   return normalizeTelegramMimeType(mimeType)?.startsWith("image/") ?? false;
 }
 
+function canInlineTelegramImage(mimeType?: string): boolean {
+  const normalized = normalizeTelegramMimeType(mimeType);
+  return (
+    !!normalized &&
+    normalized.startsWith("image/") &&
+    normalized !== "image/svg+xml"
+  );
+}
+
 function isAudioMimeType(mimeType?: string): boolean {
   return normalizeTelegramMimeType(mimeType)?.startsWith("audio/") ?? false;
 }
@@ -616,7 +625,9 @@ async function downloadTelegramAttachment(params: {
     sizeBytes: buffer.byteLength,
     kind,
     localPath,
-    ...(kind === "image" && buffer.byteLength <= MAX_TELEGRAM_INLINE_IMAGE_BYTES
+    ...(kind === "image" &&
+    canInlineTelegramImage(mimeType) &&
+    buffer.byteLength <= MAX_TELEGRAM_INLINE_IMAGE_BYTES
       ? { imageDataBase64: buffer.toString("base64") }
       : {}),
   };

--- a/src/channels/xml.test.ts
+++ b/src/channels/xml.test.ts
@@ -430,6 +430,32 @@ describe("formatChannelNotification", () => {
     expect(xml).toContain("please respond");
   });
 
+  test("does not emit inline image content parts for SVG attachments", () => {
+    const msg: InboundChannelMessage = {
+      channel: "telegram",
+      chatId: "123",
+      senderId: "456",
+      text: "Extract colors",
+      timestamp: Date.now(),
+      messageId: "10",
+      attachments: [
+        {
+          id: "svg1",
+          name: "void-final.svg",
+          mimeType: "image/svg+xml",
+          kind: "image",
+          localPath: "/tmp/void-final.svg",
+          imageDataBase64: "PHN2Zy8+",
+        },
+      ],
+    };
+
+    const content = formatChannelNotification(msg);
+    const [, notificationPart] = expectTextParts(content);
+    expect(notificationPart.text).toContain('mime_type="image/svg+xml"');
+    expect(notificationPart.text).toContain('local_path="/tmp/void-final.svg"');
+  });
+
   test("emits image content parts for inbound image attachments", () => {
     const msg: InboundChannelMessage = {
       channel: "slack",

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -139,6 +139,15 @@ function buildAttachmentXml(attachment: ChannelMessageAttachment): string {
   return `<attachment ${attrs.join(" ")} />`;
 }
 
+function canEmitInlineImageContentPart(mimeType: string): boolean {
+  const normalized = mimeType.split(";")[0]?.trim().toLowerCase();
+  return (
+    !!normalized &&
+    normalized.startsWith("image/") &&
+    normalized !== "image/svg+xml"
+  );
+}
+
 function buildReactionXml(msg: InboundChannelMessage): string | null {
   if (!msg.reaction) {
     return null;
@@ -310,7 +319,7 @@ export function formatChannelNotification(
         typeof attachment.imageDataBase64 !== "string" ||
         attachment.imageDataBase64.length === 0 ||
         typeof attachment.mimeType !== "string" ||
-        !attachment.mimeType.startsWith("image/")
+        !canEmitInlineImageContentPart(attachment.mimeType)
       ) {
         return [];
       }

--- a/src/utils/message-image-normalization.ts
+++ b/src/utils/message-image-normalization.ts
@@ -9,6 +9,10 @@ export const SUPPORTED_BASE64_IMAGE_MEDIA_TYPES = new Set([
   "image/webp",
 ]);
 
+function isSupportedBase64ImageMediaType(mediaType: string): boolean {
+  return SUPPORTED_BASE64_IMAGE_MEDIA_TYPES.has(mediaType);
+}
+
 export type Base64ImageContentPart = {
   type: "image";
   source: { type: "base64"; media_type: string; data: string };
@@ -76,6 +80,16 @@ export async function normalizeMessageContentImages(
           return null;
         }
         throw formatImageNormalizationError(error);
+      }
+
+      if (!isSupportedBase64ImageMediaType(resized.mediaType)) {
+        if (failureMode === "drop") {
+          didChange = true;
+          return null;
+        }
+        throw new Error(
+          `Unsupported base64 image media type after normalization: ${resized.mediaType}`,
+        );
       }
 
       if (
@@ -150,7 +164,7 @@ export function assertSupportedBase64ImageMediaTypes(
         continue;
       }
 
-      if (!SUPPORTED_BASE64_IMAGE_MEDIA_TYPES.has(part.source.media_type)) {
+      if (!isSupportedBase64ImageMediaType(part.source.media_type)) {
         throw new Error(
           `Unsupported base64 image media type after normalization: ${part.source.media_type}`,
         );

--- a/src/websocket/listen-client-image-normalization.test.ts
+++ b/src/websocket/listen-client-image-normalization.test.ts
@@ -167,6 +167,50 @@ describe("listen-client inbound image normalization", () => {
     expect(imagePart.source.media_type).toBe("image/png");
   });
 
+  test("drops inbound image parts when normalization leaves an unsupported media type", async () => {
+    const normalized = await __listenClientTestUtils.normalizeInboundMessages(
+      [
+        {
+          type: "message",
+          role: "user",
+          content: [
+            { type: "text", text: "channel reminder" },
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/svg+xml",
+                data: "raw-base64-image",
+              },
+            },
+            { type: "text", text: "<channel-notification />" },
+          ],
+          client_message_id: "cm-image-drop-unsupported",
+        },
+      ],
+      async (_buffer, mediaType) => ({
+        data: "still-unsupported",
+        mediaType,
+        width: 64,
+        height: 64,
+        resized: false,
+      }),
+      { imageFailureMode: "drop" },
+    );
+
+    expect(normalized).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [
+          { type: "text", text: "channel reminder" },
+          { type: "text", text: "<channel-notification />" },
+        ],
+        client_message_id: "cm-image-drop-unsupported",
+      },
+    ]);
+  });
+
   test("drops inbound image parts when best-effort normalization fails", async () => {
     const normalized = await __listenClientTestUtils.normalizeInboundMessages(
       [


### PR DESCRIPTION
## Summary
- keep Telegram SVG document uploads as local attachments instead of inlining them as base64 model image parts
- defensively suppress SVG inline image parts in channel notification formatting
- drop still-unsupported image media types during channel best-effort inbound normalization so the text/XML turn survives

## Tests
- bun test src/channels/xml.test.ts src/channels/telegram-adapter.test.ts src/websocket/listen-client-image-normalization.test.ts
- bun run typecheck
- bun run check