### PR TITLE
feat(tools): support exec_command descriptions

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -2436,6 +2436,8 @@ export function App({
 
         if (t === "exec_command") {
           command = typeof args.cmd === "string" ? args.cmd : "(no command)";
+          description =
+            typeof args.description === "string" ? args.description : "";
         } else if (t === "write_stdin") {
           const sessionId =
             typeof args.session_id === "string" ||

--- a/src/cli/components/ApprovalPreview.tsx
+++ b/src/cli/components/ApprovalPreview.tsx
@@ -116,6 +116,8 @@ export const ApprovalPreview = memo(
         let description = "";
         if (toolName === "exec_command") {
           command = typeof args.cmd === "string" ? args.cmd : "";
+          description =
+            typeof args.description === "string" ? args.description : "";
         } else if (toolName === "write_stdin") {
           const sessionId =
             typeof args.session_id === "string" ||

--- a/src/cli/components/ApprovalSwitch.tsx
+++ b/src/cli/components/ApprovalSwitch.tsx
@@ -91,6 +91,8 @@ function getBashInfo(approval: ApprovalRequest): BashInfo | null {
 
     if (t === "exec_command") {
       command = typeof args.cmd === "string" ? args.cmd : "(no command)";
+      description =
+        typeof args.description === "string" ? args.description : "";
     } else if (t === "write_stdin") {
       const sessionId =
         typeof args.session_id === "string" ||

--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -232,6 +232,7 @@ export const ToolCallMessage = memo(
       let args: ReactNode = null;
       let shellCommand: string | null = null;
       let shellSemanticKind: "read" | "list" | "search" | "run" | null = null;
+      let hasShellDescription = false;
       if (!isQuestionTool(rawName)) {
         const parseArgs = (): {
           formatted: ReturnType<typeof formatArgsDisplay> | null;
@@ -277,7 +278,13 @@ export const ToolCallMessage = memo(
           if (formattedArgs.shellSemantic) {
             shellSemanticKind = formattedArgs.shellSemantic.kind;
             displayName = formattedArgs.shellSemantic.label;
-            if (formattedArgs.shellSemantic.kind === "run") {
+            hasShellDescription =
+              typeof formattedArgs.parsed.description === "string" &&
+              formattedArgs.parsed.description.trim().length > 0;
+            if (
+              formattedArgs.shellSemantic.kind === "run" &&
+              !hasShellDescription
+            ) {
               shellCommand = formattedArgs.shellSemantic.rawCommand;
             }
           } else if (formattedArgs.displayName) {
@@ -301,6 +308,7 @@ export const ToolCallMessage = memo(
         !shellCommand &&
         isShellTool(rawName) &&
         argsText.trim() &&
+        !hasShellDescription &&
         (shellSemanticKind === null || shellSemanticKind === "run")
       ) {
         try {

--- a/src/cli/format-args-display.test.ts
+++ b/src/cli/format-args-display.test.ts
@@ -80,6 +80,36 @@ describe("formatArgsDisplay compact plan/todo headers", () => {
     });
   });
 
+  test("uses Codex unified exec description when present", () => {
+    const args = JSON.stringify({
+      cmd: "git status --short",
+      description: "Show working tree status",
+    });
+
+    const formatted = formatArgsDisplay(args, "exec_command");
+    expect(formatted.display).toBe("Show working tree status");
+    expect(formatted.shellSemantic).toMatchObject({
+      kind: "run",
+      label: "Run",
+      rawCommand: "git status --short",
+    });
+  });
+
+  test("uses Gemini shell description when present", () => {
+    const args = JSON.stringify({
+      command: "git status --short",
+      description: "Show working tree status",
+    });
+
+    const formatted = formatArgsDisplay(args, "RunShellCommand");
+    expect(formatted.display).toBe("Show working tree status");
+    expect(formatted.shellSemantic).toMatchObject({
+      kind: "run",
+      label: "Run",
+      rawCommand: "git status --short",
+    });
+  });
+
   test("summarizes Codex write_stdin without raw polling args", () => {
     const args = JSON.stringify({
       session_id: 8,

--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -339,6 +339,10 @@ function extractExecCommandDisplay(
   argsText: string | undefined,
 ): string | null {
   const parsed = parseToolArgsText(argsText);
+  const description = parsed?.description;
+  if (typeof description === "string" && description.trim()) {
+    return description.trim();
+  }
   const cmd = parsed?.cmd;
   return typeof cmd === "string" && cmd.trim() ? cmd : null;
 }

--- a/src/cli/helpers/format-args-display.ts
+++ b/src/cli/helpers/format-args-display.ts
@@ -399,6 +399,10 @@ export function formatArgsDisplay(
           // Shell/Bash tools: show just the command
           if (isShellTool(toolName) && (parsed.command || parsed.cmd)) {
             const commandValue = parsed.cmd ?? parsed.command;
+            const description =
+              typeof parsed.description === "string"
+                ? parsed.description.trim()
+                : "";
             shellSemantic = summarizeShellDisplay(
               Array.isArray(commandValue)
                 ? commandValue.filter(
@@ -406,7 +410,7 @@ export function formatArgsDisplay(
                   )
                 : String(commandValue),
             );
-            display = shellSemantic.summary;
+            display = description || shellSemantic.summary;
             return { display, parsed, shellSemantic };
           }
         }

--- a/src/cli/helpers/unified-exec-accumulator.test.ts
+++ b/src/cli/helpers/unified-exec-accumulator.test.ts
@@ -44,4 +44,51 @@ describe("unified exec accumulator metadata", () => {
       unifiedExecCommandDisplay: "python3 repl.py",
     });
   });
+
+  test("prefers exec command description for write_stdin display", () => {
+    const buffers = createBuffers();
+
+    onChunk(buffers, {
+      message_type: "approval_request_message",
+      tool_call: {
+        tool_call_id: "exec-call",
+        name: "exec_command",
+        arguments: JSON.stringify({
+          cmd: "python3 repl.py",
+          description: "Run Python REPL",
+          tty: true,
+        }),
+      },
+    } as never);
+
+    onChunk(buffers, {
+      message_type: "tool_return_message",
+      tool_call_id: "exec-call",
+      status: "success",
+      tool_return: [
+        "Chunk ID: abc123",
+        "Wall time: 0.1000 seconds",
+        "Process running with session ID 8",
+        "Original token count: 1",
+        "Output:",
+        "ready",
+      ].join("\n"),
+    } as never);
+
+    onChunk(buffers, {
+      message_type: "approval_request_message",
+      tool_call: {
+        tool_call_id: "stdin-call",
+        name: "write_stdin",
+        arguments: JSON.stringify({ session_id: 8, chars: "2 + 2\n" }),
+      },
+    } as never);
+
+    const line = buffers.byId.get("stdin-call");
+    expect(line).toMatchObject({
+      kind: "tool_call",
+      name: "write_stdin",
+      unifiedExecCommandDisplay: "Run Python REPL",
+    });
+  });
 });

--- a/src/tools/codex-unified-exec-toolset.test.ts
+++ b/src/tools/codex-unified-exec-toolset.test.ts
@@ -40,7 +40,7 @@ describe("Codex unified exec toolset", () => {
       "",
       "For ordinary one-shot commands, omit `yield_time_ms` and let the default wait for completion; set `yield_time_ms` only when intentionally returning early from a long-running or interactive command.",
       "",
-      "Use the optional `description` field for a clear, concise user-facing description of what the command does. Describe the purpose, not the shell syntax. This may be shown directly in chat as part of a status row like `Running command: <description>` or `Ran command: <description>`. For simple commands, keep it brief (5-10 words). For commands that are harder to parse at a glance, add enough context to clarify what it does.",
+      "Use the optional `description` field for a clear, concise user-facing status label for what the command does. It may be shown directly in chat with no prefix, so make it grammatical by itself and avoid tense-dependent wording. Use an imperative or purpose phrase like `Find debug log entries` or `Search recent logs for errors`. Describe the command's purpose, not its shell syntax. Keep it brief for simple commands; add only enough context to clarify commands that are hard to parse at a glance.",
       "",
       extractCommitGuidance(ShellDescription),
     ].join("\n");

--- a/src/tools/codex-unified-exec-toolset.test.ts
+++ b/src/tools/codex-unified-exec-toolset.test.ts
@@ -27,6 +27,7 @@ describe("Codex unified exec toolset", () => {
   test("documents LC-specific omission of upstream sandbox fields", () => {
     const properties = Object.keys(ExecCommandSchema.properties);
 
+    expect(properties).toContain("description");
     expect(properties).not.toContain("sandbox_permissions");
     expect(properties).not.toContain("justification");
     expect(properties).not.toContain("prefix_rule");
@@ -38,6 +39,8 @@ describe("Codex unified exec toolset", () => {
       "Runs a command in a PTY, returning output or a session ID for ongoing interaction.",
       "",
       "For ordinary one-shot commands, omit `yield_time_ms` and let the default wait for completion; set `yield_time_ms` only when intentionally returning early from a long-running or interactive command.",
+      "",
+      "Use the optional `description` field for a clear, concise user-facing description of what the command does. Describe the purpose, not the shell syntax. This may be shown directly in chat as part of a status row like `Running command: <description>` or `Ran command: <description>`. For simple commands, keep it brief (5-10 words). For commands that are harder to parse at a glance, add enough context to clarify what it does.",
       "",
       extractCommitGuidance(ShellDescription),
     ].join("\n");

--- a/src/tools/descriptions/ExecCommand.md
+++ b/src/tools/descriptions/ExecCommand.md
@@ -2,7 +2,7 @@ Runs a command in a PTY, returning output or a session ID for ongoing interactio
 
 For ordinary one-shot commands, omit `yield_time_ms` and let the default wait for completion; set `yield_time_ms` only when intentionally returning early from a long-running or interactive command.
 
-Use the optional `description` field for a clear, concise user-facing description of what the command does. Describe the purpose, not the shell syntax. This may be shown directly in chat as part of a status row like `Running command: <description>` or `Ran command: <description>`. For simple commands, keep it brief (5-10 words). For commands that are harder to parse at a glance, add enough context to clarify what it does.
+Use the optional `description` field for a clear, concise user-facing status label for what the command does. It may be shown directly in chat with no prefix, so make it grammatical by itself and avoid tense-dependent wording. Use an imperative or purpose phrase like `Find debug log entries` or `Search recent logs for errors`. Describe the command's purpose, not its shell syntax. Keep it brief for simple commands; add only enough context to clarify commands that are hard to parse at a glance.
 
 # Committing changes with git
 

--- a/src/tools/descriptions/ExecCommand.md
+++ b/src/tools/descriptions/ExecCommand.md
@@ -2,6 +2,8 @@ Runs a command in a PTY, returning output or a session ID for ongoing interactio
 
 For ordinary one-shot commands, omit `yield_time_ms` and let the default wait for completion; set `yield_time_ms` only when intentionally returning early from a long-running or interactive command.
 
+Use the optional `description` field for a clear, concise user-facing description of what the command does. Describe the purpose, not the shell syntax. This may be shown directly in chat as part of a status row like `Running command: <description>` or `Ran command: <description>`. For simple commands, keep it brief (5-10 words). For commands that are harder to parse at a glance, add enough context to clarify what it does.
+
 # Committing changes with git
 
 Only create commits when requested by the user. If unclear, ask first. When the user asks you to create a new git commit, follow these steps carefully:

--- a/src/tools/impl/exec-command.ts
+++ b/src/tools/impl/exec-command.ts
@@ -34,6 +34,7 @@ const EXEC_SESSION_CLEANUP_MS = 5 * 60 * 1000;
 
 interface ExecCommandArgs {
   cmd: string;
+  description?: string;
   workdir?: string;
   shell?: string;
   tty?: boolean;

--- a/src/tools/schemas/ExecCommand.json
+++ b/src/tools/schemas/ExecCommand.json
@@ -6,6 +6,10 @@
       "type": "string",
       "description": "Shell command to execute."
     },
+    "description": {
+      "type": "string",
+      "description": "Clear, concise user-facing description of what this command does in active voice. This may be shown directly in chat as part of a status row like `Running command: <description>` or `Ran command: <description>`. Describe the command's purpose, not its shell syntax. For simple commands, keep it brief (5-10 words). For commands that are harder to parse at a glance, add enough context to clarify what it does."
+    },
     "login": {
       "type": "boolean",
       "description": "True runs the shell with -l/-i semantics; false disables them. Defaults to true."

--- a/src/tools/schemas/ExecCommand.json
+++ b/src/tools/schemas/ExecCommand.json
@@ -8,7 +8,7 @@
     },
     "description": {
       "type": "string",
-      "description": "Clear, concise user-facing description of what this command does in active voice. This may be shown directly in chat as part of a status row like `Running command: <description>` or `Ran command: <description>`. Describe the command's purpose, not its shell syntax. For simple commands, keep it brief (5-10 words). For commands that are harder to parse at a glance, add enough context to clarify what it does."
+      "description": "Clear, concise user-facing status label for what this command does. It may be shown directly in chat with no prefix, so make it grammatical by itself and avoid tense-dependent wording. Use an imperative or purpose phrase like `Find debug log entries` or `Search recent logs for errors`. Describe the command's purpose, not its shell syntax. Keep it brief for simple commands; add only enough context to clarify commands that are hard to parse at a glance."
     },
     "login": {
       "type": "boolean",


### PR DESCRIPTION
## Summary

- Add an optional `description` field to Codex `exec_command`, matching the existing optional Bash and Gemini shell description shape.
- Prefer shell descriptions in tool row display while preserving raw commands in approval previews for transparency.
- Carry exec command descriptions into later `write_stdin` rows so background-terminal follow-ups stay readable.

## Test plan

- `bun test src/tools/codex-unified-exec-toolset.test.ts src/cli/format-args-display.test.ts src/cli/helpers/unified-exec-accumulator.test.ts`
- `bun run typecheck`
- `bun run check`

?? Generated with [Letta Code](https://letta.com)
