### PR TITLE
feat(slack): show memory tool lifecycle reactions

### DIFF
--- a/src/channels/discord/adapter.ts
+++ b/src/channels/discord/adapter.ts
@@ -922,6 +922,9 @@ export function createDiscordAdapter(
         return;
       }
       if (event.type === "processing") return;
+      if (event.type === "tool_started" || event.type === "tool_finished") {
+        return;
+      }
       const nextState: LifecycleState =
         event.outcome === "completed"
           ? "completed"

--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -2,7 +2,10 @@ import { afterAll, afterEach, beforeEach, expect, mock, test } from "bun:test";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ChannelMessageAttachment } from "@/channels/types";
+import type {
+  ChannelMessageAttachment,
+  ChannelTurnSource,
+} from "@/channels/types";
 
 type SlackMessageHandler = (args: {
   message: {
@@ -127,12 +130,26 @@ class FakeSlackWriteClient {
 
   readonly token: string;
   readonly options: Record<string, unknown> | undefined;
+  readonly reactionCalls: Array<{
+    action: "add" | "remove";
+    args: { channel: string; timestamp: string; name: string };
+  }> = [];
   readonly chat = {
     postMessage: mock(async () => ({ ts: "1712800000.000100" })),
   };
   readonly reactions = {
-    add: mock(async () => ({ ok: true })),
-    remove: mock(async () => ({ ok: true })),
+    add: mock(
+      async (args: { channel: string; timestamp: string; name: string }) => {
+        this.reactionCalls.push({ action: "add", args });
+        return { ok: true };
+      },
+    ),
+    remove: mock(
+      async (args: { channel: string; timestamp: string; name: string }) => {
+        this.reactionCalls.push({ action: "remove", args });
+        return { ok: true };
+      },
+    ),
   };
   readonly files = {
     getUploadURLExternal: mock(async () => ({
@@ -1235,6 +1252,128 @@ test("slack adapter adds eyes while a queued turn is processing, then swaps to c
     timestamp: "1712800000.000100",
     name: "white_check_mark",
   });
+});
+
+test("slack adapter adds and removes brain reactions around memory tools", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+
+  const source: ChannelTurnSource = {
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    chatType: "channel",
+    messageId: "1712800000.000110",
+    threadId: "1712790000.000050",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  };
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "tool_started",
+    toolName: "memory",
+    sources: [source],
+  });
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "tool_finished",
+    toolName: "memory",
+    sources: [source],
+  });
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "tool_started",
+    toolName: "Bash",
+    sources: [source],
+  });
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient?.reactions.add).toHaveBeenCalledTimes(1);
+  expect(writeClient?.reactions.add).toHaveBeenCalledWith({
+    channel: "C123",
+    timestamp: "1712800000.000110",
+    name: "brain",
+  });
+  expect(writeClient?.reactions.remove).toHaveBeenCalledTimes(1);
+  expect(writeClient?.reactions.remove).toHaveBeenCalledWith({
+    channel: "C123",
+    timestamp: "1712800000.000110",
+    name: "brain",
+  });
+});
+
+test("slack adapter clears stranded brain before terminal lifecycle reactions", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+
+  const source: ChannelTurnSource = {
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    chatType: "channel",
+    messageId: "1712800000.000120",
+    threadId: "1712790000.000050",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  };
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "tool_started",
+    toolName: "memory_apply_patch",
+    sources: [source],
+  });
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "finished",
+    batchId: "batch-stranded-brain",
+    outcome: "completed",
+    sources: [source],
+  });
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient?.reactionCalls).toEqual([
+    {
+      action: "add",
+      args: {
+        channel: "C123",
+        timestamp: "1712800000.000120",
+        name: "brain",
+      },
+    },
+    {
+      action: "remove",
+      args: {
+        channel: "C123",
+        timestamp: "1712800000.000120",
+        name: "brain",
+      },
+    },
+    {
+      action: "add",
+      args: {
+        channel: "C123",
+        timestamp: "1712800000.000120",
+        name: "white_check_mark",
+      },
+    },
+  ]);
 });
 
 test("slack adapter can suppress the completed checkmark while preserving queued eyes", async () => {

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -241,6 +241,14 @@ const SLACK_INGRESS_DEDUPE_MAX = 2_000;
 const SLACK_LIFECYCLE_STATE_TTL_MS = 6 * 60 * 60 * 1000;
 const SLACK_LIFECYCLE_STATE_MAX = 2_000;
 const SLACK_LIFECYCLE_ERROR_TEXT_MAX = 3_000;
+const SLACK_MEMORY_TOOL_REACTION = "brain";
+const SLACK_MEMORY_TOOL_NAMES = new Set([
+  "memory",
+  "memory_apply_patch",
+  "memory_insert",
+  "memory_replace",
+  "memory_rethink",
+]);
 
 type SlackLifecycleState = "queued" | "completed" | "error" | "cancelled";
 
@@ -506,6 +514,11 @@ export function createSlackAdapter(
     { state: SlackLifecycleState; updatedAt: number }
   >();
   const lifecycleOperationByMessageKey = new Map<string, Promise<void>>();
+  const memoryToolReactionDepthByMessageKey = new Map<string, number>();
+  const memoryToolReactionOperationByMessageKey = new Map<
+    string,
+    Promise<void>
+  >();
 
   // ── Inbound debounce (optional) ───────────────────────────────
   // When `inboundDebounceMs > 0`, short back-to-back messages from the same
@@ -794,6 +807,67 @@ export function createSlackAdapter(
       thread_ts: replyToMessageId,
     });
     rememberMessageThread(response.ts, replyToMessageId);
+  }
+
+  function scheduleMemoryToolReactionUpdate(
+    source: ChannelTurnSource,
+    action: "add" | "remove",
+    options?: { force?: boolean },
+  ): Promise<void> | null {
+    const key = getLifecycleMessageKey(source);
+    if (!key) {
+      return null;
+    }
+
+    const previous =
+      memoryToolReactionOperationByMessageKey.get(key) ?? Promise.resolve();
+    const operation = previous
+      .catch(() => {})
+      .then(async () => {
+        const currentDepth = memoryToolReactionDepthByMessageKey.get(key) ?? 0;
+        if (action === "add") {
+          if (currentDepth > 0) {
+            memoryToolReactionDepthByMessageKey.set(key, currentDepth + 1);
+            return;
+          }
+          try {
+            await sendLifecycleReaction(source, SLACK_MEMORY_TOOL_REACTION);
+            memoryToolReactionDepthByMessageKey.set(key, 1);
+          } catch (error) {
+            console.warn(
+              `[Slack] Failed to add memory tool reaction for ${key}:`,
+              error instanceof Error ? error.message : error,
+            );
+          }
+          return;
+        }
+
+        if (currentDepth <= 0) {
+          return;
+        }
+        if (!options?.force && currentDepth > 1) {
+          memoryToolReactionDepthByMessageKey.set(key, currentDepth - 1);
+          return;
+        }
+
+        memoryToolReactionDepthByMessageKey.delete(key);
+        try {
+          await sendLifecycleReaction(source, SLACK_MEMORY_TOOL_REACTION, true);
+        } catch (error) {
+          console.warn(
+            `[Slack] Failed to remove memory tool reaction for ${key}:`,
+            error instanceof Error ? error.message : error,
+          );
+        }
+      })
+      .finally(() => {
+        if (memoryToolReactionOperationByMessageKey.get(key) === operation) {
+          memoryToolReactionOperationByMessageKey.delete(key);
+        }
+      });
+
+    memoryToolReactionOperationByMessageKey.set(key, operation);
+    return operation;
   }
 
   function scheduleLifecycleTransition(
@@ -1324,6 +1398,8 @@ export function createSlackAdapter(
       seenIngressMessageKeys.clear();
       lifecycleStateByMessageKey.clear();
       lifecycleOperationByMessageKey.clear();
+      memoryToolReactionDepthByMessageKey.clear();
+      memoryToolReactionOperationByMessageKey.clear();
       pendingTopLevelDebounceKeys.clear();
       appMentionRetryKeys.clear();
       appMentionDispatchedKeys.clear();
@@ -1349,6 +1425,25 @@ export function createSlackAdapter(
       if (event.type === "processing") {
         return;
       }
+
+      if (event.type === "tool_started" || event.type === "tool_finished") {
+        if (!SLACK_MEMORY_TOOL_NAMES.has(event.toolName)) {
+          return;
+        }
+        const action = event.type === "tool_started" ? "add" : "remove";
+        await Promise.all(
+          event.sources.map((source) =>
+            scheduleMemoryToolReactionUpdate(source, action),
+          ),
+        );
+        return;
+      }
+
+      await Promise.all(
+        event.sources.map((source) =>
+          scheduleMemoryToolReactionUpdate(source, "remove", { force: true }),
+        ),
+      );
 
       const nextState: SlackLifecycleState =
         event.outcome === "completed"

--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -1484,6 +1484,10 @@ export function createTelegramAdapter(
         return;
       }
 
+      if (event.type === "tool_started" || event.type === "tool_finished") {
+        return;
+      }
+
       for (const source of event.sources) {
         stopTypingForSource(source);
       }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -114,6 +114,16 @@ export type ChannelTurnLifecycleEvent =
       sources: ChannelTurnSource[];
     }
   | {
+      type: "tool_started";
+      sources: ChannelTurnSource[];
+      toolName: string;
+    }
+  | {
+      type: "tool_finished";
+      sources: ChannelTurnSource[];
+      toolName: string;
+    }
+  | {
       type: "finished";
       batchId: string;
       sources: ChannelTurnSource[];

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -2071,7 +2071,11 @@ async function dispatchMemoryToolLifecycleEvent(
   sources: ChannelTurnSource[],
 ): Promise<void> {
   try {
-    await getChannelRegistry().dispatchTurnLifecycleEvent({
+    const registry = getChannelRegistry();
+    if (!registry) {
+      return;
+    }
+    await registry.dispatchTurnLifecycleEvent({
       type,
       toolName,
       sources,

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -16,7 +16,7 @@ import {
   getCachedDynamicMessageChannelToolDefinition,
   type MessageChannelToolDiscoveryScope,
 } from "@/channels/message-tool";
-import { getActiveChannelIds } from "@/channels/registry";
+import { getActiveChannelIds, getChannelRegistry } from "@/channels/registry";
 import type { ChannelTurnSource } from "@/channels/types";
 import { INTERRUPTED_BY_USER } from "@/constants";
 import {
@@ -236,6 +236,15 @@ const STREAMING_SHELL_TOOLS = new Set([
 
 // Tools that write files — used to trigger onFileWrite broadcast after execution.
 const FILE_MUTATING_TOOLS = new Set(["Edit", "Write", "MultiEdit", "replace"]);
+
+// Memory-mutating tools. Keep local to avoid importing toolset.ts, which imports this module.
+const MEMORY_MUTATING_TOOL_NAMES = new Set<string>([
+  "memory",
+  "memory_apply_patch",
+  "memory_insert",
+  "memory_replace",
+  "memory_rethink",
+]);
 
 // Maps internal tool names to server/model-facing tool names
 // This allows us to have multiple implementations (e.g., write_file_gemini, Write from Anthropic)
@@ -730,6 +739,12 @@ function buildExecutionRuntimeContextSnapshot(options?: {
     getCurrentWorkingDirectory();
   mergedScope.permissionMode =
     options?.permissionModeState?.mode ?? mergedScope.permissionMode;
+  if (options?.channelToolScope !== undefined) {
+    mergedScope.channelToolScope = options.channelToolScope;
+  }
+  if (options?.channelTurnSources?.length) {
+    mergedScope.channelTurnSources = [...options.channelTurnSources];
+  }
 
   return mergedScope;
 }
@@ -2037,6 +2052,39 @@ function getModToolStatus(result: unknown): "success" | "error" {
   return "success";
 }
 
+function getMemoryToolLifecycleSources(
+  toolName: string,
+  executionScope: RuntimeContextSnapshot,
+): ChannelTurnSource[] | undefined {
+  if (!MEMORY_MUTATING_TOOL_NAMES.has(toolName)) {
+    return undefined;
+  }
+  if (!executionScope.channelTurnSources?.length) {
+    return undefined;
+  }
+  return [...executionScope.channelTurnSources];
+}
+
+async function dispatchMemoryToolLifecycleEvent(
+  type: "tool_started" | "tool_finished",
+  toolName: string,
+  sources: ChannelTurnSource[],
+): Promise<void> {
+  try {
+    await getChannelRegistry().dispatchTurnLifecycleEvent({
+      type,
+      toolName,
+      sources,
+    });
+  } catch (error) {
+    debugLog(
+      "channels",
+      `Failed to dispatch memory tool lifecycle event ${type} for ${toolName}`,
+      error,
+    );
+  }
+}
+
 type ToolHookContext = {
   args: Record<string, unknown>;
   debugLabel: string;
@@ -2424,10 +2472,12 @@ export async function executeTool(
         workingDirectory: context.runtimeContext.workingDirectory ?? undefined,
         permissionModeState: context.permissionModeState,
         runtimeContext: context.runtimeContext,
+        channelTurnSources: options?.channelTurnSources,
       })
     : buildExecutionRuntimeContextSnapshot({
         workingDirectory: context?.workingDirectory,
         permissionModeState: context?.permissionModeState,
+        channelTurnSources: options?.channelTurnSources,
       });
   const workingDirectory =
     executionScope.workingDirectory ?? getCurrentWorkingDirectory();
@@ -2668,7 +2718,30 @@ export async function executeTool(
         };
       }
 
-      const result = await tool.fn(enhancedArgs);
+      const memoryLifecycleSources = getMemoryToolLifecycleSources(
+        internalName,
+        executionScope,
+      );
+      if (memoryLifecycleSources) {
+        await dispatchMemoryToolLifecycleEvent(
+          "tool_started",
+          internalName,
+          memoryLifecycleSources,
+        );
+      }
+
+      let result: unknown;
+      try {
+        result = await tool.fn(enhancedArgs);
+      } finally {
+        if (memoryLifecycleSources) {
+          await dispatchMemoryToolLifecycleEvent(
+            "tool_finished",
+            internalName,
+            memoryLifecycleSources,
+          );
+        }
+      }
       const duration = Date.now() - startTime;
 
       // Broadcast file content after file-mutating tools so web clients update


### PR DESCRIPTION
## Summary
- Emit `tool_started` / `tool_finished` lifecycle events around actual internal memory tool execution when channel turn sources are present.
- Add Slack `:brain:` reactions while memory tools run, with best-effort cleanup before terminal lifecycle reactions.
- Ignore the new lifecycle events in non-Slack adapters and cover Slack memory reaction behavior in tests.

## Test plan
- [x] `bun test src/channels/slack-adapter.test.ts`
- [x] `bun run typecheck`
- [x] `bun run lint`

👾 Generated with [Letta Code](https://letta.com)