### PR TITLE
fix(skills): enforce skill name frontmatter

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -46,6 +46,13 @@ if ! node scripts/check-filename-casing.js --staged 2>/dev/null; then
   exit 1
 fi
 
+# Check staged skill metadata for required name headers
+if ! node scripts/check-skill-frontmatter.js --staged; then
+  echo ""
+  echo "❌ Invalid skill metadata — run 'bun run check:skill-frontmatter' for details."
+  exit 1
+fi
+
 # Lint staged files only (fast)
 # Guard: lint-staged v16 exits code 1 when no files match, which would
 # fail the hook even on empty commits. Only run if lintable files are staged.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,8 +178,9 @@ Test files live **next to their source** (`local-store.test.ts` next to `local-s
 3. **boundaries** — `scripts/check-layer-boundaries.js`; checks import direction per layer
 4. **exported-functions** — `scripts/check-exported-functions.js`; flags `export const fn =`
 5. **test-mock-isolation** — `scripts/check-test-mock-isolation.js`; flags unsafe `mock.module` patterns
-6. **biome** — format + lint across all files
-7. **typescript** — full `tsc --noEmit`
+6. **skill frontmatter** — checks every `SKILL.md` has a non-empty `name:` header
+7. **biome** — format + lint across all files
+8. **typescript** — full `tsc --noEmit`
 
 ### Environment Variables
 

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "check:filename-casing": "node scripts/check-filename-casing.js",
     "check:test-mock-isolation": "bun run scripts/check-test-mock-isolation.js",
     "check:test-coverage": "node scripts/check-test-coverage.cjs",
+    "check:skill-frontmatter": "node scripts/check-skill-frontmatter.js",
     "check:bundled-skill-scripts": "node scripts/check-bundled-skill-scripts.js",
     "check": "bun run scripts/check.js",
     "dev": "node scripts/dev.cjs",

--- a/scripts/check-skill-frontmatter.js
+++ b/scripts/check-skill-frontmatter.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+
+const isStagedOnly = process.argv.includes("--staged");
+
+function git(args) {
+  const result = spawnSync("git", args, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    maxBuffer: 20 * 1024 * 1024,
+  });
+
+  if (result.status !== 0) {
+    throw new Error(
+      (result.stderr || result.stdout || "git command failed").trim(),
+    );
+  }
+
+  return result.stdout;
+}
+
+function splitNul(output) {
+  return output.split("\0").filter(Boolean);
+}
+
+function isSkillMarkdownFile(file) {
+  return file.split(/[\\/]/).pop() === "SKILL.md";
+}
+
+function getCandidateFiles() {
+  if (isStagedOnly) {
+    return splitNul(
+      git(["diff", "--cached", "--name-only", "--diff-filter=ACMR", "-z"]),
+    ).filter(isSkillMarkdownFile);
+  }
+
+  return splitNul(git(["ls-files", "-z"])).filter(isSkillMarkdownFile);
+}
+
+function readStagedFile(file) {
+  return git(["show", `:${file}`]);
+}
+
+function readCurrentFile(file) {
+  if (!existsSync(file)) {
+    return null;
+  }
+  return readFileSync(file, "utf8");
+}
+
+function checkSkillFrontmatterName(content) {
+  const normalized = content.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+  const match = normalized.match(/^---\n([\s\S]*?)\n---(?:\n|$)/);
+  if (!match) {
+    return "missing YAML frontmatter";
+  }
+
+  const frontmatter = match[1] ?? "";
+  const nameLine = frontmatter
+    .split("\n")
+    .find((line) => /^\s*name\s*:/.test(line));
+
+  if (!nameLine) {
+    return "missing name frontmatter";
+  }
+
+  const nameValue = nameLine.replace(/^\s*name\s*:\s*/, "").trim();
+  if (!nameValue) {
+    return "empty name frontmatter";
+  }
+
+  return null;
+}
+
+let violations = [];
+let files = [];
+try {
+  files = getCandidateFiles();
+  violations = files.flatMap((file) => {
+    const content = isStagedOnly ? readStagedFile(file) : readCurrentFile(file);
+    if (content === null) {
+      return [];
+    }
+
+    const reason = checkSkillFrontmatterName(content);
+    return reason ? [{ file, reason }] : [];
+  });
+} catch (error) {
+  console.error(
+    `Failed to check skill frontmatter: ${error instanceof Error ? error.message : String(error)}`,
+  );
+  process.exit(1);
+}
+
+if (violations.length > 0) {
+  console.error("\n❌ Skill frontmatter violations found:\n");
+  for (const violation of violations) {
+    console.error(`${violation.file}`);
+    console.error(`  ${violation.reason}`);
+    console.error(
+      "  ↳ Add a non-empty `name:` field to SKILL.md frontmatter.\n",
+    );
+  }
+  console.error(
+    `Found ${violations.length} skill frontmatter violation${violations.length === 1 ? "" : "s"}.`,
+  );
+  process.exit(1);
+}
+
+if (!isStagedOnly) {
+  console.log(
+    `✅ Skill frontmatter name headers present (${files.length} SKILL.md file${files.length === 1 ? "" : "s"}).`,
+  );
+}

