### PR TITLE
feat(cli): add `letta dream --to` for agentic AGENTS.md maintenance

### DIFF
--- a/src/cli/subcommands/dream-targets.test.ts
+++ b/src/cli/subcommands/dream-targets.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildTargetInstruction,
+  readExistingTarget,
+  resolveDreamTarget,
+  writeTarget,
+} from "./dream-targets";
+
+describe("resolveDreamTarget", () => {
+  test("classifies AGENTS.md / AGENT.md (case-insensitive) as agents-md", () => {
+    expect(resolveDreamTarget("./AGENTS.md")).toEqual({
+      path: "./AGENTS.md",
+      fileName: "AGENTS.md",
+      kind: "agents-md",
+    });
+    expect(resolveDreamTarget("/repo/AGENT.md").kind).toBe("agents-md");
+    expect(resolveDreamTarget("/repo/agents.md").kind).toBe("agents-md");
+  });
+
+  test("classifies other markdown files as generic", () => {
+    expect(resolveDreamTarget("./notes/memory.md")).toEqual({
+      path: "./notes/memory.md",
+      fileName: "memory.md",
+      kind: "generic",
+    });
+  });
+
+  test("rejects an empty path", () => {
+    expect(() => resolveDreamTarget("")).toThrow("expected a file path");
+  });
+});
+
+describe("buildTargetInstruction", () => {
+  test("agents-md includes the standard guidance and the file name", () => {
+    const target = resolveDreamTarget("./AGENTS.md");
+    const out = buildTargetInstruction(target, "# Existing\nrules");
+    expect(out).toContain("$MEMORY_DIR/AGENTS.md");
+    expect(out).toContain("agents.md");
+    expect(out).toContain("COMMANDS");
+    expect(out).toContain("edit in place");
+    expect(out).toContain("# Existing\nrules");
+  });
+
+  test("generic uses generic guidance, not the agents.md standard text", () => {
+    const target = resolveDreamTarget("./memory.md");
+    const out = buildTargetInstruction(target, null);
+    expect(out).toContain("$MEMORY_DIR/memory.md");
+    expect(out).not.toContain("agents.md");
+    expect(out).toContain("does not exist yet — create it");
+  });
+});
+
+describe("readExistingTarget / writeTarget", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "dream-target-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("returns null for a missing file, content when present", async () => {
+    const target = resolveDreamTarget(join(dir, "AGENTS.md"));
+    expect(await readExistingTarget(target)).toBeNull();
+    await writeFile(target.path, "hello");
+    expect(await readExistingTarget(target)).toBe("hello");
+  });
+
+  test("writeTarget creates parent directories", async () => {
+    const target = resolveDreamTarget(join(dir, "nested", "deep", "AGENTS.md"));
+    await writeTarget(target, "# Guide\n");
+    expect(await readExistingTarget(target)).toBe("# Guide\n");
+  });
+});

