### PR TITLE
fix(cli): honor non-retryable LLM metadata

### DIFF
--- a/src/agent/approval-recovery.ts
+++ b/src/agent/approval-recovery.ts
@@ -43,6 +43,7 @@ export {
   refreshInputOtidsForNewRequest,
   STALE_APPROVAL_RECOVERY_DENIAL_REASON,
   shouldAttemptApprovalRecovery,
+  shouldRetryPostStreamRunError,
   shouldRetryPreStreamTransientError,
   shouldRetryRunMetadataError,
 } from "./turn-recovery-policy";

--- a/src/agent/turn-recovery-policy.test.ts
+++ b/src/agent/turn-recovery-policy.test.ts
@@ -17,6 +17,7 @@ import {
   rebuildInputWithFreshDenials,
   refreshInputOtidsForNewRequest,
   shouldAttemptApprovalRecovery,
+  shouldRetryPostStreamRunError,
   shouldRetryPreStreamTransientError,
   shouldRetryRunMetadataError,
 } from "@/agent/turn-recovery-policy";
@@ -238,6 +239,11 @@ describe("provider detail retry helpers", () => {
     expect(
       isNonRetryableProviderErrorDetail("OpenAI API error: invalid API key"),
     ).toBe(true);
+    expect(
+      isNonRetryableProviderErrorDetail(
+        "Z.ai Chat Completions API stream failed (401): Authentication Failed",
+      ),
+    ).toBe(true);
     expect(isNonRetryableProviderErrorDetail("Error code: 401")).toBe(true);
   });
 
@@ -266,6 +272,24 @@ describe("provider detail retry helpers", () => {
         "You've reached your hosted model usage limit.",
       ),
     ).toBe(false);
