### PR TITLE
feat(cli): dream --to syncs doc into memfs system/ (repo-as-truth) before reflecting

### DIFF
--- a/src/cli/subcommands/dream-targets.test.ts
+++ b/src/cli/subcommands/dream-targets.test.ts
@@ -3,9 +3,12 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  addManagedFrontmatter,
   buildTargetInstruction,
   readExistingTarget,
   resolveDreamTarget,
+  seedTargetIntoMemory,
+  stripFrontmatter,
   writeTarget,
 } from "./dream-targets";
 
@@ -34,22 +37,44 @@ describe("resolveDreamTarget", () => {
 });
 
 describe("buildTargetInstruction", () => {
-  test("agents-md includes the standard guidance and the file name", () => {
+  test("agents-md points at system/ and includes the standard guidance", () => {
     const target = resolveDreamTarget("./AGENTS.md");
-    const out = buildTargetInstruction(target, "# Existing\nrules");
-    expect(out).toContain("$MEMORY_DIR/AGENTS.md");
+    const out = buildTargetInstruction(target);
+    expect(out).toContain("$MEMORY_DIR/system/AGENTS.md");
     expect(out).toContain("agents.md");
     expect(out).toContain("COMMANDS");
-    expect(out).toContain("edit in place");
-    expect(out).toContain("# Existing\nrules");
+    expect(out).toContain("revise it in place");
   });
 
   test("generic uses generic guidance, not the agents.md standard text", () => {
     const target = resolveDreamTarget("./memory.md");
-    const out = buildTargetInstruction(target, null);
-    expect(out).toContain("$MEMORY_DIR/memory.md");
+    const out = buildTargetInstruction(target);
+    expect(out).toContain("$MEMORY_DIR/system/memory.md");
     expect(out).not.toContain("agents.md");
-    expect(out).toContain("does not exist yet — create it");
+  });
+});
+
+describe("managed frontmatter (system/ files require it)", () => {
+  test("adds a description frontmatter to a plain doc and strips it back out", () => {
+    const plain = "# Guide\n\nUse bun.";
+    const withFm = addManagedFrontmatter(plain, "agents-md");
+    expect(withFm.startsWith("---\n")).toBe(true);
+    expect(withFm).toContain("description:");
+    expect(stripFrontmatter(withFm)).toBe(plain);
+  });
+
+  test("leaves an existing description frontmatter untouched", () => {
+    const already = "---\ndescription: mine\n---\n# Body\n";
+    expect(addManagedFrontmatter(already, "agents-md")).toBe(already);
+  });
+});
+
+describe("seedTargetIntoMemory", () => {
+  test("is a no-op when there is no on-disk content to seed", async () => {
+    const target = resolveDreamTarget("./AGENTS.md");
+    expect(await seedTargetIntoMemory("agent-x", target, null)).toEqual({
+      seeded: false,
+    });
   });
 });
 

--- a/src/cli/subcommands/dream-targets.test.ts
+++ b/src/cli/subcommands/dream-targets.test.ts
@@ -7,8 +7,8 @@ import {
   buildTargetInstruction,
   readExistingTarget,
   resolveDreamTarget,
-  seedTargetIntoMemory,
   stripFrontmatter,
+  syncTargetIntoMemory,
   writeTarget,
 } from "./dream-targets";
 
@@ -69,11 +69,11 @@ describe("managed frontmatter (system/ files require it)", () => {
   });
 });
 
