### PR TITLE
fix(local): stamp git-memory-enabled tag on agents created with local memfs

### DIFF
--- a/src/backend/local/local-backend.ts
+++ b/src/backend/local/local-backend.ts
@@ -1,5 +1,6 @@
 import type { Usage } from "@earendil-works/pi-ai";
 import {
+  GIT_MEMORY_ENABLED_TAG,
   type InitializeLocalMemoryRepoFile,
   initializeLocalMemoryRepo,
 } from "@/agent/memory-git";
@@ -319,7 +320,22 @@ export class LocalBackend extends HeadlessBackend {
   override async createAgent(
     ...args: Parameters<HeadlessBackend["createAgent"]>
   ) {
-    const [body] = args;
+    let [body, ...restArgs] = args;
+    // When local memfs is enabled, stamp the git-memory-enabled tag on the
+    // agent body so all downstream tag-checking paths (isMemfsEnabledOnServer,
+    // memfs-sync, etc.) see this agent as memfs-enabled from creation.
+    if (this.isLocalMemfsEnabled()) {
+      const bodyRecord = body as Record<string, unknown>;
+      const existingTags = Array.isArray(bodyRecord.tags)
+        ? (bodyRecord.tags as string[])
+        : [];
+      if (!existingTags.includes(GIT_MEMORY_ENABLED_TAG)) {
+        body = {
+          ...bodyRecord,
+          tags: [...existingTags, GIT_MEMORY_ENABLED_TAG],
+        } as typeof body;
+      }
+    }
     const requestedCompactionSettings = compactionSettingsRecord(
       (body as Record<string, unknown>).compaction_settings,
     );
@@ -332,7 +348,7 @@ export class LocalBackend extends HeadlessBackend {
     const compactionSettingsForStorage = localCompactionSettingsForStorage(
       requestedCompactionSettings,
     );
-    let agent = await super.createAgent(...args);
+    let agent = await super.createAgent(body, ...restArgs);
     if (compactionSettingsForStorage !== undefined) {
       agent = this.store.setAgentCompactionSettings(
         agent.id,


### PR DESCRIPTION
## summary
- `LocalBackend.createAgent()` initializes the local git repo when memfs is enabled but never stamped `GIT_MEMORY_ENABLED_TAG` on the agent
- agents created via `runtime_start` (and any non-`create.ts` path) were missing the tag, causing `isMemfsEnabledOnServer` and `memfs-sync` to treat them as memfs-disabled
- injects the tag into the create body before the store write so all downstream tag-checking paths see the correct state from creation
- pairs with #2945 which adds a separate `capabilities.localMemfs` short-circuit to `isMemfsEnabledOnServer` as a defense-in-depth layer

## test plan
- [ ] create a new local agent via `runtime_start` (Desktop new agent flow)
- [ ] verify agent has `git-memory-enabled` tag in its record
- [ ] open Memory panel � should show initialized
- [ ] write a memory file via Desktop � should succeed
- [ ] `bun test src/backend/local-backend.test.ts src/agent/create.test.ts`

?? Generated with [Letta Code](https://letta.com)
