### PR TITLE
fix(tui): guard AskUserQuestion approval against malformed questions/options

### DIFF
--- a/src/cli/app/approval-questions.test.ts
+++ b/src/cli/app/approval-questions.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import type { ApprovalRequest } from "@/cli/helpers/stream";
+import { getQuestionsFromApproval } from "./approval-questions";
+
+const approval = (toolArgs: string): ApprovalRequest => ({
+  toolCallId: "tc-1",
+  toolName: "AskUserQuestion",
+  toolArgs,
+});
+
+describe("getQuestionsFromApproval (shared validator)", () => {
+  // This parser shares parseAskUserQuestions with ApprovalSwitch.getQuestions,
+  // so it must reject the same malformed shapes that would brick the TUI via
+  // the render path. These cases pin the submit-side path against regressions.
+
+  test("returns parsed questions for a well-formed payload", () => {
+    const args = JSON.stringify({
+      questions: [
+        {
+          header: "H",
+          question: "Q?",
+          options: [{ label: "A", description: "d" }],
+          multiSelect: false,
+        },
+      ],
+    });
+    expect(getQuestionsFromApproval(approval(args))).toHaveLength(1);
+  });
+
+  test("returns [] when `questions` is a JSON string (regression)", () => {
+    const malformed = JSON.stringify({
+      questions: JSON.stringify([
+        {
+          header: "H",
+          question: "Q?",
+          options: [{ label: "A", description: "" }],
+          multiSelect: false,
+        },
+      ]),
+    });
+    expect(getQuestionsFromApproval(approval(malformed))).toEqual([]);
+  });
+
+  test("returns [] for non-string question/header/description", () => {
+    const baseOptions = [{ label: "A", description: "" }];
+    const nonStringQuestion = JSON.stringify({
+      questions: [
+        {
+          header: "H",
+          question: { bad: true } as unknown as string,
+          options: baseOptions,
+          multiSelect: false,
+        },
+      ],
+    });
+    expect(getQuestionsFromApproval(approval(nonStringQuestion))).toEqual([]);
+    const nonStringDescription = JSON.stringify({
+      questions: [
+        {
+          header: "H",
+          question: "Q?",
+          options: [
+            { label: "A", description: {} } as unknown as {
+              label: string;
+              description: string;
+            },
+          ],
+          multiSelect: false,
+        },
+      ],
+    });
+    expect(getQuestionsFromApproval(approval(nonStringDescription))).toEqual(
+      [],
+    );
+  });
+
+  test("returns [] for unparseable/empty toolArgs", () => {
+    expect(getQuestionsFromApproval(approval("{not json"))).toEqual([]);
+    expect(getQuestionsFromApproval(approval(""))).toEqual([]);
+  });
+});

--- a/src/cli/app/approval-questions.test.ts
+++ b/src/cli/app/approval-questions.test.ts
@@ -19,7 +19,10 @@ describe("getQuestionsFromApproval (shared validator)", () => {
         {
           header: "H",
           question: "Q?",
-          options: [{ label: "A", description: "d" }],
+          options: [
+            { label: "A", description: "d" },
+            { label: "B", description: "d" },
+          ],
           multiSelect: false,
         },
       ],

--- a/src/cli/app/approval-questions.test.ts
+++ b/src/cli/app/approval-questions.test.ts
@@ -78,4 +78,12 @@ describe("getQuestionsFromApproval (shared validator)", () => {
     expect(getQuestionsFromApproval(approval("{not json"))).toEqual([]);
     expect(getQuestionsFromApproval(approval(""))).toEqual([]);
   });
+
+  test("returns [] for toolArgs that parse to a non-object (regression)", () => {
+    // "null" is valid JSON parsing to null; dereferencing .questions on it
+    // would throw. The shared validator must treat it as malformed.
+    expect(getQuestionsFromApproval(approval("null"))).toEqual([]);
+    expect(getQuestionsFromApproval(approval("true"))).toEqual([]);
+    expect(getQuestionsFromApproval(approval("42"))).toEqual([]);
+  });
 });

