### PR TITLE
fix(cli): fail gracefully on bad subcommand args (server/remote, local-backend)

### DIFF
--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -341,73 +341,88 @@ export const __listenSubcommandTestUtils = {
   },
 };
 
+const LISTEN_OPTIONS = {
+  "env-name": { type: "string" },
+  channels: { type: "string" },
+  "install-channel-runtimes": { type: "boolean" },
+  help: { type: "boolean", short: "h" },
+  debug: { type: "boolean" },
+} as const;
+
+function printListenUsage(): void {
+  console.log(
+    "Usage: letta server [--env-name <name>] [--channels <list>] [--debug]\n",
+  );
+  console.log(
+    "Register this letta-code instance to receive messages from Letta Cloud.\n",
+  );
+  console.log("Options:");
+  console.log(
+    "  --env-name <name>  Friendly name for this environment (uses hostname if not provided)",
+  );
+  console.log(
+    "  --channels <list>  Comma-separated channel names to enable (e.g. telegram)",
+  );
+  console.log(
+    "  --install-channel-runtimes  Install missing runtime deps for the selected channels before startup",
+  );
+  console.log(
+    "  --debug            Plain-text mode: log all WebSocket events instead of interactive UI",
+  );
+  console.log("  -h, --help         Show this help message\n");
+  console.log("Examples:");
+  console.log(
+    "  letta channels configure telegram          # Configure Telegram first",
+  );
+  console.log(
+    "  letta server                              # Uses hostname as default",
+  );
+  console.log('  letta server --env-name "work-laptop"');
+  console.log(
+    "  letta server --channels telegram           # Enable Telegram channel",
+  );
+  console.log("  letta server --channels telegram --install-channel-runtimes");
+  console.log(
+    "  letta server --debug                       # Log all WS events\n",
+  );
+  console.log(
+    "Once connected, this instance will listen for incoming messages from cloud agents.",
+  );
+  console.log(
+    "Messages will be executed locally using your letta-code environment.",
+  );
+  console.log(
+    "Telegram flow: configure the bot, start the listener with --channels telegram,",
+  );
+  console.log(
+    "then message the bot from Telegram and run /channels telegram pair <code> in the target conversation.",
+  );
+}
+
 export async function runListenSubcommand(argv: string[]): Promise<number> {
   // Parse arguments
-  const { values } = parseArgs({
-    args: argv,
-    options: {
-      "env-name": { type: "string" },
-      channels: { type: "string" },
-      "install-channel-runtimes": { type: "boolean" },
-      help: { type: "boolean", short: "h" },
-      debug: { type: "boolean" },
-    },
-    allowPositionals: false,
-  });
+  let values: ReturnType<
+    typeof parseArgs<{ options: typeof LISTEN_OPTIONS }>
+  >["values"];
+  try {
+    ({ values } = parseArgs({
+      args: argv,
+      options: LISTEN_OPTIONS,
+      strict: true,
+      allowPositionals: false,
+    }));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Error: ${message}`);
+    printListenUsage();
+    return 1;
+  }
 
   const debugMode = !!values.debug;
 
   // Show help
   if (values.help) {
-    console.log(
-      "Usage: letta server [--env-name <name>] [--channels <list>] [--debug]\n",
-    );
-    console.log(
-      "Register this letta-code instance to receive messages from Letta Cloud.\n",
-    );
-    console.log("Options:");
-    console.log(
-      "  --env-name <name>  Friendly name for this environment (uses hostname if not provided)",
-    );
-    console.log(
-      "  --channels <list>  Comma-separated channel names to enable (e.g. telegram)",
-    );
-    console.log(
-      "  --install-channel-runtimes  Install missing runtime deps for the selected channels before startup",
-    );
-    console.log(
-      "  --debug            Plain-text mode: log all WebSocket events instead of interactive UI",
-    );
-    console.log("  -h, --help         Show this help message\n");
-    console.log("Examples:");
-    console.log(
-      "  letta channels configure telegram          # Configure Telegram first",
-    );
-    console.log(
-      "  letta server                              # Uses hostname as default",
-    );
-    console.log('  letta server --env-name "work-laptop"');
-    console.log(
-      "  letta server --channels telegram           # Enable Telegram channel",
-    );
-    console.log(
-      "  letta server --channels telegram --install-channel-runtimes",
-    );
-    console.log(
-      "  letta server --debug                       # Log all WS events\n",
-    );
-    console.log(
-      "Once connected, this instance will listen for incoming messages from cloud agents.",
-    );
-    console.log(
-      "Messages will be executed locally using your letta-code environment.",
-    );
-    console.log(
-      "Telegram flow: configure the bot, start the listener with --channels telegram,",
-    );
-    console.log(
-      "then message the bot from Telegram and run /channels telegram pair <code> in the target conversation.",
-    );
+    printListenUsage();
     return 0;
   }
 

--- a/src/cli/subcommands/local-backend.ts
+++ b/src/cli/subcommands/local-backend.ts
@@ -2,6 +2,20 @@ import { parseArgs } from "node:util";
 import { getLocalBackendStorageDir } from "@/backend/local/paths";
 import { migrateLocalBackendTranscripts } from "@/backend/local/transcript-migration";
 
+const LOCAL_BACKEND_OPTIONS = {
+  help: { type: "boolean", short: "h" },
+  "storage-dir": { type: "string" },
+  "dry-run": { type: "boolean" },
+} as const;
+
+function parseLocalBackendArgs(argv: string[]) {
+  return parseArgs({
+    args: argv,
+    options: LOCAL_BACKEND_OPTIONS,
+    strict: true,
+  });
+}
+
 function printUsage(): void {
   console.log(
     `
@@ -34,15 +48,15 @@ export async function runLocalBackendSubcommand(
     return 1;
   }
 
-  const parsed = parseArgs({
-    args: rest,
-    options: {
-      help: { type: "boolean", short: "h" },
-      "storage-dir": { type: "string" },
-      "dry-run": { type: "boolean" },
-    },
-    strict: true,
-  });
+  let parsed: ReturnType<typeof parseLocalBackendArgs>;
+  try {
+    parsed = parseLocalBackendArgs(rest);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Error: ${message}`);
+    printUsage();
+    return 1;
+  }
   if (parsed.values.help) {
     printUsage();
     return 0;


### PR DESCRIPTION
## Summary
Two CLI subcommands ran `parseArgs` without a try/catch, so invalid input dumped a raw `ERR_PARSE_ARGS_*` stack trace leaking internal `letta.js` frames:
- `letta server` / `letta remote` (e.g. `letta remote list`)
- `letta local-backend migrate-transcripts`

Both now print `Error: <message>` + usage and exit 1, matching the existing `agents`/`messages`/`app-server` pattern. Help text extracted into shared `printUsage` helpers so error and `--help` paths share one source of truth.

Audited all other subcommands (`agents`, `app-server`, `cron`, `memory`, `messages`, `skills`, `channels`, `connect`) — already wrapped. `backend` does manual parsing (no `parseArgs`). These two were the only offenders.

## Before
```
$ letta remote list
TypeError: Unexpected argument 'list'. This command does not take positional arguments
 code: "ERR_PARSE_ARGS_UNEXPECTED_POSITIONAL"
      at runListenSubcommand (.../letta.js:514490:31)
      ...
```

## After
```
$ letta remote list
Error: Unexpected argument 'list'. This command does not take positional arguments
Usage: letta server [--env-name <name>] [--channels <list>] [--debug]
...
(exit 1)
```

## Test plan
- [x] `letta remote list` → clean error + usage, exit 1
- [x] `letta remote --bogus` → clean error + usage, exit 1
- [x] `letta server --help` → usage, exit 0
- [x] `letta local-backend migrate-transcripts --bogus` → clean error + usage, exit 1
- [x] `letta local-backend migrate-transcripts --help` → usage, exit 0
- [x] `bun run typecheck` clean
- [x] biome clean (pre-commit)