+  });
+
+  test("post-stream llm_api_error honors explicit non-retryable metadata", () => {
+    expect(
+      shouldRetryPostStreamRunError({
+        stopReason: "llm_api_error",
+        errorType: "llm_authentication",
+        detail:
+          "Z.ai Chat Completions API stream failed (401): Authentication Failed",
+        retryable: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRetryPostStreamRunError({
+        stopReason: "llm_api_error",
+        detail: "unclassified provider transport failure",
+      }),
+    ).toBe(true);
   });
 
   test("OpenRouter streaming incomplete chunked reads are retryable", () => {

--- a/src/agent/turn-recovery-policy.ts
+++ b/src/agent/turn-recovery-policy.ts
@@ -67,6 +67,7 @@ const NON_RETRYABLE_PROVIDER_DETAIL_PATTERNS = [
   "invalid api key",
   "incorrect api key",
   "authentication error",
+  "authentication failed",
   "unauthorized",
   "permission denied",
   "forbidden",
@@ -75,6 +76,14 @@ const NON_RETRYABLE_PROVIDER_DETAIL_PATTERNS = [
   "model_not_found",
   "context_length_exceeded",
   "invalid_encrypted_content",
+];
+const NON_RETRYABLE_RUN_ERROR_TYPES = [
+  "llm_authentication",
+  "llm_bad_request",
+  "llm_insufficient_credits",
+  "llm_permission_denied",
+  "llm_not_found",
+  "llm_unprocessable_entity",
 ];
 const NON_RETRYABLE_429_REASONS = [
   "agents-limit-exceeded",
@@ -118,6 +127,13 @@ function hasNonRetryableQuotaDetail(detail: unknown): boolean {
     NON_RETRYABLE_QUOTA_DETAIL_PATTERNS.some((pattern) =>
       normalized.includes(pattern),
     )
+  );
+}
+
+function isNonRetryableRunErrorType(errorType: unknown): boolean {
+  return (
+    typeof errorType === "string" &&
+    NON_RETRYABLE_RUN_ERROR_TYPES.includes(errorType)
   );
 }
 
@@ -189,16 +205,37 @@ export function shouldRetryRunMetadataError(
   detail: unknown,
 ): boolean {
   const explicitLlmError = errorType === "llm_error";
+  const nonRetryableErrorType = isNonRetryableRunErrorType(errorType);
   const nonRetryableQuotaDetail = hasNonRetryableQuotaDetail(detail);
   const retryable429Detail =
     typeof detail === "string" && RETRYABLE_429_PATTERN.test(detail);
   const retryableDetail = isRetryableProviderErrorDetail(detail);
   const nonRetryableDetail = isNonRetryableProviderErrorDetail(detail);
 
+  if (nonRetryableErrorType) return false;
   if (nonRetryableQuotaDetail) return false;
   if (nonRetryableDetail && !retryable429Detail) return false;
   if (explicitLlmError) return true;
   return retryable429Detail || retryableDetail;
+}
+
+export function shouldRetryPostStreamRunError(opts: {
+  stopReason: StopReasonType;
+  errorType?: unknown;
+  detail?: unknown;
+  retryable?: boolean;
+}): boolean {
+  if (opts.retryable === false) return false;
+  if (opts.retryable === true) return true;
+  if (shouldRetryRunMetadataError(opts.errorType, opts.detail)) return true;
+  if (opts.stopReason !== "llm_api_error") return false;
+  if (isNonRetryableRunErrorType(opts.errorType)) return false;
+  if (hasNonRetryableQuotaDetail(opts.detail)) return false;
+  if (isNonRetryableProviderErrorDetail(opts.detail)) return false;
+
+  // The backend uses llm_api_error for provider failures. If it did not attach
+  // a recognized non-retryable signal, preserve the legacy transient retry.
+  return true;
 }
 
 export function normalizeStreamErrorTypeToStopReason(

--- a/src/cli/app/retry.ts
+++ b/src/cli/app/retry.ts
@@ -1,5 +1,5 @@
 import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs";
-import { shouldRetryRunMetadataError } from "@/agent/approval-recovery";
+import { shouldRetryPostStreamRunError } from "@/agent/approval-recovery";
 import { getBackend } from "@/backend";
 
 // Check if error is retriable based on stop reason and run metadata
@@ -8,9 +8,6 @@ export async function isRetriableError(
   lastRunId: string | null | undefined,
   fallbackDetail?: string | null,
 ): Promise<boolean> {
-  // Primary check: backend sets stop_reason=llm_api_error for LLMError exceptions
-  if (stopReason === "llm_api_error") return true;
-
   // Early exit for stop reasons that should never be retried
   const nonRetriableReasons: StopReasonType[] = [
     "cancelled",
@@ -26,7 +23,9 @@ export async function isRetriableError(
 
   // Fallback check: for error-like stop_reasons, check metadata for retriable patterns
   // This handles cases where the backend sends a generic error stop_reason but the
-  // underlying cause is a transient LLM/network issue that should be retried
+  // underlying cause is a transient LLM/network issue that should be retried.
+  // llm_api_error is only retried by default after explicit non-retryable run
+  // metadata, such as auth failures, has had a chance to opt out.
   if (lastRunId) {
     try {
       const run = await getBackend().retrieveRun(lastRunId);
@@ -46,20 +45,21 @@ export async function isRetriableError(
 
       // Check for llm_error at top level or nested (handles error.error nesting)
       const errorType = metaError?.error_type ?? metaError?.error?.error_type;
-      const detail = metaError?.detail ?? metaError?.error?.detail ?? "";
+      const detail = metaError?.detail ?? metaError?.error?.detail;
       const retryable = metaError?.retryable ?? metaError?.error?.retryable;
 
-      if (retryable === false) return false;
-      if (retryable === true) return true;
-
-      if (shouldRetryRunMetadataError(errorType, detail)) {
-        return true;
-      }
-
-      return false;
+      return shouldRetryPostStreamRunError({
+        stopReason,
+        errorType,
+        detail,
+        retryable,
+      });
     } catch {
-      return shouldRetryRunMetadataError(undefined, fallbackDetail);
+      return shouldRetryPostStreamRunError({
+        stopReason,
+        detail: fallbackDetail,
+      });
     }
   }
-  return shouldRetryRunMetadataError(undefined, fallbackDetail);
+  return shouldRetryPostStreamRunError({ stopReason, detail: fallbackDetail });
 }

--- a/src/cli/retry.test.ts
+++ b/src/cli/retry.test.ts
@@ -54,4 +54,17 @@ describe("post-stream retry classification", () => {
       isRetriableError("error" as StopReasonType, "local-run-1"),
     ).resolves.toBe(false);
   });
+
+  test("does not retry llm_api_error when run metadata says auth is non-retryable", async () => {
+    setRunErrorMetadata({
+      error_type: "llm_authentication",
+      detail:
+        "Z.ai Chat Completions API stream failed (401): Authentication Failed",
+      retryable: false,
+    });
+
+    await expect(
+      isRetriableError("llm_api_error" as StopReasonType, "local-run-1"),
+    ).resolves.toBe(false);
+  });
 });

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -20,7 +20,7 @@ import {
   normalizeStreamErrorTypeToStopReason,
   STALE_APPROVAL_RECOVERY_DENIAL_REASON,
   shouldAttemptApprovalRecovery,
-  shouldRetryRunMetadataError,
+  shouldRetryPostStreamRunError,
 } from "@/agent/turn-recovery-policy";
 import { getBackend } from "@/backend";
 import { createBuffers } from "@/cli/helpers/accumulator";
@@ -123,10 +123,6 @@ export async function isRetriablePostStopError(
   lastRunId: string | null | undefined,
   fallbackDetail?: string | null,
 ): Promise<boolean> {
-  if (stopReason === "llm_api_error") {
-    return true;
-  }
-
   const nonRetriableReasons: StopReasonType[] = [
     "cancelled",
     "requires_approval",
@@ -142,7 +138,10 @@ export async function isRetriablePostStopError(
   }
 
   if (!lastRunId) {
-    return shouldRetryRunMetadataError(undefined, fallbackDetail);
+    return shouldRetryPostStreamRunError({
+      stopReason,
+      detail: fallbackDetail,
+    });
   }
 
   try {
@@ -161,17 +160,19 @@ export async function isRetriablePostStopError(
       | undefined;
 
     const errorType = metaError?.error_type ?? metaError?.error?.error_type;
-    const detail = metaError?.detail ?? metaError?.error?.detail ?? "";
+    const detail = metaError?.detail ?? metaError?.error?.detail;
     const retryable = metaError?.retryable ?? metaError?.error?.retryable;
-    if (retryable === false) {
-      return false;
-    }
-    if (retryable === true) {
-      return true;
-    }
-    return shouldRetryRunMetadataError(errorType, detail);
+    return shouldRetryPostStreamRunError({
+      stopReason,
+      errorType,
+      detail,
+      retryable,
+    });
   } catch {
-    return shouldRetryRunMetadataError(undefined, fallbackDetail);
+    return shouldRetryPostStreamRunError({
+      stopReason,
+      detail: fallbackDetail,
+    });
   }
 }
 

--- a/src/websocket/recovery.test.ts
+++ b/src/websocket/recovery.test.ts
@@ -62,4 +62,17 @@ describe("websocket post-stop retry fallback", () => {
       false,
     );
   });
+
+  test("does not retry llm_api_error when run metadata says auth is non-retryable", async () => {
+    setRunErrorMetadata({
+      error_type: "llm_authentication",
+      detail:
+        "Z.ai Chat Completions API stream failed (401): Authentication Failed",
+      retryable: false,
+    });
+
+    await expect(
+      isRetriablePostStopError("llm_api_error", "run-1"),
+    ).resolves.toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Honor retryable:false and non-retryable LLM error types before falling back to legacy llm_api_error retries.
- Share the post-stream retry policy between CLI and listener recovery.
- Classify Z.AI 401 Authentication Failed detail as non-retryable.

Internal tracking: LET-9456

## Test plan
- [x] bun test src/agent/turn-recovery-policy.test.ts src/cli/retry.test.ts src/websocket/recovery.test.ts
- [x] bun run check

👾 Generated with [Letta Code](https://letta.com)