### PR TITLE
fix(tools): apply session tool filters to client snapshots

### DIFF
--- a/src/tools/filter.ts
+++ b/src/tools/filter.ts
@@ -44,7 +44,7 @@ class ToolFilterManager {
    * Get list of enabled tools (null means all tools)
    */
   getEnabledTools(): string[] | null {
-    return this.enabledTools ? [...this.enabledTools] : null;
+    return this.enabledTools === null ? null : [...this.enabledTools];
   }
 
   /**

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -66,6 +66,7 @@ import { settingsManager } from "@/settings-manager";
 import { telemetry } from "@/telemetry";
 import { debugLog } from "@/utils/debug";
 import { isRecord } from "@/utils/type-guards";
+import { toolFilter } from "./filter";
 import {
   functionToolForm,
   type JsonSchema,
@@ -342,6 +343,26 @@ function filterExternalToolsByClientAllowlist(
   return new Map(
     Array.from(externalTools.entries()).filter(([internalName, tool]) =>
       matchesClientToolAllowlistEntry(allowSet, tool.name, internalName),
+    ),
+  );
+}
+
+function filterToolRegistryByClientAllowlist(
+  registry: ToolRegistry,
+  clientToolAllowlist?: string[],
+): ToolRegistry {
+  if (clientToolAllowlist === undefined) {
+    return new Map(registry);
+  }
+
+  const allowSet = new Set(clientToolAllowlist);
+  return new Map(
+    Array.from(registry.entries()).filter(([internalName]) =>
+      matchesClientToolAllowlistEntry(
+        allowSet,
+        getServerToolName(internalName),
+        internalName,
+      ),
     ),
   );
 }
@@ -1123,14 +1144,20 @@ function capturePreparedToolExecutionContext(
   },
 ): PreparedToolExecutionContext {
   const runtimeContext = buildExecutionRuntimeContextSnapshot(options);
+  const clientToolAllowlist =
+    options?.clientToolAllowlist ?? toolFilter.getEnabledTools() ?? undefined;
   if (options?.channelToolScope !== undefined) {
     runtimeContext.channelToolScope = options.channelToolScope;
   }
   if (options?.channelTurnSources?.length) {
     runtimeContext.channelTurnSources = [...options.channelTurnSources];
   }
+  const toolRegistrySnapshot = filterToolRegistryByClientAllowlist(
+    withDynamicMessageChannelCache(snapshot.toolRegistry),
+    clientToolAllowlist,
+  );
   const executionSnapshot: ToolExecutionContextSnapshot = {
-    toolRegistry: withDynamicMessageChannelCache(snapshot.toolRegistry),
+    toolRegistry: toolRegistrySnapshot,
     externalTools: toModelFacingExternalToolMap(
       filterExternalToolsByClientAllowlist(
         filterExternalToolsByScopeIds(
@@ -1140,7 +1167,7 @@ function capturePreparedToolExecutionContext(
           ),
           options?.externalToolScopeIds,
         ),
-        options?.clientToolAllowlist,
+        clientToolAllowlist,
       ),
     ),
     externalExecutor: snapshot.externalExecutor,
@@ -1149,7 +1176,7 @@ function capturePreparedToolExecutionContext(
     modPermissions: snapshot.modPermissions,
     modTools: filterModToolsByClientAllowlist(
       snapshot.modTools,
-      options?.clientToolAllowlist,
+      clientToolAllowlist,
     ),
     workingDirectory:
       runtimeContext.workingDirectory ?? getCurrentWorkingDirectory(),

--- a/src/tools/tool-execution-context.test.ts
+++ b/src/tools/tool-execution-context.test.ts
@@ -37,6 +37,7 @@ import {
   LETTA_INHERITED_CHANNEL_CONTEXT_ENV,
   runWithRuntimeContext,
 } from "@/runtime-context";
+import { toolFilter } from "@/tools/filter";
 import {
   captureToolExecutionContext,
   clearCapturedToolExecutionContexts,
@@ -124,6 +125,7 @@ describe("tool execution context snapshot", () => {
     clearExternalTools();
     clearModPermissions();
     clearModTools();
+    toolFilter.reset();
     clearAllRoutes();
     __testOverrideLoadRoutes(null);
     __testOverrideSaveRoutes(null);
@@ -395,6 +397,69 @@ describe("tool execution context snapshot", () => {
 
     expect(prepared.loadedToolNames).toEqual([]);
     expect(prepared.clientTools).toEqual([]);
+  });
+
+  test("session tool filter excludes mod tools from current snapshots", async () => {
+    toolFilter.setEnabledTools("Bash");
+    await loadSpecificTools(["Bash"]);
+    registerEchoModTool(new AbortController().signal);
+
+    const prepared = await prepareCurrentToolExecutionContext();
+
+    expect(prepared.loadedToolNames).toEqual(["Bash"]);
+    expect(prepared.clientTools.map((tool) => tool.name)).toEqual(["Bash"]);
+
+    const denied = await executeTool(
+      "local_echo",
+      { message: "hi" },
+      { toolContextId: prepared.contextId },
+    );
+    expect(denied.status).toBe("error");
+    expect(asText(denied.toolReturn)).toContain("Tool not found: local_echo");
+  });
+
+  test("session tool filter excludes external tools from current snapshots", async () => {
+    toolFilter.setEnabledTools("Bash");
+    await loadSpecificTools(["Bash"]);
+    registerExternalTools([
+      {
+        name: "RemoteFoo",
+        description: "External tool filtered by session --tools",
+        parameters: { type: "object", properties: {}, required: [] },
+      },
+    ]);
+
+    const prepared = await prepareCurrentToolExecutionContext();
+
+    expect(prepared.loadedToolNames).toEqual(["Bash"]);
+    expect(prepared.clientTools.map((tool) => tool.name)).toEqual(["Bash"]);
+
+    const denied = await executeTool(
+      "RemoteFoo",
+      {},
+      { toolContextId: prepared.contextId },
+    );
+    expect(denied.status).toBe("error");
+    expect(asText(denied.toolReturn)).toContain("Tool not found: RemoteFoo");
+  });
+
+  test("empty session tool filter excludes mod tools from current snapshots", async () => {
+    toolFilter.setEnabledTools("");
+    await loadSpecificTools(["Bash"]);
+    registerEchoModTool(new AbortController().signal);
+
+    const prepared = await prepareCurrentToolExecutionContext();
+
+    expect(prepared.loadedToolNames).toEqual([]);
+    expect(prepared.clientTools).toEqual([]);
+
+    const denied = await executeTool(
+      "local_echo",
+      { message: "hi" },
+      { toolContextId: prepared.contextId },
+    );
+    expect(denied.status).toBe("error");
+    expect(asText(denied.toolReturn)).toContain("Tool not found: local_echo");
   });
 
   test("runtime-owned external tools stay scoped to their runtime", async () => {


### PR DESCRIPTION
## Summary

Fixes #2989 by making the session `--tools` filter act as a hard client-tool allowlist for turn snapshots, not just built-in tool loading.

Previously, a narrow subagent scope like `--tools Bash` could still include local mod tools in the final client tool snapshot because mod/external tools were collected after built-in filtering. This change applies the effective allowlist when capturing the turn-scoped execution context across:

- built-in tool registry snapshots
- external tools
- local mod tools

It also preserves empty `--tools ""` as an empty allowlist instead of collapsing it to `null` / all tools.

## Tests

- `bun test src/tools/tools-filter.test.ts`
- `bun test src/tools/tool-execution-context.test.ts`
- `bun run typecheck`
- `bun run check`

## Live smoke

Ran a one-off headless smoke with a temporary real local mod file registering `smoke_local_mod_tool`:

1. no session filter: confirmed the mod tool appears in the headless tool snapshot and dispatch succeeds through the captured `toolContextId`
2. `toolFilter.setEnabledTools("Bash")` (equivalent to `--tools Bash`): confirmed the snapshot only includes `Bash` and dispatching `smoke_local_mod_tool` through that `toolContextId` returns `Tool not found: smoke_local_mod_tool. Available tools: Bash`

## Follow-up

Filed broader first-class tool-scope design issue separately: #2995
