### PR TITLE
feat(local): add OpenRouter app attribution headers

### DIFF
--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -143,7 +143,11 @@ const PI_PROVIDER_OVERRIDES: Partial<
   openrouter: {
     localProviderNames: ["openrouter", LOCAL_OPENROUTER_PROVIDER_NAME],
     baseUrlEnv: () => process.env.OPENROUTER_BASE_URL,
-    headers: () => ({ "X-Title": "Letta Code" }),
+    headers: () => ({
+      "HTTP-Referer": "https://letta.com",
+      "X-OpenRouter-Title": "Letta Code",
+      "X-OpenRouter-Categories": "cli-agent,personal-agent",
+    }),
   },
   zai: {
     providerTypes: ["zai", "zai_coding"],


### PR DESCRIPTION
Letta Code (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Summary

Adds OpenRouter app attribution headers to the local backend OpenRouter provider so Letta Code appears on OpenRouter's public app rankings and analytics.

## Changes

Updated the OpenRouter provider override in `src/backend/dev/pi-provider-registry.ts` to send:
- `HTTP-Referer: https://letta.com` — required for app attribution
- `X-OpenRouter-Title: Letta Code` — display name in rankings
- `X-OpenRouter-Categories: cli-agent,personal-agent` — marketplace categories

Previously only sent `X-Title: Letta Code` (no `HTTP-Referer`, so no app page was created).

Co-Authored-By: Letta Code <noreply@letta.com>