### PR TITLE
fix(channels): keep tool error output out of progress row titles

### DIFF
--- a/src/channels/progress.test.ts
+++ b/src/channels/progress.test.ts
@@ -466,8 +466,84 @@ test("channel progress builds failed file titles", () => {
       runId: "run-1",
       toolCallId: "call-1",
       toolName: "Write",
-      toolDetails: "failed",
+      toolDetails: "/repo/src/lib.rs",
+      errorDetails: "failed",
       toolTitle: "Tried to write lib.rs",
+    },
+  ]);
+});
+
+test("channel progress keeps shell error output out of toolDetails (LET-9509)", () => {
+  const builder = createChannelTurnProgressBuilder();
+  builder.buildUpdates({
+    message_type: "tool_call_message",
+    run_id: "run-1",
+    tool_calls: [
+      {
+        tool_call_id: "call-1",
+        name: "Bash",
+        arguments: JSON.stringify({
+          command: "gh run view 28890486751",
+          description: "Check CI run status",
+        }),
+      },
+    ],
+  } as unknown as StreamDelta);
+
+  const updates = builder.buildUpdates({
+    message_type: "tool_return_message",
+    run_id: "run-1",
+    tool_returns: [
+      {
+        tool_call_id: "call-1",
+        status: "error",
+        tool_return:
+          "Exit code: 1\nrun 28890486751 is still in progress; logs will be available when it is complete",
+      },
+    ],
+  } as unknown as StreamDelta);
+
+  expect(updates).toEqual([
+    {
+      kind: "tool",
+      state: "error",
+      message: "Tool failed",
+      runId: "run-1",
+      toolCallId: "call-1",
+      toolName: "Bash",
+      // Argument-derived: safe to use as a row title on rich surfaces.
+      toolDetails: "Check CI run status",
+      // Output preview: detail text only, never a title.
+      errorDetails:
+        "Exit code: 1 run 28890486751 is still in progress; logs will be available when it is complete",
+    },
+  ]);
+});
+
+test("channel progress emits only errorDetails when failed shell args never arrived", () => {
+  const builder = createChannelTurnProgressBuilder();
+  const updates = builder.buildUpdates({
+    message_type: "tool_return_message",
+    run_id: "run-1",
+    tool_returns: [
+      {
+        tool_call_id: "call-9",
+        name: "Bash",
+        status: "error",
+        tool_return: "Exit code: 1\nboom",
+      },
+    ],
+  } as unknown as StreamDelta);
+
+  expect(updates).toEqual([
+    {
+      kind: "tool",
+      state: "error",
+      message: "Tool failed",
+      runId: "run-1",
+      toolCallId: "call-9",
+      toolName: "Bash",
+      errorDetails: "Exit code: 1 boom",
     },
   ]);
 });
@@ -903,7 +979,7 @@ test("channel progress maps canonical parallel tool return arrays", () => {
       message: "Tool failed",
       runId: "run-1",
       toolCallId: "call-2",
-      toolDetails: "failed",
+      errorDetails: "failed",
     },
   ]);
 });

