### PR TITLE
feat(cli): rename dream options to --memory/--from, reserve --to/--effort

### DIFF
--- a/src/cli/subcommands/dream.test.ts
+++ b/src/cli/subcommands/dream.test.ts
@@ -35,7 +35,8 @@ describe("dream subcommand", () => {
       const output = captured.logs.join("\n");
       expect(output).toContain("Usage:");
       expect(output).toContain("letta dream");
-      expect(output).toContain("--agent");
+      expect(output).toContain("--memory");
+      expect(output).toContain("--from");
       expect(output).toContain("--instruction");
     } finally {
       captured.restore();

--- a/src/cli/subcommands/dream.ts
+++ b/src/cli/subcommands/dream.ts
@@ -52,30 +52,6 @@ function parseDreamArgs(argv: string[]) {
   });
 }
 
-/**
- * Resolve the --memory value to an agent id. Accepts a bare agent id or an
- * `agent:<id>` form. Only agent-backed memory is supported in this version.
- */
-function resolveMemoryAgentId(memory: string | undefined): string {
-  if (!memory) {
-    return (
-      process.env.LETTA_AGENT_ID || settingsManager.getGlobalLastAgentId() || ""
-    );
-  }
-  return memory.startsWith("agent:") ? memory.slice("agent:".length) : memory;
-}
-
-/**
- * Resolve the --from value to a conversation id. A bare conversation id is
- * treated as `self` (the memory agent's own transcript for that conversation);
- * `self` or an omitted value means the agent's primary "default" history.
- */
-function resolveFromConversationId(from: string | undefined): string {
-  if (!from || from === "self") return "default";
-  if (from.startsWith("self,conv=")) return from.slice("self,conv=".length);
-  return from;
-}
-
 interface DreamCompletion {
   success: boolean;
   error?: string;
@@ -129,7 +105,11 @@ export async function runDreamSubcommand(argv: string[]): Promise<number> {
 
   await settingsManager.initialize();
 
-  const agentId = resolveMemoryAgentId(parsed.values.memory);
+  const agentId =
+    parsed.values.memory ||
+    process.env.LETTA_AGENT_ID ||
+    settingsManager.getGlobalLastAgentId() ||
+    "";
   if (!agentId) {
     console.error(
       "Missing agent id. Pass --memory <agent-id>, set LETTA_AGENT_ID, or run a session first.",
@@ -148,7 +128,7 @@ export async function runDreamSubcommand(argv: string[]): Promise<number> {
     return 1;
   }
 
-  const conversationId = resolveFromConversationId(parsed.values.from);
+  const conversationId = parsed.values.from || "default";
 
   const { launchReflectionSubagent } = await import(
     "@/cli/helpers/reflection-launcher"

--- a/src/cli/subcommands/dream.ts
+++ b/src/cli/subcommands/dream.ts
@@ -10,10 +10,12 @@ Usage:
 Run a memory reflection pass for an agent and wait for it to finish.
 
 Options:
-  --agent <id>                Agent id (default: $LETTA_AGENT_ID, then the
-                              last-used agent for the current server)
-  --conv <id>                 Conversation transcript to process
-                              (default: "default")
+  --memory <agent-id>         Agent whose memory to refine (default:
+                              $LETTA_AGENT_ID, then the last-used agent)
+  --from <conv-id>            Conversation transcript to reflect on
+                              (default: the agent's primary "default" history)
+  --to <spec>                 Render target (reserved; not yet implemented)
+  --effort <level>            Reflection effort (reserved; not yet implemented)
   --timeout <seconds>         Fail if the reflection pass has not completed
                               in this many seconds (default: 1500)
   -i, --instruction <text>    Additional instruction for the reflection pass
@@ -30,8 +32,10 @@ Notes:
 
 const DREAM_OPTIONS = {
   help: { type: "boolean", short: "h" },
-  agent: { type: "string" },
-  conv: { type: "string" },
+  memory: { type: "string" },
+  from: { type: "string" },
+  to: { type: "string" },
+  effort: { type: "string" },
   timeout: { type: "string" },
   instruction: { type: "string", short: "i" },
   json: { type: "boolean" },
@@ -46,6 +50,30 @@ function parseDreamArgs(argv: string[]) {
     strict: true,
     allowPositionals: true,
   });
+}
+
+/**
+ * Resolve the --memory value to an agent id. Accepts a bare agent id or an
+ * `agent:<id>` form. Only agent-backed memory is supported in this version.
+ */
+function resolveMemoryAgentId(memory: string | undefined): string {
+  if (!memory) {
+    return (
+      process.env.LETTA_AGENT_ID || settingsManager.getGlobalLastAgentId() || ""
+    );
+  }
+  return memory.startsWith("agent:") ? memory.slice("agent:".length) : memory;
+}
+
+/**
+ * Resolve the --from value to a conversation id. A bare conversation id is
+ * treated as `self` (the memory agent's own transcript for that conversation);
+ * `self` or an omitted value means the agent's primary "default" history.
+ */
+function resolveFromConversationId(from: string | undefined): string {
+  if (!from || from === "self") return "default";
+  if (from.startsWith("self,conv=")) return from.slice("self,conv=".length);
+  return from;
 }
 
 interface DreamCompletion {
@@ -82,6 +110,14 @@ export async function runDreamSubcommand(argv: string[]): Promise<number> {
 
   const asJson = Boolean(parsed.values.json);
 
+  // --to and --effort are part of the target/effort interface but are not yet
+  // wired up; accept them so the surface is stable, but say they're inert.
+  if (!asJson && (parsed.values.to || parsed.values.effort)) {
+    console.error(
+      "Note: --to and --effort are accepted but not yet implemented; ignoring.",
+    );
+  }
+
   let timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
   if (parsed.values.timeout) {
     timeoutSeconds = Number.parseInt(parsed.values.timeout, 10);
@@ -93,14 +129,10 @@ export async function runDreamSubcommand(argv: string[]): Promise<number> {
 
   await settingsManager.initialize();
 
-  const agentId =
-    parsed.values.agent ||
-    process.env.LETTA_AGENT_ID ||
-    settingsManager.getGlobalLastAgentId() ||
-    "";
+  const agentId = resolveMemoryAgentId(parsed.values.memory);
   if (!agentId) {
     console.error(
-      "Missing agent id. Pass --agent, set LETTA_AGENT_ID, or run a session first.",
+      "Missing agent id. Pass --memory <agent-id>, set LETTA_AGENT_ID, or run a session first.",
     );
     return 1;
   }
@@ -116,7 +148,7 @@ export async function runDreamSubcommand(argv: string[]): Promise<number> {
     return 1;
   }
 
-  const conversationId = parsed.values.conv || "default";
+  const conversationId = resolveFromConversationId(parsed.values.from);
 
   const { launchReflectionSubagent } = await import(
     "@/cli/helpers/reflection-launcher"


### PR DESCRIPTION
Stacked on #3212 (`feat/reflection-cli-entrypoint`).

## Summary
Renames the `letta dream` options to match the dream-process interface we're converging on, and reserves the two options that the fuller interface will need:

- **`--agent` → `--memory`** — the base whose memory is refined. Takes an agent id (or `agent:<id>`).
- **`--conv` → `--from`** — the experience to reflect on. Takes a conversation id, treated as the agent's own transcript (`self`); `self` or omitted = the agent's primary `default` history.
- **`--to` (new, inert)** — render target. Accepted so the surface is stable; not yet implemented (prints a note).
- **`--effort` (new, inert)** — reflection effort. Accepted, not yet implemented.

Bare `letta dream` still falls back to `$LETTA_AGENT_ID` / the last-used agent and the `default` conversation.

No back-compat: `--agent`/`--conv` are removed, not aliased.

## Why
`--memory`/`--from` name absolute roles (base vs ingress) instead of the agent/conversation coupling, which is the direction for the broader dream interface (memory = source of truth, `from` = experience in, `to` = projections out). `--to`/`--effort` are stubbed now so callers can adopt the final shape before the projection/effort machinery lands.

## Scope
Agent-backed memory + single-conversation reflection only — same capability as #3212, just the renamed surface. `--to`/`--effort` do nothing yet.

## Test
- Unit tests updated (`dream.test.ts`) and pass; `bun run check` green (10/10).
- Smoke-tested on the local backend: `--memory <id> --from default` resolves and reflects; `--to`/`--effort` print the inert note; missing-id error references `--memory`.