### PR TITLE
feat: support ChatGPT OAuth provider aliases

### DIFF
--- a/src/agent/available-models-backend.test.ts
+++ b/src/agent/available-models-backend.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
   clearAvailableModelsCache,
   getAvailableModelHandles,
+  getModelProviderType,
 } from "@/agent/available-models";
 import { __testSetBackend } from "@/backend";
 import { FakeHeadlessBackend } from "@/backend/dev/fake-headless-backend";
@@ -19,5 +20,7 @@ describe("available models backend wiring", () => {
 
     expect(result.source).toBe("network");
     expect(Array.from(result.handles)).toEqual(["dev/fake-headless"]);
+    expect(result.providerTypes.get("dev/fake-headless")).toBe("openai");
+    expect(await getModelProviderType("dev/fake-headless")).toBe("openai");
   });
 });

--- a/src/agent/available-models.ts
+++ b/src/agent/available-models.ts
@@ -6,6 +6,7 @@ const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 type CacheEntry = {
   handles: Set<string>;
   contextWindows: Map<string, number>; // handle -> max_context_window
+  providerTypes: Map<string, string>; // handle -> provider_type
   fetchedAt: number;
 };
 
@@ -18,6 +19,7 @@ function isFresh(now = Date.now()) {
 
 export type AvailableModelHandlesResult = {
   handles: Set<string>;
+  providerTypes: Map<string, string>;
   source: "cache" | "network";
   fetchedAt: number;
 };
@@ -54,6 +56,18 @@ export function getCachedModelHandles(): Set<string> | null {
   return new Set(cache.handles);
 }
 
+/**
+ * Return cached provider_type metadata by handle if available.
+ * Used to carry backend model-catalog provider identity through selection
+ * without re-listing models during model update mutations.
+ */
+export function getCachedModelProviderTypes(): Map<string, string> | null {
+  if (!cache) {
+    return null;
+  }
+  return new Map(cache.providerTypes);
+}
+
 async function fetchFromNetwork(): Promise<CacheEntry> {
   const modelsList = await getBackend().listModels();
   const handles = new Set(
@@ -61,12 +75,22 @@ async function fetchFromNetwork(): Promise<CacheEntry> {
   );
   // Build context window map from API response
   const contextWindows = new Map<string, number>();
+  const providerTypes = new Map<string, string>();
   for (const model of modelsList) {
     if (model.handle && model.max_context_window) {
       contextWindows.set(model.handle, model.max_context_window);
     }
+    const providerType =
+      typeof model.provider_type === "string"
+        ? model.provider_type
+        : typeof model.model_endpoint_type === "string"
+          ? model.model_endpoint_type
+          : undefined;
+    if (model.handle && providerType) {
+      providerTypes.set(model.handle, providerType);
+    }
   }
-  return { handles, contextWindows, fetchedAt: Date.now() };
+  return { handles, contextWindows, providerTypes, fetchedAt: Date.now() };
 }
 
 export async function getAvailableModelHandles(options?: {
@@ -78,6 +102,7 @@ export async function getAvailableModelHandles(options?: {
   if (!forceRefresh && isFresh(now) && cache) {
     return {
       handles: cache.handles,
+      providerTypes: cache.providerTypes,
       source: "cache",
       fetchedAt: cache.fetchedAt,
     };
@@ -87,6 +112,7 @@ export async function getAvailableModelHandles(options?: {
     const entry = await inflight;
     return {
       handles: entry.handles,
+      providerTypes: entry.providerTypes,
       source: "network",
       fetchedAt: entry.fetchedAt,
     };
@@ -111,6 +137,7 @@ export async function getAvailableModelHandles(options?: {
   const entry = await inflight;
   return {
     handles: entry.handles,
+    providerTypes: entry.providerTypes,
     source: "network",
     fetchedAt: entry.fetchedAt,
   };
@@ -138,4 +165,17 @@ export async function getModelContextWindow(
     await getAvailableModelHandles();
   }
   return cache?.contextWindows.get(handle);
+}
+
+/**
+ * Get provider_type metadata for a model handle from the cached API model list.
+ * Ensures the shared cache is populated before reading.
+ */
+export async function getModelProviderType(
+  handle: string,
+): Promise<string | undefined> {
+  if (!cache) {
+    await getAvailableModelHandles();
+  }
+  return cache?.providerTypes.get(handle);
 }

--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -280,43 +280,6 @@ function maxTokensForUpdatePayload(
     : undefined;
 }
 
-async function providerTypeForModelHandle(
-  backend: ReturnType<typeof getBackend>,
-  modelHandle: string,
-): Promise<string | undefined> {
-  try {
-    const models = await backend.listModels();
-    const match = models.find(
-      (model: { handle?: string | null }) => model.handle === modelHandle,
-    ) as { provider_type?: string | null } | undefined;
-    return typeof match?.provider_type === "string"
-      ? match.provider_type
-      : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-async function enrichUpdateArgsWithProviderType(
-  backend: ReturnType<typeof getBackend>,
-  modelHandle: string,
-  updateArgs: Record<string, unknown> | undefined,
-): Promise<Record<string, unknown> | undefined> {
-  if (typeof updateArgs?.provider_type === "string") {
-    return updateArgs;
-  }
-
-  const providerType = await providerTypeForModelHandle(backend, modelHandle);
-  if (!providerType) {
-    return updateArgs;
-  }
-
-  return {
-    ...(updateArgs ?? {}),
-    provider_type: providerType,
-  };
-}
-
 /**
  * Updates an agent's model and model settings.
  *
@@ -346,15 +309,10 @@ export async function updateAgentLLMConfig(
 ): Promise<AgentState> {
   const backend = getBackend();
   const useBackendModelCatalog = backend.capabilities.localModelCatalog;
-  const enrichedUpdateArgs = await enrichUpdateArgsWithProviderType(
-    backend,
-    modelHandle,
-    updateArgs,
-  );
 
   const modelSettings = buildModelSettings(
     modelHandle,
-    updateArgsForModelSettings(enrichedUpdateArgs, { useBackendModelCatalog }),
+    updateArgsForModelSettings(updateArgs, { useBackendModelCatalog }),
   );
   const explicitContextWindow = useBackendModelCatalog
     ? undefined
@@ -404,15 +362,10 @@ export async function updateConversationLLMConfig(
 ): Promise<Conversation> {
   const backend = getBackend();
   const useBackendModelCatalog = backend.capabilities.localModelCatalog;
-  const enrichedUpdateArgs = await enrichUpdateArgsWithProviderType(
-    backend,
-    modelHandle,
-    updateArgs,
-  );
 
   const modelSettings = buildModelSettings(
     modelHandle,
-    updateArgsForModelSettings(enrichedUpdateArgs, { useBackendModelCatalog }),
+    updateArgsForModelSettings(updateArgs, { useBackendModelCatalog }),
   );
   const explicitContextWindow = useBackendModelCatalog
     ? undefined

--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -36,22 +36,39 @@ function buildModelSettings(
   modelHandle: string,
   updateArgs?: Record<string, unknown>,
 ): ModelSettings {
-  // Include our custom ChatGPT OAuth provider (chatgpt-plus-pro)
-  const isOpenAICodex = modelHandle.startsWith("openai-codex/");
+  const explicitProviderType =
+    typeof updateArgs?.provider_type === "string"
+      ? updateArgs.provider_type
+      : undefined;
+  // Include ChatGPT OAuth/Codex providers, including user-defined aliases whose
+  // provider_type is supplied by the server model catalog.
+  const isOpenAICodex =
+    explicitProviderType === "chatgpt_oauth" ||
+    modelHandle.startsWith("openai-codex/");
   const isOpenAI =
+    explicitProviderType === "openai" ||
     modelHandle.startsWith("openai/") ||
     isOpenAICodex ||
     modelHandle.startsWith(`${OPENAI_CODEX_PROVIDER_NAME}/`);
   // Include legacy custom Anthropic OAuth provider (claude-pro-max) and minimax
   const isAnthropic =
+    explicitProviderType === "anthropic" ||
     modelHandle.startsWith("anthropic/") ||
     modelHandle.startsWith("claude-pro-max/") ||
     modelHandle.startsWith("minimax/");
-  const isZai = modelHandle.startsWith("zai/");
-  const isGoogleAI = modelHandle.startsWith("google_ai/");
-  const isGoogleVertex = modelHandle.startsWith("google_vertex/");
-  const isOpenRouter = modelHandle.startsWith("openrouter/");
-  const isBedrock = modelHandle.startsWith("bedrock/");
+  const isZai =
+    explicitProviderType === "zai" || modelHandle.startsWith("zai/");
+  const isGoogleAI =
+    explicitProviderType === "google_ai" ||
+    modelHandle.startsWith("google_ai/");
+  const isGoogleVertex =
+    explicitProviderType === "google_vertex" ||
+    modelHandle.startsWith("google_vertex/");
+  const isOpenRouter =
+    explicitProviderType === "openrouter" ||
+    modelHandle.startsWith("openrouter/");
+  const isBedrock =
+    explicitProviderType === "bedrock" || modelHandle.startsWith("bedrock/");
 
   let settings: ModelSettings;
 
@@ -263,6 +280,43 @@ function maxTokensForUpdatePayload(
     : undefined;
 }
 
+async function providerTypeForModelHandle(
+  backend: ReturnType<typeof getBackend>,
+  modelHandle: string,
+): Promise<string | undefined> {
+  try {
+    const models = await backend.listModels();
+    const match = models.find(
+      (model: { handle?: string | null }) => model.handle === modelHandle,
+    ) as { provider_type?: string | null } | undefined;
+    return typeof match?.provider_type === "string"
+      ? match.provider_type
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function enrichUpdateArgsWithProviderType(
+  backend: ReturnType<typeof getBackend>,
+  modelHandle: string,
+  updateArgs: Record<string, unknown> | undefined,
+): Promise<Record<string, unknown> | undefined> {
+  if (typeof updateArgs?.provider_type === "string") {
+    return updateArgs;
+  }
+
+  const providerType = await providerTypeForModelHandle(backend, modelHandle);
+  if (!providerType) {
+    return updateArgs;
+  }
+
+  return {
+    ...(updateArgs ?? {}),
+    provider_type: providerType,
+  };
+}
+
 /**
  * Updates an agent's model and model settings.
  *
@@ -292,10 +346,15 @@ export async function updateAgentLLMConfig(
 ): Promise<AgentState> {
   const backend = getBackend();
   const useBackendModelCatalog = backend.capabilities.localModelCatalog;
+  const enrichedUpdateArgs = await enrichUpdateArgsWithProviderType(
+    backend,
+    modelHandle,
+    updateArgs,
+  );
 
   const modelSettings = buildModelSettings(
     modelHandle,
-    updateArgsForModelSettings(updateArgs, { useBackendModelCatalog }),
+    updateArgsForModelSettings(enrichedUpdateArgs, { useBackendModelCatalog }),
   );
   const explicitContextWindow = useBackendModelCatalog
     ? undefined
@@ -345,10 +404,15 @@ export async function updateConversationLLMConfig(
 ): Promise<Conversation> {
   const backend = getBackend();
   const useBackendModelCatalog = backend.capabilities.localModelCatalog;
+  const enrichedUpdateArgs = await enrichUpdateArgsWithProviderType(
+    backend,
+    modelHandle,
+    updateArgs,
+  );
 
   const modelSettings = buildModelSettings(
     modelHandle,
-    updateArgsForModelSettings(updateArgs, { useBackendModelCatalog }),
+    updateArgsForModelSettings(enrichedUpdateArgs, { useBackendModelCatalog }),
   );
   const explicitContextWindow = useBackendModelCatalog
     ? undefined

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -3107,9 +3107,14 @@ export function App({
           if (persistedToolsetPreference === "auto") {
             if (agentModelHandle) {
               const { switchToolsetForModel } = await import("@/tools/toolset");
+              const providerType =
+                providerTypeFromModelSettings(agent.model_settings) ??
+                agent.llm_config?.model_endpoint_type ??
+                null;
               const derivedToolset = await switchToolsetForModel(
                 agentModelHandle,
                 agentId,
+                providerType,
               );
               setCurrentToolset(derivedToolset);
             } else {

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -214,6 +214,7 @@ import {
   getPreferredAgentModelHandle,
   inferReasoningEffortFromModelPreset,
   mapHandleToLlmConfigPatch,
+  providerTypeFromModelSettings,
 } from "./model-config";
 import { saveLastSessionBeforeExit } from "./session";
 import type {
@@ -3403,7 +3404,10 @@ export function App({
         setCurrentModelId(modelInfo?.id ?? effectiveModelHandle);
         setLlmConfig({
           ...agentState.llm_config,
-          ...mapHandleToLlmConfigPatch(effectiveModelHandle),
+          ...mapHandleToLlmConfigPatch(
+            effectiveModelHandle,
+            providerTypeFromModelSettings(resolvedConversationModelSettings),
+          ),
           ...(typeof reasoningEffort === "string"
             ? { reasoning_effort: reasoningEffort }
             : {}),

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -962,10 +962,10 @@ export function AppView(props: AppViewProps) {
                         refreshDerived,
                         setCommandRunning,
                         target,
-                        onCodexConnected: () => {
+                        onCodexConnected: (providerName) => {
                           markLocalModelsAvailable();
                           setModelSelectorOptions({
-                            filterProvider: "chatgpt-plus-pro",
+                            filterProvider: providerName,
                             forceRefresh: true,
                           });
                           openOverlay(

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -945,7 +945,7 @@ export function AppView(props: AppViewProps) {
             {activeOverlay === "connect" && (
               <ProviderSelector
                 onCancel={closeOverlay}
-                onStartOAuth={async (provider, target) => {
+                onStartOAuth={async (provider, target, providerName) => {
                   const overlayCommand = completeOverlay("connect");
                   const cmd =
                     overlayCommand ??
@@ -976,7 +976,12 @@ export function AppView(props: AppViewProps) {
                           );
                         },
                       },
-                      `/connect ${provider.id === "openai-codex-oauth" ? "chatgpt" : provider.id}`,
+                      `/connect ${
+                        provider.id === "openai-codex-oauth" ||
+                        provider.providerType === "chatgpt_oauth"
+                          ? "chatgpt"
+                          : provider.id
+                      }${providerName ? ` --name ${providerName}` : ""}`,
                     );
                   } finally {
                     setActiveConnectCommandId(null);

--- a/src/cli/app/model-config.test.ts
+++ b/src/cli/app/model-config.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import {
+  mapHandleToLlmConfigPatch,
+  providerTypeFromModelSettings,
+  providerTypeFromUpdateArgs,
+} from "./model-config";
+
+describe("model config helpers", () => {
+  test("maps custom ChatGPT OAuth alias handles using provider type metadata", () => {
+    expect(
+      mapHandleToLlmConfigPatch("chatgpt-personal/gpt-5.5", "chatgpt_oauth"),
+    ).toEqual({
+      model: "gpt-5.5",
+      model_endpoint_type: "chatgpt_oauth",
+    });
+  });
+
+  test("does not invent endpoint type from unknown aliases without metadata", () => {
+    expect(mapHandleToLlmConfigPatch("chatgpt-personal/gpt-5.5")).toEqual({
+      model: "chatgpt-personal/gpt-5.5",
+    });
+  });
+
+  test("extracts provider type from model settings and update args", () => {
+    expect(
+      providerTypeFromModelSettings({ provider_type: "chatgpt_oauth" }),
+    ).toBe("chatgpt_oauth");
+    expect(providerTypeFromUpdateArgs({ provider_type: "chatgpt_oauth" })).toBe(
+      "chatgpt_oauth",
+    );
+  });
+});

--- a/src/cli/app/model-config.ts
+++ b/src/cli/app/model-config.ts
@@ -111,6 +111,32 @@ export function getPreferredAgentModelHandle(
   return buildModelHandleFromLlmConfig(agent.llm_config);
 }
 
+export function providerTypeFromModelSettings(
+  modelSettings: unknown,
+): string | null {
+  if (
+    typeof modelSettings !== "object" ||
+    modelSettings === null ||
+    !("provider_type" in modelSettings)
+  ) {
+    return null;
+  }
+  const providerType = (modelSettings as { provider_type?: unknown })
+    .provider_type;
+  return typeof providerType === "string" && providerType.length > 0
+    ? providerType
+    : null;
+}
+
+export function providerTypeFromUpdateArgs(
+  updateArgs: Record<string, unknown> | undefined | null,
+): string | null {
+  const providerType = updateArgs?.provider_type;
+  return typeof providerType === "string" && providerType.length > 0
+    ? providerType
+    : null;
+}
+
 export function mapHandleToLlmConfigPatch(
   modelHandle: string,
   providerType?: string | null,

--- a/src/cli/app/model-config.ts
+++ b/src/cli/app/model-config.ts
@@ -113,6 +113,7 @@ export function getPreferredAgentModelHandle(
 
 export function mapHandleToLlmConfigPatch(
   modelHandle: string,
+  providerType?: string | null,
 ): Partial<LlmConfig> {
   const [provider, ...modelParts] = modelHandle.split("/");
   const modelName = modelParts.join("/");
@@ -121,10 +122,31 @@ export function mapHandleToLlmConfigPatch(
       model: modelHandle,
     };
   }
+  const knownEndpointTypes = new Set([
+    "anthropic",
+    "bedrock",
+    "chatgpt_oauth",
+    "google_ai",
+    "google_vertex",
+    "minimax",
+    "moonshot",
+    "moonshot_coding",
+    "openai",
+    "openrouter",
+    "zai",
+    "zai_coding",
+  ]);
   const endpointType =
-    provider === OPENAI_CODEX_PROVIDER_NAME || provider === "openai-codex"
-      ? "chatgpt_oauth"
-      : provider;
+    typeof providerType === "string" && providerType.length > 0
+      ? providerType
+      : provider === OPENAI_CODEX_PROVIDER_NAME || provider === "openai-codex"
+        ? "chatgpt_oauth"
+        : knownEndpointTypes.has(provider)
+          ? provider
+          : null;
+  if (!endpointType) {
+    return { model: modelHandle };
+  }
   return {
     model: modelName,
     model_endpoint_type: endpointType as LlmConfig["model_endpoint_type"],

--- a/src/cli/app/submit-connection-commands.ts
+++ b/src/cli/app/submit-connection-commands.ts
@@ -148,10 +148,10 @@ export async function handleConnectionCommand(
           buffersRef,
           refreshDerived,
           setCommandRunning,
-          onCodexConnected: () => {
+          onCodexConnected: (providerName) => {
             markLocalModelsAvailable();
             setModelSelectorOptions({
-              filterProvider: "chatgpt-plus-pro",
+              filterProvider: providerName,
               forceRefresh: true,
             });
             openOverlay(

--- a/src/cli/app/use-configuration-handlers.ts
+++ b/src/cli/app/use-configuration-handlers.ts
@@ -33,6 +33,7 @@ import {
 import { DEFAULT_SUMMARIZATION_MODEL } from "@/constants";
 import { experimentManager } from "@/experiments/manager";
 import type { ExperimentId } from "@/experiments/types";
+import { OPENAI_CODEX_PROVIDER_NAME } from "@/providers/openai-codex-provider";
 import { settingsManager } from "@/settings-manager";
 import { getToolNames } from "@/tools/manager";
 import type { ToolsetName, ToolsetPreference } from "@/tools/toolset";
@@ -41,6 +42,8 @@ import { formatToolsetName } from "@/tools/toolset-labels";
 import {
   deriveReasoningEffort,
   mapHandleToLlmConfigPatch,
+  providerTypeFromModelSettings,
+  providerTypeFromUpdateArgs,
 } from "./model-config";
 import { formatReflectionSettings } from "./reflection";
 import type {
@@ -211,6 +214,26 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
             null
           );
         };
+        let apiProviderType: string | undefined;
+        let didLoadApiProviderType = false;
+        const getApiProviderType = async () => {
+          if (didLoadApiProviderType) return apiProviderType;
+          const { getModelProviderType } = await import(
+            "@/agent/available-models"
+          );
+          apiProviderType = await getModelProviderType(modelId);
+          didLoadApiProviderType = true;
+          return apiProviderType;
+        };
+        const registryHandleForProviderType = (
+          handle: string,
+          providerType?: string,
+        ) => {
+          if (providerType !== "chatgpt_oauth") return handle;
+          const slashIndex = handle.indexOf("/");
+          if (slashIndex === -1) return handle;
+          return `${OPENAI_CODEX_PROVIDER_NAME}/${handle.slice(slashIndex + 1)}`;
+        };
         selectedModel = inputSelection
           ? {
               id: inputSelection.id,
@@ -223,22 +246,29 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
           : (models.find((m) => m.id === modelId) ?? null);
 
         if (!selectedModel && modelId.includes("/")) {
-          const handleMatch = pickPreferredModelForHandle(modelId);
+          const providerType = await getApiProviderType();
+          const registryCandidate = registryHandleForProviderType(
+            modelId,
+            providerType,
+          );
+          const handleMatch = pickPreferredModelForHandle(registryCandidate);
           if (handleMatch) {
             const fastRegistryHandle =
-              getChatGptFastRegistryHandleForModelHandle(modelId);
+              getChatGptFastRegistryHandleForModelHandle(registryCandidate);
             const updateArgs = {
               ...((handleMatch.updateArgs as
                 | Record<string, unknown>
                 | undefined) ?? {}),
               ...(fastRegistryHandle ? { service_tier: null } : {}),
+              ...(providerType ? { provider_type: providerType } : {}),
             };
             selectedModel = {
               ...handleMatch,
               id: modelId,
               handle: modelId,
               registryHandle:
-                normalizeModelHandleForRegistry(modelId) ?? modelId,
+                normalizeModelHandleForRegistry(registryCandidate) ??
+                registryCandidate,
               updateArgs:
                 Object.keys(updateArgs).length > 0 ? updateArgs : undefined,
             } as unknown as (typeof models)[number];
@@ -249,9 +279,11 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
           const { getModelContextWindow } = await import(
             "@/agent/available-models"
           );
+          const providerType = await getApiProviderType();
           const apiContextWindow = await getModelContextWindow(modelId);
           const updateArgs: Record<string, unknown> = {
             ...(apiContextWindow ? { context_window: apiContextWindow } : {}),
+            ...(providerType ? { provider_type: providerType } : {}),
             ...(opts?.reasoningEffort
               ? { reasoning_effort: opts.reasoningEffort }
               : {}),
@@ -325,11 +357,13 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
             (entry) => entry.id === option.modelId,
           );
           const serviceTier = modelUpdateArgs?.service_tier;
+          const providerType = providerTypeFromUpdateArgs(modelUpdateArgs);
           const optionUpdateArgs = {
             ...((optionModel?.updateArgs as
               | Record<string, unknown>
               | undefined) ?? {}),
             ...(serviceTier !== undefined ? { service_tier: serviceTier } : {}),
+            ...(providerType ? { provider_type: providerType } : {}),
           };
           return {
             ...option,
@@ -506,6 +540,10 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
                 : typeof presetContextWindow === "number"
                   ? presetContextWindow
                   : undefined;
+          const resolvedProviderType =
+            providerTypeFromModelSettings(conversationModelSettings) ??
+            providerTypeFromUpdateArgs(modelUpdateArgsForRequest) ??
+            providerTypeFromUpdateArgs(modelUpdateArgs);
           if (!isDefaultConversation) {
             setConversationOverrideContextWindowLimit(
               typeof resolvedContextWindow === "number"
@@ -518,7 +556,7 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
             ...(updatedAgent?.llm_config ??
               llmConfigRef.current ??
               ({} as LlmConfig)),
-            ...mapHandleToLlmConfigPatch(modelHandle),
+            ...mapHandleToLlmConfigPatch(modelHandle, resolvedProviderType),
             ...(typeof resolvedReasoningEffort === "string"
               ? {
                   reasoning_effort:

--- a/src/cli/app/use-configuration-handlers.ts
+++ b/src/cli/app/use-configuration-handlers.ts
@@ -595,6 +595,7 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
             const toolsetName = await switchToolsetForModel(
               modelHandle,
               agentId,
+              resolvedProviderType,
             );
             setCurrentToolsetPreference("auto");
             setCurrentToolset(toolsetName);
@@ -1166,9 +1167,14 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
               );
             }
 
+            const providerType =
+              providerTypeFromModelSettings(agentState?.model_settings) ??
+              llmConfig?.model_endpoint_type ??
+              null;
             const derivedToolset = await switchToolsetForModel(
               modelHandle,
               agentId,
+              providerType,
             );
             settingsManager.setToolsetPreference(agentId, "auto");
             setCurrentToolsetPreference("auto");
@@ -1210,6 +1216,7 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
     },
     [
       agentId,
+      agentState?.model_settings,
       commandRunner,
       consumeOverlayCommand,
       currentToolset,

--- a/src/cli/app/use-reasoning-cycle.ts
+++ b/src/cli/app/use-reasoning-cycle.ts
@@ -20,6 +20,7 @@ import { OPENAI_CODEX_PROVIDER_NAME } from "@/providers/openai-codex-provider";
 import {
   deriveReasoningEffort,
   mapHandleToLlmConfigPatch,
+  providerTypeFromModelSettings,
 } from "./model-config";
 import type { CommandStarter } from "./types";
 
@@ -263,7 +264,14 @@ export function useReasoningCycle(ctx: ReasoningCycleContext) {
             ...(updatedAgent?.llm_config ??
               llmConfigRef.current ??
               ({} as LlmConfig)),
-            ...mapHandleToLlmConfigPatch(desired.modelHandle),
+            ...mapHandleToLlmConfigPatch(
+              desired.modelHandle,
+              providerTypeFromModelSettings(
+                isDefaultConversation
+                  ? (updatedAgent?.model_settings ?? null)
+                  : conversationModelSettings,
+              ),
+            ),
             reasoning_effort: resolvedReasoningEffort as ModelReasoningEffort,
             ...(typeof resolvedConversationContextWindowLimit === "number"
               ? { context_window: resolvedConversationContextWindowLimit }

--- a/src/cli/commands/connect-oauth-core.ts
+++ b/src/cli/commands/connect-oauth-core.ts
@@ -59,11 +59,16 @@ const DEFAULT_DEPS: OAuthFlowDeps = {
       (port as typeof OPENAI_OAUTH_CONFIG.defaultPort | undefined) ??
         OPENAI_OAUTH_CONFIG.defaultPort,
     ),
-  startCallbackServer: (expectedState: string, port?: number) =>
+  startCallbackServer: (
+    expectedState: string,
+    port?: number,
+    signal?: AbortSignal,
+  ) =>
     startLocalOAuthServer(
       expectedState,
       (port as typeof OPENAI_OAUTH_CONFIG.defaultPort | undefined) ??
         OPENAI_OAUTH_CONFIG.defaultPort,
+      signal,
     ),
   exchangeTokens: exchangeCodeForTokens,
   extractAccountId: extractAccountIdFromToken,

--- a/src/cli/commands/connect-oauth-core.ts
+++ b/src/cli/commands/connect-oauth-core.ts
@@ -10,7 +10,7 @@ import {
   type ChatGPTOAuthConfig,
   createOrUpdateOpenAICodexProvider,
   getOpenAICodexProvider,
-  OPENAI_CODEX_PROVIDER_NAME,
+  normalizeChatGPTOAuthProviderName,
 } from "@/providers/openai-codex-provider";
 import { settingsManager } from "@/settings-manager";
 
@@ -44,7 +44,10 @@ interface OAuthFlowDeps {
     redirectUri: string,
   ) => Promise<OpenAITokens>;
   extractAccountId: (accessToken: string) => string;
-  createOrUpdateProvider: (config: ChatGPTOAuthConfig) => Promise<unknown>;
+  createOrUpdateProvider: (
+    config: ChatGPTOAuthConfig,
+    providerName: string,
+  ) => Promise<unknown>;
   getProvider: () => Promise<unknown>;
   storeOAuthState: typeof settingsManager.storeOAuthState;
   clearOAuthState: typeof settingsManager.clearOAuthState;
@@ -64,7 +67,8 @@ const DEFAULT_DEPS: OAuthFlowDeps = {
     ),
   exchangeTokens: exchangeCodeForTokens,
   extractAccountId: extractAccountIdFromToken,
-  createOrUpdateProvider: createOrUpdateOpenAICodexProvider,
+  createOrUpdateProvider: (config, providerName) =>
+    createOrUpdateOpenAICodexProvider(config, {}, providerName),
   getProvider: getOpenAICodexProvider,
   storeOAuthState: (...args) => settingsManager.storeOAuthState(...args),
   clearOAuthState: () => settingsManager.clearOAuthState(),
@@ -74,6 +78,7 @@ export interface ChatGPTOAuthFlowCallbacks {
   onStatus: (message: string) => void | Promise<void>;
   openBrowser?: (authorizationUrl: string) => Promise<void>;
   signal?: AbortSignal;
+  providerName?: string;
 }
 
 export async function openOAuthBrowser(
@@ -104,6 +109,9 @@ export async function runChatGPTOAuthConnectFlow(
 ): Promise<{ providerName: string }> {
   const mergedDeps = { ...DEFAULT_DEPS, ...deps };
   const browserOpener = callbacks.openBrowser ?? openOAuthBrowser;
+  const providerName = normalizeChatGPTOAuthProviderName(
+    callbacks.providerName,
+  );
 
   await callbacks.onStatus("Checking account eligibility...");
 
@@ -155,17 +163,22 @@ export async function runChatGPTOAuthConnectFlow(
     await callbacks.onStatus("Extracting account information...");
     const accountId = mergedDeps.extractAccountId(tokens.access_token);
 
-    await callbacks.onStatus("Creating ChatGPT OAuth provider...");
-    await mergedDeps.createOrUpdateProvider({
-      access_token: tokens.access_token,
-      id_token: tokens.id_token,
-      refresh_token: tokens.refresh_token,
-      account_id: accountId,
-      expires_at: Date.now() + tokens.expires_in * 1000,
-    });
+    await callbacks.onStatus(
+      `Creating ChatGPT OAuth provider '${providerName}'...`,
+    );
+    await mergedDeps.createOrUpdateProvider(
+      {
+        access_token: tokens.access_token,
+        id_token: tokens.id_token,
+        refresh_token: tokens.refresh_token,
+        account_id: accountId,
+        expires_at: Date.now() + tokens.expires_in * 1000,
+      },
+      providerName,
+    );
 
     mergedDeps.clearOAuthState();
-    return { providerName: OPENAI_CODEX_PROVIDER_NAME };
+    return { providerName };
   } catch (error) {
     mergedDeps.clearOAuthState();
     throw error;

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -18,6 +18,7 @@ import {
 import {
   createOrUpdateOpenAICodexProvider,
   getOpenAICodexProvider,
+  normalizeChatGPTOAuthProviderName,
   OPENAI_CODEX_PROVIDER_NAME,
 } from "@/providers/openai-codex-provider";
 import { getErrorMessage } from "@/utils/error";
@@ -56,7 +57,7 @@ export interface ConnectCommandContext {
   refreshDerived: () => void;
   setCommandRunning: (running: boolean) => void;
   target?: ProviderStorageTarget;
-  onCodexConnected?: () => void;
+  onCodexConnected?: (providerName: string) => void;
 }
 
 function addCommandResult(
@@ -124,6 +125,7 @@ function formatConnectUsage(): string {
     "",
     "Examples:",
     "  /connect chatgpt",
+    "  /connect chatgpt --name chatgpt-work",
     "  /connect codex",
     "  /connect anthropic <api_key>",
     "  /connect openai <api_key>",
@@ -312,6 +314,39 @@ function parseApiProviderArgs(args: string[]): {
   };
 }
 
+function parseChatGPTArgs(args: string[]): {
+  providerName: string;
+  error?: string;
+} {
+  let providerName = OPENAI_CODEX_PROVIDER_NAME;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const token = args[i] ?? "";
+    if (token === "--name" || token.startsWith("--name=")) {
+      const parsed = readFlagValue(args, i, "--name");
+      if (parsed.error) return { providerName, error: parsed.error };
+      providerName = parsed.value ?? providerName;
+      i = parsed.nextIndex;
+      continue;
+    }
+
+    if (token.startsWith("--")) {
+      return { providerName, error: `Unknown option: ${token}` };
+    }
+
+    return { providerName, error: `Unexpected argument: ${token}` };
+  }
+
+  try {
+    return { providerName: normalizeChatGPTOAuthProviderName(providerName) };
+  } catch (error) {
+    return {
+      providerName,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
 function providerOptionsSummary(options: {
   baseURL?: string;
   timeout?: LocalProviderTimeout;
@@ -346,16 +381,18 @@ function formatZaiCodingPlanPrompt(apiKey?: string): string {
 async function handleConnectChatGPT(
   ctx: ConnectCommandContext,
   msg: string,
+  providerName: string = OPENAI_CODEX_PROVIDER_NAME,
 ): Promise<void> {
   const existingProvider = await isChatGPTOAuthConnected({
-    getProvider: () => getOpenAICodexProvider({ target: ctx.target }),
+    getProvider: () =>
+      getOpenAICodexProvider({ target: ctx.target }, providerName),
   });
   if (existingProvider) {
     addCommandResult(
       ctx.buffersRef,
       ctx.refreshDerived,
       msg,
-      "Already connected to ChatGPT via OAuth.\n\nOpen /connect and select ChatGPT / Codex plan in the current tab to disconnect or re-authenticate.",
+      `Already connected to ChatGPT via OAuth as '${providerName}'.\n\nOpen /connect and select ChatGPT / Codex plan in the current tab to disconnect or re-authenticate.`,
       false,
     );
     return;
@@ -377,6 +414,7 @@ async function handleConnectChatGPT(
     await runChatGPTOAuthConnectFlow(
       {
         signal: abortController.signal,
+        providerName,
         onStatus: (status) =>
           updateCommandResult(
             ctx.buffersRef,
@@ -389,9 +427,14 @@ async function handleConnectChatGPT(
           ),
       },
       {
-        getProvider: () => getOpenAICodexProvider({ target: ctx.target }),
+        getProvider: () =>
+          getOpenAICodexProvider({ target: ctx.target }, providerName),
         createOrUpdateProvider: (config) =>
-          createOrUpdateOpenAICodexProvider(config, { target: ctx.target }),
+          createOrUpdateOpenAICodexProvider(
+            config,
+            { target: ctx.target },
+            providerName,
+          ),
       },
     );
 
@@ -401,14 +444,14 @@ async function handleConnectChatGPT(
       cmdId,
       msg,
       `✓ Successfully connected to ChatGPT!\n\n` +
-        `Provider '${OPENAI_CODEX_PROVIDER_NAME}' saved in ${providerStorageTargetLabel(ctx.target)}.\n` +
+        `Provider '${providerName}' saved in ${providerStorageTargetLabel(ctx.target)}.\n` +
         "Your ChatGPT Plus/Pro subscription is now linked.",
       true,
       "finished",
     );
 
     if (ctx.onCodexConnected) {
-      setTimeout(() => ctx.onCodexConnected?.(), 500);
+      setTimeout(() => ctx.onCodexConnected?.(providerName), 500);
     }
   } catch (error) {
     const isCancelled = error instanceof Error && error.name === "AbortError";
@@ -488,7 +531,10 @@ async function handleConnectLocalOAuthProvider(
     );
 
     if (provider.byokProvider.oauthProviderId === "openai-codex") {
-      setTimeout(() => ctx.onCodexConnected?.(), 500);
+      setTimeout(
+        () => ctx.onCodexConnected?.(provider.byokProvider.providerName),
+        500,
+      );
     }
   } catch (error) {
     const isCancelled = error instanceof Error && error.name === "AbortError";
@@ -753,7 +799,18 @@ export async function handleConnect(
     if (provider.target === "local") {
       await handleConnectLocalOAuthProvider(ctx, msg, provider);
     } else {
-      await handleConnectChatGPT(ctx, msg);
+      const parsed = parseChatGPTArgs(parts.slice(2));
+      if (parsed.error) {
+        addCommandResult(
+          ctx.buffersRef,
+          ctx.refreshDerived,
+          msg,
+          `${parsed.error}\n\nUsage: /connect chatgpt [--name <provider-name>]`,
+          false,
+        );
+        return;
+      }
+      await handleConnectChatGPT(ctx, msg, parsed.providerName);
     }
     return;
   }

--- a/src/cli/components/ModelSelector-byok-custom-provider.test.tsx
+++ b/src/cli/components/ModelSelector-byok-custom-provider.test.tsx
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import { getReasoningTierOptionsForHandle } from "@/agent/model";
 import {
   buildByokProviderAliases,
   isByokHandleForSelector,
   labelForChatGPTByokAlias,
+  registryHandleForByokAlias,
+  toByokSelectorModel,
 } from "@/cli/components/ModelSelector";
 
 describe("ModelSelector custom BYOK provider detection", () => {
@@ -47,6 +50,70 @@ describe("ModelSelector custom BYOK provider detection", () => {
     expect(isByokHandleForSelector("chatgpt-personal/gpt-5.5", aliases)).toBe(
       true,
     );
+  });
+
+  test("resolves alias-backed BYOK handles to registry handles for reasoning tiers", () => {
+    const aliases = buildByokProviderAliases([
+      {
+        name: "chatgpt-personal",
+        provider_type: "chatgpt_oauth",
+      },
+      {
+        name: "openai-sarah",
+        provider_type: "openai",
+      },
+    ]);
+
+    expect(
+      registryHandleForByokAlias("chatgpt-personal/gpt-5.5", aliases),
+    ).toBe("chatgpt-plus-pro/gpt-5.5");
+    expect(registryHandleForByokAlias("openai-sarah/gpt-5.5", aliases)).toBe(
+      "openai/gpt-5.5",
+    );
+
+    const reasoningOptions = getReasoningTierOptionsForHandle(
+      registryHandleForByokAlias("chatgpt-personal/gpt-5.5", aliases),
+    );
+    expect(reasoningOptions.map((option) => option.effort)).toEqual([
+      "none",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+  });
+
+  test("keeps alias handles while carrying canonical registry metadata", () => {
+    const aliases = buildByokProviderAliases([
+      {
+        name: "chatgpt-personal",
+        provider_type: "chatgpt_oauth",
+      },
+    ]);
+
+    const model = toByokSelectorModel(
+      {
+        id: "gpt-5.5-plus-pro-high",
+        handle: "chatgpt-plus-pro/gpt-5.5",
+        label: "GPT-5.5 (ChatGPT)",
+        description: "OpenAI's most capable model",
+        updateArgs: { reasoning_effort: "high" },
+      },
+      "chatgpt-personal/gpt-5.5",
+      aliases,
+      { reasoning_effort: "high", provider_type: "chatgpt_oauth" },
+    );
+
+    expect(model).toMatchObject({
+      id: "chatgpt-personal/gpt-5.5",
+      handle: "chatgpt-personal/gpt-5.5",
+      registryHandle: "chatgpt-plus-pro/gpt-5.5",
+      label: "GPT-5.5 (chatgpt-personal)",
+      updateArgs: {
+        reasoning_effort: "high",
+        provider_type: "chatgpt_oauth",
+      },
+    });
   });
 
   test("uses ChatGPT OAuth provider aliases in recommended BYOK labels", () => {

--- a/src/cli/components/ModelSelector-byok-custom-provider.test.tsx
+++ b/src/cli/components/ModelSelector-byok-custom-provider.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildByokProviderAliases,
   isByokHandleForSelector,
+  labelForChatGPTByokAlias,
 } from "@/cli/components/ModelSelector";
 
 describe("ModelSelector custom BYOK provider detection", () => {
@@ -46,6 +47,29 @@ describe("ModelSelector custom BYOK provider detection", () => {
     expect(isByokHandleForSelector("chatgpt-personal/gpt-5.5", aliases)).toBe(
       true,
     );
+  });
+
+  test("uses ChatGPT OAuth provider aliases in recommended BYOK labels", () => {
+    const aliases = buildByokProviderAliases([
+      {
+        name: "chatgpt-personal",
+        provider_type: "chatgpt_oauth",
+      },
+    ]);
+
+    expect(
+      labelForChatGPTByokAlias(
+        "GPT-5.5 (ChatGPT)",
+        "chatgpt-personal/gpt-5.5",
+        aliases,
+      ),
+    ).toBe("GPT-5.5 (chatgpt-personal)");
+
+    expect(
+      labelForChatGPTByokAlias("GPT-5.5", "openai-sarah/gpt-5.5", {
+        "openai-sarah": "openai",
+      }),
+    ).toBe("GPT-5.5");
   });
 
   test("preserves existing lc-* aliases", () => {

--- a/src/cli/components/ModelSelector-byok-custom-provider.test.tsx
+++ b/src/cli/components/ModelSelector-byok-custom-provider.test.tsx
@@ -34,6 +34,20 @@ describe("ModelSelector custom BYOK provider detection", () => {
     expect(`${baseProvider}/${model}`).toBe("openai/gpt-5.4-fast");
   });
 
+  test("maps custom ChatGPT OAuth provider handles back to Codex registry handles", () => {
+    const aliases = buildByokProviderAliases([
+      {
+        name: "chatgpt-personal",
+        provider_type: "chatgpt_oauth",
+      },
+    ]);
+
+    expect(aliases["chatgpt-personal"]).toBe("openai-codex");
+    expect(isByokHandleForSelector("chatgpt-personal/gpt-5.5", aliases)).toBe(
+      true,
+    );
+  });
+
   test("preserves existing lc-* aliases", () => {
     const aliases = buildByokProviderAliases([]);
 

--- a/src/cli/components/ModelSelector.tsx
+++ b/src/cli/components/ModelSelector.tsx
@@ -39,6 +39,9 @@ type ModelCategory =
   | "server-recommended"
   | "server-all";
 
+const CHATGPT_OAUTH_BASE_PROVIDER = "openai-codex";
+const CHATGPT_LABEL_SUFFIX_PATTERN = /\s+\(ChatGPT\)$/;
+
 // Re-export for consumers that import from ModelSelector
 export { buildByokProviderAliases, isByokHandleForSelector };
 
@@ -116,6 +119,22 @@ export type ModelSelectorSelection = Pick<
   UiModel,
   "id" | "handle" | "label" | "description" | "registryHandle" | "updateArgs"
 >;
+
+export function labelForChatGPTByokAlias(
+  label: string,
+  handle: string,
+  byokProviderAliases: Record<string, string>,
+): string {
+  const slashIndex = handle.indexOf("/");
+  if (slashIndex === -1) return label;
+
+  const providerAlias = handle.slice(0, slashIndex);
+  if (byokProviderAliases[providerAlias] !== CHATGPT_OAUTH_BASE_PROVIDER) {
+    return label;
+  }
+
+  return label.replace(CHATGPT_LABEL_SUFFIX_PATTERN, ` (${providerAlias})`);
+}
 
 export function toSelectorModelForHandle(handle: string): UiModel {
   const registryHandle = normalizeModelHandleForRegistry(handle) ?? handle;
@@ -589,6 +608,11 @@ export function ModelSelector({
           ...staticModel,
           id: handle,
           handle: handle,
+          label: labelForChatGPTByokAlias(
+            staticModel.label,
+            handle,
+            byokProviderAliases,
+          ),
           updateArgs: withProviderTypeMetadata(
             handle,
             staticModel.updateArgs as Record<string, unknown> | undefined,
@@ -612,6 +636,7 @@ export function ModelSelector({
   }, [
     availableHandles,
     allApiHandles,
+    byokProviderAliases,
     pickPreferredStaticModel,
     searchQuery,
     isByokHandle,
@@ -724,6 +749,11 @@ export function ModelSelector({
           ...staticModel,
           id: handle,
           handle,
+          label: labelForChatGPTByokAlias(
+            staticModel.label,
+            handle,
+            byokProviderAliases,
+          ),
           updateArgs: withProviderTypeMetadata(
             handle,
             staticModel.updateArgs as Record<string, unknown> | undefined,
@@ -743,6 +773,7 @@ export function ModelSelector({
     return resolved;
   }, [
     availableHandles,
+    byokProviderAliases,
     pickPreferredStaticModel,
     toBaseHandle,
     withProviderTypeMetadata,

--- a/src/cli/components/ModelSelector.tsx
+++ b/src/cli/components/ModelSelector.tsx
@@ -136,6 +136,55 @@ export function labelForChatGPTByokAlias(
   return label.replace(CHATGPT_LABEL_SUFFIX_PATTERN, ` (${providerAlias})`);
 }
 
+export function baseHandleForByokAlias(
+  handle: string,
+  byokProviderAliases: Record<string, string>,
+): string {
+  const slashIndex = handle.indexOf("/");
+  if (slashIndex === -1) return handle;
+
+  const provider = handle.slice(0, slashIndex);
+  const model = handle.slice(slashIndex + 1);
+  const baseProvider = byokProviderAliases[provider];
+
+  if (baseProvider) {
+    return `${baseProvider}/${model}`;
+  }
+  return handle;
+}
+
+export function registryHandleForByokAlias(
+  handle: string,
+  byokProviderAliases: Record<string, string>,
+): string {
+  const baseHandle = baseHandleForByokAlias(handle, byokProviderAliases);
+  return normalizeModelHandleForRegistry(baseHandle) ?? baseHandle;
+}
+
+export function toByokSelectorModel(
+  staticModel: UiModel,
+  handle: string,
+  byokProviderAliases: Record<string, string>,
+  updateArgs?: Record<string, unknown>,
+): UiModel {
+  const resolvedUpdateArgs =
+    updateArgs ??
+    (staticModel.updateArgs as Record<string, unknown> | undefined);
+
+  return {
+    ...staticModel,
+    id: handle,
+    handle,
+    registryHandle: registryHandleForByokAlias(handle, byokProviderAliases),
+    label: labelForChatGPTByokAlias(
+      staticModel.label,
+      handle,
+      byokProviderAliases,
+    ),
+    updateArgs: resolvedUpdateArgs,
+  };
+}
+
 export function toSelectorModelForHandle(handle: string): UiModel {
   const registryHandle = normalizeModelHandleForRegistry(handle) ?? handle;
   const modelInfo = getModelInfo(registryHandle);
@@ -574,19 +623,8 @@ export function ModelSelector({
   // e.g., "lc-anthropic/claude-3-5-haiku" -> "anthropic/claude-3-5-haiku"
   // e.g., "lc-gemini/gemini-2.0-flash" -> "google_ai/gemini-2.0-flash"
   const toBaseHandle = useCallback(
-    (handle: string): string => {
-      const slashIndex = handle.indexOf("/");
-      if (slashIndex === -1) return handle;
-
-      const provider = handle.slice(0, slashIndex);
-      const model = handle.slice(slashIndex + 1);
-      const baseProvider = byokProviderAliases[provider];
-
-      if (baseProvider) {
-        return `${baseProvider}/${model}`;
-      }
-      return handle;
-    },
+    (handle: string): string =>
+      baseHandleForByokAlias(handle, byokProviderAliases),
     [byokProviderAliases],
   );
 
@@ -604,20 +642,17 @@ export function ModelSelector({
       const staticModel = pickPreferredStaticModel(baseHandle);
       if (staticModel) {
         // Use models.json data but with the BYOK handle as the ID
-        matched.push({
-          ...staticModel,
-          id: handle,
-          handle: handle,
-          label: labelForChatGPTByokAlias(
-            staticModel.label,
+        matched.push(
+          toByokSelectorModel(
+            staticModel,
             handle,
             byokProviderAliases,
+            withProviderTypeMetadata(
+              handle,
+              staticModel.updateArgs as Record<string, unknown> | undefined,
+            ),
           ),
-          updateArgs: withProviderTypeMetadata(
-            handle,
-            staticModel.updateArgs as Record<string, unknown> | undefined,
-          ),
-        });
+        );
       }
     }
 
@@ -745,20 +780,17 @@ export function ModelSelector({
       // Try to resolve to a static model with label/description
       const staticModel = pickPreferredStaticModel(toBaseHandle(handle));
       if (staticModel) {
-        resolved.push({
-          ...staticModel,
-          id: handle,
-          handle,
-          label: labelForChatGPTByokAlias(
-            staticModel.label,
+        resolved.push(
+          toByokSelectorModel(
+            staticModel,
             handle,
             byokProviderAliases,
+            withProviderTypeMetadata(
+              handle,
+              staticModel.updateArgs as Record<string, unknown> | undefined,
+            ),
           ),
-          updateArgs: withProviderTypeMetadata(
-            handle,
-            staticModel.updateArgs as Record<string, unknown> | undefined,
-          ),
-        });
+        );
       } else {
         const fallbackModel = toSelectorModelForHandle(handle);
         resolved.push({
@@ -785,13 +817,23 @@ export function ModelSelector({
       recents: recentModels,
       supported: supportedModels,
       byok: byokModels,
-      "byok-all": byokAllModels.map((handle) => ({
-        id: handle,
-        handle,
-        label: handle,
-        description: "",
-        updateArgs: withProviderTypeMetadata(handle, undefined),
-      })),
+      "byok-all": byokAllModels.map((handle) => {
+        const staticModel = pickPreferredStaticModel(toBaseHandle(handle));
+        const staticUpdateArgs = staticModel?.updateArgs as
+          | Record<string, unknown>
+          | undefined;
+
+        return {
+          id: handle,
+          handle,
+          label: handle,
+          description: staticModel?.description ?? "",
+          registryHandle: staticModel
+            ? registryHandleForByokAlias(handle, byokProviderAliases)
+            : undefined,
+          updateArgs: withProviderTypeMetadata(handle, staticUpdateArgs),
+        };
+      }),
       "server-recommended": serverRecommendedModels,
       "server-all": serverAllModelRows,
       all: allLettaModels,
@@ -804,6 +846,9 @@ export function ModelSelector({
       allLettaModels,
       serverRecommendedModels,
       serverAllModelRows,
+      byokProviderAliases,
+      pickPreferredStaticModel,
+      toBaseHandle,
       withProviderTypeMetadata,
     ],
   );

--- a/src/cli/components/ModelSelector.tsx
+++ b/src/cli/components/ModelSelector.tsx
@@ -6,6 +6,7 @@ import {
   getAvailableModelHandles,
   getAvailableModelsCacheInfo,
   getCachedModelHandles,
+  getCachedModelProviderTypes,
 } from "@/agent/available-models";
 import {
   CHATGPT_FAST_SERVICE_TIER,
@@ -220,6 +221,9 @@ export function ModelSelector({
   const [allApiHandles, setAllApiHandles] = useState<string[]>(
     cachedHandlesAtMount ? Array.from(cachedHandlesAtMount) : [],
   );
+  const [providerTypesByHandle, setProviderTypesByHandle] = useState<
+    Map<string, string>
+  >(() => getCachedModelProviderTypes() ?? new Map());
   const [isLoading, setIsLoading] = useState(cachedHandlesAtMount === null);
   const [error, setError] = useState<string | null>(null);
   const [isCached, setIsCached] = useState(cachedHandlesAtMount !== null);
@@ -279,6 +283,7 @@ export function ModelSelector({
 
       setAvailableHandles(result.handles);
       setAllApiHandles(Array.from(result.handles));
+      setProviderTypesByHandle(new Map(result.providerTypes));
       setIsCached(!forceRefresh && cacheInfoBefore.isFresh);
       setIsLoading(false);
       setRefreshing(false);
@@ -290,6 +295,7 @@ export function ModelSelector({
       // Fallback: show all models if API fails
       setAvailableHandles(null);
       setAllApiHandles([]);
+      setProviderTypesByHandle(new Map());
     }
   });
 
@@ -369,6 +375,21 @@ export function ModelSelector({
     [],
   );
 
+  const withProviderTypeMetadata = useCallback(
+    (
+      handle: string,
+      updateArgs: Record<string, unknown> | undefined,
+    ): Record<string, unknown> | undefined => {
+      const providerType = providerTypesByHandle.get(handle);
+      if (!providerType) return updateArgs;
+      return {
+        ...(updateArgs ?? {}),
+        provider_type: providerType,
+      };
+    },
+    [providerTypesByHandle],
+  );
+
   const modelsForBackendHandle = useCallback(
     (handle: string, includeUnknown: boolean): UiModel[] => {
       const registryHandle = normalizeModelHandleForRegistry(handle) ?? handle;
@@ -382,15 +403,28 @@ export function ModelSelector({
           | undefined) ?? {}),
         ...(fastRegistryHandle ? { service_tier: null } : {}),
       };
+      const baseUpdateArgsWithProviderType = withProviderTypeMetadata(
+        handle,
+        Object.keys(baseUpdateArgs).length > 0 ? baseUpdateArgs : undefined,
+      );
+      const fallbackModel = includeUnknown
+        ? toSelectorModelForHandle(handle)
+        : null;
       const baseModel = baseStaticModel
         ? withActualHandle(
             baseStaticModel,
             handle,
             registryHandle,
-            Object.keys(baseUpdateArgs).length > 0 ? baseUpdateArgs : undefined,
+            baseUpdateArgsWithProviderType,
           )
-        : includeUnknown
-          ? toSelectorModelForHandle(handle)
+        : fallbackModel
+          ? {
+              ...fallbackModel,
+              updateArgs: withProviderTypeMetadata(
+                handle,
+                fallbackModel.updateArgs,
+              ),
+            }
           : null;
 
       const result = baseModel ? [baseModel] : [];
@@ -404,6 +438,7 @@ export function ModelSelector({
                 | Record<string, unknown>
                 | undefined) ?? {}),
               service_tier: CHATGPT_FAST_SERVICE_TIER,
+              ...withProviderTypeMetadata(handle, undefined),
             }),
           );
         }
@@ -411,7 +446,7 @@ export function ModelSelector({
 
       return result;
     },
-    [pickPreferredStaticModel, withActualHandle],
+    [pickPreferredStaticModel, withActualHandle, withProviderTypeMetadata],
   );
 
   // Supported models: models.json entries that are available
@@ -554,6 +589,10 @@ export function ModelSelector({
           ...staticModel,
           id: handle,
           handle: handle,
+          updateArgs: withProviderTypeMetadata(
+            handle,
+            staticModel.updateArgs as Record<string, unknown> | undefined,
+          ),
         });
       }
     }
@@ -577,6 +616,7 @@ export function ModelSelector({
     searchQuery,
     isByokHandle,
     toBaseHandle,
+    withProviderTypeMetadata,
   ]);
 
   // BYOK (all): all BYOK handles from API (including recommended ones)
@@ -678,19 +718,35 @@ export function ModelSelector({
       if (availableHandles !== null && !availableHandles.has(handle)) continue;
 
       // Try to resolve to a static model with label/description
-      const staticModel = pickPreferredStaticModel(handle);
+      const staticModel = pickPreferredStaticModel(toBaseHandle(handle));
       if (staticModel) {
         resolved.push({
           ...staticModel,
           id: handle,
           handle,
+          updateArgs: withProviderTypeMetadata(
+            handle,
+            staticModel.updateArgs as Record<string, unknown> | undefined,
+          ),
         });
       } else {
-        resolved.push(toSelectorModelForHandle(handle));
+        const fallbackModel = toSelectorModelForHandle(handle);
+        resolved.push({
+          ...fallbackModel,
+          updateArgs: withProviderTypeMetadata(
+            handle,
+            fallbackModel.updateArgs,
+          ),
+        });
       }
     }
     return resolved;
-  }, [availableHandles, pickPreferredStaticModel]);
+  }, [
+    availableHandles,
+    pickPreferredStaticModel,
+    toBaseHandle,
+    withProviderTypeMetadata,
+  ]);
 
   // Map category -> list for O(1) lookup
   const categoryListMap = useMemo(
@@ -703,6 +759,7 @@ export function ModelSelector({
         handle,
         label: handle,
         description: "",
+        updateArgs: withProviderTypeMetadata(handle, undefined),
       })),
       "server-recommended": serverRecommendedModels,
       "server-all": serverAllModelRows,
@@ -716,6 +773,7 @@ export function ModelSelector({
       allLettaModels,
       serverRecommendedModels,
       serverAllModelRows,
+      withProviderTypeMetadata,
     ],
   );
 

--- a/src/cli/components/ProviderSelector.tsx
+++ b/src/cli/components/ProviderSelector.tsx
@@ -16,6 +16,7 @@ import {
   type ProviderStorageTarget,
   removeProviderByName,
 } from "@/providers/byok-providers";
+import { connectedRecordsForProvider } from "@/providers/provider-connections";
 import { type Settings, settingsManager } from "@/settings-manager";
 import { type AwsProfile, parseAwsCredentials } from "@/utils/aws-credentials";
 import { debugLog } from "@/utils/debug";
@@ -112,6 +113,18 @@ export function providerSelectionFlow(
   if ("authMethods" in provider && provider.authMethods) return "methodSelect";
   if ("fields" in provider && provider.fields) return "multiInput";
   return "input";
+}
+
+export function connectedProviderSummary(
+  provider: ByokProvider,
+  records: readonly ProviderResponse[],
+): string {
+  if (records.length === 0) return provider.description;
+  if (records.length > 1) return `${records.length} connected`;
+
+  const record = records[0];
+  if (!record || record.name === provider.providerName) return "Connected";
+  return `Connected (${record.name})`;
 }
 
 export function fieldValuesFromProviderPlaceholders(
@@ -344,46 +357,25 @@ export function ProviderSelector({
     setViewState({ type: "list" });
   }, [showProviderStoreTabs]);
 
-  // Check if a provider is connected
-  const isConnected = useCallback(
-    (provider: ByokProvider) => {
-      const providerNames = provider.providerNames ?? [provider.providerName];
-      return providerNames.some((name) => {
-        const connected = connectedProviders.get(name);
-        if (!connected) return false;
-        if (selectedTarget !== "local" || !connected.auth_type) return true;
-        return provider.isOAuth
-          ? connected.auth_type === "oauth"
-          : connected.auth_type !== "oauth";
-      });
-    },
+  const getConnectedProviderRecords = useCallback(
+    (provider: ByokProvider): ProviderResponse[] =>
+      connectedRecordsForProvider(provider, connectedProviders, selectedTarget),
     [connectedProviders, selectedTarget],
   );
 
   const getConnectedProviderName = useCallback(
     (provider: ByokProvider): string | undefined => {
-      const providerNames = provider.providerNames ?? [provider.providerName];
-      return providerNames.find((name) => {
-        const connected = connectedProviders.get(name);
-        if (!connected) return false;
-        if (selectedTarget !== "local" || !connected.auth_type) return true;
-        return provider.isOAuth
-          ? connected.auth_type === "oauth"
-          : connected.auth_type !== "oauth";
-      });
+      return getConnectedProviderRecords(provider)[0]?.name;
     },
-    [connectedProviders, selectedTarget],
+    [getConnectedProviderRecords],
   );
 
   // Get provider ID if connected
   const getProviderId = useCallback(
     (provider: ByokProvider): string | undefined => {
-      const providerName = getConnectedProviderName(provider);
-      return providerName
-        ? connectedProviders.get(providerName)?.id
-        : undefined;
+      return getConnectedProviderRecords(provider)[0]?.id;
     },
-    [connectedProviders, getConnectedProviderName],
+    [getConnectedProviderRecords],
   );
 
   // Handle selecting a provider from the list
@@ -656,33 +648,40 @@ export function ProviderSelector({
   ]);
 
   // Handle disconnect
-  const handleDisconnect = useCallback(async () => {
-    if (viewState.type !== "options") return;
+  const handleDisconnect = useCallback(
+    async (providerName?: string) => {
+      if (viewState.type !== "options") return;
 
-    const { provider } = viewState;
-    try {
-      await removeProviderByName(
-        getConnectedProviderName(provider) ?? provider.providerName,
-        {
+      const { provider } = viewState;
+      try {
+        await removeProviderByName(
+          providerName ??
+            getConnectedProviderName(provider) ??
+            provider.providerName,
+          {
+            target: selectedTarget,
+          },
+        );
+        clearAvailableModelsCache();
+        // Refresh connected providers
+        const providers = await getConnectedProviders({
           target: selectedTarget,
-        },
-      );
-      clearAvailableModelsCache();
-      // Refresh connected providers
-      const providers = await getConnectedProviders({ target: selectedTarget });
-      if (mountedRef.current) {
-        setConnectedProvidersForTarget(selectedTarget, providers);
-        setViewState({ type: "list" });
+        });
+        if (mountedRef.current) {
+          setConnectedProvidersForTarget(selectedTarget, providers);
+          setViewState({ type: "list" });
+        }
+      } catch {
+        // Silently fail, stay on options view
       }
-    } catch {
-      // Silently fail, stay on options view
-    }
-  }, [
-    viewState,
-    selectedTarget,
-    getConnectedProviderName,
-    setConnectedProvidersForTarget,
-  ]);
+    },
+    [
+      viewState,
+      selectedTarget,
+      getConnectedProviderName,
+      setConnectedProvidersForTarget,
+    ],
+  );
 
   useInput((input, key) => {
     // CTRL-C: immediately cancel
@@ -867,16 +866,17 @@ export function ProviderSelector({
         }
       }
     } else if (viewState.type === "options") {
-      const options = ["Disconnect", "Back"];
+      const connectedRecords = getConnectedProviderRecords(viewState.provider);
+      const optionsLength = connectedRecords.length + 1;
       if (key.escape) {
         setViewState({ type: "list" });
       } else if (key.upArrow) {
         setOptionIndex((prev) => Math.max(0, prev - 1));
       } else if (key.downArrow) {
-        setOptionIndex((prev) => Math.min(options.length - 1, prev + 1));
+        setOptionIndex((prev) => Math.min(optionsLength - 1, prev + 1));
       } else if (key.return) {
-        if (optionIndex === 0) {
-          handleDisconnect();
+        if (optionIndex < connectedRecords.length) {
+          handleDisconnect(connectedRecords[optionIndex]?.name);
         } else {
           setViewState({ type: "list" });
         }
@@ -949,7 +949,8 @@ export function ProviderSelector({
           {visibleProviders.map((provider, index) => {
             const actualIndex = providerStartIndex + index;
             const isSelected = actualIndex === selectedIndex;
-            const connected = isConnected(provider);
+            const connectedRecords = getConnectedProviderRecords(provider);
+            const connected = connectedRecords.length > 0;
 
             return (
               <Box key={provider.id} flexDirection="row">
@@ -975,7 +976,9 @@ export function ProviderSelector({
                 <Text dimColor>
                   {" · "}
                   {connected ? (
-                    <Text color="green">Connected</Text>
+                    <Text color="green">
+                      {connectedProviderSummary(provider, connectedRecords)}
+                    </Text>
                   ) : (
                     provider.description
                   )}
@@ -1347,23 +1350,33 @@ export function ProviderSelector({
   const renderOptionsView = () => {
     if (viewState.type !== "options") return null;
     const { provider } = viewState;
-    const options = ["Disconnect provider", "Back"];
+    const connectedRecords = getConnectedProviderRecords(provider);
+    const options = [
+      ...connectedRecords.map((record) => `Disconnect ${record.name}`),
+      "Back",
+    ];
 
     return (
       <>
         <Box flexDirection="column" marginBottom={1}>
           <Text bold color={colors.selector.title}>
-            Disconnect {provider.displayName}
+            Manage {provider.displayName}
           </Text>
           <Box height={1} />
-          <Box flexDirection="row">
-            <Text>{"  "}</Text>
-            <Text color="green">[✓]</Text>
-            <Text> </Text>
-            <Text bold>{provider.displayName}</Text>
-            <Text dimColor> · </Text>
-            <Text color="green">Connected</Text>
-          </Box>
+          {connectedRecords.length > 0 ? (
+            connectedRecords.map((record) => (
+              <Box key={record.id} flexDirection="row">
+                <Text>{"  "}</Text>
+                <Text color="green">[✓]</Text>
+                <Text> </Text>
+                <Text bold>{record.name}</Text>
+                <Text dimColor> · </Text>
+                <Text color="green">Connected</Text>
+              </Box>
+            ))
+          ) : (
+            <Text dimColor>{"  "}No connected providers.</Text>
+          )}
         </Box>
 
         <Box flexDirection="column">

--- a/src/cli/components/ProviderSelector.tsx
+++ b/src/cli/components/ProviderSelector.tsx
@@ -16,6 +16,10 @@ import {
   type ProviderStorageTarget,
   removeProviderByName,
 } from "@/providers/byok-providers";
+import {
+  formatChatGPTUsageQuotaRows,
+  readChatGPTUsage,
+} from "@/providers/chatgpt-usage-service";
 import { normalizeChatGPTOAuthProviderName } from "@/providers/openai-codex-provider";
 import { connectedRecordsForProvider } from "@/providers/provider-connections";
 import { type Settings, settingsManager } from "@/settings-manager";
@@ -48,6 +52,11 @@ type ProviderSelectionFlow =
 type ConnectedProvidersByTarget = Partial<
   Record<ProviderStorageTarget, Map<string, ProviderResponse>>
 >;
+
+type ChatGPTUsageStatus =
+  | { status: "loading" }
+  | { status: "ready"; rows: string[] }
+  | { status: "error"; message: string };
 
 interface ProviderSelectorProps {
   onCancel: () => void;
@@ -181,6 +190,21 @@ export function isProviderTargetLoading(input: {
   );
 }
 
+export function isChatGPTUsageProvider(provider: ByokProvider): boolean {
+  return (
+    provider.providerType === "chatgpt_oauth" ||
+    provider.oauthProviderId === "openai-codex" ||
+    provider.providerName === "chatgpt-plus-pro" ||
+    (provider.providerNames ?? []).includes("openai-codex")
+  );
+}
+
+function usageStatusRows(status: ChatGPTUsageStatus | undefined): string[] {
+  if (!status || status.status === "loading") return ["Loading..."];
+  if (status.status === "error") return [`Unavailable: ${status.message}`];
+  return status.rows;
+}
+
 export function ProviderSelector({
   onCancel,
   onStartOAuth,
@@ -211,6 +235,9 @@ export function ProviderSelector({
     useState<ValidationState>("idle");
   const [validationError, setValidationError] = useState<string | null>(null);
   const [optionIndex, setOptionIndex] = useState(0);
+  const [chatGPTUsageByProvider, setChatGPTUsageByProvider] = useState<
+    Record<string, ChatGPTUsageStatus>
+  >({});
   // Multi-field input state (for providers like Bedrock)
   const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
   const [focusedFieldIndex, setFocusedFieldIndex] = useState(0);
@@ -404,6 +431,58 @@ export function ProviderSelector({
     },
     [getConnectedProviderRecords],
   );
+
+  const loadChatGPTUsageForProvider = useCallback(
+    (provider: ByokProvider, forceRefresh = false) => {
+      if (!isChatGPTUsageProvider(provider)) return;
+
+      const records = getConnectedProviderRecords(provider);
+      for (const record of records) {
+        const providerName = record.name;
+        setChatGPTUsageByProvider((previous) => ({
+          ...previous,
+          [providerName]: { status: "loading" },
+        }));
+
+        void readChatGPTUsage({
+          target: selectedTarget,
+          providerName,
+          forceRefresh,
+        })
+          .then((result) => {
+            if (!mountedRef.current) return;
+            setChatGPTUsageByProvider((previous) => ({
+              ...previous,
+              [providerName]: result.success
+                ? {
+                    status: "ready",
+                    rows: formatChatGPTUsageQuotaRows(result.usage),
+                  }
+                : { status: "error", message: result.error.message },
+            }));
+          })
+          .catch((error) => {
+            if (!mountedRef.current) return;
+            setChatGPTUsageByProvider((previous) => ({
+              ...previous,
+              [providerName]: {
+                status: "error",
+                message:
+                  error instanceof Error
+                    ? error.message
+                    : "Failed to read ChatGPT usage.",
+              },
+            }));
+          });
+      }
+    },
+    [getConnectedProviderRecords, selectedTarget],
+  );
+
+  useEffect(() => {
+    if (viewState.type !== "options") return;
+    loadChatGPTUsageForProvider(viewState.provider);
+  }, [loadChatGPTUsageForProvider, viewState]);
 
   // Get provider ID if connected
   const getProviderId = useCallback(
@@ -939,8 +1018,13 @@ export function ProviderSelector({
         viewState.provider,
         selectedTarget,
       );
+      const showUsageRefresh =
+        isChatGPTUsageProvider(viewState.provider) &&
+        connectedRecords.length > 0;
       const connectAnotherIndex = connectedRecords.length;
-      const backIndex = connectedRecords.length + (canConnectAnother ? 1 : 0);
+      const usageRefreshIndex =
+        connectAnotherIndex + (canConnectAnother ? 1 : 0);
+      const backIndex = usageRefreshIndex + (showUsageRefresh ? 1 : 0);
       const optionsLength = backIndex + 1;
       if (key.escape) {
         setViewState({ type: "list" });
@@ -960,6 +1044,8 @@ export function ProviderSelector({
             type: "oauthNameInput",
             provider: viewState.provider,
           });
+        } else if (showUsageRefresh && optionIndex === usageRefreshIndex) {
+          loadChatGPTUsageForProvider(viewState.provider, true);
         } else {
           setViewState({ type: "list" });
         }
@@ -1451,9 +1537,11 @@ export function ProviderSelector({
       provider,
       selectedTarget,
     );
+    const showUsage = isChatGPTUsageProvider(provider);
     const options = [
       ...connectedRecords.map((record) => `Disconnect ${record.name}`),
       ...(canConnectAnother ? [connectAnotherProviderOption(provider)] : []),
+      ...(showUsage && connectedRecords.length > 0 ? ["Refresh usage"] : []),
       "Back",
     ];
 
@@ -1465,16 +1553,40 @@ export function ProviderSelector({
           </Text>
           <Box height={1} />
           {connectedRecords.length > 0 ? (
-            connectedRecords.map((record) => (
-              <Box key={record.id} flexDirection="row">
-                <Text>{"  "}</Text>
-                <Text color="green">[✓]</Text>
-                <Text> </Text>
-                <Text bold>{record.name}</Text>
-                <Text dimColor> · </Text>
-                <Text color="green">Connected</Text>
-              </Box>
-            ))
+            connectedRecords.map((record) => {
+              const usageStatus = chatGPTUsageByProvider[record.name];
+              return (
+                <Box key={record.id} flexDirection="column">
+                  <Box flexDirection="row">
+                    <Text>{"  "}</Text>
+                    <Text color="green">[✓]</Text>
+                    <Text> </Text>
+                    <Text bold>{record.name}</Text>
+                    <Text dimColor> · </Text>
+                    <Text color="green">Connected</Text>
+                  </Box>
+                  {showUsage && (
+                    <Box flexDirection="column">
+                      {usageStatusRows(usageStatus).map((row) => (
+                        <Box key={row} flexDirection="row">
+                          <Text>{"      "}</Text>
+                          <Text
+                            color={
+                              usageStatus?.status === "error"
+                                ? "yellow"
+                                : undefined
+                            }
+                            dimColor={usageStatus?.status !== "error"}
+                          >
+                            {row}
+                          </Text>
+                        </Box>
+                      ))}
+                    </Box>
+                  )}
+                </Box>
+              );
+            })
           ) : (
             <Text dimColor>{"  "}No connected providers.</Text>
           )}

--- a/src/cli/components/ProviderSelector.tsx
+++ b/src/cli/components/ProviderSelector.tsx
@@ -16,6 +16,7 @@ import {
   type ProviderStorageTarget,
   removeProviderByName,
 } from "@/providers/byok-providers";
+import { normalizeChatGPTOAuthProviderName } from "@/providers/openai-codex-provider";
 import { connectedRecordsForProvider } from "@/providers/provider-connections";
 import { type Settings, settingsManager } from "@/settings-manager";
 import { type AwsProfile, parseAwsCredentials } from "@/utils/aws-credentials";
@@ -32,7 +33,8 @@ type ViewState =
   | { type: "multiInput"; provider: ByokProvider; authMethod?: AuthMethod }
   | { type: "methodSelect"; provider: ByokProvider }
   | { type: "profileSelect"; provider: ByokProvider }
-  | { type: "options"; provider: ByokProvider };
+  | { type: "options"; provider: ByokProvider }
+  | { type: "oauthNameInput"; provider: ByokProvider };
 
 type ValidationState = "idle" | "validating" | "valid" | "invalid" | "saving";
 
@@ -53,6 +55,7 @@ interface ProviderSelectorProps {
   onStartOAuth?: (
     provider: ByokProvider,
     target: ProviderStorageTarget,
+    providerName?: string,
   ) => void;
 }
 
@@ -127,6 +130,34 @@ export function connectedProviderSummary(
   return `Connected (${record.name})`;
 }
 
+export function canConnectAnotherProvider(
+  provider: ByokProvider,
+  target: ProviderStorageTarget,
+): boolean {
+  return (
+    target === "api" &&
+    provider.isOAuth === true &&
+    provider.providerType === "chatgpt_oauth"
+  );
+}
+
+export function nextProviderConnectionName(
+  provider: ByokProvider,
+  records: readonly ProviderResponse[],
+): string {
+  const existingNames = new Set(records.map((record) => record.name));
+  if (!existingNames.has(provider.providerName)) return provider.providerName;
+
+  for (let index = 2; ; index += 1) {
+    const candidate = `${provider.providerName}-${index}`;
+    if (!existingNames.has(candidate)) return candidate;
+  }
+}
+
+export function connectAnotherProviderOption(provider: ByokProvider): string {
+  return `Connect another ${provider.displayName}`;
+}
+
 export function fieldValuesFromProviderPlaceholders(
   fields: readonly ProviderField[] | undefined,
 ): Record<string, string> {
@@ -172,6 +203,10 @@ export function ProviderSelector({
   const [viewState, setViewState] = useState<ViewState>({ type: "list" });
   const [searchQuery, setSearchQuery] = useState("");
   const [apiKeyInput, setApiKeyInput] = useState("");
+  const [providerNameInput, setProviderNameInput] = useState("");
+  const [providerNameError, setProviderNameError] = useState<string | null>(
+    null,
+  );
   const [validationState, setValidationState] =
     useState<ValidationState>("idle");
   const [validationError, setValidationError] = useState<string | null>(null);
@@ -683,6 +718,39 @@ export function ProviderSelector({
     ],
   );
 
+  const startNamedOAuthConnect = useCallback(() => {
+    if (viewState.type !== "oauthNameInput") return;
+
+    let providerName: string;
+    try {
+      providerName = normalizeChatGPTOAuthProviderName(providerNameInput);
+    } catch (error) {
+      setProviderNameError(
+        error instanceof Error ? error.message : String(error),
+      );
+      return;
+    }
+
+    if (connectedProviders.has(providerName)) {
+      setProviderNameError(`Provider '${providerName}' already exists.`);
+      return;
+    }
+
+    if (!onStartOAuth) {
+      setProviderNameError("OAuth connection is unavailable.");
+      return;
+    }
+
+    setProviderNameError(null);
+    onStartOAuth(viewState.provider, selectedTarget, providerName);
+  }, [
+    viewState,
+    providerNameInput,
+    connectedProviders,
+    onStartOAuth,
+    selectedTarget,
+  ]);
+
   useInput((input, key) => {
     // CTRL-C: immediately cancel
     if (key.ctrl && input === "c") {
@@ -867,7 +935,13 @@ export function ProviderSelector({
       }
     } else if (viewState.type === "options") {
       const connectedRecords = getConnectedProviderRecords(viewState.provider);
-      const optionsLength = connectedRecords.length + 1;
+      const canConnectAnother = canConnectAnotherProvider(
+        viewState.provider,
+        selectedTarget,
+      );
+      const connectAnotherIndex = connectedRecords.length;
+      const backIndex = connectedRecords.length + (canConnectAnother ? 1 : 0);
+      const optionsLength = backIndex + 1;
       if (key.escape) {
         setViewState({ type: "list" });
       } else if (key.upArrow) {
@@ -877,9 +951,31 @@ export function ProviderSelector({
       } else if (key.return) {
         if (optionIndex < connectedRecords.length) {
           handleDisconnect(connectedRecords[optionIndex]?.name);
+        } else if (canConnectAnother && optionIndex === connectAnotherIndex) {
+          setProviderNameInput(
+            nextProviderConnectionName(viewState.provider, connectedRecords),
+          );
+          setProviderNameError(null);
+          setViewState({
+            type: "oauthNameInput",
+            provider: viewState.provider,
+          });
         } else {
           setViewState({ type: "list" });
         }
+      }
+    } else if (viewState.type === "oauthNameInput") {
+      if (key.escape) {
+        setProviderNameError(null);
+        setViewState({ type: "options", provider: viewState.provider });
+      } else if (key.return) {
+        startNamedOAuthConnect();
+      } else if (key.backspace || key.delete) {
+        setProviderNameInput((prev) => prev.slice(0, -1));
+        setProviderNameError(null);
+      } else if (input && !key.ctrl && !key.meta) {
+        setProviderNameInput((prev) => prev + input);
+        setProviderNameError(null);
       }
     }
   });
@@ -1351,8 +1447,13 @@ export function ProviderSelector({
     if (viewState.type !== "options") return null;
     const { provider } = viewState;
     const connectedRecords = getConnectedProviderRecords(provider);
+    const canConnectAnother = canConnectAnotherProvider(
+      provider,
+      selectedTarget,
+    );
     const options = [
       ...connectedRecords.map((record) => `Disconnect ${record.name}`),
+      ...(canConnectAnother ? [connectAnotherProviderOption(provider)] : []),
       "Back",
     ];
 
@@ -1411,6 +1512,38 @@ export function ProviderSelector({
     );
   };
 
+  const renderOAuthNameInputView = () => {
+    if (viewState.type !== "oauthNameInput") return null;
+    const { provider } = viewState;
+
+    return (
+      <>
+        <Box flexDirection="column" marginBottom={1}>
+          <Text bold color={colors.selector.title}>
+            Connect another {provider.displayName}
+          </Text>
+          <Box height={1} />
+          <Box flexDirection="row">
+            <Text>{"  "}Provider name: </Text>
+            <Text>{providerNameInput}</Text>
+          </Box>
+          {providerNameError ? (
+            <Box marginTop={1}>
+              <Text color="red">
+                {"  "}
+                {providerNameError}
+              </Text>
+            </Box>
+          ) : null}
+        </Box>
+
+        <Box marginTop={1}>
+          <Text dimColor>{"  "}Enter connect · Backspace edit · Esc back</Text>
+        </Box>
+      </>
+    );
+  };
+
   return (
     <Box flexDirection="column">
       {/* Command header */}
@@ -1425,6 +1558,7 @@ export function ProviderSelector({
       {viewState.type === "profileSelect" && renderProfileSelectView()}
       {viewState.type === "multiInput" && renderMultiInputView()}
       {viewState.type === "options" && renderOptionsView()}
+      {viewState.type === "oauthNameInput" && renderOAuthNameInputView()}
     </Box>
   );
 }

--- a/src/cli/components/provider-selector.test.ts
+++ b/src/cli/components/provider-selector.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import { commands } from "@/cli/commands/registry";
 import {
+  canConnectAnotherProvider,
+  connectAnotherProviderOption,
   connectedProviderSummary,
   fieldValuesFromProviderPlaceholders,
   filterProviderConfigs,
   hasConstellationProviderStoreCredentials,
   isProviderTargetLoading,
+  nextProviderConnectionName,
   providerApiKeyFromInput,
   providerSelectionFlow,
   shouldShowProviderStoreTabs,
@@ -272,6 +275,39 @@ describe("ProviderSelector connected provider actions", () => {
         chatgptWorkProvider,
       ]),
     ).toBe("2 connected");
+  });
+
+  test("surfaces connect-another only for API ChatGPT OAuth providers", () => {
+    const openai = getProviderConfigs("api").find(
+      (provider) => provider.id === "openai",
+    );
+    if (!openai) throw new Error("Expected openai provider config");
+
+    expect(canConnectAnotherProvider(codexProvider, "api")).toBe(true);
+    expect(canConnectAnotherProvider(codexProvider, "local")).toBe(false);
+    expect(canConnectAnotherProvider(openai, "api")).toBe(false);
+    expect(connectAnotherProviderOption(codexProvider)).toBe(
+      "Connect another ChatGPT / Codex plan",
+    );
+  });
+
+  test("suggests the next available ChatGPT OAuth provider name", () => {
+    expect(nextProviderConnectionName(codexProvider, [])).toBe(
+      "chatgpt-plus-pro",
+    );
+    expect(
+      nextProviderConnectionName(codexProvider, [chatgptDefaultProvider]),
+    ).toBe("chatgpt-plus-pro-2");
+    expect(
+      nextProviderConnectionName(codexProvider, [
+        chatgptDefaultProvider,
+        {
+          ...chatgptDefaultProvider,
+          id: "provider-chatgpt-plus-pro-2",
+          name: "chatgpt-plus-pro-2",
+        },
+      ]),
+    ).toBe("chatgpt-plus-pro-3");
   });
 
   test("removes the legacy slash disconnect command from discovery", () => {

--- a/src/cli/components/provider-selector.test.ts
+++ b/src/cli/components/provider-selector.test.ts
@@ -7,6 +7,7 @@ import {
   fieldValuesFromProviderPlaceholders,
   filterProviderConfigs,
   hasConstellationProviderStoreCredentials,
+  isChatGPTUsageProvider,
   isProviderTargetLoading,
   nextProviderConnectionName,
   providerApiKeyFromInput,
@@ -58,6 +59,14 @@ function providerById(id: string): ByokProvider {
 }
 
 describe("ProviderSelector local provider API keys", () => {
+  test("recognizes ChatGPT OAuth providers for usage display", () => {
+    const chatgpt = providerById("openai-codex-oauth");
+    const openai = providerById("openai");
+
+    expect(isChatGPTUsageProvider(chatgpt)).toBe(true);
+    expect(isChatGPTUsageProvider(openai)).toBe(false);
+  });
+
   test("keeps LM Studio UI identity while using server provider type", () => {
     const lmstudio = providerById("lmstudio");
 

--- a/src/cli/components/provider-selector.test.ts
+++ b/src/cli/components/provider-selector.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { commands } from "@/cli/commands/registry";
 import {
+  connectedProviderSummary,
   fieldValuesFromProviderPlaceholders,
   filterProviderConfigs,
   hasConstellationProviderStoreCredentials,
@@ -13,6 +14,7 @@ import {
   type ByokProvider,
   defaultProviderApiKey,
   getProviderConfigs,
+  type ProviderResponse,
 } from "@/providers/byok-providers";
 
 function withEnv<T>(
@@ -204,6 +206,27 @@ describe("ProviderSelector multi-field defaults", () => {
 });
 
 describe("ProviderSelector connected provider actions", () => {
+  const codexProvider: ByokProvider = {
+    id: "codex",
+    displayName: "ChatGPT / Codex plan",
+    description: "Connect your ChatGPT coding plan",
+    providerType: "chatgpt_oauth",
+    providerName: "chatgpt-plus-pro",
+    isOAuth: true,
+  };
+  const chatgptWorkProvider: ProviderResponse = {
+    id: "provider-chatgpt-work",
+    name: "chatgpt-work",
+    provider_type: "chatgpt_oauth",
+    provider_category: "byok",
+  };
+  const chatgptDefaultProvider: ProviderResponse = {
+    id: "provider-chatgpt-plus-pro",
+    name: "chatgpt-plus-pro",
+    provider_type: "chatgpt_oauth",
+    provider_category: "byok",
+  };
+
   test("opens options for connected OAuth providers before starting OAuth", () => {
     const codex = getProviderConfigs("api").find(
       (provider) => provider.id === "codex",
@@ -222,6 +245,33 @@ describe("ProviderSelector connected provider actions", () => {
 
     expect(providerSelectionFlow(openai)).toBe("input");
     expect(providerSelectionFlow(openai, "provider-2")).toBe("options");
+  });
+
+  test("summarizes disconnected providers with their description", () => {
+    expect(connectedProviderSummary(codexProvider, [])).toBe(
+      "Connect your ChatGPT coding plan",
+    );
+  });
+
+  test("summarizes a single named provider with its alias", () => {
+    expect(connectedProviderSummary(codexProvider, [chatgptWorkProvider])).toBe(
+      "Connected (chatgpt-work)",
+    );
+  });
+
+  test("summarizes the built-in provider name as connected", () => {
+    expect(
+      connectedProviderSummary(codexProvider, [chatgptDefaultProvider]),
+    ).toBe("Connected");
+  });
+
+  test("summarizes multiple named providers by count", () => {
+    expect(
+      connectedProviderSummary(codexProvider, [
+        chatgptDefaultProvider,
+        chatgptWorkProvider,
+      ]),
+    ).toBe("2 connected");
   });
 
   test("removes the legacy slash disconnect command from discovery", () => {

--- a/src/cli/connect-oauth-core.test.ts
+++ b/src/cli/connect-oauth-core.test.ts
@@ -37,6 +37,7 @@ describe("connect OAuth core", () => {
     const storeOAuthState = mock(() => undefined);
     const clearOAuthState = mock(() => undefined);
     const openBrowser = mock(() => Promise.resolve());
+    const abortController = new AbortController();
     const statuses: string[] = [];
 
     const result = await runChatGPTOAuthConnectFlow(
@@ -45,6 +46,7 @@ describe("connect OAuth core", () => {
           statuses.push(status);
         },
         openBrowser,
+        signal: abortController.signal,
       },
       {
         startOAuth,
@@ -60,6 +62,11 @@ describe("connect OAuth core", () => {
     expect(result.providerName).toBe("chatgpt-plus-pro");
     expect(startOAuth).toHaveBeenCalledTimes(1);
     expect(startCallbackServer).toHaveBeenCalledTimes(1);
+    expect(startCallbackServer).toHaveBeenCalledWith(
+      "state-123",
+      1455,
+      abortController.signal,
+    );
     expect(exchangeTokens).toHaveBeenCalledWith(
       "oauth-code",
       "verifier-123",

--- a/src/cli/connect-oauth-core.test.ts
+++ b/src/cli/connect-oauth-core.test.ts
@@ -67,6 +67,15 @@ describe("connect OAuth core", () => {
     );
     expect(extractAccountId).toHaveBeenCalledWith("access-token");
     expect(createOrUpdateProvider).toHaveBeenCalledTimes(1);
+    expect(createOrUpdateProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        access_token: "access-token",
+        id_token: "id-token",
+        refresh_token: "refresh-token",
+        account_id: "acct_123",
+      }),
+      "chatgpt-plus-pro",
+    );
     expect(storeOAuthState).toHaveBeenCalledWith(
       "state-123",
       "verifier-123",
@@ -79,6 +88,52 @@ describe("connect OAuth core", () => {
     );
     expect(serverClose).toHaveBeenCalledTimes(1);
     expect(statuses.length).toBeGreaterThan(3);
+  });
+
+  test("uses custom ChatGPT OAuth provider name", async () => {
+    const createOrUpdateProvider = mock(() =>
+      Promise.resolve({ id: "provider-work" }),
+    );
+
+    const result = await runChatGPTOAuthConnectFlow(
+      {
+        providerName: "chatgpt-work",
+        onStatus: () => undefined,
+        openBrowser: () => Promise.resolve(),
+      },
+      {
+        startOAuth: () =>
+          Promise.resolve({
+            authorizationUrl: "https://auth.openai.com/oauth/authorize?abc",
+            state: "state-123",
+            codeVerifier: "verifier-123",
+            redirectUri: "http://localhost:1455/auth/callback",
+          }),
+        startCallbackServer: () =>
+          Promise.resolve({
+            result: { code: "oauth-code", state: "state-123" },
+            server: { close: () => undefined },
+          }),
+        exchangeTokens: () =>
+          Promise.resolve({
+            access_token: "access-token",
+            id_token: "id-token",
+            refresh_token: "refresh-token",
+            token_type: "Bearer",
+            expires_in: 3600,
+          }),
+        extractAccountId: () => "acct_123",
+        createOrUpdateProvider,
+        storeOAuthState: () => undefined,
+        clearOAuthState: () => undefined,
+      },
+    );
+
+    expect(result.providerName).toBe("chatgpt-work");
+    expect(createOrUpdateProvider).toHaveBeenCalledWith(
+      expect.any(Object),
+      "chatgpt-work",
+    );
   });
 
   test("clears OAuth state when flow fails", async () => {

--- a/src/cli/subcommands/connect.test.ts
+++ b/src/cli/subcommands/connect.test.ts
@@ -92,6 +92,22 @@ describe("connect subcommand", () => {
     );
   });
 
+  test("passes custom ChatGPT provider name to OAuth flow", async () => {
+    const { stdout, deps } = createIoDeps();
+
+    const exitCode = await runConnectSubcommand(
+      ["chatgpt", "--name", "chatgpt-work"],
+      deps,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(deps.isChatGPTOAuthConnected).toHaveBeenCalledWith("chatgpt-work");
+    expect(deps.runChatGPTOAuthConnectFlow).toHaveBeenCalledWith(
+      expect.objectContaining({ providerName: "chatgpt-work" }),
+    );
+    expect(stdout.join("\n")).toContain("Provider 'chatgpt-work' saved.");
+  });
+
   test("connects API key provider from positional key", async () => {
     const { deps } = createIoDeps();
 

--- a/src/cli/subcommands/connect.ts
+++ b/src/cli/subcommands/connect.ts
@@ -27,6 +27,11 @@ import {
   type ProviderConnectionOptions,
   providerStorageTargetLabel,
 } from "@/providers/byok-providers";
+import {
+  getOpenAICodexProvider,
+  normalizeChatGPTOAuthProviderName,
+  OPENAI_CODEX_PROVIDER_NAME,
+} from "@/providers/openai-codex-provider";
 import { settingsManager } from "@/settings-manager";
 import { getErrorMessage } from "@/utils/error";
 
@@ -39,6 +44,7 @@ const CONNECT_OPTIONS = {
   region: { type: "string" },
   profile: { type: "string" },
   "base-url": { type: "string" },
+  name: { type: "string" },
   timeout: { type: "string" },
   "no-timeout": { type: "boolean" },
 } as const;
@@ -65,7 +71,7 @@ interface ConnectSubcommandDeps {
     profile?: string,
     options?: ProviderConnectionOptions,
   ) => Promise<unknown>;
-  isChatGPTOAuthConnected: () => Promise<boolean>;
+  isChatGPTOAuthConnected: (providerName?: string) => Promise<boolean>;
   runChatGPTOAuthConnectFlow: (
     callbacks: ChatGPTOAuthFlowCallbacks,
   ) => Promise<unknown>;
@@ -93,7 +99,11 @@ const DEFAULT_DEPS: ConnectSubcommandDeps = {
   promptSecret: promptSecret,
   checkProviderApiKey,
   createOrUpdateProvider,
-  isChatGPTOAuthConnected,
+  isChatGPTOAuthConnected: (providerName) =>
+    isChatGPTOAuthConnected({
+      getProvider: () =>
+        getOpenAICodexProvider({}, providerName ?? OPENAI_CODEX_PROVIDER_NAME),
+    }),
   runChatGPTOAuthConnectFlow,
   runLocalOAuthConnectFlow,
   providerStorageTargetLabel,
@@ -109,6 +119,7 @@ function formatUsage(): string {
     "",
     "Examples:",
     "  letta connect chatgpt",
+    "  letta connect chatgpt --name chatgpt-work",
     "  letta connect codex",
     "  letta connect codex --method device-code",
     "  letta connect anthropic <api_key>",
@@ -230,19 +241,31 @@ export async function runConnectSubcommand(
     try {
       if (provider.target !== "local") {
         await io.ensureSettingsReady();
+        let providerName: string;
+        try {
+          providerName = normalizeChatGPTOAuthProviderName(
+            readStringOption(parsed.values.name),
+          );
+        } catch (error) {
+          io.stderr(error instanceof Error ? error.message : String(error));
+          return 1;
+        }
 
-        if (await io.isChatGPTOAuthConnected()) {
+        if (await io.isChatGPTOAuthConnected(providerName)) {
           io.stdout(
-            "Already connected to ChatGPT via OAuth. Use /connect in the TUI and select ChatGPT / Codex plan to disconnect or re-authenticate.",
+            `Already connected to ChatGPT via OAuth as '${providerName}'. Use /connect in the TUI and select ChatGPT / Codex plan to disconnect or re-authenticate.`,
           );
           return 0;
         }
 
         await io.runChatGPTOAuthConnectFlow({
+          providerName,
           onStatus: (status) => io.stdout(status),
         });
 
-        io.stdout("Successfully connected to ChatGPT OAuth.");
+        io.stdout(
+          `Successfully connected to ChatGPT OAuth.\nProvider '${providerName}' saved.`,
+        );
         return 0;
       }
 

--- a/src/providers/chatgpt-usage-service.test.ts
+++ b/src/providers/chatgpt-usage-service.test.ts
@@ -1,0 +1,453 @@
+import { describe, expect, mock, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  LOCAL_CHATGPT_PROVIDER_NAME,
+  setLocalOAuthProvider,
+} from "@/backend/local/local-provider-auth-store";
+import {
+  formatChatGPTUsageQuotaRows,
+  formatChatGPTUsageSnapshot,
+  normalizeWhamUsageResponse,
+  readChatGPTUsage,
+} from "@/providers/chatgpt-usage-service";
+
+async function withEnv<T>(
+  updates: Record<string, string | undefined>,
+  run: () => Promise<T>,
+): Promise<T> {
+  const previous = Object.fromEntries(
+    Object.keys(updates).map((key) => [key, process.env[key]]),
+  );
+  try {
+    for (const [key, value] of Object.entries(updates)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    return await run();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+describe("ChatGPT usage service", () => {
+  test("normalizes WHAM rate limit windows and builds a compact summary", () => {
+    const snapshot = normalizeWhamUsageResponse({
+      providerName: "chatgpt-plus-pro",
+      nowMs: Date.parse("2026-06-18T12:00:00Z"),
+      raw: {
+        plan_type: "plus",
+        rate_limit: {
+          limit_reached: false,
+          primary_window: {
+            used_percent: 25.5,
+            limit_window_seconds: 18_000,
+            reset_after_seconds: 7_200,
+          },
+          secondary_window: {
+            used_percent: 12,
+            limit_window_seconds: 604_800,
+            reset_after_seconds: 432_000,
+          },
+          additional_rate_limits: [
+            {
+              name: "extra",
+              used_percent: 40,
+              window_minutes: 60,
+              reset_after_seconds: 1_800,
+            },
+          ],
+        },
+        credits: {
+          balance: "12.5",
+        },
+      },
+    });
+
+    expect(snapshot.providerName).toBe("chatgpt-plus-pro");
+    expect(snapshot.planType).toBe("plus");
+    expect(snapshot.limitReached).toBe(false);
+    expect(snapshot.primary).toEqual({
+      label: "primary",
+      usedPercent: 25.5,
+      windowDurationMins: 300,
+      resetsAt: 1_781_791_200,
+    });
+    expect(snapshot.secondary?.windowDurationMins).toBe(10_080);
+    expect(snapshot.additional[0]).toEqual({
+      label: "extra",
+      usedPercent: 40,
+      windowDurationMins: 60,
+      resetsAt: 1_781_785_800,
+    });
+    expect(snapshot.credits).toEqual({ balance: "12.5" });
+    expect(snapshot.summary).toBe(
+      "Usage: 5h 74.5% left resets in 2h · 7d 88% left resets in 5d · extra 1h 60% left resets in 30m · credits 12.5",
+    );
+    expect(
+      formatChatGPTUsageQuotaRows(snapshot, new Date("2026-06-18T12:00:00Z")),
+    ).toEqual(["5h 74.5% left resets in 2h", "7d 88% left resets in 5d"]);
+  });
+
+  test("accepts camelCase fields and millisecond reset timestamps", () => {
+    const snapshot = normalizeWhamUsageResponse({
+      providerName: "chatgpt-work",
+      nowMs: Date.parse("2026-06-18T12:00:00Z"),
+      raw: {
+        rateLimit: {
+          primaryWindow: {
+            usedPercent: 100,
+            windowDurationMins: 300,
+            resetsAt: Date.parse("2026-06-18T15:00:00Z"),
+          },
+        },
+        rateLimitReachedType: "primary",
+      },
+    });
+
+    expect(snapshot.rateLimitReachedType).toBe("primary");
+    expect(snapshot.primary?.resetsAt).toBe(1_781_794_800);
+    expect(snapshot.summary).toBe("Usage: 5h 0% left resets in 3h");
+  });
+
+  test("formats an empty usage response without throwing", () => {
+    const snapshot = normalizeWhamUsageResponse({
+      providerName: "chatgpt-plus-pro",
+      nowMs: Date.parse("2026-06-18T12:00:00Z"),
+      raw: {},
+    });
+
+    expect(
+      formatChatGPTUsageSnapshot(snapshot, new Date("2026-06-18T12:00:00Z")),
+    ).toBe("Usage: no active quota window reported");
+  });
+
+  test("normalizes the Codex WHAM usage payload shape", () => {
+    const snapshot = normalizeWhamUsageResponse({
+      providerName: "chatgpt-plus-pro",
+      nowMs: Date.parse("2026-06-18T12:00:00Z"),
+      raw: {
+        plan_type: "pro",
+        rate_limit: {
+          allowed: true,
+          limit_reached: false,
+          primary_window: {
+            used_percent: 42,
+            limit_window_seconds: 300,
+            reset_after_seconds: 0,
+            reset_at: 123,
+          },
+          secondary_window: {
+            used_percent: 84,
+            limit_window_seconds: 3600,
+            reset_after_seconds: 0,
+            reset_at: 456,
+          },
+        },
+        additional_rate_limits: [
+          {
+            limit_name: "codex_other",
+            metered_feature: "codex_other",
+            rate_limit: {
+              allowed: true,
+              limit_reached: false,
+              primary_window: {
+                used_percent: 70,
+                limit_window_seconds: 900,
+                reset_after_seconds: 0,
+                reset_at: 789,
+              },
+            },
+          },
+        ],
+        credits: {
+          has_credits: true,
+          unlimited: false,
+          balance: "9.99",
+        },
+        rate_limit_reset_credits: {
+          available_count: 3,
+        },
+        spend_control: {
+          reached: false,
+          individual_limit: {
+            limit: "25000",
+            used: "8000",
+            remaining: "17000",
+            used_percent: 32,
+            remaining_percent: 68,
+            reset_after_seconds: 3600,
+            reset_at: 789,
+          },
+        },
+        rate_limit_reached_type: {
+          type: "workspace_member_credits_depleted",
+        },
+      },
+    });
+
+    expect(snapshot.planType).toBe("pro");
+    expect(snapshot.limitReached).toBe(false);
+    expect(snapshot.rateLimitReachedType).toBe(
+      "workspace_member_credits_depleted",
+    );
+    expect(snapshot.additional).toEqual([
+      {
+        label: "codex_other",
+        usedPercent: 70,
+        windowDurationMins: 15,
+        resetsAt: 789,
+      },
+    ]);
+    expect(snapshot.credits).toEqual({
+      balance: "9.99",
+      availableCount: 3,
+      hasCredits: true,
+      unlimited: false,
+    });
+    expect(snapshot.individualLimit).toEqual({
+      limit: "25000",
+      used: "8000",
+      remainingPercent: 68,
+      resetsAt: 789,
+    });
+  });
+
+  test("reads api-target usage from the Letta Cloud provider endpoint", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchMock = mock(
+      async (url: Parameters<typeof fetch>[0], init?: RequestInit) => {
+        calls.push({ url: String(url), init });
+        return Response.json({
+          providerName: "chatgpt-jin",
+          fetchedAt: "2026-06-18T12:00:00.000Z",
+          summary: "Usage: 5h 70% left resets in 2h",
+          planType: "plus",
+          limitReached: false,
+          rateLimitReachedType: null,
+          primary: {
+            label: "primary",
+            usedPercent: 30,
+            windowDurationMins: 300,
+            resetsAt: 1_781_791_200,
+          },
+          secondary: null,
+          additional: [],
+          credits: null,
+          individualLimit: {
+            limit: "80",
+            used: "24",
+            remainingPercent: 70,
+            resetsAt: 1_781_791_200,
+          },
+        });
+      },
+    ) as unknown as typeof fetch;
+
+    const result = await withEnv(
+      { LETTA_API_KEY: undefined, LETTA_BASE_URL: undefined },
+      () =>
+        readChatGPTUsage({
+          target: "api",
+          providerName: "chatgpt-jin",
+          forceRefresh: true,
+          fetch: fetchMock,
+          now: () => Date.parse("2026-06-18T12:00:00Z"),
+          getSettings: async () => ({
+            env: {
+              LETTA_API_KEY: "letta-access-token",
+              LETTA_BASE_URL: "https://api.test.letta.com",
+            },
+            refreshToken: undefined,
+            tokenExpiresAt: undefined,
+          }),
+        }),
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error(result.error.message);
+    expect(calls).toHaveLength(1);
+    const call = calls[0];
+    if (!call) throw new Error("Expected usage fetch to be called");
+    expect(call.url).toBe(
+      "https://api.test.letta.com/v1/providers/chatgpt-usage?provider_name=chatgpt-jin",
+    );
+    const headers = new Headers(call.init?.headers);
+    expect(headers.get("authorization")).toBe("Bearer letta-access-token");
+    expect(result.usage.summary).toBe("Usage: 5h 70% left resets in 2h");
+    expect(result.usage.individualLimit).toEqual({
+      limit: "80",
+      used: "24",
+      remainingPercent: 70,
+      resetsAt: 1_781_791_200,
+    });
+  });
+
+  test("maps api-target cloud errors without falling back to local usage", async () => {
+    const fetchMock = mock(async () =>
+      Response.json({ message: "Provider not connected" }, { status: 404 }),
+    ) as unknown as typeof fetch;
+
+    const result = await withEnv(
+      { LETTA_API_KEY: undefined, LETTA_BASE_URL: undefined },
+      () =>
+        readChatGPTUsage({
+          target: "api",
+          providerName: "chatgpt-missing",
+          forceRefresh: true,
+          fetch: fetchMock,
+          getSettings: async () => ({
+            env: {
+              LETTA_API_KEY: "letta-access-token",
+              LETTA_BASE_URL: "https://api.test.letta.com",
+            },
+            refreshToken: undefined,
+            tokenExpiresAt: undefined,
+          }),
+        }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error("Expected cloud usage read to fail");
+    expect(result.error).toEqual({
+      code: "not_connected",
+      message: "Provider not connected",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not treat a missing cloud usage endpoint as a disconnected provider", async () => {
+    const fetchMock = mock(
+      async () => new Response("Not Found", { status: 404 }),
+    ) as unknown as typeof fetch;
+
+    const result = await withEnv(
+      { LETTA_API_KEY: undefined, LETTA_BASE_URL: undefined },
+      () =>
+        readChatGPTUsage({
+          target: "api",
+          providerName: "chatgpt-jin",
+          forceRefresh: true,
+          fetch: fetchMock,
+          getSettings: async () => ({
+            env: {
+              LETTA_API_KEY: "letta-access-token",
+              LETTA_BASE_URL: "https://api.test.letta.com",
+            },
+            refreshToken: undefined,
+            tokenExpiresAt: undefined,
+          }),
+        }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error("Expected cloud usage read to fail");
+    expect(result.error).toEqual({
+      code: "network_error",
+      message: "Letta Cloud ChatGPT usage endpoint is unavailable.",
+    });
+  });
+
+  test("keeps the cloud usage timeout active while reading the response body", async () => {
+    const fetchMock = mock(
+      async (_url: Parameters<typeof fetch>[0], init?: RequestInit) =>
+        ({
+          ok: true,
+          status: 200,
+          json: () =>
+            new Promise((_resolve, reject) => {
+              init?.signal?.addEventListener("abort", () =>
+                reject(new Error("aborted")),
+              );
+            }),
+        }) as Response,
+    ) as unknown as typeof fetch;
+
+    const result = await withEnv(
+      { LETTA_API_KEY: undefined, LETTA_BASE_URL: undefined },
+      () =>
+        readChatGPTUsage({
+          target: "api",
+          providerName: "chatgpt-jin",
+          forceRefresh: true,
+          fetch: fetchMock,
+          timeoutMs: 1,
+          getSettings: async () => ({
+            env: {
+              LETTA_API_KEY: "letta-access-token",
+              LETTA_BASE_URL: "https://api.test.letta.com",
+            },
+            refreshToken: undefined,
+            tokenExpiresAt: undefined,
+          }),
+        }),
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        code: "network_error",
+        message: "Letta Cloud ChatGPT usage request timed out.",
+      },
+    });
+  });
+
+  test("keeps the local WHAM timeout active while reading the response body", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "chatgpt-usage-timeout-"));
+    try {
+      setLocalOAuthProvider({
+        storageDir,
+        providerName: LOCAL_CHATGPT_PROVIDER_NAME,
+        providerType: "chatgpt_oauth",
+        auth: {
+          type: "oauth",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
+          accountId: "account-id",
+        },
+      });
+
+      const fetchMock = mock(
+        async (_url: Parameters<typeof fetch>[0], init?: RequestInit) =>
+          ({
+            ok: true,
+            status: 200,
+            json: () =>
+              new Promise((_resolve, reject) => {
+                init?.signal?.addEventListener("abort", () =>
+                  reject(new Error("aborted")),
+                );
+              }),
+          }) as Response,
+      ) as unknown as typeof fetch;
+
+      const result = await readChatGPTUsage({
+        target: "local",
+        storageDir,
+        fetch: fetchMock,
+        timeoutMs: 1,
+      });
+
+      expect(result).toEqual({
+        success: false,
+        error: {
+          code: "network_error",
+          message: "ChatGPT usage request timed out.",
+        },
+      });
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/providers/chatgpt-usage-service.ts
+++ b/src/providers/chatgpt-usage-service.ts
@@ -1,0 +1,1115 @@
+import { hostname } from "node:os";
+import {
+  LETTA_CLOUD_API_URL,
+  refreshAccessToken as refreshLettaAccessToken,
+  type TokenResponse,
+} from "@/auth/oauth";
+import { getLettaCodeHeaders } from "@/backend/api/http-headers";
+import {
+  getLocalOAuthApiKey,
+  getLocalProviderRecordByName,
+  LOCAL_CHATGPT_PROVIDER_NAME,
+  type LocalProviderRecord,
+} from "@/backend/local/local-provider-auth-store";
+import type { ProviderStorageTarget } from "@/providers/byok-providers";
+import { type Settings, settingsManager } from "@/settings-manager";
+
+const CHATGPT_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
+const CLOUD_CHATGPT_USAGE_PATH = "/v1/providers/chatgpt-usage";
+const OPENAI_CODEX_OAUTH_PROVIDER_ID = "openai-codex";
+const CACHE_TTL_MS = 30_000;
+const DEFAULT_TIMEOUT_MS = 15_000;
+const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+
+export interface ChatGPTUsageWindow {
+  label: string;
+  usedPercent: number | null;
+  windowDurationMins: number | null;
+  resetsAt: number | null;
+}
+
+export interface ChatGPTUsageCredits {
+  balance?: string | null;
+  availableCount?: number | null;
+  hasCredits?: boolean | null;
+  unlimited?: boolean | null;
+}
+
+export interface ChatGPTUsageIndividualLimit {
+  limit: string;
+  used: string;
+  remainingPercent: number;
+  resetsAt: number;
+}
+
+export interface ChatGPTUsageSnapshot {
+  providerName: string;
+  fetchedAt: string;
+  summary: string;
+  planType?: string | null;
+  limitReached?: boolean | null;
+  rateLimitReachedType?: string | null;
+  primary: ChatGPTUsageWindow | null;
+  secondary: ChatGPTUsageWindow | null;
+  additional: ChatGPTUsageWindow[];
+  credits?: ChatGPTUsageCredits | null;
+  individualLimit?: ChatGPTUsageIndividualLimit | null;
+}
+
+export type ChatGPTUsageErrorCode =
+  | "bad_request"
+  | "not_connected"
+  | "unsupported_target"
+  | "refresh_failed"
+  | "unauthorized"
+  | "forbidden"
+  | "rate_limited"
+  | "network_error"
+  | "bad_response";
+
+export interface ChatGPTUsageError {
+  code: ChatGPTUsageErrorCode;
+  message: string;
+  retryAfterMs?: number;
+}
+
+export type ChatGPTUsageReadResult =
+  | { success: true; usage: ChatGPTUsageSnapshot }
+  | { success: false; error: ChatGPTUsageError };
+
+export interface ReadChatGPTUsageInput {
+  target?: ProviderStorageTarget;
+  providerName?: string;
+  forceRefresh?: boolean;
+  storageDir?: string;
+  timeoutMs?: number;
+  fetch?: typeof fetch;
+  now?: () => number;
+  getSettings?: () => Promise<
+    Pick<Settings, "env" | "refreshToken" | "tokenExpiresAt">
+  >;
+  refreshAccessToken?: (
+    refreshToken: string,
+    deviceId: string,
+    deviceName?: string,
+  ) => Promise<TokenResponse>;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+type CachedUsage = {
+  expiresAt: number;
+  result: Extract<ChatGPTUsageReadResult, { success: true }>;
+};
+
+const usageCache = new Map<string, CachedUsage>();
+
+function asRecord(value: unknown): JsonRecord | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : undefined;
+}
+
+function getValue(record: JsonRecord | undefined, keys: string[]): unknown {
+  if (!record) return undefined;
+  for (const key of keys) {
+    const value = record[key];
+    if (value !== undefined && value !== null) return value;
+  }
+  return undefined;
+}
+
+function getRecord(
+  record: JsonRecord | undefined,
+  keys: string[],
+): JsonRecord | undefined {
+  return asRecord(getValue(record, keys));
+}
+
+function getRecordArray(
+  record: JsonRecord | undefined,
+  keys: string[],
+): JsonRecord[] {
+  const value = getValue(record, keys);
+  if (!Array.isArray(value)) return [];
+  return value.map(asRecord).filter((item): item is JsonRecord => !!item);
+}
+
+function getNumber(
+  record: JsonRecord | undefined,
+  keys: string[],
+): number | null {
+  const value = getValue(record, keys);
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function getString(
+  record: JsonRecord | undefined,
+  keys: string[],
+): string | null {
+  const value = getValue(record, keys);
+  if (typeof value === "string" && value.trim()) return value.trim();
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return null;
+}
+
+function getBoolean(
+  record: JsonRecord | undefined,
+  keys: string[],
+): boolean | null {
+  const value = getValue(record, keys);
+  return typeof value === "boolean" ? value : null;
+}
+
+function normalizeTimestampSeconds(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value > 1_000_000_000_000 ? Math.floor(value / 1000) : value;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return normalizeTimestampSeconds(numeric);
+
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return Math.floor(parsed / 1000);
+  }
+  return null;
+}
+
+function getTimestampSeconds(
+  record: JsonRecord | undefined,
+  keys: string[],
+): number | null {
+  return normalizeTimestampSeconds(getValue(record, keys));
+}
+
+function normalizeUsageWindow(
+  value: unknown,
+  label: string,
+  nowMs: number,
+): ChatGPTUsageWindow | null {
+  const record = asRecord(value);
+  if (!record) return null;
+
+  const usedPercent = getNumber(record, [
+    "used_percent",
+    "usedPercent",
+    "used_percentage",
+    "usedPercentage",
+    "percent_used",
+    "percentUsed",
+  ]);
+  const limitWindowSeconds = getNumber(record, [
+    "limit_window_seconds",
+    "limitWindowSeconds",
+  ]);
+  const windowDurationMins =
+    getNumber(record, [
+      "window_duration_minutes",
+      "windowDurationMinutes",
+      "window_duration_mins",
+      "windowDurationMins",
+      "window_minutes",
+      "windowMinutes",
+    ]) ?? (limitWindowSeconds === null ? null : limitWindowSeconds / 60);
+
+  const resetAfterSeconds = getNumber(record, [
+    "reset_after_seconds",
+    "resetAfterSeconds",
+  ]);
+  const resetsAt =
+    getTimestampSeconds(record, [
+      "reset_at",
+      "resetAt",
+      "resets_at",
+      "resetsAt",
+    ]) ??
+    (resetAfterSeconds === null
+      ? null
+      : Math.floor(nowMs / 1000 + resetAfterSeconds));
+
+  if (
+    usedPercent === null &&
+    windowDurationMins === null &&
+    resetsAt === null
+  ) {
+    return null;
+  }
+
+  return {
+    label,
+    usedPercent,
+    windowDurationMins,
+    resetsAt,
+  };
+}
+
+function normalizeCredits(
+  raw: JsonRecord | undefined,
+  rateLimit: JsonRecord | undefined,
+): ChatGPTUsageCredits | null {
+  const credits =
+    getRecord(raw, ["credits", "credit_balance", "creditBalance"]) ??
+    getRecord(rateLimit, [
+      "credits",
+      "credit_balance",
+      "creditBalance",
+      "reset_credits",
+      "resetCredits",
+      "rate_limit_reset_credits",
+      "rateLimitResetCredits",
+    ]);
+  const resetCredits =
+    getRecord(raw, ["rate_limit_reset_credits", "rateLimitResetCredits"]) ??
+    getRecord(rateLimit, ["rate_limit_reset_credits", "rateLimitResetCredits"]);
+  if (!credits && !resetCredits) return null;
+
+  const balance = getString(credits, ["balance", "credit_balance", "amount"]);
+  const availableCount =
+    getNumber(credits, ["available_count", "availableCount", "count"]) ??
+    getNumber(resetCredits, ["available_count", "availableCount", "count"]);
+  const hasCredits = getBoolean(credits, ["has_credits", "hasCredits"]);
+  const unlimited = getBoolean(credits, ["unlimited", "is_unlimited"]);
+
+  if (
+    balance === null &&
+    availableCount === null &&
+    hasCredits === null &&
+    unlimited === null
+  ) {
+    return null;
+  }
+
+  return {
+    ...(balance !== null ? { balance } : {}),
+    ...(availableCount !== null ? { availableCount } : {}),
+    ...(hasCredits !== null ? { hasCredits } : {}),
+    ...(unlimited !== null ? { unlimited } : {}),
+  };
+}
+
+function normalizeIndividualLimit(
+  raw: JsonRecord | undefined,
+  nowMs: number,
+): ChatGPTUsageIndividualLimit | null {
+  const spendControl = getRecord(raw, ["spend_control", "spendControl"]);
+  const record =
+    getRecord(raw, ["individual_limit", "individualLimit"]) ??
+    getRecord(spendControl, ["individual_limit", "individualLimit"]);
+  if (!record) return null;
+
+  const limit = getString(record, ["limit"]);
+  const used = getString(record, ["used"]);
+  const remainingPercent = getNumber(record, [
+    "remaining_percent",
+    "remainingPercent",
+  ]);
+  const resetAfterSeconds = getNumber(record, [
+    "reset_after_seconds",
+    "resetAfterSeconds",
+  ]);
+  const resetsAt =
+    getTimestampSeconds(record, [
+      "reset_at",
+      "resetAt",
+      "resets_at",
+      "resetsAt",
+    ]) ??
+    (resetAfterSeconds === null
+      ? null
+      : Math.floor(nowMs / 1000 + resetAfterSeconds));
+
+  if (
+    limit === null ||
+    used === null ||
+    remainingPercent === null ||
+    resetsAt === null
+  ) {
+    return null;
+  }
+
+  return {
+    limit,
+    used,
+    remainingPercent,
+    resetsAt,
+  };
+}
+
+function normalizeCloudUsageWindow(
+  value: unknown,
+  fallbackLabel: string,
+  nowMs: number,
+): ChatGPTUsageWindow | null {
+  const record = asRecord(value);
+  if (!record) return null;
+  return normalizeUsageWindow(
+    record,
+    getString(record, ["label", "name"]) ?? fallbackLabel,
+    nowMs,
+  );
+}
+
+function normalizeAdditionalRateLimit(
+  details: JsonRecord,
+  index: number,
+  nowMs: number,
+): ChatGPTUsageWindow[] {
+  const label =
+    getString(details, [
+      "limit_name",
+      "limitName",
+      "metered_feature",
+      "meteredFeature",
+      "label",
+      "name",
+      "model",
+      "limit_id",
+      "limitId",
+    ]) ?? `limit ${index + 1}`;
+  const nestedRateLimit = getRecord(details, ["rate_limit", "rateLimit"]);
+  const source = nestedRateLimit ?? details;
+  const primary = normalizeUsageWindow(
+    getValue(source, ["primary_window", "primaryWindow", "primary"]),
+    label,
+    nowMs,
+  );
+  const secondary = normalizeUsageWindow(
+    getValue(source, ["secondary_window", "secondaryWindow", "secondary"]),
+    `${label} secondary`,
+    nowMs,
+  );
+  const direct = nestedRateLimit
+    ? null
+    : normalizeUsageWindow(details, label, nowMs);
+
+  return [primary, secondary, direct].filter(
+    (window): window is ChatGPTUsageWindow => !!window,
+  );
+}
+
+function getRateLimitReachedType(raw: JsonRecord | undefined): string | null {
+  const value = getValue(raw, [
+    "rate_limit_reached_type",
+    "rateLimitReachedType",
+  ]);
+  if (typeof value === "string" && value.trim()) return value.trim();
+
+  const record = asRecord(value);
+  return getString(record, ["type", "kind"]);
+}
+
+function formatPercent(value: number): string {
+  const rounded = Math.round(value);
+  return Number.isInteger(value) || Math.abs(value - rounded) < 0.05
+    ? String(rounded)
+    : value.toFixed(1);
+}
+
+function formatDuration(minutes: number | null): string | null {
+  if (minutes === null || !Number.isFinite(minutes) || minutes <= 0) {
+    return null;
+  }
+  if (minutes % 1440 === 0) return `${minutes / 1440}d`;
+  if (minutes % 60 === 0) return `${minutes / 60}h`;
+  return `${Math.round(minutes)}m`;
+}
+
+function formatResetDistance(
+  resetsAt: number | null,
+  now: Date,
+): string | null {
+  if (resetsAt === null) return null;
+  const deltaMs = resetsAt * 1000 - now.getTime();
+  if (deltaMs <= 0) return "now";
+
+  const minutes = Math.ceil(deltaMs / 60_000);
+  if (minutes < 60) return `in ${minutes}m`;
+
+  const hours = Math.ceil(minutes / 60);
+  if (hours < 48) return `in ${hours}h`;
+
+  return `in ${Math.ceil(hours / 24)}d`;
+}
+
+function formatWindowLabel(window: ChatGPTUsageWindow): string {
+  const duration = formatDuration(window.windowDurationMins);
+  if (duration) return duration;
+  return window.label;
+}
+
+function formatNamedWindowLabel(window: ChatGPTUsageWindow): string {
+  const normalizedLabel = window.label.replace(/_/g, " ").trim();
+  const duration = formatDuration(window.windowDurationMins);
+  return duration ? `${normalizedLabel} ${duration}` : normalizedLabel;
+}
+
+function formatUsageWindow(
+  window: ChatGPTUsageWindow | null,
+  now: Date,
+  options: { includeName?: boolean } = {},
+): string | null {
+  if (!window) return null;
+
+  const label = options.includeName
+    ? formatNamedWindowLabel(window)
+    : formatWindowLabel(window);
+  const parts: string[] = [label];
+  if (window.usedPercent !== null) {
+    const remaining = Math.max(0, 100 - window.usedPercent);
+    parts.push(`${formatPercent(remaining)}% left`);
+  }
+
+  const resetDistance = formatResetDistance(window.resetsAt, now);
+  if (resetDistance) parts.push(`resets ${resetDistance}`);
+
+  return parts.join(" ");
+}
+
+function formatCredits(
+  credits: ChatGPTUsageCredits | null | undefined,
+): string | null {
+  if (!credits) return null;
+  if (credits.unlimited) return "credits unlimited";
+  if (typeof credits.availableCount === "number") {
+    return `credits ${formatPercent(credits.availableCount)}`;
+  }
+  if (credits.balance) return `credits ${credits.balance}`;
+  if (credits.hasCredits !== null && credits.hasCredits !== undefined) {
+    return credits.hasCredits ? "credits available" : "no credits";
+  }
+  return null;
+}
+
+export function formatChatGPTUsageSnapshot(
+  snapshot: Omit<ChatGPTUsageSnapshot, "summary">,
+  now: Date = new Date(),
+): string {
+  const windows = [
+    formatUsageWindow(snapshot.primary, now),
+    formatUsageWindow(snapshot.secondary, now),
+    ...snapshot.additional.map((window) =>
+      formatUsageWindow(window, now, { includeName: true }),
+    ),
+  ].filter((item): item is string => !!item);
+
+  const credits = formatCredits(snapshot.credits);
+  if (credits) windows.push(credits);
+
+  if (windows.length === 0) {
+    return "Usage: no active quota window reported";
+  }
+  return `Usage: ${windows.join(" · ")}`;
+}
+
+export function formatChatGPTUsageQuotaRows(
+  snapshot: ChatGPTUsageSnapshot,
+  now: Date = new Date(),
+): string[] {
+  const rows = [
+    formatUsageWindow(snapshot.primary, now),
+    formatUsageWindow(snapshot.secondary, now),
+  ].filter((item): item is string => !!item);
+
+  return rows.length > 0 ? rows : [snapshot.summary.replace(/^Usage:\s*/, "")];
+}
+
+export function normalizeWhamUsageResponse(input: {
+  raw: unknown;
+  providerName: string;
+  nowMs?: number;
+}): ChatGPTUsageSnapshot {
+  const raw = asRecord(input.raw);
+  const nowMs = input.nowMs ?? Date.now();
+  const fetchedAt = new Date(nowMs).toISOString();
+  const rateLimit =
+    getRecord(raw, ["rate_limit", "rateLimit", "rate_limits", "rateLimits"]) ??
+    raw;
+  const primary = normalizeUsageWindow(
+    getValue(rateLimit, ["primary_window", "primaryWindow", "primary"]),
+    "primary",
+    nowMs,
+  );
+  const secondary = normalizeUsageWindow(
+    getValue(rateLimit, ["secondary_window", "secondaryWindow", "secondary"]),
+    "secondary",
+    nowMs,
+  );
+  const additionalSources = [
+    ...getRecordArray(raw, [
+      "additional_rate_limits",
+      "additionalRateLimits",
+      "additional",
+    ]),
+    ...(raw === rateLimit
+      ? []
+      : getRecordArray(rateLimit, [
+          "additional_rate_limits",
+          "additionalRateLimits",
+          "additional",
+        ])),
+  ];
+  const additional = additionalSources.flatMap((details, index) =>
+    normalizeAdditionalRateLimit(details, index, nowMs),
+  );
+  const spendControl = getRecord(raw, ["spend_control", "spendControl"]);
+
+  const snapshotWithoutSummary = {
+    providerName: input.providerName,
+    fetchedAt,
+    planType: getString(raw, ["plan_type", "planType"]),
+    limitReached:
+      getBoolean(rateLimit, ["limit_reached", "limitReached"]) ??
+      getBoolean(spendControl, ["reached"]),
+    rateLimitReachedType: getRateLimitReachedType(raw),
+    primary,
+    secondary,
+    additional,
+    credits: normalizeCredits(raw, rateLimit),
+    individualLimit: normalizeIndividualLimit(raw, nowMs),
+  };
+
+  return {
+    ...snapshotWithoutSummary,
+    summary: formatChatGPTUsageSnapshot(
+      snapshotWithoutSummary,
+      new Date(nowMs),
+    ),
+  };
+}
+
+export function normalizeCloudChatGPTUsageResponse(input: {
+  raw: unknown;
+  providerName: string;
+  nowMs?: number;
+}): ChatGPTUsageSnapshot | null {
+  const raw = asRecord(input.raw);
+  if (!raw) return null;
+
+  const nowMs = input.nowMs ?? Date.now();
+  const fetchedAt =
+    getString(raw, ["fetchedAt", "fetched_at"]) ??
+    new Date(nowMs).toISOString();
+  const additional = getRecordArray(raw, [
+    "additional",
+    "additional_rate_limits",
+    "additionalRateLimits",
+  ])
+    .map((window, index) =>
+      normalizeCloudUsageWindow(window, `limit ${index + 1}`, nowMs),
+    )
+    .filter((window): window is ChatGPTUsageWindow => !!window);
+
+  const snapshotWithoutSummary = {
+    providerName:
+      getString(raw, ["providerName", "provider_name"]) ?? input.providerName,
+    fetchedAt,
+    planType: getString(raw, ["planType", "plan_type"]),
+    limitReached: getBoolean(raw, ["limitReached", "limit_reached"]),
+    rateLimitReachedType: getString(raw, [
+      "rateLimitReachedType",
+      "rate_limit_reached_type",
+    ]),
+    primary: normalizeCloudUsageWindow(
+      getValue(raw, ["primary", "primary_window", "primaryWindow"]),
+      "primary",
+      nowMs,
+    ),
+    secondary: normalizeCloudUsageWindow(
+      getValue(raw, ["secondary", "secondary_window", "secondaryWindow"]),
+      "secondary",
+      nowMs,
+    ),
+    additional,
+    credits: normalizeCredits(raw, raw),
+    individualLimit: normalizeIndividualLimit(raw, nowMs),
+  };
+
+  return {
+    ...snapshotWithoutSummary,
+    summary:
+      getString(raw, ["summary"]) ??
+      formatChatGPTUsageSnapshot(snapshotWithoutSummary, new Date(nowMs)),
+  };
+}
+
+function retryAfterMs(response: Response): number | undefined {
+  const value = response.headers.get("retry-after");
+  if (!value) return undefined;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+
+  const retryAt = Date.parse(value);
+  return Number.isFinite(retryAt)
+    ? Math.max(0, retryAt - Date.now())
+    : undefined;
+}
+
+function retryAfterMsFromBody(raw: JsonRecord | null): number | undefined {
+  const value = getNumber(raw ?? undefined, ["retryAfterMs", "retry_after_ms"]);
+  return value === null ? undefined : Math.max(0, value);
+}
+
+async function readJsonRecord(response: Response): Promise<JsonRecord | null> {
+  try {
+    return asRecord(await response.json()) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function responseMessage(raw: JsonRecord | null, fallback: string): string {
+  return (
+    getString(raw ?? undefined, ["message", "error", "detail"]) ?? fallback
+  );
+}
+
+function chatGPTUsageError(
+  code: ChatGPTUsageErrorCode,
+  message: string,
+  retryAfter?: number,
+): ChatGPTUsageReadResult {
+  return {
+    success: false,
+    error: {
+      code,
+      message,
+      ...(retryAfter !== undefined ? { retryAfterMs: retryAfter } : {}),
+    },
+  };
+}
+
+function cloudBaseUrl(settings: Pick<Settings, "env">): string {
+  return (
+    process.env.LETTA_BASE_URL ||
+    settings.env?.LETTA_BASE_URL ||
+    LETTA_CLOUD_API_URL
+  ).replace(/\/+$/, "");
+}
+
+async function cloudApiKey(input: {
+  settings: Pick<Settings, "env" | "refreshToken" | "tokenExpiresAt">;
+  now: number;
+  refreshAccessToken?: ReadChatGPTUsageInput["refreshAccessToken"];
+}): Promise<{ apiKey: string | null; error?: ChatGPTUsageError }> {
+  const settings = input.settings;
+  const envApiKey = process.env.LETTA_API_KEY;
+  let apiKey = envApiKey || settings.env?.LETTA_API_KEY || null;
+
+  if (
+    !envApiKey &&
+    settings.refreshToken &&
+    (!apiKey ||
+      (settings.tokenExpiresAt !== undefined &&
+        settings.tokenExpiresAt - input.now < TOKEN_REFRESH_BUFFER_MS))
+  ) {
+    try {
+      const refresh = input.refreshAccessToken ?? refreshLettaAccessToken;
+      const tokens = await refresh(
+        settings.refreshToken,
+        settingsManager.getOrCreateDeviceId(),
+        hostname(),
+      );
+      apiKey = tokens.access_token;
+      settingsManager.updateSettings({
+        env: { LETTA_API_KEY: tokens.access_token },
+        refreshToken: tokens.refresh_token || settings.refreshToken,
+        tokenExpiresAt: input.now + tokens.expires_in * 1000,
+      });
+    } catch (error) {
+      return {
+        apiKey: null,
+        error: {
+          code: "refresh_failed",
+          message:
+            error instanceof Error
+              ? error.message
+              : "Failed to refresh the Letta Cloud access token.",
+        },
+      };
+    }
+  }
+
+  if (!apiKey) {
+    return {
+      apiKey: null,
+      error: {
+        code: "unauthorized",
+        message: "Sign in to Letta Cloud to read ChatGPT usage.",
+      },
+    };
+  }
+
+  return { apiKey };
+}
+
+function localProviderNames(providerName: string | undefined): string[] {
+  if (providerName?.trim()) return [providerName.trim()];
+  return [LOCAL_CHATGPT_PROVIDER_NAME, OPENAI_CODEX_OAUTH_PROVIDER_ID];
+}
+
+function isChatGPTOAuthRecord(
+  record: LocalProviderRecord,
+): record is LocalProviderRecord & {
+  auth: { type: "oauth"; accountId?: string };
+} {
+  return (
+    record.auth.type === "oauth" &&
+    (record.provider_type === "chatgpt_oauth" ||
+      record.provider_type === OPENAI_CODEX_OAUTH_PROVIDER_ID)
+  );
+}
+
+function isConnectedChatGPTOAuthRecord(
+  record: LocalProviderRecord | null,
+): record is LocalProviderRecord & {
+  auth: { type: "oauth"; accountId?: string };
+} {
+  return !!record && isChatGPTOAuthRecord(record);
+}
+
+async function readCloudChatGPTUsage(
+  input: ReadChatGPTUsageInput,
+  now: number,
+): Promise<ChatGPTUsageReadResult> {
+  const providerName = input.providerName?.trim();
+  if (!providerName) {
+    return chatGPTUsageError(
+      "bad_request",
+      "A ChatGPT provider name is required for cloud usage.",
+    );
+  }
+
+  let settings: Pick<Settings, "env" | "refreshToken" | "tokenExpiresAt">;
+  try {
+    settings = await (
+      input.getSettings ?? (() => settingsManager.getSettingsWithSecureTokens())
+    )();
+  } catch (error) {
+    return chatGPTUsageError(
+      "unauthorized",
+      error instanceof Error
+        ? error.message
+        : "Failed to read Letta Cloud credentials.",
+    );
+  }
+
+  const baseUrl = cloudBaseUrl(settings);
+  const cacheKey = `api:${baseUrl}:${providerName}`;
+  const cached = usageCache.get(cacheKey);
+  if (!input.forceRefresh && cached && cached.expiresAt > now) {
+    return cached.result;
+  }
+
+  const auth = await cloudApiKey({
+    settings,
+    now,
+    refreshAccessToken: input.refreshAccessToken,
+  });
+  if (auth.error || !auth.apiKey) {
+    return {
+      success: false,
+      error: auth.error ?? {
+        code: "unauthorized",
+        message: "Sign in to Letta Cloud to read ChatGPT usage.",
+      },
+    };
+  }
+
+  const url = new URL(`${baseUrl}${CLOUD_CHATGPT_USAGE_PATH}`);
+  url.searchParams.set("provider_name", providerName);
+
+  const controller = new AbortController();
+  let didTimeOut = false;
+  const timeout = setTimeout(() => {
+    didTimeOut = true;
+    controller.abort();
+  }, input.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await (input.fetch ?? fetch)(url, {
+      method: "GET",
+      headers: {
+        ...getLettaCodeHeaders(auth.apiKey),
+        Accept: "application/json",
+      },
+      signal: controller.signal,
+    });
+  } catch (error) {
+    clearTimeout(timeout);
+    return chatGPTUsageError(
+      "network_error",
+      didTimeOut
+        ? "Letta Cloud ChatGPT usage request timed out."
+        : error instanceof Error
+          ? error.message
+          : "Failed to fetch ChatGPT usage from Letta Cloud.",
+    );
+  }
+
+  try {
+    if (response.status === 400) {
+      const raw = await readJsonRecord(response);
+      return chatGPTUsageError(
+        didTimeOut ? "network_error" : "bad_request",
+        didTimeOut
+          ? "Letta Cloud ChatGPT usage request timed out."
+          : responseMessage(
+              raw,
+              "Letta Cloud rejected the ChatGPT usage request.",
+            ),
+      );
+    }
+    if (response.status === 401) {
+      const raw = await readJsonRecord(response);
+      return chatGPTUsageError(
+        didTimeOut ? "network_error" : "unauthorized",
+        didTimeOut
+          ? "Letta Cloud ChatGPT usage request timed out."
+          : responseMessage(
+              raw,
+              "Sign in to Letta Cloud to read ChatGPT usage.",
+            ),
+      );
+    }
+    if (response.status === 403) {
+      const raw = await readJsonRecord(response);
+      return chatGPTUsageError(
+        didTimeOut ? "network_error" : "forbidden",
+        didTimeOut
+          ? "Letta Cloud ChatGPT usage request timed out."
+          : responseMessage(
+              raw,
+              "ChatGPT usage is not available for this account.",
+            ),
+      );
+    }
+    if (response.status === 404) {
+      const raw = await readJsonRecord(response);
+      if (didTimeOut) {
+        return chatGPTUsageError(
+          "network_error",
+          "Letta Cloud ChatGPT usage request timed out.",
+        );
+      }
+      if (!raw) {
+        return chatGPTUsageError(
+          "network_error",
+          "Letta Cloud ChatGPT usage endpoint is unavailable.",
+        );
+      }
+      return chatGPTUsageError(
+        "not_connected",
+        responseMessage(raw, "No cloud ChatGPT OAuth provider is connected."),
+      );
+    }
+    if (response.status === 429) {
+      const raw = await readJsonRecord(response);
+      return chatGPTUsageError(
+        "rate_limited",
+        didTimeOut
+          ? "Letta Cloud ChatGPT usage request timed out."
+          : responseMessage(
+              raw,
+              "ChatGPT usage is rate limited. Try again later.",
+            ),
+        retryAfterMsFromBody(raw) ?? retryAfterMs(response),
+      );
+    }
+    if (!response.ok) {
+      const raw = await readJsonRecord(response);
+      return chatGPTUsageError(
+        "network_error",
+        didTimeOut
+          ? "Letta Cloud ChatGPT usage request timed out."
+          : responseMessage(
+              raw,
+              `Letta Cloud ChatGPT usage request failed with HTTP ${response.status}.`,
+            ),
+      );
+    }
+
+    const raw = await readJsonRecord(response);
+    if (!raw) {
+      return chatGPTUsageError(
+        didTimeOut ? "network_error" : "bad_response",
+        didTimeOut
+          ? "Letta Cloud ChatGPT usage request timed out."
+          : "Letta Cloud ChatGPT usage returned invalid JSON.",
+      );
+    }
+
+    const usage = normalizeCloudChatGPTUsageResponse({
+      raw,
+      providerName,
+      nowMs: now,
+    });
+    if (!usage) {
+      return chatGPTUsageError(
+        "bad_response",
+        "Letta Cloud ChatGPT usage returned an invalid payload.",
+      );
+    }
+
+    const result: Extract<ChatGPTUsageReadResult, { success: true }> = {
+      success: true,
+      usage,
+    };
+    usageCache.set(cacheKey, { expiresAt: now + CACHE_TTL_MS, result });
+    return result;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function readChatGPTUsage(
+  input: ReadChatGPTUsageInput = {},
+): Promise<ChatGPTUsageReadResult> {
+  const target = input.target ?? "local";
+  const now = input.now?.() ?? Date.now();
+  if (target === "api") {
+    return readCloudChatGPTUsage(input, now);
+  }
+  if (target !== "local") {
+    return chatGPTUsageError(
+      "unsupported_target",
+      "ChatGPT usage is only available for local or cloud ChatGPT OAuth providers.",
+    );
+  }
+
+  const providerNames = localProviderNames(input.providerName);
+  const record = providerNames
+    .map((name) => getLocalProviderRecordByName(name, input.storageDir))
+    .find(isConnectedChatGPTOAuthRecord);
+
+  if (!record) {
+    return chatGPTUsageError(
+      "not_connected",
+      "No local ChatGPT OAuth provider is connected.",
+    );
+  }
+
+  const cacheKey = `${target}:${record.name}`;
+  const cached = usageCache.get(cacheKey);
+  if (!input.forceRefresh && cached && cached.expiresAt > now) {
+    return cached.result;
+  }
+
+  let oauthApiKey: Awaited<ReturnType<typeof getLocalOAuthApiKey>>;
+  try {
+    oauthApiKey = await getLocalOAuthApiKey({
+      providerId: OPENAI_CODEX_OAUTH_PROVIDER_ID,
+      providerNames: [record.name],
+      storageDir: input.storageDir,
+    });
+  } catch (error) {
+    return chatGPTUsageError(
+      "refresh_failed",
+      error instanceof Error
+        ? error.message
+        : "Failed to refresh the ChatGPT OAuth token.",
+    );
+  }
+
+  if (!oauthApiKey) {
+    return chatGPTUsageError(
+      "not_connected",
+      "No local ChatGPT OAuth token is available.",
+    );
+  }
+
+  const accountId =
+    typeof oauthApiKey.credentials.accountId === "string"
+      ? oauthApiKey.credentials.accountId
+      : typeof record.auth.accountId === "string"
+        ? record.auth.accountId
+        : undefined;
+  const controller = new AbortController();
+  let didTimeOut = false;
+  const timeout = setTimeout(() => {
+    didTimeOut = true;
+    controller.abort();
+  }, input.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await (input.fetch ?? fetch)(CHATGPT_USAGE_URL, {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${oauthApiKey.apiKey}`,
+        "User-Agent": "letta-code",
+        ...(accountId ? { "chatgpt-account-id": accountId } : {}),
+      },
+      signal: controller.signal,
+    });
+  } catch (error) {
+    clearTimeout(timeout);
+    return chatGPTUsageError(
+      "network_error",
+      didTimeOut
+        ? "ChatGPT usage request timed out."
+        : error instanceof Error
+          ? error.message
+          : "Failed to fetch ChatGPT usage.",
+    );
+  }
+
+  try {
+    if (response.status === 401) {
+      return chatGPTUsageError(
+        "unauthorized",
+        "ChatGPT rejected the OAuth token. Reconnect ChatGPT Plus/Pro and try again.",
+      );
+    }
+    if (response.status === 403) {
+      return chatGPTUsageError(
+        "forbidden",
+        "ChatGPT usage is not available for this account.",
+      );
+    }
+    if (response.status === 429) {
+      return chatGPTUsageError(
+        "rate_limited",
+        "ChatGPT usage is rate limited. Try again later.",
+        retryAfterMs(response),
+      );
+    }
+    if (!response.ok) {
+      return chatGPTUsageError(
+        "network_error",
+        `ChatGPT usage request failed with HTTP ${response.status}.`,
+      );
+    }
+
+    let raw: unknown;
+    try {
+      raw = await response.json();
+    } catch {
+      return chatGPTUsageError(
+        didTimeOut ? "network_error" : "bad_response",
+        didTimeOut
+          ? "ChatGPT usage request timed out."
+          : "ChatGPT usage returned invalid JSON.",
+      );
+    }
+
+    const result: Extract<ChatGPTUsageReadResult, { success: true }> = {
+      success: true,
+      usage: normalizeWhamUsageResponse({
+        raw,
+        providerName: record.name,
+        nowMs: now,
+      }),
+    };
+    usageCache.set(cacheKey, { expiresAt: now + CACHE_TTL_MS, result });
+    return result;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/providers/connect-provider-service.test.ts
+++ b/src/providers/connect-provider-service.test.ts
@@ -39,6 +39,7 @@ describe("connect provider service", () => {
           },
         ],
         connected: { is_connected: false },
+        connected_providers: [],
       },
     ]);
     expect(JSON.stringify(entries)).not.toContain("secret-value");
@@ -85,6 +86,7 @@ describe("connect provider service", () => {
     const entries = buildConnectProviderEntries(providers, connected, "local");
 
     expect(entries[0]?.connected).toEqual({ is_connected: false });
+    expect(entries[0]?.connected_providers).toEqual([]);
     expect(entries[1]?.connected).toEqual({
       is_connected: true,
       id: "local-provider-lc-anthropic",
@@ -94,8 +96,109 @@ describe("connect provider service", () => {
       base_url: "https://example.test",
       region: "us-east-1",
     });
+    expect(entries[1]?.connected_providers).toEqual([
+      {
+        is_connected: true,
+        id: "local-provider-lc-anthropic",
+        provider_name: "lc-anthropic",
+        provider_type: "anthropic",
+        auth_type: "api",
+        base_url: "https://example.test",
+        region: "us-east-1",
+      },
+    ]);
     expect(JSON.stringify(entries)).not.toContain("secret-value");
     expect(JSON.stringify(entries)).not.toContain("secret-access-key");
+  });
+
+  test("marks ChatGPT OAuth aliases connected by provider type", () => {
+    const providers: ByokProvider[] = [
+      {
+        id: "codex",
+        displayName: "ChatGPT / Codex plan",
+        description: "Connect your ChatGPT coding plan",
+        providerType: "chatgpt_oauth",
+        providerName: "chatgpt-plus-pro",
+        isOAuth: true,
+      },
+    ];
+    const connected = new Map<string, ProviderResponse>([
+      [
+        "openai",
+        {
+          id: "provider-base-openai",
+          name: "openai",
+          provider_type: "openai",
+          provider_category: "base",
+        },
+      ],
+      [
+        "chatgpt-work",
+        {
+          id: "provider-chatgpt-work",
+          name: "chatgpt-work",
+          provider_type: "chatgpt_oauth",
+          provider_category: "byok",
+        },
+      ],
+    ]);
+
+    const [entry] = buildConnectProviderEntries(providers, connected, "api");
+
+    expect(entry?.connected).toEqual({
+      is_connected: true,
+      id: "provider-chatgpt-work",
+      provider_name: "chatgpt-work",
+      provider_type: "chatgpt_oauth",
+    });
+    expect(entry?.connected_providers).toEqual([
+      {
+        is_connected: true,
+        id: "provider-chatgpt-work",
+        provider_name: "chatgpt-work",
+        provider_type: "chatgpt_oauth",
+      },
+    ]);
+  });
+
+  test("lists all connected aliases while preserving the built-in name first", () => {
+    const providers: ByokProvider[] = [
+      {
+        id: "codex",
+        displayName: "ChatGPT / Codex plan",
+        description: "Connect your ChatGPT coding plan",
+        providerType: "chatgpt_oauth",
+        providerName: "chatgpt-plus-pro",
+        isOAuth: true,
+      },
+    ];
+    const connected = new Map<string, ProviderResponse>([
+      [
+        "chatgpt-work",
+        {
+          id: "provider-chatgpt-work",
+          name: "chatgpt-work",
+          provider_type: "chatgpt_oauth",
+          provider_category: "byok",
+        },
+      ],
+      [
+        "chatgpt-plus-pro",
+        {
+          id: "provider-chatgpt-plus-pro",
+          name: "chatgpt-plus-pro",
+          provider_type: "chatgpt_oauth",
+          provider_category: "byok",
+        },
+      ],
+    ]);
+
+    const [entry] = buildConnectProviderEntries(providers, connected, "api");
+
+    expect(entry?.connected.provider_name).toBe("chatgpt-plus-pro");
+    expect(
+      entry?.connected_providers.map((provider) => provider.provider_name),
+    ).toEqual(["chatgpt-plus-pro", "chatgpt-work"]);
   });
 
   test("serializes auth methods instead of default fields", () => {

--- a/src/providers/connect-provider-service.ts
+++ b/src/providers/connect-provider-service.ts
@@ -13,6 +13,10 @@ import {
   type ProviderStorageTarget,
   removeProviderByName,
 } from "@/providers/byok-providers";
+import {
+  connectedRecordsForProvider,
+  uniqueProviderNames,
+} from "@/providers/provider-connections";
 
 export interface ConnectProviderField {
   key: string;
@@ -53,6 +57,7 @@ export interface ConnectProviderEntry {
   fields?: ConnectProviderField[];
   auth_methods?: ConnectProviderAuthMethod[];
   connected: ConnectProviderConnectionState;
+  connected_providers: ConnectProviderConnectionState[];
 }
 
 export interface ListConnectProvidersResult<
@@ -76,6 +81,7 @@ export interface DisconnectProviderInput<
 > {
   target: TTarget;
   providerId: string;
+  providerName?: string;
 }
 
 export interface ResolvedProviderConnectionFields {
@@ -84,38 +90,6 @@ export interface ResolvedProviderConnectionFields {
   region?: string;
   profile?: string;
   options: ProviderConnectionOptions;
-}
-
-function uniqueProviderNames(provider: ByokProvider): string[] {
-  return [
-    ...new Set([provider.providerName, ...(provider.providerNames ?? [])]),
-  ];
-}
-
-function providerIsConnectedToRecord(
-  provider: ByokProvider,
-  record: ProviderResponse | undefined,
-  target: ProviderStorageTarget,
-): record is ProviderResponse {
-  if (!record) return false;
-  if (target !== "local" || !record.auth_type) return true;
-  return provider.isOAuth === true
-    ? record.auth_type === "oauth"
-    : record.auth_type !== "oauth";
-}
-
-function connectedRecordForProvider(
-  provider: ByokProvider,
-  connectedProviders: ReadonlyMap<string, ProviderResponse>,
-  target: ProviderStorageTarget,
-): ProviderResponse | undefined {
-  for (const providerName of uniqueProviderNames(provider)) {
-    const record = connectedProviders.get(providerName);
-    if (providerIsConnectedToRecord(provider, record, target)) {
-      return record;
-    }
-  }
-  return undefined;
 }
 
 function serializeConnectedProvider(
@@ -272,11 +246,12 @@ export function buildConnectProviderEntries(
   target: ProviderStorageTarget,
 ): ConnectProviderEntry[] {
   return providers.map((provider) => {
-    const connected = connectedRecordForProvider(
+    const connectedRecords = connectedRecordsForProvider(
       provider,
       connectedProviders,
       target,
     );
+    const connected = connectedRecords[0];
     const fields = fieldsForProvider(provider);
     return {
       id: provider.id,
@@ -295,6 +270,7 @@ export function buildConnectProviderEntries(
         ? { auth_methods: serializeAuthMethods(provider.authMethods) }
         : {}),
       connected: serializeConnectedProvider(connected),
+      connected_providers: connectedRecords.map(serializeConnectedProvider),
     };
   });
 }
@@ -358,11 +334,14 @@ export async function disconnectProvider<TTarget extends ProviderStorageTarget>(
   const connectedProviders = await getConnectedProviders({
     target: input.target,
   });
-  const connected = connectedRecordForProvider(
+  const connectedRecords = connectedRecordsForProvider(
     provider,
     connectedProviders,
     input.target,
   );
+  const connected = input.providerName
+    ? connectedRecords.find((record) => record.name === input.providerName)
+    : connectedRecords[0];
   if (connected) {
     await removeProviderByName(connected.name, { target: input.target });
   }

--- a/src/providers/openai-codex-provider.ts
+++ b/src/providers/openai-codex-provider.ts
@@ -19,8 +19,25 @@ export { listProviders };
 // Provider name constant for letta-code's ChatGPT OAuth provider
 export const OPENAI_CODEX_PROVIDER_NAME = "chatgpt-plus-pro";
 
+const CHATGPT_OAUTH_PROVIDER_NAME_PATTERN = /^[A-Za-z0-9._-]+$/;
+
 // Provider type for ChatGPT OAuth (backend handles transformation)
 export const CHATGPT_OAUTH_PROVIDER_TYPE = "chatgpt_oauth";
+
+export function normalizeChatGPTOAuthProviderName(
+  providerName?: string | null,
+): string {
+  const normalized = (providerName ?? OPENAI_CODEX_PROVIDER_NAME).trim();
+  if (!normalized) {
+    throw new Error("ChatGPT provider name cannot be empty.");
+  }
+  if (!CHATGPT_OAUTH_PROVIDER_NAME_PATTERN.test(normalized)) {
+    throw new Error(
+      "ChatGPT provider name may only contain letters, numbers, dots, underscores, and hyphens.",
+    );
+  }
+  return normalized;
+}
 
 /**
  * ChatGPT OAuth configuration persisted by the active provider store.
@@ -54,8 +71,12 @@ function encodeOAuthConfig(config: ChatGPTOAuthConfig): string {
  */
 export async function getOpenAICodexProvider(
   options: ProviderOperationOptions = {},
+  providerName: string = OPENAI_CODEX_PROVIDER_NAME,
 ): Promise<ProviderResponse | null> {
-  return getProviderByName(OPENAI_CODEX_PROVIDER_NAME, options);
+  return getProviderByName(
+    normalizeChatGPTOAuthProviderName(providerName),
+    options,
+  );
 }
 
 /**
@@ -65,10 +86,11 @@ export async function getOpenAICodexProvider(
 export async function createOpenAICodexProvider(
   config: ChatGPTOAuthConfig,
   options: ProviderOperationOptions = {},
+  providerName: string = OPENAI_CODEX_PROVIDER_NAME,
 ): Promise<ProviderResponse> {
   return createProvider(
     CHATGPT_OAUTH_PROVIDER_TYPE,
-    OPENAI_CODEX_PROVIDER_NAME,
+    normalizeChatGPTOAuthProviderName(providerName),
     encodeOAuthConfig(config),
     undefined,
     undefined,
@@ -111,14 +133,25 @@ export async function updateOpenAICodexProvider(
 export async function createOrUpdateOpenAICodexProvider(
   config: ChatGPTOAuthConfig,
   options: ProviderOperationOptions = {},
+  providerName: string = OPENAI_CODEX_PROVIDER_NAME,
 ): Promise<ProviderResponse> {
-  const existing = await getOpenAICodexProvider(options);
+  const normalizedProviderName =
+    normalizeChatGPTOAuthProviderName(providerName);
+  const existing = await getOpenAICodexProvider(
+    options,
+    normalizedProviderName,
+  );
 
   if (existing) {
+    if (existing.provider_type !== CHATGPT_OAUTH_PROVIDER_TYPE) {
+      throw new Error(
+        `Provider '${normalizedProviderName}' already exists with type '${existing.provider_type}'. Choose a different ChatGPT provider name.`,
+      );
+    }
     return updateOpenAICodexProvider(existing.id, config, options);
   }
 
-  return createOpenAICodexProvider(config, options);
+  return createOpenAICodexProvider(config, options, normalizedProviderName);
 }
 
 /**

--- a/src/providers/provider-connections.test.ts
+++ b/src/providers/provider-connections.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import type { ProviderResponse } from "@/backend/api/providers";
+import type { ByokProvider } from "@/providers/byok-providers";
+import { connectedRecordsForProvider } from "@/providers/provider-connections";
+
+function providerRecord(
+  name: string,
+  providerType: string,
+  input: Partial<ProviderResponse> = {},
+): ProviderResponse {
+  return {
+    id: `provider-${name}`,
+    name,
+    provider_type: providerType,
+    provider_category: "byok",
+    ...input,
+  };
+}
+
+describe("provider connections", () => {
+  test("matches named ChatGPT OAuth providers by provider type", () => {
+    const provider: ByokProvider = {
+      id: "codex",
+      displayName: "ChatGPT / Codex plan",
+      description: "Connect your ChatGPT coding plan",
+      providerType: "chatgpt_oauth",
+      providerName: "chatgpt-plus-pro",
+      isOAuth: true,
+    };
+    const connectedProviders = new Map<string, ProviderResponse>([
+      [
+        "openai",
+        providerRecord("openai", "openai", { provider_category: "base" }),
+      ],
+      ["chatgpt-work", providerRecord("chatgpt-work", "chatgpt_oauth")],
+    ]);
+
+    expect(
+      connectedRecordsForProvider(provider, connectedProviders, "api").map(
+        (record) => record.name,
+      ),
+    ).toEqual(["chatgpt-work"]);
+  });
+
+  test("preserves exact provider names before same-type aliases", () => {
+    const provider: ByokProvider = {
+      id: "codex",
+      displayName: "ChatGPT / Codex plan",
+      description: "Connect your ChatGPT coding plan",
+      providerType: "chatgpt_oauth",
+      providerName: "chatgpt-plus-pro",
+      isOAuth: true,
+    };
+    const connectedProviders = new Map<string, ProviderResponse>([
+      ["chatgpt-work", providerRecord("chatgpt-work", "chatgpt_oauth")],
+      ["chatgpt-plus-pro", providerRecord("chatgpt-plus-pro", "chatgpt_oauth")],
+    ]);
+
+    expect(
+      connectedRecordsForProvider(provider, connectedProviders, "api").map(
+        (record) => record.name,
+      ),
+    ).toEqual(["chatgpt-plus-pro", "chatgpt-work"]);
+  });
+
+  test("separates local OAuth and API-key records for the same provider type", () => {
+    const oauthProvider: ByokProvider = {
+      id: "anthropic-oauth",
+      displayName: "Claude OAuth",
+      description: "Connect Claude OAuth",
+      providerType: "anthropic",
+      providerName: "anthropic",
+      providerNames: ["anthropic", "lc-anthropic"],
+      isOAuth: true,
+    };
+    const apiProvider: ByokProvider = {
+      id: "anthropic-api",
+      displayName: "Claude API",
+      description: "Connect Claude API",
+      providerType: "anthropic",
+      providerName: "lc-anthropic",
+      providerNames: ["anthropic", "lc-anthropic"],
+    };
+    const connectedProviders = new Map<string, ProviderResponse>([
+      [
+        "anthropic",
+        providerRecord("anthropic", "anthropic", { auth_type: "oauth" }),
+      ],
+      [
+        "lc-anthropic",
+        providerRecord("lc-anthropic", "anthropic", { auth_type: "api" }),
+      ],
+    ]);
+
+    expect(
+      connectedRecordsForProvider(
+        oauthProvider,
+        connectedProviders,
+        "local",
+      ).map((record) => record.name),
+    ).toEqual(["anthropic"]);
+    expect(
+      connectedRecordsForProvider(apiProvider, connectedProviders, "local").map(
+        (record) => record.name,
+      ),
+    ).toEqual(["lc-anthropic"]);
+  });
+});

--- a/src/providers/provider-connections.ts
+++ b/src/providers/provider-connections.ts
@@ -1,0 +1,55 @@
+import type { ProviderResponse } from "@/backend/api/providers";
+import type {
+  ByokProvider,
+  ProviderStorageTarget,
+} from "@/providers/byok-providers";
+
+export function uniqueProviderNames(provider: ByokProvider): string[] {
+  return [
+    ...new Set([provider.providerName, ...(provider.providerNames ?? [])]),
+  ];
+}
+
+function isUserProviderRecord(record: ProviderResponse): boolean {
+  return record.provider_category !== "base";
+}
+
+export function providerIsConnectedToRecord(
+  provider: ByokProvider,
+  record: ProviderResponse | undefined,
+  target: ProviderStorageTarget,
+): record is ProviderResponse {
+  if (!record || !isUserProviderRecord(record)) return false;
+  if (target !== "local" || !record.auth_type) return true;
+  return provider.isOAuth === true
+    ? record.auth_type === "oauth"
+    : record.auth_type !== "oauth";
+}
+
+export function connectedRecordsForProvider(
+  provider: ByokProvider,
+  connectedProviders: ReadonlyMap<string, ProviderResponse>,
+  target: ProviderStorageTarget,
+): ProviderResponse[] {
+  const records: ProviderResponse[] = [];
+  const seen = new Set<string>();
+
+  const addRecord = (record: ProviderResponse | undefined) => {
+    if (!providerIsConnectedToRecord(provider, record, target)) return;
+    if (seen.has(record.id)) return;
+    seen.add(record.id);
+    records.push(record);
+  };
+
+  for (const providerName of uniqueProviderNames(provider)) {
+    addRecord(connectedProviders.get(providerName));
+  }
+
+  for (const record of connectedProviders.values()) {
+    if (record.provider_type === provider.providerType) {
+      addRecord(record);
+    }
+  }
+
+  return records;
+}

--- a/src/tools/model-provider-detection.test.ts
+++ b/src/tools/model-provider-detection.test.ts
@@ -46,6 +46,12 @@ describe("deriveToolsetFromModel", () => {
     expect(deriveToolsetFromModel("openai-codex/gpt-5.5")).toBe("codex");
   });
 
+  test("maps custom ChatGPT OAuth aliases to codex toolset via provider type", () => {
+    expect(
+      deriveToolsetFromModel("chatgpt-work/gpt-5.5", "chatgpt_oauth"),
+    ).toBe("codex");
+  });
+
   test("maps Gemini models to default (anthropic) toolset", () => {
     expect(deriveToolsetFromModel("google_ai/gemini-2.5-pro")).toBe("default");
     expect(deriveToolsetFromModel("gemini-pro")).toBe("default");

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -861,9 +861,17 @@ export async function forceToolsetSwitch(
 export async function switchToolsetForModel(
   modelIdentifier: string,
   agentId: string,
+  providerType?: string | null,
 ): Promise<ToolsetName> {
   // Resolve model ID to handle when possible so provider checks stay consistent
   const resolvedModel = resolveModel(modelIdentifier) ?? modelIdentifier;
+  const typedToolsetName = deriveToolsetFromModel(resolvedModel, providerType);
+  const stringOnlyToolsetName = deriveToolsetFromModel(resolvedModel);
+
+  if (typedToolsetName !== stringOnlyToolsetName) {
+    await forceToolsetSwitch(typedToolsetName, agentId);
+    return typedToolsetName;
+  }
 
   // Load the appropriate set for the target model
   // Note: loadTools acquires a switch lock that causes sendMessageStream to wait,
@@ -888,6 +896,5 @@ export async function switchToolsetForModel(
   // Ensure base server memory tool is attached
   await ensureCorrectMemoryTool(agentId, resolvedModel);
 
-  const toolsetName = deriveToolsetFromModel(resolvedModel);
-  return toolsetName;
+  return typedToolsetName;
 }

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -63,12 +63,25 @@ export type ToolsetPreference = ToolsetName | "auto";
 
 export function deriveToolsetFromModel(
   modelIdentifier: string,
+  providerType?: string | null,
 ): "codex" | "default" {
+  if (providerType === "chatgpt_oauth" || providerType === "openai-codex") {
+    return "codex";
+  }
   const resolvedModel = resolveModel(modelIdentifier) ?? modelIdentifier;
   return isOpenAIModel(resolvedModel) ? "codex" : "default";
 }
 
-type ScopeModelCarrier = Pick<AgentState, "model" | "llm_config">;
+type ScopeModelCarrier = Pick<
+  AgentState,
+  "model" | "llm_config" | "model_settings"
+>;
+
+function providerTypeFromModelSettings(modelSettings: unknown): string | null {
+  if (!isRecord(modelSettings)) return null;
+  const providerType = modelSettings.provider_type;
+  return typeof providerType === "string" ? providerType : null;
+}
 
 export type PreparedScopeToolContext = {
   preparedToolContext: PreparedToolExecutionContext;
@@ -191,6 +204,7 @@ function areGoalToolsEnabledForScope(params: {
 
 export async function prepareToolExecutionContextForResolvedTarget(params: {
   modelIdentifier?: string | null;
+  providerType?: string | null;
   conversationId?: string | null;
   toolsetPreference: ToolsetPreference;
   exclude?: ToolName[];
@@ -206,6 +220,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
 }): Promise<PreparedScopeToolContext> {
   const {
     modelIdentifier,
+    providerType,
     conversationId,
     toolsetPreference,
     exclude,
@@ -226,7 +241,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
 
   if (toolsetPreference === "auto") {
     const derivedToolset = effectiveModel
-      ? deriveToolsetFromModel(effectiveModel)
+      ? deriveToolsetFromModel(effectiveModel, providerType)
       : "default";
     const scopedModContext = buildModInvocationContext({
       agent,
@@ -493,6 +508,9 @@ export async function prepareToolExecutionContextForScope(params: {
     overrideModel && overrideModel.length > 0
       ? (resolveModel(overrideModel) ?? overrideModel)
       : null;
+  let effectiveProviderType = providerTypeFromModelSettings(
+    (agent as { model_settings?: unknown }).model_settings,
+  );
 
   if (
     !effectiveModel &&
@@ -508,6 +526,10 @@ export async function prepareToolExecutionContextForScope(params: {
     if (typeof conversationModel === "string" && conversationModel.length > 0) {
       effectiveModel = resolveModel(conversationModel) ?? conversationModel;
     }
+    effectiveProviderType =
+      providerTypeFromModelSettings(
+        (conversation as { model_settings?: unknown }).model_settings,
+      ) ?? effectiveProviderType;
   }
 
   if (!effectiveModel) {
@@ -537,6 +559,7 @@ export async function prepareToolExecutionContextForScope(params: {
 
   const result = await prepareToolExecutionContextForResolvedTarget({
     modelIdentifier: effectiveModel,
+    providerType: effectiveProviderType,
     conversationId: conversationId ?? undefined,
     toolsetPreference,
     exclude,

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -1364,6 +1364,7 @@ export interface ListModelsCommand {
 }
 
 export type ConnectProviderStorageTarget = "local";
+export type ChatGPTUsageReadTarget = "local" | "api";
 
 export interface ListConnectProvidersCommand {
   type: "list_connect_providers";
@@ -1397,6 +1398,18 @@ export interface DisconnectProviderCommand {
   provider_id: string;
   /** Optional connected provider name to remove when a row has multiple aliases. */
   provider_name?: string;
+}
+
+export interface ChatGPTUsageReadCommand {
+  type: "chatgpt_usage_read";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  /** Provider store to inspect. */
+  target: ChatGPTUsageReadTarget;
+  /** Optional connected ChatGPT provider alias. Defaults to the built-in alias. */
+  provider_name?: string;
+  /** Skip the short listener-side cache. */
+  force_refresh?: boolean;
 }
 
 export interface ConnectProviderField {
@@ -1470,6 +1483,65 @@ export interface DisconnectProviderResponseMessage {
   providers: ConnectProviderEntry[];
   models_may_have_changed: boolean;
   error?: string;
+}
+
+export interface ChatGPTUsageWindowPayload {
+  label: string;
+  usedPercent: number | null;
+  windowDurationMins: number | null;
+  resetsAt: number | null;
+}
+
+export interface ChatGPTUsageCreditsPayload {
+  balance?: string | null;
+  availableCount?: number | null;
+  hasCredits?: boolean | null;
+  unlimited?: boolean | null;
+}
+
+export interface ChatGPTUsageIndividualLimitPayload {
+  limit: string;
+  used: string;
+  remainingPercent: number;
+  resetsAt: number;
+}
+
+export interface ChatGPTUsageSnapshotPayload {
+  providerName: string;
+  fetchedAt: string;
+  summary: string;
+  planType?: string | null;
+  limitReached?: boolean | null;
+  rateLimitReachedType?: string | null;
+  primary: ChatGPTUsageWindowPayload | null;
+  secondary: ChatGPTUsageWindowPayload | null;
+  additional: ChatGPTUsageWindowPayload[];
+  credits?: ChatGPTUsageCreditsPayload | null;
+  individualLimit?: ChatGPTUsageIndividualLimitPayload | null;
+}
+
+export interface ChatGPTUsageReadErrorPayload {
+  code:
+    | "bad_request"
+    | "not_connected"
+    | "unsupported_target"
+    | "refresh_failed"
+    | "unauthorized"
+    | "forbidden"
+    | "rate_limited"
+    | "network_error"
+    | "bad_response";
+  message: string;
+  retryAfterMs?: number;
+}
+
+export interface ChatGPTUsageReadResponseMessage {
+  type: "chatgpt_usage_read_response";
+  request_id: string;
+  success: boolean;
+  target: ChatGPTUsageReadTarget;
+  usage?: ChatGPTUsageSnapshotPayload;
+  error?: ChatGPTUsageReadErrorPayload;
 }
 
 export interface UpdateModelPayload {
@@ -2682,6 +2754,7 @@ export type WsProtocolCommand =
   | ListConnectProvidersCommand
   | ConnectProviderCommand
   | DisconnectProviderCommand
+  | ChatGPTUsageReadCommand
   | UpdateModelCommand
   | UpdateToolsetCommand
   | CronListCommand
@@ -2778,6 +2851,7 @@ export type WsProtocolMessage =
   | ListConnectProvidersResponseMessage
   | ConnectProviderResponseMessage
   | DisconnectProviderResponseMessage
+  | ChatGPTUsageReadResponseMessage
   | UpdateModelResponseMessage
   | UpdateToolsetResponseMessage
   | CronListResponseMessage

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -1395,6 +1395,8 @@ export interface DisconnectProviderCommand {
   target: ConnectProviderStorageTarget;
   /** Provider id from list_connect_providers. */
   provider_id: string;
+  /** Optional connected provider name to remove when a row has multiple aliases. */
+  provider_name?: string;
 }
 
 export interface ConnectProviderField {
@@ -1435,7 +1437,10 @@ export interface ConnectProviderEntry {
   requires_api_key: boolean;
   fields?: ConnectProviderField[];
   auth_methods?: ConnectProviderAuthMethod[];
+  /** First connected provider, preserved for older clients. */
   connected: ConnectProviderConnectionState;
+  /** All connected provider aliases represented by this row. */
+  connected_providers: ConnectProviderConnectionState[];
 }
 
 export interface ListConnectProvidersResponseMessage {

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -1430,6 +1430,68 @@ describe("listen-client parseServerMessage", () => {
     expect(parsed?.type).toBe("disconnect_provider");
   });
 
+  test("parses chatgpt_usage_read command", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "chatgpt_usage_read",
+          request_id: "chatgpt-usage-1",
+          target: "local",
+          provider_name: "chatgpt-work",
+          force_refresh: true,
+        }),
+      ),
+    );
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.type).toBe("chatgpt_usage_read");
+  });
+
+  test("parses chatgpt_usage_read command for api target", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "chatgpt_usage_read",
+          request_id: "chatgpt-usage-2",
+          target: "api",
+          provider_name: "chatgpt-work",
+        }),
+      ),
+    );
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.type).toBe("chatgpt_usage_read");
+  });
+
+  test("rejects chatgpt_usage_read command for unknown target", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "chatgpt_usage_read",
+          request_id: "chatgpt-usage-3",
+          target: "project",
+        }),
+      ),
+    );
+
+    expect(parsed).toBeNull();
+  });
+
+  test("rejects chatgpt_usage_read command with bad force_refresh", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "chatgpt_usage_read",
+          request_id: "chatgpt-usage-4",
+          target: "local",
+          force_refresh: "true",
+        }),
+      ),
+    );
+
+    expect(parsed).toBeNull();
+  });
+
   test("parses update_model command with model_id", () => {
     const parsed = parseServerMessage(
       Buffer.from(

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -1413,6 +1413,23 @@ describe("listen-client parseServerMessage", () => {
     expect(parsed?.type).toBe("disconnect_provider");
   });
 
+  test("parses disconnect_provider command with a provider name", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "disconnect_provider",
+          request_id: "disconnect-provider-2",
+          target: "local",
+          provider_id: "codex",
+          provider_name: "chatgpt-work",
+        }),
+      ),
+    );
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.type).toBe("disconnect_provider");
+  });
+
   test("parses update_model command with model_id", () => {
     const parsed = parseServerMessage(
       Buffer.from(

--- a/src/websocket/listener/commands/chatgpt-usage.ts
+++ b/src/websocket/listener/commands/chatgpt-usage.ts
@@ -1,0 +1,82 @@
+import type WebSocket from "ws";
+import { readChatGPTUsage } from "@/providers/chatgpt-usage-service";
+import type {
+  ChatGPTUsageReadCommand,
+  ChatGPTUsageReadResponseMessage,
+} from "@/types/protocol_v2";
+import { isChatGPTUsageReadCommand } from "@/websocket/listener/protocol-inbound";
+import type { RunDetachedListenerTask, SafeSocketSend } from "./types";
+
+type ChatGPTUsageCommandContext = {
+  socket: WebSocket;
+  safeSocketSend: SafeSocketSend;
+  runDetachedListenerTask: RunDetachedListenerTask;
+};
+
+export async function buildChatGPTUsageReadResponse(
+  command: ChatGPTUsageReadCommand,
+): Promise<ChatGPTUsageReadResponseMessage> {
+  const result = await readChatGPTUsage({
+    target: command.target,
+    ...(command.provider_name ? { providerName: command.provider_name } : {}),
+    forceRefresh: command.force_refresh === true,
+  });
+
+  if (!result.success) {
+    return {
+      type: "chatgpt_usage_read_response",
+      request_id: command.request_id,
+      success: false,
+      target: command.target,
+      error: result.error,
+    };
+  }
+
+  return {
+    type: "chatgpt_usage_read_response",
+    request_id: command.request_id,
+    success: true,
+    target: command.target,
+    usage: result.usage,
+  };
+}
+
+export function handleChatGPTUsageCommand(
+  parsed: unknown,
+  context: ChatGPTUsageCommandContext,
+): boolean {
+  if (!isChatGPTUsageReadCommand(parsed)) return false;
+
+  const { socket, safeSocketSend, runDetachedListenerTask } = context;
+  runDetachedListenerTask("chatgpt_usage_read", async () => {
+    try {
+      const response = await buildChatGPTUsageReadResponse(parsed);
+      safeSocketSend(
+        socket,
+        response,
+        "listener_chatgpt_usage_read_send_failed",
+        "listener_chatgpt_usage_read",
+      );
+    } catch (error) {
+      safeSocketSend(
+        socket,
+        {
+          type: "chatgpt_usage_read_response",
+          request_id: parsed.request_id,
+          success: false,
+          target: parsed.target,
+          error: {
+            code: "network_error",
+            message:
+              error instanceof Error
+                ? error.message
+                : "Failed to read ChatGPT usage.",
+          },
+        },
+        "listener_chatgpt_usage_read_send_failed",
+        "listener_chatgpt_usage_read",
+      );
+    }
+  });
+  return true;
+}

--- a/src/websocket/listener/commands/connect-providers.ts
+++ b/src/websocket/listener/commands/connect-providers.ts
@@ -65,6 +65,7 @@ export async function buildDisconnectProviderResponse(
   const result = await disconnectProvider({
     target: command.target,
     providerId: command.provider_id,
+    ...(command.provider_name ? { providerName: command.provider_name } : {}),
   });
   clearAvailableModelsCache();
   return {

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -25,6 +25,7 @@ import {
   handleChannelsProtocolCommand,
   isDetachedChannelsCommand,
 } from "./commands/channels";
+import { handleChatGPTUsageCommand } from "./commands/chatgpt-usage";
 import { handleConnectProvidersCommand } from "./commands/connect-providers";
 import { handleCronProtocolCommand } from "./commands/cron";
 import { handleGitBranchCommand } from "./commands/git-branches";
@@ -800,6 +801,16 @@ export function createListenerMessageHandler(
 
       if (
         handleConnectProvidersCommand(parsed, {
+          socket,
+          safeSocketSend,
+          runDetachedListenerTask,
+        })
+      ) {
+        return;
+      }
+
+      if (
+        handleChatGPTUsageCommand(parsed, {
           socket,
           safeSocketSend,
           runDetachedListenerTask,

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -30,6 +30,7 @@ import type {
   ChannelsListCommand,
   ChannelTargetBindCommand,
   ChannelTargetsListCommand,
+  ChatGPTUsageReadCommand,
   CheckoutBranchCommand,
   ConnectProviderCommand,
   ConversationCompactCommand,
@@ -891,6 +892,26 @@ export function isDisconnectProviderCommand(
     c.target === "local" &&
     typeof c.provider_id === "string" &&
     (c.provider_name === undefined || typeof c.provider_name === "string")
+  );
+}
+
+export function isChatGPTUsageReadCommand(
+  value: unknown,
+): value is ChatGPTUsageReadCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    target?: unknown;
+    provider_name?: unknown;
+    force_refresh?: unknown;
+  };
+  return (
+    c.type === "chatgpt_usage_read" &&
+    typeof c.request_id === "string" &&
+    (c.target === "local" || c.target === "api") &&
+    (c.provider_name === undefined || typeof c.provider_name === "string") &&
+    (c.force_refresh === undefined || typeof c.force_refresh === "boolean")
   );
 }
 
@@ -2169,6 +2190,7 @@ export function parseServerMessage(
       isListConnectProvidersCommand(parsed) ||
       isConnectProviderCommand(parsed) ||
       isDisconnectProviderCommand(parsed) ||
+      isChatGPTUsageReadCommand(parsed) ||
       isUpdateModelCommand(parsed) ||
       isUpdateToolsetCommand(parsed) ||
       isCronListCommand(parsed) ||

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -883,12 +883,14 @@ export function isDisconnectProviderCommand(
     request_id?: unknown;
     target?: unknown;
     provider_id?: unknown;
+    provider_name?: unknown;
   };
   return (
     c.type === "disconnect_provider" &&
     typeof c.request_id === "string" &&
     c.target === "local" &&
-    typeof c.provider_id === "string"
+    typeof c.provider_id === "string" &&
+    (c.provider_name === undefined || typeof c.provider_name === "string")
   );
 }
 


### PR DESCRIPTION
## Summary
- add `--name` support for ChatGPT OAuth connection flows so users can save multiple accounts under custom provider aliases
- preserve `chatgpt_oauth` metadata for aliased model handles when updating agent/conversation model settings
- route custom ChatGPT OAuth aliases to Codex/OpenAI-style tooling and update related tests

## Companion PR
- letta-cloud: https://github.com/letta-ai/letta-cloud/pull/12469

## Tests
- `bun run check`
- `bun test src/cli/connect-oauth-core.test.ts src/cli/subcommands/connect.test.ts src/tools/model-provider-detection.test.ts`
