### PR TITLE
fix(cli): back pins with favorite tags

### DIFF
--- a/src/agent/favorites.test.ts
+++ b/src/agent/favorites.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import { __testSetBackend, type Backend } from "@/backend";
+import { settingsManager } from "@/settings-manager";
+import { setServiceName } from "@/utils/secrets";
+import {
+  __testSetCurrentUserMetadataFetcher,
+  generateFavoriteTag,
+  LOCAL_DESKTOP_FAVORITE_TAG,
+  pinAgentForCurrentUser,
+  unpinAgentForCurrentUser,
+} from "./favorites";
+
+const originalHome = process.env.HOME;
+
+let testHomeDir: string;
+
+function agentWithTags(id: string, tags: string[]): AgentState {
+  return { id, name: id, tags } as AgentState;
+}
+
+function installBackend(agent: AgentState) {
+  let currentAgent = agent;
+  const retrieveAgent = mock(async () => currentAgent);
+  const updateAgent = mock(
+    async (_agentId: string, body: { tags?: string[] }) => {
+      currentAgent = {
+        ...currentAgent,
+        ...(body.tags ? { tags: body.tags } : {}),
+      };
+      return currentAgent;
+    },
+  );
+
+  __testSetBackend({
+    retrieveAgent,
+    updateAgent,
+  } as unknown as Backend);
+
+  return {
+    retrieveAgent,
+    updateAgent,
+    getAgent: () => currentAgent,
+  };
+}
+
+beforeEach(async () => {
+  setServiceName("letta-code-test");
+  await settingsManager.reset();
+  testHomeDir = await mkdtemp(join(tmpdir(), "letta-favorites-test-home-"));
+  process.env.HOME = testHomeDir;
+  await settingsManager.initialize();
+});
+
+afterEach(async () => {
+  __testSetBackend(null);
+  __testSetCurrentUserMetadataFetcher(null);
+  await settingsManager.reset();
+  await rm(testHomeDir, { recursive: true, force: true });
+  process.env.HOME = originalHome;
+  setServiceName("letta-code");
+});
+
+describe("favorite-backed pinning", () => {
+  test("pins local agents by adding the local favorite tag", async () => {
+    const backend = installBackend(
+      agentWithTags("agent-local-1", ["existing"]),
+    );
+
+    const status = await pinAgentForCurrentUser("agent-local-1");
+
+    expect(status).toBe("pinned");
+    expect(backend.getAgent().tags).toEqual([
+      LOCAL_DESKTOP_FAVORITE_TAG,
+      "existing",
+    ]);
+    expect(settingsManager.isAgentPinned("agent-local-1")).toBe(false);
+  });
+
+  test("pins cloud agents with the current user favorite tag", async () => {
+    __testSetCurrentUserMetadataFetcher(async () => ({ id: "user-1" }));
+    const backend = installBackend(agentWithTags("agent-cloud-1", []));
+
+    const status = await pinAgentForCurrentUser("agent-cloud-1");
+
+    expect(status).toBe("pinned");
+    expect(backend.getAgent().tags).toEqual([generateFavoriteTag("user-1")]);
+    expect(settingsManager.isAgentPinned("agent-cloud-1")).toBe(false);
+  });
+
+  test("falls back to settings pins when cloud user lookup is unavailable", async () => {
+    __testSetCurrentUserMetadataFetcher(async () => ({}));
+    const backend = installBackend(agentWithTags("agent-cloud-1", []));
+
+    const status = await pinAgentForCurrentUser("agent-cloud-1");
+
+    expect(status).toBe("pinned");
+    expect(backend.updateAgent).not.toHaveBeenCalled();
+    expect(settingsManager.isAgentPinned("agent-cloud-1")).toBe(true);
+  });
+
+  test("unpins both favorite tags and legacy settings pins", async () => {
+    const agentId = "agent-local-1";
+    settingsManager.pinAgent(agentId);
+    const backend = installBackend(
+      agentWithTags(agentId, [LOCAL_DESKTOP_FAVORITE_TAG, "existing"]),
+    );
+
+    const status = await unpinAgentForCurrentUser(agentId);
+
+    expect(status).toBe("unpinned");
+    expect(backend.getAgent().tags).toEqual(["existing"]);
+    expect(settingsManager.isAgentPinned(agentId)).toBe(false);
+  });
+});

