### PR TITLE
fix(models): split GLM 5.2 context presets

### DIFF
--- a/src/models.json
+++ b/src/models.json
@@ -1664,7 +1664,7 @@
     },
     {
       "id": "glm-5.2-1m",
-      "handle": "zai/glm-5.2[1m]",
+      "handle": "zai/glm-5.2",
       "label": "GLM-5.2 1M",
       "description": "zAI's latest reasoning and coding model with 1M context",
       "isFeatured": false,

--- a/src/models.json
+++ b/src/models.json
@@ -1653,8 +1653,21 @@
       "id": "glm-5.2",
       "handle": "zai/glm-5.2",
       "label": "GLM-5.2",
-      "description": "zAI's latest reasoning and coding model with 1M context",
+      "description": "zAI's latest reasoning and coding model with 200K context",
       "isFeatured": true,
+      "free": true,
+      "updateArgs": {
+        "context_window": 200000,
+        "max_output_tokens": 131072,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "glm-5.2-1m",
+      "handle": "zai/glm-5.2[1m]",
+      "label": "GLM-5.2 1M",
+      "description": "zAI's latest reasoning and coding model with 1M context",
+      "isFeatured": false,
       "free": true,
       "updateArgs": {
         "context_window": 1000000,


### PR DESCRIPTION
Makes the default `zai/glm-5.2` preset use the observed 200K-class limit and adds an explicit `zai/glm-5.2[1m]` preset for opt-in long context. This avoids suppressing compaction for the default direct GLM path while keeping the 1M variant available.

Validated with:
- `bun run check`