### PR TITLE
fix: support Windows credential auth in Node CLI

### DIFF
--- a/src/utils/secrets.test.ts
+++ b/src/utils/secrets.test.ts
@@ -2,6 +2,7 @@
 // Tests for secrets utility functions
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { randomUUID } from "node:crypto";
 import {
   __resetSecretWarningStateForTests,
   __setSecretGetOverrideForTests,
@@ -16,9 +17,23 @@ import {
   setApiKey,
   setRefreshToken,
   setSecureTokens,
+  setServiceName,
 } from "@/utils/secrets";
+import {
+  deleteWindowsCredential,
+  getWindowsCredential,
+  getWindowsCredentials,
+  isWindowsCredentialManagerAvailable,
+  setWindowsCredential,
+} from "@/utils/windows-credential-manager";
+
+const TEST_SERVICE_NAME = `letta-code-test-${randomUUID()}`;
+setServiceName(TEST_SERVICE_NAME);
 
 const keychainAvailablePrecompute = await isKeychainAvailable();
+const bunSecretsForTests = (
+  globalThis as typeof globalThis & { Bun?: { secrets?: typeof Bun.secrets } }
+).Bun?.secrets;
 
 describe("Secrets utilities", () => {
   const originalConsoleWarn = console.warn;
@@ -280,3 +295,55 @@ describe("Secrets utilities", () => {
     expect(String(warn.mock.calls[1]?.[0])).toContain("api key failure 2");
   });
 });
+
+describe.skipIf(process.platform !== "win32")(
+  "Windows Credential Manager adapter",
+  () => {
+    test("stores, reads, and deletes UTF-8 credentials", async () => {
+      if (!(await isWindowsCredentialManagerAvailable())) {
+        return;
+      }
+
+      const service = `letta-code-windows-test-${randomUUID()}`;
+      const name = "probe-secret";
+      const value = "utf8-test-🔐-mañana-東京";
+
+      try {
+        await setWindowsCredential(service, name, value);
+        expect(await getWindowsCredential(service, name)).toBe(value);
+        expect(await getWindowsCredentials(service, [name])).toEqual({
+          [name]: value,
+        });
+        expect(await deleteWindowsCredential(service, name)).toBe(true);
+        expect(await getWindowsCredential(service, name)).toBe(null);
+      } finally {
+        await deleteWindowsCredential(service, name);
+      }
+    }, 20_000);
+
+    test.skipIf(!bunSecretsForTests)(
+      "reads credentials written by Bun.secrets",
+      async () => {
+        if (
+          !(await isWindowsCredentialManagerAvailable()) ||
+          !bunSecretsForTests
+        ) {
+          return;
+        }
+
+        const service = `letta-code-bun-compat-test-${randomUUID()}`;
+        const name = "probe-secret";
+        const value = "bun-compatible-secret";
+
+        try {
+          await bunSecretsForTests.set({ service, name, value });
+          expect(await getWindowsCredential(service, name)).toBe(value);
+        } finally {
+          await bunSecretsForTests.delete({ service, name });
+          await deleteWindowsCredential(service, name);
+        }
+      },
+      20_000,
+    );
+  },
+);

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -1,19 +1,29 @@
 /// <reference types="bun-types" />
 // src/utils/secrets.ts
-// Secure storage utilities for tokens using Bun's secrets API with Node.js fallback
+// Secure storage utilities for tokens using Bun's secrets API, with a
+// Windows Credential Manager fallback for the npm/Node CLI runtime.
 
 import { debugWarn } from "./debug.js";
+import {
+  deleteWindowsCredential,
+  getWindowsCredential,
+  getWindowsCredentials,
+  isWindowsCredentialManagerAvailable,
+  setWindowsCredential,
+} from "./windows-credential-manager.js";
 
-let secrets: typeof Bun.secrets;
-let secretsAvailable = false;
+type BunSecrets = typeof Bun.secrets;
 
-// Try to import Bun's secrets API, fallback if unavailable
-try {
-  secrets = require("bun").secrets;
-  secretsAvailable = true;
-} catch {
-  // Running in Node.js or Bun secrets unavailable
-  secretsAvailable = false;
+interface SecretBackend {
+  kind: "bun" | "windows-credential-manager";
+  get(options: { service: string; name: string }): Promise<string | null>;
+  getMany?(options: {
+    service: string;
+    names: string[];
+  }): Promise<Record<string, string | null>>;
+  set(options: { service: string; name: string; value: string }): Promise<void>;
+  delete(options: { service: string; name: string }): Promise<boolean>;
+  isAvailable(): Promise<boolean>;
 }
 
 let SERVICE_NAME = "letta-code";
@@ -37,11 +47,54 @@ function isDuplicateKeychainItemError(error: unknown): boolean {
   );
 }
 
+function getBunSecrets(): BunSecrets | null {
+  const runtime = globalThis as typeof globalThis & {
+    Bun?: { secrets?: BunSecrets };
+  };
+  return runtime.Bun?.secrets ?? null;
+}
+
+function getSecretBackend(): SecretBackend | null {
+  const bunSecrets = getBunSecrets();
+  if (bunSecrets) {
+    return {
+      kind: "bun",
+      get: (options) => bunSecrets.get(options),
+      set: (options) => bunSecrets.set(options),
+      delete: (options) => bunSecrets.delete(options),
+      isAvailable: async () => {
+        await bunSecrets.get({
+          service: SERVICE_NAME,
+          name: API_KEY_NAME,
+        });
+        return true;
+      },
+    };
+  }
+
+  if (process.platform === "win32") {
+    return {
+      kind: "windows-credential-manager",
+      get: (options) => getWindowsCredential(options.service, options.name),
+      getMany: (options) =>
+        getWindowsCredentials(options.service, options.names),
+      set: (options) =>
+        setWindowsCredential(options.service, options.name, options.value),
+      delete: (options) =>
+        deleteWindowsCredential(options.service, options.name),
+      isAvailable: () => isWindowsCredentialManagerAvailable(),
+    };
+  }
+
+  return null;
+}
+
 export async function getSecretValue(
   name: string,
   label: string,
 ): Promise<string | null> {
-  if (!secretsAvailable && !secretGetOverrideForTests) {
+  const backend = getSecretBackend();
+  if (!backend && !secretGetOverrideForTests) {
     return null;
   }
 
@@ -52,9 +105,9 @@ export async function getSecretValue(
     };
     const value = secretGetOverrideForTests
       ? await secretGetOverrideForTests(options)
-      : await secrets.get(options);
+      : await backend?.get(options);
     warnedSecretReadFailures.delete(name);
-    return value;
+    return value ?? null;
   } catch (error) {
     const message = `Failed to retrieve ${label} from secrets: ${error}`;
     if (!warnedSecretReadFailures.has(name)) {
@@ -71,26 +124,27 @@ export async function setSecretValue(
   name: string,
   value: string,
 ): Promise<void> {
-  if (!secretsAvailable) {
+  const backend = getSecretBackend();
+  if (!backend) {
     throw new Error("Secrets API unavailable");
   }
 
   try {
-    await secrets.set({
+    await backend.set({
       service: SERVICE_NAME,
       name,
       value,
     });
     return;
   } catch (error) {
-    if (!isDuplicateKeychainItemError(error)) {
+    if (backend.kind !== "bun" || !isDuplicateKeychainItemError(error)) {
       throw error;
     }
   }
 
   // Replace existing keychain item and retry once.
   try {
-    await secrets.delete({
+    await backend.delete({
       service: SERVICE_NAME,
       name,
     });
@@ -98,7 +152,7 @@ export async function setSecretValue(
     // Ignore delete errors and retry set below.
   }
 
-  await secrets.set({
+  await backend.set({
     service: SERVICE_NAME,
     name,
     value,
@@ -106,12 +160,13 @@ export async function setSecretValue(
 }
 
 export async function deleteSecretValue(name: string): Promise<boolean> {
-  if (!secretsAvailable) {
+  const backend = getSecretBackend();
+  if (!backend) {
     return false;
   }
 
   try {
-    return await secrets.delete({
+    return await backend.delete({
       service: SERVICE_NAME,
       name,
     });
@@ -128,9 +183,8 @@ export function setServiceName(name: string): void {
   SERVICE_NAME = name;
 }
 
-// Note: When secrets API is unavailable (Node.js), tokens will be managed
-// by the settings manager which falls back to storing in the settings file
-// This provides persistence across restarts
+// Note: On platforms without an OS secret backend, tokens are managed by the
+// settings manager fallback so authentication still persists across restarts.
 
 export interface SecureTokens {
   apiKey?: string;
@@ -141,11 +195,6 @@ export interface SecureTokens {
  * Store API key in system secrets
  */
 export async function setApiKey(apiKey: string): Promise<void> {
-  if (!secretsAvailable) {
-    // When secrets unavailable, let the settings manager handle fallback
-    throw new Error("Secrets API unavailable");
-  }
-
   await setSecretValue(API_KEY_NAME, apiKey);
 }
 
@@ -160,11 +209,6 @@ export async function getApiKey(): Promise<string | null> {
  * Store refresh token in system secrets
  */
 export async function setRefreshToken(refreshToken: string): Promise<void> {
-  if (!secretsAvailable) {
-    // When secrets unavailable, let the settings manager handle fallback
-    throw new Error("Secrets API unavailable");
-  }
-
   await setSecretValue(REFRESH_TOKEN_NAME, refreshToken);
 }
 
@@ -179,6 +223,35 @@ export async function getRefreshToken(): Promise<string | null> {
  * Get both tokens from secrets
  */
 export async function getSecureTokens(): Promise<SecureTokens> {
+  const backend = getSecretBackend();
+  if (!secretGetOverrideForTests && backend?.getMany) {
+    try {
+      const values = await backend.getMany({
+        service: SERVICE_NAME,
+        names: [API_KEY_NAME, REFRESH_TOKEN_NAME],
+      });
+      warnedSecretReadFailures.delete(API_KEY_NAME);
+      warnedSecretReadFailures.delete(REFRESH_TOKEN_NAME);
+      return {
+        apiKey: values[API_KEY_NAME] || undefined,
+        refreshToken: values[REFRESH_TOKEN_NAME] || undefined,
+      };
+    } catch (error) {
+      const message = `Failed to retrieve secure tokens from secrets: ${error}`;
+      if (
+        !warnedSecretReadFailures.has(API_KEY_NAME) ||
+        !warnedSecretReadFailures.has(REFRESH_TOKEN_NAME)
+      ) {
+        warnedSecretReadFailures.add(API_KEY_NAME);
+        warnedSecretReadFailures.add(REFRESH_TOKEN_NAME);
+        console.warn(message);
+      } else {
+        debugWarn("secrets", message);
+      }
+      return {};
+    }
+  }
+
   const [apiKey, refreshToken] = await Promise.allSettled([
     getApiKey(),
     getRefreshToken(),
@@ -217,40 +290,14 @@ export async function setSecureTokens(tokens: SecureTokens): Promise<void> {
  * Remove API key from system secrets
  */
 export async function deleteApiKey(): Promise<void> {
-  if (secretsAvailable) {
-    try {
-      await secrets.delete({
-        service: SERVICE_NAME,
-        name: API_KEY_NAME,
-      });
-      return;
-    } catch (error) {
-      console.warn(`Failed to delete API key from secrets: ${error}`);
-    }
-  }
-
-  // When secrets unavailable, deletion is handled by settings manager
-  // No action needed here
+  await deleteSecretValue(API_KEY_NAME);
 }
 
 /**
  * Remove refresh token from system secrets
  */
 export async function deleteRefreshToken(): Promise<void> {
-  if (secretsAvailable) {
-    try {
-      await secrets.delete({
-        service: SERVICE_NAME,
-        name: REFRESH_TOKEN_NAME,
-      });
-      return;
-    } catch (error) {
-      console.warn(`Failed to delete refresh token from secrets: ${error}`);
-    }
-  }
-
-  // When secrets unavailable, deletion is handled by settings manager
-  // No action needed here
+  await deleteSecretValue(REFRESH_TOKEN_NAME);
 }
 
 /**
@@ -279,17 +326,14 @@ export async function isKeychainAvailable(): Promise<boolean> {
     return false;
   }
 
-  if (!secretsAvailable) {
+  const backend = getSecretBackend();
+  if (!backend) {
     return false;
   }
 
   try {
     // Non-mutating probe: if this call succeeds (even with null), keychain is usable.
-    await secrets.get({
-      service: SERVICE_NAME,
-      name: API_KEY_NAME,
-    });
-    return true;
+    return await backend.isAvailable();
   } catch {
     return false;
   }

--- a/src/utils/windows-credential-manager.ts
+++ b/src/utils/windows-credential-manager.ts
@@ -1,0 +1,416 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { delimiter, join } from "node:path";
+
+const WINDOWS_CREDENTIAL_MAX_BLOB_BYTES = 2_560;
+const WINDOWS_CREDENTIAL_TIMEOUT_MS = 10_000;
+
+const WINDOWS_CREDENTIAL_SCRIPT = `
+$ErrorActionPreference = 'Stop'
+
+$inputJson = [Console]::In.ReadToEnd()
+$request = $inputJson | ConvertFrom-Json
+
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+
+public static class LettaCredentialNative {
+  public const int CRED_TYPE_GENERIC = 1;
+  public const int CRED_PERSIST_LOCAL_MACHINE = 2;
+
+  [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+  public struct CREDENTIAL {
+    public UInt32 Flags;
+    public UInt32 Type;
+    public string TargetName;
+    public string Comment;
+    public System.Runtime.InteropServices.ComTypes.FILETIME LastWritten;
+    public UInt32 CredentialBlobSize;
+    public IntPtr CredentialBlob;
+    public UInt32 Persist;
+    public UInt32 AttributeCount;
+    public IntPtr Attributes;
+    public string TargetAlias;
+    public string UserName;
+  }
+
+  [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+  public static extern bool CredRead(string target, uint type, int reservedFlag, out IntPtr credentialPtr);
+
+  [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+  public static extern bool CredWrite([In] ref CREDENTIAL userCredential, uint flags);
+
+  [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+  public static extern bool CredDelete(string target, uint type, uint flags);
+
+  [DllImport("advapi32.dll", SetLastError = true)]
+  public static extern void CredFree(IntPtr buffer);
+}
+"@
+
+function Write-LettaJson($value) {
+  $value | ConvertTo-Json -Compress -Depth 4
+}
+
+function Get-LettaCredentialTarget([string]$service, [string]$name) {
+  return "$service/$name"
+}
+
+function Read-LettaCredentialBase64([string]$target) {
+  $credentialPtr = [IntPtr]::Zero
+  $ok = [LettaCredentialNative]::CredRead($target, [uint32][LettaCredentialNative]::CRED_TYPE_GENERIC, 0, [ref]$credentialPtr)
+  if (-not $ok) {
+    $code = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    if ($code -eq 1168) {
+      return $null
+    }
+    throw "CredRead failed with Windows error code $code"
+  }
+
+  try {
+    $credential = [Runtime.InteropServices.Marshal]::PtrToStructure($credentialPtr, [type][LettaCredentialNative+CREDENTIAL])
+    $bytes = New-Object byte[] $credential.CredentialBlobSize
+    if ($bytes.Length -gt 0) {
+      [Runtime.InteropServices.Marshal]::Copy($credential.CredentialBlob, $bytes, 0, $bytes.Length)
+    }
+    return [Convert]::ToBase64String($bytes)
+  } finally {
+    if ($credentialPtr -ne [IntPtr]::Zero) {
+      [LettaCredentialNative]::CredFree($credentialPtr)
+    }
+  }
+}
+
+function Get-LettaCredential([string]$target) {
+  Write-LettaJson @{ ok = $true; valueBase64 = Read-LettaCredentialBase64 $target }
+}
+
+function Get-LettaCredentials([string]$service, $names) {
+  $values = @{}
+  foreach ($name in @($names)) {
+    $nameString = [string]$name
+    $target = Get-LettaCredentialTarget $service $nameString
+    $values[$nameString] = Read-LettaCredentialBase64 $target
+  }
+  Write-LettaJson @{ ok = $true; valuesBase64 = $values }
+}
+
+function Set-LettaCredential([string]$target, [string]$name, [string]$valueBase64) {
+  $bytes = [Convert]::FromBase64String($valueBase64)
+  $blob = [IntPtr]::Zero
+  if ($bytes.Length -gt 0) {
+    $blob = [Runtime.InteropServices.Marshal]::AllocCoTaskMem($bytes.Length)
+    [Runtime.InteropServices.Marshal]::Copy($bytes, 0, $blob, $bytes.Length)
+  }
+
+  try {
+    $credential = New-Object LettaCredentialNative+CREDENTIAL
+    $credential.Flags = 0
+    $credential.Type = [uint32][LettaCredentialNative]::CRED_TYPE_GENERIC
+    $credential.TargetName = $target
+    $credential.CredentialBlobSize = [uint32]$bytes.Length
+    $credential.CredentialBlob = $blob
+    $credential.Persist = [uint32][LettaCredentialNative]::CRED_PERSIST_LOCAL_MACHINE
+    $credential.AttributeCount = 0
+    $credential.Attributes = [IntPtr]::Zero
+    $credential.TargetAlias = $null
+    $credential.UserName = $name
+
+    $ok = [LettaCredentialNative]::CredWrite([ref]$credential, 0)
+    if (-not $ok) {
+      $code = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+      throw "CredWrite failed with Windows error code $code"
+    }
+
+    Write-LettaJson @{ ok = $true }
+  } finally {
+    if ($blob -ne [IntPtr]::Zero) {
+      [Runtime.InteropServices.Marshal]::FreeCoTaskMem($blob)
+    }
+  }
+}
+
+function Remove-LettaCredential([string]$target) {
+  $ok = [LettaCredentialNative]::CredDelete($target, [uint32][LettaCredentialNative]::CRED_TYPE_GENERIC, 0)
+  if (-not $ok) {
+    $code = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    if ($code -eq 1168) {
+      Write-LettaJson @{ ok = $true; deleted = $false }
+      return
+    }
+    throw "CredDelete failed with Windows error code $code"
+  }
+
+  Write-LettaJson @{ ok = $true; deleted = $true }
+}
+
+try {
+  if ($request.operation -eq 'probe') {
+    Write-LettaJson @{ ok = $true; available = $true }
+    exit 0
+  }
+
+  $target = Get-LettaCredentialTarget ([string]$request.service) ([string]$request.name)
+  switch ([string]$request.operation) {
+    'get' { Get-LettaCredential $target }
+    'getMany' { Get-LettaCredentials ([string]$request.service) $request.names }
+    'set' { Set-LettaCredential $target ([string]$request.name) ([string]$request.valueBase64) }
+    'delete' { Remove-LettaCredential $target }
+    default { throw "Unknown credential operation: $($request.operation)" }
+  }
+} catch {
+  Write-LettaJson @{ ok = $false; error = $_.Exception.Message }
+  exit 1
+}
+`;
+
+const WINDOWS_CREDENTIAL_ENCODED_COMMAND = Buffer.from(
+  WINDOWS_CREDENTIAL_SCRIPT,
+  "utf16le",
+).toString("base64");
+
+interface WindowsCredentialRequest {
+  operation: "probe" | "get" | "getMany" | "set" | "delete";
+  service?: string;
+  name?: string;
+  names?: string[];
+  valueBase64?: string;
+}
+
+interface WindowsCredentialResponse {
+  ok?: boolean;
+  available?: boolean;
+  valueBase64?: string | null;
+  valuesBase64?: Record<string, string | null>;
+  deleted?: boolean;
+  error?: string;
+}
+
+let availabilityCache: boolean | null = null;
+
+function findExecutableOnPath(executable: string): string | null {
+  const paths = process.env.PATH?.split(delimiter) ?? [];
+  for (const path of paths) {
+    if (!path) {
+      continue;
+    }
+
+    const candidate = join(path, executable);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function getPowerShellPath(): string | null {
+  const systemRoot = process.env.SystemRoot || "C:\\Windows";
+  const bundledPath = join(
+    systemRoot,
+    "System32",
+    "WindowsPowerShell",
+    "v1.0",
+    "powershell.exe",
+  );
+  if (existsSync(bundledPath)) {
+    return bundledPath;
+  }
+
+  return (
+    findExecutableOnPath("powershell.exe") ?? findExecutableOnPath("pwsh.exe")
+  );
+}
+
+function parseCredentialResponse(stdout: string): WindowsCredentialResponse {
+  const trimmed = stdout.trim();
+  if (!trimmed) {
+    throw new Error("Windows Credential Manager command returned no output");
+  }
+  return JSON.parse(trimmed) as WindowsCredentialResponse;
+}
+
+async function runWindowsCredentialCommand(
+  request: WindowsCredentialRequest,
+): Promise<WindowsCredentialResponse> {
+  if (process.platform !== "win32") {
+    throw new Error("Windows Credential Manager is only available on Windows");
+  }
+
+  const powershellPath = getPowerShellPath();
+  if (!powershellPath) {
+    throw new Error("PowerShell is unavailable");
+  }
+
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    const child = spawn(
+      powershellPath,
+      [
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-EncodedCommand",
+        WINDOWS_CREDENTIAL_ENCODED_COMMAND,
+      ],
+      { stdio: ["pipe", "pipe", "pipe"], windowsHide: true },
+    );
+
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill();
+      reject(new Error("Windows Credential Manager command timed out"));
+    }, WINDOWS_CREDENTIAL_TIMEOUT_MS);
+
+    child.stdout?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+
+    child.on("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(error);
+    });
+
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+
+      try {
+        const response = parseCredentialResponse(stdout);
+        if (code === 0 && response.ok !== false) {
+          resolve(response);
+          return;
+        }
+        reject(
+          new Error(
+            response.error ||
+              stderr.trim() ||
+              `Windows Credential Manager command failed with exit code ${code}`,
+          ),
+        );
+      } catch (error) {
+        reject(
+          new Error(
+            stderr.trim() ||
+              (error instanceof Error ? error.message : String(error)),
+          ),
+        );
+      }
+    });
+
+    if (!child.stdin) {
+      child.kill();
+      reject(new Error("Windows Credential Manager command stdin unavailable"));
+      return;
+    }
+
+    child.stdin.end(JSON.stringify(request));
+  });
+}
+
+export async function isWindowsCredentialManagerAvailable(): Promise<boolean> {
+  if (process.platform !== "win32") {
+    return false;
+  }
+  if (availabilityCache !== null) {
+    return availabilityCache;
+  }
+
+  try {
+    const response = await runWindowsCredentialCommand({ operation: "probe" });
+    availabilityCache = response.available === true;
+  } catch {
+    availabilityCache = false;
+  }
+
+  return availabilityCache;
+}
+
+export async function getWindowsCredential(
+  service: string,
+  name: string,
+): Promise<string | null> {
+  const response = await runWindowsCredentialCommand({
+    operation: "get",
+    service,
+    name,
+  });
+  if (response.valueBase64 === null || response.valueBase64 === undefined) {
+    return null;
+  }
+  return Buffer.from(response.valueBase64, "base64").toString("utf8");
+}
+
+export async function getWindowsCredentials(
+  service: string,
+  names: string[],
+): Promise<Record<string, string | null>> {
+  const response = await runWindowsCredentialCommand({
+    operation: "getMany",
+    service,
+    names,
+  });
+  const valuesBase64 = response.valuesBase64 ?? {};
+  const values: Record<string, string | null> = {};
+
+  for (const name of names) {
+    const valueBase64 = valuesBase64[name];
+    values[name] =
+      valueBase64 === null || valueBase64 === undefined
+        ? null
+        : Buffer.from(valueBase64, "base64").toString("utf8");
+  }
+
+  return values;
+}
+
+export async function setWindowsCredential(
+  service: string,
+  name: string,
+  value: string,
+): Promise<void> {
+  const valueBuffer = Buffer.from(value, "utf8");
+  if (valueBuffer.byteLength > WINDOWS_CREDENTIAL_MAX_BLOB_BYTES) {
+    throw new Error(
+      `Windows Credential Manager value is too large (${valueBuffer.byteLength} bytes; max ${WINDOWS_CREDENTIAL_MAX_BLOB_BYTES} bytes)`,
+    );
+  }
+
+  await runWindowsCredentialCommand({
+    operation: "set",
+    service,
+    name,
+    valueBase64: valueBuffer.toString("base64"),
+  });
+}
+
+export async function deleteWindowsCredential(
+  service: string,
+  name: string,
+): Promise<boolean> {
+  const response = await runWindowsCredentialCommand({
+    operation: "delete",
+    service,
+    name,
+  });
+  return response.deleted === true;
+}
+
+export function __resetWindowsCredentialManagerAvailabilityForTests(): void {
+  availabilityCache = null;
+}


### PR DESCRIPTION
## Summary
- Add a Node-compatible Windows Credential Manager backend for secure auth persistence.
- Use the same credential target format as Bun/Desktop so npm CLI and Desktop can share saved auth.
- Batch token reads, preserve graceful fallback behavior, and keep settings.json fallback for unavailable secure storage.
- Add Windows credential adapter tests, including UTF-8 and Bun.secrets compatibility coverage.

## Testing
- bun test src/utils/secrets.test.ts
- bun test src/settings-manager.test.ts
- bunx --bun @biomejs/biome@2.2.5 check src/utils/secrets.ts src/utils/windows-credential-manager.ts src/utils/secrets.test.ts
- bun run typecheck
- bun run check
- Node smoke test with LETTA_API_KEY removed and temporary HOME: exit=0, no fallback tokens written to settings.json

## Notes
- On Windows, bun run build emits letta.js but still fails at the existing Unix chmod step; the emitted bundle was used for the Node smoke test.