### PR TITLE
fix(telemetry): route Desktop metadata through proxy

### DIFF
--- a/src/backend/api/metadata.ts
+++ b/src/backend/api/metadata.ts
@@ -1,5 +1,5 @@
 import { LETTA_CLOUD_API_URL } from "@/auth/oauth";
-import { apiRequest } from "./request";
+import { apiRequest, getApiRequestConfig } from "./request";
 
 export interface BalanceMetadata {
   total_balance: number;
@@ -35,33 +35,32 @@ function isLoopbackHostname(hostname: string): boolean {
   );
 }
 
-function getDesktopProxyMetadataBaseUrl(): string | undefined {
+function isLoopbackBaseUrl(baseUrl: string): boolean {
+  try {
+    const parsed = new URL(baseUrl);
+    return isLoopbackHostname(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
+async function getMetadataRequestConfig(
+  apiKey: string | undefined,
+): Promise<{ baseUrl: string; apiKey: string }> {
   if (
     !isDesktopListenerRuntime() ||
     process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL === "1"
   ) {
-    return undefined;
+    return { baseUrl: LETTA_CLOUD_API_URL, apiKey: apiKey ?? "" };
   }
 
-  const baseUrl = process.env.LETTA_BASE_URL?.trim();
-  if (!baseUrl) {
-    return undefined;
+  const config = await getApiRequestConfig();
+
+  if (isLoopbackBaseUrl(config.baseUrl)) {
+    return config;
   }
 
-  try {
-    const parsed = new URL(baseUrl);
-    if (!isLoopbackHostname(parsed.hostname)) {
-      return undefined;
-    }
-  } catch {
-    return undefined;
-  }
-
-  return baseUrl.replace(/\/+$/, "");
-}
-
-function getMetadataBaseUrl(): string {
-  return getDesktopProxyMetadataBaseUrl() ?? LETTA_CLOUD_API_URL;
+  return { baseUrl: LETTA_CLOUD_API_URL, apiKey: apiKey ?? "" };
 }
 
 export async function submitFeedbackMetadata(
@@ -69,9 +68,9 @@ export async function submitFeedbackMetadata(
   deviceId: string,
   payload: Record<string, unknown>,
 ): Promise<void> {
+  const config = await getMetadataRequestConfig(apiKey);
   await apiRequest<void>("POST", "/v1/metadata/feedback", payload, {
-    baseUrl: getMetadataBaseUrl(),
-    apiKey: apiKey ?? "",
+    ...config,
     headers: {
       "X-Letta-Code-Device-ID": deviceId,
     },
@@ -84,9 +83,9 @@ export async function submitTelemetryMetadata(
   payload: Record<string, unknown>,
   options?: { signal?: AbortSignal },
 ): Promise<void> {
+  const config = await getMetadataRequestConfig(apiKey);
   await apiRequest<void>("POST", "/v1/metadata/telemetry", payload, {
-    baseUrl: getMetadataBaseUrl(),
-    apiKey: apiKey ?? "",
+    ...config,
     headers: {
       "X-Letta-Code-Device-ID": deviceId,
     },

--- a/src/backend/api/metadata.ts
+++ b/src/backend/api/metadata.ts
@@ -21,13 +21,56 @@ export async function getBillingTier(): Promise<string | null> {
   }
 }
 
+function isDesktopListenerRuntime(): boolean {
+  return process.env.LETTA_DESKTOP_DEBUG_PANEL === "1";
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return (
+    normalized === "localhost" ||
+    normalized === "0.0.0.0" ||
+    normalized === "::1" ||
+    normalized.startsWith("127.")
+  );
+}
+
+function getDesktopProxyMetadataBaseUrl(): string | undefined {
+  if (
+    !isDesktopListenerRuntime() ||
+    process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL === "1"
+  ) {
+    return undefined;
+  }
+
+  const baseUrl = process.env.LETTA_BASE_URL?.trim();
+  if (!baseUrl) {
+    return undefined;
+  }
+
+  try {
+    const parsed = new URL(baseUrl);
+    if (!isLoopbackHostname(parsed.hostname)) {
+      return undefined;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return baseUrl.replace(/\/+$/, "");
+}
+
+function getMetadataBaseUrl(): string {
+  return getDesktopProxyMetadataBaseUrl() ?? LETTA_CLOUD_API_URL;
+}
+
 export async function submitFeedbackMetadata(
   apiKey: string | undefined,
   deviceId: string,
   payload: Record<string, unknown>,
 ): Promise<void> {
   await apiRequest<void>("POST", "/v1/metadata/feedback", payload, {
-    baseUrl: LETTA_CLOUD_API_URL,
+    baseUrl: getMetadataBaseUrl(),
     apiKey: apiKey ?? "",
     headers: {
       "X-Letta-Code-Device-ID": deviceId,
@@ -42,7 +85,7 @@ export async function submitTelemetryMetadata(
   options?: { signal?: AbortSignal },
 ): Promise<void> {
   await apiRequest<void>("POST", "/v1/metadata/telemetry", payload, {
-    baseUrl: LETTA_CLOUD_API_URL,
+    baseUrl: getMetadataBaseUrl(),
     apiKey: apiKey ?? "",
     headers: {
       "X-Letta-Code-Device-ID": deviceId,

--- a/src/backend/api/metadata.ts
+++ b/src/backend/api/metadata.ts
@@ -1,4 +1,5 @@
 import { LETTA_CLOUD_API_URL } from "@/auth/oauth";
+import { isLoopbackUrl } from "@/utils/url";
 import { apiRequest, getApiRequestConfig } from "./request";
 
 export interface BalanceMetadata {
@@ -25,25 +26,6 @@ function isDesktopListenerRuntime(): boolean {
   return process.env.LETTA_DESKTOP_DEBUG_PANEL === "1";
 }
 
-function isLoopbackHostname(hostname: string): boolean {
-  const normalized = hostname.toLowerCase();
-  return (
-    normalized === "localhost" ||
-    normalized === "0.0.0.0" ||
-    normalized === "::1" ||
-    normalized.startsWith("127.")
-  );
-}
-
-function isLoopbackBaseUrl(baseUrl: string): boolean {
-  try {
-    const parsed = new URL(baseUrl);
-    return isLoopbackHostname(parsed.hostname);
-  } catch {
-    return false;
-  }
-}
-
 async function getMetadataRequestConfig(
   apiKey: string | undefined,
 ): Promise<{ baseUrl: string; apiKey: string }> {
@@ -56,7 +38,7 @@ async function getMetadataRequestConfig(
 
   const config = await getApiRequestConfig();
 
-  if (isLoopbackBaseUrl(config.baseUrl)) {
+  if (isLoopbackUrl(config.baseUrl)) {
     return config;
   }
 

--- a/src/telemetry/flush-auth.test.ts
+++ b/src/telemetry/flush-auth.test.ts
@@ -249,4 +249,30 @@ describe("telemetry flush auth", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  test("desktop listener telemetry routes through the local proxy", async () => {
+    setEnvVar("LETTA_DESKTOP_DEBUG_PANEL", "1");
+    setEnvVar("LETTA_BASE_URL", "http://localhost:54321/");
+    setEnvVar("LETTA_API_KEY", "desktop-session-token");
+
+    const fetchMock = mock(
+      async (url: string | URL | Request, init?: RequestInit) => {
+        expect(String(url)).toBe(
+          "http://localhost:54321/v1/metadata/telemetry",
+        );
+        expect(init?.headers).toMatchObject({
+          Authorization: "Bearer desktop-session-token",
+        });
+        return new Response(null, { status: 200 });
+      },
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    telemetry.trackReflectionStart("step-count", {
+      conversationId: "conv-1",
+    });
+    await telemetry.flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/telemetry/flush-auth.test.ts
+++ b/src/telemetry/flush-auth.test.ts
@@ -209,7 +209,10 @@ describe("telemetry flush auth", () => {
   test("self-hosted users still send usage telemetry", async () => {
     setEnvVar("LETTA_BASE_URL", "http://localhost:8283");
 
-    const fetchMock = mock(async () => new Response(null, { status: 200 }));
+    const fetchMock = mock(async (url: string | URL | Request) => {
+      expect(String(url)).toBe("https://api.letta.com/v1/metadata/telemetry");
+      return new Response(null, { status: 200 });
+    });
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
     settingsManager.getSettingsWithSecureTokens = mock(async () => ({
@@ -252,7 +255,7 @@ describe("telemetry flush auth", () => {
 
   test("desktop listener telemetry routes through the local proxy", async () => {
     setEnvVar("LETTA_DESKTOP_DEBUG_PANEL", "1");
-    setEnvVar("LETTA_BASE_URL", "http://localhost:54321/");
+    setEnvVar("LETTA_BASE_URL", "http://localhost:54321");
     setEnvVar("LETTA_API_KEY", "desktop-session-token");
 
     const fetchMock = mock(

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -6,6 +6,7 @@ import { submitTelemetryMetadata } from "@/backend/api/metadata";
 import { isLocalBackendEnvEnabled } from "@/backend/local/paths";
 import { settingsManager } from "@/settings-manager";
 import { debugLogFile } from "@/utils/debug";
+import { isLoopbackHostname, parseUrl } from "@/utils/url";
 import { getVersion } from "@/version";
 
 export type TelemetrySurface =
@@ -130,38 +131,16 @@ export function getListenerTelemetrySurface(
     : "letta_code_cli_server";
 }
 
-function parseTelemetryUrl(value: string): URL | null {
-  try {
-    return new URL(value);
-  } catch {
-    try {
-      return new URL(`http://${value}`);
-    } catch {
-      return null;
-    }
-  }
-}
-
 function isTelemetryCloudServerUrl(serverUrl: string): boolean {
-  const parsed = parseTelemetryUrl(serverUrl);
-  const cloud = parseTelemetryUrl(LETTA_CLOUD_API_URL);
+  const parsed = parseUrl(serverUrl, { allowMissingProtocol: true });
+  const cloud = parseUrl(LETTA_CLOUD_API_URL, { allowMissingProtocol: true });
   return Boolean(parsed && cloud && parsed.hostname === cloud.hostname);
 }
 
-function isLoopbackHost(hostname: string): boolean {
-  const normalized = hostname.toLowerCase();
-  return (
-    normalized === "localhost" ||
-    normalized === "0.0.0.0" ||
-    normalized === "::1" ||
-    normalized.startsWith("127.")
-  );
-}
-
 function isLikelyDeprecatedDockerBackendUrl(serverUrl: string): boolean {
-  const parsed = parseTelemetryUrl(serverUrl);
+  const parsed = parseUrl(serverUrl, { allowMissingProtocol: true });
   return Boolean(
-    parsed && isLoopbackHost(parsed.hostname) && parsed.port === "8283",
+    parsed && isLoopbackHostname(parsed.hostname) && parsed.port === "8283",
   );
 }
 

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { isLoopbackHostname, isLoopbackUrl, parseUrl } from "@/utils/url";
+
+describe("url utilities", () => {
+  test("detects loopback hostnames", () => {
+    expect(isLoopbackHostname("localhost")).toBe(true);
+    expect(isLoopbackHostname("127.0.0.1")).toBe(true);
+    expect(isLoopbackHostname("127.42.0.9")).toBe(true);
+    expect(isLoopbackHostname("::1")).toBe(true);
+    expect(isLoopbackHostname("api.letta.com")).toBe(false);
+  });
+
+  test("parses URLs with optional http fallback", () => {
+    expect(parseUrl("https://api.letta.com")?.hostname).toBe("api.letta.com");
+    expect(parseUrl("localhost:8283")).toBeNull();
+    expect(
+      parseUrl("localhost:8283", { allowMissingProtocol: true })?.hostname,
+    ).toBe("localhost");
+  });
+
+  test("detects loopback URLs", () => {
+    expect(isLoopbackUrl("http://localhost:54321")).toBe(true);
+    expect(isLoopbackUrl("http://127.0.0.1:54321")).toBe(true);
+    expect(isLoopbackUrl("https://api.letta.com")).toBe(false);
+    expect(isLoopbackUrl("localhost:54321")).toBe(false);
+    expect(
+      isLoopbackUrl("localhost:54321", { allowMissingProtocol: true }),
+    ).toBe(true);
+  });
+});

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,48 @@
+export function parseUrl(
+  value: string,
+  options: { allowMissingProtocol?: boolean } = {},
+): URL | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.hostname) {
+      return parsed;
+    }
+  } catch {
+    // Fall through to optional http:// fallback below.
+  }
+
+  if (!options.allowMissingProtocol) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(`http://${trimmed}`);
+    return parsed.hostname ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return (
+    normalized === "localhost" ||
+    normalized === "0.0.0.0" ||
+    normalized === "::1" ||
+    normalized === "[::1]" ||
+    normalized.startsWith("127.")
+  );
+}
+
+export function isLoopbackUrl(
+  value: string,
+  options: { allowMissingProtocol?: boolean } = {},
+): boolean {
+  const parsed = parseUrl(value, options);
+  return Boolean(parsed && isLoopbackHostname(parsed.hostname));
+}


### PR DESCRIPTION
## Summary
- route Desktop listener telemetry/feedback metadata through `LETTA_BASE_URL` when it points at the local Desktop proxy
- keep non-Desktop and Desktop local-backend metadata on the existing Cloud metadata path
- add coverage that Desktop reflection telemetry flushes to the local proxy instead of sending the local session token directly to Cloud

## Context
Code Desktop starts the normal listener with `LETTA_BASE_URL=http://localhost:<proxy>` and `LETTA_API_KEY=<local desktop session token>`. Telemetry previously forced `LETTA_CLOUD_API_URL`, so it sent the local proxy token directly to `api.letta.com`, producing Cloud 401s or device-id fallback attribution instead of real Cloud user/org attribution.

Routing through the Desktop proxy lets the proxy replace local auth with the real Cloud credential before forwarding to `/v1/metadata/telemetry` or `/v1/metadata/feedback`.

Manual `/reflect` command wiring is intentionally out of scope for this PR.

## Test plan
- `bun test src/telemetry/flush-auth.test.ts`
- `bun run typecheck`
- `bun run check`
- `git diff --check`