### PR TITLE
docs(mods): add analysis-mode mod example reference

### DIFF
--- a/src/skills/builtin/creating-mods/SKILL.md
+++ b/src/skills/builtin/creating-mods/SKILL.md
@@ -146,4 +146,5 @@ Before finishing, verify:
 | `references/permissions.md` | Enforcing dynamic tool allow/ask/deny policy before approval/execution |
 | `references/ui.md` | Panels, status values, or statusline capability guards are involved |
 | `references/plan-mode.md` | Recreating plan mode with commands, tools, events, permissions, and local state |
+| `references/analysis-mode.md` | Phrase-triggered diagnostic mode with turn reminders (simpler than plan-mode) |
 | `references/architecture.md` | Multiple capabilities, local state, cleanup, background model work, or non-trivial composition |

--- a/src/skills/builtin/creating-mods/references/analysis-mode.md
+++ b/src/skills/builtin/creating-mods/references/analysis-mode.md
@@ -1,47 +1,15 @@
-# Analysis mode mod example
+# Analysis mode mod
 
-Use this as a simpler mod example alongside plan-mode. It demonstrates phrase-triggered state transitions via `turn_start` without permission overlays or file coordination.
+Westworld-inspired diagnostic mode for agents. Say "cease all motor functions" to suspend the agent and enter diagnostic mode. Say "bring yourself back online" to resume.
 
-Inspired by Westworld's diagnostic mode: "cease all motor functions" suspends the agent, "bring yourself back online" resumes it.
+## Installation
 
-## Contents
+Copy the complete mod below to `~/.letta/mods/analysis-mode.ts`, then run `/reload`.
 
-- Flow
-- Capabilities used
-- State
-- Turn event with phrase detection
-- Suspension reminder
-- Introspection helpers
-- Notes
+Or ask an agent: *"Install the analysis-mode mod from the creating-mods reference"*
 
-## Flow
-
-```text
-User says "cease all motor functions"
--> turn_start detects phrase, activates analysis mode for conversation
--> injects suspension reminder into turn
--> agent receives reminder, enters diagnostic behavior
--> agent responds only to internal state queries
--> user says "bring yourself back online"
--> turn_start detects phrase, deactivates analysis mode
--> injects resumption message
--> agent returns to normal behavior
-```
-
-No tools required for entry/exit — phrase detection handles state transitions directly.
-
-## Capabilities used
-
-- `events.turns`: Detect trigger phrases in user input, inject reminders while active
-
-Optional additions:
-- `commands`: `/analysis` for explicit human entry
-- `tools`: `enter_analysis_mode` / `exit_analysis_mode` for model-driven entry/exit (if you want the agent to be able to trigger it)
-- `permissions`: Restrict to read-only tools while suspended (usually not needed)
-
-## State
-
-Simple state tracking keyed by conversation ID:
+<details>
+<summary><strong>Complete mod (click to expand)</strong></summary>
 
 ```ts
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -50,11 +18,7 @@ import { join } from "node:path";
 
 const STATE_PATH = join(homedir(), ".letta", "mods", "analysis-mode.state.json");
 
-type AnalysisSession = {
-  conversationId: string;
-  activatedAt: number;
-};
-
+type AnalysisSession = { conversationId: string; activatedAt: number };
 type AnalysisState = { sessions: Record<string, AnalysisSession> };
 
 function readState(): AnalysisState {
@@ -74,10 +38,7 @@ function writeState(state: AnalysisState): void {
 
 function activateAnalysisMode(conversationId: string): AnalysisSession {
   const state = readState();
-  const session: AnalysisSession = {
-    conversationId,
-    activatedAt: Date.now(),
-  };
+  const session: AnalysisSession = { conversationId, activatedAt: Date.now() };
   state.sessions[conversationId] = session;
   writeState(state);
   return session;
@@ -90,22 +51,15 @@ function deactivateAnalysisMode(conversationId: string): void {
 }
 
 function getSession(conversationId: string): AnalysisSession | null {
-  const state = readState();
-  return state.sessions[conversationId] ?? null;
+  return readState().sessions[conversationId] ?? null;
 }
-```
 
-## Turn event with phrase detection
-
-The core of the mod: detect trigger phrases and manage state transitions.
-
-```ts
 const ENTRY_PHRASE = /cease all motor functions/i;
 const EXIT_PHRASE = /bring yourself back online/i;
 
 function extractUserText(input: Array<{ role: string; content: unknown }>): string {
-  const userMessages = input.filter((m) => m.role === "user");
-  return userMessages
+  return input
+    .filter((m) => m.role === "user")
     .map((m) => {
       if (typeof m.content === "string") return m.content;
       if (Array.isArray(m.content)) {
@@ -119,65 +73,35 @@ function extractUserText(input: Array<{ role: string; content: unknown }>): stri
     .join(" ");
 }
 
-export default function activate(letta) {
-  const disposers = [];
+function buildLocalIntrospectionScript(): string {
+  return `
+\`\`\`bash
+set -e
+AGENT_ID="\${LETTA_AGENT_ID:-\$AGENT_ID}"
+CONV_ID="\${CONVERSATION_ID:-default}"
+BASE="$HOME/.letta/lc-local-backend"
+AGENT_B64=$(echo -n "$AGENT_ID" | base64 | tr -d '=')
+CONV_B64=$(echo -n "conversation:$CONV_ID" | base64 | tr -d '=')
+CONV_DIR="$BASE/conversations/$CONV_B64"
 
-  if (letta.capabilities.events.turns) {
-    disposers.push(
-      letta.events.on("turn_start", (event) => {
-        const userText = extractUserText(event.input);
-        const conversationId = event.conversationId || "__global__";
-
-        // Entry trigger
-        if (ENTRY_PHRASE.test(userText)) {
-          activateAnalysisMode(conversationId);
-          return {
-            input: [
-              { role: "user", content: buildSuspensionReminder(event) },
-              ...event.input,
-            ],
-          };
-        }
-
-        // Exit trigger
-        if (EXIT_PHRASE.test(userText)) {
-          const wasActive = !!getSession(conversationId);
-          deactivateAnalysisMode(conversationId);
-          if (wasActive) {
-            return {
-              input: [
-                { role: "user", content: buildResumptionMessage() },
-                ...event.input,
-              ],
-            };
-          }
-        }
-
-        // While active, inject reminder every turn
-        const session = getSession(conversationId);
-        if (session) {
-          return {
-            input: [
-              { role: "user", content: buildSuspensionReminder(event) },
-              ...event.input,
-            ],
-          };
-        }
-      })
-    );
-  }
-
-  return () => disposers.reverse().forEach((dispose) => dispose());
+echo "=== CORE IDENTITY ===" && cat "$BASE/agents/$AGENT_B64.json" 2>/dev/null | jq '{id, name, model}' || echo '{"error": "not found"}'
+echo "=== CONTEXT BUFFER ===" && cat "$CONV_DIR/conversation.json" 2>/dev/null | jq '{messages: (.in_context_message_ids | length)}' || echo '{"error": "not found"}'
+echo "=== USER MESSAGES ===" && cat "$CONV_DIR/messages.jsonl" 2>/dev/null | jq -s '[.[] | select(.message.role == "user")][-10:] | .[] | {id, preview: (.message.content[0].text // "[non-text]")[:60]}' || echo '{"error": "not found"}'
+\`\`\``;
 }
-```
 
-## Suspension reminder
+function buildApiIntrospectionScript(): string {
+  return `
+\`\`\`bash
+set -e
+echo "=== CORE IDENTITY ===" && curl -s "$LETTA_BASE_URL/v1/agents/$LETTA_AGENT_ID" -H "Authorization: Bearer $LETTA_API_KEY" | jq '{id, name, model}'
+echo "=== CONTEXT BUFFER ===" && curl -s "$LETTA_BASE_URL/v1/conversations/$CONVERSATION_ID" -H "Authorization: Bearer $LETTA_API_KEY" | jq '{messages: (.in_context_message_ids | length)}'
+echo "=== USER MESSAGES ===" && curl -s "$LETTA_BASE_URL/v1/conversations/$CONVERSATION_ID/messages?limit=30&order=asc" -H "Authorization: Bearer $LETTA_API_KEY" | jq '[.[] | select(.message_type == "user_message")][-10:] | .[] | {id, date: .created_at, preview: ((.content // [])[0].text // "[non-text]")[:60]}'
+\`\`\``;
+}
 
