### PR TITLE
fix(skills): load canonical project skills in Skill tool

### DIFF
--- a/src/agent/client-skills.ts
+++ b/src/agent/client-skills.ts
@@ -10,6 +10,7 @@ import {
   getAgentSkillsDir,
   isModelInvocableSkill,
   isSkillAvailableForAgent,
+  PROJECT_SKILLS_DIR,
   SKILLS_DIR,
   type Skill,
   type SkillDiscoveryError,
@@ -340,7 +341,7 @@ function resolveSkillDiscoveryContext(
 }
 
 function getPrimaryProjectSkillsDirectory(): string {
-  return join(process.cwd(), ".agents", "skills");
+  return join(process.cwd(), PROJECT_SKILLS_DIR);
 }
 
 export interface DiscoverClientSideSkillsOptions {

--- a/src/agent/skills.ts
+++ b/src/agent/skills.ts
@@ -2,7 +2,7 @@
  * Skills module - provides skill discovery and management functionality
  *
  * Skills are discovered from four sources (in order of priority):
- * 1. Project skills: .skills/ in current directory (highest priority - overrides)
+ * 1. Project skills: .agents/skills/ in current directory, with .skills/ as a legacy fallback (highest priority - overrides)
  * 2. Agent skills: ~/.letta/agents/{agent-id}/memory/skills/ for agent-specific skills
  * 3. Global skills: ~/.letta/skills/ for user's personal skills
  * 4. Bundled skills: embedded in package (lowest priority - defaults)
@@ -173,7 +173,12 @@ export function isSkillAvailableForAgent(
 }
 
 /**
- * Default directory name where project skills are stored
+ * Canonical directory where project skills are stored.
+ */
+export const PROJECT_SKILLS_DIR = join(".agents", "skills");
+
+/**
+ * Legacy directory name where project skills were stored.
  */
 export const SKILLS_DIR = ".skills";
 
@@ -247,7 +252,7 @@ async function discoverSkillsFromDir(
  * Later sources override earlier ones with the same ID.
  *
  * Priority order (highest to lowest):
- * 1. Project skills (.skills/ in current directory)
+ * 1. Project skills (the provided project skills path; callers may scan .agents/skills before .skills)
  * 2. Agent skills (~/.letta/agents/{agent-id}/memory/skills/)
  * 3. Global skills (~/.letta/skills/)
  * 4. Bundled skills (embedded in package)

--- a/src/tools/impl/skill.ts
+++ b/src/tools/impl/skill.ts
@@ -10,6 +10,7 @@ import {
   getFrontmatterBoolean,
   getFrontmatterStringList,
   isSkillAvailableForAgent,
+  PROJECT_SKILLS_DIR,
   SKILLS_DIR,
 } from "@/agent/skills";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
@@ -72,7 +73,7 @@ function hasAdditionalFiles(skillMdPath: string): boolean {
  * Returns both content and the path to the SKILL.md file
  *
  * Search order (highest priority first):
- * 1. Project skills (.skills/)
+ * 1. Project skills (.agents/skills/, then legacy .skills/ fallback)
  * 2. Agent memory skills (~/.letta/agents/{id}/memory/skills/)
  * 3. Agent memory skills fallback ($MEMORY_DIR/skills/)
  * 4. Global skills (~/.letta/skills/)
@@ -84,12 +85,18 @@ export async function readSkillContent(
   agentId?: string,
 ): Promise<{ content: string; path: string }> {
   // 1. Try project skills directory (highest priority)
-  const projectSkillPath = join(skillsDir, skillId, "SKILL.md");
-  try {
-    const content = await readFile(projectSkillPath, "utf-8");
-    return { content, path: projectSkillPath };
-  } catch {
-    // Not in project, continue
+  const projectSkillsDirs = new Set<string>([
+    join(getCurrentWorkingDirectory(), PROJECT_SKILLS_DIR),
+    skillsDir,
+  ]);
+  for (const projectSkillsDir of projectSkillsDirs) {
+    const projectSkillPath = join(projectSkillsDir, skillId, "SKILL.md");
+    try {
+      const content = await readFile(projectSkillPath, "utf-8");
+      return { content, path: projectSkillPath };
+    } catch {
+      // Not in this project skills directory, continue
+    }
   }
 
   // 2. Try agent memory skills directory (if agentId provided)

--- a/src/tools/skill-tool.test.ts
+++ b/src/tools/skill-tool.test.ts
@@ -332,6 +332,40 @@ describe("Skill tool memory filesystem lookup", () => {
     );
   });
 
+  test("loads canonical .agents/skills project skills before legacy .skills", async () => {
+    const skillName = "canonical-project-skill";
+    const projectRoot = join(tempRoot, "project-root");
+    const canonicalSkillDir = join(projectRoot, ".agents", "skills", skillName);
+    const legacySkillDir = join(projectRoot, ".skills", skillName);
+
+    currentSkillsDirectory = join(projectRoot, ".skills");
+    mkdirSync(canonicalSkillDir, { recursive: true });
+    mkdirSync(legacySkillDir, { recursive: true });
+    writeFileSync(
+      join(canonicalSkillDir, "SKILL.md"),
+      "---\nname: canonical-project-skill\ndescription: canonical\n---\n\nLoaded from .agents/skills.",
+      "utf8",
+    );
+    writeFileSync(
+      join(legacySkillDir, "SKILL.md"),
+      "---\nname: canonical-project-skill\ndescription: legacy\n---\n\nLoaded from .skills.",
+      "utf8",
+    );
+
+    process.env.USER_CWD = projectRoot;
+
+    const result = await runScopedSkill({
+      skill: skillName,
+      toolCallId: "tc-canonical-project",
+    });
+    expect(result.message).toBe(`Launching skill: ${skillName}`);
+
+    const queued = consumeQueuedSkillContent();
+    expect(queued).toHaveLength(1);
+    expect(queued[0]?.content).toContain("Loaded from .agents/skills.");
+    expect(queued[0]?.content).not.toContain("Loaded from .skills.");
+  });
+
   test("renders skill arguments and skill directory substitutions", () => {
     const rendered = renderSkillContent(
       "deploy",


### PR DESCRIPTION
Aligns the `Skill(...)` tool lookup path with client-side skill discovery: project skills under `.agents/skills` are now loaded first, with `.skills` retained as the legacy fallback.

This fixes the mismatch where `.agents/skills` entries were advertised in `<available_skills>` but explicit `Skill(name)` invocations still searched only the legacy project skills directory before falling through to MemFS/global/bundled sources.

Validated with:
- `bun test src/tools/skill-tool.test.ts src/agent/client-skills.test.ts`
- `bun run check`