### PR TITLE
feat(mods): install local packages

### DIFF
--- a/src/cli/subcommands/mods.test.ts
+++ b/src/cli/subcommands/mods.test.ts
@@ -251,11 +251,11 @@ describe("mods subcommand", () => {
   test("rejects unknown actions", async () => {
     const consoleCapture = captureConsole();
     try {
-      const exitCode = await runModsSubcommand(["install"]);
+      const exitCode = await runModsSubcommand(["publish"]);
 
       expect(exitCode).toBe(1);
       expect(consoleCapture.errors.join("\n")).toContain(
-        "Unknown mods action: install",
+        "Unknown mods action: publish",
       );
       expect(consoleCapture.logs.join("\n")).toContain("Usage:");
     } finally {

--- a/src/cli/subcommands/skills.test.ts
+++ b/src/cli/subcommands/skills.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { mkdir, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -12,7 +18,57 @@ import {
   parseClawHubSpecifier,
   parseDirectSkillFileUrlSpecifier,
   parseGitHubSpecifier,
+  runInstallSubcommand,
 } from "./skills";
+
+function captureConsole(): {
+  errors: string[];
+  logs: string[];
+  restore: () => void;
+} {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = (message?: unknown) => {
+    logs.push(String(message));
+  };
+  console.error = (message?: unknown) => {
+    errors.push(String(message));
+  };
+  return {
+    errors,
+    logs,
+    restore() {
+      console.log = originalLog;
+      console.error = originalError;
+    },
+  };
+}
+
+function writeLocalModPackage(params: {
+  capabilities?: string[];
+  packageRoot: string;
+}): void {
+  mkdirSync(join(params.packageRoot, "mods"), { recursive: true });
+  writeFileSync(join(params.packageRoot, "mods", "index.ts"), "export {};\n");
+  writeFileSync(
+    join(params.packageRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "@caren/my-mod",
+        version: "0.1.0",
+        letta: {
+          manifestVersion: 1,
+          mods: ["mods/index.ts"],
+          ...(params.capabilities ? { capabilities: params.capabilities } : {}),
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
 
 describe("skills subcommand", () => {
   test("parses GitHub tree URLs", () => {
@@ -169,6 +225,95 @@ describe("skills subcommand", () => {
     ).rejects.toThrow(
       `Direct skill file exceeds ${MAX_DIRECT_SKILL_FILE_BYTES} byte limit.`,
     );
+  });
+
+  test("top-level install installs local mod packages", async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "letta-install-test-"));
+    const consoleCapture = captureConsole();
+    try {
+      const packageRoot = join(tempRoot, "package");
+      const modsRoot = join(tempRoot, "mods");
+      writeLocalModPackage({ capabilities: ["commands"], packageRoot });
+
+      const exitCode = await runInstallSubcommand([packageRoot], {
+        globalModsDirectory: modsRoot,
+      });
+
+      expect(exitCode).toBe(0);
+      expect(consoleCapture.logs.join("\n")).toContain(
+        "Warning: mods are trusted local code and can execute on startup.",
+      );
+      expect(consoleCapture.logs.join("\n")).toContain(
+        "Installed npm:@caren/my-mod@0.1.0",
+      );
+      expect(consoleCapture.logs.join("\n")).toContain("Run /reload");
+      expect(
+        existsSync(
+          join(
+            modsRoot,
+            "packages",
+            "npm",
+            "@caren",
+            "my-mod",
+            "mods",
+            "index.ts",
+          ),
+        ),
+      ).toBe(true);
+      expect(
+        JSON.parse(readFileSync(join(modsRoot, "packages.json"), "utf8")),
+      ).toEqual({
+        packages: [
+          {
+            source: "npm:@caren/my-mod",
+            version: "0.1.0",
+            enabled: true,
+            root: "packages/npm/@caren/my-mod",
+            entries: ["mods/index.ts"],
+          },
+        ],
+      });
+    } finally {
+      consoleCapture.restore();
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("top-level install rejects agent-scoped local mod package install", async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "letta-install-test-"));
+    const consoleCapture = captureConsole();
+    try {
+      const packageRoot = join(tempRoot, "package");
+      writeLocalModPackage({ packageRoot });
+
+      const exitCode = await runInstallSubcommand([
+        "--agent",
+        "agent-123",
+        packageRoot,
+      ]);
+
+      expect(exitCode).toBe(1);
+      expect(consoleCapture.errors.join("\n")).toContain(
+        "Agent-scoped mod package install is not supported yet.",
+      );
+    } finally {
+      consoleCapture.restore();
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("top-level install reserves npm package specs for mod packages", async () => {
+    const consoleCapture = captureConsole();
+    try {
+      const exitCode = await runInstallSubcommand(["npm:@caren/my-mod"]);
+
+      expect(exitCode).toBe(1);
+      expect(consoleCapture.errors.join("\n")).toContain(
+        "Network mod package install is not supported yet. Pass a local package path.",
+      );
+    } finally {
+      consoleCapture.restore();
+    }
   });
 
   test("lists installed skill directories with frontmatter metadata", async () => {

--- a/src/cli/subcommands/skills.ts
+++ b/src/cli/subcommands/skills.ts
@@ -13,6 +13,11 @@ import { basename, dirname, join, normalize, resolve, sep } from "node:path";
 import { parseArgs, TextDecoder, TextEncoder } from "node:util";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import { isLocalAgentId } from "@/agent/agent-id";
+import {
+  installLocalManagedModPackage,
+  isLocalLettaModPackageDirectory,
+} from "@/mods/package-installer";
+import { resolveDefaultGlobalModsDirectory } from "@/mods/paths";
 import { parseFrontmatter } from "@/utils/frontmatter";
 
 const HERMES_REPO_URL = "https://github.com/NousResearch/hermes-agent.git";
@@ -67,6 +72,10 @@ type FetchSkillFile = (
   ...args: Parameters<typeof fetch>
 ) => ReturnType<typeof fetch>;
 
+interface RunInstallOptions {
+  globalModsDirectory?: string;
+}
+
 const CLAWHUB_API_BASE_URL = "https://clawhub.ai/api/v1";
 
 let activeAgentPromptStatus: { stop: () => void } | null = null;
@@ -75,11 +84,12 @@ function printUsage(): void {
   console.log(
     `
 Usage:
-  letta install <skill> [--agent <id> | -n <agent name>] [--force]
+  letta install <thing> [--agent <id> | -n <agent name>] [--force]
   letta skills list [--agent <id> | -n <agent name>]
   letta skills delete <skill_name> --agent <id>
 
 Sources:
+  ./path/to/package     Local mod package with package.json#letta
   official/<path>         Hermes official optional skill, e.g. official/finance/stocks
   clawhub/<slug>          ClawHub registry skill, e.g. clawhub/nano-banana-pro
   clawhub:<slug>          ClawHub registry skill, optionally <slug>@<version>
@@ -922,7 +932,10 @@ function stopAgentPromptStatus(): void {
   activeAgentPromptStatus = null;
 }
 
-async function runInstall(argv: string[]): Promise<number> {
+async function runInstall(
+  argv: string[],
+  options: RunInstallOptions = {},
+): Promise<number> {
   let parsed: ReturnType<typeof parseSkillsArgs>;
   try {
     parsed = parseSkillsArgs(argv);
@@ -946,6 +959,41 @@ async function runInstall(argv: string[]): Promise<number> {
     return 1;
   }
 
+  if (specifier.startsWith("npm:")) {
+    console.error(
+      "Network mod package install is not supported yet. Pass a local package path.",
+    );
+    return 1;
+  }
+
+  const maybeLocalPath = resolve(specifier);
+  if (isLocalLettaModPackageDirectory(maybeLocalPath)) {
+    if (
+      parsed.values.agent ||
+      parsed.values["agent-id"] ||
+      parsed.values.name
+    ) {
+      console.error("Agent-scoped mod package install is not supported yet.");
+      return 1;
+    }
+    try {
+      const result = installLocalManagedModPackage({
+        modsRoot:
+          options.globalModsDirectory ?? resolveDefaultGlobalModsDirectory(),
+        packageDirectory: maybeLocalPath,
+      });
+      console.log(
+        "Warning: mods are trusted local code and can execute on startup.",
+      );
+      console.log(`Installed ${result.source}@${result.version}`);
+      console.log("Run /reload in active sessions for changes to take effect.");
+      return 0;
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      return 1;
+    }
+  }
+
   try {
     const agentId = await initializeAndResolveAgent(
       parsed.values,
@@ -966,8 +1014,11 @@ async function runInstall(argv: string[]): Promise<number> {
   }
 }
 
-export async function runInstallSubcommand(argv: string[]): Promise<number> {
-  return runInstall(argv);
+export async function runInstallSubcommand(
+  argv: string[],
+  options: RunInstallOptions = {},
+): Promise<number> {
+  return runInstall(argv, options);
 }
 
 async function runList(argv: string[]): Promise<number> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,7 +186,7 @@ USAGE
   letta connect ...     Connect providers from terminal
   letta backend ...     Show or set the default backend
   letta setup           Re-run first-run setup
-  letta install ...     Install a skill into an agent memfs repository
+  letta install ...     Install a skill or local mod package
   letta skills ...      List or delete installed agent skills
 
 OPTIONS
@@ -212,7 +212,7 @@ SUBCOMMANDS
   letta mods remove <package-spec>
   letta app-server [--listen ws://127.0.0.1:4500]
   letta connect <provider> [options]
-  letta install <skill> [--agent <id> | -n <name>]
+  letta install <thing> [--agent <id> | -n <name>]
   letta skills list [--agent <id> | -n <name>]
   letta skills delete <skill_name> --agent <id>
   letta backend [api|local]

--- a/src/mods/package-installer.test.ts
+++ b/src/mods/package-installer.test.ts
@@ -116,6 +116,36 @@ describe("local managed mod package installer", () => {
     ]);
   });
 
+  test("first install removes copied package root when registry write fails", () => {
+    if (process.platform === "win32") return;
+    const root = createTempDir();
+    const packageRoot = path.join(root, "source");
+    const modsRoot = path.join(root, "mods");
+    mkdirSync(modsRoot, { recursive: true });
+    writeFileSync(
+      path.join(modsRoot, "packages.json"),
+      '{\n  "packages": []\n}\n',
+    );
+    writeLocalPackage({ packageRoot });
+    const registryPath = path.join(modsRoot, "packages.json");
+    chmodSync(registryPath, 0o444);
+
+    try {
+      expect(() =>
+        installLocalManagedModPackage({
+          modsRoot,
+          packageDirectory: packageRoot,
+        }),
+      ).toThrow();
+    } finally {
+      chmodSync(registryPath, 0o644);
+    }
+    expect(
+      existsSync(path.join(modsRoot, "packages", "npm", "@caren", "my-mod")),
+    ).toBe(false);
+    expect(readFileSync(registryPath, "utf8")).toBe('{\n  "packages": []\n}\n');
+  });
+
   test("reinstall replaces the package root and updates the same registry entry", () => {
     const root = createTempDir();
     const packageRoot = path.join(root, "source");

--- a/src/mods/package-installer.test.ts
+++ b/src/mods/package-installer.test.ts
@@ -1,0 +1,316 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { installLocalManagedModPackage } from "@/mods/package-installer";
+
+const tempRoots: string[] = [];
+
+function createTempDir(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "letta-package-installer-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+function writeLocalPackage(params: {
+  capabilities?: string[];
+  entries?: string[];
+  name?: string;
+  packageRoot: string;
+  version?: string;
+  writeEntries?: boolean;
+}): void {
+  const entries = params.entries ?? ["mods/index.ts"];
+  mkdirSync(params.packageRoot, { recursive: true });
+  if (params.writeEntries !== false) {
+    for (const entry of entries) {
+      const entryPath = path.join(params.packageRoot, ...entry.split("/"));
+      mkdirSync(path.dirname(entryPath), { recursive: true });
+      writeFileSync(
+        entryPath,
+        `export const value = ${JSON.stringify(entry)};\n`,
+      );
+    }
+  }
+  writeFileSync(
+    path.join(params.packageRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name: params.name ?? "@caren/my-mod",
+        version: params.version ?? "0.1.0",
+        letta: {
+          manifestVersion: 1,
+          mods: entries,
+          ...(params.capabilities ? { capabilities: params.capabilities } : {}),
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+function readRegistry(modsRoot: string): {
+  packages: Array<Record<string, unknown>>;
+} {
+  return JSON.parse(readFileSync(path.join(modsRoot, "packages.json"), "utf8"));
+}
+
+afterEach(() => {
+  for (const dir of tempRoots.splice(0)) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe("local managed mod package installer", () => {
+  test("installs a local package into the managed package directory", () => {
+    const root = createTempDir();
+    const packageRoot = path.join(root, "source");
+    const modsRoot = path.join(root, "mods");
+    writeLocalPackage({
+      capabilities: ["commands"],
+      packageRoot,
+    });
+    mkdirSync(path.join(packageRoot, ".git"), { recursive: true });
+    writeFileSync(path.join(packageRoot, ".git", "config"), "ignored\n");
+    mkdirSync(path.join(packageRoot, "node_modules", "dep"), {
+      recursive: true,
+    });
+    writeFileSync(
+      path.join(packageRoot, "node_modules", "dep", "index.js"),
+      "ignored\n",
+    );
+
+    const result = installLocalManagedModPackage({
+      modsRoot,
+      packageDirectory: packageRoot,
+    });
+
+    expect(result).toMatchObject({
+      capabilities: ["commands"],
+      entries: ["mods/index.ts"],
+      rootRelativePath: "packages/npm/@caren/my-mod",
+      source: "npm:@caren/my-mod",
+      version: "0.1.0",
+    });
+    expect(existsSync(path.join(result.root, "mods", "index.ts"))).toBe(true);
+    expect(existsSync(path.join(result.root, ".git"))).toBe(false);
+    expect(existsSync(path.join(result.root, "node_modules"))).toBe(false);
+    expect(readRegistry(modsRoot).packages).toEqual([
+      {
+        source: "npm:@caren/my-mod",
+        version: "0.1.0",
+        enabled: true,
+        root: "packages/npm/@caren/my-mod",
+        entries: ["mods/index.ts"],
+      },
+    ]);
+  });
+
+  test("reinstall replaces the package root and updates the same registry entry", () => {
+    const root = createTempDir();
+    const packageRoot = path.join(root, "source");
+    const modsRoot = path.join(root, "mods");
+    writeLocalPackage({ packageRoot });
+    const first = installLocalManagedModPackage({
+      modsRoot,
+      packageDirectory: packageRoot,
+    });
+    writeFileSync(path.join(first.root, "stale.ts"), "stale\n");
+    rmSync(path.join(packageRoot, "mods", "index.ts"));
+
+    writeLocalPackage({
+      entries: ["mods/next.ts"],
+      packageRoot,
+      version: "0.2.0",
+    });
+    const second = installLocalManagedModPackage({
+      modsRoot,
+      packageDirectory: packageRoot,
+    });
+
+    expect(second.root).toBe(first.root);
+    expect(existsSync(path.join(second.root, "mods", "next.ts"))).toBe(true);
+    expect(existsSync(path.join(second.root, "mods", "index.ts"))).toBe(false);
+    expect(existsSync(path.join(second.root, "stale.ts"))).toBe(false);
+    expect(readRegistry(modsRoot).packages).toEqual([
+      {
+        source: "npm:@caren/my-mod",
+        version: "0.2.0",
+        enabled: true,
+        root: "packages/npm/@caren/my-mod",
+        entries: ["mods/next.ts"],
+      },
+    ]);
+  });
+
+  test("reinstall restores existing package root when registry write fails", () => {
+    if (process.platform === "win32") return;
+    const root = createTempDir();
+    const packageRoot = path.join(root, "source");
+    const modsRoot = path.join(root, "mods");
+    writeLocalPackage({ packageRoot });
+    const first = installLocalManagedModPackage({
+      modsRoot,
+      packageDirectory: packageRoot,
+    });
+    rmSync(path.join(packageRoot, "mods", "index.ts"));
+    writeLocalPackage({
+      entries: ["mods/next.ts"],
+      packageRoot,
+      version: "0.2.0",
+    });
+    const registryPath = path.join(modsRoot, "packages.json");
+    chmodSync(registryPath, 0o444);
+
+    try {
+      expect(() =>
+        installLocalManagedModPackage({
+          modsRoot,
+          packageDirectory: packageRoot,
+        }),
+      ).toThrow();
+    } finally {
+      chmodSync(registryPath, 0o644);
+    }
+    expect(existsSync(path.join(first.root, "mods", "index.ts"))).toBe(true);
+    expect(existsSync(path.join(first.root, "mods", "next.ts"))).toBe(false);
+    expect(readRegistry(modsRoot).packages).toEqual([
+      {
+        source: "npm:@caren/my-mod",
+        version: "0.1.0",
+        enabled: true,
+        root: "packages/npm/@caren/my-mod",
+        entries: ["mods/index.ts"],
+      },
+    ]);
+  });
+
+  test("missing letta manifest fails before writing", () => {
+    const root = createTempDir();
+    const packageRoot = path.join(root, "source");
+    const modsRoot = path.join(root, "mods");
+    mkdirSync(packageRoot, { recursive: true });
+    writeFileSync(
+      path.join(packageRoot, "package.json"),
+      `${JSON.stringify({ name: "@caren/my-mod", version: "0.1.0" })}\n`,
+    );
+
+    expect(() =>
+      installLocalManagedModPackage({
+        modsRoot,
+        packageDirectory: packageRoot,
+      }),
+    ).toThrow("Package does not include a package.json#letta manifest");
+    expect(existsSync(path.join(modsRoot, "packages"))).toBe(false);
+    expect(existsSync(path.join(modsRoot, "packages.json"))).toBe(false);
+  });
+
+  test("missing declared mod file fails before writing", () => {
+    const root = createTempDir();
+    const packageRoot = path.join(root, "source");
+    const modsRoot = path.join(root, "mods");
+    writeLocalPackage({
+      entries: ["mods/missing.ts"],
+      packageRoot,
+      writeEntries: false,
+    });
+
+    expect(() =>
+      installLocalManagedModPackage({
+        modsRoot,
+        packageDirectory: packageRoot,
+      }),
+    ).toThrow("Package mod entry does not exist: mods/missing.ts");
+    expect(existsSync(path.join(modsRoot, "packages"))).toBe(false);
+    expect(existsSync(path.join(modsRoot, "packages.json"))).toBe(false);
+  });
+
+  test("malformed registry fails before copying", () => {
+    const root = createTempDir();
+    const packageRoot = path.join(root, "source");
+    const modsRoot = path.join(root, "mods");
+    mkdirSync(modsRoot, { recursive: true });
+    writeFileSync(path.join(modsRoot, "packages.json"), "{\n");
+    writeLocalPackage({ packageRoot });
+
+    expect(() =>
+      installLocalManagedModPackage({
+        modsRoot,
+        packageDirectory: packageRoot,
+      }),
+    ).toThrow();
+    expect(readFileSync(path.join(modsRoot, "packages.json"), "utf8")).toBe(
+      "{\n",
+    );
+    expect(
+      existsSync(path.join(modsRoot, "packages", "npm", "@caren", "my-mod")),
+    ).toBe(false);
+  });
+
+  test("source inside managed packages directory is rejected", () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    const packageRoot = path.join(
+      modsRoot,
+      "packages",
+      "npm",
+      "@caren",
+      "my-mod",
+    );
+    writeLocalPackage({ packageRoot });
+
+    expect(() =>
+      installLocalManagedModPackage({
+        modsRoot,
+        packageDirectory: packageRoot,
+      }),
+    ).toThrow(
+      "Cannot install a package from inside the managed packages directory",
+    );
+  });
+
+  test("destination inside source package directory is rejected", () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    writeLocalPackage({ packageRoot: modsRoot });
+
+    expect(() =>
+      installLocalManagedModPackage({
+        modsRoot,
+        packageDirectory: modsRoot,
+      }),
+    ).toThrow("Cannot install a package into one of its own subdirectories");
+  });
+
+  test("symlinks in source packages are rejected", () => {
+    if (process.platform === "win32") return;
+    const root = createTempDir();
+    const packageRoot = path.join(root, "source");
+    const modsRoot = path.join(root, "mods");
+    writeLocalPackage({ packageRoot });
+    symlinkSync(
+      path.join(packageRoot, "mods", "index.ts"),
+      path.join(packageRoot, "linked.ts"),
+    );
+
+    expect(() =>
+      installLocalManagedModPackage({
+        modsRoot,
+        packageDirectory: packageRoot,
+      }),
+    ).toThrow("Package contains unsupported symlink");
+    expect(
+      existsSync(path.join(modsRoot, "packages", "npm", "@caren", "my-mod")),
+    ).toBe(false);
+  });
+});

--- a/src/mods/package-installer.ts
+++ b/src/mods/package-installer.ts
@@ -1,0 +1,339 @@
+import {
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import {
+  type LettaPackageCapability,
+  readLettaPackageManifest,
+} from "@/mods/package-manifest";
+import {
+  getManagedModPackageRootRelativePathForSource,
+  MOD_PACKAGES_DIRECTORY_NAME,
+  upsertManagedModPackage,
+  validateManagedModPackageRegistryForMutation,
+} from "@/mods/package-registry";
+
+export interface InstallLocalManagedModPackageResult {
+  capabilities: LettaPackageCapability[];
+  entries: string[];
+  packageDirectory: string;
+  registryPath: string;
+  root: string;
+  rootRelativePath: string;
+  source: string;
+  version: string;
+}
+
+const SKIPPED_PACKAGE_COPY_NAMES = new Set([".git", "node_modules"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isPathInsideOrEqual(childPath: string, parentPath: string): boolean {
+  const child = path.resolve(childPath);
+  const parent = path.resolve(parentPath);
+  const relative = path.relative(parent, child);
+  return (
+    relative === "" ||
+    (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}
+
+function readPackageJson(packageJsonPath: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+  } catch (error) {
+    throw new Error(
+      `Could not read package.json: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (!isRecord(parsed)) {
+    throw new Error("package.json must be an object");
+  }
+  return parsed;
+}
+
+export function isLocalLettaModPackageDirectory(
+  packageDirectory: string,
+): boolean {
+  const resolvedPackageDirectory = path.resolve(packageDirectory);
+  try {
+    const packageStats = lstatSync(resolvedPackageDirectory);
+    if (packageStats.isSymbolicLink() || !packageStats.isDirectory()) {
+      return false;
+    }
+    const packageJson = readPackageJson(
+      path.join(resolvedPackageDirectory, "package.json"),
+    );
+    return Object.hasOwn(packageJson, "letta");
+  } catch {
+    return false;
+  }
+}
+
+function normalizeModEntry(entry: string): string {
+  return path.posix.normalize(entry);
+}
+
+function resolvePackageRelativePath(
+  packageRoot: string,
+  relativePath: string,
+): string {
+  const normalized = normalizeModEntry(relativePath);
+  const resolvedRoot = path.resolve(packageRoot);
+  const resolved = path.resolve(resolvedRoot, ...normalized.split("/"));
+  if (!isPathInsideOrEqual(resolved, resolvedRoot)) {
+    throw new Error(
+      `Package path '${relativePath}' resolves outside the package root`,
+    );
+  }
+  return resolved;
+}
+
+function validateManifestEntriesExist(
+  packageRoot: string,
+  entries: string[],
+): void {
+  for (const entry of entries) {
+    const entryPath = resolvePackageRelativePath(packageRoot, entry);
+    let stats: ReturnType<typeof lstatSync>;
+    try {
+      stats = lstatSync(entryPath);
+    } catch {
+      throw new Error(`Package mod entry does not exist: ${entry}`);
+    }
+    if (stats.isSymbolicLink()) {
+      throw new Error(`Package mod entry must not be a symlink: ${entry}`);
+    }
+    if (!stats.isFile()) {
+      throw new Error(`Package mod entry must be a file: ${entry}`);
+    }
+  }
+}
+
+function validatePackageSource(packageDirectory: string): {
+  capabilities: LettaPackageCapability[];
+  entries: string[];
+  packageDirectory: string;
+  rootRelativePath: string;
+  source: string;
+  version: string;
+} {
+  const resolvedPackageDirectory = path.resolve(packageDirectory);
+  let packageStats: ReturnType<typeof lstatSync>;
+  try {
+    packageStats = lstatSync(resolvedPackageDirectory);
+  } catch {
+    throw new Error(`Package directory does not exist: ${packageDirectory}`);
+  }
+  if (packageStats.isSymbolicLink()) {
+    throw new Error(
+      `Package directory must not be a symlink: ${packageDirectory}`,
+    );
+  }
+  if (!packageStats.isDirectory()) {
+    throw new Error(`Package path must be a directory: ${packageDirectory}`);
+  }
+
+  const packageJsonPath = path.join(resolvedPackageDirectory, "package.json");
+  const packageJson = readPackageJson(packageJsonPath);
+  const name = packageJson.name;
+  if (typeof name !== "string" || !name.trim()) {
+    throw new Error("package.json.name must be a valid npm package name");
+  }
+  const source = `npm:${name.trim()}`;
+  const rootRelativePath =
+    getManagedModPackageRootRelativePathForSource(source);
+  if (!rootRelativePath) {
+    throw new Error("package.json.name must be a valid npm package name");
+  }
+
+  const version = packageJson.version;
+  if (typeof version !== "string" || !version.trim()) {
+    throw new Error("package.json.version must be a string");
+  }
+
+  const manifestResult = readLettaPackageManifest(packageJsonPath);
+  if (!manifestResult.ok) {
+    throw new Error(
+      manifestResult.errors
+        .map((error) => `${error.path}: ${error.message}`)
+        .join("\n"),
+    );
+  }
+  if (!manifestResult.manifest) {
+    throw new Error("Package does not include a package.json#letta manifest");
+  }
+  validateManifestEntriesExist(
+    resolvedPackageDirectory,
+    manifestResult.manifest.mods,
+  );
+
+  return {
+    capabilities: manifestResult.manifest.capabilities ?? [],
+    entries: manifestResult.manifest.mods,
+    packageDirectory: resolvedPackageDirectory,
+    rootRelativePath,
+    source,
+    version: version.trim(),
+  };
+}
+
+function copyPackageDirectory(sourceRoot: string, targetRoot: string): void {
+  mkdirSync(targetRoot, { recursive: true });
+  for (const entry of readdirSync(sourceRoot, { withFileTypes: true })) {
+    if (SKIPPED_PACKAGE_COPY_NAMES.has(entry.name)) continue;
+    const sourcePath = path.join(sourceRoot, entry.name);
+    const targetPath = path.join(targetRoot, entry.name);
+    const stats = lstatSync(sourcePath);
+    if (stats.isSymbolicLink()) {
+      throw new Error(`Package contains unsupported symlink: ${sourcePath}`);
+    }
+    if (stats.isDirectory()) {
+      copyPackageDirectory(sourcePath, targetPath);
+      continue;
+    }
+    if (stats.isFile()) {
+      mkdirSync(path.dirname(targetPath), { recursive: true });
+      copyFileSync(sourcePath, targetPath);
+      continue;
+    }
+    throw new Error(
+      `Package contains unsupported filesystem entry: ${sourcePath}`,
+    );
+  }
+}
+
+function restoreRegistry(
+  registryPath: string,
+  previousContents: string | null,
+): void {
+  if (previousContents === null) {
+    rmSync(registryPath, { force: true });
+    return;
+  }
+  mkdirSync(path.dirname(registryPath), { recursive: true });
+  writeFileSync(registryPath, previousContents);
+}
+
+function removeIfExists(targetPath: string | null): void {
+  if (!targetPath) return;
+  rmSync(targetPath, { force: true, recursive: true });
+}
+
+function restoreDestination(params: {
+  backupRoot: string | null;
+  destinationRoot: string;
+}): void {
+  rmSync(params.destinationRoot, { force: true, recursive: true });
+  if (params.backupRoot && existsSync(params.backupRoot)) {
+    renameSync(params.backupRoot, params.destinationRoot);
+  }
+}
+
+function restoreDestinationIfNeeded(params: {
+  backupRoot: string | null;
+  destinationRoot: string;
+}): void {
+  if (!params.backupRoot || !existsSync(params.backupRoot)) return;
+  restoreDestination(params);
+}
+
+function makeSiblingTempDirectory(
+  destinationRoot: string,
+  label: "backup" | "tmp",
+): string {
+  const parent = path.dirname(destinationRoot);
+  const baseName = path
+    .basename(destinationRoot)
+    .replace(/[^a-zA-Z0-9._-]/g, "-");
+  mkdirSync(parent, { recursive: true });
+  return mkdtempSync(path.join(parent, `.${baseName}.${label}-`));
+}
+
+export function installLocalManagedModPackage(params: {
+  modsRoot: string;
+  packageDirectory: string;
+}): InstallLocalManagedModPackageResult {
+  const packageInfo = validatePackageSource(params.packageDirectory);
+  const packagesRoot = path.resolve(
+    params.modsRoot,
+    MOD_PACKAGES_DIRECTORY_NAME,
+  );
+  if (isPathInsideOrEqual(packageInfo.packageDirectory, packagesRoot)) {
+    throw new Error(
+      "Cannot install a package from inside the managed packages directory",
+    );
+  }
+  const destinationRoot = path.resolve(
+    params.modsRoot,
+    ...packageInfo.rootRelativePath.split("/"),
+  );
+  if (isPathInsideOrEqual(destinationRoot, packageInfo.packageDirectory)) {
+    throw new Error(
+      "Cannot install a package into one of its own subdirectories",
+    );
+  }
+
+  const registrySnapshot = validateManagedModPackageRegistryForMutation(
+    params.modsRoot,
+  );
+  let stagingRoot: string | null = makeSiblingTempDirectory(
+    destinationRoot,
+    "tmp",
+  );
+  let backupRoot: string | null = null;
+
+  try {
+    copyPackageDirectory(packageInfo.packageDirectory, stagingRoot);
+    if (existsSync(destinationRoot)) {
+      backupRoot = makeSiblingTempDirectory(destinationRoot, "backup");
+      rmSync(backupRoot, { force: true, recursive: true });
+      renameSync(destinationRoot, backupRoot);
+    }
+    renameSync(stagingRoot, destinationRoot);
+    stagingRoot = null;
+
+    try {
+      const upsertResult = upsertManagedModPackage({
+        entries: packageInfo.entries,
+        modsRoot: params.modsRoot,
+        source: packageInfo.source,
+        version: packageInfo.version,
+      });
+      removeIfExists(backupRoot);
+      backupRoot = null;
+      return {
+        capabilities: packageInfo.capabilities,
+        entries: packageInfo.entries,
+        packageDirectory: packageInfo.packageDirectory,
+        registryPath: upsertResult.registryPath,
+        root: destinationRoot,
+        rootRelativePath: packageInfo.rootRelativePath,
+        source: packageInfo.source,
+        version: packageInfo.version,
+      };
+    } catch (error) {
+      restoreDestinationIfNeeded({ backupRoot, destinationRoot });
+      backupRoot = null;
+      restoreRegistry(registrySnapshot.registryPath, registrySnapshot.contents);
+      throw error;
+    }
+  } catch (error) {
+    removeIfExists(stagingRoot);
+    restoreDestinationIfNeeded({ backupRoot, destinationRoot });
+    backupRoot = null;
+    throw error;
+  }
+}

--- a/src/mods/package-installer.ts
+++ b/src/mods/package-installer.ts
@@ -246,7 +246,10 @@ function restoreDestinationIfNeeded(params: {
   backupRoot: string | null;
   destinationRoot: string;
 }): void {
-  if (!params.backupRoot || !existsSync(params.backupRoot)) return;
+  if (!params.backupRoot || !existsSync(params.backupRoot)) {
+    rmSync(params.destinationRoot, { force: true, recursive: true });
+    return;
+  }
   restoreDestination(params);
 }
 
@@ -294,6 +297,7 @@ export function installLocalManagedModPackage(params: {
     "tmp",
   );
   let backupRoot: string | null = null;
+  let destinationNeedsRollback = false;
 
   try {
     copyPackageDirectory(packageInfo.packageDirectory, stagingRoot);
@@ -301,8 +305,10 @@ export function installLocalManagedModPackage(params: {
       backupRoot = makeSiblingTempDirectory(destinationRoot, "backup");
       rmSync(backupRoot, { force: true, recursive: true });
       renameSync(destinationRoot, backupRoot);
+      destinationNeedsRollback = true;
     }
     renameSync(stagingRoot, destinationRoot);
+    destinationNeedsRollback = true;
     stagingRoot = null;
 
     try {
@@ -314,6 +320,7 @@ export function installLocalManagedModPackage(params: {
       });
       removeIfExists(backupRoot);
       backupRoot = null;
+      destinationNeedsRollback = false;
       return {
         capabilities: packageInfo.capabilities,
         entries: packageInfo.entries,
@@ -325,15 +332,20 @@ export function installLocalManagedModPackage(params: {
         version: packageInfo.version,
       };
     } catch (error) {
-      restoreDestinationIfNeeded({ backupRoot, destinationRoot });
-      backupRoot = null;
+      if (destinationNeedsRollback) {
+        restoreDestinationIfNeeded({ backupRoot, destinationRoot });
+        backupRoot = null;
+        destinationNeedsRollback = false;
+      }
       restoreRegistry(registrySnapshot.registryPath, registrySnapshot.contents);
       throw error;
     }
   } catch (error) {
     removeIfExists(stagingRoot);
-    restoreDestinationIfNeeded({ backupRoot, destinationRoot });
-    backupRoot = null;
+    if (destinationNeedsRollback) {
+      restoreDestinationIfNeeded({ backupRoot, destinationRoot });
+      backupRoot = null;
+    }
     throw error;
   }
 }

--- a/src/mods/package-registry.test.ts
+++ b/src/mods/package-registry.test.ts
@@ -10,9 +10,11 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
+  getManagedModPackageRootRelativePathForSource,
   listManagedModPackages,
   removeManagedModPackage,
   setManagedModPackageEnabled,
+  upsertManagedModPackage,
 } from "@/mods/package-registry";
 
 const tempRoots: string[] = [];
@@ -76,7 +78,7 @@ function writeRegistry(
 }
 
 function readRegistry(modsRoot: string): {
-  packages: Array<{ enabled: boolean }>;
+  packages: Array<Record<string, unknown>>;
 } {
   return JSON.parse(readFileSync(path.join(modsRoot, "packages.json"), "utf8"));
 }
@@ -88,6 +90,102 @@ afterEach(() => {
 });
 
 describe("managed mod package registry", () => {
+  test("derives npm package roots from valid package sources", () => {
+    expect(getManagedModPackageRootRelativePathForSource("npm:my-mod")).toBe(
+      "packages/npm/my-mod",
+    );
+    expect(
+      getManagedModPackageRootRelativePathForSource("npm:@caren/my-mod"),
+    ).toBe("packages/npm/@caren/my-mod");
+
+    for (const source of [
+      "npm:@caren",
+      "npm:my/mod",
+      "npm:../my-mod",
+      "npm:.",
+      "npm:",
+      "path:my-mod",
+    ]) {
+      expect(getManagedModPackageRootRelativePathForSource(source)).toBeNull();
+    }
+  });
+
+  test("upsert derives root and creates registry", () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+
+    const result = upsertManagedModPackage({
+      entries: ["mods/index.ts"],
+      modsRoot,
+      source: "npm:@caren/my-mod",
+      version: "0.1.0",
+    });
+
+    expect(result).toMatchObject({ replaced: false, removedDuplicates: 0 });
+    expect(readRegistry(modsRoot).packages).toEqual([
+      {
+        source: "npm:@caren/my-mod",
+        version: "0.1.0",
+        enabled: true,
+        root: "packages/npm/@caren/my-mod",
+        entries: ["mods/index.ts"],
+      },
+    ]);
+  });
+
+  test("upsert replaces same source in place and removes duplicates", () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    mkdirSync(modsRoot, { recursive: true });
+    writeRegistry(modsRoot, [
+      {
+        enabled: true,
+        root: "packages/npm/first",
+        source: "npm:first",
+        version: "0.1.0",
+      },
+      {
+        enabled: false,
+        root: "packages/npm/@caren/my-mod",
+        source: "npm:@caren/my-mod",
+        version: "0.1.0",
+      },
+      {
+        enabled: true,
+        root: "packages/npm/last",
+        source: "npm:last",
+        version: "0.1.0",
+      },
+      {
+        enabled: true,
+        root: "packages/npm/@caren/my-mod",
+        source: "npm:@caren/my-mod",
+        version: "0.0.1",
+      },
+    ]);
+
+    const result = upsertManagedModPackage({
+      enabled: true,
+      entries: ["mods/next.ts"],
+      modsRoot,
+      source: "npm:@caren/my-mod",
+      version: "0.2.0",
+    });
+
+    expect(result).toMatchObject({ replaced: true, removedDuplicates: 1 });
+    expect(readRegistry(modsRoot).packages).toEqual([
+      expect.objectContaining({ source: "npm:first" }),
+      {
+        source: "npm:@caren/my-mod",
+        version: "0.2.0",
+        enabled: true,
+        root: "packages/npm/@caren/my-mod",
+        entries: ["mods/next.ts"],
+      },
+      expect.objectContaining({ source: "npm:last" }),
+    ]);
+  });
+
   test("lists enabled and disabled packages with manifest capabilities", () => {
     const root = createTempDir();
     const modsRoot = path.join(root, "mods");

--- a/src/mods/package-registry.ts
+++ b/src/mods/package-registry.ts
@@ -1,4 +1,10 @@
-import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import {
   isSafeLettaPackageModEntryPath,
@@ -51,6 +57,17 @@ export interface ManagedModPackageMutationResult {
   package: ManagedModPackageListItem;
   registryPath: string;
   removedRoot?: string;
+}
+
+export interface ManagedModPackageRegistrySnapshot {
+  contents: string | null;
+  registryPath: string;
+}
+
+export interface UpsertManagedModPackageResult
+  extends ManagedModPackageMutationResult {
+  removedDuplicates: number;
+  replaced: boolean;
 }
 
 const PACKAGE_ENTRY_KEYS = new Set([
@@ -654,7 +671,11 @@ function formatManagedPackageSpecifier(pkg: {
   return `${pkg.source}@${pkg.version}`;
 }
 
-function expectedRootRelativePathForSource(source: string): string | null {
+function isValidNpmPackageNamePart(value: string): boolean {
+  return /^[a-z0-9][a-z0-9._~-]*$/.test(value);
+}
+
+export function parseManagedNpmPackageSource(source: string): string | null {
   if (!source.startsWith("npm:")) return null;
   const packageName = source.slice("npm:".length);
   const normalizedPackageName = normalizeRelativePath(packageName);
@@ -663,19 +684,31 @@ function expectedRootRelativePathForSource(source: string): string | null {
   const isScopedPackage =
     packageNameParts.length === 2 &&
     Boolean(packageNameParts[0]?.startsWith("@")) &&
-    Boolean(packageNameParts[0]?.slice(1)) &&
-    Boolean(packageNameParts[1]);
+    isValidNpmPackageNamePart(packageNameParts[0]?.slice(1) ?? "") &&
+    isValidNpmPackageNamePart(packageNameParts[1] ?? "");
   const isUnscopedPackage =
-    packageNameParts.length === 1 && !packageNameParts[0]?.startsWith("@");
+    packageNameParts.length === 1 &&
+    !packageNameParts[0]?.startsWith("@") &&
+    isValidNpmPackageNamePart(packageNameParts[0] ?? "");
   if (!isScopedPackage && !isUnscopedPackage) return null;
-  return `${MOD_PACKAGES_DIRECTORY_NAME}/npm/${normalizedPackageName}`;
+  return normalizedPackageName;
+}
+
+export function getManagedModPackageRootRelativePathForSource(
+  source: string,
+): string | null {
+  const packageName = parseManagedNpmPackageSource(source);
+  if (!packageName) return null;
+  return `${MOD_PACKAGES_DIRECTORY_NAME}/npm/${packageName}`;
 }
 
 function assertSafePackageRemovalRoot(
   metadata: Extract<ReturnType<typeof validatePackageMetadata>, { ok: true }>,
 ): void {
   const normalizedRoot = normalizeRelativePath(metadata.rootRelativePath);
-  const expectedRoot = expectedRootRelativePathForSource(metadata.source);
+  const expectedRoot = getManagedModPackageRootRelativePathForSource(
+    metadata.source,
+  );
   if (!normalizedRoot || !expectedRoot || normalizedRoot !== expectedRoot) {
     throw new Error(
       `Refusing to remove ${formatManagedPackageSpecifier(metadata)} because registry root '${metadata.rootRelativePath}' does not match expected package root '${expectedRoot ?? "(unknown)"}'.`,
@@ -683,7 +716,10 @@ function assertSafePackageRemovalRoot(
   }
 }
 
-function readMutablePackageRegistry(modsRoot: string): {
+function readMutablePackageRegistry(
+  modsRoot: string,
+  options: { createIfMissing?: boolean } = {},
+): {
   packagesValue: unknown[];
   registry: Record<string, unknown>;
   registryPath: string;
@@ -691,6 +727,14 @@ function readMutablePackageRegistry(modsRoot: string): {
   const result = readRegistryObject(modsRoot);
   if (!result.ok) {
     if (!result.registryExists) {
+      if (options.createIfMissing) {
+        const packagesValue: unknown[] = [];
+        return {
+          packagesValue,
+          registry: { packages: packagesValue },
+          registryPath: result.registryPath,
+        };
+      }
       throw new Error("No managed mod packages are installed.");
     }
     throw new Error(
@@ -721,6 +765,15 @@ function getPackageMetadataForMutation(
     );
   }
   return metadata;
+}
+
+function validatePackageRegistryEntriesForMutation(
+  modsRoot: string,
+  packagesValue: unknown[],
+): void {
+  packagesValue.forEach((entry, index) => {
+    getPackageMetadataForMutation(modsRoot, entry, index);
+  });
 }
 
 function findPackageIndex(
@@ -764,7 +817,22 @@ function writePackageRegistry(
   registryPath: string,
   registry: Record<string, unknown>,
 ): void {
+  mkdirSync(path.dirname(registryPath), { recursive: true });
   writeFileSync(registryPath, `${JSON.stringify(registry, null, 2)}\n`);
+}
+
+export function validateManagedModPackageRegistryForMutation(
+  modsRoot: string,
+): ManagedModPackageRegistrySnapshot {
+  const registryPath = getRegistryPath(modsRoot);
+  const contents = existsSync(registryPath)
+    ? readFileSync(registryPath, "utf8")
+    : null;
+  const registry = readMutablePackageRegistry(modsRoot, {
+    createIfMissing: true,
+  });
+  validatePackageRegistryEntriesForMutation(modsRoot, registry.packagesValue);
+  return { contents, registryPath };
 }
 
 function mutationItem(
@@ -806,6 +874,86 @@ export function setManagedModPackageEnabled(params: {
   return {
     package: mutationItem(match.metadata, match.index, params.enabled),
     registryPath: registry.registryPath,
+  };
+}
+
+export function upsertManagedModPackage(params: {
+  enabled?: boolean;
+  entries: string[];
+  modsRoot: string;
+  source: string;
+  version: string;
+}): UpsertManagedModPackageResult {
+  const rootRelativePath = getManagedModPackageRootRelativePathForSource(
+    params.source,
+  );
+  if (!rootRelativePath) {
+    throw new Error(`Invalid managed mod package source: ${params.source}`);
+  }
+  if (!params.version.trim()) {
+    throw new Error("Package version must not be empty");
+  }
+  const entriesResult = validatePackageEntries(
+    params.entries,
+    "package.entries",
+  );
+  if (!entriesResult.ok) {
+    throw new Error(
+      entriesResult.diagnostics[0]?.error.message ?? "Invalid package entries",
+    );
+  }
+
+  const registry = readMutablePackageRegistry(params.modsRoot, {
+    createIfMissing: true,
+  });
+  validatePackageRegistryEntriesForMutation(
+    params.modsRoot,
+    registry.packagesValue,
+  );
+
+  const entry = {
+    source: params.source,
+    version: params.version,
+    enabled: params.enabled ?? true,
+    root: rootRelativePath,
+    entries: entriesResult.entries,
+  };
+  const nextPackages: unknown[] = [];
+  let insertionIndex = -1;
+  let removedDuplicates = 0;
+  let replaced = false;
+
+  registry.packagesValue.forEach((rawEntry) => {
+    if (isRecord(rawEntry) && rawEntry.source === params.source) {
+      if (!replaced) {
+        insertionIndex = nextPackages.length;
+        nextPackages.push(entry);
+        replaced = true;
+      } else {
+        removedDuplicates += 1;
+      }
+      return;
+    }
+    nextPackages.push(rawEntry);
+  });
+
+  if (!replaced) {
+    insertionIndex = nextPackages.length;
+    nextPackages.push(entry);
+  }
+  registry.registry.packages = nextPackages;
+  writePackageRegistry(registry.registryPath, registry.registry);
+
+  const metadata = getPackageMetadataForMutation(
+    params.modsRoot,
+    entry,
+    insertionIndex,
+  );
+  return {
+    package: mutationItem(metadata, insertionIndex, metadata.enabled),
+    registryPath: registry.registryPath,
+    removedDuplicates,
+    replaced,
   };
 }
 


### PR DESCRIPTION
## Summary
- add a local managed mod package installer that validates package.json#letta, copies into the managed packages dir, and upserts packages.json
- expose local package install through top-level `letta install ./path/to/package` while keeping `letta mods` for list/enable/disable/remove
- derive package roots from npm sources and preserve existing installs on failed replacement rollback

## Tests
- `bun test src/mods/package-installer.test.ts`
- `bun test src/mods/package-registry.test.ts`
- `bun test src/cli/subcommands/skills.test.ts`
- `bun test src/cli/subcommands/mods.test.ts`
- `bun test src/mods/mod-engine.test.ts`
- `bun test src/cli/mods/local-mod-loader.test.ts`
- `bun run typecheck`
- `bun run check`