### PR TITLE
feat: create Tutor as the default agent for brand-new accounts [LET-9413]

### DIFF
--- a/src/agent/defaults.ts
+++ b/src/agent/defaults.ts
@@ -11,10 +11,20 @@ import { settingsManager } from "@/settings-manager";
 import { type CreateAgentOptions, createAgent } from "./create";
 import { parseMdxFrontmatter } from "./memory";
 import { getDefaultModel, resolveModel } from "./model";
+import { buildCreateAgentOptionsForPersonality } from "./personality";
 import { MEMORY_PROMPTS } from "./prompt-assets";
 
 // Tags used to identify default agents
 export const MEMO_TAG = "default:memo";
+export const TUTOR_TAG = "default:tutorial";
+
+/**
+ * Personalities the startup bootstrap can create. Kept deliberately simple:
+ * a true fresh start (brand-new account, nothing to resume) gets the Tutor
+ * onboarding agent, while an explicit `--new-agent` (and headless runs) get
+ * the standard Letta Code (memo) agent.
+ */
+export type DefaultAgentPersonality = "memo" | "tutorial";
 
 // Letta Code's default memory blocks - loaded from Memo-specific prompts.
 const MEMO_PERSONA = parseMdxFrontmatter(
@@ -153,11 +163,15 @@ export async function ensureDefaultAgents(
   backend: Backend,
   options?: {
     preferredModel?: string;
+    /** Which personality the created agent gets. Defaults to memo (Letta Code). */
+    personality?: DefaultAgentPersonality;
   },
 ): Promise<AgentState | null> {
   if (!settingsManager.shouldCreateDefaultAgents()) {
     return null;
   }
+
+  const personality = options?.personality ?? "memo";
 
   try {
     // Pre-determine memfs mode so the agent is created with the correct prompt.
@@ -170,12 +184,32 @@ export async function ensureDefaultAgents(
         ? "memfs"
         : undefined;
 
-    const { agent } = await createAgent({
-      ...DEFAULT_AGENT_CONFIGS.memo,
-      model: await resolveDefaultAgentModel(backend, options?.preferredModel),
-      memoryPromptMode,
-    });
-    await addTagToAgent(backend, agent.id, MEMO_TAG);
+    const model = await resolveDefaultAgentModel(
+      backend,
+      options?.preferredModel,
+    );
+
+    const createOptions: CreateAgentOptions =
+      personality === "tutorial"
+        ? {
+            ...(await buildCreateAgentOptionsForPersonality({
+              personalityId: "tutorial",
+              model,
+            })),
+            memoryPromptMode,
+          }
+        : {
+            ...DEFAULT_AGENT_CONFIGS.memo,
+            model,
+            memoryPromptMode,
+          };
+
+    const { agent } = await createAgent(createOptions);
+    await addTagToAgent(
+      backend,
+      agent.id,
+      personality === "tutorial" ? TUTOR_TAG : MEMO_TAG,
+    );
     settingsManager.pinAgent(agent.id);
 
     return agent;

--- a/src/agent/resolve-startup-agent-files.test.ts
+++ b/src/agent/resolve-startup-agent-files.test.ts
@@ -116,7 +116,7 @@ afterEach(async () => {
 describe("startup resolution from settings files", () => {
   test("no local/global settings files => create", async () => {
     const target = await resolveFromSettings();
-    expect(target).toEqual({ action: "create" });
+    expect(target).toEqual({ action: "create", trigger: "fresh-start" });
   });
 
   test("fresh dir + valid global session => resume global agent", async () => {
@@ -155,7 +155,7 @@ describe("startup resolution from settings files", () => {
     });
 
     const target = await resolveFromSettings();
-    expect(target).toEqual({ action: "create" });
+    expect(target).toEqual({ action: "create", trigger: "fresh-start" });
   });
 
   test("local session + valid local agent => resume local agent", async () => {
@@ -365,7 +365,7 @@ describe("startup resolution from settings files", () => {
       forceNew: true,
     });
 
-    expect(target).toEqual({ action: "create" });
+    expect(target).toEqual({ action: "create", trigger: "force-new" });
   });
 
   test("sessionsByServer takes precedence over legacy lastAgent (global)", async () => {

--- a/src/agent/resolve-startup-agent.test.ts
+++ b/src/agent/resolve-startup-agent.test.ts
@@ -65,7 +65,7 @@ describe("resolveStartupTarget", () => {
         pinnedCount: 0,
       }),
     );
-    expect(result).toEqual({ action: "create" });
+    expect(result).toEqual({ action: "create", trigger: "fresh-start" });
   });
 
   test("dir with local LRU + valid agent → resumes local with conversation", () => {
@@ -219,7 +219,7 @@ describe("resolveStartupTarget", () => {
 
   test("true fresh user (no local, no global, no pinned) → create", () => {
     const result = resolveStartupTarget(makeInput());
-    expect(result).toEqual({ action: "create" });
+    expect(result).toEqual({ action: "create", trigger: "fresh-start" });
   });
 
   test("no LRU but pinned agents exist → select", () => {
@@ -241,7 +241,7 @@ describe("resolveStartupTarget", () => {
         forceNew: true,
       }),
     );
-    expect(result).toEqual({ action: "create" });
+    expect(result).toEqual({ action: "create", trigger: "force-new" });
   });
 
   test("needsModelPicker + no valid agents → select (not create)", () => {
@@ -304,7 +304,7 @@ describe("resolveStartupTarget", () => {
         pinnedCount: 0,
       }),
     );
-    expect(result).toEqual({ action: "create" });
+    expect(result).toEqual({ action: "create", trigger: "fresh-start" });
   });
 
   test("same local/global ID invalid + pinned → select", () => {

--- a/src/agent/resolve-startup-agent.ts
+++ b/src/agent/resolve-startup-agent.ts
@@ -11,7 +11,17 @@
 export type StartupTarget =
   | { action: "resume"; agentId: string; conversationId?: string }
   | { action: "select" }
-  | { action: "create" };
+  | {
+      action: "create";
+      /**
+       * Why we're creating: an explicit `--new-agent` request vs a true
+       * fresh start (nothing to resume or select). Callers map this to a
+       * default personality — e.g. the interactive CLI creates a Tutor
+       * agent for fresh starts and a standard Letta Code agent for
+       * `--new-agent`.
+       */
+      trigger: "force-new" | "fresh-start";
+    };
 
 export interface StartupResolutionInput {
   /** The pinned agent to resume when exactly one pin exists for the active org */
@@ -67,7 +77,7 @@ export function resolveStartupTarget(
 ): StartupTarget {
   // --new-agent always creates
   if (input.forceNew) {
-    return { action: "create" };
+    return { action: "create", trigger: "force-new" };
   }
 
   // Step 1: Pinned agent
@@ -128,5 +138,5 @@ export function resolveStartupTarget(
   }
 
   // Step 7: True fresh user — create default agent
-  return { action: "create" };
+  return { action: "create", trigger: "fresh-start" };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2006,6 +2006,11 @@ async function main(): Promise<void> {
             try {
               const defaultAgent = await ensureDefaultAgents(getBackend(), {
                 preferredModel: model,
+                // True fresh start (brand-new account, nothing to resume)
+                // gets the Tutor onboarding agent; an explicit --new-agent
+                // gets the standard Letta Code agent.
+                personality:
+                  target.trigger === "fresh-start" ? "tutorial" : "memo",
               });
               if (defaultAgent) {
                 startupCreatedAgentRef.current = defaultAgent;


### PR DESCRIPTION
LET-9413 (letta-code half; the desktop/web half is a separate letta-cloud PR)
Linear: https://linear.app/letta/issue/LET-9413/make-tutor-the-default-agent-thats-created-for-a-brand-new-account-on

## Summary
- A true fresh start — no pins, no resumable agents, nothing to select — now creates the **Tutor** (`tutorial`) personality instead of the standard Letta Code (memo) agent, so new users get onboarding instead of a blank coding agent.
- The rules are deliberately simple, one per entrypoint, with no account-state branching:
  - **fresh start** (interactive CLI) → Tutor
  - **explicit `--new-agent`** → Letta Code (memo), always — you asked for a new agent, you get the standard one
  - **headless `-p` bootstrap** → Letta Code (memo), always — no human to tutor in automation (unchanged: `ensureDefaultAgents` defaults to memo)
- Mechanics: `resolveStartupTarget` now includes `trigger: "force-new" | "fresh-start"` on the create action (pure + unit-tested); the interactive caller maps trigger → personality; `ensureDefaultAgents` accepts `personality` and builds Tutor agents through the existing `buildCreateAgentOptionsForPersonality` path with the same memfs-mode/model resolution and pinning as the memo default. Tutor defaults get tagged `default:tutorial` (alongside the existing `default:memo`).

## Test plan
- [x] `bun test src/agent/resolve-startup-agent.test.ts` (21 pass, force-new/fresh-start triggers covered)
- [x] `bun test src/agent/resolve-startup-agent-files.test.ts` (19 pass)
- [x] `bun run check` (all 9)

👾 Generated with [Letta Code](https://letta.com)