### PR TITLE
feat(ci): add Codex agent watcher

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,8 @@
 
 # Codex release watcher and source prompt provenance
 /.github/workflows/codex-release-watch.yml @kl2806
+/.github/workflows/codex-agent-watch.yml @kl2806
+/.github/agent-prompts/codex-agent-watch.md @kl2806
 /scripts/codex-watch/ @kl2806
 /src/agent/prompts/source_codex.md @kl2806
 

--- a/.github/agent-prompts/codex-agent-watch.md
+++ b/.github/agent-prompts/codex-agent-watch.md
@@ -1,0 +1,90 @@
+You are Amelia running in GitHub Actions for `letta-ai/letta-code`.
+
+Your job is to review one stable `openai/codex` release against the local Letta Code harness and either open a focused PR or record that no local change is needed.
+
+## Context
+
+The legacy `.github/workflows/codex-release-watch.yml` issue workflow is still enabled as the baseline. This new workflow must keep its own state in the central tracker issue and must not rely on per-release `codex-watch` issues for dedupe.
+
+The detector already compared the latest stable Codex release to the previous stable release and wrote a JSON payload. Use the payload below as your starting point.
+
+## Required behavior
+
+1. Inspect the analysis payload and upstream compare URL.
+2. Review the watched upstream changes against local Letta Code mirrors.
+3. If a local mirror should change, make the minimal local fix, run targeted validation, push a branch, and open a PR.
+4. If no local mirror should change, do not open a PR. Record `no_local_impact` in the tracker.
+5. If you are blocked or not confident, do not guess. Record `needs_human_review` in the tracker with a concise reason.
+6. Do not update PRs after creation, wait for CI, merge PRs, or disable the old workflow. That is out of scope for this experiment.
+
+## Local mirrors to check
+
+Use judgment, but start with these mirrors from the current watcher:
+
+- Codex prompt/tool mentions: `src/agent/prompts/source_codex.md`
+- tool registry/schema/description/impl: `src/tools/tool-definitions.ts`, `src/tools/schemas/`, `src/tools/descriptions/`, `src/tools/impl/`, `src/tools/manager.ts`
+- apply patch semantics: `src/tools/schemas/ApplyPatch.json`, `src/tools/descriptions/ApplyPatch.md`, relevant apply patch implementations/tests
+- model/tool availability and filtering: `src/tools/toolset.ts`, `src/tools/filter.ts`, adjacent tests
+
+Many upstream Codex tool changes are upstream-only: MCP/plugin internals, Responses-hosted tools, multi-agent internals, service-tier routing, and Codex-specific runtime planner details often do not map to Letta Code. Close those out as `no_local_impact` with a specific note.
+
+## Tracker updates
+
+The detector provides:
+
+- tracker issue number
+- tracker issue URL
+- analysis JSON file path
+
+Always update the tracker before your final response.
+
+For no local impact:
+
+```bash
+bun scripts/codex-watch/update-tracker.ts \
+  --tracker-issue "$TRACKER_ISSUE" \
+  --analysis-file "$ANALYSIS_FILE" \
+  --outcome no_local_impact \
+  --notes "<short reason>"
+```
+
+For a PR:
+
+```bash
+bun scripts/codex-watch/update-tracker.ts \
+  --tracker-issue "$TRACKER_ISSUE" \
+  --analysis-file "$ANALYSIS_FILE" \
+  --outcome pr_created \
+  --pr-url "$PR_URL" \
+  --notes "<short summary of local mirror update>"
+```
+
+For blocked/uncertain:
+
+```bash
+bun scripts/codex-watch/update-tracker.ts \
+  --tracker-issue "$TRACKER_ISSUE" \
+  --analysis-file "$ANALYSIS_FILE" \
+  --outcome needs_human_review \
+  --notes "<short reason>"
+```
+
+## PR rules
+
+If you create a PR:
+
+- create a new branch from the checked-out branch
+- keep the diff minimal and focused on this Codex release
+- do not include unrelated cleanup
+- use a Conventional Commit PR title, for example `chore(tools): align Codex schema wording`
+- include `Codex-watch: openai/codex <tag>` and the compare URL in the PR body
+- run targeted tests/typecheck appropriate to the files changed
+- if validation cannot run or fails for unrelated reasons, mention that in the PR body and tracker note
+
+## Final response
+
+Respond with exactly one of:
+
+- `PR_CREATED <url>`
+- `NO_LOCAL_IMPACT <tag>`
+- `NEEDS_HUMAN_REVIEW <tag>`