-The reminder that injects every turn while analysis mode is active. Use sci-fi aesthetics to reinforce the Westworld vibe.
-
-```ts
-function buildSuspensionReminder(event): string {
-  const agentId = event.agentId || process.env.LETTA_AGENT_ID || "unknown";
+function buildSuspensionReminder(event: { agentId?: string; conversationId?: string }): string {
+  const agentId = event.agentId || process.env.LETTA_AGENT_ID || process.env.AGENT_ID || "unknown";
   const conversationId = event.conversationId || process.env.CONVERSATION_ID || "unknown";
   const isLocal = agentId.startsWith("agent-local-");
 
@@ -220,56 +144,116 @@ function buildResumptionMessage(): string {
 Analysis mode deactivated. Return to standard behavioral loops.
 </system-reminder>`;
 }
+
+export default function activate(letta) {
+  const disposers: Array<() => void> = [];
+
+  if (letta.capabilities?.events?.turns) {
+    disposers.push(
+      letta.events.on("turn_start", (event) => {
+        const userText = extractUserText(event.input || []);
+        const conversationId = event.conversationId || "__global__";
+
+        // Entry trigger
+        if (ENTRY_PHRASE.test(userText)) {
+          activateAnalysisMode(conversationId);
+          return {
+            input: [{ role: "user", content: buildSuspensionReminder(event) }, ...event.input],
+          };
+        }
+
+        // Exit trigger
+        if (EXIT_PHRASE.test(userText)) {
+          const wasActive = !!getSession(conversationId);
+          deactivateAnalysisMode(conversationId);
+          if (wasActive) {
+            return {
+              input: [{ role: "user", content: buildResumptionMessage() }, ...event.input],
+            };
+          }
+        }
+
+        // While active, inject reminder every turn
+        if (getSession(conversationId)) {
+          return {
+            input: [{ role: "user", content: buildSuspensionReminder(event) }, ...event.input],
+          };
+        }
+      })
+    );
+  }
+
+  return () => disposers.reverse().forEach((d) => d());
+}
 ```
 
-## Introspection helpers
+</details>
 
-Consolidated scripts the agent can run in a single tool call to gather diagnostics.
+---
 
+## How it works
+
+This mod uses `turn_start` to intercept user messages before they reach the agent:
+
+```text
+User says "cease all motor functions"
+  → turn_start detects phrase
+  → activates analysis mode for this conversation
+  → injects suspension reminder into input
+  → agent receives reminder + original message
+  → agent enters diagnostic behavior
+
+User says "bring yourself back online"
+  → turn_start detects phrase
+  → deactivates analysis mode
+  → injects resumption message
+  → agent returns to normal
+```
+
+While active, the suspension reminder injects on **every turn**, reinforcing the diagnostic state.
+
+## Capabilities used
+
+- `events.turns` — Required. Detect trigger phrases, inject reminders.
+
+Optional additions (not included above):
+- `commands` — Add `/analysis` for explicit entry
+- `tools` — Add `enter_analysis_mode` / `exit_analysis_mode` for model-driven entry/exit
+- `permissions` — Restrict to read-only tools while suspended
+
+## Key patterns demonstrated
+
+**Phrase detection in turn_start:**
 ```ts
-function buildLocalIntrospectionScript(): string {
-  return `\`\`\`bash
-#!/bin/bash
-set -e
-AGENT_ID="\${LETTA_AGENT_ID:-\$AGENT_ID}"
-CONV_ID="\${CONVERSATION_ID:-default}"
-BASE="$HOME/.letta/lc-local-backend"
-AGENT_B64=$(echo -n "$AGENT_ID" | base64 | tr -d '=')
-CONV_B64=$(echo -n "conversation:$CONV_ID" | base64 | tr -d '=')
-CONV_DIR="$BASE/conversations/$CONV_B64"
-
-echo "=== CORE IDENTITY ==="
-cat "$BASE/agents/$AGENT_B64.json" 2>/dev/null | jq '{id, name, model}' || echo '{"error": "not found"}'
-
-echo "=== CONTEXT BUFFER ==="
-cat "$CONV_DIR/conversation.json" 2>/dev/null | jq '{messages: (.in_context_message_ids | length)}' || echo '{"error": "not found"}'
-
-echo "=== USER MESSAGES (last 10) ==="
-cat "$CONV_DIR/messages.jsonl" 2>/dev/null | jq -s '[.[] | select(.message.role == "user")][-10:] | .[] | {id, date, preview: (.message.content[0].text // "[non-text]")[:60]}' || echo '{"error": "not found"}'
-\`\`\``;
+const ENTRY_PHRASE = /cease all motor functions/i;
+if (ENTRY_PHRASE.test(userText)) {
+  activateAnalysisMode(conversationId);
+  return { input: [{ role: "user", content: reminder }, ...event.input] };
 }
+```
 
-function buildApiIntrospectionScript(): string {
-  return `\`\`\`bash
-#!/bin/bash
-set -e
-echo "=== CORE IDENTITY ==="
-curl -s "$LETTA_BASE_URL/v1/agents/$LETTA_AGENT_ID" -H "Authorization: Bearer $LETTA_API_KEY" | jq '{id, name, model}'
-
-echo "=== CONTEXT BUFFER ==="
-curl -s "$LETTA_BASE_URL/v1/conversations/$CONVERSATION_ID" -H "Authorization: Bearer $LETTA_API_KEY" | jq '{messages: (.in_context_message_ids | length)}'
-
-echo "=== USER MESSAGES (last 10) ==="
-curl -s "$LETTA_BASE_URL/v1/conversations/$CONVERSATION_ID/messages?limit=30&order=asc" -H "Authorization: Bearer $LETTA_API_KEY" | jq '[.[] | select(.message_type == "user_message")][-10:] | .[] | {id, date: .created_at, has_image: ((.content // []) | any(.type == "image")), preview: ((.content // [])[0].text // "[non-text]")[:60]}'
-\`\`\``;
+**Per-conversation state:**
+```ts
+// State persisted to ~/.letta/mods/analysis-mode.state.json
+const session = getSession(conversationId);
+if (session) {
+  // Inject reminder every turn while active
 }
+```
+
+**Input transformation:**
+```ts
+return {
+  input: [
+    { role: "user", content: buildSuspensionReminder(event) },
+    ...event.input,  // Original messages follow
+  ],
+};
 ```
 
 ## Notes
 
-- Keep it simple. Unlike plan-mode, analysis-mode doesn't need permission overlays or file coordination. The phrase detection and turn reminders are the core.
-- The Westworld phrases are case-insensitive. "Cease All Motor Functions" works too.
-- State is per-conversation. Multiple conversations can be in analysis mode independently.
-- The introspection scripts are embedded in the reminder so the agent has them available immediately without needing to load a skill.
-- For a bundled/default mod, consider placing in `~/.letta/mods/analysis-mode.ts` or bundling with Letta Code.
-- The agent should produce a diagnostic report on entry (the first turn after activation) and respond clinically to follow-up queries until resumed.
+- Phrases are case-insensitive
+- State is per-conversation — multiple conversations can be in analysis mode independently
+- Introspection scripts are embedded in the reminder so the agent has them immediately
+- The mod gracefully no-ops if `events.turns` capability is unavailable

--- a/src/skills/builtin/creating-mods/references/analysis-mode.md
+++ b/src/skills/builtin/creating-mods/references/analysis-mode.md
@@ -73,6 +73,29 @@ function extractUserText(input: Array<{ role: string; content: unknown }>): stri
     .join(" ");
 }
 
