### PR TITLE
feat(headless): add turn_end event with continue effect

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -461,6 +461,50 @@ async function emitHeadlessTurnStart(options: {
   }
 }
 
+function findLastAssistantText(lines: Line[]): string | undefined {
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i];
+    if (
+      line?.kind === "assistant" &&
+      "text" in line &&
+      typeof line.text === "string" &&
+      line.text.trim().length > 0
+    ) {
+      return line.text;
+    }
+  }
+  return undefined;
+}
+
+async function emitHeadlessTurnEnd(options: {
+  agent: AgentState;
+  conversationId: string;
+  stopReason: string;
+  assistantMessage?: string;
+  adapter: ModAdapter;
+  context: ModContext;
+}): Promise<string | undefined> {
+  try {
+    const event: {
+      agentId: string | null;
+      conversationId: string | null;
+      stopReason: string;
+      assistantMessage?: string;
+      continue?: string;
+    } = {
+      agentId: options.agent.id,
+      conversationId: options.conversationId,
+      stopReason: options.stopReason,
+      assistantMessage: options.assistantMessage,
+    };
+    await options.adapter.events.emit("turn_end", event, options.context);
+    return typeof event.continue === "string" ? event.continue : undefined;
+  } catch {
+    // Mod turn_end handlers should not block turn completion.
+    return undefined;
+  }
+}
+
 async function sendScopedApprovalMessages(params: {
   agentId: string;
   conversationId: string;
@@ -2379,6 +2423,37 @@ ${SYSTEM_REMINDER_CLOSE}
         llmApiErrorRetries = 0;
         emptyResponseRetries = 0;
         conversationBusyRetries = 0;
+
+        // Emit turn_end. A mod may return { continue: "..." } to append a
+        // follow-up user message and run another turn. Auto-continues re-enter
+        // the loop and count against --max-turns via checkMaxTurns at the top.
+        const continueMessage = await emitHeadlessTurnEnd({
+          agent,
+          conversationId,
+          stopReason,
+          assistantMessage: findLastAssistantText(toLines(buffers)),
+          adapter: headlessModAdapter,
+          context: turnStartModContext,
+        });
+
+        if (continueMessage) {
+          currentInput = [
+            {
+              role: "user",
+              content: continueMessage,
+              otid: randomUUID(),
+            },
+          ];
+          currentInput = await emitHeadlessTurnStart({
+            agent,
+            conversationId,
+            input: currentInput,
+            adapter: headlessModAdapter,
+            context: turnStartModContext,
+          });
+          continue;
+        }
+
         break;
       }
 


### PR DESCRIPTION
## Summary
- Adds the `turn_end` mod event to headless mode, following the TUI implementation merged in #3077.
- When a headless run reaches `end_turn`, it emits `turn_end` with `{ stopReason, assistantMessage }`. If a mod returns `{ continue: "..." }`, the message is injected as a follow-up user message and another turn runs instead of finishing.
- **No bespoke loop cap.** Auto-continues re-enter the main loop and hit the existing `checkMaxTurns` budget at the top, so `--max-turns` bounds runaway continues. This matches how Amp/PI bound things (budget, not a turn-count cap) and keeps a hard backstop for unattended runs where no human is watching.
- Re-emits `turn_start` for the continued turn so the `turn_start`/`turn_end` pairing stays symmetric (a continued turn is a new turn), matching the TUI path which re-enters via `processConversation`.

## Why this is safe
- `turn_end` only fires inside the `end_turn` branch — never on `requires_approval` — so injecting a `user` continue message can never brick an API call that expects a tool-approval response.
- `turns: true` was already enabled in `HEADLESS_MOD_CAPABILITIES`; this just wires the emission.

## Test plan
- [x] `tsc --noEmit` clean
- [x] biome clean
- [x] shared `turn_end` emit/capture logic covered by `mod-engine.test.ts` (from #3077)
- [ ] E2E: drop a demo mod in `~/.letta/mods/` that returns `{ continue }` once, run `letta -p "..."` headless, confirm it auto-continues and that `--max-turns N` caps it

```ts
// ~/.letta/mods/headless-turn-end-demo.ts
let continued = false;
export default function (letta) {
  letta.events.on("turn_end", (event) => {
    if (event.stopReason !== "end_turn" || continued) return;
    if (!(event.assistantMessage ?? "").toLowerCase().includes("done")) {
      continued = true;
      return { continue: "say the word done before finishing" };
    }
  });
}
```

👾 Generated with [Letta Code](https://letta.com)