### PR TITLE
fix: detect orphaned CLI process and exit when parent dies

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,7 @@ import { startStartupAutoUpdateCheck } from "./startup-auto-update";
 import { loadTools } from "./tools/manager";
 import { clearPersistedClientToolRules } from "./tools/toolset";
 import { debugLog, debugWarn, isDebugEnabled } from "./utils/debug";
+import { startOrphanDetection } from "./utils/orphan-detection";
 import { markMilestone } from "./utils/timing";
 
 // Stable empty array constants to prevent new references on every render
@@ -638,6 +639,11 @@ async function getLocalBackendStartupFallbackSession(
 
 async function main(): Promise<void> {
   markMilestone("CLI_START");
+
+  // Detect if the parent process (Desktop, terminal) dies and we get
+  // orphaned to PID 1. Without this, a detached CLI can run for days
+  // accumulating memory after the parent exits without cleanly killing it.
+  startOrphanDetection();
 
   const rawCliArgs = process.argv.slice(2);
   let subcommandArgs = rawCliArgs;

--- a/src/utils/orphan-detection.ts
+++ b/src/utils/orphan-detection.ts
@@ -1,0 +1,45 @@
+/**
+ * Parent-death detection for the Letta Code CLI process.
+ *
+ * When Desktop (or a terminal) spawns the CLI with `detached: true` and then
+ * exits without cleanly sending SIGTERM — a crash, force-quit, or terminal
+ * close where bun ignores SIGHUP — the CLI is reparented to PID 1 (launchd /
+ * init) and keeps running indefinitely. Over days this accumulates enormous
+ * memory through swap and compression, eventually triggering "out of
+ * application memory" alerts.
+ *
+ * This watcher polls `process.ppid` once per second. If the parent becomes
+ * PID 1 (and wasn't already at startup), the process exits gracefully.
+ */
+
+let watcher: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Start watching for parent-process death. If the parent was already PID 1
+ * at startup (e.g. launched by a daemon), no watcher is installed — the
+ * process is expected to manage its own lifecycle.
+ */
+export function startOrphanDetection(): void {
+  const initialParent = process.ppid;
+
+  // If we were already orphaned at startup, there's nothing to detect.
+  if (initialParent === 1) return;
+
+  watcher = setInterval(() => {
+    if (process.ppid === 1) {
+      stopOrphanDetection();
+      process.exit(0);
+    }
+  }, 1_000);
+
+  // Don't keep the event loop alive solely for this timer.
+  watcher.unref();
+}
+
+/** Stop the orphan-detection watcher. */
+export function stopOrphanDetection(): void {
+  if (watcher !== null) {
+    clearInterval(watcher);
+    watcher = null;
+  }
+}


### PR DESCRIPTION
## Summary

- Add parent-death detection to the CLI process. When the parent (Desktop, terminal) dies and the CLI is reparented to PID 1 (launchd/init), the process exits gracefully instead of running indefinitely.

## Problem

Desktop spawns the CLI with `detached: true` (intentional — allows killing the whole process group via `kill(-pgid)`). When Desktop exits without cleanly sending SIGTERM — a crash, force-quit, or terminal close where bun ignores SIGHUP — the CLI is orphaned to PID 1 and keeps running forever. Over days this accumulates memory through swap and compression, eventually triggering "out of application memory" alerts.

Observed in the wild: a 5-day-old orphaned `bun run src/index.ts` process consuming ~5GB RSS and 18GB of swap on a 24GB machine.

## Fix

A lightweight `setInterval` polls `process.ppid` once per second. If the parent becomes PID 1 (and was not already PID 1 at startup — e.g. launched by a daemon), the process exits. The timer is `unref`-ed so it does not keep the event loop alive.

## Test plan

- [ ] Launch CLI from a terminal, close the terminal, verify the CLI exits within ~1s
- [ ] Launch CLI from Desktop (dev mode), force-quit Desktop, verify the CLI exits
- [ ] Launch CLI with parent already PID 1, verify no watcher is installed and the process runs normally

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>