### PR TITLE
fix: await memfs push before emitting memory_updated + write/delete responses (LET-9481)

### DIFF
--- a/src/websocket/listener/commands/memory-write-push-ordering.test.ts
+++ b/src/websocket/listener/commands/memory-write-push-ordering.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Push-before-notify contract for GUI-initiated memory writes (LET-9481).
+ *
+ * Server-of-record reads (e.g. cloud-api's agent profile picture endpoint)
+ * are served from the remote memfs (Pierre), so `memory_updated` and the
+ * `write_memory_file_response` / `delete_memory_file_response` frames must
+ * not be emitted until the push has completed. Otherwise the UI invalidates
+ * its query caches, refetches stale bytes from the remote, and drops its
+ * optimistic state (the "profile picture doesn't refresh" bug).
+ *
+ * Source-level pins are used because the handler wires the sync via dynamic
+ * imports and `mock.module` in other suites is process-global under Bun
+ * (matching the `acting-user-attribution.test.ts` convention).
+ */
+
+const handlerSource = readFileSync(
+  fileURLToPath(new URL("./memory.ts", import.meta.url)),
+  "utf-8",
+);
+
+function handlerBlock(startMarker: string, endMarker: string | null): string {
+  const start = handlerSource.indexOf(startMarker);
+  expect(start).toBeGreaterThan(-1);
+  if (endMarker === null) return handlerSource.slice(start);
+  const end = handlerSource.indexOf(endMarker, start + startMarker.length);
+  expect(end).toBeGreaterThan(start);
+  return handlerSource.slice(start, end);
+}
+
+describe("listener memory write push ordering (contract)", () => {
+  const writeBlock = handlerBlock(
+    "isWriteMemoryFileCommand(parsed)",
+    "isDeleteMemoryFileCommand(parsed)",
+  );
+  const deleteBlock = handlerBlock("isDeleteMemoryFileCommand(parsed)", null);
+
+  for (const [name, block] of [
+    ["write_memory_file", writeBlock],
+    ["delete_memory_file", deleteBlock],
+  ] as const) {
+    test(`${name} awaits the remote push before emitting memory_updated`, () => {
+      const pushIdx = block.indexOf("await syncPendingMemoryCommitsAfterTurn(");
+      const memoryUpdatedIdx = block.indexOf('type: "memory_updated"');
+      // The success-path response emission is the last occurrence — the
+      // first occurrence is the `sendFailure` helper at the top of each
+      // handler.
+      const responseIdx = block.lastIndexOf(`type: "${name}_response"`);
+
+      expect(pushIdx).toBeGreaterThan(-1);
+      expect(memoryUpdatedIdx).toBeGreaterThan(pushIdx);
+      expect(responseIdx).toBeGreaterThan(pushIdx);
+    });
+
+    test(`${name} does not fire-and-forget the push`, () => {
+      expect(block).not.toMatch(
+        /syncPendingMemoryCommitsAfterTurn\([\s\S]{0,120}?\)\.catch\(/,
+      );
+    });
+  }
+});

--- a/src/websocket/listener/commands/memory-write-push-ordering.test.ts
+++ b/src/websocket/listener/commands/memory-write-push-ordering.test.ts
@@ -42,8 +42,8 @@ describe("listener memory write push ordering (contract)", () => {
     ["write_memory_file", writeBlock],
     ["delete_memory_file", deleteBlock],
   ] as const) {
-    test(`${name} awaits the remote push before emitting memory_updated`, () => {
-      const pushIdx = block.indexOf("await syncPendingMemoryCommitsAfterTurn(");
+    test(`${name} awaits the bounded push before emitting memory_updated`, () => {
+      const pushIdx = block.indexOf("await awaitMemoryPushBounded(");
       const memoryUpdatedIdx = block.indexOf('type: "memory_updated"');
       // The success-path response emission is the last occurrence — the
       // first occurrence is the `sendFailure` helper at the top of each
@@ -61,4 +61,26 @@ describe("listener memory write push ordering (contract)", () => {
       );
     });
   }
+
+  test("bounded helper races the push against the cap", () => {
+    const helperBlock = handlerBlock(
+      "async function awaitMemoryPushBounded(",
+      "export async function handleListMemoryCommand(",
+    );
+    expect(helperBlock).toContain("await Promise.race([syncPromise,");
+  });
+
+  test("push-await cap stays below the desktop UI's 10s device-command timeout", () => {
+    // useSendDeviceCommand in letta-cloud rejects after DEFAULT_TIMEOUT_MS
+    // (10s) — the skills install/uninstall UI sends write/delete_memory_file
+    // through it with no override. A cap at or above 10s would turn slow
+    // pushes into spurious client-side failures.
+    const match = handlerSource.match(
+      /const MEMORY_PUSH_AWAIT_CAP_MS = ([\d_]+);/,
+    );
+    expect(match).not.toBeNull();
+    const capMs = Number(match?.[1]?.replaceAll("_", ""));
+    expect(capMs).toBeGreaterThan(0);
+    expect(capMs).toBeLessThan(10_000);
+  });
 });

--- a/src/websocket/listener/commands/memory.ts
+++ b/src/websocket/listener/commands/memory.ts
@@ -797,19 +797,36 @@ export function handleMemoryProtocolCommand(
           ...(memorySyncMode ? { syncMode: memorySyncMode } : {}),
         });
 
-        // ── Push immediately (non-turn writes don't get post-turn sync) ─
+        // ── Push before notifying (non-turn writes don't get post-turn ──
+        // sync). Server-of-record reads (e.g. the agent profile picture
+        // endpoint) are served from the remote memfs, so emitting
+        // memory_updated / the response before the push lands lets the UI
+        // refetch stale bytes and drop its optimistic state (LET-9481).
+        // On push failure, warn and continue — the local commit succeeded
+        // and a later sync will retry.
         if (commitResult.committed && !memorySyncMode) {
           const { syncPendingMemoryCommitsAfterTurn } = await import(
             "@/agent/memory-git"
           );
-          syncPendingMemoryCommitsAfterTurn(parsed.agent_id, {
-            memoryDir: memoryRoot,
-          }).catch((err) => {
+          try {
+            const syncResult = await syncPendingMemoryCommitsAfterTurn(
+              parsed.agent_id,
+              { memoryDir: memoryRoot },
+            );
+            if (
+              syncResult.status === "push_failed" ||
+              syncResult.status === "conflict"
+            ) {
+              console.warn(
+                `[write_memory_file] push failed for ${parsed.agent_id}: ${syncResult.summary}`,
+              );
+            }
+          } catch (err) {
             console.warn(
-              `[write_memory_file] background push failed for ${parsed.agent_id}:`,
+              `[write_memory_file] push failed for ${parsed.agent_id}:`,
               err instanceof Error ? err.message : err,
             );
-          });
+          }
         }
 
         // ── Notify UI so the memory view auto-refreshes ────────────────
@@ -988,19 +1005,34 @@ export function handleMemoryProtocolCommand(
           ...(memorySyncMode ? { syncMode: memorySyncMode } : {}),
         });
 
-        // ── Push immediately (non-turn writes don't get post-turn sync) ─
+        // ── Push before notifying (non-turn deletes don't get post-turn ─
+        // sync). Same ordering requirement as write_memory_file: remote
+        // reads must not race the push (LET-9481). On push failure, warn
+        // and continue — the local commit succeeded and a later sync will
+        // retry.
         if (commitResult.committed && !memorySyncMode) {
           const { syncPendingMemoryCommitsAfterTurn } = await import(
             "@/agent/memory-git"
           );
-          syncPendingMemoryCommitsAfterTurn(parsed.agent_id, {
-            memoryDir: memoryRoot,
-          }).catch((err) => {
+          try {
+            const syncResult = await syncPendingMemoryCommitsAfterTurn(
+              parsed.agent_id,
+              { memoryDir: memoryRoot },
+            );
+            if (
+              syncResult.status === "push_failed" ||
+              syncResult.status === "conflict"
+            ) {
+              console.warn(
+                `[delete_memory_file] push failed for ${parsed.agent_id}: ${syncResult.summary}`,
+              );
+            }
+          } catch (err) {
             console.warn(
-              `[delete_memory_file] background push failed for ${parsed.agent_id}:`,
+              `[delete_memory_file] push failed for ${parsed.agent_id}:`,
               err instanceof Error ? err.message : err,
             );
-          });
+          }
         }
 
         if (commitResult.committed) {

--- a/src/websocket/listener/commands/memory.ts
+++ b/src/websocket/listener/commands/memory.ts
@@ -68,6 +68,71 @@ function trackListenerError(
   });
 }
 
