### PR TITLE
fix(app-server): Fix app-server runTurn approval terminality

### DIFF
--- a/src/app-server-client.test.ts
+++ b/src/app-server-client.test.ts
@@ -318,6 +318,153 @@ describe("app-server client", () => {
     });
   });
 
+  test("runTurn waits through intermediate requires_approval stop_reason", async () => {
+    const { client, control, stream } = createFakeClient();
+    control.open();
+    stream.open();
+    await client.connect();
+
+    const runtime = { agent_id: "agent-1", conversation_id: "conv-1" };
+    const turn = client.runTurn({
+      runtime,
+      payload: {
+        kind: "create_message",
+        messages: [{ role: "user", content: "use a tool" }],
+      },
+    });
+
+    stream.receive({
+      type: "stream_delta",
+      runtime,
+      event_seq: 1,
+      emitted_at: "2026-06-11T00:00:00.000Z",
+      idempotency_key: "stream-1",
+      delta: {
+        type: "message",
+        message_type: "approval_request_message",
+        run_id: "run-approval",
+        tool_calls: [
+          {
+            tool_call_id: "call-1",
+            name: "Bash",
+            arguments: '{"command":"pwd"}',
+          },
+        ],
+      },
+    });
+    stream.receive({
+      type: "stream_delta",
+      runtime,
+      event_seq: 2,
+      emitted_at: "2026-06-11T00:00:00.001Z",
+      idempotency_key: "stream-2",
+      delta: {
+        type: "message",
+        message_type: "stop_reason",
+        run_id: "run-approval",
+        stop_reason: "requires_approval",
+      },
+    });
+    stream.receive({
+      type: "update_loop_status",
+      runtime,
+      event_seq: 3,
+      emitted_at: "2026-06-11T00:00:00.002Z",
+      idempotency_key: "loop-1",
+      loop_status: {
+        status: "EXECUTING_CLIENT_SIDE_TOOL",
+        active_run_ids: ["run-approval"],
+      },
+    });
+    stream.receive({
+      type: "stream_delta",
+      runtime,
+      event_seq: 4,
+      emitted_at: "2026-06-11T00:00:00.003Z",
+      idempotency_key: "stream-3",
+      delta: {
+        type: "message",
+        message_type: "stop_reason",
+        run_id: "run-final",
+        stop_reason: "end_turn",
+      },
+    });
+
+    expect(await turn).toMatchObject({
+      runtime,
+      stopReason: "end_turn",
+      runIds: ["run-approval", "run-final"],
+      completedBy: "stop_reason",
+    });
+  });
+
+  test("runTurn resolves requires_approval only when listener is waiting on approval", async () => {
+    const { client, control, stream } = createFakeClient();
+    control.open();
+    stream.open();
+    await client.connect();
+
+    const runtime = { agent_id: "agent-1", conversation_id: "conv-1" };
+    const turn = client.runTurn({
+      runtime,
+      payload: {
+        kind: "create_message",
+        messages: [{ role: "user", content: "use a tool" }],
+      },
+    });
+
+    stream.receive({
+      type: "stream_delta",
+      runtime,
+      event_seq: 1,
+      emitted_at: "2026-06-11T00:00:00.000Z",
+      idempotency_key: "stream-1",
+      delta: {
+        type: "message",
+        message_type: "approval_request_message",
+        run_id: "run-approval",
+        tool_calls: [
+          {
+            tool_call_id: "call-1",
+            name: "Bash",
+            arguments: '{"command":"rm -rf tmp"}',
+          },
+        ],
+      },
+    });
+    stream.receive({
+      type: "stream_delta",
+      runtime,
+      event_seq: 2,
+      emitted_at: "2026-06-11T00:00:00.001Z",
+      idempotency_key: "stream-2",
+      delta: {
+        type: "message",
+        message_type: "stop_reason",
+        run_id: "run-approval",
+        stop_reason: "requires_approval",
+      },
+    });
+    stream.receive({
+      type: "update_loop_status",
+      runtime,
+      event_seq: 3,
+      emitted_at: "2026-06-11T00:00:00.002Z",
+      idempotency_key: "loop-1",
+      loop_status: {
+        status: "WAITING_ON_APPROVAL",
+        active_run_ids: ["run-approval"],
+      },
+    });
+
+    expect(await turn).toMatchObject({
+      runtime,
+      stopReason: "requires_approval",
+      runIds: ["run-approval"],
+      completedBy: "loop_status_waiting_on_approval",
+    });
+  });
+
   test("runTurn does not treat idle status alone as terminal", async () => {
     const { client, control, stream } = createFakeClient();
     control.open();

--- a/src/app-server-client.ts
+++ b/src/app-server-client.ts
@@ -86,6 +86,7 @@ type PendingRequest = {
 
 export type AppServerTurnCompletionSource =
   | "stop_reason"
+  | "loop_status_waiting_on_approval"
   | "loop_status_waiting_fallback";
 
 export interface AppServerTurnResult {
@@ -231,6 +232,12 @@ function sameRuntime(a: RuntimeScope | undefined, b: RuntimeScope): boolean {
 
 function isWaitingLoopStatus(message: LoopStatusUpdateMessage): boolean {
   return message.loop_status.status === "WAITING_ON_INPUT";
+}
+
+function isWaitingOnApprovalLoopStatus(
+  message: LoopStatusUpdateMessage,
+): boolean {
+  return message.loop_status.status === "WAITING_ON_APPROVAL";
 }
 
 function streamDeltaRunId(message: StreamDeltaMessage): string | null {
@@ -510,6 +517,7 @@ export class AppServerClient {
     const commandWithIds = this.withClientMessageIds(command);
     const runIds = new Set<string>();
     let observedTurnEvidence = false;
+    let observedRequiresApprovalStop = false;
 
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
@@ -569,7 +577,12 @@ export class AppServerClient {
             return;
           }
           if (messageType === "stop_reason") {
-            finish("stop_reason", message, streamDeltaStopReason(message));
+            const stopReason = streamDeltaStopReason(message);
+            if (stopReason === "requires_approval") {
+              observedRequiresApprovalStop = true;
+              return;
+            }
+            finish("stop_reason", message, stopReason);
           }
           return;
         }
@@ -578,6 +591,17 @@ export class AppServerClient {
           for (const runId of message.loop_status.active_run_ids) {
             observedTurnEvidence = true;
             runIds.add(runId);
+          }
+          if (
+            (observedTurnEvidence || observedRequiresApprovalStop) &&
+            isWaitingOnApprovalLoopStatus(message)
+          ) {
+            finish(
+              "loop_status_waiting_on_approval",
+              message,
+              "requires_approval",
+            );
+            return;
           }
           if (
             options.allowLoopStatusFallback === true &&


### PR DESCRIPTION
## Summary

This fixes an app-server client terminality bug that we uncovered while working on the `letta-code-sdk` remote/app-server PR (`LET-9237`).

The SDK live integration tests were running turns with:

- SDK `permissionMode: "bypassPermissions"`
- app-server runtime mode `"unrestricted"`

In that mode, complete tool approvals should be auto-allowed by the app-server listener, executed client-side, and then continued to the final model stop reason. Instead, the SDK sometimes saw a terminal SDK result with:

```ts
stopReason: "requires_approval"
approvalConflict: true
```

That looked at first like an SDK mapping issue, but tracing the live stream through `letta-code` showed the SDK was faithfully reflecting a premature result from the exported app-server client helper.

## Root cause

The listener path treats `requires_approval` as an intermediate backend/model boundary, not necessarily as a terminal turn state:

1. The backend stream emits `stop_reason: "requires_approval"`.
2. `src/websocket/listener/turn.ts` routes that through `handleApprovalStop(...)` rather than ending the turn.
3. Under scoped permission mode `"unrestricted"`, `src/websocket/listener/turn-approval.ts` auto-allows complete approvals, executes the tool batch, emits tool returns, sends the approval continuation, and continues to the final stop reason.

However, exported `AppServerClient.runTurn()` resolved on **any** stream delta whose `message_type` was `"stop_reason"`, including the intermediate `requires_approval` stop. That made SDK consumers believe the turn had ended before the listener had a chance to execute and continue the auto-approved tool call.

So the bug is in the upstream app-server client helper's definition of terminality, not in the SDK:

> Raw `stop_reason: "requires_approval"` is not terminal by itself. It is terminal only if the listener loop actually reaches `WAITING_ON_APPROVAL`.

## Fix

- `runTurn()` now waits through raw/intermediate `stop_reason: "requires_approval"`.
- It terminalizes approval conflict only when an `update_loop_status` frame reports `WAITING_ON_APPROVAL` for the same runtime/turn evidence.
- Existing final stop reasons like `end_turn` still resolve via `completedBy: "stop_reason"`.
- The guarded `WAITING_ON_INPUT` fallback behavior is preserved.

## Regression coverage

Added app-server client tests for both sides of the distinction:

1. Auto-handled approval continuation:
   - approval request
   - raw `stop_reason: "requires_approval"`
   - listener status moves to tool execution
   - later final `stop_reason: "end_turn"`
   - `runTurn()` resolves success on `end_turn`, not on `requires_approval`

2. Genuine pending approval:
   - approval request
   - raw `stop_reason: "requires_approval"`
   - listener status becomes `WAITING_ON_APPROVAL`
   - `runTurn()` resolves with `stopReason: "requires_approval"` and `completedBy: "loop_status_waiting_on_approval"`

## SDK validation

After making this upstream fix, I removed the temporary SDK-side workaround and linked the SDK worktree to this locally patched `letta-code` package:

```text
node_modules/@letta-ai/letta-code -> /Users/loaner/dev/letta-code-prod/.letta/worktrees/fix-app-server-requires-approval-terminality
```

Then I reran the stricter SDK tests that no longer tolerate approval conflicts under bypass/unrestricted.

SDK validation against this patched package:

- `bun run check`
- `bun test src/tests/client.test.ts`
- `bun test`
- `LETTA_LIVE_INTEGRATION=1 LETTA_API_KEY=set LETTA_BASE_URL=http://localhost:60736 LETTA_AGENT_ID=agent-6b383e6f-f2df-43ed-ad88-8c832f1129d0 bun test src/tests/live.integration.test.ts`

The live SDK suite passed with the stricter assertions:

```text
8 pass
0 fail
```

## Testing

Upstream tests/checks:

- `bun test src/app-server-client.test.ts`
- `bun run typecheck`
- `bun run check`
