### PR TITLE
fix(telemetry): add version and platform to reflection events

### DIFF
--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -99,6 +99,8 @@ export interface ReflectionStartData {
   conversation_id?: string;
   start_message_id?: string;
   end_message_id?: string;
+  version?: string;
+  platform?: string;
 }
 
 export interface ReflectionEndData {
@@ -109,6 +111,8 @@ export interface ReflectionEndData {
   error?: string;
   step_count?: number;
   duration_ms?: number;
+  version?: string;
+  platform?: string;
 }
 
 export function isLettaCodeDesktopRuntime(
@@ -712,6 +716,8 @@ class TelemetryManager {
       conversation_id: options?.conversationId,
       start_message_id: options?.startMessageId,
       end_message_id: options?.endMessageId,
+      version: getVersion(),
+      platform: process.platform,
     };
     this.track("reflection_start", data);
   }
@@ -738,6 +744,8 @@ class TelemetryManager {
       error: options?.error,
       step_count: options?.stepCount,
       duration_ms: options?.durationMs,
+      version: getVersion(),
+      platform: process.platform,
     };
     this.track("reflection_end", data);
   }


### PR DESCRIPTION
## Summary
- Add `version` and `platform` to `ReflectionStartData` and `ReflectionEndData` interfaces
- Populate them with `getVersion()` and `process.platform` in `trackReflectionStart()` and `trackReflectionEnd()`
- These fields were only on `session_start` events; now they flow through reflection events too so they appear in PostHog and can be used in alert filters

## Test plan
- [x] `bun run typecheck` passes
- [ ] Verify reflection_end events in PostHog show non-null `version` and `platform` after deploy

👾 Generated with [Letta Code](https://letta.com)