### PR TITLE
feat(mods): expose mod slash commands in the desktop listener

### DIFF
--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -26,6 +26,7 @@ import {
   gatherInitGitContext,
 } from "@/cli/helpers/init-command";
 import { getReflectionSettings } from "@/cli/helpers/memory-reminder";
+import { buildModCommandPrompt } from "@/cli/mods/command-runtime";
 import {
   DEFAULT_SUMMARIZATION_MODEL,
   SYSTEM_REMINDER_CLOSE,
@@ -33,6 +34,7 @@ import {
 } from "@/constants";
 import { goalLoopMode } from "@/goal-loop-mode";
 import { runPreCompactHooks } from "@/hooks";
+import type { ModCommand } from "@/mods/types";
 import { settingsManager } from "@/settings-manager";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
 import type {
@@ -45,6 +47,7 @@ import { debugLog } from "@/utils/debug";
 import { markSecretsReminderRefreshPending } from "./commands/secrets";
 import { getConversationWorkingDirectory } from "./cwd";
 import { reloadListenerModAdapter } from "./mod-adapter";
+import { getListenerModCommand, runListenerModCommand } from "./mod-commands";
 import {
   getOrCreateConversationPermissionModeStateRef,
   persistPermissionModeMapForRuntime,
@@ -52,6 +55,7 @@ import {
 import {
   createLifecycleMessageBase,
   emitCanonicalMessageDelta,
+  emitDeviceStatusUpdate,
 } from "./protocol-outbound";
 import { clearConversationRuntimeState, emitListenerStatus } from "./runtime";
 import {
@@ -151,6 +155,8 @@ export async function handleExecuteCommand(
 
       case "reload":
         output = await handleReloadCommand(conversationRuntime);
+        // Re-advertise commands so newly (un)registered mod commands appear.
+        emitDeviceStatusUpdate(socket, conversationRuntime, scope);
         break;
 
       case "context-limit":
@@ -174,14 +180,32 @@ export async function handleExecuteCommand(
         output = await handleUpgradeLettaCodeCommand(opts);
         break;
 
-      default:
-        emitSlashCommandEnd(socket, conversationRuntime, scope, {
-          command_id: command.command_id,
+      default: {
+        const modCommand = getListenerModCommand(
+          conversationRuntime.listener,
+          command.command_id,
+        );
+        if (!modCommand) {
+          emitSlashCommandEnd(socket, conversationRuntime, scope, {
+            command_id: command.command_id,
+            input,
+            output: `Unknown command: ${command.command_id}`,
+            success: false,
+          });
+          return;
+        }
+        await handleModCommand(
+          modCommand,
+          command,
           input,
-          output: `Unknown command: ${command.command_id}`,
-          success: false,
-        });
+          trimmedArgs,
+          socket,
+          conversationRuntime,
+          scope,
+          opts,
+        );
         return;
+      }
     }
 
     emitSlashCommandEnd(socket, conversationRuntime, scope, {
@@ -209,6 +233,88 @@ export async function handleExecuteCommand(
     // "interrupt_in_progress"). Reset it so subsequent user messages drain.
     conversationRuntime.cancelRequested = false;
   }
+}
+
+/**
+ * Run a mod-registered slash command and surface its result. Mirrors the TUI
+ * mod command path: `output` is shown as command output, `handled` closes
+ * silently, and `prompt` injects a user turn through the normal message flow.
+ */
+async function handleModCommand(
+  modCommand: ModCommand,
+  command: ExecuteCommandCommand,
+  input: string,
+  trimmedArgs: string | undefined,
+  socket: WebSocket,
+  conversationRuntime: ConversationRuntime,
+  scope: { agent_id: string | null; conversation_id: string },
+  opts: {
+    onStatusChange?: StartListenerOptions["onStatusChange"];
+    connectionId?: string;
+  },
+): Promise<void> {
+  const result = await runListenerModCommand(conversationRuntime, modCommand, {
+    commandId: command.command_id,
+    args: trimmedArgs ?? "",
+    rawInput: input,
+  });
+
+  if (result.type === "prompt") {
+    if (!modCommand.showInTranscript) {
+      emitSlashCommandEnd(socket, conversationRuntime, scope, {
+        command_id: command.command_id,
+        input,
+        output: `/${modCommand.id} returned a prompt with showInTranscript: false. Hidden mod commands must return output or handled.`,
+        success: false,
+      });
+      return;
+    }
+
+    const agentId = conversationRuntime.agentId;
+    if (!agentId) {
+      emitSlashCommandEnd(socket, conversationRuntime, scope, {
+        command_id: command.command_id,
+        input,
+        output: `No agent available to run /${modCommand.id}.`,
+        success: false,
+      });
+      return;
+    }
+
+    emitSlashCommandEnd(socket, conversationRuntime, scope, {
+      command_id: command.command_id,
+      input,
+      output: `Running /${modCommand.id}...`,
+      success: true,
+    });
+
+    await handleIncomingMessage(
+      {
+        type: "message",
+        agentId,
+        conversationId: conversationRuntime.conversationId,
+        messages: [
+          {
+            type: "message",
+            role: "user",
+            content: [{ type: "text", text: buildModCommandPrompt(result) }],
+          },
+        ],
+      },
+      socket,
+      conversationRuntime,
+      opts.onStatusChange,
+      opts.connectionId,
+    );
+    return;
+  }
+
+  emitSlashCommandEnd(socket, conversationRuntime, scope, {
+    command_id: command.command_id,
+    input,
+    output: result.type === "output" ? result.output : "",
+    success: result.type === "output" ? (result.success ?? true) : true,
+  });
 }
 
 async function handleReloadCommand(

--- a/src/websocket/listener/mod-adapter.test.ts
+++ b/src/websocket/listener/mod-adapter.test.ts
@@ -46,7 +46,7 @@ describe("listener mod adapter", () => {
   test("uses provider and tool capabilities", () => {
     expect(LISTENER_MOD_CAPABILITIES).toEqual({
       tools: true,
-      commands: false,
+      commands: true,
       events: {
         lifecycle: false,
         tools: true,
@@ -113,7 +113,7 @@ describe("listener mod adapter", () => {
     expect(context.toolset).toBe("default");
   });
 
-  test("loads provider and tool registrations without exposing other listener capabilities", async () => {
+  test("loads provider, tool, and command registrations without exposing events or panels", async () => {
     const root = createTempDir();
     const modsDir = join(root, "mods");
     const cacheDir = join(root, "cache");
@@ -139,8 +139,8 @@ describe("listener mod adapter", () => {
           }],
         });
         letta.commands.register({
-          id: "ignored-command",
-          description: "Should not register on listener",
+          id: "listener-command",
+          description: "Should register on listener",
           run() { return { type: "handled" }; },
         });
         letta.tools.register({
@@ -178,7 +178,11 @@ describe("listener mod adapter", () => {
     const snapshot = adapter.getSnapshot().registry;
     expect(snapshot.capabilities).toEqual(LISTENER_MOD_CAPABILITIES);
     expect(snapshot.loadedPaths).toEqual([modPath]);
-    expect(snapshot.commands).toEqual({});
+    expect(snapshot.commands["listener-command"]).toMatchObject({
+      id: "listener-command",
+      description: "Should register on listener",
+      path: modPath,
+    });
     expect(snapshot.tools.listener_tool).toMatchObject({
       name: "listener_tool",
       description: "Should register on listener",

--- a/src/websocket/listener/mod-adapter.ts
+++ b/src/websocket/listener/mod-adapter.ts
@@ -8,7 +8,7 @@ import type { ListenerRuntime } from "./types";
 
 export const LISTENER_MOD_CAPABILITIES: ModCapabilities = {
   tools: true,
-  commands: false,
+  commands: true,
   events: {
     lifecycle: false,
     tools: true,

--- a/src/websocket/listener/mod-commands.test.ts
+++ b/src/websocket/listener/mod-commands.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { __testSetBackend } from "@/backend";
+import { FakeHeadlessBackend } from "@/backend/dev/fake-headless-backend";
+import { createListenerModAdapter } from "@/websocket/listener/mod-adapter";
+import {
+  getListenerModCommand,
+  listListenerModCommandIds,
+  runListenerModCommand,
+} from "@/websocket/listener/mod-commands";
+import type {
+  ConversationRuntime,
+  ListenerRuntime,
+} from "@/websocket/listener/types";
+
+const tempRoots: string[] = [];
+
+function createTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "letta-listener-modcmd-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  __testSetBackend(null);
+  for (const dir of tempRoots.splice(0)) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+function fakeConversationRuntime(
+  listener: ListenerRuntime,
+): ConversationRuntime {
+  return {
+    listener,
+    agentId: "agent-1",
+    conversationId: "conv-1",
+    currentToolset: null,
+  } as unknown as ConversationRuntime;
+}
+
+function fakeListener(
+  modAdapter: ListenerRuntime["modAdapter"],
+  bootWorkingDirectory: string,
+): ListenerRuntime {
+  return {
+    modAdapter,
+    workingDirectoryByConversation: new Map(),
+    bootWorkingDirectory,
+    permissionModeByConversation: new Map(),
+  } as unknown as ListenerRuntime;
+}
+
+describe("listener mod commands", () => {
+  test("lists and looks up registered mod command ids", () => {
+    const adapter = {
+      getSnapshot: () => ({
+        registry: { commands: { greet: { id: "greet" }, bye: { id: "bye" } } },
+      }),
+    } as unknown as ListenerRuntime["modAdapter"];
+    const listener = fakeListener(adapter, "/tmp/project");
+
+    expect(listListenerModCommandIds(listener)).toEqual(["greet", "bye"]);
+    expect(getListenerModCommand(listener, "greet")).toMatchObject({
+      id: "greet",
+    });
+    expect(getListenerModCommand(listener, "missing")).toBeUndefined();
+  });
+
+  test("returns no command ids when no mod adapter is loaded", () => {
+    const listener = fakeListener(undefined, "/tmp/project");
+    expect(listListenerModCommandIds(listener)).toEqual([]);
+    expect(getListenerModCommand(listener, "greet")).toBeUndefined();
+  });
+
+  test("runs a mod command and surfaces output and prompt results", async () => {
+    __testSetBackend(
+      new FakeHeadlessBackend(
+        "agent-1",
+        undefined,
+        {},
+        { modelHandle: "anthropic/claude-sonnet-4-6" },
+      ),
+    );
+    const root = createTempDir();
+    const modsDir = join(root, "mods");
+    const cacheDir = join(root, "cache");
+    mkdirSync(modsDir, { recursive: true });
+    writeFileSync(
+      join(modsDir, "greet.ts"),
+      `export default function activate(letta) {
+        letta.commands.register({
+          id: "greet",
+          description: "Greets with args and conversation id",
+          run(ctx) {
+            return { type: "output", output: "hi " + ctx.args + " in " + ctx.conversation.id };
+          },
+        });
+        letta.commands.register({
+          id: "ask",
+          description: "Returns a prompt",
+          run(ctx) {
+            return { type: "prompt", content: "do the thing: " + ctx.argv.join(",") };
+          },
+        });
+      }`,
+    );
+
+    const adapter = createListenerModAdapter({
+      cacheDirectory: cacheDir,
+      globalModsDirectory: modsDir,
+      sessionId: "conv-1",
+      workingDirectory: root,
+    });
+    await adapter.reload();
+
+    const runtime = fakeConversationRuntime(fakeListener(adapter, root));
+
+    const greet = getListenerModCommand(runtime.listener, "greet");
+    if (!greet) throw new Error("greet command was not registered");
+    const outputResult = await runListenerModCommand(runtime, greet, {
+      commandId: "greet",
+      args: "there",
+      rawInput: "/greet there",
+    });
+    expect(outputResult).toEqual({
+      type: "output",
+      output: "hi there in conv-1",
+    });
+
+    const ask = getListenerModCommand(runtime.listener, "ask");
+    if (!ask) throw new Error("ask command was not registered");
+    const promptResult = await runListenerModCommand(runtime, ask, {
+      commandId: "ask",
+      args: "one two",
+      rawInput: "/ask one two",
+    });
+    expect(promptResult).toEqual({
+      type: "prompt",
+      content: "do the thing: one,two",
+    });
+
+    adapter.dispose();
+  });
+});

--- a/src/websocket/listener/mod-commands.ts
+++ b/src/websocket/listener/mod-commands.ts
@@ -1,0 +1,81 @@
+import { sendMessageStreamWithBackend } from "@/agent/message";
+import { getBackend } from "@/backend";
+import {
+  parseModCommandArgv,
+  runModCommandWithTimeout,
+} from "@/cli/mods/command-runtime";
+import { createModConversationHandle } from "@/mods/conversation-handle";
+import type {
+  ModCommand,
+  ModCommandContext,
+  ModCommandResult,
+} from "@/mods/types";
+import { getConversationWorkingDirectory } from "./cwd";
+import { createListenerModContext } from "./mod-adapter";
+import { getConversationPermissionModeState } from "./permission-mode";
+import type { ConversationRuntime, ListenerRuntime } from "./types";
+
+/** Registered mod command ids, for advertising in supported_commands. */
+export function listListenerModCommandIds(runtime: ListenerRuntime): string[] {
+  const registry = runtime.modAdapter?.getSnapshot().registry;
+  return registry ? Object.keys(registry.commands) : [];
+}
+
+/** Look up a registered mod command by id, if any. */
+export function getListenerModCommand(
+  runtime: ListenerRuntime,
+  commandId: string,
+): ModCommand | undefined {
+  return runtime.modAdapter?.getSnapshot().registry.commands[commandId];
+}
+
+/**
+ * Run a mod command in the listener and return its result. Builds a
+ * ModCommandContext that mirrors the TUI command path (createModConversationHandle
+ * with the shared sendMessageStreamWithBackend so fork/send/updateLlmConfig work
+ * across local and Constellation backends).
+ */
+export async function runListenerModCommand(
+  conversationRuntime: ConversationRuntime,
+  modCommand: ModCommand,
+  parsed: { commandId: string; args: string; rawInput: string },
+): Promise<ModCommandResult> {
+  const { listener, agentId, conversationId } = conversationRuntime;
+  const cwd = getConversationWorkingDirectory(
+    listener,
+    agentId,
+    conversationId,
+  );
+  const permissionMode = getConversationPermissionModeState(
+    listener,
+    agentId,
+    conversationId,
+  ).mode;
+
+  const modContext = createListenerModContext({
+    sessionId: conversationId,
+    workingDirectory: cwd,
+    agent: agentId ? { id: agentId } : null,
+    permissionMode,
+    toolset: conversationRuntime.currentToolset,
+  });
+
+  const conversation = createModConversationHandle({
+    agentId,
+    backend: getBackend(),
+    conversationId,
+    sendMessageStream: sendMessageStreamWithBackend,
+    workingDirectory: cwd,
+  });
+
+  const context: ModCommandContext = {
+    ...modContext,
+    args: parsed.args,
+    argv: parseModCommandArgv(parsed.args),
+    command: parsed.commandId,
+    conversation: { ...conversation, id: conversationId },
+    rawInput: parsed.rawInput,
+  };
+
+  return runModCommandWithTimeout(modCommand, context);
+}

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -40,6 +40,7 @@ import { isDebugEnabled } from "@/utils/debug";
 import { SYSTEM_REMINDER_RE } from "./constants";
 import { getConversationWorkingDirectory } from "./cwd";
 import { SUPPORTED_REMOTE_COMMANDS } from "./listener-constants";
+import { listListenerModCommandIds } from "./mod-commands";
 import { getConversationPermissionModeState } from "./permission-mode";
 import {
   getConversationRuntime,
@@ -76,6 +77,19 @@ const MAX_GIT_CONTEXT_CACHE_ENTRIES = 64;
  * web client). (LET-8948)
  */
 const FROZEN_SUPPORTED_COMMANDS: string[] = [...SUPPORTED_REMOTE_COMMANDS];
+
+/**
+ * Built-in commands plus any commands registered by local mods. Returns the
+ * frozen built-in array unchanged when no mod commands exist, so the common
+ * case still avoids a per-status allocation. (LET-8948)
+ */
+function buildSupportedCommands(listener: ListenerRuntime): string[] {
+  const modCommandIds = listListenerModCommandIds(listener).filter(
+    (id) => !SUPPORTED_REMOTE_COMMANDS.includes(id),
+  );
+  if (modCommandIds.length === 0) return FROZEN_SUPPORTED_COMMANDS;
+  return [...SUPPORTED_REMOTE_COMMANDS, ...modCommandIds];
+}
 const PROTOCOL_PERF_FLUSH_INTERVAL_MS = 1_000;
 const PROTOCOL_PERF_ENV_VALUES = new Set(["1", "true", "yes"]);
 const PROTOCOL_PERF_ENABLED = PROTOCOL_PERF_ENV_VALUES.has(
@@ -484,7 +498,7 @@ export function buildDeviceStatus(
         }
       : {}),
     should_doctor: systemPromptDoctorState?.should_doctor ?? false,
-    supported_commands: FROZEN_SUPPORTED_COMMANDS,
+    supported_commands: buildSupportedCommands(listener),
     reflection_settings: scopedAgentId
       ? {
           agent_id: scopedAgentId,


### PR DESCRIPTION
## Summary
Mod-registered slash commands worked in the TUI but were silently dropped in the desktop/app-server (listener) path. This wires them through end to end:

- **Enable**: flip the mod `commands` capability on for the listener so `letta.commands.register(...)` actually registers (it was a no-op).
- **Advertise**: `DeviceStatus.supported_commands` now includes registered mod command ids (built-in list is returned unchanged when there are no mod commands, preserving the per-status allocation optimization).
- **Execute**: `handleExecuteCommand` routes unknown built-ins to the mod registry and runs them, mirroring the TUI mapping: `output` shows as command output, `handled` closes silently, `prompt` injects a user turn via `handleIncomingMessage`.
- **Reload**: re-push device status after `/reload` so newly (un)registered commands appear in the palette.

Command runtime context is built the same way as the TUI (`createModConversationHandle` + the shared `sendMessageStreamWithBackend`), so `fork`/`send`/`updateLlmConfig` work across local and Constellation backends.

## Not included (follow-up)
- Command **descriptions/args** are not surfaced yet — `supported_commands` is names-only. Rich palette rendering needs a client-side (letta-cloud) change to read a new metadata field.
- The desktop client must send a `command_id` it sees in `supported_commands`. If letta-cloud has a hardcoded command allowlist beyond `supported_commands`, it will need a matching change for these to appear/execute.

## Test plan
- [x] `bun test src/websocket/listener/` (96 pass)
- [x] New `mod-commands.test.ts`: advertise/lookup accessors + run output & prompt results
- [x] Updated `mod-adapter.test.ts`: listener now registers mod commands
- [x] typecheck + lint clean
- [ ] Validate in Desktop: register a mod command, confirm it shows in the palette, executes, and refreshes after `/reload`

👾 Generated with [Letta Code](https://letta.com)