### PR TITLE
fix(memfs): surface dirty markdown encoding issues

### DIFF
--- a/src/agent/memory-git.auth.test.ts
+++ b/src/agent/memory-git.auth.test.ts
@@ -105,6 +105,13 @@ function commitFile(repo: string, fileName: string, content: string): string {
   return git(repo, "rev-parse HEAD").trim();
 }
 
+function utf16leWithBom(content: string): Buffer {
+  return Buffer.concat([
+    Buffer.from([0xff, 0xfe]),
+    Buffer.from(content, "utf16le"),
+  ]);
+}
+
 function makeSyncedRepo(): { repo: string; remote: string } {
   const remote = makeBareGitRepo();
   const repo = makeGitRepo();
@@ -604,6 +611,30 @@ describe("assertMemoryRepoCleanForWrite", () => {
     await assertMemoryRepoCleanForWrite(repo);
 
     expect(git(repo, "rev-parse HEAD").trim()).toBe(originalSha);
+  });
+
+  test("reports UTF-16 dirty markdown files", async () => {
+    const { repo } = makeSyncedRepo();
+    writeFileSync(
+      join(repo, "human.md"),
+      utf16leWithBom("---\ndescription: human\n---\nnotes"),
+    );
+
+    await expect(assertMemoryRepoCleanForWrite(repo)).rejects.toThrow(
+      /Dirty markdown encoding issue\(s\): human\.md has UTF-16LE BOM/,
+    );
+  });
+
+  test("reports NUL bytes in dirty markdown files", async () => {
+    const { repo } = makeSyncedRepo();
+    writeFileSync(
+      join(repo, "human.md"),
+      Buffer.from("---\ndescription: human\n---\nnotes", "utf16le"),
+    );
+
+    await expect(assertMemoryRepoCleanForWrite(repo)).rejects.toThrow(
+      /Dirty markdown encoding issue\(s\): human\.md contains NUL bytes, possibly UTF-16/,
+    );
   });
 });
 

--- a/src/agent/memory-git.ts
+++ b/src/agent/memory-git.ts
@@ -30,6 +30,7 @@ import {
   getMemfsServerUrl,
 } from "@/backend/api/memfs-git-proxy";
 import { debugLog, debugWarn } from "@/utils/debug";
+import { getUtf16Bom } from "@/utils/text-files";
 import { getScopedMemoryFilesystemRoot } from "./memory-filesystem";
 
 const execFile = promisify(execFileCb);
@@ -1343,10 +1344,76 @@ export async function assertMemoryRepoCleanForWrite(
 ): Promise<void> {
   const status = await runGit(memoryDir, ["status", "--porcelain"]);
   if (status.stdout.trim().length > 0) {
+    const encodingDetails = describeDirtyMarkdownEncodingIssues(
+      memoryDir,
+      status.stdout,
+    );
     throw new Error(
-      "Memory repo has uncommitted changes. Commit, discard, or sync them before using memory tools.",
+      "Memory repo has uncommitted changes. Commit, discard, or sync them before using memory tools." +
+        encodingDetails,
     );
   }
+}
+
+function describeDirtyMarkdownEncodingIssues(
+  memoryDir: string,
+  porcelainStatus: string,
+): string {
+  const issues = porcelainStatus
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0)
+    .map(parsePorcelainPath)
+    .filter((path): path is string => path !== null && path.endsWith(".md"))
+    .map((path) => describeMarkdownEncodingIssue(memoryDir, path))
+    .filter((issue): issue is string => issue !== null);
+
+  if (issues.length === 0) {
+    return "";
+  }
+
+  return ` Dirty markdown encoding issue(s): ${issues.join("; ")}.`;
+}
+
+function parsePorcelainPath(line: string): string | null {
+  if (line.length < 4) {
+    return null;
+  }
+
+  const status = line.slice(0, 2);
+  if (status === " D" || status === "D " || status === "DD") {
+    return null;
+  }
+
+  const rawPath = line.slice(3);
+  const renameSeparator = " -> ";
+  const path = rawPath.includes(renameSeparator)
+    ? (rawPath.split(renameSeparator).pop() ?? rawPath)
+    : rawPath;
+
+  return path.replace(/^"|"$/g, "");
+}
+
+function describeMarkdownEncodingIssue(
+  memoryDir: string,
+  relativePath: string,
+): string | null {
+  const filePath = join(memoryDir, relativePath);
+  if (!existsSync(filePath)) {
+    return null;
+  }
+
+  const bytes = readFileSync(filePath);
+  const utf16Bom = getUtf16Bom(bytes);
+  if (utf16Bom) {
+    return `${relativePath} has ${utf16Bom} BOM`;
+  }
+
+  if (bytes.includes(0)) {
+    return `${relativePath} contains NUL bytes, possibly UTF-16`;
+  }
+
+  return null;
 }
 
 export async function commitMemoryWrite(


### PR DESCRIPTION
## summary
- add dirty markdown encoding details to assertMemoryRepoCleanForWrite errors
- report UTF-16 BOMs and NUL bytes for dirty .md files
- add regression coverage for both cases

## testing
- not run, bun is not installed in this Windows environment