### PR TITLE
fix: avoid stale MemFS env for shell tools

### DIFF
--- a/src/cli/helpers/session-context-windows.test.ts
+++ b/src/cli/helpers/session-context-windows.test.ts
@@ -10,6 +10,7 @@ describe("Session Context Windows Notes", () => {
 - The Bash tool uses PowerShell or cmd.exe on Windows
 - HEREDOC syntax (e.g., \`$(cat <<'EOF'...EOF)\`) does NOT work on Windows
 - For multiline strings (git commits, PR bodies), use simple quoted strings instead
+- Letta context variables are PowerShell environment variables; for MemFS paths use \`$env:MEMORY_DIR\` or \`Join-Path $env:MEMORY_DIR 'profile.png'\`
 `;
 
   test("Windows shell notes contain heredoc warning", () => {
@@ -23,6 +24,13 @@ describe("Session Context Windows Notes", () => {
 
   test("Windows shell notes provide alternative for multiline strings", () => {
     expect(windowsShellNotes).toContain("simple quoted strings");
+  });
+
+  test("Windows shell notes explain MemFS env var syntax", () => {
+    expect(windowsShellNotes).toContain("$env:MEMORY_DIR");
+    expect(windowsShellNotes).toContain(
+      "Join-Path $env:MEMORY_DIR 'profile.png'",
+    );
   });
 
   if (process.platform === "win32") {

--- a/src/cli/helpers/session-context.ts
+++ b/src/cli/helpers/session-context.ts
@@ -174,6 +174,7 @@ ${gitInfo.status}
 - The Bash tool uses PowerShell or cmd.exe on Windows
 - HEREDOC syntax (e.g., \`$(cat <<'EOF'...EOF)\`) does NOT work on Windows
 - For multiline strings (git commits, PR bodies), use simple quoted strings instead
+- Letta context variables are PowerShell environment variables; for MemFS paths use \`$env:MEMORY_DIR\` or \`Join-Path $env:MEMORY_DIR 'profile.png'\`
 `;
     }
 

--- a/src/skills/builtin/image-generation/SKILL.md
+++ b/src/skills/builtin/image-generation/SKILL.md
@@ -41,15 +41,16 @@ print("saved robot-mascot.png; credits:", response["billing"]["credits_charged"]
 PY
 ```
 
-In Bash tools launched by Letta Code, use the runtime-provided
-`LETTA_BASE_URL` and `LETTA_API_KEY` together for Letta API calls. Build URLs
-relative to `${LETTA_BASE_URL%/}` and send `Authorization: Bearer $LETTA_API_KEY`.
-Do not hardcode `https://api.letta.com`: Desktop and remote runtimes may provide
-a proxy base URL, and the credential may only be valid through that URL. If
-either variable is missing, the user needs to authenticate with Letta Cloud (or
-provide a Letta API key); do **not** ask for an OpenAI/Gemini provider key. This
-endpoint also does not use `/connect` BYOK providers — the only `provider` values
-supported here are `flux`, `gemini`, and `openai`.
+In shell tools launched by Letta Code, use the runtime-provided `LETTA_BASE_URL`
+and `LETTA_API_KEY` together for Letta API calls. Build URLs relative to
+`${LETTA_BASE_URL%/}` in Bash or `$env:LETTA_BASE_URL.TrimEnd('/')` in
+PowerShell, and send `Authorization: Bearer $LETTA_API_KEY`. Do not hardcode
+`https://api.letta.com`: Desktop and remote runtimes may provide a proxy base
+URL, and the credential may only be valid through that URL. If either variable is
+missing, the user needs to authenticate with Letta Cloud (or provide a Letta API
+key); do **not** ask for an OpenAI/Gemini provider key. This endpoint also does
+not use `/connect` BYOK providers — the only `provider` values supported here are
+`flux`, `gemini`, and `openai`.
 
 Then **show the image to the user** by embedding the saved file in your reply:
 
@@ -64,6 +65,19 @@ appears inline. **Always display generated images this way** — don't just repo
 the path, and never paste the raw base64 / a `data:` URI. The markdown path must
 match where you saved the file. For `n > 1`, save each image to its own file and
 embed each on its own line. Also tell the user the `credits_charged`.
+
+## Agent profile images
+
+When asked to create or update your own avatar/profile image, save the final PNG
+directly to MemFS as `profile.png`:
+
+- Bash/macOS/Linux: `target="$MEMORY_DIR/profile.png"`
+- Windows PowerShell: `$target = Join-Path $env:MEMORY_DIR 'profile.png'`
+
+Verify `MEMORY_DIR` exists and is writable. Do not use Read/Write tool paths like
+literal `$MEMORY_DIR/profile.png`; those tools do not shell-expand variables. If
+`MEMORY_DIR` is missing, use the concrete Memory directory from the system
+reminder or tell the user MemFS is not enabled.
 
 ## Request body
 

--- a/src/skills/builtin/image-generation/image-generation.test.ts
+++ b/src/skills/builtin/image-generation/image-generation.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import ImageGenerationSkill from "./SKILL.md";
+
+describe("image-generation skill", () => {
+  test("uses the runtime Letta base URL and token", () => {
+    expect(ImageGenerationSkill).toContain("$" + "{LETTA_BASE_URL%/}");
+    expect(ImageGenerationSkill).toContain("$env:LETTA_BASE_URL.TrimEnd('/')");
+    expect(ImageGenerationSkill).toContain(
+      "Authorization: Bearer $LETTA_API_KEY",
+    );
+    expect(ImageGenerationSkill).toContain("Do not hardcode");
+  });
+
+  test("explains cross-platform profile image placement", () => {
+    expect(ImageGenerationSkill).toContain("Agent profile images");
+    expect(ImageGenerationSkill).toContain("$MEMORY_DIR/profile.png");
+    expect(ImageGenerationSkill).toContain(
+      "Join-Path $env:MEMORY_DIR 'profile.png'",
+    );
+    expect(ImageGenerationSkill).toContain(
+      "Read/Write tool paths like\nliteral `$MEMORY_DIR/profile.png`",
+    );
+  });
+});

--- a/src/tools/bash-windows-description.test.ts
+++ b/src/tools/bash-windows-description.test.ts
@@ -25,6 +25,8 @@ describe("Bash Windows tool description", () => {
     expect(description).toContain("PowerShell-compatible syntax");
     expect(description).toContain("heredocs");
     expect(description).toContain("`export VAR=...`");
+    expect(description).toContain("`$env:MEMORY_DIR`");
+    expect(description).toContain("Join-Path $env:MEMORY_DIR 'profile.png'");
     expect(description).toContain("Windows safety rules:");
     expect(description).toContain("`Remove-Item` / `Move-Item`");
     expect(description).toContain("`Start-Process`");

--- a/src/tools/impl/shell-env.ts
+++ b/src/tools/impl/shell-env.ts
@@ -337,45 +337,56 @@ export function getShellEnv(): NodeJS.ProcessEnv {
     env.LETTA_AGENT_ID = agentId;
     env.AGENT_ID = agentId;
 
-    try {
-      const localBackendNoMemfs = isLocalBackendNoMemfsEnvEnabled();
-      const localBackendEnabled =
-        process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL === "1" ||
-        process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL?.toLowerCase() === "true";
+    const inheritedMemoryDir = process.env.MEMORY_DIR?.trim();
+    const inheritedLettaMemoryDir = process.env.LETTA_MEMORY_DIR?.trim();
+    const parentAgentId = process.env.LETTA_PARENT_AGENT_ID?.trim();
+    const inheritedParentMemoryDir = parentAgentId
+      ? getScopedMemoryFilesystemRoot(parentAgentId)
+      : null;
+
+    const clearOrExposeInheritedParentMemoryDir = () => {
       if (
-        !localBackendNoMemfs &&
-        (settingsManager.isMemfsEnabled(agentId) || localBackendEnabled)
+        inheritedMemoryDir &&
+        inheritedParentMemoryDir &&
+        path.resolve(inheritedMemoryDir) ===
+          path.resolve(inheritedParentMemoryDir)
       ) {
+        env.MEMORY_DIR = inheritedMemoryDir;
+        env.LETTA_MEMORY_DIR = inheritedLettaMemoryDir || inheritedMemoryDir;
+        return;
+      }
+
+      // Clear inherited/stale memory-dir vars for non-memfs agents. This is
+      // especially important on Windows, where an inherited MEMORY_DIR can point
+      // at USERPROFILE and make agents think MemFS exists when it does not.
+      delete env.LETTA_MEMORY_DIR;
+      delete env.MEMORY_DIR;
+    };
+
+    const localBackendNoMemfs = isLocalBackendNoMemfsEnvEnabled();
+    const localBackendEnabled =
+      process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL === "1" ||
+      process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL?.toLowerCase() === "true";
+    let memfsEnabled = false;
+    try {
+      memfsEnabled = settingsManager.isMemfsEnabled(agentId);
+    } catch {
+      memfsEnabled = false;
+    }
+
+    if (!localBackendNoMemfs && (memfsEnabled || localBackendEnabled)) {
+      try {
         const memoryDir = resolveScopedMemoryDir({ agentId });
         if (!memoryDir) {
           throw new Error("Unable to resolve memory directory");
         }
         env.LETTA_MEMORY_DIR = memoryDir;
         env.MEMORY_DIR = memoryDir;
-      } else {
-        const inheritedMemoryDir = process.env.MEMORY_DIR?.trim();
-        const inheritedLettaMemoryDir = process.env.LETTA_MEMORY_DIR?.trim();
-        const parentAgentId = process.env.LETTA_PARENT_AGENT_ID?.trim();
-        const inheritedParentMemoryDir = parentAgentId
-          ? getScopedMemoryFilesystemRoot(parentAgentId)
-          : null;
-
-        if (
-          inheritedMemoryDir &&
-          inheritedParentMemoryDir &&
-          path.resolve(inheritedMemoryDir) ===
-            path.resolve(inheritedParentMemoryDir)
-        ) {
-          env.MEMORY_DIR = inheritedMemoryDir;
-          env.LETTA_MEMORY_DIR = inheritedLettaMemoryDir || inheritedMemoryDir;
-        } else {
-          // Clear inherited/stale memory-dir vars for non-memfs agents.
-          delete env.LETTA_MEMORY_DIR;
-          delete env.MEMORY_DIR;
-        }
+      } catch {
+        clearOrExposeInheritedParentMemoryDir();
       }
-    } catch {
-      // Settings may not be initialized in tests/startup; preserve inherited values.
+    } else {
+      clearOrExposeInheritedParentMemoryDir();
     }
   }
   // Inject conversation ID if available
@@ -398,6 +409,17 @@ export function getShellEnv(): NodeJS.ProcessEnv {
   }
 
   // Inject API key and base URL from settings if not already in env
+  if (!env.LETTA_API_KEY) {
+    try {
+      const apiKey = settingsManager.getCachedSecureTokens().apiKey;
+      if (apiKey) {
+        env.LETTA_API_KEY = apiKey;
+      }
+    } catch {
+      // Settings not initialized yet, skip
+    }
+  }
+
   if (!env.LETTA_API_KEY || !env.LETTA_BASE_URL) {
     try {
       const settings = settingsManager.getSettings();

--- a/src/tools/shell-env.test.ts
+++ b/src/tools/shell-env.test.ts
@@ -355,6 +355,73 @@ test("getShellEnv does not inject MEMORY_DIR aliases when memfs is disabled", ()
   });
 });
 
+test("getShellEnv clears stale MEMORY_DIR aliases when memfs lookup fails", () => {
+  withTemporaryAgentEnv(`agent-test-${Date.now()}`, () => {
+    const originalIsMemfsEnabled =
+      settingsManager.isMemfsEnabled.bind(settingsManager);
+    const originalMemoryDir = process.env.MEMORY_DIR;
+    const originalLettaMemoryDir = process.env.LETTA_MEMORY_DIR;
+    (
+      settingsManager as unknown as { isMemfsEnabled: (id: string) => boolean }
+    ).isMemfsEnabled = () => {
+      throw new Error("settings unavailable");
+    };
+    process.env.MEMORY_DIR =
+      process.platform === "win32" ? "C:\\Users\\example" : "/Users/example";
+    process.env.LETTA_MEMORY_DIR = process.env.MEMORY_DIR;
+
+    try {
+      const env = getShellEnv();
+      expect(env.LETTA_MEMORY_DIR).toBeUndefined();
+      expect(env.MEMORY_DIR).toBeUndefined();
+    } finally {
+      (
+        settingsManager as unknown as {
+          isMemfsEnabled: (id: string) => boolean;
+        }
+      ).isMemfsEnabled = originalIsMemfsEnabled;
+
+      if (originalMemoryDir === undefined) {
+        delete process.env.MEMORY_DIR;
+      } else {
+        process.env.MEMORY_DIR = originalMemoryDir;
+      }
+
+      if (originalLettaMemoryDir === undefined) {
+        delete process.env.LETTA_MEMORY_DIR;
+      } else {
+        process.env.LETTA_MEMORY_DIR = originalLettaMemoryDir;
+      }
+    }
+  });
+});
+
+test("getShellEnv uses cached secure API tokens for shell tools", () => {
+  withTemporaryEnv({ LETTA_API_KEY: undefined }, () => {
+    const originalGetCachedSecureTokens =
+      settingsManager.getCachedSecureTokens.bind(settingsManager);
+    (
+      settingsManager as unknown as {
+        getCachedSecureTokens: () => { apiKey?: string; refreshToken?: string };
+      }
+    ).getCachedSecureTokens = () => ({ apiKey: "sk-cached-shell-token" });
+
+    try {
+      const env = getShellEnv();
+      expect(env.LETTA_API_KEY).toBe("sk-cached-shell-token");
+    } finally {
+      (
+        settingsManager as unknown as {
+          getCachedSecureTokens: () => {
+            apiKey?: string;
+            refreshToken?: string;
+          };
+        }
+      ).getCachedSecureTokens = originalGetCachedSecureTokens;
+    }
+  });
+});
+
 test("getShellEnv preserves inherited parent MEMORY_DIR for subagents", () => {
   const parentAgentId = `agent-parent-${Date.now()}`;
   const childAgentId = `agent-child-${Date.now()}`;

--- a/src/tools/tool-definitions.ts
+++ b/src/tools/tool-definitions.ts
@@ -152,6 +152,7 @@ const WINDOWS_UNIFIED_EXEC_GUIDANCE = `Windows safety rules:
 const WINDOWS_BASH_EXECUTION_GUIDANCE = `Windows execution:
 - Despite the tool name, on Windows this tool does not run commands through bash by default. It uses the native Windows shell launcher: PowerShell Core (\`pwsh\`) when available, then Windows PowerShell, then \`cmd.exe\` as fallback.
 - Write commands using PowerShell-compatible syntax by default. POSIX/bash constructs such as heredocs, \`export VAR=...\`, and Unix-style shell quoting may not work unless you explicitly invoke a POSIX shell.
+- Letta context variables are available as PowerShell environment variables such as \`$env:MEMORY_DIR\`; common variables are also aliased as \`$MEMORY_DIR\`. For MemFS paths, prefer \`Join-Path $env:MEMORY_DIR 'profile.png'\`.
 
 ${WINDOWS_UNIFIED_EXEC_GUIDANCE}`;
 


### PR DESCRIPTION
## Summary

Windows shell tools could inherit a stale `MEMORY_DIR` from the parent process when MemFS settings were unavailable. In the reported Desktop/cloud-agent case, that value resolved to the Windows user profile directory, so the agent treated `C:\Users\...` as MemFS even though the agent had no memory filesystem.

This PR changes shell env construction to fail closed for MemFS: if MemFS is disabled or cannot be resolved, `MEMORY_DIR`/`LETTA_MEMORY_DIR` are removed unless they are the expected inherited parent-agent memory directory. It also exposes cached secure API tokens to shell tools so Desktop gateway calls can use the token already loaded by the app, and updates image-generation guidance for PowerShell/profile-image placement.

## Validation

- `bun test src/tools/shell-env.test.ts src/tools/bash-windows-description.test.ts src/cli/helpers/session-context-windows.test.ts src/skills/builtin/image-generation/image-generation.test.ts`
- `bun run check`
