### PR TITLE
fix(channels): clarify pairing instructions

### DIFF
--- a/src/channels/discord-registry.test.ts
+++ b/src/channels/discord-registry.test.ts
@@ -382,7 +382,7 @@ describe("discord channel registry", () => {
     ]);
   });
 
-  test("keeps explicit Discord pairing DMs on the pairing flow", async () => {
+  test("keeps explicit Discord pairing DMs on the pairing flow with the account agent", async () => {
     const { ChannelRegistry } = await import("@/channels/registry");
     const registry = new ChannelRegistry();
     const replies: Array<{ chatId: string; text: string }> = [];
@@ -410,6 +410,14 @@ describe("discord channel registry", () => {
     expect(deliveries).toHaveLength(0);
     expect(replies).toHaveLength(1);
     expect(replies[0]?.text).toContain("Pairing code:");
+    expect(replies[0]?.text).toContain(
+      "letta channels pair --channel discord --code",
+    );
+    expect(replies[0]?.text).toContain("--agent agent-1");
+    expect(replies[0]?.text).not.toContain("--agent <agent-id>");
+    expect(replies[0]?.text).not.toContain(
+      "Find your agent id with letta agents list.",
+    );
   });
 
   // ── Delivery-time gate (allowed_channels re-check) ─────────────

--- a/src/channels/registry-community-copy.test.ts
+++ b/src/channels/registry-community-copy.test.ts
@@ -7,13 +7,16 @@ const { buildPairingInstructions, buildUnboundRouteInstructions } =
 describe("registry copy: first-party channels", () => {
   test("pairing instructions point at both desktop UI and CLI for telegram", () => {
     const text = buildPairingInstructions("telegram", "ABC123");
-    expect(text).toContain("open Channels >");
+    expect(text).toContain("Connect this chat to a Letta agent.");
+    expect(text).toContain("In Letta Code: open Channels > Telegram");
     expect(text).toContain("Telegram");
     expect(text).toContain("Pairing code: ABC123");
+    expect(text).toContain("CLI on the listener machine:");
     expect(text).toContain(
       "letta channels pair --channel telegram --code ABC123 --agent <agent-id>",
     );
-    expect(text).toContain("Find your agent id with letta agents list.");
+    expect(text).toContain("Find the target agent with: letta agents list");
+    expect(text).toContain("This code expires in 15 minutes.");
     expect(text).not.toContain("(community channel)");
   });
 
@@ -30,23 +33,26 @@ describe("registry copy: first-party channels", () => {
     const text = buildPairingInstructions("discord", "XYZ789", {
       agentId: "agent-discord",
     });
-    expect(text).toContain("open Channels >");
+    expect(text).toContain("In Letta Code: open Channels > Discord");
     expect(text).toContain("Discord");
     expect(text).toContain(
       "letta channels pair --channel discord --code XYZ789 --agent agent-discord",
     );
     expect(text).not.toContain("--agent <agent-id>");
-    expect(text).not.toContain("Find your agent id with letta agents list.");
+    expect(text).not.toContain("Find the target agent with: letta agents list");
   });
 
   test("first-party whatsapp pairing includes the desktop and CLI paths", () => {
-    const text = buildPairingInstructions("whatsapp", "W123");
-    expect(text).toContain("open Channels >");
+    const text = buildPairingInstructions("whatsapp", "W123", {
+      agentId: "agent-whatsapp",
+    });
+    expect(text).toContain("In Letta Code: open Channels > WhatsApp");
     expect(text).toContain("WhatsApp");
     expect(text).toContain("Pairing code: W123");
     expect(text).toContain(
-      "letta channels pair --channel whatsapp --code W123 --agent <agent-id>",
+      "letta channels pair --channel whatsapp --code W123 --agent agent-whatsapp",
     );
+    expect(text).not.toContain("--agent <agent-id>");
   });
 
   test("first-party whatsapp unbound route keeps the desktop wording", () => {
@@ -88,13 +94,14 @@ describe("registry copy: community channels", () => {
 
   test("pairing instructions surface the CLI command for community channels", () => {
     const text = buildPairingInstructions("custom-chat", "ABC123");
-    expect(text).toContain("isn't connected to a Letta agent yet");
-    expect(text).toContain("Pairing code: ABC123 (expires in 15 minutes)");
-    expect(text).toContain("On the machine where your listener runs");
+    expect(text).toContain("Connect this chat to a Letta agent.");
+    expect(text).toContain("Pairing code: ABC123");
+    expect(text).toContain("CLI on the listener machine:");
     expect(text).toContain(
       "letta channels pair --channel custom-chat --code ABC123 --agent <agent-id>",
     );
-    expect(text).toContain("Find your agent id with letta agents list.");
+    expect(text).toContain("Find the target agent with: letta agents list");
+    expect(text).toContain("This code expires in 15 minutes.");
     expect(text).not.toContain("open Channels >");
     expect(text).not.toContain("(community channel)");
     // Hard-stop against shipping the wrong subcommand again.
@@ -123,12 +130,12 @@ describe("registry copy: community channels", () => {
       "letta channels pair --channel custom-chat --code ABC123 --agent agent-custom",
     );
     expect(text).not.toContain("--agent <agent-id>");
-    expect(text).not.toContain("Find your agent id with letta agents list.");
+    expect(text).not.toContain("Find the target agent with: letta agents list");
   });
 
   test("any non-first-party channel id triggers community copy", () => {
     const text = buildPairingInstructions("imessage", "QQQ");
-    expect(text).toContain("isn't connected to a Letta agent yet");
+    expect(text).toContain("Connect this chat to a Letta agent.");
     expect(text).toContain(
       "letta channels pair --channel imessage --code QQQ --agent <agent-id>",
     );

--- a/src/channels/registry-community-copy.test.ts
+++ b/src/channels/registry-community-copy.test.ts
@@ -26,13 +26,17 @@ describe("registry copy: first-party channels", () => {
     expect(text).not.toContain("(community channel)");
   });
 
-  test("first-party discord pairing includes the CLI pairing command", () => {
-    const text = buildPairingInstructions("discord", "XYZ789");
+  test("first-party discord pairing uses a configured agent in the CLI command", () => {
+    const text = buildPairingInstructions("discord", "XYZ789", {
+      agentId: "agent-discord",
+    });
     expect(text).toContain("open Channels >");
     expect(text).toContain("Discord");
     expect(text).toContain(
-      "letta channels pair --channel discord --code XYZ789 --agent <agent-id>",
+      "letta channels pair --channel discord --code XYZ789 --agent agent-discord",
     );
+    expect(text).not.toContain("--agent <agent-id>");
+    expect(text).not.toContain("Find your agent id with letta agents list.");
   });
 
   test("first-party whatsapp pairing includes the desktop and CLI paths", () => {
@@ -109,6 +113,17 @@ describe("registry copy: community channels", () => {
     expect(text).not.toContain("(community channel)");
     expect(text).not.toContain("paste a route");
     expect(text).not.toContain("routing.yaml");
+  });
+
+  test("community pairing instructions use a configured agent when available", () => {
+    const text = buildPairingInstructions("custom-chat", "ABC123", {
+      agentId: "agent-custom",
+    });
+    expect(text).toContain(
+      "letta channels pair --channel custom-chat --code ABC123 --agent agent-custom",
+    );
+    expect(text).not.toContain("--agent <agent-id>");
+    expect(text).not.toContain("Find your agent id with letta agents list.");
   });
 
   test("any non-first-party channel id triggers community copy", () => {

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -141,25 +141,35 @@ export function buildPairingInstructions(
   const displayName = channelDisplayName(channelId);
   const configuredAgentId = normalizeAgentId(options.agentId);
   const pairingCommand = `letta channels pair --channel ${channelId} --code ${code} --agent ${configuredAgentId ?? "<agent-id>"}`;
-  const agentLookupInstruction = configuredAgentId
-    ? ""
-    : "\n\nFind your agent id with letta agents list.";
+  const agentLookupLines = configuredAgentId
+    ? []
+    : ["Find the target agent with: letta agents list"];
   if (!isFirstPartyChannelPlugin(channelId)) {
-    return (
-      `This chat isn't connected to a Letta agent yet.\n\n` +
-      `Pairing code: ${code} (expires in 15 minutes)\n\n` +
-      `On the machine where your listener runs:\n\n` +
-      pairingCommand +
-      agentLookupInstruction
-    );
+    return [
+      "Connect this chat to a Letta agent.",
+      "",
+      `Pairing code: ${code}`,
+      "",
+      "CLI on the listener machine:",
+      pairingCommand,
+      ...agentLookupLines,
+      "",
+      "This code expires in 15 minutes.",
+    ].join("\n");
   }
-  return (
-    `To connect this chat to a Letta agent, either open Channels > ${displayName} in Letta Code and finish connecting this chat there, or run this on the machine where your listener runs:\n\n` +
-    pairingCommand +
-    agentLookupInstruction +
-    `\n\nPairing code: ${code}\n\n` +
-    `This code expires in 15 minutes.`
-  );
+  return [
+    "Connect this chat to a Letta agent.",
+    "",
+    `Pairing code: ${code}`,
+    "",
+    `In Letta Code: open Channels > ${displayName} and approve this pending chat.`,
+    "",
+    "CLI on the listener machine:",
+    pairingCommand,
+    ...agentLookupLines,
+    "",
+    "This code expires in 15 minutes.",
+  ].join("\n");
 }
 
 export function buildUnboundRouteInstructions(

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -103,28 +103,61 @@ function channelDisplayName(channelId: string): string {
   }
 }
 
+type PairingInstructionOptions = {
+  agentId?: string | null;
+};
+
+type AccountAgentIdSource = {
+  agentId?: string | null;
+  binding?: {
+    agentId?: string | null;
+  };
+};
+
+function normalizeAgentId(agentId: string | null | undefined): string | null {
+  const normalized = agentId?.trim();
+  return normalized ? normalized : null;
+}
+
+function getConfiguredAgentId(config: unknown): string | null {
+  if (!config || typeof config !== "object") {
+    return null;
+  }
+  const source = config as AccountAgentIdSource;
+  return (
+    normalizeAgentId(source.agentId) ??
+    normalizeAgentId(source.binding?.agentId)
+  );
+}
+
 export function buildPairingInstructions(
   channelId: string,
   code: string,
+  options: PairingInstructionOptions = {},
 ): string {
   // First-party channels (telegram, slack, discord) have UI in the desktop
   // app. Community plugins installed under ~/.letta/channels/<id>/ do not,
   // so the user-facing copy needs to point at CLI commands instead.
   const displayName = channelDisplayName(channelId);
+  const configuredAgentId = normalizeAgentId(options.agentId);
+  const pairingCommand = `letta channels pair --channel ${channelId} --code ${code} --agent ${configuredAgentId ?? "<agent-id>"}`;
+  const agentLookupInstruction = configuredAgentId
+    ? ""
+    : "\n\nFind your agent id with letta agents list.";
   if (!isFirstPartyChannelPlugin(channelId)) {
     return (
       `This chat isn't connected to a Letta agent yet.\n\n` +
       `Pairing code: ${code} (expires in 15 minutes)\n\n` +
       `On the machine where your listener runs:\n\n` +
-      `letta channels pair --channel ${channelId} --code ${code} --agent <agent-id>\n\n` +
-      `Find your agent id with letta agents list.`
+      pairingCommand +
+      agentLookupInstruction
     );
   }
   return (
     `To connect this chat to a Letta agent, either open Channels > ${displayName} in Letta Code and finish connecting this chat there, or run this on the machine where your listener runs:\n\n` +
-    `letta channels pair --channel ${channelId} --code ${code} --agent <agent-id>\n\n` +
-    `Find your agent id with letta agents list.\n\n` +
-    `Pairing code: ${code}\n\n` +
+    pairingCommand +
+    agentLookupInstruction +
+    `\n\nPairing code: ${code}\n\n` +
     `This code expires in 15 minutes.`
   );
 }
@@ -1477,7 +1510,9 @@ export class ChannelRegistry {
         });
         await adapter.sendDirectReply(
           msg.chatId,
-          buildPairingInstructions(msg.channel, code),
+          buildPairingInstructions(msg.channel, code, {
+            agentId: getConfiguredAgentId(config),
+          }),
         );
         return;
       }


### PR DESCRIPTION
## Summary
- Rewrite shared channel pairing instructions so every channel leads with the pairing code, shows the expiration clearly, and separates the Letta Code UI path from the listener-machine CLI path.
- Use a configured account/binding agent ID in the CLI command when one is available, so Discord/WhatsApp/etc. pairing replies do not ask users to look up an agent unnecessarily.
- Keep the placeholder agent ID and agent-list guidance for unbound accounts and community channels without a configured agent.

## Test plan
- [x] bun test src/channels/registry-community-copy.test.ts src/channels/discord-registry.test.ts
- [x] bun run check

👾 Generated with [Letta Code](https://letta.com)
