### PR TITLE
fix(sandbox): make the cross-agent shell sandbox opt-in, keep memory-subagent sandbox default-on

### DIFF
--- a/src/agent/subagents/sandbox.test.ts
+++ b/src/agent/subagents/sandbox.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@/permissions/sandbox-policy";
 import {
   isFsSandboxEnabled,
+  isShellSandboxEnabled,
   type SandboxAvailability,
 } from "@/sandbox/availability";
 import { SANDBOX_ENV_VAR } from "@/sandbox/policy";
@@ -56,6 +57,19 @@ test("isFsSandboxEnabled is on by default and only an explicit off-switch disabl
   expect(isFsSandboxEnabled({ LETTA_FS_SANDBOX: "0" })).toBe(false);
   expect(isFsSandboxEnabled({ LETTA_FS_SANDBOX: "false" })).toBe(false);
   expect(isFsSandboxEnabled({ LETTA_FS_SANDBOX: "FALSE" })).toBe(false);
+});
+
+test("isShellSandboxEnabled is off by default and only an explicit on-switch enables it", () => {
+  // Default off (unset / empty): only memory subagents are sandboxed.
+  expect(isShellSandboxEnabled({})).toBe(false);
+  expect(isShellSandboxEnabled({ LETTA_FS_SANDBOX: "" })).toBe(false);
+  // Explicit off values stay off.
+  expect(isShellSandboxEnabled({ LETTA_FS_SANDBOX: "0" })).toBe(false);
+  expect(isShellSandboxEnabled({ LETTA_FS_SANDBOX: "false" })).toBe(false);
+  // Only the on-switch turns it on.
+  expect(isShellSandboxEnabled({ LETTA_FS_SANDBOX: "1" })).toBe(true);
+  expect(isShellSandboxEnabled({ LETTA_FS_SANDBOX: "true" })).toBe(true);
+  expect(isShellSandboxEnabled({ LETTA_FS_SANDBOX: "TRUE" })).toBe(true);
 });
 
 test("wraps an API subagent with the memory-subagent profile under the backend", () => {

--- a/src/agent/subagents/sandbox.ts
+++ b/src/agent/subagents/sandbox.ts
@@ -21,8 +21,10 @@ import type { SubagentLaunchProfile } from ".";
  * process kernel-enforces the write scope — covering its in-process Write/Edit
  * tools, its Bash commands, and anything those spawn.
  *
- * Enabled by default; set `LETTA_FS_SANDBOX=0` to opt out. No-ops when the host
- * has no sandbox backend.
+ * Enabled by default (unlike the cross-agent shell sandbox, which is opt-in:
+ * memory subagents run non-interactively, so there is no approve/deny flow to
+ * fall back on); set `LETTA_FS_SANDBOX=0` to opt out. No-ops when the host has
+ * no sandbox backend.
  *
  * Both backends scope writes to the harness state dir (`~/.letta`): a memory
  * subagent may persist memory + harness metadata (settings, logs, conversations,

--- a/src/permissions/cross-agent-guard.ts
+++ b/src/permissions/cross-agent-guard.ts
@@ -8,12 +8,15 @@
 // `canonicalToolName`, all carrying an explicit absolute path). These never
 // fork, so the kernel filesystem sandbox (src/sandbox/) cannot see them.
 //
-// Spawned shell commands ARE confined by the kernel sandbox, which supersedes
-// this guard for them — so shell commands are intentionally no longer analyzed
-// here (the old token/raw-command scanner is gone). Subagents with the memory-subagent profile are
-// also confined as whole processes and skip the guard entirely when the
-// sandbox sentinel is set. The guard is the in-process safety net; the kernel
-// is the enforcement boundary for spawned shells and process-confined subagents.
+// Spawned shell commands are intentionally no longer analyzed here (the old
+// token/raw-command scanner is gone — it was bypassable by symlinks, command
+// substitution, globbing, and subprocesses). When the opt-in cross-agent shell
+// sandbox is enabled (`LETTA_FS_SANDBOX=1`), the kernel confines spawned
+// shells instead; by default agent shells run unconfined. Subagents with the
+// memory-subagent profile are confined as whole processes (default-on) and
+// skip the guard entirely when the sandbox sentinel is set. The guard is the
+// in-process safety net; the kernel is the enforcement boundary for opted-in
+// shells and process-confined subagents.
 //
 // The guard runs BEFORE any other permission logic (decision step 0 in
 // checkPermission). Its deny is unbypassable by modes and permission rules.

--- a/src/permissions/sandbox-gate.test.ts
+++ b/src/permissions/sandbox-gate.test.ts
@@ -16,6 +16,16 @@ test("false when the flag is off (no host probe needed)", () => {
   expect(willSandboxShell(REPO_CWD, {}, SEATBELT)).toBe(false);
 });
 
+test("false by default: the shell sandbox is opt-in, even with roots and a backend", () => {
+  // Same env as the passing parent case below, minus the opt-in flag.
+  expect(willSandboxShell(REPO_CWD, { MEMORY_DIR: MEM }, SEATBELT)).toBe(false);
+});
+
+test("false when the flag is explicitly off", () => {
+  const env = { LETTA_FS_SANDBOX: "0", MEMORY_DIR: MEM };
+  expect(willSandboxShell(REPO_CWD, env, SEATBELT)).toBe(false);
+});
+
 test("false when already inside a sandbox", () => {
   const env = {
     LETTA_FS_SANDBOX: "1",

--- a/src/permissions/sandbox-gate.ts
+++ b/src/permissions/sandbox-gate.ts
@@ -1,6 +1,6 @@
 import {
   detectSandboxBackend,
-  isFsSandboxEnabled,
+  isShellSandboxEnabled,
   type SandboxAvailability,
   warnSandboxBackendUnavailable,
 } from "@/sandbox/availability";
@@ -31,19 +31,21 @@ export interface ShellSandboxContext {
 /**
  * Resolve the context for confining an agent process's shell commands under the
  * kernel cross-agent sandbox, or null when this process's shells must not be
- * wrapped (flag off, already sandboxed, no backend, cwd inside the agents tree,
- * or no resolvable self roots).
+ * wrapped (not opted in, already sandboxed, no backend, cwd inside the agents
+ * tree, or no resolvable self roots).
  *
- * The kernel sandbox is the sole cross-agent enforcement for spawned shells (the
- * static cross-agent guard no longer analyzes shell commands), so this is what
- * `applyShellSandbox` consults to decide whether — and with what — to wrap.
+ * Opt-in via `LETTA_FS_SANDBOX=1`: by default only memory subagents are
+ * sandboxed (as whole processes) and agent shells run unconfined. When opted
+ * in, the kernel sandbox is the sole cross-agent enforcement for spawned shells
+ * (the static cross-agent guard no longer analyzes shell commands), so this is
+ * what `applyShellSandbox` consults to decide whether — and with what — to wrap.
  */
 export function resolveShellSandboxContext(
   cwd: string,
   env: NodeJS.ProcessEnv,
   availability?: SandboxAvailability,
 ): ShellSandboxContext | null {
-  if (!isFsSandboxEnabled(env)) return null;
+  if (!isShellSandboxEnabled(env)) return null;
   // Already inside a sandbox: subagents with the memory-subagent profile are confined as whole
   // processes at spawn, so their nested shell commands must not be double
   // wrapped. Default-profile subagents do not have this sentinel and should get the

--- a/src/sandbox/availability.ts
+++ b/src/sandbox/availability.ts
@@ -51,14 +51,16 @@ export function resetSandboxAvailabilityCache(): void {
 }
 
 /**
- * Whether filesystem sandboxing is enabled. It is **on by default** now that the
- * kernel backends (Seatbelt + bwrap) are validated; set `LETTA_FS_SANDBOX=0`
- * (or `false`) to opt out. When no backend is available on the host,
- * {@link detectSandboxBackend} returns `{backend:null}` and every sandbox entry
- * point no-ops regardless of this flag.
+ * Whether the memory-subagent filesystem sandbox is enabled. It is **on by
+ * default**: memory subagents (reflection, memory, init, history-analyzer) run
+ * as whole confined processes with a scoped write surface, and there is no
+ * interactive approve/deny flow that could stand in for it. Set
+ * `LETTA_FS_SANDBOX=0` (or `false`) to opt out entirely. When no backend is
+ * available on the host, {@link detectSandboxBackend} returns `{backend:null}`
+ * and every sandbox entry point no-ops regardless of this flag.
  *
  * Lives in this leaf so both subagent spawning (agent layer) and parent Bash
- * wrapping (tools layer) gate on the same check without importing each other.
+ * wrapping (tools layer) gate on the same env var without importing each other.
  */
 export function isFsSandboxEnabled(
   env: NodeJS.ProcessEnv = process.env,
@@ -66,6 +68,29 @@ export function isFsSandboxEnabled(
   const value = env.LETTA_FS_SANDBOX?.trim().toLowerCase();
   // Default on: only an explicit off-switch disables it.
   return value !== "0" && value !== "false";
+}
+
+/**
+ * Whether the cross-agent shell sandbox (per-shell-command confinement of the
+ * agent process's spawned shells) is enabled. It is **off by default**: an
+ * interactive agent's own shells walling off other agents' memory broke
+ * legitimate workflows (agents inspecting `~/.letta/agents`) with kernel
+ * `Operation not permitted` errors that no permission mode could approve
+ * through. Set `LETTA_FS_SANDBOX=1` (or `true`) to opt in — recommended for
+ * multi-tenant deployments (app server, experiment runners) where one host
+ * runs many agents that must not read each other's memory.
+ *
+ * `LETTA_FS_SANDBOX` semantics across both checks:
+ *   - unset  → memory subagents sandboxed; agent shells unconfined
+ *   - `1`/`true`  → both sandboxed
+ *   - `0`/`false` → nothing sandboxed
+ */
+export function isShellSandboxEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const value = env.LETTA_FS_SANDBOX?.trim().toLowerCase();
+  // Opt-in only: an explicit on-switch enables it.
+  return value === "1" || value === "true";
 }
 
 /**

--- a/src/tools/impl/shell-sandbox.ts
+++ b/src/tools/impl/shell-sandbox.ts
@@ -23,8 +23,9 @@ import { wrapLauncher } from "@/sandbox/wrap";
  * symlinks, command substitution, globbing, and subprocesses). The kernel
  * resolves real paths regardless of how the command spelled them.
  *
- * Enabled by default; set `LETTA_FS_SANDBOX=0` to opt out. No-ops when the host
- * has no sandbox backend.
+ * OFF by default; set `LETTA_FS_SANDBOX=1` to opt in (recommended for
+ * multi-tenant deployments where agents must not read each other's memory).
+ * No-ops when the host has no sandbox backend.
  */
 
 export interface ShellSandboxResult {


### PR DESCRIPTION
## Summary
- The default-on kernel shell sandbox (#2853) walled off `~/.letta/agents` for the primary agent's own shell commands, so agents hit kernel `Operation not permitted` errors accessing memfs/agent dirs even in **unrestricted** mode ([report](https://letta-ai.slack.com/archives/C07AFH896V7/p1782933882270059)). A kernel deny has no approve/deny escape hatch, and making it mode-toggleable would require unmounting/remounting the process sandbox — per the thread, the agreed fix is off-by-default with documented opt-in.
- Splits the single `LETTA_FS_SANDBOX` gate into two checks in `sandbox/availability.ts`:
  - **`isFsSandboxEnabled` (default ON)** — memory-subagent whole-process sandbox (reflection/memory/init/history-analyzer). These run non-interactively with a scoped write surface, so they keep kernel confinement: sandboxes for memory subagents only.
  - **`isShellSandboxEnabled` (default OFF)** — per-shell-command cross-agent confinement of agent shells (`sandbox-gate.ts` → `applyShellSandbox`). Opt in with `LETTA_FS_SANDBOX=1` for multi-tenant deployments (app server, experiment runners) where co-hosted agents must not read each other's memory.
- `LETTA_FS_SANDBOX` semantics: **unset** → memory subagents only · **`1`/`true`** → both · **`0`/`false`** → nothing.
- The in-process cross-agent guard (Read/Write/etc.) is unchanged; its header comment is updated to reflect that spawned shells are only kernel-confined when opted in.

Front-running @devanshrj's planned PR for this since it blocks the next Letta Desktop release — Devansh, please sanity-check the split.

## Test plan
- [x] New gate tests: shell sandbox not applied with flag unset / `0`, still applied with `1`
- [x] New flag tests: `isShellSandboxEnabled` opt-in semantics alongside existing `isFsSandboxEnabled` opt-out semantics
- [x] All sandbox/permissions suites green (149 tests across 10 files); `bun run check` 9/9

👾 Generated with [Letta Code](https://letta.com)