### PR TITLE
feat(listener): send stable listenerInstanceId when registering environments

### DIFF
--- a/src/cli/commands/listen.ts
+++ b/src/cli/commands/listen.ts
@@ -9,7 +9,10 @@ import type { Buffers, Line } from "@/cli/helpers/accumulator";
 import { buildAgentReference } from "@/cli/helpers/app-urls";
 import { settingsManager } from "@/settings-manager";
 import { getErrorMessage } from "@/utils/error";
-import { registerWithCloudRetry } from "@/websocket/listen-register";
+import {
+  deriveListenerInstanceId,
+  registerWithCloudRetry,
+} from "@/websocket/listen-register";
 
 // tiny helper for unique ids
 function uid(prefix: string) {
@@ -231,6 +234,10 @@ export async function handleListen(
           apiKey,
           deviceId,
           connectionName,
+          listenerInstanceId: deriveListenerInstanceId(
+            "listen",
+            connectionName,
+          ),
         },
         {
           onRetry: (attempt, delayMs, error) => {
@@ -342,7 +349,16 @@ export async function handleListen(
 
           try {
             const reregisterResult = await registerWithCloudRetry(
-              { serverUrl, apiKey, deviceId, connectionName },
+              {
+                serverUrl,
+                apiKey,
+                deviceId,
+                connectionName,
+                listenerInstanceId: deriveListenerInstanceId(
+                  "listen",
+                  connectionName,
+                ),
+              },
               {
                 maxDurationMs: Infinity,
                 onRetry: (attempt, delayMs, error) => {

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -29,6 +29,7 @@ import { settingsManager } from "@/settings-manager";
 import { getListenerTelemetrySurface, telemetry } from "@/telemetry";
 import { RemoteSessionLog } from "@/websocket/listen-log";
 import {
+  deriveListenerInstanceId,
   type RegisterOptions,
   registerWithCloudRetry,
 } from "@/websocket/listen-register";
@@ -304,6 +305,7 @@ async function resolveListenerRegistrationOptions(
       apiKey: envApiKey,
       deviceId,
       connectionName,
+      listenerInstanceId: deriveListenerInstanceId("server", connectionName),
     };
   }
 
@@ -346,6 +348,7 @@ async function resolveListenerRegistrationOptions(
     apiKey,
     deviceId,
     connectionName,
+    listenerInstanceId: deriveListenerInstanceId("server", connectionName),
   };
 }
 

--- a/src/websocket/listen-register.test.ts
+++ b/src/websocket/listen-register.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import {
+  deriveListenerInstanceId,
   registerWithCloud,
   registerWithCloudRetry,
 } from "@/websocket/listen-register";
@@ -62,6 +63,34 @@ describe("registerWithCloud", () => {
         nodeVersion: expect.any(String),
       },
     });
+    // Not provided → omitted so legacy servers see an unchanged payload
+    expect(body).not.toHaveProperty("listenerInstanceId");
+  });
+
+  it("includes listenerInstanceId in the payload when provided", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ connectionId: "conn-1", wsUrl: "wss://example.com" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await registerWithCloud(
+      {
+        ...defaultOpts,
+        listenerInstanceId: deriveListenerInstanceId("server", "test-machine"),
+      },
+      mockFetch as unknown as typeof fetch,
+    );
+
+    const [, init] = mockFetch.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    const body = JSON.parse(init.body as string);
+    expect(body.listenerInstanceId).toBe(
+      deriveListenerInstanceId("server", "test-machine"),
+    );
   });
 
   it("returns advertised split-channel support when present", async () => {
@@ -269,5 +298,25 @@ describe("registerWithCloud", () => {
     });
 
     expect(slept).toEqual([1125]);
+  });
+});
+
+describe("deriveListenerInstanceId", () => {
+  it("is deterministic for the same surface and name", () => {
+    expect(deriveListenerInstanceId("server", "mac-mini")).toBe(
+      deriveListenerInstanceId("server", "mac-mini"),
+    );
+  });
+
+  it("differs across surfaces and across names", () => {
+    const server = deriveListenerInstanceId("server", "mac-mini");
+    expect(deriveListenerInstanceId("listen", "mac-mini")).not.toBe(server);
+    expect(deriveListenerInstanceId("server", "other-name")).not.toBe(server);
+  });
+
+  it("produces a compact prefixed id", () => {
+    expect(deriveListenerInstanceId("server", "mac-mini")).toMatch(
+      /^server-[0-9a-f]{16}$/,
+    );
   });
 });

