### PR TITLE
fix(cron): validate conversation targets

### DIFF
--- a/src/cli/subcommands/cron.test.ts
+++ b/src/cli/subcommands/cron.test.ts
@@ -1,0 +1,221 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import { __testSetBackend, type Backend } from "@/backend";
+import { runCronSubcommand } from "@/cli/subcommands/cron";
+import { listTasks } from "@/cron";
+
+const TEST_DIR = path.join(import.meta.dir, "__cron_subcommand_test_tmp__");
+
+const retrieveConversationMock = mock(async (conversationId: string) => ({
+  id: conversationId,
+  agent_id: "agent-test",
+}));
+
+const backend = {
+  capabilities: {
+    remoteMemfs: true,
+    serverSideToolManagement: true,
+    serverSecrets: true,
+    agentFileImportExport: true,
+    promptRecompile: true,
+    byokProviderRefresh: true,
+    localModelCatalog: false,
+    localMemfs: false,
+  },
+  retrieveConversation: retrieveConversationMock,
+} as unknown as Backend;
+
+type SavedEnv = {
+  LETTA_HOME?: string;
+  LETTA_AGENT_ID?: string;
+  LETTA_CONVERSATION_ID?: string;
+};
+
+let savedEnv: SavedEnv;
+
+function captureConsole() {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const logSpy = spyOn(console, "log").mockImplementation(
+    (...args: unknown[]) => {
+      stdout.push(args.map((arg) => String(arg)).join(" "));
+    },
+  );
+  const errorSpy = spyOn(console, "error").mockImplementation(
+    (...args: unknown[]) => {
+      stderr.push(args.map((arg) => String(arg)).join(" "));
+    },
+  );
+
+  return {
+    stdout,
+    stderr,
+    restore: () => {
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
+    },
+  };
+}
+
+function restoreEnv(): void {
+  for (const key of Object.keys(savedEnv) as Array<keyof SavedEnv>) {
+    const value = savedEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function cronAddArgs(conversationId: string): string[] {
+  return [
+    "add",
+    "--name",
+    "memory-maintenance",
+    "--description",
+    "Memory hygiene",
+    "--prompt",
+    "run maintenance",
+    "--every",
+    "5m",
+    "--agent",
+    "agent-test",
+    "--conversation",
+    conversationId,
+  ];
+}
+
+function parseCronAddOutput(stdout: string[]): Record<string, unknown> {
+  return JSON.parse(stdout.join("\n")) as Record<string, unknown>;
+}
+
+describe("cron add conversation validation", () => {
+  beforeEach(() => {
+    savedEnv = {
+      LETTA_HOME: process.env.LETTA_HOME,
+      LETTA_AGENT_ID: process.env.LETTA_AGENT_ID,
+      LETTA_CONVERSATION_ID: process.env.LETTA_CONVERSATION_ID,
+    };
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.env.LETTA_HOME = TEST_DIR;
+    delete process.env.LETTA_AGENT_ID;
+    delete process.env.LETTA_CONVERSATION_ID;
+
+    retrieveConversationMock.mockClear();
+    retrieveConversationMock.mockImplementation(
+      async (conversationId: string) => ({
+        id: conversationId,
+        agent_id: "agent-test",
+      }),
+    );
+    __testSetBackend(backend);
+  });
+
+  afterEach(() => {
+    __testSetBackend(null);
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    restoreEnv();
+  });
+
+  test("accepts an existing conversation id for the selected agent", async () => {
+    const capture = captureConsole();
+    try {
+      const code = await runCronSubcommand(cronAddArgs("conv-valid"));
+
+      expect(code).toBe(0);
+      expect(retrieveConversationMock).toHaveBeenCalledWith("conv-valid");
+      expect(listTasks()).toHaveLength(1);
+      const output = parseCronAddOutput(capture.stdout);
+      expect(output.conversation_id).toBe("conv-valid");
+    } finally {
+      capture.restore();
+    }
+  });
+
+  test("rejects an invalid conversation label without writing a task", async () => {
+    retrieveConversationMock.mockImplementation(async () => {
+      throw new Error("not found");
+    });
+
+    const capture = captureConsole();
+    try {
+      const code = await runCronSubcommand(cronAddArgs("cron-memory"));
+
+      expect(code).toBe(1);
+      expect(retrieveConversationMock).toHaveBeenCalledWith("cron-memory");
+      expect(listTasks()).toHaveLength(0);
+      const error = capture.stderr.join("\n");
+      expect(error).toContain('Invalid conversation target "cron-memory"');
+      expect(error).toContain(
+        'expects "default", "new", or an existing conversation id',
+      );
+      expect(error).toContain("labels/names are not accepted");
+    } finally {
+      capture.restore();
+    }
+  });
+
+  test("allows the default conversation sentinel without lookup", async () => {
+    const capture = captureConsole();
+    try {
+      const code = await runCronSubcommand(cronAddArgs("default"));
+
+      expect(code).toBe(0);
+      expect(retrieveConversationMock).not.toHaveBeenCalled();
+      expect(listTasks()).toHaveLength(1);
+      const output = parseCronAddOutput(capture.stdout);
+      expect(output.conversation_id).toBe("default");
+    } finally {
+      capture.restore();
+    }
+  });
+
+  test("allows the new conversation sentinel without lookup", async () => {
+    const capture = captureConsole();
+    try {
+      const code = await runCronSubcommand(cronAddArgs("new"));
+
+      expect(code).toBe(0);
+      expect(retrieveConversationMock).not.toHaveBeenCalled();
+      expect(listTasks()).toHaveLength(1);
+      const output = parseCronAddOutput(capture.stdout);
+      expect(output.conversation_id).toBe("new");
+    } finally {
+      capture.restore();
+    }
+  });
+
+  test("rejects a valid conversation id that belongs to another agent", async () => {
+    retrieveConversationMock.mockImplementation(
+      async (conversationId: string) => ({
+        id: conversationId,
+        agent_id: "agent-other",
+      }),
+    );
+
+    const capture = captureConsole();
+    try {
+      const code = await runCronSubcommand(cronAddArgs("conv-other-agent"));
+
+      expect(code).toBe(1);
+      expect(retrieveConversationMock).toHaveBeenCalledWith("conv-other-agent");
+      expect(listTasks()).toHaveLength(0);
+      expect(capture.stderr.join("\n")).toContain(
+        'Conversation "conv-other-agent" belongs to agent "agent-other", not selected agent "agent-test".',
+      );
+    } finally {
+      capture.restore();
+    }
+  });
+});

--- a/src/cli/subcommands/cron.ts
+++ b/src/cli/subcommands/cron.ts
@@ -111,6 +111,7 @@ async function validateConversationTarget(
   conversationId: string,
 ): Promise<void> {
   // These are scheduler sentinels, not persisted conversation ids resolved here.
+  // Scheduler/runtime resolves "default" to the agent default conversation; "new" creates a fresh one at fire time.
   if (
     conversationId === DEFAULT_CONVERSATION_TARGET ||
     conversationId === NEW_CONVERSATION_TARGET

--- a/src/cli/subcommands/cron.ts
+++ b/src/cli/subcommands/cron.ts
@@ -110,6 +110,7 @@ async function validateConversationTarget(
   agentId: string,
   conversationId: string,
 ): Promise<void> {
+  // These are scheduler sentinels, not persisted conversation ids resolved here.
   if (
     conversationId === DEFAULT_CONVERSATION_TARGET ||
     conversationId === NEW_CONVERSATION_TARGET
@@ -117,6 +118,8 @@ async function validateConversationTarget(
     return;
   }
 
+  // Everything else must be a real id before addTask persists it; labels or
+  // names would create scheduled tasks that cannot be resolved when they run.
   let conversation: { agent_id?: string | null };
   try {
     conversation = await getBackend().retrieveConversation(conversationId);

--- a/src/cli/subcommands/cron.ts
+++ b/src/cli/subcommands/cron.ts
@@ -13,6 +13,7 @@
  */
 
 import { parseArgs } from "node:util";
+import { getBackend } from "@/backend";
 import {
   addTask,
   deleteAllTasks,
@@ -98,9 +99,44 @@ function getConversationId(fromArgs?: string): string {
   return fromArgs || process.env.LETTA_CONVERSATION_ID || "default";
 }
 
+const DEFAULT_CONVERSATION_TARGET = "default";
+const NEW_CONVERSATION_TARGET = "new";
+
+function invalidConversationTargetMessage(conversationId: string): string {
+  return `Invalid conversation target "${conversationId}". --conversation expects "default", "new", or an existing conversation id like "conv-..."; labels/names are not accepted.`;
+}
+
+async function validateConversationTarget(
+  agentId: string,
+  conversationId: string,
+): Promise<void> {
+  if (
+    conversationId === DEFAULT_CONVERSATION_TARGET ||
+    conversationId === NEW_CONVERSATION_TARGET
+  ) {
+    return;
+  }
+
+  let conversation: { agent_id?: string | null };
+  try {
+    conversation = await getBackend().retrieveConversation(conversationId);
+  } catch {
+    throw new Error(invalidConversationTargetMessage(conversationId));
+  }
+
+  const conversationAgentId = conversation.agent_id ?? "unknown";
+  if (conversationAgentId !== agentId) {
+    throw new Error(
+      `Conversation "${conversationId}" belongs to agent "${conversationAgentId}", not selected agent "${agentId}".`,
+    );
+  }
+}
+
 // ── Handlers ────────────────────────────────────────────────────────
 
-function handleAdd(values: ReturnType<typeof parseCronArgs>["values"]): number {
+async function handleAdd(
+  values: ReturnType<typeof parseCronArgs>["values"],
+): Promise<number> {
   const name = values.name;
   if (!name || typeof name !== "string") {
     console.error("Error: --name is required.");
@@ -189,6 +225,8 @@ function handleAdd(values: ReturnType<typeof parseCronArgs>["values"]): number {
   }
 
   try {
+    await validateConversationTarget(agentId, conversationId);
+
     const result = addTask({
       agent_id: agentId,
       conversation_id: conversationId,


### PR DESCRIPTION
## Summary
- Validate cron add conversation targets before persisting tasks.
- Preserve the existing default and new sentinels while rejecting missing or wrong-agent conversation ids.
- Add targeted CLI coverage for valid ids, invalid labels, default, new, and wrong-agent targets.

Fixes #3018

## Test plan
- [x] bun test ./src/cli/subcommands/cron.test.ts
- [x] bun test ./src/cron
- [x] bunx --bun @biomejs/biome@2.2.5 check src/cli/subcommands/cron.ts src/cli/subcommands/cron.test.ts
- [x] bun run typecheck

👾 Generated with [Letta Code](https://letta.com)