### PR TITLE
fix(slack): stop sending markdown_text alongside chunks in chat.stopStream

### DIFF
--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -161,10 +161,29 @@ class FakeSlackWriteClient {
       }),
     ),
     stopStream: mock(
-      async (): Promise<{ ok: boolean; ts?: string; error?: string }> => ({
-        ok: true,
-        ts: "1712800000.000300",
-      }),
+      async (args?: {
+        markdown_text?: string;
+        chunks?: unknown[];
+      }): Promise<{ ok: boolean; ts?: string; error?: string }> => {
+        // Pin the real Slack wire contract: chat.stopStream rejects
+        // markdown_text combined with chunks (verified live 2026-07-07).
+        // Sending both silently broke every terminal card close in prod
+        // while the previous accept-anything mock kept tests green.
+        if (
+          typeof args?.markdown_text === "string" &&
+          Array.isArray(args?.chunks) &&
+          args.chunks.length > 0
+        ) {
+          return {
+            ok: false,
+            error: "cannot_provide_both_markdown_text_and_chunks",
+          };
+        }
+        return {
+          ok: true,
+          ts: "1712800000.000300",
+        };
+      },
     ),
   };
   readonly assistant = {
@@ -2836,9 +2855,13 @@ test("slack adapter anchors direct message progress to the inbound message", asy
         type: "plan_update",
         title: "Read a file",
       },
+      // The Letta Chat footnote must ride inside chunks: Slack rejects
+      // markdown_text combined with chunks on chat.stopStream.
+      {
+        type: "markdown_text",
+        text: "_<https://app.letta.com/chat/agent-1?conversation=conv-1|Open in Letta Chat>_",
+      },
     ],
-    markdown_text:
-      "_<https://app.letta.com/chat/agent-1?conversation=conv-1|Open in Letta Chat>_",
   });
   expect(writeClient?.chat.appendStream).toHaveBeenCalledTimes(0);
 });
@@ -3858,9 +3881,13 @@ test("slack adapter includes final error details in rich progress streams", asyn
         type: "plan_update",
         title: "Failed",
       }),
+      // The Letta Chat footnote must ride inside chunks: Slack rejects
+      // markdown_text combined with chunks on chat.stopStream.
+      expect.objectContaining({
+        type: "markdown_text",
+        text: "_<https://app.letta.com/chat/agent-1?conversation=conv-1|Open in Letta Chat>_",
+      }),
     ]),
-    markdown_text:
-      "_<https://app.letta.com/chat/agent-1?conversation=conv-1|Open in Letta Chat>_",
   });
 });
 
@@ -5095,4 +5122,128 @@ test("inbound debounce: app_mention arrives first, message-for-same-ts is droppe
   await sleep(80);
 
   expect(onMessage).toHaveBeenCalledTimes(1);
+});
+
+test("slack adapter closes the progress stream at turn end despite the chat footnote (stopStream wire contract)", async () => {
+  // Regression: chat.stopStream rejects markdown_text combined with chunks
+  // (cannot_provide_both_markdown_text_and_chunks). The footnote must be sent
+  // as a trailing markdown_text chunk or every terminal close fails and the
+  // spinner card never leaves streaming state. Replays a full channel turn
+  // with fire-and-forget progress dispatch, matching the listener's
+  // dispatchChannelTurnProgressFromDelta semantics.
+  process.env.LETTA_SLACK_COMPLETION_FINALIZE_GRACE_MS = "50";
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+  adapter.onMessage = mock(async () => {});
+  const source = {
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    chatType: "channel" as const,
+    senderId: "U123",
+    senderTeamId: "T123",
+    messageId: "1712800000.000200",
+    threadId: "1712790000.000050",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  };
+
+  await adapter.start();
+
+  const progress = (
+    event: Record<string, unknown>,
+  ): Promise<void> | undefined =>
+    adapter.handleTurnProgressEvent?.({
+      type: "progress",
+      batchId: "batch-1",
+      sources: [source],
+      ...event,
+    } as Parameters<NonNullable<typeof adapter.handleTurnProgressEvent>>[0]);
+
+  await adapter.handleTurnLifecycleEvent?.({ type: "queued", source });
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "processing",
+    batchId: "batch-1",
+    sources: [source],
+  });
+
+  void progress({ kind: "thinking", state: "updated", message: "Thinking" });
+  void progress({
+    kind: "tool",
+    state: "started",
+    message: "Running command",
+    toolCallId: "call-1",
+    toolName: "Bash",
+    toolDetails: "ps aux | grep letta",
+  });
+  await sleep(5);
+  void progress({
+    kind: "tool",
+    state: "completed",
+    message: "Ran command",
+    toolCallId: "call-1",
+  });
+  void progress({
+    kind: "tool",
+    state: "started",
+    message: "Sending message",
+    toolCallId: "call-2",
+    toolName: "MessageChannel",
+  });
+
+  await adapter.sendMessage({
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    text: "Still good.",
+    threadId: null,
+    replyToMessageId: "1712800000.000200",
+  });
+
+  void progress({
+    kind: "tool",
+    state: "completed",
+    message: "Sent message",
+    toolCallId: "call-2",
+  });
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "finished",
+    batchId: "batch-1",
+    outcome: "completed",
+    sources: [source],
+  });
+  await sleep(200);
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  expect(writeClient?.chat.startStream).toHaveBeenCalledTimes(1);
+  const stopCalls = writeClient?.chat.stopStream.mock.calls as Array<
+    Array<{
+      markdown_text?: string;
+      chunks?: Array<{ type: string; text?: string }>;
+    }>
+  >;
+  expect(stopCalls.length).toBeGreaterThan(0);
+  for (const [args] of stopCalls) {
+    // The contract-enforcing mock rejects the combination, but assert the
+    // shape explicitly so the intent survives mock changes.
+    expect(
+      typeof args?.markdown_text === "string" &&
+        (args?.chunks?.length ?? 0) > 0,
+    ).toBe(false);
+  }
+  // The close must actually succeed: the footnote rides as a trailing chunk.
+  const [stopArgs] = stopCalls[0] ?? [];
+  expect(stopArgs?.chunks?.at(-1)).toEqual({
+    type: "markdown_text",
+    text: "_<https://app.letta.com/chat/agent-1?conversation=conv-1|Open in Letta Chat>_",
+  });
 });

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -2874,12 +2874,19 @@ export function createSlackAdapter(
         channel: entry.source.chatId,
         ts: entry.streamTs,
       };
