### PR TITLE
feat(mods): add conversation handle updateLlmConfig for model/reasoning/context window

### DIFF
--- a/src/agent/modify-update-model-config.test.ts
+++ b/src/agent/modify-update-model-config.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import type { Backend } from "@/backend";
+import { type ModelConfigTarget, updateModelConfig } from "./modify";
+
+type UpdateCall = { id: string; body: Record<string, unknown> };
+
+function makeBackend(opts?: {
+  localModelCatalog?: boolean;
+  agentModel?: string;
+  conversationModel?: string | null;
+}) {
+  const calls = {
+    updateAgent: [] as UpdateCall[],
+    updateConversation: [] as UpdateCall[],
+    retrieveAgent: 0,
+    retrieveConversation: 0,
+  };
+  const backend = {
+    capabilities: { localModelCatalog: opts?.localModelCatalog ?? false },
+    retrieveAgent: async () => {
+      calls.retrieveAgent += 1;
+      return {
+        model: opts?.agentModel ?? "anthropic/claude-opus-4-8",
+        llm_config: {},
+      };
+    },
+    retrieveConversation: async () => {
+      calls.retrieveConversation += 1;
+      return { model: opts?.conversationModel ?? null };
+    },
+    updateAgent: async (id: string, body: Record<string, unknown>) => {
+      calls.updateAgent.push({ id, body });
+      return {};
+    },
+    updateConversation: async (id: string, body: Record<string, unknown>) => {
+      calls.updateConversation.push({ id, body });
+      return {};
+    },
+  } as unknown as Backend;
+  return { backend, calls };
+}
+
+const conversationTarget: ModelConfigTarget = {
+  scope: "conversation",
+  conversationId: "conv-1",
+  agentId: "agent-1",
+};
+
+describe("updateModelConfig", () => {
+  test("context-window-only sends just context_window_limit, preserving model/settings", async () => {
+    const { backend, calls } = makeBackend();
+    await updateModelConfig(backend, conversationTarget, {
+      contextWindow: 200000,
+    });
+    expect(calls.updateConversation).toHaveLength(1);
+    expect(calls.updateConversation[0]?.body).toEqual({
+      context_window_limit: 200000,
+    });
+    // No model resolution needed when only the context window changes.
+    expect(calls.retrieveConversation).toBe(0);
+    expect(calls.retrieveAgent).toBe(0);
+  });
+
+  test("reasoning-effort-only resolves the current model and rebuilds settings", async () => {
+    const { backend, calls } = makeBackend({
+      agentModel: "anthropic/claude-opus-4-8",
+    });
+    await updateModelConfig(backend, conversationTarget, {
+      reasoningEffort: "high",
+    });
+    expect(calls.updateConversation).toHaveLength(1);
+    const body = calls.updateConversation[0]?.body ?? {};
+    expect(body.model).toBeUndefined();
+    expect(body.context_window_limit).toBeUndefined();
+    expect((body.model_settings as { effort?: string }).effort).toBe("high");
+    // Conversation has no override, so it falls back to the agent's model.
+    expect(calls.retrieveAgent).toBe(1);
+  });
+
+  test("model change rebuilds settings and honors an explicit context window", async () => {
+    const { backend, calls } = makeBackend();
+    await updateModelConfig(backend, conversationTarget, {
+      model: "openai/gpt-5.5",
+      reasoningEffort: "max",
+      contextWindow: 400000,
+    });
+    expect(calls.updateConversation).toHaveLength(1);
+    const body = calls.updateConversation[0]?.body ?? {};
+    expect(body.model).toBe("openai/gpt-5.5");
+    expect(body.context_window_limit).toBe(400000);
+    expect(body.model_settings).toBeDefined();
+    // Model supplied explicitly, so no lookup of the current model is needed.
+    expect(calls.retrieveAgent).toBe(0);
+    expect(calls.retrieveConversation).toBe(0);
+  });
+
+  test("agent scope routes through updateAgent", async () => {
+    const { backend, calls } = makeBackend();
+    await updateModelConfig(
+      backend,
+      { scope: "agent", agentId: "agent-1" },
+      { contextWindow: 123000 },
+    );
+    expect(calls.updateAgent).toHaveLength(1);
+    expect(calls.updateAgent[0]?.body).toEqual({
+      context_window_limit: 123000,
+    });
+    expect(calls.updateConversation).toHaveLength(0);
+  });
+
+  test("empty update is a no-op", async () => {
+    const { backend, calls } = makeBackend();
+    await updateModelConfig(backend, conversationTarget, {});
+    expect(calls.updateConversation).toHaveLength(0);
+    expect(calls.updateAgent).toHaveLength(0);
+  });
+});

