### PR TITLE
fix(local): inherit conversation context_window_limit from model_settings

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -1,9 +1,9 @@
 {
   "src/agent/client-skills.test.ts": 1196,
   "src/agent/memory-git.ts": 2129,
-  "src/backend/local-backend.test.ts": 2534,
+  "src/backend/local-backend.test.ts": 2618,
   "src/backend/local/local-backend.ts": 1058,
-  "src/backend/local/local-store.ts": 3613,
+  "src/backend/local/local-store.ts": 3615,
   "src/backend/pi-stream-adapter.test.ts": 1442,
   "src/cli/app/AppCoordinator.tsx": 5198,
   "src/cli/app/AppView.tsx": 1750,

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -252,6 +252,90 @@ describe("local backend pi transcript", () => {
     }
   });
 
+  test("new conversations inherit context_window_limit nested in model_settings", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-conversation-context-window-"),
+    );
+    try {
+      const backend = new LocalBackend({ storageDir, memfsEnabled: false });
+      const agent = await backend.createAgent({
+        name: "Local",
+        model: "anthropic/claude-sonnet-4-6",
+        model_settings: {
+          provider_type: "anthropic",
+          context_window_limit: 1000000,
+        },
+      } as never);
+
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+        model: "anthropic/claude-sonnet-4-6",
+        model_settings: {
+          provider_type: "anthropic",
+          context_window_limit: 1000000,
+          max_tokens: 131072,
+        },
+      } as never);
+
+      expect(
+        (conversation as unknown as { context_window_limit?: number })
+          .context_window_limit,
+      ).toBe(1000000);
+
+      const retrieved = (await backend.retrieveConversation(
+        conversation.id,
+      )) as unknown as { context_window_limit?: number };
+      expect(retrieved.context_window_limit).toBe(1000000);
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("top-level context_window_limit wins over the model_settings value", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-conversation-context-window-top-"),
+    );
+    try {
+      const backend = new LocalBackend({ storageDir, memfsEnabled: false });
+      const agent = await backend.createAgent({ name: "Local" } as never);
+
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+        context_window_limit: 200000,
+        model_settings: { context_window_limit: 1000000 },
+      } as never);
+
+      expect(
+        (conversation as unknown as { context_window_limit?: number })
+          .context_window_limit,
+      ).toBe(200000);
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("conversations without any context window limit leave the field unset", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-conversation-context-window-none-"),
+    );
+    try {
+      const backend = new LocalBackend({ storageDir, memfsEnabled: false });
+      const agent = await backend.createAgent({ name: "Local" } as never);
+
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+        model_settings: { provider_type: "anthropic" },
+      } as never);
+
+      expect(
+        (conversation as unknown as { context_window_limit?: number })
+          .context_window_limit,
+      ).toBeUndefined();
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
   test("refreshes conversation metadata changed by another local backend process", async () => {
     const storageDir = await mkdtemp(
       join(tmpdir(), "local-backend-external-conversation-update-"),

--- a/src/backend/local/local-model-normalization.ts
+++ b/src/backend/local/local-model-normalization.ts
@@ -97,6 +97,24 @@ export function supportedConversationModelSettingsFromBody(
   return Object.keys(next).length > 0 ? next : modelSettings;
 }
 
+export function conversationContextWindowLimitFromBody(
+  bodyRecord: Record<string, unknown>,
+): number | undefined {
+  if (typeof bodyRecord.context_window_limit === "number") {
+    return bodyRecord.context_window_limit;
+  }
+  // Conversation create requests often carry the limit only inside
+  // model_settings (the desktop draft flow sends it that way). Lift it to the
+  // top-level field so the stored record keeps the agent's configured window
+  // instead of falling back to the 128k default.
+  const modelSettings = isRecord(bodyRecord.model_settings)
+    ? bodyRecord.model_settings
+    : undefined;
+  return typeof modelSettings?.context_window_limit === "number"
+    ? modelSettings.context_window_limit
+    : undefined;
+}
+
 export function normalizeStoredLocalModelRecord<
   T extends { model?: string | null; model_settings?: unknown },
 >(record: T): T {

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -53,6 +53,7 @@ import {
   withProjectedMessageDates,
 } from "./local-message-projection";
 import {
+  conversationContextWindowLimitFromBody,
   localLlmConfigModelPatch,
   modelHandleFromLegacyLlmConfig,
   normalizeLocalModelHandle,
@@ -215,6 +216,7 @@ function createLocalConversationRecord(
   const bodyRecord = body as Record<string, unknown>;
   const now = currentIsoTimestamp();
   const modelSettings = supportedConversationModelSettingsFromBody(bodyRecord);
+  const contextWindowLimit = conversationContextWindowLimitFromBody(bodyRecord);
   return {
     id: conversationId,
     agent_id: agentId,
@@ -237,8 +239,8 @@ function createLocalConversationRecord(
         }
       : {}),
     ...(modelSettings !== undefined ? { model_settings: modelSettings } : {}),
-    ...(typeof bodyRecord.context_window_limit === "number"
-      ? { context_window_limit: bodyRecord.context_window_limit }
+    ...(contextWindowLimit !== undefined
+      ? { context_window_limit: contextWindowLimit }
       : {}),
     ...(typeof bodyRecord.hidden === "boolean"
       ? { hidden: bodyRecord.hidden }


### PR DESCRIPTION
## Summary
- New local-backend conversations dropped the agent's configured `context_window_limit`: the desktop draft flow (and other callers) send the limit nested inside `model_settings`, but `createLocalConversationRecord` only read the top-level `context_window_limit` field. The stored record ended up without a limit, so every new conversation fell back to the hardcoded 128000 default even when the agent was configured with a much larger window.
- Lift `model_settings.context_window_limit` to the conversation record's top-level field at creation when no explicit top-level value is provided. An explicit top-level value still wins, and conversations with no configured limit keep the field unset.

Fixes #3132.

## Test plan
- [x] `bun test src/backend/local-backend.test.ts` — adds a repro test (fails without the fix) plus guards for top-level precedence and the no-limit case
- [x] `bun run check`
- [x] Full unit suite — no new failures vs a clean `main` baseline on the same machine

## AI disclosure
Following the policy proposed in #3139: this PR was developed with AI assistance (Claude Code) — the investigation, patch, and tests were AI-assisted. I directed the work, reviewed the change, and ran the validation above locally; the repro test was mutation-checked (it fails with the fix reverted).

cc @cpacker — this sits right next to the record-normalization work in #3136, happy to adjust if you'd rather fold it in there.