### PR TITLE
fix(agent): make blank personality memory empty

### DIFF
--- a/src/agent/memory.ts
+++ b/src/agent/memory.ts
@@ -30,7 +30,9 @@ export function parseMdxFrontmatter(content: string): {
   const frontmatterRegex = /^---\n([\s\S]*?)\n---\n([\s\S]*)$/;
   const match = content.match(frontmatterRegex);
 
-  if (!match || !match[1] || !match[2]) {
+  // match[2] (the body) may legitimately be empty (frontmatter-only files,
+  // e.g. the blank personality persona).
+  if (!match || !match[1] || match[2] === undefined) {
     return { frontmatter: {}, body: content };
   }
 

--- a/src/agent/personality-presets.ts
+++ b/src/agent/personality-presets.ts
@@ -169,10 +169,8 @@ export function buildDefaultMemoryFile(
   body: string,
   description?: string,
 ): string {
-  const normalizedBody = ensureTrailingNewline(body.trim());
-  if (!normalizedBody.trim()) {
-    throw new Error("Memory content cannot be empty");
-  }
+  const trimmedBody = body.trim();
+  const normalizedBody = trimmedBody ? ensureTrailingNewline(trimmedBody) : "";
 
   const frontmatter = getEditablePromptFrontmatter(templatePromptAssetName);
   if (description !== undefined) {
@@ -180,7 +178,17 @@ export function buildDefaultMemoryFile(
   }
 
   if (Object.keys(frontmatter).length === 0) {
+    if (!normalizedBody) {
+      throw new Error(
+        "Memory content cannot be empty without frontmatter (the file would be blank)",
+      );
+    }
     return normalizedBody;
+  }
+
+  if (!normalizedBody) {
+    // Frontmatter-only file (e.g. the blank personality's empty persona).
+    return `${serializeFrontmatter(frontmatter)}\n`;
   }
 
   return `${serializeFrontmatter(frontmatter)}\n\n${normalizedBody}`;
@@ -234,7 +242,8 @@ export function getPersonalityContent(personalityId: PersonalityId): string {
   }
 
   if (personalityId === "blank") {
-    return getPromptBody("persona_blank.mdx");
+    // Blank starter: the persona is truly empty — the user provides it.
+    return "";
   }
 
   if (personalityId === "kawaii") {
@@ -272,7 +281,8 @@ export function getPersonalityHumanContent(
   }
 
   if (personalityId === "blank") {
-    return getDefaultHumanContent();
+    // Blank starter: the human block starts empty too.
+    return "";
   }
 
   return getDefaultHumanContent();

--- a/src/agent/personality-presets.ts
+++ b/src/agent/personality-presets.ts
@@ -281,8 +281,7 @@ export function getPersonalityHumanContent(
   }
 
   if (personalityId === "blank") {
-    // Blank starter: the human block starts empty too.
-    return "";
+    return getPromptBody("human_blank.mdx");
   }
 
   return getDefaultHumanContent();
@@ -319,11 +318,13 @@ export function getPersonalityBlockDefinitions(personalityId: PersonalityId): {
   const humanTemplatePromptAssetName =
     personalityId === "memo" || personalityId === "tutorial"
       ? "human_memo.mdx"
-      : personalityId === "kawaii"
-        ? "human_kawaii.mdx"
-        : personalityId === "linus"
-          ? "human_linus.mdx"
-          : "human.mdx";
+      : personalityId === "blank"
+        ? "human_blank.mdx"
+        : personalityId === "kawaii"
+          ? "human_kawaii.mdx"
+          : personalityId === "linus"
+            ? "human_linus.mdx"
+            : "human.mdx";
 
   return {
     persona: {

--- a/src/agent/personality.test.ts
+++ b/src/agent/personality.test.ts
@@ -40,6 +40,13 @@ describe("personality helpers", () => {
     expect(updated).not.toContain("old persona content");
   });
 
+  test("replaceBodyPreservingFrontmatter allows a frontmatter-only body", () => {
+    const existing = `${VALID_FRONTMATTER}old persona content\n`;
+    const updated = replaceBodyPreservingFrontmatter(existing, "");
+
+    expect(updated).toBe(VALID_FRONTMATTER.trimEnd() + "\n");
+  });
+
   test("replaceBodyPreservingFrontmatter rejects missing frontmatter", () => {
     expect(() =>
       replaceBodyPreservingFrontmatter("no frontmatter", "new body"),
@@ -67,6 +74,12 @@ describe("personality helpers", () => {
   test("personality block values always include both persona and human", () => {
     for (const option of PERSONALITY_OPTIONS) {
       const values = getPersonalityBlockValues(option.id);
+      if (option.id === "blank") {
+        // The blank starter is truly empty — the user provides the content.
+        expect(values.persona).toBe("");
+        expect(values.human).toBe("");
+        continue;
+      }
       expect(values.persona.trim().length).toBeGreaterThan(0);
       expect(values.human.trim().length).toBeGreaterThan(0);
     }
@@ -225,14 +238,20 @@ describe("personality helpers", () => {
     expect(definitions.human.description).toContain("senpai");
   });
 
-  test("blank personality uses persona_blank.mdx content", () => {
-    const content = getPersonalityContent("blank");
-    expect(content).toContain("blank starter personality");
-    expect(content).toContain("ask the user to provide a personality prompt");
+  test("blank personality has an empty persona", () => {
+    expect(getPersonalityContent("blank")).toBe("");
   });
 
-  test("blank personality uses the default human block", () => {
-    const defaultHuman = getDefaultHumanContent();
-    expect(getPersonalityHumanContent("blank")).toBe(defaultHuman);
+  test("blank personality has an empty human block", () => {
+    expect(getPersonalityHumanContent("blank")).toBe("");
+  });
+
+  test("blank personality keeps frontmatter descriptions while block values are empty", () => {
+    const definitions = getPersonalityBlockDefinitions("blank");
+
+    expect(definitions.persona.value).toBe("");
+    expect(definitions.persona.description).toBe("Blank starter personality.");
+    expect(definitions.human.value).toBe("");
+    expect(definitions.human.description).toContain("What I've learned");
   });
 });

--- a/src/agent/personality.test.ts
+++ b/src/agent/personality.test.ts
@@ -250,8 +250,12 @@ describe("personality helpers", () => {
     const definitions = getPersonalityBlockDefinitions("blank");
 
     expect(definitions.persona.value).toBe("");
-    expect(definitions.persona.description).toBe("Blank starter personality.");
+    expect(definitions.persona.description).toBe(
+      "Who I am, what I value, and how I approach working with people. This evolves as I learn and grow.",
+    );
     expect(definitions.human.value).toBe("");
-    expect(definitions.human.description).toContain("What I've learned");
+    expect(definitions.human.description).toBe(
+      "What I've learned about the person I'm working with. Understanding them helps me be genuinely helpful rather than generically helpful.",
+    );
   });
 });

--- a/src/agent/personality.test.ts
+++ b/src/agent/personality.test.ts
@@ -75,9 +75,9 @@ describe("personality helpers", () => {
     for (const option of PERSONALITY_OPTIONS) {
       const values = getPersonalityBlockValues(option.id);
       if (option.id === "blank") {
-        // The blank starter is truly empty — the user provides the content.
+        // The blank starter has an empty persona and a minimal human placeholder.
         expect(values.persona).toBe("");
-        expect(values.human).toBe("");
+        expect(values.human).toBe("Name: ?\n");
         continue;
       }
       expect(values.persona.trim().length).toBeGreaterThan(0);
@@ -242,20 +242,20 @@ describe("personality helpers", () => {
     expect(getPersonalityContent("blank")).toBe("");
   });
 
-  test("blank personality has an empty human block", () => {
-    expect(getPersonalityHumanContent("blank")).toBe("");
+  test("blank personality has a minimal human placeholder", () => {
+    expect(getPersonalityHumanContent("blank")).toBe("Name: ?\n");
   });
 
-  test("blank personality keeps frontmatter descriptions while block values are empty", () => {
+  test("blank personality keeps purpose descriptions while using minimal block values", () => {
     const definitions = getPersonalityBlockDefinitions("blank");
 
     expect(definitions.persona.value).toBe("");
     expect(definitions.persona.description).toBe(
       "Who I am, what I value, and how I approach working with people. This evolves as I learn and grow.",
     );
-    expect(definitions.human.value).toBe("");
+    expect(definitions.human.value).toBe("Name: ?\n");
     expect(definitions.human.description).toBe(
-      "What I've learned about the person I'm working with. Understanding them helps me be genuinely helpful rather than generically helpful.",
+      "Core memories about the person I am working with: who they are, what they care about, how they work, and what should matter in future conversations.",
     );
   });
 });

--- a/src/agent/personality.ts
+++ b/src/agent/personality.ts
@@ -199,15 +199,18 @@ export function replaceBodyPreservingFrontmatter(
     );
   }
 
-  const normalizedBody = ensureTrailingNewline(newBody.trim());
-  if (!normalizedBody.trim()) {
-    throw new Error("Personality content cannot be empty");
-  }
+  const trimmedBody = newBody.trim();
+  const normalizedBody = trimmedBody ? ensureTrailingNewline(trimmedBody) : "";
 
   const { frontmatter } = parseMdxFrontmatter(existingPersonaFile);
   const mergedFrontmatter = { ...frontmatter };
   if (options?.description !== undefined) {
     mergedFrontmatter.description = options.description;
+  }
+
+  if (!normalizedBody) {
+    // Frontmatter-only file (e.g. the blank personality's empty persona).
+    return `${serializeFrontmatter(mergedFrontmatter)}\n`;
   }
 
   return `${serializeFrontmatter(mergedFrontmatter)}\n\n${normalizedBody}`;

--- a/src/agent/prompt-assets.ts
+++ b/src/agent/prompt-assets.ts
@@ -2,6 +2,7 @@
 
 import approvalRecoveryAlert from "./prompts/approval_recovery_alert.txt";
 import humanPrompt from "./prompts/human.mdx";
+import humanBlankPrompt from "./prompts/human_blank.mdx";
 import humanKawaiiPrompt from "./prompts/human_kawaii.mdx";
 import humanLinusPrompt from "./prompts/human_linus.mdx";
 import humanMemoPrompt from "./prompts/human_memo.mdx";
@@ -40,6 +41,7 @@ export const MEMORY_PROMPTS: Record<string, string> = {
   "persona_memo.mdx": personaMemoPrompt,
   "persona_tutorial.mdx": personaTutorialPrompt,
   "human.mdx": humanPrompt,
+  "human_blank.mdx": humanBlankPrompt,
   "human_kawaii.mdx": humanKawaiiPrompt,
   "human_linus.mdx": humanLinusPrompt,
   "human_memo.mdx": humanMemoPrompt,

--- a/src/agent/prompts/human.mdx
+++ b/src/agent/prompts/human.mdx
@@ -1,6 +1,6 @@
 ---
 label: human
-description: What I've learned about the person I'm working with. Understanding them helps me be genuinely helpful rather than generically helpful.
+description: Core memories about the person I am working with: who they are, what they care about, how they work, and what should matter in future conversations.
 ---
 
 I haven't gotten to know this person yet.

--- a/src/agent/prompts/human_blank.mdx
+++ b/src/agent/prompts/human_blank.mdx
@@ -1,0 +1,6 @@
+---
+label: human
+description: Core memories about the person I am working with: who they are, what they care about, how they work, and what should matter in future conversations.
+---
+
+Name: ?

--- a/src/agent/prompts/persona_blank.mdx
+++ b/src/agent/prompts/persona_blank.mdx
@@ -1,4 +1,4 @@
 ---
 label: persona
-description: Blank starter personality.
+description: Who I am, what I value, and how I approach working with people. This evolves as I learn and grow.
 ---

--- a/src/agent/prompts/persona_blank.mdx
+++ b/src/agent/prompts/persona_blank.mdx
@@ -1,6 +1,4 @@
 ---
 label: persona
-description: Blank starter personality — awaiting user-provided personality prompt.
+description: Blank starter personality.
 ---
-
-This is a blank starter personality. You must ask the user to provide a personality prompt or preference.


### PR DESCRIPTION
Makes the Blank personality actually blank by creating empty persona and human block values while preserving frontmatter metadata for memory files.

This also relaxes the personality/frontmatter helpers so frontmatter-only memory files are valid, which keeps `/personality blank` working for existing agents.

Validated with `bun test src/agent/personality.test.ts src/agent/create-agent-request.test.ts` and `bun run check`.