### PR TITLE
Add christinatong01 as codeowner for websocket code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 /src/agent/memoryGit.ts @letta-ai/system-prompt-owners
 
 # WebSocket listener and protocol code
-/src/websocket/ @cpacker @4shub @kl2806 @carenthomas
+/src/websocket/ @cpacker @4shub @kl2806 @carenthomas @christinatong01
 
 # Headless mode runtime
 /src/headless.ts @cpacker @4shub @kl2806 @devanshrj @sarahwooders @jnjpng @carenthomas

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,4 +15,4 @@
 /src/agent/prompts/source_codex.md @kl2806
 
 # TUI/CLI runtime and UI
-/src/cli/ @cpacker @4shub @kl2806 @sarahwooders @jnjpng @carenthomas
+/src/cli/ @cpacker @4shub @kl2806 @sarahwooders @jnjpng @carenthomas @christinatong01


### PR DESCRIPTION
## Summary
- Adds `@christinatong01` to the `/src/websocket/` CODEOWNERS entry so Christina is a required reviewer on websocket PRs

## Test plan
- [ ] Verify CODEOWNERS syntax is valid
- [ ] Confirm PRs touching `src/websocket/` now request review from christinatong01

🤖 Generated with [Letta Code](https://letta.com)