### PR TITLE
fix(code-desktop): preserve BYOK Opus reasoning settings

### DIFF
--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -36,22 +36,38 @@ function buildModelSettings(
   modelHandle: string,
   updateArgs?: Record<string, unknown>,
 ): ModelSettings {
+  const explicitProviderType =
+    typeof updateArgs?.provider_type === "string"
+      ? updateArgs.provider_type
+      : undefined;
   // Include our custom ChatGPT OAuth provider (chatgpt-plus-pro)
-  const isOpenAICodex = modelHandle.startsWith("openai-codex/");
+  const isOpenAICodex =
+    explicitProviderType === "chatgpt_oauth" ||
+    modelHandle.startsWith("openai-codex/");
   const isOpenAI =
+    explicitProviderType === "openai" ||
     modelHandle.startsWith("openai/") ||
     isOpenAICodex ||
     modelHandle.startsWith(`${OPENAI_CODEX_PROVIDER_NAME}/`);
   // Include legacy custom Anthropic OAuth provider (claude-pro-max) and minimax
   const isAnthropic =
+    explicitProviderType === "anthropic" ||
     modelHandle.startsWith("anthropic/") ||
     modelHandle.startsWith("claude-pro-max/") ||
     modelHandle.startsWith("minimax/");
-  const isZai = modelHandle.startsWith("zai/");
-  const isGoogleAI = modelHandle.startsWith("google_ai/");
-  const isGoogleVertex = modelHandle.startsWith("google_vertex/");
-  const isOpenRouter = modelHandle.startsWith("openrouter/");
-  const isBedrock = modelHandle.startsWith("bedrock/");
+  const isZai =
+    explicitProviderType === "zai" || modelHandle.startsWith("zai/");
+  const isGoogleAI =
+    explicitProviderType === "google_ai" ||
+    modelHandle.startsWith("google_ai/");
+  const isGoogleVertex =
+    explicitProviderType === "google_vertex" ||
+    modelHandle.startsWith("google_vertex/");
+  const isOpenRouter =
+    explicitProviderType === "openrouter" ||
+    modelHandle.startsWith("openrouter/");
+  const isBedrock =
+    explicitProviderType === "bedrock" || modelHandle.startsWith("bedrock/");
 
   let settings: ModelSettings;
 

--- a/src/websocket/listen-model-update.test.ts
+++ b/src/websocket/listen-model-update.test.ts
@@ -238,6 +238,87 @@ describe("listen-client applyModelUpdateForRuntime wiring", () => {
     expect(source).toContain('appliedTo = "conversation"');
   });
 
+  test("preserves registry provider type for BYOK model id updates", () => {
+    const resolved = __listenClientTestUtils.resolveModelForUpdate({
+      model_id: "opus-4.8-medium",
+      model_handle: "lc-anthropic/claude-opus-4-8",
+    });
+
+    expect(resolved).not.toBeNull();
+    expect(resolved?.handle).toBe("lc-anthropic/claude-opus-4-8");
+    expect(resolved?.updateArgs?.provider_type).toBe("anthropic");
+    expect(resolved?.updateArgs?.reasoning_effort).toBe("medium");
+  });
+
+  test("returns Anthropic effort settings for BYOK Opus 4.8 max update", async () => {
+    const storageDir = await mkdtemp(join(os.tmpdir(), "ws-byok-opus-max-"));
+    const previousHome = process.env.HOME;
+    try {
+      process.env.HOME = storageDir;
+      await settingsManager.reset();
+      await settingsManager.initialize();
+
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+      });
+      __testSetBackend(backend);
+      const agent = await backend.createAgent({
+        name: "BYOK Opus Agent",
+        model: "lc-anthropic/claude-opus-4-8",
+        model_settings: {
+          provider_type: "anthropic",
+          effort: "high",
+          parallel_tool_calls: true,
+        },
+      } as AgentCreateBody);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as ConversationCreateBody);
+
+      const listener = __listenClientTestUtils.createListenerRuntime();
+      const scopedRuntime =
+        __listenClientTestUtils.getOrCreateConversationRuntime(
+          listener,
+          agent.id,
+          conversation.id,
+        );
+      const model = __listenClientTestUtils.resolveModelForUpdate({
+        model_id: "opus-4.8-max",
+        model_handle: "lc-anthropic/claude-opus-4-8",
+      });
+      if (!model) throw new Error("Expected opus-4.8-max model fixture");
+
+      const response = await __listenClientTestUtils.applyModelUpdateForRuntime(
+        {
+          socket: new MockSocket() as unknown as WebSocket,
+          listener,
+          scopedRuntime,
+          requestId: "byok-opus-max",
+          model,
+        },
+      );
+
+      expect(response.success).toBe(true);
+      expect(response.model_id).toBe("opus-4.8-max");
+      expect(response.model_handle).toBe("lc-anthropic/claude-opus-4-8");
+      expect(response.model_settings).toMatchObject({
+        provider_type: "anthropic",
+        effort: "max",
+      });
+      expect(
+        (response.model_settings as Record<string, unknown> | null)?.reasoning,
+      ).toBeUndefined();
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
   test("preserves conversation context limit for same-handle desktop model updates", async () => {
     const storageDir = await mkdtemp(join(os.tmpdir(), "ws-model-context-"));
     const previousHome = process.env.HOME;

--- a/src/websocket/listener/commands/model-toolset.ts
+++ b/src/websocket/listener/commands/model-toolset.ts
@@ -73,6 +73,27 @@ type ModelScopeSnapshot = {
   } | null;
 };
 
+function inferProviderTypeFromRegistryHandle(
+  modelHandle: string,
+): string | undefined {
+  const provider = modelHandle.split("/")[0];
+  if (!provider) return undefined;
+  if (provider === "openai-codex") return "chatgpt_oauth";
+  if (
+    provider === "anthropic" ||
+    provider === "bedrock" ||
+    provider === "google_ai" ||
+    provider === "google_vertex" ||
+    provider === "minimax" ||
+    provider === "openai" ||
+    provider === "openrouter" ||
+    provider === "zai"
+  ) {
+    return provider;
+  }
+  return undefined;
+}
+
 function buildModelHandleFromConfig(
   config: ModelScopeSnapshot["llmConfig"],
 ): string | null {
@@ -163,15 +184,25 @@ export function resolveModelForUpdate(payload: {
         payload.model_handle.length > 0
           ? payload.model_handle
           : null;
+      const updateArgs =
+        byId.updateArgs && typeof byId.updateArgs === "object"
+          ? ({ ...byId.updateArgs } as Record<string, unknown>)
+          : undefined;
+      const providerType = inferProviderTypeFromRegistryHandle(byId.handle);
+      if (
+        explicitHandle &&
+        updateArgs &&
+        providerType &&
+        typeof updateArgs.provider_type !== "string"
+      ) {
+        updateArgs.provider_type = providerType;
+      }
 
       return {
         id: byId.id,
         handle: explicitHandle ?? byId.handle,
         label: byId.label,
-        updateArgs:
-          byId.updateArgs && typeof byId.updateArgs === "object"
-            ? ({ ...byId.updateArgs } as Record<string, unknown>)
-            : undefined,
+        updateArgs,
       };
     }
   }


### PR DESCRIPTION
## Summary
- infer the registry provider type when desktop updates a BYOK model handle by model id
- make model-settings construction honor explicit provider_type for BYOK aliases like lc-anthropic
- cover Opus 4.8 Max updates returning Anthropic effort settings instead of OpenAI reasoning settings

## Testing
- bun test src/websocket/listen-model-update.test.ts src/agent/modify-local.test.ts
- bun run typecheck
- git diff --check