### PR TITLE
fix(worktree): use junction links on Windows

### DIFF
--- a/src/tools/enter-worktree.test.ts
+++ b/src/tools/enter-worktree.test.ts
@@ -19,6 +19,7 @@ import { settingsManager } from "@/settings-manager";
 import {
   addWindowsPathLengthHint,
   enter_worktree,
+  getDirectorySymlinkType,
 } from "@/tools/impl/enter-worktree";
 import {
   clearToolsWithLock,
@@ -781,6 +782,12 @@ describe("EnterWorktree tool", () => {
     expect(await releaseWorktreeLock({ worktreeGitDir: gitDir, owner })).toBe(
       false,
     );
+  });
+
+  test("uses junctions for directory links on windows", () => {
+    expect(getDirectorySymlinkType("win32")).toBe("junction");
+    expect(getDirectorySymlinkType("linux")).toBe("dir");
+    expect(getDirectorySymlinkType("darwin")).toBe("dir");
   });
 
   test("adds a windows path-length hint to git checkout failures", () => {

--- a/src/tools/impl/enter-worktree.ts
+++ b/src/tools/impl/enter-worktree.ts
@@ -72,6 +72,16 @@ const DEFAULT_GIT_TIMEOUT_MS = 120_000;
 const FETCH_GIT_TIMEOUT_MS = 180_000;
 const MAX_SLUG_LENGTH = 48;
 
+type DirectorySymlinkType = "dir" | "junction";
+
+export function getDirectorySymlinkType(
+  platform: NodeJS.Platform = process.platform,
+): DirectorySymlinkType {
+  // Windows directory symlinks often require elevated privileges;
+  // junctions are the safer directory-link type there.
+  return platform === "win32" ? "junction" : "dir";
+}
+
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -567,7 +577,7 @@ async function symlinkDirIntoWorktree(
   }
 
   await mkdir(path.dirname(dest), { recursive: true });
-  await symlink(source, dest, "dir");
+  await symlink(source, dest, getDirectorySymlinkType());
   return {
     linked: true,
     note: `symlinked ${normalized} from the primary checkout`,


### PR DESCRIPTION
## Problem
Follow-up to #3059: worktree provisioning links dependency and hook directories with `fs.promises.symlink(..., "dir")`, which is brittle on Windows because directory symlinks can require elevated privileges.

## Approach
- Select `junction` for directory provisioning links on `win32`, preserving `dir` elsewhere.
- Route dependency directory and relative git hook links through the shared helper selector.

## Validation
- `bun test src/tools/enter-worktree.test.ts`
- `bun run typecheck`
- `bunx --bun @biomejs/biome@2.2.5 check src/tools/impl/enter-worktree.ts src/tools/enter-worktree.test.ts`

## Risk / limits
Low risk: non-Windows link behavior is unchanged; Windows coverage verifies target-type selection rather than creating junctions on a non-Windows runner.

👾 Generated with [Letta Code](https://letta.com)