### PR TITLE
fix(mods): replace stale runtime dependency cache symlinks

### DIFF
--- a/src/mods/mod-engine.test.ts
+++ b/src/mods/mod-engine.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type Letta from "@letta-ai/letta-client";
@@ -161,6 +168,45 @@ describe("mod engine", () => {
       expect(engine.getSnapshot()).toBe(snapshot);
 
       unsubscribe();
+      engine.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("reload replaces stale runtime dependency cache symlinks", async () => {
+    const root = createTempDir();
+    try {
+      const modDir = path.join(root, "global-mods");
+      const modPath = path.join(modDir, "command.ts");
+      const cacheNodeModules = path.join(root, "mod-cache", "node_modules");
+      const reactLink = path.join(cacheNodeModules, "react");
+      mkdirSync(modDir, { recursive: true });
+      mkdirSync(cacheNodeModules, { recursive: true });
+      symlinkSync(
+        path.join(root, "missing-react"),
+        reactLink,
+        process.platform === "win32" ? "junction" : "dir",
+      );
+      writeFileSync(
+        modPath,
+        `export default function(letta) {
+          letta.commands.register({
+            id: "hello",
+            description: "Say hello",
+            run() { return { type: "output", output: "hello" }; },
+          });
+        }`,
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+      const snapshot = engine.getSnapshot();
+
+      expect(getModErrorDiagnostics(snapshot.diagnostics)).toEqual([]);
+      expect(snapshot.loadedPaths).toEqual([modPath]);
+      expect(readlinkSync(reactLink)).not.toContain("missing-react");
+
       engine.dispose();
     } finally {
       rmSync(root, { force: true, recursive: true });

--- a/src/mods/mod-engine.ts
+++ b/src/mods/mod-engine.ts
@@ -1,9 +1,11 @@
 import { createHash } from "node:crypto";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   readdirSync,
   readFileSync,
+  readlinkSync,
   statSync,
   symlinkSync,
   unlinkSync,
@@ -471,20 +473,49 @@ function getRuntimePackageDirectory(packageName: string): string {
   );
 }
 
+function normalizeRuntimeDependencyPath(value: string): string {
+  const normalized = path.normalize(value).replace(/^\\\\\?\\/, "");
+  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
 function ensureRuntimeDependencySymlink(
   cacheDirectory: string,
   packageName: string,
 ): void {
   const nodeModulesDirectory = path.join(cacheDirectory, "node_modules");
   const linkPath = path.join(nodeModulesDirectory, packageName);
-  if (existsSync(linkPath)) return;
+  const packageDirectory = path.resolve(
+    getRuntimePackageDirectory(packageName),
+  );
 
   mkdirSync(nodeModulesDirectory, { recursive: true });
-  symlinkSync(
-    getRuntimePackageDirectory(packageName),
-    linkPath,
-    process.platform === "win32" ? "junction" : "dir",
-  );
+  try {
+    const stats = lstatSync(linkPath);
+    if (!stats.isSymbolicLink()) return;
+
+    const existingTarget = readlinkSync(linkPath);
+    const resolvedTarget = path.resolve(nodeModulesDirectory, existingTarget);
+    if (
+      normalizeRuntimeDependencyPath(resolvedTarget) ===
+      normalizeRuntimeDependencyPath(packageDirectory)
+    ) {
+      return;
+    }
+
+    unlinkSync(linkPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+
+  try {
+    symlinkSync(
+      packageDirectory,
+      linkPath,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+  }
 }
 
 function ensureModCache(cacheDirectory: string): void {


### PR DESCRIPTION
## Summary
- make runtime dependency cache symlink setup tolerate stale/dangling symlinks
- replace stale symlinks that point at an old runtime package path
- normalize symlink target comparisons for Windows path casing / long-path prefixes
- add regression coverage for a stale cached React symlink

## Motivation
`existsSync` follows symlinks, so a dangling `~/.letta/mod-cache/node_modules/react` symlink looks absent. The next reload then attempts to create the symlink at the same path and fails with `EEXIST`, preventing all local mods from transpiling.

## Test plan
- [x] `bun test src/mods/mod-engine.test.ts`
- [x] `bun --check src/mods/mod-engine.ts src/mods/mod-engine.test.ts`
- [x] `bun run typecheck`
- [x] commit hooks