### PR TITLE
feat(models): add letta/glm preset

### DIFF
--- a/src/cli/components/ModelSelector-availability.test.tsx
+++ b/src/cli/components/ModelSelector-availability.test.tsx
@@ -6,6 +6,7 @@ type StubModel = { handle: string; label: string };
 const MODELS: StubModel[] = [
   { handle: "letta/auto", label: "Auto" },
   { handle: "letta/auto-fast", label: "Auto Fast" },
+  { handle: "letta/glm", label: "GLM" },
   { handle: "anthropic/claude-sonnet-4-6", label: "Sonnet 4.6" },
 ];
 
@@ -37,19 +38,22 @@ describe("ModelSelector availability gating", () => {
     expect(result.map((m) => m.handle)).not.toContain("letta/auto");
   });
 
-  test("fallback mode hides letta/auto unless explicitly present in allApiHandles", () => {
+  test("fallback mode hides API-gated Letta models unless explicitly present in allApiHandles", () => {
     const hiddenResult = filterModelsByAvailabilityForSelector(MODELS, null, [
       "anthropic/claude-sonnet-4-6",
     ]);
     expect(hiddenResult.map((m) => m.handle)).not.toContain("letta/auto");
+    expect(hiddenResult.map((m) => m.handle)).not.toContain("letta/glm");
     expect(hiddenResult.map((m) => m.handle)).toContain(
       "anthropic/claude-sonnet-4-6",
     );
 
     const shownResult = filterModelsByAvailabilityForSelector(MODELS, null, [
       "letta/auto",
+      "letta/glm",
       "anthropic/claude-sonnet-4-6",
     ]);
     expect(shownResult.map((m) => m.handle)).toContain("letta/auto");
+    expect(shownResult.map((m) => m.handle)).toContain("letta/glm");
   });
 });

--- a/src/cli/components/ModelSelector.tsx
+++ b/src/cli/components/ModelSelector.tsx
@@ -206,7 +206,11 @@ export function toSelectorModelForHandle(handle: string): UiModel {
   };
 }
 
-const API_GATED_MODEL_HANDLES = new Set(["letta/auto", "letta/auto-fast"]);
+const API_GATED_MODEL_HANDLES = new Set([
+  "letta/auto",
+  "letta/auto-fast",
+  "letta/glm",
+]);
 
 export function filterModelsByAvailabilityForSelector<
   T extends { handle: string },

--- a/src/models.json
+++ b/src/models.json
@@ -42,7 +42,7 @@
     {
       "id": "glm",
       "handle": "letta/glm",
-      "label": "GLM",
+      "label": "Letta GLM",
       "description": "Route directly to Letta-hosted GLM 5.2",
       "free": true,
       "updateArgs": {

--- a/src/models.json
+++ b/src/models.json
@@ -46,7 +46,7 @@
       "description": "Route directly to Letta-hosted GLM 5.2",
       "free": true,
       "updateArgs": {
-        "context_window": 140000,
+        "context_window": 200000,
         "max_output_tokens": 28000,
         "parallel_tool_calls": true
       }

--- a/src/models.json
+++ b/src/models.json
@@ -40,6 +40,18 @@
       "isFeatured": true
     },
     {
+      "id": "glm",
+      "handle": "letta/glm",
+      "label": "GLM",
+      "description": "Route directly to Letta-hosted GLM 5.2",
+      "free": true,
+      "updateArgs": {
+        "context_window": 140000,
+        "max_output_tokens": 28000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "fable",
       "handle": "anthropic/claude-fable-5",
       "label": "Fable 5",


### PR DESCRIPTION
## Summary
Adds letta/glm to the Letta Code model registry so clients can select the new Cloud/Core handle once the server advertises it. The selector gates the preset on API availability, matching the pattern used for Letta-managed models that may not exist on every backend.

This PR is the client half of the Cloud/Core letta/glm endpoint work. It does not add local Pi/provider routing for GLM; local provider catalogs continue to use their existing Z.ai entries.

## Behavior
Before: Letta Code had Auto and provider-specific Z.ai GLM entries, but no direct letta/glm preset.

After: letta/glm appears as a registry preset when the connected API reports the handle, with the same conservative context/output defaults used by the other Letta-hosted presets.

## Validation
- env -u USER_CWD bun test src/cli/components/ModelSelector-availability.test.tsx src/tools/model-provider-detection.test.ts
- bunx prettier --check src/models.json src/cli/components/ModelSelector.tsx src/cli/components/ModelSelector-availability.test.tsx

👾 Generated with [Letta Code](https://letta.com)