### PR TITLE
fix(providers): always emit is_oauth for chatgpt_oauth in connect provider response

### DIFF
--- a/src/providers/connect-provider-service.ts
+++ b/src/providers/connect-provider-service.ts
@@ -260,7 +260,9 @@ export function buildConnectProviderEntries(
       provider_type: provider.providerType,
       provider_name: provider.providerName,
       provider_names: uniqueProviderNames(provider),
-      ...(provider.isOAuth ? { is_oauth: true } : {}),
+      ...(provider.isOAuth || provider.providerType === "chatgpt_oauth"
+        ? { is_oauth: true }
+        : {}),
       ...(provider.oauthProviderId
         ? { oauth_provider_id: provider.oauthProviderId }
         : {}),

--- a/src/providers/connect-provider-service.ts
+++ b/src/providers/connect-provider-service.ts
@@ -260,7 +260,9 @@ export function buildConnectProviderEntries(
       provider_type: provider.providerType,
       provider_name: provider.providerName,
       provider_names: uniqueProviderNames(provider),
-      ...(provider.isOAuth || provider.providerType === "chatgpt_oauth"
+      ...(provider.isOAuth ||
+      provider.providerType === "chatgpt_oauth" ||
+      provider.providerType === "openai-codex"
         ? { is_oauth: true }
         : {}),
       ...(provider.oauthProviderId


### PR DESCRIPTION
buildConnectProviderEntries() only set is_oauth=true when provider.isOAuth was truthy. A chatgpt_oauth provider can be constructed via byokProviderFromPiSpec() rather than localOAuthProviderConfigs(), and that path does not set isOAuth. When is_oauth is absent from the response, the letta-cloud desktop UI falls back to connectorKind=apiKey and shows a coming-soon banner instead of the real OAuth flow.

Fix: also emit is_oauth=true when provider_type is chatgpt_oauth, so the protocol field is always correct regardless of which code path constructed the ByokProvider.

Companion source fix to letta-cloud PR #12699.