--- a/src/cli/subcommands/dream-targets.ts
+++ b/src/cli/subcommands/dream-targets.ts
@@ -1,0 +1,125 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { basename, dirname } from "node:path";
+import { getScopedMemoryFilesystemRoot } from "@/agent/memory-filesystem";
+
+/**
+ * A `--to` render target. In this pass, memory is refined in a single
+ * reflection pass (Approach A): the reflection agent maintains the target doc
+ * as an external memory file at `$MEMORY_DIR/<fileName>`, and we copy the
+ * committed result out to `path` afterwards.
+ *
+ * Note: because the doc lives in the memfs, it is also compiled into the
+ * agent's system prompt. That is acceptable for a dedicated dreaming agent
+ * with a small doc; revisit (carve-out, or a separate projection pass) if
+ * maintenance gets tedious or docs grow large/numerous.
+ *
+ * The memfs is the source of truth for the doc: the agent builds on its own
+ * committed copy and we overwrite `path` with the result. This is cycle-free
+ * (updates are gated by the reflection cursor — no new experience, no change)
+ * but does NOT merge out-of-band edits made to `path` between runs. The dream
+ * owns the generated doc; reconciling human edits or unmerged-PR drift is the
+ * caller's responsibility (e.g. handled on the automation side), not here.
+ */
+export interface DreamTarget {
+  /** Absolute or relative filesystem path to write the rendered doc to. */
+  path: string;
+  /** The file name the agent maintains inside `$MEMORY_DIR`. */
+  fileName: string;
+  kind: "agents-md" | "generic";
+}
+
+export function resolveDreamTarget(spec: string): DreamTarget {
+  const fileName = basename(spec);
+  if (!fileName) {
+    throw new Error(`Invalid --to "${spec}": expected a file path`);
+  }
+  const lower = fileName.toLowerCase();
+  const kind =
+    lower === "agents.md" || lower === "agent.md" ? "agents-md" : "generic";
+  return { path: spec, fileName, kind };
+}
+
+const AGENTS_MD_GUIDANCE = [
+  "This file is an AGENTS.md — a README *for coding agents* (the agents.md",
+  "open standard). Maintain it as durable, repo-level guidance an agent needs:",
+  "build/test/setup COMMANDS (put these early), code-style conventions,",
+  "testing instructions, security considerations, and commit/PR rules. Use",
+  "plain Markdown with any headings. Do NOT duplicate human-README content",
+  "(project pitch, quickstart, contribution guide). Prefer editing/merging",
+  "existing sections over appending; remove guidance that new evidence",
+  "contradicts.",
+].join("\n");
+
+const GENERIC_GUIDANCE = [
+  "Maintain this markdown document as durable, forward-looking guidance",
+  "distilled from the conversation(s). Prefer editing/merging existing",
+  "sections over appending; remove content that new evidence contradicts.",
+].join("\n");
+
+/**
+ * Build the instruction fragment that asks the reflection agent to maintain
+ * the target doc as an external memory file, seeded with the current on-disk
+ * content so human edits to the repo copy are respected.
+ */
+export function buildTargetInstruction(
+  target: DreamTarget,
+  existingContent: string | null,
+): string {
+  const guidance =
+    target.kind === "agents-md" ? AGENTS_MD_GUIDANCE : GENERIC_GUIDANCE;
+  const lines = [
+    `In addition to updating memory, maintain an external memory file named "${target.fileName}" at $MEMORY_DIR/${target.fileName}.`,
+    guidance,
+    "",
+    "The authoritative current content of this file is below. Treat it as the",
+    "base to revise: apply only the changes the new experience warrants, using",
+    "your judgment. Often no change is needed — if so, leave it as-is. Write the",
+    `final version to $MEMORY_DIR/${target.fileName} (overwriting), then commit.`,
+    "",
+    `--- current ${target.fileName} (${existingContent === null ? "does not exist yet — create it" : "edit in place"}) ---`,
+    existingContent ?? "(none)",
+    `--- end ${target.fileName} ---`,
+  ];
+  return lines.join("\n");
+}
+
+/** Read the current on-disk target doc, or null if it doesn't exist. */
+export async function readExistingTarget(
+  target: DreamTarget,
+): Promise<string | null> {
+  try {
+    return await readFile(target.path, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the doc the reflection agent committed into the agent's memory, or null
+ * if it wasn't written.
+ */
+export function readTargetFromMemory(
+  agentId: string,
+  target: DreamTarget,
+): string | null {
+  const memoryDir = getScopedMemoryFilesystemRoot(agentId);
+  try {
+    return execFileSync("git", ["show", `HEAD:${target.fileName}`], {
+      cwd: memoryDir,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return null;
+  }
+}
+
+/** Write the rendered doc to the target path, creating parent dirs. */
+export async function writeTarget(
+  target: DreamTarget,
+  content: string,
+): Promise<void> {
+  await mkdir(dirname(target.path), { recursive: true });
+  await writeFile(target.path, content, "utf-8");
+}

--- a/src/cli/subcommands/dream.test.ts
+++ b/src/cli/subcommands/dream.test.ts
@@ -37,6 +37,7 @@ describe("dream subcommand", () => {
       expect(output).toContain("letta dream");
       expect(output).toContain("--memory");
       expect(output).toContain("--from");
+      expect(output).toContain("--to");
       expect(output).toContain("--instruction");
     } finally {
       captured.restore();

--- a/src/cli/subcommands/dream.ts
+++ b/src/cli/subcommands/dream.ts
@@ -1,4 +1,12 @@
 import { parseArgs } from "node:util";
+import {
+  buildTargetInstruction,
+  type DreamTarget,
+  readExistingTarget,
+  readTargetFromMemory,
+  resolveDreamTarget,
+  writeTarget,
+} from "@/cli/subcommands/dream-targets";
 import { settingsManager } from "@/settings-manager";
 
 function printUsage(): void {
@@ -14,7 +22,8 @@ Options:
                               $LETTA_AGENT_ID, then the last-used agent)
   --from <conv-id>            Conversation transcript to reflect on
                               (default: the agent's primary "default" history)
-  --to <spec>                 Render target (reserved; not yet implemented)
+  --to <path>                 Maintain a doc (e.g. ./AGENTS.md) from memory;
+                              the agent edits it in place, using judgment
   --effort <level>            Reflection effort (reserved; not yet implemented)
   --timeout <seconds>         Fail if the reflection pass has not completed
                               in this many seconds (default: 1500)
@@ -86,11 +95,21 @@ export async function runDreamSubcommand(argv: string[]): Promise<number> {
 
   const asJson = Boolean(parsed.values.json);
 
-  // --to and --effort are part of the target/effort interface but are not yet
-  // wired up; accept them so the surface is stable, but say they're inert.
-  if (!asJson && (parsed.values.to || parsed.values.effort)) {
+  let target: DreamTarget | undefined;
+  if (parsed.values.to) {
+    try {
+      target = resolveDreamTarget(parsed.values.to);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`Error: ${message}`);
+      return 1;
+    }
+  }
+
+  // --effort is part of the interface but not yet wired up.
+  if (!asJson && parsed.values.effort) {
     console.error(
-      "Note: --to and --effort are accepted but not yet implemented; ignoring.",
+      "Note: --effort is accepted but not yet implemented; ignoring.",
     );
   }
 
@@ -130,6 +149,18 @@ export async function runDreamSubcommand(argv: string[]): Promise<number> {
 
   const conversationId = parsed.values.from || "default";
 
+  // Approach A: fold the target-doc maintenance directive into the reflection
+  // instruction so the single reflection pass also maintains the doc as an
+  // external memory file. We read it back out of the memfs afterwards.
+  let instruction = parsed.values.instruction;
+  if (target) {
+    const existing = await readExistingTarget(target);
+    const targetInstruction = buildTargetInstruction(target, existing);
+    instruction = instruction
+      ? `${instruction}\n\n${targetInstruction}`
+      : targetInstruction;
+  }
+
   const { launchReflectionSubagent } = await import(
     "@/cli/helpers/reflection-launcher"
   );
@@ -145,7 +176,7 @@ export async function runDreamSubcommand(argv: string[]): Promise<number> {
     memfsEnabled: true,
     triggerSource: "manual",
     description: "Reflect on recent conversations",
-    instruction: parsed.values.instruction,
+    instruction,
     recompileByConversation: new Map(),
     recompileQueuedByConversation: new Set(),
     onCompletionMessage: (message, completionResult) => {
@@ -211,22 +242,47 @@ export async function runDreamSubcommand(argv: string[]): Promise<number> {
     clearTimeout(timeoutHandle);
   }
 
+  // On success, copy the doc the reflection agent committed into memory out to
+  // the target path. If the agent chose not to write it, leave the target
+  // untouched.
+  let targetWritten = false;
+  let targetError: string | undefined;
+  if (target && outcome.success) {
+    try {
+      const rendered = readTargetFromMemory(agentId, target);
+      if (rendered !== null) {
+        await writeTarget(target, rendered);
+        targetWritten = true;
+      }
+    } catch (error) {
+      targetError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
   if (asJson) {
     emitJson({
       launched: true,
-      success: outcome.success,
+      success: outcome.success && !targetError,
       message: outcome.message,
       ...(outcome.error ? { error: outcome.error } : {}),
       ...(timedOut ? { timedOut: true } : {}),
       agentId,
       conversationId,
       transcriptPath: result.payloadPath,
+      ...(target ? { targetPath: target.path, targetWritten } : {}),
+      ...(targetError ? { targetError } : {}),
     });
   } else if (outcome.success) {
     console.log(outcome.message);
+    if (targetWritten) {
+      console.log(`Wrote ${target?.path}`);
+    }
+    if (targetError) {
+      console.error(`Failed to write --to target: ${targetError}`);
+    }
   } else {
     console.error(outcome.message);
   }
 
-  return outcome.success ? 0 : 1;
+  return outcome.success && !targetError ? 0 : 1;
 }


### PR DESCRIPTION
## Summary
Turns `--to <path>` from a reserved/inert flag into a working feature: `letta dream` reflects as usual and, in the **same pass**, has the agent maintain a doc (e.g. `AGENTS.md`) as an external memory file, then copies the committed result out to the target path.

- `--to ./AGENTS.md` — the doc's current content is folded into the reflection instruction with **agents.md-standard** guidance (commands early, conventions/testing/security/PR rules, don't duplicate README, edit-don't-append). Other `*.md` files get a generic "maintain this doc" fallback.
- The agent **edits the doc in place using judgment** — often a no-op. Result is read back out of the memfs and written to `--to`.
- `--json` reports `targetPath` / `targetWritten`.

## Approach
Approach A: a single reflection pass maintains the doc as a file in the agent's memfs (no separate projection agent, no launcher changes — the directive rides the existing `instruction` channel). Contained entirely to the `dream` subcommand.

## Source-of-truth boundary (intentional)
The **memfs is the source of truth** for the doc. This is **cycle-free** — doc updates are gated by the reflection cursor, so no new experience → no change (verified). The tradeoff: **out-of-band edits to the target between runs are not merged.** The dream owns the generated doc; reconciling human edits / unmerged-PR drift is the **consumer's responsibility (handled on the automation side)**, not in this command. Proper 3-way merge is deferred.

Also: because the doc lives in the memfs it's compiled into the agent's system prompt — fine for a dedicated dreaming agent with a small doc; noted for revisit if docs grow large/numerous.

## Verified (live, Haiku, local backend)
- create AGENTS.md from scratch → clean, conventions-grounded, no persona leakage
- later run with new experience → preserves prior sections **and** merges the new convention
- no new experience → `no_payload`, doc byte-identical (no-op)

## Scope / non-goals
AGENTS.md/AGENT.md (+ generic `.md` fallback), single `--to`. Not included: `--from openhands` (separate PR), `--memory repo`, `--effort` wiring, multiple/parallel `--to`, non-AGENTS.md instruction sets.

## Files
- `dream-targets.ts` (new) — target resolution, instruction building, memfs read-back, write-out
- `dream-targets.test.ts` (new) — resolution + instruction + fs round-trip
- `dream.ts` — wiring; `dream.test.ts` — help assertion