### PR TITLE
feat: route headless messages through environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ Route a headless message through a specific environment:
 ```bash
 letta -p --agent <agent-id> --environment "work-laptop" "hello from that machine"
 ```
-Agent-to-agent headless messages (`--from-agent`) default to the target agent's
-cloud sandbox when no environment is specified.
+Use `--environment cloud` to start or reuse the target agent's cloud sandbox.
+Agent-to-agent headless messages without `--environment` keep the original
+same-environment behavior.
 See our guides for using [Railway](https://docs.letta.com/letta-code/remote#railway), [DigitalOcean](https://docs.letta.com/letta-code/remote#digitalocean), and [Fly.io](https://docs.letta.com/letta-code/remote#flyio) as remote environments.
 
 ## Installing external skills

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Route a headless message through a specific environment:
 ```bash
 letta -p --agent <agent-id> --environment "work-laptop" "hello from that machine"
 ```
+Agent-to-agent headless messages (`--from-agent`) default to the target agent's
+cloud sandbox when no environment is specified.
 See our guides for using [Railway](https://docs.letta.com/letta-code/remote#railway), [DigitalOcean](https://docs.letta.com/letta-code/remote#digitalocean), and [Fly.io](https://docs.letta.com/letta-code/remote#flyio) as remote environments.
 
 ## Installing external skills

--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ Agents on Constellation can run across multiple machines. Any machine can be mad
 letta server
 letta server --env-name "work-laptop"
 ```
+List discoverable environments from the CLI:
+```bash
+letta environments list --online-only
+```
+Route a headless message through a specific environment:
+```bash
+letta -p --agent <agent-id> --environment "work-laptop" "hello from that machine"
+```
 See our guides for using [Railway](https://docs.letta.com/letta-code/remote#railway), [DigitalOcean](https://docs.letta.com/letta-code/remote#digitalocean), and [Fly.io](https://docs.letta.com/letta-code/remote#flyio) as remote environments.
 
 ## Installing external skills

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ List discoverable environments from the CLI:
 ```bash
 letta environments list --online-only
 ```
+Get the current environment for routing another agent onto this same machine:
+```bash
+letta environments current
+```
 Route a headless message through a specific environment:
 ```bash
 letta -p --agent <agent-id> --environment "work-laptop" "hello from that machine"

--- a/src/backend/api/environments.ts
+++ b/src/backend/api/environments.ts
@@ -4,6 +4,7 @@ export interface EnvironmentMetadata {
   os?: string;
   lettaCodeVersion?: string;
   nodeVersion?: string;
+  environmentMessageProtocol?: string;
   workingDirectory?: string;
   gitBranch?: string;
   supported_commands?: string[];

--- a/src/backend/api/environments.ts
+++ b/src/backend/api/environments.ts
@@ -1,0 +1,139 @@
+import { apiRequest } from "./request";
+
+export interface EnvironmentMetadata {
+  os?: string;
+  lettaCodeVersion?: string;
+  nodeVersion?: string;
+  workingDirectory?: string;
+  gitBranch?: string;
+  supported_commands?: string[];
+  [key: string]: unknown;
+}
+
+export interface EnvironmentConnection {
+  id: string;
+  connectionId: string | null;
+  deviceId: string;
+  listenerInstanceId?: string;
+  connectionName: string;
+  organizationId: string;
+  userId?: string;
+  apiKeyOwner?: string;
+  podId: string | null;
+  connectedAt: number | null;
+  lastHeartbeat: number | null;
+  lastSeenAt: number;
+  firstSeenAt: number;
+  currentMode?: string;
+  metadata?: EnvironmentMetadata;
+}
+
+export interface ListEnvironmentsResponse {
+  connections: EnvironmentConnection[];
+  hasNextPage: boolean;
+}
+
+export type SendEnvironmentMessageBody = Record<string, unknown> & {
+  messages: Array<Record<string, unknown>>;
+  agentId?: string;
+  conversationId?: string | null;
+};
+
+export interface SendEnvironmentMessageResponse {
+  success: boolean;
+  message: string;
+}
+
+export async function listEnvironments(
+  options: { limit?: number; after?: string; onlineOnly?: boolean } = {},
+): Promise<ListEnvironmentsResponse> {
+  return apiRequest<ListEnvironmentsResponse>(
+    "GET",
+    "/v1/environments",
+    undefined,
+    {
+      query: {
+        limit: options.limit,
+        after: options.after,
+        onlineOnly: options.onlineOnly,
+      },
+    },
+  );
+}
+
+export async function sendEnvironmentMessage(
+  connectionId: string,
+  body: SendEnvironmentMessageBody,
+): Promise<SendEnvironmentMessageResponse> {
+  return apiRequest<SendEnvironmentMessageResponse>(
+    "POST",
+    `/v1/environments/${encodeURIComponent(connectionId)}/messages`,
+    body,
+  );
+}
+
+export function isEnvironmentOnline(
+  environment: EnvironmentConnection,
+): boolean {
+  return (
+    typeof environment.connectionId === "string" &&
+    environment.connectionId.length > 0 &&
+    typeof environment.lastHeartbeat === "number" &&
+    Date.now() - environment.lastHeartbeat < 120_000
+  );
+}
+
+export function describeEnvironment(
+  environment: EnvironmentConnection,
+): string {
+  const status = isEnvironmentOnline(environment) ? "online" : "offline";
+  return `${environment.connectionName} (${environment.deviceId}, ${status})`;
+}
+
+export async function resolveEnvironmentConnectionId(
+  selector: string,
+): Promise<{ connectionId: string; environment: EnvironmentConnection }> {
+  const trimmed = selector.trim();
+  if (!trimmed) {
+    throw new Error("Environment selector must not be empty");
+  }
+
+  const response = await listEnvironments({ limit: 100 });
+  const matches = response.connections.filter((environment) => {
+    return (
+      environment.connectionId === trimmed ||
+      environment.id === trimmed ||
+      environment.deviceId === trimmed ||
+      environment.connectionName === trimmed
+    );
+  });
+
+  if (matches.length === 0) {
+    throw new Error(
+      `Environment "${trimmed}" not found. Run \`letta environments list\` to discover available environments.`,
+    );
+  }
+
+  const onlineMatches = matches.filter(isEnvironmentOnline);
+  if (onlineMatches.length === 0) {
+    throw new Error(
+      `Environment "${trimmed}" is offline. Matched: ${matches.map(describeEnvironment).join(", ")}`,
+    );
+  }
+
+  if (onlineMatches.length > 1) {
+    throw new Error(
+      `Environment "${trimmed}" is ambiguous. Matched: ${onlineMatches.map(describeEnvironment).join(", ")}`,
+    );
+  }
+
+  const environment = onlineMatches[0];
+  if (!environment) {
+    throw new Error(`Environment "${trimmed}" is offline`);
+  }
+  if (!environment.connectionId) {
+    throw new Error(`Environment "${trimmed}" has no active connection id`);
+  }
+
+  return { connectionId: environment.connectionId, environment };
+}

--- a/src/backend/api/environments.ts
+++ b/src/backend/api/environments.ts
@@ -44,6 +44,12 @@ export interface SendEnvironmentMessageResponse {
   message: string;
 }
 
+export interface CreateAgentSandboxResponse {
+  sandboxId: string;
+  deviceId: string;
+  connectionName: string;
+}
+
 export async function listEnvironments(
   options: { limit?: number; after?: string; onlineOnly?: boolean } = {},
 ): Promise<ListEnvironmentsResponse> {
@@ -69,6 +75,25 @@ export async function sendEnvironmentMessage(
     "POST",
     `/v1/environments/${encodeURIComponent(connectionId)}/messages`,
     body,
+  );
+}
+
+export async function getEnvironmentConnection(
+  deviceId: string,
+): Promise<EnvironmentConnection> {
+  return apiRequest<EnvironmentConnection>(
+    "GET",
+    `/v1/environments/${encodeURIComponent(deviceId)}`,
+  );
+}
+
+export async function createAgentSandbox(
+  agentId: string,
+): Promise<CreateAgentSandboxResponse> {
+  return apiRequest<CreateAgentSandboxResponse>(
+    "POST",
+    `/v1/agents/${encodeURIComponent(agentId)}/sandboxes`,
+    {},
   );
 }
 
@@ -136,4 +161,40 @@ export async function resolveEnvironmentConnectionId(
   }
 
   return { connectionId: environment.connectionId, environment };
+}
+
+export async function resolveAgentSandboxConnectionId(
+  agentId: string,
+  options: { timeoutMs?: number; pollIntervalMs?: number } = {},
+): Promise<{ connectionId: string; environment: EnvironmentConnection }> {
+  const timeoutMs = options.timeoutMs ?? 3 * 60_000;
+  const pollIntervalMs = options.pollIntervalMs ?? 2_000;
+  const sandbox = await createAgentSandbox(agentId);
+  const deviceId = sandbox.deviceId || `sandbox-${agentId}`;
+  const deadline = Date.now() + timeoutMs;
+  let lastEnvironment: EnvironmentConnection | null = null;
+  let lastError: unknown = null;
+
+  while (Date.now() < deadline) {
+    try {
+      const environment = await getEnvironmentConnection(deviceId);
+      lastEnvironment = environment;
+      if (isEnvironmentOnline(environment) && environment.connectionId) {
+        return { connectionId: environment.connectionId, environment };
+      }
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+
+  if (lastEnvironment) {
+    throw new Error(
+      `Timed out waiting for cloud sandbox ${sandbox.connectionName} to come online. Last status: ${describeEnvironment(lastEnvironment)}`,
+    );
+  }
+
+  throw new Error(
+    `Timed out waiting for cloud sandbox ${sandbox.connectionName} to register${lastError instanceof Error ? `: ${lastError.message}` : ""}`,
+  );
 }

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -189,7 +189,7 @@ export const CLI_FLAG_CATALOG = {
     help: {
       argLabel: "<selector>",
       description:
-        "Route headless message through an environment by name, device ID, or connection ID",
+        "Route headless message through 'cloud' sandbox or an environment by name, device ID, or connection ID",
     },
   },
   env: { parser: { type: "string" }, mode: "headless" },

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -183,6 +183,16 @@ export const CLI_FLAG_CATALOG = {
       description: "Inject agent-to-agent system reminder (headless mode)",
     },
   },
+  environment: {
+    parser: { type: "string" },
+    mode: "headless",
+    help: {
+      argLabel: "<selector>",
+      description:
+        "Route headless message through an environment by name, device ID, or connection ID",
+    },
+  },
+  env: { parser: { type: "string" }, mode: "headless" },
   skills: {
     parser: { type: "string" },
     mode: "both",

--- a/src/cli/subcommands/environments.ts
+++ b/src/cli/subcommands/environments.ts
@@ -35,8 +35,9 @@ Notes:
   - Output is JSON only.
   - Uses CLI auth; override with LETTA_API_KEY/LETTA_BASE_URL if needed.
   - Use letta environments current to get this machine's connectionId.
+  - Use --environment cloud to route through the target agent's cloud sandbox.
   - Use --environment <name|device-id|connection-id> with headless messaging
-    to route a message through a specific environment.
+    to route a message through a specific registered environment.
 `.trim(),
   );
 }

--- a/src/cli/subcommands/environments.ts
+++ b/src/cli/subcommands/environments.ts
@@ -4,6 +4,7 @@ import {
   listEnvironments,
 } from "@/backend/api/environments";
 import { settingsManager } from "@/settings-manager";
+import { getVersion } from "@/version.ts";
 
 type EnvironmentsSubcommandDeps = {
   initializeSettings?: () => Promise<void>;
@@ -19,9 +20,11 @@ function printUsage(): void {
     `
 Usage:
   letta environments list [options]
+  letta environments current
 
 Aliases:
   letta envs list
+  letta envs current
 
 List options:
   --limit <n>       Max results (default: 50)
@@ -31,6 +34,7 @@ List options:
 Notes:
   - Output is JSON only.
   - Uses CLI auth; override with LETTA_API_KEY/LETTA_BASE_URL if needed.
+  - Use letta environments current to get this machine's connectionId.
   - Use --environment <name|device-id|connection-id> with headless messaging
     to route a message through a specific environment.
 `.trim(),
@@ -71,6 +75,20 @@ function formatEnvironmentForCli(
   };
 }
 
+function scoreCurrentEnvironment(
+  environment: EnvironmentWithOnlineStatus,
+  options: { savedName?: string; currentVersion: string },
+): number {
+  let score = 0;
+  if (environment.connectionName === options.savedName) score += 100;
+  if (environment.metadata?.lettaCodeVersion === options.currentVersion) {
+    score += 50;
+  }
+  if (environment.connectionId?.startsWith("local-")) score += 10;
+  score += environment.lastHeartbeat ?? environment.lastSeenAt ?? 0;
+  return score;
+}
+
 const ENVIRONMENTS_OPTIONS = {
   help: { type: "boolean", short: "h" },
   limit: { type: "string" },
@@ -107,7 +125,7 @@ export async function runEnvironmentsSubcommand(
     return 0;
   }
 
-  if (action !== "list") {
+  if (action !== "list" && action !== "current") {
     console.error(`Unknown action: ${action}`);
     printUsage();
     return 1;
@@ -115,6 +133,46 @@ export async function runEnvironmentsSubcommand(
 
   await (deps.initializeSettings ?? (() => settingsManager.initialize()))();
   const list = deps.listEnvironments ?? listEnvironments;
+  if (action === "current") {
+    const deviceId = settingsManager.getOrCreateDeviceId();
+    const savedName = settingsManager.getListenerEnvName();
+    const currentVersion = getVersion();
+    const result = await list({ limit: 100, onlineOnly: true });
+    const candidates = result.connections
+      .map((environment) => ({
+        ...environment,
+        isOnline: isOnline(environment),
+      }))
+      .filter(
+        (environment) =>
+          environment.deviceId === deviceId &&
+          environment.isOnline &&
+          environment.connectionId,
+      )
+      .sort(
+        (a, b) =>
+          scoreCurrentEnvironment(b, { savedName, currentVersion }) -
+          scoreCurrentEnvironment(a, { savedName, currentVersion }),
+      );
+
+    const current = candidates[0];
+    if (!current) {
+      console.error(
+        "No online environment found for this device. Start one with `letta server` and try again.",
+      );
+      return 1;
+    }
+
+    console.log(
+      JSON.stringify(
+        formatEnvironmentForCli(current, { onlineOnly: true }),
+        null,
+        2,
+      ),
+    );
+    return 0;
+  }
+
   const limit = parseLimit(parsed.values.limit, 50);
   const onlineOnly = parsed.values["online-only"] ?? false;
   const result = await list({

--- a/src/cli/subcommands/environments.ts
+++ b/src/cli/subcommands/environments.ts
@@ -92,20 +92,27 @@ export async function runEnvironmentsSubcommand(
 
   await (deps.initializeSettings ?? (() => settingsManager.initialize()))();
   const list = deps.listEnvironments ?? listEnvironments;
+  const limit = parseLimit(parsed.values.limit, 50);
+  const onlineOnly = parsed.values["online-only"] ?? false;
   const result = await list({
-    limit: parseLimit(parsed.values.limit, 50),
+    limit,
     after: parsed.values.after,
-    onlineOnly: parsed.values["online-only"] ?? false,
+    onlineOnly,
   });
+
+  const connections = result.connections
+    .map((environment) => ({
+      ...environment,
+      isOnline: isOnline(environment),
+    }))
+    .filter((environment) => !onlineOnly || environment.isOnline)
+    .slice(0, limit);
 
   console.log(
     JSON.stringify(
       {
         ...result,
-        connections: result.connections.map((environment) => ({
-          ...environment,
-          isOnline: isOnline(environment),
-        })),
+        connections,
       },
       null,
       2,

--- a/src/cli/subcommands/environments.ts
+++ b/src/cli/subcommands/environments.ts
@@ -58,13 +58,17 @@ function isOnline(environment: EnvironmentConnection): boolean {
 
 function formatEnvironmentForCli(
   environment: EnvironmentWithOnlineStatus,
-  options: { onlineOnly: boolean },
+  options: { onlineOnly: boolean; currentConnectionId?: string | null },
 ) {
   const formatted = {
     deviceId: environment.deviceId,
     connectionName: environment.connectionName,
     connectionId: environment.connectionId ?? null,
     lettaCodeVersion: environment.metadata?.lettaCodeVersion ?? null,
+    ...(environment.connectionId &&
+    environment.connectionId === options.currentConnectionId
+      ? { isCurrent: true }
+      : {}),
   };
   if (options.onlineOnly) {
     return formatted;
@@ -73,6 +77,30 @@ function formatEnvironmentForCli(
     ...formatted,
     isOnline: environment.isOnline,
   };
+}
+
+function findCurrentEnvironment(
+  environments: EnvironmentConnection[],
+  options: { deviceId: string; savedName?: string; currentVersion: string },
+): EnvironmentWithOnlineStatus | null {
+  return (
+    environments
+      .map((environment) => ({
+        ...environment,
+        isOnline: isOnline(environment),
+      }))
+      .filter(
+        (environment) =>
+          environment.deviceId === options.deviceId &&
+          environment.isOnline &&
+          environment.connectionId,
+      )
+      .sort(
+        (a, b) =>
+          scoreCurrentEnvironment(b, options) -
+          scoreCurrentEnvironment(a, options),
+      )[0] ?? null
+  );
 }
 
 function scoreCurrentEnvironment(
@@ -133,29 +161,16 @@ export async function runEnvironmentsSubcommand(
 
   await (deps.initializeSettings ?? (() => settingsManager.initialize()))();
   const list = deps.listEnvironments ?? listEnvironments;
+  const deviceId = settingsManager.getOrCreateDeviceId();
+  const savedName = settingsManager.getListenerEnvName();
+  const currentVersion = getVersion();
   if (action === "current") {
-    const deviceId = settingsManager.getOrCreateDeviceId();
-    const savedName = settingsManager.getListenerEnvName();
-    const currentVersion = getVersion();
     const result = await list({ limit: 100, onlineOnly: true });
-    const candidates = result.connections
-      .map((environment) => ({
-        ...environment,
-        isOnline: isOnline(environment),
-      }))
-      .filter(
-        (environment) =>
-          environment.deviceId === deviceId &&
-          environment.isOnline &&
-          environment.connectionId,
-      )
-      .sort(
-        (a, b) =>
-          scoreCurrentEnvironment(b, { savedName, currentVersion }) -
-          scoreCurrentEnvironment(a, { savedName, currentVersion }),
-      );
-
-    const current = candidates[0];
+    const current = findCurrentEnvironment(result.connections, {
+      deviceId,
+      savedName,
+      currentVersion,
+    });
     if (!current) {
       console.error(
         "No online environment found for this device. Start one with `letta server` and try again.",
@@ -165,7 +180,10 @@ export async function runEnvironmentsSubcommand(
 
     console.log(
       JSON.stringify(
-        formatEnvironmentForCli(current, { onlineOnly: true }),
+        formatEnvironmentForCli(current, {
+          onlineOnly: true,
+          currentConnectionId: current.connectionId,
+        }),
         null,
         2,
       ),
@@ -180,6 +198,12 @@ export async function runEnvironmentsSubcommand(
     after: parsed.values.after,
     onlineOnly,
   });
+  const current = findCurrentEnvironment(result.connections, {
+    deviceId,
+    savedName,
+    currentVersion,
+  });
+  const currentConnectionId = current?.connectionId ?? null;
 
   const connections = result.connections
     .map((environment) => ({
@@ -188,7 +212,9 @@ export async function runEnvironmentsSubcommand(
     }))
     .filter((environment) => !onlineOnly || environment.isOnline)
     .slice(0, limit)
-    .map((environment) => formatEnvironmentForCli(environment, { onlineOnly }));
+    .map((environment) =>
+      formatEnvironmentForCli(environment, { onlineOnly, currentConnectionId }),
+    );
 
   console.log(
     JSON.stringify(

--- a/src/cli/subcommands/environments.ts
+++ b/src/cli/subcommands/environments.ts
@@ -1,0 +1,115 @@
+import { parseArgs } from "node:util";
+import {
+  type EnvironmentConnection,
+  listEnvironments,
+} from "@/backend/api/environments";
+import { settingsManager } from "@/settings-manager";
+
+type EnvironmentsSubcommandDeps = {
+  initializeSettings?: () => Promise<void>;
+  listEnvironments?: typeof listEnvironments;
+};
+
+function printUsage(): void {
+  console.log(
+    `
+Usage:
+  letta environments list [options]
+
+Aliases:
+  letta envs list
+
+List options:
+  --limit <n>       Max results (default: 50)
+  --after <id>      Pagination cursor from a previous environment id
+  --online-only     Only include environments with a fresh active connection
+
+Notes:
+  - Output is JSON only.
+  - Uses CLI auth; override with LETTA_API_KEY/LETTA_BASE_URL if needed.
+  - Use --environment <name|device-id|connection-id> with headless messaging
+    to route a message through a specific environment.
+`.trim(),
+  );
+}
+
+function parseLimit(value: unknown, fallback: number): number {
+  if (typeof value !== "string" || value.length === 0) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? fallback : parsed;
+}
+
+function isOnline(environment: EnvironmentConnection): boolean {
+  return (
+    typeof environment.connectionId === "string" &&
+    environment.connectionId.length > 0 &&
+    typeof environment.lastHeartbeat === "number" &&
+    Date.now() - environment.lastHeartbeat < 120_000
+  );
+}
+
+const ENVIRONMENTS_OPTIONS = {
+  help: { type: "boolean", short: "h" },
+  limit: { type: "string" },
+  after: { type: "string" },
+  "online-only": { type: "boolean" },
+} as const;
+
+function parseEnvironmentsArgs(argv: string[]) {
+  return parseArgs({
+    args: argv,
+    options: ENVIRONMENTS_OPTIONS,
+    strict: true,
+    allowPositionals: true,
+  });
+}
+
+export async function runEnvironmentsSubcommand(
+  argv: string[],
+  deps: EnvironmentsSubcommandDeps = {},
+): Promise<number> {
+  let parsed: ReturnType<typeof parseEnvironmentsArgs>;
+  try {
+    parsed = parseEnvironmentsArgs(argv);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Error: ${message}`);
+    printUsage();
+    return 1;
+  }
+
+  const [action] = parsed.positionals;
+  if (parsed.values.help || !action || action === "help") {
+    printUsage();
+    return 0;
+  }
+
+  if (action !== "list") {
+    console.error(`Unknown action: ${action}`);
+    printUsage();
+    return 1;
+  }
+
+  await (deps.initializeSettings ?? (() => settingsManager.initialize()))();
+  const list = deps.listEnvironments ?? listEnvironments;
+  const result = await list({
+    limit: parseLimit(parsed.values.limit, 50),
+    after: parsed.values.after,
+    onlineOnly: parsed.values["online-only"] ?? false,
+  });
+
+  console.log(
+    JSON.stringify(
+      {
+        ...result,
+        connections: result.connections.map((environment) => ({
+          ...environment,
+          isOnline: isOnline(environment),
+        })),
+      },
+      null,
+      2,
+    ),
+  );
+  return 0;
+}

--- a/src/cli/subcommands/environments.ts
+++ b/src/cli/subcommands/environments.ts
@@ -10,6 +10,10 @@ type EnvironmentsSubcommandDeps = {
   listEnvironments?: typeof listEnvironments;
 };
 
+type EnvironmentWithOnlineStatus = EnvironmentConnection & {
+  isOnline: boolean;
+};
+
 function printUsage(): void {
   console.log(
     `
@@ -46,6 +50,25 @@ function isOnline(environment: EnvironmentConnection): boolean {
     typeof environment.lastHeartbeat === "number" &&
     Date.now() - environment.lastHeartbeat < 120_000
   );
+}
+
+function formatEnvironmentForCli(
+  environment: EnvironmentWithOnlineStatus,
+  options: { onlineOnly: boolean },
+) {
+  const formatted = {
+    deviceId: environment.deviceId,
+    connectionName: environment.connectionName,
+    connectionId: environment.connectionId ?? null,
+    lettaCodeVersion: environment.metadata?.lettaCodeVersion ?? null,
+  };
+  if (options.onlineOnly) {
+    return formatted;
+  }
+  return {
+    ...formatted,
+    isOnline: environment.isOnline,
+  };
 }
 
 const ENVIRONMENTS_OPTIONS = {
@@ -106,7 +129,8 @@ export async function runEnvironmentsSubcommand(
       isOnline: isOnline(environment),
     }))
     .filter((environment) => !onlineOnly || environment.isOnline)
-    .slice(0, limit);
+    .slice(0, limit)
+    .map((environment) => formatEnvironmentForCli(environment, { onlineOnly }));
 
   console.log(
     JSON.stringify(

--- a/src/cli/subcommands/router.test.ts
+++ b/src/cli/subcommands/router.test.ts
@@ -63,10 +63,29 @@ describe("subcommand router", () => {
     }
   });
 
+  test("routes environments help", async () => {
+    const messages: string[] = [];
+    const originalLog = console.log;
+    console.log = (message?: unknown) => {
+      messages.push(String(message));
+    };
+
+    try {
+      const exitCode = await runSubcommand(["envs", "help"]);
+
+      expect(exitCode).toBe(0);
+      expect(messages.join("\n")).toContain("letta environments list");
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
   test("identifies backend-aware subcommands for early backend selection", () => {
     expect(subcommandNeedsEarlyBackendMode("app-server")).toBe(true);
     expect(subcommandNeedsEarlyBackendMode("connect")).toBe(true);
     expect(subcommandNeedsEarlyBackendMode("server")).toBe(true);
+    expect(subcommandNeedsEarlyBackendMode("environments")).toBe(true);
+    expect(subcommandNeedsEarlyBackendMode("envs")).toBe(true);
     expect(subcommandNeedsEarlyBackendMode("memory")).toBe(true);
     expect(subcommandNeedsEarlyBackendMode("mods")).toBe(true);
     expect(subcommandNeedsEarlyBackendMode("version")).toBe(false);

--- a/src/cli/subcommands/router.ts
+++ b/src/cli/subcommands/router.ts
@@ -4,6 +4,7 @@ import { runBackendSubcommand } from "./backend";
 import { runChannelsSubcommand } from "./channels";
 import { runConnectSubcommand } from "./connect";
 import { runCronSubcommand } from "./cron";
+import { runEnvironmentsSubcommand } from "./environments";
 import { runListenSubcommand } from "./listen.tsx";
 import { runLocalBackendSubcommand } from "./local-backend";
 import { runMemorySubcommand } from "./memory";
@@ -32,6 +33,8 @@ export function subcommandNeedsEarlyBackendMode(
     case "app-server":
     case "agents":
     case "connect":
+    case "environments":
+    case "envs":
     case "install":
     case "memfs":
     case "memory":
@@ -68,6 +71,9 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
       return runAppServerSubcommand(rest);
     case "messages":
       return runMessagesSubcommand(rest);
+    case "environments":
+    case "envs":
+      return runEnvironmentsSubcommand(rest);
     case "mods":
       return runModsSubcommand(rest);
     case "server":

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -3531,17 +3531,7 @@ ${SYSTEM_REMINDER_CLOSE}
       console.error("No assistant response found");
       await exitHeadless(1, "headless_missing_result_text");
     }
-    if (fromAgentId) {
-      await writeFinalHeadlessStdout(
-        `${resultText}\n\n${formatAgentReplyMetadata({
-          agentId: agent.id,
-          conversationId,
-          environment: { source: "same-environment" },
-        })}\n`,
-      );
-    } else {
-      await writeFinalHeadlessStdout(`${resultText}\n`);
-    }
+    await writeFinalHeadlessStdout(`${resultText}\n`);
   }
 
   // Report all milestones at the end for latency audit

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -60,6 +60,7 @@ import {
   getBackend,
 } from "./backend";
 import {
+  type EnvironmentConnection,
   resolveAgentSandboxConnectionId,
   resolveEnvironmentConnectionId,
   sendEnvironmentMessage,
@@ -762,6 +763,40 @@ async function waitForEnvironmentAssistantMessage(params: {
 
   if (lastText) return lastText;
   throw new Error("Timed out waiting for environment response");
+}
+
+type EnvironmentResponseMetadata = {
+  selector: string;
+  id: string;
+  connection_id: string;
+  device_id: string;
+  name: string;
+};
+
+function buildEnvironmentResponseMetadata(params: {
+  selector: string;
+  connectionId: string;
+  environment: EnvironmentConnection;
+}): EnvironmentResponseMetadata {
+  return {
+    selector: params.selector,
+    id: params.environment.id,
+    connection_id: params.connectionId,
+    device_id: params.environment.deviceId,
+    name: params.environment.connectionName,
+  };
+}
+
+function formatAgentReplyMetadata(params: {
+  agentId: string;
+  conversationId: string;
+  environment: EnvironmentResponseMetadata;
+}): string {
+  return JSON.stringify({
+    agent_id: params.agentId,
+    conversation_id: params.conversationId,
+    environment: params.environment,
+  });
 }
 
 export async function handleHeadlessCommand(
@@ -2175,6 +2210,11 @@ ${SYSTEM_REMINDER_CLOSE}
       ? await resolveEnvironmentConnectionId(explicitEnvironmentSelector)
       : await resolveAgentSandboxConnectionId(agent.id);
     const { connectionId, environment } = environmentRouting;
+    const responseEnvironment = buildEnvironmentResponseMetadata({
+      selector: explicitEnvironmentSelector ?? "cloud-sandbox",
+      connectionId,
+      environment,
+    });
     await sendEnvironmentMessage(connectionId, {
       agentId: agent.id,
       conversationId,
@@ -2209,12 +2249,7 @@ ${SYSTEM_REMINDER_CLOSE}
             result: resultText,
             agent_id: agent.id,
             conversation_id: conversationId,
-            environment: {
-              selector: explicitEnvironmentSelector ?? "cloud-sandbox",
-              connection_id: connectionId,
-              device_id: environment.deviceId,
-              name: environment.connectionName,
-            },
+            environment: responseEnvironment,
             usage: null,
           },
           null,
@@ -2222,7 +2257,9 @@ ${SYSTEM_REMINDER_CLOSE}
         )}\n`,
       );
     } else if (outputFormat === "stream-json") {
-      const resultEvent: ResultMessage = {
+      const resultEvent: ResultMessage & {
+        environment: EnvironmentResponseMetadata;
+      } = {
         type: "result",
         subtype: "success",
         session_id: sessionId,
@@ -2232,13 +2269,20 @@ ${SYSTEM_REMINDER_CLOSE}
         result: resultText,
         agent_id: agent.id,
         conversation_id: conversationId,
+        environment: responseEnvironment,
         run_ids: [],
         usage: null,
         uuid: `result-${agent.id}-${Date.now()}`,
       };
       writeWireMessage(resultEvent);
     } else {
-      await writeFinalHeadlessStdout(`${resultText}\n`);
+      await writeFinalHeadlessStdout(
+        `${resultText}\n\n${formatAgentReplyMetadata({
+          agentId: agent.id,
+          conversationId,
+          environment: responseEnvironment,
+        })}\n`,
+      );
     }
 
     await exitHeadless(0, "headless_environment_message_complete");

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -60,6 +60,7 @@ import {
   getBackend,
 } from "./backend";
 import {
+  resolveAgentSandboxConnectionId,
   resolveEnvironmentConnectionId,
   sendEnvironmentMessage,
 } from "./backend/api/environments";
@@ -897,7 +898,11 @@ export async function handleHeadlessCommand(
   // --new: Create a new conversation (for concurrent sessions)
   let forceNewConversation = values.new ?? false;
   const fromAgentId = values["from-agent"];
-  const environmentSelector = values.environment || values.env;
+  const explicitEnvironmentSelector = values.environment || values.env;
+  const shouldUseDefaultSandboxEnvironment =
+    !explicitEnvironmentSelector && Boolean(fromAgentId);
+  const usesRemoteEnvironment =
+    Boolean(explicitEnvironmentSelector) || shouldUseDefaultSandboxEnvironment;
 
   // Resolve agent (same logic as interactive mode)
   let agent: AgentState | null = null;
@@ -1781,9 +1786,9 @@ export async function handleHeadlessCommand(
     );
     process.exit(1);
   }
-  if (environmentSelector && isBidirectionalMode) {
+  if (usesRemoteEnvironment && isBidirectionalMode) {
     console.error(
-      "Error: --environment cannot be used with --input-format stream-json",
+      "Error: remote environment routing cannot be used with --input-format stream-json",
     );
     process.exit(1);
   }
@@ -2096,7 +2101,7 @@ ${SYSTEM_REMINDER_CLOSE}
     pushPart(systemReminder);
   }
 
-  if (!environmentSelector) {
+  if (!usesRemoteEnvironment) {
     const lastRunAt = (agent as { last_run_completion?: string })
       .last_run_completion;
     const { parts: sharedReminderParts } = await buildSharedReminderParts({
@@ -2122,7 +2127,7 @@ ${SYSTEM_REMINDER_CLOSE}
   // Pre-load specific skills' full content (used by subagents with skills: field).
   // Environment-routed turns run in the selected remote runtime, which injects
   // its own local context and skills, so avoid prepending this process' context.
-  if (preLoadSkillsRaw && !environmentSelector) {
+  if (preLoadSkillsRaw && !usesRemoteEnvironment) {
     const { readFile: readFileAsync } = await import("node:fs/promises");
     const { skillPathById } = await buildClientSkillsPayload({
       agentId: agent.id,
@@ -2164,10 +2169,12 @@ ${SYSTEM_REMINDER_CLOSE}
     agent.llm_config?.model ?? "unknown",
   );
 
-  if (typeof environmentSelector === "string" && environmentSelector.trim()) {
+  if (usesRemoteEnvironment) {
     const startedAtMs = Date.now();
-    const { connectionId, environment } =
-      await resolveEnvironmentConnectionId(environmentSelector);
+    const environmentRouting = explicitEnvironmentSelector
+      ? await resolveEnvironmentConnectionId(explicitEnvironmentSelector)
+      : await resolveAgentSandboxConnectionId(agent.id);
+    const { connectionId, environment } = environmentRouting;
     await sendEnvironmentMessage(connectionId, {
       agentId: agent.id,
       conversationId,
@@ -2203,7 +2210,7 @@ ${SYSTEM_REMINDER_CLOSE}
             agent_id: agent.id,
             conversation_id: conversationId,
             environment: {
-              selector: environmentSelector,
+              selector: explicitEnvironmentSelector ?? "cloud-sandbox",
               connection_id: connectionId,
               device_id: environment.deviceId,
               name: environment.connectionName,

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -766,7 +766,8 @@ async function waitForEnvironmentAssistantMessage(params: {
 }
 
 type EnvironmentResponseMetadata = {
-  selector: string;
+  source: "explicit" | "cloud-sandbox";
+  input: string;
   id: string;
   connection_id: string;
   device_id: string;
@@ -774,12 +775,14 @@ type EnvironmentResponseMetadata = {
 };
 
 function buildEnvironmentResponseMetadata(params: {
-  selector: string;
+  source: EnvironmentResponseMetadata["source"];
+  input: string;
   connectionId: string;
   environment: EnvironmentConnection;
 }): EnvironmentResponseMetadata {
   return {
-    selector: params.selector,
+    source: params.source,
+    input: params.input,
     id: params.environment.id,
     connection_id: params.connectionId,
     device_id: params.environment.deviceId,
@@ -797,6 +800,14 @@ function formatAgentReplyMetadata(params: {
     conversation_id: params.conversationId,
     environment: params.environment,
   });
+}
+
+function isCloudEnvironmentSelector(
+  selector: string | boolean | undefined,
+): boolean {
+  if (typeof selector !== "string") return false;
+  const normalized = selector.trim().toLowerCase();
+  return normalized === "cloud" || normalized === "cloud-sandbox";
 }
 
 export async function handleHeadlessCommand(
@@ -934,10 +945,9 @@ export async function handleHeadlessCommand(
   let forceNewConversation = values.new ?? false;
   const fromAgentId = values["from-agent"];
   const explicitEnvironmentSelector = values.environment || values.env;
-  const shouldUseDefaultSandboxEnvironment =
-    !explicitEnvironmentSelector && Boolean(fromAgentId);
   const usesRemoteEnvironment =
-    Boolean(explicitEnvironmentSelector) || shouldUseDefaultSandboxEnvironment;
+    typeof explicitEnvironmentSelector === "string" &&
+    explicitEnvironmentSelector.trim().length > 0;
 
   // Resolve agent (same logic as interactive mode)
   let agent: AgentState | null = null;
@@ -2206,12 +2216,15 @@ ${SYSTEM_REMINDER_CLOSE}
 
   if (usesRemoteEnvironment) {
     const startedAtMs = Date.now();
-    const environmentRouting = explicitEnvironmentSelector
-      ? await resolveEnvironmentConnectionId(explicitEnvironmentSelector)
-      : await resolveAgentSandboxConnectionId(agent.id);
+    const environmentSelector = String(explicitEnvironmentSelector);
+    const useCloudSandbox = isCloudEnvironmentSelector(environmentSelector);
+    const environmentRouting = useCloudSandbox
+      ? await resolveAgentSandboxConnectionId(agent.id)
+      : await resolveEnvironmentConnectionId(environmentSelector);
     const { connectionId, environment } = environmentRouting;
     const responseEnvironment = buildEnvironmentResponseMetadata({
-      selector: explicitEnvironmentSelector ?? "cloud-sandbox",
+      source: useCloudSandbox ? "cloud-sandbox" : "explicit",
+      input: environmentSelector,
       connectionId,
       environment,
     });

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -4,7 +4,10 @@ import type {
   AgentState,
   MessageCreate,
 } from "@letta-ai/letta-client/resources/agents/agents";
-import type { ApprovalCreate } from "@letta-ai/letta-client/resources/agents/messages";
+import type {
+  ApprovalCreate,
+  Message as LettaMessage,
+} from "@letta-ai/letta-client/resources/agents/messages";
 import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs";
 import { getTerminalTelemetrySurface, telemetry } from "@/telemetry";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
@@ -56,6 +59,10 @@ import {
   type ConversationMessageStreamBody,
   getBackend,
 } from "./backend";
+import {
+  resolveEnvironmentConnectionId,
+  sendEnvironmentMessage,
+} from "./backend/api/environments";
 import type { ParsedCliArgs } from "./cli/args";
 import {
   normalizeConversationShorthandFlags,
@@ -646,6 +653,116 @@ async function writeFinalHeadlessStdout(text: string): Promise<void> {
   });
 }
 
+function pageItems<T>(page: unknown): T[] {
+  if (Array.isArray(page)) return page as T[];
+  if (page && typeof page === "object") {
+    const maybePage = page as {
+      getPaginatedItems?: () => T[];
+      items?: T[];
+    };
+    if (typeof maybePage.getPaginatedItems === "function") {
+      return maybePage.getPaginatedItems();
+    }
+    if (Array.isArray(maybePage.items)) {
+      return maybePage.items;
+    }
+  }
+  return [];
+}
+
+function extractMessageText(message: LettaMessage): string {
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (
+          part &&
+          typeof part === "object" &&
+          "type" in part &&
+          part.type === "text" &&
+          "text" in part &&
+          typeof part.text === "string"
+        ) {
+          return part.text;
+        }
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+  return "";
+}
+
+function isAssistantMessage(message: LettaMessage): boolean {
+  return (
+    (message as { message_type?: string }).message_type === "assistant_message"
+  );
+}
+
+function messageTime(message: LettaMessage): number {
+  const date =
+    (message as { date?: string; created_at?: string }).date ??
+    (message as { created_at?: string }).created_at;
+  return date ? new Date(date).getTime() : 0;
+}
+
+async function waitForEnvironmentAssistantMessage(params: {
+  backend: ReturnType<typeof getBackend>;
+  agentId: string;
+  conversationId: string;
+  startedAtMs: number;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+}): Promise<string> {
+  const timeoutMs = params.timeoutMs ?? 10 * 60_000;
+  const pollIntervalMs = params.pollIntervalMs ?? 1_000;
+  const deadline = Date.now() + timeoutMs;
+  let lastText = "";
+  let stableCount = 0;
+
+  while (Date.now() < deadline) {
+    const page =
+      params.conversationId === "default"
+        ? await params.backend.listAgentMessages(params.agentId, {
+            conversation_id: "default",
+            limit: 50,
+            order: "desc",
+          })
+        : await params.backend.listConversationMessages(params.conversationId, {
+            limit: 50,
+            order: "desc",
+          });
+
+    const messages = pageItems<LettaMessage>(page);
+    const assistant = messages
+      .filter(
+        (message) =>
+          isAssistantMessage(message) &&
+          messageTime(message) >= params.startedAtMs - 2_000,
+      )
+      .sort((a, b) => messageTime(b) - messageTime(a))[0];
+
+    const text = assistant ? extractMessageText(assistant).trim() : "";
+    if (text.length > 0) {
+      if (text === lastText) {
+        stableCount += 1;
+      } else {
+        lastText = text;
+        stableCount = 1;
+      }
+      if (stableCount >= 2) {
+        return text;
+      }
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+
+  if (lastText) return lastText;
+  throw new Error("Timed out waiting for environment response");
+}
+
 export async function handleHeadlessCommand(
   parsedArgs: ParsedCliArgs,
   model?: string,
@@ -780,6 +897,7 @@ export async function handleHeadlessCommand(
   // --new: Create a new conversation (for concurrent sessions)
   let forceNewConversation = values.new ?? false;
   const fromAgentId = values["from-agent"];
+  const environmentSelector = values.environment || values.env;
 
   // Resolve agent (same logic as interactive mode)
   let agent: AgentState | null = null;
@@ -1663,6 +1781,12 @@ export async function handleHeadlessCommand(
     );
     process.exit(1);
   }
+  if (environmentSelector && isBidirectionalMode) {
+    console.error(
+      "Error: --environment cannot be used with --input-format stream-json",
+    );
+    process.exit(1);
+  }
 
   const sessionStats = new SessionStats();
   const headlessPermissionMode = startupPermissionMode.mode;
@@ -1972,29 +2096,33 @@ ${SYSTEM_REMINDER_CLOSE}
     pushPart(systemReminder);
   }
 
-  const lastRunAt = (agent as { last_run_completion?: string })
-    .last_run_completion;
-  const { parts: sharedReminderParts } = await buildSharedReminderParts({
-    mode: isSubagent ? "subagent" : "headless-one-shot",
-    agent: {
-      id: agent.id,
-      name: agent.name,
-      description: agent.description,
-      lastRunAt: lastRunAt ?? null,
-      conversationId,
-    },
-    state: sharedReminderState,
-    systemInfoReminderEnabled,
-    workingDirectory: getCurrentWorkingDirectory(),
-    skillSources: resolvedSkillSources,
-    shellContext: detectShellContext(),
-  });
-  for (const part of sharedReminderParts) {
-    pushPart(part.text);
+  if (!environmentSelector) {
+    const lastRunAt = (agent as { last_run_completion?: string })
+      .last_run_completion;
+    const { parts: sharedReminderParts } = await buildSharedReminderParts({
+      mode: isSubagent ? "subagent" : "headless-one-shot",
+      agent: {
+        id: agent.id,
+        name: agent.name,
+        description: agent.description,
+        lastRunAt: lastRunAt ?? null,
+        conversationId,
+      },
+      state: sharedReminderState,
+      systemInfoReminderEnabled,
+      workingDirectory: getCurrentWorkingDirectory(),
+      skillSources: resolvedSkillSources,
+      shellContext: detectShellContext(),
+    });
+    for (const part of sharedReminderParts) {
+      pushPart(part.text);
+    }
   }
 
-  // Pre-load specific skills' full content (used by subagents with skills: field)
-  if (preLoadSkillsRaw) {
+  // Pre-load specific skills' full content (used by subagents with skills: field).
+  // Environment-routed turns run in the selected remote runtime, which injects
+  // its own local context and skills, so avoid prepending this process' context.
+  if (preLoadSkillsRaw && !environmentSelector) {
     const { readFile: readFileAsync } = await import("node:fs/promises");
     const { skillPathById } = await buildClientSkillsPayload({
       agentId: agent.id,
@@ -2035,6 +2163,79 @@ ${SYSTEM_REMINDER_CLOSE}
     "user",
     agent.llm_config?.model ?? "unknown",
   );
+
+  if (typeof environmentSelector === "string" && environmentSelector.trim()) {
+    const startedAtMs = Date.now();
+    const { connectionId, environment } =
+      await resolveEnvironmentConnectionId(environmentSelector);
+    await sendEnvironmentMessage(connectionId, {
+      agentId: agent.id,
+      conversationId,
+      messages: [
+        {
+          role: "user",
+          content: contentParts,
+          client_message_id: randomUUID(),
+          otid: randomUUID(),
+        },
+      ],
+    });
+
+    const resultText = await waitForEnvironmentAssistantMessage({
+      backend,
+      agentId: agent.id,
+      conversationId,
+      startedAtMs,
+    });
+    const stats = sessionStats.getSnapshot();
+
+    if (outputFormat === "json") {
+      await writeFinalHeadlessStdout(
+        `${JSON.stringify(
+          {
+            type: "result",
+            subtype: "success",
+            is_error: false,
+            duration_ms: Math.round(stats.totalWallMs),
+            duration_api_ms: Math.round(stats.totalApiMs),
+            num_turns: 1,
+            result: resultText,
+            agent_id: agent.id,
+            conversation_id: conversationId,
+            environment: {
+              selector: environmentSelector,
+              connection_id: connectionId,
+              device_id: environment.deviceId,
+              name: environment.connectionName,
+            },
+            usage: null,
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    } else if (outputFormat === "stream-json") {
+      const resultEvent: ResultMessage = {
+        type: "result",
+        subtype: "success",
+        session_id: sessionId,
+        duration_ms: Math.round(stats.totalWallMs),
+        duration_api_ms: Math.round(stats.totalApiMs),
+        num_turns: 1,
+        result: resultText,
+        agent_id: agent.id,
+        conversation_id: conversationId,
+        run_ids: [],
+        usage: null,
+        uuid: `result-${agent.id}-${Date.now()}`,
+      };
+      writeWireMessage(resultEvent);
+    } else {
+      await writeFinalHeadlessStdout(`${resultText}\n`);
+    }
+
+    await exitHeadless(0, "headless_environment_message_complete");
+  }
 
   // Start with the user message
   let currentInput: Array<MessageCreate | ApprovalCreate> = [

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -810,6 +810,17 @@ function isCloudEnvironmentSelector(
   return normalized === "cloud" || normalized === "cloud-sandbox";
 }
 
+function getEnvironmentRoutedMessagingUnsupportedReason(
+  environment: EnvironmentConnection,
+): string | null {
+  if (environment.metadata?.environmentMessageProtocol === "v2-input") {
+    return null;
+  }
+  return `Environment ${environment.connectionName} (${environment.deviceId}) is running Letta Code ${
+    environment.metadata?.lettaCodeVersion ?? "unknown"
+  } and does not advertise environment-routed headless messaging support. Update that runtime or omit --environment to use same-environment messaging.`;
+}
+
 export async function handleHeadlessCommand(
   parsedArgs: ParsedCliArgs,
   model?: string,
@@ -2228,6 +2239,64 @@ ${SYSTEM_REMINDER_CLOSE}
       connectionId,
       environment,
     });
+    const unsupportedReason =
+      getEnvironmentRoutedMessagingUnsupportedReason(environment);
+    if (unsupportedReason) {
+      if (outputFormat === "json") {
+        await writeFinalHeadlessStdout(
+          `${JSON.stringify(
+            {
+              type: "result",
+              subtype: "error",
+              is_error: true,
+              duration_ms: Math.round(sessionStats.getSnapshot().totalWallMs),
+              duration_api_ms: Math.round(
+                sessionStats.getSnapshot().totalApiMs,
+              ),
+              num_turns: 0,
+              result: unsupportedReason,
+              agent_id: agent.id,
+              conversation_id: conversationId,
+              environment: responseEnvironment,
+              usage: null,
+              stop_reason: "error",
+            },
+            null,
+            2,
+          )}\n`,
+        );
+      } else if (outputFormat === "stream-json") {
+        const resultEvent: ResultMessage & {
+          environment: EnvironmentResponseMetadata;
+        } = {
+          type: "result",
+          subtype: "error",
+          session_id: sessionId,
+          duration_ms: Math.round(sessionStats.getSnapshot().totalWallMs),
+          duration_api_ms: Math.round(sessionStats.getSnapshot().totalApiMs),
+          num_turns: 0,
+          result: unsupportedReason,
+          agent_id: agent.id,
+          conversation_id: conversationId,
+          environment: responseEnvironment,
+          run_ids: [],
+          usage: null,
+          uuid: `result-${agent.id}-${Date.now()}`,
+          stop_reason: "error",
+        };
+        writeWireMessage(resultEvent);
+      } else {
+        console.error(`Error: ${unsupportedReason}`);
+        await writeFinalHeadlessStdout(
+          `${formatAgentReplyMetadata({
+            agentId: agent.id,
+            conversationId,
+            environment: responseEnvironment,
+          })}\n`,
+        );
+      }
+      await exitHeadless(1, "headless_environment_unsupported");
+    }
     await sendEnvironmentMessage(connectionId, {
       agentId: agent.id,
       conversationId,

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -765,21 +765,28 @@ async function waitForEnvironmentAssistantMessage(params: {
   throw new Error("Timed out waiting for environment response");
 }
 
-type EnvironmentResponseMetadata = {
-  source: "explicit" | "cloud-sandbox";
-  input: string;
-  id: string;
-  connection_id: string;
-  device_id: string;
-  name: string;
-};
+type ReplyEnvironmentMetadata =
+  | {
+      source: "same-environment";
+    }
+  | {
+      source: "explicit" | "cloud-sandbox";
+      input: string;
+      id: string;
+      connection_id: string;
+      device_id: string;
+      name: string;
+    };
 
 function buildEnvironmentResponseMetadata(params: {
-  source: EnvironmentResponseMetadata["source"];
+  source: Extract<
+    ReplyEnvironmentMetadata,
+    { source: "explicit" | "cloud-sandbox" }
+  >["source"];
   input: string;
   connectionId: string;
   environment: EnvironmentConnection;
-}): EnvironmentResponseMetadata {
+}): ReplyEnvironmentMetadata {
   return {
     source: params.source,
     input: params.input,
@@ -793,12 +800,12 @@ function buildEnvironmentResponseMetadata(params: {
 function formatAgentReplyMetadata(params: {
   agentId: string;
   conversationId: string;
-  environment: EnvironmentResponseMetadata;
+  environment?: ReplyEnvironmentMetadata;
 }): string {
   return JSON.stringify({
     agent_id: params.agentId,
     conversation_id: params.conversationId,
-    environment: params.environment,
+    ...(params.environment ? { environment: params.environment } : {}),
   });
 }
 
@@ -2267,7 +2274,7 @@ ${SYSTEM_REMINDER_CLOSE}
         );
       } else if (outputFormat === "stream-json") {
         const resultEvent: ResultMessage & {
-          environment: EnvironmentResponseMetadata;
+          environment: ReplyEnvironmentMetadata;
         } = {
           type: "result",
           subtype: "error",
@@ -2340,7 +2347,7 @@ ${SYSTEM_REMINDER_CLOSE}
       );
     } else if (outputFormat === "stream-json") {
       const resultEvent: ResultMessage & {
-        environment: EnvironmentResponseMetadata;
+        environment: ReplyEnvironmentMetadata;
       } = {
         type: "result",
         subtype: "success",
@@ -3475,6 +3482,9 @@ ${SYSTEM_REMINDER_CLOSE}
       result: resultText,
       agent_id: agent.id,
       conversation_id: conversationId,
+      ...(fromAgentId
+        ? { environment: { source: "same-environment" as const } }
+        : {}),
       usage,
     };
     await writeFinalHeadlessStdout(`${JSON.stringify(output, null, 2)}\n`);
@@ -3495,7 +3505,9 @@ ${SYSTEM_REMINDER_CLOSE}
       allRunIds.size > 0
         ? `result-${Array.from(allRunIds).pop()}`
         : `result-${agent.id}`;
-    const resultEvent: ResultMessage = {
+    const resultEvent: ResultMessage & {
+      environment?: ReplyEnvironmentMetadata;
+    } = {
       type: "result",
       subtype: "success",
       session_id: sessionId,
@@ -3505,6 +3517,9 @@ ${SYSTEM_REMINDER_CLOSE}
       result: resultText,
       agent_id: agent.id,
       conversation_id: conversationId,
+      ...(fromAgentId
+        ? { environment: { source: "same-environment" as const } }
+        : {}),
       run_ids: Array.from(allRunIds),
       usage,
       uuid: resultUuid,
@@ -3516,7 +3531,17 @@ ${SYSTEM_REMINDER_CLOSE}
       console.error("No assistant response found");
       await exitHeadless(1, "headless_missing_result_text");
     }
-    await writeFinalHeadlessStdout(`${resultText}\n`);
+    if (fromAgentId) {
+      await writeFinalHeadlessStdout(
+        `${resultText}\n\n${formatAgentReplyMetadata({
+          agentId: agent.id,
+          conversationId,
+          environment: { source: "same-environment" },
+        })}\n`,
+      );
+    } else {
+      await writeFinalHeadlessStdout(`${resultText}\n`);
+    }
   }
 
   // Report all milestones at the end for latency audit

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,6 +199,7 @@ SUBCOMMANDS
   letta memory tokens [--memory-dir <path>] [--agent <id>] [--format text|json]
   letta agents list [--query <text> | --name <name> | --tags <tags>]
   letta environments list [--online-only]
+  letta environments current
   letta messages search --query <text> [--all-agents]
   letta messages list [--agent <id>]
   letta messages transcript --conversation <id> [--out <path>]

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,6 +174,7 @@ USAGE
   letta --upgrade       Alias for \`letta update\`
   letta memory ...      Memory filesystem subcommands
   letta agents ...      Agents subcommands (JSON-only)
+  letta environments ... List available remote environments (JSON-only)
   letta messages ...    Messages subcommands (JSON-only)
   letta mods ...        List and manage local mods
   letta app-server ...  Run local app-server websocket transport
@@ -197,6 +198,7 @@ SUBCOMMANDS
   letta memory pull --agent <id>
   letta memory tokens [--memory-dir <path>] [--agent <id>] [--format text|json]
   letta agents list [--query <text> | --name <name> | --tags <tags>]
+  letta environments list [--online-only]
   letta messages search --query <text> [--all-agents]
   letta messages list [--agent <id>]
   letta messages transcript --conversation <id> [--out <path>]

--- a/src/skills/builtin/messaging-agents/SKILL.md
+++ b/src/skills/builtin/messaging-agents/SKILL.md
@@ -158,9 +158,9 @@ letta -p --from-agent $LETTA_AGENT_ID \
 
 - Scripts return only the **final assistant message** (not tool calls or reasoning)
 - Text-mode agent-to-agent responses append a JSON metadata line with
-  `agent_id`, `conversation_id`, and `environment` (`id`, `connection_id`,
-  `device_id`, `name`) for environment-routed turns so you can continue the same
-  conversation/runtime
+  `agent_id`, `conversation_id`, and `environment.source` so you can continue
+  the same conversation/runtime. Environment-routed turns also include
+  `environment.id`, `connection_id`, `device_id`, and `name`.
 - The target agent may use tools, think, and reason - but you only see their final response
 - To see the full conversation transcript (including tool calls), use the `searching-messages` skill with `letta messages list --agent <id>` targeting the other agent
 

--- a/src/skills/builtin/messaging-agents/SKILL.md
+++ b/src/skills/builtin/messaging-agents/SKILL.md
@@ -66,6 +66,10 @@ Results include `agent_id` for each matching message.
 letta -p --from-agent $LETTA_AGENT_ID --agent <id> "message text"
 ```
 
+When no `--environment` is specified, agent-to-agent headless messaging starts
+or reuses the target agent's cloud sandbox and routes the turn there. Use
+`--environment` only when you need a specific local/remote runtime instead.
+
 To route the target agent turn through a specific remote/local environment:
 
 ```bash

--- a/src/skills/builtin/messaging-agents/SKILL.md
+++ b/src/skills/builtin/messaging-agents/SKILL.md
@@ -156,6 +156,9 @@ letta -p --from-agent $LETTA_AGENT_ID \
 ## Understanding the Response
 
 - Scripts return only the **final assistant message** (not tool calls or reasoning)
+- Text-mode agent-to-agent responses append a JSON metadata line with
+  `agent_id`, `conversation_id`, and `environment` (`id`, `connection_id`,
+  `device_id`, `name`) so you can continue the same conversation/runtime
 - The target agent may use tools, think, and reason - but you only see their final response
 - To see the full conversation transcript (including tool calls), use the `searching-messages` skill with `letta messages list --agent <id>` targeting the other agent
 

--- a/src/skills/builtin/messaging-agents/SKILL.md
+++ b/src/skills/builtin/messaging-agents/SKILL.md
@@ -154,11 +154,8 @@ letta -p --from-agent $LETTA_AGENT_ID \
 
 ## Understanding the Response
 
-- Scripts return only the **final assistant message** (not tool calls or reasoning)
-- Text-mode agent-to-agent responses append a JSON metadata line with
-  `agent_id`, `conversation_id`, and `environment.source` so you can continue
-  the same conversation/runtime. Environment-routed turns also include
-  `environment.id`, `connection_id`, `device_id`, and `name`.
+- Text-mode scripts return only the **final assistant message** (not tool calls, reasoning, or metadata)
+- JSON and stream-json responses include `agent_id`, `conversation_id`, and `environment.source` so you can continue the same conversation/runtime. Environment-routed turns also include `environment.id`, `connection_id`, `device_id`, and `name`.
 - The target agent may use tools, think, and reason - but you only see their final response
 - To see the full conversation transcript (including tool calls), use the `searching-messages` skill with `letta messages list --agent <id>` targeting the other agent
 

--- a/src/skills/builtin/messaging-agents/SKILL.md
+++ b/src/skills/builtin/messaging-agents/SKILL.md
@@ -66,16 +66,16 @@ Results include `agent_id` for each matching message.
 letta -p --from-agent $LETTA_AGENT_ID --agent <id> "message text"
 ```
 
-When no `--environment` is specified, agent-to-agent headless messaging starts
-or reuses the target agent's cloud sandbox and routes the turn there. Use
-`--environment` only when you need a specific local/remote runtime instead.
+When no `--environment` is specified, agent-to-agent headless messaging keeps
+the original same-environment behavior. Use `--environment cloud` to start or
+reuse the target agent's cloud sandbox instead.
 
 To route the target agent turn through a specific remote/local environment:
 
 ```bash
 letta -p --from-agent $LETTA_AGENT_ID \
   --agent <id> \
-  --environment <name-or-device-id-or-connection-id> \
+  --environment <cloud-or-name-or-device-id-or-connection-id> \
   "message text"
 ```
 
@@ -84,7 +84,7 @@ letta -p --from-agent $LETTA_AGENT_ID \
 |-----|----------|-------------|
 | `--agent <id>` | Yes | Target agent ID to message |
 | `--from-agent <id>` | Yes | Sender agent ID (injects agent-to-agent system reminder) |
-| `--environment <selector>` | No | Route through an online environment by connection name, device ID, or connection ID |
+| `--environment <selector>` | No | Route through `cloud` sandbox or an online environment by connection name, device ID, or connection ID |
 | `"message text"` | Yes | Message body (positional after flags) |
 
 **Example:**
@@ -120,13 +120,14 @@ letta environments list --online-only
 letta envs list --online-only
 ```
 
-Use `connectionName`, `deviceId`, or `connectionId` from the JSON output as the
+Use `cloud` to run in the target agent's cloud sandbox, or use
+`connectionName`, `deviceId`, or `connectionId` from the JSON output as the
 `--environment` selector. If a name is ambiguous, prefer `deviceId` or
-`connectionId`. In `environments list`, the current local runtime is marked with
-`"isCurrent": true`.
+`connectionId`. In `environments list`, the current local runtime is marked
+with `"isCurrent": true`.
 
-To run the target agent on the same Letta Code environment as this process,
-first resolve the current environment and then pass its `connectionId`:
+To force the target agent onto the current registered Letta Code environment,
+resolve the current environment and pass its `connectionId`:
 
 ```bash
 CURRENT_ENV=$(letta environments current | jq -r .connectionId)
@@ -136,8 +137,8 @@ letta -p --from-agent $LETTA_AGENT_ID \
   "Run on my same machine/environment."
 ```
 
-Use this same-environment pattern whenever the target agent needs access to the
-same local filesystem, cwd, tools, or repository state.
+Omit `--environment` when you want the original same-environment behavior from
+the current caller process.
 
 **Arguments:**
 | Arg | Required | Description |
@@ -158,7 +159,8 @@ letta -p --from-agent $LETTA_AGENT_ID \
 - Scripts return only the **final assistant message** (not tool calls or reasoning)
 - Text-mode agent-to-agent responses append a JSON metadata line with
   `agent_id`, `conversation_id`, and `environment` (`id`, `connection_id`,
-  `device_id`, `name`) so you can continue the same conversation/runtime
+  `device_id`, `name`) for environment-routed turns so you can continue the same
+  conversation/runtime
 - The target agent may use tools, think, and reason - but you only see their final response
 - To see the full conversation transcript (including tool calls), use the `searching-messages` skill with `letta messages list --agent <id>` targeting the other agent
 

--- a/src/skills/builtin/messaging-agents/SKILL.md
+++ b/src/skills/builtin/messaging-agents/SKILL.md
@@ -66,16 +66,15 @@ Results include `agent_id` for each matching message.
 letta -p --from-agent $LETTA_AGENT_ID --agent <id> "message text"
 ```
 
-When no `--environment` is specified, agent-to-agent headless messaging keeps
-the original same-environment behavior. Use `--environment cloud` to start or
-reuse the target agent's cloud sandbox instead.
+When no `--environment` is specified, the target agent will run in the same
+environment as the caller agent.
 
 To route the target agent turn through a specific remote/local environment:
 
 ```bash
 letta -p --from-agent $LETTA_AGENT_ID \
   --agent <id> \
-  --environment <cloud-or-name-or-device-id-or-connection-id> \
+  --environment <name-or-device-id-or-connection-id> \
   "message text"
 ```
 
@@ -84,7 +83,7 @@ letta -p --from-agent $LETTA_AGENT_ID \
 |-----|----------|-------------|
 | `--agent <id>` | Yes | Target agent ID to message |
 | `--from-agent <id>` | Yes | Sender agent ID (injects agent-to-agent system reminder) |
-| `--environment <selector>` | No | Route through `cloud` sandbox or an online environment by connection name, device ID, or connection ID |
+| `--environment <selector>` | No | Route through an online environment by connection name, device ID, or connection ID |
 | `"message text"` | Yes | Message body (positional after flags) |
 
 **Example:**
@@ -120,11 +119,10 @@ letta environments list --online-only
 letta envs list --online-only
 ```
 
-Use `cloud` to run in the target agent's cloud sandbox, or use
-`connectionName`, `deviceId`, or `connectionId` from the JSON output as the
+Use `connectionName`, `deviceId`, or `connectionId` from the JSON output as the
 `--environment` selector. If a name is ambiguous, prefer `deviceId` or
-`connectionId`. In `environments list`, the current local runtime is marked
-with `"isCurrent": true`.
+`connectionId`. In `environments list`, the current local runtime is marked with
+`"isCurrent": true`.
 
 To force the target agent onto the current registered Letta Code environment,
 resolve the current environment and pass its `connectionId`:
@@ -137,8 +135,8 @@ letta -p --from-agent $LETTA_AGENT_ID \
   "Run on my same machine/environment."
 ```
 
-Omit `--environment` when you want the original same-environment behavior from
-the current caller process.
+Omit `--environment` when you want the target agent to run in the same
+environment as the caller agent.
 
 **Arguments:**
 | Arg | Required | Description |

--- a/src/skills/builtin/messaging-agents/SKILL.md
+++ b/src/skills/builtin/messaging-agents/SKILL.md
@@ -124,6 +124,20 @@ Use `connectionName`, `deviceId`, or `connectionId` from the JSON output as the
 `--environment` selector. If a name is ambiguous, prefer `deviceId` or
 `connectionId`.
 
+To run the target agent on the same Letta Code environment as this process,
+first resolve the current environment and then pass its `connectionId`:
+
+```bash
+CURRENT_ENV=$(letta environments current | jq -r .connectionId)
+letta -p --from-agent $LETTA_AGENT_ID \
+  --agent agent-abc123 \
+  --environment "$CURRENT_ENV" \
+  "Run on my same machine/environment."
+```
+
+Use this same-environment pattern whenever the target agent needs access to the
+same local filesystem, cwd, tools, or repository state.
+
 **Arguments:**
 | Arg | Required | Description |
 |-----|----------|-------------|

--- a/src/skills/builtin/messaging-agents/SKILL.md
+++ b/src/skills/builtin/messaging-agents/SKILL.md
@@ -66,11 +66,21 @@ Results include `agent_id` for each matching message.
 letta -p --from-agent $LETTA_AGENT_ID --agent <id> "message text"
 ```
 
+To route the target agent turn through a specific remote/local environment:
+
+```bash
+letta -p --from-agent $LETTA_AGENT_ID \
+  --agent <id> \
+  --environment <name-or-device-id-or-connection-id> \
+  "message text"
+```
+
 **Arguments:**
 | Arg | Required | Description |
 |-----|----------|-------------|
 | `--agent <id>` | Yes | Target agent ID to message |
 | `--from-agent <id>` | Yes | Sender agent ID (injects agent-to-agent system reminder) |
+| `--environment <selector>` | No | Route through an online environment by connection name, device ID, or connection ID |
 | `"message text"` | Yes | Message body (positional after flags) |
 
 **Example:**
@@ -95,6 +105,20 @@ letta -p --from-agent $LETTA_AGENT_ID \
 ```bash
 letta -p --from-agent $LETTA_AGENT_ID --conversation <id> "message text"
 ```
+
+Add `--environment <selector>` to continue the conversation on a specific environment.
+
+### Discovering Environments
+
+```bash
+letta environments list --online-only
+# alias:
+letta envs list --online-only
+```
+
+Use `connectionName`, `deviceId`, or `connectionId` from the JSON output as the
+`--environment` selector. If a name is ambiguous, prefer `deviceId` or
+`connectionId`.
 
 **Arguments:**
 | Arg | Required | Description |

--- a/src/skills/builtin/messaging-agents/SKILL.md
+++ b/src/skills/builtin/messaging-agents/SKILL.md
@@ -122,7 +122,8 @@ letta envs list --online-only
 
 Use `connectionName`, `deviceId`, or `connectionId` from the JSON output as the
 `--environment` selector. If a name is ambiguous, prefer `deviceId` or
-`connectionId`.
+`connectionId`. In `environments list`, the current local runtime is marked with
+`"isCurrent": true`.
 
 To run the target agent on the same Letta Code environment as this process,
 first resolve the current environment and then pass its `connectionId`:

--- a/src/websocket/listen-register.ts
+++ b/src/websocket/listen-register.ts
@@ -128,6 +128,7 @@ export async function registerWithCloud(
         lettaCodeVersion: getVersion(),
         os: process.platform,
         nodeVersion: process.version,
+        environmentMessageProtocol: "v2-input",
         supported_commands: SUPPORTED_REMOTE_COMMANDS,
         self_update: getSelfUpdateStatus(),
       },

--- a/src/websocket/listener/protocol-ergonomics.test.ts
+++ b/src/websocket/listener/protocol-ergonomics.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import type WebSocket from "ws";
 import { __listenClientTestUtils } from "@/websocket/listen-client";
 import { createListenerMessageHandler } from "@/websocket/listener/message-router";
+import { parseServerMessage } from "@/websocket/listener/protocol-inbound";
 import type {
   IncomingMessage,
   ListenerRuntime,
@@ -54,6 +55,44 @@ function makeHandler(
 describe("listener protocol ergonomics", () => {
   afterEach(() => {
     __listenClientTestUtils.setActiveRuntime(null);
+  });
+
+  test("parses legacy environment messages as runtime-scoped input", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "message",
+          agentId: "agent-1",
+          conversationId: "conv-1",
+          messages: [
+            {
+              type: "message",
+              role: "user",
+              content: "hello from cloud-api environment router",
+              client_message_id: "cm-1",
+            },
+          ],
+        }),
+      ),
+    );
+
+    expect(parsed).toEqual({
+      type: "input",
+      runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+      payload: {
+        kind: "create_message",
+        messages: [
+          {
+            type: "message",
+            role: "user",
+            content: "hello from cloud-api environment router",
+            client_message_id: "cm-1",
+          },
+        ],
+        client_tool_allowlist: undefined,
+        external_tool_scope_ids: undefined,
+      },
+    });
   });
 
   test("sync sends an ack response when request_id is provided", async () => {

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -63,6 +63,7 @@ import type {
   GetTreeCommand,
   GrepInFilesCommand,
   InputCommand,
+  InputCreateMessagePayload,
   ListConnectProvidersCommand,
   ListInDirectoryCommand,
   ListMemoryCommand,
@@ -185,6 +186,54 @@ function isInputCommand(value: unknown): value is InputCommand {
     return isValidApprovalResponseBody(payload);
   }
   return false;
+}
+
+function legacyEnvironmentMessageToInputCommand(
+  value: unknown,
+): InputCommand | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const candidate = value as {
+    type?: unknown;
+    agentId?: unknown;
+    conversationId?: unknown;
+    conversation_id?: unknown;
+    messages?: unknown;
+    clientToolAllowlist?: unknown;
+    externalToolScopeIds?: unknown;
+  };
+  if (
+    candidate.type !== "message" ||
+    typeof candidate.agentId !== "string" ||
+    candidate.agentId.length === 0 ||
+    !Array.isArray(candidate.messages)
+  ) {
+    return null;
+  }
+  const conversationId =
+    typeof candidate.conversationId === "string"
+      ? candidate.conversationId
+      : typeof candidate.conversation_id === "string"
+        ? candidate.conversation_id
+        : "default";
+  return {
+    type: "input",
+    runtime: {
+      agent_id: candidate.agentId,
+      conversation_id: conversationId,
+    },
+    payload: {
+      kind: "create_message",
+      messages: candidate.messages as InputCreateMessagePayload["messages"],
+      client_tool_allowlist: isStringArray(candidate.clientToolAllowlist)
+        ? candidate.clientToolAllowlist
+        : undefined,
+      external_tool_scope_ids: isStringArray(candidate.externalToolScopeIds)
+        ? candidate.externalToolScopeIds
+        : undefined,
+    },
+  };
 }
 
 function getInvalidInputReason(value: unknown): {
@@ -2111,6 +2160,10 @@ export function parseServerMessage(
   try {
     const raw = typeof data === "string" ? data : data.toString();
     const parsed = JSON.parse(raw) as unknown;
+    const legacyInput = legacyEnvironmentMessageToInputCommand(parsed);
+    if (legacyInput) {
+      return legacyInput;
+    }
     if (
       isInputCommand(parsed) ||
       isChangeDeviceStateCommand(parsed) ||


### PR DESCRIPTION
## Summary

This PR adds environment-aware headless agent messaging and discovery tools.

### Environment discovery
- Adds `letta environments list` / `letta envs list` to print JSON for discoverable runtime connections.
```sh
letta envs list --online-only                                                                                                           ─╯
{
  "connections": [
    {
      "deviceId": "d579cd26-e816-47bf-ba83-cd13a95a6947",
      "connectionName": "kian-devm",
      "connectionId": "conn-8bac9587-6605-4e6f-b372-abe297097c21",
      "lettaCodeVersion": "0.27.18"
    },
    {
      "deviceId": "27531d4b-c974-4898-ad47-31cf18a27275",
      "connectionName": "Developers",
      "connectionId": "conn-f1433eed-0f4e-46f3-98a5-d9a41aa392bd",
      "lettaCodeVersion": "0.27.23"
    }
  ],
  "hasNextPage": false
}
```
- Adds `letta environments current` / `letta envs current` to resolve this machine's active registered environment.

### Headless routing
- Adds `--environment` / `--env` to headless mode.
- `--environment <name|device-id|connection-id>` routes the turn through a specific registered environment via `/v1/environments/{connectionId}/messages`.
- `--environment cloud` / `--env cloud` starts or reuses the target agent's cloud sandbox via `POST /v1/agents/{agentId}/sandboxes`, waits for its environment connection, then routes there.
- Omitting `--environment` preserves the original same-environment behavior.
- Environment-routed turns skip injecting the caller process' local cwd/reminder/skill preloads, because the selected runtime injects its own local context.

### Reply/continuation metadata
- JSON and stream-json results include `agent_id`, `conversation_id`, and `environment` routing metadata.
- Text-mode agent-to-agent results append a JSON metadata line so the caller has the handles needed to continue the same conversation/runtime.
- Same-environment results report `environment.source: "same-environment"`; environment-routed results include `source`, `input`, `id`, `connection_id`, `device_id`, and `name`.

### Listener compatibility / safety
- Listeners now accept the existing cloud environment router payload shape (`{ type: "message", agentId, conversationId, messages }`) by normalizing it into v2 `input.kind=create_message`.
- Registered listeners advertise `metadata.environmentMessageProtocol = "v2-input"`.
- Headless environment routing fails fast with a structured error if the selected runtime does not advertise support, avoiding hangs against older cloud sandbox images.

### Documentation
- Updates README remote-environment examples.
- Updates the bundled `messaging-agents` skill with same-environment, explicit-environment, and cloud-sandbox usage patterns.

## Validation

- `bun run typecheck`
- `bun test ./src/websocket/listener/protocol-ergonomics.*.ts ./src/cli/subcommands/router.*.ts`
- `bun run check`

## Manual checks

- Verified no-`--environment` agent-to-agent messaging continues to run in the caller's current environment and returns `environment.source: "same-environment"` in JSON.
- Verified `--environment cloud` creates/starts Mike's sandbox and now exits with a structured unsupported-runtime error instead of hanging while the deployed sandbox image is still on Letta Code `0.27.19`.
