### PR TITLE
fix(channels): include run IDs in lifecycle errors

### DIFF
--- a/src/channels/discord/adapter.ts
+++ b/src/channels/discord/adapter.ts
@@ -307,10 +307,14 @@ export function buildDiscordReplyOptions(
   };
 }
 
-function formatDiscordLifecycleErrorMessage(errorText: string): string {
+function formatDiscordLifecycleErrorMessage(
+  errorText: string,
+  runId?: string | null,
+): string {
   return formatChannelLifecycleErrorMessage(errorText, {
     codeBlock: true,
     maxLength: DISCORD_LIFECYCLE_ERROR_TEXT_MAX,
+    runId,
   });
 }
 
@@ -520,6 +524,7 @@ export function createDiscordAdapter(
   async function sendLifecycleErrorReply(
     source: ChannelTurnSource,
     errorText: string,
+    runId?: string | null,
   ): Promise<void> {
     if (!client) return;
     const key = getLifecycleReplyKey(source);
@@ -535,7 +540,7 @@ export function createDiscordAdapter(
     const reply = buildDiscordReplyOptions(source.messageId, targetChannelId);
     await channel.send({
       allowedMentions: { parse: [] },
-      content: formatDiscordLifecycleErrorMessage(errorText),
+      content: formatDiscordLifecycleErrorMessage(errorText, runId),
       ...(reply ?? {}),
     });
   }
@@ -1095,7 +1100,7 @@ export function createDiscordAdapter(
       await Promise.all(
         Array.from(uniqueReplySources.values()).map(async (source) => {
           try {
-            await sendLifecycleErrorReply(source, errorText);
+            await sendLifecycleErrorReply(source, errorText, event.runId);
           } catch (error) {
             console.warn(
               `[Discord] Failed to post lifecycle error for ${source.chatId}:`,

--- a/src/channels/lifecycle-error-report.ts
+++ b/src/channels/lifecycle-error-report.ts
@@ -41,8 +41,11 @@ function withDefinedValues(
 export function buildChannelLifecycleErrorReport(
   source: ChannelTurnSource,
   errorText: string | null | undefined,
+  options: { runId?: string | null } = {},
 ): ChannelLifecycleErrorReport {
-  const display = getChannelLifecycleErrorDisplay(errorText);
+  const display = getChannelLifecycleErrorDisplay(errorText, {
+    runId: options.runId,
+  });
   return {
     channel: source.channel,
     accountId: source.accountId,

--- a/src/channels/lifecycle-error.test.ts
+++ b/src/channels/lifecycle-error.test.ts
@@ -94,6 +94,21 @@ describe("formatChannelLifecycleErrorMessage", () => {
       ),
     ).not.toContain("```");
   });
+
+  test("appends explicit run IDs to generic channel errors", () => {
+    expect(
+      formatChannelLifecycleErrorMessage("Unexpected stop reason: error", {
+        codeBlock: true,
+        runId: "run-456",
+      }),
+    ).toBe(
+      "Turn failed:\n" +
+        "```\n" +
+        "Something went wrong while processing that message. Please try again.\n" +
+        "```\n\n" +
+        "Run ID: run-456",
+    );
+  });
 });
 
 describe("sanitizeChannelLifecycleErrorText", () => {

--- a/src/channels/lifecycle-error.ts
+++ b/src/channels/lifecycle-error.ts
@@ -29,6 +29,7 @@ export type ChannelLifecycleErrorKind =
 
 export interface ChannelLifecycleErrorDisplayOptions {
   automaticRetry?: boolean;
+  runId?: string | null;
 }
 
 export interface ChannelLifecycleErrorDisplay {
@@ -147,7 +148,8 @@ export function getChannelLifecycleErrorDisplay(
   options: ChannelLifecycleErrorDisplayOptions = {},
 ): ChannelLifecycleErrorDisplay {
   const normalized = sanitizeChannelLifecycleErrorText(errorText);
-  const runId = extractChannelLifecycleRunId(errorText);
+  const optionsRunId = options.runId?.trim();
+  const runId = optionsRunId || extractChannelLifecycleRunId(errorText);
 
   if (!normalized || RAW_LOOP_ERROR_PATTERN.test(normalized)) {
     return {
@@ -211,8 +213,16 @@ export function formatChannelLifecycleErrorMessage(
 
   if (options.codeBlock) {
     const escaped = body.replace(/```/g, "``\u200b`");
-    return `${display.title}:\n\`\`\`\n${escaped}\n\`\`\``;
+    const lines = [`${display.title}:`, "```", escaped, "```"];
+    if (display.runId) {
+      lines.push("", `Run ID: ${display.runId}`);
+    }
+    return lines.join("\n");
   }
 
-  return `${display.title}:\n${body}`;
+  const lines = [`${display.title}:`, body];
+  if (display.runId) {
+    lines.push("", `Run ID: ${display.runId}`);
+  }
+  return lines.join("\n");
 }

--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -1510,6 +1510,7 @@ test("slack adapter posts the lifecycle error back into the same thread as a cod
     batchId: "batch-3",
     outcome: "error",
     error: "Boom: something went wrong\nsecond line",
+    runId: "run-123",
     sources: [
       {
         channel: "slack",
@@ -1532,7 +1533,7 @@ test("slack adapter posts the lifecycle error back into the same thread as a cod
   });
   expect(writeClient?.chat.postMessage).toHaveBeenCalledWith({
     channel: "C123",
-    text: "Turn failed:\n```\nBoom: something went wrong\nsecond line\n```",
+    text: "Turn failed:\n```\nBoom: something went wrong\nsecond line\n```\n\nRun ID: run-123",
     thread_ts: "1712790000.000050",
   });
 });
@@ -1636,6 +1637,7 @@ test("slack adapter hides raw generic lifecycle errors", async () => {
     batchId: "batch-raw-error",
     outcome: "error",
     error: "Unexpected stop reason: error",
+    runId: "run-raw-error",
     sources: [
       {
         channel: "slack",
@@ -1653,7 +1655,7 @@ test("slack adapter hides raw generic lifecycle errors", async () => {
   const writeClient = FakeSlackWriteClient.instances[0];
   expect(writeClient?.chat.postMessage).toHaveBeenCalledWith({
     channel: "C123",
-    text: "Turn failed:\n```\nSomething went wrong while processing that message. Please try again.\n```",
+    text: "Turn failed:\n```\nSomething went wrong while processing that message. Please try again.\n```\n\nRun ID: run-raw-error",
     thread_ts: "1712790000.000050",
   });
 });

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -721,10 +721,14 @@ export function createSlackAdapter(
     return `${source.chatId}:${replyToMessageId}`;
   }
 
-  function formatSlackLifecycleErrorMessage(errorText: string): string {
+  function formatSlackLifecycleErrorMessage(
+    errorText: string,
+    runId?: string | null,
+  ): string {
     return formatChannelLifecycleErrorMessage(errorText, {
       codeBlock: true,
       maxLength: SLACK_LIFECYCLE_ERROR_TEXT_MAX,
+      runId,
     });
   }
 
@@ -780,6 +784,7 @@ export function createSlackAdapter(
   async function sendLifecycleErrorReply(
     source: ChannelTurnSource,
     errorText: string,
+    runId?: string | null,
   ): Promise<void> {
     const replyToMessageId = source.threadId ?? source.messageId;
     if (!isNonEmptyString(replyToMessageId)) {
@@ -790,7 +795,7 @@ export function createSlackAdapter(
     const slackClient = await ensureWriteClient();
     const response = await slackClient.chat.postMessage({
       channel: source.chatId,
-      text: formatSlackLifecycleErrorMessage(errorText),
+      text: formatSlackLifecycleErrorMessage(errorText, runId),
       thread_ts: replyToMessageId,
     });
     rememberMessageThread(response.ts, replyToMessageId);
@@ -1380,7 +1385,7 @@ export function createSlackAdapter(
       await Promise.all(
         Array.from(uniqueReplySources.values()).map(async (source) => {
           try {
-            await sendLifecycleErrorReply(source, errorText);
+            await sendLifecycleErrorReply(source, errorText, event.runId);
           } catch (error) {
             console.warn(
               `[Slack] Failed to post lifecycle error for ${source.chatId}:`,

--- a/src/channels/telegram/adapter.ts
+++ b/src/channels/telegram/adapter.ts
@@ -612,9 +612,13 @@ function getTelegramLifecycleErrorReplyKey(
   ].join(":");
 }
 
-function formatTelegramLifecycleErrorMessage(errorText: string): string {
+function formatTelegramLifecycleErrorMessage(
+  errorText: string,
+  runId?: string | null,
+): string {
   return formatChannelLifecycleErrorMessage(errorText, {
     maxLength: TELEGRAM_LIFECYCLE_ERROR_TEXT_MAX,
+    runId,
   });
 }
 
@@ -1089,12 +1093,13 @@ export function createTelegramAdapter(
   function rememberLifecycleErrorReport(
     source: ChannelTurnSource,
     errorText: string,
+    runId?: string | null,
   ): string {
     pruneLifecycleErrorReports();
     const token = randomUUID();
     lifecycleErrorReports.set(token, {
       expiresAt: Date.now() + TELEGRAM_LIFECYCLE_ERROR_REPORT_TTL_MS,
-      report: buildChannelLifecycleErrorReport(source, errorText),
+      report: buildChannelLifecycleErrorReport(source, errorText, { runId }),
       submitted: false,
     });
     return `${TELEGRAM_REPORT_CALLBACK_PREFIX}${token}`;
@@ -1164,6 +1169,7 @@ export function createTelegramAdapter(
   async function sendLifecycleErrorReply(
     source: ChannelTurnSource,
     errorText: string,
+    runId?: string | null,
   ): Promise<void> {
     const key = getTelegramLifecycleErrorReplyKey(source);
     if (!key || !rememberLifecycleErrorReply(key)) {
@@ -1190,7 +1196,11 @@ export function createTelegramAdapter(
         [
           {
             text: "Report error",
-            callback_data: rememberLifecycleErrorReport(source, errorText),
+            callback_data: rememberLifecycleErrorReport(
+              source,
+              errorText,
+              runId,
+            ),
           },
         ],
       ],
@@ -1198,7 +1208,7 @@ export function createTelegramAdapter(
 
     await telegramBot.api.sendMessage(
       source.chatId,
-      formatTelegramLifecycleErrorMessage(errorText),
+      formatTelegramLifecycleErrorMessage(errorText, runId),
       options,
     );
   }
@@ -1504,7 +1514,11 @@ export function createTelegramAdapter(
       await Promise.all(
         Array.from(uniqueSources.values()).map(async (source) => {
           try {
-            await sendLifecycleErrorReply(source, event.error ?? "Turn failed");
+            await sendLifecycleErrorReply(
+              source,
+              event.error ?? "Turn failed",
+              event.runId,
+            );
           } catch (error) {
             console.warn(
               `[Telegram] Failed to send lifecycle error reply for ${source.chatId}:`,

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -120,6 +120,7 @@ export type ChannelTurnLifecycleEvent =
       sources: ChannelTurnSource[];
       outcome: ChannelTurnOutcome;
       error?: string;
+      runId?: string;
     };
 
 // ── Adapter interface ─────────────────────────────────────────────

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -1,4 +1,5 @@
 import { formatChannelControlRequestPrompt } from "@/channels/interactive";
+import { formatChannelLifecycleErrorMessage } from "@/channels/lifecycle-error";
 import type {
   ChannelAdapter,
   ChannelControlRequestEvent,
@@ -622,9 +623,13 @@ export function createWhatsAppAdapter(
       await Promise.all(
         Array.from(uniqueSources.values()).map(async (source) => {
           try {
-            await adapter.sendDirectReply(source.chatId, errorText, {
-              replyToMessageId: source.messageId,
-            });
+            await adapter.sendDirectReply(
+              source.chatId,
+              formatChannelLifecycleErrorMessage(errorText, {
+                runId: event.runId,
+              }),
+              { replyToMessageId: source.messageId },
+            );
           } catch (error) {
             console.warn(
               `[WhatsApp:${account.accountId}] Failed to send lifecycle error reply for ${source.chatId}:`,

--- a/src/websocket/listen-client-concurrency.test.ts
+++ b/src/websocket/listen-client-concurrency.test.ts
@@ -1301,6 +1301,7 @@ describe("listen-client multi-worker concurrency", () => {
         runtime.lastStopReason = "error";
         runtime.lastTerminalLoopErrorMessage =
           "ChatGPT usage limit reached. Resets at 1:00 PM.";
+        runtime.lastTerminalLoopErrorRunId = "run-limit";
       },
     );
 
@@ -1312,6 +1313,7 @@ describe("listen-client multi-worker concurrency", () => {
       sources: channelTurnSources,
       outcome: "error",
       error: "ChatGPT usage limit reached. Resets at 1:00 PM.",
+      runId: "run-limit",
     });
   });
 

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -166,6 +166,7 @@ async function dispatchChannelTurnLifecycleEvent(
         sources: ChannelTurnSource[];
         outcome: ChannelTurnOutcome;
         error?: string;
+        runId?: string;
       },
 ): Promise<void> {
   if (event.sources.length === 0) {
@@ -188,6 +189,7 @@ async function dispatchChannelTurnLifecycleEvent(
     sources: event.sources,
     outcome: event.outcome,
     ...(event.error ? { error: event.error } : {}),
+    ...(event.runId ? { runId: event.runId } : {}),
   });
 }
 
@@ -574,6 +576,9 @@ async function drainQueuedMessages(
             sources: channelTurnSources,
             outcome,
             ...(lifecycleError ? { error: lifecycleError } : {}),
+            ...(runtime.lastTerminalLoopErrorRunId
+              ? { runId: runtime.lastTerminalLoopErrorRunId }
+              : {}),
           });
         }
       }

--- a/src/websocket/listener/runtime.ts
+++ b/src/websocket/listener/runtime.ts
@@ -165,6 +165,7 @@ export function createConversationRuntime(
     recoveredApprovalState: null,
     lastStopReason: null,
     lastTerminalLoopErrorMessage: null,
+    lastTerminalLoopErrorRunId: null,
     isProcessing: false,
     activeWorkingDirectory: null,
     expectedWorktreePath: null,

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -444,6 +444,7 @@ export async function handleIncomingMessage(
   runtime.cancelRequested = false;
   runtime.lastStopReason = null;
   runtime.lastTerminalLoopErrorMessage = null;
+  runtime.lastTerminalLoopErrorRunId = null;
   const turnAbortController = new AbortController();
   runtime.activeAbortController = turnAbortController;
   const turnAbortSignal = turnAbortController.signal;
@@ -1282,11 +1283,13 @@ export async function handleIncomingMessage(
         const errorMessage =
           errorDetail || `Unexpected stop reason: ${stopReason}`;
 
+        const terminalRunId =
+          runId || runtime.activeRunId || runErrorInfo?.run_id;
         const formattedError = emitLoopErrorNotice(socket, runtime, {
           message: errorMessage,
           stopReason: effectiveStopReason,
           isTerminal: true,
-          runId: runId,
+          runId: terminalRunId,
           agentId,
           conversationId,
           runErrorInfo: runErrorInfo ?? undefined,
@@ -1294,6 +1297,7 @@ export async function handleIncomingMessage(
           abortSignal: turnAbortSignal,
         });
         runtime.lastTerminalLoopErrorMessage = formattedError ?? errorMessage;
+        runtime.lastTerminalLoopErrorRunId = terminalRunId ?? null;
         break;
       }
 
@@ -1392,10 +1396,12 @@ export async function handleIncomingMessage(
     });
 
     const errorMessage = error instanceof Error ? error.message : String(error);
+    const terminalRunId = runtime.activeRunId;
     const formattedError = emitLoopErrorNotice(socket, runtime, {
       message: errorMessage,
       stopReason: "error",
       isTerminal: true,
+      runId: terminalRunId,
       agentId: agentId || undefined,
       conversationId,
       error,
@@ -1403,6 +1409,7 @@ export async function handleIncomingMessage(
       abortSignal: turnAbortSignal,
     });
     runtime.lastTerminalLoopErrorMessage = formattedError ?? errorMessage;
+    runtime.lastTerminalLoopErrorRunId = terminalRunId ?? null;
     if (isDebugEnabled()) {
       console.error("[Listen] Error handling message:", error);
     }

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -145,6 +145,7 @@ export type ConversationRuntime = {
   recoveredApprovalState: RecoveredApprovalState | null;
   lastStopReason: string | null;
   lastTerminalLoopErrorMessage: string | null;
+  lastTerminalLoopErrorRunId: string | null;
   isProcessing: boolean;
   activeWorkingDirectory: string | null;
   expectedWorktreePath: string | null;


### PR DESCRIPTION
Linear: https://linear.app/letta/issue/LET-9361/include-run-ids-in-outbound-channel-error-messages

## Problem

Channel lifecycle error replies are the dumps people see in Slack and other outbound channels when a turn fails. The listener often knew the run ID, but the finished lifecycle event only carried error text, and the shared formatter only showed a run ID when it happened to be embedded in the raw error string. Generic Slack fallback errors therefore had no direct handle for Datadog/run-log lookup.

## Change

- Store the latest terminal loop error run ID on the conversation runtime and pass it through finished channel lifecycle events.
- Let the shared lifecycle error formatter accept an explicit run ID and append `Run ID: ...` after normal text or code-block output.
- Pass that run ID through Slack, Discord, Telegram, and WhatsApp lifecycle error replies.
- Include the same explicit run ID in Telegram lifecycle error report metadata.

## Behavior

Before: a generic Slack lifecycle error could be reduced to the safe fallback text with no run ID.

After: when the runtime has a terminal run ID, the outbound channel error includes the safe error text plus `Run ID: <id>`.

Errors that happen before a run exists still omit the run ID. Signal only clears typing on lifecycle events today, so there is no Signal error-reply path to update.

## Validation

- `bun test src/channels/lifecycle-error.test.ts src/channels/slack-adapter.test.ts src/channels/telegram-adapter.test.ts src/websocket/listen-client-concurrency.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run check`
