### PR TITLE
feat(cli): add `letta dream --from` external sources via adapter framework

### DIFF
--- a/src/cli/helpers/reflection-transcript.ts
+++ b/src/cli/helpers/reflection-transcript.ts
@@ -1054,6 +1054,108 @@ export async function appendTranscriptDeltaJsonl(
 }
 
 /**
+ * A transcript entry supplied by an external source adapter (e.g. converted
+ * OpenHands events). Mirrors the on-disk TranscriptEntry shape, but
+ * captured_at may be omitted (stamped at append time).
+ */
+export type ExternalTranscriptEntry =
+  | {
+      kind: "user" | "assistant" | "reasoning" | "error";
+      text: string;
+      captured_at?: string;
+      source_message_id?: string;
+    }
+  | {
+      kind: "tool_call";
+      name?: string;
+      argsText?: string;
+      resultText?: string;
+      resultOk?: boolean;
+      captured_at?: string;
+      source_message_id?: string;
+    };
+
+function externalToTranscriptEntry(
+  entry: ExternalTranscriptEntry,
+  fallbackCapturedAt: string,
+): TranscriptEntry | null {
+  const capturedAt = normalizeString(entry.captured_at) ?? fallbackCapturedAt;
+  if (entry.kind === "tool_call") {
+    return {
+      kind: "tool_call",
+      name: entry.name,
+      argsText: entry.argsText,
+      resultText: entry.resultText,
+      resultOk: entry.resultOk,
+      captured_at: capturedAt,
+      source_message_id: entry.source_message_id,
+    };
+  }
+  if (typeof entry.text !== "string" || entry.text.length === 0) {
+    return null;
+  }
+  return {
+    kind: entry.kind,
+    text: entry.text,
+    captured_at: capturedAt,
+    source_message_id: entry.source_message_id,
+  };
+}
+
+/**
+ * Append externally-sourced transcript entries (already in transcript shape)
+ * for later processing by a reflection pass. Entries whose source_message_id
+ * already exists in the transcript are skipped, so repeated ingestion of an
+ * overlapping event window is idempotent.
+ */
+export async function appendExternalTranscriptEntries(
+  agentId: string,
+  conversationId: string,
+  entries: ExternalTranscriptEntry[],
+): Promise<{ appended: number; skipped: number }> {
+  return withStateLock(agentId, conversationId, async () => {
+    const paths = getReflectionTranscriptPaths(agentId, conversationId);
+    await ensurePaths(paths);
+    const state = await readState(paths);
+
+    const existingIds = new Set(
+      parseTranscriptRows(await readTranscriptLines(paths))
+        .map((row) => row.entry.source_message_id)
+        .filter((id): id is string => typeof id === "string" && id.length > 0),
+    );
+
+    const fallbackCapturedAt = new Date().toISOString();
+    const fresh: TranscriptEntry[] = [];
+    let skipped = 0;
+    for (const external of entries) {
+      const entry = externalToTranscriptEntry(external, fallbackCapturedAt);
+      if (!entry) {
+        skipped += 1;
+        continue;
+      }
+      const id = entry.source_message_id;
+      if (id && existingIds.has(id)) {
+        skipped += 1;
+        continue;
+      }
+      if (id) {
+        existingIds.add(id);
+      }
+      fresh.push(entry);
+    }
+    if (fresh.length === 0) {
+      return { appended: 0, skipped };
+    }
+
+    const payload = fresh.map((entry) => JSON.stringify(entry)).join("\n");
+    await appendFile(paths.transcriptPath, `${payload}\n`, "utf-8");
+    state.total_completed_steps += countAssistantRows(fresh);
+    await writeState(paths, state);
+    return { appended: fresh.length, skipped };
+  });
+}
+
+/**
  * Strip dynamic / noisy sections from a system prompt so the reflection agent
  * sees only the core behavioural instructions.
  *

--- a/src/cli/subcommands/dream-sources/index.test.ts
+++ b/src/cli/subcommands/dream-sources/index.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { TRANSCRIPT_ROOT_ENV } from "@/utils/transcript-paths";
+import {
+  conversationIdForSource,
+  parseFromSource,
+  stageFromSource,
+} from "./index";
+
+describe("parseFromSource", () => {
+  test("returns null for a bare conversation id", () => {
+    expect(parseFromSource("conv-123")).toBeNull();
+    expect(parseFromSource("default")).toBeNull();
+  });
+
+  test("resolves a registered typed source", () => {
+    const parsed = parseFromSource("openhands:/tmp/events.json");
+    expect(parsed?.adapter.type).toBe("openhands");
+    expect(parsed?.locator).toBe("/tmp/events.json");
+  });
+
+  test("errors on an unknown source type", () => {
+    expect(() => parseFromSource("github:letta-ai/x")).toThrow(
+      'Unknown source type "github"',
+    );
+  });
+
+  test("errors on a typed source missing a locator", () => {
+    expect(() => parseFromSource("openhands:")).toThrow("missing path");
+  });
+});
+
+describe("conversationIdForSource", () => {
+  test("is stable for the same spec and differs across specs", () => {
+    const a = conversationIdForSource(parseFromSource("openhands:/a.json")!);
+    const a2 = conversationIdForSource(parseFromSource("openhands:/a.json")!);
+    const b = conversationIdForSource(parseFromSource("openhands:/b.json")!);
+    expect(a).toBe(a2);
+    expect(a).not.toBe(b);
+    expect(a.startsWith("from-openhands-")).toBe(true);
+  });
+});
+
+describe("stageFromSource", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "dream-from-test-"));
+    process.env[TRANSCRIPT_ROOT_ENV] = root;
+  });
+
+  afterEach(async () => {
+    delete process.env[TRANSCRIPT_ROOT_ENV];
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("stages openhands events and is idempotent on re-ingestion", async () => {
+    const eventsPath = join(root, "events.json");
+    await writeFile(
+      eventsPath,
+      JSON.stringify({
+        items: [
+          {
+            kind: "MessageEvent",
+            id: "e1",
+            timestamp: "2026-07-04T10:00:00.000000",
+            source: "user",
+            llm_message: {
+              role: "user",
+              content: [{ type: "text", text: "hi" }],
+            },
+          },
+          {
+            kind: "MessageEvent",
+            id: "e2",
+            timestamp: "2026-07-04T10:00:01.000000",
+            source: "agent",
+            llm_message: {
+              role: "assistant",
+              content: [{ type: "text", text: "ok" }],
+            },
+          },
+        ],
+      }),
+    );
+    const parsed = parseFromSource(`openhands:${eventsPath}`)!;
+
+    const first = await stageFromSource("agent-1", parsed);
+    expect(first.appended).toBe(2);
+    expect(first.skipped).toBe(0);
+    expect(first.conversationId).toBe(conversationIdForSource(parsed));
+
+    const second = await stageFromSource("agent-1", parsed);
+    expect(second.appended).toBe(0);
+    expect(second.skipped).toBe(2);
+
+    const transcript = await readFile(
+      join(root, "agent-1", first.conversationId, "transcript.jsonl"),
+      "utf-8",
+    );
+    const rows = transcript
+      .split("\n")
+      .filter((line) => line.trim().length > 0)
+      .map((line) => JSON.parse(line));
+    expect(rows).toHaveLength(2);
+    expect(rows[0].source_message_id).toBe("e1");
+  });
+
+  test("stages generic transcript JSONL", async () => {
+    const rowsPath = join(root, "rows.jsonl");
+    await writeFile(
+      rowsPath,
+      `${JSON.stringify({ kind: "user", text: "hello", source_message_id: "r1" })}\n`,
+    );
+    const parsed = parseFromSource(`transcript:${rowsPath}`)!;
+    const result = await stageFromSource("agent-1", parsed);
+    expect(result.appended).toBe(1);
+  });
+});

--- a/src/cli/subcommands/dream-sources/index.ts
+++ b/src/cli/subcommands/dream-sources/index.ts
@@ -1,0 +1,80 @@
+import { createHash } from "node:crypto";
+import { appendExternalTranscriptEntries } from "@/cli/helpers/reflection-transcript";
+import { openHandsAdapter } from "./openhands";
+import { transcriptAdapter } from "./transcript";
+import type { SourceAdapter } from "./types";
+
+export type { SourceAdapter } from "./types";
+
+/**
+ * Registered source adapters, keyed by the `<type>` in `--from <type>:<path>`.
+ * Add a new source type by importing its adapter and adding one entry here.
+ */
+const ADAPTERS: Record<string, SourceAdapter> = {
+  openhands: openHandsAdapter,
+  transcript: transcriptAdapter,
+};
+
+export interface ParsedSource {
+  adapter: SourceAdapter;
+  locator: string;
+}
+
+/**
+ * Parse a `--from` value. Returns the adapter + locator for a typed source
+ * (`<type>:<path>`), or null for a bare conversation id (the agent's own
+ * transcript). Throws on a typed value whose type is not registered.
+ */
+export function parseFromSource(spec: string): ParsedSource | null {
+  const sep = spec.indexOf(":");
+  if (sep < 0) return null; // bare conversation id → the agent's own transcript
+  const type = spec.slice(0, sep);
+  const locator = spec.slice(sep + 1);
+  const adapter = ADAPTERS[type];
+  if (!adapter) {
+    throw new Error(
+      `Unknown source type "${type}". Supported: ${Object.keys(ADAPTERS).join(", ")}`,
+    );
+  }
+  if (!locator) {
+    throw new Error(`Invalid --from "${spec}": missing path after "${type}:"`);
+  }
+  return { adapter, locator };
+}
+
+/**
+ * A stable synthetic conversation id for a source spec, so repeated runs of
+ * the same source accumulate into (and dedupe against) the same transcript.
+ */
+export function conversationIdForSource(parsed: ParsedSource): string {
+  const hash = createHash("sha1")
+    .update(`${parsed.adapter.type}:${parsed.locator}`)
+    .digest("hex")
+    .slice(0, 12);
+  return `from-${parsed.adapter.type}-${hash}`;
+}
+
+export interface StageFromSourceResult {
+  conversationId: string;
+  appended: number;
+  skipped: number;
+}
+
+/**
+ * Convert a typed `--from` source and stage it into the reflection transcript.
+ * Returns the synthetic conversation id the entries were staged under (which
+ * the caller reflects on) plus append/skip counts.
+ */
+export async function stageFromSource(
+  agentId: string,
+  parsed: ParsedSource,
+): Promise<StageFromSourceResult> {
+  const conversationId = conversationIdForSource(parsed);
+  const entries = await parsed.adapter.convert(parsed.locator);
+  const { appended, skipped } = await appendExternalTranscriptEntries(
+    agentId,
+    conversationId,
+    entries,
+  );
+  return { conversationId, appended, skipped };
+}

