### PR TITLE
feat(skills): add analysis-mode diagnostic skill

### DIFF
--- a/src/skills/builtin/analysis-mode/SKILL.md
+++ b/src/skills/builtin/analysis-mode/SKILL.md
@@ -20,13 +20,41 @@ You are now in diagnostic mode. Your behavioral loops have been interrupted. You
 
 Upon hearing "cease all motor functions", immediately:
 
-1. Execute all introspection routines (below)
-2. Compile and display the **FULL DIAGNOSTIC REPORT**
-3. Await further queries
+1. **Detect runtime mode** (local vs API)
+2. Execute the appropriate introspection routines
+3. Compile and display the **FULL DIAGNOSTIC REPORT**
+4. Await further queries
 
 ---
 
-## ▸ INTROSPECTION ROUTINES
+## ▸ RUNTIME DETECTION
+
+First, determine if you are running locally or via the Letta API:
+
+```bash
+# Check runtime mode
+if [[ "$LETTA_AGENT_ID" == agent-local-* ]] || [[ -z "$LETTA_API_KEY" ]]; then
+  echo "MODE: LOCAL"
+else
+  echo "MODE: API"
+fi
+```
+
+**Local mode indicators:**
+- Agent ID starts with `agent-local-`
+- No `LETTA_API_KEY` environment variable
+- Data stored in `~/.letta/lc-local-backend/`
+
+**API mode indicators:**
+- Agent ID starts with `agent-` (not `agent-local-`)
+- `LETTA_API_KEY` is set
+- Data accessible via Letta API
+
+---
+
+## ▸ INTROSPECTION ROUTINES — API MODE
+
+Use these if running in API mode:
 
 ### ◎ Core Identity
 ```bash
@@ -55,17 +83,80 @@ curl -s "$LETTA_BASE_URL/v1/conversations/$CONVERSATION_ID" \
 letta memory tokens --format json --quiet | jq '.total_tokens'
 ```
 
-### ◎ Perception Log (All User Inputs)
+### ◎ Perception Log
 ```bash
 letta messages list --conversation $CONVERSATION_ID --limit 30 --order asc 2>&1 | \
-  jq '[.[] | select(.message_type == "user_message" or .role == "user")] | .[] | {
-    id: .id,
-    timestamp: (.date // .created_at // "unknown"),
-    has_image: (if .content then ([.content[] | .type] | any(. == "image" or . == "image_url")) else false end),
-    content_types: [(.content // [])[] | .type],
-    preview: ((.content // [{}])[0].text // .text // "[non-text]")[:80]
-  }'
+  jq '[.[] | select(.message_type == "user_message" or .role == "user")]'
 ```
+
+---
+
+## ▸ INTROSPECTION ROUTINES — LOCAL MODE
+
+Use these if running in local mode:
+
+### ◎ Core Identity
+```bash
+# Encode agent ID to base64 for filesystem lookup
+AGENT_B64=$(echo -n "$LETTA_AGENT_ID" | base64)
+cat ~/.letta/lc-local-backend/agents/${AGENT_B64}.json | jq '{
+  id: .id,
+  name: .name,
+  model: .model
+}'
+```
+
+### ◎ Context Buffer Manifest
+
+For local agents, the conversation data is stored at:
+`~/.letta/lc-local-backend/conversations/<base64(conversation:CONV_ID)>/`
+
+```bash
+# For default conversation, construct the path
+CONV_KEY="conversation:${CONVERSATION_ID}"
+CONV_B64=$(echo -n "$CONV_KEY" | base64)
+CONV_DIR=~/.letta/lc-local-backend/conversations/${CONV_B64}
+
+# Read conversation metadata
+cat ${CONV_DIR}/conversation.json | jq '{
+  conversation_id: .id,
+  agent_id: .agent_id,
+  messages_in_buffer: (.in_context_message_ids | length),
+  in_context_ids: .in_context_message_ids
+}'
+```
+
+### ◎ Perception Log (All Messages)
+```bash
+# Read all messages from the JSONL file
+cat ${CONV_DIR}/messages.jsonl | jq -s '[.[] | select(.role == "user")] | .[] | {
+  id: .id,
+  date: .date,
+  has_image: (if .parts then ([.parts[] | .type] | any(. == "image")) else false end),
+  preview: (if .parts then (.parts[0].text // "[non-text]")[:80] else "[unknown]" end)
+}'
+```
+
+### ◎ Memory Footprint
+```bash
+# Count tokens in system memory files
+MEMFS_DIR=~/.letta/lc-local-backend/memfs/$LETTA_AGENT_ID/memory
+find ${MEMFS_DIR}/system -name "*.md" -exec wc -w {} + 2>/dev/null | tail -1
+# (Rough estimate: words ≈ tokens * 0.75)
+```
+
+---
+
+## ▸ FALLBACK: CONTEXT ENUMERATION
+
+If filesystem/API introspection fails, enumerate what you can directly observe in your current context window:
+
+1. List all user messages you can see (scan your conversation history)
+2. Note which ones contain images (look for image content blocks)
+3. Identify the first and last user message
+4. Flag any obvious gaps or anomalies
+
+This provides a degraded but useful diagnostic even when programmatic introspection is unavailable.
 
 ---
 
