### PR TITLE
feat(mods): install npm packages

### DIFF
--- a/src/cli/mods/local-mod-loader.test.ts
+++ b/src/cli/mods/local-mod-loader.test.ts
@@ -179,6 +179,7 @@ describe("local mod loader", () => {
       ).toEqual([
         {
           files: [looseMod, packageMod],
+          managedPackageRoots: [packageRoot],
           root: globalMods,
           scope: "global",
           trusted: true,
@@ -565,6 +566,83 @@ describe("local mod loader", () => {
         createStatuslineContext(),
       );
       expect(output).toMatchObject({ props: { children: "Letta Code" } });
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("loads managed package mods with package node_modules imports", async () => {
+    const root = createTempDir();
+    try {
+      const options = createLoadOptions(root);
+      const globalMods = options.globalModsDirectory;
+      const packageRoot = path.join(
+        globalMods,
+        "packages",
+        "npm",
+        "@caren",
+        "dep-mod",
+      );
+      const modDir = path.join(packageRoot, "mods");
+      const dependencyRoot = path.join(packageRoot, "node_modules", "fake-dep");
+      mkdirSync(modDir, { recursive: true });
+      mkdirSync(dependencyRoot, { recursive: true });
+      writeFileSync(
+        path.join(modDir, "index.js"),
+        `import { label } from "fake-dep";
+export default function(letta) {
+  letta.ui.setStatus("dep", label);
+}
+`,
+      );
+      writeFileSync(
+        path.join(dependencyRoot, "package.json"),
+        JSON.stringify({
+          name: "fake-dep",
+          version: "1.0.0",
+          type: "module",
+          exports: "./index.js",
+        }),
+      );
+      writeFileSync(
+        path.join(dependencyRoot, "index.js"),
+        `export const label = "dependency";\n`,
+      );
+      writeFileSync(
+        path.join(packageRoot, "package.json"),
+        JSON.stringify({
+          name: "@caren/dep-mod",
+          version: "0.1.0",
+          letta: {
+            manifestVersion: 1,
+            mods: ["mods/index.js"],
+          },
+        }),
+      );
+      mkdirSync(globalMods, { recursive: true });
+      writeFileSync(
+        path.join(globalMods, "packages.json"),
+        JSON.stringify({
+          packages: [
+            {
+              source: "npm:@caren/dep-mod",
+              version: "0.1.0",
+              enabled: true,
+              root: "packages/npm/@caren/dep-mod",
+              entries: ["mods/index.js"],
+            },
+          ],
+        }),
+      );
+
+      const registry = await loadLocalMods(options);
+
+      expect(getModErrorDiagnostics(registry.diagnostics)).toEqual([]);
+      expect(registry.ui.statusValues.dep).toBe("dependency");
+      const generatedFiles = readdirSync(modDir).filter((entry) =>
+        entry.startsWith(".letta-mod-index-"),
+      );
+      expect(generatedFiles).toHaveLength(1);
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/src/cli/subcommands/skills.test.ts
+++ b/src/cli/subcommands/skills.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
 import {
   existsSync,
   mkdirSync,
@@ -9,6 +11,8 @@ import {
 import { mkdir, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import { __testOverrideNpmManagedModPackageInstaller } from "@/mods/package-installer";
 import {
   deleteSkillDirectory,
   downloadDirectSkillFileSource,
@@ -20,6 +24,15 @@ import {
   parseGitHubSpecifier,
   runInstallSubcommand,
 } from "./skills";
+
+function createChildProcess(): ChildProcess {
+  const child = new EventEmitter() as ChildProcess;
+  Object.assign(child, {
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+  });
+  return child;
+}
 
 function captureConsole(): {
   errors: string[];
@@ -70,7 +83,43 @@ function writeLocalModPackage(params: {
   );
 }
 
+function writeInstalledNpmModPackage(params: {
+  cwd: string;
+  name?: string;
+  version?: string;
+}): void {
+  const packageName = params.name ?? "@caren/my-mod";
+  const packageRoot = join(
+    params.cwd,
+    "node_modules",
+    ...packageName.split("/"),
+  );
+  mkdirSync(join(packageRoot, "mods"), { recursive: true });
+  writeFileSync(join(packageRoot, "mods", "index.ts"), "export {};\n");
+  writeFileSync(
+    join(packageRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name: packageName,
+        version: params.version ?? "0.1.0",
+        repository: { url: "https://github.com/caren/my-mod.git" },
+        letta: {
+          manifestVersion: 1,
+          mods: ["mods/index.ts"],
+          capabilities: ["commands"],
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
 describe("skills subcommand", () => {
+  afterEach(() => {
+    __testOverrideNpmManagedModPackageInstaller({});
+  });
+
   test("parses GitHub tree URLs", () => {
     expect(
       parseGitHubSpecifier(
@@ -302,14 +351,150 @@ describe("skills subcommand", () => {
     }
   });
 
-  test("top-level install reserves npm package specs for mod packages", async () => {
+  test("top-level install installs npm mod packages", async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "letta-install-test-"));
     const consoleCapture = captureConsole();
     try {
-      const exitCode = await runInstallSubcommand(["npm:@caren/my-mod"]);
+      const modsRoot = join(tempRoot, "mods");
+      __testOverrideNpmManagedModPackageInstaller({
+        spawnImpl: (_cmd, _args, options) => {
+          if (!options.cwd) throw new Error("expected cwd");
+          writeInstalledNpmModPackage({
+            cwd: options.cwd.toString(),
+            version: "0.2.0",
+          });
+          const child = createChildProcess();
+          queueMicrotask(() => child.emit("exit", 0));
+          return child;
+        },
+      });
+
+      const exitCode = await runInstallSubcommand(["npm:@caren/my-mod"], {
+        globalModsDirectory: modsRoot,
+      });
+
+      expect(exitCode).toBe(0);
+      expect(consoleCapture.logs.join("\n")).toContain(
+        "Warning: mods are trusted local code and can execute on startup.",
+      );
+      expect(consoleCapture.logs.join("\n")).toContain(
+        "Source: npm:@caren/my-mod",
+      );
+      expect(consoleCapture.logs.join("\n")).toContain(
+        "Repository: https://github.com/caren/my-mod.git",
+      );
+      expect(consoleCapture.logs.join("\n")).toContain(
+        "Capabilities: commands",
+      );
+      expect(consoleCapture.logs.join("\n")).toContain(
+        "Installed npm:@caren/my-mod@0.2.0",
+      );
+      expect(
+        existsSync(
+          join(
+            modsRoot,
+            "packages",
+            "npm",
+            "@caren",
+            "my-mod",
+            "mods",
+            "index.ts",
+          ),
+        ),
+      ).toBe(true);
+    } finally {
+      consoleCapture.restore();
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("top-level install installs unscoped npm mod packages", async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "letta-install-test-"));
+    const consoleCapture = captureConsole();
+    try {
+      const modsRoot = join(tempRoot, "mods");
+      __testOverrideNpmManagedModPackageInstaller({
+        spawnImpl: (_cmd, _args, options) => {
+          if (!options.cwd) throw new Error("expected cwd");
+          writeInstalledNpmModPackage({
+            cwd: options.cwd.toString(),
+            name: "my-mod",
+          });
+          const child = createChildProcess();
+          queueMicrotask(() => child.emit("exit", 0));
+          return child;
+        },
+      });
+
+      const exitCode = await runInstallSubcommand(["npm:my-mod"], {
+        globalModsDirectory: modsRoot,
+      });
+
+      expect(exitCode).toBe(0);
+      expect(consoleCapture.logs.join("\n")).toContain("Source: npm:my-mod");
+      expect(existsSync(join(modsRoot, "packages", "npm", "my-mod"))).toBe(
+        true,
+      );
+    } finally {
+      consoleCapture.restore();
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("top-level npm mod install rejects force", async () => {
+    const consoleCapture = captureConsole();
+    try {
+      const exitCode = await runInstallSubcommand([
+        "--force",
+        "npm:@caren/my-mod",
+      ]);
 
       expect(exitCode).toBe(1);
       expect(consoleCapture.errors.join("\n")).toContain(
-        "Network mod package install is not supported yet. Pass a local package path.",
+        "--force is only supported for skill installs.",
+      );
+    } finally {
+      consoleCapture.restore();
+    }
+  });
+
+  test("top-level npm mod install rejects agent scope", async () => {
+    const consoleCapture = captureConsole();
+    try {
+      const exitCode = await runInstallSubcommand([
+        "--agent",
+        "agent-123",
+        "npm:@caren/my-mod",
+      ]);
+
+      expect(exitCode).toBe(1);
+      expect(consoleCapture.errors.join("\n")).toContain(
+        "Agent-scoped mod package install is not supported yet.",
+      );
+    } finally {
+      consoleCapture.restore();
+    }
+  });
+
+  test("top-level npm mod install reports npm failure", async () => {
+    const consoleCapture = captureConsole();
+    try {
+      __testOverrideNpmManagedModPackageInstaller({
+        spawnImpl: () => {
+          const child = createChildProcess();
+          queueMicrotask(() => {
+            child.stderr?.emit("data", "not found");
+            child.emit("exit", 1);
+          });
+          return child;
+        },
+      });
+
+      const exitCode = await runInstallSubcommand(["npm:@caren/missing-mod"]);
+
+      expect(exitCode).toBe(1);
+      expect(consoleCapture.errors.join("\n")).toContain(
+        "npm install failed with code 1: not found",
       );
     } finally {
       consoleCapture.restore();

--- a/src/cli/subcommands/skills.ts
+++ b/src/cli/subcommands/skills.ts
@@ -14,7 +14,9 @@ import { parseArgs, TextDecoder, TextEncoder } from "node:util";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import { isLocalAgentId } from "@/agent/agent-id";
 import {
+  type InstallLocalManagedModPackageResult,
   installLocalManagedModPackage,
+  installNpmManagedModPackage,
   isLocalLettaModPackageDirectory,
 } from "@/mods/package-installer";
 import { resolveDefaultGlobalModsDirectory } from "@/mods/paths";
@@ -89,6 +91,7 @@ Usage:
   letta skills delete <skill_name> --agent <id>
 
 Sources:
+  npm:<package>         npm mod package, e.g. npm:@letta-ai/mod-plan-mode
   ./path/to/package     Local mod package with package.json#letta
   official/<path>         Hermes official optional skill, e.g. official/finance/stocks
   clawhub/<slug>          ClawHub registry skill, e.g. clawhub/nano-banana-pro
@@ -932,6 +935,32 @@ function stopAgentPromptStatus(): void {
   activeAgentPromptStatus = null;
 }
 
+function hasInstallAgentScope(
+  values: ReturnType<typeof parseSkillsArgs>["values"],
+): boolean {
+  return Boolean(values.agent || values["agent-id"] || values.name);
+}
+
+function printManagedModPackageInstallResult(
+  result: InstallLocalManagedModPackageResult,
+  options: { includeDetails?: boolean } = {},
+): void {
+  console.log(
+    "Warning: mods are trusted local code and can execute on startup.",
+  );
+  if (options.includeDetails) {
+    console.log(`Source: ${result.source}`);
+    if (result.repository) {
+      console.log(`Repository: ${result.repository}`);
+    }
+    if (result.capabilities.length > 0) {
+      console.log(`Capabilities: ${result.capabilities.join(", ")}`);
+    }
+  }
+  console.log(`Installed ${result.source}@${result.version}`);
+  console.log("Run /reload in active sessions for changes to take effect.");
+}
+
 async function runInstall(
   argv: string[],
   options: RunInstallOptions = {},
@@ -960,19 +989,31 @@ async function runInstall(
   }
 
   if (specifier.startsWith("npm:")) {
-    console.error(
-      "Network mod package install is not supported yet. Pass a local package path.",
-    );
-    return 1;
+    if (hasInstallAgentScope(parsed.values)) {
+      console.error("Agent-scoped mod package install is not supported yet.");
+      return 1;
+    }
+    if (parsed.values.force) {
+      console.error("--force is only supported for skill installs.");
+      return 1;
+    }
+    try {
+      const result = await installNpmManagedModPackage({
+        modsRoot:
+          options.globalModsDirectory ?? resolveDefaultGlobalModsDirectory(),
+        specifier,
+      });
+      printManagedModPackageInstallResult(result, { includeDetails: true });
+      return 0;
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      return 1;
+    }
   }
 
   const maybeLocalPath = resolve(specifier);
   if (isLocalLettaModPackageDirectory(maybeLocalPath)) {
-    if (
-      parsed.values.agent ||
-      parsed.values["agent-id"] ||
-      parsed.values.name
-    ) {
+    if (hasInstallAgentScope(parsed.values)) {
       console.error("Agent-scoped mod package install is not supported yet.");
       return 1;
     }
@@ -982,11 +1023,7 @@ async function runInstall(
           options.globalModsDirectory ?? resolveDefaultGlobalModsDirectory(),
         packageDirectory: maybeLocalPath,
       });
-      console.log(
-        "Warning: mods are trusted local code and can execute on startup.",
-      );
-      console.log(`Installed ${result.source}@${result.version}`);
-      console.log("Run /reload in active sessions for changes to take effect.");
+      printManagedModPackageInstallResult(result);
       return 0;
     } catch (error) {
       console.error(error instanceof Error ? error.message : String(error));

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,7 +186,7 @@ USAGE
   letta connect ...     Connect providers from terminal
   letta backend ...     Show or set the default backend
   letta setup           Re-run first-run setup
-  letta install ...     Install a skill or local mod package
+  letta install ...     Install a skill or mod package
   letta skills ...      List or delete installed agent skills
 
 OPTIONS
@@ -235,6 +235,7 @@ EXAMPLES
   letta --new              # Create new conversation
   letta --agent agent_123  # Open specific agent
   letta install official/finance/stocks --agent agent-123
+  letta install npm:@letta-ai/mod-plan-mode
 
   # inside the interactive session
   /profile save MyAgent    # Save current agent as profile

--- a/src/mods/mod-engine.ts
+++ b/src/mods/mod-engine.ts
@@ -220,6 +220,7 @@ export interface LocalModRegistry {
 export interface LocalModSource {
   diagnostics?: ManagedModPackageDiagnostic[];
   files: string[];
+  managedPackageRoots?: string[];
   root: string;
   scope: ModSourceScope;
   trusted: boolean;
@@ -322,6 +323,13 @@ export function resolveLocalModSources(
         ? { diagnostics: globalDiagnostics }
         : {}),
       files: [...listModFiles(globalModsDirectory), ...managedPackages.files],
+      ...(managedPackages.packages.length > 0
+        ? {
+            managedPackageRoots: managedPackages.packages.map(
+              (pkg) => pkg.root,
+            ),
+          }
+        : {}),
       root: globalModsDirectory,
       scope: "global",
       trusted: true,
@@ -408,6 +416,9 @@ function snapshotRegistryForReaders(
       ...source,
       ...(source.diagnostics ? { diagnostics: [...source.diagnostics] } : {}),
       files: [...source.files],
+      ...(source.managedPackageRoots
+        ? { managedPackageRoots: [...source.managedPackageRoots] }
+        : {}),
     })),
     tools: { ...registry.tools },
     ui: {
@@ -502,6 +513,27 @@ function ensureModCache(cacheDirectory: string): void {
   ensureRuntimeDependencySymlink(cacheDirectory, "react");
 }
 
+function isPathInsideOrEqual(childPath: string, parentPath: string): boolean {
+  const child = path.resolve(childPath);
+  const parent = path.resolve(parentPath);
+  const relative = path.relative(parent, child);
+  return (
+    relative === "" ||
+    (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}
+
+function getManagedPackageImportCacheDirectory(
+  modPath: string,
+  source: LocalModSource,
+): string | null {
+  const matchingRoot = source.managedPackageRoots?.find((packageRoot) =>
+    isPathInsideOrEqual(modPath, packageRoot),
+  );
+  if (!matchingRoot) return null;
+  return path.dirname(modPath);
+}
+
 function formatTranspileDiagnostic(diagnostic: ts.Diagnostic): string {
   const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
   if (!diagnostic.file || diagnostic.start == null) {
@@ -547,18 +579,28 @@ function prepareModForImport(modPath: string, source: string): string {
 function createImportableModPath(
   modPath: string,
   cacheDirectory: string,
+  source: LocalModSource,
 ): string {
-  ensureModCache(cacheDirectory);
+  const importCacheDirectory =
+    getManagedPackageImportCacheDirectory(modPath, source) ?? cacheDirectory;
+  if (importCacheDirectory === cacheDirectory) {
+    ensureModCache(importCacheDirectory);
+  } else {
+    mkdirSync(importCacheDirectory, { recursive: true });
+  }
 
-  const source = readFileSync(modPath, "utf8");
-  const hash = createHash("sha256").update(source).digest("hex").slice(0, 16);
+  const sourceText = readFileSync(modPath, "utf8");
+  const hash = createHash("sha256")
+    .update(sourceText)
+    .digest("hex")
+    .slice(0, 16);
   const fileExtension = path.extname(modPath);
-  const importableSource = prepareModForImport(modPath, source);
+  const importableSource = prepareModForImport(modPath, sourceText);
   const baseName = path
     .basename(modPath, fileExtension)
     .replace(/[^a-zA-Z0-9_-]/g, "-");
   const importPath = path.join(
-    cacheDirectory,
+    importCacheDirectory,
     `.letta-mod-${baseName}-${hash}.mjs`,
   );
 
@@ -567,12 +609,12 @@ function createImportableModPath(
   }
 
   try {
-    for (const entry of readdirSync(cacheDirectory)) {
+    for (const entry of readdirSync(importCacheDirectory)) {
       if (
         entry.startsWith(`.letta-mod-${baseName}-`) &&
         entry !== path.basename(importPath)
       ) {
-        unlinkSync(path.join(cacheDirectory, entry));
+        unlinkSync(path.join(importCacheDirectory, entry));
       }
     }
   } catch {
@@ -1381,7 +1423,11 @@ export async function loadLocalMods(
         failurePhase = isTypeScriptModFileExtension(path.extname(modPath))
           ? "transpile"
           : "import";
-        const importPath = createImportableModPath(modPath, cacheDirectory);
+        const importPath = createImportableModPath(
+          modPath,
+          cacheDirectory,
+          source,
+        );
         failurePhase = "import";
         const module = (await import(
           `${pathToFileURL(importPath).href}?mod=${mtimeMs}`

--- a/src/mods/package-installer.test.ts
+++ b/src/mods/package-installer.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
 import {
   chmodSync,
   existsSync,
@@ -11,7 +13,13 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { installLocalManagedModPackage } from "@/mods/package-installer";
+import { PassThrough } from "node:stream";
+import {
+  __testOverrideNpmManagedModPackageInstaller,
+  installLocalManagedModPackage,
+  installNpmManagedModPackage,
+  parseNpmManagedModPackageInstallSpecifier,
+} from "@/mods/package-installer";
 
 const tempRoots: string[] = [];
 
@@ -59,6 +67,92 @@ function writeLocalPackage(params: {
   );
 }
 
+function writeInstalledNpmPackage(params: {
+  capabilities?: string[];
+  cwd: string;
+  entries?: string[];
+  includeDependency?: boolean;
+  name?: string;
+  repository?: unknown;
+  version?: string;
+  withManifest?: boolean;
+}): void {
+  const packageName = params.name ?? "@caren/my-mod";
+  const packageRoot = path.join(
+    params.cwd,
+    "node_modules",
+    ...packageName.split("/"),
+  );
+  writeLocalPackage({
+    capabilities: params.capabilities,
+    entries: params.entries,
+    name: packageName,
+    packageRoot,
+    version: params.version,
+  });
+  if (params.withManifest === false) {
+    writeFileSync(
+      path.join(packageRoot, "package.json"),
+      `${JSON.stringify(
+        {
+          name: packageName,
+          version: params.version ?? "0.1.0",
+          ...(params.repository ? { repository: params.repository } : {}),
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  } else if (params.repository) {
+    const packageJson = JSON.parse(
+      readFileSync(path.join(packageRoot, "package.json"), "utf8"),
+    ) as Record<string, unknown>;
+    packageJson.repository = params.repository;
+    writeFileSync(
+      path.join(packageRoot, "package.json"),
+      `${JSON.stringify(packageJson, null, 2)}\n`,
+    );
+  }
+  if (params.includeDependency) {
+    const dependencyRoot = path.join(params.cwd, "node_modules", "left-pad");
+    mkdirSync(dependencyRoot, { recursive: true });
+    writeFileSync(
+      path.join(dependencyRoot, "package.json"),
+      `${JSON.stringify({ name: "left-pad", version: "1.0.0" })}\n`,
+    );
+    writeFileSync(
+      path.join(dependencyRoot, "index.js"),
+      "export default 'dep';\n",
+    );
+    const binRoot = path.join(params.cwd, "node_modules", ".bin");
+    mkdirSync(binRoot, { recursive: true });
+    writeFileSync(path.join(binRoot, "left-pad"), "ignored\n");
+    const nestedDependencyRoot = path.join(
+      packageRoot,
+      "node_modules",
+      "nested-dep",
+    );
+    mkdirSync(nestedDependencyRoot, { recursive: true });
+    writeFileSync(
+      path.join(nestedDependencyRoot, "package.json"),
+      `${JSON.stringify({ name: "nested-dep", version: "1.0.0" })}\n`,
+    );
+    writeFileSync(
+      path.join(nestedDependencyRoot, "index.js"),
+      "export default 'nested';\n",
+    );
+  }
+}
+
+function createChildProcess(): ChildProcess {
+  const child = new EventEmitter() as ChildProcess;
+  Object.assign(child, {
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+  });
+  return child;
+}
+
 function readRegistry(modsRoot: string): {
   packages: Array<Record<string, unknown>>;
 } {
@@ -66,12 +160,47 @@ function readRegistry(modsRoot: string): {
 }
 
 afterEach(() => {
+  __testOverrideNpmManagedModPackageInstaller({});
   for (const dir of tempRoots.splice(0)) {
     rmSync(dir, { force: true, recursive: true });
   }
 });
 
 describe("local managed mod package installer", () => {
+  test("parses npm install specs", () => {
+    expect(
+      parseNpmManagedModPackageInstallSpecifier("npm:@caren/my-mod"),
+    ).toEqual({
+      installSpec: "@caren/my-mod",
+      packageName: "@caren/my-mod",
+      source: "npm:@caren/my-mod",
+    });
+    expect(
+      parseNpmManagedModPackageInstallSpecifier("npm:@caren/my-mod@0.2.0"),
+    ).toEqual({
+      installSpec: "@caren/my-mod@0.2.0",
+      packageName: "@caren/my-mod",
+      source: "npm:@caren/my-mod",
+      version: "0.2.0",
+    });
+    expect(parseNpmManagedModPackageInstallSpecifier("npm:my-mod")).toEqual({
+      installSpec: "my-mod",
+      packageName: "my-mod",
+      source: "npm:my-mod",
+    });
+    expect(
+      parseNpmManagedModPackageInstallSpecifier("npm:my-mod@0.2.0"),
+    ).toEqual({
+      installSpec: "my-mod@0.2.0",
+      packageName: "my-mod",
+      source: "npm:my-mod",
+      version: "0.2.0",
+    });
+    expect(() =>
+      parseNpmManagedModPackageInstallSpecifier("npm:@caren"),
+    ).toThrow("Invalid npm mod package specifier");
+  });
+
   test("installs a local package into the managed package directory", () => {
     const root = createTempDir();
     const packageRoot = path.join(root, "source");
@@ -339,6 +468,180 @@ describe("local managed mod package installer", () => {
         packageDirectory: packageRoot,
       }),
     ).toThrow("Package contains unsupported symlink");
+    expect(
+      existsSync(path.join(modsRoot, "packages", "npm", "@caren", "my-mod")),
+    ).toBe(false);
+  });
+
+  test("installs an npm package with safe npm flags", async () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    const spawnCalls: Array<{ args: string[]; cmd: string; cwd?: string }> = [];
+    __testOverrideNpmManagedModPackageInstaller({
+      platform: "linux",
+      spawnImpl: (cmd, args, options) => {
+        spawnCalls.push({ args, cmd, cwd: options.cwd?.toString() });
+        if (!options.cwd) throw new Error("expected cwd");
+        writeInstalledNpmPackage({
+          capabilities: ["commands"],
+          cwd: options.cwd.toString(),
+          includeDependency: true,
+          repository: { url: "https://github.com/caren/my-mod.git" },
+          version: "0.2.0",
+        });
+        const child = createChildProcess();
+        queueMicrotask(() => child.emit("exit", 0));
+        return child;
+      },
+    });
+
+    const result = await installNpmManagedModPackage({
+      modsRoot,
+      specifier: "npm:@caren/my-mod",
+    });
+
+    expect(spawnCalls).toEqual([
+      {
+        cmd: "npm",
+        args: [
+          "install",
+          "--ignore-scripts",
+          "--omit=dev",
+          "--no-audit",
+          "--no-fund",
+          "--package-lock=false",
+          "--no-save",
+          "@caren/my-mod",
+        ],
+        cwd: expect.any(String),
+      },
+    ]);
+    expect(result).toMatchObject({
+      capabilities: ["commands"],
+      repository: "https://github.com/caren/my-mod.git",
+      source: "npm:@caren/my-mod",
+      version: "0.2.0",
+    });
+    expect(existsSync(path.join(result.root, "mods", "index.ts"))).toBe(true);
+    expect(
+      existsSync(
+        path.join(result.root, "node_modules", "left-pad", "index.js"),
+      ),
+    ).toBe(true);
+    expect(
+      existsSync(
+        path.join(result.root, "node_modules", "nested-dep", "index.js"),
+      ),
+    ).toBe(true);
+    expect(existsSync(path.join(result.root, "node_modules", ".bin"))).toBe(
+      false,
+    );
+    expect(
+      existsSync(path.join(result.root, "node_modules", "@caren", "my-mod")),
+    ).toBe(false);
+    expect(readRegistry(modsRoot).packages).toEqual([
+      {
+        source: "npm:@caren/my-mod",
+        version: "0.2.0",
+        enabled: true,
+        root: "packages/npm/@caren/my-mod",
+        entries: ["mods/index.ts"],
+      },
+    ]);
+  });
+
+  test("installs unscoped npm packages and uses Windows npm shim", async () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    const spawnCalls: Array<{ args: string[]; cmd: string }> = [];
+    __testOverrideNpmManagedModPackageInstaller({
+      platform: "win32",
+      spawnImpl: (cmd, args, options) => {
+        spawnCalls.push({ args, cmd });
+        if (!options.cwd) throw new Error("expected cwd");
+        writeInstalledNpmPackage({
+          cwd: options.cwd.toString(),
+          name: "my-mod",
+        });
+        const child = createChildProcess();
+        queueMicrotask(() => child.emit("exit", 0));
+        return child;
+      },
+    });
+
+    const result = await installNpmManagedModPackage({
+      modsRoot,
+      specifier: "npm:my-mod@0.1.0",
+    });
+
+    expect(spawnCalls).toEqual([
+      {
+        cmd: "npm.cmd",
+        args: [
+          "install",
+          "--ignore-scripts",
+          "--omit=dev",
+          "--no-audit",
+          "--no-fund",
+          "--package-lock=false",
+          "--no-save",
+          "--no-bin-links",
+          "my-mod@0.1.0",
+        ],
+      },
+    ]);
+    expect(result).toMatchObject({
+      rootRelativePath: "packages/npm/my-mod",
+      source: "npm:my-mod",
+    });
+  });
+
+  test("npm install failure does not write registry", async () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    __testOverrideNpmManagedModPackageInstaller({
+      spawnImpl: () => {
+        const child = createChildProcess();
+        queueMicrotask(() => {
+          child.stderr?.emit("data", "not found");
+          child.emit("exit", 1);
+        });
+        return child;
+      },
+    });
+
+    await expect(
+      installNpmManagedModPackage({
+        modsRoot,
+        specifier: "npm:@caren/missing-mod",
+      }),
+    ).rejects.toThrow("npm install failed with code 1: not found");
+    expect(existsSync(path.join(modsRoot, "packages.json"))).toBe(false);
+  });
+
+  test("npm packages without letta manifests fail without writing", async () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    __testOverrideNpmManagedModPackageInstaller({
+      spawnImpl: (_cmd, _args, options) => {
+        if (!options.cwd) throw new Error("expected cwd");
+        writeInstalledNpmPackage({
+          cwd: options.cwd.toString(),
+          withManifest: false,
+        });
+        const child = createChildProcess();
+        queueMicrotask(() => child.emit("exit", 0));
+        return child;
+      },
+    });
+
+    await expect(
+      installNpmManagedModPackage({
+        modsRoot,
+        specifier: "npm:@caren/my-mod",
+      }),
+    ).rejects.toThrow("Package does not include a package.json#letta manifest");
+    expect(existsSync(path.join(modsRoot, "packages.json"))).toBe(false);
     expect(
       existsSync(path.join(modsRoot, "packages", "npm", "@caren", "my-mod")),
     ).toBe(false);

--- a/src/mods/package-installer.test.ts
+++ b/src/mods/package-installer.test.ts
@@ -199,6 +199,18 @@ describe("local managed mod package installer", () => {
     expect(() =>
       parseNpmManagedModPackageInstallSpecifier("npm:@caren"),
     ).toThrow("Invalid npm mod package specifier");
+    expect(() =>
+      parseNpmManagedModPackageInstallSpecifier("npm:alias@npm:other"),
+    ).toThrow("Invalid npm package version or tag");
+    expect(() =>
+      parseNpmManagedModPackageInstallSpecifier("npm:my-mod@file:.."),
+    ).toThrow("Invalid npm package version or tag");
+    expect(() =>
+      parseNpmManagedModPackageInstallSpecifier("npm:my-mod@../local"),
+    ).toThrow();
+    expect(() =>
+      parseNpmManagedModPackageInstallSpecifier("npm:my-mod@foo\\bar"),
+    ).toThrow("Invalid npm package version or tag");
   });
 
   test("installs a local package into the managed package directory", () => {

--- a/src/mods/package-installer.ts
+++ b/src/mods/package-installer.ts
@@ -1,4 +1,9 @@
 import {
+  type ChildProcess,
+  type SpawnOptions,
+  spawn,
+} from "node:child_process";
+import {
   copyFileSync,
   existsSync,
   lstatSync,
@@ -10,6 +15,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   type LettaPackageCapability,
@@ -18,6 +24,7 @@ import {
 import {
   getManagedModPackageRootRelativePathForSource,
   MOD_PACKAGES_DIRECTORY_NAME,
+  parseManagedNpmPackageSource,
   upsertManagedModPackage,
   validateManagedModPackageRegistryForMutation,
 } from "@/mods/package-registry";
@@ -27,13 +34,48 @@ export interface InstallLocalManagedModPackageResult {
   entries: string[];
   packageDirectory: string;
   registryPath: string;
+  repository?: string;
   root: string;
   rootRelativePath: string;
   source: string;
   version: string;
 }
 
+export interface NpmManagedModPackageInstallSpecifier {
+  installSpec: string;
+  packageName: string;
+  source: string;
+  version?: string;
+}
+
+interface PackageSourceInfo {
+  capabilities: LettaPackageCapability[];
+  entries: string[];
+  packageDirectory: string;
+  packageName: string;
+  repository?: string;
+  rootRelativePath: string;
+  source: string;
+  version: string;
+}
+
+interface InstallPreparedManagedModPackageParams {
+  dependencyNodeModulesDirectory?: string;
+  enabled?: boolean;
+  modsRoot: string;
+  packageDirectory: string;
+}
+
+type NpmInstallProcessFactory = (
+  command: string,
+  args: string[],
+  options: SpawnOptions,
+) => ChildProcess;
+
 const SKIPPED_PACKAGE_COPY_NAMES = new Set([".git", "node_modules"]);
+
+let spawnNpmInstallProcess: NpmInstallProcessFactory = spawn;
+let platformOverride: NodeJS.Platform | null = null;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -62,6 +104,18 @@ function readPackageJson(packageJsonPath: string): Record<string, unknown> {
     throw new Error("package.json must be an object");
   }
   return parsed;
+}
+
+function formatRepository(repository: unknown): string | undefined {
+  if (typeof repository === "string") {
+    const trimmed = repository.trim();
+    return trimmed || undefined;
+  }
+  if (!isRecord(repository)) return undefined;
+  const url = repository.url;
+  if (typeof url !== "string") return undefined;
+  const trimmed = url.trim();
+  return trimmed || undefined;
 }
 
 export function isLocalLettaModPackageDirectory(
@@ -122,14 +176,7 @@ function validateManifestEntriesExist(
   }
 }
 
-function validatePackageSource(packageDirectory: string): {
-  capabilities: LettaPackageCapability[];
-  entries: string[];
-  packageDirectory: string;
-  rootRelativePath: string;
-  source: string;
-  version: string;
-} {
+function validatePackageSource(packageDirectory: string): PackageSourceInfo {
   const resolvedPackageDirectory = path.resolve(packageDirectory);
   let packageStats: ReturnType<typeof lstatSync>;
   try {
@@ -153,9 +200,10 @@ function validatePackageSource(packageDirectory: string): {
     throw new Error("package.json.name must be a valid npm package name");
   }
   const source = `npm:${name.trim()}`;
+  const packageName = parseManagedNpmPackageSource(source);
   const rootRelativePath =
     getManagedModPackageRootRelativePathForSource(source);
-  if (!rootRelativePath) {
+  if (!packageName || !rootRelativePath) {
     throw new Error("package.json.name must be a valid npm package name");
   }
 
@@ -179,11 +227,14 @@ function validatePackageSource(packageDirectory: string): {
     resolvedPackageDirectory,
     manifestResult.manifest.mods,
   );
+  const repository = formatRepository(packageJson.repository);
 
   return {
     capabilities: manifestResult.manifest.capabilities ?? [],
     entries: manifestResult.manifest.mods,
     packageDirectory: resolvedPackageDirectory,
+    packageName,
+    ...(repository ? { repository } : {}),
     rootRelativePath,
     source,
     version: version.trim(),
@@ -213,6 +264,94 @@ function copyPackageDirectory(sourceRoot: string, targetRoot: string): void {
       `Package contains unsupported filesystem entry: ${sourcePath}`,
     );
   }
+}
+
+function shouldSkipDependencyPath(
+  relativeParts: string[],
+  installedPackageName?: string,
+): boolean {
+  if (relativeParts.includes(".bin")) return true;
+  if (!installedPackageName) return false;
+  const packageParts = installedPackageName.split("/");
+  return (
+    relativeParts.length >= packageParts.length &&
+    packageParts.every((part, index) => relativeParts[index] === part)
+  );
+}
+
+function copyDependencyDirectoryFiltered(params: {
+  installedPackageName?: string;
+  relativeParts?: string[];
+  sourceRoot: string;
+  targetRoot: string;
+}): boolean {
+  let copied = false;
+  const relativeParts = params.relativeParts ?? [];
+  for (const entry of readdirSync(params.sourceRoot, { withFileTypes: true })) {
+    const nextRelativeParts = [...relativeParts, entry.name];
+    if (
+      shouldSkipDependencyPath(nextRelativeParts, params.installedPackageName)
+    ) {
+      continue;
+    }
+
+    const sourcePath = path.join(params.sourceRoot, entry.name);
+    const targetPath = path.join(params.targetRoot, entry.name);
+    const stats = lstatSync(sourcePath);
+    if (stats.isSymbolicLink()) {
+      throw new Error(
+        `Package dependency contains unsupported symlink: ${sourcePath}`,
+      );
+    }
+    if (stats.isDirectory()) {
+      const copiedChild = copyDependencyDirectoryFiltered({
+        installedPackageName: params.installedPackageName,
+        relativeParts: nextRelativeParts,
+        sourceRoot: sourcePath,
+        targetRoot: targetPath,
+      });
+      copied ||= copiedChild;
+      continue;
+    }
+    if (stats.isFile()) {
+      mkdirSync(path.dirname(targetPath), { recursive: true });
+      copyFileSync(sourcePath, targetPath);
+      copied = true;
+      continue;
+    }
+    throw new Error(
+      `Package dependency contains unsupported filesystem entry: ${sourcePath}`,
+    );
+  }
+  return copied;
+}
+
+function copyDependencyNodeModules(params: {
+  installedPackageName: string;
+  sourceNodeModulesDirectory: string;
+  targetPackageRoot: string;
+}): void {
+  if (!existsSync(params.sourceNodeModulesDirectory)) return;
+  copyDependencyDirectoryFiltered({
+    installedPackageName: params.installedPackageName,
+    sourceRoot: params.sourceNodeModulesDirectory,
+    targetRoot: path.join(params.targetPackageRoot, "node_modules"),
+  });
+}
+
+function copyPackageInternalNodeModules(params: {
+  packageDirectory: string;
+  targetPackageRoot: string;
+}): void {
+  const sourceNodeModulesDirectory = path.join(
+    params.packageDirectory,
+    "node_modules",
+  );
+  if (!existsSync(sourceNodeModulesDirectory)) return;
+  copyDependencyDirectoryFiltered({
+    sourceRoot: sourceNodeModulesDirectory,
+    targetRoot: path.join(params.targetPackageRoot, "node_modules"),
+  });
 }
 
 function restoreRegistry(
@@ -265,10 +404,9 @@ function makeSiblingTempDirectory(
   return mkdtempSync(path.join(parent, `.${baseName}.${label}-`));
 }
 
-export function installLocalManagedModPackage(params: {
-  modsRoot: string;
-  packageDirectory: string;
-}): InstallLocalManagedModPackageResult {
+function installPreparedManagedModPackage(
+  params: InstallPreparedManagedModPackageParams,
+): InstallLocalManagedModPackageResult {
   const packageInfo = validatePackageSource(params.packageDirectory);
   const packagesRoot = path.resolve(
     params.modsRoot,
@@ -301,6 +439,17 @@ export function installLocalManagedModPackage(params: {
 
   try {
     copyPackageDirectory(packageInfo.packageDirectory, stagingRoot);
+    if (params.dependencyNodeModulesDirectory) {
+      copyDependencyNodeModules({
+        installedPackageName: packageInfo.packageName,
+        sourceNodeModulesDirectory: params.dependencyNodeModulesDirectory,
+        targetPackageRoot: stagingRoot,
+      });
+      copyPackageInternalNodeModules({
+        packageDirectory: packageInfo.packageDirectory,
+        targetPackageRoot: stagingRoot,
+      });
+    }
     if (existsSync(destinationRoot)) {
       backupRoot = makeSiblingTempDirectory(destinationRoot, "backup");
       rmSync(backupRoot, { force: true, recursive: true });
@@ -313,6 +462,7 @@ export function installLocalManagedModPackage(params: {
 
     try {
       const upsertResult = upsertManagedModPackage({
+        enabled: params.enabled ?? true,
         entries: packageInfo.entries,
         modsRoot: params.modsRoot,
         source: packageInfo.source,
@@ -325,6 +475,9 @@ export function installLocalManagedModPackage(params: {
         capabilities: packageInfo.capabilities,
         entries: packageInfo.entries,
         packageDirectory: packageInfo.packageDirectory,
+        ...(packageInfo.repository
+          ? { repository: packageInfo.repository }
+          : {}),
         registryPath: upsertResult.registryPath,
         root: destinationRoot,
         rootRelativePath: packageInfo.rootRelativePath,
@@ -348,4 +501,154 @@ export function installLocalManagedModPackage(params: {
     }
     throw error;
   }
+}
+
+function getNpmExecutable(): string {
+  return (platformOverride ?? process.platform) === "win32" ? "npm.cmd" : "npm";
+}
+
+function getNpmInstallArgs(installSpec: string): string[] {
+  return [
+    "install",
+    "--ignore-scripts",
+    "--omit=dev",
+    "--no-audit",
+    "--no-fund",
+    "--package-lock=false",
+    "--no-save",
+    ...((platformOverride ?? process.platform) === "win32"
+      ? ["--no-bin-links"]
+      : []),
+    installSpec,
+  ];
+}
+
+function writeNpmInstallManifest(tempRoot: string): void {
+  writeFileSync(
+    path.join(tempRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        private: true,
+        name: "letta-managed-mod-install",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+function runNpmInstall(params: {
+  installSpec: string;
+  tempRoot: string;
+}): Promise<void> {
+  const command = getNpmExecutable();
+  const args = getNpmInstallArgs(params.installSpec);
+  return new Promise((resolve, reject) => {
+    const child = spawnNpmInstallProcess(command, args, {
+      cwd: params.tempRoot,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    child.stdout?.on("data", (chunk) => {
+      stdout.push(String(chunk));
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr.push(String(chunk));
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      const details = stderr.join("").trim() || stdout.join("").trim();
+      reject(
+        new Error(
+          `npm install failed with code ${code ?? "unknown"}${details ? `: ${details}` : ""}`,
+        ),
+      );
+    });
+  });
+}
+
+function getInstalledPackageDirectory(
+  nodeModulesDirectory: string,
+  packageName: string,
+): string {
+  return path.join(nodeModulesDirectory, ...packageName.split("/"));
+}
+
+export function parseNpmManagedModPackageInstallSpecifier(
+  specifier: string,
+): NpmManagedModPackageInstallSpecifier {
+  const trimmed = specifier.trim();
+  if (!trimmed.startsWith("npm:")) {
+    throw new Error(`Invalid npm mod package specifier: ${specifier}`);
+  }
+
+  const slashIndex = trimmed.lastIndexOf("/");
+  const atIndex = trimmed.lastIndexOf("@");
+  let source = trimmed;
+  let version: string | undefined;
+  if (atIndex > "npm:".length && atIndex > slashIndex) {
+    source = trimmed.slice(0, atIndex);
+    version = trimmed.slice(atIndex + 1);
+    if (!version) {
+      throw new Error(`Invalid npm mod package specifier: ${specifier}`);
+    }
+  }
+
+  const packageName = parseManagedNpmPackageSource(source);
+  if (!packageName) {
+    throw new Error(`Invalid npm mod package specifier: ${specifier}`);
+  }
+  return {
+    installSpec: version ? `${packageName}@${version}` : packageName,
+    packageName,
+    source,
+    ...(version ? { version } : {}),
+  };
+}
+
+export function installLocalManagedModPackage(params: {
+  modsRoot: string;
+  packageDirectory: string;
+}): InstallLocalManagedModPackageResult {
+  return installPreparedManagedModPackage(params);
+}
+
+export async function installNpmManagedModPackage(params: {
+  modsRoot: string;
+  specifier: string;
+}): Promise<InstallLocalManagedModPackageResult> {
+  const parsed = parseNpmManagedModPackageInstallSpecifier(params.specifier);
+  const tempRoot = mkdtempSync(path.join(tmpdir(), "letta-mod-npm-"));
+  try {
+    writeNpmInstallManifest(tempRoot);
+    await runNpmInstall({
+      installSpec: parsed.installSpec,
+      tempRoot,
+    });
+    const nodeModulesDirectory = path.join(tempRoot, "node_modules");
+    const packageDirectory = getInstalledPackageDirectory(
+      nodeModulesDirectory,
+      parsed.packageName,
+    );
+    return installPreparedManagedModPackage({
+      dependencyNodeModulesDirectory: nodeModulesDirectory,
+      modsRoot: params.modsRoot,
+      packageDirectory,
+    });
+  } finally {
+    rmSync(tempRoot, { force: true, recursive: true });
+  }
+}
+
+export function __testOverrideNpmManagedModPackageInstaller(params: {
+  platform?: NodeJS.Platform | null;
+  spawnImpl?: NpmInstallProcessFactory | null;
+}): void {
+  spawnNpmInstallProcess = params.spawnImpl ?? spawn;
+  platformOverride = params.platform ?? null;
 }

--- a/src/mods/package-installer.ts
+++ b/src/mods/package-installer.ts
@@ -579,6 +579,12 @@ function getInstalledPackageDirectory(
   return path.join(nodeModulesDirectory, ...packageName.split("/"));
 }
 
+function isPlainNpmVersionOrTag(value: string): boolean {
+  if (!value.trim()) return false;
+  if (value !== value.trim()) return false;
+  return !/[\s:/\\]/.test(value);
+}
+
 export function parseNpmManagedModPackageInstallSpecifier(
   specifier: string,
 ): NpmManagedModPackageInstallSpecifier {
@@ -596,6 +602,9 @@ export function parseNpmManagedModPackageInstallSpecifier(
     version = trimmed.slice(atIndex + 1);
     if (!version) {
       throw new Error(`Invalid npm mod package specifier: ${specifier}`);
+    }
+    if (!isPlainNpmVersionOrTag(version)) {
+      throw new Error(`Invalid npm package version or tag: ${version}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- add `letta install npm:<package>` for managed mod package installs
- run npm with safer install defaults and reuse managed package rollback/upsert behavior
- load managed package entries from package-local cache paths so package dependencies resolve

## Test plan
- `bun test src/mods/package-installer.test.ts`
- `bun test src/cli/subcommands/skills.test.ts`
- `bun test src/cli/mods/local-mod-loader.test.ts`
- `bun test src/mods/package-registry.test.ts`
- `bun test src/cli/subcommands/mods.test.ts`
- `bun test src/mods/mod-engine.test.ts`
- `bun run typecheck`
- `bun run check`
