### PR TITLE
fix(listen): refresh environment context on runtime switch

### DIFF
--- a/src/cli/helpers/session-context.test.ts
+++ b/src/cli/helpers/session-context.test.ts
@@ -20,4 +20,12 @@ describe("session context reminder", () => {
     expect(context).not.toContain("Agent name");
     expect(context).not.toContain("Server location");
   });
+
+  test("uses environment-changed intro for intra-session environment switches", () => {
+    const context = buildSessionContext({ reason: "environment_changed" });
+
+    expect(context).toContain(
+      "The execution environment for this conversation has changed. Updated environment context follows.",
+    );
+  });
 });

--- a/src/cli/helpers/session-context.ts
+++ b/src/cli/helpers/session-context.ts
@@ -90,6 +90,9 @@ function getIntroText(
   if (reason === "cwd_changed") {
     return "The working directory for this conversation has changed. Updated environment context follows.";
   }
+  if (reason === "environment_changed") {
+    return "The execution environment for this conversation has changed. Updated environment context follows.";
+  }
   switch (source) {
     case "listen":
       return "This conversation is now connected to a Letta Code execution environment.";

--- a/src/reminders/listen-session-context.test.ts
+++ b/src/reminders/listen-session-context.test.ts
@@ -52,7 +52,10 @@ function listenContext(
     agentDescription?: string | null;
     agentLastRunAt?: string | null;
     workingDirectory?: string;
-    sessionContextReason?: "initial_attach" | "cwd_changed";
+    sessionContextReason?:
+      | "initial_attach"
+      | "cwd_changed"
+      | "environment_changed";
   },
 ) {
   return buildListenReminderContext({

--- a/src/reminders/state.ts
+++ b/src/reminders/state.ts
@@ -23,7 +23,10 @@ export interface MemoryGitSyncReminder {
   text: string;
 }
 
-export type SessionContextReason = "initial_attach" | "cwd_changed";
+export type SessionContextReason =
+  | "initial_attach"
+  | "cwd_changed"
+  | "environment_changed";
 
 export interface SharedReminderState {
   hasSentAgentInfo: boolean;

--- a/src/websocket/listener/commands/runtime-start.ts
+++ b/src/websocket/listener/commands/runtime-start.ts
@@ -103,6 +103,18 @@ function sendRuntimeStartResponse(
   );
 }
 
+function rearmSessionContextForEnvironmentSwitch(
+  scopedRuntime: ConversationRuntime,
+): void {
+  if (!scopedRuntime.reminderState.hasSentSessionContext) {
+    return;
+  }
+
+  scopedRuntime.reminderState.hasSentSessionContext = false;
+  scopedRuntime.reminderState.pendingSessionContextReason =
+    "environment_changed";
+}
+
 function validateRuntimeStartShape(parsed: RuntimeStartCommand): void {
   const hasAgentId = hasString(parsed.agent_id);
   const hasCreateAgent = parsed.create_agent !== undefined;
@@ -233,6 +245,7 @@ export async function handleRuntimeStartCommand(
       runtimeScope.conversation_id,
     );
     await applyRuntimeStartState(parsed, context, runtimeScope, scopedRuntime);
+    rearmSessionContextForEnvironmentSwitch(scopedRuntime);
     registerRuntimeExternalTools(
       context.runtime,
       runtimeScope,


### PR DESCRIPTION
## Summary
- Re-arm listen-mode session context when an existing conversation receives a new runtime_start after its initial context was already sent.
- Add an `environment_changed` session-context reason so the injected system alert says the execution environment changed, not just the CWD.
- Keep initial attach behavior unchanged by only re-arming conversations that already sent session context.

## Test plan
- [x] `bun test src/cli/helpers/session-context.test.ts src/reminders/listen-session-context.test.ts`
- [x] `bun run typecheck`
- [x] `bun run check`

<img width="565" height="289" alt="image" src="https://github.com/user-attachments/assets/23f1689a-d522-48b5-b04c-ac0f2b17a498" />