### PR TITLE
test(local): preserve pi-ai image downgrade

### DIFF
--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -282,46 +282,6 @@ function toPiMessages(messages: readonly LocalMessage[]): Message[] {
   return normalized;
 }
 
-function contextHasImageInput(context: Context): boolean {
-  return context.messages.some(
-    (message) =>
-      Array.isArray(message.content) &&
-      message.content.some((part) => isRecord(part) && part.type === "image"),
-  );
-}
-
-function modelInputTypes(model: Model<string>): string[] {
-  const input = (model as { input?: readonly unknown[] }).input;
-  if (!Array.isArray(input)) return [];
-  return input.filter((value): value is string => typeof value === "string");
-}
-
-function modelLabel(model: Model<string>): string {
-  const provider =
-    typeof model.provider === "string" && model.provider.length > 0
-      ? `${model.provider}/`
-      : "";
-  return `${provider}${model.id}`;
-}
-
-function assertModelSupportsContextInput(
-  model: Model<string>,
-  context: Context,
-): void {
-  if (!contextHasImageInput(context)) return;
-
-  const inputTypes = modelInputTypes(model);
-  if (inputTypes.includes("image")) return;
-
-  const supportedInputs =
-    inputTypes.length > 0 ? inputTypes.join(", ") : "none";
-  throw new Error(
-    `The selected model "${modelLabel(
-      model,
-    )}" does not support image input (supported inputs: ${supportedInputs}). Choose a vision-capable model or remove the image attachment.`,
-  );
-}
-
 function stripOpenAIResponsesReplayItemIds(
   payload: unknown,
 ): unknown | undefined {
@@ -712,7 +672,6 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
       messages: toPiMessages(input.uiMessages),
       ...(tools ? { tools } : {}),
     };
