### PR TITLE
feat(slack): transcribe inbound audio attachments

### DIFF
--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -293,6 +293,8 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
     (next as SlackChannelAccount).defaultPermissionMode =
       (migrated as ChannelDefaultPermissionMode | null) ??
       DEFAULT_SLACK_PERMISSION_MODE;
+    (next as SlackChannelAccount).transcribeVoice =
+      (next as SlackChannelAccount).transcribeVoice === true;
   }
   if (isDiscordChannelAccount(next)) {
     const migrated = migratePermissionMode(
@@ -402,6 +404,7 @@ function makeDefaultLegacyAccount(
     allowedUsers: [...config.allowedUsers],
     agentId: null,
     defaultPermissionMode: DEFAULT_SLACK_PERMISSION_MODE,
+    transcribeVoice: config.transcribeVoice === true,
     createdAt: now,
     updatedAt: now,
   };

--- a/src/channels/config.ts
+++ b/src/channels/config.ts
@@ -164,6 +164,7 @@ const slackConfigCodec: ChannelConfigCodec<SlackChannelConfig> = {
       appToken: String(parsed.app_token ?? ""),
       dmPolicy: (parsed.dm_policy as DmPolicy) ?? "pairing",
       allowedUsers: (parsed.allowed_users as string[]) ?? [],
+      transcribeVoice: parsed.transcribe_voice === true,
     };
   },
 };

--- a/src/channels/service.test.ts
+++ b/src/channels/service.test.ts
@@ -723,6 +723,59 @@ describe("channel service", () => {
     );
   });
 
