### PR TITLE
feat(slack): add reaction and listen mode controls

### DIFF
--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -45,7 +45,9 @@ const SNAKE_TO_CAMEL: Record<string, string> = {
   acknowledge_message_reaction: "acknowledgeMessageReaction",
   group_mode: "groupMode",
   inbound_debounce_ms: "inboundDebounceMs",
+  listen_mode: "listenMode",
   remove_stale_routes: "removeStaleRoutes",
+  show_completed_reaction: "showCompletedReaction",
   thread_policy_by_channel: "threadPolicyByChannel",
   transcribe_voice: "transcribeVoice",
 };
@@ -295,6 +297,10 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
       DEFAULT_SLACK_PERMISSION_MODE;
     (next as SlackChannelAccount).transcribeVoice =
       (next as SlackChannelAccount).transcribeVoice === true;
+    (next as SlackChannelAccount).showCompletedReaction =
+      (next as SlackChannelAccount).showCompletedReaction !== false;
+    (next as SlackChannelAccount).listenMode =
+      (next as SlackChannelAccount).listenMode === true;
   }
   if (isDiscordChannelAccount(next)) {
     const migrated = migratePermissionMode(
@@ -405,6 +411,8 @@ function makeDefaultLegacyAccount(
     agentId: null,
     defaultPermissionMode: DEFAULT_SLACK_PERMISSION_MODE,
     transcribeVoice: config.transcribeVoice === true,
+    showCompletedReaction: config.showCompletedReaction !== false,
+    listenMode: config.listenMode === true,
     createdAt: now,
     updatedAt: now,
   };

--- a/src/channels/config.ts
+++ b/src/channels/config.ts
@@ -165,6 +165,8 @@ const slackConfigCodec: ChannelConfigCodec<SlackChannelConfig> = {
       dmPolicy: (parsed.dm_policy as DmPolicy) ?? "pairing",
       allowedUsers: (parsed.allowed_users as string[]) ?? [],
       transcribeVoice: parsed.transcribe_voice === true,
+      showCompletedReaction: parsed.show_completed_reaction !== false,
+      listenMode: parsed.listen_mode === true,
     };
   },
 };

