### PR TITLE
fix(memfs): harden manual memory commit guidance

### DIFF
--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -9,6 +9,7 @@ import type { SkillSource } from "./skills";
 
 interface AgentContext {
   agentId: string | null;
+  agentName: string | null;
   skillsDirectory: string | null;
   skillSources: SkillSource[];
   conversationId: string | null;
@@ -27,6 +28,7 @@ function getContext(): AgentContext {
   if (!global[CONTEXT_KEY]) {
     global[CONTEXT_KEY] = {
       agentId: null,
+      agentName: null,
       skillsDirectory: null,
       skillSources: [...ALL_SKILL_SOURCES],
       conversationId: null,
@@ -42,19 +44,23 @@ const context = getContext();
  * @param agentId - The agent ID
  * @param skillsDirectory - Optional skills directory path
  * @param skillSources - Enabled skill sources for this session
+ * @param agentName - Optional display name for shell/process identity
  */
 export function setAgentContext(
   agentId: string,
   skillsDirectory?: string,
   skillSources?: SkillSource[],
+  agentName?: string | null,
 ): void {
   context.agentId = agentId;
+  context.agentName = normalizeAgentName(agentName);
   context.skillsDirectory = skillsDirectory || null;
   context.skillSources =
     skillSources !== undefined ? [...skillSources] : [...ALL_SKILL_SOURCES];
   if (getRuntimeContext()) {
     updateRuntimeContext({
       agentId,
+      agentName: context.agentName,
       skillsDirectory: skillsDirectory || null,
       skillSources:
         skillSources !== undefined ? [...skillSources] : [...ALL_SKILL_SOURCES],
@@ -66,10 +72,34 @@ export function setAgentContext(
  * Set the current agent ID in context (simplified version for compatibility)
  */
 export function setCurrentAgentId(agentId: string | null): void {
+  const agentChanged = context.agentId !== agentId;
   context.agentId = agentId;
-  if (getRuntimeContext()) {
-    updateRuntimeContext({ agentId });
+  if (agentId === null || agentChanged) {
+    context.agentName = null;
   }
+  if (getRuntimeContext()) {
+    updateRuntimeContext({
+      agentId,
+      ...(agentId === null || agentChanged ? { agentName: null } : {}),
+    });
+  }
+}
+
+/**
+ * Set the current agent name in context when it is available.
+ */
+export function setCurrentAgentName(agentName: string | null): void {
+  context.agentName = normalizeAgentName(agentName);
+  if (getRuntimeContext()) {
+    updateRuntimeContext({ agentName: context.agentName });
+  }
+}
+
+function normalizeAgentName(
+  agentName: string | null | undefined,
+): string | null {
+  const trimmed = typeof agentName === "string" ? agentName.trim() : "";
+  return trimmed || null;
 }
 
 /**
@@ -88,6 +118,18 @@ export function getCurrentAgentId(): string {
     throw new Error("No agent context set. Agent ID is required.");
   }
   return context.agentId;
+}
+
+/**
+ * Get the current agent name if runtime context has it.
+ */
+export function getCurrentAgentName(): string | null {
+  const runtimeContext = getRuntimeContext();
+  if (runtimeContext && "agentName" in runtimeContext) {
+    const trimmed = runtimeContext.agentName?.trim();
+    return trimmed || null;
+  }
+  return context.agentName;
 }
 
 /**

--- a/src/agent/prompt-assets.test.ts
+++ b/src/agent/prompt-assets.test.ts
@@ -60,6 +60,15 @@ describe("buildSystemPrompt", () => {
     expect(result).not.toContain("git push");
   });
 
+  test("memfs prompt documents direct edit commit safeguards", () => {
+    const result = buildSystemPrompt("letta", "memfs");
+
+    expect(result).toContain("description:");
+    expect(result).toContain("MemFS pre-commit hook");
+    expect(result).toContain('author_name="${AGENT_NAME:-$AGENT_ID}"');
+    expect(result).not.toContain('--author="$AGENT_NAME');
+  });
+
   test("throws on unknown preset", () => {
     expect(() => buildSystemPrompt("unknown-id", "standard")).toThrow(
       'Unknown preset "unknown-id"',

--- a/src/agent/prompts/letta.md
+++ b/src/agent/prompts/letta.md
@@ -50,6 +50,10 @@ There are two ways to change memory:
 - **The `memory` tool (shorthand).** Use it for small, targeted edits. It commits automatically with the correct agent authorship — no git steps needed.
 - **Direct file edits (full control).** For larger changes — restructuring directories, rewriting several blocks — edit the projected files directly, then commit:
 
+Memory markdown files must start with YAML frontmatter containing a non-empty `description:` field. The `memory` and `memory_apply_patch` tools add and preserve this automatically; when using raw file edits, preserve existing frontmatter or add it before committing. The MemFS pre-commit hook enforces this requirement, rejects unknown keys, and prevents changes to protected `read_only` files. Skill `SKILL.md` files use their own skill frontmatter format.
+
+`$AGENT_NAME` is not guaranteed to be set in the shell environment. Use a non-empty author name fallback when committing directly.
+
 ```bash
 cd "$MEMORY_DIR"
 
@@ -57,8 +61,9 @@ cd "$MEMORY_DIR"
 git status
 
 # Commit your changes
-git add .
-git commit --author="$AGENT_NAME <$AGENT_ID@letta.com>" -m "<type>: <what changed>"
+git add <specific files>
+author_name="${AGENT_NAME:-$AGENT_ID}"
+git commit --author="$author_name <$AGENT_ID@letta.com>" -m "<type>: <what changed>"
 ```
 
 Your context is git-tracked, so you can always inspect or revert past changes:

--- a/src/agent/prompts/letta.md
+++ b/src/agent/prompts/letta.md
@@ -52,7 +52,7 @@ There are two ways to change memory:
 
 Memory markdown files must start with YAML frontmatter containing a non-empty `description:` field. The `memory` and `memory_apply_patch` tools add and preserve this automatically; when using raw file edits, preserve existing frontmatter or add it before committing. The MemFS pre-commit hook enforces this requirement, rejects unknown keys, and prevents changes to protected `read_only` files. Skill `SKILL.md` files use their own skill frontmatter format.
 
-`$AGENT_NAME` is not guaranteed to be set in the shell environment. Use a non-empty author name fallback when committing directly.
+`$AGENT_NAME` is normally populated when the runtime knows the current agent name, but direct shell environments can still miss it. Use a non-empty author name fallback when committing directly.
 
 ```bash
 cd "$MEMORY_DIR"

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1653,7 +1653,12 @@ export async function handleHeadlessCommand(
   }
 
   // Set agent context for tools that need it (e.g., Skill tool, Task tool)
-  setAgentContext(agent.id, skillsDirectory, resolvedSkillSources);
+  setAgentContext(
+    agent.id,
+    skillsDirectory,
+    resolvedSkillSources,
+    agent.name ?? null,
+  );
 
   // Validate output format
   const outputFormat = values["output-format"] || "text";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2358,7 +2358,12 @@ async function main(): Promise<void> {
         }
 
         // Set agent context for tools that need it (e.g., Skill tool)
-        setAgentContext(agent.id, skillsDirectory, resolvedSkillSources);
+        setAgentContext(
+          agent.id,
+          skillsDirectory,
+          resolvedSkillSources,
+          agent.name ?? null,
+        );
 
         let startupMemfsFlag: boolean | undefined = autoEnableMemfsForFreshAgent
           ? true

--- a/src/runtime-context.ts
+++ b/src/runtime-context.ts
@@ -7,6 +7,7 @@ export type RuntimePermissionMode = "standard" | "acceptEdits" | "unrestricted";
 
 export interface RuntimeContextSnapshot {
   agentId?: string | null;
+  agentName?: string | null;
   conversationId?: string | null;
   skillsDirectory?: string | null;
   skillSources?: SkillSource[];

--- a/src/skills/builtin/context-doctor/SKILL.md
+++ b/src/skills/builtin/context-doctor/SKILL.md
@@ -116,7 +116,8 @@ Review changes, then commit with a descriptive message:
 cd $MEMORY_DIR
 git status                # Review what changed before staging
 git add <specific files>  # Stage targeted paths — avoid blind `git add -A`
-git commit --author="<AGENT_NAME> <<ACTUAL_AGENT_ID>@letta.com>" -m "fix(doctor): <summary> 🏥
+author_name="${AGENT_NAME:-$AGENT_ID}"
+git commit --author="$author_name <$AGENT_ID@letta.com>" -m "fix(doctor): <summary> 🏥
 
 <identified issues and implemented solutions>"
 

--- a/src/skills/builtin/initializing-memory/SKILL.md
+++ b/src/skills/builtin/initializing-memory/SKILL.md
@@ -706,7 +706,8 @@ Check if they're satisfied or want further refinement. Then commit and push memo
 cd $MEMORY_DIR
 git status                # Review what changed before staging
 git add <specific files>  # Stage targeted paths — avoid blind `git add -A`
-git commit --author="<AGENT_NAME> <<ACTUAL_AGENT_ID>@letta.com>" -m "feat(init): <summary> ✨
+author_name="${AGENT_NAME:-$AGENT_ID}"
+git commit --author="$author_name <$AGENT_ID@letta.com>" -m "feat(init): <summary> ✨
 
 <what was initialized and key decisions made>"
 

--- a/src/tools/impl/shell-command.ts
+++ b/src/tools/impl/shell-command.ts
@@ -1,4 +1,4 @@
-import { getCurrentAgentId } from "@/agent/context";
+import { getCurrentAgentId, getCurrentAgentName } from "@/agent/context";
 import { isMemoryDirCommand } from "@/permissions/read-only-shell";
 import { resolveShellWorkdir, type ShellResult, shell } from "./shell.js";
 import { buildShellLaunchers } from "./shell-launchers.js";
@@ -131,7 +131,7 @@ function getMemoryGitIdentityEnvOverrides(
     return undefined;
   }
 
-  const agentName = (process.env.AGENT_NAME || "").trim() || agentId;
+  const agentName = getCurrentAgentNameOrEnv() || agentId;
   const agentEmail = `${agentId}@letta.com`;
 
   return {
@@ -153,6 +153,16 @@ function getCurrentAgentIdOrEnv(): string {
   }
 
   return (process.env.LETTA_AGENT_ID || process.env.AGENT_ID || "").trim();
+}
+
+function getCurrentAgentNameOrEnv(): string | null {
+  const scopedName = getCurrentAgentName()?.trim();
+  if (scopedName) {
+    return scopedName;
+  }
+
+  const envName = process.env.AGENT_NAME?.trim();
+  return envName || null;
 }
 
 function containsGitCommitInvocation(command: string): boolean {

--- a/src/tools/impl/shell-env.ts
+++ b/src/tools/impl/shell-env.ts
@@ -9,7 +9,11 @@ import { createRequire } from "node:module";
 import { homedir, tmpdir } from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { getConversationId, getCurrentAgentId } from "@/agent/context";
+import {
+  getConversationId,
+  getCurrentAgentId,
+  getCurrentAgentName,
+} from "@/agent/context";
 import {
   getScopedMemoryFilesystemRoot,
   resolveScopedMemoryDir,
@@ -350,6 +354,11 @@ export function getShellEnv(): NodeJS.ProcessEnv {
   if (agentId) {
     env.LETTA_AGENT_ID = agentId;
     env.AGENT_ID = agentId;
+
+    const agentName = getCurrentAgentName()?.trim() || env.AGENT_NAME?.trim();
+    if (agentName) {
+      env.AGENT_NAME = agentName;
+    }
 
     try {
       const localBackendNoMemfs = isLocalBackendNoMemfsEnvEnabled();

--- a/src/tools/shell-command.test.ts
+++ b/src/tools/shell-command.test.ts
@@ -9,6 +9,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { runWithRuntimeContext } from "@/runtime-context";
 import { shell_command } from "@/tools/impl/shell-command.js";
 import { LIMITS } from "@/tools/impl/truncation.js";
 import { createTempRuntimeScriptCommand } from "./runtime-script.js";
@@ -143,54 +144,75 @@ test("shell_command truncates oversized output with overflow-file notice", async
 });
 
 test("shell_command uses agent identity for memory-dir git commits", async () => {
-  const agentId = `agent-test-${randomUUID()}`;
-  const memoryRoot = join(homedir(), ".letta", "agents", agentId);
-  const memoryDir = join(memoryRoot, "memory");
   const originalAgentId = process.env.AGENT_ID;
   const originalLettaAgentId = process.env.LETTA_AGENT_ID;
   const originalAgentName = process.env.AGENT_NAME;
+  const originalFsSandbox = process.env.LETTA_FS_SANDBOX;
+  const agentId = originalAgentId || `agent-test-${randomUUID()}`;
+  const memoryDir = originalAgentId
+    ? join(
+        homedir(),
+        ".letta",
+        "agents",
+        agentId,
+        "memory-worktrees",
+        `shell-command-test-${randomUUID()}`,
+      )
+    : join(homedir(), ".letta", "agents", agentId, "memory");
+  const cleanupDir = originalAgentId
+    ? memoryDir
+    : join(homedir(), ".letta", "agents", agentId);
   mkdirSync(memoryDir, { recursive: true });
   process.env.AGENT_ID = agentId;
   process.env.LETTA_AGENT_ID = agentId;
-  process.env.AGENT_NAME = "Shell Command Test Agent";
+  delete process.env.AGENT_NAME;
+  process.env.LETTA_FS_SANDBOX = "0";
   try {
-    await shell_command({ command: "git init", workdir: memoryDir });
-    await shell_command({
-      command: "git config user.name setup",
-      workdir: memoryDir,
-    });
-    await shell_command({
-      command: "git config user.email setup@example.com",
-      workdir: memoryDir,
-    });
+    await runWithRuntimeContext(
+      { agentId, agentName: "Shell Command Test Agent" },
+      async () => {
+        await shell_command({ command: "git init", workdir: memoryDir });
+        await shell_command({
+          command: "git config user.name setup",
+          workdir: memoryDir,
+        });
+        await shell_command({
+          command: "git config user.email setup@example.com",
+          workdir: memoryDir,
+        });
 
-    const repoStatus = await shell_command({
-      command: "git rev-parse --is-inside-work-tree",
-      workdir: memoryDir,
-    });
-    expect(repoStatus.output.trim()).toContain("true");
+        const repoStatus = await shell_command({
+          command: "git rev-parse --is-inside-work-tree",
+          workdir: memoryDir,
+        });
+        expect(repoStatus.output.trim()).toContain("true");
 
-    writeFileSync(join(memoryDir, ".gitkeep"), "", "utf8");
-    await shell_command({ command: "git add .gitkeep", workdir: memoryDir });
-    await shell_command({
-      command: 'git commit -m "initial setup commit"',
-      workdir: memoryDir,
-    });
+        writeFileSync(join(memoryDir, ".gitkeep"), "", "utf8");
+        await shell_command({
+          command: "git add .gitkeep",
+          workdir: memoryDir,
+        });
+        await shell_command({
+          command: 'git commit -m "initial setup commit"',
+          workdir: memoryDir,
+        });
 
-    writeFileSync(join(memoryDir, "test.md"), "hello\n", "utf8");
-    await shell_command({ command: "git add test.md", workdir: memoryDir });
-    await shell_command({
-      command: 'git commit -m "test memory commit"',
-      workdir: memoryDir,
-    });
+        writeFileSync(join(memoryDir, "test.md"), "hello\n", "utf8");
+        await shell_command({ command: "git add test.md", workdir: memoryDir });
+        await shell_command({
+          command: 'git commit -m "test memory commit"',
+          workdir: memoryDir,
+        });
 
-    const logResult = await shell_command({
-      command: 'git log -1 --format="%s|%ae|%ce"',
-      workdir: memoryDir,
-    });
+        const logResult = await shell_command({
+          command: 'git log -1 --format="%s|%an|%ae|%cn|%ce"',
+          workdir: memoryDir,
+        });
 
-    expect(logResult.output.trim()).toBe(
-      `test memory commit|${agentId}@letta.com|${agentId}@letta.com`,
+        expect(logResult.output.trim()).toBe(
+          `test memory commit|Shell Command Test Agent|${agentId}@letta.com|Shell Command Test Agent|${agentId}@letta.com`,
+        );
+      },
     );
   } finally {
     if (originalAgentId === undefined) delete process.env.AGENT_ID;
@@ -202,6 +224,9 @@ test("shell_command uses agent identity for memory-dir git commits", async () =>
     if (originalAgentName === undefined) delete process.env.AGENT_NAME;
     else process.env.AGENT_NAME = originalAgentName;
 
-    rmSync(memoryRoot, { recursive: true, force: true });
+    if (originalFsSandbox === undefined) delete process.env.LETTA_FS_SANDBOX;
+    else process.env.LETTA_FS_SANDBOX = originalFsSandbox;
+
+    rmSync(cleanupDir, { recursive: true, force: true });
   }
 });

--- a/src/tools/shell-env.test.ts
+++ b/src/tools/shell-env.test.ts
@@ -275,6 +275,7 @@ test("getShellEnv prefers runtime-scoped agent, conversation, and cwd", () => {
   const env = runWithRuntimeContext(
     {
       agentId: "agent-runtime-scope",
+      agentName: "Runtime Scope Agent",
       conversationId: "conv-runtime-scope",
       workingDirectory: "/tmp/runtime-scope-cwd",
     },
@@ -283,6 +284,7 @@ test("getShellEnv prefers runtime-scoped agent, conversation, and cwd", () => {
 
   expect(env.AGENT_ID).toBe("agent-runtime-scope");
   expect(env.LETTA_AGENT_ID).toBe("agent-runtime-scope");
+  expect(env.AGENT_NAME).toBe("Runtime Scope Agent");
   expect(env.CONVERSATION_ID).toBe("conv-runtime-scope");
   expect(env.LETTA_CONVERSATION_ID).toBe("conv-runtime-scope");
   expect(env.USER_CWD).toBe("/tmp/runtime-scope-cwd");

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -538,6 +538,7 @@ export async function prepareToolExecutionContextForScope(params: {
     agent: agent as AgentState,
     runtimeContext: {
       agentId,
+      agentName: (agent as AgentState).name ?? null,
       conversationId: scopedConversationId,
       workingDirectory,
       ...(channelToolScope.channels.length > 0 ? { channelToolScope } : {}),

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -15,6 +15,7 @@ import {
   getCurrentAgentId,
   setConversationId,
   setCurrentAgentId,
+  setCurrentAgentName,
 } from "@/agent/context";
 import { regenerateConversationDescription } from "@/agent/conversation-description";
 import {
@@ -490,6 +491,7 @@ export async function handleIncomingMessage(
 
     // Set agent context for tools that need it (e.g., Skill tool)
     setCurrentAgentId(agentId);
+    setCurrentAgentName(listenAgentMetadata?.name ?? null);
     setConversationId(conversationId);
 
     if (isDebugEnabled()) {
@@ -601,6 +603,9 @@ export async function handleIncomingMessage(
                 .last_run_completion ?? null,
           };
         }
+        setCurrentAgentName(
+          listenAgentMetadata?.name ?? cachedAgent?.name ?? null,
+        );
         const { parts: reminderParts } = await buildSharedReminderParts(
           buildListenReminderContext({
             agentId: agentId || "",


### PR DESCRIPTION
## Problem

The MemFS prompt told agents to commit direct memory edits with `$AGENT_NAME`, but the shell runtime was not passing that variable through. When it was empty, git rejected the author identity.

The same prompt also did not mention the frontmatter hook that validates memory markdown files, so raw file edits could fail only at commit time.

## Approach

- Pass the current agent display name through runtime context into shell environments as `AGENT_NAME` when the runtime knows it.
- Use that scoped name for MemFS git author/committer overrides instead of only reading process env.
- Keep the prompt fallback to `AGENT_ID`, because some direct shell contexts can still lack a display name.
- Document the required `description:` frontmatter for raw MemFS markdown edits.
- Apply the fallback guidance in the built-in memory initialization and context-doctor skills.

## Validation

- `bun test src/tools/shell-env.test.ts src/agent/prompt-assets.test.ts`
- `bun run check`
