### PR TITLE
fix: recover startup after default agent limit failures

### DIFF
--- a/src/agent/defaults.ts
+++ b/src/agent/defaults.ts
@@ -217,6 +217,7 @@ export async function ensureDefaultAgents(
     // Re-throw so caller can handle/exit appropriately
     throw new Error(
       `Failed to create default agents: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
     );
   }
 }

--- a/src/cli/agent-selector-shortcuts.test.ts
+++ b/src/cli/agent-selector-shortcuts.test.ts
@@ -43,4 +43,21 @@ describe("agent selector shortcuts", () => {
     expect(source).toContain("<Box height={1} />");
     expect(source).not.toContain("<Box height={2} />");
   });
+
+  test("supports startup fallback from empty pinned tab to Constellation", () => {
+    const selectorPath = fileURLToPath(
+      new URL("../cli/components/AgentSelector.tsx", import.meta.url),
+    );
+    const source = readFileSync(selectorPath, "utf-8");
+
+    expect(source).toContain("initialTab?: TabId");
+    expect(source).toContain("emptyPinnedFallbackTab?: TabId");
+    expect(source).toContain("notice?: string");
+    expect(source).toContain("useState<TabId>(initialTab)");
+    expect(source).toContain('activeTab === "pinned"');
+    expect(source).toContain("emptyPinnedFallbackTab");
+    expect(source).toContain("validPinnedAgents.length === 0");
+    expect(source).toContain("setActiveTab(fallbackTab)");
+    expect(source).toContain('showNewTab && (input === "n" || input === "N")');
+  });
 });

--- a/src/cli/app-urls.test.ts
+++ b/src/cli/app-urls.test.ts
@@ -8,6 +8,7 @@ import {
   buildAgentTerminalLink,
   buildChatUrl,
   isLocalAgentId,
+  LETTA_USAGE_URL,
 } from "@/cli/helpers/app-urls";
 
 describe("app URL helpers", () => {
@@ -59,5 +60,9 @@ describe("app URL helpers", () => {
     expect(buildAgentTerminalLink("agent-abc", undefined, "memories")).toBe(
       `\x1b]8;;${targetUrl}\x1b\\memories\x1b]8;;\x1b\\`,
     );
+  });
+
+  test("billing links use chat.letta.com preferences", () => {
+    expect(LETTA_USAGE_URL).toBe("https://chat.letta.com/preferences/usage");
   });
 });

--- a/src/cli/components/AgentInfoBar.tsx
+++ b/src/cli/components/AgentInfoBar.tsx
@@ -4,9 +4,9 @@ import { memo, useMemo } from "react";
 import stringWidth from "string-width";
 import type { ModelReasoningEffort } from "@/agent/model";
 import {
-  buildAppUrl,
   buildChatUrl,
   isLocalAgentId,
+  LETTA_USAGE_URL,
 } from "@/cli/helpers/app-urls";
 import { shouldHideReasoningForModelDisplay } from "@/cli/helpers/startup-model-display";
 import { useTerminalWidth } from "@/cli/hooks/use-terminal-width";
@@ -123,7 +123,7 @@ export const AgentInfoBar = memo(function AgentInfoBar({
     showCloudLinks && agentId && agentId !== "loading"
       ? buildChatUrl(agentId, { conversationId })
       : "";
-  const usageUrl = buildAppUrl("/settings/organization/usage");
+  const usageUrl = LETTA_USAGE_URL;
   const showBottomBar = agentId && agentId !== "loading";
   const reasoningLabel = shouldHideReasoningForModelDisplay(currentModel)
     ? null

--- a/src/cli/components/AgentSelector.tsx
+++ b/src/cli/components/AgentSelector.tsx
@@ -41,9 +41,15 @@ interface AgentSelectorProps {
   allowDelete?: boolean;
   /** Whether Shift+P can unpin agents from the selector. */
   allowPinActions?: boolean;
+  /** Initial tab to show when the selector opens. */
+  initialTab?: TabId;
+  /** Tab to switch to if the initial Pinned tab has no valid agents. */
+  emptyPinnedFallbackTab?: TabId;
+  /** Optional notice shown above the tab contents. */
+  notice?: string;
 }
 
-type TabId = "pinned" | "local" | "constellation" | "new";
+export type TabId = "pinned" | "local" | "constellation" | "new";
 
 type ViewState =
   | { type: "list" }
@@ -175,6 +181,9 @@ export function AgentSelector({
   showNewTab = true,
   allowDelete = true,
   allowPinActions = true,
+  initialTab = "pinned",
+  emptyPinnedFallbackTab,
+  notice,
 }: AgentSelectorProps) {
   const terminalWidth = useTerminalWidth();
 
@@ -199,16 +208,14 @@ export function AgentSelector({
     [hasLocalAgents, showNewTab],
   );
 
-  const [activeTab, setActiveTab] = useState<TabId>("pinned");
+  const [activeTab, setActiveTab] = useState<TabId>(initialTab);
 
-  // If active tab is no longer visible (e.g. local tab hidden after deleting all local agents), fall back
+  // If active tab is no longer visible (e.g. local tab hidden after deleting all local agents), fall back.
   useEffect(() => {
-    if (activeTab === "local" && !hasLocalAgents) {
-      setActiveTab("constellation");
-    } else if (activeTab === "new" && !showNewTab) {
-      setActiveTab("pinned");
+    if (!visibleTabs.some((tab) => tab.id === activeTab)) {
+      setActiveTab(visibleTabs[0]?.id ?? "pinned");
     }
-  }, [activeTab, hasLocalAgents, showNewTab]);
+  }, [activeTab, visibleTabs]);
 
   // Pinned tab state
   const [pinnedAgents, setPinnedAgents] = useState<PinnedAgentData[]>([]);
@@ -531,6 +538,28 @@ export function AgentSelector({
     pinnedStartIndex,
     pinnedStartIndex + DISPLAY_PAGE_SIZE,
   );
+
+  useEffect(() => {
+    if (
+      activeTab === "pinned" &&
+      emptyPinnedFallbackTab &&
+      !pinnedLoading &&
+      validPinnedAgents.length === 0
+    ) {
+      const fallbackTab = visibleTabs.some(
+        (tab) => tab.id === emptyPinnedFallbackTab,
+      )
+        ? emptyPinnedFallbackTab
+        : (visibleTabs[0]?.id ?? "pinned");
+      setActiveTab(fallbackTab);
+    }
+  }, [
+    activeTab,
+    emptyPinnedFallbackTab,
+    pinnedLoading,
+    validPinnedAgents.length,
+    visibleTabs,
+  ]);
 
   // Pagination calculations - Local (current agent pinned to top)
   const sortedLocalAgents = useMemo(
@@ -1081,6 +1110,11 @@ export function AgentSelector({
           }
         />
         <Text dimColor> {TAB_DESCRIPTIONS[activeTab]}</Text>
+        {notice && (
+          <Box marginTop={1}>
+            <Text color="yellow"> {notice}</Text>
+          </Box>
+        )}
         <Box height={1} />
       </Box>
 

--- a/src/cli/components/SessionStats.tsx
+++ b/src/cli/components/SessionStats.tsx
@@ -1,5 +1,5 @@
 import type { SessionStatsSnapshot } from "@/agent/stats";
-import { buildAppUrl } from "@/cli/helpers/app-urls";
+import { LETTA_USAGE_URL } from "@/cli/helpers/app-urls";
 import { formatCompact } from "@/cli/helpers/format";
 
 export function formatDuration(ms: number): string {
@@ -67,7 +67,7 @@ export function formatUsageStats({
 
     outputLines.push(
       `Plan: [${balance.billing_tier}]`,
-      buildAppUrl("/settings/organization/usage"),
+      LETTA_USAGE_URL,
       "",
       `Available credits:     ◎${formatNumber(totalCredits)} ($${toDollars(totalCredits)})`,
       `Monthly credits:       ◎${formatNumber(monthlyCredits)} ($${toDollars(monthlyCredits)})`,

--- a/src/cli/helpers/app-urls.ts
+++ b/src/cli/helpers/app-urls.ts
@@ -1,6 +1,9 @@
 import { isLocalAgentId as isLocalAgentIdShared } from "@/agent/agent-id";
 
 const APP_BASE = "https://app.letta.com";
+const CHAT_BASE = "https://chat.letta.com";
+
+export const LETTA_USAGE_URL = `${CHAT_BASE}/preferences/usage`;
 
 export function isLocalAgentId(agentId: string): boolean {
   return isLocalAgentIdShared(agentId);

--- a/src/cli/helpers/error-formatter.ts
+++ b/src/cli/helpers/error-formatter.ts
@@ -3,12 +3,9 @@ import {
   formatConversationBusyErrorMessage,
   isConversationBusyErrorText,
 } from "@/utils/conversation-busy-error";
-import { buildAgentTerminalLink, buildAppUrl } from "./app-urls";
+import { buildAgentTerminalLink, LETTA_USAGE_URL } from "./app-urls";
 import { getErrorContext } from "./error-context";
 import { checkZaiError } from "./zai-errors";
-
-const LETTA_USAGE_URL = buildAppUrl("/settings/organization/usage");
-const LETTA_AGENTS_URL = buildAppUrl("/projects/default-project/agents");
 
 export type ErrorDisplaySurface = "plain" | "terminal";
 
@@ -743,11 +740,11 @@ export function formatErrorDetails(
       const { billingTier } = getErrorContext();
 
       if (billingTier?.toLowerCase() === "free") {
-        return `You've reached the agent limit (3) for the Free Plan. Delete agents at: ${LETTA_AGENTS_URL}\nOr upgrade to Pro for unlimited agents at: ${LETTA_USAGE_URL}`;
+        return `You've reached the agent limit (3) for the Free Plan. Delete an agent, or upgrade to Pro for unlimited agents at: ${LETTA_USAGE_URL}`;
       }
 
       // Fallback for paid tiers (shouldn't normally hit this, but just in case)
