### PR TITLE
fix: retire the node experiment (x-letta-node from LETTA_NODE env only)

### DIFF
--- a/src/agent/client-experiments.test.ts
+++ b/src/agent/client-experiments.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getClientDefaultHeaders } from "@/backend/api/client";
-import { experimentManager } from "@/experiments/manager";
+import type { Settings } from "@/settings-manager";
 import { settingsManager } from "@/settings-manager";
 
 const originalHome = process.env.HOME;
@@ -59,20 +59,31 @@ afterEach(async () => {
 });
 
 describe("getClient experiment headers", () => {
-  test("uses LETTA_NODE when no explicit experiment override exists", async () => {
+  test("sends the node header when LETTA_NODE is enabled", async () => {
     process.env.LETTA_NODE = "1";
 
     expect(getClientDefaultHeaders()["x-letta-node"]).toBe("1");
   });
 
-  test("sends an explicit off header when the override disables node", async () => {
-    process.env.LETTA_NODE = "1";
-    experimentManager.set("node", false);
+  test("sends an explicit off header when LETTA_NODE is set but disabled", async () => {
+    process.env.LETTA_NODE = "0";
 
     expect(getClientDefaultHeaders()["x-letta-node"]).toBe("0");
   });
 
-  test("omits the node header when the experiment is default-off", async () => {
+  test("omits the node header when LETTA_NODE is unset", async () => {
+    expect(getClientDefaultHeaders()["x-letta-node"]).toBeUndefined();
+  });
+
+  test("ignores a persisted legacy node experiment override", async () => {
+    // Stale `experiments: { node: false }` settings (LET-9516) must not
+    // produce an opt-out header anymore.
+    // "node" is intentionally no longer a valid ExperimentId; simulate the
+    // legacy on-disk shape that older builds persisted.
+    settingsManager.updateSettings({
+      experiments: { node: false },
+    } as unknown as Partial<Settings>);
+
     expect(getClientDefaultHeaders()["x-letta-node"]).toBeUndefined();
   });
 

--- a/src/backend/api/client.ts
+++ b/src/backend/api/client.ts
@@ -1,7 +1,6 @@
 import { hostname } from "node:os";
 import Letta from "@letta-ai/letta-client";
 import { LETTA_CLOUD_API_URL, refreshAccessToken } from "@/auth/oauth";
-import { experimentManager } from "@/experiments/manager";
 import { type Settings, settingsManager } from "@/settings-manager";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
 import { isDebugEnabled } from "@/utils/debug";
@@ -125,9 +124,26 @@ export {
   type MemfsGitProxyRewriteConfig,
 } from "./memfs-git-proxy";
 
-export function getClientDefaultHeaders(): Record<string, string> {
-  const nodeExperiment = experimentManager.getSnapshot("node");
+const NODE_HEADER_ENABLED_VALUES = new Set(["1", "true", "yes"]);
 
+/**
+ * Resolve the `x-letta-node` runtime routing header from the LETTA_NODE env
+ * var only. The old "node" experiment is retired: persisted
+ * `experiments.node` settings overrides are ignored so a stale opt-out can no
+ * longer silently pin an installation's traffic to the Python core runtime
+ * (LET-9516). When LETTA_NODE is unset, no header is sent and the server
+ * routes letta-code traffic to the TS runtime by default.
+ */
+function getNodeRoutingHeader(): Record<string, string> {
+  const raw = process.env.LETTA_NODE;
+  if (raw === undefined || raw.trim() === "") {
+    return {};
+  }
+  const enabled = NODE_HEADER_ENABLED_VALUES.has(raw.trim().toLowerCase());
+  return { "x-letta-node": enabled ? "1" : "0" };
+}
+
+export function getClientDefaultHeaders(): Record<string, string> {
   return {
     "X-Letta-Source": "letta-code",
     "User-Agent": `letta-code/${packageJson.version}`,
@@ -136,11 +152,7 @@ export function getClientDefaultHeaders(): Record<string, string> {
     // restore it on other browsers/sessions. The cloud middleware
     // ignores this header on non-message routes.
     "X-Letta-Environment-Device-Id": settingsManager.getOrCreateDeviceId(),
-    ...(nodeExperiment.source === "override"
-      ? { "x-letta-node": nodeExperiment.enabled ? "1" : "0" }
-      : nodeExperiment.enabled
-        ? { "x-letta-node": "1" }
-        : {}),
+    ...getNodeRoutingHeader(),
     ...(process.env.LETTA_MEMFS_BACKEND === "hosted"
       ? { "x-letta-memfs-backend": "hosted" }
       : {}),

--- a/src/experiments/manager.test.ts
+++ b/src/experiments/manager.test.ts
@@ -7,7 +7,6 @@ import { settingsManager } from "@/settings-manager";
 
 const originalHome = process.env.HOME;
 const originalUserProfile = process.env.USERPROFILE;
-const originalNodeFlag = process.env.LETTA_NODE;
 const originalArtifactsFlag = process.env.LETTA_ARTIFACTS;
 
 let testHomeDir = "";
@@ -17,7 +16,6 @@ beforeEach(async () => {
   testHomeDir = await mkdtemp(join(tmpdir(), "letta-experiments-home-"));
   process.env.HOME = testHomeDir;
   process.env.USERPROFILE = testHomeDir;
-  delete process.env.LETTA_NODE;
   delete process.env.LETTA_ARTIFACTS;
   await settingsManager.initialize();
 });
@@ -34,12 +32,6 @@ afterEach(async () => {
     delete process.env.USERPROFILE;
   } else {
     process.env.USERPROFILE = originalUserProfile;
-  }
-
-  if (originalNodeFlag === undefined) {
-    delete process.env.LETTA_NODE;
-  } else {
-    process.env.LETTA_NODE = originalNodeFlag;
   }
 
   if (originalArtifactsFlag === undefined) {
@@ -61,22 +53,11 @@ describe("experimentManager", () => {
     });
   });
 
-  test("falls back to LETTA_NODE when no override is stored", () => {
-    process.env.LETTA_NODE = "1";
-
-    expect(experimentManager.getSnapshot("node")).toMatchObject({
-      id: "node",
-      enabled: true,
-      source: "env",
-      override: null,
-    });
-  });
-
   test("persists explicit overrides and lets them beat the env flag", async () => {
-    process.env.LETTA_NODE = "1";
+    process.env.LETTA_ARTIFACTS = "1";
 
-    expect(experimentManager.set("node", false)).toMatchObject({
-      id: "node",
+    expect(experimentManager.set("artifacts", false)).toMatchObject({
+      id: "artifacts",
       enabled: false,
       source: "override",
       override: false,
@@ -86,12 +67,18 @@ describe("experimentManager", () => {
     await settingsManager.reset();
     await settingsManager.initialize();
 
-    expect(experimentManager.getSnapshot("node")).toMatchObject({
-      id: "node",
+    expect(experimentManager.getSnapshot("artifacts")).toMatchObject({
+      id: "artifacts",
       enabled: false,
       source: "override",
       override: false,
     });
+  });
+
+  test("does not expose the retired node experiment", () => {
+    expect(
+      experimentManager.list().find((entry) => entry.id === ("node" as never)),
+    ).toBeUndefined();
   });
 
   test("maps conversation title experiment controls to the persistent setting", async () => {

--- a/src/experiments/manager.ts
+++ b/src/experiments/manager.ts
@@ -37,12 +37,6 @@ const EXPERIMENT_DEFINITIONS: readonly ExperimentDefinition[] = [
       "Open browser-based worktree diff previews powered by Diffs from Pierre.",
   },
   {
-    id: "node",
-    label: "node",
-    description: "Route API requests through the Letta Node / TS core path.",
-    envVar: "LETTA_NODE",
-  },
-  {
     id: "tui_cron",
     label: "TUI cron scheduler",
     description:

--- a/src/experiments/types.ts
+++ b/src/experiments/types.ts
@@ -3,7 +3,6 @@ export type ExperimentId =
   | "conversation_titles"
   | "desktop_conversation_bootstrap"
   | "diffs"
-  | "node"
   | "tui_cron";
 
 export type ExperimentSource = "override" | "env" | "default";

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -38,7 +38,6 @@ export type ExperimentId =
   | "conversation_titles"
   | "desktop_conversation_bootstrap"
   | "diffs"
-  | "node"
   | "tui_cron";
 
 export type ExperimentSource = "override" | "env" | "default";

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -1695,7 +1695,7 @@ describe("listen-client parseServerMessage", () => {
         JSON.stringify({
           type: "set_experiment",
           request_id: "experiment-set-1",
-          experiment_id: "node",
+          experiment_id: "tui_cron",
           enabled: true,
         }),
       ),
@@ -3520,11 +3520,9 @@ describe("listen-client experiment command handling", () => {
   test("wraps typed experiment reads and writes over WS", async () => {
     const originalGetSettings = settingsManager.getSettings;
     const originalUpdateSettings = settingsManager.updateSettings;
-    const originalNodeFlag = process.env.LETTA_NODE;
     const globalSettings = { autoConversationTitles: false } as Settings;
 
     try {
-      delete process.env.LETTA_NODE;
       (settingsManager as typeof settingsManager).getSettings = (() =>
         globalSettings) as typeof settingsManager.getSettings;
       (settingsManager as typeof settingsManager).updateSettings = ((
@@ -3560,7 +3558,7 @@ describe("listen-client experiment command handling", () => {
         success: true,
         experiments: expect.arrayContaining([
           expect.objectContaining({
-            id: "node",
+            id: "tui_cron",
             enabled: false,
             source: "default",
           }),
@@ -3577,7 +3575,7 @@ describe("listen-client experiment command handling", () => {
         {
           type: "set_experiment",
           request_id: "experiment-set-1",
-          experiment_id: "node",
+          experiment_id: "tui_cron",
           enabled: true,
         },
         socket as unknown as WebSocket,
@@ -3592,7 +3590,7 @@ describe("listen-client experiment command handling", () => {
         success: true,
         experiments: expect.arrayContaining([
           expect.objectContaining({
-            id: "node",
+            id: "tui_cron",
             enabled: true,
             source: "override",
           }),
@@ -3603,7 +3601,7 @@ describe("listen-client experiment command handling", () => {
         device_status: {
           experiments: expect.arrayContaining([
             expect.objectContaining({
-              id: "node",
+              id: "tui_cron",
               enabled: true,
               source: "override",
             }),
@@ -3638,11 +3636,6 @@ describe("listen-client experiment command handling", () => {
       });
       expect(globalSettings.autoConversationTitles).toBe(true);
     } finally {
-      if (originalNodeFlag === undefined) {
-        delete process.env.LETTA_NODE;
-      } else {
-        process.env.LETTA_NODE = originalNodeFlag;
-      }
       (settingsManager as typeof settingsManager).getSettings =
         originalGetSettings;
       (settingsManager as typeof settingsManager).updateSettings =
@@ -4181,31 +4174,21 @@ describe("listen-client v2 status builders", () => {
   });
 
   test("buildDeviceStatus includes the effective working directory", () => {
-    const originalNodeFlag = process.env.LETTA_NODE;
-    delete process.env.LETTA_NODE;
     const runtime = __listenClientTestUtils.createRuntime();
-    try {
-      const deviceStatus = __listenClientTestUtils.buildDeviceStatus(runtime);
-      expect(typeof deviceStatus.current_working_directory).toBe("string");
-      expect(
-        (deviceStatus.current_working_directory ?? "").length,
-      ).toBeGreaterThan(0);
-      expect(deviceStatus.current_toolset_preference).toBe("auto");
-      expect(deviceStatus.experiments).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            id: "node",
-            source: "default",
-          }),
-        ]),
-      );
-    } finally {
-      if (originalNodeFlag === undefined) {
-        delete process.env.LETTA_NODE;
-      } else {
-        process.env.LETTA_NODE = originalNodeFlag;
-      }
-    }
+    const deviceStatus = __listenClientTestUtils.buildDeviceStatus(runtime);
+    expect(typeof deviceStatus.current_working_directory).toBe("string");
+    expect(
+      (deviceStatus.current_working_directory ?? "").length,
+    ).toBeGreaterThan(0);
+    expect(deviceStatus.current_toolset_preference).toBe("auto");
+    expect(deviceStatus.experiments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "tui_cron",
+          source: "default",
+        }),
+      ]),
+    );
   });
 
   test("buildDeviceStatus includes should_doctor state when available", () => {

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -101,7 +101,6 @@ import type {
 const EXPERIMENT_IDS = new Set<ExperimentId>([
   "conversation_titles",
   "desktop_conversation_bootstrap",
-  "node",
   "tui_cron",
 ]);
 


### PR DESCRIPTION
## Summary

- Root cause from LET-9516: a persisted `experiments: { node: false }` in `~/.letta/settings.json` made letta-code send `x-letta-node: 0`, silently routing every request from that installation to the Python core runtime instead of the TS runtime — indefinitely, with no visibility. Datadog sizing (Jul 1–8): ~41k explicitly opted-out message POSTs vs ~480k defaulting to TS, concentrated on a handful of hosts with stale overrides (largest: a Mac mini running a Slack channel listener, which is how the LET-9501 byte-overflow run ended up on Python).
- The TS runtime rollout is at 100%, so the persisted client-side toggle no longer serves a purpose. This PR retires the `node` experiment: removed from the experiment registry (so it disappears from `/experiments` and the desktop experiments UI, which list dynamically), from the `ExperimentId` types, and from the WS `set_experiment` allowlist.
- `x-letta-node` is now derived purely from the `LETTA_NODE` env var: unset → no header (server default: TS runtime); truthy → `1`; set-but-falsy → `0` (kept as a per-process debugging escape hatch that cannot be accidentally persisted). Legacy `experiments.node` keys in settings.json are ignored — a regression test pins this.

## Notes

- Remote `set_experiment` frames with `experiment_id: "node"` are now rejected as invalid input; the desktop UI never hardcodes the id, so nothing sends them after listing.
- Baseline failures in this environment (biome `noTemplateCurlyInString` in `prompt-assets.test.ts`, sandbox EPERM in the `should_doctor` memfs test) are pre-existing on main and unrelated.

Fixes LET-9516.

👾 Generated with [Letta Code](https://letta.com)