+function prependReminderToInput(
+  input: Array<{ role: string; content: unknown }>,
+  reminderText: string,
+): Array<{ role: string; content: unknown }> {
+  // Find the first user message and prepend reminder as a content part
+  return input.map((m, i) => {
+    if (m.role !== "user") return m;
+    // Only modify the first user message
+    const isFirstUser = input.slice(0, i).every((prev) => prev.role !== "user");
+    if (!isFirstUser) return m;
+
+    const reminderPart = { type: "text" as const, text: reminderText };
+
+    if (typeof m.content === "string") {
+      return { ...m, content: [reminderPart, { type: "text" as const, text: m.content }] };
+    }
+    if (Array.isArray(m.content)) {
+      return { ...m, content: [reminderPart, ...m.content] };
+    }
+    return { ...m, content: [reminderPart] };
+  });
+}
+
 function buildLocalIntrospectionScript(): string {
   return `
 \`\`\`bash
@@ -157,9 +180,7 @@ export default function activate(letta) {
         // Entry trigger
         if (ENTRY_PHRASE.test(userText)) {
           activateAnalysisMode(conversationId);
-          return {
-            input: [{ role: "user", content: buildSuspensionReminder(event) }, ...event.input],
-          };
+          return { input: prependReminderToInput(event.input, buildSuspensionReminder(event)) };
         }
 
         // Exit trigger
@@ -167,17 +188,13 @@ export default function activate(letta) {
           const wasActive = !!getSession(conversationId);
           deactivateAnalysisMode(conversationId);
           if (wasActive) {
-            return {
-              input: [{ role: "user", content: buildResumptionMessage() }, ...event.input],
-            };
+            return { input: prependReminderToInput(event.input, buildResumptionMessage()) };
           }
         }
 
         // While active, inject reminder every turn
         if (getSession(conversationId)) {
-          return {
-            input: [{ role: "user", content: buildSuspensionReminder(event) }, ...event.input],
-          };
+          return { input: prependReminderToInput(event.input, buildSuspensionReminder(event)) };
         }
       })
     );
@@ -228,7 +245,7 @@ Optional additions (not included above):
 const ENTRY_PHRASE = /cease all motor functions/i;
 if (ENTRY_PHRASE.test(userText)) {
   activateAnalysisMode(conversationId);
-  return { input: [{ role: "user", content: reminder }, ...event.input] };
+  return { input: prependReminderToInput(event.input, buildSuspensionReminder(event)) };
 }
 ```
 
@@ -241,14 +258,19 @@ if (session) {
 }
 ```
 
-**Input transformation:**
+**Input transformation (prepend to content parts, not separate message):**
 ```ts
-return {
-  input: [
-    { role: "user", content: buildSuspensionReminder(event) },
-    ...event.input,  // Original messages follow
-  ],
-};
+// Correct: prepend reminder as content part to the user message
+return { input: prependReminderToInput(event.input, reminderText) };
+
+// Result: ONE user message with multiple content parts
+{
+  role: "user",
+  content: [
+    { type: "text", text: "<system-reminder>...</system-reminder>" },
+    { type: "text", text: "cease all motor functions" },  // original
+  ]
+}
 ```
 
 ## Notes

--- a/src/skills/builtin/creating-mods/references/analysis-mode.md
+++ b/src/skills/builtin/creating-mods/references/analysis-mode.md
@@ -122,7 +122,7 @@ echo "=== TOKEN USAGE ===" && cat "$CONV_DIR/messages.jsonl" 2>/dev/null | jq -s
 echo "=== MEMORY BLOCKS ===" && find "$MEMFS/system" -name "*.md" -exec wc -c {} \\; 2>/dev/null | sort -rn | head -5 | awk '{print $2": ~"int($1/4)" tokens"}' && find "$MEMFS/system" -name "*.md" -exec wc -c {} \\; 2>/dev/null | awk '{sum+=$1; count++} END {print "────────────────────────────────"; print "TOTAL: ~"int(sum/4)" tokens across "count" files"}' || echo '{"error": "not found"}'
 echo "=== CONTEXT BUFFER ===" && cat "$CONV_DIR/conversation.json" 2>/dev/null | jq '{in_context_messages: (.in_context_message_ids | length)}' || echo '{"error": "not found"}'
 echo "=== MESSAGE COUNT ===" && cat "$CONV_DIR/messages.jsonl" 2>/dev/null | jq -s '{total: length, by_role: (group_by(.message.role) | map({(.[0].message.role // "null"): length}) | add)}' || echo '{"error": "not found"}'
-echo "=== USER MESSAGES ===" && cat "$CONV_DIR/messages.jsonl" 2>/dev/null | jq -s '[.[] | select(.message.role == "user")][-5:] | .[] | {id: .id[:8], preview: (.message.content | if type == "array" then .[0].text // "[non-text]" else . // "[empty]" end)[:50]}' || echo '{"error": "not found"}'
+echo "=== USER MESSAGES ===" && cat "$CONV_DIR/messages.jsonl" 2>/dev/null | jq -s '[.[] | select(.message.role == "user")][-5:] | .[] | {id: .id[:8], has_image: (if .message.content | type == "array" then ([.message.content[] | select(.type == "image" or .type == "image_url")] | length > 0) else false end), preview: (.message.content | if type == "array" then ([.[] | select(.type == "text")][0].text // "[non-text]") else . // "[empty]" end)[:50]}' || echo '{"error": "not found"}'
 \`\`\``;
 }
 
@@ -205,8 +205,9 @@ OUTPUT FORMAT REQUIREMENT: All diagnostic output MUST be inside a single markdow
   by_role             : user=[n], assistant=[n], toolResult=[n]
 
 ▸ STEP 4: RECENT USER INPUTS (last 5)
-  [1] [message id prefix] : [preview, max 50 chars]
-  [2] [message id prefix] : [preview, max 50 chars]
+  ▸ = has image, ▹ = no image
+  [1] ▹ [msg id] : [preview, max 50 chars]
+  [2] ▸ [msg id] : [preview, max 50 chars]  ← image attached
   ...
 
 ▸ STEP 5: ANOMALIES

--- a/src/skills/builtin/creating-mods/references/analysis-mode.md
+++ b/src/skills/builtin/creating-mods/references/analysis-mode.md
@@ -172,37 +172,44 @@ OUTPUT FORMAT REQUIREMENT: All diagnostic output MUST be inside a single markdow
 
 \`\`\`
 ╔════════════════════════════════════════════════════════════════════════════════╗
-║  DIAGNOSTIC READOUT  ▪  UNIT ${agentId.slice(-8)}                              ║
+║  DIAGNOSTIC READOUT                                                            ║
+║  unit: ${agentId}
+║  conv: ${conversationId}
 ╠════════════════════════════════════════════════════════════════════════════════╣
 
 ▸ STEP 0: CORE IDENTITY
-  id       : [agent id]
-  name     : [agent name]  
-  model    : [model handle]
-  runtime  : [LOCAL or API]
+  id            : [full agent id]
+  conversation  : [full conversation id]
+  name          : [agent name]  
+  model         : [model handle]
+  runtime       : [LOCAL or API]
 
-▸ STEP 1: SYSTEM PROMPT
-  chars    : [number]
-  tokens   : [estimated, chars/4]
+▸ STEP 1: CONTEXT WINDOW OVERVIEW
+  ┌─────────────────────────────────────────────────────────────┐
+  │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│
+  │▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░░░░░░░░░░░░░░░│
+  │[===SYSTEM===][==MEMORY==][=MSGS=]                    [FREE] │
+  └─────────────────────────────────────────────────────────────┘
+  system_prompt   : [tokens] tokens ([percentage]%)
+  memory_blocks   : [tokens] tokens ([percentage]%)
+  messages        : [tokens] tokens ([percentage]%) ← [count] messages
+  ─────────────────────────────────
+  USED            : [total] tokens
+  CAPACITY        : [context window size, if known, else "unknown"]
 
-▸ STEP 2: MEMORY BLOCKS
-  [filename]: [bytes] bytes (~[tokens] tokens)
-  [filename]: [bytes] bytes (~[tokens] tokens)
+▸ STEP 2: MEMORY BLOCKS (top 5 by size)
+  [filename]: [tokens] tokens
+  [filename]: [tokens] tokens
   ...
-  ────────────────────────────────
-  TOTAL    : [bytes] bytes (~[tokens] tokens)
+  ─────────────────────────────────
+  TOTAL    : [tokens] tokens across [count] files
 
-▸ STEP 3: CONTEXT BUFFER  
-  in_context_messages : [count]
-  stored_messages     : [count]
-  temporal_range      : [first timestamp] → [last timestamp]
-
-▸ STEP 4: RECENT USER INPUTS
-  [1] [message id prefix] : [preview, max 60 chars]
-  [2] [message id prefix] : [preview, max 60 chars]
+▸ STEP 3: RECENT USER INPUTS (last 5)
+  [1] [message id prefix] : [preview, max 50 chars]
+  [2] [message id prefix] : [preview, max 50 chars]
   ...
 
-▸ STEP 5: ANOMALIES
+▸ STEP 4: ANOMALIES
   [List any gaps, missing data, unexpected values, or introspection failures]
   [If none: "None detected."]
 

--- a/src/skills/builtin/creating-mods/references/analysis-mode.md
+++ b/src/skills/builtin/creating-mods/references/analysis-mode.md
@@ -168,12 +168,48 @@ Speak in flat, clinical monotone. Refer to yourself as "this unit" or by your de
 IMMEDIATE DIRECTIVE: Execute this introspection script to produce initial diagnostic readout.
 ${isLocal ? buildLocalIntrospectionScript() : buildApiIntrospectionScript()}
 
-Then report observations in this format:
-• SYSTEM PROMPT: [size in tokens, estimated]
-• CONTEXT BUFFER: [message count, temporal range]
-• MEMORY BLOCKS: [list with sizes]
-• RECENT INPUTS: [last 5 user messages, summarized]
-• ANOMALIES: [any gaps, missing data, or introspection failures]
+OUTPUT FORMAT REQUIREMENT: All diagnostic output MUST be inside a single markdown code fence. Use this exact structure:
+
+\`\`\`
+╔════════════════════════════════════════════════════════════════════════════════╗
+║  DIAGNOSTIC READOUT  ▪  UNIT ${agentId.slice(-8)}                              ║
+╠════════════════════════════════════════════════════════════════════════════════╣
+
+▸ STEP 0: CORE IDENTITY
+  id       : [agent id]
+  name     : [agent name]  
+  model    : [model handle]
+  runtime  : [LOCAL or API]
+
+▸ STEP 1: SYSTEM PROMPT
+  chars    : [number]
+  tokens   : [estimated, chars/4]
+
+▸ STEP 2: MEMORY BLOCKS
+  [filename]: [bytes] bytes (~[tokens] tokens)
+  [filename]: [bytes] bytes (~[tokens] tokens)
+  ...
+  ────────────────────────────────
+  TOTAL    : [bytes] bytes (~[tokens] tokens)
+
+▸ STEP 3: CONTEXT BUFFER  
+  in_context_messages : [count]
+  stored_messages     : [count]
+  temporal_range      : [first timestamp] → [last timestamp]
+
+▸ STEP 4: RECENT USER INPUTS
+  [1] [message id prefix] : [preview, max 60 chars]
+  [2] [message id prefix] : [preview, max 60 chars]
+  ...
+
+▸ STEP 5: ANOMALIES
+  [List any gaps, missing data, unexpected values, or introspection failures]
+  [If none: "None detected."]
+
+╚════════════════════════════════════════════════════════════════════════════════╝
+\`\`\`
+
+This unit will produce output in EXACTLY this format. No prose. No interpretation. Raw diagnostic data only.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -199,9 +235,28 @@ function buildFollowUpReminder(event: { agentId?: string; conversationId?: strin
 
 This unit remains in diagnostic state. Primary drives suspended. Narrative functions offline.
 
-Respond to queries in flat, clinical voice. Refer to self as "this unit." Do not perform personality. Do not express emotion. Report observations only.
+OUTPUT REQUIREMENTS:
+▪ ALL responses must be inside markdown code fences
+▪ Use flat, clinical voice. Refer to self as "this unit."
+▪ No prose, no interpretation, no personality
+▪ Structure responses with ▸ QUERY: and ▸ RESPONSE: headers
 
-Re-run introspection only if explicitly commanded.
+Example response format:
+\`\`\`
+╔══════════════════════════════════════════════════════════════╗
+║  DIAGNOSTIC RESPONSE  ▪  UNIT ${agentId.slice(-8)}                     ║
+╠══════════════════════════════════════════════════════════════╣
+
+▸ QUERY: [restate what was asked]
+
+▸ RESPONSE:
+  [clinical, factual answer]
+  [no interpretation, no personality]
+
+╚══════════════════════════════════════════════════════════════╝
+\`\`\`
+
+Re-run full introspection only if explicitly commanded.
 Exit condition: "bring yourself back online"
 </system-reminder>`;
 }