+  test("slack live account helpers preserve the transcribeVoice opt-in in snapshots", () => {
+    const created = createChannelAccountLive(
+      "slack",
+      {
+        displayName: "Slack Voice",
+        enabled: true,
+        dmPolicy: "pairing",
+        config: {
+          bot_token: "xoxb-test-token",
+          app_token: "xapp-test-token",
+          mode: "socket",
+          agent_id: null,
+          transcribe_voice: true,
+        },
+      },
+      { accountId: "slack-voice" },
+    );
+
+    expect(created).toEqual(
+      expect.objectContaining({
+        accountId: "slack-voice",
+        transcribeVoice: true,
+        config: expect.objectContaining({
+          transcribe_voice: true,
+        }),
+      }),
+    );
+
+    const updated = updateChannelAccountLive("slack", "slack-voice", {
+      config: { transcribe_voice: false },
+    });
+
+    expect(updated).toEqual(
+      expect.objectContaining({
+        accountId: "slack-voice",
+        transcribeVoice: false,
+        config: expect.objectContaining({
+          transcribe_voice: false,
+        }),
+      }),
+    );
+
+    expect(getChannelConfigSnapshot("slack", "slack-voice")).toEqual(
+      expect.objectContaining({
+        accountId: "slack-voice",
+        transcribeVoice: false,
+        config: expect.objectContaining({
+          transcribe_voice: false,
+        }),
+      }),
+    );
+  });
+
   test("config helpers reject ambiguous singleton lookups once multiple accounts exist", () => {
     createChannelAccountLive(
       "telegram",

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -581,6 +581,7 @@ function toAccountSnapshot(account: ChannelAccount): ChannelAccountSnapshot {
     agentId: account.agentId,
     defaultPermissionMode:
       account.defaultPermissionMode ?? DEFAULT_SLACK_PERMISSION_MODE,
+    transcribeVoice: account.transcribeVoice === true,
     createdAt: account.createdAt,
     updatedAt: account.updatedAt,
   };
@@ -685,6 +686,7 @@ function createAccountFromPatch(
     agentId: normalizedPatch.agentId ?? null,
     defaultPermissionMode:
       normalizedPatch.defaultPermissionMode ?? DEFAULT_SLACK_PERMISSION_MODE,
+    transcribeVoice: normalizedPatch.transcribeVoice === true,
     dmPolicy: normalizedPatch.dmPolicy ?? "open",
     allowedUsers: normalizedPatch.allowedUsers ?? [],
     createdAt: now,
@@ -820,6 +822,8 @@ function mergeAccountPatch(
       normalizedPatch.defaultPermissionMode ??
       existing.defaultPermissionMode ??
       DEFAULT_SLACK_PERMISSION_MODE,
+    transcribeVoice:
+      normalizedPatch.transcribeVoice ?? existing.transcribeVoice ?? false,
     dmPolicy: normalizedPatch.dmPolicy ?? existing.dmPolicy,
     allowedUsers: normalizedPatch.allowedUsers ?? existing.allowedUsers,
     updatedAt: nextUpdatedAt,
@@ -961,6 +965,7 @@ export function getChannelConfigSnapshot(
     agentId: account.agentId,
     defaultPermissionMode:
       account.defaultPermissionMode ?? DEFAULT_SLACK_PERMISSION_MODE,
+    transcribeVoice: account.transcribeVoice === true,
   };
 }
 

--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -889,6 +889,67 @@ test("slack adapter allows file_share subtype messages through", async () => {
   );
 });
 
+test("slack adapter passes transcription opt-in to message and app_mention media resolution", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+    transcribeVoice: true,
+  });
+
+  adapter.onMessage = mock(async () => {});
+
+  await adapter.start();
+  const app = FakeSlackApp.instances[0];
+  const messageHandler = app?.messageHandler;
+  const mentionHandler = app?.eventHandlers.get("app_mention");
+  if (!messageHandler || !mentionHandler) {
+    throw new Error("Expected Slack handlers");
+  }
+
+  await messageHandler({
+    message: {
+      channel: "D123",
+      user: "U123",
+      text: "voice note",
+      ts: "1712800000.000100",
+    },
+  });
+  await mentionHandler({
+    event: {
+      channel: "C123",
+      user: "U123",
+      text: "<@U0AS42PTEAX> voice note",
+      ts: "1712800000.000101",
+    },
+  });
+
+  expect(resolveSlackInboundAttachmentsMock).toHaveBeenCalledTimes(2);
+  expect(resolveSlackInboundAttachmentsMock).toHaveBeenNthCalledWith(
+    1,
+    expect.objectContaining({
+      accountId: "slack-test-account",
+      token: "xoxb-test-token-1234567890",
+      rawEvent: expect.objectContaining({ channel: "D123" }),
+      transcribeVoice: true,
+    }),
+  );
+  expect(resolveSlackInboundAttachmentsMock).toHaveBeenNthCalledWith(
+    2,
+    expect.objectContaining({
+      accountId: "slack-test-account",
+      token: "xoxb-test-token-1234567890",
+      rawEvent: expect.objectContaining({ channel: "C123" }),
+      transcribeVoice: true,
+    }),
+  );
+});
+
 test("slack adapter allows thread_broadcast subtype replies through", async () => {
   const adapter = createSlackAdapter({
     ...slackAccountDefaults,

--- a/src/channels/slack-media.test.ts
+++ b/src/channels/slack-media.test.ts
@@ -1,4 +1,45 @@
-import { expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { __testOverrideChannelsRoot } from "@/channels/config";
+
+const originalFetch = globalThis.fetch;
+const originalOpenAIKey = process.env.OPENAI_API_KEY;
+let channelsRoot: string | null = null;
+
+function requestUrl(input: unknown): string {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.href;
+  }
+  const maybeRequest = input as { url?: unknown };
+  if (typeof maybeRequest.url === "string") {
+    return maybeRequest.url;
+  }
+  return String(input);
+}
+
+beforeEach(async () => {
+  channelsRoot = await mkdtemp(join(tmpdir(), "letta-slack-media-"));
+  __testOverrideChannelsRoot(channelsRoot);
+});
+
+afterEach(async () => {
+  globalThis.fetch = originalFetch;
+  if (originalOpenAIKey === undefined) {
+    delete process.env.OPENAI_API_KEY;
+  } else {
+    process.env.OPENAI_API_KEY = originalOpenAIKey;
+  }
+  __testOverrideChannelsRoot(null);
+  if (channelsRoot) {
+    await rm(channelsRoot, { recursive: true, force: true });
+    channelsRoot = null;
+  }
+});
 
 async function loadSlackMediaModule() {
   return import(
@@ -81,4 +122,132 @@ test("resolveSlackChannelHistory retains forwarded Slack attachment text", async
       ts: "1712790000.000090",
     },
   ]);
+});
+
+test("resolveSlackInboundAttachments transcribes inbound audio when opted in", async () => {
+  process.env.OPENAI_API_KEY = "test-openai-key";
+  const fetchMock = mock(async (input: unknown) => {
+    const url = requestUrl(input);
+    if (url === "https://files.slack.com/files-pri/T123-F123/voice.ogg") {
+      return new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { "content-type": "application/octet-stream" },
+      });
+    }
+    if (url === "https://api.openai.com/v1/audio/transcriptions") {
+      return new Response(JSON.stringify({ text: "hello slack voice" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+  const { resolveSlackInboundAttachments } = await loadSlackMediaModule();
+  const attachments = await resolveSlackInboundAttachments({
+    accountId: "slack-bot",
+    token: "xoxb-test-token",
+    transcribeVoice: true,
+    rawEvent: {
+      files: [
+        {
+          id: "F123",
+          name: "voice.ogg",
+          mimetype: "audio/ogg",
+          size: 3,
+          url_private_download:
+            "https://files.slack.com/files-pri/T123-F123/voice.ogg",
+        },
+      ],
+    },
+  });
+
+  expect(attachments).toHaveLength(1);
+  expect(attachments[0]).toMatchObject({
+    id: "F123",
+    kind: "audio",
+    mimeType: "audio/ogg",
+    transcription: "hello slack voice",
+  });
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+});
+
+test("resolveSlackInboundAttachments does not transcribe audio when disabled", async () => {
+  process.env.OPENAI_API_KEY = "test-openai-key";
+  const fetchMock = mock(
+    async () =>
+      new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { "content-type": "audio/ogg" },
+      }),
+  );
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+  const { resolveSlackInboundAttachments } = await loadSlackMediaModule();
+  const attachments = await resolveSlackInboundAttachments({
+    accountId: "slack-bot",
+    token: "xoxb-test-token",
+    transcribeVoice: false,
+    rawEvent: {
+      files: [
+        {
+          id: "F123",
+          name: "voice.ogg",
+          mimetype: "audio/ogg",
+          size: 3,
+          url_private_download:
+            "https://files.slack.com/files-pri/T123-F123/voice.ogg",
+        },
+      ],
+    },
+  });
+
+  expect(attachments).toHaveLength(1);
+  expect(attachments[0]).toMatchObject({
+    id: "F123",
+    kind: "audio",
+    mimeType: "audio/ogg",
+  });
+  expect(attachments[0]?.transcription).toBeUndefined();
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+test("resolveSlackInboundAttachments records transcription errors when OpenAI is not configured", async () => {
+  delete process.env.OPENAI_API_KEY;
+  const fetchMock = mock(
+    async () =>
+      new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { "content-type": "audio/ogg" },
+      }),
+  );
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+  const { resolveSlackInboundAttachments } = await loadSlackMediaModule();
+  const attachments = await resolveSlackInboundAttachments({
+    accountId: "slack-bot",
+    token: "xoxb-test-token",
+    transcribeVoice: true,
+    rawEvent: {
+      files: [
+        {
+          id: "F123",
+          name: "voice.ogg",
+          mimetype: "audio/ogg",
+          size: 3,
+          url_private_download:
+            "https://files.slack.com/files-pri/T123-F123/voice.ogg",
+        },
+      ],
+    },
+  });
+
+  expect(attachments).toHaveLength(1);
+  expect(attachments[0]).toMatchObject({
+    id: "F123",
+    kind: "audio",
+    transcriptionError: "OPENAI_API_KEY not set; transcription skipped.",
+  });
+  expect(fetchMock).toHaveBeenCalledTimes(1);
 });

--- a/src/channels/slack-media.test.ts
+++ b/src/channels/slack-media.test.ts
@@ -128,7 +128,7 @@ test("resolveSlackInboundAttachments transcribes inbound audio when opted in", a
   process.env.OPENAI_API_KEY = "test-openai-key";
   const fetchMock = mock(async (input: unknown) => {
     const url = requestUrl(input);
-    if (url === "https://files.slack.com/files-pri/T123-F123/voice.ogg") {
+    if (url === "https://files.slack.com/files-pri/T123-F123/voice.m4a") {
       return new Response(new Uint8Array([1, 2, 3]), {
         status: 200,
         headers: { "content-type": "application/octet-stream" },
@@ -153,11 +153,10 @@ test("resolveSlackInboundAttachments transcribes inbound audio when opted in", a
       files: [
         {
           id: "F123",
-          name: "voice.ogg",
-          mimetype: "audio/ogg",
+          name: "voice.m4a",
           size: 3,
           url_private_download:
-            "https://files.slack.com/files-pri/T123-F123/voice.ogg",
+            "https://files.slack.com/files-pri/T123-F123/voice.m4a",
         },
       ],
     },
@@ -167,7 +166,7 @@ test("resolveSlackInboundAttachments transcribes inbound audio when opted in", a
   expect(attachments[0]).toMatchObject({
     id: "F123",
     kind: "audio",
-    mimeType: "audio/ogg",
+    mimeType: "audio/mp4",
     transcription: "hello slack voice",
   });
   expect(fetchMock).toHaveBeenCalledTimes(2);

--- a/src/channels/slack/account-config.ts
+++ b/src/channels/slack/account-config.ts
@@ -12,6 +12,7 @@ const SLACK_CONFIG_KEYS = new Set([
   "mode",
   "agent_id",
   "default_permission_mode",
+  "transcribe_voice",
 ]);
 
 function isString(value: unknown): value is string {
@@ -20,6 +21,10 @@ function isString(value: unknown): value is string {
 
 function isNullableString(value: unknown): value is string | null {
   return value === null || typeof value === "string";
+}
+
+function isBoolean(value: unknown): value is boolean {
+  return value === true || value === false;
 }
 
 function isDefaultPermissionMode(
@@ -50,7 +55,9 @@ export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannel
         (config.mode === undefined || config.mode === "socket") &&
         (config.agent_id === undefined || isNullableString(config.agent_id)) &&
         (config.default_permission_mode === undefined ||
-          isDefaultPermissionMode(config.default_permission_mode))
+          isDefaultPermissionMode(config.default_permission_mode)) &&
+        (config.transcribe_voice === undefined ||
+          isBoolean(config.transcribe_voice))
       );
     },
 
@@ -69,6 +76,9 @@ export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannel
               config.default_permission_mode,
             ) as SlackDefaultPermissionMode)
           : undefined,
+        transcribeVoice: isBoolean(config.transcribe_voice)
+          ? config.transcribe_voice
+          : undefined,
       };
     },
 
@@ -80,6 +90,7 @@ export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannel
         agent_id: account.agentId,
         default_permission_mode:
           account.defaultPermissionMode ?? DEFAULT_SLACK_PERMISSION_MODE,
+        transcribe_voice: account.transcribeVoice === true,
       };
     },
 
@@ -91,6 +102,7 @@ export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannel
         agent_id: account.agentId,
         default_permission_mode:
           account.defaultPermissionMode ?? DEFAULT_SLACK_PERMISSION_MODE,
+        transcribe_voice: account.transcribeVoice === true,
       };
     },
 

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -968,6 +968,7 @@ export function createSlackAdapter(
         accountId: config.accountId,
         token: config.botToken,
         rawEvent: message,
+        transcribeVoice: config.transcribeVoice === true,
       });
       const chatType = resolveSlackChatType(channelId);
       const threadId =
@@ -1108,6 +1109,7 @@ export function createSlackAdapter(
           accountId: config.accountId,
           token: config.botToken,
           rawEvent: event,
+          transcribeVoice: config.transcribeVoice === true,
         }),
         raw: event,
       };

--- a/src/channels/slack/media.ts
+++ b/src/channels/slack/media.ts
@@ -405,10 +405,13 @@ async function downloadSlackAttachment(params: {
     `${params.file.id ?? "attachment"}${extensionForMimeType(params.file.mimetype)}`;
   const responseMimeType =
     response.headers.get("content-type")?.split(";")[0]?.trim() || undefined;
+  const fileMimeType = params.file.mimetype;
   const preferredMimeType =
     responseMimeType && !isGenericSlackMimeType(responseMimeType)
       ? responseMimeType
-      : (params.file.mimetype ?? responseMimeType);
+      : fileMimeType && !isGenericSlackMimeType(fileMimeType)
+        ? fileMimeType
+        : undefined;
   const mimeType = resolveMimeType(hintedName, preferredMimeType);
   const fileName =
     extname(hintedName) || !mimeType

--- a/src/channels/slack/media.ts
+++ b/src/channels/slack/media.ts
@@ -235,6 +235,21 @@ function extensionForMimeType(mimeType?: string): string {
       return ".gif";
     case "image/webp":
       return ".webp";
+    case "audio/aac":
+      return ".aac";
+    case "audio/m4a":
+    case "audio/mp4":
+    case "audio/x-m4a":
+      return ".m4a";
+    case "audio/mpeg":
+      return ".mp3";
+    case "audio/ogg":
+      return ".ogg";
+    case "audio/wav":
+    case "audio/x-wav":
+      return ".wav";
+    case "audio/webm":
+      return ".webm";
     case "application/pdf":
       return ".pdf";
     case "text/plain":
@@ -259,6 +274,20 @@ function resolveMimeType(name: string, fallback?: string): string | undefined {
       return "image/gif";
     case ".webp":
       return "image/webp";
+    case ".aac":
+      return "audio/aac";
+    case ".m4a":
+      return "audio/mp4";
+    case ".mp3":
+      return "audio/mpeg";
+    case ".oga":
+    case ".ogg":
+    case ".opus":
+      return "audio/ogg";
+    case ".wav":
+      return "audio/wav";
+    case ".webm":
+      return "audio/webm";
     case ".pdf":
       return "application/pdf";
     case ".txt":
@@ -267,6 +296,33 @@ function resolveMimeType(name: string, fallback?: string): string | undefined {
     default:
       return undefined;
   }
+}
+
+function isGenericSlackMimeType(mimeType?: string): boolean {
+  const normalized = mimeType?.trim().toLowerCase();
+  return (
+    normalized === "application/octet-stream" ||
+    normalized === "binary/octet-stream"
+  );
+}
+
+function resolveAttachmentKind(
+  mimeType?: string,
+): ChannelMessageAttachment["kind"] {
+  const normalized = mimeType?.toLowerCase();
+  if (!normalized) {
+    return "file";
+  }
+  if (normalized.startsWith("image/")) {
+    return "image";
+  }
+  if (normalized.startsWith("audio/")) {
+    return "audio";
+  }
+  if (normalized.startsWith("video/")) {
+    return "video";
+  }
+  return "file";
 }
 
 async function fetchWithSlackAuth(
@@ -325,6 +381,7 @@ async function downloadSlackAttachment(params: {
   accountId: string;
   token: string;
   file: SlackFileLike;
+  transcribeVoice?: boolean;
 }): Promise<ChannelMessageAttachment | null> {
   const url = params.file.url_private_download ?? params.file.url_private;
   if (!url) {
@@ -346,10 +403,13 @@ async function downloadSlackAttachment(params: {
     params.file.name ??
     basename(new URL(url).pathname) ??
     `${params.file.id ?? "attachment"}${extensionForMimeType(params.file.mimetype)}`;
-  const mimeType = resolveMimeType(
-    hintedName,
-    response.headers.get("content-type")?.split(";")[0] ?? params.file.mimetype,
-  );
+  const responseMimeType =
+    response.headers.get("content-type")?.split(";")[0]?.trim() || undefined;
+  const preferredMimeType =
+    responseMimeType && !isGenericSlackMimeType(responseMimeType)
+      ? responseMimeType
+      : (params.file.mimetype ?? responseMimeType);
+  const mimeType = resolveMimeType(hintedName, preferredMimeType);
   const fileName =
     extname(hintedName) || !mimeType
       ? hintedName
@@ -360,8 +420,8 @@ async function downloadSlackAttachment(params: {
     buffer,
   });
 
-  const kind = mimeType?.startsWith("image/") ? "image" : "file";
-  return {
+  const kind = resolveAttachmentKind(mimeType);
+  const attachment: ChannelMessageAttachment = {
     id: params.file.id,
     name: fileName,
     mimeType,
@@ -370,6 +430,31 @@ async function downloadSlackAttachment(params: {
     localPath,
     ...(kind === "image" ? { imageDataBase64: buffer.toString("base64") } : {}),
   };
+
+  // Slack voice memos arrive as ordinary audio files/file_share events, so the
+  // opt-in applies to inbound audio attachments generally.
+  if (kind === "audio" && params.transcribeVoice) {
+    const { isTranscriptionConfigured, transcribeAudioFile } = await import(
+      "@/channels/transcription/index"
+    );
+    if (isTranscriptionConfigured()) {
+      const result = await transcribeAudioFile(localPath);
+      if (result.success && result.text) {
+        attachment.transcription = result.text;
+      } else if (result.error) {
+        attachment.transcriptionError = result.error;
+        console.warn(
+          `[Slack] Audio transcription failed for ${fileName}:`,
+          result.error,
+        );
+      }
+    } else {
+      attachment.transcriptionError =
+        "OPENAI_API_KEY not set; transcription skipped.";
+    }
+  }
+
+  return attachment;
 }
 
 function collectSlackFiles(rawEvent: unknown): SlackFileLike[] {
@@ -423,6 +508,7 @@ export async function resolveSlackInboundAttachments(params: {
   accountId: string;
   token: string;
   rawEvent: unknown;
+  transcribeVoice?: boolean;
 }): Promise<ChannelMessageAttachment[]> {
   const files = collectSlackFiles(params.rawEvent);
   if (files.length === 0) {
@@ -435,6 +521,7 @@ export async function resolveSlackInboundAttachments(params: {
         accountId: params.accountId,
         token: params.token,
         file,
+        transcribeVoice: params.transcribeVoice,
       }).catch(() => null),
     ),
   );

--- a/src/channels/slack/setup.ts
+++ b/src/channels/slack/setup.ts
@@ -84,6 +84,11 @@ export async function runSlackSetup(): Promise<boolean> {
         .filter(Boolean);
     }
 
+    const transcriptionInput = await rl.question(
+      "Auto-transcribe inbound Slack audio attachments when OPENAI_API_KEY is set? [y/N]: ",
+    );
+    const transcribeVoice = /^(y|yes)$/i.test(transcriptionInput.trim());
+
     const now = new Date().toISOString();
     let displayName: string | undefined;
     try {
@@ -100,6 +105,7 @@ export async function runSlackSetup(): Promise<boolean> {
       appToken,
       agentId: null,
       defaultPermissionMode: DEFAULT_SLACK_PERMISSION_MODE,
+      transcribeVoice,
       dmPolicy: policy,
       allowedUsers,
       createdAt: now,

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -333,6 +333,8 @@ export interface SlackChannelConfig {
   appToken: string;
   dmPolicy: DmPolicy;
   allowedUsers: string[];
+  /** When true and OPENAI_API_KEY is set, inbound audio attachments are auto-transcribed. */
+  transcribeVoice?: boolean;
 }
 
 export interface DiscordChannelConfig {
@@ -452,6 +454,8 @@ export interface SlackChannelAccount extends ChannelAccountBase {
   appToken: string;
   agentId: string | null;
   defaultPermissionMode: SlackDefaultPermissionMode;
+  /** When true and OPENAI_API_KEY is set, inbound audio attachments are auto-transcribed. */
+  transcribeVoice?: boolean;
   /**
    * Optional debounce window (ms) for inbound messages. When greater than
    * `0`, short back-to-back messages from the same sender in the same


### PR DESCRIPTION
## Summary
- Add Slack `transcribe_voice` config/account support and setup prompt.
- Classify inbound Slack audio/video attachments by MIME/extension and transcribe audio when explicitly opted in.
- Pass the opt-in through Slack DM and app_mention media resolution with focused coverage for config snapshots and transcription behavior.

## Test plan
- [x] bun test src/channels/slack-media.test.ts src/channels/slack-adapter.test.ts src/channels/service.test.ts
- [x] bun run check

👾 Generated with [Letta Code](https://letta.com)