### PR TITLE
feat(channels): support Slack mention bang commands

### DIFF
--- a/src/channels/commands.test.ts
+++ b/src/channels/commands.test.ts
@@ -7,18 +7,21 @@ import {
   buildChannelCancelUnavailableMessage,
   buildChannelChatLinkMessage,
   buildChannelChatUnavailableMessage,
+  buildChannelDetachedMessage,
   buildChannelHelpMessage,
   buildChannelModelListMessage,
   buildChannelModelListUnavailableMessage,
   buildChannelModelUnavailableMessage,
   buildChannelModelUpdatedMessage,
   buildChannelModelUpdateFailedMessage,
+  buildChannelNewConversationMessage,
   buildChannelNoRouteMessage,
   buildChannelPausedMessage,
   buildChannelResumedMessage,
   buildChannelStatusMessage,
   buildUnsupportedChannelCommandMessage,
   listChannelSlashCommands,
+  parseChannelBangCommand,
   parseChannelSlashCommand,
 } from "@/channels/commands";
 
@@ -34,6 +37,15 @@ describe("channel slash commands", () => {
   test("ignores normal text and slash-like paths", () => {
     expect(parseChannelSlashCommand("hello /help")).toBeNull();
     expect(parseChannelSlashCommand("/tmp/file.txt")).toBeNull();
+  });
+
+  test("parses bang commands for mention-scoped Slack dispatch", () => {
+    expect(parseChannelBangCommand(" !MODEL sonnet ")).toEqual({
+      name: "model",
+      args: "sonnet",
+      raw: "!MODEL sonnet",
+    });
+    expect(parseChannelBangCommand("hello !help")).toBeNull();
   });
 
   test("lists supported commands for channel help", () => {
@@ -56,6 +68,11 @@ describe("channel slash commands", () => {
     expect(text).toContain("Telegram is connected to Letta Code.");
     expect(text).toContain(
       "Supported slash commands here: /help, /status, /pause, /resume, /cancel, /chat, /model, /reflection.",
+    );
+
+    const slackText = buildChannelHelpMessage("slack");
+    expect(slackText).toContain(
+      "In Slack threads, mention the app with bang commands: !help, !detach, !model, !new, !reload.",
     );
   });
 
@@ -158,6 +175,12 @@ describe("channel slash commands", () => {
     expect(buildChannelChatUnavailableMessage("telegram", route)).toContain(
       "chat UI is not available",
     );
+    expect(buildChannelDetachedMessage("slack")).toContain(
+      "detached this thread",
+    );
+    expect(buildChannelNewConversationMessage("slack", route)).toContain(
+      "started a new conversation",
+    );
   });
 
   test("builds model selector-style command messages", () => {
@@ -249,5 +272,19 @@ describe("channel slash commands", () => {
       "Supported slash commands here: /help, /status, /pause, /resume, /cancel, /chat, /model, /reflection.",
     );
     expect(text).toContain("without a leading slash");
+
+    const bangCommand = parseChannelBangCommand("!pause");
+    expect(bangCommand).not.toBeNull();
+    if (!bangCommand) {
+      throw new Error("Expected !pause to parse as a bang command");
+    }
+    const bangText = buildUnsupportedChannelCommandMessage(
+      "slack",
+      bangCommand,
+    );
+    expect(bangText).toContain("Slack received !pause");
+    expect(bangText).toContain(
+      "Supported bang commands here: !help, !detach, !model, !new, !reload.",
+    );
   });
 });

--- a/src/channels/commands.test.ts
+++ b/src/channels/commands.test.ts
@@ -66,11 +66,13 @@ describe("channel slash commands", () => {
 
     const text = buildChannelHelpMessage("telegram");
     expect(text).toContain("Telegram is connected to Letta Code.");
+    expect(text).not.toContain("MessageChannel");
     expect(text).toContain(
       "Supported slash commands here: /help, /status, /pause, /resume, /cancel, /chat, /model, /reflection.",
     );
 
     const slackText = buildChannelHelpMessage("slack");
+    expect(slackText).not.toContain("MessageChannel");
     expect(slackText).toContain(
       "In Slack threads, mention the app with bang commands: !help, !detach, !model, !new, !reload.",
     );

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -35,7 +35,15 @@ export type ChannelSlashCommandHandlers = {
     command: ParsedChannelSlashCommand,
     msg: InboundChannelMessage,
   ) => Promise<ChannelSlashCommandHandlerResult>;
+  detach?: (
+    command: ParsedChannelSlashCommand,
+    msg: InboundChannelMessage,
+  ) => Promise<ChannelSlashCommandHandlerResult>;
   model?: (
+    command: ParsedChannelSlashCommand,
+    msg: InboundChannelMessage,
+  ) => Promise<ChannelSlashCommandHandlerResult>;
+  newConversation?: (
     command: ParsedChannelSlashCommand,
     msg: InboundChannelMessage,
   ) => Promise<ChannelSlashCommandHandlerResult>;
@@ -44,6 +52,10 @@ export type ChannelSlashCommandHandlers = {
     msg: InboundChannelMessage,
   ) => Promise<ChannelSlashCommandHandlerResult>;
   reflection?: (
+    command: ParsedChannelSlashCommand,
+    msg: InboundChannelMessage,
+  ) => Promise<ChannelSlashCommandHandlerResult>;
+  reload?: (
     command: ParsedChannelSlashCommand,
     msg: InboundChannelMessage,
   ) => Promise<ChannelSlashCommandHandlerResult>;
@@ -63,6 +75,7 @@ export type ChannelStatusContext = {
 export type ChannelSlashCommandOptions = {
   statusContext?: ChannelStatusContext;
   handlers?: ChannelSlashCommandHandlers;
+  enableBangCommands?: boolean;
 };
 
 const CHANNEL_SLASH_COMMANDS: ChannelSlashCommandDefinition[] = [
@@ -109,6 +122,14 @@ const CHANNEL_SLASH_COMMANDS: ChannelSlashCommandDefinition[] = [
   },
 ];
 
+const CHANNEL_BANG_COMMAND_NAMES = [
+  "help",
+  "detach",
+  "model",
+  "new",
+  "reload",
+] as const;
+
 function channelDisplayName(channelId: string): string {
   try {
     return getChannelDisplayName(channelId);
@@ -146,14 +167,55 @@ export function parseChannelSlashCommand(
   };
 }
 
-function supportedCommandsText(): string {
+export function parseChannelBangCommand(
+  text: string,
+): ParsedChannelSlashCommand | null {
+  const trimmed = text.trim();
+  const match = trimmed.match(/^!([A-Za-z][\w-]*)(?:\s+(.*))?$/);
+  if (!match) {
+    return null;
+  }
+  const [, name, args] = match;
+  if (!name) {
+    return null;
+  }
+
+  return {
+    name: name.toLowerCase(),
+    args: args?.trim() ?? "",
+    raw: trimmed,
+  };
+}
+
+function supportedCommandsText(prefix: "/" | "!" = "/"): string {
   return listChannelSlashCommands()
-    .map((definition) => `/${definition.name}`)
+    .map((definition) => `${prefix}${definition.name}`)
     .join(", ");
+}
+
+function supportedBangCommandsText(): string {
+  return CHANNEL_BANG_COMMAND_NAMES.map((name) => `!${name}`).join(", ");
+}
+
+function isSupportedChannelBangCommand(commandName: string): boolean {
+  return CHANNEL_BANG_COMMAND_NAMES.includes(
+    commandName as (typeof CHANNEL_BANG_COMMAND_NAMES)[number],
+  );
 }
 
 export function buildChannelHelpMessage(channelId: string): string {
   const displayName = channelDisplayName(channelId);
+
+  if (channelId === "slack") {
+    return [
+      `${displayName} is connected to Letta Code.`,
+      "Send a normal message here and the connected agent will reply in this chat.",
+      "Use MessageChannel-supported actions by asking naturally, for example: send a message, react, or upload a file when available.",
+      `Supported slash commands here: ${supportedCommandsText()}.`,
+      `In Slack threads, mention the app with bang commands: ${supportedBangCommandsText()}.`,
+      "If this chat is not connected yet, send any non-command message and follow the pairing instructions.",
+    ].join("\n\n");
+  }
 
   return [
     `${displayName} is connected to Letta Code.`,
@@ -169,11 +231,13 @@ export function buildUnsupportedChannelCommandMessage(
   command: ParsedChannelSlashCommand,
 ): string {
   const displayName = channelDisplayName(channelId);
+  const isBang = command.raw.startsWith("!");
+  const commandKind = isBang ? "bang" : "slash";
 
   return [
-    `${displayName} received ${command.raw}, but that slash command is not supported in channels yet.`,
-    `Supported slash commands here: ${supportedCommandsText()}.`,
-    "Send normal messages without a leading slash to talk to the connected agent.",
+    `${displayName} received ${command.raw}, but that ${commandKind} command is not supported in channels yet.`,
+    `Supported ${commandKind} commands here: ${isBang ? supportedBangCommandsText() : supportedCommandsText()}.`,
+    `Send normal messages without a leading ${isBang ? "bang" : "slash"} command to talk to the connected agent.`,
   ].join("\n\n");
 }
 
@@ -204,6 +268,13 @@ export function buildChannelStatusMessage(
     lines.push(`Conversation: ${route.conversationId}.`);
     if (route.threadId) {
       lines.push(`Thread: ${route.threadId}.`);
+    }
+    if (route.detached) {
+      lines.push("Slack thread is detached until the app is mentioned again.");
+    } else if (route.outboundEnabled === false) {
+      lines.push(
+        "Outbound replies are disabled until the app is mentioned again.",
+      );
     }
   } else {
     lines.push(
@@ -293,6 +364,38 @@ export function buildChannelChatUnavailableMessage(
 ): string {
   const displayName = channelDisplayName(channelId);
   return `${displayName} chat UI is not available for local backend agent ${route.agentId}.`;
+}
+
+export function buildChannelDetachUnsupportedMessage(
+  channelId: string,
+): string {
+  const displayName = channelDisplayName(channelId);
+  return `${displayName} can only detach Slack channel threads.`;
+}
+
+export function buildChannelDetachedMessage(channelId: string): string {
+  const displayName = channelDisplayName(channelId);
+  return `${displayName} detached this thread. I will ignore follow-up replies here until someone mentions the app again.`;
+}
+
+export function buildChannelAlreadyDetachedMessage(channelId: string): string {
+  const displayName = channelDisplayName(channelId);
+  return `${displayName} is already detached from this thread. Mention the app again to reattach.`;
+}
+
+export function buildChannelNewConversationMessage(
+  channelId: string,
+  route: ChannelRoute,
+): string {
+  const displayName = channelDisplayName(channelId);
+  return `${displayName} started a new conversation for this chat. Conversation: ${route.conversationId}.`;
+}
+
+export function buildChannelNewConversationUnavailableMessage(
+  channelId: string,
+): string {
+  const displayName = channelDisplayName(channelId);
+  return `${displayName} cannot start a new conversation for this chat because no agent is configured.`;
 }
 
 type ChannelModelListEntry = Pick<
@@ -500,6 +603,13 @@ export function buildChannelReflectionUnavailableMessage(
   return `${displayName} cannot start reflection for this chat because the listener is not ready yet. Try again in a moment.`;
 }
 
+export function buildChannelReloadUnavailableMessage(
+  channelId: string,
+): string {
+  const displayName = channelDisplayName(channelId);
+  return `${displayName} cannot reload listener settings for this chat because the listener is not ready yet. Try again in a moment.`;
+}
+
 async function handleScopedCommand(params: {
   msg: InboundChannelMessage;
   command: ParsedChannelSlashCommand;
@@ -523,9 +633,21 @@ export async function tryHandleChannelSlashCommand(
   msg: InboundChannelMessage,
   options: ChannelSlashCommandOptions = {},
 ): Promise<boolean> {
-  const command = parseChannelSlashCommand(msg.text);
+  const command =
+    parseChannelSlashCommand(msg.text) ??
+    (options.enableBangCommands ? parseChannelBangCommand(msg.text) : null);
   if (!command) {
     return false;
+  }
+  const isBangCommand = command.raw.startsWith("!");
+
+  if (isBangCommand && !isSupportedChannelBangCommand(command.name)) {
+    await adapter.sendDirectReply(
+      msg.chatId,
+      buildUnsupportedChannelCommandMessage(msg.channel, command),
+      msg.threadId ? { replyToMessageId: msg.threadId } : undefined,
+    );
+    return true;
   }
 
   const text = await (async () => {
@@ -566,11 +688,29 @@ export async function tryHandleChannelSlashCommand(
           command,
           handler: options.handlers?.chat,
         });
+      case "detach":
+        if (!isBangCommand) {
+          return buildUnsupportedChannelCommandMessage(msg.channel, command);
+        }
+        return handleScopedCommand({
+          msg,
+          command,
+          handler: options.handlers?.detach,
+        });
       case "model":
         return handleScopedCommand({
           msg,
           command,
           handler: options.handlers?.model,
+        });
+      case "new":
+        if (!isBangCommand) {
+          return buildUnsupportedChannelCommandMessage(msg.channel, command);
+        }
+        return handleScopedCommand({
+          msg,
+          command,
+          handler: options.handlers?.newConversation,
         });
       case "reflect":
       case "reflection":
@@ -578,6 +718,15 @@ export async function tryHandleChannelSlashCommand(
           msg,
           command,
           handler: options.handlers?.reflection,
+        });
+      case "reload":
+        if (!isBangCommand) {
+          return buildUnsupportedChannelCommandMessage(msg.channel, command);
+        }
+        return handleScopedCommand({
+          msg,
+          command,
+          handler: options.handlers?.reload,
         });
       default:
         return buildUnsupportedChannelCommandMessage(msg.channel, command);

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -210,7 +210,6 @@ export function buildChannelHelpMessage(channelId: string): string {
     return [
       `${displayName} is connected to Letta Code.`,
       "Send a normal message here and the connected agent will reply in this chat.",
-      "Use MessageChannel-supported actions by asking naturally, for example: send a message, react, or upload a file when available.",
       `Supported slash commands here: ${supportedCommandsText()}.`,
       `In Slack threads, mention the app with bang commands: ${supportedBangCommandsText()}.`,
       "If this chat is not connected yet, send any non-command message and follow the pairing instructions.",
@@ -220,7 +219,6 @@ export function buildChannelHelpMessage(channelId: string): string {
   return [
     `${displayName} is connected to Letta Code.`,
     "Send a normal message here and the connected agent will reply in this chat.",
-    "Use MessageChannel-supported actions by asking naturally, for example: send a message, react, or upload a file when available.",
     `Supported slash commands here: ${supportedCommandsText()}.`,
     "If this chat is not connected yet, send any non-command message and follow the pairing instructions.",
   ].join("\n\n");

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -23,16 +23,23 @@ import {
 } from "./accounts";
 import {
   buildChannelAlreadyActiveMessage,
+  buildChannelAlreadyDetachedMessage,
   buildChannelAlreadyPausedMessage,
   buildChannelCancelNoActiveTurnMessage,
   buildChannelCancelUnavailableMessage,
   buildChannelChatLinkMessage,
   buildChannelChatUnavailableMessage,
+  buildChannelDetachedMessage,
+  buildChannelDetachUnsupportedMessage,
   buildChannelModelUnavailableMessage,
+  buildChannelNewConversationMessage,
+  buildChannelNewConversationUnavailableMessage,
   buildChannelNoRouteMessage,
   buildChannelPausedMessage,
   buildChannelReflectionUnavailableMessage,
+  buildChannelReloadUnavailableMessage,
   buildChannelResumedMessage,
+  parseChannelBangCommand,
   parseChannelSlashCommand,
   tryHandleChannelSlashCommand,
 } from "./commands";
@@ -482,6 +489,16 @@ export type ChannelModelHandler = (params: {
   text?: string;
 }>;
 
+export type ChannelReloadHandler = (params: {
+  runtime: {
+    agent_id: string;
+    conversation_id: string;
+  };
+}) => Promise<{
+  handled: boolean;
+  text?: string;
+}>;
+
 type ChannelStartupOptions = {
   logger?: ChannelStartupLogger;
 };
@@ -586,6 +603,7 @@ export class ChannelRegistry {
   private cancelHandler: ChannelCancelHandler | null = null;
   private reflectionHandler: ChannelReflectionHandler | null = null;
   private modelHandler: ChannelModelHandler | null = null;
+  private reloadHandler: ChannelReloadHandler | null = null;
   private readonly buffer: ChannelInboundDelivery[] = [];
   private readonly pendingControlRequestsById = new Map<
     string,
@@ -738,6 +756,10 @@ export class ChannelRegistry {
 
   setModelHandler(handler: ChannelModelHandler | null): void {
     this.modelHandler = handler;
+  }
+
+  setReloadHandler(handler: ChannelReloadHandler | null): void {
+    this.reloadHandler = handler;
   }
 
   setEventHandler(
@@ -1076,6 +1098,7 @@ export class ChannelRegistry {
     this.cancelHandler = null;
     this.reflectionHandler = null;
     this.modelHandler = null;
+    this.reloadHandler = null;
   }
 
   /**
@@ -1095,6 +1118,7 @@ export class ChannelRegistry {
     this.cancelHandler = null;
     this.reflectionHandler = null;
     this.modelHandler = null;
+    this.reloadHandler = null;
     this.pendingControlRequestsById.clear();
     this.pendingControlRequestIdByScope.clear();
     this.unsubscribeWhatsAppState();
@@ -1107,8 +1131,12 @@ export class ChannelRegistry {
     adapter: ChannelAdapter,
     msg: InboundChannelMessage,
   ): Promise<boolean> {
-    const slashCommand = parseChannelSlashCommand(msg.text);
-    if (slashCommand) {
+    const channelCommand =
+      parseChannelSlashCommand(msg.text) ??
+      (msg.channel === "slack" && msg.isMention === true
+        ? parseChannelBangCommand(msg.text)
+        : null);
+    if (channelCommand) {
       return false;
     }
 
@@ -1297,6 +1325,122 @@ export class ChannelRegistry {
     };
   }
 
+  private async handleDetachSlashCommand(
+    msg: InboundChannelMessage,
+  ): Promise<{ handled: boolean; text?: string }> {
+    if (
+      msg.channel !== "slack" ||
+      msg.chatType !== "channel" ||
+      !msg.threadId
+    ) {
+      return {
+        handled: true,
+        text: buildChannelDetachUnsupportedMessage(msg.channel),
+      };
+    }
+
+    const existingRoute = this.loadAndFindRawRouteForMessage(msg);
+    if (existingRoute?.detached === true) {
+      return {
+        handled: true,
+        text: buildChannelAlreadyDetachedMessage(msg.channel),
+      };
+    }
+
+    const now = new Date().toISOString();
+    if (existingRoute) {
+      const updatedRoute: ChannelRoute = {
+        ...existingRoute,
+        enabled: true,
+        outboundEnabled: false,
+        detached: true,
+        updatedAt: now,
+      };
+      addRoute(msg.channel, updatedRoute);
+      return {
+        handled: true,
+        text: buildChannelDetachedMessage(msg.channel),
+      };
+    }
+
+    const accountId = msg.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID;
+    const config = getChannelAccount(msg.channel, accountId);
+    if (!config || !isSlackChannelAccount(config) || !config.agentId) {
+      return {
+        handled: true,
+        text: buildChannelNoRouteMessage(msg.channel),
+      };
+    }
+
+    await this.createSlackRoute(config, msg, {
+      outboundEnabled: false,
+      detached: true,
+    });
+    return {
+      handled: true,
+      text: buildChannelDetachedMessage(msg.channel),
+    };
+  }
+
+  private async handleNewConversationSlashCommand(
+    msg: InboundChannelMessage,
+  ): Promise<{ handled: boolean; text?: string }> {
+    if (msg.channel !== "slack") {
+      return {
+        handled: true,
+        text: buildChannelNewConversationUnavailableMessage(msg.channel),
+      };
+    }
+
+    const accountId = msg.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID;
+    const config = getChannelAccount(msg.channel, accountId);
+    if (!config || !isSlackChannelAccount(config) || !config.agentId) {
+      return {
+        handled: true,
+        text: buildChannelNewConversationUnavailableMessage(msg.channel),
+      };
+    }
+
+    const existingRoute = this.loadAndFindRawRouteForMessage(msg);
+    const agentId = existingRoute?.agentId ?? config.agentId;
+    const conversationId = await this.createConversationForAgent(
+      agentId,
+      buildSlackConversationSummary(msg),
+    );
+    const now = new Date().toISOString();
+    const route: ChannelRoute = {
+      accountId: config.accountId,
+      chatId: msg.chatId,
+      chatType: msg.chatType,
+      threadId:
+        msg.chatType === "channel"
+          ? (msg.threadId ?? msg.messageId ?? null)
+          : null,
+      agentId,
+      conversationId,
+      enabled: true,
+      outboundEnabled: true,
+      detached: false,
+      createdAt: existingRoute?.createdAt ?? now,
+      updatedAt: now,
+    };
+
+    addRoute(msg.channel, route);
+    this.eventHandler?.({
+      type: "slack_conversation_created",
+      channelId: "slack",
+      accountId: config.accountId,
+      agentId,
+      conversationId,
+      defaultPermissionMode: config.defaultPermissionMode,
+    });
+
+    return {
+      handled: true,
+      text: buildChannelNewConversationMessage(msg.channel, route),
+    };
+  }
+
   private async handleReflectionSlashCommand(
     msg: InboundChannelMessage,
   ): Promise<{ handled: boolean; text?: string }> {
@@ -1316,6 +1460,32 @@ export class ChannelRegistry {
     }
 
     return this.reflectionHandler({
+      runtime: {
+        agent_id: route.agentId,
+        conversation_id: route.conversationId,
+      },
+    });
+  }
+
+  private async handleReloadSlashCommand(
+    msg: InboundChannelMessage,
+  ): Promise<{ handled: boolean; text?: string }> {
+    const route = this.loadAndFindRawRouteForMessage(msg);
+    if (!route?.enabled) {
+      return {
+        handled: true,
+        text: buildChannelNoRouteMessage(msg.channel),
+      };
+    }
+
+    if (!this.reloadHandler) {
+      return {
+        handled: true,
+        text: buildChannelReloadUnavailableMessage(msg.channel),
+      };
+    }
+
+    return this.reloadHandler({
       runtime: {
         agent_id: route.agentId,
         conversation_id: route.conversationId,
@@ -1388,18 +1558,22 @@ export class ChannelRegistry {
     return matches.length === 1 ? (matches[0] ?? null) : null;
   }
 
-  private hasExactEnabledRouteForMessage(
+  private getExactEnabledRouteForMessage(
     msg: InboundChannelMessage,
     accountId: string,
-  ): boolean {
-    if (getRouteFromStore(msg.channel, msg.chatId, accountId, msg.threadId)) {
-      return true;
+  ): ChannelRoute | null {
+    const existingRoute = getRouteFromStore(
+      msg.channel,
+      msg.chatId,
+      accountId,
+      msg.threadId,
+    );
+    if (existingRoute) {
+      return existingRoute;
     }
 
     loadRoutes(msg.channel);
-    return Boolean(
-      getRouteFromStore(msg.channel, msg.chatId, accountId, msg.threadId),
-    );
+    return getRouteFromStore(msg.channel, msg.chatId, accountId, msg.threadId);
   }
 
   private shouldDropUnroutedSlackThreadInput(
@@ -1407,15 +1581,25 @@ export class ChannelRegistry {
     accountId: string,
     config: ChannelAccount | null,
   ): boolean {
+    if (
+      msg.channel !== "slack" ||
+      msg.chatType !== "channel" ||
+      msg.threadId == null ||
+      msg.isMention === true
+    ) {
+      return false;
+    }
+
+    const exactRoute = this.getExactEnabledRouteForMessage(msg, accountId);
+    if (exactRoute?.detached === true) {
+      return true;
+    }
+
     return (
-      msg.channel === "slack" &&
-      msg.chatType === "channel" &&
-      msg.threadId != null &&
-      msg.isMention !== true &&
       (!config ||
         !isSlackChannelAccount(config) ||
         config.listenMode !== true) &&
-      !this.hasExactEnabledRouteForMessage(msg, accountId)
+      !exactRoute
     );
   }
 
@@ -1467,13 +1651,20 @@ export class ChannelRegistry {
             this.handleCancelSlashCommand(commandMsg),
           chat: async (_command, commandMsg) =>
             this.handleChatSlashCommand(commandMsg),
+          detach: async (_command, commandMsg) =>
+            this.handleDetachSlashCommand(commandMsg),
           model: async (command, commandMsg) =>
             this.handleModelSlashCommand(command, commandMsg),
+          newConversation: async (_command, commandMsg) =>
+            this.handleNewConversationSlashCommand(commandMsg),
           pause: async () => this.handlePauseResumeSlashCommand("pause", msg),
           reflection: async (_command, commandMsg) =>
             this.handleReflectionSlashCommand(commandMsg),
+          reload: async (_command, commandMsg) =>
+            this.handleReloadSlashCommand(commandMsg),
           resume: async () => this.handlePauseResumeSlashCommand("resume", msg),
         },
+        enableBangCommands: msg.channel === "slack" && msg.isMention === true,
       })
     ) {
       return;
@@ -1743,7 +1934,7 @@ export class ChannelRegistry {
   private async createSlackRoute(
     config: SlackChannelAccount,
     msg: InboundChannelMessage,
-    options: { outboundEnabled?: boolean } = {},
+    options: { outboundEnabled?: boolean; detached?: boolean } = {},
   ): Promise<ChannelRoute> {
     if (!config.agentId) {
       throw new Error("Slack app is missing an agent binding.");
@@ -1766,6 +1957,7 @@ export class ChannelRegistry {
       conversationId,
       enabled: true,
       outboundEnabled: options.outboundEnabled !== false,
+      detached: options.detached === true,
       createdAt: now,
       updatedAt: now,
     };
@@ -1842,11 +2034,12 @@ export class ChannelRegistry {
       if (
         msg.chatType === "channel" &&
         msg.isMention === true &&
-        route.outboundEnabled === false
+        (route.outboundEnabled === false || route.detached === true)
       ) {
         const updatedRoute: ChannelRoute = {
           ...route,
           outboundEnabled: true,
+          detached: false,
           updatedAt: new Date().toISOString(),
         };
         addRoute(msg.channel, updatedRoute);

--- a/src/channels/routing.ts
+++ b/src/channels/routing.ts
@@ -68,6 +68,7 @@ export function loadRoutes(channelId: string): void {
             conversationId: route.conversationId,
             enabled: route.enabled !== false,
             outboundEnabled: route.outboundEnabled !== false,
+            detached: route.detached === true,
             createdAt: route.createdAt ?? new Date().toISOString(),
             updatedAt:
               route.updatedAt ?? route.createdAt ?? new Date().toISOString(),
@@ -99,6 +100,7 @@ export function loadRoutes(channelId: string): void {
             conversationId: route.conversationId,
             enabled: route.enabled !== false,
             outboundEnabled: route.outboundEnabled !== false,
+            detached: route.detached === true,
             createdAt: route.createdAt ?? new Date().toISOString(),
             updatedAt:
               route.updatedAt ?? route.createdAt ?? new Date().toISOString(),

--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -486,6 +486,50 @@ test("slack adapter forwards DM messages as direct channel input", async () => {
   );
 });
 
+test("slack adapter normalizes mentioned DM text", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  const onMessage = mock(async () => {});
+  adapter.onMessage = onMessage;
+
+  await adapter.start();
+  const app = FakeSlackApp.instances[0];
+  const handler = app?.messageHandler;
+  if (!handler) {
+    throw new Error("Expected Slack message handler");
+  }
+
+  await handler({
+    message: {
+      channel: "D123",
+      user: "U123",
+      text: "<@U0AS42PTEAX>!help",
+      ts: "1712800000.000100",
+    },
+  });
+
+  expect(onMessage).toHaveBeenCalledWith(
+    expect.objectContaining({
+      channel: "slack",
+      chatId: "D123",
+      senderId: "U123",
+      text: "!help",
+      messageId: "1712800000.000100",
+      chatType: "direct",
+      isMention: true,
+    }),
+  );
+});
+
 test("slack adapter forwards app mentions as channel input", async () => {
   const adapter = createSlackAdapter({
     ...slackAccountDefaults,
@@ -512,7 +556,7 @@ test("slack adapter forwards app mentions as channel input", async () => {
     event: {
       channel: "C123",
       user: "U123",
-      text: "<@U999> please help",
+      text: "<@U0AS42PTEAX>!help",
       ts: "1712800000.000100",
       thread_ts: "1712790000.000050",
     },
@@ -523,7 +567,7 @@ test("slack adapter forwards app mentions as channel input", async () => {
       channel: "slack",
       chatId: "C123",
       senderId: "U123",
-      text: "please help",
+      text: "!help",
       messageId: "1712800000.000100",
       threadId: "1712790000.000050",
       chatType: "channel",

--- a/src/channels/slack-registry.test.ts
+++ b/src/channels/slack-registry.test.ts
@@ -275,6 +275,40 @@ describe("slack channel registry", () => {
     expect(deliveries).toHaveLength(2);
   });
 
+  test("mention bang help in a DM is handled before agent delivery", async () => {
+    const { ChannelRegistry } = await import("@/channels/registry");
+    const registry = new ChannelRegistry();
+    const replies: string[] = [];
+    const adapter = {
+      ...createAdapter(),
+      sendDirectReply: async (_chatId: string, text: string) => {
+        replies.push(text);
+      },
+    };
+    registry.registerAdapter(adapter);
+
+    const deliveries: unknown[] = [];
+    registry.setMessageHandler((delivery) => {
+      deliveries.push(delivery);
+    });
+    registry.setReady();
+
+    await adapter.onMessage?.(
+      createInboundMessage({
+        chatId: "D123",
+        chatType: "direct",
+        threadId: null,
+        isMention: true,
+        text: "!help",
+        messageId: "1712800001.000300",
+      }),
+    );
+
+    expect(deliveries).toEqual([]);
+    expect(replies).toHaveLength(1);
+    expect(replies[0]).toContain("mention the app with bang commands");
+  });
+
   test("unmentioned bang text stays normal routed Slack input", async () => {
     const { ChannelRegistry } = await import("@/channels/registry");
     const registry = new ChannelRegistry();

--- a/src/channels/slack-registry.test.ts
+++ b/src/channels/slack-registry.test.ts
@@ -219,4 +219,133 @@ describe("slack channel registry", () => {
       ),
     ).not.toBeNull();
   });
+
+  test("mention bang detach silences the thread until the app is mentioned again", async () => {
+    const { ChannelRegistry } = await import("@/channels/registry");
+    const registry = new ChannelRegistry();
+    const adapter = createAdapter();
+    registry.registerAdapter(adapter);
+
+    const deliveries: Array<{ turnSources?: unknown[] }> = [];
+    registry.setMessageHandler((delivery) => {
+      deliveries.push(delivery);
+    });
+    registry.setReady();
+
+    await adapter.onMessage?.(
+      createInboundMessage({
+        isMention: true,
+        text: "please take a look",
+        messageId: "1712800001.000300",
+      }),
+    );
+    await adapter.onMessage?.(
+      createInboundMessage({
+        isMention: true,
+        text: "!detach",
+        messageId: "1712800002.000400",
+      }),
+    );
+
+    let route = getRoute("slack", "C123", "slack-bot", "1712790000.000050");
+    expect(route).toEqual(
+      expect.objectContaining({ detached: true, outboundEnabled: false }),
+    );
+
+    await adapter.onMessage?.(
+      createInboundMessage({
+        text: "normal follow-up after detach",
+        messageId: "1712800003.000500",
+      }),
+    );
+    expect(deliveries).toHaveLength(1);
+
+    await adapter.onMessage?.(
+      createInboundMessage({
+        isMention: true,
+        text: "rejoining this thread",
+        messageId: "1712800004.000600",
+      }),
+    );
+
+    route = getRoute("slack", "C123", "slack-bot", "1712790000.000050");
+    expect(route).toEqual(
+      expect.objectContaining({ detached: false, outboundEnabled: true }),
+    );
+    expect(deliveries).toHaveLength(2);
+  });
+
+  test("unmentioned bang text stays normal routed Slack input", async () => {
+    const { ChannelRegistry } = await import("@/channels/registry");
+    const registry = new ChannelRegistry();
+    const adapter = createAdapter();
+    registry.registerAdapter(adapter);
+
+    const deliveries: unknown[] = [];
+    registry.setMessageHandler((delivery) => {
+      deliveries.push(delivery);
+    });
+    registry.setReady();
+
+    await adapter.onMessage?.(
+      createInboundMessage({
+        isMention: true,
+        text: "please take a look",
+        messageId: "1712800001.000300",
+      }),
+    );
+    await adapter.onMessage?.(
+      createInboundMessage({
+        text: "!detach",
+        messageId: "1712800002.000400",
+      }),
+    );
+
+    const route = getRoute("slack", "C123", "slack-bot", "1712790000.000050");
+    expect(route).toEqual(expect.objectContaining({ outboundEnabled: true }));
+    expect(route?.detached).not.toBe(true);
+    expect(deliveries).toHaveLength(2);
+  });
+
+  test("mention bang new replaces the Slack thread route conversation", async () => {
+    createConversation
+      .mockResolvedValueOnce({ id: "conv-original" })
+      .mockResolvedValueOnce({ id: "conv-replacement" });
+
+    const { ChannelRegistry } = await import("@/channels/registry");
+    const registry = new ChannelRegistry();
+    const adapter = createAdapter();
+    registry.registerAdapter(adapter);
+
+    const deliveries: unknown[] = [];
+    registry.setMessageHandler((delivery) => {
+      deliveries.push(delivery);
+    });
+    registry.setReady();
+
+    await adapter.onMessage?.(
+      createInboundMessage({
+        isMention: true,
+        text: "please take a look",
+        messageId: "1712800001.000300",
+      }),
+    );
+    await adapter.onMessage?.(
+      createInboundMessage({
+        isMention: true,
+        text: "!new",
+        messageId: "1712800002.000400",
+      }),
+    );
+
+    expect(createConversation).toHaveBeenCalledTimes(2);
+    expect(getRoute("slack", "C123", "slack-bot", "1712790000.000050")).toEqual(
+      expect.objectContaining({
+        conversationId: "conv-replacement",
+        detached: false,
+        outboundEnabled: true,
+      }),
+    );
+    expect(deliveries).toHaveLength(1);
+  });
 });

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -1003,7 +1003,7 @@ export function createSlackAdapter(
           chatId: channelId,
           senderId: rawMessage.user,
           senderName,
-          text,
+          text: wasMentioned ? normalizeSlackText(text) : text,
           timestamp: slackTimestampToMillis(rawMessage.ts),
           messageId: rawMessage.ts,
           threadId: null,

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -319,6 +319,8 @@ export interface ChannelRoute {
   enabled: boolean;
   /** Whether this route permits outbound MessageChannel sends. Defaults true. */
   outboundEnabled?: boolean;
+  /** Slack-only: a detached thread stays silent until the app is mentioned again. */
+  detached?: boolean;
   /** ISO 8601 creation timestamp. */
   createdAt: string;
   /** ISO 8601 update timestamp. */

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -317,7 +317,7 @@ async function handleModCommand(
   });
 }
 
-async function handleReloadCommand(
+export async function handleReloadCommand(
   conversationRuntime: ConversationRuntime,
 ): Promise<string> {
   const { listener } = conversationRuntime;

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -33,6 +33,7 @@ import { isDebugEnabled } from "@/utils/debug";
 import { setMessageQueueAdder } from "@/utils/message-queue-bridge";
 import { killAllTerminals } from "@/websocket/terminal-handler";
 import { rejectPendingApprovalResolvers } from "./approval";
+import { handleReloadCommand } from "./commands";
 import { handleChannelRegistryEvent } from "./commands/channels";
 import {
   applyModelUpdateForRuntime,
@@ -606,6 +607,27 @@ export async function wireChannelIngress(
           modelIdentifier,
           error instanceof Error ? error.message : "Failed to update model",
         ),
+      };
+    }
+  });
+
+  registry.setReloadHandler(async ({ runtime }) => {
+    const scopedRuntime = getOrCreateScopedRuntime(
+      listener,
+      runtime.agent_id,
+      runtime.conversation_id,
+    );
+    try {
+      const output = await handleReloadCommand(scopedRuntime);
+      emitDeviceStatusUpdate(socket, scopedRuntime, runtime);
+      return {
+        handled: true,
+        text: output,
+      };
+    } catch (error) {
+      return {
+        handled: true,
+        text: `Failed to reload listener settings: ${error instanceof Error ? error.message : String(error)}`,
       };
     }
   });


### PR DESCRIPTION
## Summary
- Handle Slack app-mention bang commands through the shared channel command router: `!help`, `!detach`, `!model`, `!new`, and `!reload`.
- Add a Slack-only detached route state so normal unmentioned thread replies stay silent until a later app mention reattaches the thread.
- Wire `!new` to replace the Slack thread with a fresh conversation route, and wire `!reload` to the existing listener reload path.

## Why
Slack app mentions already normalize away the bot mention before channel routing. Without a bang-command path, operational messages like `!detach` were delivered as model input instead of being handled by the listener.

## Notes
- Bang parsing is only enabled for Slack messages marked as app mentions.
- Unmentioned bang-looking text remains normal routed input unless the thread is already detached.
- `/detach`, `/new`, and `/reload` are not exposed as general channel slash commands.

## Validation
- `bun test src/channels/commands.test.ts src/channels/slack-registry.test.ts`
- `bun run typecheck`
- `bun run check`
