### PR TITLE
fix(channels): keep MessageChannel for scoped no-tool turns

### DIFF
--- a/src/tools/tool-execution-context.test.ts
+++ b/src/tools/tool-execution-context.test.ts
@@ -54,6 +54,7 @@ import {
   registerExternalTools,
 } from "@/tools/manager";
 import {
+  prepareToolExecutionContextForResolvedTarget,
   prepareToolExecutionContextForScope,
   resolveConversationChannelToolScope,
 } from "@/tools/toolset";
@@ -959,6 +960,25 @@ describe("tool execution context snapshot", () => {
     );
 
     expect(prepared.loadedToolNames).toContain("MessageChannel");
+  });
+
+  test("keeps scoped MessageChannel available for pinned none toolsets", async () => {
+    await loadSpecificTools(["Read"]);
+
+    const prepared = await prepareToolExecutionContextForResolvedTarget({
+      modelIdentifier: "anthropic/claude-opus-4-1-20250805",
+      toolsetPreference: "none",
+      channelToolScope: {
+        channels: [{ channelId: "discord", accountId: "acct-discord" }],
+      },
+    });
+
+    expect(prepared.preparedToolContext.loadedToolNames).toEqual([
+      "MessageChannel",
+    ]);
+    expect(
+      prepared.preparedToolContext.clientTools.map((tool) => tool.name),
+    ).toEqual(["MessageChannel"]);
   });
 
   test("hydrates inherited channel scope from serialized child env", async () => {

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -121,7 +121,8 @@ function getToolNamesForToolset(
       tools = [...GEMINI_DEFAULT_TOOLS];
       break;
     case "none":
-      return [];
+      tools = [];
+      break;
     default:
       tools = [...ANTHROPIC_DEFAULT_TOOLS];
       break;


### PR DESCRIPTION
## Summary

Fixes LET-9190.

Cron/channel turns that are scoped to an existing channel route still need `MessageChannel` as their delivery path. The manual `none` toolset was returning before the scoped channel tool could be appended, leaving the request with no client tools and making channel sends fail.

This changes `none` to build an empty client-tool list and then run through the existing scoped-channel append logic. It does not add any other tools.

## Validation

- `bun test src/tools/tool-execution-context.test.ts -t MessageChannel`
- `bun test src/tools/tool-execution-context.test.ts -t "pinned none"`
- `bun run tsc --noEmit`
- pre-commit hooks: layer boundary/export/filename checks, Biome on staged files, `tsc --noEmit`

Note: the full `src/tools/tool-execution-context.test.ts` file still has two unrelated existing failures around `Read` resolving `README.md` in this local worktree context; the MessageChannel-targeted subset passes.
