### PR TITLE
fix(slack): strip the dead-stream rewrite down to a single terminal summary line

### DIFF
--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -3577,7 +3577,9 @@ test("slack adapter rewrites dead streams with the final card state", async () =
   // Slack already took the message out of streaming state (expiry or an
   // external stop), so stopStream cannot deliver the final retitle. The
   // adapter rewrites the message via chat.update instead of silently
-  // dropping the terminal state and leaving a red in-progress row.
+  // dropping the terminal state and leaving a red in-progress row. The
+  // rewrite is a single terminal summary line (plan title + footnote) — no
+  // per-task dump: the card already showed the rows while it was live.
   expect(writeClient?.chat.update).toHaveBeenCalledTimes(1);
   const updateCalls = writeClient?.chat.update.mock.calls as unknown as Array<
     Array<{
@@ -3591,10 +3593,13 @@ test("slack adapter rewrites dead streams with the final card state", async () =
   expect(updateArgs).toMatchObject({
     channel: "C123",
     ts: "1712800000.000300",
+    text: "Read a file",
   });
   const renderedBlocks = JSON.stringify(updateArgs?.blocks ?? []);
-  expect(renderedBlocks).toContain("Read");
-  expect(renderedBlocks).toContain(":white_check_mark:");
+  expect(renderedBlocks).toContain("*Read a file*");
+  expect(renderedBlocks).toContain("Open in Letta Chat");
+  expect(renderedBlocks).not.toContain("task_update");
+  expect(renderedBlocks).not.toContain(":white_check_mark:");
   expect(renderedBlocks).not.toContain("in_progress");
 });
 
@@ -3759,8 +3764,11 @@ test("slack adapter stops appending after the stream leaves streaming state and 
     channel: "C123",
     ts: "1712800000.000300",
   });
+  // The rewrite is a single terminal summary title covering the turn's
+  // activity — individual task rows are not re-dumped as text.
   const renderedBlocks = JSON.stringify(updateCalls[0]?.[0]?.blocks ?? []);
-  expect(renderedBlocks).toContain("Search");
+  expect(renderedBlocks).toContain("*Read a file, searched files*");
+  expect(renderedBlocks).not.toContain(":white_check_mark:");
   expect(renderedBlocks).not.toContain("in_progress");
 });
 

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -544,9 +544,6 @@ function normalizeSlackReactionName(value: string): string {
 const SLACK_INGRESS_DEDUPE_TTL_MS = 60_000;
 const SLACK_INGRESS_DEDUPE_MAX = 2_000;
 const SLACK_LIFECYCLE_ERROR_TEXT_MAX = 3_000;
-// Slack section blocks cap mrkdwn text at 3000 characters; leave headroom
-// for the truncation marker when rewriting a dead stream's final state.
-const SLACK_DEAD_STREAM_REWRITE_TEXT_MAX = 2_900;
 const SLACK_PROGRESS_CARD_TEXT_MAX = 300;
 const SLACK_PROGRESS_CARD_STATE_TTL_MS = 6 * 60 * 60 * 1000;
 const SLACK_PROGRESS_CARD_STATE_MAX = 2_000;
@@ -841,13 +838,16 @@ function buildTerminalSlackStreamChunks(
 }
 
 /**
- * Render terminal stream chunks as plain message blocks for a stream Slack
- * has already taken out of streaming state (expired or externally stopped).
+ * Render the terminal state as a single plain message block for a stream
+ * Slack has already taken out of streaming state (expired or externally
+ * stopped). stopStream no-ops with `message_not_in_streaming_state` on such
+ * messages, so the rich close cannot be delivered.
  *
- * stopStream no-ops with `message_not_in_streaming_state` on such messages,
- * which previously dropped the final retitle/error details entirely and left
- * the card stuck on a red in-progress row. Rewriting the message via
- * chat.update replaces the stale streaming UI with the real final state.
+ * Deliberately minimal: just the terminal plan title (the same summary the
+ * rich card would have shown, e.g. "Ran 3 commands, wrote a file") plus the
+ * chat footnote. The previous per-task ":white_check_mark: title — details"
+ * dump duplicated rows the card already displayed, coalesced into the
+ * preceding reply as a wall of text, and had truncation/encoding artifacts.
  */
 function buildSlackDeadStreamRewrite(
   entry: SlackProgressCardEntry,
@@ -860,39 +860,12 @@ function buildSlackDeadStreamRewrite(
   const headerText =
     sanitizeSlackProgressText(planTitle ?? "", SLACK_STREAM_CHUNK_TEXT_MAX) ||
     formatSlackProgressCardText(entry.status, entry.latestText);
-  const lines: string[] = [];
-  for (const chunk of chunks) {
-    if (chunk.type !== "task_update") {
-      continue;
-    }
-    const icon =
-      chunk.status === "error"
-        ? ":warning:"
-        : chunk.status === "complete"
-          ? ":white_check_mark:"
-          : ":hourglass_flowing_sand:";
-    const details = isNonEmptyString(chunk.details)
-      ? ` — ${chunk.details}`
-      : "";
-    lines.push(`${icon} ${chunk.title}${details}`);
-  }
-  const body = truncateChannelProgressText(
-    lines.join("\n"),
-    SLACK_DEAD_STREAM_REWRITE_TEXT_MAX,
-    "…",
-  );
   const blocks: SlackBlock[] = [
     {
       type: "section",
       text: { type: "mrkdwn", text: `*${headerText}*` },
     },
   ];
-  if (body) {
-    blocks.push({
-      type: "section",
-      text: { type: "mrkdwn", text: body },
-    });
-  }
   const footnote = buildSlackChatFootnote(entry.source);
   if (footnote) {
     blocks.push({


### PR DESCRIPTION
## Summary

- Follow-up to #3275. The dead-stream rewrite — the chat.update fallback for cards Slack already expired out of streaming state — previously re-dumped every task row as ":white_check_mark: title — details" plain text. Slack coalesces the rewritten card under the preceding same-sender reply, so threads showed a giant non-rich wall of text duplicating rows the live card had already rendered (see the LCD-update thread in #letta-code-harness-tui, 2026-07-07).
- The rewrite now renders only the terminal plan title (the same activity summary the rich card shows at close, e.g. "Ran 3 commands, wrote a file") plus the Letta Chat footnote. One visual language across live rich cards, orphan-sweep replays, and dead-card rewrites.
- Deleting the dump also deletes its defects: the truncation that could insert the ellipsis mid-emoji-shortcode, and the mojibake-prone em-dash/ellipsis literals in that path.
- With #3275 merged (terminal stops actually succeed), this fallback only fires for genuinely expired streams — process death mid-turn — so it is now both rare and minimal.

## Test plan

- [x] `bun test src/channels/slack-adapter.test.ts` (77 pass; both rewrite tests updated to pin the one-line format and assert the task dump is gone)
- [x] `bun run check` (all 10 checks pass)

👾 Generated with [Letta Code](https://letta.com)