### PR TITLE
fix(slack): surface thread context media

### DIFF
--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -159,6 +159,7 @@ const resolveSlackThreadStarterMock = mock(
     userId?: string;
     botId?: string;
     ts?: string;
+    attachments?: ChannelMessageAttachment[];
   } | null> => null,
 );
 const resolveSlackThreadHistoryMock = mock(
@@ -168,6 +169,7 @@ const resolveSlackThreadHistoryMock = mock(
       userId?: string;
       botId?: string;
       ts?: string;
+      attachments?: ChannelMessageAttachment[];
     }>
   > => [],
 );
@@ -178,6 +180,7 @@ const resolveSlackChannelHistoryMock = mock(
       userId?: string;
       botId?: string;
       ts?: string;
+      attachments?: ChannelMessageAttachment[];
     }>
   > => [],
 );
@@ -600,6 +603,16 @@ test("slack adapter hydrates prior Slack thread context, including bot-authored 
     text: "Original question from the thread root",
     userId: "U111",
     ts: "1712790000.000050",
+    attachments: [
+      {
+        id: "FROOT",
+        name: "root-screenshot.png",
+        mimeType: "image/png",
+        kind: "image",
+        localPath: "/tmp/root-screenshot.png",
+        imageDataBase64: "abc",
+      },
+    ],
   });
   resolveSlackThreadHistoryMock.mockResolvedValueOnce([
     {
@@ -638,6 +651,12 @@ test("slack adapter hydrates prior Slack thread context, including bot-authored 
       messageId: "1712790000.000050",
       senderId: "U111",
       text: "Original question from the thread root",
+      attachments: [
+        expect.objectContaining({
+          id: "FROOT",
+          localPath: "/tmp/root-screenshot.png",
+        }),
+      ],
     }),
   );
   expect(prepared?.threadContext?.history).toEqual([
@@ -655,7 +674,21 @@ test("slack adapter hydrates prior Slack thread context, including bot-authored 
   ]);
   expect(prepared?.threadContext?.label).toContain("Slack thread in #random");
   expect(resolveSlackThreadStarterMock).toHaveBeenCalledTimes(1);
+  expect(resolveSlackThreadStarterMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      accountId: "slack-test-account",
+      token: "xoxb-test-token-1234567890",
+      transcribeVoice: false,
+    }),
+  );
   expect(resolveSlackThreadHistoryMock).toHaveBeenCalledTimes(1);
+  expect(resolveSlackThreadHistoryMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      accountId: "slack-test-account",
+      token: "xoxb-test-token-1234567890",
+      transcribeVoice: false,
+    }),
+  );
 });
 
 test("slack adapter rehydrates bot-authored Slack thread context on existing routed turns", async () => {

--- a/src/channels/slack-media.test.ts
+++ b/src/channels/slack-media.test.ts
@@ -85,6 +85,79 @@ test("resolveSlackThreadStarter falls back to forwarded Slack attachment text", 
   });
 });
 
