### PR TITLE
feat(tools): expand ~ and $VAR in file_path for Read/Write/Edit

### DIFF
--- a/src/tools/impl/edit.ts
+++ b/src/tools/impl/edit.ts
@@ -1,5 +1,5 @@
-import * as path from "node:path";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
+import { expandFilePath } from "@/utils/file-path";
 import { readUtf8TextStrict, writeUtf8Text } from "@/utils/text-files";
 import { validateRequiredParams } from "./validation.js";
 
@@ -141,9 +141,7 @@ export async function edit(args: EditArgs): Promise<EditResult> {
     );
   }
   const userCwd = getCurrentWorkingDirectory();
-  const resolvedPath = path.isAbsolute(file_path)
-    ? file_path
-    : path.resolve(userCwd, file_path);
+  const resolvedPath = expandFilePath(file_path, userCwd);
   if (old_string === new_string)
     throw new Error(
       "No changes to make: old_string and new_string are exactly the same.",

--- a/src/tools/impl/multi-edit.ts
+++ b/src/tools/impl/multi-edit.ts
@@ -1,5 +1,5 @@
-import * as path from "node:path";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
+import { expandFilePath } from "@/utils/file-path";
 import { readUtf8TextStrict, writeUtf8Text } from "@/utils/text-files";
 import { validateRequiredParams } from "./validation.js";
 
@@ -29,9 +29,7 @@ export async function multi_edit(
   validateRequiredParams(args, ["file_path", "edits"], "MultiEdit");
   const { file_path, edits } = args;
   const userCwd = getCurrentWorkingDirectory();
-  const resolvedPath = path.isAbsolute(file_path)
-    ? file_path
-    : path.resolve(userCwd, file_path);
+  const resolvedPath = expandFilePath(file_path, userCwd);
   if (!edits || edits.length === 0) throw new Error("No edits provided");
   for (let i = 0; i < edits.length; i++) {
     const edit = edits[i];

--- a/src/tools/impl/read.ts
+++ b/src/tools/impl/read.ts
@@ -7,6 +7,7 @@ import type {
 import { SYSTEM_REMINDER_CLOSE, SYSTEM_REMINDER_OPEN } from "@/constants";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
 import { debugLog } from "@/utils/debug.js";
+import { expandFilePath } from "@/utils/file-path";
 import { resizeImageIfNeeded } from "@/utils/image-resize.js";
 import { getUtf16Bom, readUtf8TextStrict } from "@/utils/text-files";
 import { OVERFLOW_CONFIG, writeOverflowFile } from "./overflow.js";
@@ -210,9 +211,7 @@ export async function read(args: ReadArgs): Promise<ReadResult> {
   validateRequiredParams(args, ["file_path"], "Read");
   const { file_path, offset, limit } = args;
   const userCwd = getCurrentWorkingDirectory();
-  const resolvedPath = path.isAbsolute(file_path)
-    ? file_path
-    : path.resolve(userCwd, file_path);
+  const resolvedPath = expandFilePath(file_path, userCwd);
   try {
     const stats = await fs.stat(resolvedPath);
     if (stats.isDirectory())

--- a/src/tools/impl/write.ts
+++ b/src/tools/impl/write.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
+import { expandFilePath } from "@/utils/file-path";
 import { writeUtf8Text } from "@/utils/text-files";
 import { validateRequiredParams } from "./validation.js";
 
@@ -16,9 +17,7 @@ export async function write(args: WriteArgs): Promise<WriteResult> {
   validateRequiredParams(args, ["file_path", "content"], "Write");
   const { file_path, content } = args;
   const userCwd = getCurrentWorkingDirectory();
-  const resolvedPath = path.isAbsolute(file_path)
-    ? file_path
-    : path.resolve(userCwd, file_path);
+  const resolvedPath = expandFilePath(file_path, userCwd);
   try {
     const dir = path.dirname(resolvedPath);
     await fs.mkdir(dir, { recursive: true });

--- a/src/tools/multiedit.test.ts
+++ b/src/tools/multiedit.test.ts
@@ -41,6 +41,26 @@ describe("MultiEdit tool", () => {
     expect(result.edits_applied).toBe(2);
   });
 
+  test("expands environment variables in file_path", async () => {
+    testDir = new TestDirectory();
+    const file = testDir.createFile("test.txt", "foo bar");
+    const originalEnv = process.env.LETTA_MULTI_EDIT_TEST_DIR;
+    process.env.LETTA_MULTI_EDIT_TEST_DIR = testDir.path;
+
+    try {
+      await multi_edit({
+        file_path: "$LETTA_MULTI_EDIT_TEST_DIR/test.txt",
+        edits: [{ old_string: "foo", new_string: "FOO" }],
+      });
+    } finally {
+      if (originalEnv === undefined)
+        delete process.env.LETTA_MULTI_EDIT_TEST_DIR;
+      else process.env.LETTA_MULTI_EDIT_TEST_DIR = originalEnv;
+    }
+
+    expect(readFileSync(file, "utf-8")).toBe("FOO bar");
+  });
+
   test("throws error when file_path is missing", async () => {
     await expect(
       multi_edit({

--- a/src/utils/file-path.ts
+++ b/src/utils/file-path.ts
@@ -1,0 +1,29 @@
+import * as os from "node:os";
+import * as path from "node:path";
+
+/**
+ * Expand a file_path argument before resolving it:
+ * 1. Expand leading `~` to the home directory.
+ * 2. Expand `$VAR` and `${VAR}` references using process.env (fallback: leave
+ *    the token as-is so the downstream error message is still readable).
+ * 3. Resolve relative paths against `userCwd`.
+ */
+export function expandFilePath(filePath: string, userCwd: string): string {
+  // 1. Tilde expansion
+  let expanded = filePath;
+  if (expanded === "~" || expanded.startsWith("~/")) {
+    expanded = path.join(os.homedir(), expanded.slice(1));
+  }
+
+  // 2. Environment-variable expansion ($VAR and ${VAR})
+  expanded = expanded.replace(
+    /\$\{([^}]+)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g,
+    (match, braced?: string, unbraced?: string) => {
+      const name = braced ?? unbraced ?? "";
+      return process.env[name] ?? match; // leave unresolved vars intact
+    },
+  );
+
+  // 3. Absolute vs relative
+  return path.isAbsolute(expanded) ? expanded : path.resolve(userCwd, expanded);
+}


### PR DESCRIPTION
## Summary
- Add `src/utils/file-path.ts` with `expandFilePath()` that expands `~` (home dir) and `$VAR`/`${VAR}` env vars before resolving paths
- Wire it into `Read`, `Write`, and `Edit` tool implementations, replacing the inline `path.isAbsolute ? ... : path.resolve(cwd, ...)` pattern
- Unresolved variables are left as-is so error messages stay readable

Allows agents to pass paths like `$MEMORY_DIR/system/human.md` directly to file tools instead of needing to pre-expand via Bash.

## Test plan
- `bun run check` passes (all 9 checks)

👾 Generated with [Letta Code](https://letta.com)