### PR TITLE
fix(dream): don't create a placeholder --to doc when nothing is learned

### DIFF
--- a/src/cli/subcommands/dream-targets.test.ts
+++ b/src/cli/subcommands/dream-targets.test.ts
@@ -52,6 +52,13 @@ describe("buildTargetInstruction", () => {
     expect(out).toContain("$MEMORY_DIR/system/memory.md");
     expect(out).not.toContain("agents.md");
   });
+
+  test("tells the agent to skip creation (no placeholder) when nothing is learned", () => {
+    const out = buildTargetInstruction(resolveDreamTarget("./AGENTS.md"));
+    expect(out).toContain("do NOT create the file");
+    expect(out).toContain("leave it absent");
+    expect(out).toContain("placeholder");
+  });
 });
 
 describe("managed frontmatter (system/ files require it)", () => {

--- a/src/cli/subcommands/dream-targets.ts
+++ b/src/cli/subcommands/dream-targets.ts
@@ -97,8 +97,12 @@ const GENERIC_GUIDANCE = [
 
 /**
  * Build the instruction fragment that asks the reflection agent to maintain
- * the target doc at `$MEMORY_DIR/system/<fileName>`. The doc has already been
- * synced there from the target, so the agent reads and edits it in place.
+ * the target doc at `$MEMORY_DIR/system/<fileName>`. When the on-disk target
+ * exists it has already been synced there and the agent edits it in place;
+ * when it does not, the agent creates it — but only if the new experience
+ * actually yields durable guidance, so a no-signal run leaves the target
+ * absent (no file → no diff → no PR downstream) rather than committing a
+ * "nothing learned yet" placeholder.
  */
 export function buildTargetInstruction(target: DreamTarget): string {
   const guidance =
@@ -108,11 +112,19 @@ export function buildTargetInstruction(target: DreamTarget): string {
     `In addition to updating memory, maintain the file at $MEMORY_DIR/${relPath}.`,
     guidance,
     "",
-    `Read the existing $MEMORY_DIR/${relPath} (create it if it does not exist)`,
-    "and revise it in place: apply only the changes the new experience",
-    "warrants, using your judgment. Often no change is needed — if so, leave it",
-    "as-is. Keep the YAML frontmatter block (--- ... ---) at the top intact;",
-    "edit only the body below it. Commit when done.",
+    `If $MEMORY_DIR/${relPath} already exists, revise it in place: apply only`,
+    "the changes the new experience warrants, using your judgment. Often no",
+    "change is needed — if so, leave it as-is. Keep the YAML frontmatter block",
+    "(--- ... ---) at the top intact and edit only the body below it.",
+    "",
+    "If it does not exist, create it ONLY when the new experience yields",
+    "durable, forward-looking guidance worth recording, and begin the file with",
+    "a YAML frontmatter block (a --- ... --- header with a short `description:`).",
+    "If there is nothing substantive to record yet, do NOT create the file —",
+    "leave it absent rather than writing a placeholder that says nothing was",
+    "learned. The file should first appear on a run that produces real guidance.",
+    "",
+    "Commit when done.",
   ].join("\n");
 }
 


### PR DESCRIPTION
## Problem

When `letta dream --to <path>` targets a file that doesn't exist yet, `buildTargetInstruction` told the reflection agent to create it unconditionally (*"create it if it does not exist"*). On a run whose experience yields **no** durable, repo-relevant guidance — e.g. off-topic chatter like "test" / "what's your name?" — the agent still created a content-free placeholder:

```md
# AGENTS.md

No repository-specific build, test, setup, style, security, commit, or PR conventions have been learned yet.
...
```

That placeholder is a real diff, and for the OpenHands dreaming automation it becomes an unwanted PR ([example](https://github.com/letta-ai/openhands-dreaming/pull/1/files)). A run that learns nothing should be a no-op.

## Fix

Make target creation conditional in `buildTargetInstruction`:
- **File exists** → revise in place, applying only warranted changes (often none), frontmatter preserved — unchanged.
- **File doesn't exist** → create it **only** when the experience produces real guidance (and seed the required YAML frontmatter); otherwise **leave it absent** rather than writing a placeholder.

No code path changes are needed downstream: when the agent commits nothing, `readTargetFromMemory` returns `null` and `dream.ts` already skips `writeTarget` (`targetWritten` stays `false`) — so a no-signal run produces no file, no diff, and no PR. The doc still appears on the first substantive run.

## Test

Added a `buildTargetInstruction` case asserting the no-placeholder guidance is present. Existing assertions unchanged. `bun run check` clean.