### PR TITLE
feat: add turn_end event with continue effect

### DIFF
--- a/src/cli/app/use-conversation-loop.ts
+++ b/src/cli/app/use-conversation-loop.ts
@@ -1656,6 +1656,54 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
               return;
             }
 
+            // Emit turn_end mod event. A mod may return { continue: "..." } to
+            // append a follow-up user message and start another turn.
+            const turnEndEvent: {
+              agentId: string | null;
+              conversationId: string | null;
+              stopReason: string;
+              assistantMessage?: string;
+              continue?: string;
+            } = {
+              agentId: agentIdRef.current ?? null,
+              conversationId: conversationIdRef.current ?? null,
+              stopReason: stopReasonToHandle,
+              assistantMessage,
+            };
+            let turnEndContinue: string | undefined;
+            try {
+              await modAdapter.events.emit(
+                "turn_end",
+                turnEndEvent,
+                modAdapter.context,
+              );
+              turnEndContinue =
+                typeof turnEndEvent.continue === "string"
+                  ? turnEndEvent.continue
+                  : undefined;
+            } catch {
+              // turn_end handlers are best-effort; never block turn completion.
+              turnEndContinue = undefined;
+            }
+
+            if (turnEndContinue) {
+              const continueOtid = randomUUID();
+              setTimeout(() => {
+                processConversation(
+                  [
+                    {
+                      type: "message",
+                      role: "user",
+                      content: turnEndContinue,
+                      otid: continueOtid,
+                    },
+                  ],
+                  { allowReentry: true },
+                );
+              }, 0);
+              return;
+            }
+
             // Disable eager approval check after first successful message (LET-7101)
             // Any new approvals from here on are from our own turn, not orphaned
             if (needsEagerApprovalCheck) {

--- a/src/mods/mod-engine.test.ts
+++ b/src/mods/mod-engine.test.ts
@@ -1150,6 +1150,115 @@ describe("mod engine", () => {
     }
   });
 
