### PR TITLE
fix(local): surface GLM 5.2 for zAI connections

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,11 +1,10 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@letta-ai/letta-code",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.79.1",
+        "@earendil-works/pi-ai": "^0.79.6",
         "@letta-ai/letta-client": "^1.10.2",
         "@pierre/diffs": "1.2.2",
         "glob": "^13.0.0",
@@ -111,7 +110,7 @@
 
     "@discoveryjs/json-ext": ["@discoveryjs/json-ext@1.1.0", "", {}, "sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.79.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-UnORwrcsTNLm4StEvoM8iEom0u87Te7BXEWxhec3iNXygWD6eEBosUoq9ddcveqtj/QpUZBMPWUu81cCtZxzkQ=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.79.6", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-KGepEdgEeWDs7Imwlp96tBsO8TjSIpcDBvazsCDtHRa81+uwJI/YGetTegI52pMlKhVpJFLIGajRi4PCGC5MUg=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "^0.79.1",
+    "@earendil-works/pi-ai": "^0.79.6",
     "@letta-ai/letta-client": "^1.10.2",
     "@pierre/diffs": "1.2.2",
     "glob": "^13.0.0",

--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -100,7 +100,7 @@ export const PI_TUI_DEFAULT_MODEL_IDS: Partial<Record<KnownProvider, string>> =
     xai: "grok-4.20-0309-reasoning",
     groq: "openai/gpt-oss-120b",
     cerebras: "zai-glm-4.7",
-    zai: "glm-5.1",
+    zai: "glm-5.2",
     mistral: "devstral-medium-latest",
     minimax: "MiniMax-M2.7",
     "minimax-cn": "MiniMax-M2.7",

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -827,7 +827,10 @@ describe("local backend pi transcript", () => {
     const handles = (await listLocalModels(storageDir)).map(
       (model) => model.handle,
     );
+    const zaiHandles = handles.filter((handle) => handle.startsWith("zai/"));
+    expect(zaiHandles[0]).toBe("zai/glm-5.2");
     expect(handles).toContain("zai/glm-4.5-air");
+    expect(handles).toContain("zai/glm-5.2");
     expect(handles).toContain("zai/glm-5.1");
   });
 


### PR DESCRIPTION
This bumps `@earendil-works/pi-ai` to `0.79.6`, which includes `glm-5.2` in the zAI catalog, and updates the local zAI default to `glm-5.2` so a connected zAI key surfaces GLM 5.2 in the model selector.

I also tightened the local backend regression coverage to assert that GLM 5.2 appears in the configured zAI catalog and is the first zAI default.

Validated with `bun test src/backend/local-backend.test.ts --test-name-pattern "zAI"` and `bun run check`.