### PR TITLE
feat(local): autodetect local model endpoints

### DIFF
--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -40,6 +40,7 @@ export interface PiProviderSpec {
   fallbackApiKey?: string;
   headers?: () => Record<string, string> | undefined;
   localModelDiscovery?: "ollama" | "openai-compatible";
+  autoDetectLocalEndpoint?: boolean;
   envConfigured?: () => boolean;
   createCustomModel?: boolean;
   catalogModelHandle?: (model: Model<Api>) => string | undefined;
@@ -55,6 +56,7 @@ interface PiProviderOverride {
   fallbackApiKey?: string;
   headers?: () => Record<string, string> | undefined;
   localModelDiscovery?: "ollama" | "openai-compatible";
+  autoDetectLocalEndpoint?: boolean;
   envConfigured?: () => boolean;
   createCustomModel?: boolean;
   catalogModelHandle?: (model: Model<Api>) => string | undefined;
@@ -237,6 +239,9 @@ function makePiProviderSpec(provider: KnownProvider): PiProviderSpec {
     ...(override.localModelDiscovery
       ? { localModelDiscovery: override.localModelDiscovery }
       : {}),
+    ...(override.autoDetectLocalEndpoint !== undefined
+      ? { autoDetectLocalEndpoint: override.autoDetectLocalEndpoint }
+      : {}),
     envConfigured:
       override.envConfigured ?? (() => getEnvApiKey(provider) !== undefined),
     ...(override.createCustomModel !== undefined
@@ -259,6 +264,7 @@ const LOCAL_ENDPOINT_PROVIDER_SPECS: readonly PiProviderSpec[] = [
     baseUrlEnv: () => process.env.OLLAMA_BASE_URL,
     fallbackApiKey: "not-needed",
     localModelDiscovery: "ollama",
+    autoDetectLocalEndpoint: true,
     envConfigured: () =>
       hasEnvValue(process.env.OLLAMA_LOCAL_API_KEY) ||
       hasEnvValue(process.env.OLLAMA_BASE_URL),
@@ -289,6 +295,7 @@ const LOCAL_ENDPOINT_PROVIDER_SPECS: readonly PiProviderSpec[] = [
     baseUrlEnv: () => process.env.LMSTUDIO_BASE_URL,
     fallbackApiKey: "not-needed",
     localModelDiscovery: "openai-compatible",
+    autoDetectLocalEndpoint: true,
     envConfigured: () =>
       hasEnvValue(process.env.LMSTUDIO_API_KEY) ||
       hasEnvValue(process.env.LMSTUDIO_BASE_URL),
@@ -305,6 +312,7 @@ const LOCAL_ENDPOINT_PROVIDER_SPECS: readonly PiProviderSpec[] = [
       process.env.LLAMA_CPP_BASE_URL ?? process.env.LLAMACPP_BASE_URL,
     fallbackApiKey: "not-needed",
     localModelDiscovery: "openai-compatible",
+    autoDetectLocalEndpoint: true,
     envConfigured: () =>
       hasEnvValue(process.env.LLAMA_CPP_API_KEY) ||
       hasEnvValue(process.env.LLAMA_CPP_BASE_URL) ||

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -1228,17 +1228,47 @@ describe("local backend pi transcript", () => {
       await listLocalModels(storageDir, { fetch: fetchImpl })
     ).map((model) => model.handle);
 
-    expect(calls).toEqual([
-      "http://localhost:11434/v1/models",
-      "http://localhost:11434/api/tags",
-      "http://127.0.0.1:1234/v1/models",
-      "http://localhost:8080/v1/models",
-    ]);
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        "http://localhost:11434/v1/models",
+        "http://localhost:11434/api/tags",
+        "http://127.0.0.1:1234/v1/models",
+        "http://localhost:8080/v1/models",
+      ]),
+    );
     expect(handles).toContain("ollama/qwen2.5-coder:7b");
     expect(handles).toContain("lmstudio/openai/gpt-oss-20b");
     expect(handles.some((handle) => handle.startsWith("llama.cpp/"))).toBe(
       false,
     );
+  });
+
+  test("auto-detects reachable local model endpoints alongside saved providers", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-pi-autodetect-with-provider-"),
+    );
+    await createOrUpdateLocalProvider({
+      providerType: "anthropic",
+      providerName: "lc-anthropic",
+      apiKey: "dummy",
+      storageDir,
+    });
+    const fetchImpl = (async (input: unknown) => {
+      const url = typeof input === "string" ? input : String(input);
+      if (url === "http://127.0.0.1:1234/v1/models") {
+        return new Response(JSON.stringify({ data: [{ id: "local-model" }] }), {
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const handles = (
+      await listLocalModels(storageDir, { fetch: fetchImpl })
+    ).map((model) => model.handle);
+
+    expect(handles).toContain("anthropic/claude-opus-4-7");
+    expect(handles).toContain("lmstudio/local-model");
   });
 
   test("discovers configured LM Studio models from OpenAI-compatible catalog", async () => {
@@ -1256,17 +1286,22 @@ describe("local backend pi transcript", () => {
     const fetchImpl = (async (input: unknown) => {
       const url = typeof input === "string" ? input : String(input);
       calls.push(url);
-      return new Response(
-        JSON.stringify({ data: [{ id: "openai/gpt-oss-20b" }] }),
-        { headers: { "content-type": "application/json" } },
-      );
+      if (url === "http://127.0.0.1:1234/v1/models") {
+        return new Response(
+          JSON.stringify({ data: [{ id: "openai/gpt-oss-20b" }] }),
+          { headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
     }) as unknown as typeof fetch;
 
     const handles = (
       await listLocalModels(storageDir, { fetch: fetchImpl })
     ).map((model) => model.handle);
 
-    expect(calls).toEqual(["http://127.0.0.1:1234/v1/models"]);
+    expect(calls).toEqual(
+      expect.arrayContaining(["http://127.0.0.1:1234/v1/models"]),
+    );
     expect(handles).toContain("lmstudio/openai/gpt-oss-20b");
     expect(handles).not.toContain("lmstudio/google/gemma-3n-e4b");
   });
@@ -1299,10 +1334,12 @@ describe("local backend pi transcript", () => {
       await listLocalModels(storageDir, { fetch: fetchImpl })
     ).map((model) => model.handle);
 
-    expect(calls).toEqual([
-      "http://localhost:11434/v1/models",
-      "http://localhost:11434/api/tags",
-    ]);
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        "http://localhost:11434/v1/models",
+        "http://localhost:11434/api/tags",
+      ]),
+    );
     expect(handles).toContain("ollama/qwen2.5-coder:7b");
     expect(handles).not.toContain("ollama/llama2");
   });
@@ -1345,7 +1382,12 @@ describe("local backend pi transcript", () => {
 
     const models = await listLocalModels(storageDir, { fetch: fetchImpl });
 
-    expect(calls).toEqual([]);
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        "http://localhost:11434/v1/models",
+        "http://localhost:8080/v1/models",
+      ]),
+    );
     expect(models).toContainEqual({
       handle: "lmstudio/gemma-4-26B-A4B-it-oQ6",
       max_context_window: 256000,
@@ -1517,18 +1559,25 @@ describe("local backend pi transcript", () => {
     const fetchImpl = (async (input: unknown, init?: RequestInit) => {
       const url = typeof input === "string" ? input : String(input);
       calls.push(url);
-      captured.authorization = new Headers(init?.headers).get("Authorization");
-      return new Response(
-        JSON.stringify({ data: [{ id: "rnj-1:8b" }, { id: "glm-5.1" }] }),
-        { headers: { "content-type": "application/json" } },
-      );
+      if (url === "https://ollama.com/v1/models") {
+        captured.authorization = new Headers(init?.headers).get(
+          "Authorization",
+        );
+        return new Response(
+          JSON.stringify({ data: [{ id: "rnj-1:8b" }, { id: "glm-5.1" }] }),
+          { headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
     }) as unknown as typeof fetch;
 
     const handles = (
       await listLocalModels(storageDir, { fetch: fetchImpl })
     ).map((model) => model.handle);
 
-    expect(calls).toEqual(["https://ollama.com/v1/models"]);
+    expect(calls).toEqual(
+      expect.arrayContaining(["https://ollama.com/v1/models"]),
+    );
     expect(captured.authorization).toBe("Bearer ollama-key");
     expect(handles).toContain("ollama-cloud/rnj-1:8b");
     expect(handles).toContain("ollama-cloud/glm-5.1");
@@ -1548,11 +1597,20 @@ describe("local backend pi transcript", () => {
       storageDir,
     });
     const captured: { authorization?: string | null } = {};
-    const fetchImpl = (async (_input: unknown, init?: RequestInit) => {
-      captured.authorization = new Headers(init?.headers).get("Authorization");
-      return new Response(JSON.stringify({ data: [{ id: "secure-model" }] }), {
-        headers: { "content-type": "application/json" },
-      });
+    const fetchImpl = (async (input: unknown, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : String(input);
+      if (url === "http://localhost:8000/v1/models") {
+        captured.authorization = new Headers(init?.headers).get(
+          "Authorization",
+        );
+        return new Response(
+          JSON.stringify({ data: [{ id: "secure-model" }] }),
+          {
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      return new Response("not found", { status: 404 });
     }) as unknown as typeof fetch;
 
     await withEnv({ LMSTUDIO_API_KEY: "1234" }, async () => {

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -1186,14 +1186,56 @@ describe("local backend pi transcript", () => {
     const storageDir = await mkdtemp(
       join(tmpdir(), "local-backend-pi-unconfigured-local-"),
     );
+    const fetchImpl = (async () =>
+      new Response("not found", { status: 404 })) as unknown as typeof fetch;
 
-    const handles = (await listLocalModels(storageDir)).map(
-      (model) => model.handle,
-    );
+    const handles = (
+      await listLocalModels(storageDir, { fetch: fetchImpl })
+    ).map((model) => model.handle);
     expect(handles.some((handle) => handle.startsWith("ollama/"))).toBe(false);
     expect(handles.some((handle) => handle.startsWith("lmstudio/"))).toBe(
       false,
     );
+    expect(handles.some((handle) => handle.startsWith("llama.cpp/"))).toBe(
+      false,
+    );
+  });
+
+  test("auto-detects reachable local model endpoints without saved providers", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-pi-autodetect-local-"),
+    );
+    const calls: string[] = [];
+    const fetchImpl = (async (input: unknown) => {
+      const url = typeof input === "string" ? input : String(input);
+      calls.push(url);
+      if (url === "http://localhost:11434/api/tags") {
+        return new Response(
+          JSON.stringify({ models: [{ name: "qwen2.5-coder:7b" }] }),
+          { headers: { "content-type": "application/json" } },
+        );
+      }
+      if (url === "http://127.0.0.1:1234/v1/models") {
+        return new Response(
+          JSON.stringify({ data: [{ id: "openai/gpt-oss-20b" }] }),
+          { headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const handles = (
+      await listLocalModels(storageDir, { fetch: fetchImpl })
+    ).map((model) => model.handle);
+
+    expect(calls).toEqual([
+      "http://localhost:11434/v1/models",
+      "http://localhost:11434/api/tags",
+      "http://127.0.0.1:1234/v1/models",
+      "http://localhost:8080/v1/models",
+    ]);
+    expect(handles).toContain("ollama/qwen2.5-coder:7b");
+    expect(handles).toContain("lmstudio/openai/gpt-oss-20b");
     expect(handles.some((handle) => handle.startsWith("llama.cpp/"))).toBe(
       false,
     );

--- a/src/backend/local/local-model-config.ts
+++ b/src/backend/local/local-model-config.ts
@@ -18,6 +18,7 @@ import {
   listConfiguredPiProviders,
   localModelHandle,
   localProviderType,
+  PI_PROVIDER_SPECS,
   resolveLocalModel,
   resolveProviderFromModelHandle,
   resolveProviderFromProviderType,
@@ -203,6 +204,10 @@ function providerRecordFor(
 
 function isDiscoverableLocalProvider(provider: PiProvider): boolean {
   return getPiProviderSpec(provider).localModelDiscovery !== undefined;
+}
+
+function isAutoDetectableLocalEndpointProvider(provider: PiProvider): boolean {
+  return getPiProviderSpec(provider).autoDetectLocalEndpoint === true;
 }
 
 function isPiProviderForLocalModelHandle(
@@ -485,7 +490,15 @@ export async function listLocalModels(
       parsePositiveNumber(options.discoveryTimeoutMs) ??
       LOCAL_MODEL_DISCOVERY_TIMEOUT_MS,
   };
-  for (const provider of listConfiguredPiProviders(providerNames)) {
+  const providersToDiscover = new Set([
+    ...listConfiguredPiProviders(providerNames),
+    ...(providerNames.size === 0
+      ? PI_PROVIDER_SPECS.filter((provider) =>
+          isAutoDetectableLocalEndpointProvider(provider.id),
+        ).map((provider) => provider.id)
+      : []),
+  ]);
+  for (const provider of providersToDiscover) {
     if (registeredProvidersWithModels.has(provider)) continue;
     if (isDiscoverableLocalProvider(provider)) {
       try {

--- a/src/backend/local/local-model-config.ts
+++ b/src/backend/local/local-model-config.ts
@@ -54,9 +54,11 @@ interface LocalModelListEntry {
 interface ListLocalModelsOptions {
   fetch?: typeof fetch;
   discoveryTimeoutMs?: number;
+  autoDetectDiscoveryTimeoutMs?: number;
 }
 
 const LOCAL_MODEL_DISCOVERY_TIMEOUT_MS = 2_000;
+const LOCAL_MODEL_AUTODETECT_DISCOVERY_TIMEOUT_MS = 500;
 
 function trimTrailingSlashes(value: string): string {
   return value.replace(/\/+$/, "");
@@ -489,34 +491,48 @@ export async function listLocalModels(
     discoveryTimeoutMs:
       parsePositiveNumber(options.discoveryTimeoutMs) ??
       LOCAL_MODEL_DISCOVERY_TIMEOUT_MS,
+    autoDetectDiscoveryTimeoutMs:
+      parsePositiveNumber(options.autoDetectDiscoveryTimeoutMs) ??
+      LOCAL_MODEL_AUTODETECT_DISCOVERY_TIMEOUT_MS,
   };
+  const configuredProviders = new Set(listConfiguredPiProviders(providerNames));
   const providersToDiscover = new Set([
-    ...listConfiguredPiProviders(providerNames),
-    ...(providerNames.size === 0
-      ? PI_PROVIDER_SPECS.filter((provider) =>
-          isAutoDetectableLocalEndpointProvider(provider.id),
-        ).map((provider) => provider.id)
-      : []),
+    ...configuredProviders,
+    ...PI_PROVIDER_SPECS.filter((provider) =>
+      isAutoDetectableLocalEndpointProvider(provider.id),
+    ).map((provider) => provider.id),
   ]);
-  for (const provider of providersToDiscover) {
-    if (registeredProvidersWithModels.has(provider)) continue;
-    if (isDiscoverableLocalProvider(provider)) {
+  const discoveryResults = await Promise.all(
+    [...providersToDiscover].map(async (provider) => {
+      if (registeredProvidersWithModels.has(provider)) {
+        return { provider, models: [] };
+      }
+
+      if (!isDiscoverableLocalProvider(provider)) {
+        return { provider, models: listCatalogModelsForProvider(provider) };
+      }
+
       try {
-        for (const model of await discoverModelIdsForProvider(
+        const timeoutMs = configuredProviders.has(provider)
+          ? discoveryOptions.discoveryTimeoutMs
+          : discoveryOptions.autoDetectDiscoveryTimeoutMs;
+        const discoveredModels = await discoverModelIdsForProvider(
           provider,
           records,
-          discoveryOptions,
-        )) {
-          addModel(provider, model);
-        }
+          { ...discoveryOptions, discoveryTimeoutMs: timeoutMs },
+        );
+        return { provider, models: discoveredModels };
       } catch {
         // Do not surface stale guessed models when a local provider is not
         // reachable; simply omit that provider's catalog from /model.
+        return { provider, models: [] };
       }
-    } else {
-      for (const model of listCatalogModelsForProvider(provider)) {
-        addModel(provider, model);
-      }
+    }),
+  );
+
+  for (const result of discoveryResults) {
+    for (const model of result.models) {
+      addModel(result.provider, model);
     }
   }
   return models;


### PR DESCRIPTION
## Summary
- autodetect reachable default local model endpoints for Ollama, LM Studio, and llama.cpp even when other local providers are already saved
- run configured provider discovery and default local endpoint autodetect probes in parallel
- keep configured providers at the existing 2s discovery window while bounding implicit autodetect probes to 500ms

## Validation
- bun test src/backend/local-backend.test.ts
- bun run typecheck
- bun run check

Tested with LMStudio and Ollama
<img width="665" height="391" alt="image" src="https://github.com/user-attachments/assets/5f7c2aed-b4dc-4ead-b406-f0fc0ad4cbde" />
