### PR TITLE
fix(cron): preserve channel scope for scheduled runs

### DIFF
--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -819,6 +819,7 @@ export class ChannelRegistry {
     agentId: string,
     conversationId: string,
     accountId?: string,
+    threadId?: string | null,
   ): ChannelRoute | null {
     const normalizedAccountId = accountId?.trim();
     const matches = getRoutesForChannel(channel).filter(
@@ -826,6 +827,9 @@ export class ChannelRegistry {
         route.chatId === chatId &&
         route.agentId === agentId &&
         route.conversationId === conversationId &&
+        (threadId === undefined
+          ? true
+          : (route.threadId ?? null) === (threadId ?? null)) &&
         (!normalizedAccountId ||
           (route.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID) ===
             normalizedAccountId) &&

--- a/src/cli/subcommands/cron.ts
+++ b/src/cli/subcommands/cron.ts
@@ -25,6 +25,8 @@ import {
   parseEvery,
   readCronRunLogEntriesPage,
 } from "@/cron";
+import { extractCronChannelTargetsFromInheritedContext } from "@/cron/channel-targets";
+import { LETTA_INHERITED_CHANNEL_CONTEXT_ENV } from "@/runtime-context";
 
 // ── Usage ───────────────────────────────────────────────────────────
 
@@ -126,6 +128,11 @@ function handleAdd(values: ReturnType<typeof parseCronArgs>["values"]): number {
   }
 
   const conversationId = getConversationId(values.conversation);
+  const channelTargets = extractCronChannelTargetsFromInheritedContext({
+    raw: process.env[LETTA_INHERITED_CHANNEL_CONTEXT_ENV],
+    agentId,
+    conversationId,
+  });
 
   // Determine schedule type
   const everyValue = values.every;
@@ -197,6 +204,7 @@ function handleAdd(values: ReturnType<typeof parseCronArgs>["values"]): number {
       cron,
       recurring,
       prompt,
+      channel_targets: channelTargets,
       scheduled_for: scheduledFor,
     });
 
@@ -207,6 +215,7 @@ function handleAdd(values: ReturnType<typeof parseCronArgs>["values"]): number {
       recurring: result.task.recurring,
       agent_id: result.task.agent_id,
       conversation_id: result.task.conversation_id,
+      channel_targets: result.task.channel_targets,
       created_at: result.task.created_at,
     };
 

--- a/src/cron/channel-targets.test.ts
+++ b/src/cron/channel-targets.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { ChannelRegistry, getChannelRegistry } from "@/channels/registry";
+import {
+  __testOverrideLoadRoutes,
+  __testOverrideSaveRoutes,
+  clearAllRoutes,
+  setRouteInMemory,
+} from "@/channels/routing";
+import type { ChannelAdapter } from "@/channels/types";
+import {
+  extractCronChannelTargetsFromInheritedContext,
+  resolveCronChannelContext,
+} from "./channel-targets";
+import type { CronTask } from "./cron-file";
+
+function createAdapter(params: {
+  channelId: string;
+  accountId: string;
+  running?: boolean;
+}): ChannelAdapter {
+  return {
+    id: `${params.channelId}:${params.accountId}`,
+    channelId: params.channelId,
+    accountId: params.accountId,
+    name: params.channelId,
+    start: async () => {},
+    stop: async () => {},
+    isRunning: () => params.running ?? true,
+    sendMessage: async () => ({ messageId: "msg-1" }),
+    sendDirectReply: async () => {},
+  };
+}
+
+function createTask(overrides: Partial<CronTask> = {}): CronTask {
+  return {
+    id: "cron-1",
+    agent_id: "agent-1",
+    conversation_id: "default",
+    name: "Daily check",
+    description: "Check status",
+    cron: "0 9 * * *",
+    timezone: "UTC",
+    recurring: true,
+    prompt: "send status",
+    channel_targets: [],
+    status: "active",
+    created_at: "2026-04-11T00:00:00.000Z",
+    expires_at: null,
+    last_fired_at: null,
+    fire_count: 0,
+    cancel_reason: null,
+    jitter_offset_ms: 0,
+    last_run_at: null,
+    last_run_outcome: null,
+    last_run_reason: null,
+    last_run_error: null,
+    last_missed_at: null,
+    missed_count: 0,
+    failed_count: 0,
+    scheduled_for: null,
+    fired_at: null,
+    missed_at: null,
+    ...overrides,
+  };
+}
+
+describe("cron channel targets", () => {
+  afterEach(async () => {
+    const registry = getChannelRegistry();
+    if (registry) {
+      await registry.stopAll();
+    }
+    clearAllRoutes();
+    __testOverrideLoadRoutes(null);
+    __testOverrideSaveRoutes(null);
+  });
+
+  test("extracts current channel turn sources for the scheduled scope", () => {
+    const raw = JSON.stringify({
+      channelTurnSources: [
+        {
+          channel: "slack",
+          accountId: "acct-slack",
+          chatId: "C123",
+          chatType: "channel",
+          threadId: "1712790000.000050",
+          messageId: "1712790000.000050",
+          agentId: "agent-1",
+          conversationId: "default",
+        },
+        {
+          channel: "slack",
+          accountId: "acct-other",
+          chatId: "C999",
+          agentId: "agent-2",
+          conversationId: "default",
+        },
+      ],
+    });
+
+    expect(
+      extractCronChannelTargetsFromInheritedContext({
+        raw,
+        agentId: "agent-1",
+        conversationId: "default",
+      }),
+    ).toEqual([
+      {
+        channel: "slack",
+        account_id: "acct-slack",
+        chat_id: "C123",
+        chat_type: "channel",
+        thread_id: "1712790000.000050",
+        message_id: "1712790000.000050",
+      },
+    ]);
+  });
+
+  test("resolves only stored targets with live routes", () => {
+    __testOverrideLoadRoutes(() => null);
+    __testOverrideSaveRoutes(() => {});
+    const registry = new ChannelRegistry();
+    registry.registerAdapter(
+      createAdapter({ channelId: "slack", accountId: "acct-slack" }),
+    );
+    registry.registerAdapter(
+      createAdapter({
+        channelId: "discord",
+        accountId: "acct-discord",
+        running: false,
+      }),
+    );
+
+    setRouteInMemory("slack", {
+      accountId: "acct-slack",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "default",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+    setRouteInMemory("discord", {
+      accountId: "acct-discord",
+      chatId: "room-123",
+      chatType: "channel",
+      agentId: "agent-1",
+      conversationId: "default",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const context = resolveCronChannelContext({
+      task: createTask({
+        channel_targets: [
+          {
+            channel: "slack",
+            account_id: "acct-slack",
+            chat_id: "C123",
+          },
+          {
+            channel: "discord",
+            account_id: "acct-discord",
+            chat_id: "room-123",
+          },
+        ],
+      }),
+      conversationId: "default",
+    });
+
+    expect(context.channelToolScope).toEqual({
+      channels: [{ channelId: "slack", accountId: "acct-slack" }],
+    });
+    expect(context.channelTurnSources).toEqual([
+      {
+        channel: "slack",
+        accountId: "acct-slack",
+        chatId: "C123",
+        chatType: "channel",
+        threadId: "1712790000.000050",
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    ]);
+  });
+});

--- a/src/cron/channel-targets.ts
+++ b/src/cron/channel-targets.ts
@@ -1,0 +1,294 @@
+import type { MessageChannelToolDiscoveryScope } from "@/channels/message-tool";
+import { getChannelRegistry } from "@/channels/registry";
+import { getRoutesForChannel, loadRoutes } from "@/channels/routing";
+import type { ChannelChatType, ChannelTurnSource } from "@/channels/types";
+import { isRecord } from "@/utils/type-guards";
+
+export interface CronChannelTarget {
+  channel: string;
+  account_id?: string | null;
+  chat_id: string;
+  chat_type?: ChannelChatType;
+  thread_id?: string | null;
+  message_id?: string | null;
+}
+
+export interface ResolvedCronChannelContext {
+  channelToolScope: MessageChannelToolDiscoveryScope;
+  channelTurnSources: ChannelTurnSource[];
+  availableTargets: CronChannelTarget[];
+}
+
+interface CronChannelTaskScope {
+  agent_id: string;
+  channel_targets: CronChannelTarget[];
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function normalizeNullableString(value: unknown): string | null | undefined {
+  if (value === null) {
+    return null;
+  }
+  return asNonEmptyString(value) ?? undefined;
+}
+
+function normalizeChatType(value: unknown): ChannelChatType | undefined {
+  return value === "direct" || value === "channel" ? value : undefined;
+}
+
+function targetKey(target: CronChannelTarget): string {
+  return [
+    target.channel,
+    target.account_id ?? "",
+    target.chat_id,
+    target.chat_type ?? "",
+    target.thread_id ?? "",
+    target.message_id ?? "",
+  ].join("\t");
+}
+
+export function normalizeCronChannelTargets(
+  value: unknown,
+): CronChannelTarget[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const targets: CronChannelTarget[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry)) {
+      continue;
+    }
+
+    const channel = asNonEmptyString(entry.channel);
+    const chatId = asNonEmptyString(entry.chat_id ?? entry.chatId);
+    if (!channel || !chatId) {
+      continue;
+    }
+
+    const target: CronChannelTarget = {
+      channel,
+      chat_id: chatId,
+      ...(normalizeNullableString(entry.account_id ?? entry.accountId) !==
+      undefined
+        ? {
+            account_id: normalizeNullableString(
+              entry.account_id ?? entry.accountId,
+            ),
+          }
+        : {}),
+      ...(normalizeChatType(entry.chat_type ?? entry.chatType)
+        ? { chat_type: normalizeChatType(entry.chat_type ?? entry.chatType) }
+        : {}),
+      ...(normalizeNullableString(entry.thread_id ?? entry.threadId) !==
+      undefined
+        ? {
+            thread_id: normalizeNullableString(
+              entry.thread_id ?? entry.threadId,
+            ),
+          }
+        : {}),
+      ...(normalizeNullableString(entry.message_id ?? entry.messageId) !==
+      undefined
+        ? {
+            message_id: normalizeNullableString(
+              entry.message_id ?? entry.messageId,
+            ),
+          }
+        : {}),
+    };
+
+    const key = targetKey(target);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    targets.push(target);
+  }
+
+  return targets;
+}
+
+function channelTurnSourceToCronTarget(
+  source: Record<string, unknown>,
+): CronChannelTarget | null {
+  const channel = asNonEmptyString(source.channel);
+  const chatId = asNonEmptyString(source.chatId);
+  if (!channel || !chatId) {
+    return null;
+  }
+
+  return {
+    channel,
+    chat_id: chatId,
+    ...(asNonEmptyString(source.accountId)
+      ? { account_id: asNonEmptyString(source.accountId) }
+      : {}),
+    ...(normalizeChatType(source.chatType)
+      ? { chat_type: normalizeChatType(source.chatType) }
+      : {}),
+    ...(normalizeNullableString(source.threadId) !== undefined
+      ? { thread_id: normalizeNullableString(source.threadId) }
+      : {}),
+    ...(asNonEmptyString(source.messageId)
+      ? { message_id: asNonEmptyString(source.messageId) }
+      : {}),
+  };
+}
+
+export function extractCronChannelTargetsFromInheritedContext(params: {
+  raw: string | undefined;
+  agentId: string;
+  conversationId: string;
+}): CronChannelTarget[] {
+  if (!params.raw) {
+    return [];
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(params.raw);
+    if (!isRecord(parsed) || !Array.isArray(parsed.channelTurnSources)) {
+      return [];
+    }
+
+    const targets: CronChannelTarget[] = [];
+    for (const entry of parsed.channelTurnSources) {
+      if (
+        !isRecord(entry) ||
+        entry.agentId !== params.agentId ||
+        entry.conversationId !== params.conversationId
+      ) {
+        continue;
+      }
+      const target = channelTurnSourceToCronTarget(entry);
+      if (target) {
+        targets.push(target);
+      }
+    }
+
+    return normalizeCronChannelTargets(targets);
+  } catch {
+    return [];
+  }
+}
+
+function findMatchingRoutes(params: {
+  task: CronChannelTaskScope;
+  target: CronChannelTarget;
+  conversationId: string;
+}): CronChannelTarget[] {
+  loadRoutes(params.target.channel);
+  const routes = getRoutesForChannel(params.target.channel).filter((route) => {
+    if (
+      route.agentId !== params.task.agent_id ||
+      route.conversationId !== params.conversationId ||
+      route.chatId !== params.target.chat_id ||
+      !route.enabled
+    ) {
+      return false;
+    }
+    if (
+      params.target.account_id &&
+      (route.accountId ?? null) !== params.target.account_id
+    ) {
+      return false;
+    }
+    if (
+      params.target.thread_id !== undefined &&
+      (route.threadId ?? null) !== (params.target.thread_id ?? null)
+    ) {
+      return false;
+    }
+    return true;
+  });
+
+  return routes.map((route) => ({
+    ...params.target,
+    ...(route.accountId ? { account_id: route.accountId } : {}),
+    ...(route.chatType ? { chat_type: route.chatType } : {}),
+    ...(route.threadId !== undefined ? { thread_id: route.threadId } : {}),
+  }));
+}
+
+export function resolveCronChannelContext(params: {
+  task: CronChannelTaskScope;
+  conversationId: string;
+}): ResolvedCronChannelContext {
+  const registry = getChannelRegistry();
+  const availableTargets: CronChannelTarget[] = [];
+
+  if (registry) {
+    for (const target of params.task.channel_targets) {
+      for (const matched of findMatchingRoutes({
+        task: params.task,
+        target,
+        conversationId: params.conversationId,
+      })) {
+        const adapter = registry.getAdapter(
+          matched.channel,
+          matched.account_id ?? undefined,
+        );
+        if (!adapter?.isRunning()) {
+          continue;
+        }
+        availableTargets.push(matched);
+      }
+    }
+  }
+
+  const normalizedTargets = normalizeCronChannelTargets(availableTargets);
+  const scopeSeen = new Set<string>();
+  const channelToolScope: MessageChannelToolDiscoveryScope = { channels: [] };
+  const channelTurnSources: ChannelTurnSource[] = [];
+
+  for (const target of normalizedTargets) {
+    const scopeKey = `${target.channel}:${target.account_id ?? ""}`;
+    if (!scopeSeen.has(scopeKey)) {
+      scopeSeen.add(scopeKey);
+      channelToolScope.channels.push({
+        channelId: target.channel,
+        accountId: target.account_id ?? null,
+      });
+    }
+
+    channelTurnSources.push({
+      channel: target.channel,
+      ...(target.account_id ? { accountId: target.account_id } : {}),
+      chatId: target.chat_id,
+      ...(target.chat_type ? { chatType: target.chat_type } : {}),
+      ...(target.message_id ? { messageId: target.message_id } : {}),
+      ...(target.thread_id !== undefined ? { threadId: target.thread_id } : {}),
+      agentId: params.task.agent_id,
+      conversationId: params.conversationId,
+    });
+  }
+
+  return {
+    channelToolScope,
+    channelTurnSources,
+    availableTargets: normalizedTargets,
+  };
+}
+
+export function formatCronChannelTargetForPrompt(
+  target: CronChannelTarget,
+): string {
+  const args = [
+    'action="send"',
+    `channel="${target.channel}"`,
+    `chat_id="${target.chat_id}"`,
+  ];
+  if (target.account_id) {
+    args.push(`accountId="${target.account_id}"`);
+  }
+  if (target.thread_id) {
+    args.push(`threadId="${target.thread_id}"`);
+  }
+  return `MessageChannel(${args.join(", ")}, message="...")`;
+}

--- a/src/cron/cron-file.test.ts
+++ b/src/cron/cron-file.test.ts
@@ -101,6 +101,35 @@ describe("addTask", () => {
     expect(result.task.scheduled_for).toBe(scheduledFor.toISOString());
   });
 
+  test("stores explicit channel targets", () => {
+    const result = addTask(
+      makeInput({
+        channel_targets: [
+          {
+            channel: "slack",
+            account_id: "acct-slack",
+            chat_id: "C123",
+            chat_type: "channel",
+            thread_id: "1712790000.000050",
+          },
+        ],
+      }),
+    );
+
+    expect(result.task.channel_targets).toEqual([
+      {
+        channel: "slack",
+        account_id: "acct-slack",
+        chat_id: "C123",
+        chat_type: "channel",
+        thread_id: "1712790000.000050",
+      },
+    ]);
+    expect(readCronFile().tasks[0]?.channel_targets).toEqual(
+      result.task.channel_targets,
+    );
+  });
+
   test("multiple tasks get unique IDs", () => {
     const r1 = addTask(makeInput());
     const r2 = addTask(makeInput({ prompt: "echo world" }));

--- a/src/cron/cron-file.ts
+++ b/src/cron/cron-file.ts
@@ -19,6 +19,10 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import {
+  type CronChannelTarget,
+  normalizeCronChannelTargets,
+} from "./channel-targets";
 import { estimatePeriodMs } from "./parse-interval";
 
 // ── Types ───────────────────────────────────────────────────────────
@@ -67,6 +71,8 @@ export interface CronTask {
 
   // Content
   prompt: string;
+  /** Explicit external channel destinations this scheduled run may message. */
+  channel_targets: CronChannelTarget[];
 
   // Lifecycle
   status: CronTaskStatus;
@@ -141,6 +147,7 @@ function emptyFile(): CronFileData {
 function normalizeTask(task: CronTask): CronTask {
   return {
     ...task,
+    channel_targets: normalizeCronChannelTargets(task.channel_targets),
     last_run_at: task.last_run_at ?? null,
     last_run_outcome: task.last_run_outcome ?? null,
     last_run_reason: task.last_run_reason ?? null,
@@ -476,6 +483,7 @@ export interface AddTaskInput {
   timezone?: string;
   recurring: boolean;
   prompt: string;
+  channel_targets?: CronChannelTarget[];
   scheduled_for?: Date; // for one-shots
 }
 
@@ -518,6 +526,7 @@ export function addTask(input: AddTaskInput): AddTaskResult {
       timezone,
       recurring: input.recurring,
       prompt: input.prompt,
+      channel_targets: normalizeCronChannelTargets(input.channel_targets),
       status: "active",
       created_at: now.toISOString(),
       // Recurring tasks do not auto-expire (expires_at: null)

--- a/src/cron/index.ts
+++ b/src/cron/index.ts
@@ -1,4 +1,13 @@
 export {
+  type CronChannelTarget,
+  extractCronChannelTargetsFromInheritedContext,
+  formatCronChannelTargetForPrompt,
+  normalizeCronChannelTargets,
+  type ResolvedCronChannelContext,
+  resolveCronChannelContext,
+} from "./channel-targets";
+
+export {
   type AddTaskInput,
   type AddTaskResult,
   addTask,

--- a/src/cron/scheduler.test.ts
+++ b/src/cron/scheduler.test.ts
@@ -143,6 +143,31 @@ describe("task lifecycle", () => {
     expect(wrapCronPrompt(task)).not.toContain("<system-reminder>");
   });
 
+  test("cron prompt names stored channel destinations", () => {
+    const { task } = addTask(
+      makeInput({
+        channel_targets: [
+          {
+            channel: "discord",
+            account_id: "acct-discord",
+            chat_id: "room-123",
+            chat_type: "channel",
+            thread_id: "thread-456",
+          },
+        ],
+      }),
+    );
+
+    const prompt = wrapCronPrompt(task);
+
+    expect(prompt).toContain(
+      "Available outbound channel destinations for this scheduled run:",
+    );
+    expect(prompt).toContain(
+      'MessageChannel(action="send", channel="discord", chat_id="room-123", accountId="acct-discord", threadId="thread-456", message="...")',
+    );
+  });
+
   test("new recurring task starts with fire_count 0", () => {
     const { task } = addTask(makeInput());
     expect(task.fire_count).toBe(0);

--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -31,6 +31,11 @@ import type {
   StartListenerOptions,
 } from "@/websocket/listener/types";
 import {
+  type CronChannelTarget,
+  formatCronChannelTargetForPrompt,
+  resolveCronChannelContext,
+} from "./channel-targets";
+import {
   type CronRunOutcome,
   type CronRunReason,
   type CronTask,
@@ -101,6 +106,7 @@ export function minuteKey(date: Date): string {
 }
 
 export function wrapCronPrompt(task: CronTask): string {
+  const availableChannelTargets = task.channel_targets;
   const lines = [
     `Scheduled task "${task.name}" is firing.`,
     `Description: ${task.description}`,
@@ -110,7 +116,41 @@ export function wrapCronPrompt(task: CronTask): string {
     "",
     `Prompt: ${task.prompt}`,
   ];
+
+  if (availableChannelTargets.length > 0) {
+    lines.push(
+      "",
+      "Available outbound channel destinations for this scheduled run:",
+      ...availableChannelTargets.map(
+        (target) => `- ${formatCronChannelTargetForPrompt(target)}`,
+      ),
+      "Only these destinations are authorized for MessageChannel. Plain assistant text is not delivered to external channels; use MessageChannel if a channel-visible message is needed.",
+    );
+  }
+
   return lines.join("\n");
+}
+
+function wrapCronPromptForFire(
+  task: CronTask,
+  availableChannelTargets: CronChannelTarget[],
+): string {
+  if (task.channel_targets.length === 0) {
+    return wrapCronPrompt(task);
+  }
+
+  if (availableChannelTargets.length > 0) {
+    return wrapCronPrompt({
+      ...task,
+      channel_targets: availableChannelTargets,
+    });
+  }
+
+  return [
+    wrapCronPrompt({ ...task, channel_targets: [] }),
+    "",
+    "This schedule has stored outbound channel destinations, but none are currently available. MessageChannel is not available for this run unless the channel route and adapter are restored.",
+  ].join("\n");
 }
 
 function getCronConversationSummary(task: CronTask): string {
@@ -283,7 +323,12 @@ async function fireCronTask(
     rawRuntime,
   );
 
-  const text = wrapCronPrompt(task);
+  const cronConversationId = targetConversationId ?? "default";
+  const channelContext = resolveCronChannelContext({
+    task,
+    conversationId: cronConversationId,
+  });
+  const text = wrapCronPromptForFire(task, channelContext.availableTargets);
 
   const queuedItem = conversationRuntime.queueRuntime.enqueue({
     kind: "cron_prompt",
@@ -291,7 +336,7 @@ async function fireCronTask(
     text,
     cronTaskId: task.id,
     agentId: task.agent_id,
-    conversationId: targetConversationId ?? "default",
+    conversationId: cronConversationId,
   } as Omit<CronPromptQueueItem, "id" | "enqueuedAt">);
 
   if (!queuedItem) {
@@ -311,6 +356,22 @@ async function fireCronTask(
     });
     return false;
   }
+
+  conversationRuntime.queuedMessagesByItemId.set(queuedItem.id, {
+    type: "message",
+    agentId: task.agent_id,
+    conversationId: cronConversationId,
+    channelToolScope: channelContext.channelToolScope,
+    ...(channelContext.channelTurnSources.length > 0
+      ? { channelTurnSources: channelContext.channelTurnSources }
+      : {}),
+    messages: [
+      {
+        role: "user",
+        content: text,
+      },
+    ],
+  });
 
   scheduleQueuePump(conversationRuntime, socket, opts, processQueuedTurn);
 
@@ -347,9 +408,9 @@ async function fireCronTask(
     queueItemId: queuedItem.id,
     scheduledFor: task.scheduled_for,
     firedAt: nowIso,
-    conversationId: targetConversationId ?? "default",
+    conversationId: cronConversationId,
   });
-  emitCronsUpdated(socket, task, targetConversationId ?? "default");
+  emitCronsUpdated(socket, task, cronConversationId);
   return true;
 }
 

--- a/src/tools/impl/message-channel.ts
+++ b/src/tools/impl/message-channel.ts
@@ -841,6 +841,7 @@ export async function message_channel(
         scope.agentId,
         scope.conversationId,
         resolvedAccountId,
+        input.threadId ?? undefined,
       );
       if (!route) {
         return resolvedAccountId

--- a/src/tools/impl/shell-env.ts
+++ b/src/tools/impl/shell-env.ts
@@ -16,7 +16,11 @@ import {
 } from "@/agent/memory-filesystem";
 import { getServerUrl } from "@/backend/api/client";
 import { isLocalBackendNoMemfsEnvEnabled } from "@/backend/local/paths";
-import { getCurrentWorkingDirectory } from "@/runtime-context";
+import {
+  getCurrentWorkingDirectory,
+  getRuntimeContext,
+  LETTA_INHERITED_CHANNEL_CONTEXT_ENV,
+} from "@/runtime-context";
 import { settingsManager } from "@/settings-manager";
 import { getRipgrepBinDir } from "./ripgrep-manager.js";
 
@@ -285,6 +289,7 @@ function applyHostedMemfsGitHeaderEnv(env: NodeJS.ProcessEnv): void {
  */
 export function getShellEnv(): NodeJS.ProcessEnv {
   const env = { ...process.env };
+  const runtimeContext = getRuntimeContext();
   const pathKey =
     Object.keys(env).find((k) => k.toUpperCase() === "PATH") || "PATH";
   const pathPrefixes: string[] = [];
@@ -317,9 +322,16 @@ export function getShellEnv(): NodeJS.ProcessEnv {
   // Add Letta context for skill scripts.
   // Prefer explicit agent context, but fall back to inherited env values.
   let agentId: string | undefined;
+  if (typeof runtimeContext?.agentId === "string") {
+    agentId = runtimeContext.agentId.trim() || undefined;
+  }
   try {
-    const resolvedAgentId = getCurrentAgentId();
-    if (typeof resolvedAgentId === "string" && resolvedAgentId.trim()) {
+    const resolvedAgentId = agentId ?? getCurrentAgentId();
+    if (
+      !agentId &&
+      typeof resolvedAgentId === "string" &&
+      resolvedAgentId.trim()
+    ) {
       agentId = resolvedAgentId.trim();
     }
   } catch {
@@ -380,9 +392,12 @@ export function getShellEnv(): NodeJS.ProcessEnv {
   }
   // Inject conversation ID if available
   let convId: string | undefined;
+  if (typeof runtimeContext?.conversationId === "string") {
+    convId = runtimeContext.conversationId.trim() || undefined;
+  }
   try {
-    const resolved = getConversationId();
-    if (resolved) convId = resolved;
+    const resolved = convId ?? getConversationId();
+    if (!convId && resolved) convId = resolved;
   } catch {
     // Not set yet
   }
@@ -395,6 +410,20 @@ export function getShellEnv(): NodeJS.ProcessEnv {
   if (convId) {
     env.LETTA_CONVERSATION_ID = convId;
     env.CONVERSATION_ID = convId;
+  }
+
+  if (
+    runtimeContext?.channelToolScope?.channels.length ||
+    runtimeContext?.channelTurnSources?.length
+  ) {
+    env[LETTA_INHERITED_CHANNEL_CONTEXT_ENV] = JSON.stringify({
+      ...(runtimeContext.channelToolScope?.channels.length
+        ? { channelToolScope: runtimeContext.channelToolScope }
+        : {}),
+      ...(runtimeContext.channelTurnSources?.length
+        ? { channelTurnSources: runtimeContext.channelTurnSources }
+        : {}),
+    });
   }
 
   // Inject API key and base URL from settings if not already in env

--- a/src/tools/shell-env.test.ts
+++ b/src/tools/shell-env.test.ts
@@ -7,7 +7,10 @@ import {
   getLocalBackendMemoryFilesystemRoot,
   LOCAL_BACKEND_NO_MEMFS_ENV,
 } from "@/backend/local/paths";
-import { runWithRuntimeContext } from "@/runtime-context";
+import {
+  LETTA_INHERITED_CHANNEL_CONTEXT_ENV,
+  runWithRuntimeContext,
+} from "@/runtime-context";
 import { settingsManager } from "@/settings-manager";
 import {
   ensureLettaShimDir,
@@ -275,6 +278,49 @@ test("getShellEnv prefers runtime-scoped agent, conversation, and cwd", () => {
   expect(env.CONVERSATION_ID).toBe("conv-runtime-scope");
   expect(env.LETTA_CONVERSATION_ID).toBe("conv-runtime-scope");
   expect(env.USER_CWD).toBe("/tmp/runtime-scope-cwd");
+});
+
+test("getShellEnv serializes runtime channel context for child processes", () => {
+  const env = runWithRuntimeContext(
+    {
+      agentId: "agent-runtime-scope",
+      conversationId: "conv-runtime-scope",
+      channelToolScope: {
+        channels: [{ channelId: "slack", accountId: "acct-slack" }],
+      },
+      channelTurnSources: [
+        {
+          channel: "slack",
+          accountId: "acct-slack",
+          chatId: "C123",
+          chatType: "channel",
+          threadId: "1712790000.000050",
+          agentId: "agent-runtime-scope",
+          conversationId: "conv-runtime-scope",
+        },
+      ],
+    },
+    () => getShellEnv(),
+  );
+
+  expect(
+    JSON.parse(env[LETTA_INHERITED_CHANNEL_CONTEXT_ENV] ?? "null"),
+  ).toEqual({
+    channelToolScope: {
+      channels: [{ channelId: "slack", accountId: "acct-slack" }],
+    },
+    channelTurnSources: [
+      {
+        channel: "slack",
+        accountId: "acct-slack",
+        chatId: "C123",
+        chatType: "channel",
+        threadId: "1712790000.000050",
+        agentId: "agent-runtime-scope",
+        conversationId: "conv-runtime-scope",
+      },
+    ],
+  });
 });
 
 test("getShellEnv isolates overlapping runtime scopes", async () => {

--- a/src/tools/tool-execution-context.test.ts
+++ b/src/tools/tool-execution-context.test.ts
@@ -54,6 +54,7 @@ import {
   registerExternalTools,
 } from "@/tools/manager";
 import {
+  prepareToolExecutionContextForResolvedTarget,
   prepareToolExecutionContextForScope,
   resolveConversationChannelToolScope,
 } from "@/tools/toolset";
@@ -70,7 +71,7 @@ describe("tool execution context snapshot", () => {
   let initialTools: string[] = [];
 
   function createRunningAdapter(
-    channelId: "slack" | "telegram",
+    channelId: "discord" | "slack" | "telegram",
     accountId: string,
   ): ChannelAdapter {
     return {
@@ -959,6 +960,66 @@ describe("tool execution context snapshot", () => {
     );
 
     expect(prepared.loadedToolNames).toContain("MessageChannel");
+  });
+
+  test("keeps scoped MessageChannel available for pinned none toolsets", async () => {
+    await loadSpecificTools(["Read"]);
+
+    const prepared = await prepareToolExecutionContextForResolvedTarget({
+      modelIdentifier: "anthropic/claude-opus-4-1-20250805",
+      toolsetPreference: "none",
+      channelToolScope: {
+        channels: [{ channelId: "discord", accountId: "acct-discord" }],
+      },
+    });
+
+    expect(prepared.preparedToolContext.loadedToolNames).toEqual([
+      "MessageChannel",
+    ]);
+    expect(
+      prepared.preparedToolContext.clientTools.map((tool) => tool.name),
+    ).toEqual(["MessageChannel"]);
+  });
+
+  test("explicit empty channel scope prevents route fallback", async () => {
+    installChannelAccountTestOverrides();
+    __testOverrideLoadRoutes(() => null);
+    __testOverrideSaveRoutes(() => {});
+    await loadSpecificTools(["Read"]);
+
+    const registry = new ChannelRegistry();
+    registry.registerAdapter(createRunningAdapter("slack", "acct-slack"));
+    __testSetBackend(
+      new FakeHeadlessBackend(
+        "agent-1",
+        undefined,
+        {},
+        {
+          modelHandle: "anthropic/claude-opus-4-1-20250805",
+        },
+      ),
+    );
+    setRouteInMemory("slack", {
+      accountId: "acct-slack",
+      chatId: "C123",
+      chatType: "channel",
+      agentId: "agent-1",
+      conversationId: "default",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const prepared = await prepareToolExecutionContextForScope({
+      agentId: "agent-1",
+      conversationId: "default",
+      overrideModel: "anthropic/claude-opus-4-1-20250805",
+      channelToolScope: { channels: [] },
+    });
+
+    expect(prepared.preparedToolContext.loadedToolNames).not.toContain(
+      "MessageChannel",
+    );
   });
 
   test("hydrates inherited channel scope from serialized child env", async () => {

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -121,7 +121,8 @@ function getToolNamesForToolset(
       tools = [...GEMINI_DEFAULT_TOOLS];
       break;
     case "none":
-      return [];
+      tools = [];
+      break;
     default:
       tools = [...ANTHROPIC_DEFAULT_TOOLS];
       break;
@@ -438,6 +439,7 @@ export async function prepareToolExecutionContextForScope(params: {
   workingDirectory?: string;
   permissionModeState?: PermissionModeState;
   cachedAgent?: AgentState | null;
+  channelToolScope?: MessageChannelToolDiscoveryScope | null;
   channelTurnSources?: import("@/channels/types").ChannelTurnSource[];
   modEvents?: ModEvents;
 }): Promise<PreparedScopeToolContext> {
@@ -452,6 +454,7 @@ export async function prepareToolExecutionContextForScope(params: {
     workingDirectory,
     permissionModeState,
     cachedAgent,
+    channelToolScope: explicitChannelToolScope,
     channelTurnSources: explicitChannelTurnSources,
     modEvents,
   } = params;
@@ -500,10 +503,20 @@ export async function prepareToolExecutionContextForScope(params: {
     inheritedChannelContext?.channelTurnSources ??
     [];
   const scopedConversationId = conversationId ?? "default";
-  const channelToolScope =
-    inheritedChannelToolScope && inheritedChannelToolScope.channels.length > 0
-      ? inheritedChannelToolScope
-      : resolveConversationChannelToolScope(agentId, scopedConversationId);
+  let channelToolScope: MessageChannelToolDiscoveryScope;
+  if (explicitChannelToolScope !== undefined) {
+    channelToolScope = explicitChannelToolScope ?? { channels: [] };
+  } else if (
+    inheritedChannelToolScope &&
+    inheritedChannelToolScope.channels.length > 0
+  ) {
+    channelToolScope = inheritedChannelToolScope;
+  } else {
+    channelToolScope = resolveConversationChannelToolScope(
+      agentId,
+      scopedConversationId,
+    );
+  }
 
   const result = await prepareToolExecutionContextForResolvedTarget({
     modelIdentifier: effectiveModel,

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -65,6 +65,15 @@ export type CronRunReason =
   | "task_cancelled"
   | "scheduler_error";
 
+export interface CronChannelTarget {
+  channel: string;
+  account_id?: string | null;
+  chat_id: string;
+  chat_type?: "direct" | "channel";
+  thread_id?: string | null;
+  message_id?: string | null;
+}
+
 export interface CronTask {
   id: string;
   agent_id: string;
@@ -75,6 +84,7 @@ export interface CronTask {
   timezone: string;
   recurring: boolean;
   prompt: string;
+  channel_targets: CronChannelTarget[];
   status: CronTaskStatus;
   created_at: string;
   expires_at: string | null;
@@ -1566,6 +1576,7 @@ export interface CronAddCommand {
   timezone?: string;
   recurring: boolean;
   prompt: string;
+  channel_targets?: CronChannelTarget[];
   /** Optional ISO timestamp for one-shot tasks. */
   scheduled_for?: string | null;
 }
@@ -1609,6 +1620,7 @@ export interface CronUpdateCommand {
   timezone?: string;
   recurring?: boolean;
   prompt?: string;
+  channel_targets?: CronChannelTarget[];
   /** Optional ISO timestamp for one-shot tasks. */
   scheduled_for?: string | null;
 }

--- a/src/websocket/listener/commands/cron.ts
+++ b/src/websocket/listener/commands/cron.ts
@@ -6,6 +6,7 @@ import {
   getCronRunLogPath,
   getTask as getCronTask,
   listTasks as listCronTasks,
+  normalizeCronChannelTargets,
   readCronRunLogEntriesPage,
   updateTask as updateCronTask,
 } from "@/cron";
@@ -124,6 +125,7 @@ export async function handleCronCommand(
         timezone: parsed.timezone,
         recurring: parsed.recurring,
         prompt: parsed.prompt,
+        channel_targets: parsed.channel_targets,
         scheduled_for: scheduledFor,
       });
       safeSocketSend(
@@ -290,6 +292,11 @@ export async function handleCronCommand(
         if (parsed.recurring !== undefined)
           current.recurring = parsed.recurring;
         if (parsed.prompt !== undefined) current.prompt = parsed.prompt;
+        if (parsed.channel_targets !== undefined) {
+          current.channel_targets = normalizeCronChannelTargets(
+            parsed.channel_targets,
+          );
+        }
         if (parsed.scheduled_for !== undefined) {
           current.scheduled_for = scheduledForIso ?? null;
         }

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -963,6 +963,44 @@ export function isCronListCommand(value: unknown): value is CronListCommand {
   );
 }
 
+function isCronChannelTargets(value: unknown): boolean {
+  if (value === undefined) {
+    return true;
+  }
+  if (!Array.isArray(value)) {
+    return false;
+  }
+  return value.every((entry) => {
+    if (!entry || typeof entry !== "object") {
+      return false;
+    }
+    const target = entry as {
+      channel?: unknown;
+      account_id?: unknown;
+      chat_id?: unknown;
+      chat_type?: unknown;
+      thread_id?: unknown;
+      message_id?: unknown;
+    };
+    return (
+      typeof target.channel === "string" &&
+      typeof target.chat_id === "string" &&
+      (target.account_id === undefined ||
+        target.account_id === null ||
+        typeof target.account_id === "string") &&
+      (target.chat_type === undefined ||
+        target.chat_type === "direct" ||
+        target.chat_type === "channel") &&
+      (target.thread_id === undefined ||
+        target.thread_id === null ||
+        typeof target.thread_id === "string") &&
+      (target.message_id === undefined ||
+        target.message_id === null ||
+        typeof target.message_id === "string")
+    );
+  });
+}
+
 export function isCronAddCommand(value: unknown): value is CronAddCommand {
   if (!value || typeof value !== "object") return false;
   const c = value as {
@@ -976,6 +1014,7 @@ export function isCronAddCommand(value: unknown): value is CronAddCommand {
     timezone?: unknown;
     recurring?: unknown;
     prompt?: unknown;
+    channel_targets?: unknown;
     scheduled_for?: unknown;
   };
   return (
@@ -990,6 +1029,7 @@ export function isCronAddCommand(value: unknown): value is CronAddCommand {
     (c.timezone === undefined || typeof c.timezone === "string") &&
     typeof c.recurring === "boolean" &&
     typeof c.prompt === "string" &&
+    isCronChannelTargets(c.channel_targets) &&
     (c.scheduled_for === undefined ||
       c.scheduled_for === null ||
       typeof c.scheduled_for === "string")
@@ -1061,6 +1101,7 @@ export function isCronUpdateCommand(
     timezone?: unknown;
     recurring?: unknown;
     prompt?: unknown;
+    channel_targets?: unknown;
     scheduled_for?: unknown;
   };
   return (
@@ -1075,6 +1116,7 @@ export function isCronUpdateCommand(
     (c.timezone === undefined || typeof c.timezone === "string") &&
     (c.recurring === undefined || typeof c.recurring === "boolean") &&
     (c.prompt === undefined || typeof c.prompt === "string") &&
+    isCronChannelTargets(c.channel_targets) &&
     (c.scheduled_for === undefined ||
       c.scheduled_for === null ||
       typeof c.scheduled_for === "string")

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -1,4 +1,5 @@
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
+import type { MessageChannelToolDiscoveryScope } from "@/channels/message-tool";
 import { getChannelRegistry } from "@/channels/registry";
 import type { ChannelTurnOutcome, ChannelTurnSource } from "@/channels/types";
 import type {
@@ -145,6 +146,36 @@ function collectBatchChannelTurnSources(
   return sources.length > 0 ? sources : undefined;
 }
 
+function collectBatchChannelToolScope(
+  runtime: ConversationRuntime,
+  batch: DequeuedBatch,
+): MessageChannelToolDiscoveryScope | null | undefined {
+  let sawExplicitScope = false;
+  const channels: MessageChannelToolDiscoveryScope["channels"] = [];
+  const seen = new Set<string>();
+
+  for (const item of batch.items) {
+    const template = runtime.queuedMessagesByItemId.get(item.id);
+    if (!template || !("channelToolScope" in template)) {
+      continue;
+    }
+    sawExplicitScope = true;
+    for (const entry of template.channelToolScope?.channels ?? []) {
+      const key = `${entry.channelId}:${entry.accountId ?? ""}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      channels.push({
+        channelId: entry.channelId,
+        accountId: entry.accountId ?? null,
+      });
+    }
+  }
+
+  return sawExplicitScope ? { channels } : undefined;
+}
+
 async function dispatchChannelTurnLifecycleEvent(
   event:
     | {
@@ -277,6 +308,10 @@ function buildQueuedTurnMessage(
   batch: DequeuedBatch,
 ): IncomingMessage | null {
   const channelTurnSources = collectBatchChannelTurnSources(runtime, batch);
+  let channelToolScope = collectBatchChannelToolScope(runtime, batch);
+  if (channelToolScope?.channels.length === 0 && channelTurnSources) {
+    channelToolScope = undefined;
+  }
   const actingUserId = pickBatchActingUserId(batch.items);
   const primaryItem = getPrimaryQueueMessageItem(batch.items);
   if (!primaryItem) {
@@ -297,6 +332,7 @@ function buildQueuedTurnMessage(
       type: "message",
       agentId: scopeItem?.agentId ?? runtime.agentId ?? undefined,
       conversationId: scopeItem?.conversationId ?? runtime.conversationId,
+      ...(channelToolScope !== undefined ? { channelToolScope } : {}),
       ...(channelTurnSources ? { channelTurnSources } : {}),
       ...(actingUserId ? { actingUserId } : {}),
       messages: [
@@ -341,6 +377,7 @@ function buildQueuedTurnMessage(
 
   return {
     ...template,
+    ...(channelToolScope !== undefined ? { channelToolScope } : {}),
     ...(channelTurnSources ? { channelTurnSources } : {}),
     ...(actingUserId ? { actingUserId } : {}),
     messages,

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -543,6 +543,7 @@ export async function handleIncomingMessage(
       workingDirectory: turnWorkingDirectory,
       permissionModeState: turnPermissionModeState,
       cachedAgent,
+      channelToolScope: msg.channelToolScope,
       channelTurnSources: msg.channelTurnSources,
     });
     runtime.currentToolset = preparedToolContext.toolset;

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -5,6 +5,7 @@ import type {
   ApprovalDecision,
   ApprovalResult,
 } from "@/agent/approval-execution";
+import type { MessageChannelToolDiscoveryScope } from "@/channels/message-tool";
 import type { ChannelTurnSource } from "@/channels/types";
 import type { ContextTracker } from "@/cli/helpers/context-tracker";
 import type { ApprovalRequest } from "@/cli/helpers/stream";
@@ -60,6 +61,7 @@ export interface IncomingMessage {
   type: "message";
   agentId?: string;
   conversationId?: string;
+  channelToolScope?: MessageChannelToolDiscoveryScope | null;
   channelTurnSources?: ChannelTurnSource[];
   clientToolAllowlist?: string[];
   externalToolScopeIds?: string[];


### PR DESCRIPTION
Authored by Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974).

## Problem
Scheduled runs are not channel-originated turns, so they have historically depended on whatever channel routes happened to exist for the conversation. The cron file also did not remember which outbound destinations were intended, and the scheduled prompt did not tell the agent how to message an allowed channel.

## What changed
- Cron tasks now persist normalized `channel_targets`.
- `letta cron add` captures the current routed channel context when invoked from a channel turn, and the WS cron protocol can also add/update explicit targets.
- The listener resolves stored targets against live routes/adapters at fire time, injects that explicit MessageChannel scope into the queued scheduled turn, and tells the agent the exact authorized `MessageChannel(...)` call shape.
- Scheduled runs with no stored targets get an explicit empty channel scope instead of falling back to all conversation routes.
- MessageChannel route resolution now honors `threadId` when one is supplied, so stored thread-scoped schedule destinations do not become ambiguous with other routes in the same chat.

## Usage examples

### Schedule a thread-visible follow-up from Slack
If a user asks from a routed Slack thread:

```text
Remind this thread tomorrow morning to check PR 2925.
```

The agent can create the schedule from that turn:

```sh
letta cron add \
  --name pr-2925-followup \
  --description "Check PR 2925 and report back to this Slack thread" \
  --prompt "Check PR 2925. If there is a meaningful update, send it back to the originating Slack thread." \
  --cron "0 9 * * *" \
  --agent "$AGENT_ID" \
  --conversation "$CONVERSATION_ID"
```

Because the command runs inside a routed Slack turn, the persisted cron task includes the current channel destination, e.g.:

```json
{
  "channel_targets": [
    {
      "channel": "slack",
      "account_id": "5f7559d8-1a52-47a8-96dc-cfb004f80652",
      "chat_id": "C0B36B9QW7K",
      "chat_type": "channel",
      "thread_id": "1781565691.348579"
    }
  ]
}
```

When the schedule fires, the prompt shown to the agent includes the exact authorized call:

```text
Available outbound channel destinations for this scheduled run:
- MessageChannel(action="send", channel="slack", chat_id="C0B36B9QW7K", accountId="5f7559d8-1a52-47a8-96dc-cfb004f80652", threadId="1781565691.348579", message="...")
Only these destinations are authorized for MessageChannel.
```

### Create a schedule over the listener protocol
Clients that already know the intended target can pass it explicitly with `cron_add`:

```json
{
  "type": "cron_add",
  "request_id": "req-1",
  "agent_id": "agent-123",
  "conversation_id": "conv-123",
  "name": "daily-support-digest",
  "description": "Post support digest to the ops thread",
  "cron": "0 17 * * 1-5",
  "recurring": true,
  "prompt": "Summarize today's support issues and post the digest to the configured channel.",
  "channel_targets": [
    {
      "channel": "slack",
      "account_id": "acct-slack",
      "chat_id": "C123",
      "chat_type": "channel",
      "thread_id": "1712790000.000050"
    }
  ]
}
```

### Stored target is unavailable at fire time
If the stored route is disabled or the adapter is not running, the scheduled prompt says no stored destination is currently available and the run does not get MessageChannel scope for that stale target.

## Validation
- `bun run check`
- `env -u USER_CWD bun test src/cron/cron-file.test.ts src/cron/scheduler.test.ts src/cron/channel-targets.test.ts src/tools/shell-env.test.ts src/tools/tool-execution-context.test.ts src/tools/impl/message-channel.test.ts src/channels/message-channel.test.ts src/websocket/listen-client-protocol.test.ts`

## Notes
This covers listener/WS-scheduled cron fires and CLI-created schedules from routed channel turns. It does not add a new manual CLI flag for arbitrary proactive destinations.
