### PR TITLE
fix(slack): require exact thread routes for Slack thread input

### DIFF
--- a/src/channels/registry.test.ts
+++ b/src/channels/registry.test.ts
@@ -888,6 +888,83 @@ describe("ChannelRegistry", () => {
     ]);
     expect(replies[0]?.text).toBe("Started a reflection pass.");
   });
+
+  test("Slack root channel routes do not catch unmentioned thread input", async () => {
+    const replies: Array<{
+      chatId: string;
+      text: string;
+      replyToMessageId?: string;
+    }> = [];
+    const registry = new ChannelRegistry();
+    const delivered: unknown[] = [];
+    const reflections: unknown[] = [];
+    registry.setMessageHandler((delivery) => delivered.push(delivery));
+    registry.setReflectionHandler(async (params) => {
+      reflections.push(params);
+      return { handled: true, text: "Started a reflection pass." };
+    });
+    registry.setReady();
+    registry.registerAdapter({
+      id: "slack:acct-slack",
+      channelId: "slack",
+      accountId: "acct-slack",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "msg-1" }),
+      sendDirectReply: async (chatId, text, options) => {
+        replies.push({
+          chatId,
+          text,
+          replyToMessageId: options?.replyToMessageId,
+        });
+      },
+      onMessage: undefined,
+    });
+    addRoute("slack", {
+      accountId: "acct-slack",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: null,
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: "2026-05-19T00:00:00.000Z",
+    });
+
+    const adapter = registry.getAdapter("slack", "acct-slack");
+    await adapter?.onMessage?.({
+      channel: "slack",
+      accountId: "acct-slack",
+      chatId: "C123",
+      senderId: "U123",
+      senderName: "Charles",
+      text: "ok i think i did it",
+      timestamp: Date.now(),
+      messageId: "1712800000.000200",
+      threadId: "1712790000.000050",
+      chatType: "channel",
+      isMention: false,
+    });
+    await adapter?.onMessage?.({
+      channel: "slack",
+      accountId: "acct-slack",
+      chatId: "C123",
+      senderId: "U123",
+      senderName: "Charles",
+      text: "/reflection",
+      timestamp: Date.now(),
+      messageId: "1712800000.000201",
+      threadId: "1712790000.000050",
+      chatType: "channel",
+      isMention: false,
+    });
+
+    expect(delivered).toHaveLength(0);
+    expect(reflections).toHaveLength(0);
+    expect(replies).toHaveLength(0);
+  });
 });
 
 describe("buildSlackConversationSummary", () => {

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -1070,12 +1070,9 @@ export class ChannelRegistry {
   private findRawRouteForMessage(
     msg: InboundChannelMessage,
   ): ChannelRoute | null {
-    const route =
-      getRouteRaw(msg.channel, msg.chatId, msg.accountId, msg.threadId) ??
-      (msg.threadId
-        ? getRouteRaw(msg.channel, msg.chatId, msg.accountId, null)
-        : undefined);
-    return route ?? null;
+    return (
+      getRouteRaw(msg.channel, msg.chatId, msg.accountId, msg.threadId) ?? null
+    );
   }
 
   private loadAndFindRawRouteForMessage(
@@ -1287,6 +1284,33 @@ export class ChannelRegistry {
     return matches.length === 1 ? (matches[0] ?? null) : null;
   }
 
+  private hasExactEnabledRouteForMessage(
+    msg: InboundChannelMessage,
+    accountId: string,
+  ): boolean {
+    if (getRouteFromStore(msg.channel, msg.chatId, accountId, msg.threadId)) {
+      return true;
+    }
+
+    loadRoutes(msg.channel);
+    return Boolean(
+      getRouteFromStore(msg.channel, msg.chatId, accountId, msg.threadId),
+    );
+  }
+
+  private shouldDropUnroutedSlackThreadInput(
+    msg: InboundChannelMessage,
+    accountId: string,
+  ): boolean {
+    return (
+      msg.channel === "slack" &&
+      msg.chatType === "channel" &&
+      msg.threadId != null &&
+      msg.isMention !== true &&
+      !this.hasExactEnabledRouteForMessage(msg, accountId)
+    );
+  }
+
   private async handleInboundMessage(
     msg: InboundChannelMessage,
   ): Promise<void> {
@@ -1294,6 +1318,10 @@ export class ChannelRegistry {
     const adapter = this.getAdapter(msg.channel, accountId);
     if (!adapter) return;
     if (await this.tryHandlePendingControlRequest(adapter, msg)) {
+      return;
+    }
+
+    if (this.shouldDropUnroutedSlackThreadInput(msg, accountId)) {
       return;
     }
 


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Problem

A Slack channel-level route can be persisted with `threadId: null`. That route should not act as a catch-all for replies inside arbitrary Slack threads, especially in private channels where the bot was not mentioned in the thread.

## Approach

Require an exact enabled Slack thread route before processing unmentioned threaded Slack input. Also remove the raw-route fallback that let threaded channel slash commands resolve to a root channel route.

Explicit mentions still create or use the appropriate thread route, and existing routed threads continue to work.

## Validation

- `bun test src/channels/registry.test.ts`
- `bun run check`