--- a/src/cli/subcommands/dream-sources/openhands.test.ts
+++ b/src/cli/subcommands/dream-sources/openhands.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+import { convertOpenHandsEvents } from "./openhands";
+
+const USER_MESSAGE_EVENT = {
+  kind: "MessageEvent",
+  id: "evt-user-1",
+  timestamp: "2026-07-04T09:15:23.123456",
+  source: "user",
+  llm_message: {
+    role: "user",
+    content: [{ type: "text", text: "Fix the failing test" }],
+  },
+};
+
+const AGENT_MESSAGE_EVENT = {
+  kind: "MessageEvent",
+  id: "evt-agent-1",
+  timestamp: "2026-07-04T09:16:00.000000",
+  source: "agent",
+  llm_message: {
+    role: "assistant",
+    content: [
+      { type: "text", text: "Done — the test " },
+      { type: "text", text: "passes now." },
+    ],
+  },
+};
+
+const ACTION_EVENT = {
+  kind: "ActionEvent",
+  id: "evt-action-1",
+  timestamp: "2026-07-04T09:15:30.001122",
+  source: "agent",
+  thought: [{ type: "text", text: "I'll run the tests first." }],
+  tool_name: "terminal",
+  tool_call_id: "toolu_01ABC",
+  tool_call: {
+    id: "toolu_01ABC",
+    name: "terminal",
+    arguments: '{"command": "bun test"}',
+  },
+  action: { kind: "TerminalAction", command: "bun test" },
+};
+
+const OBSERVATION_EVENT = {
+  kind: "ObservationEvent",
+  id: "evt-obs-1",
+  timestamp: "2026-07-04T09:15:35.445566",
+  source: "environment",
+  tool_name: "terminal",
+  tool_call_id: "toolu_01ABC",
+  action_id: "evt-action-1",
+  observation: {
+    kind: "TerminalObservation",
+    content: [{ type: "text", text: "1 pass, 0 fail" }],
+    is_error: false,
+  },
+};
+
+describe("convertOpenHandsEvents", () => {
+  test("converts user and agent messages", () => {
+    const entries = convertOpenHandsEvents([
+      USER_MESSAGE_EVENT,
+      AGENT_MESSAGE_EVENT,
+    ]);
+    expect(entries).toEqual([
+      {
+        kind: "user",
+        text: "Fix the failing test",
+        captured_at: "2026-07-04T09:15:23.123456Z",
+        source_message_id: "evt-user-1",
+      },
+      {
+        kind: "assistant",
+        text: "Done — the test passes now.",
+        captured_at: "2026-07-04T09:16:00.000000Z",
+        source_message_id: "evt-agent-1",
+      },
+    ]);
+  });
+
+  test("preserves timestamps that already carry a timezone", () => {
+    const entries = convertOpenHandsEvents([
+      { ...USER_MESSAGE_EVENT, timestamp: "2026-07-04T09:15:23+02:00" },
+    ]);
+    expect(entries[0]?.captured_at).toBe("2026-07-04T09:15:23+02:00");
+  });
+
+  test("pairs actions with observations and emits thought as assistant", () => {
+    const entries = convertOpenHandsEvents([ACTION_EVENT, OBSERVATION_EVENT]);
+    expect(entries).toEqual([
+      {
+        kind: "assistant",
+        text: "I'll run the tests first.",
+        captured_at: "2026-07-04T09:15:30.001122Z",
+        source_message_id: "evt-action-1:thought",
+      },
+      {
+        kind: "tool_call",
+        name: "terminal",
+        argsText: '{"command": "bun test"}',
+        resultText: "1 pass, 0 fail",
+        resultOk: true,
+        captured_at: "2026-07-04T09:15:30.001122Z",
+        source_message_id: "evt-action-1",
+      },
+    ]);
+  });
+
+  test("maps agent errors to failed tool results", () => {
+    const entries = convertOpenHandsEvents([
+      { ...ACTION_EVENT, thought: [] },
+      {
+        kind: "AgentErrorEvent",
+        id: "evt-err-1",
+        timestamp: "2026-07-04T09:15:36.000000",
+        source: "agent",
+        tool_call_id: "toolu_01ABC",
+        action_id: "evt-action-1",
+        error: "command not found",
+      },
+    ]);
+    expect(entries).toEqual([
+      {
+        kind: "tool_call",
+        name: "terminal",
+        argsText: '{"command": "bun test"}',
+        resultText: "command not found",
+        resultOk: false,
+        captured_at: "2026-07-04T09:15:30.001122Z",
+        source_message_id: "evt-action-1",
+      },
+    ]);
+  });
+
+  test("skips non-conversational events and empty/environment messages", () => {
+    const entries = convertOpenHandsEvents([
+      { kind: "SystemPromptEvent", id: "evt-sys-1", source: "agent" },
+      { kind: "ConversationStateUpdateEvent", id: "evt-state-1" },
+      {
+        ...USER_MESSAGE_EVENT,
+        id: "evt-empty",
+        llm_message: { role: "user", content: [] },
+      },
+      { ...USER_MESSAGE_EVENT, id: "evt-env", source: "environment" },
+    ]);
+    expect(entries).toEqual([]);
+  });
+});

