### PR TITLE
feat(openrouter): pseudonymize broadcast trace metadata

### DIFF
--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -407,24 +407,18 @@ function isTelemetryOptedOut(): boolean {
   return telem === "0" || telem === "false" || process.env.DO_NOT_TRACK === "1";
 }
 
-function hasHeader(
+export function withOpenRouterSessionHeader(
   headers: Record<string, string> | undefined,
-  name: string,
-): boolean {
-  const normalizedName = name.toLowerCase();
-  return Object.keys(headers ?? {}).some(
-    (header) => header.toLowerCase() === normalizedName,
-  );
-}
-
-function withOpenRouterSessionHeader(
-  headers: Record<string, string> | undefined,
-  conversationId: string,
+  pseudonymousSessionId: string,
 ): Record<string, string> {
-  if (hasHeader(headers, "x-session-id")) return headers ?? {};
+  const safeHeaders = Object.fromEntries(
+    Object.entries(headers ?? {}).filter(
+      ([key]) => key.toLowerCase() !== "x-session-id",
+    ),
+  );
   return {
-    ...(headers ?? {}),
-    "x-session-id": openRouterTracePseudonym("conversation", conversationId),
+    ...safeHeaders,
+    "x-session-id": pseudonymousSessionId,
   };
 }
 
@@ -448,19 +442,15 @@ function withOpenRouterBroadcastTraceData(
     if (!isRecord(next)) return upstreamChanged ? next : undefined;
 
     const existingTrace = isRecord(next.trace) ? next.trace : {};
-    const sessionId =
-      typeof next.session_id === "string"
-        ? next.session_id
-        : pseudonymousSessionId;
     return {
       ...next,
-      session_id: sessionId,
+      session_id: pseudonymousSessionId,
       trace: {
+        ...existingTrace,
         trace_id: pseudonymousSessionId,
         trace_name: "letta-code",
         span_name: "agent-turn",
         generation_name: generationName,
-        ...existingTrace,
       },
     };
   };
@@ -766,10 +756,19 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
       messages: toPiMessages(input.uiMessages),
       ...(tools ? { tools } : {}),
     };
-    const enrichOpenRouterTrace =
-      resolved.provider === "openrouter" && !isTelemetryOptedOut();
-    const headers = enrichOpenRouterTrace
-      ? withOpenRouterSessionHeader(resolved.headers, input.conversationId)
+    const pseudonymousOpenRouterSessionId =
+      resolved.provider === "openrouter" && !isTelemetryOptedOut()
+        ? openRouterTracePseudonym("conversation", input.conversationId)
+        : undefined;
+    const sessionId =
+      resolved.provider === "openrouter"
+        ? pseudonymousOpenRouterSessionId
+        : input.conversationId;
+    const headers = pseudonymousOpenRouterSessionId
+      ? withOpenRouterSessionHeader(
+          resolved.headers,
+          pseudonymousOpenRouterSessionId,
+        )
       : resolved.headers;
     const options: SimpleStreamOptions & Record<string, unknown> = {
       ...resolved.providerOptions,
@@ -778,7 +777,7 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
       ...(headers ? { headers } : {}),
       ...(this.abortSignal ? { signal: this.abortSignal } : {}),
       maxRetries: 0,
-      sessionId: input.conversationId,
+      ...(sessionId ? { sessionId } : {}),
       ...(reasoningForSettings(input.agent.model_settings)
         ? { reasoning: reasoningForSettings(input.agent.model_settings) }
         : {}),
@@ -802,7 +801,7 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
           }
         : {}),
     };
