### PR TITLE
docs(skills): add channel configuration skill

### DIFF
--- a/src/skills/builtin/configuring-channels/SKILL.md
+++ b/src/skills/builtin/configuring-channels/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: configuring-channels
+description: Configures and debugs Letta Code messaging channels such as Telegram, Signal, Discord, Slack, WhatsApp, and custom channels. Use when setting up `letta channels`, pairing chats, installing channel runtimes, editing channel account/routing config, running channel listeners, configuring Signal via signal-cli, diagnosing inbound/outbound MessageChannel delivery, or managing systemd channel services.
+---
+
+# Configuring Channels
+
+Use this skill for Letta Code channel setup and debugging.
+
+Core rule: generated assistant text is not delivered to external users. When handling a routed external channel turn, reply through `MessageChannel` with the routed `channel`, `chat_id`, and `accountId` unless no user-visible reply is appropriate.
+
+## Load the right reference
+
+Start with [operations.md](references/operations.md) for common preflight, account config, routing, pairing, listener/systemd, and smoke-test procedures. Load [troubleshooting.md](references/troubleshooting.md) when something is broken or ambiguous.
+
+Load channel-specific references only when relevant:
+
+- [signal.md](references/signal.md) — Signal, signal-cli, native daemon, captcha/verification, profile/avatar, recipient aliases.
+- [telegram.md](references/telegram.md) — Telegram bots, BotFather tokens, chat IDs, rich messages, groups/topics, routed replies.
+- [discord.md](references/discord.md) — Discord bots, privileged intents, guild modes, allowed channels, threads, reactions.
+- [slack.md](references/slack.md) — Slack Socket Mode, xoxb/xapp tokens, scopes/events, slash command, reactions/files.
+- [whatsapp.md](references/whatsapp.md) — WhatsApp linked-device QR, self-chat vs dedicated number, groups/media/voice.
+- [custom.md](references/custom.md) — custom channel config, arbitrary account JSON, scaffolding new first-party or local integrations.
+
+If the user asks about an unlisted channel, inspect `src/channels/<channel>/plugin.ts`, `setup.ts`, `account-config.ts`, and tests before editing config or docs.
+
+## Fast workflow
+
+1. Identify the canonical Letta Code checkout and version.
+2. Inspect `./letta.js channels status` and existing routes before changing anything.
+3. Install/configure the channel runtime through `./letta.js channels install <channel>` and `./letta.js channels configure <channel>` when possible.
+4. For long-running listeners, update the service channel list and restart `letta-channels.service` after config, route, or account changes that were not made through a live WS/UI path.
+5. Pair the chat to the target agent/conversation, then list routes to confirm.
+6. Smoke-test both directions: platform → `<channel-notification>` and `MessageChannel` → platform.
+7. Record reusable gotchas in the relevant reference or channel README when setup required non-obvious recovery. Human setup instructions belong in channel READMEs; agent operation/diagnosis patterns belong in this skill.
+
+## Safety rules
+
+- Do not print tokens, app passwords, Signal captcha URLs, raw private message bodies, or verification codes in durable logs or docs.
+- Prefer dedicated bot/agent accounts or numbers over personal accounts unless the user explicitly wants self-chat mode.
+- Preserve channel-specific chat target formats, especially `signal:` prefixes, Slack thread targets, Discord thread IDs, and Telegram topic/thread IDs.
+- Do not commit channel config, local account files, downloaded media, or secrets.
+- Do not commit repo changes unless the user explicitly asks.

