### PR TITLE
fix(slack): stop inlining inbound attachments as base64 images (LET-9517)

### DIFF
--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -1151,7 +1151,6 @@ test("slack adapter hydrates prior Slack thread context, including bot-authored 
         mimeType: "image/png",
         kind: "image",
         localPath: "/tmp/root-screenshot.png",
-        imageDataBase64: "abc",
       },
     ],
   });
@@ -1505,7 +1504,6 @@ test("slack adapter allows file_share subtype messages through", async () => {
       mimeType: "image/png",
       kind: "image",
       localPath: "/tmp/screenshot.png",
-      imageDataBase64: "abc",
     },
   ]);
 

--- a/src/channels/slack-media.test.ts
+++ b/src/channels/slack-media.test.ts
@@ -152,9 +152,11 @@ test("resolveSlackThreadStarter downloads Slack files for thread context", async
     kind: "image",
     mimeType: "image/png",
     sizeBytes: 4,
-    imageDataBase64: "AQIDBA==",
     localPath: expect.stringContaining("root.png"),
   });
+  // Images are not inlined as base64; the agent Reads local_path on demand
+  // (LET-9517 — inlined attachments accumulated past provider byte limits).
+  expect(attachment.imageDataBase64).toBeUndefined();
   expect(fetchMock).toHaveBeenCalledTimes(1);
 });
 

--- a/src/channels/slack/media.ts
+++ b/src/channels/slack/media.ts
@@ -443,6 +443,12 @@ async function downloadSlackAttachment(params: {
   });
 
   const kind = resolveAttachmentKind(mimeType);
+  // Images are deliberately NOT inlined as base64 (no imageDataBase64):
+  // attachments are saved to disk and surfaced via local_path in the channel
+  // notification, so the agent Reads them on demand through the shared image
+  // resize seam. Inlining every attachment let per-image-legal payloads
+  // accumulate past the inference gateway's request byte limit (LET-9517,
+  // LET-9501).
   const attachment: ChannelMessageAttachment = {
     id: params.file.id,
     name: fileName,
@@ -450,7 +456,6 @@ async function downloadSlackAttachment(params: {
     sizeBytes: buffer.byteLength,
     kind,
     localPath,
-    ...(kind === "image" ? { imageDataBase64: buffer.toString("base64") } : {}),
   };
 
   // Slack voice memos arrive as ordinary audio files/file_share events, so the


### PR DESCRIPTION
## Summary

- Slack ingestion base64-inlined every image attachment (up to 20MB each) into the user message. Each image is individually bounded by the shared resize seam (2000px/5MB), but nothing bounds the **aggregate** — per-image-legal payloads accumulated past the inference gateway request-body limit and byte-bricked turns that token-based compaction could not recover. Receipts on [LET-9501](https://linear.app/letta/issue/LET-9501/context-overflow-error): 4 inlined attachments alone produced a ~14MB user message; the conversation reached ~34MB and 413d through three compaction retries.
- Attachments were already saved to disk and surfaced via `local_path` in the channel notification XML, which also carries an explicit hint that Read/ViewImage can inspect them. The inline base64 copy was redundant. This drops it: the agent Reads images on demand, re-ingesting them through the shared resize seam and only for images it actually needs (OpenClaw ships this same model — files on disk + placeholder, no base64 in messages).
- Tradeoff (accepted on LET-9517): the agent spends a Read call to see an image instead of seeing it inline.
- Slack only: Telegram/Discord/Signal still inline (same pattern, lower exposure) — follow-up tracked on LET-9517. The server-side fix for image-byte accumulation in general (e.g. many parallel image Reads) is LET-9501 and still needed.

Fixes the ingestion half of [LET-9517](https://linear.app/letta/issue/LET-9517).

👾 Generated with [Letta Code](https://letta.com)

## How attachments flow into context (unchanged by this PR)

`formatChannelNotification` (xml.ts) builds the user message as separate content parts — this PR only deletes the trailing image parts; the two text parts already carried everything the agent needs:

```
content: [
  { type: "text", text: <system-reminder block> },
  { type: "text", text: <channel-notification XML> },
  // removed by this PR (Slack): one { type: "image", source: { type: "base64", ... } }
  // part per image attachment
]
```

**Part 1 — `<system-reminder>`**: reply semantics (MessageChannel usage), channel capabilities, local time, and — emitted only when attachments are present — the hint that makes the on-demand flow work:

> "If this notification includes attachment local_path values, you may be able to inspect those files using local file or image tools available in your current toolset (for example Read or ViewImage), using the local_path."

**Part 2 — `<channel-notification>` XML**: sender/chat/thread attributes, one self-closing `<attachment>` element per file, then the escaped message text:

```xml
<channel-notification channel="slack" chat_id="C123" chat_type="channel" sender_id="U123" sender_name="Dorota" message_id="1783443810.951099">
<attachment kind="image" local_path="/Users/.../channels/slack/<account>/1783...-warning.png" attachment_id="F123" name="warning.png" mime_type="image/png" size_bytes="2097152" />
Hey, created another applet to generate marketing materials...
</channel-notification>
```

The reminder and notification are separate text parts by design (see the `formatChannelNotification` docstring): UIs that hide pure system-reminder parts can drop part 1 without parsing concatenated XML blobs.
