### PR TITLE
fix(reflection): gate queued step-count launches

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -3666,11 +3666,12 @@ export function App({
       return;
     }
     try {
+      const reflectionSettings = getReflectionSettings(reflectionAgentId);
       await maybeLaunchPostTurnReflection({
         agentId: reflectionAgentId,
         conversationId: conversationIdRef.current ?? "default",
         memfsEnabled: isActiveMemfsEnabled(reflectionAgentId),
-        reflectionSettings: getReflectionSettings(reflectionAgentId),
+        reflectionSettings,
         reminderState: sharedReminderStateRef.current,
         contextTracker: contextTrackerRef.current,
         launch: async (triggerSource) => {
@@ -3679,6 +3680,7 @@ export function App({
             conversationId: conversationIdRef.current ?? "default",
             memfsEnabled: isActiveMemfsEnabled(reflectionAgentId),
             triggerSource,
+            reflectionSettings,
             description: AUTO_REFLECTION_DESCRIPTION,
             completionConversationId: () => conversationIdRef.current,
             recompileByConversation:

--- a/src/cli/helpers/reflection-launcher.test.ts
+++ b/src/cli/helpers/reflection-launcher.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  type ReflectionLaunchOptions,
+  shouldRunQueuedReflectionLaunch,
+} from "@/cli/helpers/reflection-launcher";
+import {
+  REFLECTION_STATE_SCHEMA_VERSION,
+  type ReflectionTranscriptState,
+} from "@/cli/helpers/reflection-transcript";
+
+function queuedLaunchOptions(
+  overrides: Partial<ReflectionLaunchOptions> = {},
+): ReflectionLaunchOptions {
+  return {
+    agentId: "agent-1",
+    conversationId: "conv-1",
+    memfsEnabled: true,
+    triggerSource: "step-count",
+    reflectionSettings: { trigger: "step-count", stepCount: 25 },
+    description: "Reflect on recent conversations",
+    recompileByConversation: new Map(),
+    recompileQueuedByConversation: new Set(),
+    ...overrides,
+  };
+}
+
+function transcriptState(
+  stepsSinceLastSuccessfulReflection: number,
+): ReflectionTranscriptState {
+  return {
+    schema_version: REFLECTION_STATE_SCHEMA_VERSION,
+    total_completed_steps: stepsSinceLastSuccessfulReflection,
+    reflected_completed_steps: 0,
+    steps_since_last_successful_reflection: stepsSinceLastSuccessfulReflection,
+  };
+}
+
+describe("shouldRunQueuedReflectionLaunch", () => {
+  test("skips queued step-count launches when the threshold is no longer met", async () => {
+    const getTranscriptState = mock(async () => transcriptState(1));
+
+    const shouldRun = await shouldRunQueuedReflectionLaunch(
+      queuedLaunchOptions(),
+      { getTranscriptState },
+    );
+
+    expect(shouldRun).toBe(false);
+    expect(getTranscriptState).toHaveBeenCalledWith("agent-1", "conv-1");
+  });
+
+  test("runs queued step-count launches when the threshold is still met", async () => {
+    const getTranscriptState = mock(async () => transcriptState(25));
+
+    const shouldRun = await shouldRunQueuedReflectionLaunch(
+      queuedLaunchOptions(),
+      { getTranscriptState },
+    );
+
+    expect(shouldRun).toBe(true);
+  });
+
+  test("does not re-check non-step-count queued launches", async () => {
+    const getTranscriptState = mock(async () => transcriptState(0));
+
+    const shouldRun = await shouldRunQueuedReflectionLaunch(
+      queuedLaunchOptions({ triggerSource: "compaction-event" }),
+      { getTranscriptState },
+    );
+
+    expect(shouldRun).toBe(true);
+    expect(getTranscriptState).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/helpers/reflection-launcher.ts
+++ b/src/cli/helpers/reflection-launcher.ts
@@ -1,13 +1,19 @@
 import { getScopedMemoryFilesystemRoot } from "@/agent/memory-filesystem";
 import { getSubagents } from "@/agent/subagent-state";
 import { getBackend } from "@/backend";
-import type { ReflectionTrigger } from "@/cli/helpers/memory-reminder";
+import {
+  getReflectionSettings,
+  type ReflectionSettings,
+  type ReflectionTrigger,
+  shouldFireStepCountTrigger,
+} from "@/cli/helpers/memory-reminder";
 import { handleMemorySubagentCompletion } from "@/cli/helpers/memory-subagent-completion";
 import {
   buildAutoReflectionPayload,
   buildParentMemorySnapshot,
   buildReflectionSubagentPrompt,
   finalizeAutoReflectionPayload,
+  getReflectionTranscriptState,
 } from "@/cli/helpers/reflection-transcript";
 import { telemetry } from "@/telemetry";
 import { maybeSendReflectionThresholdFeedback } from "@/telemetry/reflection-threshold-feedback";
@@ -60,6 +66,7 @@ export interface ReflectionLaunchOptions {
   conversationId: string;
   memfsEnabled: boolean;
   triggerSource: ReflectionLaunchTriggerSource;
+  reflectionSettings?: ReflectionSettings;
   description: string;
   instruction?: string;
   systemPrompt?: string;
@@ -118,13 +125,53 @@ function queuePendingReflectionLaunch(options: ReflectionLaunchOptions): void {
   );
 }
 
+export async function shouldRunQueuedReflectionLaunch(
+  options: ReflectionLaunchOptions,
+  deps: {
+    getTranscriptState?: typeof getReflectionTranscriptState;
+    getSettings?: typeof getReflectionSettings;
+  } = {},
+): Promise<boolean> {
+  if (options.triggerSource !== "step-count") {
+    return true;
+  }
+
+  const settings =
+    options.reflectionSettings ??
+    (deps.getSettings ?? getReflectionSettings)(options.agentId);
+  const readTranscriptState =
+    deps.getTranscriptState ?? getReflectionTranscriptState;
+  const transcriptState = await readTranscriptState(
+    options.agentId,
+    options.conversationId,
+  );
+  const shouldLaunch = shouldFireStepCountTrigger(
+    transcriptState.steps_since_last_successful_reflection,
+    settings,
+  );
+
+  if (!shouldLaunch) {
+    debugLog(
+      "memory",
+      `Skipping queued reflection launch (${options.triggerSource}) because the trigger threshold is no longer met`,
+    );
+  }
+
+  return shouldLaunch;
+}
+
 function schedulePendingReflectionLaunch(agentId: string): void {
   const pendingOptions = pendingReflectionLaunches.get(agentId);
   if (!pendingOptions) return;
   pendingReflectionLaunches.delete(agentId);
 
   queueMicrotask(() => {
-    void launchReflectionSubagent(pendingOptions).catch((error) => {
+    void (async () => {
+      if (!(await shouldRunQueuedReflectionLaunch(pendingOptions))) {
+        return;
+      }
+      await launchReflectionSubagent(pendingOptions);
+    })().catch((error) => {
       debugWarn(
         "memory",
         `Failed to launch queued reflection (${pendingOptions.triggerSource}): ${

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -3287,6 +3287,7 @@ async function runBidirectionalMode(
       conversationId,
       memfsEnabled: settingsManager.isMemfsEnabled(agent.id),
       triggerSource,
+      reflectionSettings,
       description: AUTO_REFLECTION_DESCRIPTION,
       systemPrompt: agent.system ?? undefined,
       recompileByConversation: systemPromptRecompileByConversation,

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -39,6 +39,7 @@ import {
 import { getRetryStatusMessage } from "@/cli/helpers/error-formatter";
 import {
   getReflectionSettings,
+  type ReflectionSettings,
   type ReflectionTrigger,
 } from "@/cli/helpers/memory-reminder";
 import { maybeLaunchPostTurnReflection } from "@/cli/helpers/post-turn-reflection";
@@ -309,10 +310,18 @@ export function buildMaybeLaunchReflectionSubagent(params: {
   socket: ListenerTransport;
   agentId: string;
   conversationId: string;
+  reflectionSettings?: ReflectionSettings;
   cachedAgent?: AgentState | null;
 }): (triggerSource: Exclude<ReflectionTrigger, "off">) => Promise<boolean> {
   return async (triggerSource) => {
-    const { runtime, socket, agentId, conversationId, cachedAgent } = params;
+    const {
+      runtime,
+      socket,
+      agentId,
+      conversationId,
+      reflectionSettings,
+      cachedAgent,
+    } = params;
 
     if (!agentId) {
       return false;
@@ -323,6 +332,7 @@ export function buildMaybeLaunchReflectionSubagent(params: {
       conversationId,
       memfsEnabled: settingsManager.isMemfsEnabled(agentId),
       triggerSource,
+      reflectionSettings,
       description: AUTO_REFLECTION_DESCRIPTION,
       systemPrompt: cachedAgent?.system ?? undefined,
       recompileByConversation:
@@ -951,6 +961,7 @@ export async function handleIncomingMessage(
               socket,
               agentId: agentId || "",
               conversationId,
+              reflectionSettings,
               cachedAgent,
             }),
           });


### PR DESCRIPTION
## Summary

- Re-check step-count reflection thresholds before running a queued launch
- Preserve queued manual/compaction behavior
- Pass the resolved reflection settings through post-turn launchers so queued checks use the same settings context
- Add regression tests for stale queued step-count launches

## Tests

- `bun test src/cli/helpers/reflection-launcher.test.ts src/cli/helpers/post-turn-reflection.test.ts`
- `bun run typecheck`
- `bun run check`