### PR TITLE
fix(local): use safe id search in forkConversation to avoid stomping existing conversations

### DIFF
--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -508,6 +508,43 @@ describe("local backend pi transcript", () => {
     expect(latestVariants[0]?.date).toBe("2026-01-01T00:02:00.000Z");
   });
 
+  test("fork skips ids already on disk from a separate LocalStore instance", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-store-fork-collision-"),
+    );
+    const agentId = "agent-fork";
+    const sourceId = "conv-source";
+    const existingId = "conv-existing";
+
+    // Store A creates a source conversation and an existing conversation that
+    // occupies the next seq slot, simulating a second LocalStore process that
+    // wrote a conversation to the shared storage directory.
+    const storeA = new LocalStore(agentId, { storageDir });
+    storeA.appendTurnInput(sourceId, {
+      agent_id: agentId,
+      messages: [{ role: "user", content: "hello" }],
+    });
+    storeA.appendTurnInput(existingId, {
+      agent_id: agentId,
+      messages: [{ role: "user", content: "existing" }],
+    });
+
+    // Store B loads from the same storage dir — it sees both conversations and
+    // sets conversationSeq to the max existing value.  A fork from Store B
+    // must not clobber the existing conversation even if its raw seq would
+    // land on that slot.
+    const storeB = new LocalStore(agentId, { storageDir });
+    const { id: forkedId } = storeB.forkConversation(sourceId);
+
+    // The fork must not reuse any id that already exists on disk.
+    expect(forkedId).not.toBe(sourceId);
+    expect(forkedId).not.toBe(existingId);
+
+    // The existing conversation must still be intact.
+    const existing = storeB.retrieveConversation(existingId);
+    expect(existing.id).toBe(existingId);
+  });
+
   test("interrupt rolls back unpersisted partial assistant message before reload", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "local-store-interrupt-"));
     const agentId = "agent-interrupt";

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -1586,9 +1586,9 @@ export class LocalStore {
       throw new LocalBackendNotFoundError("Agent", targetAgentId);
     }
     this.ensureAgent(targetAgentId);
-    this.conversationSeq += 1;
+    const forkedConversationId = this.nextConversationId(targetAgentId);
     const forked = createLocalConversationRecord(
-      `${this.conversationIdPrefix}${this.conversationSeq}`,
+      forkedConversationId,
       targetAgentId,
       this.conversationSeq,
       {
@@ -3492,11 +3492,12 @@ export class LocalStore {
     return conversation;
   }
 
-  private nextConversationId(): string {
+  private nextConversationId(agentId?: string): string {
+    const resolvedAgentId = agentId ?? this.defaultAgentId;
     for (;;) {
       this.conversationSeq += 1;
       const conversationId = `${this.conversationIdPrefix}${this.conversationSeq}`;
-      const key = this.conversationKey(conversationId, this.defaultAgentId);
+      const key = this.conversationKey(conversationId, resolvedAgentId);
       if (this.conversations.has(key)) continue;
       const conversationDir = this.conversationDirForKey(key);
       if (conversationDir && existsSync(conversationDir)) continue;


### PR DESCRIPTION
## Summary
- forkConversation was blindly using conversationSeq+1 as the new id with no existence check, unlike nextConversationId which loops until it finds a free id in both memory and on disk
- Generalise nextConversationId to accept an optional agentId param so forkConversation can reuse the safe loop instead of duplicating the pattern without the safety check
- Add regression: two LocalStore instances sharing the same storage directory no longer produce a colliding fork id that stomps an existing conversation

## Testing
- bun test src\backend\local-backend.test.ts --grep "fork skips ids already on disk"
- bunx --bun @biomejs/biome@2.2.5 check src\backend\local\local-store.ts src\backend\local-backend.test.ts
- bun run tsc --noEmit

Generated with Letta Code