--- a/src/channels/plugin-types.ts
+++ b/src/channels/plugin-types.ts
@@ -157,6 +157,8 @@ export interface ChannelPluginAccountPatch {
   autoThreadOnMention?: boolean;
   threadPolicyByChannel?: Record<string, boolean>;
   acknowledgeMessageReaction?: boolean;
+  showCompletedReaction?: boolean;
+  listenMode?: boolean;
   removeStaleRoutes?: boolean;
   inboundDebounceMs?: number;
   selfChatMode?: boolean;

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -71,6 +71,7 @@ import {
 } from "./routing";
 import { loadTargetStore, upsertChannelTarget } from "./targets";
 import type {
+  ChannelAccount,
   ChannelAdapter,
   ChannelControlRequestEvent,
   ChannelDefaultPermissionMode,
@@ -825,6 +826,7 @@ export class ChannelRegistry {
         route.chatId === chatId &&
         route.agentId === agentId &&
         route.conversationId === conversationId &&
+        route.outboundEnabled !== false &&
         (!normalizedAccountId ||
           (route.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID) ===
             normalizedAccountId) &&
@@ -1301,12 +1303,16 @@ export class ChannelRegistry {
   private shouldDropUnroutedSlackThreadInput(
     msg: InboundChannelMessage,
     accountId: string,
+    config: ChannelAccount | null,
   ): boolean {
     return (
       msg.channel === "slack" &&
       msg.chatType === "channel" &&
       msg.threadId != null &&
       msg.isMention !== true &&
+      (!config ||
+        !isSlackChannelAccount(config) ||
+        config.listenMode !== true) &&
       !this.hasExactEnabledRouteForMessage(msg, accountId)
     );
   }
@@ -1321,11 +1327,11 @@ export class ChannelRegistry {
       return;
     }
 
-    if (this.shouldDropUnroutedSlackThreadInput(msg, accountId)) {
+    const config = getChannelAccount(msg.channel, accountId);
+
+    if (this.shouldDropUnroutedSlackThreadInput(msg, accountId, config)) {
       return;
     }
-
-    const config = getChannelAccount(msg.channel, accountId);
 
     const getStatusRoute = (): ChannelRoute | null => {
       let statusRoute = getRouteFromStore(
@@ -1606,6 +1612,7 @@ export class ChannelRegistry {
   private async createSlackRoute(
     config: SlackChannelAccount,
     msg: InboundChannelMessage,
+    options: { outboundEnabled?: boolean } = {},
   ): Promise<ChannelRoute> {
     if (!config.agentId) {
       throw new Error("Slack app is missing an agent binding.");
@@ -1627,6 +1634,7 @@ export class ChannelRegistry {
       agentId: config.agentId,
       conversationId,
       enabled: true,
+      outboundEnabled: options.outboundEnabled !== false,
       createdAt: now,
       updatedAt: now,
     };
@@ -1652,6 +1660,9 @@ export class ChannelRegistry {
     isFirstRouteTurn: boolean;
   } | null> {
     if (!config.agentId) {
+      if (msg.chatType === "channel" && msg.isMention !== true) {
+        return null;
+      }
       await adapter.sendDirectReply(
         msg.chatId,
         buildSlackAppSetupInstructions(),
@@ -1697,13 +1708,38 @@ export class ChannelRegistry {
     }
 
     if (route) {
+      if (
+        msg.chatType === "channel" &&
+        msg.isMention === true &&
+        route.outboundEnabled === false
+      ) {
+        const updatedRoute: ChannelRoute = {
+          ...route,
+          outboundEnabled: true,
+          updatedAt: new Date().toISOString(),
+        };
+        addRoute(msg.channel, updatedRoute);
+        return {
+          route: updatedRoute,
+          isFirstRouteTurn: false,
+        };
+      }
       return {
         route,
         isFirstRouteTurn: false,
       };
     }
 
-    if (msg.chatType === "channel" && !msg.isMention) {
+    const shouldCreateListenOnlyRoute =
+      msg.chatType === "channel" &&
+      msg.isMention !== true &&
+      config.listenMode === true;
+
+    if (
+      msg.chatType === "channel" &&
+      msg.isMention !== true &&
+      !shouldCreateListenOnlyRoute
+    ) {
       return null;
     }
 
@@ -1725,7 +1761,9 @@ export class ChannelRegistry {
     });
 
     return {
-      route: await this.createSlackRoute(config, msg),
+      route: await this.createSlackRoute(config, msg, {
+        outboundEnabled: !shouldCreateListenOnlyRoute,
+      }),
       isFirstRouteTurn: true,
     };
   }

--- a/src/channels/routing.ts
+++ b/src/channels/routing.ts
@@ -67,6 +67,7 @@ export function loadRoutes(channelId: string): void {
             agentId: route.agentId,
             conversationId: route.conversationId,
             enabled: route.enabled !== false,
+            outboundEnabled: route.outboundEnabled !== false,
             createdAt: route.createdAt ?? new Date().toISOString(),
             updatedAt:
               route.updatedAt ?? route.createdAt ?? new Date().toISOString(),
@@ -97,6 +98,7 @@ export function loadRoutes(channelId: string): void {
             agentId: route.agentId,
             conversationId: route.conversationId,
             enabled: route.enabled !== false,
+            outboundEnabled: route.outboundEnabled !== false,
             createdAt: route.createdAt ?? new Date().toISOString(),
             updatedAt:
               route.updatedAt ?? route.createdAt ?? new Date().toISOString(),
@@ -216,6 +218,7 @@ export function addRoute(channelId: string, route: ChannelRoute): void {
       ...route,
       accountId: normalizeAccountId(route.accountId),
       threadId: route.threadId ?? null,
+      outboundEnabled: route.outboundEnabled !== false,
     },
   );
   saveRoutes(channelId);
@@ -262,6 +265,7 @@ export function setRouteInMemory(channelId: string, route: ChannelRoute): void {
       ...route,
       accountId: normalizeAccountId(route.accountId),
       threadId: route.threadId ?? null,
+      outboundEnabled: route.outboundEnabled !== false,
     },
   );
 }

--- a/src/channels/service.test.ts
+++ b/src/channels/service.test.ts
@@ -736,6 +736,8 @@ describe("channel service", () => {
           mode: "socket",
           agent_id: null,
           transcribe_voice: true,
+          show_completed_reaction: false,
+          listen_mode: true,
         },
       },
       { accountId: "slack-voice" },
@@ -747,12 +749,18 @@ describe("channel service", () => {
         transcribeVoice: true,
         config: expect.objectContaining({
           transcribe_voice: true,
+          show_completed_reaction: false,
+          listen_mode: true,
         }),
       }),
     );
 
     const updated = updateChannelAccountLive("slack", "slack-voice", {
-      config: { transcribe_voice: false },
+      config: {
+        transcribe_voice: false,
+        show_completed_reaction: true,
+        listen_mode: false,
+      },
     });
 
     expect(updated).toEqual(
@@ -761,6 +769,8 @@ describe("channel service", () => {
         transcribeVoice: false,
         config: expect.objectContaining({
           transcribe_voice: false,
+          show_completed_reaction: true,
+          listen_mode: false,
         }),
       }),
     );
@@ -771,6 +781,8 @@ describe("channel service", () => {
         transcribeVoice: false,
         config: expect.objectContaining({
           transcribe_voice: false,
+          show_completed_reaction: true,
+          listen_mode: false,
         }),
       }),
     );

--- a/src/channels/service.test.ts
+++ b/src/channels/service.test.ts
@@ -336,6 +336,58 @@ describe("channel service", () => {
     );
   });
 
+  test("updateChannelRouteLive preserves listen-only outbound state", () => {
+    createChannelAccountLive(
+      "slack",
+      {
+        displayName: "DocsBot Slack",
+        enabled: true,
+        botToken: "xoxb-test-token",
+        appToken: "xapp-test-token",
+        dmPolicy: "pairing",
+      },
+      { accountId: "docsbot" },
+    );
+    addRoute("slack", {
+      accountId: "docsbot",
+      chatId: "C-listen-only",
+      chatType: "channel",
+      threadId: null,
+      agentId: "agent-old",
+      conversationId: "conv-old",
+      enabled: true,
+      outboundEnabled: false,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const updated = updateChannelRouteLive(
+      "slack",
+      "C-listen-only",
+      "agent-new",
+      "conv-new",
+      "docsbot",
+    );
+
+    expect(updated).toEqual(
+      expect.objectContaining({
+        channelId: "slack",
+        accountId: "docsbot",
+        chatId: "C-listen-only",
+        agentId: "agent-new",
+        conversationId: "conv-new",
+        outboundEnabled: false,
+      }),
+    );
+    expect(getRoute("slack", "C-listen-only", "docsbot")).toEqual(
+      expect.objectContaining({
+        agentId: "agent-new",
+        conversationId: "conv-new",
+        outboundEnabled: false,
+      }),
+    );
+  });
+
   test("updateChannelRouteLive creates a Telegram route and binds the account", () => {
     createChannelAccountLive(
       "telegram",

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -112,6 +112,8 @@ export interface ChannelConfigSnapshot {
   autoThreadOnMention?: boolean;
   threadPolicyByChannel?: Record<string, boolean>;
   acknowledgeMessageReaction?: boolean;
+  showCompletedReaction?: boolean;
+  listenMode?: boolean;
   removeStaleRoutes?: boolean;
   inboundDebounceMs?: number;
   selfChatMode?: boolean;
@@ -141,6 +143,7 @@ export interface ChannelRouteSnapshot {
   agentId: string;
   conversationId: string;
   enabled: boolean;
+  outboundEnabled?: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -202,6 +205,8 @@ export interface ChannelAccountSnapshot {
   autoThreadOnMention?: boolean;
   threadPolicyByChannel?: Record<string, boolean>;
   acknowledgeMessageReaction?: boolean;
+  showCompletedReaction?: boolean;
+  listenMode?: boolean;
   removeStaleRoutes?: boolean;
   inboundDebounceMs?: number;
   selfChatMode?: boolean;
@@ -403,6 +408,7 @@ function toRouteSnapshot(
     agentId: route.agentId,
     conversationId: route.conversationId,
     enabled: route.enabled,
+    outboundEnabled: route.outboundEnabled !== false,
     createdAt: route.createdAt,
     updatedAt: route.updatedAt ?? route.createdAt,
   };
@@ -582,6 +588,8 @@ function toAccountSnapshot(account: ChannelAccount): ChannelAccountSnapshot {
     defaultPermissionMode:
       account.defaultPermissionMode ?? DEFAULT_SLACK_PERMISSION_MODE,
     transcribeVoice: account.transcribeVoice === true,
+    showCompletedReaction: account.showCompletedReaction !== false,
+    listenMode: account.listenMode === true,
     createdAt: account.createdAt,
     updatedAt: account.updatedAt,
   };
@@ -687,6 +695,8 @@ function createAccountFromPatch(
     defaultPermissionMode:
       normalizedPatch.defaultPermissionMode ?? DEFAULT_SLACK_PERMISSION_MODE,
     transcribeVoice: normalizedPatch.transcribeVoice === true,
+    showCompletedReaction: normalizedPatch.showCompletedReaction !== false,
+    listenMode: normalizedPatch.listenMode === true,
     dmPolicy: normalizedPatch.dmPolicy ?? "open",
     allowedUsers: normalizedPatch.allowedUsers ?? [],
     createdAt: now,
@@ -824,6 +834,11 @@ function mergeAccountPatch(
       DEFAULT_SLACK_PERMISSION_MODE,
     transcribeVoice:
       normalizedPatch.transcribeVoice ?? existing.transcribeVoice ?? false,
+    showCompletedReaction:
+      normalizedPatch.showCompletedReaction ??
+      existing.showCompletedReaction ??
+      true,
+    listenMode: normalizedPatch.listenMode ?? existing.listenMode ?? false,
     dmPolicy: normalizedPatch.dmPolicy ?? existing.dmPolicy,
     allowedUsers: normalizedPatch.allowedUsers ?? existing.allowedUsers,
     updatedAt: nextUpdatedAt,
@@ -966,6 +981,8 @@ export function getChannelConfigSnapshot(
     defaultPermissionMode:
       account.defaultPermissionMode ?? DEFAULT_SLACK_PERMISSION_MODE,
     transcribeVoice: account.transcribeVoice === true,
+    showCompletedReaction: account.showCompletedReaction !== false,
+    listenMode: account.listenMode === true,
   };
 }
 
@@ -1006,6 +1023,8 @@ export async function setChannelConfigLive(
       autoThreadOnMention: normalizedPatch.autoThreadOnMention,
       threadPolicyByChannel: normalizedPatch.threadPolicyByChannel,
       acknowledgeMessageReaction: normalizedPatch.acknowledgeMessageReaction,
+      showCompletedReaction: normalizedPatch.showCompletedReaction,
+      listenMode: normalizedPatch.listenMode,
       removeStaleRoutes: normalizedPatch.removeStaleRoutes,
       inboundDebounceMs: normalizedPatch.inboundDebounceMs,
       selfChatMode: normalizedPatch.selfChatMode,
@@ -1039,6 +1058,8 @@ export async function setChannelConfigLive(
         autoThreadOnMention: normalizedPatch.autoThreadOnMention,
         threadPolicyByChannel: normalizedPatch.threadPolicyByChannel,
         acknowledgeMessageReaction: normalizedPatch.acknowledgeMessageReaction,
+        showCompletedReaction: normalizedPatch.showCompletedReaction,
+        listenMode: normalizedPatch.listenMode,
         removeStaleRoutes: normalizedPatch.removeStaleRoutes,
         inboundDebounceMs: normalizedPatch.inboundDebounceMs,
         selfChatMode: normalizedPatch.selfChatMode,
@@ -1685,6 +1706,7 @@ export function bindChannelTarget(
     agentId,
     conversationId,
     enabled: true,
+    outboundEnabled: true,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
   };
@@ -1803,6 +1825,7 @@ export function updateChannelRouteLive(
     }),
     agentId,
     conversationId,
+    outboundEnabled: true,
     updatedAt: new Date().toISOString(),
   };
 

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -1825,7 +1825,7 @@ export function updateChannelRouteLive(
     }),
     agentId,
     conversationId,
-    outboundEnabled: true,
+    outboundEnabled: existingRoute?.outboundEnabled ?? true,
     updatedAt: new Date().toISOString(),
   };
 

--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -1237,6 +1237,67 @@ test("slack adapter adds eyes while a queued turn is processing, then swaps to c
   });
 });
 
+test("slack adapter can suppress the completed checkmark while preserving queued eyes", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+    showCompletedReaction: false,
+  });
+
+  await adapter.start();
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "queued",
+    source: {
+      channel: "slack",
+      accountId: "slack-test-account",
+      chatId: "C123",
+      chatType: "channel",
+      messageId: "1712800000.000150",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+    },
+  });
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "finished",
+    batchId: "batch-1",
+    outcome: "completed",
+    sources: [
+      {
+        channel: "slack",
+        accountId: "slack-test-account",
+        chatId: "C123",
+        chatType: "channel",
+        messageId: "1712800000.000150",
+        threadId: "1712790000.000050",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      },
+    ],
+  });
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient?.reactions.add).toHaveBeenCalledTimes(1);
+  expect(writeClient?.reactions.add).toHaveBeenCalledWith({
+    channel: "C123",
+    timestamp: "1712800000.000150",
+    name: "eyes",
+  });
+  expect(writeClient?.reactions.remove).toHaveBeenCalledWith({
+    channel: "C123",
+    timestamp: "1712800000.000150",
+    name: "eyes",
+  });
+});
+
 test("slack adapter swaps queued turns to x when the turn fails", async () => {
   const adapter = createSlackAdapter({
     ...slackAccountDefaults,

--- a/src/channels/slack-registry.test.ts
+++ b/src/channels/slack-registry.test.ts
@@ -23,6 +23,11 @@ import {
   clearAllRoutes,
   getRoute,
 } from "@/channels/routing";
+import {
+  __testOverrideLoadTargetStore,
+  __testOverrideSaveTargetStore,
+  clearTargetStores,
+} from "@/channels/targets";
 import type { ChannelAdapter, InboundChannelMessage } from "@/channels/types";
 
 const createConversation = mock(async () => ({ id: "conv-slack" }));
@@ -41,12 +46,15 @@ describe("slack channel registry", () => {
     clearChannelAccountStores();
     clearAllRoutes();
     clearPairingStores();
+    clearTargetStores();
     __testOverrideLoadChannelAccounts(null);
     __testOverrideSaveChannelAccounts(null);
     __testOverrideLoadRoutes(null);
     __testOverrideSaveRoutes(null);
     __testOverrideLoadPairingStore(null);
     __testOverrideSavePairingStore(null);
+    __testOverrideLoadTargetStore(null);
+    __testOverrideSaveTargetStore(null);
     createConversation.mockReset();
     createConversation.mockResolvedValue({ id: "conv-slack" });
   }
@@ -108,6 +116,8 @@ describe("slack channel registry", () => {
     __testOverrideSaveRoutes(() => {});
     __testOverrideLoadPairingStore(() => null);
     __testOverrideSavePairingStore(() => {});
+    __testOverrideLoadTargetStore(() => null);
+    __testOverrideSaveTargetStore(() => {});
   });
 
   afterEach(async () => {

--- a/src/channels/slack-registry.test.ts
+++ b/src/channels/slack-registry.test.ts
@@ -1,0 +1,212 @@
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import {
+  __testOverrideLoadChannelAccounts,
+  __testOverrideSaveChannelAccounts,
+  clearChannelAccountStores,
+} from "@/channels/accounts";
+import {
+  __testOverrideLoadPairingStore,
+  __testOverrideSavePairingStore,
+  clearPairingStores,
+} from "@/channels/pairing";
+import {
+  __testOverrideLoadRoutes,
+  __testOverrideSaveRoutes,
+  clearAllRoutes,
+  getRoute,
+} from "@/channels/routing";
+import type { ChannelAdapter, InboundChannelMessage } from "@/channels/types";
+
+const createConversation = mock(async () => ({ id: "conv-slack" }));
+
+mock.module("@/backend/api/client", () => ({
+  getServerUrl: () => "https://api.letta.com",
+  getClient: async () => ({
+    conversations: {
+      create: createConversation,
+    },
+  }),
+}));
+
+describe("slack channel registry", () => {
+  function resetState(): void {
+    clearChannelAccountStores();
+    clearAllRoutes();
+    clearPairingStores();
+    __testOverrideLoadChannelAccounts(null);
+    __testOverrideSaveChannelAccounts(null);
+    __testOverrideLoadRoutes(null);
+    __testOverrideSaveRoutes(null);
+    __testOverrideLoadPairingStore(null);
+    __testOverrideSavePairingStore(null);
+    createConversation.mockReset();
+    createConversation.mockResolvedValue({ id: "conv-slack" });
+  }
+
+  function createInboundMessage(
+    overrides: Partial<InboundChannelMessage> = {},
+  ): InboundChannelMessage {
+    return {
+      channel: "slack",
+      accountId: "slack-bot",
+      chatId: "C123",
+      senderId: "U123",
+      senderName: "Cameron",
+      text: "thread update",
+      timestamp: Date.now(),
+      messageId: "1712800000.000200",
+      threadId: "1712790000.000050",
+      chatType: "channel",
+      isMention: false,
+      ...overrides,
+    };
+  }
+
+  function createAdapter(): ChannelAdapter {
+    return {
+      id: "slack:slack-bot",
+      channelId: "slack",
+      accountId: "slack-bot",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "outbound-1" }),
+      sendDirectReply: async () => {},
+    };
+  }
+
+  beforeEach(() => {
+    resetState();
+    __testOverrideLoadChannelAccounts(() => [
+      {
+        channel: "slack",
+        accountId: "slack-bot",
+        enabled: true,
+        mode: "socket",
+        botToken: "xoxb-test-token",
+        appToken: "xapp-test-token",
+        agentId: "agent-1",
+        defaultPermissionMode: "unrestricted",
+        dmPolicy: "open",
+        allowedUsers: [],
+        listenMode: true,
+        createdAt: "2026-04-11T00:00:00.000Z",
+        updatedAt: "2026-04-11T00:00:00.000Z",
+      },
+    ]);
+    __testOverrideSaveChannelAccounts(() => {});
+    __testOverrideLoadRoutes(() => null);
+    __testOverrideSaveRoutes(() => {});
+    __testOverrideLoadPairingStore(() => null);
+    __testOverrideSavePairingStore(() => {});
+  });
+
+  afterEach(async () => {
+    const { getChannelRegistry } = await import("@/channels/registry");
+    const registry = getChannelRegistry();
+    if (registry) {
+      await registry.stopAll();
+    }
+    resetState();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  test("listen mode delivers unmentioned thread activity without outbound route access", async () => {
+    const { ChannelRegistry } = await import("@/channels/registry");
+    const registry = new ChannelRegistry();
+    const adapter = createAdapter();
+    registry.registerAdapter(adapter);
+
+    const deliveries: Array<{ turnSources?: unknown[] }> = [];
+    registry.setMessageHandler((delivery) => {
+      deliveries.push(delivery);
+    });
+    registry.setReady();
+
+    await adapter.onMessage?.(createInboundMessage());
+
+    expect(createConversation).toHaveBeenCalledTimes(1);
+    const route = getRoute("slack", "C123", "slack-bot", "1712790000.000050");
+    expect(route).toEqual(expect.objectContaining({ outboundEnabled: false }));
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]?.turnSources).toEqual([
+      expect.objectContaining({
+        channel: "slack",
+        accountId: "slack-bot",
+        chatId: "C123",
+        threadId: "1712790000.000050",
+        messageId: "1712800000.000200",
+        agentId: "agent-1",
+        conversationId: "conv-slack",
+      }),
+    ]);
+    expect(
+      registry.getRouteForScope(
+        "slack",
+        "C123",
+        "agent-1",
+        "conv-slack",
+        "slack-bot",
+      ),
+    ).toBeNull();
+  });
+
+  test("an explicit Slack mention upgrades a listen-only route for outbound replies", async () => {
+    const { ChannelRegistry } = await import("@/channels/registry");
+    const registry = new ChannelRegistry();
+    const adapter = createAdapter();
+    registry.registerAdapter(adapter);
+
+    const deliveries: Array<{ turnSources?: unknown[] }> = [];
+    registry.setMessageHandler((delivery) => {
+      deliveries.push(delivery);
+    });
+    registry.setReady();
+
+    await adapter.onMessage?.(createInboundMessage());
+    await adapter.onMessage?.(
+      createInboundMessage({
+        isMention: true,
+        text: "can you look?",
+        messageId: "1712800001.000300",
+      }),
+    );
+
+    expect(createConversation).toHaveBeenCalledTimes(1);
+    const route = getRoute("slack", "C123", "slack-bot", "1712790000.000050");
+    expect(route).toEqual(expect.objectContaining({ outboundEnabled: true }));
+    expect(deliveries).toHaveLength(2);
+    expect(deliveries[1]?.turnSources).toEqual([
+      expect.objectContaining({
+        channel: "slack",
+        accountId: "slack-bot",
+        chatId: "C123",
+        threadId: "1712790000.000050",
+        messageId: "1712800001.000300",
+        agentId: "agent-1",
+        conversationId: "conv-slack",
+      }),
+    ]);
+    expect(
+      registry.getRouteForScope(
+        "slack",
+        "C123",
+        "agent-1",
+        "conv-slack",
+        "slack-bot",
+      ),
+    ).not.toBeNull();
+  });
+});

--- a/src/channels/slack/account-config.ts
+++ b/src/channels/slack/account-config.ts
@@ -13,6 +13,8 @@ const SLACK_CONFIG_KEYS = new Set([
   "agent_id",
   "default_permission_mode",
   "transcribe_voice",
+  "show_completed_reaction",
+  "listen_mode",
 ]);
 
 function isString(value: unknown): value is string {
@@ -57,7 +59,10 @@ export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannel
         (config.default_permission_mode === undefined ||
           isDefaultPermissionMode(config.default_permission_mode)) &&
         (config.transcribe_voice === undefined ||
-          isBoolean(config.transcribe_voice))
+          isBoolean(config.transcribe_voice)) &&
+        (config.show_completed_reaction === undefined ||
+          isBoolean(config.show_completed_reaction)) &&
+        (config.listen_mode === undefined || isBoolean(config.listen_mode))
       );
     },
 
@@ -79,6 +84,12 @@ export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannel
         transcribeVoice: isBoolean(config.transcribe_voice)
           ? config.transcribe_voice
           : undefined,
+        showCompletedReaction: isBoolean(config.show_completed_reaction)
+          ? config.show_completed_reaction
+          : undefined,
+        listenMode: isBoolean(config.listen_mode)
+          ? config.listen_mode
+          : undefined,
       };
     },
 
@@ -91,6 +102,8 @@ export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannel
         default_permission_mode:
           account.defaultPermissionMode ?? DEFAULT_SLACK_PERMISSION_MODE,
         transcribe_voice: account.transcribeVoice === true,
+        show_completed_reaction: account.showCompletedReaction !== false,
+        listen_mode: account.listenMode === true,
       };
     },
 
@@ -103,6 +116,8 @@ export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannel
         default_permission_mode:
           account.defaultPermissionMode ?? DEFAULT_SLACK_PERMISSION_MODE,
         transcribe_voice: account.transcribeVoice === true,
+        show_completed_reaction: account.showCompletedReaction !== false,
+        listen_mode: account.listenMode === true,
       };
     },
 

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -837,10 +837,15 @@ export function createSlackAdapter(
           } catch {}
         }
 
