### PR TITLE
fix(cli): refresh secrets reminder after secret changes

### DIFF
--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -119,6 +119,7 @@ import {
 import { runPostTurnMemorySync } from "@/reminders/memory-git-sync";
 import {
   enqueueMemoryGitSyncReminder,
+  markSecretsInfoReminderPending,
   type SharedReminderState,
 } from "@/reminders/state";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
@@ -3285,6 +3286,9 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           // Don't treat as command - continue to regular message handling below
         } else {
           // Known command - show in transcript and handle result
+          if (result.success && result.refreshSecretsInfo) {
+            markSecretsInfoReminderPending(sharedReminderStateRef.current);
+          }
           if (registryCmd) {
             registryCmd.finish(result.output, result.success);
           }

--- a/src/cli/commands/registry.test.ts
+++ b/src/cli/commands/registry.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { setCurrentAgentId } from "@/agent/context";
+import { executeCommand } from "@/cli/commands/registry";
+import {
+  __testOverrideSecretsBackend,
+  clearSecretsCache,
+} from "@/utils/secrets-store";
+
+const AGENT_ID = "agent-registry-secret-command";
+
+const retrieveAgentMock = mock((_agentId: string, _options?: unknown) =>
+  Promise.resolve({
+    secrets: [] as Array<{ key: string; value: string }>,
+  }),
+);
+
+const updateAgentMock = mock(
+  (_agentId: string, _body: unknown, _options?: unknown) =>
+    Promise.resolve({ id: AGENT_ID }),
+);
+
+const capabilities = {
+  remoteMemfs: true,
+  serverSideToolManagement: true,
+  serverSecrets: true,
+  agentFileImportExport: true,
+  promptRecompile: true,
+  byokProviderRefresh: true,
+  localModelCatalog: false,
+  localMemfs: false,
+};
+
+describe("command registry", () => {
+  beforeEach(() => {
+    retrieveAgentMock.mockReset();
+    updateAgentMock.mockReset();
+    retrieveAgentMock.mockResolvedValue({ secrets: [] });
+    updateAgentMock.mockResolvedValue({ id: AGENT_ID });
+    setCurrentAgentId(AGENT_ID);
+    clearSecretsCache(AGENT_ID);
+    __testOverrideSecretsBackend({
+      capabilities,
+      retrieveAgent: retrieveAgentMock,
+      updateAgent: updateAgentMock,
+    });
+  });
+
+  afterEach(() => {
+    __testOverrideSecretsBackend(null);
+    clearSecretsCache(AGENT_ID);
+    setCurrentAgentId(null);
+  });
+
+  test("propagates secrets reminder refresh metadata for secret mutations", async () => {
+    const setResult = await executeCommand(
+      "/secret set registry_token registry-value",
+    );
+
+    expect(setResult).toEqual({
+      success: true,
+      output: "Secret '$REGISTRY_TOKEN' set.",
+      refreshSecretsInfo: true,
+    });
+
+    retrieveAgentMock.mockResolvedValueOnce({
+      secrets: [{ key: "REGISTRY_TOKEN", value: "registry-value" }],
+    });
+
+    const unsetResult = await executeCommand("/secret unset registry_token");
+
+    expect(unsetResult).toEqual({
+      success: true,
+      output: "Secret '$REGISTRY_TOKEN' unset.",
+      refreshSecretsInfo: true,
+    });
+  });
+
+  test("does not request a secrets reminder refresh for non-mutating commands", async () => {
+    const result = await executeCommand("/secret help");
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("Secret management commands");
+    expect(result.refreshSecretsInfo).toBeUndefined();
+  });
+});

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -4,7 +4,16 @@
 import { handleMemoryRepositoryCommand } from "./memory-repository";
 import { handleSecretCommand } from "./secret";
 
-type CommandHandler = (args: string[]) => Promise<string> | string;
+type CommandHandlerResult =
+  | string
+  | {
+      output: string;
+      refreshSecretsInfo?: boolean;
+    };
+
+type CommandHandler = (
+  args: string[],
+) => Promise<CommandHandlerResult> | CommandHandlerResult;
 
 interface Command {
   desc: string;
@@ -347,10 +356,7 @@ export const commands: Record<string, Command> = {
     desc: "Manage secrets for shell commands",
     order: 33,
     args: "<set|list|unset> [key] [value]",
-    handler: async (args: string[]) => {
-      const result = await handleSecretCommand(args);
-      return result.output;
-    },
+    handler: (args: string[]) => handleSecretCommand(args),
   },
   "/memory-repository": {
     desc: "Push this agent's memory repo to an additional git remote",
@@ -635,12 +641,29 @@ export const commands: Record<string, Command> = {
   },
 };
 
+export interface CommandExecutionResult {
+  success: boolean;
+  output: string;
+  notFound?: boolean;
+  refreshSecretsInfo?: boolean;
+}
+
+function normalizeCommandHandlerResult(result: CommandHandlerResult): {
+  output: string;
+  refreshSecretsInfo?: boolean;
+} {
+  if (typeof result === "string") {
+    return { output: result };
+  }
+  return result;
+}
+
 /**
  * Execute a command and return the result
  */
 export async function executeCommand(
   input: string,
-): Promise<{ success: boolean; output: string; notFound?: boolean }> {
+): Promise<CommandExecutionResult> {
   const [command, ...args] = input.trim().split(/\s+/);
 
   if (!command) {
@@ -667,8 +690,8 @@ export async function executeCommand(
   }
 
   try {
-    const output = await handler.handler(args);
-    return { success: true, output };
+    const result = normalizeCommandHandlerResult(await handler.handler(args));
+    return { success: true, ...result };
   } catch (error) {
     return {
       success: false,

--- a/src/cli/commands/secret.test.ts
+++ b/src/cli/commands/secret.test.ts
@@ -78,6 +78,7 @@ describe("/secret command", () => {
     const result = await handleSecretCommand(["set", "new_token", "new-value"]);
 
     expect(result.output).toBe("Secret '$NEW_TOKEN' set.");
+    expect(result.refreshSecretsInfo).toBe(true);
     expect(updateAgentMock).toHaveBeenCalledWith(AGENT_ID, {
       secrets: {
         CLOUDFLARE_API_TOKEN: "cf-token",
@@ -94,6 +95,17 @@ describe("/secret command", () => {
     const result = await handleSecretCommand(["unset", "CLOUDFLARE_API_TOKEN"]);
 
     expect(result.output).toBe("Secret '$CLOUDFLARE_API_TOKEN' unset.");
+    expect(result.refreshSecretsInfo).toBe(true);
     expect(updateAgentMock).toHaveBeenCalledWith(AGENT_ID, { secrets: {} });
+  });
+
+  test("unchanged or invalid commands do not request a secrets reminder refresh", async () => {
+    const invalidSet = await handleSecretCommand(["set", "1bad", "value"]);
+    const missingValue = await handleSecretCommand(["set", "TOKEN"]);
+    const missingUnset = await handleSecretCommand(["unset", "MISSING_TOKEN"]);
+
+    expect(invalidSet.refreshSecretsInfo).toBeUndefined();
+    expect(missingValue.refreshSecretsInfo).toBeUndefined();
+    expect(missingUnset.refreshSecretsInfo).toBeUndefined();
   });
 });

--- a/src/cli/commands/secret.ts
+++ b/src/cli/commands/secret.ts
@@ -12,6 +12,7 @@ import {
 
 export interface SecretCommandResult {
   output: string;
+  refreshSecretsInfo?: boolean;
 }
 
 /**
@@ -49,7 +50,10 @@ export async function handleSecretCommand(
 
       try {
         await setSecretOnServer(normalizedKey, value);
-        return { output: `Secret '$${normalizedKey}' set.` };
+        return {
+          output: `Secret '$${normalizedKey}' set.`,
+          refreshSecretsInfo: true,
+        };
       } catch (error) {
         return {
           output: `Failed to set secret: ${error instanceof Error ? error.message : String(error)}`,
@@ -95,7 +99,10 @@ export async function handleSecretCommand(
         const deleted = await deleteSecretOnServer(normalizedKey);
 
         if (deleted) {
-          return { output: `Secret '$${normalizedKey}' unset.` };
+          return {
+            output: `Secret '$${normalizedKey}' unset.`,
+            refreshSecretsInfo: true,
+          };
         }
 
         return {
@@ -118,7 +125,7 @@ export async function handleSecretCommand(
   /secret list            List available secret names
   /secret unset KEY       Unset a secret
 
-Secrets are stored on the Letta server. Available secret names are shown to the agent via a system reminder at session start.
+Secrets are stored on the Letta server. Available secret names are shown to the agent via system reminders at session start and after secret changes.
 The key must be all caps and can include underscores and numbers, but must start with a letter or underscore.
 Your agent can use $SECRET_NAME in shell commands and the value will be substituted at runtime, without the secret value being leaked into agent context.`,
       };


### PR DESCRIPTION
## Problem
- `/secret set` in the CLI updates server secrets but the active conversation did not re-arm the secrets-info reminder, so agents only learned the new `$SECRET_NAME` after a new session.

## Approach
- Return `refreshSecretsInfo` metadata from the `/secret` command for successful set/unset mutations.
- Preserve that metadata through the command registry and mark the active shared reminder state pending in the TUI submit path.

## Validation
- [x] `bun test src/cli/commands/secret.test.ts src/cli/commands/registry.test.ts`
- [x] `bun run check`

## Risk
- Low. The refresh flag is only set after successful secret mutations; list/help/invalid/no-op commands do not re-arm the reminder.

👾 Generated with [Letta Code](https://letta.com)