+test("resolveSlackThreadStarter downloads Slack files for thread context", async () => {
+  const fetchMock = mock(async (input: unknown, init?: RequestInit) => {
+    expect(requestUrl(input)).toBe(
+      "https://files.slack.com/files-pri/T123-FROOT/root.png",
+    );
+    expect(init).toMatchObject({
+      headers: { Authorization: "Bearer xoxb-test-token" },
+      redirect: "manual",
+    });
+    return new Response(new Uint8Array([1, 2, 3, 4]), {
+      status: 200,
+      headers: { "content-type": "image/png" },
+    });
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+  const { resolveSlackThreadStarter } = await loadSlackMediaModule();
+  const client = {
+    conversations: {
+      history: mock(async () => ({ messages: [] })),
+      replies: mock(async () => ({
+        messages: [
+          {
+            ts: "1712790000.000050",
+            user: "U111",
+            text: "Root screenshot",
+            files: [
+              {
+                id: "FROOT",
+                name: "root.png",
+                mimetype: "image/png",
+                url_private_download:
+                  "https://files.slack.com/files-pri/T123-FROOT/root.png",
+              },
+            ],
+          },
+        ],
+      })),
+    },
+  };
+
+  const starter = await resolveSlackThreadStarter({
+    channelId: "C123",
+    threadTs: "1712790000.000050",
+    client,
+    accountId: "slack-bot",
+    token: "xoxb-test-token",
+    transcribeVoice: false,
+  });
+
+  expect(starter).toMatchObject({
+    text: "Root screenshot",
+    userId: "U111",
+    botId: undefined,
+    ts: "1712790000.000050",
+  });
+  expect(starter?.attachments).toHaveLength(1);
+  const attachment = starter?.attachments?.[0];
+  if (!attachment) {
+    throw new Error("Expected starter attachment");
+  }
+  expect(attachment).toMatchObject({
+    id: "FROOT",
+    name: "root.png",
+    kind: "image",
+    mimeType: "image/png",
+    sizeBytes: 4,
+    imageDataBase64: "AQIDBA==",
+    localPath: expect.stringContaining("root.png"),
+  });
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
 test("resolveSlackChannelHistory retains forwarded Slack attachment text", async () => {
   const { resolveSlackChannelHistory } = await loadSlackMediaModule();
   const client = {

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -1509,12 +1509,18 @@ export function createSlackAdapter(
       }
 
       const slackApp = await ensureApp();
+      const threadAttachmentParams = {
+        accountId: config.accountId,
+        token: config.botToken,
+        transcribeVoice: config.transcribeVoice === true,
+      };
       const starter =
         shouldHydrateExistingThreadContext && isFirstRouteTurn
           ? await resolveSlackThreadStarter({
               channelId: msg.chatId,
               threadTs: msg.threadId,
               client: slackApp.client,
+              ...threadAttachmentParams,
             })
           : null;
       const resolvedHistory = shouldHydrateExistingThreadContext
@@ -1524,12 +1530,14 @@ export function createSlackAdapter(
             client: slackApp.client,
             currentMessageTs: msg.messageId,
             limit: INITIAL_SLACK_THREAD_HISTORY_LIMIT,
+            ...threadAttachmentParams,
           })
         : await resolveSlackChannelHistory({
             channelId: msg.chatId,
             beforeTs: msg.messageId,
             client: slackApp.client,
             limit: INITIAL_SLACK_THREAD_HISTORY_LIMIT,
+            ...threadAttachmentParams,
           });
       // Existing routed thread turns already deliver human messages into the
       // Letta conversation. Bot-authored Slack messages are intentionally not
@@ -1589,6 +1597,9 @@ export function createSlackAdapter(
                     starter.botId,
                   ),
                   text: starter.text,
+                  ...(starter.attachments?.length
+                    ? { attachments: starter.attachments }
+                    : {}),
                 },
               }
             : {}),
@@ -1602,6 +1613,9 @@ export function createSlackAdapter(
                     entry.botId,
                   ),
                   text: entry.text,
+                  ...(entry.attachments?.length
+                    ? { attachments: entry.attachments }
+                    : {}),
                 })),
               }
             : {}),

--- a/src/channels/slack/media.ts
+++ b/src/channels/slack/media.ts
@@ -63,21 +63,40 @@ type SlackRepliesPage = {
   response_metadata?: { next_cursor?: string };
 };
 
+type SlackThreadAttachmentParams = {
+  accountId?: string;
+  token?: string;
+  transcribeVoice?: boolean;
+};
+
+type SlackThreadAttachmentOptions = {
+  accountId: string;
+  token: string;
+  transcribeVoice?: boolean;
+};
+
 export type SlackThreadMessage = {
   text: string;
   userId?: string;
   botId?: string;
   ts?: string;
+  attachments?: ChannelMessageAttachment[];
 };
 