-        await sendLifecycleReaction(
-          source,
-          nextState === "completed" ? "white_check_mark" : "x",
-        );
+        if (
+          nextState !== "completed" ||
+          config.showCompletedReaction !== false
+        ) {
+          await sendLifecycleReaction(
+            source,
+            nextState === "completed" ? "white_check_mark" : "x",
+          );
+        }
         lifecycleStateByMessageKey.set(key, {
           state: nextState,
           updatedAt: Date.now(),

--- a/src/channels/slack/proactive-accounts.ts
+++ b/src/channels/slack/proactive-accounts.ts
@@ -29,7 +29,8 @@ export function listEligibleProactiveSlackAccounts(params: {
     if (
       route.agentId !== params.agentId ||
       route.conversationId !== params.conversationId ||
-      !route.enabled
+      !route.enabled ||
+      route.outboundEnabled === false
     ) {
       continue;
     }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -279,6 +279,8 @@ export interface ChannelRoute {
   conversationId: string;
   /** Whether this route is active. */
   enabled: boolean;
+  /** Whether this route permits outbound MessageChannel sends. Defaults true. */
+  outboundEnabled?: boolean;
   /** ISO 8601 creation timestamp. */
   createdAt: string;
   /** ISO 8601 update timestamp. */
@@ -335,6 +337,10 @@ export interface SlackChannelConfig {
   allowedUsers: string[];
   /** When true and OPENAI_API_KEY is set, inbound audio attachments are auto-transcribed. */
   transcribeVoice?: boolean;
+  /** When false, successful turns remove 👀 without adding ✅. Default true. */
+  showCompletedReaction?: boolean;
+  /** When true, unmentioned Slack thread replies are delivered read-only until an @mention. */
+  listenMode?: boolean;
 }
 
 export interface DiscordChannelConfig {
@@ -456,6 +462,10 @@ export interface SlackChannelAccount extends ChannelAccountBase {
   defaultPermissionMode: SlackDefaultPermissionMode;
   /** When true and OPENAI_API_KEY is set, inbound audio attachments are auto-transcribed. */
   transcribeVoice?: boolean;
+  /** When false, successful turns remove 👀 without adding ✅. Default true. */
+  showCompletedReaction?: boolean;
+  /** When true, unmentioned Slack thread replies are delivered read-only until an @mention. */
+  listenMode?: boolean;
   /**
    * Optional debounce window (ms) for inbound messages. When greater than
    * `0`, short back-to-back messages from the same sender in the same

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -304,7 +304,8 @@ export function resolveConversationChannelToolScope(
       if (
         route.agentId !== agentId ||
         route.conversationId !== conversationId ||
-        !route.enabled
+        !route.enabled ||
+        route.outboundEnabled === false
       ) {
         continue;
       }

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -398,6 +398,7 @@ export interface ChannelRouteSnapshot {
   agent_id: string;
   conversation_id: string;
   enabled: boolean;
+  outbound_enabled?: boolean;
   created_at: string;
   updated_at: string;
 }

--- a/src/websocket/listener/commands/channels.ts
+++ b/src/websocket/listener/commands/channels.ts
@@ -396,6 +396,7 @@ export async function handleChannelsProtocolCommand(
     agent_id: route.agentId,
     conversation_id: route.conversationId,
     enabled: route.enabled,
+    outbound_enabled: route.outboundEnabled,
     created_at: route.createdAt,
     updated_at: route.updatedAt,
   });


### PR DESCRIPTION
Agent: Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Problem

Slack runs currently always add a completed ✅ reaction after removing 👀. In busy threads that creates visual clutter, while 👀 and ❌ are still useful state indicators.

There is also no read-only Slack intake mode for agents that should see thread activity without being allowed to post until they are explicitly invited.

## Approach

- Add Slack account config fields `show_completed_reaction` and `listen_mode` across config parsing, account persistence, snapshots, and protocol config payloads.
- Keep 👀 queued reactions and ❌ failure reactions unchanged, but skip the completed ✅ when `show_completed_reaction` is false.
- Add route-level `outboundEnabled` state. Slack listen mode can create a read-only route for unmentioned threaded channel activity; that route still carries lifecycle source context, but MessageChannel/proactive Slack eligibility ignores it.
- Upgrade a listen-only Slack route to outbound-enabled on an explicit mention in the same thread.

## Behavior

Default behavior is unchanged: completed turns still add ✅ and normal Slack mentions still create outbound-capable routes.

With `show_completed_reaction: false`, completion removes 👀 and does not add ✅. Failed turns still add ❌.

With `listen_mode: true`, unmentioned Slack thread replies can reach the bound agent conversation, but the route is not eligible for MessageChannel sends until someone explicitly mentions the agent in that thread.

## Validation

- `bun test src/channels/slack-adapter.test.ts src/channels/service.test.ts src/channels/slack-registry.test.ts`
- `bun test src/websocket/listen-client-protocol.test.ts`
- `bun run check`
