### PR TITLE
fix(model-selector): show discovered local models in recommended tab

### DIFF
--- a/src/cli/components/ModelSelector-categories.test.tsx
+++ b/src/cli/components/ModelSelector-categories.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   getModelCategories,
+  includeUnknownBackendHandleInRecommended,
   toSelectorModelForHandle,
   usesBackendModelCatalog,
 } from "@/cli/components/ModelSelector";
@@ -81,6 +82,33 @@ describe("getModelCategories", () => {
     expect(usesBackendModelCatalog(false, true)).toBe(true);
     expect(usesBackendModelCatalog(true, false)).toBe(true);
     expect(usesBackendModelCatalog(false, false)).toBe(false);
+  });
+
+  test("keeps discovered local endpoint models in recommended backend catalogs", () => {
+    expect(
+      includeUnknownBackendHandleInRecommended("llama.cpp/local-model"),
+    ).toBe(true);
+    expect(
+      includeUnknownBackendHandleInRecommended("llama-cpp/local-model"),
+    ).toBe(true);
+    expect(
+      includeUnknownBackendHandleInRecommended("lmstudio/local-model"),
+    ).toBe(true);
+    expect(
+      includeUnknownBackendHandleInRecommended("ollama/qwen2.5-coder:7b"),
+    ).toBe(true);
+    expect(
+      includeUnknownBackendHandleInRecommended("ollama-cloud/gpt-oss:120b"),
+    ).toBe(true);
+  });
+
+  test("does not promote unknown hosted backend handles to recommended", () => {
+    expect(
+      includeUnknownBackendHandleInRecommended("openai/not-in-registry"),
+    ).toBe(false);
+    expect(
+      includeUnknownBackendHandleInRecommended("custom-provider/model"),
+    ).toBe(false);
   });
 });
 

--- a/src/cli/components/ModelSelector.tsx
+++ b/src/cli/components/ModelSelector.tsx
@@ -13,6 +13,7 @@ import {
   getChatGptFastRegistryHandleForModelHandle,
   getLocalModelLabel,
   getModelInfo,
+  isLocalModelHandle,
   models,
   normalizeModelHandleForRegistry,
 } from "@/agent/model";
@@ -211,6 +212,13 @@ const API_GATED_MODEL_HANDLES = new Set([
   "letta/auto-fast",
   "letta/glm",
 ]);
+
+export function includeUnknownBackendHandleInRecommended(
+  handle: string,
+): boolean {
+  const registryHandle = normalizeModelHandleForRegistry(handle) ?? handle;
+  return isLocalModelHandle(registryHandle);
+}
 
 export function filterModelsByAvailabilityForSelector<
   T extends { handle: string },
@@ -701,13 +709,21 @@ export function ModelSelector({
     return filtered;
   }, [availableHandles, allApiHandles, searchQuery, isByokHandle]);
 
-  // Server-recommended models: models.json entries available on the server (for self-hosted)
+  // Server-recommended models: models.json entries available on the server.
+  // Discoverable local endpoint providers (Ollama, LM Studio, llama.cpp) do
+  // not have a static models.json catalog, so include their live-discovered
+  // handles here instead of hiding them until the user switches to "All".
   // Filter out letta/letta-free legacy model
   const serverRecommendedModels = useMemo(() => {
     if (!backendModelCatalog || availableHandles === undefined) return [];
     let available = allApiHandles
       .filter((handle) => handle !== "letta/letta-free")
-      .flatMap((handle) => modelsForBackendHandle(handle, false));
+      .flatMap((handle) =>
+        modelsForBackendHandle(
+          handle,
+          includeUnknownBackendHandleInRecommended(handle),
+        ),
+      );
     if (searchQuery) {
       const query = searchQuery.toLowerCase();
       available = available.filter(


### PR DESCRIPTION
## Summary
- keep live-discovered local endpoint models visible in the backend recommended model catalog
- add coverage for llama.cpp, LM Studio, Ollama, and Ollama Cloud handles
- avoid promoting arbitrary unknown hosted handles to recommended

## Validation
- bun test src/cli/components/ModelSelector-categories.test.tsx
- bun run check

Requested by Cameron after Discord support report.