### PR TITLE
docs: add AI contribution policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,94 @@
+name: Bug Report
+description: Create a report to help us improve
+labels: ["bug"]
+body:
+  - type: checkboxes
+    id: ai-disclosure
+    attributes:
+      label: AI Disclosure
+      description: |
+        We require all issue authors to disclose AI usage per our [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md).
+        Check **all** that apply.
+      options:
+        - label: This issue was written entirely by a human
+        - label: This issue was written with AI assistance (e.g. Copilot, ChatGPT, Claude) and **reviewed and edited by a human**
+        - label: I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms
+          required: true
+    validations:
+      required: true
+
+  - type: textarea
+    id: human-verification
+    attributes:
+      label: Human Verification
+      description: |
+        To help us combat spam, please copy and paste the following phrase **exactly** into the box below:
+        `I have read the AI policy and I confirm this issue was reviewed by a human.`
+      placeholder: "I have read the AI policy and I confirm this issue was reviewed by a human."
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+      placeholder: What happened? What did you expect to happen?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: mode
+    attributes:
+      label: How are you running Letta Code?
+      options:
+        - npm package / global install
+        - From source
+        - Desktop
+        - GitHub Action
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      placeholder: e.g. macOS 15.4, Ubuntu 24.04, Windows 11
+
+  - type: input
+    id: version
+    attributes:
+      label: Letta Code Version
+      description: Run `letta --version` or check your package version.
+      placeholder: e.g. 0.27.11
+
+  - type: input
+    id: model
+    attributes:
+      label: Model
+      description: Which LLM model are you using?
+      placeholder: e.g. gpt-5, claude-sonnet-4-5-20250929
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Start Letta Code with ...
+        2. Run ...
+        3. See error ...
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs / Screenshots
+      description: Paste any relevant log output, error messages, or screenshots.
+      render: shell
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord
+    url: https://discord.gg/9GEQrxmVyE
+    about: Chat with the Letta community and get help.
+  - name: Documentation
+    url: https://docs.letta.com
+    about: Check the docs before filing an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature Request
+description: Suggest an idea for this project
+labels: ["enhancement"]
+body:
+  - type: checkboxes
+    id: ai-disclosure
+    attributes:
+      label: AI Disclosure
+      description: |
+        We require all issue authors to disclose AI usage per our [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md).
+        Check **all** that apply.
+      options:
+        - label: This issue was written entirely by a human
+        - label: This issue was written with AI assistance (e.g. Copilot, ChatGPT, Claude) and **reviewed and edited by a human**
+        - label: I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms
+          required: true
+    validations:
+      required: true
+
+  - type: textarea
+    id: human-verification
+    attributes:
+      label: Human Verification
+      description: |
+        To help us combat spam, please copy and paste the following phrase **exactly** into the box below:
+        `I have read the AI policy and I confirm this issue was reviewed by a human.`
+      placeholder: "I have read the AI policy and I confirm this issue was reviewed by a human."
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: Is your feature request related to a problem? Describe it clearly.
+      placeholder: I'm always frustrated when [...]
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or features you've considered.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context or screenshots about the feature request.

--- a/.github/TRUSTED_CONTRIBUTORS
+++ b/.github/TRUSTED_CONTRIBUTORS
@@ -1,0 +1,13 @@
+# Trusted Contributors
+#
+# Users listed here bypass issue validation checks (AI disclosure,
+# human verification phrase). One GitHub username per line.
+#
+# Note: Members of the letta-ai GitHub organization are automatically
+# trusted and do not need to be listed here. This file is for
+# non-org contributors who have earned trust.
+#
+# To add someone, open a PR adding their username to this list.
+
+# Letta community contributors
+ezra-letta

--- a/.github/workflows/issue-guard.yml
+++ b/.github/workflows/issue-guard.yml
@@ -5,6 +5,7 @@ on:
     types: [opened]
 
 permissions:
+  contents: read
   issues: write
 
 jobs:

