### PR TITLE
feat(slack): per-account text progress mode

### DIFF
--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -53,6 +53,7 @@ const SNAKE_TO_CAMEL: Record<string, string> = {
   listen_mode: "listenMode",
   media_max_bytes: "mediaMaxBytes",
   mention_patterns: "mentionPatterns",
+  progress_ui: "progressUi",
   recipient_aliases: "recipientAliases",
   remove_stale_routes: "removeStaleRoutes",
   rich_draft_streaming: "richDraftStreaming",
@@ -324,6 +325,9 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
     delete (next as unknown as Record<string, unknown>).showCompletedReaction;
     (next as SlackChannelAccount).listenMode =
       (next as SlackChannelAccount).listenMode === true;
+    if ((next as SlackChannelAccount).progressUi !== "text") {
+      delete (next as SlackChannelAccount).progressUi;
+    }
   }
   if (isDiscordChannelAccount(next)) {
     const migrated = migratePermissionMode(

--- a/src/channels/plugin-types.ts
+++ b/src/channels/plugin-types.ts
@@ -9,6 +9,7 @@ import type {
   OutboundChannelMessage,
   SignalGroupMode,
   SlackChannelMode,
+  SlackProgressUiMode,
   TelegramGroupMode,
   WhatsAppGroupMode,
 } from "./types";
@@ -176,6 +177,7 @@ export interface ChannelPluginAccountPatch {
   /** Signal UUID/identity -> replyable recipient aliases, e.g. UUID to E.164 phone. */
   recipientAliases?: Record<string, string>;
   transcribeVoice?: boolean;
+  progressUi?: SlackProgressUiMode;
   richPrivateChatDefault?: boolean;
   richDraftStreaming?: boolean;
   downloadMedia?: boolean;

--- a/src/channels/slack-account-config.test.ts
+++ b/src/channels/slack-account-config.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import { slackAccountConfigAdapter } from "@/channels/slack/account-config";
+import type { SlackChannelAccount } from "@/channels/types";
+
+const baseAccount: SlackChannelAccount = {
+  channel: "slack",
+  accountId: "acct-1",
+  enabled: true,
+  mode: "socket",
+  botToken: "xoxb-test-token",
+  appToken: "xapp-test-token",
+  dmPolicy: "pairing",
+  allowedUsers: [],
+  agentId: null,
+  defaultPermissionMode: "standard",
+  createdAt: "2026-07-07T00:00:00.000Z",
+  updatedAt: "2026-07-07T00:00:00.000Z",
+};
+
+describe("slackAccountConfigAdapter progress_ui", () => {
+  test("accepts rich, text, and undefined", () => {
+    expect(
+      slackAccountConfigAdapter.isValidConfig({ progress_ui: "rich" }),
+    ).toBe(true);
+    expect(
+      slackAccountConfigAdapter.isValidConfig({ progress_ui: "text" }),
+    ).toBe(true);
+    expect(slackAccountConfigAdapter.isValidConfig({})).toBe(true);
+  });
+
+  test("rejects unknown progress_ui values", () => {
+    expect(
+      slackAccountConfigAdapter.isValidConfig({ progress_ui: "fancy" }),
+    ).toBe(false);
+    expect(slackAccountConfigAdapter.isValidConfig({ progress_ui: 1 })).toBe(
+      false,
+    );
+  });
+
+  test("maps progress_ui into the account patch", () => {
+    expect(
+      slackAccountConfigAdapter.toAccountPatch({ progress_ui: "text" })
+        .progressUi,
+    ).toBe("text");
+    expect(
+      slackAccountConfigAdapter.toAccountPatch({}).progressUi,
+    ).toBeUndefined();
+  });
+
+  test("emits progress_ui in config views, defaulting to rich", () => {
+    expect(
+      slackAccountConfigAdapter.toAccountConfig(baseAccount).progress_ui,
+    ).toBe("rich");
+    expect(
+      slackAccountConfigAdapter.toAccountConfig({
+        ...baseAccount,
+        progressUi: "text",
+      }).progress_ui,
+    ).toBe("text");
+    expect(
+      slackAccountConfigAdapter.toConfigSnapshotConfig({
+        ...baseAccount,
+        progressUi: "text",
+      }).progress_ui,
+    ).toBe("text");
+  });
+});

--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -142,6 +142,8 @@ class FakeSlackApp {
 
 class FakeSlackWriteClient {
   static instances: FakeSlackWriteClient[] = [];
+  /** Simulates a Slack client/workspace without chat.startStream support. */
+  static disableStartStream = false;
 
   readonly token: string;
   readonly options: Record<string, unknown> | undefined;
@@ -207,6 +209,9 @@ class FakeSlackWriteClient {
   constructor(token: string, options?: Record<string, unknown>) {
     this.token = token;
     this.options = options;
+    if (FakeSlackWriteClient.disableStartStream) {
+      (this.chat as { startStream?: unknown }).startStream = undefined;
+    }
     FakeSlackWriteClient.instances.push(this);
   }
 }
@@ -301,6 +306,7 @@ const fetchMock = mock(
 beforeEach(() => {
   FakeSlackApp.instances.length = 0;
   FakeSlackWriteClient.instances.length = 0;
+  FakeSlackWriteClient.disableStartStream = false;
   resolveSlackInboundAttachmentsMock.mockReset();
   resolveSlackInboundAttachmentsMock.mockImplementation(async () => []);
   resolveSlackThreadStarterMock.mockReset();
@@ -336,7 +342,7 @@ afterEach(() => {
   for (const instance of FakeSlackWriteClient.instances) {
     instance.chat.postMessage.mockClear();
     instance.chat.update.mockClear();
-    instance.chat.startStream.mockClear();
+    instance.chat.startStream?.mockClear();
     instance.chat.appendStream.mockClear();
     instance.chat.stopStream.mockClear();
     instance.assistant.threads.setStatus.mockClear();
@@ -5246,4 +5252,161 @@ test("slack adapter closes the progress stream at turn end despite the chat foot
     type: "markdown_text",
     text: "_<https://app.letta.com/chat/agent-1?conversation=conv-1|Open in Letta Chat>_",
   });
+});
+
+test("slack adapter text progress mode posts one status message and edits it in place", async () => {
+  process.env.LETTA_SLACK_COMPLETION_FINALIZE_GRACE_MS = "50";
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+    progressUi: "text",
+  });
+  const source = {
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    chatType: "channel" as const,
+    senderId: "U123",
+    senderTeamId: "T123",
+    messageId: "1712800000.000100",
+    threadId: "1712790000.000050",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  };
+
+  await adapter.start();
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "processing",
+    batchId: "batch-1",
+    sources: [source],
+  });
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-1",
+    sources: [source],
+    kind: "tool",
+    state: "started",
+    message: "Reading files",
+    toolCallId: "call-1",
+    toolName: "read_file",
+  });
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-1",
+    sources: [source],
+    kind: "tool",
+    state: "completed",
+    message: "Read files",
+    toolCallId: "call-1",
+  });
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "finished",
+    batchId: "batch-1",
+    outcome: "completed",
+    sources: [source],
+  });
+  await sleep(200);
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  // Text mode never touches the streaming API.
+  expect(writeClient?.chat.startStream).not.toHaveBeenCalled();
+  expect(writeClient?.chat.appendStream).not.toHaveBeenCalled();
+  expect(writeClient?.chat.stopStream).not.toHaveBeenCalled();
+  // One status message posted in-thread, then edited in place.
+  expect(writeClient?.chat.postMessage).toHaveBeenCalledTimes(1);
+  const postCalls = writeClient?.chat.postMessage.mock
+    .calls as unknown as Array<
+    Array<{ channel: string; text: string; thread_ts?: string }>
+  >;
+  expect(postCalls[0]?.[0]).toMatchObject({
+    channel: "C123",
+    thread_ts: "1712790000.000050",
+  });
+  expect(postCalls[0]?.[0]?.text).toContain("Working");
+  const updateCalls = writeClient?.chat.update.mock.calls as unknown as Array<
+    Array<{
+      channel: string;
+      ts: string;
+      text: string;
+      blocks?: Array<{ type: string }>;
+    }>
+  >;
+  expect(updateCalls.length).toBeGreaterThan(0);
+  const terminalArgs = updateCalls[updateCalls.length - 1]?.[0];
+  // Terminal edit collapses to the activity summary plus the footnote.
+  expect(terminalArgs).toMatchObject({
+    channel: "C123",
+    ts: "1712800000.000100",
+    text: "Read a file",
+  });
+  const renderedBlocks = JSON.stringify(terminalArgs?.blocks ?? []);
+  expect(renderedBlocks).toContain("*Read a file*");
+  expect(renderedBlocks).toContain("Open in Letta Chat");
+});
+
+test("slack adapter degrades rich progress to text mode when chat.startStream is unavailable", async () => {
+  process.env.LETTA_SLACK_COMPLETION_FINALIZE_GRACE_MS = "50";
+  FakeSlackWriteClient.disableStartStream = true;
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+  const source = {
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    chatType: "channel" as const,
+    senderId: "U123",
+    senderTeamId: "T123",
+    messageId: "1712800000.000100",
+    threadId: "1712790000.000050",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  };
+
+  await adapter.start();
+
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    batchId: "batch-1",
+    sources: [source],
+    kind: "tool",
+    state: "started",
+    message: "Reading files",
+    toolCallId: "call-1",
+    toolName: "read_file",
+  });
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "finished",
+    batchId: "batch-1",
+    outcome: "completed",
+    sources: [source],
+  });
+  await sleep(200);
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  // Degraded to the plain status message instead of silently dropping
+  // progress (the old behavior requeued chunks forever and rendered nothing).
+  expect(writeClient?.chat.postMessage).toHaveBeenCalledTimes(1);
+  const postCalls = writeClient?.chat.postMessage.mock
+    .calls as unknown as Array<
+    Array<{ channel: string; text: string; thread_ts?: string }>
+  >;
+  expect(postCalls[0]?.[0]?.text).toContain("Working");
+  const updateCalls = writeClient?.chat.update.mock.calls as unknown as Array<
+    Array<{ text: string }>
+  >;
+  expect(updateCalls[updateCalls.length - 1]?.[0]?.text).toBe("Read a file");
 });