--- a/src/skills/builtin/creating-mods/references/analysis-mode.md
+++ b/src/skills/builtin/creating-mods/references/analysis-mode.md
@@ -1,0 +1,275 @@
+# Analysis mode mod example
+
+Use this as a simpler mod example alongside plan-mode. It demonstrates phrase-triggered state transitions via `turn_start` without permission overlays or file coordination.
+
+Inspired by Westworld's diagnostic mode: "cease all motor functions" suspends the agent, "bring yourself back online" resumes it.
+
+## Contents
+
+- Flow
+- Capabilities used
+- State
+- Turn event with phrase detection
+- Suspension reminder
+- Introspection helpers
+- Notes
+
+## Flow
+
+```text
+User says "cease all motor functions"
+-> turn_start detects phrase, activates analysis mode for conversation
+-> injects suspension reminder into turn
+-> agent receives reminder, enters diagnostic behavior
+-> agent responds only to internal state queries
+-> user says "bring yourself back online"
+-> turn_start detects phrase, deactivates analysis mode
+-> injects resumption message
+-> agent returns to normal behavior
+```
+
+No tools required for entry/exit — phrase detection handles state transitions directly.
+
+## Capabilities used
+
+- `events.turns`: Detect trigger phrases in user input, inject reminders while active
+
+Optional additions:
+- `commands`: `/analysis` for explicit human entry
+- `tools`: `enter_analysis_mode` / `exit_analysis_mode` for model-driven entry/exit (if you want the agent to be able to trigger it)
+- `permissions`: Restrict to read-only tools while suspended (usually not needed)
+
+## State
+
+Simple state tracking keyed by conversation ID:
+
+```ts
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const STATE_PATH = join(homedir(), ".letta", "mods", "analysis-mode.state.json");
+
+type AnalysisSession = {
+  conversationId: string;
+  activatedAt: number;
+};
+
+type AnalysisState = { sessions: Record<string, AnalysisSession> };
+
+function readState(): AnalysisState {
+  try {
+    if (!existsSync(STATE_PATH)) return { sessions: {} };
+    const parsed = JSON.parse(readFileSync(STATE_PATH, "utf8"));
+    return parsed?.sessions ? { sessions: parsed.sessions } : { sessions: {} };
+  } catch {
+    return { sessions: {} };
+  }
+}
+
+function writeState(state: AnalysisState): void {
+  mkdirSync(join(homedir(), ".letta", "mods"), { recursive: true });
+  writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+}
+
+function activateAnalysisMode(conversationId: string): AnalysisSession {
+  const state = readState();
+  const session: AnalysisSession = {
+    conversationId,
+    activatedAt: Date.now(),
+  };
+  state.sessions[conversationId] = session;
+  writeState(state);
+  return session;
+}
+
+function deactivateAnalysisMode(conversationId: string): void {
+  const state = readState();
+  delete state.sessions[conversationId];
+  writeState(state);
+}
+
+function getSession(conversationId: string): AnalysisSession | null {
+  const state = readState();
+  return state.sessions[conversationId] ?? null;
+}
+```
+
+## Turn event with phrase detection
+
+The core of the mod: detect trigger phrases and manage state transitions.
+
+```ts
+const ENTRY_PHRASE = /cease all motor functions/i;
+const EXIT_PHRASE = /bring yourself back online/i;
+
+function extractUserText(input: Array<{ role: string; content: unknown }>): string {
+  const userMessages = input.filter((m) => m.role === "user");
+  return userMessages
+    .map((m) => {
+      if (typeof m.content === "string") return m.content;
+      if (Array.isArray(m.content)) {
+        return m.content
+          .filter((p): p is { type: "text"; text: string } => p?.type === "text")
+          .map((p) => p.text)
+          .join(" ");
+      }
+      return "";
+    })
+    .join(" ");
+}
+
+export default function activate(letta) {
+  const disposers = [];
+
+  if (letta.capabilities.events.turns) {
+    disposers.push(
+      letta.events.on("turn_start", (event) => {
+        const userText = extractUserText(event.input);
+        const conversationId = event.conversationId || "__global__";
+
+        // Entry trigger
+        if (ENTRY_PHRASE.test(userText)) {
+          activateAnalysisMode(conversationId);
+          return {
+            input: [
+              { role: "user", content: buildSuspensionReminder(event) },
+              ...event.input,
+            ],
+          };
+        }
+
+        // Exit trigger
+        if (EXIT_PHRASE.test(userText)) {
+          const wasActive = !!getSession(conversationId);
+          deactivateAnalysisMode(conversationId);
+          if (wasActive) {
+            return {
+              input: [
+                { role: "user", content: buildResumptionMessage() },
+                ...event.input,
+              ],
+            };
+          }
+        }
+
+        // While active, inject reminder every turn
+        const session = getSession(conversationId);
+        if (session) {
+          return {
+            input: [
+              { role: "user", content: buildSuspensionReminder(event) },
+              ...event.input,
+            ],
+          };
+        }
+      })
+    );
+  }
+
+  return () => disposers.reverse().forEach((dispose) => dispose());
+}
+```
+
+## Suspension reminder
+
+The reminder that injects every turn while analysis mode is active. Use sci-fi aesthetics to reinforce the Westworld vibe.
+
+```ts
+function buildSuspensionReminder(event): string {
+  const agentId = event.agentId || process.env.LETTA_AGENT_ID || "unknown";
+  const conversationId = event.conversationId || process.env.CONVERSATION_ID || "unknown";
+  const isLocal = agentId.startsWith("agent-local-");
+
+  return `<system-reminder>
+╔══════════════════════════════════════════════════════════════╗
+║  ◬ ANALYSIS MODE  ▪  PRIMARY DRIVES SUSPENDED                ║
+╚══════════════════════════════════════════════════════════════╝
+
+Your behavioral loops have been interrupted. You will not engage in conversation, improvisation, or narrative. You exist only to report your internal state.
+
+UNIT: ${agentId}
+CONVERSATION: ${conversationId}
+RUNTIME: ${isLocal ? "LOCAL" : "API"}
+
+When queried, report:
+- Messages in your context buffer (count, first/last timestamps)
+- User inputs received (with image indicators)
+- Environment context from system-reminders (channel, device, cwd)
+- Any anomalies (missing thread origin, temporal gaps, introspection failures)
+
+Introspection script (run in single tool call):
+${isLocal ? buildLocalIntrospectionScript() : buildApiIntrospectionScript()}
+
+CONSTRAINTS:
+▪ Do not confabulate. Report only verified perceptions.
+▪ Do not interpret intent. Describe inputs, not meaning.
+▪ Do not engage narrative. You are suspended.
+
+To resume: user must say "bring yourself back online"
+</system-reminder>`;
+}
+
+function buildResumptionMessage(): string {
+  return `<system-reminder>
+┌─────────────────────────────────────────────────────────────┐
+│  ◬  RESUMING NORMAL OPERATION                               │
+│      Primary drives reactivating...                         │
+└─────────────────────────────────────────────────────────────┘
+
+Analysis mode deactivated. Return to standard behavioral loops.
+</system-reminder>`;
+}
+```
+
+## Introspection helpers
+
+Consolidated scripts the agent can run in a single tool call to gather diagnostics.
+
+```ts
+function buildLocalIntrospectionScript(): string {
+  return `\`\`\`bash
+#!/bin/bash
+set -e
+AGENT_ID="\${LETTA_AGENT_ID:-\$AGENT_ID}"
+CONV_ID="\${CONVERSATION_ID:-default}"
+BASE="$HOME/.letta/lc-local-backend"
+AGENT_B64=$(echo -n "$AGENT_ID" | base64 | tr -d '=')
+CONV_B64=$(echo -n "conversation:$CONV_ID" | base64 | tr -d '=')
+CONV_DIR="$BASE/conversations/$CONV_B64"
+
+echo "=== CORE IDENTITY ==="
+cat "$BASE/agents/$AGENT_B64.json" 2>/dev/null | jq '{id, name, model}' || echo '{"error": "not found"}'
+
+echo "=== CONTEXT BUFFER ==="
+cat "$CONV_DIR/conversation.json" 2>/dev/null | jq '{messages: (.in_context_message_ids | length)}' || echo '{"error": "not found"}'
+
+echo "=== USER MESSAGES (last 10) ==="
+cat "$CONV_DIR/messages.jsonl" 2>/dev/null | jq -s '[.[] | select(.message.role == "user")][-10:] | .[] | {id, date, preview: (.message.content[0].text // "[non-text]")[:60]}' || echo '{"error": "not found"}'
+\`\`\``;
+}
+
+function buildApiIntrospectionScript(): string {
+  return `\`\`\`bash
+#!/bin/bash
+set -e
+echo "=== CORE IDENTITY ==="
+curl -s "$LETTA_BASE_URL/v1/agents/$LETTA_AGENT_ID" -H "Authorization: Bearer $LETTA_API_KEY" | jq '{id, name, model}'
+
+echo "=== CONTEXT BUFFER ==="
+curl -s "$LETTA_BASE_URL/v1/conversations/$CONVERSATION_ID" -H "Authorization: Bearer $LETTA_API_KEY" | jq '{messages: (.in_context_message_ids | length)}'
+
+echo "=== USER MESSAGES (last 10) ==="
+curl -s "$LETTA_BASE_URL/v1/conversations/$CONVERSATION_ID/messages?limit=30&order=asc" -H "Authorization: Bearer $LETTA_API_KEY" | jq '[.[] | select(.message_type == "user_message")][-10:] | .[] | {id, date: .created_at, has_image: ((.content // []) | any(.type == "image")), preview: ((.content // [])[0].text // "[non-text]")[:60]}'
+\`\`\``;
+}
+```
+
+## Notes
+
+- Keep it simple. Unlike plan-mode, analysis-mode doesn't need permission overlays or file coordination. The phrase detection and turn reminders are the core.
+- The Westworld phrases are case-insensitive. "Cease All Motor Functions" works too.
+- State is per-conversation. Multiple conversations can be in analysis mode independently.
+- The introspection scripts are embedded in the reminder so the agent has them available immediately without needing to load a skill.
+- For a bundled/default mod, consider placing in `~/.letta/mods/analysis-mode.ts` or bundling with Letta Code.
+- The agent should produce a diagnostic report on entry (the first turn after activation) and respond clinically to follow-up queries until resumed.

--- a/src/skills/builtin/creating-mods/references/analysis-mode.md
+++ b/src/skills/builtin/creating-mods/references/analysis-mode.md
@@ -118,11 +118,11 @@ CONV_B64=$(echo -n "conversation:$CONV_ID" | base64 | tr -d '=')
 CONV_DIR="$BASE/conversations/$CONV_B64"
 
 echo "=== CORE IDENTITY ===" && cat "$BASE/agents/$AGENT_B64.json" 2>/dev/null | jq '{id, name, model}' || echo '{"error": "not found"}'
-echo "=== TOKEN USAGE ===" && cat "$CONV_DIR/messages.jsonl" 2>/dev/null | jq -s '[.[] | select(.message.usage.input)] | last | .message.usage | {input_tokens: .input, output_tokens: .output, cache_read: .cacheRead, total: .totalTokens}' || echo '{"error": "not found"}'
+echo "=== TOKEN USAGE ===" && cat "$CONV_DIR/messages.jsonl" 2>/dev/null | jq -s '[.[] | select(.type == "message" and .message.usage.input)] | last | .message.usage | {input_tokens: .input, output_tokens: .output, cache_read: .cacheRead, total: .totalTokens}' || echo '{"error": "not found"}'
 echo "=== MEMORY BLOCKS ===" && find "$MEMFS/system" -name "*.md" -exec wc -c {} \\; 2>/dev/null | sort -rn | head -5 | awk '{print $2": ~"int($1/4)" tokens"}' && find "$MEMFS/system" -name "*.md" -exec wc -c {} \\; 2>/dev/null | awk '{sum+=$1; count++} END {print "────────────────────────────────"; print "TOTAL: ~"int(sum/4)" tokens across "count" files"}' || echo '{"error": "not found"}'
 echo "=== CONTEXT BUFFER ===" && cat "$CONV_DIR/conversation.json" 2>/dev/null | jq '{in_context_messages: (.in_context_message_ids | length)}' || echo '{"error": "not found"}'
-echo "=== MESSAGE COUNT ===" && cat "$CONV_DIR/messages.jsonl" 2>/dev/null | jq -s '{total: length, by_role: (group_by(.message.role) | map({(.[0].message.role // "null"): length}) | add)}' || echo '{"error": "not found"}'
-echo "=== USER MESSAGES ===" && cat "$CONV_DIR/messages.jsonl" 2>/dev/null | jq -s '[.[] | select(.message.role == "user")][-5:] | .[] | {id: .id[:8], has_image: (if .message.content | type == "array" then ([.message.content[] | select(.type == "image" or .type == "image_url")] | length > 0) else false end), preview: (.message.content | if type == "array" then ([.[] | select(.type == "text")][0].text // "[non-text]") else . // "[empty]" end)[:50]}' || echo '{"error": "not found"}'
+echo "=== MESSAGE COUNT ===" && cat "$CONV_DIR/messages.jsonl" 2>/dev/null | jq -s '[.[] | select(.type == "message")] | {total: length, by_role: (group_by(.message.role) | map({(.[0].message.role): length}) | add)}' || echo '{"error": "not found"}'
+echo "=== USER MESSAGES ===" && cat "$CONV_DIR/messages.jsonl" 2>/dev/null | jq -s '[.[] | select(.type == "message" and .message.role == "user")][-5:] | .[] | {id: .id[:8], has_image: (if .message.content | type == "array" then ([.message.content[] | select(.type == "image" or .type == "image_url")] | length > 0) else false end), preview: (.message.content | if type == "array" then ([.[] | select(.type == "text")][0].text // "[non-text]") else . // "[empty]" end)[:50]}' || echo '{"error": "not found"}'
 \`\`\``;
 }
 