--- a/src/channels/progress.ts
+++ b/src/channels/progress.ts
@@ -1009,11 +1009,13 @@ export function createChannelTurnProgressBuilder(
           const toolWithAccumulatedArgs = accumulatedArgs
             ? { ...summary, argumentsText: accumulatedArgs }
             : summary;
-          const toolDetails =
-            status === "error"
-              ? errorDetails ||
-                formatToolProgressDetails(toolWithAccumulatedArgs, options)
-              : formatToolProgressDetails(toolWithAccumulatedArgs, options);
+          // toolDetails stays argument-derived even on errors: surfaces use it
+          // for row titles (e.g. shell rows), so tool output must never leak
+          // into it. Error-output previews travel in errorDetails (LET-9509).
+          const toolDetails = formatToolProgressDetails(
+            toolWithAccumulatedArgs,
+            options,
+          );
           const toolTitle = formatToolProgressTitle(
             toolWithAccumulatedArgs,
             status,
@@ -1027,6 +1029,7 @@ export function createChannelTurnProgressBuilder(
                 ...(summary.id ? { toolCallId: summary.id } : {}),
                 ...(summary.name ? { toolName: summary.name } : {}),
                 ...(toolDetails ? { toolDetails } : {}),
+                ...(status === "error" && errorDetails ? { errorDetails } : {}),
                 ...(toolTitle ? { toolTitle } : {}),
               },
               runId,
@@ -1074,12 +1077,13 @@ export function createChannelTurnProgressBuilder(
           tool && accumulatedArgs
             ? { ...tool, argumentsText: accumulatedArgs }
             : tool;
+        // toolDetails stays argument-derived even on errors (see the
+        // tool_return_message handler); error previews go to errorDetails.
         const toolDetails = toolWithAccumulatedArgs
-          ? state === "error"
-            ? formatToolErrorDetails(record) ||
-              formatToolProgressDetails(toolWithAccumulatedArgs, options)
-            : formatToolProgressDetails(toolWithAccumulatedArgs, options)
+          ? formatToolProgressDetails(toolWithAccumulatedArgs, options)
           : undefined;
+        const errorDetails =
+          state === "error" ? formatToolErrorDetails(record) : undefined;
         const toolTitle = toolWithAccumulatedArgs
           ? formatToolProgressTitle(toolWithAccumulatedArgs, state)
           : undefined;
@@ -1092,6 +1096,7 @@ export function createChannelTurnProgressBuilder(
               ...(tool?.id ? { toolCallId: tool.id } : {}),
               ...(tool?.name ? { toolName: tool.name } : {}),
               ...(toolDetails ? { toolDetails } : {}),
+              ...(errorDetails ? { errorDetails } : {}),
               ...(toolTitle ? { toolTitle } : {}),
             },
             runId,

--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -2056,6 +2056,73 @@ test("slack adapter streams native task progress and clears thread status", asyn
   });
 });
 
