### PR TITLE
fix(mods): decouple panel render from input keystroke churn

### DIFF
--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -1927,6 +1927,20 @@ export function Input({
     previousFooterNotificationRef.current = footerNotification ?? null;
   }, [footerNotification, showStatuslineTransientHint]);
 
+  // Decoupled from input churn (value/cursorPos) so panel content only
+  // re-renders when the panels themselves change, mirroring how BtwPane
+  // stays flash-free. Folding this into lowerPane would rebuild it on every
+  // keystroke.
+  const modPanelRow = useMemo(() => {
+    if (suppressDividers) return null;
+    return (
+      <ModPanelRow
+        panels={modAdapter.registry?.ui.panels}
+        terminalWidth={terminalWidth}
+      />
+    );
+  }, [suppressDividers, modAdapter.registry?.ui.panels, terminalWidth]);
+
   const lowerPane = useMemo(() => {
     return (
       <>
@@ -1937,12 +1951,7 @@ export function Input({
 
         {interactionEnabled ? (
           <Box flexDirection="column">
-            {!suppressDividers && (
-              <ModPanelRow
-                panels={modAdapter.registry?.ui.panels}
-                terminalWidth={terminalWidth}
-              />
-            )}
+            {modPanelRow}
 
             {!suppressDividers && (
               <ProductStatusRow
@@ -2060,6 +2069,7 @@ export function Input({
     );
   }, [
     messageQueue,
+    modPanelRow,
     interactionEnabled,
     isBashMode,
     horizontalLine,


### PR DESCRIPTION
## Summary
- Mod panels (`ModPanelRow`) render inside `InputRich.lowerPane`, whose `useMemo` depends on `value` and `cursorPos`. The pane (and the panel) therefore re-rendered on **every keystroke and cursor move**. Combined with streamed panel content changing height, this caused the flashing/duplication that originally motivated removing panels.
- Extract the panel into its own `useMemo`, keyed only on the panels registry + width (+ `suppressDividers`), so it re-renders only when panel content actually changes — the same property that keeps `BtwPane` flash-free. The stable element reference lets React bail out of re-rendering it on keystrokes.
- No API change, no position change: existing panel mods (e.g. `openPanel`) keep working as-is and simply stop flashing while you type.

## Test plan
- [ ] Build this branch, register a mod that opens a panel and `update()`s it on a timer (streaming content)
- [ ] Type in the input while the panel is updating → panel updates smoothly, no flashing, no duplicated lines
- [ ] Confirm panel still appears/clears correctly on `open`/`close` and is hidden during approvals/selectors

👾 Generated with [Letta Code](https://letta.com)