--- a/src/skills/builtin/configuring-channels/references/custom.md
+++ b/src/skills/builtin/configuring-channels/references/custom.md
@@ -1,0 +1,38 @@
+# Custom channels
+
+Use for local/prototype channel integrations and arbitrary remote-service account config.
+
+## Source files
+
+- Plugin/setup/scaffolding: `src/channels/custom/plugin.ts`, `scaffolding.ts`.
+- Account/config/inbound-outbound: `account-config.ts`, `adapter.ts`.
+- High-signal tests: `src/channels/custom-account-config.test.ts`, `custom-adapter.test.ts`, plus generic channel registry/routing/message-channel tests when custom behavior touches shared infrastructure.
+
+## Existing custom adapter
+
+The generic custom channel accepts user-supplied account/config JSON and a token shape rather than a first-party setup wizard.
+
+Source of truth:
+
+- `src/channels/custom/plugin.ts`
+- `src/channels/custom/account-config.ts`
+- `src/channels/custom/scaffolding.ts`
+
+Important config inputs:
+
+- `accounts_json`: JSON array describing remote accounts.
+- `configs_json`: JSON object/array for service-level config.
+- `agent_id`: default routing target where supported.
+- Any other values must be validated by the custom adapter or scaffolding before use.
+
+## When adding a first-party channel
+
+Prefer a real channel plugin over overloading custom config when the channel will be maintained:
+
+- `plugin.ts` declares metadata, runtime packages/modules, adapter, message actions, and setup.
+- `setup.ts` handles interactive configuration and secret storage.
+- `account-config.ts` validates editable account config and snapshots.
+- `adapter.ts` handles inbound normalization and outbound actions.
+- Tests should cover config parsing, registry/routing, MessageChannel actions, media, and error replies.
+
+Follow existing channel patterns for Telegram, Discord, Slack, WhatsApp, or Signal rather than inventing a parallel config system.

--- a/src/skills/builtin/configuring-channels/references/discord.md
+++ b/src/skills/builtin/configuring-channels/references/discord.md
@@ -1,0 +1,50 @@
+# Discord channel
+
+Use for Discord bot setup, guild/DM routing, allowed channels, threads, reactions, media, and privileged intents.
+
+## Source files
+
+- Plugin/runtime/setup: `src/channels/discord/plugin.ts`, `runtime.ts`, `setup.ts`.
+- Account/config/routing gates: `account-config.ts`, `channel-gating.ts`, `debounce.ts`.
+- Inbound/outbound/media/errors: `adapter.ts`, `message-actions.ts`, `media.ts`, `error-reply.ts`.
+- High-signal tests: `src/channels/discord-service.test.ts`, `discord-registry.test.ts`, `discord-reconcile.test.ts`, `discord-channel-gating.test.ts`, `discord-adapter.test.ts`, `discord-media.test.ts`, `discord-error-reply.test.ts`, and Discord cases in `src/channels/message-channel.test.ts`.
+
+## Setup
+
+Create a Discord application and bot at <https://discord.com/developers>, then run:
+
+```bash
+./letta.js channels install discord
+./letta.js channels configure discord
+./letta.js server --channels discord
+```
+
+Recommended bot permissions: Send Messages, Read Message History, Add Reactions, Create Public Threads, Send Messages in Threads, Attach Files.
+
+Enable Message Content privileged intent when the bot must read non-mention guild text, replies, or thread messages. Mention-only workflows may still need it depending on the interaction shape.
+
+Important config fields:
+
+- `token`: bot token; never print or commit.
+- `agent_id`: account-bound routing target for DMs and guild mentions.
+- `allowed_channels`: array or map of channel IDs to `open`/`mention-only`.
+- `default_permission_mode`: `standard`, `acceptEdits`, or `unrestricted`.
+- `auto_thread_on_mention`: create thread after mention.
+- `thread_policy_by_channel`: per-channel thread behavior.
+- `acknowledge_message_reaction`: sends acknowledgment reactions.
+- `remove_stale_routes`: route reconciliation can remove disallowed channel routes when true.
+- `inbound_debounce_ms`, `transcribe_voice`.
+
+## Routing behavior
+
+- DMs usually use pairing unless `dm_policy` is `open` or allowlisted.
+- Guild mention mode creates/routes only explicit mentions or existing routed threads.
+- Open guild mode should be restricted with `allowed_channels`; do not let a bot answer every channel accidentally.
+- Thread routes have both parent channel and thread context; preserve `threadId` on replies.
+
+## Common gotchas
+
+- Discord reactions may be disabled by policy or missing permissions even when text works.
+- Stale route reconciliation is deliberately conservative unless `remove_stale_routes` is true.
+- A bot can be installed but unable to read/send in a channel due to Discord role/channel permissions.
+- Do not broaden intents/permissions in the developer portal without user approval.

