### PR TITLE
fix(websocket): seed channel conversation cwd mappings

### DIFF
--- a/src/channels/discord-registry.test.ts
+++ b/src/channels/discord-registry.test.ts
@@ -286,7 +286,7 @@ describe("discord channel registry", () => {
     expect(deliveries).toHaveLength(1);
   });
 
-  test("emits default permission mode when Discord creates a conversation", async () => {
+  test("emits standard permission mode when Discord creates a conversation", async () => {
     clearChannelAccountStores();
     __testOverrideLoadChannelAccounts(() => [
       {
@@ -295,7 +295,7 @@ describe("discord channel registry", () => {
         enabled: true,
         token: "discord-token",
         agentId: "agent-1",
-        defaultPermissionMode: "unrestricted",
+        defaultPermissionMode: "standard",
         dmPolicy: "open",
         allowedUsers: [],
         createdAt: "2026-04-11T00:00:00.000Z",
@@ -327,7 +327,7 @@ describe("discord channel registry", () => {
       accountId: "discord-bot",
       agentId: "agent-1",
       conversationId: "conv-discord",
-      defaultPermissionMode: "unrestricted",
+      defaultPermissionMode: "standard",
     });
   });
 

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -1848,16 +1848,14 @@ export class ChannelRegistry {
     };
 
     addRoute(msg.channel, route);
-    if (config.defaultPermissionMode !== "standard") {
-      this.eventHandler?.({
-        type: "discord_conversation_created",
-        channelId: "discord",
-        accountId: config.accountId,
-        agentId: config.agentId,
-        conversationId,
-        defaultPermissionMode: config.defaultPermissionMode,
-      });
-    }
+    this.eventHandler?.({
+      type: "discord_conversation_created",
+      channelId: "discord",
+      accountId: config.accountId,
+      agentId: config.agentId,
+      conversationId,
+      defaultPermissionMode: config.defaultPermissionMode,
+    });
     return route;
   }
 

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -3536,6 +3536,7 @@ describe("listen-client permission mode scope keys", () => {
 
   test("slack conversation created event seeds the new conversation permission mode", () => {
     const listener = __listenClientTestUtils.createListenerRuntime();
+    listener.workingDirectoryByConversation.delete("conversation:conv-slack-1");
     const socket = new MockSocket(WebSocket.OPEN);
 
     __listenClientTestUtils.handleChannelRegistryEvent(
@@ -3562,10 +3563,34 @@ describe("listen-client permission mode scope keys", () => {
     ).toEqual({
       mode: "unrestricted",
     });
+    expect(
+      listener.workingDirectoryByConversation.get("conversation:conv-slack-1"),
+    ).toBe(listener.bootWorkingDirectory);
+
+    const emittedStatus = socket.sentPayloads.map((payload) =>
+      JSON.parse(payload),
+    )[0];
+    expect(emittedStatus).toMatchObject({
+      type: "update_device_status",
+      runtime: {
+        agent_id: "agent-123",
+        conversation_id: "conv-slack-1",
+      },
+      device_status: {
+        current_working_directory: listener.bootWorkingDirectory,
+        cwd_map: {
+          "conversation:conv-slack-1": listener.bootWorkingDirectory,
+        },
+        boot_working_directory: listener.bootWorkingDirectory,
+      },
+    });
   });
 
   test("discord conversation created event seeds the new conversation permission mode", () => {
     const listener = __listenClientTestUtils.createListenerRuntime();
+    listener.workingDirectoryByConversation.delete(
+      "conversation:conv-discord-1",
+    );
     const socket = new MockSocket(WebSocket.OPEN);
 
     __listenClientTestUtils.handleChannelRegistryEvent(
@@ -3591,6 +3616,29 @@ describe("listen-client permission mode scope keys", () => {
       listener.permissionModeByConversation.get("conversation:conv-discord-1"),
     ).toEqual({
       mode: "acceptEdits",
+    });
+    expect(
+      listener.workingDirectoryByConversation.get(
+        "conversation:conv-discord-1",
+      ),
+    ).toBe(listener.bootWorkingDirectory);
+
+    const emittedStatus = socket.sentPayloads.map((payload) =>
+      JSON.parse(payload),
+    )[0];
+    expect(emittedStatus).toMatchObject({
+      type: "update_device_status",
+      runtime: {
+        agent_id: "agent-123",
+        conversation_id: "conv-discord-1",
+      },
+      device_status: {
+        current_working_directory: listener.bootWorkingDirectory,
+        cwd_map: {
+          "conversation:conv-discord-1": listener.bootWorkingDirectory,
+        },
+        boot_working_directory: listener.bootWorkingDirectory,
+      },
     });
   });
 });

--- a/src/websocket/listener/commands/channels.ts
+++ b/src/websocket/listener/commands/channels.ts
@@ -29,6 +29,7 @@ import type {
   ChannelAccountSnapshot as ProtocolChannelAccountSnapshot,
   ChannelConfigSnapshot as ProtocolChannelConfigSnapshot,
 } from "@/types/protocol_v2";
+import { seedConversationWorkingDirectory } from "@/websocket/listener/cwd";
 import {
   getOrCreateConversationPermissionModeStateRef,
   persistPermissionModeMapForRuntime,
@@ -55,6 +56,8 @@ import {
   isChannelTargetBindCommand,
   isChannelTargetsListCommand,
 } from "@/websocket/listener/protocol-inbound";
+import { emitDeviceStatusUpdate } from "@/websocket/listener/protocol-outbound";
+import { getOrCreateConversationRuntime } from "@/websocket/listener/runtime";
 import type { ListenerTransport } from "@/websocket/listener/transport";
 import type {
   IncomingMessage,
@@ -1419,4 +1422,21 @@ export function handleChannelRegistryEvent(
   );
   permissionModeState.mode = event.defaultPermissionMode;
   persistPermissionModeMapForRuntime(runtime);
+
+  const seededWorkingDirectory = seedConversationWorkingDirectory(
+    runtime,
+    event.agentId,
+    event.conversationId,
+    runtime.bootWorkingDirectory,
+  );
+  if (seededWorkingDirectory) {
+    emitDeviceStatusUpdate(
+      socket,
+      getOrCreateConversationRuntime(
+        runtime,
+        event.agentId,
+        event.conversationId,
+      ),
+    );
+  }
 }

--- a/src/websocket/listener/cwd.ts
+++ b/src/websocket/listener/cwd.ts
@@ -73,3 +73,19 @@ export function setConversationWorkingDirectory(
 
   persistCwdMap(runtime.workingDirectoryByConversation);
 }
+
+export function seedConversationWorkingDirectory(
+  runtime: ListenerRuntime,
+  agentId: string | null,
+  conversationId: string,
+  workingDirectory: string,
+): boolean {
+  const scopeKey = getWorkingDirectoryScopeKey(agentId, conversationId);
+  if (runtime.workingDirectoryByConversation.has(scopeKey)) {
+    return false;
+  }
+
+  runtime.workingDirectoryByConversation.set(scopeKey, workingDirectory);
+  persistCwdMap(runtime.workingDirectoryByConversation);
+  return true;
+}

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -54,7 +54,7 @@ import {
   findFallbackRuntime,
   getOrCreateScopedRuntime,
 } from "./conversation-runtime";
-import { loadPersistedCwdMap } from "./cwd";
+import { loadPersistedCwdMap, seedConversationWorkingDirectory } from "./cwd";
 import {
   installExternalToolBridge,
   rejectPendingExternalToolCalls,
@@ -435,6 +435,16 @@ export async function wireChannelIngress(
       delivery.route.conversationId,
     );
     if (!rawRuntime) return;
+
+    const seededWorkingDirectory = seedConversationWorkingDirectory(
+      listener,
+      delivery.route.agentId,
+      delivery.route.conversationId,
+      listener.bootWorkingDirectory,
+    );
+    if (seededWorkingDirectory) {
+      emitDeviceStatusUpdate(socket, rawRuntime);
+    }
 
     if (delivery.defaultPermissionMode) {
       const permissionModeState = getOrCreateConversationPermissionModeStateRef(

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -477,7 +477,7 @@ export function buildDeviceStatus(
     memory_directory: scopedAgentId
       ? getScopedMemoryFilesystemRoot(scopedAgentId)
       : null,
-    ...(!scope
+    ...(params === undefined
       ? {
           cwd_map: Object.fromEntries(listener.workingDirectoryByConversation),
           boot_working_directory: listener.bootWorkingDirectory,


### PR DESCRIPTION
## Problem
Channel-created conversations could rely on listener boot-directory fallback without an explicit conversation-to-cwd entry. Desktop needs that explicit scoped mapping to keep channel conversations attached to the correct local environment instead of falling back to an unrelated folder.

## Approach
- Seed a persisted conversation working-directory mapping from the listener boot cwd when Slack/Discord channel-created conversation events arrive.
- Seed the same mapping on channel inbound delivery as a fallback for delivery-created routes.
- Include the cwd map on device-status emissions from scoped runtimes when no explicit status scope was supplied.
- Emit Discord conversation-created events for standard permission mode too, so standard-created routes have the same listener event path.

## Before / After
Before: channel-created conversations could have an effective cwd only through fallback, leaving Desktop without an explicit `conversation:<id>` mapping.

After: new Slack/Discord channel-created conversations get `conversation:<id> -> listener.bootWorkingDirectory` persisted and emitted in device status.

## Risk / Limits
- Existing explicit cwd mappings are preserved; seeding is skipped when a conversation mapping already exists.
- The change intentionally stores boot-directory mappings instead of deleting them as redundant fallback, because Desktop needs the explicit association.
- Manual visual proof in Desktop is pending; I could not capture a local LCD sidebar screenshot in this environment.

## Validation
- `bun --loader=.md:text --loader=.mdx:text --loader=.txt:text test src/websocket/listen-client-protocol.test.ts` — 161 pass, 0 fail, 516 expect
- `bun test src/channels/discord-registry.test.ts` — 11 pass, 0 fail, 37 expect
- `bunx --bun @biomejs/biome@2.2.5 check src/websocket/listener/cwd.ts src/websocket/listener/lifecycle.ts src/websocket/listener/protocol-outbound.ts src/websocket/listener/commands/channels.ts src/websocket/listen-client-protocol.test.ts src/channels/registry.ts src/channels/discord-registry.test.ts` — passed
- `bun run lint` — passed, checked 1133 files
- `bun run typecheck` — failed on existing unrelated project errors: `src/backend/dev/pi-provider-registry.ts(111,5)`, `src/cli/commands/connect-local-oauth.test.ts(53,32)`, and missing `@pierre/diffs` types in `src/web/generate-diff-viewer.ts`

👾 Generated with [Letta Code](https://letta.com)