### PR TITLE
feat(headless): emit local tool calls and returns in stream-json

### DIFF
--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -108,7 +108,6 @@ interface ExecutionState {
     stepCount?: number;
   } | null;
   displayedToolCalls: Set<string>;
-  pendingToolCalls: Map<string, { name: string; args: string }>;
 }
 
 // ============================================================================
@@ -384,11 +383,22 @@ function handleInitEvent(
 }
 
 /**
- * Handle an approval request message event
+ * Handle a tool_call_message event. The subagent runs headless with
+ * --output-format stream-json and emits a tool_call_message (with complete
+ * arguments) for every tool it calls — both server-side tools and locally
+ * executed ones. Record each so the subagent's tool-call list stays in sync.
  */
-function handleApprovalRequestEvent(
-  event: { tool_calls?: unknown[]; tool_call?: unknown },
+function handleToolCallEvent(
+  event: {
+    tool_call?: { tool_call_id?: string; name?: string; arguments?: string };
+    tool_calls?: Array<{
+      tool_call_id?: string;
+      name?: string;
+      arguments?: string;
+    }>;
+  },
   state: ExecutionState,
+  subagentId: string,
 ): void {
   const toolCalls = Array.isArray(event.tool_calls)
     ? event.tool_calls
@@ -396,43 +406,17 @@ function handleApprovalRequestEvent(
       ? [event.tool_call]
       : [];
 
-  for (const toolCall of toolCalls) {
-    const tc = toolCall as {
-      tool_call_id?: string;
-      name?: string;
-      arguments?: string;
-    };
-    const id = tc.tool_call_id;
-    if (!id) continue;
-
-    const prev = state.pendingToolCalls.get(id) || { name: "", args: "" };
-    const name = tc.name || prev.name;
-    const args = prev.args + (tc.arguments || "");
-    state.pendingToolCalls.set(id, { name, args });
-  }
-}
-
-/**
- * Handle an auto_approval event
- */
-function handleAutoApprovalEvent(
-  event: {
-    tool_call?: { tool_call_id?: string; name?: string; arguments?: string };
-  },
-  state: ExecutionState,
-  subagentId: string,
-): void {
-  const tc = event.tool_call;
-  if (!tc) return;
-  const { tool_call_id, name, arguments: tool_args = "{}" } = tc;
-  if (tool_call_id && name) {
-    recordToolCall(
-      subagentId,
-      tool_call_id,
-      name,
-      tool_args,
-      state.displayedToolCalls,
-    );
+  for (const tc of toolCalls) {
+    const { tool_call_id, name, arguments: toolArgs = "{}" } = tc;
+    if (tool_call_id && name) {
+      recordToolCall(
+        subagentId,
+        tool_call_id,
+        name,
+        toolArgs,
+        state.displayedToolCalls,
+      );
+    }
   }
 }
 
@@ -462,19 +446,6 @@ function handleResultEvent(
 
   if (event.is_error) {
     state.finalError = event.result || "Unknown error";
-  } else {
-    // Record any pending tool calls that weren't auto-approved
-    for (const [id, { name, args }] of state.pendingToolCalls.entries()) {
-      if (name && !state.displayedToolCalls.has(id)) {
-        recordToolCall(
-          subagentId,
-          id,
-          name,
-          args || "{}",
-          state.displayedToolCalls,
-        );
-      }
-    }
   }
 
   // Update state store with final stats
@@ -505,17 +476,12 @@ function processStreamEvent(
         break;
 
       case "message":
-        if (event.message_type === "approval_request_message") {
-          handleApprovalRequestEvent(event, state);
-        } else {
-          // Forward non-approval message events for WS streaming to the web UI.
-          // Approval requests are internal to the subagent's permission flow.
-          emitStreamEvent(subagentId, event);
+        // Record tool calls so the subagent's tool-call list stays in sync,
+        // then forward the message for WS streaming to the web UI.
+        if (event.message_type === "tool_call_message") {
+          handleToolCallEvent(event, state, subagentId);
         }
-        break;
-
-      case "auto_approval":
-        handleAutoApprovalEvent(event, state, subagentId);
+        emitStreamEvent(subagentId, event);
         break;
 
       case "result":
@@ -1186,7 +1152,6 @@ async function executeSubagent(
       finalError: null,
       resultStats: null,
       displayedToolCalls: new Set(),
-      pendingToolCalls: new Map(),
     };
 
     // Parse child stdout manually instead of using readline. This keeps the

--- a/src/headless-tool-events.test.ts
+++ b/src/headless-tool-events.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import type { ApprovalResult } from "@/agent/approval-execution";
+import {
+  emitLocalToolCalls,
+  emitLocalToolReturns,
+} from "./headless-tool-events";
+
+/**
+ * Capture the JSON lines written via writeWireMessage (which uses console.log)
+ * without mock.module — swap console.log locally and restore it afterwards.
+ */
+function captureWireLines(fn: () => void): Array<Record<string, unknown>> {
+  const original = console.log;
+  const lines: Array<Record<string, unknown>> = [];
+  console.log = (msg?: unknown) => {
+    if (typeof msg === "string") lines.push(JSON.parse(msg));
+  };
+  try {
+    fn();
+  } finally {
+    console.log = original;
+  }
+  return lines;
+}
+
+describe("emitLocalToolReturns", () => {
+  test("emits a tool_return_message per executed tool", () => {
+    const results: ApprovalResult[] = [
+      {
+        type: "tool",
+        tool_call_id: "call_1",
+        status: "success",
+        tool_return: "hello",
+        stdout: ["hello"],
+      },
+      {
+        type: "tool",
+        tool_call_id: "call_2",
+        status: "error",
+        tool_return: "boom",
+      },
+    ];
+
+    const lines = captureWireLines(() =>
+      emitLocalToolReturns(results, "agent-x"),
+    );
+
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toMatchObject({
+      type: "message",
+      message_type: "tool_return_message",
+      tool_call_id: "call_1",
+      status: "success",
+      tool_return: "hello",
+      stdout: ["hello"],
+      session_id: "agent-x",
+      uuid: "tool-return-call_1",
+    });
+    expect(lines[1]).toMatchObject({
+      tool_call_id: "call_2",
+      status: "error",
+      tool_return: "boom",
+    });
+  });
+
+  test("stringifies multimodal tool_return content", () => {
+    const results = [
+      {
+        type: "tool",
+        tool_call_id: "c",
+        status: "success",
+        tool_return: [
+          { type: "text", text: "a" },
+          { type: "text", text: "b" },
+        ],
+      },
+    ] as unknown as ApprovalResult[];
+
+    const [line] = captureWireLines(() => emitLocalToolReturns(results, "s"));
+
+    expect(line?.tool_return).toBe("a\nb");
+  });
+
+  test("skips approval-only results that carry no tool output", () => {
+    const results = [
+      { type: "approval", tool_call_id: "c", approve: true },
+    ] as unknown as ApprovalResult[];
+
+    const lines = captureWireLines(() => emitLocalToolReturns(results, "s"));
+
+    expect(lines).toHaveLength(0);
+  });
+});
+
+describe("emitLocalToolCalls", () => {
+  test("emits a normalized tool_call_message per decision", () => {
+    const decisions = [
+      {
+        approval: {
+          toolCallId: "call_1",
+          toolName: "Bash",
+          toolArgs: '{"command":"ls"}',
+        },
+      },
+    ];
+
+    const [line] = captureWireLines(() =>
+      emitLocalToolCalls(decisions, "agent-x"),
+    );
+
+    expect(line).toMatchObject({
+      type: "message",
+      message_type: "tool_call_message",
+      session_id: "agent-x",
+      uuid: "tool-call-call_1",
+    });
+    expect(line?.tool_call).toMatchObject({
+      name: "Bash",
+      tool_call_id: "call_1",
+      arguments: '{"command":"ls"}',
+    });
+  });
+
+  test("defaults empty tool args to {}", () => {
+    const decisions = [
+      { approval: { toolCallId: "c", toolName: "Read", toolArgs: "" } },
+    ];
+
+    const [line] = captureWireLines(() => emitLocalToolCalls(decisions, "s"));
+
+    expect(line?.tool_call).toMatchObject({ arguments: "{}" });
+  });
+});

--- a/src/headless-tool-events.ts
+++ b/src/headless-tool-events.ts
@@ -1,0 +1,90 @@
+/**
+ * Stream-json wire events for LOCALLY-executed tools.
+ *
+ * The Letta server only streams `tool_call_message` / `tool_return_message`
+ * for tools it runs itself (e.g. `web_search`, `fetch_webpage`). Tools executed
+ * client-side by the CLI — Bash, Read, Edit, Write, Grep, … — run through
+ * `executeApprovalBatch`, and their results are fed back to the server as the
+ * next request's input. They never appear on the server stream, so a stream-json
+ * consumer sees the `auto_approval` call hint but never the tool's output.
+ *
+ * These emitters give local tools the same `tool_call_message` → `tool_return_message`
+ * pairing (keyed by `tool_call_id`) that server-side tools already get on the wire,
+ * so downstream consumers can pair calls with returns uniformly regardless of where
+ * the tool executed.
+ */
+
+import type { ApprovalResult } from "@/agent/approval-execution";
+import { getDisplayableToolReturn } from "@/agent/approval-execution";
+import { writeWireMessage } from "./stream-json-writer";
+import type {
+  ToolCallMessageWire,
+  ToolReturnMessageWire,
+} from "./types/protocol";
+
+/** Minimal shape shared by the `Decision` unions at both headless call sites. */
+interface LocalToolDecision {
+  approval: {
+    toolCallId: string;
+    toolName: string;
+    toolArgs: string;
+  };
+}
+
+/**
+ * Emit a normalized `tool_call_message` for each locally-executed tool decision.
+ * Call this immediately before `executeApprovalBatch` so the call is observed on
+ * the wire before its (awaited) result.
+ */
+export function emitLocalToolCalls(
+  decisions: LocalToolDecision[],
+  sessionId: string,
+): void {
+  const date = new Date().toISOString();
+  for (const decision of decisions) {
+    const { toolCallId, toolName, toolArgs } = decision.approval;
+    const msg: ToolCallMessageWire = {
+      type: "message",
+      message_type: "tool_call_message",
+      id: `tool-call-${toolCallId}`,
+      date,
+      tool_call: {
+        name: toolName,
+        tool_call_id: toolCallId,
+        arguments: toolArgs || "{}",
+      },
+      session_id: sessionId,
+      uuid: `tool-call-${toolCallId}`,
+    };
+    writeWireMessage(msg);
+  }
+}
+
+/**
+ * Emit a `tool_return_message` for each locally-executed tool result. Results
+ * that carry no tool output (approval-only entries) are skipped.
+ */
+export function emitLocalToolReturns(
+  results: ApprovalResult[],
+  sessionId: string,
+): void {
+  const date = new Date().toISOString();
+  for (const result of results) {
+    // ApprovalReturn entries carry an approval decision, not tool output.
+    if (!("tool_return" in result)) continue;
+    const msg: ToolReturnMessageWire = {
+      type: "message",
+      message_type: "tool_return_message",
+      id: `tool-return-${result.tool_call_id}`,
+      date,
+      status: result.status,
+      tool_call_id: result.tool_call_id,
+      tool_return: getDisplayableToolReturn(result.tool_return),
+      stdout: result.stdout,
+      stderr: result.stderr,
+      session_id: sessionId,
+      uuid: `tool-return-${result.tool_call_id}`,
+    };
+    writeWireMessage(msg);
+  }
+}

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -106,6 +106,10 @@ import {
   emitHeadlessConversationClose,
   emitHeadlessConversationOpen,
 } from "./headless-mod-adapter";
+import {
+  emitLocalToolCalls,
+  emitLocalToolReturns,
+} from "./headless-tool-events";
 import { computeDiffPreviews } from "./helpers/diff-preview";
 import { disableModsForProcess, shouldDisableMods } from "./mods/disable";
 import type { ModAdapter } from "./mods/mod-adapter";
@@ -2442,6 +2446,14 @@ ${SYSTEM_REMINDER_CLOSE}
         const { executeApprovalBatch } = await import(
           "@/agent/approval-execution"
         );
+
+        // Local tools execute client-side, so their calls + returns never reach
+        // the server stream. Surface them on the wire so stream-json consumers get
+        // the same tool_call_message → tool_return_message pairing as server tools.
+        if (outputFormat === "stream-json") {
+          emitLocalToolCalls(decisions, sessionId);
+        }
+
         const executedResults = await executeApprovalBatch(
           decisions,
           undefined,
@@ -2449,6 +2461,10 @@ ${SYSTEM_REMINDER_CLOSE}
             toolContextId: turnToolContextId ?? undefined,
           },
         );
+
+        if (outputFormat === "stream-json") {
+          emitLocalToolReturns(executedResults, sessionId);
+        }
 
         // Send all results in one batch
         const approvalInputWithOtid = {
@@ -4283,11 +4299,18 @@ async function runBidirectionalMode(
             const { executeApprovalBatch } = await import(
               "@/agent/approval-execution"
             );
+
+            // Bidirectional mode always emits stream-json. Surface locally
+            // executed tool calls + returns (see one-shot path above).
+            emitLocalToolCalls(decisions, sessionId);
+
             const executedResults = await executeApprovalBatch(
               decisions,
               undefined,
               { toolContextId: turnToolContextId ?? undefined },
             );
+
+            emitLocalToolReturns(executedResults, sessionId);
 
             // Send approval results back to continue
             const approvalInputWithOtid = {

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -144,7 +144,6 @@ import {
   prepareToolExecutionContextForScope,
 } from "./tools/toolset";
 import type {
-  AutoApprovalMessage,
   BootstrapSessionStateRequest,
   CanUseToolControlRequest,
   CanUseToolResponse,
@@ -2209,14 +2208,10 @@ ${SYSTEM_REMINDER_CLOSE}
       let approvalPendingRecovery = false;
 
       if (outputFormat === "stream-json") {
-        // Track approval requests across streamed chunks
-        const autoApprovalEmitted = new Set<string>();
-
-        const streamJsonHook: DrainStreamHook = async ({
+        const streamJsonHook: DrainStreamHook = ({
           chunk,
           shouldOutput,
           errorInfo,
-          updatedApproval,
         }) => {
           let shouldOutputChunk = shouldOutput;
 
@@ -2264,40 +2259,16 @@ ${SYSTEM_REMINDER_CLOSE}
             return { stopReason: "error", shouldAccumulate: true };
           }
 
-          // Check if this approval will be auto-approved. Dedup per tool_call_id
+          // Approval-flow chunks are omitted from stream-json so the stream
+          // matches other coding agents (Claude Code / Codex): the canonical
+          // tool_call_message emitted post-drain is the single call event, and
+          // approvals are handled out-of-band. See emitLocalToolCalls.
+          const messageType = (chunk as { message_type?: string }).message_type;
           if (
-            updatedApproval &&
-            !autoApprovalEmitted.has(updatedApproval.toolCallId)
+            messageType === "approval_request_message" ||
+            messageType === "approval_response_message"
           ) {
-            const { autoAllowed } = await classifyApprovals([updatedApproval], {
-              alwaysRequiresUserInput: isInteractiveApprovalTool,
-              requireArgsForAutoApprove: true,
-              missingNameReason: "Tool call incomplete - missing name",
-              toolContextId: turnToolContextId ?? undefined,
-            });
-
-            const [approval] = autoAllowed;
-            if (approval) {
-              const permission = approval.permission;
-              shouldOutputChunk = false;
-              const autoApprovalMsg: AutoApprovalMessage = {
-                type: "auto_approval",
-                tool_call: {
-                  name: approval.approval.toolName,
-                  tool_call_id: approval.approval.toolCallId,
-                  arguments: approval.approval.toolArgs || "{}",
-                },
-                reason: permission.reason || "Allowed by permission rule",
-                matched_rule:
-                  "matchedRule" in permission && permission.matchedRule
-                    ? permission.matchedRule
-                    : "auto-approved",
-                session_id: sessionId,
-                uuid: `auto-approval-${approval.approval.toolCallId}`,
-              };
-              writeWireMessage(autoApprovalMsg);
-              autoApprovalEmitted.add(approval.approval.toolCallId);
-            }
+            shouldOutputChunk = false;
           }
 
           if (shouldOutputChunk) {
@@ -4121,6 +4092,16 @@ async function runBidirectionalMode(
               return { shouldAccumulate: true };
             }
 
+            // Omit approval-flow chunks from stream-json (see one-shot path).
+            const messageType = (chunk as { message_type?: string })
+              .message_type;
+            if (
+              messageType === "approval_request_message" ||
+              messageType === "approval_response_message"
+            ) {
+              return { shouldAccumulate: true };
+            }
+
             const chunkWithIds = chunk as typeof chunk & {
               otid?: string;
               id?: string;
@@ -4228,26 +4209,6 @@ async function runBidirectionalMode(
               })),
             ];
 
-            for (const approvalItem of autoAllowed) {
-              const permission = approvalItem.permission;
-              const autoApprovalMsg: AutoApprovalMessage = {
-                type: "auto_approval",
-                tool_call: {
-                  name: approvalItem.approval.toolName,
-                  tool_call_id: approvalItem.approval.toolCallId,
-                  arguments: approvalItem.approval.toolArgs,
-                },
-                reason: permission.reason || "auto-approved",
-                matched_rule:
-                  "matchedRule" in permission && permission.matchedRule
-                    ? permission.matchedRule
-                    : "auto-approved",
-                session_id: sessionId,
-                uuid: `auto-approval-${approvalItem.approval.toolCallId}`,
-              };
-              writeWireMessage(autoApprovalMsg);
-            }
-
             for (const ac of needsUserInput) {
               // permission.decision is ask/alwaysAsk - request permission from SDK
               const permResponse = await requestPermission(
@@ -4271,21 +4232,6 @@ async function runBidirectionalMode(
                   approval: finalApproval,
                   matchedRule: "SDK callback approved",
                 });
-
-                // Emit auto_approval event for SDK-approved tool
-                const autoApprovalMsg: AutoApprovalMessage = {
-                  type: "auto_approval",
-                  tool_call: {
-                    name: finalApproval.toolName,
-                    tool_call_id: finalApproval.toolCallId,
-                    arguments: finalApproval.toolArgs,
-                  },
-                  reason: permResponse.reason || "SDK callback approved",
-                  matched_rule: "canUseTool callback",
-                  session_id: sessionId,
-                  uuid: `auto-approval-${ac.approval.toolCallId}`,
-                };
-                writeWireMessage(autoApprovalMsg);
               } else {
                 decisions.push({
                   type: "deny",

--- a/src/integration-tests/headless-input-format.test.ts
+++ b/src/integration-tests/headless-input-format.test.ts
@@ -674,13 +674,33 @@ describe("input-format stream-json", () => {
         expect(result).toBeDefined();
         expect(result?.subtype).toBe("success");
 
-        const autoApprovals = objects.filter(
-          (o) =>
-            o.type === "auto_approval" &&
-            "tool_call" in o &&
-            o.tool_call?.name === "Agent",
-        );
-        expect(autoApprovals.length).toBeGreaterThan(0);
+        // The Agent tool runs locally, so its invocation surfaces as a
+        // canonical tool_call_message (approval events are no longer emitted).
+        const agentToolCalls = objects.filter((o) => {
+          const m = o as {
+            type?: string;
+            message_type?: string;
+            tool_call?: { name?: string };
+          };
+          return (
+            m.type === "message" &&
+            m.message_type === "tool_call_message" &&
+            m.tool_call?.name === "Agent"
+          );
+        });
+        expect(agentToolCalls.length).toBeGreaterThan(0);
+
+        // Approval-flow events are stripped from stream-json output so the
+        // stream matches other coding agents.
+        expect(objects.some((o) => o.type === "auto_approval")).toBe(false);
+        expect(
+          objects.some(
+            (o) =>
+              o.type === "message" &&
+              "message_type" in o &&
+              o.message_type === "approval_request_message",
+          ),
+        ).toBe(false);
 
         const resultText = result?.result ?? "";
         const normalizedResultText = resultText.replaceAll("\\", "/");

--- a/src/integration-tests/lazy-approval-recovery.test.ts
+++ b/src/integration-tests/lazy-approval-recovery.test.ts
@@ -192,12 +192,13 @@ async function runLazyRecoveryTest(timeoutMs = 300000): Promise<{
           return;
         }
 
-        // Step 2: When we see approval request, send another user message instead,
-        // then explicitly deny the pending approval so the flow can complete in
-        // headless stream-json mode (which waits for approval responses).
+        // Step 2: A tool_call_message signals a tool was invoked. Approval-flow
+        // chunks are no longer emitted, so this is the canonical point to inject
+        // the concurrent user message. A real pending approval (control_request)
+        // is handled separately above.
         if (
           msg.type === "message" &&
-          msg.message_type === "approval_request_message" &&
+          msg.message_type === "tool_call_message" &&
           !approvalSeen
         ) {
           approvalSeen = true;
@@ -210,8 +211,7 @@ async function runLazyRecoveryTest(timeoutMs = 300000): Promise<{
               ? (toolCall as { tool_call_id?: string }).tool_call_id
               : undefined;
 
-          // If approval stream chunks arrive before can_use_tool callback,
-          // still send the concurrent user message now.
+          // Send the concurrent user message now (mid-turn).
           if (!interruptSent) {
             interruptSent = true;
             const userMsg = JSON.stringify({
@@ -331,10 +331,11 @@ describe("lazy approval recovery", () => {
       }
     }
 
-    // We should have seen at least one approval signal (message stream or control callback)
+    // We should have seen at least one tool invocation (tool_call_message) or a
+    // real approval prompt (control_request) — i.e. the tool flow was entered.
     const approvalSignal = result.messages.find(
       (m) =>
-        m.message_type === "approval_request_message" ||
+        (m.type === "message" && m.message_type === "tool_call_message") ||
         (m.type === "control_request" && m.request?.subtype === "can_use_tool"),
     );
     expect(approvalSignal).toBeDefined();


### PR DESCRIPTION
Makes the headless `--output-format stream-json` output surface local tool I/O and match the shape of other coding agents (Claude Code / Codex). Two commits (the second, #3086, merged into this branch):

1. **Emit local tool calls + returns** (`0d3f3dcf`)
2. **Strip approval events** (`4948fde3`, #3086)

## Problem

Locally-executed tools (Bash, Read, Edit, Write, …) run client-side via `executeApprovalBatch`, and their results are fed back to the server as the next request's input — so they never appear on the server stream. As a result, `stream-json` consumers saw the tool *call* (only via an `auto_approval` event) but never the tool's **output**, while the stream was also cluttered with approval-flow events no other agent emits.

## What this does

Local tools now get the same `tool_call_message` → `tool_return_message` pairing (keyed by `tool_call_id`) that server-side tools already get — i.e. the `tool_use` → `tool_result` shape of Claude Code / Codex — and the approval-flow noise is removed.

### 1. Emit local tool calls + returns
- New `src/headless-tool-events.ts` with `emitLocalToolCalls` / `emitLocalToolReturns` (multimodal returns stringified via `getDisplayableToolReturn`; approval-only results skipped).
- Wired into both headless paths (one-shot `-p` and bidirectional `--input-format stream-json`): emit calls before `executeApprovalBatch`, returns after.
- Unit tests in `src/headless-tool-events.test.ts` (call/return shape, multimodal stringification, empty-args default, approval-only skip).

### 2. Strip approval events
- `headless.ts` (both paths): suppress `approval_request_message` / `approval_response_message` chunks; remove all three `auto_approval` emit sites. The post-drain approval *logic* (classify → execute) is untouched — only what's printed changes. Approvals remain available out-of-band via the control protocol (`can_use_tool`).
- `manager.ts` (the only in-repo consumer of these events): reconstruct subagent tool calls from `tool_call_message` instead of `auto_approval` + partial `approval_request_message` deltas — dropping `pendingToolCalls`, the two approval handlers, and the result-time flush, since it now gets complete args in one event.
- Bidirectional integration test asserts `tool_call_message` instead of `auto_approval`, plus a regression guard that approval events are absent.

## Result

Same forced-`Bash` prompt, before → after: 12 events → 9. The stream is now `system/init` → `reasoning` → `tool_call_message` → `tool_return_message` → `assistant_message` → `result`, with no `auto_approval` or `approval_request_message`.

## Verification

Live runs against real Letta cloud + Sonnet:
- **Single `Bash` call** — `tool_call_message` (complete args) → `tool_return_message` (status + output), paired by `tool_call_id`.
- **Parallel reads (3 at once)** — 3 calls then 3 returns, all paired by id, no errors.
- **Subagent run** — exercises the migrated `manager.ts`; parent records the child's tool calls from `tool_call_message`, completes cleanly.

`bun run check` passes (all 9 checks).

## Note

`AutoApprovalMessage` is now unemitted but left defined in `protocol.ts` (the SDK imports from there); dead-type cleanup can be a separate pass.
