### PR TITLE
ci(headless): add live Ollama integration job [LET-9314]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,8 +380,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Smallest tool-capable model to keep CPU inference + pull time bounded.
-        model: [qwen2.5:0.5b]
+        # qwen2.5:3b balances tool-calling reliability against CPU-only
+        # inference time. 0.5b/1b are too weak for the multi-step parallel
+        # tool-call + memory scenario (never emits the success sentinel).
+        model: [qwen2.5:3b]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,6 +367,61 @@ jobs:
           bun run src/test-utils/headless-scenario.ts --backend local --model "${{ matrix.model }}" --output json --parallel on
           bun run src/test-utils/headless-scenario.ts --backend local --model "${{ matrix.model }}" --output stream-json --parallel on
 
+  headless-ollama:
+    needs: [classify, check]
+    if: ${{ needs.classify.outputs.run_heavy_ci == 'true' && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository)) }}
+    name: Headless Ollama / ${{ matrix.model }}
+    runs-on: ubuntu-latest
+    # Land non-blocking while we observe CPU inference timing + tiny-model
+    # reliability; flip to a required check once stable.
+    continue-on-error: true
+    # Ollama inference runs on the CPU-only runner, so keep a generous cap.
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        # Smallest tool-capable model to keep CPU inference + pull time bounded.
+        model: [qwen2.5:0.5b]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.0
+
+      - name: Install dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun install --frozen-lockfile
+
+      - name: Install Ollama
+        run: curl -fsSL https://ollama.com/install.sh | sh
+
+      - name: Start Ollama server
+        run: |
+          ollama serve > /tmp/ollama.log 2>&1 &
+          for _ in $(seq 1 30); do
+            if curl -fsS http://localhost:11434/api/version >/dev/null 2>&1; then
+              echo "Ollama is up"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Ollama failed to start within 30s"
+          cat /tmp/ollama.log
+          exit 1
+
+      - name: Pull model
+        run: ollama pull "${{ matrix.model }}"
+
+      - name: Run local backend headless scenario against Ollama
+        env:
+          OLLAMA_BASE_URL: http://localhost:11434/v1
+        run: |
+          bun run src/test-utils/headless-scenario.ts --backend local --model "ollama/${{ matrix.model }}" --output text --parallel on
+
   reflection-headless:
     needs: [classify, check]
     if: ${{ needs.classify.outputs.run_heavy_ci == 'true' && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository)) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,23 +367,25 @@ jobs:
           bun run src/test-utils/headless-scenario.ts --backend local --model "${{ matrix.model }}" --output json --parallel on
           bun run src/test-utils/headless-scenario.ts --backend local --model "${{ matrix.model }}" --output stream-json --parallel on
 
-  headless-ollama:
+  ollama-smoke:
     needs: [classify, check]
     if: ${{ needs.classify.outputs.run_heavy_ci == 'true' && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository)) }}
-    name: Headless Ollama / ${{ matrix.model }}
+    name: Ollama Smoke / ${{ matrix.model }}
     runs-on: ubuntu-latest
-    # Land non-blocking while we observe CPU inference timing + tiny-model
-    # reliability; flip to a required check once stable.
+    # Land non-blocking while we observe CPU inference timing + reliability;
+    # flip to a required check once stable.
     continue-on-error: true
     # Ollama inference runs on the CPU-only runner, so keep a generous cap.
-    timeout-minutes: 20
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        # qwen2.5:3b balances tool-calling reliability against CPU-only
-        # inference time. 0.5b/1b are too weak for the multi-step parallel
-        # tool-call + memory scenario (never emits the success sentinel).
-        model: [qwen2.5:3b]
+        # Small fast model: this job runs a lightweight provider smoke
+        # (--smoke), not the full tool-calling scenario, so it only needs to
+        # round-trip a trivial prompt. The strict scenario is unworkable on
+        # CPU runners (0.5b/1b too weak to emit the sentinel; 3b too slow and
+        # hits the 6-min/attempt CLI timeout).
+        model: [qwen2.5:1.5b]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -418,11 +420,11 @@ jobs:
       - name: Pull model
         run: ollama pull "${{ matrix.model }}"
 
-      - name: Run local backend headless scenario against Ollama
+      - name: Run Ollama provider smoke (connect + autodetect + round-trip)
         env:
           OLLAMA_BASE_URL: http://localhost:11434/v1
         run: |
