### PR TITLE
chore(codeowners): add jnjpng as owner for websocket code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 /src/agent/memoryGit.ts @letta-ai/system-prompt-owners
 
 # WebSocket listener and protocol code
-/src/websocket/ @cpacker @4shub @kl2806 @carenthomas @christinatong01
+/src/websocket/ @cpacker @4shub @kl2806 @carenthomas @christinatong01 @jnjpng
 
 # Headless mode runtime
 /src/headless.ts @cpacker @4shub @kl2806 @devanshrj @sarahwooders @jnjpng @carenthomas


### PR DESCRIPTION
Adds @jnjpng to the `/src/websocket/` CODEOWNERS entry so Jin is auto-requested on websocket listener/protocol changes.

Closes LET-9323