### PR TITLE
test: update listener mod capabilities expectation for enabled permissions

### DIFF
--- a/src/websocket/listener/mod-adapter.test.ts
+++ b/src/websocket/listener/mod-adapter.test.ts
@@ -54,7 +54,7 @@ describe("listener mod adapter", () => {
         compact: false,
         llm: false,
       },
-      permissions: false,
+      permissions: true,
       providers: true,
       ui: {
         panels: false,


### PR DESCRIPTION
## Summary
- #3199 flipped `LISTENER_MOD_CAPABILITIES.permissions` to `true` but left the test expecting `false`, so `mod-adapter.test.ts` fails on main. This updates the expectation to match.

👾 Generated with [Letta Code](https://letta.com)