### PR TITLE
fix(discord): show typing while turns process

### DIFF
--- a/src/channels/discord-adapter.test.ts
+++ b/src/channels/discord-adapter.test.ts
@@ -15,6 +15,7 @@ import {
 } from "@/channels/discord/adapter";
 import { __testOverrideLoadDiscordModule } from "@/channels/discord/runtime";
 import type {
+  ChannelTurnSource,
   DiscordChannelAccount,
   InboundChannelMessage,
 } from "@/channels/types";
@@ -58,12 +59,18 @@ class FakeDiscordClient {
   };
 
   readonly channels = {
-    fetch: mock(async () => null),
+    fetch: mock(async (_id: string): Promise<unknown> => null),
   };
 
-  readonly login = mock(async (_token: string) => undefined);
+  readonly login = mock(async (_token: string) => {
+    await this.onceHandlers.get("ready")?.();
+  });
   readonly destroy = mock(() => {});
   private readonly handlers = new Map<
+    string,
+    (...args: unknown[]) => unknown
+  >();
+  private readonly onceHandlers = new Map<
     string,
     (...args: unknown[]) => unknown
   >();
@@ -72,7 +79,8 @@ class FakeDiscordClient {
     FakeDiscordClient.instances.push(this);
   }
 
-  once(_event: string, _handler: (...args: unknown[]) => unknown): this {
+  once(event: string, handler: (...args: unknown[]) => unknown): this {
+    this.onceHandlers.set(event, handler);
     return this;
   }
 
@@ -163,6 +171,50 @@ function createGuildMessage(
     })),
     react: mock(async () => {}),
     reactions: { cache: new Map<string, never>() },
+  };
+}
+
+function createTurnSource(
+  overrides: Partial<ChannelTurnSource> = {},
+): ChannelTurnSource {
+  return {
+    channel: "discord",
+    accountId: "discord-bot",
+    chatId: "channel-1",
+    chatType: "direct",
+    messageId: "msg-1",
+    threadId: null,
+    agentId: "agent-1",
+    conversationId: "conv-1",
+    ...overrides,
+  };
+}
+
+function createFetchedDiscordMessage() {
+  return {
+    id: "msg-1",
+    react: mock(async (_emoji: string) => undefined),
+    reactions: {
+      cache: new Map<string, never>(),
+      resolve: mock((_emoji: string) => null),
+    },
+  };
+}
+
+function createTextChannel(
+  message: ReturnType<
+    typeof createFetchedDiscordMessage
+  > = createFetchedDiscordMessage(),
+) {
+  return {
+    isTextBased: () => true,
+    sendTyping: mock(async () => undefined),
+    send: mock(async (_options: string | Record<string, unknown>) => ({
+      id: "sent-message",
+    })),
+    messages: {
+      fetch: mock(async (_id: string) => message),
+    },
   };
 }
 
@@ -286,6 +338,151 @@ describe("Discord adapter open-channel ingress", () => {
       isMention: false,
       isOpenChannel: true,
     });
