### PR TITLE
fix(providers): promote chatgpt_oauth as canonical providerType for openai-codex

### DIFF
--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -196,7 +196,7 @@ const PI_PROVIDER_OVERRIDES: Partial<
     localProviderNames: ["amazon-bedrock", LOCAL_BEDROCK_PROVIDER_NAME],
   },
   "openai-codex": {
-    providerTypes: ["openai-codex", "chatgpt_oauth"],
+    providerTypes: ["chatgpt_oauth", "openai-codex"],
     handlePrefixes: ["openai-codex/", "chatgpt-plus-pro/"],
     localProviderNames: ["openai-codex", LOCAL_CHATGPT_PROVIDER_NAME],
   },

--- a/src/providers/connect-provider-service.ts
+++ b/src/providers/connect-provider-service.ts
@@ -260,7 +260,9 @@ export function buildConnectProviderEntries(
       provider_type: provider.providerType,
       provider_name: provider.providerName,
       provider_names: uniqueProviderNames(provider),
-      ...(provider.isOAuth ? { is_oauth: true } : {}),
+      ...(provider.isOAuth || provider.providerType === "chatgpt_oauth"
+        ? { is_oauth: true }
+        : {}),
       ...(provider.oauthProviderId
         ? { oauth_provider_id: provider.oauthProviderId }
         : {}),

--- a/src/providers/connect-provider-service.ts
+++ b/src/providers/connect-provider-service.ts
@@ -260,7 +260,9 @@ export function buildConnectProviderEntries(
       provider_type: provider.providerType,
       provider_name: provider.providerName,
       provider_names: uniqueProviderNames(provider),
-      ...(provider.isOAuth || provider.providerType === "chatgpt_oauth"
+      ...(provider.isOAuth ||
+      provider.providerType === "chatgpt_oauth" ||
+      provider.providerType === "openai-codex"
         ? { is_oauth: true }
         : {}),
       ...(provider.oauthProviderId

--- a/src/providers/connect-provider-service.ts
+++ b/src/providers/connect-provider-service.ts
@@ -260,9 +260,7 @@ export function buildConnectProviderEntries(
       provider_type: provider.providerType,
       provider_name: provider.providerName,
       provider_names: uniqueProviderNames(provider),
-      ...(provider.isOAuth ||
-      provider.providerType === "chatgpt_oauth" ||
-      provider.providerType === "openai-codex"
+      ...(provider.isOAuth || provider.providerType === "chatgpt_oauth"
         ? { is_oauth: true }
         : {}),
       ...(provider.oauthProviderId

--- a/src/providers/connect-provider-service.ts
+++ b/src/providers/connect-provider-service.ts
@@ -260,9 +260,7 @@ export function buildConnectProviderEntries(
       provider_type: provider.providerType,
       provider_name: provider.providerName,
       provider_names: uniqueProviderNames(provider),
-      ...(provider.isOAuth || provider.providerType === "chatgpt_oauth"
-        ? { is_oauth: true }
-        : {}),
+      ...(provider.isOAuth ? { is_oauth: true } : {}),
       ...(provider.oauthProviderId
         ? { oauth_provider_id: provider.oauthProviderId }
         : {}),


### PR DESCRIPTION
The openai-codex spec had providerTypes: ["openai-codex", "chatgpt_oauth"]. Since providerTypes[0] is used as the provider_type in the WS list_connect_providers response, the desktop UI received "openai-codex" instead of "chatgpt_oauth". Downstream checks in letta-cloud that identified the ChatGPT OAuth provider by type all missed it, causing the connect flow to show a coming-soon banner instead of the real OAuth flow.

Swapping the order makes chatgpt_oauth the canonical type emitted over the wire, consistent with how the provider is stored in the local auth file and how letta-cloud identifies it.

Root cause fix. Companion to letta-cloud PR #12699 which adds openai-codex fallbacks as defense in depth for older desktop versions already in the field.
