### PR TITLE
feat(reflection): auto-trigger multi-convo reflection

### DIFF
--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -3234,6 +3234,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
                           },
                           instruction: reflectArgs.instruction,
                           systemPrompt,
+                          rangeMode: "replay",
                         });
                       if (!autoReflectionPayload) {
                         releaseReflectionReservation();
@@ -3250,6 +3251,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
                         instruction: reflectArgs.instruction,
                         memoryDir,
                         parentMemory,
+                        mode: "multi",
                       });
 
                       spawnBackgroundSubagentTask({
@@ -3371,6 +3373,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
               instruction: reflectArgs.instruction,
               memoryDir,
               parentMemory,
+              mode: "multi",
             });
 
             const {

--- a/src/cli/helpers/reflection-launcher.ts
+++ b/src/cli/helpers/reflection-launcher.ts
@@ -22,7 +22,7 @@ export const AUTO_META_REFLECTION_INTERVAL = 10;
 export const AUTO_META_REFLECTION_RECENT_LIMIT = 10;
 
 const AUTO_META_REFLECTION_INSTRUCTION =
-  "This is an automatic meta-reflection triggered after 10 successful reflection passes. Synthesize across the included recent reflected conversations: look for repeated durable user preferences, recurring agent mistakes, contradictions or stale memory, and cross-session patterns. Avoid storing one-off task state.";
+  "This is an automatic meta-reflection triggered after 10 successful reflection passes; the included conversations were already reflected on individually, so focus on higher-level patterns that only emerge across them.";
 
 /** Max background wait for the reflection subagent's agent ID before emitting `reflection_start` (previously 1s inline, timed out ~100% of the time). */
 export const REFLECTION_AGENT_ID_WAIT_MS = 30_000;

--- a/src/cli/helpers/reflection-launcher.ts
+++ b/src/cli/helpers/reflection-launcher.ts
@@ -183,6 +183,7 @@ async function launchMetaReflectionSubagent(
       },
       instruction: AUTO_META_REFLECTION_INSTRUCTION,
       systemPrompt: options.systemPrompt,
+      rangeMode: "replay",
     });
     if (!reflectionPayload) {
       releaseReflectionLaunch(agentId);
@@ -195,6 +196,7 @@ async function launchMetaReflectionSubagent(
       instruction: AUTO_META_REFLECTION_INSTRUCTION,
       memoryDir,
       parentMemory,
+      mode: "multi",
     });
 
     const { spawnBackgroundSubagentTask, waitForBackgroundSubagentAgentId } =

--- a/src/cli/helpers/reflection-launcher.ts
+++ b/src/cli/helpers/reflection-launcher.ts
@@ -5,15 +5,24 @@ import type { ReflectionTrigger } from "@/cli/helpers/memory-reminder";
 import { handleMemorySubagentCompletion } from "@/cli/helpers/memory-subagent-completion";
 import {
   buildAutoReflectionPayload,
+  buildMultiReflectionPayload,
   buildParentMemorySnapshot,
   buildReflectionSubagentPrompt,
   finalizeAutoReflectionPayload,
+  finalizeMultiReflectionPayload,
+  recordMetaReflectionResult,
+  recordSuccessfulReflectionForMetaTrigger,
 } from "@/cli/helpers/reflection-transcript";
 import { telemetry } from "@/telemetry";
 import { maybeSendReflectionThresholdFeedback } from "@/telemetry/reflection-threshold-feedback";
 import { debugLog, debugWarn } from "@/utils/debug";
 
 export const AUTO_REFLECTION_DESCRIPTION = "Reflect on recent conversations";
