### PR TITLE
fix(tools): allow omitted AskUserQuestion multiSelect

### DIFF
--- a/src/tools/impl/ask-user-question.test.ts
+++ b/src/tools/impl/ask-user-question.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { ask_user_question } from "./ask-user-question";
+
+describe("ask_user_question", () => {
+  const baseQuestion = {
+    question: "Which approach should we use?",
+    header: "Approach",
+    options: [
+      {
+        label: "Recommended",
+        description: "Use the recommended approach",
+      },
+      {
+        label: "Alternative",
+        description: "Use the alternative approach",
+      },
+    ],
+  };
+
+  test("defaults missing multiSelect to single-select for answered questions", async () => {
+    const result = await ask_user_question({
+      questions: [baseQuestion],
+      answers: {
+        "Which approach should we use?": "Recommended",
+      },
+    });
+
+    expect(result.message).toBe(
+      'User has answered your questions: "Which approach should we use?"="Recommended". You can now continue with the user\'s answers in mind.',
+    );
+  });
+
+  test("rejects non-boolean multiSelect values", async () => {
+    await expect(
+      ask_user_question({
+        questions: [
+          {
+            ...baseQuestion,
+            multiSelect: "false" as never,
+          },
+        ],
+      }),
+    ).rejects.toThrow("Each question's multiSelect must be a boolean");
+  });
+});

--- a/src/tools/impl/ask-user-question.ts
+++ b/src/tools/impl/ask-user-question.ts
@@ -9,7 +9,7 @@ interface Question {
   question: string;
   header: string;
   options: QuestionOption[];
-  multiSelect: boolean;
+  multiSelect?: boolean;
 }
 
 interface AskUserQuestionArgs {
@@ -48,8 +48,8 @@ export async function ask_user_question(
     ) {
       throw new Error("Each question must have 2-4 options");
     }
-    if (typeof q.multiSelect !== "boolean") {
-      throw new Error("Each question must have a multiSelect boolean");
+    if (q.multiSelect !== undefined && typeof q.multiSelect !== "boolean") {
+      throw new Error("Each question's multiSelect must be a boolean");
     }
     for (const opt of q.options) {
       if (!opt.label || typeof opt.label !== "string") {

--- a/src/tools/schemas/AskUserQuestion.json
+++ b/src/tools/schemas/AskUserQuestion.json
@@ -41,7 +41,7 @@
             "description": "Set to true to allow the user to select multiple options instead of just one. Use when choices are not mutually exclusive."
           }
         },
-        "required": ["question", "header", "options", "multiSelect"],
+        "required": ["question", "header", "options"],
         "additionalProperties": false
       },
       "minItems": 1,


### PR DESCRIPTION
## Summary
- Treat omitted `AskUserQuestion` question-level `multiSelect` as the schema default (`false`) instead of a validation error.
- Remove `multiSelect` from the schema required list while preserving boolean validation when present.
- Add regression coverage for answered question payloads missing `multiSelect`.

## Why
Models have emitted AskUserQuestion calls without `multiSelect`. The UI can collect an answer, but tool execution then rejected the answered payload with `Each question must have a multiSelect boolean`, discarding the user response.

## Test plan
- `bun test src/tools/impl/ask-user-question.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run check`

👾 Generated with [Letta Code](https://letta.com)