### PR TITLE
fix(agent): accept canonical image content in tool-return type guard

### DIFF
--- a/src/agent/approval-result-normalization.test.ts
+++ b/src/agent/approval-result-normalization.test.ts
@@ -190,6 +190,89 @@ describe("normalizeApprovalResultsForPersistence", () => {
       ],
     });
   });
+
+  test("preserves canonical image content in approved tool returns", () => {
+    const approvals: ApprovalResult[] = [
+      {
+        type: "approval",
+        tool_call_id: "call-img",
+        approve: true,
+        tool_return: [
+          { type: "text", text: "[Image: chart.png]" },
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: "aGVsbG8=",
+            },
+          },
+        ],
+      } as unknown as ApprovalResult,
+    ];
+
+    const normalized = normalizeApprovalResultsForPersistence(approvals);
+
+    expect(normalized[0]).toMatchObject({
+      type: "tool",
+      tool_call_id: "call-img",
+      status: "success",
+      tool_return: [
+        { type: "text", text: "[Image: chart.png]" },
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: "image/png",
+            data: "aGVsbG8=",
+          },
+        },
+      ],
+    });
+  });
+
+  test("preserves image content when prepending an approval comment", () => {
+    const approvals: ApprovalResult[] = [
+      {
+        type: "tool",
+        tool_call_id: "call-img-comment",
+        tool_return: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: "aGVsbG8=",
+            },
+          },
+        ],
+        status: "success",
+        reason: "Look at this",
+      } as ApprovalResult,
+    ];
+
+    const normalized = normalizeApprovalResultsForPersistence(approvals);
+
+    expect(normalized[0]).toMatchObject({
+      type: "tool",
+      tool_call_id: "call-img-comment",
+      status: "success",
+      tool_return: [
+        {
+          type: "text",
+          text: 'The user approved the tool execution with the following comment: "Look at this"',
+        },
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: "image/png",
+            data: "aGVsbG8=",
+          },
+        },
+      ],
+    });
+  });
 });
 
 describe("normalizeOutgoingApprovalMessages", () => {

--- a/src/agent/approval-result-normalization.ts
+++ b/src/agent/approval-result-normalization.ts
@@ -64,10 +64,14 @@ function isToolReturnContent(value: unknown): value is ToolReturnContent {
         "text" in part &&
         typeof (part as { text?: unknown }).text === "string") ||
         ((part as { type?: unknown }).type === "image" &&
-          "data" in part &&
-          typeof (part as { data?: unknown }).data === "string" &&
-          "mimeType" in part &&
-          typeof (part as { mimeType?: unknown }).mimeType === "string")),
+          "source" in part &&
+          !!(part as { source?: unknown }).source &&
+          typeof (part as { source?: unknown }).source === "object" &&
+          (part as { source: { type?: unknown } }).source.type === "base64" &&
+          typeof (part as { source: { data?: unknown } }).source.data ===
+            "string" &&
+          typeof (part as { source: { media_type?: unknown } }).source
+            .media_type === "string")),
   );
 }
 


### PR DESCRIPTION
Ref #2942

## Summary

Tool-return images (e.g. `Read` on an image file, `ViewImage`) were silently flattened to a text placeholder before persistence, so the model never received the actual image. On the local backend this meant reading an image produced only the `[Image: <name>]` text label.

The cause is `isToolReturnContent` in `src/agent/approval-result-normalization.ts`. It is declared `value is ToolReturnContent`, but its image branch validated a flat `{ type: "image", data, mimeType }` block, which is not a valid `ImageContent`. The canonical `ImageContent` (`@letta-ai/letta-client`) is nested — `{ type: "image", source: { type: "base64", data, media_type } }` — which is exactly what the tools emit. Because the canonical block failed the guard, `coerceToolReturnContent` fell through to `normalizeToolReturnText`, which keeps only `text` parts and dropped the image.

## Changes

- **`src/agent/approval-result-normalization.ts`** — fix `isToolReturnContent`'s image branch to validate the canonical base64 `ImageContent` shape (`source.type === "base64"`, string `source.data`, string `source.media_type`) so the guard matches its declared type. Kept in the agent layer (no dependency on the local-backend `localImageContentFromLegacyImage`, to respect layer boundaries).
- **`src/agent/approval-result-normalization.test.ts`** — add regression tests for image preservation, both with and without an approval comment. (The image branch previously had no coverage, which is why this went unnoticed.)

## Why this layer / shape

`isToolReturnContent` is a guard for `ToolReturnContent` (`string | Array<TextContent | ImageContent>`), so it must validate the SDK `ImageContent` shape. The flat `{ data, mimeType }` it previously checked is the local backend's internal `LocalImageContent` storage representation (from `src/backend/local/local-store.ts`), not a `ToolReturnContent`. The strict fix is to replace the flat check with the canonical nested check rather than accept both, since the flat shape is not a valid tool return.

## Test plan

- [x] `bun test src/agent/approval-result-normalization.test.ts` — 13/13 pass.
- [x] `bunx --bun @biomejs/biome@2.2.5 check` — clean on changed files.
- [x] `tsc --noEmit` — 0 errors.
- [x] Full suite shows no failures