### PR TITLE
feat(reflection): embed reflection agent ID in task-notification XML

### DIFF
--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -613,15 +613,20 @@ export async function wireChannelIngress(
       feedbackContext: {
         surface: getListenerTelemetrySurface(),
       },
-      onCompletionMessage: async (completionMessage) => {
+      onCompletionMessage: async (completionMessage, result) => {
         const conversationRuntime = getOrCreateConversationRuntime(
           listener,
           agentId,
           conversationId,
         );
+        const reflectionAgentIdTag = result.reflectionAgentId
+          ? `<reflection-agent-id>${escapeTaskNotificationSummary(
+              result.reflectionAgentId,
+            )}</reflection-agent-id>`
+          : "";
         const notificationXml = `<task-notification><summary>${escapeTaskNotificationSummary(
           completionMessage,
-        )}</summary></task-notification>`;
+        )}</summary>${reflectionAgentIdTag}</task-notification>`;
         emitStreamDelta(
           socket,
           conversationRuntime,

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -238,10 +238,15 @@ export function buildMaybeLaunchReflectionSubagent(params: {
       feedbackContext: {
         surface: getListenerTelemetrySurface(),
       },
-      onCompletionMessage: async (completionMessage) => {
+      onCompletionMessage: async (completionMessage, result) => {
+        const reflectionAgentIdTag = result.reflectionAgentId
+          ? `<reflection-agent-id>${escapeTaskNotificationSummary(
+              result.reflectionAgentId,
+            )}</reflection-agent-id>`
+          : "";
         const notificationXml = `<task-notification><summary>${escapeTaskNotificationSummary(
           completionMessage,
-        )}</summary></task-notification>`;
+        )}</summary>${reflectionAgentIdTag}</task-notification>`;
         emitCanonicalMessageDelta(
           socket,
           runtime,


### PR DESCRIPTION
## Summary
- Include `<reflection-agent-id>` in the reflection completion `<task-notification>` emitted over the listener websocket (both `turn.ts` and `lifecycle.ts` build sites).
- The agent ID is already available via `onCompletionMessage`s result arg — this just surfaces it so downstream surfaces (e.g. the desktop app) can link to the persistent reflection subagent.
- TUI parsing is unaffected: `extractTaskNotificationsForDisplay` only reads `<summary>`/`<status>`, so the extra tag is ignored there.

This is the letta-code half of a two-repo change. The letta-cloud half (desktop rendering + links) is in letta-cloud#TBD.

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test src/cli/helpers/post-turn-reflection.test.ts` passes
- [ ] Manually verify a reflection completion notification includes `<reflection-agent-id>` when run against the desktop listener

👾 Generated with [Letta Code](https://letta.com)