### PR TITLE
fix(channels): bake polyglot shebang into build and warn on unhydratable secret refs

### DIFF
--- a/build.js
+++ b/build.js
@@ -17,6 +17,11 @@ const pkg = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf-8"));
 const version = pkg.version;
 const useMagick = Bun.env.USE_MAGICK;
 const features = [];
+const NODE_SHEBANG = "#!/usr/bin/env node";
+const POLYGLOT_SHEBANG = `#!/bin/sh
+":" //#; exec /usr/bin/env sh -c 'command -v bun >/dev/null && exec bun "$0" "$@" || exec node "$0" "$@"' "$0" "$@"`;
+const executableShebang =
+  process.platform === "win32" ? NODE_SHEBANG : POLYGLOT_SHEBANG;
 
 console.log(`📦 Building Letta Code v${version}...`);
 if (useMagick) {
@@ -70,7 +75,7 @@ content = content.replace(
   `globalThis.Bun.secrets`,
 );
 
-const withShebang = `#!/usr/bin/env node
+const withShebang = `${executableShebang}
 ${content}`;
 await Bun.write(outputPath, withShebang);
 

--- a/scripts/postinstall-patches.js
+++ b/scripts/postinstall-patches.js
@@ -1,7 +1,6 @@
 // Postinstall patcher for vendoring our Ink modifications without patch-package.
 // Copies patched runtime files from ./src/vendor into node_modules.
 
-import { execSync } from "node:child_process";
 import {
   copyFileSync,
   existsSync,
@@ -16,6 +15,9 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkgRoot = dirname(__dirname);
 const require = createRequire(import.meta.url);
+const NODE_SHEBANG = "#!/usr/bin/env node";
+const POLYGLOT_SHEBANG = `#!/bin/sh
+":" //#; exec /usr/bin/env sh -c 'command -v bun >/dev/null && exec bun "$0" "$@" || exec node "$0" "$@"' "$0" "$@"`;
 
 async function copyToResolved(srcRel, targetSpecifier) {
   const src = join(pkgRoot, srcRel);
@@ -111,26 +113,20 @@ await copyToResolved(
 
 console.log("[patch] Ink runtime patched");
 
-// On Unix with Bun available, use polyglot shebang to prefer Bun runtime.
-// This enables Bun.secrets for secure keychain storage instead of fallback.
-// Windows always uses #!/usr/bin/env node (polyglot shebang breaks npm wrappers).
-if (process.platform !== "win32") {
-  try {
-    execSync("bun --version", { stdio: "ignore" });
-    const lettaPath = join(pkgRoot, "letta.js");
-    if (existsSync(lettaPath)) {
-      let content = readFileSync(lettaPath, "utf-8");
-      if (content.startsWith("#!/usr/bin/env node")) {
-        content = content.replace(
-          "#!/usr/bin/env node",
-          `#!/bin/sh
-":" //#; exec /usr/bin/env sh -c 'command -v bun >/dev/null && exec bun "$0" "$@" || exec node "$0" "$@"' "$0" "$@"`,
-        );
-        writeFileSync(lettaPath, content);
-        console.log("[patch] Configured letta to prefer Bun runtime");
-      }
+// Non-Windows builds should prefer Bun at runtime for Bun.secrets keyring access.
+// Windows npm wrappers break on the polyglot shebang, so revert it there.
+const lettaPath = join(pkgRoot, "letta.js");
+if (existsSync(lettaPath)) {
+  let content = readFileSync(lettaPath, "utf-8");
+  if (process.platform === "win32") {
+    if (content.startsWith(POLYGLOT_SHEBANG)) {
+      content = content.replace(POLYGLOT_SHEBANG, NODE_SHEBANG);
+      writeFileSync(lettaPath, content);
+      console.log("[patch] Configured letta to use Node runtime on Windows");
     }
-  } catch {
-    // Bun not available, keep node shebang
+  } else if (content.startsWith(NODE_SHEBANG)) {
+    content = content.replace(NODE_SHEBANG, POLYGLOT_SHEBANG);
+    writeFileSync(lettaPath, content);
+    console.log("[patch] Configured letta to prefer Bun runtime");
   }
 }

--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -593,6 +593,18 @@ export async function hydrateChannelAccountSecrets(
   const mode = await getActiveChannelCredentialsStoreMode();
   const store = getStore(channelId);
   if (mode !== "keyring") {
+    for (const account of store.accounts) {
+      const refs = getSecretRefs(account);
+      if (Object.keys(refs).length > 0) {
+        console.error(
+          `[Channels] Account ${account.channel}/${account.accountId} has keyring-backed secret references ` +
+            `but the credential store is in "${mode}" mode (keyring unavailable). ` +
+            `Token values cannot be hydrated — channel adapters will fail with invalid credentials. ` +
+            `Run "letta channels configure ${account.channel}" to re-enter credentials in file mode, ` +
+            `or ensure the process runs under Bun with keyring access.`,
+        );
+      }
+    }
     return;
   }
 

--- a/src/channels/credential-store.test.ts
+++ b/src/channels/credential-store.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   existsSync,
   mkdirSync,
@@ -165,6 +165,50 @@ describe("channel credential storage", () => {
     __setChannelKeychainAvailableForTests(false);
 
     expect(await getActiveChannelCredentialsStoreMode()).toBe("file");
+  });
+
+  test("file mode warns about keyring secret refs it cannot hydrate", async () => {
+    __setChannelCredentialsStoreModeForTests("auto");
+    __setChannelKeychainAvailableForTests(false);
+    mkdirSync(join(channelsRoot, "slack"), { recursive: true });
+    writeFileSync(
+      join(channelsRoot, "slack", "accounts.json"),
+      `${JSON.stringify(
+        {
+          accounts: [
+            {
+              ...makeSlackAccount(),
+              botToken: "__letta_channel_secret_present__",
+              appToken: "__letta_channel_secret_present__",
+              __letta_secret_refs: {
+                botToken: true,
+                appToken: true,
+              },
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const originalConsoleError = console.error;
+    const consoleError = mock(() => {});
+    console.error = consoleError as typeof console.error;
+    try {
+      await expect(
+        hydrateChannelAccountSecrets("slack"),
+      ).resolves.toBeUndefined();
+    } finally {
+      console.error = originalConsoleError;
+    }
+
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining("keyring-backed secret references"),
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining("keyring unavailable"),
+    );
   });
 
   test("explicit keyring mode errors when keyring is unavailable", async () => {


### PR DESCRIPTION
## Problem

When Letta Code is staged manually (symlinks, file copies without `npm install`), `postinstall-patches.js` never runs, so `letta.js` keeps `#!/usr/bin/env node` instead of the Bun-preferring polyglot shebang. Under Node, `require("bun").secrets` fails → `secretsAvailable = false` → keyring unavailable → channel accounts with `__letta_secret_refs` cannot be hydrated.

In `auto` mode, the fallback to `file` mode is **silent** — `hydrateChannelAccountSecrets()` returns immediately when mode is `file`, but accounts with secret refs still have placeholder values that get passed to Telegram/Discord adapters → confusing 404/TokenInvalid errors instead of a clear diagnostic.

Fixes LET-9257.

## Changes

### 1. Build-time polyglot shebang (`build.js`)

The Bun-preferring polyglot shebang is now written directly into the build output on non-Windows. This means the published package already has the Bun preference — manual staging preserves it without relying on postinstall. The shebang self-selects at runtime: Bun if available, Node otherwise.

### 2. Postinstall shebang normalization (`scripts/postinstall-patches.js`)

- Windows: reverts polyglot shebang to Node shebang (polyglot breaks npm wrappers on Windows).
- Non-Windows: patches old Node shebangs to polyglot as a fallback. Leaves existing polyglot shebangs alone.
- Removed the `bun --version` gate — the polyglot shebang handles runtime selection itself.
- Ink vendor patching is unchanged.

### 3. Runtime diagnostic (`src/channels/accounts.ts`)

When `hydrateChannelAccountSecrets()` runs in file mode (auto fallback) and accounts have `__letta_secret_refs`, it now logs a clear error per affected account instead of silently passing placeholder tokens to adapters.

### 4. Test coverage (`src/channels/credential-store.test.ts`)

New test verifies the warning is logged when file-mode encounters keyring-backed secret refs.

## Validation

- `bun run check` — all 9 checks pass
- `bun test src/channels/credential-store.test.ts` — 7/7 pass
- `bun run build` — succeeds, output `letta.js` starts with polyglot shebang

## Risk

Low. The polyglot shebang falls back to Node at runtime. The diagnostic warning is a console.error — it does not throw or change control flow.

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>