### PR TITLE
feat(mods): add tool_end event with result modification

### DIFF
--- a/src/mods/mod-engine.test.ts
+++ b/src/mods/mod-engine.test.ts
@@ -1150,6 +1150,100 @@ describe("mod engine", () => {
     }
   });
 
+  test("tool_end result: first handler wins, replaces the result", async () => {
+    const root = createTempDir();
+    try {
+      const modDir = path.join(root, "global-mods");
+      mkdirSync(modDir, { recursive: true });
+      writeFileSync(
+        path.join(modDir, "tool-end.ts"),
+        `export default function(letta) {
+          letta.events.on("tool_end", (event) => {
+            if (event.toolName === "Bash" && event.status === "success") {
+              return { result: { status: "success", output: "redacted" } };
+            }
+          });
+          letta.events.on("tool_end", (event) => {
+            if (event.toolName === "Bash") {
+              return { result: { status: "error", output: "should not win" } };
+            }
+          });
+        }`,
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+      const event = {
+        agentId: "agent-1",
+        conversationId: "conversation-1",
+        toolCallId: "toolu-1",
+        toolName: "Bash",
+        status: "success" as const,
+        output: "secret token abc123",
+      };
+
+      const result = await engine.emitEvent(
+        "tool_end",
+        event,
+        createModContext(),
+      );
+
+      expect(result.handlerCount).toBe(2);
+      expect(
+        (event as { result?: { status: string; output: string } }).result,
+      ).toEqual({
+        status: "success",
+        output: "redacted",
+      });
+
+      engine.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("tool_end result: no result when condition not met", async () => {
+    const root = createTempDir();
+    try {
+      const modDir = path.join(root, "global-mods");
+      mkdirSync(modDir, { recursive: true });
+      writeFileSync(
+        path.join(modDir, "tool-end.ts"),
+        `export default function(letta) {
+          letta.events.on("tool_end", (event) => {
+            if (event.toolName === "Read") {
+              return { result: { status: "success", output: "redacted" } };
+            }
+          });
+        }`,
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+      const event = {
+        agentId: "agent-1",
+        conversationId: "conversation-1",
+        toolCallId: "toolu-1",
+        toolName: "Bash",
+        status: "success" as const,
+        output: "untouched",
+      };
+
+      const result = await engine.emitEvent(
+        "tool_end",
+        event,
+        createModContext(),
+      );
+
+      expect(result.handlerCount).toBe(1);
+      expect((event as { result?: unknown }).result).toBeUndefined();
+
+      engine.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("turn_end continue: first handler wins", async () => {
     const root = createTempDir();
     try {

--- a/src/mods/mod-engine.ts
+++ b/src/mods/mod-engine.ts
@@ -93,6 +93,7 @@ import type {
   ModPermissionRegistration,
   ModSourceScope,
   ModTool,
+  ModToolEndEvent,
   ModToolRegistration,
   ModToolStartEvent,
   ModTurnEndEvent,
@@ -694,6 +695,7 @@ const SUPPORTED_MOD_EVENT_NAMES = new Set<ModEventName>([
   "conversation_open",
   "conversation_close",
   "tool_start",
+  "tool_end",
   "turn_start",
   "turn_end",
 ]);
@@ -713,6 +715,7 @@ function isModEventCapabilityEnabled(
     case "conversation_close":
       return capabilities.events.lifecycle;
     case "tool_start":
+    case "tool_end":
       return capabilities.events.tools;
     case "turn_start":
     case "turn_end":
@@ -779,6 +782,18 @@ function isToolStartResultWithResult(
 ): result is { result: { status: "success" | "error"; output: string } } {
   return (
     name === "tool_start" &&
+    typeof result === "object" &&
+    result !== null &&
+    isToolStartResult((result as { result?: unknown }).result)
+  );
+}
+
+function isToolEndResultWithResult(
+  name: ModEventName,
+  result: unknown,
+): result is { result: { status: "success" | "error"; output: string } } {
+  return (
+    name === "tool_end" &&
     typeof result === "object" &&
     result !== null &&
     isToolStartResult((result as { result?: unknown }).result)
@@ -1711,6 +1726,16 @@ export async function emitLocalModEvent<TName extends ModEventName>(
       ) {
         (
           event as ModToolStartEvent & {
+            result?: { status: "success" | "error"; output: string };
+          }
+        ).result = result.result;
+      }
+      if (
+        isToolEndResultWithResult(name, result) &&
+        !(event as ModToolEndEvent & { result?: unknown }).result
+      ) {
+        (
+          event as ModToolEndEvent & {
             result?: { status: "success" | "error"; output: string };
           }
         ).result = result.result;

--- a/src/mods/types.ts
+++ b/src/mods/types.ts
@@ -144,6 +144,7 @@ export type ModEventName =
   | "conversation_open"
   | "conversation_close"
   | "tool_start"
+  | "tool_end"
   | "turn_start"
   | "turn_end";
 
@@ -201,6 +202,19 @@ export interface ModToolStartResult {
   result?: { status: "success" | "error"; output: string };
 }
 
+export interface ModToolEndEvent {
+  agentId: string | null;
+  conversationId: string | null;
+  toolCallId: string | null;
+  toolName: string;
+  status: "success" | "error";
+  output: string;
+}
+
+export interface ModToolEndResult {
+  result?: { status: "success" | "error"; output: string };
+}
+
 export interface ModTurnEndEvent {
   agentId: string | null;
   conversationId: string | null;
@@ -216,6 +230,7 @@ export interface ModEventMap {
   conversation_open: ModConversationOpenEvent;
   conversation_close: ModConversationCloseEvent;
   tool_start: ModToolStartEvent;
+  tool_end: ModToolEndEvent;
   turn_start: ModTurnStartEvent;
   turn_end: ModTurnEndEvent;
 }
@@ -224,6 +239,7 @@ export interface ModEventResultMap {
   conversation_open: undefined;
   conversation_close: undefined;
   tool_start: ModToolStartResult | undefined;
+  tool_end: ModToolEndResult | undefined;
   turn_start: ModTurnStartResult | undefined;
   turn_end: ModTurnEndResult | undefined;
 }

--- a/src/skills/builtin/creating-mods/references/events.md
+++ b/src/skills/builtin/creating-mods/references/events.md
@@ -65,6 +65,7 @@ Lifecycle handlers are notification-only and should not return values. `turn_sta
 "conversation_open"
 "conversation_close"
 "tool_start"
+"tool_end"
 "turn_start"
 ```
 
@@ -137,6 +138,30 @@ letta.events.on("tool_start", (event) => {
 Handlers run in registration order. Later handlers see the current args after earlier mutations/returns. If a handler throws, its partial `event.args` mutation is rolled back and the error is recorded as a mod diagnostic.
 
 `tool_start` is intentionally a trusted local mod point: it can rewrite commands, file paths, and other tool inputs before execution. Keep transforms focused and unsurprising.
+
+`tool_end` event:
+
+```ts
+{
+  agentId: string | null;
+  conversationId: string | null;
+  toolCallId: string | null;
+  toolName: string;
+  status: "success" | "error";
+  output: string;
+}
+```
+
+`tool_end` fires immediately after a tool produces a result, before the agent sees it. Handlers can inspect the result, or return `{ result: { status, output } }` to replace it:
+
+```ts
+letta.events.on("tool_end", (event) => {
+  if (event.toolName !== "Bash" || event.status !== "success") return;
+  return { result: { status: "success", output: redactSecrets(event.output) } };
+});
+```
+
+The first handler that returns a `result` wins; later handlers are shadowed. Only string results are surfaced — multimodal/image results pass through unchanged. `tool_end` is the trusted-local-mod equivalent of the `PostToolUse` / `PostToolUseFailure` hooks for observing and rewriting tool results.
 
 `turn_start` fires before outbound turns that include a user message. In the TUI this includes normal submits and prompt-style command turns. In headless it includes one-shot prompts and bidirectional user turns.
 

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -45,6 +45,7 @@ import {
 import type {
   ModContext,
   ModSecretResolver,
+  ModToolEndEvent,
   ModToolRunContext,
   ModToolStartEvent,
   ToolApprovalPolicy,
@@ -2327,6 +2328,36 @@ async function emitToolStartEvent(options: {
   };
 }
 
+async function emitToolEndEvent(options: {
+  events?: ModEvents;
+  executionScope: RuntimeContextSnapshot;
+  modContext: ModContext;
+  toolCallId?: string;
+  toolName: string;
+  status: "success" | "error";
+  output: string;
+}): Promise<{ status: "success" | "error"; output: string } | undefined> {
+  const event: ModToolEndEvent & {
+    result?: { status: "success" | "error"; output: string };
+  } = {
+    agentId: options.executionScope.agentId ?? null,
+    conversationId: options.executionScope.conversationId ?? null,
+    toolCallId: options.toolCallId ?? null,
+    toolName: options.toolName,
+    status: options.status,
+    output: options.output,
+  };
+
+  try {
+    await emitModEvent(options.events, "tool_end", event, options.modContext);
+  } catch (error) {
+    debugLog("mods", "tool_end event failed", error);
+    return undefined;
+  }
+
+  return event.result;
+}
+
 async function executeModTool(
   toolName: string,
   tool: ModToolDefinition,
@@ -2575,7 +2606,7 @@ function toolExecutionModContext(
  * @param options - Optional execution options (abort signal, tool call ID, streaming callback)
  * @returns Promise with the tool's execution result including status and optional stdout/stderr
  */
-export async function executeTool(
+async function executeToolInner(
   name: string,
   args: ToolArgs,
   options?: {
@@ -3044,6 +3075,64 @@ export async function executeTool(
   };
 
   return runWithRuntimeContext(executionScope, run);
+}
+
+/**
+ * Executes a tool and gives mods a chance to observe or replace the result via
+ * the `tool_end` event. A handler returning `{ result: { status, output } }`
+ * overrides what the agent sees (first handler wins). Only fires for string
+ * results — multimodal/image results pass through unchanged. Delivery is
+ * capability-gated (`events.tools`), so only enabled surfaces receive it.
+ *
+ * @param name - Name of the tool to execute
+ * @param args - Arguments object to pass to the tool
+ * @param options - Optional execution options (abort signal, tool call ID, streaming callback)
+ * @returns Promise with the tool's execution result including status and optional stdout/stderr
+ */
+export async function executeTool(
+  ...params: Parameters<typeof executeToolInner>
+): Promise<ToolExecutionResult> {
+  const [name, args, options] = params;
+  const res = await executeToolInner(name, args, options);
+
+  const context = options?.toolContextId
+    ? getExecutionContextById(options.toolContextId)
+    : undefined;
+  const modEvents = context?.modEvents;
+  if (!modEvents || typeof res.toolReturn !== "string") {
+    return res;
+  }
+
+  const executionScope = context?.runtimeContext
+    ? buildExecutionRuntimeContextSnapshot({
+        workingDirectory: context.runtimeContext.workingDirectory ?? undefined,
+        permissionModeState: context.permissionModeState,
+        runtimeContext: context.runtimeContext,
+      })
+    : buildExecutionRuntimeContextSnapshot({
+        workingDirectory: context?.workingDirectory,
+        permissionModeState: context?.permissionModeState,
+      });
+  const modContext =
+    context?.modContext ??
+    toolExecutionModContext(executionScope, {
+      workingDirectory:
+        executionScope.workingDirectory ?? getCurrentWorkingDirectory(),
+    });
+
+  const override = await emitToolEndEvent({
+    events: modEvents,
+    executionScope,
+    modContext,
+    toolCallId: options?.toolCallId,
+    toolName: name,
+    status: res.status,
+    output: res.toolReturn,
+  });
+
+  return override
+    ? { ...res, toolReturn: override.output, status: override.status }
+    : res;
 }
 
 /**

--- a/src/tools/tool-execution-context.test.ts
+++ b/src/tools/tool-execution-context.test.ts
@@ -32,7 +32,11 @@ import {
   registerModPermission,
 } from "@/mods/permission-registry";
 import { clearModTools, registerModTool } from "@/mods/tool-registry";
-import type { ModDiagnostic, ModToolStartEvent } from "@/mods/types";
+import type {
+  ModDiagnostic,
+  ModToolEndEvent,
+  ModToolStartEvent,
+} from "@/mods/types";
 import {
   LETTA_INHERITED_CHANNEL_CONTEXT_ENV,
   runWithRuntimeContext,
@@ -253,6 +257,55 @@ describe("tool execution context snapshot", () => {
       "mod permission:execution-gate",
     );
     expect(asText(result.toolReturn)).toContain("mutated path blocked");
+  });
+
+  test("applies a tool_end result override to replace the tool result", async () => {
+    await loadSpecificTools(["Read"]);
+
+    const prepared = await prepareCurrentToolExecutionContext({
+      modEvents: {
+        async emit(name, event) {
+          if (name === "tool_end") {
+            (
+              event as ModToolEndEvent & {
+                result?: { status: "success" | "error"; output: string };
+              }
+            ).result = { status: "success", output: "redacted by mod" };
+          }
+          return { diagnostics: [], handlerCount: 0, name, results: [] };
+        },
+      },
+    });
+
+    const result = await executeTool(
+      "Read",
+      { file_path: "README.md" },
+      { toolContextId: prepared.contextId },
+    );
+
+    expect(result.status).toBe("success");
+    expect(asText(result.toolReturn)).toBe("redacted by mod");
+  });
+
+  test("passes the tool result through when no tool_end override", async () => {
+    await loadSpecificTools(["Read"]);
+
+    const prepared = await prepareCurrentToolExecutionContext({
+      modEvents: {
+        async emit(name, _event) {
+          return { diagnostics: [], handlerCount: 0, name, results: [] };
+        },
+      },
+    });
+
+    const result = await executeTool(
+      "Read",
+      { file_path: "README.md" },
+      { toolContextId: prepared.contextId },
+    );
+
+    expect(result.status).toBe("success");
+    expect(asText(result.toolReturn)).not.toBe("redacted by mod");
   });
 
   test("reports execution-phase ask decisions as blocked approval requests", async () => {


### PR DESCRIPTION
## Summary
- Adds a `tool_end` mod event that fires after a tool produces a result, letting trusted local mods observe or **replace** the result by returning `{ result: { status, output } }` (first handler wins).
- Mirrors the existing `tool_start` `result` effect end-to-end (types, engine writeback, emit helper). Gated by the `events.tools` capability, so it delivers on TUI + headless while desktop/listener stays deferred (one-flag flip later), matching `tool_start`.
- Implemented as a thin `executeTool` wrapper around the renamed `executeToolInner` — one emit site covering every result path. Only string results are surfaced; multimodal/image results pass through unchanged.

## Why a wrapper
`executeTool` has ~8 return points (real executions, synthesized results, structural errors). Wrapping the body in a closure would force a ~420-line reindent; renaming to `executeToolInner` + a wrapper keeps the diff additive and gives a single, clean `tool_end` hook.

## Test plan
- [x] `mod-engine` tests: `tool_end` result first-handler-wins; no override when condition not met
- [x] `executeTool` end-to-end: result replaced when a `tool_end` mod returns `{ result }`; passthrough when none
- [x] `npx tsc --noEmit` clean, biome clean, 166 mod/tool tests pass
- [x] Docs: `tool_end` payload + redact-secrets example in the creating-mods events reference

## Out of scope
- Desktop/listener delivery (flip `events.tools`), removing legacy `PostToolUse`/`PostToolUseFailure` hooks, and `compaction_*` events.

👾 Generated with [Letta Code](https://letta.com)