### PR TITLE
feat(mods): load managed package entries

### DIFF
--- a/src/cli/mods/local-mod-loader.test.ts
+++ b/src/cli/mods/local-mod-loader.test.ts
@@ -130,6 +130,150 @@ describe("local mod loader", () => {
     }
   });
 
+  test("discovers managed package entries after loose global mods", () => {
+    const root = createTempDir();
+    try {
+      const { globalModsDirectory: globalMods } = createLoadOptions(root);
+      const packageRoot = path.join(
+        globalMods,
+        "packages",
+        "npm",
+        "@caren",
+        "my-mod",
+      );
+      const packageMod = path.join(packageRoot, "mods", "index.ts");
+      const packageExtra = path.join(packageRoot, "mods", "extra.ts");
+      const looseMod = path.join(globalMods, "loose.ts");
+      mkdirSync(path.dirname(packageMod), { recursive: true });
+      writeFileSync(looseMod, "export default () => {};\n");
+      writeFileSync(packageMod, "export default () => {};\n");
+      writeFileSync(packageExtra, "export default () => {};\n");
+      writeFileSync(
+        path.join(packageRoot, "package.json"),
+        JSON.stringify({
+          letta: {
+            manifestVersion: 1,
+            mods: ["./mods/index.ts"],
+          },
+        }),
+      );
+      writeFileSync(
+        path.join(globalMods, "packages.json"),
+        JSON.stringify({
+          packages: [
+            {
+              source: "npm:@caren/my-mod",
+              version: "0.1.0",
+              enabled: true,
+              root: "packages/npm/@caren/my-mod",
+              entries: ["./mods/index.ts"],
+            },
+          ],
+        }),
+      );
+
+      expect(
+        resolveLocalModSources({
+          globalModsDirectory: globalMods,
+        }),
+      ).toEqual([
+        {
+          files: [looseMod, packageMod],
+          root: globalMods,
+          scope: "global",
+          trusted: true,
+        },
+      ]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("skips disabled managed packages", () => {
+    const root = createTempDir();
+    try {
+      const { globalModsDirectory: globalMods } = createLoadOptions(root);
+      mkdirSync(globalMods, { recursive: true });
+      writeFileSync(
+        path.join(globalMods, "packages.json"),
+        JSON.stringify({
+          packages: [
+            {
+              source: "npm:@caren/my-disabled-mod",
+              version: "0.1.0",
+              enabled: false,
+              root: "packages/npm/@caren/my-disabled-mod",
+              entries: ["./mods/index.ts"],
+            },
+          ],
+        }),
+      );
+
+      expect(
+        resolveLocalModSources({
+          globalModsDirectory: globalMods,
+        }),
+      ).toEqual([
+        {
+          files: [],
+          root: globalMods,
+          scope: "global",
+          trusted: true,
+        },
+      ]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("reports invalid managed package manifests", () => {
+    const root = createTempDir();
+    try {
+      const { globalModsDirectory: globalMods } = createLoadOptions(root);
+      const packageRoot = path.join(
+        globalMods,
+        "packages",
+        "npm",
+        "@caren",
+        "bad-mod",
+      );
+      const packageJsonPath = path.join(packageRoot, "package.json");
+      mkdirSync(packageRoot, { recursive: true });
+      writeFileSync(
+        packageJsonPath,
+        JSON.stringify({ name: "@caren/bad-mod" }),
+      );
+      writeFileSync(
+        path.join(globalMods, "packages.json"),
+        JSON.stringify({
+          packages: [
+            {
+              source: "npm:@caren/bad-mod",
+              version: "0.1.0",
+              enabled: true,
+              root: "packages/npm/@caren/bad-mod",
+              entries: ["./mods/index.ts"],
+            },
+          ],
+        }),
+      );
+
+      const sources = resolveLocalModSources({
+        globalModsDirectory: globalMods,
+      });
+
+      expect(sources).toHaveLength(1);
+      expect(sources[0]?.files).toEqual([]);
+      expect(sources[0]?.diagnostics).toHaveLength(1);
+      expect(sources[0]?.diagnostics?.[0]?.path).toBe(packageJsonPath);
+      expect(sources[0]?.diagnostics?.[0]?.error.message).toContain(
+        "package.json#letta",
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("does not initialize SDK client when no mod files exist", async () => {
     const root = createTempDir();
     try {

--- a/src/mods/mod-engine.test.ts
+++ b/src/mods/mod-engine.test.ts
@@ -215,6 +215,223 @@ describe("mod engine", () => {
     }
   });
 
+  test("loads managed package entries from the global mods directory", async () => {
+    const root = createTempDir();
+    try {
+      const globalMods = path.join(root, "global-mods");
+      const packageRoot = path.join(
+        globalMods,
+        "packages",
+        "npm",
+        "@caren",
+        "hello-mod",
+      );
+      const packagePath = path.join(packageRoot, "mods", "command.ts");
+      const undeclaredPath = path.join(packageRoot, "mods", "undeclared.ts");
+      mkdirSync(path.dirname(packagePath), { recursive: true });
+      writeFileSync(
+        packagePath,
+        `export default function(letta) {
+          letta.commands.register({
+            id: "packaged-hello",
+            description: "Packaged hello",
+            run() { return { type: "handled" }; },
+          });
+        }`,
+      );
+      writeFileSync(
+        undeclaredPath,
+        `export default function(letta) {
+          letta.commands.register({
+            id: "undeclared",
+            description: "Should not load",
+            run() { return { type: "handled" }; },
+          });
+        }`,
+      );
+      writeFileSync(
+        path.join(packageRoot, "package.json"),
+        JSON.stringify({
+          letta: {
+            manifestVersion: 1,
+            mods: ["./mods/command.ts"],
+          },
+        }),
+      );
+      writeFileSync(
+        path.join(globalMods, "packages.json"),
+        JSON.stringify({
+          packages: [
+            {
+              source: "npm:@caren/hello-mod",
+              version: "0.1.0",
+              enabled: true,
+              root: "packages/npm/@caren/hello-mod",
+              entries: ["./mods/command.ts"],
+            },
+          ],
+        }),
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+      const snapshot = engine.getSnapshot();
+
+      expect(getModErrorDiagnostics(snapshot.diagnostics)).toEqual([]);
+      expect(snapshot.loadedPaths).toEqual([packagePath]);
+      expect(snapshot.commands["packaged-hello"]).toMatchObject({
+        description: "Packaged hello",
+        owner: { path: packagePath, scope: "global" },
+      });
+      expect(snapshot.commands.undeclared).toBeUndefined();
+
+      engine.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("reports invalid managed package entries without loading them", async () => {
+    const root = createTempDir();
+    try {
+      const globalMods = path.join(root, "global-mods");
+      const packageRoot = path.join(
+        globalMods,
+        "packages",
+        "npm",
+        "@caren",
+        "bad-entry",
+      );
+      const packagePath = path.join(packageRoot, "mods", "command.ts");
+      mkdirSync(path.dirname(packagePath), { recursive: true });
+      writeFileSync(
+        packagePath,
+        `export default function(letta) {
+          letta.commands.register({
+            id: "bad-entry",
+            description: "Bad entry",
+            run() { return { type: "handled" }; },
+          });
+        }`,
+      );
+      writeFileSync(
+        path.join(packageRoot, "package.json"),
+        JSON.stringify({
+          letta: {
+            manifestVersion: 1,
+            mods: ["./mods/other.ts"],
+          },
+        }),
+      );
+      writeFileSync(
+        path.join(globalMods, "packages.json"),
+        JSON.stringify({
+          packages: [
+            {
+              source: "npm:@caren/bad-entry",
+              version: "0.1.0",
+              enabled: true,
+              root: "packages/npm/@caren/bad-entry",
+              entries: ["./mods/command.ts"],
+            },
+          ],
+        }),
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+      const snapshot = engine.getSnapshot();
+      const errors = getModErrorDiagnostics(snapshot.diagnostics);
+
+      expect(snapshot.loadedPaths).toEqual([]);
+      expect(snapshot.commands["bad-entry"]).toBeUndefined();
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.phase).toBe("package_manifest");
+      expect(errors[0]?.error.message).toContain("not declared");
+
+      engine.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("agent commands shadow managed global package commands", async () => {
+    const root = createTempDir();
+    try {
+      const globalMods = path.join(root, "global-mods");
+      const agentMods = path.join(root, "memory", "mods");
+      const packageRoot = path.join(
+        globalMods,
+        "packages",
+        "npm",
+        "@caren",
+        "hello-mod",
+      );
+      const packagePath = path.join(packageRoot, "mods", "command.ts");
+      const agentPath = path.join(agentMods, "command.ts");
+      mkdirSync(path.dirname(packagePath), { recursive: true });
+      mkdirSync(agentMods, { recursive: true });
+      writeFileSync(
+        packagePath,
+        `export default function(letta) {
+          letta.commands.register({
+            id: "hello",
+            description: "Packaged hello",
+            run() { return { type: "handled" }; },
+          });
+        }`,
+      );
+      writeFileSync(
+        path.join(packageRoot, "package.json"),
+        JSON.stringify({
+          letta: {
+            manifestVersion: 1,
+            mods: ["./mods/command.ts"],
+          },
+        }),
+      );
+      writeFileSync(
+        path.join(globalMods, "packages.json"),
+        JSON.stringify({
+          packages: [
+            {
+              source: "npm:@caren/hello-mod",
+              version: "0.1.0",
+              enabled: true,
+              root: "packages/npm/@caren/hello-mod",
+              entries: ["./mods/command.ts"],
+            },
+          ],
+        }),
+      );
+      writeFileSync(
+        agentPath,
+        `export default function(letta) {
+          letta.commands.register({
+            id: "hello",
+            description: "Agent hello",
+            run() { return { type: "handled" }; },
+          });
+        }`,
+      );
+
+      const engine = createEngine(root, undefined, undefined, agentMods);
+      await engine.reload();
+      const snapshot = engine.getSnapshot();
+
+      expect(getModErrorDiagnostics(snapshot.diagnostics)).toEqual([]);
+      expect(snapshot.loadedPaths).toEqual([packagePath, agentPath]);
+      expect(snapshot.commands.hello).toMatchObject({
+        description: "Agent hello",
+        owner: { path: agentPath, scope: "agent" },
+      });
+
+      engine.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("agent tools shadow global tools and update the process registry", async () => {
     const root = createTempDir();
     try {

--- a/src/mods/mod-engine.ts
+++ b/src/mods/mod-engine.ts
@@ -47,6 +47,10 @@ import {
   recordStaleHandleUse,
 } from "@/mods/mod-diagnostics";
 import {
+  type ManagedModPackageDiagnostic,
+  resolveManagedModPackages,
+} from "@/mods/package-registry";
+import {
   getGlobalModsDirectory,
   getLegacyGlobalExtensionsDirectory,
   getModCacheDirectory,
@@ -214,6 +218,7 @@ export interface LocalModRegistry {
 }
 
 export interface LocalModSource {
+  diagnostics?: ManagedModPackageDiagnostic[];
   files: string[];
   root: string;
   scope: ModSourceScope;
@@ -309,9 +314,14 @@ export function resolveLocalModSources(
 ): LocalModSource[] {
   const globalModsDirectory =
     options.globalModsDirectory ?? resolveDefaultGlobalModsDirectory();
+  const managedPackages = resolveManagedModPackages(globalModsDirectory);
+  const globalDiagnostics = managedPackages.diagnostics;
   const sources: LocalModSource[] = [
     {
-      files: listModFiles(globalModsDirectory),
+      ...(globalDiagnostics.length > 0
+        ? { diagnostics: globalDiagnostics }
+        : {}),
+      files: [...listModFiles(globalModsDirectory), ...managedPackages.files],
       root: globalModsDirectory,
       scope: "global",
       trusted: true,
@@ -396,6 +406,7 @@ function snapshotRegistryForReaders(
     permissions: { ...registry.permissions },
     sources: registry.sources.map((source) => ({
       ...source,
+      ...(source.diagnostics ? { diagnostics: [...source.diagnostics] } : {}),
       files: [...source.files],
     })),
     tools: { ...registry.tools },
@@ -1331,6 +1342,19 @@ export async function loadLocalMods(
   const registry = createEmptyModRegistry(sources, generation, capabilities);
 
   for (const source of sources) {
+    for (const diagnostic of source.diagnostics ?? []) {
+      const owner = createModOwner(diagnostic.path, source, generation);
+      recordModDiagnostic(
+        registry,
+        {
+          error: diagnostic.error,
+          owner,
+          phase: "package_manifest",
+        },
+        options.onDiagnostic,
+      );
+    }
+
     for (const modPath of source.files) {
       const owner = createModOwner(modPath, source, generation);
       const abortController = new AbortController();

--- a/src/mods/package-manifest.ts
+++ b/src/mods/package-manifest.ts
@@ -67,7 +67,7 @@ function isWindowsAbsolutePath(value: string): boolean {
   return path.win32.isAbsolute(value) || /^[a-zA-Z]:[\\/]/.test(value);
 }
 
-function isSafeRelativeModPath(value: string): boolean {
+export function isSafeLettaPackageModEntryPath(value: string): boolean {
   if (!value.trim()) return false;
   if (value.includes("\0")) return false;
   if (value.includes("\\")) return false;
@@ -170,7 +170,7 @@ function validateMods(
       addError(errors, entryPath, "mod entry must be a string path");
       return;
     }
-    if (!isSafeRelativeModPath(entry)) {
+    if (!isSafeLettaPackageModEntryPath(entry)) {
       addError(
         errors,
         entryPath,

--- a/src/mods/package-registry.ts
+++ b/src/mods/package-registry.ts
@@ -1,0 +1,428 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import {
+  isSafeLettaPackageModEntryPath,
+  readLettaPackageManifest,
+} from "@/mods/package-manifest";
+
+export const MOD_PACKAGES_REGISTRY_FILENAME = "packages.json";
+export const MOD_PACKAGES_DIRECTORY_NAME = "packages";
+
+export interface ManagedModPackageSource {
+  entries: string[];
+  files: string[];
+  root: string;
+  source: string;
+  version: string;
+}
+
+export interface ManagedModPackageDiagnostic {
+  error: Error;
+  path: string;
+}
+
+export interface ResolveManagedModPackagesResult {
+  diagnostics: ManagedModPackageDiagnostic[];
+  files: string[];
+  packages: ManagedModPackageSource[];
+}
+
+const PACKAGE_ENTRY_KEYS = new Set([
+  "source",
+  "version",
+  "enabled",
+  "root",
+  "entries",
+]);
+const PACKAGE_REGISTRY_KEYS = new Set(["packages"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function createDiagnostic(
+  diagnosticPath: string,
+  message: string,
+): ManagedModPackageDiagnostic {
+  return {
+    error: new Error(message),
+    path: diagnosticPath,
+  };
+}
+
+function getUnknownKeys(
+  value: Record<string, unknown>,
+  knownKeys: Set<string>,
+): string[] {
+  return Object.keys(value).filter((key) => !knownKeys.has(key));
+}
+
+function isWindowsAbsolutePath(value: string): boolean {
+  return path.win32.isAbsolute(value) || /^[a-zA-Z]:[\\/]/.test(value);
+}
+
+function normalizeRelativePath(value: string): string | null {
+  if (!value.trim()) return null;
+  if (value.includes("\0")) return null;
+  if (value.includes("\\")) return null;
+  if (path.posix.isAbsolute(value) || path.isAbsolute(value)) return null;
+  if (isWindowsAbsolutePath(value)) return null;
+
+  const normalized = path.posix.normalize(value);
+  if (normalized === "." || normalized === "") return null;
+  if (normalized === ".." || normalized.startsWith("../")) return null;
+  if (normalized.split("/").includes("..")) return null;
+  return normalized;
+}
+
+function resolveRelativePath(
+  root: string,
+  relativePath: string,
+): string | null {
+  const normalized = normalizeRelativePath(relativePath);
+  if (!normalized) return null;
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(resolvedRoot, ...normalized.split("/"));
+  const rootWithSeparator = resolvedRoot.endsWith(path.sep)
+    ? resolvedRoot
+    : `${resolvedRoot}${path.sep}`;
+  if (resolved !== resolvedRoot && !resolved.startsWith(rootWithSeparator)) {
+    return null;
+  }
+  return resolved;
+}
+
+function parseJsonFile(filePath: string):
+  | {
+      ok: true;
+      value: unknown;
+    }
+  | {
+      error: ManagedModPackageDiagnostic;
+      ok: false;
+    } {
+  try {
+    return {
+      ok: true,
+      value: JSON.parse(readFileSync(filePath, "utf8")),
+    };
+  } catch (error) {
+    return {
+      error: createDiagnostic(
+        filePath,
+        error instanceof Error ? error.message : String(error),
+      ),
+      ok: false,
+    };
+  }
+}
+
+function validatePackageEntries(
+  value: unknown,
+  diagnosticPath: string,
+):
+  | {
+      diagnostics: ManagedModPackageDiagnostic[];
+      entries: string[];
+      ok: true;
+    }
+  | {
+      diagnostics: ManagedModPackageDiagnostic[];
+      ok: false;
+    } {
+  const diagnostics: ManagedModPackageDiagnostic[] = [];
+  if (!Array.isArray(value)) {
+    return {
+      diagnostics: [
+        createDiagnostic(diagnosticPath, "package entries must be an array"),
+      ],
+      ok: false,
+    };
+  }
+  if (value.length === 0) {
+    return {
+      diagnostics: [
+        createDiagnostic(diagnosticPath, "package entries must not be empty"),
+      ],
+      ok: false,
+    };
+  }
+
+  const entries: string[] = [];
+  value.forEach((entry, index) => {
+    const entryPath = `${diagnosticPath}[${index}]`;
+    if (typeof entry !== "string") {
+      diagnostics.push(
+        createDiagnostic(entryPath, "package entry must be a string"),
+      );
+      return;
+    }
+    if (!isSafeLettaPackageModEntryPath(entry)) {
+      diagnostics.push(
+        createDiagnostic(
+          entryPath,
+          "package entry must be a safe relative .ts, .tsx, .js, or .mjs path",
+        ),
+      );
+      return;
+    }
+    entries.push(entry);
+  });
+
+  if (diagnostics.length > 0) {
+    return { diagnostics, ok: false };
+  }
+  return { diagnostics: [], entries, ok: true };
+}
+
+function normalizeModEntry(value: string): string {
+  return path.posix.normalize(value);
+}
+
+function resolvePackageEntry(
+  packageRoot: string,
+  entry: string,
+): string | null {
+  const normalized = normalizeModEntry(entry);
+  return resolveRelativePath(packageRoot, normalized);
+}
+
+function resolvePackage(
+  modsRoot: string,
+  rawEntry: unknown,
+  index: number,
+):
+  | {
+      diagnostics: ManagedModPackageDiagnostic[];
+      ok: false;
+    }
+  | {
+      diagnostics: [];
+      files: string[];
+      ok: true;
+      packageSource: ManagedModPackageSource | null;
+    } {
+  const diagnosticPath = `packages[${index}]`;
+  if (!isRecord(rawEntry)) {
+    return {
+      diagnostics: [
+        createDiagnostic(
+          diagnosticPath,
+          "package registry entry must be an object",
+        ),
+      ],
+      ok: false,
+    };
+  }
+
+  const diagnostics: ManagedModPackageDiagnostic[] = [];
+  for (const key of getUnknownKeys(rawEntry, PACKAGE_ENTRY_KEYS)) {
+    diagnostics.push(
+      createDiagnostic(
+        `${diagnosticPath}.${key}`,
+        `unknown package field '${key}'`,
+      ),
+    );
+  }
+
+  const source = rawEntry.source;
+  const version = rawEntry.version;
+  const enabled = rawEntry.enabled;
+  if (typeof source !== "string" || !source.trim()) {
+    diagnostics.push(
+      createDiagnostic(
+        `${diagnosticPath}.source`,
+        "package source must be a string",
+      ),
+    );
+  }
+  if (typeof version !== "string" || !version.trim()) {
+    diagnostics.push(
+      createDiagnostic(
+        `${diagnosticPath}.version`,
+        "package version must be a string",
+      ),
+    );
+  }
+  if (typeof enabled !== "boolean") {
+    diagnostics.push(
+      createDiagnostic(
+        `${diagnosticPath}.enabled`,
+        "package enabled must be a boolean",
+      ),
+    );
+  }
+
+  if (
+    diagnostics.length > 0 ||
+    typeof source !== "string" ||
+    typeof version !== "string" ||
+    typeof enabled !== "boolean"
+  ) {
+    return { diagnostics, ok: false };
+  }
+
+  if (enabled === false) {
+    return { diagnostics: [], files: [], ok: true, packageSource: null };
+  }
+
+  if (typeof rawEntry.root !== "string") {
+    return {
+      diagnostics: [
+        createDiagnostic(
+          `${diagnosticPath}.root`,
+          "package root must be a string",
+        ),
+      ],
+      ok: false,
+    };
+  }
+  const packageRoot = resolveRelativePath(modsRoot, rawEntry.root);
+  if (!packageRoot) {
+    return {
+      diagnostics: [
+        createDiagnostic(
+          `${diagnosticPath}.root`,
+          "package root must be a safe relative path",
+        ),
+      ],
+      ok: false,
+    };
+  }
+
+  const entriesResult = validatePackageEntries(
+    rawEntry.entries,
+    `${diagnosticPath}.entries`,
+  );
+  if (!entriesResult.ok) {
+    return { diagnostics: entriesResult.diagnostics, ok: false };
+  }
+
+  const packageJsonPath = path.join(packageRoot, "package.json");
+  const manifestResult = readLettaPackageManifest(packageJsonPath);
+  if (!manifestResult.ok) {
+    return {
+      diagnostics: manifestResult.errors.map((error) =>
+        createDiagnostic(
+          packageJsonPath,
+          `Invalid package manifest at ${error.path}: ${error.message}`,
+        ),
+      ),
+      ok: false,
+    };
+  }
+  if (!manifestResult.manifest) {
+    return {
+      diagnostics: [
+        createDiagnostic(
+          packageJsonPath,
+          "Package does not include a package.json#letta manifest",
+        ),
+      ],
+      ok: false,
+    };
+  }
+
+  const manifestEntries = new Set(
+    manifestResult.manifest.mods.map(normalizeModEntry),
+  );
+  const files: string[] = [];
+  for (const entry of entriesResult.entries) {
+    const normalizedEntry = normalizeModEntry(entry);
+    if (!manifestEntries.has(normalizedEntry)) {
+      diagnostics.push(
+        createDiagnostic(
+          `${diagnosticPath}.entries`,
+          `Package entry '${entry}' is not declared in package.json#letta.mods`,
+        ),
+      );
+      continue;
+    }
+    const entryPath = resolvePackageEntry(packageRoot, normalizedEntry);
+    if (!entryPath) {
+      diagnostics.push(
+        createDiagnostic(
+          `${diagnosticPath}.entries`,
+          `Package entry '${entry}' resolves outside the package root`,
+        ),
+      );
+      continue;
+    }
+    files.push(entryPath);
+  }
+
+  if (diagnostics.length > 0) {
+    return { diagnostics, ok: false };
+  }
+
+  return {
+    diagnostics: [],
+    files,
+    ok: true,
+    packageSource: {
+      entries: entriesResult.entries,
+      files,
+      root: packageRoot,
+      source,
+      version,
+    },
+  };
+}
+
+export function resolveManagedModPackages(
+  modsRoot: string,
+): ResolveManagedModPackagesResult {
+  const registryPath = path.join(modsRoot, MOD_PACKAGES_REGISTRY_FILENAME);
+  if (!existsSync(registryPath)) {
+    return { diagnostics: [], files: [], packages: [] };
+  }
+
+  const registryResult = parseJsonFile(registryPath);
+  if (!registryResult.ok) {
+    return { diagnostics: [registryResult.error], files: [], packages: [] };
+  }
+  if (!isRecord(registryResult.value)) {
+    return {
+      diagnostics: [
+        createDiagnostic(registryPath, "packages.json must be an object"),
+      ],
+      files: [],
+      packages: [],
+    };
+  }
+
+  const diagnostics: ManagedModPackageDiagnostic[] = [];
+  for (const key of getUnknownKeys(
+    registryResult.value,
+    PACKAGE_REGISTRY_KEYS,
+  )) {
+    diagnostics.push(
+      createDiagnostic(
+        `packages.json.${key}`,
+        `unknown registry field '${key}'`,
+      ),
+    );
+  }
+
+  const packagesValue = registryResult.value.packages;
+  if (!Array.isArray(packagesValue)) {
+    diagnostics.push(
+      createDiagnostic("packages.json.packages", "packages must be an array"),
+    );
+    return { diagnostics, files: [], packages: [] };
+  }
+
+  const files: string[] = [];
+  const packages: ManagedModPackageSource[] = [];
+  packagesValue.forEach((entry, index) => {
+    const result = resolvePackage(modsRoot, entry, index);
+    diagnostics.push(...result.diagnostics);
+    if (!result.ok) return;
+    files.push(...result.files);
+    if (result.packageSource) {
+      packages.push(result.packageSource);
+    }
+  });
+
+  return { diagnostics, files, packages };
+}

--- a/src/mods/types.ts
+++ b/src/mods/types.ts
@@ -260,6 +260,7 @@ export type ModDiagnosticPhase =
   | "transpile"
   | "import"
   | "activate"
+  | "package_manifest"
   | "command_override"
   | "command.run"
   | "deprecated_api"


### PR DESCRIPTION
## Summary
- add harness-scoped `packages.json` resolution for managed mod packages
- validate package entries against package roots and `package.json#letta.mods`
- load only declared package entry files, while keeping agent MemFS mods loose-only and higher priority
- surface invalid package registry/manifest state as `package_manifest` diagnostics

## Tests
- `bun test src/mods/package-manifest.test.ts`
- `bun test src/mods/mod-engine.test.ts`
- `bun test src/cli/mods/local-mod-loader.test.ts`
- `bun run typecheck`
- `bun run check`