--- a/src/cli/subcommands/dream-sources/openhands.test.ts
+++ b/src/cli/subcommands/dream-sources/openhands.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, test } from "bun:test";
-import { convertOpenHandsEvents } from "./openhands";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { convertOpenHandsEvents, openHandsAdapter } from "./openhands";
 
 const USER_MESSAGE_EVENT = {
   kind: "MessageEvent",
@@ -145,5 +148,66 @@ describe("convertOpenHandsEvents", () => {
       { ...USER_MESSAGE_EVENT, id: "evt-env", source: "environment" },
     ]);
     expect(entries).toEqual([]);
+  });
+});
+
+describe("openHandsAdapter.convert", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "oh-conv-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  async function writeEvent(eventsDir: string, seq: string, event: unknown) {
+    const id = (event as { id: string }).id;
+    await writeFile(
+      join(eventsDir, `event-${seq}-${id}.json`),
+      JSON.stringify(event),
+    );
+  }
+
+  test("reads a conversation directory with an events/ subdir, in sequence order", async () => {
+    const events = join(dir, "events");
+    await mkdir(events, { recursive: true });
+    // Write out of filesystem order to prove sequence sorting.
+    await writeEvent(events, "00001", USER_MESSAGE_EVENT);
+    await writeEvent(events, "00000", {
+      kind: "SystemPromptEvent",
+      id: "evt-sys",
+      source: "agent",
+    });
+    await writeEvent(events, "00002", AGENT_MESSAGE_EVENT);
+    // Non-event files must be ignored.
+    await writeFile(join(dir, "meta.json"), "{}");
+
+    const entries = await openHandsAdapter.convert(dir);
+    expect(entries.map((e) => e.source_message_id)).toEqual([
+      "evt-user-1",
+      "evt-agent-1",
+    ]);
+  });
+
+  test("accepts the events/ directory directly", async () => {
+    await writeEvent(dir, "00000", USER_MESSAGE_EVENT);
+    const entries = await openHandsAdapter.convert(dir);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.source_message_id).toBe("evt-user-1");
+  });
+
+  test("errors on a directory with no event files", async () => {
+    await expect(openHandsAdapter.convert(dir)).rejects.toThrow(
+      "No OpenHands event files",
+    );
+  });
+
+  test("still reads a single JSON events file", async () => {
+    const file = join(dir, "events.json");
+    await writeFile(file, JSON.stringify({ items: [USER_MESSAGE_EVENT] }));
+    const entries = await openHandsAdapter.convert(file);
+    expect(entries).toHaveLength(1);
   });
 });

