### PR TITLE
fix(tui): preserve BYOK handle when cycling reasoning

### DIFF
--- a/src/agent/model-tier-selection.test.ts
+++ b/src/agent/model-tier-selection.test.ts
@@ -252,6 +252,9 @@ describe("getReasoningTierOptionsForHandle", () => {
       getChatGptFastRegistryHandleForModelHandle("openai-codex/gpt-5.4"),
     ).toBe("chatgpt-plus-pro/gpt-5.4-fast");
     expect(
+      getChatGptFastRegistryHandleForModelHandle("chatgpt-plus-pro/gpt-5.5"),
+    ).toBe("chatgpt-plus-pro/gpt-5.5-fast");
+    expect(
       getChatGptFastRegistryHandleForModelHandle("openai-codex/gpt-5.5-fast"),
     ).toBeNull();
   });

--- a/src/agent/model.ts
+++ b/src/agent/model.ts
@@ -110,7 +110,8 @@ export function getChatGptFastRegistryHandleForModelHandle(
   const [provider] = modelHandle.split("/");
   if (
     provider !== LOCAL_CHATGPT_OAUTH_HANDLE_PREFIX.slice(0, -1) &&
-    provider !== CHATGPT_OAUTH_LLM_CONFIG_PROVIDER
+    provider !== CHATGPT_OAUTH_LLM_CONFIG_PROVIDER &&
+    provider !== OPENAI_CODEX_PROVIDER_NAME
   ) {
     return null;
   }

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -869,6 +869,10 @@ export function App({
   const [currentModelHandle, setCurrentModelHandle] = useState<string | null>(
     null,
   );
+  const currentModelHandleRef = useRef(currentModelHandle);
+  useEffect(() => {
+    currentModelHandleRef.current = currentModelHandle;
+  }, [currentModelHandle]);
   // Derive agentName from agentState (single source of truth)
   const agentName = agentState?.name ?? null;
   const [agentDescription, setAgentDescription] = useState<string | null>(null);
@@ -4037,6 +4041,8 @@ export function App({
     modelHandle: string;
     effort: string;
     modelId: string;
+    providerType?: string | null;
+    serviceTier?: string | null;
   } | null>(null);
   const reasoningCycleLastConfirmedRef = useRef<LlmConfig | null>(null);
   const reasoningCycleLastConfirmedAgentStateRef = useRef<AgentState | null>(
@@ -4626,6 +4632,7 @@ export function App({
       commandRunner,
       conversationOverrideModelSettingsRef,
       conversationIdRef,
+      currentModelHandleRef,
       hasConversationModelOverrideRef,
       isAgentBusy,
       llmConfigRef,

--- a/src/cli/app/use-reasoning-cycle.test.ts
+++ b/src/cli/app/use-reasoning-cycle.test.ts
@@ -111,6 +111,32 @@ describe("resolveReasoningCycleTierLookupHandle", () => {
       } as unknown as AgentState["model_settings"]),
     ).toBe("chatgpt-plus-pro/gpt-5.5");
   });
+
+  test("uses ChatGPT OAuth registry handles for custom ChatGPT aliases", () => {
+    expect(
+      resolveReasoningCycleTierLookupHandle("chatgpt-personal/gpt-5.5", {
+        provider_type: "chatgpt_oauth",
+      } as unknown as AgentState["model_settings"]),
+    ).toBe("chatgpt-plus-pro/gpt-5.5");
+  });
+
+  test("keeps local provider handles unchanged for fallback tiers", () => {
+    expect(
+      resolveReasoningCycleTierLookupHandle("lmstudio/local-model", {
+        provider_type: "lmstudio_openai",
+      } as unknown as AgentState["model_settings"]),
+    ).toBe("lmstudio/local-model");
+    expect(
+      resolveReasoningCycleTierLookupHandle("llama.cpp/local-model", {
+        provider_type: "llama_cpp",
+      } as unknown as AgentState["model_settings"]),
+    ).toBe("llama.cpp/local-model");
+    expect(
+      resolveReasoningCycleTierLookupHandle("ollama-cloud/local-model", {
+        provider_type: "ollama_cloud",
+      } as unknown as AgentState["model_settings"]),
+    ).toBe("ollama-cloud/local-model");
+  });
 });
 
 describe("serviceTierForReasoningCycle", () => {
@@ -130,6 +156,15 @@ describe("serviceTierForReasoningCycle", () => {
         service_tier: null,
       } as unknown as AgentState["model_settings"]),
     ).toBeNull();
+  });
+
+  test("preserves canonical ChatGPT priority service tier", () => {
+    expect(
+      serviceTierForReasoningCycle("chatgpt-plus-pro/gpt-5.5", {
+        provider_type: "chatgpt_oauth",
+        service_tier: "priority",
+      } as unknown as AgentState["model_settings"]),
+    ).toBe("priority");
   });
 
   test("ignores non-ChatGPT Fast-capable models", () => {

--- a/src/cli/app/use-reasoning-cycle.test.ts
+++ b/src/cli/app/use-reasoning-cycle.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import {
   resolveReasoningCycleModelHandle,
+  resolveReasoningCycleTierLookupHandle,
   serviceTierForReasoningCycle,
 } from "@/cli/app/use-reasoning-cycle";
 
@@ -55,6 +56,59 @@ describe("resolveReasoningCycleModelHandle", () => {
         },
         null,
       ),
+    ).toBe("chatgpt-plus-pro/gpt-5.5");
+  });
+
+  test("preserves active BYOK alias handles over compatibility llm_config", () => {
+    expect(
+      resolveReasoningCycleModelHandle(
+        {
+          model: "claude-opus-4-8",
+          model_endpoint_type: "anthropic",
+          context_window: 200000,
+        },
+        null,
+        "lc-anthropic/claude-opus-4-8",
+      ),
+    ).toBe("lc-anthropic/claude-opus-4-8");
+  });
+
+  test("preserves agent BYOK alias handles over compatibility llm_config", () => {
+    expect(
+      resolveReasoningCycleModelHandle(
+        {
+          model: "claude-opus-4-8",
+          model_endpoint_type: "anthropic",
+          context_window: 200000,
+        },
+        "lc-anthropic/claude-opus-4-8",
+      ),
+    ).toBe("lc-anthropic/claude-opus-4-8");
+  });
+});
+
+describe("resolveReasoningCycleTierLookupHandle", () => {
+  test("uses canonical Anthropic registry handles for lc-anthropic aliases", () => {
+    expect(
+      resolveReasoningCycleTierLookupHandle("lc-anthropic/claude-opus-4-8", {
+        provider_type: "anthropic",
+      } as unknown as AgentState["model_settings"]),
+    ).toBe("anthropic/claude-opus-4-8");
+  });
+
+  test("keeps canonical handles unchanged", () => {
+    expect(
+      resolveReasoningCycleTierLookupHandle("anthropic/claude-opus-4-8", {
+        provider_type: "anthropic",
+      } as unknown as AgentState["model_settings"]),
+    ).toBe("anthropic/claude-opus-4-8");
+  });
+
+  test("uses ChatGPT OAuth registry handles for local ChatGPT aliases", () => {
+    expect(
+      resolveReasoningCycleTierLookupHandle("openai-codex/gpt-5.5", {
+        provider_type: "chatgpt_oauth",
+      } as unknown as AgentState["model_settings"]),
     ).toBe("chatgpt-plus-pro/gpt-5.5");
   });
 });

