### PR TITLE
fix(git): add windowsHide to git-context execFileSync on Windows

### DIFF
--- a/src/cli/helpers/git-context.ts
+++ b/src/cli/helpers/git-context.ts
@@ -25,6 +25,7 @@ function runGit(args: string[], cwd: string): string | null {
       cwd,
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
     }).trim();
   } catch {
     return null;


### PR DESCRIPTION
adds windowsHide: true to the execFileSync call in git-context.ts so git subprocess spawns dont create visible console windows on windows.

every periodic git poll (branch, status, recent commits for the device status bar) was flashing a console window on windows because execFileSync was missing windowsHide.
