### PR TITLE
fix(mods): enable mod permissions in listener/desktop runtime

### DIFF
--- a/src/websocket/listener/mod-adapter.ts
+++ b/src/websocket/listener/mod-adapter.ts
@@ -16,7 +16,7 @@ export const LISTENER_MOD_CAPABILITIES: ModCapabilities = {
     compact: false,
     llm: false,
   },
-  permissions: false,
+  permissions: true,
   providers: true,
   ui: {
     panels: false,


### PR DESCRIPTION
## Summary
- Flip `LISTENER_MOD_CAPABILITIES.permissions` from `false` to `true`
- The listener approval flow already calls `checkPermissionWithHooks` → `checkModPermissions`, but the mod engine was silently no-oping `registerPermission` calls because the capability was disabled
- No new wiring needed — the permission checking infrastructure was already in place

## Test plan
- [ ] Install a mod that registers a permission check (e.g. tool-guard-inspector) in listener/desktop mode
- [ ] Verify the mod permission is enforced during tool approval
- [ ] Verify existing permission flows are unaffected

👾 Generated with [Letta Code](https://letta.com)