### PR TITLE
feat(mods): include args in tool_end events

### DIFF
--- a/src/mods/mod-engine.test.ts
+++ b/src/mods/mod-engine.test.ts
@@ -1336,7 +1336,7 @@ describe("mod engine", () => {
         path.join(modDir, "tool-end.ts"),
         `export default function(letta) {
           letta.events.on("tool_end", (event) => {
-            if (event.toolName === "Bash" && event.status === "success") {
+            if (event.toolName === "Bash" && event.args.command === "secret") {
               return { result: { status: "success", output: "redacted" } };
             }
           });
@@ -1355,6 +1355,7 @@ describe("mod engine", () => {
         conversationId: "conversation-1",
         toolCallId: "toolu-1",
         toolName: "Bash",
+        args: { command: "secret" },
         status: "success" as const,
         output: "secret token abc123",
       };
@@ -1402,6 +1403,7 @@ describe("mod engine", () => {
         conversationId: "conversation-1",
         toolCallId: "toolu-1",
         toolName: "Bash",
+        args: { command: "echo untouched" },
         status: "success" as const,
         output: "untouched",
       };

--- a/src/mods/types.ts
+++ b/src/mods/types.ts
@@ -233,6 +233,7 @@ export interface ModToolEndEvent {
   conversationId: string | null;
   toolCallId: string | null;
   toolName: string;
+  args: Record<string, unknown>;
   status: "success" | "error";
   output: string;
 }

--- a/src/skills/builtin/creating-mods/references/events.md
+++ b/src/skills/builtin/creating-mods/references/events.md
@@ -155,16 +155,18 @@ Handlers run in registration order. Later handlers see the current args after ea
   conversationId: string | null;
   toolCallId: string | null;
   toolName: string;
+  args: Record<string, unknown>;
   status: "success" | "error";
   output: string;
 }
 ```
 
-`tool_end` fires immediately after a tool produces a result, before the agent sees it. Handlers can inspect the result, or return `{ result: { status, output } }` to replace it:
+`tool_end` fires immediately after a tool produces a result, before the agent sees it. `event.args` contains the effective tool invocation arguments after `tool_start` transforms, so handlers can react to the specific file, command, query, etc. Handlers can inspect the result, or return `{ result: { status, output } }` to replace it:
 
 ```ts
 letta.events.on("tool_end", (event) => {
   if (event.toolName !== "Bash" || event.status !== "success") return;
+  if (typeof event.args.command !== "string") return;
   return { result: { status: "success", output: redactSecrets(event.output) } };
 });
 ```

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -2329,6 +2329,7 @@ async function emitToolStartEvent(options: {
 }
 
 async function emitToolEndEvent(options: {
+  args: ToolArgs;
   events?: ModEvents;
   executionScope: RuntimeContextSnapshot;
   modContext: ModContext;
@@ -2344,6 +2345,7 @@ async function emitToolEndEvent(options: {
     conversationId: options.executionScope.conversationId ?? null,
     toolCallId: options.toolCallId ?? null,
     toolName: options.toolName,
+    args: cloneToolArgsForModEvent(options.args),
     status: options.status,
     output: options.output,
   };
@@ -2619,6 +2621,7 @@ async function executeToolInner(
     /** Called after a file-mutating tool (Edit, Write, MultiEdit) writes to disk.
      *  The listener layer uses this to broadcast the new content via WebSocket. */
     onFileWrite?: (filePath: string, content: string) => void;
+    toolEndArgsRef?: { current: ToolArgs };
   },
 ): Promise<ToolExecutionResult> {
   const context = options?.toolContextId
@@ -2672,11 +2675,13 @@ async function executeToolInner(
       toolName: name,
     });
     if (result) {
+      if (options?.toolEndArgsRef) options.toolEndArgsRef.current = eventArgs;
       return {
         toolReturn: result.output,
         status: result.status,
       };
     }
+    if (options?.toolEndArgsRef) options.toolEndArgsRef.current = eventArgs;
     const permissionDecision = await checkModPermissionForContext({
       args: eventArgs,
       context,
@@ -2712,11 +2717,13 @@ async function executeToolInner(
       toolName: name,
     });
     if (result) {
+      if (options?.toolEndArgsRef) options.toolEndArgsRef.current = eventArgs;
       return {
         toolReturn: result.output,
         status: result.status,
       };
     }
+    if (options?.toolEndArgsRef) options.toolEndArgsRef.current = eventArgs;
     const permissionDecision = await checkModPermissionForContext({
       args: eventArgs,
       context,
@@ -2774,12 +2781,14 @@ async function executeToolInner(
     toolName: internalName,
   });
   if (result) {
+    if (options?.toolEndArgsRef) options.toolEndArgsRef.current = eventArgs;
     return {
       toolReturn: result.output,
       status: result.status,
     };
   }
   args = eventArgs;
+  if (options?.toolEndArgsRef) options.toolEndArgsRef.current = args;
   const permissionDecision = await checkModPermissionForContext({
     args,
     context,
@@ -2819,6 +2828,7 @@ async function executeToolInner(
         ...preHookResult.updatedInput,
       };
     }
+    if (options?.toolEndArgsRef) options.toolEndArgsRef.current = args;
 
     try {
       // Inject options for tools that support them without altering schemas
@@ -3093,7 +3103,11 @@ export async function executeTool(
   ...params: Parameters<typeof executeToolInner>
 ): Promise<ToolExecutionResult> {
   const [name, args, options] = params;
-  const res = await executeToolInner(name, args, options);
+  const toolEndArgsRef = { current: args };
+  const res = await executeToolInner(name, args, {
+    ...options,
+    toolEndArgsRef,
+  });
 
   const context = options?.toolContextId
     ? getExecutionContextById(options.toolContextId)
@@ -3121,6 +3135,7 @@ export async function executeTool(
     });
 
   const override = await emitToolEndEvent({
+    args: toolEndArgsRef.current,
     events: modEvents,
     executionScope,
     modContext,

--- a/src/tools/tool-execution-context.test.ts
+++ b/src/tools/tool-execution-context.test.ts
@@ -265,7 +265,17 @@ describe("tool execution context snapshot", () => {
     const prepared = await prepareCurrentToolExecutionContext({
       modEvents: {
         async emit(name, event) {
+          if (name === "tool_start") {
+            const toolStartEvent = event as ModToolStartEvent;
+            toolStartEvent.args = {
+              ...toolStartEvent.args,
+              file_path: "package.json",
+            };
+          }
           if (name === "tool_end") {
+            expect((event as ModToolEndEvent).args).toEqual({
+              file_path: "package.json",
+            });
             (
               event as ModToolEndEvent & {
                 result?: { status: "success" | "error"; output: string };

--- a/src/websocket/listener/mod-adapter.test.ts
+++ b/src/websocket/listener/mod-adapter.test.ts
@@ -489,6 +489,7 @@ describe("listener mod adapter", () => {
         letta.events.on("tool_end", (event) => {
           globalThis.__lettaToolEndSeen = {
             toolName: event.toolName,
+            args: event.args,
             status: event.status,
             output: event.output,
           };
@@ -516,6 +517,7 @@ describe("listener mod adapter", () => {
       conversationId: string;
       toolCallId: string;
       toolName: string;
+      args: Record<string, unknown>;
       status: "success" | "error";
       output: string;
       result?: { status: "success" | "error"; output: string };
@@ -524,6 +526,7 @@ describe("listener mod adapter", () => {
       conversationId: "conv-tool-end-test",
       toolCallId: "call-1",
       toolName: "Bash",
+      args: { command: "echo secret" },
       status: "success",
       output: "secret",
     };
@@ -534,6 +537,7 @@ describe("listener mod adapter", () => {
       (globalThis as { __lettaToolEndSeen?: unknown }).__lettaToolEndSeen,
     ).toEqual({
       toolName: "Bash",
+      args: { command: "echo secret" },
       status: "success",
       output: "secret",
     });


### PR DESCRIPTION
## Summary
- include effective tool invocation args on mod `tool_end` events
- preserve `tool_start` argument transforms and PreToolUse input rewrites in the args delivered to `tool_end`
- update mod event docs and test TUI/listener delivery paths

## Motivation
`tool_end` handlers often need to know what a completed tool operated on, e.g. which file an `Edit` changed or which command a `Bash` call ran. Including args avoids fragile output parsing or tool_start/tool_end bookkeeping in every mod.

## Test plan
- [x] `bun test src/tools/tool-execution-context.test.ts src/mods/mod-engine.test.ts src/websocket/listener/mod-adapter.test.ts`
- [x] `bun --check src/mods/types.ts src/tools/manager.ts src/tools/tool-execution-context.test.ts src/mods/mod-engine.test.ts src/websocket/listener/mod-adapter.test.ts`
- [x] `bun run typecheck`
- [x] commit hooks