### PR TITLE
feat(mods): add letta.ui.select blocking dialogs

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -4940,8 +4940,15 @@ export function App({
     trajectoryTokenDisplayRef.current,
   );
   const inputVisible = !showExitStats;
+  // A mod-driven blocking dialog (letta.ui.select) owns input while open, so the
+  // main input must stop capturing keys (otherwise Enter both submits and
+  // selects the dialog's highlighted option).
+  const modDialogActive = (modAdapter.registry?.ui.dialogs?.length ?? 0) > 0;
   const inputEnabled =
-    !showExitStats && pendingApprovals.length === 0 && !anySelectorOpen;
+    !showExitStats &&
+    pendingApprovals.length === 0 &&
+    !anySelectorOpen &&
+    !modDialogActive;
   const onEscapeCommandCancel = useCallback(() => {
     if (isActiveConnectOperationCancellable()) {
       cancelActiveConnectOperation();

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -33,6 +33,7 @@ import { McpSelector } from "@/cli/components/McpSelector";
 import { MemfsTreeViewer } from "@/cli/components/MemfsTreeViewer";
 import { MemoryTabViewer } from "@/cli/components/MemoryTabViewer";
 import { MessageSearch } from "@/cli/components/MessageSearch";
+import { ModDialogPrompt } from "@/cli/components/ModDialogPrompt";
 import { ModelReasoningSelector } from "@/cli/components/ModelReasoningSelector";
 import {
   ModelSelector,
@@ -481,6 +482,17 @@ export function AppView(props: AppViewProps) {
     updateAgentName,
   } = props;
 
+  // Mod-driven blocking dialog (letta.ui.select); the first queued entry is the
+  // active one. Only shown when nothing else owns input, so it never stacks
+  // under an approval/overlay; when shown it takes over the input region like
+  // AskUserQuestion does.
+  const activeModDialog = modAdapter.registry?.ui.dialogs?.[0];
+  const modDialogHasFocus =
+    !!activeModDialog &&
+    !currentApproval &&
+    !anySelectorOpen &&
+    activeOverlay === null;
+
   return (
     <Box key={resumeKey} flexDirection="column">
       <StaticTranscript
@@ -700,6 +712,18 @@ export function AppView(props: AppViewProps) {
               />
             )}
 
+            {/* Mod-driven blocking dialog (letta.ui.select) - takes over the
+                input, resolving the awaiting select() call on submit/cancel */}
+            {activeModDialog && modDialogHasFocus && (
+              <Box marginTop={1}>
+                <ModDialogPrompt
+                  key={activeModDialog.id}
+                  dialog={activeModDialog}
+                  engine={modAdapter.engine}
+                />
+              </Box>
+            )}
+
             {/* Input row - always mounted to preserve state */}
             <Box marginTop={1}>
               <Input
@@ -717,7 +741,9 @@ export function AppView(props: AppViewProps) {
                 onBashInterrupt={handleBashInterrupt}
                 inputEnabled={inputEnabled}
                 collapseInputWhenDisabled={
-                  pendingApprovals.length > 0 || anySelectorOpen
+                  pendingApprovals.length > 0 ||
+                  anySelectorOpen ||
+                  !!activeModDialog
                 }
                 permissionMode={uiPermissionMode}
                 onPermissionModeChange={handlePermissionModeChange}

--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -1933,8 +1933,12 @@ export function Input({
     [statusLinePayload, currentModelProvider],
   );
 
+  // A mod-driven blocking dialog (letta.ui.select) takes over the input region,
+  // so hide mod panels while one is open.
+  const hasActiveModDialog = (modAdapter.registry?.ui.dialogs?.length ?? 0) > 0;
+
   const modPanelRow = useMemo(() => {
-    if (suppressDividers) return null;
+    if (suppressDividers || hasActiveModDialog) return null;
     return (
       <ModPanelRow
         panels={modAdapter.registry?.ui.panels}
@@ -1945,13 +1949,14 @@ export function Input({
     );
   }, [
     suppressDividers,
+    hasActiveModDialog,
     modAdapter.registry?.ui.panels,
     terminalWidth,
     panelLiveContext,
   ]);
 
   const modPanelRowBelow = useMemo(() => {
-    if (suppressDividers) return null;
+    if (suppressDividers || hasActiveModDialog) return null;
     return (
       <ModPanelRow
         panels={modAdapter.registry?.ui.panels}
@@ -1962,6 +1967,7 @@ export function Input({
     );
   }, [
     suppressDividers,
+    hasActiveModDialog,
     modAdapter.registry?.ui.panels,
     terminalWidth,
     panelLiveContext,

--- a/src/cli/components/ModDialogPrompt.test.tsx
+++ b/src/cli/components/ModDialogPrompt.test.tsx
@@ -1,0 +1,96 @@
+import { expect, test } from "bun:test";
+import { Readable, Writable } from "node:stream";
+import { render } from "ink";
+import stripAnsi from "strip-ansi";
+import type { ModDialog, ModEngine } from "@/mods/mod-engine";
+import { ModDialogPrompt } from "./ModDialogPrompt";
+
+class CaptureStream extends Writable {
+  columns = 100;
+  rows = 24;
+  isTTY = true;
+  chunks: string[] = [];
+
+  override _write(
+    chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ) {
+    this.chunks.push(String(chunk));
+    callback();
+  }
+}
+
+function createInputStream(): NodeJS.ReadStream {
+  const input = new Readable({ read() {} }) as NodeJS.ReadStream;
+  input.isTTY = true;
+  input.setRawMode = () => input;
+  input.ref = () => input;
+  input.unref = () => input;
+  return input;
+}
+
+// Only resolveDialog is exercised here; the prompt never calls anything else.
+const noopEngine = { resolveDialog: () => {} } as unknown as ModEngine;
+
+async function renderDialog(dialog: ModDialog): Promise<string> {
+  const stdout = new CaptureStream() as CaptureStream & NodeJS.WriteStream;
+  const originalWrite = process.stdout.write;
+  process.stdout.write = (() => true) as typeof process.stdout.write;
+
+  try {
+    const instance = render(
+      <ModDialogPrompt dialog={dialog} engine={noopEngine} />,
+      {
+        stdout,
+        stdin: createInputStream(),
+        debug: false,
+        patchConsole: false,
+        exitOnCtrlC: false,
+      },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    instance.unmount();
+    instance.cleanup();
+    return stripAnsi(stdout.chunks.join(""));
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+}
+
+test("normalizes a bare question (no options) into a free-text dialog", async () => {
+  const dialog: ModDialog = {
+    id: "dialog-1",
+    questions: [{ header: "Name", question: "What should I call it?" }],
+    resolve: () => {},
+  };
+
+  const frame = await renderDialog(dialog);
+
+  expect(frame).toContain("Name");
+  expect(frame).toContain("What should I call it?");
+  // options defaulted to [], allowOther undefined -> free-text row shown.
+  expect(frame).toContain("Type something.");
+});
+
+test("renders options and hides the free-text row when allowOther is false", async () => {
+  const dialog: ModDialog = {
+    id: "dialog-2",
+    questions: [
+      {
+        header: "Color",
+        question: "Pick a color",
+        options: [{ label: "red" }, { label: "blue" }],
+        allowOther: false,
+      },
+    ],
+    resolve: () => {},
+  };
+
+  const frame = await renderDialog(dialog);
+
+  expect(frame).toContain("red");
+  expect(frame).toContain("blue");
+  expect(frame).not.toContain("Type something.");
+});

--- a/src/cli/components/ModDialogPrompt.tsx
+++ b/src/cli/components/ModDialogPrompt.tsx
@@ -1,0 +1,43 @@
+import { memo, useMemo } from "react";
+import type { ModDialog, ModEngine } from "@/mods/mod-engine";
+import { InlineQuestionApproval } from "./InlineQuestionApproval";
+
+type Props = {
+  dialog: ModDialog;
+  engine: ModEngine;
+};
+
+/**
+ * Renders a mod-driven blocking dialog (letta.ui.select) through the same
+ * InlineQuestionApproval component as the built-in AskUserQuestion tool, so the
+ * UX is identical. Normalizes the mod-facing ModDialogQuestion shape (optional
+ * options/multiSelect) to the component's required shape, and settles the
+ * awaiting select() call via engine.resolveDialog. Only mounted when the dialog
+ * has input focus, so it always renders focused.
+ */
+export const ModDialogPrompt = memo(({ dialog, engine }: Props) => {
+  const questions = useMemo(
+    () =>
+      dialog.questions.map((question) => ({
+        question: question.question,
+        header: question.header,
+        options: (question.options ?? []).map((option) => ({
+          label: option.label,
+          description: option.description ?? "",
+        })),
+        multiSelect: question.multiSelect ?? false,
+        allowOther: question.allowOther,
+      })),
+    [dialog.questions],
+  );
+
+  return (
+    <InlineQuestionApproval
+      questions={questions}
+      onSubmit={(answers) => engine.resolveDialog(dialog.id, answers)}
+      onCancel={() => engine.resolveDialog(dialog.id, null)}
+    />
+  );
+});
+
+ModDialogPrompt.displayName = "ModDialogPrompt";

--- a/src/cli/mods/capabilities.ts
+++ b/src/cli/mods/capabilities.ts
@@ -14,5 +14,6 @@ export const TUI_MOD_CAPABILITIES: ModCapabilities = {
   providers: true,
   ui: {
     panels: true,
+    dialogs: true,
   },
 };

--- a/src/headless-mod-adapter.ts
+++ b/src/headless-mod-adapter.ts
@@ -31,6 +31,7 @@ export const HEADLESS_MOD_CAPABILITIES: ModCapabilities = {
   providers: true,
   ui: {
     panels: false,
+    dialogs: false,
   },
 };
 

--- a/src/headless-mod-lifecycle.test.ts
+++ b/src/headless-mod-lifecycle.test.ts
@@ -49,6 +49,7 @@ describe("headless mod adapter", () => {
       providers: true,
       ui: {
         panels: false,
+        dialogs: false,
       },
     });
   });

--- a/src/mods/capabilities.ts
+++ b/src/mods/capabilities.ts
@@ -11,6 +11,7 @@ export const MOD_CAPABILITY_IDS = [
   "events.compact",
   "events.llm",
   "ui.panels",
+  "ui.dialogs",
 ] as const;
 
 export type ModCapabilityId = (typeof MOD_CAPABILITY_IDS)[number];
@@ -35,6 +36,7 @@ export const DEFAULT_MOD_CAPABILITIES: ModCapabilities = {
   providers: true,
   ui: {
     panels: true,
+    dialogs: true,
   },
 };
 
@@ -52,6 +54,7 @@ export const DISABLED_MOD_CAPABILITIES: ModCapabilities = {
   providers: false,
   ui: {
     panels: false,
+    dialogs: false,
   },
 };
 
@@ -72,6 +75,7 @@ export function cloneModCapabilities(
     providers: capabilities.providers,
     ui: {
       panels: capabilities.ui.panels,
+      dialogs: capabilities.ui.dialogs,
     },
   };
 }

--- a/src/mods/disabled-mod-adapter.ts
+++ b/src/mods/disabled-mod-adapter.ts
@@ -24,6 +24,7 @@ function createDisabledModRegistry(): LocalModRegistry {
     tools: {},
     ui: {
       panels: {},
+      dialogs: [],
     },
   };
 }
@@ -40,6 +41,7 @@ function createDisabledModEngine(registry: LocalModRegistry): ModEngine {
     reload() {
       return Promise.resolve();
     },
+    resolveDialog() {},
     subscribe(_listener: () => void) {
       return () => undefined;
     },

--- a/src/mods/mod-engine.test.ts
+++ b/src/mods/mod-engine.test.ts
@@ -31,6 +31,10 @@ type ModTestGlobal = typeof globalThis & {
   __lettaModEvents?: string[];
   __lettaModGate?: Promise<void>;
   __lettaModPanel?: ModPanelHandle;
+  __lettaModAsked?: boolean;
+  __lettaModSelectResult?: Promise<Record<string, string> | null>;
+  __lettaModSelectA?: Promise<Record<string, string> | null>;
+  __lettaModSelectB?: Promise<Record<string, string> | null>;
   __lettaModSignal?: AbortSignal;
   __lettaModStarted?: () => void;
   __lettaSwapBackend?: () => void;
@@ -114,6 +118,7 @@ const TOOL_ONLY_MOD_CAPABILITIES: ModCapabilities = {
   providers: false,
   ui: {
     panels: false,
+    dialogs: false,
   },
 };
 
@@ -587,6 +592,248 @@ describe("mod engine", () => {
       expect(Object.keys(snapshot.tools)).toEqual(["visible_tool"]);
     } finally {
       delete testGlobal.__lettaModCapabilities;
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("ui.select enqueues a dialog and resolves via resolveDialog", async () => {
+    const root = createTempDir();
+    const testGlobal = globalThis as ModTestGlobal;
+    delete testGlobal.__lettaModSelectResult;
+
+    try {
+      const modDir = path.join(root, "global-mods");
+      const modPath = path.join(modDir, "ask.ts");
+      mkdirSync(modDir, { recursive: true });
+      writeFileSync(
+        modPath,
+        `export default function(letta) {
+          globalThis.__lettaModSelectResult = letta.ui.select({
+            questions: [
+              {
+                header: "Pick",
+                question: "Pick one",
+                options: [{ label: "A" }, { label: "B" }],
+              },
+            ],
+          });
+        }`,
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+
+      const snapshot = engine.getSnapshot();
+      expect(snapshot.ui.dialogs).toHaveLength(1);
+      const dialog = snapshot.ui.dialogs[0];
+      expect(dialog?.questions[0]?.question).toBe("Pick one");
+
+      const answer: Record<string, string> = { "Pick one": "A" };
+      engine.resolveDialog(dialog?.id ?? "", answer);
+
+      const result = (await testGlobal.__lettaModSelectResult) as
+        | Record<string, string>
+        | undefined;
+      expect(result).toEqual(answer);
+      // The active dialog is drained once resolved.
+      expect(engine.getSnapshot().ui.dialogs).toHaveLength(0);
+    } finally {
+      delete testGlobal.__lettaModSelectResult;
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("settling a dialog directly off the snapshot drains the queue", async () => {
+    const root = createTempDir();
+    const testGlobal = globalThis as ModTestGlobal;
+    delete testGlobal.__lettaModSelectResult;
+
+    try {
+      const modDir = path.join(root, "global-mods");
+      const modPath = path.join(modDir, "ask.ts");
+      mkdirSync(modDir, { recursive: true });
+      writeFileSync(
+        modPath,
+        `export default function(letta) {
+          globalThis.__lettaModSelectResult = letta.ui.select({
+            questions: [{ header: "Pick", question: "Pick one" }],
+          });
+        }`,
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+
+      const dialog = engine.getSnapshot().ui.dialogs[0];
+      expect(dialog).toBeDefined();
+      // Bypassing engine.resolveDialog must be equivalent: the self-dequeuing
+      // resolver removes the entry so no zombie dialog is left on screen.
+      dialog?.resolve(null);
+
+      const result = await testGlobal.__lettaModSelectResult;
+      expect(result).toBeNull();
+      expect(engine.getSnapshot().ui.dialogs).toHaveLength(0);
+    } finally {
+      delete testGlobal.__lettaModSelectResult;
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("a pending dialog settles to null when the engine reloads", async () => {
+    const root = createTempDir();
+    const testGlobal = globalThis as ModTestGlobal;
+    delete testGlobal.__lettaModSelectResult;
+    delete testGlobal.__lettaModAsked;
+
+    try {
+      const modDir = path.join(root, "global-mods");
+      const modPath = path.join(modDir, "ask.ts");
+      mkdirSync(modDir, { recursive: true });
+      // Guard so the dialog is enqueued only on the first activation; otherwise
+      // each reload re-enqueues and we can't observe the queue draining.
+      writeFileSync(
+        modPath,
+        `export default function(letta) {
+          if (globalThis.__lettaModAsked) return;
+          globalThis.__lettaModAsked = true;
+          globalThis.__lettaModSelectResult = letta.ui.select({
+            questions: [{ header: "Pick", question: "Pick one" }],
+          });
+        }`,
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+
+      const pending = testGlobal.__lettaModSelectResult;
+      expect(engine.getSnapshot().ui.dialogs).toHaveLength(1);
+
+      await engine.reload();
+
+      expect(await pending).toBeNull();
+      expect(engine.getSnapshot().ui.dialogs).toHaveLength(0);
+    } finally {
+      delete testGlobal.__lettaModSelectResult;
+      delete testGlobal.__lettaModAsked;
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("a pending dialog settles to null when the engine is disposed", async () => {
+    const root = createTempDir();
+    const testGlobal = globalThis as ModTestGlobal;
+    delete testGlobal.__lettaModSelectResult;
+
+    try {
+      const modDir = path.join(root, "global-mods");
+      const modPath = path.join(modDir, "ask.ts");
+      mkdirSync(modDir, { recursive: true });
+      writeFileSync(
+        modPath,
+        `export default function(letta) {
+          globalThis.__lettaModSelectResult = letta.ui.select({
+            questions: [{ header: "Pick", question: "Pick one" }],
+          });
+        }`,
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+
+      const pending = testGlobal.__lettaModSelectResult;
+      expect(engine.getSnapshot().ui.dialogs).toHaveLength(1);
+
+      engine.dispose();
+
+      expect(await pending).toBeNull();
+      expect(engine.getSnapshot().ui.dialogs).toHaveLength(0);
+    } finally {
+      delete testGlobal.__lettaModSelectResult;
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("dialogs queue FIFO; resolving the active one promotes the next", async () => {
+    const root = createTempDir();
+    const testGlobal = globalThis as ModTestGlobal;
+    delete testGlobal.__lettaModSelectA;
+    delete testGlobal.__lettaModSelectB;
+
+    try {
+      const modDir = path.join(root, "global-mods");
+      const modPath = path.join(modDir, "ask.ts");
+      mkdirSync(modDir, { recursive: true });
+      writeFileSync(
+        modPath,
+        `export default function(letta) {
+          globalThis.__lettaModSelectA = letta.ui.select({
+            questions: [{ header: "A", question: "Q-A", options: [{ label: "a" }] }],
+          });
+          globalThis.__lettaModSelectB = letta.ui.select({
+            questions: [{ header: "B", question: "Q-B", options: [{ label: "b" }] }],
+          });
+        }`,
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+
+      let dialogs = engine.getSnapshot().ui.dialogs;
+      expect(dialogs).toHaveLength(2);
+      // The first enqueued question is the active (head) entry.
+      expect(dialogs[0]?.questions[0]?.question).toBe("Q-A");
+
+      const answerA: Record<string, string> = { "Q-A": "a" };
+      engine.resolveDialog(dialogs[0]?.id ?? "", answerA);
+
+      dialogs = engine.getSnapshot().ui.dialogs;
+      expect(dialogs).toHaveLength(1);
+      expect(dialogs[0]?.questions[0]?.question).toBe("Q-B");
+      const resultA = (await testGlobal.__lettaModSelectA) as
+        | Record<string, string>
+        | undefined;
+      expect(resultA).toEqual(answerA);
+
+      const answerB: Record<string, string> = { "Q-B": "b" };
+      engine.resolveDialog(dialogs[0]?.id ?? "", answerB);
+      const resultB = (await testGlobal.__lettaModSelectB) as
+        | Record<string, string>
+        | undefined;
+      expect(resultB).toEqual(answerB);
+      expect(engine.getSnapshot().ui.dialogs).toHaveLength(0);
+    } finally {
+      delete testGlobal.__lettaModSelectA;
+      delete testGlobal.__lettaModSelectB;
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("ui.select resolves null when the dialogs capability is disabled", async () => {
+    const root = createTempDir();
+    const testGlobal = globalThis as ModTestGlobal;
+    delete testGlobal.__lettaModSelectResult;
+
+    try {
+      const modDir = path.join(root, "global-mods");
+      const modPath = path.join(modDir, "ask.ts");
+      mkdirSync(modDir, { recursive: true });
+      writeFileSync(
+        modPath,
+        `export default function(letta) {
+          globalThis.__lettaModSelectResult = letta.ui.select({
+            questions: [{ header: "Pick", question: "Pick one" }],
+          });
+        }`,
+      );
+
+      const engine = createEngine(root, TOOL_ONLY_MOD_CAPABILITIES);
+      await engine.reload();
+
+      expect(engine.getSnapshot().ui.dialogs).toHaveLength(0);
+      const result = await testGlobal.__lettaModSelectResult;
+      expect(result).toBeNull();
+    } finally {
+      delete testGlobal.__lettaModSelectResult;
       rmSync(root, { force: true, recursive: true });
     }
   });

--- a/src/mods/mod-engine.ts
+++ b/src/mods/mod-engine.ts
@@ -70,6 +70,7 @@ import type {
   ModDiagnostic,
   ModDiagnosticReportOptions,
   ModDiagnosticSeverity,
+  ModDialogQuestion,
   ModEventContext,
   ModEventEmissionResult,
   ModEventHandler,
@@ -84,6 +85,8 @@ import type {
   ModPanelRender,
   ModPermission,
   ModPermissionRegistration,
+  ModSelectOptions,
+  ModSelectResult,
   ModSourceScope,
   ModTool,
   ModToolEndEvent,
@@ -158,6 +161,13 @@ export interface LettaModApi {
   ui: {
     closePanel: (id: string) => void;
     openPanel: (panel: ModPanelOptions) => ModPanelHandle;
+    /**
+     * Show a blocking question and await the answer. Renders through the same
+     * host question UI as the built-in AskUserQuestion tool. Resolves to an
+     * answers map keyed by question text, or `null` if the user cancels (ESC)
+     * or the host can't show the prompt.
+     */
+    select: (options: ModSelectOptions) => Promise<ModSelectResult>;
     /** @deprecated Removed. Use openPanel; calls emit a migration diagnostic. */
     setStatus: (key: string, value?: unknown) => void;
     /** @deprecated Removed. Use openPanel; calls emit a migration diagnostic. */
@@ -173,8 +183,24 @@ export interface LocalModDisposer {
   owner: ModOwner;
 }
 
+/**
+ * A pending blocking dialog awaiting a user answer. The host renders the active
+ * dialog (the first in the queue) and calls `engine.resolveDialog` to settle it.
+ */
+export interface ModDialog {
+  id: string;
+  questions: ModDialogQuestion[];
+  /**
+   * Settles the awaiting `letta.ui.select` call. Host-local and not
+   * serializable; remote surfaces settle by id via `engine.resolveDialog`.
+   */
+  resolve: (value: ModSelectResult) => void;
+}
+
 export interface LocalModUiRegistry {
   panels: Record<string, ModPanel>;
+  /** FIFO queue of pending dialogs; the first entry is the active one. */
+  dialogs: ModDialog[];
 }
 
 type LocalModEventsRegistry = Partial<
@@ -238,6 +264,12 @@ export interface ModEngine {
   ) => Promise<ModEventEmissionResult<TName>>;
   getSnapshot: () => LocalModRegistry;
   reload: () => Promise<void>;
+  /**
+   * Settle a pending dialog (see {@link ModDialog}) by id. Removes it from the
+   * queue and resolves the awaiting `letta.ui.select` call. A `null` value
+   * represents cancellation. No-op if the id isn't pending.
+   */
+  resolveDialog: (id: string, value: ModSelectResult) => void;
   subscribe: (listener: () => void) => () => void;
 }
 
@@ -368,6 +400,7 @@ function createEmptyModRegistry(
     tools: {},
     ui: {
       panels: {},
+      dialogs: [],
     },
   };
 }
@@ -420,6 +453,7 @@ function snapshotRegistryForReaders(
     ui: {
       ...registry.ui,
       panels: { ...registry.ui.panels },
+      dialogs: [...registry.ui.dialogs],
     },
   };
 }
@@ -950,6 +984,43 @@ function createNoopModPanelHandle(): ModPanelHandle {
   };
 }
 
+let modDialogCounter = 0;
+
+function enqueueModDialog(
+  registry: LocalModRegistry,
+  questions: ModDialogQuestion[],
+  onChange: () => void,
+): Promise<ModSelectResult> {
+  modDialogCounter += 1;
+  const id = `dialog-${modDialogCounter}`;
+  return new Promise<ModSelectResult>((settle) => {
+    let settled = false;
+    // Self-dequeuing resolver: settling a dialog also removes it from the queue
+    // and republishes, so calling resolve directly is equivalent to
+    // engine.resolveDialog and can never leave a zombie entry on screen.
+    // Idempotent, so a double-settle (e.g. resolve then flush) is a no-op.
+    const resolve = (value: ModSelectResult) => {
+      if (settled) return;
+      settled = true;
+      const index = registry.ui.dialogs.findIndex((entry) => entry.id === id);
+      if (index !== -1) {
+        registry.ui.dialogs.splice(index, 1);
+      }
+      settle(value);
+      onChange();
+    };
+    registry.ui.dialogs.push({ id, questions, resolve });
+  });
+}
+
+/** Cancel every pending dialog (resolve to null), draining the queue. */
+function flushPendingModDialogs(registry: LocalModRegistry): void {
+  // Copy first: each resolve() dequeues its own entry from registry.ui.dialogs.
+  for (const dialog of [...registry.ui.dialogs]) {
+    dialog.resolve(null);
+  }
+}
+
 function createLettaModApi(
   registry: LocalModRegistry,
   owner: ModOwner,
@@ -1325,6 +1396,21 @@ function createLettaModApi(
     },
     ui: {
       closePanel,
+      select(options) {
+        if (!capabilities.ui.dialogs) {
+          return Promise.resolve(null);
+        }
+        if (!guardLive({ id: "select", kind: "dialog" })) {
+          return Promise.resolve(null);
+        }
+        const questions = options?.questions ?? [];
+        if (questions.length === 0) {
+          return Promise.resolve(null);
+        }
+        const promise = enqueueModDialog(registry, questions, onChange);
+        onChange();
+        return promise;
+      },
       openPanel(panel) {
         if (!capabilities.ui.panels) {
           return createNoopModPanelHandle();
@@ -1763,6 +1849,9 @@ export function createModEngine(options: CreateModEngineOptions): ModEngine {
 
     disposeLocalMods(activeRegistry);
     generation += 1;
+    // After the generation bump, the pending dialogs' captured onChange no-ops,
+    // so flushing settles their awaits to null without an extra publish.
+    flushPendingModDialogs(activeRegistry);
     const loadGeneration = generation;
     activeRegistry = createEmptyModRegistry(
       resolveLocalModSources(modOptions),
@@ -1800,6 +1889,9 @@ export function createModEngine(options: CreateModEngineOptions): ModEngine {
     });
     loadingRegistry = nextRegistry;
     if (disposed || loadGeneration !== generation) {
+      // A newer reload (or dispose) superseded this load. Flush so any dialog a
+      // mod enqueued during activation settles to null instead of hanging.
+      flushPendingModDialogs(nextRegistry);
       disposeLocalMods(nextRegistry);
       return;
     }
@@ -1813,6 +1905,7 @@ export function createModEngine(options: CreateModEngineOptions): ModEngine {
       if (disposed) return;
       disposed = true;
       generation += 1;
+      flushPendingModDialogs(activeRegistry);
       disposeLocalMods(activeRegistry);
       activeRegistry = createEmptyModRegistry(
         resolveLocalModSources(modOptions),
@@ -1844,6 +1937,12 @@ export function createModEngine(options: CreateModEngineOptions): ModEngine {
       return snapshot;
     },
     reload,
+    resolveDialog(id, value) {
+      if (disposed) return;
+      // resolve is self-dequeuing and republishes; no manual publish needed.
+      const dialog = activeRegistry.ui.dialogs.find((entry) => entry.id === id);
+      dialog?.resolve(value);
+    },
     subscribe(listener) {
       listeners.add(listener);
       return () => {

--- a/src/mods/types.ts
+++ b/src/mods/types.ts
@@ -67,6 +67,7 @@ export interface ModBackgroundAgentContext {
 
 export interface ModUiCapabilities {
   panels: boolean;
+  dialogs: boolean;
 }
 
 export interface ModEventCapabilities {
@@ -359,6 +360,7 @@ export type ModCapabilityKind =
   | "provider"
   | "tool"
   | "panel"
+  | "dialog"
   | "status"
   | "statusline";
 
@@ -486,6 +488,36 @@ export interface ModPanelHandle {
   close: () => void;
   update: (options?: { order?: number }) => void;
 }
+
+/**
+ * A single question in a dialog. Mirrors the shape the host's question UI
+ * (shared with the built-in AskUserQuestion tool) renders, so mods inherit any
+ * future improvements to that view for free. Omit `options` for a free-text
+ * question; set `multiSelect` for many-of-N (the answer is the chosen labels
+ * joined by ", ").
+ */
+export interface ModDialogQuestion {
+  /** The question text shown to the user. Also the key in the answers map. */
+  question: string;
+  /** Short label for the question (header chip). */
+  header: string;
+  /** Choices. Omit or leave empty for a free-text question. */
+  options?: Array<{ label: string; description?: string }>;
+  /** Allow selecting multiple options. */
+  multiSelect?: boolean;
+  /** Show a free-text "type something" option (default true). */
+  allowOther?: boolean;
+}
+
+export interface ModSelectOptions {
+  questions: ModDialogQuestion[];
+}
+
+/**
+ * Answers keyed by question text → the chosen label(s) or free text. `null`
+ * when the user cancels (ESC) or the host can't show the prompt.
+ */
+export type ModSelectResult = Record<string, string> | null;
 
 export interface ModCommandRegistration {
   id: string;

--- a/src/skills/builtin/creating-mods/SKILL.md
+++ b/src/skills/builtin/creating-mods/SKILL.md
@@ -91,6 +91,7 @@ letta.capabilities.events.llm
 letta.capabilities.permissions
 letta.capabilities.providers
 letta.capabilities.ui.panels
+letta.capabilities.ui.dialogs
 ```
 
 ## Scoped API model

--- a/src/skills/builtin/creating-mods/references/ui.md
+++ b/src/skills/builtin/creating-mods/references/ui.md
@@ -1,6 +1,6 @@
 # Mod UI recipes
 
-UI capabilities are optional. Always guard UI work with `letta.capabilities.ui.panels` when writing portable mods.
+UI capabilities are optional. Always guard UI work with the matching `letta.capabilities.ui.*` flag when writing portable mods.
 
 For UI that belongs to a larger command/event mod, also read `architecture.md` for cleanup and composition patterns.
 
@@ -8,9 +8,11 @@ For UI that belongs to a larger command/event mod, also read `architecture.md` f
 
 ```ts
 letta.capabilities.ui.panels
+letta.capabilities.ui.dialogs
 ```
 
-- `panels`: text blocks placed around the input bar (the only mod UI surface). Desktop/listener disables panel UI.
+- `panels`: text blocks placed around the input bar. Desktop/listener disables panel UI.
+- `dialogs`: blocking question prompts via `letta.ui.select`. Desktop/listener disables dialog UI (calls resolve to `null`).
 
 ## Panels
 
@@ -59,6 +61,64 @@ render(ctx: {
 `row`/`columns` are ANSI-aware, so chalk-colored segments align correctly.
 
 Close panels when they are transient, and close/replace long-lived panels from the activation disposer if reload should remove them.
+
+## Blocking dialogs (`letta.ui.select`)
+
+`letta.ui.select` asks the user one or more questions and blocks until they answer or cancel. It renders through the same component as the built-in `AskUserQuestion` tool, so the UX is identical and it takes over the input region while open. Use it from a command's `run` (or any async mod code) when you need a choice before continuing.
+
+```ts
+export default function activate(letta) {
+  if (!letta.capabilities.commands) return;
+
+  return letta.commands.register({
+    id: "pick",
+    description: "Ask the user to pick something",
+    showInTranscript: false,
+    async run() {
+      // Guard: dialogs are unavailable on non-TUI surfaces.
+      if (!letta.capabilities.ui.dialogs) {
+        return { type: "output", output: "dialogs not supported here" };
+      }
+
+      const answer = await letta.ui.select({
+        questions: [
+          {
+            header: "Color",
+            question: "Pick a color",
+            options: [
+              { label: "red", description: "warm" },
+              { label: "blue", description: "cool" },
+            ],
+          },
+        ],
+      });
+
+      if (!answer) return { type: "output", output: "cancelled" };
+      return { type: "output", output: `picked ${answer["Pick a color"]}` };
+    },
+  });
+}
+```
+
+### Question shape
+
+```ts
+letta.ui.select({
+  questions: [{
+    question: string;   // shown to the user, and the key the answer is returned under
+    header: string;     // short chip label
+    options?: { label: string; description?: string }[]; // omit for a free-text question
+    multiSelect?: boolean;  // many-of-N (labels come back comma-joined)
+    allowOther?: boolean;   // append a "Type something." free-text row (default true)
+  }],
+}): Promise<Record<string, string> | null>
+```
+
+- The result is keyed by each question's `question` string; `null` means the user cancelled (ESC).
+- **Single-select**: the answer is the chosen option's `label`, or the typed text if they used the free-text row.
+- **Multiselect** (`multiSelect: true`): selected labels are comma-joined (e.g. `"red, blue"`).
+- **Free-text**: omit `options` (or rely on the default `allowOther` row) to collect typed input. Set `allowOther: false` to force a choice among the listed options only.
+- Pass multiple `questions` to ask them in sequence within one dialog; each answer is keyed by its own `question` string.
 
 ## Timers and cleanup
 

--- a/src/websocket/listener/mod-adapter.test.ts
+++ b/src/websocket/listener/mod-adapter.test.ts
@@ -58,6 +58,7 @@ describe("listener mod adapter", () => {
       providers: true,
       ui: {
         panels: false,
+        dialogs: false,
       },
     });
   });

--- a/src/websocket/listener/mod-adapter.ts
+++ b/src/websocket/listener/mod-adapter.ts
@@ -20,6 +20,7 @@ export const LISTENER_MOD_CAPABILITIES: ModCapabilities = {
   providers: true,
   ui: {
     panels: false,
+    dialogs: false,
   },
 };
 


### PR DESCRIPTION
## Summary
- Adds `letta.ui.select`, a surface-agnostic blocking dialog primitive for mods. It enqueues a question dialog onto the mod registry and awaits the answer, settling via a self-dequeuing resolver keyed by id (`engine.resolveDialog`). Pending dialogs flush to `null` on reload, dispose, and superseded loads, so a `select()` call can never hang.
- The TUI renders the active dialog through the **same `InlineQuestionApproval` component as `AskUserQuestion`** (zero UX drift). When shown it takes over the input region: input is disabled + collapsed and mod panels are hidden. It only mounts when nothing else owns input (no approval/overlay/selector), so it never stacks under another prompt.
- Gated behind a new `ui.dialogs` capability — `true` for the TUI, `false` for headless and the WS listener, so it safely resolves to `null` on those surfaces today.

## Behavior impact
No change to existing flows. `InlineQuestionApproval.tsx` is untouched, and every shared-file change (`AppCoordinator` input gating, `InputRich` panel hiding, `AppView` render/collapse) is gated on an active mod dialog, which only exists when a mod calls `letta.ui.select`. `AskUserQuestion` (a tool/permission flow) never touches the mod-dialog queue.

## Desktop / Phase 5 (not in this PR)
Desktop currently renders `AskUserQuestion` by riding the tool-call + permission-request channel (keyed by `toolCallId`); there is no first-class question protocol message. A mod dialog is not a tool call, so enabling this on desktop needs new WS protocol surface: an outbound message carrying the active dialog (`{ id, questions }`, `resolve` stripped) and an inbound resolve message (`{ id, answers }`) routed to `engine.resolveDialog`. The engine contract here is stable and built for that — the open decision is whether to generalize the existing elicitation channel so `AskUserQuestion` and `ui.select` share one transport + the desktop question renderer.

## Test plan
- [x] `bun test src/mods/mod-engine.test.ts` — enqueue/resolve, direct-settle drains, capability-disabled → null, **reload/dispose flush → null + drain**, **FIFO promotion**
- [x] `bun test src/cli/components/ModDialogPrompt.test.tsx` — question normalization (bare question → free-text row; `allowOther: false` → options only)
- [x] tsc + biome clean
- [x] Manual TUI: single-select, free-text (`allowOther`), ESC cancel, submit-while-open no longer double-fires, panels hidden during dialog

👾 Generated with [Letta Code](https://letta.com)