--- a/src/cli/subcommands/dream-sources/openhands.ts
+++ b/src/cli/subcommands/dream-sources/openhands.ts
@@ -1,0 +1,184 @@
+import { readFile } from "node:fs/promises";
+import type { ExternalTranscriptEntry } from "@/cli/helpers/reflection-transcript";
+import { safeJsonParseOr } from "@/cli/helpers/safe-json-parse";
+import type { SourceAdapter } from "./types";
+
+/** Maximum characters kept for a tool result when converting external traces. */
+const RESULT_TEXT_TRUNCATE_LIMIT = 4000;
+
+interface OpenHandsTextContent {
+  type?: string;
+  text?: string;
+}
+
+interface OpenHandsEvent {
+  kind?: string;
+  id?: string;
+  timestamp?: string;
+  source?: string;
+  llm_message?: {
+    role?: string;
+    content?: OpenHandsTextContent[];
+  };
+  // ActionEvent fields
+  thought?: OpenHandsTextContent[];
+  action?: Record<string, unknown> | null;
+  tool_name?: string;
+  tool_call_id?: string;
+  tool_call?: { arguments?: string } | null;
+  // ObservationEvent / result fields
+  action_id?: string;
+  observation?: {
+    content?: OpenHandsTextContent[];
+    is_error?: boolean;
+  } | null;
+  error?: string;
+  rejection_reason?: string;
+}
+
+function joinTextContent(content: OpenHandsTextContent[] | undefined): string {
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((item) => item?.type === "text" && typeof item.text === "string")
+    .map((item) => item.text)
+    .join("");
+}
+
+/**
+ * OpenHands timestamps are naive local datetimes (no timezone suffix) in most
+ * deployments. Treat suffix-less timestamps as UTC so ordering is stable.
+ */
+function normalizeOpenHandsTimestamp(value: string | undefined): string {
+  if (!value) return new Date().toISOString();
+  if (/(Z|[+-]\d{2}:?\d{2})$/.test(value)) return value;
+  return `${value}Z`;
+}
+
+function truncateResultText(text: string): string {
+  if (text.length <= RESULT_TEXT_TRUNCATE_LIMIT) return text;
+  return `${text.slice(0, RESULT_TEXT_TRUNCATE_LIMIT)}… [truncated]`;
+}
+
+interface ToolResult {
+  resultText: string;
+  resultOk: boolean;
+}
+
+function extractToolResult(event: OpenHandsEvent): ToolResult | null {
+  switch (event.kind) {
+    case "ObservationEvent":
+      return {
+        resultText: joinTextContent(event.observation?.content),
+        resultOk: event.observation?.is_error !== true,
+      };
+    case "AgentErrorEvent":
+      return { resultText: event.error ?? "", resultOk: false };
+    case "UserRejectObservation":
+      return { resultText: event.rejection_reason ?? "", resultOk: false };
+    default:
+      return null;
+  }
+}
+
+function actionArgsText(event: OpenHandsEvent): string | undefined {
+  const raw = event.tool_call?.arguments;
+  if (typeof raw === "string" && raw.length > 0) return raw;
+  if (event.action && typeof event.action === "object") {
+    const { kind: _kind, ...rest } = event.action;
+    return JSON.stringify(rest);
+  }
+  return undefined;
+}
+
+/**
+ * Convert OpenHands conversation events (from
+ * GET /api/v1/conversation/{id}/events/search) into transcript entries the
+ * reflection machinery can process. Non-conversational events (system
+ * prompts, state updates, condensation, streaming deltas) are skipped.
+ */
+export function convertOpenHandsEvents(
+  events: OpenHandsEvent[],
+): ExternalTranscriptEntry[] {
+  const resultsByToolCallId = new Map<string, ToolResult>();
+  const resultsByActionId = new Map<string, ToolResult>();
+  for (const event of events) {
+    const result = extractToolResult(event);
+    if (!result) continue;
+    if (event.tool_call_id) resultsByToolCallId.set(event.tool_call_id, result);
+    if (event.action_id) resultsByActionId.set(event.action_id, result);
+  }
+
+  const entries: ExternalTranscriptEntry[] = [];
+  for (const event of events) {
+    if (!event.id) continue;
+    const capturedAt = normalizeOpenHandsTimestamp(event.timestamp);
+
+    if (event.kind === "MessageEvent") {
+      if (event.source !== "user" && event.source !== "agent") continue;
+      const text = joinTextContent(event.llm_message?.content);
+      if (!text) continue;
+      entries.push({
+        kind: event.source === "user" ? "user" : "assistant",
+        text,
+        captured_at: capturedAt,
+        source_message_id: event.id,
+      });
+      continue;
+    }
+
+    if (event.kind === "ActionEvent") {
+      // Batched tool-call turns produce no MessageEvent; the assistant text
+      // rides on the first ActionEvent's `thought`.
+      const thought = joinTextContent(event.thought);
+      if (thought) {
+        entries.push({
+          kind: "assistant",
+          text: thought,
+          captured_at: capturedAt,
+          source_message_id: `${event.id}:thought`,
+        });
+      }
+      const result =
+        (event.tool_call_id
+          ? resultsByToolCallId.get(event.tool_call_id)
+          : undefined) ?? resultsByActionId.get(event.id);
+      entries.push({
+        kind: "tool_call",
+        name: event.tool_name,
+        argsText: actionArgsText(event),
+        resultText: result ? truncateResultText(result.resultText) : undefined,
+        resultOk: result?.resultOk,
+        captured_at: capturedAt,
+        source_message_id: event.id,
+      });
+    }
+  }
+  return entries;
+}
+
+function parseOpenHandsEventsFile(raw: string, path: string): OpenHandsEvent[] {
+  const parsed = safeJsonParseOr<unknown>(raw, null);
+  if (Array.isArray(parsed)) return parsed as OpenHandsEvent[];
+  if (
+    parsed &&
+    typeof parsed === "object" &&
+    Array.isArray((parsed as { items?: unknown[] }).items)
+  ) {
+    return (parsed as { items: OpenHandsEvent[] }).items;
+  }
+  throw new Error(
+    `Could not parse ${path}: expected a JSON array of events or {"items": [...]}`,
+  );
+}
+
+/**
+ * Reads a local OpenHands events JSON file (an array, or the
+ * `{ items: [...] }` envelope returned by the events API) and converts it.
+ */
+export const openHandsAdapter: SourceAdapter = {
+  type: "openhands",
+  async convert(locator: string): Promise<ExternalTranscriptEntry[]> {
+    const raw = await readFile(locator, "utf-8");
+    return convertOpenHandsEvents(parseOpenHandsEventsFile(raw, locator));
+  },
+};

