### PR TITLE
feat(desktop): add artifact file tools experiment

### DIFF
--- a/src/experiments/manager.test.ts
+++ b/src/experiments/manager.test.ts
@@ -8,6 +8,7 @@ import { settingsManager } from "@/settings-manager";
 const originalHome = process.env.HOME;
 const originalUserProfile = process.env.USERPROFILE;
 const originalNodeFlag = process.env.LETTA_NODE;
+const originalArtifactsFlag = process.env.LETTA_ARTIFACTS;
 
 let testHomeDir = "";
 
@@ -17,6 +18,7 @@ beforeEach(async () => {
   process.env.HOME = testHomeDir;
   process.env.USERPROFILE = testHomeDir;
   delete process.env.LETTA_NODE;
+  delete process.env.LETTA_ARTIFACTS;
   await settingsManager.initialize();
 });
 
@@ -39,9 +41,26 @@ afterEach(async () => {
   } else {
     process.env.LETTA_NODE = originalNodeFlag;
   }
+
+  if (originalArtifactsFlag === undefined) {
+    delete process.env.LETTA_ARTIFACTS;
+  } else {
+    process.env.LETTA_ARTIFACTS = originalArtifactsFlag;
+  }
 });
 
 describe("experimentManager", () => {
+  test("falls back to LETTA_ARTIFACTS when no override is stored", () => {
+    process.env.LETTA_ARTIFACTS = "true";
+
+    expect(experimentManager.getSnapshot("artifacts")).toMatchObject({
+      id: "artifacts",
+      enabled: true,
+      source: "env",
+      override: null,
+    });
+  });
+
   test("falls back to LETTA_NODE when no override is stored", () => {
     process.env.LETTA_NODE = "1";
 

--- a/src/experiments/manager.ts
+++ b/src/experiments/manager.ts
@@ -13,6 +13,13 @@ const ENABLED_TOGGLE_VALUES = new Set(["1", "true", "yes"]);
 
 const EXPERIMENT_DEFINITIONS: readonly ExperimentDefinition[] = [
   {
+    id: "artifacts",
+    label: "artifacts",
+    description:
+      "Expose Letta Code Desktop artifact creation tools and artifact UI surfaces.",
+    envVar: "LETTA_ARTIFACTS",
+  },
+  {
     id: "conversation_titles",
     label: "conversation titles",
     description: "Generate AI conversation titles automatically when possible.",

--- a/src/experiments/types.ts
+++ b/src/experiments/types.ts
@@ -1,4 +1,5 @@
 export type ExperimentId =
+  | "artifacts"
   | "conversation_titles"
   | "desktop_conversation_bootstrap"
   | "diffs"

--- a/src/tools/artifact-files.test.ts
+++ b/src/tools/artifact-files.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { experimentManager } from "@/experiments/manager";
+import { settingsManager } from "@/settings-manager";
+import {
+  read_artifact_file,
+  write_artifact_file,
+} from "@/tools/impl/artifact-files";
+import {
+  clearCapturedToolExecutionContexts,
+  prepareToolExecutionContextForModel,
+} from "@/tools/manager";
+
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+const originalArtifactsDir = process.env.LETTA_ARTIFACTS_DIR;
+
+let testHomeDir = "";
+
+beforeEach(async () => {
+  await settingsManager.reset();
+  testHomeDir = await mkdtemp(join(tmpdir(), "letta-artifacts-home-"));
+  process.env.HOME = testHomeDir;
+  process.env.USERPROFILE = testHomeDir;
+  process.env.LETTA_ARTIFACTS_DIR = join(testHomeDir, ".letta", "artifacts");
+  await settingsManager.initialize();
+});
+
+afterEach(async () => {
+  clearCapturedToolExecutionContexts();
+  await settingsManager.reset();
+  if (testHomeDir) {
+    await rm(testHomeDir, { recursive: true, force: true });
+    testHomeDir = "";
+  }
+  process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) {
+    delete process.env.USERPROFILE;
+  } else {
+    process.env.USERPROFILE = originalUserProfile;
+  }
+  if (originalArtifactsDir === undefined) {
+    delete process.env.LETTA_ARTIFACTS_DIR;
+  } else {
+    process.env.LETTA_ARTIFACTS_DIR = originalArtifactsDir;
+  }
+});
+
+describe("artifact file tools", () => {
+  test("are disabled until the artifacts experiment is enabled", async () => {
+    await expect(
+      write_artifact_file({
+        path: "todo-app/ui/index.html",
+        content: "<h1>Todo</h1>",
+      }),
+    ).rejects.toThrow("artifacts experiment is disabled");
+  });
+
+  test("write and read files under ~/.letta/artifacts", async () => {
+    experimentManager.set("artifacts", true);
+
+    const writeResult = await write_artifact_file({
+      path: "artifacts/todo-app/ui/index.html",
+      content: "<h1>Todo</h1>",
+    });
+
+    expect(writeResult.path).toBe("todo-app/ui/index.html");
+    expect(writeResult.bytes).toBeGreaterThan(0);
+    await expect(
+      readFile(
+        join(
+          testHomeDir,
+          ".letta",
+          "artifacts",
+          "todo-app",
+          "ui",
+          "index.html",
+        ),
+        "utf8",
+      ),
+    ).resolves.toBe("<h1>Todo</h1>");
+
+    const readResult = await read_artifact_file({
+      path: "external/artifacts/todo-app/ui/index.html",
+    });
+    expect(readResult).toEqual({
+      path: "todo-app/ui/index.html",
+      content: "<h1>Todo</h1>",
+      encoding: "utf8",
+    });
+  });
+
+  test("rejects paths that escape the artifacts root", async () => {
+    experimentManager.set("artifacts", true);
+
+    await expect(
+      write_artifact_file({ path: "../outside.txt", content: "no" }),
+    ).rejects.toThrow("cannot contain '..'");
+  });
+
+  test("experiment gates model-facing artifact tools", async () => {
+    const disabled = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+    );
+    expect(disabled.loadedToolNames).not.toContain("read_artifact_file");
+    expect(disabled.loadedToolNames).not.toContain("write_artifact_file");
+
+    experimentManager.set("artifacts", true);
+    const enabled = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+    );
+    expect(enabled.loadedToolNames).toContain("read_artifact_file");
+    expect(enabled.loadedToolNames).toContain("write_artifact_file");
+  });
+});

--- a/src/tools/descriptions/ReadArtifactFile.md
+++ b/src/tools/descriptions/ReadArtifactFile.md
@@ -1,0 +1,1 @@
+Read a file from the Letta Code Desktop artifacts directory (`~/.letta/artifacts`). Paths must be relative to the artifacts root, such as `todo-app/ui/index.html`. Use this to inspect existing artifact files before editing them. Supports `utf8` (default) and `base64` for binary files.

--- a/src/tools/descriptions/WriteArtifactFile.md
+++ b/src/tools/descriptions/WriteArtifactFile.md
@@ -1,0 +1,1 @@
+Write a file under the Letta Code Desktop artifacts directory (`~/.letta/artifacts`). Paths must be relative to the artifacts root, such as `todo-app/ui/index.html`. Use this to create or update artifact files. The tool creates parent directories as needed and rejects paths that escape the artifacts root.

--- a/src/tools/impl/artifact-files.ts
+++ b/src/tools/impl/artifact-files.ts
@@ -1,0 +1,128 @@
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { experimentManager } from "@/experiments/manager";
+import { validateRequiredParams } from "./validation";
+
+const ARTIFACTS_REFERENCE_ROOT = "external/artifacts/";
+const ARTIFACTS_ALIAS_ROOT = "artifacts/";
+const MAX_READ_FILE_BYTES = 10 * 1024 * 1024;
+
+type ArtifactEncoding = "utf8" | "base64";
+
+interface ReadArtifactFileArgs {
+  path: string;
+  encoding?: ArtifactEncoding;
+}
+
+interface WriteArtifactFileArgs {
+  path: string;
+  content: string;
+  encoding?: ArtifactEncoding;
+}
+
+interface ReadArtifactFileResult {
+  path: string;
+  content: string;
+  encoding: ArtifactEncoding;
+}
+
+interface WriteArtifactFileResult {
+  path: string;
+  bytes: number;
+  message: string;
+}
+
+function assertArtifactsExperimentEnabled(toolName: string): void {
+  if (!experimentManager.isEnabled("artifacts")) {
+    throw new Error(
+      `${toolName}: artifacts experiment is disabled. Enable it with /experiments in Letta Code Desktop.`,
+    );
+  }
+}
+
+function getArtifactsRoot(): string {
+  const override = process.env.LETTA_ARTIFACTS_DIR?.trim();
+  if (override) return override;
+  return join(homedir(), ".letta", "artifacts");
+}
+
+function normalizeArtifactRelativePath(path: string): string {
+  const withoutLeadingSlash = path.replace(/^\/+/, "").replace(/\\/g, "/");
+  let normalized = withoutLeadingSlash;
+  if (normalized.startsWith(ARTIFACTS_REFERENCE_ROOT)) {
+    normalized = normalized.slice(ARTIFACTS_REFERENCE_ROOT.length);
+  } else if (normalized.startsWith(ARTIFACTS_ALIAS_ROOT)) {
+    normalized = normalized.slice(ARTIFACTS_ALIAS_ROOT.length);
+  }
+
+  if (!normalized) {
+    throw new Error("artifact path must be a non-empty relative path");
+  }
+  if (isAbsolute(normalized)) {
+    throw new Error("artifact path must be relative to ~/.letta/artifacts");
+  }
+  if (normalized.split("/").some((part) => part === "..")) {
+    throw new Error("artifact path cannot contain '..'");
+  }
+  return normalized;
+}
+
+function resolveArtifactPath(path: string): {
+  absolutePath: string;
+  relativePath: string;
+} {
+  const relativePath = normalizeArtifactRelativePath(path);
+  const root = getArtifactsRoot();
+  const absolutePath = resolve(root, relativePath);
+  const relativeToRoot = relative(root, absolutePath);
+  if (relativeToRoot.startsWith("..") || isAbsolute(relativeToRoot)) {
+    throw new Error("artifact path must resolve inside ~/.letta/artifacts");
+  }
+  return { absolutePath, relativePath };
+}
+
+function getEncoding(value: ArtifactEncoding | undefined): ArtifactEncoding {
+  return value === "base64" ? "base64" : "utf8";
+}
+
+export async function read_artifact_file(
+  args: ReadArtifactFileArgs,
+): Promise<ReadArtifactFileResult> {
+  assertArtifactsExperimentEnabled("read_artifact_file");
+  validateRequiredParams(args, ["path"], "read_artifact_file");
+  const { absolutePath, relativePath } = resolveArtifactPath(args.path);
+  const encoding = getEncoding(args.encoding);
+  const stats = await stat(absolutePath);
+  if (!stats.isFile()) {
+    throw new Error(`read_artifact_file: ${relativePath} is not a file`);
+  }
+  if (stats.size > MAX_READ_FILE_BYTES) {
+    throw new Error(
+      `read_artifact_file: file is too large to read (${stats.size} bytes)`,
+    );
+  }
+  const buffer = await readFile(absolutePath);
+  return {
+    path: relativePath,
+    content: buffer.toString(encoding),
+    encoding,
+  };
+}
+
+export async function write_artifact_file(
+  args: WriteArtifactFileArgs,
+): Promise<WriteArtifactFileResult> {
+  assertArtifactsExperimentEnabled("write_artifact_file");
+  validateRequiredParams(args, ["path", "content"], "write_artifact_file");
+  const { absolutePath, relativePath } = resolveArtifactPath(args.path);
+  const encoding = getEncoding(args.encoding);
+  const buffer = Buffer.from(args.content, encoding);
+  await mkdir(dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, buffer);
+  return {
+    path: relativePath,
+    bytes: buffer.byteLength,
+    message: `Wrote artifact file ${relativePath} (${buffer.byteLength} bytes).`,
+  };
+}

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -19,6 +19,7 @@ import {
 import { getActiveChannelIds } from "@/channels/registry";
 import type { ChannelTurnSource } from "@/channels/types";
 import { INTERRUPTED_BY_USER } from "@/constants";
+import { experimentManager } from "@/experiments/manager";
 import {
   runPostToolUseFailureHooks,
   runPostToolUseHooks,
@@ -318,6 +319,10 @@ export function filterBuiltInToolNamesByClientAllowlist(
 }
 
 const WORKTREE_TOOL_NAMES = new Set<ToolName>(["EnterWorktree"]);
+const ARTIFACT_TOOL_NAMES: ToolName[] = [
+  "read_artifact_file",
+  "write_artifact_file",
+];
 
 function shouldIncludeWorktreeTool(): boolean {
   try {
@@ -333,6 +338,19 @@ function filterWorktreeTools(toolNames: ToolName[]): ToolName[] {
   }
 
   return toolNames.filter((name) => !WORKTREE_TOOL_NAMES.has(name));
+}
+
+function resolveArtifactToolNames(toolNames: ToolName[]): ToolName[] {
+  const artifactToolSet = new Set<ToolName>(ARTIFACT_TOOL_NAMES);
+  const withoutArtifactTools = toolNames.filter(
+    (name) => !artifactToolSet.has(name),
+  );
+
+  if (!experimentManager.isEnabled("artifacts")) {
+    return withoutArtifactTools;
+  }
+
+  return [...withoutArtifactTools, ...ARTIFACT_TOOL_NAMES];
 }
 
 function filterExternalToolsByClientAllowlist(
@@ -537,6 +555,7 @@ const TOOL_PERMISSIONS: Record<
   MessageChannel: { requiresApproval: false },
   MultiEdit: { requiresApproval: true },
   Read: { requiresApproval: false },
+  read_artifact_file: { requiresApproval: false },
   view_image: { requiresApproval: false },
   ViewImage: { requiresApproval: false },
   ReadLSP: { requiresApproval: false },
@@ -548,6 +567,7 @@ const TOOL_PERMISSIONS: Record<
   TaskUpdate: { requiresApproval: false },
   TodoWrite: { requiresApproval: false },
   Write: { requiresApproval: true },
+  write_artifact_file: { requiresApproval: false },
   shell_command: { requiresApproval: true },
   exec_command: { requiresApproval: true },
   write_stdin: { requiresApproval: false },
@@ -1653,6 +1673,8 @@ async function resolveBaseToolNamesForModel(
   }
 
   baseToolNames = filterWorktreeTools(baseToolNames);
+
+  baseToolNames = resolveArtifactToolNames(baseToolNames);
 
   // Append channel tool if channels are active
   baseToolNames = maybeAppendChannelTools(

--- a/src/tools/schemas/ReadArtifactFile.json
+++ b/src/tools/schemas/ReadArtifactFile.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string",
+      "description": "Path relative to ~/.letta/artifacts, e.g. todo-app/ui/index.html. The aliases artifacts/... and external/artifacts/... are accepted."
+    },
+    "encoding": {
+      "type": "string",
+      "enum": ["utf8", "base64"],
+      "description": "Encoding for the returned content. Defaults to utf8."
+    }
+  },
+  "required": ["path"],
+  "additionalProperties": false
+}

--- a/src/tools/schemas/WriteArtifactFile.json
+++ b/src/tools/schemas/WriteArtifactFile.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string",
+      "description": "Path relative to ~/.letta/artifacts, e.g. todo-app/ui/index.html. The aliases artifacts/... and external/artifacts/... are accepted."
+    },
+    "content": {
+      "type": "string",
+      "description": "File content as a utf8 string or base64-encoded bytes, depending on encoding."
+    },
+    "encoding": {
+      "type": "string",
+      "enum": ["utf8", "base64"],
+      "description": "Encoding of content. Defaults to utf8."
+    }
+  },
+  "required": ["path", "content"],
+  "additionalProperties": false
+}

--- a/src/tools/tool-definitions.ts
+++ b/src/tools/tool-definitions.ts
@@ -22,6 +22,7 @@ import MemoryApplyPatchDescription from "./descriptions/MemoryApplyPatch.md";
 import MessageChannelDescription from "./descriptions/MessageChannel.md";
 import MultiEditDescription from "./descriptions/MultiEdit.md";
 import ReadDescription from "./descriptions/Read.md";
+import ReadArtifactFileDescription from "./descriptions/ReadArtifactFile.md";
 import ReadFileCodexDescription from "./descriptions/ReadFileCodex.md";
 import ReadFileGeminiDescription from "./descriptions/ReadFileGemini.md";
 import ReadLSPDescription from "./descriptions/ReadLSP.md";
@@ -44,10 +45,12 @@ import UpdateGoalDescription from "./descriptions/UpdateGoal.md";
 import UpdatePlanDescription from "./descriptions/UpdatePlan.md";
 import ViewImageDescription from "./descriptions/ViewImage.md";
 import WriteDescription from "./descriptions/Write.md";
+import WriteArtifactFileDescription from "./descriptions/WriteArtifactFile.md";
 import WriteFileGeminiDescription from "./descriptions/WriteFileGemini.md";
 import WriteStdinDescription from "./descriptions/WriteStdin.md";
 import WriteTodosGeminiDescription from "./descriptions/WriteTodosGemini.md";
 import { apply_patch } from "./impl/apply-patch";
+import { read_artifact_file, write_artifact_file } from "./impl/artifact-files";
 import { ask_user_question } from "./impl/ask-user-question";
 import { bash } from "./impl/bash";
 import { bash_output } from "./impl/bash-output";
@@ -118,6 +121,7 @@ import MemoryApplyPatchSchema from "./schemas/MemoryApplyPatch.json";
 import MessageChannelSchema from "./schemas/MessageChannel.json";
 import MultiEditSchema from "./schemas/MultiEdit.json";
 import ReadSchema from "./schemas/Read.json";
+import ReadArtifactFileSchema from "./schemas/ReadArtifactFile.json";
 import ReadFileCodexSchema from "./schemas/ReadFileCodex.json";
 import ReadFileGeminiSchema from "./schemas/ReadFileGemini.json";
 import ReadLSPSchema from "./schemas/ReadLSP.json";
@@ -140,6 +144,7 @@ import UpdateGoalSchema from "./schemas/UpdateGoal.json";
 import UpdatePlanSchema from "./schemas/UpdatePlan.json";
 import ViewImageSchema from "./schemas/ViewImage.json";
 import WriteSchema from "./schemas/Write.json";
+import WriteArtifactFileSchema from "./schemas/WriteArtifactFile.json";
 import WriteFileGeminiSchema from "./schemas/WriteFileGemini.json";
 import WriteStdinSchema from "./schemas/WriteStdin.json";
 import WriteTodosGeminiSchema from "./schemas/WriteTodosGemini.json";
@@ -252,6 +257,11 @@ const toolDefinitions = {
     description: ReadDescription.trim(),
     impl: read,
   }),
+  read_artifact_file: defineTool({
+    schema: ReadArtifactFileSchema,
+    description: ReadArtifactFileDescription.trim(),
+    impl: read_artifact_file,
+  }),
   view_image: defineTool({
     schema: ViewImageSchema,
     description: ViewImageDescription.trim(),
@@ -307,6 +317,11 @@ const toolDefinitions = {
     schema: WriteSchema,
     description: WriteDescription.trim(),
     impl: write,
+  }),
+  write_artifact_file: defineTool({
+    schema: WriteArtifactFileSchema,
+    description: WriteArtifactFileDescription.trim(),
+    impl: write_artifact_file,
   }),
   shell_command: defineTool({
     schema: ShellCommandSchema,

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -7,6 +7,7 @@ import { getSupportedChannelIds } from "@/channels/plugin-registry";
 import { getChannelRegistry } from "@/channels/registry";
 import { getRoutesForChannel, loadRoutes } from "@/channels/routing";
 import type { ChannelTurnSource, SupportedChannelId } from "@/channels/types";
+import { experimentManager } from "@/experiments/manager";
 import { buildModInvocationContext } from "@/mods/context";
 import type { ModEvents } from "@/mods/event-emitter";
 import type { ModContext } from "@/mods/types";
@@ -38,6 +39,22 @@ import {
 import type { ToolName } from "./tool-definitions";
 
 // Toolset definitions from manager.ts (single source of truth)
+
+const ARTIFACT_TOOL_NAMES: ToolName[] = [
+  "read_artifact_file",
+  "write_artifact_file",
+];
+
+function appendArtifactToolsIfEnabled(toolNames: ToolName[]): ToolName[] {
+  const artifactToolSet = new Set<ToolName>(ARTIFACT_TOOL_NAMES);
+  const withoutArtifactTools = toolNames.filter(
+    (name) => !artifactToolSet.has(name),
+  );
+  if (!experimentManager.isEnabled("artifacts")) {
+    return withoutArtifactTools;
+  }
+  return [...withoutArtifactTools, ...ARTIFACT_TOOL_NAMES];
+}
 // Keep these as direct references at call-sites (not top-level aliases) to avoid
 // temporal-dead-zone issues under circular import initialization.
 
@@ -153,7 +170,7 @@ function getToolNamesForToolset(
     tools.push("MessageChannel" as ToolName);
   }
 
-  return tools;
+  return appendArtifactToolsIfEnabled(tools);
 }
 
 export function getGoalToolNamesForToolset(

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -34,6 +34,7 @@ import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs"
 export type DmPolicy = "pairing" | "allowlist" | "open";
 
 export type ExperimentId =
+  | "artifacts"
   | "conversation_titles"
   | "desktop_conversation_bootstrap"
   | "diffs"


### PR DESCRIPTION
Expose read_artifact_file and write_artifact_file behind an artifacts experiment so Desktop can gate artifact UI and model tools together.

👾 Generated with [Letta Code](https://letta.com)