### PR TITLE
feat(headless): strip approval events from stream-json output

### DIFF
--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -108,7 +108,6 @@ interface ExecutionState {
     stepCount?: number;
   } | null;
   displayedToolCalls: Set<string>;
-  pendingToolCalls: Map<string, { name: string; args: string }>;
 }
 
 // ============================================================================
@@ -384,11 +383,22 @@ function handleInitEvent(
 }
 
 /**
- * Handle an approval request message event
+ * Handle a tool_call_message event. The subagent runs headless with
+ * --output-format stream-json and emits a tool_call_message (with complete
+ * arguments) for every tool it calls — both server-side tools and locally
+ * executed ones. Record each so the subagent's tool-call list stays in sync.
  */
-function handleApprovalRequestEvent(
-  event: { tool_calls?: unknown[]; tool_call?: unknown },
+function handleToolCallEvent(
+  event: {
+    tool_call?: { tool_call_id?: string; name?: string; arguments?: string };
+    tool_calls?: Array<{
+      tool_call_id?: string;
+      name?: string;
+      arguments?: string;
+    }>;
+  },
   state: ExecutionState,
+  subagentId: string,
 ): void {
   const toolCalls = Array.isArray(event.tool_calls)
     ? event.tool_calls
@@ -396,43 +406,17 @@ function handleApprovalRequestEvent(
       ? [event.tool_call]
       : [];
 
-  for (const toolCall of toolCalls) {
-    const tc = toolCall as {
-      tool_call_id?: string;
-      name?: string;
-      arguments?: string;
-    };
-    const id = tc.tool_call_id;
-    if (!id) continue;
-
-    const prev = state.pendingToolCalls.get(id) || { name: "", args: "" };
-    const name = tc.name || prev.name;
-    const args = prev.args + (tc.arguments || "");
-    state.pendingToolCalls.set(id, { name, args });
-  }
-}
-
-/**
- * Handle an auto_approval event
- */
-function handleAutoApprovalEvent(
-  event: {
-    tool_call?: { tool_call_id?: string; name?: string; arguments?: string };
-  },
-  state: ExecutionState,
-  subagentId: string,
-): void {
-  const tc = event.tool_call;
-  if (!tc) return;
-  const { tool_call_id, name, arguments: tool_args = "{}" } = tc;
-  if (tool_call_id && name) {
-    recordToolCall(
-      subagentId,
-      tool_call_id,
-      name,
-      tool_args,
-      state.displayedToolCalls,
-    );
+  for (const tc of toolCalls) {
+    const { tool_call_id, name, arguments: toolArgs = "{}" } = tc;
+    if (tool_call_id && name) {
+      recordToolCall(
+        subagentId,
+        tool_call_id,
+        name,
+        toolArgs,
+        state.displayedToolCalls,
+      );
+    }
   }
 }
 
@@ -462,19 +446,6 @@ function handleResultEvent(
 
   if (event.is_error) {
     state.finalError = event.result || "Unknown error";
-  } else {
-    // Record any pending tool calls that weren't auto-approved
-    for (const [id, { name, args }] of state.pendingToolCalls.entries()) {
-      if (name && !state.displayedToolCalls.has(id)) {
-        recordToolCall(
-          subagentId,
-          id,
-          name,
-          args || "{}",
-          state.displayedToolCalls,
-        );
-      }
-    }
   }
 
   // Update state store with final stats
@@ -505,17 +476,12 @@ function processStreamEvent(
         break;
 
       case "message":
-        if (event.message_type === "approval_request_message") {
-          handleApprovalRequestEvent(event, state);
-        } else {
-          // Forward non-approval message events for WS streaming to the web UI.
-          // Approval requests are internal to the subagent's permission flow.
-          emitStreamEvent(subagentId, event);
+        // Record tool calls so the subagent's tool-call list stays in sync,
+        // then forward the message for WS streaming to the web UI.
+        if (event.message_type === "tool_call_message") {
+          handleToolCallEvent(event, state, subagentId);
         }
-        break;
-
-      case "auto_approval":
-        handleAutoApprovalEvent(event, state, subagentId);
+        emitStreamEvent(subagentId, event);
         break;
 
       case "result":
@@ -1186,7 +1152,6 @@ async function executeSubagent(
       finalError: null,
       resultStats: null,
       displayedToolCalls: new Set(),
-      pendingToolCalls: new Map(),
     };
 
     // Parse child stdout manually instead of using readline. This keeps the

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -144,7 +144,6 @@ import {
   prepareToolExecutionContextForScope,
 } from "./tools/toolset";
 import type {
-  AutoApprovalMessage,
   BootstrapSessionStateRequest,
   CanUseToolControlRequest,
   CanUseToolResponse,
@@ -2209,14 +2208,10 @@ ${SYSTEM_REMINDER_CLOSE}
       let approvalPendingRecovery = false;
 
       if (outputFormat === "stream-json") {
-        // Track approval requests across streamed chunks
-        const autoApprovalEmitted = new Set<string>();
-
-        const streamJsonHook: DrainStreamHook = async ({
+        const streamJsonHook: DrainStreamHook = ({
           chunk,
           shouldOutput,
           errorInfo,
-          updatedApproval,
         }) => {
           let shouldOutputChunk = shouldOutput;
 
@@ -2264,40 +2259,16 @@ ${SYSTEM_REMINDER_CLOSE}
             return { stopReason: "error", shouldAccumulate: true };
           }
 
-          // Check if this approval will be auto-approved. Dedup per tool_call_id
+          // Approval-flow chunks are omitted from stream-json so the stream
+          // matches other coding agents (Claude Code / Codex): the canonical
+          // tool_call_message emitted post-drain is the single call event, and
+          // approvals are handled out-of-band. See emitLocalToolCalls.
+          const messageType = (chunk as { message_type?: string }).message_type;
           if (
-            updatedApproval &&
-            !autoApprovalEmitted.has(updatedApproval.toolCallId)
+            messageType === "approval_request_message" ||
+            messageType === "approval_response_message"
           ) {
-            const { autoAllowed } = await classifyApprovals([updatedApproval], {
-              alwaysRequiresUserInput: isInteractiveApprovalTool,
-              requireArgsForAutoApprove: true,
-              missingNameReason: "Tool call incomplete - missing name",
-              toolContextId: turnToolContextId ?? undefined,
-            });
-
-            const [approval] = autoAllowed;
-            if (approval) {
-              const permission = approval.permission;
-              shouldOutputChunk = false;
-              const autoApprovalMsg: AutoApprovalMessage = {
-                type: "auto_approval",
-                tool_call: {
-                  name: approval.approval.toolName,
-                  tool_call_id: approval.approval.toolCallId,
-                  arguments: approval.approval.toolArgs || "{}",
-                },
-                reason: permission.reason || "Allowed by permission rule",
-                matched_rule:
-                  "matchedRule" in permission && permission.matchedRule
-                    ? permission.matchedRule
-                    : "auto-approved",
-                session_id: sessionId,
-                uuid: `auto-approval-${approval.approval.toolCallId}`,
-              };
-              writeWireMessage(autoApprovalMsg);
-              autoApprovalEmitted.add(approval.approval.toolCallId);
-            }
+            shouldOutputChunk = false;
           }
 
           if (shouldOutputChunk) {
@@ -4121,6 +4092,16 @@ async function runBidirectionalMode(
               return { shouldAccumulate: true };
             }
 
+            // Omit approval-flow chunks from stream-json (see one-shot path).
+            const messageType = (chunk as { message_type?: string })
+              .message_type;
+            if (
+              messageType === "approval_request_message" ||
+              messageType === "approval_response_message"
+            ) {
+              return { shouldAccumulate: true };
+            }
+
             const chunkWithIds = chunk as typeof chunk & {
               otid?: string;
               id?: string;
@@ -4228,26 +4209,6 @@ async function runBidirectionalMode(
               })),
             ];
 
-            for (const approvalItem of autoAllowed) {
-              const permission = approvalItem.permission;
-              const autoApprovalMsg: AutoApprovalMessage = {
-                type: "auto_approval",
-                tool_call: {
-                  name: approvalItem.approval.toolName,
-                  tool_call_id: approvalItem.approval.toolCallId,
-                  arguments: approvalItem.approval.toolArgs,
-                },
-                reason: permission.reason || "auto-approved",
-                matched_rule:
-                  "matchedRule" in permission && permission.matchedRule
-                    ? permission.matchedRule
-                    : "auto-approved",
-                session_id: sessionId,
-                uuid: `auto-approval-${approvalItem.approval.toolCallId}`,
-              };
-              writeWireMessage(autoApprovalMsg);
-            }
-
             for (const ac of needsUserInput) {
               // permission.decision is ask/alwaysAsk - request permission from SDK
               const permResponse = await requestPermission(
@@ -4271,21 +4232,6 @@ async function runBidirectionalMode(
                   approval: finalApproval,
                   matchedRule: "SDK callback approved",
                 });
-
-                // Emit auto_approval event for SDK-approved tool
-                const autoApprovalMsg: AutoApprovalMessage = {
-                  type: "auto_approval",
-                  tool_call: {
-                    name: finalApproval.toolName,
-                    tool_call_id: finalApproval.toolCallId,
-                    arguments: finalApproval.toolArgs,
-                  },
-                  reason: permResponse.reason || "SDK callback approved",
-                  matched_rule: "canUseTool callback",
-                  session_id: sessionId,
-                  uuid: `auto-approval-${ac.approval.toolCallId}`,
-                };
-                writeWireMessage(autoApprovalMsg);
               } else {
                 decisions.push({
                   type: "deny",

--- a/src/integration-tests/headless-input-format.test.ts
+++ b/src/integration-tests/headless-input-format.test.ts
@@ -674,13 +674,33 @@ describe("input-format stream-json", () => {
         expect(result).toBeDefined();
         expect(result?.subtype).toBe("success");
 
-        const autoApprovals = objects.filter(
-          (o) =>
-            o.type === "auto_approval" &&
-            "tool_call" in o &&
-            o.tool_call?.name === "Agent",
-        );
-        expect(autoApprovals.length).toBeGreaterThan(0);
+        // The Agent tool runs locally, so its invocation surfaces as a
+        // canonical tool_call_message (approval events are no longer emitted).
+        const agentToolCalls = objects.filter((o) => {
+          const m = o as {
+            type?: string;
+            message_type?: string;
+            tool_call?: { name?: string };
+          };
+          return (
+            m.type === "message" &&
+            m.message_type === "tool_call_message" &&
+            m.tool_call?.name === "Agent"
+          );
+        });
+        expect(agentToolCalls.length).toBeGreaterThan(0);
+
+        // Approval-flow events are stripped from stream-json output so the
+        // stream matches other coding agents.
+        expect(objects.some((o) => o.type === "auto_approval")).toBe(false);
+        expect(
+          objects.some(
+            (o) =>
+              o.type === "message" &&
+              "message_type" in o &&
+              o.message_type === "approval_request_message",
+          ),
+        ).toBe(false);
 
         const resultText = result?.result ?? "";
         const normalizedResultText = resultText.replaceAll("\\", "/");


### PR DESCRIPTION
Stacked on #3085 (based off `feat/headless-local-tool-events`).

## What

Removes approval-flow events from the headless `stream-json` output so the stream matches other coding agents (Claude Code / Codex): the canonical `tool_call_message` → `tool_return_message` pair (added in #3085) is the single call/return signal, and approvals are handled out-of-band via the control protocol (`can_use_tool`), which is unchanged.

## Changes

- `headless.ts` (both one-shot and bidirectional): suppress `approval_request_message` / `approval_response_message` chunks; remove all three `auto_approval` emit sites. The post-drain approval *logic* (classify → execute) is untouched — only what's printed changes.
- `manager.ts` (the only in-repo consumer of these events): reconstruct subagent tool calls from `tool_call_message` instead of `auto_approval` + partial `approval_request_message` deltas. Drops `pendingToolCalls`, the two approval handlers, and the result-time flush — it now gets complete args in one event.
- Updated the bidirectional integration test to assert `tool_call_message` instead of `auto_approval`, plus a regression guard that approval events are absent.

## Before / after

Same forced-`Bash` prompt: 12 events → 9. `auto_approval` and `approval_request_message` no longer appear; `tool_call_message` → `tool_return_message` → `assistant_message` → `result` remains.

## Verification

Live one-shot, parallel (3 reads), and subagent runs all clean — the subagent run exercises the migrated `manager.ts` (parent records the child's tool calls from `tool_call_message`). `bun run check` passes.

## Note

`AutoApprovalMessage` is now unemitted but left defined in `protocol.ts` (the SDK imports from there); dead-type cleanup can be a separate pass.
