### PR TITLE
feat(tools): make shell `description` a required parameter across toolsets

### DIFF
--- a/src/cli/approval-classification.test.ts
+++ b/src/cli/approval-classification.test.ts
@@ -125,7 +125,7 @@ describe("classifyApprovals", () => {
           toolCallId: "call_missing_cmd",
           toolName: "exec_command",
           toolArgs: JSON.stringify({
-            yield_time_ms: 1000,
+            description: "Wait for command output",
           }),
         },
       ],
@@ -142,7 +142,7 @@ describe("classifyApprovals", () => {
     const [denied] = result.autoDenied;
     expect(denied?.missingRequiredArgs).toEqual(["cmd"]);
     expect(denied?.denyReason).toBe(
-      "exec_command tool missing required parameter: cmd. Received parameters: yield_time_ms",
+      "exec_command tool missing required parameter: cmd. Received parameters: description",
     );
   });
 

--- a/src/tools/codex-unified-exec-toolset.test.ts
+++ b/src/tools/codex-unified-exec-toolset.test.ts
@@ -40,7 +40,7 @@ describe("Codex unified exec toolset", () => {
       "",
       "For ordinary one-shot commands, omit `yield_time_ms` and let the default wait for completion; set `yield_time_ms` only when intentionally returning early from a long-running or interactive command.",
       "",
-      "Use the optional `description` field for a clear, concise user-facing status label for what the command does. It may be shown directly in chat with no prefix, so make it grammatical by itself and avoid tense-dependent wording. Use an imperative or purpose phrase like `Find debug log entries` or `Search recent logs for errors`. Describe the command's purpose, not its shell syntax. Keep it brief for simple commands; add only enough context to clarify commands that are hard to parse at a glance.",
+      "Provide the required `description` field as a clear, concise user-facing status label for what the command does. It may be shown directly in chat with no prefix, so make it grammatical by itself and avoid tense-dependent wording. Use an imperative or purpose phrase like `Find debug log entries` or `Search recent logs for errors`. Describe the command's purpose, not its shell syntax. Keep it brief for simple commands; add only enough context to clarify commands that are hard to parse at a glance.",
       "",
       extractCommitGuidance(ShellDescription),
     ].join("\n");

--- a/src/tools/descriptions/Bash.md
+++ b/src/tools/descriptions/Bash.md
@@ -21,9 +21,9 @@ Before executing the command, please follow these steps:
    - Capture the output of the command.
 
 Usage notes:
-  - The command argument is required.
+  - The command and description arguments are required.
   - You can specify an optional timeout in milliseconds (up to 600000ms / 10 minutes). If not specified, commands will timeout after 120000ms (2 minutes).
-  - It is very helpful if you write a clear, concise user-facing description of what this command does. This description may be shown directly in chat as part of a status row like `Running command: <description>` or `Ran command: <description>`. Describe the command's purpose, not its shell syntax. For simple commands, keep it brief (5-10 words). For complex commands (piped commands, obscure flags, or anything hard to understand at a glance), add enough context to clarify what it does.
+  - Write a clear, concise user-facing description of what this command does. This description may be shown directly in chat as part of a status row like `Running command: <description>` or `Ran command: <description>`. Describe the command's purpose, not its shell syntax. For simple commands, keep it brief (5-10 words). For complex commands (piped commands, obscure flags, or anything hard to understand at a glance), add enough context to clarify what it does.
   - If the output exceeds 30000 characters, output will be truncated before being returned to you.
   - You can use the `run_in_background` parameter to run the command in the background. Only use this if you don't need the result immediately and are OK being notified when the command completes later. You do not need to check the output right away - you'll be notified when it finishes. You do not need to use '&' at the end of the command when using this parameter.
   

--- a/src/tools/descriptions/ExecCommand.md
+++ b/src/tools/descriptions/ExecCommand.md
@@ -2,7 +2,7 @@ Runs a command in a PTY, returning output or a session ID for ongoing interactio
 
 For ordinary one-shot commands, omit `yield_time_ms` and let the default wait for completion; set `yield_time_ms` only when intentionally returning early from a long-running or interactive command.
 
-Use the optional `description` field for a clear, concise user-facing status label for what the command does. It may be shown directly in chat with no prefix, so make it grammatical by itself and avoid tense-dependent wording. Use an imperative or purpose phrase like `Find debug log entries` or `Search recent logs for errors`. Describe the command's purpose, not its shell syntax. Keep it brief for simple commands; add only enough context to clarify commands that are hard to parse at a glance.
+Provide the required `description` field as a clear, concise user-facing status label for what the command does. It may be shown directly in chat with no prefix, so make it grammatical by itself and avoid tense-dependent wording. Use an imperative or purpose phrase like `Find debug log entries` or `Search recent logs for errors`. Describe the command's purpose, not its shell syntax. Keep it brief for simple commands; add only enough context to clarify commands that are hard to parse at a glance.
 
 # Committing changes with git
 

--- a/src/tools/descriptions/RunShellCommandGemini.md
+++ b/src/tools/descriptions/RunShellCommandGemini.md
@@ -1,4 +1,4 @@
-This tool executes a given shell command as `bash -c <command>`. Command can start background processes using `&`. Command is executed as a subprocess that leads its own process group. Command process group can be terminated as `kill -- -PGID` or signaled as `kill -s SIGNAL -- -PGID`.
+This tool executes a given shell command as `bash -c <command>`. Command can start background processes using `&`. Command is executed as a subprocess that leads its own process group. Command process group can be terminated as `kill -- -PGID` or signaled as `kill -s SIGNAL -- -PGID`. Provide the required `description` field as a clear, concise user-facing status label for what the command does.
 
 The following information is returned:
 

--- a/src/tools/descriptions/ShellCommand.md
+++ b/src/tools/descriptions/ShellCommand.md
@@ -1,4 +1,5 @@
 Runs a shell command and returns its output.
+- Provide the required `description` field as a clear, concise user-facing status label for what the command does.
 - Always set the `workdir` param when using the shell_command function. Do not use `cd` unless absolutely necessary.
 
 # Committing changes with git

--- a/src/tools/impl/run-shell-command-gemini.ts
+++ b/src/tools/impl/run-shell-command-gemini.ts
@@ -20,6 +20,7 @@ export async function run_shell_command(
 ): Promise<{ message: string }> {
   const result = await shell_command({
     command: args.command,
+    description: args.description,
     workdir: args.dir_path,
     timeout_ms: args.timeout_ms,
     signal: args.signal,

--- a/src/tools/impl/shell-command.ts
+++ b/src/tools/impl/shell-command.ts
@@ -8,6 +8,7 @@ import { validateRequiredParams } from "./validation.js";
 
 interface ShellCommandArgs {
   command: string;
+  description?: string;
   workdir?: string;
   login?: boolean;
   timeout_ms?: number;

--- a/src/tools/schemas/Bash.json
+++ b/src/tools/schemas/Bash.json
@@ -18,7 +18,7 @@
       "description": "Set to true to run this command in the background. Use TaskOutput to read the output later."
     }
   },
-  "required": ["command"],
+  "required": ["command", "description"],
   "additionalProperties": false,
   "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/src/tools/schemas/ExecCommand.json
+++ b/src/tools/schemas/ExecCommand.json
@@ -35,6 +35,6 @@
       "description": "Wait before yielding output. Defaults to 10000 ms; effective range is 250-30000 ms."
     }
   },
-  "required": ["cmd"],
+  "required": ["cmd", "description"],
   "additionalProperties": false
 }