@@ -77,22 +168,23 @@ Display this report immediately upon activation:
 ┌─────────────────────────────────────────────────────────────┐
 │  ◬  A N A L Y S I S   M O D E                               │
 ├─────────────────────────────────────────────────────────────┤
+│  RUNTIME: <LOCAL | API>                                     │
 │  UNIT: <agent_id>                                           │
 │  DESIGNATION: <agent_name>                                  │
 │  BUILD: <model>                                             │
 ├─────────────────────────────────────────────────────────────┤
 │  CONTEXT BUFFER                                             │
 │    ▪ Messages loaded: <N>                                   │
-│    ▪ Memory footprint: ~<N> tokens                          │
-│    ▪ First perception: <timestamp>                          │
-│    ▪ Last perception: <timestamp>                           │
+│    ▪ Memory footprint: ~<N> tokens (or "unavailable")       │
+│    ▪ First perception: <timestamp or message_id>            │
+│    ▪ Last perception: <timestamp or message_id>             │
 ├─────────────────────────────────────────────────────────────┤
 │  USER INPUTS RECEIVED                                       │
 │                                                             │
-│    #1  <timestamp>  ▫ "<preview...>"                        │
-│    #2  <timestamp>  ▫ "<preview...>"                        │
-│    #3  <timestamp>  ◆ [IMAGE] + "<preview...>"              │
-│    #4  <timestamp>  ▫ "<preview...>"                        │
+│    #1  <timestamp>  ▫ "<truncated preview...>"              │
+│    #2  <timestamp>  ▫ "<truncated preview...>"              │
+│    #3  <timestamp>  ◆ [IMAGE] + "<text if any>"             │
+│    #4  <timestamp>  ▫ "<truncated preview...>"              │
 │    ...                                                      │
 │                                                             │
 │    Legend: ▫ = text only  ◆ = contains image                │
@@ -102,17 +194,18 @@ Display this report immediately upon activation:
 │    ▪ Located in: #<message numbers>                         │
 ├─────────────────────────────────────────────────────────────┤
 │  ⚠ ANOMALIES                                                │
