### PR TITLE
feat(mods): add package manifest validation

### DIFF
--- a/src/mods/capabilities.ts
+++ b/src/mods/capabilities.ts
@@ -15,6 +15,12 @@ export const MOD_CAPABILITY_IDS = [
 
 export type ModCapabilityId = (typeof MOD_CAPABILITY_IDS)[number];
 
+const MOD_CAPABILITY_ID_SET = new Set<string>(MOD_CAPABILITY_IDS);
+
+export function isModCapabilityId(value: string): value is ModCapabilityId {
+  return MOD_CAPABILITY_ID_SET.has(value);
+}
+
 export const DEFAULT_MOD_CAPABILITIES: ModCapabilities = {
   tools: true,
   commands: true,

--- a/src/mods/capabilities.ts
+++ b/src/mods/capabilities.ts
@@ -1,5 +1,20 @@
 import type { ModCapabilities } from "@/mods/types";
 
+export const MOD_CAPABILITY_IDS = [
+  "tools",
+  "commands",
+  "providers",
+  "permissions",
+  "events.lifecycle",
+  "events.turns",
+  "events.tools",
+  "ui.panels",
+  "ui.statusValues",
+  "ui.statusline",
+] as const;
+
+export type ModCapabilityId = (typeof MOD_CAPABILITY_IDS)[number];
+
 export const DEFAULT_MOD_CAPABILITIES: ModCapabilities = {
   tools: true,
   commands: true,

--- a/src/mods/file-extensions.ts
+++ b/src/mods/file-extensions.ts
@@ -1,0 +1,21 @@
+export const MOD_FILE_EXTENSIONS = [".js", ".mjs", ".ts", ".tsx"] as const;
+export const TYPESCRIPT_MOD_FILE_EXTENSIONS = [".ts", ".tsx"] as const;
+
+export type ModFileExtension = (typeof MOD_FILE_EXTENSIONS)[number];
+export type TypeScriptModFileExtension =
+  (typeof TYPESCRIPT_MOD_FILE_EXTENSIONS)[number];
+
+const MOD_FILE_EXTENSION_SET = new Set<string>(MOD_FILE_EXTENSIONS);
+const TYPESCRIPT_MOD_FILE_EXTENSION_SET = new Set<string>(
+  TYPESCRIPT_MOD_FILE_EXTENSIONS,
+);
+
+export function isModFileExtension(value: string): value is ModFileExtension {
+  return MOD_FILE_EXTENSION_SET.has(value);
+}
+
+export function isTypeScriptModFileExtension(
+  value: string,
+): value is TypeScriptModFileExtension {
+  return TYPESCRIPT_MOD_FILE_EXTENSION_SET.has(value);
+}

--- a/src/mods/mod-engine.ts
+++ b/src/mods/mod-engine.ts
@@ -38,6 +38,10 @@ import {
   recordDeprecatedContextApiSourceDiagnostics,
 } from "@/mods/deprecated-api";
 import {
+  isModFileExtension,
+  isTypeScriptModFileExtension,
+} from "@/mods/file-extensions";
+import {
   appendModDiagnostic,
   recordModDiagnostic,
   recordStaleHandleUse,
@@ -95,8 +99,6 @@ export const LEGACY_GLOBAL_EXTENSIONS_DIRECTORY =
   getLegacyGlobalExtensionsDirectory();
 export const MOD_CACHE_DIRECTORY = getModCacheDirectory();
 
-const MOD_FILE_EXTENSIONS = new Set([".js", ".mjs", ".ts", ".tsx"]);
-const TYPESCRIPT_MOD_FILE_EXTENSIONS = new Set([".ts", ".tsx"]);
 const requireFromRuntime = createRequire(import.meta.url);
 
 export type StatuslineRenderFunction = (
@@ -265,7 +267,7 @@ function listModFiles(directory: string): string[] {
     .filter((entry) => {
       if (!entry.isFile()) return false;
       if (entry.name.startsWith(".")) return false;
-      return MOD_FILE_EXTENSIONS.has(path.extname(entry.name));
+      return isModFileExtension(path.extname(entry.name));
     })
     .map((entry) => path.join(directory, entry.name))
     .sort((a, b) => a.localeCompare(b));
@@ -483,7 +485,7 @@ function transpileTypeScriptMod(modPath: string, source: string): string {
 
 function prepareModForImport(modPath: string, source: string): string {
   const fileExtension = path.extname(modPath);
-  if (TYPESCRIPT_MOD_FILE_EXTENSIONS.has(fileExtension)) {
+  if (isTypeScriptModFileExtension(fileExtension)) {
     return transpileTypeScriptMod(modPath, source);
   }
 
@@ -1277,7 +1279,7 @@ export async function loadLocalMods(
             );
           },
         );
-        failurePhase = TYPESCRIPT_MOD_FILE_EXTENSIONS.has(path.extname(modPath))
+        failurePhase = isTypeScriptModFileExtension(path.extname(modPath))
           ? "transpile"
           : "import";
         const importPath = createImportableModPath(modPath, cacheDirectory);

--- a/src/mods/package-manifest.test.ts
+++ b/src/mods/package-manifest.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  parseLettaPackageManifest,
+  readLettaPackageManifest,
+} from "@/mods/package-manifest";
+
+function createTempDir(): string {
+  return mkdtempSync(path.join(tmpdir(), "letta-package-manifest-"));
+}
+
+function errorPathsFor(packageJson: unknown): string[] {
+  const result = parseLettaPackageManifest(packageJson);
+  if (result.ok) return [];
+  return result.errors.map((error) => error.path);
+}
+
+function errorMessagesFor(packageJson: unknown): string[] {
+  const result = parseLettaPackageManifest(packageJson);
+  if (result.ok) return [];
+  return result.errors.map((error) => error.message);
+}
+
+describe("Letta package manifest", () => {
+  test("parses a valid minimal manifest", () => {
+    const result = parseLettaPackageManifest({
+      letta: {
+        manifestVersion: 1,
+        mods: ["./mods/index.ts"],
+      },
+    });
+
+    expect(result).toEqual({
+      errors: [],
+      manifest: {
+        manifestVersion: 1,
+        mods: ["./mods/index.ts"],
+      },
+      ok: true,
+    });
+  });
+
+  test("parses capabilities and engines", () => {
+    const result = parseLettaPackageManifest({
+      letta: {
+        manifestVersion: 1,
+        mods: ["mods/provider.mjs", "mods/statusline.tsx"],
+        capabilities: ["providers", "ui.statusline", "events.lifecycle"],
+        engines: {
+          lettaCodeCli: ">=0.28.0",
+          lettaCodeDesktop: ">=0.12.0 <0.20.0",
+        },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.manifest).toEqual({
+      manifestVersion: 1,
+      mods: ["mods/provider.mjs", "mods/statusline.tsx"],
+      capabilities: ["providers", "ui.statusline", "events.lifecycle"],
+      engines: {
+        lettaCodeCli: ">=0.28.0",
+        lettaCodeDesktop: ">=0.12.0 <0.20.0",
+      },
+    });
+  });
+
+  test("returns null when package has no Letta manifest", () => {
+    expect(parseLettaPackageManifest({ name: "@caren/example" })).toEqual({
+      errors: [],
+      manifest: null,
+      ok: true,
+    });
+  });
+
+  test("rejects non-object package and manifest values", () => {
+    expect(errorPathsFor(null)).toEqual(["package"]);
+    expect(errorPathsFor({ letta: true })).toEqual(["letta"]);
+  });
+
+  test("rejects invalid manifestVersion", () => {
+    expect(
+      errorPathsFor({
+        letta: {
+          manifestVersion: 2,
+          mods: ["mods/index.ts"],
+        },
+      }),
+    ).toContain("letta.manifestVersion");
+  });
+
+  test("rejects missing, non-array, and empty mods", () => {
+    expect(errorPathsFor({ letta: { manifestVersion: 1 } })).toContain(
+      "letta.mods",
+    );
+    expect(
+      errorPathsFor({ letta: { manifestVersion: 1, mods: "mods/index.ts" } }),
+    ).toContain("letta.mods");
+    expect(
+      errorPathsFor({ letta: { manifestVersion: 1, mods: [] } }),
+    ).toContain("letta.mods");
+  });
+
+  test("rejects unsafe mod entry paths", () => {
+    const entries = [
+      "",
+      "/tmp/mod.ts",
+      "../mod.ts",
+      "mods/../mod.ts",
+      "mods/index.json",
+      "C:/Users/caren/mod.ts",
+      "C:\\Users\\caren\\mod.ts",
+      "\\\\server\\share\\mod.ts",
+    ];
+
+    const result = parseLettaPackageManifest({
+      letta: {
+        manifestVersion: 1,
+        mods: entries,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.errors.map((error) => error.path)).toEqual(
+      entries.map((_, index) => `letta.mods[${index}]`),
+    );
+  });
+
+  test("rejects unknown capabilities and non-string capability entries", () => {
+    const result = parseLettaPackageManifest({
+      letta: {
+        manifestVersion: 1,
+        mods: ["mods/index.ts"],
+        capabilities: ["commands", "ui.unknown", 1],
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.errors.map((error) => error.path)).toEqual([
+      "letta.capabilities[1]",
+      "letta.capabilities[2]",
+    ]);
+  });
+
+  test("accepts common semver range syntax", () => {
+    const result = parseLettaPackageManifest({
+      letta: {
+        manifestVersion: 1,
+        mods: ["mods/index.ts"],
+        engines: {
+          lettaCodeCli: "^0.28.0 || ~0.29.0",
+          lettaCodeDesktop: ">=0.12.0-beta.1+build.5 <0.20.x",
+        },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects malformed engines", () => {
+    const result = parseLettaPackageManifest({
+      letta: {
+        manifestVersion: 1,
+        mods: ["mods/index.ts"],
+        engines: {
+          lettaCodeCli: "1.2.3+build+extra",
+          lettaCodeDesktop: 1,
+          unknownRuntime: ">=1.0.0",
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.errors.map((error) => error.path).sort()).toEqual([
+      "letta.engines.lettaCodeCli",
+      "letta.engines.lettaCodeDesktop",
+      "letta.engines.unknownRuntime",
+    ]);
+  });
+
+  test("rejects unknown manifest keys", () => {
+    const result = parseLettaPackageManifest({
+      letta: {
+        manifestVersion: 1,
+        mods: ["mods/index.ts"],
+        skills: ["skills/example"],
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.errors).toEqual([
+      {
+        message: "unknown manifest field 'skills'",
+        path: "letta.skills",
+      },
+    ]);
+  });
+
+  test("reads manifest from package.json", () => {
+    const root = createTempDir();
+    try {
+      const packageJsonPath = path.join(root, "package.json");
+      mkdirSync(path.dirname(packageJsonPath), { recursive: true });
+      writeFileSync(
+        packageJsonPath,
+        JSON.stringify({
+          letta: {
+            manifestVersion: 1,
+            mods: ["mods/index.js"],
+          },
+        }),
+      );
+
+      expect(readLettaPackageManifest(packageJsonPath)).toEqual({
+        errors: [],
+        manifest: {
+          manifestVersion: 1,
+          mods: ["mods/index.js"],
+        },
+        ok: true,
+      });
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("surfaces package.json read and parse errors", () => {
+    const root = createTempDir();
+    try {
+      const packageJsonPath = path.join(root, "package.json");
+      writeFileSync(packageJsonPath, "{");
+
+      expect(
+        errorMessagesFor({ letta: { manifestVersion: 1, mods: [1] } }),
+      ).toEqual(["mod entry must be a string path"]);
+      const result = readLettaPackageManifest(packageJsonPath);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.errors[0]?.path).toBe(packageJsonPath);
+      expect(result.errors[0]?.message).toContain("JSON");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/src/mods/package-manifest.test.ts
+++ b/src/mods/package-manifest.test.ts
@@ -111,6 +111,7 @@ describe("Letta package manifest", () => {
       "/tmp/mod.ts",
       "../mod.ts",
       "mods/../mod.ts",
+      "mods\\index.ts",
       "mods/index.json",
       "C:/Users/caren/mod.ts",
       "C:\\Users\\caren\\mod.ts",

--- a/src/mods/package-manifest.ts
+++ b/src/mods/package-manifest.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { MOD_CAPABILITY_IDS, type ModCapabilityId } from "@/mods/capabilities";
+import { isModCapabilityId, type ModCapabilityId } from "@/mods/capabilities";
+import { isModFileExtension } from "@/mods/file-extensions";
 
 export const LETTA_PACKAGE_MANIFEST_VERSION = 1;
 
@@ -42,8 +43,6 @@ const MANIFEST_KEYS = new Set([
   "engines",
 ]);
 const ENGINE_KEYS = new Set(["lettaCodeCli", "lettaCodeDesktop"]);
-const CAPABILITIES = new Set<string>(MOD_CAPABILITY_IDS);
-const MOD_ENTRY_EXTENSIONS = new Set([".js", ".mjs", ".ts", ".tsx"]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -71,6 +70,7 @@ function isWindowsAbsolutePath(value: string): boolean {
 function isSafeRelativeModPath(value: string): boolean {
   if (!value.trim()) return false;
   if (value.includes("\0")) return false;
+  if (value.includes("\\")) return false;
   if (path.posix.isAbsolute(value) || path.isAbsolute(value)) return false;
   if (isWindowsAbsolutePath(value)) return false;
 
@@ -81,7 +81,7 @@ function isSafeRelativeModPath(value: string): boolean {
   if (normalized === ".." || normalized.startsWith("../")) return false;
   if (normalized.split("/").includes("..")) return false;
 
-  return MOD_ENTRY_EXTENSIONS.has(path.posix.extname(normalized));
+  return isModFileExtension(path.posix.extname(normalized));
 }
 
 function isValidSemverIdentifier(value: string): boolean {
@@ -201,11 +201,11 @@ function validateCapabilities(
       addError(errors, entryPath, "capability must be a string");
       return;
     }
-    if (!CAPABILITIES.has(entry)) {
+    if (!isModCapabilityId(entry)) {
       addError(errors, entryPath, `unknown capability '${entry}'`);
       return;
     }
-    capabilities.push(entry as LettaPackageCapability);
+    capabilities.push(entry);
   });
 
   return capabilities;

--- a/src/mods/package-manifest.ts
+++ b/src/mods/package-manifest.ts
@@ -1,23 +1,10 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
+import { MOD_CAPABILITY_IDS, type ModCapabilityId } from "@/mods/capabilities";
 
 export const LETTA_PACKAGE_MANIFEST_VERSION = 1;
 
-export const LETTA_PACKAGE_CAPABILITIES = [
-  "tools",
-  "commands",
-  "providers",
-  "permissions",
-  "events.lifecycle",
-  "events.turns",
-  "events.tools",
-  "ui.panels",
-  "ui.statusValues",
-  "ui.statusline",
-] as const;
-
-export type LettaPackageCapability =
-  (typeof LETTA_PACKAGE_CAPABILITIES)[number];
+export type LettaPackageCapability = ModCapabilityId;
 
 export interface LettaPackageEngines {
   lettaCodeCli?: string;
@@ -55,7 +42,7 @@ const MANIFEST_KEYS = new Set([
   "engines",
 ]);
 const ENGINE_KEYS = new Set(["lettaCodeCli", "lettaCodeDesktop"]);
-const CAPABILITIES = new Set<string>(LETTA_PACKAGE_CAPABILITIES);
+const CAPABILITIES = new Set<string>(MOD_CAPABILITY_IDS);
 const MOD_ENTRY_EXTENSIONS = new Set([".js", ".mjs", ".ts", ".tsx"]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/mods/package-manifest.ts
+++ b/src/mods/package-manifest.ts
@@ -1,0 +1,337 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+export const LETTA_PACKAGE_MANIFEST_VERSION = 1;
+
+export const LETTA_PACKAGE_CAPABILITIES = [
+  "tools",
+  "commands",
+  "providers",
+  "permissions",
+  "events.lifecycle",
+  "events.turns",
+  "events.tools",
+  "ui.panels",
+  "ui.statusValues",
+  "ui.statusline",
+] as const;
+
+export type LettaPackageCapability =
+  (typeof LETTA_PACKAGE_CAPABILITIES)[number];
+
+export interface LettaPackageEngines {
+  lettaCodeCli?: string;
+  lettaCodeDesktop?: string;
+}
+
+export interface LettaPackageManifest {
+  manifestVersion: typeof LETTA_PACKAGE_MANIFEST_VERSION;
+  mods: string[];
+  capabilities?: LettaPackageCapability[];
+  engines?: LettaPackageEngines;
+}
+
+export interface LettaPackageManifestValidationError {
+  message: string;
+  path: string;
+}
+
+export type LettaPackageManifestParseResult =
+  | {
+      errors: [];
+      manifest: LettaPackageManifest | null;
+      ok: true;
+    }
+  | {
+      errors: LettaPackageManifestValidationError[];
+      manifest: null;
+      ok: false;
+    };
+
+const MANIFEST_KEYS = new Set([
+  "manifestVersion",
+  "mods",
+  "capabilities",
+  "engines",
+]);
+const ENGINE_KEYS = new Set(["lettaCodeCli", "lettaCodeDesktop"]);
+const CAPABILITIES = new Set<string>(LETTA_PACKAGE_CAPABILITIES);
+const MOD_ENTRY_EXTENSIONS = new Set([".js", ".mjs", ".ts", ".tsx"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function addError(
+  errors: LettaPackageManifestValidationError[],
+  errorPath: string,
+  message: string,
+): void {
+  errors.push({ message, path: errorPath });
+}
+
+function getUnknownKeys(
+  value: Record<string, unknown>,
+  knownKeys: Set<string>,
+): string[] {
+  return Object.keys(value).filter((key) => !knownKeys.has(key));
+}
+
+function isWindowsAbsolutePath(value: string): boolean {
+  return path.win32.isAbsolute(value) || /^[a-zA-Z]:[\\/]/.test(value);
+}
+
+function isSafeRelativeModPath(value: string): boolean {
+  if (!value.trim()) return false;
+  if (value.includes("\0")) return false;
+  if (path.posix.isAbsolute(value) || path.isAbsolute(value)) return false;
+  if (isWindowsAbsolutePath(value)) return false;
+
+  const posixPath = value.replace(/\\/g, "/");
+  if (posixPath.split("/").includes("..")) return false;
+  const normalized = path.posix.normalize(posixPath);
+  if (normalized === "." || normalized === "") return false;
+  if (normalized === ".." || normalized.startsWith("../")) return false;
+  if (normalized.split("/").includes("..")) return false;
+
+  return MOD_ENTRY_EXTENSIONS.has(path.posix.extname(normalized));
+}
+
+function isValidSemverIdentifier(value: string): boolean {
+  return /^[0-9A-Za-z-]+$/.test(value);
+}
+
+function isValidSemverVersion(value: string): boolean {
+  if (value === "*" || /^[xX]$/.test(value)) return true;
+
+  const buildSeparatorIndex = value.indexOf("+");
+  const versionWithPrerelease =
+    buildSeparatorIndex >= 0 ? value.slice(0, buildSeparatorIndex) : value;
+  const build =
+    buildSeparatorIndex >= 0 ? value.slice(buildSeparatorIndex + 1) : undefined;
+  if (build !== undefined) {
+    if (!build || build.includes("+")) return false;
+    const buildParts = build.split(".");
+    if (buildParts.some((part) => !part || !isValidSemverIdentifier(part))) {
+      return false;
+    }
+  }
+
+  const prereleaseSeparatorIndex = versionWithPrerelease.indexOf("-");
+  const version =
+    prereleaseSeparatorIndex >= 0
+      ? versionWithPrerelease.slice(0, prereleaseSeparatorIndex)
+      : versionWithPrerelease;
+  const prerelease =
+    prereleaseSeparatorIndex >= 0
+      ? versionWithPrerelease.slice(prereleaseSeparatorIndex + 1)
+      : undefined;
+  if (prerelease !== undefined) {
+    if (!prerelease) return false;
+    const prereleaseParts = prerelease.split(".");
+    if (
+      prereleaseParts.some((part) => !part || !isValidSemverIdentifier(part))
+    ) {
+      return false;
+    }
+  }
+
+  const parts = version.split(".");
+  if (parts.length < 1 || parts.length > 3) return false;
+
+  return parts.every((part) => {
+    if (part === "*" || /^[xX]$/.test(part)) return true;
+    return /^(0|[1-9]\d*)$/.test(part);
+  });
+}
+
+function isValidSemverComparator(value: string): boolean {
+  const match = value.match(/^(?:<=|>=|<|>|=|~\s*|\^\s*)?(.+)$/);
+  const version = match?.[1]?.trim();
+  if (!version) return false;
+  return isValidSemverVersion(version);
+}
+
+function isValidSemverRange(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+
+  return trimmed.split("||").every((part) => {
+    const comparators = part.trim().split(/\s+/).filter(Boolean);
+    if (comparators.length === 0) return false;
+    return comparators.every(isValidSemverComparator);
+  });
+}
+
+function validateMods(
+  value: unknown,
+  errors: LettaPackageManifestValidationError[],
+): string[] | null {
+  if (!Array.isArray(value)) {
+    addError(errors, "letta.mods", "mods must be a non-empty array");
+    return null;
+  }
+  if (value.length === 0) {
+    addError(errors, "letta.mods", "mods must include at least one entry");
+    return null;
+  }
+
+  const mods: string[] = [];
+  value.forEach((entry, index) => {
+    const entryPath = `letta.mods[${index}]`;
+    if (typeof entry !== "string") {
+      addError(errors, entryPath, "mod entry must be a string path");
+      return;
+    }
+    if (!isSafeRelativeModPath(entry)) {
+      addError(
+        errors,
+        entryPath,
+        "mod entry must be a safe relative .ts, .tsx, .js, or .mjs path",
+      );
+      return;
+    }
+    mods.push(entry);
+  });
+
+  return mods;
+}
+
+function validateCapabilities(
+  value: unknown,
+  errors: LettaPackageManifestValidationError[],
+): LettaPackageCapability[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) {
+    addError(errors, "letta.capabilities", "capabilities must be an array");
+    return undefined;
+  }
+
+  const capabilities: LettaPackageCapability[] = [];
+  value.forEach((entry, index) => {
+    const entryPath = `letta.capabilities[${index}]`;
+    if (typeof entry !== "string") {
+      addError(errors, entryPath, "capability must be a string");
+      return;
+    }
+    if (!CAPABILITIES.has(entry)) {
+      addError(errors, entryPath, `unknown capability '${entry}'`);
+      return;
+    }
+    capabilities.push(entry as LettaPackageCapability);
+  });
+
+  return capabilities;
+}
+
+function validateEngines(
+  value: unknown,
+  errors: LettaPackageManifestValidationError[],
+): LettaPackageEngines | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) {
+    addError(errors, "letta.engines", "engines must be an object");
+    return undefined;
+  }
+
+  for (const key of getUnknownKeys(value, ENGINE_KEYS)) {
+    addError(errors, `letta.engines.${key}`, `unknown engine '${key}'`);
+  }
+
+  const engines: LettaPackageEngines = {};
+  for (const key of ENGINE_KEYS) {
+    const engineRange = value[key];
+    if (engineRange === undefined) continue;
+    if (typeof engineRange !== "string") {
+      addError(errors, `letta.engines.${key}`, "engine range must be a string");
+      continue;
+    }
+    if (!isValidSemverRange(engineRange)) {
+      addError(
+        errors,
+        `letta.engines.${key}`,
+        "engine range must be semver-compatible",
+      );
+      continue;
+    }
+    engines[key as keyof LettaPackageEngines] = engineRange;
+  }
+
+  return Object.keys(engines).length > 0 ? engines : undefined;
+}
+
+export function parseLettaPackageManifest(
+  packageJson: unknown,
+): LettaPackageManifestParseResult {
+  if (!isRecord(packageJson)) {
+    return {
+      errors: [{ message: "package.json must be an object", path: "package" }],
+      manifest: null,
+      ok: false,
+    };
+  }
+
+  const rawManifest = packageJson.letta;
+  if (rawManifest === undefined) {
+    return { errors: [], manifest: null, ok: true };
+  }
+  if (!isRecord(rawManifest)) {
+    return {
+      errors: [{ message: "letta manifest must be an object", path: "letta" }],
+      manifest: null,
+      ok: false,
+    };
+  }
+
+  const errors: LettaPackageManifestValidationError[] = [];
+  for (const key of getUnknownKeys(rawManifest, MANIFEST_KEYS)) {
+    addError(errors, `letta.${key}`, `unknown manifest field '${key}'`);
+  }
+
+  if (rawManifest.manifestVersion !== LETTA_PACKAGE_MANIFEST_VERSION) {
+    addError(
+      errors,
+      "letta.manifestVersion",
+      `manifestVersion must be ${LETTA_PACKAGE_MANIFEST_VERSION}`,
+    );
+  }
+
+  const mods = validateMods(rawManifest.mods, errors);
+  const capabilities = validateCapabilities(rawManifest.capabilities, errors);
+  const engines = validateEngines(rawManifest.engines, errors);
+
+  if (errors.length > 0 || !mods) {
+    return { errors, manifest: null, ok: false };
+  }
+
+  return {
+    errors: [],
+    manifest: {
+      manifestVersion: LETTA_PACKAGE_MANIFEST_VERSION,
+      mods,
+      ...(capabilities && capabilities.length > 0 ? { capabilities } : {}),
+      ...(engines ? { engines } : {}),
+    },
+    ok: true,
+  };
+}
+
+export function readLettaPackageManifest(
+  packageJsonPath: string,
+): LettaPackageManifestParseResult {
+  try {
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    return parseLettaPackageManifest(packageJson);
+  } catch (error) {
+    return {
+      errors: [
+        {
+          message: error instanceof Error ? error.message : String(error),
+          path: packageJsonPath,
+        },
+      ],
+      manifest: null,
+      ok: false,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add a parser/validator for `package.json#letta` package manifests
- validate manifest v1 mod entry paths, declared capabilities, and `engines.lettaCodeCli` / `engines.lettaCodeDesktop`
- cover valid, missing, malformed, and unsafe manifest cases with focused tests

## Tests
- `bun test src/mods/package-manifest.test.ts`
- `bun run typecheck`
- `bun run check`