### PR TITLE
fix(lsp): reject pending requests when the server process exits or stdout errors

### DIFF
--- a/src/lsp/client.test.ts
+++ b/src/lsp/client.test.ts
@@ -1,0 +1,119 @@
+import { expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import { LSPClient } from "@/lsp/client";
+
+/**
+ * Spawn a minimal "LSP server" process: it reads JSON-RPC messages from stdin
+ * (so the client's Content-Length framing works) but its behavior is controlled
+ * by the script. We use this instead of a mock so the real ChildProcess wiring
+ * and exit handling in LSPClient are exercised.
+ */
+function spawnScript(script: string) {
+  return spawn("bun", ["-e", script], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+test("pending request is rejected when the server process exits without responding", async () => {
+  // Server: read and discard stdin, then exit immediately on the first message.
+  const server = spawnScript(`
+    let buf = "";
+    process.stdin.on("data", (chunk) => {
+      buf += chunk.toString();
+      // Once we've received anything, exit without responding.
+      if (buf.includes("Content-Length:")) {
+        // Exit on next tick so the client's write flushes.
+        setImmediate(() => process.exit(0));
+      }
+    });
+  `);
+
+  const client = new LSPClient({
+    serverID: "test",
+    server: { process: server },
+    rootUri: process.cwd(),
+  });
+
+  // sendRequest is private, so reach it through the public surface. A bogus
+  // method is fine — what matters is that a request is pending when the
+  // process dies, and that it rejects instead of hanging forever.
+  const pending = (
+    client as unknown as {
+      sendRequest<T>(method: string, params?: unknown): Promise<T>;
+    }
+  ).sendRequest("some/pendingMethod", {});
+
+  // Before the fix, this promise would hang because the exit handler did not
+  // reject outstanding requests.
+  await expect(pending).rejects.toThrow(/LSP server exited/);
+
+  server.kill();
+});
+
+test("request sent after the server exited rejects immediately", async () => {
+  // Server that exits right away.
+  const server = spawnScript(`setImmediate(() => process.exit(0));`);
+
+  const client = new LSPClient({
+    serverID: "test",
+    server: { process: server },
+    rootUri: process.cwd(),
+  });
+
+  // Wait for the exit handler to mark the client as disposed.
+  await new Promise<void>((resolve) => {
+    client.on("exit", () => resolve());
+  });
+
+  const pending = (
+    client as unknown as {
+      sendRequest<T>(method: string, params?: unknown): Promise<T>;
+    }
+  ).sendRequest("anything", {});
+
+  // New requests against a dead server must fail fast rather than enqueue a
+  // promise that can never be settled.
+  await expect(pending).rejects.toThrow(/LSP server has exited/);
+});
+
+test("responded request resolves; only a later, unrelated exit rejects others", async () => {
+  // Server: respond to the first message, then exit on the second.
+  const server = spawnScript(`
+    let buf = "";
+    let handled = false;
+    process.stdin.on("data", (chunk) => {
+      buf += chunk.toString();
+      const match = buf.match(/Content-Length: (\\d+)/);
+      if (match && !handled) {
+        const body = '{"jsonrpc":"2.0","id":1,"result":{"ok":true}}';
+        process.stdout.write('Content-Length: ' + body.length + '\\r\\n\\r\\n' + body);
+        handled = true;
+        buf = "";
+      } else if (match && handled) {
+        setImmediate(() => process.exit(1));
+      }
+    });
+  `);
+
+  const client = new LSPClient({
+    serverID: "test",
+    server: { process: server },
+    rootUri: process.cwd(),
+  });
+
+  const sendRequest = (
+    client as unknown as {
+      sendRequest<T>(method: string, params?: unknown): Promise<T>;
+    }
+  ).sendRequest.bind(client);
+
+  const first = sendRequest<{ ok: boolean }>("first");
+  const firstResult = await first;
+  expect(firstResult.ok).toBe(true);
+
+  // Second request will still be pending when the server exits.
+  const second = sendRequest("second");
+  await expect(second).rejects.toThrow(/LSP server exited/);
+
+  server.kill();
+});

--- a/src/lsp/client.ts
+++ b/src/lsp/client.ts
@@ -38,6 +38,7 @@ export class LSPClient extends EventEmitter {
   >();
   private buffer = "";
   private initialized = false;
+  private disposed = false;
 
   constructor(options: LSPClientOptions) {
     super();
@@ -64,11 +65,34 @@ export class LSPClient extends EventEmitter {
 
     this.stdout.on("error", (err) => {
       this.emit("error", err);
+      // A broken stdout means no more responses will arrive — fail pending
+      // requests instead of leaving their promises pending forever.
+      this.rejectAllPending(
+        new Error(`LSP stdout stream error: ${err.message}`),
+      );
     });
 
     this.process.process.on("exit", (code) => {
+      this.disposed = true;
+      // The server process is gone, so in-flight requests will never get a
+      // response — reject them so callers (including shutdown()) don't hang.
+      this.rejectAllPending(
+        new Error(`LSP server exited (code ${code ?? "null"})`),
+      );
       this.emit("exit", code);
     });
+  }
+
+  /**
+   * Reject every outstanding request with the given error and clear the table.
+   * Safe to call multiple times — once the pending map is empty it's a no-op.
+   */
+  private rejectAllPending(error: Error): void {
+    if (this.pendingRequests.size === 0) return;
+    for (const [, pending] of this.pendingRequests) {
+      pending.reject(error);
+    }
+    this.pendingRequests.clear();
   }
 
   private processBuffer(): void {
@@ -131,6 +155,12 @@ export class LSPClient extends EventEmitter {
 
   private sendRequest<T>(method: string, params?: unknown): Promise<T> {
     return new Promise((resolve, reject) => {
+      // If the server is already gone, fail fast instead of enqueueing a
+      // request that can never be written or answered.
+      if (this.disposed) {
+        reject(new Error("LSP server has exited"));
+        return;
+      }
       const id = ++this.requestId;
       const request: JsonRpcRequest = {
         jsonrpc: "2.0",
@@ -158,6 +188,12 @@ export class LSPClient extends EventEmitter {
   }
 
   private sendMessage(message: JsonRpcRequest | JsonRpcNotification): void {
+    if (this.disposed) {
+      // Server process is gone — writing to its stdin would throw. Drop the
+      // message; any request waiting on a response was already rejected by
+      // the exit/error handler.
+      return;
+    }
     const content = JSON.stringify(message);
     const header = `Content-Length: ${content.length}\r\n\r\n`;
     this.stdin.write(header + content);


### PR DESCRIPTION
## Problem

`LSPClient` only settled pending requests when a JSON-RPC **response** arrived (`handleMessage`). The `'exit'` handler on the server process just emitted an event and did nothing with `pendingRequests`. So if the server process exited while requests were outstanding — a crash, or a normal `shutdown()` that races with another in-flight request — those promises were **left pending forever**:

- callers awaiting them (including `shutdown()` itself, which `await`s `sendRequest("shutdown")`) would hang;
- the `pendingRequests` map leaked.

There was also no `'error'` handling on stdout: a broken stream likewise meant no response would ever arrive, with the same hang.

## Fix

- Add a `rejectAllPending(error)` helper that rejects every outstanding request and clears the map (no-op once empty, so safe to call from multiple teardown paths).
- On server `'exit'`: mark the client `disposed`, then `rejectAllPending` with a descriptive error, then emit `'exit'`.
- On stdout `'error'`: `rejectAllPending` (no response can arrive via a broken stream) in addition to emitting `'error'`.
- `sendRequest` fails fast when already `disposed`, so new requests against a dead server reject immediately instead of enqueueing an unanswerable promise.
- `sendMessage` no-ops when `disposed`, to avoid writing to a dead stdin (which would throw `ERR_STREAM_WRITE_AFTER_END` / `EPIPE`).

Normal request/response flow is unchanged: a request that gets a response still resolves; only the "no response will ever come" paths now reject.

## Tests

New `src/lsp/client.test.ts` (no external language server required — spawns a tiny `bun -e` script that controls stdin/stdout and exit behavior):

- **pending request is rejected when the server exits without responding**: a request in-flight when the process dies rejects with `LSP server exited` (before the fix this hung).
- **request sent after the server exited rejects immediately**: subsequent `sendRequest` against a disposed client fails fast with `LSP server has exited`.
- **responded request still resolves; only a later unrelated exit rejects others**: a normal response resolves normally, then a second request pending at exit is rejected — proving the happy path is intact.

## Verification

- `bun test src/lsp/client.test.ts` — 3 pass (run with a timeout guard)
- `bun run typecheck` — clean
- `bun run check:boundaries`, `check:cycles`, `check:exported-functions`, `check:filename-casing` — clean
- biome — clean on changed files

## AI disclosure

Authored with AI assistance (Claude Code) and reviewed by a human before submission.