### PR TITLE
fix(dream): nudge --to AGENTS.md toward concise, timeless wording

### DIFF
--- a/src/cli/subcommands/dream-targets.test.ts
+++ b/src/cli/subcommands/dream-targets.test.ts
@@ -46,6 +46,12 @@ describe("buildTargetInstruction", () => {
     expect(out).toContain("revise it in place");
   });
 
+  test("agents-md guidance asks for concise, timeless wording", () => {
+    const out = buildTargetInstruction(resolveDreamTarget("./AGENTS.md"));
+    expect(out).toContain("concise and scannable");
+    expect(out).toContain("timelessly");
+  });
+
   test("generic uses generic guidance, not the agents.md standard text", () => {
     const target = resolveDreamTarget("./memory.md");
     const out = buildTargetInstruction(target);

--- a/src/cli/subcommands/dream-targets.ts
+++ b/src/cli/subcommands/dream-targets.ts
@@ -86,7 +86,10 @@ const AGENTS_MD_GUIDANCE = [
   "plain Markdown with any headings. Do NOT duplicate human-README content",
   "(project pitch, quickstart, contribution guide). Prefer editing/merging",
   "existing sections over appending; remove guidance that new evidence",
-  "contradicts.",
+  "contradicts. Keep it concise and scannable — favor short bullets over prose",
+  "so a coding agent can skim it quickly. Write timelessly: describe how the",
+  "repo works, not how it recently changed, and avoid time-relative wording",
+  "(currently, for now, no longer) that goes stale.",
 ].join("\n");
 
 const GENERIC_GUIDANCE = [


### PR DESCRIPTION
## What

Adds two durable, repo-agnostic quality nudges to `AGENTS_MD_GUIDANCE` (the instruction the reflection agent follows when maintaining a `--to` AGENTS.md):

- **Concise & scannable** — favor short bullets over prose so a coding agent can skim it quickly.
- **Timeless wording** — describe how the repo works, not how it recently changed; avoid time-relative phrasing (`currently`, `for now`, `no longer`) that goes stale as the doc persists across dream runs.

## Why

From reviewing a real dreamed AGENTS.md ([openhands-dreaming#1](https://github.com/letta-ai/openhands-dreaming/pull/1/files)): the output was good and accurate, but used time-relative wording like *"letta dream currently uses …"* and leaned toward prose in places. These two properties help every repo, not just that one, so they belong in the instruction rather than as per-consumer post-processing.

Deliberately **not** included (session-specific, wouldn't generalize): rules to avoid "design-doc" content or to label local-only observations — those were artifacts of a session that happened to be about building an automation, and a blanket rule would suppress legitimate architecture notes in repos where the implementation *is* the product.

## Test

Added an assertion that the agents-md guidance contains the concise/timeless nudges. Existing assertions unchanged. `bun run check` clean.

---
Separate from #3264 (the no-placeholder fix) — one logical change each; they touch different constants in the same file.