### PR TITLE
feat(mods): support agent-scoped package installs

### DIFF
--- a/src/cli/mods/local-mod-loader.test.ts
+++ b/src/cli/mods/local-mod-loader.test.ts
@@ -227,6 +227,73 @@ describe("local mod loader", () => {
     }
   });
 
+  test("discovers managed package entries from the agent mods directory", () => {
+    const root = createTempDir();
+    try {
+      const { globalModsDirectory: globalMods } = createLoadOptions(root);
+      const agentMods = path.join(root, "memory", "mods");
+      const packageRoot = path.join(
+        agentMods,
+        "packages",
+        "npm",
+        "@caren",
+        "agent-mod",
+      );
+      const packageMod = path.join(packageRoot, "mods", "index.ts");
+      const agentModFile = path.join(agentMods, "agent.ts");
+      mkdirSync(globalMods, { recursive: true });
+      mkdirSync(path.dirname(packageMod), { recursive: true });
+      writeFileSync(agentModFile, "export default () => {};\n");
+      writeFileSync(packageMod, "export default () => {};\n");
+      writeFileSync(
+        path.join(packageRoot, "package.json"),
+        JSON.stringify({
+          letta: {
+            manifestVersion: 1,
+            mods: ["./mods/index.ts"],
+          },
+        }),
+      );
+      writeFileSync(
+        path.join(agentMods, "packages.json"),
+        JSON.stringify({
+          packages: [
+            {
+              source: "npm:@caren/agent-mod",
+              version: "0.1.0",
+              enabled: true,
+              root: "packages/npm/@caren/agent-mod",
+              entries: ["./mods/index.ts"],
+            },
+          ],
+        }),
+      );
+
+      expect(
+        resolveLocalModSources({
+          agentModsDirectory: agentMods,
+          globalModsDirectory: globalMods,
+        }),
+      ).toEqual([
+        {
+          files: [],
+          root: globalMods,
+          scope: "global",
+          trusted: true,
+        },
+        {
+          files: [agentModFile, packageMod],
+          managedPackageRoots: [packageRoot],
+          root: agentMods,
+          scope: "agent",
+          trusted: true,
+        },
+      ]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("skips disabled managed packages", () => {
     const root = createTempDir();
     try {

--- a/src/cli/mods/local-mod-loader.test.ts
+++ b/src/cli/mods/local-mod-loader.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
@@ -622,6 +623,89 @@ export default function(letta) {
         entry.startsWith(".letta-mod-index-"),
       );
       expect(generatedFiles).toHaveLength(1);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("loads agent managed package mods without writing import caches into memory", async () => {
+    const root = createTempDir();
+    try {
+      const options = createLoadOptions(root);
+      const agentMods = path.join(root, "memory", "mods");
+      const packageRoot = path.join(
+        agentMods,
+        "packages",
+        "npm",
+        "@caren",
+        "agent-dep-mod",
+      );
+      const modDir = path.join(packageRoot, "mods");
+      const dependencyRoot = path.join(packageRoot, "node_modules", "fake-dep");
+      mkdirSync(modDir, { recursive: true });
+      mkdirSync(dependencyRoot, { recursive: true });
+      writeFileSync(
+        path.join(modDir, "index.js"),
+        `import { label } from "fake-dep";
+export default function(letta) {
+  letta.ui.openPanel({ id: "agent-dep", render: () => label });
+}
+`,
+      );
+      writeFileSync(
+        path.join(dependencyRoot, "package.json"),
+        JSON.stringify({
+          name: "fake-dep",
+          version: "1.0.0",
+          type: "module",
+          exports: "./index.js",
+        }),
+      );
+      writeFileSync(
+        path.join(dependencyRoot, "index.js"),
+        `export const label = "agent dependency";\n`,
+      );
+      writeFileSync(
+        path.join(packageRoot, "package.json"),
+        JSON.stringify({
+          name: "@caren/agent-dep-mod",
+          version: "0.1.0",
+          letta: {
+            manifestVersion: 1,
+            mods: ["mods/index.js"],
+          },
+        }),
+      );
+      writeFileSync(
+        path.join(agentMods, "packages.json"),
+        JSON.stringify({
+          packages: [
+            {
+              source: "npm:@caren/agent-dep-mod",
+              version: "0.1.0",
+              enabled: true,
+              root: "packages/npm/@caren/agent-dep-mod",
+              entries: ["mods/index.js"],
+            },
+          ],
+        }),
+      );
+
+      const registry = await loadLocalMods({
+        ...options,
+        agentModsDirectory: agentMods,
+      });
+
+      expect(getModErrorDiagnostics(registry.diagnostics)).toEqual([]);
+      const panel = Object.values(registry.ui.panels)[0];
+      expect(panel?.render(renderCtx(80))).toBe("agent dependency");
+      const generatedFiles = readdirSync(modDir).filter((entry) =>
+        entry.startsWith(".letta-mod-index-"),
+      );
+      expect(generatedFiles).toHaveLength(0);
+      expect(
+        existsSync(path.join(options.cacheDirectory, "managed-packages")),
+      ).toBe(true);
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/src/cli/subcommands/mods.test.ts
+++ b/src/cli/subcommands/mods.test.ts
@@ -293,6 +293,38 @@ describe("mods subcommand", () => {
     );
   });
 
+  test("lists agent packages separately from harness packages", () => {
+    const root = createTempDir();
+    const harnessMods = join(root, "mods");
+    const agentMods = join(root, "memory", "mods");
+    mkdirSync(harnessMods, { recursive: true });
+    mkdirSync(agentMods, { recursive: true });
+    writeManagedPackage({
+      capabilities: ["commands"],
+      modsRoot: agentMods,
+      source: "npm:@caren/agent-mod",
+      root: "packages/npm/@caren/agent-mod",
+    });
+
+    const result = listMods({
+      agentModsDirectory: agentMods,
+      globalModsDirectory: harnessMods,
+    });
+
+    expect(result.agentPackages).toMatchObject([
+      {
+        capabilities: ["commands"],
+        enabled: true,
+        source: "npm:@caren/agent-mod",
+        version: "0.1.0",
+      },
+    ]);
+    expect(formatModsList(result)).toContain("Agent packages");
+    expect(formatModsList(result)).toContain(
+      "  enabled  npm:@caren/agent-mod@0.1.0    commands",
+    );
+  });
+
   test("lists package registry diagnostics", () => {
     const root = createTempDir();
     const harnessMods = join(root, "mods");

--- a/src/cli/subcommands/mods.ts
+++ b/src/cli/subcommands/mods.ts
@@ -28,6 +28,8 @@ interface ModFileSection {
 
 export interface ModsList {
   agent?: ModFileSection;
+  agentPackageDiagnostics: ManagedModPackageDiagnostic[];
+  agentPackages: ManagedModPackageListItem[];
   harness: ModFileSection;
   legacyHarness?: ModFileSection;
   packageDiagnostics: ManagedModPackageDiagnostic[];
@@ -143,9 +145,14 @@ export function listMods(options: ListModsOptions = {}): ModsList {
   const harness = sources.find((source) => source.scope === "global");
   const agent = sources.find((source) => source.scope === "agent");
   const managedPackages = listManagedModPackages(globalModsDirectory);
+  const agentManagedPackages = agentModsDirectory
+    ? listManagedModPackages(agentModsDirectory)
+    : null;
 
   return {
     ...(agent ? { agent: toSection(agent) } : {}),
+    agentPackageDiagnostics: agentManagedPackages?.diagnostics ?? [],
+    agentPackages: agentManagedPackages?.packages ?? [],
     harness: harness ? toSection(harness) : { files: [], root: "" },
     ...(legacyHarness ? { legacyHarness: toSection(legacyHarness) } : {}),
     packageDiagnostics: managedPackages.diagnostics,
@@ -171,9 +178,10 @@ function formatPackageSpecifier(pkg: ManagedModPackageListItem): string {
 }
 
 function formatInstalledPackagesSection(
+  title: string,
   mods: Pick<ModsList, "packageDiagnostics" | "packages">,
 ): string {
-  const lines = ["Installed packages"];
+  const lines = [title];
   if (mods.packages.length === 0 && mods.packageDiagnostics.length === 0) {
     lines.push("  (none)");
     return lines.join("\n");
@@ -199,13 +207,24 @@ export function formatModsList(mods: ModsList): string {
   if (mods.agent) {
     sections.push(formatModFileSection("Agent mods", mods.agent));
   }
+  if (
+    mods.agentPackages.length > 0 ||
+    mods.agentPackageDiagnostics.length > 0
+  ) {
+    sections.push(
+      formatInstalledPackagesSection("Agent packages", {
+        packageDiagnostics: mods.agentPackageDiagnostics,
+        packages: mods.agentPackages,
+      }),
+    );
+  }
   if (mods.legacyHarness) {
     sections.push(
       formatModFileSection("Legacy extensions", mods.legacyHarness),
     );
   }
   sections.push(formatModFileSection("Harness mods", mods.harness));
-  sections.push(formatInstalledPackagesSection(mods));
+  sections.push(formatInstalledPackagesSection("Installed packages", mods));
   return sections.join("\n\n");
 }
 

--- a/src/cli/subcommands/skills.test.ts
+++ b/src/cli/subcommands/skills.test.ts
@@ -633,6 +633,69 @@ describe("skills subcommand", () => {
     }
   });
 
+  test("top-level GitHub tree mod install installs into agent memory", async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "letta-install-test-"));
+    const consoleCapture = captureConsole();
+    try {
+      const memoryDir = join(tempRoot, "memory");
+      __testOverrideNpmManagedModPackageInstaller({
+        gitSpawnImpl: (_cmd, args) => {
+          if (args[0] === "clone") {
+            writeGitModPackage(
+              join(String(args.at(-1)), "packages", "control-room"),
+            );
+          }
+          const child = createChildProcess();
+          queueMicrotask(() => {
+            if (args[0] === "rev-parse") child.stdout?.emit("data", "abc123\n");
+            child.emit("exit", 0);
+          });
+          return child;
+        },
+      });
+
+      const exitCode = await runInstallSubcommand(
+        [
+          "--agent",
+          "agent-123",
+          "https://github.com/letta-ai/mods/tree/main/packages/control-room",
+        ],
+        {
+          agentMemoryDirectory: memoryDir,
+          commitAgentMemoryChanges: false,
+        },
+      );
+
+      expect(exitCode).toBe(0);
+      expect(consoleCapture.logs.join("\n")).toContain(
+        "Target: agent agent-123",
+      );
+      expect(
+        existsSync(
+          join(
+            memoryDir,
+            "mods",
+            "packages",
+            "git",
+            "github.com",
+            "letta-ai",
+            "mods",
+            "tree",
+            "main",
+            "packages",
+            "control-room",
+            "src",
+            "mod.ts",
+          ),
+        ),
+      ).toBe(true);
+      expect(consoleCapture.errors).toEqual([]);
+    } finally {
+      consoleCapture.restore();
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   test("top-level install installs unscoped npm mod packages", async () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "letta-install-test-"));
     const consoleCapture = captureConsole();

--- a/src/cli/subcommands/skills.test.ts
+++ b/src/cli/subcommands/skills.test.ts
@@ -344,23 +344,121 @@ describe("skills subcommand", () => {
     }
   });
 
-  test("top-level install rejects agent-scoped local mod package install", async () => {
+  test("top-level install installs local mod packages into agent memory", async () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "letta-install-test-"));
     const consoleCapture = captureConsole();
     try {
       const packageRoot = join(tempRoot, "package");
+      const memoryDir = join(tempRoot, "memory");
       writeLocalModPackage({ packageRoot });
 
-      const exitCode = await runInstallSubcommand([
-        "--agent",
-        "agent-123",
-        packageRoot,
-      ]);
-
-      expect(exitCode).toBe(1);
-      expect(consoleCapture.errors.join("\n")).toContain(
-        "Agent-scoped mod package install is not supported yet.",
+      const exitCode = await runInstallSubcommand(
+        ["--agent", "agent-123", packageRoot],
+        {
+          agentMemoryDirectory: memoryDir,
+          commitAgentMemoryChanges: false,
+        },
       );
+
+      expect(exitCode).toBe(0);
+      expect(consoleCapture.logs.join("\n")).toContain(
+        "Target: agent agent-123",
+      );
+      expect(
+        existsSync(
+          join(
+            memoryDir,
+            "mods",
+            "packages",
+            "npm",
+            "@caren",
+            "my-mod",
+            "mods",
+            "index.ts",
+          ),
+        ),
+      ).toBe(true);
+      expect(
+        JSON.parse(
+          readFileSync(join(memoryDir, "mods", "packages.json"), "utf8"),
+        ),
+      ).toEqual({
+        packages: [
+          {
+            source: "npm:@caren/my-mod",
+            version: "0.1.0",
+            enabled: true,
+            root: "packages/npm/@caren/my-mod",
+            entries: ["mods/index.ts"],
+          },
+        ],
+      });
+      expect(consoleCapture.errors).toEqual([]);
+    } finally {
+      consoleCapture.restore();
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("top-level install installs npm mod packages into agent memory", async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "letta-install-test-"));
+    const consoleCapture = captureConsole();
+    try {
+      const memoryDir = join(tempRoot, "memory");
+      __testOverrideNpmManagedModPackageInstaller({
+        spawnImpl: (_cmd, _args, options) => {
+          if (!options.cwd) throw new Error("expected cwd");
+          writeInstalledNpmModPackage({
+            cwd: options.cwd.toString(),
+            version: "0.2.0",
+          });
+          const child = createChildProcess();
+          queueMicrotask(() => child.emit("exit", 0));
+          return child;
+        },
+      });
+
+      const exitCode = await runInstallSubcommand(
+        ["npm:@caren/my-mod", "--agent", "agent-123"],
+        {
+          agentMemoryDirectory: memoryDir,
+          commitAgentMemoryChanges: false,
+        },
+      );
+
+      expect(exitCode).toBe(0);
+      expect(consoleCapture.logs.join("\n")).toContain(
+        "Target: agent agent-123",
+      );
+      expect(
+        existsSync(
+          join(
+            memoryDir,
+            "mods",
+            "packages",
+            "npm",
+            "@caren",
+            "my-mod",
+            "mods",
+            "index.ts",
+          ),
+        ),
+      ).toBe(true);
+      expect(
+        JSON.parse(
+          readFileSync(join(memoryDir, "mods", "packages.json"), "utf8"),
+        ),
+      ).toMatchObject({
+        packages: [
+          {
+            source: "npm:@caren/my-mod",
+            version: "0.2.0",
+            enabled: true,
+            root: "packages/npm/@caren/my-mod",
+          },
+        ],
+      });
+      expect(consoleCapture.errors).toEqual([]);
     } finally {
       consoleCapture.restore();
       await rm(tempRoot, { recursive: true, force: true });
@@ -482,21 +580,56 @@ describe("skills subcommand", () => {
     }
   });
 
-  test("top-level GitHub mod install rejects agent scope", async () => {
+  test("top-level GitHub mod install installs into agent memory", async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "letta-install-test-"));
     const consoleCapture = captureConsole();
     try {
-      const exitCode = await runInstallSubcommand([
-        "--agent",
-        "agent-123",
-        "git:github.com/caren/git-mod",
-      ]);
+      const memoryDir = join(tempRoot, "memory");
+      __testOverrideNpmManagedModPackageInstaller({
+        gitSpawnImpl: (_cmd, args) => {
+          if (args[0] === "clone") {
+            writeGitModPackage(String(args.at(-1)));
+          }
+          const child = createChildProcess();
+          queueMicrotask(() => {
+            if (args[0] === "rev-parse") child.stdout?.emit("data", "abc123\n");
+            child.emit("exit", 0);
+          });
+          return child;
+        },
+      });
 
-      expect(exitCode).toBe(1);
-      expect(consoleCapture.errors.join("\n")).toContain(
-        "Agent-scoped mod package install is not supported yet.",
+      const exitCode = await runInstallSubcommand(
+        ["--agent", "agent-123", "git:github.com/caren/git-mod"],
+        {
+          agentMemoryDirectory: memoryDir,
+          commitAgentMemoryChanges: false,
+        },
       );
+
+      expect(exitCode).toBe(0);
+      expect(consoleCapture.logs.join("\n")).toContain(
+        "Target: agent agent-123",
+      );
+      expect(
+        existsSync(
+          join(
+            memoryDir,
+            "mods",
+            "packages",
+            "git",
+            "github.com",
+            "caren",
+            "git-mod",
+            "src",
+            "mod.ts",
+          ),
+        ),
+      ).toBe(true);
+      expect(consoleCapture.errors).toEqual([]);
     } finally {
       consoleCapture.restore();
+      await rm(tempRoot, { recursive: true, force: true });
     }
   });
 
@@ -544,24 +677,6 @@ describe("skills subcommand", () => {
       expect(exitCode).toBe(1);
       expect(consoleCapture.errors.join("\n")).toContain(
         "--force is only supported for skill installs.",
-      );
-    } finally {
-      consoleCapture.restore();
-    }
-  });
-
-  test("top-level npm mod install rejects agent scope", async () => {
-    const consoleCapture = captureConsole();
-    try {
-      const exitCode = await runInstallSubcommand([
-        "--agent",
-        "agent-123",
-        "npm:@caren/my-mod",
-      ]);
-
-      expect(exitCode).toBe(1);
-      expect(consoleCapture.errors.join("\n")).toContain(
-        "Agent-scoped mod package install is not supported yet.",
       );
     } finally {
       consoleCapture.restore();

--- a/src/cli/subcommands/skills.ts
+++ b/src/cli/subcommands/skills.ts
@@ -77,6 +77,8 @@ type FetchSkillFile = (
 ) => ReturnType<typeof fetch>;
 
 interface RunInstallOptions {
+  agentMemoryDirectory?: string;
+  commitAgentMemoryChanges?: boolean;
   globalModsDirectory?: string;
 }
 
@@ -844,7 +846,12 @@ async function installSkill(
   }
 }
 
-async function getAgentMemoryDir(agentId: string): Promise<string> {
+async function getAgentMemoryDir(
+  agentId: string,
+  options: Pick<RunInstallOptions, "agentMemoryDirectory"> = {},
+): Promise<string> {
+  if (options.agentMemoryDirectory) return options.agentMemoryDirectory;
+
   if (isLocalAgentId(agentId)) {
     const { getLocalBackendMemoryFilesystemRoot } = await import(
       "@/backend/local/paths"
@@ -861,12 +868,15 @@ async function getAgentMemoryDir(agentId: string): Promise<string> {
   return getScopedMemoryFilesystemRoot(agentId);
 }
 
-async function commitSkillMemoryChange(params: {
+async function commitAgentMemoryChange(params: {
   agentId: string;
   memoryDir: string;
-  skillName: string;
+  pathspecs: string[];
   reason: string;
+  skip?: boolean;
 }): Promise<{ committed: boolean; sha?: string }> {
+  if (params.skip) return { committed: false };
+
   const { commitMemoryWrite } = await import("@/agent/memory-git");
   const { getBackend } = await import("@/backend");
 
@@ -882,7 +892,7 @@ async function commitSkillMemoryChange(params: {
 
   const result = await commitMemoryWrite({
     memoryDir: params.memoryDir,
-    pathspecs: [`skills/${params.skillName}`],
+    pathspecs: params.pathspecs,
     reason: params.reason,
     author: {
       agentId: params.agentId,
@@ -893,6 +903,35 @@ async function commitSkillMemoryChange(params: {
   });
 
   return { committed: result.committed, sha: result.sha };
+}
+
+async function commitSkillMemoryChange(params: {
+  agentId: string;
+  memoryDir: string;
+  skillName: string;
+  reason: string;
+}): Promise<{ committed: boolean; sha?: string }> {
+  return commitAgentMemoryChange({
+    agentId: params.agentId,
+    memoryDir: params.memoryDir,
+    pathspecs: [`skills/${params.skillName}`],
+    reason: params.reason,
+  });
+}
+
+async function commitAgentModMemoryChange(params: {
+  agentId: string;
+  memoryDir: string;
+  result: InstallLocalManagedModPackageResult;
+  skip?: boolean;
+}): Promise<{ committed: boolean; sha?: string }> {
+  return commitAgentMemoryChange({
+    agentId: params.agentId,
+    memoryDir: params.memoryDir,
+    pathspecs: ["mods/packages.json", `mods/${params.result.rootRelativePath}`],
+    reason: `chore(mods): install ${params.result.source}`,
+    skip: params.skip,
+  });
 }
 
 async function listSkills(agentId: string): Promise<{
@@ -947,13 +986,20 @@ function hasInstallAgentScope(
 
 function printManagedModPackageInstallResult(
   result: InstallLocalManagedModPackageResult,
-  options: { includeDetails?: boolean } = {},
+  options: {
+    agentId?: string;
+    commit?: { committed: boolean; sha?: string };
+    includeDetails?: boolean;
+  } = {},
 ): void {
   console.log(
     "Warning: mods are trusted local code and can execute on startup.",
   );
   if (options.includeDetails) {
     console.log(`Source: ${result.source}`);
+    if (options.agentId) {
+      console.log(`Target: agent ${options.agentId}`);
+    }
     if (result.repository) {
       console.log(`Repository: ${result.repository}`);
     }
@@ -962,7 +1008,32 @@ function printManagedModPackageInstallResult(
     }
   }
   console.log(`Installed ${result.source}@${result.version}`);
+  if (options.commit?.committed) {
+    console.log(
+      `Committed agent memory change ${options.commit.sha?.slice(0, 7) ?? ""}`.trim(),
+    );
+  }
   console.log("Run /reload in active sessions for changes to take effect.");
+}
+
+async function installAgentManagedModPackage(params: {
+  agentId: string;
+  install: (modsRoot: string) => Promise<InstallLocalManagedModPackageResult>;
+  options?: RunInstallOptions;
+}): Promise<{
+  commit: { committed: boolean; sha?: string };
+  result: InstallLocalManagedModPackageResult;
+}> {
+  const memoryDir = await getAgentMemoryDir(params.agentId, params.options);
+  const modsRoot = join(memoryDir, "mods");
+  const result = await params.install(modsRoot);
+  const commit = await commitAgentModMemoryChange({
+    agentId: params.agentId,
+    memoryDir,
+    result,
+    skip: params.options?.commitAgentMemoryChanges === false,
+  });
+  return { commit, result };
 }
 
 async function runInstall(
@@ -993,15 +1064,31 @@ async function runInstall(
   }
 
   if (specifier.startsWith("npm:")) {
-    if (hasInstallAgentScope(parsed.values)) {
-      console.error("Agent-scoped mod package install is not supported yet.");
-      return 1;
-    }
     if (parsed.values.force) {
       console.error("--force is only supported for skill installs.");
       return 1;
     }
     try {
+      if (hasInstallAgentScope(parsed.values)) {
+        const agentId = await initializeAndResolveAgent(
+          parsed.values,
+          `Installing ${specifier}...`,
+        );
+        const { commit, result } = await installAgentManagedModPackage({
+          agentId,
+          install: (modsRoot) =>
+            installNpmManagedModPackage({ modsRoot, specifier }),
+          options,
+        });
+        stopAgentPromptStatus();
+        printManagedModPackageInstallResult(result, {
+          agentId,
+          commit,
+          includeDetails: true,
+        });
+        return 0;
+      }
+
       const result = await installNpmManagedModPackage({
         modsRoot:
           options.globalModsDirectory ?? resolveDefaultGlobalModsDirectory(),
@@ -1010,6 +1097,7 @@ async function runInstall(
       printManagedModPackageInstallResult(result, { includeDetails: true });
       return 0;
     } catch (error) {
+      stopAgentPromptStatus();
       console.error(error instanceof Error ? error.message : String(error));
       return 1;
     }
@@ -1025,15 +1113,31 @@ async function runInstall(
     return 1;
   }
   if (gitPackageSpecifier) {
-    if (hasInstallAgentScope(parsed.values)) {
-      console.error("Agent-scoped mod package install is not supported yet.");
-      return 1;
-    }
     if (parsed.values.force) {
       console.error("--force is only supported for skill installs.");
       return 1;
     }
     try {
+      if (hasInstallAgentScope(parsed.values)) {
+        const agentId = await initializeAndResolveAgent(
+          parsed.values,
+          `Installing ${specifier}...`,
+        );
+        const { commit, result } = await installAgentManagedModPackage({
+          agentId,
+          install: (modsRoot) =>
+            installGitManagedModPackage({ modsRoot, specifier }),
+          options,
+        });
+        stopAgentPromptStatus();
+        printManagedModPackageInstallResult(result, {
+          agentId,
+          commit,
+          includeDetails: true,
+        });
+        return 0;
+      }
+
       const result = await installGitManagedModPackage({
         modsRoot:
           options.globalModsDirectory ?? resolveDefaultGlobalModsDirectory(),
@@ -1042,6 +1146,7 @@ async function runInstall(
       printManagedModPackageInstallResult(result, { includeDetails: true });
       return 0;
     } catch (error) {
+      stopAgentPromptStatus();
       console.error(error instanceof Error ? error.message : String(error));
       return 1;
     }
@@ -1049,11 +1154,30 @@ async function runInstall(
 
   const maybeLocalPath = resolve(specifier);
   if (isLocalLettaModPackageDirectory(maybeLocalPath)) {
-    if (hasInstallAgentScope(parsed.values)) {
-      console.error("Agent-scoped mod package install is not supported yet.");
-      return 1;
-    }
     try {
+      if (hasInstallAgentScope(parsed.values)) {
+        const agentId = await initializeAndResolveAgent(
+          parsed.values,
+          `Installing ${specifier}...`,
+        );
+        const { commit, result } = await installAgentManagedModPackage({
+          agentId,
+          install: async (modsRoot) =>
+            installLocalManagedModPackage({
+              modsRoot,
+              packageDirectory: maybeLocalPath,
+            }),
+          options,
+        });
+        stopAgentPromptStatus();
+        printManagedModPackageInstallResult(result, {
+          agentId,
+          commit,
+          includeDetails: true,
+        });
+        return 0;
+      }
+
       const result = installLocalManagedModPackage({
         modsRoot:
           options.globalModsDirectory ?? resolveDefaultGlobalModsDirectory(),
@@ -1062,6 +1186,7 @@ async function runInstall(
       printManagedModPackageInstallResult(result);
       return 0;
     } catch (error) {
+      stopAgentPromptStatus();
       console.error(error instanceof Error ? error.message : String(error));
       return 1;
     }

--- a/src/mods/mod-engine.ts
+++ b/src/mods/mod-engine.ts
@@ -552,13 +552,67 @@ function isPathInsideOrEqual(childPath: string, parentPath: string): boolean {
 
 function getManagedPackageImportCacheDirectory(
   modPath: string,
+  cacheDirectory: string,
   source: LocalModSource,
 ): string | null {
   const matchingRoot = source.managedPackageRoots?.find((packageRoot) =>
     isPathInsideOrEqual(modPath, packageRoot),
   );
   if (!matchingRoot) return null;
-  return path.dirname(modPath);
+  if (source.scope !== "agent") return path.dirname(modPath);
+
+  const packageRootHash = createHash("sha256")
+    .update(path.resolve(matchingRoot))
+    .digest("hex")
+    .slice(0, 16);
+  const packageCacheRoot = path.join(
+    cacheDirectory,
+    "managed-packages",
+    packageRootHash,
+  );
+  const packageNodeModules = path.join(matchingRoot, "node_modules");
+  if (existsSync(packageNodeModules)) {
+    mkdirSync(packageCacheRoot, { recursive: true });
+    const cacheNodeModules = path.join(packageCacheRoot, "node_modules");
+    try {
+      const stats = lstatSync(cacheNodeModules);
+      if (stats.isSymbolicLink()) {
+        const existingTarget = readlinkSync(cacheNodeModules);
+        const resolvedTarget = path.resolve(packageCacheRoot, existingTarget);
+        if (
+          normalizeRuntimeDependencyPath(resolvedTarget) !==
+          normalizeRuntimeDependencyPath(path.resolve(packageNodeModules))
+        ) {
+          unlinkSync(cacheNodeModules);
+          symlinkSync(
+            packageNodeModules,
+            cacheNodeModules,
+            process.platform === "win32" ? "junction" : "dir",
+          );
+        }
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      symlinkSync(
+        packageNodeModules,
+        cacheNodeModules,
+        process.platform === "win32" ? "junction" : "dir",
+      );
+    }
+  }
+
+  const relativeModDirectory = path.relative(
+    matchingRoot,
+    path.dirname(modPath),
+  );
+  if (
+    !relativeModDirectory ||
+    relativeModDirectory.startsWith("..") ||
+    path.isAbsolute(relativeModDirectory)
+  ) {
+    return packageCacheRoot;
+  }
+  return path.join(packageCacheRoot, relativeModDirectory);
 }
 
 function formatTranspileDiagnostic(diagnostic: ts.Diagnostic): string {
@@ -608,11 +662,11 @@ function createImportableModPath(
   cacheDirectory: string,
   source: LocalModSource,
 ): string {
+  ensureModCache(cacheDirectory);
   const importCacheDirectory =
-    getManagedPackageImportCacheDirectory(modPath, source) ?? cacheDirectory;
-  if (importCacheDirectory === cacheDirectory) {
-    ensureModCache(importCacheDirectory);
-  } else {
+    getManagedPackageImportCacheDirectory(modPath, cacheDirectory, source) ??
+    cacheDirectory;
+  if (importCacheDirectory !== cacheDirectory) {
     mkdirSync(importCacheDirectory, { recursive: true });
   }
 

--- a/src/mods/mod-engine.ts
+++ b/src/mods/mod-engine.ts
@@ -341,8 +341,23 @@ export function resolveLocalModSources(
   });
 
   if (options.agentModsDirectory) {
+    const agentManagedPackages = resolveManagedModPackages(
+      options.agentModsDirectory,
+    );
+    const agentDiagnostics = agentManagedPackages.diagnostics;
     sources.push({
-      files: listModFiles(options.agentModsDirectory),
+      ...(agentDiagnostics.length > 0 ? { diagnostics: agentDiagnostics } : {}),
+      files: [
+        ...listModFiles(options.agentModsDirectory),
+        ...agentManagedPackages.files,
+      ],
+      ...(agentManagedPackages.packages.length > 0
+        ? {
+            managedPackageRoots: agentManagedPackages.packages.map(
+              (pkg) => pkg.root,
+            ),
+          }
+        : {}),
       root: options.agentModsDirectory,
       scope: "agent",
       trusted: true,

--- a/src/mods/package-installer.test.ts
+++ b/src/mods/package-installer.test.ts
@@ -272,6 +272,19 @@ describe("local managed mod package installer", () => {
     ).toBeNull();
     expect(
       parseGitManagedModPackageInstallSpecifier(
+        "https://github.com/Caren/Mods/tree/main/packages/control-room",
+      ),
+    ).toMatchObject({
+      cloneUrl: "https://github.com/caren/mods.git",
+      owner: "caren",
+      ref: "main",
+      repo: "mods",
+      source:
+        "git:https://github.com/caren/mods/tree/main/packages/control-room",
+      subdir: "packages/control-room",
+    });
+    expect(
+      parseGitManagedModPackageInstallSpecifier(
         "https://gitlab.com/caren/my-mod",
       ),
     ).toBeNull();
@@ -1073,6 +1086,70 @@ describe("local managed mod package installer", () => {
     ]);
   });
 
+  test("installs a GitHub tree URL package subdirectory", async () => {
+    const root = createTempDir();
+    const modsRoot = path.join(root, "mods");
+    const gitCalls: Array<{ args: string[]; cwd?: string }> = [];
+    __testOverrideNpmManagedModPackageInstaller({
+      gitSpawnImpl: (_cmd, args, options) => {
+        gitCalls.push({ args, cwd: options.cwd?.toString() });
+        if (args[0] === "clone") {
+          const repoRoot = String(args.at(-1));
+          mkdirSync(path.join(repoRoot, "unrelated"), { recursive: true });
+          writeFileSync(
+            path.join(repoRoot, "unrelated", "file.ts"),
+            "ignored\n",
+          );
+          writeLocalPackage({
+            capabilities: ["commands"],
+            name: "@letta-ai/control-room",
+            packageRoot: path.join(repoRoot, "packages", "control-room"),
+          });
+        }
+        const child = createChildProcess();
+        queueMicrotask(() => {
+          if (args[0] === "rev-parse") {
+            child.stdout?.emit("data", "abc123\n");
+          }
+          child.emit("exit", 0);
+        });
+        return child;
+      },
+    });
+
+    const result = await installGitManagedModPackage({
+      modsRoot,
+      specifier:
+        "https://github.com/letta-ai/mods/tree/main/packages/control-room",
+    });
+
+    expect(gitCalls.map((call) => call.args)).toEqual([
+      ["clone", "https://github.com/letta-ai/mods.git", expect.any(String)],
+      ["checkout", "--detach", "main"],
+      ["rev-parse", "--short", "HEAD"],
+    ]);
+    expect(result).toMatchObject({
+      capabilities: ["commands"],
+      rootRelativePath:
+        "packages/git/github.com/letta-ai/mods/tree/main/packages/control-room",
+      source:
+        "git:https://github.com/letta-ai/mods/tree/main/packages/control-room",
+      version: "0.1.0",
+    });
+    expect(existsSync(path.join(result.root, "mods", "index.ts"))).toBe(true);
+    expect(existsSync(path.join(result.root, "unrelated"))).toBe(false);
+    expect(readRegistry(modsRoot).packages).toEqual([
+      {
+        source:
+          "git:https://github.com/letta-ai/mods/tree/main/packages/control-room",
+        version: "0.1.0",
+        enabled: true,
+        root: "packages/git/github.com/letta-ai/mods/tree/main/packages/control-room",
+        entries: ["mods/index.ts"],
+      },
+    ]);
+  });
+
   test("installs a compatibility GitHub package from src/mod.ts", async () => {
     const root = createTempDir();
     const modsRoot = path.join(root, "mods");
@@ -1209,7 +1286,7 @@ describe("local managed mod package installer", () => {
     expect(existsSync(path.join(modsRoot, "packages"))).toBe(false);
   });
 
-  test("git checkout uses -- separator to prevent option injection", async () => {
+  test("git checkout uses a validated ref to prevent option injection", async () => {
     const root = createTempDir();
     const modsRoot = path.join(root, "mods");
     const gitCalls: Array<{ args: string[]; cwd?: string }> = [];
@@ -1241,7 +1318,7 @@ describe("local managed mod package installer", () => {
 
     expect(gitCalls.map((call) => call.args)).toEqual([
       ["clone", "https://github.com/caren/git-mod.git", expect.any(String)],
-      ["checkout", "--", "v1.2.3"],
+      ["checkout", "--detach", "v1.2.3"],
       ["rev-parse", "--short", "HEAD"],
     ]);
   });

--- a/src/mods/package-installer.ts
+++ b/src/mods/package-installer.ts
@@ -70,6 +70,7 @@ export interface GitManagedModPackageInstallSpecifier {
   repo: string;
   repository: string;
   source: string;
+  subdir?: string;
 }
 
 interface PackageSourceInfo {
@@ -695,10 +696,40 @@ function splitGitRef(value: string): { ref?: string; source: string } {
   return { source: value };
 }
 
+function assertValidGitRef(ref: string): void {
+  if (!/^[a-z0-9][a-z0-9._/-]*$/i.test(ref)) {
+    throw new Error(`Invalid git ref: ${ref}`);
+  }
+}
+
+function normalizeGitHubTreeSubdir(parts: string[]): string | undefined {
+  if (parts.length === 0) return undefined;
+  if (
+    parts.some(
+      (part) => !part || part === "." || part === ".." || part.includes("\0"),
+    )
+  ) {
+    return undefined;
+  }
+  if (parts[0] !== "packages") return undefined;
+  const normalized = path.posix.normalize(parts.join("/"));
+  if (
+    !normalized ||
+    normalized === "." ||
+    normalized === ".." ||
+    normalized.startsWith("../") ||
+    normalized.split("/").includes("..")
+  ) {
+    return undefined;
+  }
+  return normalized;
+}
+
 function normalizeGitHubInstallSource(params: {
   owner: string;
   ref?: string;
   repo: string;
+  subdir?: string;
 }): GitManagedModPackageInstallSpecifier {
   const owner = params.owner.toLowerCase();
   const repo = stripGitSuffix(params.repo).toLowerCase();
@@ -709,13 +740,17 @@ function normalizeGitHubInstallSource(params: {
     throw new Error(`Invalid GitHub repository: ${params.repo}`);
   }
   const repository = `https://github.com/${owner}/${repo}`;
+  const treeSource = params.subdir
+    ? `${repository}/tree/${params.ref ?? "HEAD"}/${params.subdir}`
+    : repository;
   return {
     cloneUrl: `${repository}.git`,
     owner,
     ...(params.ref ? { ref: params.ref } : {}),
     repo,
     repository,
-    source: `git:${repository}`,
+    source: `git:${treeSource}`,
+    ...(params.subdir ? { subdir: params.subdir } : {}),
   };
 }
 
@@ -734,11 +769,19 @@ function parseGitHubHttpsInstallSource(
   }
   if (url.username || url.password || url.search || url.hash) return null;
   const parts = url.pathname.split("/").filter(Boolean);
-  if (parts.length !== 2) return null;
+  if (parts.length !== 2 && (parts.length < 5 || parts[2] !== "tree")) {
+    return null;
+  }
+  const treeRef = parts[2] === "tree" ? parts[3] : undefined;
+  const treeSubdir =
+    parts[2] === "tree" ? normalizeGitHubTreeSubdir(parts.slice(4)) : undefined;
+  if (parts[2] === "tree" && (!treeRef || !treeSubdir)) return null;
+  if (treeRef) assertValidGitRef(treeRef);
   return normalizeGitHubInstallSource({
     owner: parts[0] ?? "",
-    ...(ref ? { ref } : {}),
+    ...(treeRef || ref ? { ref: ref ?? treeRef } : {}),
     repo: parts[1] ?? "",
+    ...(treeSubdir ? { subdir: treeSubdir } : {}),
   });
 }
 
@@ -988,6 +1031,24 @@ function createGitPackageSourceInfo(params: {
   };
 }
 
+function resolveGitPackageDirectory(params: {
+  parsed: GitManagedModPackageInstallSpecifier;
+  repoDirectory: string;
+}): string {
+  if (!params.parsed.subdir) return params.repoDirectory;
+  const resolvedRepoDirectory = path.resolve(params.repoDirectory);
+  const resolvedPackageDirectory = path.resolve(
+    resolvedRepoDirectory,
+    ...params.parsed.subdir.split("/"),
+  );
+  if (!isPathInsideOrEqual(resolvedPackageDirectory, resolvedRepoDirectory)) {
+    throw new Error(
+      `Invalid GitHub package subdirectory: ${params.parsed.subdir}`,
+    );
+  }
+  return resolvedPackageDirectory;
+}
+
 function getGitExecutable(): string {
   return "git";
 }
@@ -1024,7 +1085,7 @@ async function checkoutGitPackage(params: {
   await runGit(cloneArgs, params.tempRoot);
   if (params.parsed.ref) {
     await runGit(
-      ["checkout", "--", params.parsed.ref],
+      ["checkout", "--detach", params.parsed.ref],
       params.packageDirectory,
     );
   }
@@ -1080,11 +1141,15 @@ export async function installGitManagedModPackage(params: {
   }
   const tempRoot = mkdtempSync(path.join(tmpdir(), "letta-mod-git-"));
   try {
-    const packageDirectory = path.join(tempRoot, "repo");
+    const repoDirectory = path.join(tempRoot, "repo");
     const revision = await checkoutGitPackage({
-      packageDirectory,
+      packageDirectory: repoDirectory,
       parsed,
       tempRoot,
+    });
+    const packageDirectory = resolveGitPackageDirectory({
+      parsed,
+      repoDirectory,
     });
     const packageJson = readPackageJsonIfExists(packageDirectory);
     if (hasRuntimeDependencies(packageJson)) {
@@ -1158,11 +1223,15 @@ export async function updateGitManagedModPackage(params: {
   }).package;
   const tempRoot = mkdtempSync(path.join(tmpdir(), "letta-mod-git-"));
   try {
-    const packageDirectory = path.join(tempRoot, "repo");
+    const repoDirectory = path.join(tempRoot, "repo");
     const revision = await checkoutGitPackage({
-      packageDirectory,
+      packageDirectory: repoDirectory,
       parsed,
       tempRoot,
+    });
+    const packageDirectory = resolveGitPackageDirectory({
+      parsed,
+      repoDirectory,
     });
     const packageJson = readPackageJsonIfExists(packageDirectory);
     if (hasRuntimeDependencies(packageJson)) {

--- a/src/mods/package-registry.test.ts
+++ b/src/mods/package-registry.test.ts
@@ -102,6 +102,13 @@ describe("managed mod package registry", () => {
         "git:https://github.com/caren/my-mod",
       ),
     ).toBe("packages/git/github.com/caren/my-mod");
+    expect(
+      getManagedModPackageRootRelativePathForSource(
+        "git:https://github.com/caren/mods/tree/main/packages/control-room",
+      ),
+    ).toBe(
+      "packages/git/github.com/caren/mods/tree/main/packages/control-room",
+    );
 
     for (const source of [
       "npm:@caren",
@@ -111,6 +118,7 @@ describe("managed mod package registry", () => {
       "npm:",
       "git:https://github.com/caren",
       "git:https://gitlab.com/caren/my-mod",
+      "git:https://github.com/caren/mods/tree/main",
       "path:my-mod",
     ]) {
       expect(getManagedModPackageRootRelativePathForSource(source)).toBeNull();

--- a/src/mods/package-registry.ts
+++ b/src/mods/package-registry.ts
@@ -697,6 +697,7 @@ export function parseManagedNpmPackageSource(source: string): string | null {
 export interface ManagedGitPackageSource {
   host: "github.com";
   owner: string;
+  pathParts: string[];
   repo: string;
 }
 
@@ -713,15 +714,19 @@ export function parseManagedGitPackageSource(
   const normalizedRepoPath = normalizeRelativePath(repoPath);
   if (!normalizedRepoPath) return null;
   const parts = normalizedRepoPath.split("/");
-  if (parts.length !== 2) return null;
+  if (parts.length !== 2 && (parts.length < 5 || parts[2] !== "tree")) {
+    return null;
+  }
   const [owner, repo] = parts;
   if (!owner || !repo) return null;
   if (!isValidGitHubPathPart(owner) || !isValidGitHubPathPart(repo)) {
     return null;
   }
+  const pathParts = parts.length > 2 ? parts.slice(2) : [];
   return {
     host: "github.com",
     owner: owner.toLowerCase(),
+    pathParts,
     repo: repo.toLowerCase(),
   };
 }
@@ -733,7 +738,14 @@ export function getManagedModPackageRootRelativePathForSource(
   if (packageName) return `${MOD_PACKAGES_DIRECTORY_NAME}/npm/${packageName}`;
   const gitSource = parseManagedGitPackageSource(source);
   if (gitSource) {
-    return `${MOD_PACKAGES_DIRECTORY_NAME}/git/${gitSource.host}/${gitSource.owner}/${gitSource.repo}`;
+    return [
+      MOD_PACKAGES_DIRECTORY_NAME,
+      "git",
+      gitSource.host,
+      gitSource.owner,
+      gitSource.repo,
+      ...gitSource.pathParts,
+    ].join("/");
   }
   return null;
 }


### PR DESCRIPTION
## Summary

Adds agent-scoped managed mod package support for `letta install --agent`:

- installs npm, local, GitHub repo, and GitHub tree package-directory mod packages into the target agent MemFS under `mods/`
- commits changed agent memory paths after install
- loads agent-scoped managed package entries from `$MEMORY_DIR/mods/packages.json`
- keeps transient import caches for agent package mods out of committed MemFS package directories
- shows agent packages separately in `letta mods list --agent`

## Why

Global managed mod packages could be installed and loaded, but agent-scoped package installs were rejected. That meant package mods such as the packages in `letta-ai/mods` could not be installed cleanly for a single agent without a direct shim file.

## Behavior

Examples now covered:

- `letta install --agent <agent-id> npm:@letta-ai/some-mod`
- `letta install --agent <agent-id> ./path/to/package`
- `letta install --agent <agent-id> https://github.com/owner/repo`
- `letta install --agent <agent-id> https://github.com/letta-ai/mods/tree/main/packages/control-room`

GitHub tree mod installs are intentionally limited to package-directory links under `packages/...` so normal GitHub tree URLs can still be used for skill installs.

## Validation

- `bun test src/mods/package-installer.test.ts src/mods/package-registry.test.ts src/cli/subcommands/skills.test.ts src/cli/subcommands/mods.test.ts src/cli/mods/local-mod-loader.test.ts`
- `bun run lint`
- `bun run typecheck`
- commit hooks reran biome on staged files, layer checks, and `tsc --noEmit`
