### PR TITLE
feat: echo acting-user on listener conversation create/fork [LET-9420]

### DIFF
--- a/src/agent/acting-user.ts
+++ b/src/agent/acting-user.ts
@@ -1,0 +1,26 @@
+/**
+ * Header the listener echoes back to cloud-api so it can re-attribute
+ * requests to the human who actually initiated them (rather than the
+ * user whose API key spawned the sandbox / desktop runtime).
+ *
+ * Cloud-api stamps `acting_user_id` onto relayed WS frames
+ * (`input` create_message, `execute_command`, `conversation_create`);
+ * the listener echoes the value on the corresponding outbound HTTP
+ * call. Cloud-api validates listener origin + org membership before
+ * honoring it (see tryApplyActingUserOverride in cloud-api).
+ */
+export const ACTING_USER_ID_HEADER = "X-Letta-Acting-User-Id";
+
+/**
+ * Build per-request options carrying the acting-user header, or
+ * undefined when no acting user is present (self-hosted / direct
+ * flows), so call sites can spread it without conditionals.
+ */
+export function actingUserRequestOptions(
+  actingUserId: string | undefined,
+): { headers: Record<string, string> } | undefined {
+  if (!actingUserId) {
+    return undefined;
+  }
+  return { headers: { [ACTING_USER_ID_HEADER]: actingUserId } };
+}

