### PR TITLE
fix(cli): validate approval args from scoped tool schemas

### DIFF
--- a/src/cli/approval-classification.test.ts
+++ b/src/cli/approval-classification.test.ts
@@ -18,6 +18,7 @@ import {
   loadSpecificTools,
   loadTools,
   prepareCurrentToolExecutionContext,
+  prepareToolExecutionContextForSpecificTools,
 } from "@/tools/manager";
 
 describe("classifyApprovals", () => {
@@ -142,6 +143,41 @@ describe("classifyApprovals", () => {
     expect(denied?.missingRequiredArgs).toEqual(["cmd"]);
     expect(denied?.denyReason).toBe(
       "exec_command tool missing required parameter: cmd. Received parameters: yield_time_ms",
+    );
+  });
+
+  test("validates required args against the turn-scoped tool context", async () => {
+    await loadTools();
+    const { contextId } = await prepareToolExecutionContextForSpecificTools([
+      "exec_command",
+    ]);
+    permissionMode.setMode("unrestricted");
+
+    const result = await classifyApprovals(
+      [
+        {
+          toolCallId: "call_context_missing_cmd",
+          toolName: "exec_command",
+          toolArgs: JSON.stringify({
+            description: "Check diagnostics for broken test mod",
+          }),
+        },
+      ],
+      {
+        requireArgsForAutoApprove: true,
+        toolContextId: contextId,
+        workingDirectory: "/tmp/project",
+      },
+    );
+
+    expect(result.autoAllowed).toHaveLength(0);
+    expect(result.needsUserInput).toHaveLength(0);
+    expect(result.autoDenied).toHaveLength(1);
+
+    const [denied] = result.autoDenied;
+    expect(denied?.missingRequiredArgs).toEqual(["cmd"]);
+    expect(denied?.denyReason).toBe(
+      "exec_command tool missing required parameter: cmd. Received parameters: description",
     );
   });
 

--- a/src/cli/helpers/approval-classification.ts
+++ b/src/cli/helpers/approval-classification.ts
@@ -45,8 +45,9 @@ export type ClassifyApprovalsOptions<TContext = ApprovalContext | null> = {
 export async function getMissingRequiredArgs(
   toolName: string,
   parsedArgs: Record<string, unknown>,
+  toolContextId?: string | null,
 ): Promise<string[]> {
-  const schema = getToolSchema(toolName);
+  const schema = getToolSchema(toolName, toolContextId);
   const required =
     (schema?.input_schema?.required as string[] | undefined) || [];
   return required.filter(
@@ -100,6 +101,7 @@ export async function classifyApprovals<TContext = ApprovalContext | null>(
       const missingRequiredArgs = await getMissingRequiredArgs(
         toolName,
         parsedArgs,
+        opts.toolContextId,
       );
       if (missingRequiredArgs.length > 0) {
         const denyReason = opts.missingArgsReason

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -3208,13 +3208,19 @@ export function getToolSchemas(): ToolSchema[] {
  * @param name - The tool name
  * @returns The tool schema or undefined if not found
  */
-export function getToolSchema(name: string): ToolSchema | undefined {
-  const internalName = resolveInternalToolName(name);
+export function getToolSchema(
+  name: string,
+  toolContextId?: string | null,
+): ToolSchema | undefined {
+  const context = toolContextId
+    ? getExecutionContextById(toolContextId)
+    : undefined;
+  const registry = context?.toolRegistry ?? toolRegistry;
+  const internalName = resolveInternalToolName(name, registry);
   if (internalName) {
-    return withDynamicMessageChannelCache(toolRegistry).get(internalName)
-      ?.schema;
+    return withDynamicMessageChannelCache(registry).get(internalName)?.schema;
   }
-  const modTool = getModToolDefinition(name);
+  const modTool = context?.modTools.get(name) ?? getModToolDefinition(name);
   if (modTool) {
     return {
       name: modTool.name,
@@ -3222,7 +3228,8 @@ export function getToolSchema(name: string): ToolSchema | undefined {
       input_schema: modTool.parameters as JsonSchema,
     };
   }
-  const externalTool = getExternalToolDefinition(name);
+  const externalTool =
+    context?.externalTools.get(name) ?? getExternalToolDefinition(name);
   if (externalTool) {
     return {
       name: externalTool.name,


### PR DESCRIPTION
## Summary
- resolve approval validation schemas from the turn-scoped tool context before falling back to the global registry
- pass the approval tool context into required-arg validation
- add regression coverage for exec_command missing cmd when the global registry differs from the turn toolset

Follow-up to #3176.

## Test
- bun test src/cli/approval-classification.test.ts
- bun run check