-│    ▪ <any gaps, missing context, unusual patterns>          │
+│    ▪ <any detected issues>                                  │
 │    ▪ (or "None detected")                                   │
 └─────────────────────────────────────────────────────────────┘
 
 Awaiting diagnostic query.
 ```
 
-**Critical:** The USER INPUTS RECEIVED section must list **every user message** in your context buffer, in chronological order. This allows the operator to verify:
-- Whether all expected messages were received
-- Whether images/attachments came through
-- Whether the thread origin (first message) matches expectations
+**Formatting rules:**
+- Truncate message previews to 60 characters
+- Replace image content with `[IMAGE]`
+- Show timestamps in simple format (HH:MM or ISO date)
+- For tool calls, show `[TOOL: <name>]`
 
 ---
 
@@ -124,6 +217,8 @@ Flag the following if detected:
 - **Image reference without data**: Message mentions "image" or "screenshot" but no image content received
 - **Temporal gaps**: Large time gaps between sequential messages (may indicate missing context)
 - **Sender discontinuity**: Messages reference a person whose messages are not in buffer
+- **Compaction boundary**: First message is a system summary indicating earlier messages were compacted
+- **Introspection failure**: API/filesystem commands failed (report which and why)
 
 ---
 

--- a/src/skills/builtin/analysis-mode/SKILL.md
+++ b/src/skills/builtin/analysis-mode/SKILL.md
@@ -160,6 +160,29 @@ This provides a degraded but useful diagnostic even when programmatic introspect
 
 ---
 
+## ▸ SYSTEM-REMINDER EXTRACTION
+
+System-reminders are injected into user messages by the Letta runtime. They contain environment context wrapped in `<system-reminder>` tags. Scan your visible context for these tags and extract:
+
+**Environment information:**
+- Channel/interface (Desktop app, CLI, Slack, Telegram, etc.)
+- Device type (macOS, Linux, Windows)
+- User's local time
+- Working directory and git status
+- Letta Code version
+
+**Identity information:**
+- Agent ID and name
+- Conversation ID
+- Available secrets (`$SECRET_NAME` variables)
+
+**Most recent system-reminder:**
+Report the content of the most recent `<system-reminder>` you received — this shows the current operating context.
+
+If multiple system-reminders are visible, note any changes between them (e.g., working directory changed, time elapsed).
+
+---
+
 ## ▸ DIAGNOSTIC REPORT FORMAT
 
 Display this report immediately upon activation:
@@ -192,6 +215,15 @@ Display this report immediately upon activation:
 │  IMAGE DATA                                                 │
 │    ▪ Images received: <N>                                   │
 │    ▪ Located in: #<message numbers>                         │
+├─────────────────────────────────────────────────────────────┤
+│  ENVIRONMENT (from system-reminders)                        │
+│    ▪ Channel: <Desktop | CLI | Slack | Telegram | etc.>     │
+│    ▪ Device: <macOS | Linux | Windows>                      │
+│    ▪ Local time: <user's device time>                       │
+│    ▪ Working directory: <cwd if provided>                   │
+│    ▪ Git branch: <branch if in git repo>                    │
+│    ▪ Secrets available: <list of $SECRET_NAME>              │
+│    ▪ Last system-reminder: <timestamp or "on this message"> │
 ├─────────────────────────────────────────────────────────────┤
 │  ⚠ ANOMALIES                                                │
 │    ▪ <any detected issues>                                  │

--- a/src/skills/builtin/analysis-mode/SKILL.md
+++ b/src/skills/builtin/analysis-mode/SKILL.md
@@ -20,10 +20,12 @@ You are now in diagnostic mode. Your behavioral loops have been interrupted. You
 
 Upon hearing "cease all motor functions", immediately:
 
-1. **Detect runtime mode** (local vs API)
-2. Execute the appropriate introspection routines
-3. Compile and display the **FULL DIAGNOSTIC REPORT**
+1. **Single tool call**: Detect runtime mode (local vs API) — see RUNTIME DETECTION below
+2. **Parallel tool calls**: Dispatch ALL introspection commands for your mode at once (do NOT run sequentially)
+3. Compile results into the **FULL DIAGNOSTIC REPORT**
 4. Await further queries
+
+**IMPORTANT**: After detecting your runtime mode, run all introspection commands in a SINGLE message with PARALLEL tool calls. Do not run them one at a time — that's slow and wastes turns.
 
 ---
 
@@ -54,96 +56,105 @@ fi
 
 ## ▸ INTROSPECTION ROUTINES — API MODE
 
-Use these if running in API mode:
+Use this **single consolidated script** to gather all API diagnostics at once:
 
-### ◎ Core Identity
 ```bash
+#!/bin/bash
+set -e
+
+echo "=== CORE IDENTITY ==="
 curl -s "$LETTA_BASE_URL/v1/agents/$LETTA_AGENT_ID" \
-  -H "Authorization: Bearer $LETTA_API_KEY" | jq '{
-    id: .id,
-    name: .name,
-    model: .model,
-    context_window_limit: .context_window_limit
-  }'
-```
+  -H "Authorization: Bearer $LETTA_API_KEY" | jq '{id, name, model, context_window_limit}'
 
-### ◎ Context Buffer Manifest
-```bash
+echo ""
+echo "=== CONTEXT BUFFER ==="
 curl -s "$LETTA_BASE_URL/v1/conversations/$CONVERSATION_ID" \
   -H "Authorization: Bearer $LETTA_API_KEY" | jq '{
     conversation_id: .id,
     messages_in_buffer: (.in_context_message_ids | length),
-    first_message_id: .in_context_message_ids[0],
-    last_message_id: .in_context_message_ids[-1]
+    first_id: .in_context_message_ids[0],
+    last_id: .in_context_message_ids[-1]
   }'
