### PR TITLE
fix(resume): handle stale local in-context messages

### DIFF
--- a/src/agent/check-approval-resume-data.test.ts
+++ b/src/agent/check-approval-resume-data.test.ts
@@ -367,6 +367,37 @@ describe("getResumeData", () => {
     expect(output).not.toContain("Backfill scan found 0 assistant messages");
   });
 
+  test("does not fail resume when stale in-context message is missing", async () => {
+    const conversationsRetrieve = mock(async () => ({
+      in_context_message_ids: ["ui-msg-missing"],
+    }));
+    const conversationsList = mock(async () => ({
+      getPaginatedItems: () => [makeUserMessage("ui-msg-earlier")],
+    }));
+    const messagesRetrieve = mock(async () => {
+      const error = new Error("Message ui-msg-missing not found") as Error & {
+        status: number;
+      };
+      error.status = 404;
+      throw error;
+    });
+
+    installBackend({
+      retrieveConversation: conversationsRetrieve,
+      listConversationMessages: conversationsList,
+      retrieveMessage: messagesRetrieve,
+    });
+
+    const resume = await getResumeDataFromBackend(makeAgent(), "conv-stale");
+
+    expect(messagesRetrieve).toHaveBeenCalledWith("ui-msg-missing");
+    expect(resume.pendingApprovals).toEqual([]);
+    expect(resume.pendingApproval).toBeNull();
+    expect(resume.messageHistory.map((message) => message.id)).toEqual([
+      "ui-msg-earlier",
+    ]);
+  });
+
   test("warns about missing assistant messages after a full backfill scan", async () => {
     const conversationsRetrieve = mock(async () => ({
       in_context_message_ids: ["msg-49"],

--- a/src/agent/check-approval.ts
+++ b/src/agent/check-approval.ts
@@ -256,6 +256,33 @@ function tailStartsInsideSourceMessage(
   return firstMessage ? messageMatchesSourceId(firstMessage, sourceId) : false;
 }
 
+function isNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    ((error as { status?: unknown }).status === 404 ||
+      (error as { status?: unknown }).status === 422)
+  );
+}
+
+async function retrieveMessageVariantsForPendingApproval(
+  messageId: string,
+): Promise<Message[]> {
+  try {
+    return await getBackend().retrieveMessage(messageId);
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      debugWarn(
+        "check-approval",
+        `Unable to retrieve in-context message ${messageId} while checking pending approvals: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return [];
+    }
+    throw error;
+  }
+}
+
 /**
  * Prepare message history for backfill, trimming orphaned tool returns.
  * Messages should already be in chronological order (oldest first).
@@ -440,12 +467,13 @@ async function pendingApprovalsFromTailOrRetrieve(
     tailStartsInsideSourceMessage(messages, lastInContextId)
   ) {
     const retrievedMessages =
-      await getBackend().retrieveMessage(lastInContextId);
+      await retrieveMessageVariantsForPendingApproval(lastInContextId);
     return pendingApprovalsFromMessageVariants(retrievedMessages);
   }
   if (tailCheck.messageToCheck || !lastInContextId) return tailCheck;
 
-  const retrievedMessages = await getBackend().retrieveMessage(lastInContextId);
+  const retrievedMessages =
+    await retrieveMessageVariantsForPendingApproval(lastInContextId);
   return pendingApprovalsFromMessageVariants(retrievedMessages);
 }
 
@@ -579,10 +607,7 @@ export async function getResumeDataFromBackend(
   } catch (error) {
     // Re-throw "not found" errors (404/422) so callers can handle appropriately
     // (e.g., /resume command should fail for non-existent conversations)
-    if (
-      error instanceof APIError &&
-      (error.status === 404 || error.status === 422)
-    ) {
+    if (error instanceof APIError && isNotFoundError(error)) {
       throw error;
     }
     console.error("Error getting resume data:", error);

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -514,7 +514,6 @@ describe("local backend pi transcript", () => {
     const conversationId = "conv-interrupt";
 
     const store = new LocalStore(agentId, { storageDir });
-    store.ensureConversation(conversationId, agentId);
     store.appendTurnInput(conversationId, {
       agent_id: agentId,
       messages: [{ role: "user", content: "hello" }],
@@ -526,7 +525,7 @@ describe("local backend pi transcript", () => {
 
     const conversationBeforeReload = store.retrieveConversation(conversationId);
     const partialAssistantId =
-      conversationBeforeReload.in_context_message_ids.at(-1);
+      conversationBeforeReload.in_context_message_ids?.at(-1);
     expect(partialAssistantId).toBe("ui-msg-2");
 
     store.settleInterruptedToolCalls(conversationId, { agentId });

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -35,6 +35,7 @@ import { emptyLocalUsage } from "@/backend/local/local-message";
 import { LOCAL_REPAIRED_TOOL_RESULT_TEXT_MAX_CHARS } from "@/backend/local/local-message-projection";
 import { listLocalModels } from "@/backend/local/local-model-config";
 import {
+  LocalStore,
   LocalTranscriptMigrationRequiredError,
   LocalTranscriptRepairRequiredError,
 } from "@/backend/local/local-store";
@@ -505,6 +506,38 @@ describe("local backend pi transcript", () => {
       await backendForDirectLookup.retrieveMessage("ui-msg-latest");
     expect(latestVariants[0]?.id).toBe("ui-msg-latest");
     expect(latestVariants[0]?.date).toBe("2026-01-01T00:02:00.000Z");
+  });
+
+  test("interrupt rolls back unpersisted partial assistant message before reload", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-store-interrupt-"));
+    const agentId = "agent-interrupt";
+    const conversationId = "conv-interrupt";
+
+    const store = new LocalStore(agentId, { storageDir });
+    store.ensureConversation(conversationId, agentId);
+    store.appendTurnInput(conversationId, {
+      agent_id: agentId,
+      messages: [{ role: "user", content: "hello" }],
+    });
+    store.appendStreamChunk(conversationId, agentId, {
+      message_type: "assistant_message",
+      content: [{ type: "text", text: "partial" }],
+    } as LettaStreamingResponse);
+
+    const conversationBeforeReload = store.retrieveConversation(conversationId);
+    const partialAssistantId =
+      conversationBeforeReload.in_context_message_ids.at(-1);
+    expect(partialAssistantId).toBe("ui-msg-2");
+
+    store.settleInterruptedToolCalls(conversationId, { agentId });
+
+    const reloaded = new LocalStore(agentId, { storageDir });
+    const conversationAfterReload =
+      reloaded.retrieveConversation(conversationId);
+    expect(conversationAfterReload.in_context_message_ids).not.toContain(
+      partialAssistantId,
+    );
+    expect(reloaded.retrieveMessage(partialAssistantId ?? "")).toEqual([]);
   });
 
   test("recompiles cached system prompt when committed memory changes", async () => {

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -2229,6 +2229,8 @@ export class LocalStore {
     const conversation = this.findConversation(conversationId, agentId);
     if (!conversation) return 0;
 
+    this.rollbackUnpersistedTrailingAssistantMessage(conversation, agentId);
+
     const messages = this.localMessagesForConversation(
       conversation.id,
       agentId,
@@ -2252,6 +2254,35 @@ export class LocalStore {
 
     if (settledCount > 0) this.rebuildMessageIndex();
     return settledCount;
+  }
+
+  private rollbackUnpersistedTrailingAssistantMessage(
+    conversation: StoredConversation,
+    agentId: string,
+  ): void {
+    const key = this.conversationKey(conversation.id, agentId);
+    const messages = this.localMessagesForConversation(
+      conversation.id,
+      agentId,
+    );
+    const last = messages.at(-1);
+    if (last?.role !== "assistant") return;
+    if (this.sessionEntryIdsByMessageId(key).has(last.id)) return;
+
+    messages.pop();
+    this.localMessagesByConversationKey.set(key, messages);
+    conversation.in_context_message_ids =
+      conversation.in_context_message_ids.filter((id) => id !== last.id);
+    const previousLastMessage = messages.at(-1);
+    conversation.last_message_at = previousLastMessage
+      ? localMessageDate(previousLastMessage, conversation.last_message_at)
+      : conversation.created_at;
+    conversation.updated_at = currentIsoTimestamp();
+    this.conversations.set(key, conversation);
+    this.persistConversationState(conversation.id, agentId, {
+      transcript: "skip",
+    });
+    this.rebuildMessageIndex();
   }
 
   private findToolCall(

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -1147,6 +1147,11 @@ export class LocalStore {
     LocalCompiledSystemPrompt
   >();
   private readonly messagesById = new Map<string, StoredMessage[]>();
+  // Tracks local assistant message ids that have received a stop_reason chunk,
+  // meaning the turn completed (or was cancelled normally). Used by
+  // rollbackUnpersistedTrailingAssistantMessage to distinguish a clean completed
+  // turn from one that was cut off before stop_reason.
+  private readonly settledLocalMessageIds = new Set<string>();
   private conversationRecordsScanned = false;
   private conversationSeq = 0;
   private messageSeq = 0;
@@ -2267,6 +2272,11 @@ export class LocalStore {
     );
     const last = messages.at(-1);
     if (last?.role !== "assistant") return;
+    // If a stop_reason chunk was received for this message, the turn completed
+    // normally — do not roll it back. Works for both disk-backed and in-memory stores.
+    if (this.settledLocalMessageIds.has(last.id)) return;
+    // For disk-backed stores also check the persisted transcript index as a
+    // belt-and-suspenders fallback (covers messages loaded from a previous session).
     if (this.sessionEntryIdsByMessageId(key).has(last.id)) return;
 
     messages.pop();
@@ -2794,6 +2804,9 @@ export class LocalStore {
       });
       return;
     }
+    // Mark as settled regardless of storageDir so rollback detection works for
+    // in-memory backends too (persistConversationState is a no-op without storageDir).
+    this.settledLocalMessageIds.add(last.id);
     this.persistConversationState(conversationId, agentId, {
       transcript: "append",
       message: last,

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -2275,7 +2275,10 @@ export class LocalStore {
       conversation.in_context_message_ids.filter((id) => id !== last.id);
     const previousLastMessage = messages.at(-1);
     conversation.last_message_at = previousLastMessage
-      ? localMessageDate(previousLastMessage, conversation.last_message_at)
+      ? localMessageDate(
+          previousLastMessage,
+          conversation.last_message_at ?? currentIsoTimestamp(),
+        )
       : conversation.created_at;
     conversation.updated_at = currentIsoTimestamp();
     this.conversations.set(key, conversation);


### PR DESCRIPTION
## Summary
- roll back unpersisted trailing assistant messages during local interrupt settlement so conversation.json does not point at missing transcript rows
- make resume pending-approval lookup tolerate older stale in-context message pointers
- add regressions for interrupted local rollback and stale resume pointers

## Testing
- bun test src\backend\local-backend.test.ts --grep "interrupt rolls back unpersisted partial assistant message"
- bun test src\agent\check-approval-resume-data.test.ts
- bunx --bun @biomejs/biome@2.2.5 check src\backend\local\local-store.ts src\backend\local-backend.test.ts src\agent\check-approval.ts src\agent\check-approval-resume-data.test.ts
