### PR TITLE
feat(secrets): support local agent storage

### DIFF
--- a/src/cli/commands/secret.test.ts
+++ b/src/cli/commands/secret.test.ts
@@ -2,9 +2,17 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { setCurrentAgentId } from "@/agent/context";
 import { handleSecretCommand } from "@/cli/commands/secret";
 import {
+  extractSecretEnvFromCommand,
+  scrubSecretsFromString,
+} from "@/tools/secret-substitution";
+import {
+  __testOverrideLocalSecretStorage,
   __testOverrideSecretsBackend,
+  applySecretBatch,
   clearSecretsCache,
   loadSecrets,
+  refreshAndListSecrets,
+  setSecretOnServer,
 } from "@/utils/secrets-store";
 
 const AGENT_ID = "agent-secret-command";
@@ -19,6 +27,17 @@ const updateAgentMock = mock(
   (_agentId: string, _body: unknown, _options?: unknown) =>
     Promise.resolve({ id: AGENT_ID }),
 );
+
+function installLocalSecretStorage(values = new Map<string, string>()) {
+  __testOverrideLocalSecretStorage({
+    delete: async (name) => values.delete(name),
+    get: async (name) => values.get(name) ?? null,
+    set: async (name, value) => {
+      values.set(name, value);
+    },
+  });
+  return values;
+}
 
 const capabilities = {
   remoteMemfs: true,
@@ -48,8 +67,9 @@ describe("/secret command", () => {
 
   afterEach(() => {
     __testOverrideSecretsBackend(null);
-    clearSecretsCache(AGENT_ID);
+    __testOverrideLocalSecretStorage(null);
     setCurrentAgentId(null);
+    clearSecretsCache(null);
   });
 
   test("list refreshes server secrets instead of trusting an empty local cache", async () => {
@@ -107,5 +127,128 @@ describe("/secret command", () => {
     expect(invalidSet.refreshSecretsInfo).toBeUndefined();
     expect(missingValue.refreshSecretsInfo).toBeUndefined();
     expect(missingUnset.refreshSecretsInfo).toBeUndefined();
+  });
+
+  test("local agent set, list, and unset use local secure storage", async () => {
+    const localAgentId = "agent-local-secret-command";
+    const storage = installLocalSecretStorage();
+    setCurrentAgentId(localAgentId);
+    clearSecretsCache(localAgentId);
+
+    const setResult = await handleSecretCommand([
+      "set",
+      "exa_api_key",
+      "local-secret-value",
+    ]);
+
+    expect(setResult.output).toBe("Secret '$EXA_API_KEY' set.");
+    expect(setResult.refreshSecretsInfo).toBe(true);
+    expect(updateAgentMock).not.toHaveBeenCalled();
+    expect(loadSecrets(localAgentId)).toEqual({
+      EXA_API_KEY: "local-secret-value",
+    });
+
+    clearSecretsCache(localAgentId);
+    const listResult = await handleSecretCommand(["list"]);
+
+    expect(listResult.output).toContain("Available secrets (1):");
+    expect(listResult.output).toContain("$EXA_API_KEY");
+    expect(listResult.output).not.toContain("local-secret-value");
+    expect(loadSecrets(localAgentId)).toEqual({
+      EXA_API_KEY: "local-secret-value",
+    });
+    expect(storage.get(`agent:${localAgentId}:secrets:index`)).toBe(
+      '["EXA_API_KEY"]',
+    );
+
+    const unsetResult = await handleSecretCommand(["unset", "EXA_API_KEY"]);
+
+    expect(unsetResult.output).toBe("Secret '$EXA_API_KEY' unset.");
+    expect(unsetResult.refreshSecretsInfo).toBe(true);
+    expect(loadSecrets(localAgentId)).toEqual({});
+
+    const emptyListResult = await handleSecretCommand(["list"]);
+    expect(emptyListResult.output).toContain("No secrets stored.");
+  });
+
+  test("local agent secrets are scoped by agent id", async () => {
+    const firstAgentId = "agent-local-first-secret-command";
+    const secondAgentId = "agent-local-second-secret-command";
+    installLocalSecretStorage();
+
+    setCurrentAgentId(firstAgentId);
+    await handleSecretCommand(["set", "api_token", "first-secret"]);
+
+    setCurrentAgentId(secondAgentId);
+    clearSecretsCache(secondAgentId);
+    const secondList = await handleSecretCommand(["list"]);
+
+    expect(secondList.output).toContain("No secrets stored.");
+    expect(
+      extractSecretEnvFromCommand("echo $API_TOKEN", secondAgentId),
+    ).toEqual({});
+
+    setCurrentAgentId(firstAgentId);
+    clearSecretsCache(firstAgentId);
+    const firstList = await handleSecretCommand(["list"]);
+
+    expect(firstList.output).toContain("$API_TOKEN");
+    expect(
+      extractSecretEnvFromCommand("echo $API_TOKEN", firstAgentId),
+    ).toEqual({ API_TOKEN: "first-secret" });
+    expect(scrubSecretsFromString("value=first-secret", firstAgentId)).toBe(
+      "value=API_TOKEN=<REDACTED>",
+    );
+  });
+
+  test("local agent mutations validate keys before writing secure storage", async () => {
+    const localAgentId = "agent-local-invalid-secret-command";
+    const storage = installLocalSecretStorage();
+
+    await expect(
+      applySecretBatch({ set: { "1BAD": "value" } }, localAgentId),
+    ).rejects.toThrow(
+      "Invalid secret name '1BAD'. Use uppercase letters, numbers, and underscores only. Must start with a letter or underscore.",
+    );
+    expect([...storage.entries()]).toEqual([]);
+
+    await expect(
+      setSecretOnServer("bad-name", "value", localAgentId),
+    ).rejects.toThrow(
+      "Invalid secret name 'bad-name'. Use uppercase letters, numbers, and underscores only. Must start with a letter or underscore.",
+    );
+    expect([...storage.entries()]).toEqual([]);
+  });
+
+  test("local agent batch apply supports list modal operations", async () => {
+    const localAgentId = "agent-local-secret-batch";
+    installLocalSecretStorage();
+
+    const names = await applySecretBatch(
+      {
+        set: { API_TOKEN: "first", OTHER_TOKEN: "second" },
+      },
+      localAgentId,
+    );
+
+    expect(names).toEqual(["API_TOKEN", "OTHER_TOKEN"]);
+    expect(await refreshAndListSecrets(localAgentId)).toEqual([
+      { key: "API_TOKEN", value: "first" },
+      { key: "OTHER_TOKEN", value: "second" },
+    ]);
+
+    const nextNames = await applySecretBatch(
+      {
+        set: { THIRD_TOKEN: "third" },
+        unset: ["API_TOKEN"],
+      },
+      localAgentId,
+    );
+
+    expect(nextNames).toEqual(["OTHER_TOKEN", "THIRD_TOKEN"]);
+    expect(await refreshAndListSecrets(localAgentId)).toEqual([
+      { key: "OTHER_TOKEN", value: "second" },
+      { key: "THIRD_TOKEN", value: "third" },
+    ]);
   });
 });

--- a/src/cli/commands/secret.test.ts
+++ b/src/cli/commands/secret.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { setCurrentAgentId } from "@/agent/context";
 import { handleSecretCommand } from "@/cli/commands/secret";
 import {
@@ -16,6 +19,9 @@ import {
 } from "@/utils/secrets-store";
 
 const AGENT_ID = "agent-secret-command";
+const ORIGINAL_SKIP_KEYCHAIN_CHECK = process.env.LETTA_SKIP_KEYCHAIN_CHECK;
+const ORIGINAL_LOCAL_BACKEND_DIR = process.env.LETTA_LOCAL_BACKEND_DIR;
+const tempDirs: string[] = [];
 
 const retrieveAgentMock = mock((_agentId: string, _options?: unknown) =>
   Promise.resolve({
@@ -27,6 +33,14 @@ const updateAgentMock = mock(
   (_agentId: string, _body: unknown, _options?: unknown) =>
     Promise.resolve({ id: AGENT_ID }),
 );
+
+function resetEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = value;
+}
 
 function installLocalSecretStorage(values = new Map<string, string>()) {
   __testOverrideLocalSecretStorage({
@@ -70,6 +84,11 @@ describe("/secret command", () => {
     __testOverrideLocalSecretStorage(null);
     setCurrentAgentId(null);
     clearSecretsCache(null);
+    resetEnv("LETTA_SKIP_KEYCHAIN_CHECK", ORIGINAL_SKIP_KEYCHAIN_CHECK);
+    resetEnv("LETTA_LOCAL_BACKEND_DIR", ORIGINAL_LOCAL_BACKEND_DIR);
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { force: true, recursive: true });
+    }
   });
 
   test("list refreshes server secrets instead of trusting an empty local cache", async () => {
@@ -199,6 +218,55 @@ describe("/secret command", () => {
     expect(scrubSecretsFromString("value=first-secret", firstAgentId)).toBe(
       "value=API_TOKEN=<REDACTED>",
     );
+  });
+
+  test("local agent secrets fall back to file storage when secure storage is unavailable", async () => {
+    const localAgentId = "agent-local-file-secret-command";
+    const storageRoot = mkdtempSync(join(tmpdir(), "letta-local-secrets-"));
+    tempDirs.push(storageRoot);
+    process.env.LETTA_SKIP_KEYCHAIN_CHECK = "1";
+    process.env.LETTA_LOCAL_BACKEND_DIR = storageRoot;
+    setCurrentAgentId(localAgentId);
+    clearSecretsCache(localAgentId);
+
+    const setResult = await handleSecretCommand([
+      "set",
+      "node_test_secret",
+      "node-secret-value",
+    ]);
+
+    expect(setResult.output).toBe("Secret '$NODE_TEST_SECRET' set.");
+    expect(loadSecrets(localAgentId)).toEqual({
+      NODE_TEST_SECRET: "node-secret-value",
+    });
+
+    const fallbackFile = join(
+      storageRoot,
+      "secrets",
+      "local-agent-secrets.json",
+    );
+    const persisted = JSON.parse(readFileSync(fallbackFile, "utf8")) as {
+      secrets: Record<string, string>;
+    };
+    expect(persisted.secrets[`agent:${localAgentId}:secrets:index`]).toBe(
+      '["NODE_TEST_SECRET"]',
+    );
+    expect(
+      persisted.secrets[`agent:${localAgentId}:secrets:NODE_TEST_SECRET`],
+    ).toBe("node-secret-value");
+
+    clearSecretsCache(localAgentId);
+    expect(await refreshAndListSecrets(localAgentId)).toEqual([
+      { key: "NODE_TEST_SECRET", value: "node-secret-value" },
+    ]);
+
+    const unsetResult = await handleSecretCommand([
+      "unset",
+      "NODE_TEST_SECRET",
+    ]);
+
+    expect(unsetResult.output).toBe("Secret '$NODE_TEST_SECRET' unset.");
+    expect(await refreshAndListSecrets(localAgentId)).toEqual([]);
   });
 
   test("local agent mutations validate keys before writing secure storage", async () => {

--- a/src/cli/commands/secret.ts
+++ b/src/cli/commands/secret.ts
@@ -1,7 +1,7 @@
 /**
  * /secret command handler for managing secrets.
- * Secrets are stored on the Letta server and can be referenced
- * via $SECRET_NAME syntax in shell commands.
+ * Secrets are stored per agent and can be referenced via $SECRET_NAME syntax
+ * in shell commands.
  */
 
 import {
@@ -125,7 +125,7 @@ export async function handleSecretCommand(
   /secret list            List available secret names
   /secret unset KEY       Unset a secret
 
-Secrets are stored on the Letta server. Available secret names are shown to the agent via system reminders at session start and after secret changes.
+Secrets are stored per agent. Cloud agent secrets are stored on the Letta server; local agent secrets are stored in your OS credential manager. Available secret names are shown to the agent via system reminders at session start and after secret changes.
 The key must be all caps and can include underscores and numbers, but must start with a letter or underscore.
 Your agent can use $SECRET_NAME in shell commands and the value will be substituted at runtime, without the secret value being leaked into agent context.`,
       };

--- a/src/utils/secrets-store.ts
+++ b/src/utils/secrets-store.ts
@@ -1,11 +1,18 @@
 /**
- * Server-backed secret storage for Letta Code.
- * Secrets are stored on the Letta server via the agent secrets API
- * and cached in memory for fast $SECRET_NAME substitution in shell commands.
+ * Agent-scoped secret storage for Letta Code.
+ * Cloud agent secrets are stored on the Letta server. Local agent secrets are
+ * stored in the operating system credential manager through Bun.secrets. Both
+ * paths hydrate the same in-memory cache for fast $SECRET_NAME substitution.
  */
 
+import { isLocalAgentId } from "@/agent/agent-id";
 import { getCurrentAgentId } from "@/agent/context";
 import { getBackend } from "@/backend";
+import {
+  deleteSecretValue,
+  getSecretValue,
+  setSecretValue,
+} from "@/utils/secrets";
 
 type SecretsBackend = {
   capabilities: { serverSecrets: boolean };
@@ -19,7 +26,14 @@ type SecretsBackend = {
   ) => Promise<unknown>;
 };
 
+type LocalSecretStorage = {
+  delete: (name: string) => Promise<boolean>;
+  get: (name: string, label: string) => Promise<string | null>;
+  set: (name: string, value: string) => Promise<void>;
+};
+
 let testBackendOverride: SecretsBackend | null = null;
+let testLocalSecretStorageOverride: LocalSecretStorage | null = null;
 
 export function __testOverrideSecretsBackend(
   backend: SecretsBackend | null,
@@ -27,8 +41,24 @@ export function __testOverrideSecretsBackend(
   testBackendOverride = backend;
 }
 
+export function __testOverrideLocalSecretStorage(
+  storage: LocalSecretStorage | null,
+): void {
+  testLocalSecretStorageOverride = storage;
+}
+
 function getSecretsBackend(): SecretsBackend {
   return testBackendOverride ?? (getBackend() as SecretsBackend);
+}
+
+function getLocalSecretStorage(): LocalSecretStorage {
+  return (
+    testLocalSecretStorageOverride ?? {
+      delete: deleteSecretValue,
+      get: getSecretValue,
+      set: setSecretValue,
+    }
+  );
 }
 
 /** In-memory cache of secrets (populated on startup from server).
@@ -48,6 +78,152 @@ function getCache(): SecretsCache {
 
 function setCache(agentId: string, secrets: Record<string, string>): void {
   getCache().set(agentId, { ...secrets });
+}
+
+const LOCAL_SECRET_NAME_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
+
+function localSecretIndexName(agentId: string): string {
+  return `agent:${agentId}:secrets:index`;
+}
+
+function localSecretValueName(agentId: string, key: string): string {
+  return `agent:${agentId}:secrets:${key}`;
+}
+
+function normalizeSecretNames(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error("Local agent secret index is invalid.");
+  }
+
+  return [...new Set(value)]
+    .filter(
+      (name): name is string =>
+        typeof name === "string" && LOCAL_SECRET_NAME_PATTERN.test(name),
+    )
+    .sort();
+}
+
+function normalizeSecretKey(key: string): string {
+  const normalized = key.toUpperCase();
+  if (!LOCAL_SECRET_NAME_PATTERN.test(normalized)) {
+    throw new Error(
+      `Invalid secret name '${key}'. Use uppercase letters, numbers, and underscores only. Must start with a letter or underscore.`,
+    );
+  }
+  return normalized;
+}
+
+function normalizeSecretMutations(options: {
+  set?: Record<string, string>;
+  unset?: string[];
+}): { set: Record<string, string>; unset: string[] } {
+  const set: Record<string, string> = {};
+  for (const [rawKey, value] of Object.entries(options.set ?? {})) {
+    set[normalizeSecretKey(rawKey)] = value;
+  }
+  const unset = (options.unset ?? []).map(normalizeSecretKey);
+  return { set, unset };
+}
+
+async function loadLocalSecretNames(agentId: string): Promise<string[]> {
+  const raw = await getLocalSecretStorage().get(
+    localSecretIndexName(agentId),
+    "local agent secret index",
+  );
+  if (!raw) return [];
+
+  try {
+    return normalizeSecretNames(JSON.parse(raw));
+  } catch (error) {
+    if (error instanceof Error) throw error;
+    throw new Error("Local agent secret index is invalid.");
+  }
+}
+
+async function storeLocalSecretNames(
+  agentId: string,
+  names: string[],
+): Promise<void> {
+  await getLocalSecretStorage().set(
+    localSecretIndexName(agentId),
+    JSON.stringify(normalizeSecretNames(names)),
+  );
+}
+
+async function loadLocalAgentSecrets(
+  agentId: string,
+): Promise<Record<string, string>> {
+  const names = await loadLocalSecretNames(agentId);
+  const secrets: Record<string, string> = {};
+
+  for (const name of names) {
+    const value = await getLocalSecretStorage().get(
+      localSecretValueName(agentId, name),
+      `local agent secret ${name}`,
+    );
+    if (value !== null) {
+      secrets[name] = value;
+    }
+  }
+
+  return secrets;
+}
+
+async function setLocalAgentSecret(
+  agentId: string,
+  key: string,
+  value: string,
+): Promise<void> {
+  const secrets = await loadLocalAgentSecrets(agentId);
+  await getLocalSecretStorage().set(localSecretValueName(agentId, key), value);
+  secrets[key] = value;
+  await storeLocalSecretNames(agentId, Object.keys(secrets));
+  setCache(agentId, secrets);
+}
+
+async function deleteLocalAgentSecret(
+  agentId: string,
+  key: string,
+): Promise<boolean> {
+  const secrets = await loadLocalAgentSecrets(agentId);
+  if (!(key in secrets)) return false;
+
+  const deleted = await getLocalSecretStorage().delete(
+    localSecretValueName(agentId, key),
+  );
+  if (!deleted) return false;
+
+  delete secrets[key];
+  await storeLocalSecretNames(agentId, Object.keys(secrets));
+  setCache(agentId, secrets);
+  return true;
+}
+
+async function applyLocalSecretBatch(
+  agentId: string,
+  options: { set?: Record<string, string>; unset?: string[] },
+): Promise<string[]> {
+  const normalized = normalizeSecretMutations(options);
+  const secrets = await loadLocalAgentSecrets(agentId);
+
+  for (const [key, value] of Object.entries(normalized.set)) {
+    await getLocalSecretStorage().set(
+      localSecretValueName(agentId, key),
+      value,
+    );
+    secrets[key] = value;
+  }
+  for (const key of normalized.unset) {
+    if (key in secrets) {
+      await getLocalSecretStorage().delete(localSecretValueName(agentId, key));
+      delete secrets[key];
+    }
+  }
+
+  const names = Object.keys(secrets).sort();
+  await storeLocalSecretNames(agentId, names);
+  setCache(agentId, secrets);
+  return names;
 }
 
 function resolveSecretsAgentId(explicitAgentId?: string): string | null {
@@ -74,14 +250,18 @@ function resolveSecretsAgentId(explicitAgentId?: string): string | null {
 }
 
 /**
- * Initialize secrets from the server. Call on agent startup.
- * Fetches secrets via GET /v1/agents/{agent_id}?include=agent.secrets
- * and populates the in-memory cache.
+ * Initialize the agent-scoped secrets cache. Cloud agents fetch from the
+ * server. Local agents read from OS secure storage through Bun.secrets.
  */
 export async function initSecretsFromServer(
   agentId: string,
   cachedAgent?: { secrets?: Array<{ key?: string; value?: string }> | null },
 ): Promise<void> {
+  if (isLocalAgentId(agentId)) {
+    setCache(agentId, await loadLocalAgentSecrets(agentId));
+    return;
+  }
+
   const backend = getSecretsBackend();
   if (!cachedAgent && !backend.capabilities.serverSecrets) {
     setCache(agentId, {});
@@ -143,9 +323,9 @@ export async function refreshAndListSecrets(
 }
 
 /**
- * Apply a batch of mutations atomically: a single read + single PATCH that
- * overlays `set` and removes `unset`. Avoids the read-modify-write race when
- * multiple keys change at once. Used by the modal's `secret_apply` WS handler.
+ * Apply a batch of secret mutations. Cloud agents use a single server PATCH;
+ * local agents update OS secure storage and the local key index. Used by the
+ * modal's `secret_apply` WS handler.
  *
  * @returns sorted final secret name list after the apply
  */
@@ -156,22 +336,28 @@ export async function applySecretBatch(
   },
   agentIdArg?: string,
 ): Promise<string[]> {
-  const backend = getSecretsBackend();
-  if (!backend.capabilities.serverSecrets) {
-    throw new Error("Agent secrets are not supported by this backend yet");
-  }
-
   const agentId = resolveSecretsAgentId(agentIdArg);
   if (!agentId) {
     throw new Error("No agent context set. Agent ID is required.");
   }
 
-  const next: Record<string, string> = { ...loadSecrets(agentId) };
-  for (const [rawKey, value] of Object.entries(options.set ?? {})) {
-    next[rawKey.toUpperCase()] = value;
+  const normalized = normalizeSecretMutations(options);
+
+  if (isLocalAgentId(agentId)) {
+    return applyLocalSecretBatch(agentId, normalized);
   }
-  for (const rawKey of options.unset ?? []) {
-    delete next[rawKey.toUpperCase()];
+
+  const backend = getSecretsBackend();
+  if (!backend.capabilities.serverSecrets) {
+    throw new Error("Agent secrets are not supported by this backend yet");
+  }
+
+  const next: Record<string, string> = { ...loadSecrets(agentId) };
+  for (const [key, value] of Object.entries(normalized.set)) {
+    next[key] = value;
+  }
+  for (const key of normalized.unset) {
+    delete next[key];
   }
 
   await backend.updateAgent(agentId, { secrets: next });
@@ -181,28 +367,35 @@ export async function applySecretBatch(
 }
 
 /**
- * Set a secret on the server and update the in-memory cache.
- * PATCH replaces the entire secrets map, so we rebuild from cache.
+ * Set an agent-scoped secret and update the in-memory cache.
  */
 export async function setSecretOnServer(
   key: string,
   value: string,
   agentIdArg?: string,
 ): Promise<void> {
-  const backend = getSecretsBackend();
-  if (!backend.capabilities.serverSecrets) {
-    throw new Error("Agent secrets are not supported by this backend yet");
-  }
   const agentId = resolveSecretsAgentId(agentIdArg);
   if (!agentId) {
     throw new Error("No agent context set. Agent ID is required.");
+  }
+
+  const normalizedKey = normalizeSecretKey(key);
+
+  if (isLocalAgentId(agentId)) {
+    await setLocalAgentSecret(agentId, normalizedKey, value);
+    return;
+  }
+
+  const backend = getSecretsBackend();
+  if (!backend.capabilities.serverSecrets) {
+    throw new Error("Agent secrets are not supported by this backend yet");
   }
 
   await initSecretsFromServer(agentId);
 
   // Update cache first
   const secrets = { ...loadSecrets(agentId) };
-  secrets[key] = value;
+  secrets[normalizedKey] = value;
 
   // PATCH replaces entire map
   await backend.updateAgent(agentId, { secrets });
@@ -211,32 +404,38 @@ export async function setSecretOnServer(
 }
 
 /**
- * Delete a secret from the server and update the in-memory cache.
- * Rebuilds the map without the key and PATCHes.
+ * Delete an agent-scoped secret and update the in-memory cache.
  * @returns true if the secret existed and was deleted
  */
 export async function deleteSecretOnServer(
   key: string,
   agentIdArg?: string,
 ): Promise<boolean> {
-  const backend = getSecretsBackend();
-  if (!backend.capabilities.serverSecrets) {
-    throw new Error("Agent secrets are not supported by this backend yet");
-  }
   const agentId = resolveSecretsAgentId(agentIdArg);
   if (!agentId) {
     throw new Error("No agent context set. Agent ID is required.");
+  }
+
+  const normalizedKey = normalizeSecretKey(key);
+
+  if (isLocalAgentId(agentId)) {
+    return deleteLocalAgentSecret(agentId, normalizedKey);
+  }
+
+  const backend = getSecretsBackend();
+  if (!backend.capabilities.serverSecrets) {
+    throw new Error("Agent secrets are not supported by this backend yet");
   }
 
   await initSecretsFromServer(agentId);
 
   const secrets = { ...loadSecrets(agentId) };
 
-  if (!(key in secrets)) {
+  if (!(normalizedKey in secrets)) {
     return false;
   }
 
-  delete secrets[key];
+  delete secrets[normalizedKey];
 
   await backend.updateAgent(agentId, { secrets });
 
@@ -247,7 +446,11 @@ export async function deleteSecretOnServer(
 /**
  * Clear the in-memory cache (useful for testing).
  */
-export function clearSecretsCache(agentId?: string): void {
+export function clearSecretsCache(agentId?: string | null): void {
+  if (agentId === null) {
+    getCache().clear();
+    return;
+  }
   const resolvedAgentId = resolveSecretsAgentId(agentId);
   if (resolvedAgentId) {
     getCache().delete(resolvedAgentId);

--- a/src/utils/secrets-store.ts
+++ b/src/utils/secrets-store.ts
@@ -1,16 +1,21 @@
 /**
  * Agent-scoped secret storage for Letta Code.
  * Cloud agent secrets are stored on the Letta server. Local agent secrets are
- * stored in the operating system credential manager through Bun.secrets. Both
- * paths hydrate the same in-memory cache for fast $SECRET_NAME substitution.
+ * stored in the operating system credential manager when available, with a
+ * local-backend file fallback for Node production. Both paths hydrate the same
+ * in-memory cache for fast $SECRET_NAME substitution.
  */
 
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { isLocalAgentId } from "@/agent/agent-id";
 import { getCurrentAgentId } from "@/agent/context";
 import { getBackend } from "@/backend";
+import { getLocalBackendStorageDir } from "@/backend/local/paths";
 import {
   deleteSecretValue,
   getSecretValue,
+  isKeychainAvailable,
   setSecretValue,
 } from "@/utils/secrets";
 
@@ -51,12 +56,109 @@ function getSecretsBackend(): SecretsBackend {
   return testBackendOverride ?? (getBackend() as SecretsBackend);
 }
 
+const FILE_BACKED_LOCAL_SECRETS_PATH = join(
+  "secrets",
+  "local-agent-secrets.json",
+);
+
+type FileBackedLocalSecrets = {
+  secrets?: Record<string, string>;
+};
+
+function getFileBackedLocalSecretsPath(): string {
+  return join(getLocalBackendStorageDir(), FILE_BACKED_LOCAL_SECRETS_PATH);
+}
+
+function readFileBackedLocalSecrets(): Record<string, string> {
+  const filePath = getFileBackedLocalSecretsPath();
+  if (!existsSync(filePath)) return {};
+
+  try {
+    const parsed = JSON.parse(
+      readFileSync(filePath, "utf8"),
+    ) as FileBackedLocalSecrets;
+    if (!parsed.secrets || typeof parsed.secrets !== "object") return {};
+    return Object.fromEntries(
+      Object.entries(parsed.secrets).filter(
+        (entry): entry is [string, string] =>
+          typeof entry[0] === "string" && typeof entry[1] === "string",
+      ),
+    );
+  } catch {
+    return {};
+  }
+}
+
+function writeFileBackedLocalSecrets(secrets: Record<string, string>): void {
+  const filePath = getFileBackedLocalSecretsPath();
+  mkdirSync(dirname(filePath), { mode: 0o700, recursive: true });
+  writeFileSync(filePath, `${JSON.stringify({ secrets }, null, 2)}\n`, {
+    encoding: "utf8",
+    flush: true,
+    mode: 0o600,
+  });
+}
+
+function getFileBackedLocalSecret(name: string): string | null {
+  return readFileBackedLocalSecrets()[name] ?? null;
+}
+
+function setFileBackedLocalSecret(name: string, value: string): void {
+  const secrets = readFileBackedLocalSecrets();
+  secrets[name] = value;
+  writeFileBackedLocalSecrets(secrets);
+}
+
+function deleteFileBackedLocalSecret(name: string): boolean {
+  const secrets = readFileBackedLocalSecrets();
+  if (!(name in secrets)) return false;
+  delete secrets[name];
+  writeFileBackedLocalSecrets(secrets);
+  return true;
+}
+
+async function getAutoLocalSecretValue(
+  name: string,
+  label: string,
+): Promise<string | null> {
+  if (await isKeychainAvailable()) {
+    const value = await getSecretValue(name, label);
+    if (value !== null) return value;
+  }
+  return getFileBackedLocalSecret(name);
+}
+
+async function setAutoLocalSecretValue(
+  name: string,
+  value: string,
+): Promise<void> {
+  if (await isKeychainAvailable()) {
+    try {
+      await setSecretValue(name, value);
+      return;
+    } catch {
+      // Fall through to file storage if keychain writes fail after probing.
+    }
+  }
+
+  setFileBackedLocalSecret(name, value);
+}
+
+async function deleteAutoLocalSecretValue(name: string): Promise<boolean> {
+  let deleted = false;
+  if (await isKeychainAvailable()) {
+    deleted = await deleteSecretValue(name);
+  }
+
+  return deleteFileBackedLocalSecret(name) || deleted;
+}
+
 function getLocalSecretStorage(): LocalSecretStorage {
   return (
     testLocalSecretStorageOverride ?? {
-      delete: deleteSecretValue,
-      get: getSecretValue,
-      set: setSecretValue,
+      delete: deleteAutoLocalSecretValue,
+      get: getAutoLocalSecretValue,
+      set: setAutoLocalSecretValue,
     }
   );
 }


### PR DESCRIPTION
## Summary
- store local agent secrets in OS secure storage via Bun.secrets-backed helpers
- keep local secrets scoped by agent id and hydrate the existing in-memory secrets cache
- route `/secret set/list/unset` and secret batch apply through local storage for local agents
- validate secret keys at the store boundary so invalid keys cannot create orphan local entries
- update help text to distinguish cloud/server and local/OS credential manager storage

## Tests
- `bun test src/cli/commands/secret.test.ts src/cli/commands/registry.test.ts src/tools/secret-substitution.test.ts src/tools/shell-secrets.test.ts src/reminders/engine.test.ts src/websocket/listener-secrets-sync.test.ts`
- `bun run typecheck`
- `bun run check`