### PR TITLE
refactor(channels): remove vendor-specific code from websocket listener layer

### DIFF
--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -25,6 +25,40 @@ export type ChannelModelPickerData = {
   recentHandles?: string[];
 };
 
+/**
+ * Default channel id used for wire compatibility when WS clients omit
+ * `channel_id` on channel commands. Early protocol versions predate
+ * multi-channel support, when Telegram was the only bundled channel.
+ */
+export const LEGACY_DEFAULT_CHANNEL_ID = "telegram";
+
+/**
+ * Per-turn rich draft streaming policy derived from a channel account's
+ * generic opt-in fields. Returns null when the account has not opted in.
+ * Any channel account config may declare `richDraftStreaming` /
+ * `richPrivateChatDefault`; adapters that also implement
+ * `sendRichMessageDraft` get live draft streaming from the listener.
+ */
+export type ChannelRichDraftStreamingPolicy = {
+  richPrivateChatDefault: boolean;
+};
+
+export function getRichDraftStreamingPolicy(
+  account: unknown,
+): ChannelRichDraftStreamingPolicy | null {
+  if (!account || typeof account !== "object") {
+    return null;
+  }
+  const record = account as {
+    richDraftStreaming?: unknown;
+    richPrivateChatDefault?: unknown;
+  };
+  if (record.richDraftStreaming !== true) {
+    return null;
+  }
+  return { richPrivateChatDefault: record.richPrivateChatDefault !== false };
+}
+
 export const FIRST_PARTY_CHANNEL_IDS = [
   "telegram",
   "slack",

--- a/src/websocket/listener/channel-rich-draft-streamer.test.ts
+++ b/src/websocket/listener/channel-rich-draft-streamer.test.ts
@@ -11,8 +11,8 @@ import { __testOverrideChannelsRoot } from "@/channels/config";
 import { ChannelRegistry, getChannelRegistry } from "@/channels/registry";
 import type { ChannelAdapter, ChannelTurnSource } from "@/channels/types";
 import {
-  createTelegramRichDraftStreamer,
-  extractTelegramSendRichDraftIntent,
+  createChannelRichDraftStreamer,
+  extractChannelSendRichDraftIntent,
 } from "./channel-rich-draft-streamer";
 
 let channelRoot: string | null = null;
@@ -112,7 +112,7 @@ describe("Telegram rich draft streamer", () => {
     upsertTelegramAccount(false);
     registerTelegramAdapter();
 
-    const streamer = createTelegramRichDraftStreamer({
+    const streamer = createChannelRichDraftStreamer({
       batchId: "batch-1",
       sources: [telegramSource()],
       debounceMs: 0,
@@ -125,7 +125,7 @@ describe("Telegram rich draft streamer", () => {
     upsertTelegramAccount(true);
     const { sendRichMessageDraft } = registerTelegramAdapter();
 
-    const streamer = createTelegramRichDraftStreamer({
+    const streamer = createChannelRichDraftStreamer({
       batchId: "batch-1",
       sources: [telegramSource({ threadId: "42" })],
       debounceMs: 0,
@@ -160,7 +160,7 @@ describe("Telegram rich draft streamer", () => {
     upsertTelegramAccount(true);
     const { sendRichMessageDraft } = registerTelegramAdapter();
 
-    const streamer = createTelegramRichDraftStreamer({
+    const streamer = createChannelRichDraftStreamer({
       batchId: "batch-1",
       sources: [telegramSource()],
       debounceMs: 0,
@@ -194,7 +194,7 @@ describe("Telegram rich draft streamer", () => {
     upsertTelegramAccount(true, false);
     const { sendRichMessageDraft } = registerTelegramAdapter();
 
-    const streamer = createTelegramRichDraftStreamer({
+    const streamer = createChannelRichDraftStreamer({
       batchId: "batch-1",
       sources: [telegramSource()],
       debounceMs: 0,
@@ -220,7 +220,7 @@ describe("Telegram rich draft streamer", () => {
     upsertTelegramAccount(true);
     const { sendRichMessageDraft } = registerTelegramAdapter();
 
-    const streamer = createTelegramRichDraftStreamer({
+    const streamer = createChannelRichDraftStreamer({
       batchId: "batch-1",
       sources: [telegramSource({ chatType: "channel", threadId: "42" })],
       debounceMs: 0,
@@ -246,7 +246,7 @@ describe("Telegram rich draft streamer", () => {
     upsertTelegramAccount(true);
     const { sendRichMessageDraft } = registerTelegramAdapter();
 
-    const streamer = createTelegramRichDraftStreamer({
+    const streamer = createChannelRichDraftStreamer({
       batchId: "batch-1",
       sources: [telegramSource()],
       debounceMs: 750,
@@ -294,7 +294,7 @@ describe("Telegram rich draft streamer", () => {
     upsertTelegramAccount(true);
     const { sendRichMessageDraft } = registerTelegramAdapter();
 
-    const streamer = createTelegramRichDraftStreamer({
+    const streamer = createChannelRichDraftStreamer({
       batchId: "batch-1",
       sources: [telegramSource()],
       debounceMs: 30,
@@ -341,7 +341,7 @@ describe("Telegram rich draft streamer", () => {
     });
     registerTelegramAdapter(sendRichMessageDraft);
 
-    const streamer = createTelegramRichDraftStreamer({
+    const streamer = createChannelRichDraftStreamer({
       batchId: "batch-1",
       sources: [telegramSource()],
       debounceMs: 0,
@@ -384,7 +384,7 @@ describe("Telegram rich draft streamer", () => {
     upsertTelegramAccount(true);
     const { sendRichMessageDraft } = registerTelegramAdapter();
 
-    const streamer = createTelegramRichDraftStreamer({
+    const streamer = createChannelRichDraftStreamer({
       batchId: "batch-1",
       sources: [telegramSource()],
       debounceMs: 20,
@@ -439,7 +439,7 @@ describe("Telegram rich draft streamer", () => {
     });
     registerTelegramAdapter(sendRichMessageDraft);
 
-    const streamer = createTelegramRichDraftStreamer({
+    const streamer = createChannelRichDraftStreamer({
       batchId: "batch-1",
       sources: [telegramSource()],
       debounceMs: 0,
@@ -468,7 +468,7 @@ describe("Telegram rich draft streamer", () => {
   test("refuses drafts whose target route does not match the inbound source", async () => {
     upsertTelegramAccount(true);
     const { sendRichMessageDraft } = registerTelegramAdapter();
-    const streamer = createTelegramRichDraftStreamer({
+    const streamer = createChannelRichDraftStreamer({
       batchId: "batch-1",
       sources: [telegramSource()],
       debounceMs: 0,
@@ -496,7 +496,7 @@ describe("Telegram rich draft streamer", () => {
       throw new Error("draft endpoint unavailable");
     });
     registerTelegramAdapter(sendRichMessageDraft);
-    const streamer = createTelegramRichDraftStreamer({
+    const streamer = createChannelRichDraftStreamer({
       batchId: "batch-1",
       sources: [telegramSource()],
       debounceMs: 0,
@@ -519,7 +519,7 @@ describe("Telegram rich draft streamer", () => {
   });
 
   test("extracts partial JSON strings with real newlines", () => {
-    const intent = extractTelegramSendRichDraftIntent(
+    const intent = extractChannelSendRichDraftIntent(
       '{"action":"send-rich","channel":"telegram","chat_id":"chat-12345","message":"# Title\\n\\n- item',
       telegramSource() as ChannelTurnSource & {
         channel: "telegram";

--- a/src/websocket/listener/channel-rich-draft-streamer.ts
+++ b/src/websocket/listener/channel-rich-draft-streamer.ts
@@ -2,7 +2,7 @@ import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/ag
 import { getChannelAccount } from "@/channels/accounts";
 import { getChannelRegistry } from "@/channels/registry";
 import type { ChannelAdapter, ChannelTurnSource } from "@/channels/types";
-import { isTelegramChannelAccount } from "@/channels/types";
+import { getRichDraftStreamingPolicy } from "@/channels/types";
 import { debugLog, debugWarn } from "@/utils/debug";
 
 const MESSAGE_CHANNEL_TOOL_NAMES = new Set([
@@ -12,8 +12,7 @@ const MESSAGE_CHANNEL_TOOL_NAMES = new Set([
 const DEFAULT_DRAFT_DEBOUNCE_MS = 1000;
 const MIN_DRAFT_TEXT_LENGTH = 1;
 
-type TelegramDraftSource = ChannelTurnSource & {
-  channel: "telegram";
+type ChannelDraftSource = ChannelTurnSource & {
   accountId: string;
 };
 
@@ -44,48 +43,47 @@ type DraftCallState = {
 
 type UnknownRecord = Record<string, unknown>;
 
-export type TelegramRichDraftStreamer = {
+export type ChannelRichDraftStreamer = {
   handleChunk(chunk: LettaStreamingResponse): void;
   flushPending(): Promise<void>;
   dispose(): void;
 };
 
-export function createTelegramRichDraftStreamer(options: {
+export function createChannelRichDraftStreamer(options: {
   batchId: string;
   sources?: ChannelTurnSource[];
   debounceMs?: number;
-}): TelegramRichDraftStreamer | null {
-  const source = resolveSingleTelegramDraftSource(options.sources ?? []);
+}): ChannelRichDraftStreamer | null {
+  const source = resolveSingleChannelDraftSource(options.sources ?? []);
   if (!source) {
     debugLog(
       "channels",
-      "Telegram rich draft streamer disabled: no single Telegram source",
+      "Channel rich draft streamer disabled: no single channel source",
     );
     return null;
   }
 
-  const account = getChannelAccount("telegram", source.accountId);
-  if (
-    !account ||
-    !isTelegramChannelAccount(account) ||
-    account.richDraftStreaming !== true
-  ) {
+  const account = getChannelAccount(source.channel, source.accountId);
+  const policy = getRichDraftStreamingPolicy(account);
+  if (!policy) {
     debugLog(
       "channels",
-      "Telegram rich draft streamer disabled: account not opted in (%s)",
+      "Channel rich draft streamer disabled: account not opted in (%s:%s)",
+      source.channel,
       source.accountId,
     );
     return null;
   }
 
   const adapter = getChannelRegistry()?.getAdapter(
-    "telegram",
+    source.channel,
     source.accountId,
   );
   if (!adapter?.sendRichMessageDraft || !adapter.isRunning()) {
     debugLog(
       "channels",
-      "Telegram rich draft streamer disabled: adapter unavailable (%s)",
+      "Channel rich draft streamer disabled: adapter unavailable (%s:%s)",
+      source.channel,
       source.accountId,
     );
     return null;
@@ -93,38 +91,42 @@ export function createTelegramRichDraftStreamer(options: {
 
   debugLog(
     "channels",
-    "Telegram rich draft streamer enabled for account=%s chat=%s thread=%s",
+    "Channel rich draft streamer enabled for channel=%s account=%s chat=%s thread=%s",
+    source.channel,
     source.accountId,
     source.chatId,
     source.threadId ?? "",
   );
 
-  return new TelegramRichDraftStreamerImpl({
+  return new ChannelRichDraftStreamerImpl({
     adapter,
     batchId: options.batchId,
     source,
-    richPrivateChatDefault: account.richPrivateChatDefault !== false,
+    richPrivateChatDefault: policy.richPrivateChatDefault,
     debounceMs: options.debounceMs ?? DEFAULT_DRAFT_DEBOUNCE_MS,
   });
 }
 
-function resolveSingleTelegramDraftSource(
+function resolveSingleChannelDraftSource(
   sources: ChannelTurnSource[],
-): TelegramDraftSource | null {
-  const telegramSources = sources.filter(
-    (source): source is TelegramDraftSource =>
-      source.channel === "telegram" &&
+): ChannelDraftSource | null {
+  const candidateSources = sources.filter(
+    (source): source is ChannelDraftSource =>
       typeof source.accountId === "string" &&
-      source.accountId.trim().length > 0,
+      source.accountId.trim().length > 0 &&
+      getRichDraftStreamingPolicy(
+        getChannelAccount(source.channel, source.accountId.trim()),
+      ) !== null,
   );
-  if (telegramSources.length === 0) {
+  if (candidateSources.length === 0) {
     return null;
   }
 
-  const byRoute = new Map<string, TelegramDraftSource>();
-  for (const source of telegramSources) {
+  const byRoute = new Map<string, ChannelDraftSource>();
+  for (const source of candidateSources) {
     byRoute.set(
       [
+        source.channel,
         source.accountId.trim(),
         source.chatId,
         source.threadId ?? "",
@@ -138,10 +140,10 @@ function resolveSingleTelegramDraftSource(
   return byRoute.size === 1 ? ([...byRoute.values()][0] ?? null) : null;
 }
 
-class TelegramRichDraftStreamerImpl implements TelegramRichDraftStreamer {
+class ChannelRichDraftStreamerImpl implements ChannelRichDraftStreamer {
   private readonly adapter: ChannelAdapter;
   private readonly batchId: string;
-  private readonly source: TelegramDraftSource;
+  private readonly source: ChannelDraftSource;
   private readonly richPrivateChatDefault: boolean;
   private readonly debounceMs: number;
   private readonly calls = new Map<string, DraftCallState>();
@@ -153,7 +155,7 @@ class TelegramRichDraftStreamerImpl implements TelegramRichDraftStreamer {
   constructor(options: {
     adapter: ChannelAdapter;
     batchId: string;
-    source: TelegramDraftSource;
+    source: ChannelDraftSource;
     richPrivateChatDefault: boolean;
     debounceMs: number;
   }) {
@@ -202,7 +204,7 @@ class TelegramRichDraftStreamerImpl implements TelegramRichDraftStreamer {
       if (state.name && MESSAGE_CHANNEL_TOOL_NAMES.has(state.name)) {
         debugLog(
           "channels",
-          "Telegram rich draft streamer saw MessageChannel args: call=%s bytes=%d",
+          "Channel rich draft streamer saw MessageChannel args: call=%s bytes=%d",
           state.toolCallId,
           state.argumentsText.length,
         );
@@ -282,7 +284,7 @@ class TelegramRichDraftStreamerImpl implements TelegramRichDraftStreamer {
       return;
     }
 
-    const intent = extractTelegramSendRichDraftIntent(
+    const intent = extractChannelSendRichDraftIntent(
       state.argumentsText,
       this.source,
       { richPrivateChatDefault: this.richPrivateChatDefault },
@@ -290,7 +292,7 @@ class TelegramRichDraftStreamerImpl implements TelegramRichDraftStreamer {
     if (!intent) {
       debugLog(
         "channels",
-        "Telegram rich draft streamer waiting for routable intent: call=%s bytes=%d",
+        "Channel rich draft streamer waiting for routable intent: call=%s bytes=%d",
         state.toolCallId,
         state.argumentsText.length,
       );
@@ -305,7 +307,7 @@ class TelegramRichDraftStreamerImpl implements TelegramRichDraftStreamer {
     ) {
       debugLog(
         "channels",
-        "Telegram rich draft streamer skipped unchanged/empty draft: call=%s chars=%d",
+        "Channel rich draft streamer skipped unchanged/empty draft: call=%s chars=%d",
         state.toolCallId,
         message.length,
       );
@@ -342,13 +344,13 @@ class TelegramRichDraftStreamerImpl implements TelegramRichDraftStreamer {
     this.lastDraftAttemptAtMs = Date.now();
     debugLog(
       "channels",
-      "Telegram rich draft streamer sending draft: call=%s draft=%d chars=%d",
+      "Channel rich draft streamer sending draft: call=%s draft=%d chars=%d",
       state.toolCallId,
       state.draftId,
       message.length,
     );
     const draft = {
-      channel: "telegram",
+      channel: this.source.channel,
       accountId: this.source.accountId,
       chatId: this.source.chatId,
       threadId: this.source.threadId ?? null,
@@ -364,7 +366,7 @@ class TelegramRichDraftStreamerImpl implements TelegramRichDraftStreamer {
           state.lastSentMessage = message;
         }
       } catch (error) {
-        const retryAfterMs = getTelegramRetryAfterMs(error);
+        const retryAfterMs = extractRetryAfterMs(error);
         if (retryAfterMs !== null) {
           this.retryBlockedUntilMs = Math.max(
             this.retryBlockedUntilMs,
@@ -378,14 +380,14 @@ class TelegramRichDraftStreamerImpl implements TelegramRichDraftStreamer {
         }
         debugWarn(
           "channels",
-          `[Telegram] Rich draft update failed: ${
+          `[${this.source.channel}] Rich draft update failed: ${
             error instanceof Error ? error.message : String(error)
           }`,
         );
         if (retryAfterMs !== null) {
           debugWarn(
             "channels",
-            `[Telegram] Rich draft update rate-limited; retrying after ${retryAfterMs}ms`,
+            `[${this.source.channel}] Rich draft update rate-limited; retrying after ${retryAfterMs}ms`,
           );
         }
         return;
@@ -467,7 +469,12 @@ class TelegramRichDraftStreamerImpl implements TelegramRichDraftStreamer {
   }
 }
 
-function getTelegramRetryAfterMs(error: unknown): number | null {
+/**
+ * Best-effort extraction of a rate-limit retry hint from adapter send errors.
+ * Understands common bot-API shapes (`parameters.retry_after` seconds nested
+ * under response/payload/error) plus a `retry_after`-style message fallback.
+ */
+function extractRetryAfterMs(error: unknown): number | null {
   const candidates = findRetryAfterCandidates(error);
   for (const candidate of candidates) {
     const seconds = Number(candidate);
@@ -500,9 +507,9 @@ function findRetryAfterCandidates(error: unknown): unknown[] {
   ];
 }
 
-export function extractTelegramSendRichDraftIntent(
+export function extractChannelSendRichDraftIntent(
   argumentsText: string,
-  source: ChannelTurnSource & { channel: "telegram"; accountId: string },
+  source: ChannelTurnSource & { accountId: string },
   options: { richPrivateChatDefault?: boolean } = {},
 ): DraftIntent | null {
   const action = extractStringField(argumentsText, "action", false)?.value;
@@ -515,18 +522,19 @@ export function extractTelegramSendRichDraftIntent(
   if (!isExplicitRichSend && !isDefaultRichPrivateSend) {
     debugLog(
       "channels",
-      "Telegram rich draft intent rejected: action=%s",
+      "Channel rich draft intent rejected: action=%s",
       action ?? "",
     );
     return null;
   }
 
   const channel = extractStringField(argumentsText, "channel", false)?.value;
-  if (channel?.trim().toLowerCase() !== "telegram") {
+  if (channel?.trim().toLowerCase() !== source.channel) {
     debugLog(
       "channels",
-      "Telegram rich draft intent rejected: channel=%s",
+      "Channel rich draft intent rejected: channel=%s source=%s",
       channel ?? "",
+      source.channel,
     );
     return null;
   }
@@ -536,7 +544,7 @@ export function extractTelegramSendRichDraftIntent(
   if (!chatId || chatId !== source.chatId) {
     debugLog(
       "channels",
-      "Telegram rich draft intent rejected: chat=%s source=%s",
+      "Channel rich draft intent rejected: chat=%s source=%s",
       chatId ?? "",
       source.chatId,
     );
@@ -545,7 +553,7 @@ export function extractTelegramSendRichDraftIntent(
 
   const target = extractStringField(argumentsText, "target", false)?.value;
   if (target?.trim()) {
-    debugLog("channels", "Telegram rich draft intent rejected: target present");
+    debugLog("channels", "Channel rich draft intent rejected: target present");
     return null;
   }
 
@@ -557,7 +565,7 @@ export function extractTelegramSendRichDraftIntent(
   if (accountId?.trim() && accountId.trim() !== source.accountId) {
     debugLog(
       "channels",
-      "Telegram rich draft intent rejected: account=%s source=%s",
+      "Channel rich draft intent rejected: account=%s source=%s",
       accountId.trim(),
       source.accountId,
     );
@@ -570,7 +578,7 @@ export function extractTelegramSendRichDraftIntent(
   if (requestedThreadId !== null && requestedThreadId !== sourceThreadId) {
     debugLog(
       "channels",
-      "Telegram rich draft intent rejected: thread=%s source=%s",
+      "Channel rich draft intent rejected: thread=%s source=%s",
       requestedThreadId,
       sourceThreadId ?? "",
     );
@@ -579,16 +587,13 @@ export function extractTelegramSendRichDraftIntent(
 
   const media = extractStringField(argumentsText, "media", false)?.value;
   if (media?.trim()) {
-    debugLog("channels", "Telegram rich draft intent rejected: media present");
+    debugLog("channels", "Channel rich draft intent rejected: media present");
     return null;
   }
 
   const message = extractStringField(argumentsText, "message", true)?.value;
   if (!message?.trim()) {
-    debugLog(
-      "channels",
-      "Telegram rich draft intent rejected: message missing",
-    );
+    debugLog("channels", "Channel rich draft intent rejected: message missing");
     return null;
   }
 

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -817,11 +817,11 @@ async function handleSetMaxContextCommand(
 /**
  * /channels — Manage external channel integrations.
  *
- * Subcommands (via WS):
- *   /channels telegram pair <code>    — Approve pairing + bind chat to this agent/conversation
- *   /channels telegram enable --chat-id <id> — Bind a known chat to this agent/conversation
- *   /channels telegram disable        — Unbind this agent/conversation
- *   /channels status                  — Show channel status
+ * Subcommands (via WS), generic across all supported channels:
+ *   /channels <channel> pair <code>    — Approve pairing + bind chat to this agent/conversation
+ *   /channels <channel> enable --chat-id <id> — Bind a known chat to this agent/conversation
+ *   /channels <channel> disable        — Unbind this agent/conversation
+ *   /channels status                   — Show channel status
  */
 async function handleChannelsCommand(
   _socket: WebSocket,
@@ -850,10 +850,12 @@ async function handleChannelsCommand(
     const { getPendingPairings, getApprovedUsers, loadPairingStore } =
       await import("@/channels/pairing");
 
-    const channels = ["telegram"];
+    const { getSupportedChannelIds } = await import(
+      "@/channels/plugin-registry"
+    );
     const lines: string[] = [];
 
-    for (const ch of channels) {
+    for (const ch of getSupportedChannelIds()) {
       const accounts = listChannelAccountSnapshots(ch);
       if (accounts.length === 0) {
         lines.push(`${ch}: not configured`);
@@ -873,7 +875,15 @@ async function handleChannelsCommand(
     return lines.join("\n") || "No channels configured.";
   }
 
-  if (subCmd === "telegram") {
+  const {
+    getSupportedChannelIds,
+    isSupportedChannelId,
+    getChannelDisplayName,
+  } = await import("@/channels/plugin-registry");
+
+  if (subCmd && isSupportedChannelId(subCmd)) {
+    const ch = subCmd;
+    const displayName = getChannelDisplayName(ch);
     const accountIdFlag = rest.indexOf("--account-id");
     const accountId =
       accountIdFlag >= 0 ? (rest[accountIdFlag + 1] ?? undefined) : undefined;
@@ -881,18 +891,18 @@ async function handleChannelsCommand(
     if (action === "pair") {
       const code = rest[0];
       if (!code) {
-        return "Usage: /channels telegram pair <code>";
+        return `Usage: /channels ${ch} pair <code>`;
       }
 
       const { completePairing } = await import("@/channels/registry");
       const { loadRoutes } = await import("@/channels/routing");
       const { loadPairingStore } = await import("@/channels/pairing");
 
-      loadRoutes("telegram");
-      loadPairingStore("telegram");
+      loadRoutes(ch);
+      loadPairingStore(ch);
 
       const result = completePairing(
-        "telegram",
+        ch,
         code,
         agentId,
         conversationId,
@@ -910,7 +920,7 @@ async function handleChannelsCommand(
       const chatId = chatIdFlag >= 0 ? rest[chatIdFlag + 1] : undefined;
 
       if (!chatId) {
-        return "Usage: /channels telegram enable --chat-id <id> [--account-id <id>]";
+        return `Usage: /channels ${ch} enable --chat-id <id> [--account-id <id>]`;
       }
 
       const { getChannelAccount, listChannelAccounts } = await import(
@@ -920,26 +930,26 @@ async function handleChannelsCommand(
 
       let resolvedAccountId = accountId?.trim();
       if (resolvedAccountId) {
-        if (!getChannelAccount("telegram", resolvedAccountId)) {
-          return `Unknown Telegram account: ${resolvedAccountId}`;
+        if (!getChannelAccount(ch, resolvedAccountId)) {
+          return `Unknown ${displayName} account: ${resolvedAccountId}`;
         }
       } else {
-        const accounts = listChannelAccounts("telegram");
+        const accounts = listChannelAccounts(ch);
         if (accounts.length === 0) {
-          return "Telegram is not configured yet.";
+          return `${displayName} is not configured yet.`;
         }
         if (accounts.length > 1) {
-          return "Telegram has multiple accounts. Re-run with --account-id <id>.";
+          return `${displayName} has multiple accounts. Re-run with --account-id <id>.`;
         }
         resolvedAccountId = accounts[0]?.accountId;
       }
 
       if (!resolvedAccountId) {
-        return "Could not resolve a Telegram account for this route.";
+        return `Could not resolve a ${displayName} account for this route.`;
       }
 
-      loadRoutes("telegram");
-      addRoute("telegram", {
+      loadRoutes(ch);
+      addRoute(ch, {
         accountId: resolvedAccountId,
         chatId,
         agentId,
@@ -948,7 +958,7 @@ async function handleChannelsCommand(
         createdAt: new Date().toISOString(),
       });
 
-      return `Route created: telegram:${chatId} → ${agentId}/${conversationId}`;
+      return `Route created: ${ch}:${chatId} → ${agentId}/${conversationId}`;
     }
 
     if (action === "disable") {
@@ -956,15 +966,15 @@ async function handleChannelsCommand(
         "@/channels/routing"
       );
 
-      loadRoutes("telegram");
-      const removed = removeRoutesForScope("telegram", agentId, conversationId);
+      loadRoutes(ch);
+      const removed = removeRoutesForScope(ch, agentId, conversationId);
       return removed > 0
         ? `Removed ${removed} route(s) for this agent/conversation.`
         : "No routes found for this agent/conversation.";
     }
 
-    return "Usage: /channels telegram <pair|enable|disable>";
+    return `Usage: /channels ${ch} <pair|enable|disable>`;
   }
 
-  return "Usage: /channels <telegram|status>";
+  return `Usage: /channels <status|${getSupportedChannelIds().join("|")}> ...`;
 }

--- a/src/websocket/listener/commands/channels.ts
+++ b/src/websocket/listener/commands/channels.ts
@@ -3,6 +3,7 @@ import { getChannelPluginConfig } from "@/channels/account-config";
 import { removeUserPlugin } from "@/channels/custom/scaffolding";
 import { getChannelPluginMetadata } from "@/channels/plugin-registry";
 import type { ChannelRegistryEvent } from "@/channels/registry";
+import { LEGACY_DEFAULT_CHANNEL_ID } from "@/channels/types";
 import type { DequeuedBatch } from "@/queue/queue-runtime";
 import type {
   ChannelAccountBindCommand,
@@ -305,28 +306,6 @@ export async function handleChannelsProtocolCommand(
     if (!snapshot) {
       return null;
     }
-    if (snapshot.channelId === "telegram") {
-      return {
-        channel_id: snapshot.channelId,
-        account_id: snapshot.accountId,
-        display_name: snapshot.displayName,
-        enabled: snapshot.enabled,
-        dm_policy: snapshot.dmPolicy,
-        allowed_users: snapshot.allowedUsers,
-        config: snapshot.config ?? {},
-      };
-    }
-    if (snapshot.channelId === "discord") {
-      return {
-        channel_id: snapshot.channelId,
-        account_id: snapshot.accountId,
-        display_name: snapshot.displayName,
-        enabled: snapshot.enabled,
-        dm_policy: snapshot.dmPolicy,
-        allowed_users: snapshot.allowedUsers,
-        config: snapshot.config ?? {},
-      };
-    }
     return {
       channel_id: snapshot.channelId,
       account_id: snapshot.accountId,
@@ -341,38 +320,6 @@ export async function handleChannelsProtocolCommand(
   const mapChannelAccount = (
     snapshot: ReturnType<typeof listChannelAccountSnapshots>[number],
   ): ProtocolChannelAccountSnapshot => {
-    if (snapshot.channelId === "telegram") {
-      return {
-        channel_id: snapshot.channelId,
-        account_id: snapshot.accountId,
-        display_name: snapshot.displayName,
-        enabled: snapshot.enabled,
-        configured: snapshot.configured,
-        running: snapshot.running,
-        dm_policy: snapshot.dmPolicy,
-        allowed_users: snapshot.allowedUsers,
-        config: snapshot.config ?? {},
-        created_at: snapshot.createdAt,
-        updated_at: snapshot.updatedAt,
-      };
-    }
-
-    if (snapshot.channelId === "discord") {
-      return {
-        channel_id: snapshot.channelId,
-        account_id: snapshot.accountId,
-        display_name: snapshot.displayName,
-        enabled: snapshot.enabled,
-        configured: snapshot.configured,
-        running: snapshot.running,
-        dm_policy: snapshot.dmPolicy,
-        allowed_users: snapshot.allowedUsers,
-        config: snapshot.config ?? {},
-        created_at: snapshot.createdAt,
-        updated_at: snapshot.updatedAt,
-      };
-    }
-
     return {
       channel_id: snapshot.channelId,
       account_id: snapshot.accountId,
@@ -1153,7 +1100,7 @@ export async function handleChannelsProtocolCommand(
 
   if (parsed.type === "channel_routes_list") {
     try {
-      const channelId = parsed.channel_id ?? "telegram";
+      const channelId = parsed.channel_id ?? LEGACY_DEFAULT_CHANNEL_ID;
       safeSocketSend(
         socket,
         {

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -67,7 +67,7 @@ import { prepareToolExecutionContextForScope } from "@/tools/toolset";
 import type { StopReasonType, StreamDelta } from "@/types/protocol_v2";
 import { debugLog, debugWarn, isDebugEnabled } from "@/utils/debug";
 import { detectShellContext } from "@/utils/shell-context";
-import { createTelegramRichDraftStreamer } from "./channel-rich-draft-streamer";
+import { createChannelRichDraftStreamer } from "./channel-rich-draft-streamer";
 import {
   EMPTY_RESPONSE_MAX_RETRIES,
   LLM_API_ERROR_MAX_RETRIES,
@@ -448,7 +448,7 @@ export async function handleIncomingMessage(
   let lastExecutionResults: ApprovalResult[] | null = null;
   let lastExecutingToolCallIds: string[] = [];
   let lastNeedsUserInputToolCallIds: string[] = [];
-  const richDraftStreamer = createTelegramRichDraftStreamer({
+  const richDraftStreamer = createChannelRichDraftStreamer({
     batchId: dequeuedBatchId,
     sources: msg.channelTurnSources,
   });


### PR DESCRIPTION
## Summary

Linear: LET-9513. Follow-up to #3029, which fixed the same boundary violation for Slack (commit 842350c3): the listener and generic channel contracts expose vendor-neutral channel seams, and Slack/Telegram/Discord adapters (or future external custom channels) plug in with their code isolated in `src/channels/<vendor>/`. This PR removes the pre-existing Telegram/Discord leakage from `src/websocket/listener/*`:

- **`channel-rich-draft-streamer.ts`** — the Telegram-only rich draft streamer is now generic. The debounce/partial-JSON/draft state machine was already channel-agnostic; the vendor pieces are replaced: opt-in is read from generic account fields (`richDraftStreaming` / `richPrivateChatDefault`) via a new `getRichDraftStreamingPolicy` helper in `channels/types.ts`, the MessageChannel intent check matches `source.channel` instead of a `"telegram"` literal, the outbound draft carries the source channel, and retry-after extraction is a generic best-effort parse of common bot-API rate-limit shapes. Any adapter that implements `sendRichMessageDraft` and whose account opts in now gets draft streaming.
- **`commands.ts`** — the `/channels` slash command accepts any supported channel id (validated against the plugin registry) for `pair`/`enable`/`disable` instead of hardcoding telegram, and `/channels status` enumerates all supported channels rather than a `["telegram"]` literal.
- **`commands/channels.ts`** — deletes the `telegram`/`discord` snapshot-mapping branches (byte-identical to the generic fallback — dead vendor branching) and replaces the bare `?? "telegram"` default for `channel_routes_list` with a documented `LEGACY_DEFAULT_CHANNEL_ID` wire-compat constant in the channels layer (`channel_id` is optional on the wire; early clients predate multi-channel support).

Behavior is unchanged for existing setups: only Telegram accounts can currently declare the rich-draft opt-in fields, and the single-route resolution semantics are preserved (the route key now includes the channel id).

After this, `grep -i "slack\|telegram\|discord" src/websocket/listener` matches only test fixtures and the documented legacy constant reference.

## Testing

- `bun run check` green
- `src/websocket/listener/` suites: 109 pass, 0 fail (rich-draft streamer tests updated to the renamed generic API; all behavioral assertions unchanged)
- `src/channels/` suites: 712 pass, 0 fail
- Broader `src/websocket/` failures (listen-client concurrency, app-server native ws, memfs status) reproduce identically on clean `origin/main` in this environment — pre-existing, not from this branch

👾 Generated with [Letta Code](https://letta.com)