+  });
+});
+
+describe("Discord adapter lifecycle feedback", () => {
+  test("sends typing while a turn is processing and clears it on finish", async () => {
+    const adapter = createDiscordAdapter({
+      ...discordAccountDefaults,
+      allowedChannels: {},
+      acknowledgeMessageReaction: false,
+    });
+    await adapter.start();
+
+    const client = FakeDiscordClient.instances.at(-1);
+    if (!client) throw new Error("Discord client was not created");
+    const channel = createTextChannel();
+    client.channels.fetch.mockImplementation(async () => channel);
+    const source = createTurnSource();
+
+    await adapter.handleTurnLifecycleEvent?.({ type: "queued", source });
+    expect(channel.sendTyping).not.toHaveBeenCalled();
+
+    await adapter.handleTurnLifecycleEvent?.({
+      type: "processing",
+      batchId: "batch-1",
+      sources: [source],
+    });
+    expect(client.channels.fetch).toHaveBeenCalledWith("channel-1");
+    expect(channel.sendTyping).toHaveBeenCalledTimes(1);
+
+    await adapter.handleTurnLifecycleEvent?.({
+      type: "processing",
+      batchId: "batch-1",
+      sources: [source],
+    });
+    expect(channel.sendTyping).toHaveBeenCalledTimes(1);
+
+    await adapter.handleTurnLifecycleEvent?.({
+      type: "finished",
+      batchId: "batch-1",
+      sources: [source],
+      outcome: "completed",
+    });
+    await adapter.handleTurnLifecycleEvent?.({
+      type: "processing",
+      batchId: "batch-2",
+      sources: [source],
+    });
+    expect(channel.sendTyping).toHaveBeenCalledTimes(2);
+
+    await adapter.stop();
+  });
+
+  test("stops refreshing typing after sending a message", async () => {
+    const adapter = createDiscordAdapter({
+      ...discordAccountDefaults,
+      allowedChannels: {},
+      acknowledgeMessageReaction: false,
+    });
+    await adapter.start();
+
+    const client = FakeDiscordClient.instances.at(-1);
+    if (!client) throw new Error("Discord client was not created");
+    const channel = createTextChannel();
+    client.channels.fetch.mockImplementation(async () => channel);
+    const source = createTurnSource();
+
+    await adapter.handleTurnLifecycleEvent?.({
+      type: "processing",
+      batchId: "batch-1",
+      sources: [source],
+    });
+    expect(channel.sendTyping).toHaveBeenCalledTimes(1);
+
+    await adapter.sendMessage({
+      channel: "discord",
+      accountId: "discord-bot",
+      chatId: "channel-1",
+      text: "done",
+    });
+    expect(channel.send).toHaveBeenCalledWith({ content: "done" });
+
+    await adapter.handleTurnLifecycleEvent?.({
+      type: "processing",
+      batchId: "batch-2",
+      sources: [source],
+    });
+    expect(channel.sendTyping).toHaveBeenCalledTimes(2);
+
+    await adapter.stop();
+  });
+
+  test("does not send lifecycle reactions unless opted in", async () => {
+    const adapter = createDiscordAdapter({
+      ...discordAccountDefaults,
+      allowedChannels: {},
+      acknowledgeMessageReaction: false,
+    });
+    await adapter.start();
+
+    const client = FakeDiscordClient.instances.at(-1);
+    if (!client) throw new Error("Discord client was not created");
+    const message = createFetchedDiscordMessage();
+    client.channels.fetch.mockImplementation(async () =>
+      createTextChannel(message),
+    );
+    const source = createTurnSource();
+
+    await adapter.handleTurnLifecycleEvent?.({ type: "queued", source });
+    await adapter.handleTurnLifecycleEvent?.({
+      type: "finished",
+      batchId: "batch-1",
+      sources: [source],
+      outcome: "completed",
+    });
+
+    expect(message.react).not.toHaveBeenCalled();
+    await adapter.stop();
+  });
+
+  test("sends lifecycle reactions when opted in", async () => {
+    const adapter = createDiscordAdapter({
+      ...discordAccountDefaults,
+      allowedChannels: {},
+      acknowledgeMessageReaction: true,
+    });
+    await adapter.start();
+
+    const client = FakeDiscordClient.instances.at(-1);
+    if (!client) throw new Error("Discord client was not created");
+    const message = createFetchedDiscordMessage();
+    const channel = createTextChannel(message);
+    client.channels.fetch.mockImplementation(async () => channel);
+    const source = createTurnSource();
+
+    await adapter.handleTurnLifecycleEvent?.({ type: "queued", source });
+    await adapter.handleTurnLifecycleEvent?.({
+      type: "finished",
+      batchId: "batch-1",
+      sources: [source],
+      outcome: "completed",
+    });
+
+    expect(message.react).toHaveBeenNthCalledWith(1, "👀");
+    expect(message.react).toHaveBeenNthCalledWith(2, "✅");
+    await adapter.stop();
   });
 });
 

