### PR TITLE
Surface mod learning headless conversations

### DIFF
--- a/src/cli/commands/mods.test.ts
+++ b/src/cli/commands/mods.test.ts
@@ -225,6 +225,11 @@ describe("/mods command", () => {
             runDir: path.join(cwd, ".letta", "test-run"),
           });
           options.onProgress?.({
+            activeConversation: {
+              agentId: "agent-headless-123",
+              conversationId: "conv-headless-123",
+              label: "eval scenario 1/7 mod-loads",
+            },
             attempts: [
               {
                 candidateIndex: 1,
@@ -400,6 +405,12 @@ describe("/mods command", () => {
     expect(updates.at(-1)?.output).toContain("scenario 1/7 mod-loads");
     expect(updates.at(-1)?.output).toContain(
       "Background mod optimization: memory-citations",
+    );
+    expect(updates.at(-1)?.output).toContain(
+      "Running conversation: conv-headless-123 · agent agent-headless-123",
+    );
+    expect(updates.at(-1)?.output).toContain(
+      "ADE: https://app.letta.com/projects/default-project/agents/agent-headless-123?conversation=conv-headless-123",
     );
     expect(updates.at(-1)?.output).toMatch(
       /[⠀⠶⠰⣿⠆⢾⣉⡷⣏⣹⡁⢈]+ Background mod optimization/,

--- a/src/cli/commands/mods.test.ts
+++ b/src/cli/commands/mods.test.ts
@@ -442,6 +442,7 @@ describe("/mods command", () => {
     expect(updates.at(-1)?.output).toContain("Finished mod learning");
     expect(updates.at(-1)?.output).toContain("Score: 4/6 (67%)");
     expect(updates.at(-1)?.output).toContain("Score graph: ▁█");
-    expect(updates.at(-1)?.output).toContain("did not promote or load");
+    expect(updates.at(-1)?.output).toContain("Review the learned mod at");
+    expect(updates.at(-1)?.output).toContain("install with `/reload`");
   });
 });

--- a/src/cli/commands/mods.ts
+++ b/src/cli/commands/mods.ts
@@ -3,6 +3,7 @@ import memoryCitationsEnvJson from "@/../docs/examples/mods/learning/memory-cita
 import type { AppCommandRunner } from "@/cli/app/types";
 import type { CommandHandle } from "@/cli/commands/runner";
 import { BRAILLE_ANIMATIONS } from "@/cli/components/spinners/animations";
+import { buildAppUrl } from "@/cli/helpers/app-urls";
 import { parseModCommandArgv } from "@/cli/mods/command-runtime";
 import type {
   CommandRunner,
@@ -568,6 +569,25 @@ function formatElapsed(elapsedMs: number | undefined): string | null {
     : `${seconds}s elapsed`;
 }
 
+function formatHeadlessConversationLine(
+  progress: ModLearningProgress,
+): string | null {
+  const activeConversation = progress.activeConversation;
+  if (!activeConversation) return null;
+  const agentPart = activeConversation.agentId
+    ? ` · agent ${activeConversation.agentId}`
+    : "";
+  const url = activeConversation.agentId
+    ? `${buildAppUrl(
+        `/projects/default-project/agents/${encodeURIComponent(activeConversation.agentId)}`,
+      )}?conversation=${encodeURIComponent(activeConversation.conversationId)}`
+    : null;
+  return [
+    `Running conversation: ${activeConversation.conversationId}${agentPart}`,
+    ...(url ? [`ADE: ${url}`] : []),
+  ].join("\n");
+}
+
 function formatProgress(
   learn: LearnCommand,
   progress: ModLearningProgress,
@@ -609,9 +629,11 @@ function formatProgress(
       ? `Target mod: ${path.basename(progress.candidatePath)} (${displayPath(progress.candidatePath, cwd)})`
       : `Target mod: ${path.basename(progress.candidatePath)}`;
   const elapsed = formatElapsed(elapsedMs);
+  const headlessConversationLine = formatHeadlessConversationLine(progress);
   return [
     `${pulseFrame} Background mod optimization: ${learn.targetLabel}`,
     `Phase: ${progress.message}${elapsed ? ` · ${elapsed}` : ""}`,
+    ...(headlessConversationLine ? [headlessConversationLine] : []),
     ...(stepLine ? [stepLine] : []),
     ...(currentScoreLine ? [currentScoreLine] : []),
     ...(bestScoreLine ? [bestScoreLine] : []),

--- a/src/cli/commands/mods.ts
+++ b/src/cli/commands/mods.ts
@@ -693,7 +693,7 @@ export function formatModLearningSummary(
       : []),
     "",
     report.passed
-      ? "Review the candidate source before installing it. This command did not promote or load the mod."
+      ? `Review the learned mod at ${displayPath(report.candidatePath, cwd)}, and install with \`/reload\`.`
       : "Open the report, generation stdout/stderr, and eval stdout/stderr in the run directory to debug the candidate.",
   ];
   return lines.join("\n");

--- a/src/mods/learning-harness.ts
+++ b/src/mods/learning-harness.ts
@@ -75,6 +75,7 @@ export type ModLearningAssertion =
 export interface CommandRunOptions {
   cwd: string;
   env: NodeJS.ProcessEnv;
+  onStdout?: (chunk: string) => void;
   timeoutMs: number;
 }
 
@@ -161,7 +162,14 @@ export type ModLearningProgressPhase =
   | "writing-report"
   | "done";
 
+export interface ModLearningHeadlessConversation {
+  agentId?: string;
+  conversationId: string;
+  label: string;
+}
+
 export interface ModLearningProgress {
+  activeConversation?: ModLearningHeadlessConversation;
   attempts?: ModLearningAttemptSummary[];
   candidateIndex?: number;
   candidatePath: string;
@@ -287,6 +295,7 @@ interface ModLearningEvaluatorContext {
   cliCommand: string;
   evalModel?: string;
   onScenarioProgress?: (progress: {
+    activeConversation?: ModLearningHeadlessConversation;
     evaluation: ModLearningEvaluationResult;
     scenarioCount: number;
     scenarioIndex: number;
@@ -723,7 +732,69 @@ async function prepareMemoryFiles(
 }
 
 function renderEvaluationPrompt(prompt: string, memoryDir: string): string {
-  return prompt.replace(/\$\{MEMORY_DIR\}|\$MEMORY_DIR/g, () => memoryDir);
+  const renderedPrompt = prompt.replace(/\$\{MEMORY_DIR\}|\$MEMORY_DIR/g, () =>
+    memoryDir,
+  );
+  return [
+    "You are running one isolated mod-learning evaluation scenario.",
+    "Follow only the scenario instructions below. Do not search this repository for other evaluation scenarios, do not run /mods learn, and do not run test suites unless the scenario explicitly asks you to do so.",
+    "If the scenario asks for a final answer marker, provide that marker directly once the scenario-specific work is complete.",
+    "",
+    "Scenario instructions:",
+    renderedPrompt,
+  ].join("\n");
+}
+
+function extractHeadlessConversation(
+  value: Record<string, unknown>,
+): { agentId?: string; conversationId?: string } {
+  const payload =
+    value.type === "stream_event" &&
+    value.event &&
+    typeof value.event === "object"
+      ? (value.event as Record<string, unknown>)
+      : value;
+  const agentId =
+    typeof payload.agent_id === "string" ? payload.agent_id : undefined;
+  const conversationId =
+    typeof payload.conversation_id === "string"
+      ? payload.conversation_id
+      : undefined;
+  return { agentId, conversationId };
+}
+
+function createHeadlessConversationObserver(
+  label: string,
+  onConversation: (conversation: ModLearningHeadlessConversation) => void,
+): (chunk: string) => void {
+  let buffer = "";
+  let emittedConversationId: string | null = null;
+  const emitFromLine = (line: string) => {
+    if (!line.trim()) return;
+    try {
+      const parsed = JSON.parse(line) as Record<string, unknown>;
+      const { agentId, conversationId } = extractHeadlessConversation(parsed);
+      if (!conversationId || conversationId === emittedConversationId) return;
+      emittedConversationId = conversationId;
+      onConversation({
+        ...(agentId ? { agentId } : {}),
+        conversationId,
+        label,
+      });
+    } catch {
+      // Ignore non-JSON diagnostics and incomplete chunks; stdout is still
+      // persisted as an artifact.
+    }
+  };
+  return (chunk: string) => {
+    buffer += chunk;
+    const lines = buffer.split(/\r?\n/);
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      emitFromLine(line);
+    }
+    emitFromLine(buffer);
+  };
 }
 
 function renderAssertionSummary(
@@ -1680,7 +1751,10 @@ export async function defaultCommandRunner(
       }, 5000).unref();
     }, options.timeoutMs);
 
-    child.stdout.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdoutChunks.push(chunk);
+      options.onStdout?.(chunk.toString("utf8"));
+    });
     child.stderr.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
     child.on("error", (error) => {
       stderrChunks.push(Buffer.from(String(error.stack ?? error.message)));
@@ -1800,6 +1874,22 @@ function createScenarioSuiteEvaluator(params: {
                 LETTA_MODS_DIR: context.candidate.dir,
                 MEMORY_DIR: scenarioMemoryDir,
               },
+              onStdout: createHeadlessConversationObserver(
+                `eval scenario ${scenarioIndex + 1}/${scenarios.length} ${scenario.name}`,
+                (activeConversation) => {
+                  const partialEvaluation = hasConfiguredScenarios
+                    ? aggregateScenarioEvaluations(scenarioResults)
+                    : scenarioEvaluation;
+                  context.onScenarioProgress?.({
+                    activeConversation,
+                    evaluation: partialEvaluation,
+                    scenarioCount: scenarios.length,
+                    scenarioIndex: scenarioIndex + 1,
+                    scenarioName: scenario.name,
+                    score: markerScore(partialEvaluation),
+                  });
+                },
+              ),
               timeoutMs: scenarioSpec.timeoutMs ?? 15 * 60 * 1000,
             },
           );
@@ -2052,11 +2142,13 @@ async function runModLearningCandidate(
       candidatePath,
     );
   } else if (!options.skipGeneration) {
-    emitProgress(
-      "generating",
+    const generationMessage =
       params.candidateCount > 1
         ? `Generating optimization iteration ${params.candidateIndex}/${params.candidateCount}`
-        : "Generating candidate mod",
+        : "Generating candidate mod";
+    emitProgress(
+      "generating",
+      generationMessage,
     );
     const promptHistory: ModLearningPromptHistory = {
       candidateCount: params.candidateCount,
@@ -2095,6 +2187,14 @@ async function runModLearningCandidate(
         LETTA_DISABLE_EXTENSIONS: "1",
         LETTA_DISABLE_MODS: "1",
       },
+      onStdout: createHeadlessConversationObserver(
+        `generation iteration ${params.candidateIndex}`,
+        (activeConversation) => {
+          emitProgress("generating", generationMessage, {
+            activeConversation,
+          });
+        },
+      ),
       timeoutMs: 15 * 60 * 1000,
     });
     await writeCommandArtifacts(
@@ -2149,6 +2249,9 @@ async function runModLearningCandidate(
               : "Evaluating candidate mod"
           }: scenario ${progress.scenarioIndex}/${progress.scenarioCount} ${progress.scenarioName}`,
           {
+            ...(progress.activeConversation
+              ? { activeConversation: progress.activeConversation }
+              : {}),
             passed: progress.evaluation.passed,
             score: progress.score,
           },

--- a/src/mods/learning-harness.ts
+++ b/src/mods/learning-harness.ts
@@ -732,8 +732,9 @@ async function prepareMemoryFiles(
 }
 
 function renderEvaluationPrompt(prompt: string, memoryDir: string): string {
-  const renderedPrompt = prompt.replace(/\$\{MEMORY_DIR\}|\$MEMORY_DIR/g, () =>
-    memoryDir,
+  const renderedPrompt = prompt.replace(
+    /\$\{MEMORY_DIR\}|\$MEMORY_DIR/g,
+    () => memoryDir,
   );
   return [
     "You are running one isolated mod-learning evaluation scenario.",
@@ -745,9 +746,10 @@ function renderEvaluationPrompt(prompt: string, memoryDir: string): string {
   ].join("\n");
 }
 
-function extractHeadlessConversation(
-  value: Record<string, unknown>,
-): { agentId?: string; conversationId?: string } {
+function extractHeadlessConversation(value: Record<string, unknown>): {
+  agentId?: string;
+  conversationId?: string;
+} {
   const payload =
     value.type === "stream_event" &&
     value.event &&
@@ -2146,10 +2148,7 @@ async function runModLearningCandidate(
       params.candidateCount > 1
         ? `Generating optimization iteration ${params.candidateIndex}/${params.candidateCount}`
         : "Generating candidate mod";
-    emitProgress(
-      "generating",
-      generationMessage,
-    );
+    emitProgress("generating", generationMessage);
     const promptHistory: ModLearningPromptHistory = {
       candidateCount: params.candidateCount,
       candidateIndex: params.candidateIndex,


### PR DESCRIPTION
## Summary
- show the active mod-learning generation/eval conversation ID and ADE link in progress output
- stream headless stdout to detect conversation metadata as soon as child runs start
- tighten mod-learning eval prompt guidance so each headless run stays scoped to its isolated scenario

## Test plan
- bun test src/cli/commands/mods.test.ts
- bun run typecheck