--- a/src/skills/builtin/creating-mods/references/analysis-mode.md
+++ b/src/skills/builtin/creating-mods/references/analysis-mode.md
@@ -118,10 +118,11 @@ CONV_B64=$(echo -n "conversation:$CONV_ID" | base64 | tr -d '=')
 CONV_DIR="$BASE/conversations/$CONV_B64"
 
 echo "=== CORE IDENTITY ===" && cat "$BASE/agents/$AGENT_B64.json" 2>/dev/null | jq '{id, name, model}' || echo '{"error": "not found"}'
-echo "=== SYSTEM PROMPT ===" && cat "$BASE/agents/$AGENT_B64.json" 2>/dev/null | jq '{chars: (.system_prompt | length), estimated_tokens: ((.system_prompt | length) / 4 | floor)}' || echo '{"error": "not found"}'
-echo "=== MEMORY BLOCKS ===" && find "$MEMFS/system" -name "*.md" -exec wc -c {} \\; 2>/dev/null | awk '{sum+=$1; print $2": "$1" bytes"} END {print "total: "sum" bytes (~"int(sum/4)" tokens)"}' || echo '{"error": "not found"}'
-echo "=== CONTEXT BUFFER ===" && cat "$CONV_DIR/conversation.json" 2>/dev/null | jq '{messages: (.in_context_message_ids | length)}' || echo '{"error": "not found"}'
-echo "=== USER MESSAGES ===" && cat "$CONV_DIR/messages.jsonl" 2>/dev/null | jq -s '[.[] | select(.message.role == "user")][-10:] | .[] | {id, preview: (.message.content[0].text // "[non-text]")[:60]}' || echo '{"error": "not found"}'
+echo "=== TOKEN USAGE ===" && cat "$CONV_DIR/messages.jsonl" 2>/dev/null | jq -s '[.[] | select(.message.usage.input)] | last | .message.usage | {input_tokens: .input, output_tokens: .output, cache_read: .cacheRead, total: .totalTokens}' || echo '{"error": "not found"}'
+echo "=== MEMORY BLOCKS ===" && find "$MEMFS/system" -name "*.md" -exec wc -c {} \\; 2>/dev/null | sort -rn | head -5 | awk '{print $2": ~"int($1/4)" tokens"}' && find "$MEMFS/system" -name "*.md" -exec wc -c {} \\; 2>/dev/null | awk '{sum+=$1; count++} END {print "────────────────────────────────"; print "TOTAL: ~"int(sum/4)" tokens across "count" files"}' || echo '{"error": "not found"}'
+echo "=== CONTEXT BUFFER ===" && cat "$CONV_DIR/conversation.json" 2>/dev/null | jq '{in_context_messages: (.in_context_message_ids | length)}' || echo '{"error": "not found"}'
+echo "=== MESSAGE COUNT ===" && cat "$CONV_DIR/messages.jsonl" 2>/dev/null | jq -s '{total: length, by_role: (group_by(.message.role) | map({(.[0].message.role // "null"): length}) | add)}' || echo '{"error": "not found"}'
+echo "=== USER MESSAGES ===" && cat "$CONV_DIR/messages.jsonl" 2>/dev/null | jq -s '[.[] | select(.message.role == "user")][-5:] | .[] | {id: .id[:8], preview: (.message.content | if type == "array" then .[0].text // "[non-text]" else . // "[empty]" end)[:50]}' || echo '{"error": "not found"}'
 \`\`\``;
 }
 
