### PR TITLE
fix(build): make build and dev windows-safe

### DIFF
--- a/build.js
+++ b/build.js
@@ -75,7 +75,9 @@ ${content}`;
 await Bun.write(outputPath, withShebang);
 
 // Make executable
-await Bun.$`chmod +x letta.js`;
+if (process.platform !== "win32") {
+  await Bun.$`chmod +x letta.js`;
+}
 
 await Bun.build({
   entrypoints: ["./src/app-server-client.ts"],

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "check:test-coverage": "node scripts/check-test-coverage.cjs",
     "check:bundled-skill-scripts": "node scripts/check-bundled-skill-scripts.js",
     "check": "bun run scripts/check.js",
-    "dev": "LETTA_DEBUG=${LETTA_DEBUG:-1} LETTA_RESPONSES_WS=${LETTA_RESPONSES_WS:-1} bun --loader=.md:text --loader=.mdx:text --loader=.txt:text run src/index.ts",
+    "dev": "node scripts/dev.cjs",
     "build": "node scripts/postinstall-patches.js && bun run build.js",
     "test:update-chain:manual": "bun run src/test-utils/update-chain-smoke.ts --mode manual",
     "test:update-chain:startup": "bun run src/test-utils/update-chain-smoke.ts --mode startup",

--- a/scripts/dev.cjs
+++ b/scripts/dev.cjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+const { spawn } = require('node:child_process');
+
+const env = { ...process.env };
+if (!env.LETTA_DEBUG) env.LETTA_DEBUG = '1';
+if (!env.LETTA_RESPONSES_WS) env.LETTA_RESPONSES_WS = '1';
+
+const bunArgs = [
+  '--loader=.md:text',
+  '--loader=.mdx:text',
+  '--loader=.txt:text',
+  'run',
+  'src/index.ts',
+  ...process.argv.slice(2),
+];
+
+const child = spawn('bun', bunArgs, {
+  stdio: 'inherit',
+  env,
+  windowsHide: true,
+});
+
+child.on('error', (error) => {
+  console.error('failed to launch bun for dev mode:', error.message);
+  process.exit(1);
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});


### PR DESCRIPTION
skip chmod on windows during build, and route dev startup through a small node launcher so powershell does not need bash-style env expansion.

this keeps the existing mac flow intact while making the default windows path work without special shell syntax.