### PR TITLE
fix(desktop): use selected provider for toolset refresh

### DIFF
--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -476,6 +476,7 @@ export async function prepareToolExecutionContextForScope(params: {
   agentId: string;
   conversationId?: string | null;
   overrideModel?: string | null;
+  overrideProviderType?: string | null;
   cachedEffectiveModel?: string | null;
   exclude?: ToolName[];
   clientToolAllowlist?: string[];
@@ -491,6 +492,7 @@ export async function prepareToolExecutionContextForScope(params: {
     agentId,
     conversationId,
     overrideModel,
+    overrideProviderType,
     cachedEffectiveModel,
     exclude,
     clientToolAllowlist,
@@ -510,9 +512,12 @@ export async function prepareToolExecutionContextForScope(params: {
     overrideModel && overrideModel.length > 0
       ? (resolveModel(overrideModel) ?? overrideModel)
       : null;
-  let effectiveProviderType = providerTypeFromModelSettings(
-    (agent as { model_settings?: unknown }).model_settings,
-  );
+  let effectiveProviderType =
+    overrideProviderType !== undefined
+      ? overrideProviderType
+      : providerTypeFromModelSettings(
+          (agent as { model_settings?: unknown }).model_settings,
+        );
 
   if (
     !effectiveModel &&

--- a/src/websocket/listen-model-update.test.ts
+++ b/src/websocket/listen-model-update.test.ts
@@ -250,7 +250,7 @@ describe("listen-client applyModelUpdateForRuntime wiring", () => {
     expect(resolved?.updateArgs?.reasoning_effort).toBe("medium");
   });
 
-  test("returns Anthropic effort settings for BYOK Opus 4.8 max update", async () => {
+  test("switches BYOK Opus 4.8 max update from stale ChatGPT provider state to default toolset", async () => {
     const storageDir = await mkdtemp(join(os.tmpdir(), "ws-byok-opus-max-"));
     const previousHome = process.env.HOME;
     try {
@@ -265,10 +265,10 @@ describe("listen-client applyModelUpdateForRuntime wiring", () => {
       __testSetBackend(backend);
       const agent = await backend.createAgent({
         name: "BYOK Opus Agent",
-        model: "lc-anthropic/claude-opus-4-8",
+        model: "chatgpt-jin/gpt-5.5",
         model_settings: {
-          provider_type: "anthropic",
-          effort: "high",
+          provider_type: "chatgpt_oauth",
+          reasoning: { reasoning_effort: "high" },
           parallel_tool_calls: true,
         },
       } as AgentCreateBody);
@@ -306,6 +306,9 @@ describe("listen-client applyModelUpdateForRuntime wiring", () => {
         provider_type: "anthropic",
         effort: "max",
       });
+      expect(scopedRuntime.currentToolset).toBe("default");
+      expect(scopedRuntime.currentLoadedTools).toContain("Edit");
+      expect(scopedRuntime.currentLoadedTools).not.toContain("exec_command");
       expect(
         (response.model_settings as Record<string, unknown> | null)?.reasoning,
       ).toBeUndefined();

--- a/src/websocket/listener/commands/model-toolset.ts
+++ b/src/websocket/listener/commands/model-toolset.ts
@@ -104,6 +104,13 @@ function buildModelHandleFromConfig(
   return config.model ?? null;
 }
 
+function providerTypeFromModelSettings(
+  modelSettings: Record<string, unknown> | null,
+): string | null {
+  const providerType = modelSettings?.provider_type;
+  return typeof providerType === "string" ? providerType : null;
+}
+
 function withContextWindow(
   baseConfig: ModelScopeSnapshot["llmConfig"],
   contextWindow?: number,
@@ -401,6 +408,10 @@ export async function applyModelUpdateForRuntime(params: {
       agentId,
       conversationId,
       overrideModel: model.handle,
+      overrideProviderType:
+        providerTypeFromModelSettings(modelSettings) ??
+        inferProviderTypeFromRegistryHandle(model.handle) ??
+        null,
       modEvents: ensureListenerModAdapter(listener).events,
     });
     nextToolset = preparedToolContext.toolset;


### PR DESCRIPTION
## Summary
- pass the selected model provider type into the scoped tool refresh during desktop model updates
- prevent stale ChatGPT OAuth provider state from forcing the Codex toolset after switching to Anthropic/Opus models
- add a regression covering ChatGPT OAuth -> BYOK Opus 4.8 Max on a non-default conversation

## Testing
- `bun test src/websocket/listen-model-update.test.ts`
- `bun run typecheck`
- precommit: biome, boundary/export/filename checks, typecheck
