### PR TITLE
feat: send Letta Code client metadata headers

### DIFF
--- a/src/agent/client-experiments.test.ts
+++ b/src/agent/client-experiments.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { getClientDefaultHeaders } from "@/backend/api/client";
 import { experimentManager } from "@/experiments/manager";
 import { settingsManager } from "@/settings-manager";
+import { getVersion } from "@/version";
 
 const originalHome = process.env.HOME;
 const originalUserProfile = process.env.USERPROFILE;
@@ -59,6 +60,19 @@ afterEach(async () => {
 });
 
 describe("getClient experiment headers", () => {
+  test("includes shared Letta Code client metadata", async () => {
+    const headers = getClientDefaultHeaders();
+
+    expect(headers).toMatchObject({
+      "User-Agent": `letta-code/${getVersion()}`,
+      "X-Letta-Source": "letta-code",
+      "X-Letta-Client-Name": "letta-code",
+      "X-Letta-Client-Version": getVersion(),
+      "X-Letta-Client-Platform": process.platform,
+    });
+    expect(headers["X-Letta-Environment-Device-Id"]).toBeTruthy();
+  });
+
   test("uses LETTA_NODE when no explicit experiment override exists", async () => {
     process.env.LETTA_NODE = "1";
 

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -6,6 +6,7 @@
 import Letta from "@letta-ai/letta-client";
 import { APIError } from "@letta-ai/letta-client/core/error";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
+import { getLettaCodeRequestHeaders } from "@/utils/letta-code-headers";
 
 export const LETTA_CLOUD_API_URL = "https://api.letta.com";
 
@@ -399,7 +400,7 @@ export async function validateCredentialsWithResult(
     const client = new Letta({
       apiKey,
       baseURL: baseUrl,
-      defaultHeaders: { "X-Letta-Source": "letta-code" },
+      defaultHeaders: getLettaCodeRequestHeaders(),
     });
 
     // Try to list agents - this requires valid authentication

--- a/src/backend/api/client.ts
+++ b/src/backend/api/client.ts
@@ -5,8 +5,8 @@ import { experimentManager } from "@/experiments/manager";
 import { type Settings, settingsManager } from "@/settings-manager";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
 import { isDebugEnabled } from "@/utils/debug";
+import { getLettaCodeRequestHeaders } from "@/utils/letta-code-headers";
 import { createTimingFetch, isTimingsEnabled } from "@/utils/timing";
-import packageJson from "../../../package.json";
 
 const SDK_DIAGNOSTIC_MAX_LEN = 400;
 const SDK_DIAGNOSTIC_MAX_LINES = 4;
@@ -129,8 +129,7 @@ export function getClientDefaultHeaders(): Record<string, string> {
   const nodeExperiment = experimentManager.getSnapshot("node");
 
   return {
-    "X-Letta-Source": "letta-code",
-    "User-Agent": `letta-code/${packageJson.version}`,
+    ...getLettaCodeRequestHeaders(),
     // Identify this device on user-message turns so the cloud can
     // persist the (agent, conversation) → device association and
     // restore it on other browsers/sessions. The cloud middleware

--- a/src/backend/api/http-headers.test.ts
+++ b/src/backend/api/http-headers.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { getLettaCodeHeaders } from "@/backend/api/http-headers";
+import { getVersion } from "@/version";
+
+describe("getLettaCodeHeaders", () => {
+  test("adds auth and shared Letta Code client metadata headers", () => {
+    const headers = getLettaCodeHeaders("test-key");
+
+    expect(headers).toMatchObject({
+      Authorization: "Bearer test-key",
+      "Content-Type": "application/json",
+      "User-Agent": `letta-code/${getVersion()}`,
+      "X-Letta-Source": "letta-code",
+      "X-Letta-Client-Name": "letta-code",
+      "X-Letta-Client-Version": getVersion(),
+      "X-Letta-Client-Platform": process.platform,
+    });
+  });
+});

--- a/src/backend/api/http-headers.ts
+++ b/src/backend/api/http-headers.ts
@@ -1,4 +1,4 @@
-import packageJson from "../../../package.json";
+import { getLettaCodeRequestHeaders } from "@/utils/letta-code-headers";
 
 /**
  * Get standard headers for manual HTTP calls to Letta API.
@@ -7,8 +7,7 @@ import packageJson from "../../../package.json";
 export function getLettaCodeHeaders(apiKey?: string): Record<string, string> {
   return {
     "Content-Type": "application/json",
-    "User-Agent": `letta-code/${packageJson.version}`,
-    "X-Letta-Source": "letta-code",
+    ...getLettaCodeRequestHeaders(),
     ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
   };
 }

--- a/src/utils/letta-code-headers.test.ts
+++ b/src/utils/letta-code-headers.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  getLettaCodeClientMetadataHeaders,
+  getLettaCodeEnvironment,
+  getLettaCodeRequestHeaders,
+} from "@/utils/letta-code-headers";
+import { getVersion } from "@/version";
+
+const originalDesktopManaged = process.env.LETTA_CODE_DESKTOP_MANAGED;
+
+afterEach(() => {
+  if (originalDesktopManaged === undefined) {
+    delete process.env.LETTA_CODE_DESKTOP_MANAGED;
+  } else {
+    process.env.LETTA_CODE_DESKTOP_MANAGED = originalDesktopManaged;
+  }
+});
+
+describe("Letta Code request headers", () => {
+  test("includes allowlisted client runtime metadata", () => {
+    const headers = getLettaCodeClientMetadataHeaders();
+
+    expect(headers).toMatchObject({
+      "X-Letta-Client-Name": "letta-code",
+      "X-Letta-Client-Version": getVersion(),
+      "X-Letta-Client-Platform": process.platform,
+      "X-Letta-Client-Runtime-Version":
+        process.versions.bun ?? process.versions.node,
+    });
+    const runtime = headers["X-Letta-Client-Runtime"] ?? "";
+    expect(["bun", "node"]).toContain(runtime);
+    expect(headers["X-Letta-Client-OS-Type"]).toBeTruthy();
+    expect(headers["X-Letta-Client-OS-Release"]).toBeTruthy();
+    expect(headers["X-Letta-Client-Arch"]).toBeTruthy();
+  });
+
+  test("keeps request headers limited to source, user agent, and allowlisted metadata", () => {
+    const headers = getLettaCodeRequestHeaders();
+
+    expect(headers["X-Letta-Source"]).toBe("letta-code");
+    expect(headers["User-Agent"]).toBe(`letta-code/${getVersion()}`);
+    expect(Object.keys(headers).sort()).toEqual([
+      "User-Agent",
+      "X-Letta-Client-Arch",
+      "X-Letta-Client-Environment",
+      "X-Letta-Client-Name",
+      "X-Letta-Client-OS-Release",
+      "X-Letta-Client-OS-Type",
+      "X-Letta-Client-Platform",
+      "X-Letta-Client-Runtime",
+      "X-Letta-Client-Runtime-Version",
+      "X-Letta-Client-Version",
+      "X-Letta-Source",
+    ]);
+  });
+
+  test("marks desktop-managed runtimes without reading arbitrary env values", () => {
+    delete process.env.LETTA_CODE_DESKTOP_MANAGED;
+    expect(getLettaCodeEnvironment()).toBe("cli");
+
+    process.env.LETTA_CODE_DESKTOP_MANAGED = "1";
+    expect(getLettaCodeEnvironment()).toBe("desktop");
+  });
+});

--- a/src/utils/letta-code-headers.ts
+++ b/src/utils/letta-code-headers.ts
@@ -1,0 +1,75 @@
+import { arch, release, type } from "node:os";
+import { getVersion } from "@/version";
+
+const CLIENT_METADATA_HEADER_MAX_LENGTH = 160;
+const DESKTOP_MANAGED_ENV = "LETTA_CODE_DESKTOP_MANAGED";
+
+function replaceHeaderUnsafeCharacters(value: string): string {
+  let sanitized = "";
+
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    sanitized += codePoint < 32 || codePoint === 127 ? " " : character;
+  }
+
+  return sanitized;
+}
+
+function sanitizeHeaderValue(value: string): string {
+  const normalized = replaceHeaderUnsafeCharacters(value)
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return normalized.slice(0, CLIENT_METADATA_HEADER_MAX_LENGTH);
+}
+
+function setHeader(
+  headers: Record<string, string>,
+  name: string,
+  value: string,
+): void {
+  const sanitized = sanitizeHeaderValue(value);
+  if (sanitized.length > 0) {
+    headers[name] = sanitized;
+  }
+}
+
+function getRuntimeName(): string {
+  return process.versions.bun ? "bun" : "node";
+}
+
+function getRuntimeVersion(): string {
+  return process.versions.bun ?? process.versions.node;
+}
+
+export function getLettaCodeEnvironment(): string {
+  return process.env[DESKTOP_MANAGED_ENV] === "1" ? "desktop" : "cli";
+}
+
+export function getLettaCodeUserAgent(): string {
+  return `letta-code/${getVersion()}`;
+}
+
+export function getLettaCodeClientMetadataHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {};
+
+  setHeader(headers, "X-Letta-Client-Name", "letta-code");
+  setHeader(headers, "X-Letta-Client-Version", getVersion());
+  setHeader(headers, "X-Letta-Client-Platform", process.platform);
+  setHeader(headers, "X-Letta-Client-OS-Type", type());
+  setHeader(headers, "X-Letta-Client-OS-Release", release());
+  setHeader(headers, "X-Letta-Client-Arch", arch());
+  setHeader(headers, "X-Letta-Client-Runtime", getRuntimeName());
+  setHeader(headers, "X-Letta-Client-Runtime-Version", getRuntimeVersion());
+  setHeader(headers, "X-Letta-Client-Environment", getLettaCodeEnvironment());
+
+  return headers;
+}
+
+export function getLettaCodeRequestHeaders(): Record<string, string> {
+  return {
+    "User-Agent": getLettaCodeUserAgent(),
+    "X-Letta-Source": "letta-code",
+    ...getLettaCodeClientMetadataHeaders(),
+  };
+}

--- a/src/websocket/listen-register.test.ts
+++ b/src/websocket/listen-register.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { getVersion } from "@/version";
 import {
   registerWithCloud,
   registerWithCloudRetry,
@@ -49,9 +50,11 @@ describe("registerWithCloud", () => {
     expect((init.headers as Record<string, string>).Authorization).toBe(
       "Bearer sk-test-key",
     );
-    expect((init.headers as Record<string, string>)["X-Letta-Source"]).toBe(
-      "letta-code",
-    );
+    const headers = init.headers as Record<string, string>;
+    expect(headers["X-Letta-Source"]).toBe("letta-code");
+    expect(headers["User-Agent"]).toBe(`letta-code/${getVersion()}`);
+    expect(headers["X-Letta-Client-Name"]).toBe("letta-code");
+    expect(headers["X-Letta-Client-Version"]).toBe(getVersion());
     const body = JSON.parse(init.body as string);
     expect(body).toMatchObject({
       deviceId: "device-123",

--- a/src/websocket/listen-register.ts
+++ b/src/websocket/listen-register.ts
@@ -4,6 +4,7 @@
  */
 
 import { getSelfUpdateStatus } from "@/updater/auto-update";
+import { getLettaCodeRequestHeaders } from "@/utils/letta-code-headers";
 import { getVersion } from "@/version.ts";
 import { SUPPORTED_REMOTE_COMMANDS } from "./listener/listener-constants";
 
@@ -85,8 +86,8 @@ export async function registerWithCloud(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      ...getLettaCodeRequestHeaders(),
       Authorization: `Bearer ${opts.apiKey}`,
-      "X-Letta-Source": "letta-code",
     },
     body: JSON.stringify({
       deviceId: opts.deviceId,


### PR DESCRIPTION
## Summary
- Centralize Letta Code request identity headers in a shared helper.
- Add allowlisted client metadata headers for client version, OS platform/type/release/arch, runtime/version, and coarse environment.
- Use the shared headers for SDK default headers, manual API fetches, credential validation, and environment registration.

## Privacy boundary
The helper does not read or send cwd, home paths, hostnames, usernames, raw environment values, auth material, or secrets. The environment header is only `cli` or `desktop`, derived from the existing desktop-managed runtime flag.

## Validation
- `bun test src/utils/letta-code-headers.test.ts src/backend/api/http-headers.test.ts src/agent/client-experiments.test.ts src/websocket/listen-register.test.ts`
- `bun run typecheck`
- `bun run check`
