### PR TITLE
fix(slack): preserve progress cards across continuations

### DIFF
--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -1659,22 +1659,7 @@ test("slack adapter streams native task progress and clears thread status", asyn
     status: "complete",
   });
   expect(JSON.stringify(appendCall?.chunks)).not.toContain("token=abc");
-  expect(writeClient?.chat.stopStream).toHaveBeenCalledWith({
-    channel: "C123",
-    ts: "1712800000.000300",
-    chunks: [
-      {
-        type: "task_update",
-        id: "task_call-1",
-        title: "Ran",
-        status: "complete",
-      },
-      {
-        type: "plan_update",
-        title: "Completed",
-      },
-    ],
-  });
+  expect(writeClient?.chat.stopStream).not.toHaveBeenCalled();
   expect(writeClient?.assistant.threads.setStatus).toHaveBeenLastCalledWith({
     channel_id: "C123",
     thread_ts: "1712790000.000050",
@@ -2124,26 +2109,7 @@ test("slack adapter keeps separate task rows for parallel tool progress", async 
       }),
     ]),
   );
-  expect(writeClient?.chat.stopStream).toHaveBeenCalledWith({
-    channel: "C123",
-    ts: "1712800000.000300",
-    chunks: expect.arrayContaining([
-      expect.objectContaining({
-        id: "task_call-web",
-        title: "Searched articles",
-        status: "complete",
-      }),
-      expect.objectContaining({
-        id: "task_call-read",
-        title: "Read",
-        status: "complete",
-      }),
-      expect.objectContaining({
-        type: "plan_update",
-        title: "Completed",
-      }),
-    ]),
-  });
+  expect(writeClient?.chat.stopStream).not.toHaveBeenCalled();
 });
 
 test("slack adapter renders approval progress without thread status noise", async () => {
@@ -2476,6 +2442,97 @@ test("slack adapter keeps one active progress card slot until finalized", async 
   });
 });
 
