### PR TITLE
fix(app-server): Emit app-server approval control requests

### DIFF
--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -2795,6 +2795,7 @@ export type WsProtocolCommand =
 export type WsProtocolCommandType = WsProtocolCommand["type"];
 
 export type WsProtocolMessage =
+  | ControlRequest
   | DeviceStatusUpdateMessage
   | LoopStatusUpdateMessage
   | QueueUpdateMessage

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -5226,7 +5226,7 @@ describe("listen-client capability-gated approval flow", () => {
     }
   });
 
-  test("requestApprovalOverWS exposes the control request through device status instead of stream_delta", () => {
+  test("requestApprovalOverWS emits control_request and exposes it through device status", () => {
     const listener = __listenClientTestUtils.createListenerRuntime();
     const runtime = __listenClientTestUtils.getOrCreateScopedRuntime(
       listener,
@@ -5254,8 +5254,21 @@ describe("listen-client capability-gated approval flow", () => {
     const deviceStatus = outbound.find(
       (payload) => payload.type === "update_device_status",
     );
+    const controlRequest = outbound.find(
+      (payload) => payload.type === "control_request",
+    );
+    expect(controlRequest).toBeDefined();
     expect(loopStatus).toBeDefined();
     expect(deviceStatus).toBeDefined();
+    expect(controlRequest.type).toBe("control_request");
+    expect(controlRequest.request_id).toBe(requestId);
+    expect(controlRequest.request).toEqual(
+      makeControlRequest(requestId).request,
+    );
+    expect(controlRequest.runtime).toEqual({
+      agent_id: "agent-1",
+      conversation_id: "default",
+    });
     expect(loopStatus.type).toBe("update_loop_status");
     expect(loopStatus.loop_status.status).toBe("WAITING_ON_APPROVAL");
     expect(runtime.lastStopReason).toBe("requires_approval");

--- a/src/websocket/listener/approval.ts
+++ b/src/websocket/listener/approval.ts
@@ -3,6 +3,7 @@ import type { ApprovalResponseBody, ControlRequest } from "@/types/protocol_v2";
 import {
   emitDeviceStatusIfOpen,
   emitLoopStatusIfOpen,
+  emitProtocolV2Message,
   setLoopStatus,
 } from "./protocol-outbound";
 import { evictConversationRuntimeIfIdle } from "./runtime";
@@ -298,6 +299,10 @@ export function requestApprovalOverWS(
     }
     runtime.lastStopReason = "requires_approval";
     setLoopStatus(runtime, "WAITING_ON_APPROVAL");
+    emitProtocolV2Message(socket, runtime, controlRequest, {
+      agent_id: runtime.agentId,
+      conversation_id: runtime.conversationId,
+    });
     emitLoopStatusIfOpen(runtime.listener, {
       agent_id: runtime.agentId,
       conversation_id: runtime.conversationId,


### PR DESCRIPTION
## Summary
- emit  frames when app-server approvals need user input
- keep pending approval requests projected in device status for existing clients
- include  in the app-server outbound protocol message union

## Tests
- bun test v1.3.4 (5eb2145b)
- 
- Checked 1205 files in 304ms. No fixes applied.
Found 4 warnings.