### PR TITLE
fix(cli): accept deprecated --no-memfs as hidden no-op for version skew

### DIFF
--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -172,6 +172,18 @@ describe("shared CLI arg schema", () => {
     );
   });
 
+  test("accepts deprecated --no-memfs as a hidden no-op (version-skew compat)", () => {
+    // Older parents spawn subagents with --no-memfs; after auto-update the
+    // child binary is newer than the running parent (LET-9436). The flag must
+    // parse without error, do nothing, and stay out of help output.
+    const parsed = parseCliArgs(
+      preprocessCliArgs(["node", "script", "-p", "hello", "--no-memfs"]),
+      true,
+    );
+    expect(parsed.values["no-memfs"]).toBe(true);
+    expect(renderCliOptionsHelp()).not.toContain("--no-memfs");
+  });
+
   test("rejects removed system-append flag in strict mode", () => {
     expect(() =>
       parseCliArgs(

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -220,6 +220,17 @@ export const CLI_FLAG_CATALOG = {
     mode: "both",
     help: { description: "Enable memory filesystem for this agent" },
   },
+  // DEPRECATED no-op, intentionally hidden from help. Accepted for backward
+  // compatibility: older parent processes (pre-mandatory-memfs) spawn
+  // subagents with --no-memfs, and after an auto-update the child binary on
+  // disk is newer than the still-running parent. Rejecting the flag broke
+  // reflection subagents during that version skew (LET-9436). Subagent
+  // statelessness now derives from LETTA_CODE_AGENT_ROLE=subagent, so the
+  // flag is simply ignored.
+  "no-memfs": {
+    parser: { type: "boolean" },
+    mode: "both",
+  },
   "memfs-startup": {
     parser: { type: "string" },
     mode: "headless",


### PR DESCRIPTION
## Summary
- Fixes LET-9436: reflection subagents failing with `Unknown option '--no-memfs'` after the v0.27.22 release.
- Root cause is **version skew during auto-update**: the mandatory-memfs purge (#3202) removed both the flag *and* the spawn site that passed it — but a long-running parent process from an older release keeps spawning subagents with `--no-memfs`, while the child binary on disk has already updated to the new version that rejects it. CI could not catch this because CI always tests parent and child at the same version.
- Re-registers `--no-memfs` as a **hidden no-op**: parses cleanly in strict mode, nothing consumes it (subagent statelessness derives from `LETTA_CODE_AGENT_ROLE=subagent`), and it is excluded from `--help`.

## Test plan
- [x] New regression test: `--no-memfs` parses in strict mode and stays out of help output
- [x] `bun test src/cli/args.test.ts` (14 pass)
- [x] `tsc --noEmit` + lint clean
- [ ] After release: confirm reflection subagents from an old parent spawn successfully against the new child binary

👾 Generated with [Letta Code](https://letta.com)