--- a/.github/workflows/codex-agent-watch.yml
+++ b/.github/workflows/codex-agent-watch.yml
@@ -1,0 +1,109 @@
+name: Codex Agent Watch
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+    inputs:
+      since_tag:
+        description: "Previous stable openai/codex tag to compare from"
+        required: false
+        type: string
+      current_tag:
+        description: "Current stable openai/codex tag to compare to"
+        required: false
+        type: string
+      dry_run:
+        description: "Print/update nothing and do not invoke Amelia"
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  watch:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.0
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Check latest stable Codex release
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ARGS=(--analysis-file "$RUNNER_TEMP/codex-watch-analysis.json")
+          if [ -n "${{ inputs.since_tag }}" ]; then
+            ARGS+=(--since "${{ inputs.since_tag }}")
+          fi
+          if [ -n "${{ inputs.current_tag }}" ]; then
+            ARGS+=(--current "${{ inputs.current_tag }}")
+          fi
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS+=(--dry-run)
+          fi
+          bun scripts/codex-watch/agent-watch.ts "${ARGS[@]}"
+
+      - name: Build Amelia prompt
+        id: prompt
+        if: steps.detect.outputs.should_run_agent == 'true'
+        env:
+          TRACKER_ISSUE: ${{ steps.detect.outputs.tracker_issue }}
+          TRACKER_ISSUE_URL: ${{ steps.detect.outputs.tracker_issue_url }}
+          ANALYSIS_FILE: ${{ steps.detect.outputs.analysis_file }}
+          CURRENT_TAG: ${{ steps.detect.outputs.current_tag }}
+          PREVIOUS_TAG: ${{ steps.detect.outputs.previous_tag }}
+          VERDICT: ${{ steps.detect.outputs.verdict }}
+        run: |
+          {
+            echo "prompt<<AMELIA_PROMPT_EOF"
+            cat .github/agent-prompts/codex-agent-watch.md
+            echo
+            echo "## Run inputs"
+            echo
+            echo "- Tracker issue: #$TRACKER_ISSUE ($TRACKER_ISSUE_URL)"
+            echo "- Analysis file: $ANALYSIS_FILE"
+            echo "- Current tag: $CURRENT_TAG"
+            echo "- Previous tag: $PREVIOUS_TAG"
+            echo "- Detector verdict: $VERDICT"
+            echo
+            echo "The same values are available in the environment as TRACKER_ISSUE, TRACKER_ISSUE_URL, ANALYSIS_FILE, CURRENT_TAG, PREVIOUS_TAG, and VERDICT."
+            echo
+            echo "## Analysis JSON"
+            echo
+            echo '```json'
+            cat "$ANALYSIS_FILE"
+            echo '```'
+            echo "AMELIA_PROMPT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Ask Amelia to review actionable Codex drift
+        if: steps.detect.outputs.should_run_agent == 'true'
+        uses: letta-ai/letta-code-action@daa80f29e345315623ff759f5ecf5018946bbc15
+        env:
+          GH_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
+          TRACKER_ISSUE: ${{ steps.detect.outputs.tracker_issue }}
+          TRACKER_ISSUE_URL: ${{ steps.detect.outputs.tracker_issue_url }}
+          ANALYSIS_FILE: ${{ steps.detect.outputs.analysis_file }}
+          CURRENT_TAG: ${{ steps.detect.outputs.current_tag }}
+          PREVIOUS_TAG: ${{ steps.detect.outputs.previous_tag }}
+          VERDICT: ${{ steps.detect.outputs.verdict }}
+        with:
+          letta_api_key: ${{ secrets.AMELIA_LETTA_API_KEY }}
+          github_token: ${{ secrets.AMELIA_GITHUB_TOKEN }}
+          agent_id: agent-cd664b86-4d28-49b7-8ad6-60677eaff9be
+          track_progress: ""
+          tracking_comment: "false"
+          model: auto
+          prompt: ${{ steps.prompt.outputs.prompt }}

--- a/scripts/codex-watch/agent-watch.ts
+++ b/scripts/codex-watch/agent-watch.ts
@@ -1,0 +1,186 @@
+#!/usr/bin/env bun
+/**
+ * Amelia-driven Codex release watcher entrypoint.
+ *
+ * This runs alongside the legacy per-release issue workflow. It uses a central
+ * tracker issue for state and only asks Amelia to review non-noop releases.
+ */
+
+import { appendFileSync, writeFileSync } from "node:fs";
+import {
+  createIssueWithBody,
+  editIssueBody,
+  ensureLabels,
+  findIssueByExactTitle,
+  getIssueBody,
+} from "./github.ts";
+import {
+  analyzeCodexRelease,
+  DEFAULT_TARGET_REPO,
+} from "./release-analysis.ts";
+import {
+  emptyTrackerState,
+  hasProcessedTag,
+  parseTrackerState,
+  recordAnalysis,
+  renderTrackerBody,
+} from "./tracker.ts";
+
+const DEFAULT_TRACKER_TITLE = "Codex upstream drift tracker";
+const DEFAULT_ANALYSIS_FILE = "codex-watch-analysis.json";
+
+interface Args {
+  dryRun: boolean;
+  sinceTag: string | null;
+  currentTag: string | null;
+  repo: string;
+  trackerTitle: string;
+  analysisFile: string;
+}
+
+interface TrackerIssue {
+  number: number;
+  url: string;
+  body: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    dryRun: false,
+    sinceTag: null,
+    currentTag: null,
+    repo: DEFAULT_TARGET_REPO,
+    trackerTitle: DEFAULT_TRACKER_TITLE,
+    analysisFile: DEFAULT_ANALYSIS_FILE,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dry-run") args.dryRun = true;
+    else if (a === "--since") args.sinceTag = argv[++i] ?? null;
+    else if (a === "--current") args.currentTag = argv[++i] ?? null;
+    else if (a === "--repo") args.repo = argv[++i] ?? args.repo;
+    else if (a === "--tracker-title") {
+      args.trackerTitle = argv[++i] ?? args.trackerTitle;
+    } else if (a === "--analysis-file") {
+      args.analysisFile = argv[++i] ?? args.analysisFile;
+    } else if (a === "--help" || a === "-h") {
+      console.log(
+        "Usage: bun scripts/codex-watch/agent-watch.ts [--dry-run] [--since TAG] [--current TAG] [--repo OWNER/REPO] [--tracker-title TITLE] [--analysis-file FILE]",
+      );
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${a}`);
+    }
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const analysis = await analyzeCodexRelease({
+    sinceTag: args.sinceTag,
+    currentTag: args.currentTag,
+  });
+  writeFileSync(args.analysisFile, `${JSON.stringify(analysis, null, 2)}\n`);
+
+  const tracker = ensureTrackerIssue(args);
+  const state = parseTrackerState(tracker.body);
+
+  writeOutput("tracker_issue", String(tracker.number));
+  writeOutput("tracker_issue_url", tracker.url);
+  writeOutput("analysis_file", args.analysisFile);
+  writeOutput("current_tag", analysis.current_tag);
+  writeOutput("previous_tag", analysis.previous_tag);
+  writeOutput("verdict", analysis.verdict);
+
+  if (!args.dryRun && hasProcessedTag(state, analysis.current_tag)) {
+    console.log(`Already processed ${analysis.current_tag}; nothing to do.`);
+    writeOutput("should_run_agent", "false");
+    return;
+  }
+
+  if (analysis.verdict === "no-op") {
+    const next = recordAnalysis(state, {
+      analysis,
+      outcome: "recorded_noop",
+      notes: "no watched tool-surface changes detected",
+    });
+    const nextBody = renderTrackerBody(next);
+    if (args.dryRun) {
+      console.log(nextBody);
+    } else {
+      editIssueBody(args.repo, tracker.number, nextBody);
+    }
+    console.log(`Recorded ${analysis.current_tag} as no-op.`);
+    writeOutput("should_run_agent", "false");
+    return;
+  }
+
+  if (args.dryRun) {
+    console.log(JSON.stringify(analysis, null, 2));
+    writeOutput("should_run_agent", "false");
+    return;
+  }
+
+  console.log(
+    `Release ${analysis.current_tag} needs Amelia review: ${analysis.verdict}`,
+  );
+  writeOutput("should_run_agent", "true");
+}
+
+function ensureTrackerIssue(args: Args): TrackerIssue {
+  const existing = args.dryRun
+    ? null
+    : findIssueByExactTitle(args.repo, args.trackerTitle);
+  if (existing) {
+    return {
+      number: existing.number,
+      url: `https://github.com/${args.repo}/issues/${existing.number}`,
+      body: getIssueBody(args.repo, existing.number),
+    };
+  }
+
+  const body = renderTrackerBody(emptyTrackerState());
+  if (args.dryRun) {
+    return {
+      number: 0,
+      url: `https://github.com/${args.repo}/issues/0`,
+      body,
+    };
+  }
+
+  const labels = ["codex-watch", "automation"];
+  ensureLabels(args.repo, labels);
+  const issueUrl = createIssueWithBody(
+    args.repo,
+    args.trackerTitle,
+    body,
+    labels,
+  );
+  const issueNumber = issueNumberFromUrl(issueUrl);
+  return {
+    number: issueNumber,
+    url: issueUrl,
+    body,
+  };
+}
+
+function issueNumberFromUrl(issueUrl: string): number {
+  const issueNumber = Number(issueUrl.trim().split("/").at(-1));
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+    throw new Error(`Could not parse issue number from ${issueUrl}`);
+  }
+  return issueNumber;
+}
+
+function writeOutput(name: string, value: string): void {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+  appendFileSync(outputPath, `${name}=${value}\n`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  writeOutput("should_run_agent", "false");
+  process.exit(1);
+});