--- a/src/cli/subcommands/dream-sources/openhands.ts
+++ b/src/cli/subcommands/dream-sources/openhands.ts
@@ -1,4 +1,5 @@
-import { readFile } from "node:fs/promises";
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
 import type { ExternalTranscriptEntry } from "@/cli/helpers/reflection-transcript";
 import { safeJsonParseOr } from "@/cli/helpers/safe-json-parse";
 import type { SourceAdapter } from "./types";
@@ -171,13 +172,65 @@ function parseOpenHandsEventsFile(raw: string, path: string): OpenHandsEvent[] {
   );
 }
 
+/** The `<seq>` in `event-<seq>-<uuid>.json` — the durable ordering key. */
+function eventSequence(fileName: string): number {
+  const digits = fileName.match(/^event-(\d+)-/)?.[1];
+  return digits ? Number.parseInt(digits, 10) : 0;
+}
+
 /**
- * Reads a local OpenHands events JSON file (an array, or the
- * `{ items: [...] }` envelope returned by the events API) and converts it.
+ * Read an OpenHands conversation directory, where each event is its own
+ * `event-<seq>-<uuid>.json` file. Accepts either the conversation directory
+ * (with an `events/` subdir) or the `events/` directory itself. Files are
+ * ordered by sequence prefix. (Large tool outputs offloaded to
+ * `observations/` are not needed — tool results are not surfaced to the
+ * reflection payload.)
+ */
+async function readOpenHandsEventDir(dir: string): Promise<OpenHandsEvent[]> {
+  let eventsDir = dir;
+  try {
+    const nested = join(dir, "events");
+    if ((await stat(nested)).isDirectory()) {
+      eventsDir = nested;
+    }
+  } catch {
+    // No events/ subdir — treat `dir` itself as the events directory.
+  }
+
+  const fileNames = (await readdir(eventsDir))
+    .filter((name) => /^event-\d+-.*\.json$/.test(name))
+    .sort((a, b) => eventSequence(a) - eventSequence(b));
+  if (fileNames.length === 0) {
+    throw new Error(
+      `No OpenHands event files (event-*.json) found in ${eventsDir}`,
+    );
+  }
+
+  const events: OpenHandsEvent[] = [];
+  for (const name of fileNames) {
+    const raw = await readFile(join(eventsDir, name), "utf-8");
+    const event = safeJsonParseOr<OpenHandsEvent | null>(raw, null);
+    if (event && typeof event === "object") {
+      events.push(event);
+    }
+  }
+  return events;
+}
+
+/**
+ * Reads local OpenHands events and converts them. The locator may be:
+ *  - a conversation directory (`.../dev_conversations/<id>/`) or its
+ *    `events/` subdir — one `event-<seq>-<uuid>.json` file per event; or
+ *  - a single JSON file (an array, or the `{ items: [...] }` events-API
+ *    envelope).
  */
 export const openHandsAdapter: SourceAdapter = {
   type: "openhands",
   async convert(locator: string): Promise<ExternalTranscriptEntry[]> {
+    const info = await stat(locator).catch(() => null);
+    if (info?.isDirectory()) {
+      return convertOpenHandsEvents(await readOpenHandsEventDir(locator));
+    }
     const raw = await readFile(locator, "utf-8");
     return convertOpenHandsEvents(parseOpenHandsEventsFile(raw, locator));
   },

--- a/src/cli/subcommands/dream-sources/transcript.ts
+++ b/src/cli/subcommands/dream-sources/transcript.ts
@@ -1,0 +1,31 @@
+import { readFile } from "node:fs/promises";
+import type { ExternalTranscriptEntry } from "@/cli/helpers/reflection-transcript";
+import { safeJsonParseOr } from "@/cli/helpers/safe-json-parse";
+import type { SourceAdapter } from "./types";
+
+/**
+ * Reference adapter: a passthrough of transcript-entry JSONL (one
+ * ExternalTranscriptEntry object per line). This is the simplest adapter and
+ * the template to copy when adding a new source type — a new adapter only has
+ * to map its own format into `ExternalTranscriptEntry[]`.
+ */
+export const transcriptAdapter: SourceAdapter = {
+  type: "transcript",
+  async convert(locator: string): Promise<ExternalTranscriptEntry[]> {
+    const raw = await readFile(locator, "utf-8");
+    const entries: ExternalTranscriptEntry[] = [];
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const entry = safeJsonParseOr<ExternalTranscriptEntry | null>(
+        trimmed,
+        null,
+      );
+      if (!entry || typeof entry !== "object" || !("kind" in entry)) {
+        throw new Error(`Could not parse a JSONL transcript row in ${locator}`);
+      }
+      entries.push(entry);
+    }
+    return entries;
+  },
+};