--- a/src/backend/api/conversations.ts
+++ b/src/backend/api/conversations.ts
@@ -3,6 +3,8 @@ import { apiRequest } from "./request";
 export interface ForkConversationOptions {
   agentId?: string;
   hidden?: boolean;
+  /** Extra headers forwarded on the request (e.g. acting-user echo). */
+  headers?: Record<string, string>;
 }
 
 export type ConversationDescriptionUpdateBody = Record<string, unknown> & {
@@ -31,7 +33,7 @@ export async function forkConversation(
     "POST",
     `/v1/conversations/${encodeURIComponent(conversationId)}/fork`,
     undefined,
-    { query },
+    { query, ...(options.headers ? { headers: options.headers } : {}) },
   );
 }
 

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -1830,6 +1830,16 @@ export interface ConversationCreateCommand {
   request_id: string;
   /** Body forwarded to the Letta conversations create API. */
   body: ConversationCreateParams;
+  /**
+   * Set by cloud-api when relaying the command: the authenticated WS
+   * subscriber's cloud user id. The listener echoes it back as the
+   * `X-Letta-Acting-User-Id` HTTP header on the outbound
+   * conversations.create call so cloud attributes the new conversation
+   * to the human who actually created it — not the user whose API key
+   * spawned the sandbox / desktop runtime. Absent for self-hosted or
+   * direct (non-relayed) flows.
+   */
+  acting_user_id?: string;
 }
 
 export interface ConversationUpdateCommand {
@@ -1863,6 +1873,12 @@ export interface ConversationForkCommand {
   request_id: string;
   conversation_id: string;
   body?: ConversationForkBody;
+  /**
+   * Set by cloud-api when relaying the command — see
+   * `ConversationCreateCommand.acting_user_id`. The fork produces a new
+   * conversation, so it is attributed the same way.
+   */
+  acting_user_id?: string;
 }
 
 export interface ConversationMessagesListCommand {

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import type WebSocket from "ws";
+import { actingUserRequestOptions } from "@/agent/acting-user";
 import { regenerateConversationDescription } from "@/agent/conversation-description";
 import {
   applySetMaxContext,
@@ -102,7 +103,10 @@ export async function handleExecuteCommand(
 
     switch (command.command_id) {
       case "clear":
-        output = await handleClearCommand(socket, conversationRuntime, opts);
+        output = await handleClearCommand(socket, conversationRuntime, {
+          ...opts,
+          actingUserId: command.runtime.acting_user_id,
+        });
         break;
 
       case "doctor":
@@ -572,6 +576,8 @@ async function handleClearCommand(
   opts: {
     onStatusChange?: StartListenerOptions["onStatusChange"];
     connectionId?: string;
+    /** Cloud user id stamped on the relayed frame; echoed on the create call. */
+    actingUserId?: string;
   },
 ): Promise<string> {
   const backend = getBackend();
@@ -594,10 +600,14 @@ async function handleClearCommand(
     });
   }
 
-  // Create a new conversation
-  const conversation = await backend.createConversation({
-    agent_id: agentId,
-  });
+  // Create a new conversation, attributing it to the human who ran
+  // /clear when the frame was relayed by cloud with an acting user.
+  const conversation = await backend.createConversation(
+    {
+      agent_id: agentId,
+    },
+    actingUserRequestOptions(opts.actingUserId),
+  );
 
   // Clear runtime state for the current conversation
   clearConversationRuntimeState(conversationRuntime);

--- a/src/websocket/listener/commands/acting-user-attribution.test.ts
+++ b/src/websocket/listener/commands/acting-user-attribution.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  ACTING_USER_ID_HEADER,
+  actingUserRequestOptions,
+} from "@/agent/acting-user";
+
+/**
+ * Attribution contract for listener-created conversations.
+ *
+ * Cloud-api stamps `acting_user_id` onto relayed `conversation_create`,
+ * `conversation_fork`, and `execute_command` frames; the listener must
+ * echo it back as the `X-Letta-Acting-User-Id` header on the outbound
+ * create/fork HTTP calls so cloud attributes the new conversation to
+ * the human who actually created it (see tryApplyActingUserOverride in
+ * cloud-api). Without the echo, conversations created via `/clear` or
+ * the sidebar are stamped as the sandbox/API-key owner.
+ *
+ * Source-level pins are used for the handler wiring (matching the
+ * existing `send-message-stream-acting-user.test.ts` convention, and
+ * for the same reason: `mock.module` in other suites is process-global
+ * under Bun). The helper itself is tested behaviorally.
+ */
+
+describe("actingUserRequestOptions", () => {
+  test("header literal matches the wire contract used by message.ts and cloud-api", () => {
+    expect(ACTING_USER_ID_HEADER).toBe("X-Letta-Acting-User-Id");
+  });
+
+  test("builds header options when an acting user is present", () => {
+    expect(actingUserRequestOptions("user-123")).toEqual({
+      headers: { "X-Letta-Acting-User-Id": "user-123" },
+    });
+  });
+
+  test("returns undefined for self-hosted / direct flows", () => {
+    expect(actingUserRequestOptions(undefined)).toBeUndefined();
+    expect(actingUserRequestOptions("")).toBeUndefined();
+  });
+});
+
+describe("listener conversation-create attribution wiring (contract)", () => {
+  const handlerSource = readFileSync(
+    fileURLToPath(new URL("./agents-conversations.ts", import.meta.url)),
+    "utf-8",
+  );
+  const commandsSource = readFileSync(
+    fileURLToPath(new URL("../commands.ts", import.meta.url)),
+    "utf-8",
+  );
+
+  test("conversation_create echoes the relayed acting user", () => {
+    expect(handlerSource).toMatch(
+      /backend\.createConversation\(\s*parsed\.body,\s*actingUserRequestOptions\(parsed\.acting_user_id\),\s*\)/,
+    );
+  });
+
+  test("conversation_fork echoes the relayed acting user", () => {
+    expect(handlerSource).toMatch(
+      /backend\.forkConversation\([\s\S]*?actingUserRequestOptions\(parsed\.acting_user_id\)/,
+    );
+  });
+
+  test("/clear passes the frame's acting user into its conversation create", () => {
+    expect(commandsSource).toMatch(
+      /handleClearCommand\(socket, conversationRuntime, \{\s*\.\.\.opts,\s*actingUserId: command\.runtime\.acting_user_id,\s*\}\)/,
+    );
+    expect(commandsSource).toMatch(
+      /backend\.createConversation\(\s*\{\s*agent_id: agentId,\s*\},\s*actingUserRequestOptions\(opts\.actingUserId\),\s*\)/,
+    );
+  });
+});

--- a/src/websocket/listener/commands/agents-conversations.ts
+++ b/src/websocket/listener/commands/agents-conversations.ts
@@ -1,4 +1,5 @@
 import type WebSocket from "ws";
+import { actingUserRequestOptions } from "@/agent/acting-user";
 import { getBackend } from "@/backend";
 import type {
   AgentCreateCommand,
@@ -309,7 +310,10 @@ export async function handleAgentConversationManagementCommand(
 
   if (parsed.type === "conversation_create") {
     try {
-      const conversation = await backend.createConversation(parsed.body);
+      const conversation = await backend.createConversation(
+        parsed.body,
+        actingUserRequestOptions(parsed.acting_user_id),
+      );
       safeSocketSend(
         socket,
         {
@@ -417,6 +421,7 @@ export async function handleAgentConversationManagementCommand(
           ...(typeof parsed.body?.hidden === "boolean"
             ? { hidden: parsed.body.hidden }
             : {}),
+          ...(actingUserRequestOptions(parsed.acting_user_id) ?? {}),
         },
       );
       safeSocketSend(


### PR DESCRIPTION
## Summary
- Conversations created through the listener WS paths (sidebar `conversation_create`/`conversation_fork`, `/clear` via `execute_command`) are attributed to the user whose API key spawned the runtime, because that key is the sole bearer credential on the outbound HTTP calls. Cloud already re-attributes `createMessage` via the `X-Letta-Acting-User-Id` echo — this extends the same pattern to conversation-creating calls so `created_by` reflects the human who actually created the conversation.
- Protocol: optional `acting_user_id` on `ConversationCreateCommand` and `ConversationForkCommand` (`execute_command` already carries it via `RuntimeScope`); stamped by cloud on relay, never trusted from browsers.
- Listener: echoes the header on `backend.createConversation` (WS handler + `/clear`) and `backend.forkConversation`; shared `actingUserRequestOptions` helper pins the header literal.
- Self-hosted / direct (non-relayed) flows never see the field, so behavior there is unchanged.

Pairs with letta-ai/letta-cloud#12754 stamping `acting_user_id` on relayed frames; the field is optional so either side can deploy first.

👾 Generated with [Letta Code](https://letta.com)