### PR TITLE
fix(cli): support direct skill file URLs

### DIFF
--- a/src/cli/subcommands/skills.test.ts
+++ b/src/cli/subcommands/skills.test.ts
@@ -5,9 +5,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   deleteSkillDirectory,
+  downloadDirectSkillFileSource,
   installSkillDirectory,
   listSkillDirectories,
+  MAX_DIRECT_SKILL_FILE_BYTES,
   parseClawHubSpecifier,
+  parseDirectSkillFileUrlSpecifier,
   parseGitHubSpecifier,
 } from "./skills";
 
@@ -33,6 +36,40 @@ describe("skills subcommand", () => {
       repoUrl: "https://github.com/owner/repo.git",
       branch: null,
       subdir: "main/path/to/skill",
+    });
+  });
+
+  test("does not parse non-GitHub absolute URLs as GitHub shorthand", () => {
+    expect(parseGitHubSpecifier("https://docs.x.com/skill.md")).toBeNull();
+    expect(parseGitHubSpecifier("https://docs.x.com/not-a-skill")).toBeNull();
+  });
+
+  test("parses direct HTTPS skill file URLs", () => {
+    expect(
+      parseDirectSkillFileUrlSpecifier(
+        "https://docs.x.com/path/skill.md?download=1",
+      ),
+    ).toEqual({
+      url: "https://docs.x.com/path/skill.md?download=1",
+    });
+    expect(
+      parseDirectSkillFileUrlSpecifier("https://docs.x.com/path/SKILL.md"),
+    ).toEqual({
+      url: "https://docs.x.com/path/SKILL.md",
+    });
+    expect(
+      parseDirectSkillFileUrlSpecifier("https://docs.x.com/path/readme.md"),
+    ).toBeNull();
+    expect(
+      parseDirectSkillFileUrlSpecifier("https://user:pass@docs.x.com/SKILL.md"),
+    ).toBeNull();
+    expect(
+      parseDirectSkillFileUrlSpecifier("http://docs.x.com/SKILL.md"),
+    ).toBeNull();
+    expect(
+      parseDirectSkillFileUrlSpecifier("http://localhost:3000/SKILL.md"),
+    ).toEqual({
+      url: "http://localhost:3000/SKILL.md",
     });
   });
 
