### PR TITLE
fix(channels): gate Discord thread creation on auto_thread_on_mention setting

### DIFF
--- a/src/channels/discord-adapter.test.ts
+++ b/src/channels/discord-adapter.test.ts
@@ -241,6 +241,32 @@ async function startAdapterWithDeliveries(
   return { client, deliveries };
 }
 
+async function startAdapterWithMentionConfig(
+  overrides: Pick<
+    DiscordChannelAccount,
+    "allowedChannels" | "autoThreadOnMention" | "threadPolicyByChannel"
+  >,
+): Promise<{
+  client: FakeDiscordClient;
+  deliveries: InboundChannelMessage[];
+}> {
+  const adapter = createDiscordAdapter({
+    ...discordAccountDefaults,
+    ...overrides,
+  });
+  const deliveries: InboundChannelMessage[] = [];
+  adapter.onMessage = async (message) => {
+    deliveries.push(message);
+  };
+
+  await adapter.start();
+  const client = FakeDiscordClient.instances.at(-1);
+  if (!client) {
+    throw new Error("Discord client was not created");
+  }
+  return { client, deliveries };
+}
+
 beforeEach(() => {
   FakeDiscordClient.instances.length = 0;
   __testOverrideLoadDiscordModule(async () => createFakeDiscordRuntime());
@@ -337,6 +363,110 @@ describe("Discord adapter open-channel ingress", () => {
       chatType: "channel",
       isMention: false,
       isOpenChannel: true,
+    });
+  });
+});
+
+// ── Discord adapter auto-thread-on-mention gating ───────────────────────
+
+describe("Discord adapter auto-thread-on-mention gating", () => {
+  test("does not create a thread when autoThreadOnMention is disabled (default)", async () => {
+    const { client, deliveries } = await startAdapterWithMentionConfig({
+      allowedChannels: { "channel-mention": "mention-only" },
+      // autoThreadOnMention omitted → defaults to false
+    });
+
+    const message = createGuildMessage({
+      id: "msg-mention-nothread",
+      channelId: "channel-mention",
+      content: "<@bot-user> hello there",
+      mentioned: true,
+    });
+
+    await client.emitMessageCreate(message);
+
+    // No thread should be spawned; the mention routes to the channel itself.
+    expect(message.startThread).not.toHaveBeenCalled();
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]).toMatchObject({
+      chatId: "channel-mention",
+      threadId: null,
+      parentChannelId: "channel-mention",
+      isMention: true,
+      isOpenChannel: false,
+    });
+  });
+
+  test("creates a thread when autoThreadOnMention is enabled", async () => {
+    const { client, deliveries } = await startAdapterWithMentionConfig({
+      allowedChannels: { "channel-mention": "mention-only" },
+      autoThreadOnMention: true,
+    });
+
+    const message = createGuildMessage({
+      id: "msg-mention-thread",
+      channelId: "channel-mention",
+      content: "<@bot-user> hello there",
+      mentioned: true,
+    });
+
+    await client.emitMessageCreate(message);
+
+    expect(message.startThread).toHaveBeenCalledTimes(1);
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]).toMatchObject({
+      chatId: "created-thread",
+      threadId: "created-thread",
+      parentChannelId: "channel-mention",
+      isMention: true,
+    });
+  });
+
+  test("per-channel false override suppresses thread creation even when account-level is true", async () => {
+    const { client, deliveries } = await startAdapterWithMentionConfig({
+      allowedChannels: { "channel-mention": "mention-only" },
+      autoThreadOnMention: true,
+      threadPolicyByChannel: { "channel-mention": false },
+    });
+
+    const message = createGuildMessage({
+      id: "msg-mention-override-false",
+      channelId: "channel-mention",
+      content: "<@bot-user> hello there",
+      mentioned: true,
+    });
+
+    await client.emitMessageCreate(message);
+
+    expect(message.startThread).not.toHaveBeenCalled();
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]).toMatchObject({
+      chatId: "channel-mention",
+      threadId: null,
+    });
+  });
+
+  test("per-channel true override creates a thread even when account-level is false", async () => {
+    const { client, deliveries } = await startAdapterWithMentionConfig({
+      allowedChannels: { "channel-mention": "mention-only" },
+      autoThreadOnMention: false,
+      threadPolicyByChannel: { "channel-mention": true },
+    });
+
+    const message = createGuildMessage({
+      id: "msg-mention-override-true",
+      channelId: "channel-mention",
+      content: "<@bot-user> hello there",
+      mentioned: true,
+    });
+
+    await client.emitMessageCreate(message);
+
+    expect(message.startThread).toHaveBeenCalledTimes(1);
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]).toMatchObject({
+      chatId: "created-thread",
+      threadId: "created-thread",
     });
   });
 });

