### PR TITLE
feat(mods): deliver tool_start/tool_end on desktop

### DIFF
--- a/src/websocket/listener/mod-adapter.test.ts
+++ b/src/websocket/listener/mod-adapter.test.ts
@@ -49,7 +49,7 @@ describe("listener mod adapter", () => {
       commands: false,
       events: {
         lifecycle: false,
-        tools: false,
+        tools: true,
         turns: true,
       },
       permissions: false,
@@ -471,6 +471,73 @@ describe("listener mod adapter", () => {
     });
 
     delete (globalThis as { __lettaTurnEndSeen?: unknown }).__lettaTurnEndSeen;
+    adapter.dispose();
+  });
+
+  test("tool_end handlers are delivered and can replace the result", async () => {
+    const root = createTempDir();
+    const modsDir = join(root, "mods");
+    const cacheDir = join(root, "cache");
+    mkdirSync(modsDir, { recursive: true });
+    writeFileSync(
+      join(modsDir, "tool-end-mod.ts"),
+      `export default function activate(letta) {
+        letta.events.on("tool_end", (event) => {
+          globalThis.__lettaToolEndSeen = {
+            toolName: event.toolName,
+            status: event.status,
+            output: event.output,
+          };
+          if (event.toolName === "Bash") {
+            return { result: { status: "success", output: "redacted" } };
+          }
+        });
+      }`,
+    );
+
+    const adapter = createListenerModAdapter({
+      cacheDirectory: cacheDir,
+      globalModsDirectory: modsDir,
+      sessionId: "tool-end-test",
+      workingDirectory: root,
+    });
+    await adapter.reload();
+
+    const context = createListenerModContext({
+      sessionId: "conv-tool-end-test",
+      workingDirectory: root,
+    });
+    const event: {
+      agentId: string;
+      conversationId: string;
+      toolCallId: string;
+      toolName: string;
+      status: "success" | "error";
+      output: string;
+      result?: { status: "success" | "error"; output: string };
+    } = {
+      agentId: "agent-tool-end",
+      conversationId: "conv-tool-end-test",
+      toolCallId: "call-1",
+      toolName: "Bash",
+      status: "success",
+      output: "secret",
+    };
+
+    const result = await adapter.events.emit("tool_end", event, context);
+    expect(result.diagnostics).toHaveLength(0);
+    expect(
+      (globalThis as { __lettaToolEndSeen?: unknown }).__lettaToolEndSeen,
+    ).toEqual({
+      toolName: "Bash",
+      status: "success",
+      output: "secret",
+    });
+    // events.tools is enabled for the listener, so the handler runs and its
+    // result override is written back onto the event (first handler wins).
+    expect(event.result).toEqual({ status: "success", output: "redacted" });
+
+    delete (globalThis as { __lettaToolEndSeen?: unknown }).__lettaToolEndSeen;
     adapter.dispose();
   });
 

--- a/src/websocket/listener/mod-adapter.ts
+++ b/src/websocket/listener/mod-adapter.ts
@@ -11,7 +11,7 @@ export const LISTENER_MOD_CAPABILITIES: ModCapabilities = {
   commands: false,
   events: {
     lifecycle: false,
-    tools: false,
+    tools: true,
     turns: true,
   },
   permissions: false,


### PR DESCRIPTION
## Summary
- Enables the `events.tools` capability on the listener (`LISTENER_MOD_CAPABILITIES`) so **desktop mods receive `tool_start` and `tool_end`**, with their full effects (`tool_start` args/synthesize, `tool_end` result replacement). Brings desktop to parity with TUI + headless.
- The plumbing was already in place: the listener turn threads `modEvents` into the tool execution context (`turn.ts` `prepareToolExecutionContextForScope({ ..., modEvents })`), which flows through `toolset.ts` into the context `executeTool` reads. `turn_start`/`turn_end` already work on the listener via the same handle, so the capability flag was the only gate.

## Changes
- `mod-adapter.ts`: `events.tools` `false → true`.
- `mod-adapter.test.ts`: update the capabilities assertion, and add a test that a listener `tool_end` handler is delivered and its `{ result }` override is applied through the listener path.

## Notes
- No backend changes; no new capability. The earlier deferral was a scoping choice, not a technical blocker.
- External tools are bridged to the controller, but `executeTool` still wraps the bridged call on the listener, so events fire regardless. `tool_end` surfaces string results only (multimodal passes through), identical to TUI/headless.
- Out of scope: lifecycle events on desktop (`events.lifecycle` stays `false`).

## Test plan
- [x] `bun test src/websocket/listener/mod-adapter.test.ts` (11 pass, incl. new tool_end delivery test)
- [x] `bun test src/mods src/tools/tool-execution-context.test.ts` (169 pass)
- [x] `tsc --noEmit` + biome clean

👾 Generated with [Letta Code](https://letta.com)