@@ -77,6 +114,61 @@ describe("skills subcommand", () => {
     } finally {
       await rm(tempRoot, { recursive: true, force: true });
     }
+  });
+
+  test("downloads a direct skill file URL as a skill directory", async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "letta-skills-test-"));
+    let downloaded: { tmpDir: string; sourceDir: string } | null = null;
+    try {
+      const memoryDir = join(tempRoot, "memory");
+      const skillText =
+        "---\nname: direct-url\ndescription: test\n---\n\n# Direct URL\n";
+
+      downloaded = await downloadDirectSkillFileSource(
+        { url: "https://docs.x.com/SKILL.md" },
+        {
+          fetchImpl: async (url) => {
+            expect(String(url)).toBe("https://docs.x.com/SKILL.md");
+            return new Response(skillText, {
+              headers: { "content-length": String(skillText.length) },
+            });
+          },
+        },
+      );
+
+      const result = await installSkillDirectory({
+        sourceDir: downloaded.sourceDir,
+        memoryDir,
+      });
+
+      expect(result.name).toBe("direct-url");
+      expect(await readFile(join(result.path, "SKILL.md"), "utf8")).toBe(
+        skillText,
+      );
+    } finally {
+      if (downloaded) {
+        await rm(downloaded.tmpDir, { recursive: true, force: true });
+      }
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects oversized direct skill file downloads", async () => {
+    await expect(
+      downloadDirectSkillFileSource(
+        { url: "https://docs.x.com/SKILL.md" },
+        {
+          fetchImpl: async () =>
+            new Response("too large", {
+              headers: {
+                "content-length": String(MAX_DIRECT_SKILL_FILE_BYTES + 1),
+              },
+            }),
+        },
+      ),
+    ).rejects.toThrow(
+      `Direct skill file exceeds ${MAX_DIRECT_SKILL_FILE_BYTES} byte limit.`,
+    );
   });
 
   test("lists installed skill directories with frontmatter metadata", async () => {

--- a/src/cli/subcommands/skills.ts
+++ b/src/cli/subcommands/skills.ts
@@ -10,18 +10,23 @@ import {
 import { mkdir, readdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, normalize, resolve, sep } from "node:path";
-import { parseArgs } from "node:util";
+import { parseArgs, TextDecoder, TextEncoder } from "node:util";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import { isLocalAgentId } from "@/agent/agent-id";
 import { parseFrontmatter } from "@/utils/frontmatter";
 
 const HERMES_REPO_URL = "https://github.com/NousResearch/hermes-agent.git";
 const HERMES_OPTIONAL_SKILLS_DIR = "optional-skills";
+export const MAX_DIRECT_SKILL_FILE_BYTES = 1024 * 1024;
 
 interface SkillSourceLocation {
   repoUrl: string;
   branch: string | null;
   subdir: string | null;
+}
+
+interface DirectSkillFileSourceLocation {
+  url: string;
 }
 
 interface InstallResult {
@@ -53,6 +58,15 @@ interface ClawHubSourceLocation {
   version: string | null;
 }
 
+type ResolvedSkillSource =
+  | { type: "git"; location: SkillSourceLocation }
+  | { type: "direct-file"; location: DirectSkillFileSourceLocation }
+  | { type: "clawhub"; location: ClawHubSourceLocation };
+
+type FetchSkillFile = (
+  ...args: Parameters<typeof fetch>
+) => ReturnType<typeof fetch>;
+
 const CLAWHUB_API_BASE_URL = "https://clawhub.ai/api/v1";
 
 let activeAgentPromptStatus: { stop: () => void } | null = null;
@@ -70,6 +84,7 @@ Sources:
   clawhub/<slug>          ClawHub registry skill, e.g. clawhub/nano-banana-pro
   clawhub:<slug>          ClawHub registry skill, optionally <slug>@<version>
   https://github.com/...  GitHub repository, tree URL, or SKILL.md blob URL
+  https://.../SKILL.md    Direct external skill file URL
   owner/repo/path         GitHub repo/path shorthand
 
 Options:
@@ -223,16 +238,36 @@ async function resolveAgentId(
   return promptForAgent(promptStatusMessage);
 }
 
+function parseAbsoluteUrl(input: string): URL | null {
+  try {
+    return new URL(input);
+  } catch {
+    return null;
+  }
+}
+
+function isLocalhostHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return (
+    normalized === "localhost" ||
+    normalized.endsWith(".localhost") ||
+    normalized === "127.0.0.1" ||
+    normalized === "::1" ||
+    normalized === "[::1]"
+  );
+}
+
 export function parseGitHubSpecifier(
   input: string,
 ): SkillSourceLocation | null {
   const trimmed = input.trim();
+  const url = parseAbsoluteUrl(trimmed);
 
   if (
-    trimmed.startsWith("https://github.com/") ||
-    trimmed.startsWith("http://github.com/")
+    url &&
+    (url.protocol === "https:" || url.protocol === "http:") &&
+    url.hostname.toLowerCase() === "github.com"
   ) {
-    const url = new URL(trimmed);
     const parts = url.pathname.split("/").filter(Boolean);
     if (parts.length < 2) return null;
     const [owner, repoWithSuffix] = parts;
@@ -250,6 +285,8 @@ export function parseGitHubSpecifier(
     }
     return { repoUrl, branch: null, subdir: null };
   }
+
+  if (url) return null;
 
   const shorthand = trimmed.split("/").filter(Boolean);
   if (shorthand.length >= 3 && shorthand[0] !== "official") {
@@ -269,6 +306,22 @@ export function parseGitHubSpecifier(
   }
 
   return null;
+}
+
+export function parseDirectSkillFileUrlSpecifier(
+  input: string,
+): DirectSkillFileSourceLocation | null {
+  const url = parseAbsoluteUrl(input.trim());
+  if (!url) return null;
+  if (url.username || url.password) return null;
+  if (
+    url.protocol !== "https:" &&
+    !(url.protocol === "http:" && isLocalhostHostname(url.hostname))
+  ) {
+    return null;
+  }
+  if (basename(url.pathname).toLowerCase() !== "skill.md") return null;
+  return { url: url.toString() };
 }
 
 export function parseClawHubSpecifier(
@@ -324,6 +377,28 @@ function parseOfficialSpecifier(input: string): SkillSourceLocation | null {
     branch: null,
     subdir: `${HERMES_OPTIONAL_SKILLS_DIR}/${relativePath}`,
   };
+}
+
+function resolveSkillSourceSpecifier(
+  input: string,
+): ResolvedSkillSource | null {
+  const clawHubSource = parseClawHubSpecifier(input);
+  if (clawHubSource) {
+    return { type: "clawhub", location: clawHubSource };
+  }
+
+  const gitSource =
+    parseOfficialSpecifier(input) ?? parseGitHubSpecifier(input);
+  if (gitSource) {
+    return { type: "git", location: gitSource };
+  }
+
+  const directFileSource = parseDirectSkillFileUrlSpecifier(input);
+  if (directFileSource) {
+    return { type: "direct-file", location: directFileSource };
+  }
+
+  return null;
 }
 
 async function execFile(
@@ -386,6 +461,91 @@ async function cloneSkillSource(
     ? join(tmpDir, resolvedLocation.subdir)
     : tmpDir;
   return { tmpDir, sourceDir };
+}
+
+function assertDirectSkillFileSize(
+  receivedBytes: number,
+  maxBytes: number,
+): void {
+  if (receivedBytes > maxBytes) {
+    throw new Error(`Direct skill file exceeds ${maxBytes} byte limit.`);
+  }
+}
+
+async function readResponseTextWithLimit(
+  response: Response,
+  maxBytes: number,
+): Promise<string> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength) {
+    const parsedLength = Number.parseInt(contentLength, 10);
+    if (Number.isFinite(parsedLength)) {
+      assertDirectSkillFileSize(parsedLength, maxBytes);
+    }
+  }
+
+  if (!response.body) {
+    const text = await response.text();
+    assertDirectSkillFileSize(
+      new TextEncoder().encode(text).byteLength,
+      maxBytes,
+    );
+    return text;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let receivedBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      receivedBytes += value.byteLength;
+      if (receivedBytes > maxBytes) {
+        await reader.cancel();
+        assertDirectSkillFileSize(receivedBytes, maxBytes);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const body = new Uint8Array(receivedBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(body);
+}
+
+export async function downloadDirectSkillFileSource(
+  location: DirectSkillFileSourceLocation,
+  options: { fetchImpl?: FetchSkillFile } = {},
+): Promise<{ tmpDir: string; sourceDir: string }> {
+  const response = await (options.fetchImpl ?? fetch)(location.url);
+  if (!response.ok) {
+    throw new Error(
+      `Direct skill file download failed for ${location.url}: ${response.status}`,
+    );
+  }
+
+  const skillText = await readResponseTextWithLimit(
+    response,
+    MAX_DIRECT_SKILL_FILE_BYTES,
+  );
+  const tmpDir = mkdtempSync(join(tmpdir(), "letta-direct-skill-"));
+  try {
+    const sourceDir = join(tmpDir, "skill");
+    await mkdir(sourceDir, { recursive: true });
+    writeFileSync(join(sourceDir, "SKILL.md"), skillText, "utf8");
+    return { tmpDir, sourceDir };
+  } catch (error) {
+    rmSync(tmpDir, { recursive: true, force: true });
+    throw error;
+  }
 }
 
 async function fetchJson(url: string): Promise<unknown> {
@@ -620,27 +780,32 @@ async function installSkill(
   agentId: string,
   force: boolean,
 ): Promise<InstallResult> {
-  const clawHubSource = parseClawHubSpecifier(specifier);
-  const gitSource = clawHubSource
-    ? null
-    : (parseOfficialSpecifier(specifier) ?? parseGitHubSpecifier(specifier));
-  if (!gitSource && !clawHubSource) {
+  const source = resolveSkillSourceSpecifier(specifier);
+  if (!source) {
     throw new Error(`Unsupported skill source: ${specifier}`);
   }
 
   const memoryDir = await getAgentMemoryDir(agentId);
   let tmpDir: string | null = null;
   try {
-    const downloaded = gitSource
-      ? await cloneSkillSource(gitSource)
-      : await downloadClawHubSkillSource(
-          clawHubSource as ClawHubSourceLocation,
-        );
+    let downloaded: { tmpDir: string; sourceDir: string };
+    if (source.type === "git") {
+      downloaded = await cloneSkillSource(source.location);
+    } else if (source.type === "direct-file") {
+      downloaded = await downloadDirectSkillFileSource(source.location);
+    } else {
+      downloaded = await downloadClawHubSkillSource(source.location);
+    }
     tmpDir = downloaded.tmpDir;
     const sourceDir = resolve(downloaded.sourceDir);
     assertInside(tmpDir, sourceDir);
     if (!existsSync(sourceDir)) {
-      const missingPath = gitSource?.subdir || clawHubSource?.slug || ".";
+      const missingPath =
+        source.type === "git"
+          ? (source.location.subdir ?? ".")
+          : source.type === "direct-file"
+            ? source.location.url
+            : source.location.slug;
       throw new Error(`Skill path not found: ${missingPath}`);
     }
     const result = await installSkillDirectory({ sourceDir, memoryDir, force });


### PR DESCRIPTION
## Summary
- Add a dedicated direct external `SKILL.md` URL source path with HTTPS validation, credential rejection, and bounded text download into a temporary skill directory.
- Stop non-GitHub absolute URLs from falling through into GitHub owner/repo/path shorthand parsing.
- Cover direct URL parsing, materialization through `installSkillDirectory()`, and oversize rejection.

## Test plan
- [x] `bun test ./src/cli/subcommands/skills.test.ts`
- [x] `bunx --bun @biomejs/biome@2.2.5 check src/cli/subcommands/skills.ts src/cli/subcommands/skills.test.ts`
- [ ] `bun run check` (fails in this checkout: `madge` not found; existing TypeScript errors in `src/backend/dev/pi-provider-registry.ts`, `src/cli/commands/connect-local-oauth.test.ts`, and `src/web/generate-diff-viewer.ts`)

👾 Generated with [Letta Code](https://letta.com)