### PR TITLE
feat(desktop): add turn_end continue effect for the listener

### DIFF
--- a/src/queue/queue-runtime.test.ts
+++ b/src/queue/queue-runtime.test.ts
@@ -49,6 +49,12 @@ function makeOverlay(): Omit<
   return { kind: "overlay_action", source: "system", text: "plan_mode" };
 }
 
+function makeContinue(
+  text = "keep going",
+): Omit<Extract<QueueItem, { kind: "mod_continue" }>, "id" | "enqueuedAt"> {
+  return { kind: "mod_continue", source: "system", text };
+}
+
 // ── Enqueue ───────────────────────────────────────────────────────
 
 describe("enqueue basics", () => {
@@ -191,6 +197,16 @@ describe("dequeue coalescable items", () => {
     expect(batch).not.toBeNull();
     expect(batch?.items).toHaveLength(3);
     expect(batch?.mergedCount).toBe(3);
+  });
+
+  test("mod_continue items are coalescable and dequeue as a batch", () => {
+    const q = new QueueRuntime();
+    q.enqueue(makeContinue("keep going"));
+    const batch = q.tryDequeue(null);
+    expect(batch).not.toBeNull();
+    expect(batch?.items).toHaveLength(1);
+    expect(batch?.items[0]?.kind).toBe("mod_continue");
+    expect(q.length).toBe(0);
   });
 
   test("onDequeued fires with correct batch metadata", () => {

--- a/src/queue/queue-runtime.ts
+++ b/src/queue/queue-runtime.ts
@@ -67,19 +67,29 @@ export type CronPromptQueueItem = QueueItemBase & {
   cronTaskId: string;
 };
 
+export type ModContinueQueueItem = QueueItemBase & {
+  kind: "mod_continue";
+  /** Follow-up text from a mod's turn_end { continue }, sent as a user message. */
+  text: string;
+};
+
 export type QueueItem =
   | MessageQueueItem
   | TaskNotificationQueueItem
   | CronPromptQueueItem
   | ApprovalResultQueueItem
-  | OverlayActionQueueItem;
+  | OverlayActionQueueItem
+  | ModContinueQueueItem;
 
 // ── Coalescability ───────────────────────────────────────────────
 
 /** Coalescable items can be merged into a single submission batch. */
 export function isCoalescable(kind: QueueItemKind): boolean {
   return (
-    kind === "message" || kind === "task_notification" || kind === "cron_prompt"
+    kind === "message" ||
+    kind === "task_notification" ||
+    kind === "cron_prompt" ||
+    kind === "mod_continue"
   );
 }
 

--- a/src/types/protocol-queue-lifecycle.test.ts
+++ b/src/types/protocol-queue-lifecycle.test.ts
@@ -61,8 +61,9 @@ describe("QueueItemEnqueuedEvent wire shape", () => {
       cron_prompt: true,
       approval_result: true,
       overlay_action: true,
+      mod_continue: true,
     } satisfies Record<QueueItemKind, true>;
-    expect(Object.keys(kinds)).toHaveLength(5);
+    expect(Object.keys(kinds)).toHaveLength(6);
   });
 });
 

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -366,13 +366,15 @@ export type QueueItemSource =
  * - task_notification: Background task completed notification
  * - approval_result: Tool approval/denial result
  * - overlay_action: AskUserQuestion or other overlay action
+ * - mod_continue: Follow-up turn injected by a mod's turn_end { continue }
  */
 export type QueueItemKind =
   | "message"
   | "task_notification"
   | "cron_prompt"
   | "approval_result"
-  | "overlay_action";
+  | "overlay_action"
+  | "mod_continue";
 
 /**
  * Canonical queue item wire shape used by listener state snapshots

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -479,7 +479,8 @@ export type QueueMessageKind =
   | "task_notification"
   | "cron_prompt"
   | "approval_result"
-  | "overlay_action";
+  | "overlay_action"
+  | "mod_continue";
 
 export type QueueMessageSource =
   | "user"

--- a/src/websocket/listen-client-concurrency.test.ts
+++ b/src/websocket/listen-client-concurrency.test.ts
@@ -22,6 +22,7 @@ import {
 import { permissionMode } from "@/permissions/mode";
 import type {
   MessageQueueItem,
+  ModContinueQueueItem,
   TaskNotificationQueueItem,
 } from "@/queue/queue-runtime";
 import { sharedReminderProviders } from "@/reminders/engine";
@@ -1407,6 +1408,40 @@ describe("listen-client multi-worker concurrency", () => {
     expect(runtime.queueRuntime.peek().map((item) => item.id)).toEqual([
       otherMessageItem.id,
     ]);
+  });
+
+  test("consumeQueuedTurn builds a user turn from a mod_continue-only batch", () => {
+    const runtime = __listenClientTestUtils.createRuntime();
+    const continueInput = {
+      kind: "mod_continue",
+      source: "system",
+      text: "double-check your work before finishing",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+    } satisfies Omit<ModContinueQueueItem, "id" | "enqueuedAt">;
+    const continueItem = runtime.queueRuntime.enqueue(continueInput);
+
+    if (!continueItem) {
+      throw new Error("Expected queued mod_continue item");
+    }
+
+    const consumed = __listenClientTestUtils.consumeQueuedTurn(runtime);
+
+    expect(consumed).not.toBeNull();
+    expect(
+      consumed?.dequeuedBatch.items.map((item: { id: string }) => item.id),
+    ).toEqual([continueItem.id]);
+    // No template registration needed — the continue is synthesized as a
+    // plain user turn (renders via the backend, suppressed optimistically).
+    expect(consumed?.queuedTurn.messages).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "double-check your work before finishing" },
+        ],
+      },
+    ]);
+    expect(runtime.queueRuntime.length).toBe(0);
   });
 
   test("resolveStaleApprovals injects stale denials and queued turns without replaying tools", async () => {

--- a/src/websocket/listener/protocol-outbound.test.ts
+++ b/src/websocket/listener/protocol-outbound.test.ts
@@ -148,4 +148,40 @@ describe("emitDequeuedUserMessage", () => {
 
     expect(socket.sentPayloads).toHaveLength(0);
   });
+
+  test("suppresses the echo for mod_continue-only turns", () => {
+    const { runtime, socket } = createRuntime();
+    const continueText = "keep going and double-check your work";
+    const incoming = {
+      type: "message",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: continueText }],
+        },
+      ],
+    } as IncomingMessage;
+    const batch = {
+      batchId: "batch-continue",
+      items: [
+        {
+          id: "item-continue",
+          kind: "mod_continue",
+          source: "system",
+          text: continueText,
+          agentId: "agent-1",
+          conversationId: "conv-1",
+          enqueuedAt: Date.now(),
+        },
+      ],
+      mergedCount: 1,
+      queueLenAfter: 0,
+    } satisfies DequeuedBatch;
+
+    emitDequeuedUserMessage(socket as never, runtime, incoming, batch);
+
+    expect(socket.sentPayloads).toHaveLength(0);
+  });
 });

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -852,6 +852,16 @@ export function emitDequeuedUserMessage(
   incoming: IncomingMessage,
   batch: DequeuedBatch,
 ): void {
+  // A mod-driven continue turn carries no real user input — suppress the
+  // optimistic echo so the follow-up stays seamless (matches TUI, where the
+  // continue is injected without rendering a user message).
+  if (
+    batch.items.length > 0 &&
+    batch.items.every((item) => item.kind === "mod_continue")
+  ) {
+    return;
+  }
+
   const firstUserPayload = incoming.messages.find(
     (payload): payload is MessageCreate & { client_message_id?: string } =>
       "content" in payload,

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -103,6 +103,14 @@ function mergeDequeuedBatchContent(
         kind: "cron_prompt",
         text: item.text,
       });
+      continue;
+    }
+    if (item.kind === "mod_continue") {
+      // A continue is plain user text — merge it as user content.
+      queuedInputs.push({
+        kind: "user",
+        content: item.text,
+      });
     }
   }
 
@@ -413,6 +421,7 @@ export function consumeQueuedTurn(runtime: ConversationRuntime): {
   let hasMessage = false;
   let hasTaskNotification = false;
   let hasCronPrompt = false;
+  let hasModContinue = false;
   for (const item of queuedItems) {
     if (
       !isCoalescable(item.kind) ||
@@ -431,10 +440,16 @@ export function consumeQueuedTurn(runtime: ConversationRuntime): {
     if (item.kind === "cron_prompt") {
       hasCronPrompt = true;
     }
+    if (item.kind === "mod_continue") {
+      hasModContinue = true;
+    }
   }
 
   if (
-    (!hasMessage && !hasTaskNotification && !hasCronPrompt) ||
+    (!hasMessage &&
+      !hasTaskNotification &&
+      !hasCronPrompt &&
+      !hasModContinue) ||
     queueLen === 0
   ) {
     return null;

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -263,7 +263,7 @@ async function emitListenerTurnEnd(options: {
   workingDirectory: string;
   permissionMode?: string | null;
   cachedAgent?: AgentState | null;
-}): Promise<void> {
+}): Promise<string | undefined> {
   try {
     const modAdapter = ensureListenerModAdapter(options.runtime);
     const context = createListenerModContext({
@@ -272,15 +272,25 @@ async function emitListenerTurnEnd(options: {
       permissionMode: options.permissionMode ?? null,
       agent: options.cachedAgent ?? null,
     });
-    const event = {
+    const event: {
+      agentId: string;
+      conversationId: string;
+      stopReason: string;
+      assistantMessage?: string;
+      continue?: string;
+    } = {
       agentId: options.agentId,
       conversationId: options.conversationId,
       stopReason: options.stopReason,
       assistantMessage: options.assistantMessage,
     };
     await modAdapter.events.emit("turn_end", event, context);
+    return typeof event.continue === "string" && event.continue.length > 0
+      ? event.continue
+      : undefined;
   } catch {
     // Mod turn_end handlers should not block turn completion.
+    return undefined;
   }
 }
 
@@ -839,7 +849,7 @@ export async function handleIncomingMessage(
       }
 
       if (stopReason === "end_turn") {
-        await emitListenerTurnEnd({
+        const continueText = await emitListenerTurnEnd({
           agentId,
           conversationId,
           stopReason,
@@ -849,6 +859,22 @@ export async function handleIncomingMessage(
           permissionMode: turnPermissionModeState.mode,
           cachedAgent,
         });
+        if (continueText) {
+          // A mod asked to keep going: enqueue a follow-up turn. The post-turn
+          // re-pump runs it. The phantom user message is suppressed in
+          // emitDequeuedUserMessage so the continue stays seamless.
+          runtime.queueRuntime.enqueue({
+            kind: "mod_continue",
+            source: "system",
+            text: continueText,
+            agentId: agentId ?? undefined,
+            conversationId,
+            actingUserId: msg.actingUserId,
+          } as Omit<
+            import("@/queue/queue-runtime").ModContinueQueueItem,
+            "id" | "enqueuedAt"
+          >);
+        }
         try {
           const transcriptLines = toLines(buffers);
           if (transcriptLines.length > 0) {


### PR DESCRIPTION
## Summary
- When a listener-mode mod sets `{ continue }` in `turn_end`, the listener now enqueues a new `mod_continue` queue item, and the drain loop runs it as a seamless follow-up turn (same proven mechanism as `cron_prompt`/`task_notification`).
- The injected user message is suppressed in `emitDequeuedUserMessage` for `mod_continue`-only batches, so the continue stays invisible on desktop, matching the TUI continue behavior (where the backend does not echo input and no optimistic row is rendered).
- letta-code only, no client changes. The continue is mapped to plain user content at merge time, so the shared `QueuedTurnInput` (and headless) is untouched.

Completes the desktop side of the `turn_end` continue effect (mirrors #3077 TUI and #3080 headless); builds on the emission PR #3082.

## Changes
- `mod_continue` queue kind: `queue-runtime.ts` (type + `isCoalescable`), `protocol.ts` / `protocol_v2.ts` (kind enums)
- `queue.ts`: maps `mod_continue` to user content in `mergeDequeuedBatchContent`; `hasModContinue` in the `consumeQueuedTurn` validity guard
- `turn.ts`: `emitListenerTurnEnd` returns the continue string; enqueues `mod_continue` in the `end_turn` block
- `protocol-outbound.ts`: suppress the optimistic echo for `mod_continue`-only batches
- Tests: queue coalesce/dequeue, `consumeQueuedTurn` builds a user turn from a continue-only batch, echo suppression

## Test plan
- [ ] `npx tsc --noEmit` clean
- [ ] `bun test src/queue/ src/websocket/listener/ src/websocket/listen-client-concurrency.test.ts` green
- [ ] Dogfood on desktop: run a `turn_end` mod that returns `{ continue }` and confirm the follow-up turn runs without rendering a phantom user message

## Notes / follow-ups
- Covered for the normal client-message path (drain loop re-consumes). A continue requested on an exotic non-pump turn (e.g. command-driven) would wait for the next pump — acceptable for v1.
- Distinct "auto-continued" rendering (a labeled row in both clients) is deferred as optional Phase 2 polish.

👾 Generated with [Letta Code](https://letta.com)