### PR TITLE
fix(tools): remind worktree users to verify git hooks

### DIFF
--- a/src/tools/create-worktree.test.ts
+++ b/src/tools/create-worktree.test.ts
@@ -137,6 +137,9 @@ describe("CreateWorktree tool", () => {
     expect(result.branch_name).toStartWith("letta/fix-login-flow-");
     expect(result.base_ref).toBe("main");
     expect(result.switched_cwd).toBe(false);
+    expect(result.content[0]?.text).toContain(
+      "If the repo uses git hooks, verify they are installed and active in this worktree before committing",
+    );
     expect(
       path.normalize(
         git(["rev-parse", "--show-toplevel"], result.worktree_path),

--- a/src/tools/impl/create-worktree.ts
+++ b/src/tools/impl/create-worktree.ts
@@ -357,6 +357,7 @@ function buildSuccessMessage(params: {
     "- Confirm you are in the new worktree with `git status` before editing.",
     "- Read README, AGENTS.md, or other project setup docs before running commands.",
     "- If this repo needs per-worktree dependency setup, install dependencies with the project's package manager. Check the repo first: if it uses Bun, run `bun install` instead of `npm install`; if it uses pnpm, yarn, or npm, use that package manager instead.",
+    "- If the repo uses git hooks, verify they are installed and active in this worktree before committing; run the project's documented hook setup if needed.",
     "- Then make changes, test, commit, and push from this worktree.",
   ];
   return lines.join("\n");


### PR DESCRIPTION
## Summary

Add the missing git-hooks reminder back to the `CreateWorktree` success output.

## Why

The old `working-in-parallel` skill reminded agents that some repos need hook setup after creating a worktree. When that guidance moved into the built-in tool, the dependency/setup reminders were preserved but the hook caveat was not.

Putting this only in the tool return keeps the always-loaded tool description lean while still showing the reminder at the point where the agent can act on it.

## Validation

- `bun test src/tools/create-worktree.test.ts`
- `bun run check`