+  test("turn_end continue: first handler wins", async () => {
+    const root = createTempDir();
+    try {
+      const modDir = path.join(root, "global-mods");
+      mkdirSync(modDir, { recursive: true });
+      writeFileSync(
+        path.join(modDir, "turn-end.ts"),
+        `export default function(letta) {
+          letta.events.on("turn_end", () => ({ continue: "first follow-up" }));
+          letta.events.on("turn_end", () => ({ continue: "second follow-up" }));
+        }`,
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+      const event = {
+        agentId: "agent-1",
+        conversationId: "conversation-1",
+        stopReason: "end_turn",
+        assistantMessage: "done",
+      };
+
+      const result = await engine.emitEvent(
+        "turn_end",
+        event,
+        createModContext(),
+      );
+
+      expect(result.handlerCount).toBe(2);
+      expect((event as { continue?: string }).continue).toBe("first follow-up");
+
+      engine.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("turn_end continue: no continue when handler returns nothing", async () => {
+    const root = createTempDir();
+    try {
+      const modDir = path.join(root, "global-mods");
+      mkdirSync(modDir, { recursive: true });
+      writeFileSync(
+        path.join(modDir, "turn-end.ts"),
+        `export default function(letta) {
+          letta.events.on("turn_end", () => {});
+        }`,
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+      const event = {
+        agentId: "agent-1",
+        conversationId: "conversation-1",
+        stopReason: "end_turn",
+        assistantMessage: "done",
+      };
+
+      const result = await engine.emitEvent(
+        "turn_end",
+        event,
+        createModContext(),
+      );
+
+      expect(result.handlerCount).toBe(1);
+      expect((event as { continue?: string }).continue).toBeUndefined();
+
+      engine.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("turn_end continue: empty string is ignored", async () => {
+    const root = createTempDir();
+    try {
+      const modDir = path.join(root, "global-mods");
+      mkdirSync(modDir, { recursive: true });
+      writeFileSync(
+        path.join(modDir, "turn-end.ts"),
+        `export default function(letta) {
+          letta.events.on("turn_end", () => ({ continue: "" }));
+        }`,
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+      const event = {
+        agentId: "agent-1",
+        conversationId: "conversation-1",
+        stopReason: "end_turn",
+        assistantMessage: "done",
+      };
+
+      const result = await engine.emitEvent(
+        "turn_end",
+        event,
+        createModContext(),
+      );
+
+      expect(result.handlerCount).toBe(1);
+      expect((event as { continue?: string }).continue).toBeUndefined();
+
+      engine.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("reload aborts old activations and ignores stale handles", async () => {
     const root = createTempDir();
     const testGlobal = globalThis as ModTestGlobal;

--- a/src/mods/mod-engine.ts
+++ b/src/mods/mod-engine.ts
@@ -95,6 +95,7 @@ import type {
   ModTool,
   ModToolRegistration,
   ModToolStartEvent,
+  ModTurnEndEvent,
   ModTurnStartEvent,
 } from "@/mods/types";
 
@@ -694,6 +695,7 @@ const SUPPORTED_MOD_EVENT_NAMES = new Set<ModEventName>([
   "conversation_close",
   "tool_start",
   "turn_start",
+  "turn_end",
 ]);
 
 function validateModEventName(name: string): asserts name is ModEventName {
@@ -713,6 +715,7 @@ function isModEventCapabilityEnabled(
     case "tool_start":
       return capabilities.events.tools;
     case "turn_start":
+    case "turn_end":
       return capabilities.events.turns;
   }
 }
@@ -779,6 +782,19 @@ function isToolStartResultWithResult(
     typeof result === "object" &&
     result !== null &&
     isToolStartResult((result as { result?: unknown }).result)
+  );
+}
+
+function isTurnEndResultWithContinue(
+  name: ModEventName,
+  result: unknown,
+): result is { continue: string } {
+  return (
+    name === "turn_end" &&
+    typeof result === "object" &&
+    result !== null &&
+    typeof (result as { continue?: unknown }).continue === "string" &&
+    (result as { continue: string }).continue.length > 0
   );
 }
 
@@ -1698,6 +1714,13 @@ export async function emitLocalModEvent<TName extends ModEventName>(
             result?: { status: "success" | "error"; output: string };
           }
         ).result = result.result;
+      }
+      if (
+        isTurnEndResultWithContinue(name, result) &&
+        !(event as ModTurnEndEvent & { continue?: unknown }).continue
+      ) {
+        (event as ModTurnEndEvent & { continue?: string }).continue =
+          result.continue;
       }
       if (result != null) {
         results.push(result as NonNullable<ModEventResultMap[TName]>);

--- a/src/mods/types.ts
+++ b/src/mods/types.ts
@@ -144,7 +144,8 @@ export type ModEventName =
   | "conversation_open"
   | "conversation_close"
   | "tool_start"
-  | "turn_start";
+  | "turn_start"
+  | "turn_end";
 
 export type ModConversationOpenReason =
   | "startup"
@@ -200,11 +201,23 @@ export interface ModToolStartResult {
   result?: { status: "success" | "error"; output: string };
 }
 
+export interface ModTurnEndEvent {
+  agentId: string | null;
+  conversationId: string | null;
+  stopReason: string;
+  assistantMessage?: string;
+}
+
+export interface ModTurnEndResult {
+  continue?: string;
+}
+
 export interface ModEventMap {
   conversation_open: ModConversationOpenEvent;
   conversation_close: ModConversationCloseEvent;
   tool_start: ModToolStartEvent;
   turn_start: ModTurnStartEvent;
+  turn_end: ModTurnEndEvent;
 }
 
 export interface ModEventResultMap {
@@ -212,6 +225,7 @@ export interface ModEventResultMap {
   conversation_close: undefined;
   tool_start: ModToolStartResult | undefined;
   turn_start: ModTurnStartResult | undefined;
+  turn_end: ModTurnEndResult | undefined;
 }
 
 export interface ModInvocationContext extends ModContext {}


### PR DESCRIPTION
## Summary

- New `turn_end` mod event fires when a turn fully completes (agent reached `end_turn`)
- Handlers can return `{ continue: "message" }` to append a follow-up user message and auto-start another turn
- First-handler-wins semantics (matches existing `tool_start` result and permission deny patterns)
- Payload: `{ agentId, conversationId, stopReason, assistantMessage }`

## Scope

- **TUI only** for this PR. Desktop (listener) and headless are follow-ups — the `turns` capability already exists on all surfaces, so extending later is straightforward.
- **No loop cap for MVP.** Mirrors Stop hooks (which have no hard cap). The single centralized reentry point (`if (turnEndContinue) { ... }`) makes adding a cap trivial later — a `consecutiveContinuesRef` incremented there, reset on real user submit, checked before reentering.
- Payload is `stopReason` + last assistant message. Mods needing more detail use `ctx.conversation.getHistory()`.

## Files

- `src/mods/types.ts` — `turn_end` in `ModEventName`, `ModTurnEndEvent`, `ModTurnEndResult`, register in maps
- `src/mods/mod-engine.ts` — register in `SUPPORTED_MOD_EVENT_NAMES`, map to `turns` capability, `isTurnEndResultWithContinue` guard (rejects empty strings), emit-loop capture (first handler wins)
- `src/cli/app/use-conversation-loop.ts` — emit `turn_end` in the `end_turn` block after Stop hooks; if continue returned, reenter via `processConversation([user msg], { allowReentry: true })` — mirrors existing Stop-hook `blocked` reentry exactly
- `src/mods/mod-engine.test.ts` — 3 tests: first-handler-wins, no-continue, empty-string-ignored

## Example

```ts
letta.events.on("turn_end", (event) => {
  if (event.stopReason === "end_turn" && needsFollowup(event.assistantMessage)) {
    return { continue: "now run the tests and report results" };
  }
});
```

Closes the gap with Amp `agent.end` continue and PI `agent_end`.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `bun test src/mods/mod-engine.test.ts` — 28/28 pass (3 new + 25 existing)
- [x] `bunx @biomejs/biome check` — no new warnings from changed files
- [ ] CI green

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>