### PR TITLE
feat(listener): enable turn_start event for listener mods

### DIFF
--- a/src/websocket/listener/mod-adapter.test.ts
+++ b/src/websocket/listener/mod-adapter.test.ts
@@ -50,7 +50,7 @@ describe("listener mod adapter", () => {
       events: {
         lifecycle: false,
         tools: false,
-        turns: false,
+        turns: true,
       },
       permissions: false,
       providers: true,
@@ -306,6 +306,123 @@ describe("listener mod adapter", () => {
     expect(result.toolReturn).toBe(
       "agent-scoped:/tmp/listener-workspace:anthropic:standard:default",
     );
+  });
+
+  test("turn_start handlers can modify input", async () => {
+    const root = createTempDir();
+    const modsDir = join(root, "mods");
+    const cacheDir = join(root, "cache");
+    mkdirSync(modsDir, { recursive: true });
+    writeFileSync(
+      join(modsDir, "turn-mod.ts"),
+      `export default function activate(letta) {
+        letta.events.on("turn_start", (event) => {
+          // Prepend a reminder to the first user message
+          const transformed = event.input.map((m, i) => {
+            if (m.role === "user" && i === 0) {
+              const reminder = { type: "text", text: "<reminder>test</reminder>" };
+              const content = Array.isArray(m.content) ? m.content : [{ type: "text", text: m.content }];
+              return { ...m, content: [reminder, ...content] };
+            }
+            return m;
+          });
+          return { input: transformed };
+        });
+      }`,
+    );
+
+    const adapter = createListenerModAdapter({
+      cacheDirectory: cacheDir,
+      globalModsDirectory: modsDir,
+      sessionId: "turn-test",
+      workingDirectory: root,
+    });
+    await adapter.reload();
+
+    const context = createListenerModContext({
+      sessionId: "conv-turn-test",
+      workingDirectory: root,
+    });
+    const originalInput = [
+      {
+        role: "user" as const,
+        content: [{ type: "text" as const, text: "hello" }],
+      },
+    ];
+    const event = {
+      agentId: "agent-turn",
+      conversationId: "conv-turn-test",
+      input: originalInput,
+    };
+
+    await adapter.events.emit("turn_start", event, context);
+
+    // Handler should have prepended the reminder
+    expect(event.input).toHaveLength(1);
+    const firstMsg = event.input[0];
+    if (!firstMsg || !("content" in firstMsg)) {
+      throw new Error("Expected first message with content");
+    }
+    expect(Array.isArray(firstMsg.content)).toBe(true);
+    const content = firstMsg.content as unknown[];
+    expect(content).toHaveLength(2);
+    expect(content[0]).toEqual({
+      type: "text",
+      text: "<reminder>test</reminder>",
+    });
+    expect(content[1]).toEqual({ type: "text", text: "hello" });
+
+    adapter.dispose();
+  });
+
+  test("turn_start handler errors do not block emission", async () => {
+    const root = createTempDir();
+    const modsDir = join(root, "mods");
+    const cacheDir = join(root, "cache");
+    mkdirSync(modsDir, { recursive: true });
+    writeFileSync(
+      join(modsDir, "throw-mod.ts"),
+      `export default function activate(letta) {
+        letta.events.on("turn_start", () => {
+          throw new Error("handler error");
+        });
+      }`,
+    );
+
+    const adapter = createListenerModAdapter({
+      cacheDirectory: cacheDir,
+      globalModsDirectory: modsDir,
+      sessionId: "throw-test",
+      workingDirectory: root,
+    });
+    await adapter.reload();
+
+    const context = createListenerModContext({
+      sessionId: "conv-throw-test",
+      workingDirectory: root,
+    });
+    const originalInput = [
+      {
+        role: "user" as const,
+        content: [{ type: "text" as const, text: "test" }],
+      },
+    ];
+    const event = {
+      agentId: "agent-throw",
+      conversationId: "conv-throw-test",
+      input: originalInput,
+    };
+
+    // Should not throw, emission continues despite handler error
+    const result = await adapter.events.emit("turn_start", event, context);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.error).toBeInstanceOf(Error);
+    expect(result.diagnostics[0]?.error.message).toBe("handler error");
+
+    // Input should be unchanged since handler threw
+    expect(event.input).toEqual(originalInput);
+
+    adapter.dispose();
   });
 
   test("mod tools with isEnabled are isolated across listener scopes", async () => {

--- a/src/websocket/listener/mod-adapter.ts
+++ b/src/websocket/listener/mod-adapter.ts
@@ -12,7 +12,7 @@ export const LISTENER_MOD_CAPABILITIES: ModCapabilities = {
   events: {
     lifecycle: false,
     tools: false,
-    turns: false,
+    turns: true,
   },
   permissions: false,
   providers: true,

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -229,6 +229,7 @@ async function emitListenerTurnStart(options: {
   input: Array<MessageCreate | ApprovalCreate>;
   runtime: ListenerRuntime;
   workingDirectory: string;
+  permissionMode?: string | null;
   cachedAgent?: AgentState | null;
 }): Promise<Array<MessageCreate | ApprovalCreate>> {
   try {
@@ -236,6 +237,7 @@ async function emitListenerTurnStart(options: {
     const context = createListenerModContext({
       sessionId: options.conversationId,
       workingDirectory: options.workingDirectory,
+      permissionMode: options.permissionMode ?? null,
       agent: options.cachedAgent ?? null,
     });
     const event = {
@@ -492,7 +494,9 @@ export async function handleIncomingMessage(
           : m,
       ),
     );
-    const inboundUserTranscriptLines =
+    // Build transcript lines after turn_start so transformed input is shown.
+    // This is reassigned below after emitListenerTurnStart.
+    let inboundUserTranscriptLines =
       buildInboundUserTranscriptLines(messagesToSend);
 
     const firstMessage = normalizedMessages[0];
@@ -584,14 +588,29 @@ export async function handleIncomingMessage(
       }
     }
 
-    let currentInput = await emitListenerTurnStart({
-      agentId,
-      conversationId,
-      input: messagesToSend,
-      runtime: runtime.listener,
-      workingDirectory: turnWorkingDirectory,
-      cachedAgent,
-    });
+    // Only emit turn_start for user messages, not approval-only continuations.
+    // A mod could otherwise rewrite approval payloads and break routing.
+    const hasUserMessage = messagesToSend.some(
+      (m) => "role" in m && m.role === "user",
+    );
+    let currentInput = hasUserMessage
+      ? await emitListenerTurnStart({
+          agentId,
+          conversationId,
+          input: messagesToSend,
+          runtime: runtime.listener,
+          workingDirectory: turnWorkingDirectory,
+          permissionMode: turnPermissionModeState.mode,
+          cachedAgent,
+        })
+      : messagesToSend;
+
+    // Rebuild transcript lines from the potentially transformed input so
+    // Desktop shows post-transform text, not the original user message.
+    if (currentInput !== messagesToSend) {
+      inboundUserTranscriptLines =
+        buildInboundUserTranscriptLines(currentInput);
+    }
     const providerFallback = createProviderFallbackState(cachedAgent);
     let pendingNormalizationInterruptedToolCallIds = [
       ...queuedInterruptedToolCallIds,

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -77,7 +77,10 @@ import {
   normalizeToolReturnWireMessage,
   populateInterruptQueue,
 } from "./interrupts";
-import { ensureListenerModAdapter } from "./mod-adapter";
+import {
+  createListenerModContext,
+  ensureListenerModAdapter,
+} from "./mod-adapter";
 import {
   getOrCreateConversationPermissionModeStateRef,
   persistPermissionModeMapForRuntime,
@@ -125,6 +128,7 @@ import type {
   ConversationRuntime,
   InboundMessagePayload,
   IncomingMessage,
+  ListenerRuntime,
 } from "./types";
 import { ensureListenerWarmStateForTurn } from "./warmup";
 
@@ -208,6 +212,43 @@ function escapeTaskNotificationSummary(summary: string): string {
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
+}
+
+function isTurnInputArray(
+  value: unknown,
+): value is Array<MessageCreate | ApprovalCreate> {
+  return (
+    Array.isArray(value) &&
+    value.every((item) => typeof item === "object" && item !== null)
+  );
+}
+
+async function emitListenerTurnStart(options: {
+  agentId: string;
+  conversationId: string;
+  input: Array<MessageCreate | ApprovalCreate>;
+  runtime: ListenerRuntime;
+  workingDirectory: string;
+  cachedAgent?: AgentState | null;
+}): Promise<Array<MessageCreate | ApprovalCreate>> {
+  try {
+    const modAdapter = ensureListenerModAdapter(options.runtime);
+    const context = createListenerModContext({
+      sessionId: options.conversationId,
+      workingDirectory: options.workingDirectory,
+      agent: options.cachedAgent ?? null,
+    });
+    const event = {
+      agentId: options.agentId,
+      conversationId: options.conversationId,
+      input: options.input,
+    };
+    await modAdapter.events.emit("turn_start", event, context);
+    return isTurnInputArray(event.input) ? event.input : options.input;
+  } catch {
+    // Mod turn_start handlers should not block sending the turn.
+    return options.input;
+  }
 }
 
 export function buildMaybeLaunchReflectionSubagent(params: {
@@ -543,7 +584,14 @@ export async function handleIncomingMessage(
       }
     }
 
-    let currentInput = messagesToSend;
+    let currentInput = await emitListenerTurnStart({
+      agentId,
+      conversationId,
+      input: messagesToSend,
+      runtime: runtime.listener,
+      workingDirectory: turnWorkingDirectory,
+      cachedAgent,
+    });
     const providerFallback = createProviderFallbackState(cachedAgent);
     let pendingNormalizationInterruptedToolCallIds = [
       ...queuedInterruptedToolCallIds,


### PR DESCRIPTION
## Summary

This PR enables `turn_start` event handlers for listener mods (Desktop, Slack, channels), allowing mods to intercept and transform user input before it reaches the agent.

## Context for Caren

Your PR #2949 wired `modEvents` through the listener at all the right callsites, but left `events.turns: false` in `LISTENER_MOD_CAPABILITIES`. This PR flips that flag and adds the actual `turn_start` emission.

## Changes

**`mod-adapter.ts`** (1 line)
```diff
events: {
  lifecycle: false,
  tools: false,
- turns: false,
+ turns: true,
},
```

**`turn.ts`** (~50 lines)
- Add `isTurnInputArray()` type guard (same as headless.ts)
- Add `emitListenerTurnStart()` helper that:
  - Creates a `ModContext` via `createListenerModContext()`
  - Emits `turn_start` with `{ agentId, conversationId, input }`
  - Returns potentially modified input (or original if handler throws)
- Call `emitListenerTurnStart()` right after `currentInput = messagesToSend`

## Use Case

This unblocks mods that need to intercept user messages for listener-served agents (Slack, Desktop API agents). Example: a diagnostic mode mod that detects trigger phrases and injects system reminders.

## Test

- `bun run check` passes (ignoring unrelated filename casing issue)
- Manual testing needed for actual turn_start handler behavior

👾 Generated with [Letta Code](https://letta.com)