### PR TITLE
fix(app-server): strip model_settings from conversation create body on cloud

### DIFF
--- a/src/websocket/listener/commands/agents-conversations.ts
+++ b/src/websocket/listener/commands/agents-conversations.ts
@@ -30,6 +30,7 @@ import {
   isConversationRetrieveCommand,
   isConversationUpdateCommand,
 } from "@/websocket/listener/protocol-inbound";
+import { sanitizeConversationCreateBody } from "./conversation-body";
 import type { RunDetachedListenerTask, SafeSocketSend } from "./types";
 
 export type AgentConversationManagementCommand =
@@ -302,7 +303,13 @@ export async function handleAgentConversationManagementCommand(
 
   if (parsed.type === "conversation_create") {
     try {
-      const conversation = await backend.createConversation(parsed.body);
+      const sanitizedBody = sanitizeConversationCreateBody(
+        parsed.body as Record<string, unknown>,
+        backend.capabilities,
+      );
+      const conversation = await backend.createConversation(
+        sanitizedBody as typeof parsed.body,
+      );
       safeSocketSend(
         socket,
         {

--- a/src/websocket/listener/commands/conversation-body.test.ts
+++ b/src/websocket/listener/commands/conversation-body.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { sanitizeConversationCreateBody } from "./conversation-body";
+
+const cloudCapabilities = { localMemfs: false };
+const localCapabilities = { localMemfs: true };
+
+describe("sanitizeConversationCreateBody", () => {
+  test("strips model_settings on cloud backend", () => {
+    const body = {
+      agent_id: "agent-1",
+      model: "lc-zai-coding/glm-5.1",
+      model_settings: { parallel_tool_calls: true, provider_type: "zai_coding" },
+    };
+    const result = sanitizeConversationCreateBody(body, cloudCapabilities);
+    expect(result).not.toHaveProperty("model_settings");
+    expect(result).toMatchObject({ agent_id: "agent-1", model: "lc-zai-coding/glm-5.1" });
+  });
+
+  test("strips empty model_settings object on cloud backend", () => {
+    const body = { agent_id: "agent-1", model_settings: {} };
+    const result = sanitizeConversationCreateBody(body, cloudCapabilities);
+    expect(result).not.toHaveProperty("model_settings");
+  });
+
+  test("strips null model_settings on cloud backend", () => {
+    const body = { agent_id: "agent-1", model_settings: null };
+    const result = sanitizeConversationCreateBody(body, cloudCapabilities);
+    expect(result).not.toHaveProperty("model_settings");
+  });
+
+  test("passes body through unchanged when model_settings is absent (cloud)", () => {
+    const body = { agent_id: "agent-1", model: "anthropic/claude-opus-4-5" };
+    const result = sanitizeConversationCreateBody(body, cloudCapabilities);
+    expect(result).toBe(body);
+  });
+
+  test("preserves model_settings on local backend", () => {
+    const body = {
+      agent_id: "agent-local-1",
+      model: "openai/gpt-5-mini",
+      model_settings: { provider_type: "openai", parallel_tool_calls: false },
+    };
+    const result = sanitizeConversationCreateBody(body, localCapabilities);
+    expect(result).toBe(body);
+    expect(result).toHaveProperty("model_settings");
+  });
+
+  test("does not mutate the original body", () => {
+    const body = {
+      agent_id: "agent-1",
+      model_settings: { provider_type: "zai_coding" },
+    };
+    const original = { ...body };
+    sanitizeConversationCreateBody(body, cloudCapabilities);
+    expect(body).toEqual(original);
+  });
+});

--- a/src/websocket/listener/commands/conversation-body.ts
+++ b/src/websocket/listener/commands/conversation-body.ts
@@ -1,0 +1,30 @@
+/**
+ * Helpers for sanitizing conversation create/update request bodies before
+ * they are forwarded to the backend API.
+ */
+
+import type { BackendCapabilities } from "@/backend";
+
+/**
+ * Strips fields from a conversation create body that are accepted by the
+ * TS client SDK types but rejected by the cloud API endpoint.
+ *
+ * Specifically, `model_settings` is advertised in `ConversationCreateParams`
+ * (letta-client 1.10.2) but the live `POST /v1/conversations/` endpoint
+ * returns 500 when it is present. The local backend stores and uses
+ * `model_settings` on conversations for per-conversation model overrides, so
+ * we only strip it on the cloud path.
+ */
+export function sanitizeConversationCreateBody(
+  body: Record<string, unknown>,
+  capabilities: Pick<BackendCapabilities, "localMemfs">,
+): Record<string, unknown> {
+  if (capabilities.localMemfs) {
+    return body;
+  }
+  if (!Object.hasOwn(body, "model_settings")) {
+    return body;
+  }
+  const { model_settings: _stripped, ...rest } = body;
+  return rest;
+}

--- a/src/websocket/listener/commands/runtime-start.ts
+++ b/src/websocket/listener/commands/runtime-start.ts
@@ -19,6 +19,7 @@ import type {
   ConversationRuntime,
   ListenerRuntime,
 } from "@/websocket/listener/types";
+import { sanitizeConversationCreateBody } from "./conversation-body";
 import type {
   GetOrCreateScopedRuntime,
   RunDetachedListenerTask,
@@ -166,10 +167,14 @@ async function resolveRuntimeStartConversation(
     return conversation;
   }
 
-  const body = {
+  const rawBody = {
     ...(parsed.create_conversation?.body ?? {}),
     agent_id: agent.id,
   } satisfies ConversationCreateParams;
+  const body = sanitizeConversationCreateBody(
+    rawBody as Record<string, unknown>,
+    backend.capabilities,
+  ) as typeof rawBody;
   const conversation = await backend.createConversation(body);
   created.conversation = true;
   return conversation;


### PR DESCRIPTION
## summary
- Desktop v0.27.9 New Conversation always 500s via the app-server conversation create paths
- Root cause: `letta-client` SDK advertises `model_settings` on `ConversationCreateParams` but the cloud `POST /v1/conversations/` endpoint rejects it (returns 500, not 422, hiding the cause)
- Both app-server paths added in #2828/#2832 forward the body directly without stripping `model_settings`
- Fix: `sanitizeConversationCreateBody()` strips `model_settings` before forwarding on the cloud path; local backend preserves it (used for per-conversation model overrides)

## affected paths
- `conversation_create` WS command (`agents-conversations.ts`)
- `runtime_start` with `create_conversation` body (`runtime-start.ts`)

## test plan
- [ ] New Conversation button in Desktop no longer 500s
- [ ] Fork still works (unaffected path)
- [ ] Local backend conversation create with `model_settings` still works
- [ ] `bun test src/websocket/listener/commands/conversation-body.test.ts`
- [ ] `bun test src/websocket/listen-client-protocol.test.ts`

?? Generated with [Letta Code](https://letta.com)
