### PR TITLE
fix(transcripts): persist approval-request tool calls

### DIFF
--- a/src/cli/app/reflection-transcript-wiring.test.ts
+++ b/src/cli/app/reflection-transcript-wiring.test.ts
@@ -15,26 +15,20 @@ describe("interactive reflection transcript wiring", () => {
     expect(source).toContain("description: AUTO_REFLECTION_DESCRIPTION");
   });
 
-  test("conversation loop evaluates reflection after the transcript append on end_turn", () => {
+  test("conversation loop evaluates reflection after the transcript append", () => {
     const conversationLoopPath = fileURLToPath(
       new URL("./use-conversation-loop.ts", import.meta.url),
     );
     const loopSource = readFileSync(conversationLoopPath, "utf-8");
 
-    const endTurnIndex = loopSource.indexOf(
-      'if (stopReasonToHandle === "end_turn")',
-    );
     const appendIndex = loopSource.indexOf(
-      "appendTranscriptDeltaJsonl(",
-      endTurnIndex,
+      "appendTranscriptDeltaJsonlForStopReason(",
     );
     const reflectionIndex = loopSource.indexOf(
       "await maybeRunPostTurnReflection();",
-      endTurnIndex,
     );
 
-    expect(endTurnIndex).toBeGreaterThanOrEqual(0);
-    expect(appendIndex).toBeGreaterThan(endTurnIndex);
+    expect(appendIndex).toBeGreaterThanOrEqual(0);
     expect(reflectionIndex).toBeGreaterThan(appendIndex);
   });
 
@@ -65,10 +59,13 @@ describe("interactive reflection transcript wiring", () => {
     expect(loopSource).toContain("const transcriptTurnStartLineIndex =");
     expect(loopSource).toContain('if (stopReasonToHandle === "end_turn")');
     expect(loopSource).toContain("toLines(buffersRef.current).slice(");
-    expect(loopSource).toContain("appendTranscriptDeltaJsonl(");
+    expect(loopSource).toContain("appendTranscriptDeltaJsonlForStopReason(");
+    expect(loopSource).toContain("stopReasonToHandle,");
 
     expect(
+      loopSource.indexOf("appendTranscriptDeltaJsonlForStopReason("),
+    ).toBeLessThan(
       loopSource.indexOf('if (stopReasonToHandle === "end_turn")'),
-    ).toBeLessThan(loopSource.indexOf("appendTranscriptDeltaJsonl("));
+    );
   });
 });

--- a/src/cli/app/use-conversation-loop.ts
+++ b/src/cli/app/use-conversation-loop.ts
@@ -74,7 +74,7 @@ import {
   buildQueuedUserText,
   getQueuedNotificationSummaries,
 } from "@/cli/helpers/queued-message-parts";
