### PR TITLE
feat(mods): advertise mod slash commands to clients via mod_commands

### DIFF
--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -462,6 +462,21 @@ export interface DeviceStatus {
   reflection_settings: ReflectionSettingsSnapshot | null;
   /** Remote slash command IDs this letta-code version can handle via `execute_command`. */
   supported_commands: string[];
+  /**
+   * Slash commands contributed by locally loaded mods. Advertised separately
+   * from `supported_commands` (which gates the client's built-in allowlist) so
+   * clients can auto-surface mod commands by their own policy. Invoked through
+   * the same `execute_command` path. Omitted when no mod commands are loaded.
+   */
+  mod_commands?: ModCommandInfo[];
+}
+
+/** A mod-contributed slash command advertised to clients for rendering. */
+export interface ModCommandInfo {
+  id: string;
+  description: string;
+  /** Optional argument hint shown in the palette (e.g. "<query>"). */
+  args?: string;
 }
 
 export type LoopStatus =

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -26,6 +26,7 @@ import {
   gatherInitGitContext,
 } from "@/cli/helpers/init-command";
 import { getReflectionSettings } from "@/cli/helpers/memory-reminder";
+import { buildModCommandPrompt } from "@/cli/mods/command-runtime";
 import {
   DEFAULT_SUMMARIZATION_MODEL,
   SYSTEM_REMINDER_CLOSE,
@@ -33,6 +34,7 @@ import {
 } from "@/constants";
 import { goalLoopMode } from "@/goal-loop-mode";
 import { runPreCompactHooks } from "@/hooks";
+import type { ModCommand } from "@/mods/types";
 import { settingsManager } from "@/settings-manager";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
 import type {
@@ -45,6 +47,7 @@ import { debugLog } from "@/utils/debug";
 import { markSecretsReminderRefreshPending } from "./commands/secrets";
 import { getConversationWorkingDirectory } from "./cwd";
 import { reloadListenerModAdapter } from "./mod-adapter";
+import { getListenerModCommand, runListenerModCommand } from "./mod-commands";
 import {
   getOrCreateConversationPermissionModeStateRef,
   persistPermissionModeMapForRuntime,
@@ -52,6 +55,7 @@ import {
 import {
   createLifecycleMessageBase,
   emitCanonicalMessageDelta,
+  emitDeviceStatusUpdate,
 } from "./protocol-outbound";
 import { clearConversationRuntimeState, emitListenerStatus } from "./runtime";
 import {
@@ -151,6 +155,8 @@ export async function handleExecuteCommand(
 
       case "reload":
         output = await handleReloadCommand(conversationRuntime);
+        // Re-advertise so newly (un)registered mod commands reach the client.
+        emitDeviceStatusUpdate(socket, conversationRuntime, scope);
         break;
 
       case "context-limit":
@@ -174,14 +180,32 @@ export async function handleExecuteCommand(
         output = await handleUpgradeLettaCodeCommand(opts);
         break;
 
-      default:
-        emitSlashCommandEnd(socket, conversationRuntime, scope, {
-          command_id: command.command_id,
+      default: {
+        const modCommand = getListenerModCommand(
+          conversationRuntime.listener,
+          command.command_id,
+        );
+        if (!modCommand) {
+          emitSlashCommandEnd(socket, conversationRuntime, scope, {
+            command_id: command.command_id,
+            input,
+            output: `Unknown command: ${command.command_id}`,
+            success: false,
+          });
+          return;
+        }
+        await handleModCommand(
+          modCommand,
+          command,
           input,
-          output: `Unknown command: ${command.command_id}`,
-          success: false,
-        });
+          trimmedArgs,
+          socket,
+          conversationRuntime,
+          scope,
+          opts,
+        );
         return;
+      }
     }
 
     emitSlashCommandEnd(socket, conversationRuntime, scope, {
@@ -209,6 +233,88 @@ export async function handleExecuteCommand(
     // "interrupt_in_progress"). Reset it so subsequent user messages drain.
     conversationRuntime.cancelRequested = false;
   }
+}
+
+/**
+ * Run a mod-registered slash command and surface its result. Mirrors the TUI
+ * mod command path: `output` is shown as command output, `handled` closes
+ * silently, and `prompt` injects a user turn through the normal message flow.
+ */
+async function handleModCommand(
+  modCommand: ModCommand,
+  command: ExecuteCommandCommand,
+  input: string,
+  trimmedArgs: string | undefined,
+  socket: WebSocket,
+  conversationRuntime: ConversationRuntime,
+  scope: { agent_id: string | null; conversation_id: string },
+  opts: {
+    onStatusChange?: StartListenerOptions["onStatusChange"];
+    connectionId?: string;
+  },
+): Promise<void> {
+  const result = await runListenerModCommand(conversationRuntime, modCommand, {
+    commandId: command.command_id,
+    args: trimmedArgs ?? "",
+    rawInput: input,
+  });
+
+  if (result.type === "prompt") {
+    if (!modCommand.showInTranscript) {
+      emitSlashCommandEnd(socket, conversationRuntime, scope, {
+        command_id: command.command_id,
+        input,
+        output: `/${modCommand.id} returned a prompt with showInTranscript: false. Hidden mod commands must return output or handled.`,
+        success: false,
+      });
+      return;
+    }
+
+    const agentId = conversationRuntime.agentId;
+    if (!agentId) {
+      emitSlashCommandEnd(socket, conversationRuntime, scope, {
+        command_id: command.command_id,
+        input,
+        output: `No agent available to run /${modCommand.id}.`,
+        success: false,
+      });
+      return;
+    }
+
+    emitSlashCommandEnd(socket, conversationRuntime, scope, {
+      command_id: command.command_id,
+      input,
+      output: `Running /${modCommand.id}...`,
+      success: true,
+    });
+
+    await handleIncomingMessage(
+      {
+        type: "message",
+        agentId,
+        conversationId: conversationRuntime.conversationId,
+        messages: [
+          {
+            type: "message",
+            role: "user",
+            content: [{ type: "text", text: buildModCommandPrompt(result) }],
+          },
+        ],
+      },
+      socket,
+      conversationRuntime,
+      opts.onStatusChange,
+      opts.connectionId,
+    );
+    return;
+  }
+
+  emitSlashCommandEnd(socket, conversationRuntime, scope, {
+    command_id: command.command_id,
+    input,
+    output: result.type === "output" ? result.output : "",
+    success: result.type === "output" ? (result.success ?? true) : true,
+  });
 }
 
 async function handleReloadCommand(

--- a/src/websocket/listener/mod-adapter.test.ts
+++ b/src/websocket/listener/mod-adapter.test.ts
@@ -46,7 +46,7 @@ describe("listener mod adapter", () => {
   test("uses provider and tool capabilities", () => {
     expect(LISTENER_MOD_CAPABILITIES).toEqual({
       tools: true,
-      commands: false,
+      commands: true,
       events: {
         lifecycle: false,
         tools: true,
@@ -113,7 +113,7 @@ describe("listener mod adapter", () => {
     expect(context.toolset).toBe("default");
   });
 
-  test("loads provider and tool registrations without exposing other listener capabilities", async () => {
+  test("loads provider, tool, and command registrations without exposing events or panels", async () => {
     const root = createTempDir();
     const modsDir = join(root, "mods");
     const cacheDir = join(root, "cache");
@@ -139,8 +139,9 @@ describe("listener mod adapter", () => {
           }],
         });
         letta.commands.register({
-          id: "ignored-command",
-          description: "Should not register on listener",
+          id: "listener-command",
+          description: "Should register on listener",
+          args: "<thing>",
           run() { return { type: "handled" }; },
         });
         letta.tools.register({
@@ -178,7 +179,11 @@ describe("listener mod adapter", () => {
     const snapshot = adapter.getSnapshot().registry;
     expect(snapshot.capabilities).toEqual(LISTENER_MOD_CAPABILITIES);
     expect(snapshot.loadedPaths).toEqual([modPath]);
-    expect(snapshot.commands).toEqual({});
+    expect(snapshot.commands["listener-command"]).toMatchObject({
+      id: "listener-command",
+      description: "Should register on listener",
+      path: modPath,
+    });
     expect(snapshot.tools.listener_tool).toMatchObject({
       name: "listener_tool",
       description: "Should register on listener",

--- a/src/websocket/listener/mod-adapter.ts
+++ b/src/websocket/listener/mod-adapter.ts
@@ -8,7 +8,7 @@ import type { ListenerRuntime } from "./types";
 
 export const LISTENER_MOD_CAPABILITIES: ModCapabilities = {
   tools: true,
-  commands: false,
+  commands: true,
   events: {
     lifecycle: false,
     tools: true,

--- a/src/websocket/listener/mod-commands.test.ts
+++ b/src/websocket/listener/mod-commands.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { __testSetBackend } from "@/backend";
+import { FakeHeadlessBackend } from "@/backend/dev/fake-headless-backend";
+import { createListenerModAdapter } from "@/websocket/listener/mod-adapter";
+import {
+  getListenerModCommand,
+  listListenerModCommands,
+  runListenerModCommand,
+} from "@/websocket/listener/mod-commands";
+import type {
+  ConversationRuntime,
+  ListenerRuntime,
+} from "@/websocket/listener/types";
+
+const tempRoots: string[] = [];
+
+function createTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "letta-listener-modcmd-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  __testSetBackend(null);
+  for (const dir of tempRoots.splice(0)) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+function fakeConversationRuntime(
+  listener: ListenerRuntime,
+): ConversationRuntime {
+  return {
+    listener,
+    agentId: "agent-1",
+    conversationId: "conv-1",
+    currentToolset: null,
+  } as unknown as ConversationRuntime;
+}
+
+function fakeListener(
+  modAdapter: ListenerRuntime["modAdapter"],
+  bootWorkingDirectory: string,
+): ListenerRuntime {
+  return {
+    modAdapter,
+    workingDirectoryByConversation: new Map(),
+    bootWorkingDirectory,
+    permissionModeByConversation: new Map(),
+  } as unknown as ListenerRuntime;
+}
+
+describe("listener mod commands", () => {
+  test("advertises registered mod commands as descriptors", () => {
+    const adapter = {
+      getSnapshot: () => ({
+        registry: {
+          commands: {
+            greet: { id: "greet", description: "Greets you", args: "<name>" },
+            bye: { id: "bye", description: "Says bye" },
+          },
+        },
+      }),
+    } as unknown as ListenerRuntime["modAdapter"];
+    const listener = fakeListener(adapter, "/tmp/project");
+
+    expect(listListenerModCommands(listener)).toEqual([
+      { id: "greet", description: "Greets you", args: "<name>" },
+      { id: "bye", description: "Says bye" },
+    ]);
+    expect(getListenerModCommand(listener, "greet")).toMatchObject({
+      id: "greet",
+    });
+    expect(getListenerModCommand(listener, "missing")).toBeUndefined();
+  });
+
+  test("returns no commands when no mod adapter is loaded", () => {
+    const listener = fakeListener(undefined, "/tmp/project");
+    expect(listListenerModCommands(listener)).toEqual([]);
+    expect(getListenerModCommand(listener, "greet")).toBeUndefined();
+  });
+
+  test("runs a mod command and surfaces output and prompt results", async () => {
+    __testSetBackend(
+      new FakeHeadlessBackend(
+        "agent-1",
+        undefined,
+        {},
+        { modelHandle: "anthropic/claude-sonnet-4-6" },
+      ),
+    );
+    const root = createTempDir();
+    const modsDir = join(root, "mods");
+    const cacheDir = join(root, "cache");
+    mkdirSync(modsDir, { recursive: true });
+    writeFileSync(
+      join(modsDir, "greet.ts"),
+      `export default function activate(letta) {
+        letta.commands.register({
+          id: "greet",
+          description: "Greets with args and conversation id",
+          args: "<name>",
+          run(ctx) {
+            return { type: "output", output: "hi " + ctx.args + " in " + ctx.conversation.id };
+          },
+        });
+        letta.commands.register({
+          id: "ask",
+          description: "Returns a prompt",
+          run(ctx) {
+            return { type: "prompt", content: "do the thing: " + ctx.argv.join(",") };
+          },
+        });
+      }`,
+    );
+
+    const adapter = createListenerModAdapter({
+      cacheDirectory: cacheDir,
+      globalModsDirectory: modsDir,
+      sessionId: "conv-1",
+      workingDirectory: root,
+    });
+    await adapter.reload();
+
+    const runtime = fakeConversationRuntime(fakeListener(adapter, root));
+
+    // The loaded command carries its args hint into the advertised descriptor.
+    expect(listListenerModCommands(runtime.listener)).toContainEqual({
+      id: "greet",
+      description: "Greets with args and conversation id",
+      args: "<name>",
+    });
+
+    const greet = getListenerModCommand(runtime.listener, "greet");
+    if (!greet) throw new Error("greet command was not registered");
+    const outputResult = await runListenerModCommand(runtime, greet, {
+      commandId: "greet",
+      args: "there",
+      rawInput: "/greet there",
+    });
+    expect(outputResult).toEqual({
+      type: "output",
+      output: "hi there in conv-1",
+    });
+
+    const ask = getListenerModCommand(runtime.listener, "ask");
+    if (!ask) throw new Error("ask command was not registered");
+    const promptResult = await runListenerModCommand(runtime, ask, {
+      commandId: "ask",
+      args: "one two",
+      rawInput: "/ask one two",
+    });
+    expect(promptResult).toEqual({
+      type: "prompt",
+      content: "do the thing: one,two",
+    });
+
+    adapter.dispose();
+  });
+});

--- a/src/websocket/listener/mod-commands.ts
+++ b/src/websocket/listener/mod-commands.ts
@@ -1,0 +1,93 @@
+import { sendMessageStreamWithBackend } from "@/agent/message";
+import { getBackend } from "@/backend";
+import {
+  parseModCommandArgv,
+  runModCommandWithTimeout,
+} from "@/cli/mods/command-runtime";
+import { createModConversationHandle } from "@/mods/conversation-handle";
+import type {
+  ModCommand,
+  ModCommandContext,
+  ModCommandResult,
+} from "@/mods/types";
+import type { ModCommandInfo } from "@/types/protocol_v2";
+import { getConversationWorkingDirectory } from "./cwd";
+import { createListenerModContext } from "./mod-adapter";
+import { getConversationPermissionModeState } from "./permission-mode";
+import type { ConversationRuntime, ListenerRuntime } from "./types";
+
+/**
+ * Registered mod commands as advertisable facts. Clients read these to surface
+ * mod commands in their palette by their own policy (separate from the built-in
+ * `supported_commands` allowlist).
+ */
+export function listListenerModCommands(
+  runtime: ListenerRuntime,
+): ModCommandInfo[] {
+  const registry = runtime.modAdapter?.getSnapshot().registry;
+  if (!registry) return [];
+  return Object.values(registry.commands).map((command) => ({
+    id: command.id,
+    description: command.description,
+    ...(command.args ? { args: command.args } : {}),
+  }));
+}
+
+/** Look up a registered mod command by id, if any. */
+export function getListenerModCommand(
+  runtime: ListenerRuntime,
+  commandId: string,
+): ModCommand | undefined {
+  return runtime.modAdapter?.getSnapshot().registry.commands[commandId];
+}
+
+/**
+ * Run a mod command in the listener and return its result. Builds a
+ * ModCommandContext that mirrors the TUI command path (createModConversationHandle
+ * with the shared sendMessageStreamWithBackend so fork/send/updateLlmConfig work
+ * across local and Constellation backends).
+ */
+export async function runListenerModCommand(
+  conversationRuntime: ConversationRuntime,
+  modCommand: ModCommand,
+  parsed: { commandId: string; args: string; rawInput: string },
+): Promise<ModCommandResult> {
+  const { listener, agentId, conversationId } = conversationRuntime;
+  const cwd = getConversationWorkingDirectory(
+    listener,
+    agentId,
+    conversationId,
+  );
+  const permissionMode = getConversationPermissionModeState(
+    listener,
+    agentId,
+    conversationId,
+  ).mode;
+
+  const modContext = createListenerModContext({
+    sessionId: conversationId,
+    workingDirectory: cwd,
+    agent: agentId ? { id: agentId } : null,
+    permissionMode,
+    toolset: conversationRuntime.currentToolset,
+  });
+
+  const conversation = createModConversationHandle({
+    agentId,
+    backend: getBackend(),
+    conversationId,
+    sendMessageStream: sendMessageStreamWithBackend,
+    workingDirectory: cwd,
+  });
+
+  const context: ModCommandContext = {
+    ...modContext,
+    args: parsed.args,
+    argv: parseModCommandArgv(parsed.args),
+    command: parsed.commandId,
+    conversation: { ...conversation, id: conversationId },
+    rawInput: parsed.rawInput,
+  };
+
+  return runModCommandWithTimeout(modCommand, context);
+}

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -24,6 +24,7 @@ import type {
   LoopState,
   LoopStatus,
   LoopStatusUpdateMessage,
+  ModCommandInfo,
   QueueMessage,
   QueueUpdateMessage,
   RetryMessage,
@@ -40,6 +41,7 @@ import { isDebugEnabled } from "@/utils/debug";
 import { SYSTEM_REMINDER_RE } from "./constants";
 import { getConversationWorkingDirectory } from "./cwd";
 import { SUPPORTED_REMOTE_COMMANDS } from "./listener-constants";
+import { listListenerModCommands } from "./mod-commands";
 import { getConversationPermissionModeState } from "./permission-mode";
 import {
   getConversationRuntime,
@@ -76,6 +78,17 @@ const MAX_GIT_CONTEXT_CACHE_ENTRIES = 64;
  * web client). (LET-8948)
  */
 const FROZEN_SUPPORTED_COMMANDS: string[] = [...SUPPORTED_REMOTE_COMMANDS];
+
+/**
+ * Mod-contributed commands for the device status, omitted entirely when no mods
+ * register commands so the common case adds no field.
+ */
+function buildModCommandsField(listener: ListenerRuntime): {
+  mod_commands?: ModCommandInfo[];
+} {
+  const modCommands = listListenerModCommands(listener);
+  return modCommands.length > 0 ? { mod_commands: modCommands } : {};
+}
 const PROTOCOL_PERF_FLUSH_INTERVAL_MS = 1_000;
 const PROTOCOL_PERF_ENV_VALUES = new Set(["1", "true", "yes"]);
 const PROTOCOL_PERF_ENABLED = PROTOCOL_PERF_ENV_VALUES.has(
@@ -485,6 +498,7 @@ export function buildDeviceStatus(
       : {}),
     should_doctor: systemPromptDoctorState?.should_doctor ?? false,
     supported_commands: FROZEN_SUPPORTED_COMMANDS,
+    ...buildModCommandsField(listener),
     reflection_settings: scopedAgentId
       ? {
           agent_id: scopedAgentId,


### PR DESCRIPTION
## Summary
Mod-registered slash commands work in the TUI but were inert in the desktop/app-server (listener) path. This wires the listener side so any client can discover and run them:

- **Enable**: turn on the mod `commands` capability for the listener (it was a no-op, so `letta.commands.register(...)` registered nothing).
- **Advertise**: add a dedicated `DeviceStatus.mod_commands` field (`{ id, description, args }`), **separate from `supported_commands`**. `supported_commands` keeps gating the client's built-in allowlist; `mod_commands` carries mod-contributed commands as client-agnostic facts so each client can auto-surface them by its own policy.
- **Execute**: route mod commands through `handleExecuteCommand`, mirroring the TUI: `output` → command output, `handled` → silent close, `prompt` → inject a user turn via `handleIncomingMessage`.
- **Reload**: re-push device status after `/reload` so newly (un)registered commands appear.

## Why a separate field (not merged into `supported_commands`)
Merging mod ids into `supported_commands` (the prior approach in #3108) conflates two sets a client must keep apart: built-in remote commands the client intentionally hides (it has no hardcoded entry for them) vs. mod commands it should auto-surface. As bare strings they're indistinguishable. Keeping `mod_commands` separate lets the **listener stay client-agnostic** (it advertises facts) while **curation stays per-client** (a UX decision that doesn't scale into the listener). Invocation reuses the existing `execute_command` path.

## Not included (follow-up)
- **Client rendering**: letta-cloud needs to read `mod_commands` and synthesize dynamic palette entries (dedupe against client-side commands). Tracked separately.

## Test plan
- [x] `bun test src/websocket/listener/` (96 pass)
- [x] `mod-commands.test.ts`: advertises descriptors (id/description/args), lookup, run output & prompt
- [x] `mod-adapter.test.ts`: listener now registers mod commands
- [x] typecheck + lint clean
- [ ] Validate in Desktop once the letta-cloud side lands: create a mod command, `/reload`, confirm it shows + executes

👾 Generated with [Letta Code](https://letta.com)