### PR TITLE
feat(models): add Claude Sonnet 5 as the new default sonnet

### DIFF
--- a/src/agent/max-context.test.ts
+++ b/src/agent/max-context.test.ts
@@ -43,6 +43,9 @@ describe("max context command helpers", () => {
 
   test("resolves model.json default context windows", () => {
     expect(
+      resolveModelJsonContextWindow({ modelId: "sonnet" }).contextWindow,
+    ).toBe(1_000_000);
+    expect(
       resolveModelJsonContextWindow({ modelId: "sonnet-4.6" }).contextWindow,
     ).toBe(200_000);
     expect(
@@ -67,7 +70,7 @@ describe("max context command helpers", () => {
       __testSetBackend(backend);
       const agent = await backend.createAgent({
         name: "Max Context Agent",
-        model: "anthropic/claude-sonnet-4-6",
+        model: "anthropic/claude-sonnet-5",
         model_settings: {
           provider_type: "anthropic",
           effort: "high",
@@ -80,7 +83,7 @@ describe("max context command helpers", () => {
           agentId: agent.id,
           conversationId: "default",
           args: `${MIN_CONTEXT_WINDOW_TOKENS - 1}`,
-          currentModelId: "sonnet-4.6",
+          currentModelId: "sonnet",
         }),
       ).rejects.toThrow("at least 30,000 tokens");
 
@@ -88,16 +91,16 @@ describe("max context command helpers", () => {
         applySetMaxContext({
           agentId: agent.id,
           conversationId: "default",
-          args: "250000",
-          currentModelId: "sonnet-4.6",
+          args: "1100000",
+          currentModelId: "sonnet",
         }),
-      ).rejects.toThrow("model.json default of 200,000 tokens");
+      ).rejects.toThrow("model.json default of 1,000,000 tokens");
 
       const overrideResult = await applySetMaxContext({
         agentId: agent.id,
         conversationId: "default",
         args: "10000 --override",
-        currentModelId: "sonnet-4.6",
+        currentModelId: "sonnet",
       });
       expect(overrideResult.contextWindow).toBe(10_000);
       expect(overrideResult.appliedTo).toBe("agent");
@@ -113,9 +116,9 @@ describe("max context command helpers", () => {
         agentId: agent.id,
         conversationId: "default",
         args: "",
-        currentModelId: "sonnet-4.6",
+        currentModelId: "sonnet",
       });
-      expect(resetResult.contextWindow).toBe(200_000);
+      expect(resetResult.contextWindow).toBe(1_000_000);
       expect(resetResult.reset).toBe(true);
 
       await backend.updateAgent(agent.id, {
@@ -133,7 +136,7 @@ describe("max context command helpers", () => {
         agentId: agent.id,
         conversationId: conversation.id,
         args: "50000",
-        currentModelId: "sonnet-4.6",
+        currentModelId: "sonnet",
       });
       expect(conversationResult.appliedTo).toBe("conversation");
       expect(conversationResult.conversationModelSettings).toMatchObject({

--- a/src/agent/max-context.test.ts
+++ b/src/agent/max-context.test.ts
@@ -43,7 +43,7 @@ describe("max context command helpers", () => {
 
   test("resolves model.json default context windows", () => {
     expect(
-      resolveModelJsonContextWindow({ modelId: "sonnet" }).contextWindow,
+      resolveModelJsonContextWindow({ modelId: "sonnet-4.6" }).contextWindow,
     ).toBe(200_000);
     expect(
       resolveModelJsonContextWindow({
@@ -80,7 +80,7 @@ describe("max context command helpers", () => {
           agentId: agent.id,
           conversationId: "default",
           args: `${MIN_CONTEXT_WINDOW_TOKENS - 1}`,
-          currentModelId: "sonnet",
+          currentModelId: "sonnet-4.6",
         }),
       ).rejects.toThrow("at least 30,000 tokens");
 
@@ -89,7 +89,7 @@ describe("max context command helpers", () => {
           agentId: agent.id,
           conversationId: "default",
           args: "250000",
-          currentModelId: "sonnet",
+          currentModelId: "sonnet-4.6",
         }),
       ).rejects.toThrow("model.json default of 200,000 tokens");
 
@@ -97,7 +97,7 @@ describe("max context command helpers", () => {
         agentId: agent.id,
         conversationId: "default",
         args: "10000 --override",
-        currentModelId: "sonnet",
+        currentModelId: "sonnet-4.6",
       });
       expect(overrideResult.contextWindow).toBe(10_000);
       expect(overrideResult.appliedTo).toBe("agent");
@@ -113,7 +113,7 @@ describe("max context command helpers", () => {
         agentId: agent.id,
         conversationId: "default",
         args: "",
-        currentModelId: "sonnet",
+        currentModelId: "sonnet-4.6",
       });
       expect(resetResult.contextWindow).toBe(200_000);
       expect(resetResult.reset).toBe(true);
@@ -133,7 +133,7 @@ describe("max context command helpers", () => {
         agentId: agent.id,
         conversationId: conversation.id,
         args: "50000",
-        currentModelId: "sonnet",
+        currentModelId: "sonnet-4.6",
       });
       expect(conversationResult.appliedTo).toBe("conversation");
       expect(conversationResult.conversationModelSettings).toMatchObject({

--- a/src/agent/model-tier-selection.test.ts
+++ b/src/agent/model-tier-selection.test.ts
@@ -280,8 +280,28 @@ describe("getReasoningTierOptionsForHandle", () => {
       "sonnet-4.6-no-reasoning",
       "sonnet-4.6-low",
       "sonnet-4.6-medium",
-      "sonnet",
+      "sonnet-4.6",
       "sonnet-4.6-xhigh",
+    ]);
+  });
+
+  test("returns reasoning options for anthropic sonnet 5", () => {
+    const options = getReasoningTierOptionsForHandle(
+      "anthropic/claude-sonnet-5",
+    );
+    expect(options.map((option) => option.effort)).toEqual([
+      "none",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+    expect(options.map((option) => option.modelId)).toEqual([
+      "sonnet-5-no-reasoning",
+      "sonnet-5-low",
+      "sonnet-5-medium",
+      "sonnet",
+      "sonnet-5-xhigh",
     ]);
   });
 

--- a/src/cli/app/constants.ts
+++ b/src/cli/app/constants.ts
@@ -36,12 +36,12 @@ export const PROVIDER_FALLBACK_MAP: Record<string, string> = {
   "opus-4.6-medium": "bedrock-opus-4.6",
   "opus-4.6-high": "bedrock-opus-4.6",
   "opus-4.6-xhigh": "bedrock-opus-4.6",
-  // Sonnet 5 + Sonnet 4.6 variants -> Bedrock Sonnet 4.6 (Bedrock has no Sonnet 5 yet, degrade to 4.6)
-  sonnet: "bedrock-sonnet-4.6",
-  "sonnet-5-no-reasoning": "bedrock-sonnet-4.6",
-  "sonnet-5-low": "bedrock-sonnet-4.6",
-  "sonnet-5-medium": "bedrock-sonnet-4.6",
-  "sonnet-5-xhigh": "bedrock-sonnet-4.6",
+  // Sonnet 5 variants -> Bedrock Sonnet 5; Sonnet 4.6 variants -> Bedrock Sonnet 4.6
+  sonnet: "bedrock-sonnet-5",
+  "sonnet-5-no-reasoning": "bedrock-sonnet-5",
+  "sonnet-5-low": "bedrock-sonnet-5",
+  "sonnet-5-medium": "bedrock-sonnet-5",
+  "sonnet-5-xhigh": "bedrock-sonnet-5",
   "sonnet-4.6": "bedrock-sonnet-4.6",
   "sonnet-1m": "bedrock-sonnet-4.6",
   "sonnet-4.6-no-reasoning": "bedrock-sonnet-4.6",

--- a/src/cli/app/constants.ts
+++ b/src/cli/app/constants.ts
@@ -36,8 +36,13 @@ export const PROVIDER_FALLBACK_MAP: Record<string, string> = {
   "opus-4.6-medium": "bedrock-opus-4.6",
   "opus-4.6-high": "bedrock-opus-4.6",
   "opus-4.6-xhigh": "bedrock-opus-4.6",
-  // Sonnet 4.6 variants -> Bedrock Sonnet 4.6
+  // Sonnet 5 + Sonnet 4.6 variants -> Bedrock Sonnet 4.6 (Bedrock has no Sonnet 5 yet, degrade to 4.6)
   sonnet: "bedrock-sonnet-4.6",
+  "sonnet-5-no-reasoning": "bedrock-sonnet-4.6",
+  "sonnet-5-low": "bedrock-sonnet-4.6",
+  "sonnet-5-medium": "bedrock-sonnet-4.6",
+  "sonnet-5-xhigh": "bedrock-sonnet-4.6",
+  "sonnet-4.6": "bedrock-sonnet-4.6",
   "sonnet-1m": "bedrock-sonnet-4.6",
   "sonnet-4.6-no-reasoning": "bedrock-sonnet-4.6",
   "sonnet-4.6-low": "bedrock-sonnet-4.6",

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -191,12 +191,12 @@ const PROVIDER_FALLBACK_MAP: Record<string, string> = {
   "opus-4.6-medium": "bedrock-opus-4.6",
   "opus-4.6-high": "bedrock-opus-4.6",
   "opus-4.6-xhigh": "bedrock-opus-4.6",
-  // Sonnet 5 + Sonnet 4.6 variants → Bedrock Sonnet 4.6 (Bedrock has no Sonnet 5 yet, degrade to 4.6)
-  sonnet: "bedrock-sonnet-4.6",
-  "sonnet-5-no-reasoning": "bedrock-sonnet-4.6",
-  "sonnet-5-low": "bedrock-sonnet-4.6",
-  "sonnet-5-medium": "bedrock-sonnet-4.6",
-  "sonnet-5-xhigh": "bedrock-sonnet-4.6",
+  // Sonnet 5 variants → Bedrock Sonnet 5; Sonnet 4.6 variants → Bedrock Sonnet 4.6
+  sonnet: "bedrock-sonnet-5",
+  "sonnet-5-no-reasoning": "bedrock-sonnet-5",
+  "sonnet-5-low": "bedrock-sonnet-5",
+  "sonnet-5-medium": "bedrock-sonnet-5",
+  "sonnet-5-xhigh": "bedrock-sonnet-5",
   "sonnet-4.6": "bedrock-sonnet-4.6",
   "sonnet-1m": "bedrock-sonnet-4.6",
   "sonnet-4.6-no-reasoning": "bedrock-sonnet-4.6",

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -191,8 +191,13 @@ const PROVIDER_FALLBACK_MAP: Record<string, string> = {
   "opus-4.6-medium": "bedrock-opus-4.6",
   "opus-4.6-high": "bedrock-opus-4.6",
   "opus-4.6-xhigh": "bedrock-opus-4.6",
-  // Sonnet 4.6 variants → Bedrock Sonnet 4.6
+  // Sonnet 5 + Sonnet 4.6 variants → Bedrock Sonnet 4.6 (Bedrock has no Sonnet 5 yet, degrade to 4.6)
   sonnet: "bedrock-sonnet-4.6",
+  "sonnet-5-no-reasoning": "bedrock-sonnet-4.6",
+  "sonnet-5-low": "bedrock-sonnet-4.6",
+  "sonnet-5-medium": "bedrock-sonnet-4.6",
+  "sonnet-5-xhigh": "bedrock-sonnet-4.6",
+  "sonnet-4.6": "bedrock-sonnet-4.6",
   "sonnet-1m": "bedrock-sonnet-4.6",
   "sonnet-4.6-no-reasoning": "bedrock-sonnet-4.6",
   "sonnet-4.6-low": "bedrock-sonnet-4.6",

--- a/src/models.json
+++ b/src/models.json
@@ -337,10 +337,77 @@
     },
     {
       "id": "sonnet",
+      "handle": "anthropic/claude-sonnet-5",
+      "label": "Sonnet 5",
+      "description": "Sonnet 5 (high reasoning)",
+      "isFeatured": true,
+      "updateArgs": {
+        "context_window": 1000000,
+        "max_output_tokens": 128000,
+        "reasoning_effort": "high",
+        "enable_reasoner": true,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "sonnet-5-no-reasoning",
+      "handle": "anthropic/claude-sonnet-5",
+      "label": "Sonnet 5",
+      "description": "Sonnet 5 with no reasoning (faster)",
+      "updateArgs": {
+        "context_window": 1000000,
+        "max_output_tokens": 128000,
+        "reasoning_effort": "none",
+        "enable_reasoner": false,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "sonnet-5-low",
+      "handle": "anthropic/claude-sonnet-5",
+      "label": "Sonnet 5",
+      "description": "Sonnet 5 (low reasoning)",
+      "updateArgs": {
+        "context_window": 1000000,
+        "max_output_tokens": 128000,
+        "reasoning_effort": "low",
+        "enable_reasoner": true,
+        "max_reasoning_tokens": 4000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "sonnet-5-medium",
+      "handle": "anthropic/claude-sonnet-5",
+      "label": "Sonnet 5",
+      "description": "Sonnet 5 (med reasoning)",
+      "updateArgs": {
+        "context_window": 1000000,
+        "max_output_tokens": 128000,
+        "reasoning_effort": "medium",
+        "enable_reasoner": true,
+        "max_reasoning_tokens": 12000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "sonnet-5-xhigh",
+      "handle": "anthropic/claude-sonnet-5",
+      "label": "Sonnet 5",
+      "description": "Sonnet 5 (max reasoning)",
+      "updateArgs": {
+        "context_window": 1000000,
+        "max_output_tokens": 128000,
+        "reasoning_effort": "xhigh",
+        "enable_reasoner": true,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "sonnet-4.6",
       "handle": "anthropic/claude-sonnet-4-6",
       "label": "Sonnet 4.6",
       "description": "Sonnet 4.6 (high reasoning)",
-      "isFeatured": true,
       "updateArgs": {
         "context_window": 200000,
         "max_output_tokens": 128000,

--- a/src/models.json
+++ b/src/models.json
@@ -781,6 +781,19 @@
       }
     },
     {
+      "id": "bedrock-sonnet-5",
+      "handle": "bedrock/us.anthropic.claude-sonnet-5",
+      "label": "Bedrock Sonnet 5",
+      "shortLabel": "Sonnet 5 BR",
+      "description": "Sonnet 5 via AWS Bedrock",
+      "updateArgs": {
+        "context_window": 180000,
+        "max_output_tokens": 64000,
+        "max_reasoning_tokens": 31999,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "haiku",
       "handle": "anthropic/claude-haiku-4-5",
       "label": "Haiku 4.5",

--- a/src/websocket/listener-provider-fallback.test.ts
+++ b/src/websocket/listener-provider-fallback.test.ts
@@ -28,7 +28,7 @@ describe("listener provider fallback", () => {
       }),
     );
 
-    expect(state.sourceModelId).toBe("sonnet");
+    expect(state.sourceModelId).toBe("sonnet-4.6");
     expect(maybeApplyProviderFallback(state, 1)).toBeNull();
 
     const fallbackHandle = maybeApplyProviderFallback(state, 2);

--- a/src/websocket/listener-provider-fallback.test.ts
+++ b/src/websocket/listener-provider-fallback.test.ts
@@ -22,18 +22,18 @@ function agentWithModel(
 describe("listener provider fallback", () => {
   test("maps sonnet to Bedrock after the first retry attempt", () => {
     const state = createProviderFallbackState(
-      agentWithModel("anthropic/claude-sonnet-4-6", {
+      agentWithModel("anthropic/claude-sonnet-5", {
         reasoning_effort: "high",
         enable_reasoner: true,
       }),
     );
 
-    expect(state.sourceModelId).toBe("sonnet-4.6");
+    expect(state.sourceModelId).toBe("sonnet");
     expect(maybeApplyProviderFallback(state, 1)).toBeNull();
 
     const fallbackHandle = maybeApplyProviderFallback(state, 2);
-    expect(fallbackHandle).toBe("bedrock/us.anthropic.claude-sonnet-4-6");
-    expect(state.overrideModel).toBe("bedrock/us.anthropic.claude-sonnet-4-6");
+    expect(fallbackHandle).toBe("bedrock/us.anthropic.claude-sonnet-5");
+    expect(state.overrideModel).toBe("bedrock/us.anthropic.claude-sonnet-5");
     expect(state.attempted).toBe(true);
     expect(maybeApplyProviderFallback(state, 3)).toBeNull();
   });

--- a/src/websocket/listener/constants.ts
+++ b/src/websocket/listener/constants.ts
@@ -27,12 +27,12 @@ export const PROVIDER_FALLBACK_MAP: Record<string, string> = {
   "opus-4.6-medium": "bedrock-opus-4.6",
   "opus-4.6-high": "bedrock-opus-4.6",
   "opus-4.6-xhigh": "bedrock-opus-4.6",
-  // Sonnet 5 + Sonnet 4.6 variants -> Bedrock Sonnet 4.6 (Bedrock has no Sonnet 5 yet, degrade to 4.6)
-  sonnet: "bedrock-sonnet-4.6",
-  "sonnet-5-no-reasoning": "bedrock-sonnet-4.6",
-  "sonnet-5-low": "bedrock-sonnet-4.6",
-  "sonnet-5-medium": "bedrock-sonnet-4.6",
-  "sonnet-5-xhigh": "bedrock-sonnet-4.6",
+  // Sonnet 5 variants -> Bedrock Sonnet 5; Sonnet 4.6 variants -> Bedrock Sonnet 4.6
+  sonnet: "bedrock-sonnet-5",
+  "sonnet-5-no-reasoning": "bedrock-sonnet-5",
+  "sonnet-5-low": "bedrock-sonnet-5",
+  "sonnet-5-medium": "bedrock-sonnet-5",
+  "sonnet-5-xhigh": "bedrock-sonnet-5",
   "sonnet-4.6": "bedrock-sonnet-4.6",
   "sonnet-1m": "bedrock-sonnet-4.6",
   "sonnet-4.6-no-reasoning": "bedrock-sonnet-4.6",

--- a/src/websocket/listener/constants.ts
+++ b/src/websocket/listener/constants.ts
@@ -27,8 +27,13 @@ export const PROVIDER_FALLBACK_MAP: Record<string, string> = {
   "opus-4.6-medium": "bedrock-opus-4.6",
   "opus-4.6-high": "bedrock-opus-4.6",
   "opus-4.6-xhigh": "bedrock-opus-4.6",
-  // Sonnet 4.6 variants -> Bedrock Sonnet 4.6
+  // Sonnet 5 + Sonnet 4.6 variants -> Bedrock Sonnet 4.6 (Bedrock has no Sonnet 5 yet, degrade to 4.6)
   sonnet: "bedrock-sonnet-4.6",
+  "sonnet-5-no-reasoning": "bedrock-sonnet-4.6",
+  "sonnet-5-low": "bedrock-sonnet-4.6",
+  "sonnet-5-medium": "bedrock-sonnet-4.6",
+  "sonnet-5-xhigh": "bedrock-sonnet-4.6",
+  "sonnet-4.6": "bedrock-sonnet-4.6",
   "sonnet-1m": "bedrock-sonnet-4.6",
   "sonnet-4.6-no-reasoning": "bedrock-sonnet-4.6",
   "sonnet-4.6-low": "bedrock-sonnet-4.6",


### PR DESCRIPTION
Tracked in Linear: [LET-9310](https://linear.app/letta/issue/LET-9310/add-claude-sonnet-5-across-core-cloud-and-letta-code)

## Summary
Adds Claude **Sonnet 5** (`anthropic/claude-sonnet-5`) to Letta Code and makes it the new default `sonnet`. Sonnet 4.6 stays reachable as separate ids.

- `sonnet` (featured default) -> `claude-sonnet-5`, **1M native context**, high reasoning.
- New variants: `sonnet-5-no-reasoning`, `sonnet-5-low`, `sonnet-5-medium`, `sonnet-5-xhigh`.
- Added explicit `sonnet-4.6` (high) id so 4.6 high-reasoning stays reachable now that bare `sonnet` is 5. All existing `sonnet-4.6-*` and `sonnet-1m-*` ids unchanged.

## Provider fallback
- Added `sonnet-5*` + `sonnet-4.6` -> `bedrock-sonnet-4.6` to the 3 duplicated `PROVIDER_FALLBACK_MAP`s (cli/app, headless, websocket/listener). Bedrock has no Sonnet 5 yet, so it degrades to 4.6 — consistent with the existing "all sonnet -> bedrock-sonnet-4.6" convention.

## Tests
- Updated `model-tier-selection.test.ts`: `claude-sonnet-4-6` high now resolves to `sonnet-4.6` (was `sonnet`); added a `claude-sonnet-5` tier case.
- Updated `max-context.test.ts`: repointed the 200k-default assertions from `sonnet` to `sonnet-4.6`.
- Updated `listener-provider-fallback.test.ts`: `sourceModelId` for 4.6-high is now `sonnet-4.6`.

## Depends on
- letta-cloud PR #12675 (core + node provider + pricing) must be deployed before release so `anthropic/claude-sonnet-5` resolves.

## Test plan
- [x] `bun test` model-tier-selection / max-context / listener-provider-fallback green
- [x] `tsc --noEmit` + biome clean
- [ ] Headless smoke `--model sonnet -p "what model are you?"` after cloud deploy
- [ ] CI matrix (kept on `sonnet-4.6-low`; switch to sonnet-5 post-deploy if desired)

---
## Update (rev 2)
- **Bedrock**: added `bedrock-sonnet-5` (`bedrock/us.anthropic.claude-sonnet-5`); repointed sonnet-5 provider-fallback entries from `bedrock-sonnet-4.6` to `bedrock-sonnet-5` (Sonnet 5 is on Bedrock now).
- **Tests**: reworked `max-context` + `listener-provider-fallback` to assert against the new default `sonnet` (Sonnet 5, 1M) instead of repointing them to `sonnet-4.6`.
- Note: Bedrock handle assumes AWS profile `us.anthropic.claude-sonnet-5` (same non-dated convention as 4.6) — verify against `list_inference_profiles`.