-      if (chunks.length > 0) {
-        args.chunks = chunks;
-      }
       // Add small footnote with link to Letta Chat for non-local agents.
+      // The Slack API rejects `markdown_text` combined with `chunks`
+      // (`cannot_provide_both_markdown_text_and_chunks`) even though the SDK
+      // types advertise both, so the footnote must ride inside the chunks
+      // array. Sending both silently broke EVERY terminal stop — cards only
+      // left streaming state when Slack expired them (verified against the
+      // live API, 2026-07-07).
       const footnote = buildSlackChatFootnote(entry.source);
-      if (footnote) {
+      if (chunks.length > 0) {
+        args.chunks = footnote
+          ? [...chunks, { type: "markdown_text", text: footnote }]
+          : chunks;
+      } else if (footnote) {
         args.markdown_text = footnote;
       }
       const response = await stopStream.call(slackClient.chat, args);


### PR DESCRIPTION
## Summary

- **Root cause of the never-closing "Thinking" spinner cards (LET-9524 live symptom):** the Slack API rejects `chat.stopStream` calls that combine `markdown_text` with `chunks`, returning `cannot_provide_both_markdown_text_and_chunks` — even though the `@slack/web-api` TypeScript types advertise both fields. Every terminal progress-card close sent both (non-empty terminal chunks + the "Open in Letta Chat" footnote), so **every** stop failed silently on every turn — outbound close, turn-end finalizer, and error close alike — and cards only left streaming state when Slack expired them with the red timeout warning. `startStream`/`appendStream` were unaffected because they never send `markdown_text`.
- Reproduced and verified against the **live Slack API**: start → append → stop-with-both fails with `cannot_provide_both_markdown_text_and_chunks`; stop with the footnote as a trailing `markdown_text` **chunk** succeeds and renders the footnote.
- Fix: the footnote now rides inside the `chunks` array as a trailing `markdown_text` chunk. `markdown_text` as a top-level arg is only used when there are no terminal chunks.
- Tests: `FakeSlackWriteClient.stopStream` now **enforces the real wire contract** (rejects the invalid combination), which converts every existing close-path test into a regression guard — two existing tests had pinned the broken shape and were updated. A new test replays a full channel turn (thinking → tools → MessageChannel reply → finished lifecycle → completion finalizer) with fire-and-forget progress dispatch matching the listener, and asserts the close succeeds with the footnote as a chunk.

Why the earlier fixes did not resolve the live symptom: #3272 (outbound anchor canonicalization) correctly made the close *run* for replies anchored to non-root messages, but Slack then rejected the stop itself. #3267 (orphan sweep) uses a chunks-only stop that the API accepts — but it only fires for recorded orphans on the next stream in the same thread, so the live experience remained a stuck spinner on every turn.

## Test plan

- [x] `bun test src/channels/slack-adapter.test.ts` (77 pass, includes new end-to-end regression test)
- [x] `bun run check` (all 10 checks pass)
- [x] Live Slack API verification of both the failure and the fix shape
- [ ] Redeploy the channel listener and confirm cards close green at reply/turn end

👾 Generated with [Letta Code](https://letta.com)