### PR TITLE
fix(worktree): use junction instead of symlink on Windows

### DIFF
--- a/src/tools/impl/enter-worktree.ts
+++ b/src/tools/impl/enter-worktree.ts
@@ -567,7 +567,13 @@ async function symlinkDirIntoWorktree(
   }
 
   await mkdir(path.dirname(dest), { recursive: true });
-  await symlink(source, dest, "dir");
+  // On Windows, directory symlinks require admin privileges or Developer Mode.
+  // Junctions achieve the same result without elevated permissions.
+  await symlink(
+    source,
+    dest,
+    process.platform === "win32" ? "junction" : "dir",
+  );
   return {
     linked: true,
     note: `symlinked ${normalized} from the primary checkout`,


### PR DESCRIPTION
## Summary
- `fs.symlink(source, dest, "dir")` requires admin privileges or Developer Mode on Windows — without elevation it throws EPERM and the provisioning step silently no-ops (caught by best-effort try/catch)
- Switch to `"junction"` type on win32, which achieves the same result without elevated permissions
- Pattern matches openclaw's approach: `process.platform === "win32" ? "junction" : "dir"`

## Test plan
- [x] All 22 existing worktree tests pass on macOS (uses `"dir"` path)
- [ ] Verify on Windows that worktree provisioning (hooks linking, opt-in dependency symlinks) succeeds without admin/Developer Mode

Based on #3059 (EnterWorktree rename).

👾 Generated with [Letta Code](https://letta.com)