--- a/src/channels/slack/account-config.ts
+++ b/src/channels/slack/account-config.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_SLACK_PERMISSION_MODE,
   type SlackChannelAccount,
   type SlackDefaultPermissionMode,
+  type SlackProgressUiMode,
 } from "@/channels/types";
 import { migratePermissionMode } from "@/permissions/mode";
 
@@ -15,6 +16,7 @@ const SLACK_CONFIG_KEYS = new Set([
   "transcribe_voice",
   "show_completed_reaction",
   "listen_mode",
+  "progress_ui",
 ]);
 
 function isString(value: unknown): value is string {
@@ -27,6 +29,10 @@ function isNullableString(value: unknown): value is string | null {
 
 function isBoolean(value: unknown): value is boolean {
   return value === true || value === false;
+}
+
+function isProgressUiMode(value: unknown): value is SlackProgressUiMode {
+  return value === "rich" || value === "text";
 }
 
 function isDefaultPermissionMode(
@@ -62,7 +68,9 @@ export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannel
           isBoolean(config.transcribe_voice)) &&
         (config.show_completed_reaction === undefined ||
           isBoolean(config.show_completed_reaction)) &&
-        (config.listen_mode === undefined || isBoolean(config.listen_mode))
+        (config.listen_mode === undefined || isBoolean(config.listen_mode)) &&
+        (config.progress_ui === undefined ||
+          isProgressUiMode(config.progress_ui))
       );
     },
 