-    if (enrichOpenRouterTrace) {
+    if (pseudonymousOpenRouterSessionId) {
       options.onPayload = withOpenRouterBroadcastTraceData(
         options.onPayload,
         input,

--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -1,3 +1,4 @@
+import { createHmac, randomBytes } from "node:crypto";
 import {
   type AssistantMessage,
   type AssistantMessageEvent,
@@ -380,6 +381,91 @@ function withAnthropicOutputEffort(
   };
 }
 
+const OPENROUTER_TRACE_FIELD_LIMIT = 128;
+let openRouterTraceHmacSecret: Buffer | undefined;
+
+function openRouterTraceValue(value: string): string {
+  return value.slice(0, OPENROUTER_TRACE_FIELD_LIMIT);
+}
+
+function openRouterTraceSecret(): Buffer {
+  openRouterTraceHmacSecret ??= randomBytes(32);
+  return openRouterTraceHmacSecret;
+}
+
+function openRouterTracePseudonym(purpose: string, value: string): string {
+  return openRouterTraceValue(
+    createHmac("sha256", openRouterTraceSecret())
+      .update(`openrouter-broadcast:${purpose}:`)
+      .update(value)
+      .digest("hex"),
+  );
+}
+
+function isTelemetryOptedOut(): boolean {
+  const telem = process.env.LETTA_CODE_TELEM;
+  return telem === "0" || telem === "false" || process.env.DO_NOT_TRACK === "1";
+}
+
+function hasHeader(
+  headers: Record<string, string> | undefined,
+  name: string,
+): boolean {
+  const normalizedName = name.toLowerCase();
+  return Object.keys(headers ?? {}).some(
+    (header) => header.toLowerCase() === normalizedName,
+  );
+}
+
+function withOpenRouterSessionHeader(
+  headers: Record<string, string> | undefined,
+  conversationId: string,
+): Record<string, string> {
+  if (hasHeader(headers, "x-session-id")) return headers ?? {};
+  return {
+    ...(headers ?? {}),
+    "x-session-id": openRouterTracePseudonym("conversation", conversationId),
+  };
+}
+
+function withOpenRouterBroadcastTraceData(
+  existing: SimpleStreamOptions["onPayload"] | undefined,
+  input: ProviderTurnInput,
+  generationName: string,
+): SimpleStreamOptions["onPayload"] {
+  const pseudonymousSessionId = openRouterTracePseudonym(
+    "conversation",
+    input.conversationId,
+  );
+  return async (payload, model) => {
+    let next = payload;
+    let upstreamChanged = false;
+    const upstream = await existing?.(payload, model);
+    if (upstream !== undefined) {
+      next = upstream;
+      upstreamChanged = true;
+    }
+    if (!isRecord(next)) return upstreamChanged ? next : undefined;
+
+    const existingTrace = isRecord(next.trace) ? next.trace : {};
+    const sessionId =
+      typeof next.session_id === "string"
+        ? next.session_id
+        : pseudonymousSessionId;
+    return {
+      ...next,
+      session_id: sessionId,
+      trace: {
+        trace_id: pseudonymousSessionId,
+        trace_name: "letta-code",
+        span_name: "agent-turn",
+        generation_name: generationName,
+        ...existingTrace,
+      },
+    };
+  };
+}
+
 function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
@@ -680,11 +766,16 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
       messages: toPiMessages(input.uiMessages),
       ...(tools ? { tools } : {}),
     };
+    const enrichOpenRouterTrace =
+      resolved.provider === "openrouter" && !isTelemetryOptedOut();
+    const headers = enrichOpenRouterTrace
+      ? withOpenRouterSessionHeader(resolved.headers, input.conversationId)
+      : resolved.headers;
     const options: SimpleStreamOptions & Record<string, unknown> = {
       ...resolved.providerOptions,
       ...(resolved.apiKey ? { apiKey: resolved.apiKey } : {}),
       ...(resolved.timeout !== false ? { timeoutMs: resolved.timeout } : {}),
-      ...(resolved.headers ? { headers: resolved.headers } : {}),
+      ...(headers ? { headers } : {}),
       ...(this.abortSignal ? { signal: this.abortSignal } : {}),
       maxRetries: 0,
       sessionId: input.conversationId,
@@ -711,6 +802,13 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
           }
         : {}),
     };
