### PR TITLE
LET-9295: keep Slack reasoning out of task rows

### DIFF
--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -1662,12 +1662,6 @@ test("slack adapter streams native task progress and clears thread status", asyn
         status: "complete",
       },
       {
-        type: "task_update",
-        id: "task_reasoning_1",
-        title: "Finished",
-        status: "complete",
-      },
-      {
         type: "plan_update",
         title: "Completed",
       },
@@ -1678,6 +1672,118 @@ test("slack adapter streams native task progress and clears thread status", asyn
     thread_ts: "1712790000.000050",
     status: "",
   });
+});
+
+test("slack adapter keeps reasoning updates out of concrete task rows", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+  const source = {
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    chatType: "channel" as const,
+    senderId: "U123",
+    senderTeamId: "T123",
+    messageId: "1712800000.000100",
+    threadId: "1712790000.000050",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  };
+
+  await adapter.start();
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-1",
+    sources: [source],
+    kind: "tool",
+    state: "started",
+    message: "Reading files",
+    toolCallId: "call-read",
+    toolName: "read_file",
+  });
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-1",
+    sources: [source],
+    kind: "tool",
+    state: "completed",
+    message: "Read files",
+    toolCallId: "call-read",
+  });
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-1",
+    sources: [source],
+    kind: "thinking",
+    state: "updated",
+    message: "Thinking",
+  });
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-1",
+    sources: [source],
+    kind: "tool",
+    state: "started",
+    message: "Running command",
+    toolCallId: "call-bash",
+    toolName: "exec_command",
+  });
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "finished",
+    batchId: "batch-1",
+    outcome: "completed",
+    sources: [source],
+  });
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  const startCalls = writeClient?.chat.startStream.mock
+    .calls as unknown as Array<[{ chunks?: Array<Record<string, unknown>> }]>;
+  const appendCalls = writeClient?.chat.appendStream.mock
+    .calls as unknown as Array<[{ chunks?: Array<Record<string, unknown>> }]>;
+  const stopCalls = writeClient?.chat.stopStream.mock.calls as unknown as Array<
+    [{ chunks?: Array<Record<string, unknown>> }]
+  >;
+  expect(appendCalls.map(([call]) => call.chunks)).toEqual(
+    expect.arrayContaining([
+      [
+        {
+          type: "plan_update",
+          title: "Thinking",
+        },
+      ],
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "task_call-bash",
+          title: "Running",
+          status: "in_progress",
+        }),
+      ]),
+    ]),
+  );
+  const streamedChunks = [
+    ...startCalls.flatMap(([call]) => call.chunks ?? []),
+    ...appendCalls.flatMap(([call]) => call.chunks ?? []),
+    ...stopCalls.flatMap(([call]) => call.chunks ?? []),
+  ];
+  expect(streamedChunks).not.toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ id: expect.stringMatching(/^task_reasoning/) }),
+    ]),
+  );
+  expect(streamedChunks).not.toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ title: "Finished" }),
+      expect.objectContaining({ title: "Thought" }),
+    ]),
+  );
 });
 
 test("slack adapter does not start thread progress in direct messages", async () => {

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -226,8 +226,6 @@ function resolveSlackAppModule(value: unknown): SlackAppConstructor | null {
   return isConstructorFunction<SlackAppConstructor>(app) ? app : null;
 }
 const INITIAL_SLACK_THREAD_HISTORY_LIMIT = 20;
-const SLACK_REASONING_TASK_ID_PREFIX = "task_reasoning_";
-
 function resolveSlackAppConstructor(mod: SlackBoltModule): SlackAppConstructor {
   const defaultExport =
     mod && typeof mod === "object" ? Reflect.get(mod, "default") : undefined;
@@ -441,8 +439,6 @@ type SlackProgressCardEntry = {
   toolTasksById?: Map<string, SlackProgressToolTask>;
   sentTaskDetailsById?: Map<string, string>;
   reasoningActive?: boolean;
-  activeReasoningTaskId?: string;
-  reasoningTaskSequence?: number;
   pendingStreamChunks?: SlackStreamChunk[];
   hiddenToolCallIds?: Set<string>;
   lastSentText?: string;
@@ -796,9 +792,6 @@ function formatSlackToolTitleForTerminalStatus(
   title: string,
   status: SlackStreamTaskStatus,
 ): string {
-  if (status === "complete" && (title === "Thinking" || title === "Working")) {
-    return getCompletedSlackReasoningTaskTitle(title);
-  }
   if (title === "Running") {
     return status === "complete" ? "Ran" : "Running";
   }
@@ -962,92 +955,6 @@ function buildSlackPlanUpdateChunk(
   };
 }
 
-function getSlackReasoningTaskTitle(entry: SlackProgressCardEntry): string {
-  return entry.reasoningActive ? "Thinking" : "Working";
-}
-
-function getCompletedSlackReasoningTaskTitle(title: string): string {
-  if (title === "Thinking") {
-    return "Thought";
-  }
-  if (title === "Working") {
-    return "Finished";
-  }
-  return title;
-}
-
-function isSlackReasoningTaskId(id: string): boolean {
-  return id.startsWith(SLACK_REASONING_TASK_ID_PREFIX);
-}
-
-function hasRunningRealSlackTask(entry: SlackProgressCardEntry): boolean {
-  for (const task of entry.toolTasksById?.values() ?? []) {
-    if (isSlackReasoningTaskId(task.id)) {
-      continue;
-    }
-    if (task.status === "in_progress" || task.status === "pending") {
-      return true;
-    }
-  }
-  return false;
-}
-
-function ensureSlackReasoningTask(
-  entry: SlackProgressCardEntry,
-): SlackStreamChunk[] {
-  if (entry.status !== "processing" || hasRunningRealSlackTask(entry)) {
-    return [];
-  }
-
-  entry.toolTasksById ??= new Map();
-  const title = getSlackReasoningTaskTitle(entry);
-  const prevTask = entry.activeReasoningTaskId
-    ? entry.toolTasksById.get(entry.activeReasoningTaskId)
-    : undefined;
-  if (prevTask?.status === "in_progress" && prevTask.title === title) {
-    return [];
-  }
-
-  const id =
-    prevTask?.status === "in_progress"
-      ? prevTask.id
-      : `${SLACK_REASONING_TASK_ID_PREFIX}${(entry.reasoningTaskSequence ?? 0) + 1}`;
-  if (prevTask?.status !== "in_progress") {
-    entry.reasoningTaskSequence = (entry.reasoningTaskSequence ?? 0) + 1;
-    entry.activeReasoningTaskId = id;
-  }
-
-  const task: SlackProgressToolTask = {
-    id,
-    kind: "thinking",
-    title,
-    status: "in_progress",
-  };
-  entry.toolTasksById.set(id, task);
-  return [toSlackTaskUpdateChunk(task)];
-}
-
-function completeSlackReasoningTask(
-  entry: SlackProgressCardEntry,
-): SlackStreamChunk[] {
-  const activeReasoningTaskId = entry.activeReasoningTaskId;
-  const prevTask = activeReasoningTaskId
-    ? entry.toolTasksById?.get(activeReasoningTaskId)
-    : undefined;
-  if (!prevTask || prevTask.status === "complete") {
-    return [];
-  }
-
-  const task: SlackProgressToolTask = {
-    ...prevTask,
-    title: getCompletedSlackReasoningTaskTitle(prevTask.title),
-    status: "complete",
-  };
-  entry.toolTasksById?.set(prevTask.id, task);
-  entry.activeReasoningTaskId = undefined;
-  return [toSlackTaskUpdateChunk(task)];
-}
-
 function resolveSlackToolActionTaskId(
   update: ChannelTurnProgressEvent,
 ): string | null {
@@ -1095,13 +1002,10 @@ function buildSlackStreamProgressChunks(
     entry.reasoningActive = reasoningActive;
     // Do not create a stream for reasoning-only turns. If a stream already
     // exists because visible tools ran earlier in the turn, update the native
-    // plan/header title to reflect current reasoning.
-    const reasoningChunks =
-      entry.mode === "stream" ? ensureSlackReasoningTask(entry) : [];
+    // plan/header title without adding synthetic task rows. Synthetic rows
+    // become stale next to concrete tool rows because Slack keeps every task id.
     const chunks =
-      entry.mode === "stream"
-        ? [buildSlackPlanUpdateChunk(entry), ...reasoningChunks]
-        : [];
+      entry.mode === "stream" ? [buildSlackPlanUpdateChunk(entry)] : [];
     debugSlackProgress(
       `[REASONING] kind=${update.kind} state=${update.state} active=${reasoningActive} mode=${entry.mode ?? "none"} chunks=${describeSlackStreamChunks(chunks)}`,
     );
@@ -1158,14 +1062,9 @@ function buildSlackStreamProgressChunks(
   };
   entry.toolTasksById ??= new Map();
   const chunks: SlackStreamChunk[] = [];
-  if (!prevTask && status === "in_progress") {
-    entry.reasoningActive = false;
-    chunks.push(...completeSlackReasoningTask(entry));
-  }
+  entry.reasoningActive = false;
 
   entry.toolTasksById.set(id, task);
-
-  const reasoningChunks = ensureSlackReasoningTask(entry);
 
   // Only include details in the chunk when they actually changed.
   // Slack's streaming API accumulates the details field across
@@ -1184,7 +1083,6 @@ function buildSlackStreamProgressChunks(
       ? { details }
       : {}),
   });
-  chunks.push(...reasoningChunks);
 
   debugSlackProgress(
     `[BUILD-CHUNKS] id=${id} title=${title} status=${status} details=${details ?? "none"} detailsChanged=${detailsChanged} chunks=${describeSlackStreamChunks(chunks)}`,
@@ -2244,7 +2142,7 @@ export function createSlackAdapter(
     // For thinking/responding events, track header state without creating
     // stream chunks — we only want a streaming block when actual tools are
     // called. Still save the entry so an existing stream can update its plan
-    // title, or a later tool can start from the latest reasoning state.
+    // title, and the next tool update can clear the transient state.
     const isReasoningEvent =
       options.update?.kind === "thinking" ||
       options.update?.kind === "responding";
@@ -2265,10 +2163,10 @@ export function createSlackAdapter(
       activeProgressCardKeyByReplyKey.set(replyKey, key);
     }
 
-    // Reasoning-only updates are tracked so a later tool start can include a
-    // completed Thinking row, but they must not start/throttle the Slack stream.
-    // Otherwise the first real tool can be delayed by the reasoning timestamp
-    // and appear only once it has already completed.
+    // Reasoning-only updates with no stream chunks are status state only; they
+    // must not start/throttle the Slack stream. Otherwise the first real tool
+    // can be delayed by the reasoning timestamp and appear only once it has
+    // already completed.
     if (isReasoningEvent && streamChunks.length === 0) {
       debugSlackProgress(
         `[UPSERT-REASONING-NO-FLUSH] kind=${options.update?.kind} state=${options.update?.state}`,


### PR DESCRIPTION
## Summary
- Treat Slack thinking/responding progress as plan header updates instead of synthetic task rows.
- Remove terminal task_reasoning rows so concrete tool progress no longer alternates with generic Finished/Thought placeholders.
- Add regression coverage for thinking between concrete tool calls.

## Test plan
- [x] bun test src/channels/slack-adapter.test.ts
- [x] bunx --bun @biomejs/biome@2.2.5 check src/channels/slack/adapter.ts src/channels/slack-adapter.test.ts
- [x] bun run typecheck

Review requested from @4shub.

👾 Generated with [Letta Code](https://letta.com)