### PR TITLE
fix(channels): close Slack progress card when reply is anchored to a non-root message (LET-9524)

### DIFF
--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -4127,6 +4127,146 @@ test("slack adapter finishes an active progress card when MessageChannel sends",
   expect(writeClient?.chat.startStream).toHaveBeenCalledTimes(2);
 });
 
+test("slack adapter closes the active card when the reply is anchored to a non-root message (LET-9524)", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+  adapter.onMessage = mock(async () => {});
+  const source = {
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    chatType: "channel" as const,
+    senderId: "U123",
+    senderTeamId: "T123",
+    messageId: "1712800000.000200",
+    threadId: "1712790000.000050",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  };
+
+  await adapter.start();
+  const app = FakeSlackApp.instances[0];
+  const messageHandler = app?.messageHandler;
+  if (!messageHandler) {
+    throw new Error("Expected Slack message handler");
+  }
+
+  // The user's follow-up is a non-root message in the thread; ingestion
+  // remembers its ts → thread-root mapping.
+  await messageHandler({
+    message: {
+      channel: "C123",
+      user: "U123",
+      text: "did it work?",
+      ts: "1712800000.000200",
+      thread_ts: "1712790000.000050",
+    },
+  });
+
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-1",
+    sources: [source],
+    kind: "tool",
+    state: "started",
+    message: "Running command",
+    toolCallId: "call-1",
+    toolName: "Bash",
+    toolDetails: "bun --version",
+  });
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient?.chat.startStream).toHaveBeenCalledTimes(1);
+
+  // MessageChannel `replyTo` sends null the threadId and anchor the outbound
+  // message to the replied-to (non-root) ts. The card must still close.
+  await adapter.sendMessage({
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    text: "Yes, it worked.",
+    threadId: null,
+    replyToMessageId: "1712800000.000200",
+  });
+
+  const stopCalls = writeClient?.chat.stopStream.mock.calls as unknown as Array<
+    Array<{ channel: string; ts: string; chunks?: unknown[] }>
+  >;
+  expect(stopCalls?.length).toBe(1);
+  expect(stopCalls?.[0]?.[0]).toMatchObject({
+    channel: "C123",
+    ts: "1712800000.000300",
+  });
+
+  // Post-reply work reassembles as a fresh card below the reply.
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-1",
+    sources: [source],
+    kind: "tool",
+    state: "started",
+    message: "Reading files",
+    toolCallId: "call-2",
+    toolName: "read_file",
+  });
+  expect(writeClient?.chat.startStream).toHaveBeenCalledTimes(2);
+});
+
+test("slack adapter closes the active card when a direct reply posts into the thread (LET-9524)", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+  const source = {
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    chatType: "channel" as const,
+    senderId: "U123",
+    senderTeamId: "T123",
+    messageId: "1712800000.000100",
+    threadId: "1712790000.000050",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  };
+
+  await adapter.start();
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-1",
+    sources: [source],
+    kind: "tool",
+    state: "started",
+    message: "Running command",
+    toolCallId: "call-1",
+    toolName: "Bash",
+    toolDetails: "bun --version",
+  });
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient?.chat.startStream).toHaveBeenCalledTimes(1);
+
+  await adapter.sendDirectReply("C123", "Model updated.", {
+    threadId: "1712790000.000050",
+  });
+
+  expect(writeClient?.chat.stopStream).toHaveBeenCalledTimes(1);
+});
+
 test("slack adapter suppresses MessageChannel responding rows with an active progress card", async () => {
   const adapter = createSlackAdapter({
     ...slackAccountDefaults,

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -3437,14 +3437,23 @@ export function createSlackAdapter(
     if (msg.channel !== "slack" || msg.reaction) {
       return;
     }
-    const replyToMessageId = resolveSlackOutboundProgressThreadTs({
+    const anchorTs = resolveSlackOutboundProgressThreadTs({
       threadId: msg.threadId,
       replyToMessageId: msg.replyToMessageId,
     });
-    if (!isNonEmptyString(replyToMessageId)) {
+    if (!isNonEmptyString(anchorTs)) {
       return;
     }
-    const replyKey = `${msg.chatId}:${replyToMessageId}`;
+    // Canonicalize the anchor to its thread root before the card lookup.
+    // Outbound replies can be anchored to a non-root message in the thread
+    // (MessageChannel `replyTo` nulls threadId, and Slack happily threads a
+    // reply-ts `thread_ts` under the parent), while progress cards are always
+    // keyed by the thread root. Any bot message posted into a thread with a
+    // live progress stream must invalidate that stream — the card closes out
+    // above the reply and post-reply work reassembles as a fresh card below
+    // (LET-9524).
+    const rootTs = knownThreadIdsByMessageId.get(anchorTs) ?? anchorTs;
+    const replyKey = `${msg.chatId}:${rootTs}`;
     const cardKey = activeProgressCardKeyByReplyKey.get(replyKey) ?? replyKey;
     const entry = progressCardByReplyKey.get(cardKey);
     if (!entry) {
@@ -4256,6 +4265,18 @@ export function createSlackAdapter(
       ) {
         agentThreadTracker.remember(chatId, outboundThreadId);
       }
+
+      // Direct replies (channel command responses, notices) are bot messages
+      // in the thread like any other: if a live progress stream exists there,
+      // close it out so the spinner never renders above a newer bot message
+      // (LET-9524).
+      await finishSlackProgressCardForOutboundMessage({
+        channel: "slack",
+        chatId,
+        text,
+        threadId: options?.threadId ?? null,
+        replyToMessageId: options?.replyToMessageId,
+      });
     },
 
     async handleControlRequestEvent(


### PR DESCRIPTION
Fixes LET-9524.

## Summary
- Live repro (software-factory, 2026-07-07): the agent's reply lands in the thread but the progress card above it keeps spinning ("Thinking" + live "Still working" row) for the rest of the turn — and on builds without #3255, until Slack expires it into a red warning card.
- Root cause: MessageChannel sends with `replyTo` null the outbound `threadId` (`message-actions.ts` — deliberate, so `replyTo` can target other threads), so `finishSlackProgressCardForOutboundMessage` keyed its lookup off the replied-to **non-root** message ts. Progress cards are keyed by the thread **root**, so both the active-key lookup and the fallback silently missed and the close never ran. The reply still rendered correctly threaded because Slack tolerates a reply-ts `thread_ts`, which is why the bug was invisible on the message itself and only manifested as a stale spinner. When the agent omits `replyTo`, the thread root is inferred from turn sources and the close works — hence the flakiness.
- Fix: canonicalize the outbound anchor to its thread root via the existing `knownThreadIdsByMessageId` map (populated at ingestion for every inbound message) before the card lookup. Also extend the same invalidation to `sendDirectReply`, which previously posted bot messages into threads without closing a live stream at all.
- Invariant this defends: any bot message posted into a thread with a live progress stream invalidates that stream — the spinner closes out above the new message and post-reply work reassembles as a fresh card below ("two runs" rendering), thread-scoped rather than anchor-string-scoped.
- Deliberately NOT changed: the `threadId` nulling in `message-actions.ts` (it lets `replyTo` win over the inferred turn thread for cross-thread sends), and control-request prompts (open design question on LET-9524 whether approval posts should also invalidate).

## Tests
- New: reply anchored to a non-root ts (ingested via the real inbound handler so `knownThreadIdsByMessageId` is exercised) closes the card and post-reply progress starts a fresh stream.
- New: `sendDirectReply` into a thread with a live card closes it.
- `bun test src/channels/` 709 pass; `bun run check` 10/10.

👾 Generated with [Letta Code](https://letta.com)