--- a/src/cli/app/approval-questions.test.ts
+++ b/src/cli/app/approval-questions.test.ts
@@ -45,7 +45,10 @@ describe("getQuestionsFromApproval (shared validator)", () => {
   });
 
   test("returns [] for non-string question/header/description", () => {
-    const baseOptions = [{ label: "A", description: "" }];
+    const baseOptions = [
+      { label: "A", description: "" },
+      { label: "B", description: "" },
+    ];
     const nonStringQuestion = JSON.stringify({
       questions: [
         {
@@ -57,6 +60,8 @@ describe("getQuestionsFromApproval (shared validator)", () => {
       ],
     });
     expect(getQuestionsFromApproval(approval(nonStringQuestion))).toEqual([]);
+    // Two valid options so the failure is attributable to the non-string
+    // `description`, not the 2–4 options bound.
     const nonStringDescription = JSON.stringify({
       questions: [
         {
@@ -67,6 +72,7 @@ describe("getQuestionsFromApproval (shared validator)", () => {
               label: string;
               description: string;
             },
+            { label: "B", description: "" },
           ],
           multiSelect: false,
         },

--- a/src/cli/app/approval-questions.ts
+++ b/src/cli/app/approval-questions.ts
@@ -1,18 +1,15 @@
-import { safeJsonParseOr } from "@/cli/helpers/safe-json-parse";
+import {
+  type AskUserQuestion,
+  parseAskUserQuestions,
+} from "@/cli/helpers/ask-user-questions";
 import type { ApprovalRequest } from "@/cli/helpers/stream";
 
-// Extract questions from AskUserQuestion tool args
-export function getQuestionsFromApproval(approval: ApprovalRequest) {
-  const parsed = safeJsonParseOr<Record<string, unknown>>(
-    approval.toolArgs,
-    {},
-  );
-  return (
-    (parsed.questions as Array<{
-      question: string;
-      header: string;
-      options: Array<{ label: string; description: string }>;
-      multiSelect: boolean;
-    }>) || []
-  );
+// Extract questions from an AskUserQuestion tool call's args. Delegates to the
+// shared parseAskUserQuestions validator (single source of truth shared with
+// the ApprovalSwitch render path) so malformed shapes are rejected rather than
+// reaching the submit handler. Returns [] for anything malformed.
+export function getQuestionsFromApproval(
+  approval: ApprovalRequest,
+): AskUserQuestion[] {
+  return parseAskUserQuestions(approval);
 }

--- a/src/cli/components/ApprovalSwitch.test.ts
+++ b/src/cli/components/ApprovalSwitch.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import type { ApprovalRequest } from "@/cli/helpers/stream";
+import { getQuestions } from "./ApprovalSwitch";
+
+const approval = (toolArgs: string): ApprovalRequest => ({
+  toolCallId: "tc-1",
+  toolName: "AskUserQuestion",
+  toolArgs,
+});
+
+const validArgs = JSON.stringify({
+  questions: [
+    {
+      header: "Goal",
+      question: "What is your goal?",
+      options: [
+        { label: "A", description: "opt a" },
+        { label: "B", description: "opt b" },
+      ],
+      multiSelect: false,
+    },
+  ],
+});
+
+describe("getQuestions (AskUserQuestion shape validation)", () => {
+  test("returns parsed questions for a well-formed payload", () => {
+    const q = getQuestions(approval(validArgs));
+    expect(q).toHaveLength(1);
+    expect(q[0]?.header).toBe("Goal");
+    expect(q[0]?.options).toHaveLength(2);
+  });
+
+  test("returns [] when `questions` is emitted as a JSON string (regression)", () => {
+    // This is the exact malformed payload observed in the wild: the model
+    // double-encoded `questions` as a string. The old code did
+    // `args.questions as Question[]` and returned the string, whose `.length`
+    // was truthy, so InlineQuestionApproval spread `questions[0].options`
+    // (undefined) and crashed the TUI.
+    const malformed = JSON.stringify({
+      questions: JSON.stringify([
+        {
+          header: "Goal",
+          question: "...",
+          options: [{ label: "A", description: "" }],
+        },
+      ]),
+    });
+    expect(getQuestions(approval(malformed))).toEqual([]);
+  });
+
+  test("returns [] when `questions` is missing", () => {
+    expect(getQuestions(approval(JSON.stringify({})))).toEqual([]);
+  });
+
+  test("returns [] when `questions` is not an array", () => {
+    expect(getQuestions(approval(JSON.stringify({ questions: null })))).toEqual(
+      [],
+    );
+    expect(getQuestions(approval(JSON.stringify({ questions: {} })))).toEqual(
+      [],
+    );
+  });
+
+  test("returns [] when a question is missing its `options` array", () => {
+    const noOptions = JSON.stringify({
+      questions: [{ header: "H", question: "Q?" }],
+    });
+    expect(getQuestions(approval(noOptions))).toEqual([]);
+  });
+
+  test("returns [] when a question has null/empty `options`", () => {
+    const nullOptions = JSON.stringify({
+      questions: [{ header: "H", question: "Q?", options: null }],
+    });
+    expect(getQuestions(approval(nullOptions))).toEqual([]);
+    const emptyOptions = JSON.stringify({
+      questions: [
+        {
+          header: "H",
+          question: "Q?",
+          options: [],
+        },
+      ],
+    });
+    expect(getQuestions(approval(emptyOptions))).toEqual([]);
+  });
+
+  test("returns [] if any single question is malformed (all-or-nothing)", () => {
+    const mixed = JSON.stringify({
+      questions: [
+        {
+          header: "H",
+          question: "Q?",
+          options: [{ label: "A", description: "" }],
+        },
+        { header: "H2", question: "Q2?" }, // missing options
+      ],
+    });
+    expect(getQuestions(approval(mixed))).toEqual([]);
+  });
+
+  test("returns [] for unparseable toolArgs", () => {
+    expect(getQuestions(approval("{not valid json"))).toEqual([]);
+  });
+
+  test("returns [] for empty toolArgs", () => {
+    expect(getQuestions(approval(""))).toEqual([]);
+  });
+});

--- a/src/cli/components/ApprovalSwitch.tsx
+++ b/src/cli/components/ApprovalSwitch.tsx
@@ -325,11 +325,26 @@ function getMemoryFileEditInfo(
   }
 }
 
-// Parse questions from AskUserQuestion args
-function getQuestions(approval: ApprovalRequest): Question[] {
+// Parse questions from AskUserQuestion args.
+// Validates shape defensively: a malformed tool call (e.g. `questions` emitted
+// as a JSON string rather than an array, or a question missing its required
+// `options` array) must never reach InlineQuestionApproval, which spreads
+// `options` without a guard and would crash the TUI. Returns [] for anything
+// malformed so ApprovalSwitch falls through to InlineGenericApproval, matching
+// how malformed Bash/Task args are already handled.
+export function getQuestions(approval: ApprovalRequest): Question[] {
   try {
     const args = JSON.parse(approval.toolArgs || "{}");
-    return (args.questions as Question[]) || [];
+    const questions = args.questions;
+    if (!Array.isArray(questions) || questions.length === 0) return [];
+    const wellFormed = questions.every(
+      (q) =>
+        q != null &&
+        typeof q === "object" &&
+        Array.isArray((q as Question).options) &&
+        (q as Question).options.length > 0,
+    );
+    return wellFormed ? (questions as Question[]) : [];
   } catch {
     return [];
   }

--- a/src/cli/components/ApprovalSwitch.tsx
+++ b/src/cli/components/ApprovalSwitch.tsx
@@ -337,13 +337,18 @@ export function getQuestions(approval: ApprovalRequest): Question[] {
     const args = JSON.parse(approval.toolArgs || "{}");
     const questions = args.questions;
     if (!Array.isArray(questions) || questions.length === 0) return [];
-    const wellFormed = questions.every(
-      (q) =>
-        q != null &&
-        typeof q === "object" &&
-        Array.isArray((q as Question).options) &&
-        (q as Question).options.length > 0,
-    );
+    const wellFormed = questions.every((q) => {
+      if (q == null || typeof q !== "object") return false;
+      const options = (q as { options?: unknown }).options;
+      if (!Array.isArray(options) || options.length === 0) return false;
+      return options.every(
+        (o) =>
+          o != null &&
+          typeof o === "object" &&
+          typeof (o as { label?: unknown }).label === "string" &&
+          (o as { label: string }).label.length > 0,
+      );
+    });
     return wellFormed ? (questions as Question[]) : [];
   } catch {
     return [];

--- a/src/cli/components/ApprovalSwitch.tsx
+++ b/src/cli/components/ApprovalSwitch.tsx
@@ -1,4 +1,8 @@
 import { memo } from "react";
+import {
+  type AskUserQuestion,
+  parseAskUserQuestions,
+} from "@/cli/helpers/ask-user-questions";
 import type { AdvancedDiffSuccess } from "@/cli/helpers/diff";
 import type { ApprovalRequest } from "@/cli/helpers/stream";
 import {
@@ -46,13 +50,6 @@ type TaskInfo = {
   prompt: string;
   model?: string;
   isBackground?: boolean;
-};
-
-type Question = {
-  question: string;
-  header: string;
-  options: Array<{ label: string; description: string }>;
-  multiSelect: boolean;
 };
 
 type Props = {
@@ -325,34 +322,17 @@ function getMemoryFileEditInfo(
   }
 }
 
-// Parse questions from AskUserQuestion args.
-// Validates shape defensively: a malformed tool call (e.g. `questions` emitted
-// as a JSON string rather than an array, or a question missing its required
-// `options` array) is rejected here so ApprovalSwitch falls through to
-// InlineGenericApproval, matching how malformed Bash/Task args are handled.
-// InlineQuestionApproval also coerces `options` to an array as defense-in-depth,
-// but this gate keeps malformed payloads out of the specialized renderer.
-export function getQuestions(approval: ApprovalRequest): Question[] {
-  try {
-    const args = JSON.parse(approval.toolArgs || "{}");
-    const questions = args.questions;
-    if (!Array.isArray(questions) || questions.length === 0) return [];
-    const wellFormed = questions.every((q) => {
-      if (q == null || typeof q !== "object") return false;
-      const options = (q as { options?: unknown }).options;
-      if (!Array.isArray(options) || options.length === 0) return false;
-      return options.every(
-        (o) =>
-          o != null &&
-          typeof o === "object" &&
-          typeof (o as { label?: unknown }).label === "string" &&
-          (o as { label: string }).label.length > 0,
-      );
-    });
-    return wellFormed ? (questions as Question[]) : [];
-  } catch {
-    return [];
-  }
+// Parse questions from AskUserQuestion args. Delegates to the shared
+// parseAskUserQuestions validator (single source of truth shared with the
+// use-approval-flow submit path) so malformed shapes — e.g. `questions` as a
+// JSON string, a non-string `question`/`header`/`description`, or a
+// non-array/empty `options` — are rejected here and ApprovalSwitch falls
+// through to InlineGenericApproval, matching how malformed Bash/Task args are
+// handled. InlineQuestionApproval also coerces/filters `options` as
+// defense-in-depth, but this gate keeps malformed payloads out of the
+// specialized renderer.
+export function getQuestions(approval: ApprovalRequest): AskUserQuestion[] {
+  return parseAskUserQuestions(approval);
 }
 
 /**

--- a/src/cli/components/ApprovalSwitch.tsx
+++ b/src/cli/components/ApprovalSwitch.tsx
@@ -328,10 +328,10 @@ function getMemoryFileEditInfo(
 // Parse questions from AskUserQuestion args.
 // Validates shape defensively: a malformed tool call (e.g. `questions` emitted
 // as a JSON string rather than an array, or a question missing its required
-// `options` array) must never reach InlineQuestionApproval, which spreads
-// `options` without a guard and would crash the TUI. Returns [] for anything
-// malformed so ApprovalSwitch falls through to InlineGenericApproval, matching
-// how malformed Bash/Task args are already handled.
+// `options` array) is rejected here so ApprovalSwitch falls through to
+// InlineGenericApproval, matching how malformed Bash/Task args are handled.
+// InlineQuestionApproval also coerces `options` to an array as defense-in-depth,
+// but this gate keeps malformed payloads out of the specialized renderer.
 export function getQuestions(approval: ApprovalRequest): Question[] {
   try {
     const args = JSON.parse(approval.toolArgs || "{}");

--- a/src/cli/components/InlineQuestionApproval.test.tsx
+++ b/src/cli/components/InlineQuestionApproval.test.tsx
@@ -116,7 +116,8 @@ test("InlineQuestionApproval coerces non-array `options` instead of throwing (de
 
   // An `options` array containing null/non-object entries must not throw when
   // the render path reads option.label/option.description. The component
-  // filters out non-object entries as defense-in-depth.
+  // filters out non-object entries (and non-string label/description) as
+  // defense-in-depth.
   const renderWithEntries = (options: unknown) =>
     renderWithQuestions([
       {
@@ -131,6 +132,20 @@ test("InlineQuestionApproval coerces non-array `options` instead of throwing (de
     [42],
     [null, { label: "A", description: "" }],
     [{ label: "A", description: "" }, "bad"],
+    // Object entries with non-string label/description would throw when
+    // rendered as React children / used as a key — the filter drops them.
+    [
+      { label: {}, description: "" } as unknown as {
+        label: string;
+        description: string;
+      },
+    ],
+    [
+      { label: "A", description: {} } as unknown as {
+        label: string;
+        description: string;
+      },
+    ],
   ]) {
     const output = await renderWithEntries(badEntries);
     expect(typeof output).toBe("string");

--- a/src/cli/components/InlineQuestionApproval.test.tsx
+++ b/src/cli/components/InlineQuestionApproval.test.tsx
@@ -113,4 +113,26 @@ test("InlineQuestionApproval coerces non-array `options` instead of throwing (de
     const output = await renderWithOptions(bad);
     expect(typeof output).toBe("string");
   }
+
+  // An `options` array containing null/non-object entries must not throw when
+  // the render path reads option.label/option.description. The component
+  // filters out non-object entries as defense-in-depth.
+  const renderWithEntries = (options: unknown) =>
+    renderWithQuestions([
+      {
+        header: "H",
+        question: "Q?",
+        options,
+        multiSelect: false,
+      },
+    ] as QuestionsProp);
+  for (const badEntries of [
+    [null],
+    [42],
+    [null, { label: "A", description: "" }],
+    [{ label: "A", description: "" }, "bad"],
+  ]) {
+    const output = await renderWithEntries(badEntries);
+    expect(typeof output).toBe("string");
+  }
 });

--- a/src/cli/components/InlineQuestionApproval.test.tsx
+++ b/src/cli/components/InlineQuestionApproval.test.tsx
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import { Readable, Writable } from "node:stream";
 import { render } from "ink";
+import type { ComponentProps } from "react";
 import stripAnsi from "strip-ansi";
 import { InlineQuestionApproval } from "./InlineQuestionApproval";
 
@@ -29,7 +30,9 @@ function createInputStream(): NodeJS.ReadStream {
   return input;
 }
 
-async function renderQuestion(question: string): Promise<string> {
+type QuestionsProp = ComponentProps<typeof InlineQuestionApproval>["questions"];
+
+async function renderWithQuestions(questions: QuestionsProp): Promise<string> {
   const stdout = new CaptureStream() as CaptureStream & NodeJS.WriteStream;
   const originalWrite = process.stdout.write;
   process.stdout.write = (() => true) as typeof process.stdout.write;
@@ -37,18 +40,7 @@ async function renderQuestion(question: string): Promise<string> {
   try {
     const instance = render(
       <InlineQuestionApproval
-        questions={[
-          {
-            header: "Review plan",
-            question,
-            options: [
-              { label: "Approve", description: "Proceed" },
-              { label: "Revise", description: "Keep planning" },
-            ],
-            multiSelect: false,
-            allowOther: false,
-          },
-        ]}
+        questions={questions}
         onSubmit={() => {}}
         isFocused={false}
       />,
@@ -70,6 +62,21 @@ async function renderQuestion(question: string): Promise<string> {
   }
 }
 
+async function renderQuestion(question: string): Promise<string> {
+  return renderWithQuestions([
+    {
+      header: "Review plan",
+      question,
+      options: [
+        { label: "Approve", description: "Proceed" },
+        { label: "Revise", description: "Keep planning" },
+      ],
+      multiSelect: false,
+      allowOther: false,
+    },
+  ]);
+}
+
 test("InlineQuestionApproval renders multiline markdown question text", async () => {
   const output = await renderQuestion(
     [
@@ -85,4 +92,25 @@ test("InlineQuestionApproval renders multiline markdown question text", async ()
   expect(output).toContain("- Update InlineQuestionApproval");
   expect(output).toContain("Approve");
   expect(output).toContain("Revise");
+});
+
+test("InlineQuestionApproval coerces non-array `options` instead of throwing (defense-in-depth)", async () => {
+  // Regression: a malformed AskUserQuestion payload can carry `options` as a
+  // non-iterable value (e.g. {} or a number). Spreading it would throw
+  // "...iterable not be null or undefined" / "object is not iterable" and brick
+  // the TUI. The component must coerce to an empty array and keep rendering.
+  const renderWithOptions = (options: unknown) =>
+    renderWithQuestions([
+      {
+        header: "H",
+        question: "Q?",
+        options,
+        multiSelect: false,
+      },
+    ] as QuestionsProp);
+
+  for (const bad of [undefined, null, { a: 1 }, 42, "nope"]) {
+    const output = await renderWithOptions(bad);
+    expect(typeof output).toBe("string");
+  }
 });

--- a/src/cli/components/InlineQuestionApproval.tsx
+++ b/src/cli/components/InlineQuestionApproval.tsx
@@ -72,7 +72,9 @@ export const InlineQuestionApproval = memo(
     const showOther = currentQuestion?.allowOther !== false;
     const baseOptions = currentQuestion
       ? [
-          ...(currentQuestion.options ?? []),
+          ...(Array.isArray(currentQuestion.options)
+            ? currentQuestion.options
+            : []),
           ...(showOther ? [{ label: "Type something.", description: "" }] : []),
         ]
       : [];

--- a/src/cli/components/InlineQuestionApproval.tsx
+++ b/src/cli/components/InlineQuestionApproval.tsx
@@ -72,7 +72,7 @@ export const InlineQuestionApproval = memo(
     const showOther = currentQuestion?.allowOther !== false;
     const baseOptions = currentQuestion
       ? [
-          ...currentQuestion.options,
+          ...(currentQuestion.options ?? []),
           ...(showOther ? [{ label: "Type something.", description: "" }] : []),
         ]
       : [];

--- a/src/cli/components/InlineQuestionApproval.tsx
+++ b/src/cli/components/InlineQuestionApproval.tsx
@@ -73,7 +73,9 @@ export const InlineQuestionApproval = memo(
     const baseOptions = currentQuestion
       ? [
           ...(Array.isArray(currentQuestion.options)
-            ? currentQuestion.options
+            ? currentQuestion.options.filter(
+                (o): o is QuestionOption => o != null && typeof o === "object",
+              )
             : []),
           ...(showOther ? [{ label: "Type something.", description: "" }] : []),
         ]

--- a/src/cli/components/InlineQuestionApproval.tsx
+++ b/src/cli/components/InlineQuestionApproval.tsx
@@ -74,7 +74,12 @@ export const InlineQuestionApproval = memo(
       ? [
           ...(Array.isArray(currentQuestion.options)
             ? currentQuestion.options.filter(
-                (o): o is QuestionOption => o != null && typeof o === "object",
+                (o): o is QuestionOption =>
+                  o != null &&
+                  typeof o === "object" &&
+                  typeof (o as { label?: unknown }).label === "string" &&
+                  typeof (o as { description?: unknown }).description ===
+                    "string",
               )
             : []),
           ...(showOther ? [{ label: "Type something.", description: "" }] : []),

--- a/src/cli/components/approval-switch.test.ts
+++ b/src/cli/components/approval-switch.test.ts
@@ -141,6 +141,24 @@ describe("getQuestions (AskUserQuestion shape validation)", () => {
       ],
     });
     expect(getQuestions(approval(missingLabel))).toEqual([]);
+    // A non-string `description` (e.g. {}) is rendered as a React child when
+    // truthy, which throws — reject it.
+    const nonStringDescription = JSON.stringify({
+      questions: [
+        {
+          header: "H",
+          question: "Q?",
+          options: [
+            { label: "A", description: {} } as unknown as {
+              label: string;
+              description: string;
+            },
+          ],
+        },
+      ],
+    });
+    expect(getQuestions(approval(nonStringDescription))).toEqual([]);
+
     // One bad entry invalidates the whole question (all-or-nothing).
     const mixedEntries = JSON.stringify({
       questions: [
@@ -155,6 +173,74 @@ describe("getQuestions (AskUserQuestion shape validation)", () => {
       ],
     });
     expect(getQuestions(approval(mixedEntries))).toEqual([]);
+  });
+
+  test("returns [] when question-level fields have the wrong type", () => {
+    // InlineQuestionApproval calls `question.includes(...)` and renders
+    // `header` as a React child, so non-string values throw. multiSelect/
+    // allowOther must be booleans (allowOther may be omitted).
+    const baseOptions = [{ label: "A", description: "" }];
+    const nonStringQuestion = JSON.stringify({
+      questions: [
+        {
+          header: "H",
+          question: { bad: true } as unknown as string,
+          options: baseOptions,
+          multiSelect: false,
+        },
+      ],
+    });
+    expect(getQuestions(approval(nonStringQuestion))).toEqual([]);
+    const nonStringHeader = JSON.stringify({
+      questions: [
+        {
+          header: { bad: true } as unknown as string,
+          question: "Q?",
+          options: baseOptions,
+          multiSelect: false,
+        },
+      ],
+    });
+    expect(getQuestions(approval(nonStringHeader))).toEqual([]);
+    const nonBooleanMultiSelect = JSON.stringify({
+      questions: [
+        {
+          header: "H",
+          question: "Q?",
+          options: baseOptions,
+          multiSelect: "yes" as unknown as boolean,
+        },
+      ],
+    });
+    expect(getQuestions(approval(nonBooleanMultiSelect))).toEqual([]);
+    const missingMultiSelect = JSON.stringify({
+      questions: [{ header: "H", question: "Q?", options: baseOptions }],
+    });
+    expect(getQuestions(approval(missingMultiSelect))).toEqual([]);
+    const nonBooleanAllowOther = JSON.stringify({
+      questions: [
+        {
+          header: "H",
+          question: "Q?",
+          options: baseOptions,
+          multiSelect: false,
+          allowOther: "yes" as unknown as boolean,
+        },
+      ],
+    });
+    expect(getQuestions(approval(nonBooleanAllowOther))).toEqual([]);
+    // allowOther omitted is fine (it's optional).
+    const validWithoutAllowOther = JSON.stringify({
+      questions: [
+        {
+          header: "H",
+          question: "Q?",
+          options: [{ label: "A", description: "d" }],
+          multiSelect: false,
+        },
+      ],
+    });
+    expect(getQuestions(approval(validWithoutAllowOther))).toHaveLength(1);
   });
 
   test("returns [] if any single question is malformed (all-or-nothing)", () => {

--- a/src/cli/components/approval-switch.test.ts
+++ b/src/cli/components/approval-switch.test.ts
@@ -261,6 +261,17 @@ describe("getQuestions (AskUserQuestion shape validation)", () => {
     expect(getQuestions(approval("{not valid json"))).toEqual([]);
   });
 
+  test("returns [] for toolArgs that parse to a non-object (regression)", () => {
+    // `safeJsonParseOr` returns the raw JSON.parse result, so valid-but-
+    // non-object JSON (e.g. "null", "true", "42", "\"x\"") flows through.
+    // `null` in particular must not reach `parsed.questions` (throws and
+    // bricks the TUI via the render path).
+    expect(getQuestions(approval("null"))).toEqual([]);
+    expect(getQuestions(approval("true"))).toEqual([]);
+    expect(getQuestions(approval("42"))).toEqual([]);
+    expect(getQuestions(approval('"a string"'))).toEqual([]);
+  });
+
   test("returns [] for empty toolArgs", () => {
     expect(getQuestions(approval(""))).toEqual([]);
   });

--- a/src/cli/components/approval-switch.test.ts
+++ b/src/cli/components/approval-switch.test.ts
@@ -175,6 +175,69 @@ describe("getQuestions (AskUserQuestion shape validation)", () => {
     expect(getQuestions(approval(mixedEntries))).toEqual([]);
   });
 
+  test("returns [] when the questions/options counts violate the 1–4 / 2–4 contract", () => {
+    // The AskUserQuestion schema + tool implementation cap questions at 1–4 and
+    // each question's options at 2–4. The validator must mirror that so a
+    // payload the tool will reject on submit falls through to InlineGenericApproval
+    // instead of rendering a specialized prompt the user can't successfully answer.
+    const twoOptions = [
+      { label: "A", description: "" },
+      { label: "B", description: "" },
+    ];
+    const mkQuestion = () => ({
+      header: "H",
+      question: "Q?",
+      options: twoOptions,
+      multiSelect: false,
+    });
+    // >4 questions
+    const tooManyQuestions = JSON.stringify({
+      questions: [
+        mkQuestion(),
+        mkQuestion(),
+        mkQuestion(),
+        mkQuestion(),
+        mkQuestion(),
+      ],
+    });
+    expect(getQuestions(approval(tooManyQuestions))).toEqual([]);
+    // exactly 4 questions is fine
+    const fourQuestions = JSON.stringify({
+      questions: [mkQuestion(), mkQuestion(), mkQuestion(), mkQuestion()],
+    });
+    expect(getQuestions(approval(fourQuestions))).toHaveLength(4);
+    // single option (< 2)
+    const singleOption = JSON.stringify({
+      questions: [
+        {
+          header: "H",
+          question: "Q?",
+          options: [{ label: "A", description: "" }],
+          multiSelect: false,
+        },
+      ],
+    });
+    expect(getQuestions(approval(singleOption))).toEqual([]);
+    // 5 options (> 4)
+    const fiveOptions = JSON.stringify({
+      questions: [
+        {
+          header: "H",
+          question: "Q?",
+          options: [
+            { label: "1", description: "" },
+            { label: "2", description: "" },
+            { label: "3", description: "" },
+            { label: "4", description: "" },
+            { label: "5", description: "" },
+          ],
+          multiSelect: false,
+        },
+      ],
+    });
+    expect(getQuestions(approval(fiveOptions))).toEqual([]);
+  });
+
   test("returns [] when question-level fields have the wrong type", () => {
     // InlineQuestionApproval calls `question.includes(...)` and renders
     // `header` as a React child, so non-string values throw. multiSelect/
@@ -235,7 +298,10 @@ describe("getQuestions (AskUserQuestion shape validation)", () => {
         {
           header: "H",
           question: "Q?",
-          options: [{ label: "A", description: "d" }],
+          options: [
+            { label: "A", description: "d" },
+            { label: "B", description: "d" },
+          ],
           multiSelect: false,
         },
       ],

--- a/src/cli/components/approval-switch.test.ts
+++ b/src/cli/components/approval-switch.test.ts
@@ -242,7 +242,10 @@ describe("getQuestions (AskUserQuestion shape validation)", () => {
     // InlineQuestionApproval calls `question.includes(...)` and renders
     // `header` as a React child, so non-string values throw. multiSelect/
     // allowOther must be booleans (allowOther may be omitted).
-    const baseOptions = [{ label: "A", description: "" }];
+    const baseOptions = [
+      { label: "A", description: "" },
+      { label: "B", description: "" },
+    ];
     const nonStringQuestion = JSON.stringify({
       questions: [
         {
@@ -310,14 +313,22 @@ describe("getQuestions (AskUserQuestion shape validation)", () => {
   });
 
   test("returns [] if any single question is malformed (all-or-nothing)", () => {
+    // The first question is fully well-formed (2 options + multiSelect); only
+    // the second is malformed (missing options). This pins all-or-nothing: the
+    // validator must reject the whole batch because of the bad entry, not
+    // because the good one also happens to be invalid.
     const mixed = JSON.stringify({
       questions: [
         {
           header: "H",
           question: "Q?",
-          options: [{ label: "A", description: "" }],
+          options: [
+            { label: "A", description: "" },
+            { label: "B", description: "" },
+          ],
+          multiSelect: false,
         },
-        { header: "H2", question: "Q2?" }, // missing options
+        { header: "H2", question: "Q2?", multiSelect: false }, // missing options
       ],
     });
     expect(getQuestions(approval(mixed))).toEqual([]);

--- a/src/cli/components/approval-switch.test.ts
+++ b/src/cli/components/approval-switch.test.ts
@@ -95,6 +95,68 @@ describe("getQuestions (AskUserQuestion shape validation)", () => {
     expect(getQuestions(approval(stringOptions))).toEqual([]);
   });
 
+  test("returns [] when an `options` entry is null/non-object/missing label", () => {
+    // The renderer derefs option.label (React key + display) and option.description,
+    // so a null/non-object entry (e.g. options: [null]) would throw downstream.
+    const nullEntry = JSON.stringify({
+      questions: [
+        {
+          header: "H",
+          question: "Q?",
+          options: [null as unknown as { label: string; description: string }],
+        },
+      ],
+    });
+    expect(getQuestions(approval(nullEntry))).toEqual([]);
+    const nonObjectEntry = JSON.stringify({
+      questions: [
+        {
+          header: "H",
+          question: "Q?",
+          options: [42 as unknown as { label: string; description: string }],
+        },
+      ],
+    });
+    expect(getQuestions(approval(nonObjectEntry))).toEqual([]);
+    const emptyLabel = JSON.stringify({
+      questions: [
+        {
+          header: "H",
+          question: "Q?",
+          options: [{ label: "", description: "x" }],
+        },
+      ],
+    });
+    expect(getQuestions(approval(emptyLabel))).toEqual([]);
+    const missingLabel = JSON.stringify({
+      questions: [
+        {
+          header: "H",
+          question: "Q?",
+          options: [{ description: "x" }] as unknown as {
+            label: string;
+            description: string;
+          }[],
+        },
+      ],
+    });
+    expect(getQuestions(approval(missingLabel))).toEqual([]);
+    // One bad entry invalidates the whole question (all-or-nothing).
+    const mixedEntries = JSON.stringify({
+      questions: [
+        {
+          header: "H",
+          question: "Q?",
+          options: [
+            { label: "A", description: "" },
+            null as unknown as { label: string; description: string },
+          ],
+        },
+      ],
+    });
+    expect(getQuestions(approval(mixedEntries))).toEqual([]);
+  });
+
   test("returns [] if any single question is malformed (all-or-nothing)", () => {
     const mixed = JSON.stringify({
       questions: [

--- a/src/cli/components/approval-switch.test.ts
+++ b/src/cli/components/approval-switch.test.ts
@@ -68,7 +68,7 @@ describe("getQuestions (AskUserQuestion shape validation)", () => {
     expect(getQuestions(approval(noOptions))).toEqual([]);
   });
 
-  test("returns [] when a question has null/empty `options`", () => {
+  test("returns [] when a question has null/empty/non-array `options`", () => {
     const nullOptions = JSON.stringify({
       questions: [{ header: "H", question: "Q?", options: null }],
     });
@@ -83,6 +83,16 @@ describe("getQuestions (AskUserQuestion shape validation)", () => {
       ],
     });
     expect(getQuestions(approval(emptyOptions))).toEqual([]);
+    // Non-array `options` (e.g. an object or string) must be rejected too —
+    // spreading a non-iterable like {} would otherwise throw downstream.
+    const objectOptions = JSON.stringify({
+      questions: [{ header: "H", question: "Q?", options: { a: 1 } }],
+    });
+    expect(getQuestions(approval(objectOptions))).toEqual([]);
+    const stringOptions = JSON.stringify({
+      questions: [{ header: "H", question: "Q?", options: "nope" }],
+    });
+    expect(getQuestions(approval(stringOptions))).toEqual([]);
   });
 
   test("returns [] if any single question is malformed (all-or-nothing)", () => {

--- a/src/cli/helpers/ask-user-questions.ts
+++ b/src/cli/helpers/ask-user-questions.ts
@@ -30,6 +30,10 @@ export function parseAskUserQuestions(
   approval: ApprovalRequest,
 ): AskUserQuestion[] {
   const parsed = safeJsonParseOr<unknown>(approval.toolArgs, {});
+  // safeJsonParseOr returns the raw JSON.parse result, so valid-but-non-object
+  // toolArgs (e.g. "null" → null, "true", "42", "[1,2]") reaches here. Guard
+  // before dereferencing `.questions` — this parser runs in the render path and
+  // a throw bricks the TUI. Reject null, primitives, and arrays.
   if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
     return [];
   }

--- a/src/cli/helpers/ask-user-questions.ts
+++ b/src/cli/helpers/ask-user-questions.ts
@@ -29,11 +29,11 @@ export type AskUserQuestion = {
 export function parseAskUserQuestions(
   approval: ApprovalRequest,
 ): AskUserQuestion[] {
-  const parsed = safeJsonParseOr<Record<string, unknown>>(
-    approval.toolArgs,
-    {},
-  );
-  const questions = parsed.questions;
+  const parsed = safeJsonParseOr<unknown>(approval.toolArgs, {});
+  if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return [];
+  }
+  const questions = (parsed as Record<string, unknown>).questions;
   if (!Array.isArray(questions) || questions.length === 0) return [];
   return questions.every(isWellFormedQuestion)
     ? (questions as AskUserQuestion[])

--- a/src/cli/helpers/ask-user-questions.ts
+++ b/src/cli/helpers/ask-user-questions.ts
@@ -1,0 +1,68 @@
+import { safeJsonParseOr } from "@/cli/helpers/safe-json-parse";
+import type { ApprovalRequest } from "@/cli/helpers/stream";
+
+export type AskUserQuestionOption = { label: string; description: string };
+
+export type AskUserQuestion = {
+  question: string;
+  header: string;
+  options: AskUserQuestionOption[];
+  multiSelect: boolean;
+  allowOther?: boolean;
+};
+
+/**
+ * Parse and validate the `questions` array from an AskUserQuestion tool call.
+ *
+ * The TUI renders a pending AskUserQuestion approval before the tool
+ * implementation can reject bad args, so malformed shapes must never reach the
+ * renderer. InlineQuestionApproval derefs `question` (`.includes()`), renders
+ * `header`/`option.description` as React children, and spreads `options`, so a
+ * non-string `question`/`header`/`description` or a non-array `options` throws
+ * and bricks the TUI on startup.
+ *
+ * Returns [] for anything malformed so callers fall through to a safe generic
+ * approval path. This is the single source of truth shared by both the
+ * ApprovalSwitch render path and the use-approval-flow submit path, to avoid
+ * the dual-validation drift flagged in the architecture notes.
+ */
+export function parseAskUserQuestions(
+  approval: ApprovalRequest,
+): AskUserQuestion[] {
+  const parsed = safeJsonParseOr<Record<string, unknown>>(
+    approval.toolArgs,
+    {},
+  );
+  const questions = parsed.questions;
+  if (!Array.isArray(questions) || questions.length === 0) return [];
+  return questions.every(isWellFormedQuestion)
+    ? (questions as AskUserQuestion[])
+    : [];
+}
+
+function isWellFormedQuestion(q: unknown): boolean {
+  if (q == null || typeof q !== "object") return false;
+  const question = q as Record<string, unknown>;
+  if (typeof question.question !== "string") return false;
+  if (typeof question.header !== "string") return false;
+  if (typeof question.multiSelect !== "boolean") return false;
+  if (
+    question.allowOther !== undefined &&
+    typeof question.allowOther !== "boolean"
+  ) {
+    return false;
+  }
+  const options = question.options;
+  if (!Array.isArray(options) || options.length === 0) return false;
+  return options.every(isWellFormedOption);
+}
+
+function isWellFormedOption(o: unknown): boolean {
+  if (o == null || typeof o !== "object") return false;
+  const option = o as Record<string, unknown>;
+  return (
+    typeof option.label === "string" &&
+    option.label.length > 0 &&
+    typeof option.description === "string"
+  );
+}

--- a/src/cli/helpers/ask-user-questions.ts
+++ b/src/cli/helpers/ask-user-questions.ts
@@ -38,7 +38,18 @@ export function parseAskUserQuestions(
     return [];
   }
   const questions = (parsed as Record<string, unknown>).questions;
-  if (!Array.isArray(questions) || questions.length === 0) return [];
+  // AskUserQuestion contract (src/tools/schemas/AskUserQuestion.json): 1–4
+  // questions, each with 2–4 options. The tool implementation
+  // (src/tools/impl/ask-user-question.ts) rejects anything outside these
+  // bounds on submit, so accept them here too — otherwise we'd render the
+  // specialized question UI for a payload guaranteed to be rejected.
+  if (
+    !Array.isArray(questions) ||
+    questions.length < 1 ||
+    questions.length > 4
+  ) {
+    return [];
+  }
   return questions.every(isWellFormedQuestion)
     ? (questions as AskUserQuestion[])
     : [];
@@ -57,7 +68,10 @@ function isWellFormedQuestion(q: unknown): boolean {
     return false;
   }
   const options = question.options;
-  if (!Array.isArray(options) || options.length === 0) return false;
+  // 2–4 options per the AskUserQuestion contract (see header comment).
+  if (!Array.isArray(options) || options.length < 2 || options.length > 4) {
+    return false;
+  }
   return options.every(isWellFormedOption);
 }
 


### PR DESCRIPTION
## Problem

A malformed `AskUserQuestion` tool call can brick the TUI on startup with:

```
ERROR  Spread syntax requires ...iterable not be null or undefined
…/letta.js:455593
  …currentQuestion.options,
```

`ApprovalSwitch.getQuestions()` parsed args with a bare type assertion and **no runtime validation**:

```ts
function getQuestions(approval: ApprovalRequest): Question[] {
  try {
    const args = JSON.parse(approval.toolArgs || "{}");
    return (args.questions as Question[]) || [];   // ← no shape check
  } catch { return []; }
}
```

When a model emits `questions` as a **JSON string** instead of an array (observed in the wild — a gstack `/office-hours`-style skill produced exactly this), that string is returned as-is. Then:

- `ApprovalSwitch` checks `questions.length > 0` → a string has `.length`, so it **passes** → renders `InlineQuestionApproval`.
- `InlineQuestionApproval` does `currentQuestion = questions[0]` → the first **character** (truthy) → `...currentQuestion.options` → `undefined` → **throws**.
- The malformed tool call is persisted as a pending approval, so the TUI **crashes on every subsequent startup** until the approval is cleared (`letta --new`) or denied.

`options` is required by the tool schema, but the renderer must not assume well-formed input — it runs before the tool implementation can reject bad args.

## Fix (two layers)

1. **`getQuestions()` validates shape** — returns `[]` unless `questions` is a non-empty array where every entry is an object with a non-empty `options` array. Malformed payloads fall through to `InlineGenericApproval`, matching how malformed Bash/Task args are already handled.
2. **`InlineQuestionApproval` guards `currentQuestion.options`** with `?? []` as defense-in-depth for any other path that could construct the component with bad data.

## Verification

- New `ApprovalSwitch.test.ts` (9 cases): string-encoded `questions`, missing/null/empty `options`, non-array, partial malformation, unparseable/empty args — all return `[]`; well-formed payload returns the questions.
- `bun test` ✅ 9 pass
- `tsc --noEmit` ✅ clean
- `biome check` ✅ clean

## Notes

- `getQuestions` is now `export`ed so the parser is unit-testable in isolation.
- Minimal diff: ~25 lines across two source files + a colocated test.