--- a/src/skills/builtin/configuring-channels/references/operations.md
+++ b/src/skills/builtin/configuring-channels/references/operations.md
@@ -1,0 +1,103 @@
+# Channel operations
+
+Use this reference for common channel setup and debugging before loading a channel-specific reference.
+
+## Source of truth
+
+- Channel source code: `src/channels/<channel>/`.
+- Built-in channel plugins: `src/channels/<channel>/plugin.ts`.
+- Setup wizard: `src/channels/<channel>/setup.ts`.
+- Account config validation: `src/channels/<channel>/account-config.ts`.
+- User config root: `~/.letta/channels/<channel>/`.
+- Common files: `accounts.json`, `routing.yaml`, `pairing.yaml`, `targets.json`.
+- Bundled built-in skills source: `src/skills/builtin/`.
+
+## Preflight
+
+```bash
+pwd
+git status --short --branch
+./letta.js --version
+./letta.js channels status
+./letta.js channels route list --channel <channel>
+```
+
+For packaged/root installs, confirm which executable the service uses. A global `letta` wrapper may not be the same checkout as `./letta.js`.
+
+## Configure and run
+
+```bash
+./letta.js channels install <channel>
+./letta.js channels configure <channel>
+./letta.js server --channels <channel>
+```
+
+For a multi-channel service:
+
+```bash
+systemctl --user cat letta-channels.service
+systemctl --user status letta-channels.service --no-pager
+journalctl --user -u letta-channels.service -n 100 --no-pager
+```
+
+If channels run under systemd and the channel set changes, update `ExecStart`, then run:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user restart letta-channels.service
+```
+
+## Pairing and routes
+
+Pair a code to a specific agent/conversation:
+
+```bash
+./letta.js channels pair \
+  --channel <channel> \
+  --code <PAIRING_CODE> \
+  --agent <agent-id> \
+  --conversation <conversation-id>
+```
+
+Then verify:
+
+```bash
+./letta.js channels route list --channel <channel>
+./letta.js channels status
+```
+
+If the CLI reports that a listener restart is needed, restart the listener. Pairing through live UI/WS paths may not require restart.
+
+## Smoke test
+
+A real channel setup is not complete until both paths work:
+
+1. Send a normal platform message and confirm the agent receives a `<channel-notification>`.
+2. Send a user-visible reply with `MessageChannel`, using the notification's `channel`, `chat_id`, and `accountId`.
+3. Confirm the platform displays the reply.
+4. If supported, test media upload/download and reactions separately.
+
+Plain assistant final text is only local to Letta Code; it is not sent to Telegram/Signal/Discord/etc.
+
+## Common failure modes
+
+- Wrong checkout: systemd runs a different `letta.js` or global `letta` than the repo being edited.
+- Runtime missing: `channels status` shows not installed; run `channels install` or the setup wizard.
+- Listener stale: config or routes changed while the listener process is still holding old state.
+- Secrets unavailable: service lacks env files or secret backend access.
+- Account mismatch: outbound `accountId` is omitted or picks a different configured account.
+- Target shape mismatch: thread IDs, topic IDs, Signal UUIDs, Slack cached targets, or Discord thread routes are missing.
+- Local files leaked: inbound attachments/config files should be inspected locally but not committed.
+
+## Documentation updates
+
+Add durable lessons when setup exposed non-obvious recovery:
+
+- minimum supported external tool versions;
+- restart/reload requirements;
+- systemd units or service env files;
+- exact account config fields;
+- pairing route caveats;
+- profile/avatar setup;
+- platform-specific delivery semantics;
+- privacy or secret-handling hazards.

--- a/src/skills/builtin/configuring-channels/references/signal.md
+++ b/src/skills/builtin/configuring-channels/references/signal.md
@@ -1,0 +1,147 @@
+# Signal channel
+
+Use for Signal setup, `signal-cli`, dedicated numbers, linked devices, profile/avatar changes, and Signal-specific send/receive issues.
+
+## Source files
+
+- Plugin/runtime/setup: `src/channels/signal/plugin.ts`, `runtime.ts`, `setup.ts`, `README.md`.
+- Account/config/targeting: `account-config.ts`, `target.ts`, `client.ts`.
+- Inbound/outbound: `adapter.ts`, `message-actions.ts`.
+- High-signal tests: `src/channels/signal/setup.test.ts`, `adapter.test.ts`, `client.test.ts`, `target.test.ts`, plus `src/channels/signal-config.test.ts`, `signal-protocol.test.ts`, `signal-registry.test.ts`, `signal-service.test.ts`.
+
+## Recommended runtime
+
+First-party Signal support talks to a native `signal-cli daemon` or compatible JSON-RPC/SSE bridge at `/api/v1/check`, `/api/v1/rpc`, and `/api/v1/events`.
+
+Prefer `signal-cli >= 0.14.5`. Version 0.13.23 can register but fail verification with opaque errors such as `StatusCode: 499`.
+
+```bash
+signal-cli --version
+```
+
+## Dedicated-number setup
+
+Use one config directory consistently:
+
+```bash
+export SIGNAL_CLI_CONFIG="$HOME/.local/share/signal-cli-letta"
+export SIGNAL_ACCOUNT="+15555550100"
+
+signal-cli -c "$SIGNAL_CLI_CONFIG" -a "$SIGNAL_ACCOUNT" register
+```
+
+If Signal requires captcha, solve <https://signalcaptchas.org/registration/generate.html>, copy the `signalcaptcha://...` URL, and rerun registration with `--captcha`. Do not log or commit captcha URLs.
+
+```bash
+signal-cli -c "$SIGNAL_CLI_CONFIG" -a "$SIGNAL_ACCOUNT" register --captcha 'signalcaptcha://...'
+signal-cli -c "$SIGNAL_CLI_CONFIG" -a "$SIGNAL_ACCOUNT" verify 123456
+```
+
+Registration can de-authenticate other sessions for that phone number. Prefer a dedicated number for bot-style accounts.
+
+## Linked-device setup
+
+For an existing Signal account:
+
+```bash
+signal-cli -c "$SIGNAL_CLI_CONFIG" link -n "Letta Code"
+```
+
+Scan the emitted `sgnl://linkdevice?...` QR/URI from Signal mobile: Settings → Linked Devices → +.
+
+## Native daemon
+
+```bash
+signal-cli -c "$SIGNAL_CLI_CONFIG" daemon \
+  --http 127.0.0.1:8080 \
+  --receive-mode on-connection \
+  --ignore-stories
+```
+
+Health checks:
+
+```bash
+curl -i --max-time 2 http://127.0.0.1:8080/api/v1/check
+curl -i --max-time 2 -N http://127.0.0.1:8080/api/v1/events
+```
+
+Useful user systemd unit at `~/.config/systemd/user/signal-cli-letta.service`:
+
+```ini
+[Unit]
+Description=Signal CLI daemon for Letta Code
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=%h/.local/bin/signal-cli -c %h/.local/share/signal-cli-letta daemon --http 127.0.0.1:8080 --receive-mode on-connection --ignore-stories
+Restart=always
+RestartSec=5
+KillSignal=SIGTERM
+TimeoutStopSec=20
+
+[Install]
+WantedBy=default.target
+```
+
+Enable it:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now signal-cli-letta.service
+```
+
+## Letta configuration
+
+Run:
+
+```bash
+./letta.js channels configure signal
+```
+
+The wizard can use native `signal-cli` commands or `signal-cli-rest-api` setup endpoints when available. Native `signal-cli daemon` exposes runtime endpoints but not the wrapper `/v1/*` setup endpoints.
+
+Signal account config lives in `~/.letta/channels/signal/accounts.json`.
+
+Important fields:
+
+- `accountId`: local Letta label, not phone number.
+- `base_url`: usually `http://127.0.0.1:8080`.
+- `account`: Signal E.164 number.
+- `agent_id`: optional account-bound auto-routing agent.
+- `self_chat_mode`: personal-number Note to Self mode.
+- `dm_policy`: `pairing`, `allowlist`, or `open`.
+- `group_mode`: `disabled`, `mention`, or `open`.
+- `recipient_aliases`: map inbound UUIDs to replyable E.164 recipients when native Signal receives a UUID but outbound send needs a phone number.
+- `download_media`, `media_max_bytes`, `transcribe_voice`: inbound media/voice behavior.
+
+## Profile name/avatar
+
+Update the Signal profile with:
+
+```bash
+signal-cli -c "$SIGNAL_CLI_CONFIG" -a "$SIGNAL_ACCOUNT" updateProfile \
+  --given-name 'Co' \
+  --about 'Letta agent' \
+  --about-emoji '◯' \
+  --avatar /path/to/avatar.jpg
+```
+
+If it waits on a config lock, stop the daemon, update the profile, then start the daemon again.
+
+```bash
+systemctl --user stop signal-cli-letta.service
+signal-cli -c "$SIGNAL_CLI_CONFIG" -a "$SIGNAL_ACCOUNT" updateProfile --given-name 'Co' --avatar /path/to/avatar.jpg
+systemctl --user start signal-cli-letta.service
+```
+
+Client UIs may take a refresh/sync before showing the new name or avatar.
+
+## Signal gotchas
+
+- Preserve `signal:` chat IDs when using `MessageChannel`.
+- If direct `signal-cli send` works but JSON-RPC send fails, restart the daemon.
+- If registration/linking fails while a daemon is running against the same config dir, stop the daemon and retry setup.
+- Native setup-before-daemon is often simpler: register/link first, then start the daemon, then configure Letta.
+- Signal formatting is body text plus body ranges, not Markdown.

--- a/src/skills/builtin/configuring-channels/references/slack.md
+++ b/src/skills/builtin/configuring-channels/references/slack.md
@@ -1,0 +1,53 @@
+# Slack channel
+
+Use for Slack Socket Mode setup, xoxb/xapp tokens, app events, scopes, slash commands, reactions, files, and Slack thread routing.
+
+## Source files
+
+- Plugin/runtime/setup: `src/channels/slack/plugin.ts`, `runtime.ts`, `setup.ts`.
+- Account/config: `account-config.ts`.
+- Inbound/outbound/targets/media: `adapter.ts`, `message-actions.ts`, `target-resolution.ts`, `proactive-accounts.ts`, `media.ts`, `web-api-client.ts`.
+- High-signal tests: `src/channels/slack/adapter.test.ts`, `slack-adapter.test.ts`, `slack-registry.test.ts`, `slack-target-resolution.test.ts`, `slack-media.test.ts`, and Slack cases in `src/channels/message-channel.test.ts`.
+
+## Setup
+
+Slack uses Socket Mode with both a bot token and an app token:
+
+```bash
+./letta.js channels install slack
+./letta.js channels configure slack
+./letta.js server --channels slack
+```
+
+Recommended setup:
+
+- Create a Slack app for the workspace.
+- Enable Socket Mode and create an `xapp-...` app token.
+- Install the app to get an `xoxb-...` bot token.
+- Enable App Home messages.
+- Subscribe to `app_mention`, `message.channels`, `message.groups`, `message.im`, `reaction_added`, and `reaction_removed` as needed.
+- Add `/cancel` if Slack-native cancellation is desired.
+
+Recommended bot scopes include `app_mentions:read`, `channels:history`, `chat:write`, `commands`, `groups:history`, `im:history`, `users:read`, `reactions:read`, `reactions:write`, `files:read`, and `files:write`.
+
+Important config fields:
+
+- `bot_token`: `xoxb-...`; never print or commit.
+- `app_token`: `xapp-...`; never print or commit.
+- `mode`: currently `socket`.
+- `agent_id`: account-bound routing target.
+- `default_permission_mode`: tool permission behavior for Slack-originated turns.
+- `transcribe_voice`, `show_completed_reaction`, `listen_mode`.
+
+## Routing behavior
+
+- Slack DMs are often `open` by default, but allowlist can be used for private workspaces.
+- Preserve Slack thread context for replies. A channel route may still need an active thread target.
+- For proactive sends, prefer explicit cached targets when supported rather than guessing from a channel name.
+
+## Common gotchas
+
+- Bot token and app token are both required for Socket Mode.
+- Missing event subscriptions can make the app appear online but not receive messages.
+- File upload/reaction support depends on scopes.
+- Workspace app installation must be refreshed after adding scopes/events.

--- a/src/skills/builtin/configuring-channels/references/telegram.md
+++ b/src/skills/builtin/configuring-channels/references/telegram.md
@@ -1,0 +1,54 @@
+# Telegram channel
+
+Use for Telegram bot setup, routed Telegram replies, chat IDs, groups/topics, media/reactions, and rich/private message behavior.
+
+## Source files
+
+- Plugin/runtime/setup: `src/channels/telegram/plugin.ts`, `runtime.ts`, `setup.ts`.
+- Account/config: `account-config.ts`.
+- Inbound/outbound/media: `adapter.ts`, `message-actions.ts`, `media.ts`, `debounce.ts`.
+- High-signal tests: `src/channels/telegram-account-config.test.ts`, `telegram-adapter.test.ts`, `telegram-registry.test.ts`, `telegram-live-smoke.test.ts`, and Telegram cases in `src/channels/message-channel.test.ts`.
+
+## Setup
+
+Create a bot with @BotFather and run:
+
+```bash
+./letta.js channels install telegram
+./letta.js channels configure telegram
+./letta.js server --channels telegram
+```
+
+The setup wizard validates the token with Telegram, then writes `~/.letta/channels/telegram/accounts.json` using secret storage when available.
+
+Important config fields:
+
+- `token`: bot token; never print or commit.
+- `dm_policy`: `pairing`, `allowlist`, or `open`.
+- `allowed_users`: Telegram user ID allowlist when enabled.
+- `group_mode`: `open` or `mention-only`.
+- `transcribe_voice`: voice memo transcription when `OPENAI_API_KEY` is set.
+- `rich_private_chat_default`: private chats use rich delivery by default unless false.
+- `rich_draft_streaming`: optional draft streaming.
+- `inbound_debounce_ms`: group/topic debounce, capped at 10000 ms.
+
+## Pairing and replies
+
+For routed Telegram turns, use the incoming notification's `chat_id` and `accountId`. Do not assume `$TELEGRAM_CHAT_ID` is the right target for a routed reply.
+
+Telegram external turns require `MessageChannel`; plain assistant final text is not delivered.
+
+Use `send-rich` when the output benefits from rendered Markdown structure. Use `upload-file` for local media; do not try to embed local files in rich Markdown.
+
+## Groups and topics
+
+- Preserve topic/thread IDs from the notification when replying in groups/topics.
+- Mention-only mode should route only explicit mentions or existing routed threads/topics.
+- Debounce group/topic bursts if users send multi-message chunks.
+
+## Common gotchas
+
+- Global bot secrets may exist, but configured channel accounts live under `~/.letta/channels/telegram/`.
+- Telegram `chat_id` can be numeric, negative for groups, or tied to a topic/thread context.
+- Rich/private defaults can make normal `send` messages render through Bot API rich messages depending on account settings.
+- SVG attachments should be uploaded as files, not inlined as images.

--- a/src/skills/builtin/configuring-channels/references/troubleshooting.md
+++ b/src/skills/builtin/configuring-channels/references/troubleshooting.md
@@ -1,0 +1,164 @@
+# Channel troubleshooting
+
+Use this reference when a configured channel does not behave as expected. First classify the failure; do not start editing config at random. Random config edits are how integrations acquire folklore.
+
+## Quick classification
+
+1. **No listener**: service/process is not running, exits, or never starts the channel.
+2. **No inbound**: platform messages do not produce `<channel-notification>` turns.
+3. **Inbound works, outbound fails**: agent receives messages but `MessageChannel` send/react/upload fails.
+4. **Pairing/route failure**: pairing code exists but route is missing, stale, disabled, or bound to the wrong agent/conversation.
+5. **Wrong account/target**: replies go from the wrong bot/account or to the wrong chat/thread/topic.
+6. **Media/reaction failure**: text works but upload, download, transcription, or reactions fail.
+7. **Formatting failure**: message arrives but rich text, thread placement, quote/reply, or Markdown/body-ranges are wrong.
+
+## Baseline checks
+
+```bash
+pwd
+git status --short --branch
+./letta.js --version
+./letta.js channels status
+./letta.js channels route list --channel <channel>
+systemctl --user status letta-channels.service --no-pager
+journalctl --user -u letta-channels.service -n 150 --no-pager
+```
+
+Confirm the listener service uses the checkout you are editing:
+
+```bash
+systemctl --user cat letta-channels.service
+```
+
+If a global `letta` command and `./letta.js` disagree, trust the executable used by the service.
+
+## No listener or channel not started
+
+Symptoms:
+
+- `systemctl` inactive/failed.
+- Logs show missing runtime module.
+- `channels status` says runtime is not installed.
+- Service `ExecStart` omits the channel.
+
+Actions:
+
+1. Run `./letta.js channels install <channel>` or rerun setup.
+2. Ensure the service `ExecStart` includes the channel in `--channels`.
+3. Run `systemctl --user daemon-reload` after unit edits.
+4. Restart and re-check logs.
+5. If runtime packages are installed under a packaged channel runtime, inspect `src/channels/<channel>/runtime.ts` and `src/channels/runtime-deps.ts`.
+
+## No inbound
+
+Symptoms:
+
+- Platform message is visible in the external app but no `<channel-notification>` arrives.
+- Listener is running and not obviously failing.
+
+Actions:
+
+1. Check platform-side permissions/intents/events/scopes.
+2. Confirm the channel account is enabled in `accounts.json`.
+3. Confirm DM/group/open/mention policy allows the incoming message.
+4. Check route/pairing behavior: a first unpaired DM may only return pairing instructions.
+5. Inspect channel adapter logs around inbound normalization.
+6. For group/thread/topic channels, confirm the bot can see that venue and preserve topic/thread IDs.
+
+Channel-specific likely causes:
+
+- Telegram: bot privacy/group mode/topic mismatch.
+- Discord: missing Message Content intent, role/channel permissions, or not mentioned in mention-only mode.
+- Slack: missing Socket Mode, event subscription, or app not reinstalled after scopes changed.
+- Signal: daemon not connected, wrong config dir, account not registered, or self-chat/group policy filters it.
+- WhatsApp: QR linked-device session missing/expired, self-chat mode filtering other chats.
+
+## Inbound works, outbound fails
+
+Symptoms:
+
+- Agent receives the message.
+- `MessageChannel` send/react/upload errors or silently sends nowhere.
+
+Actions:
+
+1. Use the exact `channel`, `chat_id`, and `accountId` from the notification.
+2. Preserve `threadId`, Telegram topic IDs, Discord thread IDs, and Slack thread context when present.
+3. Check `message-actions.ts` for expected target shape.
+4. Confirm outbound permissions/scopes include send/upload/react as needed.
+5. Check cached targets in `targets.json` for proactive sends.
+6. Restart the listener if config/routes changed outside the live UI/WS path.
+
+Channel-specific likely causes:
+
+- Signal: inbound sender is a UUID but outbound needs E.164; add `recipient_aliases` or use the replyable target.
+- Telegram: local media must use `upload-file`; rich Markdown media blocks require HTTP/HTTPS URLs.
+- Discord: bot lacks channel/thread send permissions or thread is archived/locked.
+- Slack: file/reaction scopes missing; thread target missing.
+- WhatsApp: linked session stale or JID shape mismatch.
+
+## Pairing or route failure
+
+Symptoms:
+
+- Pairing code is consumed but messages still do not route.
+- Route points at wrong agent/conversation.
+- CLI says restart is required.
+
+Actions:
+
+```bash
+./letta.js channels route list --channel <channel>
+./letta.js channels status
+```
+
+1. Confirm the code was paired to the intended agent and conversation.
+2. Confirm route is enabled and `outboundEnabled` is not false.
+3. Restart the listener if pairing happened through CLI and the listener does not hot-reload the store.
+4. For account-bound routing, confirm the account has the right `agent_id`/binding.
+5. Remove or replace stale routes only after checking whether they are intentionally preserved.
+
+## Wrong account or wrong target
+
+Symptoms:
+
+- Another bot/account replies.
+- Reply appears in the wrong chat, thread, group, topic, or self-chat.
+
+Actions:
+
+1. Inspect `accounts.json` and route `accountId` values.
+2. Always pass explicit `accountId` when replying from a routed turn.
+3. Preserve `chat_id` exactly, including prefixes like `signal:`.
+4. Inspect channel target resolution code and `targets.json` for proactive sends.
+5. Check for duplicate accounts with overlapping permissions.
+
+## Media, voice, reactions, and formatting
+
+Text success does not imply media success.
+
+- Media download/upload depends on channel runtime support, local file readability, size caps, and platform scopes.
+- Voice transcription requires `OPENAI_API_KEY` and often `ffmpeg` or platform-specific audio conversion.
+- Reactions require platform permissions/scopes and sometimes message IDs that encode author/timestamp.
+- Rich formatting is channel-specific: Telegram has rich Markdown helpers; Signal uses body text/bodyRanges; Discord and Slack have their own markdown-ish rules.
+
+Inspect `media.ts`, `message-actions.ts`, and `message-channel.test.ts` before changing behavior.
+
+## When to restart
+
+Restart after:
+
+- systemd unit edits;
+- changing `--channels` list;
+- manual edits to `accounts.json`, `routing.yaml`, `targets.json`, or `pairing.yaml`;
+- Signal account registration/link/profile updates that require stopping the daemon;
+- runtime dependency installation;
+- stale config symptoms after a CLI operation.
+
+Do not restart blindly in the middle of interactive linking/registration unless the external tool is wedged.
+
+## What to update after debugging
+
+- Update a channel README when a human needs setup instructions.
+- Update this skill when an agent needs a reusable diagnostic or operational pattern.
+- Update source/tests when behavior is wrong or the setup wizard can prevent the failure.

--- a/src/skills/builtin/configuring-channels/references/whatsapp.md
+++ b/src/skills/builtin/configuring-channels/references/whatsapp.md
@@ -1,0 +1,42 @@
+# WhatsApp channel
+
+Use for WhatsApp linked-device setup, QR scanning, self-chat mode, groups, media, and voice transcription.
+
+## Source files
+
+- Plugin/runtime/setup: `src/channels/whatsapp/plugin.ts`, `runtime.ts`, `setup.ts`.
+- Account/session/state: `account-config.ts`, `session.ts`, `state.ts`, `jid.ts`.
+- Inbound/outbound/media: `adapter.ts`, `message-actions.ts`, `media.ts`.
+- High-signal tests: `src/channels/whatsapp-service.test.ts`, `whatsapp-protocol.test.ts`, `whatsapp-session.test.ts`, `whatsapp-jid.test.ts`, `whatsapp-adapter.test.ts`, `whatsapp-media.test.ts`, `whatsapp-message-channel.test.ts`.
+
+## Setup
+
+WhatsApp uses a linked-device runtime and QR login:
+
+```bash
+./letta.js channels install whatsapp
+./letta.js channels configure whatsapp
+./letta.js server --channels whatsapp
+```
+
+After starting the listener, scan the QR from WhatsApp: Settings → Linked Devices → Link a Device.
+
+Important config fields:
+
+- `agent_id`: optional account-bound routing target.
+- `self_chat_mode`: talk to the agent by messaging yourself; recommended for personal numbers.
+- `group_mode`: `disabled`, `mention`, or `open`.
+- `allowed_groups`: group JID allowlist.
+- `mention_patterns`: aliases or regexes for mention mode.
+- `download_media`, `media_max_bytes`, `transcribe_voice`.
+
+## Self-chat vs dedicated number
+
+If using a personal WhatsApp number, prefer self-chat mode so the agent does not send ordinary messages as the user. If using a dedicated WhatsApp number for the agent, disable self-chat only after confirming the user understands replies will come from that number.
+
+## Common gotchas
+
+- QR login happens after the listener starts; configuration alone is not a complete login.
+- Linked-device sessions can expire or be revoked from WhatsApp clients.
+- Group JIDs and user JIDs are not always the same shape as phone numbers.
+- Media download and transcription require runtime support and may fail independently from text delivery.


### PR DESCRIPTION
## Summary
- add a built-in `configuring-channels` skill for Letta Code channel setup, pairing, listener operations, and smoke tests
- split guidance into progressive references for Signal, Telegram, Discord, Slack, WhatsApp, custom channels, common operations, and troubleshooting
- include source-file/test pointers so agents can find canonical channel implementation details instead of relying on stale procedural notes

## Test plan
- `bun src/skills/builtin/creating-skills/scripts/validate-skill.ts src/skills/builtin/configuring-channels`
- `bun run check`

👾 Generated with [Letta Code](https://letta.com)