### PR TITLE
fix(slack): never leave progress cards stuck on dead streams (LET-9499)

### DIFF
--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -3229,7 +3229,7 @@ test("slack adapter keeps progress cards active across completed continuation li
   expect(writeClient?.chat.startStream).toHaveBeenCalledTimes(2);
 });
 
-test("slack adapter treats already-closed stream stop errors as benign", async () => {
+test("slack adapter rewrites dead streams with the final card state", async () => {
   const adapter = createSlackAdapter({
     ...slackAccountDefaults,
     channel: "slack",
@@ -3302,7 +3302,246 @@ test("slack adapter treats already-closed stream stop errors as benign", async (
     text: "Done.",
     thread_ts: "1712790000.000050",
   });
-  expect(writeClient?.chat.update).not.toHaveBeenCalled();
+  // Slack already took the message out of streaming state (expiry or an
+  // external stop), so stopStream cannot deliver the final retitle. The
+  // adapter rewrites the message via chat.update instead of silently
+  // dropping the terminal state and leaving a red in-progress row.
+  expect(writeClient?.chat.update).toHaveBeenCalledTimes(1);
+  const updateCalls = writeClient?.chat.update.mock.calls as unknown as Array<
+    Array<{
+      channel: string;
+      ts: string;
+      text: string;
+      blocks?: Array<{ type: string; text?: { text?: string } }>;
+    }>
+  >;
+  const updateArgs = updateCalls[0]?.[0];
+  expect(updateArgs).toMatchObject({
+    channel: "C123",
+    ts: "1712800000.000300",
+  });
+  const renderedBlocks = JSON.stringify(updateArgs?.blocks ?? []);
+  expect(renderedBlocks).toContain("Read");
+  expect(renderedBlocks).toContain(":white_check_mark:");
+  expect(renderedBlocks).not.toContain("in_progress");
+});
+
+test("slack adapter closes cancelled turns without the red error status", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+  const source = {
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    chatType: "channel" as const,
+    senderId: "U123",
+    senderTeamId: "T123",
+    messageId: "1712800000.000100",
+    threadId: "1712790000.000050",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  };
+
+  await adapter.start();
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-1",
+    sources: [source],
+    kind: "tool",
+    state: "started",
+    message: "Reading files",
+    toolCallId: "call-1",
+    toolName: "read_file",
+  });
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "finished",
+    batchId: "batch-1",
+    outcome: "cancelled",
+    sources: [source],
+  });
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient?.chat.stopStream).toHaveBeenCalledTimes(1);
+  const stopCalls = writeClient?.chat.stopStream.mock.calls as unknown as Array<
+    Array<{ chunks?: Array<Record<string, unknown>> }>
+  >;
+  const stopChunks = stopCalls[0]?.[0]?.chunks ?? [];
+  // A user stop is not a failure: no chunk may carry the red error status.
+  expect(stopChunks.filter((chunk) => chunk.status === "error")).toHaveLength(
+    0,
+  );
+  expect(stopChunks).toContainEqual({
+    type: "task_update",
+    id: "task_call-1",
+    title: "Read",
+    status: "complete",
+  });
+  expect(stopChunks).toContainEqual({
+    type: "plan_update",
+    title: "Cancelled",
+  });
+});
+
+test("slack adapter stops appending after the stream leaves streaming state and rewrites at finish", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+  const source = {
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    chatType: "channel" as const,
+    senderId: "U123",
+    senderTeamId: "T123",
+    messageId: "1712800000.000100",
+    threadId: "1712790000.000050",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  };
+
+  await adapter.start();
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-1",
+    sources: [source],
+    kind: "tool",
+    state: "started",
+    message: "Reading files",
+    toolCallId: "call-1",
+    toolName: "read_file",
+  });
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  // Slack expired the stream mid-turn (e.g. idle timeout).
+  writeClient?.chat.appendStream.mockResolvedValueOnce({
+    ok: false,
+    error: "message_not_in_streaming_state",
+  });
+
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-1",
+    sources: [source],
+    kind: "tool",
+    state: "started",
+    message: "Searching files",
+    toolCallId: "call-2",
+    toolName: "grep",
+  });
+  const appendCallsAfterDeath =
+    writeClient?.chat.appendStream.mock.calls.length ?? 0;
+
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-1",
+    sources: [source],
+    kind: "tool",
+    state: "completed",
+    message: "Searched files",
+    toolCallId: "call-2",
+    toolName: "grep",
+  });
+  // A dead stream accepts no further appends.
+  expect(writeClient?.chat.appendStream.mock.calls.length ?? 0).toBe(
+    appendCallsAfterDeath,
+  );
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "finished",
+    batchId: "batch-1",
+    outcome: "completed",
+    sources: [source],
+  });
+  // The final assistant reply closes the active card immediately.
+  await adapter.sendMessage({
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    text: "Done.",
+    threadId: "1712790000.000050",
+  });
+
+  // Finishing must not call stopStream on a dead stream; the final state is
+  // rewritten onto the frozen message via chat.update instead.
+  expect(writeClient?.chat.stopStream).not.toHaveBeenCalled();
+  expect(writeClient?.chat.update).toHaveBeenCalledTimes(1);
+  const updateCalls = writeClient?.chat.update.mock.calls as unknown as Array<
+    Array<{ channel: string; ts: string; blocks?: unknown[] }>
+  >;
+  expect(updateCalls[0]?.[0]).toMatchObject({
+    channel: "C123",
+    ts: "1712800000.000300",
+  });
+  const renderedBlocks = JSON.stringify(updateCalls[0]?.[0]?.blocks ?? []);
+  expect(renderedBlocks).toContain("Search");
+  expect(renderedBlocks).not.toContain("in_progress");
+});
+
+test("slack adapter keepalive survives a transient append failure", async () => {
+  process.env.LETTA_SLACK_PROGRESS_STREAM_KEEPALIVE_MS = "20";
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+  const source = {
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    chatType: "channel" as const,
+    senderId: "U123",
+    senderTeamId: "T123",
+    messageId: "1712800000.000100",
+    threadId: "1712790000.000050",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  };
+
+  await adapter.start();
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-1",
+    sources: [source],
+    kind: "tool",
+    state: "started",
+    message: "Reading files",
+    toolCallId: "call-1",
+    toolName: "read_file",
+  });
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  // One transient failure (rate limit / network blip) must not permanently
+  // silence the keepalive — Slack expires idle streams into a red card.
+  writeClient?.chat.appendStream.mockResolvedValueOnce({
+    ok: false,
+    error: "ratelimited",
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 120));
+
+  expect(
+    writeClient?.chat.appendStream.mock.calls.length ?? 0,
+  ).toBeGreaterThanOrEqual(2);
 });
 
 test("slack adapter includes final error details in rich progress streams", async () => {

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -44,6 +44,7 @@ import {
   isTaskTool,
   isWebSearchTool,
 } from "@/cli/helpers/tool-name-mapping";
+import { trackBoundaryError } from "@/telemetry/error-reporting";
 import {
   resolveSlackChannelHistory,
   resolveSlackInboundAttachments,
@@ -543,6 +544,9 @@ function normalizeSlackReactionName(value: string): string {
 const SLACK_INGRESS_DEDUPE_TTL_MS = 60_000;
 const SLACK_INGRESS_DEDUPE_MAX = 2_000;
 const SLACK_LIFECYCLE_ERROR_TEXT_MAX = 3_000;
+// Slack section blocks cap mrkdwn text at 3000 characters; leave headroom
+// for the truncation marker when rewriting a dead stream's final state.
+const SLACK_DEAD_STREAM_REWRITE_TEXT_MAX = 2_900;
 const SLACK_PROGRESS_CARD_TEXT_MAX = 300;
 const SLACK_PROGRESS_CARD_STATE_TTL_MS = 6 * 60 * 60 * 1000;
 const SLACK_PROGRESS_CARD_STATE_MAX = 2_000;
@@ -583,6 +587,13 @@ type SlackProgressCardEntry = {
   source: ChannelTurnSource;
   mode?: "stream";
   streamTs?: string;
+  /**
+   * Set once Slack reports the stream left streaming state while we still
+   * expected it to be live (expiry, external stop). A dead stream never
+   * accepts appends again; the terminal flush rewrites the message via
+   * chat.update instead so the card cannot stay stuck on a red spinner row.
+   */
+  streamDead?: boolean;
   status: SlackProgressCardState;
   latestText: string;
   latestUpdate?: ChannelTurnProgressEvent;
@@ -793,9 +804,15 @@ function buildTerminalSlackStreamChunks(
       }
       continue;
     }
+    // Preserve rows that already reached a real terminal state: completed
+    // rows always, and errored rows unless the turn itself completed (a
+    // completed turn intentionally downgrades stale error rows). Keyed on the
+    // turn outcome, not terminalTaskStatus, so cancelled turns (which now
+    // close remaining rows as "complete"/"Stopped") keep genuine tool
+    // failures visible instead of repainting them green.
     const shouldPreserveTerminalTask =
       task.status === "complete" ||
-      (task.status === "error" && terminalTaskStatus !== "complete");
+      (task.status === "error" && entry.status !== "completed");
     const terminalTask = shouldPreserveTerminalTask
       ? task
       : {
@@ -819,6 +836,69 @@ function buildTerminalSlackStreamChunks(
     chunks.push(buildSlackPlanUpdateChunk(entry));
   }
   return chunks;
+}
+
+/**
+ * Render terminal stream chunks as plain message blocks for a stream Slack
+ * has already taken out of streaming state (expired or externally stopped).
+ *
+ * stopStream no-ops with `message_not_in_streaming_state` on such messages,
+ * which previously dropped the final retitle/error details entirely and left
+ * the card stuck on a red in-progress row. Rewriting the message via
+ * chat.update replaces the stale streaming UI with the real final state.
+ */
+function buildSlackDeadStreamRewrite(
+  entry: SlackProgressCardEntry,
+  chunks: SlackStreamChunk[],
+): { text: string; blocks: SlackBlock[] } {
+  const planTitle = chunks.reduce<string | null>(
+    (latest, chunk) => (chunk.type === "plan_update" ? chunk.title : latest),
+    null,
+  );
+  const headerText =
+    sanitizeSlackProgressText(planTitle ?? "", SLACK_STREAM_CHUNK_TEXT_MAX) ||
+    formatSlackProgressCardText(entry.status, entry.latestText);
+  const lines: string[] = [];
+  for (const chunk of chunks) {
+    if (chunk.type !== "task_update") {
+      continue;
+    }
+    const icon =
+      chunk.status === "error"
+        ? ":warning:"
+        : chunk.status === "complete"
+          ? ":white_check_mark:"
+          : ":hourglass_flowing_sand:";
+    const details = isNonEmptyString(chunk.details)
+      ? ` — ${chunk.details}`
+      : "";
+    lines.push(`${icon} ${chunk.title}${details}`);
+  }
+  const body = truncateChannelProgressText(
+    lines.join("\n"),
+    SLACK_DEAD_STREAM_REWRITE_TEXT_MAX,
+    "…",
+  );
+  const blocks: SlackBlock[] = [
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: `*${headerText}*` },
+    },
+  ];
+  if (body) {
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: body },
+    });
+  }
+  const footnote = buildSlackChatFootnote(entry.source);
+  if (footnote) {
+    blocks.push({
+      type: "context",
+      elements: [{ type: "mrkdwn", text: footnote }],
+    });
+  }
+  return { text: headerText, blocks };
 }
 
 function isDuplicateSkillTaskDetails(
@@ -2532,6 +2612,7 @@ export function createSlackAdapter(
       }
       entry.mode = "stream";
       entry.streamTs = response.ts;
+      entry.streamDead = undefined;
       rememberMessageThread(response.ts, replyToMessageId);
       rememberSlackStreamTaskDetails(entry, args.chunks ?? []);
       // Once the native stream card is visible, clear Slack's assistant
@@ -2548,12 +2629,70 @@ export function createSlackAdapter(
     }
   }
 
