### PR TITLE
refactor(settings): remove conversation pins

### DIFF
--- a/src/cli/app/submit-profile-commands.ts
+++ b/src/cli/app/submit-profile-commands.ts
@@ -11,7 +11,6 @@ import {
   validateProfileLoad,
 } from "@/cli/commands/profile";
 import type { Buffers } from "@/cli/helpers/accumulator";
-import { settingsManager } from "@/settings-manager";
 import type { ActiveOverlay, AppCommandRunner } from "./types";
 
 type SubmitCommandResult = { submitted: boolean };
@@ -25,7 +24,6 @@ type ProfileConfirmPending = {
 type ProfileCommandRouterContext = {
   agentId: string;
   agentName: string | null;
-  conversationId: string;
   buffersRef: MutableRefObject<Buffers>;
   commandRunner: AppCommandRunner;
   handleAgentSelect: (
@@ -58,7 +56,6 @@ export async function handleProfileCommand(
   const {
     agentId,
     agentName,
-    conversationId,
     buffersRef,
     commandRunner,
     handleAgentSelect,
@@ -160,12 +157,11 @@ export async function handleProfileCommand(
       const output = [
         "/pin help",
         "",
-        "Pin agents and conversations.",
+        "Pin the current agent.",
         "",
         "USAGE",
         "  /pin [name]         — pin the current agent",
         "  /pin agent [name]   — pin the current agent",
-        "  /pin convo [-l]     — pin the current conversation",
         "  /pin help           — show this help",
       ].join("\n");
       cmd.finish(output, true);
@@ -178,47 +174,15 @@ export async function handleProfileCommand(
       return { submitted: true };
     }
 
-    if (target === "convo" || target === "conversation") {
-      const convoArgs = parts.slice(1);
-      const local = convoArgs.some(
-        (part) => part === "-l" || part === "--local",
-      );
-      const hasUnsupportedArg = convoArgs.some(
-        (part) => part !== "-l" && part !== "--local",
-      );
-      const cmd = commandRunner.start(trimmed, "Pinning conversation...");
-
-      if (hasUnsupportedArg) {
-        cmd.fail("Usage: /pin convo [-l]");
-        return { submitted: true };
-      }
-
-      const pinnedIds = local
-        ? settingsManager.getLocalPinnedConversations(agentId)
-        : settingsManager.getGlobalPinnedConversations(agentId);
-      const scopeText = local ? "to this project" : "globally";
-
-      if (pinnedIds.includes(conversationId)) {
-        cmd.fail(`This conversation is already pinned ${scopeText}.`);
-        return { submitted: true };
-      }
-
-      if (local) {
-        settingsManager.pinConversationLocal(agentId, conversationId);
-      } else {
-        settingsManager.pinConversationGlobal(agentId, conversationId);
-      }
-      cmd.finish(`Pinned current conversation ${scopeText}.`, true);
-      return { submitted: true };
-    }
-
     if (
+      target === "convo" ||
+      target === "conversation" ||
       target === "convos" ||
       target === "conversations" ||
       target === "agents"
     ) {
       const cmd = commandRunner.start(trimmed, "Checking pin command...");
-      cmd.fail("Usage: /pin agent [name] or /pin convo [-l]");
+      cmd.fail("Usage: /pin [name]");
       return { submitted: true };
     }
 

--- a/src/cli/app/submit-profile-commands.ts
+++ b/src/cli/app/submit-profile-commands.ts
@@ -149,49 +149,11 @@ export async function handleProfileCommand(
 
   if (trimmed === "/pin" || trimmed.startsWith("/pin ")) {
     const argsStr = trimmed.slice(4).trim();
-    const parts = argsStr.split(/\s+/).filter(Boolean);
-    const target = parts[0]?.toLowerCase();
 
-    if (target === "help") {
-      const cmd = commandRunner.start(trimmed, "Showing pin help...");
-      const output = [
-        "/pin help",
-        "",
-        "Pin the current agent.",
-        "",
-        "USAGE",
-        "  /pin [name]         — pin the current agent",
-        "  /pin agent [name]   — pin the current agent",
-        "  /pin help           — show this help",
-      ].join("\n");
-      cmd.finish(output, true);
-      return { submitted: true };
-    }
-
-    if (target === "-l" || target === "--local") {
-      const cmd = commandRunner.start(trimmed, "Checking pin command...");
-      cmd.fail("Agent pins are global-only. Usage: /pin [name]");
-      return { submitted: true };
-    }
-
-    if (
-      target === "convo" ||
-      target === "conversation" ||
-      target === "convos" ||
-      target === "conversations" ||
-      target === "agents"
-    ) {
-      const cmd = commandRunner.start(trimmed, "Checking pin command...");
-      cmd.fail("Usage: /pin [name]");
-      return { submitted: true };
-    }
-
-    const currentArgs = target === "agent" ? parts.slice(1).join(" ") : argsStr;
-
-    if (!currentArgs && target !== "agent") {
+    if (!argsStr) {
       openOverlay(
         "pin",
-        target === "agent" ? "/pin agent" : "/pin",
+        "/pin",
         "Opening pin dialog...",
         "Pin dialog dismissed",
       );
@@ -209,7 +171,7 @@ export async function handleProfileCommand(
     const cmd = commandRunner.start(trimmed, "Pinning agent...");
     setActiveProfileCommandId(cmd.id);
     try {
-      await handlePin(profileCtx, msg, currentArgs);
+      await handlePin(profileCtx, msg, argsStr);
     } finally {
       setActiveProfileCommandId(null);
     }
@@ -217,23 +179,6 @@ export async function handleProfileCommand(
   }
 
   if (trimmed === "/unpin" || trimmed.startsWith("/unpin ")) {
-    const unpinArgsStr = trimmed.slice(6).trim();
-
-    if (unpinArgsStr === "help") {
-      const cmd = commandRunner.start(trimmed, "Showing unpin help...");
-      const output = [
-        "/unpin help",
-        "",
-        "Unpin the current agent.",
-        "",
-        "USAGE",
-        "  /unpin       — unpin the current agent",
-        "  /unpin help  — show this help",
-      ].join("\n");
-      cmd.finish(output, true);
-      return { submitted: true };
-    }
-
     const profileCtx: ProfileCommandContext = {
       buffersRef,
       refreshDerived,

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -2410,7 +2410,6 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
         const profileCommandResult = await handleProfileCommand(msg, trimmed, {
           agentId,
           agentName,
-          conversationId,
           buffersRef,
           commandRunner,
           handleAgentSelect,

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -231,7 +231,7 @@ export const commands: Record<string, Command> = {
     },
   },
   "/pin": {
-    desc: "Pin current agent (/pin [name]|agent [name])",
+    desc: "Pin current agent (/pin [name])",
     order: 22,
     handler: () => {
       // Handled specially in App.tsx

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -231,7 +231,7 @@ export const commands: Record<string, Command> = {
     },
   },
   "/pin": {
-    desc: "Pin current agent or conversation (/pin [name]|agent [name]|convo)",
+    desc: "Pin current agent (/pin [name]|agent [name])",
     order: 22,
     handler: () => {
       // Handled specially in App.tsx

--- a/src/cli/components/ConversationSelector.tsx
+++ b/src/cli/components/ConversationSelector.tsx
@@ -60,16 +60,8 @@ const RESUME_PREVIEW_MESSAGE_TYPES: MessageType[] = [
   "assistant_message",
 ];
 
-export function isDefaultConversationId(conversationId: string): boolean {
-  return conversationId === "default";
-}
-
 export function buildConversationSelectorHints(): string {
   return "Enter select · ↑↓ navigate · Esc clear/cancel";
-}
-
-export function normalizeConversationSearchInput(value: string): string {
-  return value.replace(/[π∏]/g, "");
 }
 
 function paginatedItems<T>(value: T[] | { getPaginatedItems(): T[] }): T[] {
@@ -853,9 +845,8 @@ export function ConversationSelector({
         <PasteAwareTextInput
           value={searchInput}
           onChange={(value) => {
-            const nextSearchInput = normalizeConversationSearchInput(value);
-            if (nextSearchInput === searchInput) return;
-            setSearchInput(nextSearchInput);
+            if (value === searchInput) return;
+            setSearchInput(value);
             setSelectedIndex(0);
           }}
           placeholder="search conversation titles"

--- a/src/cli/components/ConversationSelector.tsx
+++ b/src/cli/components/ConversationSelector.tsx
@@ -12,7 +12,6 @@ import {
   useTerminalWidth,
 } from "@/cli/hooks/use-terminal-width";
 import { SYSTEM_ALERT_OPEN, SYSTEM_REMINDER_OPEN } from "@/constants";
-import { settingsManager } from "@/settings-manager";
 import { colors } from "./colors";
 import { MarkdownDisplay } from "./MarkdownDisplay";
 import { PasteAwareTextInput } from "./PasteAwareTextInput";
@@ -50,22 +49,6 @@ interface EnrichedConversation {
   lastActiveAt: string | null; // Falls back to updated_at until enriched
   messageCount: number; // -1 = unknown/loading
   enriched: boolean; // Whether message data has been fetched
-  isPinned: boolean;
-  isPinnedLocal: boolean;
-}
-
-export function isPinShortcut(
-  input: string,
-  key: { ctrl?: boolean; meta?: boolean },
-): boolean {
-  if (key.ctrl) return false;
-
-  // macOS Option+P can arrive as literal glyphs when Option isn't Meta.
-  if (input === "π" || input === "∏") return true;
-
-  if (!key.meta) return false;
-  const normalizedInput = input.replaceAll("\u001b", "");
-  return normalizedInput === "p" || normalizedInput === "P";
 }
 
 const MAX_DISPLAY_PAGE_SIZE = 5;
@@ -81,41 +64,12 @@ export function isDefaultConversationId(conversationId: string): boolean {
   return conversationId === "default";
 }
 
-export function isConversationPinned(params: {
-  conversationId: string;
-  pinnedIds: Set<string>;
-}): boolean {
-  return isDefaultConversationId(params.conversationId)
-    ? true
-    : params.pinnedIds.has(params.conversationId);
-}
-
-export function buildConversationSelectorHints(params: {
-  isSelectedDefaultConversation: boolean;
-}): string {
-  return params.isSelectedDefaultConversation
-    ? "Enter select · ↑↓ navigate · Esc clear/cancel"
-    : "Enter select · ↑↓ navigate · Alt+P pin/unpin · Esc clear/cancel";
+export function buildConversationSelectorHints(): string {
+  return "Enter select · ↑↓ navigate · Esc clear/cancel";
 }
 
 export function normalizeConversationSearchInput(value: string): string {
   return value.replace(/[π∏]/g, "");
-}
-
-export function findConversationIndexById<
-  T extends { conversation: { id: string } },
->(items: T[], conversationId: string): number {
-  return items.findIndex((item) => item.conversation.id === conversationId);
-}
-
-export function sortPinnedConversations<
-  T extends { conversation: { id: string }; isPinned: boolean },
->(items: T[]): T[] {
-  return [...items].sort((a, b) => {
-    if (a.conversation.id === "default") return -1;
-    if (b.conversation.id === "default") return 1;
-    return Number(b.isPinned) - Number(a.isPinned);
-  });
 }
 
 function paginatedItems<T>(value: T[] | { getPaginatedItems(): T[] }): T[] {
@@ -331,24 +285,7 @@ export function buildDefaultConversationEntry(
     lastActiveAt: stats.lastActiveAt,
     messageCount: stats.messageCount,
     enriched: true,
-    isPinned: false,
-    isPinnedLocal: false,
   };
-}
-
-export function mergePinnedConversationRecords(
-  listedConversations: Conversation[],
-  pinnedConversations: Conversation[],
-): Conversation[] {
-  const listedIds = new Set(
-    listedConversations.map((conversation) => conversation.id),
-  );
-  return [
-    ...pinnedConversations.filter(
-      (conversation) => !listedIds.has(conversation.id),
-    ),
-    ...listedConversations,
-  ];
 }
 
 export function ConversationSelector({
@@ -383,17 +320,6 @@ export function ConversationSelector({
     EnrichedConversation[] | null
   >(null);
   const [searching, setSearching] = useState(false);
-  const [pinNotice, setPinNotice] = useState<string | null>(null);
-  const pinNoticeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const preserveSelectionIdRef = useRef<string | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (pinNoticeTimerRef.current) {
-        clearTimeout(pinNoticeTimerRef.current);
-      }
-    };
-  }, []);
 
   // Enrich a single conversation with message data, updating state in-place
   const enrichConversation = useCallback(
@@ -472,14 +398,6 @@ export function ConversationSelector({
       try {
         const backend = selectorBackend();
 
-        const pinnedRefs = !afterCursor
-          ? settingsManager.getMergedPinnedConversations(agentId)
-          : [];
-        const pinnedIdSet = new Set(pinnedRefs.map((p) => p.conversationId));
-        const localPinnedIdSet = new Set(
-          pinnedRefs.filter((p) => p.isLocal).map((p) => p.conversationId),
-        );
-
         // Phase 1: Fetch conversation list + default messages in parallel
         const conversationListPromise = backend.listConversations({
           agent_id: agentId,
@@ -524,57 +442,14 @@ export function ConversationSelector({
           defaultPromise,
         ]);
 
-        const pinnedConversations = !afterCursor
-          ? (
-              await Promise.all(
-                pinnedRefs
-                  .filter(
-                    (pin) =>
-                      pin.conversationId !== "default" &&
-                      !result.some(
-                        (conversation) =>
-                          conversation.id === pin.conversationId,
-                      ),
-                  )
-                  .map(async (pin) => {
-                    try {
-                      const conversation = await backend.retrieveConversation(
-                        pin.conversationId,
-                      );
-                      return conversation.agent_id === agentId
-                        ? conversation
-                        : null;
-                    } catch {
-                      return null;
-                    }
-                  }),
-              )
-            ).filter(
-              (conversation): conversation is Conversation =>
-                conversation !== null,
-            )
-          : [];
-
-        const conversationRecords = mergePinnedConversationRecords(
-          result,
-          pinnedConversations,
-        );
-
         // Build unenriched conversation list using data already on the object
-        const unenrichedList: EnrichedConversation[] = conversationRecords.map(
-          (conv) => ({
-            conversation: conv,
-            previewLines: null, // Not loaded yet
-            lastActiveAt: conv.updated_at ?? conv.created_at ?? null,
-            messageCount: -1, // Unknown until enriched
-            enriched: false,
-            isPinned: isConversationPinned({
-              conversationId: conv.id,
-              pinnedIds: pinnedIdSet,
-            }),
-            isPinnedLocal: localPinnedIdSet.has(conv.id),
-          }),
-        );
+        const unenrichedList: EnrichedConversation[] = result.map((conv) => ({
+          conversation: conv,
+          previewLines: null, // Not loaded yet
+          lastActiveAt: conv.updated_at ?? conv.created_at ?? null,
+          messageCount: -1, // Unknown until enriched
+          enriched: false,
+        }));
 
         // Don't filter yet — we'll remove empties after enrichment confirms messageCount
         const nonEmptyList = unenrichedList;
@@ -589,37 +464,9 @@ export function ConversationSelector({
           setConversations((prev) => [...prev, ...nonEmptyList]);
         } else {
           const initialConversations = defaultConversation
-            ? [
-                {
-                  ...defaultConversation,
-                  isPinned: true,
-                  isPinnedLocal: localPinnedIdSet.has("default"),
-                },
-                ...nonEmptyList,
-              ]
+            ? [defaultConversation, ...nonEmptyList]
             : nonEmptyList;
-          const byId = new Map(
-            initialConversations.map((item) => [item.conversation.id, item]),
-          );
-          const defaultItem = byId.get("default");
-          const pinnedOrdered = pinnedRefs
-            .map((p) => byId.get(p.conversationId))
-            .filter(
-              (item): item is EnrichedConversation =>
-                item !== undefined && item.conversation.id !== "default",
-            );
-          const prioritizedIds = new Set([
-            ...(defaultItem ? [defaultItem.conversation.id] : []),
-            ...pinnedOrdered.map((item) => item.conversation.id),
-          ]);
-          const allConversations = [
-            ...(defaultItem ? [defaultItem] : []),
-            ...pinnedOrdered,
-            ...initialConversations.filter(
-              (item) => !prioritizedIds.has(item.conversation.id),
-            ),
-          ];
-          setConversations(allConversations);
+          setConversations(initialConversations);
           setSelectedIndex(0);
         }
         setCursor(newCursor);
@@ -730,17 +577,6 @@ export function ConversationSelector({
                 conversation.updated_at ?? conversation.created_at ?? null,
               messageCount: -1,
               enriched: false,
-              isPinned: isConversationPinned({
-                conversationId: conversation.id,
-                pinnedIds: new Set(
-                  settingsManager
-                    .getMergedPinnedConversations(agentId)
-                    .map((pinned) => pinned.conversationId),
-                ),
-              }),
-              isPinnedLocal: settingsManager
-                .getLocalPinnedConversations(agentId)
-                .includes(conversation.id),
             })),
           );
         } catch {
@@ -791,20 +627,6 @@ export function ConversationSelector({
       })()
     : conversations;
 
-  useEffect(() => {
-    const conversationId = preserveSelectionIdRef.current;
-    if (!conversationId) return;
-
-    preserveSelectionIdRef.current = null;
-    const nextSelectedIndex = findConversationIndexById(
-      filteredConversations,
-      conversationId,
-    );
-    if (nextSelectedIndex >= 0) {
-      setSelectedIndex(nextSelectedIndex);
-    }
-  }, [filteredConversations]);
-
   // Sliding window calculations (same interaction model as /search).
   const startIndex = Math.max(
     0,
@@ -836,44 +658,6 @@ export function ConversationSelector({
     if (loadingMore || !hasMore || !cursor) return;
     await loadConversations(cursor);
   }, [loadingMore, hasMore, cursor, loadConversations]);
-
-  const togglePinnedConversation = useCallback(
-    (selected: EnrichedConversation | undefined) => {
-      if (!selected?.conversation.id) return;
-      const conversationId = selected.conversation.id;
-      if (isDefaultConversationId(conversationId)) {
-        if (pinNoticeTimerRef.current) {
-          clearTimeout(pinNoticeTimerRef.current);
-        }
-        setPinNotice("Default conversation is always pinned.");
-        pinNoticeTimerRef.current = setTimeout(() => {
-          pinNoticeTimerRef.current = null;
-          setPinNotice(null);
-        }, 2000);
-        return;
-      }
-      setPinNotice(null);
-      if (selected.isPinned) {
-        settingsManager.unpinConversationBoth(agentId, conversationId);
-      } else {
-        settingsManager.pinConversationGlobal(agentId, conversationId);
-      }
-      preserveSelectionIdRef.current = conversationId;
-      const updatePinState = (item: EnrichedConversation) =>
-        item.conversation.id === conversationId
-          ? {
-              ...item,
-              isPinned: !selected.isPinned,
-              isPinnedLocal: false,
-            }
-          : item;
-      setConversations((prev) =>
-        sortPinnedConversations(prev.map(updatePinState)),
-      );
-      setSearchResults((prev) => prev?.map(updatePinState) ?? null);
-    },
-    [agentId],
-  );
 
   useInput((input, key) => {
     // CTRL-C: immediately cancel
@@ -911,8 +695,6 @@ export function ConversationSelector({
         return;
       }
       onCancel();
-    } else if (isPinShortcut(input, key)) {
-      togglePinnedConversation(filteredConversations[selectedIndex]);
     } else if (key.leftArrow || key.rightArrow) {
       // Let the search input own horizontal cursor movement.
       return;
@@ -932,7 +714,6 @@ export function ConversationSelector({
       messageCount,
     } = enrichedConv;
     const isCurrent = conv.id === currentConversationId;
-    const isPinned = enrichedConv.isPinned;
 
     const timestampText = formatConversationTimestampText({
       lastActiveAt,
@@ -1024,7 +805,6 @@ export function ConversationSelector({
             {isSelected ? ">" : " "}
           </Text>
           <Text> </Text>
-          {isPinned && <Text>📌 </Text>}
           <Text
             bold={isSelected}
             color={isSelected ? colors.selector.itemHighlighted : undefined}
@@ -1052,10 +832,6 @@ export function ConversationSelector({
 
   const terminalWidth = useTerminalWidth();
   const solidLine = SOLID_LINE.repeat(Math.max(terminalWidth, 10));
-  const selectedConversation = filteredConversations[selectedIndex];
-  const isSelectedDefaultConversation = selectedConversation
-    ? isDefaultConversationId(selectedConversation.conversation.id)
-    : false;
 
   return (
     <Box flexDirection="column">
@@ -1142,9 +918,7 @@ export function ConversationSelector({
         (() => {
           const footerWidth = Math.max(0, terminalWidth - 2);
           const pageText = `Showing ${startIndex + 1}-${Math.min(startIndex + visibleConversations.length, filteredConversations.length)} of ${filteredConversations.length}${!normalizedSearch && hasMore ? "+" : ""}${loadingMore ? " (loading...)" : ""}`;
-          const hintsText = buildConversationSelectorHints({
-            isSelectedDefaultConversation,
-          });
+          const hintsText = buildConversationSelectorHints();
 
           return (
             <Box flexDirection="column">
@@ -1160,14 +934,6 @@ export function ConversationSelector({
                   <MarkdownDisplay text={hintsText} dimColor />
                 </Box>
               </Box>
-              {pinNotice && (
-                <Box flexDirection="row">
-                  <Box width={2} flexShrink={0} />
-                  <Box flexGrow={1} width={footerWidth}>
-                    <Text color="yellow">{pinNotice}</Text>
-                  </Box>
-                </Box>
-              )}
             </Box>
           );
         })()}

--- a/src/cli/conversation-selector.test.ts
+++ b/src/cli/conversation-selector.test.ts
@@ -3,7 +3,6 @@ import {
   buildConversationSelectorHints,
   buildDefaultConversationEntry,
   formatConversationTimestampText,
-  normalizeConversationSearchInput,
 } from "@/cli/components/ConversationSelector";
 
 describe("ConversationSelector timestamps", () => {
@@ -73,12 +72,7 @@ describe("ConversationSelector timestamps", () => {
   });
 });
 
-describe("ConversationSelector search input", () => {
-  test("strips macOS Option+P glyphs from search input", () => {
-    expect(normalizeConversationSearchInput("π")).toBe("");
-    expect(normalizeConversationSearchInput("foo∏bar")).toBe("foobar");
-  });
-
+describe("ConversationSelector hints", () => {
   test("shows navigation hints without pin shortcuts", () => {
     expect(buildConversationSelectorHints()).toBe(
       "Enter select · ↑↓ navigate · Esc clear/cancel",

--- a/src/cli/conversation-selector.test.ts
+++ b/src/cli/conversation-selector.test.ts
@@ -1,15 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import type { Conversation } from "@letta-ai/letta-client/resources/conversations/conversations";
 import {
   buildConversationSelectorHints,
   buildDefaultConversationEntry,
-  findConversationIndexById,
   formatConversationTimestampText,
-  isConversationPinned,
-  isPinShortcut,
-  mergePinnedConversationRecords,
   normalizeConversationSearchInput,
-  sortPinnedConversations,
 } from "@/cli/components/ConversationSelector";
 
 describe("ConversationSelector timestamps", () => {
@@ -79,86 +73,15 @@ describe("ConversationSelector timestamps", () => {
   });
 });
 
-describe("ConversationSelector pinned conversations", () => {
-  test("treats macOS Option+P glyphs as pin shortcuts", () => {
-    expect(isPinShortcut("π", {})).toBe(true);
-    expect(isPinShortcut("∏", {})).toBe(true);
-    expect(isPinShortcut("p", { meta: true })).toBe(true);
-    expect(isPinShortcut("p", { ctrl: true, meta: true })).toBe(false);
-  });
-
+describe("ConversationSelector search input", () => {
   test("strips macOS Option+P glyphs from search input", () => {
     expect(normalizeConversationSearchInput("π")).toBe("");
     expect(normalizeConversationSearchInput("foo∏bar")).toBe("foobar");
   });
 
-  test("keeps the toggled conversation selectable after pin sorting", () => {
-    const conversations = [
-      { conversation: { id: "default" }, isPinned: true },
-      { conversation: { id: "conv-a" }, isPinned: false },
-      { conversation: { id: "conv-b" }, isPinned: true },
-      { conversation: { id: "conv-c" }, isPinned: false },
-    ];
-
-    const sorted = sortPinnedConversations(
-      conversations.map((item) =>
-        item.conversation.id === "conv-a" ? { ...item, isPinned: true } : item,
-      ),
+  test("shows navigation hints without pin shortcuts", () => {
+    expect(buildConversationSelectorHints()).toBe(
+      "Enter select · ↑↓ navigate · Esc clear/cancel",
     );
-
-    expect(sorted.map((item) => item.conversation.id)).toEqual([
-      "default",
-      "conv-a",
-      "conv-b",
-      "conv-c",
-    ]);
-    expect(findConversationIndexById(sorted, "conv-a")).toBe(1);
-  });
-
-  test("hides the pin shortcut hint when default conversation is selected", () => {
-    expect(
-      buildConversationSelectorHints({ isSelectedDefaultConversation: true }),
-    ).not.toContain("Alt+P");
-    expect(
-      buildConversationSelectorHints({ isSelectedDefaultConversation: false }),
-    ).toContain("Alt+P pin/unpin");
-  });
-
-  test("treats the default conversation as permanently pinned", () => {
-    expect(
-      isConversationPinned({
-        conversationId: "default",
-        pinnedIds: new Set(),
-      }),
-    ).toBe(true);
-  });
-
-  test("uses stored pin state for non-default conversations", () => {
-    const pinnedIds = new Set(["conv-pinned"]);
-
-    expect(
-      isConversationPinned({ conversationId: "conv-pinned", pinnedIds }),
-    ).toBe(true);
-    expect(
-      isConversationPinned({ conversationId: "conv-unpinned", pinnedIds }),
-    ).toBe(false);
-  });
-
-  test("includes pinned conversations missing from the recent page", () => {
-    const listed = [{ id: "recent-1" }, { id: "recent-2" }] as Conversation[];
-    const pinned = [{ id: "old-pinned" }] as Conversation[];
-
-    expect(
-      mergePinnedConversationRecords(listed, pinned).map((c) => c.id),
-    ).toEqual(["old-pinned", "recent-1", "recent-2"]);
-  });
-
-  test("does not duplicate pinned conversations already in the recent page", () => {
-    const listed = [{ id: "recent-1" }, { id: "old-pinned" }] as Conversation[];
-    const pinned = [{ id: "old-pinned" }] as Conversation[];
-
-    expect(
-      mergePinnedConversationRecords(listed, pinned).map((c) => c.id),
-    ).toEqual(["recent-1", "old-pinned"]);
   });
 });

--- a/src/settings-manager.test.ts
+++ b/src/settings-manager.test.ts
@@ -5,7 +5,6 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { CommandHookConfig, HookCommand } from "@/hooks/types";
 import { runWithRuntimeContext } from "@/runtime-context";
-import type { LocalProjectSettings, Settings } from "@/settings-manager";
 import { settingsManager } from "@/settings-manager";
 
 // Type-safe helper to extract command from a hook (tests only use command hooks)
@@ -140,6 +139,9 @@ describe("Settings Manager - Initialization", () => {
       JSON.stringify({
         reflectionBehavior: "reminder",
         enableSleeptime: true,
+        pinnedConversationsByServer: {
+          "api.letta.com": { "agent-1": ["conv-1"] },
+        },
         reflectionTrigger: "step-count",
         reflectionStepCount: 12,
       }),
@@ -154,6 +156,7 @@ describe("Settings Manager - Initialization", () => {
     expect(settings.reflectionStepCount).toBe(12);
     expect(settings).not.toHaveProperty("reflectionBehavior");
     expect(settings).not.toHaveProperty("enableSleeptime");
+    expect(settings).not.toHaveProperty("pinnedConversationsByServer");
 
     settingsManager.updateSettings({ tokenStreaming: true });
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -164,6 +167,7 @@ describe("Settings Manager - Initialization", () => {
     >;
     expect(persisted).not.toHaveProperty("reflectionBehavior");
     expect(persisted).not.toHaveProperty("enableSleeptime");
+    expect(persisted).not.toHaveProperty("pinnedConversationsByServer");
   });
 });
 
@@ -499,6 +503,9 @@ describe("Settings Manager - Local Project Settings", () => {
       JSON.stringify({
         lastAgent: "agent-local-legacy",
         reflectionBehavior: "reminder",
+        pinnedConversationsByServer: {
+          "api.letta.com": { "agent-1": ["conv-1"] },
+        },
         reflectionTrigger: "step-count",
         reflectionStepCount: 9,
       }),
@@ -508,12 +515,14 @@ describe("Settings Manager - Local Project Settings", () => {
       await settingsManager.loadLocalProjectSettings(testProjectDir);
     expect(localSettings.lastAgent).toBe("agent-local-legacy");
     expect(localSettings).not.toHaveProperty("reflectionBehavior");
+    expect(localSettings).not.toHaveProperty("pinnedConversationsByServer");
 
     const persisted = JSON.parse(await readFile(settingsPath)) as Record<
       string,
       unknown
     >;
     expect(persisted).not.toHaveProperty("reflectionBehavior");
+    expect(persisted).not.toHaveProperty("pinnedConversationsByServer");
   });
 
   test("Get local project settings returns cached value", async () => {
@@ -1723,184 +1732,6 @@ describe("Settings Manager - Conversation Goals", () => {
     expect(
       settingsManager.areConversationGoalToolsEnabled("conv-1", testProjectDir),
     ).toBe(false);
-  });
-});
-
-describe("Settings Manager - Conversation Pins", () => {
-  async function initPinTest() {
-    await settingsManager.initialize();
-    await settingsManager.loadLocalProjectSettings(testProjectDir);
-  }
-
-  test("pins conversations globally and locally per agent", async () => {
-    await initPinTest();
-
-    settingsManager.pinConversationGlobal("agent-1", "conv-1");
-    settingsManager.pinConversationLocal("agent-1", "conv-2", testProjectDir);
-
-    expect(settingsManager.getGlobalPinnedConversations("agent-1")).toEqual([
-      "conv-1",
-    ]);
-    expect(
-      settingsManager.getLocalPinnedConversations("agent-1", testProjectDir),
-    ).toEqual(["conv-2"]);
-    expect(
-      settingsManager.getMergedPinnedConversations("agent-1", testProjectDir),
-    ).toEqual([
-      { conversationId: "conv-2", isLocal: true },
-      { conversationId: "conv-1", isLocal: false },
-    ]);
-  });
-
-  test("global conversation pin writes merge with latest settings on disk", async () => {
-    const { readFile, writeFile } = await import("@/utils/fs.js");
-    await initPinTest();
-
-    settingsManager.pinConversationGlobal("agent-1", "stale-conv");
-
-    const settingsPath = join(testHomeDir, ".letta", "settings.json");
-    await writeFile(
-      settingsPath,
-      JSON.stringify({
-        pinnedConversationsByServer: {
-          "api.letta.com": {
-            "agent-1": ["fresh-conv"],
-          },
-        },
-      }),
-    );
-
-    settingsManager.pinConversationGlobal("agent-1", "new-conv");
-
-    const persisted = JSON.parse(await readFile(settingsPath)) as Settings;
-    expect(
-      persisted.pinnedConversationsByServer?.["api.letta.com"]?.["agent-1"],
-    ).toEqual(["fresh-conv", "new-conv"]);
-    expect(settingsManager.getGlobalPinnedConversations("agent-1")).toEqual([
-      "fresh-conv",
-      "new-conv",
-    ]);
-  });
-
-  test("global conversation unpin writes do not restore stale cached pins", async () => {
-    const { readFile, writeFile } = await import("@/utils/fs.js");
-    await initPinTest();
-
-    settingsManager.pinConversationGlobal("agent-1", "stale-conv");
-    settingsManager.pinConversationGlobal("agent-1", "remove-conv");
-
-    const settingsPath = join(testHomeDir, ".letta", "settings.json");
-    await writeFile(
-      settingsPath,
-      JSON.stringify({
-        pinnedConversationsByServer: {
-          "api.letta.com": {
-            "agent-1": ["fresh-conv", "remove-conv"],
-          },
-        },
-      }),
-    );
-
-    settingsManager.unpinConversationGlobal("agent-1", "remove-conv");
-
-    const persisted = JSON.parse(await readFile(settingsPath)) as Settings;
-    expect(
-      persisted.pinnedConversationsByServer?.["api.letta.com"]?.["agent-1"],
-    ).toEqual(["fresh-conv"]);
-  });
-
-  test("local conversation pin writes merge with latest project settings on disk", async () => {
-    const { readFile, writeFile } = await import("@/utils/fs.js");
-    await initPinTest();
-
-    settingsManager.pinConversationLocal(
-      "agent-1",
-      "stale-local-conv",
-      testProjectDir,
-    );
-
-    const localSettingsPath = join(
-      testProjectDir,
-      ".letta",
-      "settings.local.json",
-    );
-    await writeFile(
-      localSettingsPath,
-      JSON.stringify({
-        pinnedConversationsByServer: {
-          "api.letta.com": {
-            "agent-1": ["fresh-local-conv"],
-          },
-        },
-      }),
-    );
-
-    settingsManager.pinConversationLocal(
-      "agent-1",
-      "new-local-conv",
-      testProjectDir,
-    );
-
-    const persisted = JSON.parse(
-      await readFile(localSettingsPath),
-    ) as LocalProjectSettings;
-    expect(
-      persisted.pinnedConversationsByServer?.["api.letta.com"]?.["agent-1"],
-    ).toEqual(["fresh-local-conv", "new-local-conv"]);
-  });
-
-  test("LETTA_SETTINGS_BASE_URL scopes conversation pins independently from LETTA_BASE_URL", async () => {
-    const originalBaseUrl = process.env.LETTA_BASE_URL;
-    const originalSettingsBaseUrl = process.env.LETTA_SETTINGS_BASE_URL;
-
-    try {
-      process.env.LETTA_BASE_URL = "http://localhost:49692";
-      process.env.LETTA_SETTINGS_BASE_URL = "https://api.letta.com";
-      await initPinTest();
-
-      settingsManager.pinConversationGlobal("agent-1", "cloud-conv");
-
-      expect(settingsManager.getGlobalPinnedConversations("agent-1")).toEqual([
-        "cloud-conv",
-      ]);
-      const { readFile } = await import("@/utils/fs.js");
-      const persisted = JSON.parse(
-        await readFile(join(testHomeDir, ".letta", "settings.json")),
-      ) as Settings;
-      expect(
-        persisted.pinnedConversationsByServer?.["api.letta.com"]?.["agent-1"],
-      ).toEqual(["cloud-conv"]);
-      expect(
-        persisted.pinnedConversationsByServer?.["localhost:49692"]?.["agent-1"],
-      ).toBeUndefined();
-    } finally {
-      if (originalBaseUrl === undefined) {
-        delete process.env.LETTA_BASE_URL;
-      } else {
-        process.env.LETTA_BASE_URL = originalBaseUrl;
-      }
-      if (originalSettingsBaseUrl === undefined) {
-        delete process.env.LETTA_SETTINGS_BASE_URL;
-      } else {
-        process.env.LETTA_SETTINGS_BASE_URL = originalSettingsBaseUrl;
-      }
-    }
-  });
-
-  test("conversation pins are scoped by local backend storage dir", async () => {
-    process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL = "1";
-    process.env.LETTA_LOCAL_BACKEND_DIR = join(testHomeDir, "local-store-a");
-    await initPinTest();
-
-    settingsManager.pinConversationGlobal("local-agent-1", "conv-a");
-    expect(
-      settingsManager.getGlobalPinnedConversations("local-agent-1"),
-    ).toEqual(["conv-a"]);
-
-    process.env.LETTA_LOCAL_BACKEND_DIR = join(testHomeDir, "local-store-b");
-    expect(
-      settingsManager.getGlobalPinnedConversations("local-agent-1"),
-    ).toEqual([]);
   });
 });
 

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -2,7 +2,7 @@
 // In-memory settings manager that loads once and provides sync access
 
 import { randomUUID } from "node:crypto";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { isCloudAgentId, isLocalAgentId } from "./agent/agent-id";
@@ -106,7 +106,6 @@ export interface Settings {
   experiments?: Partial<Record<ExperimentId, boolean>>;
   // Server-indexed settings (agent IDs are server-specific)
   sessionsByServer?: Record<string, SessionRef>; // key = normalized base URL (e.g., "api.letta.com", "localhost:8283")
-  pinnedConversationsByServer?: Record<string, Record<string, string[]>>; // server -> agentId -> conversation IDs
   // Per-agent settings (global, keyed by agentId+serverKey)
   agents?: AgentSettings[];
   // Letta Cloud OAuth token management (stored separately in secrets)
@@ -154,7 +153,6 @@ export interface LocalProjectSettings {
   >;
   // Server-indexed settings (agent IDs are server-specific)
   sessionsByServer?: Record<string, SessionRef>; // key = normalized base URL
-  pinnedConversationsByServer?: Record<string, Record<string, string[]>>; // server -> agentId -> conversation IDs
   listenerEnvName?: string; // Saved environment name for listener connections (project-specific)
   conversationGoalsByServer?: Record<string, Record<string, ConversationGoal>>;
   conversationGoalToolsByServer?: Record<string, Record<string, boolean>>;
@@ -166,6 +164,7 @@ const OBSOLETE_SETTINGS_KEYS = [
   "enableSleeptime",
   "pinnedAgents",
   "pinnedAgentsByServer",
+  "pinnedConversationsByServer",
 ];
 
 const DEFAULT_SETTINGS: Settings = {
@@ -338,80 +337,12 @@ class SettingsManager {
     this.secureTokensCache = {};
   }
 
-  private ensureInitialized(): void {
-    if (!this.initialized || !this.settings) {
-      throw new Error(
-        "Settings not initialized. Call settingsManager.initialize() first.",
-      );
-    }
-  }
-
   private readJsonObjectSync(path: string): Record<string, unknown> {
     if (!exists(path)) return {};
     try {
       return JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
     } catch {
       return {};
-    }
-  }
-
-  private normalizeSettingsRecord(
-    raw: Record<string, unknown>,
-  ): Record<string, unknown> {
-    const normalized = { ...raw };
-    for (const key of OBSOLETE_SETTINGS_KEYS) {
-      delete normalized[key];
-    }
-    return normalized;
-  }
-
-  private settingsFromRaw(raw: Record<string, unknown>): Settings {
-    return {
-      ...DEFAULT_SETTINGS,
-      ...(this.normalizeSettingsRecord(raw) as Partial<Settings>),
-    };
-  }
-
-  private readSettingsSnapshot(): Settings {
-    this.ensureInitialized();
-    const raw = this.readJsonObjectSync(this.getSettingsPath());
-    const mergedRaw = this.normalizeSettingsRecord(raw);
-
-    if (this.settings) {
-      const currentRecord = this.settings as unknown as Record<string, unknown>;
-      for (const key of this.dirtyKeys) {
-        if (key in currentRecord) {
-          mergedRaw[key] = currentRecord[key];
-        } else {
-          delete mergedRaw[key];
-        }
-      }
-    }
-
-    const settings = this.settingsFromRaw(mergedRaw);
-    this.settings = settings;
-    for (const key of Object.keys(mergedRaw)) {
-      this.managedKeys.add(key);
-    }
-    return settings;
-  }
-
-  private writeSettingsRecordSync(raw: Record<string, unknown>): void {
-    const settingsPath = this.getSettingsPath();
-    const home = process.env.HOME || homedir();
-    const dirPath = join(home, ".letta");
-    if (!exists(dirPath)) {
-      mkdirSync(dirPath, { recursive: true });
-    }
-
-    const normalized = this.normalizeSettingsRecord(raw);
-    writeFileSync(settingsPath, JSON.stringify(normalized, null, 2), {
-      encoding: "utf-8",
-      flush: true,
-    });
-    this.settings = this.settingsFromRaw(normalized);
-    for (const key of Object.keys(normalized)) {
-      this.managedKeys.add(key);
     }
   }
 
@@ -1732,218 +1663,6 @@ class SettingsManager {
    */
   unpinAgent(agentId: string): void {
     this.upsertAgentSettings(agentId, { pinned: false });
-  }
-
-  /**
-   * Get globally pinned conversation IDs for an agent on the current server.
-   */
-  getGlobalPinnedConversations(agentId: string): string[] {
-    const settings = this.readSettingsSnapshot();
-    const serverKey = getCurrentServerKey(settings);
-    return settings.pinnedConversationsByServer?.[serverKey]?.[agentId] ?? [];
-  }
-
-  private readLocalProjectSettingsSnapshot(
-    workingDirectory: string,
-  ): LocalProjectSettings {
-    const raw = this.normalizeSettingsRecord(
-      this.readJsonObjectSync(
-        this.getLocalProjectSettingsPath(workingDirectory),
-      ),
-    );
-    const settings = {
-      ...DEFAULT_LOCAL_PROJECT_SETTINGS,
-      ...(raw as Partial<LocalProjectSettings>),
-    };
-    this.localProjectSettings.set(workingDirectory, settings);
-    return settings;
-  }
-
-  private writeLocalProjectSettingsRecordSync(
-    workingDirectory: string,
-    raw: Record<string, unknown>,
-  ): void {
-    const dirPath = join(workingDirectory, ".letta");
-    if (!exists(dirPath)) {
-      mkdirSync(dirPath, { recursive: true });
-    }
-
-    const normalized = this.normalizeSettingsRecord(raw);
-    writeFileSync(
-      this.getLocalProjectSettingsPath(workingDirectory),
-      JSON.stringify(normalized, null, 2),
-      { encoding: "utf-8", flush: true },
-    );
-    this.localProjectSettings.set(workingDirectory, {
-      ...DEFAULT_LOCAL_PROJECT_SETTINGS,
-      ...(normalized as Partial<LocalProjectSettings>),
-    });
-  }
-
-  /**
-   * Get locally pinned conversation IDs for an agent on the current server.
-   */
-  getLocalPinnedConversations(
-    agentId: string,
-    workingDirectory: string = process.cwd(),
-  ): string[] {
-    const globalSettings = this.readSettingsSnapshot();
-    const serverKey = getCurrentServerKey(globalSettings);
-    const localSettings =
-      this.readLocalProjectSettingsSnapshot(workingDirectory);
-    return (
-      localSettings.pinnedConversationsByServer?.[serverKey]?.[agentId] ?? []
-    );
-  }
-
-  /**
-   * Get merged pinned conversation IDs for an agent (local first, then global).
-   */
-  getMergedPinnedConversations(
-    agentId: string,
-    workingDirectory: string = process.cwd(),
-  ): Array<{ conversationId: string; isLocal: boolean }> {
-    const localConversations = this.getLocalPinnedConversations(
-      agentId,
-      workingDirectory,
-    );
-    const globalConversations = this.getGlobalPinnedConversations(agentId);
-
-    const result: Array<{ conversationId: string; isLocal: boolean }> = [];
-    const seenConversationIds = new Set<string>();
-
-    for (const conversationId of localConversations) {
-      result.push({ conversationId, isLocal: true });
-      seenConversationIds.add(conversationId);
-    }
-
-    for (const conversationId of globalConversations) {
-      if (!seenConversationIds.has(conversationId)) {
-        result.push({ conversationId, isLocal: false });
-        seenConversationIds.add(conversationId);
-      }
-    }
-
-    return result;
-  }
-
-  pinConversationGlobal(agentId: string, conversationId: string): void {
-    this.ensureInitialized();
-    const raw = this.normalizeSettingsRecord(
-      this.readJsonObjectSync(this.getSettingsPath()),
-    );
-    const settings = this.settingsFromRaw(raw);
-    const serverKey = getCurrentServerKey(settings);
-    const current =
-      settings.pinnedConversationsByServer?.[serverKey]?.[agentId] ?? [];
-    if (current.includes(conversationId)) return;
-
-    this.writeSettingsRecordSync({
-      ...raw,
-      pinnedConversationsByServer: {
-        ...(settings.pinnedConversationsByServer ?? {}),
-        [serverKey]: {
-          ...(settings.pinnedConversationsByServer?.[serverKey] ?? {}),
-          [agentId]: [...current, conversationId],
-        },
-      },
-    });
-    this.dirtyKeys.delete("pinnedConversationsByServer");
-  }
-
-  unpinConversationGlobal(agentId: string, conversationId: string): void {
-    this.ensureInitialized();
-    const raw = this.normalizeSettingsRecord(
-      this.readJsonObjectSync(this.getSettingsPath()),
-    );
-    const settings = this.settingsFromRaw(raw);
-    const serverKey = getCurrentServerKey(settings);
-    const current =
-      settings.pinnedConversationsByServer?.[serverKey]?.[agentId] ?? [];
-
-    this.writeSettingsRecordSync({
-      ...raw,
-      pinnedConversationsByServer: {
-        ...(settings.pinnedConversationsByServer ?? {}),
-        [serverKey]: {
-          ...(settings.pinnedConversationsByServer?.[serverKey] ?? {}),
-          [agentId]: current.filter((id) => id !== conversationId),
-        },
-      },
-    });
-    this.dirtyKeys.delete("pinnedConversationsByServer");
-  }
-
-  pinConversationLocal(
-    agentId: string,
-    conversationId: string,
-    workingDirectory: string = process.cwd(),
-  ): void {
-    const globalSettings = this.readSettingsSnapshot();
-    const serverKey = getCurrentServerKey(globalSettings);
-    const raw = this.normalizeSettingsRecord(
-      this.readJsonObjectSync(
-        this.getLocalProjectSettingsPath(workingDirectory),
-      ),
-    );
-    const localSettings = {
-      ...DEFAULT_LOCAL_PROJECT_SETTINGS,
-      ...(raw as Partial<LocalProjectSettings>),
-    };
-    const current =
-      localSettings.pinnedConversationsByServer?.[serverKey]?.[agentId] ?? [];
-    if (current.includes(conversationId)) return;
-
-    this.writeLocalProjectSettingsRecordSync(workingDirectory, {
-      ...raw,
-      pinnedConversationsByServer: {
-        ...(localSettings.pinnedConversationsByServer ?? {}),
-        [serverKey]: {
-          ...(localSettings.pinnedConversationsByServer?.[serverKey] ?? {}),
-          [agentId]: [...current, conversationId],
-        },
-      },
-    });
-  }
-
-  unpinConversationLocal(
-    agentId: string,
-    conversationId: string,
-    workingDirectory: string = process.cwd(),
-  ): void {
-    const globalSettings = this.readSettingsSnapshot();
-    const serverKey = getCurrentServerKey(globalSettings);
-    const raw = this.normalizeSettingsRecord(
-      this.readJsonObjectSync(
-        this.getLocalProjectSettingsPath(workingDirectory),
-      ),
-    );
-    const localSettings = {
-      ...DEFAULT_LOCAL_PROJECT_SETTINGS,
-      ...(raw as Partial<LocalProjectSettings>),
-    };
-    const current =
-      localSettings.pinnedConversationsByServer?.[serverKey]?.[agentId] ?? [];
-
-    this.writeLocalProjectSettingsRecordSync(workingDirectory, {
-      ...raw,
-      pinnedConversationsByServer: {
-        ...(localSettings.pinnedConversationsByServer ?? {}),
-        [serverKey]: {
-          ...(localSettings.pinnedConversationsByServer?.[serverKey] ?? {}),
-          [agentId]: current.filter((id) => id !== conversationId),
-        },
-      },
-    });
-  }
-
-  unpinConversationBoth(
-    agentId: string,
-    conversationId: string,
-    workingDirectory: string = process.cwd(),
-  ): void {
-    this.unpinConversationLocal(agentId, conversationId, workingDirectory);
-    this.unpinConversationGlobal(agentId, conversationId);
   }
 
   // DEPRECATED: Keep for backwards compatibility

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -1806,42 +1806,6 @@ export interface GetCwdMapResponseMessage {
   error?: string;
 }
 
-export type ConversationPinScope = "global" | "local_project" | "both";
-export type ConversationPinAction = "pin" | "unpin" | "toggle";
-
-export interface ListConversationPinsCommand {
-  type: "list_conversation_pins";
-  request_id: string;
-  runtime: RuntimeScope;
-}
-
-export interface ListConversationPinsResponseMessage {
-  type: "list_conversation_pins_response";
-  request_id: string;
-  success: boolean;
-  pins: Array<{ conversation_id: string; is_local: boolean }>;
-  error?: string;
-}
-
-export interface SetConversationPinCommand {
-  type: "set_conversation_pin";
-  request_id: string;
-  runtime: RuntimeScope;
-  conversation_id: string;
-  action: ConversationPinAction;
-  scope?: ConversationPinScope;
-}
-
-export interface SetConversationPinResponseMessage {
-  type: "set_conversation_pin_response";
-  request_id: string;
-  success: boolean;
-  conversation_id: string;
-  pinned: boolean;
-  pins: Array<{ conversation_id: string; is_local: boolean }>;
-  error?: string;
-}
-
 export interface GetReflectionSettingsCommand {
   type: "get_reflection_settings";
   /** Echoed back in the response for request correlation. */
@@ -2704,8 +2668,6 @@ export type WsProtocolCommand =
   | ConversationMessagesListCommand
   | ConversationCompactCommand
   | GetCwdMapCommand
-  | ListConversationPinsCommand
-  | SetConversationPinCommand
   | GetReflectionSettingsCommand
   | SetReflectionSettingsCommand
   | GetExperimentsCommand
@@ -2804,8 +2766,6 @@ export type WsProtocolMessage =
   | RuntimeStartResponseMessage
   | GetExperimentsResponseMessage
   | SetExperimentResponseMessage
-  | ListConversationPinsResponseMessage
-  | SetConversationPinResponseMessage
   | GetReflectionSettingsResponseMessage
   | SetReflectionSettingsResponseMessage
   | ChannelsListResponseMessage

--- a/src/websocket/listener/commands/settings.ts
+++ b/src/websocket/listener/commands/settings.ts
@@ -4,16 +4,11 @@ import {
   persistReflectionSettingsForAgent,
 } from "@/cli/helpers/memory-reminder";
 import { experimentManager } from "@/experiments/manager";
-import { settingsManager } from "@/settings-manager";
 import type {
   GetExperimentsCommand,
   GetExperimentsResponseMessage,
   GetReflectionSettingsCommand,
-  ListConversationPinsCommand,
-  ListConversationPinsResponseMessage,
   ReflectionSettingsScope,
-  SetConversationPinCommand,
-  SetConversationPinResponseMessage,
   SetExperimentCommand,
   SetExperimentResponseMessage,
   SetReflectionSettingsCommand,
@@ -22,8 +17,6 @@ import { getConversationWorkingDirectory } from "@/websocket/listener/cwd";
 import {
   isGetExperimentsCommand,
   isGetReflectionSettingsCommand,
-  isListConversationPinsCommand,
-  isSetConversationPinCommand,
   isSetExperimentCommand,
   isSetReflectionSettingsCommand,
 } from "@/websocket/listener/protocol-inbound";
@@ -36,10 +29,6 @@ export type ReflectionSettingsCommand =
   | SetReflectionSettingsCommand;
 
 export type ExperimentCommand = GetExperimentsCommand | SetExperimentCommand;
-
-export type ConversationPinCommand =
-  | ListConversationPinsCommand
-  | SetConversationPinCommand;
 
 type SettingsCommandContext = {
   socket: WebSocket;
@@ -146,116 +135,6 @@ export async function handleExperimentCommand(
     );
   }
 
-  return true;
-}
-
-function toConversationPinResponseItems(
-  agentId: string,
-  workingDirectory: string,
-): Array<{ conversation_id: string; is_local: boolean }> {
-  return settingsManager
-    .getMergedPinnedConversations(agentId, workingDirectory)
-    .map((pin) => ({
-      conversation_id: pin.conversationId,
-      is_local: pin.isLocal,
-    }));
-}
-
-export async function handleConversationPinCommand(
-  parsed: ConversationPinCommand,
-  socket: WebSocket,
-  listener: ListenerRuntime,
-  safeSocketSend: SafeSocketSend,
-): Promise<boolean> {
-  const agentId = parsed.runtime.agent_id;
-  const workingDirectory = getConversationWorkingDirectory(
-    listener,
-    parsed.runtime.agent_id,
-    parsed.runtime.conversation_id,
-  );
-
-  if (parsed.type === "list_conversation_pins") {
-    const response: ListConversationPinsResponseMessage = {
-      type: "list_conversation_pins_response",
-      request_id: parsed.request_id,
-      success: true,
-      pins: toConversationPinResponseItems(agentId, workingDirectory),
-    };
-    safeSocketSend(
-      socket,
-      response,
-      "listener_conversation_pins_send_failed",
-      "listener_conversation_pins",
-    );
-    return true;
-  }
-
-  const scope = parsed.scope ?? "global";
-  const localPinned = settingsManager
-    .getLocalPinnedConversations(agentId, workingDirectory)
-    .includes(parsed.conversation_id);
-  const globalPinned = settingsManager
-    .getGlobalPinnedConversations(agentId)
-    .includes(parsed.conversation_id);
-  const currentlyPinned =
-    scope === "local_project"
-      ? localPinned
-      : scope === "global"
-        ? globalPinned
-        : localPinned || globalPinned;
-  const shouldPin =
-    parsed.action === "toggle" ? !currentlyPinned : parsed.action === "pin";
-
-  if (scope === "local_project") {
-    if (shouldPin) {
-      settingsManager.pinConversationLocal(
-        agentId,
-        parsed.conversation_id,
-        workingDirectory,
-      );
-    } else {
-      settingsManager.unpinConversationLocal(
-        agentId,
-        parsed.conversation_id,
-        workingDirectory,
-      );
-    }
-  } else if (scope === "both") {
-    if (shouldPin) {
-      settingsManager.pinConversationLocal(
-        agentId,
-        parsed.conversation_id,
-        workingDirectory,
-      );
-      settingsManager.pinConversationGlobal(agentId, parsed.conversation_id);
-    } else {
-      settingsManager.unpinConversationBoth(
-        agentId,
-        parsed.conversation_id,
-        workingDirectory,
-      );
-    }
-  } else if (shouldPin) {
-    settingsManager.pinConversationGlobal(agentId, parsed.conversation_id);
-  } else {
-    settingsManager.unpinConversationGlobal(agentId, parsed.conversation_id);
-  }
-
-  const pins = toConversationPinResponseItems(agentId, workingDirectory);
-  const response: SetConversationPinResponseMessage = {
-    type: "set_conversation_pin_response",
-    request_id: parsed.request_id,
-    success: true,
-    conversation_id: parsed.conversation_id,
-    pinned: pins.some((pin) => pin.conversation_id === parsed.conversation_id),
-    pins,
-  };
-  safeSocketSend(
-    socket,
-    response,
-    "listener_conversation_pins_send_failed",
-    "listener_conversation_pins",
-  );
   return true;
 }
 
@@ -370,21 +249,6 @@ export function handleSettingsProtocolCommand(
   if (isGetExperimentsCommand(parsed) || isSetExperimentCommand(parsed)) {
     runDetachedListenerTask("experiment_command", async () => {
       await handleExperimentCommand(parsed, socket, runtime, safeSocketSend);
-    });
-    return true;
-  }
-
-  if (
-    isListConversationPinsCommand(parsed) ||
-    isSetConversationPinCommand(parsed)
-  ) {
-    runDetachedListenerTask("conversation_pin_command", async () => {
-      await handleConversationPinCommand(
-        parsed,
-        socket,
-        runtime,
-        safeSocketSend,
-      );
     });
     return true;
   }

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -63,7 +63,6 @@ import type {
   GrepInFilesCommand,
   InputCommand,
   ListConnectProvidersCommand,
-  ListConversationPinsCommand,
   ListInDirectoryCommand,
   ListMemoryCommand,
   ListModelsCommand,
@@ -79,7 +78,6 @@ import type {
   SearchFilesCommand,
   SecretApplyCommand,
   SecretListCommand,
-  SetConversationPinCommand,
   SetExperimentCommand,
   SetReflectionSettingsCommand,
   SkillDisableCommand,
@@ -1387,47 +1385,6 @@ export function isConversationCompactCommand(
   );
 }
 
-export function isListConversationPinsCommand(
-  value: unknown,
-): value is ListConversationPinsCommand {
-  if (!value || typeof value !== "object") return false;
-  const c = value as {
-    type?: unknown;
-    request_id?: unknown;
-    runtime?: unknown;
-  };
-  return (
-    c.type === "list_conversation_pins" &&
-    typeof c.request_id === "string" &&
-    isRuntimeScope(c.runtime)
-  );
-}
-
-export function isSetConversationPinCommand(
-  value: unknown,
-): value is SetConversationPinCommand {
-  if (!value || typeof value !== "object") return false;
-  const c = value as {
-    type?: unknown;
-    request_id?: unknown;
-    runtime?: unknown;
-    conversation_id?: unknown;
-    action?: unknown;
-    scope?: unknown;
-  };
-  return (
-    c.type === "set_conversation_pin" &&
-    typeof c.request_id === "string" &&
-    isRuntimeScope(c.runtime) &&
-    typeof c.conversation_id === "string" &&
-    (c.action === "pin" || c.action === "unpin" || c.action === "toggle") &&
-    (c.scope === undefined ||
-      c.scope === "global" ||
-      c.scope === "local_project" ||
-      c.scope === "both")
-  );
-}
-
 export function isGetReflectionSettingsCommand(
   value: unknown,
 ): value is GetReflectionSettingsCommand {
@@ -2196,8 +2153,6 @@ export function parseServerMessage(
       isGetCwdMapCommand(parsed) ||
       isGetExperimentsCommand(parsed) ||
       isSetExperimentCommand(parsed) ||
-      isListConversationPinsCommand(parsed) ||
-      isSetConversationPinCommand(parsed) ||
       isGetReflectionSettingsCommand(parsed) ||
       isSetReflectionSettingsCommand(parsed) ||
       isChannelsListCommand(parsed) ||


### PR DESCRIPTION
## Summary
- remove conversation pin storage/APIs and strip legacy `pinnedConversationsByServer` settings
- make `/pin` agent-only and remove conversation pin UI/sorting from the conversation selector
- drop listener protocol support for `list_conversation_pins` / `set_conversation_pin`

## Testing
- `bun run typecheck`
- `bun run lint`
- `bun test src/settings-manager.test.ts src/cli/conversation-selector.test.ts src/websocket/listen-client-protocol.test.ts`

Note: attempted full `bun test`, but live headless integration tests failed on 402 insufficient credits, unrelated to this change.