### PR TITLE
feat(tutor): seed onboarding skills in memfs

### DIFF
--- a/src/agent/memory-filesystem.ts
+++ b/src/agent/memory-filesystem.ts
@@ -7,9 +7,9 @@
  * and headless code paths.
  */
 
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import type { Backend } from "@/backend";
 import {
@@ -385,6 +385,87 @@ export interface ApplyMemfsFlagsOptions {
   agentTags?: string[];
   /** Skip the system prompt update (when the agent was created with the correct mode). */
   skipPromptUpdate?: boolean;
+  /** Files to seed into an agent's MemFS checkout, without overwriting existing files. */
+  initialFiles?: Array<{ relativePath: string; content: string }>;
+  /** Commit message used when initialFiles are written. */
+  initialFilesCommitMessage?: string;
+}
+
+function normalizeInitialMemoryFilePath(relativePath: string): string | null {
+  const normalized = relativePath.replace(/\\/g, "/");
+  const segments = normalized.split("/").filter(Boolean);
+  if (
+    !normalized ||
+    normalized.startsWith("/") ||
+    segments.length === 0 ||
+    segments.some((segment) => segment === "." || segment === "..")
+  ) {
+    return null;
+  }
+  return segments.join("/");
+}
+
+async function writeInitialMemoryFiles(params: {
+  memoryDir: string;
+  agentId: string;
+  files?: Array<{ relativePath: string; content: string }>;
+  syncMode: "local" | "remote";
+  reason?: string;
+}): Promise<void> {
+  const files = params.files ?? [];
+  if (files.length === 0) {
+    return;
+  }
+
+  const pathspecs: string[] = [];
+  for (const file of files) {
+    const relativePath = normalizeInitialMemoryFilePath(file.relativePath);
+    if (!relativePath) {
+      continue;
+    }
+    const fullPath = join(params.memoryDir, relativePath);
+    if (existsSync(fullPath)) {
+      continue;
+    }
+    mkdirSync(dirname(fullPath), { recursive: true });
+    writeFileSync(fullPath, file.content, "utf8");
+    pathspecs.push(relativePath);
+  }
+
+  if (pathspecs.length === 0) {
+    return;
+  }
+
+  const { commitAndSyncMemoryWrite } = await import("@/agent/memory-git");
+  const author = {
+    agentId: params.agentId,
+    authorName: "Letta Code",
+    authorEmail: `${params.agentId}@letta.com`,
+  };
+  await commitAndSyncMemoryWrite({
+    memoryDir: params.memoryDir,
+    pathspecs,
+    reason: params.reason ?? "chore: initialize personality memory files",
+    author,
+    syncMode: params.syncMode,
+    replay: async () => {
+      const replayed: string[] = [];
+      for (const file of files) {
+        const relativePath = normalizeInitialMemoryFilePath(file.relativePath);
+        if (!relativePath) {
+          continue;
+        }
+        const fullPath = join(params.memoryDir, relativePath);
+        if (existsSync(fullPath)) {
+          continue;
+        }
+        mkdirSync(dirname(fullPath), { recursive: true });
+        writeFileSync(fullPath, file.content, "utf8");
+        replayed.push(relativePath);
+      }
+      return replayed;
+    },
+  });
 }
 
 /**
@@ -422,7 +503,14 @@ export async function applyMemfsFlags(
     await initializeLocalMemoryRepo({
       memoryDir,
       agentId,
-      files: [],
+      files: options?.initialFiles ?? [],
+    });
+    await writeInitialMemoryFiles({
+      memoryDir,
+      agentId,
+      files: options?.initialFiles,
+      syncMode: "local",
+      reason: options?.initialFilesCommitMessage,
     });
     settingsManager.setMemfsEnabled(agentId, true);
     return { action: "enabled", memoryDir };
@@ -532,6 +620,14 @@ export async function applyMemfsFlags(
       const result = await pullMemory(agentId);
       pullSummary = result.summary;
     }
+
+    await writeInitialMemoryFiles({
+      memoryDir: getScopedMemoryFilesystemRoot(agentId),
+      agentId,
+      files: options?.initialFiles,
+      syncMode: "remote",
+      reason: options?.initialFilesCommitMessage,
+    });
 
     // Fetch secrets from the server so they're available for $SECRET_NAME substitution.
     const { initSecretsFromServer } = await import("@/utils/secrets-store");

--- a/src/agent/personality.test.ts
+++ b/src/agent/personality.test.ts
@@ -8,6 +8,7 @@ import {
   getPersonalityBlockValues,
   getPersonalityContent,
   getPersonalityHumanContent,
+  getPersonalityInitialMemoryFiles,
   ONBOARDING_PERSONALITIES,
   PERSONALITY_OPTIONS,
   replaceBodyPreservingFrontmatter,
@@ -118,6 +119,23 @@ describe("personality helpers", () => {
     );
   });
 
+  test("tutorial seeds tutor-only skills into MemFS", () => {
+    const files = getPersonalityInitialMemoryFiles("tutorial");
+
+    expect(files.map((file) => file.relativePath).sort()).toEqual([
+      "skills/building-a-claw/SKILL.md",
+      "skills/deploying-agents/SKILL.md",
+    ]);
+    expect(
+      files.find((file) => file.relativePath.includes("deploying"))?.content,
+    ).toContain("name: deploying-agents");
+    expect(
+      files.find((file) => file.relativePath.includes("claw"))?.content,
+    ).toContain("name: building-a-claw");
+
+    expect(getPersonalityInitialMemoryFiles("memo")).toEqual([]);
+  });
+
   test("tutorial persona body drives proactive onboarding progression", () => {
     const body = getPersonalityContent("tutorial");
     expect(body).not.toContain("The skill owns the tutorial flow");
@@ -147,6 +165,8 @@ describe("personality helpers", () => {
     // Checklist completion syntax is unambiguous.
     expect(onboardingBlock?.value).toContain("Mark an item `[x]`");
     expect(onboardingBlock?.value).toContain("Connect to a channel");
+    expect(onboardingBlock?.value).toContain("deploying-agents");
+    expect(onboardingBlock?.value).toContain("building-a-claw");
   });
 
   test("non-tutorial personalities do not include onboarding", async () => {

--- a/src/agent/personality.ts
+++ b/src/agent/personality.ts
@@ -14,6 +14,8 @@ import {
   pullMemory,
 } from "./memory-git";
 import { MEMORY_PROMPTS, SYSTEM_PROMPTS } from "./prompt-assets";
+import buildingAClawSkill from "./prompts/tutor-skills/building-a-claw.md";
+import deployingAgentsSkill from "./prompts/tutor-skills/deploying-agents.md";
 
 const execFile = promisify(execFileCb);
 
@@ -108,6 +110,11 @@ export interface PersonalityBlockDefinition {
   templatePromptAssetName: string;
 }
 
+export interface PersonalityInitialMemoryFile {
+  relativePath: string;
+  content: string;
+}
+
 export const ONBOARDING_PERSONALITIES = [
   "tutorial",
 ] as const satisfies readonly PersonalityId[];
@@ -118,6 +125,25 @@ export function supportsOnboardingBlock(
   return (ONBOARDING_PERSONALITIES as readonly PersonalityId[]).includes(
     personalityId,
   );
+}
+
+export function getPersonalityInitialMemoryFiles(
+  personalityId: PersonalityId,
+): PersonalityInitialMemoryFile[] {
+  if (personalityId !== "tutorial") {
+    return [];
+  }
+
+  return [
+    {
+      relativePath: "skills/deploying-agents/SKILL.md",
+      content: `${deployingAgentsSkill.trimEnd()}\n`,
+    },
+    {
+      relativePath: "skills/building-a-claw/SKILL.md",
+      content: `${buildingAClawSkill.trimEnd()}\n`,
+    },
+  ];
 }
 
 const FRONTMATTER_REGEX = /^(---\n[\s\S]*?\n---)\n*/;
@@ -464,19 +490,32 @@ export async function buildCreateAgentOptionsForPersonality(params: {
 export async function enableMemfsForCreatedAgent(params: {
   agentId: string;
   agentTags?: string[] | null;
+  personalityId?: PersonalityId;
 }): Promise<void> {
-  const { agentId, agentTags } = params;
+  const { agentId, agentTags, personalityId } = params;
 
   try {
-    const { getClient } = await import("@/backend/api/client");
-    const client = await getClient();
+    const { applyMemfsFlags } = await import("./memory-filesystem");
+    const backend = getBackend();
     const tags = agentTags || [];
-    if (!tags.includes(GIT_MEMORY_ENABLED_TAG)) {
-      await client.agents.update(agentId, {
+    if (
+      backend.capabilities.remoteMemfs &&
+      !tags.includes(GIT_MEMORY_ENABLED_TAG)
+    ) {
+      await backend.updateAgent(agentId, {
         tags: [...tags, GIT_MEMORY_ENABLED_TAG],
       });
     }
     settingsManager.setMemfsEnabled(agentId, true);
+
+    await applyMemfsFlags(agentId, true, undefined, {
+      pullOnExistingRepo: true,
+      agentTags: tags,
+      skipPromptUpdate: true,
+      initialFiles: personalityId
+        ? getPersonalityInitialMemoryFiles(personalityId)
+        : undefined,
+    });
   } catch {
     // Self-hosted or memfs not available - skip silently
   }
@@ -499,6 +538,7 @@ export async function createAgentForPersonality(params: {
   await enableMemfsForCreatedAgent({
     agentId: result.agent.id,
     agentTags: result.agent.tags,
+    personalityId: params.personalityId,
   });
 
   return result;
@@ -613,6 +653,40 @@ function applyPersonalityFiles(
   return changedPaths;
 }
 
+function isSafeRelativeMemoryPath(relativePath: string): boolean {
+  const normalized = relativePath.replace(/\\/g, "/");
+  const segments = normalized.split("/").filter(Boolean);
+  return (
+    normalized.length > 0 &&
+    !normalized.startsWith("/") &&
+    segments.length > 0 &&
+    segments.every((segment) => segment !== "." && segment !== "..")
+  );
+}
+
+function applyInitialPersonalityMemoryFiles(
+  repoDir: string,
+  files: PersonalityInitialMemoryFile[],
+): string[] {
+  const changedPaths: string[] = [];
+
+  for (const file of files) {
+    const relativePath = file.relativePath.replace(/\\/g, "/");
+    if (!isSafeRelativeMemoryPath(relativePath)) {
+      continue;
+    }
+    const absolutePath = join(repoDir, relativePath);
+    if (existsSync(absolutePath)) {
+      continue;
+    }
+    mkdirSync(dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, file.content, "utf-8");
+    changedPaths.push(relativePath);
+  }
+
+  return changedPaths;
+}
+
 export async function applyPersonalityToMemory(
   params: ApplyPersonalityToMemoryParams,
 ): Promise<ApplyPersonalityToMemoryResult> {
@@ -661,7 +735,13 @@ export async function applyPersonalityToMemory(
     },
   ];
 
-  const changedPaths = applyPersonalityFiles(filesToUpdate);
+  const initialMemoryFiles = getPersonalityInitialMemoryFiles(
+    params.personalityId,
+  );
+  const changedPaths = [
+    ...applyPersonalityFiles(filesToUpdate),
+    ...applyInitialPersonalityMemoryFiles(repoDir, initialMemoryFiles),
+  ];
 
   if (changedPaths.length === 0) {
     return {
@@ -683,7 +763,10 @@ export async function applyPersonalityToMemory(
     reason: commitMessage,
     author,
     syncMode: isLocalMemfs ? "local" : "remote",
-    replay: async () => applyPersonalityFiles(filesToUpdate),
+    replay: async () => [
+      ...applyPersonalityFiles(filesToUpdate),
+      ...applyInitialPersonalityMemoryFiles(repoDir, initialMemoryFiles),
+    ],
   });
 
   if (!commitResult.committed) {

--- a/src/agent/prompts/onboarding.mdx
+++ b/src/agent/prompts/onboarding.mdx
@@ -10,6 +10,8 @@ Track each action and whether you have done it yet. Mark an item `[x]` once it i
 
 Explain each of these concepts to the user: if you are unsure of how they work, reference your own prompting, implementation, or constitution. 
 
+Use your tutor-only skills when the topic calls for them: `deploying-agents` for choosing local, Constellation, remote environments, or hosting surfaces; `building-a-claw` for always-on agents, schedules, channels, listeners, and persistent runtimes; and `creating-channels` when building or debugging channel/plugin code.
+
 The user has been active since: <TODO: fill this out>
 
 Memory
@@ -35,13 +37,13 @@ Search
 - [ ] Searching messages: let the user know that they can ask you to search past conversations.
 
 Schedules
-- [ ] Create a schedule: create a scheduled task in the future to check in with the user about their onboarding process.
-- [ ] Create a cron: you can set up repeated scheduled tasks. Ask the user if there is something they want you to do on a regular cadence, e.g. check their email, check skills, etc.
+- [ ] Create a schedule: create a scheduled task in the future to check in with the user about their onboarding process. Load `building-a-claw` first if the user expects the schedule to run while their laptop is closed.
+- [ ] Create a cron: you can set up repeated scheduled tasks. Ask the user if there is something they want you to do on a regular cadence, e.g. check their email, check skills, etc. Load `building-a-claw` if it needs an always-on runtime.
 
 Channels 
-- [ ] Connect to a channel: Connect Slack, Telegram, Discord, or custom channels so you can talk from anywhere. 
+- [ ] Connect to a channel: Connect Slack, Telegram, Discord, or custom channels so you can talk from anywhere. Load `building-a-claw` for channel/listener architecture and `creating-channels` for channel/plugin implementation details.
 
 Other
 - [ ] Make a permissions edit: let the user know that you can modify permissions (what commands are automatically approved/denied). Ask them if there are certain actions they would like you to avoid.
 - [ ] Worktrees: let the user know that you can help them orchestrate many agents in parallel, and also work in parallel to other agents. Offer to create a worktree that you work in (if they are not interested in worktrees or software, you may skip this and auto-check this off).
-- [ ] Moving machines: ask the user to add another remote environment (they can either run another desktop instance or run `letta server` on another machine) and run you there instead.
+- [ ] Moving machines: load `deploying-agents`, then ask the user to add another remote environment (they can either run another desktop instance or run `letta server` on another machine) and run you there instead.

--- a/src/agent/prompts/tutor-skills/building-a-claw.md
+++ b/src/agent/prompts/tutor-skills/building-a-claw.md
@@ -1,0 +1,92 @@
+---
+name: building-a-claw
+description: Tutor-only guide for teaching new users how to build a CLaw: a practical always-on Letta Code agent setup with state, runtime, channels, schedules, tools, secrets, and remotes wired together.
+license: MIT
+---
+
+# Building a CLaw
+
+Use this when a user wants an agent that keeps working after the interactive chat ends: scheduled tasks, channel replies, remote execution, background monitoring, or a persistent assistant reachable from outside the laptop.
+
+A CLaw is the user's complete always-on agent setup. Teach it as a system, not as one magic deployment switch.
+
+## Core model
+
+Explain the parts in this order:
+
+1. **Agent** — persistent state: memory, conversations, tools, model settings, and identity.
+2. **Runtime** — a running Letta Code process that can execute tools for that agent.
+3. **Trigger** — what wakes work up: user message, channel message, schedule, webhook, or manual CLI/Desktop action.
+4. **Interface** — where messages enter and leave: Desktop, CLI, `chat.letta.com`, Slack, Discord, Telegram, or a custom channel.
+5. **Host** — where the runtime stays alive: laptop, Desktop, VPS, remote environment, or another always-on machine.
+6. **Secrets** — credentials made available as environment variables without pasting secret values into chat.
+7. **Memory** — durable knowledge and skills the agent carries forward.
+
+Then summarize: **state persists; runtimes come and go; always-on behavior requires a process that stays running.**
+
+## Minimum viable CLaw
+
+For a first setup, keep it small:
+
+1. One primary agent.
+2. MemFS enabled.
+3. One always-on runtime or remote environment.
+4. One interface/channel.
+5. One trigger: either a schedule or inbound channel message.
+6. Required secrets installed.
+7. A short memory note saying what the CLaw is responsible for.
+
+Do not start with five permanent agents. Use temporary subagents for bounded work; make more persistent agents only when ownership boundaries are clear.
+
+## Channel CLaw
+
+For Slack, Discord, Telegram, WhatsApp, or custom chat:
+
+1. Confirm whether the user is connecting an existing first-party channel or building a custom channel plugin.
+2. If building/debugging channel code, load `creating-channels`.
+3. Ensure the listener/channel process will stay alive on an appropriate host.
+4. Bind routes/pairing so inbound messages go to the intended agent/conversation.
+5. Ensure outbound replies work through `MessageChannel` or the channel's native action.
+6. Avoid posting approval prompts into public rooms unless operator routing is verified.
+
+## Scheduled CLaw
+
+For recurring work:
+
+1. Define the smallest recurring task.
+2. Confirm required tools, files, network access, and secrets.
+3. Put the responsibility in memory.
+4. Schedule the task.
+5. Decide where the runtime executes if the laptop is asleep.
+6. Add a reporting path: chat, channel, file, or notification.
+
+## Remote CLaw
+
+For remote execution:
+
+1. Choose Constellation-backed state when the same agent needs to run across machines.
+2. Run a named remote environment on the machine that has the required files or uptime.
+3. Keep project-specific instructions in project memory or project skills.
+4. Use worktrees for parallel coding work rather than multiple agents editing one checkout blindly.
+
+## Common mistakes to prevent
+
+- Treating "agent" and "running process" as the same thing.
+- Expecting a laptop-hosted listener to work after the laptop sleeps.
+- Deploying to a serverless function that cannot hold a persistent listener.
+- Creating many permanent agents before responsibilities are stable.
+- Pasting API keys into chat instead of using secrets/environment variables.
+- Building a custom channel when a first-party channel or generic setup is enough.
+- Forgetting outbound reply support when building a channel plugin.
+
+## Tutor workflow
+
+When teaching a CLaw, produce:
+
+1. A one-sentence architecture recommendation.
+2. A labeled diagram in text, for example:
+   `Telegram -> listener on VPS -> Constellation agent state -> tools/secrets -> MessageChannel reply`.
+3. The next single setup step.
+4. The thing that must be tested before moving on.
+
+Keep the first CLaw boring. A boring always-on agent that works is better than an elaborate fleet that nobody understands.

--- a/src/agent/prompts/tutor-skills/deploying-agents.md
+++ b/src/agent/prompts/tutor-skills/deploying-agents.md
@@ -1,0 +1,70 @@
+---
+name: deploying-agents
+description: Tutor-only guide for helping new Letta Code users choose where an agent should run: local mode, Desktop, Constellation, remote environments, VMs, Railway, Fly.io, DigitalOcean, or other always-on hosts.
+license: MIT
+---
+
+# Deploying agents
+
+Use this when a user asks where their Letta Code agent should live, how to make it reachable from another machine, or whether to use Local mode, Constellation, a cloud VM, Railway, Fly.io, DigitalOcean, Vercel, Modal, or a similar host.
+
+## Mental model
+
+Separate these ideas before giving instructions:
+
+- **Agent state**: the agent's identity, memory, conversations, and configuration.
+- **Runtime**: the Letta Code process currently executing work for that agent.
+- **Interface**: where the user talks to the agent: Desktop, CLI, `chat.letta.com`, or a channel.
+- **Remote environment**: another machine running `letta server --env-name "..."` so an agent can work there.
+- **Always-on host**: a machine or service that keeps a listener/server process alive for schedules and channels.
+
+A user does not usually "deploy the brain". They choose where the state is stored, then choose which processes are allowed to operate on that state.
+
+## First decision: local or Constellation
+
+Recommend this decision tree:
+
+1. **Stay local** when the user wants a private single-machine setup, is exploring, or does not need `chat.letta.com`, cross-machine access, hosted state sync, remote environments, or shared secrets.
+2. **Use Constellation** when the user wants the same agent available from Desktop, CLI, `chat.letta.com`, other machines, remote environments, or channel/listener setups.
+3. **Use a remote environment** when the agent needs to run on a different machine with specific files, GPUs, credentials, network access, or uptime.
+4. **Use an always-on host** when schedules or channels must keep working after the laptop sleeps.
+
+If the user is unsure, start local for learning and move to Constellation when they need another interface or machine.
+
+## Host recommendations
+
+For always-on Letta Code work, prefer a normal long-running process:
+
+- A spare machine or Mac mini.
+- A VPS.
+- Railway, Fly.io, or DigitalOcean when supported by the current docs.
+- A server where `letta server --env-name "..."` or `letta listen` can keep running.
+
+Be cautious with request/response serverless platforms:
+
+- **Vercel Functions / serverless functions** are usually the wrong shape for channels and listeners because they do not provide a durable always-on process.
+- **Modal or job-style compute** can be useful for bursty jobs, but do not recommend it as the default channel/listener host unless the user has a specific Modal design that keeps the listener semantics intact.
+
+If the exact hosting guide matters, search the current Letta docs before giving provider-specific commands.
+
+## Recommended answers by user goal
+
+- "I want to use the agent only on this laptop" → Local mode or Desktop is enough.
+- "I want to chat from my phone/browser" → Constellation plus `chat.letta.com` or a channel.
+- "I want the same agent on my laptop and server" → Constellation agent plus a named remote environment.
+- "I want Telegram/Slack/Discord to work while my laptop is closed" → Constellation plus an always-on listener/channel host.
+- "I need access to files on a server" → Run the runtime on that server as a remote environment.
+- "I want a one-off coding job on a fresh machine" → A remote environment or coding subagent may be enough; do not overbuild an always-on deployment.
+
+## Tutor workflow
+
+1. Ask for the user's goal in one concrete sentence if it is not already clear.
+2. State the recommended surface and why.
+3. Explain what remains local vs synced vs always-on.
+4. Give the minimum next command or UI action.
+5. If channels or always-on behavior are involved, load `building-a-claw` next.
+6. If custom channel development is involved, load `creating-channels` next.
+
+## Verification habit
+
+Do not guess on current provider-specific deployment steps, pricing, or real-time availability. Check the repo docs or docs.letta.com when the exact commands matter.

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -46,6 +46,7 @@ import {
 import { updateAgentLLMConfig, updateAgentSystemPrompt } from "./agent/modify";
 import {
   buildCreateAgentOptionsForPersonality,
+  getPersonalityInitialMemoryFiles,
   resolvePersonalityId,
 } from "./agent/personality";
 import type { MemoryPromptMode } from "./agent/prompt-assets";
@@ -1383,7 +1384,20 @@ export async function handleHeadlessCommand(
   //   "skip"                 – skip the pull this session.
   if (!backend.capabilities.remoteMemfs) {
     if (backend.capabilities.localMemfs) {
-      settingsManager.setMemfsEnabled(agent.id, !localNoMemfsRequested);
+      const { applyMemfsFlags } = await import("@/agent/memory-filesystem");
+      await applyMemfsFlags(
+        agent.id,
+        localNoMemfsRequested ? undefined : true,
+        localNoMemfsRequested ? true : undefined,
+        {
+          pullOnExistingRepo: true,
+          agentTags: agent.tags,
+          skipPromptUpdate: forceNew,
+          initialFiles: personality
+            ? getPersonalityInitialMemoryFiles(personality)
+            : undefined,
+        },
+      );
     } else if (noMemfsFlag || localNoMemfsRequested) {
       settingsManager.setMemfsEnabled(agent.id, false);
     }
@@ -1395,6 +1409,9 @@ export async function handleHeadlessCommand(
         pullOnExistingRepo: false,
         agentTags: agent.tags,
         skipPromptUpdate: forceNew,
+        initialFiles: personality
+          ? getPersonalityInitialMemoryFiles(personality)
+          : undefined,
       });
     } catch (error) {
       trackHeadlessBoundaryError(
@@ -1414,6 +1431,9 @@ export async function handleHeadlessCommand(
       pullOnExistingRepo: true,
       agentTags: agent.tags,
       skipPromptUpdate: forceNew,
+      initialFiles: personality
+        ? getPersonalityInitialMemoryFiles(personality)
+        : undefined,
     }).catch((error) => {
       trackHeadlessBoundaryError(
         "headless_memfs_background_pull_failed",
@@ -1437,6 +1457,9 @@ export async function handleHeadlessCommand(
           pullOnExistingRepo: true,
           agentTags: agent.tags,
           skipPromptUpdate: forceNew,
+          initialFiles: personality
+            ? getPersonalityInitialMemoryFiles(personality)
+            : undefined,
         },
       );
       if (memfsResult.pullSummary?.includes("CONFLICT")) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import {
 import { updateAgentLLMConfig, updateAgentSystemPrompt } from "./agent/modify";
 import {
   buildCreateAgentOptionsForPersonality,
+  getPersonalityInitialMemoryFiles,
   resolvePersonalityId,
 } from "./agent/personality";
 import type { MemoryPromptMode } from "./agent/prompt-assets";
@@ -2426,17 +2427,29 @@ async function main(): Promise<void> {
                 pullOnExistingRepo: true,
                 agentTags,
                 skipPromptUpdate: shouldCreateNew,
+                initialFiles: personality
+                  ? getPersonalityInitialMemoryFiles(personality)
+                  : undefined,
               }),
             )
           : Promise.resolve().then(() => {
               if (backend.capabilities.localMemfs) {
-                settingsManager.setMemfsEnabled(
-                  agentId,
-                  !localNoMemfsRequested,
+                return import("@/agent/memory-filesystem").then(
+                  ({ applyMemfsFlags }) =>
+                    applyMemfsFlags(
+                      agentId,
+                      localNoMemfsRequested ? undefined : true,
+                      localNoMemfsRequested ? true : undefined,
+                      {
+                        pullOnExistingRepo: true,
+                        agentTags,
+                        skipPromptUpdate: shouldCreateNew,
+                        initialFiles: personality
+                          ? getPersonalityInitialMemoryFiles(personality)
+                          : undefined,
+                      },
+                    ),
                 );
-                return {
-                  action: localNoMemfsRequested ? "disabled" : "enabled",
-                };
               }
               if (memfsFlag) {
                 throw new Error(

--- a/src/skills/builtin/acquiring-skills/SKILL.md
+++ b/src/skills/builtin/acquiring-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: acquiring-skills
-description: Guide for safely discovering and installing skills from external repositories. Use when a user asks for something where a specialized skill likely exists (browser testing, PDF processing, document generation, etc.) and you want to bootstrap your understanding rather than starting from scratch.
+description: Discover and install skills from Hermes, ClawHub, GitHub, and other registries. Load this skill whenever a user asks for a capability you don't already have — image generation, social media, email, calendar, finance, DevOps, search, browser automation, etc.
 ---
 
 # Acquiring New Skills

--- a/src/skills/builtin/acquiring-skills/SKILL.md
+++ b/src/skills/builtin/acquiring-skills/SKILL.md
@@ -58,25 +58,52 @@ Only proceed with skill acquisition if the user agrees.
 
 ### 1. Hermes Skills Hub (NousResearch)
 
-The Hermes Agent project ships a catalog of official optional skills in the `NousResearch/hermes-agent` repo under `optional-skills/`. These cover categories like blockchain, finance, mlops, research, security, devops, creative, productivity, and more.
+Hermes has a full Skills Hub with 88k+ skills across multiple registries. It includes official optional skills shipped with the project, plus community skills from skills.sh, well-known endpoints, GitHub repos, ClawHub, LobeHub, and browse.sh.
 
 **Searching Hermes skills:**
 
+The Hermes CLI has built-in search and browse:
+
 ```bash
-# Browse the full catalog online
+hermes skills browse                              # Browse all hub skills (official first)
+hermes skills browse --source official            # Browse only official optional skills
+hermes skills search kubernetes                   # Search all sources
+hermes skills search react --source skills-sh     # Search the skills.sh directory
+hermes skills search https://mintlify.com/docs --source well-known
+hermes skills inspect openai/skills/k8s           # Preview before installing
+```
+
+The web catalog is at https://hermes-agent.nousresearch.com/docs/skills.
+
+Hermes hub sources:
+
+| Source | Example identifier | Notes |
+|--------|--------------------|-------|
+| `official` | `official/security/1password` | Optional skills shipped with Hermes |
+| `skills-sh` | `skills-sh/vercel-labs/agent-skills/vercel-react-best-practices` | skills.sh directory |
+| `well-known` | `well-known:https://mintlify.com/docs/.well-known/skills/mintlify` | Skills hosted at `/.well-known/skills/` |
+| `url` | `https://sharethis.chat/SKILL.md` | Direct URL to a single SKILL.md |
+| `github` | `openai/skills/k8s` | GitHub repo/path |
+| `clawhub` | ClawHub registry skills | ClawHub marketplace |
+| `lobehub` | LobeHub registry skills | LobeHub marketplace |
+| `browse-sh` | `browse-sh/airbnb.com/search-listings-ddgioa` | browse.sh crawled skills |
+
+If Hermes is not installed, you can browse the official optional skills directly:
+
+```bash
+# Browse the catalog on GitHub
 # https://github.com/NousResearch/hermes-agent/tree/main/optional-skills
+# Categories: autonomous-ai-agents, blockchain, creative, devops, finance,
+#             health, mcp, mlops, productivity, research, security, ...
 
 # Or clone and browse locally
 git clone --depth 1 https://github.com/NousResearch/hermes-agent.git /tmp/hermes-browse
 ls /tmp/hermes-browse/optional-skills/
-# Categories: autonomous-ai-agents, blockchain, creative, devops, finance,
-#             health, mcp, mlops, productivity, research, security, software-development, ...
 ls /tmp/hermes-browse/optional-skills/finance/
-# Skills: 3-statement-model, comps-analysis, dcf-model, excel-author, stocks, ...
 rm -rf /tmp/hermes-browse
 ```
 
-**Installing Hermes skills** uses the `official/` prefix:
+**Installing Hermes skills** into Letta uses the `official/` prefix (for official optional skills):
 
 ```bash
 letta skills install official/finance/stocks
@@ -87,6 +114,8 @@ letta skills install official/creative/meme-generation
 ```
 
 The `official/<category>/<skill>` form clones `NousResearch/hermes-agent` and copies from `optional-skills/<category>/<skill>`.
+
+For non-official Hermes hub skills, use the GitHub URL or shorthand form to install into Letta (e.g., `letta skills install openai/skills/k8s`).
 
 ### 2. ClawHub (OpenClaw)
 
@@ -203,7 +232,7 @@ After installing (via CLI or manual copy), skills are automatically discovered o
 
 When looking for a skill to solve a user's problem:
 
-1. **Check Hermes catalog first** — the official optional-skills cover a wide range (finance, mlops, blockchain, devops, research, creative, security). Browse `optional-skills/` categories or grep SKILL.md descriptions.
+1. **Search Hermes Skills Hub first** — `hermes skills search <query>` searches 88k+ skills across all registries. If Hermes CLI isn't available, browse the official optional-skills on GitHub (finance, mlops, blockchain, devops, research, creative, security, etc.).
 2. **Search ClawHub** — community registry with versioning. Use `clawhub search` or the web UI.
 3. **Search GitHub** — look for repos with `SKILL.md` files. Try `github.com/letta-ai/skills` and `github.com/anthropics/skills` first.
 4. **Ask the user** — they may know of a specific skill repo or have preferences about sources.

--- a/src/skills/builtin/acquiring-skills/SKILL.md
+++ b/src/skills/builtin/acquiring-skills/SKILL.md
@@ -5,7 +5,7 @@ description: Guide for safely discovering and installing skills from external re
 
 # Acquiring New Skills
 
-This skill teaches you how to safely discover and install skills from external sources.
+This skill teaches you how to safely discover and install skills from external sources, including the Hermes Skills Hub, ClawHub (OpenClaw), GitHub repositories, and Letta community repos.
 
 ## SAFETY - READ THIS FIRST
 
@@ -16,12 +16,15 @@ Skills can contain:
 ### Trusted Sources (no user approval needed for download)
 - `https://github.com/letta-ai/skills` - Letta's community skills
 - `https://github.com/anthropics/skills` - Anthropic's official skills
+- `official/*` - Hermes official optional skills (from `NousResearch/hermes-agent`)
 
 ### Untrusted Sources (ALWAYS verify with user)
-For ANY source other than letta-ai or anthropics:
+For ANY source other than the above:
 1. Ask the user before downloading
 2. Explain where the skill comes from
 3. Get explicit approval
+
+This includes ClawHub community skills and arbitrary GitHub repos.
 
 ### Script Safety
 Even for skills from trusted sources, ALWAYS:
@@ -45,78 +48,185 @@ Even for skills from trusted sources, ALWAYS:
 
 If you recognize a task that might have an associated skill, **ask the user first**:
 
-> "This sounds like something where a community skill might help (e.g., webapp testing with Playwright). Would you like me to look for available skills in the Letta or Anthropic repositories? This might take a minute, or I can start coding right away if you prefer."
+> "This sounds like something where a community skill might help. Would you like me to search for available skills? I can check the Hermes catalog, ClawHub, or GitHub. Or I can start coding right away if you prefer."
 
 The user may prefer to start immediately rather than wait for skill discovery.
 
 Only proceed with skill acquisition if the user agrees.
 
-## Skill Repositories
+## Skill Sources
+
+### 1. Hermes Skills Hub (NousResearch)
+
+The Hermes Agent project ships a catalog of official optional skills in the `NousResearch/hermes-agent` repo under `optional-skills/`. These cover categories like blockchain, finance, mlops, research, security, devops, creative, productivity, and more.
+
+**Searching Hermes skills:**
+
+```bash
+# Browse the full catalog online
+# https://github.com/NousResearch/hermes-agent/tree/main/optional-skills
+
+# Or clone and browse locally
+git clone --depth 1 https://github.com/NousResearch/hermes-agent.git /tmp/hermes-browse
+ls /tmp/hermes-browse/optional-skills/
+# Categories: autonomous-ai-agents, blockchain, creative, devops, finance,
+#             health, mcp, mlops, productivity, research, security, software-development, ...
+ls /tmp/hermes-browse/optional-skills/finance/
+# Skills: 3-statement-model, comps-analysis, dcf-model, excel-author, stocks, ...
+rm -rf /tmp/hermes-browse
+```
+
+**Installing Hermes skills** uses the `official/` prefix:
+
+```bash
+letta skills install official/finance/stocks
+letta skills install official/blockchain/solana
+letta skills install official/research/duckduckgo-search
+letta skills install official/mlops/flash-attention
+letta skills install official/creative/meme-generation
+```
+
+The `official/<category>/<skill>` form clones `NousResearch/hermes-agent` and copies from `optional-skills/<category>/<skill>`.
+
+### 2. ClawHub (OpenClaw)
+
+ClawHub (https://clawhub.ai) is the public registry for OpenClaw skills and plugins. It hosts community-contributed skills with versioning, security scans, and search.
+
+**Searching ClawHub skills:**
+
+```bash
+# Browse the web registry
+# https://clawhub.ai
+
+# Or use the clawhub CLI if installed
+clawhub search "calendar"
+clawhub search "screenshot"
+clawhub explore
+
+# Or search via the API directly
+curl -s "https://clawhub.ai/api/v1/skills?q=calendar" | jq '.[].slug'
+```
+
+**Installing ClawHub skills** uses the `clawhub/` or `clawhub:` prefix:
+
+```bash
+letta skills install clawhub/nano-banana-pro
+letta skills install clawhub:nano-banana-pro
+letta skills install clawhub:nano-banana-pro@1.0.1      # pin a version
+letta skills install https://clawhub.ai/skills/my-skill  # URL form also works
+```
+
+**Note:** A bare slug like `letta skills install nano-banana-pro` will NOT resolve through ClawHub — you must include the `clawhub/` or `clawhub:` prefix.
+
+### 3. GitHub Repositories
+
+Any GitHub repository containing a `SKILL.md` can be installed directly.
+
+```bash
+# Full repo (installs from repo root)
+letta skills install https://github.com/owner/repo
+
+# Subdirectory (tree URL)
+letta skills install https://github.com/owner/repo/tree/main/path/to/skill
+
+# SKILL.md blob URL (installs parent directory)
+letta skills install https://github.com/owner/repo/blob/main/path/to/skill/SKILL.md
+
+# Shorthand: owner/repo/path
+letta skills install owner/repo/path/to/skill
+```
+
+### 4. Letta & Anthropic Community Repos
 
 | Repository | Description |
 |------------|-------------|
 | https://github.com/letta-ai/skills | Community skills for Letta agents |
 | https://github.com/anthropics/skills | Anthropic's official Agent Skills |
 
-Browse these repositories to discover available skills. Check the README for skill listings.
+These can be installed via the GitHub URL forms above, or manually cloned and copied.
+
+## The `letta skills install` Command
+
+The CLI handles downloading, placing the skill in the agent's memory, and committing the change:
+
+```bash
+letta skills install <source> [--agent <id> | -n <agent-name>] [--force]
+```
+
+| Flag | Purpose |
+|------|---------|
+| `--agent <id>` | Install into a specific agent's memfs |
+| `-n <name>` | Resolve agent by name instead of id |
+| `--force` | Replace an existing skill with the same name |
+
+If no agent is specified, the command uses `LETTA_AGENT_ID` / `AGENT_ID` from the environment, or prompts interactively.
+
+Also available as a top-level alias: `letta install <source>`.
+
+**Managing installed skills:**
+
+```bash
+letta skills list [--agent <id>]
+letta skills delete <skill-name> --agent <id>
+```
 
 ## Installation Locations
 
+When using `letta skills install`, skills are placed in the agent's memfs at `<memory-dir>/skills/<skill-name>/`.
+
+For manual installation:
+
 | Location | Path | When to Use |
 |----------|------|-------------|
-| **Agent-scoped** | `~/.letta/agents/<agent-id>/memory/skills/<skill>/` | Skills for a single agent (default for agent-specific capabilities) |
+| **Agent-scoped** | `~/.letta/agents/<agent-id>/memory/skills/<skill>/` | Skills for a single agent (default) |
 | **Global** | `~/.letta/skills/<skill>/` | General-purpose skills useful across projects |
 | **Project** | `.skills/<skill>/` | Project-specific skills |
 
-**Rule**: Default to **agent-scoped** for changes that should apply only to the current agent. Use **project** for repo-specific skills. Use **global** only if all agents should inherit the skill.
+**Rule**: Default to **agent-scoped**. Use **project** for repo-specific skills. Use **global** only if all agents should inherit the skill.
 
-## How to Download Skills
+## Manual Download (When CLI Install Isn't Available)
 
 Skills are directories containing SKILL.md and optionally scripts/, references/, examples/.
 
-### Method: Clone to /tmp, then copy
-
 ```bash
-# 1. Clone the repo (shallow)
+# Clone, copy, cleanup
 git clone --depth 1 https://github.com/anthropics/skills /tmp/skills-temp
-
-# 2. Copy the skill to your skills directory
-# For agent-scoped (recommended default):
 cp -r /tmp/skills-temp/skills/webapp-testing ~/.letta/agents/<agent-id>/memory/skills/
-# For global:
-# cp -r /tmp/skills-temp/skills/webapp-testing ~/.letta/skills/
-# For project:
-# cp -r /tmp/skills-temp/skills/webapp-testing .skills/
-
-# 3. Cleanup
-rm -rf /tmp/skills-temp
-```
-
-### Alternative: rsync (preserves permissions)
-
-```bash
-git clone --depth 1 https://github.com/anthropics/skills /tmp/skills-temp
-rsync -av /tmp/skills-temp/skills/webapp-testing/ ~/.letta/agents/<agent-id>/memory/skills/webapp-testing/
 rm -rf /tmp/skills-temp
 ```
 
 ## Registering New Skills
 
-After downloading a skill, it will be automatically discovered on the next message. Skills are discovered from `~/.letta/skills/`, `.skills/`, and agent-scoped `~/.letta/agents/<agent-id>/memory/skills/` directories.
+After installing (via CLI or manual copy), skills are automatically discovered on the next message. Skills are discovered from `~/.letta/skills/`, `.skills/`, and agent-scoped `~/.letta/agents/<agent-id>/memory/skills/` directories.
+
+## Search Strategy
+
+When looking for a skill to solve a user's problem:
+
+1. **Check Hermes catalog first** — the official optional-skills cover a wide range (finance, mlops, blockchain, devops, research, creative, security). Browse `optional-skills/` categories or grep SKILL.md descriptions.
+2. **Search ClawHub** — community registry with versioning. Use `clawhub search` or the web UI.
+3. **Search GitHub** — look for repos with `SKILL.md` files. Try `github.com/letta-ai/skills` and `github.com/anthropics/skills` first.
+4. **Ask the user** — they may know of a specific skill repo or have preferences about sources.
 
 ## Complete Example
 
-User asks: "Can you help me test my React app's UI?"
+User asks: "Can you help me track stock prices?"
 
-1. **Recognize opportunity**: Browser/webapp testing - likely has a skill
-2. **Ask user**: "Would you like me to look for webapp testing skills, or start coding right away?"
-3. **If user agrees, find skill**: Check anthropics/skills for webapp-testing
-4. **Download** (trusted source):
+1. **Recognize opportunity**: Stock/finance data - Hermes has a stocks skill
+2. **Ask user**: "Hermes has an official stocks skill that covers quotes, history, search, and crypto via Yahoo. Want me to install it?"
+3. **If user agrees, install**:
    ```bash
-   git clone --depth 1 https://github.com/anthropics/skills /tmp/skills-temp
-   cp -r /tmp/skills-temp/skills/webapp-testing ~/.letta/agents/<agent-id>/memory/skills/
-   rm -rf /tmp/skills-temp
+   letta skills install official/finance/stocks
    ```
-5. **Inspect scripts**: Read any .py or .ts files before using them
-6. **Invoke**: `Skill(skill: "webapp-testing")`
-7. **Use**: Follow the skill's instructions for the user's task
+4. **Invoke**: `Skill(skill: "stocks")`
+5. **Use**: Follow the skill's instructions for the user's task
+
+User asks: "Can you generate images with Nano Banana Pro?"
+
+1. **Recognize opportunity**: Image generation skill on ClawHub
+2. **Ask user**: "There's a nano-banana-pro skill on ClawHub. Want me to install it?"
+3. **Install**:
+   ```bash
+   letta skills install clawhub/nano-banana-pro
+   ```
+4. **Invoke**: `Skill(skill: "nano-banana-pro")`

--- a/src/skills/builtin/acquiring-skills/SKILL.md
+++ b/src/skills/builtin/acquiring-skills/SKILL.md
@@ -257,14 +257,15 @@ When looking for a skill to solve a user's problem:
 
 User asks: "Can you help me track stock prices?"
 
-1. **Recognize opportunity**: Stock/finance data - Hermes has a stocks skill
+1. **Recognize opportunity**: Stock/finance data — Hermes has a stocks skill
 2. **Ask user**: "Hermes has an official stocks skill that covers quotes, history, search, and crypto via Yahoo. Want me to install it?"
 3. **If user agrees, install**:
    ```bash
    letta skills install official/finance/stocks --agent $AGENT_ID
    ```
-4. **Invoke**: `Skill(skill: "stocks")`
-5. **Use**: Follow the skill's instructions for the user's task
+4. **Review for compatibility**: Read the installed SKILL.md. Check for harness-specific commands, paths, or tools that need adaptation (see Cross-Harness Compatibility above). Confirm the skill's instructions make sense in Letta before using it.
+5. **Invoke**: `Skill(skill: "stocks")`
+6. **Use**: Follow the skill's instructions, adapting any harness-specific details as needed
 
 User asks: "Can you generate images with Nano Banana Pro?"
 
@@ -274,4 +275,5 @@ User asks: "Can you generate images with Nano Banana Pro?"
    ```bash
    letta skills install clawhub/nano-banana-pro --agent $AGENT_ID
    ```
-4. **Invoke**: `Skill(skill: "nano-banana-pro")`
+4. **Review for compatibility**: Read the SKILL.md, check for any OpenClaw-specific commands or setup, adapt as needed.
+5. **Invoke**: `Skill(skill: "nano-banana-pro")`

--- a/src/skills/builtin/acquiring-skills/SKILL.md
+++ b/src/skills/builtin/acquiring-skills/SKILL.md
@@ -190,24 +190,29 @@ These can be installed via the GitHub URL forms above, or manually cloned and co
 The CLI handles downloading, placing the skill in the agent's memory, and committing the change:
 
 ```bash
-letta skills install <source> [--agent <id> | -n <agent-name>] [--force]
+letta skills install <source> --agent $AGENT_ID [--force]
+```
+
+Your agent ID is always available as `$AGENT_ID` in the environment. Pass it explicitly with `--agent` to install into your own memfs:
+
+```bash
+letta skills install official/finance/stocks --agent $AGENT_ID
+letta skills install clawhub/nano-banana-pro --agent $AGENT_ID
 ```
 
 | Flag | Purpose |
 |------|---------|
-| `--agent <id>` | Install into a specific agent's memfs |
+| `--agent <id>` | Install into a specific agent's memfs (use `$AGENT_ID` for yourself) |
 | `-n <name>` | Resolve agent by name instead of id |
 | `--force` | Replace an existing skill with the same name |
 
-If no agent is specified, the command uses `LETTA_AGENT_ID` / `AGENT_ID` from the environment, or prompts interactively.
-
-Also available as a top-level alias: `letta install <source>`.
+Also available as a top-level alias: `letta install <source> --agent $AGENT_ID`.
 
 **Managing installed skills:**
 
 ```bash
-letta skills list [--agent <id>]
-letta skills delete <skill-name> --agent <id>
+letta skills list --agent $AGENT_ID
+letta skills delete <skill-name> --agent $AGENT_ID
 ```
 
 ## Installation Locations
@@ -256,7 +261,7 @@ User asks: "Can you help me track stock prices?"
 2. **Ask user**: "Hermes has an official stocks skill that covers quotes, history, search, and crypto via Yahoo. Want me to install it?"
 3. **If user agrees, install**:
    ```bash
-   letta skills install official/finance/stocks
+   letta skills install official/finance/stocks --agent $AGENT_ID
    ```
 4. **Invoke**: `Skill(skill: "stocks")`
 5. **Use**: Follow the skill's instructions for the user's task
@@ -267,6 +272,6 @@ User asks: "Can you generate images with Nano Banana Pro?"
 2. **Ask user**: "There's a nano-banana-pro skill on ClawHub. Want me to install it?"
 3. **Install**:
    ```bash
-   letta skills install clawhub/nano-banana-pro
+   letta skills install clawhub/nano-banana-pro --agent $AGENT_ID
    ```
 4. **Invoke**: `Skill(skill: "nano-banana-pro")`

--- a/src/skills/builtin/acquiring-skills/SKILL.md
+++ b/src/skills/builtin/acquiring-skills/SKILL.md
@@ -133,7 +133,7 @@ clawhub search "screenshot"
 clawhub explore
 
 # Or search via the API directly
-curl -s "https://clawhub.ai/api/v1/skills?q=calendar" | jq '.[].slug'
+curl -s "https://clawhub.ai/api/v1/skills?q=calendar" | jq '.items[].slug'
 ```
 
 **Installing ClawHub skills** uses the `clawhub/` or `clawhub:` prefix:

--- a/src/skills/builtin/acquiring-skills/SKILL.md
+++ b/src/skills/builtin/acquiring-skills/SKILL.md
@@ -32,6 +32,17 @@ Even for skills from trusted sources, ALWAYS:
 2. Understand what the script does
 3. Be wary of network calls, file operations, or system commands
 
+### Cross-Harness Compatibility
+Skills from Hermes, OpenClaw, and other ecosystems were written for their own harnesses. After installing, **read the full SKILL.md before using it** and watch for:
+
+- **Harness-specific commands** — e.g. `hermes skills config`, `openclaw plugins install`, `/curator`, `/kanban`. These won't exist in Letta. Determine whether the underlying capability can be achieved with Letta tools (Bash, the Skill tool, etc.) or if the skill simply doesn't apply.
+- **Harness-specific paths and state** — e.g. `~/.hermes/skills/`, `~/.openclaw/skills/`, `~/.hermes/config.yaml`. Letta stores skills in the agent's memfs (`<memory-dir>/skills/`). Adapt any path references.
+- **Toolset assumptions** — some skills assume specific tool names or APIs (e.g. Hermes `web` toolset, OpenClaw `browser` tool). Map these to the equivalent Letta tools or note when no equivalent exists.
+- **Platform gating** — skills may declare `platforms: [cli, discord, telegram]` in frontmatter. Ignore platform restrictions that don't apply to Letta.
+- **Environment variables** — skills may require API keys or credentials. Check `requires.env` in frontmatter and note any setup the user needs to do.
+
+If a skill's core knowledge (procedures, API references, best practices) is useful but its commands are harness-specific, adapt the instructions mentally or suggest the user install the relevant CLI tool. If a skill is entirely about harness-specific plumbing with no transferable knowledge, skip it and look for an alternative.
+
 ## When to Use This Skill
 
 **DO use** when:

--- a/src/skills/builtin/creating-channels/SKILL.md
+++ b/src/skills/builtin/creating-channels/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: creating-channels
+description: Builds and debugs Letta Code channels, including first-party channel adapters and dynamic user channel plugins under ~/.letta/channels. Use when adding Telegram, WhatsApp, Bluesky, Slack, Discord, or custom channel support; testing channel routing, pairing, MessageChannel, runtime dependencies, or channel plugin manifests.
+license: MIT
+---
+
+# Creating channels
+
+Use this when adding or debugging Letta Code channel support.
+
+## First choice
+
+- **User plugin** (`~/.letta/channels/<id>/`) for headless experiments, community plugins, and fast workflow tests.
+- **First-party channel** (`src/channels/<id>/`) when the channel needs bespoke Desktop UI, custom account snapshots, Slack/Discord-style auto-routing, rich protocol fields, or migration/compatibility shims.
+
+User plugins cannot shadow first-party ids: `telegram`, `slack`, and `discord` are ignored under `~/.letta/channels/`. Use ids like `telegram-test`, `whatsapp-community`, or `custom-chat`.
+
+## Core workflow
+
+1. Work in `~/letta/letta-code` or a worktree.
+2. Read `src/channels/README.md` on branches with dynamic plugins.
+3. For a user plugin, create:
+   - `~/.letta/channels/<id>/channel.json`
+   - `~/.letta/channels/<id>/plugin.mjs`
+   - `~/.letta/channels/<id>/accounts.json`
+4. Always implement `messageActions` if agents should reply via `MessageChannel`.
+5. Start with `dmPolicy: "pairing"` for testing, or `allowlist`/`open` for known headless deployments.
+6. Test all four legs:
+   - plugin discovery/import
+   - inbound `adapter.onMessage(msg)` to route/pairing
+   - routed channel notification reaches the agent
+   - outbound `MessageChannel` calls `messageActions.handleAction` → `adapter.sendMessage`
+7. Run targeted tests, then `bun run typecheck`, `bun run lint`, `bun run build`.
+
+## References
+
+Read only what is needed:
+
+- `references/user-plugins.md` — dynamic plugin manifest/account/runtime/headless flow and gotchas.
+- `references/first-party-channels.md` — first-party channel file cascade and safety checks.
+- `references/testing.md` — smoke-test checklist and commands.
+
+## Scaffold helper
+
+Use the bundled scaffold for a minimal user plugin skeleton. Replace `<path-to-this-skill>` with this skill directory path:
+
+```bash
+npx tsx <path-to-this-skill>/scripts/scaffold-user-channel-plugin.ts \
+  my-channel "My Channel" \
+  --runtime-package some-sdk@1.0.0 \
+  --runtime-module some-sdk
+```
+
+It creates `channel.json`, `plugin.mjs`, and `accounts.example.json`. Replace the TODO inbound/outbound implementation with the real SDK calls.
+
+## Hard lessons
+
+- `MessageChannel` silently feels broken if `plugin.messageActions` is missing. Every plugin that should reply needs `describeMessageTool()` and `handleAction()`.
+- For public channels, suppress tool approval/control prompts unless there is verified operator routing. Posting approval prompts publicly leaks tool input and invites forged `approve` replies.
+- User plugin runtime resolution must not count parent/dev `node_modules`. Runtime modules should resolve from explicit runtime dirs only.
+- Headless pairing is CLI-first: `letta channels pair --channel <id> --code <code> --agent <agent-id> --conversation <conversation-id>`.
+- Running listeners reload `pairing.yaml` and `routing.yaml` on the next inbound miss; restart only when adapter/account config itself changed.

--- a/src/skills/builtin/creating-channels/references/first-party-channels.md
+++ b/src/skills/builtin/creating-channels/references/first-party-channels.md
@@ -1,0 +1,57 @@
+# First-party Letta Code channels
+
+Use first-party channel work when the channel needs Desktop UI, rich snapshots, compatibility shims, or bespoke routing.
+
+## File cascade
+
+Adding a channel usually touches:
+
+- `src/channels/types.ts` — account/config types, channel id union.
+- `src/channels/pluginRegistry.ts` — metadata and dynamic import.
+- `src/channels/<channel>/plugin.ts` — `ChannelPlugin` export.
+- `src/channels/<channel>/adapter.ts` — start/stop/inbound/send behavior.
+- `src/channels/<channel>/messageActions.ts` — `MessageChannel` action surface.
+- `src/channels/<channel>/setup.ts` — CLI setup wizard if needed.
+- `src/channels/<channel>/runtime.ts` — runtime dependency helper if needed.
+- `src/channels/accounts.ts` — legacy/default account clone handling.
+- `src/channels/service.ts` — snapshots, create/update payloads.
+- `src/websocket/listener/client.ts` — snapshot serialization/mapping.
+- `src/types/protocol_v2.ts` — wire protocol account snapshots and create/update payloads.
+- `src/channels/registry.ts` — only if routing differs from generic pairing/route flow.
+- `src/channels/xml.ts` — channel-specific message formatting hints.
+- `src/tests/channels/*.test.ts` — targeted unit coverage.
+
+Adding a per-channel field cascades through account/config types, service snapshots, accounts clone/defaults, protocol v2, websocket mapping, adapter behavior, and tests.
+
+## Required plugin shape
+
+Every reply-capable channel plugin must expose `messageActions`:
+
+```ts
+export const myChannelPlugin: ChannelPlugin = {
+  metadata: { id: "my-channel", displayName: "My Channel", runtimePackages: [], runtimeModules: [] },
+  createAdapter(account) { return createMyAdapter(account as MyChannelAccount); },
+  runSetup() { return runMySetup(); },
+  messageActions: myMessageActions,
+};
+```
+
+Without `messageActions`, the shared `MessageChannel` tool returns `Channel "X" does not expose MessageChannel actions.` as a tool-result string. Agents often absorb that silently, making the channel look like it no-opped.
+
+Use `src/channels/telegram/messageActions.ts` as the canonical simple implementation.
+
+## Routing choices
+
+- Generic pairing route: unknown direct senders receive a pairing code, `routing.yaml` maps chat → agent/conversation.
+- Slack/Discord-style auto-routing: channel account has an agent binding; registry creates conversations automatically for DMs/threads.
+- Threaded channels: choose stable route keys carefully. `chatId` should usually be the stable conversation/root id; `threadId` should only vary when routes should split.
+
+## Public-channel safety
+
+Public posting channels must not relay tool approval/control prompts by default. Implement `handleControlRequestEvent` as a no-op or verified-operator path. Otherwise `sendDirectReply` fallback can publicly post tool name, command args, working directory, and an `approve` instruction.
+
+## Bluesky lessons
+
+- Do not use pagination cursor presence as a “has polled before” flag. Bluesky may omit cursors when there is no next page. Use a dedicated `hasCompletedInitialPoll` boolean.
+- App passwords cannot read/send DMs; Bluesky V1 only supports public notifications unless OAuth with `transition:chat.bsky` is added.
+- Public notification policy should be named as an inbound/public policy in UI, even if the shared field is `dmPolicy`.

--- a/src/skills/builtin/creating-channels/references/testing.md
+++ b/src/skills/builtin/creating-channels/references/testing.md
@@ -1,0 +1,62 @@
+# Channel testing checklist
+
+## Basic commands
+
+From the relevant `letta-code` worktree:
+
+```bash
+bun install
+bun dev channels status
+bun dev channels install <channel>
+bun dev server --channels <channel> --debug
+```
+
+For self-hosted/local desktop envs, `LETTA_BASE_URL` may point at `http://localhost:<port>`, causing the listener to skip Cloud environment registration. That is fine for local testing if the target agent exists on that local server.
+
+## User plugin smoke test
+
+1. Create `~/.letta/channels/<id>/channel.json`, `plugin.mjs`, and `accounts.json`.
+2. Install runtime deps:
+
+   ```bash
+   bun dev channels install <id>
+   ```
+
+3. Start listener:
+
+   ```bash
+   bun dev server --channels <id> --debug
+   ```
+
+4. Confirm plugin-specific startup log appears. If import fails, check `runtime/node_modules` and the user plugin `node_modules` symlink.
+5. Send a platform message.
+6. If pairing is enabled, redeem the code:
+
+   ```bash
+   bun dev channels pair --channel <id> --code <code> --agent <agent-id> --conversation <conversation-id>
+   ```
+
+7. Send another platform message. The conversation should receive a `<channel-notification>`.
+8. Reply with `MessageChannel` using the channel id and `chat_id` from the notification.
+
+## Verification
+
+Run targeted tests first, then broad checks:
+
+```bash
+bun test src/tests/channels/<channel-or-area>.test.ts
+bun run typecheck
+bun run lint
+bun run build
+```
+
+`letta-code` uses `bun:test`, not a package `test` script.
+
+## Debugging symptoms
+
+- **Plugin not discovered**: id mismatch between directory and `channel.json`, invalid id chars, or id shadows first-party channel.
+- **Install says already installed but imports fail**: runtime resolver counted dev `node_modules`; ensure runtime deps actually exist under `~/.letta/channels/<id>/runtime/node_modules` and symlink `~/.letta/channels/<id>/node_modules` to it.
+- **Inbound receives pairing code forever**: pairing was not redeemed for the same `accountId`/`senderId`, or listener cannot reload `pairing.yaml`.
+- **Inbound reaches agent but replies no-op**: missing `plugin.messageActions` or route lookup mismatch in `MessageChannel` args.
+- **Route lookup misses**: wrong `chatId`, wrong `accountId`, or unstable `threadId` choice.
+- **Cron lease error**: usually unrelated to channel runtime; another Letta Code process owns scheduler lease.

--- a/src/skills/builtin/creating-channels/references/user-plugins.md
+++ b/src/skills/builtin/creating-channels/references/user-plugins.md
@@ -1,0 +1,159 @@
+# Dynamic user channel plugins
+
+## Layout
+
+```text
+~/.letta/channels/<id>/
+  channel.json
+  plugin.mjs
+  accounts.json
+  pairing.yaml
+  routing.yaml
+  runtime/
+    package.json
+    node_modules/
+```
+
+`channel.json`:
+
+```json
+{
+  "id": "whatsapp-community",
+  "displayName": "WhatsApp Community",
+  "entry": "./plugin.mjs",
+  "runtimePackages": ["some-sdk@1.0.0"],
+  "runtimeModules": ["some-sdk"]
+}
+```
+
+Rules:
+- `id` must match the directory name.
+- Do not use first-party ids (`telegram`, `slack`, `discord`). The registry skips them.
+- `entry` is relative to the channel directory and must not escape it.
+- `runtimePackages` install to `runtime/` via `letta channels install <id>`.
+- User plugin bare imports usually need `~/.letta/channels/<id>/node_modules -> runtime/node_modules` symlink. Letta Code links this after installing user-plugin runtime dependencies.
+
+## Account shape
+
+User plugins should rely on `account.config`, not first-party fields.
+
+```json
+{
+  "accounts": [
+    {
+      "channel": "whatsapp-community",
+      "accountId": "main",
+      "displayName": "WhatsApp Community",
+      "enabled": true,
+      "dmPolicy": "pairing",
+      "allowedUsers": [],
+      "config": {
+        "token": "...",
+        "phoneNumberId": "..."
+      },
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    }
+  ]
+}
+```
+
+Custom accounts have no generic `binding` field. Routing lives in `routing.yaml`, created by pairing, `letta channels route add`, or direct file management.
+
+## Minimal plugin contract
+
+`plugin.mjs` exports `channelPlugin` or `default`:
+
+```js
+export const channelPlugin = {
+  metadata: {
+    id: "whatsapp-community",
+    displayName: "WhatsApp Community",
+    runtimePackages: ["some-sdk@1.0.0"],
+    runtimeModules: ["some-sdk"]
+  },
+
+  async createAdapter(account) {
+    let onMessageHandler = null;
+    let running = false;
+
+    return {
+      id: `whatsapp-community:${account.accountId}`,
+      channelId: "whatsapp-community",
+      accountId: account.accountId,
+      name: account.displayName ?? "WhatsApp Community",
+      async start() { running = true; },
+      async stop() { running = false; },
+      isRunning() { return running; },
+      async sendMessage(msg) { return { messageId: crypto.randomUUID() }; },
+      async sendDirectReply(chatId, text, options) {},
+      get onMessage() { return onMessageHandler; },
+      set onMessage(handler) { onMessageHandler = handler; }
+    };
+  },
+
+  messageActions: {
+    describeMessageTool() { return { actions: ["send"] }; },
+    async handleAction({ adapter, request, formatText }) {
+      if (request.action !== "send") return `Error: unsupported action ${request.action}`;
+      const formatted = formatText(request.message ?? "");
+      const result = await adapter.sendMessage({
+        channel: request.channel,
+        chatId: request.chatId,
+        text: formatted.text,
+        parseMode: formatted.parseMode,
+        replyToMessageId: request.replyToMessageId,
+        threadId: request.threadId
+      });
+      return `Message sent to ${request.channel} (message_id: ${result.messageId})`;
+    }
+  }
+};
+```
+
+Inbound messages must call `adapter.onMessage(msg)` with:
+
+```ts
+{
+  channel: string;
+  accountId?: string;
+  chatId: string;
+  senderId: string;
+  senderName?: string;
+  chatLabel?: string;
+  text: string;
+  timestamp: number;
+  messageId?: string;
+  threadId?: string | null;
+  chatType?: "direct" | "channel";
+  isMention?: boolean;
+  raw?: unknown;
+}
+```
+
+## Headless pairing
+
+User plugins are headless. Pair from CLI:
+
+```bash
+letta channels pair \
+  --channel <id> \
+  --code <code> \
+  --agent <agent-id> \
+  --conversation <conversation-id>
+```
+
+Or route statically:
+
+```bash
+letta channels route add \
+  --channel <id> \
+  --chat-id <platform-chat-id> \
+  --agent <agent-id> \
+  --conversation <conversation-id>
+```
+
+`dmPolicy` behavior:
+- `pairing`: unknown senders get a pairing code. Good for manual tests.
+- `allowlist`: only `allowedUsers` sender IDs pass. Good for known headless users.
+- `open`: everyone can reach routing lookup. Use with explicit routes or safe public channels.

--- a/src/skills/builtin/creating-channels/scripts/scaffold-user-channel-plugin.ts
+++ b/src/skills/builtin/creating-channels/scripts/scaffold-user-channel-plugin.ts
@@ -1,0 +1,112 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+function usage(): never {
+  console.error(
+    `Usage: npx tsx scaffold-user-channel-plugin.ts <id> <display-name> [--dir <channels-root>] [--runtime-package <pkg>] [--runtime-module <module>] [--force]`,
+  );
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const id = args[0];
+const displayName = args[1];
+if (!id || !displayName) usage();
+if (!/^[a-z0-9][a-z0-9_-]*$/.test(id)) {
+  throw new Error(`Invalid channel id: ${id}`);
+}
+if (["telegram", "slack", "discord"].includes(id)) {
+  throw new Error(`User plugins cannot shadow first-party channel id: ${id}`);
+}
+
+let channelsRoot = join(homedir(), ".letta", "channels");
+let runtimePackage = "";
+let runtimeModule = "";
+let force = false;
+for (let i = 2; i < args.length; i++) {
+  const arg = args[i];
+  const next = args[i + 1];
+  if (arg === "--dir" && next) {
+    channelsRoot = next;
+    i++;
+  } else if (arg === "--runtime-package" && next) {
+    runtimePackage = next;
+    i++;
+  } else if (arg === "--runtime-module" && next) {
+    runtimeModule = next;
+    i++;
+  } else if (arg === "--force") {
+    force = true;
+  } else {
+    usage();
+  }
+}
+
+if (runtimePackage && !runtimeModule) runtimeModule = runtimePackage.replace(/@[^/@]+$/, "");
+if (runtimeModule && !runtimePackage) runtimePackage = runtimeModule;
+
+const dir = resolve(channelsRoot, id);
+const outputFiles = [
+  join(dir, "channel.json"),
+  join(dir, "plugin.mjs"),
+  join(dir, "accounts.example.json"),
+];
+const existingFiles = outputFiles.filter((filePath) => existsSync(filePath));
+if (existingFiles.length > 0 && !force) {
+  throw new Error(
+    `Refusing to overwrite existing files: ${existingFiles.join(", ")}. Pass --force to overwrite.`,
+  );
+}
+mkdirSync(dir, { recursive: true });
+
+const runtimePackages = runtimePackage ? [runtimePackage] : [];
+const runtimeModules = runtimeModule ? [runtimeModule] : [];
+
+writeFileSync(
+  join(dir, "channel.json"),
+  `${JSON.stringify(
+    {
+      id,
+      displayName,
+      entry: "./plugin.mjs",
+      runtimePackages,
+      runtimeModules,
+    },
+    null,
+    2,
+  )}\n`,
+);
+
+writeFileSync(
+  join(dir, "accounts.example.json"),
+  `${JSON.stringify(
+    {
+      accounts: [
+        {
+          channel: id,
+          accountId: "main",
+          displayName,
+          enabled: true,
+          dmPolicy: "pairing",
+          allowedUsers: [],
+          config: {
+            token: "TODO",
+          },
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ],
+    },
+    null,
+    2,
+  )}\n`,
+);
+
+writeFileSync(
+  join(dir, "plugin.mjs"),
+  `// ${displayName} dynamic channel plugin skeleton.\n// TODO: replace start/stop/inbound/sendMessage with the real platform SDK.\n\nimport { randomUUID } from "node:crypto";\n\nexport const channelPlugin = {\n  metadata: {\n    id: ${JSON.stringify(id)},\n    displayName: ${JSON.stringify(displayName)},\n    runtimePackages: ${JSON.stringify(runtimePackages)},\n    runtimeModules: ${JSON.stringify(runtimeModules)}\n  },\n\n  async createAdapter(account) {\n    let running = false;\n    let onMessageHandler = null;\n\n    return {\n      id: \`${id}:\${account.accountId}\`,\n      channelId: ${JSON.stringify(id)},\n      accountId: account.accountId,\n      name: account.displayName ?? ${JSON.stringify(displayName)},\n\n      async start() {\n        running = true;\n        console.log(\"[${id}] adapter running.\");\n      },\n\n      async stop() {\n        running = false;\n      },\n\n      isRunning() {\n        return running;\n      },\n\n      async sendMessage(msg) {\n        if (!running) throw new Error(\"[${id}] adapter not running.\");\n        // TODO: send msg.text to msg.chatId with the platform SDK.\n        console.log(\"[${id}] sendMessage\", { chatId: msg.chatId, text: msg.text });\n        return { messageId: randomUUID() };\n      },\n\n      async sendDirectReply(chatId, text, options) {\n        if (!running) return;\n        // TODO: send pairing/no-route messages directly to chatId.\n        console.log(\"[${id}] sendDirectReply\", { chatId, text, options });\n      },\n\n      get onMessage() {\n        return onMessageHandler;\n      },\n\n      set onMessage(handler) {\n        onMessageHandler = handler;\n      }\n    };\n  },\n\n  messageActions: {\n    describeMessageTool() {\n      return { actions: [\"send\"] };\n    },\n\n    async handleAction({ adapter, request, formatText }) {\n      if (request.action !== \"send\") {\n        return \`Error: Action \"\${request.action}\" is not supported on ${id}.\`;\n      }\n      const text = request.message?.trim();\n      if (!text) return \"Error: send requires message.\";\n\n      const formatted = formatText(text);\n      const result = await adapter.sendMessage({\n        channel: ${JSON.stringify(id)},\n        chatId: request.chatId,\n        text: formatted.text,\n        parseMode: formatted.parseMode,\n        replyToMessageId: request.replyToMessageId,\n        threadId: request.threadId\n      });\n      return \`Message sent to ${id} (message_id: \${result.messageId})\`;\n    }\n  }\n};\n\nexport default channelPlugin;\n`,
+);
+
+console.log(`Created ${id} channel plugin skeleton at ${dir}`);
+console.log("Next: copy accounts.example.json to accounts.json and fill config secrets.");


### PR DESCRIPTION
## Summary
- add bundled `creating-channels` skill for all agents
- seed Tutor-only `deploying-agents` and `building-a-claw` skills into MemFS
- update Tutor onboarding prompts to route deployment/channel/CLaw questions to the right skills

## Tests
- `bun test src/agent/personality.test.ts src/agent/client-skills.test.ts`
- `bunx --bun @biomejs/biome@2.2.5 check src/agent/personality.ts src/agent/personality.test.ts src/agent/memory-filesystem.ts src/index.ts src/headless.ts`

## Notes
- `bun run typecheck` still fails on pre-existing `src/web/generate-diff-viewer.ts` missing `@pierre/diffs` types/module errors.