### PR TITLE
fix(telemetry): drain telemetry after reflection events

### DIFF
--- a/src/cli/helpers/reflection-launcher.ts
+++ b/src/cli/helpers/reflection-launcher.ts
@@ -29,6 +29,15 @@ export type ReflectionLaunchSkippedReason =
   | "no_payload"
   | "error";
 
+function drainReflectionTelemetry(): void {
+  telemetry.drain().catch((error) => {
+    debugWarn(
+      "telemetry",
+      `Failed to flush reflection telemetry: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  });
+}
+
 export type ReflectionLaunchResult =
   | {
       launched: true;
@@ -162,6 +171,7 @@ export async function launchReflectionSubagent(
         startMessageId: autoPayload.startMessageId,
         endMessageId: autoPayload.endMessageId,
       });
+      drainReflectionTelemetry();
     };
 
     const { subagentId } = spawnBackgroundSubagentTask({
@@ -185,6 +195,7 @@ export async function launchReflectionSubagent(
           stepCount,
           durationMs,
         });
+        drainReflectionTelemetry();
         maybeSendReflectionThresholdFeedback({
           parentAgentId: agentId,
           parentAgentName: options.feedbackContext?.parentAgentName,


### PR DESCRIPTION
## Summary
- drain telemetry immediately after tracking reflection_start
- drain telemetry immediately after tracking reflection_end
- use drain instead of plain flush so events queued behind an in-flight flush are also sent

## Why
Reflection telemetry was buffered until the periodic telemetry flush. If the desktop session/process went away before the next timer tick, memory commits could appear in the viewer without matching PostHog reflection invocation/completion events.

## Test plan
- bun run typecheck
- bun test src/telemetry/flush-batching.test.ts