### PR TITLE
feat(mods): add turn_start cancellation

### DIFF
--- a/src/cli/app/use-conversation-loop.ts
+++ b/src/cli/app/use-conversation-loop.ts
@@ -699,6 +699,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
           });
           buffersRef.current.order.push(statusId);
           refreshDerived();
+          userCancelledRef.current = false;
           return;
         }
 

--- a/src/cli/app/use-conversation-loop.ts
+++ b/src/cli/app/use-conversation-loop.ts
@@ -97,6 +97,7 @@ import type { LocalModAdapter } from "@/cli/mods/use-local-mod-adapter";
 import { SYSTEM_ALERT_OPEN, SYSTEM_REMINDER_OPEN } from "@/constants";
 import { goalLoopMode } from "@/goal-loop-mode";
 import { runStopHooks } from "@/hooks";
+import { getTurnStartCancel } from "@/mods/turn-start-cancel";
 import type { ApprovalContext } from "@/permissions/analyzer";
 import { formatPermissionDenial } from "@/permissions/format-denial";
 import type { PermissionMode } from "@/permissions/mode";
@@ -632,6 +633,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
         return;
       }
       processingConversationRef.current += 1;
+      let turnStartCancelReason: string | null = null;
 
       if (hasUserMessageInput(currentInput)) {
         const originalInput = currentInput;
@@ -649,9 +651,12 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
           currentInput = isTurnInputArray(turnStartEvent.input)
             ? turnStartEvent.input
             : originalInput;
+          turnStartCancelReason =
+            getTurnStartCancel(turnStartEvent)?.reason ?? null;
         } catch {
           // Mod turn_start handlers should not block sending the turn.
           currentInput = originalInput;
+          turnStartCancelReason = null;
         }
       }
 