--- a/scripts/check.js
+++ b/scripts/check.js
@@ -19,6 +19,7 @@ const checks = [
   { name: "filename casing", script: ["check:filename-casing"] },
   { name: "test mock isolation", script: ["check:test-mock-isolation"] },
   { name: "test coverage", script: ["check:test-coverage"] },
+  { name: "skill frontmatter", script: ["check:skill-frontmatter"] },
   { name: "bundled skill scripts", script: ["check:bundled-skill-scripts"] },
   { name: "biome", script: ["lint"] },
   { name: "typescript", script: ["typecheck"] },

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -84,6 +84,10 @@ import {
   finalizeMultiReflectionPayload,
   readReflectionAutoSelection,
 } from "@/cli/helpers/reflection-transcript";
+import {
+  formatSkillNameFrontmatterRepairReport,
+  repairMissingSkillNameFrontmatter,
+} from "@/cli/helpers/skill-name-frontmatter-repair";
 import type { ApprovalRequest } from "@/cli/helpers/stream";
 import {
   estimateSystemTokens,
@@ -3291,10 +3295,17 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
 
             const { context: gitContext } = gatherInitGitContext();
             const memoryDir = getActiveMemoryDirectory(agentId);
+            const skillNameFrontmatterRepair =
+              await repairMissingSkillNameFrontmatter(memoryDir);
+            const skillNameFrontmatterRepairReport =
+              formatSkillNameFrontmatterRepairReport(
+                skillNameFrontmatterRepair,
+              );
 
             const doctorMessage = buildDoctorMessage({
               gitContext,
               memoryDir,
+              skillNameFrontmatterRepairReport,
             });
 
             await processConversationWithQueuedApprovals([

--- a/src/cli/helpers/init-command.ts
+++ b/src/cli/helpers/init-command.ts
@@ -123,14 +123,18 @@ ${SYSTEM_REMINDER_CLOSE}`;
 export function buildDoctorMessage(args: {
   gitContext: string;
   memoryDir?: string;
+  skillNameFrontmatterRepairReport?: string;
 }): string {
   const memfsSection = args.memoryDir
     ? `\n## Memory filesystem\n\nMemory filesystem is enabled. Memory directory: \`${args.memoryDir}\`\n`
     : "";
+  const skillRepairSection = args.skillNameFrontmatterRepairReport
+    ? `\n## Automatic skill metadata repair\n\n${args.skillNameFrontmatterRepairReport}\n`
+    : "";
 
   return `${SYSTEM_REMINDER_OPEN}
 The user has requested a memory structure check via /doctor.
-${memfsSection}
+${memfsSection}${skillRepairSection}
 ## 1. Invoke the context-doctor skill
 
 Use the \`Skill\` tool with \`skill: "context-doctor"\` to load guidance for memory structure refinement.

--- a/src/cli/helpers/skill-name-frontmatter-repair.test.ts
+++ b/src/cli/helpers/skill-name-frontmatter-repair.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  repairMissingSkillNameFrontmatter,
+  repairSkillNameFrontmatterContent,
+} from "@/cli/helpers/skill-name-frontmatter-repair";
+
+let fixtureRoot: string | null = null;
+
+function createFixtureRoot(prefix: string): string {
+  fixtureRoot = mkdtempSync(join(tmpdir(), prefix));
+  return fixtureRoot;
+}
+
+afterEach(() => {
+  if (fixtureRoot && existsSync(fixtureRoot)) {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+  fixtureRoot = null;
+});
+
+test("repairSkillNameFrontmatterContent inserts missing name header", () => {
+  const repaired = repairSkillNameFrontmatterContent(
+    "---\ndescription: Updates docs\n---\n\n# Updating docs\n",
+    "updating-docs",
+  );
+
+  expect(repaired.changed).toBe(true);
+  expect(repaired.content).toBe(
+    "---\nname: updating-docs\ndescription: Updates docs\n---\n\n# Updating docs\n",
+  );
+});
+
+test("repairSkillNameFrontmatterContent leaves existing names unchanged", () => {
+  const original = "---\nname: updating-docs\ndescription: Updates docs\n---\n";
+  const repaired = repairSkillNameFrontmatterContent(original, "updating-docs");
+
+  expect(repaired.changed).toBe(false);
+  expect(repaired.content).toBe(original);
+});
+
+test("repairMissingSkillNameFrontmatter repairs memory skills", async () => {
+  const memoryDir = createFixtureRoot("skill-name-repair-");
+  const skillDir = join(memoryDir, "skills", "updating-wiki");
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(skillDir, "SKILL.md"),
+    "---\ndescription: Regenerates the wiki\n---\n\n# Updating Wiki\n",
+  );
+
+  const result = await repairMissingSkillNameFrontmatter(memoryDir);
+
+  expect(result.scanned).toBe(1);
+  expect(result.repaired).toEqual(["skills/updating-wiki/SKILL.md"]);
+  expect(result.skipped).toEqual([]);
+  await expect(readFile(join(skillDir, "SKILL.md"), "utf8")).resolves.toContain(
+    "name: updating-wiki\ndescription:",
+  );
+});
+
+test("repairMissingSkillNameFrontmatter reports malformed skills without rewriting", async () => {
+  const memoryDir = createFixtureRoot("skill-name-repair-malformed-");
+  const skillDir = join(memoryDir, "skills", "broken-skill");
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(join(skillDir, "SKILL.md"), "# Broken\n");
+
+  const result = await repairMissingSkillNameFrontmatter(memoryDir);
+
+  expect(result.scanned).toBe(1);
+  expect(result.repaired).toEqual([]);
+  expect(result.skipped).toEqual([
+    {
+      path: "skills/broken-skill/SKILL.md",
+      reason: "missing YAML frontmatter",
+    },
+  ]);
+});

--- a/src/cli/helpers/skill-name-frontmatter-repair.ts
+++ b/src/cli/helpers/skill-name-frontmatter-repair.ts
@@ -1,0 +1,204 @@
+import { readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, join, relative } from "node:path";
+
+export interface SkillNameFrontmatterRepairSkippedFile {
+  path: string;
+  reason: string;
+}
+
+export interface SkillNameFrontmatterRepairResult {
+  scanned: number;
+  repaired: string[];
+  skipped: SkillNameFrontmatterRepairSkippedFile[];
+}
+
+interface SkillNameFrontmatterContentRepairResult {
+  content: string;
+  changed: boolean;
+  reason?: string;
+}
+
+const FRONTMATTER_REGEX = /^(---\r?\n)([\s\S]*?)(\r?\n---(?:\r?\n|$))/;
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findSkillMarkdownFiles(root: string): Promise<string[]> {
+  const entries = await readdir(root, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.name === ".git" || entry.name === "node_modules") {
+      continue;
+    }
+
+    const fullPath = join(root, entry.name);
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
+
+    if (entry.isDirectory()) {
+      files.push(...(await findSkillMarkdownFiles(fullPath)));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name === "SKILL.md") {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function formatYamlScalar(value: string): string {
+  if (/^[A-Za-z0-9_-]+$/.test(value)) {
+    return value;
+  }
+
+  return JSON.stringify(value);
+}
+
+function isNonEmptyNameLine(line: string): boolean {
+  const match = line.match(/^\s*name\s*:\s*(.*?)\s*$/);
+  return !!match?.[1]?.trim();
+}
+
+export function repairSkillNameFrontmatterContent(
+  content: string,
+  skillName: string,
+): SkillNameFrontmatterContentRepairResult {
+  if (!skillName.trim()) {
+    return {
+      content,
+      changed: false,
+      reason: "skill directory name is empty",
+    };
+  }
+
+  const match = content.match(FRONTMATTER_REGEX);
+  if (!match) {
+    return {
+      content,
+      changed: false,
+      reason: "missing YAML frontmatter",
+    };
+  }
+
+  const opening = match[1] ?? "";
+  const frontmatter = match[2] ?? "";
+  const closing = match[3] ?? "";
+  const newline = opening.includes("\r\n") ? "\r\n" : "\n";
+  const lines = frontmatter.replace(/\r\n/g, "\n").split("\n");
+  const nameLineIndex = lines.findIndex((line) => /^\s*name\s*:/.test(line));
+
+  if (nameLineIndex >= 0 && isNonEmptyNameLine(lines[nameLineIndex] ?? "")) {
+    return { content, changed: false };
+  }
+
+  const nameLine = `name: ${formatYamlScalar(skillName.trim())}`;
+  if (nameLineIndex >= 0) {
+    lines[nameLineIndex] = nameLine;
+  } else {
+    lines.unshift(nameLine);
+  }
+
+  const nextContent = `${opening}${lines.join(newline)}${closing}${content.slice(
+    match[0].length,
+  )}`;
+
+  return { content: nextContent, changed: true };
+}
+
+export async function repairMissingSkillNameFrontmatter(
+  memoryDir: string | undefined,
+): Promise<SkillNameFrontmatterRepairResult> {
+  const result: SkillNameFrontmatterRepairResult = {
+    scanned: 0,
+    repaired: [],
+    skipped: [],
+  };
+
+  if (!memoryDir) {
+    return result;
+  }
+
+  const skillsDir = join(memoryDir, "skills");
+  if (!(await pathExists(skillsDir))) {
+    return result;
+  }
+
+  let skillFiles: string[];
+  try {
+    skillFiles = await findSkillMarkdownFiles(skillsDir);
+  } catch (error) {
+    result.skipped.push({
+      path: "skills/",
+      reason: `failed to scan skills directory: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    return result;
+  }
+
+  for (const skillFile of skillFiles.sort()) {
+    const displayPath = relative(memoryDir, skillFile).replace(/\\/g, "/");
+    result.scanned++;
+
+    try {
+      const content = await readFile(skillFile, "utf8");
+      const repair = repairSkillNameFrontmatterContent(
+        content,
+        basename(dirname(skillFile)),
+      );
+
+      if (repair.reason) {
+        result.skipped.push({ path: displayPath, reason: repair.reason });
+        continue;
+      }
+
+      if (!repair.changed) {
+        continue;
+      }
+
+      await writeFile(skillFile, repair.content, "utf8");
+      result.repaired.push(displayPath);
+    } catch (error) {
+      result.skipped.push({
+        path: displayPath,
+        reason: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return result;
+}
+
+export function formatSkillNameFrontmatterRepairReport(
+  result: SkillNameFrontmatterRepairResult,
+): string {
+  const sections: string[] = [];
+
+  if (result.repaired.length > 0) {
+    sections.push(
+      `- Added missing \`name:\` frontmatter to ${result.repaired.length} skill${
+        result.repaired.length === 1 ? "" : "s"
+      }: ${result.repaired.map((path) => `\`${path}\``).join(", ")}`,
+    );
+  }
+
+  if (result.skipped.length > 0) {
+    sections.push(
+      `- Could not automatically repair ${result.skipped.length} skill${
+        result.skipped.length === 1 ? "" : "s"
+      }: ${result.skipped
+        .map((item) => `\`${item.path}\` (${item.reason})`)
+        .join(", ")}`,
+    );
+  }
+
+  return sections.join("\n");
+}

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -17,6 +17,10 @@ import {
   gatherInitGitContext,
 } from "@/cli/helpers/init-command";
 import { getReflectionSettings } from "@/cli/helpers/memory-reminder";
+import {
+  formatSkillNameFrontmatterRepairReport,
+  repairMissingSkillNameFrontmatter,
+} from "@/cli/helpers/skill-name-frontmatter-repair";
 import { buildModCommandPrompt } from "@/cli/mods/command-runtime";
 import {
   DEFAULT_SUMMARIZATION_MODEL,
@@ -640,8 +644,16 @@ async function handleDoctorCommand(
   const memoryDir = settingsManager.isMemfsEnabled(agentId)
     ? getScopedMemoryFilesystemRoot(agentId)
     : undefined;
+  const skillNameFrontmatterRepair =
+    await repairMissingSkillNameFrontmatter(memoryDir);
+  const skillNameFrontmatterRepairReport =
+    formatSkillNameFrontmatterRepairReport(skillNameFrontmatterRepair);
 
-  const doctorMessage = buildDoctorMessage({ gitContext, memoryDir });
+  const doctorMessage = buildDoctorMessage({
+    gitContext,
+    memoryDir,
+    skillNameFrontmatterRepairReport,
+  });
 
   // Feed the doctor prompt as a user message through the normal turn pipeline.
   // This triggers a full agent turn whose deltas stream back to the web UI.


### PR DESCRIPTION
## Summary

Skill files are documented as requiring a `name:` frontmatter field, but the runtime tolerates missing names by deriving one from the directory. That leniency let description-only MemFS skills load, while downstream UI/preview code could no longer identify them as proper skill blocks.

This PR adds a repo check for non-empty `name:` headers in every tracked `SKILL.md`, wires the same check into pre-commit for staged skill files, and teaches `/doctor` to repair existing MemFS skills by inserting the directory name when the header is missing or empty.

## Validation

- `bun test src/cli/helpers/skill-name-frontmatter-repair.test.ts`
- `bun run check:skill-frontmatter`
- `bun run check`

## Risk

The check only validates that `name:` exists and is non-empty, rather than enforcing the full skill validator, to avoid making unrelated existing metadata conventions part of this fix. `/doctor` only rewrites skills under the active memory directory and reports malformed files it cannot safely repair.

👾 Generated with [Letta Code](https://letta.com)