### PR TITLE
fix(cli): validate auto-approved TUI tool args

### DIFF
--- a/src/cli/app/use-conversation-loop.ts
+++ b/src/cli/app/use-conversation-loop.ts
@@ -1992,6 +1992,7 @@ export function useConversationLoop(ctx: ConversationLoopContext) {
               await classifyApprovals(approvalsToProcess, {
                 getContext: analyzeToolApproval,
                 alwaysRequiresUserInput,
+                requireArgsForAutoApprove: true,
                 missingNameReason:
                   "Tool call incomplete - missing name or arguments",
                 toolContextId: approvalToolContextIdRef.current,

--- a/src/cli/approval-classification.test.ts
+++ b/src/cli/approval-classification.test.ts
@@ -14,7 +14,11 @@ import {
   savePermissionRule,
 } from "@/permissions/loader";
 import { permissionMode } from "@/permissions/mode";
-import { loadTools, prepareCurrentToolExecutionContext } from "@/tools/manager";
+import {
+  loadSpecificTools,
+  loadTools,
+  prepareCurrentToolExecutionContext,
+} from "@/tools/manager";
 
 describe("classifyApprovals", () => {
   const originalMemoryDir = process.env.MEMORY_DIR;
@@ -108,6 +112,37 @@ describe("classifyApprovals", () => {
       "Bash tool missing required parameter: command. Received parameters: description",
     );
     expect(denied?.permission.reason).toBe(denied?.denyReason);
+  });
+
+  test("reports missing exec_command cmd as validation error before auto-allow", async () => {
+    await loadSpecificTools(["exec_command"]);
+    permissionMode.setMode("unrestricted");
+
+    const result = await classifyApprovals(
+      [
+        {
+          toolCallId: "call_missing_cmd",
+          toolName: "exec_command",
+          toolArgs: JSON.stringify({
+            yield_time_ms: 1000,
+          }),
+        },
+      ],
+      {
+        requireArgsForAutoApprove: true,
+        workingDirectory: "/tmp/project",
+      },
+    );
+
+    expect(result.autoAllowed).toHaveLength(0);
+    expect(result.needsUserInput).toHaveLength(0);
+    expect(result.autoDenied).toHaveLength(1);
+
+    const [denied] = result.autoDenied;
+    expect(denied?.missingRequiredArgs).toEqual(["cmd"]);
+    expect(denied?.denyReason).toBe(
+      "exec_command tool missing required parameter: cmd. Received parameters: yield_time_ms",
+    );
   });
 
   test("mod permission overlays deny before unrestricted auto-allow", async () => {


### PR DESCRIPTION
## Summary
- validate required tool args before TUI auto-approval in unrestricted mode
- cover malformed exec_command approvals missing cmd

## Test
- bun test src/cli/approval-classification.test.ts
- bun run check