### PR TITLE
fix(slack): rehydrate bot-authored thread context

### DIFF
--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -658,6 +658,66 @@ test("slack adapter hydrates prior Slack thread context, including bot-authored 
   expect(resolveSlackThreadHistoryMock).toHaveBeenCalledTimes(1);
 });
 
+test("slack adapter rehydrates bot-authored Slack thread context on existing routed turns", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+
+  resolveSlackThreadHistoryMock.mockResolvedValueOnce([
+    {
+      text: "Already-delivered human context",
+      userId: "U222",
+      ts: "1712795000.000060",
+    },
+    {
+      text: "Automated deployment note since the last human turn",
+      botId: "BDEPLOY",
+      ts: "1712796000.000070",
+    },
+  ]);
+
+  const prepared = await adapter.prepareInboundMessage?.(
+    {
+      channel: "slack",
+      accountId: "slack-test-account",
+      chatId: "C123",
+      chatLabel: "#random",
+      senderId: "U123",
+      senderName: "Charles",
+      text: "what did deploy say?",
+      timestamp: 1712800000100,
+      messageId: "1712800000.000100",
+      threadId: "1712790000.000050",
+      chatType: "channel",
+      isMention: false,
+    },
+    { isFirstRouteTurn: false },
+  );
+
+  expect(prepared).toBeDefined();
+  expect(prepared?.threadContext?.starter).toBeUndefined();
+  expect(prepared?.threadContext?.history).toEqual([
+    expect.objectContaining({
+      messageId: "1712796000.000070",
+      senderId: "BDEPLOY",
+      senderName: "Bot (BDEPLOY)",
+      text: "Automated deployment note since the last human turn",
+    }),
+  ]);
+  expect(resolveSlackThreadStarterMock).not.toHaveBeenCalled();
+  expect(resolveSlackThreadHistoryMock).toHaveBeenCalledTimes(1);
+  expect(resolveSlackChannelHistoryMock).not.toHaveBeenCalled();
+});
+
 test("slack adapter hydrates recent channel context, including bot-authored entries, when a mention creates a new thread", async () => {
   const adapter = createSlackAdapter({
     ...slackAccountDefaults,

--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -578,7 +578,7 @@ test("slack adapter forwards threaded channel replies as channel input", async (
   );
 });
 
-test("slack adapter hydrates prior Slack thread context on the first routed turn", async () => {
+test("slack adapter hydrates prior Slack thread context, including bot-authored entries, on the first routed turn", async () => {
   const adapter = createSlackAdapter({
     ...slackAccountDefaults,
     channel: "slack",
@@ -606,6 +606,11 @@ test("slack adapter hydrates prior Slack thread context on the first routed turn
       text: "Some follow-up before the bot was tagged",
       userId: "U222",
       ts: "1712795000.000060",
+    },
+    {
+      text: "Automated deployment note before the bot was tagged",
+      botId: "BDEPLOY",
+      ts: "1712796000.000070",
     },
   ]);
 
@@ -641,13 +646,19 @@ test("slack adapter hydrates prior Slack thread context on the first routed turn
       senderId: "U222",
       text: "Some follow-up before the bot was tagged",
     }),
+    expect.objectContaining({
+      messageId: "1712796000.000070",
+      senderId: "BDEPLOY",
+      senderName: "Bot (BDEPLOY)",
+      text: "Automated deployment note before the bot was tagged",
+    }),
   ]);
   expect(prepared?.threadContext?.label).toContain("Slack thread in #random");
   expect(resolveSlackThreadStarterMock).toHaveBeenCalledTimes(1);
   expect(resolveSlackThreadHistoryMock).toHaveBeenCalledTimes(1);
 });
 
-test("slack adapter hydrates recent channel context when a mention creates a new thread", async () => {
+test("slack adapter hydrates recent channel context, including bot-authored entries, when a mention creates a new thread", async () => {
   const adapter = createSlackAdapter({
     ...slackAccountDefaults,
     channel: "slack",
@@ -666,6 +677,11 @@ test("slack adapter hydrates recent channel context when a mention creates a new
       text: "Earlier channel context before the mention",
       userId: "U111",
       ts: "1712799000.000040",
+    },
+    {
+      text: "Automated channel update before the mention",
+      botId: "BSTATUS",
+      ts: "1712799250.000042",
     },
     {
       text: "More recent channel context before the mention",
@@ -699,6 +715,12 @@ test("slack adapter hydrates recent channel context when a mention creates a new
       messageId: "1712799000.000040",
       senderId: "U111",
       text: "Earlier channel context before the mention",
+    }),
+    expect.objectContaining({
+      messageId: "1712799250.000042",
+      senderId: "BSTATUS",
+      senderName: "Bot (BSTATUS)",
+      text: "Automated channel update before the mention",
     }),
     expect.objectContaining({
       messageId: "1712799500.000045",
@@ -1036,6 +1058,43 @@ test("slack adapter ignores hidden bookkeeping thread wrapper events", async () 
   });
 
   expect(onMessage).not.toHaveBeenCalled();
+});
+
+test("slack adapter ignores live bot_message events as runnable input", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  const onMessage = mock(async () => {});
+  adapter.onMessage = onMessage;
+
+  await adapter.start();
+  const app = FakeSlackApp.instances[0];
+  const handler = app?.messageHandler;
+  if (!handler) {
+    throw new Error("Expected Slack message handler");
+  }
+
+  await handler({
+    message: {
+      channel: "C123",
+      bot_id: "BDEPLOY",
+      text: "deployment completed",
+      ts: "1712800000.000103",
+      thread_ts: "1712790000.000050",
+      subtype: "bot_message",
+    },
+  });
+
+  expect(onMessage).not.toHaveBeenCalled();
+  expect(resolveSlackInboundAttachmentsMock).not.toHaveBeenCalled();
 });
 
 test("slack adapter forwards reaction events into the routed Slack thread", async () => {

--- a/src/channels/slack-media.test.ts
+++ b/src/channels/slack-media.test.ts
@@ -124,6 +124,85 @@ test("resolveSlackChannelHistory retains forwarded Slack attachment text", async
   ]);
 });
 
+test("resolveSlackThreadHistory retains bot-authored Slack replies", async () => {
+  const { resolveSlackThreadHistory } = await loadSlackMediaModule();
+  const client = {
+    conversations: {
+      history: mock(async () => ({ messages: [] })),
+      replies: mock(async () => ({
+        messages: [
+          {
+            ts: "1712790000.000050",
+            user: "U111",
+            text: "Thread root",
+          },
+          {
+            ts: "1712795000.000060",
+            bot_id: "BDEPLOY",
+            text: "Deployment succeeded",
+            subtype: "bot_message",
+          },
+          {
+            ts: "1712800000.000100",
+            user: "U222",
+            text: "Current mention",
+          },
+        ],
+      })),
+    },
+  };
+
+  await expect(
+    resolveSlackThreadHistory({
+      channelId: "C123",
+      threadTs: "1712790000.000050",
+      currentMessageTs: "1712800000.000100",
+      client,
+    }),
+  ).resolves.toEqual([
+    {
+      text: "Deployment succeeded",
+      userId: undefined,
+      botId: "BDEPLOY",
+      ts: "1712795000.000060",
+    },
+  ]);
+});
+
+test("resolveSlackChannelHistory retains bot-authored Slack messages", async () => {
+  const { resolveSlackChannelHistory } = await loadSlackMediaModule();
+  const client = {
+    conversations: {
+      history: mock(async () => ({
+        messages: [
+          {
+            ts: "1712799500.000045",
+            bot_id: "BSTATUS",
+            text: "Automated channel status update",
+            subtype: "bot_message",
+          },
+        ],
+      })),
+      replies: mock(async () => ({ messages: [] })),
+    },
+  };
+
+  await expect(
+    resolveSlackChannelHistory({
+      channelId: "C123",
+      beforeTs: "1712800000.000100",
+      client,
+    }),
+  ).resolves.toEqual([
+    {
+      text: "Automated channel status update",
+      userId: undefined,
+      botId: "BSTATUS",
+      ts: "1712799500.000045",
+    },
+  ]);
+});
+
 test("resolveSlackInboundAttachments transcribes inbound audio when opted in", async () => {
   process.env.OPENAI_API_KEY = "test-openai-key";
   const fetchMock = mock(async (input: unknown) => {

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -1481,7 +1481,6 @@ export function createSlackAdapter(
       options?: { isFirstRouteTurn?: boolean },
     ): Promise<InboundChannelMessage> {
       if (
-        !options?.isFirstRouteTurn ||
         msg.channel !== "slack" ||
         msg.chatType !== "channel" ||
         !isNonEmptyString(msg.threadId) ||
@@ -1490,9 +1489,12 @@ export function createSlackAdapter(
         return msg;
       }
 
+      const isFirstRouteTurn = options?.isFirstRouteTurn === true;
       const shouldHydrateExistingThreadContext = msg.threadId !== msg.messageId;
       const shouldHydrateChannelBootstrapContext =
-        msg.isMention === true && msg.threadId === msg.messageId;
+        isFirstRouteTurn &&
+        msg.isMention === true &&
+        msg.threadId === msg.messageId;
 
       if (
         !shouldHydrateExistingThreadContext &&
@@ -1502,14 +1504,15 @@ export function createSlackAdapter(
       }
 
       const slackApp = await ensureApp();
-      const starter = shouldHydrateExistingThreadContext
-        ? await resolveSlackThreadStarter({
-            channelId: msg.chatId,
-            threadTs: msg.threadId,
-            client: slackApp.client,
-          })
-        : null;
-      const history = shouldHydrateExistingThreadContext
+      const starter =
+        shouldHydrateExistingThreadContext && isFirstRouteTurn
+          ? await resolveSlackThreadStarter({
+              channelId: msg.chatId,
+              threadTs: msg.threadId,
+              client: slackApp.client,
+            })
+          : null;
+      const resolvedHistory = shouldHydrateExistingThreadContext
         ? await resolveSlackThreadHistory({
             channelId: msg.chatId,
             threadTs: msg.threadId,
@@ -1523,6 +1526,14 @@ export function createSlackAdapter(
             client: slackApp.client,
             limit: INITIAL_SLACK_THREAD_HISTORY_LIMIT,
           });
+      // Existing routed thread turns already deliver human messages into the
+      // Letta conversation. Bot-authored Slack messages are intentionally not
+      // runnable input, so rehydrate those skipped entries as context on the
+      // next human turn instead of waking the agent for every bot event.
+      const history =
+        shouldHydrateExistingThreadContext && !isFirstRouteTurn
+          ? resolvedHistory.filter((entry) => isNonEmptyString(entry.botId))
+          : resolvedHistory;
 
       if (!starter && history.length === 0) {
         return msg;


### PR DESCRIPTION
## Summary
- Keep live Slack `bot_message` events ignored as runnable input, so bot activity does not wake agents.
- Rehydrate Slack thread history on later routed human turns and include only bot-authored entries from that skipped history in `threadContext`.
- Add regression coverage for bot-authored thread/channel history hydration, the later routed-turn path, and the non-runnable live bot event guard.

## Behavior
Before, Slack API history hydration happened only on the first routed turn. If another Slack bot replied after the route already existed, that bot reply was intentionally ignored as live input and was also absent from the next human turn.

After, the next human turn in an existing routed Slack thread fetches recent thread history and carries bot-authored entries as context. Human history is not repeated on later routed turns because those messages already enter the conversation normally.

## Validation
- `bun test src/channels/slack-adapter.test.ts src/channels/slack-media.test.ts`
- `bun run check`

👾 Generated with [Letta Code](https://letta.com)