--- a/src/agent/favorites.ts
+++ b/src/agent/favorites.ts
@@ -1,0 +1,172 @@
+import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import { isLocalAgentId } from "@/agent/agent-id";
+import { type Backend, getBackend } from "@/backend";
+import { apiRequest } from "@/backend/api/request";
+import { settingsManager } from "@/settings-manager";
+
+export const LETTA_CHAT_FAVORITE_TAG_BASE = "view:letta-chat";
+export const LETTA_CHAT_FAVORITE_TAG_PREFIX = "favorite:user:";
+export const LOCAL_FAVORITE_OWNER_ID = "local";
+export const LOCAL_DESKTOP_FAVORITE_TAG = generateFavoriteTag(
+  LOCAL_FAVORITE_OWNER_ID,
+);
+
+interface CurrentUserMetadata {
+  id?: unknown;
+}
+
+type CurrentUserMetadataFetcher = () => Promise<CurrentUserMetadata>;
+
+let currentUserMetadataFetcherOverride: CurrentUserMetadataFetcher | null =
+  null;
+
+export function __testSetCurrentUserMetadataFetcher(
+  fetcher: CurrentUserMetadataFetcher | null,
+): void {
+  currentUserMetadataFetcherOverride = fetcher;
+}
+
+export function generateFavoriteTag(ownerId: string): string {
+  return `${LETTA_CHAT_FAVORITE_TAG_PREFIX}${ownerId}`;
+}
+
+async function fetchCurrentUserMetadata(): Promise<CurrentUserMetadata> {
+  if (currentUserMetadataFetcherOverride) {
+    return currentUserMetadataFetcherOverride();
+  }
+  return apiRequest<CurrentUserMetadata>("GET", "/v1/metadata/user");
+}
+
+export async function getCurrentCloudFavoriteTag(): Promise<string | null> {
+  try {
+    const user = await fetchCurrentUserMetadata();
+    return typeof user.id === "string" && user.id
+      ? generateFavoriteTag(user.id)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function getFavoriteTagForAgent(
+  agentId: string,
+): Promise<string | null> {
+  if (isLocalAgentId(agentId)) {
+    return LOCAL_DESKTOP_FAVORITE_TAG;
+  }
+  return getCurrentCloudFavoriteTag();
+}
+
+export function getAgentTags(agent: Pick<AgentState, "tags">): string[] {
+  return Array.isArray(agent.tags) ? agent.tags : [];
+}
+
+export function addFavoriteTag(tags: string[], favoriteTag: string): string[] {
+  if (tags.includes(favoriteTag)) return tags;
+  return [favoriteTag, ...tags];
+}
+
+export function removeFavoriteTag(
+  tags: string[],
+  favoriteTag: string,
+): string[] {
+  return tags.filter(
+    (tag) => tag !== favoriteTag && tag !== LETTA_CHAT_FAVORITE_TAG_BASE,
+  );
+}
+
+function arraysEqual(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+export type FavoriteMutationStatus = "changed" | "unchanged" | "unavailable";
+
+export async function setAgentFavoriteTag(
+  backend: Backend,
+  agentId: string,
+): Promise<FavoriteMutationStatus> {
+  const favoriteTag = await getFavoriteTagForAgent(agentId);
+  if (!favoriteTag) return "unavailable";
+
+  const agent = await backend.retrieveAgent(agentId, {
+    include: ["agent.tags"],
+  });
+  const tags = getAgentTags(agent);
+  const nextTags = addFavoriteTag(tags, favoriteTag);
+  if (arraysEqual(tags, nextTags)) return "unchanged";
+
+  await backend.updateAgent(agentId, { tags: nextTags });
+  return "changed";
+}
+
+export async function unsetAgentFavoriteTag(
+  backend: Backend,
+  agentId: string,
+): Promise<FavoriteMutationStatus> {
+  const favoriteTag = await getFavoriteTagForAgent(agentId);
+  if (!favoriteTag) return "unavailable";
+
+  const agent = await backend.retrieveAgent(agentId, {
+    include: ["agent.tags"],
+  });
+  const tags = getAgentTags(agent);
+  const nextTags = removeFavoriteTag(tags, favoriteTag);
+  if (arraysEqual(tags, nextTags)) return "unchanged";
+
+  await backend.updateAgent(agentId, { tags: nextTags });
+  return "changed";
+}
+
+export type PinAgentStatus = "pinned" | "already-pinned";
+export type UnpinAgentStatus = "unpinned" | "not-pinned";
+
+export async function pinAgentForCurrentUser(
+  agentId: string,
+  backend: Backend = getBackend(),
+): Promise<PinAgentStatus> {
+  const wasPinnedInSettings = settingsManager.isAgentPinned(agentId);
+
+  try {
+    const result = await setAgentFavoriteTag(backend, agentId);
+    if (result !== "unavailable") {
+      if (wasPinnedInSettings) {
+        settingsManager.unpinAgent(agentId);
+      }
+      return result === "unchanged" || wasPinnedInSettings
+        ? "already-pinned"
+        : "pinned";
+    }
+  } catch {
+    // Fall back to legacy settings pins below.
+  }
+
+  if (wasPinnedInSettings) return "already-pinned";
+  settingsManager.pinAgent(agentId);
+  return "pinned";
+}
+
+export async function unpinAgentForCurrentUser(
+  agentId: string,
+  backend: Backend = getBackend(),
+): Promise<UnpinAgentStatus> {
+  const wasPinnedInSettings = settingsManager.isAgentPinned(agentId);
+
+  try {
+    const result = await unsetAgentFavoriteTag(backend, agentId);
+    if (result !== "unavailable") {
+      if (wasPinnedInSettings) {
+        settingsManager.unpinAgent(agentId);
+      }
+      return result === "changed" || wasPinnedInSettings
+        ? "unpinned"
+        : "not-pinned";
+    }
+  } catch (error) {
+    if (!wasPinnedInSettings) throw error;
+    // Fall back to legacy settings pins below.
+  }
+
+  if (!wasPinnedInSettings) return "not-pinned";
+  settingsManager.unpinAgent(agentId);
+  return "unpinned";
+}

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -5,6 +5,7 @@ import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents"
 import { Box } from "ink";
 import type { Dispatch, RefObject, SetStateAction } from "react";
 import { getResumeDataFromBackend } from "@/agent/check-approval";
+import { pinAgentForCurrentUser } from "@/agent/favorites";
 import { isActiveMemfsEnabled } from "@/agent/memory-runtime";
 import type { ModelReasoningEffort } from "@/agent/model";
 import type { PersonalityId } from "@/agent/personality";
@@ -1690,11 +1691,14 @@ export function AppView(props: AppViewProps) {
                       updateAgentName(newName);
                     }
 
-                    // Pin the agent
-                    settingsManager.pinAgent(agentId);
+                    const pinStatus = await pinAgentForCurrentUser(agentId);
 
                     if (newName && newName !== agentName) {
                       cmd.agentHint = `Your name is now "${newName}" — acknowledge this and save your new name to memory.`;
+                    }
+                    if (pinStatus === "already-pinned") {
+                      cmd.finish("This agent is already pinned.", false);
+                      return;
                     }
                     cmd.finish(
                       `Pinned "${newName || agentName || agentId.slice(0, 12)}".`,

--- a/src/cli/app/submit-profile-commands.ts
+++ b/src/cli/app/submit-profile-commands.ts
@@ -191,7 +191,7 @@ export async function handleProfileCommand(
     const cmd = commandRunner.start(trimmed, "Unpinning agent...");
     setActiveProfileCommandId(cmd.id);
     try {
-      handleUnpin(profileCtx, msg, argsStr);
+      await handleUnpin(profileCtx, msg, argsStr);
     } finally {
       setActiveProfileCommandId(null);
     }

--- a/src/cli/commands/profile.ts
+++ b/src/cli/commands/profile.ts
@@ -1,6 +1,10 @@
 // src/cli/commands/profile.ts
 // Profile command handlers for managing local agent profiles
 
+import {
+  pinAgentForCurrentUser,
+  unpinAgentForCurrentUser,
+} from "@/agent/favorites";
 import { getBackend } from "@/backend";
 import type { Buffers, Line } from "@/cli/helpers/accumulator";
 import { formatErrorDetails } from "@/cli/helpers/error-formatter";
@@ -178,7 +182,7 @@ export async function handleProfileSave(
     await getBackend().updateAgent(ctx.agentId, { name: profileName });
     ctx.updateAgentName(profileName);
 
-    settingsManager.pinAgent(ctx.agentId);
+    await pinAgentForCurrentUser(ctx.agentId);
 
     updateCommandResult(
       ctx.buffersRef,
@@ -317,7 +321,6 @@ export async function handlePin(
   argsStr: string,
 ): Promise<void> {
   const name = argsStr.trim() || undefined;
-  const pinned = settingsManager.getPinnedAgents();
 
   // If user provided a name, rename the agent first
   if (name && name !== ctx.agentName) {
@@ -338,7 +341,9 @@ export async function handlePin(
 
   const displayName = name || ctx.agentName || ctx.agentId.slice(0, 12);
 
-  if (pinned.includes(ctx.agentId)) {
+  const pinStatus = await pinAgentForCurrentUser(ctx.agentId);
+
+  if (pinStatus === "already-pinned") {
     addCommandResult(
       ctx.buffersRef,
       ctx.refreshDerived,
@@ -348,7 +353,7 @@ export async function handlePin(
     );
     return;
   }
-  settingsManager.pinAgent(ctx.agentId);
+
   addCommandResult(
     ctx.buffersRef,
     ctx.refreshDerived,
@@ -359,11 +364,11 @@ export async function handlePin(
 }
 
 // /unpin - Unpin the current agent
-export function handleUnpin(
+export async function handleUnpin(
   ctx: ProfileCommandContext,
   msg: string,
   argsStr: string,
-): void {
+): Promise<void> {
   if (argsStr.trim()) {
     addCommandResult(
       ctx.buffersRef,
@@ -375,10 +380,22 @@ export function handleUnpin(
     return;
   }
 
-  const pinned = settingsManager.getPinnedAgents();
   const displayName = ctx.agentName || ctx.agentId.slice(0, 12);
+  let unpinStatus: Awaited<ReturnType<typeof unpinAgentForCurrentUser>>;
+  try {
+    unpinStatus = await unpinAgentForCurrentUser(ctx.agentId);
+  } catch (error) {
+    addCommandResult(
+      ctx.buffersRef,
+      ctx.refreshDerived,
+      msg,
+      `Failed to unpin agent: ${error}`,
+      false,
+    );
+    return;
+  }
 
-  if (!pinned.includes(ctx.agentId)) {
+  if (unpinStatus === "not-pinned") {
     addCommandResult(
       ctx.buffersRef,
       ctx.refreshDerived,
@@ -389,7 +406,6 @@ export function handleUnpin(
     return;
   }
 
-  settingsManager.unpinAgent(ctx.agentId);
   addCommandResult(
     ctx.buffersRef,
     ctx.refreshDerived,

--- a/src/cli/components/AgentSelector.tsx
+++ b/src/cli/components/AgentSelector.tsx
@@ -2,6 +2,11 @@ import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents"
 import { Box, useInput } from "ink";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { isLocalAgentId } from "@/agent/agent-id";
+import {
+  getCurrentCloudFavoriteTag,
+  LOCAL_DESKTOP_FAVORITE_TAG,
+  unpinAgentForCurrentUser,
+} from "@/agent/favorites";
 import { getModelDisplayName } from "@/agent/model";
 import { getBackendForMode } from "@/backend/backend";
 import { listLocalAgentsFromDisk } from "@/cli/helpers/local-agent-listing";
@@ -54,7 +59,6 @@ interface PinnedAgentData {
   agent: AgentState | null;
   error: string | null;
   backendMode: AgentBackendMode;
-  source: "settings" | "localFavorite";
 }
 
 const ALL_TABS: { id: TabId; label: string }[] = [
@@ -81,7 +85,6 @@ const TAB_EMPTY_STATES: Record<TabId, string> = {
 const DISPLAY_PAGE_SIZE = 5;
 const FETCH_PAGE_SIZE = 20;
 const NEW_AGENT_DEFAULT_BACKEND: AgentBackendMode = "api";
-const LOCAL_DESKTOP_FAVORITE_TAG = "favorite:user:local";
 
 export function getPinnedAgentBackendMode(agentId: string): AgentBackendMode {
   return isLocalAgentId(agentId) ? "local" : "api";
@@ -265,6 +268,27 @@ export function AgentSelector({
       const localFavoriteAgents = listLocalAgentsFromDisk().filter((agent) =>
         agent.tags.includes(LOCAL_DESKTOP_FAVORITE_TAG),
       );
+      let cloudFavoriteAgents: AgentState[] = [];
+
+      if (hasCloudCredentials()) {
+        try {
+          const favoriteTag = await getCurrentCloudFavoriteTag();
+          if (favoriteTag) {
+            const { getClient } = await import("@/backend/api/client");
+            const client = await getClient();
+            const agentList = await client.agents.list({
+              limit: FETCH_PAGE_SIZE,
+              include: ["agent.blocks"],
+              order: "desc",
+              order_by: "last_run_completion",
+              tags: [favoriteTag],
+            });
+            cloudFavoriteAgents = agentList.items;
+          }
+        } catch {
+          // Keep legacy settings pins available if cloud favorite lookup fails.
+        }
+      }
 
       let pinnedData: PinnedAgentData[] = [];
 
@@ -280,7 +304,6 @@ export function AgentSelector({
                   agent: null,
                   error: "Not signed in",
                   backendMode,
-                  source: "settings",
                 };
               }
               const agentBackend = getBackendForMode(backendMode);
@@ -292,7 +315,6 @@ export function AgentSelector({
                 agent,
                 error: null,
                 backendMode,
-                source: "settings",
               };
             } catch {
               return {
@@ -300,21 +322,33 @@ export function AgentSelector({
                 agent: null,
                 error: "Agent not found",
                 backendMode,
-                source: "settings",
               };
             }
           }),
         );
       }
 
-      const favoriteData: PinnedAgentData[] = localFavoriteAgents
-        .filter((agent) => !pinnedIdSet.has(agent.id))
-        .map((agent) => ({
-          agentId: agent.id,
+      const favoriteAgents: Array<{
+        agent: AgentState;
+        backendMode: AgentBackendMode;
+      }> = [
+        ...localFavoriteAgents.map((agent) => ({
           agent,
+          backendMode: "local" as const,
+        })),
+        ...cloudFavoriteAgents.map((agent) => ({
+          agent,
+          backendMode: "api" as const,
+        })),
+      ];
+
+      const favoriteData: PinnedAgentData[] = favoriteAgents
+        .filter(({ agent }) => !pinnedIdSet.has(agent.id))
+        .map((agent) => ({
+          agentId: agent.agent.id,
+          agent: agent.agent,
           error: null,
-          backendMode: "local",
-          source: "localFavorite",
+          backendMode: agent.backendMode,
         }));
       pinnedData = [...pinnedData, ...favoriteData];
 
@@ -759,9 +793,11 @@ export function AgentSelector({
     ) {
       // Unpin from current scope (pinned tab only)
       const selected = pinnedPageAgents[pinnedSelectedIndex];
-      if (selected?.source === "settings") {
-        settingsManager.unpinAgent(selected.agentId);
-        loadPinnedAgents();
+      if (selected) {
+        const backend = getBackendForMode(selected.backendMode);
+        void unpinAgentForCurrentUser(selected.agentId, backend).finally(() => {
+          loadPinnedAgents();
+        });
       }
     } else if (allowDelete && input === "D") {
       // Delete agent - open confirmation
@@ -1011,7 +1047,7 @@ export function AgentSelector({
               const pinnedHint =
                 allowPinActions &&
                 activeTab === "pinned" &&
-                selectedPinnedAgent?.source === "settings"
+                selectedPinnedAgent !== undefined
                   ? " · Shift+P unpin"
                   : "";
               const hintsText = `Enter select · ↑↓ ←→ navigate · Tab switch${deleteHint}${pinnedHint} · Esc cancel`;


### PR DESCRIPTION
## Summary
- add shared favorite tag helpers for `favorite:user:local` and `favorite:user:${userId}`
- make `/pin`, `/unpin`, and the pin dialog write through agent favorite tags with legacy settings pins as fallback
- include cloud favorite tags in the AgentSelector pinned-tab read union
- let Shift+P unpin both legacy settings pins and favorite-tag pins from the selector

## Validation
- `bun test src/agent/favorites.test.ts`
- `bun run typecheck`
- `bun run check`
