### PR TITLE
feat(models): add GLM-5.2

### DIFF
--- a/src/models.json
+++ b/src/models.json
@@ -1612,6 +1612,32 @@
       }
     },
     {
+      "id": "glm-5.2",
+      "handle": "zai/glm-5.2",
+      "label": "GLM-5.2",
+      "description": "zAI's latest coding model",
+      "isFeatured": true,
+      "free": true,
+      "updateArgs": {
+        "context_window": 1000000,
+        "max_output_tokens": 131072,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "glm-5.2-1m",
+      "handle": "zai/glm-5.2[1m]",
+      "label": "GLM-5.2 1M",
+      "description": "zAI's latest coding model with 1M context",
+      "isFeatured": true,
+      "free": true,
+      "updateArgs": {
+        "context_window": 1000000,
+        "max_output_tokens": 131072,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "minimax-m3",
       "handle": "minimax/MiniMax-M3",
       "label": "MiniMax M3",


### PR DESCRIPTION
Problem

GLM-5.2 is not in the Letta Code curated model registry, so the BYOK recommended tab cannot show it even after Core exposes the Z.ai handles.

Approach

This adds Z.ai GLM-5.2 and GLM-5.2 1M model presets to src/models.json using the documented coding-plan context window and max-token limit. Both entries stay BYOK/free, matching the existing GLM-5.1 entry, and keep parallel tool calls enabled.

Before

The BYOK selector could only match Z.ai BYOK handles back to the GLM-5.1 registry entry.

After

Once Core returns the GLM-5.2 BYOK handles, the normal BYOK tab can show curated GLM-5.2 entries instead of requiring the raw BYOK all tab.

Validation

- python3 -m json.tool src/models.json
- bun test src/tools/model-provider-detection.test.ts
- bun test src/cli/components/ModelSelector-byok-custom-provider.test.tsx src/providers/byok-provider-aliases.test.ts

Related

- Core/provider PR: https://github.com/letta-ai/letta-cloud/pull/12334
- Z.ai GLM Coding Plan model-switching docs: https://docs.z.ai/devpack/latest-model.md
