### PR TITLE
feat(mods): support GitHub package installs

### DIFF
--- a/src/cli/subcommands/skills.test.ts
+++ b/src/cli/subcommands/skills.test.ts
@@ -443,10 +443,9 @@ describe("skills subcommand", () => {
         },
       });
 
-      const exitCode = await runInstallSubcommand(
-        ["https://github.com/caren/git-mod"],
-        { globalModsDirectory: modsRoot },
-      );
+      const exitCode = await runInstallSubcommand(["github:caren/git-mod"], {
+        globalModsDirectory: modsRoot,
+      });
 
       expect(exitCode).toBe(0);
       expect(consoleCapture.logs.join("\n")).toContain(

--- a/src/cli/subcommands/skills.test.ts
+++ b/src/cli/subcommands/skills.test.ts
@@ -115,6 +115,22 @@ function writeInstalledNpmModPackage(params: {
   );
 }
 
+function writeGitModPackage(packageRoot: string): void {
+  mkdirSync(join(packageRoot, "src"), { recursive: true });
+  writeFileSync(join(packageRoot, "src", "mod.ts"), "export {};\n");
+  writeFileSync(
+    join(packageRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "git-mod",
+        version: "0.1.0",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
 describe("skills subcommand", () => {
   afterEach(() => {
     __testOverrideNpmManagedModPackageInstaller({});
@@ -405,6 +421,82 @@ describe("skills subcommand", () => {
     } finally {
       consoleCapture.restore();
       await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("top-level install installs GitHub mod packages", async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "letta-install-test-"));
+    const consoleCapture = captureConsole();
+    try {
+      const modsRoot = join(tempRoot, "mods");
+      __testOverrideNpmManagedModPackageInstaller({
+        gitSpawnImpl: (_cmd, args) => {
+          if (args[0] === "clone") {
+            writeGitModPackage(String(args.at(-1)));
+          }
+          const child = createChildProcess();
+          queueMicrotask(() => {
+            if (args[0] === "rev-parse") child.stdout?.emit("data", "abc123\n");
+            child.emit("exit", 0);
+          });
+          return child;
+        },
+      });
+
+      const exitCode = await runInstallSubcommand(
+        ["https://github.com/caren/git-mod"],
+        { globalModsDirectory: modsRoot },
+      );
+
+      expect(exitCode).toBe(0);
+      expect(consoleCapture.logs.join("\n")).toContain(
+        "Warning: mods are trusted local code and can execute on startup.",
+      );
+      expect(consoleCapture.logs.join("\n")).toContain(
+        "Source: git:https://github.com/caren/git-mod",
+      );
+      expect(consoleCapture.logs.join("\n")).toContain(
+        "Repository: https://github.com/caren/git-mod",
+      );
+      expect(consoleCapture.logs.join("\n")).toContain(
+        "Installed git:https://github.com/caren/git-mod@0.1.0",
+      );
+      expect(consoleCapture.logs.join("\n")).toContain("Run /reload");
+      expect(
+        existsSync(
+          join(
+            modsRoot,
+            "packages",
+            "git",
+            "github.com",
+            "caren",
+            "git-mod",
+            "src",
+            "mod.ts",
+          ),
+        ),
+      ).toBe(true);
+    } finally {
+      consoleCapture.restore();
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("top-level GitHub mod install rejects agent scope", async () => {
+    const consoleCapture = captureConsole();
+    try {
+      const exitCode = await runInstallSubcommand([
+        "--agent",
+        "agent-123",
+        "git:github.com/caren/git-mod",
+      ]);
+
+      expect(exitCode).toBe(1);
+      expect(consoleCapture.errors.join("\n")).toContain(
+        "Agent-scoped mod package install is not supported yet.",
+      );
+    } finally {
+      consoleCapture.restore();
     }
   });
 

--- a/src/cli/subcommands/skills.test.ts
+++ b/src/cli/subcommands/skills.test.ts
@@ -443,9 +443,10 @@ describe("skills subcommand", () => {
         },
       });
 
-      const exitCode = await runInstallSubcommand(["github:caren/git-mod"], {
-        globalModsDirectory: modsRoot,
-      });
+      const exitCode = await runInstallSubcommand(
+        ["git:github.com/caren/git-mod"],
+        { globalModsDirectory: modsRoot },
+      );
 
       expect(exitCode).toBe(0);
       expect(consoleCapture.logs.join("\n")).toContain(

--- a/src/cli/subcommands/skills.ts
+++ b/src/cli/subcommands/skills.ts
@@ -15,9 +15,11 @@ import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents"
 import { isLocalAgentId } from "@/agent/agent-id";
 import {
   type InstallLocalManagedModPackageResult,
+  installGitManagedModPackage,
   installLocalManagedModPackage,
   installNpmManagedModPackage,
   isLocalLettaModPackageDirectory,
+  parseGitManagedModPackageInstallSpecifier,
 } from "@/mods/package-installer";
 import { resolveDefaultGlobalModsDirectory } from "@/mods/paths";
 import { parseFrontmatter } from "@/utils/frontmatter";
@@ -92,6 +94,8 @@ Usage:
 
 Sources:
   npm:<package>         npm mod package, e.g. npm:@letta-ai/mod-plan-mode
+  git:github.com/o/r    GitHub mod package
+  https://github.com/o/r GitHub mod package
   ./path/to/package     Local mod package with package.json#letta
   official/<path>         Hermes official optional skill, e.g. official/finance/stocks
   clawhub/<slug>          ClawHub registry skill, e.g. clawhub/nano-banana-pro
@@ -999,6 +1003,38 @@ async function runInstall(
     }
     try {
       const result = await installNpmManagedModPackage({
+        modsRoot:
+          options.globalModsDirectory ?? resolveDefaultGlobalModsDirectory(),
+        specifier,
+      });
+      printManagedModPackageInstallResult(result, { includeDetails: true });
+      return 0;
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      return 1;
+    }
+  }
+
+  let gitPackageSpecifier: ReturnType<
+    typeof parseGitManagedModPackageInstallSpecifier
+  >;
+  try {
+    gitPackageSpecifier = parseGitManagedModPackageInstallSpecifier(specifier);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+  if (gitPackageSpecifier) {
+    if (hasInstallAgentScope(parsed.values)) {
+      console.error("Agent-scoped mod package install is not supported yet.");
+      return 1;
+    }
+    if (parsed.values.force) {
+      console.error("--force is only supported for skill installs.");
+      return 1;
+    }
+    try {
+      const result = await installGitManagedModPackage({
         modsRoot:
           options.globalModsDirectory ?? resolveDefaultGlobalModsDirectory(),
         specifier,

--- a/src/cli/subcommands/skills.ts
+++ b/src/cli/subcommands/skills.ts
@@ -94,6 +94,7 @@ Usage:
 
 Sources:
   npm:<package>         npm mod package, e.g. npm:@letta-ai/mod-plan-mode
+  github:o/r            GitHub mod package shorthand
   git:github.com/o/r    GitHub mod package
   https://github.com/o/r GitHub mod package
   ./path/to/package     Local mod package with package.json#letta

--- a/src/cli/subcommands/skills.ts
+++ b/src/cli/subcommands/skills.ts
@@ -94,7 +94,6 @@ Usage:
 
 Sources:
   npm:<package>         npm mod package, e.g. npm:@letta-ai/mod-plan-mode
-  github:o/r            GitHub mod package shorthand
   git:github.com/o/r    GitHub mod package
   https://github.com/o/r GitHub mod package
   ./path/to/package     Local mod package with package.json#letta

--- a/src/mods/package-installer.test.ts
+++ b/src/mods/package-installer.test.ts
@@ -256,6 +256,13 @@ describe("local managed mod package installer", () => {
       source: "git:https://github.com/caren/my-mod",
     });
     expect(
+      parseGitManagedModPackageInstallSpecifier("github:caren/my-mod@v2"),
+    ).toMatchObject({
+      cloneUrl: "https://github.com/caren/my-mod.git",
+      ref: "v2",
+      source: "git:https://github.com/caren/my-mod",
+    });
+    expect(
       parseGitManagedModPackageInstallSpecifier(
         "ssh://git@github.com/caren/my-mod.git@abc123",
       ),
@@ -273,6 +280,47 @@ describe("local managed mod package installer", () => {
         "https://gitlab.com/caren/my-mod",
       ),
     ).toBeNull();
+  });
+
+  test("rejects git refs that start with a dash (option injection)", () => {
+    expect(() =>
+      parseGitManagedModPackageInstallSpecifier(
+        "https://github.com/caren/my-mod@--orphan=evil",
+      ),
+    ).toThrow("Invalid git ref");
+    expect(() =>
+      parseGitManagedModPackageInstallSpecifier(
+        "https://github.com/caren/my-mod@-f",
+      ),
+    ).toThrow("Invalid git ref");
+    expect(() =>
+      parseGitManagedModPackageInstallSpecifier(
+        "git:github.com/caren/my-mod@-B",
+      ),
+    ).toThrow("Invalid git ref");
+    expect(() =>
+      parseGitManagedModPackageInstallSpecifier(
+        "ssh://git@github.com/caren/my-mod.git@--upload-pack=evil",
+      ),
+    ).toThrow("Invalid git ref");
+  });
+
+  test("accepts valid git refs with dots and dashes", () => {
+    expect(
+      parseGitManagedModPackageInstallSpecifier(
+        "https://github.com/caren/my-mod@v1.2.3",
+      ),
+    ).toMatchObject({ ref: "v1.2.3" });
+    expect(
+      parseGitManagedModPackageInstallSpecifier(
+        "git:github.com/caren/my-mod@release-1.0",
+      ),
+    ).toMatchObject({ ref: "release-1.0" });
+    expect(
+      parseGitManagedModPackageInstallSpecifier(
+        "ssh://git@github.com/caren/my-mod.git@abc123",
+      ),
+    ).toMatchObject({ ref: "abc123" });
   });
 
   test("installs a local package into the managed package directory", () => {
@@ -915,5 +963,42 @@ describe("local managed mod package installer", () => {
     ).rejects.toThrow("GitHub repo is not an installable Letta mod package");
     expect(existsSync(path.join(modsRoot, "packages.json"))).toBe(false);
     expect(existsSync(path.join(modsRoot, "packages"))).toBe(false);
+  });
+
+  test("git checkout uses -- separator to prevent option injection", async () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    const gitCalls: Array<{ args: string[]; cwd?: string }> = [];
+    __testOverrideNpmManagedModPackageInstaller({
+      gitSpawnImpl: (_cmd, args, options) => {
+        gitCalls.push({ args, cwd: options.cwd?.toString() });
+        if (args[0] === "clone") {
+          writeLocalPackage({
+            capabilities: ["commands"],
+            name: "git-mod",
+            packageRoot: String(args.at(-1)),
+          });
+        }
+        const child = createChildProcess();
+        queueMicrotask(() => {
+          if (args[0] === "rev-parse") {
+            child.stdout?.emit("data", "abc123\n");
+          }
+          child.emit("exit", 0);
+        });
+        return child;
+      },
+    });
+
+    await installGitManagedModPackage({
+      modsRoot,
+      specifier: "https://github.com/caren/git-mod@v1.2.3",
+    });
+
+    expect(gitCalls.map((call) => call.args)).toEqual([
+      ["clone", "https://github.com/caren/git-mod.git", expect.any(String)],
+      ["checkout", "--", "v1.2.3"],
+      ["rev-parse", "--short", "HEAD"],
+    ]);
   });
 });

--- a/src/mods/package-installer.test.ts
+++ b/src/mods/package-installer.test.ts
@@ -16,8 +16,10 @@ import path from "node:path";
 import { PassThrough } from "node:stream";
 import {
   __testOverrideNpmManagedModPackageInstaller,
+  installGitManagedModPackage,
   installLocalManagedModPackage,
   installNpmManagedModPackage,
+  parseGitManagedModPackageInstallSpecifier,
   parseNpmManagedModPackageInstallSpecifier,
 } from "@/mods/package-installer";
 
@@ -144,6 +146,27 @@ function writeInstalledNpmPackage(params: {
   }
 }
 
+function writeCompatibilityGitPackage(params: {
+  dependencies?: Record<string, string>;
+  packageRoot: string;
+  version?: string;
+}): void {
+  mkdirSync(path.join(params.packageRoot, "src"), { recursive: true });
+  writeFileSync(path.join(params.packageRoot, "src", "mod.ts"), "export {};\n");
+  writeFileSync(
+    path.join(params.packageRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "git-mod",
+        version: params.version ?? "0.1.0",
+        ...(params.dependencies ? { dependencies: params.dependencies } : {}),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
 function createChildProcess(): ChildProcess {
   const child = new EventEmitter() as ChildProcess;
   Object.assign(child, {
@@ -211,6 +234,45 @@ describe("local managed mod package installer", () => {
     expect(() =>
       parseNpmManagedModPackageInstallSpecifier("npm:my-mod@foo\\bar"),
     ).toThrow("Invalid npm package version or tag");
+  });
+
+  test("parses GitHub package install specs", () => {
+    expect(
+      parseGitManagedModPackageInstallSpecifier(
+        "https://github.com/Caren/My-Mod.git@v1",
+      ),
+    ).toEqual({
+      cloneUrl: "https://github.com/caren/my-mod.git",
+      owner: "caren",
+      ref: "v1",
+      repo: "my-mod",
+      repository: "https://github.com/caren/my-mod",
+      source: "git:https://github.com/caren/my-mod",
+    });
+    expect(
+      parseGitManagedModPackageInstallSpecifier("git:github.com/caren/my-mod"),
+    ).toMatchObject({
+      cloneUrl: "https://github.com/caren/my-mod.git",
+      source: "git:https://github.com/caren/my-mod",
+    });
+    expect(
+      parseGitManagedModPackageInstallSpecifier(
+        "ssh://git@github.com/caren/my-mod.git@abc123",
+      ),
+    ).toMatchObject({
+      ref: "abc123",
+      source: "git:https://github.com/caren/my-mod",
+    });
+    expect(
+      parseGitManagedModPackageInstallSpecifier(
+        "https://github.com/caren/my-mod/tree/main",
+      ),
+    ).toBeNull();
+    expect(
+      parseGitManagedModPackageInstallSpecifier(
+        "https://gitlab.com/caren/my-mod",
+      ),
+    ).toBeNull();
   });
 
   test("installs a local package into the managed package directory", () => {
@@ -657,5 +719,201 @@ describe("local managed mod package installer", () => {
     expect(
       existsSync(path.join(modsRoot, "packages", "npm", "@caren", "my-mod")),
     ).toBe(false);
+  });
+
+  test("installs a GitHub package with a manifest", async () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    const gitCalls: Array<{ args: string[]; cwd?: string }> = [];
+    __testOverrideNpmManagedModPackageInstaller({
+      gitSpawnImpl: (_cmd, args, options) => {
+        gitCalls.push({ args, cwd: options.cwd?.toString() });
+        if (args[0] === "clone") {
+          const packageRoot = String(args.at(-1));
+          writeLocalPackage({
+            capabilities: ["commands"],
+            name: "git-mod",
+            packageRoot,
+          });
+        }
+        const child = createChildProcess();
+        queueMicrotask(() => {
+          if (args[0] === "rev-parse") {
+            child.stdout?.emit("data", "abc123\n");
+          }
+          child.emit("exit", 0);
+        });
+        return child;
+      },
+    });
+
+    const result = await installGitManagedModPackage({
+      modsRoot,
+      specifier: "https://github.com/caren/git-mod",
+    });
+
+    expect(gitCalls.map((call) => call.args)).toEqual([
+      [
+        "clone",
+        "--depth",
+        "1",
+        "https://github.com/caren/git-mod.git",
+        expect.any(String),
+      ],
+      ["rev-parse", "--short", "HEAD"],
+    ]);
+    expect(result).toMatchObject({
+      capabilities: ["commands"],
+      repository: "https://github.com/caren/git-mod",
+      rootRelativePath: "packages/git/github.com/caren/git-mod",
+      source: "git:https://github.com/caren/git-mod",
+      version: "0.1.0",
+    });
+    expect(existsSync(path.join(result.root, "mods", "index.ts"))).toBe(true);
+    expect(readRegistry(modsRoot).packages).toEqual([
+      {
+        source: "git:https://github.com/caren/git-mod",
+        version: "0.1.0",
+        enabled: true,
+        root: "packages/git/github.com/caren/git-mod",
+        entries: ["mods/index.ts"],
+      },
+    ]);
+  });
+
+  test("installs a compatibility GitHub package from src/mod.ts", async () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    __testOverrideNpmManagedModPackageInstaller({
+      gitSpawnImpl: (_cmd, args) => {
+        if (args[0] === "clone") {
+          writeCompatibilityGitPackage({ packageRoot: String(args.at(-1)) });
+        }
+        const child = createChildProcess();
+        queueMicrotask(() => {
+          if (args[0] === "rev-parse") child.stdout?.emit("data", "def456\n");
+          child.emit("exit", 0);
+        });
+        return child;
+      },
+    });
+
+    const result = await installGitManagedModPackage({
+      modsRoot,
+      specifier: "git:github.com/caren/compat-mod",
+    });
+
+    expect(result).toMatchObject({
+      capabilities: [],
+      entries: ["src/mod.ts"],
+      source: "git:https://github.com/caren/compat-mod",
+      version: "0.1.0",
+    });
+    expect(
+      JSON.parse(readFileSync(path.join(result.root, "package.json"), "utf8"))
+        .letta,
+    ).toEqual({
+      manifestVersion: 1,
+      mods: ["src/mod.ts"],
+    });
+    expect(readRegistry(modsRoot).packages[0]).toMatchObject({
+      root: "packages/git/github.com/caren/compat-mod",
+      entries: ["src/mod.ts"],
+    });
+  });
+
+  test("GitHub package install runs safe dependency install", async () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    const npmCalls: Array<{ args: string[]; cmd: string; cwd?: string }> = [];
+    __testOverrideNpmManagedModPackageInstaller({
+      platform: "linux",
+      gitSpawnImpl: (_cmd, args) => {
+        if (args[0] === "clone") {
+          writeCompatibilityGitPackage({
+            dependencies: { "left-pad": "1.0.0" },
+            packageRoot: String(args.at(-1)),
+          });
+        }
+        const child = createChildProcess();
+        queueMicrotask(() => {
+          if (args[0] === "rev-parse") child.stdout?.emit("data", "abc123\n");
+          child.emit("exit", 0);
+        });
+        return child;
+      },
+      spawnImpl: (cmd, args, options) => {
+        npmCalls.push({ args, cmd, cwd: options.cwd?.toString() });
+        if (!options.cwd) throw new Error("expected cwd");
+        const dependencyRoot = path.join(
+          options.cwd.toString(),
+          "node_modules",
+          "left-pad",
+        );
+        mkdirSync(dependencyRoot, { recursive: true });
+        writeFileSync(path.join(dependencyRoot, "index.js"), "export {};\n");
+        const child = createChildProcess();
+        queueMicrotask(() => child.emit("exit", 0));
+        return child;
+      },
+    });
+
+    const result = await installGitManagedModPackage({
+      modsRoot,
+      specifier: "https://github.com/caren/deps-mod@v1",
+    });
+
+    expect(npmCalls).toEqual([
+      {
+        cmd: "npm",
+        args: [
+          "install",
+          "--ignore-scripts",
+          "--omit=dev",
+          "--no-audit",
+          "--no-fund",
+          "--package-lock=false",
+          "--no-save",
+        ],
+        cwd: expect.any(String),
+      },
+    ]);
+    expect(
+      existsSync(
+        path.join(result.root, "node_modules", "left-pad", "index.js"),
+      ),
+    ).toBe(true);
+  });
+
+  test("GitHub packages without a manifest or conventional entry fail without writing", async () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    __testOverrideNpmManagedModPackageInstaller({
+      gitSpawnImpl: (_cmd, args) => {
+        if (args[0] === "clone") {
+          const packageRoot = String(args.at(-1));
+          mkdirSync(packageRoot, { recursive: true });
+          writeFileSync(
+            path.join(packageRoot, "package.json"),
+            `${JSON.stringify({ name: "not-a-mod", version: "0.1.0" })}\n`,
+          );
+        }
+        const child = createChildProcess();
+        queueMicrotask(() => {
+          if (args[0] === "rev-parse") child.stdout?.emit("data", "abc123\n");
+          child.emit("exit", 0);
+        });
+        return child;
+      },
+    });
+
+    await expect(
+      installGitManagedModPackage({
+        modsRoot,
+        specifier: "https://github.com/caren/not-a-mod",
+      }),
+    ).rejects.toThrow("GitHub repo is not an installable Letta mod package");
+    expect(existsSync(path.join(modsRoot, "packages.json"))).toBe(false);
+    expect(existsSync(path.join(modsRoot, "packages"))).toBe(false);
   });
 });

--- a/src/mods/package-installer.test.ts
+++ b/src/mods/package-installer.test.ts
@@ -256,13 +256,6 @@ describe("local managed mod package installer", () => {
       source: "git:https://github.com/caren/my-mod",
     });
     expect(
-      parseGitManagedModPackageInstallSpecifier("github:caren/my-mod@v2"),
-    ).toMatchObject({
-      cloneUrl: "https://github.com/caren/my-mod.git",
-      ref: "v2",
-      source: "git:https://github.com/caren/my-mod",
-    });
-    expect(
       parseGitManagedModPackageInstallSpecifier(
         "ssh://git@github.com/caren/my-mod.git@abc123",
       ),

--- a/src/mods/package-installer.ts
+++ b/src/mods/package-installer.ts
@@ -674,6 +674,9 @@ function splitGitRef(value: string): { ref?: string; source: string } {
     if (!source || !ref) {
       throw new Error(`Invalid git mod package specifier: ${value}`);
     }
+    if (!/^[a-z0-9][a-z0-9._/-]*$/i.test(ref)) {
+      throw new Error(`Invalid git ref: ${ref}`);
+    }
     return { ref, source };
   }
   return { source: value };
@@ -739,6 +742,19 @@ function parseGitHubShorthandInstallSource(
   });
 }
 
+function parseGitHubPackageInstallSource(
+  specifier: string,
+): GitManagedModPackageInstallSpecifier | null {
+  const { ref, source } = splitGitRef(specifier);
+  const parts = source.split("/").filter(Boolean);
+  if (parts.length !== 2) return null;
+  return normalizeGitHubInstallSource({
+    owner: parts[0] ?? "",
+    ...(ref ? { ref } : {}),
+    repo: parts[1] ?? "",
+  });
+}
+
 function parseGitHubSshInstallSource(
   specifier: string,
 ): GitManagedModPackageInstallSpecifier | null {
@@ -780,6 +796,9 @@ export function parseGitManagedModPackageInstallSpecifier(
   }
   if (trimmed.startsWith("git@github.com:")) {
     return parseGitHubSshInstallSource(trimmed);
+  }
+  if (trimmed.startsWith("github:")) {
+    return parseGitHubPackageInstallSource(trimmed.slice("github:".length));
   }
   if (!trimmed.startsWith("git:")) return null;
   const gitSource = trimmed.slice("git:".length);
@@ -1007,7 +1026,10 @@ async function checkoutGitPackage(params: {
       ];
   await runGit(cloneArgs, params.tempRoot);
   if (params.parsed.ref) {
-    await runGit(["checkout", params.parsed.ref], params.packageDirectory);
+    await runGit(
+      ["checkout", "--", params.parsed.ref],
+      params.packageDirectory,
+    );
   }
   const revision = await runGit(
     ["rev-parse", "--short", "HEAD"],

--- a/src/mods/package-installer.ts
+++ b/src/mods/package-installer.ts
@@ -742,19 +742,6 @@ function parseGitHubShorthandInstallSource(
   });
 }
 
-function parseGitHubPackageInstallSource(
-  specifier: string,
-): GitManagedModPackageInstallSpecifier | null {
-  const { ref, source } = splitGitRef(specifier);
-  const parts = source.split("/").filter(Boolean);
-  if (parts.length !== 2) return null;
-  return normalizeGitHubInstallSource({
-    owner: parts[0] ?? "",
-    ...(ref ? { ref } : {}),
-    repo: parts[1] ?? "",
-  });
-}
-
 function parseGitHubSshInstallSource(
   specifier: string,
 ): GitManagedModPackageInstallSpecifier | null {
@@ -796,9 +783,6 @@ export function parseGitManagedModPackageInstallSpecifier(
   }
   if (trimmed.startsWith("git@github.com:")) {
     return parseGitHubSshInstallSource(trimmed);
-  }
-  if (trimmed.startsWith("github:")) {
-    return parseGitHubPackageInstallSource(trimmed.slice("github:".length));
   }
   if (!trimmed.startsWith("git:")) return null;
   const gitSource = trimmed.slice("git:".length);

--- a/src/mods/package-installer.ts
+++ b/src/mods/package-installer.ts
@@ -17,7 +17,9 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { isModFileExtension } from "@/mods/file-extensions";
 import {
+  LETTA_PACKAGE_MANIFEST_VERSION,
   type LettaPackageCapability,
   readLettaPackageManifest,
 } from "@/mods/package-manifest";
@@ -48,6 +50,15 @@ export interface NpmManagedModPackageInstallSpecifier {
   version?: string;
 }
 
+export interface GitManagedModPackageInstallSpecifier {
+  cloneUrl: string;
+  owner: string;
+  ref?: string;
+  repo: string;
+  repository: string;
+  source: string;
+}
+
 interface PackageSourceInfo {
   capabilities: LettaPackageCapability[];
   entries: string[];
@@ -62,11 +73,13 @@ interface PackageSourceInfo {
 interface InstallPreparedManagedModPackageParams {
   dependencyNodeModulesDirectory?: string;
   enabled?: boolean;
+  includePackageNodeModules?: boolean;
   modsRoot: string;
   packageDirectory: string;
+  packageInfo?: PackageSourceInfo;
 }
 
-type NpmInstallProcessFactory = (
+type ManagedPackageProcessFactory = (
   command: string,
   args: string[],
   options: SpawnOptions,
@@ -74,7 +87,8 @@ type NpmInstallProcessFactory = (
 
 const SKIPPED_PACKAGE_COPY_NAMES = new Set([".git", "node_modules"]);
 
-let spawnNpmInstallProcess: NpmInstallProcessFactory = spawn;
+let spawnNpmInstallProcess: ManagedPackageProcessFactory = spawn;
+let spawnGitInstallProcess: ManagedPackageProcessFactory = spawn;
 let platformOverride: NodeJS.Platform | null = null;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -176,7 +190,7 @@ function validateManifestEntriesExist(
   }
 }
 
-function validatePackageSource(packageDirectory: string): PackageSourceInfo {
+function resolvePackageDirectory(packageDirectory: string): string {
   const resolvedPackageDirectory = path.resolve(packageDirectory);
   let packageStats: ReturnType<typeof lstatSync>;
   try {
@@ -192,6 +206,11 @@ function validatePackageSource(packageDirectory: string): PackageSourceInfo {
   if (!packageStats.isDirectory()) {
     throw new Error(`Package path must be a directory: ${packageDirectory}`);
   }
+  return resolvedPackageDirectory;
+}
+
+function validatePackageSource(packageDirectory: string): PackageSourceInfo {
+  const resolvedPackageDirectory = resolvePackageDirectory(packageDirectory);
 
   const packageJsonPath = path.join(resolvedPackageDirectory, "package.json");
   const packageJson = readPackageJson(packageJsonPath);
@@ -407,7 +426,8 @@ function makeSiblingTempDirectory(
 function installPreparedManagedModPackage(
   params: InstallPreparedManagedModPackageParams,
 ): InstallLocalManagedModPackageResult {
-  const packageInfo = validatePackageSource(params.packageDirectory);
+  const packageInfo =
+    params.packageInfo ?? validatePackageSource(params.packageDirectory);
   const packagesRoot = path.resolve(
     params.modsRoot,
     MOD_PACKAGES_DIRECTORY_NAME,
@@ -445,6 +465,8 @@ function installPreparedManagedModPackage(
         sourceNodeModulesDirectory: params.dependencyNodeModulesDirectory,
         targetPackageRoot: stagingRoot,
       });
+    }
+    if (params.includePackageNodeModules) {
       copyPackageInternalNodeModules({
         packageDirectory: packageInfo.packageDirectory,
         targetPackageRoot: stagingRoot,
@@ -507,7 +529,7 @@ function getNpmExecutable(): string {
   return (platformOverride ?? process.platform) === "win32" ? "npm.cmd" : "npm";
 }
 
-function getNpmInstallArgs(installSpec: string): string[] {
+function getNpmInstallArgs(installSpec?: string): string[] {
   return [
     "install",
     "--ignore-scripts",
@@ -519,7 +541,7 @@ function getNpmInstallArgs(installSpec: string): string[] {
     ...((platformOverride ?? process.platform) === "win32"
       ? ["--no-bin-links"]
       : []),
-    installSpec,
+    ...(installSpec ? [installSpec] : []),
   ];
 }
 
@@ -537,15 +559,15 @@ function writeNpmInstallManifest(tempRoot: string): void {
   );
 }
 
-function runNpmInstall(params: {
-  installSpec: string;
-  tempRoot: string;
-}): Promise<void> {
-  const command = getNpmExecutable();
-  const args = getNpmInstallArgs(params.installSpec);
+function runProcess(params: {
+  args: string[];
+  command: string;
+  cwd: string;
+  spawnImpl: ManagedPackageProcessFactory;
+}): Promise<{ stderr: string; stdout: string }> {
   return new Promise((resolve, reject) => {
-    const child = spawnNpmInstallProcess(command, args, {
-      cwd: params.tempRoot,
+    const child = params.spawnImpl(params.command, params.args, {
+      cwd: params.cwd,
       stdio: ["ignore", "pipe", "pipe"],
     });
     const stdout: string[] = [];
@@ -559,17 +581,36 @@ function runNpmInstall(params: {
     child.on("error", reject);
     child.on("exit", (code) => {
       if (code === 0) {
-        resolve();
+        resolve({ stderr: stderr.join(""), stdout: stdout.join("") });
         return;
       }
       const details = stderr.join("").trim() || stdout.join("").trim();
       reject(
         new Error(
-          `npm install failed with code ${code ?? "unknown"}${details ? `: ${details}` : ""}`,
+          `${params.command} failed with code ${code ?? "unknown"}${details ? `: ${details}` : ""}`,
         ),
       );
     });
   });
+}
+
+async function runNpmInstall(params: {
+  installSpec?: string;
+  tempRoot: string;
+}): Promise<void> {
+  try {
+    await runProcess({
+      args: getNpmInstallArgs(params.installSpec),
+      command: getNpmExecutable(),
+      cwd: params.tempRoot,
+      spawnImpl: spawnNpmInstallProcess,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      message.replace(/^npm(?:\.cmd)? failed/, "npm install failed"),
+    );
+  }
 }
 
 function getInstalledPackageDirectory(
@@ -620,6 +661,361 @@ export function parseNpmManagedModPackageInstallSpecifier(
   };
 }
 
+function stripGitSuffix(value: string): string {
+  return value.replace(/\.git$/i, "");
+}
+
+function splitGitRef(value: string): { ref?: string; source: string } {
+  const slashIndex = value.lastIndexOf("/");
+  const atIndex = value.lastIndexOf("@");
+  if (atIndex > slashIndex) {
+    const source = value.slice(0, atIndex);
+    const ref = value.slice(atIndex + 1);
+    if (!source || !ref) {
+      throw new Error(`Invalid git mod package specifier: ${value}`);
+    }
+    return { ref, source };
+  }
+  return { source: value };
+}
+
+function normalizeGitHubInstallSource(params: {
+  owner: string;
+  ref?: string;
+  repo: string;
+}): GitManagedModPackageInstallSpecifier {
+  const owner = params.owner.toLowerCase();
+  const repo = stripGitSuffix(params.repo).toLowerCase();
+  if (!/^[a-z0-9][a-z0-9._-]*$/i.test(owner)) {
+    throw new Error(`Invalid GitHub owner: ${params.owner}`);
+  }
+  if (!/^[a-z0-9][a-z0-9._-]*$/i.test(repo)) {
+    throw new Error(`Invalid GitHub repository: ${params.repo}`);
+  }
+  const repository = `https://github.com/${owner}/${repo}`;
+  return {
+    cloneUrl: `${repository}.git`,
+    owner,
+    ...(params.ref ? { ref: params.ref } : {}),
+    repo,
+    repository,
+    source: `git:${repository}`,
+  };
+}
+
+function parseGitHubHttpsInstallSource(
+  specifier: string,
+): GitManagedModPackageInstallSpecifier | null {
+  const { ref, source } = splitGitRef(specifier);
+  let url: URL;
+  try {
+    url = new URL(source);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "https:" || url.hostname !== "github.com") {
+    return null;
+  }
+  if (url.username || url.password || url.search || url.hash) return null;
+  const parts = url.pathname.split("/").filter(Boolean);
+  if (parts.length !== 2) return null;
+  return normalizeGitHubInstallSource({
+    owner: parts[0] ?? "",
+    ...(ref ? { ref } : {}),
+    repo: parts[1] ?? "",
+  });
+}
+
+function parseGitHubShorthandInstallSource(
+  specifier: string,
+): GitManagedModPackageInstallSpecifier | null {
+  const { ref, source } = splitGitRef(specifier);
+  const parts = source.split("/").filter(Boolean);
+  if (parts.length !== 3 || parts[0] !== "github.com") return null;
+  return normalizeGitHubInstallSource({
+    owner: parts[1] ?? "",
+    ...(ref ? { ref } : {}),
+    repo: parts[2] ?? "",
+  });
+}
+
+function parseGitHubSshInstallSource(
+  specifier: string,
+): GitManagedModPackageInstallSpecifier | null {
+  const { ref, source } = splitGitRef(specifier);
+  const scpMatch = source.match(/^git@github\.com:([^/]+)\/(.+)$/);
+  if (scpMatch) {
+    return normalizeGitHubInstallSource({
+      owner: scpMatch[1] ?? "",
+      ...(ref ? { ref } : {}),
+      repo: scpMatch[2] ?? "",
+    });
+  }
+  let url: URL;
+  try {
+    url = new URL(source);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "ssh:" || url.hostname !== "github.com") return null;
+  const parts = url.pathname.split("/").filter(Boolean);
+  if (parts.length !== 2) return null;
+  return normalizeGitHubInstallSource({
+    owner: parts[0] ?? "",
+    ...(ref ? { ref } : {}),
+    repo: parts[1] ?? "",
+  });
+}
+
+export function parseGitManagedModPackageInstallSpecifier(
+  specifier: string,
+): GitManagedModPackageInstallSpecifier | null {
+  const trimmed = specifier.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith("https://github.com/")) {
+    return parseGitHubHttpsInstallSource(trimmed);
+  }
+  if (trimmed.startsWith("ssh://git@github.com/")) {
+    return parseGitHubSshInstallSource(trimmed);
+  }
+  if (trimmed.startsWith("git@github.com:")) {
+    return parseGitHubSshInstallSource(trimmed);
+  }
+  if (!trimmed.startsWith("git:")) return null;
+  const gitSource = trimmed.slice("git:".length);
+  if (gitSource.startsWith("https://github.com/")) {
+    return parseGitHubHttpsInstallSource(gitSource);
+  }
+  if (gitSource.startsWith("ssh://git@github.com/")) {
+    return parseGitHubSshInstallSource(gitSource);
+  }
+  if (gitSource.startsWith("git@github.com:")) {
+    return parseGitHubSshInstallSource(gitSource);
+  }
+  return parseGitHubShorthandInstallSource(gitSource);
+}
+
+function hasRuntimeDependencies(
+  packageJson: Record<string, unknown> | null,
+): boolean {
+  if (!packageJson) return false;
+  const dependencies = packageJson.dependencies;
+  return isRecord(dependencies) && Object.keys(dependencies).length > 0;
+}
+
+function readPackageJsonIfExists(
+  packageDirectory: string,
+): Record<string, unknown> | null {
+  const packageJsonPath = path.join(packageDirectory, "package.json");
+  if (!existsSync(packageJsonPath)) return null;
+  return readPackageJson(packageJsonPath);
+}
+
+function isRegularModFile(filePath: string): boolean {
+  try {
+    const stats = lstatSync(filePath);
+    return !stats.isSymbolicLink() && stats.isFile();
+  } catch {
+    return false;
+  }
+}
+
+function inferCompatibilityModEntries(packageDirectory: string): string[] {
+  const modsDirectory = path.join(packageDirectory, "mods");
+  if (existsSync(modsDirectory)) {
+    const stats = lstatSync(modsDirectory);
+    if (stats.isSymbolicLink()) {
+      throw new Error(`Package mods directory must not be a symlink: mods`);
+    }
+    if (stats.isDirectory()) {
+      const entries = readdirSync(modsDirectory, { withFileTypes: true })
+        .filter(
+          (entry) =>
+            entry.isFile() && isModFileExtension(path.extname(entry.name)),
+        )
+        .map((entry) => `mods/${entry.name}`)
+        .sort();
+      if (entries.length > 0) return entries;
+    }
+  }
+
+  for (const entry of [
+    "src/mod.ts",
+    "src/mod.tsx",
+    "src/mod.js",
+    "src/mod.mjs",
+    "mod.ts",
+    "mod.tsx",
+    "mod.js",
+    "mod.mjs",
+  ]) {
+    if (isRegularModFile(path.join(packageDirectory, ...entry.split("/")))) {
+      return [entry];
+    }
+  }
+  return [];
+}
+
+function getPackageNameForGitPackage(params: {
+  packageJson: Record<string, unknown> | null;
+  repo: string;
+}): string {
+  const name = params.packageJson?.name;
+  if (typeof name === "string" && name.trim()) return name.trim();
+  return params.repo;
+}
+
+function getPackageVersionForGitPackage(params: {
+  packageJson: Record<string, unknown> | null;
+  revision: string;
+}): string {
+  const version = params.packageJson?.version;
+  if (typeof version === "string" && version.trim()) return version.trim();
+  return params.revision;
+}
+
+function writeCompatibilityPackageManifest(params: {
+  entries: string[];
+  packageDirectory: string;
+  packageJson: Record<string, unknown> | null;
+  packageName: string;
+  version: string;
+}): void {
+  const packageJsonPath = path.join(params.packageDirectory, "package.json");
+  writeFileSync(
+    packageJsonPath,
+    `${JSON.stringify(
+      {
+        ...(params.packageJson ?? {}),
+        name: params.packageName,
+        version: params.version,
+        letta: {
+          manifestVersion: LETTA_PACKAGE_MANIFEST_VERSION,
+          mods: params.entries,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+function createGitPackageSourceInfo(params: {
+  packageDirectory: string;
+  parsed: GitManagedModPackageInstallSpecifier;
+  revision: string;
+}): PackageSourceInfo {
+  const packageDirectory = resolvePackageDirectory(params.packageDirectory);
+  let packageJson = readPackageJsonIfExists(packageDirectory);
+  const packageJsonPath = path.join(packageDirectory, "package.json");
+  const packageName = getPackageNameForGitPackage({
+    packageJson,
+    repo: params.parsed.repo,
+  });
+  const version = getPackageVersionForGitPackage({
+    packageJson,
+    revision: params.revision,
+  });
+  let capabilities: LettaPackageCapability[] = [];
+  let entries: string[];
+
+  if (packageJson && Object.hasOwn(packageJson, "letta")) {
+    const manifestResult = readLettaPackageManifest(packageJsonPath);
+    if (!manifestResult.ok) {
+      throw new Error(
+        manifestResult.errors
+          .map((error) => `${error.path}: ${error.message}`)
+          .join("\n"),
+      );
+    }
+    if (!manifestResult.manifest) {
+      throw new Error("Package does not include a package.json#letta manifest");
+    }
+    entries = manifestResult.manifest.mods;
+    capabilities = manifestResult.manifest.capabilities ?? [];
+  } else {
+    entries = inferCompatibilityModEntries(packageDirectory);
+    if (entries.length === 0) {
+      throw new Error(
+        "GitHub repo is not an installable Letta mod package. Add package.json#letta or a conventional mod entry.",
+      );
+    }
+    writeCompatibilityPackageManifest({
+      entries,
+      packageDirectory,
+      packageJson,
+      packageName,
+      version,
+    });
+    packageJson = readPackageJson(packageJsonPath);
+  }
+
+  validateManifestEntriesExist(packageDirectory, entries);
+  const rootRelativePath = getManagedModPackageRootRelativePathForSource(
+    params.parsed.source,
+  );
+  if (!rootRelativePath) {
+    throw new Error(
+      `Invalid managed mod package source: ${params.parsed.source}`,
+    );
+  }
+  return {
+    capabilities,
+    entries,
+    packageDirectory,
+    packageName,
+    repository:
+      formatRepository(packageJson?.repository) ?? params.parsed.repository,
+    rootRelativePath,
+    source: params.parsed.source,
+    version,
+  };
+}
+
+function getGitExecutable(): string {
+  return "git";
+}
+
+async function runGit(
+  args: string[],
+  cwd: string,
+): Promise<{
+  stderr: string;
+  stdout: string;
+}> {
+  return runProcess({
+    args,
+    command: getGitExecutable(),
+    cwd,
+    spawnImpl: spawnGitInstallProcess,
+  });
+}
+
+async function checkoutGitPackage(params: {
+  packageDirectory: string;
+  parsed: GitManagedModPackageInstallSpecifier;
+  tempRoot: string;
+}): Promise<string> {
+  const cloneArgs = params.parsed.ref
+    ? ["clone", params.parsed.cloneUrl, params.packageDirectory]
+    : [
+        "clone",
+        "--depth",
+        "1",
+        params.parsed.cloneUrl,
+        params.packageDirectory,
+      ];
+  await runGit(cloneArgs, params.tempRoot);
+  if (params.parsed.ref) {
+    await runGit(["checkout", params.parsed.ref], params.packageDirectory);
+  }
+  const revision = await runGit(
+    ["rev-parse", "--short", "HEAD"],
+    params.packageDirectory,
+  );
+  return revision.stdout.trim() || "unknown";
+}
+
 export function installLocalManagedModPackage(params: {
   modsRoot: string;
   packageDirectory: string;
@@ -646,6 +1042,7 @@ export async function installNpmManagedModPackage(params: {
     );
     return installPreparedManagedModPackage({
       dependencyNodeModulesDirectory: nodeModulesDirectory,
+      includePackageNodeModules: true,
       modsRoot: params.modsRoot,
       packageDirectory,
     });
@@ -654,10 +1051,48 @@ export async function installNpmManagedModPackage(params: {
   }
 }
 
+export async function installGitManagedModPackage(params: {
+  modsRoot: string;
+  specifier: string;
+}): Promise<InstallLocalManagedModPackageResult> {
+  const parsed = parseGitManagedModPackageInstallSpecifier(params.specifier);
+  if (!parsed) {
+    throw new Error(`Invalid git mod package specifier: ${params.specifier}`);
+  }
+  const tempRoot = mkdtempSync(path.join(tmpdir(), "letta-mod-git-"));
+  try {
+    const packageDirectory = path.join(tempRoot, "repo");
+    const revision = await checkoutGitPackage({
+      packageDirectory,
+      parsed,
+      tempRoot,
+    });
+    const packageJson = readPackageJsonIfExists(packageDirectory);
+    if (hasRuntimeDependencies(packageJson)) {
+      await runNpmInstall({ tempRoot: packageDirectory });
+    }
+    const packageInfo = createGitPackageSourceInfo({
+      packageDirectory,
+      parsed,
+      revision,
+    });
+    return installPreparedManagedModPackage({
+      includePackageNodeModules: true,
+      modsRoot: params.modsRoot,
+      packageDirectory,
+      packageInfo,
+    });
+  } finally {
+    rmSync(tempRoot, { force: true, recursive: true });
+  }
+}
+
 export function __testOverrideNpmManagedModPackageInstaller(params: {
+  gitSpawnImpl?: ManagedPackageProcessFactory | null;
   platform?: NodeJS.Platform | null;
-  spawnImpl?: NpmInstallProcessFactory | null;
+  spawnImpl?: ManagedPackageProcessFactory | null;
 }): void {
+  spawnGitInstallProcess = params.gitSpawnImpl ?? spawn;
   spawnNpmInstallProcess = params.spawnImpl ?? spawn;
   platformOverride = params.platform ?? null;
 }

--- a/src/mods/package-registry.test.ts
+++ b/src/mods/package-registry.test.ts
@@ -97,6 +97,11 @@ describe("managed mod package registry", () => {
     expect(
       getManagedModPackageRootRelativePathForSource("npm:@caren/my-mod"),
     ).toBe("packages/npm/@caren/my-mod");
+    expect(
+      getManagedModPackageRootRelativePathForSource(
+        "git:https://github.com/caren/my-mod",
+      ),
+    ).toBe("packages/git/github.com/caren/my-mod");
 
     for (const source of [
       "npm:@caren",
@@ -104,6 +109,8 @@ describe("managed mod package registry", () => {
       "npm:../my-mod",
       "npm:.",
       "npm:",
+      "git:https://github.com/caren",
+      "git:https://gitlab.com/caren/my-mod",
       "path:my-mod",
     ]) {
       expect(getManagedModPackageRootRelativePathForSource(source)).toBeNull();

--- a/src/mods/package-registry.ts
+++ b/src/mods/package-registry.ts
@@ -694,12 +694,48 @@ export function parseManagedNpmPackageSource(source: string): string | null {
   return normalizedPackageName;
 }
 
+export interface ManagedGitPackageSource {
+  host: "github.com";
+  owner: string;
+  repo: string;
+}
+
+function isValidGitHubPathPart(value: string): boolean {
+  return /^[a-z0-9][a-z0-9._-]*$/i.test(value);
+}
+
+export function parseManagedGitPackageSource(
+  source: string,
+): ManagedGitPackageSource | null {
+  const prefix = "git:https://github.com/";
+  if (!source.startsWith(prefix)) return null;
+  const repoPath = source.slice(prefix.length).replace(/\.git$/i, "");
+  const normalizedRepoPath = normalizeRelativePath(repoPath);
+  if (!normalizedRepoPath) return null;
+  const parts = normalizedRepoPath.split("/");
+  if (parts.length !== 2) return null;
+  const [owner, repo] = parts;
+  if (!owner || !repo) return null;
+  if (!isValidGitHubPathPart(owner) || !isValidGitHubPathPart(repo)) {
+    return null;
+  }
+  return {
+    host: "github.com",
+    owner: owner.toLowerCase(),
+    repo: repo.toLowerCase(),
+  };
+}
+
 export function getManagedModPackageRootRelativePathForSource(
   source: string,
 ): string | null {
   const packageName = parseManagedNpmPackageSource(source);
-  if (!packageName) return null;
-  return `${MOD_PACKAGES_DIRECTORY_NAME}/npm/${packageName}`;
+  if (packageName) return `${MOD_PACKAGES_DIRECTORY_NAME}/npm/${packageName}`;
+  const gitSource = parseManagedGitPackageSource(source);
+  if (gitSource) {
+    return `${MOD_PACKAGES_DIRECTORY_NAME}/git/${gitSource.host}/${gitSource.owner}/${gitSource.repo}`;
+  }
+  return null;
 }
 
 function assertSafePackageRemovalRoot(


### PR DESCRIPTION
## Summary
- Add `letta install https://github.com/owner/repo` and `letta install git:github.com/owner/repo` for managed mod packages
- Install GitHub packages under `packages/git/github.com/owner/repo` with normalized `git:https://github.com/owner/repo` registry sources
- Support package.json#letta manifests first, with a compatibility fallback for conventional mod entries like `src/mod.ts`
- Run safe runtime dependency installs for GitHub packages with `npm install --ignore-scripts --omit=dev --no-audit --no-fund --package-lock=false --no-save`

## Tests
- `bun test src/mods/package-registry.test.ts src/mods/package-installer.test.ts src/cli/subcommands/skills.test.ts`
- `bun run check`
- Smoke-tested temp installs for `klittle32/letta-mcp-mod` and `rl-0x000/letta-secrets-scanning-mod`