### PR TITLE
feat(mods): emit llm_end for provider errors

### DIFF
--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -29,6 +29,7 @@ import {
   isRetryableLocalProviderError,
   localProviderRetryDelayMs,
   localProviderRetryMessage,
+  normalizeLocalProviderError,
 } from "./local-provider-errors";
 import {
   applyPiEnvOverrides,
@@ -36,6 +37,7 @@ import {
   resolvePiModelForAgent,
 } from "./pi-model-factory";
 import type {
+  LlmEndErrorInfo,
   LlmEndInfo,
   LlmStartInfo,
   ProviderStreamAdapter,
@@ -462,6 +464,22 @@ function isModelOutputEvent(event: ProviderStreamEvent): boolean {
   }
 }
 
+function llmEndErrorFromError(error: unknown): {
+  error: LlmEndErrorInfo;
+  stopReason: string;
+} {
+  const info = normalizeLocalProviderError(error);
+  return {
+    error: {
+      message: info.message,
+      detail: info.detail,
+      errorType: info.error_type,
+      retryable: info.retryable,
+    },
+    stopReason: info.stop_reason,
+  };
+}
+
 function isOverflowError(error: unknown, contextWindow?: number): boolean {
   if (error instanceof PiProviderError) {
     return isContextOverflow(error.assistant, contextWindow);
@@ -736,6 +754,22 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
 
     const restoreEnv = applyPiEnvOverrides(resolved.envOverrides);
     const llmStartedAt = Date.now();
+    let llmEnded = false;
+    const emitLlmEnd = async (
+      info: Omit<
+        LlmEndInfo,
+        "agentId" | "conversationId" | "durationMs" | "model"
+      >,
+    ): Promise<void> => {
+      llmEnded = true;
+      await this.onLlmEnd?.({
+        agentId: input.agentId,
+        conversationId: input.conversationId,
+        model: input.agent.model,
+        durationMs: Date.now() - llmStartedAt,
+        ...info,
+      });
+    };
     try {
       await this.onLlmStart?.({
         agentId: input.agentId,
@@ -774,17 +808,19 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
 
       if (streamError) throw streamError;
       finalMessage ??= await result.result();
-      await this.onLlmEnd?.({
-        agentId: input.agentId,
-        conversationId: input.conversationId,
-        model: input.agent.model,
+      const finalMessageError =
+        finalMessage.stopReason === "error" ||
+        finalMessage.stopReason === "aborted"
+          ? llmEndErrorFromError(new PiProviderError(finalMessage)).error
+          : undefined;
+      await emitLlmEnd({
         stopReason: finalMessage.stopReason,
         usage: {
           promptTokens: finalMessage.usage.input,
           completionTokens: finalMessage.usage.output,
           totalTokens: finalMessage.usage.totalTokens,
         },
-        durationMs: Date.now() - llmStartedAt,
+        ...(finalMessageError ? { error: finalMessageError } : {}),
       });
       if (
         finalMessage.stopReason === "error" ||
@@ -798,6 +834,16 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
           yield* this.emitCompactionChunks(compaction, "context_window_limit");
         }
       }
+    } catch (error) {
+      if (!llmEnded) {
+        const endError = llmEndErrorFromError(error);
+        await emitLlmEnd({
+          stopReason: endError.stopReason,
+          usage: null,
+          error: endError.error,
+        });
+      }
+      throw error;
     } finally {
       restoreEnv();
     }

--- a/src/backend/dev/provider-turn-executor.ts
+++ b/src/backend/dev/provider-turn-executor.ts
@@ -45,6 +45,13 @@ export interface LlmStartInfo {
   contextWindow: number;
 }
 
+export interface LlmEndErrorInfo {
+  message: string;
+  detail: string;
+  errorType: "llm_error" | "local_backend_error";
+  retryable: boolean;
+}
+
 /** Provider-request completion info emitted once a final message is produced. */
 export interface LlmEndInfo {
   agentId: string;
@@ -55,8 +62,9 @@ export interface LlmEndInfo {
     promptTokens: number;
     completionTokens: number;
     totalTokens: number;
-  };
+  } | null;
   durationMs: number;
+  error?: LlmEndErrorInfo;
 }
 
 export type ProviderStreamEvent =

--- a/src/backend/pi-stream-adapter.test.ts
+++ b/src/backend/pi-stream-adapter.test.ts
@@ -1353,7 +1353,7 @@ describe("PiStreamAdapter", () => {
     expect(ends[0]?.durationMs).toBeGreaterThanOrEqual(0);
   });
 
-  test("emits llm_start per provider request but llm_end only on completion across retries", async () => {
+  test("emits llm_end for failed and successful provider requests across retries", async () => {
     let calls = 0;
     const stream: PiStreamFunction = () => {
       calls += 1;
@@ -1374,20 +1374,69 @@ describe("PiStreamAdapter", () => {
     };
 
     let startCount = 0;
-    let endCount = 0;
+    const ends: LlmEndInfo[] = [];
     const adapter = new PiStreamAdapter({
       stream,
       onLlmStart: () => {
         startCount += 1;
       },
-      onLlmEnd: () => {
-        endCount += 1;
+      onLlmEnd: (info) => {
+        ends.push(info);
       },
     });
     await collectEvents(adapter.stream(input()));
 
     expect(calls).toBe(2);
     expect(startCount).toBe(2);
-    expect(endCount).toBe(1);
+    expect(ends).toHaveLength(2);
+    expect(ends[0]).toMatchObject({
+      stopReason: "llm_api_error",
+      usage: null,
+      error: {
+        errorType: "llm_error",
+        retryable: true,
+      },
+    });
+    expect(ends[0]?.error?.message).toContain("WebSocket closed");
+    expect(ends[1]).toMatchObject({
+      stopReason: "stop",
+    });
+    expect(ends[1]?.error).toBeUndefined();
+    expect(ends[1]?.usage).not.toBeNull();
+  });
+
+  test("emits one llm_end with error details for final error messages", async () => {
+    const finalMessage = assistantErrorMessage("usage limit reached");
+    const stream: PiStreamFunction = () =>
+      streamFromEvents(
+        [{ type: "done", reason: "stop", message: finalMessage }],
+        finalMessage,
+      );
+
+    const ends: LlmEndInfo[] = [];
+    const adapter = new PiStreamAdapter({
+      stream,
+      onLlmEnd: (info) => {
+        ends.push(info);
+      },
+    });
+
+    await expect(collectEvents(adapter.stream(input()))).rejects.toThrow(
+      "usage limit reached",
+    );
+
+    expect(ends).toHaveLength(1);
+    expect(ends[0]).toMatchObject({
+      stopReason: "error",
+      usage: {
+        promptTokens: finalMessage.usage.input,
+        completionTokens: finalMessage.usage.output,
+        totalTokens: finalMessage.usage.totalTokens,
+      },
+      error: {
+        message: "usage limit reached",
+        retryable: false,
+      },
+    });
   });
 });

--- a/src/cli/mods/local-backend-mod-events.ts
+++ b/src/cli/mods/local-backend-mod-events.ts
@@ -72,6 +72,7 @@ export function installLocalBackendModEventHooks(options: {
           stopReason: info.stopReason,
           usage: info.usage,
           durationMs: info.durationMs,
+          ...(info.error ? { error: info.error } : {}),
         },
         buildContext(info.conversationId),
       );

--- a/src/mods/mod-engine.test.ts
+++ b/src/mods/mod-engine.test.ts
@@ -1014,7 +1014,7 @@ describe("mod engine", () => {
           });
           letta.events.on("llm_end", (event) => {
             globalThis.__lettaModEvents.push(
-              "end:" + event.stopReason + ":" + event.usage.totalTokens + ":" + event.durationMs + "ms",
+              "end:" + event.stopReason + ":" + (event.usage?.totalTokens ?? "no-usage") + ":" + (event.error?.message ?? "no-error") + ":" + event.durationMs + "ms",
             );
           });
         }`,
@@ -1048,10 +1048,29 @@ describe("mod engine", () => {
         },
         createModContext(),
       );
+      await engine.emitEvent(
+        "llm_end",
+        {
+          agentId: "agent-1",
+          conversationId: "conversation-1",
+          model: "anthropic/claude-fable-5",
+          stopReason: "llm_api_error",
+          usage: null,
+          error: {
+            message: "provider failed",
+            detail: "provider failed\nretry-after-ms: 0",
+            errorType: "llm_error" as const,
+            retryable: true,
+          },
+          durationMs: 42,
+        },
+        createModContext(),
+      );
 
       expect(testGlobal.__lettaModEvents).toEqual([
         "start:anthropic/claude-fable-5:8/200000",
-        "end:stop:120:1234ms",
+        "end:stop:120:no-error:1234ms",
+        "end:llm_api_error:no-usage:provider failed:42ms",
       ]);
 
       engine.dispose();

--- a/src/mods/types.ts
+++ b/src/mods/types.ts
@@ -285,6 +285,13 @@ export interface ModLlmUsage {
   totalTokens: number;
 }
 
+export interface ModLlmEndError {
+  message: string;
+  detail: string;
+  errorType: "llm_error" | "local_backend_error";
+  retryable: boolean;
+}
+
 export interface ModLlmStartEvent {
   agentId: string | null;
   conversationId: string | null;
@@ -298,8 +305,9 @@ export interface ModLlmEndEvent {
   conversationId: string | null;
   model: string;
   stopReason: string;
-  usage: ModLlmUsage;
+  usage: ModLlmUsage | null;
   durationMs: number;
+  error?: ModLlmEndError;
 }
 
 export interface ModEventMap {

--- a/src/skills/builtin/creating-mods/references/events.md
+++ b/src/skills/builtin/creating-mods/references/events.md
@@ -284,12 +284,18 @@ Handlers run in registration order. Later handlers see the current input after e
     promptTokens: number;
     completionTokens: number;
     totalTokens: number;
-  };
+  } | null;
   durationMs: number;
+  error?: {
+    message: string;
+    detail: string;
+    errorType: "llm_error" | "local_backend_error";
+    retryable: boolean;
+  };
 }
 ```
 
-`llm_end` fires once a provider request produces a final message, carrying the stop reason, token usage, and wall-clock duration. A request that fails before producing a final message (e.g. a transport error that triggers a retry) emits no `llm_end`. Both events are notification-only; return values are ignored. A throwing handler is isolated and never breaks the provider request.
+`llm_end` fires when a provider request ends, success or failure. Successful requests include token usage. Requests that fail before usage is available set `usage: null` and include `error`. Retry/failover effects are not supported yet; both events are notification-only and return values are ignored. A throwing handler is isolated and never breaks the provider request.
 
 Handlers also receive:
 


### PR DESCRIPTION
## Summary
- emit `llm_end` for provider request failures before a final assistant message
- add structured `llm_end.error` and nullable `usage` for failed requests
- preserve existing retry/error behavior while restoring the start/end lifecycle invariant
- update docs and tests for retry failures and final error messages

## Tests
- `bun test src/backend/pi-stream-adapter.test.ts`
- `bun test src/mods/mod-engine.test.ts`
- `bun run check`