### PR TITLE
fix(slack): close orphaned progress streams before starting a new one

### DIFF
--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -2212,7 +2212,7 @@ test("slack adapter closes orphaned progress streams before starting a new one (
   // render (turn 1 was cancelled), not a generic label.
   expect(orphanStop?.chunks?.[0]).toMatchObject({
     type: "plan_update",
-    title: "Cancelled",
+    title: "Interrupted",
   });
 });
 
@@ -3635,7 +3635,7 @@ test("slack adapter closes cancelled turns without the red error status", async 
   });
   expect(stopChunks).toContainEqual({
     type: "plan_update",
-    title: "Cancelled",
+    title: "Interrupted",
   });
 });
 

--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -2123,6 +2123,188 @@ test("slack adapter keeps shell error output out of task titles (LET-9509)", asy
   expect(taskChunk?.title).not.toContain("Exit code");
 });
 
+test("slack adapter closes orphaned progress streams before starting a new one (LET-9515)", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+  const source = {
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    chatType: "channel" as const,
+    senderId: "U123",
+    senderTeamId: "T123",
+    messageId: "1712800000.000100",
+    threadId: "1712790000.000050",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  };
+  const followUpSource = { ...source, messageId: "1712800002.000200" };
+
+  await adapter.start();
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "processing",
+    batchId: "batch-1",
+    sources: [source],
+  });
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-1",
+    sources: [source],
+    kind: "tool",
+    state: "started",
+    message: "Running tool",
+    toolCallId: "call-1",
+    toolName: "exec_command",
+  });
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient?.chat.startStream).toHaveBeenCalledTimes(1);
+
+  // Turn 1's stop fails transiently (rate limit): the Slack-side stream
+  // stays live/spinning even though the adapter resets the card entry.
+  writeClient?.chat.stopStream.mockImplementationOnce(async () => ({
+    ok: false,
+    error: "rate_limited",
+  }));
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "finished",
+    batchId: "batch-1",
+    outcome: "cancelled",
+    sources: [source],
+  });
+  expect(writeClient?.chat.stopStream).toHaveBeenCalledTimes(1);
+
+  // The follow-up turn's new stream must close the orphan first so two live
+  // spinners never render side by side in the thread.
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "processing",
+    batchId: "batch-2",
+    sources: [followUpSource],
+  });
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-2",
+    sources: [followUpSource],
+    kind: "tool",
+    state: "started",
+    message: "Running tool",
+    toolCallId: "call-2",
+    toolName: "exec_command",
+  });
+  expect(writeClient?.chat.startStream).toHaveBeenCalledTimes(2);
+  expect(writeClient?.chat.stopStream).toHaveBeenCalledTimes(2);
+  const stopCalls = writeClient?.chat.stopStream.mock.calls as unknown as Array<
+    [{ channel: string; ts: string; chunks?: Array<Record<string, unknown>> }]
+  >;
+  const orphanStop = stopCalls[1]?.[0];
+  expect(orphanStop).toMatchObject({
+    channel: "C123",
+    ts: "1712800000.000300",
+  });
+  expect(orphanStop?.chunks?.[0]).toMatchObject({
+    type: "plan_update",
+    title: "Completed",
+  });
+});
+
+test("slack adapter drops orphan records once the stream is already terminal", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+  const source = {
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    chatType: "channel" as const,
+    senderId: "U123",
+    senderTeamId: "T123",
+    messageId: "1712800000.000100",
+    threadId: "1712790000.000050",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  };
+
+  await adapter.start();
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-1",
+    sources: [source],
+    kind: "tool",
+    state: "started",
+    message: "Running tool",
+    toolCallId: "call-1",
+    toolName: "exec_command",
+  });
+  const writeClient = FakeSlackWriteClient.instances[0];
+  writeClient?.chat.stopStream.mockImplementationOnce(async () => ({
+    ok: false,
+    error: "rate_limited",
+  }));
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "finished",
+    batchId: "batch-1",
+    outcome: "cancelled",
+    sources: [source],
+  });
+
+  // By sweep time the orphan already left streaming state (expired or
+  // finalized): treated as terminal, swept once, and never retried.
+  writeClient?.chat.stopStream.mockImplementationOnce(async () => ({
+    ok: false,
+    error: "message_not_in_streaming_state",
+  }));
+  const followUpSource = { ...source, messageId: "1712800002.000200" };
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-2",
+    sources: [followUpSource],
+    kind: "tool",
+    state: "started",
+    message: "Running tool",
+    toolCallId: "call-2",
+    toolName: "exec_command",
+  });
+  expect(writeClient?.chat.startStream).toHaveBeenCalledTimes(2);
+  expect(writeClient?.chat.stopStream).toHaveBeenCalledTimes(2);
+
+  // A third stream in the thread must not re-attempt the swept orphan.
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "finished",
+    batchId: "batch-2",
+    outcome: "cancelled",
+    sources: [followUpSource],
+  });
+  const thirdSource = { ...source, messageId: "1712800004.000300" };
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-3",
+    sources: [thirdSource],
+    kind: "tool",
+    state: "started",
+    message: "Running tool",
+    toolCallId: "call-3",
+    toolName: "exec_command",
+  });
+  expect(writeClient?.chat.startStream).toHaveBeenCalledTimes(3);
+  // Stops: failed turn-1 stop, not_in_streaming_state sweep, successful
+  // turn-2 stop — and no extra sweep before stream 3.
+  expect(writeClient?.chat.stopStream).toHaveBeenCalledTimes(3);
+});
+
 test("slack adapter labels subagent task rows and includes prompt previews", async () => {
   const adapter = createSlackAdapter({
     ...slackAccountDefaults,

--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -2208,9 +2208,11 @@ test("slack adapter closes orphaned progress streams before starting a new one (
     channel: "C123",
     ts: "1712800000.000300",
   });
+  // The sweep replays the terminal title the failed stop was trying to
+  // render (turn 1 was cancelled), not a generic label.
   expect(orphanStop?.chunks?.[0]).toMatchObject({
     type: "plan_update",
-    title: "Completed",
+    title: "Cancelled",
   });
 });
 

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -550,6 +550,8 @@ const SLACK_DEAD_STREAM_REWRITE_TEXT_MAX = 2_900;
 const SLACK_PROGRESS_CARD_TEXT_MAX = 300;
 const SLACK_PROGRESS_CARD_STATE_TTL_MS = 6 * 60 * 60 * 1000;
 const SLACK_PROGRESS_CARD_STATE_MAX = 2_000;
+const SLACK_ORPHANED_STREAMS_PER_THREAD_MAX = 4;
+const SLACK_ORPHANED_STREAM_THREADS_MAX = 500;
 const SLACK_STREAM_CHUNK_TEXT_MAX = 256;
 const SLACK_LIFECYCLE_ERROR_TASK_ID = "task_lifecycle_error";
 const SLACK_CHANNEL_RESPONSE_TASK_ID = "task_channel_response";
@@ -2116,6 +2118,12 @@ export function createSlackAdapter(
   const agentThreadTracker = createAgentThreadTracker();
   const progressCardByReplyKey = new Map<string, SlackProgressCardEntry>();
   const activeProgressCardKeyByReplyKey = new Map<string, string>();
+  // Live Slack-side streams whose stop failed transiently (rate limit,
+  // network blip — anything but the dead-stream case): the local entry gets
+  // reset for the next turn, but Slack keeps rendering the old spinner.
+  // Recorded per replyKey and swept before the next startStream in the same
+  // thread, so at most one live progress stream exists per thread (LET-9515).
+  const orphanedStreamTsByReplyKey = new Map<string, Set<string>>();
   const assistantStatusReplyKeys = new Set<string>();
   const assistantStatusTextByReplyKey = new Map<string, string>();
   const progressUpdateThrottleMs = resolveSlackProgressUpdateThrottleMs();
@@ -2595,6 +2603,89 @@ export function createSlackAdapter(
     return args;
   }
 
+  function rememberOrphanedSlackProgressStream(
+    source: ChannelTurnSource,
+    streamTs: string,
+  ): void {
+    const replyKey = getLifecycleReplyKey(source);
+    if (!replyKey) {
+      return;
+    }
+    let orphans = orphanedStreamTsByReplyKey.get(replyKey);
+    if (!orphans) {
+      if (
+        orphanedStreamTsByReplyKey.size >= SLACK_ORPHANED_STREAM_THREADS_MAX
+      ) {
+        const oldestKey = orphanedStreamTsByReplyKey.keys().next().value;
+        if (oldestKey !== undefined) {
+          orphanedStreamTsByReplyKey.delete(oldestKey);
+        }
+      }
+      orphans = new Set();
+      orphanedStreamTsByReplyKey.set(replyKey, orphans);
+    }
+    if (orphans.size >= SLACK_ORPHANED_STREAMS_PER_THREAD_MAX) {
+      return;
+    }
+    orphans.add(streamTs);
+    console.warn(
+      "[Slack] Progress stream stop failed; deferring close until the next stream in this thread:",
+      streamTs,
+    );
+  }
+
+  /**
+   * Close any live streams a previous turn failed to stop in this thread
+   * before starting a new one, so two spinners never render side by side
+   * (LET-9515). Each orphan gets one close attempt: a stream that already
+   * left streaming state (finalized or expired) is terminal either way, so
+   * `message_not_in_streaming_state` is treated as success and anything else
+   * is logged and dropped rather than retried forever.
+   */
+  async function sweepOrphanedSlackProgressStreams(
+    source: ChannelTurnSource,
+    slackClient: SlackWriteClient,
+  ): Promise<void> {
+    const replyKey = getLifecycleReplyKey(source);
+    if (!replyKey) {
+      return;
+    }
+    const orphans = orphanedStreamTsByReplyKey.get(replyKey);
+    if (!orphans || orphans.size === 0) {
+      return;
+    }
+    orphanedStreamTsByReplyKey.delete(replyKey);
+    const stopStream = slackClient.chat.stopStream;
+    if (!stopStream) {
+      return;
+    }
+    for (const ts of orphans) {
+      try {
+        const response = await stopStream.call(slackClient.chat, {
+          channel: source.chatId,
+          ts,
+          chunks: [{ type: "plan_update", title: "Completed" }],
+        });
+        if (
+          response.ok === false &&
+          !isSlackMessageNotStreamingStateError(response.error)
+        ) {
+          console.warn(
+            "[Slack] Failed to stop orphaned progress stream:",
+            response.error ?? "unknown error",
+          );
+        }
+      } catch (error) {
+        if (!isSlackMessageNotStreamingStateError(error)) {
+          console.warn(
+            "[Slack] Failed to stop orphaned progress stream:",
+            error instanceof Error ? error.message : error,
+          );
+        }
+      }
+    }
+  }
+
   async function startSlackProgressStream(
     entry: SlackProgressCardEntry,
     replyToMessageId: string,
@@ -2612,6 +2703,7 @@ export function createSlackAdapter(
     if (!startStream) {
       return false;
     }
+    await sweepOrphanedSlackProgressStreams(entry.source, slackClient);
     try {
       const args = buildSlackStartStreamArgs(
         entry,
@@ -3249,6 +3341,13 @@ export function createSlackAdapter(
               entry.latestText,
             );
             entry.lastSentAt = Date.now();
+          } else if (!entry.streamDead && entry.streamTs) {
+            // The Slack-side stream is still live (spinning) but the entry
+            // reset below wipes our record of it. Remember the orphan so the
+            // next stream in this thread closes it first (LET-9515). Dead
+            // streams are excluded: they already left streaming state, so
+            // there is no spinner to close.
+            rememberOrphanedSlackProgressStream(source, entry.streamTs);
           }
         } else {
           await upsertSlackProgressCard(

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -2121,9 +2121,10 @@ export function createSlackAdapter(
   // Live Slack-side streams whose stop failed transiently (rate limit,
   // network blip — anything but the dead-stream case): the local entry gets
   // reset for the next turn, but Slack keeps rendering the old spinner.
-  // Recorded per replyKey and swept before the next startStream in the same
-  // thread, so at most one live progress stream exists per thread (LET-9515).
-  const orphanedStreamTsByReplyKey = new Map<string, Set<string>>();
+  // Recorded per replyKey (stream ts → intended terminal plan title) and
+  // swept before the next startStream in the same thread, so at most one
+  // live progress stream exists per thread (LET-9515).
+  const orphanedStreamsByReplyKey = new Map<string, Map<string, string>>();
   const assistantStatusReplyKeys = new Set<string>();
   const assistantStatusTextByReplyKey = new Map<string, string>();
   const progressUpdateThrottleMs = resolveSlackProgressUpdateThrottleMs();
@@ -2606,28 +2607,27 @@ export function createSlackAdapter(
   function rememberOrphanedSlackProgressStream(
     source: ChannelTurnSource,
     streamTs: string,
+    terminalPlanTitle: string,
   ): void {
     const replyKey = getLifecycleReplyKey(source);
     if (!replyKey) {
       return;
     }
-    let orphans = orphanedStreamTsByReplyKey.get(replyKey);
+    let orphans = orphanedStreamsByReplyKey.get(replyKey);
     if (!orphans) {
-      if (
-        orphanedStreamTsByReplyKey.size >= SLACK_ORPHANED_STREAM_THREADS_MAX
-      ) {
-        const oldestKey = orphanedStreamTsByReplyKey.keys().next().value;
+      if (orphanedStreamsByReplyKey.size >= SLACK_ORPHANED_STREAM_THREADS_MAX) {
+        const oldestKey = orphanedStreamsByReplyKey.keys().next().value;
         if (oldestKey !== undefined) {
-          orphanedStreamTsByReplyKey.delete(oldestKey);
+          orphanedStreamsByReplyKey.delete(oldestKey);
         }
       }
-      orphans = new Set();
-      orphanedStreamTsByReplyKey.set(replyKey, orphans);
+      orphans = new Map();
+      orphanedStreamsByReplyKey.set(replyKey, orphans);
     }
     if (orphans.size >= SLACK_ORPHANED_STREAMS_PER_THREAD_MAX) {
       return;
     }
-    orphans.add(streamTs);
+    orphans.set(streamTs, terminalPlanTitle);
     console.warn(
       "[Slack] Progress stream stop failed; deferring close until the next stream in this thread:",
       streamTs,
@@ -2650,21 +2650,21 @@ export function createSlackAdapter(
     if (!replyKey) {
       return;
     }
-    const orphans = orphanedStreamTsByReplyKey.get(replyKey);
+    const orphans = orphanedStreamsByReplyKey.get(replyKey);
     if (!orphans || orphans.size === 0) {
       return;
     }
-    orphanedStreamTsByReplyKey.delete(replyKey);
+    orphanedStreamsByReplyKey.delete(replyKey);
     const stopStream = slackClient.chat.stopStream;
     if (!stopStream) {
       return;
     }
-    for (const ts of orphans) {
+    for (const [ts, terminalPlanTitle] of orphans) {
       try {
         const response = await stopStream.call(slackClient.chat, {
           channel: source.chatId,
           ts,
-          chunks: [{ type: "plan_update", title: "Completed" }],
+          chunks: [{ type: "plan_update", title: terminalPlanTitle }],
         });
         if (
           response.ok === false &&
@@ -3343,11 +3343,21 @@ export function createSlackAdapter(
             entry.lastSentAt = Date.now();
           } else if (!entry.streamDead && entry.streamTs) {
             // The Slack-side stream is still live (spinning) but the entry
-            // reset below wipes our record of it. Remember the orphan so the
-            // next stream in this thread closes it first (LET-9515). Dead
-            // streams are excluded: they already left streaming state, so
-            // there is no spinner to close.
-            rememberOrphanedSlackProgressStream(source, entry.streamTs);
+            // reset below wipes our record of it. Remember the orphan — with
+            // the terminal plan title this stop was trying to render, so the
+            // sweep replays the turn's real outcome instead of guessing — and
+            // the next stream in this thread closes it first (LET-9515).
+            // Dead streams are excluded: they already left streaming state,
+            // so there is no spinner to close.
+            rememberOrphanedSlackProgressStream(
+              source,
+              entry.streamTs,
+              entry.status === "completed"
+                ? formatSlackCompletionPlanTitle(entry)
+                : entry.status === "cancelled"
+                  ? "Cancelled"
+                  : "Failed",
+            );
           }
         } else {
           await upsertSlackProgressCard(

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -1472,7 +1472,7 @@ function buildSlackPlanUpdateChunk(
   if (entry.status === "cancelled") {
     return {
       type: "plan_update",
-      title: "Cancelled",
+      title: "Interrupted",
     };
   }
   if (entry.status === "completed") {
@@ -1771,7 +1771,7 @@ function resolveSlackLifecycleProgressText(outcome: ChannelTurnOutcome): {
     return { status: "completed", text: "Completed" };
   }
   if (outcome === "cancelled") {
-    return { status: "cancelled", text: "Cancelled" };
+    return { status: "cancelled", text: "Interrupted" };
   }
   return { status: "error", text: "Failed" };
 }
@@ -3355,7 +3355,7 @@ export function createSlackAdapter(
               entry.status === "completed"
                 ? formatSlackCompletionPlanTitle(entry)
                 : entry.status === "cancelled"
-                  ? "Cancelled"
+                  ? "Interrupted"
                   : "Failed",
             );
           }


### PR DESCRIPTION
## Summary

- Following up while the agent was working could show **two live rich spinners** in the same thread (LET-9515 screenshot: a live "Thinking" card from the previous turn next to the new turn's live "Working" card).
- Root cause: finishSlackProgressCards resets the card entry **unconditionally** after stopStream. When the stop failed transiently (Slack rate limit, network blip — anything except the message_not_in_streaming_state case #3255 already handles via dead-rewrite), the Slack-side stream kept spinning while the local streamTs record was wiped — the orphan was unrecoverable, and the next turn started a second live stream beside it. The orphan also eventually expired into a red warning card, manufacturing LET-9502-style red artifacts.
- Invariant this defends: **at most one live progress stream per thread.**

## What changed

- Failed stops of live (non-dead) streams record the orphaned streamTs per replyKey — together with the terminal plan title that stop was trying to render — instead of discarding it.
- startSlackProgressStream sweeps recorded orphans before starting a new stream: one close attempt each, replaying the recorded terminal title (completion summary for completed turns, "Interrupted"/"Failed" otherwise) so the closed card reflects the turn's real outcome rather than a guessed label. message_not_in_streaming_state means the stream already left streaming state (finalized or expired) and is treated as success. No infinite retries.
- Closing means finalizing, not deleting: the orphaned card stops spinning, retitles to its real outcome, and stays in the thread as a static accordion.
- Bounded state: at most 4 orphans per thread, 500 threads.

Design follows the OpenClaw comparison on the Linear ticket: their stream sessions are turn-scoped and finalized in the owning dispatch frame, so a stream lexically cannot outlive its turn; this sweep approximates that ownership guarantee within our thread-keyed card architecture.

## Testing

- New regression tests: (1) failed stop → orphan closed before the follow-up turn's startStream, asserting the replayed terminal title; (2) orphan already terminal at sweep time → swept once, never re-attempted on a third stream.
- bun test src/channels/ (707 tests) and bun run check green.

Linear: LET-9515

👾 Generated with [Letta Code](https://letta.com)
