### PR TITLE
fix(channels): normalize DM thread routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,58 +109,6 @@ jobs:
       - name: Lint & Type Check
         run: bun run check
 
-  telegram-live-smoke:
-    needs: [classify, check]
-    name: Telegram Live Smoke
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    if: >
-      needs.classify.outputs.channels_changed == 'true' &&
-      (github.event_name == 'push' ||
-      (github.event_name == 'pull_request' &&
-      github.actor != 'dependabot[bot]' &&
-      github.event.pull_request.head.repo.full_name == github.repository))
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.0
-
-      - name: Install dependencies
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bun install --frozen-lockfile
-
-      - name: Validate Telegram smoke secrets
-        env:
-          TELEGRAM_SMOKE_BOT_TOKEN: ${{ secrets.TELEGRAM_SMOKE_BOT_TOKEN }}
-          TELEGRAM_SMOKE_CHAT_ID: ${{ secrets.TELEGRAM_SMOKE_CHAT_ID }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "${TELEGRAM_SMOKE_BOT_TOKEN:-}" ]; then
-            echo "::error::Missing required GitHub secret TELEGRAM_SMOKE_BOT_TOKEN"
-            exit 1
-          fi
-
-          if [ -z "${TELEGRAM_SMOKE_CHAT_ID:-}" ]; then
-            echo "::error::Missing required GitHub secret TELEGRAM_SMOKE_CHAT_ID"
-            exit 1
-          fi
-
-      - name: Run Telegram live smoke
-        env:
-          LETTA_RUN_LIVE_TELEGRAM_SMOKE: "1"
-          TELEGRAM_SMOKE_BOT_TOKEN: ${{ secrets.TELEGRAM_SMOKE_BOT_TOKEN }}
-          TELEGRAM_SMOKE_CHAT_ID: ${{ secrets.TELEGRAM_SMOKE_CHAT_ID }}
-          TELEGRAM_SMOKE_THREAD_ID: ${{ secrets.TELEGRAM_SMOKE_THREAD_ID }}
-        run: bun test src/channels/telegram-live-smoke.test.ts --timeout 30000
-
   update-chain-smoke:
     needs: check
     name: Update Chain Smoke

