### PR TITLE
fix(reminders): detect active shell for startup notes

### DIFF
--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -125,8 +125,8 @@ import { getCurrentWorkingDirectory } from "@/runtime-context";
 import { settingsManager } from "@/settings-manager";
 import { telemetry } from "@/telemetry";
 import { debugLog, debugWarn } from "@/utils/debug";
-import { extractTaskNotificationsForDisplay } from "@/utils/task-notifications";
 import { detectShellContext } from "@/utils/shell-context";
+import { extractTaskNotificationsForDisplay } from "@/utils/task-notifications";
 import { switchCurrentRuntimeWorkingDirectory } from "@/websocket/listener/cwd-change";
 
 import { shouldSlashCommandBypassQueue } from "./command-routing";

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -126,6 +126,7 @@ import { settingsManager } from "@/settings-manager";
 import { telemetry } from "@/telemetry";
 import { debugLog, debugWarn } from "@/utils/debug";
 import { extractTaskNotificationsForDisplay } from "@/utils/task-notifications";
+import { detectShellContext } from "@/utils/shell-context";
 import { switchCurrentRuntimeWorkingDirectory } from "@/websocket/listener/cwd-change";
 
 import { shouldSlashCommandBypassQueue } from "./command-routing";
@@ -3398,6 +3399,7 @@ ${SYSTEM_REMINDER_CLOSE}
           contentParts as unknown as MessageCreate["content"],
         systemInfoReminderEnabled,
         skillSources: getSkillSources(),
