### PR TITLE
fix(auth): handle reused OAuth device codes

### DIFF
--- a/src/auth/ConstellationLoginView.tsx
+++ b/src/auth/ConstellationLoginView.tsx
@@ -4,7 +4,12 @@ import { useEffect, useRef, useState } from "react";
 import { configureBackendMode } from "@/backend";
 import { Text } from "@/cli/components/Text";
 import { settingsManager } from "@/settings-manager";
-import { pollForToken, requestDeviceCode } from "./oauth";
+import {
+  LETTA_CLOUD_API_URL,
+  pollForToken,
+  requestDeviceCode,
+  validateCredentialsWithResult,
+} from "./oauth";
 
 interface ConstellationLoginViewProps {
   onComplete?: () => void;
@@ -44,9 +49,33 @@ export function ConstellationLoginView({
     const run = async () => {
       try {
         if (process.env.LETTA_API_KEY) {
-          setError(
-            "LETTA_API_KEY is set in your environment, so OAuth login cannot replace the credential Letta Code is using. Unset LETTA_API_KEY and try again.",
+          const baseURL = process.env.LETTA_BASE_URL || LETTA_CLOUD_API_URL;
+          const validation = await validateCredentialsWithResult(
+            baseURL,
+            process.env.LETTA_API_KEY,
           );
+
+          if (!validation.ok) {
+            setError(
+              `LETTA_API_KEY is set in your environment but is not valid: ${validation.message}`,
+            );
+            return;
+          }
+
+          settingsManager.updateSettings({
+            env: {
+              LETTA_API_KEY: process.env.LETTA_API_KEY,
+              ...(process.env.LETTA_BASE_URL && {
+                LETTA_BASE_URL: process.env.LETTA_BASE_URL,
+              }),
+            },
+            preferredBackendMode: "api",
+          });
+          await settingsManager.flush();
+          configureBackendMode("api");
+
+          setDoneMessage(successMessage);
+          setTimeout(() => onCompleteRef.current?.(), 500);
           return;
         }
 

--- a/src/auth/ConstellationLoginView.tsx
+++ b/src/auth/ConstellationLoginView.tsx
@@ -4,12 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { configureBackendMode } from "@/backend";
 import { Text } from "@/cli/components/Text";
 import { settingsManager } from "@/settings-manager";
-import {
-  LETTA_CLOUD_API_URL,
-  pollForToken,
-  requestDeviceCode,
-  validateCredentialsWithResult,
-} from "./oauth";
+import { pollForToken, requestDeviceCode } from "./oauth";
 
 interface ConstellationLoginViewProps {
   onComplete?: () => void;
@@ -49,33 +44,9 @@ export function ConstellationLoginView({
     const run = async () => {
       try {
         if (process.env.LETTA_API_KEY) {
-          const baseURL = process.env.LETTA_BASE_URL || LETTA_CLOUD_API_URL;
-          const validation = await validateCredentialsWithResult(
-            baseURL,
-            process.env.LETTA_API_KEY,
+          setError(
+            "LETTA_API_KEY is set in your environment, so OAuth login cannot replace the credential Letta Code is using. Unset LETTA_API_KEY and try again.",
           );
-
-          if (!validation.ok) {
-            setError(
-              `LETTA_API_KEY is set in your environment but is not valid: ${validation.message}`,
-            );
-            return;
-          }
-
-          settingsManager.updateSettings({
-            env: {
-              LETTA_API_KEY: process.env.LETTA_API_KEY,
-              ...(process.env.LETTA_BASE_URL && {
-                LETTA_BASE_URL: process.env.LETTA_BASE_URL,
-              }),
-            },
-            preferredBackendMode: "api",
-          });
-          await settingsManager.flush();
-          configureBackendMode("api");
-
-          setDoneMessage(successMessage);
-          setTimeout(() => onCompleteRef.current?.(), 500);
           return;
         }
 

--- a/src/auth/oauth-network-errors.test.ts
+++ b/src/auth/oauth-network-errors.test.ts
@@ -111,6 +111,50 @@ describe("OAuth network errors", () => {
     ).rejects.toThrow("User denied authorization");
   });
 
+  test("pollForToken shares concurrent polls for the same device code", async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            access_token: "access-token",
+            refresh_token: "refresh-token",
+            token_type: "Bearer",
+            expires_in: 3600,
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      ),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const [first, second] = await Promise.all([
+      pollForToken("shared-device-code", 0, 60, "device-id"),
+      pollForToken("shared-device-code", 0, 60, "device-id"),
+    ]);
+
+    expect(first.access_token).toBe("access-token");
+    expect(second.access_token).toBe("access-token");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("pollForToken reports already-used device codes clearly", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: "already_used" }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    ) as unknown as typeof fetch;
+
+    await expect(
+      pollForToken("already-used-device-code", 0, 60, "device-id"),
+    ).rejects.toThrow("Device code was already used before Letta Code");
+  });
+
   test("pollForToken supports cancellation via AbortSignal", async () => {
     const controller = new AbortController();
     globalThis.fetch = mock(() =>

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -38,6 +38,8 @@ export interface OAuthError {
   error_description?: string;
 }
 
+const activeDeviceTokenPolls = new Map<string, Promise<TokenResponse>>();
+
 export type CredentialValidationFailureReason =
   | "invalid_credentials"
   | "network_error"
@@ -190,6 +192,36 @@ export async function pollForToken(
   deviceName?: string,
   signal?: AbortSignal,
 ): Promise<TokenResponse> {
+  const activePoll = activeDeviceTokenPolls.get(deviceCode);
+  if (activePoll) {
+    return activePoll;
+  }
+
+  const poll = pollForTokenOnce(
+    deviceCode,
+    interval,
+    expiresIn,
+    deviceId,
+    deviceName,
+    signal,
+  );
+  activeDeviceTokenPolls.set(deviceCode, poll);
+
+  try {
+    return await poll;
+  } finally {
+    activeDeviceTokenPolls.delete(deviceCode);
+  }
+}
+
+async function pollForTokenOnce(
+  deviceCode: string,
+  interval: number = 5,
+  expiresIn: number = 900,
+  deviceId: string,
+  deviceName?: string,
+  signal?: AbortSignal,
+): Promise<TokenResponse> {
   const startTime = Date.now();
   const expiresInMs = expiresIn * 1000;
   let pollInterval = interval * 1000;
@@ -269,6 +301,12 @@ export async function pollForToken(
 
       if (error.error === "expired_token") {
         throw new Error("Device code expired");
+      }
+
+      if (error.error === "already_used") {
+        throw new Error(
+          "Device code was already used before Letta Code received the token. Please start login again. If this keeps happening, another OAuth poller may be racing this one.",
+        );
       }
 
       throw new Error(`OAuth error: ${error.error_description || error.error}`);


### PR DESCRIPTION
## Summary

Refs #2864.

This narrows the OAuth device-code handling so reused device codes are not surfaced as an unknown failure:

- Deduplicates concurrent token polling for the same `device_code`, preventing local pollers from racing each other.
- Handles the OAuth `already_used` error explicitly with a clearer message.

During local AppImage testing, we also found a separate Linux issue: Electron `safeStorage.encryptString()` can fail when Chromium/Electron does not select an available Secret Service backend. On one Arch/Omarchy setup, launching with `--password-store=gnome-libsecret` made `safeStorage` work and allowed OAuth login to complete. That keyring/backend selection problem should be handled separately and securely rather than by storing tokens in plaintext.

## Testing

- `bun test src/auth/oauth-network-errors.test.ts`
- `bun run check`
