### PR TITLE
fix(tui): route bare exit before queueing

### DIFF
--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -460,6 +460,11 @@ function parseReflectCommandArgs(input: string): ReflectCommandArgs {
   return { instruction, kind: "single" };
 }
 
+function aliasBareExitCommand(input: string): string {
+  if (input === "exit" || input === "quit") return "/exit";
+  return input;
+}
+
 export function useSubmitHandler(ctx: SubmitHandlerContext) {
   const {
     abortControllerRef,
@@ -581,6 +586,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
       const { notifications: taskNotifications, cleanedText } =
         extractTaskNotificationsForDisplay(msg);
       const userTextForInput = cleanedText.trim();
+      const routedUserText = aliasBareExitCommand(userTextForInput);
       const isSystemOnly =
         taskNotifications.length > 0 && userTextForInput.length === 0;
 
@@ -711,9 +717,9 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
         setDequeueEpoch((e: number) => e + 1);
       }
 
-      const isSlashCommand = userTextForInput.startsWith("/");
+      const isSlashCommand = routedUserText.startsWith("/");
       const parsedModCommand = isSlashCommand
-        ? parseModSlashCommand(userTextForInput.trim())
+        ? parseModSlashCommand(routedUserText.trim())
         : null;
       const parsedSlashCommandName = parsedModCommand?.command ?? null;
       const matchedCustomCommand = parsedSlashCommandName
@@ -726,15 +732,15 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
       // while the agent is busy. Overlay writes are still deferred via queuedOverlayAction.
       const shouldBypassQueue =
         isSlashCommand &&
-        shouldSlashCommandBypassQueue(userTextForInput, {
+        shouldSlashCommandBypassQueue(routedUserText, {
           hasCustomCommand: Boolean(matchedCustomCommand),
           ...(matchedModCommand ? { modCommand: matchedModCommand } : {}),
         });
 
       if (isAgentBusy() && isSlashCommand && !shouldBypassQueue) {
-        const attemptedCommand = userTextForInput.split(/\s+/)[0] || "/";
+        const attemptedCommand = routedUserText.split(/\s+/)[0] || "/";
         const disabledMessage = `'${attemptedCommand}' is disabled while the agent is running.`;
-        const cmd = commandRunner.start(userTextForInput, disabledMessage);
+        const cmd = commandRunner.start(routedUserText, disabledMessage);
         cmd.fail(disabledMessage);
         return { submitted: true }; // Clears input
       }
@@ -753,10 +759,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
       // Note: userCancelledRef.current was already reset above before the queue check
       // to ensure the dequeue effect isn't blocked by a stale cancellation flag.
 
-      let aliasedMsg = msg;
-      if (msg === "exit" || msg === "quit") {
-        aliasedMsg = "/exit";
-      }
+      const aliasedMsg = routedUserText;
 
       // Handle commands (messages starting with "/")
       if (aliasedMsg.startsWith("/")) {

--- a/src/cli/queue-ordering-wiring.test.ts
+++ b/src/cli/queue-ordering-wiring.test.ts
@@ -70,6 +70,26 @@ describe("queue ordering wiring", () => {
     );
   });
 
+  test("bare exit aliases before queue classification", () => {
+    const source = readAppSource();
+    const start = source.indexOf("const onSubmit = useCallback(");
+    const end = source.indexOf("const shouldBypassQueue =");
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    const segment = source.slice(start, end);
+    const aliasIndex = segment.indexOf(
+      "const routedUserText = aliasBareExitCommand(userTextForInput)",
+    );
+    const slashIndex = segment.indexOf(
+      "const isSlashCommand = routedUserText.startsWith",
+    );
+
+    expect(aliasIndex).toBeGreaterThan(-1);
+    expect(slashIndex).toBeGreaterThan(aliasIndex);
+  });
+
   test("queued overlay effect only runs when idle and clears action before processing", () => {
     const source = readAppSource();
     const start = source.indexOf(


### PR DESCRIPTION
## Summary
- normalize bare `exit` / `quit` to `/exit` before slash-command and queue-bypass classification
- keep display/bookkeeping text separate from routed command text
- add a wiring test so bare exit stays before the busy queue path

## Motivation
`/exit` bypasses the busy queue, but bare `exit` was being aliased only after normal message queueing. If the agent was busy, `exit` could be queued as a user message instead of closing the session.

## Test plan
- [x] `bun test src/cli/queue-ordering-wiring.test.ts`
- [x] `bun --check src/cli/app/use-submit-handler.ts src/cli/queue-ordering-wiring.test.ts`
- [x] `bun run typecheck`
- [x] commit hooks