### PR TITLE
feat(mods): expose conversation summary in context

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -2296,6 +2296,7 @@ export function App({
     currentDirectory: process.cwd(),
     projectDirectory,
     sessionId: conversationId,
+    conversationSummary,
     agentId,
     agentName,
     lastRunId: lastRunIdRef.current,

--- a/src/cli/cli-mod-context.test.ts
+++ b/src/cli/cli-mod-context.test.ts
@@ -13,6 +13,7 @@ describe("buildCliModContext", () => {
       currentDirectory: "/repo",
       projectDirectory: "/repo",
       sessionId: "conv-123",
+      conversationSummary: "Investigate mod context",
       agentId: "agent-123",
       agentName: "Test Agent",
       totalDurationMs: 10_000,
@@ -37,6 +38,7 @@ describe("buildCliModContext", () => {
     expect(context.workspace.currentDir).toBe("/repo");
     expect(context.workspace.projectDir).toBe("/repo");
     expect(context.sessionId).toBe("conv-123");
+    expect(context.conversationSummary).toBe("Investigate mod context");
     expect(context.agent.id).toBe("agent-123");
     expect(context.agent.name).toBe("Test Agent");
     expect(context.model.id).toBe("anthropic/claude-sonnet-4");
@@ -65,6 +67,7 @@ describe("buildCliModContext", () => {
     });
 
     expect(context.sessionId).toBeNull();
+    expect(context.conversationSummary).toBeNull();
     expect(context.lastRunId).toBeNull();
     expect(context.agent.id).toBeNull();
     expect(context.agent.name).toBeNull();

--- a/src/cli/components/mod-panel-row.test.ts
+++ b/src/cli/components/mod-panel-row.test.ts
@@ -11,6 +11,7 @@ const CONTEXT: ModContext = {
   },
   cwd: "/tmp/project",
   sessionId: "conv-1",
+  conversationSummary: "Investigate panel context",
   lastRunId: "run-1",
   agent: { id: "agent-1", name: "Amelia" },
   model: {
@@ -59,6 +60,7 @@ describe("renderModPanelLines", () => {
     const panel = createPanel((ctx) => {
       expect(ctx.cwd).toBe("/tmp/project");
       expect(ctx.workspace.currentDir).toBe("/tmp/project/src");
+      expect(ctx.conversationSummary).toBe("Investigate panel context");
       expect(ctx.agent.name).toBe("Amelia");
       expect(ctx.model.displayName).toBe("GPT-5.5");
       expect(ctx.width).toBe(40);

--- a/src/cli/helpers/cli-mod-context.ts
+++ b/src/cli/helpers/cli-mod-context.ts
@@ -11,6 +11,7 @@ export interface CliModContextBuildInput {
   currentDirectory: string;
   projectDirectory: string;
   sessionId?: string | null;
+  conversationSummary?: string | null;
   agentId?: string | null;
   agentName?: string | null;
   lastRunId?: string | null;
@@ -83,6 +84,7 @@ export function buildCliModContext(input: CliModContextBuildInput): ModContext {
     },
     cwd: input.currentDirectory,
     sessionId: input.sessionId ?? null,
+    conversationSummary: input.conversationSummary ?? null,
     lastRunId: input.lastRunId ?? null,
     agent: {
       id: input.agentId ?? null,

--- a/src/headless-mod-adapter.ts
+++ b/src/headless-mod-adapter.ts
@@ -77,6 +77,7 @@ export function createHeadlessModContext(options: {
     },
     cwd,
     sessionId: options.conversationId,
+    conversationSummary: null,
     lastRunId: options.lastRunId ?? null,
     agent: {
       id: options.agent.id,

--- a/src/mods/context.ts
+++ b/src/mods/context.ts
@@ -76,6 +76,7 @@ export function buildModInvocationContext(
     workspace,
     cwd,
     sessionId: options.conversationId ?? base?.sessionId ?? null,
+    conversationSummary: base?.conversationSummary ?? null,
     lastRunId: base?.lastRunId ?? null,
     agent: {
       id: options.agent?.id ?? base?.agent.id ?? null,

--- a/src/mods/learning-harness.ts
+++ b/src/mods/learning-harness.ts
@@ -493,6 +493,7 @@ function createAssertionModContext(repoRoot: string): ModContext {
     permissionMode: "standard",
     reflection: { mode: null, stepCount: 0 },
     sessionId: "mod-learning-eval-conversation",
+    conversationSummary: null,
     systemPromptId: null,
     terminalWidth: 80,
     toolset: "default",

--- a/src/mods/memory-citations-example.test.ts
+++ b/src/mods/memory-citations-example.test.ts
@@ -48,6 +48,7 @@ function createContext(memoryDir: string): ModContext {
     permissionMode: "standard",
     reflection: { mode: null, stepCount: 0 },
     sessionId: "conversation-1",
+    conversationSummary: null,
     systemPromptId: null,
     terminalWidth: 80,
     toolset: "default",

--- a/src/mods/mod-adapter.test.ts
+++ b/src/mods/mod-adapter.test.ts
@@ -57,6 +57,7 @@ function createModContext(agentName = "Amelia"): ModContext {
     permissionMode: "standard",
     reflection: { mode: null, stepCount: 0 },
     sessionId: "conversation-1",
+    conversationSummary: null,
     systemPromptId: null,
     terminalWidth: 80,
     toolset: "default",

--- a/src/mods/mod-engine.test.ts
+++ b/src/mods/mod-engine.test.ts
@@ -79,6 +79,7 @@ function createModContext(): ModContext {
     permissionMode: "standard",
     reflection: { mode: null, stepCount: 0 },
     sessionId: "conversation-1",
+    conversationSummary: null,
     systemPromptId: null,
     terminalWidth: 80,
     toolset: "default",

--- a/src/mods/types.ts
+++ b/src/mods/types.ts
@@ -430,6 +430,7 @@ export interface ModContext {
   workspace: ModWorkspaceContext;
   cwd: string;
   sessionId: string | null;
+  conversationSummary: string | null;
   lastRunId: string | null;
   agent: ModAgentContext;
   model: ModModelContext;


### PR DESCRIPTION
## Summary
- add `conversationSummary` to canonical ModContext
- populate it from the active CLI conversation summary
- preserve/null-fill the field in headless and test mod contexts

## Notes
- kept this as a top-level field to avoid overloading `ctx.conversation`, which is already the command/tool scoped conversation handle
- does not update published mods; this only exposes the host context field

## Tests
- bun test src/cli/cli-mod-context.test.ts src/cli/components/mod-panel-row.test.ts src/cli/statusline-renderer.test.tsx src/cli/mods/local-mod-loader.test.ts src/mods/mod-adapter.test.ts src/mods/mod-engine.test.ts src/mods/memory-citations-example.test.ts
- bun run check