+test("slack adapter keeps progress cards active across completed continuation lifecycles", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+  const source = {
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    chatType: "channel" as const,
+    senderId: "U123",
+    senderTeamId: "T123",
+    messageId: "1712800000.000100",
+    threadId: "1712790000.000050",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  };
+
+  await adapter.start();
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-1",
+    sources: [source],
+    kind: "tool",
+    state: "started",
+    message: "Reading files",
+    toolCallId: "call-1",
+    toolName: "read_file",
+  });
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "finished",
+    batchId: "batch-1",
+    outcome: "completed",
+    sources: [source],
+  });
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-2",
+    sources: [{ ...source, messageId: "1712800001.000100" }],
+    kind: "tool",
+    state: "started",
+    message: "Searching files",
+    toolCallId: "call-2",
+    toolName: "grep",
+  });
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient?.chat.stopStream).not.toHaveBeenCalled();
+  expect(writeClient?.chat.startStream).toHaveBeenCalledTimes(1);
+  expect(writeClient?.chat.appendStream).toHaveBeenCalledWith({
+    channel: "C123",
+    ts: "1712800000.000300",
+    chunks: expect.arrayContaining([
+      expect.objectContaining({
+        id: "task_call-2",
+        title: "Search",
+        status: "in_progress",
+      }),
+    ]),
+  });
+
+  await adapter.sendMessage({
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    text: "Done.",
+    threadId: "1712790000.000050",
+  });
+
+  expect(writeClient?.chat.stopStream).toHaveBeenCalledTimes(1);
+
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-3",
+    sources: [{ ...source, messageId: "1712800002.000100" }],
+    kind: "tool",
+    state: "started",
+    message: "Reading again",
+    toolCallId: "call-3",
+    toolName: "read_file",
+  });
+
+  expect(writeClient?.chat.startStream).toHaveBeenCalledTimes(2);
+});
+
 test("slack adapter treats already-closed stream stop errors as benign", async () => {
   const adapter = createSlackAdapter({
     ...slackAccountDefaults,
@@ -2518,11 +2575,12 @@ test("slack adapter treats already-closed stream stop errors as benign", async (
     error: "message_not_in_streaming_state",
   });
 
-  await adapter.handleTurnLifecycleEvent?.({
-    type: "finished",
-    batchId: "batch-1",
-    outcome: "completed",
-    sources: [source],
+  await adapter.sendMessage({
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    text: "Done.",
+    threadId: "1712790000.000050",
   });
 
   expect(writeClient?.chat.stopStream).toHaveBeenCalledWith({
@@ -2540,7 +2598,11 @@ test("slack adapter treats already-closed stream stop errors as benign", async (
       }),
     ]),
   });
-  expect(writeClient?.chat.postMessage).not.toHaveBeenCalled();
+  expect(writeClient?.chat.postMessage).toHaveBeenCalledWith({
+    channel: "C123",
+    text: "Done.",
+    thread_ts: "1712790000.000050",
+  });
   expect(writeClient?.chat.update).not.toHaveBeenCalled();
 });
 

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -2276,7 +2276,11 @@ export function createSlackAdapter(
     await Promise.all(
       uniqueSources.map(async (source) => {
         const key = getOrCreateSlackProgressCardKey(source, batchId);
-        const entry = key ? progressCardByReplyKey.get(key) : undefined;
+        if (!key) {
+          await clearSlackAssistantThreadStatus(source);
+          return;
+        }
+        const entry = progressCardByReplyKey.get(key);
         if (!entry) {
           await clearSlackAssistantThreadStatus(source);
           return;
@@ -2327,6 +2331,35 @@ export function createSlackAdapter(
         if (replyKey && activeProgressCardKeyByReplyKey.get(replyKey) === key) {
           activeProgressCardKeyByReplyKey.delete(replyKey);
         }
+        await clearSlackAssistantThreadStatus(source);
+      }),
+    );
+  }
+
+  async function flushSlackProgressCardsForCompletedLifecycle(
+    sources: ChannelTurnSource[],
+    batchId?: string,
+  ): Promise<void> {
+    const uniqueSources = getUniqueSlackProgressSources(sources);
+    await Promise.all(
+      uniqueSources.map(async (source) => {
+        const key = getOrCreateSlackProgressCardKey(source, batchId);
+        if (!key) {
+          await clearSlackAssistantThreadStatus(source);
+          return;
+        }
+        const entry = progressCardByReplyKey.get(key);
+        if (!entry) {
+          await clearSlackAssistantThreadStatus(source);
+          return;
+        }
+        if (entry.pendingTimer) {
+          clearTimeout(entry.pendingTimer);
+          entry.pendingTimer = undefined;
+        }
+        entry.source = source;
+        entry.updatedAt = Date.now();
+        await flushSlackProgressCard(key, entry);
         await clearSlackAssistantThreadStatus(source);
       }),
     );
@@ -2875,12 +2908,21 @@ export function createSlackAdapter(
         return;
       }
 
-      await finishSlackProgressCards(
-        event.sources,
-        event.outcome,
-        event.batchId,
-        event.error,
-      );
+      if (event.outcome === "completed") {
+        // Completed lifecycle events can be internal continuation boundaries;
+        // the final Slack send still closes the active progress card.
+        await flushSlackProgressCardsForCompletedLifecycle(
+          event.sources,
+          event.batchId,
+        );
+      } else {
+        await finishSlackProgressCards(
+          event.sources,
+          event.outcome,
+          event.batchId,
+          event.error,
+        );
+      }
 
       const errorText = event.outcome === "error" ? event.error?.trim() : null;
       if (!errorText) {


### PR DESCRIPTION
## Summary

Fixes a rich Slack progress-card lifecycle bug in the live feedback branch. Completed channel lifecycle events can happen at continuation or compaction boundaries; treating them as terminal stopped the native Slack stream and cleared the active card key. The next tool progress then started a second visible card in the same thread.

This changes completed lifecycle handling to flush pending progress and clear assistant thread status without closing the card. Final non-reaction Slack sends still close the active card, and error or cancelled lifecycle outcomes still stop the stream.

## Validation

- bun run check
- bun test src/channels/slack-adapter.test.ts
