### PR TITLE
fix(memfs): centralize startup memfs enablement

### DIFF
--- a/src/agent/defaults.ts
+++ b/src/agent/defaults.ts
@@ -172,9 +172,7 @@ export async function ensureDefaultAgents(
 
   try {
     // Pre-determine memfs mode so the agent is created with the correct prompt.
-    const { isLettaCloud, enableMemfsIfCloud } = await import(
-      "@/agent/memory-filesystem"
-    );
+    const { isLettaCloud } = await import("@/agent/memory-filesystem");
     const willAutoEnableMemfs =
       backend.capabilities.remoteMemfs && (await isLettaCloud());
     const memoryPromptMode = backend.capabilities.localMemfs
@@ -190,12 +188,6 @@ export async function ensureDefaultAgents(
     });
     await addTagToAgent(backend, agent.id, MEMO_TAG);
     settingsManager.pinAgent(agent.id);
-
-    // Enable memfs on Letta Cloud (tags, repo clone, tool detach)
-    // without blocking startup on the initial clone.
-    if (backend.capabilities.remoteMemfs) {
-      void enableMemfsIfCloud(agent.id, backend);
-    }
 
     return agent;
   } catch (err) {

--- a/src/agent/defaults.ts
+++ b/src/agent/defaults.ts
@@ -11,6 +11,7 @@ import { getServerUrl } from "@/backend/api/client";
 import { settingsManager } from "@/settings-manager";
 import { type CreateAgentOptions, createAgent } from "./create";
 import { parseMdxFrontmatter } from "./memory";
+import { GIT_MEMORY_ENABLED_TAG } from "./memory-git";
 import { getDefaultModel, resolveModel } from "./model";
 import { MEMORY_PROMPTS } from "./prompt-assets";
 
@@ -151,6 +152,20 @@ async function addTagToAgent(
   }
 }
 
+async function ensureMemfsTagOnAgent(
+  backend: Backend,
+  agent: AgentState,
+): Promise<AgentState> {
+  const currentTags = agent.tags ?? [];
+  if (currentTags.includes(GIT_MEMORY_ENABLED_TAG)) {
+    return agent;
+  }
+
+  const tags = [...currentTags, GIT_MEMORY_ENABLED_TAG];
+  await backend.updateAgent(agent.id, { tags });
+  return { ...agent, tags };
+}
+
 /**
  * Create a fresh default Letta Code agent and pin it globally.
  * Always creates a new agent — does NOT search by tag to avoid picking up
@@ -181,11 +196,14 @@ export async function ensureDefaultAgents(
         ? "memfs"
         : undefined;
 
-    const { agent } = await createAgent({
+    let { agent } = await createAgent({
       ...DEFAULT_AGENT_CONFIGS.memo,
       model: await resolveDefaultAgentModel(backend, options?.preferredModel),
       memoryPromptMode,
     });
+    if (willAutoEnableMemfs) {
+      agent = await ensureMemfsTagOnAgent(backend, agent);
+    }
     await addTagToAgent(backend, agent.id, MEMO_TAG);
     settingsManager.pinAgent(agent.id);
 

--- a/src/agent/defaults.ts
+++ b/src/agent/defaults.ts
@@ -11,7 +11,6 @@ import { getServerUrl } from "@/backend/api/client";
 import { settingsManager } from "@/settings-manager";
 import { type CreateAgentOptions, createAgent } from "./create";
 import { parseMdxFrontmatter } from "./memory";
-import { GIT_MEMORY_ENABLED_TAG } from "./memory-git";
 import { getDefaultModel, resolveModel } from "./model";
 import { MEMORY_PROMPTS } from "./prompt-assets";
 
@@ -152,20 +151,6 @@ async function addTagToAgent(
   }
 }
 
-async function ensureMemfsTagOnAgent(
-  backend: Backend,
-  agent: AgentState,
-): Promise<AgentState> {
-  const currentTags = agent.tags ?? [];
-  if (currentTags.includes(GIT_MEMORY_ENABLED_TAG)) {
-    return agent;
-  }
-
-  const tags = [...currentTags, GIT_MEMORY_ENABLED_TAG];
-  await backend.updateAgent(agent.id, { tags });
-  return { ...agent, tags };
-}
-
 /**
  * Create a fresh default Letta Code agent and pin it globally.
  * Always creates a new agent — does NOT search by tag to avoid picking up
@@ -196,14 +181,11 @@ export async function ensureDefaultAgents(
         ? "memfs"
         : undefined;
 
-    let { agent } = await createAgent({
+    const { agent } = await createAgent({
       ...DEFAULT_AGENT_CONFIGS.memo,
       model: await resolveDefaultAgentModel(backend, options?.preferredModel),
       memoryPromptMode,
     });
-    if (willAutoEnableMemfs) {
-      agent = await ensureMemfsTagOnAgent(backend, agent);
-    }
     await addTagToAgent(backend, agent.id, MEMO_TAG);
     settingsManager.pinAgent(agent.id);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2360,15 +2360,24 @@ async function main(): Promise<void> {
         // Set agent context for tools that need it (e.g., Skill tool)
         setAgentContext(agent.id, skillsDirectory, resolvedSkillSources);
 
+        let startupMemfsFlag: boolean | undefined = autoEnableMemfsForFreshAgent
+          ? true
+          : memfsFlag;
         if (backend.capabilities.remoteMemfs && !autoEnableMemfsForFreshAgent) {
-          const { hydrateMemfsSettingFromAgent } = await import(
+          const { hydrateMemfsSettingFromAgent, isLettaCloud } = await import(
             "@/agent/memory-filesystem"
           );
           const memfsEnabled = await hydrateMemfsSettingFromAgent(agent);
           if (!memfsEnabled) {
-            console.warn(
-              "Warning: this agent does not have git-backed memory enabled. Run `/memfs enable` to enable MemFS.",
-            );
+            if (!noMemfsFlag && (await isLettaCloud())) {
+              // Auto-enable memfs for existing agents that don't have it yet.
+              // Agents can be created outside Letta Code without the tag.
+              startupMemfsFlag = true;
+            } else {
+              console.warn(
+                "Warning: this agent does not have git-backed memory enabled. Run `/memfs enable` to enable MemFS.",
+              );
+            }
           }
         }
 
@@ -2377,9 +2386,6 @@ async function main(): Promise<void> {
         // unless the user explicitly requested a memfs mode toggle.
         const agentId = agent.id;
         const agentTags = agent.tags ?? undefined;
-        const startupMemfsFlag = autoEnableMemfsForFreshAgent
-          ? true
-          : memfsFlag;
         const shouldBlockOnMemfsStartup = Boolean(memfsFlag || noMemfsFlag);
         const memfsSyncPromise = backend.capabilities.remoteMemfs
           ? import("@/agent/memory-filesystem").then(({ applyMemfsFlags }) =>


### PR DESCRIPTION
## Summary
- remove the default-agent fire-and-forget `enableMemfsIfCloud()` path so startup sync is the only local checkout owner
- mirror headless behavior in TUI startup: untagged Letta Cloud agents are auto-enabled for MemFS when loaded, unless `--no-memfs` is set
- preserve support for agents created outside Letta Code without racing duplicate clone/setup flows

## Test plan
- `bun test src/agent/defaults.test.ts src/agent/create.test.ts`
- `bun run check`

Linear: https://linear.app/letta/issue/LET-9316/fix-default-agent-memfs-startup-race