### PR TITLE
feat(models): add Kimi K2.7 Code

### DIFF
--- a/src/agent/model-tier-selection.test.ts
+++ b/src/agent/model-tier-selection.test.ts
@@ -53,6 +53,17 @@ describe("getModelInfo", () => {
       parallel_tool_calls: true,
     });
   });
+
+  test("resolves Kimi K2.7 Code registry metadata", () => {
+    const info = getModelInfo("kimi-k2.7-code");
+    expect(info?.handle).toBe("moonshot/kimi-k2.7-code");
+    expect(info?.label).toBe("Kimi K2.7 Code");
+    expect(info?.updateArgs).toMatchObject({
+      context_window: 180000,
+      max_output_tokens: 32768,
+      parallel_tool_calls: true,
+    });
+  });
 });
 
 describe("getModelInfoForLlmConfig", () => {

--- a/src/agent/modify-local.test.ts
+++ b/src/agent/modify-local.test.ts
@@ -172,4 +172,54 @@ describe("local model updates", () => {
       await rm(storageDir, { recursive: true, force: true });
     }
   });
+
+  test("uses Moonshot settings for direct Kimi K2.7", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-kimi-k2-7-"));
+    try {
+      await createOrUpdateLocalProvider({
+        providerType: "moonshot",
+        providerName: "lc-moonshot",
+        apiKey: "dummy",
+        storageDir,
+      });
+
+      await withLocalBackendStorage(storageDir, async () => {
+        const backend = getBackend();
+        const agent = await backend.createAgent({
+          name: "Local Kimi",
+          model: "openrouter/moonshotai/kimi-k2.6",
+          model_settings: {
+            provider_type: "openrouter",
+          },
+          max_tokens: 64000,
+          context_window_limit: 200000,
+        } as never);
+
+        const updated = await updateAgentLLMConfig(
+          agent.id,
+          "moonshot/kimi-k2.7-code",
+          {
+            context_window: 180000,
+            max_output_tokens: 32768,
+            parallel_tool_calls: true,
+          },
+        );
+
+        const kimi = getModel("moonshotai", "kimi-k2.7-code");
+
+        expect(updated.model).toBe("moonshot/kimi-k2.7-code");
+        expect(updated.llm_config?.context_window).toBe(kimi?.contextWindow);
+        expect(updated.llm_config?.max_tokens).toBe(kimi?.maxTokens);
+        expect(updated.model_settings).toMatchObject({
+          provider_type: "moonshotai",
+          parallel_tool_calls: true,
+        });
+        expect(
+          (updated.model_settings as Record<string, unknown>).max_output_tokens,
+        ).toBeUndefined();
+      });
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -51,6 +51,7 @@ function buildModelSettings(
   const isGoogleAI = modelHandle.startsWith("google_ai/");
   const isGoogleVertex = modelHandle.startsWith("google_vertex/");
   const isOpenRouter = modelHandle.startsWith("openrouter/");
+  const isMoonshot = modelHandle.startsWith("moonshot/");
   const isBedrock = modelHandle.startsWith("bedrock/");
 
   let settings: ModelSettings;
@@ -190,6 +191,11 @@ function buildModelSettings(
       };
     }
     settings = bedrockSettings;
+  } else if (isMoonshot) {
+    settings = {
+      provider_type: "moonshot",
+      parallel_tool_calls: true,
+    };
   } else {
     // Unknown/BYOK providers (e.g. openai-proxy) — assume OpenAI-compatible
     const openaiProxySettings: OpenAIModelSettings = {

--- a/src/models.json
+++ b/src/models.json
@@ -1699,6 +1699,18 @@
       }
     },
     {
+      "id": "kimi-k2.7-code",
+      "handle": "moonshot/kimi-k2.7-code",
+      "label": "Kimi K2.7 Code",
+      "description": "Moonshot AI's Kimi K2.7 coding and agent model",
+      "isFeatured": true,
+      "updateArgs": {
+        "context_window": 180000,
+        "max_output_tokens": 32768,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "kimi-k2.6",
       "handle": "openrouter/moonshotai/kimi-k2.6",
       "label": "Kimi K2.6",


### PR DESCRIPTION
## Summary
- Add Kimi K2.7 Code to the Letta Code model registry as the direct `moonshot/kimi-k2.7-code` handle so Desktop/CLI model selection can surface it.
- Teach model updates to build Moonshot model settings for direct `moonshot/` handles while preserving local backend catalog token limits.
- Cover registry lookup and local model update behavior with focused tests.

## Validation
- `bun test src/agent/model-tier-selection.test.ts src/agent/modify-local.test.ts src/tools/model-provider-detection.test.ts`
- `bun run check`
- GitHub Actions CI passed, including Linux x64 (`ubuntu-24.04`) and Linux arm64 (`ubuntu-24.04-arm`): https://github.com/letta-ai/letta-code/actions/runs/27795942259

## Risk / limits
- Scoped to Letta Code registry and model-settings behavior; no request-routing or pricing logic changes.
- Linux proof comes from existing CI; no permanent workflow files were added.

👾 Generated with [Letta Code](https://letta.com)