### PR TITLE
fix: wait for env-routed final assistant response

### DIFF
--- a/src/headless-environment-response.test.ts
+++ b/src/headless-environment-response.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { __headlessTestUtils } from "@/headless";
+
+function assistantMessage(id: string, text: string, createdAt: string) {
+  return {
+    id,
+    message_type: "assistant_message",
+    created_at: createdAt,
+    content: [{ type: "text", text }],
+  };
+}
+
+describe("headless environment-routed responses", () => {
+  test("waits for turn completion before returning the latest assistant message", async () => {
+    const startedAtMs = Date.parse("2026-07-07T12:00:00.000Z");
+    const baselineCompletionMs = Date.parse("2026-07-07T11:59:00.000Z");
+    let retrieveCalls = 0;
+    let messageCalls = 0;
+
+    const backend = {
+      async retrieveAgent() {
+        retrieveCalls += 1;
+        if (retrieveCalls < 3) {
+          return {
+            id: "agent-env",
+            last_run_completion: "2026-07-07T11:59:00.000Z",
+            last_stop_reason: "end_turn",
+          };
+        }
+        return {
+          id: "agent-env",
+          last_run_completion: "2026-07-07T12:00:06.000Z",
+          last_stop_reason: "end_turn",
+        };
+      },
+      async listConversationMessages() {
+        messageCalls += 1;
+        if (messageCalls < 4) {
+          return [
+            assistantMessage(
+              "msg-initial",
+              "Let me gather the concrete details.",
+              "2026-07-07T12:00:01.000Z",
+            ),
+          ];
+        }
+        return [
+          assistantMessage(
+            "msg-final",
+            "Here's my concrete execution environment.",
+            "2026-07-07T12:00:05.000Z",
+          ),
+          assistantMessage(
+            "msg-initial",
+            "Let me gather the concrete details.",
+            "2026-07-07T12:00:01.000Z",
+          ),
+        ];
+      },
+      async listAgentMessages() {
+        throw new Error("default conversation path should not be used");
+      },
+    };
+
+    const result = await __headlessTestUtils.waitForEnvironmentAssistantMessage(
+      {
+        backend: backend as never,
+        agentId: "agent-env",
+        conversationId: "conv-env",
+        startedAtMs,
+        baselineLastRunCompletionMs: baselineCompletionMs,
+        pollIntervalMs: 0,
+        timeoutMs: 1_000,
+      },
+    );
+
+    expect(result).toEqual({
+      text: "Here's my concrete execution environment.",
+      stopReason: "end_turn",
+    });
+    expect(messageCalls).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -354,6 +354,7 @@ export const __headlessTestUtils = {
   contentToTaskNotificationText,
   toBidirectionalQueuedInput,
   prepareHeadlessToolExecutionContext,
+  waitForEnvironmentAssistantMessage,
 };
 
 type ReflectionOverrides = {
@@ -737,21 +738,54 @@ function messageTime(message: LettaMessage): number {
   return date ? new Date(date).getTime() : 0;
 }
 
+function agentLastRunCompletionMs(agent: AgentState): number | null {
+  const raw = (agent as { last_run_completion?: unknown }).last_run_completion;
+  if (typeof raw !== "string" || raw.length === 0) return null;
+  const ms = new Date(raw).getTime();
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function agentLastStopReason(agent: AgentState): StopReasonType | null {
+  const raw = (agent as { last_stop_reason?: unknown }).last_stop_reason;
+  return typeof raw === "string" && raw.length > 0
+    ? (raw as StopReasonType)
+    : null;
+}
+
 async function waitForEnvironmentAssistantMessage(params: {
   backend: ReturnType<typeof getBackend>;
   agentId: string;
   conversationId: string;
   startedAtMs: number;
+  baselineLastRunCompletionMs?: number | null;
   timeoutMs?: number;
   pollIntervalMs?: number;
-}): Promise<string> {
+}): Promise<{ text: string; stopReason: StopReasonType | null }> {
   const timeoutMs = params.timeoutMs ?? 10 * 60_000;
   const pollIntervalMs = params.pollIntervalMs ?? 1_000;
   const deadline = Date.now() + timeoutMs;
   let lastText = "";
-  let stableCount = 0;
+  let postCompletionStableCount = 0;
+  let observedCompletion = false;
+  let observedStopReason: StopReasonType | null = null;
 
   while (Date.now() < deadline) {
+    const freshAgent = await params.backend.retrieveAgent(params.agentId);
+    const completionMs = agentLastRunCompletionMs(freshAgent);
+    const baselineCompletionMs = params.baselineLastRunCompletionMs ?? null;
+    const wasObservedCompletion = observedCompletion;
+    if (
+      completionMs !== null &&
+      (baselineCompletionMs === null || completionMs > baselineCompletionMs) &&
+      completionMs >= params.startedAtMs - 5_000
+    ) {
+      observedCompletion = true;
+      observedStopReason = agentLastStopReason(freshAgent);
+      if (!wasObservedCompletion) {
+        postCompletionStableCount = 0;
+      }
+    }
+
     const page =
       params.conversationId === "default"
         ? await params.backend.listAgentMessages(params.agentId, {
@@ -776,21 +810,23 @@ async function waitForEnvironmentAssistantMessage(params: {
     const text = assistant ? extractMessageText(assistant).trim() : "";
     if (text.length > 0) {
       if (text === lastText) {
-        stableCount += 1;
+        if (observedCompletion) postCompletionStableCount += 1;
       } else {
         lastText = text;
-        stableCount = 1;
+        postCompletionStableCount = observedCompletion ? 1 : 0;
       }
-      if (stableCount >= 2) {
-        return text;
+      if (observedCompletion && postCompletionStableCount >= 2) {
+        return { text, stopReason: observedStopReason };
       }
     }
 
     await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
   }
 
-  if (lastText) return lastText;
-  throw new Error("Timed out waiting for environment response");
+  if (observedCompletion && lastText) {
+    return { text: lastText, stopReason: observedStopReason };
+  }
+  throw new Error("Timed out waiting for environment turn completion");
 }
 
 type ReplyEnvironmentMetadata =
@@ -2261,7 +2297,6 @@ ${SYSTEM_REMINDER_CLOSE}
   );
 
   if (usesRemoteEnvironment) {
-    const startedAtMs = Date.now();
     const environmentSelector = String(explicitEnvironmentSelector);
     const useCloudSandbox = isCloudEnvironmentSelector(environmentSelector);
     const environmentRouting = useCloudSandbox
@@ -2332,6 +2367,8 @@ ${SYSTEM_REMINDER_CLOSE}
       }
       await exitHeadless(1, "headless_environment_unsupported");
     }
+    const startedAtMs = Date.now();
+    const baselineLastRunCompletionMs = agentLastRunCompletionMs(agent);
     await sendEnvironmentMessage(connectionId, {
       agentId: agent.id,
       conversationId,
@@ -2345,12 +2382,14 @@ ${SYSTEM_REMINDER_CLOSE}
       ],
     });
 
-    const resultText = await waitForEnvironmentAssistantMessage({
+    const environmentResult = await waitForEnvironmentAssistantMessage({
       backend,
       agentId: agent.id,
       conversationId,
       startedAtMs,
+      baselineLastRunCompletionMs,
     });
+    const resultText = environmentResult.text;
     const stats = sessionStats.getSnapshot();
 
     if (outputFormat === "json") {
@@ -2368,6 +2407,10 @@ ${SYSTEM_REMINDER_CLOSE}
             conversation_id: conversationId,
             environment: responseEnvironment,
             usage: null,
+            ...(environmentResult.stopReason &&
+            environmentResult.stopReason !== "end_turn"
+              ? { stop_reason: environmentResult.stopReason }
+              : {}),
           },
           null,
           2,
@@ -2390,6 +2433,10 @@ ${SYSTEM_REMINDER_CLOSE}
         run_ids: [],
         usage: null,
         uuid: `result-${agent.id}-${Date.now()}`,
+        ...(environmentResult.stopReason &&
+        environmentResult.stopReason !== "end_turn"
+          ? { stop_reason: environmentResult.stopReason }
+          : {}),
       };
       writeWireMessage(resultEvent);
     } else {

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -2440,13 +2440,7 @@ ${SYSTEM_REMINDER_CLOSE}
       };
       writeWireMessage(resultEvent);
     } else {
-      await writeFinalHeadlessStdout(
-        `${resultText}\n\n${formatAgentReplyMetadata({
-          agentId: agent.id,
-          conversationId,
-          environment: responseEnvironment,
-        })}\n`,
-      );
+      await writeFinalHeadlessStdout(`${resultText}\n`);
     }
 
     await exitHeadless(0, "headless_environment_message_complete");


### PR DESCRIPTION
Env-routed headless messaging was returning the first stable assistant message, which could be a preliminary note before tool calls completed. This waits for the target agent turn completion marker to advance before reading the latest assistant message, so tool-using remote turns return the final response.

Validated with:
- `bun test src/headless-environment-response.test.ts`
- `bun run typecheck`
- `bun run check`
- Live smoke test against Draft on `Lettamates-Mac-mini.local`, returning `FINAL_ENV_RESPONSE_OK` after a tool call.