### PR TITLE
feat(mods): add git package update support

### DIFF
--- a/src/cli/subcommands/mods.test.ts
+++ b/src/cli/subcommands/mods.test.ts
@@ -451,6 +451,64 @@ describe("mods subcommand", () => {
     }
   });
 
+  test("update command updates git package and prints old to new version", async () => {
+    const root = createTempDir();
+    const modsRoot = join(root, "mods");
+    mkdirSync(modsRoot, { recursive: true });
+    writeManagedPackage({
+      modsRoot,
+      root: "packages/git/github.com/caren/git-mod",
+      source: "git:https://github.com/caren/git-mod",
+      version: "0.1.0",
+    });
+    __testOverrideNpmManagedModPackageInstaller({
+      gitSpawnImpl: (_cmd, args) => {
+        if (args[0] === "clone") {
+          const packageRoot = String(args.at(-1));
+          mkdirSync(join(packageRoot, "mods"), { recursive: true });
+          writeFileSync(join(packageRoot, "mods", "index.ts"), "export {};\n");
+          writeFileSync(
+            join(packageRoot, "package.json"),
+            `${JSON.stringify({
+              name: "git-mod",
+              version: "0.2.0",
+              letta: {
+                manifestVersion: 1,
+                mods: ["mods/index.ts"],
+              },
+            })}\n`,
+          );
+        }
+        const child = createChildProcess();
+        queueMicrotask(() => {
+          if (args[0] === "rev-parse") child.stdout?.emit("data", "def456\n");
+          child.emit("exit", 0);
+        });
+        return child;
+      },
+    });
+    const consoleCapture = captureConsole();
+
+    try {
+      const exitCode = await runModsSubcommand(
+        ["update", "https://github.com/caren/git-mod"],
+        { globalModsDirectory: modsRoot },
+      );
+
+      expect(exitCode).toBe(0);
+      expect(consoleCapture.logs.join("\n")).toContain(
+        "Updated git:https://github.com/caren/git-mod 0.1.0 -> 0.2.0",
+      );
+      expect(consoleCapture.logs.join("\n")).toContain("Run /reload");
+      expect(
+        JSON.parse(readFileSync(join(modsRoot, "packages.json"), "utf8"))
+          .packages[0].version,
+      ).toBe("0.2.0");
+    } finally {
+      consoleCapture.restore();
+    }
+  });
+
   test("update command rejects agent option", async () => {
     const consoleCapture = captureConsole();
 

--- a/src/cli/subcommands/mods.ts
+++ b/src/cli/subcommands/mods.ts
@@ -2,7 +2,11 @@ import { dirname, join } from "node:path";
 import { parseArgs } from "node:util";
 import { getScopedMemoryFilesystemRoot } from "@/agent/memory-filesystem";
 import { type LocalModSource, resolveLocalModSources } from "@/mods/mod-engine";
-import { updateNpmManagedModPackage } from "@/mods/package-installer";
+import {
+  parseGitManagedModPackageInstallSpecifier,
+  updateGitManagedModPackage,
+  updateNpmManagedModPackage,
+} from "@/mods/package-installer";
 import {
   listManagedModPackages,
   type ManagedModPackageDiagnostic,
@@ -62,7 +66,7 @@ function printUsage(): void {
 Usage:
   letta mods list [--agent <id>]
   letta mods package <mod-file> --name <package-name> [--out <dir>]
-  letta mods update <npm-package-spec>
+  letta mods update <npm-package-spec | git-package-spec>
   letta mods enable <package-spec>
   letta mods disable <package-spec>
   letta mods remove <package-spec>
@@ -344,11 +348,12 @@ async function runPackageUpdate(
   }
 
   try {
-    const result = await updateNpmManagedModPackage({
-      modsRoot:
-        options.globalModsDirectory ?? resolveDefaultGlobalModsDirectory(),
-      specifier,
-    });
+    const modsRoot =
+      options.globalModsDirectory ?? resolveDefaultGlobalModsDirectory();
+    const gitParsed = parseGitManagedModPackageInstallSpecifier(specifier);
+    const result = gitParsed
+      ? await updateGitManagedModPackage({ modsRoot, specifier })
+      : await updateNpmManagedModPackage({ modsRoot, specifier });
     const disabledSuffix = result.enabled ? "" : " (disabled)";
     console.log(
       `Updated ${result.source} ${result.previousVersion} -> ${result.version}${disabledSuffix}`,

--- a/src/mods/package-installer.test.ts
+++ b/src/mods/package-installer.test.ts
@@ -21,6 +21,7 @@ import {
   installNpmManagedModPackage,
   parseGitManagedModPackageInstallSpecifier,
   parseNpmManagedModPackageInstallSpecifier,
+  updateGitManagedModPackage,
   updateNpmManagedModPackage,
 } from "@/mods/package-installer";
 
@@ -830,6 +831,135 @@ describe("local managed mod package installer", () => {
         specifier: "npm:@caren/my-mod",
       }),
     ).rejects.toThrow("No managed mod packages are installed.");
+  });
+
+  test("updates an installed git package and reports old and new versions", async () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    let cloneCount = 0;
+    __testOverrideNpmManagedModPackageInstaller({
+      gitSpawnImpl: (_cmd, args, _options) => {
+        if (args[0] === "clone") {
+          cloneCount++;
+          writeLocalPackage({
+            capabilities: ["commands"],
+            entries: cloneCount === 1 ? ["mods/index.ts"] : ["mods/next.ts"],
+            name: "git-mod",
+            packageRoot: String(args.at(-1)),
+            version: cloneCount === 1 ? "0.1.0" : "0.2.0",
+          });
+        }
+        const child = createChildProcess();
+        queueMicrotask(() => {
+          if (args[0] === "rev-parse") {
+            child.stdout?.emit(
+              "data",
+              cloneCount === 1 ? "abc123\n" : "def456\n",
+            );
+          }
+          child.emit("exit", 0);
+        });
+        return child;
+      },
+    });
+
+    const first = await installGitManagedModPackage({
+      modsRoot,
+      specifier: "https://github.com/caren/git-mod",
+    });
+    writeFileSync(path.join(first.root, "stale.ts"), "stale\n");
+
+    const result = await updateGitManagedModPackage({
+      modsRoot,
+      specifier: "https://github.com/caren/git-mod",
+    });
+
+    expect(result).toMatchObject({
+      enabled: true,
+      previousVersion: "0.1.0",
+      source: "git:https://github.com/caren/git-mod",
+      version: "0.2.0",
+    });
+    expect(existsSync(path.join(result.root, "mods", "next.ts"))).toBe(true);
+    expect(existsSync(path.join(result.root, "mods", "index.ts"))).toBe(false);
+    expect(existsSync(path.join(result.root, "stale.ts"))).toBe(false);
+    expect(readRegistry(modsRoot).packages).toEqual([
+      {
+        source: "git:https://github.com/caren/git-mod",
+        version: "0.2.0",
+        enabled: true,
+        root: "packages/git/github.com/caren/git-mod",
+        entries: ["mods/next.ts"],
+      },
+    ]);
+  });
+
+  test("update git package preserves disabled state", async () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    let cloneCount = 0;
+    __testOverrideNpmManagedModPackageInstaller({
+      gitSpawnImpl: (_cmd, args) => {
+        if (args[0] === "clone") {
+          cloneCount++;
+          writeLocalPackage({
+            name: "git-mod",
+            packageRoot: String(args.at(-1)),
+            version: cloneCount === 1 ? "0.1.0" : "0.2.0",
+          });
+        }
+        const child = createChildProcess();
+        queueMicrotask(() => {
+          if (args[0] === "rev-parse") child.stdout?.emit("data", "abc123\n");
+          child.emit("exit", 0);
+        });
+        return child;
+      },
+    });
+
+    await installGitManagedModPackage({
+      modsRoot,
+      specifier: "https://github.com/caren/git-mod",
+    });
+    const registry = readRegistry(modsRoot);
+    registry.packages[0] = { ...registry.packages[0], enabled: false };
+    writeFileSync(
+      path.join(modsRoot, "packages.json"),
+      `${JSON.stringify(registry, null, 2)}\n`,
+    );
+
+    const result = await updateGitManagedModPackage({
+      modsRoot,
+      specifier: "https://github.com/caren/git-mod",
+    });
+
+    expect(result.enabled).toBe(false);
+    expect(readRegistry(modsRoot).packages[0]?.enabled).toBe(false);
+    expect(readRegistry(modsRoot).packages[0]?.version).toBe("0.2.0");
+  });
+
+  test("git update requires an installed package", async () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+
+    await expect(
+      updateGitManagedModPackage({
+        modsRoot,
+        specifier: "https://github.com/caren/git-mod",
+      }),
+    ).rejects.toThrow("No managed mod packages are installed.");
+  });
+
+  test("git update invalid specifier fails", async () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+
+    await expect(
+      updateGitManagedModPackage({
+        modsRoot,
+        specifier: "npm:invalid",
+      }),
+    ).rejects.toThrow("Invalid git mod package specifier");
   });
 
   test("npm install failure does not write registry", async () => {

--- a/src/mods/package-installer.ts
+++ b/src/mods/package-installer.ts
@@ -50,6 +50,12 @@ export interface UpdateNpmManagedModPackageResult
   previousVersion: string;
 }
 
+export interface UpdateGitManagedModPackageResult
+  extends InstallLocalManagedModPackageResult {
+  enabled: boolean;
+  previousVersion: string;
+}
+
 export interface NpmManagedModPackageInstallSpecifier {
   installSpec: string;
   packageName: string;
@@ -1127,6 +1133,52 @@ export async function updateNpmManagedModPackage(params: {
       includePackageNodeModules: true,
       modsRoot: params.modsRoot,
       packageDirectory,
+    });
+    return {
+      ...updated,
+      enabled: existing.enabled,
+      previousVersion: existing.version,
+    };
+  } finally {
+    rmSync(tempRoot, { force: true, recursive: true });
+  }
+}
+
+export async function updateGitManagedModPackage(params: {
+  modsRoot: string;
+  specifier: string;
+}): Promise<UpdateGitManagedModPackageResult> {
+  const parsed = parseGitManagedModPackageInstallSpecifier(params.specifier);
+  if (!parsed) {
+    throw new Error(`Invalid git mod package specifier: ${params.specifier}`);
+  }
+  const existing = getManagedModPackage({
+    modsRoot: params.modsRoot,
+    specifier: parsed.source,
+  }).package;
+  const tempRoot = mkdtempSync(path.join(tmpdir(), "letta-mod-git-"));
+  try {
+    const packageDirectory = path.join(tempRoot, "repo");
+    const revision = await checkoutGitPackage({
+      packageDirectory,
+      parsed,
+      tempRoot,
+    });
+    const packageJson = readPackageJsonIfExists(packageDirectory);
+    if (hasRuntimeDependencies(packageJson)) {
+      await runNpmInstall({ tempRoot: packageDirectory });
+    }
+    const packageInfo = createGitPackageSourceInfo({
+      packageDirectory,
+      parsed,
+      revision,
+    });
+    const updated = installPreparedManagedModPackage({
+      enabled: existing.enabled,
+      includePackageNodeModules: true,
+      modsRoot: params.modsRoot,
+      packageDirectory,
+      packageInfo,
     });
     return {
       ...updated,


### PR DESCRIPTION
## Summary
- Implements `letta mods update` for git-managed mod packages (previously only supported npm)
- Adds `updateGitManagedModPackage` function that mirrors the existing npm update flow
- CLI detects git specifiers and routes to the appropriate update function
- Preserves enabled/disabled state across updates

## Test plan
- [x] Unit tests: 4 new tests for git update in package-installer.test.ts
- [x] CLI test: 1 new test for end-to-end git update in mods.test.ts
- [x] All 49 tests pass
- [x] All 9 lint/check passes