### PR TITLE
refactor(mods): remove loose terminology

### DIFF
--- a/src/cli/mods/local-mod-loader.test.ts
+++ b/src/cli/mods/local-mod-loader.test.ts
@@ -168,7 +168,7 @@ describe("local mod loader", () => {
     }
   });
 
-  test("discovers managed package entries after loose global mods", () => {
+  test("discovers managed package entries after harness mod files", () => {
     const root = createTempDir();
     try {
       const { globalModsDirectory: globalMods } = createLoadOptions(root);
@@ -181,9 +181,9 @@ describe("local mod loader", () => {
       );
       const packageMod = path.join(packageRoot, "mods", "index.ts");
       const packageExtra = path.join(packageRoot, "mods", "extra.ts");
-      const looseMod = path.join(globalMods, "loose.ts");
+      const modFile = path.join(globalMods, "mod-file.ts");
       mkdirSync(path.dirname(packageMod), { recursive: true });
-      writeFileSync(looseMod, "export default () => {};\n");
+      writeFileSync(modFile, "export default () => {};\n");
       writeFileSync(packageMod, "export default () => {};\n");
       writeFileSync(packageExtra, "export default () => {};\n");
       writeFileSync(
@@ -216,7 +216,7 @@ describe("local mod loader", () => {
         }),
       ).toEqual([
         {
-          files: [looseMod, packageMod],
+          files: [modFile, packageMod],
           managedPackageRoots: [packageRoot],
           root: globalMods,
           scope: "global",

--- a/src/cli/subcommands/mods.test.ts
+++ b/src/cli/subcommands/mods.test.ts
@@ -106,7 +106,7 @@ afterEach(() => {
 });
 
 describe("mods subcommand", () => {
-  test("lists harness loose mods without an agent section", () => {
+  test("lists harness mods without an agent section", () => {
     const root = createTempDir();
     const harnessMods = join(root, "mods");
     mkdirSync(harnessMods, { recursive: true });
@@ -164,7 +164,7 @@ describe("mods subcommand", () => {
     );
   });
 
-  test("lists agent loose mods before harness loose mods", () => {
+  test("lists agent mods before harness mods", () => {
     const root = createTempDir();
     const harnessMods = join(root, "mods");
     const agentMods = join(root, "memory", "mods");
@@ -215,7 +215,7 @@ describe("mods subcommand", () => {
     );
   });
 
-  test("uses runtime loose mod discovery rules", () => {
+  test("uses runtime mod file discovery rules", () => {
     const root = createTempDir();
     const harnessMods = join(root, "mods");
     mkdirSync(join(harnessMods, "nested"), { recursive: true });
@@ -229,7 +229,7 @@ describe("mods subcommand", () => {
     expect(result.harness.files).toEqual([join(harnessMods, "visible.tsx")]);
   });
 
-  test("lists installed packages separately from harness loose mods", () => {
+  test("lists installed packages separately from harness mods", () => {
     const root = createTempDir();
     const harnessMods = join(root, "mods");
     mkdirSync(harnessMods, { recursive: true });

--- a/src/cli/subcommands/mods.ts
+++ b/src/cli/subcommands/mods.ts
@@ -16,15 +16,15 @@ import {
   resolveDefaultGlobalModsDirectory,
 } from "@/mods/paths";
 
-interface LooseModSection {
+interface ModFileSection {
   files: string[];
   root: string;
 }
 
 export interface ModsList {
-  agent?: LooseModSection;
-  harness: LooseModSection;
-  legacyHarness?: LooseModSection;
+  agent?: ModFileSection;
+  harness: ModFileSection;
+  legacyHarness?: ModFileSection;
   packageDiagnostics: ManagedModPackageDiagnostic[];
   packages: ManagedModPackageListItem[];
 }
@@ -66,7 +66,7 @@ Usage:
   letta mods remove <package-spec>
 
 Options:
-  --agent <id>       Include loose mods from this agent's MemFS directory
+  --agent <id>       Include agent mods from this agent's MemFS directory
   --agent-id <id>    Alias for --agent
   -h, --help         Show this help
 `.trim(),
@@ -108,7 +108,7 @@ function directFilesForSource(source: LocalModSource): string[] {
   return source.files.filter((file) => dirname(file) === source.root);
 }
 
-function toSection(source: LocalModSource): LooseModSection {
+function toSection(source: LocalModSource): ModFileSection {
   return {
     files: directFilesForSource(source),
     root: source.root,
@@ -147,10 +147,7 @@ export function listMods(options: ListModsOptions = {}): ModsList {
   };
 }
 
-function formatLooseModSection(
-  title: string,
-  section: LooseModSection,
-): string {
+function formatModFileSection(title: string, section: ModFileSection): string {
   const lines = [title];
   if (section.files.length === 0) {
     lines.push("  (none)");
@@ -194,14 +191,14 @@ function formatInstalledPackagesSection(
 export function formatModsList(mods: ModsList): string {
   const sections: string[] = [];
   if (mods.agent) {
-    sections.push(formatLooseModSection("Agent mods", mods.agent));
+    sections.push(formatModFileSection("Agent mods", mods.agent));
   }
   if (mods.legacyHarness) {
     sections.push(
-      formatLooseModSection("Legacy extensions", mods.legacyHarness),
+      formatModFileSection("Legacy extensions", mods.legacyHarness),
     );
   }
-  sections.push(formatLooseModSection("Harness mods", mods.harness));
+  sections.push(formatModFileSection("Harness mods", mods.harness));
   sections.push(formatInstalledPackagesSection(mods));
   return sections.join("\n\n");
 }
@@ -358,7 +355,7 @@ async function runPackageScaffold(argv: string[]): Promise<number> {
     console.log(`Created mod package ${result.outputDirectory}`);
     console.log(`Copied ${result.sourceFile} -> ${result.targetModPath}`);
     console.log(
-      "The original loose mod is still present and may still load until you remove it.",
+      "The original mod file is still present and may still load until you remove it.",
     );
     console.log(`Install with: ${result.installCommand}`);
     return 0;

--- a/src/mods/package-registry.test.ts
+++ b/src/mods/package-registry.test.ts
@@ -312,12 +312,12 @@ describe("managed mod package registry", () => {
     const root = createTempDir();
     const modsRoot = path.join(root, "mods");
     mkdirSync(modsRoot, { recursive: true });
-    const looseModPath = path.join(modsRoot, "loose.ts");
-    writeFileSync(looseModPath, "export {};\n");
+    const modFilePath = path.join(modsRoot, "mod-file.ts");
+    writeFileSync(modFilePath, "export {};\n");
     writeRegistry(modsRoot, [
       {
         enabled: true,
-        root: "loose.ts",
+        root: "mod-file.ts",
         source: "npm:@caren/my-mod",
         version: "0.1.0",
       },
@@ -329,7 +329,7 @@ describe("managed mod package registry", () => {
         specifier: "npm:@caren/my-mod",
       }),
     ).toThrow("Refusing to remove npm:@caren/my-mod@0.1.0");
-    expect(existsSync(looseModPath)).toBe(true);
+    expect(existsSync(modFilePath)).toBe(true);
     expect(readRegistry(modsRoot).packages).toHaveLength(1);
   });
 

--- a/src/mods/package-scaffolder.test.ts
+++ b/src/mods/package-scaffolder.test.ts
@@ -29,7 +29,7 @@ afterEach(() => {
 });
 
 describe("local mod package scaffolder", () => {
-  test("creates a package scaffold from a loose mod file", () => {
+  test("creates a package scaffold from a mod file", () => {
     const root = createTempDir();
     const sourceFile = path.join(root, "hello.ts");
     const outputDirectory = path.join(root, "hello-package");


### PR DESCRIPTION
## Summary
- replace “loose” mod wording in the mods CLI with mod/mod file terminology
- rename internal section helpers from loose mod sections to mod file sections
- update tests and fixtures so directly loaded mods are just called mods/mod files, while package-backed entries remain separate

## Notes
- dependency/vendored occurrences like `loose-envify` are unrelated and untouched

## Test plan
- `rg -n -i 'loose' src --glob '!src/web/memory-viewer-template.txt' || true`
- `bun test src/cli/subcommands/mods.test.ts`
- `bun test src/cli/mods/local-mod-loader.test.ts`
- `bun test src/mods/package-registry.test.ts src/mods/package-scaffolder.test.ts`
- `bun run check`