-describe("seedTargetIntoMemory", () => {
-  test("is a no-op when there is no on-disk content to seed", async () => {
+describe("syncTargetIntoMemory", () => {
+  test("is a no-op when there is no on-disk content to sync", async () => {
     const target = resolveDreamTarget("./AGENTS.md");
-    expect(await seedTargetIntoMemory("agent-x", target, null)).toEqual({
-      seeded: false,
+    expect(await syncTargetIntoMemory("agent-x", target, null)).toEqual({
+      synced: false,
     });
   });
 });

--- a/src/cli/subcommands/dream-targets.ts
+++ b/src/cli/subcommands/dream-targets.ts
@@ -14,12 +14,14 @@ import { parseFrontmatter } from "@/utils/frontmatter";
  * agent's in-context memory at `$MEMORY_DIR/system/<fileName>`, and we copy the
  * committed result out to `path` afterwards.
  *
- * On the first run the doc is seeded into the memfs from `path` (if `path`
- * exists and the memfs has no copy yet); thereafter the memfs copy is the
- * source of truth. This is cycle-free (updates are gated by the reflection
- * cursor) but does NOT merge out-of-band edits made to `path` between runs.
- * The dream owns the generated doc; reconciling human edits or unmerged-PR
- * drift is the caller's responsibility (e.g. the automation side), not here.
+ * Each run syncs the doc into the memfs from `path` when the memfs has no copy
+ * or `path` has changed (another agent's merged edits, or a human edit), so the
+ * agent starts from the current shared state — the repo is the source of truth
+ * for a doc shared across agents (one agent per user+repo). Updates to the doc
+ * are gated by the reflection cursor (no new experience → no change), so this
+ * is churn-free. Choosing which on-disk revision is "current" (base branch vs
+ * an open PR branch carrying this agent's unmerged output) and resolving
+ * cross-agent PR conflicts is the caller's (automation's) responsibility.
  *
  * Note: because the doc lives in `system/`, it is compiled into the agent's
  * system prompt. That is acceptable for a dedicated dreaming agent with a small
@@ -96,7 +98,7 @@ const GENERIC_GUIDANCE = [
 /**
  * Build the instruction fragment that asks the reflection agent to maintain
  * the target doc at `$MEMORY_DIR/system/<fileName>`. The doc has already been
- * seeded there when a base existed, so the agent reads and edits it in place.
+ * synced there from the target, so the agent reads and edits it in place.
  */
 export function buildTargetInstruction(target: DreamTarget): string {
   const guidance =
@@ -125,37 +127,50 @@ export async function readExistingTarget(
   }
 }
 
-function existsInMemoryHead(memoryDir: string, relPath: string): boolean {
+/** The committed memfs content at `relPath` (via `git show HEAD:…`), or null. */
+function readMemfsHead(memoryDir: string, relPath: string): string | null {
   try {
-    execFileSync("git", ["cat-file", "-e", `HEAD:${relPath}`], {
+    return execFileSync("git", ["show", `HEAD:${relPath}`], {
       cwd: memoryDir,
-      stdio: "ignore",
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
     });
-    return true;
   } catch {
-    return false;
+    return null;
   }
 }
 
 /**
- * Seed the target doc into the agent's memory at `system/<fileName>` when the
- * memfs has no copy yet, using the current on-disk content as the base. If a
- * copy already exists in the memfs it is left untouched (the memfs copy is the
- * source of truth). Must run before the reflection worktree is created, since
- * the worktree is checked out from HEAD.
+ * Sync the on-disk target doc into the agent's memory at `system/<fileName>`:
+ * write it when the memfs has no copy OR the on-disk copy differs from the
+ * memfs copy (e.g. another agent's merged edits, or a human edit landed in the
+ * repo). The repo is the source of truth for a doc shared across agents (one
+ * agent per user+repo), so each run starts from the current shared state; the
+ * agent's durable knowledge still lives in its memory blocks. Bodies are
+ * compared (the memfs copy carries managed frontmatter the on-disk copy lacks).
+ *
+ * Must run before the reflection worktree is created, since the worktree is
+ * checked out from HEAD. Selecting which on-disk revision counts as "current"
+ * (base branch vs an open PR branch with this agent's unmerged output) is the
+ * caller's responsibility.
  */
-export async function seedTargetIntoMemory(
+export async function syncTargetIntoMemory(
   agentId: string,
   target: DreamTarget,
   content: string | null,
-): Promise<{ seeded: boolean }> {
+): Promise<{ synced: boolean }> {
   if (content === null) {
-    return { seeded: false };
+    return { synced: false };
   }
   const memoryDir = getScopedMemoryFilesystemRoot(agentId);
   const relPath = memfsRelPath(target);
-  if (existsInMemoryHead(memoryDir, relPath)) {
-    return { seeded: false };
+
+  const committed = readMemfsHead(memoryDir, relPath);
+  if (
+    committed !== null &&
+    stripFrontmatter(committed) === stripFrontmatter(content)
+  ) {
+    return { synced: false };
   }
 
   const absPath = join(memoryDir, relPath);
@@ -171,7 +186,7 @@ export async function seedTargetIntoMemory(
     const result = await commitMemoryWrite({
       memoryDir,
       pathspecs: [relPath],
-      reason: `dream: seed ${target.fileName} into memory`,
+      reason: `dream: sync ${target.fileName} from target`,
       author: {
         agentId,
         authorName: agentId,
@@ -179,7 +194,7 @@ export async function seedTargetIntoMemory(
       },
       syncMode,
     });
-    return { seeded: result.committed };
+    return { synced: result.committed };
   } catch (error) {
     // Roll back the uncommitted file so the parent memfs stays clean — a dirty
     // parent would block the reflection worktree merge.
@@ -197,23 +212,14 @@ export function readTargetFromMemory(
   target: DreamTarget,
 ): string | null {
   const memoryDir = getScopedMemoryFilesystemRoot(agentId);
-  try {
-    const committed = execFileSync(
-      "git",
-      ["show", `HEAD:${memfsRelPath(target)}`],
-      {
-        cwd: memoryDir,
-        encoding: "utf-8",
-        stdio: ["ignore", "pipe", "ignore"],
-      },
-    );
-    // Strip the managed frontmatter so the exported doc is plain markdown.
-    // parseFrontmatter trims the body; restore a trailing newline.
-    const body = stripFrontmatter(committed);
-    return body.length > 0 ? `${body}\n` : body;
-  } catch {
+  const committed = readMemfsHead(memoryDir, memfsRelPath(target));
+  if (committed === null) {
     return null;
   }
+  // Strip the managed frontmatter so the exported doc is plain markdown.
+  // parseFrontmatter trims the body; restore a trailing newline.
+  const body = stripFrontmatter(committed);
+  return body.length > 0 ? `${body}\n` : body;
 }
 
 /** Write the rendered doc to the target path, creating parent dirs. */

--- a/src/cli/subcommands/dream-targets.ts
+++ b/src/cli/subcommands/dream-targets.ts
@@ -1,30 +1,34 @@
 import { execFileSync } from "node:child_process";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { basename, dirname } from "node:path";
-import { getScopedMemoryFilesystemRoot } from "@/agent/memory-filesystem";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import {
+  getScopedMemoryFilesystemRoot,
+  MEMORY_SYSTEM_DIR,
+} from "@/agent/memory-filesystem";
+import { commitMemoryWrite } from "@/agent/memory-git";
+import { parseFrontmatter } from "@/utils/frontmatter";
 
 /**
- * A `--to` render target. In this pass, memory is refined in a single
- * reflection pass (Approach A): the reflection agent maintains the target doc
- * as an external memory file at `$MEMORY_DIR/<fileName>`, and we copy the
+ * A `--to` render target. Memory is refined in a single reflection pass
+ * (Approach A): the reflection agent maintains the target doc as a file in the
+ * agent's in-context memory at `$MEMORY_DIR/system/<fileName>`, and we copy the
  * committed result out to `path` afterwards.
  *
- * Note: because the doc lives in the memfs, it is also compiled into the
- * agent's system prompt. That is acceptable for a dedicated dreaming agent
- * with a small doc; revisit (carve-out, or a separate projection pass) if
- * maintenance gets tedious or docs grow large/numerous.
+ * On the first run the doc is seeded into the memfs from `path` (if `path`
+ * exists and the memfs has no copy yet); thereafter the memfs copy is the
+ * source of truth. This is cycle-free (updates are gated by the reflection
+ * cursor) but does NOT merge out-of-band edits made to `path` between runs.
+ * The dream owns the generated doc; reconciling human edits or unmerged-PR
+ * drift is the caller's responsibility (e.g. the automation side), not here.
  *
- * The memfs is the source of truth for the doc: the agent builds on its own
- * committed copy and we overwrite `path` with the result. This is cycle-free
- * (updates are gated by the reflection cursor — no new experience, no change)
- * but does NOT merge out-of-band edits made to `path` between runs. The dream
- * owns the generated doc; reconciling human edits or unmerged-PR drift is the
- * caller's responsibility (e.g. handled on the automation side), not here.
+ * Note: because the doc lives in `system/`, it is compiled into the agent's
+ * system prompt. That is acceptable for a dedicated dreaming agent with a small
+ * doc; revisit if docs grow large/numerous.
  */
 export interface DreamTarget {
   /** Absolute or relative filesystem path to write the rendered doc to. */
   path: string;
-  /** The file name the agent maintains inside `$MEMORY_DIR`. */
+  /** The file name maintained inside `$MEMORY_DIR/system/`. */
   fileName: string;
   kind: "agents-md" | "generic";
 }
@@ -38,6 +42,38 @@ export function resolveDreamTarget(spec: string): DreamTarget {
   const kind =
     lower === "agents.md" || lower === "agent.md" ? "agents-md" : "generic";
   return { path: spec, fileName, kind };
+}
+
+/** The doc's path inside the memfs, relative to `$MEMORY_DIR`. */
+function memfsRelPath(target: DreamTarget): string {
+  return `${MEMORY_SYSTEM_DIR}/${target.fileName}`;
+}
+
+const MANAGED_DESCRIPTION: Record<DreamTarget["kind"], string> = {
+  "agents-md":
+    "Repository guidance for coding agents, maintained by letta dream.",
+  generic: "Document distilled by letta dream.",
+};
+
+/**
+ * Files under `system/` must carry YAML frontmatter (enforced by the memfs
+ * pre-commit hook). The target doc is plain markdown, so we add a managed
+ * frontmatter block when seeding (unless one with a description already
+ * exists) and strip it when copying the doc back out to `--to`.
+ */
+export function addManagedFrontmatter(
+  content: string,
+  kind: DreamTarget["kind"],
+): string {
+  const { frontmatter, body } = parseFrontmatter(content);
+  if (typeof frontmatter.description === "string" && frontmatter.description) {
+    return content;
+  }
+  return `---\ndescription: ${MANAGED_DESCRIPTION[kind]}\n---\n${body}`;
+}
+
+export function stripFrontmatter(content: string): string {
+  return parseFrontmatter(content).body;
 }
 
 const AGENTS_MD_GUIDANCE = [
@@ -59,29 +95,23 @@ const GENERIC_GUIDANCE = [
 
 /**
  * Build the instruction fragment that asks the reflection agent to maintain
- * the target doc as an external memory file, seeded with the current on-disk
- * content so human edits to the repo copy are respected.
+ * the target doc at `$MEMORY_DIR/system/<fileName>`. The doc has already been
+ * seeded there when a base existed, so the agent reads and edits it in place.
  */
-export function buildTargetInstruction(
-  target: DreamTarget,
-  existingContent: string | null,
-): string {
+export function buildTargetInstruction(target: DreamTarget): string {
   const guidance =
     target.kind === "agents-md" ? AGENTS_MD_GUIDANCE : GENERIC_GUIDANCE;
-  const lines = [
-    `In addition to updating memory, maintain an external memory file named "${target.fileName}" at $MEMORY_DIR/${target.fileName}.`,
+  const relPath = memfsRelPath(target);
+  return [
+    `In addition to updating memory, maintain the file at $MEMORY_DIR/${relPath}.`,
     guidance,
     "",
-    "The authoritative current content of this file is below. Treat it as the",
-    "base to revise: apply only the changes the new experience warrants, using",
-    "your judgment. Often no change is needed — if so, leave it as-is. Write the",
-    `final version to $MEMORY_DIR/${target.fileName} (overwriting), then commit.`,
-    "",
-    `--- current ${target.fileName} (${existingContent === null ? "does not exist yet — create it" : "edit in place"}) ---`,
-    existingContent ?? "(none)",
-    `--- end ${target.fileName} ---`,
-  ];
-  return lines.join("\n");
+    `Read the existing $MEMORY_DIR/${relPath} (create it if it does not exist)`,
+    "and revise it in place: apply only the changes the new experience",
+    "warrants, using your judgment. Often no change is needed — if so, leave it",
+    "as-is. Keep the YAML frontmatter block (--- ... ---) at the top intact;",
+    "edit only the body below it. Commit when done.",
+  ].join("\n");
 }
 
 /** Read the current on-disk target doc, or null if it doesn't exist. */
@@ -95,6 +125,69 @@ export async function readExistingTarget(
   }
 }
 
+function existsInMemoryHead(memoryDir: string, relPath: string): boolean {
+  try {
+    execFileSync("git", ["cat-file", "-e", `HEAD:${relPath}`], {
+      cwd: memoryDir,
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Seed the target doc into the agent's memory at `system/<fileName>` when the
+ * memfs has no copy yet, using the current on-disk content as the base. If a
+ * copy already exists in the memfs it is left untouched (the memfs copy is the
+ * source of truth). Must run before the reflection worktree is created, since
+ * the worktree is checked out from HEAD.
+ */
+export async function seedTargetIntoMemory(
+  agentId: string,
+  target: DreamTarget,
+  content: string | null,
+): Promise<{ seeded: boolean }> {
+  if (content === null) {
+    return { seeded: false };
+  }
+  const memoryDir = getScopedMemoryFilesystemRoot(agentId);
+  const relPath = memfsRelPath(target);
+  if (existsInMemoryHead(memoryDir, relPath)) {
+    return { seeded: false };
+  }
+
+  const absPath = join(memoryDir, relPath);
+  await mkdir(dirname(absPath), { recursive: true });
+  await writeFile(
+    absPath,
+    addManagedFrontmatter(content, target.kind),
+    "utf-8",
+  );
+  try {
+    const { getBackend } = await import("@/backend");
+    const syncMode = getBackend().capabilities.localMemfs ? "local" : "remote";
+    const result = await commitMemoryWrite({
+      memoryDir,
+      pathspecs: [relPath],
+      reason: `dream: seed ${target.fileName} into memory`,
+      author: {
+        agentId,
+        authorName: agentId,
+        authorEmail: `${agentId}@letta.com`,
+      },
+      syncMode,
+    });
+    return { seeded: result.committed };
+  } catch (error) {
+    // Roll back the uncommitted file so the parent memfs stays clean — a dirty
+    // parent would block the reflection worktree merge.
+    await rm(absPath, { force: true });
+    throw error;
+  }
+}
+
 /**
  * Read the doc the reflection agent committed into the agent's memory, or null
  * if it wasn't written.
@@ -105,11 +198,19 @@ export function readTargetFromMemory(
 ): string | null {
   const memoryDir = getScopedMemoryFilesystemRoot(agentId);
   try {
-    return execFileSync("git", ["show", `HEAD:${target.fileName}`], {
-      cwd: memoryDir,
-      encoding: "utf-8",
-      stdio: ["ignore", "pipe", "ignore"],
-    });
+    const committed = execFileSync(
+      "git",
+      ["show", `HEAD:${memfsRelPath(target)}`],
+      {
+        cwd: memoryDir,
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+      },
+    );
+    // Strip the managed frontmatter so the exported doc is plain markdown.
+    // parseFrontmatter trims the body; restore a trailing newline.
+    const body = stripFrontmatter(committed);
+    return body.length > 0 ? `${body}\n` : body;
   } catch {
     return null;
   }

--- a/src/cli/subcommands/dream.ts
+++ b/src/cli/subcommands/dream.ts
@@ -10,7 +10,7 @@ import {
   readExistingTarget,
   readTargetFromMemory,
   resolveDreamTarget,
-  seedTargetIntoMemory,
+  syncTargetIntoMemory,
   writeTarget,
 } from "@/cli/subcommands/dream-targets";
 import { settingsManager } from "@/settings-manager";
@@ -200,19 +200,20 @@ export async function runDreamSubcommand(argv: string[]): Promise<number> {
 
   // Approach A: fold the target-doc maintenance directive into the reflection
   // instruction so the single reflection pass also maintains the doc (in the
-  // agent's system/ memory). Seed the doc into the memfs from the on-disk
-  // target first (only if the memfs has no copy yet) so the agent edits an
-  // existing file. We read the result back out of the memfs afterwards.
+  // agent's system/ memory). Sync the doc into the memfs from the on-disk
+  // target first (when the memfs has no copy or the target changed) so the
+  // agent starts from the current shared state. We read the result back out of
+  // the memfs afterwards.
   let instruction = parsed.values.instruction;
   if (target) {
     const existing = await readExistingTarget(target);
     try {
-      await seedTargetIntoMemory(agentId, target, existing);
+      await syncTargetIntoMemory(agentId, target, existing);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       if (!asJson) {
         console.error(
-          `Note: could not seed ${target.fileName} into memory (${message}); the reflection will create it.`,
+          `Note: could not sync ${target.fileName} into memory (${message}); the reflection will create it.`,
         );
       }
     }

--- a/src/cli/subcommands/dream.ts
+++ b/src/cli/subcommands/dream.ts
@@ -10,6 +10,7 @@ import {
   readExistingTarget,
   readTargetFromMemory,
   resolveDreamTarget,
+  seedTargetIntoMemory,
   writeTarget,
 } from "@/cli/subcommands/dream-targets";
 import { settingsManager } from "@/settings-manager";
@@ -198,12 +199,24 @@ export async function runDreamSubcommand(argv: string[]): Promise<number> {
   }
 
   // Approach A: fold the target-doc maintenance directive into the reflection
-  // instruction so the single reflection pass also maintains the doc as an
-  // external memory file. We read it back out of the memfs afterwards.
+  // instruction so the single reflection pass also maintains the doc (in the
+  // agent's system/ memory). Seed the doc into the memfs from the on-disk
+  // target first (only if the memfs has no copy yet) so the agent edits an
+  // existing file. We read the result back out of the memfs afterwards.
   let instruction = parsed.values.instruction;
   if (target) {
     const existing = await readExistingTarget(target);
-    const targetInstruction = buildTargetInstruction(target, existing);
+    try {
+      await seedTargetIntoMemory(agentId, target, existing);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!asJson) {
+        console.error(
+          `Note: could not seed ${target.fileName} into memory (${message}); the reflection will create it.`,
+        );
+      }
+    }
+    const targetInstruction = buildTargetInstruction(target);
     instruction = instruction
       ? `${instruction}\n\n${targetInstruction}`
       : targetInstruction;


### PR DESCRIPTION
## Summary
Makes `--to` robust for the production model — **one letta agent per (user, repo)**, so multiple agents commit to the same repo doc. Before reflection, the target doc is **synced into the agent's memory** at `$MEMORY_DIR/system/<fileName>` so the agent edits an existing file (not create-at-exact-path), and the committed result is copied back out to `--to` after a successful run.

## Repo-as-truth (not memfs-as-truth)
Because many agents share one repo doc, the **repo is the source of truth**: each run **reseeds the memfs copy from the on-disk target when it has changed** (another agent's merged edits, or a human edit) — so every run starts from the current shared state. Under the earlier memfs-as-truth (seed-only-if-absent), each agent's memfs went stale and exports clobbered others' merged edits.

- Sync writes the memfs copy when it's absent **or** the on-disk body differs (bodies compared, since the memfs copy carries managed frontmatter the repo copy lacks).
- **Churn-free:** doc edits are gated by the reflection cursor, so an unchanged repo → no reseed, and no-new-experience → no doc change → no PR.
- Commits **before** the reflection worktree is created (worktree is checked out from `HEAD`); rolls back the file if the commit fails so the parent memfs stays clean.

## Frontmatter
`system/` files require YAML frontmatter (memfs pre-commit hook), but the doc is plain markdown — so a managed `description:` frontmatter is added on sync, the agent is told to keep it, and it's stripped when copying back to `--to`.

## Not in scope (caller/automation's job)
Choosing which on-disk revision is "current" — base branch vs an open PR branch carrying this agent's own unmerged output (reseeding from base would drop it) — and resolving cross-agent PR merge conflicts. These are the automation's reconciliation responsibility.

## Verified (local backend)
- **Deterministic reseed:** run 1 seeds `v0`; run 2 (repo changed to `v1` by "another agent") reseeds to `v1`; run 3 (unchanged) does **not** reseed. Frontmatter added on sync, stripped on export.
- **Live (Haiku):** seeded a base doc + fed a new convention → agent merged both while keeping the frontmatter (its commit passed the pre-commit hook) → exported clean markdown.
- Unit tests (14) + `bun run check` 10/10.