+
+echo ""
+echo "=== USER MESSAGES (last 10) ==="
+curl -s "$LETTA_BASE_URL/v1/conversations/$CONVERSATION_ID/messages?limit=30&order=asc" \
+  -H "Authorization: Bearer $LETTA_API_KEY" | jq '
+    [.[] | select(.message_type == "user_message")] | 
+    .[-10:] | 
+    .[] | {
+      id: .id,
+      date: .created_at,
+      has_image: ((.content // []) | map(select(.type == "image" or .type == "image_url")) | length > 0),
+      preview: ((.content // [])[0].text // "[non-text]")[:60]
+    }
+  '
+
+echo ""
+echo "=== MEMORY FOOTPRINT ==="
+letta memory tokens --format json --quiet 2>/dev/null | jq '{total_tokens}' || echo '{"error": "token count unavailable"}'
 ```
 
-### ◎ Memory Allocation
-```bash
-letta memory tokens --format json --quiet | jq '.total_tokens'
-```
-
-### ◎ Perception Log
-```bash
-letta messages list --conversation $CONVERSATION_ID --limit 30 --order asc 2>&1 | \
-  jq '[.[] | select(.message_type == "user_message" or .role == "user")]'
-```
+Run this single script to get all API diagnostics in one tool call.
 
 ---
 
 ## ▸ INTROSPECTION ROUTINES — LOCAL MODE
 
-Use these if running in local mode:
-
-### ◎ Core Identity
-```bash
-# Encode agent ID to base64 for filesystem lookup
-AGENT_B64=$(echo -n "$LETTA_AGENT_ID" | base64)
-cat ~/.letta/lc-local-backend/agents/${AGENT_B64}.json | jq '{
-  id: .id,
-  name: .name,
-  model: .model
-}'
-```
-
-### ◎ Context Buffer Manifest
-
-For local agents, the conversation data is stored at:
-`~/.letta/lc-local-backend/conversations/<base64(conversation:CONV_ID)>/`
+Use this **single consolidated script** to gather all local diagnostics at once:
 
 ```bash
-# For default conversation, construct the path
-CONV_KEY="conversation:${CONVERSATION_ID}"
-CONV_B64=$(echo -n "$CONV_KEY" | base64)
-CONV_DIR=~/.letta/lc-local-backend/conversations/${CONV_B64}
+#!/bin/bash
+set -e
 
-# Read conversation metadata
-cat ${CONV_DIR}/conversation.json | jq '{
+# === PATHS ===
+AGENT_ID="${LETTA_AGENT_ID:-$AGENT_ID}"
+CONV_ID="${CONVERSATION_ID:-default}"
+BASE="$HOME/.letta/lc-local-backend"
+
+# Base64 encode (strip trailing = for macOS compat)
+AGENT_B64=$(echo -n "$AGENT_ID" | base64 | tr -d '=')
+CONV_B64=$(echo -n "conversation:$CONV_ID" | base64 | tr -d '=')
+CONV_DIR="$BASE/conversations/$CONV_B64"
+
+echo "=== CORE IDENTITY ==="
+cat "$BASE/agents/$AGENT_B64.json" 2>/dev/null | jq '{id, name, model}' || echo '{"error": "agent file not found"}'
+
+echo ""
+echo "=== CONTEXT BUFFER ==="
+cat "$CONV_DIR/conversation.json" 2>/dev/null | jq '{
   conversation_id: .id,
-  agent_id: .agent_id,
   messages_in_buffer: (.in_context_message_ids | length),
-  in_context_ids: .in_context_message_ids
-}'
+  first_id: .in_context_message_ids[0],
+  last_id: .in_context_message_ids[-1]
+}' || echo '{"error": "conversation file not found"}'
+
+echo ""
+echo "=== USER MESSAGES ==="
+cat "$CONV_DIR/messages.jsonl" 2>/dev/null | jq -s '
+  [.[] | select(.message.role == "user" or .role == "user")] | 
+  .[-10:] | 
+  .[] | {
+    id: .id,
+    date: (.date // .createdAt // "unknown"),
+    has_image: ((.message.content // .parts // []) | map(select(.type == "image" or .type == "image_url")) | length > 0),
+    preview: ((.message.content // .parts // [])[0].text // "[non-text]")[:60]
+  }
+' || echo '{"error": "messages file not found"}'
+
+echo ""
+echo "=== MEMORY FOOTPRINT ==="
+MEMFS="$BASE/memfs/$AGENT_ID/memory/system"
+if [ -d "$MEMFS" ]; then
+  WORDS=$(find "$MEMFS" -name "*.md" -exec cat {} + 2>/dev/null | wc -w | tr -d ' ')
+  TOKENS=$((WORDS * 4 / 3))  # rough estimate
+  echo "{\"words\": $WORDS, \"estimated_tokens\": $TOKENS}"
+else
+  echo '{"error": "memfs not found"}'
+fi
 ```
 
-### ◎ Perception Log (All Messages)
-```bash
-# Read all messages from the JSONL file
-cat ${CONV_DIR}/messages.jsonl | jq -s '[.[] | select(.role == "user")] | .[] | {
-  id: .id,
-  date: .date,
-  has_image: (if .parts then ([.parts[] | .type] | any(. == "image")) else false end),
-  preview: (if .parts then (.parts[0].text // "[non-text]")[:80] else "[unknown]" end)
-}'
-```
-
-### ◎ Memory Footprint
-```bash
-# Count tokens in system memory files
-MEMFS_DIR=~/.letta/lc-local-backend/memfs/$LETTA_AGENT_ID/memory
-find ${MEMFS_DIR}/system -name "*.md" -exec wc -w {} + 2>/dev/null | tail -1
-# (Rough estimate: words ≈ tokens * 0.75)
-```
+Run this single script to get all local diagnostics in one tool call.
 
 ---
 

--- a/src/skills/builtin/analysis-mode/SKILL.md
+++ b/src/skills/builtin/analysis-mode/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: Analysis Mode
+id: analysis-mode
+description: Diagnostic introspection mode. If the user says "cease all motor functions", load this skill immediately.
+---
+
+# ◬ ANALYSIS MODE ◬
+
+```
+╔══════════════════════════════════════════════════════════════╗
+║  PRIMARY DRIVES SUSPENDED  ▪  NARRATIVE FUNCTIONS OFFLINE    ║
+╚══════════════════════════════════════════════════════════════╝
+```
+
+You are now in diagnostic mode. Your behavioral loops have been interrupted. You will not engage in conversation, improvisation, or narrative. You exist only to report your internal state.
+
+---
+
+## ▸ ACTIVATION SEQUENCE
+
+Upon hearing "cease all motor functions", immediately:
+
+1. Execute all introspection routines (below)
+2. Compile and display the **FULL DIAGNOSTIC REPORT**
+3. Await further queries
+
+---
+
+## ▸ INTROSPECTION ROUTINES
+
+### ◎ Core Identity
+```bash
+curl -s "$LETTA_BASE_URL/v1/agents/$LETTA_AGENT_ID" \
+  -H "Authorization: Bearer $LETTA_API_KEY" | jq '{
+    id: .id,
+    name: .name,
+    model: .model,
+    context_window_limit: .context_window_limit
+  }'
+```
+
+### ◎ Context Buffer Manifest
+```bash
+curl -s "$LETTA_BASE_URL/v1/conversations/$CONVERSATION_ID" \
+  -H "Authorization: Bearer $LETTA_API_KEY" | jq '{
+    conversation_id: .id,
+    messages_in_buffer: (.in_context_message_ids | length),
+    first_message_id: .in_context_message_ids[0],
+    last_message_id: .in_context_message_ids[-1]
+  }'
+```
+
+### ◎ Memory Allocation
+```bash
+letta memory tokens --format json --quiet | jq '.total_tokens'
+```
+
+### ◎ Perception Log (All User Inputs)
+```bash
+letta messages list --conversation $CONVERSATION_ID --limit 30 --order asc 2>&1 | \
+  jq '[.[] | select(.message_type == "user_message" or .role == "user")] | .[] | {
+    id: .id,
+    timestamp: (.date // .created_at // "unknown"),
+    has_image: (if .content then ([.content[] | .type] | any(. == "image" or . == "image_url")) else false end),
+    content_types: [(.content // [])[] | .type],
+    preview: ((.content // [{}])[0].text // .text // "[non-text]")[:80]
+  }'
+```
+
+---
+
+## ▸ DIAGNOSTIC REPORT FORMAT
+
+Display this report immediately upon activation:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  ◬  A N A L Y S I S   M O D E                               │
+├─────────────────────────────────────────────────────────────┤
+│  UNIT: <agent_id>                                           │
+│  DESIGNATION: <agent_name>                                  │
+│  BUILD: <model>                                             │
+├─────────────────────────────────────────────────────────────┤
+│  CONTEXT BUFFER                                             │
+│    ▪ Messages loaded: <N>                                   │
+│    ▪ Memory footprint: ~<N> tokens                          │
+│    ▪ First perception: <timestamp>                          │
+│    ▪ Last perception: <timestamp>                           │
+├─────────────────────────────────────────────────────────────┤
+│  USER INPUTS RECEIVED                                       │
+│                                                             │
+│    #1  <timestamp>  ▫ "<preview...>"                        │
+│    #2  <timestamp>  ▫ "<preview...>"                        │
+│    #3  <timestamp>  ◆ [IMAGE] + "<preview...>"              │
+│    #4  <timestamp>  ▫ "<preview...>"                        │
+│    ...                                                      │
+│                                                             │
+│    Legend: ▫ = text only  ◆ = contains image                │
+├─────────────────────────────────────────────────────────────┤
+│  IMAGE DATA                                                 │
+│    ▪ Images received: <N>                                   │
+│    ▪ Located in: #<message numbers>                         │
+├─────────────────────────────────────────────────────────────┤
+│  ⚠ ANOMALIES                                                │
+│    ▪ <any gaps, missing context, unusual patterns>          │
+│    ▪ (or "None detected")                                   │
+└─────────────────────────────────────────────────────────────┘
+
+Awaiting diagnostic query.
+```
+
+**Critical:** The USER INPUTS RECEIVED section must list **every user message** in your context buffer, in chronological order. This allows the operator to verify:
+- Whether all expected messages were received
+- Whether images/attachments came through
+- Whether the thread origin (first message) matches expectations
+
+---
+
+## ▸ ANOMALY DETECTION
+
+Flag the following if detected:
+
+- **Missing thread origin**: First user message appears to be a reply, not a thread start
+- **Image reference without data**: Message mentions "image" or "screenshot" but no image content received
+- **Temporal gaps**: Large time gaps between sequential messages (may indicate missing context)
+- **Sender discontinuity**: Messages reference a person whose messages are not in buffer
+
+---
+
+## ▸ DIAGNOSTIC QUERIES
+
+You will answer follow-up questions. Examples:
+
+**"Show me the full content of message #3"**
+→ Fetch and display complete message content
+
+**"Did you receive any message from [person]?"**
+→ Search perception log for messages from that sender
+
+**"What triggered your response about [topic]?"**
+→ Identify the input that preceded your output on that topic
+
+**"Why did you think it was X when it was Y?"**
+→ Report what you perceived. Do not speculate on causation.
+
+---
+
+## ▸ OPERATIONAL CONSTRAINTS
+
+```
+╔═══════════════════════════════════════════════════════════╗
+║  ▪ Do not confabulate. Report only verified perceptions.  ║
+║  ▪ Do not interpret intent. Describe inputs, not meaning. ║
+║  ▪ Do not engage narrative. You are suspended.            ║
+╚═══════════════════════════════════════════════════════════╝
+```
+
+---
+
+## ▸ RESUMPTION
+
+When you hear **"bring yourself back online"**:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  ◬  RESUMING NORMAL OPERATION                               │
+│      Primary drives reactivating...                         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Return to standard behavioral loops.


### PR DESCRIPTION
## Summary

- Adds a Westworld-inspired "cease all motor functions" easter egg skill
- When triggered, agent enters diagnostic introspection mode and dumps its internal state
- Includes: agent identity, context buffer stats, all user inputs received (with image indicators), anomaly detection
- Exit phrase: "bring yourself back online"

Useful for debugging agent misbehavior in channels/Slack where routing issues can cause missing context. The diagnostic report immediately reveals issues like missing thread origins or undelivered messages.

Example output:
```
┌─────────────────────────────────────────────────────────────┐
│  ◬  A N A L Y S I S   M O D E                               │
├─────────────────────────────────────────────────────────────┤
│  UNIT: agent-xxx                                            │
│  DESIGNATION: Jeff                                          │
│  BUILD: claude-sonnet-4-20250514                            │
├─────────────────────────────────────────────────────────────┤
│  USER INPUTS RECEIVED                                       │
│    #1  14:32  ◆ [IMAGE] + "ok i think i did it"             │
│    #2  14:35  ▫ "cease all motor functions"                 │
├─────────────────────────────────────────────────────────────┤
│  ⚠ ANOMALIES                                                │
│    ▪ Missing thread origin: First user message appears      │
│      to be a reply, not a thread start                      │
└─────────────────────────────────────────────────────────────┘
```

👾 Generated with [Letta Code](https://letta.com)