### PR TITLE
feat(cli): add cron update command

### DIFF
--- a/src/cli/subcommands/cron.test.ts
+++ b/src/cli/subcommands/cron.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { runCronSubcommand } from "@/cli/subcommands/cron";
+import {
+  type AddTaskInput,
+  addTask,
+  getTask,
+  updateTask,
+} from "@/cron/cron-file";
+
+const TEST_DIR = path.join(import.meta.dir, "__cron_cli_test_tmp__");
+const origHome = process.env.LETTA_HOME;
+const origXdg = process.env.XDG_CONFIG_HOME;
+
+beforeEach(() => {
+  if (existsSync(TEST_DIR)) {
+    rmSync(TEST_DIR, { recursive: true });
+  }
+  mkdirSync(TEST_DIR, { recursive: true });
+  process.env.LETTA_HOME = TEST_DIR;
+});
+
+afterEach(() => {
+  if (existsSync(TEST_DIR)) {
+    rmSync(TEST_DIR, { recursive: true });
+  }
+  if (origHome) process.env.LETTA_HOME = origHome;
+  else delete process.env.LETTA_HOME;
+  if (origXdg) process.env.XDG_CONFIG_HOME = origXdg;
+  else delete process.env.XDG_CONFIG_HOME;
+});
+
+function makeInput(overrides: Partial<AddTaskInput> = {}): AddTaskInput {
+  return {
+    agent_id: "agent-test-001",
+    conversation_id: "default",
+    name: "Test task",
+    description: "A test cron task",
+    prompt: "original prompt",
+    cron: "*/5 * * * *",
+    recurring: true,
+    ...overrides,
+  };
+}
+
+async function runCron(argv: string[]): Promise<{
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}> {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = (message?: unknown) => {
+    logs.push(String(message ?? ""));
+  };
+  console.error = (message?: unknown) => {
+    errors.push(String(message ?? ""));
+  };
+
+  try {
+    const exitCode = await runCronSubcommand(argv);
+    return {
+      exitCode,
+      stdout: logs.join("\n"),
+      stderr: errors.join("\n"),
+    };
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+}
+
+function parseJson<T>(stdout: string): T {
+  return JSON.parse(stdout) as T;
+}
+
+function markRunMetadata(taskId: string): void {
+  updateTask(taskId, (task) => {
+    task.fire_count = 7;
+    task.last_fired_at = "2026-01-01T00:00:00.000Z";
+    task.last_run_at = "2026-01-01T00:00:01.000Z";
+    task.last_run_outcome = "queued";
+    task.last_run_reason = "scheduled_time_matched";
+    task.last_run_error = "kept for regression coverage";
+    task.last_missed_at = "2026-01-01T00:01:00.000Z";
+    task.missed_count = 2;
+    task.failed_count = 1;
+  });
+}
+
+describe("letta cron update", () => {
+  test("updates prompt in place and preserves run metadata", async () => {
+    const { task } = addTask(makeInput());
+    markRunMetadata(task.id);
+
+    const result = await runCron([
+      "update",
+      task.id,
+      "--prompt",
+      "updated prompt",
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    const output = parseJson<typeof task>(result.stdout);
+    expect(output.id).toBe(task.id);
+    expect(output.prompt).toBe("updated prompt");
+    expect(output.fire_count).toBe(7);
+    expect(output.last_fired_at).toBe("2026-01-01T00:00:00.000Z");
+    expect(output.last_run_outcome).toBe("queued");
+    expect(output.missed_count).toBe(2);
+    expect(getTask(task.id)?.prompt).toBe("updated prompt");
+  });
+
+  test("updates prompt from --prompt-file", async () => {
+    const { task } = addTask(makeInput());
+    const promptPath = path.join(TEST_DIR, "prompt.txt");
+    writeFileSync(promptPath, "from file\nwith context", "utf8");
+
+    const result = await runCron([
+      "update",
+      task.id,
+      "--prompt-file",
+      promptPath,
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    const output = parseJson<typeof task>(result.stdout);
+    expect(output.id).toBe(task.id);
+    expect(output.prompt).toBe("from file\nwith context");
+    expect(getTask(task.id)?.prompt).toBe("from file\nwith context");
+  });
+
+  test("updates recurring cron schedule without changing task identity", async () => {
+    const { task } = addTask(makeInput());
+    markRunMetadata(task.id);
+
+    const result = await runCron(["update", task.id, "--cron", "0 9 * * 1-5"]);
+
+    expect(result.exitCode).toBe(0);
+    const output = parseJson<typeof task>(result.stdout);
+    expect(output.id).toBe(task.id);
+    expect(output.created_at).toBe(task.created_at);
+    expect(output.cron).toBe("0 9 * * 1-5");
+    expect(output.recurring).toBe(true);
+    expect(output.scheduled_for).toBeNull();
+    expect(output.fire_count).toBe(7);
+    expect(getTask(task.id)?.cron).toBe("0 9 * * 1-5");
+  });
+
+  test("updates a task to a one-shot schedule", async () => {
+    const { task } = addTask(makeInput());
+    const before = Date.now();
+
+    const result = await runCron(["update", task.id, "--at", "in 30m"]);
+
+    expect(result.exitCode).toBe(0);
+    const output = parseJson<typeof task>(result.stdout);
+    expect(output.id).toBe(task.id);
+    expect(output.recurring).toBe(false);
+    expect(output.scheduled_for).not.toBeNull();
+    expect(new Date(output.scheduled_for ?? "").getTime()).toBeGreaterThan(
+      before,
+    );
+    expect(output.cron.split(/\s+/)).toHaveLength(5);
+    expect(getTask(task.id)?.recurring).toBe(false);
+  });
+
+  test("updates name, description, conversation, and timezone", async () => {
+    const { task } = addTask(makeInput());
+
+    const result = await runCron([
+      "update",
+      task.id,
+      "--name",
+      "renamed task",
+      "--description",
+      "new description",
+      "--conversation",
+      "conversation-123",
+      "--timezone",
+      "America/Los_Angeles",
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    const output = parseJson<typeof task>(result.stdout);
+    expect(output.id).toBe(task.id);
+    expect(output.name).toBe("renamed task");
+    expect(output.description).toBe("new description");
+    expect(output.conversation_id).toBe("conversation-123");
+    expect(output.timezone).toBe("America/Los_Angeles");
+    expect(getTask(task.id)?.timezone).toBe("America/Los_Angeles");
+  });
+
+  test("rejects invalid cron expressions without mutating the task", async () => {
+    const { task } = addTask(makeInput());
+    const before = getTask(task.id);
+
+    const result = await runCron(["update", task.id, "--cron", "not a cron"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("invalid cron expression");
+    expect(getTask(task.id)).toEqual(before);
+  });
+
+  test("requires a task ID", async () => {
+    const result = await runCron(["update", "--prompt", "updated"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("task ID required");
+  });
+});

--- a/src/cli/subcommands/cron.ts
+++ b/src/cli/subcommands/cron.ts
@@ -8,13 +8,16 @@
  *   letta cron list [--agent <id>] [--conversation <id>]
  *   letta cron get <id>
  *   letta cron runs --id <id>
+ *   letta cron update <id> [--prompt <text> | --prompt-file <path>] [--cron <expr> | --every <interval> | --at <time>]
  *   letta cron delete <id>
  *   letta cron delete --all [--agent <id>]
  */
 
+import { readFileSync } from "node:fs";
 import { parseArgs } from "node:util";
 import {
   addTask,
+  computeJitter,
   deleteAllTasks,
   deleteTask,
   getCronRunLogPath,
@@ -24,6 +27,7 @@ import {
   parseAt,
   parseEvery,
   readCronRunLogEntriesPage,
+  updateTask,
 } from "@/cron";
 
 // ── Usage ───────────────────────────────────────────────────────────
@@ -38,6 +42,7 @@ Usage:
   letta cron list [options]
   letta cron get <id>
   letta cron runs --id <id> [--limit <n>]
+  letta cron update <id> [options]
   letta cron delete <id>
   letta cron delete --all [--agent <id>]
 
@@ -49,6 +54,18 @@ Add options:
   --cron <expr>          Raw 5-field cron expression
   --agent <id>           Agent ID (defaults to LETTA_AGENT_ID)
   --conversation <id>    Conversation ID (defaults to LETTA_CONVERSATION_ID or "default")
+  --timezone <iana>      Timezone for cron matching (defaults to local timezone)
+
+Update options:
+  --prompt <text>        Replace the task prompt
+  --prompt-file <path>   Read replacement prompt from a file
+  --every <interval>     Replace schedule with a recurring interval
+  --at <time>            Replace schedule with a one-shot time
+  --cron <expr>          Replace schedule with a raw recurring cron expression
+  --name <text>          Replace the task name
+  --description <text>   Replace the task description
+  --conversation <id>    Replace the conversation binding
+  --timezone <iana>      Replace the timezone used for cron matching
 
 List/filter options:
   --agent <id>           Filter by agent ID
@@ -69,12 +86,14 @@ const CRON_OPTIONS = {
   name: { type: "string" },
   description: { type: "string" },
   prompt: { type: "string" },
+  "prompt-file": { type: "string" },
   every: { type: "string" },
   at: { type: "string" },
   once: { type: "boolean" },
   cron: { type: "string" },
   agent: { type: "string" },
   conversation: { type: "string" },
+  timezone: { type: "string" },
   all: { type: "boolean" },
   id: { type: "string" },
   limit: { type: "string" },
@@ -90,6 +109,8 @@ function parseCronArgs(argv: string[]) {
   });
 }
 
+type CronValues = ReturnType<typeof parseCronArgs>["values"];
+
 function getAgentId(fromArgs?: string): string {
   return fromArgs || process.env.LETTA_AGENT_ID || "";
 }
@@ -98,9 +119,116 @@ function getConversationId(fromArgs?: string): string {
   return fromArgs || process.env.LETTA_CONVERSATION_ID || "default";
 }
 
+type SchedulePatch = {
+  cron: string;
+  recurring: boolean;
+  scheduledFor: Date | null;
+};
+
+function parsePromptPatch(values: CronValues): {
+  prompt?: string;
+  error?: string;
+} {
+  const prompt = values.prompt;
+  const promptFile = values["prompt-file"];
+
+  if (prompt !== undefined && promptFile !== undefined) {
+    return { error: "Error: only one of --prompt or --prompt-file allowed." };
+  }
+
+  if (prompt !== undefined) {
+    if (!prompt) {
+      return { error: "Error: --prompt must not be empty." };
+    }
+    return { prompt };
+  }
+
+  if (promptFile !== undefined) {
+    if (!promptFile) {
+      return { error: "Error: --prompt-file requires a path." };
+    }
+    try {
+      const filePrompt = readFileSync(promptFile, "utf8");
+      if (!filePrompt) {
+        return { error: `Error: prompt file ${promptFile} is empty.` };
+      }
+      return { prompt: filePrompt };
+    } catch (err) {
+      return {
+        error: `Error: failed to read prompt file ${promptFile}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      };
+    }
+  }
+
+  return {};
+}
+
+function parseSchedulePatch(values: CronValues): {
+  patch?: SchedulePatch;
+  error?: string;
+} {
+  const everyValue = values.every;
+  const atValue = values.at;
+  const cronValue = values.cron;
+
+  const specCount = [everyValue, atValue, cronValue].filter(
+    (value) => value !== undefined,
+  ).length;
+  if (specCount > 1) {
+    return { error: "Error: only one of --every, --at, or --cron allowed." };
+  }
+
+  if (values.once && atValue === undefined) {
+    return {
+      error: "Error: --once can only be used with --at for one-shot tasks.",
+    };
+  }
+
+  if (everyValue !== undefined) {
+    const parsed = parseEvery(everyValue);
+    if (!parsed) {
+      return {
+        error: `Error: invalid interval "${everyValue}". Try: 5m, 2h, 1d`,
+      };
+    }
+    return {
+      patch: { cron: parsed.cron, recurring: true, scheduledFor: null },
+    };
+  }
+
+  if (atValue !== undefined) {
+    const parsed = parseAt(atValue);
+    if (!parsed) {
+      return {
+        error: `Error: invalid time "${atValue}". Try: "3:00pm", "in 45m"`,
+      };
+    }
+    return {
+      patch: {
+        cron: parsed.cron,
+        recurring: false,
+        scheduledFor: parsed.scheduledFor,
+      },
+    };
+  }
+
+  if (cronValue !== undefined) {
+    if (!isValidCron(cronValue)) {
+      return {
+        error: `Error: invalid cron expression "${cronValue}". Needs 5 fields.`,
+      };
+    }
+    return { patch: { cron: cronValue, recurring: true, scheduledFor: null } };
+  }
+
+  return {};
+}
+
 // ── Handlers ────────────────────────────────────────────────────────
 
-function handleAdd(values: ReturnType<typeof parseCronArgs>["values"]): number {
+function handleAdd(values: CronValues): number {
   const name = values.name;
   if (!name || typeof name !== "string") {
     console.error("Error: --name is required.");
@@ -197,6 +325,7 @@ function handleAdd(values: ReturnType<typeof parseCronArgs>["values"]): number {
       cron,
       recurring,
       prompt,
+      timezone: values.timezone,
       scheduled_for: scheduledFor,
     });
 
@@ -231,9 +360,7 @@ function handleAdd(values: ReturnType<typeof parseCronArgs>["values"]): number {
   }
 }
 
-function handleList(
-  values: ReturnType<typeof parseCronArgs>["values"],
-): number {
+function handleList(values: CronValues): number {
   const agentId = values.agent || process.env.LETTA_AGENT_ID || undefined;
   const conversationId = values.conversation || undefined;
 
@@ -263,9 +390,7 @@ function handleGet(positionals: string[]): number {
   return 0;
 }
 
-function handleRuns(
-  values: ReturnType<typeof parseCronArgs>["values"],
-): number {
+function handleRuns(values: CronValues): number {
   const id = values.id;
   if (!id || typeof id !== "string") {
     console.error("Error: --id is required. Usage: letta cron runs --id <id>");
@@ -291,10 +416,85 @@ function handleRuns(
   }
 }
 
-function handleDelete(
-  values: ReturnType<typeof parseCronArgs>["values"],
-  positionals: string[],
-): number {
+function handleUpdate(values: CronValues, positionals: string[]): number {
+  const taskId = positionals[1];
+  if (!taskId) {
+    console.error("Error: task ID required. Usage: letta cron update <id>");
+    return 1;
+  }
+
+  const promptPatch = parsePromptPatch(values);
+  if (promptPatch.error) {
+    console.error(promptPatch.error);
+    return 1;
+  }
+
+  const schedulePatch = parseSchedulePatch(values);
+  if (schedulePatch.error) {
+    console.error(schedulePatch.error);
+    return 1;
+  }
+
+  const hasPatch =
+    values.name !== undefined ||
+    values.description !== undefined ||
+    values.conversation !== undefined ||
+    values.timezone !== undefined ||
+    promptPatch.prompt !== undefined ||
+    schedulePatch.patch !== undefined;
+  if (!hasPatch) {
+    console.error("Error: at least one update option is required.");
+    return 1;
+  }
+
+  try {
+    const updated = updateTask(taskId, (task) => {
+      if (values.name !== undefined) task.name = values.name;
+      if (values.description !== undefined) {
+        task.description = values.description;
+      }
+      if (values.conversation !== undefined) {
+        task.conversation_id = values.conversation;
+      }
+      if (values.timezone !== undefined) {
+        task.timezone = values.timezone;
+      }
+      if (promptPatch.prompt !== undefined) {
+        task.prompt = promptPatch.prompt;
+      }
+      if (schedulePatch.patch !== undefined) {
+        const createdAt = new Date(task.created_at);
+        const jitterCreatedAt = Number.isNaN(createdAt.getTime())
+          ? new Date()
+          : createdAt;
+        task.cron = schedulePatch.patch.cron;
+        task.recurring = schedulePatch.patch.recurring;
+        task.scheduled_for =
+          schedulePatch.patch.scheduledFor?.toISOString() ?? null;
+        task.jitter_offset_ms = computeJitter(
+          task.id,
+          task.cron,
+          task.recurring,
+          schedulePatch.patch.scheduledFor,
+          jitterCreatedAt,
+        );
+      }
+    });
+
+    if (!updated) {
+      console.error(`Error: task ${taskId} not found.`);
+      return 1;
+    }
+
+    console.log(JSON.stringify(updated, null, 2));
+    return 0;
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+}
+
+function handleDelete(values: CronValues, positionals: string[]): number {
   if (values.all) {
     const agentId = getAgentId(values.agent);
     if (!agentId) {
@@ -351,6 +551,8 @@ export async function runCronSubcommand(argv: string[]): Promise<number> {
       return handleGet(parsed.positionals);
     case "runs":
       return handleRuns(parsed.values);
+    case "update":
+      return handleUpdate(parsed.values, parsed.positionals);
     case "delete":
       return handleDelete(parsed.values, parsed.positionals);
     default:

--- a/src/skills/builtin/scheduling-tasks/SKILL.md
+++ b/src/skills/builtin/scheduling-tasks/SKILL.md
@@ -12,7 +12,7 @@ This skill lets you create, list, and manage scheduled tasks using the `letta cr
 - User asks to be reminded of something ("remind me to X at Y")
 - User wants a recurring check-in ("every morning ask me about X")
 - User wants a one-shot delayed message ("in 30 minutes, check on X")
-- User wants to see or cancel existing scheduled tasks
+- User wants to see, edit, or cancel existing scheduled tasks
 
 ## CLI Usage
 
@@ -46,6 +46,7 @@ letta cron add --name <short-name> --description <text> --prompt <text> <schedul
 |------|-------------|
 | `--agent <id>` | Agent ID (defaults to `LETTA_AGENT_ID` from the current shell/session) |
 | `--conversation <id>` | Conversation ID (defaults to `LETTA_CONVERSATION_ID` from the current shell/session, otherwise `"default"`) |
+| `--timezone <iana>` | Timezone used for cron matching (defaults to the local timezone) |
 
 ### Listing Tasks
 
@@ -59,6 +60,18 @@ Optional filters: `--agent <id>`, `--conversation <id>`
 
 ```bash
 letta cron get <task-id>
+```
+
+### Updating Tasks
+
+Patch an existing task in place instead of deleting and recreating it. This preserves the task ID and run metadata.
+
+```bash
+letta cron update <task-id> --prompt "Updated prompt"
+letta cron update <task-id> --prompt-file ./prompt.txt
+letta cron update <task-id> --cron "0 9 * * 1-5"
+letta cron update <task-id> --timezone "America/Los_Angeles"
+letta cron update <task-id> --at "in 30m"
 ```
 
 ### Binding a Task to the Right Conversation
@@ -147,6 +160,16 @@ If you need to confirm the exact conversation a task is bound to, list with expl
 
 ```bash
 letta cron list --agent "$AGENT_ID" --conversation "$CONVERSATION_ID"
+```
+
+### "Change the dog walk reminder prompt"
+
+First list to find the task ID, then update it in place:
+
+```bash
+letta cron list
+# Find the task ID from the output, then:
+letta cron update <task-id> --prompt "Hey! Walk the dog before standup."
 ```
 
 ### "Cancel the dog walk reminder"


### PR DESCRIPTION
## Summary
- Add `letta cron update <id>` to patch prompts, schedules, metadata fields, timezone, and conversation in place while preserving task IDs and run metadata.
- Support `--prompt-file`, recurring and one-shot schedule edits, cron validation, and jitter recomputation on schedule changes.
- Update bundled scheduling skill guidance to prefer in-place updates.

## Test plan
- [x] bun test src/cli/subcommands/cron.test.ts
- [x] bun run check

Fixes #2937

👾 Generated with [Letta Code](https://letta.com)