### PR TITLE
feat(mods): expose secrets to tool invocations

### DIFF
--- a/src/mods/types.ts
+++ b/src/mods/types.ts
@@ -422,10 +422,16 @@ export type ModToolRunResult =
       success?: boolean;
     };
 
+export type ModSecretResolver = (
+  name: string,
+  options?: { envFallback?: boolean },
+) => Promise<string | null>;
+
 export interface ModToolRunContext extends ModInvocationContext {
   args: Record<string, unknown>;
   toolCallId: string | null;
   signal: AbortSignal;
+  secret: ModSecretResolver;
   onOutput?: (chunk: string, stream: "stdout" | "stderr") => void;
   conversation: ModConversationHandle;
 }

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -44,6 +44,7 @@ import {
 } from "@/mods/tool-registry";
 import type {
   ModContext,
+  ModSecretResolver,
   ModToolRunContext,
   ToolApprovalPolicy,
 } from "@/mods/types";
@@ -65,6 +66,7 @@ import {
 import { settingsManager } from "@/settings-manager";
 import { telemetry } from "@/telemetry";
 import { debugLog } from "@/utils/debug";
+import { refreshAndListSecrets } from "@/utils/secrets-store";
 import { isRecord } from "@/utils/type-guards";
 import { toolFilter } from "./filter";
 import {
@@ -1940,6 +1942,126 @@ function isMultimodalContent(
   );
 }
 
+const MOD_SECRET_NAME_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
+
+type InvocationSecretRedactions = Map<string, string>;
+
+function normalizeModSecretName(name: string): string {
+  const normalized = name.toUpperCase();
+  if (!MOD_SECRET_NAME_PATTERN.test(normalized)) {
+    throw new Error(
+      `Invalid secret name '${name}'. Use uppercase letters, numbers, and underscores only. Must start with a letter or underscore.`,
+    );
+  }
+  return normalized;
+}
+
+function scrubInvocationSecretRedactions(
+  input: string,
+  redactions: InvocationSecretRedactions,
+): string {
+  let result = input;
+  const entries = Array.from(redactions.entries()).sort(
+    ([, a], [, b]) => b.length - a.length,
+  );
+  for (const [name, value] of entries) {
+    if (value.length > 0) {
+      result = result.replaceAll(value, `${name}=<REDACTED>`);
+    }
+  }
+  return result;
+}
+
+function scrubModToolString(
+  input: string,
+  agentId: string | undefined,
+  redactions: InvocationSecretRedactions,
+): string {
+  return scrubInvocationSecretRedactions(
+    scrubSecretsFromString(input, agentId),
+    redactions,
+  );
+}
+
+function scrubModToolReturnContent(
+  content: ToolReturnContent,
+  agentId: string | undefined,
+  redactions: InvocationSecretRedactions,
+): ToolReturnContent {
+  if (typeof content === "string") {
+    return scrubModToolString(content, agentId, redactions);
+  }
+  return content.map((block) =>
+    block.type === "text"
+      ? { ...block, text: scrubModToolString(block.text, agentId, redactions) }
+      : block,
+  );
+}
+
+function scrubModToolLines(
+  lines: string[] | undefined,
+  agentId: string | undefined,
+  redactions: InvocationSecretRedactions,
+): string[] | undefined {
+  return lines?.map((line) => scrubModToolString(line, agentId, redactions));
+}
+
+function createScrubbedError(error: unknown, message: string): Error {
+  const scrubbedError = new Error(message);
+  if (error instanceof Error) {
+    scrubbedError.name = error.name;
+  }
+  return scrubbedError;
+}
+
+function createModSecretResolver(options: {
+  addRedaction: (name: string, value: string) => void;
+  agentId: string | null | undefined;
+}): ModSecretResolver {
+  let agentSecretsPromise: Promise<Record<string, string>> | null = null;
+
+  const loadAgentSecrets = async (): Promise<Record<string, string>> => {
+    if (!options.agentId) return {};
+    agentSecretsPromise ??= refreshAndListSecrets(options.agentId).then(
+      (entries) =>
+        Object.fromEntries(entries.map(({ key, value }) => [key, value])),
+    );
+    return agentSecretsPromise;
+  };
+
+  return async (name, resolverOptions) => {
+    const key = normalizeModSecretName(name);
+    let agentLookupError: unknown;
+
+    if (options.agentId) {
+      try {
+        const agentSecrets = await loadAgentSecrets();
+        if (Object.hasOwn(agentSecrets, key)) {
+          const value = agentSecrets[key] ?? "";
+          options.addRedaction(key, value);
+          return value;
+        }
+      } catch (error) {
+        agentLookupError = error;
+      }
+    }
+
+    if (resolverOptions?.envFallback === true) {
+      const value = process.env[key];
+      if (value !== undefined) {
+        options.addRedaction(key, value);
+        return value;
+      }
+    }
+
+    if (agentLookupError !== undefined) {
+      throw agentLookupError;
+    }
+
+    return null;
+  };
+}
+
 function flattenToolResponse(result: unknown): ToolReturnContent {
   if (result === null || result === undefined) {
     return "";
@@ -2216,6 +2338,12 @@ async function executeModTool(
     tool.activationSignal,
   ]);
   const { signal } = linkedSignal;
+  const redactions: InvocationSecretRedactions = new Map();
+  const addRedaction = (name: string, value: string): void => {
+    if (value.length > 0) {
+      redactions.set(name, value);
+    }
+  };
 
   const run = async (): Promise<ToolExecutionResult> => {
     const preHookResult = await runPreToolUseHooks(
@@ -2241,12 +2369,20 @@ async function executeModTool(
         args: args as Record<string, unknown>,
         toolCallId: options.toolCallId ?? null,
         signal,
+        secret: createModSecretResolver({
+          addRedaction,
+          agentId: modContext.agent.id,
+        }),
         ...(options.onOutput
           ? {
               onOutput: (chunk: string, stream: "stdout" | "stderr") => {
                 options.onOutput?.(
                   stripAnsi(
-                    scrubSecretsFromString(chunk, options.scopedAgentId),
+                    scrubModToolString(
+                      chunk,
+                      options.scopedAgentId,
+                      redactions,
+                    ),
                   ),
                   stream,
                 );
@@ -2276,14 +2412,22 @@ async function executeModTool(
       );
       const duration = Date.now() - startTime;
       const recordResult = isRecord(result) ? result : undefined;
-      const stdout = isStringArray(recordResult?.stdout)
-        ? recordResult.stdout
-        : undefined;
-      const stderr = isStringArray(recordResult?.stderr)
-        ? recordResult.stderr
-        : undefined;
+      const stdout = scrubModToolLines(
+        isStringArray(recordResult?.stdout) ? recordResult.stdout : undefined,
+        options.scopedAgentId,
+        redactions,
+      );
+      const stderr = scrubModToolLines(
+        isStringArray(recordResult?.stderr) ? recordResult.stderr : undefined,
+        options.scopedAgentId,
+        redactions,
+      );
       const toolStatus = getModToolStatus(result);
-      const flattenedResponse = flattenToolResponse(result);
+      const flattenedResponse = scrubModToolReturnContent(
+        flattenToolResponse(result),
+        options.scopedAgentId,
+        redactions,
+      );
       const responseSize =
         typeof flattenedResponse === "string"
           ? flattenedResponse.length
@@ -2329,11 +2473,6 @@ async function executeModTool(
         ...(stderr && { stderr }),
       };
     } catch (error) {
-      tool.recordDiagnostic?.({
-        capability: { id: toolName, kind: "tool" },
-        error: error instanceof Error ? error : new Error(String(error)),
-        phase: "tool.run",
-      });
       const duration = Date.now() - startTime;
       const isAbort =
         signal.aborted ||
@@ -2346,11 +2485,21 @@ async function executeModTool(
         : error instanceof Error
           ? error.name
           : "unknown";
-      const errorMessage = isAbort
-        ? INTERRUPTED_BY_USER
-        : error instanceof Error
-          ? error.message
-          : String(error);
+      const errorMessage = scrubModToolString(
+        isAbort
+          ? INTERRUPTED_BY_USER
+          : error instanceof Error
+            ? error.message
+            : String(error),
+        options.scopedAgentId,
+        redactions,
+      );
+
+      tool.recordDiagnostic?.({
+        capability: { id: toolName, kind: "tool" },
+        error: createScrubbedError(error, errorMessage),
+        phase: "tool.run",
+      });
 
       telemetry.trackToolUsage(
         toolName,
@@ -2401,6 +2550,7 @@ function toolExecutionModContext(
   options: { workingDirectory: string; modContext?: ModContext },
 ): ModContext {
   return buildModInvocationContext({
+    agent: { id: executionScope.agentId ?? null },
     base: options.modContext,
     conversationId: executionScope.conversationId ?? null,
     permissionMode: executionScope.permissionMode ?? null,

--- a/src/tools/tool-execution-context.test.ts
+++ b/src/tools/tool-execution-context.test.ts
@@ -32,7 +32,7 @@ import {
   registerModPermission,
 } from "@/mods/permission-registry";
 import { clearModTools, registerModTool } from "@/mods/tool-registry";
-import type { ModToolStartEvent } from "@/mods/types";
+import type { ModDiagnostic, ModToolStartEvent } from "@/mods/types";
 import {
   LETTA_INHERITED_CHANNEL_CONTEXT_ENV,
   runWithRuntimeContext,
@@ -59,6 +59,10 @@ import {
   prepareToolExecutionContextForScope,
   resolveConversationChannelToolScope,
 } from "@/tools/toolset";
+import {
+  __testOverrideSecretsBackend,
+  clearSecretsCache,
+} from "@/utils/secrets-store";
 
 function asText(
   toolReturn: Awaited<ReturnType<typeof executeTool>>["toolReturn"],
@@ -134,6 +138,9 @@ describe("tool execution context snapshot", () => {
     __testOverrideLoadChannelAccounts(null);
     __testOverrideSaveChannelAccounts(null);
     delete process.env[LETTA_INHERITED_CHANNEL_CONTEXT_ENV];
+    __testOverrideSecretsBackend(null);
+    clearSecretsCache(null);
+    delete process.env.TAVILY_API_KEY;
     __testSetBackend(null);
   });
 
@@ -622,6 +629,173 @@ describe("tool execution context snapshot", () => {
     expect(result.status).toBe("success");
     expect(asText(result.toolReturn)).toBe(
       "agent-1:/tmp/listener-workspace:xai-build:standard",
+    );
+  });
+
+  test("exposes agent-scoped secrets to mod tools", async () => {
+    process.env.TAVILY_API_KEY = "env-secret-value";
+    const retrieveCalls: string[] = [];
+    let seenSecret = "";
+    __testOverrideSecretsBackend({
+      capabilities: { serverSecrets: true },
+      retrieveAgent: async (agentId) => {
+        retrieveCalls.push(agentId);
+        return {
+          secrets: [{ key: "TAVILY_API_KEY", value: "agent-secret-value" }],
+        };
+      },
+      updateAgent: async () => ({}),
+    });
+
+    const controller = new AbortController();
+    registerModTool({
+      name: "secret_echo",
+      description: "Echo a secret",
+      parameters: { type: "object", properties: {}, required: [] },
+      owner: {
+        id: "global:/tmp/secret-echo.ts",
+        path: "/tmp/secret-echo.ts",
+        scope: "global",
+        generation: 1,
+      },
+      path: "/tmp/secret-echo.ts",
+      approvalPolicy: "auto",
+      requiresApproval: false,
+      parallelSafe: true,
+      activationSignal: controller.signal,
+      run: async (ctx) => {
+        seenSecret =
+          (await ctx.secret("tavily_api_key", { envFallback: true })) ?? "";
+        return `secret:${seenSecret}`;
+      },
+    });
+
+    const result = await runWithRuntimeContext(
+      { agentId: "agent-secret-a", conversationId: "default" },
+      () => executeTool("secret_echo", {}),
+    );
+
+    expect(seenSecret).toBe("agent-secret-value");
+    expect(retrieveCalls).toEqual(["agent-secret-a"]);
+    expect(result.status).toBe("success");
+    expect(asText(result.toolReturn)).toBe("secret:TAVILY_API_KEY=<REDACTED>");
+  });
+
+  test("mod tool env fallback secrets are invocation-redacted", async () => {
+    process.env.TAVILY_API_KEY = "env-secret-value";
+    __testOverrideSecretsBackend({
+      capabilities: { serverSecrets: true },
+      retrieveAgent: async () => ({ secrets: [] }),
+      updateAgent: async () => ({}),
+    });
+    const chunks: Array<{ chunk: string; stream: string }> = [];
+
+    const controller = new AbortController();
+    registerModTool({
+      name: "secret_env_echo",
+      description: "Echo an env fallback secret",
+      parameters: { type: "object", properties: {}, required: [] },
+      owner: {
+        id: "global:/tmp/secret-env-echo.ts",
+        path: "/tmp/secret-env-echo.ts",
+        scope: "global",
+        generation: 1,
+      },
+      path: "/tmp/secret-env-echo.ts",
+      approvalPolicy: "auto",
+      requiresApproval: false,
+      parallelSafe: true,
+      activationSignal: controller.signal,
+      run: async (ctx) => {
+        const secret = await ctx.secret("TAVILY_API_KEY", {
+          envFallback: true,
+        });
+        ctx.onOutput?.(`stream:${secret}`, "stdout");
+        return {
+          status: "error",
+          content: `content:${secret}`,
+          stdout: [`stdout:${secret}`],
+          stderr: [`stderr:${secret}`],
+        };
+      },
+    });
+
+    const result = await runWithRuntimeContext(
+      { agentId: "agent-secret-env", conversationId: "default" },
+      () =>
+        executeTool(
+          "secret_env_echo",
+          {},
+          {
+            onOutput: (chunk, stream) => chunks.push({ chunk, stream }),
+          },
+        ),
+    );
+
+    expect(result.status).toBe("error");
+    expect(asText(result.toolReturn)).toBe("content:TAVILY_API_KEY=<REDACTED>");
+    expect(result.stdout).toEqual(["stdout:TAVILY_API_KEY=<REDACTED>"]);
+    expect(result.stderr).toEqual(["stderr:TAVILY_API_KEY=<REDACTED>"]);
+    expect(chunks).toEqual([
+      { chunk: "stream:TAVILY_API_KEY=<REDACTED>", stream: "stdout" },
+    ]);
+  });
+
+  test("mod tool thrown errors are redacted after ctx.secret", async () => {
+    process.env.TAVILY_API_KEY = "throw-secret-value";
+    __testOverrideSecretsBackend({
+      capabilities: { serverSecrets: true },
+      retrieveAgent: async () => ({ secrets: [] }),
+      updateAgent: async () => ({}),
+    });
+    const diagnostics: ModDiagnostic[] = [];
+
+    const controller = new AbortController();
+    registerModTool({
+      name: "secret_throw",
+      description: "Throw a secret",
+      parameters: { type: "object", properties: {}, required: [] },
+      owner: {
+        id: "global:/tmp/secret-throw.ts",
+        path: "/tmp/secret-throw.ts",
+        scope: "global",
+        generation: 1,
+      },
+      path: "/tmp/secret-throw.ts",
+      approvalPolicy: "auto",
+      requiresApproval: false,
+      parallelSafe: true,
+      activationSignal: controller.signal,
+      recordDiagnostic: (diagnostic) => {
+        diagnostics.push({
+          ...diagnostic,
+          owner: {
+            id: "global:/tmp/secret-throw.ts",
+            path: "/tmp/secret-throw.ts",
+            scope: "global",
+            generation: 1,
+          },
+          timestamp: Date.now(),
+        });
+      },
+      run: async (ctx) => {
+        const secret = await ctx.secret("TAVILY_API_KEY", {
+          envFallback: true,
+        });
+        throw new Error(`failed:${secret}`);
+      },
+    });
+
+    const result = await runWithRuntimeContext(
+      { agentId: "agent-secret-throw", conversationId: "default" },
+      () => executeTool("secret_throw", {}),
+    );
+
+    expect(result.status).toBe("error");
+    expect(asText(result.toolReturn)).toBe("failed:TAVILY_API_KEY=<REDACTED>");
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.error.message).toBe(
+      "failed:TAVILY_API_KEY=<REDACTED>",
     );
   });
 


### PR DESCRIPTION
## Summary
- add tool-only `ctx.secret(name, { envFallback })` for mod tool invocations
- resolve secrets from the scoped agent store first, then opt-in process env fallback
- add invocation-local redaction for returned values across mod tool output, stdout/stderr, streaming chunks, thrown errors, diagnostics, hooks, and telemetry paths

## Tests
- `bun test src/tools/tool-execution-context.test.ts`
- `bun test src/tools/tool-execution-context.test.ts src/tools/secret-substitution.test.ts src/tools/shell-secrets.test.ts src/mods/mod-engine.test.ts`
- `bun run typecheck`
- `bun run check`
- `bun run build`