### PR TITLE
feat(mods): add agentId to ModBackgroundAgentContext

### DIFF
--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -2321,6 +2321,7 @@ export function App({
       type: a.type,
       status: a.status,
       durationMs: Date.now() - a.startTime,
+      agentId: a.agentId ?? null,
     })),
   });
   const agentModsDirectory =

--- a/src/cli/cli-mod-context.test.ts
+++ b/src/cli/cli-mod-context.test.ts
@@ -30,7 +30,12 @@ describe("buildCliModContext", () => {
       networkPhase: "download",
       terminalWidth: 120,
       backgroundAgents: [
-        { type: "general-purpose", status: "running", durationMs: 1234 },
+        {
+          type: "general-purpose",
+          status: "running",
+          durationMs: 1234,
+          agentId: "agent-bg-1",
+        },
       ],
     });
 
@@ -56,7 +61,12 @@ describe("buildCliModContext", () => {
     expect(context.networkPhase).toBe("download");
     expect(context.terminalWidth).toBe(120);
     expect(context.backgroundAgents).toEqual([
-      { type: "general-purpose", status: "running", durationMs: 1234 },
+      {
+        type: "general-purpose",
+        status: "running",
+        durationMs: 1234,
+        agentId: "agent-bg-1",
+      },
     ]);
   });
 

--- a/src/mods/types.ts
+++ b/src/mods/types.ts
@@ -63,6 +63,7 @@ export interface ModBackgroundAgentContext {
   type: string;
   status: string;
   durationMs: number;
+  agentId: string | null;
 }
 
 export interface ModUiCapabilities {


### PR DESCRIPTION
## Summary
- Add `agentId: string | null` to `ModBackgroundAgentContext` so panel authors can build agent links
- Populated in `AppCoordinator` from `getActiveBackgroundAgents()` — no consumers yet, the field is unused

## Test plan
- [x] `bun run check` passes
- [x] Affected tests pass (`cli-mod-context.test.ts`, `mod-engine.test.ts`, `mod-adapter.test.ts`)

👾 Generated with [Letta Code](https://letta.com)