### PR TITLE
fix(memory): surface reflection failure details

### DIFF
--- a/src/cli/helpers/memory-subagent-completion.ts
+++ b/src/cli/helpers/memory-subagent-completion.ts
@@ -1,9 +1,23 @@
 import { recompileAgentSystemPrompt } from "@/agent/modify";
-import { isDebugEnabled } from "@/utils/debug";
+import { debugWarn } from "@/utils/debug";
 import {
   estimateSystemTokens,
   setSystemPromptDoctorState,
 } from "./system-prompt-warning";
+
+const MAX_FAILURE_DETAIL_LENGTH = 200;
+
+function rawFailureDetail(error: string | undefined): string {
+  return error?.trim() || "Unknown error";
+}
+
+function normalizeFailureDetail(error: string | undefined): string {
+  const normalized = rawFailureDetail(error).replace(/\s+/g, " ").trim();
+  if (normalized.length <= MAX_FAILURE_DETAIL_LENGTH) {
+    return normalized;
+  }
+  return `${normalized.slice(0, MAX_FAILURE_DETAIL_LENGTH - 3).trimEnd()}...`;
+}
 
 export type MemorySubagentType = "init" | "reflection";
 
@@ -82,12 +96,17 @@ export async function handleMemorySubagentCompletion(
   }
 
   if (!success) {
+    const rawError = rawFailureDetail(error);
+    const detail = normalizeFailureDetail(error);
+    debugWarn(
+      "memory",
+      `Memory ${subagentType} subagent failed for ${agentId} in conversation ${conversationId}: ${rawError}`,
+    );
+
     if (subagentType === "reflection") {
-      const detail = isDebugEnabled() ? `: ${error || "Unknown error"}` : "";
-      return `Tried to reflect, but got lost in the palace${detail}`;
+      return `Tried to reflect, but got lost in the palace: ${detail}`;
     }
-    const normalizedError = error || "Unknown error";
-    return `Memory initialization failed: ${normalizedError}`;
+    return `Memory initialization failed: ${detail}`;
   }
 
   const baseMessage =

--- a/src/cli/memory-subagent-recompile.test.ts
+++ b/src/cli/memory-subagent-recompile.test.ts
@@ -195,4 +195,72 @@ describe("memory subagent recompile handling", () => {
       "agent-shared",
     );
   });
+
+  test("includes reflection failure detail", async () => {
+    const message = await handleMemorySubagentCompletion(
+      {
+        agentId: "agent-reflection-fail",
+        conversationId: "conv-reflection-fail",
+        subagentType: "reflection",
+        success: false,
+        error: "provider returned 500",
+      },
+      {
+        recompileByConversation: new Map(),
+        recompileQueuedByConversation: new Set(),
+        recompileAgentSystemPromptImpl: recompileAgentSystemPromptMock,
+      },
+    );
+
+    expect(message).toBe(
+      "Tried to reflect, but got lost in the palace: provider returned 500",
+    );
+    expect(recompileAgentSystemPromptMock).not.toHaveBeenCalled();
+  });
+
+  test("truncates long multiline reflection failure detail", async () => {
+    const message = await handleMemorySubagentCompletion(
+      {
+        agentId: "agent-reflection-long-fail",
+        conversationId: "conv-reflection-long-fail",
+        subagentType: "reflection",
+        success: false,
+        error: `first line\n${"x".repeat(400)}\nfinal line`,
+      },
+      {
+        recompileByConversation: new Map(),
+        recompileQueuedByConversation: new Set(),
+        recompileAgentSystemPromptImpl: recompileAgentSystemPromptMock,
+      },
+    );
+
+    const prefix = "Tried to reflect, but got lost in the palace: ";
+    expect(message.startsWith(prefix)).toBe(true);
+    expect(message).not.toContain("\n");
+    expect(message).not.toContain("final line");
+    expect(message.endsWith("...")).toBe(true);
+    expect(message.length).toBeLessThanOrEqual(prefix.length + 200);
+  });
+
+  test("init failure still includes error detail", async () => {
+    const message = await handleMemorySubagentCompletion(
+      {
+        agentId: "agent-init-fail",
+        conversationId: "conv-init-fail",
+        subagentType: "init",
+        success: false,
+        error: "memory root unavailable",
+      },
+      {
+        recompileByConversation: new Map(),
+        recompileQueuedByConversation: new Set(),
+        recompileAgentSystemPromptImpl: recompileAgentSystemPromptMock,
+      },
+    );
+
+    expect(message).toBe(
+      "Memory initialization failed: memory root unavailable",
+    );
+    expect(recompileAgentSystemPromptMock).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- Surface normalized reflection subagent failure details in the "got lost in the palace" completion message outside debug mode.
- Persist memory subagent failures to the session debug log via `debugWarn("memory", ...)`.
- Add focused coverage for reflection failure detail, long/multiline truncation, and init failure detail.

## Test plan
- [x] `bun test /Users/lettamate/letta-code/.letta/worktrees/reflection-error-details/src/cli/memory-subagent-recompile.test.ts`
- [x] `cd /Users/lettamate/letta-code/.letta/worktrees/reflection-error-details && bunx --bun @biomejs/biome@2.2.5 check src/cli/helpers/memory-subagent-completion.ts src/cli/memory-subagent-recompile.test.ts`

👾 Generated with [Letta Code](https://letta.com)