### PR TITLE
fix(listener): keep the model availability cache honest across provider connects (LET-9479)

### DIFF
--- a/src/agent/available-models.test.ts
+++ b/src/agent/available-models.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Backend } from "@/backend";
+import { __testSetBackend } from "@/backend";
+import { FakeHeadlessBackend } from "@/backend/dev/fake-headless-backend";
 
 /**
  * Cache semantics for the listener's model-availability cache (LET-9479).
@@ -11,8 +14,8 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
  *  2. There was no force path: user-initiated refreshes were always eligible
  *     to be answered from a stale-but-within-TTL snapshot.
  *
- * Note: `mock.module` is process-global under Bun, so this file only mocks
- * modules that no other behavior in this suite depends on.
+ * Note: avoid `mock.module` here. Bun mocks are process-global and can leak
+ * into sibling tests that import the real backend module.
  */
 
 type FakeModel = {
@@ -23,18 +26,11 @@ type FakeModel = {
 
 let listModelsImpl: () => Promise<FakeModel[]> = async () => [];
 
-mock.module("@/backend", () => ({
-  getBackend: () => ({
-    capabilities: { byokProviderRefresh: false },
-    listModels: () => listModelsImpl(),
-  }),
-}));
-
-mock.module("@/backend/api/providers", () => ({
-  refreshByokProviders: async () => {
-    throw new Error("refreshByokProviders must not run without capability");
-  },
-}));
+class AvailableModelsTestBackend extends FakeHeadlessBackend {
+  override async listModels(): ReturnType<Backend["listModels"]> {
+    return listModelsImpl() as ReturnType<Backend["listModels"]>;
+  }
+}
 
 const {
   clearAvailableModelsCache,
@@ -54,6 +50,12 @@ describe("available-models cache semantics", () => {
   beforeEach(() => {
     clearAvailableModelsCache();
     listModelsImpl = async () => [];
+    __testSetBackend(new AvailableModelsTestBackend());
+  });
+
+  afterEach(() => {
+    clearAvailableModelsCache();
+    __testSetBackend(null);
   });
 
   test("a fetch that started before a cache clear cannot commit stale results", async () => {

--- a/src/agent/available-models.test.ts
+++ b/src/agent/available-models.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+/**
+ * Cache semantics for the listener's model-availability cache (LET-9479).
+ *
+ * Two staleness bugs made "no models after connecting a provider" stick for
+ * the full 5-minute TTL:
+ *  1. `clearAvailableModelsCache()` cleared `cache` but not `inflight`, so a
+ *     fetch that started BEFORE a provider connect could complete afterward
+ *     and commit its pre-connect (empty) handle set as a fresh cache entry.
+ *  2. There was no force path: user-initiated refreshes were always eligible
+ *     to be answered from a stale-but-within-TTL snapshot.
+ *
+ * Note: `mock.module` is process-global under Bun, so this file only mocks
+ * modules that no other behavior in this suite depends on.
+ */
+
+type FakeModel = {
+  handle: string;
+  max_context_window?: number;
+  provider_type?: string;
+};
+
+let listModelsImpl: () => Promise<FakeModel[]> = async () => [];
+
+mock.module("@/backend", () => ({
+  getBackend: () => ({
+    capabilities: { byokProviderRefresh: false },
+    listModels: () => listModelsImpl(),
+  }),
+}));
+
+mock.module("@/backend/api/providers", () => ({
+  refreshByokProviders: async () => {
+    throw new Error("refreshByokProviders must not run without capability");
+  },
+}));
+
+const {
+  clearAvailableModelsCache,
+  getAvailableModelHandles,
+  getCachedModelHandles,
+} = await import("@/agent/available-models");
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe("available-models cache semantics", () => {
+  beforeEach(() => {
+    clearAvailableModelsCache();
+    listModelsImpl = async () => [];
+  });
+
+  test("a fetch that started before a cache clear cannot commit stale results", async () => {
+    const preConnect = deferred<FakeModel[]>();
+    listModelsImpl = () => preConnect.promise;
+
+    // Fetch A starts (e.g. boot-time list_models before any provider exists).
+    const fetchA = getAvailableModelHandles();
+
+    // Provider connect clears the cache while A is still in flight.
+    clearAvailableModelsCache();
+
+    // Fetch B starts post-connect and sees the new provider's models.
+    const postConnect = deferred<FakeModel[]>();
+    listModelsImpl = () => postConnect.promise;
+    const fetchB = getAvailableModelHandles();
+
+    // A resolves late with the pre-connect (empty) snapshot.
+    preConnect.resolve([]);
+    await fetchA;
+
+    // The stale result must not have been committed to the cache.
+    expect(getCachedModelHandles()).toBeNull();
+
+    postConnect.resolve([{ handle: "openai/gpt-4o" }]);
+    const resultB = await fetchB;
+    expect([...resultB.handles]).toEqual(["openai/gpt-4o"]);
+
+    // B's result is the cached truth — and A's late `.finally` must not have
+    // nulled out B's inflight slot mid-fetch either.
+    expect([...(getCachedModelHandles() ?? [])]).toEqual(["openai/gpt-4o"]);
+
+    // Subsequent calls serve B's committed cache entry.
+    listModelsImpl = async () => {
+      throw new Error("must be served from cache");
+    };
+    const cached = await getAvailableModelHandles();
+    expect(cached.source).toBe("cache");
+    expect([...cached.handles]).toEqual(["openai/gpt-4o"]);
+  });
+
+  test("forceRefresh bypasses a fresh cache entry", async () => {
+    listModelsImpl = async () => [{ handle: "openai/gpt-4o" }];
+    const first = await getAvailableModelHandles();
+    expect([...first.handles]).toEqual(["openai/gpt-4o"]);
+
+    // Cache is fresh: a normal call must serve it.
+    listModelsImpl = async () => [
+      { handle: "openai/gpt-4o" },
+      { handle: "zai/glm-4.6" },
+    ];
+    const cached = await getAvailableModelHandles();
+    expect(cached.source).toBe("cache");
+    expect([...cached.handles]).toEqual(["openai/gpt-4o"]);
+
+    // Force refresh must hit the network despite the fresh cache.
+    const forced = await getAvailableModelHandles({ forceRefresh: true });
+    expect(forced.source).toBe("network");
+    expect([...forced.handles]).toEqual(["openai/gpt-4o", "zai/glm-4.6"]);
+  });
+
+  test("clearAvailableModelsCache drops the inflight fetch so the next call refetches", async () => {
+    const wedged = deferred<FakeModel[]>();
+    listModelsImpl = () => wedged.promise;
+    const fetchA = getAvailableModelHandles();
+
+    clearAvailableModelsCache();
+
+    // Next caller must start a fresh fetch instead of piggybacking on A.
+    listModelsImpl = async () => [{ handle: "anthropic/claude-sonnet-4-5" }];
+    const resultB = await getAvailableModelHandles();
+    expect([...resultB.handles]).toEqual(["anthropic/claude-sonnet-4-5"]);
+
+    wedged.resolve([]);
+    await fetchA;
+    expect([...(getCachedModelHandles() ?? [])]).toEqual([
+      "anthropic/claude-sonnet-4-5",
+    ]);
+  });
+});

--- a/src/agent/available-models.ts
+++ b/src/agent/available-models.ts
@@ -12,6 +12,10 @@ type CacheEntry = {
 
 let cache: CacheEntry | null = null;
 let inflight: Promise<CacheEntry> | null = null;
+// Bumped on every cache clear so an in-flight fetch that started BEFORE the
+// clear (e.g. before a provider connect) can never commit its now-stale
+// result into the cache after the clear.
+let generation = 0;
 
 function isFresh(now = Date.now()) {
   return cache !== null && now - cache.fetchedAt < CACHE_TTL_MS;
@@ -26,6 +30,8 @@ export type AvailableModelHandlesResult = {
 
 export function clearAvailableModelsCache() {
   cache = null;
+  inflight = null;
+  generation++;
 }
 
 export function getAvailableModelsCacheInfo(): {
@@ -125,16 +131,26 @@ export async function getAvailableModelHandles(options?: {
     await refreshByokProviders();
   }
 
-  inflight = fetchFromNetwork()
+  const requestGeneration = generation;
+  const request: Promise<CacheEntry> = fetchFromNetwork()
     .then((entry) => {
-      cache = entry;
+      // Only commit if the cache wasn't cleared while we were fetching;
+      // otherwise this result predates a provider mutation and is stale.
+      if (generation === requestGeneration) {
+        cache = entry;
+      }
       return entry;
     })
     .finally(() => {
-      inflight = null;
+      // A forced or post-clear fetch may have replaced `inflight` already —
+      // never null out someone else's request.
+      if (inflight === request) {
+        inflight = null;
+      }
     });
+  inflight = request;
 
-  const entry = await inflight;
+  const entry = await request;
   return {
     handles: entry.handles,
     providerTypes: entry.providerTypes,

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -1379,6 +1379,12 @@ export interface ListModelsCommand {
   type: "list_models";
   /** Echoed back in the response for request correlation. */
   request_id: string;
+  /**
+   * Bypass the listener's availability cache and refetch from the backend.
+   * Sent by user-initiated refreshes so they can never be answered with a
+   * stale-but-within-TTL snapshot.
+   */
+  force?: boolean;
 }
 
 export type ConnectProviderStorageTarget = "local";

--- a/src/websocket/listen-model-update.test.ts
+++ b/src/websocket/listen-model-update.test.ts
@@ -551,7 +551,7 @@ describe("listen-client list_models response wiring", () => {
 
     // The response builder should use Promise.allSettled for parallel fetches
     expect(source).toContain("Promise.allSettled");
-    expect(source).toContain("getAvailableModelHandles()");
+    expect(source).toContain("getAvailableModelHandles(");
     expect(source).toContain("listProviders()");
     expect(source).toContain("buildByokProviderAliases(providers)");
   });
@@ -560,7 +560,19 @@ describe("listen-client list_models response wiring", () => {
     const source = readModelToolsetCommandSource();
 
     // Handler should be wrapped in void (async () => { ... })() pattern
-    expect(source).toContain("buildListModelsResponse(parsed.request_id)");
+    expect(source).toContain("buildListModelsResponse(parsed.request_id, {");
+  });
+
+  test("user-initiated force refresh bypasses the availability cache", () => {
+    const source = readModelToolsetCommandSource();
+
+    // The WS command's force flag must reach getAvailableModelHandles as
+    // forceRefresh — otherwise "Refresh model list" can be answered from a
+    // stale-but-within-TTL cache snapshot (LET-9479).
+    expect(source).toContain("forceRefresh: parsed.force === true");
+    expect(source).toContain(
+      "getAvailableModelHandles(\n      options.forceRefresh === true ? { forceRefresh: true } : undefined,\n    )",
+    );
   });
 
   test("response type includes available_handles and byok_provider_aliases fields", () => {

--- a/src/websocket/listener/commands/model-toolset.ts
+++ b/src/websocket/listener/commands/model-toolset.ts
@@ -597,11 +597,17 @@ export function buildListModelsEntries(): ListModelsResponseModelEntry[] {
  */
 export async function buildListModelsResponse(
   requestId: string,
+  options: { forceRefresh?: boolean } = {},
 ): Promise<ListModelsResponseMessage> {
   const entries = buildListModelsEntries();
 
   const [handlesResult, providersResult] = await Promise.allSettled([
-    getAvailableModelHandles(),
+    // User-initiated refreshes bypass the availability cache: within the
+    // cache TTL a stale snapshot would otherwise make every "Refresh model
+    // list" click return the same wrong answer.
+    getAvailableModelHandles(
+      options.forceRefresh === true ? { forceRefresh: true } : undefined,
+    ),
     listProviders(),
   ]);
 
@@ -640,7 +646,9 @@ export function handleModelToolsetCommand(
   if (isListModelsCommand(parsed)) {
     runDetachedListenerTask("list_models", async () => {
       try {
-        const response = await buildListModelsResponse(parsed.request_id);
+        const response = await buildListModelsResponse(parsed.request_id, {
+          forceRefresh: parsed.force === true,
+        });
         safeSocketSend(
           socket,
           response,

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -876,8 +876,13 @@ export function isListModelsCommand(
   const c = value as {
     type?: unknown;
     request_id?: unknown;
+    force?: unknown;
   };
-  return c.type === "list_models" && typeof c.request_id === "string";
+  return (
+    c.type === "list_models" &&
+    typeof c.request_id === "string" &&
+    (c.force === undefined || typeof c.force === "boolean")
+  );
 }
 
 export function isListConnectProvidersCommand(


### PR DESCRIPTION
## Summary

letta-code half of the LET-9479 re-test failures ("after adding a provider, no models show up" / "Refresh model list does not work" — full investigation on the Linear ticket). Two staleness bugs in the listener's model-availability cache (`src/agent/available-models.ts`) made an empty model list stick for the full 5-minute TTL in local mode:

- **In-flight fetch survives a cache clear.** `clearAvailableModelsCache()` (called by the WS `connect_provider`/`disconnect_provider` handlers) nulled `cache` but not `inflight`, so a fetch that started before the provider connect could complete afterward and commit its pre-connect (empty) handle set as a fresh cache entry. Cache commits are now generation-guarded, the inflight slot is dropped on clear, and a late fetch can no longer null out a newer request's inflight slot in its `finally`.
- **User refreshes could not bypass the TTL.** `buildListModelsResponse` always called `getAvailableModelHandles()` cache-first, so once anything left the cache stale, "Refresh model list" faithfully returned the same wrong answer for up to 5 minutes. The `list_models` WS command now accepts an optional `force` flag (backward compatible — older clients simply omit it) that maps to `getAvailableModelHandles({forceRefresh: true})`.

The desktop UI companion PR (letta-cloud) sends `force: true` from the "Refresh model list" action and fixes the client-side wedge where a forced refresh piggybacked on a dead in-flight request.

## Testing

- New behavioral suite `src/agent/available-models.test.ts` covering: stale in-flight results cannot commit after a clear, `forceRefresh` bypasses a fresh cache, and post-clear callers refetch instead of piggybacking.
- Updated the `listen-model-update` source pins for the new signatures + force plumbing.
- `bun run check` clean for the changed files (the biome failure on `prompt-assets.test.ts` is pre-existing on origin/main).

👾 Generated with [Letta Code](https://letta.com)