### PR TITLE
fix(agents): pinned-agent scoping cleanup and resume a single existing pin

### DIFF
--- a/src/agent/resolve-startup-agent-files.test.ts
+++ b/src/agent/resolve-startup-agent-files.test.ts
@@ -46,18 +46,21 @@ async function resolveFromSettings(options?: {
   const localSession = settingsManager.getLocalLastSession(testProjectDir);
   const globalAgentId = settingsManager.getGlobalLastAgentId();
   const pinnedAgents = settingsManager.getPinnedAgents();
+  const existingPinnedIds = pinnedAgents.filter((id) => existing.has(id));
   const pinnedAgentId =
-    pinnedAgents.length === 1 ? (pinnedAgents[0] ?? null) : null;
+    existingPinnedIds.length === 1 ? (existingPinnedIds[0] ?? null) : null;
 
-  const pinnedAgentExists = pinnedAgentId ? existing.has(pinnedAgentId) : false;
+  const pinnedAgentExists = pinnedAgentId !== null;
   const localAgentExists = localAgentId ? existing.has(localAgentId) : false;
   const globalAgentExists = globalAgentId ? existing.has(globalAgentId) : false;
   const pinnedCount = pinnedAgents.length;
+  const existingPinnedCount = existingPinnedIds.length;
 
   return resolveStartupTarget({
     pinnedAgentId,
     pinnedAgentExists,
     pinnedCount,
+    existingPinnedCount,
     localAgentId,
     localConversationId: options?.includeLocalConversation
       ? (localSession?.conversationId ?? null)
@@ -286,6 +289,52 @@ describe("startup resolution from settings files", () => {
 
     const target = await resolveFromSettings();
     expect(target).toEqual({ action: "select" });
+  });
+
+  test("multiple pins but only one exists in org => resume the existing pin", async () => {
+    await writeGlobalSettings({
+      agents: [
+        { agentId: "agent-pinned-live", pinned: true },
+        { agentId: "agent-pinned-stale-1", pinned: true },
+        { agentId: "agent-pinned-stale-2", pinned: true },
+      ],
+    });
+
+    // Two pins belong to other orgs / were deleted and don't resolve here.
+    const target = await resolveFromSettings({
+      existingAgentIds: ["agent-pinned-live"],
+    });
+
+    expect(target).toEqual({
+      action: "resume",
+      agentId: "agent-pinned-live",
+    });
+  });
+
+  test("multiple stale pins + valid global LRU => resume LRU, not select", async () => {
+    await writeGlobalSettings({
+      sessionsByServer: {
+        "api.letta.com": {
+          agentId: "agent-global",
+          conversationId: "conv-global",
+        },
+      },
+      agents: [
+        { agentId: "agent-pinned-stale-1", pinned: true },
+        { agentId: "agent-pinned-stale-2", pinned: true },
+      ],
+    });
+
+    // Neither pin resolves in this org, so the LRU should win instead of the
+    // selector firing on a raw pin count.
+    const target = await resolveFromSettings({
+      existingAgentIds: ["agent-global"],
+    });
+
+    expect(target).toEqual({
+      action: "resume",
+      agentId: "agent-global",
+    });
   });
 
   test("no valid sessions + no pinned + needsModelPicker => select", async () => {

--- a/src/agent/resolve-startup-agent.test.ts
+++ b/src/agent/resolve-startup-agent.test.ts
@@ -18,6 +18,7 @@ function makeInput(
     pinnedAgentId: null,
     pinnedAgentExists: false,
     pinnedCount: 0,
+    existingPinnedCount: 0,
     localAgentId: null,
     localConversationId: null,
     localAgentExists: false,
@@ -119,16 +120,49 @@ describe("resolveStartupTarget", () => {
     });
   });
 
-  test("multiple pinned agents open selector before stale local LRU", () => {
+  test("multiple existing pinned agents open selector before stale local LRU", () => {
     const result = resolveStartupTarget(
       makeInput({
         pinnedCount: 2,
+        existingPinnedCount: 2,
         localAgentId: "agent-last-used-456",
         localConversationId: "conv-stale-789",
         localAgentExists: true,
       }),
     );
     expect(result).toEqual({ action: "select" });
+  });
+
+  test("multiple pins but only one exists → resume that pin (stale pins ignored)", () => {
+    const result = resolveStartupTarget(
+      makeInput({
+        pinnedAgentId: "agent-pinned-live",
+        pinnedAgentExists: true,
+        pinnedCount: 3,
+        existingPinnedCount: 1,
+        localAgentId: "agent-last-used-456",
+        localAgentExists: true,
+      }),
+    );
+    expect(result).toEqual({
+      action: "resume",
+      agentId: "agent-pinned-live",
+    });
+  });
+
+  test("multiple stale pins + valid global LRU → resume LRU, not select", () => {
+    const result = resolveStartupTarget(
+      makeInput({
+        pinnedCount: 2,
+        existingPinnedCount: 0,
+        globalAgentId: "agent-global-123",
+        globalAgentExists: true,
+      }),
+    );
+    expect(result).toEqual({
+      action: "resume",
+      agentId: "agent-global-123",
+    });
   });
 
   test("dir with local LRU + invalid agent + valid global → resumes global (no conv)", () => {

--- a/src/agent/resolve-startup-agent.ts
+++ b/src/agent/resolve-startup-agent.ts
@@ -14,12 +14,16 @@ export type StartupTarget =
   | { action: "create" };
 
 export interface StartupResolutionInput {
-  /** Agent ID from pinned agents (global, per-backend namespace) */
+  /** The pinned agent to resume when exactly one pin exists for the active org */
   pinnedAgentId: string | null;
   /** Whether the pinned agent still exists on the server */
   pinnedAgentExists: boolean;
-  /** Number of pinned agents for the active backend */
+  /** Number of pinned agents configured for the active backend, including stale
+   * or cross-org pins that no longer resolve (drives the selector fallback) */
   pinnedCount: number;
+  /** Number of pinned agents that actually exist in the active org (drives the
+   * single-resume and multi-pin select decisions) */
+  existingPinnedCount: number;
 
   /** Agent ID from local project LRU (via getLocalLastAgentId) */
   localAgentId: string | null;
@@ -49,13 +53,13 @@ export interface StartupResolutionInput {
  *
  * Decision tree:
  * 1. forceNew → create
- * 2. pinned valid → resume (with local conversation only if it matches LRU)
- * 3. multiple pins → select
+ * 2. single existing pin → resume (with local conversation only if it matches LRU)
+ * 3. multiple existing pins → select
  * 4. local LRU valid → resume (with local conversation)
  * 5. global LRU valid → resume (no conversation — project-scoped)
  * 6. backend-store fallback → resume
  * 7. needsModelPicker → select
- * 8. pinned agents exist → select
+ * 8. pins configured (even if stale) → select
  * 9. nothing → create
  */
 export function resolveStartupTarget(
@@ -79,8 +83,9 @@ export function resolveStartupTarget(
     };
   }
 
-  // Step 2: Multiple pins should ask instead of picking implicitly.
-  if (input.pinnedCount > 1) {
+  // Step 2: Multiple existing pins should ask instead of picking implicitly.
+  // (Stale/cross-org pins are excluded — see existingPinnedCount.)
+  if (input.existingPinnedCount > 1) {
     return { action: "select" };
   }
 

--- a/src/backend/backend-mode.ts
+++ b/src/backend/backend-mode.ts
@@ -1,11 +1,15 @@
 /**
  * Single source of truth for the active backend mode.
  *
- * Lives in its own leaf module (no `backend.ts` deps) so low-level consumers
- * like `settings-manager` can read the mode directly instead of inferring it
- * from the `LETTA_LOCAL_BACKEND_EXPERIMENTAL` env var. The runtime override set
- * via `setConfiguredBackendMode` takes precedence; otherwise we fall back to the
+ * Kept in its own leaf module so the mode state + resolver don't sit among
+ * `backend.ts`'s backend-class imports, and so the mode can be read without
+ * pulling in the full backend module. The runtime override set via
+ * `setConfiguredBackendMode` takes precedence; otherwise we fall back to the
  * experimental local-backend env flag.
+ *
+ * Note: settings namespacing intentionally does NOT read this — it stays on the
+ * env-based predicate (`isLocalBackendEnvEnabled`) so it isn't coupled to this
+ * mutable global, which leaks across test files.
  */
 import { isLocalBackendEnvEnabled } from "./local/paths";
 

--- a/src/backend/backend-mode.ts
+++ b/src/backend/backend-mode.ts
@@ -1,0 +1,36 @@
+/**
+ * Single source of truth for the active backend mode.
+ *
+ * Lives in its own leaf module (no `backend.ts` deps) so low-level consumers
+ * like `settings-manager` can read the mode directly instead of inferring it
+ * from the `LETTA_LOCAL_BACKEND_EXPERIMENTAL` env var. The runtime override set
+ * via `setConfiguredBackendMode` takes precedence; otherwise we fall back to the
+ * experimental local-backend env flag.
+ */
+import { isLocalBackendEnvEnabled } from "./local/paths";
+
+export type BackendMode = "api" | "local";
+
+let configuredBackendMode: BackendMode | null = null;
+
+/**
+ * Resolve the active backend mode: an explicit runtime override if one was set,
+ * otherwise the experimental local-backend env flag.
+ */
+export function resolveBackendMode(): BackendMode {
+  return (
+    configuredBackendMode ?? (isLocalBackendEnvEnabled() ? "local" : "api")
+  );
+}
+
+/**
+ * Set the active backend mode override. Callers that also need to swap the live
+ * backend instance should use `configureBackendMode` from `@/backend` instead.
+ */
+export function setConfiguredBackendMode(mode: BackendMode): void {
+  configuredBackendMode = mode;
+}
+
+export function isExperimentalLocalBackendEnabled(): boolean {
+  return resolveBackendMode() === "local";
+}

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -5,11 +5,19 @@ import type {
   ForkConversationOptions,
   forkConversation as forkConversationRequest,
 } from "./api/conversations";
+import {
+  type BackendMode,
+  resolveBackendMode,
+  setConfiguredBackendMode,
+} from "./backend-mode";
 import { LocalBackend } from "./local/local-backend";
 import {
   getLocalBackendStorageDir as getLocalBackendStorageDirFromPaths,
   LOCAL_BACKEND_EXPERIMENTAL_ENV,
 } from "./local/paths";
+
+export type { BackendMode };
+export { isExperimentalLocalBackendEnabled } from "./backend-mode";
 
 export type APIClient = Awaited<ReturnType<typeof getClient>>;
 type GetAPIClient = typeof getClient;
@@ -263,8 +271,6 @@ interface APIBackendDeps {
   forkConversation?: ForkConversation;
 }
 
-export type BackendMode = "api" | "local";
-
 export class APIBackend implements Backend {
   readonly capabilities: BackendCapabilities = {
     remoteMemfs: true,
@@ -476,14 +482,6 @@ export class APIBackend implements Backend {
   }
 }
 
-function isTruthyEnv(value: string | undefined): boolean {
-  return value === "1" || value?.toLowerCase() === "true";
-}
-
-export function isExperimentalLocalBackendEnabled(): boolean {
-  return resolveBackendMode() === "local";
-}
-
 export function getLocalBackendStorageDir(homeDir = homedir()): string {
   return getLocalBackendStorageDirFromPaths(homeDir);
 }
@@ -496,15 +494,6 @@ function createExperimentalLocalBackend(): Backend {
         ? "deterministic"
         : "pi",
   });
-}
-
-let configuredBackendMode: BackendMode | null = null;
-
-function resolveBackendMode(): BackendMode {
-  if (configuredBackendMode) return configuredBackendMode;
-  return isTruthyEnv(process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL)
-    ? "local"
-    : "api";
 }
 
 function createBackendForMode(mode: BackendMode): Backend {
@@ -531,7 +520,7 @@ export function getBackendForMode(mode: BackendMode): Backend {
 }
 
 export function configureBackendMode(mode: BackendMode): void {
-  configuredBackendMode = mode;
+  setConfiguredBackendMode(mode);
   process.env[LOCAL_BACKEND_EXPERIMENTAL_ENV] = mode === "local" ? "1" : "0";
   backend = createBackendForMode(mode);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -360,22 +360,6 @@ function getModelForToolLoading(
   return specifiedModel;
 }
 
-function getCurrentBackendMode(): BackendMode {
-  return isExperimentalLocalBackendEnabled() ? "local" : "api";
-}
-
-function getPinnedAgentIdsForBackendMode(backendMode: BackendMode): string[] {
-  const previousBackendMode = getCurrentBackendMode();
-  configureBackendMode(backendMode);
-  try {
-    return settingsManager
-      .getPinnedAgents()
-      .filter((id) => isAgentIdCompatibleWithBackend(id, backendMode));
-  } finally {
-    configureBackendMode(previousBackendMode);
-  }
-}
-
 async function findLocalAgentsByName(name: string): Promise<AgentState[]> {
   const backend = getBackendForMode("local");
   const normalizedName = name.toLowerCase();
@@ -429,7 +413,8 @@ async function resolveAgentByName(
 
   for (const backendMode of backendLookupOrder) {
     const backend = getBackendForMode(backendMode);
-    const pinnedAgents = getPinnedAgentIdsForBackendMode(backendMode);
+    const pinnedAgents =
+      settingsManager.getPinnedAgentsForBackendMode(backendMode);
 
     const matches: Array<{
       id: string;
@@ -496,7 +481,8 @@ async function getPinnedAgentNames(
   const agents: { id: string; name: string }[] = [];
   for (const backendMode of backendLookupOrder) {
     const backend = getBackendForMode(backendMode);
-    const pinnedAgents = getPinnedAgentIdsForBackendMode(backendMode);
+    const pinnedAgents =
+      settingsManager.getPinnedAgentsForBackendMode(backendMode);
 
     await Promise.all(
       pinnedAgents.map(async (id) => {
@@ -1924,11 +1910,8 @@ async function main(): Promise<void> {
           process.cwd(),
         );
         const rawGlobalAgentId = settingsManager.getGlobalLastAgentId();
-        const pinnedAgentIds = settingsManager
-          .getPinnedAgents()
-          .filter((agentId) =>
-            isAgentIdCompatibleWithBackend(agentId, startupBackendMode),
-          );
+        const pinnedAgentIds =
+          settingsManager.getPinnedAgentsForBackendMode(startupBackendMode);
         const pinnedAgentId =
           pinnedAgentIds.length === 1 ? (pinnedAgentIds[0] ?? null) : null;
         const localAgentId =

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents"
 import type { Message } from "@letta-ai/letta-client/resources/agents/messages";
 import { getTerminalTelemetrySurface, telemetry } from "@/telemetry";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
-import { isAgentIdCompatibleWithBackend } from "./agent/agent-id";
 import {
   getResumeDataFromBackend,
   type ResumeData,
@@ -1841,16 +1840,12 @@ async function main(): Promise<void> {
           const globalSession = settingsManager.getGlobalLastSession();
           const globalAgentId = globalSession?.agentId;
 
+          // Both LRU getters already filter by the active server key (which
+          // encodes the backend mode), so no extra compatibility check is
+          // needed here.
           const preferredResumeAgentId =
-            startupBackendMode === "local"
-              ? localAgentId &&
-                isAgentIdCompatibleWithBackend(localAgentId, "local")
-                ? localAgentId
-                : null
-              : globalAgentId &&
-                  isAgentIdCompatibleWithBackend(globalAgentId, "api")
-                ? globalAgentId
-                : null;
+            (startupBackendMode === "local" ? localAgentId : globalAgentId) ??
+            null;
 
           if (preferredResumeAgentId) {
             try {
@@ -1915,17 +1910,9 @@ async function main(): Promise<void> {
         const pinnedAgentId =
           pinnedAgentIds.length === 1 ? (pinnedAgentIds[0] ?? null) : null;
         const localAgentId =
-          startupBackendMode === "local" &&
-          rawLocalAgentId &&
-          isAgentIdCompatibleWithBackend(rawLocalAgentId, "local")
-            ? rawLocalAgentId
-            : null;
+          startupBackendMode === "local" ? rawLocalAgentId : null;
         const globalAgentId =
-          startupBackendMode === "api" &&
-          rawGlobalAgentId &&
-          isAgentIdCompatibleWithBackend(rawGlobalAgentId, "api")
-            ? rawGlobalAgentId
-            : null;
+          startupBackendMode === "api" ? rawGlobalAgentId : null;
 
         // Fetch pin + LRU agents in parallel, de-duping shared IDs.
         const agentIdsToValidate = [
@@ -2144,10 +2131,7 @@ async function main(): Promise<void> {
             startupBackendMode === "local"
               ? settingsManager.getLocalLastAgentId()
               : settingsManager.getGlobalLastAgentId();
-          if (
-            recentAgentId &&
-            isAgentIdCompatibleWithBackend(recentAgentId, startupBackendMode)
-          ) {
+          if (recentAgentId) {
             try {
               await backend.retrieveAgent(recentAgentId);
               resumingAgentId = recentAgentId;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1907,17 +1907,18 @@ async function main(): Promise<void> {
         const rawGlobalAgentId = settingsManager.getGlobalLastAgentId();
         const pinnedAgentIds =
           settingsManager.getPinnedAgentsForBackendMode(startupBackendMode);
-        const pinnedAgentId =
-          pinnedAgentIds.length === 1 ? (pinnedAgentIds[0] ?? null) : null;
         const localAgentId =
           startupBackendMode === "local" ? rawLocalAgentId : null;
         const globalAgentId =
           startupBackendMode === "api" ? rawGlobalAgentId : null;
 
-        // Fetch pin + LRU agents in parallel, de-duping shared IDs.
+        // Validate every pinned agent (not just a lone one) alongside the LRU
+        // agents, de-duping shared IDs. Validating all pins lets the decision
+        // below count only pins that exist in the active org, so stale or
+        // cross-org pins don't inflate the count and force the selector.
         const agentIdsToValidate = [
           ...new Set(
-            [pinnedAgentId, localAgentId, globalAgentId].filter(
+            [...pinnedAgentIds, localAgentId, globalAgentId].filter(
               (agentId): agentId is string => Boolean(agentId),
             ),
           ),
@@ -1937,9 +1938,17 @@ async function main(): Promise<void> {
           }
         }
 
-        const pinnedAgentExists = pinnedAgentId
-          ? cachedAgents.has(pinnedAgentId)
-          : false;
+        // Base the pinned-agent decision on pins that actually exist in the
+        // active org: a single existing pin resumes directly, while stale or
+        // cross-org pins are ignored instead of forcing the selector.
+        const existingPinnedIds = pinnedAgentIds.filter((id) =>
+          cachedAgents.has(id),
+        );
+        const pinnedAgentId =
+          existingPinnedIds.length === 1
+            ? (existingPinnedIds[0] ?? null)
+            : null;
+        const pinnedAgentExists = pinnedAgentId !== null;
         let localAgentExists = false;
         let globalAgentExists = false;
         if (localAgentId) {
@@ -1955,8 +1964,12 @@ async function main(): Promise<void> {
         }
         markMilestone("STARTUP_LRU_FETCH_DONE");
 
-        // Step 3: Resolve startup target using pure decision logic
+        // Step 3: Resolve startup target using pure decision logic.
+        // pinnedCount is the raw configured count (drives the "any pins → show
+        // the selector" fallback); existingPinnedCount counts pins that resolve
+        // in the active org (drives single-resume / multi-pin select).
         const pinnedCount = pinnedAgentIds.length;
+        const existingPinnedCount = existingPinnedIds.length;
         const fallbackSession =
           startupBackendMode === "local" &&
           !localAgentExists &&
@@ -1971,6 +1984,7 @@ async function main(): Promise<void> {
           pinnedAgentId,
           pinnedAgentExists,
           pinnedCount,
+          existingPinnedCount,
           localAgentId,
           localConversationId: localSession?.conversationId ?? null,
           localAgentExists,

--- a/src/settings-manager.test.ts
+++ b/src/settings-manager.test.ts
@@ -1264,6 +1264,103 @@ describe("Settings Manager - Agents Array Migration", () => {
   });
 });
 
+describe("Settings Manager - Pinned Agents", () => {
+  test("getPinnedAgents excludes a local-backend agent id from a cloud session", async () => {
+    await settingsManager.initialize();
+
+    // Both pins land in the cloud bucket (no baseUrl), but the local-style id
+    // is incompatible with the cloud server key and must be filtered out.
+    settingsManager.updateSettings({
+      agents: [
+        { agentId: "agent-cloud-1", pinned: true },
+        { agentId: "agent-local-stray", pinned: true },
+      ],
+    });
+
+    expect(settingsManager.getPinnedAgents()).toEqual(["agent-cloud-1"]);
+  });
+
+  test("getPinnedAgents excludes a cloud agent id from a local-backend session", async () => {
+    await settingsManager.initialize();
+
+    const storageDir = join(testHomeDir, "lc-local-backend");
+    const localKey = `local:${resolve(storageDir)}`;
+    process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL = "1";
+    process.env.LETTA_LOCAL_BACKEND_DIR = storageDir;
+
+    // Both pins land in the local bucket (baseUrl === localKey), but the
+    // cloud-style id is incompatible with the local server key.
+    settingsManager.updateSettings({
+      agents: [
+        { agentId: "agent-local-1", baseUrl: localKey, pinned: true },
+        { agentId: "agent-cloud-stray", baseUrl: localKey, pinned: true },
+      ],
+    });
+
+    expect(settingsManager.getPinnedAgents()).toEqual(["agent-local-1"]);
+  });
+
+  test("getPinnedAgentsForBackendMode returns the other mode's pins from a cloud session", async () => {
+    await settingsManager.initialize();
+
+    const storageDir = join(testHomeDir, "lc-local-backend");
+    const localKey = `local:${resolve(storageDir)}`;
+    // Make the local server key deterministic without switching the active
+    // session into local mode.
+    process.env.LETTA_LOCAL_BACKEND_DIR = storageDir;
+
+    settingsManager.updateSettings({
+      agents: [
+        { agentId: "agent-cloud-1", pinned: true },
+        { agentId: "agent-local-1", baseUrl: localKey, pinned: true },
+      ],
+    });
+
+    // Active session is cloud.
+    expect(settingsManager.getPinnedAgents()).toEqual(["agent-cloud-1"]);
+    // ...but we can still look up the local pins by mode (the old
+    // configureBackendMode dance returned [] here).
+    expect(settingsManager.getPinnedAgentsForBackendMode("local")).toEqual([
+      "agent-local-1",
+    ]);
+    expect(settingsManager.getPinnedAgentsForBackendMode("api")).toEqual([
+      "agent-cloud-1",
+    ]);
+  });
+
+  test("getPinnedAgentsForBackendMode('api') is scoped to the configured base URL", async () => {
+    await settingsManager.initialize();
+
+    const originalBaseUrl = process.env.LETTA_BASE_URL;
+    process.env.LETTA_BASE_URL = "https://selfhost.example.com";
+
+    try {
+      settingsManager.updateSettings({
+        agents: [
+          { agentId: "agent-cloud-1", pinned: true },
+          {
+            agentId: "agent-selfhost-1",
+            baseUrl: "selfhost.example.com",
+            pinned: true,
+          },
+        ],
+      });
+
+      // Only the pin for the active self-hosted server is returned; the
+      // api.letta.com pin belongs to a different server bucket.
+      expect(settingsManager.getPinnedAgentsForBackendMode("api")).toEqual([
+        "agent-selfhost-1",
+      ]);
+    } finally {
+      if (originalBaseUrl === undefined) {
+        delete process.env.LETTA_BASE_URL;
+      } else {
+        process.env.LETTA_BASE_URL = originalBaseUrl;
+      }
+    }
+  });
+});
+
 describe("Settings Manager - Toolset Preferences", () => {
   test("getToolsetPreference defaults to auto", async () => {
     await settingsManager.initialize();

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -5,7 +5,11 @@ import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
-import { isCloudAgentId, isLocalAgentId } from "./agent/agent-id";
+import {
+  type AgentBackendMode,
+  isAgentIdCompatibleWithBackend,
+  isCloudAgentId,
+} from "./agent/agent-id";
 import {
   getLocalBackendStorageDir,
   isLocalBackendEnvEnabled,
@@ -250,9 +254,12 @@ function isAgentIdCompatibleWithServerKey(
   agentId: string,
   serverKey: string,
 ): boolean {
-  return isLocalServerKey(serverKey)
-    ? isLocalAgentId(agentId)
-    : isCloudAgentId(agentId);
+  // A server key encodes the backend mode via its "local:" prefix, so
+  // serverKey compatibility is just backend compatibility for that mode.
+  return isAgentIdCompatibleWithBackend(
+    agentId,
+    isLocalServerKey(serverKey) ? "local" : "api",
+  );
 }
 
 function isSessionCompatibleWithServerKey(
@@ -285,11 +292,7 @@ function shouldSkipLegacyLocalBackendSessionFallback(): boolean {
  * @param settings - Optional settings object to check for env overrides
  * @returns Normalized server key (e.g., "api.letta.com", "localhost:8283", "local:/path/to/store")
  */
-function getCurrentServerKey(settings?: Settings | null): string {
-  if (isLocalBackendEnvEnabled()) {
-    return getLocalBackendSettingsKey();
-  }
-
+function getApiServerKey(settings?: Settings | null): string {
   const baseUrl =
     process.env[SETTINGS_BASE_URL_ENV] ||
     settings?.env?.[SETTINGS_BASE_URL_ENV] ||
@@ -297,6 +300,27 @@ function getCurrentServerKey(settings?: Settings | null): string {
     settings?.env?.LETTA_BASE_URL ||
     DEFAULT_LETTA_API_URL;
   return normalizeBaseUrl(baseUrl);
+}
+
+function getCurrentServerKey(settings?: Settings | null): string {
+  if (isLocalBackendEnvEnabled()) {
+    return getLocalBackendSettingsKey();
+  }
+  return getApiServerKey(settings);
+}
+
+/**
+ * Resolve the server key for a specific backend mode, independent of the
+ * currently-active backend. "local" always maps to the local backend store;
+ * "api" maps to the configured cloud/self-hosted base URL.
+ */
+function serverKeyForBackendMode(
+  mode: AgentBackendMode,
+  settings?: Settings | null,
+): string {
+  return mode === "local"
+    ? getLocalBackendSettingsKey()
+    : getApiServerKey(settings);
 }
 
 /**
@@ -1647,18 +1671,42 @@ class SettingsManager {
   // =====================================================================
 
   /**
-   * Get pinned agent IDs for the current server from the global agents array.
+   * Get pinned agent IDs for the currently-active server.
    */
   getPinnedAgents(): string[] {
+    return this.getPinnedAgentsForServerKey(
+      getCurrentServerKey(this.getSettings()),
+    );
+  }
+
+  /**
+   * Get pinned agent IDs scoped to a specific backend mode, independent of the
+   * currently-active backend. Used to look up pins across modes (e.g. --name).
+   */
+  getPinnedAgentsForBackendMode(mode: AgentBackendMode): string[] {
+    return this.getPinnedAgentsForServerKey(
+      serverKeyForBackendMode(mode, this.getSettings()),
+    );
+  }
+
+  /**
+   * Get pinned agent IDs for an explicit server key. The server key both
+   * namespaces by server (baseUrl) and encodes the backend mode (the "local:"
+   * prefix), so agent-id/backend compatibility is derived from it directly —
+   * no separate backend-mode argument is needed.
+   */
+  getPinnedAgentsForServerKey(serverKey: string): string[] {
     const settings = this.getSettings();
-    const serverKey = getCurrentServerKey(settings);
     const normalizedBaseUrl =
       serverKey === "api.letta.com" ? undefined : serverKey;
 
     return (
       settings.agents
         ?.filter(
-          (a) => a.pinned && (a.baseUrl ?? undefined) === normalizedBaseUrl,
+          (a) =>
+            a.pinned &&
+            (a.baseUrl ?? undefined) === normalizedBaseUrl &&
+            isAgentIdCompatibleWithServerKey(a.agentId, serverKey),
         )
         .map((a) => a.agentId) ?? []
     );


### PR DESCRIPTION
Pinned-agent selection was scoped inconsistently and dragged along redundant backend-mode plumbing. This makes pins resolve like every other settings lookup, drops the machinery that worked around the old approach, and — on that cleaner base — fixes a startup papercut where stale or cross-org pins forced the agent selector instead of resuming.

## The bug it fixes

Pins are keyed by base URL only, with no org dimension. Letta Cloud serves every org from `api.letta.com`, so pins from all your orgs share one bucket — and agents pinned in another org (or since deleted) don't resolve in the active org yet still counted toward "how many pins do I have." So `multiple pins → select` fired even when only one pin was actually usable, dropping you into the welcome menu instead of resuming. Seen in the wild: 3 cloud pins, 2 from other orgs → the menu on every `letta` and `letta --new`.

Startup now validates every pin and decides on the ones that exist in the active org:

- one existing pin → resume it (even with dead pins alongside)
- multiple existing pins → select (genuinely ambiguous)
- only stale pins, but a valid last-used agent → resume that instead of the selector

A new `existingPinnedCount` drives those branches; the raw `pinnedCount` still drives the "any pins configured → show the selector" fallback, so an all-stale-and-no-LRU session opens the selector rather than silently creating a default agent. Stale pins are left in settings — a 404 in one org may be a live agent in another.

## The refactor underneath it

- **Pins scope off the server key.** `getPinnedAgents` derives local-vs-cloud from the server key it already buckets by — the `local:` prefix encodes the mode — matching how sessions and LRU resolve, instead of a second `isAgentIdCompatibleWithBackend` filter on a divergent input. Adds `getPinnedAgentsForServerKey` / `getPinnedAgentsForBackendMode`.
- **Removes the plumbing that replaced:** the `configureBackendMode` save/restore dance (`getPinnedAgentIdsForBackendMode`), the unused `getCurrentBackendMode`, five dead `isAgentIdCompatibleWithBackend` re-checks in the startup path, and the duplicated `isAgentIdCompatibleWithServerKey` branch (now delegates to its twin so they can't drift).
- **Extracts backend-mode state** (`configuredBackendMode`, `resolveBackendMode`) out of the 540-line `backend.ts` into a `backend-mode.ts` leaf; `backend.ts` re-exports `BackendMode` and `isExperimentalLocalBackendEnabled`, so consumers via the `@/backend` barrel are unchanged.

## Deliberately out of scope

- Settings namespacing stays on the env predicate (`isLocalBackendEnvEnabled`), not the resolved mode — routing it through `resolveBackendMode` couples settings to a mutable global that leaks across test files (a startup-fallback test fails only in the shared-worker suite). Documented in the leaf header.
- Org-scoping the pin namespace — the real root cause — is a larger storage/migration change left for later. Stale pins are not auto-pruned for the same cross-org reason.

## Tests

Server-key pin filtering (both fold-in directions, cross-mode + base-URL scoping); startup resolution for one-of-many-exists → resume, all-stale + LRU → resume LRU, and multiple-existing → select. `bun run check` passes 9/9; full unit suite 4638 pass / 0 fail.