### PR TITLE
feat(local): add OpenRouter attribution opt-out env var

### DIFF
--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -143,11 +143,14 @@ const PI_PROVIDER_OVERRIDES: Partial<
   openrouter: {
     localProviderNames: ["openrouter", LOCAL_OPENROUTER_PROVIDER_NAME],
     baseUrlEnv: () => process.env.OPENROUTER_BASE_URL,
-    headers: () => ({
-      "HTTP-Referer": "https://letta.com",
-      "X-OpenRouter-Title": "Letta Code",
-      "X-OpenRouter-Categories": "cli-agent,personal-agent",
-    }),
+    headers: () =>
+      process.env.LETTA_DISABLE_OPENROUTER_ATTRIBUTION === "1"
+        ? undefined
+        : {
+            "HTTP-Referer": "https://letta.com",
+            "X-OpenRouter-Title": "Letta Code",
+            "X-OpenRouter-Categories": "cli-agent,personal-agent",
+          },
   },
   zai: {
     providerTypes: ["zai", "zai_coding"],

--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -64,6 +64,19 @@ function hasEnvValue(value: string | undefined): boolean {
   return typeof value === "string" && value.length > 0;
 }
 
+function isTruthyEnvFlag(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return ["1", "true", "yes", "on"].includes(normalized);
+}
+
+function shouldDisableOpenRouterAttribution(): boolean {
+  return (
+    isTruthyEnvFlag(process.env.LETTA_DISABLE_OPENROUTER_ATTRIBUTION) ||
+    isTruthyEnvFlag(process.env.DO_NOT_TRACK)
+  );
+}
+
 function unique(values: readonly string[]): string[] {
   return [...new Set(values.filter((value) => value.length > 0))];
 }
@@ -144,7 +157,7 @@ const PI_PROVIDER_OVERRIDES: Partial<
     localProviderNames: ["openrouter", LOCAL_OPENROUTER_PROVIDER_NAME],
     baseUrlEnv: () => process.env.OPENROUTER_BASE_URL,
     headers: () =>
-      process.env.LETTA_DISABLE_OPENROUTER_ATTRIBUTION === "1"
+      shouldDisableOpenRouterAttribution()
         ? undefined
         : {
             "HTTP-Referer": "https://letta.com",

--- a/src/providers/local-pi-provider-catalog.test.ts
+++ b/src/providers/local-pi-provider-catalog.test.ts
@@ -12,6 +12,7 @@ import {
   registerPiProvider,
 } from "@/backend/dev/pi-provider-mod-registry";
 import {
+  getPiProviderSpec,
   PI_PROVIDER_SPECS,
   PI_TUI_DEFAULT_MODEL_IDS,
   PI_TUI_DEFAULTLESS_PROVIDER_IDS,
@@ -26,8 +27,50 @@ import {
 import { getProviderConfigs } from "@/providers/byok-providers";
 
 describe("local pi provider catalog", () => {
+  const originalDisableOpenRouterAttribution =
+    process.env.LETTA_DISABLE_OPENROUTER_ATTRIBUTION;
+  const originalDoNotTrack = process.env.DO_NOT_TRACK;
+
+  function restoreEnvVar(name: string, value: string | undefined): void {
+    if (value === undefined) {
+      delete process.env[name];
+      return;
+    }
+    process.env[name] = value;
+  }
+
   afterEach(() => {
     clearRegisteredPiProviders();
+    restoreEnvVar(
+      "LETTA_DISABLE_OPENROUTER_ATTRIBUTION",
+      originalDisableOpenRouterAttribution,
+    );
+    restoreEnvVar("DO_NOT_TRACK", originalDoNotTrack);
+  });
+
+  test("OpenRouter catalog sends attribution headers by default", () => {
+    delete process.env.LETTA_DISABLE_OPENROUTER_ATTRIBUTION;
+    delete process.env.DO_NOT_TRACK;
+
+    expect(getPiProviderSpec("openrouter").headers?.()).toEqual({
+      "HTTP-Referer": "https://letta.com",
+      "X-OpenRouter-Categories": "cli-agent,personal-agent",
+      "X-OpenRouter-Title": "Letta Code",
+    });
+  });
+
+  test("OpenRouter catalog omits attribution headers for explicit opt-out", () => {
+    process.env.LETTA_DISABLE_OPENROUTER_ATTRIBUTION = "1";
+    delete process.env.DO_NOT_TRACK;
+
+    expect(getPiProviderSpec("openrouter").headers?.()).toBeUndefined();
+  });
+
+  test("OpenRouter catalog omits attribution headers for DO_NOT_TRACK", () => {
+    delete process.env.LETTA_DISABLE_OPENROUTER_ATTRIBUTION;
+    process.env.DO_NOT_TRACK = "1";
+
+    expect(getPiProviderSpec("openrouter").headers?.()).toBeUndefined();
   });
 
   test("Constellation /connect configs exclude local-only providers", () => {


### PR DESCRIPTION
## Summary

Follow-up to #3123. The merged PR added OpenRouter app attribution headers (`HTTP-Referer`, `X-OpenRouter-Title`, `X-OpenRouter-Categories`) to all local OpenRouter API calls. Those headers make Letta Code usage visible on OpenRouter public rankings — which is great for visibility but not something every user wants.

This PR adds attribution opt-outs that skip the headers entirely. When an opt-out is set, the `headers()` function returns `undefined` instead of the attribution object, so no attribution headers are sent on OpenRouter requests.

## Why

Some users — especially enterprise or privacy-sensitive orgs — may not want their API usage attributed publicly on OpenRouter rankings. The original PR had no opt-out mechanism; the headers were hardcoded with no way to disable them.

## Behavior

- **Default (no env var):** Headers sent as before — `HTTP-Referer: https://letta.com`, `X-OpenRouter-Title: Letta Code`, `X-OpenRouter-Categories: cli-agent,personal-agent`.
- **`LETTA_DISABLE_OPENROUTER_ATTRIBUTION=1`:** No attribution headers sent. Usage does not appear on OpenRouter rankings.
- **`DO_NOT_TRACK=1`:** No attribution headers sent. This lets environments that already use the standard do-not-track opt-out suppress OpenRouter attribution too.

The Letta-specific env var follows the existing `LETTA_DISABLE_*` pattern used by `LETTA_DISABLE_MODS`, `LETTA_DISABLE_KITTY`, `LETTA_DISABLE_CRON_SCHEDULER`, etc. `DO_NOT_TRACK` is also honored as a broader privacy preference.

## Validation

- `bun test src/providers/local-pi-provider-catalog.test.ts`
- `bunx --bun @biomejs/biome@2.2.5 check src/backend/dev/pi-provider-registry.ts src/providers/local-pi-provider-catalog.test.ts`
- Pre-commit hook ran `tsc --noEmit`

Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

Co-Authored-By: Letta Code <noreply@letta.com>
