### PR TITLE
feat(telemetry): trace tool call errors

### DIFF
--- a/scripts/run-unit-tests.cjs
+++ b/scripts/run-unit-tests.cjs
@@ -21,7 +21,6 @@ const dirs = [
   "src/queue",
   "src/reminders",
   "src/skills",
-  "src/telemetry",
   "src/test-utils",
   "src/tools",
   "src/types",
@@ -57,6 +56,13 @@ const channelTestFiles = findTestFiles("src/channels", [
   "src/channels/slack-media.test.ts",
 ]);
 
+// flush-auth mutates process.env plus telemetry/settings singletons while
+// asserting constellation/self-hosted routing. Bun runs test files in shared
+// workers, so unrelated env-mutating tests can race it. Keep it isolated.
+const telemetryTestFiles = findTestFiles("src/telemetry", [
+  "src/telemetry/flush-auth.test.ts",
+]);
+
 const opts = { stdio: "inherit", shell: process.platform === "win32" };
 let exitCode = 0;
 
@@ -67,10 +73,21 @@ try {
   exitCode = e.status ?? 1;
 }
 
+// Run telemetry flush-auth in isolation (clean env/settings globals)
+try {
+  execSync("bun test src/telemetry/flush-auth.test.ts --timeout 15000", opts);
+} catch (e) {
+  exitCode = e.status ?? 1;
+}
+
 // Run everything else
 try {
   execSync(
-    `bun test ${[...dirs, ...channelTestFiles].join(" ")} --timeout 15000`,
+    `bun test ${[
+      ...dirs,
+      ...telemetryTestFiles,
+      ...channelTestFiles,
+    ].join(" ")} --timeout 15000`,
     opts,
   );
 } catch (e) {

--- a/src/runtime-context.ts
+++ b/src/runtime-context.ts
@@ -12,6 +12,7 @@ export type RuntimePermissionMode =
 export interface RuntimeContextSnapshot {
   agentId?: string | null;
   conversationId?: string | null;
+  stepId?: string | null;
   skillsDirectory?: string | null;
   skillSources?: SkillSource[];
   workingDirectory?: string | null;

--- a/src/telemetry/flush-auth.test.ts
+++ b/src/telemetry/flush-auth.test.ts
@@ -206,6 +206,53 @@ describe("telemetry flush auth", () => {
     expect(telemetryState.events).toHaveLength(0);
   });
 
+  test("tool call error telemetry queues only safe constellation metadata", () => {
+    telemetry.trackToolCallError({
+      toolName: "Bash",
+      toolType: "built_in",
+      reason: "tool_exception",
+      errorType: "ShellExecutionError",
+      toolCallId: "call-1",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+    });
+
+    expect(telemetryState.events).toHaveLength(1);
+    const event = telemetryState.events[0] as {
+      type?: string;
+      data?: Record<string, unknown>;
+    };
+    expect(event.type).toBe("tool_call_error");
+    expect(event.data).toMatchObject({
+      agent_id: "agent-1",
+      backend: "constellation",
+      conversation_id: "conv-1",
+      error_type: "ShellExecutionError",
+      reason: "tool_exception",
+      status: "error",
+      tool_call_id: "call-1",
+      tool_name: "Bash",
+      tool_type: "built_in",
+    });
+    expect(event.data && "stderr" in event.data).toBe(false);
+    expect(event.data && "tool_arguments" in event.data).toBe(false);
+    expect(event.data && "error_message" in event.data).toBe(false);
+  });
+
+  test("self-hosted users do not queue tool call error telemetry", () => {
+    setEnvVar("LETTA_BASE_URL", "https://self-hosted.example.com");
+
+    telemetry.trackToolCallError({
+      toolName: "Bash",
+      toolType: "built_in",
+      reason: "tool_exception",
+      errorType: "ShellExecutionError",
+      toolCallId: "call-1",
+    });
+
+    expect(telemetryState.events).toHaveLength(0);
+  });
+
   test("self-hosted users still send usage telemetry", async () => {
     setEnvVar("LETTA_BASE_URL", "http://localhost:8283");
 

--- a/src/telemetry/flush-auth.test.ts
+++ b/src/telemetry/flush-auth.test.ts
@@ -215,6 +215,7 @@ describe("telemetry flush auth", () => {
       toolCallId: "call-1",
       agentId: "agent-1",
       conversationId: "conv-1",
+      stepId: "step-1",
     });
 
     expect(telemetryState.events).toHaveLength(1);
@@ -228,8 +229,12 @@ describe("telemetry flush auth", () => {
       backend: "constellation",
       conversation_id: "conv-1",
       error_type: "ShellExecutionError",
+      node_version: process.version,
+      os_arch: process.arch,
+      os_platform: process.platform,
       reason: "tool_exception",
       status: "error",
+      step_id: "step-1",
       tool_call_id: "call-1",
       tool_name: "Bash",
       tool_type: "built_in",

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -89,6 +89,10 @@ export interface ToolCallErrorData {
   tool_call_id?: string;
   agent_id?: string;
   conversation_id?: string;
+  step_id?: string;
+  os_platform: string;
+  os_arch: string;
+  node_version: string;
 }
 
 export interface ErrorData {
@@ -663,7 +667,8 @@ class TelemetryManager {
 
   /**
    * Track tool call failures with safe, constellation-only metadata.
-   * Do not include tool arguments, tool output, stderr, or user content here.
+   * Do not include tool arguments, tool output, stderr, user content, or
+   * raw exception messages here.
    */
   trackToolCallError(options: {
     toolName: string;
@@ -673,6 +678,7 @@ class TelemetryManager {
     toolCallId?: string;
     agentId?: string | null;
     conversationId?: string | null;
+    stepId?: string | null;
   }) {
     if (resolveTelemetryBackend() !== "constellation") {
       return;
@@ -687,6 +693,10 @@ class TelemetryManager {
       tool_call_id: options.toolCallId,
       agent_id: options.agentId ?? undefined,
       conversation_id: options.conversationId ?? undefined,
+      step_id: options.stepId ?? undefined,
+      os_platform: process.platform,
+      os_arch: process.arch,
+      node_version: process.version,
     };
     this.track("tool_call_error", data);
   }

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -27,6 +27,7 @@ export interface TelemetryEvent {
     | "session_start"
     | "session_end"
     | "tool_usage"
+    | "tool_call_error"
     | "error"
     | "user_input"
     | "reflection_start"
@@ -67,6 +68,27 @@ export interface ToolUsageData {
   response_length?: number;
   error_type?: string;
   stderr?: string;
+}
+
+export type ToolCallErrorToolType = "built_in" | "external" | "mod" | "unknown";
+
+export type ToolCallErrorReason =
+  | "tool_returned_error"
+  | "tool_exception"
+  | "tool_not_found"
+  | "tool_context_not_found"
+  | "permission_denied"
+  | "pre_tool_hook_blocked";
+
+export interface ToolCallErrorData {
+  tool_name: string;
+  tool_type: ToolCallErrorToolType;
+  status: "error";
+  reason: ToolCallErrorReason;
+  error_type?: string;
+  tool_call_id?: string;
+  agent_id?: string;
+  conversation_id?: string;
 }
 
 export interface ErrorData {
@@ -413,6 +435,7 @@ class TelemetryManager {
       | SessionStartData
       | SessionEndData
       | ToolUsageData
+      | ToolCallErrorData
       | ErrorData
       | UserInputData
       | ReflectionStartData
@@ -422,13 +445,19 @@ class TelemetryManager {
       return;
     }
 
+    const dataRecord = data as Record<string, unknown>;
+    const eventAgentId =
+      typeof dataRecord.agent_id === "string" && dataRecord.agent_id.length > 0
+        ? dataRecord.agent_id
+        : this.currentAgentId || undefined;
+
     const event: TelemetryEvent = {
       type,
       timestamp: new Date().toISOString(),
       data: {
         ...data,
         session_id: this.sessionId,
-        agent_id: this.currentAgentId || undefined,
+        agent_id: eventAgentId,
         surface: this.surface,
         backend: resolveTelemetryBackend(),
       },
@@ -630,6 +659,36 @@ class TelemetryManager {
       stderr,
     };
     this.track("tool_usage", data);
+  }
+
+  /**
+   * Track tool call failures with safe, constellation-only metadata.
+   * Do not include tool arguments, tool output, stderr, or user content here.
+   */
+  trackToolCallError(options: {
+    toolName: string;
+    toolType: ToolCallErrorToolType;
+    reason: ToolCallErrorReason;
+    errorType?: string;
+    toolCallId?: string;
+    agentId?: string | null;
+    conversationId?: string | null;
+  }) {
+    if (resolveTelemetryBackend() !== "constellation") {
+      return;
+    }
+
+    const data: ToolCallErrorData = {
+      tool_name: options.toolName,
+      tool_type: options.toolType,
+      status: "error",
+      reason: options.reason,
+      error_type: options.errorType,
+      tool_call_id: options.toolCallId,
+      agent_id: options.agentId ?? undefined,
+      conversation_id: options.conversationId ?? undefined,
+    };
+    this.track("tool_call_error", data);
   }
 
   /**

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -444,6 +444,7 @@ class TelemetryManager {
       | UserInputData
       | ReflectionStartData
       | ReflectionEndData,
+    options?: { backend?: TelemetryBackend },
   ) {
     if (!this.isTelemetryEnabled()) {
       return;
@@ -463,7 +464,7 @@ class TelemetryManager {
         session_id: this.sessionId,
         agent_id: eventAgentId,
         surface: this.surface,
-        backend: resolveTelemetryBackend(),
+        backend: options?.backend ?? resolveTelemetryBackend(),
       },
     };
 
@@ -680,7 +681,8 @@ class TelemetryManager {
     conversationId?: string | null;
     stepId?: string | null;
   }) {
-    if (resolveTelemetryBackend() !== "constellation") {
+    const backend = resolveTelemetryBackend();
+    if (backend !== "constellation") {
       return;
     }
 
@@ -698,7 +700,7 @@ class TelemetryManager {
       os_arch: process.arch,
       node_version: process.version,
     };
-    this.track("tool_call_error", data);
+    this.track("tool_call_error", data, { backend });
   }
 
   /**

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -63,7 +63,11 @@ import {
   runWithRuntimeContext,
 } from "@/runtime-context";
 import { settingsManager } from "@/settings-manager";
-import { telemetry } from "@/telemetry";
+import {
+  type ToolCallErrorReason,
+  type ToolCallErrorToolType,
+  telemetry,
+} from "@/telemetry";
 import { debugLog } from "@/utils/debug";
 import { isRecord } from "@/utils/type-guards";
 import {
@@ -596,6 +600,30 @@ export type ToolExecutionResult = {
   stdout?: string[];
   stderr?: string[];
 };
+
+type ToolCallErrorTelemetryContext = {
+  agentId?: string | null;
+  conversationId?: string | null;
+  errorType?: string;
+  reason: ToolCallErrorReason;
+  toolCallId?: string;
+  toolName: string;
+  toolType: ToolCallErrorToolType;
+};
+
+function trackToolCallErrorTelemetry(
+  context: ToolCallErrorTelemetryContext,
+): void {
+  telemetry.trackToolCallError({
+    toolName: context.toolName,
+    toolType: context.toolType,
+    reason: context.reason,
+    errorType: context.errorType,
+    toolCallId: context.toolCallId,
+    agentId: context.agentId,
+    conversationId: context.conversationId,
+  });
+}
 
 type ToolRegistry = Map<string, ToolDefinition>;
 
@@ -2200,6 +2228,15 @@ async function executeModTool(
     );
     if (preHookResult.blocked) {
       const feedback = preHookResult.feedback.join("\n") || "Blocked by hook";
+      trackToolCallErrorTelemetry({
+        agentId: executionScope.agentId,
+        conversationId: executionScope.conversationId,
+        errorType: "hook_blocked",
+        reason: "pre_tool_hook_blocked",
+        toolCallId: options.toolCallId,
+        toolName,
+        toolType: "mod",
+      });
       return {
         toolReturn: `Error: Tool execution blocked by hook. ${feedback}`,
         status: "error",
@@ -2268,8 +2305,19 @@ async function executeModTool(
         duration,
         responseSize,
         toolStatus === "error" ? "tool_error" : undefined,
-        stderr ? stderr.join("\n") : undefined,
+        undefined,
       );
+      if (toolStatus === "error") {
+        trackToolCallErrorTelemetry({
+          agentId: executionScope.agentId,
+          conversationId: executionScope.conversationId,
+          errorType: "tool_error",
+          reason: "tool_returned_error",
+          toolCallId: options.toolCallId,
+          toolName,
+          toolType: "mod",
+        });
+      }
 
       const hookFeedback = await collectPostToolHookFeedback(
         {
@@ -2331,8 +2379,17 @@ async function executeModTool(
         duration,
         errorMessage.length,
         errorType,
-        errorMessage,
+        undefined,
       );
+      trackToolCallErrorTelemetry({
+        agentId: executionScope.agentId,
+        conversationId: executionScope.conversationId,
+        errorType,
+        reason: "tool_exception",
+        toolCallId: options.toolCallId,
+        toolName,
+        toolType: "mod",
+      });
 
       const hookFeedback = await collectPostToolHookFeedback(
         {
@@ -2408,6 +2465,13 @@ export async function executeTool(
     ? getExecutionContextById(options.toolContextId)
     : undefined;
   if (options?.toolContextId && !context) {
+    trackToolCallErrorTelemetry({
+      errorType: "tool_context_not_found",
+      reason: "tool_context_not_found",
+      toolCallId: options.toolCallId,
+      toolName: name,
+      toolType: "unknown",
+    });
     return {
       toolReturn: `Tool execution context not found: ${options.toolContextId}`,
       status: "error",
@@ -2441,6 +2505,15 @@ export async function executeTool(
   if (activeModTools.has(name)) {
     const modTool = activeModTools.get(name);
     if (!modTool) {
+      trackToolCallErrorTelemetry({
+        agentId: executionScope.agentId,
+        conversationId: executionScope.conversationId,
+        errorType: "tool_not_found",
+        reason: "tool_not_found",
+        toolCallId: options?.toolCallId,
+        toolName: name,
+        toolType: "mod",
+      });
       return {
         toolReturn: `Mod tool not found: ${name}`,
         status: "error",
@@ -2464,6 +2537,15 @@ export async function executeTool(
     });
     if (permissionDecision?.decision !== undefined) {
       if (permissionDecision.decision !== "allow") {
+        trackToolCallErrorTelemetry({
+          agentId: executionScope.agentId,
+          conversationId: executionScope.conversationId,
+          errorType: "permission_denied",
+          reason: "permission_denied",
+          toolCallId: options?.toolCallId,
+          toolName: name,
+          toolType: "mod",
+        });
         return createModPermissionToolResult(permissionDecision);
       }
     }
@@ -2498,16 +2580,37 @@ export async function executeTool(
     });
     if (permissionDecision?.decision !== undefined) {
       if (permissionDecision.decision !== "allow") {
+        trackToolCallErrorTelemetry({
+          agentId: executionScope.agentId,
+          conversationId: executionScope.conversationId,
+          errorType: "permission_denied",
+          reason: "permission_denied",
+          toolCallId: options?.toolCallId,
+          toolName: name,
+          toolType: "external",
+        });
         return createModPermissionToolResult(permissionDecision);
       }
     }
-    return executeExternalTool(
+    const externalResult = await executeExternalTool(
       options?.toolCallId ?? `ext-${Date.now()}`,
       name,
       eventArgs as Record<string, unknown>,
       activeExternalExecutor,
       externalTool,
     );
+    if (externalResult.status === "error") {
+      trackToolCallErrorTelemetry({
+        agentId: executionScope.agentId,
+        conversationId: executionScope.conversationId,
+        errorType: "tool_error",
+        reason: "tool_returned_error",
+        toolCallId: options?.toolCallId,
+        toolName: name,
+        toolType: "external",
+      });
+    }
+    return externalResult;
   }
 
   const internalName = resolveInternalToolName(name, activeRegistry);
@@ -2517,6 +2620,15 @@ export async function executeTool(
       ...Array.from(activeExternalTools.keys()),
       ...Array.from(activeModTools.keys()),
     ];
+    trackToolCallErrorTelemetry({
+      agentId: executionScope.agentId,
+      conversationId: executionScope.conversationId,
+      errorType: "tool_not_found",
+      reason: "tool_not_found",
+      toolCallId: options?.toolCallId,
+      toolName: name,
+      toolType: "unknown",
+    });
     return {
       toolReturn: `Tool not found: ${name}. Available tools: ${availableTools.join(", ")}`,
       status: "error",
@@ -2530,6 +2642,15 @@ export async function executeTool(
       ...Array.from(activeExternalTools.keys()),
       ...Array.from(activeModTools.keys()),
     ];
+    trackToolCallErrorTelemetry({
+      agentId: executionScope.agentId,
+      conversationId: executionScope.conversationId,
+      errorType: "tool_not_found",
+      reason: "tool_not_found",
+      toolCallId: options?.toolCallId,
+      toolName: name,
+      toolType: "built_in",
+    });
     return {
       toolReturn: `Tool not found: ${name}. Available tools: ${availableTools.join(", ")}`,
       status: "error",
@@ -2555,6 +2676,15 @@ export async function executeTool(
   });
   if (permissionDecision?.decision !== undefined) {
     if (permissionDecision.decision !== "allow") {
+      trackToolCallErrorTelemetry({
+        agentId: executionScope.agentId,
+        conversationId: executionScope.conversationId,
+        errorType: "permission_denied",
+        reason: "permission_denied",
+        toolCallId: options?.toolCallId,
+        toolName: internalName,
+        toolType: "built_in",
+      });
       return createModPermissionToolResult(permissionDecision);
     }
   }
@@ -2571,6 +2701,15 @@ export async function executeTool(
     );
     if (preHookResult.blocked) {
       const feedback = preHookResult.feedback.join("\n") || "Blocked by hook";
+      trackToolCallErrorTelemetry({
+        agentId: executionScope.agentId,
+        conversationId: executionScope.conversationId,
+        errorType: "hook_blocked",
+        reason: "pre_tool_hook_blocked",
+        toolCallId: options?.toolCallId,
+        toolName: internalName,
+        toolType: "built_in",
+      });
       return {
         toolReturn: `Error: Tool execution blocked by hook. ${feedback}`,
         status: "error",
@@ -2746,8 +2885,19 @@ export async function executeTool(
         duration,
         responseSize,
         toolStatus === "error" ? "tool_error" : undefined,
-        stderr ? stderr.join("\n") : undefined,
+        undefined,
       );
+      if (toolStatus === "error") {
+        trackToolCallErrorTelemetry({
+          agentId: executionScope.agentId,
+          conversationId: executionScope.conversationId,
+          errorType: "tool_error",
+          reason: "tool_returned_error",
+          toolCallId: options?.toolCallId,
+          toolName: internalName,
+          toolType: "built_in",
+        });
+      }
 
       const hookFeedback = await collectPostToolHookFeedback(
         {
@@ -2806,8 +2956,17 @@ export async function executeTool(
         duration,
         errorMessage.length,
         errorType,
-        errorMessage,
+        undefined,
       );
+      trackToolCallErrorTelemetry({
+        agentId: executionScope.agentId,
+        conversationId: executionScope.conversationId,
+        errorType,
+        reason: "tool_exception",
+        toolCallId: options?.toolCallId,
+        toolName: internalName,
+        toolType: "built_in",
+      });
 
       const hookFeedback = await collectPostToolHookFeedback(
         {

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -604,6 +604,7 @@ export type ToolExecutionResult = {
 type ToolCallErrorTelemetryContext = {
   agentId?: string | null;
   conversationId?: string | null;
+  stepId?: string | null;
   errorType?: string;
   reason: ToolCallErrorReason;
   toolCallId?: string;
@@ -622,6 +623,7 @@ function trackToolCallErrorTelemetry(
     toolCallId: context.toolCallId,
     agentId: context.agentId,
     conversationId: context.conversationId,
+    stepId: context.stepId,
   });
 }
 
@@ -2231,6 +2233,7 @@ async function executeModTool(
       trackToolCallErrorTelemetry({
         agentId: executionScope.agentId,
         conversationId: executionScope.conversationId,
+        stepId: executionScope.stepId,
         errorType: "hook_blocked",
         reason: "pre_tool_hook_blocked",
         toolCallId: options.toolCallId,
@@ -2311,6 +2314,7 @@ async function executeModTool(
         trackToolCallErrorTelemetry({
           agentId: executionScope.agentId,
           conversationId: executionScope.conversationId,
+          stepId: executionScope.stepId,
           errorType: "tool_error",
           reason: "tool_returned_error",
           toolCallId: options.toolCallId,
@@ -2384,6 +2388,7 @@ async function executeModTool(
       trackToolCallErrorTelemetry({
         agentId: executionScope.agentId,
         conversationId: executionScope.conversationId,
+        stepId: executionScope.stepId,
         errorType,
         reason: "tool_exception",
         toolCallId: options.toolCallId,
@@ -2465,7 +2470,12 @@ export async function executeTool(
     ? getExecutionContextById(options.toolContextId)
     : undefined;
   if (options?.toolContextId && !context) {
+    const runtimeContext = getRuntimeContext();
     trackToolCallErrorTelemetry({
+      agentId: runtimeContext?.agentId ?? options.parentScope?.agentId,
+      conversationId:
+        runtimeContext?.conversationId ?? options.parentScope?.conversationId,
+      stepId: runtimeContext?.stepId,
       errorType: "tool_context_not_found",
       reason: "tool_context_not_found",
       toolCallId: options.toolCallId,
@@ -2508,6 +2518,7 @@ export async function executeTool(
       trackToolCallErrorTelemetry({
         agentId: executionScope.agentId,
         conversationId: executionScope.conversationId,
+        stepId: executionScope.stepId,
         errorType: "tool_not_found",
         reason: "tool_not_found",
         toolCallId: options?.toolCallId,
@@ -2540,6 +2551,7 @@ export async function executeTool(
         trackToolCallErrorTelemetry({
           agentId: executionScope.agentId,
           conversationId: executionScope.conversationId,
+          stepId: executionScope.stepId,
           errorType: "permission_denied",
           reason: "permission_denied",
           toolCallId: options?.toolCallId,
@@ -2583,6 +2595,7 @@ export async function executeTool(
         trackToolCallErrorTelemetry({
           agentId: executionScope.agentId,
           conversationId: executionScope.conversationId,
+          stepId: executionScope.stepId,
           errorType: "permission_denied",
           reason: "permission_denied",
           toolCallId: options?.toolCallId,
@@ -2603,6 +2616,7 @@ export async function executeTool(
       trackToolCallErrorTelemetry({
         agentId: executionScope.agentId,
         conversationId: executionScope.conversationId,
+        stepId: executionScope.stepId,
         errorType: "tool_error",
         reason: "tool_returned_error",
         toolCallId: options?.toolCallId,
@@ -2679,6 +2693,7 @@ export async function executeTool(
       trackToolCallErrorTelemetry({
         agentId: executionScope.agentId,
         conversationId: executionScope.conversationId,
+        stepId: executionScope.stepId,
         errorType: "permission_denied",
         reason: "permission_denied",
         toolCallId: options?.toolCallId,
@@ -2704,6 +2719,7 @@ export async function executeTool(
       trackToolCallErrorTelemetry({
         agentId: executionScope.agentId,
         conversationId: executionScope.conversationId,
+        stepId: executionScope.stepId,
         errorType: "hook_blocked",
         reason: "pre_tool_hook_blocked",
         toolCallId: options?.toolCallId,
@@ -2891,6 +2907,7 @@ export async function executeTool(
         trackToolCallErrorTelemetry({
           agentId: executionScope.agentId,
           conversationId: executionScope.conversationId,
+          stepId: executionScope.stepId,
           errorType: "tool_error",
           reason: "tool_returned_error",
           toolCallId: options?.toolCallId,
@@ -2961,6 +2978,7 @@ export async function executeTool(
       trackToolCallErrorTelemetry({
         agentId: executionScope.agentId,
         conversationId: executionScope.conversationId,
+        stepId: executionScope.stepId,
         errorType,
         reason: "tool_exception",
         toolCallId: options?.toolCallId,

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -2637,6 +2637,7 @@ export async function executeTool(
     trackToolCallErrorTelemetry({
       agentId: executionScope.agentId,
       conversationId: executionScope.conversationId,
+      stepId: executionScope.stepId,
       errorType: "tool_not_found",
       reason: "tool_not_found",
       toolCallId: options?.toolCallId,
@@ -2659,6 +2660,7 @@ export async function executeTool(
     trackToolCallErrorTelemetry({
       agentId: executionScope.agentId,
       conversationId: executionScope.conversationId,
+      stepId: executionScope.stepId,
       errorType: "tool_not_found",
       reason: "tool_not_found",
       toolCallId: options?.toolCallId,

--- a/src/tools/tool-error-telemetry.test.ts
+++ b/src/tools/tool-error-telemetry.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { clearModTools, registerModTool } from "@/mods/tool-registry";
+import { runWithRuntimeContext } from "@/runtime-context";
+import { telemetry } from "@/telemetry";
+import { executeTool } from "@/tools/manager";
+
+const originalTrackToolCallError = telemetry.trackToolCallError;
+const originalTrackToolUsage = telemetry.trackToolUsage;
+
+type ToolCallErrorPayload = Parameters<typeof telemetry.trackToolCallError>[0];
+
+type ModRun = Parameters<typeof registerModTool>[0]["run"];
+
+type MockWithCalls = {
+  mock: { calls: unknown };
+};
+
+function getFirstToolCallErrorPayload(
+  trackToolCallError: MockWithCalls,
+): ToolCallErrorPayload {
+  const calls = trackToolCallError.mock.calls as Array<[ToolCallErrorPayload]>;
+  const payload = calls[0]?.[0];
+  if (!payload) {
+    throw new Error("Expected tool call error telemetry payload");
+  }
+  return payload;
+}
+
+function registerLocalModTool(name: string, run: ModRun): void {
+  registerModTool({
+    name,
+    description: "Local test mod tool",
+    parameters: {
+      type: "object",
+      properties: { message: { type: "string" } },
+    },
+    owner: {
+      id: `global:/tmp/${name}.ts`,
+      path: `/tmp/${name}.ts`,
+      scope: "global",
+      generation: 1,
+    },
+    path: `/tmp/${name}.ts`,
+    approvalPolicy: "auto",
+    requiresApproval: false,
+    parallelSafe: true,
+    activationSignal: new AbortController().signal,
+    run,
+  });
+}
+
+describe("tool error telemetry", () => {
+  afterEach(() => {
+    telemetry.trackToolCallError = originalTrackToolCallError;
+    telemetry.trackToolUsage = originalTrackToolUsage;
+    clearModTools();
+  });
+
+  test("traces returned tool errors without leaking output or arguments", async () => {
+    const trackToolCallError = mock(() => {});
+    telemetry.trackToolCallError =
+      trackToolCallError as unknown as typeof telemetry.trackToolCallError;
+    telemetry.trackToolUsage = mock(
+      () => {},
+    ) as unknown as typeof telemetry.trackToolUsage;
+
+    registerLocalModTool("local_fail", () => ({
+      status: "error",
+      content: "secret output from the tool",
+      stderr: ["secret stderr from the tool"],
+    }));
+
+    const result = await runWithRuntimeContext(
+      {
+        agentId: "agent-1",
+        conversationId: "conv-1",
+        workingDirectory: process.cwd(),
+      },
+      () =>
+        executeTool(
+          "local_fail",
+          { message: "secret argument from the model" },
+          { toolCallId: "call-1" },
+        ),
+    );
+
+    expect(result.status).toBe("error");
+    expect(trackToolCallError).toHaveBeenCalledTimes(1);
+    const payload = getFirstToolCallErrorPayload(trackToolCallError);
+    expect(payload).toEqual({
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      errorType: "tool_error",
+      reason: "tool_returned_error",
+      toolCallId: "call-1",
+      toolName: "local_fail",
+      toolType: "mod",
+    });
+    expect(JSON.stringify(payload)).not.toContain("secret");
+  });
+
+  test("traces thrown tool errors without leaking exception messages", async () => {
+    const trackToolCallError = mock(() => {});
+    telemetry.trackToolCallError =
+      trackToolCallError as unknown as typeof telemetry.trackToolCallError;
+    telemetry.trackToolUsage = mock(
+      () => {},
+    ) as unknown as typeof telemetry.trackToolUsage;
+
+    registerLocalModTool("local_throw", () => {
+      throw new TypeError("secret exception message from tool internals");
+    });
+
+    const result = await runWithRuntimeContext(
+      {
+        agentId: "agent-1",
+        conversationId: "conv-1",
+        workingDirectory: process.cwd(),
+      },
+      () =>
+        executeTool(
+          "local_throw",
+          { message: "secret argument from the model" },
+          { toolCallId: "call-2" },
+        ),
+    );
+
+    expect(result.status).toBe("error");
+    expect(trackToolCallError).toHaveBeenCalledTimes(1);
+    const payload = getFirstToolCallErrorPayload(trackToolCallError);
+    expect(payload).toEqual({
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      errorType: "TypeError",
+      reason: "tool_exception",
+      toolCallId: "call-2",
+      toolName: "local_throw",
+      toolType: "mod",
+    });
+    expect(JSON.stringify(payload)).not.toContain("secret");
+  });
+});

--- a/src/tools/tool-error-telemetry.test.ts
+++ b/src/tools/tool-error-telemetry.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { clearModTools, registerModTool } from "@/mods/tool-registry";
 import { runWithRuntimeContext } from "@/runtime-context";
 import { telemetry } from "@/telemetry";
-import { executeTool } from "@/tools/manager";
+import {
+  clearCapturedToolExecutionContexts,
+  executeTool,
+  getExecutionContextById,
+  prepareToolExecutionContextForSpecificTools,
+} from "@/tools/manager";
 
 const originalTrackToolCallError = telemetry.trackToolCallError;
 const originalTrackToolUsage = telemetry.trackToolUsage;
@@ -53,6 +58,7 @@ describe("tool error telemetry", () => {
   afterEach(() => {
     telemetry.trackToolCallError = originalTrackToolCallError;
     telemetry.trackToolUsage = originalTrackToolUsage;
+    clearCapturedToolExecutionContexts();
     clearModTools();
   });
 
@@ -142,5 +148,85 @@ describe("tool error telemetry", () => {
       toolType: "mod",
     });
     expect(JSON.stringify(payload)).not.toContain("secret");
+  });
+
+  test("traces unresolved tools with runtime step ids", async () => {
+    const trackToolCallError = mock(() => {});
+    telemetry.trackToolCallError =
+      trackToolCallError as unknown as typeof telemetry.trackToolCallError;
+    telemetry.trackToolUsage = mock(
+      () => {},
+    ) as unknown as typeof telemetry.trackToolUsage;
+
+    const result = await runWithRuntimeContext(
+      {
+        agentId: "agent-1",
+        conversationId: "conv-1",
+        stepId: "step-3",
+        workingDirectory: process.cwd(),
+      },
+      () => executeTool("missing_tool", {}, { toolCallId: "call-3" }),
+    );
+
+    expect(result.status).toBe("error");
+    expect(trackToolCallError).toHaveBeenCalledTimes(1);
+    const payload = getFirstToolCallErrorPayload(trackToolCallError);
+    expect(payload).toEqual({
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      errorType: "tool_not_found",
+      reason: "tool_not_found",
+      stepId: "step-3",
+      toolCallId: "call-3",
+      toolName: "missing_tool",
+      toolType: "unknown",
+    });
+  });
+
+  test("traces missing built-in registry entries with runtime step ids", async () => {
+    const trackToolCallError = mock(() => {});
+    telemetry.trackToolCallError =
+      trackToolCallError as unknown as typeof telemetry.trackToolCallError;
+    telemetry.trackToolUsage = mock(
+      () => {},
+    ) as unknown as typeof telemetry.trackToolUsage;
+
+    const prepared = await prepareToolExecutionContextForSpecificTools(
+      ["Read"],
+      {
+        runtimeContext: {
+          agentId: "agent-1",
+          conversationId: "conv-1",
+          stepId: "step-4",
+          workingDirectory: process.cwd(),
+        },
+        workingDirectory: process.cwd(),
+      },
+    );
+    const context = getExecutionContextById(prepared.contextId);
+    if (!context) {
+      throw new Error("Expected prepared tool execution context");
+    }
+    context.toolRegistry.set("Read", undefined as never);
+
+    const result = await executeTool(
+      "Read",
+      {},
+      { toolCallId: "call-4", toolContextId: prepared.contextId },
+    );
+
+    expect(result.status).toBe("error");
+    expect(trackToolCallError).toHaveBeenCalledTimes(1);
+    const payload = getFirstToolCallErrorPayload(trackToolCallError);
+    expect(payload).toEqual({
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      errorType: "tool_not_found",
+      reason: "tool_not_found",
+      stepId: "step-4",
+      toolCallId: "call-4",
+      toolName: "Read",
+      toolType: "built_in",
+    });
   });
 });

--- a/src/tools/tool-error-telemetry.test.ts
+++ b/src/tools/tool-error-telemetry.test.ts
@@ -74,6 +74,7 @@ describe("tool error telemetry", () => {
       {
         agentId: "agent-1",
         conversationId: "conv-1",
+        stepId: "step-1",
         workingDirectory: process.cwd(),
       },
       () =>
@@ -92,6 +93,7 @@ describe("tool error telemetry", () => {
       conversationId: "conv-1",
       errorType: "tool_error",
       reason: "tool_returned_error",
+      stepId: "step-1",
       toolCallId: "call-1",
       toolName: "local_fail",
       toolType: "mod",
@@ -115,6 +117,7 @@ describe("tool error telemetry", () => {
       {
         agentId: "agent-1",
         conversationId: "conv-1",
+        stepId: "step-2",
         workingDirectory: process.cwd(),
       },
       () =>
@@ -133,6 +136,7 @@ describe("tool error telemetry", () => {
       conversationId: "conv-1",
       errorType: "TypeError",
       reason: "tool_exception",
+      stepId: "step-2",
       toolCallId: "call-2",
       toolName: "local_throw",
       toolType: "mod",


### PR DESCRIPTION
## Summary
- Add a constellation-only `tool_call_error` telemetry event for tool failures with tool name/type, failure reason, agent/conversation IDs, optional runtime step ID, tool call ID, safe OS/runtime metadata, and error class.
- Wire built-in, mod, and external tool error paths to emit safe metadata without tool args, stderr, command output, user content, secrets, or raw exception text.
- Add telemetry gating/privacy tests and execution-path tests for returned and thrown tool errors, including runtime step ID propagation when provided.

## Step ID availability
- No existing concrete `step_id` source was found in the normal tool execution path. The event includes `step_id` only when `RuntimeContextSnapshot.stepId` is populated; otherwise it is omitted.

## Test plan
- [x] `bun test /Users/lettamate/letta-code/.letta/worktrees/tool-call-error-tracing/src/telemetry/flush-auth.test.ts /Users/lettamate/letta-code/.letta/worktrees/tool-call-error-tracing/src/tools/tool-error-telemetry.test.ts`
- [x] `bun run typecheck`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)