### PR TITLE
fix(tools): clarify system memory path guidance

### DIFF
--- a/src/tools/descriptions/Edit.md
+++ b/src/tools/descriptions/Edit.md
@@ -3,7 +3,7 @@
 Performs exact string replacements in files. 
 
 Usage:
-- You must use your `Read` tool at least once in the conversation before editing. This tool will error if you attempt an edit without reading the file. Exception: files under `$MEMORY_DIR/system/` do not require a Read call first, since their contents are already provided in your system prompt.
+- You must use your `Read` tool at least once in the conversation before editing. This tool will error if you attempt an edit without reading the file. Exception: system memory files whose contents are already shown in your prompt do not require a Read call first. When passing a `file_path`, use a relative path such as `system/human.md` (from the memory repo) or an expanded absolute path; environment variables are not expanded.
 - `file_path` is literal: `$VAR`, `$MEMORY_DIR`, `~`, etc. are not expanded.
 - When editing text from Read tool output, ensure you preserve the exact indentation (tabs/spaces) as it appears AFTER the line number prefix. The line number prefix format is: spaces + line number + tab. Everything after that tab is the actual file content to match. Never include any part of the line number prefix in the old_string or new_string.
 - ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.

--- a/src/tools/descriptions/Edit.md
+++ b/src/tools/descriptions/Edit.md
@@ -3,7 +3,7 @@
 Performs exact string replacements in files. 
 
 Usage:
-- You must use your `Read` tool at least once in the conversation before editing. This tool will error if you attempt an edit without reading the file. Exception: system memory files whose contents are already shown in your prompt do not require a Read call first. When passing a `file_path`, use a relative path such as `system/human.md` (from the memory repo) or an expanded absolute path; environment variables are not expanded.
+- You must use your `Read` tool at least once in the conversation before editing. This tool will error if you attempt an edit without reading the file. Exception: system memory files whose contents are already shown in your prompt do not require a Read call first. For memory files, pass an expanded absolute path (use Bash to resolve `$MEMORY_DIR` first if needed).
 - `file_path` is literal: `$VAR`, `$MEMORY_DIR`, `~`, etc. are not expanded.
 - When editing text from Read tool output, ensure you preserve the exact indentation (tabs/spaces) as it appears AFTER the line number prefix. The line number prefix format is: spaces + line number + tab. Everything after that tab is the actual file content to match. Never include any part of the line number prefix in the old_string or new_string.
 - ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.

--- a/src/tools/descriptions/Write.md
+++ b/src/tools/descriptions/Write.md
@@ -4,7 +4,7 @@ Writes a file to the local filesystem.
 
 Usage:
 - This tool will overwrite the existing file if there is one at the provided path.
-- If this is an existing file, you MUST use the Read tool first to read the file's contents. This tool will fail if you did not read the file first. Exception: system memory files whose contents are already shown in your prompt do not require a Read call first. When passing a `file_path`, use a relative path such as `system/human.md` (from the memory repo) or an expanded absolute path; environment variables are not expanded.
+- If this is an existing file, you MUST use the Read tool first to read the file's contents. This tool will fail if you did not read the file first. Exception: system memory files whose contents are already shown in your prompt do not require a Read call first. For memory files, pass an expanded absolute path (use Bash to resolve `$MEMORY_DIR` first if needed).
 - `file_path` is literal: `$VAR`, `$MEMORY_DIR`, `~`, etc. are not expanded.
 - ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
 - NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.

--- a/src/tools/descriptions/Write.md
+++ b/src/tools/descriptions/Write.md
@@ -4,7 +4,7 @@ Writes a file to the local filesystem.
 
 Usage:
 - This tool will overwrite the existing file if there is one at the provided path.
-- If this is an existing file, you MUST use the Read tool first to read the file's contents. This tool will fail if you did not read the file first. Exception: files under `$MEMORY_DIR/system/` do not require a Read call first, since their contents are already provided in your system prompt.
+- If this is an existing file, you MUST use the Read tool first to read the file's contents. This tool will fail if you did not read the file first. Exception: system memory files whose contents are already shown in your prompt do not require a Read call first. When passing a `file_path`, use a relative path such as `system/human.md` (from the memory repo) or an expanded absolute path; environment variables are not expanded.
 - `file_path` is literal: `$VAR`, `$MEMORY_DIR`, `~`, etc. are not expanded.
 - ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
 - NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.


### PR DESCRIPTION
## Summary
- reword Edit and Write tool descriptions to avoid suggesting literal `$MEMORY_DIR/system` paths
- clarify that system memory files already shown in the prompt do not need a Read call
- direct agents to use relative memory-repo paths like `system/human.md` or expanded absolute paths

## Testing
- pre-commit checks ran during `git commit` (including TypeScript `tsc --noEmit`)