### PR TITLE
fix(channels): forward plugin MessageChannel fields

### DIFF
--- a/src/channels/message-channel.test.ts
+++ b/src/channels/message-channel.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   __testOverrideLoadChannelAccounts,
@@ -6,6 +9,8 @@ import {
   clearChannelAccountStores,
   upsertChannelAccount,
 } from "@/channels/accounts";
+import { __testOverrideChannelsRoot } from "@/channels/config";
+import { __testClearUserChannelPluginCache } from "@/channels/plugin-registry";
 import { ChannelRegistry, getChannelRegistry } from "@/channels/registry";
 import { clearAllRoutes, setRouteInMemory } from "@/channels/routing";
 import {
@@ -18,6 +23,8 @@ import type { ChannelAdapter } from "@/channels/types";
 import { message_channel } from "@/tools/impl/message-channel";
 
 describe("MessageChannel", () => {
+  let userChannelsRoot: string | null = null;
+
   afterEach(async () => {
     const registry = getChannelRegistry();
     if (registry) {
@@ -30,7 +37,77 @@ describe("MessageChannel", () => {
     __testOverrideSaveChannelAccounts(null);
     __testOverrideLoadTargetStore(null);
     __testOverrideSaveTargetStore(null);
+    __testOverrideChannelsRoot(null);
+    __testClearUserChannelPluginCache();
+    if (userChannelsRoot) {
+      rmSync(userChannelsRoot, { recursive: true, force: true });
+      userChannelsRoot = null;
+    }
   });
+
+  function writeDemoChannelPlugin(): void {
+    userChannelsRoot = mkdtempSync(
+      join(tmpdir(), "letta-message-channel-fields-"),
+    );
+    __testOverrideChannelsRoot(userChannelsRoot);
+    __testClearUserChannelPluginCache();
+
+    const channelDir = join(userChannelsRoot, "demo");
+    mkdirSync(channelDir, { recursive: true });
+    writeFileSync(
+      join(channelDir, "channel.json"),
+      `${JSON.stringify(
+        {
+          id: "demo",
+          displayName: "Demo Chat",
+          entry: "./plugin.mjs",
+          runtimePackages: [],
+          runtimeModules: [],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    writeFileSync(
+      join(channelDir, "plugin.mjs"),
+      `export const channelPlugin = {
+        metadata: {
+          id: "demo",
+          displayName: "Demo Chat",
+          runtimePackages: [],
+          runtimeModules: []
+        },
+        createAdapter(account) {
+          return {
+            id: "demo:" + account.accountId,
+            channelId: "demo",
+            accountId: account.accountId,
+            name: "Demo Chat",
+            start: async () => {},
+            stop: async () => {},
+            isRunning: () => true,
+            sendMessage: async () => ({ messageId: "demo-1" }),
+            sendDirectReply: async () => {}
+          };
+        },
+        messageActions: {
+          describeMessageTool() {
+            return {
+              actions: ["send"],
+              schema: {
+                properties: {
+                  reply_to_uri: { type: "string" },
+                  control_command: { type: "string" },
+                  dry_run: { type: "boolean" }
+                }
+              }
+            };
+          },
+          handleAction: async ({ request }) => JSON.stringify(request.pluginFields ?? {})
+        }
+      };\n`,
+    );
+  }
 
   function installChannelStateTestOverrides(): void {
     __testOverrideLoadChannelAccounts(() => []);
@@ -810,6 +887,57 @@ describe("MessageChannel", () => {
       "Error: Multiple proactive Slack accounts are available for this agent. Pass accountId.",
     );
     expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  test("passes plugin-owned MessageChannel fields to channel actions", async () => {
+    writeDemoChannelPlugin();
+    const registry = new ChannelRegistry();
+
+    const adapter: ChannelAdapter = {
+      id: "demo:account-1",
+      channelId: "demo",
+      accountId: "account-1",
+      name: "Demo Chat",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "demo-msg-1" }),
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+
+    setRouteInMemory("demo", {
+      accountId: "account-1",
+      chatId: "room-1",
+      chatType: "channel",
+      threadId: null,
+      agentId: "agent-1",
+      conversationId: "default",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const result = await message_channel({
+      action: "send",
+      channel: "demo",
+      chat_id: "room-1",
+      accountId: "account-1",
+      message: "hello",
+      reply_to_uri: "at://did:plc:example/app.bsky.feed.post/3exampleparent",
+      control_command: "",
+      dry_run: true,
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    } as unknown as Parameters<typeof message_channel>[0]);
+
+    expect(JSON.parse(result)).toEqual({
+      dry_run: true,
+      reply_to_uri: "at://did:plc:example/app.bsky.feed.post/3exampleparent",
+    });
   });
 
   test("rejects proactive Slack sends for accounts outside the agent scope", async () => {

--- a/src/channels/plugin-types.ts
+++ b/src/channels/plugin-types.ts
@@ -229,6 +229,8 @@ export interface ChannelMessageActionRequest {
   mediaPath?: string;
   filename?: string;
   title?: string;
+  /** Channel/plugin-owned tool fields advertised through describeMessageTool(). */
+  pluginFields?: Record<string, unknown>;
 }
 
 export interface ChannelResolvedMessageTarget {

--- a/src/tools/impl/message-channel.ts
+++ b/src/tools/impl/message-channel.ts
@@ -548,7 +548,27 @@ interface NormalizedMessageChannelInput {
   mediaPath?: string;
   filename?: string;
   title?: string;
+  pluginFields?: Record<string, unknown>;
 }
+
+const MESSAGE_CHANNEL_CORE_ARG_KEYS = new Set([
+  "action",
+  "channel",
+  "chat_id",
+  "target",
+  "accountId",
+  "message",
+  "replyTo",
+  "threadId",
+  "messageId",
+  "emoji",
+  "remove",
+  "media",
+  "filename",
+  "title",
+  "parentScope",
+  "channelTurnSources",
+]);
 
 interface ResolvedMessageChannelExecutionContext {
   request: ChannelMessageActionRequest;
@@ -604,6 +624,23 @@ function normalizeMessageAction(
   return normalized.length > 0 ? normalized : null;
 }
 
+function collectPluginFields(
+  args: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const pluginFields: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(args)) {
+    if (MESSAGE_CHANNEL_CORE_ARG_KEYS.has(key) || value === undefined) {
+      continue;
+    }
+    if (typeof value === "string" && value.trim().length === 0) {
+      continue;
+    }
+    pluginFields[key] = value;
+  }
+
+  return Object.keys(pluginFields).length > 0 ? pluginFields : undefined;
+}
+
 function normalizeMessageChannelInput(
   args: MessageChannelArgs,
 ): NormalizedMessageChannelInput | string {
@@ -649,6 +686,9 @@ function normalizeMessageChannelInput(
     mediaPath: firstNonEmptyString(args.media),
     filename: firstNonEmptyString(args.filename),
     title: firstNonEmptyString(args.title),
+    pluginFields: collectPluginFields(
+      args as unknown as Record<string, unknown>,
+    ),
   };
 }
 
@@ -670,6 +710,7 @@ function buildMessageChannelRequest(
     mediaPath: input.mediaPath,
     filename: input.filename,
     title: input.title,
+    pluginFields: input.pluginFields,
   };
 }
 


### PR DESCRIPTION
## Summary
- Preserve plugin-owned MessageChannel fields through normalization as `pluginFields`
- Include forwarded plugin fields in `ChannelMessageActionRequest`
- Add a user-channel regression test covering dynamic fields like `reply_to_uri`

## Tests
- `bun test src/channels/message-channel.test.ts`
- `bun run check`