-import { appendTranscriptDeltaJsonl } from "@/cli/helpers/reflection-transcript";
+import { appendTranscriptDeltaJsonlForStopReason } from "@/cli/helpers/reflection-transcript";
 import { safeJsonParseOr } from "@/cli/helpers/safe-json-parse";
 import {
   type ApprovalRequest,
@@ -1536,6 +1536,29 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
           // Record the final stop reason so the dequeue gate can check it.
           lastStopReasonRef.current = stopReasonToHandle;
 
+          if (transcriptTurnStartLineIndex !== null) {
+            try {
+              const transcriptLines = toLines(buffersRef.current).slice(
+                transcriptTurnStartLineIndex,
+              );
+              await appendTranscriptDeltaJsonlForStopReason(
+                agentIdRef.current,
+                conversationIdRef.current,
+                transcriptLines,
+                stopReasonToHandle,
+              );
+            } catch (transcriptError) {
+              debugWarn(
+                "memory",
+                `Failed to append transcript delta: ${
+                  transcriptError instanceof Error
+                    ? transcriptError.message
+                    : String(transcriptError)
+                }`,
+              );
+            }
+          }
+
           // Case 1: Turn ended normally
           if (stopReasonToHandle === "end_turn") {
             clearApprovalToolContext();
@@ -1558,27 +1581,6 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
             lastSentInputRef.current = null; // Clear - no recovery needed
             pendingInterruptRecoveryConversationIdRef.current = null;
 
-            if (transcriptTurnStartLineIndex !== null) {
-              try {
-                const transcriptLines = toLines(buffersRef.current).slice(
-                  transcriptTurnStartLineIndex,
-                );
-                await appendTranscriptDeltaJsonl(
-                  agentIdRef.current,
-                  conversationIdRef.current,
-                  transcriptLines,
-                );
-              } catch (transcriptError) {
-                debugWarn(
-                  "memory",
-                  `Failed to append transcript delta: ${
-                    transcriptError instanceof Error
-                      ? transcriptError.message
-                      : String(transcriptError)
-                  }`,
-                );
-              }
-            }
             pendingTranscriptStartLineIndexRef.current = null;
 
             // Evaluate reflection triggers now that the turn's transcript

--- a/src/cli/helpers/reflection-transcript.ts
+++ b/src/cli/helpers/reflection-transcript.ts
@@ -498,6 +498,15 @@ function countAssistantRows(entries: TranscriptEntry[]): number {
   return entries.filter((entry) => entry.kind === "assistant").length;
 }
 
+function getTranscriptEntrySourceLineId(
+  entry: TranscriptEntry,
+): string | undefined {
+  return typeof entry.source_line_id === "string" &&
+    entry.source_line_id.length > 0
+    ? entry.source_line_id
+    : undefined;
+}
+
 /** Maximum characters to keep for tool-call arguments in the reflection payload. */
 const TOOL_ARGS_TRUNCATE_LIMIT = 300;
 
@@ -872,6 +881,76 @@ export function getReflectionTranscriptPaths(
   };
 }
 
+type TranscriptAppendMerge = {
+  lines: string[];
+  assistantStepDelta: number;
+  rewroteTranscript: boolean;
+};
+
+function mergeTranscriptEntriesBySourceLineId(
+  existingLines: string[],
+  entries: TranscriptEntry[],
+): TranscriptAppendMerge {
+  const latestEntryBySourceLineId = new Map<string, TranscriptEntry>();
+  for (const entry of entries) {
+    const sourceLineId = getTranscriptEntrySourceLineId(entry);
+    if (sourceLineId) {
+      latestEntryBySourceLineId.set(sourceLineId, entry);
+    }
+  }
+
+  const mergedLines: string[] = [];
+  const replacedSourceLineIds = new Set<string>();
+  let assistantStepDelta = 0;
+  let rewroteTranscript = false;
+
+  for (const existingLine of existingLines) {
+    const existingEntry = safeJsonParseOr<TranscriptEntry | null>(
+      existingLine,
+      null,
+    );
+    const sourceLineId = existingEntry
+      ? getTranscriptEntrySourceLineId(existingEntry)
+      : undefined;
+    const replacement = sourceLineId
+      ? latestEntryBySourceLineId.get(sourceLineId)
+      : undefined;
+
+    if (!replacement || !sourceLineId) {
+      mergedLines.push(existingLine);
+      continue;
+    }
+
+    rewroteTranscript = true;
+    if (!replacedSourceLineIds.has(sourceLineId)) {
+      mergedLines.push(JSON.stringify(replacement));
+      replacedSourceLineIds.add(sourceLineId);
+      assistantStepDelta +=
+        (replacement.kind === "assistant" ? 1 : 0) -
+        (existingEntry?.kind === "assistant" ? 1 : 0);
+    } else if (existingEntry?.kind === "assistant") {
+      assistantStepDelta -= 1;
+    }
+  }
+
+  for (const entry of entries) {
+    const sourceLineId = getTranscriptEntrySourceLineId(entry);
+    if (sourceLineId) {
+      if (latestEntryBySourceLineId.get(sourceLineId) !== entry) {
+        continue;
+      }
+      if (replacedSourceLineIds.has(sourceLineId)) {
+        continue;
+      }
+    }
+
+    mergedLines.push(JSON.stringify(entry));
+    assistantStepDelta += entry.kind === "assistant" ? 1 : 0;
+  }
+
+  return { lines: mergedLines, assistantStepDelta, rewroteTranscript };
+}
+
 export async function appendTranscriptDeltaJsonl(
   agentId: string,
   conversationId: string,
@@ -890,12 +969,48 @@ export async function appendTranscriptDeltaJsonl(
       return 0;
     }
 
-    const payload = entries.map((entry) => JSON.stringify(entry)).join("\n");
-    await appendFile(paths.transcriptPath, `${payload}\n`, "utf-8");
-    state.total_completed_steps += countAssistantRows(entries);
+    const existingLines = await readTranscriptLines(paths);
+    const merge = mergeTranscriptEntriesBySourceLineId(existingLines, entries);
+    if (merge.rewroteTranscript) {
+      await writeFile(
+        paths.transcriptPath,
+        `${merge.lines.join("\n")}\n`,
+        "utf-8",
+      );
+    } else {
+      const payload = entries.map((entry) => JSON.stringify(entry)).join("\n");
+      await appendFile(paths.transcriptPath, `${payload}\n`, "utf-8");
+    }
+
+    state.total_completed_steps = Math.max(
+      0,
+      state.total_completed_steps + merge.assistantStepDelta,
+    );
+    state.reflected_completed_steps = Math.min(
+      state.reflected_completed_steps,
+      state.total_completed_steps,
+    );
     await writeState(paths, state);
     return entries.length;
   });
