### PR TITLE
fix(local): hide hidden agents from local listings

### DIFF
--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -39,7 +39,9 @@ import {
   LocalTranscriptMigrationRequiredError,
   LocalTranscriptRepairRequiredError,
 } from "@/backend/local/local-store";
+import { LOCAL_BACKEND_DIR_ENV } from "@/backend/local/paths";
 import { migrateLocalBackendTranscripts } from "@/backend/local/transcript-migration";
+import { listLocalAgentsFromDisk } from "@/cli/helpers/local-agent-listing";
 
 async function firstConversationDir(storageDir: string): Promise<string> {
   const entries = await readdir(join(storageDir, "conversations"));
@@ -95,6 +97,11 @@ async function collect(stream: AsyncIterable<unknown>): Promise<unknown[]> {
 
 function pageItems<T>(value: T[] | { getPaginatedItems(): T[] }): T[] {
   return Array.isArray(value) ? value : value.getPaginatedItems();
+}
+
+function localAgentListIds(page: unknown): string[] {
+  const items = (page as { items?: Array<{ id: string }> }).items;
+  return Array.isArray(items) ? items.map((agent) => agent.id) : [];
 }
 
 async function withEnv<T>(
@@ -298,6 +305,48 @@ describe("local backend pi transcript", () => {
         await readFile(conversationPath, "utf8"),
       ) as Record<string, unknown>;
       expect(persisted.summary).toBe("Desktop rename");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("hides local hidden agents from backend and disk listings", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-hidden-agents-"),
+    );
+    try {
+      const backend = new LocalBackend({ storageDir, memfsEnabled: false });
+      const visible = await backend.createAgent({ name: "Visible" } as never);
+      const hidden = await backend.createAgent({
+        name: "Hidden",
+        hidden: true,
+      } as never);
+
+      expect((hidden as { hidden?: boolean }).hidden).toBe(true);
+
+      const listedIds = localAgentListIds(
+        await backend.listAgents({ limit: 10 } as never),
+      );
+      expect(listedIds).toContain(visible.id);
+      expect(listedIds).not.toContain(hidden.id);
+
+      const reloaded = new LocalBackend({ storageDir, memfsEnabled: false });
+      const reloadedListedIds = localAgentListIds(
+        await reloaded.listAgents({ limit: 10 } as never),
+      );
+      expect(reloadedListedIds).toContain(visible.id);
+      expect(reloadedListedIds).not.toContain(hidden.id);
+
+      const retrievedHidden = await reloaded.retrieveAgent(hidden.id);
+      expect((retrievedHidden as { hidden?: boolean }).hidden).toBe(true);
+
+      await withEnv({ [LOCAL_BACKEND_DIR_ENV]: storageDir }, async () => {
+        const diskListedIds = listLocalAgentsFromDisk().map(
+          (agent) => agent.id,
+        );
+        expect(diskListedIds).toContain(visible.id);
+        expect(diskListedIds).not.toContain(hidden.id);
+      });
     } finally {
       await rm(storageDir, { recursive: true, force: true });
     }

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -321,6 +321,32 @@ describe("local backend pi transcript", () => {
         name: "Hidden",
         hidden: true,
       } as never);
+      const legacySubagentId = "agent-local-legacy-subagent";
+      const legacySubagentPath = join(
+        storageDir,
+        "agents",
+        `${Buffer.from(legacySubagentId).toString("base64url")}.json`,
+      );
+      await writeFile(
+        legacySubagentPath,
+        `${JSON.stringify(
+          {
+            id: legacySubagentId,
+            name: "Legacy subagent",
+            description: null,
+            system: "",
+            tags: [
+              "origin:letta-code",
+              "role:subagent",
+              "type:general-purpose",
+            ],
+            model: "local/default",
+            model_settings: {},
+          },
+          null,
+          2,
+        )}\n`,
+      );
 
       expect((hidden as { hidden?: boolean }).hidden).toBe(true);
 
@@ -330,15 +356,35 @@ describe("local backend pi transcript", () => {
       expect(listedIds).toContain(visible.id);
       expect(listedIds).not.toContain(hidden.id);
 
+      await withEnv({ [LOCAL_BACKEND_DIR_ENV]: storageDir }, async () => {
+        const diskListedIds = listLocalAgentsFromDisk().map(
+          (agent) => agent.id,
+        );
+        expect(diskListedIds).toContain(visible.id);
+        expect(diskListedIds).not.toContain(hidden.id);
+        expect(diskListedIds).not.toContain(legacySubagentId);
+      });
+
       const reloaded = new LocalBackend({ storageDir, memfsEnabled: false });
       const reloadedListedIds = localAgentListIds(
         await reloaded.listAgents({ limit: 10 } as never),
       );
       expect(reloadedListedIds).toContain(visible.id);
       expect(reloadedListedIds).not.toContain(hidden.id);
+      expect(reloadedListedIds).not.toContain(legacySubagentId);
 
       const retrievedHidden = await reloaded.retrieveAgent(hidden.id);
       expect((retrievedHidden as { hidden?: boolean }).hidden).toBe(true);
+      const retrievedLegacySubagent =
+        await reloaded.retrieveAgent(legacySubagentId);
+      expect((retrievedLegacySubagent as { hidden?: boolean }).hidden).toBe(
+        true,
+      );
+
+      const migratedLegacySubagent = JSON.parse(
+        await readFile(legacySubagentPath, "utf8"),
+      ) as Record<string, unknown>;
+      expect(migratedLegacySubagent.hidden).toBe(true);
 
       await withEnv({ [LOCAL_BACKEND_DIR_ENV]: storageDir }, async () => {
         const diskListedIds = listLocalAgentsFromDisk().map(
@@ -346,6 +392,7 @@ describe("local backend pi transcript", () => {
         );
         expect(diskListedIds).toContain(visible.id);
         expect(diskListedIds).not.toContain(hidden.id);
+        expect(diskListedIds).not.toContain(legacySubagentId);
       });
     } finally {
       await rm(storageDir, { recursive: true, force: true });

--- a/src/backend/local/index.ts
+++ b/src/backend/local/index.ts
@@ -60,6 +60,7 @@ export {
   updateLocalProvider,
 } from "./local-provider-auth-store";
 export {
+  isHiddenLocalAgentRecord,
   type LocalAgentRecord,
   LocalBackendNotFoundError,
   LocalStore,

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -72,10 +72,48 @@ const LEGACY_LOCAL_CONTEXT_WINDOW_LIMIT = 128000;
 const DEFAULT_LOCAL_CONVERSATION_ID_PREFIX = "local-conv-";
 const DEFAULT_LOCAL_STORED_MESSAGE_ID_PREFIX = "letta-msg-";
 const DEFAULT_LOCAL_UI_MESSAGE_ID_PREFIX = "ui-msg-";
+const LETTA_CODE_SUBAGENT_TAG = "role:subagent";
 
 function isStringArray(value: unknown): value is string[] {
   return (
     Array.isArray(value) && value.every((item) => typeof item === "string")
+  );
+}
+
+function normalizeAgentHiddenFlag(
+  hidden: unknown,
+  tags: string[],
+): boolean | null | undefined {
+  if (typeof hidden === "boolean") return hidden;
+  if ((hidden === undefined || hidden === null) && isSubagentTags(tags)) {
+    return true;
+  }
+  return hidden === null ? null : undefined;
+}
+
+function isSubagentTags(tags: string[]): boolean {
+  return tags.includes(LETTA_CODE_SUBAGENT_TAG);
+}
+
+export function isHiddenLocalAgentRecord(record: {
+  hidden?: boolean | null;
+  tags?: unknown;
+}): boolean {
+  const tags = isStringArray(record.tags) ? record.tags : [];
+  return (
+    record.hidden === true || (record.hidden == null && isSubagentTags(tags))
+  );
+}
+
+function shouldPersistSubagentHiddenBackfill(
+  raw: unknown,
+  record: LocalAgentRecord,
+): boolean {
+  return (
+    isRecord(raw) &&
+    (raw.hidden === undefined || raw.hidden === null) &&
+    record.hidden === true &&
+    isSubagentTags(record.tags)
   );
 }
 
@@ -132,17 +170,17 @@ function createLocalAgentRecord(
   defaultAgentModel: string,
 ): LocalAgentRecord {
   const bodyRecord = body as Record<string, unknown>;
+  const tags = isStringArray(bodyRecord.tags) ? bodyRecord.tags : [];
+  const hidden = normalizeAgentHiddenFlag(bodyRecord.hidden, tags);
   return {
     id: `agent-local-${randomUUID()}`,
     name: optionalString(bodyRecord.name) ?? defaultAgentName,
     description: optionalStringOrNull(bodyRecord.description) ?? null,
     system: optionalString(bodyRecord.system) ?? "",
-    tags: isStringArray(bodyRecord.tags) ? bodyRecord.tags : [],
+    tags,
     model: optionalString(bodyRecord.model) ?? defaultAgentModel,
     model_settings: supportedModelSettingsFromBody(bodyRecord),
-    ...(typeof bodyRecord.hidden === "boolean"
-      ? { hidden: bodyRecord.hidden }
-      : {}),
+    ...(hidden !== undefined ? { hidden } : {}),
   };
 }
 
@@ -306,20 +344,20 @@ function normalizeAgentRecord(
   }
 
   const compactionSettings = optionalRecordOrNull(value.compaction_settings);
+  const tags = isStringArray(value.tags) ? value.tags : [];
+  const hidden = normalizeAgentHiddenFlag(value.hidden, tags);
   return {
     id: value.id,
     name: optionalString(value.name) ?? "Letta Code",
     description: optionalStringOrNull(value.description) ?? null,
     system: optionalString(value.system) ?? "",
-    tags: isStringArray(value.tags) ? value.tags : [],
+    tags,
     model:
       optionalString(value.model) ??
       optionalString(legacyLlmConfig.model) ??
       defaultAgentModel,
     model_settings: modelSettings,
-    ...(typeof value.hidden === "boolean" || value.hidden === null
-      ? { hidden: value.hidden }
-      : {}),
+    ...(hidden !== undefined ? { hidden } : {}),
     ...(compactionSettings !== undefined
       ? { compaction_settings: compactionSettings }
       : {}),
@@ -332,6 +370,7 @@ export function projectLocalAgentState(
   inContextMessageIds: string[] = messageIds,
   lastRunCompletion?: string | null,
 ): AgentState {
+  const hidden = normalizeAgentHiddenFlag(record.hidden, record.tags);
   const nestedReasoning = isRecord(record.model_settings.reasoning)
     ? record.model_settings.reasoning
     : undefined;
@@ -359,7 +398,7 @@ export function projectLocalAgentState(
     tags: record.tags,
     model: record.model,
     model_settings: record.model_settings,
-    ...(record.hidden !== undefined ? { hidden: record.hidden } : {}),
+    ...(hidden !== undefined ? { hidden } : {}),
     ...(record.compaction_settings !== undefined
       ? { compaction_settings: record.compaction_settings }
       : {}),
@@ -1209,7 +1248,7 @@ export class LocalStore {
     const after = optionalString(bodyRecord.after);
     const limit = typeof bodyRecord.limit === "number" ? bodyRecord.limit : 20;
     let agents = [...this.agents.values()]
-      .filter((agent) => agent.hidden !== true)
+      .filter((agent) => !isHiddenLocalAgentRecord(agent))
       .map((agent) => this.projectAgent(agent));
 
     if (tags.length > 0) {
@@ -3118,12 +3157,13 @@ export class LocalStore {
     if (existsSync(agentsDir)) {
       for (const file of readdirSync(agentsDir)) {
         if (!file.endsWith(".json")) continue;
-        const agent = normalizeAgentRecord(
-          readJsonFile<unknown>(join(agentsDir, file)),
-          this.defaultAgentModel,
-        );
+        const raw = readJsonFile<unknown>(join(agentsDir, file));
+        const agent = normalizeAgentRecord(raw, this.defaultAgentModel);
         if (agent?.id) {
           this.agents.set(agent.id, agent);
+          if (shouldPersistSubagentHiddenBackfill(raw, agent)) {
+            this.persistAgent(agent.id);
+          }
         }
       }
     }

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -140,6 +140,9 @@ function createLocalAgentRecord(
     tags: isStringArray(bodyRecord.tags) ? bodyRecord.tags : [],
     model: optionalString(bodyRecord.model) ?? defaultAgentModel,
     model_settings: supportedModelSettingsFromBody(bodyRecord),
+    ...(typeof bodyRecord.hidden === "boolean"
+      ? { hidden: bodyRecord.hidden }
+      : {}),
   };
 }
 
@@ -314,6 +317,9 @@ function normalizeAgentRecord(
       optionalString(legacyLlmConfig.model) ??
       defaultAgentModel,
     model_settings: modelSettings,
+    ...(typeof value.hidden === "boolean" || value.hidden === null
+      ? { hidden: value.hidden }
+      : {}),
     ...(compactionSettings !== undefined
       ? { compaction_settings: compactionSettings }
       : {}),
@@ -353,6 +359,7 @@ export function projectLocalAgentState(
     tags: record.tags,
     model: record.model,
     model_settings: record.model_settings,
+    ...(record.hidden !== undefined ? { hidden: record.hidden } : {}),
     ...(record.compaction_settings !== undefined
       ? { compaction_settings: record.compaction_settings }
       : {}),
@@ -1201,9 +1208,9 @@ export class LocalStore {
     const tags = isStringArray(bodyRecord.tags) ? bodyRecord.tags : [];
     const after = optionalString(bodyRecord.after);
     const limit = typeof bodyRecord.limit === "number" ? bodyRecord.limit : 20;
-    let agents = [...this.agents.values()].map((agent) =>
-      this.projectAgent(agent),
-    );
+    let agents = [...this.agents.values()]
+      .filter((agent) => agent.hidden !== true)
+      .map((agent) => this.projectAgent(agent));
 
     if (tags.length > 0) {
       agents = agents.filter((agent) =>
@@ -1341,6 +1348,9 @@ export class LocalStore {
       }),
       ...(isStringArray(bodyRecord.tags) && { tags: bodyRecord.tags }),
       ...(nextModel && { model: nextModel }),
+      ...(typeof bodyRecord.hidden === "boolean" && {
+        hidden: bodyRecord.hidden,
+      }),
       model_settings: nextModelSettings,
     };
     this.agents.set(agentId, updated);

--- a/src/backend/local/local-types.ts
+++ b/src/backend/local/local-types.ts
@@ -22,5 +22,6 @@ export interface LocalAgentRecord {
   tags: string[];
   model: string;
   model_settings: Record<string, unknown>;
+  hidden?: boolean | null;
   compaction_settings?: Record<string, unknown> | null;
 }

--- a/src/cli/helpers/local-agent-listing.ts
+++ b/src/cli/helpers/local-agent-listing.ts
@@ -30,6 +30,7 @@ export function listLocalAgentsFromDisk(): AgentState[] {
       const filePath = join(agentsDir, file);
       const raw = readFileSync(filePath, "utf8");
       const record = JSON.parse(raw) as LocalAgentRecord;
+      if (record.hidden === true) continue;
       const mtime = statSync(filePath).mtimeMs;
       agents.push({
         agent: projectLocalAgentState(

--- a/src/cli/helpers/local-agent-listing.ts
+++ b/src/cli/helpers/local-agent-listing.ts
@@ -8,7 +8,10 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
-import { projectLocalAgentState } from "@/backend/local";
+import {
+  isHiddenLocalAgentRecord,
+  projectLocalAgentState,
+} from "@/backend/local";
 import type { LocalAgentRecord } from "@/backend/local/local-types";
 import { getLocalBackendStorageDir } from "@/backend/local/paths";
 
@@ -30,7 +33,7 @@ export function listLocalAgentsFromDisk(): AgentState[] {
       const filePath = join(agentsDir, file);
       const raw = readFileSync(filePath, "utf8");
       const record = JSON.parse(raw) as LocalAgentRecord;
-      if (record.hidden === true) continue;
+      if (isHiddenLocalAgentRecord(record)) continue;
       const mtime = statSync(filePath).mtimeMs;
       agents.push({
         agent: projectLocalAgentState(


### PR DESCRIPTION
Fixes local backend parity for hidden subagents.

Problem:
Local subagent creation already passes hidden=true, but LocalStore dropped that field from persisted agent records. The normal local agent list and the disk-backed local agent selector then treated hidden subagents as visible agents. Older local subagent files can also lack the hidden field even though they still carry the role:subagent tag.

Change:
- Persist and project the hidden field on local agent records.
- Exclude hidden agents from LocalStore.listAgents and the lightweight disk listing used by the local agent selector.
- Backfill legacy local subagent records one-way: if hidden is missing/null and tags include role:subagent, treat the record as hidden and persist hidden=true on load.
- Preserve explicit hidden=false; hidden is not treated as proof that an agent is a subagent.
- Add a persisted-state regression test covering backend listing, reload, direct retrieval, disk listing, and legacy subagent backfill.

Validation:
- bun run check
- bun test src/backend/local-backend.test.ts
