### PR TITLE
fix: reuse an existing agent when default agent creation hits the account limit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -538,6 +538,53 @@ function paginatedItems<T>(page: unknown): T[] {
   return [];
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isDefaultAgentLimitCreateFailure(error: unknown): boolean {
+  const message = errorMessage(error).toLowerCase();
+  const status = (error as { status?: unknown } | null)?.status;
+  const statusCode = typeof status === "number" ? status : undefined;
+
+  if (message.includes("agents-limit-exceeded")) return true;
+
+  return (
+    message.includes("agent") &&
+    message.includes("limit") &&
+    (statusCode === 402 ||
+      statusCode === 429 ||
+      message.includes("402") ||
+      message.includes("429") ||
+      message.includes("you have reached your limit"))
+  );
+}
+
+function formatStartupFallbackAgent(agent: AgentState): string {
+  const name = agent.name?.trim();
+  return name ? `"${name}" (${agent.id})` : agent.id;
+}
+
+async function waitForStartupFallbackAcknowledgement(): Promise<void> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return;
+
+  process.stdout.write("Press any key to continue...");
+  await new Promise<void>((resolve) => {
+    const wasRaw = process.stdin.isRaw;
+    const cleanup = () => {
+      process.stdin.off("data", onData);
+      process.stdin.setRawMode(wasRaw);
+      process.stdout.write("\n");
+      resolve();
+    };
+    const onData = () => cleanup();
+
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.once("data", onData);
+  });
+}
+
 function timestampMs(value: string | null | undefined): number {
   if (!value) return 0;
   const parsed = Date.parse(value);
@@ -2022,7 +2069,8 @@ async function main(): Promise<void> {
           case "create": {
             const { ensureDefaultAgents } = await import("@/agent/defaults");
             try {
-              const defaultAgent = await ensureDefaultAgents(getBackend(), {
+              const backend = getBackend();
+              const defaultAgent = await ensureDefaultAgents(backend, {
                 preferredModel: model,
               });
               if (defaultAgent) {
@@ -2036,8 +2084,35 @@ async function main(): Promise<void> {
               // If null (createDefaultAgents disabled), fall through
             } catch (err) {
               console.error(
-                `Failed to create default agent: ${err instanceof Error ? err.message : String(err)}`,
+                `Failed to create default agent: ${errorMessage(err)}`,
               );
+              if (isDefaultAgentLimitCreateFailure(err)) {
+                try {
+                  const backend = getBackend();
+                  const fallbackAgentsPage = await backend.listAgents({
+                    limit: 1,
+                  } as never);
+                  const fallbackAgent =
+                    paginatedItems<AgentState>(fallbackAgentsPage)[0];
+                  if (fallbackAgent) {
+                    console.warn(
+                      `Selected existing agent ${formatStartupFallbackAgent(fallbackAgent)} by default.`,
+                    );
+                    await waitForStartupFallbackAcknowledgement();
+                    setValidatedAgent(fallbackAgent);
+                    setSelectedGlobalAgentId(fallbackAgent.id);
+                    setLoadingState("assembling");
+                    return;
+                  }
+                  console.error(
+                    "No existing agents were available after default agent creation failed.",
+                  );
+                } catch (fallbackErr) {
+                  console.error(
+                    `Failed to list existing agents after default agent creation failed: ${errorMessage(fallbackErr)}`,
+                  );
+                }
+              }
               process.exit(1);
             }
             break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -544,19 +544,13 @@ function errorMessage(error: unknown): string {
 
 function isDefaultAgentLimitCreateFailure(error: unknown): boolean {
   const message = errorMessage(error).toLowerCase();
-  const status = (error as { status?: unknown } | null)?.status;
-  const statusCode = typeof status === "number" ? status : undefined;
-
   if (message.includes("agents-limit-exceeded")) return true;
 
   return (
-    message.includes("agent") &&
-    message.includes("limit") &&
-    (statusCode === 402 ||
-      statusCode === 429 ||
-      message.includes("402") ||
-      message.includes("429") ||
-      message.includes("you have reached your limit"))
+    message.includes("you have reached your limit for agents") ||
+    message.includes("reached the agent limit") ||
+    message.includes("reached your agent limit") ||
+    message.includes("limit for agents")
   );
 }
 

--- a/src/startup-flow.test.ts
+++ b/src/startup-flow.test.ts
@@ -267,4 +267,41 @@ describe("Startup Flow - Default Agent Fallback Wiring", () => {
     expect(createCase).toContain("setSelectedGlobalAgentId(fallbackAgent.id)");
     expect(createCase).toContain('setLoadingState("assembling")');
   });
+
+  test("default agent limit detection stays narrow and acknowledgement remains TTY-gated", () => {
+    const source = readIndexSource();
+    const classifierStart = source.indexOf(
+      "function isDefaultAgentLimitCreateFailure",
+    );
+    const classifierEnd = source.indexOf(
+      "function formatStartupFallbackAgent",
+      classifierStart,
+    );
+    const acknowledgementStart = source.indexOf(
+      "async function waitForStartupFallbackAcknowledgement",
+    );
+    const acknowledgementEnd = source.indexOf(
+      "function timestampMs",
+      acknowledgementStart,
+    );
+
+    expect(classifierStart).toBeGreaterThan(-1);
+    expect(classifierEnd).toBeGreaterThan(classifierStart);
+    expect(acknowledgementStart).toBeGreaterThan(-1);
+    expect(acknowledgementEnd).toBeGreaterThan(acknowledgementStart);
+
+    const classifier = source.slice(classifierStart, classifierEnd);
+    const acknowledgement = source.slice(
+      acknowledgementStart,
+      acknowledgementEnd,
+    );
+
+    expect(classifier).toContain("agents-limit-exceeded");
+    expect(classifier).toContain("you have reached your limit for agents");
+    expect(classifier).not.toContain('message.includes("429")');
+    expect(classifier).not.toContain("statusCode === 429");
+    expect(acknowledgement).toContain(
+      "if (!process.stdin.isTTY || !process.stdout.isTTY) return;",
+    );
+  });
 });

--- a/src/startup-flow.test.ts
+++ b/src/startup-flow.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { createIsolatedCliTestEnv } from "@/test-utils/test-process-env";
 
 /**
@@ -10,6 +11,10 @@ import { createIsolatedCliTestEnv } from "@/test-utils/test-process-env";
  */
 
 const projectRoot = process.cwd();
+
+function readIndexSource(): string {
+  return readFileSync(new URL("./index.ts", import.meta.url), "utf-8");
+}
 
 async function runCli(
   args: string[],
@@ -230,5 +235,36 @@ describe("Startup Flow - Smoke", () => {
     expect(result.stderr).toContain("Missing LETTA_API_KEY");
     expect(result.stderr).not.toContain("Unknown option '--max-turns'");
     expect(result.stderr).not.toContain("Unknown option '--pre-load-skills'");
+  });
+});
+
+describe("Startup Flow - Default Agent Fallback Wiring", () => {
+  test("quota-limited default creation falls back to first existing agent in the active inline flow", () => {
+    const source = readIndexSource();
+    const createCaseStart = source.indexOf('case "create": {');
+    const createCaseEnd = source.indexOf("break;", createCaseStart);
+
+    expect(createCaseStart).toBeGreaterThan(-1);
+    expect(createCaseEnd).toBeGreaterThan(createCaseStart);
+
+    const createCase = source.slice(createCaseStart, createCaseEnd);
+
+    expect(source).toContain("function isDefaultAgentLimitCreateFailure");
+    expect(source).toContain(
+      "async function waitForStartupFallbackAcknowledgement",
+    );
+    expect(createCase).toContain("isDefaultAgentLimitCreateFailure(err)");
+    expect(createCase).toContain("backend.listAgents");
+    expect(createCase).toContain("limit: 1");
+    expect(createCase).toContain(
+      "paginatedItems<AgentState>(fallbackAgentsPage)[0]",
+    );
+    expect(createCase).toContain("Selected existing agent");
+    expect(createCase).toContain(
+      "await waitForStartupFallbackAcknowledgement()",
+    );
+    expect(createCase).toContain("setValidatedAgent(fallbackAgent)");
+    expect(createCase).toContain("setSelectedGlobalAgentId(fallbackAgent.id)");
+    expect(createCase).toContain('setLoadingState("assembling")');
   });
 });

--- a/src/startup-setup-pty.test.ts
+++ b/src/startup-setup-pty.test.ts
@@ -1,16 +1,16 @@
 import { describe, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
 import { join } from "node:path";
 
 const projectRoot = process.cwd();
+let builtCliPath: string | null = null;
 
 function ensureBuiltCli(): string {
-  const cliPath = join(projectRoot, "letta.js");
-  if (existsSync(cliPath)) {
-    return cliPath;
+  if (builtCliPath) {
+    return builtCliPath;
   }
 
+  const cliPath = join(projectRoot, "letta.js");
   const result = spawnSync("bun", ["run", "build"], {
     cwd: projectRoot,
     encoding: "utf-8",
@@ -20,6 +20,7 @@ function ensureBuiltCli(): string {
       `Failed to build letta.js\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
     );
   }
+  builtCliPath = cliPath;
   return cliPath;
 }
 

--- a/src/startup-setup-pty.test.ts
+++ b/src/startup-setup-pty.test.ts
@@ -25,35 +25,71 @@ function ensureBuiltCli(): string {
 
 const ptyTest = process.platform === "win32" ? test.skip : test;
 
+function runPtyScenario(scenario: string, failureLabel: string): void {
+  const runnerPath = join(
+    projectRoot,
+    "src/test-utils/startup-setup-pty-runner.cjs",
+  );
+  const result = spawnSync(
+    "node",
+    [runnerPath, ensureBuiltCli(), projectRoot, scenario],
+    {
+      cwd: projectRoot,
+      encoding: "utf-8",
+      timeout: 30000,
+    },
+  );
+
+  if (result.status !== 0 || result.signal !== null || result.stderr) {
+    throw new Error(
+      [
+        `${failureLabel} failed with status ${result.status} signal ${result.signal}`,
+        result.stdout ? `stdout:\n${result.stdout}` : null,
+        result.stderr ? `stderr:\n${result.stderr}` : null,
+      ]
+        .filter(Boolean)
+        .join("\n\n"),
+    );
+  }
+}
+
 describe("startup setup PTY", () => {
   ptyTest(
     "setup menu keeps raw keyboard input after terminal preflight",
     () => {
-      const runnerPath = join(
-        projectRoot,
-        "src/test-utils/startup-setup-pty-runner.cjs",
-      );
-      const result = spawnSync(
-        "node",
-        [runnerPath, ensureBuiltCli(), projectRoot],
-        {
-          cwd: projectRoot,
-          encoding: "utf-8",
-          timeout: 30000,
-        },
-      );
+      runPtyScenario("setup-menu-raw-input", "PTY setup runner");
+    },
+    { timeout: 35000 },
+  );
 
-      if (result.status !== 0 || result.signal !== null || result.stderr) {
-        throw new Error(
-          [
-            `PTY setup runner failed with status ${result.status} signal ${result.signal}`,
-            result.stdout ? `stdout:\n${result.stdout}` : null,
-            result.stderr ? `stderr:\n${result.stderr}` : null,
-          ]
-            .filter(Boolean)
-            .join("\n\n"),
-        );
-      }
+  ptyTest(
+    "agent-limit default creation falls back to an existing agent and waits for acknowledgement",
+    () => {
+      runPtyScenario("agent-limit-fallback", "PTY fallback runner");
+    },
+    { timeout: 35000 },
+  );
+
+  ptyTest(
+    "non-quota default creation failure does not fallback to existing agents",
+    () => {
+      runPtyScenario("non-quota-create-failure", "PTY non-quota runner");
+    },
+    { timeout: 35000 },
+  );
+
+  ptyTest(
+    "agent-limit default creation still fails when no existing agents are available",
+    () => {
+      runPtyScenario("agent-limit-empty-list", "PTY empty-list runner");
+    },
+    { timeout: 35000 },
+  );
+
+  ptyTest(
+    "agent-limit default creation still fails when existing agents cannot be listed",
+    () => {
+      runPtyScenario("agent-limit-list-failure", "PTY list-failure runner");
     },
     { timeout: 35000 },
   );

--- a/src/test-utils/startup-setup-pty-runner.cjs
+++ b/src/test-utils/startup-setup-pty-runner.cjs
@@ -326,8 +326,9 @@ async function runAgentLimitFallback() {
       );
     }
 
+    const continuationRequest = `GET /v1/agents/${FALLBACK_AGENT_ID}/messages`;
     await sleep(250);
-    if (fakeApi.requests.includes(`GET /v1/agents/${FALLBACK_AGENT_ID}`)) {
+    if (fakeApi.requests.includes(continuationRequest)) {
       throw new Error(
         `CLI continued past acknowledgement before keypress. Requests:\n${fakeApi.requests.join("\n")}`,
       );
@@ -336,8 +337,8 @@ async function runAgentLimitFallback() {
     terminal.write("x");
     await waitForRequest(
       fakeApi.requests,
-      `GET /v1/agents/${FALLBACK_AGENT_ID}`,
-      "selected fallback agent retrieval after acknowledgement",
+      continuationRequest,
+      "selected fallback agent session loading after acknowledgement",
     );
 
     if (exited) {

--- a/src/test-utils/startup-setup-pty-runner.cjs
+++ b/src/test-utils/startup-setup-pty-runner.cjs
@@ -37,6 +37,17 @@ async function waitForExit(getOutput, hasExited, label, timeoutMs = 10000) {
   );
 }
 
+async function waitForRequest(requests, request, label, timeoutMs = 10000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (requests.includes(request)) return;
+    await sleep(25);
+  }
+  throw new Error(
+    `Timed out waiting for ${label}. Requests:\n${requests.join("\n")}`,
+  );
+}
+
 function writeBrokenLocalTranscriptStore(homeDir) {
   const lettaDir = path.join(homeDir, ".letta");
   const conversationDir = path.join(
@@ -308,12 +319,23 @@ async function runAgentLimitFallback() {
       );
     }
 
-    terminal.write("x");
     await sleep(250);
+    if (fakeApi.requests.includes(`GET /v1/agents/${FALLBACK_AGENT_ID}`)) {
+      throw new Error(
+        `CLI continued past acknowledgement before keypress. Requests:\n${fakeApi.requests.join("\n")}`,
+      );
+    }
+
+    terminal.write("x");
+    await waitForRequest(
+      fakeApi.requests,
+      `GET /v1/agents/${FALLBACK_AGENT_ID}`,
+      "selected fallback agent retrieval after acknowledgement",
+    );
 
     if (exited) {
       throw new Error(
-        `CLI exited immediately after fallback acknowledgement. Output:\n${globalThis.stripAnsi(output)}`,
+        `CLI exited while continuing after fallback acknowledgement. Output:\n${globalThis.stripAnsi(output)}`,
       );
     }
   } finally {
@@ -337,6 +359,7 @@ async function runDefaultCreateFailureScenario({
   );
   let terminal;
   let exited = false;
+  let exitCode = null;
   try {
     let output = "";
     terminal = pty.spawn("node", [cliPath, "--backend", "api"], {
@@ -357,8 +380,9 @@ async function runDefaultCreateFailureScenario({
     terminal.onData((data) => {
       output += data;
     });
-    terminal.onExit(() => {
+    terminal.onExit((event) => {
       exited = true;
+      exitCode = event.exitCode;
     });
 
     await waitForOutput(
@@ -374,6 +398,11 @@ async function runDefaultCreateFailureScenario({
       () => exited,
       "startup failure exit",
     );
+    if (exitCode !== 1) {
+      throw new Error(
+        `Expected startup failure to exit 1, got ${exitCode}. Output:\n${globalThis.stripAnsi(output)}`,
+      );
+    }
 
     const stripped = globalThis.stripAnsi(output);
     if (!stripped.includes(expectedOutput)) {

--- a/src/test-utils/startup-setup-pty-runner.cjs
+++ b/src/test-utils/startup-setup-pty-runner.cjs
@@ -86,6 +86,12 @@ function json(res, status, body) {
   res.end(`${JSON.stringify(body)}\n`);
 }
 
+function normalizeRequestPath(pathname) {
+  return pathname.length > 1 && pathname.endsWith("/")
+    ? pathname.slice(0, -1)
+    : pathname;
+}
+
 async function readRequestBody(req) {
   for await (const _chunk of req) {
     // Drain request bodies so the client can finish cleanly.
@@ -111,9 +117,10 @@ async function startAgentLimitServer(options = {}) {
   };
   const server = http.createServer(async (req, res) => {
     const url = new URL(req.url || "/", "http://127.0.0.1");
-    requests.push(`${req.method} ${url.pathname}`);
+    const requestPath = normalizeRequestPath(url.pathname);
+    requests.push(`${req.method} ${requestPath}`);
 
-    if (req.method === "GET" && url.pathname === "/v1/models/") {
+    if (req.method === "GET" && requestPath === "/v1/models") {
       json(res, 200, [
         {
           handle: "openai/gpt-4o-mini",
@@ -126,20 +133,20 @@ async function startAgentLimitServer(options = {}) {
       return;
     }
 
-    if (req.method === "POST" && url.pathname === "/v1/agents/") {
+    if (req.method === "POST" && requestPath === "/v1/agents") {
       await readRequestBody(req);
       json(res, createStatus, createBody);
       return;
     }
 
-    if (req.method === "GET" && url.pathname === "/v1/agents/") {
+    if (req.method === "GET" && requestPath === "/v1/agents") {
       json(res, listStatus, listBody ?? [fallbackAgent]);
       return;
     }
 
     if (
       req.method === "GET" &&
-      url.pathname === `/v1/agents/${FALLBACK_AGENT_ID}`
+      requestPath === `/v1/agents/${FALLBACK_AGENT_ID}`
     ) {
       json(res, 200, fallbackAgent);
       return;
@@ -418,7 +425,7 @@ async function runDefaultCreateFailureScenario({
     }
 
     const listAgentRequests = fakeApi.requests.filter(
-      (request) => request === "GET /v1/agents/",
+      (request) => request === "GET /v1/agents",
     ).length;
     if (expectListAgents && listAgentRequests === 0) {
       throw new Error(

--- a/src/test-utils/startup-setup-pty-runner.cjs
+++ b/src/test-utils/startup-setup-pty-runner.cjs
@@ -1,10 +1,14 @@
 const fs = require("node:fs");
+const http = require("node:http");
 const os = require("node:os");
 const path = require("node:path");
 const pty = require("node-pty");
 
-const [, , cliPath, projectRoot] = process.argv;
+const [, , cliPath, projectRoot, scenario = "setup-menu-raw-input"] =
+  process.argv;
 const INK_BRACKETED_PASTE_ENABLE = "\x1b[?2004h";
+const FALLBACK_AGENT_ID = "agent-existing-1";
+const FALLBACK_AGENT_NAME = "Existing Agent";
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -15,6 +19,17 @@ async function waitForOutput(getOutput, predicate, label, timeoutMs = 10000) {
   while (Date.now() < deadline) {
     const output = getOutput();
     if (predicate(output)) return output;
+    await sleep(25);
+  }
+  throw new Error(
+    `Timed out waiting for ${label}. Output:\n${globalThis.stripAnsi(getOutput()).slice(-4000)}`,
+  );
+}
+
+async function waitForExit(getOutput, hasExited, label, timeoutMs = 10000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (hasExited()) return;
     await sleep(25);
   }
   throw new Error(
@@ -55,15 +70,94 @@ function writeBrokenLocalTranscriptStore(homeDir) {
   fs.writeFileSync(path.join(conversationDir, "messages.jsonl"), "");
 }
 
-async function main() {
-  if (!cliPath || !projectRoot) {
-    throw new Error(
-      "Usage: startup-setup-pty-runner.cjs <cliPath> <projectRoot>",
-    );
+function json(res, status, body) {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(`${JSON.stringify(body)}\n`);
+}
+
+async function readRequestBody(req) {
+  for await (const _chunk of req) {
+    // Drain request bodies so the client can finish cleanly.
+  }
+}
+
+async function startAgentLimitServer(options = {}) {
+  const {
+    createStatus = 402,
+    createBody = {
+      error:
+        "You have reached your limit for agents, please upgrade your plan or delete some agents",
+      limit: 3,
+    },
+    listStatus = 200,
+    listBody,
+  } = options;
+  const requests = [];
+  const fallbackAgent = {
+    id: FALLBACK_AGENT_ID,
+    name: FALLBACK_AGENT_NAME,
+    tags: [],
+  };
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url || "/", "http://127.0.0.1");
+    requests.push(`${req.method} ${url.pathname}`);
+
+    if (req.method === "GET" && url.pathname === "/v1/models/") {
+      json(res, 200, [
+        {
+          handle: "openai/gpt-4o-mini",
+          max_context_window: 128000,
+          model: "gpt-4o-mini",
+          model_endpoint_type: "openai",
+          provider_type: "openai",
+        },
+      ]);
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/v1/agents/") {
+      await readRequestBody(req);
+      json(res, createStatus, createBody);
+      return;
+    }
+
+    if (req.method === "GET" && url.pathname === "/v1/agents/") {
+      json(res, listStatus, listBody ?? [fallbackAgent]);
+      return;
+    }
+
+    if (
+      req.method === "GET" &&
+      url.pathname === `/v1/agents/${FALLBACK_AGENT_ID}`
+    ) {
+      json(res, 200, fallbackAgent);
+      return;
+    }
+
+    json(res, 404, { error: `Unexpected fake API route ${req.method} ${url}` });
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Fake API server did not bind to a TCP port");
   }
 
-  globalThis.stripAnsi = (await import("strip-ansi")).default;
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise((resolve) => server.close(resolve)),
+    requests,
+  };
+}
 
+async function runSetupMenuRawInput() {
   const homeDir = fs.mkdtempSync(
     path.join(os.tmpdir(), "letta-setup-pty-home-"),
   );
@@ -151,6 +245,229 @@ async function main() {
     }
     fs.rmSync(homeDir, { recursive: true, force: true });
   }
+}
+
+async function runAgentLimitFallback() {
+  const fakeApi = await startAgentLimitServer();
+  const homeDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "letta-agent-limit-pty-home-"),
+  );
+  let terminal;
+  try {
+    let output = "";
+    let exited = false;
+    terminal = pty.spawn("node", [cliPath, "--backend", "api"], {
+      cols: 120,
+      cwd: projectRoot,
+      env: {
+        PATH: process.env.PATH,
+        HOME: homeDir,
+        TERM: "xterm-256color",
+        DISABLE_AUTOUPDATER: "1",
+        LETTA_BASE_URL: fakeApi.baseUrl,
+        LETTA_DISABLE_SESSION_PERSIST: "1",
+        LETTA_REQUEST_TIMEOUT_MS: "2000",
+      },
+      name: "xterm-256color",
+      rows: 30,
+    });
+    terminal.onData((data) => {
+      output += data;
+    });
+    terminal.onExit(() => {
+      exited = true;
+    });
+
+    await waitForOutput(
+      () => output,
+      (current) =>
+        globalThis
+          .stripAnsi(current)
+          .includes("Failed to create default agent"),
+      "default-agent creation failure",
+    );
+
+    await waitForOutput(
+      () => output,
+      (current) => {
+        const stripped = globalThis.stripAnsi(current);
+        return (
+          stripped.includes("You have reached your limit for agents") &&
+          stripped.includes(
+            `Selected existing agent "${FALLBACK_AGENT_NAME}" (${FALLBACK_AGENT_ID})`,
+          ) &&
+          stripped.includes("Press any key to continue")
+        );
+      },
+      "fallback selected-agent acknowledgement",
+    );
+
+    if (exited) {
+      throw new Error(
+        `CLI exited before fallback acknowledgement. Output:\n${globalThis.stripAnsi(output)}`,
+      );
+    }
+
+    terminal.write("x");
+    await sleep(250);
+
+    if (exited) {
+      throw new Error(
+        `CLI exited immediately after fallback acknowledgement. Output:\n${globalThis.stripAnsi(output)}`,
+      );
+    }
+  } finally {
+    if (terminal) {
+      terminal.write("\x03");
+      terminal.kill();
+    }
+    await fakeApi.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+}
+
+async function runDefaultCreateFailureScenario({
+  serverOptions,
+  expectedOutput,
+  expectListAgents,
+}) {
+  const fakeApi = await startAgentLimitServer(serverOptions);
+  const homeDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "letta-create-failure-pty-home-"),
+  );
+  let terminal;
+  let exited = false;
+  try {
+    let output = "";
+    terminal = pty.spawn("node", [cliPath, "--backend", "api"], {
+      cols: 120,
+      cwd: projectRoot,
+      env: {
+        PATH: process.env.PATH,
+        HOME: homeDir,
+        TERM: "xterm-256color",
+        DISABLE_AUTOUPDATER: "1",
+        LETTA_BASE_URL: fakeApi.baseUrl,
+        LETTA_DISABLE_SESSION_PERSIST: "1",
+        LETTA_REQUEST_TIMEOUT_MS: "2000",
+      },
+      name: "xterm-256color",
+      rows: 30,
+    });
+    terminal.onData((data) => {
+      output += data;
+    });
+    terminal.onExit(() => {
+      exited = true;
+    });
+
+    await waitForOutput(
+      () => output,
+      (current) =>
+        globalThis
+          .stripAnsi(current)
+          .includes("Failed to create default agent"),
+      "default-agent creation failure",
+    );
+    await waitForExit(
+      () => output,
+      () => exited,
+      "startup failure exit",
+    );
+
+    const stripped = globalThis.stripAnsi(output);
+    if (!stripped.includes(expectedOutput)) {
+      throw new Error(
+        `Expected output to include "${expectedOutput}". Output:\n${stripped}`,
+      );
+    }
+    if (stripped.includes("Selected existing agent")) {
+      throw new Error(`Unexpected fallback selection. Output:\n${stripped}`);
+    }
+    if (stripped.includes("Press any key to continue")) {
+      throw new Error(`Unexpected keypress prompt. Output:\n${stripped}`);
+    }
+
+    const listAgentRequests = fakeApi.requests.filter(
+      (request) => request === "GET /v1/agents/",
+    ).length;
+    if (expectListAgents && listAgentRequests === 0) {
+      throw new Error(
+        `Expected startup to list existing agents. Requests:\n${fakeApi.requests.join("\n")}`,
+      );
+    }
+    if (!expectListAgents && listAgentRequests !== 0) {
+      throw new Error(
+        `Did not expect startup to list existing agents. Requests:\n${fakeApi.requests.join("\n")}`,
+      );
+    }
+  } finally {
+    if (terminal && !exited) {
+      terminal.write("\x03");
+      terminal.kill();
+    }
+    await fakeApi.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  if (!cliPath || !projectRoot) {
+    throw new Error(
+      "Usage: startup-setup-pty-runner.cjs <cliPath> <projectRoot> [scenario]",
+    );
+  }
+
+  globalThis.stripAnsi = (await import("strip-ansi")).default;
+
+  if (scenario === "setup-menu-raw-input") {
+    await runSetupMenuRawInput();
+    return;
+  }
+
+  if (scenario === "agent-limit-fallback") {
+    await runAgentLimitFallback();
+    return;
+  }
+
+  if (scenario === "non-quota-create-failure") {
+    await runDefaultCreateFailureScenario({
+      serverOptions: {
+        createStatus: 500,
+        createBody: {
+          error: "Internal server exploded while creating agent",
+        },
+      },
+      expectedOutput: "Internal server exploded while creating agent",
+      expectListAgents: false,
+    });
+    return;
+  }
+
+  if (scenario === "agent-limit-empty-list") {
+    await runDefaultCreateFailureScenario({
+      serverOptions: { listBody: [] },
+      expectedOutput:
+        "No existing agents were available after default agent creation failed.",
+      expectListAgents: true,
+    });
+    return;
+  }
+
+  if (scenario === "agent-limit-list-failure") {
+    await runDefaultCreateFailureScenario({
+      serverOptions: {
+        listStatus: 500,
+        listBody: { error: "Unable to list agents" },
+      },
+      expectedOutput:
+        "Failed to list existing agents after default agent creation failed",
+      expectListAgents: true,
+    });
+    return;
+  }
+
+  throw new Error(`Unknown PTY startup scenario: ${scenario}`);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
Fixes #3167.

When an account is already at its agent limit, startup would still try to create a new default agent, fail with a 402, and exit — even though the account already has a usable Letta Code agent sitting right there. This mostly shows up when local settings point at a stale/missing `lastSession` agent ID, so the CLI decides it needs to create a new one instead of noticing an existing agent is available.

Now, when default-agent creation fails specifically because of an agent-limit/quota error, the CLI lists the account's existing agents, picks the first one, prints which agent it selected, and waits for a keypress before continuing — so the fallback is visible rather than silent. Any other create failure (network errors, auth issues, etc.) still exits immediately like before, and if listing agents also fails or comes back empty, it still hard-fails rather than pretending everything's fine. The acknowledgement prompt only shows up in an interactive TTY session; non-interactive runs skip straight through.

**Testing**
- `bun test src/startup-flow.test.ts` — fallback wiring is in place, and quota detection stays narrow (doesn't accidentally swallow unrelated errors like generic 429s)
- `bun test src/startup-setup-pty.test.ts` — end-to-end PTY coverage for the fallback path, the "no agents available" case, the "listing failed" case, and confirming non-quota failures still hard-fail (Windows skips the existing PTY cases)
- `cmd /c bun run check`

---
Authored by Claude, Codex, and Opencode. Reviewed by a real human too.