### PR TITLE
fix(websocket): log v2 command details

### DIFF
--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -166,6 +166,192 @@ type MessageRouterParams = {
   wireChannelIngress: WireChannelIngress;
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function formatLogValue(value: unknown): string | null {
+  if (value === undefined) return null;
+  if (value === null) return "null";
+  if (typeof value === "string") {
+    return value.length > 80 ? `${value.slice(0, 77)}...` : value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.length}]`;
+  }
+  return null;
+}
+
+function pushField(
+  fields: string[],
+  key: string,
+  value: unknown,
+  label = key,
+): void {
+  const formatted = formatLogValue(value);
+  if (formatted !== null) {
+    fields.push(`${label}=${formatted}`);
+  }
+}
+
+function summarizeInputPayload(payload: unknown): string[] {
+  if (!isRecord(payload)) return [];
+  const fields: string[] = [];
+  pushField(fields, "kind", payload.kind);
+  if (payload.kind === "create_message") {
+    pushField(fields, "messages", payload.messages);
+    pushField(fields, "client_tool_allowlist", payload.client_tool_allowlist);
+    pushField(
+      fields,
+      "external_tool_scope_ids",
+      payload.external_tool_scope_ids,
+    );
+  } else if (payload.kind === "approval_response") {
+    pushField(fields, "request_id", payload.request_id);
+    pushField(fields, "response", payload.response);
+    pushField(
+      fields,
+      "selected_suggestion_ids",
+      payload.selected_suggestion_ids,
+    );
+  }
+  return fields;
+}
+
+function summarizeRuntimeStartCommand(
+  command: Record<string, unknown>,
+): string[] {
+  const fields: string[] = [];
+  pushField(fields, "agent_id", command.agent_id, "agent");
+  pushField(fields, "conversation_id", command.conversation_id, "conversation");
+  if (isRecord(command.create_agent)) fields.push("create_agent=true");
+  if (isRecord(command.create_conversation)) {
+    fields.push("create_conversation=true");
+  }
+  pushField(fields, "cwd", command.cwd);
+  pushField(fields, "mode", command.mode);
+  pushField(fields, "external_tools", command.external_tools);
+  return fields;
+}
+
+function summarizeV2Command(parsed: unknown): string {
+  if (!isRecord(parsed) || typeof parsed.type !== "string") return "unknown";
+  const fields: string[] = [];
+  const runtime = isRecord(parsed.runtime) ? parsed.runtime : null;
+  if (runtime) {
+    fields.push(
+      `runtime=${runtime.agent_id ?? "<unknown>"}/${runtime.conversation_id ?? "<unknown>"}`,
+    );
+  }
+  pushField(fields, "request_id", parsed.request_id);
+
+  if (parsed.type === "input") {
+    fields.push(...summarizeInputPayload(parsed.payload));
+  } else if (
+    parsed.type === "change_device_state" &&
+    isRecord(parsed.payload)
+  ) {
+    pushField(fields, "mode", parsed.payload.mode);
+    pushField(fields, "cwd", parsed.payload.cwd);
+    pushField(fields, "agent_id", parsed.payload.agent_id);
+    pushField(fields, "conversation_id", parsed.payload.conversation_id);
+  } else if (parsed.type === "runtime_start") {
+    fields.push(...summarizeRuntimeStartCommand(parsed));
+  } else {
+    for (const key of [
+      "agent_id",
+      "conversation_id",
+      "task_id",
+      "channel_id",
+      "account_id",
+      "route_id",
+      "target_id",
+      "pairing_id",
+      "path",
+      "file_path",
+      "ref",
+      "encoding",
+      "query",
+      "glob",
+      "is_regex",
+      "case_sensitive",
+      "whole_word",
+      "cwd",
+      "mode",
+      "run_id",
+      "item_id",
+      "terminal_id",
+      "cols",
+      "rows",
+      "depth",
+      "limit",
+      "offset",
+      "max_results",
+      "context_lines",
+      "include_files",
+      "model_id",
+      "model_handle",
+      "toolset",
+      "provider_name",
+      "auth_method",
+      "scope",
+      "command_id",
+      "args",
+      "name",
+      "cron",
+      "recurring",
+      "source",
+      "replace_all",
+      "expected_replacements",
+      "recover_approvals",
+      "force_device_status",
+    ]) {
+      pushField(fields, key, parsed[key]);
+    }
+  }
+
+  if (parsed.type === "write_file" && typeof parsed.content === "string") {
+    fields.push(`content_bytes=${Buffer.byteLength(parsed.content)}`);
+  }
+  if (
+    parsed.type === "write_memory_file" &&
+    typeof parsed.content === "string"
+  ) {
+    fields.push(`content_bytes=${Buffer.byteLength(parsed.content)}`);
+  }
+  if (parsed.type === "edit_file") {
+    if (typeof parsed.old_string === "string") {
+      fields.push(`old_bytes=${Buffer.byteLength(parsed.old_string)}`);
+    }
+    if (typeof parsed.new_string === "string") {
+      fields.push(`new_bytes=${Buffer.byteLength(parsed.new_string)}`);
+    }
+  }
+  if (parsed.type === "file_ops") {
+    pushField(fields, "cg_entries", parsed.cg_entries);
+    pushField(fields, "ops", parsed.ops);
+    if (typeof parsed.document_content === "string") {
+      fields.push(
+        `document_bytes=${Buffer.byteLength(parsed.document_content)}`,
+      );
+    }
+  }
+  if (parsed.type === "terminal_input" && typeof parsed.data === "string") {
+    fields.push(`data_bytes=${Buffer.byteLength(parsed.data)}`);
+  }
+  if (parsed.type === "execute_command") {
+    pushField(fields, "command_id", parsed.command_id);
+    pushField(fields, "args", parsed.args);
+  }
+
+  return fields.length > 0
+    ? `${parsed.type} command (${fields.join(", ")})`
+    : `${parsed.type} command`;
+}
+
 export function createListenerMessageHandler(
   params: MessageRouterParams,
 ): (data: WebSocket.RawData) => Promise<void> {
@@ -220,6 +406,8 @@ export function createListenerMessageHandler(
         return;
       }
 
+      console.log(`[Listen V2] Received ${summarizeV2Command(parsed)}`);
+
       if (parsed.type === "__invalid_input") {
         emitLoopErrorNotice(socket, runtime, {
           message: parsed.reason,
@@ -250,9 +438,6 @@ export function createListenerMessageHandler(
       }
 
       if (parsed.type === "sync") {
-        console.log(
-          `[Listen V2] Received sync command for runtime=${parsed.runtime.agent_id}/${parsed.runtime.conversation_id}`,
-        );
         if (runtime !== getActiveRuntime() || runtime.intentionallyClosed) {
           console.log(`[Listen V2] Dropping sync: runtime mismatch or closed`);
           if (parsed.request_id) {
@@ -311,9 +496,6 @@ export function createListenerMessageHandler(
       }
 
       if (parsed.type === "input") {
-        console.log(
-          `[Listen V2] Received input command, kind=${parsed.payload?.kind}`,
-        );
         if (runtime !== getActiveRuntime() || runtime.intentionallyClosed) {
           console.log(`[Listen V2] Dropping input: runtime mismatch or closed`);
           return;


### PR DESCRIPTION
## summary
- add one centralized v2 command receipt log in the listener message router
- include safe command-identifying fields like runtime, request_id, path, command_id, model/toolset, channel ids, queue item ids, and byte counts for content-bearing commands
- avoid dumping sensitive or large payload contents while still showing enough command shape for Desktop debugging

## test plan
- bun test src/websocket/listen-client-protocol.test.ts
- bun run check

?? Generated with [Letta Code](https://letta.com)
