### PR TITLE
refactor(subagent): remove unused mode metadata

### DIFF
--- a/src/agent/subagent-builtins.test.ts
+++ b/src/agent/subagent-builtins.test.ts
@@ -65,14 +65,6 @@ describe("built-in subagents", () => {
     }
   });
 
-  test("parses subagent mode and defaults missing mode to stateful", async () => {
-    const configs = await getAllSubagentConfigs();
-
-    expect(configs.reflection?.mode).toBe("stateless");
-    expect(configs["general-purpose"]?.mode).toBe("stateful");
-    expect(configs.memory?.mode).toBe("stateful");
-  });
-
   test("reuses MemFS built-in prompts when local backend is active", async () => {
     __testSetBackend({
       capabilities: { localMemfs: true },

--- a/src/agent/subagent-model-resolution.test.ts
+++ b/src/agent/subagent-model-resolution.test.ts
@@ -245,7 +245,6 @@ describe("buildSubagentArgs", () => {
     allowedTools: "all",
     recommendedModel: "inherit",
     skills: [],
-    mode: "stateful",
     fork: false,
     background: false,
   };

--- a/src/agent/subagents/builtin/fork.md
+++ b/src/agent/subagents/builtin/fork.md
@@ -3,7 +3,6 @@ name: fork
 description: Fork of the parent agent with full context and tools. Recommended to run in background (run_in_background: true).
 tools: Bash, TaskOutput, Edit, KillBash, LS, MultiEdit, Read, TodoWrite, Write
 model: inherit
-mode: stateful
 fork: true
 background: true
 ---

--- a/src/agent/subagents/builtin/general-purpose.md
+++ b/src/agent/subagents/builtin/general-purpose.md
@@ -3,7 +3,6 @@ name: general-purpose
 description: Full-capability agent for research, planning, and implementation
 tools: Bash, TaskOutput, Edit, KillBash, LS, MultiEdit, Read, TodoWrite, Write
 model: auto
-mode: stateful
 ---
 
 You are a general-purpose coding agent that can research, plan, and implement.
@@ -32,4 +31,4 @@ You DO have access to the full conversation history before you were launched.
 3. Any assumptions or decisions you made
 4. Suggested next steps (if any)
 
-Remember: You are stateless and return ONE final report when done. Make changes confidently based on the context provided.
+Remember: Return ONE final report when done. Make changes confidently based on the context provided.

--- a/src/agent/subagents/builtin/history-analyzer.md
+++ b/src/agent/subagents/builtin/history-analyzer.md
@@ -4,7 +4,6 @@ description: Analyze Claude Code or Codex conversation history and directly upda
 tools: Read, Write, Bash
 skills:
 model: auto
-mode: stateless
 permissionMode: memory
 ---
 

--- a/src/agent/subagents/builtin/recall.md
+++ b/src/agent/subagents/builtin/recall.md
@@ -3,7 +3,6 @@ name: recall
 description: Recall past interactions and experience
 tools: Bash, Read, TaskOutput
 model: inherit
-mode: stateful
 fork: true
 ---
 

--- a/src/agent/subagents/builtin/reflection.md
+++ b/src/agent/subagents/builtin/reflection.md
@@ -3,7 +3,6 @@ name: reflection
 description: Background agent that reflects on recent conversations and updates memory files
 tools: Bash
 model: inherit
-mode: stateless
 permissionMode: memory
 ---
 

--- a/src/agent/subagents/index.ts
+++ b/src/agent/subagents/index.ts
@@ -52,8 +52,6 @@ const LOCAL_MEMFS_BUILTIN_SOURCES = [
 /**
  * Subagent configuration
  */
-export type SubagentMode = "stateful" | "stateless";
-
 export interface SubagentConfig {
   /** Unique identifier for the subagent */
   name: string;
@@ -67,8 +65,6 @@ export interface SubagentConfig {
   recommendedModel: string;
   /** Skills to auto-load */
   skills: string[];
-  /** Stateless agents should not persist private working memory. */
-  mode: SubagentMode;
   /** Whether this subagent should fork the parent conversation before launch. */
   fork: boolean;
   /** Whether this subagent should run in the background by default. */
@@ -155,12 +151,6 @@ function parseSkills(skillsStr: string | undefined): string[] {
   return parseCommaSeparatedList(skillsStr);
 }
 
-function parseSubagentMode(modeStr: string | undefined): SubagentMode {
-  return modeStr?.trim().toLowerCase() === "stateless"
-    ? "stateless"
-    : "stateful";
-}
-
 /**
  * Validate subagent frontmatter
  * Only validates required fields - optional fields are validated at runtime where needed
@@ -215,7 +205,6 @@ function parseSubagentContent(content: string): SubagentConfig {
     allowedTools: parseTools(getStringField(frontmatter, "tools")),
     recommendedModel: getStringField(frontmatter, "model") || "inherit",
     skills: parseSkills(getStringField(frontmatter, "skills")),
-    mode: parseSubagentMode(getStringField(frontmatter, "mode")),
     fork: getStringField(frontmatter, "fork")?.toLowerCase() === "true",
     background:
       getStringField(frontmatter, "background")?.toLowerCase() === "true",


### PR DESCRIPTION
## Summary
- remove the unused stateful/stateless subagent mode field from config parsing and types
- drop mode frontmatter from built-in subagents
- remove tests that asserted mode parsing/defaulting

## Tests
- bun test src/agent/subagent-builtins.test.ts src/agent/subagent-model-resolution.test.ts
- bun run lint
- bun run check

Note: ruff check was attempted but ruff is not installed in this repo/env.