-function mapSlackThreadMessage(
+async function mapSlackThreadMessage(
   message: SlackRepliesPageMessage,
-): SlackThreadMessage {
+  attachmentOptions?: SlackThreadAttachmentOptions,
+): Promise<SlackThreadMessage> {
+  const attachments = await resolveSlackMessageAttachments(
+    message,
+    attachmentOptions,
+  );
   return {
     text: resolveSlackThreadMessageText(message),
     userId: isNonEmptyString(message.user) ? message.user : undefined,
     botId: isNonEmptyString(message.bot_id) ? message.bot_id : undefined,
     ts: isNonEmptyString(message.ts) ? message.ts : undefined,
+    ...(attachments.length > 0 ? { attachments } : {}),
   };
 }
 
@@ -507,19 +526,18 @@ function collectSlackFiles(rawEvent: unknown): SlackFileLike[] {
   return Array.from(deduped.values()).slice(0, MAX_SLACK_ATTACHMENTS);
 }
 
-export async function resolveSlackInboundAttachments(params: {
+async function resolveSlackFilesAsAttachments(params: {
   accountId: string;
   token: string;
-  rawEvent: unknown;
+  files: SlackFileLike[];
   transcribeVoice?: boolean;
 }): Promise<ChannelMessageAttachment[]> {
-  const files = collectSlackFiles(params.rawEvent);
-  if (files.length === 0) {
+  if (params.files.length === 0) {
     return [];
   }
 
   const resolved = await Promise.all(
-    files.map((file) =>
+    params.files.map((file) =>
       downloadSlackAttachment({
         accountId: params.accountId,
         token: params.token,
@@ -534,17 +552,79 @@ export async function resolveSlackInboundAttachments(params: {
   );
 }
 
+function resolveSlackThreadAttachmentOptions(
+  params: SlackThreadAttachmentParams,
+): SlackThreadAttachmentOptions | undefined {
+  if (!isNonEmptyString(params.accountId) || !isNonEmptyString(params.token)) {
+    return undefined;
+  }
+
+  return {
+    accountId: params.accountId,
+    token: params.token,
+    transcribeVoice: params.transcribeVoice,
+  };
+}
+
+function hasSlackThreadMessageContent(
+  message: SlackRepliesPageMessage,
+  attachmentOptions?: SlackThreadAttachmentOptions,
+): boolean {
+  if (resolveSlackThreadMessageText(message)) {
+    return true;
+  }
+  return Boolean(attachmentOptions && collectSlackFiles(message).length > 0);
+}
+
+function hasHydratedSlackThreadMessageContent(
+  message: SlackThreadMessage,
+): boolean {
+  return message.text.length > 0 || Boolean(message.attachments?.length);
+}
+
+async function resolveSlackMessageAttachments(
+  message: SlackRepliesPageMessage,
+  attachmentOptions?: SlackThreadAttachmentOptions,
+): Promise<ChannelMessageAttachment[]> {
+  if (!attachmentOptions) {
+    return [];
+  }
+
+  return resolveSlackFilesAsAttachments({
+    accountId: attachmentOptions.accountId,
+    token: attachmentOptions.token,
+    files: collectSlackFiles(message),
+    transcribeVoice: attachmentOptions.transcribeVoice,
+  });
+}
+
+export async function resolveSlackInboundAttachments(params: {
+  accountId: string;
+  token: string;
+  rawEvent: unknown;
+  transcribeVoice?: boolean;
+}): Promise<ChannelMessageAttachment[]> {
+  return resolveSlackFilesAsAttachments({
+    accountId: params.accountId,
+    token: params.token,
+    files: collectSlackFiles(params.rawEvent),
+    transcribeVoice: params.transcribeVoice,
+  });
+}
+
 export async function readSlackAttachmentFile(
   localPath: string,
 ): Promise<Buffer> {
   return readFile(localPath);
 }
 
-export async function resolveSlackThreadStarter(params: {
-  channelId: string;
-  threadTs: string;
-  client: SlackRepliesClient;
-}): Promise<SlackThreadMessage | null> {
+export async function resolveSlackThreadStarter(
+  params: {
+    channelId: string;
+    threadTs: string;
+    client: SlackRepliesClient;
+  } & SlackThreadAttachmentParams,
+): Promise<SlackThreadMessage | null> {
   try {
     const response = (await params.client.conversations.replies({
       channel: params.channelId,
@@ -558,29 +638,27 @@ export async function resolveSlackThreadStarter(params: {
       return null;
     }
 
-    const text = resolveSlackThreadMessageText(message);
-    if (!text) {
+    const attachmentOptions = resolveSlackThreadAttachmentOptions(params);
+    if (!hasSlackThreadMessageContent(message, attachmentOptions)) {
       return null;
     }
 
-    return {
-      text,
-      userId: isNonEmptyString(message.user) ? message.user : undefined,
-      botId: isNonEmptyString(message.bot_id) ? message.bot_id : undefined,
-      ts: isNonEmptyString(message.ts) ? message.ts : undefined,
-    };
+    const mapped = await mapSlackThreadMessage(message, attachmentOptions);
+    return hasHydratedSlackThreadMessageContent(mapped) ? mapped : null;
   } catch {
     return null;
   }
 }
 
-export async function resolveSlackThreadHistory(params: {
-  channelId: string;
-  threadTs: string;
-  client: SlackRepliesClient;
-  currentMessageTs?: string;
-  limit?: number;
-}): Promise<SlackThreadMessage[]> {
+export async function resolveSlackThreadHistory(
+  params: {
+    channelId: string;
+    threadTs: string;
+    client: SlackRepliesClient;
+    currentMessageTs?: string;
+    limit?: number;
+  } & SlackThreadAttachmentParams,
+): Promise<SlackThreadMessage[]> {
   const maxMessages = params.limit ?? 20;
   if (!Number.isFinite(maxMessages) || maxMessages <= 0) {
     return [];
@@ -588,6 +666,7 @@ export async function resolveSlackThreadHistory(params: {
 
   const fetchLimit = 200;
   const retained: SlackRepliesPageMessage[] = [];
+  const attachmentOptions = resolveSlackThreadAttachmentOptions(params);
   let cursor: string | undefined;
 
   try {
@@ -601,8 +680,7 @@ export async function resolveSlackThreadHistory(params: {
       })) as SlackRepliesPage;
 
       for (const message of response.messages ?? []) {
-        const text = resolveSlackThreadMessageText(message);
-        if (!text) {
+        if (!hasSlackThreadMessageContent(message, attachmentOptions)) {
           continue;
         }
         if (params.currentMessageTs && message.ts === params.currentMessageTs) {
@@ -625,24 +703,32 @@ export async function resolveSlackThreadHistory(params: {
           : undefined;
     } while (cursor);
 
-    return retained.map(mapSlackThreadMessage);
+    const mapped = await Promise.all(
+      retained.map((message) =>
+        mapSlackThreadMessage(message, attachmentOptions),
+      ),
+    );
+    return mapped.filter(hasHydratedSlackThreadMessageContent);
   } catch {
     return [];
   }
 }
 
-export async function resolveSlackChannelHistory(params: {
-  channelId: string;
-  beforeTs: string;
-  client: SlackRepliesClient;
-  limit?: number;
-}): Promise<SlackThreadMessage[]> {
+export async function resolveSlackChannelHistory(
+  params: {
+    channelId: string;
+    beforeTs: string;
+    client: SlackRepliesClient;
+    limit?: number;
+  } & SlackThreadAttachmentParams,
+): Promise<SlackThreadMessage[]> {
   const maxMessages = params.limit ?? 20;
   if (!Number.isFinite(maxMessages) || maxMessages <= 0) {
     return [];
   }
 
   const fetchLimit = Math.min(Math.max(maxMessages * 3, maxMessages), 100);
+  const attachmentOptions = resolveSlackThreadAttachmentOptions(params);
 
   try {
     const response = (await params.client.conversations.history({
@@ -658,12 +744,17 @@ export async function resolveSlackChannelHistory(params: {
           return false;
         }
 
-        return Boolean(resolveSlackThreadMessageText(message));
+        return hasSlackThreadMessageContent(message, attachmentOptions);
       })
       .slice(0, fetchLimit)
       .reverse();
 
-    return retained.slice(-maxMessages).map(mapSlackThreadMessage);
+    const mapped = await Promise.all(
+      retained
+        .slice(-maxMessages)
+        .map((message) => mapSlackThreadMessage(message, attachmentOptions)),
+    );
+    return mapped.filter(hasHydratedSlackThreadMessageContent);
   } catch {
     return [];
   }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -64,6 +64,7 @@ export interface ChannelThreadContextEntry {
   senderId?: string;
   senderName?: string;
   text: string;
+  attachments?: ChannelMessageAttachment[];
 }
 
 export interface ChannelThreadContext {

--- a/src/channels/xml.test.ts
+++ b/src/channels/xml.test.ts
@@ -371,6 +371,16 @@ describe("formatChannelNotification", () => {
           senderId: "U111",
           senderName: "Alice",
           text: "Original question from the thread root",
+          attachments: [
+            {
+              id: "FROOT",
+              kind: "image",
+              localPath: "/tmp/thread-root.png",
+              name: "thread-root.png",
+              mimeType: "image/png",
+              sizeBytes: 7,
+            },
+          ],
         },
         history: [
           {
@@ -378,6 +388,15 @@ describe("formatChannelNotification", () => {
             senderId: "U222",
             senderName: "Bob",
             text: "Some follow-up before the bot was tagged",
+            attachments: [
+              {
+                id: "FHIST",
+                kind: "file",
+                localPath: "/tmp/thread-history.pdf",
+                name: "thread-history.pdf",
+                mimeType: "application/pdf",
+              },
+            ],
           },
         ],
       },
@@ -393,11 +412,15 @@ describe("formatChannelNotification", () => {
       '<thread-starter sender_id="U111" sender_name="Alice" message_id="1712790000.000050">',
     );
     expect(xml).toContain("Original question from the thread root");
+    expect(xml).toContain(
+      '<attachment kind="image" local_path="/tmp/thread-root.png" attachment_id="FROOT" name="thread-root.png" mime_type="image/png" size_bytes="7" />',
+    );
     expect(xml).toContain("<thread-history>");
     expect(xml).toContain(
       '<thread-message sender_id="U222" sender_name="Bob" message_id="1712795000.000060">',
     );
     expect(xml).toContain("Some follow-up before the bot was tagged");
+    expect(xml).toContain('local_path="/tmp/thread-history.pdf"');
     expect(xml).toContain("please help");
   });
 

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -32,6 +32,18 @@ function escapeXmlAttribute(text: string): string {
   return escapeXmlText(text).replace(/"/g, "&quot;").replace(/'/g, "&apos;");
 }
 
+function hasNotificationAttachmentPaths(msg: InboundChannelMessage): boolean {
+  if (msg.attachments?.length) {
+    return true;
+  }
+  if (msg.threadContext?.starter?.attachments?.length) {
+    return true;
+  }
+  return Boolean(
+    msg.threadContext?.history?.some((entry) => entry.attachments?.length),
+  );
+}
+
 /**
  * Format the reminder text that explains channel reply semantics to the agent.
  */
@@ -97,7 +109,7 @@ export function buildChannelReminderText(msg: InboundChannelMessage): string {
       'On Signal, MessageChannel also supports action="react" with emoji + messageId, and action="upload-file" with media. Replies are sent as the linked Signal account through signal-cli-rest-api.',
     );
   }
-  if (msg.attachments?.length) {
+  if (hasNotificationAttachmentPaths(msg)) {
     lines.splice(
       lines.length - 2,
       0,
@@ -215,7 +227,11 @@ function buildThreadContextEntryXml(
   }
 
   const attrString = attrs.length > 0 ? ` ${attrs.join(" ")}` : "";
-  return `<${tagName}${attrString}>\n${escapeXmlText(entry.text)}\n</${tagName}>`;
+  const body = [
+    ...(entry.text ? [escapeXmlText(entry.text)] : []),
+    ...(entry.attachments ?? []).map(buildAttachmentXml),
+  ].join("\n");
+  return `<${tagName}${attrString}>\n${body}\n</${tagName}>`;
 }
 
 function buildThreadContextXml(msg: InboundChannelMessage): string | null {


### PR DESCRIPTION
## Summary
- Download Slack files attached to hydrated thread starter/history context through the existing authenticated attachment path.
- Carry thread-context attachments through prepared inbound messages and render nested `<attachment local_path="...">` XML.
- Cover resolver, adapter, and XML behavior for Slack thread media context.

## Test plan
- [x] bun run --cwd /Users/lettamate/letta-code/.letta/worktrees/slack-thread-media-context check
- [x] bun test /Users/lettamate/letta-code/.letta/worktrees/slack-thread-media-context/src/channels/slack-media.test.ts /Users/lettamate/letta-code/.letta/worktrees/slack-thread-media-context/src/channels/slack-adapter.test.ts /Users/lettamate/letta-code/.letta/worktrees/slack-thread-media-context/src/channels/xml.test.ts

Letta Code (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

👾 Generated with [Letta Code](https://letta.com)