@@ -87,6 +95,9 @@ export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannel
         listenMode: isBoolean(config.listen_mode)
           ? config.listen_mode
           : undefined,
+        progressUi: isProgressUiMode(config.progress_ui)
+          ? config.progress_ui
+          : undefined,
       };
     },
 
@@ -100,6 +111,7 @@ export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannel
           account.defaultPermissionMode ?? DEFAULT_SLACK_PERMISSION_MODE,
         transcribe_voice: account.transcribeVoice === true,
         listen_mode: account.listenMode === true,
+        progress_ui: account.progressUi === "text" ? "text" : "rich",
       };
     },
 
@@ -113,6 +125,7 @@ export const slackAccountConfigAdapter: ChannelAccountConfigAdapter<SlackChannel
           account.defaultPermissionMode ?? DEFAULT_SLACK_PERMISSION_MODE,
         transcribe_voice: account.transcribeVoice === true,
         listen_mode: account.listenMode === true,
+        progress_ui: account.progressUi === "text" ? "text" : "rich",
       };
     },
 

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -32,6 +32,7 @@ import type {
   InboundChannelMessage,
   OutboundChannelMessage,
   SlackChannelAccount,
+  SlackProgressUiMode,
 } from "@/channels/types";
 import {
   getDisplayToolName,
@@ -587,8 +588,10 @@ type SlackProgressToolTask = {
 
 type SlackProgressCardEntry = {
   source: ChannelTurnSource;
-  mode?: "stream";
+  mode?: "stream" | "text";
   streamTs?: string;
+  /** Message ts of the plain text-mode progress message, edited in place. */
+  textTs?: string;
   /**
    * Set once Slack reports the stream left streaming state while we still
    * expected it to be live (expiry, external stop). A dead stream never
@@ -718,6 +721,48 @@ export function formatSlackProgressCardText(
   return safeProgressText
     ? `${statusLine}\nStatus: ${safeProgressText}`
     : statusLine;
+}
+
+/**
+ * Live line for text progress mode: the title of the task currently in
+ * progress (same vocabulary as the rich card rows), falling back to the most
+ * recent task title, then a generic placeholder. ASCII only.
+ */
+function formatSlackTextProgressLiveText(
+  entry: SlackProgressCardEntry,
+): string {
+  let inProgressTitle: string | undefined;
+  let latestTitle: string | undefined;
+  for (const task of entry.toolTasksById?.values() ?? []) {
+    if (isSlackTransientTask(task)) {
+      continue;
+    }
+    latestTitle = task.title;
+    if (task.status === "in_progress") {
+      inProgressTitle = task.title;
+    }
+  }
+  const detail = sanitizeSlackProgressText(
+    inProgressTitle ?? latestTitle ?? "",
+    SLACK_PROGRESS_CARD_TEXT_MAX,
+  );
+  return detail ? `_Working: ${detail}_` : "_Working..._";
+}
+
+/**
+ * Terminal line for text progress mode: the same activity summary the rich
+ * card uses for its terminal plan title.
+ */
+function formatSlackTextProgressTerminalText(
+  entry: SlackProgressCardEntry,
+): string {
+  if (entry.status === "completed") {
+    return (
+      entry.completionHeaderText?.trim() ||
+      formatSlackCompletionPlanTitle(entry)
+    );
+  }
+  return entry.status === "cancelled" ? "Interrupted" : "Failed";
 }
 
 function buildSlackLifecycleErrorTaskChunk(
@@ -2130,6 +2175,12 @@ export function createSlackAdapter(
   const progressUpdateThrottleMs = resolveSlackProgressUpdateThrottleMs();
   const progressStreamKeepaliveMs = resolveSlackProgressStreamKeepaliveMs();
   const completionFinalizeGraceMs = resolveSlackCompletionFinalizeGraceMs();
+  // Per-account progress rendering style. "rich" (default) uses streamed
+  // progress cards; "text" posts one plain status message per turn and edits
+  // it in place. "rich" degrades to "text" when the Slack client/workspace
+  // does not expose chat.startStream.
+  const configuredProgressUi: SlackProgressUiMode =
+    config.progressUi === "text" ? "text" : "rich";
 
   // ── Inbound debounce (optional) ───────────────────────────────
   // When `inboundDebounceMs > 0`, short back-to-back messages from the same
@@ -3045,6 +3096,77 @@ export function createSlackAdapter(
     scheduleSlackProgressStreamKeepalive(key, entry);
   }
 
+  /**
+   * Plain-text progress ("text" progress UI): one status message per turn,
+   * posted on the first flush with visible activity and edited in place
+   * afterwards. The terminal edit collapses to the turn's activity summary
+   * (the rich card's terminal plan title) plus the chat footnote. Also the
+   * automatic degradation target when chat.startStream is unavailable.
+   */
+  async function upsertSlackTextProgressMessage(
+    entry: SlackProgressCardEntry,
+    replyToMessageId: string,
+  ): Promise<boolean> {
+    const slackClient = await ensureWriteClient();
+    const terminal = entry.status !== "processing";
+    try {
+      if (!entry.textTs) {
+        if (terminal) {
+          // Nothing was ever posted for this turn; a terminal-only status
+          // message would be noise (the reply itself is the outcome).
+          return true;
+        }
+        const response = await slackClient.chat.postMessage({
+          channel: entry.source.chatId,
+          text: formatSlackTextProgressLiveText(entry),
+          thread_ts: replyToMessageId,
+        });
+        if (!isNonEmptyString(response.ts)) {
+          return false;
+        }
+        entry.mode = "text";
+        entry.textTs = response.ts;
+        rememberMessageThread(response.ts, replyToMessageId);
+        return true;
+      }
+      if (terminal) {
+        const headerText = formatSlackTextProgressTerminalText(entry);
+        const blocks: SlackBlock[] = [
+          {
+            type: "section",
+            text: { type: "mrkdwn", text: `*${headerText}*` },
+          },
+        ];
+        const footnote = buildSlackChatFootnote(entry.source);
+        if (footnote) {
+          blocks.push({
+            type: "context",
+            elements: [{ type: "mrkdwn", text: footnote }],
+          });
+        }
+        await slackClient.chat.update({
+          channel: entry.source.chatId,
+          ts: entry.textTs,
+          text: headerText,
+          blocks,
+        });
+        return true;
+      }
+      await slackClient.chat.update({
+        channel: entry.source.chatId,
+        ts: entry.textTs,
+        text: formatSlackTextProgressLiveText(entry),
+      });
+      return true;
+    } catch (error) {
+      console.warn(
+        "[Slack] Failed to send text progress update:",
+        error instanceof Error ? error.message : error,
+      );
+      return false;
+    }
+  }
+
   async function flushSlackProgressCard(
     key: string,
     entry: SlackProgressCardEntry,
@@ -3094,13 +3216,27 @@ export function createSlackAdapter(
       entry.pendingStreamChunks = [];
       let didSend = true;
       if (!entry.mode) {
-        didSend = await startSlackProgressStream(
-          entry,
-          replyToMessageId,
-          chunksToSend,
-        );
+        // Route the turn's first visible progress: text mode by explicit
+        // config, or as automatic degradation when the Slack client/workspace
+        // does not expose chat.startStream.
+        const slackClient = await ensureWriteClient();
+        const canStream = typeof slackClient.chat.startStream === "function";
+        if (configuredProgressUi === "text" || !canStream) {
+          didSend = await upsertSlackTextProgressMessage(
+            entry,
+            replyToMessageId,
+          );
+        } else {
+          didSend = await startSlackProgressStream(
+            entry,
+            replyToMessageId,
+            chunksToSend,
+          );
+        }
       } else if (entry.mode === "stream") {
         didSend = await appendSlackProgressStream(entry, chunksToSend);
+      } else {
+        didSend = await upsertSlackTextProgressMessage(entry, replyToMessageId);
       }
 
       if (!didSend && chunksToSend.length > 0) {
@@ -3383,6 +3519,7 @@ export function createSlackAdapter(
         entry.mode = undefined;
         entry.streamTs = undefined;
         entry.streamDead = undefined;
+        entry.textTs = undefined;
         entry.toolTasksById = undefined;
         entry.pendingStreamChunks = undefined;
         entry.toolNamesByCallId = undefined;
@@ -3430,7 +3567,7 @@ export function createSlackAdapter(
         entry.source = source;
         entry.updatedAt = Date.now();
         await flushSlackProgressCard(key, entry);
-        if (entry.mode === "stream") {
+        if (entry.mode === "stream" || entry.mode === "text") {
           scheduleSlackCompletionFinalizer(key, entry, batchId);
         }
         await clearSlackAssistantThreadStatus(source);

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -659,6 +659,14 @@ export interface TelegramChannelAccount extends ChannelAccountBase {
   inboundDebounceMs?: number;
 }
 
+/**
+ * Turn-progress rendering style for Slack threads.
+ * - "rich" (default): native streamed progress cards (chat.startStream).
+ * - "text": one plain status message per turn, edited in place while the
+ *   turn runs and finished as a terminal activity summary.
+ */
+export type SlackProgressUiMode = "rich" | "text";
+
 export interface SlackChannelAccount extends ChannelAccountBase {
   channel: "slack";
   mode: SlackChannelMode;
@@ -670,6 +678,12 @@ export interface SlackChannelAccount extends ChannelAccountBase {
   transcribeVoice?: boolean;
   /** When true, unmentioned Slack thread replies are delivered read-only until an @mention. */
   listenMode?: boolean;
+  /**
+   * Turn-progress rendering style. Defaults to "rich" (streamed progress
+   * cards). "rich" degrades to "text" automatically when the Slack
+   * client/workspace does not support chat.startStream.
+   */
+  progressUi?: SlackProgressUiMode;
   /**
    * Optional debounce window (ms) for inbound messages. When greater than
    * `0`, short back-to-back messages from the same sender in the same


### PR DESCRIPTION
## Summary

- Adds a per-account "progress_ui" setting to Slack channel accounts: "rich" (default, the current streamed progress cards) or "text" (LET-9527).
- Text mode is one plain status message per turn, posted on the first visible activity and edited in place ("_Working: <current task>_", same task-title vocabulary as the rich card rows), then collapsed at turn end to the terminal activity summary the rich card would have shown ("Ran 3 commands, wrote a file") plus the Letta Chat footnote. No accordion, no task-row dumps, ASCII-only strings.
- Rich mode now degrades to text mode automatically when the Slack client/workspace does not expose chat.startStream. Previously that path rendered nothing: startSlackProgressStream returned false and progress chunks requeued forever, so non-streaming workspaces silently got no progress UI at all. The legacy "no-streaming fallback" is now this first-class mode instead of a dead code path.
- Plumbing follows the existing listen_mode/transcribe_voice pattern: SlackChannelAccount type, snake_case↔camelCase account normalization, config adapter validation/patch/snapshots, and ChannelPluginAccountPatch.
- Fixes an adjacent gap: the completion finalizer grace path only scheduled for stream-mode entries, so non-stream terminal closes never ran; it now covers text mode, and terminal resets clear the text message ts alongside stream state.

## Test plan

- [x] New adapter tests: text mode posts exactly one status message + in-place edits, never touches the streaming API, terminal edit renders the activity summary + footnote; rich-to-text degradation when chat.startStream is unavailable
- [x] New slack-account-config tests for progress_ui validation/patch/snapshot mapping
- [x] `bun test src/channels/` (716 pass) and `bun test src/websocket/listener/` (109 pass)
- [x] `bun run check` (all 10 checks pass)

👾 Generated with [Letta Code](https://letta.com)
