### PR TITLE
feat(mods): manage installed packages

### DIFF
--- a/src/cli/subcommands/mods.test.ts
+++ b/src/cli/subcommands/mods.test.ts
@@ -1,10 +1,17 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
-  formatLooseModsList,
-  listLooseMods,
+  formatModsList,
+  listMods,
   runModsSubcommand,
 } from "@/cli/subcommands/mods";
 
@@ -41,6 +48,57 @@ function captureConsole(): {
   };
 }
 
+function writeManagedPackage(params: {
+  capabilities?: string[];
+  enabled?: boolean;
+  entries?: string[];
+  modsRoot: string;
+  root?: string;
+  source?: string;
+  version?: string;
+}): string {
+  const source = params.source ?? "npm:@caren/my-mod";
+  const version = params.version ?? "0.1.0";
+  const packageRootRelative = params.root ?? "packages/npm/@caren/my-mod";
+  const entries = params.entries ?? ["mods/index.ts"];
+  const packageRoot = join(params.modsRoot, ...packageRootRelative.split("/"));
+  mkdirSync(join(packageRoot, "mods"), { recursive: true });
+  writeFileSync(join(packageRoot, "mods", "index.ts"), "export {};\n");
+  writeFileSync(
+    join(packageRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        letta: {
+          manifestVersion: 1,
+          mods: entries,
+          ...(params.capabilities ? { capabilities: params.capabilities } : {}),
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeFileSync(
+    join(params.modsRoot, "packages.json"),
+    `${JSON.stringify(
+      {
+        packages: [
+          {
+            source,
+            version,
+            enabled: params.enabled ?? true,
+            root: packageRootRelative,
+            entries,
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  return packageRoot;
+}
+
 afterEach(() => {
   for (const dir of tempRoots.splice(0)) {
     rmSync(dir, { force: true, recursive: true });
@@ -55,18 +113,21 @@ describe("mods subcommand", () => {
     writeFileSync(join(harnessMods, "statusline.ts"), "export {};\n");
     writeFileSync(join(harnessMods, "provider.mjs"), "export {};\n");
 
-    const result = listLooseMods({ globalModsDirectory: harnessMods });
+    const result = listMods({ globalModsDirectory: harnessMods });
 
     expect(result.agent).toBeUndefined();
     expect(result.harness.files).toEqual([
       join(harnessMods, "provider.mjs"),
       join(harnessMods, "statusline.ts"),
     ]);
-    expect(formatLooseModsList(result)).toBe(
+    expect(formatModsList(result)).toBe(
       [
         "Harness mods",
         `  enabled  ${join(harnessMods, "provider.mjs")}`,
         `  enabled  ${join(harnessMods, "statusline.ts")}`,
+        "",
+        "Installed packages",
+        "  (none)",
       ].join("\n"),
     );
   });
@@ -80,33 +141,45 @@ describe("mods subcommand", () => {
     writeFileSync(join(harnessMods, "global.ts"), "export {};\n");
     writeFileSync(join(agentMods, "agent.ts"), "export {};\n");
 
-    const result = listLooseMods({
+    const result = listMods({
       agentModsDirectory: agentMods,
       globalModsDirectory: harnessMods,
     });
 
     expect(result.agent?.files).toEqual([join(agentMods, "agent.ts")]);
     expect(result.harness.files).toEqual([join(harnessMods, "global.ts")]);
-    expect(formatLooseModsList(result)).toBe(
+    expect(formatModsList(result)).toBe(
       [
         "Agent mods",
         `  enabled  ${join(agentMods, "agent.ts")}`,
         "",
         "Harness mods",
         `  enabled  ${join(harnessMods, "global.ts")}`,
+        "",
+        "Installed packages",
+        "  (none)",
       ].join("\n"),
     );
   });
 
   test("formats empty sections", () => {
     const root = createTempDir();
-    const result = listLooseMods({
+    const result = listMods({
       agentModsDirectory: join(root, "memory", "mods"),
       globalModsDirectory: join(root, "mods"),
     });
 
-    expect(formatLooseModsList(result)).toBe(
-      ["Agent mods", "  (none)", "", "Harness mods", "  (none)"].join("\n"),
+    expect(formatModsList(result)).toBe(
+      [
+        "Agent mods",
+        "  (none)",
+        "",
+        "Harness mods",
+        "  (none)",
+        "",
+        "Installed packages",
+        "  (none)",
+      ].join("\n"),
     );
   });
 
@@ -119,9 +192,46 @@ describe("mods subcommand", () => {
     writeFileSync(join(harnessMods, "notes.md"), "# not a mod\n");
     writeFileSync(join(harnessMods, "nested", "nested.ts"), "export {};\n");
 
-    const result = listLooseMods({ globalModsDirectory: harnessMods });
+    const result = listMods({ globalModsDirectory: harnessMods });
 
     expect(result.harness.files).toEqual([join(harnessMods, "visible.tsx")]);
+  });
+
+  test("lists installed packages separately from harness loose mods", () => {
+    const root = createTempDir();
+    const harnessMods = join(root, "mods");
+    mkdirSync(harnessMods, { recursive: true });
+    writeFileSync(join(harnessMods, "global.ts"), "export {};\n");
+    writeManagedPackage({
+      capabilities: ["commands"],
+      modsRoot: harnessMods,
+    });
+
+    const result = listMods({ globalModsDirectory: harnessMods });
+
+    expect(result.harness.files).toEqual([join(harnessMods, "global.ts")]);
+    expect(result.packages).toMatchObject([
+      {
+        capabilities: ["commands"],
+        enabled: true,
+        source: "npm:@caren/my-mod",
+        version: "0.1.0",
+      },
+    ]);
+    expect(formatModsList(result)).toContain(
+      "  enabled  npm:@caren/my-mod@0.1.0    commands",
+    );
+  });
+
+  test("lists package registry diagnostics", () => {
+    const root = createTempDir();
+    const harnessMods = join(root, "mods");
+    mkdirSync(harnessMods, { recursive: true });
+    writeFileSync(join(harnessMods, "packages.json"), "{\n");
+
+    expect(
+      formatModsList(listMods({ globalModsDirectory: harnessMods })),
+    ).toContain("  error");
   });
 
   test("prints usage for help", async () => {
@@ -148,6 +258,107 @@ describe("mods subcommand", () => {
         "Unknown mods action: install",
       );
       expect(consoleCapture.logs.join("\n")).toContain("Usage:");
+    } finally {
+      consoleCapture.restore();
+    }
+  });
+
+  test("disable command updates the global package registry and prints reload hint", async () => {
+    const root = createTempDir();
+    const home = join(root, "home");
+    const modsRoot = join(home, ".letta", "mods");
+    mkdirSync(modsRoot, { recursive: true });
+    writeManagedPackage({ modsRoot });
+    const consoleCapture = captureConsole();
+
+    try {
+      const exitCode = await runModsSubcommand(
+        ["disable", "npm:@caren/my-mod"],
+        { globalModsDirectory: modsRoot },
+      );
+
+      expect(exitCode).toBe(0);
+      expect(consoleCapture.logs.join("\n")).toContain(
+        "disabled npm:@caren/my-mod@0.1.0",
+      );
+      expect(consoleCapture.logs.join("\n")).toContain("Run /reload");
+      const registry = JSON.parse(
+        readFileSync(join(modsRoot, "packages.json"), "utf8"),
+      );
+      expect(registry.packages[0].enabled).toBe(false);
+    } finally {
+      consoleCapture.restore();
+    }
+  });
+
+  test("enable command updates the global package registry", async () => {
+    const root = createTempDir();
+    const modsRoot = join(root, "mods");
+    mkdirSync(modsRoot, { recursive: true });
+    writeManagedPackage({ enabled: false, modsRoot });
+    const consoleCapture = captureConsole();
+
+    try {
+      const exitCode = await runModsSubcommand(
+        ["enable", "npm:@caren/my-mod"],
+        { globalModsDirectory: modsRoot },
+      );
+
+      expect(exitCode).toBe(0);
+      expect(consoleCapture.logs.join("\n")).toContain(
+        "enabled npm:@caren/my-mod@0.1.0",
+      );
+      const registry = JSON.parse(
+        readFileSync(join(modsRoot, "packages.json"), "utf8"),
+      );
+      expect(registry.packages[0].enabled).toBe(true);
+    } finally {
+      consoleCapture.restore();
+    }
+  });
+
+  test("unknown package exits nonzero", async () => {
+    const root = createTempDir();
+    const modsRoot = join(root, "mods");
+    mkdirSync(modsRoot, { recursive: true });
+    writeManagedPackage({ modsRoot });
+    const consoleCapture = captureConsole();
+
+    try {
+      const exitCode = await runModsSubcommand(
+        ["disable", "npm:@caren/missing-mod"],
+        { globalModsDirectory: modsRoot },
+      );
+
+      expect(exitCode).toBe(1);
+      expect(consoleCapture.errors.join("\n")).toContain(
+        "Managed mod package not found: npm:@caren/missing-mod",
+      );
+    } finally {
+      consoleCapture.restore();
+    }
+  });
+
+  test("remove command deletes package root", async () => {
+    const root = createTempDir();
+    const home = join(root, "home");
+    const modsRoot = join(home, ".letta", "mods");
+    mkdirSync(modsRoot, { recursive: true });
+    const packageRoot = writeManagedPackage({ modsRoot });
+    const consoleCapture = captureConsole();
+
+    try {
+      const exitCode = await runModsSubcommand(
+        ["remove", "npm:@caren/my-mod@0.1.0"],
+        { globalModsDirectory: modsRoot },
+      );
+
+      expect(exitCode).toBe(0);
+      expect(existsSync(packageRoot)).toBe(false);
+      const registry = JSON.parse(
+        readFileSync(join(modsRoot, "packages.json"), "utf8"),
+      );
+      expect(registry.packages).toEqual([]);
     } finally {
       consoleCapture.restore();
     }

--- a/src/cli/subcommands/mods.ts
+++ b/src/cli/subcommands/mods.ts
@@ -1,21 +1,35 @@
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { parseArgs } from "node:util";
 import { getScopedMemoryFilesystemRoot } from "@/agent/memory-filesystem";
 import { type LocalModSource, resolveLocalModSources } from "@/mods/mod-engine";
+import {
+  listManagedModPackages,
+  type ManagedModPackageDiagnostic,
+  type ManagedModPackageListItem,
+  removeManagedModPackage,
+  setManagedModPackageEnabled,
+} from "@/mods/package-registry";
+import { resolveDefaultGlobalModsDirectory } from "@/mods/paths";
 
 interface LooseModSection {
   files: string[];
   root: string;
 }
 
-export interface LooseModsList {
+export interface ModsList {
   agent?: LooseModSection;
   harness: LooseModSection;
+  packageDiagnostics: ManagedModPackageDiagnostic[];
+  packages: ManagedModPackageListItem[];
 }
 
-export interface ListLooseModsOptions {
+export interface ListModsOptions {
   agentId?: string | null;
   agentModsDirectory?: string | null;
+  globalModsDirectory?: string;
+}
+
+interface RunModsOptions {
   globalModsDirectory?: string;
 }
 
@@ -25,11 +39,17 @@ const MODS_OPTIONS = {
   "agent-id": { type: "string" },
 } as const;
 
+const RELOAD_HINT =
+  "Run /reload in active sessions for changes to take effect.";
+
 function printUsage(): void {
   console.log(
     `
 Usage:
   letta mods list [--agent <id>]
+  letta mods enable <package-spec>
+  letta mods disable <package-spec>
+  letta mods remove <package-spec>
 
 Options:
   --agent <id>       Include loose mods from this agent's MemFS directory
@@ -61,31 +81,36 @@ export function getAgentModsDirectory(agentId: string): string {
   return join(getScopedMemoryFilesystemRoot(agentId), "mods");
 }
 
+function directFilesForSource(source: LocalModSource): string[] {
+  return source.files.filter((file) => dirname(file) === source.root);
+}
+
 function toSection(source: LocalModSource): LooseModSection {
   return {
-    files: [...source.files],
+    files: directFilesForSource(source),
     root: source.root,
   };
 }
 
-export function listLooseMods(
-  options: ListLooseModsOptions = {},
-): LooseModsList {
+export function listMods(options: ListModsOptions = {}): ModsList {
   const agentModsDirectory =
     options.agentModsDirectory ??
     (options.agentId ? getAgentModsDirectory(options.agentId) : null);
+  const globalModsDirectory =
+    options.globalModsDirectory ?? resolveDefaultGlobalModsDirectory();
   const sources = resolveLocalModSources({
     ...(agentModsDirectory ? { agentModsDirectory } : {}),
-    ...(options.globalModsDirectory
-      ? { globalModsDirectory: options.globalModsDirectory }
-      : {}),
+    globalModsDirectory,
   });
   const harness = sources.find((source) => source.scope === "global");
   const agent = sources.find((source) => source.scope === "agent");
+  const managedPackages = listManagedModPackages(globalModsDirectory);
 
   return {
     ...(agent ? { agent: toSection(agent) } : {}),
     harness: harness ? toSection(harness) : { files: [], root: "" },
+    packageDiagnostics: managedPackages.diagnostics,
+    packages: managedPackages.packages,
   };
 }
 
@@ -105,16 +130,48 @@ function formatLooseModSection(
   return lines.join("\n");
 }
 
-export function formatLooseModsList(mods: LooseModsList): string {
+function formatPackageSpecifier(pkg: ManagedModPackageListItem): string {
+  return `${pkg.source}@${pkg.version}`;
+}
+
+function formatInstalledPackagesSection(
+  mods: Pick<ModsList, "packageDiagnostics" | "packages">,
+): string {
+  const lines = ["Installed packages"];
+  if (mods.packages.length === 0 && mods.packageDiagnostics.length === 0) {
+    lines.push("  (none)");
+    return lines.join("\n");
+  }
+
+  for (const pkg of mods.packages) {
+    const status = pkg.enabled ? "enabled" : "disabled";
+    const capabilities = pkg.capabilities.join(", ");
+    lines.push(
+      capabilities
+        ? `  ${status}  ${formatPackageSpecifier(pkg)}    ${capabilities}`
+        : `  ${status}  ${formatPackageSpecifier(pkg)}`,
+    );
+  }
+  for (const diagnostic of mods.packageDiagnostics) {
+    lines.push(`  error    ${diagnostic.path}    ${diagnostic.error.message}`);
+  }
+  return lines.join("\n");
+}
+
+export function formatModsList(mods: ModsList): string {
   const sections: string[] = [];
   if (mods.agent) {
     sections.push(formatLooseModSection("Agent mods", mods.agent));
   }
   sections.push(formatLooseModSection("Harness mods", mods.harness));
+  sections.push(formatInstalledPackagesSection(mods));
   return sections.join("\n\n");
 }
 
-async function runList(argv: string[]): Promise<number> {
+async function runList(
+  argv: string[],
+  options: RunModsOptions = {},
+): Promise<number> {
   let parsed: ReturnType<typeof parseModsArgs>;
   try {
     parsed = parseModsArgs(argv);
@@ -137,12 +194,85 @@ async function runList(argv: string[]): Promise<number> {
   }
 
   const agentId = getExplicitAgentId(parsed.values);
-  const mods = listLooseMods({ agentId });
-  console.log(formatLooseModsList(mods));
+  const mods = listMods({
+    agentId,
+    ...(options.globalModsDirectory
+      ? { globalModsDirectory: options.globalModsDirectory }
+      : {}),
+  });
+  console.log(formatModsList(mods));
   return 0;
 }
 
-export async function runModsSubcommand(argv: string[]): Promise<number> {
+async function runPackageMutation(
+  action: "disable" | "enable" | "remove",
+  argv: string[],
+  options: RunModsOptions = {},
+): Promise<number> {
+  let parsed: ReturnType<typeof parseModsArgs>;
+  try {
+    parsed = parseModsArgs(argv);
+  } catch (error) {
+    console.error(
+      `Error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    printUsage();
+    return 1;
+  }
+
+  if (parsed.values.help) {
+    printUsage();
+    return 0;
+  }
+  if (getExplicitAgentId(parsed.values)) {
+    console.error(`--agent is only supported for 'letta mods list'.`);
+    printUsage();
+    return 1;
+  }
+
+  const [specifier, extra] = parsed.positionals;
+  if (!specifier) {
+    console.error(`Missing package specifier.`);
+    printUsage();
+    return 1;
+  }
+  if (extra) {
+    console.error(`Unexpected argument: ${extra}`);
+    printUsage();
+    return 1;
+  }
+
+  try {
+    const modsRoot =
+      options.globalModsDirectory ?? resolveDefaultGlobalModsDirectory();
+    const result =
+      action === "remove"
+        ? removeManagedModPackage({ modsRoot, specifier })
+        : setManagedModPackageEnabled({
+            enabled: action === "enable",
+            modsRoot,
+            specifier,
+          });
+    const packageSpec = formatPackageSpecifier(result.package);
+    const status =
+      action === "remove"
+        ? "removed"
+        : action === "enable"
+          ? "enabled"
+          : "disabled";
+    console.log(`${status} ${packageSpec}`);
+    console.log(RELOAD_HINT);
+    return 0;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
+export async function runModsSubcommand(
+  argv: string[],
+  options: RunModsOptions = {},
+): Promise<number> {
   const [action, ...rest] = argv;
 
   if (!action || action === "help" || action === "--help" || action === "-h") {
@@ -152,7 +282,11 @@ export async function runModsSubcommand(argv: string[]): Promise<number> {
 
   switch (action) {
     case "list":
-      return runList(rest);
+      return runList(rest, options);
+    case "enable":
+    case "disable":
+    case "remove":
+      return runPackageMutation(action, rest, options);
     default:
       console.error(`Unknown mods action: ${action}`);
       printUsage();

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,7 @@ USAGE
   letta memory ...      Memory filesystem subcommands
   letta agents ...      Agents subcommands (JSON-only)
   letta messages ...    Messages subcommands (JSON-only)
-  letta mods ...        List installed loose mods
+  letta mods ...        List and manage local mods
   letta app-server ...  Run local app-server websocket transport
   letta connect ...     Connect providers from terminal
   letta backend ...     Show or set the default backend
@@ -207,6 +207,9 @@ SUBCOMMANDS
   letta messages list [--agent <id>]
   letta messages transcript --conversation <id> [--out <path>]
   letta mods list [--agent <id>]
+  letta mods enable <package-spec>
+  letta mods disable <package-spec>
+  letta mods remove <package-spec>
   letta app-server [--listen ws://127.0.0.1:4500]
   letta connect <provider> [options]
   letta install <skill> [--agent <id> | -n <name>]

--- a/src/mods/package-registry.test.ts
+++ b/src/mods/package-registry.test.ts
@@ -260,6 +260,30 @@ describe("managed mod package registry", () => {
     expect(readRegistry(modsRoot).packages).toHaveLength(1);
   });
 
+  test("remove refuses scoped namespace package sources", () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    const scopedRoot = path.join(modsRoot, "packages", "npm", "@caren");
+    mkdirSync(scopedRoot, { recursive: true });
+    writeRegistry(modsRoot, [
+      {
+        enabled: true,
+        root: "packages/npm/@caren",
+        source: "npm:@caren",
+        version: "0.1.0",
+      },
+    ]);
+
+    expect(() =>
+      removeManagedModPackage({
+        modsRoot,
+        specifier: "npm:@caren@0.1.0",
+      }),
+    ).toThrow("does not match expected package root");
+    expect(existsSync(scopedRoot)).toBe(true);
+    expect(readRegistry(modsRoot).packages).toHaveLength(1);
+  });
+
   test("source-only spec errors when multiple versions match", () => {
     const root = createTempDir();
     const modsRoot = path.join(root, "mods");

--- a/src/mods/package-registry.test.ts
+++ b/src/mods/package-registry.test.ts
@@ -1,0 +1,331 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  listManagedModPackages,
+  removeManagedModPackage,
+  setManagedModPackageEnabled,
+} from "@/mods/package-registry";
+
+const tempRoots: string[] = [];
+
+function createTempDir(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "letta-package-registry-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+function writePackage(params: {
+  capabilities?: string[];
+  enabled: boolean;
+  modsRoot: string;
+  root: string;
+  source: string;
+  version: string;
+}): string {
+  const packageRoot = path.join(params.modsRoot, ...params.root.split("/"));
+  mkdirSync(path.join(packageRoot, "mods"), { recursive: true });
+  writeFileSync(path.join(packageRoot, "mods", "index.ts"), "export {};\n");
+  writeFileSync(
+    path.join(packageRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        letta: {
+          manifestVersion: 1,
+          mods: ["mods/index.ts"],
+          ...(params.capabilities ? { capabilities: params.capabilities } : {}),
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  return packageRoot;
+}
+
+function writeRegistry(
+  modsRoot: string,
+  packages: Array<{
+    enabled: boolean;
+    root: string;
+    source: string;
+    version: string;
+  }>,
+): void {
+  writeFileSync(
+    path.join(modsRoot, "packages.json"),
+    `${JSON.stringify(
+      {
+        packages: packages.map((pkg) => ({
+          ...pkg,
+          entries: ["mods/index.ts"],
+        })),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+function readRegistry(modsRoot: string): {
+  packages: Array<{ enabled: boolean }>;
+} {
+  return JSON.parse(readFileSync(path.join(modsRoot, "packages.json"), "utf8"));
+}
+
+afterEach(() => {
+  for (const dir of tempRoots.splice(0)) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe("managed mod package registry", () => {
+  test("lists enabled and disabled packages with manifest capabilities", () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    mkdirSync(modsRoot, { recursive: true });
+    writePackage({
+      capabilities: ["commands"],
+      enabled: true,
+      modsRoot,
+      root: "packages/npm/@caren/enabled-mod",
+      source: "npm:@caren/enabled-mod",
+      version: "0.1.0",
+    });
+    writePackage({
+      capabilities: ["tools"],
+      enabled: false,
+      modsRoot,
+      root: "packages/npm/@caren/disabled-mod",
+      source: "npm:@caren/disabled-mod",
+      version: "0.2.0",
+    });
+    writeRegistry(modsRoot, [
+      {
+        enabled: true,
+        root: "packages/npm/@caren/enabled-mod",
+        source: "npm:@caren/enabled-mod",
+        version: "0.1.0",
+      },
+      {
+        enabled: false,
+        root: "packages/npm/@caren/disabled-mod",
+        source: "npm:@caren/disabled-mod",
+        version: "0.2.0",
+      },
+    ]);
+
+    expect(listManagedModPackages(modsRoot)).toMatchObject({
+      diagnostics: [],
+      packages: [
+        {
+          capabilities: ["commands"],
+          enabled: true,
+          source: "npm:@caren/enabled-mod",
+          version: "0.1.0",
+        },
+        {
+          capabilities: ["tools"],
+          enabled: false,
+          source: "npm:@caren/disabled-mod",
+          version: "0.2.0",
+        },
+      ],
+      registryExists: true,
+    });
+  });
+
+  test("enables and disables packages by source", () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    mkdirSync(modsRoot, { recursive: true });
+    writePackage({
+      enabled: false,
+      modsRoot,
+      root: "packages/npm/@caren/my-mod",
+      source: "npm:@caren/my-mod",
+      version: "0.1.0",
+    });
+    writeRegistry(modsRoot, [
+      {
+        enabled: false,
+        root: "packages/npm/@caren/my-mod",
+        source: "npm:@caren/my-mod",
+        version: "0.1.0",
+      },
+    ]);
+
+    expect(
+      setManagedModPackageEnabled({
+        enabled: true,
+        modsRoot,
+        specifier: "npm:@caren/my-mod",
+      }).package,
+    ).toMatchObject({ enabled: true, source: "npm:@caren/my-mod" });
+    expect(readRegistry(modsRoot).packages[0]?.enabled).toBe(true);
+
+    setManagedModPackageEnabled({
+      enabled: false,
+      modsRoot,
+      specifier: "npm:@caren/my-mod@0.1.0",
+    });
+    expect(readRegistry(modsRoot).packages[0]?.enabled).toBe(false);
+  });
+
+  test("remove deletes registry entry and package root", () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    mkdirSync(modsRoot, { recursive: true });
+    const packageRoot = writePackage({
+      enabled: true,
+      modsRoot,
+      root: "packages/npm/@caren/my-mod",
+      source: "npm:@caren/my-mod",
+      version: "0.1.0",
+    });
+    writeRegistry(modsRoot, [
+      {
+        enabled: true,
+        root: "packages/npm/@caren/my-mod",
+        source: "npm:@caren/my-mod",
+        version: "0.1.0",
+      },
+    ]);
+
+    const result = removeManagedModPackage({
+      modsRoot,
+      specifier: "npm:@caren/my-mod",
+    });
+
+    expect(result.removedRoot).toBe(packageRoot);
+    expect(existsSync(packageRoot)).toBe(false);
+    expect(readRegistry(modsRoot).packages).toEqual([]);
+  });
+
+  test("remove refuses roots outside the expected package path", () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    mkdirSync(modsRoot, { recursive: true });
+    const looseModPath = path.join(modsRoot, "loose.ts");
+    writeFileSync(looseModPath, "export {};\n");
+    writeRegistry(modsRoot, [
+      {
+        enabled: true,
+        root: "loose.ts",
+        source: "npm:@caren/my-mod",
+        version: "0.1.0",
+      },
+    ]);
+
+    expect(() =>
+      removeManagedModPackage({
+        modsRoot,
+        specifier: "npm:@caren/my-mod",
+      }),
+    ).toThrow("Refusing to remove npm:@caren/my-mod@0.1.0");
+    expect(existsSync(looseModPath)).toBe(true);
+    expect(readRegistry(modsRoot).packages).toHaveLength(1);
+  });
+
+  test("remove refuses broad package parent roots", () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    mkdirSync(path.join(modsRoot, "packages", "npm", "@caren"), {
+      recursive: true,
+    });
+    writeRegistry(modsRoot, [
+      {
+        enabled: true,
+        root: "packages/npm",
+        source: "npm:@caren/my-mod",
+        version: "0.1.0",
+      },
+    ]);
+
+    expect(() =>
+      removeManagedModPackage({
+        modsRoot,
+        specifier: "npm:@caren/my-mod",
+      }),
+    ).toThrow("does not match expected package root");
+    expect(existsSync(path.join(modsRoot, "packages", "npm"))).toBe(true);
+    expect(readRegistry(modsRoot).packages).toHaveLength(1);
+  });
+
+  test("source-only spec errors when multiple versions match", () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    mkdirSync(modsRoot, { recursive: true });
+    writePackage({
+      enabled: true,
+      modsRoot,
+      root: "packages/npm/@caren/my-mod-1",
+      source: "npm:@caren/my-mod",
+      version: "0.1.0",
+    });
+    writePackage({
+      enabled: true,
+      modsRoot,
+      root: "packages/npm/@caren/my-mod-2",
+      source: "npm:@caren/my-mod",
+      version: "0.2.0",
+    });
+    writeRegistry(modsRoot, [
+      {
+        enabled: true,
+        root: "packages/npm/@caren/my-mod-1",
+        source: "npm:@caren/my-mod",
+        version: "0.1.0",
+      },
+      {
+        enabled: true,
+        root: "packages/npm/@caren/my-mod-2",
+        source: "npm:@caren/my-mod",
+        version: "0.2.0",
+      },
+    ]);
+
+    expect(() =>
+      setManagedModPackageEnabled({
+        enabled: false,
+        modsRoot,
+        specifier: "npm:@caren/my-mod",
+      }),
+    ).toThrow("Multiple versions match npm:@caren/my-mod");
+
+    setManagedModPackageEnabled({
+      enabled: false,
+      modsRoot,
+      specifier: "npm:@caren/my-mod@0.2.0",
+    });
+    expect(readRegistry(modsRoot).packages.map((pkg) => pkg.enabled)).toEqual([
+      true,
+      false,
+    ]);
+  });
+
+  test("malformed registry errors without writing", () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    mkdirSync(modsRoot, { recursive: true });
+    const registryPath = path.join(modsRoot, "packages.json");
+    writeFileSync(registryPath, "{\n");
+
+    expect(() =>
+      setManagedModPackageEnabled({
+        enabled: false,
+        modsRoot,
+        specifier: "npm:@caren/my-mod",
+      }),
+    ).toThrow();
+    expect(readFileSync(registryPath, "utf8")).toBe("{\n");
+  });
+});

--- a/src/mods/package-registry.ts
+++ b/src/mods/package-registry.ts
@@ -1,7 +1,8 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import {
   isSafeLettaPackageModEntryPath,
+  type LettaPackageCapability,
   readLettaPackageManifest,
 } from "@/mods/package-manifest";
 
@@ -25,6 +26,31 @@ export interface ResolveManagedModPackagesResult {
   diagnostics: ManagedModPackageDiagnostic[];
   files: string[];
   packages: ManagedModPackageSource[];
+}
+
+export interface ManagedModPackageListItem {
+  capabilities: LettaPackageCapability[];
+  enabled: boolean;
+  entries: string[];
+  files: string[];
+  registryIndex: number;
+  root: string;
+  rootRelativePath: string;
+  source: string;
+  version: string;
+}
+
+export interface ListManagedModPackagesResult {
+  diagnostics: ManagedModPackageDiagnostic[];
+  packages: ManagedModPackageListItem[];
+  registryExists: boolean;
+  registryPath: string;
+}
+
+export interface ManagedModPackageMutationResult {
+  package: ManagedModPackageListItem;
+  registryPath: string;
+  removedRoot?: string;
 }
 
 const PACKAGE_ENTRY_KEYS = new Set([
@@ -117,6 +143,84 @@ function parseJsonFile(filePath: string):
   }
 }
 
+function getRegistryPath(modsRoot: string): string {
+  return path.join(modsRoot, MOD_PACKAGES_REGISTRY_FILENAME);
+}
+
+function readRegistryObject(modsRoot: string):
+  | {
+      diagnostics: ManagedModPackageDiagnostic[];
+      ok: true;
+      packagesValue: unknown[];
+      registry: Record<string, unknown>;
+      registryPath: string;
+    }
+  | {
+      diagnostics: ManagedModPackageDiagnostic[];
+      ok: false;
+      registryExists: boolean;
+      registryPath: string;
+    } {
+  const registryPath = getRegistryPath(modsRoot);
+  if (!existsSync(registryPath)) {
+    return { diagnostics: [], ok: false, registryExists: false, registryPath };
+  }
+
+  const registryResult = parseJsonFile(registryPath);
+  if (!registryResult.ok) {
+    return {
+      diagnostics: [registryResult.error],
+      ok: false,
+      registryExists: true,
+      registryPath,
+    };
+  }
+  if (!isRecord(registryResult.value)) {
+    return {
+      diagnostics: [
+        createDiagnostic(registryPath, "packages.json must be an object"),
+      ],
+      ok: false,
+      registryExists: true,
+      registryPath,
+    };
+  }
+
+  const diagnostics: ManagedModPackageDiagnostic[] = [];
+  for (const key of getUnknownKeys(
+    registryResult.value,
+    PACKAGE_REGISTRY_KEYS,
+  )) {
+    diagnostics.push(
+      createDiagnostic(
+        `packages.json.${key}`,
+        `unknown registry field '${key}'`,
+      ),
+    );
+  }
+
+  const packagesValue = registryResult.value.packages;
+  if (!Array.isArray(packagesValue)) {
+    diagnostics.push(
+      createDiagnostic("packages.json.packages", "packages must be an array"),
+    );
+    return {
+      diagnostics,
+      ok: false,
+      registryExists: true,
+      registryPath,
+    };
+  }
+
+  return {
+    diagnostics,
+    ok: true,
+    packagesValue,
+    registry: registryResult.value,
+    registryPath,
+  };
+}
+
 function validatePackageEntries(
   value: unknown,
   diagnosticPath: string,
@@ -187,7 +291,7 @@ function resolvePackageEntry(
   return resolveRelativePath(packageRoot, normalized);
 }
 
-function resolvePackage(
+function validatePackageMetadata(
   modsRoot: string,
   rawEntry: unknown,
   index: number,
@@ -197,10 +301,15 @@ function resolvePackage(
       ok: false;
     }
   | {
-      diagnostics: [];
+      diagnostics: ManagedModPackageDiagnostic[];
+      enabled: boolean;
+      entries: string[];
       files: string[];
       ok: true;
-      packageSource: ManagedModPackageSource | null;
+      packageRoot: string;
+      rootRelativePath: string;
+      source: string;
+      version: string;
     } {
   const diagnosticPath = `packages[${index}]`;
   if (!isRecord(rawEntry)) {
@@ -252,31 +361,25 @@ function resolvePackage(
       ),
     );
   }
+  if (typeof rawEntry.root !== "string") {
+    diagnostics.push(
+      createDiagnostic(
+        `${diagnosticPath}.root`,
+        "package root must be a string",
+      ),
+    );
+  }
 
   if (
     diagnostics.length > 0 ||
     typeof source !== "string" ||
     typeof version !== "string" ||
-    typeof enabled !== "boolean"
+    typeof enabled !== "boolean" ||
+    typeof rawEntry.root !== "string"
   ) {
     return { diagnostics, ok: false };
   }
 
-  if (enabled === false) {
-    return { diagnostics: [], files: [], ok: true, packageSource: null };
-  }
-
-  if (typeof rawEntry.root !== "string") {
-    return {
-      diagnostics: [
-        createDiagnostic(
-          `${diagnosticPath}.root`,
-          "package root must be a string",
-        ),
-      ],
-      ok: false,
-    };
-  }
   const packageRoot = resolveRelativePath(modsRoot, rawEntry.root);
   if (!packageRoot) {
     return {
@@ -298,7 +401,61 @@ function resolvePackage(
     return { diagnostics: entriesResult.diagnostics, ok: false };
   }
 
-  const packageJsonPath = path.join(packageRoot, "package.json");
+  const files: string[] = [];
+  for (const entry of entriesResult.entries) {
+    const entryPath = resolvePackageEntry(packageRoot, entry);
+    if (!entryPath) {
+      diagnostics.push(
+        createDiagnostic(
+          `${diagnosticPath}.entries`,
+          `Package entry '${entry}' resolves outside the package root`,
+        ),
+      );
+      continue;
+    }
+    files.push(entryPath);
+  }
+  if (diagnostics.length > 0) {
+    return { diagnostics, ok: false };
+  }
+
+  return {
+    diagnostics: [],
+    enabled,
+    entries: entriesResult.entries,
+    files,
+    ok: true,
+    packageRoot,
+    rootRelativePath: rawEntry.root,
+    source,
+    version,
+  };
+}
+
+function resolvePackage(
+  modsRoot: string,
+  rawEntry: unknown,
+  index: number,
+):
+  | {
+      diagnostics: ManagedModPackageDiagnostic[];
+      ok: false;
+    }
+  | {
+      diagnostics: [];
+      files: string[];
+      ok: true;
+      packageSource: ManagedModPackageSource | null;
+    } {
+  const metadata = validatePackageMetadata(modsRoot, rawEntry, index);
+  if (!metadata.ok) {
+    return { diagnostics: metadata.diagnostics, ok: false };
+  }
+  if (!metadata.enabled) {
+    return { diagnostics: [], files: [], ok: true, packageSource: null };
+  }
+
+  const packageJsonPath = path.join(metadata.packageRoot, "package.json");
   const manifestResult = readLettaPackageManifest(packageJsonPath);
   if (!manifestResult.ok) {
     return {
@@ -327,22 +484,26 @@ function resolvePackage(
     manifestResult.manifest.mods.map(normalizeModEntry),
   );
   const files: string[] = [];
-  for (const entry of entriesResult.entries) {
+  const diagnostics: ManagedModPackageDiagnostic[] = [];
+  for (const entry of metadata.entries) {
     const normalizedEntry = normalizeModEntry(entry);
     if (!manifestEntries.has(normalizedEntry)) {
       diagnostics.push(
         createDiagnostic(
-          `${diagnosticPath}.entries`,
+          `packages[${index}].entries`,
           `Package entry '${entry}' is not declared in package.json#letta.mods`,
         ),
       );
       continue;
     }
-    const entryPath = resolvePackageEntry(packageRoot, normalizedEntry);
+    const entryPath = resolvePackageEntry(
+      metadata.packageRoot,
+      normalizedEntry,
+    );
     if (!entryPath) {
       diagnostics.push(
         createDiagnostic(
-          `${diagnosticPath}.entries`,
+          `packages[${index}].entries`,
           `Package entry '${entry}' resolves outside the package root`,
         ),
       );
@@ -360,11 +521,11 @@ function resolvePackage(
     files,
     ok: true,
     packageSource: {
-      entries: entriesResult.entries,
+      entries: metadata.entries,
       files,
-      root: packageRoot,
-      source,
-      version,
+      root: metadata.packageRoot,
+      source: metadata.source,
+      version: metadata.version,
     },
   };
 }
@@ -372,49 +533,20 @@ function resolvePackage(
 export function resolveManagedModPackages(
   modsRoot: string,
 ): ResolveManagedModPackagesResult {
-  const registryPath = path.join(modsRoot, MOD_PACKAGES_REGISTRY_FILENAME);
-  if (!existsSync(registryPath)) {
-    return { diagnostics: [], files: [], packages: [] };
-  }
-
-  const registryResult = parseJsonFile(registryPath);
+  const registryResult = readRegistryObject(modsRoot);
   if (!registryResult.ok) {
-    return { diagnostics: [registryResult.error], files: [], packages: [] };
-  }
-  if (!isRecord(registryResult.value)) {
-    return {
-      diagnostics: [
-        createDiagnostic(registryPath, "packages.json must be an object"),
-      ],
-      files: [],
-      packages: [],
-    };
+    if (!registryResult.registryExists) {
+      return { diagnostics: [], files: [], packages: [] };
+    }
+    return { diagnostics: registryResult.diagnostics, files: [], packages: [] };
   }
 
-  const diagnostics: ManagedModPackageDiagnostic[] = [];
-  for (const key of getUnknownKeys(
-    registryResult.value,
-    PACKAGE_REGISTRY_KEYS,
-  )) {
-    diagnostics.push(
-      createDiagnostic(
-        `packages.json.${key}`,
-        `unknown registry field '${key}'`,
-      ),
-    );
-  }
-
-  const packagesValue = registryResult.value.packages;
-  if (!Array.isArray(packagesValue)) {
-    diagnostics.push(
-      createDiagnostic("packages.json.packages", "packages must be an array"),
-    );
-    return { diagnostics, files: [], packages: [] };
-  }
-
+  const diagnostics: ManagedModPackageDiagnostic[] = [
+    ...registryResult.diagnostics,
+  ];
   const files: string[] = [];
   const packages: ManagedModPackageSource[] = [];
-  packagesValue.forEach((entry, index) => {
+  registryResult.packagesValue.forEach((entry, index) => {
     const result = resolvePackage(modsRoot, entry, index);
     diagnostics.push(...result.diagnostics);
     if (!result.ok) return;
@@ -425,4 +557,267 @@ export function resolveManagedModPackages(
   });
 
   return { diagnostics, files, packages };
+}
+
+export function listManagedModPackages(
+  modsRoot: string,
+): ListManagedModPackagesResult {
+  const registryResult = readRegistryObject(modsRoot);
+  if (!registryResult.ok) {
+    return {
+      diagnostics: registryResult.diagnostics,
+      packages: [],
+      registryExists: registryResult.registryExists,
+      registryPath: registryResult.registryPath,
+    };
+  }
+
+  const diagnostics: ManagedModPackageDiagnostic[] = [
+    ...registryResult.diagnostics,
+  ];
+  const packages: ManagedModPackageListItem[] = [];
+  registryResult.packagesValue.forEach((entry, index) => {
+    const metadata = validatePackageMetadata(modsRoot, entry, index);
+    diagnostics.push(...metadata.diagnostics);
+    if (!metadata.ok) return;
+
+    const packageJsonPath = path.join(metadata.packageRoot, "package.json");
+    const manifestResult = readLettaPackageManifest(packageJsonPath);
+    let capabilities: LettaPackageCapability[] = [];
+    if (!manifestResult.ok) {
+      diagnostics.push(
+        ...manifestResult.errors.map((error) =>
+          createDiagnostic(
+            packageJsonPath,
+            `Invalid package manifest at ${error.path}: ${error.message}`,
+          ),
+        ),
+      );
+    } else if (manifestResult.manifest) {
+      capabilities = manifestResult.manifest.capabilities ?? [];
+    } else {
+      diagnostics.push(
+        createDiagnostic(
+          packageJsonPath,
+          "Package does not include a package.json#letta manifest",
+        ),
+      );
+    }
+
+    packages.push({
+      capabilities,
+      enabled: metadata.enabled,
+      entries: metadata.entries,
+      files: metadata.files,
+      registryIndex: index,
+      root: metadata.packageRoot,
+      rootRelativePath: metadata.rootRelativePath,
+      source: metadata.source,
+      version: metadata.version,
+    });
+  });
+
+  return {
+    diagnostics,
+    packages,
+    registryExists: true,
+    registryPath: registryResult.registryPath,
+  };
+}
+
+function parseManagedPackageSpec(specifier: string): {
+  source: string;
+  version?: string;
+} {
+  const trimmed = specifier.trim();
+  if (!trimmed) {
+    throw new Error("Missing package specifier.");
+  }
+  const slashIndex = trimmed.lastIndexOf("/");
+  const atIndex = trimmed.lastIndexOf("@");
+  if (atIndex > slashIndex) {
+    const source = trimmed.slice(0, atIndex);
+    const version = trimmed.slice(atIndex + 1);
+    if (!source || !version) {
+      throw new Error(`Invalid package specifier: ${specifier}`);
+    }
+    return { source, version };
+  }
+
+  return { source: trimmed };
+}
+
+function formatManagedPackageSpecifier(pkg: {
+  source: string;
+  version: string;
+}): string {
+  return `${pkg.source}@${pkg.version}`;
+}
+
+function expectedRootRelativePathForSource(source: string): string | null {
+  if (!source.startsWith("npm:")) return null;
+  const packageName = source.slice("npm:".length);
+  const normalizedPackageName = normalizeRelativePath(packageName);
+  if (!normalizedPackageName) return null;
+  return `${MOD_PACKAGES_DIRECTORY_NAME}/npm/${normalizedPackageName}`;
+}
+
+function assertSafePackageRemovalRoot(
+  metadata: Extract<ReturnType<typeof validatePackageMetadata>, { ok: true }>,
+): void {
+  const normalizedRoot = normalizeRelativePath(metadata.rootRelativePath);
+  const expectedRoot = expectedRootRelativePathForSource(metadata.source);
+  if (!normalizedRoot || !expectedRoot || normalizedRoot !== expectedRoot) {
+    throw new Error(
+      `Refusing to remove ${formatManagedPackageSpecifier(metadata)} because registry root '${metadata.rootRelativePath}' does not match expected package root '${expectedRoot ?? "(unknown)"}'.`,
+    );
+  }
+}
+
+function readMutablePackageRegistry(modsRoot: string): {
+  packagesValue: unknown[];
+  registry: Record<string, unknown>;
+  registryPath: string;
+} {
+  const result = readRegistryObject(modsRoot);
+  if (!result.ok) {
+    if (!result.registryExists) {
+      throw new Error("No managed mod packages are installed.");
+    }
+    throw new Error(
+      result.diagnostics[0]?.error.message ?? "Invalid packages.json",
+    );
+  }
+  if (result.diagnostics.length > 0) {
+    throw new Error(
+      result.diagnostics[0]?.error.message ?? "Invalid packages.json",
+    );
+  }
+  return {
+    packagesValue: result.packagesValue,
+    registry: result.registry,
+    registryPath: result.registryPath,
+  };
+}
+
+function getPackageMetadataForMutation(
+  modsRoot: string,
+  rawEntry: unknown,
+  index: number,
+): Extract<ReturnType<typeof validatePackageMetadata>, { ok: true }> {
+  const metadata = validatePackageMetadata(modsRoot, rawEntry, index);
+  if (!metadata.ok) {
+    throw new Error(
+      metadata.diagnostics[0]?.error.message ?? "Invalid package entry",
+    );
+  }
+  return metadata;
+}
+
+function findPackageIndex(
+  modsRoot: string,
+  packagesValue: unknown[],
+  specifier: string,
+): {
+  index: number;
+  metadata: Extract<ReturnType<typeof validatePackageMetadata>, { ok: true }>;
+} {
+  const spec = parseManagedPackageSpec(specifier);
+  const matches: Array<{
+    index: number;
+    metadata: Extract<ReturnType<typeof validatePackageMetadata>, { ok: true }>;
+  }> = [];
+
+  packagesValue.forEach((entry, index) => {
+    const metadata = getPackageMetadataForMutation(modsRoot, entry, index);
+    if (metadata.source !== spec.source) return;
+    if (spec.version && metadata.version !== spec.version) return;
+    matches.push({ index, metadata });
+  });
+
+  if (matches.length === 0) {
+    throw new Error(`Managed mod package not found: ${specifier}`);
+  }
+  const firstMatch = matches[0];
+  if (!firstMatch) {
+    throw new Error(`Managed mod package not found: ${specifier}`);
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Multiple versions match ${specifier}. Pass a versioned specifier like ${formatManagedPackageSpecifier(firstMatch.metadata)}.`,
+    );
+  }
+
+  return firstMatch;
+}
+
+function writePackageRegistry(
+  registryPath: string,
+  registry: Record<string, unknown>,
+): void {
+  writeFileSync(registryPath, `${JSON.stringify(registry, null, 2)}\n`);
+}
+
+function mutationItem(
+  metadata: Extract<ReturnType<typeof validatePackageMetadata>, { ok: true }>,
+  index: number,
+  enabled: boolean,
+): ManagedModPackageListItem {
+  return {
+    capabilities: [],
+    enabled,
+    entries: metadata.entries,
+    files: metadata.files,
+    registryIndex: index,
+    root: metadata.packageRoot,
+    rootRelativePath: metadata.rootRelativePath,
+    source: metadata.source,
+    version: metadata.version,
+  };
+}
+
+export function setManagedModPackageEnabled(params: {
+  enabled: boolean;
+  modsRoot: string;
+  specifier: string;
+}): ManagedModPackageMutationResult {
+  const registry = readMutablePackageRegistry(params.modsRoot);
+  const match = findPackageIndex(
+    params.modsRoot,
+    registry.packagesValue,
+    params.specifier,
+  );
+  const rawEntry = registry.packagesValue[match.index];
+  if (!isRecord(rawEntry)) {
+    throw new Error("Invalid package entry");
+  }
+  rawEntry.enabled = params.enabled;
+  writePackageRegistry(registry.registryPath, registry.registry);
+
+  return {
+    package: mutationItem(match.metadata, match.index, params.enabled),
+    registryPath: registry.registryPath,
+  };
+}
+
+export function removeManagedModPackage(params: {
+  modsRoot: string;
+  specifier: string;
+}): ManagedModPackageMutationResult {
+  const registry = readMutablePackageRegistry(params.modsRoot);
+  const match = findPackageIndex(
+    params.modsRoot,
+    registry.packagesValue,
+    params.specifier,
+  );
+  assertSafePackageRemovalRoot(match.metadata);
+  registry.packagesValue.splice(match.index, 1);
+  writePackageRegistry(registry.registryPath, registry.registry);
+  rmSync(match.metadata.packageRoot, { force: true, recursive: true });
+
+  return {
+    package: mutationItem(match.metadata, match.index, match.metadata.enabled),
+    registryPath: registry.registryPath,
+    removedRoot: match.metadata.packageRoot,
+  };
 }

--- a/src/mods/package-registry.ts
+++ b/src/mods/package-registry.ts
@@ -659,6 +659,15 @@ function expectedRootRelativePathForSource(source: string): string | null {
   const packageName = source.slice("npm:".length);
   const normalizedPackageName = normalizeRelativePath(packageName);
   if (!normalizedPackageName) return null;
+  const packageNameParts = normalizedPackageName.split("/");
+  const isScopedPackage =
+    packageNameParts.length === 2 &&
+    Boolean(packageNameParts[0]?.startsWith("@")) &&
+    Boolean(packageNameParts[0]?.slice(1)) &&
+    Boolean(packageNameParts[1]);
+  const isUnscopedPackage =
+    packageNameParts.length === 1 && !packageNameParts[0]?.startsWith("@");
+  if (!isScopedPackage && !isUnscopedPackage) return null;
   return `${MOD_PACKAGES_DIRECTORY_NAME}/npm/${normalizedPackageName}`;
 }
 


### PR DESCRIPTION
## Summary
- extend `letta mods list` with installed package visibility and registry diagnostics
- add local-only package `enable`, `disable`, and `remove` commands for already-installed managed mods
- guard `remove` so it only deletes the expected npm package root, not arbitrary loose mods or broad package directories

## Tests
- `bun test src/cli/subcommands/mods.test.ts`
- `bun test src/mods/package-registry.test.ts`
- `bun test src/mods/mod-engine.test.ts`
- `bun test src/cli/mods/local-mod-loader.test.ts`
- `bun run check`