### PR TITLE
fix: add windows path-length hint for worktree creation

### DIFF
--- a/src/tools/create-worktree.test.ts
+++ b/src/tools/create-worktree.test.ts
@@ -8,7 +8,10 @@ import {
   runWithRuntimeContext,
 } from "@/runtime-context";
 import { settingsManager } from "@/settings-manager";
-import { create_worktree } from "@/tools/impl/create-worktree";
+import {
+  addWindowsPathLengthHint,
+  create_worktree,
+} from "@/tools/impl/create-worktree";
 import {
   clearToolsWithLock,
   executeTool,
@@ -368,5 +371,25 @@ describe("CreateWorktree tool", () => {
       "Current working directory is not inside a git repository",
     );
     expect(result.content[0]?.text).toContain("repo_path");
+  });
+
+  test("adds a windows path-length hint to git checkout failures", () => {
+    const message = addWindowsPathLengthHint(
+      "Failed to run git worktree add\nerror: unable to create file: filename too long\nfatal: could not reset index file to revision 'HEAD'",
+      "win32",
+    );
+
+    expect(message).toContain("Windows path-length issue");
+    expect(message).toContain("core.longpaths");
+    expect(message).toContain("C:\\src\\<repo>");
+  });
+
+  test("does not add the hint off windows", () => {
+    const message = addWindowsPathLengthHint(
+      "Failed to run git worktree add\nerror: unable to create file: filename too long",
+      "linux",
+    );
+
+    expect(message).not.toContain("Windows path-length issue");
   });
 });

--- a/src/tools/impl/create-worktree.ts
+++ b/src/tools/impl/create-worktree.ts
@@ -80,9 +80,32 @@ function slugifyName(name: string): string {
 function formatGitFailure(error: unknown): string {
   if (error instanceof GitCommandError) {
     const detail = error.result?.stderr.trim() || error.result?.stdout.trim();
-    return detail ? `${error.message}\n${detail}` : error.message;
+    const formatted = detail ? `${error.message}\n${detail}` : error.message;
+    return addWindowsPathLengthHint(formatted);
   }
-  return error instanceof Error ? error.message : String(error);
+  return addWindowsPathLengthHint(
+    error instanceof Error ? error.message : String(error),
+  );
+}
+
+export function addWindowsPathLengthHint(
+  message: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform !== "win32") {
+    return message;
+  }
+
+  const normalized = message.toLowerCase();
+  const looksLikePathLengthFailure =
+    normalized.includes("filename too long") ||
+    normalized.includes("could not reset index file to revision");
+
+  if (!looksLikePathLengthFailure) {
+    return message;
+  }
+
+  return `${message}\n\nThis looks like a Windows path-length issue. Try:\n- git config --global core.longpaths true\n- move the repo to a shorter path, like C:\\src\\<repo>, and retry.`;
 }
 
 async function runGit(


### PR DESCRIPTION
## summary\n- surface a clearer windows-specific hint when git worktree creation fails with path-length errors\n- point users to core.longpaths and shorter repo paths\n\n## validation\n- bun test src/tools/create-worktree.test.ts\n- bun run check