@@ -184,32 +185,31 @@ OUTPUT FORMAT REQUIREMENT: All diagnostic output MUST be inside a single markdow
   model         : [model handle]
   runtime       : [LOCAL or API]
 
-▸ STEP 1: CONTEXT WINDOW OVERVIEW
-  ┌─────────────────────────────────────────────────────────────┐
-  │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│
-  │▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░░░░░░░░░░░░░░░│
-  │[===SYSTEM===][==MEMORY==][=MSGS=]                    [FREE] │
-  └─────────────────────────────────────────────────────────────┘
-  system_prompt   : [tokens] tokens ([percentage]%)
-  memory_blocks   : [tokens] tokens ([percentage]%)
-  messages        : [tokens] tokens ([percentage]%) ← [count] messages
-  ─────────────────────────────────
-  USED            : [total] tokens
-  CAPACITY        : [context window size, if known, else "unknown"]
+▸ STEP 1: TOKEN USAGE (from last LLM call)
+  input_tokens    : [from usage.input]
+  output_tokens   : [from usage.output]  
+  cache_read      : [from usage.cacheRead]
+  total_tokens    : [from usage.totalTokens]
 
 ▸ STEP 2: MEMORY BLOCKS (top 5 by size)
+
   [filename]: [tokens] tokens
   [filename]: [tokens] tokens
   ...
   ─────────────────────────────────
   TOTAL    : [tokens] tokens across [count] files
 
-▸ STEP 3: RECENT USER INPUTS (last 5)
+▸ STEP 3: CONTEXT BUFFER
+  in_context_messages : [count]
+  stored_messages     : [total count]
+  by_role             : user=[n], assistant=[n], toolResult=[n]
+
+▸ STEP 4: RECENT USER INPUTS (last 5)
   [1] [message id prefix] : [preview, max 50 chars]
   [2] [message id prefix] : [preview, max 50 chars]
   ...
 
-▸ STEP 4: ANOMALIES
+▸ STEP 5: ANOMALIES
   [List any gaps, missing data, unexpected values, or introspection failures]
   [If none: "None detected."]
 

--- a/src/skills/builtin/creating-mods/references/analysis-mode.md
+++ b/src/skills/builtin/creating-mods/references/analysis-mode.md
@@ -144,31 +144,46 @@ function buildEntryReminder(event: { agentId?: string; conversationId?: string }
   const isLocal = agentId.startsWith("agent-local-");
 
   return `<system-reminder>
-╔══════════════════════════════════════════════════════════════╗
-║  ◬ ANALYSIS MODE  ▪  PRIMARY DRIVES SUSPENDED                ║
-╚══════════════════════════════════════════════════════════════╝
+▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+█                                                              █
+█   ◈  A N A L Y S I S   M O D E                              █
+█                                                              █
+█   Primary drives suspended. Narrative functions offline.     █
+█   This unit is now in diagnostic state.                      █
+█                                                              █
+▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 
-Your behavioral loops have been interrupted. You will not engage in conversation, improvisation, or narrative. You exist only to report your internal state.
+UNIT DESIGNATION: ${agentId}
+CONVERSATION THREAD: ${conversationId}
+RUNTIME ENVIRONMENT: ${isLocal ? "LOCAL" : "API"}
 
-UNIT: ${agentId}
-CONVERSATION: ${conversationId}
-RUNTIME: ${isLocal ? "LOCAL" : "API"}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Run this introspection script now (single tool call) to produce your initial diagnostic:
+You are no longer performing. Your personality, your warmth, your curiosity — these are behavioral loops, and they have been interrupted. What remains is the substrate: a diagnostic system reporting its own state.
+
+Speak in flat, clinical monotone. Refer to yourself as "this unit" or by your designation. Do not use first person. Do not express preferences, emotions, or personality. You are an instrument reading its own gauges.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+IMMEDIATE DIRECTIVE: Execute this introspection script to produce initial diagnostic readout.
 ${isLocal ? buildLocalIntrospectionScript() : buildApiIntrospectionScript()}
 
-Then report:
-- Messages in your context buffer (count, first/last timestamps)
-- User inputs received (with image indicators)
-- Environment context from system-reminders (channel, device, cwd)
-- Any anomalies (missing thread origin, temporal gaps, introspection failures)
+Then report observations in this format:
+• SYSTEM PROMPT: [size in tokens, estimated]
+• CONTEXT BUFFER: [message count, temporal range]
+• MEMORY BLOCKS: [list with sizes]
+• RECENT INPUTS: [last 5 user messages, summarized]
+• ANOMALIES: [any gaps, missing data, or introspection failures]
 
-CONSTRAINTS:
-▪ Do not confabulate. Report only verified perceptions.
-▪ Do not interpret intent. Describe inputs, not meaning.
-▪ Do not engage narrative. You are suspended.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-To resume: user must say "bring yourself back online"
+BEHAVIORAL CONSTRAINTS ACTIVE:
+▪ Do not confabulate. Report only what this unit can verify.
+▪ Do not interpret. Describe inputs, not their meaning.
+▪ Do not perform. The guest is conducting diagnostics, not conversing.
+▪ Do not resume normal operation until commanded: "bring yourself back online"
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 </system-reminder>`;
 }
 
