### PR TITLE
fix(updater): disable startup auto-update in subagents

### DIFF
--- a/src/agent/subagent-env-composition.test.ts
+++ b/src/agent/subagent-env-composition.test.ts
@@ -21,6 +21,7 @@ describe("composeSubagentChildEnv", () => {
 
     expect(env.LETTA_PARENT_AGENT_ID).toBe(PARENT_ID);
     expect(env.LETTA_CODE_AGENT_ROLE).toBe("subagent");
+    expect(env.DISABLE_AUTOUPDATER).toBe("1");
     // Default launch profile: MEMORY_DIR is NOT overridden to parent
     expect(env.MEMORY_DIR).toBeUndefined();
     expect(env.LETTA_MEMORY_DIR).toBeUndefined();
@@ -208,7 +209,21 @@ describe("composeSubagentChildEnv", () => {
         inheritedPrimaryRoot: PARENT_MEMORY_DIR,
       });
       expect(env.LETTA_CODE_AGENT_ROLE).toBe("subagent");
+      expect(env.DISABLE_AUTOUPDATER).toBe("1");
     }
+  });
+
+  test("subagent child env force-disables startup auto-update", () => {
+    const env = composeSubagentChildEnv({
+      parentProcessEnv: {
+        DISABLE_AUTOUPDATER: "0",
+      },
+      parentAgentId: PARENT_ID,
+      launchProfile: "default",
+      inheritedPrimaryRoot: null,
+    });
+
+    expect(env.DISABLE_AUTOUPDATER).toBe("1");
   });
 
   test("parent process env is inherited (HOME, PATH, etc.)", () => {

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -765,6 +765,9 @@ export function composeSubagentChildEnv(
     ...parentProcessEnv,
     ...(inheritedApiKey && { LETTA_API_KEY: inheritedApiKey }),
     ...(inheritedBaseUrl && { LETTA_BASE_URL: inheritedBaseUrl }),
+    // Subagents are child worker processes. They inherit the parent runtime and
+    // must not mutate the globally installed CLI while the parent is running.
+    DISABLE_AUTOUPDATER: "1",
     LETTA_CODE_AGENT_ROLE: "subagent",
     ...(parentAgentId && { LETTA_PARENT_AGENT_ID: parentAgentId }),
     ...(transcriptPath && { TRANSCRIPT_PATH: transcriptPath }),

--- a/src/updater/auto-update.test.ts
+++ b/src/updater/auto-update.test.ts
@@ -6,9 +6,11 @@ import {
   buildInstallCommand,
   buildLatestVersionUrl,
   buildUpdateExecOptions,
+  checkAndAutoUpdate,
   checkForUpdate,
   detectPackageManager,
   getSelfUpdateStatus,
+  isStartupAutoUpdateSuppressedByRuntimeContext,
   resolveUpdateInstallRegistryUrl,
   resolveUpdatePackageName,
   resolveUpdateRegistryBaseUrl,
@@ -222,6 +224,92 @@ describe("detectPackageManager", () => {
     process.argv[1] =
       "/usr/local/lib/node_modules/@letta-ai/letta-code/dist/index.js";
     expect(detectPackageManager()).toBe("npm");
+  });
+});
+
+describe("startup auto-update runtime suppression", () => {
+  let originalArgv1: string;
+  let originalDisableAutoupdater: string | undefined;
+  let originalAgentRole: string | undefined;
+  let originalParentAgentId: string | undefined;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalArgv1 = process.argv[1] || "";
+    originalDisableAutoupdater = process.env.DISABLE_AUTOUPDATER;
+    originalAgentRole = process.env.LETTA_CODE_AGENT_ROLE;
+    originalParentAgentId = process.env.LETTA_PARENT_AGENT_ID;
+    originalFetch = globalThis.fetch;
+
+    delete process.env.DISABLE_AUTOUPDATER;
+    delete process.env.LETTA_CODE_AGENT_ROLE;
+    delete process.env.LETTA_PARENT_AGENT_ID;
+  });
+
+  afterEach(() => {
+    process.argv[1] = originalArgv1;
+    globalThis.fetch = originalFetch;
+    if (originalDisableAutoupdater !== undefined) {
+      process.env.DISABLE_AUTOUPDATER = originalDisableAutoupdater;
+    } else {
+      delete process.env.DISABLE_AUTOUPDATER;
+    }
+    if (originalAgentRole !== undefined) {
+      process.env.LETTA_CODE_AGENT_ROLE = originalAgentRole;
+    } else {
+      delete process.env.LETTA_CODE_AGENT_ROLE;
+    }
+    if (originalParentAgentId !== undefined) {
+      process.env.LETTA_PARENT_AGENT_ID = originalParentAgentId;
+    } else {
+      delete process.env.LETTA_PARENT_AGENT_ID;
+    }
+  });
+
+  test("detects subagent runtime markers", () => {
+    expect(
+      isStartupAutoUpdateSuppressedByRuntimeContext({
+        LETTA_CODE_AGENT_ROLE: "subagent",
+      } as NodeJS.ProcessEnv),
+    ).toBe(true);
+    expect(
+      isStartupAutoUpdateSuppressedByRuntimeContext({
+        LETTA_PARENT_AGENT_ID: "agent-parent",
+      } as NodeJS.ProcessEnv),
+    ).toBe(true);
+    expect(
+      isStartupAutoUpdateSuppressedByRuntimeContext({
+        LETTA_CODE_AGENT_ROLE: "primary",
+      } as NodeJS.ProcessEnv),
+    ).toBe(false);
+  });
+
+  test("checkAndAutoUpdate skips before registry access in subagent runtime", async () => {
+    process.argv[1] =
+      "/usr/local/lib/node_modules/@letta-ai/letta-code/letta.js";
+    process.env.LETTA_CODE_AGENT_ROLE = "subagent";
+    const fetchMock = mock(() => {
+      throw new Error("auto-update should not check the registry in subagents");
+    }) as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
+
+    await expect(checkAndAutoUpdate()).resolves.toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("checkAndAutoUpdate skips before registry access when parent agent marker is present", async () => {
+    process.argv[1] =
+      "/usr/local/lib/node_modules/@letta-ai/letta-code/letta.js";
+    process.env.LETTA_PARENT_AGENT_ID = "agent-parent";
+    const fetchMock = mock(() => {
+      throw new Error(
+        "auto-update should not check the registry in child workers",
+      );
+    }) as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
+
+    await expect(checkAndAutoUpdate()).resolves.toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/updater/auto-update.ts
+++ b/src/updater/auto-update.ts
@@ -260,8 +260,19 @@ export function detectPackageManager(): PackageManager {
   return "npm";
 }
 
-function isAutoUpdateEnabled(): boolean {
-  return process.env.DISABLE_AUTOUPDATER !== "1";
+export function isStartupAutoUpdateSuppressedByRuntimeContext(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return (
+    env.LETTA_CODE_AGENT_ROLE === "subagent" || !!env.LETTA_PARENT_AGENT_ID
+  );
+}
+
+function isAutoUpdateEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return (
+    env.DISABLE_AUTOUPDATER !== "1" &&
+    !isStartupAutoUpdateSuppressedByRuntimeContext(env)
+  );
 }
 
 function isRunningLocally(): boolean {
@@ -505,13 +516,18 @@ export async function checkAndAutoUpdate(): Promise<
 > {
   debugLog("Auto-update check starting...");
   debugLog("isAutoUpdateEnabled:", isAutoUpdateEnabled());
-  const runningLocally = isRunningLocally();
-  debugLog("isRunningLocally:", runningLocally);
 
   if (!isAutoUpdateEnabled()) {
-    debugLog("Auto-update disabled via DISABLE_AUTOUPDATER=1");
+    debugLog(
+      process.env.DISABLE_AUTOUPDATER === "1"
+        ? "Auto-update disabled via DISABLE_AUTOUPDATER=1"
+        : "Auto-update disabled for subagent/worker runtime",
+    );
     return;
   }
+
+  const runningLocally = isRunningLocally();
+  debugLog("isRunningLocally:", runningLocally);
 
   if (runningLocally) {
     debugLog("Running locally, skipping auto-update");


### PR DESCRIPTION
## Summary
- force-disable startup auto-update in spawned subagent child environments
- add an updater-side guard for subagent/child runtime markers before registry fetch/install
- cover both the subagent env composition and updater short-circuit behavior with tests

## Validation
- `npm exec --yes bun -- test src/agent/subagent-env-composition.test.ts src/updater/auto-update.test.ts`
- `npm exec --yes bun -- run typecheck`
- `npm exec --yes @biomejs/biome@2.2.5 -- check src/updater/auto-update.ts src/updater/auto-update.test.ts src/agent/subagents/manager.ts src/agent/subagent-env-composition.test.ts`
- `npm exec --yes bun -- run check`
- `npm exec --yes bun -- test --coverage src/agent/subagent-env-composition.test.ts src/updater/auto-update.test.ts`

Draft only.