### PR TITLE
feat(desktop): emit turn_end mod event from the listener

### DIFF
--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -1504,6 +1504,22 @@ export function toLines(b: Buffers): Line[] {
   return out;
 }
 
+/** Returns the text of the most recent non-empty assistant line, if any. */
+export function findLastAssistantText(lines: Line[]): string | undefined {
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i];
+    if (
+      line?.kind === "assistant" &&
+      "text" in line &&
+      typeof line.text === "string" &&
+      line.text.trim().length > 0
+    ) {
+      return line.text;
+    }
+  }
+  return undefined;
+}
+
 /**
  * Set tool calls to "running" phase before execution.
  * This updates the UI to show the formatted args instead of ellipsis.

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -71,6 +71,7 @@ import {
 } from "./cli/flag-utils";
 import {
   createBuffers,
+  findLastAssistantText,
   type Line,
   markIncompleteToolsAsCancelled,
   toLines,
@@ -459,21 +460,6 @@ async function emitHeadlessTurnStart(options: {
     // Mod turn_start handlers should not block sending the turn.
     return options.input;
   }
-}
-
-function findLastAssistantText(lines: Line[]): string | undefined {
-  for (let i = lines.length - 1; i >= 0; i -= 1) {
-    const line = lines[i];
-    if (
-      line?.kind === "assistant" &&
-      "text" in line &&
-      typeof line.text === "string" &&
-      line.text.trim().length > 0
-    ) {
-      return line.text;
-    }
-  }
-  return undefined;
 }
 
 async function emitHeadlessTurnEnd(options: {

--- a/src/websocket/listener/mod-adapter.test.ts
+++ b/src/websocket/listener/mod-adapter.test.ts
@@ -425,6 +425,55 @@ describe("listener mod adapter", () => {
     adapter.dispose();
   });
 
+  test("turn_end handlers receive stop reason and assistant message", async () => {
+    const root = createTempDir();
+    const modsDir = join(root, "mods");
+    const cacheDir = join(root, "cache");
+    mkdirSync(modsDir, { recursive: true });
+    writeFileSync(
+      join(modsDir, "turn-end-mod.ts"),
+      `export default function activate(letta) {
+        letta.events.on("turn_end", (event) => {
+          globalThis.__lettaTurnEndSeen = {
+            stopReason: event.stopReason,
+            assistantMessage: event.assistantMessage,
+          };
+        });
+      }`,
+    );
+
+    const adapter = createListenerModAdapter({
+      cacheDirectory: cacheDir,
+      globalModsDirectory: modsDir,
+      sessionId: "turn-end-test",
+      workingDirectory: root,
+    });
+    await adapter.reload();
+
+    const context = createListenerModContext({
+      sessionId: "conv-turn-end-test",
+      workingDirectory: root,
+    });
+    const event = {
+      agentId: "agent-turn-end",
+      conversationId: "conv-turn-end-test",
+      stopReason: "end_turn",
+      assistantMessage: "all done",
+    };
+
+    const result = await adapter.events.emit("turn_end", event, context);
+    expect(result.diagnostics).toHaveLength(0);
+    expect(
+      (globalThis as { __lettaTurnEndSeen?: unknown }).__lettaTurnEndSeen,
+    ).toEqual({
+      stopReason: "end_turn",
+      assistantMessage: "all done",
+    });
+
+    delete (globalThis as { __lettaTurnEndSeen?: unknown }).__lettaTurnEndSeen;
+    adapter.dispose();
+  });
+
   test("mod tools with isEnabled are isolated across listener scopes", async () => {
     __testSetBackend(
       new FakeHeadlessBackend(

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -32,6 +32,7 @@ import { getBackend } from "@/backend";
 import {
   type Buffers,
   createBuffers,
+  findLastAssistantText,
   type Line,
   toLines,
 } from "@/cli/helpers/accumulator";
@@ -250,6 +251,36 @@ async function emitListenerTurnStart(options: {
   } catch {
     // Mod turn_start handlers should not block sending the turn.
     return options.input;
+  }
+}
+
+async function emitListenerTurnEnd(options: {
+  agentId: string;
+  conversationId: string;
+  stopReason: string;
+  assistantMessage?: string;
+  runtime: ListenerRuntime;
+  workingDirectory: string;
+  permissionMode?: string | null;
+  cachedAgent?: AgentState | null;
+}): Promise<void> {
+  try {
+    const modAdapter = ensureListenerModAdapter(options.runtime);
+    const context = createListenerModContext({
+      sessionId: options.conversationId,
+      workingDirectory: options.workingDirectory,
+      permissionMode: options.permissionMode ?? null,
+      agent: options.cachedAgent ?? null,
+    });
+    const event = {
+      agentId: options.agentId,
+      conversationId: options.conversationId,
+      stopReason: options.stopReason,
+      assistantMessage: options.assistantMessage,
+    };
+    await modAdapter.events.emit("turn_end", event, context);
+  } catch {
+    // Mod turn_end handlers should not block turn completion.
   }
 }
 
@@ -808,6 +839,16 @@ export async function handleIncomingMessage(
       }
 
       if (stopReason === "end_turn") {
+        await emitListenerTurnEnd({
+          agentId,
+          conversationId,
+          stopReason,
+          assistantMessage: findLastAssistantText(toLines(buffers)),
+          runtime: runtime.listener,
+          workingDirectory: turnWorkingDirectory,
+          permissionMode: turnPermissionModeState.mode,
+          cachedAgent,
+        });
         try {
           const transcriptLines = toLines(buffers);
           if (transcriptLines.length > 0) {


### PR DESCRIPTION
## Summary
- Emits the `turn_end` mod event from the listener (desktop/channel turns) when a turn reaches `end_turn`, completing event parity with TUI (#3077) and headless (#3080).
- **Emission only.** Handlers receive `{ stopReason, assistantMessage }`. The `continue` effect is intentionally left for a focused follow-up — in the listener it requires synthetic-turn injection through the queue, which is a separate concern.
- Mirrors the existing `emitListenerTurnStart` helper. Fires only on a clean `end_turn`, never on a cancelled turn (the `cancelRequested` branch breaks first).
- Hoists `findLastAssistantText` into `cli/helpers/accumulator` (next to `Line`/`toLines`) so the listener and headless share one implementation instead of duplicating it.

## Repo scope
Entirely letta-code. `turn_end` is delivered to mods running inside the listener process — it never crosses the WebSocket, so there are **no letta-cloud (desktop client) changes**.

## Test plan
- [x] `tsc --noEmit` clean
- [x] biome clean (one pre-existing warning at accumulator.ts:1093, untouched)
- [x] new listener test: `turn_end handlers receive stop reason and assistant message`
- [x] `mod-adapter.test.ts` 10 pass, `mod-engine.test.ts` 31 pass (dedup intact)

👾 Generated with [Letta Code](https://letta.com)