### PR TITLE
feat(mods): add generate-env helper command

### DIFF
--- a/scripts/mod-learning/learn-mod.ts
+++ b/scripts/mod-learning/learn-mod.ts
@@ -12,7 +12,7 @@ import {
   runModLearning,
 } from "../../src/mods/learning-harness.ts";
 
-const DEFAULT_OPTIMIZATION_STEPS = 10;
+const DEFAULT_OPTIMIZATION_STEPS = 5;
 
 interface Args {
   backend?: string;
@@ -135,7 +135,7 @@ Options:
   --env <path>                  Learning env JSON (default: memory-citations env)
   --out <dir>                   Run artifact directory (default: .letta/mod-learning-runs/<slug>-<timestamp>)
   --candidate <path>            Use an existing candidate mod instead of generation
-  --candidates <n>              Run N optimization iterations for one learned mod (default: 10 for generated runs)
+  --candidates <n>              Run N optimization iterations for one learned mod (default: 5 for generated runs)
   --candidate-file-name <name>  Candidate filename inside the eval mod directory
   --model <handle>              Model for generation and eval
   --generation-model <handle>   Model for candidate generation

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -42,7 +42,10 @@ import type { SessionStats } from "@/agent/stats";
 import { getBackend } from "@/backend";
 import { getClient } from "@/backend/api/client";
 import type { CustomCommand } from "@/cli/commands/custom";
-import { handleModsCommand } from "@/cli/commands/mods";
+import {
+  handleModsCommand,
+  parseModsGenerateEnvCommand,
+} from "@/cli/commands/mods";
 import type { CommandHandle } from "@/cli/commands/runner";
 import { validateAgentName } from "@/cli/components/PinDialog";
 import { type Buffers, type Line, toLines } from "@/cli/helpers/accumulator";
@@ -790,6 +793,62 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
             if (shouldLockCommand) {
               setCommandRunning(false);
             }
+          }
+
+          return { submitted: true };
+        }
+
+        const modsGenerateEnvCommand = parseModsGenerateEnvCommand(trimmed);
+        if (modsGenerateEnvCommand) {
+          const args = modsGenerateEnvCommand.args;
+          const cmd = commandRunner.start(
+            trimmed,
+            args
+              ? `Starting mod env generation for: ${args}`
+              : "Starting mod env generation...",
+          );
+
+          const approvalCheck = await checkPendingApprovalsForSlashCommand();
+          if (approvalCheck.blocked) {
+            cmd.fail(
+              "Pending approval(s). Resolve approvals before running /mods generate-env.",
+            );
+            return { submitted: false };
+          }
+
+          setCommandRunning(true);
+          try {
+            const { loadRenderedSkillContent, wrapSkillContent } = await import(
+              "@/tools/impl/skill"
+            );
+            const skillContent = await loadRenderedSkillContent(
+              "generating-mod-envs",
+              {
+                agentId,
+                args,
+                allowDisabledModelInvocation: true,
+              },
+            );
+            const request = args
+              ? `The user ran \`/mods generate-env ${args}\`. Use the loaded skill to help them generate, review, validate, or improve a mod learning env JSON.`
+              : "The user ran `/mods generate-env` without arguments. Use the loaded skill's bare behavior for mod learning env generation.";
+
+            cmd.finish("Running mod env generation...", true);
+            await processConversationWithQueuedApprovals([
+              {
+                type: "message",
+                role: "user",
+                content: buildTextParts(
+                  `${wrapSkillContent("generating-mod-envs", skillContent)}\n\n${SYSTEM_REMINDER_OPEN}\n${request}\n${SYSTEM_REMINDER_CLOSE}`,
+                ),
+                otid: randomUUID(),
+              },
+            ]);
+          } catch (error) {
+            const errorDetails = formatErrorDetails(error, agentId);
+            cmd.fail(`Failed to run /mods generate-env: ${errorDetails}`);
+          } finally {
+            setCommandRunning(false);
           }
 
           return { submitted: true };

--- a/src/cli/commands/mods.test.ts
+++ b/src/cli/commands/mods.test.ts
@@ -6,6 +6,7 @@ import {
   formatModLearningSummary,
   handleModsCommand,
   parseModsCommand,
+  parseModsGenerateEnvCommand,
 } from "./mods";
 
 function createFakeCommandRunner() {
@@ -40,6 +41,22 @@ function createFakeCommandRunner() {
 }
 
 describe("/mods command", () => {
+  test("parses /mods generate-env skill launcher", () => {
+    const parsed = parseModsGenerateEnvCommand(
+      "/mods generate-env create an env for a statusline mod",
+    );
+
+    expect(parsed).toEqual({
+      args: "create an env for a statusline mod",
+    });
+  });
+
+  test("does not treat /mod as a command", () => {
+    expect(
+      parseModsGenerateEnvCommand("/mod generate-env anything"),
+    ).toBeNull();
+  });
+
   test("parses built-in learn target with model options", () => {
     const parsed = parseModsCommand(
       "/mods learn memory-citations --model current --backend api --candidate-file-name learned.ts",
@@ -109,7 +126,7 @@ describe("/mods command", () => {
             score: 11,
           },
         ],
-        candidateCount: 10,
+        candidateCount: 5,
         candidateIndex: 1,
         candidatePath: path.join(cwd, "candidates", "001", "mods", "uv.ts"),
         evalMemoryDir: path.join(cwd, "candidates", "001", "eval"),
@@ -171,7 +188,7 @@ describe("/mods command", () => {
     );
 
     expect(summary).toContain(
-      "Selected iteration: 1/10 (perfect score; stopped early)",
+      "Selected iteration: 1/5 (perfect score; stopped early)",
     );
     expect(summary).toContain("Stopped early: perfect score at iteration 1");
     expect(summary).toContain("Eval: assertions only");
@@ -206,10 +223,10 @@ describe("/mods command", () => {
           expect(options.generationModel).toBe("openai/gpt-5.5");
           expect(options.evalModel).toBe("openai/gpt-5.5");
           expect(options.runDir).toBe(path.join(cwd, ".letta", "test-run"));
-          expect(options.candidateCount).toBe(10);
+          expect(options.candidateCount).toBe(5);
           expect(options.scenarioLimit).toBeUndefined();
           options.onProgress?.({
-            candidateCount: 10,
+            candidateCount: 5,
             candidateIndex: 1,
             candidatePath: path.join(
               cwd,
@@ -220,7 +237,7 @@ describe("/mods command", () => {
               "mods",
               "memory-citations.ts",
             ),
-            message: "Generating optimization iteration 1/10",
+            message: "Generating optimization iteration 1/5",
             phase: "generating",
             runDir: path.join(cwd, ".letta", "test-run"),
           });
@@ -248,7 +265,7 @@ describe("/mods command", () => {
                 score: 2,
               },
             ],
-            candidateCount: 10,
+            candidateCount: 5,
             candidateIndex: 2,
             candidatePath: path.join(
               cwd,
@@ -261,7 +278,7 @@ describe("/mods command", () => {
             ),
             maxScore: 6,
             message:
-              "Evaluating optimization iteration 2/10: scenario 1/7 mod-loads",
+              "Evaluating optimization iteration 2/5: scenario 1/7 mod-loads",
             phase: "evaluating",
             runDir: path.join(cwd, ".letta", "test-run"),
             score: 4,
@@ -351,7 +368,7 @@ describe("/mods command", () => {
                 score: 4,
               },
             ],
-            candidateCount: 10,
+            candidateCount: 5,
             candidateIndex: 2,
             evalMemoryDir: path.join(cwd, ".letta", "test-run", "eval-memory"),
             evalResult: null,
@@ -384,14 +401,12 @@ describe("/mods command", () => {
     }
     expect(learningStarted).toBe(true);
     expect(updates[0]?.output).toContain(
-      "Starting background mod optimization: memory-citations (10 iterations)",
+      "Starting background mod optimization: memory-citations (5 iterations)",
     );
     expect(updates[1]?.output).toContain(
-      "Generating optimization iteration 1/10",
+      "Generating optimization iteration 1/5",
     );
-    expect(updates[1]?.output).toContain(
-      "Optimization progress: ●○○○○○○○○○ 1/10",
-    );
+    expect(updates[1]?.output).toContain("Optimization progress: ●○○○○ 1/5");
     expect(updates[1]?.output).toContain(
       "Score graph: waiting for first evaluation…",
     );
@@ -404,7 +419,7 @@ describe("/mods command", () => {
     expect(updates.at(-1)?.output).toMatch(
       /[⠀⠶⠰⣿⠆⢾⣉⡷⣏⣹⡁⢈]+ Background mod optimization/,
     );
-    expect(updates.at(-1)?.output).toContain("Optimization iteration: 2/10");
+    expect(updates.at(-1)?.output).toContain("Optimization iteration: 2/5");
     expect(updates.at(-1)?.output).toContain(
       "Current running score: 4/6 (67%)",
     );
@@ -415,7 +430,7 @@ describe("/mods command", () => {
       "Score history: iter 1 done 2/6 (33%) → iter 2 running 4/6 (67%)",
     );
     expect(updates.at(-1)?.output).toContain(
-      "Optimization progress: ●●○○○○○○○○ 2/10",
+      "Optimization progress: ●●○○○ 2/5",
     );
     expect(updates.at(-1)?.output).toContain("Score graph: ▁█");
     expect(updates.at(-1)?.output).toContain("iter 1 done       2/6 (33%) │");

--- a/src/cli/commands/mods.ts
+++ b/src/cli/commands/mods.ts
@@ -19,7 +19,7 @@ import {
 
 const DEFAULT_TARGET = "memory-citations";
 const DEFAULT_MODEL = "auto";
-const DEFAULT_OPTIMIZATION_ITERATIONS = 10;
+const DEFAULT_OPTIMIZATION_ITERATIONS = 5;
 const MOD_OPTIMIZATION_PULSE = BRAILLE_ANIMATIONS.pulse;
 const MOD_OPTIMIZATION_RUNNING_LABELS = [
   "running",
@@ -61,6 +61,8 @@ export type ModsCommandParseResult =
   | { command: "learn"; learn: LearnCommand }
   | { command: "usage"; output: string; success: boolean };
 
+export type ModsGenerateEnvCommand = { args: string };
+
 export type HandleModsCommandContext = {
   commandRunner: Pick<AppCommandRunner, "start">;
   cwd: string;
@@ -93,6 +95,7 @@ function formatModsUsage(error?: string): string {
     "Usage:",
     "  /mods learn [memory-citations] [options]",
     "  /mods learn --env <path> [options]",
+    "  /mods generate-env [request]",
     "",
     "Options:",
     "  --model <handle>              Model for generation and eval (default: auto)",
@@ -100,7 +103,7 @@ function formatModsUsage(error?: string): string {
     "  --eval-model <handle>         Model for headless eval",
     "  --backend <api|local>          Backend flag forwarded to headless runs",
     "  --candidate <path>            Evaluate an existing candidate instead of generating",
-    "  --candidates <n>              Run N optimization iterations for one learned mod (default: 10)",
+    "  --candidates <n>              Run N optimization iterations for one learned mod (default: 5)",
     "  --scenario-limit <n>          Evaluate only the first N scenarios (fast smoke testing)",
     "  --candidate-file-name <name>  Candidate filename in the eval mod dir",
     "  --out <dir>                   Artifact directory (default: .letta/mod-learning-runs/<target>-<timestamp>)",
@@ -267,6 +270,21 @@ export function parseModsCommand(
           : "custom env"
         : options.target,
     },
+  };
+}
+
+export function parseModsGenerateEnvCommand(
+  trimmed: string,
+): ModsGenerateEnvCommand | null {
+  if (
+    trimmed !== "/mods generate-env" &&
+    !trimmed.startsWith("/mods generate-env ")
+  ) {
+    return null;
+  }
+
+  return {
+    args: trimmed.slice("/mods generate-env".length).trim(),
   };
 }
 

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -300,7 +300,7 @@ export const commands: Record<string, Command> = {
   "/mods": {
     desc: "Run mod learning targets",
     order: 27.3,
-    args: "learn [memory-citations] [options]",
+    args: "learn [memory-citations] [options] | generate-env [request]",
     handler: () => {
       // Handled specially in use-submit-handler.ts to stream mod learning progress
       return "Starting mod learning...";

--- a/src/skills/builtin/generating-mod-envs/SKILL.md
+++ b/src/skills/builtin/generating-mod-envs/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: generating-mod-envs
 description: Generates and reviews mod learning env JSON files for Letta Code local mods. Use when asked to teach, learn, or optimize a mod behavior; create, draft, validate, improve, or explain envs for `/mods learn --env`; or design evaluation scenarios, memory fixtures, requiredResultMarkers, requiredTraceMarkers, negative controls, and candidate diversity hints.
+disable-model-invocation: true
+user-invocable: true
 ---
 
 # Generating mod learning envs
@@ -62,6 +64,7 @@ Evaluation fields:
 - `evaluation.timeoutMs`, `evaluation.maxTurns`: per-scenario defaults.
 - `evaluation.memoryFiles`: files seeded under eval `$MEMORY_DIR`.
 - `evaluation.scenarios[]`: scenario-specific overrides and fixtures.
+- In scenario-suite envs, do not add a top-level `evaluation.prompt` unless that prompt must run for every scenario. Assertion-only scenarios should have `assertions` and no `prompt`; only scenarios that require model behavior should define `scenario.prompt`.
 - `requiredResultMarkers`: literal strings required in the final answer.
 - `requiredTraceMarkers`: literal strings required in raw stdout/stderr.
 - `forbiddenResultMarkers`: final-answer strings that fail the run.
@@ -121,8 +124,7 @@ Evaluation fields:
         "requiredResultMarkers": ["4"],
         "forbiddenTraceMarkers": ["hello_mod_ping"]
       }
-    ],
-    "prompt": "Run all configured evaluation.scenarios."
+    ]
   }
 }
 ```

--- a/src/skills/builtin/generating-mod-envs/scripts/validate-mod-env.ts
+++ b/src/skills/builtin/generating-mod-envs/scripts/validate-mod-env.ts
@@ -99,6 +99,11 @@ function requiredMarkerCount(record: JsonRecord): number {
   );
 }
 
+function assertionCount(record: JsonRecord): number {
+  const value = record.assertions;
+  return Array.isArray(value) ? value.length : 0;
+}
+
 function validateScenario(params: {
   evaluation: JsonRecord;
   index: number;
@@ -113,8 +118,10 @@ function validateScenario(params: {
   optionalString(scenario, "prompt", `${path}.prompt`);
   assertValid(
     typeof scenario.prompt === "string" ||
-      typeof params.evaluation.prompt === "string",
-    `${path}.prompt is required when evaluation.prompt is absent`,
+      typeof params.evaluation.prompt === "string" ||
+      assertionCount(scenario) > 0 ||
+      assertionCount(params.evaluation) > 0,
+    `${path}.prompt or ${path}.assertions is required when evaluation.prompt is absent`,
   );
   assertValid(
     scenario.outputFormat === undefined ||


### PR DESCRIPTION
Adds `/mods generate-env [request]` as a manual launcher for the bundled `generating-mod-envs` skill, while keeping that skill hidden from automatic model invocation. This also reduces the default mod-learning optimization iterations from 10 to 5 across the CLI and script entrypoint.

The env-generation skill guidance and validator now allow assertion-only scenarios without prompts and warn against top-level `evaluation.prompt` in scenario suites unless it should run for every scenario. This prevents deterministic assertion scenarios from accidentally launching headless model evals.

No generated env files are included.

Validated with:
- `bun test src/cli/commands/mods.test.ts`
- `bun src/skills/builtin/generating-mod-envs/scripts/validate-mod-env.ts docs/examples/mods/learning/memory-citations.env.json`
- `bun run check` (using an npm-backed `bunx` shim for the local Bun `@biomejs/biome@2.2.5` resolution issue)