### PR TITLE
refactor(channels): per-turn progress state, structured titles, unified sanitizers

### DIFF
--- a/src/channels/progress.test.ts
+++ b/src/channels/progress.test.ts
@@ -1,26 +1,20 @@
-import { beforeEach, expect, test } from "bun:test";
+import { expect, test } from "bun:test";
 import {
-  buildChannelTurnProgressUpdatesFromDelta,
-  clearToolCallArgumentsCache,
+  createChannelTurnProgressBuilder,
   sanitizeChannelProgressText,
 } from "@/channels/progress";
 import type { StreamDelta } from "@/types/protocol_v2";
 
-beforeEach(() => {
-  clearToolCallArgumentsCache();
-});
-
 test("channel progress converts tool call deltas without leaking args", () => {
-  const updates = buildChannelTurnProgressUpdatesFromDelta({
+  const builder = createChannelTurnProgressBuilder();
+  const updates = builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
     tool_calls: [
       {
-        id: "call-1",
-        function: {
-          name: "shell_exec",
-          arguments: "token=super-secret @channel",
-        },
+        tool_call_id: "call-1",
+        name: "shell_exec",
+        arguments: "token=super-secret @channel",
       },
     ],
   } as unknown as StreamDelta);
@@ -33,25 +27,23 @@ test("channel progress converts tool call deltas without leaking args", () => {
       runId: "run-1",
       toolCallId: "call-1",
       toolName: "shell_exec",
-      toolTitle: "Running",
     },
   ]);
 });
 
 test("channel progress uses web_search query as task details", () => {
-  const updates = buildChannelTurnProgressUpdatesFromDelta({
+  const builder = createChannelTurnProgressBuilder();
+  const updates = builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
     tool_calls: [
       {
-        id: "call-1",
-        function: {
-          name: "web_search",
-          arguments: JSON.stringify({
-            query: "letta blog",
-            category: "article",
-          }),
-        },
+        tool_call_id: "call-1",
+        name: "web_search",
+        arguments: JSON.stringify({
+          query: "letta blog",
+          category: "article",
+        }),
       },
     ],
   } as unknown as StreamDelta);
@@ -65,24 +57,22 @@ test("channel progress uses web_search query as task details", () => {
       toolCallId: "call-1",
       toolName: "web_search",
       toolDetails: "letta blog",
-      toolTitle: "Searching the web",
     },
   ]);
 });
 
