### PR TITLE
fix(bash): recover from deleted working directories

### DIFF
--- a/src/helpers/usable-directory.ts
+++ b/src/helpers/usable-directory.ts
@@ -1,0 +1,14 @@
+import { statSync } from "node:fs";
+
+/** True when the path exists and is a directory. */
+export function isUsableDirectory(dirPath: string | null | undefined): boolean {
+  if (typeof dirPath !== "string" || dirPath.length === 0) {
+    return false;
+  }
+
+  try {
+    return statSync(dirPath, { throwIfNoEntry: false })?.isDirectory() ?? false;
+  } catch {
+    return false;
+  }
+}

--- a/src/runtime-context.ts
+++ b/src/runtime-context.ts
@@ -1,4 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { existsSync, statSync } from "node:fs";
+import { homedir } from "node:os";
 import type { SkillSource } from "./agent/skills";
 import type { MessageChannelToolDiscoveryScope } from "./channels/message-tool";
 import type { ChannelTurnSource } from "./channels/types";
@@ -76,10 +78,62 @@ export function updateRuntimeContext(
   );
 }
 
+function isUsableDirectory(dirPath: string | null | undefined): boolean {
+  if (typeof dirPath !== "string" || dirPath.length === 0) {
+    return false;
+  }
+
+  try {
+    return existsSync(dirPath) && statSync(dirPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function getProcessWorkingDirectory(): string | null {
+  try {
+    return process.cwd();
+  } catch {
+    return null;
+  }
+}
+
+function getFallbackWorkingDirectory(): string {
+  const fallback = [
+    process.env.USER_CWD,
+    getProcessWorkingDirectory(),
+    homedir(),
+    process.platform === "win32" ? undefined : "/",
+  ].find(isUsableDirectory);
+
+  if (fallback) {
+    return fallback;
+  }
+
+  // Extremely defensive fallback for pathological environments where every
+  // candidate disappeared. The caller will still surface a clear cwd error.
+  return process.platform === "win32" ? "C:\\" : "/";
+}
+
 export function getCurrentWorkingDirectory(): string {
-  const workingDirectory = runtimeContextStorage.getStore()?.workingDirectory;
-  if (typeof workingDirectory === "string" && workingDirectory.length > 0) {
+  const runtimeContext = runtimeContextStorage.getStore();
+  const workingDirectory = runtimeContext?.workingDirectory;
+  if (
+    typeof workingDirectory === "string" &&
+    isUsableDirectory(workingDirectory)
+  ) {
     return workingDirectory;
   }
-  return process.env.USER_CWD || process.cwd();
+
+  const fallback = getFallbackWorkingDirectory();
+  if (
+    runtimeContext &&
+    typeof workingDirectory === "string" &&
+    workingDirectory.length > 0 &&
+    workingDirectory !== fallback
+  ) {
+    runtimeContext.workingDirectory = fallback;
+  }
+
+  return fallback;
 }

--- a/src/runtime-context.ts
+++ b/src/runtime-context.ts
@@ -1,9 +1,9 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import { existsSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import type { SkillSource } from "./agent/skills";
 import type { MessageChannelToolDiscoveryScope } from "./channels/message-tool";
 import type { ChannelTurnSource } from "./channels/types";
+import { isUsableDirectory } from "./helpers/usable-directory";
 
 export type RuntimePermissionMode = "standard" | "acceptEdits" | "unrestricted";
 
@@ -14,6 +14,12 @@ export interface RuntimeContextSnapshot {
   skillsDirectory?: string | null;
   skillSources?: SkillSource[];
   workingDirectory?: string | null;
+  /**
+   * Set when the runtime-scoped working directory was found deleted and
+   * repaired to a fallback mid-turn. Holds the original (now missing) path
+   * until a shell tool consumes it to surface a note to the model.
+   */
+  workingDirectoryRecoveredFrom?: string | null;
   toolContextId?: string | null;
   permissionMode?: RuntimePermissionMode;
   channelToolScope?: MessageChannelToolDiscoveryScope | null;
@@ -78,18 +84,6 @@ export function updateRuntimeContext(
   );
 }
 
-function isUsableDirectory(dirPath: string | null | undefined): boolean {
-  if (typeof dirPath !== "string" || dirPath.length === 0) {
-    return false;
-  }
-
-  try {
-    return existsSync(dirPath) && statSync(dirPath).isDirectory();
-  } catch {
-    return false;
-  }
-}
-
 function getProcessWorkingDirectory(): string | null {
   try {
     return process.cwd();
@@ -132,8 +126,26 @@ export function getCurrentWorkingDirectory(): string {
     workingDirectory.length > 0 &&
     workingDirectory !== fallback
   ) {
-    runtimeContext.workingDirectory = fallback;
+    updateRuntimeContext({
+      workingDirectory: fallback,
+      workingDirectoryRecoveredFrom: workingDirectory,
+    });
   }
 
   return fallback;
+}
+
+/**
+ * Returns (and clears) the original path of a working directory that was
+ * repaired mid-turn because it no longer existed, or null when no recovery
+ * happened. Shell tools use this to tell the model its cwd changed.
+ */
+export function consumeWorkingDirectoryRecovery(): string | null {
+  const runtimeContext = runtimeContextStorage.getStore();
+  const recoveredFrom = runtimeContext?.workingDirectoryRecoveredFrom;
+  if (!runtimeContext || !recoveredFrom) {
+    return null;
+  }
+  runtimeContext.workingDirectoryRecoveredFrom = null;
+  return recoveredFrom;
 }

--- a/src/tools/bash.test.ts
+++ b/src/tools/bash.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { runWithRuntimeContext } from "@/runtime-context";
@@ -52,8 +52,10 @@ describe("Bash tool", () => {
   });
 
   test("recovers when runtime working directory was deleted mid-turn", async () => {
-    const fallbackDir = await mkdtemp(
-      path.join(tmpdir(), "letta-bash-fallback-"),
+    // Resolve symlinks/8.3 short names (macOS /var -> /private/var, Windows
+    // RUNNER~1 -> runneradmin) so the assertion matches the child's cwd.
+    const fallbackDir = await realpath(
+      await mkdtemp(path.join(tmpdir(), "letta-bash-fallback-")),
     );
     const deletedDir = await mkdtemp(
       path.join(tmpdir(), "letta-bash-deleted-"),
@@ -76,6 +78,11 @@ describe("Bash tool", () => {
       expect(result.status).toBe("success");
       expect(result.content[0]?.text).toContain(fallbackDir);
       expect(result.content[0]?.text).not.toContain("Executable not found");
+      // The model must be told its cwd changed instead of silently running
+      // from a different directory.
+      expect(result.content[0]?.text).toContain(
+        `Note: working directory ${deletedDir} no longer exists`,
+      );
     } finally {
       if (originalUserCwd === undefined) delete process.env.USER_CWD;
       else process.env.USER_CWD = originalUserCwd;

--- a/src/tools/bash.test.ts
+++ b/src/tools/bash.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { runWithRuntimeContext } from "@/runtime-context";
-import { bash } from "@/tools/impl/bash";
+import { bash, spawnCommand } from "@/tools/impl/bash";
 import { backgroundProcesses } from "@/tools/impl/process_manager";
 
 async function runBashInTemp(
@@ -49,6 +49,53 @@ describe("Bash tool", () => {
     });
 
     expect(result.content[0]?.text).toContain("error message");
+  });
+
+  test("recovers when runtime working directory was deleted mid-turn", async () => {
+    const fallbackDir = await mkdtemp(
+      path.join(tmpdir(), "letta-bash-fallback-"),
+    );
+    const deletedDir = await mkdtemp(
+      path.join(tmpdir(), "letta-bash-deleted-"),
+    );
+    await rm(deletedDir, { recursive: true, force: true });
+
+    const originalUserCwd = process.env.USER_CWD;
+    process.env.USER_CWD = fallbackDir;
+
+    try {
+      const result = await runWithRuntimeContext(
+        { workingDirectory: deletedDir },
+        () =>
+          bash({
+            command: 'node -e "console.log(process.cwd())"',
+            description: "Test missing cwd recovery",
+          }),
+      );
+
+      expect(result.status).toBe("success");
+      expect(result.content[0]?.text).toContain(fallbackDir);
+      expect(result.content[0]?.text).not.toContain("Executable not found");
+    } finally {
+      if (originalUserCwd === undefined) delete process.env.USER_CWD;
+      else process.env.USER_CWD = originalUserCwd;
+      await rm(fallbackDir, { recursive: true, force: true });
+    }
+  });
+
+  test("reports missing explicit cwd instead of missing shell", async () => {
+    const missingDir = path.join(
+      tmpdir(),
+      `letta-bash-missing-${Date.now()}-${Math.random()}`,
+    );
+
+    await expect(
+      spawnCommand("node -e \"console.log('unused')\"", {
+        cwd: missingDir,
+        env: process.env,
+        timeout: 1000,
+      }),
+    ).rejects.toThrow(`Working directory not found: ${missingDir}`);
   });
 
   test("returns error for failed command", async () => {

--- a/src/tools/impl/bash.ts
+++ b/src/tools/impl/bash.ts
@@ -1,6 +1,9 @@
 import { spawn } from "node:child_process";
 import { INTERRUPTED_BY_USER } from "@/constants";
-import { getCurrentWorkingDirectory } from "@/runtime-context";
+import {
+  consumeWorkingDirectoryRecovery,
+  getCurrentWorkingDirectory,
+} from "@/runtime-context";
 import { noteExpectedWorktreeForLauncher } from "@/websocket/listener/worktree-ownership";
 import {
   appendBackgroundProcessOutput,
@@ -18,7 +21,7 @@ import {
   selectAvailableShellLauncher,
   withStrictShellPrelude,
 } from "./shell-launchers.js";
-import { spawnWithLauncher } from "./shell-runner.js";
+import { type ShellExecutionError, spawnWithLauncher } from "./shell-runner.js";
 import { applyShellSandbox } from "./shell-sandbox.js";
 import { LIMITS, truncateByChars } from "./truncation.js";
 import { validateRequiredParams } from "./validation.js";
@@ -121,8 +124,10 @@ export async function spawnCommand(
         });
         return result;
       } catch (error) {
-        const err = error as NodeJS.ErrnoException;
-        if (err.code !== "ENOENT") {
+        const err = error as ShellExecutionError;
+        // Only an executable-lookup ENOENT justifies retrying other shells.
+        // A missing cwd fails identically for every launcher.
+        if (err.code !== "ENOENT" || err.reason === "cwd_missing") {
           throw error;
         }
         cachedWorkingLauncher = null;
@@ -154,8 +159,8 @@ export async function spawnCommand(
       cachedWorkingLauncher = launcher;
       return result;
     } catch (error) {
-      const err = error as NodeJS.ErrnoException;
-      if (err.code === "ENOENT") {
+      const err = error as ShellExecutionError;
+      if (err.code === "ENOENT" && err.reason !== "cwd_missing") {
         tried.push(launcher[0] || "unknown");
         lastError = err;
         continue;
@@ -220,6 +225,14 @@ export async function bash(args: BashArgs): Promise<BashResult> {
       status: "success",
     };
   }
+
+  // If the runtime cwd was found deleted and repaired to a fallback (e.g. the
+  // agent removed its own worktree), tell the model instead of silently
+  // running from a different directory.
+  const recoveredFrom = consumeWorkingDirectoryRecovery();
+  const recoveryNote = recoveredFrom
+    ? `Note: working directory ${recoveredFrom} no longer exists; running in ${userCwd} instead.\n`
+    : "";
 
   if (run_in_background) {
     try {
@@ -321,7 +334,7 @@ export async function bash(args: BashArgs): Promise<BashResult> {
       content: [
         {
           type: "text",
-          text: `Command running in background with ID: ${bashId}\nOutput file: ${outputFile}`,
+          text: `${recoveryNote}Command running in background with ID: ${bashId}\nOutput file: ${outputFile}`,
         },
       ],
       status: "success",
@@ -356,7 +369,7 @@ export async function bash(args: BashArgs): Promise<BashResult> {
         content: [
           {
             type: "text",
-            text: `Exit code: ${exitCode}\n${truncatedOutput}`,
+            text: `${recoveryNote}Exit code: ${exitCode}\n${truncatedOutput}`,
           },
         ],
         status: "error",
@@ -364,7 +377,7 @@ export async function bash(args: BashArgs): Promise<BashResult> {
     }
 
     return {
-      content: [{ type: "text", text: truncatedOutput }],
+      content: [{ type: "text", text: `${recoveryNote}${truncatedOutput}` }],
       status: "success",
     };
   } catch (error) {
@@ -404,7 +417,14 @@ export async function bash(args: BashArgs): Promise<BashResult> {
     );
 
     return {
-      content: [{ type: "text", text: truncatedError }],
+      content: [
+        {
+          type: "text",
+          // Interrupt results must stay byte-exact (downstream code compares
+          // against INTERRUPTED_BY_USER), so skip the recovery note on abort.
+          text: isAbort ? truncatedError : `${recoveryNote}${truncatedError}`,
+        },
+      ],
       status: "error",
     };
   }

--- a/src/tools/impl/shell-runner.ts
+++ b/src/tools/impl/shell-runner.ts
@@ -1,9 +1,11 @@
 import { spawn } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
 import { noteExpectedWorktreeForLauncher } from "@/websocket/listener/worktree-ownership";
 
 export class ShellExecutionError extends Error {
   code?: string;
   executable?: string;
+  cwd?: string;
 }
 
 export type ShellSpawnOptions = {
@@ -15,6 +17,33 @@ export type ShellSpawnOptions = {
 };
 
 const ABORT_KILL_TIMEOUT_MS = 2000;
+
+function isUsableDirectory(dirPath: string): boolean {
+  try {
+    return existsSync(dirPath) && statSync(dirPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function buildSpawnError(
+  err: NodeJS.ErrnoException,
+  executable: string,
+  cwd: string,
+): ShellExecutionError {
+  let message = `Failed to execute command: ${err?.message || "unknown error"}`;
+  if (err?.code === "ENOENT") {
+    message = isUsableDirectory(cwd)
+      ? `Executable not found: ${executable}`
+      : `Working directory not found: ${cwd}`;
+  }
+
+  const execError = new ShellExecutionError(message);
+  execError.code = err?.code;
+  execError.executable = executable;
+  execError.cwd = cwd;
+  return execError;
+}
 
 /**
  * Spawn a command with a specific launcher.
@@ -28,6 +57,17 @@ export function spawnWithLauncher(
     const [executable, ...args] = launcher;
     if (!executable) {
       reject(new ShellExecutionError("Executable is required"));
+      return;
+    }
+
+    if (!isUsableDirectory(options.cwd)) {
+      reject(
+        buildSpawnError(
+          { code: "ENOENT" } as NodeJS.ErrnoException,
+          executable,
+          options.cwd,
+        ),
+      );
       return;
     }
 
@@ -112,14 +152,7 @@ export function spawnWithLauncher(
         options.signal.removeEventListener("abort", abortHandler);
       }
 
-      const execError = new ShellExecutionError(
-        err?.code === "ENOENT"
-          ? `Executable not found: ${executable}`
-          : `Failed to execute command: ${err?.message || "unknown error"}`,
-      );
-      execError.code = err?.code;
-      execError.executable = executable;
-      reject(execError);
+      reject(buildSpawnError(err, executable, options.cwd));
     });
 
     childProcess.on("close", (code) => {

--- a/src/tools/impl/shell-runner.ts
+++ b/src/tools/impl/shell-runner.ts
@@ -1,11 +1,13 @@
 import { spawn } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
+import { isUsableDirectory } from "@/helpers/usable-directory";
 import { noteExpectedWorktreeForLauncher } from "@/websocket/listener/worktree-ownership";
 
 export class ShellExecutionError extends Error {
   code?: string;
   executable?: string;
   cwd?: string;
+  /** Distinguishes which lookup failed when `code` is ENOENT. */
+  reason?: "executable_missing" | "cwd_missing";
 }
 
 export type ShellSpawnOptions = {
@@ -18,30 +20,28 @@ export type ShellSpawnOptions = {
 
 const ABORT_KILL_TIMEOUT_MS = 2000;
 
-function isUsableDirectory(dirPath: string): boolean {
-  try {
-    return existsSync(dirPath) && statSync(dirPath).isDirectory();
-  } catch {
-    return false;
-  }
-}
-
 function buildSpawnError(
   err: NodeJS.ErrnoException,
   executable: string,
   cwd: string,
 ): ShellExecutionError {
   let message = `Failed to execute command: ${err?.message || "unknown error"}`;
+  let reason: ShellExecutionError["reason"];
   if (err?.code === "ENOENT") {
-    message = isUsableDirectory(cwd)
-      ? `Executable not found: ${executable}`
-      : `Working directory not found: ${cwd}`;
+    if (isUsableDirectory(cwd)) {
+      message = `Executable not found: ${executable}`;
+      reason = "executable_missing";
+    } else {
+      message = `Working directory not found: ${cwd}`;
+      reason = "cwd_missing";
+    }
   }
 
   const execError = new ShellExecutionError(message);
   execError.code = err?.code;
   execError.executable = executable;
   execError.cwd = cwd;
+  execError.reason = reason;
   return execError;
 }
 

--- a/src/tools/impl/shell.ts
+++ b/src/tools/impl/shell.ts
@@ -1,6 +1,9 @@
-import { existsSync, statSync } from "node:fs";
 import * as path from "node:path";
-import { getCurrentWorkingDirectory } from "@/runtime-context";
+import { isUsableDirectory } from "@/helpers/usable-directory";
+import {
+  consumeWorkingDirectoryRecovery,
+  getCurrentWorkingDirectory,
+} from "@/runtime-context";
 import { noteExpectedWorktreeForLauncher } from "@/websocket/listener/worktree-ownership";
 import { getShellEnv } from "./shell-env.js";
 import { buildShellLaunchers } from "./shell-launchers.js";
@@ -47,6 +50,22 @@ type SpawnContext = {
   signal?: AbortSignal;
   onOutput?: (chunk: string, stream: "stdout" | "stderr") => void;
 };
+
+function withWorkingDirectoryRecoveryNote(
+  result: ShellResult,
+  recoveredFrom: string | null,
+  cwd: string,
+): ShellResult {
+  if (!recoveredFrom) {
+    return result;
+  }
+
+  const note = `Note: working directory ${recoveredFrom} no longer exists; running in ${cwd} instead.`;
+  return {
+    ...result,
+    output: result.output ? `${note}\n${result.output}` : note,
+  };
+}
 
 async function runProcess(context: SpawnContext): Promise<ShellResult> {
   const { stdout, stderr, exitCode } = await spawnWithLauncher(
@@ -107,6 +126,7 @@ export async function shell(args: ShellArgs): Promise<ShellResult> {
     ...(env_overrides ?? {}),
     ...(secretEnv ?? {}),
   };
+  const recoveredFrom = consumeWorkingDirectoryRecovery();
 
   // Confine the command under the cross-agent shell sandbox. The wrapper hides
   // the inner shell from spawnWithLauncher's worktree-ownership note, so note
@@ -128,16 +148,29 @@ export async function shell(args: ShellArgs): Promise<ShellResult> {
   };
 
   try {
-    return await runProcess(context);
+    return withWorkingDirectoryRecoveryNote(
+      await runProcess(context),
+      recoveredFrom,
+      cwd,
+    );
   } catch (error) {
-    if (error instanceof ShellExecutionError && error.code === "ENOENT") {
+    if (
+      error instanceof ShellExecutionError &&
+      error.code === "ENOENT" &&
+      error.reason !== "cwd_missing"
+    ) {
       for (const fallback of buildFallbackCommands(command)) {
         try {
-          return await runProcess({ ...context, command: fallback });
+          return withWorkingDirectoryRecoveryNote(
+            await runProcess({ ...context, command: fallback }),
+            recoveredFrom,
+            cwd,
+          );
         } catch (retryError) {
           if (
             retryError instanceof ShellExecutionError &&
-            retryError.code === "ENOENT"
+            retryError.code === "ENOENT" &&
+            retryError.reason !== "cwd_missing"
           ) {
             continue;
           }
@@ -165,14 +198,6 @@ function arraysEqual(a: string[], b: string[]): boolean {
     if (a[i] !== b[i]) return false;
   }
   return true;
-}
-
-function isUsableDirectory(candidate: string): boolean {
-  try {
-    return existsSync(candidate) && statSync(candidate).isDirectory();
-  } catch {
-    return false;
-  }
 }
 
 function isShellExecutableName(name: string): boolean {

--- a/src/tools/shell-command.test.ts
+++ b/src/tools/shell-command.test.ts
@@ -3,11 +3,12 @@ import { randomUUID } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
+  mkdtempSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { runWithRuntimeContext } from "@/runtime-context";
 import { shell_command } from "@/tools/impl/shell-command.js";
@@ -82,6 +83,36 @@ test("shell_command falls back when preferred shell is missing", async () => {
       if (original === undefined) delete process.env.SHELL;
       else process.env.SHELL = original;
     }
+  }
+});
+
+test("shell_command surfaces deleted runtime cwd recovery once", async () => {
+  const fallbackDir = mkdtempSync(join(tmpdir(), "shell-cwd-fallback-"));
+  const deletedDir = mkdtempSync(join(tmpdir(), "shell-cwd-deleted-"));
+  const originalUserCwd = process.env.USER_CWD;
+  rmSync(deletedDir, { recursive: true, force: true });
+  process.env.USER_CWD = fallbackDir;
+
+  try {
+    const { first, second } = await runWithRuntimeContext(
+      { workingDirectory: deletedDir },
+      async () => {
+        const first = await shell_command({ command: "echo recovered" });
+        const second = await shell_command({ command: "echo later" });
+        return { first, second };
+      },
+    );
+
+    expect(first.output).toContain(
+      `Note: working directory ${deletedDir} no longer exists; running in ${fallbackDir} instead.`,
+    );
+    expect(first.output).toContain("recovered");
+    expect(second.output).toContain("later");
+    expect(second.output).not.toContain("working directory");
+  } finally {
+    if (originalUserCwd === undefined) delete process.env.USER_CWD;
+    else process.env.USER_CWD = originalUserCwd;
+    rmSync(fallbackDir, { recursive: true, force: true });
   }
 });
 

--- a/src/tools/shell-env.test.ts
+++ b/src/tools/shell-env.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { getMemoryFilesystemRoot } from "@/agent/memory-filesystem";
 import { configureBackendMode } from "@/backend";
@@ -273,62 +275,75 @@ test("getShellEnv injects AGENT_ID aliases", () => {
 });
 
 test("getShellEnv prefers runtime-scoped agent, conversation, and cwd", () => {
-  const env = runWithRuntimeContext(
-    {
-      agentId: "agent-runtime-scope",
-      agentName: "Runtime Scope Agent",
-      conversationId: "conv-runtime-scope",
-      workingDirectory: "/tmp/runtime-scope-cwd",
-    },
-    () => getShellEnv(),
-  );
+  const runtimeCwd = mkdtempSync(path.join(tmpdir(), "runtime-scope-cwd-"));
 
-  expect(env.AGENT_ID).toBe("agent-runtime-scope");
-  expect(env.LETTA_AGENT_ID).toBe("agent-runtime-scope");
-  expect(env.AGENT_NAME).toBe("Runtime Scope Agent");
-  expect(env.CONVERSATION_ID).toBe("conv-runtime-scope");
-  expect(env.LETTA_CONVERSATION_ID).toBe("conv-runtime-scope");
-  expect(env.USER_CWD).toBe("/tmp/runtime-scope-cwd");
+  try {
+    const env = runWithRuntimeContext(
+      {
+        agentId: "agent-runtime-scope",
+        agentName: "Runtime Scope Agent",
+        conversationId: "conv-runtime-scope",
+        workingDirectory: runtimeCwd,
+      },
+      () => getShellEnv(),
+    );
+
+    expect(env.AGENT_ID).toBe("agent-runtime-scope");
+    expect(env.LETTA_AGENT_ID).toBe("agent-runtime-scope");
+    expect(env.AGENT_NAME).toBe("Runtime Scope Agent");
+    expect(env.CONVERSATION_ID).toBe("conv-runtime-scope");
+    expect(env.LETTA_CONVERSATION_ID).toBe("conv-runtime-scope");
+    expect(env.USER_CWD).toBe(runtimeCwd);
+  } finally {
+    rmSync(runtimeCwd, { recursive: true, force: true });
+  }
 });
 
 test("getShellEnv isolates overlapping runtime scopes", async () => {
+  const cwdA = mkdtempSync(path.join(tmpdir(), "agent-a-"));
+  const cwdB = mkdtempSync(path.join(tmpdir(), "agent-b-"));
   let releaseAgentA!: () => void;
   const waitForAgentA = new Promise<void>((resolve) => {
     releaseAgentA = resolve;
   });
 
-  const taskA = runWithRuntimeContext(
-    {
-      agentId: "agent-a",
-      conversationId: "conv-a",
-      workingDirectory: "/tmp/agent-a",
-    },
-    async () => {
-      await waitForAgentA;
-      return getShellEnv();
-    },
-  );
+  try {
+    const taskA = runWithRuntimeContext(
+      {
+        agentId: "agent-a",
+        conversationId: "conv-a",
+        workingDirectory: cwdA,
+      },
+      async () => {
+        await waitForAgentA;
+        return getShellEnv();
+      },
+    );
 
-  const taskB = runWithRuntimeContext(
-    {
-      agentId: "agent-b",
-      conversationId: "conv-b",
-      workingDirectory: "/tmp/agent-b",
-    },
-    async () => {
-      releaseAgentA();
-      return getShellEnv();
-    },
-  );
+    const taskB = runWithRuntimeContext(
+      {
+        agentId: "agent-b",
+        conversationId: "conv-b",
+        workingDirectory: cwdB,
+      },
+      async () => {
+        releaseAgentA();
+        return getShellEnv();
+      },
+    );
 
-  const [envA, envB] = await Promise.all([taskA, taskB]);
+    const [envA, envB] = await Promise.all([taskA, taskB]);
 
-  expect(envA.AGENT_ID).toBe("agent-a");
-  expect(envA.CONVERSATION_ID).toBe("conv-a");
-  expect(envA.USER_CWD).toBe("/tmp/agent-a");
-  expect(envB.AGENT_ID).toBe("agent-b");
-  expect(envB.CONVERSATION_ID).toBe("conv-b");
-  expect(envB.USER_CWD).toBe("/tmp/agent-b");
+    expect(envA.AGENT_ID).toBe("agent-a");
+    expect(envA.CONVERSATION_ID).toBe("conv-a");
+    expect(envA.USER_CWD).toBe(cwdA);
+    expect(envB.AGENT_ID).toBe("agent-b");
+    expect(envB.CONVERSATION_ID).toBe("conv-b");
+    expect(envB.USER_CWD).toBe(cwdB);
+  } finally {
+    rmSync(cwdA, { recursive: true, force: true });
+    rmSync(cwdB, { recursive: true, force: true });
+  }
 });
 
 test("getShellEnv does not inject MEMORY_DIR aliases when memfs is disabled", () => {

--- a/src/websocket/listener/cwd.ts
+++ b/src/websocket/listener/cwd.ts
@@ -1,5 +1,5 @@
-import { existsSync, statSync } from "node:fs";
 import path from "node:path";
+import { isUsableDirectory } from "@/helpers/usable-directory";
 import { loadRemoteSettings, saveRemoteSettings } from "./remote-settings";
 import { normalizeConversationId, normalizeCwdAgentId } from "./scope";
 import type { ListenerRuntime } from "./types";
@@ -15,15 +15,6 @@ export function getWorkingDirectoryScopeKey(
   }
 
   return `conversation:${normalizedConversationId}`;
-}
-
-/** True when the path exists and is a directory. */
-function isUsableDirectory(dirPath: string): boolean {
-  try {
-    return existsSync(dirPath) && statSync(dirPath).isDirectory();
-  } catch {
-    return false;
-  }
 }
 
 export function getConversationWorkingDirectory(


### PR DESCRIPTION
## Summary

- LET-9464: recover tool execution when the runtime-scoped working directory has been deleted mid-turn.
- Distinguish a missing working directory from a missing shell executable so deleted worktrees no longer surface as `Executable not found: /bin/zsh`.
- Surface a one-time recovery note to the model when Letta Code has to run from a fallback cwd, so relative-path commands are not silently redirected.
- Add regression coverage for Bash, shell_command, shell env, missing-cwd error handling, and cross-platform cwd path normalization.

## Anonymized trace sequence

This PR is grounded in a real internal listener trace, but the public description intentionally removes run IDs, agent IDs, organization IDs, user names, repository names, branch names, and absolute user paths.

The trace showed this sequence:

1. A macOS listener conversation had its runtime working directory set to a task-specific git worktree.
2. The agent verified merge state from the main checkout by putting `cd <main checkout> && ...` inside a Bash command. That command succeeded, but it did not change Letta Code's stored runtime working directory. The conversation still pointed at the task worktree.
3. The agent then ran its cleanup command. Because the runtime cwd was still the task worktree, the Bash tool spawned from that worktree and removed that same worktree during cleanup.
4. The cleanup command's own output then showed git failures equivalent to `fatal: Unable to read current working directory`, because the process cwd had disappeared while the shell was still running.
5. The agent tried to recover with another Bash command that again contained `cd <main checkout> && ...`, but `child_process.spawn()` has to enter the configured cwd before the command string runs. Since the configured cwd no longer existed, the command body never executed.
6. Node surfaced that spawn failure as `ENOENT`.
7. Our shell runner treated every spawn `ENOENT` as an executable lookup failure and returned `Executable not found: /bin/zsh`.
8. Several later approval continuations attempted simple shell probes such as `echo ...`. They all failed before the command body ran, with null stdout/stderr and the same misleading shell-not-found tool response.
9. The final run in that sequence was cancelled after the repeated tool failures. The model/provider steps were not the root cause; the failure was local tool execution against a deleted cwd.

## Root cause

There were two separate gaps.

First, `getConversationWorkingDirectory()` already prunes stale persisted cwd entries at listener turn start, but this incident happened inside a single active turn. `handleIncomingMessage()` captured `turnWorkingDirectory` once. Later, during the approval loop, a Bash command deleted that captured directory. The existing stale-cwd guard never got another chance to run before the next tool execution.

Second, `spawnWithLauncher()` reported all spawn-time `ENOENT` failures as missing executables. That is correct when the cwd exists and the executable path is unavailable, but it is wrong when the executable exists and the configured cwd is gone. In this case `/bin/zsh` was present; the cwd was not.

A review pass found two more parity issues after the first fix:

- Silent recovery was dangerous: a command such as `rm -rf ./build` could run from the fallback directory without the model knowing the original cwd had disappeared.
- The Codex-style `shell` / `shell_command` path needed the same cwd-missing fast-fail and recovery-note behavior as Bash, otherwise it could retry fallback launchers for a missing cwd and leave the recovery note to be consumed by a later tool call.

## Fix

This change adds these protections:

1. `getCurrentWorkingDirectory()` validates the runtime-context cwd before returning it. If the runtime cwd has disappeared, it falls back to the first usable directory from:
   - `USER_CWD`
   - `process.cwd()`
   - the user's home directory
   - `/` on Unix as a final safety fallback

   When it repairs a runtime-context cwd, it also updates the current async runtime context so subsequent tools in the same turn reuse the recovered directory instead of repeatedly trying the deleted path.

2. Shell tools consume that repair state and prepend a one-time note:

   `Note: working directory <old> no longer exists; running in <new> instead.`

   This keeps the model aware that relative paths now resolve somewhere else. Interrupt output remains byte-exact so downstream interrupt handling still works.

3. `spawnWithLauncher()` now preflights the cwd and also re-checks cwd state when spawn emits `ENOENT`. If the cwd is missing, the error becomes `Working directory not found: <path>` with reason `cwd_missing`. If the cwd is valid and the executable is missing, it still reports `Executable not found: <executable>` with reason `executable_missing`.

4. Bash and shell fallback loops only retry alternate shell launchers for executable lookup failures. A missing cwd now fails fast instead of retrying every fallback shell and potentially evicting a valid cached launcher.

5. Directory usability checks are centralized in `src/helpers/usable-directory.ts` so runtime context, shell spawning, and listener cwd cleanup use the same implementation.

The intended behavior after this patch is:

- Runtime-scoped deleted cwd: recover to a valid fallback cwd, tell the model once, and continue running tools.
- Explicit deleted cwd at spawn time: fail clearly as a missing working directory.
- Actual missing shell executable: continue reporting an executable-not-found error and use existing fallback launcher behavior where appropriate.

## Test plan

- `bun test src/tools/bash.test.ts src/tools/shell-env.test.ts src/tools/shell-command.test.ts`
- `bun run typecheck`
- `bun run check`

CI was green at head `e17d534a`. The latest head `85ad07fe` adds the shell_command parity fix and is rerunning CI.

👾 Generated with [Letta Code](https://letta.com)