### PR TITLE
docs(mods): document dreaming indicator panel overrides

### DIFF
--- a/src/skills/builtin/creating-mods/SKILL.md
+++ b/src/skills/builtin/creating-mods/SKILL.md
@@ -155,7 +155,7 @@ Before finishing, verify:
 | `references/providers.md` | Adding a custom model/API provider for local agents |
 | `references/events.md` | Reacting to lifecycle/tool/turn events or transforming turns/tools |
 | `references/permissions.md` | Enforcing dynamic tool allow/ask/deny policy before approval/execution |
-| `references/ui.md` | Panels (including order-0 statusline) or `ui.panels` capability guards are involved |
+| `references/ui.md` | Panels (including order-0 statusline and order-1 dreaming indicator) or `ui.panels` capability guards are involved |
 | `references/plan-mode.md` | Recreating plan mode with commands, tools, events, permissions, and local state |
 | `references/analysis-mode.md` | Phrase-triggered diagnostic mode with turn reminders (simpler than plan-mode) |
 | `references/architecture.md` | Multiple capabilities, local state, cleanup, background model work, or non-trivial composition |

--- a/src/skills/builtin/creating-mods/references/ui.md
+++ b/src/skills/builtin/creating-mods/references/ui.md
@@ -38,7 +38,7 @@ if (letta.capabilities.ui.panels) {
 `order` is a signed coordinate around the input:
 
 - `order > 1` — additive panels above the input, higher nearer the top (default `100`).
-- `order === 1` — replaces the default product-status row (currently dreaming/reflection status). Use this only when intentionally overriding that row; otherwise use `order > 1`.
+- `order === 1` — replaces the default dreaming/reflection indicator above the input. Use this only when intentionally overriding that row; otherwise use `order > 1`.
 - `order === 0` — the primary line just below the input, overriding the built-in `agent · model`. This is the statusline slot; use `customizing-statusline` for that work.
 - `order < 0` — stacks below the primary line, `-1` closest.
 
@@ -51,6 +51,12 @@ render(ctx: {
   width: number;
   agent: { id, name };
   model: { id, displayName, provider, reasoningEffort };
+  backgroundAgents: Array<{
+    type: string;
+    status: string;
+    durationMs: number;
+    agentId: string | null;
+  }>;
   subagents: { list(): SubagentLifecycleItem[] };
   row(left, right, width): string;
   columns(parts: string[], width): string;
@@ -62,6 +68,39 @@ render(ctx: {
 `row`/`columns` are ANSI-aware, so chalk-colored segments and OSC-8 links align correctly. Use `link(label, url)` when a compact label should hyperlink to a URL without rendering the whole URL.
 
 Close panels when they are transient, and close/replace long-lived panels from the activation disposer if reload should remove them.
+
+### Panel use case: dreaming indicator overrides
+
+When a user asks to change the "dreaming" UI/indicator, the reflection status above the input, or to add the full background-agent URL, use an `order: 1` panel replacement. The user should not need to know any internal row/component name.
+
+Checklist:
+
+- Open a panel with `order: 1`, not an additive panel.
+- Read active hidden background agents from `ctx.backgroundAgents`; filter by `status` (`pending`/`running`).
+- Use `agent.agentId` to build `https://app.letta.com/chat/${agent.agentId}`.
+- If the user asks for the full URL, render visible text; do not use `ctx.link()` because it hides the URL behind OSC-8.
+- If preserving animation, own the timer and call `panel.update()`; clean up timer and panel in the disposer.
+- Keep `render()` pure: do not call diagnostics or mutate external state from render.
+
+Critical shape:
+
+```ts
+const panel = letta.ui.openPanel({
+  id: "dreaming-url",
+  order: 1,
+  render(ctx) {
+    const agent = ctx.backgroundAgents.find(
+      (a) => a.status === "pending" || a.status === "running",
+    );
+    if (!agent) return "";
+
+    const url = agent.agentId
+      ? `https://app.letta.com/chat/${agent.agentId}`
+      : null;
+    // Render spinner/label/elapsed, plus visible URL if requested.
+  },
+});
+```
 
 ### Commands that open panels
 


### PR DESCRIPTION
## Summary
- Teach the creating-mods skill to route dreaming/background-agent indicator changes to `order: 1` panel replacements
- Document `ctx.backgroundAgents` in panel render context
- Add a compact checklist and critical shape for visible full URL mods without exposing the product-status implementation name

## Test plan
- [x] Commit hooks passed (`tsc --noEmit`)
- [ ] Not run separately — docs-only change

👾 Generated with [Letta Code](https://letta.com)