--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -8,11 +8,13 @@ import type {
   OpenAIModelSettings,
 } from "@letta-ai/letta-client/resources/agents/agents";
 import type { Conversation } from "@letta-ai/letta-client/resources/conversations/conversations";
+import type { Backend } from "@/backend";
 import { getBackend } from "@/backend";
 import { OPENAI_CODEX_PROVIDER_NAME } from "@/providers/openai-codex-provider";
 import { debugLog } from "@/utils/debug";
 import { isRecord } from "@/utils/type-guards";
 import { getModelContextWindow } from "./available-models";
+import type { ModelReasoningEffort } from "./model";
 
 type ModelSettings =
   | OpenAIModelSettings
@@ -389,6 +391,142 @@ export async function updateConversationLLMConfig(
   } as Parameters<typeof backend.updateConversation>[1];
 
   return backend.updateConversation(conversationId, payload);
+}
+
+export interface ModelConfigUpdate {
+  /** Model handle, e.g. "anthropic/claude-opus-4-8". Omit to keep the current model. */
+  model?: string;
+  /** Reasoning effort tier. Omit to leave reasoning settings untouched. */
+  reasoningEffort?: ModelReasoningEffort;
+  /** Context window limit. Omit to leave the current limit untouched. */
+  contextWindow?: number;
+}
+
+export type ModelConfigTarget =
+  | { scope: "agent"; agentId: string }
+  | { scope: "conversation"; conversationId: string; agentId?: string | null };
+
+function modelHandleFromLlmConfig(
+  llmConfig:
+    | { model?: string | null; model_endpoint_type?: string | null }
+    | null
+    | undefined,
+): string | null {
+  if (!llmConfig) return null;
+  if (llmConfig.model_endpoint_type && llmConfig.model) {
+    return `${llmConfig.model_endpoint_type}/${llmConfig.model}`;
+  }
+  return llmConfig.model ?? null;
+}
+
+async function resolveAgentModelHandle(
+  backend: Backend,
+  agentId: string,
+): Promise<string | null> {
+  const agent = await backend.retrieveAgent(agentId);
+  if (typeof agent.model === "string" && agent.model.length > 0) {
+    return agent.model;
+  }
+  return modelHandleFromLlmConfig(agent.llm_config);
+}
+
+async function resolveCurrentModelHandle(
+  backend: Backend,
+  target: ModelConfigTarget,
+): Promise<string | null> {
+  if (target.scope === "agent") {
+    return resolveAgentModelHandle(backend, target.agentId);
+  }
+  if (target.conversationId !== "default") {
+    const conversation = await backend.retrieveConversation(
+      target.conversationId,
+    );
+    const conversationModel = (conversation as { model?: unknown }).model;
+    if (typeof conversationModel === "string" && conversationModel.length > 0) {
+      return conversationModel;
+    }
+  }
+  return target.agentId
+    ? resolveAgentModelHandle(backend, target.agentId)
+    : null;
+}
+
+/**
+ * Applies a partial model-config update (model, reasoning effort, and/or context
+ * window) without rebuilding settings the caller did not touch.
+ *
+ * - Only `contextWindow`: sends `context_window_limit` alone, preserving the
+ *   current model and model_settings (including reasoning effort).
+ * - `reasoningEffort` without `model`: resolves the current model handle so
+ *   model_settings can be rebuilt for the right provider.
+ * - `model` (with optional effort/context): rebuilds model_settings and derives
+ *   a context window when one is not supplied, matching updateAgentLLMConfig.
+ *
+ * Routes through the supplied backend's updateAgent/updateConversation, so it
+ * works for both local and constellation agents.
+ */
+export async function updateModelConfig(
+  backend: Backend,
+  target: ModelConfigTarget,
+  update: ModelConfigUpdate,
+): Promise<void> {
+  const touchesModelSettings =
+    update.model !== undefined || update.reasoningEffort !== undefined;
+
+  let modelHandle = update.model;
+  if (touchesModelSettings && !modelHandle) {
+    modelHandle =
+      (await resolveCurrentModelHandle(backend, target)) ?? undefined;
+    if (!modelHandle) {
+      throw new Error(
+        "updateModelConfig: cannot change reasoning effort because the current model could not be resolved",
+      );
+    }
+  }
+
+  const useBackendModelCatalog = backend.capabilities.localModelCatalog;
+  const updateArgs =
+    update.reasoningEffort !== undefined
+      ? { reasoning_effort: update.reasoningEffort }
+      : undefined;
+
+  const modelSettings =
+    touchesModelSettings && modelHandle
+      ? buildModelSettings(
+          modelHandle,
+          updateArgsForModelSettings(updateArgs, { useBackendModelCatalog }),
+        )
+      : undefined;
+  const hasModelSettings =
+    modelSettings !== undefined && Object.keys(modelSettings).length > 0;
+
+  // Honor an explicit context window regardless of catalog mode; only derive a
+  // default (on model change) when the backend does not own the catalog.
+  const contextWindow =
+    update.contextWindow ??
+    (update.model !== undefined && !useBackendModelCatalog
+      ? await getModelContextWindow(update.model)
+      : undefined);
+
+  const patch = {
+    ...(update.model !== undefined && { model: update.model }),
+    ...(hasModelSettings && { model_settings: modelSettings }),
+    ...(contextWindow !== undefined && { context_window_limit: contextWindow }),
+  };
+
+  if (Object.keys(patch).length === 0) return;
+
+  if (target.scope === "agent") {
+    await backend.updateAgent(
+      target.agentId,
+      patch as Parameters<typeof backend.updateAgent>[1],
+    );
+  } else {
+    await backend.updateConversation(
+      target.conversationId,
+      patch as Parameters<typeof backend.updateConversation>[1],
+    );
+  }
 }
 
 /**

--- a/src/cli/mods/local-mod-loader.test.ts
+++ b/src/cli/mods/local-mod-loader.test.ts
@@ -657,6 +657,7 @@ export default function(letta) {
               },
               getHistory: async () => [],
               sendMessageStream: async () => (async function* () {})(),
+              updateLlmConfig: async () => {},
             },
             cwd: "/tmp/project",
             model: {
@@ -713,6 +714,7 @@ export default function(letta) {
                   },
                   getHistory: async () => [],
                   sendMessageStream: async () => (async function* () {})(),
+                  updateLlmConfig: async () => {},
                 },
                 rawInput: "/legacy-command",
               })
@@ -769,6 +771,7 @@ export default function(letta) {
               },
               getHistory: async () => [],
               sendMessageStream: async () => (async function* () {})(),
+              updateLlmConfig: async () => {},
             },
             cwd: "/tmp/project",
             model: {

--- a/src/mods/conversation-handle.test.ts
+++ b/src/mods/conversation-handle.test.ts
@@ -66,4 +66,79 @@ describe("mod conversation handle", () => {
       "Mod conversation backend is not available",
     );
   });
+
+  test("updateLlmConfig defaults to conversation scope", async () => {
+    const calls: Array<{ kind: string; id: string; body: unknown }> = [];
+    const backend = {
+      capabilities: { localModelCatalog: false },
+      updateConversation: async (id: string, body: unknown) => {
+        calls.push({ kind: "conversation", id, body });
+        return {};
+      },
+      updateAgent: async (id: string, body: unknown) => {
+        calls.push({ kind: "agent", id, body });
+        return {};
+      },
+    } as unknown as Backend;
+
+    const handle = createModConversationHandle({
+      agentId: "agent-1",
+      backend,
+      conversationId: "conversation-1",
+      sendMessageStream,
+    });
+
+    await handle.updateLlmConfig({ contextWindow: 200000 });
+
+    expect(calls).toEqual([
+      {
+        kind: "conversation",
+        id: "conversation-1",
+        body: { context_window_limit: 200000 },
+      },
+    ]);
+  });
+
+  test("updateLlmConfig with agent scope routes to the agent", async () => {
+    const calls: Array<{ kind: string; id: string }> = [];
+    const backend = {
+      capabilities: { localModelCatalog: false },
+      updateConversation: async (id: string) => {
+        calls.push({ kind: "conversation", id });
+        return {};
+      },
+      updateAgent: async (id: string) => {
+        calls.push({ kind: "agent", id });
+        return {};
+      },
+    } as unknown as Backend;
+
+    const handle = createModConversationHandle({
+      agentId: "agent-1",
+      backend,
+      conversationId: "conversation-1",
+      sendMessageStream,
+    });
+
+    await handle.updateLlmConfig({ scope: "agent", contextWindow: 123000 });
+
+    expect(calls).toEqual([{ kind: "agent", id: "agent-1" }]);
+  });
+
+  test("updateLlmConfig agent scope throws when agentId is unavailable", async () => {
+    const backend = {
+      capabilities: { localModelCatalog: false },
+      updateAgent: async () => ({}),
+    } as unknown as Backend;
+
+    const handle = createModConversationHandle({
+      backend,
+      conversationId: "conversation-1",
+      sendMessageStream,
+    });
+
+    await expect(
+      handle.updateLlmConfig({ scope: "agent", contextWindow: 1000 }),
+    ).rejects.toThrow("agentId is not available");
+  });
 });

--- a/src/mods/conversation-handle.ts
+++ b/src/mods/conversation-handle.ts
@@ -1,3 +1,4 @@
+import { updateModelConfig } from "@/agent/modify";
 import type { Backend } from "@/backend";
 import { loadModConversationHistoryFromBackend } from "@/mods/conversation-history";
 import type {
@@ -5,6 +6,7 @@ import type {
   ModConversationMessage,
   ModConversationSendMessageOptions,
   ModConversationSendMessageRequestOptions,
+  ModUpdateLlmConfigOptions,
 } from "@/mods/types";
 
 type SendModConversationMessageStream = (
@@ -65,6 +67,28 @@ export function createModConversationHandle(options: {
           ...sendOptions,
         },
         requestOptions,
+      );
+    },
+    async updateLlmConfig(update: ModUpdateLlmConfigOptions) {
+      const backend = requireBackend();
+      const { scope, ...config } = update;
+      if (scope === "agent") {
+        if (!options.agentId) {
+          throw new Error(
+            "Mod updateLlmConfig: agentId is not available for an agent-scope update",
+          );
+        }
+        await updateModelConfig(
+          backend,
+          { scope: "agent", agentId: options.agentId },
+          config,
+        );
+        return;
+      }
+      await updateModelConfig(
+        backend,
+        { scope: "conversation", conversationId, agentId: options.agentId },
+        config,
       );
     },
   };

--- a/src/mods/types.ts
+++ b/src/mods/types.ts
@@ -5,6 +5,7 @@ import type {
   Message,
 } from "@letta-ai/letta-client/resources/agents/messages";
 import type { ChalkInstance } from "chalk";
+import type { ModelReasoningEffort } from "@/agent/model";
 
 export interface ModWorkspaceContext {
   cwd: string;
@@ -114,6 +115,20 @@ export interface ModConversationHistoryOptions {
   includeErrors?: boolean;
 }
 
+export interface ModUpdateLlmConfigOptions {
+  /** Model handle, e.g. "anthropic/claude-opus-4-8". Omit to keep the current model. */
+  model?: string;
+  /** Reasoning effort tier. Omit to leave reasoning settings untouched. */
+  reasoningEffort?: ModelReasoningEffort;
+  /** Context window limit. Omit to leave the current limit untouched. */
+  contextWindow?: number;
+  /**
+   * Whether the change applies to this conversation only (default) or to the
+   * agent's default config. Conversation scope avoids mutating the agent default.
+   */
+  scope?: "conversation" | "agent";
+}
+
 export interface ModConversationHandle {
   id: string | null;
   fork: (
@@ -125,6 +140,12 @@ export interface ModConversationHandle {
     options?: ModConversationSendMessageOptions,
     requestOptions?: ModConversationSendMessageRequestOptions,
   ) => Promise<AsyncIterable<LettaStreamingResponse>>;
+  /**
+   * Update the model, reasoning effort, and/or context window for this
+   * conversation (or the agent default with scope: "agent"). Only the fields you
+   * pass change; others are preserved. Works for local and constellation agents.
+   */
+  updateLlmConfig: (options: ModUpdateLlmConfigOptions) => Promise<void>;
 }
 
 export type ModSourceScope =

--- a/src/skills/builtin/creating-mods/references/architecture.md
+++ b/src/skills/builtin/creating-mods/references/architecture.md
@@ -134,9 +134,12 @@ ctx.conversation.id                 // string | null
 ctx.conversation.getHistory(opts)   // recent messages
 ctx.conversation.fork(opts)         // returns a scoped handle
 ctx.conversation.sendMessageStream(messages, opts)
+ctx.conversation.updateLlmConfig(opts) // change model / reasoning effort / context window
 ```
 
 A forked handle keeps the same agent/backend defaults and targets the forked conversation. Use forked handles for background model work. Use `getHistory({ limit, order, includeErrors })` when local logic needs conversation context.
+
+`updateLlmConfig({ model?, reasoningEffort?, contextWindow?, scope? })` changes the model, reasoning effort, and/or context window, and works across local and Constellation backends. Only the fields you pass change; the rest are preserved, so `updateLlmConfig({ contextWindow })` adjusts just the context window without touching the model or reasoning effort. `scope` defaults to `"conversation"` (a conversation-scoped override that leaves the agent's default untouched); pass `scope: "agent"` to change the agent default. Changing reasoning effort without a model resolves the current model to rebuild provider-specific settings. The change takes effect on the next turn (the model is resolved per provider request).
 
 Tools currently receive `ctx.conversation.getHistory()` but not fork/send helpers. If a tool needs model-side follow-up, return information for the model to act on instead of starting a hidden run from the tool.
 

--- a/src/skills/builtin/creating-mods/references/events.md
+++ b/src/skills/builtin/creating-mods/references/events.md
@@ -171,6 +171,19 @@ letta.events.on("tool_end", (event) => {
 
 The first handler that returns a `result` wins; later handlers are shadowed. Only string results are surfaced — multimodal/image results pass through unchanged. `tool_end` is the trusted-local-mod equivalent of the `PostToolUse` / `PostToolUseFailure` hooks for observing and rewriting tool results.
 
+A handler can also react to a specific tool completing by adjusting conversation state. For example, switch model and reasoning effort when entering and exiting plan mode (`tool_end` fires only after the tool succeeds, so a denied approval won't switch):
+
+```ts
+letta.events.on("tool_end", async (event, ctx) => {
+  if (event.status !== "success") return;
+  if (event.toolName === "enter_plan_mode") {
+    await ctx.conversation.updateLlmConfig({ model: "anthropic/claude-opus-4-8", reasoningEffort: "high" });
+  } else if (event.toolName === "exit_plan_mode") {
+    await ctx.conversation.updateLlmConfig({ model: "openai/gpt-5.5", reasoningEffort: "max" });
+  }
+});
+```
+
 `turn_start` fires before outbound turns that include a user message. In the TUI this includes normal submits and prompt-style command turns. In headless it includes one-shot prompts and bidirectional user turns.
 
 Handlers can mutate `event.input` directly or return replacement input:


### PR DESCRIPTION
## Summary
- Adds `ctx.conversation.updateLlmConfig({ model?, reasoningEffort?, contextWindow?, scope? })` so trusted local mods can change the model, reasoning effort, and/or context window from event/command handlers. Works for both **local and Constellation** agents (routes through `backend.updateAgent`/`updateConversation`, which the constellation-only `letta.client` could not reach for local agents).
- **Partial by design:** only the fields you pass change. `updateLlmConfig({ contextWindow })` adjusts just the context window without touching the model or reasoning effort — the gap that motivated this.
- `scope` defaults to `"conversation"` (a conversation-scoped override that leaves the agent default untouched); `scope: "agent"` changes the agent default.

## How it works
- New `updateModelConfig(backend, target, update)` in `agent/modify.ts` builds a **minimal patch**:
  - only `contextWindow` -> sends `context_window_limit` alone (no model read, no settings rebuild)
  - `reasoningEffort` without `model` -> resolves the current model handle so `model_settings` can be rebuilt for the right provider
  - `model` (with optional effort/context) -> rebuilds `model_settings` and derives a context window when one is not supplied, matching `updateAgentLLMConfig`
- The change takes effect on the next turn (the model is resolved per provider request).
- No new `Backend` interface method and no new capability flag — the handle is gated by backend presence, same as `fork`/`getHistory`/`sendMessageStream`.

## Example (model switch per plan-mode phase)
```ts
letta.events.on("tool_end", async (event, ctx) => {
  if (event.status !== "success") return;
  if (event.toolName === "enter_plan_mode")
    await ctx.conversation.updateLlmConfig({ model: "anthropic/claude-opus-4-8", reasoningEffort: "high" });
  else if (event.toolName === "exit_plan_mode")
    await ctx.conversation.updateLlmConfig({ model: "openai/gpt-5.5", reasoningEffort: "max" });
});
```

## Test plan
- [x] `bun test src/agent/modify-update-model-config.test.ts` — context-window-only preserves model/settings; effort-only resolves current model; model change rebuilds; agent-scope routing; empty no-op
- [x] `bun test src/mods/conversation-handle.test.ts` — handle defaults to conversation scope, agent-scope routing, throws without agentId
- [x] `bun test src/mods/ src/cli/mods/local-mod-loader.test.ts` — 148 pass
- [x] `tsc --noEmit` and biome clean

👾 Generated with [Letta Code](https://letta.com)