### PR TITLE
fix: fall back when keychain blocks server secrets

### DIFF
--- a/src/agent/client-soft-fail.test.ts
+++ b/src/agent/client-soft-fail.test.ts
@@ -43,6 +43,8 @@ async function runIsolatedClientScript(
     HOME: homeDir,
     USERPROFILE: homeDir,
     LETTA_CODE_AGENT_ROLE: "subagent",
+    // This test mocks secure-token reads; do not let startup probe the real macOS keychain.
+    LETTA_SKIP_KEYCHAIN_CHECK: "1",
   };
   delete env.LETTA_API_KEY;
   delete env.LETTA_BASE_URL;

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -22,6 +22,7 @@ import {
   deleteSecureTokens,
   getSecureTokens,
   isKeychainAvailable,
+  isKeychainInteractionNotAllowed,
   type SecureTokens,
   setSecureTokens,
 } from "./utils/secrets.js";
@@ -579,8 +580,17 @@ class SettingsManager {
 
             debugWarn("settings", "Successfully migrated tokens to secrets");
           } catch (error) {
-            console.warn("Failed to migrate tokens to secrets:", error);
-            console.warn("Tokens will remain in settings file for persistence");
+            if (isKeychainInteractionNotAllowed(error)) {
+              debugWarn(
+                "settings",
+                `Secrets unavailable for this process - tokens will remain in settings file for persistence: ${error}`,
+              );
+            } else {
+              console.warn("Failed to migrate tokens to secrets:", error);
+              console.warn(
+                "Tokens will remain in settings file for persistence",
+              );
+            }
           }
         } else {
           debugWarn(
@@ -590,6 +600,13 @@ class SettingsManager {
         }
       }
     } catch (error) {
+      if (isKeychainInteractionNotAllowed(error)) {
+        debugWarn(
+          "settings",
+          `Secrets unavailable for this process - skipping token migration: ${error}`,
+        );
+        return;
+      }
       console.warn("Failed to migrate tokens to secrets:", error);
       // Don't throw - app should still work with tokens in settings file
     }

--- a/src/test-utils/test-process-env.test.ts
+++ b/src/test-utils/test-process-env.test.ts
@@ -43,6 +43,7 @@ describe("test process env helpers", () => {
     expect(env.LETTA_MEMORY_DIR).toBeUndefined();
     expect(env.MEMORY_DIR).toBeUndefined();
     expect(env.LETTA_DISABLE_SESSION_PERSIST).toBe("1");
+    expect(env.LETTA_SKIP_KEYCHAIN_CHECK).toBe("1");
     expect(env.DISABLE_AUTOUPDATER).toBe("1");
   });
 

