### PR TITLE
fix(mods): add package keyword to scaffolded packages

### DIFF
--- a/src/mods/package-scaffolder.test.ts
+++ b/src/mods/package-scaffolder.test.ts
@@ -62,7 +62,7 @@ describe("local mod package scaffolder", () => {
       name: "@caren/hello-mod",
       version: "0.1.0",
       type: "module",
-      keywords: ["letta-mod"],
+      keywords: ["letta-package", "letta-mod"],
       files: ["README.md", "MOD.md", "mods"],
       letta: {
         manifestVersion: 1,

--- a/src/mods/package-scaffolder.ts
+++ b/src/mods/package-scaffolder.ts
@@ -30,6 +30,7 @@ export interface ScaffoldLocalModPackageResult {
 }
 
 const DEFAULT_PACKAGE_VERSION = "0.1.0";
+const LETTA_PACKAGE_KEYWORD = "letta-package";
 const LETTA_MOD_KEYWORD = "letta-mod";
 
 function assertValidPackageName(packageName: string): string {
@@ -78,7 +79,7 @@ function createPackageJson(packageName: string, manifestEntry: string) {
     name: packageName,
     version: DEFAULT_PACKAGE_VERSION,
     type: "module",
-    keywords: [LETTA_MOD_KEYWORD],
+    keywords: [LETTA_PACKAGE_KEYWORD, LETTA_MOD_KEYWORD],
     files: ["README.md", "MOD.md", "mods"],
     letta: {
       manifestVersion: LETTA_PACKAGE_MANIFEST_VERSION,


### PR DESCRIPTION
## Summary
- include both `letta-package` and `letta-mod` keywords in packages generated by `letta mods package`
- update the package scaffolder test expectation

## Tests
- `bun test src/mods/package-scaffolder.test.ts`
- `bun run typecheck`
