### PR TITLE
feat(mods): wire mod events through listener tool preparation callsites

### DIFF
--- a/src/websocket/listener/commands/model-toolset.ts
+++ b/src/websocket/listener/commands/model-toolset.ts
@@ -28,6 +28,7 @@ import type {
   UpdateModelResponseMessage,
   UpdateToolsetResponseMessage,
 } from "@/types/protocol_v2";
+import { ensureListenerModAdapter } from "@/websocket/listener/mod-adapter";
 import {
   isListModelsCommand,
   isUpdateModelCommand,
@@ -369,6 +370,7 @@ export async function applyModelUpdateForRuntime(params: {
       agentId,
       conversationId,
       overrideModel: model.handle,
+      modEvents: ensureListenerModAdapter(listener).events,
     });
     nextToolset = preparedToolContext.toolset;
     nextLoadedTools = preparedToolContext.preparedToolContext.loadedToolNames;
@@ -458,6 +460,7 @@ export async function applyToolsetUpdateForRuntime(params: {
     const preparedToolContext = await prepareToolExecutionContextForScope({
       agentId,
       conversationId,
+      modEvents: ensureListenerModAdapter(listener).events,
     });
     nextToolset = preparedToolContext.toolset;
     scopedRuntime.currentToolset = preparedToolContext.toolset;

--- a/src/websocket/listener/mod-adapter.test.ts
+++ b/src/websocket/listener/mod-adapter.test.ts
@@ -2,11 +2,22 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { __testSetBackend } from "@/backend";
+import { FakeHeadlessBackend } from "@/backend/dev/fake-headless-backend";
 import {
   clearRegisteredPiProviders,
   getRegisteredPiProvider,
 } from "@/backend/dev/pi-provider-mod-registry";
-import { clearModTools, getModToolDefinition } from "@/mods/tool-registry";
+import {
+  clearModTools,
+  getModToolDefinition,
+  registerModTool,
+} from "@/mods/tool-registry";
+import {
+  clearCapturedToolExecutionContexts,
+  executeTool,
+} from "@/tools/manager";
+import { prepareToolExecutionContextForScope } from "@/tools/toolset";
 import {
   createListenerModAdapter,
   createListenerModContext,
@@ -24,6 +35,8 @@ function createTempDir(): string {
 afterEach(() => {
   clearModTools();
   clearRegisteredPiProviders();
+  clearCapturedToolExecutionContexts();
+  __testSetBackend(null);
   for (const dir of tempRoots.splice(0)) {
     rmSync(dir, { force: true, recursive: true });
   }
@@ -178,5 +191,175 @@ describe("listener mod adapter", () => {
     adapter.dispose();
     expect(getRegisteredPiProvider("kilo")).toBeUndefined();
     expect(getModToolDefinition("listener_tool")).toBeUndefined();
+  });
+
+  test("mod tools appear in scoped tool execution context for listener turns", async () => {
+    __testSetBackend(
+      new FakeHeadlessBackend(
+        "agent-1",
+        undefined,
+        {},
+        {
+          modelHandle: "anthropic/claude-sonnet-4-6",
+        },
+      ),
+    );
+    const controller = new AbortController();
+    registerModTool({
+      name: "listener_echo",
+      description: "Echo for listener turns",
+      parameters: {
+        type: "object",
+        properties: { msg: { type: "string" } },
+        required: ["msg"],
+      },
+      owner: {
+        id: "global:/tmp/listener-echo.ts",
+        path: "/tmp/listener-echo.ts",
+        scope: "global",
+        generation: 1,
+      },
+      path: "/tmp/listener-echo.ts",
+      approvalPolicy: "auto",
+      requiresApproval: false,
+      parallelSafe: true,
+      activationSignal: controller.signal,
+      run: (ctx) => `echo:${ctx.args.msg}`,
+    });
+
+    const prepared = await prepareToolExecutionContextForScope({
+      agentId: "agent-1",
+      conversationId: "default",
+      clientToolAllowlist: ["listener_echo"],
+      workingDirectory: "/tmp/listener-workspace",
+      permissionModeState: { mode: "standard" },
+    });
+
+    expect(prepared.preparedToolContext.loadedToolNames).toEqual([
+      "listener_echo",
+    ]);
+    expect(prepared.preparedToolContext.clientTools.map((t) => t.name)).toEqual(
+      ["listener_echo"],
+    );
+
+    const result = await executeTool(
+      "listener_echo",
+      { msg: "hi" },
+      { toolContextId: prepared.preparedToolContext.contextId },
+    );
+    expect(result.status).toBe("success");
+    expect(result.toolReturn).toBe("echo:hi");
+  });
+
+  test("mod tools receive scoped context matching listener turn scope", async () => {
+    __testSetBackend(
+      new FakeHeadlessBackend(
+        "agent-scoped",
+        undefined,
+        {},
+        {
+          modelHandle: "anthropic/claude-sonnet-4-6",
+        },
+      ),
+    );
+    const controller = new AbortController();
+    registerModTool({
+      name: "scope_inspector",
+      description: "Inspects listener scope",
+      parameters: { type: "object", properties: {}, required: [] },
+      owner: {
+        id: "global:/tmp/scope-inspector.ts",
+        path: "/tmp/scope-inspector.ts",
+        scope: "global",
+        generation: 1,
+      },
+      path: "/tmp/scope-inspector.ts",
+      approvalPolicy: "auto",
+      requiresApproval: false,
+      parallelSafe: true,
+      activationSignal: controller.signal,
+      run: (ctx) =>
+        [
+          ctx.agent.id,
+          ctx.cwd,
+          ctx.model.provider,
+          ctx.permissionMode,
+          ctx.toolset,
+        ].join(":"),
+    });
+
+    const prepared = await prepareToolExecutionContextForScope({
+      agentId: "agent-scoped",
+      conversationId: "conv-1",
+      overrideModel: "anthropic/claude-sonnet-4-6",
+      clientToolAllowlist: ["scope_inspector"],
+      workingDirectory: "/tmp/listener-workspace",
+      permissionModeState: { mode: "standard" },
+    });
+
+    const result = await executeTool(
+      "scope_inspector",
+      {},
+      { toolContextId: prepared.preparedToolContext.contextId },
+    );
+    expect(result.status).toBe("success");
+    expect(result.toolReturn).toBe(
+      "agent-scoped:/tmp/listener-workspace:anthropic:standard:default",
+    );
+  });
+
+  test("mod tools with isEnabled are isolated across listener scopes", async () => {
+    __testSetBackend(
+      new FakeHeadlessBackend(
+        "agent-iso",
+        undefined,
+        {},
+        {
+          modelHandle: "anthropic/claude-sonnet-4-6",
+        },
+      ),
+    );
+    const controller = new AbortController();
+    registerModTool({
+      name: "scoped_only",
+      description: "Only available for agent-iso in workspace-a",
+      parameters: { type: "object", properties: {}, required: [] },
+      owner: {
+        id: "global:/tmp/scoped-only.ts",
+        path: "/tmp/scoped-only.ts",
+        scope: "global",
+        generation: 1,
+      },
+      path: "/tmp/scoped-only.ts",
+      approvalPolicy: "auto",
+      requiresApproval: false,
+      parallelSafe: true,
+      activationSignal: controller.signal,
+      isEnabled: (ctx) =>
+        ctx.agent.id === "agent-iso" && ctx.cwd === "/tmp/workspace-a",
+      run: () => "ok",
+    });
+
+    // Scope matching: agent-iso + workspace-a should see the tool
+    const preparedA = await prepareToolExecutionContextForScope({
+      agentId: "agent-iso",
+      conversationId: "conv-a",
+      clientToolAllowlist: ["scoped_only"],
+      workingDirectory: "/tmp/workspace-a",
+      permissionModeState: { mode: "standard" },
+    });
+    expect(preparedA.preparedToolContext.loadedToolNames).toEqual([
+      "scoped_only",
+    ]);
+
+    // Scope mismatch: agent-iso + workspace-b should NOT see the tool
+    const preparedB = await prepareToolExecutionContextForScope({
+      agentId: "agent-iso",
+      conversationId: "conv-b",
+      clientToolAllowlist: ["scoped_only"],
+      workingDirectory: "/tmp/workspace-b",
+      permissionModeState: { mode: "standard" },
+    });
+    expect(preparedB.preparedToolContext.loadedToolNames).toEqual([]);
   });
 });

--- a/src/websocket/listener/mod-adapter.ts
+++ b/src/websocket/listener/mod-adapter.ts
@@ -33,7 +33,7 @@ export interface CreateListenerModAdapterOptions {
 }
 
 async function getUnavailableListenerClient(): Promise<Letta> {
-  throw new Error("letta.client is not available in listener provider mods");
+  throw new Error("letta.client is not available in listener mods");
 }
 
 export function createListenerModContext(

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -46,6 +46,7 @@ import {
   emitToolExecutionStartedEvents,
   normalizeToolReturnWireMessage,
 } from "./interrupts";
+import { ensureListenerModAdapter } from "./mod-adapter";
 import { getOrCreateConversationPermissionModeStateRef } from "./permission-mode";
 import {
   emitCanonicalMessageDelta,
@@ -660,6 +661,7 @@ export async function resolveRecoveredApprovalResponse(
       recovered.agentId,
       recovered.conversationId,
     ),
+    modEvents: ensureListenerModAdapter(runtime.listener).events,
   });
   runtime.currentToolset = preparedToolContext.toolset;
   runtime.currentToolsetPreference = preparedToolContext.toolsetPreference;

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -31,6 +31,7 @@ import {
   PROVIDER_FALLBACK_NOTICE,
 } from "./constants";
 import { getConversationWorkingDirectory } from "./cwd";
+import { ensureListenerModAdapter } from "./mod-adapter";
 import { getOrCreateConversationPermissionModeStateRef } from "./permission-mode";
 import {
   emitDequeuedUserMessage,
@@ -333,6 +334,7 @@ export async function resolveStaleApprovals(
       runtime.agentId,
       runtime.conversationId,
     ),
+    modEvents: ensureListenerModAdapter(runtime.listener).events,
   });
   runtime.currentToolset = preparedToolContext.toolset;
   runtime.currentToolsetPreference = preparedToolContext.toolsetPreference;

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -76,6 +76,7 @@ import {
   normalizeToolReturnWireMessage,
   populateInterruptQueue,
 } from "./interrupts";
+import { ensureListenerModAdapter } from "./mod-adapter";
 import {
   getOrCreateConversationPermissionModeStateRef,
   persistPermissionModeMapForRuntime,
@@ -549,6 +550,7 @@ export async function handleIncomingMessage(
       permissionModeState: turnPermissionModeState,
       cachedAgent,
       channelTurnSources: msg.channelTurnSources,
+      modEvents: ensureListenerModAdapter(runtime.listener).events,
     });
     runtime.currentToolset = preparedToolContext.toolset;
     runtime.currentToolsetPreference = preparedToolContext.toolsetPreference;


### PR DESCRIPTION
## Summary
- Passes `modEvents` from the listener mod adapter into `prepareToolExecutionContextForScope` at all five callsites (turn, send, recovery, model update, toolset update)
- Updates the `letta.client` error message from "listener provider mods" to "listener mods"
- Adds 3 tests proving mod tools work end-to-end in listener turns: exposure, scoped execution, and scope isolation

PR #2861 enabled the `tools: true` capability and scoped the invocation context builder, but did not thread `modEvents` into the captured tool execution context. Without it, `executeTool` reads `undefined` for events and permission checks — which works today because `events.tools` is still `false`, but would need separate wiring when we flip that flag. Passing it now means the capability flag is the only gate.

## No Desktop-side changes needed
The `client_tool_allowlist` field is optional — when undefined (the default from Desktop), the listener preserves the full toolset including mod tools.

## Test plan
- [x] `bun test src/websocket/listener/mod-adapter.test.ts` — 7 pass (4 existing + 3 new)
- [x] `bun test src/tools/tool-execution-context.test.ts` — 28 pass
- [ ] Manual: install a mod with a tool in Desktop, verify the tool appears in the agent's available tools and executes with correct scope

👾 Generated with [Letta Code](https://letta.com)