-    assertModelSupportsContextInput(resolved.model as Model<string>, context);
     const options: SimpleStreamOptions & Record<string, unknown> = {
       ...resolved.providerOptions,
       ...(resolved.apiKey ? { apiKey: resolved.apiKey } : {}),

--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -282,6 +282,46 @@ function toPiMessages(messages: readonly LocalMessage[]): Message[] {
   return normalized;
 }
 
+function contextHasImageInput(context: Context): boolean {
+  return context.messages.some(
+    (message) =>
+      Array.isArray(message.content) &&
+      message.content.some((part) => isRecord(part) && part.type === "image"),
+  );
+}
+
+function modelInputTypes(model: Model<string>): string[] {
+  const input = (model as { input?: readonly unknown[] }).input;
+  if (!Array.isArray(input)) return [];
+  return input.filter((value): value is string => typeof value === "string");
+}
+
+function modelLabel(model: Model<string>): string {
+  const provider =
+    typeof model.provider === "string" && model.provider.length > 0
+      ? `${model.provider}/`
+      : "";
+  return `${provider}${model.id}`;
+}
+
+function assertModelSupportsContextInput(
+  model: Model<string>,
+  context: Context,
+): void {
+  if (!contextHasImageInput(context)) return;
+
+  const inputTypes = modelInputTypes(model);
+  if (inputTypes.includes("image")) return;
+
+  const supportedInputs =
+    inputTypes.length > 0 ? inputTypes.join(", ") : "none";
+  throw new Error(
+    `The selected model "${modelLabel(
+      model,
+    )}" does not support image input (supported inputs: ${supportedInputs}). Choose a vision-capable model or remove the image attachment.`,
+  );
+}
+
 function stripOpenAIResponsesReplayItemIds(
   payload: unknown,
 ): unknown | undefined {
@@ -672,6 +712,7 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
       messages: toPiMessages(input.uiMessages),
       ...(tools ? { tools } : {}),
     };
+    assertModelSupportsContextInput(resolved.model as Model<string>, context);
     const options: SimpleStreamOptions & Record<string, unknown> = {
       ...resolved.providerOptions,
       ...(resolved.apiKey ? { apiKey: resolved.apiKey } : {}),

--- a/src/backend/pi-stream-adapter.test.ts
+++ b/src/backend/pi-stream-adapter.test.ts
@@ -9,13 +9,15 @@ import type {
   Model,
   SimpleStreamOptions,
 } from "@earendil-works/pi-ai";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import {
   PiStreamAdapter,
   type PiStreamFunction,
 } from "@/backend/dev/pi-stream-adapter";
-import type {
-  ProviderStreamEvent,
-  ProviderTurnInput,
+import {
+  type ProviderStreamEvent,
+  ProviderTurnExecutor,
+  type ProviderTurnInput,
 } from "@/backend/dev/provider-turn-executor";
 import { emptyLocalUsage } from "@/backend/local/local-message";
 import {
@@ -66,6 +68,14 @@ async function collectEvents(
   return collected;
 }
 
+async function collectChunks(
+  events: AsyncIterable<LettaStreamingResponse>,
+): Promise<LettaStreamingResponse[]> {
+  const collected: LettaStreamingResponse[] = [];
+  for await (const event of events) collected.push(event);
+  return collected;
+}
+
 function input(): ProviderTurnInput {
   return {
     conversationId: "local-conv-1",
@@ -100,6 +110,49 @@ function emptyTextBlocks(messages: Context["messages"]) {
 }
 
 describe("PiStreamAdapter", () => {
+  test("rejects image input before dispatching to text-only local models", async () => {
+    let providerCalls = 0;
+    const stream: PiStreamFunction = () => {
+      providerCalls += 1;
+      const finalMessage = assistantMessage();
+      return streamFromEvents(
+        [{ type: "done", reason: "stop", message: finalMessage }],
+        finalMessage,
+      );
+    };
+
+    const baseInput = input();
+    const chunks = await collectChunks(
+      await new ProviderTurnExecutor(new PiStreamAdapter({ stream })).execute({
+        ...baseInput,
+        agent: {
+          ...baseInput.agent,
+          model: "ollama/deepseek-r1:8b",
+          model_settings: { provider_type: "ollama" },
+        },
+        uiMessages: [
+          {
+            id: "ui-msg-image",
+            role: "user",
+            content: [
+              { type: "text", text: "describe this" },
+              { type: "image", mimeType: "image/png", data: "abc" },
+            ],
+            timestamp: Date.now(),
+          },
+        ],
+      }),
+    );
+
+    expect(providerCalls).toBe(0);
+    expect(chunks.map((chunk) => chunk.message_type)).toEqual([
+      "error_message",
+      "stop_reason",
+    ]);
+    expect(JSON.stringify(chunks)).toContain("does not support image input");
+    expect(JSON.stringify(chunks)).toContain("ollama/deepseek-r1:8b");
+  });
+
   test("routes clean provider overflow errors into compaction and retries", async () => {
     let providerCalls = 0;
     const stream: PiStreamFunction = () => {

--- a/src/backend/pi-stream-adapter.test.ts
+++ b/src/backend/pi-stream-adapter.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { once } from "node:events";
 import { mkdtemp, rm } from "node:fs/promises";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
@@ -9,15 +11,13 @@ import type {
   Model,
   SimpleStreamOptions,
 } from "@earendil-works/pi-ai";
-import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import {
   PiStreamAdapter,
   type PiStreamFunction,
 } from "@/backend/dev/pi-stream-adapter";
-import {
-  type ProviderStreamEvent,
-  ProviderTurnExecutor,
-  type ProviderTurnInput,
+import type {
+  ProviderStreamEvent,
+  ProviderTurnInput,
 } from "@/backend/dev/provider-turn-executor";
 import { emptyLocalUsage } from "@/backend/local/local-message";
 import {
@@ -68,12 +68,18 @@ async function collectEvents(
   return collected;
 }
 
-async function collectChunks(
-  events: AsyncIterable<LettaStreamingResponse>,
-): Promise<LettaStreamingResponse[]> {
-  const collected: LettaStreamingResponse[] = [];
-  for await (const event of events) collected.push(event);
-  return collected;
+async function closeServer(
+  server: ReturnType<typeof createServer>,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
 }
 
 function input(): ProviderTurnInput {
@@ -110,47 +116,126 @@ function emptyTextBlocks(messages: Context["messages"]) {
 }
 
 describe("PiStreamAdapter", () => {
-  test("rejects image input before dispatching to text-only local models", async () => {
-    let providerCalls = 0;
-    const stream: PiStreamFunction = () => {
-      providerCalls += 1;
-      const finalMessage = assistantMessage();
-      return streamFromEvents(
-        [{ type: "done", reason: "stop", message: finalMessage }],
-        finalMessage,
-      );
-    };
+  test("downgrades images through Pi-AI payload conversion for text-only local models", async () => {
+    let capturedPayload: unknown;
+    const server = createServer(async (req, res) => {
+      if (req.method !== "POST" || req.url !== "/v1/chat/completions") {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
 
-    const baseInput = input();
-    const chunks = await collectChunks(
-      await new ProviderTurnExecutor(new PiStreamAdapter({ stream })).execute({
-        ...baseInput,
-        agent: {
-          ...baseInput.agent,
-          model: "ollama/deepseek-r1:8b",
-          model_settings: { provider_type: "ollama" },
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      capturedPayload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+
+      const responseChunks = [
+        {
+          id: "chatcmpl-test",
+          object: "chat.completion.chunk",
+          created: 0,
+          model: "deepseek-r1:8b",
+          choices: [
+            {
+              index: 0,
+              delta: { content: "ok" },
+              finish_reason: null,
+            },
+          ],
         },
-        uiMessages: [
-          {
-            id: "ui-msg-image",
-            role: "user",
-            content: [
-              { type: "text", text: "describe this" },
-              { type: "image", mimeType: "image/png", data: "abc" },
-            ],
-            timestamp: Date.now(),
+        {
+          id: "chatcmpl-test",
+          object: "chat.completion.chunk",
+          created: 0,
+          model: "deepseek-r1:8b",
+          choices: [
+            {
+              index: 0,
+              delta: {},
+              finish_reason: "stop",
+            },
+          ],
+          usage: {
+            prompt_tokens: 1,
+            completion_tokens: 1,
+            total_tokens: 2,
           },
-        ],
-      }),
+        },
+      ];
+
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "close",
+      });
+      res.end(
+        `${responseChunks
+          .map((chunk) => `data: ${JSON.stringify(chunk)}`)
+          .join("\n\n")}\n\ndata: [DONE]\n\n`,
+      );
+    });
+
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected tcp server address");
+    }
+
+    const previousOllamaBaseUrl = process.env.OLLAMA_BASE_URL;
+    process.env.OLLAMA_BASE_URL = `http://127.0.0.1:${address.port}/v1`;
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "pi-stream-text-image-downgrade-"),
     );
 
-    expect(providerCalls).toBe(0);
-    expect(chunks.map((chunk) => chunk.message_type)).toEqual([
-      "error_message",
-      "stop_reason",
-    ]);
-    expect(JSON.stringify(chunks)).toContain("does not support image input");
-    expect(JSON.stringify(chunks)).toContain("ollama/deepseek-r1:8b");
+    try {
+      const baseInput = input();
+      const events = await collectEvents(
+        new PiStreamAdapter({ localProviderAuthStorageDir: storageDir }).stream(
+          {
+            ...baseInput,
+            agent: {
+              ...baseInput.agent,
+              model: "ollama/deepseek-r1:8b",
+              model_settings: { provider_type: "ollama" },
+            },
+            uiMessages: [
+              {
+                id: "ui-msg-image",
+                role: "user",
+                content: [
+                  { type: "text", text: "describe this" },
+                  { type: "image", mimeType: "image/png", data: "abc" },
+                ],
+                timestamp: Date.now(),
+              },
+            ],
+          },
+        ),
+      );
+
+      expect(events.some((event) => event.type === "local-message")).toBe(true);
+      expect(capturedPayload).toMatchObject({
+        model: "deepseek-r1:8b",
+        stream: true,
+      });
+      const payloadJson = JSON.stringify(capturedPayload);
+      expect(payloadJson).toContain(
+        "(image omitted: model does not support images)",
+      );
+      expect(payloadJson).not.toContain("image_url");
+      expect(payloadJson).not.toContain("data:image/png;base64,abc");
+    } finally {
+      if (previousOllamaBaseUrl === undefined) {
+        delete process.env.OLLAMA_BASE_URL;
+      } else {
+        process.env.OLLAMA_BASE_URL = previousOllamaBaseUrl;
+      }
+      await rm(storageDir, { recursive: true, force: true });
+      await closeServer(server);
+    }
   });
 
   test("routes clean provider overflow errors into compaction and retries", async () => {


### PR DESCRIPTION
## Summary
- Remove the speculative pre-dispatch rejection that bypassed Pi-AI normalization.
- Add a regression around the OpenAI-compatible local payload path: text-only local models get Pi-AI text placeholders for image content, not raw image payloads.
- This does not claim to fix the reported crash; it protects the known downgrade behavior while that report remains unverified.

## Test plan
- [x] bun test src/backend/pi-stream-adapter.test.ts
- [x] bunx --bun @biomejs/biome@2.2.5 check --config-path biome.json src/backend/pi-stream-adapter.test.ts
- [x] commit hooks, including tsc --noEmit
- [ ] GitHub CI for latest commit

👾 Generated with [Letta Code](https://letta.com)
