### PR TITLE
fix(channels): clear stale approval prompts after handling

### DIFF
--- a/src/channels/registry.test.ts
+++ b/src/channels/registry.test.ts
@@ -1324,6 +1324,34 @@ describe("pending channel control requests", () => {
     });
   });
 
+  test("channel replies clear pending control prompts when approval handling fails", async () => {
+    const replies: Array<{
+      chatId: string;
+      text: string;
+      replyToMessageId?: string;
+    }> = [];
+    const registry = new ChannelRegistry();
+    const adapter = createAdapter(replies);
+    registry.registerAdapter(adapter);
+
+    let approvalResponses = 0;
+    registry.setApprovalResponseHandler(async () => {
+      approvalResponses += 1;
+      throw new Error("approval handler failed");
+    });
+
+    await registry.registerPendingControlRequest(
+      createPendingControlRequestEvent(),
+    );
+
+    await expect(adapter.onMessage?.(createInboundMessage("2"))).rejects.toThrow(
+      "approval handler failed",
+    );
+
+    expect(approvalResponses).toBe(1);
+    expect(registry.hasPendingControlRequest("req-ask-1")).toBe(false);
+  });
+
   test("/cancel bypasses pending channel control prompts", async () => {
     const replies: Array<{
       chatId: string;

--- a/src/channels/registry.test.ts
+++ b/src/channels/registry.test.ts
@@ -1344,9 +1344,9 @@ describe("pending channel control requests", () => {
       createPendingControlRequestEvent(),
     );
 
-    await expect(adapter.onMessage?.(createInboundMessage("2"))).rejects.toThrow(
-      "approval handler failed",
-    );
+    await expect(
+      adapter.onMessage?.(createInboundMessage("2")),
+    ).rejects.toThrow("approval handler failed");
 
     expect(approvalResponses).toBe(1);
     expect(registry.hasPendingControlRequest("req-ask-1")).toBe(false);

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -1048,15 +1048,18 @@ export class ChannelRegistry {
       return true;
     }
 
-    const handled = await this.approvalResponseHandler({
-      runtime: {
-        agent_id: pending.event.source.agentId,
-        conversation_id: pending.event.source.conversationId,
-      },
-      response: parsed.response,
-    });
-
-    this.clearPendingControlRequest(requestId);
+    let handled: boolean;
+    try {
+      handled = await this.approvalResponseHandler({
+        runtime: {
+          agent_id: pending.event.source.agentId,
+          conversation_id: pending.event.source.conversationId,
+        },
+        response: parsed.response,
+      });
+    } finally {
+      this.clearPendingControlRequest(requestId);
+    }
 
     if (!handled) {
       await adapter.sendDirectReply(


### PR DESCRIPTION
## Problem
Channel approval replies that reached the approval handler could leave their pending control prompt registered if the handler threw. That stale prompt could keep intercepting later channel input.

## Approach
Clear the pending control request in a `finally` block after a parsed approval reply is consumed, while preserving the existing expired-prompt response when the handler returns false.

## Before / after
Before: handler failures skipped `clearPendingControlRequest`.
After: consumed approval replies always clear the prompt, including failure paths, with regression coverage.

## Risk
Low. The change is limited to the channel control-request latch after parsing a reply as an approval response.

## Validation
- `bun test src/channels/registry.test.ts`
- `bun run check`

👾 Generated with [Letta Code](https://letta.com)