--- a/src/test-utils/test-process-env.ts
+++ b/src/test-utils/test-process-env.ts
@@ -9,6 +9,9 @@ export function createIsolatedCliTestEnv(
 
   Object.assign(env, {
     LETTA_DISABLE_SESSION_PERSIST: "1",
+    // Isolated CLI tests use temporary HOME directories; probing the macOS
+    // keychain there can block on system UI instead of exercising the test.
+    LETTA_SKIP_KEYCHAIN_CHECK: "1",
     DISABLE_AUTOUPDATER: "1",
   });
 

--- a/src/utils/secrets.test.ts
+++ b/src/utils/secrets.test.ts
@@ -12,6 +12,7 @@ import {
   getRefreshToken,
   getSecureTokens,
   isKeychainAvailable,
+  isKeychainInteractionNotAllowed,
   type SecureTokens,
   setApiKey,
   setRefreshToken,
@@ -44,6 +45,22 @@ describe("Secrets utilities", () => {
   test("isKeychainAvailable works", async () => {
     const available = await isKeychainAvailable();
     expect(typeof available).toBe("boolean");
+  });
+
+  test("detects non-interactive macOS keychain errors", () => {
+    expect(
+      isKeychainInteractionNotAllowed(
+        new Error("User interaction is not allowed. (code: -25308)"),
+      ),
+    ).toBe(true);
+    expect(
+      isKeychainInteractionNotAllowed(
+        new Error('code: "ERR_SECRETS_INTERACTION_NOT_ALLOWED"'),
+      ),
+    ).toBe(true);
+    expect(isKeychainInteractionNotAllowed(new Error("other failure"))).toBe(
+      false,
+    );
   });
 
   test.skipIf(!keychainAvailablePrecompute)(
@@ -220,6 +237,21 @@ describe("Secrets utilities", () => {
     expect(String(warn.mock.calls[0]?.[0])).toContain(
       "Failed to retrieve API key from secrets",
     );
+  });
+
+  test("non-interactive keychain read failures use debug fallback without warning", async () => {
+    console.warn = mock(() => {});
+
+    const warn = console.warn as ReturnType<typeof mock>;
+
+    __setSecretGetOverrideForTests(async () => {
+      throw new Error("User interaction is not allowed. (code: -25308)");
+    });
+
+    expect(await getApiKey()).toBe(null);
+    expect(await getApiKey()).toBe(null);
+    expect(warn).not.toHaveBeenCalled();
+    expect(await isKeychainAvailable()).toBe(false);
   });
 
   test("warns once per token type when both reads fail", async () => {

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -19,8 +19,10 @@ try {
 let SERVICE_NAME = "letta-code";
 const API_KEY_NAME = "letta-api-key";
 const REFRESH_TOKEN_NAME = "letta-refresh-token";
+const AVAILABILITY_PROBE_NAME = "__availability_probe__";
 
 const warnedSecretReadFailures = new Set<string>();
+let keychainUnavailableForProcess = false;
 let secretGetOverrideForTests:
   | ((options: { service: string; name: string }) => Promise<string | null>)
   | null = null;
@@ -35,6 +37,22 @@ function isDuplicateKeychainItemError(error: unknown): boolean {
     message.includes("already exists in the keychain") ||
     message.includes("code: -25299")
   );
+}
+
+export function isKeychainInteractionNotAllowed(error: unknown): boolean {
+  const message = getErrorMessage(error);
+  return (
+    message.includes("User interaction is not allowed") ||
+    message.includes("ERR_SECRETS_INTERACTION_NOT_ALLOWED") ||
+    message.includes("code: -25308") ||
+    message.includes("-25308")
+  );
+}
+
+function markKeychainUnavailableForProcess(error: unknown): void {
+  if (isKeychainInteractionNotAllowed(error)) {
+    keychainUnavailableForProcess = true;
+  }
 }
 
 export async function getSecretValue(
@@ -56,7 +74,12 @@ export async function getSecretValue(
     warnedSecretReadFailures.delete(name);
     return value;
   } catch (error) {
+    markKeychainUnavailableForProcess(error);
     const message = `Failed to retrieve ${label} from secrets: ${error}`;
+    if (isKeychainInteractionNotAllowed(error)) {
+      debugWarn("secrets", message);
+      return null;
+    }
     if (!warnedSecretReadFailures.has(name)) {
       warnedSecretReadFailures.add(name);
       console.warn(message);
@@ -71,7 +94,7 @@ export async function setSecretValue(
   name: string,
   value: string,
 ): Promise<void> {
-  if (!secretsAvailable) {
+  if (!secretsAvailable || keychainUnavailableForProcess) {
     throw new Error("Secrets API unavailable");
   }
 
@@ -83,6 +106,7 @@ export async function setSecretValue(
     });
     return;
   } catch (error) {
+    markKeychainUnavailableForProcess(error);
     if (!isDuplicateKeychainItemError(error)) {
       throw error;
     }
@@ -106,7 +130,7 @@ export async function setSecretValue(
 }
 
 export async function deleteSecretValue(name: string): Promise<boolean> {
-  if (!secretsAvailable) {
+  if (!secretsAvailable || keychainUnavailableForProcess) {
     return false;
   }
 
@@ -116,6 +140,11 @@ export async function deleteSecretValue(name: string): Promise<boolean> {
       name,
     });
   } catch (error) {
+    markKeychainUnavailableForProcess(error);
+    if (isKeychainInteractionNotAllowed(error)) {
+      debugWarn("secrets", `Failed to delete secret ${name}: ${error}`);
+      return false;
+    }
     console.warn(`Failed to delete secret ${name}: ${error}`);
     return false;
   }
@@ -141,7 +170,7 @@ export interface SecureTokens {
  * Store API key in system secrets
  */
 export async function setApiKey(apiKey: string): Promise<void> {
-  if (!secretsAvailable) {
+  if (!secretsAvailable || keychainUnavailableForProcess) {
     // When secrets unavailable, let the settings manager handle fallback
     throw new Error("Secrets API unavailable");
   }
@@ -160,7 +189,7 @@ export async function getApiKey(): Promise<string | null> {
  * Store refresh token in system secrets
  */
 export async function setRefreshToken(refreshToken: string): Promise<void> {
-  if (!secretsAvailable) {
+  if (!secretsAvailable || keychainUnavailableForProcess) {
     // When secrets unavailable, let the settings manager handle fallback
     throw new Error("Secrets API unavailable");
   }
@@ -217,7 +246,7 @@ export async function setSecureTokens(tokens: SecureTokens): Promise<void> {
  * Remove API key from system secrets
  */
 export async function deleteApiKey(): Promise<void> {
-  if (secretsAvailable) {
+  if (secretsAvailable && !keychainUnavailableForProcess) {
     try {
       await secrets.delete({
         service: SERVICE_NAME,
@@ -237,7 +266,7 @@ export async function deleteApiKey(): Promise<void> {
  * Remove refresh token from system secrets
  */
 export async function deleteRefreshToken(): Promise<void> {
-  if (secretsAvailable) {
+  if (secretsAvailable && !keychainUnavailableForProcess) {
     try {
       await secrets.delete({
         service: SERVICE_NAME,
@@ -283,20 +312,47 @@ export async function isKeychainAvailable(): Promise<boolean> {
     return false;
   }
 
+  if (keychainUnavailableForProcess) {
+    return false;
+  }
+
   try {
-    // Non-mutating probe: if this call succeeds (even with null), keychain is usable.
+    // Read probe: if this call succeeds (even with null), keychain reads work.
     await secrets.get({
       service: SERVICE_NAME,
       name: API_KEY_NAME,
     });
+  } catch (error) {
+    markKeychainUnavailableForProcess(error);
+    return false;
+  }
+
+  const probeName = `${AVAILABILITY_PROBE_NAME}:${process.pid}`;
+  try {
+    // Write probe: macOS can allow reads while rejecting writes from
+    // non-interactive server shells with errSecInteractionNotAllowed (-25308).
+    // Treat that as secure storage unavailable so callers use file/env fallback
+    // instead of attempting token or channel credential migration and failing
+    // during startup.
+    await secrets.set({
+      service: SERVICE_NAME,
+      name: probeName,
+      value: "1",
+    });
+    await secrets.delete({
+      service: SERVICE_NAME,
+      name: probeName,
+    });
     return true;
-  } catch {
+  } catch (error) {
+    markKeychainUnavailableForProcess(error);
     return false;
   }
 }
 
 export function __resetSecretWarningStateForTests(): void {
   warnedSecretReadFailures.clear();
+  keychainUnavailableForProcess = false;
 }
 
 export function __setSecretGetOverrideForTests(


### PR DESCRIPTION
## Summary
- detect macOS/Bun keychain interaction failures (`-25308` / `ERR_SECRETS_INTERACTION_NOT_ALLOWED`) and mark OS secure storage unavailable for the process
- add a write/delete availability probe so server startup does not treat read-only keychain access as usable for token/channel migration
- downgrade non-interactive token migration failures to debug fallback logging so settings-file persistence can continue without noisy startup warnings

## Testing
- `bun test src/utils/secrets.test.ts src/channels/credential-store.test.ts`
- `bun run typecheck`
- `bun run check`

## Context
Observed on Ezra Mac mini with Letta Code 0.27.9: `letta server --channels slack,discord` failed/warned with `User interaction is not allowed. (code: -25308)` while migrating tokens/channel credentials from a non-interactive server shell. File-backed channel credentials were usable, so this should fall back instead of surfacing a blocking keychain error.