### PR TITLE
fix(mods): load legacy extensions alongside mods

### DIFF
--- a/src/cli/mods/local-mod-loader.test.ts
+++ b/src/cli/mods/local-mod-loader.test.ts
@@ -21,6 +21,7 @@ import {
 } from "@/cli/mods/local-mod-loader";
 import { getModErrorDiagnostics } from "@/mods/mod-diagnostics";
 import { clearModTools } from "@/mods/tool-registry";
+import type { ModDiagnostic } from "@/mods/types";
 
 function createTempDir(): string {
   return mkdtempSync(path.join(tmpdir(), "letta-mods-"));
@@ -80,6 +81,43 @@ describe("local mod loader", () => {
             path.join(globalMods, "a.ts"),
             path.join(globalMods, "b.tsx"),
           ],
+          root: globalMods,
+          scope: "global",
+          trusted: true,
+        },
+      ]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("discovers legacy extensions before global mods", () => {
+    const root = createTempDir();
+    try {
+      const { globalModsDirectory: globalMods } = createLoadOptions(root);
+      const legacyExtensions = path.join(root, "legacy-extensions");
+      const legacyPath = path.join(legacyExtensions, "review.ts");
+      const modPath = path.join(globalMods, "web-search.ts");
+      mkdirSync(globalMods, { recursive: true });
+      mkdirSync(legacyExtensions, { recursive: true });
+      writeFileSync(legacyPath, "export default () => {};\n");
+      writeFileSync(modPath, "export default () => {};\n");
+
+      expect(
+        resolveLocalModSources({
+          globalModsDirectory: globalMods,
+          legacyGlobalExtensionsDirectory: legacyExtensions,
+        }),
+      ).toEqual([
+        {
+          files: [legacyPath],
+          legacyMigrationTargetRoot: globalMods,
+          root: legacyExtensions,
+          scope: "legacy_global",
+          trusted: true,
+        },
+        {
+          files: [modPath],
           root: globalMods,
           scope: "global",
           trusted: true,
@@ -916,6 +954,77 @@ export default function(letta) {
       expect(
         Object.values(registry.ui.panels).map((panel) => panel.content),
       ).toEqual([["from a"], ["from b"]]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("loads legacy extensions with warnings and lets mods shadow them", async () => {
+    const root = createTempDir();
+    try {
+      const options = createLoadOptions(root);
+      const modDir = options.globalModsDirectory;
+      const legacyExtensions = path.join(root, "legacy-extensions");
+      const legacyPath = path.join(legacyExtensions, "review.ts");
+      const modPath = path.join(modDir, "review.ts");
+      mkdirSync(modDir, { recursive: true });
+      mkdirSync(legacyExtensions, { recursive: true });
+      writeFileSync(
+        legacyPath,
+        `export default function(letta) {
+          letta.commands.register({
+            id: "review",
+            description: "Legacy review",
+            run() { return { type: "output", output: "legacy" }; },
+          });
+        }`,
+      );
+      writeFileSync(
+        modPath,
+        `export default function(letta) {
+          letta.commands.register({
+            id: "review",
+            description: "Mods review",
+            run() { return { type: "output", output: "mods" }; },
+          });
+        }`,
+      );
+
+      const seenDiagnostics: ModDiagnostic[] = [];
+      const registry = await loadLocalMods({
+        ...options,
+        legacyGlobalExtensionsDirectory: legacyExtensions,
+        onDiagnostic: (diagnostic) => seenDiagnostics.push(diagnostic),
+      });
+
+      expect(registry.loadedPaths).toEqual([legacyPath, modPath]);
+      expect(getModErrorDiagnostics(registry.diagnostics)).toEqual([]);
+      expect(registry.commands.review).toMatchObject({
+        description: "Mods review",
+        owner: { path: modPath, scope: "global" },
+      });
+      expect(registry.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            error: expect.objectContaining({
+              message: `Loaded legacy extension from ${legacyPath}. Move it to ${modPath}.`,
+            }),
+            owner: expect.objectContaining({
+              path: legacyPath,
+              scope: "legacy_global",
+            }),
+            phase: "legacy_extension",
+            severity: "warning",
+          }),
+        ]),
+      );
+      expect(seenDiagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            phase: "legacy_extension",
+          }),
+        ]),
+      );
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/src/cli/subcommands/mods.test.ts
+++ b/src/cli/subcommands/mods.test.ts
@@ -132,6 +132,38 @@ describe("mods subcommand", () => {
     );
   });
 
+  test("lists legacy extensions alongside harness mods", () => {
+    const root = createTempDir();
+    const harnessMods = join(root, "mods");
+    const legacyExtensions = join(root, "extensions");
+    mkdirSync(harnessMods, { recursive: true });
+    mkdirSync(legacyExtensions, { recursive: true });
+    writeFileSync(join(harnessMods, "web-search.ts"), "export {};\n");
+    writeFileSync(join(legacyExtensions, "review.ts"), "export {};\n");
+
+    const result = listMods({
+      globalModsDirectory: harnessMods,
+      legacyGlobalExtensionsDirectory: legacyExtensions,
+    });
+
+    expect(result.legacyHarness?.files).toEqual([
+      join(legacyExtensions, "review.ts"),
+    ]);
+    expect(result.harness.files).toEqual([join(harnessMods, "web-search.ts")]);
+    expect(formatModsList(result)).toBe(
+      [
+        "Legacy extensions",
+        `  enabled  ${join(legacyExtensions, "review.ts")}`,
+        "",
+        "Harness mods",
+        `  enabled  ${join(harnessMods, "web-search.ts")}`,
+        "",
+        "Installed packages",
+        "  (none)",
+      ].join("\n"),
+    );
+  });
+
   test("lists agent loose mods before harness loose mods", () => {
     const root = createTempDir();
     const harnessMods = join(root, "mods");

--- a/src/cli/subcommands/mods.ts
+++ b/src/cli/subcommands/mods.ts
@@ -10,7 +10,11 @@ import {
   setManagedModPackageEnabled,
 } from "@/mods/package-registry";
 import { scaffoldLocalModPackage } from "@/mods/package-scaffolder";
-import { resolveDefaultGlobalModsDirectory } from "@/mods/paths";
+import {
+  getGlobalModsDirectory,
+  getLegacyGlobalExtensionsDirectory,
+  resolveDefaultGlobalModsDirectory,
+} from "@/mods/paths";
 
 interface LooseModSection {
   files: string[];
@@ -20,6 +24,7 @@ interface LooseModSection {
 export interface ModsList {
   agent?: LooseModSection;
   harness: LooseModSection;
+  legacyHarness?: LooseModSection;
   packageDiagnostics: ManagedModPackageDiagnostic[];
   packages: ManagedModPackageListItem[];
 }
@@ -28,6 +33,7 @@ export interface ListModsOptions {
   agentId?: string | null;
   agentModsDirectory?: string | null;
   globalModsDirectory?: string;
+  legacyGlobalExtensionsDirectory?: string | null;
 }
 
 interface RunModsOptions {
@@ -114,11 +120,20 @@ export function listMods(options: ListModsOptions = {}): ModsList {
     options.agentModsDirectory ??
     (options.agentId ? getAgentModsDirectory(options.agentId) : null);
   const globalModsDirectory =
-    options.globalModsDirectory ?? resolveDefaultGlobalModsDirectory();
+    options.globalModsDirectory ?? getGlobalModsDirectory();
+  const legacyGlobalExtensionsDirectory =
+    options.legacyGlobalExtensionsDirectory ??
+    (options.globalModsDirectory ? null : getLegacyGlobalExtensionsDirectory());
   const sources = resolveLocalModSources({
     ...(agentModsDirectory ? { agentModsDirectory } : {}),
     globalModsDirectory,
+    ...(legacyGlobalExtensionsDirectory
+      ? { legacyGlobalExtensionsDirectory }
+      : {}),
   });
+  const legacyHarness = sources.find(
+    (source) => source.scope === "legacy_global",
+  );
   const harness = sources.find((source) => source.scope === "global");
   const agent = sources.find((source) => source.scope === "agent");
   const managedPackages = listManagedModPackages(globalModsDirectory);
@@ -126,6 +141,7 @@ export function listMods(options: ListModsOptions = {}): ModsList {
   return {
     ...(agent ? { agent: toSection(agent) } : {}),
     harness: harness ? toSection(harness) : { files: [], root: "" },
+    ...(legacyHarness ? { legacyHarness: toSection(legacyHarness) } : {}),
     packageDiagnostics: managedPackages.diagnostics,
     packages: managedPackages.packages,
   };
@@ -179,6 +195,11 @@ export function formatModsList(mods: ModsList): string {
   const sections: string[] = [];
   if (mods.agent) {
     sections.push(formatLooseModSection("Agent mods", mods.agent));
+  }
+  if (mods.legacyHarness) {
+    sections.push(
+      formatLooseModSection("Legacy extensions", mods.legacyHarness),
+    );
   }
   sections.push(formatLooseModSection("Harness mods", mods.harness));
   sections.push(formatInstalledPackagesSection(mods));

--- a/src/mods/mod-diagnostics.test.ts
+++ b/src/mods/mod-diagnostics.test.ts
@@ -35,6 +35,7 @@ describe("mod diagnostics", () => {
     expect(getModDiagnosticSeverity("activate")).toBe("error");
     expect(getModDiagnosticSeverity("deprecated_api")).toBe("warning");
     expect(getModDiagnosticSeverity("deprecated_api", "error")).toBe("error");
+    expect(getModDiagnosticSeverity("legacy_extension")).toBe("warning");
     expect(getModDiagnosticSeverity("event")).toBe("error");
   });
 

--- a/src/mods/mod-diagnostics.ts
+++ b/src/mods/mod-diagnostics.ts
@@ -40,6 +40,7 @@ export function getModDiagnosticSeverity(
     case "command_override":
       return "warning";
     case "deprecated_api":
+    case "legacy_extension":
       return severity ?? "warning";
     case "report":
       return severity ?? "error";

--- a/src/mods/mod-engine.ts
+++ b/src/mods/mod-engine.ts
@@ -54,7 +54,6 @@ import {
   getGlobalModsDirectory,
   getLegacyGlobalExtensionsDirectory,
   getModCacheDirectory,
-  resolveDefaultGlobalModsDirectory,
 } from "@/mods/paths";
 import {
   getModPermissionDefinition,
@@ -220,6 +219,7 @@ export interface LocalModRegistry {
 export interface LocalModSource {
   diagnostics?: ManagedModPackageDiagnostic[];
   files: string[];
+  legacyMigrationTargetRoot?: string;
   managedPackageRoots?: string[];
   root: string;
   scope: ModSourceScope;
@@ -235,6 +235,7 @@ export interface ResolveLocalModSourcesOptions {
   agentModsDirectory?: string;
   cacheDirectory?: string;
   globalModsDirectory?: string;
+  legacyGlobalExtensionsDirectory?: string;
 }
 
 export interface LoadLocalModsOptions extends ResolveLocalModSourcesOptions {
@@ -283,14 +284,16 @@ function listModFiles(directory: string): string[] {
 
 function getModSourcePriority(scope: ModSourceScope): number {
   switch (scope) {
-    case "bundled":
+    case "legacy_global":
       return 0;
-    case "global":
+    case "bundled":
       return 1;
-    case "agent":
+    case "global":
       return 2;
-    case "project":
+    case "agent":
       return 3;
+    case "project":
+      return 4;
   }
 }
 
@@ -314,27 +317,43 @@ export function resolveLocalModSources(
   options: ResolveLocalModSourcesOptions = {},
 ): LocalModSource[] {
   const globalModsDirectory =
-    options.globalModsDirectory ?? resolveDefaultGlobalModsDirectory();
+    options.globalModsDirectory ?? getGlobalModsDirectory();
+  const legacyGlobalExtensionsDirectory =
+    options.legacyGlobalExtensionsDirectory ??
+    (options.globalModsDirectory
+      ? undefined
+      : getLegacyGlobalExtensionsDirectory());
   const managedPackages = resolveManagedModPackages(globalModsDirectory);
   const globalDiagnostics = managedPackages.diagnostics;
-  const sources: LocalModSource[] = [
-    {
-      ...(globalDiagnostics.length > 0
-        ? { diagnostics: globalDiagnostics }
-        : {}),
-      files: [...listModFiles(globalModsDirectory), ...managedPackages.files],
-      ...(managedPackages.packages.length > 0
-        ? {
-            managedPackageRoots: managedPackages.packages.map(
-              (pkg) => pkg.root,
-            ),
-          }
-        : {}),
-      root: globalModsDirectory,
-      scope: "global",
+  const sources: LocalModSource[] = [];
+
+  if (
+    legacyGlobalExtensionsDirectory &&
+    path.resolve(legacyGlobalExtensionsDirectory) !==
+      path.resolve(globalModsDirectory) &&
+    existsSync(legacyGlobalExtensionsDirectory)
+  ) {
+    sources.push({
+      files: listModFiles(legacyGlobalExtensionsDirectory),
+      legacyMigrationTargetRoot: globalModsDirectory,
+      root: legacyGlobalExtensionsDirectory,
+      scope: "legacy_global",
       trusted: true,
-    },
-  ];
+    });
+  }
+
+  sources.push({
+    ...(globalDiagnostics.length > 0 ? { diagnostics: globalDiagnostics } : {}),
+    files: [...listModFiles(globalModsDirectory), ...managedPackages.files],
+    ...(managedPackages.packages.length > 0
+      ? {
+          managedPackageRoots: managedPackages.packages.map((pkg) => pkg.root),
+        }
+      : {}),
+    root: globalModsDirectory,
+    scope: "global",
+    trusted: true,
+  });
 
   if (options.agentModsDirectory) {
     sources.push({
@@ -1366,6 +1385,46 @@ function getModFactory(module: LocalModModule): unknown {
     : module.activate;
 }
 
+function getLegacyExtensionMigrationTarget(
+  source: LocalModSource,
+  modPath: string,
+): string {
+  const targetRoot =
+    source.legacyMigrationTargetRoot ?? getGlobalModsDirectory();
+  const relativePath = path.relative(source.root, modPath);
+  if (
+    !relativePath ||
+    relativePath.startsWith("..") ||
+    path.isAbsolute(relativePath)
+  ) {
+    return path.join(targetRoot, path.basename(modPath));
+  }
+  return path.join(targetRoot, relativePath);
+}
+
+function recordLegacyExtensionLoadedDiagnostic(
+  registry: LocalModRegistry,
+  owner: ModOwner,
+  source: LocalModSource,
+  onDiagnostic: ((diagnostic: ModDiagnostic) => void) | undefined,
+): void {
+  const error = new Error(
+    `Loaded legacy extension from ${owner.path}. Move it to ${getLegacyExtensionMigrationTarget(source, owner.path)}.`,
+  );
+  error.name = "LegacyExtensionLoaded";
+  error.stack = undefined;
+  recordModDiagnostic(
+    registry,
+    {
+      error,
+      owner,
+      phase: "legacy_extension",
+      severity: "warning",
+    },
+    onDiagnostic,
+  );
+}
+
 export async function loadLocalMods(
   options: LoadLocalModsOptions,
 ): Promise<LocalModRegistry> {
@@ -1403,6 +1462,15 @@ export async function loadLocalMods(
       let failurePhase: ModDiagnostic["phase"] = "import";
       registry.ownerAbortControllers[owner.id] = abortController;
       registry.owners[owner.id] = owner;
+
+      if (source.scope === "legacy_global") {
+        recordLegacyExtensionLoadedDiagnostic(
+          registry,
+          owner,
+          source,
+          options.onDiagnostic,
+        );
+      }
 
       try {
         const mtimeMs = statSync(modPath).mtimeMs;

--- a/src/mods/types.ts
+++ b/src/mods/types.ts
@@ -126,7 +126,12 @@ export interface ModConversationHandle {
   ) => Promise<AsyncIterable<LettaStreamingResponse>>;
 }
 
-export type ModSourceScope = "global" | "project" | "bundled" | "agent";
+export type ModSourceScope =
+  | "legacy_global"
+  | "global"
+  | "project"
+  | "bundled"
+  | "agent";
 
 export interface ModOwner {
   id: string;
@@ -260,6 +265,7 @@ export type ModDiagnosticPhase =
   | "transpile"
   | "import"
   | "activate"
+  | "legacy_extension"
   | "package_manifest"
   | "command_override"
   | "command.run"


### PR DESCRIPTION
## Summary
- load legacy `~/.letta/extensions` files before `~/.letta/mods` during the migration window
- give `~/.letta/mods` higher source priority so new mods shadow legacy extensions
- emit warning diagnostics telling users to move each loaded legacy extension into `~/.letta/mods`

## Tests
- `bun test src/cli/mods/local-mod-loader.test.ts`
- `bun test src/mods/mod-diagnostics.test.ts src/mods/mod-engine.test.ts src/mods/paths.test.ts`
- `bun run typecheck`
- `bun run check`