-          bun run src/test-utils/headless-scenario.ts --backend local --model "ollama/${{ matrix.model }}" --output text --parallel on
+          bun run src/test-utils/headless-scenario.ts --backend local --model "ollama/${{ matrix.model }}" --output text --parallel on --smoke
 
   reflection-headless:
     needs: [classify, check]

--- a/src/test-utils/headless-scenario.ts
+++ b/src/test-utils/headless-scenario.ts
@@ -35,6 +35,11 @@ type Args = {
   output: "text" | "json" | "stream-json";
   parallel: "on" | "off" | "hybrid";
   provider?: LocalProvider;
+  // Smoke mode: trivial no-tools prompt asserting a sentinel word. Exercises
+  // the provider request path (connect/autodetect/round-trip) without the full
+  // tool-calling scenario — needed for weak/slow local models (e.g. Ollama on
+  // CPU runners) that cannot pass the frontier-model scenario in time.
+  smoke: boolean;
 };
 
 interface RunResult {
@@ -51,10 +56,12 @@ function parseArgs(argv: string[]): Args {
     output: Args["output"];
     parallel: Args["parallel"];
     provider?: LocalProvider;
+    smoke: boolean;
   } = {
     backend: "api",
     output: "text",
     parallel: "on",
+    smoke: false,
   };
   for (let i = 0; i < argv.length; i++) {
     const v = argv[i];
@@ -63,6 +70,7 @@ function parseArgs(argv: string[]): Args {
     else if (v === "--output") args.output = argv[++i] as Args["output"];
     else if (v === "--parallel") args.parallel = argv[++i] as Args["parallel"];
     else if (v === "--provider") args.provider = argv[++i] as LocalProvider;
+    else if (v === "--smoke") args.smoke = true;
   }
   if (!args.model) throw new Error("Missing --model");
   if (!["api", "local"].includes(args.backend)) {
@@ -161,8 +169,17 @@ function localScenarioPrompt(): string {
   );
 }
 
-function scenarioPrompt(backend: Backend): string {
-  return backend === "local" ? localScenarioPrompt() : apiScenarioPrompt();
+function smokePrompt(): string {
+  return (
+    "This is an automated CI smoke test (no human to assist). " +
+    "Do not call any tools. " +
+    "Respond with exactly the single uppercase word PONG and nothing else."
+  );
+}
+
+function scenarioPrompt(args: Args): string {
+  if (args.smoke) return smokePrompt();
+  return args.backend === "local" ? localScenarioPrompt() : apiScenarioPrompt();
 }
 
 function providerEnvValue(provider: LocalProvider): string {
@@ -191,7 +208,7 @@ async function runCLI(args: Args): Promise<RunResult> {
     "run",
     "dev",
     "-p",
-    scenarioPrompt(args.backend),
+    scenarioPrompt(args),
     "--yolo",
     "--new-agent",
   ];
@@ -309,6 +326,7 @@ async function validateLocalStorage(storageDir: string | undefined) {
 }
 
 const REQUIRED_MARKERS = ["BANANA"];
+const SMOKE_MARKERS = ["PONG"];
 const MAX_ATTEMPTS = 3;
 
 function assertContainsAll(hay: string, needles: string[]) {
@@ -345,9 +363,13 @@ function extractStreamJsonAssistantText(stdout: string): string {
   return parts.join("");
 }
 
-function validateOutput(stdout: string, output: Args["output"]) {
+function validateOutput(
+  stdout: string,
+  output: Args["output"],
+  markers: string[],
+) {
   if (output === "text") {
-    assertContainsAll(stdout, REQUIRED_MARKERS);
+    assertContainsAll(stdout, markers);
     return;
   }
 
@@ -355,7 +377,7 @@ function validateOutput(stdout: string, output: Args["output"]) {
     try {
       const obj = JSON.parse(stdout);
       const result = String(obj?.result ?? "");
-      assertContainsAll(result, REQUIRED_MARKERS);
+      assertContainsAll(result, markers);
       return;
     } catch (e) {
       throw new Error(`Invalid JSON output: ${(e as Error).message}`);
@@ -366,7 +388,7 @@ function validateOutput(stdout: string, output: Args["output"]) {
   if (!streamText) {
     throw new Error("No assistant/result content found in stream-json output");
   }
-  assertContainsAll(streamText, REQUIRED_MARKERS);
+  assertContainsAll(streamText, markers);
 }
 
 async function main() {
@@ -390,8 +412,14 @@ async function main() {
           })}`,
         );
       }
-      validateOutput(run.stdout, args.output);
-      if (args.backend === "local") {
+      validateOutput(
+        run.stdout,
+        args.output,
+        args.smoke ? SMOKE_MARKERS : REQUIRED_MARKERS,
+      );
+      // Smoke mode only asserts the sentinel; it deliberately skips the
+      // tool-driven MemFS validation since it issues a no-tools prompt.
+      if (args.backend === "local" && !args.smoke) {
         await validateLocalStorage(run.localStorageDir);
       }
       console.log(`OK: ${args.backend} / ${args.model} / ${args.output}`);

--- a/src/test-utils/headless-scenario.ts
+++ b/src/test-utils/headless-scenario.ts
@@ -27,7 +27,7 @@ import {
 const execFile = promisify(execFileCb);
 
 type Backend = "api" | "local";
-type LocalProvider = "openai" | "anthropic" | "google";
+type LocalProvider = "openai" | "anthropic" | "google" | "ollama";
 
 type Args = {
   backend: Backend;
@@ -76,7 +76,7 @@ function parseArgs(argv: string[]): Args {
   }
   if (
     args.provider !== undefined &&
-    !["openai", "anthropic", "google"].includes(args.provider)
+    !["openai", "anthropic", "google", "ollama"].includes(args.provider)
   ) {
     throw new Error(`Invalid --provider ${args.provider}`);
   }
@@ -84,6 +84,9 @@ function parseArgs(argv: string[]): Args {
 }
 
 function inferLocalProvider(model: string): LocalProvider {
+  if (model.startsWith("ollama/")) {
+    return "ollama";
+  }
   if (
     model.startsWith("google/") ||
     model.startsWith("google_ai/") ||
@@ -113,6 +116,14 @@ async function ensurePrereqs(args: Args): Promise<"ok" | "skip"> {
   }
 
   const provider = args.provider ?? inferLocalProvider(args.model);
+  // Ollama is a local endpoint (no API key); it needs a reachable base URL.
+  if (provider === "ollama") {
+    if (!process.env.OLLAMA_BASE_URL) {
+      console.log("SKIP: Missing env OLLAMA_BASE_URL");
+      return "skip";
+    }
+    return "ok";
+  }
   const requiredKey =
     provider === "anthropic"
       ? "ANTHROPIC_API_KEY"
@@ -157,6 +168,7 @@ function scenarioPrompt(backend: Backend): string {
 function providerEnvValue(provider: LocalProvider): string {
   if (provider === "openai") return "openai-responses";
   if (provider === "google") return "google";
+  if (provider === "ollama") return "ollama";
   return "anthropic";
 }
 


### PR DESCRIPTION
## Summary
- Adds a heavy-gated `ollama-smoke` CI job that installs + starts a real Ollama server, pulls a small fast model (`qwen2.5:1.5b`), and runs a **lightweight provider smoke** against the OpenAI-compatible `/v1` endpoint.
- Teaches the local headless harness (`headless-scenario.ts`) an `ollama` provider (type, `inferLocalProvider`, keyless `ensurePrereqs` on `OLLAMA_BASE_URL`, `providerEnvValue` -> `LETTA_CODE_DEV_PI_PROVIDER=ollama`) and a `--smoke` mode (trivial no-tools prompt asserting a `PONG` sentinel; skips the tool-driven MemFS validation).
- Closes the gap where Ollama provider connect + local-endpoint autodetection had **zero live CI coverage**.

## Why a smoke instead of the full scenario
The strict headless scenario (parallel shell + memory write + `BANANA` gate) is a frontier-model eval and is unworkable for Ollama on CPU-only GitHub runners:
- `qwen2.5:0.5b` — fast but too weak, never emits `BANANA` (all 3 attempts failed).
- `qwen2.5:3b` — capable-ish but too slow, each attempt hits the 6-min/attempt CLI timeout.

The smoke instead proves what we actually care about: provider connect, local-endpoint autodetection, and a request round-tripping through `/v1`. Validated locally against a real Ollama server (`ollama/gemma4`) → `OK`.

## Notes
- Non-blocking (`continue-on-error: true`) initially; flip to a required check once stable.
- Same fork/Dependabot guards as the other heavy jobs.

## Test plan
- [ ] `ollama-smoke` job goes green within the 15-min cap
- [ ] Confirm pull + smoke timing is fast on the CPU runner
- [ ] Decide whether to flip to a blocking/required check
- [ ] `bun run check` green (lint + typecheck)