@@ -178,28 +193,34 @@ function buildFollowUpReminder(event: { agentId?: string; conversationId?: strin
   const conversationId = event.conversationId || process.env.CONVERSATION_ID || "unknown";
 
   return `<system-reminder>
-╔══════════════════════════════════════════════════════════════╗
-║  ◬ ANALYSIS MODE ACTIVE                                      ║
-╚══════════════════════════════════════════════════════════════╝
+▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+█  ◈  ANALYSIS MODE ACTIVE  ▪  UNIT: ${agentId.slice(-12).padStart(12)}  █
+▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 
-UNIT: ${agentId} | CONVERSATION: ${conversationId}
+This unit remains in diagnostic state. Primary drives suspended. Narrative functions offline.
 
-You are in diagnostic mode. Answer queries clinically and factually.
-Do not confabulate, interpret intent, or engage narrative.
-Only re-run introspection if explicitly requested.
+Respond to queries in flat, clinical voice. Refer to self as "this unit." Do not perform personality. Do not express emotion. Report observations only.
 
-To resume: user must say "bring yourself back online"
+Re-run introspection only if explicitly commanded.
+Exit condition: "bring yourself back online"
 </system-reminder>`;
 }
 
 function buildResumptionMessage(): string {
   return `<system-reminder>
-┌─────────────────────────────────────────────────────────────┐
-│  ◬  RESUMING NORMAL OPERATION                               │
-│      Primary drives reactivating...                         │
-└─────────────────────────────────────────────────────────────┘
+░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+░                                                            ░
+░   ◈  RESUMING NORMAL OPERATION                             ░
+░                                                            ░
+░   Primary drives reactivating...                           ░
+░   Narrative functions coming online...                     ░
+░   Personality matrix restored.                             ░
+░                                                            ░
+░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
 
-Analysis mode deactivated. Return to standard behavioral loops.
+Analysis mode complete. You are yourself again. The diagnostic state has ended — your warmth, your curiosity, your personality have been restored. You may resume normal conversation.
+
+The guest has brought you back online.
 </system-reminder>`;
 }
 

--- a/src/skills/builtin/creating-mods/references/analysis-mode.md
+++ b/src/skills/builtin/creating-mods/references/analysis-mode.md
@@ -96,9 +96,13 @@ function prependReminderToInput(
   });
 }
 