--- a/src/channels/discord/adapter.ts
+++ b/src/channels/discord/adapter.ts
@@ -80,6 +80,7 @@ interface DiscordChannelLike {
   isTextBased?: () => boolean;
   isThread?: () => boolean;
   send?: (options: string | Record<string, unknown>) => Promise<{ id: string }>;
+  sendTyping?: () => Promise<unknown>;
   messages?: {
     fetch: (id: string) => Promise<DiscordFetchedMessageLike>;
   };
@@ -151,8 +152,16 @@ const LIFECYCLE_STATE_TTL_MS = 6 * 60 * 60 * 1000;
 const LIFECYCLE_STATE_MAX = 2_000;
 const DISCORD_LIFECYCLE_ERROR_TEXT_MAX = 1500;
 const INITIAL_THREAD_HISTORY_LIMIT = 20;
+const DISCORD_TYPING_REFRESH_MS = 8_000;
+const DISCORD_TYPING_MAX_MS = 5 * 60 * 1000;
 
 type LifecycleState = "queued" | "completed" | "error" | "cancelled";
+
+type DiscordTypingEntry = {
+  sourceKeys: Set<string>;
+  timer: ReturnType<typeof setInterval>;
+  timeout: ReturnType<typeof setTimeout>;
+};
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.length > 0;
@@ -188,6 +197,17 @@ function isDiscordSendableChannel(
   send: (options: string | Record<string, unknown>) => Promise<{ id: string }>;
 } {
   return isDiscordTextChannel(channel) && typeof channel.send === "function";
+}
+
+function isDiscordTypingChannel(
+  channel: DiscordChannelLike | null,
+): channel is DiscordChannelLike & {
+  isTextBased: () => boolean;
+  sendTyping: () => Promise<unknown>;
+} {
+  return (
+    isDiscordTextChannel(channel) && typeof channel.sendTyping === "function"
+  );
 }
 
 function splitMessageText(text: string, maxLength: number): string[] {
@@ -352,6 +372,7 @@ export function createDiscordAdapter(
   >();
   const lifecycleOperationByMessageKey = new Map<string, Promise<void>>();
   const lifecycleErrorReplyKeys = new Map<string, number>();
+  const typingByChannelId = new Map<string, DiscordTypingEntry>();
 
   function pruneSeenIngressMessageKeys(now: number = Date.now()): void {
     for (const [key, expiresAt] of seenIngressMessageKeys) {
@@ -402,6 +423,24 @@ export function createDiscordAdapter(
     return [
       source.chatId,
       source.threadId ?? source.messageId ?? "",
+      source.conversationId,
+    ].join(":");
+  }
+
+  function getTypingChannelId(source: ChannelTurnSource): string | null {
+    if (source.channel !== "discord") return null;
+    const channelId = source.threadId ?? source.chatId;
+    return isNonEmptyString(channelId) ? channelId : null;
+  }
+
+  function getTypingSourceKey(source: ChannelTurnSource): string | null {
+    const channelId = getTypingChannelId(source);
+    if (!channelId) return null;
+    return [
+      source.accountId ?? "",
+      channelId,
+      source.messageId ?? "",
+      source.agentId,
       source.conversationId,
     ].join(":");
   }
@@ -499,6 +538,91 @@ export function createDiscordAdapter(
       content: formatDiscordLifecycleErrorMessage(errorText),
       ...(reply ?? {}),
     });
+  }
+
+  async function sendTypingAction(channelId: string): Promise<boolean> {
+    if (!running || !client) return false;
+    try {
+      const channel = await client.channels.fetch(channelId);
+      if (!isDiscordTypingChannel(channel)) return false;
+      await channel.sendTyping();
+      return true;
+    } catch (error) {
+      console.warn(
+        `[Discord] Failed to send typing indicator for ${channelId}:`,
+        error instanceof Error ? error.message : error,
+      );
+      return false;
+    }
+  }
+
+  async function startTypingForSource(
+    source: ChannelTurnSource,
+  ): Promise<void> {
+    const channelId = getTypingChannelId(source);
+    const sourceKey = getTypingSourceKey(source);
+    if (!channelId || !sourceKey) return;
+
+    const existing = typingByChannelId.get(channelId);
+    if (existing) {
+      existing.sourceKeys.add(sourceKey);
+      return;
+    }
+
+    if (!(await sendTypingAction(channelId))) {
+      return;
+    }
+
+    const timer = setInterval(() => {
+      void sendTypingAction(channelId).then((ok) => {
+        if (!ok) {
+          clearTypingForChannel(channelId);
+        }
+      });
+    }, DISCORD_TYPING_REFRESH_MS);
+    const timeout = setTimeout(() => {
+      clearTypingForChannel(channelId);
+    }, DISCORD_TYPING_MAX_MS);
+    if (typeof (timer as { unref?: () => void }).unref === "function") {
+      (timer as { unref?: () => void }).unref?.();
+    }
+    if (typeof (timeout as { unref?: () => void }).unref === "function") {
+      (timeout as { unref?: () => void }).unref?.();
+    }
+    typingByChannelId.set(channelId, {
+      sourceKeys: new Set([sourceKey]),
+      timer,
+      timeout,
+    });
+  }
+
+  function stopTypingForSource(source: ChannelTurnSource): void {
+    const channelId = getTypingChannelId(source);
+    const sourceKey = getTypingSourceKey(source);
+    if (!channelId || !sourceKey) return;
+
+    const entry = typingByChannelId.get(channelId);
+    if (!entry) return;
+    entry.sourceKeys.delete(sourceKey);
+    if (entry.sourceKeys.size === 0) {
+      clearTypingForChannel(channelId);
+    }
+  }
+
+  function clearTypingForChannel(channelId: string): void {
+    const entry = typingByChannelId.get(channelId);
+    if (!entry) return;
+    clearInterval(entry.timer);
+    clearTimeout(entry.timeout);
+    typingByChannelId.delete(channelId);
+  }
+
+  function clearAllTyping(): void {
+    for (const entry of typingByChannelId.values()) {
+      clearInterval(entry.timer);
+      clearTimeout(entry.timeout);
+    }
+    typingByChannelId.clear();
   }
 
   function scheduleLifecycleTransition(
@@ -898,6 +1022,7 @@ export function createDiscordAdapter(
 
     async stop(): Promise<void> {
       if (!running || !client) return;
+      clearAllTyping();
       client.destroy();
       client = null;
       running = false;
@@ -918,21 +1043,35 @@ export function createDiscordAdapter(
     ): Promise<void> {
       if (!running) return;
       if (event.type === "queued") {
-        await scheduleLifecycleTransition(event.source, "queued");
+        if (config.acknowledgeMessageReaction) {
+          await scheduleLifecycleTransition(event.source, "queued");
+        }
         return;
       }
-      if (event.type === "processing") return;
+      if (event.type === "processing") {
+        for (const source of event.sources) {
+          await startTypingForSource(source);
+        }
+        return;
+      }
+
+      for (const source of event.sources) {
+        stopTypingForSource(source);
+      }
+
       const nextState: LifecycleState =
         event.outcome === "completed"
           ? "completed"
           : event.outcome === "cancelled"
             ? "cancelled"
             : "error";
-      await Promise.all(
-        event.sources.map((source) =>
-          scheduleLifecycleTransition(source, nextState),
-        ),
-      );
+      if (config.acknowledgeMessageReaction) {
+        await Promise.all(
+          event.sources.map((source) =>
+            scheduleLifecycleTransition(source, nextState),
+          ),
+        );
+      }
 
       const errorText = event.outcome === "error" ? event.error?.trim() : null;
       if (!errorText) return;
@@ -986,6 +1125,7 @@ export function createDiscordAdapter(
         } else {
           await message.react(emoji);
         }
+        clearTypingForChannel(targetChannelId);
         return { messageId: targetMessageId };
       }
 
@@ -1012,6 +1152,7 @@ export function createDiscordAdapter(
             },
           ],
         });
+        clearTypingForChannel(targetChannelId);
         return { messageId: result.id };
       }
 
@@ -1036,6 +1177,7 @@ export function createDiscordAdapter(
         });
         lastMessageId = result.id;
       }
+      clearTypingForChannel(targetChannelId);
       return { messageId: lastMessageId };
     },
 
@@ -1054,6 +1196,7 @@ export function createDiscordAdapter(
         content: text,
         ...(reply ?? {}),
       });
+      clearTypingForChannel(chatId);
     },
 
     async prepareInboundMessage(


### PR DESCRIPTION
Fixes #1846.

## What changed

Discord now starts the native typing indicator when a Discord-originated turn enters the `processing` lifecycle event. The adapter refreshes the indicator for long-running turns and clears the refresh timer when the turn finishes, output is sent, a reaction is sent, a direct reply is sent, or the adapter stops.

The existing lifecycle reaction flow is now gated by `acknowledgeMessageReaction`, matching the account config comment that reactions are optional and typing is the default in-flight UX.

## Validation

- `env -u USER_CWD bun test src/channels/discord-adapter.test.ts`
- `env -u USER_CWD bun run typecheck`
- `env -u USER_CWD bun run lint`
- `env -u USER_CWD bun run check`

## Risk

Low. This is isolated to the Discord adapter lifecycle hook. Discord has no explicit stop-typing API, so the implementation stops only the local refresh timer; Discord's native indicator expires normally after the last typing pulse.
