### PR TITLE
fix(cli): ignore legacy no-memfs launcher args

### DIFF
--- a/src/agent/subagent-model-resolution.test.ts
+++ b/src/agent/subagent-model-resolution.test.ts
@@ -48,6 +48,27 @@ describe("resolveSubagentLauncher", () => {
     });
   });
 
+  test("explicit launcher drops legacy no-memfs args", () => {
+    const launcher = resolveSubagentLauncher(["-p", "hi"], {
+      env: {
+        LETTA_CODE_BIN: "custom-bun",
+        LETTA_CODE_BIN_ARGS_JSON: JSON.stringify([
+          "run",
+          "src/index.ts",
+          "--no-memfs",
+        ]),
+      } as NodeJS.ProcessEnv,
+      argv: ["bun", "/tmp/dev-entry.ts"],
+      execPath: "/opt/homebrew/bin/bun",
+      platform: "darwin",
+    });
+
+    expect(launcher).toEqual({
+      command: "custom-bun",
+      args: ["run", "src/index.ts", "-p", "hi"],
+    });
+  });
+
   test("explicit launcher takes precedence over .js script autodetection", () => {
     const launcher = resolveSubagentLauncher(["-p", "hi"], {
       env: {

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -150,6 +150,22 @@ describe("shared CLI arg schema", () => {
     expect(parsed.values["no-mods"]).toBe(true);
   });
 
+  test("drops legacy no-memfs flag as a hidden no-op", () => {
+    const parsed = parseCliArgs(
+      preprocessCliArgs([
+        "node",
+        "script",
+        "--no-memfs",
+        "--no-memfs=true",
+        "-p",
+        "hi",
+      ]),
+      true,
+    );
+    expect(parsed.values).not.toHaveProperty("no-memfs");
+    expect(parsed.positionals.slice(2).join(" ")).toBe("hi");
+  });
+
   test("validates backend mode values", () => {
     expect(parseBackendModeFlag(undefined)).toBeUndefined();
     expect(parseBackendModeFlag("api")).toBe("api");

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -354,11 +354,24 @@ export function renderCliOptionsHelp(): string {
 }
 
 export function preprocessCliArgs(args: string[]): string[] {
-  return args.map((arg) => {
-    if (arg === "--conv") return "--conversation";
-    if (arg === "--no-extensions") return "--no-mods";
-    return arg;
-  });
+  const processed: string[] = [];
+  for (const arg of args) {
+    // Hidden compatibility no-op for older launchers that still prepend the
+    // removed MemFS opt-out flag before spawning a child CLI.
+    if (arg === "--no-memfs" || arg.startsWith("--no-memfs=")) {
+      continue;
+    }
+    if (arg === "--conv") {
+      processed.push("--conversation");
+      continue;
+    }
+    if (arg === "--no-extensions") {
+      processed.push("--no-mods");
+      continue;
+    }
+    processed.push(arg);
+  }
+  return processed;
 }
 
 export function parseCliArgs(args: string[], strict: boolean) {

--- a/src/tools/impl/shell-env.ts
+++ b/src/tools/impl/shell-env.ts
@@ -67,6 +67,14 @@ function normalizeInvocationCommand(raw: string | undefined): string | null {
   return normalized || null;
 }
 
+function dropLegacyInvocationArgs(args: string[]): string[] {
+  // Older Desktop/remote launchers may leave this removed flag in
+  // LETTA_CODE_BIN_ARGS_JSON; do not propagate it into child CLIs.
+  return args.filter(
+    (arg) => arg !== "--no-memfs" && !arg.startsWith("--no-memfs="),
+  );
+}
+
 function parseInvocationArgs(raw: string | undefined): string[] {
   if (!raw) return [];
   try {
@@ -75,7 +83,7 @@ function parseInvocationArgs(raw: string | undefined): string[] {
       Array.isArray(parsed) &&
       parsed.every((item) => typeof item === "string")
     ) {
-      return parsed;
+      return dropLegacyInvocationArgs(parsed);
     }
   } catch {
     // Ignore malformed JSON and fall back to empty args.

--- a/src/tools/shell-env.test.ts
+++ b/src/tools/shell-env.test.ts
@@ -103,6 +103,27 @@ describe("shellEnv letta shim", () => {
     });
   });
 
+  test("resolveLettaInvocation drops legacy no-memfs launcher args", () => {
+    const invocation = resolveLettaInvocation(
+      {
+        LETTA_CODE_BIN: "/tmp/custom-letta",
+        LETTA_CODE_BIN_ARGS_JSON: JSON.stringify([
+          "--no-memfs",
+          "--backend",
+          "api",
+          "--no-memfs=true",
+        ]),
+      },
+      ["node", "/tmp/ignored.ts"],
+      "/usr/local/bin/node",
+    );
+
+    expect(invocation).toEqual({
+      command: "/tmp/custom-letta",
+      args: ["--backend", "api"],
+    });
+  });
+
   test("resolveLettaInvocation infers dev entrypoint launcher", () => {
     const invocation = resolveLettaInvocation(
       {},


### PR DESCRIPTION
## Summary
- Treat stale `--no-memfs` launcher metadata as a hidden no-op during CLI arg preprocessing.
- Strip the same legacy flag from `LETTA_CODE_BIN_ARGS_JSON` before spawning child CLIs, so reflection subagents do not inherit a flag current CLIs reject.
- Cover top-level CLI parsing, shell launcher metadata, and subagent launcher inheritance.

## Test plan
- `bun test src/cli/args.test.ts src/tools/shell-env.test.ts src/agent/subagent-model-resolution.test.ts`
- `bun run check`

👾 Generated with [Letta Code](https://letta.com)