### PR TITLE
feat(listener): include image assets in list_memory responses

### DIFF
--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -1276,6 +1276,8 @@ export interface MemoryFileEntry {
   content: string;
   size: number;
   references?: string[];
+  kind?: "markdown" | "image";
+  mime_type?: string | null;
 }
 
 export interface ListMemoryResponseMessage {

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -2446,6 +2446,75 @@ describe("listen-client memory command handling", () => {
     }
   });
 
+  test("lists supported image assets alongside markdown memory", async () => {
+    const tempRoot = await mkdtemp(join(os.tmpdir(), "letta-list-memory-"));
+    const socket = new MockSocket(WebSocket.OPEN);
+    const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const ensureLocalMemfsCheckoutMock = mock(async () => {
+      await mkdir(join(tempRoot, ".git"), { recursive: true });
+      await mkdir(join(tempRoot, "system"), { recursive: true });
+      await writeFile(
+        join(tempRoot, "system", "persona.md"),
+        "---\ndescription: Persona\n---\nHello from memory\n",
+      );
+      await writeFile(join(tempRoot, "profile.png"), pngBytes);
+      await writeFile(join(tempRoot, "notes.bin"), Buffer.from([0x00, 0x01]));
+    });
+
+    try {
+      await __listenClientTestUtils.handleListMemoryCommand(
+        {
+          type: "list_memory",
+          request_id: "list-memory-images-1",
+          agent_id: "agent-1",
+          include_references: true,
+        },
+        socket as unknown as WebSocket,
+        {
+          getMemoryFilesystemRoot: () => tempRoot,
+          isMemfsEnabledOnServer: async () => true,
+          ensureLocalMemfsCheckout: ensureLocalMemfsCheckoutMock,
+        },
+      );
+
+      const messages = socket.sentPayloads.map((payload) =>
+        JSON.parse(payload as string),
+      );
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toMatchObject({
+        type: "list_memory_response",
+        request_id: "list-memory-images-1",
+        success: true,
+        done: true,
+        total: 2,
+      });
+      // Scanner orders directories first, so system/persona.md precedes
+      // the root-level profile.png. Unsupported binaries stay hidden.
+      expect(messages[0].entries).toEqual([
+        expect.objectContaining({
+          relative_path: "system/persona.md",
+          is_system: true,
+          description: "Persona",
+          kind: "markdown",
+          mime_type: "text/markdown",
+          references: [],
+        }),
+        expect.objectContaining({
+          relative_path: "profile.png",
+          is_system: false,
+          description: null,
+          content: "",
+          size: pngBytes.length,
+          kind: "image",
+          mime_type: "image/png",
+          references: [],
+        }),
+      ]);
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   test("pulls an existing local memfs checkout before scanning", async () => {
     const tempRoot = await mkdtemp(join(os.tmpdir(), "letta-list-memory-"));
     const socket = new MockSocket(WebSocket.OPEN);

--- a/src/websocket/listener/commands/memory.ts
+++ b/src/websocket/listener/commands/memory.ts
@@ -16,6 +16,31 @@ import type { RunDetachedListenerTask, SafeSocketSend } from "./types";
 
 const WIKI_LINK_REGEX = /\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g;
 
+// Image assets the memory viewer can render inline. Must stay in sync with
+// the server-side memory files API's supported image set.
+const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
+  ".gif": "image/gif",
+  ".jpeg": "image/jpeg",
+  ".jpg": "image/jpeg",
+  ".png": "image/png",
+  ".webp": "image/webp",
+};
+
+function getLowercaseExtension(path: string): string {
+  const lastSlash = path.lastIndexOf("/");
+  const lastDot = path.lastIndexOf(".");
+  if (lastDot <= lastSlash) return "";
+  return path.slice(lastDot).toLowerCase();
+}
+
+function getMemoryImageMimeType(path: string): string | null {
+  return IMAGE_MIME_BY_EXTENSION[getLowercaseExtension(path)] ?? null;
+}
+
+function isMarkdownMemoryPath(path: string): boolean {
+  return getLowercaseExtension(path) === ".md";
+}
+
 export type ListMemoryCommandTestOverrides = {
   ensureLocalMemfsCheckout?: (
     agentId: string,
@@ -65,7 +90,7 @@ export async function handleListMemoryCommand(
       await import("@/agent/memory-scanner");
     const { parseFrontmatter } = await import("@/utils/frontmatter");
 
-    const { existsSync } = await import("node:fs");
+    const { existsSync, statSync } = await import("node:fs");
     const { join, posix } = await import("node:path");
 
     const memoryRoot = getMemoryFilesystemRoot(parsed.agent_id);
@@ -105,12 +130,19 @@ export async function handleListMemoryCommand(
     }
 
     const treeNodes = scanMemoryFilesystem(memoryRoot);
-    const fileNodes = getFileNodes(treeNodes).filter((n) =>
-      n.name.endsWith(".md"),
+    const fileNodes = getFileNodes(treeNodes).filter(
+      (n) =>
+        isMarkdownMemoryPath(n.relativePath) ||
+        getMemoryImageMimeType(n.relativePath) !== null,
     );
     const includeReferences = parsed.include_references === true;
 
-    const allPaths = new Set(fileNodes.map((node) => node.relativePath));
+    // Wiki-link references only ever resolve to markdown files.
+    const allPaths = new Set(
+      fileNodes
+        .map((node) => node.relativePath)
+        .filter((path) => isMarkdownMemoryPath(path)),
+    );
 
     const normalizeMemoryReference = (
       rawReference: string,
@@ -219,14 +251,34 @@ export async function handleListMemoryCommand(
     for (let i = 0; i < total; i += CHUNK_SIZE) {
       const chunk = fileNodes.slice(i, i + CHUNK_SIZE);
       const entries = chunk.map((node) => {
+        const isSystem =
+          node.relativePath.startsWith("system/") ||
+          node.relativePath.startsWith("system\\");
+
+        const imageMimeType = getMemoryImageMimeType(node.relativePath);
+        if (imageMimeType) {
+          let size = 0;
+          try {
+            size = statSync(node.fullPath).size;
+          } catch {}
+          return {
+            relative_path: node.relativePath,
+            is_system: isSystem,
+            description: null,
+            content: "",
+            size,
+            ...(includeReferences ? { references: [] } : {}),
+            kind: "image" as const,
+            mime_type: imageMimeType,
+          };
+        }
+
         const raw = readFileContent(node.fullPath);
         const { frontmatter, body } = parseFrontmatter(raw);
         const desc = frontmatter.description;
         return {
           relative_path: node.relativePath,
-          is_system:
-            node.relativePath.startsWith("system/") ||
-            node.relativePath.startsWith("system\\"),
+          is_system: isSystem,
           description: typeof desc === "string" ? desc : null,
           content: body,
           size: body.length,
@@ -235,6 +287,8 @@ export async function handleListMemoryCommand(
                 references: extractMemoryReferences(body, node.relativePath),
               }
             : {}),
+          kind: "markdown" as const,
+          mime_type: "text/markdown",
         };
       });
 


### PR DESCRIPTION
## Summary
- The listener's `list_memory` handler filtered the MemFS scan to `.md` files, so image assets (e.g. `profile.png`) never appeared in the web memory viewer's file list — even though `read_memory_file` already supports base64 reads for them.
- Supported images (`.gif`/`.jpeg`/`.jpg`/`.png`/`.webp`) are now listed as entries with `kind: "image"` and their MIME type. Image bytes are not read during listing (`content` stays empty; `size` comes from `stat`). Unsupported binaries remain hidden.
- Markdown entries now carry `kind: "markdown"` / `mime_type: "text/markdown"` for symmetry, and `MemoryFileEntry` gains optional `kind`/`mime_type` fields (additive, so older consumers are unaffected). Wiki-link reference resolution remains markdown-only.

Companion to the web-side memory viewer image rendering change, which already consumes `kind`/`mime_type` with safe defaults (`kind ?? "markdown"`) — either side can ship first.

👾 Generated with [Letta Code](https://letta.com)