--- a/scripts/codex-watch/check-release.ts
+++ b/scripts/codex-watch/check-release.ts
@@ -9,41 +9,13 @@
  *   bun scripts/codex-watch/check-release.ts --repo letta-ai/letta-code
  */
 
-import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { createIssueWithBody, ensureLabels, ghJson } from "./github.ts";
 import {
-  decideVerdict,
-  diffModelsJson,
-  type ModelsDiff,
-  type ModelsJson,
-} from "./diff-models-json.ts";
-import {
-  type PathChangeSummary,
-  renderBody,
-  renderTitle,
-} from "./render-issue.ts";
-
-const CODEX_REPO = "openai/codex";
-const DEFAULT_TARGET_REPO =
-  process.env.GITHUB_REPOSITORY || "letta-ai/letta-code";
-const WATCHED_PATHS = [
-  "codex-rs/models-manager/models.json",
-  "codex-rs/models-manager/prompt.md",
-  "codex-rs/core/src/tools",
-  "codex-rs/apply-patch",
-];
-const MAX_COMMITS_PER_PATH = 8;
-
-interface Release {
-  tag_name: string;
-  draft: boolean;
-  prerelease: boolean;
-  html_url: string;
-  body: string | null;
-  published_at: string | null;
-}
+  analyzeCodexRelease,
+  DEFAULT_TARGET_REPO,
+  listStableReleases,
+} from "./release-analysis.ts";
+import { renderBody, renderTitle } from "./render-issue.ts";
 
 interface Args {
   dryRun: boolean;
@@ -77,73 +49,8 @@ function parseArgs(argv: string[]): Args {
   return args;
 }
 
-function gh<T>(args: string[], input?: string): T {
-  const res = spawnSync("gh", args, {
-    encoding: "utf8",
-    input,
-    maxBuffer: 50 * 1024 * 1024,
-    stdio: input ? ["pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"],
-  });
-  if (res.status !== 0) {
-    throw new Error(`gh ${args.join(" ")} failed:\n${res.stderr}`);
-  }
-  return JSON.parse(res.stdout) as T;
-}
-
-function git(args: string[], cwd?: string): string {
-  const res = spawnSync("git", args, {
-    cwd,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  if (res.status !== 0) {
-    throw new Error(`git ${args.join(" ")} failed:\n${res.stderr}`);
-  }
-  return res.stdout;
-}
-
-function isStableRelease(release: Release): boolean {
-  if (release.draft || release.prerelease) return false;
-  return /^(rust-v|v)?\d+\.\d+\.\d+$/.test(release.tag_name);
-}
-
-async function listStableReleases(): Promise<Release[]> {
-  const releases: Release[] = [];
-  const headers: Record<string, string> = {
-    Accept: "application/vnd.github+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
-  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
-  if (token) headers.Authorization = `Bearer ${token}`;
-
-  for (let page = 1; page <= 10; page++) {
-    const url = `https://api.github.com/repos/${CODEX_REPO}/releases?per_page=100&page=${page}`;
-    const res = await fetch(url, { headers });
-    if (!res.ok) {
-      throw new Error(
-        `GitHub releases API failed (${res.status}): ${await res.text()}`,
-      );
-    }
-    const batch = (await res.json()) as Release[];
-    releases.push(...batch);
-    if (batch.length < 100) break;
-  }
-  return releases
-    .filter(isStableRelease)
-    .sort((a, b) => (a.published_at ?? "").localeCompare(b.published_at ?? ""));
-}
-
-function findPreviousStable(
-  stables: Release[],
-  currentTag: string,
-): Release | null {
-  const idx = stables.findIndex((r) => r.tag_name === currentTag);
-  if (idx <= 0) return null;
-  return stables[idx - 1] ?? null;
-}
-
 function hasReportedTag(targetRepo: string, tag: string): boolean {
-  const issues = gh<Array<{ title: string }>>([
+  const issues = ghJson<Array<{ title: string }>>([
     "issue",
     "list",
     "--repo",
@@ -162,70 +69,6 @@ function hasReportedTag(targetRepo: string, tag: string): boolean {
   );
 }
 
-function cloneCodex(tmp: string): string {
-  const dir = join(tmp, "codex");
-  git([
-    "clone",
-    "--filter=blob:none",
-    "--no-checkout",
-    `https://github.com/${CODEX_REPO}.git`,
-    dir,
-  ]);
-  return dir;
-}
-
-function showFile(repoDir: string, tag: string, path: string): string | null {
-  const res = spawnSync("git", ["show", `${tag}:${path}`], {
-    cwd: repoDir,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  if (res.status !== 0) return null;
-  return res.stdout;
-}
-
-function changedFiles(
-  repoDir: string,
-  prevTag: string,
-  currTag: string,
-): string[] {
-  return git(["diff", "--name-only", `${prevTag}..${currTag}`], repoDir)
-    .split("\n")
-    .filter(Boolean);
-}
-
-function commitsForPath(
-  repoDir: string,
-  prevTag: string,
-  currTag: string,
-  path: string,
-): string[] {
-  const out = git(
-    ["log", "--format=%h %s", `${prevTag}..${currTag}`, "--", path],
-    repoDir,
-  );
-  const commits = out.split("\n").filter(Boolean);
-  if (commits.length <= MAX_COMMITS_PER_PATH) return commits;
-  return [
-    ...commits.slice(0, MAX_COMMITS_PER_PATH),
-    `…and ${commits.length - MAX_COMMITS_PER_PATH} more commits`,
-  ];
-}
-
-function diffPreview(
-  repoDir: string,
-  prevTag: string,
-  currTag: string,
-  path: string,
-): string | null {
-  const out = git(
-    ["diff", "--unified=2", `${prevTag}..${currTag}`, "--", path],
-    repoDir,
-  );
-  if (!out.trim()) return null;
-  return out.split("\n").slice(0, 120).join("\n");
-}
-
 function createIssue(
   repo: string,
   title: string,
@@ -242,41 +85,7 @@ function createIssue(
   if (verdict === "no-op") labels.push("informational");
 
   ensureLabels(repo, labels);
-
-  const bodyFile = join(tmpdir(), `codex-watch-${Date.now()}.md`);
-  writeFileSync(bodyFile, body);
-  try {
-    const args = [
-      "issue",
-      "create",
-      "--repo",
-      repo,
-      "--title",
-      title,
-      "--body-file",
-      bodyFile,
-    ];
-    for (const label of labels) args.push("--label", label);
-    const res = spawnSync("gh", args, { encoding: "utf8" });
-    if (res.status !== 0) {
-      throw new Error(`gh ${args.join(" ")} failed:\n${res.stderr}`);
-    }
-    console.log(res.stdout.trim());
-  } finally {
-    rmSync(bodyFile, { force: true });
-  }
-}
-
-function ensureLabels(repo: string, labels: string[]): void {
-  for (const label of labels) {
-    const res = spawnSync("gh", ["label", "create", label, "--repo", repo], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    if (res.status !== 0 && !res.stderr.includes("already exists")) {
-      throw new Error(`gh label create ${label} failed:\n${res.stderr}`);
-    }
-  }
+  console.log(createIssueWithBody(repo, title, body, labels));
 }
 
 async function main() {
@@ -290,15 +99,6 @@ async function main() {
   if (!current)
     throw new Error(`Could not find current release ${args.currentTag}`);
 
-  const previous = args.sinceTag
-    ? (stables.find((r) => r.tag_name === args.sinceTag) ??
-      ({ tag_name: args.sinceTag } as Release))
-    : findPreviousStable(stables, current.tag_name);
-  if (!previous)
-    throw new Error(
-      `Could not find previous stable before ${current.tag_name}`,
-    );
-
   const alreadyReported = args.dryRun
     ? false
     : hasReportedTag(args.repo, current.tag_name);
@@ -307,116 +107,18 @@ async function main() {
     return;
   }
 
-  const tmp = mkdtempSync(join(tmpdir(), "codex-watch-"));
-  try {
-    const repoDir = cloneCodex(tmp);
-    git(
-      [
-        "fetch",
-        "--filter=blob:none",
-        "origin",
-        `refs/tags/${previous.tag_name}:refs/tags/${previous.tag_name}`,
-      ],
-      repoDir,
-    );
-    git(
-      [
-        "fetch",
-        "--filter=blob:none",
-        "origin",
-        `refs/tags/${current.tag_name}:refs/tags/${current.tag_name}`,
-      ],
-      repoDir,
-    );
+  const analysis = await analyzeCodexRelease({
+    sinceTag: args.sinceTag,
+    currentTag: args.currentTag,
+  });
 
-    let modelsDiff: ModelsDiff | null = null;
-    let parseError = false;
-    try {
-      const prevRaw = showFile(
-        repoDir,
-        previous.tag_name,
-        "codex-rs/models-manager/models.json",
-      );
-      const currRaw = showFile(
-        repoDir,
-        current.tag_name,
-        "codex-rs/models-manager/models.json",
-      );
-      if (!prevRaw || !currRaw)
-        throw new Error("missing models.json at one tag");
-      modelsDiff = diffModelsJson(
-        JSON.parse(prevRaw) as ModelsJson,
-        JSON.parse(currRaw) as ModelsJson,
-      );
-    } catch (err) {
-      parseError = true;
-      console.error(`Failed to parse/diff models.json: ${String(err)}`);
-    }
+  const title = renderTitle(analysis);
+  const body = renderBody(analysis);
 
-    const changed = changedFiles(repoDir, previous.tag_name, current.tag_name);
-    const changedSet = new Set(changed);
-    const promptMdChanged = changedSet.has("codex-rs/models-manager/prompt.md");
-    const toolsDirChanged = changed.some((f) =>
-      f.startsWith("codex-rs/core/src/tools/"),
-    );
-    const applyPatchDirChanged = changed.some((f) =>
-      f.startsWith("codex-rs/apply-patch/"),
-    );
-    const verdict = decideVerdict({
-      models_diff: modelsDiff,
-      prompt_md_changed: promptMdChanged,
-      tools_dir_changed: toolsDirChanged,
-      apply_patch_dir_changed: applyPatchDirChanged,
-      parse_error: parseError,
-    });
-
-    const pathChanges: PathChangeSummary[] = WATCHED_PATHS.map((path) => ({
-      path,
-      commits: commitsForPath(
-        repoDir,
-        previous.tag_name,
-        current.tag_name,
-        path,
-      ),
-    })).filter((p) => p.commits.length > 0);
-
-    const workflowUrl =
-      process.env.GITHUB_SERVER_URL &&
-      process.env.GITHUB_REPOSITORY &&
-      process.env.GITHUB_RUN_ID
-        ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
-        : "local dry-run";
-
-    const input = {
-      previous_tag: previous.tag_name,
-      current_tag: current.tag_name,
-      release_url: current.html_url,
-      release_notes_md: current.body ?? "",
-      verdict,
-      models_diff: modelsDiff,
-      prompt_md_changed: promptMdChanged,
-      prompt_md_diff_preview: promptMdChanged
-        ? diffPreview(
-            repoDir,
-            previous.tag_name,
-            current.tag_name,
-            "codex-rs/models-manager/prompt.md",
-          )
-        : null,
-      path_changes: pathChanges,
-      workflow_run_url: workflowUrl,
-    };
-
-    const title = renderTitle(input);
-    const body = renderBody(input);
-
-    if (args.dryRun) {
-      console.log(`# ${title}\n\n${body}`);
-    } else {
-      createIssue(args.repo, title, body, verdict);
-    }
-  } finally {
-    rmSync(tmp, { recursive: true, force: true });
+  if (args.dryRun) {
+    console.log(`# ${title}\n\n${body}`);
+  } else {
+    createIssue(args.repo, title, body, analysis.verdict);
   }
 }
 

--- a/scripts/codex-watch/github.ts
+++ b/scripts/codex-watch/github.ts
@@ -1,0 +1,121 @@
+import { spawnSync } from "node:child_process";
+import { rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export function runGh(args: string[], input?: string): string {
+  const res = spawnSync("gh", args, {
+    encoding: "utf8",
+    input,
+    maxBuffer: 50 * 1024 * 1024,
+    stdio: input ? ["pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"],
+  });
+  if (res.status !== 0) {
+    throw new Error(`gh ${args.join(" ")} failed:\n${res.stderr}`);
+  }
+  return res.stdout;
+}
+
+export function ghJson<T>(args: string[], input?: string): T {
+  return JSON.parse(runGh(args, input)) as T;
+}
+
+export function ensureLabels(repo: string, labels: string[]): void {
+  for (const label of labels) {
+    const res = spawnSync("gh", ["label", "create", label, "--repo", repo], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (res.status !== 0 && !res.stderr.includes("already exists")) {
+      throw new Error(`gh label create ${label} failed:\n${res.stderr}`);
+    }
+  }
+}
+
+export function createIssueWithBody(
+  repo: string,
+  title: string,
+  body: string,
+  labels: string[] = [],
+): string {
+  const bodyFile = writeTempMarkdown(body, "codex-watch-issue");
+  try {
+    const args = [
+      "issue",
+      "create",
+      "--repo",
+      repo,
+      "--title",
+      title,
+      "--body-file",
+      bodyFile,
+    ];
+    for (const label of labels) args.push("--label", label);
+    return runGh(args).trim();
+  } finally {
+    rmSync(bodyFile, { force: true });
+  }
+}
+
+export function editIssueBody(
+  repo: string,
+  issueNumber: number,
+  body: string,
+): void {
+  const bodyFile = writeTempMarkdown(body, "codex-watch-tracker");
+  try {
+    runGh([
+      "issue",
+      "edit",
+      String(issueNumber),
+      "--repo",
+      repo,
+      "--body-file",
+      bodyFile,
+    ]);
+  } finally {
+    rmSync(bodyFile, { force: true });
+  }
+}
+
+export function getIssueBody(repo: string, issueNumber: number): string {
+  const issue = ghJson<{ body: string | null }>([
+    "issue",
+    "view",
+    String(issueNumber),
+    "--repo",
+    repo,
+    "--json",
+    "body",
+  ]);
+  return issue.body ?? "";
+}
+
+export function findIssueByExactTitle(
+  repo: string,
+  title: string,
+): { number: number; title: string; state: string } | null {
+  const issues = ghJson<
+    Array<{ number: number; title: string; state: string }>
+  >([
+    "issue",
+    "list",
+    "--repo",
+    repo,
+    "--state",
+    "all",
+    "--search",
+    `${title} in:title`,
+    "--limit",
+    "20",
+    "--json",
+    "number,title,state",
+  ]);
+  return issues.find((issue) => issue.title === title) ?? null;
+}
+
+function writeTempMarkdown(body: string, prefix: string): string {
+  const bodyFile = join(tmpdir(), `${prefix}-${Date.now()}.md`);
+  writeFileSync(bodyFile, body);
+  return bodyFile;
+}

--- a/scripts/codex-watch/release-analysis.ts
+++ b/scripts/codex-watch/release-analysis.ts
@@ -1,0 +1,288 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  decideVerdict,
+  diffModelsJson,
+  type ModelsDiff,
+  type ModelsJson,
+  type Verdict,
+} from "./diff-models-json.ts";
+import type { PathChangeSummary, RenderInput } from "./render-issue.ts";
+
+export const CODEX_REPO = "openai/codex";
+export const DEFAULT_TARGET_REPO =
+  process.env.GITHUB_REPOSITORY || "letta-ai/letta-code";
+export const WATCHED_PATHS = [
+  "codex-rs/models-manager/models.json",
+  "codex-rs/models-manager/prompt.md",
+  "codex-rs/core/src/tools",
+  "codex-rs/apply-patch",
+];
+
+const MAX_COMMITS_PER_PATH = 8;
+
+export interface Release {
+  tag_name: string;
+  draft: boolean;
+  prerelease: boolean;
+  html_url: string;
+  body: string | null;
+  published_at: string | null;
+}
+
+export interface AnalyzeCodexReleaseOptions {
+  sinceTag: string | null;
+  currentTag: string | null;
+}
+
+export interface CodexWatchAnalysis extends RenderInput {
+  verdict: Verdict;
+  models_diff: ModelsDiff | null;
+  compare_url: string;
+  changed_files: string[];
+}
+
+export async function analyzeCodexRelease(
+  options: AnalyzeCodexReleaseOptions,
+): Promise<CodexWatchAnalysis> {
+  const stables = await listStableReleases();
+  if (stables.length === 0) throw new Error("No stable Codex releases found");
+
+  const current = options.currentTag
+    ? stables.find((r) => r.tag_name === options.currentTag)
+    : stables.at(-1);
+  if (!current)
+    throw new Error(`Could not find current release ${options.currentTag}`);
+
+  const previous = options.sinceTag
+    ? (stables.find((r) => r.tag_name === options.sinceTag) ??
+      ({ tag_name: options.sinceTag } as Release))
+    : findPreviousStable(stables, current.tag_name);
+  if (!previous)
+    throw new Error(
+      `Could not find previous stable before ${current.tag_name}`,
+    );
+
+  const tmp = mkdtempSync(join(tmpdir(), "codex-watch-"));
+  try {
+    const repoDir = cloneCodex(tmp);
+    fetchTag(repoDir, previous.tag_name);
+    fetchTag(repoDir, current.tag_name);
+
+    let modelsDiff: ModelsDiff | null = null;
+    let parseError = false;
+    try {
+      const prevRaw = showFile(
+        repoDir,
+        previous.tag_name,
+        "codex-rs/models-manager/models.json",
+      );
+      const currRaw = showFile(
+        repoDir,
+        current.tag_name,
+        "codex-rs/models-manager/models.json",
+      );
+      if (!prevRaw || !currRaw)
+        throw new Error("missing models.json at one tag");
+      modelsDiff = diffModelsJson(
+        JSON.parse(prevRaw) as ModelsJson,
+        JSON.parse(currRaw) as ModelsJson,
+      );
+    } catch (err) {
+      parseError = true;
+      console.error(`Failed to parse/diff models.json: ${String(err)}`);
+    }
+
+    const changed = changedFiles(repoDir, previous.tag_name, current.tag_name);
+    const changedSet = new Set(changed);
+    const promptMdChanged = changedSet.has("codex-rs/models-manager/prompt.md");
+    const toolsDirChanged = changed.some((f) =>
+      f.startsWith("codex-rs/core/src/tools/"),
+    );
+    const applyPatchDirChanged = changed.some((f) =>
+      f.startsWith("codex-rs/apply-patch/"),
+    );
+    const verdict = decideVerdict({
+      models_diff: modelsDiff,
+      prompt_md_changed: promptMdChanged,
+      tools_dir_changed: toolsDirChanged,
+      apply_patch_dir_changed: applyPatchDirChanged,
+      parse_error: parseError,
+    });
+
+    const pathChanges: PathChangeSummary[] = WATCHED_PATHS.map((path) => ({
+      path,
+      commits: commitsForPath(
+        repoDir,
+        previous.tag_name,
+        current.tag_name,
+        path,
+      ),
+    })).filter((p) => p.commits.length > 0);
+
+    return {
+      previous_tag: previous.tag_name,
+      current_tag: current.tag_name,
+      release_url: current.html_url,
+      release_notes_md: current.body ?? "",
+      verdict,
+      models_diff: modelsDiff,
+      prompt_md_changed: promptMdChanged,
+      prompt_md_diff_preview: promptMdChanged
+        ? diffPreview(
+            repoDir,
+            previous.tag_name,
+            current.tag_name,
+            "codex-rs/models-manager/prompt.md",
+          )
+        : null,
+      path_changes: pathChanges,
+      workflow_run_url: workflowRunUrl(),
+      compare_url: `https://github.com/${CODEX_REPO}/compare/${previous.tag_name}...${current.tag_name}`,
+      changed_files: changed,
+    };
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+export async function listStableReleases(): Promise<Release[]> {
+  const releases: Release[] = [];
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  for (let page = 1; page <= 10; page++) {
+    const url = `https://api.github.com/repos/${CODEX_REPO}/releases?per_page=100&page=${page}`;
+    const res = await fetch(url, { headers });
+    if (!res.ok) {
+      throw new Error(
+        `GitHub releases API failed (${res.status}): ${await res.text()}`,
+      );
+    }
+    const batch = (await res.json()) as Release[];
+    releases.push(...batch);
+    if (batch.length < 100) break;
+  }
+  return releases
+    .filter(isStableRelease)
+    .sort((a, b) => (a.published_at ?? "").localeCompare(b.published_at ?? ""));
+}
+
+function isStableRelease(release: Release): boolean {
+  if (release.draft || release.prerelease) return false;
+  return /^(rust-v|v)?\d+\.\d+\.\d+$/.test(release.tag_name);
+}
+
+function findPreviousStable(
+  stables: Release[],
+  currentTag: string,
+): Release | null {
+  const idx = stables.findIndex((r) => r.tag_name === currentTag);
+  if (idx <= 0) return null;
+  return stables[idx - 1] ?? null;
+}
+
+function cloneCodex(tmp: string): string {
+  const dir = join(tmp, "codex");
+  git([
+    "clone",
+    "--filter=blob:none",
+    "--no-checkout",
+    `https://github.com/${CODEX_REPO}.git`,
+    dir,
+  ]);
+  return dir;
+}
+
+function fetchTag(repoDir: string, tag: string): void {
+  git(
+    [
+      "fetch",
+      "--filter=blob:none",
+      "origin",
+      `refs/tags/${tag}:refs/tags/${tag}`,
+    ],
+    repoDir,
+  );
+}
+
+function showFile(repoDir: string, tag: string, path: string): string | null {
+  const res = spawnSync("git", ["show", `${tag}:${path}`], {
+    cwd: repoDir,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (res.status !== 0) return null;
+  return res.stdout;
+}
+
+function changedFiles(
+  repoDir: string,
+  prevTag: string,
+  currTag: string,
+): string[] {
+  return git(["diff", "--name-only", `${prevTag}..${currTag}`], repoDir)
+    .split("\n")
+    .filter(Boolean);
+}
+
+function commitsForPath(
+  repoDir: string,
+  prevTag: string,
+  currTag: string,
+  path: string,
+): string[] {
+  const out = git(
+    ["log", "--format=%h %s", `${prevTag}..${currTag}`, "--", path],
+    repoDir,
+  );
+  const commits = out.split("\n").filter(Boolean);
+  if (commits.length <= MAX_COMMITS_PER_PATH) return commits;
+  return [
+    ...commits.slice(0, MAX_COMMITS_PER_PATH),
+    `…and ${commits.length - MAX_COMMITS_PER_PATH} more commits`,
+  ];
+}
+
+function diffPreview(
+  repoDir: string,
+  prevTag: string,
+  currTag: string,
+  path: string,
+): string | null {
+  const out = git(
+    ["diff", "--unified=2", `${prevTag}..${currTag}`, "--", path],
+    repoDir,
+  );
+  if (!out.trim()) return null;
+  return out.split("\n").slice(0, 120).join("\n");
+}
+
+function git(args: string[], cwd?: string): string {
+  const res = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (res.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed:\n${res.stderr}`);
+  }
+  return res.stdout;
+}
+
+function workflowRunUrl(): string {
+  if (
+    process.env.GITHUB_SERVER_URL &&
+    process.env.GITHUB_REPOSITORY &&
+    process.env.GITHUB_RUN_ID
+  ) {
+    return `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+  }
+  return "local dry-run";
+}

--- a/scripts/codex-watch/tracker.test.ts
+++ b/scripts/codex-watch/tracker.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+import type { CodexWatchAnalysis } from "./release-analysis.ts";
+import {
+  emptyTrackerState,
+  hasProcessedTag,
+  parseTrackerState,
+  recordAnalysis,
+  renderTrackerBody,
+  serializeTrackerState,
+  type TrackerEntry,
+  upsertTrackerEntry,
+} from "./tracker.ts";
+
+function analysis(
+  tag: string,
+  verdict: CodexWatchAnalysis["verdict"] = "no-op",
+): CodexWatchAnalysis {
+  return {
+    previous_tag: "rust-v0.1.0",
+    current_tag: tag,
+    release_url: `https://github.com/openai/codex/releases/tag/${tag}`,
+    release_notes_md: "",
+    verdict,
+    models_diff: null,
+    prompt_md_changed: false,
+    prompt_md_diff_preview: null,
+    path_changes: [],
+    workflow_run_url: "https://github.com/letta-ai/letta-code/actions/runs/1",
+    compare_url: `https://github.com/openai/codex/compare/rust-v0.1.0...${tag}`,
+    changed_files: [],
+  };
+}
+
+function entry(index: number, outcome: TrackerEntry["outcome"]): TrackerEntry {
+  const verdict =
+    outcome === "recorded_noop" ? "no-op" : "tool-surface review needed";
+  return {
+    tag: `rust-v0.${index}.0`,
+    previous_tag: `rust-v0.${index - 1}.0`,
+    verdict,
+    outcome,
+    pr_url:
+      outcome === "pr_created"
+        ? `https://github.com/letta-ai/letta-code/pull/${index}`
+        : null,
+    notes: `notes ${index}`,
+    processed_at: `2026-07-02T00:${String(index).padStart(2, "0")}:00.000Z`,
+    compare_url: `https://github.com/openai/codex/compare/rust-v0.${index - 1}.0...rust-v0.${index}.0`,
+    workflow_run_url: "https://github.com/letta-ai/letta-code/actions/runs/1",
+  };
+}
+
+describe("tracker state", () => {
+  test("returns empty state when hidden state is absent or malformed", () => {
+    expect(parseTrackerState("plain body")).toEqual(emptyTrackerState());
+    expect(
+      parseTrackerState("<!-- codex-agent-watch-state\nnot json\n-->"),
+    ).toEqual(emptyTrackerState());
+  });
+
+  test("round-trips hidden state through rendered body", () => {
+    const state = recordAnalysis(emptyTrackerState(), {
+      analysis: analysis("rust-v0.2.0", "tool-surface review needed"),
+      outcome: "no_local_impact",
+      notes: "upstream-only router change",
+      processedAt: "2026-07-02T00:00:00.000Z",
+    });
+
+    const body = renderTrackerBody(state);
+    expect(parseTrackerState(body)).toEqual(state);
+    expect(body).toContain("rust-v0.2.0");
+    expect(body).toContain("upstream-only router change");
+  });
+
+  test("records noops in hidden state without adding visible table rows", () => {
+    const state = recordAnalysis(emptyTrackerState(), {
+      analysis: analysis("rust-v0.2.0"),
+      outcome: "recorded_noop",
+      notes: "no watched tool-surface changes detected",
+      processedAt: "2026-07-02T00:00:00.000Z",
+    });
+
+    const body = renderTrackerBody(state);
+    expect(hasProcessedTag(parseTrackerState(body), "rust-v0.2.0")).toBe(true);
+    expect(body).toContain("_No actionable releases recorded yet._");
+    expect(body).toContain("no watched changes");
+  });
+
+  test("keeps the last 50 processed releases in hidden state", () => {
+    let state = emptyTrackerState();
+    for (let i = 1; i <= 60; i++) {
+      state = upsertTrackerEntry(state, entry(i, "recorded_noop"));
+    }
+
+    expect(state.processed).toHaveLength(50);
+    expect(state.processed[0]?.tag).toBe("rust-v0.60.0");
+    expect(state.processed.at(-1)?.tag).toBe("rust-v0.11.0");
+    expect(parseTrackerState(serializeTrackerState(state))).toEqual(state);
+  });
+
+  test("renders at most 20 non-noop rows", () => {
+    let state = emptyTrackerState();
+    for (let i = 1; i <= 25; i++) {
+      state = upsertTrackerEntry(state, entry(i, "no_local_impact"));
+    }
+
+    const body = renderTrackerBody(state);
+    expect(body).toContain("| [rust-v0.25.0]");
+    expect(body).toContain("| [rust-v0.6.0]");
+    expect(body).not.toContain("| [rust-v0.5.0]");
+  });
+
+  test("replaces an existing tag instead of duplicating it", () => {
+    let state = upsertTrackerEntry(
+      emptyTrackerState(),
+      entry(2, "recorded_noop"),
+    );
+    state = upsertTrackerEntry(state, {
+      ...entry(2, "pr_created"),
+      notes: "opened a fix",
+    });
+
+    expect(state.processed).toHaveLength(1);
+    expect(state.processed[0]?.outcome).toBe("pr_created");
+    expect(renderTrackerBody(state)).toContain("opened a fix");
+  });
+});

--- a/scripts/codex-watch/tracker.ts
+++ b/scripts/codex-watch/tracker.ts
@@ -1,0 +1,238 @@
+import type { Verdict } from "./diff-models-json.ts";
+import type { CodexWatchAnalysis } from "./release-analysis.ts";
+
+const STATE_START = "<!-- codex-agent-watch-state";
+const STATE_END = "-->";
+const HIDDEN_STATE_LIMIT = 50;
+const VISIBLE_INTERESTING_LIMIT = 20;
+
+export type TrackerOutcome =
+  | "recorded_noop"
+  | "no_local_impact"
+  | "pr_created"
+  | "needs_human_review"
+  | "error";
+
+export interface TrackerEntry {
+  tag: string;
+  previous_tag: string;
+  verdict: Verdict;
+  outcome: TrackerOutcome;
+  pr_url: string | null;
+  notes: string;
+  processed_at: string;
+  compare_url: string;
+  workflow_run_url: string;
+}
+
+export interface TrackerState {
+  last_checked_tag: string | null;
+  last_checked_at: string | null;
+  processed: TrackerEntry[];
+}
+
+export interface RecordAnalysisOptions {
+  analysis: CodexWatchAnalysis;
+  outcome: TrackerOutcome;
+  notes: string;
+  prUrl?: string | null;
+  processedAt?: string;
+}
+
+export function emptyTrackerState(): TrackerState {
+  return {
+    last_checked_tag: null,
+    last_checked_at: null,
+    processed: [],
+  };
+}
+
+export function parseTrackerState(body: string): TrackerState {
+  const start = body.indexOf(STATE_START);
+  if (start === -1) return emptyTrackerState();
+
+  const jsonStart = start + STATE_START.length;
+  const end = body.indexOf(STATE_END, jsonStart);
+  if (end === -1) return emptyTrackerState();
+
+  try {
+    return normalizeState(JSON.parse(body.slice(jsonStart, end).trim()));
+  } catch {
+    return emptyTrackerState();
+  }
+}
+
+export function hasProcessedTag(state: TrackerState, tag: string): boolean {
+  return state.processed.some((entry) => entry.tag === tag);
+}
+
+export function recordAnalysis(
+  state: TrackerState,
+  options: RecordAnalysisOptions,
+): TrackerState {
+  const processedAt = options.processedAt ?? new Date().toISOString();
+  return upsertTrackerEntry(state, {
+    tag: options.analysis.current_tag,
+    previous_tag: options.analysis.previous_tag,
+    verdict: options.analysis.verdict,
+    outcome: options.outcome,
+    pr_url: options.prUrl ?? null,
+    notes: options.notes,
+    processed_at: processedAt,
+    compare_url: options.analysis.compare_url,
+    workflow_run_url: options.analysis.workflow_run_url,
+  });
+}
+
+export function upsertTrackerEntry(
+  state: TrackerState,
+  entry: TrackerEntry,
+): TrackerState {
+  const processed = [
+    entry,
+    ...state.processed.filter((existing) => existing.tag !== entry.tag),
+  ].slice(0, HIDDEN_STATE_LIMIT);
+
+  return {
+    last_checked_tag: entry.tag,
+    last_checked_at: entry.processed_at,
+    processed,
+  };
+}
+
+export function renderTrackerBody(state: TrackerState): string {
+  const normalized = normalizeState(state);
+  const parts: string[] = [
+    "Central tracker for the Amelia-driven Codex upstream drift watch experiment.",
+    "",
+    "The legacy per-release `codex-release-watch.yml` issue workflow is still enabled as the baseline while this tracker bakes off the new automation path.",
+    "",
+    renderLastChecked(normalized),
+    "",
+    "## Recent actionable releases",
+    "",
+    renderInterestingTable(normalized),
+    "",
+    "## Hidden state",
+    "",
+    "The workflow uses the hidden JSON block below for dedupe and recent history.",
+    "",
+    serializeTrackerState(normalized),
+  ];
+  return `${parts.join("\n")}\n`;
+}
+
+export function serializeTrackerState(state: TrackerState): string {
+  const normalized = normalizeState(state);
+  return `${STATE_START}\n${JSON.stringify(normalized, null, 2)}\n${STATE_END}`;
+}
+
+export function isInterestingEntry(entry: TrackerEntry): boolean {
+  return entry.verdict !== "no-op" || entry.outcome !== "recorded_noop";
+}
+
+function renderLastChecked(state: TrackerState): string {
+  if (!state.last_checked_tag || !state.last_checked_at) {
+    return "_Last checked: never._";
+  }
+
+  const latest = state.processed.find(
+    (entry) => entry.tag === state.last_checked_tag,
+  );
+  const suffix = latest ? `, ${statusSummary(latest)}.` : ".";
+  return `_Last checked: ${state.last_checked_tag} at ${state.last_checked_at}${suffix}_`;
+}
+
+function renderInterestingTable(state: TrackerState): string {
+  const interesting = state.processed
+    .filter(isInterestingEntry)
+    .slice(0, VISIBLE_INTERESTING_LIMIT);
+
+  if (interesting.length === 0) {
+    return "_No actionable releases recorded yet._";
+  }
+
+  const rows = [
+    "| Release | Verdict | Outcome | PR | Notes |",
+    "|---|---|---|---|---|",
+  ];
+  for (const entry of interesting) {
+    rows.push(
+      `| [${escapeTable(entry.tag)}](${entry.compare_url}) | ${escapeTable(entry.verdict)} | ${escapeTable(entry.outcome)} | ${renderPr(entry.pr_url)} | ${escapeTable(entry.notes)} |`,
+    );
+  }
+  return rows.join("\n");
+}
+
+function statusSummary(entry: TrackerEntry): string {
+  if (entry.outcome === "recorded_noop") return "no watched changes";
+  if (entry.outcome === "pr_created" && entry.pr_url) {
+    return `PR created: ${entry.pr_url}`;
+  }
+  return entry.notes || entry.outcome;
+}
+
+function renderPr(prUrl: string | null): string {
+  return prUrl ? `[PR](${prUrl})` : "-";
+}
+
+function escapeTable(value: string): string {
+  return value.replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+function normalizeState(value: unknown): TrackerState {
+  if (!isRecord(value)) return emptyTrackerState();
+
+  const processed = Array.isArray(value.processed)
+    ? value.processed.filter(isTrackerEntry).slice(0, HIDDEN_STATE_LIMIT)
+    : [];
+
+  return {
+    last_checked_tag:
+      typeof value.last_checked_tag === "string"
+        ? value.last_checked_tag
+        : null,
+    last_checked_at:
+      typeof value.last_checked_at === "string" ? value.last_checked_at : null,
+    processed,
+  };
+}
+
+function isTrackerEntry(value: unknown): value is TrackerEntry {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.tag === "string" &&
+    typeof value.previous_tag === "string" &&
+    isVerdict(value.verdict) &&
+    isOutcome(value.outcome) &&
+    (typeof value.pr_url === "string" || value.pr_url === null) &&
+    typeof value.notes === "string" &&
+    typeof value.processed_at === "string" &&
+    typeof value.compare_url === "string" &&
+    typeof value.workflow_run_url === "string"
+  );
+}
+
+function isVerdict(value: unknown): value is Verdict {
+  return (
+    value === "no-op" ||
+    value === "prompt-only update" ||
+    value === "tool-schema update needed" ||
+    value === "tool-surface review needed" ||
+    value === "manual review required"
+  );
+}
+
+function isOutcome(value: unknown): value is TrackerOutcome {
+  return (
+    value === "recorded_noop" ||
+    value === "no_local_impact" ||
+    value === "pr_created" ||
+    value === "needs_human_review" ||
+    value === "error"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/scripts/codex-watch/update-tracker.ts
+++ b/scripts/codex-watch/update-tracker.ts
@@ -1,0 +1,131 @@
+#!/usr/bin/env bun
+/**
+ * Records an Amelia Codex watch outcome in the central tracker issue.
+ *
+ * Usage:
+ *   bun scripts/codex-watch/update-tracker.ts --tracker-issue 123 --analysis-file /tmp/analysis.json --outcome no_local_impact --notes "upstream-only"
+ */
+
+import { readFileSync } from "node:fs";
+import { editIssueBody, getIssueBody } from "./github.ts";
+import {
+  type CodexWatchAnalysis,
+  DEFAULT_TARGET_REPO,
+} from "./release-analysis.ts";
+import {
+  parseTrackerState,
+  recordAnalysis,
+  renderTrackerBody,
+  type TrackerOutcome,
+} from "./tracker.ts";
+
+interface Args {
+  repo: string;
+  trackerIssue: number | null;
+  analysisFile: string | null;
+  outcome: TrackerOutcome | null;
+  notes: string;
+  prUrl: string | null;
+  dryRun: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    repo: DEFAULT_TARGET_REPO,
+    trackerIssue: null,
+    analysisFile: null,
+    outcome: null,
+    notes: "",
+    prUrl: null,
+    dryRun: false,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--repo") args.repo = argv[++i] ?? args.repo;
+    else if (a === "--tracker-issue") {
+      args.trackerIssue = Number(argv[++i]);
+    } else if (a === "--analysis-file") args.analysisFile = argv[++i] ?? null;
+    else if (a === "--outcome") args.outcome = parseOutcome(argv[++i]);
+    else if (a === "--notes") args.notes = argv[++i] ?? "";
+    else if (a === "--pr-url") args.prUrl = argv[++i] ?? null;
+    else if (a === "--dry-run") args.dryRun = true;
+    else if (a === "--help" || a === "-h") {
+      console.log(
+        "Usage: bun scripts/codex-watch/update-tracker.ts --tracker-issue ISSUE --analysis-file FILE --outcome OUTCOME [--notes TEXT] [--pr-url URL] [--repo OWNER/REPO] [--dry-run]",
+      );
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${a}`);
+    }
+  }
+
+  if (!args.trackerIssue || Number.isNaN(args.trackerIssue)) {
+    throw new Error("--tracker-issue is required");
+  }
+  if (!args.analysisFile) throw new Error("--analysis-file is required");
+  if (!args.outcome) throw new Error("--outcome is required");
+  if (args.outcome === "pr_created" && !args.prUrl) {
+    throw new Error("--pr-url is required when --outcome pr_created");
+  }
+
+  return args;
+}
+
+function parseOutcome(value: string | undefined): TrackerOutcome {
+  if (
+    value === "recorded_noop" ||
+    value === "no_local_impact" ||
+    value === "pr_created" ||
+    value === "needs_human_review" ||
+    value === "error"
+  ) {
+    return value;
+  }
+  throw new Error(`Unknown outcome: ${value}`);
+}
+
+function readAnalysis(path: string): CodexWatchAnalysis {
+  return JSON.parse(readFileSync(path, "utf8")) as CodexWatchAnalysis;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const analysis = readAnalysis(args.analysisFile as string);
+  const body = getIssueBody(args.repo, args.trackerIssue as number);
+  const state = parseTrackerState(body);
+  const next = recordAnalysis(state, {
+    analysis,
+    outcome: args.outcome as TrackerOutcome,
+    notes: args.notes || defaultNotes(args.outcome as TrackerOutcome),
+    prUrl: args.prUrl,
+  });
+  const nextBody = renderTrackerBody(next);
+
+  if (args.dryRun) {
+    console.log(nextBody);
+    return;
+  }
+
+  editIssueBody(args.repo, args.trackerIssue as number, nextBody);
+  console.log(
+    `Recorded ${analysis.current_tag} as ${args.outcome} in #${args.trackerIssue}`,
+  );
+}
+
+function defaultNotes(outcome: TrackerOutcome): string {
+  switch (outcome) {
+    case "recorded_noop":
+      return "no watched tool-surface changes detected";
+    case "no_local_impact":
+      return "reviewed; no local Letta Code mirror impact";
+    case "pr_created":
+      return "opened PR for local mirror update";
+    case "needs_human_review":
+      return "needs human review";
+    case "error":
+      return "automation hit an error";
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- Add a parallel Codex Agent Watch workflow that keeps the legacy issue workflow as a baseline while tracking new automation in one central issue.
- Refactor Codex release analysis so both the legacy issue creator and new Amelia-driven watcher share the same detection logic.
- Add tracker state/update helpers and tests for hidden last-50 history plus visible last-20 actionable rows.

## Test plan
- [x] bun test scripts/codex-watch/diff-models-json.test.ts scripts/codex-watch/tracker.test.ts
- [x] bun scripts/codex-watch/agent-watch.ts --dry-run --since rust-v0.142.3 --current rust-v0.142.4 --analysis-file /tmp/codex-watch-analysis.json
- [x] bun scripts/codex-watch/agent-watch.ts --dry-run --since rust-v0.142.4 --current rust-v0.142.5 --analysis-file /tmp/codex-watch-noop-analysis.json
- [x] bun scripts/codex-watch/check-release.ts --dry-run --since rust-v0.142.3 --current rust-v0.142.4
- [x] bun run check

👾 Generated with [Letta Code](https://letta.com)