### PR TITLE
fix(tools): respect SHELL for Windows shell launchers

### DIFF
--- a/src/tools/impl/bash.ts
+++ b/src/tools/impl/bash.ts
@@ -27,6 +27,7 @@ let cachedWorkingLauncher: string[] | null = null;
 
 function rebuildCachedLauncher(
   command: string,
+  env: NodeJS.ProcessEnv,
   secretEnv?: Record<string, string>,
 ): string[] | null {
   if (!cachedWorkingLauncher) return null;
@@ -34,6 +35,7 @@ function rebuildCachedLauncher(
   if (!cachedExecutable) return null;
 
   const launchers = buildShellLaunchers(command, {
+    env,
     powershellEnvAliases: secretEnv ? Object.keys(secretEnv) : undefined,
   });
   return (
@@ -54,10 +56,11 @@ function getBackgroundLauncher(
   env: NodeJS.ProcessEnv,
   secretEnv?: Record<string, string>,
 ): string[] {
-  const cachedLauncher = rebuildCachedLauncher(command, secretEnv);
+  const cachedLauncher = rebuildCachedLauncher(command, env, secretEnv);
   if (cachedLauncher) return cachedLauncher;
 
   const launchers = buildShellLaunchers(command, {
+    env,
     powershellEnvAliases: secretEnv ? Object.keys(secretEnv) : undefined,
   });
   return selectAvailableShellLauncher(launchers, env) || [];
@@ -101,7 +104,11 @@ export async function spawnCommand(
 
   // On Windows, use fallback logic to handle PowerShell ENOENT errors (PR #482)
   if (cachedWorkingLauncher) {
-    const newLauncher = rebuildCachedLauncher(commandToRun, options.secretEnv);
+    const newLauncher = rebuildCachedLauncher(
+      commandToRun,
+      env,
+      options.secretEnv,
+    );
     if (newLauncher) {
       try {
         const result = await spawnWithLauncher(newLauncher, {
@@ -123,6 +130,7 @@ export async function spawnCommand(
   }
 
   const launchers = buildShellLaunchers(commandToRun, {
+    env,
     powershellEnvAliases: options.secretEnv
       ? Object.keys(options.secretEnv)
       : undefined,

--- a/src/tools/impl/exec-command.ts
+++ b/src/tools/impl/exec-command.ts
@@ -374,7 +374,10 @@ function buildExplicitShellLauncher(
   return [shell, shellCommandFlag(shell, login), cmd];
 }
 
-function buildExecLaunchers(args: ExecCommandArgs): string[][] {
+function buildExecLaunchers(
+  args: ExecCommandArgs,
+  env: NodeJS.ProcessEnv,
+): string[][] {
   const login = args.login ?? true;
   const envAliases = args.secretEnv ? Object.keys(args.secretEnv) : undefined;
   if (args.shell?.trim()) {
@@ -388,6 +391,7 @@ function buildExecLaunchers(args: ExecCommandArgs): string[][] {
     ];
   }
   return buildShellLaunchers(args.cmd, {
+    env,
     login,
     powershellEnvAliases: envAliases,
   });
@@ -645,7 +649,7 @@ async function startExecSession(args: ExecCommandArgs): Promise<ExecSession> {
   const outputFile = createBackgroundOutputFile(`exec_${id}`);
   const cwd = resolveShellWorkdir(args.workdir);
   const env = { ...getShellEnv(), ...(args.secretEnv ?? {}) };
-  const launchers = buildExecLaunchers(args);
+  const launchers = buildExecLaunchers(args, env);
   const launcher = selectAvailableShellLauncher(launchers, env);
   if (!launcher) {
     throw new Error("Command must be a non-empty string");

--- a/src/tools/impl/shell-launchers.ts
+++ b/src/tools/impl/shell-launchers.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import { delimiter, isAbsolute, join } from "node:path";
+import { acceptsDashC, preferredShellFromEnv } from "@/utils/shell-detection";
 
 const SEP = "\u0000";
 type ShellLaunchOptions = {
@@ -108,11 +109,23 @@ export function buildPowerShellCommand(
 function windowsLaunchers(
   command: string,
   envAliases: string[] = [],
+  env: NodeJS.ProcessEnv = process.env,
+  login = false,
 ): string[][] {
   const trimmed = command.trim();
   if (!trimmed) return [];
   const launchers: string[][] = [];
   const seen = new Set<string>();
+
+  const preferredShell = preferredShellFromEnv(env);
+  if (preferredShell && acceptsDashC(preferredShell)) {
+    pushUnique(launchers, seen, [
+      preferredShell,
+      shellCommandFlag(preferredShell, login),
+      trimmed,
+    ]);
+  }
+
   const powerShellCommand = buildPowerShellCommand(trimmed, envAliases);
 
   // Match Codex's PowerShell order: prefer PowerShell Core (`pwsh`) when
@@ -224,7 +237,11 @@ export function selectAvailableShellLauncher(
   return launchers.at(-1);
 }
 
-function unixLaunchers(command: string, login: boolean): string[][] {
+function unixLaunchers(
+  command: string,
+  login: boolean,
+  env: NodeJS.ProcessEnv = process.env,
+): string[][] {
   const trimmed = command.trim();
   if (!trimmed) return [];
   const launchers: string[][] = [];
@@ -242,7 +259,7 @@ function unixLaunchers(command: string, login: boolean): string[][] {
 
   // Try user's preferred shell from $SHELL environment variable
   // Use login semantics only when explicitly requested.
-  const envShell = process.env.SHELL?.trim();
+  const envShell = env.SHELL?.trim();
   if (envShell) {
     pushUnique(launchers, seen, [
       envShell,
@@ -289,8 +306,9 @@ export function buildShellLaunchers(
   options?: ShellLaunchOptions,
 ): string[][] {
   const login = options?.login ?? false;
-  const commandToRun = withStrictShellPrelude(command, options?.env);
+  const env = options?.env ?? process.env;
+  const commandToRun = withStrictShellPrelude(command, env);
   return process.platform === "win32"
-    ? windowsLaunchers(commandToRun, options?.powershellEnvAliases)
-    : unixLaunchers(commandToRun, login);
+    ? windowsLaunchers(commandToRun, options?.powershellEnvAliases, env, login)
+    : unixLaunchers(commandToRun, login, env);
 }

--- a/src/tools/impl/shell.ts
+++ b/src/tools/impl/shell.ts
@@ -118,7 +118,7 @@ export async function shell(args: ShellArgs): Promise<ShellResult> {
     return await runProcess(context);
   } catch (error) {
     if (error instanceof ShellExecutionError && error.code === "ENOENT") {
-      for (const fallback of buildFallbackCommands(command)) {
+      for (const fallback of buildFallbackCommands(command, context.env)) {
         try {
           return await runProcess({ ...context, command: fallback });
         } catch (retryError) {
@@ -136,14 +136,31 @@ export async function shell(args: ShellArgs): Promise<ShellResult> {
   }
 }
 
-function buildFallbackCommands(command: string[]): string[][] {
+function buildFallbackCommands(
+  command: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): string[][] {
   if (!command.length) return [];
   const shellIndex = findShellExecutableIndex(command);
   if (shellIndex === null) return [];
   const script = extractShellScript(command, shellIndex);
   if (!script) return [];
-  const launchers = buildShellLaunchers(script);
+  const launchers = buildShellLaunchers(script, {
+    env,
+    login: usesLoginShellFlag(command, shellIndex),
+  });
   return launchers.filter((launcher) => !arraysEqual(launcher, command));
+}
+
+function usesLoginShellFlag(command: string[], shellIndex: number): boolean {
+  for (let i = shellIndex + 1; i < command.length; i += 1) {
+    const token = command[i];
+    if (!token) continue;
+    const normalized = token.toLowerCase();
+    if (normalized === "-lc") return true;
+    if (normalized === "-c" || normalized === "/c") return false;
+  }
+  return false;
 }
 
 function arraysEqual(a: string[], b: string[]): boolean {

--- a/src/tools/shell-launchers.test.ts
+++ b/src/tools/shell-launchers.test.ts
@@ -5,6 +5,19 @@ import {
   POWERSHELL_UTF8_OUTPUT_PREFIX,
 } from "@/tools/impl/shell-launchers";
 
+function withPlatform<T>(platform: NodeJS.Platform, callback: () => T): T {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { value: platform });
+
+  try {
+    return callback();
+  } finally {
+    if (originalPlatform) {
+      Object.defineProperty(process, "platform", originalPlatform);
+    }
+  }
+}
+
 describe("Shell Launchers", () => {
   test("builds launchers for a command", () => {
     const launchers = buildShellLaunchers("echo hello");
@@ -59,15 +72,9 @@ describe("Shell Launchers", () => {
     ).toBe(true);
   });
 
-  test("Windows launchers match Codex PowerShell order", () => {
-    const originalPlatform = Object.getOwnPropertyDescriptor(
-      process,
-      "platform",
-    );
-    Object.defineProperty(process, "platform", { value: "win32" });
-
-    try {
-      const launchers = buildShellLaunchers("echo test");
+  test("Windows keeps PowerShell fallback order when SHELL is unset", () => {
+    withPlatform("win32", () => {
+      const launchers = buildShellLaunchers("echo test", { env: {} });
 
       expect(launchers[0]?.[0]).toBe("pwsh");
       expect(launchers[1]?.[0]).toBe(
@@ -82,11 +89,42 @@ describe("Shell Launchers", () => {
       expect(launchers[1]?.at(-1)).toContain(POWERSHELL_UTF8_OUTPUT_PREFIX);
       expect(launchers[2]?.at(-1)).toContain(POWERSHELL_UTF8_OUTPUT_PREFIX);
       expect(launchers[3]?.at(-1)).toContain(POWERSHELL_UTF8_OUTPUT_PREFIX);
-    } finally {
-      if (originalPlatform) {
-        Object.defineProperty(process, "platform", originalPlatform);
-      }
-    }
+    });
+  });
+
+  test("Windows prefers SHELL when it accepts -c", () => {
+    withPlatform("win32", () => {
+      const launchers = buildShellLaunchers("echo test", {
+        env: { SHELL: "C:\\Program Files\\Git\\bin\\bash.exe" },
+      });
+
+      expect(launchers[0]?.[0]).toBe("C:\\Program Files\\Git\\bin\\bash.exe");
+      expect(launchers[0]?.[1]).toBe("-c");
+      const psIndex = launchers.findIndex((l) => l[0] === "pwsh");
+      expect(psIndex).toBeGreaterThan(0);
+    });
+  });
+
+  test("Windows ignores SHELL when it does not accept -c", () => {
+    withPlatform("win32", () => {
+      const launchers = buildShellLaunchers("echo test", {
+        env: { SHELL: "nu.exe" },
+      });
+
+      expect(launchers[0]?.[0]).toBe("pwsh");
+    });
+  });
+
+  test("Windows preferred SHELL respects login flag", () => {
+    withPlatform("win32", () => {
+      const launchers = buildShellLaunchers("echo test", {
+        env: { SHELL: "bash" },
+        login: true,
+      });
+
+      expect(launchers[0]?.[0]).toBe("bash");
+      expect(launchers[0]?.[1]).toBe("-lc");
+    });
   });
 
   if (process.platform === "win32") {
@@ -166,17 +204,11 @@ describe("Shell Launchers", () => {
       });
 
       test("prefers user SHELL environment", () => {
-        const originalShell = process.env.SHELL;
-        process.env.SHELL = "/bin/zsh";
-
-        try {
-          const launchers = buildShellLaunchers("echo test");
-          // User's shell should be first
-          expect(launchers[0]?.[0]).toBe("/bin/zsh");
-        } finally {
-          if (originalShell === undefined) delete process.env.SHELL;
-          else process.env.SHELL = originalShell;
-        }
+        const launchers = buildShellLaunchers("echo test", {
+          env: { SHELL: "/bin/zsh" },
+        });
+        // User's shell should be first
+        expect(launchers[0]?.[0]).toBe("/bin/zsh");
       });
     });
   }

--- a/src/utils/shell-detection.ts
+++ b/src/utils/shell-detection.ts
@@ -1,0 +1,23 @@
+const DASH_C_SHELLS = new Set(["bash", "sh", "zsh", "ash", "dash"]);
+
+export function preferredShellFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const value = env.SHELL;
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length < 2) return trimmed;
+  const first = trimmed[0];
+  const last = trimmed.at(-1);
+  if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+export function acceptsDashC(shellPath: string): boolean {
+  const normalized = shellPath.replace(/\\/g, "/").toLowerCase();
+  const basename = normalized.split("/").pop() ?? normalized;
+  const name = basename.endsWith(".exe") ? basename.slice(0, -4) : basename;
+  return DASH_C_SHELLS.has(name);
+}


### PR DESCRIPTION
## Summary
- Prefer `$SHELL` on Windows when it names a `-c`-compatible shell, before falling back to PowerShell/cmd.
- Pass the effective env into shell launcher construction across Bash, shell, and exec_command paths.

Fixes #1273.

## Test plan
- [x] `bun test src/tools/shell-launchers.test.ts src/cli/helpers/session-context-windows.test.ts src/utils/shell-context.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)