### PR TITLE
feat(mods): add result effect to tool_start event

### DIFF
--- a/src/mods/mod-engine.test.ts
+++ b/src/mods/mod-engine.test.ts
@@ -1104,6 +1104,52 @@ describe("mod engine", () => {
     }
   });
 
+  test("tool_start result: error status populates error field", async () => {
+    const root = createTempDir();
+    try {
+      const modDir = path.join(root, "global-mods");
+      mkdirSync(modDir, { recursive: true });
+      writeFileSync(
+        path.join(modDir, "result-error.ts"),
+        `export default function(letta) {
+          letta.events.on("tool_start", (event) => {
+            if (event.toolName === "Bash" && event.args.command === "dangerous") {
+              return { result: { status: "error", output: "blocked: dangerous command" } };
+            }
+          });
+        }`,
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+      const event = {
+        agentId: "agent-1",
+        conversationId: "conversation-1",
+        toolCallId: "toolu-1",
+        toolName: "Bash",
+        args: { command: "dangerous" },
+      };
+
+      const result = await engine.emitEvent(
+        "tool_start",
+        event,
+        createModContext(),
+      );
+
+      expect(result.handlerCount).toBe(1);
+      expect(
+        (event as { result?: { status: string; output: string } }).result,
+      ).toEqual({
+        status: "error",
+        output: "blocked: dangerous command",
+      });
+
+      engine.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("reload aborts old activations and ignores stale handles", async () => {
     const root = createTempDir();
     const testGlobal = globalThis as ModTestGlobal;

--- a/src/mods/mod-engine.test.ts
+++ b/src/mods/mod-engine.test.ts
@@ -1012,6 +1012,96 @@ describe("mod engine", () => {
     }
   });
 
+  test("tool_start result: first handler wins, tool is short-circuited", async () => {
+    const root = createTempDir();
+    try {
+      const modDir = path.join(root, "global-mods");
+      mkdirSync(modDir, { recursive: true });
+      writeFileSync(
+        path.join(modDir, "result.ts"),
+        `export default function(letta) {
+          letta.events.on("tool_start", (event) => {
+            if (event.toolName === "Bash" && event.args.command === "cached") {
+              return { result: { status: "success", output: "cached result" } };
+            }
+          });
+          letta.events.on("tool_start", (event) => {
+            if (event.toolName === "Bash" && event.args.command === "cached") {
+              return { result: { status: "error", output: "should not win" } };
+            }
+          });
+        }`,
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+      const event = {
+        agentId: "agent-1",
+        conversationId: "conversation-1",
+        toolCallId: "toolu-1",
+        toolName: "Bash",
+        args: { command: "cached" },
+      };
+
+      const result = await engine.emitEvent(
+        "tool_start",
+        event,
+        createModContext(),
+      );
+
+      expect(result.handlerCount).toBe(2);
+      expect((event as { result?: { status: string; output: string } }).result).toEqual({
+        status: "success",
+        output: "cached result",
+      });
+
+      engine.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("tool_start result: no result when condition not met", async () => {
+    const root = createTempDir();
+    try {
+      const modDir = path.join(root, "global-mods");
+      mkdirSync(modDir, { recursive: true });
+      writeFileSync(
+        path.join(modDir, "result.ts"),
+        `export default function(letta) {
+          letta.events.on("tool_start", (event) => {
+            if (event.toolName === "Bash" && event.args.command === "cached") {
+              return { result: { status: "success", output: "cached result" } };
+            }
+          });
+        }`,
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+      const event = {
+        agentId: "agent-1",
+        conversationId: "conversation-1",
+        toolCallId: "toolu-1",
+        toolName: "Bash",
+        args: { command: "echo hello" },
+      };
+
+      const result = await engine.emitEvent(
+        "tool_start",
+        event,
+        createModContext(),
+      );
+
+      expect(result.handlerCount).toBe(1);
+      expect((event as { result?: unknown }).result).toBeUndefined();
+
+      engine.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("reload aborts old activations and ignores stale handles", async () => {
     const root = createTempDir();
     const testGlobal = globalThis as ModTestGlobal;

--- a/src/mods/mod-engine.test.ts
+++ b/src/mods/mod-engine.test.ts
@@ -1050,7 +1050,9 @@ describe("mod engine", () => {
       );
 
       expect(result.handlerCount).toBe(2);
-      expect((event as { result?: { status: string; output: string } }).result).toEqual({
+      expect(
+        (event as { result?: { status: string; output: string } }).result,
+      ).toEqual({
         status: "success",
         output: "cached result",
       });

--- a/src/mods/mod-engine.ts
+++ b/src/mods/mod-engine.ts
@@ -95,7 +95,6 @@ import type {
   ModTool,
   ModToolRegistration,
   ModToolStartEvent,
-
   ModTurnStartEvent,
 } from "@/mods/types";
 
@@ -1694,8 +1693,11 @@ export async function emitLocalModEvent<TName extends ModEventName>(
         isToolStartResultWithResult(name, result) &&
         !(event as ModToolStartEvent & { result?: unknown }).result
       ) {
-        (event as ModToolStartEvent & { result?: { status: "success" | "error"; output: string } }).result =
-          result.result;
+        (
+          event as ModToolStartEvent & {
+            result?: { status: "success" | "error"; output: string };
+          }
+        ).result = result.result;
       }
       if (result != null) {
         results.push(result as NonNullable<ModEventResultMap[TName]>);

--- a/src/mods/mod-engine.ts
+++ b/src/mods/mod-engine.ts
@@ -95,6 +95,7 @@ import type {
   ModTool,
   ModToolRegistration,
   ModToolStartEvent,
+
   ModTurnStartEvent,
 } from "@/mods/types";
 
@@ -756,6 +757,30 @@ function isToolStartResultWithArgs(
 
 function isToolStartArgs(value: unknown): value is ModToolStartEvent["args"] {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isToolStartResult(
+  value: unknown,
+): value is { status: "success" | "error"; output: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    ((value as { status?: unknown }).status === "success" ||
+      (value as { status?: unknown }).status === "error") &&
+    typeof (value as { output?: unknown }).output === "string"
+  );
+}
+
+function isToolStartResultWithResult(
+  name: ModEventName,
+  result: unknown,
+): result is { result: { status: "success" | "error"; output: string } } {
+  return (
+    name === "tool_start" &&
+    typeof result === "object" &&
+    result !== null &&
+    isToolStartResult((result as { result?: unknown }).result)
+  );
 }
 
 function cloneToolStartArgs(
@@ -1664,6 +1689,13 @@ export async function emitLocalModEvent<TName extends ModEventName>(
       }
       if (isToolStartResultWithArgs(name, result)) {
         (event as ModToolStartEvent).args = result.args;
+      }
+      if (
+        isToolStartResultWithResult(name, result) &&
+        !(event as ModToolStartEvent & { result?: unknown }).result
+      ) {
+        (event as ModToolStartEvent & { result?: { status: "success" | "error"; output: string } }).result =
+          result.result;
       }
       if (result != null) {
         results.push(result as NonNullable<ModEventResultMap[TName]>);

--- a/src/mods/types.ts
+++ b/src/mods/types.ts
@@ -197,6 +197,7 @@ export interface ModToolStartEvent {
 
 export interface ModToolStartResult {
   args?: Record<string, unknown>;
+  result?: { status: "success" | "error"; output: string };
 }
 
 export interface ModEventMap {

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -2641,7 +2641,10 @@ export async function executeTool(
       toolName: name,
     });
     if (result) {
-      return { toolReturn: result.output, status: result.status };
+      return {
+        toolReturn: result.output,
+        status: result.status,
+      };
     }
     const permissionDecision = await checkModPermissionForContext({
       args: eventArgs,
@@ -2678,7 +2681,10 @@ export async function executeTool(
       toolName: name,
     });
     if (result) {
-      return { toolReturn: result.output, status: result.status };
+      return {
+        toolReturn: result.output,
+        status: result.status,
+      };
     }
     const permissionDecision = await checkModPermissionForContext({
       args: eventArgs,
@@ -2737,7 +2743,10 @@ export async function executeTool(
     toolName: internalName,
   });
   if (result) {
-    return { toolReturn: result.output, status: result.status };
+    return {
+      toolReturn: result.output,
+      status: result.status,
+    };
   }
   args = eventArgs;
   const permissionDecision = await checkModPermissionForContext({

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -46,6 +46,7 @@ import type {
   ModContext,
   ModSecretResolver,
   ModToolRunContext,
+  ModToolStartEvent,
   ToolApprovalPolicy,
 } from "@/mods/types";
 import {
@@ -2299,8 +2300,10 @@ async function emitToolStartEvent(options: {
   modContext: ModContext;
   toolCallId?: string;
   toolName: string;
-}): Promise<{ args: ToolArgs }> {
-  const event = {
+}): Promise<{ args: ToolArgs; result?: { status: "success" | "error"; output: string } }> {
+  const event: ModToolStartEvent & {
+    result?: { status: "success" | "error"; output: string };
+  } = {
     agentId: options.executionScope.agentId ?? null,
     conversationId: options.executionScope.conversationId ?? null,
     toolCallId: options.toolCallId ?? null,
@@ -2315,7 +2318,10 @@ async function emitToolStartEvent(options: {
     return { args: options.args };
   }
 
-  return { args: isToolStartArgs(event.args) ? event.args : options.args };
+  return {
+    args: isToolStartArgs(event.args) ? event.args : options.args,
+    result: event.result,
+  };
 }
 
 async function executeModTool(
@@ -2623,7 +2629,7 @@ export async function executeTool(
         status: "error",
       };
     }
-    const { args: eventArgs } = await emitToolStartEvent({
+    const { args: eventArgs, result } = await emitToolStartEvent({
       args,
       events: modEvents,
       executionScope,
@@ -2631,6 +2637,9 @@ export async function executeTool(
       toolCallId: options?.toolCallId,
       toolName: name,
     });
+    if (result) {
+      return { toolReturn: result.output, status: result.status };
+    }
     const permissionDecision = await checkModPermissionForContext({
       args: eventArgs,
       context,
@@ -2657,7 +2666,7 @@ export async function executeTool(
   // Check if this is an external tool (SDK-executed)
   if (activeExternalTools.has(name)) {
     const externalTool = activeExternalTools.get(name);
-    const { args: eventArgs } = await emitToolStartEvent({
+    const { args: eventArgs, result } = await emitToolStartEvent({
       args,
       events: modEvents,
       executionScope,
@@ -2665,6 +2674,9 @@ export async function executeTool(
       toolCallId: options?.toolCallId,
       toolName: name,
     });
+    if (result) {
+      return { toolReturn: result.output, status: result.status };
+    }
     const permissionDecision = await checkModPermissionForContext({
       args: eventArgs,
       context,
@@ -2713,7 +2725,7 @@ export async function executeTool(
     };
   }
 
-  const { args: eventArgs } = await emitToolStartEvent({
+  const { args: eventArgs, result } = await emitToolStartEvent({
     args,
     events: modEvents,
     executionScope,
@@ -2721,6 +2733,9 @@ export async function executeTool(
     toolCallId: options?.toolCallId,
     toolName: internalName,
   });
+  if (result) {
+    return { toolReturn: result.output, status: result.status };
+  }
   args = eventArgs;
   const permissionDecision = await checkModPermissionForContext({
     args,

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -2300,7 +2300,10 @@ async function emitToolStartEvent(options: {
   modContext: ModContext;
   toolCallId?: string;
   toolName: string;
-}): Promise<{ args: ToolArgs; result?: { status: "success" | "error"; output: string } }> {
+}): Promise<{
+  args: ToolArgs;
+  result?: { status: "success" | "error"; output: string };
+}> {
   const event: ModToolStartEvent & {
     result?: { status: "success" | "error"; output: string };
   } = {


### PR DESCRIPTION
## Summary
- Allow mods to return `{ result: { status, output } }` from `tool_start` handlers to short-circuit tool execution
- First handler wins — subsequent handlers cannot override an existing result

## Test plan
- [x] Unit test: first handler wins when multiple return result
- [x] Unit test: no result when condition not met
- [x] All existing tool_start tests pass
- [x] Type check clean

👾 Generated with [Letta Code](https://letta.com)