### PR TITLE
feat(startup): resume a single existing pin, ignore stale/cross-org pins

### DIFF
--- a/src/agent/resolve-startup-agent-files.test.ts
+++ b/src/agent/resolve-startup-agent-files.test.ts
@@ -46,18 +46,21 @@ async function resolveFromSettings(options?: {
   const localSession = settingsManager.getLocalLastSession(testProjectDir);
   const globalAgentId = settingsManager.getGlobalLastAgentId();
   const pinnedAgents = settingsManager.getPinnedAgents();
+  const existingPinnedIds = pinnedAgents.filter((id) => existing.has(id));
   const pinnedAgentId =
-    pinnedAgents.length === 1 ? (pinnedAgents[0] ?? null) : null;
+    existingPinnedIds.length === 1 ? (existingPinnedIds[0] ?? null) : null;
 
-  const pinnedAgentExists = pinnedAgentId ? existing.has(pinnedAgentId) : false;
+  const pinnedAgentExists = pinnedAgentId !== null;
   const localAgentExists = localAgentId ? existing.has(localAgentId) : false;
   const globalAgentExists = globalAgentId ? existing.has(globalAgentId) : false;
   const pinnedCount = pinnedAgents.length;
+  const existingPinnedCount = existingPinnedIds.length;
 
   return resolveStartupTarget({
     pinnedAgentId,
     pinnedAgentExists,
     pinnedCount,
+    existingPinnedCount,
     localAgentId,
     localConversationId: options?.includeLocalConversation
       ? (localSession?.conversationId ?? null)
@@ -286,6 +289,52 @@ describe("startup resolution from settings files", () => {
 
     const target = await resolveFromSettings();
     expect(target).toEqual({ action: "select" });
+  });
+
+  test("multiple pins but only one exists in org => resume the existing pin", async () => {
+    await writeGlobalSettings({
+      agents: [
+        { agentId: "agent-pinned-live", pinned: true },
+        { agentId: "agent-pinned-stale-1", pinned: true },
+        { agentId: "agent-pinned-stale-2", pinned: true },
+      ],
+    });
+
+    // Two pins belong to other orgs / were deleted and don't resolve here.
+    const target = await resolveFromSettings({
+      existingAgentIds: ["agent-pinned-live"],
+    });
+
+    expect(target).toEqual({
+      action: "resume",
+      agentId: "agent-pinned-live",
+    });
+  });
+
+  test("multiple stale pins + valid global LRU => resume LRU, not select", async () => {
+    await writeGlobalSettings({
+      sessionsByServer: {
+        "api.letta.com": {
+          agentId: "agent-global",
+          conversationId: "conv-global",
+        },
+      },
+      agents: [
+        { agentId: "agent-pinned-stale-1", pinned: true },
+        { agentId: "agent-pinned-stale-2", pinned: true },
+      ],
+    });
+
+    // Neither pin resolves in this org, so the LRU should win instead of the
+    // selector firing on a raw pin count.
+    const target = await resolveFromSettings({
+      existingAgentIds: ["agent-global"],
+    });
+
+    expect(target).toEqual({
+      action: "resume",
+      agentId: "agent-global",
+    });
   });
 
   test("no valid sessions + no pinned + needsModelPicker => select", async () => {

--- a/src/agent/resolve-startup-agent.test.ts
+++ b/src/agent/resolve-startup-agent.test.ts
@@ -18,6 +18,7 @@ function makeInput(
     pinnedAgentId: null,
     pinnedAgentExists: false,
     pinnedCount: 0,
+    existingPinnedCount: 0,
     localAgentId: null,
     localConversationId: null,
     localAgentExists: false,
@@ -119,16 +120,49 @@ describe("resolveStartupTarget", () => {
     });
   });
 
-  test("multiple pinned agents open selector before stale local LRU", () => {
+  test("multiple existing pinned agents open selector before stale local LRU", () => {
     const result = resolveStartupTarget(
       makeInput({
         pinnedCount: 2,
+        existingPinnedCount: 2,
         localAgentId: "agent-last-used-456",
         localConversationId: "conv-stale-789",
         localAgentExists: true,
       }),
     );
     expect(result).toEqual({ action: "select" });
+  });
+
+  test("multiple pins but only one exists → resume that pin (stale pins ignored)", () => {
+    const result = resolveStartupTarget(
+      makeInput({
+        pinnedAgentId: "agent-pinned-live",
+        pinnedAgentExists: true,
+        pinnedCount: 3,
+        existingPinnedCount: 1,
+        localAgentId: "agent-last-used-456",
+        localAgentExists: true,
+      }),
+    );
+    expect(result).toEqual({
+      action: "resume",
+      agentId: "agent-pinned-live",
+    });
+  });
+
+  test("multiple stale pins + valid global LRU → resume LRU, not select", () => {
+    const result = resolveStartupTarget(
+      makeInput({
+        pinnedCount: 2,
+        existingPinnedCount: 0,
+        globalAgentId: "agent-global-123",
+        globalAgentExists: true,
+      }),
+    );
+    expect(result).toEqual({
+      action: "resume",
+      agentId: "agent-global-123",
+    });
   });
 
   test("dir with local LRU + invalid agent + valid global → resumes global (no conv)", () => {

--- a/src/agent/resolve-startup-agent.ts
+++ b/src/agent/resolve-startup-agent.ts
@@ -14,12 +14,16 @@ export type StartupTarget =
   | { action: "create" };
 
 export interface StartupResolutionInput {
-  /** Agent ID from pinned agents (global, per-backend namespace) */
+  /** The pinned agent to resume when exactly one pin exists for the active org */
   pinnedAgentId: string | null;
   /** Whether the pinned agent still exists on the server */
   pinnedAgentExists: boolean;
-  /** Number of pinned agents for the active backend */
+  /** Number of pinned agents configured for the active backend, including stale
+   * or cross-org pins that no longer resolve (drives the selector fallback) */
   pinnedCount: number;
+  /** Number of pinned agents that actually exist in the active org (drives the
+   * single-resume and multi-pin select decisions) */
+  existingPinnedCount: number;
 
   /** Agent ID from local project LRU (via getLocalLastAgentId) */
   localAgentId: string | null;
@@ -49,13 +53,13 @@ export interface StartupResolutionInput {
  *
  * Decision tree:
  * 1. forceNew → create
- * 2. pinned valid → resume (with local conversation only if it matches LRU)
- * 3. multiple pins → select
+ * 2. single existing pin → resume (with local conversation only if it matches LRU)
+ * 3. multiple existing pins → select
  * 4. local LRU valid → resume (with local conversation)
  * 5. global LRU valid → resume (no conversation — project-scoped)
  * 6. backend-store fallback → resume
  * 7. needsModelPicker → select
- * 8. pinned agents exist → select
+ * 8. pins configured (even if stale) → select
  * 9. nothing → create
  */
 export function resolveStartupTarget(
@@ -79,8 +83,9 @@ export function resolveStartupTarget(
     };
   }
 
-  // Step 2: Multiple pins should ask instead of picking implicitly.
-  if (input.pinnedCount > 1) {
+  // Step 2: Multiple existing pins should ask instead of picking implicitly.
+  // (Stale/cross-org pins are excluded — see existingPinnedCount.)
+  if (input.existingPinnedCount > 1) {
     return { action: "select" };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1907,17 +1907,18 @@ async function main(): Promise<void> {
         const rawGlobalAgentId = settingsManager.getGlobalLastAgentId();
         const pinnedAgentIds =
           settingsManager.getPinnedAgentsForBackendMode(startupBackendMode);
-        const pinnedAgentId =
-          pinnedAgentIds.length === 1 ? (pinnedAgentIds[0] ?? null) : null;
         const localAgentId =
           startupBackendMode === "local" ? rawLocalAgentId : null;
         const globalAgentId =
           startupBackendMode === "api" ? rawGlobalAgentId : null;
 
-        // Fetch pin + LRU agents in parallel, de-duping shared IDs.
+        // Validate every pinned agent (not just a lone one) alongside the LRU
+        // agents, de-duping shared IDs. Validating all pins lets the decision
+        // below count only pins that exist in the active org, so stale or
+        // cross-org pins don't inflate the count and force the selector.
         const agentIdsToValidate = [
           ...new Set(
-            [pinnedAgentId, localAgentId, globalAgentId].filter(
+            [...pinnedAgentIds, localAgentId, globalAgentId].filter(
               (agentId): agentId is string => Boolean(agentId),
             ),
           ),
@@ -1937,9 +1938,17 @@ async function main(): Promise<void> {
           }
         }
 
-        const pinnedAgentExists = pinnedAgentId
-          ? cachedAgents.has(pinnedAgentId)
-          : false;
+        // Base the pinned-agent decision on pins that actually exist in the
+        // active org: a single existing pin resumes directly, while stale or
+        // cross-org pins are ignored instead of forcing the selector.
+        const existingPinnedIds = pinnedAgentIds.filter((id) =>
+          cachedAgents.has(id),
+        );
+        const pinnedAgentId =
+          existingPinnedIds.length === 1
+            ? (existingPinnedIds[0] ?? null)
+            : null;
+        const pinnedAgentExists = pinnedAgentId !== null;
         let localAgentExists = false;
         let globalAgentExists = false;
         if (localAgentId) {
@@ -1955,8 +1964,12 @@ async function main(): Promise<void> {
         }
         markMilestone("STARTUP_LRU_FETCH_DONE");
 
-        // Step 3: Resolve startup target using pure decision logic
+        // Step 3: Resolve startup target using pure decision logic.
+        // pinnedCount is the raw configured count (drives the "any pins → show
+        // the selector" fallback); existingPinnedCount counts pins that resolve
+        // in the active org (drives single-resume / multi-pin select).
         const pinnedCount = pinnedAgentIds.length;
+        const existingPinnedCount = existingPinnedIds.length;
         const fallbackSession =
           startupBackendMode === "local" &&
           !localAgentExists &&
@@ -1971,6 +1984,7 @@ async function main(): Promise<void> {
           pinnedAgentId,
           pinnedAgentExists,
           pinnedCount,
+          existingPinnedCount,
           localAgentId,
           localConversationId: localSession?.conversationId ?? null,
           localAgentExists,


### PR DESCRIPTION
## Problem

Pins are namespaced by **base URL only** — no org/project dimension. Letta Cloud serves every org from `api.letta.com`, so all your pins pile into one bucket. Agents pinned in another org (or since deleted) don't resolve in the active org, but they still inflated the **raw** pin count — so `pinnedCount > 1 → select` fired and you got the selector even when only one pin was actually usable, never reaching LRU/auto-resume.

Real example: a user with 3 cloud pins where 2 were from other orgs got the welcome menu on every `letta` / `letta --new`, instead of resuming their one live agent (which was also their LRU).

## Fix

Startup (`main()` in `index.ts`) now validates **every** pinned agent and bases the resume/multi-select decision on the pins that **exist in the active org**:

- **exactly one existing pin → resume it** (even if other, dead pins are present) ← the reported case
- **multiple existing pins → select** (genuinely ambiguous)
- **only stale pins but a valid LRU → resume the LRU** instead of the selector

`resolveStartupTarget` gets a new `existingPinnedCount` input that drives the single-resume / multi-pin-select branches, while the existing `pinnedCount` (raw configured count) keeps driving the **"any pins configured → show the selector"** fallback. So an all-stale-pins-**and**-no-LRU session still opens the selector rather than silently creating a default agent.

Stale pins are **not pruned** from settings — a 404 in one org may be a live agent in another.

## Scope / notes

- Touches only the TUI startup path (`resolveStartupTarget` is called only there).
- Cost: validates all pins in parallel at startup instead of ≤1; fine for normal pin counts.
- The deeper root fix (org-scoping the pin namespace) is intentionally out of scope — bigger storage/migration change.

## Tests
- `resolve-startup-agent.test.ts`: multiple-pins-one-exists → resume; multiple-stale-pins + LRU → resume LRU; multiple **existing** pins → select.
- `resolve-startup-agent-files.test.ts`: end-to-end equivalents through real settings; existing stale-pins-only → select cases still pass unchanged.
- Full suite: 4638 pass / 0 fail; `bun run check` 9/9.

## Stacking
Based on `simplify-pin-backend-scoping` (#3081) — uses `getPinnedAgentsForBackendMode` from that PR. Retarget to `main` once #3081 merges.