### PR TITLE
fix(listener): fall back to boot dir when persisted cwd is deleted

### DIFF
--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -3722,6 +3722,49 @@ describe("listen-client permission mode scope keys", () => {
   });
 });
 
+describe("listen-client conversation working directory", () => {
+  test("falls back to boot dir and prunes a stale (deleted) persisted cwd", async () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const scopeKey = "agent:agent-123::conversation:default";
+
+    // Simulate a worktree dir that was persisted, then cleaned up.
+    const staleDir = await mkdtemp(join(os.tmpdir(), "ws-stale-cwd-"));
+    listener.workingDirectoryByConversation.set(scopeKey, staleDir);
+    await rm(staleDir, { recursive: true, force: true });
+
+    const resolved = __listenClientTestUtils.getConversationWorkingDirectory(
+      listener,
+      "agent-123",
+      "default",
+    );
+
+    expect(resolved).toBe(listener.bootWorkingDirectory);
+    // The dead entry should be pruned so it isn't served again.
+    expect(listener.workingDirectoryByConversation.has(scopeKey)).toBe(false);
+  });
+
+  test("returns a persisted cwd that still exists", async () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const scopeKey = "agent:agent-123::conversation:default";
+
+    const liveDir = await mkdtemp(join(os.tmpdir(), "ws-live-cwd-"));
+    try {
+      listener.workingDirectoryByConversation.set(scopeKey, liveDir);
+
+      const resolved = __listenClientTestUtils.getConversationWorkingDirectory(
+        listener,
+        "agent-123",
+        "default",
+      );
+
+      expect(resolved).toBe(liveDir);
+      expect(listener.workingDirectoryByConversation.has(scopeKey)).toBe(true);
+    } finally {
+      await rm(liveDir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("listen-client approval resolver wiring", () => {
   test("resolved approvals do not project WAITING_ON_INPUT while the enclosing turn is still processing", () => {
     const runtime = __listenClientTestUtils.createRuntime();
@@ -4724,32 +4767,39 @@ describe("listen-client v2 status builders", () => {
     expect(runtime.recoveredApprovalState).toBeNull();
   });
 
-  test("scopes working directory to requested agent and conversation", () => {
+  test("scopes working directory to requested agent and conversation", async () => {
     const runtime = __listenClientTestUtils.createRuntime();
-    __listenClientTestUtils.setConversationWorkingDirectory(
-      runtime,
-      "agent-a",
-      "conv-a",
-      "/repo/a",
-    );
-    __listenClientTestUtils.setConversationWorkingDirectory(
-      runtime,
-      "agent-b",
-      "default",
-      "/repo/b",
-    );
+    const repoA = await mkdtemp(join(os.tmpdir(), "ws-scope-cwd-a-"));
+    const repoB = await mkdtemp(join(os.tmpdir(), "ws-scope-cwd-b-"));
+    try {
+      __listenClientTestUtils.setConversationWorkingDirectory(
+        runtime,
+        "agent-a",
+        "conv-a",
+        repoA,
+      );
+      __listenClientTestUtils.setConversationWorkingDirectory(
+        runtime,
+        "agent-b",
+        "default",
+        repoB,
+      );
 
-    const activeStatus = __listenClientTestUtils.buildDeviceStatus(runtime, {
-      agent_id: "agent-a",
-      conversation_id: "conv-a",
-    });
-    expect(activeStatus.current_working_directory).toBe("/repo/a");
+      const activeStatus = __listenClientTestUtils.buildDeviceStatus(runtime, {
+        agent_id: "agent-a",
+        conversation_id: "conv-a",
+      });
+      expect(activeStatus.current_working_directory).toBe(repoA);
 
-    const defaultStatus = __listenClientTestUtils.buildDeviceStatus(runtime, {
-      agent_id: "agent-b",
-      conversation_id: "default",
-    });
-    expect(defaultStatus.current_working_directory).toBe("/repo/b");
+      const defaultStatus = __listenClientTestUtils.buildDeviceStatus(runtime, {
+        agent_id: "agent-b",
+        conversation_id: "default",
+      });
+      expect(defaultStatus.current_working_directory).toBe(repoB);
+    } finally {
+      await rm(repoA, { recursive: true, force: true });
+      await rm(repoB, { recursive: true, force: true });
+    }
   });
 
   test("scoped loop status is not suppressed just because another conversation is processing", () => {

--- a/src/websocket/listener/cwd.ts
+++ b/src/websocket/listener/cwd.ts
@@ -1,3 +1,4 @@
+import { existsSync, statSync } from "node:fs";
 import path from "node:path";
 import { loadRemoteSettings, saveRemoteSettings } from "./remote-settings";
 import { normalizeConversationId, normalizeCwdAgentId } from "./scope";
@@ -16,16 +17,37 @@ export function getWorkingDirectoryScopeKey(
   return `conversation:${normalizedConversationId}`;
 }
 
+/** True when the path exists and is a directory. */
+function isUsableDirectory(dirPath: string): boolean {
+  try {
+    return existsSync(dirPath) && statSync(dirPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 export function getConversationWorkingDirectory(
   runtime: ListenerRuntime,
   agentId?: string | null,
   conversationId?: string | null,
 ): string {
   const scopeKey = getWorkingDirectoryScopeKey(agentId, conversationId);
-  return (
-    runtime.workingDirectoryByConversation.get(scopeKey) ??
-    runtime.bootWorkingDirectory
-  );
+  const stored = runtime.workingDirectoryByConversation.get(scopeKey);
+  if (stored === undefined) {
+    return runtime.bootWorkingDirectory;
+  }
+
+  // A persisted cwd can become stale if its directory was deleted (e.g. a
+  // worktree that was cleaned up). Serving it would throw ENOENT on realpath
+  // /process.chdir. Fall back to the boot dir and prune the dead entry so we
+  // don't repeatedly serve it.
+  if (!isUsableDirectory(stored)) {
+    runtime.workingDirectoryByConversation.delete(scopeKey);
+    persistCwdMap(runtime.workingDirectoryByConversation);
+    return runtime.bootWorkingDirectory;
+  }
+
+  return stored;
 }
 
 /**


### PR DESCRIPTION
## Summary
- A persisted conversation cwd (e.g. a git worktree) can be cleaned up mid-session. The load-time validation in `remote-settings.ts` only runs once at process startup (cached), so a dir deleted while the listener is running stays in the in-memory `cwdMap` and gets served as the default cwd on the next conversation — throwing `ENOENT` on `realpath`/`process.chdir` and surfacing as a working-directory error banner.
- `getConversationWorkingDirectory` now validates the stored dir at **read time** and falls back to `bootWorkingDirectory` (pruning the dead entry) when it no longer exists or is not a directory.
- This is filesystem-local, so it also correctly handles foreign paths persisted on another device (`cwdMap` lives in `~/.letta/remote-settings.json` and is per-device): a path that does not exist locally falls back to that device’s own boot dir.

## Root cause
The only existing prune of `cwdMap` was startup-time (`loadRemoteSettings`, `existsSync` filter). Worktree removal during a live session had no hook into the in-memory map, so the stale path survived until the next process restart.

## Test plan
- [x] New test: stale (deleted) persisted cwd → falls back to boot dir and prunes the entry
- [x] New test: live persisted cwd → returned as-is, entry retained
- [x] Updated pre-existing scoping test to use real temp dirs (fake `/repo/a` paths now fail the existence check by design)
- [x] `bun test src/websocket/listen-client-protocol.test.ts` → 168 pass
- [x] All listener tests pass (`bun test src/websocket/listener/`)
- [x] `tsc --noEmit` clean

👾 Generated with [Letta Code](https://letta.com)