### PR TITLE
feat(tools): guard MessageChannel against no-op calls

### DIFF
--- a/src/channels/message-channel.test.ts
+++ b/src/channels/message-channel.test.ts
@@ -1189,7 +1189,10 @@ describe("MessageChannel", () => {
       },
     });
 
-    expect(result).toBe("Error: Slack send requires message or media.");
+    // The no-op guard catches this before the Slack plugin's own validation,
+    // since the legacy `text` alias is ignored and `message` is absent.
+    expect(result).toContain("Error");
+    expect(result).toContain("requires a non-empty message or media");
     expect(sendMessage).not.toHaveBeenCalled();
   });
 

--- a/src/tools/impl/message-channel.test.ts
+++ b/src/tools/impl/message-channel.test.ts
@@ -376,6 +376,14 @@ describe("message_channel (signal)", () => {
 });
 
 describe("message_channel (no-op guard)", () => {
+  afterEach(async () => {
+    const registry = getChannelRegistry();
+    if (registry) {
+      await registry.stopAll();
+    }
+    clearAllRoutes();
+  });
+
   test("send with no message or media returns an error", async () => {
     const result = await message_channel({
       action: "send",

--- a/src/tools/impl/message-channel.test.ts
+++ b/src/tools/impl/message-channel.test.ts
@@ -374,3 +374,108 @@ describe("message_channel (signal)", () => {
     );
   });
 });
+
+describe("message_channel (no-op guard)", () => {
+  test("send with no message or media returns an error", async () => {
+    const result = await message_channel({
+      action: "send",
+      channel: "slack",
+      chat_id: "C123",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    });
+
+    expect(result).toContain("Error");
+    expect(result).toContain("requires a non-empty message or media");
+  });
+
+  test("send with empty message string returns an error", async () => {
+    const result = await message_channel({
+      action: "send",
+      channel: "slack",
+      chat_id: "C123",
+      message: "   ",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    });
+
+    expect(result).toContain("Error");
+    expect(result).toContain("requires a non-empty message or media");
+  });
+
+  test("react with no emoji returns an error", async () => {
+    const result = await message_channel({
+      action: "react",
+      channel: "slack",
+      chat_id: "C123",
+      messageId: "msg-1",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    });
+
+    expect(result).toContain("Error");
+    expect(result).toContain("requires a non-empty emoji");
+  });
+
+  test("upload-file with no media returns an error", async () => {
+    const result = await message_channel({
+      action: "upload-file",
+      channel: "slack",
+      chat_id: "C123",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    });
+
+    expect(result).toContain("Error");
+    expect(result).toContain("requires a media file path");
+  });
+
+  test("send with media but no message text is allowed", async () => {
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({ messageId: "msg-1" }));
+    const adapter: ChannelAdapter = {
+      id: "discord:discord-1",
+      channelId: "discord",
+      accountId: "discord-1",
+      name: "Discord",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+
+    setRouteInMemory("discord", {
+      accountId: "discord-1",
+      chatId: "DM-123",
+      agentId: "agent-1",
+      conversationId: "default",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const result = await message_channel({
+      action: "send",
+      channel: "discord",
+      chat_id: "DM-123",
+      media: "/tmp/photo.png",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+    });
+
+    expect(result).toContain("discord");
+  });
+});

--- a/src/tools/impl/message-channel.ts
+++ b/src/tools/impl/message-channel.ts
@@ -941,6 +941,34 @@ function normalizeMessageChannelInput(
   };
 }
 
+/**
+ * Validates that a normalized MessageChannel call would actually produce
+ * output (text, media, or a reaction). Returns an error string if the call
+ * is a no-op, or undefined if the call is valid.
+ */
+function validateMessageChannelNoOp(
+  input: NormalizedMessageChannelInput,
+): string | undefined {
+  switch (input.action) {
+    case "send":
+      if (!input.message && !input.mediaPath) {
+        return 'Error: MessageChannel "send" requires a non-empty message or media attachment. Provide a message or media path.';
+      }
+      break;
+    case "react":
+      if (!input.emoji) {
+        return 'Error: MessageChannel "react" requires a non-empty emoji.';
+      }
+      break;
+    case "upload-file":
+      if (!input.mediaPath) {
+        return 'Error: MessageChannel "upload-file" requires a media file path.';
+      }
+      break;
+  }
+  return undefined;
+}
+
 function buildMessageChannelRequest(
   input: NormalizedMessageChannelInput,
   chatId: string,
@@ -1100,6 +1128,20 @@ async function resolveExplicitMessageChannelContext(params: {
 export async function message_channel(
   args: MessageChannelArgs,
 ): Promise<string> {
+  // Normalize and validate input first — these checks don't need the registry.
+  const input = normalizeMessageChannelInput(args);
+  if (typeof input === "string") {
+    return input;
+  }
+
+  // Guard against no-op calls: an agent calling MessageChannel without any
+  // text, media, or reaction would silently send an empty message. Catch
+  // this early so the agent sees an explicit error and can correct itself.
+  const noopError = validateMessageChannelNoOp(input);
+  if (noopError) {
+    return noopError;
+  }
+
   const registry = getChannelRegistry();
   if (!registry) {
     return "Error: Channel system is not initialized. Start with --channels flag.";
@@ -1111,11 +1153,6 @@ export async function message_channel(
   const scope = args.parentScope;
   if (!scope) {
     return "Error: MessageChannel requires execution scope (agentId + conversationId).";
-  }
-
-  const input = normalizeMessageChannelInput(args);
-  if (typeof input === "string") {
-    return input;
   }
 
   try {


### PR DESCRIPTION
## Problem

Agents can call `MessageChannel` with no message text, no media, and no reaction — silently sending an empty message to the channel. This was causing Kian's Telegram channel to receive blank messages.

## Change

Added `validateMessageChannelNoOp()` which rejects calls that would produce no output:

- `send` with no message text and no media → error
- `react` with no emoji → error
- `upload-file` with no media path → error

The check runs after input normalization but before registry/scope resolution, so the agent gets an immediate, actionable error string without needing the channel system to be initialized.

Input normalization already trims whitespace via `firstNonEmptyString`, so a message of `"   "` is treated as absent.

## Validation

- 5 new test cases covering each no-op scenario plus a positive case (media-only send is allowed)
- All 12 tests in `message-channel.test.ts` pass
- Biome lint clean on changed files
- Pre-commit hooks (layer boundaries, filename casing, type-check) passed

## Co-author

Cameron requested this from the bug-bash Slack thread after Kian reported empty Telegram messages.