### PR TITLE
feat(mods): support agent-scoped MemFS mods

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -1,5 +1,6 @@
 // src/cli/app/AppCoordinator.tsx
 
+import { join } from "node:path";
 import type {
   AgentState,
   MessageCreate,
@@ -2353,7 +2354,12 @@ export function App({
       statusLinePayload,
     ],
   );
+  const agentModsDirectory =
+    statusLinePayload.memfs.enabled && statusLinePayload.memfs.memory_dir
+      ? join(statusLinePayload.memfs.memory_dir, "mods")
+      : null;
   const modAdapter = useLocalModAdapter(modContext, {
+    agentModsDirectory,
     disabled: modsDisabled,
   });
 

--- a/src/cli/mods/local-mod-loader.test.ts
+++ b/src/cli/mods/local-mod-loader.test.ts
@@ -90,6 +90,46 @@ describe("local mod loader", () => {
     }
   });
 
+  test("discovers agent mod source after global mod source", () => {
+    const root = createTempDir();
+    try {
+      const { globalModsDirectory: globalMods } = createLoadOptions(root);
+      const agentMods = path.join(root, "memory", "mods");
+      mkdirSync(globalMods, { recursive: true });
+      mkdirSync(agentMods, { recursive: true });
+      writeFileSync(
+        path.join(globalMods, "global.ts"),
+        "export default () => {};\n",
+      );
+      writeFileSync(
+        path.join(agentMods, "agent.ts"),
+        "export default () => {};\n",
+      );
+
+      expect(
+        resolveLocalModSources({
+          agentModsDirectory: agentMods,
+          globalModsDirectory: globalMods,
+        }),
+      ).toEqual([
+        {
+          files: [path.join(globalMods, "global.ts")],
+          root: globalMods,
+          scope: "global",
+          trusted: true,
+        },
+        {
+          files: [path.join(agentMods, "agent.ts")],
+          root: agentMods,
+          scope: "agent",
+          trusted: true,
+        },
+      ]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("does not initialize SDK client when no mod files exist", async () => {
     const root = createTempDir();
     try {

--- a/src/cli/mods/use-local-mod-adapter.ts
+++ b/src/cli/mods/use-local-mod-adapter.ts
@@ -22,17 +22,19 @@ export interface LocalModAdapter {
 
 export function useLocalModAdapter(
   context: ModContext,
-  options: { disabled?: boolean } = {},
+  options: { agentModsDirectory?: string | null; disabled?: boolean } = {},
 ): LocalModAdapter {
-  // biome-ignore lint/correctness/useExhaustiveDependencies: the adapter is process-local; context updates are pushed through updateContext below.
+  const agentModsDirectory = options.agentModsDirectory ?? undefined;
+  const disabled = options.disabled;
   const adapter = useMemo(
     () =>
       createModAdapter({
-        disabled: options.disabled,
+        ...(agentModsDirectory ? { agentModsDirectory } : {}),
+        disabled,
         getBackend,
         getClient,
       }),
-    [],
+    [agentModsDirectory, disabled],
   );
 
   const snapshot = useSyncExternalStore(

--- a/src/headless-mod-adapter.ts
+++ b/src/headless-mod-adapter.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import { getScopedMemoryFilesystemRoot } from "@/agent/memory-filesystem";
 import { getModelInfo } from "@/agent/model";
@@ -136,7 +137,12 @@ export function createHeadlessModAdapter(options: {
   reflectionSettings?: ReflectionSettings;
   sessionStats?: SessionStats | null;
 }): ModAdapter {
+  const agentModsDirectory = isHeadlessMemfsEnabled(options.agent.id)
+    ? join(getScopedMemoryFilesystemRoot(options.agent.id), "mods")
+    : undefined;
+
   return createModAdapter({
+    ...(agentModsDirectory ? { agentModsDirectory } : {}),
     ...(options.cacheDirectory
       ? { cacheDirectory: options.cacheDirectory }
       : {}),

--- a/src/headless-mod-lifecycle.test.ts
+++ b/src/headless-mod-lifecycle.test.ts
@@ -19,6 +19,7 @@ import {
 } from "@/headless-mod-adapter";
 import { LETTA_DISABLE_MODS_ENV } from "@/mods/disable";
 import { clearModTools, getModToolDefinition } from "@/mods/tool-registry";
+import { settingsManager } from "@/settings-manager";
 import { executeTool } from "@/tools/manager";
 
 function readHeadlessSource(): string {
@@ -196,6 +197,90 @@ describe("headless mod adapter", () => {
       adapter.dispose();
       expect(getModToolDefinition(toolName)).toBeUndefined();
     } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("loads agent mod source from MemFS when enabled", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "letta-headless-agent-mods-"));
+    const originalIsMemfsEnabled = settingsManager.isMemfsEnabled;
+    const originalLocalBackendFlag =
+      process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL;
+    const originalLocalBackendDir = process.env.LETTA_LOCAL_BACKEND_DIR;
+    const agent = {
+      id: "agent-1",
+      name: "Amelia",
+      llm_config: { model: "anthropic/claude-sonnet-4" },
+    } as AgentState;
+    const backend = {
+      forkConversation: async () => ({ id: "forked" }),
+      sendMessageStream: async () => (async function* () {})(),
+    } as unknown as Backend;
+    const storageDir = path.join(root, "local-backend");
+    const agentModsDir = path.join(
+      storageDir,
+      "memfs",
+      agent.id,
+      "memory",
+      "mods",
+    );
+    const modPath = path.join(agentModsDir, "headless-agent-tool.ts");
+
+    try {
+      process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL = "1";
+      process.env.LETTA_LOCAL_BACKEND_DIR = storageDir;
+      (settingsManager as typeof settingsManager).isMemfsEnabled = (agentId) =>
+        agentId === agent.id;
+
+      mkdirSync(agentModsDir, { recursive: true });
+      writeFileSync(
+        modPath,
+        `export default function activate(letta) {
+          letta.tools.register({
+            name: "headless_agent_tool",
+            description: "Agent-scoped headless tool",
+            parameters: { type: "object", properties: {} },
+            run() { return "agent"; },
+          });
+        }`,
+      );
+
+      const adapter = createHeadlessModAdapter({
+        agent,
+        backend,
+        cacheDirectory: path.join(root, "mod-cache"),
+        conversationId: "default",
+        globalModsDirectory: path.join(root, "global-mods"),
+      });
+
+      await adapter.reload();
+      const snapshot = adapter.getSnapshot().registry;
+
+      expect(snapshot.sources.map((source) => source.scope)).toEqual([
+        "global",
+        "agent",
+      ]);
+      expect(snapshot.loadedPaths).toEqual([modPath]);
+      expect(snapshot.tools.headless_agent_tool).toMatchObject({
+        description: "Agent-scoped headless tool",
+        owner: { path: modPath, scope: "agent" },
+      });
+
+      adapter.dispose();
+      expect(getModToolDefinition("headless_agent_tool")).toBeUndefined();
+    } finally {
+      (settingsManager as typeof settingsManager).isMemfsEnabled =
+        originalIsMemfsEnabled;
+      if (originalLocalBackendFlag === undefined) {
+        delete process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL;
+      } else {
+        process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL = originalLocalBackendFlag;
+      }
+      if (originalLocalBackendDir === undefined) {
+        delete process.env.LETTA_LOCAL_BACKEND_DIR;
+      } else {
+        process.env.LETTA_LOCAL_BACKEND_DIR = originalLocalBackendDir;
+      }
       rmSync(root, { force: true, recursive: true });
     }
   });

--- a/src/mods/mod-engine.test.ts
+++ b/src/mods/mod-engine.test.ts
@@ -88,8 +88,10 @@ function createEngine(
   root: string,
   capabilities?: ModCapabilities,
   backend?: Backend,
+  agentModsDirectory?: string,
 ): ModEngine {
   return createModEngine({
+    ...(agentModsDirectory ? { agentModsDirectory } : {}),
     cacheDirectory: path.join(root, "mod-cache"),
     ...(backend ? { getBackend: () => backend } : {}),
     ...(capabilities ? { capabilities } : {}),
@@ -156,6 +158,162 @@ describe("mod engine", () => {
 
       unsubscribe();
       engine.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("agent commands shadow global commands without explicit override", async () => {
+    const root = createTempDir();
+    try {
+      const globalMods = path.join(root, "global-mods");
+      const agentMods = path.join(root, "memory", "mods");
+      const globalPath = path.join(globalMods, "command.ts");
+      const agentPath = path.join(agentMods, "command.ts");
+      mkdirSync(globalMods, { recursive: true });
+      mkdirSync(agentMods, { recursive: true });
+      writeFileSync(
+        globalPath,
+        `export default function(letta) {
+          letta.commands.register({
+            id: "hello",
+            description: "Global hello",
+            run() { return { type: "handled" }; },
+          });
+        }`,
+      );
+      writeFileSync(
+        agentPath,
+        `export default function(letta) {
+          letta.commands.register({
+            id: "hello",
+            description: "Agent hello",
+            run() { return { type: "handled" }; },
+          });
+        }`,
+      );
+
+      const engine = createEngine(root, undefined, undefined, agentMods);
+      await engine.reload();
+      const snapshot = engine.getSnapshot();
+
+      expect(getModErrorDiagnostics(snapshot.diagnostics)).toEqual([]);
+      expect(snapshot.loadedPaths).toEqual([globalPath, agentPath]);
+      expect(snapshot.commands.hello).toMatchObject({
+        description: "Agent hello",
+        owner: {
+          generation: 1,
+          id: `agent:${agentPath}`,
+          path: agentPath,
+          scope: "agent",
+        },
+      });
+
+      engine.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("agent tools shadow global tools and update the process registry", async () => {
+    const root = createTempDir();
+    try {
+      const globalMods = path.join(root, "global-mods");
+      const agentMods = path.join(root, "memory", "mods");
+      const globalPath = path.join(globalMods, "tool.ts");
+      const agentPath = path.join(agentMods, "tool.ts");
+      mkdirSync(globalMods, { recursive: true });
+      mkdirSync(agentMods, { recursive: true });
+      writeFileSync(
+        globalPath,
+        `export default function(letta) {
+          letta.tools.register({
+            name: "echo_tool",
+            description: "Global echo",
+            parameters: { type: "object", properties: {} },
+            run() { return "global"; },
+          });
+        }`,
+      );
+      writeFileSync(
+        agentPath,
+        `export default function(letta) {
+          letta.tools.register({
+            name: "echo_tool",
+            description: "Agent echo",
+            parameters: { type: "object", properties: {} },
+            run() { return "agent"; },
+          });
+        }`,
+      );
+
+      const engine = createEngine(root, undefined, undefined, agentMods);
+      await engine.reload();
+      const snapshot = engine.getSnapshot();
+
+      expect(getModErrorDiagnostics(snapshot.diagnostics)).toEqual([]);
+      expect(snapshot.tools.echo_tool).toMatchObject({
+        description: "Agent echo",
+        owner: { path: agentPath, scope: "agent" },
+      });
+      expect(getModToolDefinition("echo_tool")).toMatchObject({
+        description: "Agent echo",
+        owner: { path: agentPath, scope: "agent" },
+      });
+
+      engine.dispose();
+      expect(getModToolDefinition("echo_tool")).toBeUndefined();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("agent permissions shadow global permissions", async () => {
+    const root = createTempDir();
+    try {
+      const globalMods = path.join(root, "global-mods");
+      const agentMods = path.join(root, "memory", "mods");
+      const globalPath = path.join(globalMods, "permission.ts");
+      const agentPath = path.join(agentMods, "permission.ts");
+      mkdirSync(globalMods, { recursive: true });
+      mkdirSync(agentMods, { recursive: true });
+      writeFileSync(
+        globalPath,
+        `export default function(letta) {
+          letta.permissions.register({
+            id: "shell-policy",
+            description: "Global shell policy",
+            check() { return { decision: "ask" }; },
+          });
+        }`,
+      );
+      writeFileSync(
+        agentPath,
+        `export default function(letta) {
+          letta.permissions.register({
+            id: "shell-policy",
+            description: "Agent shell policy",
+            check() { return { decision: "deny" }; },
+          });
+        }`,
+      );
+
+      const engine = createEngine(root, undefined, undefined, agentMods);
+      await engine.reload();
+      const snapshot = engine.getSnapshot();
+
+      expect(getModErrorDiagnostics(snapshot.diagnostics)).toEqual([]);
+      expect(snapshot.permissions["shell-policy"]).toMatchObject({
+        description: "Agent shell policy",
+        owner: { path: agentPath, scope: "agent" },
+      });
+      expect(getModPermissionDefinition("shell-policy")).toMatchObject({
+        description: "Agent shell policy",
+        owner: { path: agentPath, scope: "agent" },
+      });
+
+      engine.dispose();
+      expect(getModPermissionDefinition("shell-policy")).toBeUndefined();
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/src/mods/mod-engine.ts
+++ b/src/mods/mod-engine.ts
@@ -84,6 +84,7 @@ import type {
   ModPanelUpdate,
   ModPermission,
   ModPermissionRegistration,
+  ModSourceScope,
   ModTool,
   ModToolRegistration,
   ModToolStartEvent,
@@ -213,7 +214,7 @@ export interface LocalModRegistry {
 export interface LocalModSource {
   files: string[];
   root: string;
-  scope: "global" | "project" | "bundled";
+  scope: ModSourceScope;
   trusted: boolean;
 }
 
@@ -223,6 +224,7 @@ interface LocalModModule {
 }
 
 export interface ResolveLocalModSourcesOptions {
+  agentModsDirectory?: string;
   cacheDirectory?: string;
   globalModsDirectory?: string;
 }
@@ -271,13 +273,41 @@ function listModFiles(directory: string): string[] {
     .sort((a, b) => a.localeCompare(b));
 }
 
+function getModSourcePriority(scope: ModSourceScope): number {
+  switch (scope) {
+    case "bundled":
+      return 0;
+    case "global":
+      return 1;
+    case "agent":
+      return 2;
+    case "project":
+      return 3;
+  }
+}
+
+function canShadowOwner(owner: ModOwner, existingOwner?: ModOwner): boolean {
+  return (
+    existingOwner !== undefined &&
+    getModSourcePriority(owner.scope) >
+      getModSourcePriority(existingOwner.scope)
+  );
+}
+
+function isShadowedByOwner(owner: ModOwner, existingOwner?: ModOwner): boolean {
+  return (
+    existingOwner !== undefined &&
+    getModSourcePriority(owner.scope) <
+      getModSourcePriority(existingOwner.scope)
+  );
+}
+
 export function resolveLocalModSources(
   options: ResolveLocalModSourcesOptions = {},
 ): LocalModSource[] {
   const globalModsDirectory =
     options.globalModsDirectory ?? resolveDefaultGlobalModsDirectory();
-
-  return [
+  const sources: LocalModSource[] = [
     {
       files: listModFiles(globalModsDirectory),
       root: globalModsDirectory,
@@ -285,6 +315,17 @@ export function resolveLocalModSources(
       trusted: true,
     },
   ];
+
+  if (options.agentModsDirectory) {
+    sources.push({
+      files: listModFiles(options.agentModsDirectory),
+      root: options.agentModsDirectory,
+      scope: "agent",
+      trusted: true,
+    });
+  }
+
+  return sources;
 }
 
 function createEmptyModRegistry(
@@ -1062,7 +1103,16 @@ function createLettaModApi(
         }
 
         const existing = registry.commands[normalized.id];
-        if (existing && !command.override) {
+        if (existing && isShadowedByOwner(owner, existing.owner)) {
+          throw new Error(
+            `Mod command '${normalized.id}' is already registered by higher-priority mod ${existing.path}`,
+          );
+        }
+        if (
+          existing &&
+          !command.override &&
+          !canShadowOwner(owner, existing.owner)
+        ) {
           throw new Error(
             `Mod command '${normalized.id}' is already registered by ${existing.path}`,
           );
@@ -1096,7 +1146,20 @@ function createLettaModApi(
 
         const existing = registry.tools[normalized.name];
         const existingGlobal = getModToolDefinition(normalized.name);
-        if ((existing || existingGlobal) && !tool.override) {
+        const existingOwner = existing?.owner ?? existingGlobal?.owner;
+        if (
+          (existing || existingGlobal) &&
+          isShadowedByOwner(owner, existingOwner)
+        ) {
+          throw new Error(
+            `Mod tool '${normalized.name}' is already registered by higher-priority mod ${existing?.path ?? existingGlobal?.path}`,
+          );
+        }
+        if (
+          (existing || existingGlobal) &&
+          !tool.override &&
+          !canShadowOwner(owner, existingOwner)
+        ) {
           throw new Error(
             `Mod tool '${normalized.name}' is already registered by ${existing?.path ?? existingGlobal?.path}`,
           );
@@ -1136,7 +1199,19 @@ function createLettaModApi(
         const normalized = normalizeModPermission(permission, owner);
         const existing = registry.permissions[normalized.id];
         const existingGlobal = getModPermissionDefinition(normalized.id);
-        if (existing || existingGlobal) {
+        const existingOwner = existing?.owner ?? existingGlobal?.owner;
+        if (
+          (existing || existingGlobal) &&
+          isShadowedByOwner(owner, existingOwner)
+        ) {
+          throw new Error(
+            `Mod permission '${normalized.id}' is already registered by higher-priority mod ${existing?.path ?? existingGlobal?.path}`,
+          );
+        }
+        if (
+          (existing || existingGlobal) &&
+          !canShadowOwner(owner, existingOwner)
+        ) {
           throw new Error(
             `Mod permission '${normalized.id}' is already registered by ${existing?.path ?? existingGlobal?.path}`,
           );

--- a/src/mods/types.ts
+++ b/src/mods/types.ts
@@ -126,7 +126,7 @@ export interface ModConversationHandle {
   ) => Promise<AsyncIterable<LettaStreamingResponse>>;
 }
 
-export type ModSourceScope = "global" | "project" | "bundled";
+export type ModSourceScope = "global" | "project" | "bundled" | "agent";
 
 export interface ModOwner {
   id: string;


### PR DESCRIPTION
## Summary
- load loose mods from `$MEMORY_DIR/mods` for the active agent alongside harness-level mods
- let agent-scoped mods shadow global commands, tools, and permissions
- wire agent mod sources into TUI and headless adapters while keeping listener mods harness-only

## Tests
- `bun test src/mods/mod-engine.test.ts`
- `bun test src/cli/mods/local-mod-loader.test.ts`
- `bun test src/headless-mod-lifecycle.test.ts`
- `bun test src/websocket/listener/mod-adapter.test.ts`
- `bun test src/mods src/cli/mods src/headless-mod-lifecycle.test.ts src/websocket/listener/mod-adapter.test.ts`
- `bun run typecheck`
- `bun run check`