### PR TITLE
feat(sandbox): add bundled bwrap fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,10 @@ jobs:
         if: steps.detect.outputs.should_publish == 'true'
         run: bun run check
 
+      - name: Install bundled bwrap resources
+        if: steps.detect.outputs.should_publish == 'true'
+        run: bun run prepare:bwrap
+
       - name: Build bundle
         if: steps.detect.outputs.should_publish == 'true'
         run: bun run build

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ node_modules
 bun.lockb
 package-lock.json
 bin/
+/vendor/bwrap/
 letta.js
 letta.js.map
 /skills/

--- a/build.js
+++ b/build.js
@@ -18,6 +18,26 @@ const version = pkg.version;
 const useMagick = Bun.env.USE_MAGICK;
 const features = [];
 
+function readBundledBwrapSha256() {
+  const manifestPath = join(__dirname, "vendor", "bwrap", "manifest.json");
+  if (!existsSync(manifestPath)) return {};
+
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+  const targets = manifest.targets;
+  if (!targets || typeof targets !== "object") return {};
+
+  const hashes = {};
+  for (const [key, target] of Object.entries(targets)) {
+    const sha256 = target?.sha256;
+    if (typeof sha256 === "string" && /^[a-f0-9]{64}$/i.test(sha256)) {
+      hashes[key] = sha256.toLowerCase();
+    }
+  }
+  return hashes;
+}
+
+const bundledBwrapSha256 = readBundledBwrapSha256();
+
 console.log(`📦 Building Letta Code v${version}...`);
 if (useMagick) {
   console.log(`🪄 Using magick variant of imageResize...`);
@@ -37,6 +57,7 @@ await Bun.build({
   define: {
     LETTA_VERSION: JSON.stringify(version),
     BUILD_TIME: JSON.stringify(new Date().toISOString()),
+    __BUNDLED_BWRAP_SHA256__: JSON.stringify(bundledBwrapSha256),
     __USE_MAGICK__: useMagick ? "true" : "false",
   },
   // Load text files as strings (for markdown, etc.)

--- a/package.json
+++ b/package.json
@@ -94,9 +94,10 @@
     "check": "bun run scripts/check.js",
     "dev": "node scripts/dev.cjs",
     "build": "node scripts/postinstall-patches.js && bun run build.js",
+    "prepare:bwrap": "bun run scripts/install-bundled-bwrap.js",
     "test:update-chain:manual": "bun run src/test-utils/update-chain-smoke.ts --mode manual",
     "test:update-chain:startup": "bun run src/test-utils/update-chain-smoke.ts --mode startup",
-    "prepublishOnly": "bun run build",
+    "prepublishOnly": "bun run prepare:bwrap && bun run build",
     "postinstall": "node scripts/postinstall-patches.js || echo letta: vendor patches skipped && node -e \"try{require('fs').chmodSync(require('path').join(require.resolve('node-pty/package.json'),'../prebuilds/darwin-arm64/spawn-helper'),0o755)}catch(e){}\" || true"
   },
   "lint-staged": {

--- a/scripts/install-bundled-bwrap.js
+++ b/scripts/install-bundled-bwrap.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { fileURLToPath } from "node:url";
+
+const CODEX_BWRAP_RELEASE_TAG = "rust-v0.142.1";
+const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const VENDOR_ROOT = join(REPO_ROOT, "vendor", "bwrap");
+const MANIFEST_PATH = join(VENDOR_ROOT, "manifest.json");
+const TARGETS = [
+  {
+    key: "linux-x64",
+    asset: "bwrap-x86_64-unknown-linux-musl.tar.gz",
+    extractedName: "bwrap-x86_64-unknown-linux-musl",
+    expectedSha256:
+      "7df960565a0dece99240ea4b9d0e011307817f9f3b73176c7b71fda44fe84765",
+  },
+  {
+    key: "linux-arm64",
+    asset: "bwrap-aarch64-unknown-linux-musl.tar.gz",
+    extractedName: "bwrap-aarch64-unknown-linux-musl",
+    expectedSha256:
+      "0f543a7356ab343b4827222f910461d4196778f328b28acd6c126ef18e9557ab",
+  },
+];
+
+async function downloadFile(url, dest) {
+  const response = await fetch(url);
+  if (!response.ok || !response.body) {
+    throw new Error(`failed to download ${url}: HTTP ${response.status}`);
+  }
+
+  await pipeline(Readable.fromWeb(response.body), createWriteStream(dest));
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, { stdio: "pipe" });
+  if (!result.error && result.status === 0) return;
+
+  const stderr = result.stderr?.toString().trim();
+  const stdout = result.stdout?.toString().trim();
+  const detail =
+    result.error?.message || stderr || stdout || `exit ${result.status}`;
+  throw new Error(`${command} ${args.join(" ")} failed: ${detail}`);
+}
+
+function sha256File(path) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+async function installTarget(target) {
+  const targetDir = join(VENDOR_ROOT, target.key);
+  mkdirSync(targetDir, { recursive: true });
+
+  const tempDir = await mkdtemp(join(tmpdir(), "letta-bwrap-"));
+  try {
+    const url = `https://github.com/openai/codex/releases/download/${CODEX_BWRAP_RELEASE_TAG}/${target.asset}`;
+    const archivePath = join(tempDir, target.asset);
+    await downloadFile(url, archivePath);
+
+    run("tar", ["xzf", archivePath, "-C", tempDir]);
+
+    const extractedPath = join(tempDir, target.extractedName);
+    if (!existsSync(extractedPath)) {
+      throw new Error(
+        `${target.asset} did not contain expected ${target.extractedName}`,
+      );
+    }
+
+    const actualSha256 = sha256File(extractedPath);
+    if (actualSha256 !== target.expectedSha256) {
+      throw new Error(
+        `${target.asset} SHA-256 mismatch: expected ${target.expectedSha256}, got ${actualSha256}`,
+      );
+    }
+
+    const dest = join(targetDir, "bwrap");
+    rmSync(dest, { force: true });
+    writeFileSync(dest, readFileSync(extractedPath));
+    chmodSync(dest, 0o755);
+
+    return {
+      asset: target.asset,
+      path: `vendor/bwrap/${target.key}/bwrap`,
+      sha256: actualSha256,
+      source: url,
+    };
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  mkdirSync(VENDOR_ROOT, { recursive: true });
+
+  const manifest = {
+    source: `https://github.com/openai/codex/releases/tag/${CODEX_BWRAP_RELEASE_TAG}`,
+    targets: {},
+  };
+
+  for (const target of TARGETS) {
+    const installed = await installTarget(target);
+    manifest.targets[target.key] = installed;
+    console.log(
+      `installed ${basename(installed.path)} for ${target.key} sha256:${installed.sha256}`,
+    );
+  }
+
+  writeFileSync(
+    `${MANIFEST_PATH}.tmp`,
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  rmSync(MANIFEST_PATH, { force: true });
+  writeFileSync(MANIFEST_PATH, readFileSync(`${MANIFEST_PATH}.tmp`));
+  rmSync(`${MANIFEST_PATH}.tmp`, { force: true });
+  console.log(`wrote ${MANIFEST_PATH}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/src/sandbox/availability.test.ts
+++ b/src/sandbox/availability.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { detectSandboxBackend } from "@/sandbox/availability";
+
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function writeFakeBwrap(dir: string, body: string, name = "bwrap"): string {
+  mkdirSync(dir, { recursive: true });
+  const filePath = join(dir, name);
+  writeFileSync(filePath, `#!/bin/sh\n${body}\n`, "utf-8");
+  chmodSync(filePath, 0o755);
+  return filePath;
+}
+
+function successfulBwrapBody(label: string): string {
+  return `if [ "$1" = "--version" ]; then echo "${label}"; exit 0; fi\nexit 0`;
+}
+
+function usernsFailingBwrapBody(label: string): string {
+  return `if [ "$1" = "--version" ]; then echo "${label}"; exit 0; fi\nexit 1`;
+}
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "letta-bwrap-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeBundledBwrap(packageRoot: string, body: string): string {
+  return writeFakeBwrap(
+    join(packageRoot, "vendor", "bwrap", "linux-x64"),
+    body,
+  );
+}
+
+function writeBundledManifest(packageRoot: string, sha256: string): void {
+  const manifestDir = join(packageRoot, "vendor", "bwrap");
+  mkdirSync(manifestDir, { recursive: true });
+  writeFileSync(
+    join(manifestDir, "manifest.json"),
+    JSON.stringify({ targets: { "linux-x64": { sha256 } } }),
+  );
+}
+
+test.skipIf(process.platform === "win32")(
+  "uses LETTA_BWRAP_PATH before system, PATH, or bundled bwrap",
+  () => {
+    const root = makeTempDir();
+    const overrideDir = makeTempDir();
+    const systemDir = makeTempDir();
+    const override = writeFakeBwrap(
+      overrideDir,
+      successfulBwrapBody("override bwrap"),
+    );
+    const system = writeFakeBwrap(
+      systemDir,
+      successfulBwrapBody("system bwrap"),
+    );
+    writeBundledBwrap(root, successfulBwrapBody("bundled bwrap"));
+
+    const result = detectSandboxBackend({
+      platform: "linux",
+      architecture: "x64",
+      env: { LETTA_BWRAP_PATH: override, PATH: "" },
+      systemBwrapPath: system,
+      bundledRoot: root,
+      expectedBundledSha256: sha256Hex(
+        `#!/bin/sh\n${successfulBwrapBody("bundled bwrap")}\n`,
+      ),
+      force: true,
+    });
+
+    expect(result.backend).toBe("bwrap");
+    expect(result.bwrapPath).toBe(override);
+    expect(result.reason).toBe("LETTA_BWRAP_PATH override available");
+  },
+);
+
+test.skipIf(process.platform === "win32")(
+  "prefers the system bwrap path over PATH and bundled resources",
+  () => {
+    const root = makeTempDir();
+    const systemDir = makeTempDir();
+    const pathDir = makeTempDir();
+    const system = writeFakeBwrap(
+      systemDir,
+      successfulBwrapBody("system bwrap"),
+    );
+    writeFakeBwrap(pathDir, successfulBwrapBody("PATH bwrap"));
+    writeBundledBwrap(root, successfulBwrapBody("bundled bwrap"));
+
+    const result = detectSandboxBackend({
+      platform: "linux",
+      architecture: "x64",
+      env: { PATH: pathDir },
+      systemBwrapPath: system,
+      bundledRoot: root,
+      expectedBundledSha256: sha256Hex(
+        `#!/bin/sh\n${successfulBwrapBody("bundled bwrap")}\n`,
+      ),
+      force: true,
+    });
+
+    expect(result.backend).toBe("bwrap");
+    expect(result.bwrapPath).toBe(system);
+    expect(result.reason).toBe("system bwrap available");
+  },
+);
+
+test.skipIf(process.platform === "win32")(
+  "uses PATH bwrap before bundled resources when no system path exists",
+  () => {
+    const root = makeTempDir();
+    const pathDir = makeTempDir();
+    const pathBwrap = writeFakeBwrap(
+      pathDir,
+      successfulBwrapBody("PATH bwrap"),
+    );
+    writeBundledBwrap(root, successfulBwrapBody("bundled bwrap"));
+
+    const result = detectSandboxBackend({
+      platform: "linux",
+      architecture: "x64",
+      env: { PATH: pathDir },
+      systemBwrapPath: null,
+      bundledRoot: root,
+      expectedBundledSha256: sha256Hex(
+        `#!/bin/sh\n${successfulBwrapBody("bundled bwrap")}\n`,
+      ),
+      force: true,
+    });
+
+    expect(result.backend).toBe("bwrap");
+    expect(result.bwrapPath).toBe(pathBwrap);
+    expect(result.reason).toBe("PATH bwrap available");
+  },
+);
+
+test.skipIf(process.platform === "win32")(
+  "falls back to a bundled bwrap when system and PATH bwrap are missing",
+  () => {
+    const root = makeTempDir();
+    const bundledBody = successfulBwrapBody("bundled bwrap");
+    const bundled = writeBundledBwrap(root, bundledBody);
+    writeBundledManifest(root, sha256Hex(`#!/bin/sh\n${bundledBody}\n`));
+
+    const result = detectSandboxBackend({
+      platform: "linux",
+      architecture: "x64",
+      env: { PATH: "" },
+      systemBwrapPath: null,
+      bundledRoot: root,
+      force: true,
+    });
+
+    expect(result.backend).toBe("bwrap");
+    expect(result.bwrapPath).toBe(bundled);
+    expect(result.reason).toBe("bundled bwrap available");
+  },
+);
+
+test.skipIf(process.platform === "win32")(
+  "rejects a bundled bwrap with a mismatched SHA-256",
+  () => {
+    const root = makeTempDir();
+    writeBundledBwrap(root, successfulBwrapBody("bundled bwrap"));
+
+    const result = detectSandboxBackend({
+      platform: "linux",
+      architecture: "x64",
+      env: { PATH: "" },
+      systemBwrapPath: null,
+      bundledRoot: root,
+      expectedBundledSha256: "0".repeat(64),
+      force: true,
+    });
+
+    expect(result.backend).toBeNull();
+    expect(result.reason).toContain("bundled bwrap SHA-256 mismatch");
+  },
+);
+
+test.skipIf(process.platform === "win32")(
+  "does not fall back to bundled bwrap when system bwrap cannot create user namespaces",
+  () => {
+    const root = makeTempDir();
+    const systemDir = makeTempDir();
+    const system = writeFakeBwrap(
+      systemDir,
+      usernsFailingBwrapBody("system bwrap"),
+    );
+    const bundledBody = successfulBwrapBody("bundled bwrap");
+    writeBundledBwrap(root, bundledBody);
+
+    const result = detectSandboxBackend({
+      platform: "linux",
+      architecture: "x64",
+      env: { PATH: "" },
+      systemBwrapPath: system,
+      bundledRoot: root,
+      expectedBundledSha256: sha256Hex(`#!/bin/sh\n${bundledBody}\n`),
+      force: true,
+    });
+
+    expect(result.backend).toBeNull();
+    expect(result.reason).toBe(
+      "system bwrap present but user namespaces are unavailable",
+    );
+  },
+);

--- a/src/sandbox/availability.ts
+++ b/src/sandbox/availability.ts
@@ -1,6 +1,9 @@
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { delimiter, isAbsolute, join } from "node:path";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { arch } from "node:os";
+import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { SandboxBackend } from "./policy.js";
 import { SANDBOX_EXEC_PATH } from "./seatbelt.js";
 
@@ -16,9 +19,32 @@ export interface SandboxAvailability {
 export interface DetectOptions {
   /** Override the platform (for tests). Defaults to `process.platform`. */
   platform?: NodeJS.Platform;
+  /** Override the CPU architecture (for tests). Defaults to `process.arch`. */
+  architecture?: string;
+  /** Override env lookup (for tests / CI). Defaults to `process.env`. */
+  env?: NodeJS.ProcessEnv;
+  /** Override the standard system bwrap path (for tests). */
+  systemBwrapPath?: string | null;
+  /** Override the package root used for bundled resource lookup (for tests). */
+  bundledRoot?: string | null;
+  /** Override the expected bundled bwrap SHA-256 (for tests). */
+  expectedBundledSha256?: string | null;
   /** Bypass the module-level cache (for tests / re-probing). */
   force?: boolean;
 }
+
+declare const __BUNDLED_BWRAP_SHA256__: Record<string, string> | undefined;
+
+const BWRAP_OVERRIDE_ENV = "LETTA_BWRAP_PATH";
+const SYSTEM_BWRAP_PATH = "/usr/bin/bwrap";
+const BUNDLED_BWRAP_RESOURCE_DIR = join("vendor", "bwrap");
+const BUNDLED_BWRAP_MANIFEST = "manifest.json";
+const SHA256_HEX_RE = /^[a-f0-9]{64}$/i;
+
+const BUNDLED_BWRAP_SHA256: Record<string, string | undefined> =
+  typeof __BUNDLED_BWRAP_SHA256__ === "object" && __BUNDLED_BWRAP_SHA256__
+    ? __BUNDLED_BWRAP_SHA256__
+    : {};
 
 let cached: SandboxAvailability | null = null;
 const warnedUnavailableContexts = new Set<string>();
@@ -32,14 +58,22 @@ export function detectSandboxBackend(
   options: DetectOptions = {},
 ): SandboxAvailability {
   const platform = options.platform ?? process.platform;
+  const cacheable =
+    !options.force &&
+    !options.platform &&
+    !options.architecture &&
+    !options.env &&
+    options.systemBwrapPath === undefined &&
+    options.bundledRoot === undefined &&
+    options.expectedBundledSha256 === undefined;
 
-  if (!options.force && cached && !options.platform) {
+  if (cacheable && cached) {
     return cached;
   }
 
-  const result = probe(platform);
+  const result = probe(platform, options);
 
-  if (!options.platform) {
+  if (cacheable) {
     cached = result;
   }
   return result;
@@ -89,7 +123,10 @@ export function warnSandboxBackendUnavailable(
   );
 }
 
-function probe(platform: NodeJS.Platform): SandboxAvailability {
+function probe(
+  platform: NodeJS.Platform,
+  options: DetectOptions,
+): SandboxAvailability {
   if (platform === "darwin") {
     if (existsSync(SANDBOX_EXEC_PATH)) {
       return { backend: "seatbelt", reason: "sandbox-exec available" };
@@ -101,7 +138,7 @@ function probe(platform: NodeJS.Platform): SandboxAvailability {
   }
 
   if (platform === "linux") {
-    return probeBwrap();
+    return probeBwrap(options);
   }
 
   return {
@@ -110,45 +147,180 @@ function probe(platform: NodeJS.Platform): SandboxAvailability {
   };
 }
 
-function probeBwrap(): SandboxAvailability {
-  // `bwrap` must exist on PATH (a bundled fallback can be wired in later).
-  const bwrapPath = resolveExecutableOnPath("bwrap");
-  if (!bwrapPath) {
-    return { backend: null, reason: "bwrap not found on PATH" };
+function probeBwrap(options: DetectOptions): SandboxAvailability {
+  const env = options.env ?? process.env;
+  const override = env[BWRAP_OVERRIDE_ENV]?.trim();
+  if (override) {
+    const overridePath = resolveExecutable(override, env.PATH);
+    if (!overridePath) {
+      return {
+        backend: null,
+        reason: `${BWRAP_OVERRIDE_ENV}=${override} was not found`,
+      };
+    }
+    return validateBwrapPath(overridePath, "LETTA_BWRAP_PATH override");
   }
 
-  const version = spawnSync(bwrapPath, ["--version"], { timeout: 5000 });
+  const systemBwrapPath = options.systemBwrapPath ?? SYSTEM_BWRAP_PATH;
+  if (systemBwrapPath && existsSync(systemBwrapPath)) {
+    return validateBwrapPath(systemBwrapPath, "system bwrap");
+  }
+
+  const pathBwrap = resolveExecutableOnPath("bwrap", env.PATH, systemBwrapPath);
+  if (pathBwrap) {
+    return validateBwrapPath(pathBwrap, "PATH bwrap");
+  }
+
+  const bundledBwrap = resolveBundledBwrapPath(options);
+  if (bundledBwrap) {
+    const verification = verifyBundledBwrapDigest(bundledBwrap, options);
+    if (verification) {
+      return { backend: null, reason: verification };
+    }
+    return validateBwrapPath(bundledBwrap, "bundled bwrap");
+  }
+
+  return {
+    backend: null,
+    reason: "bwrap not found on /usr/bin, PATH, or bundled resources",
+  };
+}
+
+function validateBwrapPath(path: string, source: string): SandboxAvailability {
+  const version = spawnSync(path, ["--version"], { timeout: 5000 });
   if (version.error || version.status !== 0) {
-    return { backend: null, reason: "bwrap not found on PATH" };
+    return { backend: null, reason: `${source} failed --version` };
   }
 
   // Confirm unprivileged user namespaces actually work (they don't in WSL1 or
   // some hardened/container hosts). A read-only root + /bin/true is the
-  // cheapest mount that exercises the namespace machinery.
+  // cheapest mount that exercises the namespace machinery. A bundled binary can
+  // replace a missing executable, but it cannot fix host userns policy.
   const userns = spawnSync(
-    bwrapPath,
+    path,
     ["--ro-bind", "/", "/", "--unshare-user", "/bin/true"],
     { timeout: 5000 },
   );
   if (userns.error || userns.status !== 0) {
     return {
       backend: null,
-      reason: "bwrap present but user namespaces are unavailable",
+      reason: `${source} present but user namespaces are unavailable`,
     };
   }
 
-  return { backend: "bwrap", bwrapPath, reason: "bwrap available" };
+  return { backend: "bwrap", bwrapPath: path, reason: `${source} available` };
+}
+
+function resolveExecutable(
+  executable: string,
+  envPath: string | undefined,
+): string | null {
+  if (isAbsolute(executable)) return existsSync(executable) ? executable : null;
+  if (executable.includes("/")) {
+    const candidate = resolve(executable);
+    return existsSync(candidate) ? candidate : null;
+  }
+  return resolveExecutableOnPath(executable, envPath);
 }
 
 function resolveExecutableOnPath(
   executable: string,
   envPath: string | undefined = process.env.PATH,
+  skipPath: string | null = null,
 ): string | null {
-  if (isAbsolute(executable) && existsSync(executable)) return executable;
   for (const dir of (envPath ?? "").split(delimiter)) {
-    if (!dir) continue;
+    if (!dir || !isAbsolute(dir)) continue;
     const candidate = join(dir, executable);
+    if (candidate === skipPath) continue;
     if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function resolveBundledBwrapPath(options: DetectOptions): string | null {
+  const packageRoot = options.bundledRoot ?? findPackageRoot();
+  if (!packageRoot) return null;
+
+  const key = bundledBwrapKey(options.architecture ?? arch());
+  if (!key) return null;
+
+  const candidate = join(packageRoot, BUNDLED_BWRAP_RESOURCE_DIR, key, "bwrap");
+  return existsSync(candidate) ? candidate : null;
+}
+
+function bundledBwrapKey(architecture: string): string | null {
+  switch (architecture) {
+    case "arm64":
+      return "linux-arm64";
+    case "x64":
+      return "linux-x64";
+    default:
+      return null;
+  }
+}
+
+function findPackageRoot(): string | null {
+  let current = dirname(fileURLToPath(import.meta.url));
+  while (true) {
+    const packageJsonPath = join(current, "package.json");
+    if (existsSync(packageJsonPath)) {
+      try {
+        const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+        if (packageJson?.name === "@letta-ai/letta-code") return current;
+      } catch {
+        // Keep walking; this may be an unrelated package.json.
+      }
+    }
+
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function readBundledBwrapManifestSha256(
+  key: string,
+  options: DetectOptions,
+): string | null {
+  const packageRoot = options.bundledRoot ?? findPackageRoot();
+  if (!packageRoot) return null;
+
+  const manifestPath = join(
+    packageRoot,
+    BUNDLED_BWRAP_RESOURCE_DIR,
+    BUNDLED_BWRAP_MANIFEST,
+  );
+  if (!existsSync(manifestPath)) return null;
+
+  try {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+    const sha256 = manifest?.targets?.[key]?.sha256;
+    return typeof sha256 === "string" ? sha256 : null;
+  } catch {
+    return null;
+  }
+}
+
+function verifyBundledBwrapDigest(
+  path: string,
+  options: DetectOptions,
+): string | null {
+  const key = bundledBwrapKey(options.architecture ?? arch());
+  const expected =
+    options.expectedBundledSha256 ??
+    (key &&
+      (BUNDLED_BWRAP_SHA256[key] ??
+        readBundledBwrapManifestSha256(key, options)));
+  if (!expected) {
+    return "bundled bwrap SHA-256 is not configured";
+  }
+  if (!SHA256_HEX_RE.test(expected)) {
+    return "bundled bwrap SHA-256 is invalid";
+  }
+
+  const actual = createHash("sha256").update(readFileSync(path)).digest("hex");
+  if (actual !== expected.toLowerCase()) {
+    return `bundled bwrap SHA-256 mismatch: expected ${expected.toLowerCase()}, got ${actual}`;
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- Add Linux bwrap discovery that prefers `LETTA_BWRAP_PATH`, then system `/usr/bin/bwrap`, then PATH, and only then a verified bundled fallback.
- Add a release/prepublish installer that downloads pinned Codex bwrap artifacts into `vendor/bwrap` and embeds their SHA-256s during the build.
- Keep the user-namespace probe for every bwrap source so bundled bwrap does not hide unsupported kernels/containers.

## Test plan
- [x] `bun test src/sandbox/availability.test.ts src/sandbox/wrap.test.ts src/sandbox/bwrap.test.ts`
- [x] `bun run check`
- [x] `bun run prepare:bwrap && bun run build && npm pack --dry-run --json` includes `vendor/bwrap/linux-arm64/bwrap`, `vendor/bwrap/linux-x64/bwrap`, and `vendor/bwrap/manifest.json`
- [ ] Linux live fallback smoke on a host without `/usr/bin/bwrap` (not run locally; Docker CLI exists but daemon is not running)

👾 Generated with [Letta Code](https://letta.com)