### PR TITLE
feat(mods): list loose mods

### DIFF
--- a/src/cli/subcommands/mods.test.ts
+++ b/src/cli/subcommands/mods.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  formatLooseModsList,
+  listLooseMods,
+  runModsSubcommand,
+} from "@/cli/subcommands/mods";
+
+const tempRoots: string[] = [];
+
+function createTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "letta-mods-list-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+function captureConsole(): {
+  errors: string[];
+  logs: string[];
+  restore: () => void;
+} {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = (message?: unknown) => {
+    logs.push(String(message));
+  };
+  console.error = (message?: unknown) => {
+    errors.push(String(message));
+  };
+  return {
+    errors,
+    logs,
+    restore() {
+      console.log = originalLog;
+      console.error = originalError;
+    },
+  };
+}
+
+afterEach(() => {
+  for (const dir of tempRoots.splice(0)) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe("mods subcommand", () => {
+  test("lists harness loose mods without an agent section", () => {
+    const root = createTempDir();
+    const harnessMods = join(root, "mods");
+    mkdirSync(harnessMods, { recursive: true });
+    writeFileSync(join(harnessMods, "statusline.ts"), "export {};\n");
+    writeFileSync(join(harnessMods, "provider.mjs"), "export {};\n");
+
+    const result = listLooseMods({ globalModsDirectory: harnessMods });
+
+    expect(result.agent).toBeUndefined();
+    expect(result.harness.files).toEqual([
+      join(harnessMods, "provider.mjs"),
+      join(harnessMods, "statusline.ts"),
+    ]);
+    expect(formatLooseModsList(result)).toBe(
+      [
+        "Harness mods",
+        `  enabled  ${join(harnessMods, "provider.mjs")}`,
+        `  enabled  ${join(harnessMods, "statusline.ts")}`,
+      ].join("\n"),
+    );
+  });
+
+  test("lists agent loose mods before harness loose mods", () => {
+    const root = createTempDir();
+    const harnessMods = join(root, "mods");
+    const agentMods = join(root, "memory", "mods");
+    mkdirSync(harnessMods, { recursive: true });
+    mkdirSync(agentMods, { recursive: true });
+    writeFileSync(join(harnessMods, "global.ts"), "export {};\n");
+    writeFileSync(join(agentMods, "agent.ts"), "export {};\n");
+
+    const result = listLooseMods({
+      agentModsDirectory: agentMods,
+      globalModsDirectory: harnessMods,
+    });
+
+    expect(result.agent?.files).toEqual([join(agentMods, "agent.ts")]);
+    expect(result.harness.files).toEqual([join(harnessMods, "global.ts")]);
+    expect(formatLooseModsList(result)).toBe(
+      [
+        "Agent mods",
+        `  enabled  ${join(agentMods, "agent.ts")}`,
+        "",
+        "Harness mods",
+        `  enabled  ${join(harnessMods, "global.ts")}`,
+      ].join("\n"),
+    );
+  });
+
+  test("formats empty sections", () => {
+    const root = createTempDir();
+    const result = listLooseMods({
+      agentModsDirectory: join(root, "memory", "mods"),
+      globalModsDirectory: join(root, "mods"),
+    });
+
+    expect(formatLooseModsList(result)).toBe(
+      ["Agent mods", "  (none)", "", "Harness mods", "  (none)"].join("\n"),
+    );
+  });
+
+  test("uses runtime loose mod discovery rules", () => {
+    const root = createTempDir();
+    const harnessMods = join(root, "mods");
+    mkdirSync(join(harnessMods, "nested"), { recursive: true });
+    writeFileSync(join(harnessMods, "visible.tsx"), "export {};\n");
+    writeFileSync(join(harnessMods, ".hidden.ts"), "export {};\n");
+    writeFileSync(join(harnessMods, "notes.md"), "# not a mod\n");
+    writeFileSync(join(harnessMods, "nested", "nested.ts"), "export {};\n");
+
+    const result = listLooseMods({ globalModsDirectory: harnessMods });
+
+    expect(result.harness.files).toEqual([join(harnessMods, "visible.tsx")]);
+  });
+
+  test("prints usage for help", async () => {
+    const consoleCapture = captureConsole();
+    try {
+      const exitCode = await runModsSubcommand(["help"]);
+
+      expect(exitCode).toBe(0);
+      expect(consoleCapture.logs.join("\n")).toContain("Usage:");
+      expect(consoleCapture.logs.join("\n")).toContain("letta mods list");
+      expect(consoleCapture.errors).toEqual([]);
+    } finally {
+      consoleCapture.restore();
+    }
+  });
+
+  test("rejects unknown actions", async () => {
+    const consoleCapture = captureConsole();
+    try {
+      const exitCode = await runModsSubcommand(["install"]);
+
+      expect(exitCode).toBe(1);
+      expect(consoleCapture.errors.join("\n")).toContain(
+        "Unknown mods action: install",
+      );
+      expect(consoleCapture.logs.join("\n")).toContain("Usage:");
+    } finally {
+      consoleCapture.restore();
+    }
+  });
+});

--- a/src/cli/subcommands/mods.ts
+++ b/src/cli/subcommands/mods.ts
@@ -1,0 +1,161 @@
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+import { getScopedMemoryFilesystemRoot } from "@/agent/memory-filesystem";
+import { type LocalModSource, resolveLocalModSources } from "@/mods/mod-engine";
+
+interface LooseModSection {
+  files: string[];
+  root: string;
+}
+
+export interface LooseModsList {
+  agent?: LooseModSection;
+  harness: LooseModSection;
+}
+
+export interface ListLooseModsOptions {
+  agentId?: string | null;
+  agentModsDirectory?: string | null;
+  globalModsDirectory?: string;
+}
+
+const MODS_OPTIONS = {
+  help: { type: "boolean", short: "h" },
+  agent: { type: "string" },
+  "agent-id": { type: "string" },
+} as const;
+
+function printUsage(): void {
+  console.log(
+    `
+Usage:
+  letta mods list [--agent <id>]
+
+Options:
+  --agent <id>       Include loose mods from this agent's MemFS directory
+  --agent-id <id>    Alias for --agent
+  -h, --help         Show this help
+`.trim(),
+  );
+}
+
+function parseModsArgs(argv: string[]) {
+  return parseArgs({
+    args: argv,
+    options: MODS_OPTIONS,
+    strict: true,
+    allowPositionals: true,
+  });
+}
+
+function getExplicitAgentId(
+  values: ReturnType<typeof parseModsArgs>["values"],
+): string | null {
+  const explicitAgent = values.agent || values["agent-id"];
+  return typeof explicitAgent === "string" && explicitAgent.trim()
+    ? explicitAgent.trim()
+    : null;
+}
+
+export function getAgentModsDirectory(agentId: string): string {
+  return join(getScopedMemoryFilesystemRoot(agentId), "mods");
+}
+
+function toSection(source: LocalModSource): LooseModSection {
+  return {
+    files: [...source.files],
+    root: source.root,
+  };
+}
+
+export function listLooseMods(
+  options: ListLooseModsOptions = {},
+): LooseModsList {
+  const agentModsDirectory =
+    options.agentModsDirectory ??
+    (options.agentId ? getAgentModsDirectory(options.agentId) : null);
+  const sources = resolveLocalModSources({
+    ...(agentModsDirectory ? { agentModsDirectory } : {}),
+    ...(options.globalModsDirectory
+      ? { globalModsDirectory: options.globalModsDirectory }
+      : {}),
+  });
+  const harness = sources.find((source) => source.scope === "global");
+  const agent = sources.find((source) => source.scope === "agent");
+
+  return {
+    ...(agent ? { agent: toSection(agent) } : {}),
+    harness: harness ? toSection(harness) : { files: [], root: "" },
+  };
+}
+
+function formatLooseModSection(
+  title: string,
+  section: LooseModSection,
+): string {
+  const lines = [title];
+  if (section.files.length === 0) {
+    lines.push("  (none)");
+    return lines.join("\n");
+  }
+
+  for (const file of section.files) {
+    lines.push(`  enabled  ${file}`);
+  }
+  return lines.join("\n");
+}
+
+export function formatLooseModsList(mods: LooseModsList): string {
+  const sections: string[] = [];
+  if (mods.agent) {
+    sections.push(formatLooseModSection("Agent mods", mods.agent));
+  }
+  sections.push(formatLooseModSection("Harness mods", mods.harness));
+  return sections.join("\n\n");
+}
+
+async function runList(argv: string[]): Promise<number> {
+  let parsed: ReturnType<typeof parseModsArgs>;
+  try {
+    parsed = parseModsArgs(argv);
+  } catch (error) {
+    console.error(
+      `Error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    printUsage();
+    return 1;
+  }
+
+  if (parsed.values.help) {
+    printUsage();
+    return 0;
+  }
+  if (parsed.positionals.length > 0) {
+    console.error(`Unexpected argument: ${parsed.positionals[0]}`);
+    printUsage();
+    return 1;
+  }
+
+  const agentId = getExplicitAgentId(parsed.values);
+  const mods = listLooseMods({ agentId });
+  console.log(formatLooseModsList(mods));
+  return 0;
+}
+
+export async function runModsSubcommand(argv: string[]): Promise<number> {
+  const [action, ...rest] = argv;
+
+  if (!action || action === "help" || action === "--help" || action === "-h") {
+    printUsage();
+    return 0;
+  }
+
+  switch (action) {
+    case "list":
+      return runList(rest);
+    default:
+      console.error(`Unknown mods action: ${action}`);
+      printUsage();
+      return 1;
+  }
+}

--- a/src/cli/subcommands/router.test.ts
+++ b/src/cli/subcommands/router.test.ts
@@ -45,11 +45,30 @@ describe("subcommand router", () => {
     }
   });
 
+  test("routes mods help", async () => {
+    const messages: string[] = [];
+    const originalLog = console.log;
+    console.log = (message?: unknown) => {
+      messages.push(String(message));
+    };
+
+    try {
+      const exitCode = await runSubcommand(["mods", "help"]);
+
+      expect(exitCode).toBe(0);
+      expect(messages.join("\n")).toContain("Usage:");
+      expect(messages.join("\n")).toContain("letta mods list");
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
   test("identifies backend-aware subcommands for early backend selection", () => {
     expect(subcommandNeedsEarlyBackendMode("app-server")).toBe(true);
     expect(subcommandNeedsEarlyBackendMode("connect")).toBe(true);
     expect(subcommandNeedsEarlyBackendMode("server")).toBe(true);
     expect(subcommandNeedsEarlyBackendMode("memory")).toBe(true);
+    expect(subcommandNeedsEarlyBackendMode("mods")).toBe(true);
     expect(subcommandNeedsEarlyBackendMode("version")).toBe(false);
     expect(subcommandNeedsEarlyBackendMode("backend")).toBe(false);
     expect(subcommandNeedsEarlyBackendMode(undefined)).toBe(false);

--- a/src/cli/subcommands/router.ts
+++ b/src/cli/subcommands/router.ts
@@ -8,6 +8,7 @@ import { runListenSubcommand } from "./listen.tsx";
 import { runLocalBackendSubcommand } from "./local-backend";
 import { runMemorySubcommand } from "./memory";
 import { runMessagesSubcommand } from "./messages";
+import { runModsSubcommand } from "./mods";
 import { runSetupSubcommand } from "./setup";
 import { runInstallSubcommand, runSkillsSubcommand } from "./skills";
 
@@ -35,6 +36,7 @@ export function subcommandNeedsEarlyBackendMode(
     case "memfs":
     case "memory":
     case "messages":
+    case "mods":
     case "remote":
     case "server":
     case "skills":
@@ -66,6 +68,8 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
       return runAppServerSubcommand(rest);
     case "messages":
       return runMessagesSubcommand(rest);
+    case "mods":
+      return runModsSubcommand(rest);
     case "server":
     case "remote": // alias
       return runListenSubcommand(rest);

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,6 +181,7 @@ USAGE
   letta memory ...      Memory filesystem subcommands
   letta agents ...      Agents subcommands (JSON-only)
   letta messages ...    Messages subcommands (JSON-only)
+  letta mods ...        List installed loose mods
   letta app-server ...  Run local app-server websocket transport
   letta connect ...     Connect providers from terminal
   letta backend ...     Show or set the default backend
@@ -205,6 +206,7 @@ SUBCOMMANDS
   letta messages search --query <text> [--all-agents]
   letta messages list [--agent <id>]
   letta messages transcript --conversation <id> [--out <path>]
+  letta mods list [--agent <id>]
   letta app-server [--listen ws://127.0.0.1:4500]
   letta connect <provider> [options]
   letta install <skill> [--agent <id> | -n <name>]


### PR DESCRIPTION
## Summary
- add `letta mods list` for currently discoverable loose harness mods
- add `letta mods list --agent <id>` to include that agent’s MemFS loose mods when available
- wire the mods subcommand into routing/help and cover listing behavior with tests

## Tests
- `bun test src/cli/subcommands/mods.test.ts`
- `bun test src/cli/subcommands/router.test.ts`
- `bun run typecheck`
- `bun run check`