### PR TITLE
fix(mods): pass full context to panel renders

### DIFF
--- a/src/cli/components/InputRich.tsx
+++ b/src/cli/components/InputRich.tsx
@@ -35,6 +35,7 @@ import type { StatusLinePayload } from "@/cli/helpers/status-line-payload";
 import { getRandomThinkingTip } from "@/cli/helpers/thinking-messages";
 import { useShimmerAnimation } from "@/cli/hooks/use-shimmer-animation";
 import { useTokenSmoothing } from "@/cli/hooks/use-token-smoothing";
+import type { ModContext } from "@/cli/mods/types";
 import type { LocalModAdapter } from "@/cli/mods/use-local-mod-adapter";
 import {
   ELAPSED_DISPLAY_THRESHOLD_MS,
@@ -47,11 +48,7 @@ import { settingsManager } from "@/settings-manager";
 import type { QueuedMessage } from "@/utils/message-queue-bridge";
 import { colors } from "./colors";
 import { InputAssist } from "./InputAssist";
-import {
-  type ModPanelLiveContext,
-  ModPanelRow,
-  renderModPanelLines,
-} from "./ModPanelRow";
+import { ModPanelRow, renderModPanelLines } from "./ModPanelRow";
 import { PasteAwareTextInput } from "./PasteAwareTextInput";
 import { ProductStatusRow } from "./ProductStatusRow";
 import { QueuedMessages } from "./QueuedMessages";
@@ -517,10 +514,11 @@ const StatuslineSlot = memo(function StatuslineSlot({
 
   if (idleSlotAvailable && primaryPanel) {
     const rowWidth = Math.max(0, (statuslineContext.terminalWidth ?? 0) - 1);
-    const lines = renderModPanelLines(primaryPanel, rowWidth, {
-      agent: statuslineContext.agent,
-      model: statuslineContext.model,
-    });
+    const lines = renderModPanelLines(
+      primaryPanel,
+      rowWidth,
+      statuslineContext,
+    );
     if (lines.length > 0) {
       return (
         <Box flexDirection="column">
@@ -1920,17 +1918,30 @@ export function Input({
   // re-renders when the panels themselves change, mirroring how BtwPane
   // stays flash-free. Folding this into lowerPane would rebuild it on every
   // keystroke.
-  const panelLiveContext = useMemo<ModPanelLiveContext>(
-    () => ({
-      agent: statusLinePayload.agent,
-      model: {
-        id: statusLinePayload.model.id,
-        displayName: statusLinePayload.model.display_name,
-        provider: currentModelProvider ?? null,
-        reasoningEffort: statusLinePayload.reasoning_effort,
-      },
-    }),
-    [statusLinePayload, currentModelProvider],
+  const panelLiveContext = useMemo<ModContext>(
+    () =>
+      buildStatuslineRenderContext({
+        payload: statusLinePayload,
+        ui: {
+          currentModelProvider: currentModelProvider ?? null,
+          goalStatusText: null,
+          hasTemporaryModelOverride: Boolean(hasTemporaryModelOverride),
+          isByokProvider:
+            currentModelProvider?.startsWith("lc-") ||
+            currentModelProvider === OPENAI_CODEX_PROVIDER_NAME,
+          isLocalBackend,
+          isOpenAICodexProvider:
+            currentModelProvider === OPENAI_CODEX_PROVIDER_NAME,
+          rightColumnWidth: footerRightColumnWidth,
+        },
+      }),
+    [
+      currentModelProvider,
+      footerRightColumnWidth,
+      hasTemporaryModelOverride,
+      isLocalBackend,
+      statusLinePayload,
+    ],
   );
 
   const modPanelRow = useMemo(() => {

--- a/src/cli/components/ModPanelRow.tsx
+++ b/src/cli/components/ModPanelRow.tsx
@@ -5,17 +5,14 @@ import {
   row,
   truncateToWidth,
 } from "@/cli/display/statusline/formatting";
-import type { ModPanel, ModPanelRenderContext } from "@/cli/mods/types";
-import type { ModAgentContext, ModModelContext } from "@/mods/types";
+import type {
+  ModContext,
+  ModPanel,
+  ModPanelRenderContext,
+} from "@/cli/mods/types";
 import { Text } from "./Text";
 
 const MAX_MOD_PANEL_LINES = 8;
-
-/** Live values supplied to panel renders (agent/model), filled in per frame. */
-export interface ModPanelLiveContext {
-  agent: ModAgentContext;
-  model: ModModelContext;
-}
 
 export type ModPanelPlacement = "above" | "below";
 
@@ -33,19 +30,18 @@ function placedPanels(
 export function renderModPanelLines(
   panel: ModPanel,
   width: number,
-  live: ModPanelLiveContext,
+  context: ModContext,
 ): string[] {
   let result: string | string[];
   try {
-    const context: ModPanelRenderContext = {
+    const renderContext: ModPanelRenderContext = {
+      ...context,
       width,
-      agent: live.agent,
-      model: live.model,
       row,
       columns,
       chalk,
     };
-    result = panel.render(context);
+    result = panel.render(renderContext);
   } catch {
     // A mod's render fn runs inside the input render; never let it crash the UI.
     return [];
@@ -65,7 +61,7 @@ export function ModPanelRow({
   panels?: Record<string, ModPanel>;
   terminalWidth: number;
   placement: ModPanelPlacement;
-  context: ModPanelLiveContext;
+  context: ModContext;
 }) {
   const rowWidth = Math.max(0, terminalWidth - 1);
   if (rowWidth === 0) return null;

--- a/src/cli/components/mod-panel-row.test.ts
+++ b/src/cli/components/mod-panel-row.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import type { ModContext, ModPanel } from "@/cli/mods/types";
+import { renderModPanelLines } from "./ModPanelRow";
+
+const CONTEXT: ModContext = {
+  app: { version: "0.0.0-test" },
+  workspace: {
+    cwd: "/tmp/project",
+    currentDir: "/tmp/project/src",
+    projectDir: "/tmp/project",
+  },
+  cwd: "/tmp/project",
+  sessionId: "conv-1",
+  lastRunId: "run-1",
+  agent: { id: "agent-1", name: "Amelia" },
+  model: {
+    id: "openai/gpt-5.5",
+    displayName: "GPT-5.5",
+    provider: "openai",
+    reasoningEffort: "high",
+  },
+  toolset: "auto",
+  systemPromptId: "prompt-1",
+  permissionMode: "default",
+  networkPhase: null,
+  terminalWidth: 80,
+  contextWindow: {
+    size: 200000,
+    totalInputTokens: 100,
+    totalOutputTokens: 20,
+    usedPercentage: 0.01,
+    remainingPercentage: 0.99,
+    currentUsage: null,
+  },
+  cost: {
+    totalDurationMs: 1000,
+    totalApiDurationMs: 800,
+    totalCostUsd: null,
+    totalLinesAdded: null,
+    totalLinesRemoved: null,
+  },
+  reflection: { mode: null, stepCount: 0 },
+  memfs: { enabled: false, memoryDir: null },
+  backgroundAgents: [],
+};
+
+function createPanel(render: ModPanel["render"]): ModPanel {
+  return {
+    id: "cwd",
+    render,
+    order: 0,
+    path: "/tmp/project/.letta/mods/cwd.ts",
+    updatedAt: 1,
+  };
+}
+
+describe("renderModPanelLines", () => {
+  test("passes the full mod context plus panel helpers", () => {
+    const panel = createPanel((ctx) => {
+      expect(ctx.cwd).toBe("/tmp/project");
+      expect(ctx.workspace.currentDir).toBe("/tmp/project/src");
+      expect(ctx.agent.name).toBe("Amelia");
+      expect(ctx.model.displayName).toBe("GPT-5.5");
+      expect(ctx.width).toBe(40);
+      expect(typeof ctx.row).toBe("function");
+      expect(typeof ctx.columns).toBe("function");
+      expect(typeof ctx.chalk.dim).toBe("function");
+      return ctx.row(ctx.cwd, ctx.model.displayName ?? "", ctx.width);
+    });
+
+    expect(renderModPanelLines(panel, 40, CONTEXT)).toEqual([
+      "/tmp/project                     GPT-5.5",
+    ]);
+  });
+});

--- a/src/cli/mods/local-mod-loader.test.ts
+++ b/src/cli/mods/local-mod-loader.test.ts
@@ -51,15 +51,10 @@ function createStatuslineContext(): StatuslineRenderContext {
 }
 
 function renderCtx(width: number) {
+  const context = createStatuslineContext();
   return {
+    ...context,
     width,
-    agent: { id: null, name: "Test" },
-    model: {
-      id: null,
-      displayName: "test-model",
-      provider: null,
-      reasoningEffort: null,
-    },
     row,
     columns,
     chalk,
@@ -494,7 +489,7 @@ describe("local mod loader", () => {
       expect(cacheFiles[0]?.endsWith(".mjs")).toBe(true);
       const panel = Object.values(registry.ui.panels)[0];
       const output = panel?.render(renderCtx(80));
-      expect(output).toMatchObject({ props: { children: "Test" } });
+      expect(output).toMatchObject({ props: { children: "Letta Code" } });
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/src/mods/types.ts
+++ b/src/mods/types.ts
@@ -444,13 +444,10 @@ export type ModCommandResult =
   | { type: "output"; output: string; success?: boolean }
   | { type: "handled" };
 
-export interface ModPanelRenderContext {
+/** Live mod context (`cwd`, workspace, agent, model, cost, etc.) plus panel helpers. */
+export interface ModPanelRenderContext extends ModContext {
   /** Visible width available to the panel, in columns. */
   width: number;
-  /** Live agent context (name, id) at render time. */
-  agent: ModAgentContext;
-  /** Live model context (display name, provider, ...) at render time. */
-  model: ModModelContext;
   /** Lay out a left and right segment across `width` (ANSI-aware). */
   row: (left: string, right: string, width: number) => string;
   /** Spread parts evenly across `width` (ANSI-aware). */


### PR DESCRIPTION
## Summary
- extend panel render context with the full live mod context, including cwd and workspace
- pass that context into both order-0 statusline panels and above/below input panels
- add coverage that panel renders can read cwd/workspace alongside layout helpers

## Test plan
- bun test src/cli/components/mod-panel-row.test.ts src/cli/mods/local-mod-loader.test.ts
- bun run typecheck