-      return `You've reached your agent limit. Delete agents at: ${LETTA_AGENTS_URL}\nOr check your plan at: ${LETTA_USAGE_URL}`;
+      return `You've reached your agent limit. Delete an agent, or check your plan at: ${LETTA_USAGE_URL}`;
     }
 
     if (hasErrorReason(e, "model-unknown", reasons)) {
@@ -764,7 +761,7 @@ export function formatErrorDetails(
       // Extract the resource type (agents, tools, etc.) from the message
       const match = resourceLimitMsg.match(/limit for (\w+)/);
       const resourceType = match ? match[1] : "resources";
-      return `${resourceLimitMsg}\nUpgrade at: ${LETTA_USAGE_URL}\nDelete ${resourceType} at: ${LETTA_AGENTS_URL}`;
+      return `${resourceLimitMsg}\nUpgrade at: ${LETTA_USAGE_URL}\nDelete ${resourceType} from your workspace.`;
     }
 
     // Check for credit exhaustion error - provide a friendly message

--- a/src/cli/helpers/startup-create-failure.test.ts
+++ b/src/cli/helpers/startup-create-failure.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { resolveStartupCreateFailure } from "@/cli/helpers/startup-create-failure";
+
+describe("resolveStartupCreateFailure", () => {
+  test("agent quota failure falls back to existing agent selection without create", () => {
+    const fallback = resolveStartupCreateFailure(
+      new Error(
+        'Failed to create default agents: 402 {"error":"You have reached your limit for agents","limit":3}',
+      ),
+    );
+
+    expect(fallback).toEqual({
+      disableCreateAgent: true,
+      failedAgentMessage:
+        "Could not create a default agent because your Constellation agent limit is reached. Select an existing agent below, delete an agent, or upgrade at https://chat.letta.com/preferences/usage.",
+      headlessMessage:
+        "Could not create a default agent because your Constellation agent limit is reached. Run with --agent <id> to use an existing agent, delete an agent, or upgrade at https://chat.letta.com/preferences/usage.",
+    });
+  });
+
+  test("agent-limit reason falls back to existing agent selection without create", () => {
+    const fallback = resolveStartupCreateFailure(
+      new Error("Failed to create default agents", {
+        cause: new Error("429 agents-limit-exceeded"),
+      }),
+    );
+
+    expect(fallback.disableCreateAgent).toBe(true);
+  });
+
+  test("non-agent 402 failures keep generic fallback copy", () => {
+    const fallback = resolveStartupCreateFailure(
+      new Error(
+        'Failed to create default agents: 402 {"error":"You have reached your model usage limit","limit":3}',
+      ),
+    );
+
+    expect(fallback).toEqual({
+      disableCreateAgent: false,
+      failedAgentMessage:
+        'Could not create a default agent. Select an existing agent below, or try Create a new agent again. (Failed to create default agents: 402 {"error":"You have reached your model usage limit","limit":3})',
+      headlessMessage:
+        'Could not create a default agent. Run with --agent <id> to use an existing agent, or fix the error and try again. (Failed to create default agents: 402 {"error":"You have reached your model usage limit","limit":3})',
+    });
+  });
+
+  test("non-Error create failures still fall back to existing agent selection", () => {
+    const fallback = resolveStartupCreateFailure("network unavailable");
+
+    expect(fallback).toEqual({
+      disableCreateAgent: false,
+      failedAgentMessage:
+        "Could not create a default agent. Select an existing agent below, or try Create a new agent again. (network unavailable)",
+      headlessMessage:
+        "Could not create a default agent. Run with --agent <id> to use an existing agent, or fix the error and try again. (network unavailable)",
+    });
+  });
+});

--- a/src/cli/helpers/startup-create-failure.ts
+++ b/src/cli/helpers/startup-create-failure.ts
@@ -1,0 +1,46 @@
+import { LETTA_USAGE_URL } from "@/cli/helpers/app-urls";
+
+export interface StartupCreateFailureFallback {
+  failedAgentMessage: string;
+  headlessMessage: string;
+  disableCreateAgent: boolean;
+}
+
+function getErrorDetails(error: unknown): string {
+  if (error instanceof Error) {
+    const cause = "cause" in error ? error.cause : undefined;
+    return cause
+      ? `${error.message}: ${getErrorDetails(cause)}`
+      : error.message;
+  }
+
+  return String(error);
+}
+
+function isAgentLimitError(error: unknown): boolean {
+  const details = getErrorDetails(error).toLowerCase();
+  return (
+    details.includes("agents-limit-exceeded") ||
+    details.includes("limit for agents")
+  );
+}
+
+export function resolveStartupCreateFailure(
+  error: unknown,
+): StartupCreateFailureFallback {
+  const details = getErrorDetails(error);
+
+  if (isAgentLimitError(error)) {
+    return {
+      disableCreateAgent: true,
+      failedAgentMessage: `Could not create a default agent because your Constellation agent limit is reached. Select an existing agent below, delete an agent, or upgrade at ${LETTA_USAGE_URL}.`,
+      headlessMessage: `Could not create a default agent because your Constellation agent limit is reached. Run with --agent <id> to use an existing agent, delete an agent, or upgrade at ${LETTA_USAGE_URL}.`,
+    };
+  }
+
+  return {
+    disableCreateAgent: false,
+    failedAgentMessage: `Could not create a default agent. Select an existing agent below, or try Create a new agent again. (${details})`,
+    headlessMessage: `Could not create a default agent. Run with --agent <id> to use an existing agent, or fix the error and try again. (${details})`,
+  };
+}

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -94,6 +94,7 @@ import {
   launchReflectionSubagent,
 } from "./cli/helpers/reflection-launcher";
 import { appendTranscriptDeltaJsonl } from "./cli/helpers/reflection-transcript";
+import { resolveStartupCreateFailure } from "./cli/helpers/startup-create-failure";
 import {
   type DrainStreamHook,
   drainStreamWithResume,
@@ -1526,11 +1527,17 @@ export async function handleHeadlessCommand(
   // Priority 6: Fresh user with no LRU - create default agent
   if (!agent) {
     const { ensureDefaultAgents } = await import("@/agent/defaults");
-    const defaultAgent = await ensureDefaultAgents(backend, {
-      preferredModel: model,
-    });
-    if (defaultAgent) {
-      agent = defaultAgent;
+    try {
+      const defaultAgent = await ensureDefaultAgents(backend, {
+        preferredModel: model,
+      });
+      if (defaultAgent) {
+        agent = defaultAgent;
+      }
+    } catch (error) {
+      const fallback = resolveStartupCreateFailure(error);
+      console.error(fallback.headlessMessage);
+      process.exit(1);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ import {
   preprocessCliArgs,
   renderCliOptionsHelp,
 } from "./cli/args";
+import { AgentSelector } from "./cli/components/AgentSelector";
 import { ConversationSelector } from "./cli/components/ConversationSelector";
 import {
   normalizeConversationShorthandFlags,
@@ -52,6 +53,7 @@ import {
 } from "./cli/flag-utils";
 import { formatErrorDetails } from "./cli/helpers/error-formatter";
 import { ensureFdPath, resolveFdPath } from "./cli/helpers/file-autocomplete";
+import { resolveStartupCreateFailure } from "./cli/helpers/startup-create-failure";
 import type { ApprovalRequest } from "./cli/helpers/stream";
 import { initTerminalTheme } from "./cli/helpers/terminal-theme";
 import { ProfileSelectionInline } from "./cli/profile-selection";
@@ -1542,6 +1544,7 @@ async function main(): Promise<void> {
     const [loadingState, setLoadingState] = useState<
       | "selecting"
       | "selecting_global"
+      | "selecting_agents"
       | "selecting_conversation"
       | "assembling"
       | "importing"
@@ -1585,6 +1588,10 @@ async function main(): Promise<void> {
     const [failedAgentMessage, setFailedAgentMessage] = useState<string | null>(
       null,
     );
+    const [
+      startupAgentSelectorDisableCreate,
+      setStartupAgentSelectorDisableCreate,
+    ] = useState(false);
     // For custom API backends: available model handles from server and user's selection
     const [availableServerModels, setAvailableServerModels] = useState<
       string[]
@@ -2025,10 +2032,11 @@ async function main(): Promise<void> {
               }
               // If null (createDefaultAgents disabled), fall through
             } catch (err) {
-              console.error(
-                `Failed to create default agent: ${err instanceof Error ? err.message : String(err)}`,
-              );
-              process.exit(1);
+              const fallback = resolveStartupCreateFailure(err);
+              setFailedAgentMessage(fallback.failedAgentMessage);
+              setStartupAgentSelectorDisableCreate(fallback.disableCreateAgent);
+              setLoadingState("selecting_agents");
+              return;
             }
             break;
           }
@@ -2055,6 +2063,7 @@ async function main(): Promise<void> {
         if (
           loadingState === "selecting" ||
           loadingState === "selecting_global" ||
+          loadingState === "selecting_agents" ||
           loadingState === "selecting_conversation"
         ) {
           initStartedRef.current = false;
@@ -2736,6 +2745,33 @@ async function main(): Promise<void> {
       });
     }
 
+    if (loadingState === "selecting_agents") {
+      return React.createElement(AgentSelector, {
+        currentAgentId: selectedGlobalAgentId ?? "loading",
+        title: "Select an existing agent",
+        command: "/agents",
+        initialTab: "pinned",
+        emptyPinnedFallbackTab: "constellation",
+        showNewTab: !startupAgentSelectorDisableCreate,
+        allowDelete: true,
+        allowPinActions: true,
+        notice: failedAgentMessage ?? undefined,
+        onSelect: (selectedAgentId, backendMode) => {
+          configureBackendMode(backendMode);
+          setSelectedGlobalAgentId(selectedAgentId);
+          setLoadingState("assembling");
+        },
+        onCreateNewAgent: (_name, backendMode) => {
+          configureBackendMode(backendMode);
+          setUserRequestedNewAgent(true);
+          setLoadingState("assembling");
+        },
+        onCancel: () => {
+          process.exit(0);
+        },
+      });
+    }
+
     // Show global agent selector in fresh repos with global pinned agents
     if (loadingState === "selecting_global") {
       return React.createElement(ProfileSelectionInline, {
@@ -2771,11 +2807,13 @@ async function main(): Promise<void> {
       });
     }
 
-    // At this point, loadingState is not "selecting", "selecting_global", or "selecting_conversation"
-    // (those are handled above), so it's safe to pass to App
+    // At this point, selection states are handled above, so it's safe to pass to App.
     const appLoadingState = loadingState as Exclude<
       typeof loadingState,
-      "selecting" | "selecting_global" | "selecting_conversation"
+      | "selecting"
+      | "selecting_global"
+      | "selecting_agents"
+      | "selecting_conversation"
     >;
 
     if (!agentId || !conversationId) {


### PR DESCRIPTION
Author: Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Summary
- Recovers interactive startup when default-agent creation hits the Constellation agent limit by opening the full agent selector instead of exiting.
- Starts that selector on pinned/favorite agents, falls through to Constellation when none exist, and hides new-agent creation for the quota path.
- Adds shared startup create-failure copy for interactive and headless startup, and centralizes the usage CTA at https://chat.letta.com/preferences/usage.

## Why
A fresh local state can have no remembered agent while the user already has the maximum number of Constellation agents. In that case startup previously tried to create a default agent, received an agent-limit error, and exited even though existing agents were still usable.

## Validation
- bun test src/cli/helpers/startup-create-failure.test.ts src/cli/agent-selector-shortcuts.test.ts src/agent/resolve-startup-agent.test.ts src/cli/app-urls.test.ts src/cli/error-formatter.test.ts
- bunx --bun @biomejs/biome@2.2.5 check src/agent/defaults.ts src/agent/resolve-startup-agent.ts src/agent/resolve-startup-agent.test.ts src/headless.ts src/index.ts src/cli/helpers/app-urls.ts src/cli/helpers/error-formatter.ts src/cli/helpers/startup-create-failure.ts src/cli/helpers/startup-create-failure.test.ts src/cli/components/AgentSelector.tsx src/cli/components/AgentInfoBar.tsx src/cli/components/SessionStats.tsx src/cli/app-urls.test.ts src/cli/agent-selector-shortcuts.test.ts
- bun run typecheck

## Notes
- This intentionally leaves the older Node toSorted selector crash out of scope.
- Headless startup stays deterministic: it prints --agent guidance instead of auto-selecting an existing agent.

👾 Generated with [Letta Code](https://letta.com)