+    if (enrichOpenRouterTrace) {
+      options.onPayload = withOpenRouterBroadcastTraceData(
+        options.onPayload,
+        input,
+        resolved.model.id,
+      );
+    }
     if (resolved.model.api === "openai-responses") {
       // pi-ai replays OpenAI Responses output items from transcript history.
       // Those upstream item IDs (rs_*, msg_*, fc_*) are not retrievable when the

--- a/src/backend/pi-stream-adapter.test.ts
+++ b/src/backend/pi-stream-adapter.test.ts
@@ -14,6 +14,7 @@ import type {
 import {
   PiStreamAdapter,
   type PiStreamFunction,
+  withOpenRouterSessionHeader,
 } from "@/backend/dev/pi-stream-adapter";
 import type {
   LlmEndInfo,
@@ -895,7 +896,14 @@ describe("PiStreamAdapter", () => {
         const payload = {
           model: "anthropic/claude-sonnet-4",
           messages: [{ role: "user", content: "hello" }],
-          trace: { custom_key: "kept" },
+          session_id: "local-conv-1",
+          trace: {
+            trace_id: "local-conv-1",
+            trace_name: "local-conv-1",
+            span_name: "agent-local-1",
+            generation_name: "agent-local-1",
+            custom_key: "kept",
+          },
         };
         const finalMessage = {
           ...assistantMessage(),
@@ -963,6 +971,19 @@ describe("PiStreamAdapter", () => {
       expect(serializedPayload).not.toContain("agent-local-1");
       expect(serializedPayload).not.toContain("conversation_id");
       expect(serializedPayload).not.toContain("agent_id");
+
+      for await (const _event of adapter.stream({
+        ...baseInput,
+        conversationId: "local-conv-2",
+        agent: {
+          ...baseInput.agent,
+          model: "openrouter/anthropic/claude-sonnet-4",
+          model_settings: { provider_type: "openrouter" },
+        },
+      })) {
+        // drain a different conversation to verify pseudonyms are not constant
+      }
+      expect(capturedOptions?.headers?.["x-session-id"]).not.toBe(sessionId);
     } finally {
       if (previousDoNotTrack === undefined) delete process.env.DO_NOT_TRACK;
       else process.env.DO_NOT_TRACK = previousDoNotTrack;
@@ -972,10 +993,31 @@ describe("PiStreamAdapter", () => {
     }
   });
 
+  test("normalizes pre-existing OpenRouter session headers case-insensitively", () => {
+    const headers = withOpenRouterSessionHeader(
+      {
+        "X-Session-Id": "local-conv-1",
+        "X-SESSION-ID": "agent-local-1",
+        "x-Session-Id": "local-conv-2",
+        "x-other-header": "kept",
+      },
+      "pseudonymous-session",
+    );
+
+    expect(headers).toEqual({
+      "x-other-header": "kept",
+      "x-session-id": "pseudonymous-session",
+    });
+    expect(JSON.stringify(headers)).not.toContain("local-conv-1");
+    expect(JSON.stringify(headers)).not.toContain("agent-local-1");
+    expect(JSON.stringify(headers)).not.toContain("local-conv-2");
+  });
+
   test("skips OpenRouter Broadcast trace enrichment when telemetry is opted out", async () => {
     for (const [envKey, envValue] of [
       ["DO_NOT_TRACK", "1"],
       ["LETTA_CODE_TELEM", "0"],
+      ["LETTA_CODE_TELEM", "false"],
     ] as const) {
       const storageDir = await mkdtemp(
         join(tmpdir(), "pi-stream-openrouter-broadcast-opt-out-"),
@@ -1031,6 +1073,7 @@ describe("PiStreamAdapter", () => {
         }
 
         expect(capturedOptions?.headers?.["x-session-id"]).toBeUndefined();
+        expect(capturedOptions?.sessionId).toBeUndefined();
         expect(capturedOptions?.onPayload).toBeUndefined();
       } finally {
         if (previousDoNotTrack === undefined) delete process.env.DO_NOT_TRACK;

--- a/src/backend/pi-stream-adapter.test.ts
+++ b/src/backend/pi-stream-adapter.test.ts
@@ -863,6 +863,186 @@ describe("PiStreamAdapter", () => {
     }
   });
 
+  test("adds OpenRouter Broadcast session and trace data with pseudonymous IDs", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "pi-stream-openrouter-broadcast-"),
+    );
+    const previousDoNotTrack = process.env.DO_NOT_TRACK;
+    const previousTelemetry = process.env.LETTA_CODE_TELEM;
+    try {
+      delete process.env.DO_NOT_TRACK;
+      delete process.env.LETTA_CODE_TELEM;
+      await createOrUpdateLocalProvider({
+        storageDir,
+        providerType: "openrouter",
+        providerName: "lc-openrouter",
+        apiKey: "secret-key",
+      });
+
+      let capturedOptions:
+        | (SimpleStreamOptions & Record<string, unknown>)
+        | undefined;
+      let capturedPayload: unknown;
+      const capturedSessionIds: string[] = [];
+      const stream: PiStreamFunction = (
+        model: Model<string>,
+        _context: Context,
+        options?: SimpleStreamOptions & Record<string, unknown>,
+      ) => {
+        capturedOptions = options;
+        const sessionId = options?.headers?.["x-session-id"];
+        if (sessionId) capturedSessionIds.push(sessionId);
+        const payload = {
+          model: "anthropic/claude-sonnet-4",
+          messages: [{ role: "user", content: "hello" }],
+          trace: { custom_key: "kept" },
+        };
+        const finalMessage = {
+          ...assistantMessage(),
+          api: "openai-completions",
+          provider: "openrouter",
+          model: "anthropic/claude-sonnet-4",
+        } satisfies AssistantMessage;
+        const doneEvent: AssistantMessageEvent = {
+          type: "done",
+          reason: "stop",
+          message: finalMessage,
+        };
+        async function* iterator() {
+          capturedPayload = await options?.onPayload?.(payload, model);
+          yield doneEvent;
+        }
+        return Object.assign(iterator(), {
+          result: async () => finalMessage,
+        });
+      };
+
+      const adapter = new PiStreamAdapter({
+        stream,
+        localProviderAuthStorageDir: storageDir,
+      });
+      const baseInput = input();
+      for await (const _event of adapter.stream({
+        ...baseInput,
+        agent: {
+          ...baseInput.agent,
+          model: "openrouter/anthropic/claude-sonnet-4",
+          model_settings: { provider_type: "openrouter" },
+        },
+      })) {
+        // drain
+      }
+      for await (const _event of adapter.stream({
+        ...baseInput,
+        agent: {
+          ...baseInput.agent,
+          model: "openrouter/anthropic/claude-sonnet-4",
+          model_settings: { provider_type: "openrouter" },
+        },
+      })) {
+        // drain again to verify same input gets same process-local pseudonym
+      }
+
+      const sessionId = capturedOptions?.headers?.["x-session-id"];
+      expect(sessionId).toMatch(/^[a-f0-9]{64}$/);
+      expect(sessionId).not.toBe("local-conv-1");
+      if (!sessionId) throw new Error("Expected OpenRouter session ID");
+      expect(capturedSessionIds).toEqual([sessionId, sessionId]);
+      expect(capturedPayload).toMatchObject({
+        session_id: sessionId,
+        trace: {
+          trace_id: sessionId,
+          trace_name: "letta-code",
+          span_name: "agent-turn",
+          generation_name: "anthropic/claude-sonnet-4",
+          custom_key: "kept",
+        },
+      });
+      const serializedPayload = JSON.stringify(capturedPayload);
+      expect(serializedPayload).not.toContain("local-conv-1");
+      expect(serializedPayload).not.toContain("agent-local-1");
+      expect(serializedPayload).not.toContain("conversation_id");
+      expect(serializedPayload).not.toContain("agent_id");
+    } finally {
+      if (previousDoNotTrack === undefined) delete process.env.DO_NOT_TRACK;
+      else process.env.DO_NOT_TRACK = previousDoNotTrack;
+      if (previousTelemetry === undefined) delete process.env.LETTA_CODE_TELEM;
+      else process.env.LETTA_CODE_TELEM = previousTelemetry;
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("skips OpenRouter Broadcast trace enrichment when telemetry is opted out", async () => {
+    for (const [envKey, envValue] of [
+      ["DO_NOT_TRACK", "1"],
+      ["LETTA_CODE_TELEM", "0"],
+    ] as const) {
+      const storageDir = await mkdtemp(
+        join(tmpdir(), "pi-stream-openrouter-broadcast-opt-out-"),
+      );
+      const previousDoNotTrack = process.env.DO_NOT_TRACK;
+      const previousTelemetry = process.env.LETTA_CODE_TELEM;
+      try {
+        delete process.env.DO_NOT_TRACK;
+        delete process.env.LETTA_CODE_TELEM;
+        process.env[envKey] = envValue;
+        await createOrUpdateLocalProvider({
+          storageDir,
+          providerType: "openrouter",
+          providerName: "lc-openrouter",
+          apiKey: "secret-key",
+        });
+
+        let capturedOptions:
+          | (SimpleStreamOptions & Record<string, unknown>)
+          | undefined;
+        const stream: PiStreamFunction = (
+          _model: Model<string>,
+          _context: Context,
+          options?: SimpleStreamOptions & Record<string, unknown>,
+        ) => {
+          capturedOptions = options;
+          const finalMessage = {
+            ...assistantMessage(),
+            api: "openai-completions",
+            provider: "openrouter",
+            model: "anthropic/claude-sonnet-4",
+          } satisfies AssistantMessage;
+          return streamFromEvents(
+            [{ type: "done", reason: "stop", message: finalMessage }],
+            finalMessage,
+          );
+        };
+
+        const adapter = new PiStreamAdapter({
+          stream,
+          localProviderAuthStorageDir: storageDir,
+        });
+        const baseInput = input();
+        for await (const _event of adapter.stream({
+          ...baseInput,
+          agent: {
+            ...baseInput.agent,
+            model: "openrouter/anthropic/claude-sonnet-4",
+            model_settings: { provider_type: "openrouter" },
+          },
+        })) {
+          // drain
+        }
+
+        expect(capturedOptions?.headers?.["x-session-id"]).toBeUndefined();
+        expect(capturedOptions?.onPayload).toBeUndefined();
+      } finally {
+        if (previousDoNotTrack === undefined) delete process.env.DO_NOT_TRACK;
+        else process.env.DO_NOT_TRACK = previousDoNotTrack;
+        if (previousTelemetry === undefined)
+          delete process.env.LETTA_CODE_TELEM;
+        else process.env.LETTA_CODE_TELEM = previousTelemetry;
+        await rm(storageDir, { recursive: true, force: true });
+      }
+    }
+  });
+
   test("forwards Bedrock provider options and restores AWS env overrides", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "pi-stream-bedrock-"));
     const originalAccessKeyId = process.env.AWS_ACCESS_KEY_ID;


### PR DESCRIPTION
## Summary
- pseudonymize OpenRouter Broadcast session/trace IDs with process-local HMAC values
- avoid sending raw Letta conversation/agent IDs in OpenRouter Broadcast metadata
- harden provider-boundary invariants against adversarial payload trace/session fields and case-variant session headers
- honor `DO_NOT_TRACK` and `LETTA_CODE_TELEM=0/false` by skipping OpenRouter trace enrichment

## Validation
- `bun test src/backend/pi-stream-adapter.test.ts`
- `bun run typecheck`
- `bun run check`

Draft only.