### PR TITLE
feat(mods): scaffold local packages

### DIFF
--- a/src/cli/subcommands/mods.test.ts
+++ b/src/cli/subcommands/mods.test.ts
@@ -242,6 +242,7 @@ describe("mods subcommand", () => {
       expect(exitCode).toBe(0);
       expect(consoleCapture.logs.join("\n")).toContain("Usage:");
       expect(consoleCapture.logs.join("\n")).toContain("letta mods list");
+      expect(consoleCapture.logs.join("\n")).toContain("letta mods package");
       expect(consoleCapture.errors).toEqual([]);
     } finally {
       consoleCapture.restore();
@@ -258,6 +259,86 @@ describe("mods subcommand", () => {
         "Unknown mods action: publish",
       );
       expect(consoleCapture.logs.join("\n")).toContain("Usage:");
+    } finally {
+      consoleCapture.restore();
+    }
+  });
+
+  test("package command creates a local package scaffold", async () => {
+    const root = createTempDir();
+    const sourceFile = join(root, "hello.ts");
+    const outputDirectory = join(root, "hello-package");
+    writeFileSync(sourceFile, "export default () => {};\n");
+    const consoleCapture = captureConsole();
+
+    try {
+      const exitCode = await runModsSubcommand([
+        "package",
+        sourceFile,
+        "--name",
+        "@caren/hello-mod",
+        "--out",
+        outputDirectory,
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(consoleCapture.logs.join("\n")).toContain(
+        `Created mod package ${outputDirectory}`,
+      );
+      expect(consoleCapture.logs.join("\n")).toContain(
+        "Install with: letta install",
+      );
+      expect(
+        JSON.parse(readFileSync(join(outputDirectory, "package.json"), "utf8")),
+      ).toMatchObject({
+        name: "@caren/hello-mod",
+        letta: { manifestVersion: 1, mods: ["mods/hello.ts"] },
+      });
+      expect(existsSync(join(outputDirectory, "mods", "hello.ts"))).toBe(true);
+    } finally {
+      consoleCapture.restore();
+    }
+  });
+
+  test("package command requires a package name", async () => {
+    const root = createTempDir();
+    const sourceFile = join(root, "hello.ts");
+    writeFileSync(sourceFile, "export default () => {};\n");
+    const consoleCapture = captureConsole();
+
+    try {
+      const exitCode = await runModsSubcommand(["package", sourceFile]);
+
+      expect(exitCode).toBe(1);
+      expect(consoleCapture.errors.join("\n")).toContain(
+        "Missing required --name",
+      );
+      expect(consoleCapture.logs.join("\n")).toContain("Usage:");
+    } finally {
+      consoleCapture.restore();
+    }
+  });
+
+  test("package command rejects agent option", async () => {
+    const root = createTempDir();
+    const sourceFile = join(root, "hello.ts");
+    writeFileSync(sourceFile, "export default () => {};\n");
+    const consoleCapture = captureConsole();
+
+    try {
+      const exitCode = await runModsSubcommand([
+        "package",
+        sourceFile,
+        "--name",
+        "hello-mod",
+        "--agent",
+        "agent-123",
+      ]);
+
+      expect(exitCode).toBe(1);
+      expect(consoleCapture.errors.join("\n")).toContain(
+        "--agent is not supported for 'letta mods package'",
+      );
     } finally {
       consoleCapture.restore();
     }

--- a/src/cli/subcommands/mods.ts
+++ b/src/cli/subcommands/mods.ts
@@ -9,6 +9,7 @@ import {
   removeManagedModPackage,
   setManagedModPackageEnabled,
 } from "@/mods/package-registry";
+import { scaffoldLocalModPackage } from "@/mods/package-scaffolder";
 import { resolveDefaultGlobalModsDirectory } from "@/mods/paths";
 
 interface LooseModSection {
@@ -39,6 +40,12 @@ const MODS_OPTIONS = {
   "agent-id": { type: "string" },
 } as const;
 
+const MODS_PACKAGE_OPTIONS = {
+  ...MODS_OPTIONS,
+  name: { type: "string" },
+  out: { type: "string" },
+} as const;
+
 const RELOAD_HINT =
   "Run /reload in active sessions for changes to take effect.";
 
@@ -47,6 +54,7 @@ function printUsage(): void {
     `
 Usage:
   letta mods list [--agent <id>]
+  letta mods package <mod-file> --name <package-name> [--out <dir>]
   letta mods enable <package-spec>
   letta mods disable <package-spec>
   letta mods remove <package-spec>
@@ -63,6 +71,15 @@ function parseModsArgs(argv: string[]) {
   return parseArgs({
     args: argv,
     options: MODS_OPTIONS,
+    strict: true,
+    allowPositionals: true,
+  });
+}
+
+function parseModsPackageArgs(argv: string[]) {
+  return parseArgs({
+    args: argv,
+    options: MODS_PACKAGE_OPTIONS,
     strict: true,
     allowPositionals: true,
   });
@@ -269,6 +286,67 @@ async function runPackageMutation(
   }
 }
 
+async function runPackageScaffold(argv: string[]): Promise<number> {
+  let parsed: ReturnType<typeof parseModsPackageArgs>;
+  try {
+    parsed = parseModsPackageArgs(argv);
+  } catch (error) {
+    console.error(
+      `Error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    printUsage();
+    return 1;
+  }
+
+  if (parsed.values.help) {
+    printUsage();
+    return 0;
+  }
+  if (getExplicitAgentId(parsed.values)) {
+    console.error(`--agent is not supported for 'letta mods package'.`);
+    printUsage();
+    return 1;
+  }
+
+  const [sourceFile, extra] = parsed.positionals;
+  if (!sourceFile) {
+    console.error(`Missing mod file.`);
+    printUsage();
+    return 1;
+  }
+  if (extra) {
+    console.error(`Unexpected argument: ${extra}`);
+    printUsage();
+    return 1;
+  }
+  const packageName = parsed.values.name;
+  if (typeof packageName !== "string" || !packageName.trim()) {
+    console.error(`Missing required --name <package-name>.`);
+    printUsage();
+    return 1;
+  }
+
+  try {
+    const result = scaffoldLocalModPackage({
+      ...(typeof parsed.values.out === "string" && parsed.values.out.trim()
+        ? { outputDirectory: parsed.values.out }
+        : {}),
+      packageName,
+      sourceFile,
+    });
+    console.log(`Created mod package ${result.outputDirectory}`);
+    console.log(`Copied ${result.sourceFile} -> ${result.targetModPath}`);
+    console.log(
+      "The original loose mod is still present and may still load until you remove it.",
+    );
+    console.log(`Install with: ${result.installCommand}`);
+    return 0;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
 export async function runModsSubcommand(
   argv: string[],
   options: RunModsOptions = {},
@@ -283,6 +361,8 @@ export async function runModsSubcommand(
   switch (action) {
     case "list":
       return runList(rest, options);
+    case "package":
+      return runPackageScaffold(rest);
     case "enable":
     case "disable":
     case "remove":

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,6 +207,7 @@ SUBCOMMANDS
   letta messages list [--agent <id>]
   letta messages transcript --conversation <id> [--out <path>]
   letta mods list [--agent <id>]
+  letta mods package <mod-file> --name <package-name> [--out <dir>]
   letta mods enable <package-spec>
   letta mods disable <package-spec>
   letta mods remove <package-spec>

--- a/src/mods/package-scaffolder.test.ts
+++ b/src/mods/package-scaffolder.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { installLocalManagedModPackage } from "@/mods/package-installer";
+import { readLettaPackageManifest } from "@/mods/package-manifest";
+import { scaffoldLocalModPackage } from "@/mods/package-scaffolder";
+
+const tempRoots: string[] = [];
+
+function createTempDir(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "letta-package-scaffold-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempRoots.splice(0)) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe("local mod package scaffolder", () => {
+  test("creates a package scaffold from a loose mod file", () => {
+    const root = createTempDir();
+    const sourceFile = path.join(root, "hello.ts");
+    const outputDirectory = path.join(root, "hello-package");
+    writeFileSync(
+      sourceFile,
+      `export default function activate(letta) {
+        letta.commands.register({ id: "hello", description: "Hello", run() {} });
+      }\n`,
+    );
+
+    const result = scaffoldLocalModPackage({
+      outputDirectory,
+      packageName: "@caren/hello-mod",
+      sourceFile,
+    });
+
+    expect(result).toMatchObject({
+      installCommand: `letta install ${outputDirectory}`,
+      manifestEntry: "mods/hello.ts",
+      outputDirectory,
+      packageName: "@caren/hello-mod",
+      sourceFile,
+      targetModPath: path.join(outputDirectory, "mods", "hello.ts"),
+    });
+    expect(readFileSync(result.targetModPath, "utf8")).toContain(
+      "letta.commands.register",
+    );
+    expect(JSON.parse(readFileSync(result.packageJsonPath, "utf8"))).toEqual({
+      name: "@caren/hello-mod",
+      version: "0.1.0",
+      type: "module",
+      keywords: ["letta-mod"],
+      letta: {
+        manifestVersion: 1,
+        mods: ["mods/hello.ts"],
+      },
+    });
+    expect(readLettaPackageManifest(result.packageJsonPath)).toMatchObject({
+      manifest: {
+        mods: ["mods/hello.ts"],
+      },
+      ok: true,
+    });
+    expect(readFileSync(result.readmePath, "utf8")).toContain(
+      "letta install .",
+    );
+  });
+
+  test("default output directory is derived from package name", () => {
+    const root = createTempDir();
+    const sourceFile = path.join(root, "statusline.tsx");
+    writeFileSync(sourceFile, "export default () => {};\n");
+
+    const result = scaffoldLocalModPackage({
+      packageName: "@caren/statusline-mod",
+      sourceFile,
+    });
+
+    expect(result.outputDirectory).toBe(path.join(root, "statusline-mod"));
+    expect(existsSync(path.join(result.outputDirectory, "package.json"))).toBe(
+      true,
+    );
+  });
+
+  test("created package can be installed by local package installer", () => {
+    const root = createTempDir();
+    const sourceFile = path.join(root, "tool.mjs");
+    const outputDirectory = path.join(root, "tool-package");
+    const modsRoot = path.join(root, "mods");
+    writeFileSync(sourceFile, "export default () => {};\n");
+
+    scaffoldLocalModPackage({
+      outputDirectory,
+      packageName: "tool-package",
+      sourceFile,
+    });
+    const installResult = installLocalManagedModPackage({
+      modsRoot,
+      packageDirectory: outputDirectory,
+    });
+
+    expect(installResult).toMatchObject({
+      entries: ["mods/tool.mjs"],
+      source: "npm:tool-package",
+      version: "0.1.0",
+    });
+  });
+
+  test("rejects invalid package names", () => {
+    const root = createTempDir();
+    const sourceFile = path.join(root, "hello.ts");
+    writeFileSync(sourceFile, "export default () => {};\n");
+
+    expect(() =>
+      scaffoldLocalModPackage({
+        packageName: "@caren",
+        sourceFile,
+      }),
+    ).toThrow("Package name must be a valid npm package name");
+    expect(() =>
+      scaffoldLocalModPackage({
+        packageName: "hello/world/extra",
+        sourceFile,
+      }),
+    ).toThrow("Package name must be a valid npm package name");
+  });
+
+  test("rejects unsupported source file extensions", () => {
+    const root = createTempDir();
+    const sourceFile = path.join(root, "hello.txt");
+    writeFileSync(sourceFile, "not a mod\n");
+
+    expect(() =>
+      scaffoldLocalModPackage({
+        packageName: "hello-mod",
+        sourceFile,
+      }),
+    ).toThrow("Mod file must be a .ts, .tsx, .js, or .mjs file");
+  });
+
+  test("rejects symlink source files", () => {
+    if (process.platform === "win32") return;
+    const root = createTempDir();
+    const targetFile = path.join(root, "target.ts");
+    const sourceFile = path.join(root, "linked.ts");
+    writeFileSync(targetFile, "export default () => {};\n");
+    symlinkSync(targetFile, sourceFile);
+
+    expect(() =>
+      scaffoldLocalModPackage({
+        packageName: "hello-mod",
+        sourceFile,
+      }),
+    ).toThrow("Mod file must not be a symlink");
+  });
+
+  test("rejects existing output directories", () => {
+    const root = createTempDir();
+    const sourceFile = path.join(root, "hello.ts");
+    const outputDirectory = path.join(root, "hello-package");
+    writeFileSync(sourceFile, "export default () => {};\n");
+    mkdirSync(outputDirectory, { recursive: true });
+
+    expect(() =>
+      scaffoldLocalModPackage({
+        outputDirectory,
+        packageName: "hello-mod",
+        sourceFile,
+      }),
+    ).toThrow("Output directory already exists");
+  });
+});

--- a/src/mods/package-scaffolder.test.ts
+++ b/src/mods/package-scaffolder.test.ts
@@ -49,6 +49,7 @@ describe("local mod package scaffolder", () => {
     expect(result).toMatchObject({
       installCommand: `letta install ${outputDirectory}`,
       manifestEntry: "mods/hello.ts",
+      modGuidePath: path.join(outputDirectory, "MOD.md"),
       outputDirectory,
       packageName: "@caren/hello-mod",
       sourceFile,
@@ -62,6 +63,7 @@ describe("local mod package scaffolder", () => {
       version: "0.1.0",
       type: "module",
       keywords: ["letta-mod"],
+      files: ["README.md", "MOD.md", "mods"],
       letta: {
         manifestVersion: 1,
         mods: ["mods/hello.ts"],
@@ -75,6 +77,12 @@ describe("local mod package scaffolder", () => {
     });
     expect(readFileSync(result.readmePath, "utf8")).toContain(
       "letta install .",
+    );
+    expect(readFileSync(result.modGuidePath, "utf8")).toContain(
+      "TODO: Describe what this mod does.",
+    );
+    expect(readFileSync(result.modGuidePath, "utf8")).toContain(
+      "`mods/hello.ts`",
     );
   });
 
@@ -92,6 +100,7 @@ describe("local mod package scaffolder", () => {
     expect(existsSync(path.join(result.outputDirectory, "package.json"))).toBe(
       true,
     );
+    expect(existsSync(path.join(result.outputDirectory, "MOD.md"))).toBe(true);
   });
 
   test("created package can be installed by local package installer", () => {

--- a/src/mods/package-scaffolder.ts
+++ b/src/mods/package-scaffolder.ts
@@ -1,0 +1,146 @@
+import {
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { isModFileExtension } from "@/mods/file-extensions";
+import { LETTA_PACKAGE_MANIFEST_VERSION } from "@/mods/package-manifest";
+import { parseManagedNpmPackageSource } from "@/mods/package-registry";
+
+export interface ScaffoldLocalModPackageOptions {
+  outputDirectory?: string;
+  packageName: string;
+  sourceFile: string;
+}
+
+export interface ScaffoldLocalModPackageResult {
+  installCommand: string;
+  manifestEntry: string;
+  outputDirectory: string;
+  packageJsonPath: string;
+  packageName: string;
+  readmePath: string;
+  sourceFile: string;
+  targetModPath: string;
+}
+
+const DEFAULT_PACKAGE_VERSION = "0.1.0";
+const LETTA_MOD_KEYWORD = "letta-mod";
+
+function assertValidPackageName(packageName: string): string {
+  const trimmed = packageName.trim();
+  if (!trimmed) {
+    throw new Error("Package name is required");
+  }
+  const normalizedPackageName = parseManagedNpmPackageSource(`npm:${trimmed}`);
+  if (!normalizedPackageName) {
+    throw new Error("Package name must be a valid npm package name");
+  }
+  return normalizedPackageName;
+}
+
+function defaultOutputDirectory(
+  sourceFile: string,
+  packageName: string,
+): string {
+  const nameParts = packageName.split("/");
+  const directoryName = nameParts[nameParts.length - 1] || packageName;
+  return path.join(path.dirname(sourceFile), directoryName);
+}
+
+function readSourceFile(sourceFile: string): string {
+  const resolvedSourceFile = path.resolve(sourceFile);
+  let stats: ReturnType<typeof lstatSync>;
+  try {
+    stats = lstatSync(resolvedSourceFile);
+  } catch {
+    throw new Error(`Mod file does not exist: ${sourceFile}`);
+  }
+  if (stats.isSymbolicLink()) {
+    throw new Error(`Mod file must not be a symlink: ${sourceFile}`);
+  }
+  if (!stats.isFile()) {
+    throw new Error(`Mod path must be a file: ${sourceFile}`);
+  }
+  if (!isModFileExtension(path.extname(resolvedSourceFile))) {
+    throw new Error("Mod file must be a .ts, .tsx, .js, or .mjs file");
+  }
+  return resolvedSourceFile;
+}
+
+function createPackageJson(packageName: string, manifestEntry: string) {
+  return {
+    name: packageName,
+    version: DEFAULT_PACKAGE_VERSION,
+    type: "module",
+    keywords: [LETTA_MOD_KEYWORD],
+    letta: {
+      manifestVersion: LETTA_PACKAGE_MANIFEST_VERSION,
+      mods: [manifestEntry],
+    },
+  };
+}
+
+function createReadme(packageName: string): string {
+  return `# ${packageName}
+
+Letta Code mod package.
+
+## Install locally
+
+\`\`\`bash
+letta install .
+\`\`\`
+
+Run /reload in active sessions for changes to take effect.
+`;
+}
+
+export function scaffoldLocalModPackage(
+  options: ScaffoldLocalModPackageOptions,
+): ScaffoldLocalModPackageResult {
+  const sourceFile = readSourceFile(options.sourceFile);
+  const packageName = assertValidPackageName(options.packageName);
+  const outputDirectory = path.resolve(
+    options.outputDirectory ?? defaultOutputDirectory(sourceFile, packageName),
+  );
+  if (existsSync(outputDirectory)) {
+    throw new Error(`Output directory already exists: ${outputDirectory}`);
+  }
+
+  const modFileName = path.basename(sourceFile);
+  const manifestEntry = `mods/${modFileName}`;
+  const targetModsDirectory = path.join(outputDirectory, "mods");
+  const targetModPath = path.join(targetModsDirectory, modFileName);
+  const packageJsonPath = path.join(outputDirectory, "package.json");
+  const readmePath = path.join(outputDirectory, "README.md");
+  const installCommand = `letta install ${outputDirectory}`;
+
+  try {
+    mkdirSync(targetModsDirectory, { recursive: true });
+    copyFileSync(sourceFile, targetModPath);
+    writeFileSync(
+      packageJsonPath,
+      `${JSON.stringify(createPackageJson(packageName, manifestEntry), null, 2)}\n`,
+    );
+    writeFileSync(readmePath, createReadme(packageName));
+  } catch (error) {
+    rmSync(outputDirectory, { force: true, recursive: true });
+    throw error;
+  }
+
+  return {
+    installCommand,
+    manifestEntry,
+    outputDirectory,
+    packageJsonPath,
+    packageName,
+    readmePath,
+    sourceFile,
+    targetModPath,
+  };
+}

--- a/src/mods/package-scaffolder.ts
+++ b/src/mods/package-scaffolder.ts
@@ -21,6 +21,7 @@ export interface ScaffoldLocalModPackageResult {
   installCommand: string;
   manifestEntry: string;
   outputDirectory: string;
+  modGuidePath: string;
   packageJsonPath: string;
   packageName: string;
   readmePath: string;
@@ -78,6 +79,7 @@ function createPackageJson(packageName: string, manifestEntry: string) {
     version: DEFAULT_PACKAGE_VERSION,
     type: "module",
     keywords: [LETTA_MOD_KEYWORD],
+    files: ["README.md", "MOD.md", "mods"],
     letta: {
       manifestVersion: LETTA_PACKAGE_MANIFEST_VERSION,
       mods: [manifestEntry],
@@ -100,6 +102,27 @@ Run /reload in active sessions for changes to take effect.
 `;
 }
 
+function createModGuide(packageName: string, manifestEntry: string): string {
+  return `# ${packageName}
+
+## Purpose
+
+TODO: Describe what this mod does.
+
+## Behavior
+
+TODO: Describe commands, tools, events, permissions, providers, or UI surfaces this mod registers.
+
+## Entry points
+
+- \`${manifestEntry}\`
+
+## Safety
+
+This mod is trusted local code and can execute with the user's local permissions. Review the source before installing or modifying it.
+`;
+}
+
 export function scaffoldLocalModPackage(
   options: ScaffoldLocalModPackageOptions,
 ): ScaffoldLocalModPackageResult {
@@ -118,6 +141,7 @@ export function scaffoldLocalModPackage(
   const targetModPath = path.join(targetModsDirectory, modFileName);
   const packageJsonPath = path.join(outputDirectory, "package.json");
   const readmePath = path.join(outputDirectory, "README.md");
+  const modGuidePath = path.join(outputDirectory, "MOD.md");
   const installCommand = `letta install ${outputDirectory}`;
 
   try {
@@ -128,6 +152,7 @@ export function scaffoldLocalModPackage(
       `${JSON.stringify(createPackageJson(packageName, manifestEntry), null, 2)}\n`,
     );
     writeFileSync(readmePath, createReadme(packageName));
+    writeFileSync(modGuidePath, createModGuide(packageName, manifestEntry));
   } catch (error) {
     rmSync(outputDirectory, { force: true, recursive: true });
     throw error;
@@ -136,6 +161,7 @@ export function scaffoldLocalModPackage(
   return {
     installCommand,
     manifestEntry,
+    modGuidePath,
     outputDirectory,
     packageJsonPath,
     packageName,


### PR DESCRIPTION
## Summary
- add `letta mods package <mod-file> --name <package-name> [--out <dir>]`
- scaffold local mod package directories with `package.json#letta`, README, and copied mod entry
- validate package names, supported mod extensions, symlink sources, and existing output directories
- print local install next steps without modifying the original loose mod

## Tests
- `bun test src/mods/package-scaffolder.test.ts`
- `bun test src/cli/subcommands/mods.test.ts`
- `bun test src/mods/package-installer.test.ts`
- `bun test src/mods/package-manifest.test.ts`
- `bun run typecheck`
- `bun run check`