### PR TITLE
test: align reflection prompt assertion with wc -c transcript read

### DIFF
--- a/src/cli/reflection-transcript.test.ts
+++ b/src/cli/reflection-transcript.test.ts
@@ -821,7 +821,7 @@ describe("reflectionTranscript helper", () => {
     // Prompt references the $TRANSCRIPT_PATH env var (resolved via Bash),
     // not a literal absolute path.
     expect(prompt).toContain("$TRANSCRIPT_PATH");
-    expect(prompt).toContain("cat $TRANSCRIPT_PATH");
+    expect(prompt).toContain('wc -c "$TRANSCRIPT_PATH"');
     expect(prompt).not.toContain("/tmp/transcript");
     expect(prompt).toContain(
       "In-context memory (in the parent agent's system prompt) is stored in the `system/` folder and are rendered in <memory> tags below.",


### PR DESCRIPTION
## Summary
- `#3088` ("fix: clean up tools in buildReflectionSubagentPrompt") changed the reflection prompt to suggest `wc -c "$TRANSCRIPT_PATH"` instead of `cat $TRANSCRIPT_PATH`, but the matching assertion in `reflection-transcript.test.ts` was not updated.
- This left `main` red on the unit suite (`buildReflectionSubagentPrompt uses expanded reflection instructions`), and every branch cut from main inherits the failure.
- One-line fix: update the test assertion to match the current impl. The impl is the intended behavior (`wc -c` avoids dumping a potentially huge transcript), so the test is the stale side.

## Test plan
- [x] `bun test ./src/cli/reflection-transcript.test.ts` → 29 pass, 0 fail

👾 Generated with [Letta Code](https://letta.com)