--- a/src/cli/subcommands/dream-sources/types.ts
+++ b/src/cli/subcommands/dream-sources/types.ts
@@ -1,0 +1,17 @@
+import type { ExternalTranscriptEntry } from "@/cli/helpers/reflection-transcript";
+
+/**
+ * A source adapter converts an external trace format (identified by `type` in
+ * `--from <type>:<locator>`) into transcript entries the reflection machinery
+ * can process.
+ *
+ * To add a new source type (e.g. `claude`, `codex`): create a sibling file
+ * exporting a `SourceAdapter` whose `convert(locator)` maps that tool's format
+ * into `ExternalTranscriptEntry[]`, then register it in `ADAPTERS` (./index).
+ */
+export interface SourceAdapter {
+  /** The scheme used in `--from <type>:<locator>`. */
+  type: string;
+  /** Read the located source and convert it into transcript entries. */
+  convert(locator: string): Promise<ExternalTranscriptEntry[]>;
+}

--- a/src/cli/subcommands/dream.ts
+++ b/src/cli/subcommands/dream.ts
@@ -1,5 +1,10 @@
 import { parseArgs } from "node:util";
 import {
+  type ParsedSource,
+  parseFromSource,
+  stageFromSource,
+} from "@/cli/subcommands/dream-sources";
+import {
   buildTargetInstruction,
   type DreamTarget,
   readExistingTarget,
@@ -20,8 +25,10 @@ Run a memory reflection pass for an agent and wait for it to finish.
 Options:
   --memory <agent-id>         Agent whose memory to refine (default:
                               $LETTA_AGENT_ID, then the last-used agent)
-  --from <conv-id>            Conversation transcript to reflect on
-                              (default: the agent's primary "default" history)
+  --from <conv-id|type:path>  What to reflect on: a conversation id (default:
+                              the agent's primary "default" history), or an
+                              external source, e.g. openhands:./events.json
+                              or transcript:./rows.jsonl
   --to <path>                 Maintain a doc (e.g. ./AGENTS.md) from memory;
                               the agent edits it in place, using judgment
   --effort <level>            Reflection effort (reserved; not yet implemented)
@@ -106,6 +113,20 @@ export async function runDreamSubcommand(argv: string[]): Promise<number> {
     }
   }
 
+  // A typed --from (e.g. openhands:./events.json) is an external source; a bare
+  // value is one of the agent's own conversations. Resolve the source now so an
+  // unknown type errors early.
+  let source: ParsedSource | null = null;
+  if (parsed.values.from) {
+    try {
+      source = parseFromSource(parsed.values.from);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`Error: ${message}`);
+      return 1;
+    }
+  }
+
   // --effort is part of the interface but not yet wired up.
   if (!asJson && parsed.values.effort) {
     console.error(
@@ -147,7 +168,34 @@ export async function runDreamSubcommand(argv: string[]): Promise<number> {
     return 1;
   }
 
-  const conversationId = parsed.values.from || "default";
+  // For an external source, stage its converted entries into a synthetic
+  // conversation transcript and reflect on that; the post-reflection recompile
+  // targets the agent's real "default" history (the synthetic conversation is
+  // not a backend conversation). A bare --from reflects on that conversation.
+  let conversationId: string;
+  let stagedEntries: number | undefined;
+  if (source) {
+    try {
+      const staged = await stageFromSource(agentId, source);
+      conversationId = staged.conversationId;
+      stagedEntries = staged.appended;
+      if (!asJson) {
+        console.log(
+          `Staged ${staged.appended} transcript entries (${staged.skipped} already ingested).`,
+        );
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (asJson) {
+        emitJson({ launched: false, reason: "source_error", error: message });
+      } else {
+        console.error(`Failed to stage --from source: ${message}`);
+      }
+      return 1;
+    }
+  } else {
+    conversationId = parsed.values.from || "default";
+  }
 
   // Approach A: fold the target-doc maintenance directive into the reflection
   // instruction so the single reflection pass also maintains the doc as an
@@ -173,6 +221,9 @@ export async function runDreamSubcommand(argv: string[]): Promise<number> {
   const result = await launchReflectionSubagent({
     agentId,
     conversationId,
+    // External sources stage into a synthetic conversation that doesn't exist
+    // in the backend; recompile the agent's real primary history instead.
+    ...(source ? { completionConversationId: "default" } : {}),
     memfsEnabled: true,
     triggerSource: "manual",
     description: "Reflect on recent conversations",
@@ -193,7 +244,12 @@ export async function runDreamSubcommand(argv: string[]): Promise<number> {
 
   if (!result.launched) {
     if (asJson) {
-      emitJson({ launched: false, reason: result.reason, agentId });
+      emitJson({
+        launched: false,
+        reason: result.reason,
+        agentId,
+        ...(stagedEntries !== undefined ? { stagedEntries } : {}),
+      });
       return result.reason === "no_payload" ? 0 : 1;
     }
     switch (result.reason) {
@@ -269,6 +325,7 @@ export async function runDreamSubcommand(argv: string[]): Promise<number> {
       agentId,
       conversationId,
       transcriptPath: result.payloadPath,
+      ...(stagedEntries !== undefined ? { stagedEntries } : {}),
       ...(target ? { targetPath: target.path, targetWritten } : {}),
       ...(targetError ? { targetError } : {}),
     });

--- a/src/cli/subcommands/dream.ts
+++ b/src/cli/subcommands/dream.ts
@@ -27,7 +27,7 @@ Options:
                               $LETTA_AGENT_ID, then the last-used agent)
   --from <conv-id|type:path>  What to reflect on: a conversation id (default:
                               the agent's primary "default" history), or an
-                              external source, e.g. openhands:./events.json
+                              external source, e.g. openhands:<conversation-dir>
                               or transcript:./rows.jsonl
   --to <path>                 Maintain a doc (e.g. ./AGENTS.md) from memory;
                               the agent edits it in place, using judgment


### PR DESCRIPTION
## Summary
`--from` now accepts **typed external sources** (starting with `openhands:`) in addition to a bare conversation id, behind a **registry-based adapter framework** so new source types are drop-in.

- `letta dream --from openhands:./events.json` — converts an OpenHands events file to transcript entries, stages them, and reflects.
- Bare `--from conv-123` / `--from default` — unchanged (the agent's own transcript).
- Combine with `--to`: **`--from openhands:… --to ./AGENTS.md`** is the coding-agent-traces → AGENTS.md path end to end.

## Adapter framework (the extensibility contract)
`dream-sources/`:
- `types.ts` — `SourceAdapter` interface
- `index.ts` — `ADAPTERS` registry, `parseFromSource`, `stageFromSource`, stable synthetic conversation id
- `openhands.ts` — full event converter (MessageEvent → user/assistant, ActionEvent+ObservationEvent → tool_call, AgentError/UserReject → failed results, `thought` → assistant, timezone normalization, skips system/state/streaming)
- `transcript.ts` — JSONL passthrough (reference impl / template)

**Adding `claude:` / `codex:` later** = new file `dream-sources/<type>.ts` implementing `convert(locator) → ExternalTranscriptEntry[]` + one line in `ADAPTERS`. Nothing else changes.

## Behavior
- Typed source → converted, staged into a **synthetic conversation** (stable id per source), reflected on; recompile targets the agent's real `"default"` history (the synthetic conv isn't a backend conversation).
- **Idempotent**: staging dedupes by `source_message_id`; the reflection cursor gates re-runs. Re-running the same source is a `no_payload` no-op.
- **Unknown typed prefix errors** (`github:…` → "Unknown source type … Supported: openhands, transcript").
- `--json` reports `stagedEntries`.

## Also
Adds `appendExternalTranscriptEntries` + `ExternalTranscriptEntry` to `reflection-transcript.ts` (additive staging primitive).

## Verified (live, Haiku, local backend)
`--from openhands:events.json --to ./AGENTS.md` → staged 4 entries → produced a clean AGENTS.md capturing the trace's conventions (ruff, `make lint`, type hints, commands early), no persona leakage; rerun idempotent (`no_payload`, 0 staged). Unit tests (16) + `bun run check` 10/10.

## Scope / non-goals
Single `--from` per invocation; `claude`/`codex` adapters (framework only); `--memory repo`; `--effort` wiring.