### PR TITLE
feat(channels): reload channel adapters from /reload

### DIFF
--- a/src/channels/commands.test.ts
+++ b/src/channels/commands.test.ts
@@ -45,6 +45,7 @@ describe("channel slash commands", () => {
       "cancel",
       "chat",
       "model",
+      "reload",
       "reflection",
     ]) {
       expect(listChannelSlashCommands()).toContainEqual(
@@ -55,7 +56,7 @@ describe("channel slash commands", () => {
     const text = buildChannelHelpMessage("telegram");
     expect(text).toContain("Telegram is connected to Letta Code.");
     expect(text).toContain(
-      "Supported slash commands here: /help, /status, /pause, /resume, /cancel, /chat, /model, /reflection.",
+      "Supported slash commands here: /help, /status, /pause, /resume, /cancel, /chat, /model, /reload, /reflection.",
     );
   });
 
@@ -246,7 +247,7 @@ describe("channel slash commands", () => {
     expect(text).toContain("Telegram received /compact now");
     expect(text).toContain("not supported in channels yet");
     expect(text).toContain(
-      "Supported slash commands here: /help, /status, /pause, /resume, /cancel, /chat, /model, /reflection.",
+      "Supported slash commands here: /help, /status, /pause, /resume, /cancel, /chat, /model, /reload, /reflection.",
     );
     expect(text).toContain("without a leading slash");
   });

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -47,6 +47,10 @@ export type ChannelSlashCommandHandlers = {
     command: ParsedChannelSlashCommand,
     msg: InboundChannelMessage,
   ) => Promise<ChannelSlashCommandHandlerResult>;
+  reload?: (
+    command: ParsedChannelSlashCommand,
+    msg: InboundChannelMessage,
+  ) => Promise<ChannelSlashCommandHandlerResult>;
   resume?: (
     command: ParsedChannelSlashCommand,
     msg: InboundChannelMessage,
@@ -100,6 +104,11 @@ const CHANNEL_SLASH_COMMANDS: ChannelSlashCommandDefinition[] = [
     name: "model",
     kind: "agent-scoped",
     summary: "Show or switch the model for this chat's routed conversation.",
+  },
+  {
+    name: "reload",
+    kind: "direct",
+    summary: "Reload settings, local mods, and running channel adapters.",
   },
   {
     name: "reflection",
@@ -500,6 +509,13 @@ export function buildChannelReflectionUnavailableMessage(
   return `${displayName} cannot start reflection for this chat because the listener is not ready yet. Try again in a moment.`;
 }
 
+export function buildChannelReloadUnavailableMessage(
+  channelId: string,
+): string {
+  const displayName = channelDisplayName(channelId);
+  return `${displayName} cannot reload channel adapters because the listener is not ready yet. Try again in a moment.`;
+}
+
 async function handleScopedCommand(params: {
   msg: InboundChannelMessage;
   command: ParsedChannelSlashCommand;
@@ -571,6 +587,13 @@ export async function tryHandleChannelSlashCommand(
           msg,
           command,
           handler: options.handlers?.model,
+        });
+      case "reload":
+        return handleScopedCommand({
+          msg,
+          command,
+          handler: options.handlers?.reload,
+          defaultText: buildChannelReloadUnavailableMessage(msg.channel),
         });
       case "reflect":
       case "reflection":

--- a/src/channels/plugin-registry.test.ts
+++ b/src/channels/plugin-registry.test.ts
@@ -14,6 +14,7 @@ import {
   getSupportedChannelIds,
   isSupportedChannelId,
   loadChannelPlugin,
+  reloadChannelPlugins,
 } from "@/channels/plugin-registry";
 
 let channelsRoot: string;
@@ -103,6 +104,48 @@ test("discovers user channel plugins from channel.json manifests", async () => {
     source: "user",
     firstParty: false,
   });
+});
+
+test("reloadChannelPlugins can reload first-party channel plugins", async () => {
+  reloadChannelPlugins();
+
+  const plugin = await loadChannelPlugin("slack");
+
+  expect(plugin.metadata.id).toBe("slack");
+  expect(typeof plugin.createAdapter).toBe("function");
+});
+
+test("reloadChannelPlugins reloads changed user plugin modules", async () => {
+  writeDemoChannel();
+  expect((await loadChannelPlugin("demo")).metadata.displayName).toBe(
+    "Demo Chat",
+  );
+
+  writeFileSync(
+    join(channelsRoot, "demo", "plugin.mjs"),
+    `export const channelPlugin = {
+      metadata: { id: "demo", displayName: "Reloaded Demo Chat" },
+      createAdapter(account) {
+        return {
+          id: "demo:" + account.accountId,
+          channelId: "demo",
+          accountId: account.accountId,
+          name: "Reloaded Demo Chat",
+          start: async () => {},
+          stop: async () => {},
+          isRunning: () => true,
+          sendMessage: async () => ({ messageId: "demo-2" }),
+          sendDirectReply: async () => {}
+        };
+      }
+    };\n`,
+  );
+
+  reloadChannelPlugins();
+
+  expect((await loadChannelPlugin("demo")).metadata.displayName).toBe(
+    "Reloaded Demo Chat",
+  );
 });
 
 test("user plugins can extend the MessageChannel action schema", async () => {

--- a/src/channels/plugin-registry.ts
+++ b/src/channels/plugin-registry.ts
@@ -1,6 +1,12 @@
-import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { resolve, sep } from "node:path";
-import { pathToFileURL } from "node:url";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+} from "node:fs";
+import { dirname, resolve, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { isRecord } from "@/utils/type-guards";
 import { getChannelDir, getChannelsRoot } from "./config";
 import { CUSTOM_CHANNEL_CONFIG_SCHEMA } from "./custom/plugin";
@@ -28,103 +34,176 @@ type ChannelManifest = {
 
 const CHANNEL_ID_PATTERN = /^[a-z0-9][a-z0-9_-]*$/;
 
+const TELEGRAM_CHANNEL_PLUGIN_METADATA = {
+  id: "telegram",
+  displayName: "Telegram",
+  runtimePackages: ["grammy@1.42.0"],
+  runtimeModules: ["grammy"],
+  source: "first-party",
+  firstParty: true,
+} satisfies ChannelPluginMetadata;
+
+const SLACK_CHANNEL_PLUGIN_METADATA = {
+  id: "slack",
+  displayName: "Slack",
+  runtimePackages: ["@slack/bolt@4.7.0", "@slack/web-api@7.15.0"],
+  runtimeModules: ["@slack/bolt", "@slack/web-api"],
+  source: "first-party",
+  firstParty: true,
+} satisfies ChannelPluginMetadata;
+
+const DISCORD_CHANNEL_PLUGIN_METADATA = {
+  id: "discord",
+  displayName: "Discord",
+  runtimePackages: ["discord.js@14.18.0"],
+  runtimeModules: ["discord.js"],
+  source: "first-party",
+  firstParty: true,
+} satisfies ChannelPluginMetadata;
+
+const CUSTOM_CHANNEL_PLUGIN_METADATA = {
+  id: "custom",
+  displayName: "Custom",
+  runtimePackages: [],
+  runtimeModules: [],
+  source: "first-party",
+  firstParty: true,
+  configSchema: CUSTOM_CHANNEL_CONFIG_SCHEMA,
+} satisfies ChannelPluginMetadata;
+
+const WHATSAPP_CHANNEL_PLUGIN_METADATA = {
+  id: "whatsapp",
+  displayName: "WhatsApp",
+  runtimePackages: ["@whiskeysockets/baileys@6.7.21", "qrcode-terminal@0.12.0"],
+  runtimeModules: ["@whiskeysockets/baileys", "qrcode-terminal"],
+  source: "first-party",
+  firstParty: true,
+} satisfies ChannelPluginMetadata;
+
+const SIGNAL_CHANNEL_PLUGIN_METADATA = {
+  id: "signal",
+  displayName: "Signal",
+  runtimePackages: ["qrcode-terminal@0.12.0"],
+  runtimeModules: ["qrcode-terminal"],
+  source: "first-party",
+  firstParty: true,
+} satisfies ChannelPluginMetadata;
+
+let channelPluginReloadGeneration = 0;
+
+const SOURCE_CHANNELS_DIR = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT_DIR = resolve(SOURCE_CHANNELS_DIR, "../..");
+
+function copyDirectoryForReload(sourceDir: string, cacheKey: string): string {
+  const targetDir = resolve(
+    PROJECT_ROOT_DIR,
+    ".letta",
+    "channel-reload",
+    `${process.pid}-${channelPluginReloadGeneration}`,
+    cacheKey,
+  );
+  if (!existsSync(targetDir)) {
+    mkdirSync(dirname(targetDir), { recursive: true });
+    cpSync(sourceDir, targetDir, { recursive: true });
+  }
+  return targetDir;
+}
+
+function getReloadedFirstPartyPluginSpecifier(
+  channelId: FirstPartyChannelId,
+): string | null {
+  if (channelPluginReloadGeneration === 0) {
+    return null;
+  }
+  const sourceDir = resolve(SOURCE_CHANNELS_DIR, channelId);
+  if (!existsSync(sourceDir)) {
+    return null;
+  }
+  const reloadedDir = copyDirectoryForReload(
+    sourceDir,
+    `first-party-${channelId}`,
+  );
+  return pathToFileURL(resolve(reloadedDir, "plugin.ts")).href;
+}
+
+async function loadFirstPartyPlugin(
+  channelId: FirstPartyChannelId,
+  exportName: string,
+  loadDefault: () => Promise<unknown>,
+): Promise<ChannelPlugin> {
+  const reloadedSpecifier = getReloadedFirstPartyPluginSpecifier(channelId);
+  const loaded = reloadedSpecifier
+    ? await import(reloadedSpecifier)
+    : await loadDefault();
+  if (!isRecord(loaded)) {
+    throw new Error(`First-party channel ${channelId} did not load a module.`);
+  }
+  const plugin = loaded[exportName];
+  if (!isRecord(plugin)) {
+    throw new Error(
+      `First-party channel ${channelId} did not export ${exportName}.`,
+    );
+  }
+  return plugin as unknown as ChannelPlugin;
+}
+
 const FIRST_PARTY_CHANNEL_PLUGIN_REGISTRATIONS: Record<
   FirstPartyChannelId,
   ChannelPluginRegistration
 > = {
   telegram: {
-    metadata: {
-      id: "telegram",
-      displayName: "Telegram",
-      runtimePackages: ["grammy@1.42.0"],
-      runtimeModules: ["grammy"],
-      source: "first-party",
-      firstParty: true,
-    },
-    load: async () => {
-      const { telegramChannelPlugin } = await import(
-        "@/channels/telegram/plugin"
-      );
-      return telegramChannelPlugin;
-    },
+    metadata: TELEGRAM_CHANNEL_PLUGIN_METADATA,
+    load: () =>
+      loadFirstPartyPlugin(
+        "telegram",
+        "telegramChannelPlugin",
+        () => import("@/channels/telegram/plugin"),
+      ),
   },
   slack: {
-    metadata: {
-      id: "slack",
-      displayName: "Slack",
-      runtimePackages: ["@slack/bolt@4.7.0", "@slack/web-api@7.15.0"],
-      runtimeModules: ["@slack/bolt", "@slack/web-api"],
-      source: "first-party",
-      firstParty: true,
-    },
-    load: async () => {
-      const { slackChannelPlugin } = await import("@/channels/slack/plugin");
-      return slackChannelPlugin;
-    },
+    metadata: SLACK_CHANNEL_PLUGIN_METADATA,
+    load: () =>
+      loadFirstPartyPlugin(
+        "slack",
+        "slackChannelPlugin",
+        () => import("@/channels/slack/plugin"),
+      ),
   },
   discord: {
-    metadata: {
-      id: "discord",
-      displayName: "Discord",
-      runtimePackages: ["discord.js@14.18.0"],
-      runtimeModules: ["discord.js"],
-      source: "first-party",
-      firstParty: true,
-    },
-    load: async () => {
-      const { discordChannelPlugin } = await import(
-        "@/channels/discord/plugin"
-      );
-      return discordChannelPlugin;
-    },
+    metadata: DISCORD_CHANNEL_PLUGIN_METADATA,
+    load: () =>
+      loadFirstPartyPlugin(
+        "discord",
+        "discordChannelPlugin",
+        () => import("@/channels/discord/plugin"),
+      ),
   },
   custom: {
-    metadata: {
-      id: "custom",
-      displayName: "Custom",
-      runtimePackages: [],
-      runtimeModules: [],
-      source: "first-party",
-      firstParty: true,
-      configSchema: CUSTOM_CHANNEL_CONFIG_SCHEMA,
-    },
-    load: async () => {
-      const { customChannelPlugin } = await import("@/channels/custom/plugin");
-      return customChannelPlugin;
-    },
+    metadata: CUSTOM_CHANNEL_PLUGIN_METADATA,
+    load: () =>
+      loadFirstPartyPlugin(
+        "custom",
+        "customChannelPlugin",
+        () => import("@/channels/custom/plugin"),
+      ),
   },
   whatsapp: {
-    metadata: {
-      id: "whatsapp",
-      displayName: "WhatsApp",
-      runtimePackages: [
-        "@whiskeysockets/baileys@6.7.21",
-        "qrcode-terminal@0.12.0",
-      ],
-      runtimeModules: ["@whiskeysockets/baileys", "qrcode-terminal"],
-      source: "first-party",
-      firstParty: true,
-    },
-    load: async () => {
-      const { whatsappChannelPlugin } = await import(
-        "@/channels/whatsapp/plugin"
-      );
-      return whatsappChannelPlugin;
-    },
+    metadata: WHATSAPP_CHANNEL_PLUGIN_METADATA,
+    load: () =>
+      loadFirstPartyPlugin(
+        "whatsapp",
+        "whatsappChannelPlugin",
+        () => import("@/channels/whatsapp/plugin"),
+      ),
   },
   signal: {
-    metadata: {
-      id: "signal",
-      displayName: "Signal",
-      runtimePackages: ["qrcode-terminal@0.12.0"],
-      runtimeModules: ["qrcode-terminal"],
-      source: "first-party",
-      firstParty: true,
-    },
-    load: async () => {
-      const { signalChannelPlugin } = await import("@/channels/signal/plugin");
-      return signalChannelPlugin;
-    },
+    metadata: SIGNAL_CHANNEL_PLUGIN_METADATA,
+    load: () =>
+      loadFirstPartyPlugin(
+        "signal",
+        "signalChannelPlugin",
+        () => import("@/channels/signal/plugin"),
+      ),
   },
 };
 
@@ -207,7 +286,15 @@ function createUserChannelRegistration(
         );
       }
 
-      const loadPromise = import(pathToFileURL(entryPath).href).then(
+      const runtimeChannelDir =
+        channelPluginReloadGeneration > 0
+          ? copyDirectoryForReload(channelDir, `user-${manifest.id}`)
+          : channelDir;
+      const entryUrl = pathToFileURL(
+        resolve(runtimeChannelDir, manifest.entry),
+      );
+
+      const loadPromise = import(entryUrl.href).then(
         (loaded): ChannelPlugin => {
           const exported =
             (isRecord(loaded) ? loaded.channelPlugin : undefined) ??
@@ -332,6 +419,12 @@ export async function loadChannelPlugin(
   return registration.load();
 }
 
+export function reloadChannelPlugins(): void {
+  loadedUserPlugins.clear();
+  channelPluginReloadGeneration += 1;
+}
+
 export function __testClearUserChannelPluginCache(): void {
   loadedUserPlugins.clear();
+  channelPluginReloadGeneration = 0;
 }

--- a/src/channels/registry.test.ts
+++ b/src/channels/registry.test.ts
@@ -251,6 +251,83 @@ describe("ChannelRegistry", () => {
     expect(replies[0]?.text).toContain("Telegram is connected to Letta Code");
   });
 
+  test("/reload invokes the channel reload handler without agent delivery", async () => {
+    const replies: Array<{
+      chatId: string;
+      text: string;
+      replyToMessageId?: string;
+    }> = [];
+    const reloadCalls: unknown[] = [];
+    const registry = new ChannelRegistry();
+    const delivered: unknown[] = [];
+    registry.setMessageHandler((delivery) => delivered.push(delivery));
+    registry.setReloadHandler(async (params) => {
+      reloadCalls.push(params);
+      return { handled: true, text: "Reloaded channel adapters" };
+    });
+    registry.setReady();
+    registry.registerAdapter({
+      id: "slack:acct-slack",
+      channelId: "slack",
+      accountId: "acct-slack",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "msg-1" }),
+      sendDirectReply: async (chatId, text, options) => {
+        replies.push({
+          chatId,
+          text,
+          replyToMessageId: options?.replyToMessageId,
+        });
+      },
+      onMessage: undefined,
+    });
+    addRoute("slack", {
+      accountId: "acct-slack",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: "1700000000.000001",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      enabled: true,
+      createdAt: "2026-07-06T00:00:00.000Z",
+    });
+
+    const adapter = registry.getAdapter("slack", "acct-slack");
+    await adapter?.onMessage?.({
+      channel: "slack",
+      accountId: "acct-slack",
+      chatId: "C123",
+      senderId: "U123",
+      senderName: "Alice",
+      text: "/reload",
+      timestamp: Date.now(),
+      messageId: "1700000001.000002",
+      threadId: "1700000000.000001",
+      chatType: "channel",
+      isMention: true,
+    });
+
+    expect(delivered).toHaveLength(0);
+    expect(reloadCalls).toEqual([
+      {
+        runtime: {
+          agent_id: "agent-1",
+          conversation_id: "conv-1",
+        },
+      },
+    ]);
+    expect(replies).toEqual([
+      {
+        chatId: "C123",
+        text: "Reloaded channel adapters",
+        replyToMessageId: "1700000001.000002",
+      },
+    ]);
+  });
+
   test("unsupported slash commands get direct channel guidance instead of agent delivery", async () => {
     const replies: Array<{
       chatId: string;

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -32,6 +32,7 @@ import {
   buildChannelNoRouteMessage,
   buildChannelPausedMessage,
   buildChannelReflectionUnavailableMessage,
+  buildChannelReloadUnavailableMessage,
   buildChannelResumedMessage,
   parseChannelSlashCommand,
   tryHandleChannelSlashCommand,
@@ -59,6 +60,7 @@ import {
   getSupportedChannelIds,
   isFirstPartyChannelPlugin,
   loadChannelPlugin,
+  reloadChannelPlugins,
 } from "./plugin-registry";
 import type { ChannelRestoreAgentScope } from "./restore-scope";
 import { shouldRestoreChannelAccountForAgentScope } from "./restore-scope";
@@ -482,6 +484,16 @@ export type ChannelModelHandler = (params: {
   text?: string;
 }>;
 
+export type ChannelReloadHandler = (params: {
+  runtime: {
+    agent_id: string;
+    conversation_id: string;
+  } | null;
+}) => Promise<{
+  handled: boolean;
+  text?: string;
+}>;
+
 type ChannelStartupOptions = {
   logger?: ChannelStartupLogger;
 };
@@ -490,6 +502,12 @@ export interface ChannelStartupFailure {
   channelId: string;
   accountId?: string;
   error: string;
+}
+
+export interface ChannelReloadSummary {
+  restarted: number;
+  stopped: number;
+  failures: ChannelStartupFailure[];
 }
 
 export class ChannelInitializationError extends Error {
@@ -586,6 +604,9 @@ export class ChannelRegistry {
   private cancelHandler: ChannelCancelHandler | null = null;
   private reflectionHandler: ChannelReflectionHandler | null = null;
   private modelHandler: ChannelModelHandler | null = null;
+  private reloadHandler: ChannelReloadHandler | null = null;
+  private startupChannelNames: string[] = [];
+  private startupRestoreAgentScope: ChannelRestoreAgentScope | null = null;
   private readonly buffer: ChannelInboundDelivery[] = [];
   private readonly pendingControlRequestsById = new Map<
     string,
@@ -738,6 +759,18 @@ export class ChannelRegistry {
 
   setModelHandler(handler: ChannelModelHandler | null): void {
     this.modelHandler = handler;
+  }
+
+  setReloadHandler(handler: ChannelReloadHandler | null): void {
+    this.reloadHandler = handler;
+  }
+
+  setStartupChannels(
+    channelNames: string[],
+    restoreAgentScope?: ChannelRestoreAgentScope | null,
+  ): void {
+    this.startupChannelNames = [...new Set(channelNames)];
+    this.startupRestoreAgentScope = restoreAgentScope ?? null;
   }
 
   setEventHandler(
@@ -1015,6 +1048,109 @@ export class ChannelRegistry {
     return true;
   }
 
+  async reloadActiveChannels(
+    options?: ChannelStartupOptions,
+  ): Promise<ChannelReloadSummary> {
+    reloadChannelPlugins();
+
+    const channelNames =
+      this.startupChannelNames.length > 0
+        ? this.startupChannelNames
+        : Array.from(
+            new Set(
+              Array.from(this.adapters.values()).map(
+                (adapter) => adapter.channelId ?? adapter.id,
+              ),
+            ),
+          );
+    const summary: ChannelReloadSummary = {
+      restarted: 0,
+      stopped: 0,
+      failures: [],
+    };
+
+    for (const channelId of channelNames) {
+      try {
+        await hydrateChannelAccountSecrets(channelId);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        summary.failures.push({ channelId, error: message });
+        logChannelStartup(
+          options?.logger,
+          `failed to hydrate accounts for ${channelId}: ${message}`,
+        );
+        continue;
+      }
+
+      const accounts = listChannelAccounts(channelId).filter(
+        (account) =>
+          account.enabled &&
+          shouldRestoreChannelAccountForAgentScope(
+            account,
+            this.startupRestoreAgentScope,
+          ),
+      );
+      const desiredKeys = new Set(
+        accounts.map((account) =>
+          this.getAdapterKey(channelId, account.accountId),
+        ),
+      );
+      const existingAdapters = Array.from(this.adapters.values()).filter(
+        (adapter) => (adapter.channelId ?? adapter.id) === channelId,
+      );
+
+      for (const adapter of existingAdapters) {
+        const key = this.getAdapterKey(
+          adapter.channelId ?? adapter.id,
+          adapter.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID,
+        );
+        if (desiredKeys.has(key)) {
+          continue;
+        }
+        try {
+          if (adapter.isRunning()) {
+            await adapter.stop();
+          }
+          this.adapters.delete(key);
+          summary.stopped += 1;
+        } catch (error) {
+          summary.failures.push({
+            channelId,
+            accountId: adapter.accountId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+
+      for (const account of accounts) {
+        try {
+          const started = await this.startChannelAccount(
+            channelId,
+            account.accountId,
+            options,
+          );
+          if (started) {
+            summary.restarted += 1;
+          }
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          summary.failures.push({
+            channelId,
+            accountId: account.accountId,
+            error: message,
+          });
+          logChannelStartup(
+            options?.logger,
+            `failed to reload ${channelId}/${account.accountId}: ${formatChannelStartupError(error)}`,
+          );
+        }
+      }
+    }
+
+    return summary;
+  }
+
   async stopChannel(channelId: string): Promise<boolean> {
     const adapters = Array.from(this.adapters.values()).filter(
       (adapter) => adapter.channelId === channelId,
@@ -1076,6 +1212,7 @@ export class ChannelRegistry {
     this.cancelHandler = null;
     this.reflectionHandler = null;
     this.modelHandler = null;
+    this.reloadHandler = null;
   }
 
   /**
@@ -1095,6 +1232,7 @@ export class ChannelRegistry {
     this.cancelHandler = null;
     this.reflectionHandler = null;
     this.modelHandler = null;
+    this.reloadHandler = null;
     this.pendingControlRequestsById.clear();
     this.pendingControlRequestIdByScope.clear();
     this.unsubscribeWhatsAppState();
@@ -1323,6 +1461,27 @@ export class ChannelRegistry {
     });
   }
 
+  private async handleReloadSlashCommand(
+    msg: InboundChannelMessage,
+  ): Promise<{ handled: boolean; text?: string }> {
+    const route = this.loadAndFindRawRouteForMessage(msg);
+    if (!this.reloadHandler) {
+      return {
+        handled: true,
+        text: buildChannelReloadUnavailableMessage(msg.channel),
+      };
+    }
+
+    return this.reloadHandler({
+      runtime: route
+        ? {
+            agent_id: route.agentId,
+            conversation_id: route.conversationId,
+          }
+        : null,
+    });
+  }
+
   private async handleModelSlashCommand(
     command: { args: string },
     msg: InboundChannelMessage,
@@ -1472,6 +1631,8 @@ export class ChannelRegistry {
           pause: async () => this.handlePauseResumeSlashCommand("pause", msg),
           reflection: async (_command, commandMsg) =>
             this.handleReflectionSlashCommand(commandMsg),
+          reload: async (_command, commandMsg) =>
+            this.handleReloadSlashCommand(commandMsg),
           resume: async () => this.handlePauseResumeSlashCommand("resume", msg),
         },
       })
@@ -2331,6 +2492,7 @@ export async function initializeChannels(
   },
 ): Promise<ChannelRegistry> {
   const registry = ensureChannelRegistry();
+  registry.setStartupChannels(channelNames, options?.restoreAgentScope);
   const failures: ChannelStartupFailure[] = [];
 
   logChannelStartup(

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -10,7 +10,6 @@ import { getScopedMemoryFilesystemRoot } from "@/agent/memory-filesystem";
 import { REMEMBER_PROMPT } from "@/agent/prompt-assets";
 import type { ConversationMessageCompactBody } from "@/backend";
 import { getBackend } from "@/backend";
-import { refreshCustomCommands } from "@/cli/commands/custom";
 import { formatErrorDetails } from "@/cli/helpers/error-formatter";
 import {
   buildDoctorMessage,
@@ -39,20 +38,15 @@ import type {
   StreamDelta,
 } from "@/types/protocol_v2";
 import { debugLog } from "@/utils/debug";
-import { markSecretsReminderRefreshPending } from "./commands/secrets";
 import { getConversationWorkingDirectory } from "./cwd";
-import { reloadListenerModAdapter } from "./mod-adapter";
 import { getListenerModCommand, runListenerModCommand } from "./mod-commands";
 import {
   createLifecycleMessageBase,
   emitCanonicalMessageDelta,
   emitDeviceStatusUpdate,
 } from "./protocol-outbound";
+import { reloadListenerRuntimeSurfaces } from "./reload-runtime";
 import { clearConversationRuntimeState, emitListenerStatus } from "./runtime";
-import {
-  ensureSecretsHydratedForAgent,
-  invalidateSecretsCacheForAgent,
-} from "./secrets-sync";
 import {
   buildMaybeLaunchReflectionSubagent,
   handleIncomingMessage,
@@ -305,30 +299,9 @@ async function handleModCommand(
 async function handleReloadCommand(
   conversationRuntime: ConversationRuntime,
 ): Promise<string> {
-  const { listener } = conversationRuntime;
-  settingsManager.clearCaches();
-  await settingsManager.loadProjectSettings();
-  await settingsManager.loadLocalProjectSettings();
-
-  try {
-    refreshCustomCommands();
-  } catch (error) {
-    debugLog(
-      "commands",
-      "refreshCustomCommands failed during /reload:",
-      error instanceof Error ? error.message : String(error),
-    );
-  }
-
-  await reloadListenerModAdapter(listener);
-
-  if (conversationRuntime.agentId) {
-    invalidateSecretsCacheForAgent(listener, conversationRuntime.agentId);
-    markSecretsReminderRefreshPending(listener, conversationRuntime.agentId);
-    await ensureSecretsHydratedForAgent(listener, conversationRuntime.agentId);
-  }
-
-  return "Reloaded settings, local mods, and agent secrets";
+  return reloadListenerRuntimeSurfaces(conversationRuntime.listener, {
+    agentId: conversationRuntime.agentId,
+  });
 }
 
 async function handleUpgradeLettaCodeCommand(opts: {

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -82,6 +82,7 @@ import {
 } from "./protocol-outbound";
 import { scheduleQueuePump } from "./queue";
 import { recoverApprovalStateForSync } from "./recovery";
+import { reloadListenerRuntimeSurfaces } from "./reload-runtime";
 import {
   clearConversationRuntimeState,
   clearRuntimeTimers,
@@ -515,6 +516,14 @@ export async function wireChannelIngress(
       processQueuedTurn,
     }),
   );
+
+  registry.setReloadHandler(async ({ runtime }) => ({
+    handled: true,
+    text: await reloadListenerRuntimeSurfaces(listener, {
+      agentId: runtime?.agent_id,
+      logger: opts.onLog,
+    }),
+  }));
 
   registry.setModelHandler(async ({ channelId, runtime, modelIdentifier }) => {
     if (!modelIdentifier) {

--- a/src/websocket/listener/reload-runtime.ts
+++ b/src/websocket/listener/reload-runtime.ts
@@ -1,0 +1,85 @@
+import {
+  type ChannelReloadSummary,
+  getChannelRegistry,
+} from "@/channels/registry";
+import { refreshCustomCommands } from "@/cli/commands/custom";
+import { settingsManager } from "@/settings-manager";
+import { debugLog } from "@/utils/debug";
+import { markSecretsReminderRefreshPending } from "./commands/secrets";
+import { reloadListenerModAdapter } from "./mod-adapter";
+import {
+  ensureSecretsHydratedForAgent,
+  invalidateSecretsCacheForAgent,
+} from "./secrets-sync";
+import type { ListenerRuntime } from "./types";
+
+function formatChannelReloadFailures(
+  failures: ChannelReloadSummary["failures"],
+): string {
+  return failures
+    .map((failure) => {
+      const label = failure.accountId
+        ? `${failure.channelId}/${failure.accountId}`
+        : failure.channelId;
+      return `${label}: ${failure.error}`;
+    })
+    .join("; ");
+}
+
+export async function reloadListenerRuntimeSurfaces(
+  listener: ListenerRuntime,
+  options: {
+    agentId?: string | null;
+    logger?: (message: string) => void;
+  } = {},
+): Promise<string> {
+  settingsManager.clearCaches();
+  await settingsManager.loadProjectSettings();
+  await settingsManager.loadLocalProjectSettings();
+
+  try {
+    refreshCustomCommands();
+  } catch (error) {
+    debugLog(
+      "commands",
+      "refreshCustomCommands failed during /reload:",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+
+  await reloadListenerModAdapter(listener);
+
+  const agentId = options.agentId?.trim();
+  if (agentId) {
+    invalidateSecretsCacheForAgent(listener, agentId);
+    markSecretsReminderRefreshPending(listener, agentId);
+    await ensureSecretsHydratedForAgent(listener, agentId);
+  }
+
+  const registry = getChannelRegistry();
+  const channelReloadSummary = registry
+    ? await registry.reloadActiveChannels({ logger: options.logger })
+    : null;
+
+  const base = agentId
+    ? "Reloaded settings, local mods, and agent secrets"
+    : "Reloaded settings and local mods";
+
+  if (!channelReloadSummary) {
+    return `${base}. No running channel registry was found.`;
+  }
+
+  const channelParts = [
+    `restarted ${channelReloadSummary.restarted}`,
+    `stopped ${channelReloadSummary.stopped}`,
+  ];
+  if (channelReloadSummary.failures.length > 0) {
+    channelParts.push(
+      `failed ${channelReloadSummary.failures.length} (${formatChannelReloadFailures(
+        channelReloadSummary.failures,
+      )})`,
+    );
+  }
+
+  return `${base}. Channel adapters: ${channelParts.join(", ")}.`;
+}


### PR DESCRIPTION
## Summary

This makes /reload refresh the channel runtime as well as settings and local mods. The listener reload flow now asks the channel registry to clear plugin caches and restart the active/restorable channel accounts, so adapter changes can be picked up without restarting the whole factory/listener process.

The channel slash-command layer also recognizes /reload directly from Slack/Telegram/etc. That means a routed Slack thread can trigger the same listener reload path instead of sending the command through the agent conversation.

## Behavior change

Before: /reload refreshed settings, custom commands, local mods, and agent secrets, but running channel adapters kept their already-loaded module instances.

After: /reload also reloads channel plugin modules and restarts the currently configured/restorable channel adapters. The response includes restarted/stopped/failure counts so failures are visible without pretending the reload was complete.

## Implementation notes

First-party and user channel plugins are loaded through a reload generation. Bun does not reliably reload a changed file module just because a query string is added to a file URL, so reload copies the channel plugin directory into a generation-specific .letta/channel-reload path before importing it. That gives the runtime a genuinely new module path while keeping normal startup on the existing static imports.

## Validation

- bun test src/channels/commands.test.ts src/channels/registry.test.ts src/channels/plugin-registry.test.ts
- bun test src/websocket/listen-client-protocol.test.ts
- bun run check
- Manual smoke: reloadChannelPlugins() + loadChannelPlugin("slack") successfully loads the reloaded Slack plugin

## Risk / limits

This restarts channel adapters in-process; it does not reload unrelated process state or change how credentials are stored. If an adapter start fails after reload, the response reports the failing channel/account and leaves the failure visible rather than silently swallowing it.

👾 Generated with [Letta Code](https://letta.com)