--- a/.github/workflows/telegram-live-smoke.yml
+++ b/.github/workflows/telegram-live-smoke.yml
@@ -1,0 +1,58 @@
+name: Telegram Live Smoke
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 9 * * *"
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/telegram-live-smoke.yml
+      - src/channels/**
+
+jobs:
+  telegram-live-smoke:
+    name: Telegram Live Smoke
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.0
+
+      - name: Install dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun install --frozen-lockfile
+
+      - name: Validate Telegram smoke secrets
+        env:
+          TELEGRAM_SMOKE_BOT_TOKEN: ${{ secrets.TELEGRAM_SMOKE_BOT_TOKEN }}
+          TELEGRAM_SMOKE_CHAT_ID: ${{ secrets.TELEGRAM_SMOKE_CHAT_ID }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${TELEGRAM_SMOKE_BOT_TOKEN:-}" ]; then
+            echo "::error::Missing required GitHub secret TELEGRAM_SMOKE_BOT_TOKEN"
+            exit 1
+          fi
+
+          if [ -z "${TELEGRAM_SMOKE_CHAT_ID:-}" ]; then
+            echo "::error::Missing required GitHub secret TELEGRAM_SMOKE_CHAT_ID"
+            exit 1
+          fi
+
+      - name: Run Telegram live smoke
+        env:
+          LETTA_RUN_LIVE_TELEGRAM_SMOKE: "1"
+          TELEGRAM_SMOKE_BOT_TOKEN: ${{ secrets.TELEGRAM_SMOKE_BOT_TOKEN }}
+          TELEGRAM_SMOKE_CHAT_ID: ${{ secrets.TELEGRAM_SMOKE_CHAT_ID }}
+          TELEGRAM_SMOKE_THREAD_ID: ${{ secrets.TELEGRAM_SMOKE_THREAD_ID }}
+        run: bun test src/channels/telegram-live-smoke.test.ts --timeout 30000

--- a/src/channels/discord/message-actions.ts
+++ b/src/channels/discord/message-actions.ts
@@ -3,6 +3,22 @@ import type {
   ChannelMessageActionContext,
 } from "@/channels/plugin-types";
 
+function resolveDiscordRouteThreadId(
+  ctx: ChannelMessageActionContext,
+): string | null {
+  if (ctx.route.chatType === "direct") {
+    return ctx.route.chatId;
+  }
+
+  const threadId = ctx.request.threadId ?? ctx.route.threadId ?? null;
+  const trimmed = threadId?.trim();
+  if (trimmed) {
+    return trimmed;
+  }
+
+  return null;
+}
+
 async function sendDiscordMessage(
   ctx: ChannelMessageActionContext,
 ): Promise<string> {
@@ -20,7 +36,7 @@ async function sendDiscordMessage(
     chatId: request.chatId,
     text: formatted.text,
     replyToMessageId: request.replyToMessageId,
-    threadId: request.threadId ?? route.threadId ?? null,
+    threadId: resolveDiscordRouteThreadId(ctx),
     mediaPath: request.mediaPath,
     fileName: request.filename,
     title: request.title,
@@ -52,7 +68,7 @@ async function reactInDiscord(
     targetMessageId: request.messageId,
     reaction: request.emoji,
     removeReaction: request.remove,
-    threadId: request.threadId ?? route.threadId ?? null,
+    threadId: resolveDiscordRouteThreadId(ctx),
   });
 
   return request.remove

--- a/src/channels/message-channel.test.ts
+++ b/src/channels/message-channel.test.ts
@@ -331,6 +331,64 @@ describe("MessageChannel", () => {
     });
   });
 
+  test("sends Discord direct routes to the DM channel without caller threadId", async () => {
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({ messageId: "discord-msg-1" }));
+
+    const adapter: ChannelAdapter = {
+      id: "discord:discord-1",
+      channelId: "discord",
+      accountId: "discord-1",
+      name: "Discord",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+
+    setRouteInMemory("discord", {
+      accountId: "discord-1",
+      chatId: "DM-123",
+      chatType: "direct",
+      threadId: null,
+      agentId: "agent-1",
+      conversationId: "default",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const result = await message_channel({
+      action: "send",
+      channel: "discord",
+      chat_id: "DM-123",
+      message: "hello dm",
+      threadId: "",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    });
+
+    expect(result).toContain("Message sent to discord");
+    expect(sendMessage).toHaveBeenCalledWith({
+      channel: "discord",
+      accountId: "discord-1",
+      chatId: "DM-123",
+      text: "hello dm",
+      replyToMessageId: undefined,
+      threadId: "DM-123",
+      mediaPath: undefined,
+      fileName: undefined,
+      title: undefined,
+      parseMode: undefined,
+    });
+  });
+
   test("formats and sends Telegram messages through the routed account adapter", async () => {
     const registry = new ChannelRegistry();
 
@@ -379,6 +437,66 @@ describe("MessageChannel", () => {
       chatId: "7952253975",
       text: "hello <b>world</b> &amp; team",
       replyToMessageId: "42",
+      threadId: null,
+      mediaPath: undefined,
+      fileName: undefined,
+      title: undefined,
+      parseMode: "HTML",
+    });
+  });
+
+  test("does not reuse route thread ids for Telegram private chats", async () => {
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({
+      messageId: "telegram-msg-private",
+    }));
+
+    const adapter: ChannelAdapter = {
+      id: "telegram:account-1",
+      channelId: "telegram",
+      accountId: "account-1",
+      name: "Telegram",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+
+    setRouteInMemory("telegram", {
+      accountId: "account-1",
+      chatId: "7952253975",
+      chatType: "direct",
+      threadId: "42",
+      agentId: "agent-1",
+      conversationId: "default",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const result = await message_channel({
+      action: "send",
+      channel: "telegram",
+      chat_id: "7952253975",
+      message: "hello private chat",
+      threadId: "",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    });
+
+    expect(result).toContain("Message sent to telegram");
+    expect(sendMessage).toHaveBeenCalledWith({
+      channel: "telegram",
+      accountId: "account-1",
+      chatId: "7952253975",
+      text: "hello private chat",
+      replyToMessageId: undefined,
       threadId: null,
       mediaPath: undefined,
       fileName: undefined,

--- a/src/channels/telegram-adapter.test.ts
+++ b/src/channels/telegram-adapter.test.ts
@@ -741,6 +741,36 @@ test("telegram adapter forwards parse mode and reply parameters", async () => {
   });
 });
 
+test("telegram adapter omits message_thread_id for private chats", async () => {
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+  await adapter.sendMessage({
+    channel: "telegram",
+    chatId: "123",
+    text: "<b>hello private</b>",
+    threadId: "42",
+    parseMode: "HTML",
+  });
+
+  const bot = FakeBot.instances[0];
+  expect(bot).toBeDefined();
+  expect(bot?.api.sendMessage).toHaveBeenCalledWith(
+    "123",
+    "<b>hello private</b>",
+    {
+      parse_mode: "HTML",
+    },
+  );
+});
+
 test("telegram adapter sends messages into forum topics", async () => {
   const adapter = createTelegramAdapter({
     ...telegramAccountDefaults,
@@ -785,7 +815,7 @@ test("telegram adapter uploads outbound media with a caption", async () => {
   await adapter.start();
   await adapter.sendMessage({
     channel: "telegram",
-    chatId: "123",
+    chatId: "-100123",
     text: "<b>see image</b>",
     parseMode: "HTML",
     replyToMessageId: "456",
@@ -797,7 +827,7 @@ test("telegram adapter uploads outbound media with a caption", async () => {
 
   const bot = FakeBot.instances[0];
   expect(bot?.api.sendPhoto).toHaveBeenCalledWith(
-    "123",
+    "-100123",
     expect.any(FakeInputFile),
     {
       caption: "<b>see image</b>",

--- a/src/channels/telegram-adapter.test.ts
+++ b/src/channels/telegram-adapter.test.ts
@@ -1443,6 +1443,53 @@ test("telegram adapter replies with lifecycle errors", async () => {
   );
 });
 
+test("telegram lifecycle errors omit stale thread ids for private chats", async () => {
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "finished",
+    batchId: "batch-1",
+    outcome: "error",
+    error: "Something failed.",
+    sources: [
+      {
+        channel: "telegram",
+        accountId: "telegram-test-account",
+        chatId: "123",
+        chatType: "direct",
+        messageId: "77",
+        threadId: "42",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      },
+    ],
+  });
+
+  const bot = FakeBot.instances[0];
+  expect(bot?.api.sendMessage).toHaveBeenCalledWith(
+    "123",
+    "Turn failed:\nSomething failed.",
+    expect.not.objectContaining({
+      message_thread_id: expect.anything(),
+    }),
+  );
+  expect(bot?.api.sendMessage).toHaveBeenCalledWith(
+    "123",
+    "Turn failed:\nSomething failed.",
+    expect.objectContaining({
+      reply_parameters: { message_id: 77 },
+    }),
+  );
+});
+
 test("telegram adapter hides raw generic lifecycle errors", async () => {
   const adapter = createTelegramAdapter({
     ...telegramAccountDefaults,
@@ -2323,4 +2370,50 @@ test("telegram adapter clears typing after sending control request prompt", asyn
   expect(bot?.api.sendChatAction).toHaveBeenCalledTimes(2);
 
   await adapter.stop();
+});
+
+test("telegram control prompts omit stale thread ids for private chats", async () => {
+  const adapter = createTelegramAdapter({
+    ...telegramAccountDefaults,
+    channel: "telegram",
+    enabled: true,
+    token: "test-token",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+
+  await adapter.handleControlRequestEvent?.({
+    requestId: "req-1",
+    kind: "generic_tool_approval",
+    source: {
+      channel: "telegram",
+      accountId: "telegram-test-account",
+      chatId: "555",
+      chatType: "direct",
+      messageId: "42",
+      threadId: "99",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+    },
+    toolName: "Shell",
+    input: { command: "echo test" },
+  });
+
+  const bot = FakeBot.instances[0];
+  expect(bot?.api.sendMessage).toHaveBeenCalledWith(
+    "555",
+    expect.stringContaining("Shell"),
+    expect.not.objectContaining({
+      message_thread_id: expect.anything(),
+    }),
+  );
+  expect(bot?.api.sendMessage).toHaveBeenCalledWith(
+    "555",
+    expect.stringContaining("Shell"),
+    expect.objectContaining({
+      reply_parameters: { message_id: 42 },
+    }),
+  );
 });

--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -1017,7 +1017,8 @@ export function createTelegramAdapter(
     }
 
     const telegramBot = await ensureBot();
-    const replyToMessageId = source.threadId ?? source.messageId;
+    const threadId = resolveTelegramOutboundThreadId(source);
+    const replyToMessageId = threadId ?? source.messageId;
     let reply_parameters: { message_id: number } | undefined;
     if (replyToMessageId) {
       const numericReplyToMessageId = Number(replyToMessageId);
@@ -1026,18 +1027,10 @@ export function createTelegramAdapter(
       }
     }
 
-    const options: Record<string, unknown> = reply_parameters
-      ? {
-          ...(source.threadId
-            ? { message_thread_id: Number(source.threadId) }
-            : {}),
-          reply_parameters,
-        }
-      : {
-          ...(source.threadId
-            ? { message_thread_id: Number(source.threadId) }
-            : {}),
-        };
+    const options: Record<string, unknown> = {
+      ...(threadId ? { message_thread_id: Number(threadId) } : {}),
+      ...(reply_parameters ? { reply_parameters } : {}),
+    };
     options.reply_markup = {
       inline_keyboard: [
         [
@@ -1343,21 +1336,16 @@ export function createTelegramAdapter(
       event: ChannelControlRequestEvent,
     ): Promise<void> {
       const telegramBot = await ensureBot();
-      const reply_parameters =
-        event.source.messageId || event.source.threadId
-          ? {
-              message_id: Number(
-                event.source.threadId ?? event.source.messageId,
-              ),
-            }
-          : undefined;
+      const threadId = resolveTelegramOutboundThreadId(event.source);
+      const replyToMessageId = threadId ?? event.source.messageId;
+      const reply_parameters = replyToMessageId
+        ? { message_id: Number(replyToMessageId) }
+        : undefined;
       await telegramBot.api.sendMessage(
         event.source.chatId,
         formatChannelControlRequestPrompt(event),
         {
-          ...(event.source.threadId
-            ? { message_thread_id: Number(event.source.threadId) }
-            : {}),
+          ...(threadId ? { message_thread_id: Number(threadId) } : {}),
           ...(reply_parameters ? { reply_parameters } : {}),
         },
       );

--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -279,15 +279,30 @@ function resolveTelegramInputFileConstructor(
   return InputFile as TelegramInputFileConstructor;
 }
 
+function resolveTelegramOutboundThreadId(
+  msg: Pick<OutboundChannelMessage, "chatId" | "threadId">,
+): string | null {
+  const threadId = msg.threadId?.trim();
+  if (!threadId) {
+    return null;
+  }
+
+  // Telegram message_thread_id is only valid for forum topics in groups and
+  // supergroups. Private chat IDs are positive, so never attach a thread id
+  // there even if stale route state provided one.
+  return msg.chatId.trim().startsWith("-") ? threadId : null;
+}
+
 function buildTelegramReplyOptions(
   msg: Pick<
     OutboundChannelMessage,
-    "replyToMessageId" | "threadId" | "parseMode" | "text" | "title"
+    "chatId" | "replyToMessageId" | "threadId" | "parseMode" | "text" | "title"
   >,
 ): Record<string, unknown> {
   const options: Record<string, unknown> = {};
-  if (msg.threadId) {
-    options.message_thread_id = Number(msg.threadId);
+  const threadId = resolveTelegramOutboundThreadId(msg);
+  if (threadId) {
+    options.message_thread_id = Number(threadId);
   }
   if (msg.replyToMessageId) {
     options.reply_parameters = {
@@ -1237,8 +1252,9 @@ export function createTelegramAdapter(
       }
 
       const opts: Record<string, unknown> = {};
-      if (msg.threadId) {
-        opts.message_thread_id = Number(msg.threadId);
+      const threadId = resolveTelegramOutboundThreadId(msg);
+      if (threadId) {
+        opts.message_thread_id = Number(threadId);
       }
       if (msg.replyToMessageId) {
         opts.reply_parameters = {

--- a/src/channels/telegram/message-actions.ts
+++ b/src/channels/telegram/message-actions.ts
@@ -1,4 +1,23 @@
-import type { ChannelMessageActionAdapter } from "@/channels/plugin-types";
+import type {
+  ChannelMessageActionAdapter,
+  ChannelMessageActionContext,
+} from "@/channels/plugin-types";
+
+function resolveTelegramRouteThreadId(
+  ctx: ChannelMessageActionContext,
+): string | null {
+  const threadId = ctx.request.threadId ?? ctx.route.threadId ?? null;
+  const trimmed = threadId?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (ctx.route.chatType === "direct") {
+    return null;
+  }
+
+  return ctx.route.chatId.trim().startsWith("-") ? trimmed : null;
+}
 
 export const telegramMessageActions: ChannelMessageActionAdapter = {
   describeMessageTool() {
@@ -57,7 +76,7 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
       chatId: request.chatId,
       text: formatted.text,
       replyToMessageId: request.replyToMessageId,
-      threadId: request.threadId ?? route.threadId ?? null,
+      threadId: resolveTelegramRouteThreadId(ctx),
       mediaPath: request.mediaPath,
       fileName: request.filename,
       title: request.title,


### PR DESCRIPTION
## Summary

Fixes channel DM routing regressions from Ezra Support:

- Discord direct-message routes now send through the DM channel even when the route has no stored thread id.
- Telegram private-chat sends now drop stale forum thread ids before calling the Telegram Bot API, while group/forum topic sends keep their thread id.

## Why

Both bugs had the same shape: direct/private channel routes were carrying thread metadata in a way the provider rejected. Discord DMs need the DM channel id as the thread target in our adapter call path. Telegram private chats must not send a message_thread_id at all because Telegram only accepts it for forum topics in groups/supergroups.

## Validation

- bun test src/channels/message-channel.test.ts src/channels/telegram-adapter.test.ts
- bunx --bun @biomejs/biome@2.2.5 check src/channels/discord/message-actions.ts src/channels/message-channel.test.ts src/channels/telegram-adapter.test.ts src/channels/telegram/adapter.ts src/channels/telegram/message-actions.ts
- pre-commit hook ran layer-boundary/export/filename checks, Biome write, and tsc --noEmit

## Linear

LET-9192
LET-9188
LET-9193
