### PR TITLE
feat: show ChatGPT OAuth usage

### DIFF
--- a/src/cli/components/ProviderSelector.tsx
+++ b/src/cli/components/ProviderSelector.tsx
@@ -16,6 +16,7 @@ import {
   type ProviderStorageTarget,
   removeProviderByName,
 } from "@/providers/byok-providers";
+import { readChatGPTUsage } from "@/providers/chatgpt-usage-service";
 import { normalizeChatGPTOAuthProviderName } from "@/providers/openai-codex-provider";
 import { connectedRecordsForProvider } from "@/providers/provider-connections";
 import { type Settings, settingsManager } from "@/settings-manager";
@@ -48,6 +49,11 @@ type ProviderSelectionFlow =
 type ConnectedProvidersByTarget = Partial<
   Record<ProviderStorageTarget, Map<string, ProviderResponse>>
 >;
+
+type ChatGPTUsageStatus =
+  | { status: "loading" }
+  | { status: "ready"; summary: string }
+  | { status: "error"; message: string };
 
 interface ProviderSelectorProps {
   onCancel: () => void;
@@ -181,6 +187,21 @@ export function isProviderTargetLoading(input: {
   );
 }
 
+export function isChatGPTUsageProvider(provider: ByokProvider): boolean {
+  return (
+    provider.providerType === "chatgpt_oauth" ||
+    provider.oauthProviderId === "openai-codex" ||
+    provider.providerName === "chatgpt-plus-pro" ||
+    (provider.providerNames ?? []).includes("openai-codex")
+  );
+}
+
+function usageStatusText(status: ChatGPTUsageStatus | undefined): string {
+  if (!status || status.status === "loading") return "Usage: loading...";
+  if (status.status === "error") return `Usage unavailable: ${status.message}`;
+  return status.summary;
+}
+
 export function ProviderSelector({
   onCancel,
   onStartOAuth,
@@ -211,6 +232,9 @@ export function ProviderSelector({
     useState<ValidationState>("idle");
   const [validationError, setValidationError] = useState<string | null>(null);
   const [optionIndex, setOptionIndex] = useState(0);
+  const [chatGPTUsageByProvider, setChatGPTUsageByProvider] = useState<
+    Record<string, ChatGPTUsageStatus>
+  >({});
   // Multi-field input state (for providers like Bedrock)
   const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
   const [focusedFieldIndex, setFocusedFieldIndex] = useState(0);
@@ -404,6 +428,55 @@ export function ProviderSelector({
     },
     [getConnectedProviderRecords],
   );
+
+  const loadChatGPTUsageForProvider = useCallback(
+    (provider: ByokProvider, forceRefresh = false) => {
+      if (!isChatGPTUsageProvider(provider)) return;
+
+      const records = getConnectedProviderRecords(provider);
+      for (const record of records) {
+        const providerName = record.name;
+        setChatGPTUsageByProvider((previous) => ({
+          ...previous,
+          [providerName]: { status: "loading" },
+        }));
+
+        void readChatGPTUsage({
+          target: "local",
+          providerName,
+          forceRefresh,
+        })
+          .then((result) => {
+            if (!mountedRef.current) return;
+            setChatGPTUsageByProvider((previous) => ({
+              ...previous,
+              [providerName]: result.success
+                ? { status: "ready", summary: result.usage.summary }
+                : { status: "error", message: result.error.message },
+            }));
+          })
+          .catch((error) => {
+            if (!mountedRef.current) return;
+            setChatGPTUsageByProvider((previous) => ({
+              ...previous,
+              [providerName]: {
+                status: "error",
+                message:
+                  error instanceof Error
+                    ? error.message
+                    : "Failed to read ChatGPT usage.",
+              },
+            }));
+          });
+      }
+    },
+    [getConnectedProviderRecords],
+  );
+
+  useEffect(() => {
+    if (viewState.type !== "options") return;
+    loadChatGPTUsageForProvider(viewState.provider);
+  }, [loadChatGPTUsageForProvider, viewState]);
 
   // Get provider ID if connected
   const getProviderId = useCallback(
@@ -939,8 +1012,13 @@ export function ProviderSelector({
         viewState.provider,
         selectedTarget,
       );
+      const showUsageRefresh =
+        isChatGPTUsageProvider(viewState.provider) &&
+        connectedRecords.length > 0;
       const connectAnotherIndex = connectedRecords.length;
-      const backIndex = connectedRecords.length + (canConnectAnother ? 1 : 0);
+      const usageRefreshIndex =
+        connectAnotherIndex + (canConnectAnother ? 1 : 0);
+      const backIndex = usageRefreshIndex + (showUsageRefresh ? 1 : 0);
       const optionsLength = backIndex + 1;
       if (key.escape) {
         setViewState({ type: "list" });
@@ -960,6 +1038,8 @@ export function ProviderSelector({
             type: "oauthNameInput",
             provider: viewState.provider,
           });
+        } else if (showUsageRefresh && optionIndex === usageRefreshIndex) {
+          loadChatGPTUsageForProvider(viewState.provider, true);
         } else {
           setViewState({ type: "list" });
         }
@@ -1451,9 +1531,11 @@ export function ProviderSelector({
       provider,
       selectedTarget,
     );
+    const showUsage = isChatGPTUsageProvider(provider);
     const options = [
       ...connectedRecords.map((record) => `Disconnect ${record.name}`),
       ...(canConnectAnother ? [connectAnotherProviderOption(provider)] : []),
+      ...(showUsage && connectedRecords.length > 0 ? ["Refresh usage"] : []),
       "Back",
     ];
 
@@ -1465,16 +1547,34 @@ export function ProviderSelector({
           </Text>
           <Box height={1} />
           {connectedRecords.length > 0 ? (
-            connectedRecords.map((record) => (
-              <Box key={record.id} flexDirection="row">
-                <Text>{"  "}</Text>
-                <Text color="green">[✓]</Text>
-                <Text> </Text>
-                <Text bold>{record.name}</Text>
-                <Text dimColor> · </Text>
-                <Text color="green">Connected</Text>
-              </Box>
-            ))
+            connectedRecords.map((record) => {
+              const usageStatus = chatGPTUsageByProvider[record.name];
+              return (
+                <Box key={record.id} flexDirection="column">
+                  <Box flexDirection="row">
+                    <Text>{"  "}</Text>
+                    <Text color="green">[✓]</Text>
+                    <Text> </Text>
+                    <Text bold>{record.name}</Text>
+                    <Text dimColor> · </Text>
+                    <Text color="green">Connected</Text>
+                  </Box>
+                  {showUsage && (
+                    <Box flexDirection="row">
+                      <Text>{"      "}</Text>
+                      <Text
+                        color={
+                          usageStatus?.status === "error" ? "yellow" : undefined
+                        }
+                        dimColor={usageStatus?.status !== "error"}
+                      >
+                        {usageStatusText(usageStatus)}
+                      </Text>
+                    </Box>
+                  )}
+                </Box>
+              );
+            })
           ) : (
             <Text dimColor>{"  "}No connected providers.</Text>
           )}

--- a/src/cli/components/ProviderSelector.tsx
+++ b/src/cli/components/ProviderSelector.tsx
@@ -16,7 +16,10 @@ import {
   type ProviderStorageTarget,
   removeProviderByName,
 } from "@/providers/byok-providers";
-import { readChatGPTUsage } from "@/providers/chatgpt-usage-service";
+import {
+  formatChatGPTUsageQuotaRows,
+  readChatGPTUsage,
+} from "@/providers/chatgpt-usage-service";
 import { normalizeChatGPTOAuthProviderName } from "@/providers/openai-codex-provider";
 import { connectedRecordsForProvider } from "@/providers/provider-connections";
 import { type Settings, settingsManager } from "@/settings-manager";
@@ -52,7 +55,7 @@ type ConnectedProvidersByTarget = Partial<
 
 type ChatGPTUsageStatus =
   | { status: "loading" }
-  | { status: "ready"; summary: string }
+  | { status: "ready"; rows: string[] }
   | { status: "error"; message: string };
 
 interface ProviderSelectorProps {
@@ -196,10 +199,10 @@ export function isChatGPTUsageProvider(provider: ByokProvider): boolean {
   );
 }
 
-function usageStatusText(status: ChatGPTUsageStatus | undefined): string {
-  if (!status || status.status === "loading") return "Usage: loading...";
-  if (status.status === "error") return `Usage unavailable: ${status.message}`;
-  return status.summary;
+function usageStatusRows(status: ChatGPTUsageStatus | undefined): string[] {
+  if (!status || status.status === "loading") return ["Loading..."];
+  if (status.status === "error") return [`Unavailable: ${status.message}`];
+  return status.rows;
 }
 
 export function ProviderSelector({
@@ -451,7 +454,10 @@ export function ProviderSelector({
             setChatGPTUsageByProvider((previous) => ({
               ...previous,
               [providerName]: result.success
-                ? { status: "ready", summary: result.usage.summary }
+                ? {
+                    status: "ready",
+                    rows: formatChatGPTUsageQuotaRows(result.usage),
+                  }
                 : { status: "error", message: result.error.message },
             }));
           })
@@ -1560,16 +1566,22 @@ export function ProviderSelector({
                     <Text color="green">Connected</Text>
                   </Box>
                   {showUsage && (
-                    <Box flexDirection="row">
-                      <Text>{"      "}</Text>
-                      <Text
-                        color={
-                          usageStatus?.status === "error" ? "yellow" : undefined
-                        }
-                        dimColor={usageStatus?.status !== "error"}
-                      >
-                        {usageStatusText(usageStatus)}
-                      </Text>
+                    <Box flexDirection="column">
+                      {usageStatusRows(usageStatus).map((row) => (
+                        <Box key={row} flexDirection="row">
+                          <Text>{"      "}</Text>
+                          <Text
+                            color={
+                              usageStatus?.status === "error"
+                                ? "yellow"
+                                : undefined
+                            }
+                            dimColor={usageStatus?.status !== "error"}
+                          >
+                            {row}
+                          </Text>
+                        </Box>
+                      ))}
                     </Box>
                   )}
                 </Box>

--- a/src/cli/components/ProviderSelector.tsx
+++ b/src/cli/components/ProviderSelector.tsx
@@ -442,7 +442,7 @@ export function ProviderSelector({
         }));
 
         void readChatGPTUsage({
-          target: "local",
+          target: selectedTarget,
           providerName,
           forceRefresh,
         })
@@ -470,7 +470,7 @@ export function ProviderSelector({
           });
       }
     },
-    [getConnectedProviderRecords],
+    [getConnectedProviderRecords, selectedTarget],
   );
 
   useEffect(() => {

--- a/src/cli/components/provider-selector.test.ts
+++ b/src/cli/components/provider-selector.test.ts
@@ -7,6 +7,7 @@ import {
   fieldValuesFromProviderPlaceholders,
   filterProviderConfigs,
   hasConstellationProviderStoreCredentials,
+  isChatGPTUsageProvider,
   isProviderTargetLoading,
   nextProviderConnectionName,
   providerApiKeyFromInput,
@@ -58,6 +59,14 @@ function providerById(id: string): ByokProvider {
 }
 
 describe("ProviderSelector local provider API keys", () => {
+  test("recognizes ChatGPT OAuth providers for usage display", () => {
+    const chatgpt = providerById("openai-codex-oauth");
+    const openai = providerById("openai");
+
+    expect(isChatGPTUsageProvider(chatgpt)).toBe(true);
+    expect(isChatGPTUsageProvider(openai)).toBe(false);
+  });
+
   test("keeps LM Studio UI identity while using server provider type", () => {
     const lmstudio = providerById("lmstudio");
 

--- a/src/providers/chatgpt-usage-service.test.ts
+++ b/src/providers/chatgpt-usage-service.test.ts
@@ -1,8 +1,36 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import {
   formatChatGPTUsageSnapshot,
   normalizeWhamUsageResponse,
+  readChatGPTUsage,
 } from "@/providers/chatgpt-usage-service";
+
+async function withEnv<T>(
+  updates: Record<string, string | undefined>,
+  run: () => Promise<T>,
+): Promise<T> {
+  const previous = Object.fromEntries(
+    Object.keys(updates).map((key) => [key, process.env[key]]),
+  );
+  try {
+    for (const [key, value] of Object.entries(updates)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    return await run();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
 
 describe("ChatGPT usage service", () => {
   test("normalizes WHAM rate limit windows and builds a compact summary", () => {
@@ -91,5 +119,140 @@ describe("ChatGPT usage service", () => {
     expect(
       formatChatGPTUsageSnapshot(snapshot, new Date("2026-06-18T12:00:00Z")),
     ).toBe("Usage: no active quota window reported");
+  });
+
+  test("reads api-target usage from the Letta Cloud provider endpoint", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchMock = mock(
+      async (url: Parameters<typeof fetch>[0], init?: RequestInit) => {
+        calls.push({ url: String(url), init });
+        return Response.json({
+          providerName: "chatgpt-jin",
+          fetchedAt: "2026-06-18T12:00:00.000Z",
+          summary: "Usage: 5h 70% left resets in 2h",
+          planType: "plus",
+          limitReached: false,
+          rateLimitReachedType: null,
+          primary: {
+            label: "primary",
+            usedPercent: 30,
+            windowDurationMins: 300,
+            resetsAt: 1_781_791_200,
+          },
+          secondary: null,
+          additional: [],
+          credits: null,
+          individualLimit: {
+            limit: "80",
+            used: "24",
+            remainingPercent: 70,
+            resetsAt: 1_781_791_200,
+          },
+        });
+      },
+    ) as unknown as typeof fetch;
+
+    const result = await withEnv(
+      { LETTA_API_KEY: undefined, LETTA_BASE_URL: undefined },
+      () =>
+        readChatGPTUsage({
+          target: "api",
+          providerName: "chatgpt-jin",
+          forceRefresh: true,
+          fetch: fetchMock,
+          now: () => Date.parse("2026-06-18T12:00:00Z"),
+          getSettings: async () => ({
+            env: {
+              LETTA_API_KEY: "letta-access-token",
+              LETTA_BASE_URL: "https://api.test.letta.com",
+            },
+            refreshToken: undefined,
+            tokenExpiresAt: undefined,
+          }),
+        }),
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error(result.error.message);
+    expect(calls).toHaveLength(1);
+    const call = calls[0];
+    if (!call) throw new Error("Expected usage fetch to be called");
+    expect(call.url).toBe(
+      "https://api.test.letta.com/v1/providers/chatgpt-usage?provider_name=chatgpt-jin",
+    );
+    const headers = new Headers(call.init?.headers);
+    expect(headers.get("authorization")).toBe("Bearer letta-access-token");
+    expect(result.usage.summary).toBe("Usage: 5h 70% left resets in 2h");
+    expect(result.usage.individualLimit).toEqual({
+      limit: "80",
+      used: "24",
+      remainingPercent: 70,
+      resetsAt: 1_781_791_200,
+    });
+  });
+
+  test("maps api-target cloud errors without falling back to local usage", async () => {
+    const fetchMock = mock(async () =>
+      Response.json({ message: "Provider not connected" }, { status: 404 }),
+    ) as unknown as typeof fetch;
+
+    const result = await withEnv(
+      { LETTA_API_KEY: undefined, LETTA_BASE_URL: undefined },
+      () =>
+        readChatGPTUsage({
+          target: "api",
+          providerName: "chatgpt-missing",
+          forceRefresh: true,
+          fetch: fetchMock,
+          getSettings: async () => ({
+            env: {
+              LETTA_API_KEY: "letta-access-token",
+              LETTA_BASE_URL: "https://api.test.letta.com",
+            },
+            refreshToken: undefined,
+            tokenExpiresAt: undefined,
+          }),
+        }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error("Expected cloud usage read to fail");
+    expect(result.error).toEqual({
+      code: "not_connected",
+      message: "Provider not connected",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not treat a missing cloud usage endpoint as a disconnected provider", async () => {
+    const fetchMock = mock(
+      async () => new Response("Not Found", { status: 404 }),
+    ) as unknown as typeof fetch;
+
+    const result = await withEnv(
+      { LETTA_API_KEY: undefined, LETTA_BASE_URL: undefined },
+      () =>
+        readChatGPTUsage({
+          target: "api",
+          providerName: "chatgpt-jin",
+          forceRefresh: true,
+          fetch: fetchMock,
+          getSettings: async () => ({
+            env: {
+              LETTA_API_KEY: "letta-access-token",
+              LETTA_BASE_URL: "https://api.test.letta.com",
+            },
+            refreshToken: undefined,
+            tokenExpiresAt: undefined,
+          }),
+        }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error("Expected cloud usage read to fail");
+    expect(result.error).toEqual({
+      code: "network_error",
+      message: "Letta Cloud ChatGPT usage endpoint is unavailable.",
+    });
   });
 });

--- a/src/providers/chatgpt-usage-service.test.ts
+++ b/src/providers/chatgpt-usage-service.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import {
+  formatChatGPTUsageSnapshot,
+  normalizeWhamUsageResponse,
+} from "@/providers/chatgpt-usage-service";
+
+describe("ChatGPT usage service", () => {
+  test("normalizes WHAM rate limit windows and builds a compact summary", () => {
+    const snapshot = normalizeWhamUsageResponse({
+      providerName: "chatgpt-plus-pro",
+      nowMs: Date.parse("2026-06-18T12:00:00Z"),
+      raw: {
+        plan_type: "plus",
+        rate_limit: {
+          limit_reached: false,
+          primary_window: {
+            used_percent: 25.5,
+            limit_window_seconds: 18_000,
+            reset_after_seconds: 7_200,
+          },
+          secondary_window: {
+            used_percent: 12,
+            limit_window_seconds: 604_800,
+            reset_after_seconds: 432_000,
+          },
+          additional_rate_limits: [
+            {
+              name: "extra",
+              used_percent: 40,
+              window_minutes: 60,
+              reset_after_seconds: 1_800,
+            },
+          ],
+        },
+        credits: {
+          balance: "12.5",
+        },
+      },
+    });
+
+    expect(snapshot.providerName).toBe("chatgpt-plus-pro");
+    expect(snapshot.planType).toBe("plus");
+    expect(snapshot.limitReached).toBe(false);
+    expect(snapshot.primary).toEqual({
+      label: "primary",
+      usedPercent: 25.5,
+      windowDurationMins: 300,
+      resetsAt: 1_781_791_200,
+    });
+    expect(snapshot.secondary?.windowDurationMins).toBe(10_080);
+    expect(snapshot.additional[0]).toEqual({
+      label: "extra",
+      usedPercent: 40,
+      windowDurationMins: 60,
+      resetsAt: 1_781_785_800,
+    });
+    expect(snapshot.credits).toEqual({ balance: "12.5" });
+    expect(snapshot.summary).toBe(
+      "Usage: 5h 74.5% left resets in 2h · 7d 88% left resets in 5d · 1h 60% left resets in 30m · credits 12.5",
+    );
+  });
+
+  test("accepts camelCase fields and millisecond reset timestamps", () => {
+    const snapshot = normalizeWhamUsageResponse({
+      providerName: "chatgpt-work",
+      nowMs: Date.parse("2026-06-18T12:00:00Z"),
+      raw: {
+        rateLimit: {
+          primaryWindow: {
+            usedPercent: 100,
+            windowDurationMins: 300,
+            resetsAt: Date.parse("2026-06-18T15:00:00Z"),
+          },
+        },
+        rateLimitReachedType: "primary",
+      },
+    });
+
+    expect(snapshot.rateLimitReachedType).toBe("primary");
+    expect(snapshot.primary?.resetsAt).toBe(1_781_794_800);
+    expect(snapshot.summary).toBe("Usage: 5h 0% left resets in 3h");
+  });
+
+  test("formats an empty usage response without throwing", () => {
+    const snapshot = normalizeWhamUsageResponse({
+      providerName: "chatgpt-plus-pro",
+      nowMs: Date.parse("2026-06-18T12:00:00Z"),
+      raw: {},
+    });
+
+    expect(
+      formatChatGPTUsageSnapshot(snapshot, new Date("2026-06-18T12:00:00Z")),
+    ).toBe("Usage: no active quota window reported");
+  });
+});

--- a/src/providers/chatgpt-usage-service.test.ts
+++ b/src/providers/chatgpt-usage-service.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, mock, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
+  LOCAL_CHATGPT_PROVIDER_NAME,
+  setLocalOAuthProvider,
+} from "@/backend/local/local-provider-auth-store";
+import {
+  formatChatGPTUsageQuotaRows,
   formatChatGPTUsageSnapshot,
   normalizeWhamUsageResponse,
   readChatGPTUsage,
@@ -84,8 +92,11 @@ describe("ChatGPT usage service", () => {
     });
     expect(snapshot.credits).toEqual({ balance: "12.5" });
     expect(snapshot.summary).toBe(
-      "Usage: 5h 74.5% left resets in 2h · 7d 88% left resets in 5d · 1h 60% left resets in 30m · credits 12.5",
+      "Usage: 5h 74.5% left resets in 2h · 7d 88% left resets in 5d · extra 1h 60% left resets in 30m · credits 12.5",
     );
+    expect(
+      formatChatGPTUsageQuotaRows(snapshot, new Date("2026-06-18T12:00:00Z")),
+    ).toEqual(["5h 74.5% left resets in 2h", "7d 88% left resets in 5d"]);
   });
 
   test("accepts camelCase fields and millisecond reset timestamps", () => {
@@ -119,6 +130,97 @@ describe("ChatGPT usage service", () => {
     expect(
       formatChatGPTUsageSnapshot(snapshot, new Date("2026-06-18T12:00:00Z")),
     ).toBe("Usage: no active quota window reported");
+  });
+
+  test("normalizes the Codex WHAM usage payload shape", () => {
+    const snapshot = normalizeWhamUsageResponse({
+      providerName: "chatgpt-plus-pro",
+      nowMs: Date.parse("2026-06-18T12:00:00Z"),
+      raw: {
+        plan_type: "pro",
+        rate_limit: {
+          allowed: true,
+          limit_reached: false,
+          primary_window: {
+            used_percent: 42,
+            limit_window_seconds: 300,
+            reset_after_seconds: 0,
+            reset_at: 123,
+          },
+          secondary_window: {
+            used_percent: 84,
+            limit_window_seconds: 3600,
+            reset_after_seconds: 0,
+            reset_at: 456,
+          },
+        },
+        additional_rate_limits: [
+          {
+            limit_name: "codex_other",
+            metered_feature: "codex_other",
+            rate_limit: {
+              allowed: true,
+              limit_reached: false,
+              primary_window: {
+                used_percent: 70,
+                limit_window_seconds: 900,
+                reset_after_seconds: 0,
+                reset_at: 789,
+              },
+            },
+          },
+        ],
+        credits: {
+          has_credits: true,
+          unlimited: false,
+          balance: "9.99",
+        },
+        rate_limit_reset_credits: {
+          available_count: 3,
+        },
+        spend_control: {
+          reached: false,
+          individual_limit: {
+            limit: "25000",
+            used: "8000",
+            remaining: "17000",
+            used_percent: 32,
+            remaining_percent: 68,
+            reset_after_seconds: 3600,
+            reset_at: 789,
+          },
+        },
+        rate_limit_reached_type: {
+          type: "workspace_member_credits_depleted",
+        },
+      },
+    });
+
+    expect(snapshot.planType).toBe("pro");
+    expect(snapshot.limitReached).toBe(false);
+    expect(snapshot.rateLimitReachedType).toBe(
+      "workspace_member_credits_depleted",
+    );
+    expect(snapshot.additional).toEqual([
+      {
+        label: "codex_other",
+        usedPercent: 70,
+        windowDurationMins: 15,
+        resetsAt: 789,
+      },
+    ]);
+    expect(snapshot.credits).toEqual({
+      balance: "9.99",
+      availableCount: 3,
+      hasCredits: true,
+      unlimited: false,
+    });
+    expect(snapshot.individualLimit).toEqual({
+      limit: "25000",
+      used: "8000",
+      remainingPercent: 68,
+      resetsAt: 789,
+    });
   });
 
   test("reads api-target usage from the Letta Cloud provider endpoint", async () => {
@@ -254,5 +356,98 @@ describe("ChatGPT usage service", () => {
       code: "network_error",
       message: "Letta Cloud ChatGPT usage endpoint is unavailable.",
     });
+  });
+
+  test("keeps the cloud usage timeout active while reading the response body", async () => {
+    const fetchMock = mock(
+      async (_url: Parameters<typeof fetch>[0], init?: RequestInit) =>
+        ({
+          ok: true,
+          status: 200,
+          json: () =>
+            new Promise((_resolve, reject) => {
+              init?.signal?.addEventListener("abort", () =>
+                reject(new Error("aborted")),
+              );
+            }),
+        }) as Response,
+    ) as unknown as typeof fetch;
+
+    const result = await withEnv(
+      { LETTA_API_KEY: undefined, LETTA_BASE_URL: undefined },
+      () =>
+        readChatGPTUsage({
+          target: "api",
+          providerName: "chatgpt-jin",
+          forceRefresh: true,
+          fetch: fetchMock,
+          timeoutMs: 1,
+          getSettings: async () => ({
+            env: {
+              LETTA_API_KEY: "letta-access-token",
+              LETTA_BASE_URL: "https://api.test.letta.com",
+            },
+            refreshToken: undefined,
+            tokenExpiresAt: undefined,
+          }),
+        }),
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        code: "network_error",
+        message: "Letta Cloud ChatGPT usage request timed out.",
+      },
+    });
+  });
+
+  test("keeps the local WHAM timeout active while reading the response body", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "chatgpt-usage-timeout-"));
+    try {
+      setLocalOAuthProvider({
+        storageDir,
+        providerName: LOCAL_CHATGPT_PROVIDER_NAME,
+        providerType: "chatgpt_oauth",
+        auth: {
+          type: "oauth",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
+          accountId: "account-id",
+        },
+      });
+
+      const fetchMock = mock(
+        async (_url: Parameters<typeof fetch>[0], init?: RequestInit) =>
+          ({
+            ok: true,
+            status: 200,
+            json: () =>
+              new Promise((_resolve, reject) => {
+                init?.signal?.addEventListener("abort", () =>
+                  reject(new Error("aborted")),
+                );
+              }),
+          }) as Response,
+      ) as unknown as typeof fetch;
+
+      const result = await readChatGPTUsage({
+        target: "local",
+        storageDir,
+        fetch: fetchMock,
+        timeoutMs: 1,
+      });
+
+      expect(result).toEqual({
+        success: false,
+        error: {
+          code: "network_error",
+          message: "ChatGPT usage request timed out.",
+        },
+      });
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/providers/chatgpt-usage-service.ts
+++ b/src/providers/chatgpt-usage-service.ts
@@ -1,3 +1,10 @@
+import { hostname } from "node:os";
+import {
+  LETTA_CLOUD_API_URL,
+  refreshAccessToken as refreshLettaAccessToken,
+  type TokenResponse,
+} from "@/auth/oauth";
+import { getLettaCodeHeaders } from "@/backend/api/http-headers";
 import {
   getLocalOAuthApiKey,
   getLocalProviderRecordByName,
@@ -5,11 +12,14 @@ import {
   type LocalProviderRecord,
 } from "@/backend/local/local-provider-auth-store";
 import type { ProviderStorageTarget } from "@/providers/byok-providers";
+import { type Settings, settingsManager } from "@/settings-manager";
 
 const CHATGPT_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
+const CLOUD_CHATGPT_USAGE_PATH = "/v1/providers/chatgpt-usage";
 const OPENAI_CODEX_OAUTH_PROVIDER_ID = "openai-codex";
 const CACHE_TTL_MS = 30_000;
 const DEFAULT_TIMEOUT_MS = 15_000;
+const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 
 export interface ChatGPTUsageWindow {
   label: string;
@@ -25,6 +35,13 @@ export interface ChatGPTUsageCredits {
   unlimited?: boolean | null;
 }
 
+export interface ChatGPTUsageIndividualLimit {
+  limit: string;
+  used: string;
+  remainingPercent: number;
+  resetsAt: number;
+}
+
 export interface ChatGPTUsageSnapshot {
   providerName: string;
   fetchedAt: string;
@@ -36,9 +53,11 @@ export interface ChatGPTUsageSnapshot {
   secondary: ChatGPTUsageWindow | null;
   additional: ChatGPTUsageWindow[];
   credits?: ChatGPTUsageCredits | null;
+  individualLimit?: ChatGPTUsageIndividualLimit | null;
 }
 
 export type ChatGPTUsageErrorCode =
+  | "bad_request"
   | "not_connected"
   | "unsupported_target"
   | "refresh_failed"
@@ -66,6 +85,14 @@ export interface ReadChatGPTUsageInput {
   timeoutMs?: number;
   fetch?: typeof fetch;
   now?: () => number;
+  getSettings?: () => Promise<
+    Pick<Settings, "env" | "refreshToken" | "tokenExpiresAt">
+  >;
+  refreshAccessToken?: (
+    refreshToken: string,
+    deviceId: string,
+    deviceName?: string,
+  ) => Promise<TokenResponse>;
 }
 
 type JsonRecord = Record<string, unknown>;
@@ -263,6 +290,51 @@ function normalizeCredits(
   };
 }
 
+function normalizeIndividualLimit(
+  value: unknown,
+): ChatGPTUsageIndividualLimit | null {
+  const record = asRecord(value);
+  if (!record) return null;
+
+  const limit = getString(record, ["limit"]);
+  const used = getString(record, ["used"]);
+  const remainingPercent = getNumber(record, [
+    "remaining_percent",
+    "remainingPercent",
+  ]);
+  const resetsAt = getTimestampSeconds(record, ["resets_at", "resetsAt"]);
+
+  if (
+    limit === null ||
+    used === null ||
+    remainingPercent === null ||
+    resetsAt === null
+  ) {
+    return null;
+  }
+
+  return {
+    limit,
+    used,
+    remainingPercent,
+    resetsAt,
+  };
+}
+
+function normalizeCloudUsageWindow(
+  value: unknown,
+  fallbackLabel: string,
+  nowMs: number,
+): ChatGPTUsageWindow | null {
+  const record = asRecord(value);
+  if (!record) return null;
+  return normalizeUsageWindow(
+    record,
+    getString(record, ["label", "name"]) ?? fallbackLabel,
+    nowMs,
+  );
+}
+
 function formatPercent(value: number): string {
   const rounded = Math.round(value);
   return Number.isInteger(value) || Math.abs(value - rounded) < 0.05
@@ -404,6 +476,9 @@ export function normalizeWhamUsageResponse(input: {
     secondary,
     additional,
     credits: normalizeCredits(raw, rateLimit),
+    individualLimit: normalizeIndividualLimit(
+      getValue(rateLimit, ["individual_limit", "individualLimit"]),
+    ),
   };
 
   return {
@@ -412,6 +487,63 @@ export function normalizeWhamUsageResponse(input: {
       snapshotWithoutSummary,
       new Date(nowMs),
     ),
+  };
+}
+
+export function normalizeCloudChatGPTUsageResponse(input: {
+  raw: unknown;
+  providerName: string;
+  nowMs?: number;
+}): ChatGPTUsageSnapshot | null {
+  const raw = asRecord(input.raw);
+  if (!raw) return null;
+
+  const nowMs = input.nowMs ?? Date.now();
+  const fetchedAt =
+    getString(raw, ["fetchedAt", "fetched_at"]) ??
+    new Date(nowMs).toISOString();
+  const additional = getRecordArray(raw, [
+    "additional",
+    "additional_rate_limits",
+    "additionalRateLimits",
+  ])
+    .map((window, index) =>
+      normalizeCloudUsageWindow(window, `limit ${index + 1}`, nowMs),
+    )
+    .filter((window): window is ChatGPTUsageWindow => !!window);
+
+  const snapshotWithoutSummary = {
+    providerName:
+      getString(raw, ["providerName", "provider_name"]) ?? input.providerName,
+    fetchedAt,
+    planType: getString(raw, ["planType", "plan_type"]),
+    limitReached: getBoolean(raw, ["limitReached", "limit_reached"]),
+    rateLimitReachedType: getString(raw, [
+      "rateLimitReachedType",
+      "rate_limit_reached_type",
+    ]),
+    primary: normalizeCloudUsageWindow(
+      getValue(raw, ["primary", "primary_window", "primaryWindow"]),
+      "primary",
+      nowMs,
+    ),
+    secondary: normalizeCloudUsageWindow(
+      getValue(raw, ["secondary", "secondary_window", "secondaryWindow"]),
+      "secondary",
+      nowMs,
+    ),
+    additional,
+    credits: normalizeCredits(raw, raw),
+    individualLimit: normalizeIndividualLimit(
+      getValue(raw, ["individualLimit", "individual_limit"]),
+    ),
+  };
+
+  return {
+    ...snapshotWithoutSummary,
+    summary:
+      getString(raw, ["summary"]) ??
+      formatChatGPTUsageSnapshot(snapshotWithoutSummary, new Date(nowMs)),
   };
 }
 
@@ -427,6 +559,25 @@ function retryAfterMs(response: Response): number | undefined {
     : undefined;
 }
 
+function retryAfterMsFromBody(raw: JsonRecord | null): number | undefined {
+  const value = getNumber(raw ?? undefined, ["retryAfterMs", "retry_after_ms"]);
+  return value === null ? undefined : Math.max(0, value);
+}
+
+async function readJsonRecord(response: Response): Promise<JsonRecord | null> {
+  try {
+    return asRecord(await response.json()) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function responseMessage(raw: JsonRecord | null, fallback: string): string {
+  return (
+    getString(raw ?? undefined, ["message", "error", "detail"]) ?? fallback
+  );
+}
+
 function chatGPTUsageError(
   code: ChatGPTUsageErrorCode,
   message: string,
@@ -440,6 +591,70 @@ function chatGPTUsageError(
       ...(retryAfter !== undefined ? { retryAfterMs: retryAfter } : {}),
     },
   };
+}
+
+function cloudBaseUrl(settings: Pick<Settings, "env">): string {
+  return (
+    process.env.LETTA_BASE_URL ||
+    settings.env?.LETTA_BASE_URL ||
+    LETTA_CLOUD_API_URL
+  ).replace(/\/+$/, "");
+}
+
+async function cloudApiKey(input: {
+  settings: Pick<Settings, "env" | "refreshToken" | "tokenExpiresAt">;
+  now: number;
+  refreshAccessToken?: ReadChatGPTUsageInput["refreshAccessToken"];
+}): Promise<{ apiKey: string | null; error?: ChatGPTUsageError }> {
+  const settings = input.settings;
+  const envApiKey = process.env.LETTA_API_KEY;
+  let apiKey = envApiKey || settings.env?.LETTA_API_KEY || null;
+
+  if (
+    !envApiKey &&
+    settings.refreshToken &&
+    (!apiKey ||
+      (settings.tokenExpiresAt !== undefined &&
+        settings.tokenExpiresAt - input.now < TOKEN_REFRESH_BUFFER_MS))
+  ) {
+    try {
+      const refresh = input.refreshAccessToken ?? refreshLettaAccessToken;
+      const tokens = await refresh(
+        settings.refreshToken,
+        settingsManager.getOrCreateDeviceId(),
+        hostname(),
+      );
+      apiKey = tokens.access_token;
+      settingsManager.updateSettings({
+        env: { LETTA_API_KEY: tokens.access_token },
+        refreshToken: tokens.refresh_token || settings.refreshToken,
+        tokenExpiresAt: input.now + tokens.expires_in * 1000,
+      });
+    } catch (error) {
+      return {
+        apiKey: null,
+        error: {
+          code: "refresh_failed",
+          message:
+            error instanceof Error
+              ? error.message
+              : "Failed to refresh the Letta Cloud access token.",
+        },
+      };
+    }
+  }
+
+  if (!apiKey) {
+    return {
+      apiKey: null,
+      error: {
+        code: "unauthorized",
+        message: "Sign in to Letta Cloud to read ChatGPT usage.",
+      },
+    };
+  }
+
+  return { apiKey };
 }
 
 function localProviderNames(providerName: string | undefined): string[] {
@@ -467,18 +682,180 @@ function isConnectedChatGPTOAuthRecord(
   return !!record && isChatGPTOAuthRecord(record);
 }
 
+async function readCloudChatGPTUsage(
+  input: ReadChatGPTUsageInput,
+  now: number,
+): Promise<ChatGPTUsageReadResult> {
+  const providerName = input.providerName?.trim();
+  if (!providerName) {
+    return chatGPTUsageError(
+      "bad_request",
+      "A ChatGPT provider name is required for cloud usage.",
+    );
+  }
+
+  let settings: Pick<Settings, "env" | "refreshToken" | "tokenExpiresAt">;
+  try {
+    settings = await (
+      input.getSettings ?? (() => settingsManager.getSettingsWithSecureTokens())
+    )();
+  } catch (error) {
+    return chatGPTUsageError(
+      "unauthorized",
+      error instanceof Error
+        ? error.message
+        : "Failed to read Letta Cloud credentials.",
+    );
+  }
+
+  const baseUrl = cloudBaseUrl(settings);
+  const cacheKey = `api:${baseUrl}:${providerName}`;
+  const cached = usageCache.get(cacheKey);
+  if (!input.forceRefresh && cached && cached.expiresAt > now) {
+    return cached.result;
+  }
+
+  const auth = await cloudApiKey({
+    settings,
+    now,
+    refreshAccessToken: input.refreshAccessToken,
+  });
+  if (auth.error || !auth.apiKey) {
+    return {
+      success: false,
+      error: auth.error ?? {
+        code: "unauthorized",
+        message: "Sign in to Letta Cloud to read ChatGPT usage.",
+      },
+    };
+  }
+
+  const url = new URL(`${baseUrl}${CLOUD_CHATGPT_USAGE_PATH}`);
+  url.searchParams.set("provider_name", providerName);
+
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  let response: Response;
+  try {
+    response = await (input.fetch ?? fetch)(url, {
+      method: "GET",
+      headers: {
+        ...getLettaCodeHeaders(auth.apiKey),
+        Accept: "application/json",
+      },
+      signal: controller.signal,
+    });
+  } catch (error) {
+    return chatGPTUsageError(
+      "network_error",
+      error instanceof Error
+        ? error.message
+        : "Failed to fetch ChatGPT usage from Letta Cloud.",
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (response.status === 400) {
+    const raw = await readJsonRecord(response);
+    return chatGPTUsageError(
+      "bad_request",
+      responseMessage(raw, "Letta Cloud rejected the ChatGPT usage request."),
+    );
+  }
+  if (response.status === 401) {
+    const raw = await readJsonRecord(response);
+    return chatGPTUsageError(
+      "unauthorized",
+      responseMessage(raw, "Sign in to Letta Cloud to read ChatGPT usage."),
+    );
+  }
+  if (response.status === 403) {
+    const raw = await readJsonRecord(response);
+    return chatGPTUsageError(
+      "forbidden",
+      responseMessage(raw, "ChatGPT usage is not available for this account."),
+    );
+  }
+  if (response.status === 404) {
+    const raw = await readJsonRecord(response);
+    if (!raw) {
+      return chatGPTUsageError(
+        "network_error",
+        "Letta Cloud ChatGPT usage endpoint is unavailable.",
+      );
+    }
+    return chatGPTUsageError(
+      "not_connected",
+      responseMessage(raw, "No cloud ChatGPT OAuth provider is connected."),
+    );
+  }
+  if (response.status === 429) {
+    const raw = await readJsonRecord(response);
+    return chatGPTUsageError(
+      "rate_limited",
+      responseMessage(raw, "ChatGPT usage is rate limited. Try again later."),
+      retryAfterMsFromBody(raw) ?? retryAfterMs(response),
+    );
+  }
+  if (!response.ok) {
+    const raw = await readJsonRecord(response);
+    return chatGPTUsageError(
+      "network_error",
+      responseMessage(
+        raw,
+        `Letta Cloud ChatGPT usage request failed with HTTP ${response.status}.`,
+      ),
+    );
+  }
+
+  const raw = await readJsonRecord(response);
+  if (!raw) {
+    return chatGPTUsageError(
+      "bad_response",
+      "Letta Cloud ChatGPT usage returned invalid JSON.",
+    );
+  }
+
+  const usage = normalizeCloudChatGPTUsageResponse({
+    raw,
+    providerName,
+    nowMs: now,
+  });
+  if (!usage) {
+    return chatGPTUsageError(
+      "bad_response",
+      "Letta Cloud ChatGPT usage returned an invalid payload.",
+    );
+  }
+
+  const result: Extract<ChatGPTUsageReadResult, { success: true }> = {
+    success: true,
+    usage,
+  };
+  usageCache.set(cacheKey, { expiresAt: now + CACHE_TTL_MS, result });
+  return result;
+}
+
 export async function readChatGPTUsage(
   input: ReadChatGPTUsageInput = {},
 ): Promise<ChatGPTUsageReadResult> {
   const target = input.target ?? "local";
+  const now = input.now?.() ?? Date.now();
+  if (target === "api") {
+    return readCloudChatGPTUsage(input, now);
+  }
   if (target !== "local") {
     return chatGPTUsageError(
       "unsupported_target",
-      "ChatGPT usage is only available for locally stored ChatGPT OAuth providers.",
+      "ChatGPT usage is only available for local or cloud ChatGPT OAuth providers.",
     );
   }
 
-  const now = input.now?.() ?? Date.now();
   const providerNames = localProviderNames(input.providerName);
   const record = providerNames
     .map((name) => getLocalProviderRecordByName(name, input.storageDir))

--- a/src/providers/chatgpt-usage-service.ts
+++ b/src/providers/chatgpt-usage-service.ts
@@ -113,7 +113,8 @@ function asRecord(value: unknown): JsonRecord | undefined {
 function getValue(record: JsonRecord | undefined, keys: string[]): unknown {
   if (!record) return undefined;
   for (const key of keys) {
-    if (key in record) return record[key];
+    const value = record[key];
+    if (value !== undefined && value !== null) return value;
   }
   return undefined;
 }
@@ -262,14 +263,15 @@ function normalizeCredits(
       "rate_limit_reset_credits",
       "rateLimitResetCredits",
     ]);
-  if (!credits) return null;
+  const resetCredits =
+    getRecord(raw, ["rate_limit_reset_credits", "rateLimitResetCredits"]) ??
+    getRecord(rateLimit, ["rate_limit_reset_credits", "rateLimitResetCredits"]);
+  if (!credits && !resetCredits) return null;
 
   const balance = getString(credits, ["balance", "credit_balance", "amount"]);
-  const availableCount = getNumber(credits, [
-    "available_count",
-    "availableCount",
-    "count",
-  ]);
+  const availableCount =
+    getNumber(credits, ["available_count", "availableCount", "count"]) ??
+    getNumber(resetCredits, ["available_count", "availableCount", "count"]);
   const hasCredits = getBoolean(credits, ["has_credits", "hasCredits"]);
   const unlimited = getBoolean(credits, ["unlimited", "is_unlimited"]);
 
@@ -291,9 +293,13 @@ function normalizeCredits(
 }
 
 function normalizeIndividualLimit(
-  value: unknown,
+  raw: JsonRecord | undefined,
+  nowMs: number,
 ): ChatGPTUsageIndividualLimit | null {
-  const record = asRecord(value);
+  const spendControl = getRecord(raw, ["spend_control", "spendControl"]);
+  const record =
+    getRecord(raw, ["individual_limit", "individualLimit"]) ??
+    getRecord(spendControl, ["individual_limit", "individualLimit"]);
   if (!record) return null;
 
   const limit = getString(record, ["limit"]);
@@ -302,7 +308,20 @@ function normalizeIndividualLimit(
     "remaining_percent",
     "remainingPercent",
   ]);
-  const resetsAt = getTimestampSeconds(record, ["resets_at", "resetsAt"]);
+  const resetAfterSeconds = getNumber(record, [
+    "reset_after_seconds",
+    "resetAfterSeconds",
+  ]);
+  const resetsAt =
+    getTimestampSeconds(record, [
+      "reset_at",
+      "resetAt",
+      "resets_at",
+      "resetsAt",
+    ]) ??
+    (resetAfterSeconds === null
+      ? null
+      : Math.floor(nowMs / 1000 + resetAfterSeconds));
 
   if (
     limit === null ||
@@ -333,6 +352,55 @@ function normalizeCloudUsageWindow(
     getString(record, ["label", "name"]) ?? fallbackLabel,
     nowMs,
   );
+}
+
+function normalizeAdditionalRateLimit(
+  details: JsonRecord,
+  index: number,
+  nowMs: number,
+): ChatGPTUsageWindow[] {
+  const label =
+    getString(details, [
+      "limit_name",
+      "limitName",
+      "metered_feature",
+      "meteredFeature",
+      "label",
+      "name",
+      "model",
+      "limit_id",
+      "limitId",
+    ]) ?? `limit ${index + 1}`;
+  const nestedRateLimit = getRecord(details, ["rate_limit", "rateLimit"]);
+  const source = nestedRateLimit ?? details;
+  const primary = normalizeUsageWindow(
+    getValue(source, ["primary_window", "primaryWindow", "primary"]),
+    label,
+    nowMs,
+  );
+  const secondary = normalizeUsageWindow(
+    getValue(source, ["secondary_window", "secondaryWindow", "secondary"]),
+    `${label} secondary`,
+    nowMs,
+  );
+  const direct = nestedRateLimit
+    ? null
+    : normalizeUsageWindow(details, label, nowMs);
+
+  return [primary, secondary, direct].filter(
+    (window): window is ChatGPTUsageWindow => !!window,
+  );
+}
+
+function getRateLimitReachedType(raw: JsonRecord | undefined): string | null {
+  const value = getValue(raw, [
+    "rate_limit_reached_type",
+    "rateLimitReachedType",
+  ]);
+  if (typeof value === "string" && value.trim()) return value.trim();
+
+  const record = asRecord(value);
+  return getString(record, ["type", "kind"]);
 }
 
 function formatPercent(value: number): string {
@@ -374,13 +442,22 @@ function formatWindowLabel(window: ChatGPTUsageWindow): string {
   return window.label;
 }
 
+function formatNamedWindowLabel(window: ChatGPTUsageWindow): string {
+  const normalizedLabel = window.label.replace(/_/g, " ").trim();
+  const duration = formatDuration(window.windowDurationMins);
+  return duration ? `${normalizedLabel} ${duration}` : normalizedLabel;
+}
+
 function formatUsageWindow(
   window: ChatGPTUsageWindow | null,
   now: Date,
+  options: { includeName?: boolean } = {},
 ): string | null {
   if (!window) return null;
 
-  const label = formatWindowLabel(window);
+  const label = options.includeName
+    ? formatNamedWindowLabel(window)
+    : formatWindowLabel(window);
   const parts: string[] = [label];
   if (window.usedPercent !== null) {
     const remaining = Math.max(0, 100 - window.usedPercent);
@@ -415,7 +492,9 @@ export function formatChatGPTUsageSnapshot(
   const windows = [
     formatUsageWindow(snapshot.primary, now),
     formatUsageWindow(snapshot.secondary, now),
-    ...snapshot.additional.map((window) => formatUsageWindow(window, now)),
+    ...snapshot.additional.map((window) =>
+      formatUsageWindow(window, now, { includeName: true }),
+    ),
   ].filter((item): item is string => !!item);
 
   const credits = formatCredits(snapshot.credits);
@@ -425,6 +504,18 @@ export function formatChatGPTUsageSnapshot(
     return "Usage: no active quota window reported";
   }
   return `Usage: ${windows.join(" · ")}`;
+}
+
+export function formatChatGPTUsageQuotaRows(
+  snapshot: ChatGPTUsageSnapshot,
+  now: Date = new Date(),
+): string[] {
+  const rows = [
+    formatUsageWindow(snapshot.primary, now),
+    formatUsageWindow(snapshot.secondary, now),
+  ].filter((item): item is string => !!item);
+
+  return rows.length > 0 ? rows : [snapshot.summary.replace(/^Usage:\s*/, "")];
 }
 
 export function normalizeWhamUsageResponse(input: {
@@ -448,37 +539,38 @@ export function normalizeWhamUsageResponse(input: {
     "secondary",
     nowMs,
   );
-  const additional = getRecordArray(rateLimit, [
-    "additional_rate_limits",
-    "additionalRateLimits",
-    "additional",
-  ])
-    .map((window, index) =>
-      normalizeUsageWindow(
-        window,
-        getString(window, ["label", "name", "model", "limit_id", "limitId"]) ??
-          `limit ${index + 1}`,
-        nowMs,
-      ),
-    )
-    .filter((window): window is ChatGPTUsageWindow => !!window);
+  const additionalSources = [
+    ...getRecordArray(raw, [
+      "additional_rate_limits",
+      "additionalRateLimits",
+      "additional",
+    ]),
+    ...(raw === rateLimit
+      ? []
+      : getRecordArray(rateLimit, [
+          "additional_rate_limits",
+          "additionalRateLimits",
+          "additional",
+        ])),
+  ];
+  const additional = additionalSources.flatMap((details, index) =>
+    normalizeAdditionalRateLimit(details, index, nowMs),
+  );
+  const spendControl = getRecord(raw, ["spend_control", "spendControl"]);
 
   const snapshotWithoutSummary = {
     providerName: input.providerName,
     fetchedAt,
     planType: getString(raw, ["plan_type", "planType"]),
-    limitReached: getBoolean(rateLimit, ["limit_reached", "limitReached"]),
-    rateLimitReachedType: getString(raw, [
-      "rate_limit_reached_type",
-      "rateLimitReachedType",
-    ]),
+    limitReached:
+      getBoolean(rateLimit, ["limit_reached", "limitReached"]) ??
+      getBoolean(spendControl, ["reached"]),
+    rateLimitReachedType: getRateLimitReachedType(raw),
     primary,
     secondary,
     additional,
     credits: normalizeCredits(raw, rateLimit),
-    individualLimit: normalizeIndividualLimit(
-      getValue(rateLimit, ["individual_limit", "individualLimit"]),
-    ),
+    individualLimit: normalizeIndividualLimit(raw, nowMs),
   };
 
   return {
@@ -534,9 +626,7 @@ export function normalizeCloudChatGPTUsageResponse(input: {
     ),
     additional,
     credits: normalizeCredits(raw, raw),
-    individualLimit: normalizeIndividualLimit(
-      getValue(raw, ["individualLimit", "individual_limit"]),
-    ),
+    individualLimit: normalizeIndividualLimit(raw, nowMs),
   };
 
   return {
@@ -734,10 +824,11 @@ async function readCloudChatGPTUsage(
   url.searchParams.set("provider_name", providerName);
 
   const controller = new AbortController();
-  const timeout = setTimeout(
-    () => controller.abort(),
-    input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-  );
+  let didTimeOut = false;
+  const timeout = setTimeout(() => {
+    didTimeOut = true;
+    controller.abort();
+  }, input.timeoutMs ?? DEFAULT_TIMEOUT_MS);
 
   let response: Response;
   try {
@@ -750,95 +841,130 @@ async function readCloudChatGPTUsage(
       signal: controller.signal,
     });
   } catch (error) {
+    clearTimeout(timeout);
     return chatGPTUsageError(
       "network_error",
-      error instanceof Error
-        ? error.message
-        : "Failed to fetch ChatGPT usage from Letta Cloud.",
+      didTimeOut
+        ? "Letta Cloud ChatGPT usage request timed out."
+        : error instanceof Error
+          ? error.message
+          : "Failed to fetch ChatGPT usage from Letta Cloud.",
     );
-  } finally {
-    clearTimeout(timeout);
   }
 
-  if (response.status === 400) {
-    const raw = await readJsonRecord(response);
-    return chatGPTUsageError(
-      "bad_request",
-      responseMessage(raw, "Letta Cloud rejected the ChatGPT usage request."),
-    );
-  }
-  if (response.status === 401) {
-    const raw = await readJsonRecord(response);
-    return chatGPTUsageError(
-      "unauthorized",
-      responseMessage(raw, "Sign in to Letta Cloud to read ChatGPT usage."),
-    );
-  }
-  if (response.status === 403) {
-    const raw = await readJsonRecord(response);
-    return chatGPTUsageError(
-      "forbidden",
-      responseMessage(raw, "ChatGPT usage is not available for this account."),
-    );
-  }
-  if (response.status === 404) {
+  try {
+    if (response.status === 400) {
+      const raw = await readJsonRecord(response);
+      return chatGPTUsageError(
+        didTimeOut ? "network_error" : "bad_request",
+        didTimeOut
+          ? "Letta Cloud ChatGPT usage request timed out."
+          : responseMessage(
+              raw,
+              "Letta Cloud rejected the ChatGPT usage request.",
+            ),
+      );
+    }
+    if (response.status === 401) {
+      const raw = await readJsonRecord(response);
+      return chatGPTUsageError(
+        didTimeOut ? "network_error" : "unauthorized",
+        didTimeOut
+          ? "Letta Cloud ChatGPT usage request timed out."
+          : responseMessage(
+              raw,
+              "Sign in to Letta Cloud to read ChatGPT usage.",
+            ),
+      );
+    }
+    if (response.status === 403) {
+      const raw = await readJsonRecord(response);
+      return chatGPTUsageError(
+        didTimeOut ? "network_error" : "forbidden",
+        didTimeOut
+          ? "Letta Cloud ChatGPT usage request timed out."
+          : responseMessage(
+              raw,
+              "ChatGPT usage is not available for this account.",
+            ),
+      );
+    }
+    if (response.status === 404) {
+      const raw = await readJsonRecord(response);
+      if (didTimeOut) {
+        return chatGPTUsageError(
+          "network_error",
+          "Letta Cloud ChatGPT usage request timed out.",
+        );
+      }
+      if (!raw) {
+        return chatGPTUsageError(
+          "network_error",
+          "Letta Cloud ChatGPT usage endpoint is unavailable.",
+        );
+      }
+      return chatGPTUsageError(
+        "not_connected",
+        responseMessage(raw, "No cloud ChatGPT OAuth provider is connected."),
+      );
+    }
+    if (response.status === 429) {
+      const raw = await readJsonRecord(response);
+      return chatGPTUsageError(
+        "rate_limited",
+        didTimeOut
+          ? "Letta Cloud ChatGPT usage request timed out."
+          : responseMessage(
+              raw,
+              "ChatGPT usage is rate limited. Try again later.",
+            ),
+        retryAfterMsFromBody(raw) ?? retryAfterMs(response),
+      );
+    }
+    if (!response.ok) {
+      const raw = await readJsonRecord(response);
+      return chatGPTUsageError(
+        "network_error",
+        didTimeOut
+          ? "Letta Cloud ChatGPT usage request timed out."
+          : responseMessage(
+              raw,
+              `Letta Cloud ChatGPT usage request failed with HTTP ${response.status}.`,
+            ),
+      );
+    }
+
     const raw = await readJsonRecord(response);
     if (!raw) {
       return chatGPTUsageError(
-        "network_error",
-        "Letta Cloud ChatGPT usage endpoint is unavailable.",
+        didTimeOut ? "network_error" : "bad_response",
+        didTimeOut
+          ? "Letta Cloud ChatGPT usage request timed out."
+          : "Letta Cloud ChatGPT usage returned invalid JSON.",
       );
     }
-    return chatGPTUsageError(
-      "not_connected",
-      responseMessage(raw, "No cloud ChatGPT OAuth provider is connected."),
-    );
-  }
-  if (response.status === 429) {
-    const raw = await readJsonRecord(response);
-    return chatGPTUsageError(
-      "rate_limited",
-      responseMessage(raw, "ChatGPT usage is rate limited. Try again later."),
-      retryAfterMsFromBody(raw) ?? retryAfterMs(response),
-    );
-  }
-  if (!response.ok) {
-    const raw = await readJsonRecord(response);
-    return chatGPTUsageError(
-      "network_error",
-      responseMessage(
-        raw,
-        `Letta Cloud ChatGPT usage request failed with HTTP ${response.status}.`,
-      ),
-    );
-  }
 
-  const raw = await readJsonRecord(response);
-  if (!raw) {
-    return chatGPTUsageError(
-      "bad_response",
-      "Letta Cloud ChatGPT usage returned invalid JSON.",
-    );
-  }
+    const usage = normalizeCloudChatGPTUsageResponse({
+      raw,
+      providerName,
+      nowMs: now,
+    });
+    if (!usage) {
+      return chatGPTUsageError(
+        "bad_response",
+        "Letta Cloud ChatGPT usage returned an invalid payload.",
+      );
+    }
 
-  const usage = normalizeCloudChatGPTUsageResponse({
-    raw,
-    providerName,
-    nowMs: now,
-  });
-  if (!usage) {
-    return chatGPTUsageError(
-      "bad_response",
-      "Letta Cloud ChatGPT usage returned an invalid payload.",
-    );
+    const result: Extract<ChatGPTUsageReadResult, { success: true }> = {
+      success: true,
+      usage,
+    };
+    usageCache.set(cacheKey, { expiresAt: now + CACHE_TTL_MS, result });
+    return result;
+  } finally {
+    clearTimeout(timeout);
   }
-
-  const result: Extract<ChatGPTUsageReadResult, { success: true }> = {
-    success: true,
-    usage,
-  };
-  usageCache.set(cacheKey, { expiresAt: now + CACHE_TTL_MS, result });
-  return result;
 }
 
 export async function readChatGPTUsage(
@@ -904,10 +1030,11 @@ export async function readChatGPTUsage(
         ? record.auth.accountId
         : undefined;
   const controller = new AbortController();
-  const timeout = setTimeout(
-    () => controller.abort(),
-    input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-  );
+  let didTimeOut = false;
+  const timeout = setTimeout(() => {
+    didTimeOut = true;
+    controller.abort();
+  }, input.timeoutMs ?? DEFAULT_TIMEOUT_MS);
 
   let response: Response;
   try {
@@ -922,58 +1049,67 @@ export async function readChatGPTUsage(
       signal: controller.signal,
     });
   } catch (error) {
+    clearTimeout(timeout);
     return chatGPTUsageError(
       "network_error",
-      error instanceof Error ? error.message : "Failed to fetch ChatGPT usage.",
+      didTimeOut
+        ? "ChatGPT usage request timed out."
+        : error instanceof Error
+          ? error.message
+          : "Failed to fetch ChatGPT usage.",
     );
+  }
+
+  try {
+    if (response.status === 401) {
+      return chatGPTUsageError(
+        "unauthorized",
+        "ChatGPT rejected the OAuth token. Reconnect ChatGPT Plus/Pro and try again.",
+      );
+    }
+    if (response.status === 403) {
+      return chatGPTUsageError(
+        "forbidden",
+        "ChatGPT usage is not available for this account.",
+      );
+    }
+    if (response.status === 429) {
+      return chatGPTUsageError(
+        "rate_limited",
+        "ChatGPT usage is rate limited. Try again later.",
+        retryAfterMs(response),
+      );
+    }
+    if (!response.ok) {
+      return chatGPTUsageError(
+        "network_error",
+        `ChatGPT usage request failed with HTTP ${response.status}.`,
+      );
+    }
+
+    let raw: unknown;
+    try {
+      raw = await response.json();
+    } catch {
+      return chatGPTUsageError(
+        didTimeOut ? "network_error" : "bad_response",
+        didTimeOut
+          ? "ChatGPT usage request timed out."
+          : "ChatGPT usage returned invalid JSON.",
+      );
+    }
+
+    const result: Extract<ChatGPTUsageReadResult, { success: true }> = {
+      success: true,
+      usage: normalizeWhamUsageResponse({
+        raw,
+        providerName: record.name,
+        nowMs: now,
+      }),
+    };
+    usageCache.set(cacheKey, { expiresAt: now + CACHE_TTL_MS, result });
+    return result;
   } finally {
     clearTimeout(timeout);
   }
-
-  if (response.status === 401) {
-    return chatGPTUsageError(
-      "unauthorized",
-      "ChatGPT rejected the OAuth token. Reconnect ChatGPT Plus/Pro and try again.",
-    );
-  }
-  if (response.status === 403) {
-    return chatGPTUsageError(
-      "forbidden",
-      "ChatGPT usage is not available for this account.",
-    );
-  }
-  if (response.status === 429) {
-    return chatGPTUsageError(
-      "rate_limited",
-      "ChatGPT usage is rate limited. Try again later.",
-      retryAfterMs(response),
-    );
-  }
-  if (!response.ok) {
-    return chatGPTUsageError(
-      "network_error",
-      `ChatGPT usage request failed with HTTP ${response.status}.`,
-    );
-  }
-
-  let raw: unknown;
-  try {
-    raw = await response.json();
-  } catch {
-    return chatGPTUsageError(
-      "bad_response",
-      "ChatGPT usage returned invalid JSON.",
-    );
-  }
-
-  const result: Extract<ChatGPTUsageReadResult, { success: true }> = {
-    success: true,
-    usage: normalizeWhamUsageResponse({
-      raw,
-      providerName: record.name,
-      nowMs: now,
-    }),
-  };
-  usageCache.set(cacheKey, { expiresAt: now + CACHE_TTL_MS, result });
-  return result;
 }

--- a/src/providers/chatgpt-usage-service.ts
+++ b/src/providers/chatgpt-usage-service.ts
@@ -1,0 +1,602 @@
+import {
+  getLocalOAuthApiKey,
+  getLocalProviderRecordByName,
+  LOCAL_CHATGPT_PROVIDER_NAME,
+  type LocalProviderRecord,
+} from "@/backend/local/local-provider-auth-store";
+import type { ProviderStorageTarget } from "@/providers/byok-providers";
+
+const CHATGPT_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
+const OPENAI_CODEX_OAUTH_PROVIDER_ID = "openai-codex";
+const CACHE_TTL_MS = 30_000;
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export interface ChatGPTUsageWindow {
+  label: string;
+  usedPercent: number | null;
+  windowDurationMins: number | null;
+  resetsAt: number | null;
+}
+
+export interface ChatGPTUsageCredits {
+  balance?: string | null;
+  availableCount?: number | null;
+  hasCredits?: boolean | null;
+  unlimited?: boolean | null;
+}
+
+export interface ChatGPTUsageSnapshot {
+  providerName: string;
+  fetchedAt: string;
+  summary: string;
+  planType?: string | null;
+  limitReached?: boolean | null;
+  rateLimitReachedType?: string | null;
+  primary: ChatGPTUsageWindow | null;
+  secondary: ChatGPTUsageWindow | null;
+  additional: ChatGPTUsageWindow[];
+  credits?: ChatGPTUsageCredits | null;
+}
+
+export type ChatGPTUsageErrorCode =
+  | "not_connected"
+  | "unsupported_target"
+  | "refresh_failed"
+  | "unauthorized"
+  | "forbidden"
+  | "rate_limited"
+  | "network_error"
+  | "bad_response";
+
+export interface ChatGPTUsageError {
+  code: ChatGPTUsageErrorCode;
+  message: string;
+  retryAfterMs?: number;
+}
+
+export type ChatGPTUsageReadResult =
+  | { success: true; usage: ChatGPTUsageSnapshot }
+  | { success: false; error: ChatGPTUsageError };
+
+export interface ReadChatGPTUsageInput {
+  target?: ProviderStorageTarget;
+  providerName?: string;
+  forceRefresh?: boolean;
+  storageDir?: string;
+  timeoutMs?: number;
+  fetch?: typeof fetch;
+  now?: () => number;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+type CachedUsage = {
+  expiresAt: number;
+  result: Extract<ChatGPTUsageReadResult, { success: true }>;
+};
+
+const usageCache = new Map<string, CachedUsage>();
+
+function asRecord(value: unknown): JsonRecord | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : undefined;
+}
+
+function getValue(record: JsonRecord | undefined, keys: string[]): unknown {
+  if (!record) return undefined;
+  for (const key of keys) {
+    if (key in record) return record[key];
+  }
+  return undefined;
+}
+
+function getRecord(
+  record: JsonRecord | undefined,
+  keys: string[],
+): JsonRecord | undefined {
+  return asRecord(getValue(record, keys));
+}
+
+function getRecordArray(
+  record: JsonRecord | undefined,
+  keys: string[],
+): JsonRecord[] {
+  const value = getValue(record, keys);
+  if (!Array.isArray(value)) return [];
+  return value.map(asRecord).filter((item): item is JsonRecord => !!item);
+}
+
+function getNumber(
+  record: JsonRecord | undefined,
+  keys: string[],
+): number | null {
+  const value = getValue(record, keys);
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function getString(
+  record: JsonRecord | undefined,
+  keys: string[],
+): string | null {
+  const value = getValue(record, keys);
+  if (typeof value === "string" && value.trim()) return value.trim();
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return null;
+}
+
+function getBoolean(
+  record: JsonRecord | undefined,
+  keys: string[],
+): boolean | null {
+  const value = getValue(record, keys);
+  return typeof value === "boolean" ? value : null;
+}
+
+function normalizeTimestampSeconds(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value > 1_000_000_000_000 ? Math.floor(value / 1000) : value;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return normalizeTimestampSeconds(numeric);
+
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return Math.floor(parsed / 1000);
+  }
+  return null;
+}
+
+function getTimestampSeconds(
+  record: JsonRecord | undefined,
+  keys: string[],
+): number | null {
+  return normalizeTimestampSeconds(getValue(record, keys));
+}
+
+function normalizeUsageWindow(
+  value: unknown,
+  label: string,
+  nowMs: number,
+): ChatGPTUsageWindow | null {
+  const record = asRecord(value);
+  if (!record) return null;
+
+  const usedPercent = getNumber(record, [
+    "used_percent",
+    "usedPercent",
+    "used_percentage",
+    "usedPercentage",
+    "percent_used",
+    "percentUsed",
+  ]);
+  const limitWindowSeconds = getNumber(record, [
+    "limit_window_seconds",
+    "limitWindowSeconds",
+  ]);
+  const windowDurationMins =
+    getNumber(record, [
+      "window_duration_minutes",
+      "windowDurationMinutes",
+      "window_duration_mins",
+      "windowDurationMins",
+      "window_minutes",
+      "windowMinutes",
+    ]) ?? (limitWindowSeconds === null ? null : limitWindowSeconds / 60);
+
+  const resetAfterSeconds = getNumber(record, [
+    "reset_after_seconds",
+    "resetAfterSeconds",
+  ]);
+  const resetsAt =
+    getTimestampSeconds(record, [
+      "reset_at",
+      "resetAt",
+      "resets_at",
+      "resetsAt",
+    ]) ??
+    (resetAfterSeconds === null
+      ? null
+      : Math.floor(nowMs / 1000 + resetAfterSeconds));
+
+  if (
+    usedPercent === null &&
+    windowDurationMins === null &&
+    resetsAt === null
+  ) {
+    return null;
+  }
+
+  return {
+    label,
+    usedPercent,
+    windowDurationMins,
+    resetsAt,
+  };
+}
+
+function normalizeCredits(
+  raw: JsonRecord | undefined,
+  rateLimit: JsonRecord | undefined,
+): ChatGPTUsageCredits | null {
+  const credits =
+    getRecord(raw, ["credits", "credit_balance", "creditBalance"]) ??
+    getRecord(rateLimit, [
+      "credits",
+      "credit_balance",
+      "creditBalance",
+      "reset_credits",
+      "resetCredits",
+      "rate_limit_reset_credits",
+      "rateLimitResetCredits",
+    ]);
+  if (!credits) return null;
+
+  const balance = getString(credits, ["balance", "credit_balance", "amount"]);
+  const availableCount = getNumber(credits, [
+    "available_count",
+    "availableCount",
+    "count",
+  ]);
+  const hasCredits = getBoolean(credits, ["has_credits", "hasCredits"]);
+  const unlimited = getBoolean(credits, ["unlimited", "is_unlimited"]);
+
+  if (
+    balance === null &&
+    availableCount === null &&
+    hasCredits === null &&
+    unlimited === null
+  ) {
+    return null;
+  }
+
+  return {
+    ...(balance !== null ? { balance } : {}),
+    ...(availableCount !== null ? { availableCount } : {}),
+    ...(hasCredits !== null ? { hasCredits } : {}),
+    ...(unlimited !== null ? { unlimited } : {}),
+  };
+}
+
+function formatPercent(value: number): string {
+  const rounded = Math.round(value);
+  return Number.isInteger(value) || Math.abs(value - rounded) < 0.05
+    ? String(rounded)
+    : value.toFixed(1);
+}
+
+function formatDuration(minutes: number | null): string | null {
+  if (minutes === null || !Number.isFinite(minutes) || minutes <= 0) {
+    return null;
+  }
+  if (minutes % 1440 === 0) return `${minutes / 1440}d`;
+  if (minutes % 60 === 0) return `${minutes / 60}h`;
+  return `${Math.round(minutes)}m`;
+}
+
+function formatResetDistance(
+  resetsAt: number | null,
+  now: Date,
+): string | null {
+  if (resetsAt === null) return null;
+  const deltaMs = resetsAt * 1000 - now.getTime();
+  if (deltaMs <= 0) return "now";
+
+  const minutes = Math.ceil(deltaMs / 60_000);
+  if (minutes < 60) return `in ${minutes}m`;
+
+  const hours = Math.ceil(minutes / 60);
+  if (hours < 48) return `in ${hours}h`;
+
+  return `in ${Math.ceil(hours / 24)}d`;
+}
+
+function formatWindowLabel(window: ChatGPTUsageWindow): string {
+  const duration = formatDuration(window.windowDurationMins);
+  if (duration) return duration;
+  return window.label;
+}
+
+function formatUsageWindow(
+  window: ChatGPTUsageWindow | null,
+  now: Date,
+): string | null {
+  if (!window) return null;
+
+  const label = formatWindowLabel(window);
+  const parts: string[] = [label];
+  if (window.usedPercent !== null) {
+    const remaining = Math.max(0, 100 - window.usedPercent);
+    parts.push(`${formatPercent(remaining)}% left`);
+  }
+
+  const resetDistance = formatResetDistance(window.resetsAt, now);
+  if (resetDistance) parts.push(`resets ${resetDistance}`);
+
+  return parts.join(" ");
+}
+
+function formatCredits(
+  credits: ChatGPTUsageCredits | null | undefined,
+): string | null {
+  if (!credits) return null;
+  if (credits.unlimited) return "credits unlimited";
+  if (typeof credits.availableCount === "number") {
+    return `credits ${formatPercent(credits.availableCount)}`;
+  }
+  if (credits.balance) return `credits ${credits.balance}`;
+  if (credits.hasCredits !== null && credits.hasCredits !== undefined) {
+    return credits.hasCredits ? "credits available" : "no credits";
+  }
+  return null;
+}
+
+export function formatChatGPTUsageSnapshot(
+  snapshot: Omit<ChatGPTUsageSnapshot, "summary">,
+  now: Date = new Date(),
+): string {
+  const windows = [
+    formatUsageWindow(snapshot.primary, now),
+    formatUsageWindow(snapshot.secondary, now),
+    ...snapshot.additional.map((window) => formatUsageWindow(window, now)),
+  ].filter((item): item is string => !!item);
+
+  const credits = formatCredits(snapshot.credits);
+  if (credits) windows.push(credits);
+
+  if (windows.length === 0) {
+    return "Usage: no active quota window reported";
+  }
+  return `Usage: ${windows.join(" · ")}`;
+}
+
+export function normalizeWhamUsageResponse(input: {
+  raw: unknown;
+  providerName: string;
+  nowMs?: number;
+}): ChatGPTUsageSnapshot {
+  const raw = asRecord(input.raw);
+  const nowMs = input.nowMs ?? Date.now();
+  const fetchedAt = new Date(nowMs).toISOString();
+  const rateLimit =
+    getRecord(raw, ["rate_limit", "rateLimit", "rate_limits", "rateLimits"]) ??
+    raw;
+  const primary = normalizeUsageWindow(
+    getValue(rateLimit, ["primary_window", "primaryWindow", "primary"]),
+    "primary",
+    nowMs,
+  );
+  const secondary = normalizeUsageWindow(
+    getValue(rateLimit, ["secondary_window", "secondaryWindow", "secondary"]),
+    "secondary",
+    nowMs,
+  );
+  const additional = getRecordArray(rateLimit, [
+    "additional_rate_limits",
+    "additionalRateLimits",
+    "additional",
+  ])
+    .map((window, index) =>
+      normalizeUsageWindow(
+        window,
+        getString(window, ["label", "name", "model", "limit_id", "limitId"]) ??
+          `limit ${index + 1}`,
+        nowMs,
+      ),
+    )
+    .filter((window): window is ChatGPTUsageWindow => !!window);
+
+  const snapshotWithoutSummary = {
+    providerName: input.providerName,
+    fetchedAt,
+    planType: getString(raw, ["plan_type", "planType"]),
+    limitReached: getBoolean(rateLimit, ["limit_reached", "limitReached"]),
+    rateLimitReachedType: getString(raw, [
+      "rate_limit_reached_type",
+      "rateLimitReachedType",
+    ]),
+    primary,
+    secondary,
+    additional,
+    credits: normalizeCredits(raw, rateLimit),
+  };
+
+  return {
+    ...snapshotWithoutSummary,
+    summary: formatChatGPTUsageSnapshot(
+      snapshotWithoutSummary,
+      new Date(nowMs),
+    ),
+  };
+}
+
+function retryAfterMs(response: Response): number | undefined {
+  const value = response.headers.get("retry-after");
+  if (!value) return undefined;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+
+  const retryAt = Date.parse(value);
+  return Number.isFinite(retryAt)
+    ? Math.max(0, retryAt - Date.now())
+    : undefined;
+}
+
+function chatGPTUsageError(
+  code: ChatGPTUsageErrorCode,
+  message: string,
+  retryAfter?: number,
+): ChatGPTUsageReadResult {
+  return {
+    success: false,
+    error: {
+      code,
+      message,
+      ...(retryAfter !== undefined ? { retryAfterMs: retryAfter } : {}),
+    },
+  };
+}
+
+function localProviderNames(providerName: string | undefined): string[] {
+  if (providerName?.trim()) return [providerName.trim()];
+  return [LOCAL_CHATGPT_PROVIDER_NAME, OPENAI_CODEX_OAUTH_PROVIDER_ID];
+}
+
+function isChatGPTOAuthRecord(
+  record: LocalProviderRecord,
+): record is LocalProviderRecord & {
+  auth: { type: "oauth"; accountId?: string };
+} {
+  return (
+    record.auth.type === "oauth" &&
+    (record.provider_type === "chatgpt_oauth" ||
+      record.provider_type === OPENAI_CODEX_OAUTH_PROVIDER_ID)
+  );
+}
+
+function isConnectedChatGPTOAuthRecord(
+  record: LocalProviderRecord | null,
+): record is LocalProviderRecord & {
+  auth: { type: "oauth"; accountId?: string };
+} {
+  return !!record && isChatGPTOAuthRecord(record);
+}
+
+export async function readChatGPTUsage(
+  input: ReadChatGPTUsageInput = {},
+): Promise<ChatGPTUsageReadResult> {
+  const target = input.target ?? "local";
+  if (target !== "local") {
+    return chatGPTUsageError(
+      "unsupported_target",
+      "ChatGPT usage is only available for locally stored ChatGPT OAuth providers.",
+    );
+  }
+
+  const now = input.now?.() ?? Date.now();
+  const providerNames = localProviderNames(input.providerName);
+  const record = providerNames
+    .map((name) => getLocalProviderRecordByName(name, input.storageDir))
+    .find(isConnectedChatGPTOAuthRecord);
+
+  if (!record) {
+    return chatGPTUsageError(
+      "not_connected",
+      "No local ChatGPT OAuth provider is connected.",
+    );
+  }
+
+  const cacheKey = `${target}:${record.name}`;
+  const cached = usageCache.get(cacheKey);
+  if (!input.forceRefresh && cached && cached.expiresAt > now) {
+    return cached.result;
+  }
+
+  let oauthApiKey: Awaited<ReturnType<typeof getLocalOAuthApiKey>>;
+  try {
+    oauthApiKey = await getLocalOAuthApiKey({
+      providerId: OPENAI_CODEX_OAUTH_PROVIDER_ID,
+      providerNames: [record.name],
+      storageDir: input.storageDir,
+    });
+  } catch (error) {
+    return chatGPTUsageError(
+      "refresh_failed",
+      error instanceof Error
+        ? error.message
+        : "Failed to refresh the ChatGPT OAuth token.",
+    );
+  }
+
+  if (!oauthApiKey) {
+    return chatGPTUsageError(
+      "not_connected",
+      "No local ChatGPT OAuth token is available.",
+    );
+  }
+
+  const accountId =
+    typeof oauthApiKey.credentials.accountId === "string"
+      ? oauthApiKey.credentials.accountId
+      : typeof record.auth.accountId === "string"
+        ? record.auth.accountId
+        : undefined;
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  let response: Response;
+  try {
+    response = await (input.fetch ?? fetch)(CHATGPT_USAGE_URL, {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${oauthApiKey.apiKey}`,
+        "User-Agent": "letta-code",
+        ...(accountId ? { "chatgpt-account-id": accountId } : {}),
+      },
+      signal: controller.signal,
+    });
+  } catch (error) {
+    return chatGPTUsageError(
+      "network_error",
+      error instanceof Error ? error.message : "Failed to fetch ChatGPT usage.",
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (response.status === 401) {
+    return chatGPTUsageError(
+      "unauthorized",
+      "ChatGPT rejected the OAuth token. Reconnect ChatGPT Plus/Pro and try again.",
+    );
+  }
+  if (response.status === 403) {
+    return chatGPTUsageError(
+      "forbidden",
+      "ChatGPT usage is not available for this account.",
+    );
+  }
+  if (response.status === 429) {
+    return chatGPTUsageError(
+      "rate_limited",
+      "ChatGPT usage is rate limited. Try again later.",
+      retryAfterMs(response),
+    );
+  }
+  if (!response.ok) {
+    return chatGPTUsageError(
+      "network_error",
+      `ChatGPT usage request failed with HTTP ${response.status}.`,
+    );
+  }
+
+  let raw: unknown;
+  try {
+    raw = await response.json();
+  } catch {
+    return chatGPTUsageError(
+      "bad_response",
+      "ChatGPT usage returned invalid JSON.",
+    );
+  }
+
+  const result: Extract<ChatGPTUsageReadResult, { success: true }> = {
+    success: true,
+    usage: normalizeWhamUsageResponse({
+      raw,
+      providerName: record.name,
+      nowMs: now,
+    }),
+  };
+  usageCache.set(cacheKey, { expiresAt: now + CACHE_TTL_MS, result });
+  return result;
+}

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -1364,6 +1364,7 @@ export interface ListModelsCommand {
 }
 
 export type ConnectProviderStorageTarget = "local";
+export type ChatGPTUsageReadTarget = "local" | "api";
 
 export interface ListConnectProvidersCommand {
   type: "list_connect_providers";
@@ -1403,8 +1404,8 @@ export interface ChatGPTUsageReadCommand {
   type: "chatgpt_usage_read";
   /** Echoed back in the response for request correlation. */
   request_id: string;
-  /** Provider store to inspect. MVP supports local provider storage. */
-  target: ConnectProviderStorageTarget;
+  /** Provider store to inspect. */
+  target: ChatGPTUsageReadTarget;
   /** Optional connected ChatGPT provider alias. Defaults to the built-in alias. */
   provider_name?: string;
   /** Skip the short listener-side cache. */
@@ -1498,6 +1499,13 @@ export interface ChatGPTUsageCreditsPayload {
   unlimited?: boolean | null;
 }
 
+export interface ChatGPTUsageIndividualLimitPayload {
+  limit: string;
+  used: string;
+  remainingPercent: number;
+  resetsAt: number;
+}
+
 export interface ChatGPTUsageSnapshotPayload {
   providerName: string;
   fetchedAt: string;
@@ -1509,10 +1517,12 @@ export interface ChatGPTUsageSnapshotPayload {
   secondary: ChatGPTUsageWindowPayload | null;
   additional: ChatGPTUsageWindowPayload[];
   credits?: ChatGPTUsageCreditsPayload | null;
+  individualLimit?: ChatGPTUsageIndividualLimitPayload | null;
 }
 
 export interface ChatGPTUsageReadErrorPayload {
   code:
+    | "bad_request"
     | "not_connected"
     | "unsupported_target"
     | "refresh_failed"
@@ -1529,7 +1539,7 @@ export interface ChatGPTUsageReadResponseMessage {
   type: "chatgpt_usage_read_response";
   request_id: string;
   success: boolean;
-  target: ConnectProviderStorageTarget;
+  target: ChatGPTUsageReadTarget;
   usage?: ChatGPTUsageSnapshotPayload;
   error?: ChatGPTUsageReadErrorPayload;
 }

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -1399,6 +1399,18 @@ export interface DisconnectProviderCommand {
   provider_name?: string;
 }
 
+export interface ChatGPTUsageReadCommand {
+  type: "chatgpt_usage_read";
+  /** Echoed back in the response for request correlation. */
+  request_id: string;
+  /** Provider store to inspect. MVP supports local provider storage. */
+  target: ConnectProviderStorageTarget;
+  /** Optional connected ChatGPT provider alias. Defaults to the built-in alias. */
+  provider_name?: string;
+  /** Skip the short listener-side cache. */
+  force_refresh?: boolean;
+}
+
 export interface ConnectProviderField {
   key: string;
   label: string;
@@ -1470,6 +1482,56 @@ export interface DisconnectProviderResponseMessage {
   providers: ConnectProviderEntry[];
   models_may_have_changed: boolean;
   error?: string;
+}
+
+export interface ChatGPTUsageWindowPayload {
+  label: string;
+  usedPercent: number | null;
+  windowDurationMins: number | null;
+  resetsAt: number | null;
+}
+
+export interface ChatGPTUsageCreditsPayload {
+  balance?: string | null;
+  availableCount?: number | null;
+  hasCredits?: boolean | null;
+  unlimited?: boolean | null;
+}
+
+export interface ChatGPTUsageSnapshotPayload {
+  providerName: string;
+  fetchedAt: string;
+  summary: string;
+  planType?: string | null;
+  limitReached?: boolean | null;
+  rateLimitReachedType?: string | null;
+  primary: ChatGPTUsageWindowPayload | null;
+  secondary: ChatGPTUsageWindowPayload | null;
+  additional: ChatGPTUsageWindowPayload[];
+  credits?: ChatGPTUsageCreditsPayload | null;
+}
+
+export interface ChatGPTUsageReadErrorPayload {
+  code:
+    | "not_connected"
+    | "unsupported_target"
+    | "refresh_failed"
+    | "unauthorized"
+    | "forbidden"
+    | "rate_limited"
+    | "network_error"
+    | "bad_response";
+  message: string;
+  retryAfterMs?: number;
+}
+
+export interface ChatGPTUsageReadResponseMessage {
+  type: "chatgpt_usage_read_response";
+  request_id: string;
+  success: boolean;
+  target: ConnectProviderStorageTarget;
+  usage?: ChatGPTUsageSnapshotPayload;
+  error?: ChatGPTUsageReadErrorPayload;
 }
 
 export interface UpdateModelPayload {
@@ -2682,6 +2744,7 @@ export type WsProtocolCommand =
   | ListConnectProvidersCommand
   | ConnectProviderCommand
   | DisconnectProviderCommand
+  | ChatGPTUsageReadCommand
   | UpdateModelCommand
   | UpdateToolsetCommand
   | CronListCommand
@@ -2778,6 +2841,7 @@ export type WsProtocolMessage =
   | ListConnectProvidersResponseMessage
   | ConnectProviderResponseMessage
   | DisconnectProviderResponseMessage
+  | ChatGPTUsageReadResponseMessage
   | UpdateModelResponseMessage
   | UpdateToolsetResponseMessage
   | CronListResponseMessage

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -1447,13 +1447,29 @@ describe("listen-client parseServerMessage", () => {
     expect(parsed?.type).toBe("chatgpt_usage_read");
   });
 
-  test("rejects chatgpt_usage_read command for non-local target", () => {
+  test("parses chatgpt_usage_read command for api target", () => {
     const parsed = parseServerMessage(
       Buffer.from(
         JSON.stringify({
           type: "chatgpt_usage_read",
           request_id: "chatgpt-usage-2",
           target: "api",
+          provider_name: "chatgpt-work",
+        }),
+      ),
+    );
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.type).toBe("chatgpt_usage_read");
+  });
+
+  test("rejects chatgpt_usage_read command for unknown target", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "chatgpt_usage_read",
+          request_id: "chatgpt-usage-3",
+          target: "project",
         }),
       ),
     );
@@ -1466,7 +1482,7 @@ describe("listen-client parseServerMessage", () => {
       Buffer.from(
         JSON.stringify({
           type: "chatgpt_usage_read",
-          request_id: "chatgpt-usage-3",
+          request_id: "chatgpt-usage-4",
           target: "local",
           force_refresh: "true",
         }),

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -1430,6 +1430,52 @@ describe("listen-client parseServerMessage", () => {
     expect(parsed?.type).toBe("disconnect_provider");
   });
 
+  test("parses chatgpt_usage_read command", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "chatgpt_usage_read",
+          request_id: "chatgpt-usage-1",
+          target: "local",
+          provider_name: "chatgpt-work",
+          force_refresh: true,
+        }),
+      ),
+    );
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.type).toBe("chatgpt_usage_read");
+  });
+
+  test("rejects chatgpt_usage_read command for non-local target", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "chatgpt_usage_read",
+          request_id: "chatgpt-usage-2",
+          target: "api",
+        }),
+      ),
+    );
+
+    expect(parsed).toBeNull();
+  });
+
+  test("rejects chatgpt_usage_read command with bad force_refresh", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "chatgpt_usage_read",
+          request_id: "chatgpt-usage-3",
+          target: "local",
+          force_refresh: "true",
+        }),
+      ),
+    );
+
+    expect(parsed).toBeNull();
+  });
+
   test("parses update_model command with model_id", () => {
     const parsed = parseServerMessage(
       Buffer.from(

--- a/src/websocket/listener/commands/chatgpt-usage.ts
+++ b/src/websocket/listener/commands/chatgpt-usage.ts
@@ -1,0 +1,82 @@
+import type WebSocket from "ws";
+import { readChatGPTUsage } from "@/providers/chatgpt-usage-service";
+import type {
+  ChatGPTUsageReadCommand,
+  ChatGPTUsageReadResponseMessage,
+} from "@/types/protocol_v2";
+import { isChatGPTUsageReadCommand } from "@/websocket/listener/protocol-inbound";
+import type { RunDetachedListenerTask, SafeSocketSend } from "./types";
+
+type ChatGPTUsageCommandContext = {
+  socket: WebSocket;
+  safeSocketSend: SafeSocketSend;
+  runDetachedListenerTask: RunDetachedListenerTask;
+};
+
+export async function buildChatGPTUsageReadResponse(
+  command: ChatGPTUsageReadCommand,
+): Promise<ChatGPTUsageReadResponseMessage> {
+  const result = await readChatGPTUsage({
+    target: command.target,
+    ...(command.provider_name ? { providerName: command.provider_name } : {}),
+    forceRefresh: command.force_refresh === true,
+  });
+
+  if (!result.success) {
+    return {
+      type: "chatgpt_usage_read_response",
+      request_id: command.request_id,
+      success: false,
+      target: command.target,
+      error: result.error,
+    };
+  }
+
+  return {
+    type: "chatgpt_usage_read_response",
+    request_id: command.request_id,
+    success: true,
+    target: command.target,
+    usage: result.usage,
+  };
+}
+
+export function handleChatGPTUsageCommand(
+  parsed: unknown,
+  context: ChatGPTUsageCommandContext,
+): boolean {
+  if (!isChatGPTUsageReadCommand(parsed)) return false;
+
+  const { socket, safeSocketSend, runDetachedListenerTask } = context;
+  runDetachedListenerTask("chatgpt_usage_read", async () => {
+    try {
+      const response = await buildChatGPTUsageReadResponse(parsed);
+      safeSocketSend(
+        socket,
+        response,
+        "listener_chatgpt_usage_read_send_failed",
+        "listener_chatgpt_usage_read",
+      );
+    } catch (error) {
+      safeSocketSend(
+        socket,
+        {
+          type: "chatgpt_usage_read_response",
+          request_id: parsed.request_id,
+          success: false,
+          target: parsed.target,
+          error: {
+            code: "network_error",
+            message:
+              error instanceof Error
+                ? error.message
+                : "Failed to read ChatGPT usage.",
+          },
+        },
+        "listener_chatgpt_usage_read_send_failed",
+        "listener_chatgpt_usage_read",
+      );
+    }
+  });
+  return true;
+}

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -25,6 +25,7 @@ import {
   handleChannelsProtocolCommand,
   isDetachedChannelsCommand,
 } from "./commands/channels";
+import { handleChatGPTUsageCommand } from "./commands/chatgpt-usage";
 import { handleConnectProvidersCommand } from "./commands/connect-providers";
 import { handleCronProtocolCommand } from "./commands/cron";
 import { handleGitBranchCommand } from "./commands/git-branches";
@@ -800,6 +801,16 @@ export function createListenerMessageHandler(
 
       if (
         handleConnectProvidersCommand(parsed, {
+          socket,
+          safeSocketSend,
+          runDetachedListenerTask,
+        })
+      ) {
+        return;
+      }
+
+      if (
+        handleChatGPTUsageCommand(parsed, {
           socket,
           safeSocketSend,
           runDetachedListenerTask,

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -30,6 +30,7 @@ import type {
   ChannelsListCommand,
   ChannelTargetBindCommand,
   ChannelTargetsListCommand,
+  ChatGPTUsageReadCommand,
   CheckoutBranchCommand,
   ConnectProviderCommand,
   ConversationCompactCommand,
@@ -891,6 +892,26 @@ export function isDisconnectProviderCommand(
     c.target === "local" &&
     typeof c.provider_id === "string" &&
     (c.provider_name === undefined || typeof c.provider_name === "string")
+  );
+}
+
+export function isChatGPTUsageReadCommand(
+  value: unknown,
+): value is ChatGPTUsageReadCommand {
+  if (!value || typeof value !== "object") return false;
+  const c = value as {
+    type?: unknown;
+    request_id?: unknown;
+    target?: unknown;
+    provider_name?: unknown;
+    force_refresh?: unknown;
+  };
+  return (
+    c.type === "chatgpt_usage_read" &&
+    typeof c.request_id === "string" &&
+    c.target === "local" &&
+    (c.provider_name === undefined || typeof c.provider_name === "string") &&
+    (c.force_refresh === undefined || typeof c.force_refresh === "boolean")
   );
 }
 
@@ -2169,6 +2190,7 @@ export function parseServerMessage(
       isListConnectProvidersCommand(parsed) ||
       isConnectProviderCommand(parsed) ||
       isDisconnectProviderCommand(parsed) ||
+      isChatGPTUsageReadCommand(parsed) ||
       isUpdateModelCommand(parsed) ||
       isUpdateToolsetCommand(parsed) ||
       isCronListCommand(parsed) ||

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -909,7 +909,7 @@ export function isChatGPTUsageReadCommand(
   return (
     c.type === "chatgpt_usage_read" &&
     typeof c.request_id === "string" &&
-    c.target === "local" &&
+    (c.target === "local" || c.target === "api") &&
     (c.provider_name === undefined || typeof c.provider_name === "string") &&
     (c.force_refresh === undefined || typeof c.force_refresh === "boolean")
   );


### PR DESCRIPTION
Stacked on #2971. Cloud usage reads depend on letta-cloud#12500 (`GET /v1/providers/chatgpt-usage`).

## Summary
- Add a ChatGPT OAuth usage service that returns a normalized `ChatGPTUsageSnapshot` with compact summary text, quota windows, credits, and individual-limit data.
- Keep local ChatGPT usage reads on the existing local path: read the locally stored ChatGPT OAuth provider, refresh/get the local ChatGPT OAuth token, then call `https://chatgpt.com/backend-api/wham/usage` with the ChatGPT account id when available.
- Add the cloud/API usage path for Constellation-stored ChatGPT OAuth providers: call `/v1/providers/chatgpt-usage?provider_name=<alias>` on the configured Letta API base URL using Letta Cloud auth, including access-token refresh when needed.
- Route `/connect` usage reads by the currently selected provider store target instead of always using `local`, so cloud ChatGPT aliases no longer incorrectly hit the local ChatGPT Plus/Pro WHAM path.
- Show usage for each connected ChatGPT OAuth alias in the `/connect` manage screen, and add a `Refresh usage` action for manual refresh.
- Add a detached websocket `chatgpt_usage_read` command/response so desktop/listener clients can request ChatGPT usage for both `local` and `api` provider targets.
- Add protocol payload/error types for ChatGPT usage, including `individualLimit`, `retryAfterMs`, and cloud/local error codes.
- Add error handling for unauthorized, forbidden, rate-limited, bad response, disconnected provider, and cloud endpoint unavailable cases. A missing cloud endpoint is reported separately from a missing provider alias.

## Files changed
- `src/providers/chatgpt-usage-service.ts`: new shared usage reader, local WHAM fetch path, cloud Letta API fetch path, 30s success cache, normalization/formatting helpers, token refresh, and HTTP error mapping.
- `src/cli/components/ProviderSelector.tsx`: detects ChatGPT OAuth providers, loads per-alias usage, displays usage under each connected alias, wires `Refresh usage`, and passes the selected `local`/`api` target into usage reads.
- `src/types/protocol_v2.ts`: adds `ChatGPTUsageReadCommand`, `ChatGPTUsageReadResponseMessage`, target type `local | api`, usage payloads, and error payloads.
- `src/websocket/listener/commands/chatgpt-usage.ts`: handles usage read commands asynchronously and returns typed success/error responses.
- `src/websocket/listener/message-router.ts`: routes `chatgpt_usage_read` commands through the new handler.
- `src/websocket/listener/protocol-inbound.ts`: validates `chatgpt_usage_read` commands, allowing `local` and `api` targets while rejecting unknown targets.
- `src/providers/chatgpt-usage-service.test.ts`: covers WHAM normalization, cloud endpoint URL/auth, cloud provider errors, and the missing-cloud-endpoint edge case.
- `src/websocket/listen-client-protocol.test.ts`: covers parsing `chatgpt_usage_read` for local/api targets and rejecting invalid payloads.
- `src/cli/components/provider-selector.test.ts`: covers ChatGPT OAuth usage-provider detection.

## Verification
- `bun run typecheck`
- `bun test src/providers/chatgpt-usage-service.test.ts src/websocket/listen-client-protocol.test.ts src/cli/components/provider-selector.test.ts`
- `bunx --bun @biomejs/biome@2.2.5 check src/providers/chatgpt-usage-service.ts src/providers/chatgpt-usage-service.test.ts src/cli/components/ProviderSelector.tsx src/types/protocol_v2.ts src/websocket/listener/protocol-inbound.ts src/websocket/listen-client-protocol.test.ts`
- `bun run check:boundaries`
- `bun run check:exported-functions`