+test("slack adapter keeps shell error output out of task titles (LET-9509)", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+  const source = {
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    chatType: "channel" as const,
+    senderId: "U123",
+    senderTeamId: "T123",
+    messageId: "1712800000.000100",
+    threadId: "1712790000.000050",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  };
+
+  await adapter.start();
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "processing",
+    batchId: "batch-1",
+    sources: [source],
+  });
+  // Failed shell call whose arguments never produced details (fragmented
+  // stream): the error-output preview must render as detail text only.
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-1",
+    sources: [source],
+    kind: "tool",
+    state: "error",
+    message: "Tool failed",
+    toolCallId: "call-1",
+    toolName: "Bash",
+    errorDetails:
+      "Exit code: 1 run 28890486751 is still in progress; logs will be available when it is complete",
+  });
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient?.chat.startStream).toHaveBeenCalledTimes(1);
+  const startCall = (
+    writeClient?.chat.startStream.mock.calls as unknown as Array<
+      [{ chunks?: Array<Record<string, unknown>> }]
+    >
+  )[0]?.[0];
+  const taskChunk = startCall?.chunks?.find(
+    (chunk) => chunk.type === "task_update" && chunk.id === "task_call-1",
+  );
+  // Tool-level failures render as complete rows by design (card-level error
+  // state is reserved for turn failures); the important assertions here are
+  // the title and where the error preview lands.
+  expect(taskChunk).toMatchObject({
+    title: "Ran",
+    status: "complete",
+    details:
+      "Exit code: 1 run 28890486751 is still in progress; logs will be available when it is complete",
+  });
+  expect(taskChunk?.title).not.toContain("Exit code");
+});
+
 test("slack adapter labels subagent task rows and includes prompt previews", async () => {
   const adapter = createSlackAdapter({
     ...slackAccountDefaults,

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -1092,7 +1092,9 @@ function formatSlackToolTaskTitle(
     if (details) {
       return details;
     }
-    return status === "complete" ? "Ran" : "Running";
+    // "Ran" also covers errors: the command did run and finish; the row's
+    // error status conveys the failure.
+    return status === "complete" || status === "error" ? "Ran" : "Running";
   }
   if (toolName === "TaskOutput") {
     return status === "complete"
@@ -1251,7 +1253,13 @@ function resolveSlackToolActionDetails(
   const rememberedDetails = update.toolCallId
     ? entry.toolDetailsByCallId?.get(update.toolCallId)
     : undefined;
-  const details = update.toolDetails ?? rememberedDetails;
+  // Error-output previews only ever render as detail text under the row
+  // title; toolDetails/toolTitle stay argument-derived so tool output can
+  // never become a header (LET-9509).
+  const details =
+    (update.state === "error" ? update.errorDetails : undefined) ??
+    update.toolDetails ??
+    rememberedDetails;
   if (!details) {
     return undefined;
   }
@@ -1663,7 +1671,15 @@ function buildSlackStreamProgressChunks(
     sentDetails && resolvedDetails && sentDetails !== resolvedDetails
       ? sentDetails
       : resolvedDetails;
-  const title = resolveSlackToolActionName(entry, update, details);
+  // Titles only ever derive from argument summaries — resolved details can
+  // carry an error-output preview, which must never become a header
+  // (LET-9509).
+  const titleDetails =
+    update.toolDetails ??
+    (update.toolCallId
+      ? entry.toolDetailsByCallId?.get(update.toolCallId)
+      : undefined);
+  const title = resolveSlackToolActionName(entry, update, titleDetails);
   if (!title) {
     return [];
   }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -173,6 +173,12 @@ export interface ChannelTurnProgressUpdate {
   toolName?: string;
   /** Optional sanitized argument summary for expanded tool progress details. */
   toolDetails?: string;
+  /**
+   * Optional sanitized error-output preview for failed tool calls. Kept
+   * separate from toolDetails so surfaces can render it as secondary detail
+   * text; it must never be used as a row title/header (LET-9509).
+   */
+  errorDetails?: string;
   /** Optional sanitized row title for native/rich progress surfaces. */
   toolTitle?: string;
   command?: string;


### PR DESCRIPTION
## Summary

- Failed shell calls could show their raw error output as the Slack task row header — e.g. **"Exit code: 1 run 28890486751 is still in progress; logs will be available when it is complete"** repeated for every failed poll (LET-9509 screenshot).
- Root cause: on error tool returns, the channel progress builder replaced the argument-derived toolDetails ("Check CI run status") with an error-output preview — violating the fields own documented contract ("Never include tool args or output") — and Slack shell rows use details as their title.
- Invariant this defends: **row titles only ever derive from argument summaries; tool output never becomes a header.**

## What changed

- ChannelTurnProgressUpdate gains errorDetails (sanitized error-output preview, documented as never-a-title); toolDetails stays argument-derived on errors in both the tool_return_message and client_tool_end paths.
- Slack adapter: task titles now resolve from argument-derived details only; errorDetails renders as detail text under the title on failures. Failed shell rows with no known description title as "Ran" (previously leaked output, or "Running" despite being finished).
- Only Slack consumes toolDetails today, so no other adapter changes are needed; the errorDetails field flows through the existing progress-event spread for future surfaces.

## Testing

- New regression tests: progress builder (error output → errorDetails, toolDetails stays argument-derived; fragmented-args case emits errorDetails only) and Slack adapter (task chunk title is "Ran", never "Exit code…", with the preview in details).
- Updated two existing pins that asserted the old conflated behavior.
- bun test src/channels/ (705 tests) and bun run check green.

Linear: LET-9509

👾 Generated with [Letta Code](https://letta.com)