+}
+
+export function shouldAppendTranscriptDeltaJsonlForStopReason(
+  stopReason: string | null | undefined,
+): boolean {
+  return stopReason === "end_turn" || stopReason === "requires_approval";
+}
+
+export async function appendTranscriptDeltaJsonlForStopReason(
+  agentId: string,
+  conversationId: string,
+  lines: Line[],
+  stopReason: string | null | undefined,
+): Promise<number> {
+  if (!shouldAppendTranscriptDeltaJsonlForStopReason(stopReason)) {
+    return 0;
+  }
+  return appendTranscriptDeltaJsonl(agentId, conversationId, lines);
 }
 
 /**

--- a/src/cli/reflection-transcript.test.ts
+++ b/src/cli/reflection-transcript.test.ts
@@ -10,6 +10,7 @@ import {
 } from "@/agent/subagents/context-budget";
 import {
   appendTranscriptDeltaJsonl,
+  appendTranscriptDeltaJsonlForStopReason,
   buildAutoReflectionPayload,
   buildParentMemorySnapshot,
   buildReflectionSubagentPrompt,
@@ -51,6 +52,97 @@ describe("reflectionTranscript helper", () => {
     restoreDirectoryLimitEnv();
     delete process.env.LETTA_TRANSCRIPT_ROOT;
     await rm(testRoot, { recursive: true, force: true });
+  });
+
+  test("stop-reason append records approval-ready tool calls", async () => {
+    const appended = await appendTranscriptDeltaJsonlForStopReason(
+      agentId,
+      conversationId,
+      [
+        {
+          kind: "tool_call",
+          id: "tool-call-approval",
+          toolCallId: "tool-call-approval",
+          name: "Bash",
+          argsText: '{"command":"pwd"}',
+          phase: "ready",
+        },
+      ],
+      "requires_approval",
+    );
+
+    expect(appended).toBe(1);
+
+    const paths = getReflectionTranscriptPaths(agentId, conversationId);
+    const raw = await readFile(paths.transcriptPath, "utf-8");
+    const rows = raw
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      kind: "tool_call",
+      name: "Bash",
+      argsText: '{"command":"pwd"}',
+      source_line_id: "tool-call-approval",
+    });
+
+    const skipped = await appendTranscriptDeltaJsonlForStopReason(
+      agentId,
+      conversationId,
+      [
+        {
+          kind: "assistant",
+          id: "assistant-cancelled",
+          text: "not recorded",
+          phase: "finished",
+        },
+      ],
+      "cancelled",
+    );
+    expect(skipped).toBe(0);
+  });
+
+  test("append updates matching source lines instead of duplicating them", async () => {
+    await appendTranscriptDeltaJsonl(agentId, conversationId, [
+      {
+        kind: "tool_call",
+        id: "tool-call-1",
+        toolCallId: "tool-call-1",
+        name: "Bash",
+        argsText: '{"command":"pwd"}',
+        phase: "ready",
+      },
+    ]);
+
+    await appendTranscriptDeltaJsonl(agentId, conversationId, [
+      {
+        kind: "tool_call",
+        id: "tool-call-1",
+        toolCallId: "tool-call-1",
+        name: "Bash",
+        argsText: '{"command":"pwd"}',
+        resultText: "/tmp/project",
+        resultOk: true,
+        phase: "finished",
+      },
+    ]);
+
+    const paths = getReflectionTranscriptPaths(agentId, conversationId);
+    const raw = await readFile(paths.transcriptPath, "utf-8");
+    const rows = raw
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      kind: "tool_call",
+      name: "Bash",
+      argsText: '{"command":"pwd"}',
+      resultText: "/tmp/project",
+      resultOk: true,
+      source_line_id: "tool-call-1",
+    });
   });
 
   test("auto payload advances message-id state on success", async () => {

--- a/src/headless-reminder.test.ts
+++ b/src/headless-reminder.test.ts
@@ -98,6 +98,6 @@ describe("headless shared reminder wiring", () => {
     expect(source).toContain("const userOtid = randomUUID();");
     expect(source).toContain("buffers.userLineIdByOtid.set(userOtid");
     expect(source).toContain("content: enrichedContent, otid: userOtid");
-    expect(source).toContain("appendTranscriptDeltaJsonl(");
+    expect(source).toContain("appendTranscriptDeltaJsonlForStopReason(");
   });
 });

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -90,7 +90,7 @@ import {
   AUTO_REFLECTION_DESCRIPTION,
   launchReflectionSubagent,
 } from "./cli/helpers/reflection-launcher";
-import { appendTranscriptDeltaJsonl } from "./cli/helpers/reflection-transcript";
+import { appendTranscriptDeltaJsonlForStopReason } from "./cli/helpers/reflection-transcript";
 import {
   type DrainStreamHook,
   drainStreamWithResume,
@@ -4412,9 +4412,14 @@ async function runBidirectionalMode(
             ? "error"
             : "success";
 
-        if (subtype === "success" && lastStopReason === "end_turn") {
+        if (subtype === "success") {
           try {
-            await appendTranscriptDeltaJsonl(agent.id, conversationId, lines);
+            await appendTranscriptDeltaJsonlForStopReason(
+              agent.id,
+              conversationId,
+              lines,
+              lastStopReason,
+            );
           } catch (transcriptError) {
             debugWarn(
               "memory",
@@ -4425,6 +4430,9 @@ async function runBidirectionalMode(
               }`,
             );
           }
+        }
+
+        if (subtype === "success" && lastStopReason === "end_turn") {
           try {
             await maybeLaunchPostTurnReflection({
               agentId: agent.id,

--- a/src/websocket/listener/turn-reflection.test.ts
+++ b/src/websocket/listener/turn-reflection.test.ts
@@ -33,18 +33,12 @@ describe("post-turn listener reflection", () => {
   test("records listener transcript rows before evaluating post-turn reflection", () => {
     const turnPath = fileURLToPath(new URL("./turn.ts", import.meta.url));
     const source = readFileSync(turnPath, "utf-8");
-    const endTurnIndex = source.indexOf('if (stopReason === "end_turn")');
     const appendIndex = source.indexOf(
-      "appendTranscriptDeltaJsonl(",
-      endTurnIndex,
+      "appendTranscriptDeltaJsonlForStopReason(",
     );
-    const launchIndex = source.indexOf(
-      "maybeLaunchPostTurnReflection({",
-      endTurnIndex,
-    );
+    const launchIndex = source.indexOf("maybeLaunchPostTurnReflection({");
 
-    expect(endTurnIndex).toBeGreaterThanOrEqual(0);
-    expect(appendIndex).toBeGreaterThan(endTurnIndex);
+    expect(appendIndex).toBeGreaterThanOrEqual(0);
     expect(launchIndex).toBeGreaterThan(appendIndex);
   });
 

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -45,7 +45,7 @@ import {
   AUTO_REFLECTION_DESCRIPTION,
   launchReflectionSubagent,
 } from "@/cli/helpers/reflection-launcher";
-import { appendTranscriptDeltaJsonl } from "@/cli/helpers/reflection-transcript";
+import { appendTranscriptDeltaJsonlForStopReason } from "@/cli/helpers/reflection-transcript";
 import { drainStreamWithResume } from "@/cli/helpers/stream";
 import {
   buildSharedReminderParts,
@@ -716,26 +716,28 @@ export async function handleIncomingMessage(
         break;
       }
 
-      if (stopReason === "end_turn") {
-        try {
-          const transcriptLines = toLines(buffers);
-          if (transcriptLines.length > 0) {
-            await appendTranscriptDeltaJsonl(
-              agentId || "",
-              conversationId,
-              transcriptLines,
-            );
-          }
-        } catch (transcriptError) {
-          debugWarn(
-            "memory",
-            `Failed to append transcript delta: ${
-              transcriptError instanceof Error
-                ? transcriptError.message
-                : String(transcriptError)
-            }`,
+      try {
+        const transcriptLines = toLines(buffers);
+        if (transcriptLines.length > 0) {
+          await appendTranscriptDeltaJsonlForStopReason(
+            agentId || "",
+            conversationId,
+            transcriptLines,
+            stopReason,
           );
         }
+      } catch (transcriptError) {
+        debugWarn(
+          "memory",
+          `Failed to append transcript delta: ${
+            transcriptError instanceof Error
+              ? transcriptError.message
+              : String(transcriptError)
+          }`,
+        );
+      }
+
+      if (stopReason === "end_turn") {
         try {
           const reflectionSettings = getReflectionSettings(
             agentId || undefined,


### PR DESCRIPTION
## Summary

Fixes LET-9191 by writing local reflection transcript rows when a turn pauses for tool approval.

Before this, transcript deltas were appended only for normal end_turn completions. If a stream emitted approval_request_message/tool-call rows and then the stop reason was coerced to requires_approval, those approval-ready tool calls stayed visible in the live chunks/API but never reached transcript.jsonl.

## Approach

- Route transcript appends through a stop-reason-aware helper that records both end_turn and requires_approval turns.
- Keep reflection launch itself gated on normal end_turn completions.
- Merge transcript rows by source line id so the later approved tool result updates the earlier approval-ready tool-call row instead of duplicating it.

## Validation

- bun test src/cli/reflection-transcript.test.ts src/cli/app/reflection-transcript-wiring.test.ts src/websocket/listener/turn-reflection.test.ts src/headless-reminder.test.ts
- bunx --bun @biomejs/biome@2.2.5 check src/cli/helpers/reflection-transcript.ts src/cli/reflection-transcript.test.ts src/cli/app/use-conversation-loop.ts src/cli/app/reflection-transcript-wiring.test.ts src/headless.ts src/headless-reminder.test.ts src/websocket/listener/turn.ts src/websocket/listener/turn-reflection.test.ts
- pre-commit hook ran layer-boundary/export/filename checks, Biome write, and tsc --noEmit

## Linear

LET-9191
