### PR TITLE
feat(cron): add dedicated schedule conversations

### DIFF
--- a/src/cli/subcommands/cron.test.ts
+++ b/src/cli/subcommands/cron.test.ts
@@ -1,0 +1,210 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import { __testSetBackend, type Backend } from "@/backend";
+import { runCronSubcommand } from "@/cli/subcommands/cron";
+import { listTasks } from "@/cron";
+
+const TEST_DIR = path.join(import.meta.dir, "__cron_cli_test_tmp__");
+
+const createConversationMock = mock(
+  async (_body: { agent_id: string; summary: string }) => ({
+    id: "conv-dedicated-1",
+  }),
+);
+
+const backendMock = {
+  capabilities: {
+    remoteMemfs: false,
+    serverSideToolManagement: false,
+    serverSecrets: false,
+    agentFileImportExport: false,
+    promptRecompile: false,
+    byokProviderRefresh: false,
+    localModelCatalog: false,
+    localMemfs: false,
+  },
+  createConversation: createConversationMock,
+} as unknown as Backend;
+
+function captureConsole() {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const logSpy = spyOn(console, "log").mockImplementation(
+    (...args: unknown[]) => {
+      stdout.push(args.map((arg) => String(arg)).join(" "));
+    },
+  );
+  const errorSpy = spyOn(console, "error").mockImplementation(
+    (...args: unknown[]) => {
+      stderr.push(args.map((arg) => String(arg)).join(" "));
+    },
+  );
+
+  return {
+    stdout,
+    stderr,
+    restore: () => {
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
+    },
+  };
+}
+
+describe("cron add --dedicated", () => {
+  let origHome: string | undefined;
+  let origAgentId: string | undefined;
+  let origConversationId: string | undefined;
+
+  beforeEach(() => {
+    origHome = process.env.LETTA_HOME;
+    origAgentId = process.env.LETTA_AGENT_ID;
+    origConversationId = process.env.LETTA_CONVERSATION_ID;
+
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true });
+    }
+    mkdirSync(TEST_DIR, { recursive: true });
+
+    process.env.LETTA_HOME = TEST_DIR;
+    delete process.env.LETTA_AGENT_ID;
+    delete process.env.LETTA_CONVERSATION_ID;
+
+    createConversationMock.mockClear();
+    createConversationMock.mockResolvedValue({ id: "conv-dedicated-1" });
+    __testSetBackend(backendMock);
+  });
+
+  afterEach(() => {
+    __testSetBackend(null);
+
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true });
+    }
+
+    if (origHome === undefined) delete process.env.LETTA_HOME;
+    else process.env.LETTA_HOME = origHome;
+    if (origAgentId === undefined) delete process.env.LETTA_AGENT_ID;
+    else process.env.LETTA_AGENT_ID = origAgentId;
+    if (origConversationId === undefined)
+      delete process.env.LETTA_CONVERSATION_ID;
+    else process.env.LETTA_CONVERSATION_ID = origConversationId;
+  });
+
+  test("creates a stable conversation and stores its id on the task", async () => {
+    const capture = captureConsole();
+    try {
+      const code = await runCronSubcommand([
+        "add",
+        "--name",
+        "bi-hourly-status-report",
+        "--description",
+        "Bi-hourly status report",
+        "--cron",
+        "0 */2 * * *",
+        "--agent",
+        "agent-1",
+        "--dedicated",
+        "--prompt",
+        "write the report",
+      ]);
+
+      expect(code).toBe(0);
+      expect(createConversationMock).toHaveBeenCalledTimes(1);
+      expect(createConversationMock.mock.calls[0]?.[0]).toEqual({
+        agent_id: "agent-1",
+        summary: "[Schedule] bi-hourly-status-report",
+      });
+
+      const output = JSON.parse(capture.stdout[0] ?? "{}");
+      expect(output).toMatchObject({
+        status: "active",
+        cron: "0 */2 * * *",
+        recurring: true,
+        agent_id: "agent-1",
+        conversation_id: "conv-dedicated-1",
+      });
+
+      const tasks = listTasks({ agent_id: "agent-1" });
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0]?.conversation_id).toBe("conv-dedicated-1");
+
+      const listCode = await runCronSubcommand(["list", "--agent", "agent-1"]);
+      expect(listCode).toBe(0);
+      const listOutput = JSON.parse(capture.stdout[1] ?? "[]");
+      expect(listOutput).toEqual([
+        expect.objectContaining({ conversation_id: "conv-dedicated-1" }),
+      ]);
+    } finally {
+      capture.restore();
+    }
+  });
+
+  test("rejects --dedicated with --conversation before creating anything", async () => {
+    const capture = captureConsole();
+    try {
+      const code = await runCronSubcommand([
+        "add",
+        "--name",
+        "conflict",
+        "--description",
+        "Invalid conflict",
+        "--cron",
+        "0 * * * *",
+        "--agent",
+        "agent-1",
+        "--conversation",
+        "conv-existing",
+        "--dedicated",
+        "--prompt",
+        "do not add",
+      ]);
+
+      expect(code).toBe(1);
+      expect(createConversationMock).not.toHaveBeenCalled();
+      expect(listTasks()).toHaveLength(0);
+      expect(capture.stderr.join("\n")).toContain(
+        "--dedicated cannot be used with --conversation",
+      );
+    } finally {
+      capture.restore();
+    }
+  });
+
+  test("preserves explicit new conversation target without creating one now", async () => {
+    const capture = captureConsole();
+    try {
+      const code = await runCronSubcommand([
+        "add",
+        "--name",
+        "new-each-fire",
+        "--description",
+        "Create a new conversation per fire",
+        "--cron",
+        "0 * * * *",
+        "--agent",
+        "agent-1",
+        "--conversation",
+        "new",
+        "--prompt",
+        "start fresh",
+      ]);
+
+      expect(code).toBe(0);
+      expect(createConversationMock).not.toHaveBeenCalled();
+      const output = JSON.parse(capture.stdout[0] ?? "{}");
+      expect(output.conversation_id).toBe("new");
+      expect(listTasks()[0]?.conversation_id).toBe("new");
+    } finally {
+      capture.restore();
+    }
+  });
+});