+        shellContext: detectShellContext(),
       });
       for (const part of sharedReminderParts) {
         reminderParts.push(part);

--- a/src/cli/helpers/session-context-windows.test.ts
+++ b/src/cli/helpers/session-context-windows.test.ts
@@ -1,35 +1,34 @@
 import { describe, expect, test } from "bun:test";
 
-// Test the Windows shell notes logic directly
-// The actual sessionContext.ts uses platform() which we can't easily mock,
-// but we can test that the Windows notes content is correct
+import { buildWindowsShellNotes } from "@/cli/helpers/session-context";
 
 describe("Session Context Windows Notes", () => {
-  const windowsShellNotes = `
-## Windows Shell Notes
-- The Bash tool uses PowerShell or cmd.exe on Windows
-- HEREDOC syntax (e.g., \`$(cat <<'EOF'...EOF)\`) does NOT work on Windows
-- For multiline strings (git commits, PR bodies), use simple quoted strings instead
-`;
-
   test("Windows shell notes contain heredoc warning", () => {
+    const windowsShellNotes = buildWindowsShellNotes({
+      family: "powershell",
+      displayName: "PowerShell 7",
+    });
+
     expect(windowsShellNotes).toContain("HEREDOC");
     expect(windowsShellNotes).toContain("does NOT work on Windows");
   });
 
-  test("Windows shell notes mention PowerShell", () => {
-    expect(windowsShellNotes).toContain("PowerShell");
+  test("Windows shell notes mention the detected shell", () => {
+    const windowsShellNotes = buildWindowsShellNotes({
+      family: "powershell",
+      displayName: "PowerShell 7",
+    });
+
+    expect(windowsShellNotes).toContain("Detected shell: PowerShell 7");
+    expect(windowsShellNotes).toContain("PowerShell-safe commands");
   });
 
   test("Windows shell notes provide alternative for multiline strings", () => {
+    const windowsShellNotes = buildWindowsShellNotes({
+      family: "cmd",
+      displayName: "Command Prompt",
+    });
+
     expect(windowsShellNotes).toContain("simple quoted strings");
   });
-
-  if (process.platform === "win32") {
-    test("running on Windows - notes should be relevant", () => {
-      // This test only runs on Windows CI
-      // Confirms we're actually testing on Windows
-      expect(process.platform).toBe("win32");
-    });
-  }
 });

--- a/src/cli/helpers/session-context.ts
+++ b/src/cli/helpers/session-context.ts
@@ -5,6 +5,7 @@
 import { platform } from "node:os";
 import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "@/constants";
 import type { SessionContextReason } from "@/reminders/state";
+import type { ShellContext } from "@/utils/shell-context";
 import { getVersion } from "@/version";
 import { gatherGitContextSnapshot } from "./git-context";
 
@@ -79,6 +80,7 @@ export interface BuildSessionContextOptions {
   cwd?: string;
   source?: SessionContextSource;
   reason?: SessionContextReason;
+  shellContext?: ShellContext;
 }
 
 function getIntroText(
@@ -96,6 +98,30 @@ function getIntroText(
     default:
       return "The user has just initiated a new connection via the [Letta Code CLI client](https://docs.letta.com/letta-code/index.md).";
   }
+}
+
+export function buildWindowsShellNotes(shellContext?: ShellContext): string {
+  const detected = shellContext?.family;
+  const displayName = shellContext?.displayName ?? "Windows shell";
+  const shellLine = (() => {
+    switch (detected) {
+      case "powershell":
+        return `- Detected shell: ${displayName}. Prefer PowerShell-safe commands, like \`$env:NAME=\"value\"\`, and avoid Unix-only pipeline assumptions.`;
+      case "cmd":
+        return `- Detected shell: ${displayName}. Prefer cmd-safe commands, like \`set NAME=value\`, and avoid PowerShell-only syntax.`;
+      case "bash":
+        return `- Detected shell: ${displayName}. Use Unix shell syntax.`;
+      default:
+        return "- The Bash tool uses PowerShell or cmd.exe on Windows";
+    }
+  })();
+
+  return `
+## Windows Shell Notes
+${shellLine}
+- HEREDOC syntax (e.g., \`$(cat <<'EOF'...EOF)\`) does NOT work on Windows
+- For multiline strings (git commits, PR bodies), use simple quoted strings instead
+`;
 }
 
 /**
@@ -169,12 +195,7 @@ ${gitInfo.status}
 
     // Add Windows-specific shell guidance
     if (platform() === "win32") {
-      context += `
-## Windows Shell Notes
-- The Bash tool uses PowerShell or cmd.exe on Windows
-- HEREDOC syntax (e.g., \`$(cat <<'EOF'...EOF)\`) does NOT work on Windows
-- For multiline strings (git commits, PR bodies), use simple quoted strings instead
-`;
+      context += buildWindowsShellNotes(options?.shellContext);
     }
 
     context += SYSTEM_REMINDER_CLOSE;

--- a/src/cli/helpers/session-context.ts
+++ b/src/cli/helpers/session-context.ts
@@ -106,7 +106,7 @@ export function buildWindowsShellNotes(shellContext?: ShellContext): string {
   const shellLine = (() => {
     switch (detected) {
       case "powershell":
-        return `- Detected shell: ${displayName}. Prefer PowerShell-safe commands, like \`$env:NAME=\"value\"\`, and avoid Unix-only pipeline assumptions.`;
+        return `- Detected shell: ${displayName}. Prefer PowerShell-safe commands, like \`$env:NAME="value"\`, and avoid Unix-only pipeline assumptions.`;
       case "cmd":
         return `- Detected shell: ${displayName}. Prefer cmd-safe commands, like \`set NAME=value\`, and avoid PowerShell-only syntax.`;
       case "bash":

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -7,13 +7,13 @@ import type {
 import type { ApprovalCreate } from "@letta-ai/letta-client/resources/agents/messages";
 import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs";
 import { getTerminalTelemetrySurface, telemetry } from "@/telemetry";
-import { detectShellContext } from "@/utils/shell-context";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
 import { extractTelemetryInputText } from "@/telemetry/input";
 import {
   type QueuedMessage,
   setMessageQueueAdder,
 } from "@/utils/message-queue-bridge";
+import { detectShellContext } from "@/utils/shell-context";
 import { isAgentIdCompatibleWithBackend } from "./agent/agent-id";
 import type { ApprovalResult } from "./agent/approval-execution";
 import {

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -7,6 +7,7 @@ import type {
 import type { ApprovalCreate } from "@letta-ai/letta-client/resources/agents/messages";
 import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs";
 import { getTerminalTelemetrySurface, telemetry } from "@/telemetry";
+import { detectShellContext } from "@/utils/shell-context";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
 import { extractTelemetryInputText } from "@/telemetry/input";
 import {
@@ -1845,6 +1846,7 @@ ${SYSTEM_REMINDER_CLOSE}
     systemInfoReminderEnabled,
     workingDirectory: getCurrentWorkingDirectory(),
     skillSources: resolvedSkillSources,
+    shellContext: detectShellContext(),
   });
   for (const part of sharedReminderParts) {
     pushPart(part.text);

--- a/src/reminders/engine.ts
+++ b/src/reminders/engine.ts
@@ -6,6 +6,7 @@ import {
   buildSessionContext,
   type SessionContextSource,
 } from "@/cli/helpers/session-context";
+import type { ShellContext } from "@/utils/shell-context";
 import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "@/constants";
 import { experimentManager } from "@/experiments/manager";
 import { permissionMode } from "@/permissions/mode";
@@ -39,6 +40,8 @@ export interface SharedReminderContext {
   sessionContextSource?: SessionContextSource;
   /** Reason the session context is being (re)generated. */
   sessionContextReason?: SessionContextReason;
+  /** Shell context detected at startup, if available. */
+  shellContext?: ShellContext;
 }
 
 export type ReminderTextPart = { type: "text"; text: string };
@@ -138,6 +141,7 @@ async function buildSessionContextReminder(
     cwd: context.workingDirectory,
     source: context.sessionContextSource,
     reason,
+    shellContext: context.shellContext,
   });
 
   context.state.hasSentSessionContext = true;

--- a/src/reminders/engine.ts
+++ b/src/reminders/engine.ts
@@ -6,12 +6,12 @@ import {
   buildSessionContext,
   type SessionContextSource,
 } from "@/cli/helpers/session-context";
-import type { ShellContext } from "@/utils/shell-context";
 import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "@/constants";
 import { experimentManager } from "@/experiments/manager";
 import { permissionMode } from "@/permissions/mode";
 import { settingsManager } from "@/settings-manager";
 import { debugLog } from "@/utils/debug";
+import type { ShellContext } from "@/utils/shell-context";
 import {
   SHARED_REMINDER_CATALOG,
   type SharedReminderId,

--- a/src/reminders/listen-context.ts
+++ b/src/reminders/listen-context.ts
@@ -1,6 +1,6 @@
+import type { ShellContext } from "@/utils/shell-context";
 import type { SharedReminderContext } from "./engine";
 import type { SessionContextReason, SharedReminderState } from "./state";
-import type { ShellContext } from "@/utils/shell-context";
 
 interface BuildListenReminderContextParams {
   agentId: string;

--- a/src/reminders/listen-context.ts
+++ b/src/reminders/listen-context.ts
@@ -1,5 +1,6 @@
 import type { SharedReminderContext } from "./engine";
 import type { SessionContextReason, SharedReminderState } from "./state";
+import type { ShellContext } from "@/utils/shell-context";
 
 interface BuildListenReminderContextParams {
   agentId: string;
@@ -12,6 +13,8 @@ interface BuildListenReminderContextParams {
   workingDirectory?: string;
   /** Reason for injecting session context (controls intro text). */
   sessionContextReason?: SessionContextReason;
+  /** Shell context detected at startup, if available. */
+  shellContext?: ShellContext;
 }
 
 export function buildListenReminderContext(
@@ -32,5 +35,6 @@ export function buildListenReminderContext(
     workingDirectory: params.workingDirectory,
     sessionContextSource: "listen",
     sessionContextReason: params.sessionContextReason,
+    shellContext: params.shellContext,
   };
 }

--- a/src/utils/shell-context.test.ts
+++ b/src/utils/shell-context.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { detectShellContext } from "@/utils/shell-context";
+
+describe("shell context detection", () => {
+  test("detects PowerShell on windows env", () => {
+    const shell = detectShellContext(
+      {
+        PSModulePath: "C:\\Users\\caren\\Documents\\PowerShell\\Modules",
+      } as NodeJS.ProcessEnv,
+      "win32",
+    );
+
+    expect(shell.family).toBe("powershell");
+    expect(shell.displayName).toContain("PowerShell");
+  });
+
+  test("detects cmd on windows env", () => {
+    const shell = detectShellContext(
+      { ComSpec: "C:\\Windows\\System32\\cmd.exe" } as NodeJS.ProcessEnv,
+      "win32",
+    );
+
+    expect(shell.family).toBe("cmd");
+    expect(shell.displayName).toContain("Command Prompt");
+  });
+
+  test("detects bash from SHELL on non-windows", () => {
+    const shell = detectShellContext(
+      { SHELL: "/bin/zsh" } as NodeJS.ProcessEnv,
+      "linux",
+    );
+
+    expect(shell.family).toBe("bash");
+    expect(shell.displayName).toBe("/bin/zsh");
+  });
+});

--- a/src/utils/shell-context.ts
+++ b/src/utils/shell-context.ts
@@ -1,0 +1,69 @@
+import { platform } from "node:os";
+
+export type ShellFamily = "powershell" | "cmd" | "bash" | "unknown";
+
+export interface ShellContext {
+  family: ShellFamily;
+  displayName: string;
+}
+
+function normalizeShellPath(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function detectWindowsShell(env: NodeJS.ProcessEnv): ShellContext {
+  const shell = env.SHELL?.trim();
+  if (shell) {
+    const normalized = normalizeShellPath(shell);
+    if (
+      normalized.includes("bash") ||
+      normalized.includes("zsh") ||
+      normalized.includes("sh")
+    ) {
+      return { family: "bash", displayName: shell };
+    }
+  }
+
+  const powershellPathHint = env.PSModulePath?.trim() ?? "";
+  if (
+    powershellPathHint ||
+    env.PSExecutionPolicyPreference?.trim() ||
+    env.PSEdition?.trim() ||
+    env.__PSLockdownPolicy?.trim()
+  ) {
+    return {
+      family: "powershell",
+      displayName: powershellPathHint.includes("PowerShell\\7")
+        ? "PowerShell 7"
+        : "PowerShell",
+    };
+  }
+
+  const comSpec = env.ComSpec?.trim();
+  if (comSpec) {
+    const normalized = normalizeShellPath(comSpec);
+    if (normalized.includes("powershell")) {
+      return { family: "powershell", displayName: "PowerShell" };
+    }
+    if (normalized.includes("cmd.exe")) {
+      return { family: "cmd", displayName: "Command Prompt" };
+    }
+  }
+
+  return { family: "unknown", displayName: "Windows shell" };
+}
+
+export function detectShellContext(
+  env: NodeJS.ProcessEnv = process.env,
+  currentPlatform: NodeJS.Platform = platform(),
+): ShellContext {
+  if (currentPlatform !== "win32") {
+    const shell = env.SHELL?.trim();
+    if (shell) {
+      return { family: "bash", displayName: shell };
+    }
+    return { family: "unknown", displayName: "shell" };
+  }
+
+  return detectWindowsShell(env);
+}

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -52,7 +52,6 @@ import {
   prependReminderPartsToContent,
 } from "@/reminders/engine";
 import { buildListenReminderContext } from "@/reminders/listen-context";
-import { detectShellContext } from "@/utils/shell-context";
 import { runPostTurnMemorySync } from "@/reminders/memory-git-sync";
 import { enqueueMemoryGitSyncReminder } from "@/reminders/state";
 import { settingsManager } from "@/settings-manager";
@@ -62,6 +61,7 @@ import { extractTelemetryInputText } from "@/telemetry/input";
 import { prepareToolExecutionContextForScope } from "@/tools/toolset";
 import type { StopReasonType, StreamDelta } from "@/types/protocol_v2";
 import { debugLog, debugWarn, isDebugEnabled } from "@/utils/debug";
+import { detectShellContext } from "@/utils/shell-context";
 import { createTelegramRichDraftStreamer } from "./channel-rich-draft-streamer";
 import {
   EMPTY_RESPONSE_MAX_RETRIES,

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -52,6 +52,7 @@ import {
   prependReminderPartsToContent,
 } from "@/reminders/engine";
 import { buildListenReminderContext } from "@/reminders/listen-context";
+import { detectShellContext } from "@/utils/shell-context";
 import { runPostTurnMemorySync } from "@/reminders/memory-git-sync";
 import { enqueueMemoryGitSyncReminder } from "@/reminders/state";
 import { settingsManager } from "@/settings-manager";
@@ -508,6 +509,7 @@ export async function handleIncomingMessage(
             agentLastRunAt: listenAgentMetadata?.lastRunAt ?? null,
             state: runtime.reminderState,
             workingDirectory: turnWorkingDirectory,
+            shellContext: detectShellContext(),
           }),
         );
 


### PR DESCRIPTION
detect the active shell at startup and pass it into session reminders, so the windows shell notes can give powershell or cmd specific guidance instead of the generic fallback.

this keeps the reminder short but makes the command advice more accurate on windows.