--- a/src/cli/app/use-reasoning-cycle.ts
+++ b/src/cli/app/use-reasoning-cycle.ts
@@ -150,6 +150,10 @@ export function resolveReasoningCycleTierLookupHandle(
     return normalizedHandle;
   }
 
+  if (isLocalModelHandle(modelHandle)) {
+    return modelHandle;
+  }
+
   const providerType = providerTypeFromModelSettings(modelSettings);
   const modelName = modelNameFromHandle(modelHandle);
   if (!providerType || !modelName) {
@@ -479,7 +483,7 @@ export function useReasoningCycle(ctx: ReasoningCycleContext) {
       const next = sorted[nextIndex];
       if (!next) return;
       const serviceTier = serviceTierForReasoningCycle(
-        modelHandle,
+        tierLookupHandle,
         modelSettingsForEffort,
       );
 

--- a/src/cli/app/use-reasoning-cycle.ts
+++ b/src/cli/app/use-reasoning-cycle.ts
@@ -13,6 +13,7 @@ import {
   getChatGptFastRegistryHandleForModelHandle,
   isLocalModelHandle,
   type ModelReasoningEffort,
+  normalizeModelHandleForRegistry,
 } from "@/agent/model";
 import { formatErrorDetails } from "@/cli/helpers/error-formatter";
 import { OPENAI_CODEX_PROVIDER_NAME } from "@/providers/openai-codex-provider";
@@ -28,6 +29,7 @@ type ReasoningCycleDesired = {
   modelHandle: string;
   effort: string;
   modelId: string;
+  providerType?: string | null;
   serviceTier?: string | null;
 };
 
@@ -61,6 +63,7 @@ type ReasoningCycleContext = {
     AgentState["model_settings"] | null
   >;
   conversationIdRef: MutableRefObject<string>;
+  currentModelHandleRef: MutableRefObject<string | null>;
   hasConversationModelOverrideRef: MutableRefObject<boolean>;
   isAgentBusy: () => boolean;
   llmConfigRef: MutableRefObject<LlmConfig | null>;
@@ -87,11 +90,36 @@ type ReasoningCycleContext = {
   withCommandLock: (fn: () => Promise<void>) => Promise<void>;
 };
 
+function isProviderQualifiedModelHandle(
+  modelHandle: string | null | undefined,
+): modelHandle is string {
+  if (!modelHandle) return false;
+  const slashIndex = modelHandle.indexOf("/");
+  return slashIndex > 0 && slashIndex < modelHandle.length - 1;
+}
+
+function modelNameFromHandle(modelHandle: string): string | null {
+  const slashIndex = modelHandle.indexOf("/");
+  if (slashIndex === -1 || slashIndex === modelHandle.length - 1) return null;
+  return modelHandle.slice(slashIndex + 1);
+}
+
+function registryProviderForProviderType(providerType: string): string {
+  return providerType === "chatgpt_oauth"
+    ? OPENAI_CODEX_PROVIDER_NAME
+    : providerType;
+}
+
 export function resolveReasoningCycleModelHandle(
   llmConfig: LlmConfig | null | undefined,
   agentModel: string | null | undefined,
+  currentModelHandle?: string | null,
 ): string | null {
-  if (agentModel && isLocalModelHandle(agentModel)) {
+  if (isProviderQualifiedModelHandle(currentModelHandle)) {
+    return currentModelHandle;
+  }
+
+  if (isProviderQualifiedModelHandle(agentModel)) {
     return agentModel;
   }
 
@@ -113,6 +141,30 @@ export function resolveReasoningCycleModelHandle(
   return model;
 }
 
+export function resolveReasoningCycleTierLookupHandle(
+  modelHandle: string,
+  modelSettings: AgentState["model_settings"] | null | undefined,
+): string {
+  const normalizedHandle = normalizeModelHandleForRegistry(modelHandle);
+  if (normalizedHandle && normalizedHandle !== modelHandle) {
+    return normalizedHandle;
+  }
+
+  const providerType = providerTypeFromModelSettings(modelSettings);
+  const modelName = modelNameFromHandle(modelHandle);
+  if (!providerType || !modelName) {
+    return normalizedHandle ?? modelHandle;
+  }
+
+  const registryProvider = registryProviderForProviderType(providerType);
+  const provider = modelHandle.split("/")[0];
+  if (provider === registryProvider) {
+    return normalizedHandle ?? modelHandle;
+  }
+
+  return `${registryProvider}/${modelName}`;
+}
+
 export function useReasoningCycle(ctx: ReasoningCycleContext) {
   const {
     agentId,
@@ -121,6 +173,7 @@ export function useReasoningCycle(ctx: ReasoningCycleContext) {
     commandRunner,
     conversationOverrideModelSettingsRef,
     conversationIdRef,
+    currentModelHandleRef,
     hasConversationModelOverrideRef,
     isAgentBusy,
     llmConfigRef,
@@ -196,6 +249,9 @@ export function useReasoningCycle(ctx: ReasoningCycleContext) {
               desired.modelHandle,
               {
                 reasoning_effort: desired.effort,
+                ...(desired.providerType
+                  ? { provider_type: desired.providerType }
+                  : {}),
                 ...(desired.serviceTier !== undefined
                   ? { service_tier: desired.serviceTier }
                   : {}),
@@ -211,6 +267,9 @@ export function useReasoningCycle(ctx: ReasoningCycleContext) {
               desired.modelHandle,
               {
                 reasoning_effort: desired.effort,
+                ...(desired.providerType
+                  ? { provider_type: desired.providerType }
+                  : {}),
                 ...(desired.serviceTier !== undefined
                   ? { service_tier: desired.serviceTier }
                   : {}),
@@ -358,25 +417,33 @@ export function useReasoningCycle(ctx: ReasoningCycleContext) {
       if (reasoningCycleInFlightRef.current) return;
 
       const current = llmConfigRef.current;
+      const modelSettingsForEffort = hasConversationModelOverrideRef.current
+        ? conversationOverrideModelSettingsRef.current
+        : agentStateRef.current?.model_settings;
+      const providerType = providerTypeFromModelSettings(
+        modelSettingsForEffort,
+      );
       const modelHandle = resolveReasoningCycleModelHandle(
         current,
         hasConversationModelOverrideRef.current
           ? null
           : (agentStateRef.current?.model ?? null),
+        currentModelHandleRef.current,
       );
       if (!modelHandle) return;
 
       // Derive current effort from effective model settings (conversation override aware)
-      const modelSettingsForEffort = hasConversationModelOverrideRef.current
-        ? conversationOverrideModelSettingsRef.current
-        : agentStateRef.current?.model_settings;
       const currentEffort =
         deriveReasoningEffort(modelSettingsForEffort, current) ?? "none";
+      const tierLookupHandle = resolveReasoningCycleTierLookupHandle(
+        modelHandle,
+        modelSettingsForEffort,
+      );
 
       const { getReasoningTierOptionsForHandle } = await import(
         "@/agent/model"
       );
-      const tiers = getReasoningTierOptionsForHandle(modelHandle).map(
+      const tiers = getReasoningTierOptionsForHandle(tierLookupHandle).map(
         (option) => ({
           id: option.modelId,
           effort: option.effort,
@@ -387,7 +454,7 @@ export function useReasoningCycle(ctx: ReasoningCycleContext) {
       if (tiers.length < 2) return;
 
       const anthropicXHighEffort = supportsDistinctAnthropicXHighEffort(
-        modelHandle,
+        tierLookupHandle,
       )
         ? "xhigh"
         : "max";
@@ -484,6 +551,7 @@ export function useReasoningCycle(ctx: ReasoningCycleContext) {
         modelHandle,
         effort: next.effort,
         modelId: next.id,
+        providerType,
         serviceTier,
       };
       if (reasoningCycleTimerRef.current) {


### PR DESCRIPTION
## Summary
- preserve the active provider-qualified model handle when Tab cycles reasoning tiers
- use a separate canonical registry handle for tier lookup so aliases like `lc-anthropic/claude-opus-4-8` still find Anthropic Opus reasoning options
- pass the existing `provider_type` through the reasoning update so aliased handles still rebuild provider-specific model settings correctly

## Repro Fixed
Before this change, tab reasoning on a conversation using `lc-anthropic/claude-opus-4-8` could persist the model as `anthropic/claude-opus-4-8`, losing the BYOK provider alias while showing a successful reasoning update.

## Tests
- `bun test src/cli/app/use-reasoning-cycle.test.ts`
- `bun run typecheck`
- `bun run lint`
