### PR TITLE
fix(slack): avoid threading DM replies

### DIFF
--- a/src/channels/message-channel.test.ts
+++ b/src/channels/message-channel.test.ts
@@ -235,6 +235,72 @@ describe("MessageChannel", () => {
     });
   });
 
+  test("does not treat Slack direct message ids as thread ids", async () => {
+    const registry = new ChannelRegistry();
+
+    const sendMessage = mock(async () => ({ messageId: "slack-dm-msg-2" }));
+
+    const adapter: ChannelAdapter = {
+      id: "slack:account-1",
+      channelId: "slack",
+      accountId: "account-1",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage,
+      sendDirectReply: async () => {},
+    };
+
+    registry.registerAdapter(adapter);
+
+    setRouteInMemory("slack", {
+      accountId: "account-1",
+      chatId: "D123",
+      chatType: "direct",
+      threadId: null,
+      agentId: "agent-1",
+      conversationId: "conv-dm",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const result = await message_channel({
+      action: "send",
+      channel: "slack",
+      chat_id: "D123",
+      message: "hello from DM",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "conv-dm",
+      },
+      channelTurnSources: [
+        {
+          channel: "slack",
+          accountId: "account-1",
+          chatId: "D123",
+          chatType: "direct",
+          messageId: "1712790000.000060",
+          threadId: null,
+          agentId: "agent-1",
+          conversationId: "conv-dm",
+        },
+      ],
+    });
+
+    expect(result).toContain("Message sent to slack");
+    expect(sendMessage).toHaveBeenCalledWith({
+      channel: "slack",
+      accountId: "account-1",
+      chatId: "D123",
+      text: "hello from DM",
+      replyToMessageId: undefined,
+      threadId: null,
+      parseMode: undefined,
+    });
+  });
+
   test("passes Slack reactions through MessageChannel with the routed account", async () => {
     const registry = new ChannelRegistry();
 

--- a/src/tools/impl/message-channel.ts
+++ b/src/tools/impl/message-channel.ts
@@ -1041,9 +1041,11 @@ function inferThreadIdFromChannelTurnSources(params: {
       continue;
     }
 
+    const shouldInferSlackThreadFromMessage =
+      params.input.channel === "slack" && source.chatType === "channel";
     threadIds.add(
       source.threadId ??
-        (params.input.channel === "slack" ? source.messageId : null) ??
+        (shouldInferSlackThreadFromMessage ? source.messageId : null) ??
         null,
     );
   }

--- a/src/tools/impl/message-channel.ts
+++ b/src/tools/impl/message-channel.ts
@@ -1023,6 +1023,9 @@ function inferThreadIdFromChannelTurnSources(params: {
   accountId?: string;
   channelTurnSources?: ChannelTurnSource[];
 }): string | null | undefined {
+  // Only infer a thread for routed replies where the caller did not pass an
+  // explicit threadId. If multiple active channel sources disagree below, we
+  // return undefined and let the route/action defaults decide instead.
   if (!params.input.chatId || params.input.threadId !== null) {
     return undefined;
   }
@@ -1041,6 +1044,16 @@ function inferThreadIdFromChannelTurnSources(params: {
       continue;
     }
 
+    // Slack channel routes can be scoped at the channel root while the active
+    // turn originated from a thread. In that case Slack uses the triggering
+    // message ts as the thread_ts for top-level messages, so falling back to
+    // messageId keeps channel replies in the user's active thread.
+    //
+    // Slack DMs also have message IDs, but using a DM message ts as thread_ts
+    // creates the bad behavior this helper is avoiding: replies appear inside a
+    // DM thread instead of the DM surface. Keep the messageId fallback limited
+    // to Slack channel turns; direct chats should stay unthreaded unless the
+    // caller explicitly passes a threadId/reply target.
     const shouldInferSlackThreadFromMessage =
       params.input.channel === "slack" && source.chatType === "channel";
     threadIds.add(


### PR DESCRIPTION
## Summary
- Keep Slack MessageChannel thread inference limited to channel turns so DM replies do not inherit the inbound message timestamp as `thread_ts`
- Add a regression test for Slack direct-message replies staying unthreaded

## Tests
- `bun test src/channels/message-channel.test.ts src/tools/impl/message-channel.test.ts`
- `bunx --bun @biomejs/biome@2.2.5 check src/tools/impl/message-channel.ts src/channels/message-channel.test.ts`

## Notes
- Reported from Discord: Slack agents were replying to DMs inside Slack threads after #2838 introduced channel thread inference.