### PR TITLE
fix(memfs): bypass tag check for local backend in isMemfsEnabledOnServer

### DIFF
--- a/src/agent/memory-filesystem.ts
+++ b/src/agent/memory-filesystem.ts
@@ -164,7 +164,23 @@ export async function isMemfsEnabledOnServer(
   agentId: string,
 ): Promise<boolean> {
   const { getBackend } = await import("@/backend");
-  const agent = await getBackend().retrieveAgent(agentId, {
+  const backend = getBackend();
+
+  // For local backend, memfs support is determined by local capabilities and
+  // env settings rather than a per-agent server-side tag. Agents created via
+  // runtime_start / LocalBackend.createAgent() do not get GIT_MEMORY_ENABLED_TAG
+  // automatically, so using the tag-based check would incorrectly return false.
+  if (backend.capabilities.localMemfs) {
+    const { isLocalBackendNoMemfsEnvEnabled } = await import(
+      "@/backend/local/paths"
+    );
+    const enabled = !isLocalBackendNoMemfsEnvEnabled();
+    const { settingsManager } = await import("@/settings-manager");
+    settingsManager.setMemfsEnabled(agentId, enabled);
+    return enabled;
+  }
+
+  const agent = await backend.retrieveAgent(agentId, {
     include: ["agent.tags"],
   });
   const { GIT_MEMORY_ENABLED_TAG } = await import("@/agent/memory-git");


### PR DESCRIPTION
## summary
- `isMemfsEnabledOnServer` was checking `agent.tags.includes('git-memory-enabled')` even for local backend agents
- `LocalBackend.createAgent()` (used by v2 `runtime_start`) never sets that tag, so the check incorrectly returned false for new local agents
- on a secondary path: if `isLocalBackendEnvEnabled()` was inconsistent, `ensureLocalMemfsCheckout` would call `cloneMemoryRepo` which clones to `~/.letta/agents/{id}/memory/` while the existence check uses the scoped local backend path � leaving `.git` missing after a successful clone
- fix: short-circuit to `capabilities.localMemfs + isLocalBackendNoMemfsEnvEnabled()` for local backend, matching how the rest of the local memfs path works

## test plan
- [ ] create a new local agent via Desktop (`runtime_start` with `create_agent`)
- [ ] open Memory panel � should show initialized, not disabled
- [ ] write a memory file via Desktop � should succeed
- [ ] `bun test src/websocket/listen-client-protocol.test.ts src/backend/local-backend.test.ts`

?? Generated with [Letta Code](https://letta.com)