--- a/src/channels/discord/adapter.ts
+++ b/src/channels/discord/adapter.ts
@@ -870,12 +870,21 @@ export function createDiscordAdapter(
           ? message.channelId
           : null;
 
-        // If mentioned outside a thread, create one
+        // If mentioned outside a thread, create one — but only when the
+        // account/channel is configured to auto-thread on mention. When
+        // auto-threading is disabled, the mention routes to the channel
+        // itself (effectiveChatId stays as message.channelId and
+        // effectiveThreadId stays null) instead of spawning a new thread.
         if (!isThread && wasMentioned) {
-          const createdThread = await createThreadForMention(message, content);
-          if (!createdThread) return;
-          effectiveChatId = createdThread.id;
-          effectiveThreadId = createdThread.id;
+          if (shouldAutoThreadOnDiscordMention(config, message.channelId)) {
+            const createdThread = await createThreadForMention(
+              message,
+              content,
+            );
+            if (!createdThread) return;
+            effectiveChatId = createdThread.id;
+            effectiveThreadId = createdThread.id;
+          }
         }
 
         const attachments = await collectAttachments(


### PR DESCRIPTION
## Problem

In `src/channels/discord/adapter.ts`, the guild mention path unconditionally created a new Discord thread whenever the bot was mentioned outside a thread, ignoring the `auto_thread_on_mention` setting. The helper `shouldAutoThreadOnDiscordMention()` already existed and correctly resolves `threadPolicyByChannel` overrides then falls back to `autoThreadOnMention` (defaulting to `false`), but it was never consulted in the mention path.

As a result, even when `auto_thread_on_mention: false` was set in `accounts.json`, every @mention spawned a new Discord thread/conversation.

Linear: https://linear.app/letta/issue/LET-9280/discord-channels-ignores-auto-thread-on-mentionfalse-and-creates-new

## Fix

Gate `createThreadForMention()` behind `shouldAutoThreadOnDiscordMention(config, message.channelId)`. When auto-threading is disabled, the mention now routes to the channel itself (`chatId = message.channelId`, `threadId = null`) instead of spawning a new thread.

This is a minimal, surgical change — no other behavior is refactored.

### Before
```typescript
// If mentioned outside a thread, create one
if (!isThread && wasMentioned) {
  const createdThread = await createThreadForMention(message, content);
  if (!createdThread) return;
  effectiveChatId = createdThread.id;
  effectiveThreadId = createdThread.id;
}
```

### After
```typescript
if (!isThread && wasMentioned) {
  if (shouldAutoThreadOnDiscordMention(config, message.channelId)) {
    const createdThread = await createThreadForMention(message, content);
    if (!createdThread) return;
    effectiveChatId = createdThread.id;
    effectiveThreadId = createdThread.id;
  }
  // When auto-thread is disabled, effectiveChatId stays as message.channelId
  // and effectiveThreadId stays null — the mention routes to the channel itself.
}
```

## Behavior

| Setting | Mention outside a thread |
| --- | --- |
| `autoThreadOnMention` unset / `false` (default) | Replies in the channel itself — no thread created |
| `autoThreadOnMention: true` | Creates a new Discord thread (existing behavior) |
| `threadPolicyByChannel` per-channel override | Override wins over account-level setting |

## Tests

Added a colocated `Discord adapter auto-thread-on-mention gating` test suite in `src/channels/discord-adapter.test.ts` covering:
- No thread created when `autoThreadOnMention` is disabled (default)
- Thread created when `autoThreadOnMention` is enabled
- Per-channel `false` override suppresses thread creation even when account-level is `true`
- Per-channel `true` override creates a thread even when account-level is `false`

`bun run check` passes (all 9 checks), and the Discord adapter test suite passes (47 tests).

## Scope

This PR is focused solely on the `auto_thread_on_mention` gating fix. The issue also mentions two possibly-separate problems (new conversations inside existing Discord threads, and CLI listener approval prompts for every tool call) — those are intentionally **not** addressed here.

🤖 Generated with [Letta Code](https://letta.com)