--- a/.github/workflows/issue-guard.yml
+++ b/.github/workflows/issue-guard.yml
@@ -1,0 +1,168 @@
+name: "Issue Guard"
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/TRUSTED_CONTRIBUTORS
+
+      - name: Check issue compliance
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const author = issue.user.login;
+            const body = issue.body || '';
+
+            // --- Allowlist checks ---
+
+            // 1. Bots are allowed (e.g. dependabot, renovate)
+            if (issue.user.type === 'Bot') {
+              console.log(`Skipping: ${author} is a bot`);
+              return;
+            }
+
+            // 2. Check if author has write+ access to the repo.
+            //    This catches org members who have repo access via teams,
+            //    and works with the default GITHUB_TOKEN (no extra scopes).
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: author,
+              });
+              if (['admin', 'write', 'maintain'].includes(data.permission)) {
+                console.log(`Skipping: ${author} has '${data.permission}' permission on repo`);
+                return;
+              }
+            } catch (e) {
+              console.log(`Collaborator check failed (${e.status}), continuing`);
+            }
+
+            // 3. Check org membership via public membership API (no auth needed).
+            //    Catches org members even if they don't have direct repo access.
+            try {
+              await github.rest.orgs.checkPublicMembershipForUser({
+                org: 'letta-ai',
+                username: author,
+              });
+              console.log(`Skipping: ${author} is a public letta-ai org member`);
+              return;
+            } catch (e) {
+              // 404 = not a public member
+            }
+
+            // 4. Check TRUSTED_CONTRIBUTORS file
+            const fs = require('fs');
+            try {
+              const trusted = fs.readFileSync('.github/TRUSTED_CONTRIBUTORS', 'utf8')
+                .split('\n')
+                .map(line => line.trim())
+                .filter(line => line && !line.startsWith('#'));
+              if (trusted.includes(author)) {
+                console.log(`Skipping: ${author} is in TRUSTED_CONTRIBUTORS`);
+                return;
+              }
+            } catch (e) {
+              console.log('No TRUSTED_CONTRIBUTORS file found, continuing');
+            }
+
+            // --- Validation checks ---
+
+            const failures = [];
+
+            // Check 1: Magic phrase
+            const magicPhrase = 'I have read the AI policy and I confirm this issue was reviewed by a human.';
+            if (!body.includes(magicPhrase)) {
+              failures.push('Missing human verification phrase');
+            }
+
+            // Check 2: AI disclosure checkbox (the required one: "I have read the AI Policy")
+            // YAML form checkboxes render as "- [x] text" when checked.
+            const aiPolicyChecked = /- \[[xX]\] I have read the \[AI Policy\]/.test(body);
+            if (!aiPolicyChecked) {
+              failures.push('AI Policy acknowledgment checkbox not checked');
+            }
+
+            // Check 3: At least one of the two disclosure options is checked
+            const humanWritten = /- \[[xX]\] This issue was written entirely by a human/.test(body);
+            const aiAssisted = /- \[[xX]\] This issue was written with AI assistance/.test(body);
+            if (!humanWritten && !aiAssisted) {
+              failures.push('No AI disclosure option selected (must indicate whether issue is human-written or AI-assisted)');
+            }
+
+            if (failures.length === 0) {
+              console.log(`Issue #${issue.number} passed all checks`);
+              return;
+            }
+
+            // --- Close and lock ---
+
+            console.log(`Issue #${issue.number} failed checks: ${failures.join(', ')}`);
+
+            const comment = [
+              `**This issue was automatically closed** because it does not meet our submission requirements.\n`,
+              `**What failed:**`,
+              ...failures.map(f => `- ${f}`),
+              ``,
+              `**To submit an issue, please:**`,
+              `1. Use one of the [issue templates](https://github.com/${context.repo.owner}/${context.repo.repo}/issues/new/choose)`,
+              `2. Fill out the **AI Disclosure** checkboxes`,
+              `3. Copy the **Human Verification** phrase exactly as shown`,
+              `4. Read our [AI Policy](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/AI_POLICY.md)`,
+              ``,
+              `If you believe this was a mistake, please reach out on [Discord](https://discord.gg/9GEQrxmVyE).`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: comment,
+            });
+
+            // Best-effort labeling: prefer "spam", then fall back to labels
+            // that commonly exist on repos.
+            let labelApplied = false;
+            for (const label of ['spam', 'auto-closed', 'invalid']) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  labels: [label],
+                });
+                labelApplied = true;
+                break;
+              } catch (e) {
+                console.log(`Label '${label}' unavailable or failed to apply, trying next`);
+              }
+            }
+            if (!labelApplied) {
+              console.log('No close label could be applied; continuing with close/lock');
+            }
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              state: 'closed',
+            });
+
+            await github.rest.issues.lock({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              lock_reason: 'spam',
+            });
+
+            console.log(`Issue #${issue.number} closed and locked`);

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,63 @@
+# AI Usage Policy
+
+> This policy is adapted from [Ghostty's AI Policy](https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md) with modifications for the Letta Code project.
+
+## Rules
+
+- **All AI usage in any form must be disclosed.** You must state
+  the tool you used (e.g. Claude Code, Cursor, Copilot, ChatGPT) along with
+  the extent that the work was AI-assisted.
+
+- **The human-in-the-loop must fully understand all code.** If you
+  can't explain what your changes do and how they interact with the
+  greater system without the aid of AI tools, do not contribute
+  to this project.
+
+- **Issues and discussions can use AI assistance but must have a full
+  human-in-the-loop.** This means that any content generated with AI
+  must have been reviewed _and edited_ by a human before submission.
+  AI is very good at being overly verbose and including noise that
+  distracts from the main point. Humans must do their research and
+  trim this down.
+
+- **No AI-generated media is allowed (art, images, videos, audio, etc.).**
+  Text and code are the only acceptable AI-generated content, per the
+  other rules in this policy.
+
+## Enforcement
+
+Issues that do not comply with this policy will be **automatically closed and locked**.
+Specifically, all issues must:
+
+1. Fill out the **AI Disclosure** checkboxes indicating whether the issue was human-written or AI-assisted.
+2. Include the **Human Verification** phrase as instructed in the issue template.
+3. Acknowledge that they have read this policy.
+
+Members of the [letta-ai](https://github.com/letta-ai) GitHub organization and
+[trusted contributors](.github/TRUSTED_CONTRIBUTORS) are exempt from automated checks,
+but are still expected to follow the spirit of this policy.
+
+## There are Humans Here
+
+Please remember that Letta Code is maintained by humans.
+
+Every discussion, issue, and pull request is read and reviewed by
+humans. It is a boundary point at which people interact with each other
+and the work done. It is rude and disrespectful to approach this boundary
+with low-effort, unqualified work, since it puts the burden of
+validation on the maintainer.
+
+## AI is Welcome Here
+
+Letta is a company that builds AI tools — of course we use AI!
+Many of our maintainers use AI tools extensively in their daily workflow.
+As a project, we welcome AI as a tool.
+
+**Our reason for the strict AI policy is not due to an anti-AI stance**, but
+instead due to the volume of low-quality, AI-generated issues and PRs
+that waste maintainer time. It's the quality of the contribution that
+matters, not whether AI was involved in creating it.
+
+Maintainers are exempt from automated enforcement of these rules and
+may use AI tools at their discretion; they've proven themselves
+trustworthy to apply good judgment.


### PR DESCRIPTION
## Summary

- Add `AI_POLICY.md` adapted from the Letta policy for Letta Code.
- Add bug report and feature request issue forms with AI disclosure and human verification fields.
- Add the issue guard workflow and trusted contributors allowlist to close non-compliant issues automatically.

## Validation

- `bun run check`
- YAML parsed with Ruby `YAML.load_file`

👾 Generated with [Letta Code](https://letta.com)