-test("channel progress uses Skill names as task labels and details", () => {
-  const updates = buildChannelTurnProgressUpdatesFromDelta({
+test("channel progress uses Skill names as task details", () => {
+  const builder = createChannelTurnProgressBuilder();
+  const updates = builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
     tool_calls: [
       {
-        id: "call-1",
-        function: {
-          name: "Skill",
-          arguments: JSON.stringify({
-            skill: "maintaining-machine-maintenance",
-          }),
-        },
+        tool_call_id: "call-1",
+        name: "Skill",
+        arguments: JSON.stringify({
+          skill: "maintaining-machine-maintenance",
+        }),
       },
     ],
   } as unknown as StreamDelta);
@@ -95,24 +85,22 @@ test("channel progress uses Skill names as task labels and details", () => {
       runId: "run-1",
       toolCallId: "call-1",
       toolName: "Skill",
-      toolTitle: "Skill: maintaining-machine-maintenance",
       toolDetails: "maintaining-machine-maintenance",
     },
   ]);
 });
 
 test("channel progress uses cached Skill names for streamed argument fragments", () => {
+  const builder = createChannelTurnProgressBuilder();
   expect(
-    buildChannelTurnProgressUpdatesFromDelta({
+    builder.buildUpdates({
       message_type: "tool_call_message",
       run_id: "run-1",
       tool_calls: [
         {
-          id: "call-1",
-          function: {
-            name: "Skill",
-            arguments: '{"skill":"maintaining-',
-          },
+          tool_call_id: "call-1",
+          name: "Skill",
+          arguments: '{"skill":"maintaining-',
         },
       ],
     } as unknown as StreamDelta),
@@ -128,15 +116,13 @@ test("channel progress uses cached Skill names for streamed argument fragments",
   ]);
 
   expect(
-    buildChannelTurnProgressUpdatesFromDelta({
+    builder.buildUpdates({
       message_type: "tool_call_message",
       run_id: "run-1",
       tool_calls: [
         {
-          id: "call-1",
-          function: {
-            arguments: 'machine-maintenance"}',
-          },
+          tool_call_id: "call-1",
+          arguments: 'machine-maintenance"}',
         },
       ],
     } as unknown as StreamDelta),
@@ -148,28 +134,26 @@ test("channel progress uses cached Skill names for streamed argument fragments",
       runId: "run-1",
       toolCallId: "call-1",
       toolName: "Skill",
-      toolTitle: "Skill: maintaining-machine-maintenance",
       toolDetails: "maintaining-machine-maintenance",
     },
   ]);
 });
 
-test("channel progress labels subagent dispatches and previews prompts", () => {
-  const updates = buildChannelTurnProgressUpdatesFromDelta({
+test("channel progress previews subagent prompts", () => {
+  const builder = createChannelTurnProgressBuilder();
+  const updates = builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
     tool_calls: [
       {
-        id: "call-1",
-        function: {
-          name: "Agent",
-          arguments: JSON.stringify({
-            description: "Inspect Slack progress",
-            prompt:
-              "Review the Slack rich progress patch with TOKEN=secret and tell @channel nothing.",
-            subagent_type: "general-purpose",
-          }),
-        },
+        tool_call_id: "call-1",
+        name: "Agent",
+        arguments: JSON.stringify({
+          description: "Inspect Slack progress",
+          prompt:
+            "Review the Slack rich progress patch with TOKEN=secret and tell @channel nothing.",
+          subagent_type: "general-purpose",
+        }),
       },
     ],
   } as unknown as StreamDelta);
@@ -182,7 +166,6 @@ test("channel progress labels subagent dispatches and previews prompts", () => {
       runId: "run-1",
       toolCallId: "call-1",
       toolName: "Agent",
-      toolTitle: "Subagent",
       toolDetails:
         "Review the Slack rich progress patch with TOKEN=[redacted] and tell @​channel nothing.",
     },
@@ -190,19 +173,18 @@ test("channel progress labels subagent dispatches and previews prompts", () => {
 });
 
 test("channel progress truncates subagent previews with ASCII ellipses", () => {
-  const updates = buildChannelTurnProgressUpdatesFromDelta({
+  const builder = createChannelTurnProgressBuilder();
+  const updates = builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
     tool_calls: [
       {
-        id: "call-1",
-        function: {
-          name: "Agent",
-          arguments: JSON.stringify({
-            prompt: "A".repeat(220),
-            subagent_type: "general-purpose",
-          }),
-        },
+        tool_call_id: "call-1",
+        name: "Agent",
+        arguments: JSON.stringify({
+          prompt: "A".repeat(220),
+          subagent_type: "general-purpose",
+        }),
       },
     ],
   } as unknown as StreamDelta);
@@ -212,17 +194,16 @@ test("channel progress truncates subagent previews with ASCII ellipses", () => {
 });
 
 test("channel progress keeps subagent prompt previews across streamed fragments", () => {
+  const builder = createChannelTurnProgressBuilder();
   expect(
-    buildChannelTurnProgressUpdatesFromDelta({
+    builder.buildUpdates({
       message_type: "tool_call_message",
       run_id: "run-1",
       tool_calls: [
         {
-          id: "call-1",
-          function: {
-            name: "Task",
-            arguments: '{"prompt":"Audit Slack',
-          },
+          tool_call_id: "call-1",
+          name: "Task",
+          arguments: '{"prompt":"Audit Slack',
         },
       ],
     } as unknown as StreamDelta),
@@ -234,20 +215,17 @@ test("channel progress keeps subagent prompt previews across streamed fragments"
       runId: "run-1",
       toolCallId: "call-1",
       toolName: "Task",
-      toolTitle: "Subagent",
     },
   ]);
 
   expect(
-    buildChannelTurnProgressUpdatesFromDelta({
+    builder.buildUpdates({
       message_type: "tool_call_message",
       run_id: "run-1",
       tool_calls: [
         {
-          id: "call-1",
-          function: {
-            arguments: ' progress rows"}',
-          },
+          tool_call_id: "call-1",
+          arguments: ' progress rows"}',
         },
       ],
     } as unknown as StreamDelta),
@@ -259,23 +237,21 @@ test("channel progress keeps subagent prompt previews across streamed fragments"
       runId: "run-1",
       toolCallId: "call-1",
       toolName: "Task",
-      toolTitle: "Subagent",
       toolDetails: "Audit Slack progress rows",
     },
   ]);
 });
 
-test("channel progress uses Letta Code display names for tool titles", () => {
-  const updates = buildChannelTurnProgressUpdatesFromDelta({
+test("channel progress previews fetch_webpage URLs", () => {
+  const builder = createChannelTurnProgressBuilder();
+  const updates = builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
     tool_calls: [
       {
-        id: "call-1",
-        function: {
-          name: "fetch_webpage",
-          arguments: JSON.stringify({ url: "https://cameron.stream/blog" }),
-        },
+        tool_call_id: "call-1",
+        name: "fetch_webpage",
+        arguments: JSON.stringify({ url: "https://cameron.stream/blog" }),
       },
     ],
   } as unknown as StreamDelta);
@@ -289,25 +265,23 @@ test("channel progress uses Letta Code display names for tool titles", () => {
       toolCallId: "call-1",
       toolName: "fetch_webpage",
       toolDetails: "https://cameron.stream/blog",
-      toolTitle: "Fetch Webpage",
     },
   ]);
 });
 
 test("channel progress uses Bash descriptions as task details", () => {
-  const updates = buildChannelTurnProgressUpdatesFromDelta({
+  const builder = createChannelTurnProgressBuilder();
+  const updates = builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
     tool_calls: [
       {
-        id: "call-1",
-        function: {
-          name: "Bash",
-          arguments: JSON.stringify({
-            command: "uname -a",
-            description: "Check system details",
-          }),
-        },
+        tool_call_id: "call-1",
+        name: "Bash",
+        arguments: JSON.stringify({
+          command: "uname -a",
+          description: "Check system details",
+        }),
       },
     ],
   } as unknown as StreamDelta);
@@ -321,13 +295,13 @@ test("channel progress uses Bash descriptions as task details", () => {
       toolCallId: "call-1",
       toolName: "Bash",
       toolDetails: "Check system details",
-      toolTitle: "Running",
     },
   ]);
 });
 
 test("channel progress uses exec_command descriptions as task details", () => {
-  const updates = buildChannelTurnProgressUpdatesFromDelta({
+  const builder = createChannelTurnProgressBuilder();
+  const updates = builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
     tool_calls: [
@@ -351,14 +325,14 @@ test("channel progress uses exec_command descriptions as task details", () => {
       toolCallId: "call-1",
       toolName: "exec_command",
       toolDetails: "Check working tree status",
-      toolTitle: "Running",
     },
   ]);
 });
 
 test("channel progress waits for streamed exec_command descriptions", () => {
+  const builder = createChannelTurnProgressBuilder();
   expect(
-    buildChannelTurnProgressUpdatesFromDelta({
+    builder.buildUpdates({
       message_type: "approval_request_message",
       run_id: "run-1",
       tool_calls: {
@@ -375,11 +349,10 @@ test("channel progress waits for streamed exec_command descriptions", () => {
       runId: "run-1",
       toolCallId: "call-1",
       toolName: "exec_command",
-      toolTitle: "Running",
     },
   ]);
 
-  let updates = buildChannelTurnProgressUpdatesFromDelta({
+  let updates = builder.buildUpdates({
     message_type: "approval_request_message",
     run_id: "run-1",
     tool_calls: {
@@ -397,11 +370,10 @@ test("channel progress waits for streamed exec_command descriptions", () => {
       runId: "run-1",
       toolCallId: "call-1",
       toolName: "exec_command",
-      toolTitle: "Running",
     },
   ]);
 
-  updates = buildChannelTurnProgressUpdatesFromDelta({
+  updates = builder.buildUpdates({
     message_type: "approval_request_message",
     run_id: "run-1",
     tool_calls: {
@@ -420,13 +392,13 @@ test("channel progress waits for streamed exec_command descriptions", () => {
       toolCallId: "call-1",
       toolName: "exec_command",
       toolDetails: "Check working tree status",
-      toolTitle: "Running",
     },
   ]);
 });
 
 test("channel progress remembers tool names across streamed Skill args", () => {
-  buildChannelTurnProgressUpdatesFromDelta({
+  const builder = createChannelTurnProgressBuilder();
+  builder.buildUpdates({
     message_type: "approval_request_message",
     run_id: "run-1",
     tool_call: {
@@ -436,7 +408,7 @@ test("channel progress remembers tool names across streamed Skill args", () => {
     },
   } as unknown as StreamDelta);
 
-  const updates = buildChannelTurnProgressUpdatesFromDelta({
+  const updates = builder.buildUpdates({
     message_type: "approval_request_message",
     run_id: "run-1",
     tool_call: {
@@ -456,26 +428,24 @@ test("channel progress remembers tool names across streamed Skill args", () => {
       runId: "run-1",
       toolCallId: "call-1",
       toolName: "Skill",
-      toolTitle: "Skill: maintaining-machine-maintenance",
       toolDetails: "maintaining-machine-maintenance",
     },
   ]);
 });
 
 test("channel progress renders approval request deltas as tool rows", () => {
-  const updates = buildChannelTurnProgressUpdatesFromDelta({
+  const builder = createChannelTurnProgressBuilder();
+  const updates = builder.buildUpdates({
     message_type: "approval_request_message",
     run_id: "run-1",
     tool_calls: [
       {
-        id: "approval-1",
-        function: {
-          name: "Bash",
-          arguments: JSON.stringify({
-            command: "ls src/channels",
-            description: "List channel source files",
-          }),
-        },
+        tool_call_id: "approval-1",
+        name: "Bash",
+        arguments: JSON.stringify({
+          command: "ls src/channels",
+          description: "List channel source files",
+        }),
       },
     ],
   } as unknown as StreamDelta);
@@ -488,25 +458,23 @@ test("channel progress renders approval request deltas as tool rows", () => {
       runId: "run-1",
       toolCallId: "approval-1",
       toolName: "Bash",
-      toolTitle: "Running",
       toolDetails: "List channel source files",
     },
   ]);
 });
 
 test("channel progress extracts tool details when arguments is an object", () => {
-  const updates = buildChannelTurnProgressUpdatesFromDelta({
+  const builder = createChannelTurnProgressBuilder();
+  const updates = builder.buildUpdates({
     message_type: "approval_request_message",
     run_id: "run-1",
     tool_calls: [
       {
-        id: "approval-1",
-        function: {
-          name: "Bash",
-          arguments: {
-            command: "ls src/channels",
-            description: "List channel source files",
-          },
+        tool_call_id: "approval-1",
+        name: "Bash",
+        arguments: {
+          command: "ls src/channels",
+          description: "List channel source files",
         },
       },
     ],
@@ -520,14 +488,14 @@ test("channel progress extracts tool details when arguments is an object", () =>
       runId: "run-1",
       toolCallId: "approval-1",
       toolName: "Bash",
-      toolTitle: "Running",
       toolDetails: "List channel source files",
     },
   ]);
 });
 
 test("channel progress falls back to shell command preview when description is missing", () => {
-  const updates = buildChannelTurnProgressUpdatesFromDelta({
+  const builder = createChannelTurnProgressBuilder();
+  const updates = builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
     tool_calls: [
@@ -550,50 +518,35 @@ test("channel progress falls back to shell command preview when description is m
       runId: "run-1",
       toolCallId: "call-1",
       toolName: "exec_command",
-      toolTitle: "Running",
       toolDetails: "git diff --stat; git status --short",
     },
   ]);
 });
 
-test("channel progress clear removes accumulated tool argument details", () => {
-  expect(
-    buildChannelTurnProgressUpdatesFromDelta({
-      message_type: "tool_call_message",
-      run_id: "run-1",
-      tool_calls: [
-        {
-          tool_call_id: "call-1",
-          name: "exec_command",
-          arguments: JSON.stringify({
-            cmd: "git status --short",
-          }),
-        },
-      ],
-    } as unknown as StreamDelta),
-  ).toEqual([
-    {
-      kind: "tool",
-      state: "started",
-      message: "Preparing tool: exec_command",
-      runId: "run-1",
-      toolCallId: "call-1",
-      toolName: "exec_command",
-      toolTitle: "Running",
-      toolDetails: "git status --short",
-    },
-  ]);
-
-  clearToolCallArgumentsCache();
+test("channel progress resolves details from accumulated args on tool return", () => {
+  const builder = createChannelTurnProgressBuilder();
+  builder.buildUpdates({
+    message_type: "tool_call_message",
+    run_id: "run-1",
+    tool_calls: [
+      {
+        tool_call_id: "call-1",
+        name: "exec_command",
+        arguments: JSON.stringify({
+          cmd: "git status --short",
+          description: "Check working tree status",
+        }),
+      },
+    ],
+  } as unknown as StreamDelta);
 
   expect(
-    buildChannelTurnProgressUpdatesFromDelta({
+    builder.buildUpdates({
       message_type: "tool_return_message",
       run_id: "run-1",
       tool_returns: [
         {
           tool_call_id: "call-1",
-          name: "exec_command",
           status: "success",
           tool_return: "ok",
         },
@@ -607,13 +560,56 @@ test("channel progress clear removes accumulated tool argument details", () => {
       runId: "run-1",
       toolCallId: "call-1",
       toolName: "exec_command",
-      toolTitle: "Ran",
+      toolDetails: "Check working tree status",
+    },
+  ]);
+});
+
+test("channel progress builders do not share accumulated state", () => {
+  const firstBuilder = createChannelTurnProgressBuilder();
+  firstBuilder.buildUpdates({
+    message_type: "tool_call_message",
+    run_id: "run-1",
+    tool_calls: [
+      {
+        tool_call_id: "call-1",
+        name: "exec_command",
+        arguments: JSON.stringify({
+          cmd: "git status --short",
+        }),
+      },
+    ],
+  } as unknown as StreamDelta);
+
+  // A different turn's builder must not see the first turn's cached
+  // arguments or tool names for the same tool_call_id.
+  const secondBuilder = createChannelTurnProgressBuilder();
+  expect(
+    secondBuilder.buildUpdates({
+      message_type: "tool_return_message",
+      run_id: "run-1",
+      tool_returns: [
+        {
+          tool_call_id: "call-1",
+          status: "success",
+          tool_return: "ok",
+        },
+      ],
+    } as unknown as StreamDelta),
+  ).toEqual([
+    {
+      kind: "tool",
+      state: "completed",
+      message: "Tool finished",
+      runId: "run-1",
+      toolCallId: "call-1",
     },
   ]);
 });
 
 test("channel progress maps canonical parallel tool return arrays", () => {
-  const updates = buildChannelTurnProgressUpdatesFromDelta({
+  const builder = createChannelTurnProgressBuilder();
+  const updates = builder.buildUpdates({
     message_type: "tool_return_message",
     run_id: "run-1",
     tool_returns: [
@@ -658,8 +654,9 @@ test("channel progress sanitizes status text before adapters see it", () => {
 });
 
 test("channel progress maps lifecycle stream deltas to generic updates", () => {
+  const builder = createChannelTurnProgressBuilder();
   expect(
-    buildChannelTurnProgressUpdatesFromDelta({
+    builder.buildUpdates({
       message_type: "retry",
       attempt: 2,
       max_attempts: 4,
@@ -673,7 +670,7 @@ test("channel progress maps lifecycle stream deltas to generic updates", () => {
   ]);
 
   expect(
-    buildChannelTurnProgressUpdatesFromDelta({
+    builder.buildUpdates({
       message_type: "loop_error",
     } as unknown as StreamDelta),
   ).toEqual([

--- a/src/channels/progress.ts
+++ b/src/channels/progress.ts
@@ -1,23 +1,13 @@
 import {
   getDisplayToolName,
+  isGlobTool,
+  isSearchTool,
   isShellTool,
   isTaskTool,
 } from "@/cli/helpers/tool-name-mapping";
 import { isWebSearchToolName } from "@/cli/helpers/web-search-display";
 import type { StreamDelta } from "@/types/protocol_v2";
 import type { ChannelTurnProgressUpdate } from "./types";
-
-// Accumulate fragmented tool arguments across stream deltas.
-// Keyed by tool_call_id; values are the accumulated argument strings.
-const toolCallArgumentsById = new Map<string, string>();
-const toolCallNamesById = new Map<string, string>();
-const toolCallDescriptionsById = new Map<string, string>();
-
-export function clearToolCallArgumentsCache(): void {
-  toolCallArgumentsById.clear();
-  toolCallNamesById.clear();
-  toolCallDescriptionsById.clear();
-}
 
 const MAX_PROGRESS_TEXT_LENGTH = 140;
 const MAX_PROGRESS_DETAILS_LENGTH = 180;
@@ -29,12 +19,6 @@ const SECRET_ASSIGNMENT_RE =
   /\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASS|API[_-]?KEY|ACCESS[_-]?KEY)[A-Z0-9_]*)\s*=\s*("[^"]*"|'[^']*'|\S+)/gi;
 const SECRET_JSON_RE =
   /(["']?(?:token|secret|password|api[_-]?key|access[_-]?key)["']?\s*[:=]\s*)("[^"]*"|'[^']*'|\S+)/gi;
-
-function debugChannelProgress(message: string): void {
-  if (process.env.LETTA_SLACK_PROGRESS_DEBUG === "1") {
-    console.debug(`[Channel progress] ${message}`);
-  }
-}
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object"
@@ -51,11 +35,14 @@ function firstNonEmptyString(...values: unknown[]): string | undefined {
   return undefined;
 }
 
-function truncate(value: string, maxLength: number): string {
+export function truncateChannelProgressText(
+  value: string,
+  maxLength: number,
+  marker = "...",
+): string {
   if (value.length <= maxLength) {
     return value;
   }
-  const marker = "...";
   if (maxLength <= marker.length) {
     return marker.slice(0, Math.max(0, maxLength));
   }
@@ -79,21 +66,34 @@ function replaceControlCharacters(value: string): string {
   return result;
 }
 
-export function sanitizeChannelProgressText(
-  value: unknown,
-  maxLength: number = MAX_PROGRESS_TEXT_LENGTH,
-): string {
+/**
+ * Shared sanitization core for channel-facing progress text: strips ANSI
+ * escapes and control characters, redacts secret-looking assignments, and
+ * neutralizes platform mentions. Platform adapters layer their own escaping
+ * (and truncation marker) on top of this instead of maintaining parallel
+ * redaction rules.
+ */
+export function sanitizeChannelProgressCore(value: unknown): string {
   const raw = typeof value === "string" ? value : String(value ?? "");
   const redacted = raw
     .replace(ANSI_ESCAPE_RE, "")
     .replace(SECRET_ASSIGNMENT_RE, "$1=[redacted]")
     .replace(SECRET_JSON_RE, "$1[redacted]");
-  const normalized = replaceControlCharacters(redacted)
+  return replaceControlCharacters(redacted)
     .replace(/[\r\n\t]+/g, " ")
     .replace(/@(?=channel|here|everyone|[A-Za-z0-9._-]+)/gi, "@\u200b")
     .replace(/\s+/g, " ")
     .trim();
-  return truncate(normalized, maxLength);
+}
+
+export function sanitizeChannelProgressText(
+  value: unknown,
+  maxLength: number = MAX_PROGRESS_TEXT_LENGTH,
+): string {
+  return truncateChannelProgressText(
+    sanitizeChannelProgressCore(value),
+    maxLength,
+  );
 }
 
 export function sanitizeChannelProgressIdentifier(
@@ -114,33 +114,21 @@ function summarizeShellCommand(command: string): string {
     return "";
   }
 
-  const firstSemicolonSegments = normalized
+  // Preview the first command segment (or two short ones) and drop pipelines
+  // so multi-step shell invocations stay readable at Slack-row lengths.
+  const segments = normalized
     .split(/\s*;\s*/)
     .map((segment) => segment.trim())
     .filter(Boolean);
-  const firstTwoSegments = firstSemicolonSegments.slice(0, 2).join("; ");
+  const firstTwoSegments = segments.slice(0, 2).join("; ");
   const previewSource =
     firstTwoSegments.length > 0 && firstTwoSegments.length <= 70
       ? firstTwoSegments
-      : (firstSemicolonSegments[0] ?? normalized);
+      : (segments[0] ?? normalized);
   const withoutPipeline = previewSource.split(/\s*\|\s*/)[0] ?? previewSource;
-  const withoutHugePattern = withoutPipeline.replace(
-    /\s+-Pattern\s+.*$/i,
-    " -Pattern ...",
-  );
-  const withoutLineVariable = withoutHugePattern.replace(
-    /^\$lines\s*=\s*/i,
-    "",
-  );
 
-  if (withoutLineVariable.trim()) {
-    return sanitizeChannelProgressText(
-      withoutLineVariable,
-      MAX_SHELL_PROGRESS_DETAILS_LENGTH,
-    );
-  }
   return sanitizeChannelProgressText(
-    normalized,
+    withoutPipeline.trim() || normalized,
     MAX_SHELL_PROGRESS_DETAILS_LENGTH,
   );
 }
@@ -149,17 +137,12 @@ type ToolCallSummary = {
   id?: string;
   name?: string;
   argumentsText?: string;
-  descriptionText?: string;
 };
 
 function formatShellProgressDetailsFromArguments(
-  summary: ToolCallSummary,
   parsedArguments: Record<string, unknown>,
 ): string | undefined {
-  const description = firstNonEmptyString(
-    summary.descriptionText,
-    parsedArguments.description,
-  );
+  const description = firstNonEmptyString(parsedArguments.description);
   if (description) {
     return (
       sanitizeChannelProgressText(description, MAX_PROGRESS_DETAILS_LENGTH) ||
@@ -196,42 +179,11 @@ function formatFragmentedShellProgressDetails(
   return undefined;
 }
 
-function formatSubagentNestedValue(value: unknown): string | undefined {
-  if (typeof value === "string" && value.trim().length > 0) {
-    return value;
-  }
-  const record = asRecord(value);
-  if (!record) {
-    return undefined;
-  }
-  return (
-    firstNonEmptyString(
-      record.prompt,
-      record.task,
-      record.instructions,
-      record.instruction,
-      record.command,
-      record.description,
-      record.message,
-    ) ?? stringifyRecordArgument(record)
-  );
-}
-
 function formatSubagentProgressDetailsFromArguments(
-  summary: ToolCallSummary,
   parsedArguments: Record<string, unknown>,
 ): string | undefined {
   const preview = firstNonEmptyString(
     parsedArguments.prompt,
-    parsedArguments.task,
-    parsedArguments.instructions,
-    parsedArguments.instruction,
-    parsedArguments.request,
-    parsedArguments.command,
-    formatSubagentNestedValue(parsedArguments.input),
-    formatSubagentNestedValue(parsedArguments.payload),
-    formatSubagentNestedValue(parsedArguments.args),
-    summary.descriptionText,
     parsedArguments.description,
     parsedArguments.subject,
   );
@@ -246,7 +198,7 @@ function formatFragmentedSubagentProgressDetails(
   summary: ToolCallSummary,
 ): string | undefined {
   const previewMatch = summary.argumentsText?.match(
-    /"(?:prompt|task|instructions|instruction|request|command|description|subject)"\s*:\s*"([^"]+)"/,
+    /"(?:prompt|description|subject)"\s*:\s*"([^"]+)"/,
   );
   if (!previewMatch?.[1]) {
     return undefined;
@@ -276,49 +228,6 @@ function parseToolArguments(
   }
 }
 
-function stringifyRecordArgument(value: unknown): string | undefined {
-  const record = asRecord(value);
-  return record ? JSON.stringify(record) : undefined;
-}
-
-function formatToolProgressTitle(
-  summary: ToolCallSummary,
-  state: ChannelTurnProgressUpdate["state"],
-  details?: string,
-): string | undefined {
-  if (isSkillToolName(summary.name) && details) {
-    return `Skill: ${details}`;
-  }
-
-  if (isWebSearchToolName(summary.name)) {
-    if (state === "completed") {
-      return "Searched the web";
-    }
-    if (state === "error") {
-      return "Attempted to search the web";
-    }
-    return "Searching the web";
-  }
-
-  if (summary.name && isTaskTool(summary.name)) {
-    return "Subagent";
-  }
-
-  if (summary.name && isShellTool(summary.name)) {
-    return state === "completed" ? "Ran" : "Running";
-  }
-
-  if (summary.name) {
-    const displayName = getDisplayToolName(summary.name);
-    if (displayName !== summary.name) {
-      const sanitized = sanitizeChannelProgressText(displayName);
-      return sanitized || undefined;
-    }
-  }
-
-  return undefined;
-}
-
 function isFetchWebpageToolName(name: string | undefined): boolean {
   return (
     name === "fetch_webpage" ||
@@ -327,8 +236,17 @@ function isFetchWebpageToolName(name: string | undefined): boolean {
   );
 }
 
-function isSkillToolName(name: string | undefined): boolean {
+export function isSkillToolName(name: string | undefined): boolean {
   return name === "Skill" || name === "skill";
+}
+
+function isFilePathToolName(name: string): boolean {
+  const displayName = getDisplayToolName(name);
+  return (
+    displayName === "Read" ||
+    displayName === "Update" ||
+    displayName === "Write"
+  );
 }
 
 function formatSkillProgressDetailsFromArguments(
@@ -364,24 +282,7 @@ function formatFragmentedSkillProgressDetails(
 function formatToolProgressDetails(
   summary: ToolCallSummary,
 ): string | undefined {
-  if (!summary.name) {
-    return undefined;
-  }
-  if (!summary.argumentsText) {
-    if (isTaskTool(summary.name)) {
-      const sanitized = sanitizeChannelProgressText(
-        summary.descriptionText,
-        MAX_SUBAGENT_PROGRESS_DETAILS_LENGTH,
-      );
-      return sanitized || undefined;
-    }
-    if (isShellTool(summary.name)) {
-      const sanitized = sanitizeChannelProgressText(
-        summary.descriptionText,
-        MAX_PROGRESS_DETAILS_LENGTH,
-      );
-      return sanitized || undefined;
-    }
+  if (!summary.name || !summary.argumentsText) {
     return undefined;
   }
 
@@ -411,24 +312,14 @@ function formatToolProgressDetails(
     }
 
     if (isTaskTool(summary.name)) {
-      return formatSubagentProgressDetailsFromArguments(
-        summary,
-        parsedArguments,
-      );
+      return formatSubagentProgressDetailsFromArguments(parsedArguments);
     }
 
     if (isShellTool(summary.name)) {
-      const description = firstNonEmptyString(
-        summary.descriptionText,
-        parsedArguments.description,
-      );
-      debugChannelProgress(
-        `[DETAILS-BASH-PARSED] id=${summary.id ?? "none"} keys=${Object.keys(parsedArguments).join(",")} description=${description ?? "none"}`,
-      );
-      return formatShellProgressDetailsFromArguments(summary, parsedArguments);
+      return formatShellProgressDetailsFromArguments(parsedArguments);
     }
 
-    if (summary.name === "Read" || summary.name === "read") {
+    if (isFilePathToolName(summary.name)) {
       const filePath = firstNonEmptyString(
         parsedArguments.file_path,
         parsedArguments.filePath,
@@ -441,43 +332,10 @@ function formatToolProgressDetails(
       return sanitized || undefined;
     }
 
-    if (summary.name === "Glob" || summary.name === "glob") {
+    if (isGlobTool(summary.name) || isSearchTool(summary.name)) {
       const pattern = firstNonEmptyString(parsedArguments.pattern);
       const sanitized = sanitizeChannelProgressText(
         pattern,
-        MAX_PROGRESS_DETAILS_LENGTH,
-      );
-      return sanitized || undefined;
-    }
-
-    if (summary.name === "Grep" || summary.name === "grep") {
-      const pattern = firstNonEmptyString(parsedArguments.pattern);
-      const sanitized = sanitizeChannelProgressText(
-        pattern,
-        MAX_PROGRESS_DETAILS_LENGTH,
-      );
-      return sanitized || undefined;
-    }
-
-    if (summary.name === "Edit" || summary.name === "edit") {
-      const filePath = firstNonEmptyString(
-        parsedArguments.file_path,
-        parsedArguments.filePath,
-      );
-      const sanitized = sanitizeChannelProgressText(
-        filePath,
-        MAX_PROGRESS_DETAILS_LENGTH,
-      );
-      return sanitized || undefined;
-    }
-
-    if (summary.name === "Write" || summary.name === "write") {
-      const filePath = firstNonEmptyString(
-        parsedArguments.file_path,
-        parsedArguments.filePath,
-      );
-      const sanitized = sanitizeChannelProgressText(
-        filePath,
         MAX_PROGRESS_DETAILS_LENGTH,
       );
       return sanitized || undefined;
@@ -486,13 +344,9 @@ function formatToolProgressDetails(
     return undefined;
   }
 
-  // Fallback: try to extract description from fragmented/incomplete JSON
+  // Fallback: extract known preview fields from fragmented/incomplete JSON.
   if (isShellTool(summary.name)) {
-    const details = formatFragmentedShellProgressDetails(summary);
-    debugChannelProgress(
-      `[DETAILS-BASH-FALLBACK] id=${summary.id ?? "none"} matched=${details ?? "none"} text=${sanitizeChannelProgressText(summary.argumentsText, MAX_PROGRESS_DETAILS_LENGTH)}`,
-    );
-    return details;
+    return formatFragmentedShellProgressDetails(summary);
   }
 
   if (isSkillToolName(summary.name)) {
@@ -503,15 +357,7 @@ function formatToolProgressDetails(
     return formatFragmentedSubagentProgressDetails(summary);
   }
 
-  // Fallback: try to extract file_path from fragmented/incomplete JSON
-  if (
-    summary.name === "Read" ||
-    summary.name === "read" ||
-    summary.name === "Edit" ||
-    summary.name === "edit" ||
-    summary.name === "Write" ||
-    summary.name === "write"
-  ) {
+  if (isFilePathToolName(summary.name)) {
     const filePathMatch = summary.argumentsText.match(
       /"file_path"\s*:\s*"([^"]+)"/,
     );
@@ -525,234 +371,6 @@ function formatToolProgressDetails(
   }
 
   return undefined;
-}
-
-function extractToolCallSummary(value: unknown): ToolCallSummary | null {
-  const record = asRecord(value);
-  if (!record) {
-    return null;
-  }
-  const nestedFunction = asRecord(record.function);
-  const tool = asRecord(record.tool);
-  const nestedToolFunction = asRecord(tool?.function);
-  const id = firstNonEmptyString(
-    record.id,
-    record.tool_call_id,
-    record.toolCallId,
-    record.call_id,
-  );
-  const cacheId = id
-    ? sanitizeChannelProgressIdentifier(id, "tool-call")
-    : undefined;
-  const extractedName = firstNonEmptyString(
-    record.name,
-    record.tool_name,
-    record.toolName,
-    nestedFunction?.name,
-    tool?.name,
-    nestedToolFunction?.name,
-  );
-  if (cacheId && extractedName) {
-    toolCallNamesById.set(cacheId, extractedName);
-  }
-  const name =
-    extractedName ?? (cacheId ? toolCallNamesById.get(cacheId) : undefined);
-  const descriptionText = firstNonEmptyString(
-    record.description,
-    record.display_description,
-    record.displayDescription,
-    record.summary,
-    record.reason,
-    record.purpose,
-    nestedFunction?.description,
-    tool?.description,
-    nestedToolFunction?.description,
-  );
-  if (cacheId && descriptionText) {
-    toolCallDescriptionsById.set(
-      cacheId,
-      sanitizeChannelProgressText(descriptionText, MAX_PROGRESS_DETAILS_LENGTH),
-    );
-  }
-  const resolvedName = name;
-  const resolvedDescriptionText =
-    descriptionText ??
-    (cacheId ? toolCallDescriptionsById.get(cacheId) : undefined);
-  const rawArguments =
-    firstNonEmptyString(
-      record.arguments,
-      record.args,
-      record.input,
-      nestedFunction?.arguments,
-      nestedFunction?.args,
-      tool?.arguments,
-      nestedToolFunction?.arguments,
-      nestedToolFunction?.args,
-    ) ??
-    stringifyRecordArgument(record.arguments) ??
-    stringifyRecordArgument(record.args) ??
-    stringifyRecordArgument(record.input) ??
-    stringifyRecordArgument(nestedFunction?.arguments) ??
-    stringifyRecordArgument(nestedFunction?.args) ??
-    stringifyRecordArgument(tool?.arguments) ??
-    stringifyRecordArgument(tool?.args) ??
-    stringifyRecordArgument(tool?.input) ??
-    stringifyRecordArgument(nestedToolFunction?.arguments) ??
-    stringifyRecordArgument(nestedToolFunction?.args);
-
-  if (resolvedName && isShellTool(resolvedName)) {
-    debugChannelProgress(
-      `[EXTRACT-BASH] id=${id ?? "none"} keys=${Object.keys(record).join(",")} descriptionText=${resolvedDescriptionText ?? "none"} rawType=${typeof rawArguments} raw=${sanitizeChannelProgressText(rawArguments, MAX_PROGRESS_DETAILS_LENGTH)}`,
-    );
-  }
-
-  // Accumulate fragmented arguments across stream deltas for the same tool call.
-  // If the current fragment already parses as valid JSON, use it directly
-  // and don't accumulate further (prevents duplication when complete args
-  // are sent in every delta).
-  let argumentsText: string | undefined;
-  if (cacheId && rawArguments !== undefined) {
-    const existing = toolCallArgumentsById.get(cacheId);
-    const rawArgumentsAreComplete = parseToolArguments(rawArguments) !== null;
-    if (rawArgumentsAreComplete) {
-      // Complete current arguments should replace earlier partial/object args.
-      // Some streams first expose only command content, then later include the
-      // human-friendly description; freezing the first parseable object hides it.
-      toolCallArgumentsById.set(cacheId, rawArguments);
-      argumentsText = rawArguments;
-      if (resolvedName && isShellTool(resolvedName)) {
-        debugChannelProgress(
-          `[ARGS-BASH-REPLACE-COMPLETE] id=${cacheId} text=${sanitizeChannelProgressText(argumentsText, MAX_PROGRESS_DETAILS_LENGTH)}`,
-        );
-      }
-    } else if (existing) {
-      if (parseToolArguments(existing)) {
-        argumentsText = existing;
-        if (resolvedName && isShellTool(resolvedName)) {
-          debugChannelProgress(
-            `[ARGS-BASH-KEEP-EXISTING] id=${cacheId} text=${sanitizeChannelProgressText(argumentsText, MAX_PROGRESS_DETAILS_LENGTH)}`,
-          );
-        }
-      } else {
-        const accumulated = existing + rawArguments;
-        toolCallArgumentsById.set(cacheId, accumulated);
-        argumentsText = accumulated;
-        if (resolvedName && isShellTool(resolvedName)) {
-          debugChannelProgress(
-            `[ARGS-BASH-ACCUMULATE] id=${cacheId} text=${sanitizeChannelProgressText(argumentsText, MAX_PROGRESS_DETAILS_LENGTH)}`,
-          );
-        }
-      }
-    } else {
-      toolCallArgumentsById.set(cacheId, rawArguments);
-      argumentsText = rawArguments;
-      if (resolvedName && isShellTool(resolvedName)) {
-        debugChannelProgress(
-          `[ARGS-BASH-START] id=${cacheId} text=${sanitizeChannelProgressText(argumentsText, MAX_PROGRESS_DETAILS_LENGTH)}`,
-        );
-      }
-    }
-  } else if (!id && rawArguments !== undefined) {
-    argumentsText = rawArguments;
-  }
-
-  if (!id && !resolvedName) {
-    return null;
-  }
-  return {
-    ...(cacheId ? { id: cacheId } : {}),
-    ...(resolvedName
-      ? { name: sanitizeChannelProgressIdentifier(resolvedName, "tool") }
-      : {}),
-    ...(argumentsText ? { argumentsText } : {}),
-    ...(resolvedDescriptionText
-      ? {
-          descriptionText: sanitizeChannelProgressText(
-            resolvedDescriptionText,
-            MAX_PROGRESS_DETAILS_LENGTH,
-          ),
-        }
-      : {}),
-  };
-}
-
-function extractToolCalls(delta: Record<string, unknown>): ToolCallSummary[] {
-  const candidates: unknown[] = [];
-  if (Array.isArray(delta.tool_calls)) {
-    candidates.push(...delta.tool_calls);
-  } else {
-    candidates.push(delta.tool_calls);
-  }
-  if (Array.isArray(delta.toolCalls)) {
-    candidates.push(...delta.toolCalls);
-  } else {
-    candidates.push(delta.toolCalls);
-  }
-  if (Array.isArray(delta.tools)) {
-    candidates.push(...delta.tools);
-  } else {
-    candidates.push(delta.tools);
-  }
-  if (Array.isArray(delta.approvals)) {
-    candidates.push(...delta.approvals);
-  } else {
-    candidates.push(delta.approvals);
-  }
-  candidates.push(delta.tool_call, delta.toolCall, delta.approval);
-
-  const summaries: ToolCallSummary[] = [];
-  const seen = new Set<string>();
-  for (const candidate of candidates) {
-    const summary = extractToolCallSummary(candidate);
-    if (!summary) {
-      continue;
-    }
-    const key = `${summary.id ?? ""}:${summary.name ?? ""}`;
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    summaries.push(summary);
-  }
-  return summaries;
-}
-
-function extractToolReturns(
-  delta: Record<string, unknown>,
-): ToolReturnSummary[] {
-  const candidates: unknown[] = [];
-  if (Array.isArray(delta.tool_returns)) {
-    candidates.push(...delta.tool_returns);
-  }
-  if (Array.isArray(delta.toolReturns)) {
-    candidates.push(...delta.toolReturns);
-  }
-  if (candidates.length === 0) {
-    candidates.push(delta);
-  }
-
-  const summaries: ToolReturnSummary[] = [];
-  const seen = new Set<string>();
-  for (const candidate of candidates) {
-    const record = asRecord(candidate);
-    if (!record) {
-      continue;
-    }
-    const summary = extractToolCallSummary(record);
-    if (!summary) {
-      continue;
-    }
-    const key = `${summary.id ?? ""}:${summary.name ?? ""}`;
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    summaries.push({
-      summary,
-      status: getToolStatus(record),
-    });
-  }
-  return summaries;
 }
 
 function getMessageType(delta: Record<string, unknown>): string | null {
@@ -793,300 +411,415 @@ function toolNameForMessage(summary: ToolCallSummary | undefined): string {
   return summary?.name ? `: ${summary.name}` : "";
 }
 
-export function buildChannelTurnProgressUpdatesFromDelta(
-  delta: StreamDelta,
-): ChannelTurnProgressUpdate[] {
-  const record = asRecord(delta);
-  if (!record) {
-    return [];
+/**
+ * Builds sanitized channel progress updates from stream deltas for a single
+ * turn. Instances accumulate fragmented tool-call arguments across deltas,
+ * so they must be scoped to one conversation turn (create one per turn and
+ * drop it when the turn finishes) rather than shared across conversations.
+ */
+export type ChannelTurnProgressBuilder = {
+  buildUpdates(delta: StreamDelta): ChannelTurnProgressUpdate[];
+};
+
+export function createChannelTurnProgressBuilder(): ChannelTurnProgressBuilder {
+  // Fragmented tool arguments and names accumulated across stream deltas,
+  // keyed by tool_call_id. Entries are dropped when the tool return arrives;
+  // the whole builder is dropped with the turn.
+  const argumentsByToolCallId = new Map<string, string>();
+  const namesByToolCallId = new Map<string, string>();
+
+  // Wire shapes (see ToolCall / ToolCallDelta in @letta-ai/letta-client and
+  // the local backend projections): flat `tool_call_id` / `name` /
+  // `arguments` fields, delivered either as `tool_calls` (array or single
+  // delta object) or the deprecated `tool_call`.
+  function extractToolCallSummary(value: unknown): ToolCallSummary | null {
+    const record = asRecord(value);
+    if (!record) {
+      return null;
+    }
+    const id = firstNonEmptyString(record.tool_call_id);
+    const cacheId = id
+      ? sanitizeChannelProgressIdentifier(id, "tool-call")
+      : undefined;
+    const extractedName = firstNonEmptyString(record.name);
+    if (cacheId && extractedName) {
+      namesByToolCallId.set(cacheId, extractedName);
+    }
+    const resolvedName =
+      extractedName ?? (cacheId ? namesByToolCallId.get(cacheId) : undefined);
+    const rawArguments =
+      typeof record.arguments === "string" && record.arguments.length > 0
+        ? record.arguments
+        : asRecord(record.arguments)
+          ? JSON.stringify(record.arguments)
+          : undefined;
+
+    // Accumulate fragmented arguments across stream deltas for the same tool
+    // call. A fragment that already parses as complete JSON replaces earlier
+    // partial state (some streams first expose only command content, then
+    // later re-send full arguments including the description).
+    let argumentsText: string | undefined;
+    if (cacheId && rawArguments !== undefined) {
+      const existing = argumentsByToolCallId.get(cacheId);
+      if (parseToolArguments(rawArguments)) {
+        argumentsByToolCallId.set(cacheId, rawArguments);
+        argumentsText = rawArguments;
+      } else if (existing) {
+        if (parseToolArguments(existing)) {
+          argumentsText = existing;
+        } else {
+          const accumulated = existing + rawArguments;
+          argumentsByToolCallId.set(cacheId, accumulated);
+          argumentsText = accumulated;
+        }
+      } else {
+        argumentsByToolCallId.set(cacheId, rawArguments);
+        argumentsText = rawArguments;
+      }
+    } else if (!id && rawArguments !== undefined) {
+      argumentsText = rawArguments;
+    }
+
+    if (!id && !resolvedName) {
+      return null;
+    }
+    return {
+      ...(cacheId ? { id: cacheId } : {}),
+      ...(resolvedName
+        ? { name: sanitizeChannelProgressIdentifier(resolvedName, "tool") }
+        : {}),
+      ...(argumentsText ? { argumentsText } : {}),
+    };
   }
 
-  const messageType = getMessageType(record);
-  const runId = getRunId(record);
-  const updates: ChannelTurnProgressUpdate[] = [];
+  function extractToolCalls(delta: Record<string, unknown>): ToolCallSummary[] {
+    const candidates: unknown[] = Array.isArray(delta.tool_calls)
+      ? delta.tool_calls
+      : delta.tool_calls
+        ? [delta.tool_calls]
+        : delta.tool_call
+          ? [delta.tool_call]
+          : [];
 
-  switch (messageType) {
-    case "reasoning_message":
-      return [
-        withRunId(
-          {
-            kind: "thinking",
-            state: "updated",
-            message: "Thinking",
-          },
-          runId,
-        ),
-      ];
-
-    case "assistant_message":
-      return [
-        withRunId(
-          {
-            kind: "responding",
-            state: "updated",
-            message: "Writing reply",
-          },
-          runId,
-        ),
-      ];
-
-    case "approval_request_message": {
-      const tools = extractToolCalls(record);
-      if (tools.length === 0) {
-        return [];
+    const summaries: ToolCallSummary[] = [];
+    const seen = new Set<string>();
+    for (const candidate of candidates) {
+      const summary = extractToolCallSummary(candidate);
+      if (!summary) {
+        continue;
       }
-      for (const tool of tools) {
-        const toolDetails = formatToolProgressDetails(tool);
-        const toolTitle = formatToolProgressTitle(tool, "started", toolDetails);
-        updates.push(
+      const key = `${summary.id ?? ""}:${summary.name ?? ""}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      summaries.push(summary);
+    }
+    return summaries;
+  }
+
+  function extractToolReturns(
+    delta: Record<string, unknown>,
+  ): ToolReturnSummary[] {
+    const candidates: unknown[] = Array.isArray(delta.tool_returns)
+      ? delta.tool_returns
+      : [delta];
+
+    const summaries: ToolReturnSummary[] = [];
+    const seen = new Set<string>();
+    for (const candidate of candidates) {
+      const record = asRecord(candidate);
+      if (!record) {
+        continue;
+      }
+      const summary = extractToolCallSummary(record);
+      if (!summary) {
+        continue;
+      }
+      const key = `${summary.id ?? ""}:${summary.name ?? ""}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      summaries.push({
+        summary,
+        status: getToolStatus(record),
+      });
+    }
+    return summaries;
+  }
+
+  function buildToolCallUpdates(
+    record: Record<string, unknown>,
+    runId: string | undefined,
+  ): ChannelTurnProgressUpdate[] {
+    const tools = extractToolCalls(record);
+    const updates: ChannelTurnProgressUpdate[] = [];
+    for (const tool of tools) {
+      const toolDetails = formatToolProgressDetails(tool);
+      updates.push(
+        withRunId(
+          {
+            kind: "tool",
+            state: "started",
+            message: `Preparing tool${toolNameForMessage(tool)}`,
+            ...(tool.id ? { toolCallId: tool.id } : {}),
+            ...(tool.name ? { toolName: tool.name } : {}),
+            ...(toolDetails ? { toolDetails } : {}),
+          },
+          runId,
+        ),
+      );
+    }
+    return updates;
+  }
+
+  function buildUpdates(delta: StreamDelta): ChannelTurnProgressUpdate[] {
+    const record = asRecord(delta);
+    if (!record) {
+      return [];
+    }
+
+    const messageType = getMessageType(record);
+    const runId = getRunId(record);
+
+    switch (messageType) {
+      case "reasoning_message":
+        return [
           withRunId(
             {
-              kind: "tool",
-              state: "started",
-              message: `Preparing tool${toolNameForMessage(tool)}`,
-              ...(tool.id ? { toolCallId: tool.id } : {}),
-              ...(tool.name ? { toolName: tool.name } : {}),
-              ...(toolTitle ? { toolTitle } : {}),
-              ...(toolDetails ? { toolDetails } : {}),
+              kind: "thinking",
+              state: "updated",
+              message: "Thinking",
             },
             runId,
           ),
-        );
-      }
-      return updates;
-    }
+        ];
 
-    case "tool_call_message": {
-      const tools = extractToolCalls(record);
-      if (tools.length === 0) {
+      case "assistant_message":
+        return [
+          withRunId(
+            {
+              kind: "responding",
+              state: "updated",
+              message: "Writing reply",
+            },
+            runId,
+          ),
+        ];
+
+      case "approval_request_message":
+        return buildToolCallUpdates(record, runId);
+
+      case "tool_call_message": {
+        const updates = buildToolCallUpdates(record, runId);
+        if (updates.length === 0) {
+          return [
+            withRunId(
+              {
+                kind: "tool",
+                state: "started",
+                message: "Preparing tool call",
+              },
+              runId,
+            ),
+          ];
+        }
+        return updates;
+      }
+
+      case "tool_return_message": {
+        const toolReturns = extractToolReturns(record);
+        const updates: ChannelTurnProgressUpdate[] = [];
+        for (const { summary, status } of toolReturns) {
+          // Resolve details from the accumulated arguments for this call,
+          // then drop the per-call caches.
+          const accumulatedArgs = summary.id
+            ? argumentsByToolCallId.get(summary.id)
+            : undefined;
+          if (summary.id) {
+            argumentsByToolCallId.delete(summary.id);
+            namesByToolCallId.delete(summary.id);
+          }
+          const toolWithAccumulatedArgs = accumulatedArgs
+            ? { ...summary, argumentsText: accumulatedArgs }
+            : summary;
+          const toolDetails = formatToolProgressDetails(
+            toolWithAccumulatedArgs,
+          );
+          updates.push(
+            withRunId(
+              {
+                kind: "tool",
+                state: status,
+                message: status === "error" ? "Tool failed" : "Tool finished",
+                ...(summary.id ? { toolCallId: summary.id } : {}),
+                ...(summary.name ? { toolName: summary.name } : {}),
+                ...(toolDetails ? { toolDetails } : {}),
+              },
+              runId,
+            ),
+          );
+        }
+        return updates;
+      }
+
+      case "client_tool_start":
         return [
           withRunId(
             {
               kind: "tool",
               state: "started",
-              message: "Preparing tool call",
+              message: "Running tool",
+              ...(typeof record.tool_call_id === "string"
+                ? {
+                    toolCallId: sanitizeChannelProgressIdentifier(
+                      record.tool_call_id,
+                      "tool-call",
+                    ),
+                  }
+                : {}),
+            },
+            runId,
+          ),
+        ];
+
+      case "client_tool_end": {
+        const state = getToolStatus(record);
+        return [
+          withRunId(
+            {
+              kind: "tool",
+              state,
+              message: state === "error" ? "Tool failed" : "Tool finished",
+              ...(typeof record.tool_call_id === "string"
+                ? {
+                    toolCallId: sanitizeChannelProgressIdentifier(
+                      record.tool_call_id,
+                      "tool-call",
+                    ),
+                  }
+                : {}),
             },
             runId,
           ),
         ];
       }
-      for (const tool of tools) {
-        const toolDetails = formatToolProgressDetails(tool);
-        const toolTitle = formatToolProgressTitle(tool, "started", toolDetails);
-        updates.push(
+
+      case "slash_command_start": {
+        const command = getSlashCommand(record);
+        return [
           withRunId(
             {
-              kind: "tool",
+              kind: "command",
               state: "started",
-              message: `Preparing tool${toolNameForMessage(tool)}`,
-              ...(tool.id ? { toolCallId: tool.id } : {}),
-              ...(tool.name ? { toolName: tool.name } : {}),
-              ...(toolTitle ? { toolTitle } : {}),
-              ...(toolDetails ? { toolDetails } : {}),
+              message: `Running ${command}`,
+              command,
             },
             runId,
           ),
-        );
+        ];
       }
-      return updates;
-    }
 
-    case "tool_return_message": {
-      const toolReturns = extractToolReturns(record);
-      if (toolReturns.length === 0) {
-        return [];
-      }
-      for (const { summary, status } of toolReturns) {
-        // Try to get accumulated arguments for this tool call
-        const accumulatedArgs = summary.id
-          ? toolCallArgumentsById.get(summary.id)
-          : undefined;
-        if (accumulatedArgs && summary.id) {
-          toolCallArgumentsById.delete(summary.id);
-        }
-        if (summary.id) {
-          toolCallNamesById.delete(summary.id);
-        }
-        const toolWithAccumulatedArgs = accumulatedArgs
-          ? { ...summary, argumentsText: accumulatedArgs }
-          : summary;
-        const toolDetails = formatToolProgressDetails(toolWithAccumulatedArgs);
-        const toolTitle = formatToolProgressTitle(
-          toolWithAccumulatedArgs,
-          status,
-          toolDetails,
-        );
-        updates.push(
+      case "slash_command_end": {
+        const command = getSlashCommand(record);
+        const success = record.success !== false;
+        return [
           withRunId(
             {
-              kind: "tool",
-              state: status,
-              message: status === "error" ? "Tool failed" : "Tool finished",
-              ...(summary.id ? { toolCallId: summary.id } : {}),
-              ...(summary.name ? { toolName: summary.name } : {}),
-              ...(toolTitle ? { toolTitle } : {}),
-              ...(toolDetails ? { toolDetails } : {}),
+              kind: "command",
+              state: success ? "completed" : "error",
+              message: success ? `${command} finished` : `${command} failed`,
+              command,
             },
             runId,
           ),
-        );
+        ];
       }
-      return updates;
-    }
 
-    case "client_tool_start":
-      return [
-        withRunId(
-          {
-            kind: "tool",
-            state: "started",
-            message: "Running tool",
-            ...(typeof record.tool_call_id === "string"
-              ? {
-                  toolCallId: sanitizeChannelProgressIdentifier(
-                    record.tool_call_id,
-                    "tool-call",
-                  ),
-                }
-              : {}),
-          },
-          runId,
-        ),
-      ];
+      case "command_start": {
+        const command = getCommandId(record);
+        return [
+          withRunId(
+            {
+              kind: "command",
+              state: "started",
+              message: "Running command",
+              command,
+            },
+            runId,
+          ),
+        ];
+      }
 
-    case "client_tool_end": {
-      const state = getToolStatus(record);
-      return [
-        withRunId(
-          {
-            kind: "tool",
-            state,
-            message: state === "error" ? "Tool failed" : "Tool finished",
-            ...(typeof record.tool_call_id === "string"
-              ? {
-                  toolCallId: sanitizeChannelProgressIdentifier(
-                    record.tool_call_id,
-                    "tool-call",
-                  ),
-                }
-              : {}),
-          },
-          runId,
-        ),
-      ];
-    }
+      case "command_end": {
+        const command = getCommandId(record);
+        const success = record.success !== false;
+        return [
+          withRunId(
+            {
+              kind: "command",
+              state: success ? "completed" : "error",
+              message: success ? "Command finished" : "Command failed",
+              command,
+            },
+            runId,
+          ),
+        ];
+      }
 
-    case "slash_command_start": {
-      const command = getSlashCommand(record);
-      return [
-        withRunId(
-          {
-            kind: "command",
-            state: "started",
-            message: `Running ${command}`,
-            command,
-          },
-          runId,
-        ),
-      ];
-    }
+      case "status": {
+        const message = sanitizeChannelProgressText(record.message);
+        if (!message) {
+          return [];
+        }
+        return [
+          withRunId(
+            {
+              kind: "status",
+              state: "updated",
+              message,
+            },
+            runId,
+          ),
+        ];
+      }
 
-    case "slash_command_end": {
-      const command = getSlashCommand(record);
-      const success = record.success !== false;
-      return [
-        withRunId(
-          {
-            kind: "command",
-            state: success ? "completed" : "error",
-            message: success ? `${command} finished` : `${command} failed`,
-            command,
-          },
-          runId,
-        ),
-      ];
-    }
+      case "retry": {
+        const attempt = Number(record.attempt);
+        const maxAttempts = Number(record.max_attempts ?? record.maxAttempts);
+        const suffix =
+          Number.isFinite(attempt) && Number.isFinite(maxAttempts)
+            ? ` (${attempt}/${maxAttempts})`
+            : "";
+        return [
+          withRunId(
+            {
+              kind: "retry",
+              state: "updated",
+              message: `Retrying request${suffix}`,
+            },
+            runId,
+          ),
+        ];
+      }
 
-    case "command_start": {
-      const command = getCommandId(record);
-      return [
-        withRunId(
-          {
-            kind: "command",
-            state: "started",
-            message: "Running command",
-            command,
-          },
-          runId,
-        ),
-      ];
-    }
+      case "loop_error":
+        return [
+          withRunId(
+            {
+              kind: "error",
+              state: "error",
+              message: "Encountered an error",
+            },
+            runId,
+          ),
+        ];
 
-    case "command_end": {
-      const command = getCommandId(record);
-      const success = record.success !== false;
-      return [
-        withRunId(
-          {
-            kind: "command",
-            state: success ? "completed" : "error",
-            message: success ? "Command finished" : "Command failed",
-            command,
-          },
-          runId,
-        ),
-      ];
-    }
-
-    case "status": {
-      const message = sanitizeChannelProgressText(record.message);
-      if (!message) {
+      default:
         return [];
-      }
-      return [
-        withRunId(
-          {
-            kind: "status",
-            state: "updated",
-            message,
-          },
-          runId,
-        ),
-      ];
     }
-
-    case "retry": {
-      const attempt = Number(record.attempt);
-      const maxAttempts = Number(record.max_attempts ?? record.maxAttempts);
-      const suffix =
-        Number.isFinite(attempt) && Number.isFinite(maxAttempts)
-          ? ` (${attempt}/${maxAttempts})`
-          : "";
-      return [
-        withRunId(
-          {
-            kind: "retry",
-            state: "updated",
-            message: `Retrying request${suffix}`,
-          },
-          runId,
-        ),
-      ];
-    }
-
-    case "loop_error":
-      return [
-        withRunId(
-          {
-            kind: "error",
-            state: "error",
-            message: "Encountered an error",
-          },
-          runId,
-        ),
-      ];
-
-    default:
-      return [];
   }
+
+  return { buildUpdates };
 }

--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -1826,7 +1826,6 @@ test("slack adapter updates Skill task title when the loaded skill arrives", asy
     message: "Preparing tool: Skill",
     toolCallId: "call-skill",
     toolName: "Skill",
-    toolTitle: "Skill: working-on-letta-code-channels",
     toolDetails: "working-on-letta-code-channels",
   });
 
@@ -2192,7 +2191,6 @@ test("slack adapter keeps separate task rows for parallel tool progress", async 
     message: "Searching web",
     toolCallId: "call-web",
     toolName: "web_search",
-    toolTitle: "Searching articles",
     toolDetails: "letta blog",
   });
   await adapter.handleTurnProgressEvent?.({
@@ -2238,11 +2236,11 @@ test("slack adapter keeps separate task rows for parallel tool progress", async 
       chunks: [
         expect.objectContaining({
           type: "plan_update",
-          title: "Searching articles",
+          title: "Searching the web",
         }),
         expect.objectContaining({
           id: "task_call-web",
-          title: "Searching articles",
+          title: "Searching the web",
           details: "letta blog",
           status: "in_progress",
         }),
@@ -2697,7 +2695,6 @@ test("slack adapter keeps one active progress card slot until finalized", async 
     message: "Searching web",
     toolCallId: "call-2",
     toolName: "web_search",
-    toolTitle: "Search the web",
     toolDetails: "letta slack progress cards",
   });
 
@@ -3136,7 +3133,6 @@ test("slack adapter finishes an active progress card when MessageChannel sends",
     message: "Searching web",
     toolCallId: "call-web",
     toolName: "web_search",
-    toolTitle: "Searching articles",
     toolDetails: "letta blog",
   });
   await adapter.sendMessage({
@@ -3159,7 +3155,7 @@ test("slack adapter finishes an active progress card when MessageChannel sends",
     chunks: expect.arrayContaining([
       expect.objectContaining({
         id: "task_call-web",
-        title: "Searched articles",
+        title: "Searched the web",
         status: "complete",
       }),
       expect.objectContaining({
@@ -3217,7 +3213,6 @@ test("slack adapter shows responding while MessageChannel runs with an active pr
     message: "Searching web",
     toolCallId: "call-web",
     toolName: "web_search",
-    toolTitle: "Searching articles",
     toolDetails: "letta blog",
   });
   await adapter.handleTurnProgressEvent?.({

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -11,6 +11,11 @@ import {
   formatChannelLifecycleErrorMessage,
   getChannelLifecycleErrorDisplay,
 } from "@/channels/lifecycle-error";
+import {
+  isSkillToolName,
+  sanitizeChannelProgressCore,
+  truncateChannelProgressText,
+} from "@/channels/progress";
 import type {
   ChannelAdapter,
   ChannelControlRequestEvent,
@@ -450,6 +455,8 @@ type SlackProgressCardState =
 type SlackProgressToolTask = {
   id: string;
   kind: ChannelTurnProgressEvent["kind"];
+  /** Raw tool name, when known. Titles are re-derived from this per status. */
+  toolName?: string;
   title: string;
   status: SlackStreamTaskStatus;
   details?: string;
@@ -463,7 +470,6 @@ type SlackProgressCardEntry = {
   latestText: string;
   latestUpdate?: ChannelTurnProgressEvent;
   toolNamesByCallId?: Map<string, string>;
-  toolTitlesByCallId?: Map<string, string>;
   toolDetailsByCallId?: Map<string, string>;
   toolTasksById?: Map<string, SlackProgressToolTask>;
   sentTaskDetailsById?: Map<string, string>;
@@ -478,31 +484,6 @@ type SlackProgressCardEntry = {
   requeuedFailedChunks?: boolean;
   updatedAt: number;
 };
-
-function debugSlackProgress(message: string): void {
-  if (process.env.LETTA_SLACK_PROGRESS_DEBUG === "1") {
-    console.debug(`[Slack progress] ${message}`);
-  }
-}
-
-function describeSlackStreamChunk(
-  chunk: SlackStreamChunk,
-): Record<string, unknown> {
-  if (chunk.type !== "task_update") {
-    return chunk;
-  }
-  return {
-    type: chunk.type,
-    id: chunk.id,
-    title: chunk.title,
-    status: chunk.status,
-    details: chunk.details,
-  };
-}
-
-function describeSlackStreamChunks(chunks: SlackStreamChunk[]): string {
-  return JSON.stringify(chunks.map(describeSlackStreamChunk));
-}
 
 export function resolveSlackProgressUpdateThrottleMs(): number {
   const raw = process.env.LETTA_SLACK_PROGRESS_UPDATE_THROTTLE_MS;
@@ -528,31 +509,15 @@ export function resolveSlackProgressStreamKeepaliveMs(): number {
   return Math.min(Math.trunc(parsed), 300_000);
 }
 
-function replaceSlackControlCharacters(value: string): string {
-  let result = "";
-  for (let index = 0; index < value.length; index += 1) {
-    const character = value[index] ?? "";
-    const code = character.charCodeAt(0);
-    result += code <= 31 || code === 127 ? " " : character;
-  }
-  return result;
-}
-
 function sanitizeSlackProgressText(text: string, maxLength: number): string {
-  const redacted = text.replace(
-    /\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASS|API[_-]?KEY|ACCESS[_-]?KEY)[A-Z0-9_]*)\s*=\s*("[^"]*"|'[^']*'|\S+)/gi,
-    "$1=[redacted]",
-  );
-  const normalized = replaceSlackControlCharacters(redacted)
+  // Shared channel sanitization (secrets, control characters, mentions) plus
+  // Slack-specific mrkdwn escaping and Slack's ellipsis truncation marker.
+  const normalized = sanitizeChannelProgressCore(text)
     .replace(/[<>]/g, "")
     .replace(/&/g, "and")
-    .replace(/@(?=channel|here|everyone|[A-Za-z0-9._-]+)/gi, "@\u200b")
     .replace(/\s+/g, " ")
     .trim();
-  if (normalized.length <= maxLength) {
-    return normalized;
-  }
-  return `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
+  return truncateChannelProgressText(normalized, maxLength, "…");
 }
 
 export function formatSlackProgressCardText(
@@ -647,10 +612,7 @@ function buildTerminalSlackStreamChunks(
         ? task
         : {
             ...task,
-            title: formatSlackToolTitleForTerminalStatus(
-              task.title,
-              terminalTaskStatus,
-            ),
+            title: formatSlackTaskTitleForStatus(task, terminalTaskStatus),
             status: terminalTaskStatus,
           };
     rawPending.push(toSlackTaskUpdateChunk(terminalTask));
@@ -669,7 +631,7 @@ function buildTerminalSlackStreamChunks(
 }
 
 function toSlackTaskUpdateChunk(task: SlackProgressToolTask): SlackStreamChunk {
-  const { kind: _kind, details, ...chunkTask } = task;
+  const { kind: _kind, toolName: _toolName, details, ...chunkTask } = task;
   return {
     type: "task_update",
     ...chunkTask,
@@ -710,9 +672,6 @@ function compactSlackStreamChunks(
       return [chunk];
     }
     if (lastByTaskId.get(chunk.id) !== i) {
-      debugSlackProgress(
-        `[COMPACT-DROP-OLDER] id=${chunk.id} status=${chunk.status} details=${chunk.details ?? "none"}`,
-      );
       return [];
     }
 
@@ -722,9 +681,6 @@ function compactSlackStreamChunks(
     }
     if (entry.sentTaskDetailsById?.get(chunk.id) === pendingDetails) {
       const { details: _details, ...chunkWithoutDetails } = chunk;
-      debugSlackProgress(
-        `[COMPACT-SUPPRESS-SENT-DETAILS] id=${chunk.id} status=${chunk.status} details=${pendingDetails}`,
-      );
       return [chunkWithoutDetails];
     }
     if (chunk.details === pendingDetails) {
@@ -732,9 +688,6 @@ function compactSlackStreamChunks(
     }
     return [{ ...chunk, details: pendingDetails }];
   });
-  debugSlackProgress(
-    `[COMPACT] raw=${describeSlackStreamChunks(rawChunks)} compacted=${describeSlackStreamChunks(compacted)}`,
-  );
   return compacted;
 }
 
@@ -748,9 +701,6 @@ function rememberSlackStreamTaskDetails(
     }
     entry.sentTaskDetailsById ??= new Map();
     entry.sentTaskDetailsById.set(chunk.id, chunk.details);
-    debugSlackProgress(
-      `[REMEMBER-DETAILS] id=${chunk.id} details=${chunk.details}`,
-    );
   }
 }
 
@@ -817,26 +767,55 @@ function shouldShowSlackChannelResponseProgress(
   return hasVisibleSlackProgressTask(entry);
 }
 
-function formatSlackToolNameForDisplay(
-  toolName: string,
-  update?: ChannelTurnProgressEvent,
-): string {
+function formatSlackToolNameForDisplay(toolName: string): string {
   if (isTaskTool(toolName)) {
     return "Subagent";
   }
-  if (update && isShellTool(toolName)) {
-    return update.state === "completed" ? "Ran" : "Running";
+  return getDisplayToolName(toolName);
+}
+
+/**
+ * Single source of truth for tool task titles. Titles are always derived
+ * from the raw tool name plus the task status, never re-parsed from
+ * previously rendered display strings.
+ */
+function formatSlackToolTaskTitle(
+  toolName: string,
+  status: SlackStreamTaskStatus,
+  details?: string,
+): string {
+  if (isSkillToolName(toolName)) {
+    return details ? `Skill: ${details}` : "Skill";
   }
-  if (update && isWebSearchToolName(toolName)) {
-    if (update.state === "completed") {
+  if (isTaskTool(toolName)) {
+    return "Subagent";
+  }
+  if (isShellTool(toolName)) {
+    return status === "complete" ? "Ran" : "Running";
+  }
+  if (isWebSearchToolName(toolName)) {
+    if (status === "complete") {
       return "Searched the web";
     }
-    if (update.state === "error") {
+    if (status === "error") {
       return "Attempted to search the web";
     }
     return "Searching the web";
   }
   return getDisplayToolName(toolName);
+}
+
+function formatSlackTaskTitleForStatus(
+  task: SlackProgressToolTask,
+  status: SlackStreamTaskStatus,
+): string {
+  if (task.kind === "responding") {
+    return formatSlackChannelResponseTitle(status);
+  }
+  if (task.toolName) {
+    return formatSlackToolTaskTitle(task.toolName, status, task.details);
+  }
+  return task.title;
 }
 
 function rememberSlackToolName(
@@ -850,17 +829,12 @@ function rememberSlackToolName(
     entry.hiddenToolCallIds ??= new Set();
     entry.hiddenToolCallIds.add(update.toolCallId);
     entry.toolNamesByCallId?.delete(update.toolCallId);
-    entry.toolTitlesByCallId?.delete(update.toolCallId);
     entry.toolDetailsByCallId?.delete(update.toolCallId);
     return;
   }
   if (update.toolName) {
     entry.toolNamesByCallId ??= new Map();
     entry.toolNamesByCallId.set(update.toolCallId, update.toolName);
-  }
-  if (update.toolTitle) {
-    entry.toolTitlesByCallId ??= new Map();
-    entry.toolTitlesByCallId.set(update.toolCallId, update.toolTitle);
   }
   if (update.toolDetails) {
     entry.toolDetailsByCallId ??= new Map();
@@ -878,104 +852,31 @@ function isSlackHiddenToolUpdate(
   );
 }
 
-function formatSlackToolTitleForState(
-  title: string,
-  update: ChannelTurnProgressEvent,
-): string {
-  if (title === "Running") {
-    return update.state === "completed" ? "Ran" : "Running";
-  }
-  if (title === "Bash") {
-    return update.state === "completed" ? "Ran" : "Running";
-  }
-  if (title === "Search the web") {
-    if (update.state === "completed") {
-      return "Searched the web";
-    }
-    if (update.state === "error") {
-      return "Attempted to search the web";
-    }
-    return "Searching the web";
-  }
-  if (update.state === "completed" && title.startsWith("Searching ")) {
-    return `Searched ${title.slice("Searching ".length)}`;
-  }
-  if (update.state === "error" && title.startsWith("Searching ")) {
-    return `Attempted to search ${title.slice("Searching ".length)}`;
-  }
-  return title;
-}
-
-function formatSlackToolTitleForTerminalStatus(
-  title: string,
-  status: SlackStreamTaskStatus,
-): string {
-  if (title === "Running") {
-    return status === "complete" ? "Ran" : "Running";
-  }
-  if (title === "Bash") {
-    return status === "complete" ? "Ran" : "Running";
-  }
-  if (title === "Responding") {
-    if (status === "complete") {
-      return "Responded";
-    }
-    if (status === "error") {
-      return "Response failed";
-    }
-    return "Responding";
-  }
-  if (title === "Search the web") {
-    if (status === "complete") {
-      return "Searched the web";
-    }
-    if (status === "error") {
-      return "Attempted to search the web";
-    }
-    return "Searching the web";
-  }
-  if (status === "complete" && title.startsWith("Searching ")) {
-    return `Searched ${title.slice("Searching ".length)}`;
-  }
-  if (status === "error" && title.startsWith("Searching ")) {
-    return `Attempted to search ${title.slice("Searching ".length)}`;
-  }
-  return title;
-}
-
 function resolveSlackToolActionName(
   entry: SlackProgressCardEntry,
   update: ChannelTurnProgressEvent,
+  details?: string,
 ): string | null {
   if (update.toolCallId && entry.hiddenToolCallIds?.has(update.toolCallId)) {
     return null;
   }
-  const rememberedTitle = update.toolCallId
-    ? entry.toolTitlesByCallId?.get(update.toolCallId)
-    : undefined;
-  const toolTitle = update.toolTitle ?? rememberedTitle;
   const approvalPrefix = update.kind === "approval" ? "Approval needed: " : "";
-  if (toolTitle) {
-    return sanitizeSlackProgressText(
-      `${approvalPrefix}${formatSlackToolTitleForState(toolTitle, update)}`,
-      SLACK_STREAM_CHUNK_TEXT_MAX,
-    );
-  }
-  if (update.toolName) {
-    if (isSlackHiddenToolName(update.toolName)) {
+  const toolName =
+    update.toolName ??
+    (update.toolCallId
+      ? entry.toolNamesByCallId?.get(update.toolCallId)
+      : undefined);
+  if (toolName) {
+    if (isSlackHiddenToolName(toolName)) {
       return null;
     }
-    return sanitizeSlackProgressText(
-      `${approvalPrefix}${formatSlackToolNameForDisplay(update.toolName, update)}`,
-      SLACK_STREAM_CHUNK_TEXT_MAX,
+    const title = formatSlackToolTaskTitle(
+      toolName,
+      toSlackStreamTaskStatus(update),
+      details,
     );
-  }
-  const rememberedName = update.toolCallId
-    ? entry.toolNamesByCallId?.get(update.toolCallId)
-    : undefined;
-  if (rememberedName) {
     return sanitizeSlackProgressText(
-      `${approvalPrefix}${formatSlackToolNameForDisplay(rememberedName, update)}`,
+      `${approvalPrefix}${title}`,
       SLACK_STREAM_CHUNK_TEXT_MAX,
     );
   }
@@ -1143,9 +1044,6 @@ function buildSlackChannelResponseProgressChunks(
   const title = formatSlackChannelResponseTitle(status);
   const prevTask = entry.toolTasksById?.get(SLACK_CHANNEL_RESPONSE_TASK_ID);
   if (prevTask?.title === title && prevTask.status === status) {
-    debugSlackProgress(
-      `[RESPONSE-SKIP-SAME] id=${SLACK_CHANNEL_RESPONSE_TASK_ID} title=${title} status=${status}`,
-    );
     return [];
   }
 
@@ -1159,7 +1057,7 @@ function buildSlackChannelResponseProgressChunks(
   entry.reasoningActive = false;
   entry.toolTasksById.set(task.id, task);
 
-  const chunks: SlackStreamChunk[] = [
+  return [
     buildSlackPlanUpdateChunk(entry),
     {
       type: "task_update",
@@ -1168,10 +1066,6 @@ function buildSlackChannelResponseProgressChunks(
       status: task.status,
     },
   ];
-  debugSlackProgress(
-    `[RESPONSE-CHUNKS] id=${task.id} title=${title} status=${status} chunks=${describeSlackStreamChunks(chunks)}`,
-  );
-  return chunks;
 }
 
 function buildSlackStreamProgressChunks(
@@ -1182,9 +1076,6 @@ function buildSlackStreamProgressChunks(
   if (update.kind === "thinking" || update.kind === "responding") {
     const reasoningActive = update.state !== "completed";
     if (entry.reasoningActive === reasoningActive) {
-      debugSlackProgress(
-        `[REASONING-SKIP] kind=${update.kind} state=${update.state} active=${reasoningActive}`,
-      );
       return [];
     }
     entry.reasoningActive = reasoningActive;
@@ -1192,12 +1083,7 @@ function buildSlackStreamProgressChunks(
     // exists because visible tools ran earlier in the turn, update the native
     // plan/header title without adding synthetic task rows. Synthetic rows
     // become stale next to concrete tool rows because Slack keeps every task id.
-    const chunks =
-      entry.mode === "stream" ? [buildSlackPlanUpdateChunk(entry)] : [];
-    debugSlackProgress(
-      `[REASONING] kind=${update.kind} state=${update.state} active=${reasoningActive} mode=${entry.mode ?? "none"} chunks=${describeSlackStreamChunks(chunks)}`,
-    );
-    return chunks;
+    return entry.mode === "stream" ? [buildSlackPlanUpdateChunk(entry)] : [];
   }
 
   if (isSlackMessageChannelToolUpdate(entry, update)) {
@@ -1208,14 +1094,6 @@ function buildSlackStreamProgressChunks(
   // stable per-call task ids to preserve parallel tool history in the card.
   const id = resolveSlackToolActionTaskId(update);
   if (!id) {
-    debugSlackProgress(`[NO-ID] kind=${update.kind} state=${update.state}`);
-    return [];
-  }
-  const title = resolveSlackToolActionName(entry, update);
-  if (!title) {
-    debugSlackProgress(
-      `[NO-TITLE] id=${id} kind=${update.kind} state=${update.state} tool=${update.toolName ?? "none"}`,
-    );
     return [];
   }
   const status = toSlackStreamTaskStatus(update);
@@ -1227,6 +1105,10 @@ function buildSlackStreamProgressChunks(
     sentDetails && resolvedDetails && sentDetails !== resolvedDetails
       ? sentDetails
       : resolvedDetails;
+  const title = resolveSlackToolActionName(entry, update, details);
+  if (!title) {
+    return [];
+  }
 
   // Skip the entire appendStream call if nothing has changed for this task.
   // Slack's streaming API re-renders details on every appendStream, so even
@@ -1236,9 +1118,6 @@ function buildSlackStreamProgressChunks(
   // both a "completed" and an "error" tool_return for the same call; the
   // completed event arrives first and is the reliable one.
   if (prevTask && prevTask.status === "complete" && status === "error") {
-    debugSlackProgress(
-      `[SKIP-DOWNGRADE] id=${id} title=${title} details=${details ?? "none"}`,
-    );
     return [];
   }
   if (
@@ -1247,14 +1126,17 @@ function buildSlackStreamProgressChunks(
     prevTask.status === status &&
     (prevTask.details ?? "") === (details ?? "")
   ) {
-    debugSlackProgress(
-      `[SKIP-SAME] id=${id} title=${title} status=${status} details=${details ?? "none"}`,
-    );
     return [];
   }
+  const toolName =
+    update.toolName ??
+    (update.toolCallId
+      ? entry.toolNamesByCallId?.get(update.toolCallId)
+      : undefined);
   const task: SlackProgressToolTask = {
     id,
     kind: update.kind,
+    ...(toolName ? { toolName } : {}),
     title,
     status,
     ...(details ? { details } : {}),
@@ -1282,10 +1164,6 @@ function buildSlackStreamProgressChunks(
       ? { details }
       : {}),
   });
-
-  debugSlackProgress(
-    `[BUILD-CHUNKS] id=${id} title=${title} status=${status} details=${details ?? "none"} detailsChanged=${detailsChanged} chunks=${describeSlackStreamChunks(chunks)}`,
-  );
 
   return chunks;
 }
@@ -1970,9 +1848,6 @@ export function createSlackAdapter(
       args.recipient_user_id = entry.source.senderId;
       args.recipient_team_id = recipientTeamId;
     }
-    debugSlackProgress(
-      `[START-ARGS] chunks=${describeSlackStreamChunks(args.chunks ?? [])}`,
-    );
     return args;
   }
 
@@ -2011,9 +1886,6 @@ export function createSlackAdapter(
       entry.streamTs = response.ts;
       rememberMessageThread(response.ts, replyToMessageId);
       rememberSlackStreamTaskDetails(entry, args.chunks ?? []);
-      debugSlackProgress(
-        `[START-OK] ts=${response.ts} chunks=${describeSlackStreamChunks(args.chunks ?? [])}`,
-      );
       // Once the native stream card is visible, clear Slack's assistant
       // thread status so Slack doesn't render a second "is processing" field
       // under our task card.
@@ -2037,7 +1909,6 @@ export function createSlackAdapter(
     }
     const chunks = compactSlackStreamChunks(rawChunks, entry);
     if (chunks.length === 0) {
-      debugSlackProgress("[APPEND-SKIP-EMPTY]");
       return true;
     }
     await ensureApp();
@@ -2060,9 +1931,6 @@ export function createSlackAdapter(
         return false;
       }
       rememberSlackStreamTaskDetails(entry, chunks);
-      debugSlackProgress(
-        `[APPEND-OK] chunks=${describeSlackStreamChunks(chunks)}`,
-      );
       return true;
     } catch (error) {
       console.warn(
@@ -2097,9 +1965,6 @@ export function createSlackAdapter(
       terminalTaskStatus,
       finalErrorChunk,
     );
-    debugSlackProgress(
-      `[STOP-ARGS] terminal=${terminalTaskStatus} chunks=${describeSlackStreamChunks(chunks)}`,
-    );
     try {
       const args: SlackStopStreamArgs = {
         channel: entry.source.chatId,
@@ -2120,9 +1985,6 @@ export function createSlackAdapter(
         return false;
       }
       rememberSlackStreamTaskDetails(entry, chunks);
-      debugSlackProgress(
-        `[STOP-OK] chunks=${describeSlackStreamChunks(chunks)}`,
-      );
       return true;
     } catch (error) {
       if (isSlackMessageNotStreamingStateError(error)) {
@@ -2272,11 +2134,7 @@ export function createSlackAdapter(
           chunksToSend,
         );
       } else if (entry.mode === "stream") {
-        const didAppend = await appendSlackProgressStream(entry, chunksToSend);
-        didSend = didAppend;
-        if (!didAppend) {
-          debugSlackProgress("[APPEND-FAILED-PRESERVE-STREAM]");
-        }
+        didSend = await appendSlackProgressStream(entry, chunksToSend);
       }
 
       if (!didSend && chunksToSend.length > 0) {
@@ -2404,11 +2262,6 @@ export function createSlackAdapter(
     entry.latestText = progressText;
     entry.latestUpdate = options.update;
     rememberSlackToolName(entry, options.update);
-    if (options.update) {
-      debugSlackProgress(
-        `[EVENT] kind=${options.update.kind} state=${options.update.state} toolCallId=${options.update.toolCallId ?? "none"} toolName=${options.update.toolName ?? "none"} toolTitle=${options.update.toolTitle ?? "none"} toolDetails=${options.update.toolDetails ?? "none"}`,
-      );
-    }
     const streamChunks = options.update
       ? buildSlackStreamProgressChunks(entry, options.update)
       : [];
@@ -2420,9 +2273,6 @@ export function createSlackAdapter(
       options.update?.kind === "thinking" ||
       options.update?.kind === "responding";
     if (options.update && streamChunks.length === 0 && !isReasoningEvent) {
-      debugSlackProgress(
-        `[UPSERT-SKIP-NO-CHUNKS] kind=${options.update.kind} state=${options.update.state}`,
-      );
       return;
     }
     if (streamChunks.length > 0) {
@@ -2441,9 +2291,6 @@ export function createSlackAdapter(
     // can be delayed by the reasoning timestamp and appear only once it has
     // already completed.
     if (isReasoningEvent && streamChunks.length === 0) {
-      debugSlackProgress(
-        `[UPSERT-REASONING-NO-FLUSH] kind=${options.update?.kind} state=${options.update?.state}`,
-      );
       return;
     }
 
@@ -2465,15 +2312,9 @@ export function createSlackAdapter(
       progressUpdateThrottleMs === 0 ||
       elapsed >= progressUpdateThrottleMs
     ) {
-      debugSlackProgress(
-        `[UPSERT-FLUSH] force=${Boolean(options.force)} hasNewTaskDetails=${hasNewTaskDetails} lastSentAt=${entry.lastSentAt} elapsed=${elapsed} pending=${entry.pendingStreamChunks?.length ?? 0}`,
-      );
       await flushSlackProgressCard(key, entry);
       return;
     }
-    debugSlackProgress(
-      `[UPSERT-SCHEDULE] delay=${Math.max(0, progressUpdateThrottleMs - elapsed)} hasNewTaskDetails=${hasNewTaskDetails} pending=${entry.pendingStreamChunks?.length ?? 0}`,
-    );
     scheduleProgressCardFlush(
       key,
       entry,
@@ -2543,7 +2384,6 @@ export function createSlackAdapter(
         entry.toolTasksById = undefined;
         entry.pendingStreamChunks = undefined;
         entry.toolNamesByCallId = undefined;
-        entry.toolTitlesByCallId = undefined;
         entry.toolDetailsByCallId = undefined;
         entry.sentTaskDetailsById = undefined;
         entry.reasoningActive = undefined;

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -120,8 +120,6 @@ export interface ChannelTurnProgressUpdate {
   message: string;
   toolCallId?: string;
   toolName?: string;
-  /** Optional sanitized display title for tool progress rows. */
-  toolTitle?: string;
   /** Optional sanitized argument summary for expanded tool progress details. */
   toolDetails?: string;
   command?: string;

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -5,7 +5,6 @@ import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agen
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import { getScopedMemoryFilesystemRoot } from "@/agent/memory-filesystem";
 import { getSubagents } from "@/agent/subagent-state";
-import { buildChannelTurnProgressUpdatesFromDelta } from "@/channels/progress";
 import { getChannelRegistry } from "@/channels/registry";
 import { getGitContext } from "@/cli/helpers/git-context";
 import { getReflectionSettings } from "@/cli/helpers/memory-reminder";
@@ -1133,17 +1132,22 @@ export function createLifecycleMessageBase<TMessageType extends string>(
 function getActiveChannelTurnProgressContext(runtime: RuntimeCarrier): {
   sources: NonNullable<ConversationRuntime["activeChannelTurnSources"]>;
   batchId: string | null;
+  progressBuilder: NonNullable<
+    ConversationRuntime["activeChannelTurnProgress"]
+  >;
 } | null {
   if (!runtime || !("activeChannelTurnSources" in runtime)) {
     return null;
   }
   const sources = runtime.activeChannelTurnSources;
-  if (!sources || sources.length === 0) {
+  const progressBuilder = runtime.activeChannelTurnProgress;
+  if (!sources || sources.length === 0 || !progressBuilder) {
     return null;
   }
   return {
     sources,
     batchId: runtime.activeChannelTurnBatchId,
+    progressBuilder,
   };
 }
 
@@ -1155,7 +1159,7 @@ function dispatchChannelTurnProgressFromDelta(
   if (!context) {
     return;
   }
-  const updates = buildChannelTurnProgressUpdatesFromDelta(delta);
+  const updates = context.progressBuilder.buildUpdates(delta);
   if (updates.length === 0) {
     return;
   }

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -1,5 +1,5 @@
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
-import { clearToolCallArgumentsCache } from "@/channels/progress";
+import { createChannelTurnProgressBuilder } from "@/channels/progress";
 import { getChannelRegistry } from "@/channels/registry";
 import type { ChannelTurnOutcome, ChannelTurnSource } from "@/channels/types";
 import type {
@@ -552,6 +552,10 @@ async function drainQueuedMessages(
       let didThrow = false;
       runtime.activeChannelTurnSources = channelTurnSources;
       runtime.activeChannelTurnBatchId = dequeuedBatch.batchId;
+      runtime.activeChannelTurnProgress =
+        channelTurnSources.length > 0
+          ? createChannelTurnProgressBuilder()
+          : null;
       try {
         await processQueuedTurn(queuedTurn, dequeuedBatch);
       } catch (error) {
@@ -561,8 +565,8 @@ async function drainQueuedMessages(
       } finally {
         runtime.activeChannelTurnSources = null;
         runtime.activeChannelTurnBatchId = null;
+        runtime.activeChannelTurnProgress = null;
         if (channelTurnSources.length > 0) {
-          clearToolCallArgumentsCache();
           const outcome = mapTurnLifecycleOutcome(
             runtime.lastStopReason,
             didThrow,

--- a/src/websocket/listener/runtime.ts
+++ b/src/websocket/listener/runtime.ts
@@ -161,6 +161,7 @@ export function createConversationRuntime(
     conversationId: normalizedConversationId,
     activeChannelTurnSources: null,
     activeChannelTurnBatchId: null,
+    activeChannelTurnProgress: null,
     messageQueue: Promise.resolve(),
     pendingApprovalResolvers: new Map(),
     recoveredApprovalState: null,

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -5,6 +5,7 @@ import type {
   ApprovalDecision,
   ApprovalResult,
 } from "@/agent/approval-execution";
+import type { ChannelTurnProgressBuilder } from "@/channels/progress";
 import type { ChannelTurnSource } from "@/channels/types";
 import type { ContextTracker } from "@/cli/helpers/context-tracker";
 import type { ApprovalRequest } from "@/cli/helpers/stream";
@@ -141,6 +142,8 @@ export type ConversationRuntime = {
   conversationId: string;
   activeChannelTurnSources: ChannelTurnSource[] | null;
   activeChannelTurnBatchId: string | null;
+  /** Per-turn progress builder; created when a channel turn starts and dropped when it ends. */
+  activeChannelTurnProgress: ChannelTurnProgressBuilder | null;
   messageQueue: Promise<void>;
   pendingApprovalResolvers: Map<string, PendingApprovalResolver>;
   recoveredApprovalState: RecoveredApprovalState | null;


### PR DESCRIPTION
## Summary

Follow-up to the review on #3029 — fixes the identified issues (all except the scope-creep item, which is left as-is):

- **Cross-conversation global state (#1):** `progress.ts` no longer keeps module-global `Map`s of streamed tool-call arguments/names keyed by `tool_call_id`. Progress updates are now built by a per-turn `ChannelTurnProgressBuilder` stored on `ConversationRuntime` (`activeChannelTurnProgress`), created when a channel turn starts and dropped in the same `finally` that clears the turn sources. Concurrent conversations in one listener process can no longer cross-contaminate or clear each other's streaming state, and `clearToolCallArgumentsCache()` is gone.
- **Display-string state machine (#2):** `toolTitle` is removed from `ChannelTurnProgressUpdate`. The adapter no longer pattern-matches rendered strings (`title === "Running"`, `startsWith("Searching ")`) to transition titles. Tasks store the raw `toolName`, and `formatSlackToolTaskTitle(toolName, status, details)` is the single derivation point for both live updates and terminal rewrites.
- **Shape-guessing extraction (#3):** `extractToolCallSummary` now targets the actual wire shape — flat `tool_call_id`/`name`/`arguments` per the SDK `ToolCall`/`ToolCallDelta` types and the local backend projections — instead of probing five candidate shapes (`function.arguments`, `input`, `args`, record-level fallbacks). Detail extraction dispatches on tool predicates (`isShellTool`, `isTaskTool`, display-name mapping) rather than guessing from argument shape. Object-form `arguments` are still stringified defensively (one line, not a shape fork).
- **Duplicated sanitizers (#4):** secret redaction / ANSI / control-character / mention-neutralizing logic lives once in `sanitizeChannelProgressCore`; the Slack adapter layers only mrkdwn escaping and its `…` truncation marker on top. The Slack path also gains the JSON-style secret redaction it previously lacked.
- **Debug scaffolding (#5):** `debugSlackProgress`, `describeSlackStreamChunk(s)`, and the `LETTA_SLACK_PROGRESS_DEBUG` env knob are removed.
- **PowerShell heuristics (#6):** the `-Pattern`/`$lines`-specific regex rewrites are removed from shell command previews; the generic first-segment/pipeline-trim preview remains.
- **Duplicate formatter (#7):** the parallel per-tool title formatter in progress.ts is gone along with `toolTitle`; the remaining `formatSlackToolNameForDisplay` handles only the no-status contexts (control-request blocks, command fallback).
- Remaining env knobs (throttle/keepalive) now have doc comments at their definition (#9).

Net: −425 lines. `progress.test.ts` is rewritten against the builder API and the real flat wire shape (the old tests exercised OpenAI-nested `{id, function: {...}}` shapes that no producer in this repo emits), including a regression test that two builders don't share accumulated state.

## Test plan

- [x] `bun run check` (9/9 pass)
- [x] `bun test src/channels/progress.test.ts src/channels/slack-adapter.test.ts src/websocket/turn-approval.test.ts` (84 pass / 0 fail)
- [x] Verified the 5 pre-existing local-env failures in `slack-registry.test.ts` reproduce identically on the unmodified branch head (not introduced here)

👾 Generated with [Letta Code](https://letta.com)