### PR TITLE
feat(agent): default subagents to background execution

### DIFF
--- a/src/agent/subagent-builtins.test.ts
+++ b/src/agent/subagent-builtins.test.ts
@@ -55,6 +55,52 @@ describe("built-in subagents", () => {
     expect(configs.init?.launchProfile).toBe("memory-subagent");
   });
 
+  test("subagents run in the background by default", async () => {
+    const configs = await getAllSubagentConfigs();
+
+    for (const name of [
+      "fork",
+      "general-purpose",
+      "history-analyzer",
+      "init",
+      "memory",
+      "recall",
+      "reflection",
+    ]) {
+      expect(configs[name]?.background).toBe(true);
+    }
+  });
+
+  test("custom subagents can explicitly opt out of the background default", async () => {
+    tempDir = createTempProjectDir();
+    writeCustomSubagent(
+      tempDir,
+      "background-worker.md",
+      `---
+name: background-worker
+description: Custom background worker
+tools: Read
+---
+Custom prompt body`,
+    );
+    writeCustomSubagent(
+      tempDir,
+      "foreground-worker.md",
+      `---
+name: foreground-worker
+description: Custom foreground worker
+tools: Read
+background: false
+---
+Custom prompt body`,
+    );
+
+    const configs = await getAllSubagentConfigs(tempDir);
+
+    expect(configs["background-worker"]?.background).toBe(true);
+    expect(configs["foreground-worker"]?.background).toBe(false);
+  });
+
   test("reflection exposes only Edit among first-class file tools", async () => {
     const configs = await getAllSubagentConfigs();
     const hiddenFileTools = ["Read", "Write", "Glob", "Grep"];

--- a/src/agent/subagents/index.ts
+++ b/src/agent/subagents/index.ts
@@ -159,6 +159,10 @@ function parseLaunchProfile(
   return launchProfile === "memory-subagent" ? "memory-subagent" : "default";
 }
 
+function parseBackgroundDefault(background: string | undefined): boolean {
+  return background?.toLowerCase() !== "false";
+}
+
 /**
  * Validate subagent frontmatter
  * Only validates required fields - optional fields are validated at runtime where needed
@@ -214,8 +218,9 @@ function parseSubagentContent(content: string): SubagentConfig {
     recommendedModel: getStringField(frontmatter, "model") || "inherit",
     skills: parseSkills(getStringField(frontmatter, "skills")),
     fork: getStringField(frontmatter, "fork")?.toLowerCase() === "true",
-    background:
-      getStringField(frontmatter, "background")?.toLowerCase() === "true",
+    background: parseBackgroundDefault(
+      getStringField(frontmatter, "background"),
+    ),
     launchProfile: parseLaunchProfile(
       getStringField(frontmatter, "launchProfile"),
     ),

--- a/src/headless-bidirectional-reflection.test.ts
+++ b/src/headless-bidirectional-reflection.test.ts
@@ -159,6 +159,9 @@ async function runBidirectionalReflectionScenario(): Promise<BidirectionalReflec
         LETTA_LOCAL_BACKEND_DIR: localBackendDir,
         LETTA_LOCAL_BACKEND_EXECUTOR: "deterministic",
         LETTA_TRANSCRIPT_ROOT: transcriptRoot,
+        // This test exercises transcript-driven reflection, not kernel sandbox
+        // behavior. Keep it independent of host bwrap/seatbelt availability.
+        LETTA_FS_SANDBOX: "0",
         USER_CWD: projectDir,
         LETTA_DEBUG: "1",
         NO_COLOR: "1",

--- a/src/tools/descriptions/Task.md
+++ b/src/tools/descriptions/Task.md
@@ -18,7 +18,8 @@ When using the Agent tool, you must specify a subagent_type parameter to select 
 - Always include a short description (3-5 words) summarizing what the agent will do
 - Launch multiple agents concurrently whenever possible, to maximize performance; to do that, use a single message with multiple tool uses
 - When the agent is done, it will return a single message back to you. The result returned by the agent is not visible to the user. To show the user the result, you should send a text message back to the user with a concise summary of the result.
-- You can optionally run agents in the background using the run_in_background parameter. When an agent runs in the background, the tool result will include a task ID and an output_file path, and you will be notified automatically via a <task-notification> message when it completes — no need to poll. If you need interim progress before then, use the TaskOutput tool with the task ID. You can continue working while background agents run.
+- Agents run in the background by default. The tool result will include a task ID and an output_file path, and you will be notified automatically via a <task-notification> message when it completes — no need to poll. If you need interim progress before then, use the TaskOutput tool with the task ID. You can continue working while background agents run.
+- Set `run_in_background: false` only when you must block and wait for the final report inline.
 - Agents can be resumed using the `conversation_id` parameter by passing the conversation ID from a previous invocation. When resumed, the agent continues with its full previous context preserved.
 - When the agent is done, it will return a single message back to you along with its conversation ID. You can use this ID to resume the agent later if needed for follow-up work.
 - Provide clear, detailed prompts so the agent can work autonomously and return exactly the information you need.

--- a/src/tools/schemas/Task.json
+++ b/src/tools/schemas/Task.json
@@ -19,7 +19,7 @@
     },
     "run_in_background": {
       "type": "boolean",
-      "description": "Set to true to run this agent in the background. The tool result will include an output_file path - use Read tool or Bash tail to check on output."
+      "description": "Defaults to true. Set to false only when you must block and wait for the agent's final report inline. Background runs return a task ID/output file and deliver a task notification on completion."
     },
     "agent_id": {
       "type": "string",


### PR DESCRIPTION
## Summary

- Defaults parsed subagent configs to background execution when `background` is omitted.
- Keeps an explicit foreground escape hatch with `background: false` in subagent frontmatter or `run_in_background: false` in the Agent/Task call.
- Updates the Agent tool schema/description so models know background is now the default.

Linear: https://linear.app/letta/issue/LET-9315/make-letta-code-subagents-non-blocking-by-default
Slack: https://letta-ai.slack.com/archives/C0B36B9QW7K/p1782856264850869

## Validation

- `bun test src/agent/subagent-builtins.test.ts src/tools/task-background-helper.test.ts src/tools/subagent-parent-id-propagation.test.ts`
- `bun run typecheck`
- `bun run check`
