### PR TITLE
Fix Desktop skill status for agent MemFS skills

### DIFF
--- a/src/agent/client-skills.test.ts
+++ b/src/agent/client-skills.test.ts
@@ -426,6 +426,13 @@ describe("buildClientSkillsPayload", () => {
       expect(result.skillPathById).toEqual({
         "shared-skill": join(memorySkillDir, "SKILL.md"),
       });
+      expect(result.availableSkills).toContainEqual({
+        id: "shared-skill",
+        name: "shared-skill",
+        description: "from memfs",
+        path: join(memorySkillDir, "SKILL.md"),
+        source: "agent",
+      });
     } finally {
       if (originalMemoryDir === undefined) {
         delete process.env.MEMORY_DIR;

--- a/src/agent/client-skills.ts
+++ b/src/agent/client-skills.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync, realpathSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type { MessageCreateParams as ConversationMessageCreateParams } from "@letta-ai/letta-client/resources/conversations/messages";
+import type { AvailableSkillSummary } from "@/types/protocol_v2";
 import { getSkillSources, getSkillsDirectory } from "./context";
 import { resolveScopedMemoryDir } from "./memory-filesystem";
 import {
@@ -190,6 +191,7 @@ function cloneResult(
 ): BuildClientSkillsPayloadResult {
   return {
     clientSkills: result.clientSkills.map((s) => ({ ...s })),
+    availableSkills: result.availableSkills.map((s) => ({ ...s })),
     skillPathById: { ...result.skillPathById },
     errors: result.errors.map((e) => ({ ...e })),
   };
@@ -309,6 +311,7 @@ export interface BuildClientSkillsPayloadOptions {
 
 export interface BuildClientSkillsPayloadResult {
   clientSkills: NonNullable<ConversationMessageCreateParams["client_skills"]>;
+  availableSkills: AvailableSkillSummary[];
   skillPathById: Record<string, string>;
   errors: SkillDiscoveryError[];
 }
@@ -322,6 +325,16 @@ function toClientSkill(skill: Skill): ClientSkill {
     name: skill.id,
     description: skill.description,
     location: skill.path,
+  };
+}
+
+function toAvailableSkillSummary(skill: Skill): AvailableSkillSummary {
+  return {
+    id: skill.id,
+    name: skill.name,
+    description: skill.description,
+    path: skill.path,
+    source: skill.source,
   };
 }
 
@@ -532,6 +545,7 @@ export async function buildClientSkillsPayload(
 
   const result: BuildClientSkillsPayloadResult = {
     clientSkills: sortedSkills.map(toClientSkill),
+    availableSkills: discovery.skills.map(toAvailableSkillSummary),
     skillPathById: Object.fromEntries(
       sortedSkills
         .filter(

--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -18,6 +18,7 @@ import {
   prepareCurrentToolExecutionContext,
   waitForToolsetReady,
 } from "@/tools/manager";
+import type { AvailableSkillSummary } from "@/types/protocol_v2";
 import { debugLog, debugWarn, isDebugEnabled } from "@/utils/debug";
 import {
   assertSupportedBase64ImageMediaTypes,
@@ -204,6 +205,8 @@ export type SendMessageStreamOptions = {
   allowResponseStateReuse?: boolean;
   /** Skip shared image normalization when the caller already did it. */
   skipImageNormalization?: boolean;
+  /** Called with the resolved skill snapshot used for this request. */
+  onClientSkillsDiscovered?: (skills: AvailableSkillSummary[]) => void;
   /**
    * Cloud user id of the human who pressed "send" (multi-user
    * sandbox scenario). When set, `sendMessageStream` echoes this on
@@ -318,11 +321,15 @@ export async function sendMessageStreamWithBackend(
         });
       })();
   const { clientTools, contextId } = preparedToolContext;
-  const { clientSkills, errors: clientSkillDiscoveryErrors } =
-    await buildClientSkillsPayload({
-      agentId: opts.agentId,
-      skillSources: getSkillSources(),
-    });
+  const {
+    clientSkills,
+    availableSkills,
+    errors: clientSkillDiscoveryErrors,
+  } = await buildClientSkillsPayload({
+    agentId: opts.agentId,
+    skillSources: getSkillSources(),
+  });
+  opts.onClientSkillsDiscovered?.(availableSkills);
 
   const resolvedConversationId = conversationId;
   const responseStateScope = buildResponseStateScope(

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -739,6 +739,100 @@ describe("listen-client parseServerMessage", () => {
       }
     });
 
+    test("runtime_start preloads agent MemFS skills into device status", async () => {
+      const storageDir = await mkdtemp(
+        join(os.tmpdir(), "ws-runtime-start-skills-"),
+      );
+      const originalMemoryDir = process.env.MEMORY_DIR;
+      const originalLettaMemoryDir = process.env.LETTA_MEMORY_DIR;
+      try {
+        const backend = new LocalBackend({
+          storageDir,
+          executionMode: "deterministic",
+        });
+        __testSetBackend(backend);
+        const agent = await backend.createAgent({
+          name: "Runtime Skill Agent",
+          model: "anthropic/claude-sonnet-4-6",
+        } as AgentCreateBody);
+        const conversation = await backend.createConversation({
+          agent_id: agent.id,
+          summary: "Skill status conversation",
+        });
+        const memoryDir = join(storageDir, "memory");
+        const skillDir = join(memoryDir, "skills", "agent-development");
+        await mkdir(skillDir, { recursive: true });
+        await writeFile(
+          join(skillDir, "SKILL.md"),
+          [
+            "---",
+            "name: letta-development-guide",
+            "description: Agent-scoped MemFS skill",
+            "---",
+            "",
+            "# Letta Development Guide",
+          ].join("\n"),
+        );
+        process.env.MEMORY_DIR = memoryDir;
+        delete process.env.LETTA_MEMORY_DIR;
+
+        const listener = __listenClientTestUtils.createListenerRuntime();
+        const socket = new MockSocket(WebSocket.OPEN);
+
+        await __listenClientTestUtils.handleRuntimeStartCommand(
+          {
+            type: "runtime_start",
+            request_id: "runtime-start-skills",
+            agent_id: agent.id,
+            conversation_id: conversation.id,
+            recover_approvals: false,
+          },
+          socket as unknown as WebSocket,
+          listener,
+        );
+
+        const messages = socket.sentPayloads.map((payload) =>
+          JSON.parse(payload),
+        );
+        const status = messages.find(
+          (message) =>
+            message.type === "update_device_status" &&
+            message.runtime?.agent_id === agent.id &&
+            message.runtime?.conversation_id === conversation.id,
+        );
+        expect(status).toMatchObject({
+          type: "update_device_status",
+          runtime: {
+            agent_id: agent.id,
+            conversation_id: conversation.id,
+          },
+          device_status: {
+            current_available_skills: expect.arrayContaining([
+              {
+                id: "agent-development",
+                name: "letta-development-guide",
+                description: "Agent-scoped MemFS skill",
+                path: join(skillDir, "SKILL.md"),
+                source: "agent",
+              },
+            ]),
+          },
+        });
+      } finally {
+        if (originalMemoryDir === undefined) {
+          delete process.env.MEMORY_DIR;
+        } else {
+          process.env.MEMORY_DIR = originalMemoryDir;
+        }
+        if (originalLettaMemoryDir === undefined) {
+          delete process.env.LETTA_MEMORY_DIR;
+        } else {
+          process.env.LETTA_MEMORY_DIR = originalLettaMemoryDir;
+        }
+        await rm(storageDir, { recursive: true, force: true });
+      }
+    });
+
     test("starts an agent default conversation", async () => {
       const storageDir = await mkdtemp(
         join(os.tmpdir(), "ws-runtime-start-default-"),

--- a/src/websocket/listener/commands/runtime-start.ts
+++ b/src/websocket/listener/commands/runtime-start.ts
@@ -4,6 +4,7 @@ import type {
   ConversationCreateParams,
 } from "@letta-ai/letta-client/resources/conversations/conversations";
 import type WebSocket from "ws";
+import { buildClientSkillsPayload } from "@/agent/client-skills";
 import { getBackend } from "@/backend";
 import { migratePermissionMode } from "@/permissions/mode";
 import { settingsManager } from "@/settings-manager";
@@ -208,6 +209,19 @@ async function applyRuntimeStartState(
   }
 }
 
+async function refreshRuntimeSkillSnapshot(
+  scopedRuntime: ConversationRuntime,
+): Promise<void> {
+  try {
+    const { availableSkills } = await buildClientSkillsPayload({
+      agentId: scopedRuntime.agentId ?? undefined,
+    });
+    scopedRuntime.currentAvailableSkills = availableSkills;
+  } catch {
+    scopedRuntime.currentAvailableSkills = [];
+  }
+}
+
 export async function handleRuntimeStartCommand(
   parsed: RuntimeStartCommand,
   context: RuntimeStartCommandContext,
@@ -233,6 +247,7 @@ export async function handleRuntimeStartCommand(
       runtimeScope.conversation_id,
     );
     await applyRuntimeStartState(parsed, context, runtimeScope, scopedRuntime);
+    await refreshRuntimeSkillSnapshot(scopedRuntime);
     registerRuntimeExternalTools(
       context.runtime,
       runtimeScope,

--- a/src/websocket/listener/protocol-outbound.test.ts
+++ b/src/websocket/listener/protocol-outbound.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import WebSocket from "ws";
 import type { DequeuedBatch } from "@/queue/queue-runtime";
-import type { StreamDeltaMessage } from "@/types/protocol_v2";
-import { emitDequeuedUserMessage } from "@/websocket/listener/protocol-outbound";
+import type { DeviceStatus, StreamDeltaMessage } from "@/types/protocol_v2";
+import {
+  buildDeviceStatus,
+  emitDequeuedUserMessage,
+} from "@/websocket/listener/protocol-outbound";
 import type {
   ConversationRuntime,
   IncomingMessage,
@@ -28,6 +31,14 @@ function createRuntime(): {
     socket: socket as never,
     transport: socket as never,
     streamTransport: null,
+    connectionId: "conn-1",
+    connectionName: "test-listener",
+    bootWorkingDirectory: process.cwd(),
+    workingDirectoryByConversation: new Map(),
+    permissionModeByConversation: new Map(),
+    approvalRuntimeKeyByRequestId: new Map(),
+    worktreeWatcherByConversation: new Map(),
+    pendingExternalToolCalls: new Map(),
     eventSeqCounter: 0,
     conversationRuntimes: new Map(),
   } as unknown as ListenerRuntime;
@@ -35,6 +46,13 @@ function createRuntime(): {
     listener,
     agentId: "agent-1",
     conversationId: "conv-1",
+    pendingApprovalResolvers: new Map(),
+    recoveredApprovalState: null,
+    isProcessing: false,
+    currentToolset: null,
+    currentToolsetPreference: "auto",
+    currentLoadedTools: [],
+    currentAvailableSkills: [],
   } as unknown as ConversationRuntime;
   listener.conversationRuntimes.set("test", runtime);
   return { runtime, socket };
@@ -46,6 +64,32 @@ function parseOnlyStreamDelta(socket: MockSocket): StreamDeltaMessage {
   expect(message.type).toBe("stream_delta");
   return message as StreamDeltaMessage;
 }
+
+describe("buildDeviceStatus", () => {
+  test("includes assigned agent skill paths from the conversation runtime", () => {
+    const { runtime } = createRuntime();
+    runtime.key = "agent:agent-1::conversation:conv-1";
+    runtime.currentAvailableSkills = [
+      {
+        id: "agent-development",
+        name: "letta-development-guide",
+        description: "Agent-scoped MemFS skill",
+        path: "/tmp/.letta/agents/agent-1/memory/skills/agent-development/SKILL.md",
+        source: "agent",
+      },
+    ];
+    runtime.listener.conversationRuntimes.set(runtime.key, runtime);
+
+    const status = buildDeviceStatus(runtime, {
+      agent_id: "agent-1",
+      conversation_id: "conv-1",
+    }) as DeviceStatus;
+
+    expect(status.current_available_skills).toEqual(
+      runtime.currentAvailableSkills,
+    );
+  });
+});
 
 describe("emitDequeuedUserMessage", () => {
   test("emits cron_prompt-only turns as visible scheduled task user messages", () => {

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -468,7 +468,7 @@ export function buildDeviceStatus(
     current_toolset_preference:
       conversationRuntime?.currentToolsetPreference ?? toolsetPreference,
     current_loaded_tools: conversationRuntime?.currentLoadedTools ?? [],
-    current_available_skills: [],
+    current_available_skills: conversationRuntime?.currentAvailableSkills ?? [],
     background_processes: buildBackgroundProcessSnapshot(),
     pending_control_requests: interruptedCacheActive
       ? []

--- a/src/websocket/listener/runtime.ts
+++ b/src/websocket/listener/runtime.ts
@@ -183,6 +183,7 @@ export function createConversationRuntime(
     currentToolset: null,
     currentToolsetPreference: "auto",
     currentLoadedTools: [],
+    currentAvailableSkills: [],
     pendingApprovalBatchByToolCallId: new Map(),
     pendingInterruptedResults: null,
     pendingInterruptedContext: null,

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -638,6 +638,9 @@ export async function handleIncomingMessage(
       permissionModeState: turnPermissionModeState,
       preparedToolContext: preparedToolContext.preparedToolContext,
       skipImageNormalization: true,
+      onClientSkillsDiscovered: (skills) => {
+        runtime.currentAvailableSkills = skills;
+      },
       ...(providerFallback.overrideModel
         ? { overrideModel: providerFallback.overrideModel }
         : {}),

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -20,6 +20,7 @@ import type { SharedReminderState } from "@/reminders/state";
 import type { ToolsetName, ToolsetPreference } from "@/tools/toolset";
 import type {
   ApprovalResponseBody,
+  AvailableSkillSummary,
   ControlRequest,
   ExternalToolCallResult,
   LoopStatus,
@@ -163,6 +164,7 @@ export type ConversationRuntime = {
   currentToolset: ToolsetName | null;
   currentToolsetPreference: ToolsetPreference;
   currentLoadedTools: string[];
+  currentAvailableSkills: AvailableSkillSummary[];
   pendingApprovalBatchByToolCallId: Map<string, string>;
   pendingInterruptedResults: Array<ApprovalResult> | null;
   pendingInterruptedContext: {


### PR DESCRIPTION
## Summary
- surface the resolved client-side skill snapshot as `current_available_skills` in listener device status
- preload that snapshot on `runtime_start` so Desktop has agent MemFS skill paths before the first turn
- refresh the snapshot on turns when client skills are rebuilt

## Why
Desktop can show an agent-assigned MemFS skill but fail to render its modal when the matching `~/.letta/skills/<skill>` local catalog entry is missing. The runtime already resolves the correct skill set from project/global/agent/MemFS sources; this PR exposes that resolved snapshot through the existing device status channel instead of mutating the user local skills catalog.

## Notes
- This does not add a new skill-detail/read RPC; it only exposes availability/path metadata already resolved for the active runtime.
- Absolute skill paths are already local listener state and are scoped to the existing Desktop/listener protocol.
- Skill installs/deletes between turns will refresh on runtime_start or the next turn; a separate detail/read API can be added later if Desktop needs on-demand full skill content.

## Tests
- `bun test src/agent/client-skills.test.ts src/websocket/listener/protocol-outbound.test.ts src/websocket/listen-client-protocol.test.ts --test-name-pattern "(buildClientSkillsPayload|buildDeviceStatus|runtime_start)"`
- `bun run lint`
- `bun run typecheck`
- `bun run check`