### PR TITLE
fix(hooks): match tool hooks against the model-facing Agent name

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -29,11 +29,21 @@ export * from "./types";
 // ============================================================================
 
 /**
+ * Tool names may be passed as a list of aliases for the same tool call (e.g.
+ * the model-facing "Agent" name plus the internal "Task" name). All aliases
+ * participate in matcher resolution; the first alias is the canonical name
+ * reported to hook scripts via `tool_name`.
+ */
+function canonicalToolName(toolName: string | readonly string[]): string {
+  return typeof toolName === "string" ? toolName : (toolName[0] ?? "");
+}
+
+/**
  * Run PreToolUse hooks before a tool is executed
  * Can block the tool call by returning blocked: true
  */
 export async function runPreToolUseHooks(
-  toolName: string,
+  toolName: string | readonly string[],
   toolInput: Record<string, unknown>,
   toolCallId?: string,
   workingDirectory: string = process.cwd(),
@@ -51,7 +61,7 @@ export async function runPreToolUseHooks(
   const input: PreToolUseHookInput = {
     event_type: "PreToolUse",
     working_directory: workingDirectory,
-    tool_name: toolName,
+    tool_name: canonicalToolName(toolName),
     tool_input: toolInput,
     tool_call_id: toolCallId,
     agent_id: agentId,
@@ -66,7 +76,7 @@ export async function runPreToolUseHooks(
  * These run in parallel since they cannot block
  */
 export async function runPostToolUseHooks(
-  toolName: string,
+  toolName: string | readonly string[],
   toolInput: Record<string, unknown>,
   toolResult: { status: "success" | "error"; output?: string },
   toolCallId?: string,
@@ -87,7 +97,7 @@ export async function runPostToolUseHooks(
   const input: PostToolUseHookInput = {
     event_type: "PostToolUse",
     working_directory: workingDirectory,
-    tool_name: toolName,
+    tool_name: canonicalToolName(toolName),
     tool_input: toolInput,
     tool_call_id: toolCallId,
     tool_result: toolResult,
@@ -106,7 +116,7 @@ export async function runPostToolUseHooks(
  * Stderr from hooks with exit code 2 is fed back to the agent
  */
 export async function runPostToolUseFailureHooks(
-  toolName: string,
+  toolName: string | readonly string[],
   toolInput: Record<string, unknown>,
   errorMessage: string,
   errorType?: string,
@@ -128,7 +138,7 @@ export async function runPostToolUseFailureHooks(
   const input: PostToolUseFailureHookInput = {
     event_type: "PostToolUseFailure",
     working_directory: workingDirectory,
-    tool_name: toolName,
+    tool_name: canonicalToolName(toolName),
     tool_input: toolInput,
     tool_call_id: toolCallId,
     error_message: errorMessage,

--- a/src/hooks/integration.test.ts
+++ b/src/hooks/integration.test.ts
@@ -166,6 +166,52 @@ describe.skipIf(isWindows)("Hooks Integration Tests", () => {
       expect(result.errored).toBe(false);
       expect(result.results).toHaveLength(0);
     });
+
+    test("matches the model-facing Agent alias for internal Task tool calls", async () => {
+      createHooksConfig({
+        PreToolUse: [
+          {
+            matcher: "Agent",
+            hooks: [{ type: "command", command: "cat" }],
+          },
+        ],
+      });
+
+      const result = await runPreToolUseHooks(
+        ["Agent", "Task"],
+        { description: "spawn subagent" },
+        "tool-agent-1",
+        tempDir,
+      );
+
+      expect(result.blocked).toBe(false);
+      expect(result.results).toHaveLength(1);
+      const payload = JSON.parse(result.results[0]?.stdout ?? "{}") as {
+        tool_name?: string;
+      };
+      expect(payload.tool_name).toBe("Agent");
+    });
+
+    test("keeps matching legacy Task matchers for Agent tool calls", async () => {
+      createHooksConfig({
+        PreToolUse: [
+          {
+            matcher: "Task",
+            hooks: [{ type: "command", command: "echo 'task matcher fired'" }],
+          },
+        ],
+      });
+
+      const result = await runPreToolUseHooks(
+        ["Agent", "Task"],
+        {},
+        undefined,
+        tempDir,
+      );
+
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0]?.stdout).toBe("task matcher fired");
+    });
   });
 
   // ============================================================================

--- a/src/hooks/loader.test.ts
+++ b/src/hooks/loader.test.ts
@@ -307,6 +307,45 @@ describe("Hooks Loader", () => {
       expect(hooks).toHaveLength(1);
     });
 
+    test("matches any alias when tool names are passed as a list", () => {
+      const config: HooksConfig = {
+        PreToolUse: [
+          {
+            matcher: "Agent",
+            hooks: [{ type: "command", command: "agent hook" }],
+          },
+          {
+            matcher: "Task",
+            hooks: [{ type: "command", command: "task hook" }],
+          },
+          {
+            matcher: "Bash",
+            hooks: [{ type: "command", command: "bash hook" }],
+          },
+        ],
+      };
+
+      const hooks = getMatchingHooks(config, "PreToolUse", ["Agent", "Task"]);
+      expect(hooks).toHaveLength(2);
+      expect(asCommand(hooks[0])?.command).toBe("agent hook");
+      expect(asCommand(hooks[1])?.command).toBe("task hook");
+    });
+
+    test("does not duplicate hooks when a matcher matches several aliases", () => {
+      const config: HooksConfig = {
+        PreToolUse: [
+          {
+            matcher: "Agent|Task",
+            hooks: [{ type: "command", command: "either hook" }],
+          },
+        ],
+      };
+
+      const hooks = getMatchingHooks(config, "PreToolUse", ["Agent", "Task"]);
+      expect(hooks).toHaveLength(1);
+      expect(asCommand(hooks[0])?.command).toBe("either hook");
+    });
+
     test("returns hooks from multiple matchers in order", () => {
       const config: HooksConfig = {
         PreToolUse: [

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -234,11 +234,15 @@ function filterHooksForEvent(
 
 /**
  * Get all hooks that match a specific event and tool name
+ *
+ * `toolName` may be a list of aliases for the same tool call (e.g. the
+ * model-facing "Agent" name plus the internal "Task" name); a matcher fires
+ * when it matches any alias.
  */
 export function getMatchingHooks(
   config: HooksConfig,
   event: HookEvent,
-  toolName?: string,
+  toolName?: string | readonly string[],
 ): HookCommand[] {
   if (isToolEvent(event)) {
     // Tool events use HookMatcher[] - need to match against tool name
@@ -249,9 +253,14 @@ export function getMatchingHooks(
       return [];
     }
 
+    const toolNames =
+      typeof toolName === "string" ? [toolName] : (toolName ?? []);
     const hooks: HookCommand[] = [];
     for (const matcher of matchers) {
-      if (!toolName || matchesTool(matcher.matcher, toolName)) {
+      if (
+        toolNames.length === 0 ||
+        toolNames.some((name) => matchesTool(matcher.matcher, name))
+      ) {
         hooks.push(...matcher.hooks);
       }
     }
@@ -373,7 +382,7 @@ export function areHooksDisabled(
  */
 export async function getHooksForEvent(
   event: HookEvent,
-  toolName?: string,
+  toolName?: string | readonly string[],
   workingDirectory: string = process.cwd(),
 ): Promise<HookCommand[]> {
   // Check if all hooks are disabled

--- a/src/skills/builtin/modifying-the-harness/references/hooks.md
+++ b/src/skills/builtin/modifying-the-harness/references/hooks.md
@@ -74,6 +74,7 @@ Common matchers:
 Bash          # shell commands
 Edit|Write    # edits and writes
 Read|Grep     # reads/searches
+Agent         # subagent dispatches (legacy internal alias: Task)
 *             # all tools
 ```
 

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -2209,9 +2209,20 @@ type ToolHookContext = {
   debugLabel: string;
   scopedAgentId?: string;
   toolCallId?: string;
-  toolName: string;
+  toolName: string | readonly string[];
   workingDirectory: string;
 };
+
+// Hook matchers are written against the model-facing tool name (e.g. "Agent"),
+// but built-in tools execute under their internal name (e.g. "Task"). Pass
+// both to the hook runners so either spelling matches; the model-facing name
+// comes first so hook payloads report it as tool_name.
+function hookToolNames(internalName: string): string | string[] {
+  const serverName = getServerToolName(internalName);
+  return serverName === internalName
+    ? internalName
+    : [serverName, internalName];
+}
 
 async function collectPostToolHookFeedback(
   context: ToolHookContext,
@@ -2823,7 +2834,7 @@ async function executeToolInner(
   const run = async (): Promise<ToolExecutionResult> => {
     // Run PreToolUse hooks - can block tool execution
     const preHookResult = await runPreToolUseHooks(
-      internalName,
+      hookToolNames(internalName),
       args as Record<string, unknown>,
       options?.toolCallId,
       workingDirectory,
@@ -3016,7 +3027,7 @@ async function executeToolInner(
           debugLabel: "tool result path",
           scopedAgentId,
           toolCallId: options?.toolCallId,
-          toolName: internalName,
+          toolName: hookToolNames(internalName),
           workingDirectory,
         },
         {
@@ -3076,7 +3087,7 @@ async function executeToolInner(
           debugLabel: "tool exception path",
           scopedAgentId,
           toolCallId: options?.toolCallId,
-          toolName: internalName,
+          toolName: hookToolNames(internalName),
           workingDirectory,
         },
         {


### PR DESCRIPTION
## Summary
- PreToolUse/PostToolUse/PostToolUseFailure hooks for built-in tools were matched against the **internal** tool name, but the subagent tool executes internally as `Task` while users, the docs, and the model all see it as `Agent`. A hook registered with matcher `"Agent"` therefore never fired for subagent dispatches (server-executed tools already matched on the model-facing name, so the two paths disagreed).
- The tool manager now passes both names to the hook runners: matchers fire on either the model-facing name or the internal name — so existing `"Task"` matchers keep working — and hook payloads report the model-facing name as `tool_name`. This also covers the Gemini toolset mappings (e.g. matcher `glob` now matches internal `glob_gemini`).
- Documented the `Agent` matcher in the hooks reference.

Fixes #3150.

## Test plan
- [x] `bun test src/hooks/` — new loader tests for alias matching (fail without the fix) and integration tests asserting an `Agent` matcher fires for a `["Agent", "Task"]` call with `tool_name: "Agent"` in the payload, plus legacy `Task` matcher compatibility
- [x] `bun run check`
- [x] Full unit suite — no new failures vs a clean `main` baseline on the same machine
- [x] Manually verified on Windows (integration suite is skipped there): a `.letta/settings.json` PreToolUse hook with matcher `Agent` executes 0 times with the old call shape and once with the new one

## AI disclosure
Following the policy proposed in #3139: this PR was developed with AI assistance (Claude Code) — the investigation, patch, and tests were AI-assisted. I directed the work, reviewed the change, and ran the validation above locally.

cc @jnjpng — you seem closest to `src/hooks/`; happy to adjust if you'd prefer the payload to keep reporting the internal name.