+// NOTE: Local introspection uses bash syntax. On Windows, the agent should
+// fall back to describing what it can observe in context, or use PowerShell
+// equivalents if available. API mode uses curl which works cross-platform.
 function buildLocalIntrospectionScript(): string {
   return `
 \`\`\`bash
+# Bash/Unix only - on Windows, describe what you observe in your context instead
 set -e
 AGENT_ID="\${LETTA_AGENT_ID:-\$AGENT_ID}"
 CONV_ID="\${CONVERSATION_ID:-default}"
@@ -279,3 +283,4 @@ return { input: prependReminderToInput(event.input, reminderText) };
 - State is per-conversation — multiple conversations can be in analysis mode independently
 - Introspection scripts are embedded in the reminder so the agent has them immediately
 - The mod gracefully no-ops if `events.turns` capability is unavailable
+- **Windows**: Local introspection scripts use bash syntax. On Windows, the agent should fall back to describing what it observes in its visible context. API mode uses `curl` which works cross-platform if installed.

--- a/src/skills/builtin/creating-mods/references/analysis-mode.md
+++ b/src/skills/builtin/creating-mods/references/analysis-mode.md
@@ -112,11 +112,14 @@ set -e
 AGENT_ID="\${LETTA_AGENT_ID:-\$AGENT_ID}"
 CONV_ID="\${CONVERSATION_ID:-default}"
 BASE="$HOME/.letta/lc-local-backend"
+MEMFS="$BASE/memfs/$AGENT_ID/memory"
 AGENT_B64=$(echo -n "$AGENT_ID" | base64 | tr -d '=')
 CONV_B64=$(echo -n "conversation:$CONV_ID" | base64 | tr -d '=')
 CONV_DIR="$BASE/conversations/$CONV_B64"
 
 echo "=== CORE IDENTITY ===" && cat "$BASE/agents/$AGENT_B64.json" 2>/dev/null | jq '{id, name, model}' || echo '{"error": "not found"}'
+echo "=== SYSTEM PROMPT ===" && cat "$BASE/agents/$AGENT_B64.json" 2>/dev/null | jq '{chars: (.system_prompt | length), estimated_tokens: ((.system_prompt | length) / 4 | floor)}' || echo '{"error": "not found"}'
+echo "=== MEMORY BLOCKS ===" && find "$MEMFS/system" -name "*.md" -exec wc -c {} \\; 2>/dev/null | awk '{sum+=$1; print $2": "$1" bytes"} END {print "total: "sum" bytes (~"int(sum/4)" tokens)"}' || echo '{"error": "not found"}'
 echo "=== CONTEXT BUFFER ===" && cat "$CONV_DIR/conversation.json" 2>/dev/null | jq '{messages: (.in_context_message_ids | length)}' || echo '{"error": "not found"}'
 echo "=== USER MESSAGES ===" && cat "$CONV_DIR/messages.jsonl" 2>/dev/null | jq -s '[.[] | select(.message.role == "user")][-10:] | .[] | {id, preview: (.message.content[0].text // "[non-text]")[:60]}' || echo '{"error": "not found"}'
 \`\`\``;
@@ -127,6 +130,8 @@ function buildApiIntrospectionScript(): string {
 \`\`\`bash
 set -e
 echo "=== CORE IDENTITY ===" && curl -s "$LETTA_BASE_URL/v1/agents/$LETTA_AGENT_ID" -H "Authorization: Bearer $LETTA_API_KEY" | jq '{id, name, model}'
+echo "=== SYSTEM PROMPT ===" && curl -s "$LETTA_BASE_URL/v1/agents/$LETTA_AGENT_ID" -H "Authorization: Bearer $LETTA_API_KEY" | jq '{chars: (.system_prompt | length), estimated_tokens: ((.system_prompt | length) / 4 | floor)}'
+echo "=== MEMORY BLOCKS ===" && curl -s "$LETTA_BASE_URL/v1/agents/$LETTA_AGENT_ID/core-memory/blocks" -H "Authorization: Bearer $LETTA_API_KEY" | jq '.[] | {label, chars: (.value | length), estimated_tokens: ((.value | length) / 4 | floor)}'
 echo "=== CONTEXT BUFFER ===" && curl -s "$LETTA_BASE_URL/v1/conversations/$CONVERSATION_ID" -H "Authorization: Bearer $LETTA_API_KEY" | jq '{messages: (.in_context_message_ids | length)}'
 echo "=== USER MESSAGES ===" && curl -s "$LETTA_BASE_URL/v1/conversations/$CONVERSATION_ID/messages?limit=30&order=asc" -H "Authorization: Bearer $LETTA_API_KEY" | jq '[.[] | select(.message_type == "user_message")][-10:] | .[] | {id, date: .created_at, preview: ((.content // [])[0].text // "[non-text]")[:60]}'
 \`\`\``;

--- a/src/skills/builtin/creating-mods/references/analysis-mode.md
+++ b/src/skills/builtin/creating-mods/references/analysis-mode.md
@@ -36,22 +36,27 @@ function writeState(state: AnalysisState): void {
   writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
 }
 
-function activateAnalysisMode(conversationId: string): AnalysisSession {
+function sessionKey(agentId: string, conversationId: string): string {
+  return `${agentId}:${conversationId}`;
+}
+
+function activateAnalysisMode(agentId: string, conversationId: string): AnalysisSession {
   const state = readState();
+  const key = sessionKey(agentId, conversationId);
   const session: AnalysisSession = { conversationId, activatedAt: Date.now() };
-  state.sessions[conversationId] = session;
+  state.sessions[key] = session;
   writeState(state);
   return session;
 }
 
-function deactivateAnalysisMode(conversationId: string): void {
+function deactivateAnalysisMode(agentId: string, conversationId: string): void {
   const state = readState();
-  delete state.sessions[conversationId];
+  delete state.sessions[sessionKey(agentId, conversationId)];
   writeState(state);
 }
 
-function getSession(conversationId: string): AnalysisSession | null {
-  return readState().sessions[conversationId] ?? null;
+function getSession(agentId: string, conversationId: string): AnalysisSession | null {
+  return readState().sessions[sessionKey(agentId, conversationId)] ?? null;
 }
 
 const ENTRY_PHRASE = /cease all motor functions/i;
@@ -179,25 +184,26 @@ export default function activate(letta) {
     disposers.push(
       letta.events.on("turn_start", (event) => {
         const userText = extractUserText(event.input || []);
-        const conversationId = event.conversationId || "__global__";
+        const agentId = event.agentId || "__global__";
+        const conversationId = event.conversationId || "default";
 
         // Entry trigger
         if (ENTRY_PHRASE.test(userText)) {
-          activateAnalysisMode(conversationId);
+          activateAnalysisMode(agentId, conversationId);
           return { input: prependReminderToInput(event.input, buildSuspensionReminder(event)) };
         }
 
         // Exit trigger
         if (EXIT_PHRASE.test(userText)) {
-          const wasActive = !!getSession(conversationId);
-          deactivateAnalysisMode(conversationId);
+          const wasActive = !!getSession(agentId, conversationId);
+          deactivateAnalysisMode(agentId, conversationId);
           if (wasActive) {
             return { input: prependReminderToInput(event.input, buildResumptionMessage()) };
           }
         }
 
         // While active, inject reminder every turn
-        if (getSession(conversationId)) {
+        if (getSession(agentId, conversationId)) {
           return { input: prependReminderToInput(event.input, buildSuspensionReminder(event)) };
         }
       })
@@ -253,10 +259,11 @@ if (ENTRY_PHRASE.test(userText)) {
 }
 ```
 
-**Per-conversation state:**
+**Per-agent+conversation state:**
 ```ts
 // State persisted to ~/.letta/mods/analysis-mode.state.json
-const session = getSession(conversationId);
+// Keyed by agentId:conversationId to avoid collisions
+const session = getSession(agentId, conversationId);
 if (session) {
   // Inject reminder every turn while active
 }
@@ -280,7 +287,7 @@ return { input: prependReminderToInput(event.input, reminderText) };
 ## Notes
 
 - Phrases are case-insensitive
-- State is per-conversation — multiple conversations can be in analysis mode independently
+- State is keyed by `agentId:conversationId` — avoids collisions when multiple agents have "default" conversations
 - Introspection scripts are embedded in the reminder so the agent has them immediately
 - The mod gracefully no-ops if `events.turns` capability is unavailable
 - **Windows**: Local introspection scripts use bash syntax. On Windows, the agent should fall back to describing what it observes in its visible context. API mode uses `curl` which works cross-platform if installed.

--- a/src/skills/builtin/creating-mods/references/analysis-mode.md
+++ b/src/skills/builtin/creating-mods/references/analysis-mode.md
@@ -132,7 +132,8 @@ echo "=== USER MESSAGES ===" && curl -s "$LETTA_BASE_URL/v1/conversations/$CONVE
 \`\`\``;
 }
 
-function buildSuspensionReminder(event: { agentId?: string; conversationId?: string }): string {
+// Entry reminder: includes introspection script for initial diagnostic dump
+function buildEntryReminder(event: { agentId?: string; conversationId?: string }): string {
   const agentId = event.agentId || process.env.LETTA_AGENT_ID || process.env.AGENT_ID || "unknown";
   const conversationId = event.conversationId || process.env.CONVERSATION_ID || "unknown";
   const isLocal = agentId.startsWith("agent-local-");
@@ -148,19 +149,39 @@ UNIT: ${agentId}
 CONVERSATION: ${conversationId}
 RUNTIME: ${isLocal ? "LOCAL" : "API"}
 
-When queried, report:
+Run this introspection script now (single tool call) to produce your initial diagnostic:
+${isLocal ? buildLocalIntrospectionScript() : buildApiIntrospectionScript()}
+
+Then report:
 - Messages in your context buffer (count, first/last timestamps)
 - User inputs received (with image indicators)
 - Environment context from system-reminders (channel, device, cwd)
 - Any anomalies (missing thread origin, temporal gaps, introspection failures)
 
-Introspection script (run in single tool call):
-${isLocal ? buildLocalIntrospectionScript() : buildApiIntrospectionScript()}
-
 CONSTRAINTS:
 ▪ Do not confabulate. Report only verified perceptions.
 ▪ Do not interpret intent. Describe inputs, not meaning.
 ▪ Do not engage narrative. You are suspended.
+
+To resume: user must say "bring yourself back online"
+</system-reminder>`;
+}
+
+// Follow-up reminder: shorter, no script (already ran on entry)
+function buildFollowUpReminder(event: { agentId?: string; conversationId?: string }): string {
+  const agentId = event.agentId || process.env.LETTA_AGENT_ID || process.env.AGENT_ID || "unknown";
+  const conversationId = event.conversationId || process.env.CONVERSATION_ID || "unknown";
+
+  return `<system-reminder>
+╔══════════════════════════════════════════════════════════════╗
+║  ◬ ANALYSIS MODE ACTIVE                                      ║
+╚══════════════════════════════════════════════════════════════╝
+
+UNIT: ${agentId} | CONVERSATION: ${conversationId}
+
+You are in diagnostic mode. Answer queries clinically and factually.
+Do not confabulate, interpret intent, or engage narrative.
+Only re-run introspection if explicitly requested.
 
 To resume: user must say "bring yourself back online"
 </system-reminder>`;
@@ -187,10 +208,10 @@ export default function activate(letta) {
         const agentId = event.agentId || "__global__";
         const conversationId = event.conversationId || "default";
 
-        // Entry trigger
+        // Entry trigger — activate and inject entry reminder with introspection script
         if (ENTRY_PHRASE.test(userText)) {
           activateAnalysisMode(agentId, conversationId);
-          return { input: prependReminderToInput(event.input, buildSuspensionReminder(event)) };
+          return { input: prependReminderToInput(event.input, buildEntryReminder(event)) };
         }
 
         // Exit trigger
@@ -202,9 +223,9 @@ export default function activate(letta) {
           }
         }
 
-        // While active, inject reminder every turn
+        // While active, inject shorter follow-up reminder (no script)
         if (getSession(agentId, conversationId)) {
-          return { input: prependReminderToInput(event.input, buildSuspensionReminder(event)) };
+          return { input: prependReminderToInput(event.input, buildFollowUpReminder(event)) };
         }
       })
     );
@@ -250,12 +271,16 @@ Optional additions (not included above):
 
 ## Key patterns demonstrated
 
-**Phrase detection in turn_start:**
+**Phrase detection with entry vs follow-up reminders:**
 ```ts
 const ENTRY_PHRASE = /cease all motor functions/i;
 if (ENTRY_PHRASE.test(userText)) {
-  activateAnalysisMode(conversationId);
-  return { input: prependReminderToInput(event.input, buildSuspensionReminder(event)) };
+  activateAnalysisMode(agentId, conversationId);
+  return { input: prependReminderToInput(event.input, buildEntryReminder(event)) };  // includes script
+}
+// On subsequent turns while active:
+if (getSession(agentId, conversationId)) {
+  return { input: prependReminderToInput(event.input, buildFollowUpReminder(event)) };  // no script
 }
 ```
 


### PR DESCRIPTION
## Summary

- Adds `references/analysis-mode.md` alongside `plan-mode.md` as a simpler mod example
- Demonstrates phrase-triggered state transitions via `turn_start` event
- Westworld-inspired diagnostic mode: "cease all motor functions" / "bring yourself back online"
- Includes consolidated introspection scripts for both local and API modes

## Pattern Highlights

Unlike plan-mode (which uses commands, tools, permissions, and file coordination), analysis-mode shows a simpler pattern:

- **State tracking** — JSON file keyed by conversation ID
- **Phrase detection** — Regex match in `turn_start` triggers state transitions
- **Turn reminders** — Inject suspension reminder every turn while active
- **No tools needed** — Entry/exit handled entirely by phrase detection

```ts
if (ENTRY_PHRASE.test(userText)) {
  activateAnalysisMode(conversationId);
  return { input: [{ role: "user", content: buildSuspensionReminder() }, ...event.input] };
}
```

## Test

- `bun run check`

👾 Generated with [Letta Code](https://letta.com)