--- a/src/tools/schemas/RunShellCommandGemini.json
+++ b/src/tools/schemas/RunShellCommandGemini.json
@@ -15,6 +15,6 @@
       "description": "(OPTIONAL) The path of the directory to run the command in. If not provided, the project root directory is used. Must be a directory within the workspace and must already exist."
     }
   },
-  "required": ["command"],
+  "required": ["command", "description"],
   "additionalProperties": false
 }

--- a/src/tools/schemas/ShellCommand.json
+++ b/src/tools/schemas/ShellCommand.json
@@ -6,6 +6,10 @@
       "type": "string",
       "description": "Shell script to run in the user's default shell."
     },
+    "description": {
+      "type": "string",
+      "description": "Clear, concise user-facing status label for what this command does. It may be shown directly in chat with no prefix, so make it grammatical by itself and avoid tense-dependent wording. Use an imperative or purpose phrase like `Find debug log entries` or `Search recent logs for errors`. Describe the command's purpose, not its shell syntax."
+    },
     "workdir": {
       "type": "string",
       "description": "Working directory for the command. Defaults to the turn cwd."
@@ -35,6 +39,6 @@
       "description": "Reusable approval prefix for the command, only with `sandbox_permissions: \"require_escalated\"`; for example [\"git\", \"pull\"]."
     }
   },
-  "required": ["command"],
+  "required": ["command", "description"],
   "additionalProperties": false
 }

--- a/src/tools/shell-secrets.test.ts
+++ b/src/tools/shell-secrets.test.ts
@@ -175,9 +175,9 @@ describe("shell secret execution", () => {
     try {
       const calls = [
         ["Bash", { command, description: "Test shell secrets" }],
-        ["shell_command", { command }],
-        ["ShellCommand", { command }],
-        ["run_shell_command", { command }],
+        ["shell_command", { command, description: "Test shell secrets" }],
+        ["ShellCommand", { command, description: "Test shell secrets" }],
+        ["run_shell_command", { command, description: "Test shell secrets" }],
       ] as const;
 
       for (const [toolName, args] of calls) {


### PR DESCRIPTION
## Summary
- Split out of #3029 (Slack rich live progress cards) so this model-facing change gets its own review — it affects every toolset and every session, not just Slack.
- Makes `description` required (schema `required` array + tool description text) on Bash, exec_command, shell_command/ShellCommand, and run_shell_command, so shell tool calls always carry a user-facing status label. Chat surfaces and the Slack progress cards in #3029 use this label; the cards fall back to the command text when the field is absent, so #3029 does not depend on this PR.
- Adds the `description` field to the ShellCommand schema/impl and passes it through from run_shell_command.

## Reviewer notes (please interrogate)
- Approval classification auto-denies tool calls that omit schema-required params (`src/cli/helpers/approval-classification.ts`), so models that skip `description` will have shell calls denied with a corrective message rather than executed. This is the main behavioral risk across models/providers.
- This deviates from upstream Codex parity for `exec_command`, where the field was previously an optional overlay (`src/tools/codex-unified-exec-toolset.test.ts` text updated accordingly).

Original change authored in #3029 by overlord (lettamate), co-authored here for credit.

👾 Generated with [Letta Code](https://letta.com)