+// Cap on how long a GUI-initiated memory write waits for the remote push
+// before responding. Common-case pushes land well under this, so the client
+// gets a response that is safely ordered after the server-of-record update
+// (LET-9481). Slower pushes fall back to responding immediately while the
+// push finishes in the background — the web UI reconciles that path with its
+// own retry loop. MUST stay below the desktop UI's 10s device-command
+// timeout (useSendDeviceCommand DEFAULT_TIMEOUT_MS), or skill install /
+// uninstall would report spurious timeout failures on slow networks.
+const MEMORY_PUSH_AWAIT_CAP_MS = 8_000;
+
+/**
+ * Push pending memory commits, waiting up to `MEMORY_PUSH_AWAIT_CAP_MS` so
+ * the caller can order its response/notifications after the remote update.
+ * On cap expiry the push keeps running detached (failures are logged).
+ */
+async function awaitMemoryPushBounded(
+  commandName: string,
+  agentId: string,
+  memoryRoot: string,
+): Promise<void> {
+  const { syncPendingMemoryCommitsAfterTurn } = await import(
+    "@/agent/memory-git"
+  );
+  const syncPromise = syncPendingMemoryCommitsAfterTurn(agentId, {
+    memoryDir: memoryRoot,
+  });
+
+  const warnOnFailure = (result: { status: string; summary: string }): void => {
+    if (result.status === "push_failed" || result.status === "conflict") {
+      console.warn(
+        `[${commandName}] push failed for ${agentId}: ${result.summary}`,
+      );
+    }
+  };
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const capPromise = new Promise<"timed_out">((resolve) => {
+    timer = setTimeout(() => resolve("timed_out"), MEMORY_PUSH_AWAIT_CAP_MS);
+  });
+
+  try {
+    const result = await Promise.race([syncPromise, capPromise]);
+    if (result === "timed_out") {
+      console.warn(
+        `[${commandName}] push still in flight after ${MEMORY_PUSH_AWAIT_CAP_MS}ms for ${agentId}; responding now, push continues in background`,
+      );
+      syncPromise.then(warnOnFailure).catch((err) => {
+        console.warn(
+          `[${commandName}] background push failed for ${agentId}:`,
+          err instanceof Error ? err.message : err,
+        );
+      });
+      return;
+    }
+    warnOnFailure(result);
+  } catch (err) {
+    console.warn(
+      `[${commandName}] push failed for ${agentId}:`,
+      err instanceof Error ? err.message : err,
+    );
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 export async function handleListMemoryCommand(
   parsed: ListMemoryCommand,
   socket: WebSocket,
@@ -802,31 +867,16 @@ export function handleMemoryProtocolCommand(
         // endpoint) are served from the remote memfs, so emitting
         // memory_updated / the response before the push lands lets the UI
         // refetch stale bytes and drop its optimistic state (LET-9481).
-        // On push failure, warn and continue — the local commit succeeded
-        // and a later sync will retry.
+        // Bounded: a slow push falls back to responding immediately with
+        // the push continuing in the background. Push failures are
+        // warn-and-continue — the local commit succeeded and a later sync
+        // will retry.
         if (commitResult.committed && !memorySyncMode) {
-          const { syncPendingMemoryCommitsAfterTurn } = await import(
-            "@/agent/memory-git"
+          await awaitMemoryPushBounded(
+            "write_memory_file",
+            parsed.agent_id,
+            memoryRoot,
           );
-          try {
-            const syncResult = await syncPendingMemoryCommitsAfterTurn(
-              parsed.agent_id,
-              { memoryDir: memoryRoot },
-            );
-            if (
-              syncResult.status === "push_failed" ||
-              syncResult.status === "conflict"
-            ) {
-              console.warn(
-                `[write_memory_file] push failed for ${parsed.agent_id}: ${syncResult.summary}`,
-              );
-            }
-          } catch (err) {
-            console.warn(
-              `[write_memory_file] push failed for ${parsed.agent_id}:`,
-              err instanceof Error ? err.message : err,
-            );
-          }
         }
 
         // ── Notify UI so the memory view auto-refreshes ────────────────
@@ -1006,33 +1056,14 @@ export function handleMemoryProtocolCommand(
         });
 
         // ── Push before notifying (non-turn deletes don't get post-turn ─
-        // sync). Same ordering requirement as write_memory_file: remote
-        // reads must not race the push (LET-9481). On push failure, warn
-        // and continue — the local commit succeeded and a later sync will
-        // retry.
+        // sync). Same bounded ordering requirement as write_memory_file:
+        // remote reads must not race the push (LET-9481).
         if (commitResult.committed && !memorySyncMode) {
-          const { syncPendingMemoryCommitsAfterTurn } = await import(
-            "@/agent/memory-git"
+          await awaitMemoryPushBounded(
+            "delete_memory_file",
+            parsed.agent_id,
+            memoryRoot,
           );
-          try {
-            const syncResult = await syncPendingMemoryCommitsAfterTurn(
-              parsed.agent_id,
-              { memoryDir: memoryRoot },
-            );
-            if (
-              syncResult.status === "push_failed" ||
-              syncResult.status === "conflict"
-            ) {
-              console.warn(
-                `[delete_memory_file] push failed for ${parsed.agent_id}: ${syncResult.summary}`,
-              );
-            }
-          } catch (err) {
-            console.warn(
-              `[delete_memory_file] push failed for ${parsed.agent_id}:`,
-              err instanceof Error ? err.message : err,
-            );
-          }
         }
 
         if (commitResult.committed) {


### PR DESCRIPTION
## Summary
- `write_memory_file` / `delete_memory_file` listener handlers committed locally, kicked off the push to the remote memfs **fire-and-forget**, and immediately emitted `memory_updated` + the success response (`committed: true`).
- Server-of-record reads (e.g. cloud-api's agent profile picture endpoint, which serves `profile.png` from the remote memfs) would then be invalidated and refetched by the UI **before the push landed**, returning stale bytes and causing the UI to drop its optimistic state — uploaded profile pictures appeared not to refresh (works fine on local backend, where reads come straight from the local working tree).
- The handlers now await the push before notifying, **bounded by an 8s cap**: the common case (~0.5–3s pushes) responds after the push lands (fully ordered); slower pushes fall back to responding immediately while the push finishes in the background. Push failures remain warn-and-continue (the local commit succeeded and a later sync retries).

## Why the fire-and-forget existed, and why the cap
- #2820 introduced the background push (before it, non-turn writes never pushed at all) and deliberately kept the response non-blocking for responsiveness. But several consumers actually need post-push ordering — the memory editor's save→recompile path even hard-codes a 10s `queueDelayMs` "to allow sync propagation" to paper over this gap.
- An **unbounded** await would regress two latency-sensitive consumers: the desktop skills UI sends `write/delete_memory_file` through `useSendDeviceCommand` (10s timeout, no override) — a slow push (git timeout 60s/attempt × 3 attempts + possible rebase/re-push) would surface spurious install/uninstall failures; and memory editor saves (`isSaving` spinner awaits the response) could spin for minutes on a hung network.
- The 8s cap keeps the response under the 10s client timeout in the worst case, and the capped path degrades to exactly the pre-fix behavior — which the companion UI guard (letta-cloud#12794, reconcile-with-backoff before dropping the optimistic image) covers.

## Tests
- Source-pin contract tests (`memory-write-push-ordering.test.ts`, following the `acting-user-attribution.test.ts` convention): push awaited before `memory_updated`/response in both handlers, no fire-and-forget, bounded race present, and cap pinned below the 10s client timeout.

Fixes LET-9481.

👾 Generated with [Letta Code](https://letta.com)