### PR TITLE
fix(local-backend): support OpenAI-compatible local provider models

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@letta-ai/letta-code",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.79.1",
+        "@earendil-works/pi-ai": "^0.79.4",
         "@letta-ai/letta-client": "^1.10.2",
         "@pierre/diffs": "1.2.2",
         "glob": "^13.0.0",
@@ -111,7 +111,7 @@
 
     "@discoveryjs/json-ext": ["@discoveryjs/json-ext@1.1.0", "", {}, "sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.79.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-UnORwrcsTNLm4StEvoM8iEom0u87Te7BXEWxhec3iNXygWD6eEBosUoq9ddcveqtj/QpUZBMPWUu81cCtZxzkQ=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.79.4", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-Z1j+YP+6ZyPBKDUoc5m0GO/o1hPK17fWeErtDgegCTpm2dcKzuFvL/7GTqHeJkVkfpeXRwO37xOfgozQbK6EUw=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "^0.79.1",
+    "@earendil-works/pi-ai": "^0.79.4",
     "@letta-ai/letta-client": "^1.10.2",
     "@pierre/diffs": "1.2.2",
     "glob": "^13.0.0",

--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -357,6 +357,16 @@ function customOpenAICompatibleModel(input: {
   };
 }
 
+function withDeepSeekChatCompletions(model: Model<Api>): Model<Api> {
+  if (model.provider !== "deepseek" || model.api !== "openai-responses") {
+    return model;
+  }
+  return {
+    ...model,
+    api: "openai-completions",
+  } as Model<Api>;
+}
+
 function withOverrides(
   model: Model<Api>,
   overrides: {
@@ -638,19 +648,6 @@ export async function resolvePiModelForAgent(
       `Unknown model "${modelId}" for provider "${provider}". ` +
         "Register the provider with models before using it.",
     );
-  } else if (spec.createCustomModel) {
-    if (!modelId) {
-      throw new Error(
-        `No model selected for provider "${provider}". Choose an available model with /model.`,
-      );
-    }
-    model = customOpenAICompatibleModel({
-      provider: spec.id,
-      modelId,
-      baseURL: normalizedBaseURL ?? spec.defaultBaseURL ?? "",
-      contextWindow,
-      maxTokens,
-    });
   } else {
     const catalogModel = getCatalogModel(spec.id, modelId, oauthCredentials);
     if (catalogModel) {
@@ -665,24 +662,38 @@ export async function resolvePiModelForAgent(
         spec.piProvider ?? "openai",
         modelId as never,
       ) as Model<Api> | undefined;
-      if (!fallback) {
+      if (fallback) {
+        model = withOverrides(fallback, {
+          baseURL,
+          headers,
+          contextWindow,
+          maxTokens,
+        });
+      } else if (spec.createCustomModel) {
+        if (!modelId) {
+          throw new Error(
+            `No model selected for provider "${provider}". Choose an available model with /model.`,
+          );
+        }
+        model = customOpenAICompatibleModel({
+          provider: spec.id,
+          modelId,
+          baseURL: normalizedBaseURL ?? spec.defaultBaseURL ?? "",
+          contextWindow,
+          maxTokens,
+        });
+      } else {
         throw new Error(
           `Unknown model "${modelId}" for provider "${provider}". ` +
             "Check the model handle or update the model catalog.",
         );
       }
-      model = withOverrides(fallback, {
-        baseURL,
-        headers,
-        contextWindow,
-        maxTokens,
-      });
     }
   }
 
   return {
     provider,
-    model,
+    model: withDeepSeekChatCompletions(model),
     apiKey: connection.apiKey,
     timeout: connection.timeout,
     headers,

--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -136,6 +136,7 @@ const PI_PROVIDER_OVERRIDES: Partial<
     providerTypes: ["openai", "openai-responses"],
     handlePrefixes: ["openai/", "openai-responses/"],
     localProviderNames: ["openai", LOCAL_OPENAI_PROVIDER_NAME],
+    createCustomModel: true,
   },
   anthropic: {
     localProviderNames: ["anthropic", LOCAL_ANTHROPIC_PROVIDER_NAME],

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -563,6 +563,43 @@ describe("pi model factory", () => {
     }
   });
 
+  test("accepts arbitrary local OpenAI-compatible proxy model handles", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "pi-openai-proxy-model-"));
+    try {
+      await createOrUpdateLocalProvider({
+        storageDir,
+        providerType: "openai",
+        providerName: "lc-openai",
+        apiKey: "proxy-key",
+        baseURL: "https://api.featherless.ai/v1",
+      });
+
+      const resolved = await resolvePiModelForAgent(
+        "openai/accounts/fireworks/models/qwen3-235b-a22b",
+        { provider_type: "openai" },
+        { localProviderAuthStorageDir: storageDir },
+      );
+
+      expect(resolved.apiKey).toBe("proxy-key");
+      expect(resolved.model).toMatchObject({
+        id: "accounts/fireworks/models/qwen3-235b-a22b",
+        api: "openai-completions",
+        provider: "openai",
+        baseUrl: "https://api.featherless.ai/v1",
+      });
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("uses chat completions for DeepSeek built-in models", async () => {
+    const resolved = await resolvePiModelForAgent("deepseek/deepseek-v4-pro", {
+      provider_type: "deepseek",
+    });
+
+    expect(resolved.model.api).toBe("openai-completions");
+  });
+
   test("does not let local no-key placeholders mask LM Studio env API keys", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "pi-lmstudio-env-key-"));
     try {

--- a/src/cli/subcommands/router.test.ts
+++ b/src/cli/subcommands/router.test.ts
@@ -3,6 +3,7 @@ import {
   runSubcommand,
   subcommandNeedsEarlyBackendMode,
 } from "@/cli/subcommands/router";
+import { disposeProviderOnlyModsForProcess } from "@/mods/provider-mod-adapter";
 
 describe("subcommand router", () => {
   test("routes version subcommand before TUI startup", async () => {
@@ -24,8 +25,19 @@ describe("subcommand router", () => {
   });
 
   test("routes connect subcommand", async () => {
-    const exitCode = await runSubcommand(["connect", "help"]);
-    expect(exitCode).toBe(0);
+    const originalDisableMods = process.env.LETTA_DISABLE_MODS;
+    process.env.LETTA_DISABLE_MODS = "1";
+    try {
+      const exitCode = await runSubcommand(["connect", "help"]);
+      expect(exitCode).toBe(0);
+    } finally {
+      disposeProviderOnlyModsForProcess();
+      if (originalDisableMods === undefined) {
+        delete process.env.LETTA_DISABLE_MODS;
+      } else {
+        process.env.LETTA_DISABLE_MODS = originalDisableMods;
+      }
+    }
   });
 
   test("routes app-server help without starting the server", async () => {

--- a/src/cli/subcommands/router.ts
+++ b/src/cli/subcommands/router.ts
@@ -69,8 +69,18 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
     case "server":
     case "remote": // alias
       return runListenSubcommand(rest);
-    case "connect":
+    case "connect": {
+      const { isExperimentalLocalBackendEnabled } = await import(
+        "@/backend/backend"
+      );
+      if (isExperimentalLocalBackendEnabled()) {
+        const { ensureProviderOnlyModsLoadedForProcess } = await import(
+          "@/mods/provider-mod-adapter"
+        );
+        await ensureProviderOnlyModsLoadedForProcess();
+      }
       return runConnectSubcommand(rest);
+    }
     case "backend":
       return runBackendSubcommand(rest);
     case "setup":

--- a/src/index.ts
+++ b/src/index.ts
@@ -991,6 +991,24 @@ async function main(): Promise<void> {
     }
   }
 
+  if (!modsDisabled && isExperimentalLocalBackendEnabled()) {
+    try {
+      const { ensureProviderOnlyModsLoadedForProcess } = await import(
+        "@/mods/provider-mod-adapter"
+      );
+      await ensureProviderOnlyModsLoadedForProcess();
+      // configureBackendMode eagerly creates LocalBackend, so rebuild it now
+      // that provider mods are registered and visible to local model startup.
+      configureBackendMode("local");
+    } catch (error) {
+      debugWarn(
+        "mods",
+        "failed to load provider mods before local backend startup: %s",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
   const startupTargetLookupOrder = getStartupTargetLookupOrderForCredentials({
     baseURL,
     explicitBackendMode,

--- a/src/mods/provider-mod-adapter.test.ts
+++ b/src/mods/provider-mod-adapter.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  clearRegisteredPiProviders,
+  getRegisteredPiProvider,
+} from "@/backend/dev/pi-provider-mod-registry";
+import { resolveLocalProvider } from "@/backend/local/local-model-config";
+import { createOrUpdateLocalProvider } from "@/backend/local/local-provider-auth-store";
+import { listConnectProvidersForHelp } from "@/cli/commands/connect-normalize";
+import {
+  disposeProviderOnlyModsForProcess,
+  ensureProviderOnlyModsLoadedForProcess,
+} from "@/mods/provider-mod-adapter";
+
+const tempRoots: string[] = [];
+
+function createTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "letta-provider-mod-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  disposeProviderOnlyModsForProcess();
+  clearRegisteredPiProviders();
+  for (const dir of tempRoots.splice(0)) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe("provider-only mod adapter", () => {
+  test("loads process-wide provider registrations", async () => {
+    const root = createTempDir();
+    const modsDir = join(root, "mods");
+    const cacheDir = join(root, "cache");
+    mkdirSync(modsDir, { recursive: true });
+    writeFileSync(
+      join(modsDir, "featherless.ts"),
+      `export default function activate(letta) {
+        letta.providers.register("featherless", {
+          name: "Featherless",
+          description: "Connect Featherless",
+          api: "openai-completions",
+          baseUrl: "https://api.featherless.ai/v1",
+          apiKey: "FEATHERLESS_API_KEY",
+          models: [{
+            id: "qwen3-235b-a22b",
+            name: "Qwen3 235B A22B",
+            reasoning: true,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 128000,
+            maxTokens: 8192,
+          }],
+        });
+      }`,
+    );
+
+    await ensureProviderOnlyModsLoadedForProcess({
+      cacheDirectory: cacheDir,
+      globalModsDirectory: modsDir,
+      workingDirectory: root,
+    });
+
+    expect(getRegisteredPiProvider("featherless")?.config).toMatchObject({
+      name: "Featherless",
+      baseUrl: "https://api.featherless.ai/v1",
+      models: [{ id: "qwen3-235b-a22b" }],
+    });
+    expect(listConnectProvidersForHelp("local")).toContain("featherless");
+
+    await createOrUpdateLocalProvider({
+      storageDir: root,
+      providerType: "featherless",
+      providerName: "featherless",
+      apiKey: "fake-key",
+    });
+    expect(String(resolveLocalProvider(root))).toBe("featherless");
+
+    disposeProviderOnlyModsForProcess();
+    expect(getRegisteredPiProvider("featherless")).toBeUndefined();
+  });
+});

--- a/src/mods/provider-mod-adapter.ts
+++ b/src/mods/provider-mod-adapter.ts
@@ -1,0 +1,140 @@
+import type { Backend } from "@/backend";
+import { createModAdapter, type ModAdapter } from "@/mods/mod-adapter";
+import type { ModCapabilities, ModContext } from "@/mods/types";
+import { getCurrentWorkingDirectory } from "@/runtime-context";
+import { getVersion } from "@/version";
+
+export const PROVIDER_ONLY_MOD_CAPABILITIES: ModCapabilities = {
+  tools: false,
+  commands: false,
+  events: {
+    lifecycle: false,
+    tools: false,
+    turns: false,
+  },
+  permissions: false,
+  providers: true,
+  ui: {
+    panels: false,
+    statusValues: false,
+    customStatuslineRenderer: false,
+  },
+};
+
+export interface CreateProviderOnlyModAdapterOptions {
+  cacheDirectory?: string;
+  diagnosticsRootDirectory?: string;
+  disabled?: boolean;
+  getBackend?: () => Backend | undefined;
+  globalModsDirectory?: string;
+  sessionId?: string | null;
+  workingDirectory?: string | null;
+}
+
+async function getUnavailableProviderOnlyClient(): Promise<never> {
+  throw new Error("letta.client is not available in provider-only mods");
+}
+
+export function createProviderOnlyModContext(
+  options: Pick<
+    CreateProviderOnlyModAdapterOptions,
+    "sessionId" | "workingDirectory"
+  > = {},
+): ModContext {
+  const cwd = options.workingDirectory ?? getCurrentWorkingDirectory();
+  return {
+    app: { version: getVersion() },
+    workspace: {
+      cwd,
+      currentDir: cwd,
+      projectDir: cwd,
+    },
+    cwd,
+    sessionId: options.sessionId ?? null,
+    lastRunId: null,
+    agent: {
+      id: null,
+      name: null,
+    },
+    model: {
+      id: null,
+      displayName: null,
+      provider: null,
+      reasoningEffort: null,
+    },
+    toolset: null,
+    systemPromptId: null,
+    permissionMode: null,
+    networkPhase: null,
+    terminalWidth: process.stdout.columns ?? null,
+    contextWindow: {
+      size: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      usedPercentage: null,
+      remainingPercentage: null,
+      currentUsage: null,
+    },
+    cost: {
+      totalDurationMs: 0,
+      totalApiDurationMs: 0,
+      totalCostUsd: null,
+      totalLinesAdded: null,
+      totalLinesRemoved: null,
+    },
+    reflection: {
+      mode: null,
+      stepCount: 0,
+    },
+    memfs: {
+      enabled: false,
+      memoryDir: null,
+    },
+    backgroundAgents: [],
+  };
+}
+
+export function createProviderOnlyModAdapter(
+  options: CreateProviderOnlyModAdapterOptions = {},
+): ModAdapter {
+  return createModAdapter({
+    ...(options.cacheDirectory
+      ? { cacheDirectory: options.cacheDirectory }
+      : {}),
+    capabilities: PROVIDER_ONLY_MOD_CAPABILITIES,
+    ...(options.diagnosticsRootDirectory
+      ? { diagnosticsRootDirectory: options.diagnosticsRootDirectory }
+      : {}),
+    disabled: options.disabled,
+    getBackend: options.getBackend,
+    getClient: getUnavailableProviderOnlyClient,
+    ...(options.globalModsDirectory
+      ? { globalModsDirectory: options.globalModsDirectory }
+      : {}),
+    initialContext: createProviderOnlyModContext(options),
+  });
+}
+
+let processProviderOnlyModAdapter: ModAdapter | null = null;
+let processProviderOnlyModReload: Promise<void> | null = null;
+
+export async function ensureProviderOnlyModsLoadedForProcess(
+  options: CreateProviderOnlyModAdapterOptions = {},
+): Promise<void> {
+  processProviderOnlyModAdapter ??= createProviderOnlyModAdapter(options);
+  processProviderOnlyModAdapter.updateContext(
+    createProviderOnlyModContext(options),
+  );
+  processProviderOnlyModReload ??= processProviderOnlyModAdapter
+    .reload()
+    .finally(() => {
+      processProviderOnlyModReload = null;
+    });
+  await processProviderOnlyModReload;
+}
+
+export function disposeProviderOnlyModsForProcess(): void {
+  processProviderOnlyModAdapter?.dispose();
+  processProviderOnlyModAdapter = null;
+  processProviderOnlyModReload = null;
+}

--- a/src/websocket/listener/mod-adapter.ts
+++ b/src/websocket/listener/mod-adapter.ts
@@ -1,27 +1,14 @@
-import type Letta from "@letta-ai/letta-client";
 import { getBackend } from "@/backend";
-import { createModAdapter, type ModAdapter } from "@/mods/mod-adapter";
-import type { ModCapabilities, ModContext } from "@/mods/types";
-import { getCurrentWorkingDirectory } from "@/runtime-context";
-import { getVersion } from "@/version";
+import type { ModAdapter } from "@/mods/mod-adapter";
+import {
+  createProviderOnlyModAdapter,
+  createProviderOnlyModContext,
+  PROVIDER_ONLY_MOD_CAPABILITIES,
+} from "@/mods/provider-mod-adapter";
+import type { ModContext } from "@/mods/types";
 import type { ListenerRuntime } from "./types";
 
-export const LISTENER_MOD_CAPABILITIES: ModCapabilities = {
-  tools: false,
-  commands: false,
-  events: {
-    lifecycle: false,
-    tools: false,
-    turns: false,
-  },
-  permissions: false,
-  providers: true,
-  ui: {
-    panels: false,
-    statusValues: false,
-    customStatuslineRenderer: false,
-  },
-};
+export const LISTENER_MOD_CAPABILITIES = PROVIDER_ONLY_MOD_CAPABILITIES;
 
 export interface CreateListenerModAdapterOptions {
   cacheDirectory?: string;
@@ -32,87 +19,21 @@ export interface CreateListenerModAdapterOptions {
   workingDirectory?: string | null;
 }
 
-async function getUnavailableListenerClient(): Promise<Letta> {
-  throw new Error("letta.client is not available in listener provider mods");
-}
-
 export function createListenerModContext(
   options: Pick<
     CreateListenerModAdapterOptions,
     "sessionId" | "workingDirectory"
   > = {},
 ): ModContext {
-  const cwd = options.workingDirectory ?? getCurrentWorkingDirectory();
-  return {
-    app: { version: getVersion() },
-    workspace: {
-      cwd,
-      currentDir: cwd,
-      projectDir: cwd,
-    },
-    cwd,
-    sessionId: options.sessionId ?? null,
-    lastRunId: null,
-    agent: {
-      id: null,
-      name: null,
-    },
-    model: {
-      id: null,
-      displayName: null,
-      provider: null,
-      reasoningEffort: null,
-    },
-    toolset: null,
-    systemPromptId: null,
-    permissionMode: null,
-    networkPhase: null,
-    terminalWidth: process.stdout.columns ?? null,
-    contextWindow: {
-      size: 0,
-      totalInputTokens: 0,
-      totalOutputTokens: 0,
-      usedPercentage: null,
-      remainingPercentage: null,
-      currentUsage: null,
-    },
-    cost: {
-      totalDurationMs: 0,
-      totalApiDurationMs: 0,
-      totalCostUsd: null,
-      totalLinesAdded: null,
-      totalLinesRemoved: null,
-    },
-    reflection: {
-      mode: null,
-      stepCount: 0,
-    },
-    memfs: {
-      enabled: false,
-      memoryDir: null,
-    },
-    backgroundAgents: [],
-  };
+  return createProviderOnlyModContext(options);
 }
 
 export function createListenerModAdapter(
   options: CreateListenerModAdapterOptions = {},
 ): ModAdapter {
-  return createModAdapter({
-    ...(options.cacheDirectory
-      ? { cacheDirectory: options.cacheDirectory }
-      : {}),
-    capabilities: LISTENER_MOD_CAPABILITIES,
-    ...(options.diagnosticsRootDirectory
-      ? { diagnosticsRootDirectory: options.diagnosticsRootDirectory }
-      : {}),
-    disabled: options.disabled,
+  return createProviderOnlyModAdapter({
+    ...options,
     getBackend,
-    getClient: getUnavailableListenerClient,
-    ...(options.globalModsDirectory
-      ? { globalModsDirectory: options.globalModsDirectory }
-      : {}),
-    initialContext: createListenerModContext(options),
   });
 }
 


### PR DESCRIPTION
## Summary
- Allow OpenAI-compatible local providers to use arbitrary model IDs after catalog and alias lookup, covering proxy providers with model handles outside the Pi catalog.
- Normalize DeepSeek built-in models to chat completions and bump `@earendil-works/pi-ai` to 0.79.4 for current provider/catalog metadata.
- Extract provider-only mod loading so local connect/startup/listener paths can register provider mods without exposing broader mod capabilities.

## Test plan
- [x] `bun run check`
- [x] `bun test src/backend/pi-model-factory.test.ts src/mods/provider-mod-adapter.test.ts src/websocket/listener/mod-adapter.test.ts src/cli/subcommands/router.test.ts`

👾 Generated with [Letta Code](https://letta.com)