+  function markSlackProgressStreamDead(
+    entry: SlackProgressCardEntry,
+    reason: string,
+  ): void {
+    if (entry.streamDead) {
+      return;
+    }
+    entry.streamDead = true;
+    clearSlackProgressStreamKeepalive(entry);
+    console.warn(
+      "[Slack] Progress stream left streaming state unexpectedly:",
+      reason,
+    );
+    trackBoundaryError({
+      context: "slack progress stream",
+      errorType: "slack_progress_stream_dead",
+      error: reason,
+    });
+  }
+
+  /**
+   * Replace a dead stream's message content with the terminal card state via
+   * chat.update. Slack refuses stream calls once a message leaves streaming
+   * state, so this is the only way the final retitle/error details can still
+   * reach the thread instead of leaving a stuck red spinner row.
+   */
+  async function rewriteDeadSlackProgressStream(
+    entry: SlackProgressCardEntry,
+    chunks: SlackStreamChunk[],
+  ): Promise<boolean> {
+    if (!entry.streamTs) {
+      return false;
+    }
+    try {
+      const slackClient = await ensureWriteClient();
+      const { text, blocks } = buildSlackDeadStreamRewrite(entry, chunks);
+      await slackClient.chat.update({
+        channel: entry.source.chatId,
+        ts: entry.streamTs,
+        text,
+        blocks,
+      });
+      rememberSlackStreamTaskDetails(entry, chunks);
+      return true;
+    } catch (error) {
+      console.warn(
+        "[Slack] Failed to rewrite dead progress stream:",
+        error instanceof Error ? error.message : error,
+      );
+      return false;
+    }
+  }
+
   async function appendSlackProgressStream(
     entry: SlackProgressCardEntry,
     rawChunks: SlackStreamChunk[],
   ): Promise<boolean> {
     if (!entry.streamTs) {
       return true;
+    }
+    if (entry.streamDead) {
+      // Chunks requeue via the flush path and reach the thread through the
+      // terminal dead-stream rewrite instead.
+      return false;
     }
     const chunks = compactSlackStreamChunks(rawChunks, entry);
     if (chunks.length === 0) {
@@ -2572,6 +2711,9 @@ export function createSlackAdapter(
         chunks,
       });
       if (response.ok === false) {
+        if (isSlackMessageNotStreamingStateError(response.error)) {
+          markSlackProgressStreamDead(entry, "append_not_in_streaming_state");
+        }
         console.warn(
           "[Slack] Failed to append progress stream:",
           response.error ?? "unknown error",
@@ -2581,6 +2723,9 @@ export function createSlackAdapter(
       rememberSlackStreamTaskDetails(entry, chunks);
       return true;
     } catch (error) {
+      if (isSlackMessageNotStreamingStateError(error)) {
+        markSlackProgressStreamDead(entry, "append_not_in_streaming_state");
+      }
       console.warn(
         "[Slack] Failed to append progress stream:",
         error instanceof Error ? error.message : error,
@@ -2602,17 +2747,20 @@ export function createSlackAdapter(
     if (!stopStream) {
       return false;
     }
+    // Only a genuinely failed turn closes remaining rows with the red error
+    // status. Cancelled turns are user stops, not failures — their rows close
+    // as "Stopped" with a neutral complete status so an interrupted turn is
+    // visually distinguishable from a crashed one.
     const terminalTaskStatus: SlackStreamTaskStatus =
-      entry.status === "error"
-        ? "error"
-        : entry.status === "cancelled"
-          ? "error"
-          : "complete";
+      entry.status === "error" ? "error" : "complete";
     const chunks = buildTerminalSlackStreamChunks(
       entry,
       terminalTaskStatus,
       finalErrorChunk,
     );
+    if (entry.streamDead) {
+      return await rewriteDeadSlackProgressStream(entry, chunks);
+    }
     try {
       const args: SlackStopStreamArgs = {
         channel: entry.source.chatId,
@@ -2629,7 +2777,8 @@ export function createSlackAdapter(
       const response = await stopStream.call(slackClient.chat, args);
       if (response.ok === false) {
         if (isSlackMessageNotStreamingStateError(response.error)) {
-          return true;
+          markSlackProgressStreamDead(entry, "stop_not_in_streaming_state");
+          return await rewriteDeadSlackProgressStream(entry, chunks);
         }
         console.warn(
           "[Slack] Failed to stop progress stream:",
@@ -2641,7 +2790,8 @@ export function createSlackAdapter(
       return true;
     } catch (error) {
       if (isSlackMessageNotStreamingStateError(error)) {
-        return true;
+        markSlackProgressStreamDead(entry, "stop_not_in_streaming_state");
+        return await rewriteDeadSlackProgressStream(entry, chunks);
       }
       console.warn(
         "[Slack] Failed to stop progress stream:",
@@ -2726,6 +2876,7 @@ export function createSlackAdapter(
       entry.keepaliveTimer ||
       entry.status !== "processing" ||
       entry.mode !== "stream" ||
+      entry.streamDead ||
       !entry.streamTs
     ) {
       return;
@@ -2746,6 +2897,14 @@ export function createSlackAdapter(
           buildSlackPlanUpdateChunk(entry),
         ]);
         if (!didAppend) {
+          // A transient append failure (rate limit, network blip) must not
+          // permanently silence the keepalive: Slack expires idle streams and
+          // an expired stream renders a stuck red warning row. Keep retrying
+          // on the same cadence until the turn finishes or the stream is
+          // confirmed dead.
+          if (!entry.streamDead) {
+            scheduleSlackProgressStreamKeepalive(key, entry);
+          }
           return;
         }
         entry.lastSentAt = Date.now();
@@ -3091,6 +3250,7 @@ export function createSlackAdapter(
         // blocks in the Slack accordion.
         entry.mode = undefined;
         entry.streamTs = undefined;
+        entry.streamDead = undefined;
         entry.toolTasksById = undefined;
         entry.pendingStreamChunks = undefined;
         entry.toolNamesByCallId = undefined;
@@ -3789,6 +3949,18 @@ export function createSlackAdapter(
           event.batchId,
           event.error,
         );
+      }
+
+      if (event.outcome === "error") {
+        // Every turn that surfaces as a red "Turn failed" card also emits a
+        // telemetry event, so genuine SADs are measurable and separable from
+        // cosmetic dead-stream artifacts (slack_progress_stream_dead).
+        trackBoundaryError({
+          context: "slack channel turn",
+          errorType: "slack_channel_turn_error",
+          error: event.error?.trim() || "unknown error",
+          runId: event.runId ?? undefined,
+        });
       }
 
       const errorText = event.outcome === "error" ? event.error?.trim() : null;


### PR DESCRIPTION
Stacked on #3029. Fixes the dominant class of LET-9499 "SAD" reports: red rich-spinner cards that are cosmetic dead-stream artifacts, not agent failures. Investigation details in [LET-9499](https://linear.app/letta/issue/LET-9499/many-sads-where-the-final-output-is-a-red-status-on-the-rich-spinner) (two comments: failure-chain analysis + OpenClaw comparison).

## Invariant

A Slack progress card can never remain in a red/streaming state after its turn reaches a terminal outcome, and terminal information (final retitle, error details) is never silently dropped.

## What was broken

1. The 60s keepalive died permanently on its first failed append (rate limit, network blip). Slack then expired the idle stream, freezing the card on a red "Still working" row.
2. Once expired, stopStream fails with message_not_in_streaming_state — which the adapter treated as benign success, silently dropping the final retitle and any error details. The red card stayed red forever.
3. Cancelled turns mapped to the red error task status, so user stops looked like crashes.
4. No telemetry distinguished genuine turn failures from cosmetic artifacts.

## What this does

- Tracks dead streams (streamDead) on the first message_not_in_streaming_state from append or stop; dead streams accept no further appends and the keepalive stops.
- At finish, rewrites the dead stream message via chat.update with the terminal card state (task rows, error details, footnote) instead of pretending the failed stop succeeded.
- Keepalive reschedules after transient append failures instead of dying.
- Cancelled turns close remaining rows with the neutral complete status; genuine tool-failure rows stay red (preservation now keyed on turn outcome).
- PostHog events: slack_progress_stream_dead (cosmetic artifact) and slack_channel_turn_error (genuine SAD, includes run id) so the false-SAD rate is measurable and should go to ~zero after this.

Design follows OpenClaw's battle-tested Slack streaming contract (failure latch + fallback delivery, delivered-gated error swallowing, red only means error) — comparison on the Linear ticket.

Not in scope (possible follow-ups): boot-time reconciliation of orphaned streams across process restarts, mid-turn re-streaming after death (currently progress pauses until the terminal rewrite), empirically pinning Slack's expiry window.

👾 Generated with [Letta Code](https://letta.com)
