### PR TITLE
fix(slack): show final errors in progress streams

### DIFF
--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -2544,6 +2544,78 @@ test("slack adapter treats already-closed stream stop errors as benign", async (
   expect(writeClient?.chat.update).not.toHaveBeenCalled();
 });
 
+test("slack adapter includes final error details in rich progress streams", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+  const source = {
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    chatType: "channel" as const,
+    senderId: "U123",
+    senderTeamId: "T123",
+    messageId: "1712800000.000100",
+    threadId: "1712790000.000050",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  };
+
+  await adapter.start();
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-1",
+    sources: [source],
+    kind: "tool",
+    state: "started",
+    message: "Reading files",
+    toolCallId: "call-1",
+    toolName: "read_file",
+  });
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "finished",
+    batchId: "batch-1",
+    outcome: "error",
+    error:
+      "Boom TOKEN=abc <payload> @channel & friends\nView agent: https://app.letta.com/chat/secret",
+    sources: [source],
+  });
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient?.chat.stopStream).toHaveBeenCalledWith({
+    channel: "C123",
+    ts: "1712800000.000300",
+    chunks: expect.arrayContaining([
+      expect.objectContaining({
+        id: "task_call-1",
+        title: "Read",
+        status: "error",
+      }),
+      expect.objectContaining({
+        type: "task_update",
+        id: "task_lifecycle_error",
+        title: "Turn failed",
+        status: "error",
+        details: "Boom TOKEN=[redacted] payload @\u200bchannel and friends",
+      }),
+      expect.objectContaining({
+        type: "plan_update",
+        title: "Failed",
+      }),
+    ]),
+  });
+  expect(JSON.stringify(writeClient?.chat.stopStream.mock.calls)).not.toContain(
+    "app.letta.com",
+  );
+});
+
 test("slack adapter shows a progress card while a no-tool turn is running", async () => {
   const adapter = createSlackAdapter({
     ...slackAccountDefaults,

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -7,7 +7,10 @@ import {
   type InboundDebouncer,
 } from "@/channels/inbound-debounce";
 import { formatChannelControlRequestPrompt } from "@/channels/interactive";
-import { formatChannelLifecycleErrorMessage } from "@/channels/lifecycle-error";
+import {
+  formatChannelLifecycleErrorMessage,
+  getChannelLifecycleErrorDisplay,
+} from "@/channels/lifecycle-error";
 import type {
   ChannelAdapter,
   ChannelControlRequestEvent,
@@ -412,6 +415,7 @@ const SLACK_PROGRESS_CARD_TEXT_MAX = 300;
 const SLACK_PROGRESS_CARD_STATE_TTL_MS = 6 * 60 * 60 * 1000;
 const SLACK_PROGRESS_CARD_STATE_MAX = 2_000;
 const SLACK_STREAM_CHUNK_TEXT_MAX = 256;
+const SLACK_LIFECYCLE_ERROR_TASK_ID = "task_lifecycle_error";
 const DEFAULT_SLACK_PROGRESS_UPDATE_THROTTLE_MS = 1_000;
 type SlackProgressCardState =
   | "processing"
@@ -535,6 +539,26 @@ export function formatSlackProgressCardText(
     : statusLine;
 }
 
+function buildSlackLifecycleErrorTaskChunk(
+  errorText: string | null | undefined,
+): SlackStreamChunk {
+  const display = getChannelLifecycleErrorDisplay(errorText);
+  const title =
+    sanitizeSlackProgressText(display.title, SLACK_STREAM_CHUNK_TEXT_MAX) ||
+    "Turn failed";
+  const details = sanitizeSlackProgressText(
+    display.body,
+    SLACK_STREAM_CHUNK_TEXT_MAX,
+  );
+  return {
+    type: "task_update",
+    id: SLACK_LIFECYCLE_ERROR_TASK_ID,
+    title,
+    status: "error",
+    details,
+  };
+}
+
 function formatSlackControlRequestBlocks(
   event: ChannelControlRequestEvent,
 ): SlackBlock[] | undefined {
@@ -570,6 +594,7 @@ function formatSlackControlRequestBlocks(
 function buildTerminalSlackStreamChunks(
   entry: SlackProgressCardEntry,
   terminalTaskStatus: SlackStreamTaskStatus,
+  finalErrorChunk?: SlackStreamChunk,
 ): SlackStreamChunk[] {
   // Deduplicate pending chunks by task ID, keeping only the latest.
   // pendingStreamChunks can accumulate multiple updates for the same task
@@ -595,6 +620,9 @@ function buildTerminalSlackStreamChunks(
     if (task.status !== "complete" && task.status !== "error") {
       entry.toolTasksById?.set(task.id, terminalTask);
     }
+  }
+  if (finalErrorChunk) {
+    rawPending.push(finalErrorChunk);
   }
   const chunks = compactSlackStreamChunks(rawPending, entry);
   if (chunks.some((chunk) => chunk.type === "task_update")) {
@@ -938,6 +966,13 @@ function buildSlackPlanUpdateChunk(
     return {
       type: "plan_update",
       title: entry.reasoningActive ? "Thinking" : "Working",
+    };
+  }
+
+  if (entry.status === "error") {
+    return {
+      type: "plan_update",
+      title: "Failed",
     };
   }
 
@@ -1886,6 +1921,7 @@ export function createSlackAdapter(
 
   async function stopSlackProgressStream(
     entry: SlackProgressCardEntry,
+    finalErrorChunk?: SlackStreamChunk,
   ): Promise<boolean> {
     if (!entry.streamTs) {
       return true;
@@ -1902,7 +1938,11 @@ export function createSlackAdapter(
         : entry.status === "cancelled"
           ? "error"
           : "complete";
-    const chunks = buildTerminalSlackStreamChunks(entry, terminalTaskStatus);
+    const chunks = buildTerminalSlackStreamChunks(
+      entry,
+      terminalTaskStatus,
+      finalErrorChunk,
+    );
     debugSlackProgress(
       `[STOP-ARGS] terminal=${terminalTaskStatus} chunks=${describeSlackStreamChunks(chunks)}`,
     );
@@ -2225,8 +2265,13 @@ export function createSlackAdapter(
     sources: ChannelTurnSource[],
     outcome: ChannelTurnOutcome,
     batchId?: string,
+    errorText?: string | null,
   ): Promise<void> {
     const progress = resolveSlackLifecycleProgressText(outcome);
+    const finalErrorChunk =
+      progress.status === "error"
+        ? buildSlackLifecycleErrorTaskChunk(errorText)
+        : undefined;
     const uniqueSources = getUniqueSlackProgressSources(sources);
     await Promise.all(
       uniqueSources.map(async (source) => {
@@ -2246,7 +2291,7 @@ export function createSlackAdapter(
         delete entry.latestUpdate;
         entry.updatedAt = Date.now();
         if (entry.mode === "stream") {
-          const didStop = await stopSlackProgressStream(entry);
+          const didStop = await stopSlackProgressStream(entry, finalErrorChunk);
           if (didStop) {
             entry.lastSentText = formatSlackProgressCardText(
               entry.status,
@@ -2834,6 +2879,7 @@ export function createSlackAdapter(
         event.sources,
         event.outcome,
         event.batchId,
+        event.error,
       );
 
       const errorText = event.outcome === "error" ? event.error?.trim() : null;


### PR DESCRIPTION
## Summary
- Add a terminal lifecycle error task row to Slack rich progress streams so the expandable card includes sanitized final error details.
- Keep terminal plan titles failed on lifecycle errors even when the last tool row was already complete.
- Cover redaction, Slack mention neutralization, and app-link stripping in the stream stop payload.

## Test plan
- [x] bun test src/channels/slack-adapter.test.ts
- [x] bun run check

👾 Generated with [Letta Code](https://letta.com)