--- a/src/cli/subcommands/cron.ts
+++ b/src/cli/subcommands/cron.ts
@@ -149,6 +149,7 @@ async function handleAdd(
   }
 
   const dedicated = values.dedicated === true;
+  // Dedicated mode owns the target; accepting --conversation would be ambiguous.
   if (dedicated && values.conversation !== undefined) {
     console.error("Error: --dedicated cannot be used with --conversation.");
     return 1;
@@ -216,6 +217,7 @@ async function handleAdd(
   }
 
   try {
+    // Create it now so the schedule stores one stable, real conversation id.
     const conversationId = dedicated
       ? await createDedicatedCronConversation(agentId, name)
       : getConversationId(values.conversation);

--- a/src/cli/subcommands/cron.ts
+++ b/src/cli/subcommands/cron.ts
@@ -2,9 +2,9 @@
  * `letta cron` CLI subcommand.
  *
  * Usage:
- *   letta cron add --prompt <text> --every <interval> [--agent <id>] [--conversation <id>]
- *   letta cron add --prompt <text> --at <time> [--once] [--agent <id>]
- *   letta cron add --prompt <text> --cron <expr> [--agent <id>]
+ *   letta cron add --prompt <text> --every <interval> [--agent <id>] [--conversation <id> | --dedicated]
+ *   letta cron add --prompt <text> --at <time> [--once] [--agent <id>] [--conversation <id> | --dedicated]
+ *   letta cron add --prompt <text> --cron <expr> [--agent <id>] [--conversation <id> | --dedicated]
  *   letta cron list [--agent <id>] [--conversation <id>]
  *   letta cron get <id>
  *   letta cron runs --id <id>
@@ -13,6 +13,7 @@
  */
 
 import { parseArgs } from "node:util";
+import { getBackend } from "@/backend";
 import {
   addTask,
   deleteAllTasks,
@@ -49,6 +50,7 @@ Add options:
   --cron <expr>          Raw 5-field cron expression
   --agent <id>           Agent ID (defaults to LETTA_AGENT_ID)
   --conversation <id>    Conversation ID (defaults to LETTA_CONVERSATION_ID or "default")
+  --dedicated            Create one stable conversation for this task (conflicts with --conversation)
 
 List/filter options:
   --agent <id>           Filter by agent ID
@@ -75,6 +77,7 @@ const CRON_OPTIONS = {
   cron: { type: "string" },
   agent: { type: "string" },
   conversation: { type: "string" },
+  dedicated: { type: "boolean" },
   all: { type: "boolean" },
   id: { type: "string" },
   limit: { type: "string" },
@@ -98,9 +101,29 @@ function getConversationId(fromArgs?: string): string {
   return fromArgs || process.env.LETTA_CONVERSATION_ID || "default";
 }
 
+function getDedicatedConversationSummary(name: string): string {
+  return `[Schedule] ${name}`;
+}
+
+async function createDedicatedCronConversation(
+  agentId: string,
+  name: string,
+): Promise<string> {
+  const conversation = await getBackend().createConversation({
+    agent_id: agentId,
+    summary: getDedicatedConversationSummary(name),
+  });
+  if (!conversation.id) {
+    throw new Error("Dedicated conversation creation did not return an id.");
+  }
+  return conversation.id;
+}
+
 // ── Handlers ────────────────────────────────────────────────────────
 
-function handleAdd(values: ReturnType<typeof parseCronArgs>["values"]): number {
+async function handleAdd(
+  values: ReturnType<typeof parseCronArgs>["values"],
+): Promise<number> {
   const name = values.name;
   if (!name || typeof name !== "string") {
     console.error("Error: --name is required.");
@@ -125,7 +148,11 @@ function handleAdd(values: ReturnType<typeof parseCronArgs>["values"]): number {
     return 1;
   }
 
-  const conversationId = getConversationId(values.conversation);
+  const dedicated = values.dedicated === true;
+  if (dedicated && values.conversation !== undefined) {
+    console.error("Error: --dedicated cannot be used with --conversation.");
+    return 1;
+  }
 
   // Determine schedule type
   const everyValue = values.every;
@@ -189,6 +216,10 @@ function handleAdd(values: ReturnType<typeof parseCronArgs>["values"]): number {
   }
 
   try {
+    const conversationId = dedicated
+      ? await createDedicatedCronConversation(agentId, name)
+      : getConversationId(values.conversation);
+
     const result = addTask({
       agent_id: agentId,
       conversation_id: conversationId,


### PR DESCRIPTION
## Summary
- Add `letta cron add --dedicated` to create a real conversation at schedule creation time and store that returned id on the cron task.
- Reject `--dedicated` with `--conversation`, while keeping `default` and `new` conversation target behavior unchanged.
- Cover dedicated creation, JSON/list output, and conflict validation with CLI tests.

Closes #3017

## Test plan
- [x] `bun test src/cli/subcommands/cron.test.ts`
- [x] `bunx --bun @biomejs/biome@2.2.5 check --config-path biome.json src/cli/subcommands/cron.ts src/cli/subcommands/cron.test.ts`
- [x] `bun run typecheck`
- [x] `git diff --check`

👾 Generated with [Letta Code](https://letta.com)