### PR TITLE
feat(mods): replace statusline API with signed-order panels

### DIFF
--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -18,6 +18,7 @@ import type { ModelReasoningEffort } from "@/agent/model";
 import { LETTA_CLOUD_API_URL } from "@/auth/oauth";
 import { buildStatuslineRenderContext } from "@/cli/display/statusline/context";
 import { shouldRenderDefaultStatuslineRenderer } from "@/cli/display/statusline/default-renderer-activation";
+import { truncateToWidth } from "@/cli/display/statusline/formatting";
 import {
   DEFAULT_STATUSLINE_RENDERER_ID,
   getBuiltinStatuslineRenderer,
@@ -34,22 +35,23 @@ import type { StatusLinePayload } from "@/cli/helpers/status-line-payload";
 import { getRandomThinkingTip } from "@/cli/helpers/thinking-messages";
 import { useShimmerAnimation } from "@/cli/hooks/use-shimmer-animation";
 import { useTokenSmoothing } from "@/cli/hooks/use-token-smoothing";
-import { evaluateLocalModStatuses } from "@/cli/mods/local-mod-loader";
 import type { LocalModAdapter } from "@/cli/mods/use-local-mod-adapter";
 import {
   ELAPSED_DISPLAY_THRESHOLD_MS,
   TOKEN_DISPLAY_THRESHOLD,
 } from "@/constants";
-import { attachDeprecatedGetContextTrap } from "@/mods/deprecated-api";
 import type { PermissionMode } from "@/permissions/mode";
 import { permissionMode } from "@/permissions/mode";
 import { OPENAI_CODEX_PROVIDER_NAME } from "@/providers/openai-codex-provider";
 import { settingsManager } from "@/settings-manager";
-import { debugLog } from "@/utils/debug";
 import type { QueuedMessage } from "@/utils/message-queue-bridge";
 import { colors } from "./colors";
 import { InputAssist } from "./InputAssist";
-import { ModPanelRow } from "./ModPanelRow";
+import {
+  type ModPanelLiveContext,
+  ModPanelRow,
+  renderModPanelLines,
+} from "./ModPanelRow";
 import { PasteAwareTextInput } from "./PasteAwareTextInput";
 import { ProductStatusRow } from "./ProductStatusRow";
 import { QueuedMessages } from "./QueuedMessages";
@@ -487,7 +489,7 @@ const StatuslineSlot = memo(function StatuslineSlot({
     escapePressed,
   });
 
-  const baseStatuslineContext = buildStatuslineRenderContext({
+  const statuslineContext = buildStatuslineRenderContext({
     payload: statusLinePayload,
     ui: {
       currentModelProvider: currentModelProvider ?? null,
@@ -499,52 +501,41 @@ const StatuslineSlot = memo(function StatuslineSlot({
       rightColumnWidth,
     },
   });
-  const statuslineContext = {
-    ...baseStatuslineContext,
-    statuses: evaluateLocalModStatuses(
-      modAdapter.registry,
-      baseStatuslineContext,
-    ),
-  };
 
   const builtInStatuslineRenderer = getBuiltinStatuslineRenderer(
     DEFAULT_STATUSLINE_RENDERER_ID,
   );
-  const localStatuslineRenderer =
-    modAdapter.registry?.ui.statuslineRenderer ?? null;
-  const modStatuslineLoading =
+
+  // The order-0 "primary" panel overrides the built-in agent · model line.
+  const panels = modAdapter.registry?.ui.panels ?? {};
+  const primaryPanel = Object.values(panels)
+    .filter((panel) => panel.order === 0)
+    .sort((a, b) => b.updatedAt - a.updatedAt)[0];
+  const modPanelsLoading =
     modAdapter.isLoading &&
-    (modAdapter.hasModSources || modAdapter.hadStatuslineRenderer);
-  const customStatuslineActive = Boolean(
-    localStatuslineRenderer || modStatuslineLoading,
-  );
+    (modAdapter.hasModSources || modAdapter.hadModPanels);
+  const customStatuslineActive = Boolean(primaryPanel || modPanelsLoading);
   const idleSlotAvailable = !hideFooterContent && !preemption && !transientHint;
 
-  if (idleSlotAvailable && localStatuslineRenderer) {
-    try {
-      return localStatuslineRenderer.render(
-        attachDeprecatedGetContextTrap(
-          statuslineContext,
-          modAdapter.registry?.ui.statuslineRecordDiagnostic,
-          "ctx.getContext",
-        ),
-      );
-    } catch (error) {
-      modAdapter.registry?.ui.statuslineRecordDiagnostic?.({
-        capability: { id: localStatuslineRenderer.id, kind: "statusline" },
-        error: error instanceof Error ? error : new Error(String(error)),
-        phase: "statusline.render",
-      });
-      debugLog(
-        "mods",
-        "statusline renderer %s failed: %s",
-        localStatuslineRenderer.id,
-        error instanceof Error ? error.message : String(error),
+  if (idleSlotAvailable && primaryPanel) {
+    const rowWidth = Math.max(0, (statuslineContext.terminalWidth ?? 0) - 1);
+    const lines = renderModPanelLines(primaryPanel, rowWidth, {
+      agent: statuslineContext.agent,
+      model: statuslineContext.model,
+    });
+    if (lines.length > 0) {
+      return (
+        <Box flexDirection="column">
+          {lines.map((line, index) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: panel content is caller-owned text
+            <Text key={index}>{truncateToWidth(line || " ", rowWidth)}</Text>
+          ))}
+        </Box>
       );
     }
   }
 
-  if (idleSlotAvailable && modStatuslineLoading) {
+  if (idleSlotAvailable && modPanelsLoading) {
     return <BlankStatuslineRow rightColumnWidth={rightColumnWidth} />;
   }
 
@@ -1931,15 +1922,52 @@ export function Input({
   // re-renders when the panels themselves change, mirroring how BtwPane
   // stays flash-free. Folding this into lowerPane would rebuild it on every
   // keystroke.
+  const panelLiveContext = useMemo<ModPanelLiveContext>(
+    () => ({
+      agent: statusLinePayload.agent,
+      model: {
+        id: statusLinePayload.model.id,
+        displayName: statusLinePayload.model.display_name,
+        provider: currentModelProvider ?? null,
+        reasoningEffort: statusLinePayload.reasoning_effort,
+      },
+    }),
+    [statusLinePayload, currentModelProvider],
+  );
+
   const modPanelRow = useMemo(() => {
     if (suppressDividers) return null;
     return (
       <ModPanelRow
         panels={modAdapter.registry?.ui.panels}
         terminalWidth={terminalWidth}
+        placement="above"
+        context={panelLiveContext}
       />
     );
-  }, [suppressDividers, modAdapter.registry?.ui.panels, terminalWidth]);
+  }, [
+    suppressDividers,
+    modAdapter.registry?.ui.panels,
+    terminalWidth,
+    panelLiveContext,
+  ]);
+
+  const modPanelRowBelow = useMemo(() => {
+    if (suppressDividers) return null;
+    return (
+      <ModPanelRow
+        panels={modAdapter.registry?.ui.panels}
+        terminalWidth={terminalWidth}
+        placement="below"
+        context={panelLiveContext}
+      />
+    );
+  }, [
+    suppressDividers,
+    modAdapter.registry?.ui.panels,
+    terminalWidth,
+    panelLiveContext,
+  ]);
 
   const lowerPane = useMemo(() => {
     return (
@@ -2061,6 +2089,8 @@ export function Input({
                 transientHint={statuslineTransientHint}
               />
             )}
+
+            {!suppressDividers && modPanelRowBelow}
           </Box>
         ) : reserveInputSpace ? (
           <Box height={inputChromeHeight} />
@@ -2070,6 +2100,7 @@ export function Input({
   }, [
     messageQueue,
     modPanelRow,
+    modPanelRowBelow,
     interactionEnabled,
     isBashMode,
     horizontalLine,

--- a/src/cli/components/ModPanelRow.tsx
+++ b/src/cli/components/ModPanelRow.tsx
@@ -1,40 +1,77 @@
+import chalk from "chalk";
 import { Box } from "ink";
-import { truncateText } from "@/cli/helpers/truncate-text";
-import type { ModPanel } from "@/cli/mods/types";
+import {
+  columns,
+  row,
+  truncateToWidth,
+} from "@/cli/display/statusline/formatting";
+import type { ModPanel, ModPanelRenderContext } from "@/cli/mods/types";
+import type { ModAgentContext, ModModelContext } from "@/mods/types";
 import { Text } from "./Text";
 
 const MAX_MOD_PANEL_LINES = 8;
 
-function visiblePanels(panels: Record<string, ModPanel>): ModPanel[] {
-  return Object.values(panels).sort(
-    (a, b) => a.order - b.order || b.updatedAt - a.updatedAt,
-  );
+/** Live values supplied to panel renders (agent/model), filled in per frame. */
+export interface ModPanelLiveContext {
+  agent: ModAgentContext;
+  model: ModModelContext;
 }
 
-function renderPanelLines(panel: ModPanel, width: number): string[] {
+export type ModPanelPlacement = "above" | "below";
+
+function placedPanels(
+  panels: Record<string, ModPanel>,
+  placement: ModPanelPlacement,
+): ModPanel[] {
+  return Object.values(panels)
+    .filter((panel) =>
+      placement === "above" ? panel.order > 0 : panel.order < 0,
+    )
+    .sort((a, b) => b.order - a.order || b.updatedAt - a.updatedAt);
+}
+
+export function renderModPanelLines(
+  panel: ModPanel,
+  width: number,
+  live: ModPanelLiveContext,
+): string[] {
   let result: string | string[];
   try {
-    result = panel.render({ width });
+    const context: ModPanelRenderContext = {
+      width,
+      agent: live.agent,
+      model: live.model,
+      row,
+      columns,
+      chalk,
+    };
+    result = panel.render(context);
   } catch {
     // A mod's render fn runs inside the input render; never let it crash the UI.
     return [];
   }
   const lines = Array.isArray(result) ? result : String(result).split("\n");
+  // An empty render hides the panel entirely (no blank row).
+  if (lines.every((line) => line.trim().length === 0)) return [];
   return lines.map(String);
 }
 
 export function ModPanelRow({
   panels,
   terminalWidth,
+  placement,
+  context,
 }: {
   panels?: Record<string, ModPanel>;
   terminalWidth: number;
+  placement: ModPanelPlacement;
+  context: ModPanelLiveContext;
 }) {
   const rowWidth = Math.max(0, terminalWidth - 1);
   if (rowWidth === 0) return null;
 
-  const lines = visiblePanels(panels ?? {})
-    .flatMap((panel) => renderPanelLines(panel, rowWidth))
+  const lines = placedPanels(panels ?? {}, placement)
+    .flatMap((panel) => renderModPanelLines(panel, rowWidth, context))
     .slice(0, MAX_MOD_PANEL_LINES);
   if (lines.length === 0) return null;
 
@@ -42,7 +79,7 @@ export function ModPanelRow({
     <Box width={rowWidth} flexDirection="column">
       {lines.map((line, index) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: panel content is caller-owned text
-        <Text key={index}>{truncateText(line || " ", rowWidth)}</Text>
+        <Text key={index}>{truncateToWidth(line || " ", rowWidth)}</Text>
       ))}
     </Box>
   );

--- a/src/cli/display/statusline/formatting.ts
+++ b/src/cli/display/statusline/formatting.ts
@@ -1,3 +1,5 @@
+import stripAnsi from "strip-ansi";
+
 export function truncateStatuslineText(
   value: string,
   maxChars: number,
@@ -6,4 +8,65 @@ export function truncateStatuslineText(
   if (value.length <= maxChars) return value;
   if (maxChars <= 3) return value.slice(0, maxChars);
   return `${value.slice(0, maxChars - 3)}...`;
+}
+
+/**
+ * Visible width of a string, ignoring ANSI escape codes (colors, OSC 8 links).
+ * Counts code points rather than UTF-16 units so most emoji count as 1; this
+ * is an approximation (no wide-char/grapheme awareness) but matches how the
+ * statusline historically measured text.
+ */
+export function visibleWidth(value: string): number {
+  return [...stripAnsi(value)].length;
+}
+
+/**
+ * Truncate to a visible width, appending "…" when clipped. For simplicity the
+ * ellipsis path strips ANSI before slicing; mods that need color-preserving
+ * truncation can pre-truncate to `width` themselves.
+ */
+export function truncateToWidth(value: string, width: number): string {
+  if (width <= 0) return "";
+  if (visibleWidth(value) <= width) return value;
+  if (width === 1) return "…";
+  const chars = [...stripAnsi(value)];
+  return `${chars.slice(0, width - 1).join("")}…`;
+}
+
+/**
+ * Lay out a left segment and a right segment across `width`, padding the middle
+ * with spaces. ANSI-aware. If the two collide, the left side is truncated.
+ */
+export function row(left: string, right: string, width: number): string {
+  if (width <= 0) return "";
+  const rightWidth = visibleWidth(right);
+  if (rightWidth >= width) return truncateToWidth(right, width);
+  const leftBudget = width - rightWidth;
+  const fittedLeft =
+    visibleWidth(left) > leftBudget ? truncateToWidth(left, leftBudget) : left;
+  const gap = Math.max(0, leftBudget - visibleWidth(fittedLeft));
+  return `${fittedLeft}${" ".repeat(gap)}${right}`;
+}
+
+/**
+ * Distribute parts across `width`: first left-aligned, last right-aligned,
+ * middles spread evenly between. ANSI-aware.
+ */
+export function columns(parts: string[], width: number): string {
+  const items = parts.filter((part) => part.length > 0);
+  if (items.length === 0) return "";
+  if (items.length === 1) return truncateToWidth(items[0]!, width);
+  if (items.length === 2) return row(items[0]!, items[1]!, width);
+  const totalContent = items.reduce((sum, part) => sum + visibleWidth(part), 0);
+  const gaps = items.length - 1;
+  const spare = Math.max(gaps, width - totalContent);
+  const base = Math.floor(spare / gaps);
+  let extra = spare - base * gaps;
+  let result = items[0]!;
+  for (let i = 1; i < items.length; i += 1) {
+    const pad = base + (extra > 0 ? 1 : 0);
+    if (extra > 0) extra -= 1;
+    result += " ".repeat(pad) + items[i];
+  }
+  return truncateToWidth(result, width);
 }

--- a/src/cli/mods/capabilities.ts
+++ b/src/cli/mods/capabilities.ts
@@ -12,7 +12,5 @@ export const TUI_MOD_CAPABILITIES: ModCapabilities = {
   providers: true,
   ui: {
     panels: true,
-    statusValues: true,
-    customStatuslineRenderer: true,
   },
 };

--- a/src/cli/mods/local-mod-loader.test.ts
+++ b/src/cli/mods/local-mod-loader.test.ts
@@ -9,13 +9,14 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type Letta from "@letta-ai/letta-client";
+import chalk from "chalk";
 import { buildStatuslineRenderContext } from "@/cli/display/statusline/context";
+import { columns, row } from "@/cli/display/statusline/formatting";
 import type { StatuslineRenderContext } from "@/cli/display/statusline/types";
 import { buildStatusLinePayload } from "@/cli/helpers/status-line-payload";
 import { runModCommandWithTimeout } from "@/cli/mods/command-runtime";
 import {
   disposeLocalMods,
-  evaluateLocalModStatuses,
   loadLocalMods,
   resolveLocalModSources,
 } from "@/cli/mods/local-mod-loader";
@@ -47,6 +48,22 @@ function createStatuslineContext(): StatuslineRenderContext {
       rightColumnWidth: 80,
     },
   });
+}
+
+function renderCtx(width: number) {
+  return {
+    width,
+    agent: { id: null, name: "Test" },
+    model: {
+      id: null,
+      displayName: "test-model",
+      provider: null,
+      reasoningEffort: null,
+    },
+    row,
+    columns,
+    chalk,
+  };
 }
 
 function createLoadOptions(root: string) {
@@ -346,104 +363,15 @@ describe("local mod loader", () => {
       writeFileSync(
         path.join(modDir, "status.ts"),
         `export default function(letta) {
-          letta.ui.setStatus("mode", "fast");
+          letta.ui.openPanel({ id: "mode", render: () => "fast" });
         }`,
       );
 
       const registry = await loadLocalMods(options);
 
       expect(getModErrorDiagnostics(registry.diagnostics)).toEqual([]);
-      expect(
-        evaluateLocalModStatuses(registry, createStatuslineContext()),
-      ).toEqual({ mode: "fast" });
-    } finally {
-      rmSync(root, { force: true, recursive: true });
-    }
-  });
-
-  test("loads mods that register statuses and statusline renderers", async () => {
-    const root = createTempDir();
-    try {
-      const options = createLoadOptions(root);
-      const modDir = options.globalModsDirectory;
-      const modPath = path.join(modDir, "statusline.ts");
-      mkdirSync(modDir, { recursive: true });
-      writeFileSync(
-        modPath,
-        `export default function(letta) {
-          letta.ui.setStatus("mode", "fast");
-          letta.ui.setStatus("agent", (ctx) => ctx.agent.name);
-          letta.ui.setStatuslineRenderer((ctx) => "first:" + ctx.statuses.mode);
-        }`,
-      );
-
-      const firstRegistry = await loadLocalMods(options);
-      expect(getModErrorDiagnostics(firstRegistry.diagnostics)).toEqual([]);
-      expect(firstRegistry.loadedPaths).toEqual([modPath]);
-      expect(
-        evaluateLocalModStatuses(firstRegistry, createStatuslineContext()),
-      ).toEqual({ agent: "Letta Code", mode: "fast" });
-      expect(
-        firstRegistry.ui.statuslineRenderer?.render({
-          ...createStatuslineContext(),
-          statuses: evaluateLocalModStatuses(
-            firstRegistry,
-            createStatuslineContext(),
-          ),
-        }),
-      ).toBe("first:fast");
-
-      writeFileSync(
-        modPath,
-        `export default function(letta) {
-          letta.ui.setStatus("mode", "slow");
-          letta.ui.setStatuslineRenderer((ctx) => "second:" + ctx.statuses.mode);
-        }`,
-      );
-
-      const secondRegistry = await loadLocalMods(options);
-      expect(getModErrorDiagnostics(secondRegistry.diagnostics)).toEqual([]);
-      expect(
-        evaluateLocalModStatuses(secondRegistry, createStatuslineContext()),
-      ).toEqual({ mode: "slow" });
-      expect(
-        secondRegistry.ui.statuslineRenderer?.render({
-          ...createStatuslineContext(),
-          statuses: evaluateLocalModStatuses(
-            secondRegistry,
-            createStatuslineContext(),
-          ),
-        }),
-      ).toBe("second:slow");
-    } finally {
-      rmSync(root, { force: true, recursive: true });
-    }
-  });
-
-  test("records status evaluation diagnostics", async () => {
-    const root = createTempDir();
-    try {
-      const options = createLoadOptions(root);
-      const modDir = options.globalModsDirectory;
-      mkdirSync(modDir, { recursive: true });
-      writeFileSync(
-        path.join(modDir, "bad-status.ts"),
-        `export default function(letta) {
-          letta.ui.setStatus("bad", () => {
-            throw new Error("ctx.getContext is not a function");
-          });
-        }`,
-      );
-
-      const registry = await loadLocalMods(options);
-      expect(
-        evaluateLocalModStatuses(registry, createStatuslineContext()),
-      ).toEqual({});
-      expect(registry.diagnostics.at(-1)).toMatchObject({
-        capability: { id: "bad", kind: "status" },
-        error: { message: "ctx.getContext is not a function" },
-        phase: "status.evaluate",
-      });
+      const panel = Object.values(registry.ui.panels)[0];
+      expect(panel?.render(renderCtx(80))).toBe("fast");
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
@@ -465,7 +393,6 @@ describe("local mod loader", () => {
               letta.ui.clearStatus("branch");
             }
           };
-          letta.ui.setStatuslineRenderer(() => "ok");
           void update();
         }`,
       );
@@ -473,7 +400,6 @@ describe("local mod loader", () => {
       const registry = await loadLocalMods(options);
 
       expect(getModErrorDiagnostics(registry.diagnostics)).toEqual([]);
-      expect(registry.ui.statuslineRenderer).toBeDefined();
       expect(registry.diagnostics).toContainEqual(
         expect.objectContaining({
           capability: { id: "letta.getContext", kind: "api" },
@@ -540,40 +466,6 @@ describe("local mod loader", () => {
     }
   });
 
-  test("deprecated status ctx getContext trap records even when caught", async () => {
-    const root = createTempDir();
-    try {
-      const options = createLoadOptions(root);
-      const modDir = options.globalModsDirectory;
-      mkdirSync(modDir, { recursive: true });
-      writeFileSync(
-        path.join(modDir, "caught-status.ts"),
-        `export default function(letta) {
-          letta.ui.setStatus("branch", (ctx) => {
-            try {
-              ctx.getContext();
-            } catch {}
-            return "fallback";
-          });
-        }`,
-      );
-
-      const registry = await loadLocalMods(options);
-      expect(
-        evaluateLocalModStatuses(registry, createStatuslineContext()),
-      ).toEqual({ branch: "fallback" });
-      expect(registry.diagnostics).toContainEqual(
-        expect.objectContaining({
-          capability: { id: "ctx.getContext", kind: "api" },
-          phase: "deprecated_api",
-          severity: "warning",
-        }),
-      );
-    } finally {
-      rmSync(root, { force: true, recursive: true });
-    }
-  });
-
   test("transpiles TypeScript and TSX mods to importable mjs cache files", async () => {
     const root = createTempDir();
     try {
@@ -584,9 +476,9 @@ describe("local mod loader", () => {
       writeFileSync(
         modPath,
         `export default function(letta: any) {
-          letta.ui.setStatuslineRenderer((ctx: any) => {
-            const Label = ctx.components.Text;
-            return <Label>{ctx.agent.name}</Label>;
+          letta.ui.openPanel({
+            id: "panel",
+            render: (ctx: any) => <span>{ctx.agent.name}</span>,
           });
         }`,
       );
@@ -600,10 +492,9 @@ describe("local mod loader", () => {
       );
       expect(cacheFiles).toHaveLength(1);
       expect(cacheFiles[0]?.endsWith(".mjs")).toBe(true);
-      const output = registry.ui.statuslineRenderer?.render(
-        createStatuslineContext(),
-      );
-      expect(output).toMatchObject({ props: { children: "Letta Code" } });
+      const panel = Object.values(registry.ui.panels)[0];
+      const output = panel?.render(renderCtx(80));
+      expect(output).toMatchObject({ props: { children: "Test" } });
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
@@ -629,7 +520,7 @@ describe("local mod loader", () => {
         path.join(modDir, "index.js"),
         `import { label } from "fake-dep";
 export default function(letta) {
-  letta.ui.setStatus("dep", label);
+  letta.ui.openPanel({ id: "dep", render: () => label });
 }
 `,
       );
@@ -676,7 +567,8 @@ export default function(letta) {
       const registry = await loadLocalMods(options);
 
       expect(getModErrorDiagnostics(registry.diagnostics)).toEqual([]);
-      expect(registry.ui.statusValues.dep).toBe("dependency");
+      const panel = Object.values(registry.ui.panels)[0];
+      expect(panel?.render(renderCtx(80))).toBe("dependency");
       const generatedFiles = readdirSync(modDir).filter((entry) =>
         entry.startsWith(".letta-mod-index-"),
       );
@@ -696,16 +588,15 @@ export default function(letta) {
       writeFileSync(
         path.join(modDir, "working.ts"),
         `export default function(letta) {
-          letta.ui.setStatus("ok", "true");
+          letta.ui.openPanel({ id: "ok", render: () => "true" });
         }`,
       );
 
       const registry = await loadLocalMods(options);
 
       expect(registry.loadedPaths).toEqual([path.join(modDir, "working.ts")]);
-      expect(
-        evaluateLocalModStatuses(registry, createStatuslineContext()),
-      ).toEqual({ ok: "true" });
+      const panel = Object.values(registry.ui.panels)[0];
+      expect(panel?.render(renderCtx(80))).toBe("true");
       const errorDiagnostics = getModErrorDiagnostics(registry.diagnostics);
       expect(errorDiagnostics).toHaveLength(1);
       const [errorDiagnostic] = errorDiagnostics;
@@ -918,7 +809,7 @@ export default function(letta) {
       expect(getModErrorDiagnostics(registry.diagnostics)).toEqual([]);
       const panel = Object.values(registry.ui.panels)[0];
       expect(panel).toMatchObject({ id: "btw" });
-      expect(panel?.render({ width: 80 })).toBe("answer");
+      expect(panel?.render(renderCtx(80))).toBe("answer");
 
       disposeLocalMods(registry);
       expect(registry.ui.panels).toEqual({});
@@ -951,7 +842,7 @@ export default function(letta) {
       expect(getModErrorDiagnostics(registry.diagnostics)).toEqual([]);
       expect(
         Object.values(registry.ui.panels).map((panel) =>
-          panel.render({ width: 80 }),
+          panel.render(renderCtx(80)),
         ),
       ).toEqual(["from a", "from b"]);
     } finally {
@@ -1146,26 +1037,19 @@ export default function(letta) {
       writeFileSync(
         path.join(modDir, "status.ts"),
         `export default function(letta) {
-          letta.ui.setStatus("mode", "fast");
-          letta.ui.setStatuslineRenderer(() => "statusline");
-          return () => letta.ui.clearStatus("mode");
+          const panel = letta.ui.openPanel({ id: "mode", render: () => "fast" });
+          return () => panel.close();
         }`,
       );
 
       const registry = await loadLocalMods(options);
       expect(registry.disposers).toHaveLength(1);
-      expect(
-        evaluateLocalModStatuses(registry, createStatuslineContext()),
-      ).toEqual({ mode: "fast" });
-      expect(registry.ui.statuslineRenderer).not.toBeNull();
+      expect(Object.keys(registry.ui.panels)).toHaveLength(1);
 
       disposeLocalMods(registry);
 
       expect(registry.disposers).toEqual([]);
-      expect(
-        evaluateLocalModStatuses(registry, createStatuslineContext()),
-      ).toEqual({});
-      expect(registry.ui.statuslineRenderer).toBeNull();
+      expect(registry.ui.panels).toEqual({});
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/src/cli/mods/local-mod-loader.ts
+++ b/src/cli/mods/local-mod-loader.ts
@@ -9,7 +9,6 @@ import {
   createModEngine as createModEngineBase,
   disposeLocalMods,
   emitLocalModEvent,
-  evaluateLocalModStatuses,
   GLOBAL_MODS_DIRECTORY,
   loadLocalMods as loadLocalModsBase,
   MOD_CACHE_DIRECTORY,
@@ -74,7 +73,6 @@ export {
   GLOBAL_MODS_DIRECTORY,
   disposeLocalMods,
   emitLocalModEvent,
-  evaluateLocalModStatuses,
   resolveLocalModSources,
 };
 
@@ -95,8 +93,6 @@ export type {
   LocalModSource,
   LocalModUiRegistry,
   ModEngine,
-  ModStatusValue,
   ResolveLocalModSourcesOptions,
-  StatuslineRenderFunction,
 } from "@/mods/mod-engine";
 export { TUI_MOD_CAPABILITIES } from "./capabilities";

--- a/src/cli/mods/types.ts
+++ b/src/cli/mods/types.ts
@@ -38,6 +38,7 @@ export type {
   ModPanelHandle,
   ModPanelOptions,
   ModPanelRender,
+  ModPanelRenderContext,
   ModReflectionContext,
   ModSourceScope,
   ModTokenUsageContext,

--- a/src/cli/mods/use-local-mod-adapter.ts
+++ b/src/cli/mods/use-local-mod-adapter.ts
@@ -12,7 +12,7 @@ export interface LocalModAdapter {
   context: ModContext;
   events: ModAdapter["events"];
   getBackend: ModAdapter["getBackend"];
-  hadStatuslineRenderer: boolean; // Used to prevent flicker on reload
+  hadModPanels: boolean; // Used to prevent flicker on reload
   hasModSources: boolean;
   engine: ModAdapter["engine"];
   isLoading: boolean;
@@ -56,7 +56,7 @@ export function useLocalModAdapter(
       context,
       events: adapter.events,
       getBackend: adapter.getBackend,
-      hadStatuslineRenderer: snapshot.hadStatuslineRenderer,
+      hadModPanels: snapshot.hadModPanels,
       hasModSources: snapshot.hasModSources,
       engine: adapter.engine,
       isLoading: snapshot.isLoading,

--- a/src/headless-mod-adapter.ts
+++ b/src/headless-mod-adapter.ts
@@ -29,8 +29,6 @@ export const HEADLESS_MOD_CAPABILITIES: ModCapabilities = {
   providers: true,
   ui: {
     panels: false,
-    statusValues: false,
-    customStatuslineRenderer: false,
   },
 };
 

--- a/src/headless-mod-lifecycle.test.ts
+++ b/src/headless-mod-lifecycle.test.ts
@@ -47,8 +47,6 @@ describe("headless mod adapter", () => {
       providers: true,
       ui: {
         panels: false,
-        statusValues: false,
-        customStatuslineRenderer: false,
       },
     });
   });
@@ -164,7 +162,6 @@ describe("headless mod adapter", () => {
       expect(snapshot.tools[toolName]).toBeDefined();
       expect(snapshot.commands).toEqual({});
       expect(snapshot.ui.panels).toEqual({});
-      expect(snapshot.ui.statusValues).toEqual({});
       expect(getModToolDefinition(toolName)).toBeDefined();
 
       const prepared =
@@ -338,7 +335,6 @@ describe("headless mod adapter", () => {
       expect(snapshot.registry.loadedPaths).toEqual([]);
       expect(snapshot.registry.commands).toEqual({});
       expect(snapshot.registry.tools).toEqual({});
-      expect(snapshot.registry.ui.statuslineRenderer).toBeNull();
       expect(getModToolDefinition(toolName)).toBeUndefined();
       expect(process.env[LETTA_DISABLE_MODS_ENV]).toBe("1");
 

--- a/src/mods/capabilities.ts
+++ b/src/mods/capabilities.ts
@@ -9,8 +9,6 @@ export const MOD_CAPABILITY_IDS = [
   "events.turns",
   "events.tools",
   "ui.panels",
-  "ui.statusValues",
-  "ui.statusline",
 ] as const;
 
 export type ModCapabilityId = (typeof MOD_CAPABILITY_IDS)[number];
@@ -33,8 +31,6 @@ export const DEFAULT_MOD_CAPABILITIES: ModCapabilities = {
   providers: true,
   ui: {
     panels: true,
-    statusValues: true,
-    customStatuslineRenderer: true,
   },
 };
 
@@ -50,8 +46,6 @@ export const DISABLED_MOD_CAPABILITIES: ModCapabilities = {
   providers: false,
   ui: {
     panels: false,
-    statusValues: false,
-    customStatuslineRenderer: false,
   },
 };
 
@@ -70,8 +64,6 @@ export function cloneModCapabilities(
     providers: capabilities.providers,
     ui: {
       panels: capabilities.ui.panels,
-      statusValues: capabilities.ui.statusValues,
-      customStatuslineRenderer: capabilities.ui.customStatuslineRenderer,
     },
   };
 }

--- a/src/mods/deprecated-api.ts
+++ b/src/mods/deprecated-api.ts
@@ -7,6 +7,9 @@ export type DeprecatedApiDiagnosticRecorder = (
   >,
 ) => void;
 
+const STATUSLINE_MIGRATION =
+  "The statusline mod APIs (setStatus / clearStatus / setStatuslineRenderer) have been removed. Use letta.ui.openPanel({ id, order, render }) instead: order 0 is the primary line (replaces the built-in agent · model line), negative orders stack below it, positive orders render above the input. render(ctx) returns a string; use ctx.row / ctx.columns for layout and ctx.chalk for color.";
+
 function createDeprecatedApiError(apiId: string): Error {
   if (apiId === "letta.getContext") {
     return new Error(
@@ -16,6 +19,15 @@ function createDeprecatedApiError(apiId: string): Error {
   if (apiId === "ctx.getContext") {
     return new Error(
       "ctx.getContext is no longer available. Use ctx directly; scoped fields are available as ctx.agent, ctx.cwd, ctx.conversation, ctx.model, etc.",
+    );
+  }
+  if (
+    apiId === "letta.ui.setStatus" ||
+    apiId === "letta.ui.clearStatus" ||
+    apiId === "letta.ui.setStatuslineRenderer"
+  ) {
+    return new Error(
+      `${apiId} is no longer available. ${STATUSLINE_MIGRATION}`,
     );
   }
   return new Error(
@@ -71,6 +83,15 @@ export function findDeprecatedContextApiUsages(source: string): string[] {
   }
   if (usages.size === 0 && /\.\s*getContext\s*\(/.test(source)) {
     usages.add(".getContext()");
+  }
+  if (/\.\s*setStatuslineRenderer\s*\(/.test(source)) {
+    usages.add("letta.ui.setStatuslineRenderer");
+  }
+  if (/\.\s*setStatus\s*\(/.test(source)) {
+    usages.add("letta.ui.setStatus");
+  }
+  if (/\.\s*clearStatus\s*\(/.test(source)) {
+    usages.add("letta.ui.clearStatus");
   }
   return [...usages];
 }

--- a/src/mods/disabled-mod-adapter.test.ts
+++ b/src/mods/disabled-mod-adapter.test.ts
@@ -98,7 +98,7 @@ describe("disabled mod adapter", () => {
       const adapter = createDisabledModAdapter();
 
       expect(adapter.getSnapshot()).toMatchObject({
-        hadStatuslineRenderer: false,
+        hadModPanels: false,
         hasModSources: false,
         isLoading: false,
       });
@@ -111,7 +111,6 @@ describe("disabled mod adapter", () => {
       expect(adapter.getSnapshot().registry.permissions).toEqual({});
       expect(adapter.getSnapshot().registry.tools).toEqual({});
       expect(adapter.getSnapshot().registry.ui.panels).toEqual({});
-      expect(adapter.getSnapshot().registry.ui.statuslineRenderer).toBeNull();
       expect(adapter.getBackend()).toBeUndefined();
       expect(getModPermissionDefinition("stale-permission")).toBeUndefined();
       expect(getModToolDefinition("stale_mod_tool")).toBeUndefined();

--- a/src/mods/disabled-mod-adapter.ts
+++ b/src/mods/disabled-mod-adapter.ts
@@ -24,10 +24,6 @@ function createDisabledModRegistry(): LocalModRegistry {
     tools: {},
     ui: {
       panels: {},
-      statusRecorders: {},
-      statuslineRenderer: null,
-      statusOwners: {},
-      statusValues: {},
     },
   };
 }
@@ -58,7 +54,7 @@ export function createDisabledModAdapter() {
   const registry = createDisabledModRegistry();
   const engine = createDisabledModEngine(registry);
   const snapshot = {
-    hadStatuslineRenderer: false,
+    hadModPanels: false,
     hasModSources: false,
     isLoading: false,
     registry,

--- a/src/mods/mod-adapter.ts
+++ b/src/mods/mod-adapter.ts
@@ -16,7 +16,7 @@ import { debugLog } from "@/utils/debug";
 const RUNTIME_DIAGNOSTICS_WRITE_DELAY_MS = 30_000;
 
 export interface ModAdapterLoadState {
-  hadStatuslineRenderer: boolean;
+  hadModPanels: boolean;
   hasModSources: boolean;
   isLoading: boolean;
 }
@@ -67,7 +67,7 @@ export function createModAdapter(options: CreateModAdapterOptions): ModAdapter {
   let disposed = false;
   const initialHasModSources = hasModSources(engineOptions);
   let loadState: ModAdapterLoadState = {
-    hadStatuslineRenderer: false,
+    hadModPanels: false,
     hasModSources: initialHasModSources,
     isLoading: initialHasModSources,
   };
@@ -158,11 +158,11 @@ export function createModAdapter(options: CreateModAdapterOptions): ModAdapter {
     clearPendingDiagnosticsWrite();
 
     const previousSnapshot = engine.getSnapshot();
-    const previousHadStatuslineRenderer =
-      Boolean(previousSnapshot.ui.statuslineRenderer) ||
-      loadState.hadStatuslineRenderer;
+    const previousHadModPanels =
+      Object.keys(previousSnapshot.ui.panels).length > 0 ||
+      loadState.hadModPanels;
     loadState = {
-      hadStatuslineRenderer: previousHadStatuslineRenderer,
+      hadModPanels: previousHadModPanels,
       hasModSources: hasModSources(engineOptions),
       isLoading: true,
     };
@@ -176,10 +176,10 @@ export function createModAdapter(options: CreateModAdapterOptions): ModAdapter {
 
     debugLog(
       "mods",
-      "loaded %s mod(s) from %s source(s); renderer=%s",
+      "loaded %s mod(s) from %s source(s); panels=%s",
       nextRegistry.loadedPaths.length,
       nextRegistry.sources.length,
-      nextRegistry.ui.statuslineRenderer?.id ?? "(none)",
+      Object.keys(nextRegistry.ui.panels).length,
     );
 
     for (const diagnostic of getModErrorDiagnostics(nextRegistry.diagnostics)) {
@@ -198,7 +198,7 @@ export function createModAdapter(options: CreateModAdapterOptions): ModAdapter {
     }
 
     loadState = {
-      hadStatuslineRenderer: Boolean(nextRegistry.ui.statuslineRenderer),
+      hadModPanels: Object.keys(nextRegistry.ui.panels).length > 0,
       hasModSources: nextRegistry.sources.some(
         (source) => source.files.length > 0,
       ),

--- a/src/mods/mod-engine.test.ts
+++ b/src/mods/mod-engine.test.ts
@@ -108,8 +108,6 @@ const TOOL_ONLY_MOD_CAPABILITIES: ModCapabilities = {
   providers: false,
   ui: {
     panels: false,
-    statusValues: false,
-    customStatuslineRenderer: false,
   },
 };
 
@@ -811,8 +809,6 @@ describe("mod engine", () => {
       expect(snapshot.commands).toEqual({});
       expect(snapshot.events).toEqual({});
       expect(snapshot.ui.panels).toEqual({});
-      expect(snapshot.ui.statusValues).toEqual({});
-      expect(snapshot.ui.statuslineRenderer).toBeNull();
       expect(Object.keys(snapshot.tools)).toEqual(["visible_tool"]);
     } finally {
       rmSync(root, { force: true, recursive: true });
@@ -834,7 +830,6 @@ describe("mod engine", () => {
             globalThis.__lettaModEvents.push(
               event.reason + ":" + event.agentId + ":" + ctx.agent.name + ":" + ctx.conversation.id,
             );
-            letta.ui.setStatus("lifecycle", event.reason);
           });
           letta.events.on("conversation_open", () => {
             throw new Error("event failed");
@@ -869,7 +864,6 @@ describe("mod engine", () => {
       expect(testGlobal.__lettaModEvents).toEqual([
         "startup:agent-1:Amelia:conversation-1",
       ]);
-      expect(snapshot.ui.statusValues.lifecycle).toBe("startup");
       expect(getModErrorDiagnostics(snapshot.diagnostics).at(-1)).toMatchObject(
         {
           phase: "event",

--- a/src/mods/mod-engine.ts
+++ b/src/mods/mod-engine.ts
@@ -23,11 +23,6 @@ import {
   unregisterPiProvider,
   unregisterPiProvidersForOwner,
 } from "@/backend/dev/pi-provider-mod-registry";
-import type {
-  StatuslineRenderContext,
-  StatuslineRenderer,
-  StatuslineRendererOutput,
-} from "@/cli/display/statusline/types";
 import {
   cloneModCapabilities,
   resolveModCapabilities,
@@ -82,7 +77,6 @@ import type {
   ModEventName,
   ModEventRegistration,
   ModEventResultMap,
-  ModInvocationContext,
   ModOwner,
   ModPanel,
   ModPanelHandle,
@@ -105,15 +99,6 @@ export const LEGACY_GLOBAL_EXTENSIONS_DIRECTORY =
 export const MOD_CACHE_DIRECTORY = getModCacheDirectory();
 
 const requireFromRuntime = createRequire(import.meta.url);
-
-export type StatuslineRenderFunction = (
-  context: StatuslineRenderContext,
-) => StatuslineRendererOutput;
-
-export type ModStatusValue =
-  | string
-  | null
-  | ((context: ModInvocationContext) => string | null);
 
 export type LettaModDisposer = () => void;
 
@@ -171,13 +156,14 @@ export interface LettaModApi {
     report: (diagnostic: ModDiagnosticReportOptions) => void;
   };
   ui: {
-    clearPanel: (id: string) => void;
-    clearStatus: (key: string) => void;
+    closePanel: (id: string) => void;
     openPanel: (panel: ModPanelOptions) => ModPanelHandle;
-    setStatus: (key: string, value: ModStatusValue | undefined) => void;
-    setStatuslineRenderer: (
-      renderer: StatuslineRenderer | StatuslineRenderFunction,
-    ) => void;
+    /** @deprecated Removed. Use openPanel; calls emit a migration diagnostic. */
+    setStatus: (key: string, value?: unknown) => void;
+    /** @deprecated Removed. Use openPanel; calls emit a migration diagnostic. */
+    clearStatus: (key: string) => void;
+    /** @deprecated Removed. Use openPanel; calls emit a migration diagnostic. */
+    setStatuslineRenderer: (renderer: unknown) => void;
   };
 }
 
@@ -189,12 +175,6 @@ export interface LocalModDisposer {
 
 export interface LocalModUiRegistry {
   panels: Record<string, ModPanel>;
-  statuslineRecordDiagnostic?: ModCapabilityDiagnosticRecorder;
-  statuslineRenderer: StatuslineRenderer | null;
-  statuslineRendererOwner?: ModOwner;
-  statusOwners: Record<string, ModOwner>;
-  statusRecorders: Record<string, ModCapabilityDiagnosticRecorder>;
-  statusValues: Record<string, ModStatusValue>;
 }
 
 type LocalModEventsRegistry = Partial<
@@ -388,10 +368,6 @@ function createEmptyModRegistry(
     tools: {},
     ui: {
       panels: {},
-      statusRecorders: {},
-      statuslineRenderer: null,
-      statusOwners: {},
-      statusValues: {},
     },
   };
 }
@@ -444,9 +420,6 @@ function snapshotRegistryForReaders(
     ui: {
       ...registry.ui,
       panels: { ...registry.ui.panels },
-      statusRecorders: { ...registry.ui.statusRecorders },
-      statusOwners: { ...registry.ui.statusOwners },
-      statusValues: { ...registry.ui.statusValues },
     },
   };
 }
@@ -488,20 +461,6 @@ function removeOwnerCapabilities(
   }
 
   unregisterModToolsForOwner(owner);
-
-  for (const [key, statusOwner] of Object.entries(registry.ui.statusOwners)) {
-    if (statusOwner.id === owner.id) {
-      delete registry.ui.statusOwners[key];
-      delete registry.ui.statusRecorders[key];
-      delete registry.ui.statusValues[key];
-    }
-  }
-
-  if (registry.ui.statuslineRendererOwner?.id === owner.id) {
-    registry.ui.statuslineRenderer = null;
-    delete registry.ui.statuslineRecordDiagnostic;
-    delete registry.ui.statuslineRendererOwner;
-  }
 
   delete registry.owners[owner.id];
 }
@@ -642,22 +601,6 @@ function createImportableModPath(
   }
 
   return importPath;
-}
-
-function toStatuslineRenderer(
-  renderer: StatuslineRenderer | StatuslineRenderFunction,
-  modPath: string,
-): StatuslineRenderer {
-  if (typeof renderer === "function") {
-    return {
-      id: `local:${modPath}`,
-      label: path.basename(modPath),
-      description: modPath,
-      render: renderer,
-    };
-  }
-
-  return renderer;
 }
 
 function createLazyClient(getClient: () => Promise<Letta>): Letta {
@@ -1070,7 +1013,7 @@ function createLettaModApi(
     }
   };
 
-  const clearPanel = (id: string) => {
+  const closePanel = (id: string) => {
     if (!capabilities.ui.panels) return;
     validateModPanelId(id);
     if (!guardLive({ id, kind: "panel" })) return;
@@ -1080,6 +1023,17 @@ function createLettaModApi(
       delete registry.ui.panels[panelKey];
       onChange();
     }
+  };
+
+  const recordStatuslineDeprecation = (apiId: string) => {
+    recordCapabilityDiagnostic({
+      capability: { id: apiId, kind: "statusline" },
+      error: new Error(
+        `${apiId} is no longer available. Use letta.ui.openPanel({ id, order, render }) instead — order 0 is the primary line (replaces agent · model), negative orders stack below it.`,
+      ),
+      phase: "deprecated_api",
+      severity: "warning",
+    });
   };
 
   const unregisterTool = (name: string) => {
@@ -1353,15 +1307,7 @@ function createLettaModApi(
       report: reportDiagnostic,
     },
     ui: {
-      clearPanel,
-      clearStatus(key) {
-        if (!capabilities.ui.statusValues) return;
-        if (!guardLive({ id: key, kind: "status" })) return;
-        delete registry.ui.statusValues[key];
-        delete registry.ui.statusOwners[key];
-        delete registry.ui.statusRecorders[key];
-        onChange();
-      },
+      closePanel,
       openPanel(panel) {
         if (!capabilities.ui.panels) {
           return {
@@ -1383,7 +1329,7 @@ function createLettaModApi(
         onChange();
         return {
           close() {
-            clearPanel(panel.id);
+            closePanel(panel.id);
           },
           update(options) {
             if (!guardLive({ id: panel.id, kind: "panel" })) return;
@@ -1394,31 +1340,14 @@ function createLettaModApi(
           },
         };
       },
-      setStatus(key, value) {
-        if (!capabilities.ui.statusValues) return;
-        if (!guardLive({ id: key, kind: "status" })) return;
-        if (value == null) {
-          delete registry.ui.statusValues[key];
-          delete registry.ui.statusOwners[key];
-          delete registry.ui.statusRecorders[key];
-          onChange();
-          return;
-        }
-        registry.ui.statusValues[key] = value;
-        registry.ui.statusOwners[key] = owner;
-        registry.ui.statusRecorders[key] = recordCapabilityDiagnostic;
-        onChange();
+      setStatus() {
+        recordStatuslineDeprecation("letta.ui.setStatus");
       },
-      setStatuslineRenderer(renderer) {
-        if (!capabilities.ui.customStatuslineRenderer) return;
-        if (!guardLive({ id: owner.id, kind: "statusline" })) return;
-        registry.ui.statuslineRenderer = toStatuslineRenderer(
-          renderer,
-          owner.path,
-        );
-        registry.ui.statuslineRecordDiagnostic = recordCapabilityDiagnostic;
-        registry.ui.statuslineRendererOwner = owner;
-        onChange();
+      clearStatus() {
+        recordStatuslineDeprecation("letta.ui.clearStatus");
+      },
+      setStatuslineRenderer() {
+        recordStatuslineDeprecation("letta.ui.setStatuslineRenderer");
       },
     },
   };
@@ -1599,42 +1528,6 @@ export async function loadLocalMods(
   }
 
   return registry;
-}
-
-export function evaluateLocalModStatuses(
-  registry: LocalModRegistry | null,
-  context: ModContext,
-): Record<string, string> {
-  if (!registry) return {};
-
-  const statuses: Record<string, string> = {};
-  for (const [key, value] of Object.entries(registry.ui.statusValues)) {
-    try {
-      const nextValue =
-        typeof value === "function"
-          ? value(
-              attachDeprecatedGetContextTrap(
-                { ...context },
-                registry.ui.statusRecorders[key],
-                "ctx.getContext",
-              ),
-            )
-          : value;
-      if (nextValue != null) {
-        statuses[key] = nextValue;
-      }
-    } catch (error) {
-      registry.ui.statusRecorders[key]?.({
-        capability: { id: key, kind: "status" },
-        error: error instanceof Error ? error : new Error(String(error)),
-        phase: "status.evaluate",
-      });
-      // Status providers run during render; failed providers are skipped so the
-      // mod cannot crash the TUI.
-    }
-  }
-
-  return statuses;
 }
 
 export async function emitLocalModEvent<TName extends ModEventName>(
@@ -1818,12 +1711,6 @@ export function disposeLocalMods(registry: LocalModRegistry): void {
   registry.permissions = {};
   registry.tools = {};
   registry.ui.panels = {};
-  registry.ui.statusOwners = {};
-  registry.ui.statusRecorders = {};
-  registry.ui.statusValues = {};
-  registry.ui.statuslineRenderer = null;
-  delete registry.ui.statuslineRecordDiagnostic;
-  delete registry.ui.statuslineRendererOwner;
 }
 
 export function createModEngine(options: CreateModEngineOptions): ModEngine {

--- a/src/mods/package-manifest.test.ts
+++ b/src/mods/package-manifest.test.ts
@@ -47,7 +47,7 @@ describe("Letta package manifest", () => {
       letta: {
         manifestVersion: 1,
         mods: ["mods/provider.mjs", "mods/statusline.tsx"],
-        capabilities: ["providers", "ui.statusline", "events.lifecycle"],
+        capabilities: ["providers", "ui.panels", "events.lifecycle"],
         engines: {
           lettaCodeCli: ">=0.28.0",
           lettaCodeDesktop: ">=0.12.0 <0.20.0",
@@ -61,7 +61,7 @@ describe("Letta package manifest", () => {
     expect(result.manifest).toEqual({
       manifestVersion: 1,
       mods: ["mods/provider.mjs", "mods/statusline.tsx"],
-      capabilities: ["providers", "ui.statusline", "events.lifecycle"],
+      capabilities: ["providers", "ui.panels", "events.lifecycle"],
       engines: {
         lettaCodeCli: ">=0.28.0",
         lettaCodeDesktop: ">=0.12.0 <0.20.0",

--- a/src/mods/types.ts
+++ b/src/mods/types.ts
@@ -4,6 +4,7 @@ import type {
   LettaStreamingResponse,
   Message,
 } from "@letta-ai/letta-client/resources/agents/messages";
+import type { ChalkInstance } from "chalk";
 
 export interface ModWorkspaceContext {
   cwd: string;
@@ -65,8 +66,6 @@ export interface ModBackgroundAgentContext {
 
 export interface ModUiCapabilities {
   panels: boolean;
-  statusValues: boolean;
-  customStatuslineRenderer: boolean;
 }
 
 export interface ModEventCapabilities {
@@ -366,8 +365,29 @@ export type ModCommandResult =
   | { type: "output"; output: string; success?: boolean }
   | { type: "handled" };
 
-export type ModPanelRender = (ctx: { width: number }) => string | string[];
+export interface ModPanelRenderContext {
+  /** Visible width available to the panel, in columns. */
+  width: number;
+  /** Live agent context (name, id) at render time. */
+  agent: ModAgentContext;
+  /** Live model context (display name, provider, ...) at render time. */
+  model: ModModelContext;
+  /** Lay out a left and right segment across `width` (ANSI-aware). */
+  row: (left: string, right: string, width: number) => string;
+  /** Spread parts evenly across `width` (ANSI-aware). */
+  columns: (parts: string[], width: number) => string;
+  /** Chalk instance for coloring panel output. */
+  chalk: ChalkInstance;
+}
 
+export type ModPanelRender = (ctx: ModPanelRenderContext) => string | string[];
+
+/**
+ * Panels are placed by a signed `order` around the input:
+ * `> 0` renders above the input (highest at the top), `0` is the primary line
+ * just below the input (overrides the built-in agent · model line), and `< 0`
+ * stacks below the primary line. A panel whose render is empty is hidden.
+ */
 export interface ModPanelOptions {
   id: string;
   render: ModPanelRender;

--- a/src/skills/builtin/creating-mods/SKILL.md
+++ b/src/skills/builtin/creating-mods/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: creating-mods
-description: Creates and edits trusted local Letta Code mods, including tools, slash commands, local-only model providers, lifecycle/turn events, scoped conversation helpers, panels, status values, and capability-gated behavior. Use when asked to make a mod, add an agent-callable tool, add a slash command, add a local provider/model adapter, transform turns, react to app events, or add lightweight mod UI outside the dedicated /statusline flow.
+description: Creates and edits trusted local Letta Code mods, including tools, slash commands, local-only model providers, lifecycle/turn events, scoped conversation helpers, panels, and capability-gated behavior. Use when asked to make a mod, add an agent-callable tool, add a slash command, add a local provider/model adapter, transform turns, react to app events, or add lightweight mod UI outside the dedicated /statusline flow.
 ---
 
 # Creating Mods
 
-Use this skill to create or update trusted Letta Code mod files. Mods are trusted local code that add small composable capabilities through mod APIs, not by importing app internals. Dynamic agent/conversation/workspace/model state is passed as `ctx` to tool, command, event, permission, status, and statusline callbacks; do not read mutable global context for model-callable behavior. Prefer scoped handles (`ctx.conversation`, `ctx.cwd`, `ctx.agent`) and guard optional UI with `letta.capabilities`.
+Use this skill to create or update trusted Letta Code mod files. Mods are trusted local code that add small composable capabilities through mod APIs, not by importing app internals. Dynamic agent/conversation/workspace/model state is passed as `ctx` to tool, command, event, and permission callbacks (panels receive live `agent`/`model` in their render context); do not read mutable global context for model-callable behavior. Prefer scoped handles (`ctx.conversation`, `ctx.cwd`, `ctx.agent`) and guard optional UI with `letta.capabilities`.
 
 Capabilities vary by surface. TUI/headless may load tools, commands, events, UI, and providers; the desktop listener loads provider-only mods for local provider discovery. Always guard optional capabilities.
 
@@ -89,8 +89,6 @@ letta.capabilities.events.turns
 letta.capabilities.permissions
 letta.capabilities.providers
 letta.capabilities.ui.panels
-letta.capabilities.ui.statusValues
-letta.capabilities.ui.customStatuslineRenderer
 ```
 
 ## Scoped API model
@@ -135,7 +133,7 @@ Before finishing, verify:
 - Command/tool IDs are valid; command overrides of built-ins are intentional, and tool IDs do not collide with built-ins.
 - Tool descriptions explain when the model should call them.
 - JSON schemas are object schemas with useful descriptions.
-- Optional UI/event/statusline APIs are capability-guarded.
+- Optional UI/event APIs are capability-guarded.
 - Provider mods are capability-guarded and clearly documented as local-agent only.
 - Timers, intervals, event registrations, and panels are cleaned up in a disposer.
 - Busy commands return `{ type: "handled" }` quickly and avoid main-conversation sends.
@@ -152,7 +150,7 @@ Before finishing, verify:
 | `references/providers.md` | Adding a custom model/API provider for local agents |
 | `references/events.md` | Reacting to lifecycle/tool/turn events or transforming turns/tools |
 | `references/permissions.md` | Enforcing dynamic tool allow/ask/deny policy before approval/execution |
-| `references/ui.md` | Panels, status values, or statusline capability guards are involved |
+| `references/ui.md` | Panels (including order-0 statusline) or `ui.panels` capability guards are involved |
 | `references/plan-mode.md` | Recreating plan mode with commands, tools, events, permissions, and local state |
 | `references/analysis-mode.md` | Phrase-triggered diagnostic mode with turn reminders (simpler than plan-mode) |
 | `references/architecture.md` | Multiple capabilities, local state, cleanup, background model work, or non-trivial composition |

--- a/src/skills/builtin/creating-mods/references/architecture.md
+++ b/src/skills/builtin/creating-mods/references/architecture.md
@@ -78,14 +78,22 @@ const stream = await forked.sendMessageStream([
 
 Do not call `ctx.conversation.sendMessageStream()` on the active conversation from a busy command; direct sends can conflict with the active run.
 
-### Event + status value
+### Event + panel
 
-Use lifecycle events to maintain small status values such as active conversation state. Guard both event and status capabilities.
+Use lifecycle events to maintain a small panel such as active conversation state. Guard both event and panel capabilities, and re-render with `panel.update()`.
 
 ```ts
-if (letta.capabilities.events.lifecycle && letta.capabilities.ui.statusValues) {
+if (letta.capabilities.events.lifecycle && letta.capabilities.ui.panels) {
+  let conversation = "";
+  const panel = letta.ui.openPanel({
+    id: "conversation",
+    order: 100,
+    render: ({ width, row }) => row("conversation", conversation, width),
+  });
+  disposers.push(() => panel.close());
   disposers.push(letta.events.on("conversation_open", (event) => {
-    letta.ui.setStatus("conversation", event.reason);
+    conversation = event.reason;
+    panel.update();
   }));
 }
 ```

--- a/src/skills/builtin/creating-mods/references/events.md
+++ b/src/skills/builtin/creating-mods/references/events.md
@@ -224,12 +224,23 @@ export default function activate(letta) {
   if (!letta.capabilities.events.lifecycle) return;
 
   const disposers = [];
+  let conversation = "";
 
-  disposers.push(
-    letta.events.on("conversation_open", (event) => {
-      letta.ui.setStatus("conversation", event.reason);
-    }),
-  );
+  if (letta.capabilities.ui.panels) {
+    const panel = letta.ui.openPanel({
+      id: "conversation",
+      order: 100,
+      render: ({ width, row }) => row("conversation", conversation, width),
+    });
+    disposers.push(() => panel.close());
+
+    disposers.push(
+      letta.events.on("conversation_open", (event) => {
+        conversation = event.reason;
+        panel.update();
+      }),
+    );
+  }
 
   disposers.push(
     letta.events.on("conversation_close", (event) => {
@@ -239,7 +250,6 @@ export default function activate(letta) {
 
   return () => {
     for (const dispose of disposers.reverse()) dispose();
-    letta.ui.clearStatus("conversation");
   };
 }
 ```

--- a/src/skills/builtin/creating-mods/references/plan-mode.md
+++ b/src/skills/builtin/creating-mods/references/plan-mode.md
@@ -42,7 +42,7 @@ Guard each registration with the matching capability:
 - `events.turns`: append a focused plan-mode reminder while active
 - `permissions`: block mutating tools except planning coordination tools and plan-file writes
 
-Do not use panels for persistent mode state. Panels are transient UI and can be noisy/fragile for mode indicators. Do not add a custom statusline renderer just to show plan mode; `setStatuslineRenderer` is a single global renderer, not an additive slot. This example intentionally keeps visible mode state out of scope.
+Do not use panels for persistent mode state. Panels are transient UI and can be noisy/fragile for mode indicators. Do not claim the order-0 statusline panel just to show plan mode; that slot is a single primary line, not an additive indicator. This example intentionally keeps visible mode state out of scope.
 
 ## State
 

--- a/src/skills/builtin/creating-mods/references/ui.md
+++ b/src/skills/builtin/creating-mods/references/ui.md
@@ -1,6 +1,6 @@
 # Mod UI recipes
 
-UI capabilities are optional. Always guard UI work with `letta.capabilities.ui.*` when writing portable mods.
+UI capabilities are optional. Always guard UI work with `letta.capabilities.ui.panels` when writing portable mods.
 
 For UI that belongs to a larger command/event mod, also read `architecture.md` for cleanup and composition patterns.
 
@@ -8,13 +8,9 @@ For UI that belongs to a larger command/event mod, also read `architecture.md` f
 
 ```ts
 letta.capabilities.ui.panels
-letta.capabilities.ui.statusValues
-letta.capabilities.ui.customStatuslineRenderer
 ```
 
-- `panels`: transient text blocks above the input bar.
-- `statusValues`: small named status data that renderers or future surfaces can display.
-- `customStatuslineRenderer`: TUI-only custom bottom-row renderer. Use `customizing-statusline` for statusline work.
+- `panels`: text blocks placed around the input bar (the only mod UI surface). Desktop/listener disables panel UI.
 
 ## Panels
 
@@ -35,39 +31,56 @@ if (letta.capabilities.ui.panels) {
 }
 ```
 
-`render` returns the panel body: a string or string array (one entry per line). The host owns the region — it clips each line to `width` and caps total height — so the mod owns layout: use `width` to align or build columns. The host re-invokes `render` whenever you call `panel.update()` and on terminal resize. Keep `render` cheap and side-effect-free; keep it short and use command `output` for longer text.
+`render` returns the panel body: a string or string array (one entry per line). The host owns the region — it clips each line to `width` and caps total height — so the mod owns layout: use `width`, `row(left, right, width)`, and `columns(parts, width)` to align. The host re-invokes `render` whenever you call `panel.update()` and on terminal resize. Keep `render` cheap and side-effect-free; for longer text use a command `output` instead.
+
+### Placement by `order`
+
+`order` is a signed coordinate around the input:
+
+- `order > 0` — above the input, higher nearer the top (default `100`).
+- `order === 0` — the primary line just below the input, overriding the built-in `agent · model`. This is the statusline slot; use `customizing-statusline` for that work.
+- `order < 0` — stacks below the primary line, `-1` closest.
+
+A panel whose `render` is empty (`""`, `[]`, or only blank lines) is hidden.
+
+### Render context
+
+```ts
+render(ctx: {
+  width: number;
+  agent: { id, name };
+  model: { id, displayName, provider, reasoningEffort };
+  row(left, right, width): string;
+  columns(parts: string[], width): string;
+  chalk: ChalkInstance;
+}): string | string[]
+```
+
+`row`/`columns` are ANSI-aware, so chalk-colored segments align correctly.
 
 Close panels when they are transient, and close/replace long-lived panels from the activation disposer if reload should remove them.
-
-## Status values
-
-```ts
-if (letta.capabilities.ui.statusValues) {
-  letta.ui.setStatus("branch", "main");
-}
-```
-
-Clear status values in disposers if they are owned by timers, events, or external state:
-
-```ts
-return () => {
-  letta.ui.clearStatus("branch");
-};
-```
 
 ## Timers and cleanup
 
 ```ts
 export default function activate(letta) {
-  if (!letta.capabilities.ui.statusValues) return;
+  if (!letta.capabilities.ui.panels) return;
 
-  const update = () => letta.ui.setStatus("clock", new Date().toLocaleTimeString());
-  update();
-  const timer = setInterval(update, 30_000);
+  let clock = new Date().toLocaleTimeString();
+  const panel = letta.ui.openPanel({
+    id: "clock",
+    order: 100,
+    render: ({ width, row }) => row("clock", clock, width),
+  });
+
+  const timer = setInterval(() => {
+    clock = new Date().toLocaleTimeString();
+    panel.update();
+  }, 30_000);
 
   return () => {
     clearInterval(timer);
-    letta.ui.clearStatus("clock");
+    panel.close();
   };
 }
 ```

--- a/src/skills/builtin/customizing-statusline/SKILL.md
+++ b/src/skills/builtin/customizing-statusline/SKILL.md
@@ -11,28 +11,28 @@ Use this skill to create or update the global Letta Code statusline mod:
 ~/.letta/mods/statusline.tsx
 ```
 
-The statusline is a full-row idle renderer. Host UI can still temporarily preempt it for safety confirmations and transient hints.
+The statusline is a panel registered at `order: 0` — the primary line just below the input. It overrides the built-in `agent · model` line. Host UI can still temporarily preempt it for safety confirmations and transient hints.
 
 ## Statusline ownership model
 
 ```text
 safety preemption
 else transient host hint
-else custom statusline mod
+else order-0 statusline panel
 else built-in default statusline
 ```
 
-A custom statusline owns the whole idle row. Do not preserve legacy left/right split semantics in the new API.
+The order-0 panel owns the whole primary row. It renders text (not React) and owns its own layout via the `row`/`columns` helpers.
 
 ## Workflow
 
 1. Check whether `~/.letta/mods/statusline.tsx` exists.
 2. If it exists, read it before editing and preserve unrelated code.
-3. If it does not exist, start from the built-in default template or synthesize a focused starter for the user's request.
+3. If it does not exist, synthesize a focused starter for the user's request.
 4. If the user asks to migrate, import a `.sh` file, or match a shell prompt, read `references/migration.md`.
 5. If API details or concrete patterns are needed, read `references/api.md` and `references/examples.md`.
-6. If the request combines statusline work with commands, tools, events, panels, or stateful mod behavior, also use `creating-mods` and its `references/architecture.md`.
-7. Guard statusline-specific behavior with `letta.capabilities.ui.customStatuslineRenderer` when writing new files.
+6. If the request combines statusline work with commands, tools, events, other panels, or stateful mod behavior, also use `creating-mods` and its `references/architecture.md`.
+7. Guard panel work with `letta.capabilities.ui.panels` when writing new files.
 8. Edit `~/.letta/mods/statusline.tsx`.
 9. Summarize the absolute file path changed and tell the user to run `/reload` unless the command can reload automatically.
 
@@ -42,7 +42,7 @@ If the user ran `/statusline` without a specific request:
 
 - If a custom statusline file exists, summarize what it appears to do and ask what they want to change.
 - If no custom file exists, explain that Letta is using the built-in default statusline and offer focused next steps:
-  1. start from the default Letta statusline
+  1. start from a simple `agent · model` statusline
   2. add project info like git branch, worktree, or PR
   3. migrate an existing legacy statusline `.sh` file
   4. match shell prompt / PS1
@@ -56,16 +56,15 @@ Keep this conversational. Do not build a menu UI unless the product command expl
 - Keep the mod single-file for MVP.
 - Do not assume extra npm packages are available.
 - Do not use relative multi-file imports yet.
-- Keep renderers synchronous. Do not shell, fetch, or await inside render.
-- Do async work in setup code, intervals, subscriptions, or status providers.
-- Use `letta.ui.setStatus` for data and `setStatuslineRenderer` for drawing that data.
-- Guard optional APIs with `letta.capabilities.ui.statusValues` and `letta.capabilities.ui.customStatuslineRenderer` in new files.
-- Return a disposer that clears timers/subscriptions.
+- Keep `render` synchronous and side-effect-free. Do not shell, fetch, await, or read files inside render.
+- Do async work in setup code, intervals, or subscriptions, store the result in a closure variable, then call `panel.update()` to re-render.
+- Register the statusline at `order: 0`. Compose left/right with `row(left, right, width)`; color with `chalk`.
+- Guard panel work with `letta.capabilities.ui.panels` in new files.
+- Return a disposer that clears timers/subscriptions and calls `panel.close()`.
 - Preserve existing mod code unless the user asks to reset.
-- Do not delete legacy command statusline files or settings unless the user explicitly asks.
 
 ## Useful references
 
-- `references/api.md` - mod API, render context, lifecycle rules
+- `references/api.md` - panel API, render context, lifecycle rules
 - `references/examples.md` - common statusline patterns
 - `references/migration.md` - legacy command `.sh` and PS1 migration

--- a/src/skills/builtin/customizing-statusline/references/api.md
+++ b/src/skills/builtin/customizing-statusline/references/api.md
@@ -12,48 +12,74 @@ This is a trusted, user-owned global mod file. Project mods are intentionally un
 
 ## Activation
 
-Export a default function or named `activate` function:
+Export a default function or named `activate` function. The statusline is a panel at `order: 0`:
 
 ```tsx
 export default function activate(letta) {
-  if (!letta.capabilities.ui.customStatuslineRenderer) return;
+  if (!letta.capabilities.ui.panels) return;
 
-  letta.ui.setStatuslineRenderer((context) => {
-    const { Text } = context.components;
-    return <Text>{context.agent.name} · {context.model.displayName}</Text>;
+  const panel = letta.ui.openPanel({
+    id: "statusline",
+    order: 0, // primary line: overrides the built-in agent · model
+    render: ({ width, agent, model, row, chalk }) => {
+      const left = chalk.cyan(agent.name ?? "Letta");
+      const right = chalk.dim(model.displayName ?? "no model");
+      return row(left, right, width);
+    },
   });
+
+  return () => panel.close();
 }
 ```
 
 ## API
 
 ```ts
-letta.capabilities.ui.statusValues: boolean
-letta.capabilities.ui.customStatuslineRenderer: boolean
+letta.capabilities.ui.panels: boolean
 
-letta.ui.setStatus(key: string, value: string | null | undefined | ((context) => string | null)): void
-letta.ui.clearStatus(key: string): void
-letta.ui.setStatuslineRenderer(renderer: StatuslineRenderer | ((context) => ReactNode | null)): void
+letta.ui.openPanel(options: {
+  id: string;
+  order?: number; // default 100
+  render: (ctx) => string | string[];
+}): { close(): void; update(opts?: { order?: number }): void }
+
+letta.ui.closePanel(id: string): void
 ```
 
-`setStatus` stores named string values. Renderers read evaluated values from `context.statuses`.
+`openPanel` registers (or replaces, by `id`) a panel. `render` returns the panel body as a string or an array of strings (one per line). Call the returned handle's `update()` to re-render after state changes, and `close()` to remove it.
 
-```tsx
-letta.ui.setStatus("branch", "main");
+## Order placement
 
-letta.ui.setStatuslineRenderer((context) => {
-  const { Text } = context.components;
-  return <Text>{context.statuses.branch}</Text>;
-});
+`order` is a signed coordinate around the input:
+
+- `order > 0` — above the input. Higher numbers render nearer the top. Default when omitted is `100`.
+- `order === 0` — the primary line just below the input. Overrides the built-in `agent · model`. Use this for the statusline.
+- `order < 0` — stacks below the primary line. `-1` sits closest to it, more-negative lower.
+
+A panel whose `render` returns empty (`""` or `[]`, or only blank lines) is hidden entirely — no blank row.
+
+## Render context
+
+```ts
+render(ctx: {
+  width: number;            // visible columns available to the panel
+  agent: { id, name };      // live at render time
+  model: { id, displayName, provider, reasoningEffort };
+  row(left, right, width): string;     // left + right, right-aligned, ANSI-aware
+  columns(parts: string[], width): string; // spread parts evenly, ANSI-aware
+  chalk: ChalkInstance;     // color helper
+}): string | string[]
 ```
 
-## Renderer rules
+- `row`/`columns` measure visible width with ANSI stripped, so chalk-colored segments align correctly.
+- The host clips each line to `width` and caps total height; the mod owns layout within that.
 
-- Renderer owns the entire idle bottom row.
-- Renderer must be synchronous.
-- Do not run shell commands, network requests, file reads, or awaits inside render.
-- Do async work in setup code or intervals, store results with `setStatus`, then render `context.statuses`.
-- Return `null` only when intentionally rendering nothing.
+## Render rules
+
+- `render` must be synchronous and side-effect-free.
+- Do not run shell commands, network requests, file reads, or awaits inside `render`.
+- Do async work in setup code or intervals, store the result in a closure variable, then call `panel.update()`.
+- Return `""` (or `[]`) to render nothing.
 
 ## Async state pattern
 
@@ -66,92 +92,54 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 export default function activate(letta) {
-  if (!letta.capabilities.ui.customStatuslineRenderer) return;
+  if (!letta.capabilities.ui.panels) return;
+
+  let branch = "";
+
+  const panel = letta.ui.openPanel({
+    id: "statusline",
+    order: 0,
+    render: ({ width, agent, row, chalk }) => {
+      const left = branch ? chalk.green(`\u2442 ${branch}`) : (agent.name ?? "Letta");
+      return row(left, "", width);
+    },
+  });
 
   const update = async () => {
     try {
       const { stdout } = await execFileAsync("git", ["branch", "--show-current"], {
         cwd: process.cwd(),
       });
-      if (letta.capabilities.ui.statusValues) {
-        letta.ui.setStatus("branch", stdout.trim());
-      }
+      branch = stdout.trim();
     } catch {
-      if (letta.capabilities.ui.statusValues) {
-        letta.ui.clearStatus("branch");
-      }
+      branch = "";
     }
+    panel.update();
   };
-
-  letta.ui.setStatuslineRenderer((context) => {
-    const { Text } = context.components;
-    const branch = context.statuses.branch;
-    return <Text>{branch ? `branch ${branch}` : context.agent.name}</Text>;
-  });
 
   void update();
   const timer = setInterval(update, 30_000);
 
   return () => {
     clearInterval(timer);
-    if (letta.capabilities.ui.statusValues) {
-      letta.ui.clearStatus("branch");
-    }
+    panel.close();
   };
 }
 ```
 
-## Context fields
-
-The app statusline render context source types live near:
-
-```text
-src/cli/display/statusline/types.ts
-src/cli/display/statusline/context.ts
-```
-
-Common fields:
-
-```ts
-context.components      // Display components such as Text, Box, Spacer
-context.statuses        // evaluated mod status strings
-context.app.version
-context.workspace.cwd
-context.workspace.currentDir
-context.workspace.projectDir
-context.agent.name
-context.agent.id
-context.model.id
-context.model.displayName
-context.model.provider
-context.model.reasoningEffort
-context.permissionMode
-context.terminalWidth
-context.contextWindow.usedPercentage
-context.contextWindow.remainingPercentage
-context.cost.totalDurationMs
-context.cost.totalCostUsd
-context.reflection
-context.memfs
-context.backgroundAgents
-context.rawPayload      // compatibility payload for advanced cases
-```
-
-Prefer semantic fields over `rawPayload` unless migrating old command statuslines.
-
 ## Full-row layout
 
-New statuslines do not have a host left/right API. To create left/right visual alignment, do it inside the renderer:
+There is no host left/right API. Build left/right alignment inside `render` with `row`:
 
 ```tsx
-return (
-  <Box flexDirection="row">
-    <Box flexGrow={1}>
-      <Text>left content</Text>
-    </Box>
-    <Text>right content</Text>
-  </Box>
-);
+render: ({ width, agent, model, row, chalk }) =>
+  row(chalk.dim("Press / for commands"), `${agent.name ?? "Letta"} \u00b7 ${model.displayName ?? ""}`, width),
+```
+
+Use `columns` for three or more evenly-spread segments:
+
+```tsx
+render: ({ width, columns }) => columns(["left", "middle", "right"], width),
 ```
 
 ## Reload behavior
@@ -162,4 +150,4 @@ After editing `~/.letta/mods/statusline.tsx`, tell the user to run:
 /reload
 ```
 
-The runtime tracks mod loading separately from “no custom statusline,” so a custom statusline should not flash back to the built-in default during reload.
+The runtime tracks mod loading so a custom statusline does not flash back to the built-in default during reload.

--- a/src/skills/builtin/customizing-statusline/references/examples.md
+++ b/src/skills/builtin/customizing-statusline/references/examples.md
@@ -1,17 +1,25 @@
 # Statusline Examples
 
-Use these as patterns, not mandatory templates. Keep the final mod focused on the user's request.
+Use these as patterns, not mandatory templates. Keep the final mod focused on the user's request. All register at `order: 0` (the primary line) and return text composed with `row`/`columns`/`chalk`.
 
 ## Agent and model
 
 ```tsx
 export default function activate(letta) {
-  if (!letta.capabilities.ui.customStatuslineRenderer) return;
+  if (!letta.capabilities.ui.panels) return;
 
-  letta.ui.setStatuslineRenderer((context) => {
-    const { Text } = context.components;
-    return <Text>{context.agent.name ?? "Letta"} · {context.model.displayName ?? "no model"}</Text>;
+  const panel = letta.ui.openPanel({
+    id: "statusline",
+    order: 0,
+    render: ({ width, agent, model, row, chalk }) =>
+      row(
+        chalk.cyan(agent.name ?? "Letta"),
+        chalk.dim(model.displayName ?? "no model"),
+        width,
+      ),
   });
+
+  return () => panel.close();
 }
 ```
 
@@ -24,28 +32,35 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 export default function activate(letta) {
-  if (!letta.capabilities.ui.customStatuslineRenderer) return;
+  if (!letta.capabilities.ui.panels) return;
+
+  let branch = "";
+
+  const panel = letta.ui.openPanel({
+    id: "statusline",
+    order: 0,
+    render: ({ width, agent, row, chalk }) =>
+      row(branch ? chalk.green(`git ${branch}`) : (agent.name ?? "Letta"), "", width),
+  });
 
   const update = async () => {
     try {
       const { stdout } = await execFileAsync("git", ["branch", "--show-current"], {
         cwd: process.cwd(),
       });
-      letta.ui.setStatus("branch", stdout.trim());
+      branch = stdout.trim();
     } catch {
-      letta.ui.clearStatus("branch");
+      branch = "";
     }
+    panel.update();
   };
-
-  letta.ui.setStatuslineRenderer((context) => {
-    const { Text } = context.components;
-    const branch = context.statuses.branch;
-    return <Text>{branch ? `git ${branch}` : context.agent.name}</Text>;
-  });
 
   void update();
   const timer = setInterval(update, 30_000);
-  return () => clearInterval(timer);
+  return () => {
+    clearInterval(timer);
+    panel.close();
+  };
 }
 ```
 
@@ -53,21 +68,20 @@ export default function activate(letta) {
 
 ```tsx
 export default function activate(letta) {
-  if (!letta.capabilities.ui.customStatuslineRenderer) return;
+  if (!letta.capabilities.ui.panels) return;
 
-  letta.ui.setStatuslineRenderer((context) => {
-    const { Box, Text } = context.components;
-    const model = context.model.displayName ?? "no model";
-
-    return (
-      <Box flexDirection="row">
-        <Box flexGrow={1}>
-          <Text dimColor>Press / for commands</Text>
-        </Box>
-        <Text>{context.agent.name ?? "Letta"} · {model}</Text>
-      </Box>
-    );
+  const panel = letta.ui.openPanel({
+    id: "statusline",
+    order: 0,
+    render: ({ width, agent, model, row, chalk }) =>
+      row(
+        chalk.dim("Press / for commands"),
+        `${agent.name ?? "Letta"} \u00b7 ${model.displayName ?? "no model"}`,
+        width,
+      ),
   });
+
+  return () => panel.close();
 }
 ```
 
@@ -80,7 +94,15 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 export default function activate(letta) {
-  if (!letta.capabilities.ui.customStatuslineRenderer) return;
+  if (!letta.capabilities.ui.panels) return;
+
+  let pr = "";
+
+  const panel = letta.ui.openPanel({
+    id: "statusline",
+    order: 0,
+    render: ({ width, model, row }) => row(pr || (model.displayName ?? ""), "", width),
+  });
 
   const update = async () => {
     try {
@@ -89,21 +111,19 @@ export default function activate(letta) {
         ["pr", "view", "--json", "number,title", "--jq", "\"#\\(.number) \\(.title)\""],
         { cwd: process.cwd() },
       );
-      const pr = stdout.trim();
-      pr ? letta.ui.setStatus("pr", pr) : letta.ui.clearStatus("pr");
+      pr = stdout.trim();
     } catch {
-      letta.ui.clearStatus("pr");
+      pr = "";
     }
+    panel.update();
   };
-
-  letta.ui.setStatuslineRenderer((context) => {
-    const { Text } = context.components;
-    return <Text>{context.statuses.pr ?? context.model.displayName}</Text>;
-  });
 
   void update();
   const timer = setInterval(update, 60_000);
-  return () => clearInterval(timer);
+  return () => {
+    clearInterval(timer);
+    panel.close();
+  };
 }
 ```
 
@@ -116,26 +136,34 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 export default function activate(letta) {
-  if (!letta.capabilities.ui.customStatuslineRenderer) return;
+  if (!letta.capabilities.ui.panels) return;
+
+  let music = "";
+
+  const panel = letta.ui.openPanel({
+    id: "statusline",
+    order: 0,
+    render: ({ width, agent, row, chalk }) =>
+      row(music ? chalk.magenta(music) : (agent.name ?? "Letta"), "", width),
+  });
 
   const update = async () => {
     try {
-      const script = 'tell application "Music" to if it is running then artist of current track & " - " & name of current track';
+      const script =
+        'tell application "Music" to if it is running then artist of current track & " - " & name of current track';
       const { stdout } = await execFileAsync("osascript", ["-e", script]);
-      const music = stdout.trim();
-      music ? letta.ui.setStatus("music", music) : letta.ui.clearStatus("music");
+      music = stdout.trim();
     } catch {
-      letta.ui.clearStatus("music");
+      music = "";
     }
+    panel.update();
   };
-
-  letta.ui.setStatuslineRenderer((context) => {
-    const { Text } = context.components;
-    return <Text>{context.statuses.music ?? context.agent.name}</Text>;
-  });
 
   void update();
   const timer = setInterval(update, 15_000);
-  return () => clearInterval(timer);
+  return () => {
+    clearInterval(timer);
+    panel.close();
+  };
 }
 ```

--- a/src/skills/builtin/customizing-statusline/references/migration.md
+++ b/src/skills/builtin/customizing-statusline/references/migration.md
@@ -1,6 +1,6 @@
 # Statusline Migration
 
-Use this reference when migrating legacy command statuslines, standalone `.sh` statusline scripts, or shell PS1 prompts.
+Use this reference when migrating legacy command statuslines, standalone `.sh` statusline scripts, or shell PS1 prompts into `~/.letta/mods/statusline.tsx`.
 
 ## Legacy Letta command statusline
 
@@ -40,10 +40,10 @@ When migrating:
 
 - Preserve old config and referenced files unless the user explicitly asks to delete them.
 - If `command` references a `.sh` file, read it before writing the new mod.
-- Translate polling (`refreshIntervalMs`) to `setInterval`.
-- Translate direct command output into cached status plus synchronous rendering.
-- If the command output used `\x1e` to split left/right output, convert it to internal full-row layout with `Box`; do not create a new left/right API.
-- Treat old prompt customization separately. The new statusline controls the bottom row, not necessarily the input prompt.
+- Translate polling (`refreshIntervalMs`) to `setInterval` + `panel.update()`.
+- Translate direct command output into a cached closure variable plus synchronous rendering.
+- If the command output used `\x1e` to split left/right output, convert it to `row(left, right, width)`; there is no separate left/right API.
+- Treat old prompt customization separately. The statusline controls the primary row, not necessarily the input prompt.
 
 Old model:
 
@@ -59,17 +59,36 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
-const update = async () => {
-  const { stdout } = await execFileAsync("git", ["branch", "--show-current"], {
-    cwd: process.cwd(),
-  });
-  letta.ui.setStatus("branch", stdout.trim());
-};
+export default function activate(letta) {
+  if (!letta.capabilities.ui.panels) return;
 
-letta.ui.setStatuslineRenderer((context) => {
-  const { Text } = context.components;
-  return <Text>{context.statuses.branch ?? ""}</Text>;
-});
+  let branch = "";
+
+  const panel = letta.ui.openPanel({
+    id: "statusline",
+    order: 0,
+    render: ({ width, row }) => row(branch, "", width),
+  });
+
+  const update = async () => {
+    try {
+      const { stdout } = await execFileAsync("git", ["branch", "--show-current"], {
+        cwd: process.cwd(),
+      });
+      branch = stdout.trim();
+    } catch {
+      branch = "";
+    }
+    panel.update();
+  };
+
+  void update();
+  const timer = setInterval(update, 30_000);
+  return () => {
+    clearInterval(timer);
+    panel.close();
+  };
+}
 ```
 
 ## Standalone `.sh` file migration
@@ -79,11 +98,11 @@ If the user provides a `.sh` path:
 1. Read the script.
 2. Identify commands, expected stdin JSON, environment variables, and output shape.
 3. Port shell commands to async setup/update code.
-4. Store results with `letta.ui.setStatus(key, value)`.
-5. Render cached status synchronously.
-6. Preserve graceful fallbacks for missing tools, not-a-git-repo, no PR, etc.
+4. Store results in closure variables.
+5. Render cached state synchronously and call `panel.update()` after each refresh.
+6. Preserve graceful fallbacks for missing tools, not-a-git-repo, no PR, etc. (return `""` to hide the line).
 
-If a script depends heavily on stdin JSON, use `context.rawPayload` as a temporary migration aid, but prefer semantic context fields for new code.
+Map the script's stdin JSON to the render context's semantic fields (`agent`, `model`, `width`); compute anything else in setup/update code.
 
 ## Shell PS1 import
 
@@ -127,4 +146,4 @@ If no PS1 is found and the user did not provide other instructions, ask for one 
 2. a description of what their prompt shows
 3. the current prompt output as it appears in their terminal
 
-Preserve colors where practical using display components. If the PS1 is too dynamic to port exactly, ask whether to approximate it or port specific commands.
+Preserve colors where practical with `chalk`. If the PS1 is too dynamic to port exactly, ask whether to approximate it or port specific commands.

--- a/src/websocket/listener/mod-adapter.test.ts
+++ b/src/websocket/listener/mod-adapter.test.ts
@@ -56,8 +56,6 @@ describe("listener mod adapter", () => {
       providers: true,
       ui: {
         panels: false,
-        statusValues: false,
-        customStatuslineRenderer: false,
       },
     });
   });
@@ -186,7 +184,6 @@ describe("listener mod adapter", () => {
     });
     expect(snapshot.events).toEqual({});
     expect(snapshot.ui.panels).toEqual({});
-    expect(snapshot.ui.statusValues).toEqual({});
 
     adapter.dispose();
     expect(getRegisteredPiProvider("kilo")).toBeUndefined();

--- a/src/websocket/listener/mod-adapter.ts
+++ b/src/websocket/listener/mod-adapter.ts
@@ -18,8 +18,6 @@ export const LISTENER_MOD_CAPABILITIES: ModCapabilities = {
   providers: true,
   ui: {
     panels: false,
-    statusValues: false,
-    customStatuslineRenderer: false,
   },
 };
 


### PR DESCRIPTION
## Summary
- Unify mod UI under a single `openPanel` primitive placed by a signed `order`: `>0` renders above the input (highest at top), `0` is the primary line that overrides the built-in `agent · model`, and `<0` stacks below it. A panel whose render is empty is hidden.
- Remove the separate statusline system entirely — `setStatus`/`clearStatus`/`setStatuslineRenderer`, the `statusValues`/`customStatuslineRenderer` capabilities, and the single-owner renderer path. Removed calls no-op and emit a migration diagnostic, backed by a load-time source scan.
- Panel render context now carries live `agent`/`model` plus ANSI-aware `row()`/`columns()` layout helpers and a `chalk` instance; `clearPanel` renamed to `closePanel`.
- Update `creating-mods` and `customizing-statusline` skills/docs to the new API (statusline = `openPanel({ id: "statusline", order: 0, render })` returning text).

## Test plan
- [x] `tsc --noEmit` clean (source + tests)
- [x] `bun test` for the affected mod suites (87 pass / 0 fail)
- [ ] Manual: order-0 statusline overrides the default line; `>0` stacks above input, `<0` below; empty render hides the row; `/gitstatus` renders below; an old `setStatus`/`setStatuslineRenderer` mod no-ops with a migration diagnostic and the default line still shows

👾 Generated with [Letta Code](https://letta.com)