### PR TITLE
feat(app-server): add Codex-style websocket auth guard

### DIFF
--- a/src/app-server-client.test.ts
+++ b/src/app-server-client.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   type AppServerSocketLike,
+  type AppServerSocketOptions,
   createAppServerClient,
   resolveAppServerChannelUrl,
 } from "./app-server-client";
@@ -14,7 +15,10 @@ class FakeSocket implements AppServerSocketLike {
   readonly sent: string[] = [];
   private readonly listeners = new Map<string, Set<Listener>>();
 
-  constructor(readonly url: string) {
+  constructor(
+    readonly url: string,
+    readonly options?: AppServerSocketOptions,
+  ) {
     FakeSocket.instances.push(this);
   }
 
@@ -79,6 +83,29 @@ describe("app-server client", () => {
         "stream",
       ),
     ).toBe("wss://example.test/ws?channel=stream&token=abc");
+  });
+
+  test("passes capability token as websocket authorization header", () => {
+    createAppServerClient({
+      url: "http://127.0.0.1:4500",
+      authToken: " super-secret-token\n",
+      WebSocket: FakeSocket,
+    });
+    const [control, stream] = FakeSocket.instances;
+    expect(control?.options).toEqual({
+      headers: { Authorization: "Bearer super-secret-token" },
+    });
+    expect(stream?.options).toEqual({
+      headers: { Authorization: "Bearer super-secret-token" },
+    });
+
+    expect(() =>
+      createAppServerClient({
+        url: "http://127.0.0.1:4500",
+        authToken: " \n",
+        WebSocket: FakeSocket,
+      }),
+    ).toThrow(/auth token must not be empty/);
   });
 
   test("connects both sockets and resolves request_id responses", async () => {

--- a/src/app-server-client.ts
+++ b/src/app-server-client.ts
@@ -46,13 +46,20 @@ export interface AppServerSocketLike {
   once?(type: string, listener: (event: unknown) => void): void;
 }
 
+export interface AppServerSocketOptions {
+  headers?: Record<string, string>;
+}
+
 export type AppServerSocketConstructor = new (
   url: string,
+  options?: AppServerSocketOptions,
 ) => AppServerSocketLike;
 
 export interface AppServerClientOptions {
   /** Base app-server URL, e.g. ws://127.0.0.1:4500 or http://127.0.0.1:4500. */
   url: string;
+  /** Optional capability token sent as Authorization: Bearer <token>; requires a WebSocket implementation with header support. */
+  authToken?: string;
   /** Optional WebSocket constructor for Node/tests. Browsers use globalThis.WebSocket. */
   WebSocket?: AppServerSocketConstructor;
   /** Default timeout for request_id-correlated control requests. */
@@ -226,6 +233,19 @@ function parseProtocolMessage(event: unknown): WsProtocolMessage {
   return JSON.parse(messageDataToString(event)) as WsProtocolMessage;
 }
 
+function appServerSocketOptions(
+  authToken: string | undefined,
+): AppServerSocketOptions | undefined {
+  if (authToken === undefined) {
+    return undefined;
+  }
+  const token = authToken.trim();
+  if (!token) {
+    throw new Error("app-server auth token must not be empty");
+  }
+  return { headers: { Authorization: `Bearer ${token}` } };
+}
+
 function sameRuntime(a: RuntimeScope | undefined, b: RuntimeScope): boolean {
   return a?.agent_id === b.agent_id && a?.conversation_id === b.conversation_id;
 }
@@ -288,11 +308,14 @@ export class AppServerClient {
 
     this.requestTimeoutMs =
       options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    const socketOptions = appServerSocketOptions(options.authToken);
     this.control = new WebSocket(
       resolveAppServerChannelUrl(options.url, "control"),
+      socketOptions,
     );
     this.stream = new WebSocket(
       resolveAppServerChannelUrl(options.url, "stream"),
+      socketOptions,
     );
 
     attachSocketListener(this.control, "message", (event) => {

--- a/src/cli/subcommands/app-server.ts
+++ b/src/cli/subcommands/app-server.ts
@@ -1,5 +1,6 @@
 import { parseArgs } from "node:util";
 import { startAppServer } from "@/websocket/app-server";
+import { parseAppServerWebsocketAuthSettings } from "@/websocket/app-server-auth";
 
 function printAppServerHelp(): void {
   console.log(
@@ -9,11 +10,15 @@ Run a local Letta Code app-server using native v2 websocket frames.
 
 Options:
   --listen <url>  WebSocket listen URL. Defaults to ws://127.0.0.1:0
+  --ws-auth <mode>  WebSocket auth mode for non-loopback listeners. Supported: capability-token
+  --ws-token-file <path>  Absolute path to the capability-token file
+  --ws-token-sha256 <hex>  Hex-encoded SHA-256 digest of the capability token
   -h, --help      Show this help message
 
 Examples:
   letta app-server
-  letta app-server --listen ws://127.0.0.1:4500`,
+  letta app-server --listen ws://127.0.0.1:4500
+  letta app-server --listen ws://0.0.0.0:4500 --ws-auth capability-token --ws-token-file /path/to/token`,
   );
 }
 
@@ -50,6 +55,9 @@ export async function runAppServerSubcommand(argv: string[]): Promise<number> {
       options: {
         help: { type: "boolean", short: "h" },
         listen: { type: "string" },
+        "ws-auth": { type: "string" },
+        "ws-token-file": { type: "string" },
+        "ws-token-sha256": { type: "string" },
       },
     });
   } catch (error) {
@@ -63,11 +71,27 @@ export async function runAppServerSubcommand(argv: string[]): Promise<number> {
   }
 
   try {
+    const websocketAuth = parseAppServerWebsocketAuthSettings({
+      wsAuth:
+        typeof parsed.values["ws-auth"] === "string"
+          ? parsed.values["ws-auth"]
+          : undefined,
+      wsTokenFile:
+        typeof parsed.values["ws-token-file"] === "string"
+          ? parsed.values["ws-token-file"]
+          : undefined,
+      wsTokenSha256:
+        typeof parsed.values["ws-token-sha256"] === "string"
+          ? parsed.values["ws-token-sha256"]
+          : undefined,
+    });
+
     const handle = await startAppServer({
       listen:
         typeof parsed.values.listen === "string"
           ? parsed.values.listen
           : undefined,
+      websocketAuth,
       onListening: (info) => {
         console.log(`Listening on ${info.url}`);
         console.log(`Control: ${info.controlUrl}`);

--- a/src/cli/subcommands/app-server.ts
+++ b/src/cli/subcommands/app-server.ts
@@ -10,15 +10,20 @@ Run a local Letta Code app-server using native v2 websocket frames.
 
 Options:
   --listen <url>  WebSocket listen URL. Defaults to ws://127.0.0.1:0
-  --ws-auth <mode>  WebSocket auth mode for non-loopback listeners. Supported: capability-token
+  --ws-auth <mode>  WebSocket auth mode for non-loopback listeners. Supported: capability-token, signed-bearer-token
   --ws-token-file <path>  Absolute path to the capability-token file
   --ws-token-sha256 <hex>  Hex-encoded SHA-256 digest of the capability token
+  --ws-shared-secret-file <path>  Absolute path to the shared secret file for signed JWT bearer tokens
+  --ws-issuer <issuer>  Expected issuer for signed JWT bearer tokens
+  --ws-audience <audience>  Expected audience for signed JWT bearer tokens
+  --ws-max-clock-skew-seconds <seconds>  Maximum clock skew for signed JWT bearer token validation
   -h, --help      Show this help message
 
 Examples:
   letta app-server
   letta app-server --listen ws://127.0.0.1:4500
-  letta app-server --listen ws://0.0.0.0:4500 --ws-auth capability-token --ws-token-file /path/to/token`,
+  letta app-server --listen ws://0.0.0.0:4500 --ws-auth capability-token --ws-token-file /path/to/token
+  letta app-server --listen ws://0.0.0.0:4500 --ws-auth signed-bearer-token --ws-shared-secret-file /path/to/secret`,
   );
 }
 
@@ -58,6 +63,10 @@ export async function runAppServerSubcommand(argv: string[]): Promise<number> {
         "ws-auth": { type: "string" },
         "ws-token-file": { type: "string" },
         "ws-token-sha256": { type: "string" },
+        "ws-shared-secret-file": { type: "string" },
+        "ws-issuer": { type: "string" },
+        "ws-audience": { type: "string" },
+        "ws-max-clock-skew-seconds": { type: "string" },
       },
     });
   } catch (error) {
@@ -83,6 +92,22 @@ export async function runAppServerSubcommand(argv: string[]): Promise<number> {
       wsTokenSha256:
         typeof parsed.values["ws-token-sha256"] === "string"
           ? parsed.values["ws-token-sha256"]
+          : undefined,
+      wsSharedSecretFile:
+        typeof parsed.values["ws-shared-secret-file"] === "string"
+          ? parsed.values["ws-shared-secret-file"]
+          : undefined,
+      wsIssuer:
+        typeof parsed.values["ws-issuer"] === "string"
+          ? parsed.values["ws-issuer"]
+          : undefined,
+      wsAudience:
+        typeof parsed.values["ws-audience"] === "string"
+          ? parsed.values["ws-audience"]
+          : undefined,
+      wsMaxClockSkewSeconds:
+        typeof parsed.values["ws-max-clock-skew-seconds"] === "string"
+          ? parsed.values["ws-max-clock-skew-seconds"]
           : undefined,
     });
 

--- a/src/websocket/app-server-auth.ts
+++ b/src/websocket/app-server-auth.ts
@@ -1,27 +1,41 @@
-import { createHash, timingSafeEqual } from "node:crypto";
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import type { IncomingHttpHeaders } from "node:http";
 import { isIP } from "node:net";
 import { isAbsolute } from "node:path";
 
 const INVALID_AUTHORIZATION_HEADER_MESSAGE = "invalid authorization header";
+const DEFAULT_MAX_CLOCK_SKEW_SECONDS = 30;
+const MIN_SIGNED_BEARER_SECRET_BYTES = 32;
 
-export type WebsocketAuthCliMode = "capability-token";
+export type WebsocketAuthCliMode = "capability-token" | "signed-bearer-token";
 
 export interface AppServerWebsocketAuthArgs {
   wsAuth?: string;
   wsTokenFile?: string;
   wsTokenSha256?: string;
+  wsSharedSecretFile?: string;
+  wsIssuer?: string;
+  wsAudience?: string;
+  wsMaxClockSkewSeconds?: string | number;
 }
 
 export interface AppServerWebsocketAuthSettings {
   config?: AppServerWebsocketAuthConfig;
 }
 
-export type AppServerWebsocketAuthConfig = {
-  mode: WebsocketAuthCliMode;
-  source: AppServerWebsocketCapabilityTokenSource;
-};
+export type AppServerWebsocketAuthConfig =
+  | {
+      mode: "capability-token";
+      source: AppServerWebsocketCapabilityTokenSource;
+    }
+  | {
+      mode: "signed-bearer-token";
+      sharedSecretFile: string;
+      issuer?: string;
+      audience?: string;
+      maxClockSkewSeconds: number;
+    };
 
 export type AppServerWebsocketCapabilityTokenSource =
   | { type: "token-file"; tokenFile: string }
@@ -31,10 +45,18 @@ export interface WebsocketAuthPolicy {
   mode?: WebsocketAuthMode;
 }
 
-type WebsocketAuthMode = {
-  type: "capability-token";
-  tokenSha256: Buffer;
-};
+type WebsocketAuthMode =
+  | {
+      type: "capability-token";
+      tokenSha256: Buffer;
+    }
+  | {
+      type: "signed-bearer-token";
+      sharedSecret: Buffer;
+      issuer?: string;
+      audience?: string;
+      maxClockSkewSeconds: number;
+    };
 
 export interface WebsocketAuthError {
   statusCode: number;
@@ -44,17 +66,32 @@ export interface WebsocketAuthError {
 export function parseAppServerWebsocketAuthSettings(
   args: AppServerWebsocketAuthArgs,
 ): AppServerWebsocketAuthSettings {
+  const hasSignedBearerFlag = Boolean(
+    args.wsSharedSecretFile !== undefined ||
+      args.wsIssuer !== undefined ||
+      args.wsAudience !== undefined ||
+      args.wsMaxClockSkewSeconds !== undefined,
+  );
   switch (args.wsAuth) {
     case undefined:
-      if (args.wsTokenFile || args.wsTokenSha256) {
+      if (
+        args.wsTokenFile !== undefined ||
+        args.wsTokenSha256 !== undefined ||
+        hasSignedBearerFlag
+      ) {
         throw new Error(
-          "websocket auth flags require `--ws-auth capability-token`",
+          "websocket auth flags require `--ws-auth capability-token` or `--ws-auth signed-bearer-token`",
         );
       }
       return {};
     case "capability-token": {
-      const hasTokenFile = Boolean(args.wsTokenFile);
-      const hasTokenSha256 = Boolean(args.wsTokenSha256);
+      if (hasSignedBearerFlag) {
+        throw new Error(
+          "`--ws-shared-secret-file`, `--ws-issuer`, `--ws-audience`, and `--ws-max-clock-skew-seconds` require `--ws-auth signed-bearer-token`",
+        );
+      }
+      const hasTokenFile = args.wsTokenFile !== undefined;
+      const hasTokenSha256 = args.wsTokenSha256 !== undefined;
       if (hasTokenFile && hasTokenSha256) {
         throw new Error(
           "`--ws-token-file` and `--ws-token-sha256` are mutually exclusive",
@@ -83,9 +120,39 @@ export function parseAppServerWebsocketAuthSettings(
         },
       };
     }
+    case "signed-bearer-token": {
+      if (args.wsTokenFile !== undefined || args.wsTokenSha256 !== undefined) {
+        throw new Error(
+          "`--ws-token-file` and `--ws-token-sha256` require `--ws-auth capability-token`, not `signed-bearer-token`",
+        );
+      }
+      if (args.wsSharedSecretFile === undefined) {
+        throw new Error(
+          "`--ws-shared-secret-file` is required when `--ws-auth signed-bearer-token` is set",
+        );
+      }
+      return {
+        config: {
+          mode: "signed-bearer-token",
+          sharedSecretFile: absolutePathArg(
+            "--ws-shared-secret-file",
+            args.wsSharedSecretFile,
+          ),
+          issuer: normalizeOptionalString(args.wsIssuer),
+          audience: normalizeOptionalString(args.wsAudience),
+          maxClockSkewSeconds:
+            args.wsMaxClockSkewSeconds !== undefined
+              ? nonNegativeIntegerArg(
+                  "--ws-max-clock-skew-seconds",
+                  args.wsMaxClockSkewSeconds,
+                )
+              : DEFAULT_MAX_CLOCK_SKEW_SECONDS,
+        },
+      };
+    }
     default:
       throw new Error(
-        `unsupported --ws-auth mode "${args.wsAuth}"; expected "capability-token"`,
+        `unsupported --ws-auth mode "${args.wsAuth}"; expected "capability-token" or "signed-bearer-token"`,
       );
   }
 }
@@ -109,6 +176,22 @@ export async function policyFromSettings(
               : config.source.tokenSha256,
         },
       };
+    case "signed-bearer-token": {
+      const sharedSecret = Buffer.from(
+        await readTrimmedSecret(config.sharedSecretFile),
+        "utf8",
+      );
+      validateSignedBearerSecret(config.sharedSecretFile, sharedSecret);
+      return {
+        mode: {
+          type: "signed-bearer-token",
+          sharedSecret,
+          issuer: config.issuer,
+          audience: config.audience,
+          maxClockSkewSeconds: config.maxClockSkewSeconds,
+        },
+      };
+    }
   }
 }
 
@@ -156,7 +239,159 @@ export function authorizeUpgrade(
       }
       return unauthorized("invalid websocket bearer token");
     }
+    case "signed-bearer-token":
+      return verifySignedBearerToken(
+        tokenResult,
+        mode.sharedSecret,
+        mode.issuer,
+        mode.audience,
+        mode.maxClockSkewSeconds,
+      );
   }
+}
+
+function verifySignedBearerToken(
+  token: string,
+  sharedSecret: Buffer,
+  issuer: string | undefined,
+  audience: string | undefined,
+  maxClockSkewSeconds: number,
+): WebsocketAuthError | null {
+  const claims = decodeJwtClaims(token, sharedSecret);
+  if ("error" in claims) {
+    return claims.error;
+  }
+  return validateJwtClaims(
+    claims.claims,
+    issuer,
+    audience,
+    maxClockSkewSeconds,
+  );
+}
+
+interface JwtClaims {
+  exp: number;
+  nbf?: number;
+  iss?: string;
+  aud?: string | string[];
+}
+
+function decodeJwtClaims(
+  token: string,
+  sharedSecret: Buffer,
+): { claims: JwtClaims } | { error: WebsocketAuthError } {
+  const parts = token.split(".");
+  const encodedHeader = parts[0];
+  const encodedClaims = parts[1];
+  const encodedSignature = parts[2];
+  if (
+    parts.length !== 3 ||
+    !encodedHeader ||
+    !encodedClaims ||
+    !encodedSignature
+  ) {
+    return { error: unauthorized("invalid websocket jwt") };
+  }
+
+  let header: unknown;
+  let claims: unknown;
+  let actualSignature: Buffer;
+  try {
+    header = JSON.parse(base64UrlDecode(encodedHeader).toString("utf8"));
+    claims = JSON.parse(base64UrlDecode(encodedClaims).toString("utf8"));
+    actualSignature = base64UrlDecode(encodedSignature);
+  } catch {
+    return { error: unauthorized("invalid websocket jwt") };
+  }
+
+  if (!isRecord(header) || header.alg !== "HS256") {
+    return { error: unauthorized("invalid websocket jwt") };
+  }
+
+  const expectedSignature = createHmac("sha256", sharedSecret)
+    .update(`${encodedHeader}.${encodedClaims}`)
+    .digest();
+  if (
+    actualSignature.length !== expectedSignature.length ||
+    !timingSafeEqual(actualSignature, expectedSignature)
+  ) {
+    return { error: unauthorized("invalid websocket jwt") };
+  }
+
+  if (!isJwtClaims(claims)) {
+    return { error: unauthorized("invalid websocket jwt") };
+  }
+  return { claims };
+}
+
+function validateJwtClaims(
+  claims: JwtClaims,
+  issuer: string | undefined,
+  audience: string | undefined,
+  maxClockSkewSeconds: number,
+): WebsocketAuthError | null {
+  const now = Math.floor(Date.now() / 1000);
+  if (now > claims.exp + maxClockSkewSeconds) {
+    return unauthorized("expired websocket jwt");
+  }
+  if (claims.nbf !== undefined && now < claims.nbf - maxClockSkewSeconds) {
+    return unauthorized("websocket jwt is not valid yet");
+  }
+  if (issuer !== undefined && claims.iss !== issuer) {
+    return unauthorized("websocket jwt issuer mismatch");
+  }
+  if (audience !== undefined && !audienceMatches(claims.aud, audience)) {
+    return unauthorized("websocket jwt audience mismatch");
+  }
+  return null;
+}
+
+function audienceMatches(
+  actual: JwtClaims["aud"],
+  expectedAudience: string,
+): boolean {
+  if (typeof actual === "string") {
+    return actual === expectedAudience;
+  }
+  if (Array.isArray(actual)) {
+    return actual.some((audience) => audience === expectedAudience);
+  }
+  return false;
+}
+
+function isJwtClaims(value: unknown): value is JwtClaims {
+  if (!isRecord(value) || !Number.isSafeInteger(value.exp)) {
+    return false;
+  }
+  if (value.nbf !== undefined && !Number.isSafeInteger(value.nbf)) {
+    return false;
+  }
+  if (value.iss !== undefined && typeof value.iss !== "string") {
+    return false;
+  }
+  if (value.aud !== undefined) {
+    if (typeof value.aud === "string") {
+      return true;
+    }
+    if (!Array.isArray(value.aud)) {
+      return false;
+    }
+    return value.aud.every((audience) => typeof audience === "string");
+  }
+  return true;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function base64UrlDecode(value: string): Buffer {
+  if (!/^[A-Za-z0-9_-]*$/.test(value)) {
+    throw new Error("invalid base64url");
+  }
+  const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+  return Buffer.from(`${base64}${padding}`, "base64");
 }
 
 function bearerTokenFromHeaders(
@@ -207,6 +442,32 @@ function absolutePathArg(flagName: string, path: string): string {
     throw new Error(`${flagName} must be an absolute path`);
   }
   return path;
+}
+
+function nonNegativeIntegerArg(
+  flagName: string,
+  value: string | number,
+): number {
+  const parsed = typeof value === "number" ? value : Number(value.trim());
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`${flagName} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
+function normalizeOptionalString(
+  value: string | undefined,
+): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function validateSignedBearerSecret(path: string, sharedSecret: Buffer): void {
+  if (sharedSecret.length < MIN_SIGNED_BEARER_SECRET_BYTES) {
+    throw new Error(
+      `signed websocket bearer secret ${path} must be at least ${MIN_SIGNED_BEARER_SECRET_BYTES} bytes`,
+    );
+  }
 }
 
 function sha256DigestArg(flagName: string, value: string): Buffer {

--- a/src/websocket/app-server-auth.ts
+++ b/src/websocket/app-server-auth.ts
@@ -1,0 +1,226 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import type { IncomingHttpHeaders } from "node:http";
+import { isIP } from "node:net";
+import { isAbsolute } from "node:path";
+
+const INVALID_AUTHORIZATION_HEADER_MESSAGE = "invalid authorization header";
+
+export type WebsocketAuthCliMode = "capability-token";
+
+export interface AppServerWebsocketAuthArgs {
+  wsAuth?: string;
+  wsTokenFile?: string;
+  wsTokenSha256?: string;
+}
+
+export interface AppServerWebsocketAuthSettings {
+  config?: AppServerWebsocketAuthConfig;
+}
+
+export type AppServerWebsocketAuthConfig = {
+  mode: WebsocketAuthCliMode;
+  source: AppServerWebsocketCapabilityTokenSource;
+};
+
+export type AppServerWebsocketCapabilityTokenSource =
+  | { type: "token-file"; tokenFile: string }
+  | { type: "token-sha256"; tokenSha256: Buffer };
+
+export interface WebsocketAuthPolicy {
+  mode?: WebsocketAuthMode;
+}
+
+type WebsocketAuthMode = {
+  type: "capability-token";
+  tokenSha256: Buffer;
+};
+
+export interface WebsocketAuthError {
+  statusCode: number;
+  message: string;
+}
+
+export function parseAppServerWebsocketAuthSettings(
+  args: AppServerWebsocketAuthArgs,
+): AppServerWebsocketAuthSettings {
+  switch (args.wsAuth) {
+    case undefined:
+      if (args.wsTokenFile || args.wsTokenSha256) {
+        throw new Error(
+          "websocket auth flags require `--ws-auth capability-token`",
+        );
+      }
+      return {};
+    case "capability-token": {
+      const hasTokenFile = Boolean(args.wsTokenFile);
+      const hasTokenSha256 = Boolean(args.wsTokenSha256);
+      if (hasTokenFile && hasTokenSha256) {
+        throw new Error(
+          "`--ws-token-file` and `--ws-token-sha256` are mutually exclusive",
+        );
+      }
+      if (!hasTokenFile && !hasTokenSha256) {
+        throw new Error(
+          "`--ws-token-file` or `--ws-token-sha256` is required when `--ws-auth capability-token` is set",
+        );
+      }
+      return {
+        config: {
+          mode: "capability-token",
+          source: args.wsTokenFile
+            ? {
+                type: "token-file",
+                tokenFile: absolutePathArg("--ws-token-file", args.wsTokenFile),
+              }
+            : {
+                type: "token-sha256",
+                tokenSha256: sha256DigestArg(
+                  "--ws-token-sha256",
+                  args.wsTokenSha256 as string,
+                ),
+              },
+        },
+      };
+    }
+    default:
+      throw new Error(
+        `unsupported --ws-auth mode "${args.wsAuth}"; expected "capability-token"`,
+      );
+  }
+}
+
+export async function policyFromSettings(
+  settings: AppServerWebsocketAuthSettings = {},
+): Promise<WebsocketAuthPolicy> {
+  const config = settings.config;
+  if (!config) {
+    return {};
+  }
+
+  switch (config.mode) {
+    case "capability-token":
+      return {
+        mode: {
+          type: "capability-token",
+          tokenSha256:
+            config.source.type === "token-file"
+              ? sha256Digest(await readTrimmedSecret(config.source.tokenFile))
+              : config.source.tokenSha256,
+        },
+      };
+  }
+}
+
+export function isUnauthenticatedNonLoopbackListener(
+  host: string,
+  policy: WebsocketAuthPolicy,
+): boolean {
+  return !isLoopbackListenHost(host) && !policy.mode;
+}
+
+export function isLoopbackListenHost(host: string): boolean {
+  const normalized = normalizeListenHost(host);
+  if (normalized === "localhost") {
+    return true;
+  }
+  if (isIP(normalized) === 4) {
+    return normalized.startsWith("127.");
+  }
+  return normalized === "::1";
+}
+
+export function normalizeListenHost(host: string): string {
+  return host.toLowerCase().replace(/^\[/, "").replace(/\]$/, "");
+}
+
+export function authorizeUpgrade(
+  headers: IncomingHttpHeaders,
+  policy: WebsocketAuthPolicy,
+): WebsocketAuthError | null {
+  const mode = policy.mode;
+  if (!mode) {
+    return null;
+  }
+
+  const tokenResult = bearerTokenFromHeaders(headers);
+  if (typeof tokenResult !== "string") {
+    return tokenResult;
+  }
+
+  switch (mode.type) {
+    case "capability-token": {
+      const actualSha256 = sha256Digest(tokenResult);
+      if (timingSafeEqual(mode.tokenSha256, actualSha256)) {
+        return null;
+      }
+      return unauthorized("invalid websocket bearer token");
+    }
+  }
+}
+
+function bearerTokenFromHeaders(
+  headers: IncomingHttpHeaders,
+): string | WebsocketAuthError {
+  const rawHeader = headers.authorization;
+  if (rawHeader === undefined) {
+    return unauthorized("missing websocket bearer token");
+  }
+  if (Array.isArray(rawHeader)) {
+    return unauthorized(INVALID_AUTHORIZATION_HEADER_MESSAGE);
+  }
+
+  const separatorIndex = rawHeader.indexOf(" ");
+  if (separatorIndex === -1) {
+    return unauthorized(INVALID_AUTHORIZATION_HEADER_MESSAGE);
+  }
+  const scheme = rawHeader.slice(0, separatorIndex);
+  if (scheme.toLowerCase() !== "bearer") {
+    return unauthorized(INVALID_AUTHORIZATION_HEADER_MESSAGE);
+  }
+
+  const token = rawHeader.slice(separatorIndex + 1).trim();
+  if (!token) {
+    return unauthorized(INVALID_AUTHORIZATION_HEADER_MESSAGE);
+  }
+  return token;
+}
+
+async function readTrimmedSecret(path: string): Promise<string> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`failed to read websocket auth secret ${path}: ${message}`);
+  }
+
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new Error(`websocket auth secret ${path} must not be empty`);
+  }
+  return trimmed;
+}
+
+function absolutePathArg(flagName: string, path: string): string {
+  if (!isAbsolute(path)) {
+    throw new Error(`${flagName} must be an absolute path`);
+  }
+  return path;
+}
+
+function sha256DigestArg(flagName: string, value: string): Buffer {
+  const trimmed = value.trim();
+  if (!/^[0-9a-fA-F]{64}$/.test(trimmed)) {
+    throw new Error(`${flagName} must be a 64-character hex SHA-256 digest`);
+  }
+  return Buffer.from(trimmed, "hex");
+}
+
+function sha256Digest(value: string): Buffer {
+  return createHash("sha256").update(value).digest();
+}
+
+function unauthorized(message: string): WebsocketAuthError {
+  return { statusCode: 401, message };
+}

--- a/src/websocket/app-server.test.ts
+++ b/src/websocket/app-server.test.ts
@@ -71,6 +71,7 @@ function expectWebSocketOpenFailure(
     };
     const handleError = () => {
       cleanup();
+      terminateClient(socket);
       resolve();
     };
     socket.once("open", handleOpen);

--- a/src/websocket/app-server.test.ts
+++ b/src/websocket/app-server.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { createHash } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import { join } from "node:path";
@@ -140,6 +140,21 @@ function sha256Hex(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
+function base64Url(value: string | Buffer): string {
+  return Buffer.from(value).toString("base64url");
+}
+
+function signedBearerToken(
+  sharedSecret: string,
+  claims: Record<string, unknown>,
+): string {
+  const header = base64Url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const claimsSegment = base64Url(JSON.stringify(claims));
+  const payload = `${header}.${claimsSegment}`;
+  const signature = createHmac("sha256", sharedSecret).update(payload).digest();
+  return `${payload}.${base64Url(signature)}`;
+}
+
 afterEach(() => {
   __testSetBackend(null);
 });
@@ -201,6 +216,79 @@ describe("app-server native websocket", () => {
     ).toMatchObject({ statusCode: 401 });
   });
 
+  test("parses signed-bearer websocket auth settings", async () => {
+    const authDir = await mkdtemp(join(os.tmpdir(), "letta-app-server-jwt-"));
+    const sharedSecretFile = join(authDir, "app-server-signing-secret");
+    const shortSecretFile = join(authDir, "app-server-short-secret");
+    try {
+      await writeFile(
+        sharedSecretFile,
+        "0123456789abcdef0123456789abcdef\n",
+        "utf8",
+      );
+      await writeFile(shortSecretFile, "too-short\n", "utf8");
+
+      expect(() =>
+        parseAppServerWebsocketAuthSettings({
+          wsAuth: "signed-bearer-token",
+        }),
+      ).toThrow(/--ws-shared-secret-file/);
+      expect(() =>
+        parseAppServerWebsocketAuthSettings({
+          wsAuth: "signed-bearer-token",
+          wsSharedSecretFile: sharedSecretFile,
+          wsTokenSha256: "ab".repeat(32),
+        }),
+      ).toThrow(/capability-token/);
+      expect(() =>
+        parseAppServerWebsocketAuthSettings({
+          wsSharedSecretFile: sharedSecretFile,
+        }),
+      ).toThrow(/signed-bearer-token/);
+      await expect(
+        policyFromSettings(
+          parseAppServerWebsocketAuthSettings({
+            wsAuth: "signed-bearer-token",
+            wsSharedSecretFile: shortSecretFile,
+          }),
+        ),
+      ).rejects.toThrow(/at least 32 bytes/);
+
+      const policy = await policyFromSettings(
+        parseAppServerWebsocketAuthSettings({
+          wsAuth: "signed-bearer-token",
+          wsSharedSecretFile: sharedSecretFile,
+          wsIssuer: " codex-enroller ",
+          wsAudience: "codex-app-server",
+          wsMaxClockSkewSeconds: "1",
+        }),
+      );
+      const now = Math.floor(Date.now() / 1000);
+      const validToken = signedBearerToken("0123456789abcdef0123456789abcdef", {
+        exp: now + 60,
+        iss: "codex-enroller",
+        aud: "codex-app-server",
+      });
+      expect(
+        authorizeUpgrade({ authorization: `Bearer ${validToken}` }, policy),
+      ).toBeNull();
+
+      const expiredToken = signedBearerToken(
+        "0123456789abcdef0123456789abcdef",
+        {
+          exp: now - 30,
+          iss: "codex-enroller",
+          aud: "codex-app-server",
+        },
+      );
+      expect(
+        authorizeUpgrade({ authorization: `Bearer ${expiredToken}` }, policy),
+      ).toMatchObject({ statusCode: 401 });
+    } finally {
+      await rm(authDir, { recursive: true, force: true });
+    }
+  });
+
   test("serves health probes", async () => {
     let handle: AppServerHandle | null = null;
     try {
@@ -218,6 +306,11 @@ describe("app-server native websocket", () => {
         headers: { Origin: "https://example.com" },
       });
       expect(browserHealth.status).toBe(403);
+
+      const browserReady = await fetch(`${httpUrl}/readyz`, {
+        headers: { Origin: "https://example.com" },
+      });
+      expect(browserReady.status).toBe(403);
     } finally {
       await handle?.close();
     }
@@ -264,6 +357,52 @@ describe("app-server native websocket", () => {
 
       control = new WebSocket(controlUrl, {
         headers: { Authorization: "Bearer super-secret-token" },
+      });
+      await waitForOpen(control);
+    } finally {
+      terminateClient(control);
+      await handle?.close();
+      await rm(authDir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects invalid and accepts valid signed bearer tokens", async () => {
+    const authDir = await mkdtemp(join(os.tmpdir(), "letta-app-server-jwt-"));
+    const sharedSecretFile = join(authDir, "app-server-signing-secret");
+    const sharedSecret = "0123456789abcdef0123456789abcdef";
+    let handle: AppServerHandle | null = null;
+    let control: WebSocket | null = null;
+    try {
+      await writeFile(sharedSecretFile, `${sharedSecret}\n`, "utf8");
+      handle = await startAppServer({
+        listen: "ws://0.0.0.0:0",
+        websocketAuth: parseAppServerWebsocketAuthSettings({
+          wsAuth: "signed-bearer-token",
+          wsSharedSecretFile: sharedSecretFile,
+          wsIssuer: "codex-enroller",
+          wsAudience: "codex-app-server",
+          wsMaxClockSkewSeconds: "1",
+        }),
+      });
+      const controlUrl = loopbackChannelUrl(handle.controlUrl);
+      const now = Math.floor(Date.now() / 1000);
+
+      const expiredToken = signedBearerToken(sharedSecret, {
+        exp: now - 30,
+        iss: "codex-enroller",
+        aud: "codex-app-server",
+      });
+      await expectWebSocketOpenFailure(controlUrl, {
+        Authorization: `Bearer ${expiredToken}`,
+      });
+
+      const validToken = signedBearerToken(sharedSecret, {
+        exp: now + 60,
+        iss: "codex-enroller",
+        aud: "codex-app-server",
+      });
+      control = new WebSocket(controlUrl, {
+        headers: { Authorization: `Bearer ${validToken}` },
       });
       await waitForOpen(control);
     } finally {

--- a/src/websocket/app-server.test.ts
+++ b/src/websocket/app-server.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import { join } from "node:path";
 import WebSocket from "ws";
@@ -11,6 +12,12 @@ import {
   parseAppServerListenUrl,
   startAppServer,
 } from "@/websocket/app-server";
+import {
+  authorizeUpgrade,
+  isUnauthenticatedNonLoopbackListener,
+  parseAppServerWebsocketAuthSettings,
+  policyFromSettings,
+} from "@/websocket/app-server-auth";
 
 const TEST_TIMEOUT_MS = 5000;
 
@@ -35,6 +42,36 @@ function waitForOpen(socket: WebSocket): Promise<void> {
     const handleError = (error: Error) => {
       cleanup();
       reject(error);
+    };
+    socket.once("open", handleOpen);
+    socket.once("error", handleError);
+  });
+}
+
+function expectWebSocketOpenFailure(
+  url: string,
+  headers?: Record<string, string>,
+): Promise<void> {
+  const socket = new WebSocket(url, { headers });
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      terminateClient(socket);
+      reject(new Error("Timed out waiting for websocket rejection"));
+    }, TEST_TIMEOUT_MS);
+    const cleanup = () => {
+      clearTimeout(timeout);
+      socket.off("open", handleOpen);
+      socket.off("error", handleError);
+    };
+    const handleOpen = () => {
+      cleanup();
+      terminateClient(socket);
+      reject(new Error("Expected websocket connection to be rejected"));
+    };
+    const handleError = () => {
+      cleanup();
+      resolve();
     };
     socket.once("open", handleOpen);
     socket.once("error", handleError);
@@ -88,12 +125,27 @@ function closeClient(socket: WebSocket | null): void {
   }
 }
 
+function terminateClient(socket: WebSocket | null): void {
+  if (!socket || socket.readyState === WebSocket.CLOSED) return;
+  socket.terminate();
+}
+
+function loopbackChannelUrl(url: string): string {
+  const parsed = new URL(url);
+  parsed.hostname = "127.0.0.1";
+  return parsed.toString();
+}
+
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
 afterEach(() => {
   __testSetBackend(null);
 });
 
 describe("app-server native websocket", () => {
-  test("parses loopback websocket listen URLs", () => {
+  test("parses websocket listen URLs", () => {
     expect(parseAppServerListenUrl()).toEqual({
       host: "127.0.0.1",
       port: 0,
@@ -107,9 +159,46 @@ describe("app-server native websocket", () => {
     expect(() => parseAppServerListenUrl("stdio://")).toThrow(
       /only supports ws:\/\//,
     );
-    expect(() => parseAppServerListenUrl("ws://0.0.0.0:4500")).toThrow(
-      /loopback/,
-    );
+    expect(parseAppServerListenUrl("ws://0.0.0.0:4500")).toEqual({
+      host: "0.0.0.0",
+      port: 4500,
+      path: "/ws",
+    });
+  });
+
+  test("parses capability-token websocket auth settings", async () => {
+    expect(() =>
+      parseAppServerWebsocketAuthSettings({ wsAuth: "capability-token" }),
+    ).toThrow(/--ws-token-file.*--ws-token-sha256/);
+    expect(() =>
+      parseAppServerWebsocketAuthSettings({
+        wsAuth: "capability-token",
+        wsTokenFile: "/tmp/token",
+        wsTokenSha256: "ab".repeat(32),
+      }),
+    ).toThrow(/mutually exclusive/);
+    expect(() =>
+      parseAppServerWebsocketAuthSettings({
+        wsAuth: "capability-token",
+        wsTokenSha256: "not-a-sha256",
+      }),
+    ).toThrow(/64-character hex/);
+
+    const settings = parseAppServerWebsocketAuthSettings({
+      wsAuth: "capability-token",
+      wsTokenSha256: sha256Hex("super-secret-token"),
+    });
+    const policy = await policyFromSettings(settings);
+    expect(isUnauthenticatedNonLoopbackListener("0.0.0.0", {})).toBe(true);
+    expect(isUnauthenticatedNonLoopbackListener("127.0.0.2", {})).toBe(false);
+    expect(isUnauthenticatedNonLoopbackListener("0.0.0.0", policy)).toBe(false);
+    expect(
+      authorizeUpgrade({ authorization: "Bearer super-secret-token" }, policy),
+    ).toBeNull();
+    expect(authorizeUpgrade({}, policy)).toMatchObject({ statusCode: 401 });
+    expect(
+      authorizeUpgrade({ authorization: "Bearer wrong-token" }, policy),
+    ).toMatchObject({ statusCode: 401 });
   });
 
   test("serves health probes", async () => {
@@ -131,6 +220,56 @@ describe("app-server native websocket", () => {
       expect(browserHealth.status).toBe(403);
     } finally {
       await handle?.close();
+    }
+  });
+
+  test("rejects browser-origin websocket upgrades", async () => {
+    let handle: AppServerHandle | null = null;
+    try {
+      handle = await startAppServer({ listen: "ws://127.0.0.1:0" });
+      await expectWebSocketOpenFailure(handle.controlUrl, {
+        Origin: "https://evil.example",
+      });
+    } finally {
+      await handle?.close();
+    }
+  });
+
+  test("requires capability-token auth for non-loopback websocket listeners", async () => {
+    await expect(startAppServer({ listen: "ws://0.0.0.0:0" })).rejects.toThrow(
+      /without auth/,
+    );
+  });
+
+  test("rejects missing and invalid capability tokens", async () => {
+    const authDir = await mkdtemp(join(os.tmpdir(), "letta-app-server-auth-"));
+    const tokenFile = join(authDir, "app-server-token");
+    let handle: AppServerHandle | null = null;
+    let control: WebSocket | null = null;
+    try {
+      await writeFile(tokenFile, "super-secret-token\n", "utf8");
+      handle = await startAppServer({
+        listen: "ws://0.0.0.0:0",
+        websocketAuth: parseAppServerWebsocketAuthSettings({
+          wsAuth: "capability-token",
+          wsTokenFile: tokenFile,
+        }),
+      });
+      const controlUrl = loopbackChannelUrl(handle.controlUrl);
+
+      await expectWebSocketOpenFailure(controlUrl);
+      await expectWebSocketOpenFailure(controlUrl, {
+        Authorization: "Bearer wrong-token",
+      });
+
+      control = new WebSocket(controlUrl, {
+        headers: { Authorization: "Bearer super-secret-token" },
+      });
+      await waitForOpen(control);
+    } finally {
+      terminateClient(control);
+      await handle?.close();
+      await rm(authDir, { recursive: true, force: true });
     }
   });
 

--- a/src/websocket/app-server.ts
+++ b/src/websocket/app-server.ts
@@ -7,6 +7,13 @@ import { settingsManager } from "@/settings-manager";
 import { getListenerTelemetrySurface, telemetry } from "@/telemetry";
 import { loadTools } from "@/tools/manager";
 import {
+  type AppServerWebsocketAuthSettings,
+  authorizeUpgrade,
+  isUnauthenticatedNonLoopbackListener,
+  normalizeListenHost,
+  policyFromSettings,
+} from "@/websocket/app-server-auth";
+import {
   attachOpenListenerSocket,
   createRuntime,
   stopRuntime,
@@ -26,6 +33,7 @@ type AppServerChannel = "control" | "stream";
 
 export interface StartAppServerOptions {
   listen?: string;
+  websocketAuth?: AppServerWebsocketAuthSettings;
   connectionName?: string;
   onListening?: (info: AppServerListeningInfo) => void;
   onLog?: (message: string) => void;
@@ -52,19 +60,6 @@ type ActiveAppServerSession = {
   controlSocket: WebSocket;
   streamSocket: WebSocket | null;
 };
-
-function isLoopbackHost(host: string): boolean {
-  const normalized = normalizeListenHost(host);
-  return (
-    normalized === "localhost" ||
-    normalized === "127.0.0.1" ||
-    normalized === "::1"
-  );
-}
-
-function normalizeListenHost(host: string): string {
-  return host.toLowerCase().replace(/^\[/, "").replace(/\]$/, "");
-}
 
 function getRequiredAddressInfo(server: Server): AddressInfo {
   const address = server.address();
@@ -109,10 +104,9 @@ function rejectUpgrade(
   statusCode: number,
   message: string,
 ): void {
-  socket.write(
+  socket.end(
     `HTTP/1.1 ${statusCode} ${message}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`,
   );
-  socket.destroy();
 }
 
 function getRequestUrl(request: IncomingMessage, host: string): URL {
@@ -164,11 +158,6 @@ export function parseAppServerListenUrl(
 
   if (url.protocol !== "ws:") {
     throw new Error("app-server MVP only supports ws:// listen URLs");
-  }
-  if (!isLoopbackHost(url.hostname)) {
-    throw new Error(
-      "app-server websocket listen host must be loopback for now",
-    );
   }
   if (url.username || url.password || url.search || url.hash) {
     throw new Error(
@@ -249,6 +238,12 @@ export async function startAppServer(
   await settingsManager.initialize();
 
   const listen = parseAppServerListenUrl(options.listen);
+  const authPolicy = await policyFromSettings(options.websocketAuth);
+  if (isUnauthenticatedNonLoopbackListener(listen.host, authPolicy)) {
+    throw new Error(
+      `refusing to start non-loopback websocket listener ${listen.host}:${listen.port} without auth; configure \`--ws-auth capability-token\``,
+    );
+  }
   const wss = new WebSocketServer({ noServer: true });
   let activeSession: ActiveAppServerSession | null = null;
   let pendingStreamSocket: WebSocket | null = null;
@@ -346,6 +341,14 @@ export async function startAppServer(
 
   server.on("upgrade", (request, socket, head) => {
     const requestUrl = getRequestUrl(request, listen.host);
+    if (request.headers.origin) {
+      options.onLog?.(
+        `Rejecting app-server websocket request with Origin header: ${request.url ?? "/"}`,
+      );
+      rejectUpgrade(socket, 403, "Forbidden");
+      return;
+    }
+
     if (requestUrl.pathname !== listen.path && requestUrl.pathname !== "/") {
       rejectUpgrade(socket, 404, "Not Found");
       return;
@@ -354,6 +357,15 @@ export async function startAppServer(
     const channel = getRequestChannel(requestUrl);
     if (!channel) {
       rejectUpgrade(socket, 400, "Bad Request");
+      return;
+    }
+
+    const authError = authorizeUpgrade(request.headers, authPolicy);
+    if (authError) {
+      options.onLog?.(
+        `Rejecting app-server websocket client: ${authError.message}`,
+      );
+      rejectUpgrade(socket, authError.statusCode, authError.message);
       return;
     }
 

--- a/src/websocket/app-server.ts
+++ b/src/websocket/app-server.ts
@@ -241,7 +241,7 @@ export async function startAppServer(
   const authPolicy = await policyFromSettings(options.websocketAuth);
   if (isUnauthenticatedNonLoopbackListener(listen.host, authPolicy)) {
     throw new Error(
-      `refusing to start non-loopback websocket listener ${listen.host}:${listen.port} without auth; configure \`--ws-auth capability-token\``,
+      `refusing to start non-loopback websocket listener ${listen.host}:${listen.port} without auth; configure \`--ws-auth capability-token\` or \`--ws-auth signed-bearer-token\``,
     );
   }
   const wss = new WebSocketServer({ noServer: true });
@@ -320,17 +320,21 @@ export async function startAppServer(
 
   const server = createServer((request, response) => {
     const requestUrl = getRequestUrl(request, listen.host);
+    if (request.headers.origin) {
+      options.onLog?.(
+        `Rejecting app-server request with Origin header: ${request.url ?? "/"}`,
+      );
+      response.writeHead(403);
+      response.end();
+      return;
+    }
+
     if (requestUrl.pathname === "/readyz") {
       response.writeHead(200, { "content-type": "text/plain" });
       response.end("ok\n");
       return;
     }
     if (requestUrl.pathname === "/healthz") {
-      if (request.headers.origin) {
-        response.writeHead(403);
-        response.end();
-        return;
-      }
       response.writeHead(200, { "content-type": "text/plain" });
       response.end("ok\n");
       return;


### PR DESCRIPTION
## Summary

Adds Codex-style websocket auth for `letta app-server` so the server can safely bind to non-loopback hosts.

- Loopback listeners (`localhost`, `127.x.x.x`, `::1`) still work without auth.
- Non-loopback listeners now refuse startup unless websocket auth is configured.
- Supported auth modes now match current Codex main:
  - `--ws-auth capability-token`
    - `--ws-token-file <absolute-path>` or `--ws-token-sha256 <64-char-hex>`
  - `--ws-auth signed-bearer-token`
    - `--ws-shared-secret-file <absolute-path>`
    - optional `--ws-issuer`, `--ws-audience`, `--ws-max-clock-skew-seconds`
- Requests/upgrades with an `Origin` header are rejected.
- The in-repo app-server client can pass a capability token as `Authorization: Bearer <token>` when using a WebSocket implementation that supports headers.

## Codex parity self-review

I compared this PR against latest `openai/codex` main at `64bdeed9f7adbe60c725153b3fb74ed044a36221`, specifically:

- `codex-rs/app-server-transport/src/transport/auth.rs`
- `codex-rs/app-server-transport/src/transport/websocket.rs`
- `codex-rs/app-server/src/main.rs`
- `codex-rs/app-server/tests/suite/v2/connection_handling_websocket.rs`

The first pushed version only had `capability-token`; latest Codex also has `signed-bearer-token`, so this PR now includes that mode too.

## Easy review path for Caren

1. **Start with `src/websocket/app-server-auth.ts`**
   - New isolated auth helper module.
   - Parses the CLI-shaped auth config.
   - Capability-token mode: loads/trims token files or accepts a SHA-256 digest; validates `Authorization: Bearer <token>` using SHA-256 + constant-time compare.
   - Signed-bearer mode: loads/trims a shared secret, requires at least 32 bytes, validates HS256 JWTs, `exp`, optional `nbf`, optional issuer, optional audience, and clock skew.
   - Contains loopback vs non-loopback detection.

2. **Then review `src/websocket/app-server.ts`**
   - Removes the old unconditional “loopback only” parser restriction.
   - Adds the startup guard: non-loopback + no auth => refuse to start.
   - Adds per-upgrade auth checks.
   - Rejects requests/upgrades with an `Origin` header.

3. **Then review `src/cli/subcommands/app-server.ts`**
   - Wires the Codex auth flags through to `startAppServer`.
   - Updates help text and examples.

4. **Then review `src/app-server-client.ts`**
   - Minimal client-side support for passing a capability bearer token on both control and stream sockets.
   - No protocol frame changes.

5. **Finally review tests**
   - `src/websocket/app-server.test.ts` covers auth parsing, startup refusal, rejected missing/invalid capability tokens, valid capability token connection, signed JWT validation, valid signed bearer connection, and `Origin` rejection.
   - `src/app-server-client.test.ts` covers capability bearer header wiring.

## Behavior matrix

| Listener host | Auth configured? | Result |
| --- | --- | --- |
| `ws://127.0.0.1:4500` | No | Starts, same as before |
| `ws://localhost:4500` | No | Starts, same as before |
| `ws://0.0.0.0:4500` | No | Refuses startup |
| `ws://0.0.0.0:4500` | `capability-token` | Starts; websocket clients need `Authorization: Bearer <token>` |
| `ws://0.0.0.0:4500` | `signed-bearer-token` | Starts; websocket clients need a valid signed HS256 bearer JWT |
| Any host | Request/upgrade includes `Origin` | Rejected |

## Test plan

- `bun test src/app-server-client.test.ts src/websocket/app-server.test.ts`
- `bun run check`

## Notes

This intentionally tracks Codex’s current websocket auth posture: loopback remains frictionless, any non-loopback websocket listener must opt into explicit websocket auth, and the currently supported Codex auth modes are available.