--- a/src/websocket/listen-register.ts
+++ b/src/websocket/listen-register.ts
@@ -3,6 +3,7 @@
  * Owns the HTTP request contract and error handling; callers own UX strings and logging.
  */
 
+import { createHash } from "node:crypto";
 import { getSelfUpdateStatus } from "@/updater/auto-update";
 import { getVersion } from "@/version.ts";
 import { SUPPORTED_REMOTE_COMMANDS } from "./listener/listener-constants";
@@ -18,6 +19,35 @@ export interface RegisterOptions {
   apiKey: string;
   deviceId: string;
   connectionName: string;
+  /**
+   * Stable identifier for this listener process, so multiple listeners on
+   * one device (e.g. `letta server` in a terminal plus the in-app /listen
+   * command) get separate Cloud environment rows instead of contesting a
+   * single per-device row and rotating each other's connection lease.
+   * Optional: servers that predate the field ignore it.
+   */
+  listenerInstanceId?: string;
+}
+
+/**
+ * Derive a stable listener instance id from the listener surface and its
+ * connection name. Deterministic (no stored state): the same surface + name
+ * maps to the same instance across restarts, while a rename creates a new
+ * instance (the old row ages out server-side via lastSeenAt).
+ *
+ * Surfaces:
+ * - "server": `letta server` CLI process
+ * - "listen": in-app /listen command
+ */
+export function deriveListenerInstanceId(
+  surface: "server" | "listen",
+  connectionName: string,
+): string {
+  const nameHash = createHash("sha256")
+    .update(connectionName)
+    .digest("hex")
+    .slice(0, 16);
+  return `${surface}-${nameHash}`;
 }
 
 type FetchImpl = typeof fetch;
@@ -90,6 +120,9 @@ export async function registerWithCloud(
     },
     body: JSON.stringify({
       deviceId: opts.deviceId,
+      ...(opts.listenerInstanceId
+        ? { listenerInstanceId: opts.listenerInstanceId }
+        : {}),
       connectionName: opts.connectionName,
       metadata: {
         lettaCodeVersion: getVersion(),


### PR DESCRIPTION
## Summary

Client half of letta-ai/letta-cloud#12720 (which is the server half of the interrupted-long-jobs fix, alongside the lease hotfix letta-ai/letta-cloud#12716).

Cloud now scopes environment identity to `(org, device, listenerInstanceId)` so multiple listener processes on one device — a `letta server` terminal plus the in-app `/listen` command — get **separate environment rows** instead of contesting one per-device row and rotating each other's connection lease (the collision that interrupted long-running Slack jobs).

## Changes
- `deriveListenerInstanceId(surface, connectionName)`: deterministic sha256-based id (`server-<hash16>` / `listen-<hash16>`). Stable across restarts with no stored state; a rename creates a new instance and the old row ages out server-side.
- `letta server` registration (`src/cli/subcommands/listen.tsx`) and the `/listen` command (`src/cli/commands/listen.ts`) — including both re-register paths — now send it.
- Field is omitted when absent, so servers that predate it see a byte-identical request. **Safe to merge/deploy in either order relative to the cloud PR** — until both sides are live, everything collapses to the `default` instance (current behavior).

## Test plan
- [x] New tests: payload includes the id when provided / omits it otherwise; derive fn is deterministic, surface- and name-distinct, compact format
- [x] `bun test src/websocket`: my suites green; 4 pre-existing failures confirmed identical on clean tree (EPERM sandbox + app-server native ws)
- [x] `bun run lint` + `tsc --noEmit` clean
- [ ] After both PRs deploy: run `letta server` + `/listen` on one device, confirm two environment rows with independent leases

👾 Generated with [Letta Code](https://letta.com)