### PR TITLE
feat(review): add red zone pi-ai duplication pattern to review prompt

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -109,6 +109,7 @@ jobs:
             - New state in App.tsx or approval components (flicker risk — see review-knowledge.md)
             - Redundant blocking API calls, performance footguns
             - Shell tool parity gaps, streaming code assuming one provider's behavior
+            - RED ZONE: PRs duplicating pi-ai's provider runtime in LC (image stripping, capability checks like `model.input.includes("image")`, provider format fixups past the toPiMessage boundary) — pi-ai owns this domain, require root cause artifact + upstream check before approving. See review-knowledge.md for the full checklist
 
             ## What NOT to flag
 


### PR DESCRIPTION
## Summary
- Add a RED ZONE bullet to the review workflow prompt's What to flag section for PRs that duplicate pi-ai's provider runtime responsibilities (image stripping, capability checks, payload sanitization) inside the LC adapter layer
- These PRs are suspicious by default — pi-ai owns this domain. The reviewer should require a root cause artifact and upstream check before approving
- Also updated review-knowledge.md memory with the full checklist (6 points) and case study from PR #3215

## Context
PR #3215 duplicated pi-ai's existing image downgrade logic (identical placeholder strings, identical dedup) in pi-stream-adapter.ts, gated on model.input.includes("image") — the wrong layer. This passed review. Adding the pattern to the review prompt so it's caught next time.

## Test plan
- [ ] Review workflow still triggers on non-draft PRs
- [ ] Review agent reads the new bullet and flags pi-ai duplication patterns

Generated with Letta Code

Co-Authored-By: Letta Code <noreply@letta.com>