### PR TITLE
fix(listener): reap half-open sockets on both listener transports

### DIFF
--- a/src/websocket/app-server.test.ts
+++ b/src/websocket/app-server.test.ts
@@ -116,6 +116,54 @@ function waitForJsonMessage(
   });
 }
 
+function waitForClientPing(socket: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error("Timed out waiting for server ping"));
+    }, TEST_TIMEOUT_MS);
+    const cleanup = () => {
+      clearTimeout(timeout);
+      socket.off("ping", handlePing);
+      socket.off("error", handleError);
+    };
+    const handlePing = () => {
+      cleanup();
+      resolve();
+    };
+    const handleError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    socket.once("ping", handlePing);
+    socket.once("error", handleError);
+  });
+}
+
+function waitForClientClose(socket: WebSocket): Promise<void> {
+  if (
+    socket.readyState === WebSocket.CLOSED ||
+    socket.readyState === WebSocket.CLOSING
+  ) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error("Timed out waiting for websocket close"));
+    }, TEST_TIMEOUT_MS);
+    const cleanup = () => {
+      clearTimeout(timeout);
+      socket.off("close", handleClose);
+    };
+    const handleClose = () => {
+      cleanup();
+      resolve();
+    };
+    socket.once("close", handleClose);
+  });
+}
+
 function closeClient(socket: WebSocket | null): void {
   if (!socket) return;
   if (
@@ -410,6 +458,53 @@ describe("app-server native websocket", () => {
       terminateClient(control);
       await handle?.close();
       await rm(authDir, { recursive: true, force: true });
+    }
+  });
+
+  test("pings connected clients and keeps healthy sockets open", async () => {
+    let handle: AppServerHandle | null = null;
+    let stream: WebSocket | null = null;
+    try {
+      handle = await startAppServer({
+        listen: "ws://127.0.0.1:0",
+        heartbeatIntervalMs: 25,
+        pongTimeoutMs: 5000,
+      });
+      stream = new WebSocket(handle.streamUrl);
+      await waitForOpen(stream);
+
+      // The watchdog should ping connected clients on its cadence.
+      await waitForClientPing(stream);
+
+      // The `ws` client auto-pongs, so a healthy socket survives multiple
+      // intervals without being reaped.
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      expect(stream.readyState).toBe(WebSocket.OPEN);
+    } finally {
+      closeClient(stream);
+      await handle?.close();
+    }
+  });
+
+  test("terminates sockets that exceed the pong timeout", async () => {
+    let handle: AppServerHandle | null = null;
+    let stream: WebSocket | null = null;
+    try {
+      // A 1ms pong timeout means the seeded connect timestamp is already stale
+      // by the first interval tick, so the watchdog reaps the socket.
+      handle = await startAppServer({
+        listen: "ws://127.0.0.1:0",
+        heartbeatIntervalMs: 25,
+        pongTimeoutMs: 1,
+      });
+      stream = new WebSocket(handle.streamUrl);
+      await waitForOpen(stream);
+
+      await waitForClientClose(stream);
+      expect(stream.readyState).not.toBe(WebSocket.OPEN);
+    } finally {
+      closeClient(stream);
+      await handle?.close();
     }
   });
 

--- a/src/websocket/app-server.ts
+++ b/src/websocket/app-server.ts
@@ -28,6 +28,18 @@ import type { ListenerRuntime } from "@/websocket/listener/types";
 const DEFAULT_LISTEN_URL = "ws://127.0.0.1:0";
 const DEFAULT_WS_PATH = "/ws";
 const PENDING_STREAM_TIMEOUT_MS = 5000;
+// App-server liveness watchdog. Here letta-code is the WS *server* (the client
+// is the Desktop/relay), so we use protocol-level ws.ping()/pong rather than
+// the app-level ping/pong the outbound listener uses. Ping every 30s and reap
+// any client that has not ponged within 90s (3 missed pings). A half-open
+// client connection (Desktop sleep, network switch, NAT idle timeout) never
+// emits a `close` event, which would otherwise wedge the single-occupancy
+// control channel: new control connections are rejected with 1008 while the
+// zombie session still holds `activeSession`. Terminating the dead socket
+// fires its `close` handler, clears `activeSession`, and frees the channel for
+// a reconnecting client.
+const APP_SERVER_HEARTBEAT_INTERVAL_MS = 30000;
+const APP_SERVER_PONG_TIMEOUT_MS = 90000;
 
 type AppServerChannel = "control" | "stream";
 
@@ -37,6 +49,10 @@ export interface StartAppServerOptions {
   connectionName?: string;
   onListening?: (info: AppServerListeningInfo) => void;
   onLog?: (message: string) => void;
+  /** @internal Test override for the liveness ping cadence (ms). */
+  heartbeatIntervalMs?: number;
+  /** @internal Test override for the pong timeout before a socket is reaped (ms). */
+  pongTimeoutMs?: number;
 }
 
 export interface AppServerListeningInfo {
@@ -249,6 +265,10 @@ export async function startAppServer(
   let pendingStreamSocket: WebSocket | null = null;
   let pendingStreamTimeout: ReturnType<typeof setTimeout> | null = null;
   let resolvedInfo: AppServerListeningInfo | null = null;
+  // Tracks the last time each connected client responded to a ping. Seeded on
+  // connection so a freshly-accepted socket gets a full grace window before the
+  // watchdog can reap it. WeakMap so entries are GC'd with their sockets.
+  const lastPongAtBySocket = new WeakMap<WebSocket, number>();
 
   const clearPendingStream = (): WebSocket | null => {
     if (pendingStreamTimeout) {
@@ -264,6 +284,14 @@ export async function startAppServer(
     socket: WebSocket,
     channel: AppServerChannel,
   ): void => {
+    // Liveness tracking for the heartbeat watchdog. Applies to both control
+    // and stream sockets. The `ws` library auto-replies to ping frames with a
+    // pong, so any client whose TCP is still alive refreshes this timestamp.
+    lastPongAtBySocket.set(socket, Date.now());
+    socket.on("pong", () => {
+      lastPongAtBySocket.set(socket, Date.now());
+    });
+
     if (channel === "stream") {
       if (activeSession) {
         attachStreamSocket(activeSession, socket);
@@ -378,6 +406,34 @@ export async function startAppServer(
     });
   });
 
+  const heartbeatIntervalMs =
+    options.heartbeatIntervalMs ?? APP_SERVER_HEARTBEAT_INTERVAL_MS;
+  const pongTimeoutMs = options.pongTimeoutMs ?? APP_SERVER_PONG_TIMEOUT_MS;
+  const heartbeatInterval = setInterval(() => {
+    const now = Date.now();
+    for (const client of wss.clients) {
+      const lastPongAt = lastPongAtBySocket.get(client) ?? now;
+      if (now - lastPongAt > pongTimeoutMs) {
+        // No pong within the timeout: the socket is half-open. Terminating it
+        // fires the `close` handler that clears activeSession and frees the
+        // control channel for a reconnecting client.
+        options.onLog?.(
+          `App-server terminating unresponsive socket (no pong in ${pongTimeoutMs}ms)`,
+        );
+        client.terminate();
+        continue;
+      }
+      if (client.readyState === WebSocket.OPEN) {
+        client.ping();
+      }
+    }
+  }, heartbeatIntervalMs);
+  // Do not let the watchdog keep the event loop alive on its own.
+  heartbeatInterval.unref?.();
+  wss.on("close", () => {
+    clearInterval(heartbeatInterval);
+  });
+
   await new Promise<void>((resolve, reject) => {
     const onError = (error: Error) => {
       server.off("listening", onListening);
@@ -404,6 +460,7 @@ export async function startAppServer(
   return {
     ...resolvedInfo,
     close: async () => {
+      clearInterval(heartbeatInterval);
       const streamSocket = clearPendingStream();
       terminateSocket(streamSocket);
       if (activeSession) {

--- a/src/websocket/listener-lifecycle-frames.test.ts
+++ b/src/websocket/listener-lifecycle-frames.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import type WebSocket from "ws";
 import { __listenClientTestUtils } from "@/websocket/listen-client";
+import { isListenerPongStale } from "@/websocket/listener/constants";
 import { createListenerMessageHandler } from "@/websocket/listener/message-router";
 import { parseServerLifecycleMessage } from "@/websocket/listener/protocol-inbound";
 import type {
@@ -74,6 +75,18 @@ describe("listener lifecycle frames", () => {
     ]);
   });
 
+  test("records lastPongAt when a pong frame arrives", async () => {
+    const runtime = __listenClientTestUtils.createListenerRuntime();
+    __listenClientTestUtils.setActiveRuntime(runtime);
+    expect(runtime.lastPongAt).toBeNull();
+
+    const before = Date.now();
+    await makeHandler(runtime)(Buffer.from('{"type":"pong"}'));
+
+    expect(runtime.lastPongAt).not.toBeNull();
+    expect(runtime.lastPongAt as number).toBeGreaterThanOrEqual(before);
+  });
+
   test("still logs malformed frames as unparseable lifecycle events", async () => {
     const runtime = __listenClientTestUtils.createListenerRuntime();
     const events: Array<{
@@ -95,5 +108,24 @@ describe("listener lifecycle frames", () => {
         event: { type: "_ws_unparseable", raw: "not-json" },
       },
     ]);
+  });
+});
+
+describe("isListenerPongStale", () => {
+  test("returns false before any pong is recorded", () => {
+    expect(isListenerPongStale(null, 1_000_000, 90_000)).toBe(false);
+  });
+
+  test("returns false when a pong arrived within the timeout", () => {
+    const now = 1_000_000;
+    expect(isListenerPongStale(now - 30_000, now, 90_000)).toBe(false);
+    // Exactly at the boundary is not yet stale.
+    expect(isListenerPongStale(now - 90_000, now, 90_000)).toBe(false);
+  });
+
+  test("returns true once the timeout is exceeded", () => {
+    const now = 1_000_000;
+    expect(isListenerPongStale(now - 90_001, now, 90_000)).toBe(true);
+    expect(isListenerPongStale(now - 300_000, now, 90_000)).toBe(true);
   });
 });

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -144,6 +144,7 @@ function createLegacyTestRuntime(): ConversationRuntime & {
   reminderState: ListenerRuntime["reminderState"];
   reconnectTimeout: NodeJS.Timeout | null;
   heartbeatInterval: NodeJS.Timeout | null;
+  lastPongAt: number | null;
   intentionallyClosed: boolean;
   hasSuccessfulConnection: boolean;
   everConnected: boolean;
@@ -183,6 +184,7 @@ function createLegacyTestRuntime(): ConversationRuntime & {
     reminderState: ListenerRuntime["reminderState"];
     reconnectTimeout: NodeJS.Timeout | null;
     heartbeatInterval: NodeJS.Timeout | null;
+    lastPongAt: number | null;
     intentionallyClosed: boolean;
     hasSuccessfulConnection: boolean;
     everConnected: boolean;
@@ -312,6 +314,12 @@ function createLegacyTestRuntime(): ConversationRuntime & {
       get: () => listener.heartbeatInterval,
       set: (value: NodeJS.Timeout | null) => {
         listener.heartbeatInterval = value;
+      },
+    },
+    lastPongAt: {
+      get: () => listener.lastPongAt,
+      set: (value: number | null) => {
+        listener.lastPongAt = value;
       },
     },
     intentionallyClosed: {

--- a/src/websocket/listener/constants.ts
+++ b/src/websocket/listener/constants.ts
@@ -2,6 +2,36 @@ export const MAX_RETRY_DURATION_MS = 5 * 60 * 1000; // 5 minutes
 export const INITIAL_RETRY_DELAY_MS = 1000; // 1 second
 export const MAX_RETRY_DELAY_MS = 30000; // 30 seconds
 
+// Listener heartbeat: app-level ping/pong over the cloud relay. Each `ping`
+// refreshes the environment's lastHeartbeat (the relay marks an env offline
+// after ~120s of silence) and the relay replies with a `pong`.
+export const LISTENER_HEARTBEAT_INTERVAL_MS = 30000; // 30 seconds
+// Dead-peer detection window. If no `pong` is observed within this window, the
+// underlying TCP is treated as half-open (laptop sleep, network switch,
+// NAT/idle timeout) — which never emits a `close` event — and the socket is
+// force-terminated to trigger the reconnect path. Set to 3 missed heartbeats
+// so a single transient drop does not kill an otherwise healthy connection,
+// while still reconnecting before the relay's ~120s offline cutoff.
+export const LISTENER_PONG_TIMEOUT_MS = 90000; // 3 missed heartbeats
+
+/**
+ * Returns true when the listener has not observed a relay `pong` within
+ * `timeoutMs`, indicating a likely half-open socket that should be terminated
+ * to trigger a reconnect. Returns false when no pong has been recorded yet
+ * (`lastPongAt === null`) so a freshly-connected socket is never killed before
+ * its first heartbeat round-trip completes.
+ */
+export function isListenerPongStale(
+  lastPongAt: number | null,
+  now: number,
+  timeoutMs: number,
+): boolean {
+  if (lastPongAt === null) {
+    return false;
+  }
+  return now - lastPongAt > timeoutMs;
+}
+
 export const SYSTEM_REMINDER_RE =
   /<system-reminder>[\s\S]*?<\/system-reminder>/g;
 

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -41,6 +41,9 @@ import {
 } from "./commands/model-toolset";
 import {
   INITIAL_RETRY_DELAY_MS,
+  isListenerPongStale,
+  LISTENER_HEARTBEAT_INTERVAL_MS,
+  LISTENER_PONG_TIMEOUT_MS,
   MAX_RETRY_DELAY_MS,
   MAX_RETRY_DURATION_MS,
 } from "./constants";
@@ -779,6 +782,7 @@ export function createRuntime(): ListenerRuntime {
     streamTransport: null,
     heartbeatInterval: null,
     reconnectTimeout: null,
+    lastPongAt: null,
     intentionallyClosed: false,
     hasSuccessfulConnection: false,
     everConnected: false,
@@ -1029,14 +1033,45 @@ export async function startConnectedListenerRuntime(
   });
 
   if (shouldStartHeartbeat) {
+    // Seed the pong clock so the watchdog tolerates the first ping/pong
+    // round-trip before considering the peer dead.
+    runtime.lastPongAt = Date.now();
     runtime.heartbeatInterval = setInterval(() => {
+      // Dead-peer detection. The relay replies to every `ping` with a `pong`
+      // (recorded as runtime.lastPongAt in the message router). If pongs stop
+      // arriving, the underlying TCP is likely half-open (laptop sleep,
+      // network switch, NAT/idle timeout) and will never emit a `close`
+      // event — leaving a zombie listener that the relay marks offline after
+      // ~120s while client-side tool execution silently breaks. Force a
+      // terminate so the socket's `close` handler fires and reconnects.
+      // Gated on websocket transports: the local app-server path does not run
+      // a heartbeat, and only websockets carry the relay pong round-trip.
+      if (
+        getListenerTransportKind(transport) === "websocket" &&
+        isListenerPongStale(
+          runtime.lastPongAt,
+          Date.now(),
+          LISTENER_PONG_TIMEOUT_MS,
+        )
+      ) {
+        trackListenerError(
+          "listener_pong_timeout",
+          new Error(
+            `No relay pong within ${LISTENER_PONG_TIMEOUT_MS}ms; terminating half-open socket to force reconnect`,
+          ),
+          "listener_heartbeat",
+        );
+        runtime.socket?.terminate();
+        return;
+      }
+
       safeTransportSend(
         transport,
         { type: "ping" },
         "listener_ping_send_failed",
         "listener_heartbeat",
       );
-    }, 30000);
+    }, LISTENER_HEARTBEAT_INTERVAL_MS);
   }
 
   if (shouldStartCronScheduler) {

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -382,6 +382,11 @@ export function createListenerMessageHandler(
     try {
       const lifecycleMessage = parseServerLifecycleMessage(data);
       if (lifecycleMessage) {
+        // Record relay pongs so the heartbeat watchdog can detect a half-open
+        // socket (no pong within the timeout) and force a reconnect.
+        if (lifecycleMessage.type === "pong") {
+          runtime.lastPongAt = Date.now();
+        }
         safeEmitWsEvent("recv", "lifecycle", lifecycleMessage);
         return;
       }

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -186,6 +186,12 @@ export type ListenerRuntime = {
   streamTransport?: ListenerTransport | null;
   heartbeatInterval: NodeJS.Timeout | null;
   reconnectTimeout: NodeJS.Timeout | null;
+  /**
+   * Epoch ms of the last `pong` observed from the cloud relay. Used by the
+   * heartbeat watchdog to detect a half-open socket (no `close` event) and
+   * force a reconnect. `null` until the first pong on a connection.
+   */
+  lastPongAt: number | null;
   intentionallyClosed: boolean;
   hasSuccessfulConnection: boolean;
   /** True once the WS has connected at least once. Never reset to false. */


### PR DESCRIPTION
## Summary
Long-running listeners (e.g. `kian-devm`) sometimes go **red** in the Desktop env dropdown while the process is still alive: messages + server-side tools (`web_search`/`fetch_webpage`) keep working, but **client-side tools (Bash/Read/Write/Edit) silently stop executing**. Root cause is a half-open socket that never emits a `close` event (laptop sleep/wake, WiFi switch, NAT/idle timeout), so the reconnect/cleanup path never fires. This hardens **both** listener transports against it.

### 1. Outbound cloud relay listener (`listener/*`)
- The listener pinged the relay every 30s but had **no pong-liveness watchdog** — incoming `pong` frames were only logged.
- Now records `lastPongAt` on every relay `pong` and, if no pong arrives within `LISTENER_PONG_TIMEOUT_MS` (90s = 3 missed heartbeats), force-`terminate()`s the socket so the existing `connectWithRetry` `close` handler reconnects.
- Gated to websocket transports — the local app-server path runs `startHeartbeat:false` and never pongs.
- Extracted the magic `30000` into `LISTENER_HEARTBEAT_INTERVAL_MS` + added a pure `isListenerPongStale()` helper for testability.

### 2. Inbound app-server (`app-server.ts`)
- letta-code is the WS **server** here (Desktop/relay is the client), and it had **no liveness watchdog** at all — only reacted to clean `close`/`error`.
- This path is worse: the control channel is single-occupancy and rejects new connections with `1008 "control channel already connected"` while a zombie `activeSession` is held, so a half-open client **wedges reconnect** until the stale socket is reaped.
- Added a protocol-level `ws.ping()`/pong watchdog: ping every 30s, reap any client with no pong in 90s. Terminating the dead socket fires its `close` handler, clears `activeSession`, and frees the channel.
- Added `@internal` `heartbeatIntervalMs`/`pongTimeoutMs` option overrides so the ping + reap paths are unit-testable without real-time waits.

## Test plan
- [x] `bun test src/websocket/` — 468 pass (incl. new `lastPongAt`/`isListenerPongStale` cases + app-server ping/reap tests)
- [x] `bun run typecheck` clean
- [x] biome lint clean (pre-commit hooks green on both commits)
- [ ] Manual: induce a network drop on a live `letta server`, confirm env recovers red → green within ~90s and client tools resume without manual restart
- [ ] Manual: half-open a Desktop→app-server connection, confirm the control channel frees up and reconnects instead of wedging on 1008