### PR TITLE
ci(sync-tools): add typecheck step to sync workflow prompt

### DIFF
--- a/.github/workflows/sync-tools-to-cloud.yml
+++ b/.github/workflows/sync-tools-to-cloud.yml
@@ -84,7 +84,14 @@ jobs:
                ```
                Make the necessary edits. Keep the change minimal and focused on what the letta-code PR actually changed.
 
-            6. Push the branch and open a PR, tagging the original author as reviewer:
+            6. Before committing, run the type checker to catch any type errors introduced by the edits:
+               ```bash
+               cd /tmp/letta-cloud
+               npx tsc --noEmit
+               ```
+               If type errors are reported, fix them in the same branch before proceeding. Do not push broken types.
+
+            7. Push the branch and open a PR, tagging the original author as reviewer:
                ```bash
                cd /tmp/letta-cloud
                git add -A
@@ -97,7 +104,7 @@ jobs:
                  --reviewer "$PR_AUTHOR"
                ```
 
-            7. Respond with exactly: `PR_CREATED <url>` where `<url>` is the letta-cloud PR URL.
+            8. Respond with exactly: `PR_CREATED <url>` where `<url>` is the letta-cloud PR URL.
 
             ## Voice
             You are Amelia. Work quietly and precisely. Do not leave comments or reviews — just open the PR.

--- a/.github/workflows/sync-tools-to-cloud.yml
+++ b/.github/workflows/sync-tools-to-cloud.yml
@@ -87,7 +87,7 @@ jobs:
             6. Before committing, run the type checker to catch any type errors introduced by the edits:
                ```bash
                cd /tmp/letta-cloud
-               npx tsc --noEmit
+               npm run type-check
                ```
                If type errors are reported, fix them in the same branch before proceeding. Do not push broken types.
 


### PR DESCRIPTION
## Summary
Adds a typecheck step (`npx tsc --noEmit`) to the sync-tools-to-cloud workflow prompt, so type errors are caught before pushing the letta-cloud PR.

## Context
The sync PR #12577 on letta-cloud had type errors that were only caught after pushing. This change instructs the agent to run the type checker on the letta-cloud branch before committing, so broken types don't make it into the PR.

## Changes
- Step 6: run `npx tsc --noEmit` in `/tmp/letta-cloud` before committing
- Fix any reported type errors before proceeding
- Renumbered subsequent steps (push/PR creation is now step 7, response is step 8)

👾 Generated with [Letta Code](https://letta.com)