### PR TITLE
fix(channels): scope restored channel accounts by backend

### DIFF
--- a/src/channels/registry.test.ts
+++ b/src/channels/registry.test.ts
@@ -117,6 +117,38 @@ describe("ChannelRegistry", () => {
     expect(logs.some((line) => line.includes("accounts=0"))).toBe(true);
   });
 
+  test("initializeChannels does not start accounts outside the restore scope", async () => {
+    __testOverrideLoadChannelAccounts(() => [
+      {
+        channel: "slack",
+        accountId: "acct-cloud-slack",
+        enabled: true,
+        mode: "socket",
+        botToken: "xoxb-test-token",
+        appToken: "xapp-test-token",
+        agentId: "agent-cloud",
+        defaultPermissionMode: "unrestricted",
+        dmPolicy: "pairing",
+        allowedUsers: [],
+        createdAt: "2026-06-17T00:00:00.000Z",
+        updatedAt: "2026-06-17T00:00:00.000Z",
+      },
+    ]);
+    __testOverrideSaveChannelAccounts(() => {});
+    const logs: string[] = [];
+
+    await expect(
+      initializeChannels(["slack"], {
+        restoreAgentScope: "local",
+        logger: (message) => logs.push(message),
+      }),
+    ).resolves.toBeInstanceOf(ChannelRegistry);
+
+    expect(logs).toContain(
+      '[Channels] Channel "slack" has no enabled accounts in local restore scope.',
+    );
+  });
+
   test("/help gets a direct channel reply instead of being delivered to the agent", async () => {
     __testOverrideLoadChannelAccounts(() => [
       {

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -60,6 +60,8 @@ import {
   isFirstPartyChannelPlugin,
   loadChannelPlugin,
 } from "./plugin-registry";
+import type { ChannelRestoreAgentScope } from "./restore-scope";
+import { shouldRestoreChannelAccountForAgentScope } from "./restore-scope";
 import {
   addRoute,
   getRoute as getRouteFromStore,
@@ -2059,7 +2061,11 @@ export class ChannelRegistry {
  */
 export async function initializeChannels(
   channelNames: string[],
-  options?: { failOnStartupError?: boolean; logger?: ChannelStartupLogger },
+  options?: {
+    failOnStartupError?: boolean;
+    logger?: ChannelStartupLogger;
+    restoreAgentScope?: ChannelRestoreAgentScope | null;
+  },
 ): Promise<ChannelRegistry> {
   const registry = ensureChannelRegistry();
   const failures: ChannelStartupFailure[] = [];
@@ -2088,9 +2094,17 @@ export async function initializeChannels(
     );
     await hydrateChannelAccountSecrets(channelId);
     const accounts = listChannelAccounts(channelId);
-    const enabledAccountIds = accounts
-      .filter((account) => account.enabled)
-      .map((account) => account.accountId);
+    const restorableAccounts = accounts.filter(
+      (account) =>
+        account.enabled &&
+        shouldRestoreChannelAccountForAgentScope(
+          account,
+          options?.restoreAgentScope,
+        ),
+    );
+    const enabledAccountIds = restorableAccounts.map(
+      (account) => account.accountId,
+    );
     logChannelStartup(
       options?.logger,
       `${channelId}: accounts=${accounts.length}, enabled=${enabledAccountIds.length > 0 ? enabledAccountIds.join(",") : "none"}`,
@@ -2103,18 +2117,17 @@ export async function initializeChannels(
     }
 
     if (enabledAccountIds.length === 0) {
-      const error = `Channel "${channelId}" has no enabled accounts.`;
+      const scopeSuffix = options?.restoreAgentScope
+        ? ` in ${options.restoreAgentScope} restore scope`
+        : "";
+      const error = `Channel "${channelId}" has no enabled accounts${scopeSuffix}.`;
       failures.push({ channelId, error });
       console.error(error);
       logChannelStartup(options?.logger, error);
       continue;
     }
 
-    for (const account of accounts) {
-      if (!account.enabled) {
-        continue;
-      }
-
+    for (const account of restorableAccounts) {
       try {
         await registry.startChannelAccount(channelId, account.accountId, {
           logger: options?.logger,

--- a/src/channels/restore-scope.ts
+++ b/src/channels/restore-scope.ts
@@ -1,0 +1,62 @@
+import { isLocalAgentId } from "@/agent/agent-id";
+import type { ChannelAccount } from "./types";
+
+export type ChannelRestoreAgentScope = "all" | "cloud" | "local";
+
+export const RESTORE_CHANNEL_AGENT_SCOPE_ENV =
+  "LETTA_RESTORE_CHANNEL_AGENT_SCOPE";
+export const RESTORE_ENABLED_CHANNELS_AGENT_SCOPE_ENV =
+  "LETTA_RESTORE_ENABLED_CHANNELS_AGENT_SCOPE";
+
+type AccountAgentBinding = {
+  agentId?: string | null;
+  binding?: {
+    agentId?: string | null;
+  };
+};
+
+function normalizeAgentId(agentId: string | null | undefined): string | null {
+  const normalized = agentId?.trim();
+  return normalized ? normalized : null;
+}
+
+export function getChannelAccountAgentId(
+  account: ChannelAccount,
+): string | null {
+  const binding = account as AccountAgentBinding;
+  return (
+    normalizeAgentId(binding.agentId) ??
+    normalizeAgentId(binding.binding?.agentId)
+  );
+}
+
+export function parseChannelRestoreAgentScope(
+  value: string | undefined,
+): ChannelRestoreAgentScope | null {
+  const normalized = value?.trim().toLowerCase();
+  if (
+    normalized === "all" ||
+    normalized === "cloud" ||
+    normalized === "local"
+  ) {
+    return normalized;
+  }
+  return null;
+}
+
+export function shouldRestoreChannelAccountForAgentScope(
+  account: ChannelAccount,
+  scope: ChannelRestoreAgentScope | null | undefined,
+): boolean {
+  if (!scope || scope === "all") {
+    return true;
+  }
+
+  const agentId = getChannelAccountAgentId(account);
+
+  if (scope === "local") {
+    return Boolean(agentId && isLocalAgentId(agentId));
+  }
+
+  return !agentId || !isLocalAgentId(agentId);
+}

--- a/src/channels/service.test.ts
+++ b/src/channels/service.test.ts
@@ -283,6 +283,49 @@ describe("channel service", () => {
     expect(listEnabledChannelIds()).toEqual(["telegram"]);
   });
 
+  test("listEnabledChannelIds can filter restored accounts by agent scope", () => {
+    createChannelAccountLive(
+      "telegram",
+      {
+        displayName: "Local Telegram Bot",
+        enabled: true,
+        token: "telegram-token",
+        dmPolicy: "pairing",
+      },
+      { accountId: "telegram-local" },
+    );
+    bindChannelAccountLive(
+      "telegram",
+      "telegram-local",
+      "agent-local-123",
+      "conv-local",
+    );
+
+    createChannelAccountLive(
+      "slack",
+      {
+        displayName: "Cloud Slack App",
+        enabled: true,
+        botToken: "xoxb-test-token",
+        appToken: "xapp-test-token",
+        agentId: "agent-cloud",
+        dmPolicy: "pairing",
+      },
+      { accountId: "slack-cloud" },
+    );
+
+    expect(listEnabledChannelIds({ restoreAgentScope: "local" })).toEqual([
+      "telegram",
+    ]);
+    expect(listEnabledChannelIds({ restoreAgentScope: "cloud" })).toEqual([
+      "slack",
+    ]);
+    expect(listEnabledChannelIds({ restoreAgentScope: "all" })).toEqual([
+      "telegram",
+      "slack",
+    ]);
+  });
+
   test("updateChannelRouteLive updates the Slack route without changing the app's default agent", () => {
     createChannelAccountLive(
       "slack",

--- a/src/channels/service.ts
+++ b/src/channels/service.ts
@@ -39,6 +39,8 @@ import {
   ensureChannelRegistry,
   getChannelRegistry,
 } from "./registry";
+import type { ChannelRestoreAgentScope } from "./restore-scope";
+import { shouldRestoreChannelAccountForAgentScope } from "./restore-scope";
 import {
   addRoute,
   getRoute,
@@ -882,9 +884,18 @@ export function listChannelSummaries(): ChannelSummary[] {
   });
 }
 
-export function listEnabledChannelIds(): SupportedChannelId[] {
+export function listEnabledChannelIds(options?: {
+  restoreAgentScope?: ChannelRestoreAgentScope | null;
+}): SupportedChannelId[] {
   return getSupportedChannelIds().filter((channelId) =>
-    listChannelAccounts(channelId).some((account) => account.enabled),
+    listChannelAccounts(channelId).some(
+      (account) =>
+        account.enabled &&
+        shouldRestoreChannelAccountForAgentScope(
+          account,
+          options?.restoreAgentScope,
+        ),
+    ),
   );
 }
 

--- a/src/cli/subcommands/listen-telemetry.test.ts
+++ b/src/cli/subcommands/listen-telemetry.test.ts
@@ -19,6 +19,10 @@ describe("listen subcommand telemetry", () => {
   const originalDesktopDebugPanel = process.env.LETTA_DESKTOP_MODE;
   const originalRestoreEnabledChannels =
     process.env.LETTA_RESTORE_ENABLED_CHANNELS;
+  const originalRestoreChannelAgentScope =
+    process.env.LETTA_RESTORE_CHANNEL_AGENT_SCOPE;
+  const originalRestoreEnabledChannelsAgentScope =
+    process.env.LETTA_RESTORE_ENABLED_CHANNELS_AGENT_SCOPE;
   const originalIgnoreSelfHostedListenerError =
     process.env.IGNORE_SELF_HOSTED_LISTENER_ERROR;
 
@@ -31,6 +35,8 @@ describe("listen subcommand telemetry", () => {
     delete process.env.LETTA_BASE_URL;
     delete process.env.LETTA_DESKTOP_MODE;
     delete process.env.LETTA_RESTORE_ENABLED_CHANNELS;
+    delete process.env.LETTA_RESTORE_CHANNEL_AGENT_SCOPE;
+    delete process.env.LETTA_RESTORE_ENABLED_CHANNELS_AGENT_SCOPE;
     delete process.env.IGNORE_SELF_HOSTED_LISTENER_ERROR;
     __listenSubcommandTestUtils.setOAuthDepsForTests({
       LETTA_CLOUD_API_URL: "https://api.letta.com",
@@ -81,6 +87,18 @@ describe("listen subcommand telemetry", () => {
     } else {
       process.env.LETTA_RESTORE_ENABLED_CHANNELS =
         originalRestoreEnabledChannels;
+    }
+    if (originalRestoreChannelAgentScope === undefined) {
+      delete process.env.LETTA_RESTORE_CHANNEL_AGENT_SCOPE;
+    } else {
+      process.env.LETTA_RESTORE_CHANNEL_AGENT_SCOPE =
+        originalRestoreChannelAgentScope;
+    }
+    if (originalRestoreEnabledChannelsAgentScope === undefined) {
+      delete process.env.LETTA_RESTORE_ENABLED_CHANNELS_AGENT_SCOPE;
+    } else {
+      process.env.LETTA_RESTORE_ENABLED_CHANNELS_AGENT_SCOPE =
+        originalRestoreEnabledChannelsAgentScope;
     }
     if (originalIgnoreSelfHostedListenerError === undefined) {
       delete process.env.IGNORE_SELF_HOSTED_LISTENER_ERROR;

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -17,6 +17,12 @@ import {
   requestDeviceCode,
 } from "@/auth/oauth";
 import { isLocalBackendEnvEnabled } from "@/backend/local/paths";
+import {
+  type ChannelRestoreAgentScope,
+  parseChannelRestoreAgentScope,
+  RESTORE_CHANNEL_AGENT_SCOPE_ENV,
+  RESTORE_ENABLED_CHANNELS_AGENT_SCOPE_ENV,
+} from "@/channels/restore-scope";
 import { ListenerStatusUI } from "@/cli/components/ListenerStatusUI";
 import { applyStartupPermissionMode } from "@/permissions/startup";
 import { settingsManager } from "@/settings-manager";
@@ -198,6 +204,24 @@ async function resolveListenerStartupMode(
   }
 
   return { kind: "unsupported-self-hosted", serverUrl };
+}
+
+function getScopedChannelRestoreAgentScope(): ChannelRestoreAgentScope | null {
+  return parseChannelRestoreAgentScope(
+    process.env[RESTORE_ENABLED_CHANNELS_AGENT_SCOPE_ENV],
+  );
+}
+
+function resolveChannelRestoreAgentScope(
+  scopedRestoreAgentScope: ChannelRestoreAgentScope | null,
+): ChannelRestoreAgentScope {
+  return (
+    scopedRestoreAgentScope ??
+    parseChannelRestoreAgentScope(
+      process.env[RESTORE_CHANNEL_AGENT_SCOPE_ENV],
+    ) ??
+    (isLocalBackendEnvEnabled() ? "local" : "cloud")
+  );
 }
 
 async function refreshListenerAccessToken(
@@ -481,13 +505,23 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
 
   // Initialize channels if explicitly requested, or restore persisted enabled
   // channels when a desktop wrapper opts into boot-time channel restore.
+  const scopedRestoreAgentScope = getScopedChannelRestoreAgentScope();
+  const restoreEnabledChannels =
+    !values.channels &&
+    (process.env.LETTA_RESTORE_ENABLED_CHANNELS === "1" ||
+      scopedRestoreAgentScope !== null);
+  const restoreAgentScope = restoreEnabledChannels
+    ? resolveChannelRestoreAgentScope(scopedRestoreAgentScope)
+    : null;
   const channelNames = values.channels
     ? values.channels
         .split(",")
         .map((s) => s.trim())
         .filter(Boolean)
-    : process.env.LETTA_RESTORE_ENABLED_CHANNELS === "1"
-      ? (await import("@/channels/service")).listEnabledChannelIds()
+    : restoreEnabledChannels
+      ? (await import("@/channels/service")).listEnabledChannelIds({
+          restoreAgentScope,
+        })
       : [];
 
   if (channelNames.length > 0) {
@@ -514,6 +548,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
     try {
       await initializeChannels(channelNames, {
         failOnStartupError: Boolean(values.channels),
+        restoreAgentScope,
         logger: debugMode
           ? (message) => console.log(`[${formatTimestamp()}] ${message}`)
           : undefined,


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

Problem
Listener auto-restore currently starts every enabled channel account from the shared channels directory. That is unsafe when one machine runs separate cloud and local-backend listeners: a local-backend listener can start a cloud-bound socket-mode account and consume events for agents it cannot load.

Approach
Add an agent-scope filter to channel restore. Auto-restore can now be scoped to local, cloud, or all accounts. Local scope only restores accounts bound to agent-local-*; cloud scope restores cloud-bound and unbound accounts. Explicit --channels startup is unchanged.

The new LETTA_RESTORE_ENABLED_CHANNELS_AGENT_SCOPE flag both enables scoped restore and stays safe for older builds that do not know about it. The existing LETTA_RESTORE_ENABLED_CHANNELS flag still works and can be narrowed with LETTA_RESTORE_CHANNEL_AGENT_SCOPE.

Validation
bun test src/channels/service.test.ts src/channels/registry.test.ts src/cli/subcommands/listen-telemetry.test.ts
bun run lint
bun run check
