### PR TITLE
fix(subagents): link fork subagents to their forked conversation

### DIFF
--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -1551,6 +1551,19 @@ export async function spawnSubagent(
     }
   }
 
+  // Fork subagents (e.g. recall) deploy the parent agent into a forked
+  // conversation. They don't emit an init event carrying agent_id/
+  // conversation_id (which is the usual source of agentURL), so without this
+  // the card would have no link and any fallback would route to the parent's
+  // main conversation. Set the link eagerly to the forked conversation so it
+  // opens the subagent's own thread instead.
+  if (forkedContext && existingAgentId && existingConversationId) {
+    const forkAgentURL = buildAgentReference(existingAgentId, {
+      conversationId: existingConversationId,
+    });
+    updateSubagent(subagentId, { agentURL: forkAgentURL });
+  }
+
   // Execute subagent - state updates are handled via the state store
   const result = await executeSubagent(
     type,

--- a/src/tools/impl/task.ts
+++ b/src/tools/impl/task.ts
@@ -679,7 +679,8 @@ export async function task(args: TaskArgs): Promise<string> {
       // Mark the forked conversation as hidden so it doesn't clutter the
       // parent agent's conversation list in the ADE. The subagent still
       // reads/writes this conversation normally — only archive status is
-      // affected.
+      // affected. The forked conversation remains retrievable by id, so a
+      // direct link still opens it.
       const forkedConv = await getBackend().forkConversation(parentConvId, {
         ...(parentConvId === "default" ? { agentId: parentAgentId } : {}),
         hidden: true,


### PR DESCRIPTION
## Summary
- Recall (and other `fork: true`) subagents deploy the **parent agent** into a **hidden forked conversation**, but never emit an init event carrying `agent_id`/`conversation_id` — the usual source of `agentURL`. So the subagent card had no link, and any URL fallback routed the user to the parent agent's **main conversation**.
- **Reported by Sarah**: clicking a recall subagent opened the main chat instead of anything meaningful.
- Fix: in `spawnSubagent`, set `agentURL` **eagerly** for forked deployments, pointing at the forked conversation on the parent agent (`buildAgentReference(parentAgentId, { conversationId: forkedConvId })`).

## Why this works
- The forked conversation is created with `hidden: true` (so it stays out of the conversation **listings**), but it remains **retrievable by id** (`GET /v1/conversations/{id}` has no hidden filter). The web chat route reads the conversation straight from the URL param and loads it by id — it does **not** validate against the listing — so the link opens the subagent's own thread.
- Previously `agentURL` was only set from the child's init event (`handleInitEvent`), which fork/`--conv` deployments don't emit with an `agent_id`. Setting it eagerly from the ids we already have at spawn time closes the gap.

## Notes
- Change is contained to the `agent/` layer (`manager.ts`); `task.ts` is a comment clarification only. No layer-boundary violations.
- URL construction is already covered by `app-urls.test.ts` (`buildAgentReference(..., { conversationId })`).

## Test plan
- [ ] Spawn a recall subagent; confirm its card is now clickable and opens the forked conversation (same agent), not the main chat.
- [ ] Background recall subagent: same behavior.
- [ ] Non-fork subagents (new-agent spawns) still link via the init event as before.
- [x] `tsc --noEmit`, biome lint, layer boundaries, existing subagent/task tests (22) pass.

👾 Generated with [Letta Code](https://letta.com)