@@ -685,6 +690,18 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
       let preserveTranscriptStartForApproval = false;
 
       try {
+        if (turnStartCancelReason) {
+          const statusId = uid("status");
+          buffersRef.current.byId.set(statusId, {
+            kind: "status",
+            id: statusId,
+            lines: [turnStartCancelReason],
+          });
+          buffersRef.current.order.push(statusId);
+          refreshDerived();
+          return;
+        }
+
         // Check if user hit escape before we started
         if (userCancelledRef.current) {
           userCancelledRef.current = false; // Reset for next time

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -111,6 +111,7 @@ import {
 import { computeDiffPreviews } from "./helpers/diff-preview";
 import { disableModsForProcess, shouldDisableMods } from "./mods/disable";
 import type { ModAdapter } from "./mods/mod-adapter";
+import { getTurnStartCancel } from "./mods/turn-start-cancel";
 import type { ModContext, ModConversationOpenReason } from "./mods/types";
 import { formatPermissionDenial } from "./permissions/format-denial";
 import { applyStartupPermissionMode } from "./permissions/startup";
@@ -442,13 +443,107 @@ function isTurnInputArray(
   );
 }
 
+type HeadlessTurnStartEmission =
+  | { cancelled: false; input: Array<MessageCreate | ApprovalCreate> }
+  | { cancelled: true; reason: string };
+
+async function emitHeadlessTurnStartCancellationOutput(options: {
+  agent: AgentState;
+  conversationId: string;
+  outputFormat: string;
+  reason: string;
+  sessionId: string;
+}): Promise<void> {
+  if (options.outputFormat === "stream-json") {
+    const errorMsg: ErrorMessage = {
+      type: "error",
+      message: options.reason,
+      stop_reason: "cancelled",
+      session_id: options.sessionId,
+      uuid: `error-turn-start-cancel-${randomUUID()}`,
+    };
+    await writeWireMessageAsync(errorMsg);
+    const resultMsg: ResultMessage = {
+      type: "result",
+      subtype: "error",
+      session_id: options.sessionId,
+      duration_ms: 0,
+      duration_api_ms: 0,
+      num_turns: 0,
+      result: options.reason,
+      agent_id: options.agent.id,
+      conversation_id: options.conversationId,
+      run_ids: [],
+      usage: null,
+      uuid: `result-turn-start-cancel-${randomUUID()}`,
+      stop_reason: "cancelled",
+    };
+    await writeWireMessageAsync(resultMsg);
+  } else if (options.outputFormat === "json") {
+    await writeFinalHeadlessStdout(
+      `${JSON.stringify(
+        {
+          type: "result",
+          subtype: "error",
+          is_error: true,
+          duration_ms: 0,
+          duration_api_ms: 0,
+          num_turns: 0,
+          result: options.reason,
+          agent_id: options.agent.id,
+          conversation_id: options.conversationId,
+          usage: null,
+          stop_reason: "cancelled",
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  } else {
+    console.error(`Error: ${options.reason}`);
+  }
+}
+
+function writeBidirectionalTurnStartCancellation(options: {
+  agent: AgentState;
+  conversationId: string;
+  reason: string;
+  sessionId: string;
+}): void {
+  const errorMsg: ErrorMessage = {
+    type: "error",
+    message: options.reason,
+    stop_reason: "cancelled",
+    session_id: options.sessionId,
+    uuid: `error-turn-start-cancel-${randomUUID()}`,
+  };
+  writeWireMessage(errorMsg);
+
+  const resultMsg: ResultMessage = {
+    type: "result",
+    subtype: "error",
+    session_id: options.sessionId,
+    duration_ms: 0,
+    duration_api_ms: 0,
+    num_turns: 0,
+    result: options.reason,
+    agent_id: options.agent.id,
+    conversation_id: options.conversationId,
+    run_ids: [],
+    usage: null,
+    uuid: `result-turn-start-cancel-${randomUUID()}`,
+    stop_reason: "cancelled",
+  };
+  writeWireMessage(resultMsg);
+}
+
 async function emitHeadlessTurnStart(options: {
   agent: AgentState;
   conversationId: string;
   input: Array<MessageCreate | ApprovalCreate>;
   adapter: ModAdapter;
   context: ModContext;
-}): Promise<Array<MessageCreate | ApprovalCreate>> {
+}): Promise<HeadlessTurnStartEmission> {
   try {
     const event = {
       agentId: options.agent.id,
@@ -456,10 +551,15 @@ async function emitHeadlessTurnStart(options: {
       input: options.input,
     };
     await options.adapter.events.emit("turn_start", event, options.context);
-    return isTurnInputArray(event.input) ? event.input : options.input;
+    const cancel = getTurnStartCancel(event);
+    if (cancel) return { cancelled: true, reason: cancel.reason };
+    return {
+      cancelled: false,
+      input: isTurnInputArray(event.input) ? event.input : options.input,
+    };
   } catch {
     // Mod turn_start handlers should not block sending the turn.
-    return options.input;
+    return { cancelled: false, input: options.input };
   }
 }
 
@@ -1966,13 +2066,25 @@ ${SYSTEM_REMINDER_CLOSE}
     reflectionSettings: effectiveReflectionSettings,
     sessionStats,
   });
-  currentInput = await emitHeadlessTurnStart({
+  const initialTurnStartEmission = await emitHeadlessTurnStart({
     agent,
     conversationId,
     input: currentInput,
     adapter: headlessModAdapter,
     context: turnStartModContext,
   });
+  if (initialTurnStartEmission.cancelled) {
+    await emitHeadlessTurnStartCancellationOutput({
+      agent,
+      conversationId,
+      outputFormat,
+      reason: initialTurnStartEmission.reason,
+      sessionId,
+    });
+    await exitHeadless(1, "headless_turn_start_cancelled");
+  } else {
+    currentInput = initialTurnStartEmission.input;
+  }
 
   // Track lastRunId outside the while loop so it's available in catch block
   let llmApiErrorRetries = 0;
@@ -2443,13 +2555,25 @@ ${SYSTEM_REMINDER_CLOSE}
               otid: randomUUID(),
             },
           ];
-          currentInput = await emitHeadlessTurnStart({
+          const continueTurnStartEmission = await emitHeadlessTurnStart({
             agent,
             conversationId,
             input: currentInput,
             adapter: headlessModAdapter,
             context: turnStartModContext,
           });
+          if (continueTurnStartEmission.cancelled) {
+            await emitHeadlessTurnStartCancellationOutput({
+              agent,
+              conversationId,
+              outputFormat,
+              reason: continueTurnStartEmission.reason,
+              sessionId,
+            });
+            await exitHeadless(1, "headless_turn_start_cancelled");
+          } else {
+            currentInput = continueTurnStartEmission.input;
+          }
           continue;
         }
 
@@ -4023,13 +4147,23 @@ async function runBidirectionalMode(
         let currentInput: Array<MessageCreate | ApprovalCreate> = [
           { role: "user", content: enrichedContent, otid: userOtid },
         ];
-        currentInput = await emitHeadlessTurnStart({
+        const turnStartEmission = await emitHeadlessTurnStart({
           agent,
           conversationId,
           input: currentInput,
           adapter: headlessModAdapter,
           context: turnStartModContext,
         });
+        if (turnStartEmission.cancelled) {
+          writeBidirectionalTurnStartCancellation({
+            agent,
+            conversationId,
+            reason: turnStartEmission.reason,
+            sessionId,
+          });
+          continue;
+        }
+        currentInput = turnStartEmission.input;
 
         // Approval handling loop - continue until end_turn or error
         while (true) {

--- a/src/mods/mod-engine.test.ts
+++ b/src/mods/mod-engine.test.ts
@@ -1129,6 +1129,99 @@ describe("mod engine", () => {
     }
   });
 
+  test("lets turn_start handlers cancel with first valid reason", async () => {
+    const root = createTempDir();
+    try {
+      const modDir = path.join(root, "global-mods");
+      mkdirSync(modDir, { recursive: true });
+      writeFileSync(
+        path.join(modDir, "turn-start-cancel.ts"),
+        `export default function(letta) {
+          letta.events.on("turn_start", () => ({
+            cancel: { reason: "   " },
+          }));
+          letta.events.on("turn_start", () => ({
+            cancel: { reason: " Run /plan first. " },
+          }));
+          letta.events.on("turn_start", (event) => {
+            event.cancel = { reason: "mutated event should not win" };
+            return { cancel: { reason: "second reason should not win" } };
+          });
+          letta.events.on("turn_start", () => {
+            throw new Error("turn_start failed after cancel");
+          });
+        }`,
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+      const event: {
+        agentId: string;
+        cancel?: { reason: string };
+        conversationId: string;
+        input: Array<{ role: "user"; content: string }>;
+      } = {
+        agentId: "agent-1",
+        conversationId: "conversation-1",
+        input: [{ role: "user", content: "hello" }],
+      };
+
+      const result = await engine.emitEvent(
+        "turn_start",
+        event,
+        createModContext(),
+      );
+
+      expect(result).toMatchObject({
+        handlerCount: 4,
+        name: "turn_start",
+      });
+      expect(result.diagnostics).toHaveLength(1);
+      expect(event.cancel).toEqual({ reason: "Run /plan first." });
+
+      engine.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("ignores turn_start cancel set directly on the event", async () => {
+    const root = createTempDir();
+    try {
+      const modDir = path.join(root, "global-mods");
+      mkdirSync(modDir, { recursive: true });
+      writeFileSync(
+        path.join(modDir, "turn-start-cancel-mutation.ts"),
+        `export default function(letta) {
+          letta.events.on("turn_start", (event) => {
+            event.cancel = { reason: "direct mutation should not cancel" };
+          });
+        }`,
+      );
+
+      const engine = createEngine(root);
+      await engine.reload();
+      const event: {
+        agentId: string;
+        cancel?: { reason: string };
+        conversationId: string;
+        input: Array<{ role: "user"; content: string }>;
+      } = {
+        agentId: "agent-1",
+        conversationId: "conversation-1",
+        input: [{ role: "user", content: "hello" }],
+      };
+
+      await engine.emitEvent("turn_start", event, createModContext());
+
+      expect(event.cancel).toBeUndefined();
+
+      engine.dispose();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("lets tool_start handlers replace args in registration order", async () => {
     const root = createTempDir();
     try {

--- a/src/mods/mod-engine.ts
+++ b/src/mods/mod-engine.ts
@@ -64,6 +64,7 @@ import {
   unregisterModTool,
   unregisterModToolsForOwner,
 } from "@/mods/tool-registry";
+import { normalizeTurnStartCancelReason } from "@/mods/turn-start-cancel";
 import type {
   ModCapabilities,
   ModCommand,
@@ -92,6 +93,7 @@ import type {
   ModToolRegistration,
   ModToolStartEvent,
   ModTurnEndEvent,
+  ModTurnStartCancelResult,
   ModTurnStartEvent,
 } from "@/mods/types";
 
@@ -715,6 +717,22 @@ function isTurnStartResultWithInput(
     typeof result === "object" &&
     result !== null &&
     isTurnStartInput((result as { input?: unknown }).input)
+  );
+}
+
+function isTurnStartResultWithCancel(
+  name: ModEventName,
+  result: unknown,
+): result is { cancel: ModTurnStartCancelResult } {
+  if (name !== "turn_start" || typeof result !== "object" || !result) {
+    return false;
+  }
+  const cancel = (result as { cancel?: unknown }).cancel;
+  return (
+    typeof cancel === "object" &&
+    cancel !== null &&
+    normalizeTurnStartCancelReason((cancel as { reason?: unknown }).reason) !==
+      null
   );
 }
 
@@ -1602,6 +1620,7 @@ export async function emitLocalModEvent<TName extends ModEventName>(
   const registrations = [...(registry.events[name] ?? [])];
   const diagnostics: ModDiagnostic[] = [];
   const results: Array<NonNullable<ModEventResultMap[TName]>> = [];
+  let turnStartCancel: ModTurnStartCancelResult | undefined;
 
   for (const registration of registrations) {
     const signal = registration.owner
@@ -1661,6 +1680,10 @@ export async function emitLocalModEvent<TName extends ModEventName>(
       const result = await registration.handler(event, eventContext);
       if (isTurnStartResultWithInput(name, result)) {
         (event as ModTurnStartEvent).input = result.input;
+      }
+      if (!turnStartCancel && isTurnStartResultWithCancel(name, result)) {
+        const reason = normalizeTurnStartCancelReason(result.cancel.reason);
+        if (reason) turnStartCancel = { reason };
       }
       if (isToolStartResultWithArgs(name, result)) {
         (event as ModToolStartEvent).args = result.args;
@@ -1727,6 +1750,17 @@ export async function emitLocalModEvent<TName extends ModEventName>(
         onDiagnostic,
       );
       diagnostics.push(diagnostic);
+    }
+  }
+
+  if (name === "turn_start") {
+    const turnStartEventWithCancel = event as ModTurnStartEvent & {
+      cancel?: ModTurnStartCancelResult;
+    };
+    if (turnStartCancel) {
+      turnStartEventWithCancel.cancel = { ...turnStartCancel };
+    } else {
+      delete turnStartEventWithCancel.cancel;
     }
   }
 

--- a/src/mods/turn-start-cancel.ts
+++ b/src/mods/turn-start-cancel.ts
@@ -1,0 +1,24 @@
+import type { ModTurnStartCancelResult } from "@/mods/types";
+
+const MAX_TURN_START_CANCEL_REASON_LENGTH = 2000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function normalizeTurnStartCancelReason(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.length > MAX_TURN_START_CANCEL_REASON_LENGTH
+    ? trimmed.slice(0, MAX_TURN_START_CANCEL_REASON_LENGTH)
+    : trimmed;
+}
+
+export function getTurnStartCancel(
+  event: unknown,
+): ModTurnStartCancelResult | null {
+  if (!isRecord(event) || !isRecord(event.cancel)) return null;
+  const reason = normalizeTurnStartCancelReason(event.cancel.reason);
+  return reason ? { reason } : null;
+}

--- a/src/mods/types.ts
+++ b/src/mods/types.ts
@@ -211,8 +211,13 @@ export interface ModTurnStartEvent {
   input: Array<MessageCreate | ApprovalCreate>;
 }
 
+export interface ModTurnStartCancelResult {
+  reason: string;
+}
+
 export interface ModTurnStartResult {
   input?: Array<MessageCreate | ApprovalCreate>;
+  cancel?: ModTurnStartCancelResult;
 }
 
 export interface ModToolStartEvent {

--- a/src/skills/builtin/creating-mods/references/events.md
+++ b/src/skills/builtin/creating-mods/references/events.md
@@ -59,7 +59,7 @@ letta.events.on("tool_start", (event, ctx) => {
 
 Lifecycle, turn, tool, compaction, and llm events are wired today.
 
-Lifecycle handlers are notification-only and should not return values. `turn_start` handlers can transform the outbound input for the next model turn. `tool_start` handlers can transform the tool arguments before execution. Compaction and llm handlers are notification-only.
+Lifecycle handlers are notification-only and should not return values. `turn_start` handlers can transform or cancel outbound user-message turns. `tool_start` handlers can transform the tool arguments before execution. Compaction and llm handlers are notification-only.
 
 `compact_start`/`compact_end` and `llm_start`/`llm_end` only fire on the **local backend**, where compaction and provider requests run client-side. On the constellation backend that work happens server-side and these events do not fire, so guard with `letta.capabilities.events.compact` / `letta.capabilities.events.llm` for portable mods.
 
@@ -186,7 +186,7 @@ letta.events.on("tool_end", async (event, ctx) => {
 });
 ```
 
-`turn_start` fires before outbound turns that include a user message. In the TUI this includes normal submits and prompt-style command turns. In headless it includes one-shot prompts and bidirectional user turns.
+`turn_start` fires before outbound turns that include a user message. In the TUI this includes normal submits and prompt-style command turns. In headless it includes one-shot prompts and bidirectional user turns. Listener/Desktop skips approval-only continuations so mods do not rewrite approval payloads; do not rely on `turn_start` to block approval-only continuations on every surface.
 
 Handlers can mutate `event.input` directly or return replacement input:
 
@@ -213,6 +213,18 @@ letta.events.on("turn_start", (event) => {
   return { input: event.input };
 });
 ```
+
+Handlers can also cancel a user-message turn before it reaches the backend/model:
+
+```ts
+letta.events.on("turn_start", (event) => {
+  if (!isPlanModeActive(event.conversationId)) {
+    return { cancel: { reason: "Run /plan first." } };
+  }
+});
+```
+
+If multiple handlers cancel, the first valid cancel reason wins. A valid reason is a non-empty string after trimming. Cancellation does not synthesize an assistant response or tool result; it only tells the host not to submit this turn.
 
 Handlers run in registration order. Later handlers see the current input after earlier mutations/returns. If a handler throws, its partial `event.input` mutation is rolled back and the error is recorded as a mod diagnostic.
 

--- a/src/websocket/listen-client-concurrency.test.ts
+++ b/src/websocket/listen-client-concurrency.test.ts
@@ -7,7 +7,7 @@ import {
   mock,
   test,
 } from "bun:test";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { APIError } from "@letta-ai/letta-client/error";
@@ -274,6 +274,9 @@ mock.module("../agent/approval-recovery", () => ({
 }));
 
 const listenClientModule = await import("@/websocket/listen-client");
+const { createListenerModAdapter } = await import(
+  "@/websocket/listener/mod-adapter"
+);
 const { sendApprovalContinuationWithRetry, sendMessageStreamWithRetry } =
   await import("@/websocket/listener/send");
 const {
@@ -518,6 +521,49 @@ describe("listen-client multi-worker concurrency", () => {
     await turnA;
     expect(runtimeA.isProcessing).toBe(false);
     expect(__listenClientTestUtils.getListenerStatus(listener)).toBe("idle");
+  });
+
+  test("turn_start cancel stops listener turn before sending", async () => {
+    const modsDir = await mkdtemp(join(tmpdir(), "letta-listener-mods-"));
+    const cacheDir = await mkdtemp(join(tmpdir(), "letta-listener-mod-cache-"));
+    try {
+      await writeFile(
+        join(modsDir, "cancel-turn.ts"),
+        `export default function activate(letta) {
+          letta.events.on("turn_start", () => ({
+            cancel: { reason: " Run /plan first. " },
+          }));
+        }`,
+      );
+      const listener = __listenClientTestUtils.createListenerRuntime();
+      listener.modAdapter = createListenerModAdapter({
+        cacheDirectory: cacheDir,
+        globalModsDirectory: modsDir,
+        sessionId: "listener-cancel-test",
+        workingDirectory: modsDir,
+      });
+      await listener.modAdapter.reload();
+      const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
+        listener,
+        "agent-cancel",
+        "conv-cancel",
+      );
+      const socket = new MockSocket();
+
+      await __listenClientTestUtils.handleIncomingMessage(
+        makeIncomingMessage("agent-cancel", "conv-cancel", "hello"),
+        socket as unknown as WebSocket,
+        runtime,
+      );
+
+      expect(sendMessageStreamMock).not.toHaveBeenCalled();
+      expect(runtime.isProcessing).toBe(false);
+      expect(runtime.lastStopReason).toBe("cancelled");
+      expect(JSON.stringify(socket.sentPayloads)).toContain("Run /plan first.");
+    } finally {
+      await rm(modsDir, { recursive: true, force: true });
+      await rm(cacheDir, { recursive: true, force: true });
+    }
   });
 
   test("listener turns skip duplicate shared image normalization", async () => {

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -48,6 +48,7 @@ import {
 } from "@/cli/helpers/reflection-launcher";
 import { appendTranscriptDeltaJsonl } from "@/cli/helpers/reflection-transcript";
 import { drainStreamWithResume } from "@/cli/helpers/stream";
+import { getTurnStartCancel } from "@/mods/turn-start-cancel";
 import {
   buildSharedReminderParts,
   prependReminderPartsToContent,
@@ -224,6 +225,10 @@ function isTurnInputArray(
   );
 }
 
+type ListenerTurnStartEmission =
+  | { cancelled: false; input: Array<MessageCreate | ApprovalCreate> }
+  | { cancelled: true; reason: string };
+
 async function emitListenerTurnStart(options: {
   agentId: string;
   conversationId: string;
@@ -232,7 +237,7 @@ async function emitListenerTurnStart(options: {
   workingDirectory: string;
   permissionMode?: string | null;
   cachedAgent?: AgentState | null;
-}): Promise<Array<MessageCreate | ApprovalCreate>> {
+}): Promise<ListenerTurnStartEmission> {
   try {
     const modAdapter = ensureListenerModAdapter(options.runtime);
     const context = createListenerModContext({
@@ -247,10 +252,15 @@ async function emitListenerTurnStart(options: {
       input: options.input,
     };
     await modAdapter.events.emit("turn_start", event, context);
-    return isTurnInputArray(event.input) ? event.input : options.input;
+    const cancel = getTurnStartCancel(event);
+    if (cancel) return { cancelled: true, reason: cancel.reason };
+    return {
+      cancelled: false,
+      input: isTurnInputArray(event.input) ? event.input : options.input,
+    };
   } catch {
     // Mod turn_start handlers should not block sending the turn.
-    return options.input;
+    return { cancelled: false, input: options.input };
   }
 }
 
@@ -634,7 +644,7 @@ export async function handleIncomingMessage(
     const hasUserMessage = messagesToSend.some(
       (m) => "role" in m && m.role === "user",
     );
-    let currentInput = hasUserMessage
+    const turnStartEmission = hasUserMessage
       ? await emitListenerTurnStart({
           agentId,
           conversationId,
@@ -644,7 +654,35 @@ export async function handleIncomingMessage(
           permissionMode: turnPermissionModeState.mode,
           cachedAgent,
         })
-      : messagesToSend;
+      : ({ cancelled: false, input: messagesToSend } as const);
+
+    if (turnStartEmission.cancelled) {
+      runtime.lastStopReason = "cancelled";
+      runtime.isProcessing = false;
+      clearActiveRunState(runtime);
+      setLoopStatus(runtime, "WAITING_ON_INPUT", {
+        agent_id: agentId || null,
+        conversation_id: conversationId,
+      });
+      emitRuntimeStateUpdates(runtime, {
+        agent_id: agentId || null,
+        conversation_id: conversationId,
+      });
+      const formattedError = emitLoopErrorNotice(socket, runtime, {
+        message: turnStartEmission.reason,
+        stopReason: "cancelled",
+        isTerminal: true,
+        agentId,
+        conversationId,
+        cancelRequested: runtime.cancelRequested,
+        abortSignal: turnAbortSignal,
+      });
+      runtime.lastTerminalLoopErrorMessage =
+        formattedError ?? turnStartEmission.reason;
+      return;
+    }
+
+    let currentInput = turnStartEmission.input;
 
     // Rebuild transcript lines from the potentially transformed input so
     // Desktop shows post-transform text, not the original user message.


### PR DESCRIPTION
## Summary
- add an explicit `turn_start` `{ cancel: { reason } }` effect for trusted mods
- surface cancellation before backend/model send in TUI, headless, and listener/Desktop paths
- normalize/truncate cancel reasons and preserve first valid cancel reason
- document the new event effect and add engine/listener coverage

## Tests
- `bun run check`
- `bun test src/mods/mod-engine.test.ts`
- `bun test src/websocket/listen-client-concurrency.test.ts`