+export const AUTO_META_REFLECTION_INTERVAL = 10;
+export const AUTO_META_REFLECTION_RECENT_LIMIT = 10;
+
+const AUTO_META_REFLECTION_INSTRUCTION =
+  "This is an automatic meta-reflection triggered after 10 successful reflection passes. Synthesize across the included recent reflected conversations: look for repeated durable user preferences, recurring agent mistakes, contradictions or stale memory, and cross-session patterns. Avoid storing one-off task state.";
 
 /** Max background wait for the reflection subagent's agent ID before emitting `reflection_start` (previously 1s inline, timed out ~100% of the time). */
 export const REFLECTION_AGENT_ID_WAIT_MS = 30_000;
@@ -22,6 +31,7 @@ const reservedReflectionAgentIds = new Set<string>();
 
 export type ReflectionLaunchTriggerSource =
   | "manual"
+  | "meta-reflection"
   | Exclude<ReflectionTrigger, "off">;
 
 export type ReflectionLaunchSkippedReason =
@@ -138,6 +148,169 @@ function resolveCompletionConversationId(
   return completionConversationId ?? fallback;
 }
 
+async function launchMetaReflectionSubagent(
+  options: ReflectionLaunchOptions & { systemPrompt?: string },
+): Promise<ReflectionLaunchResult> {
+  const {
+    agentId,
+    conversationId,
+    memfsEnabled,
+    recompileByConversation,
+    recompileQueuedByConversation,
+    onCompletionMessage,
+  } = options;
+  const triggerSource: ReflectionLaunchTriggerSource = "meta-reflection";
+
+  if (!memfsEnabled) {
+    return { launched: false, reason: "memfs_disabled" };
+  }
+
+  if (!tryReserveReflectionLaunch(agentId)) {
+    debugLog(
+      "memory",
+      "Skipping meta-reflection launch because a reflection is already active",
+    );
+    return { launched: false, reason: "already_active" };
+  }
+
+  let releaseOnComplete = false;
+  try {
+    const reflectionPayload = await buildMultiReflectionPayload({
+      agentId,
+      selectionPolicy: {
+        mode: "recent",
+        limit: AUTO_META_REFLECTION_RECENT_LIMIT,
+      },
+      instruction: AUTO_META_REFLECTION_INSTRUCTION,
+      systemPrompt: options.systemPrompt,
+    });
+    if (!reflectionPayload) {
+      releaseReflectionLaunch(agentId);
+      return { launched: false, reason: "no_payload" };
+    }
+
+    const memoryDir = getScopedMemoryFilesystemRoot(agentId);
+    const parentMemory = await buildParentMemorySnapshot(memoryDir);
+    const reflectionPrompt = buildReflectionSubagentPrompt({
+      instruction: AUTO_META_REFLECTION_INSTRUCTION,
+      memoryDir,
+      parentMemory,
+    });
+
+    const { spawnBackgroundSubagentTask, waitForBackgroundSubagentAgentId } =
+      await import("@/tools/impl/task");
+
+    const emitReflectionStart = (resolvedAgentId: string | null) => {
+      telemetry.trackReflectionStart(triggerSource, {
+        subagentId: resolvedAgentId ?? undefined,
+        conversationId,
+        startMessageId: reflectionPayload.startMessageId,
+        endMessageId: reflectionPayload.endMessageId,
+      });
+      drainReflectionTelemetry();
+    };
+
+    const { subagentId } = spawnBackgroundSubagentTask({
+      subagentType: "reflection",
+      prompt: reflectionPrompt,
+      description: "Meta-reflect on recent reflections",
+      silentCompletion: true,
+      transcriptPath: reflectionPayload.payloadPath,
+      parentScope: { agentId, conversationId },
+      onComplete: async ({
+        success,
+        error,
+        agentId: reflectionAgentId,
+        stepCount,
+        durationMs,
+      }) => {
+        try {
+          telemetry.trackReflectionEnd(triggerSource, success, {
+            subagentId: reflectionAgentId ?? undefined,
+            conversationId,
+            error,
+            stepCount,
+            durationMs,
+          });
+          drainReflectionTelemetry();
+          await finalizeMultiReflectionPayload(
+            agentId,
+            reflectionPayload.manifest,
+            success,
+          );
+          await recordMetaReflectionResult(agentId, success);
+
+          const completionMessage = await handleMemorySubagentCompletion(
+            {
+              agentId,
+              conversationId: resolveCompletionConversationId(
+                options.completionConversationId,
+                conversationId,
+              ),
+              subagentType: "reflection",
+              success,
+              error,
+              subagentAgentId: reflectionAgentId ?? undefined,
+            },
+            {
+              recompileByConversation,
+              recompileQueuedByConversation,
+              logRecompileFailure: (message) => debugWarn("memory", message),
+            },
+          );
+          await onCompletionMessage?.(completionMessage, {
+            success,
+            error,
+            reflectionAgentId: reflectionAgentId ?? undefined,
+          });
+        } finally {
+          releaseReflectionLaunch(agentId);
+        }
+      },
+    });
+    releaseOnComplete = true;
+
+    void waitForBackgroundSubagentAgentId(
+      subagentId,
+      REFLECTION_AGENT_ID_WAIT_MS,
+    )
+      .then((resolvedAgentId) => emitReflectionStart(resolvedAgentId))
+      .catch((err) => {
+        debugWarn(
+          "memory",
+          `Failed waiting for meta-reflection agent ID: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+        emitReflectionStart(null);
+      });
+
+    debugLog("memory", "Launched meta-reflection subagent");
+    await onCompletionMessage?.(
+      `Automatic meta-reflection triggered after ${AUTO_META_REFLECTION_INTERVAL} successful reflection passes. Payload: ${reflectionPayload.payloadPath}`,
+      { success: true },
+    );
+    return {
+      launched: true,
+      payloadPath: reflectionPayload.payloadPath,
+      subagentId,
+      startMessageId: reflectionPayload.startMessageId,
+      endMessageId: reflectionPayload.endMessageId,
+    };
+  } catch (error) {
+    if (!releaseOnComplete) {
+      releaseReflectionLaunch(agentId);
+    }
+    debugWarn(
+      "memory",
+      `Failed to launch meta-reflection subagent: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return { launched: false, reason: "error", error };
+  }
+}
+
 export async function launchReflectionSubagent(
   options: ReflectionLaunchOptions,
 ): Promise<ReflectionLaunchResult> {
@@ -220,6 +393,7 @@ export async function launchReflectionSubagent(
         stepCount,
         durationMs,
       }) => {
+        let shouldLaunchMetaReflection = false;
         try {
           telemetry.trackReflectionEnd(triggerSource, success, {
             subagentId: reflectionAgentId ?? undefined,
@@ -251,6 +425,12 @@ export async function launchReflectionSubagent(
             autoPayload.endSnapshotLine,
             success,
           );
+          if (success && triggerSource !== "meta-reflection") {
+            ({ shouldLaunchMetaReflection } =
+              await recordSuccessfulReflectionForMetaTrigger(agentId, {
+                interval: AUTO_META_REFLECTION_INTERVAL,
+              }));
+          }
 
           const completionMessage = await handleMemorySubagentCompletion(
             {
@@ -277,6 +457,14 @@ export async function launchReflectionSubagent(
           });
         } finally {
           releaseReflectionLaunch(agentId);
+          if (shouldLaunchMetaReflection) {
+            void launchMetaReflectionSubagent({
+              ...options,
+              systemPrompt,
+              triggerSource: "meta-reflection",
+              description: "Meta-reflect on recent reflections",
+            });
+          }
         }
       },
     });

--- a/src/cli/helpers/reflection-transcript.ts
+++ b/src/cli/helpers/reflection-transcript.ts
@@ -198,38 +198,68 @@ export interface ReflectionAutoPayload {
   candidates: ReflectionAutoCandidates;
 }
 
+export type ReflectionPromptMode = "standard" | "multi";
+
 export interface ReflectionPromptInput {
   instruction?: string;
   memoryDir: string;
   parentMemory?: string;
+  mode?: ReflectionPromptMode;
+}
+
+function buildReflectionPayloadInstructions(): string[] {
+  return [
+    "Review the conversation transcript payload and update memory files. The payload path is available as the `$TRANSCRIPT_PATH` env var — read it via Bash (e.g. `cat $TRANSCRIPT_PATH`). Note: `$TRANSCRIPT_PATH` only expands in shell commands; Edit/Read/Write `file_path` is literal and does NOT expand env vars.",
+    "",
+  ];
+}
+
+function buildMultiReflectionInstructions(): string[] {
+  return [
+    'The payload is a `multi_transcript_reflection_payload` manifest. Read each `payload_path` listed in `transcripts` and synthesize across all conversations. Entries with `mode: "replay"` were already reflected before and are included intentionally for re-review/deduplication; do not skip them',
+    "Synthesize across conversations and prioritize durable, cross-conversation signal over one-off task state, especially patterns that recur across multiple conversations:",
+    "- Memory failures: things the agent repeatedly forgets or fails to apply despite existing memory.",
+    "- Repeated corrections and recurring agent failure modes across sessions.",
+    "- Personalization opportunities: lasting user preferences, style, and workflow conventions.",
+    "- Skill generation: ONLY for reusable, durable, multi-step workflows, especially ones seen across conversations.",
+    "- Proactive cleanup and memory hygiene: resolve contradictions at the source, deduplicate, prune stale or too-verbose content, move memory to the right tier, split bulky files, and fix weak cross-references.",
+    "Prefer fewer, higher-confidence updates. Low-signal transcripts can support deduplication or contradiction resolution, but should not create durable memory by themselves.",
+    "",
+  ];
+}
+
+function buildReflectionMemoryFilesystemInstructions(memoryDir: string): string[] {
+  return [
+    `The primary agent's memory filesystem is located at: ${memoryDir}`,
+    "In-context memory (in the parent agent's system prompt) is stored in the `system/` folder and are rendered in <memory> tags below. Modification to files in `system/` will edit the parent agent's system prompt.",
+    "Additional memory files (such as skills and external memory) may also be read and modified.",
+    "",
+  ];
+}
+
+function buildReflectionUserInstruction(input: ReflectionPromptInput): string[] {
+  if (!input.instruction?.trim()) {
+    return [];
+  }
+
+  return [
+    "Additional user-provided reflection instruction:",
+    input.instruction.trim(),
+    "",
+    "Use this instruction to focus what you look for, but still only persist durable memory-worthy learnings and do not store transient task state.",
+    "",
+  ];
 }
 
 export function buildReflectionSubagentPrompt(
   input: ReflectionPromptInput,
 ): string {
-  const lines: string[] = [];
-
-  lines.push(
-    "Review the conversation transcript payload and update memory files. The payload path is available as the `$TRANSCRIPT_PATH` env var — read it via Bash (e.g. `cat $TRANSCRIPT_PATH`). Note: `$TRANSCRIPT_PATH` only expands in shell commands; Edit/Read/Write `file_path` is literal and does NOT expand env vars.",
-    "",
-    'The payload may be either a JSON message array for one conversation or a `multi_transcript_reflection_payload` manifest. If it is a manifest, read each `payload_path` listed in `transcripts` and synthesize across all conversations. Entries with `mode: "replay"` were already reflected before and are included intentionally for re-review/deduplication; do not ignore them just because they are replay slices.',
-    "When reviewing multiple transcripts, prefer durable patterns and latest evidence across sessions. Resolve contradictions by updating stale memory at the source, deduplicate repeated facts, and avoid storing one-off task state.",
-    "",
-    `The primary agent's memory filesystem is located at: ${input.memoryDir}`,
-    "In-context memory (in the parent agent's system prompt) is stored in the `system/` folder and are rendered in <memory> tags below. Modification to files in `system/` will edit the parent agent's system prompt.",
-    "Additional memory files (such as skills and external memory) may also be read and modified.",
-    "",
-  );
-
-  if (input.instruction?.trim()) {
-    lines.push(
-      "Additional user-provided reflection instruction:",
-      input.instruction.trim(),
-      "",
-      "Use this instruction to focus what you look for, but still only persist durable memory-worthy learnings and do not store transient task state.",
-      "",
-    );
-  }
+  const lines: string[] = [
+    ...buildReflectionPayloadInstructions(),
+    ...(input.mode === "multi" ? buildMultiReflectionInstructions() : []),
+    ...buildReflectionMemoryFilesystemInstructions(input.memoryDir),
+    ...buildReflectionUserInstruction(input),
+  ];
 
   if (input.parentMemory) {
     lines.push(input.parentMemory);
@@ -1863,6 +1893,8 @@ type MultiReflectionSelectionPolicy =
       candidatesPath?: string;
     };
 
+export type MultiReflectionRangeMode = "unreflected-first" | "replay";
+
 export interface BuildMultiReflectionPayloadOptions {
   agentId: string;
   instruction?: string;
@@ -1870,6 +1902,7 @@ export interface BuildMultiReflectionPayloadOptions {
   systemPrompt?: string;
   maxReplayTurnsPerConversation?: number;
   maxTotalChars?: number;
+  rangeMode?: MultiReflectionRangeMode;
 }
 
 async function resolveMultiReflectionConversationIds(
@@ -1940,6 +1973,7 @@ export async function buildMultiReflectionPayload(
     systemPrompt,
     maxReplayTurnsPerConversation = 50,
     maxTotalChars = 150_000,
+    rangeMode = "unreflected-first",
   } = options;
   const conversationIds = await resolveMultiReflectionConversationIds(
     agentId,
@@ -1966,16 +2000,21 @@ export async function buildMultiReflectionPayload(
       const lines = await readTranscriptLines(paths);
       const rows = parseTranscriptRows(lines);
       const state = await readState(paths);
-      const unreflectedSelection = selectUnreflectedTranscriptRange(
+      const replaySelection = selectReplayTranscriptRange(
         rows,
-        state.reflected_through_message_id,
+        maxReplayTurnsPerConversation,
       );
+      const unreflectedSelection =
+        rangeMode === "unreflected-first"
+          ? selectUnreflectedTranscriptRange(
+              rows,
+              state.reflected_through_message_id,
+            )
+          : null;
       const mode: ReflectionSliceMode = unreflectedSelection
         ? "unreflected"
         : "replay";
-      const selection =
-        unreflectedSelection ??
-        selectReplayTranscriptRange(rows, maxReplayTurnsPerConversation);
+      const selection = unreflectedSelection ?? replaySelection;
       if (!selection) {
         return null;
       }

--- a/src/cli/helpers/reflection-transcript.ts
+++ b/src/cli/helpers/reflection-transcript.ts
@@ -26,6 +26,8 @@ const TRANSCRIPT_ROOT_ENV = "LETTA_TRANSCRIPT_ROOT";
 const DEFAULT_TRANSCRIPT_DIR = "transcripts";
 const LEGACY_MESSAGE_ID_STATE_SCHEMA_VERSION = "v2_message_id";
 export const REFLECTION_STATE_SCHEMA_VERSION = "v3_assistant_steps" as const;
+const META_REFLECTION_COUNTER_SCHEMA_VERSION =
+  "v1_meta_reflection_counter" as const;
 
 export interface ReflectionTranscriptState {
   schema_version: typeof REFLECTION_STATE_SCHEMA_VERSION;
@@ -35,6 +37,16 @@ export interface ReflectionTranscriptState {
   steps_since_last_successful_reflection: number;
   last_reflection_started_at?: string;
   last_reflection_succeeded_at?: string;
+}
+
+export interface MetaReflectionCounterState {
+  schema_version: "v1_meta_reflection_counter";
+  successful_reflections_since_last_meta_reflection: number;
+  total_successful_reflections: number;
+  total_successful_meta_reflections: number;
+  last_successful_reflection_at?: string;
+  last_meta_reflection_started_at?: string;
+  last_meta_reflection_succeeded_at?: string;
 }
 
 interface LegacyMessageIdReflectionTranscriptState {
@@ -1018,6 +1030,117 @@ function buildPayloadPath(
 
 function getAgentTranscriptRoot(agentId: string): string {
   return join(getTranscriptRoot(), sanitizePathSegment(agentId));
+}
+
+function getMetaReflectionCounterStatePath(agentId: string): string {
+  return join(getAgentTranscriptRoot(agentId), "meta-reflection-state.json");
+}
+
+function getMetaReflectionCounterLockPath(agentId: string): string {
+  return join(getAgentTranscriptRoot(agentId), "meta-reflection-state.lock");
+}
+
+function normalizeMetaReflectionCounterState(
+  parsed: Partial<MetaReflectionCounterState> | null,
+): MetaReflectionCounterState {
+  return {
+    schema_version: META_REFLECTION_COUNTER_SCHEMA_VERSION,
+    successful_reflections_since_last_meta_reflection:
+      normalizeNonNegativeInteger(
+        parsed?.successful_reflections_since_last_meta_reflection,
+      ),
+    total_successful_reflections: normalizeNonNegativeInteger(
+      parsed?.total_successful_reflections,
+    ),
+    total_successful_meta_reflections: normalizeNonNegativeInteger(
+      parsed?.total_successful_meta_reflections,
+    ),
+    last_successful_reflection_at: normalizeString(
+      parsed?.last_successful_reflection_at,
+    ),
+    last_meta_reflection_started_at: normalizeString(
+      parsed?.last_meta_reflection_started_at,
+    ),
+    last_meta_reflection_succeeded_at: normalizeString(
+      parsed?.last_meta_reflection_succeeded_at,
+    ),
+  };
+}
+
+async function withMetaReflectionCounterLock<T>(
+  agentId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  await mkdir(getAgentTranscriptRoot(agentId), { recursive: true });
+  return withFileLock(getMetaReflectionCounterLockPath(agentId), fn);
+}
+
+async function readMetaReflectionCounterStateUnlocked(
+  agentId: string,
+): Promise<MetaReflectionCounterState> {
+  let raw: string | null = null;
+  try {
+    raw = await readFile(getMetaReflectionCounterStatePath(agentId), "utf-8");
+  } catch {
+    raw = null;
+  }
+  const parsed = raw
+    ? safeJsonParseOr<Partial<MetaReflectionCounterState> | null>(raw, null)
+    : null;
+  return normalizeMetaReflectionCounterState(parsed);
+}
+
+async function writeMetaReflectionCounterStateUnlocked(
+  agentId: string,
+  state: MetaReflectionCounterState,
+): Promise<void> {
+  await writeFile(
+    getMetaReflectionCounterStatePath(agentId),
+    `${JSON.stringify(state, null, 2)}\n`,
+    "utf-8",
+  );
+}
+
+export async function recordSuccessfulReflectionForMetaTrigger(
+  agentId: string,
+  options: { interval?: number } = {},
+): Promise<{
+  shouldLaunchMetaReflection: boolean;
+  state: MetaReflectionCounterState;
+}> {
+  const interval = Math.max(1, options.interval ?? 10);
+  return withMetaReflectionCounterLock(agentId, async () => {
+    const state = await readMetaReflectionCounterStateUnlocked(agentId);
+    const nowIso = new Date().toISOString();
+    state.total_successful_reflections += 1;
+    state.successful_reflections_since_last_meta_reflection += 1;
+    state.last_successful_reflection_at = nowIso;
+
+    const shouldLaunchMetaReflection =
+      state.successful_reflections_since_last_meta_reflection >= interval;
+    if (shouldLaunchMetaReflection) {
+      state.successful_reflections_since_last_meta_reflection = 0;
+      state.last_meta_reflection_started_at = nowIso;
+    }
+
+    await writeMetaReflectionCounterStateUnlocked(agentId, state);
+    return { shouldLaunchMetaReflection, state };
+  });
+}
+
+export async function recordMetaReflectionResult(
+  agentId: string,
+  success: boolean,
+): Promise<MetaReflectionCounterState> {
+  return withMetaReflectionCounterLock(agentId, async () => {
+    const state = await readMetaReflectionCounterStateUnlocked(agentId);
+    if (success) {
+      state.total_successful_meta_reflections += 1;
+      state.last_meta_reflection_succeeded_at = new Date().toISOString();
+    }
+    await writeMetaReflectionCounterStateUnlocked(agentId, state);
+    return state;
+  });
 }
 
 export function getReflectionTranscriptPaths(

--- a/src/cli/reflection-transcript.test.ts
+++ b/src/cli/reflection-transcript.test.ts
@@ -625,6 +625,46 @@ describe("reflectionTranscript helper", () => {
     }
   });
 
+  test("multi payload replay range mode replays recent content even when unreflected content exists", async () => {
+    const conv = "conv-replay-mode";
+    await appendTranscriptDeltaJsonl(agentId, conv, [
+      { kind: "user", id: "u-old", text: "old", messageId: "u-old" },
+      {
+        kind: "assistant",
+        id: "a-old",
+        text: "old response",
+        phase: "finished",
+        messageId: "a-old",
+      },
+      { kind: "user", id: "u-new", text: "new", messageId: "u-new" },
+      {
+        kind: "assistant",
+        id: "a-new",
+        text: "new response",
+        phase: "finished",
+        messageId: "a-new",
+      },
+    ]);
+
+    const multi = await buildMultiReflectionPayload({
+      agentId,
+      selectionPolicy: { mode: "explicit-conversations", conversationIds: [conv] },
+      rangeMode: "replay",
+      maxReplayTurnsPerConversation: 1,
+    });
+
+    expect(multi).not.toBeNull();
+    if (!multi) return;
+    expect(multi.manifest.transcripts).toHaveLength(1);
+    expect(multi.manifest.transcripts[0]?.mode).toBe("replay");
+    const payloadText = await readFile(
+      multi.manifest.transcripts[0]!.payload_path,
+      "utf-8",
+    );
+    expect(payloadText).toContain("new");
+    expect(payloadText).not.toContain("old");
+  });
+
   test("multi finalizer advances only unreflected slices", async () => {
     const replayConv = "conv-replay";
     const freshConv = "conv-fresh";
@@ -853,8 +893,8 @@ describe("reflectionTranscript helper", () => {
     expect(prompt).toContain("Review the conversation transcript");
     expect(prompt).not.toContain("Your current working directory is:");
     expect(prompt).toContain("The payload path is available as the");
-    expect(prompt).toContain("multi_transcript_reflection_payload");
-    expect(prompt).toContain('mode: "replay"');
+    expect(prompt).not.toContain("multi_transcript_reflection_payload");
+    expect(prompt).not.toContain('mode: "replay"');
     // Prompt references the $TRANSCRIPT_PATH env var (resolved via Bash),
     // not a literal absolute path.
     expect(prompt).toContain("$TRANSCRIPT_PATH");
@@ -869,6 +909,21 @@ describe("reflectionTranscript helper", () => {
     expect(prompt).toContain("Additional user-provided reflection instruction");
     expect(prompt).toContain("Focus on repo gotchas.");
     expect(prompt).toContain("<parent_memory>snapshot</parent_memory>");
+  });
+
+  test("buildReflectionSubagentPrompt adds multi-conversation instructions only when requested", () => {
+    const standardPrompt = buildReflectionSubagentPrompt({
+      memoryDir: "/tmp/memory",
+      parentMemory: "<parent_memory>snapshot</parent_memory>",
+    });
+    const multiPrompt = buildReflectionSubagentPrompt({
+      mode: "multi",
+      memoryDir: "/tmp/memory",
+      parentMemory: "<parent_memory>snapshot</parent_memory>",
+    });
+
+    expect(standardPrompt).not.toContain("multi_transcript_reflection_payload");
+    expect(multiPrompt).toContain("multi_transcript_reflection_payload");
   });
 
   test("reflection payload drops tool call results and truncates args", async () => {

--- a/src/cli/reflection-transcript.test.ts
+++ b/src/cli/reflection-transcript.test.ts
@@ -23,6 +23,8 @@ import {
   listReflectionTranscriptCandidates,
   REFLECTION_STATE_SCHEMA_VERSION,
   readReflectionAutoSelection,
+  recordMetaReflectionResult,
+  recordSuccessfulReflectionForMetaTrigger,
 } from "@/cli/helpers/reflection-transcript";
 import { DIRECTORY_LIMIT_ENV } from "@/utils/directory-limits";
 
@@ -521,6 +523,41 @@ describe("reflectionTranscript helper", () => {
 
     const state = await getReflectionTranscriptState(agentId, conversationId);
     expect(state.total_completed_steps).toBe(5);
+  });
+
+  test("meta-reflection counter fires every configured successful reflections", async () => {
+    for (let index = 0; index < 2; index += 1) {
+      const result = await recordSuccessfulReflectionForMetaTrigger(agentId, {
+        interval: 3,
+      });
+      expect(result.shouldLaunchMetaReflection).toBe(false);
+      expect(
+        result.state.successful_reflections_since_last_meta_reflection,
+      ).toBe(index + 1);
+    }
+
+    const third = await recordSuccessfulReflectionForMetaTrigger(agentId, {
+      interval: 3,
+    });
+    expect(third.shouldLaunchMetaReflection).toBe(true);
+    expect(third.state.successful_reflections_since_last_meta_reflection).toBe(
+      0,
+    );
+    expect(third.state.total_successful_reflections).toBe(3);
+    expect(third.state.last_meta_reflection_started_at).toBeString();
+
+    const meta = await recordMetaReflectionResult(agentId, true);
+    expect(meta.total_successful_meta_reflections).toBe(1);
+    expect(meta.last_meta_reflection_succeeded_at).toBeString();
+
+    const fourth = await recordSuccessfulReflectionForMetaTrigger(agentId, {
+      interval: 3,
+    });
+    expect(fourth.shouldLaunchMetaReflection).toBe(false);
+    expect(fourth.state.successful_reflections_since_last_meta_reflection).toBe(
+      1,
+    );
+    expect(fourth.state.total_successful_reflections).toBe(4);
   });
 
   test("multi payload recent uses replay slices when conversations are already reflected", async () => {

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -91,7 +91,8 @@ export interface UserInputData {
 export type ReflectionTriggerSource =
   | "manual"
   | "step-count"
-  | "compaction-event";
+  | "compaction-event"
+  | "meta-reflection";
 
 export interface ReflectionStartData {
   trigger_source: ReflectionTriggerSource;


### PR DESCRIPTION
## Summary

  - launch automatic agent-scoped multi-convo reflection counter that triggers after every 10 successful reflection passes
  -  reflects over the 10 most recent transcript conversations
  - new multi convo reflection prompting to emphasize proactive cleanup and distilling repeated user corrections/memory fails
  - track meta-reflection start/end telemetry with a new `meta-reflection` trigger source
  - persist meta-reflection counter state with a schema version and file lock

  ## Test plan

  - `bun test src/cli/reflection-transcript.test.ts`
  - `bun test src/cli/reflection-transcript.test.ts src/cli/helpers/post-turn-reflection.test.ts
  src/cli/reflection-scope-gate.test.ts`
  - `bun run typecheck`
  - `bun run check`