### PR TITLE
fix(cli): avoid waited copy for background terminal checks

### DIFF
--- a/src/cli/format-args-display.test.ts
+++ b/src/cli/format-args-display.test.ts
@@ -110,7 +110,7 @@ describe("formatArgsDisplay compact plan/todo headers", () => {
     expect(formatted.shellSemantic).toBeUndefined();
   });
 
-  test("summarizes Codex write_stdin polling with Codex-like language", () => {
+  test("summarizes Codex write_stdin polling as a background terminal check", () => {
     const args = JSON.stringify({
       session_id: 8,
       yield_time_ms: 1000,
@@ -118,7 +118,7 @@ describe("formatArgsDisplay compact plan/todo headers", () => {
     });
 
     const formatted = formatArgsDisplay(args, "write_stdin");
-    expect(formatted.displayName).toBe("Waited for background terminal");
+    expect(formatted.displayName).toBe("Checked background terminal");
     expect(formatted.display).toBe("(session 8)");
     expect(formatted.shellSemantic).toBeUndefined();
   });

--- a/src/cli/helpers/format-args-display.ts
+++ b/src/cli/helpers/format-args-display.ts
@@ -379,7 +379,7 @@ export function formatArgsDisplay(
               display: suffix,
               displayName: isWrite
                 ? "Interacted with background terminal"
-                : "Waited for background terminal",
+                : "Checked background terminal",
               parsed,
             };
           }


### PR DESCRIPTION
## Summary
- Rename the empty `write_stdin` background terminal display label from "Waited for background terminal" to "Checked background terminal".
- Update the focused `formatArgsDisplay` test expectation and test name for the new copy.

## Test plan
- [x] `bun test /Users/lettamate/letta-code/.letta/worktrees/background-terminal-copy/src/cli/format-args-display.test.ts`
- [x] `bunx --bun @biomejs/biome@2.2.5 check src/cli/helpers/format-args-display.ts src/cli/format-args-display.test.ts`

👾 Generated with [Letta Code](https://letta.com)