### PR TITLE
fix(mods): diagnose invalid panel renderers

### DIFF
--- a/src/mods/mod-engine.test.ts
+++ b/src/mods/mod-engine.test.ts
@@ -1547,6 +1547,45 @@ describe("mod engine", () => {
     }
   });
 
+  test("diagnoses panel registrations without render", async () => {
+    const root = createTempDir();
+    try {
+      const modDir = path.join(root, "global-mods");
+      const modPath = path.join(modDir, "panel-content.ts");
+      mkdirSync(modDir, { recursive: true });
+      writeFileSync(
+        modPath,
+        `export default function(letta) {
+          letta.ui.openPanel({
+            id: "threadkeeper",
+            order: 80,
+            content: ["legacy content panel"],
+          });
+        }`,
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+      const snapshot = engine.getSnapshot();
+
+      expect(Object.values(snapshot.ui.panels)).toEqual([]);
+      expect(snapshot.diagnostics).toContainEqual(
+        expect.objectContaining({
+          capability: { id: "threadkeeper", kind: "panel" },
+          error: expect.objectContaining({
+            message: expect.stringContaining("requires render(ctx)"),
+          }),
+          phase: "activate",
+          severity: "warning",
+        }),
+      );
+
+      engine.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("reload publishes an empty snapshot while mods are loading", async () => {
     const root = createTempDir();
     const testGlobal = globalThis as ModTestGlobal;

--- a/src/mods/mod-engine.ts
+++ b/src/mods/mod-engine.ts
@@ -943,6 +943,13 @@ function upsertModPanel(
   };
 }
 
+function createNoopModPanelHandle(): ModPanelHandle {
+  return {
+    close() {},
+    update() {},
+  };
+}
+
 function createLettaModApi(
   registry: LocalModRegistry,
   owner: ModOwner,
@@ -1320,16 +1327,24 @@ function createLettaModApi(
       closePanel,
       openPanel(panel) {
         if (!capabilities.ui.panels) {
-          return {
-            close() {},
-            update() {},
-          };
+          return createNoopModPanelHandle();
         }
         if (!guardLive({ id: panel.id, kind: "panel" })) {
-          return {
-            close() {},
-            update() {},
-          };
+          return createNoopModPanelHandle();
+        }
+        if (typeof panel.render !== "function") {
+          const usedLegacyContent = Object.hasOwn(panel as object, "content");
+          recordCapabilityDiagnostic({
+            capability: { id: panel.id, kind: "panel" },
+            error: new Error(
+              usedLegacyContent
+                ? "letta.ui.openPanel now requires render(ctx), not content. Use letta.ui.openPanel({ id, order, render: () => content }) instead."
+                : "letta.ui.openPanel requires a render(ctx) function.",
+            ),
+            phase: "activate",
+            severity: "warning",
+          });
+          return createNoopModPanelHandle();
         }
 
         upsertModPanel(registry, owner, panel.id, {


### PR DESCRIPTION
## Summary
- add an openPanel validation path for missing `render(ctx)` callbacks
- emit a warning diagnostic for legacy `openPanel({ content })` usage instead of silently skipping the panel
- return a noop panel handle for invalid registrations
- add a regression test covering the Threadkeeper-style `content` case

## Test plan
- [x] `bun test src/mods/mod-engine.test.ts`
- [x] `bun run typecheck`
- [x] `bunx biome check src/mods/mod-engine.ts src/mods/mod-engine.test.ts`
- [x] commit hooks