### PR TITLE
feat(app-server): add conversation list client helper

### DIFF
--- a/src/app-server-client.test.ts
+++ b/src/app-server-client.test.ts
@@ -221,6 +221,36 @@ describe("app-server client", () => {
     expect(sent).toEqual(["sync", "abort_message", "input"]);
   });
 
+  test("wraps conversation list requests", async () => {
+    const { client, control, stream } = createFakeClient();
+    control.open();
+    stream.open();
+    await client.connect();
+
+    const responsePromise = client.conversationList({
+      query: { agent_id: "agent-1", limit: 10 },
+    });
+
+    expect(JSON.parse(control.sent[0] ?? "{}")).toMatchObject({
+      type: "conversation_list",
+      request_id: "conversation-list-1",
+      query: { agent_id: "agent-1", limit: 10 },
+    });
+
+    control.receive({
+      type: "conversation_list_response",
+      request_id: "conversation-list-1",
+      success: true,
+      conversations: [{ id: "conv-1", agent_id: "agent-1" }],
+    });
+
+    const response = await responsePromise;
+    expect(response.success).toBe(true);
+    expect(response.conversations).toEqual([
+      { id: "conv-1", agent_id: "agent-1" },
+    ]);
+  });
+
   test("starts runtimes with external tools and responds to external tool calls", async () => {
     const { client, control, stream } = createFakeClient();
     control.open();

--- a/src/app-server-client.ts
+++ b/src/app-server-client.ts
@@ -1,6 +1,8 @@
 import type {
   AbortMessageCommand,
   AbortMessageResponseMessage,
+  ConversationListCommand,
+  ConversationListResponseMessage,
   ExternalToolCallRequestMessage,
   ExternalToolCallResult,
   InputCommand,
@@ -490,6 +492,30 @@ export class AppServerClient {
         ...options,
         predicate: (message): message is AbortMessageResponseMessage =>
           message.type === "abort_message_response",
+      },
+    );
+  }
+
+  conversationList(
+    command: Omit<ConversationListCommand, "type" | "request_id"> & {
+      request_id?: string;
+    } = {},
+    options: Omit<
+      AppServerRequestOptions<ConversationListResponseMessage>,
+      "predicate"
+    > = {},
+  ): Promise<ConversationListResponseMessage> {
+    return this.request(
+      {
+        type: "conversation_list",
+        request_id:
+          command.request_id ?? this.nextRequestId("conversation-list"),
+        ...command,
+      },
+      {
+        ...options,
+        predicate: (message): message is ConversationListResponseMessage =>
+          message.type === "conversation_list_response",
       },
     );
   }


### PR DESCRIPTION
## Summary
- add an `AppServerClient.conversationList()` helper for the existing `conversation_list` websocket command
- resolve requests on `conversation_list_response`
- cover the helper in app-server client tests

## Test
- `bun test src/app-server-client.test.ts`
- `bun run typecheck`

👾 Generated with [Letta Code](https://letta.com)