### PR TITLE
fix(cron): trace scheduled task lifecycle

### DIFF
--- a/scripts/isolated-unit-tests.json
+++ b/scripts/isolated-unit-tests.json
@@ -59,6 +59,11 @@
       "path": "src/websocket/listen-client-concurrency.test.ts",
       "timeoutMs": 30000,
       "reason": "Uses several top-level Bun module mocks and exercises real concurrent listener state."
+    },
+    {
+      "path": "src/websocket/listener/cron-run-lifecycle.test.ts",
+      "timeoutMs": 15000,
+      "reason": "Uses a top-level Bun module mock and listener IO test seams for cron turn lifecycle logging."
     }
   ]
 }

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -40,13 +40,13 @@
   "src/tools/impl/message-channel.ts": 1208,
   "src/tools/manager.ts": 3293,
   "src/tools/tool-execution-context.test.ts": 1422,
-  "src/types/protocol_v2.ts": 2932,
+  "src/types/protocol_v2.ts": 2878,
   "src/websocket/listen-client-concurrency.test.ts": 3021,
   "src/websocket/listen-client-protocol.test.ts": 6721,
   "src/websocket/listener/commands/channels.ts": 1390,
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1030,
   "src/websocket/listener/lifecycle.ts": 1766,
-  "src/websocket/listener/protocol-inbound.ts": 2279,
+  "src/websocket/listener/protocol-inbound.ts": 2274,
   "src/websocket/listener/protocol-outbound.ts": 1279
 }

--- a/src/cli/subcommands/cron.ts
+++ b/src/cli/subcommands/cron.ts
@@ -7,7 +7,7 @@
  *   letta cron add --prompt <text> --cron <expr> [--agent <id>]
  *   letta cron list [--agent <id>] [--conversation <id>]
  *   letta cron get <id>
- *   letta cron runs --id <id>
+ *   letta cron runs --id <id> [--run-id <id>] [--backend-run-id <id>] [--cron-run-id <id>]
  *   letta cron delete <id>
  *   letta cron delete --all [--agent <id>]
  */
@@ -37,7 +37,7 @@ Usage:
   letta cron add --prompt <text> --cron <expr> [options]
   letta cron list [options]
   letta cron get <id>
-  letta cron runs --id <id> [--limit <n>]
+  letta cron runs --id <id> [--limit <n>] [--run-id <id>] [--backend-run-id <id>] [--cron-run-id <id>]
   letta cron delete <id>
   letta cron delete --all [--agent <id>]
 
@@ -53,6 +53,11 @@ Add options:
 List/filter options:
   --agent <id>           Filter by agent ID
   --conversation <id>    Filter by conversation ID
+
+Run history options:
+  --run-id <id>          Filter by public/backend/cron run ID
+  --backend-run-id <id>  Filter by backend run ID
+  --cron-run-id <id>     Filter by per-fire cron run ID
 
 Delete options:
   --all                  Delete all tasks for the given agent
@@ -79,6 +84,8 @@ const CRON_OPTIONS = {
   id: { type: "string" },
   limit: { type: "string" },
   "run-id": { type: "string" },
+  "backend-run-id": { type: "string" },
+  "cron-run-id": { type: "string" },
 } as const;
 
 function parseCronArgs(argv: string[]) {
@@ -275,6 +282,8 @@ function handleRuns(
   const limitRaw = Number.parseInt(String(values.limit ?? "50"), 10);
   const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : 50;
   const runId = values["run-id"];
+  const backendRunId = values["backend-run-id"];
+  const cronRunId = values["cron-run-id"];
 
   try {
     const logPath = getCronRunLogPath(id);
@@ -282,6 +291,12 @@ function handleRuns(
       jobId: id,
       limit,
       ...(typeof runId === "string" && runId.trim() ? { runId } : {}),
+      ...(typeof backendRunId === "string" && backendRunId.trim()
+        ? { backendRunId }
+        : {}),
+      ...(typeof cronRunId === "string" && cronRunId.trim()
+        ? { cronRunId }
+        : {}),
     });
     console.log(JSON.stringify(page, null, 2));
     return 0;

--- a/src/cron/index.ts
+++ b/src/cron/index.ts
@@ -36,16 +36,23 @@ export {
 } from "./parse-interval";
 export {
   appendCronRunLog,
+  appendCronRunLogForCronRun,
   appendCronRunLogForTask,
+  type CronRunLogAction,
   type CronRunLogEntry,
   type CronRunLogPage,
+  type CronRunLogPageOptions,
+  type CronRunLogRunEntryInput,
+  type CronRunLogRunReference,
   type CronRunLogStatus,
+  type CronRunLogTaskEntryInput,
   DEFAULT_CRON_RUN_LOG_KEEP_LINES,
   DEFAULT_CRON_RUN_LOG_MAX_BYTES,
   getCronRunLogPath,
   readCronRunLogEntries,
   readCronRunLogEntriesPage,
   resolveCronRunLogPath,
+  safeAppendCronRunLogForCronRun,
   safeAppendCronRunLogForTask,
 } from "./run-log";
 export {

--- a/src/cron/run-log.test.ts
+++ b/src/cron/run-log.test.ts
@@ -98,9 +98,12 @@ describe("cron run log", () => {
     appendCronRunLog(logPath, {
       ts: 1000,
       jobId: "job-1",
-      action: "finished",
+      action: "dequeued",
       status: "ok",
+      cronRunId: "cron-run-1",
+      batchId: "batch-1",
       queueItemId: "q-1",
+      queueLenAfter: 0,
     });
     appendCronRunLog(logPath, {
       ts: 2000,
@@ -126,13 +129,19 @@ describe("cron run log", () => {
       limit: 10,
     });
     expect(entries.map((entry) => entry.ts)).toEqual([1000, 2000]);
-    expect(entries[0]?.queueItemId).toBe("q-1");
+    expect(entries[0]).toMatchObject({
+      action: "dequeued",
+      cronRunId: "cron-run-1",
+      batchId: "batch-1",
+      queueItemId: "q-1",
+      queueLenAfter: 0,
+    });
     expect(entries[1]?.error).toBe("boom");
     expect(entries[1]?.outcome).toBe("failed");
     expect(entries[1]?.reason).toBe("queue_full");
   });
 
-  test("reads newest page first and filters by run id", () => {
+  test("reads newest page first and filters by public, backend, or cron run id", () => {
     const logPath = getCronRunLogPath("job-1");
     appendCronRunLog(logPath, {
       ts: 1000,
@@ -140,6 +149,8 @@ describe("cron run log", () => {
       action: "finished",
       status: "ok",
       runId: "run-1",
+      backendRunId: "run-1",
+      cronRunId: "cron-run-1",
     });
     appendCronRunLog(logPath, {
       ts: 2000,
@@ -147,16 +158,51 @@ describe("cron run log", () => {
       action: "finished",
       status: "error",
       runId: "run-2",
+      backendRunId: "run-2",
+      cronRunId: "cron-run-2",
+    });
+    appendCronRunLog(logPath, {
+      ts: 3000,
+      jobId: "job-1",
+      action: "backend_run_started",
+      status: "ok",
+      backendRunId: "backend-only-3",
+      cronRunId: "cron-run-3",
     });
 
     expect(readCronRunLogEntriesPage(logPath, { limit: 1 })).toMatchObject({
-      total: 2,
+      total: 3,
       hasMore: true,
       nextOffset: 1,
-      entries: [{ ts: 2000 }],
+      entries: [{ ts: 3000 }],
     });
     expect(
       readCronRunLogEntriesPage(logPath, { runId: "run-1" }).entries,
     ).toEqual([expect.objectContaining({ runId: "run-1", ts: 1000 })]);
+    expect(
+      readCronRunLogEntriesPage(logPath, { runId: "backend-only-3" }).entries,
+    ).toEqual([
+      expect.objectContaining({
+        action: "backend_run_started",
+        backendRunId: "backend-only-3",
+        ts: 3000,
+      }),
+    ]);
+    expect(
+      readCronRunLogEntriesPage(logPath, { backendRunId: "backend-only-3" })
+        .entries,
+    ).toEqual([
+      expect.objectContaining({
+        action: "backend_run_started",
+        backendRunId: "backend-only-3",
+        ts: 3000,
+      }),
+    ]);
+    expect(
+      readCronRunLogEntriesPage(logPath, { runId: "cron-run-2" }).entries,
+    ).toEqual([expect.objectContaining({ cronRunId: "cron-run-2", ts: 2000 })]);
+    expect(
+      readCronRunLogEntriesPage(logPath, { cronRunId: "cron-run-3" }).entries,
+    ).toEqual([expect.objectContaining({ cronRunId: "cron-run-3", ts: 3000 })]);
   });
 });

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -23,27 +23,80 @@ import {
 } from "./cron-file";
 
 export type CronRunLogStatus = "ok" | "error" | "skipped";
+export type CronRunLogAction =
+  | "fire_started"
+  | "enqueued"
+  | "enqueue_failed"
+  | "blocked"
+  | "dequeued"
+  | "turn_started"
+  | "backend_run_started"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "dropped"
+  | "cleared"
+  | "removed"
+  | "pump_failed"
+  | "listener_closed_before_drain"
+  | "finished";
 
 export interface CronRunLogEntry {
   ts: number;
   jobId: string;
-  action: "finished";
+  action: CronRunLogAction;
   status?: CronRunLogStatus;
   outcome?: CronRunOutcome;
   reason?: CronRunReason;
   error?: string;
+  errorClass?: string;
+  errorMessage?: string;
   summary?: string;
   agentId?: string;
   conversationId?: string;
+  cronRunId?: string;
   runId?: string;
+  backendRunId?: string;
+  batchId?: string;
   runAtMs?: number;
   queueItemId?: string;
+  queueLen?: number;
+  queueLenAfter?: number;
+  mergedCount?: number;
+  blockedReason?: string;
+  droppedReason?: string;
+  clearedReason?: string;
+  clearedCount?: number;
+  removedReason?: string;
+  stopReason?: string;
+  schedulerPid?: number;
+  schedulerToken?: string;
+  schedulerStartedAt?: string;
   scheduledFor?: string | null;
   firedAt?: string;
   missedCount?: number;
   windowStart?: string;
   windowEnd?: string;
 }
+
+const CRON_RUN_LOG_ACTIONS = new Set<CronRunLogAction>([
+  "fire_started",
+  "enqueued",
+  "enqueue_failed",
+  "blocked",
+  "dequeued",
+  "turn_started",
+  "backend_run_started",
+  "completed",
+  "failed",
+  "cancelled",
+  "dropped",
+  "cleared",
+  "removed",
+  "pump_failed",
+  "listener_closed_before_drain",
+  "finished",
+]);
 
 export interface CronRunLogPage {
   entries: CronRunLogEntry[];
@@ -164,7 +217,10 @@ function parseAllRunLogEntries(raw: string, jobId?: string): CronRunLogEntry[] {
       if (!obj || typeof obj !== "object") {
         continue;
       }
-      if (obj.action !== "finished") {
+      if (
+        typeof obj.action !== "string" ||
+        !CRON_RUN_LOG_ACTIONS.has(obj.action as CronRunLogAction)
+      ) {
         continue;
       }
       if (typeof obj.jobId !== "string" || obj.jobId.trim().length === 0) {
@@ -179,17 +235,34 @@ function parseAllRunLogEntries(raw: string, jobId?: string): CronRunLogEntry[] {
       entries.push({
         ts: obj.ts,
         jobId: obj.jobId,
-        action: "finished",
+        action: obj.action as CronRunLogAction,
         status: obj.status,
         outcome: obj.outcome,
         reason: obj.reason,
         error: obj.error,
+        errorClass: obj.errorClass,
+        errorMessage: obj.errorMessage,
         summary: obj.summary,
         agentId: obj.agentId,
         conversationId: obj.conversationId,
+        cronRunId: obj.cronRunId,
         runId: obj.runId,
+        backendRunId: obj.backendRunId,
+        batchId: obj.batchId,
         runAtMs: obj.runAtMs,
         queueItemId: obj.queueItemId,
+        queueLen: obj.queueLen,
+        queueLenAfter: obj.queueLenAfter,
+        mergedCount: obj.mergedCount,
+        blockedReason: obj.blockedReason,
+        droppedReason: obj.droppedReason,
+        clearedReason: obj.clearedReason,
+        clearedCount: obj.clearedCount,
+        removedReason: obj.removedReason,
+        stopReason: obj.stopReason,
+        schedulerPid: obj.schedulerPid,
+        schedulerToken: obj.schedulerToken,
+        schedulerStartedAt: obj.schedulerStartedAt,
         scheduledFor: obj.scheduledFor,
         firedAt: obj.firedAt,
         missedCount: obj.missedCount,
@@ -217,17 +290,48 @@ export function readCronRunLogEntries(
   return parseAllRunLogEntries(raw, opts?.jobId).slice(-limit);
 }
 
+export interface CronRunLogPageOptions {
+  limit?: number;
+  offset?: number;
+  jobId?: string;
+  /** Generic filter that matches public runId, backendRunId, or cronRunId. */
+  runId?: string;
+  /** Exact backend run id filter. */
+  backendRunId?: string;
+  /** Exact per-fire cron run id filter. */
+  cronRunId?: string;
+}
+
 export function readCronRunLogEntriesPage(
   filePath: string,
-  opts?: { limit?: number; offset?: number; jobId?: string; runId?: string },
+  opts?: CronRunLogPageOptions,
 ): CronRunLogPage {
   const limit = Math.max(1, Math.min(200, Math.floor(opts?.limit ?? 50)));
   const offset = Math.max(0, Math.floor(opts?.offset ?? 0));
+  const genericRunId = opts?.runId?.trim();
+  const backendRunId = opts?.backendRunId?.trim();
+  const cronRunId = opts?.cronRunId?.trim();
   const entries = readCronRunLogEntries(filePath, {
     limit: 5000,
     jobId: opts?.jobId,
   })
-    .filter((entry) => !opts?.runId || entry.runId === opts.runId)
+    .filter((entry) => {
+      if (
+        genericRunId &&
+        entry.runId !== genericRunId &&
+        entry.backendRunId !== genericRunId &&
+        entry.cronRunId !== genericRunId
+      ) {
+        return false;
+      }
+      if (backendRunId && entry.backendRunId !== backendRunId) {
+        return false;
+      }
+      if (cronRunId && entry.cronRunId !== cronRunId) {
+        return false;
+      }
+      return true;
+    })
     .toSorted((a, b) => b.ts - a.ts);
   const pageEntries = entries.slice(offset, offset + limit);
   const nextOffset = offset + pageEntries.length;
@@ -241,19 +345,57 @@ export function readCronRunLogEntriesPage(
   };
 }
 
+export type CronRunLogTaskEntryInput = Omit<
+  CronRunLogEntry,
+  "action" | "agentId" | "jobId" | "ts"
+> & {
+  action?: CronRunLogAction;
+  ts?: number;
+};
+
 export function appendCronRunLogForTask(
   task: CronTask,
-  entry: Omit<CronRunLogEntry, "action" | "agentId" | "jobId" | "ts"> & {
-    ts?: number;
-  },
+  entry: CronRunLogTaskEntryInput,
 ): void {
+  const { action, ts, ...rest } = entry;
   appendCronRunLog(getCronRunLogPath(task.id), {
-    ts: entry.ts ?? Date.now(),
+    ts: ts ?? Date.now(),
     jobId: task.id,
-    action: "finished",
+    action: action ?? "finished",
     agentId: task.agent_id,
     conversationId: task.conversation_id,
-    ...entry,
+    ...rest,
+  });
+}
+
+export type CronRunLogRunReference = {
+  jobId: string;
+  cronRunId: string;
+  queueItemId?: string;
+  agentId?: string;
+  conversationId?: string;
+};
+
+export type CronRunLogRunEntryInput = Omit<
+  CronRunLogEntry,
+  "jobId" | "ts" | "cronRunId"
+> & {
+  ts?: number;
+};
+
+export function appendCronRunLogForCronRun(
+  ref: CronRunLogRunReference,
+  entry: CronRunLogRunEntryInput,
+): void {
+  const { ts, ...rest } = entry;
+  appendCronRunLog(getCronRunLogPath(ref.jobId), {
+    ts: ts ?? Date.now(),
+    jobId: ref.jobId,
+    cronRunId: ref.cronRunId,
+    queueItemId: ref.queueItemId,
+    agentId: ref.agentId,
+    conversationId: ref.conversationId,
+    ...rest,
   });
 }
 
@@ -266,6 +408,20 @@ export function safeAppendCronRunLogForTask(
   } catch (err) {
     console.error(
       `[Cron] Error writing run log for task ${task.id}:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+}
+
+export function safeAppendCronRunLogForCronRun(
+  ref: CronRunLogRunReference,
+  entry: Parameters<typeof appendCronRunLogForCronRun>[1],
+): void {
+  try {
+    appendCronRunLogForCronRun(ref, entry);
+  } catch (err) {
+    console.error(
+      `[Cron] Error writing run log for cron run ${ref.cronRunId}:`,
       err instanceof Error ? err.message : err,
     );
   }

--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -43,7 +43,10 @@ import {
   verifySchedulerLease,
 } from "./cron-file";
 import { cronMatchesTime } from "./parse-interval";
-import { safeAppendCronRunLogForTask } from "./run-log";
+import {
+  safeAppendCronRunLogForCronRun,
+  safeAppendCronRunLogForTask,
+} from "./run-log";
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -54,6 +57,7 @@ type ProcessQueuedTurn = (
 
 interface SchedulerState {
   token: string;
+  startedAt: string;
   tickInterval: NodeJS.Timeout;
   gcInterval: NodeJS.Timeout;
   socket: ListenerTransport;
@@ -219,6 +223,23 @@ async function fireCronTask(
   opts: StartListenerOptions,
   processQueuedTurn: ProcessQueuedTurn,
 ): Promise<boolean> {
+  const cronRunId = crypto.randomUUID();
+  const schedulerStartedAt = schedulerState?.startedAt;
+  const cronRunRef = {
+    jobId: task.id,
+    cronRunId,
+    agentId: task.agent_id,
+    conversationId: task.conversation_id,
+  };
+  safeAppendCronRunLogForCronRun(cronRunRef, {
+    action: "fire_started",
+    status: "ok",
+    runAtMs: now.getTime(),
+    scheduledFor: task.scheduled_for,
+    schedulerPid: process.pid,
+    schedulerStartedAt,
+  });
+
   const listener = getActiveRuntime();
   if (!listener) {
     setLastRunOutcome(task.id, {
@@ -227,13 +248,16 @@ async function fireCronTask(
       runAt: now,
       error: "No active runtime",
     });
-    safeAppendCronRunLogForTask(task, {
+    safeAppendCronRunLogForCronRun(cronRunRef, {
+      action: "enqueue_failed",
       status: "error",
       outcome: "failed",
       reason: "runtime_unavailable",
       error: "No active runtime",
       runAtMs: now.getTime(),
       scheduledFor: task.scheduled_for,
+      schedulerPid: process.pid,
+      schedulerStartedAt,
     });
     return false;
   }
@@ -242,12 +266,24 @@ async function fireCronTask(
   try {
     targetConversationId = await resolveCronFireConversationId(task);
   } catch (err) {
-    safeAppendCronRunLogForTask(task, {
+    const errorMessage =
+      err instanceof Error ? err.message : "failed to resolve conversation";
+    setLastRunOutcome(task.id, {
+      outcome: "failed",
+      reason: "runtime_unavailable",
+      runAt: now,
+      error: errorMessage,
+    });
+    safeAppendCronRunLogForCronRun(cronRunRef, {
+      action: "enqueue_failed",
       status: "error",
-      error:
-        err instanceof Error ? err.message : "failed to resolve conversation",
+      outcome: "failed",
+      reason: "runtime_unavailable",
+      error: errorMessage,
       runAtMs: now.getTime(),
       scheduledFor: task.scheduled_for,
+      schedulerPid: process.pid,
+      schedulerStartedAt,
     });
     return false;
   }
@@ -265,13 +301,16 @@ async function fireCronTask(
       runAt: now,
       error: "Conversation runtime unavailable",
     });
-    safeAppendCronRunLogForTask(task, {
+    safeAppendCronRunLogForCronRun(cronRunRef, {
+      action: "enqueue_failed",
       status: "error",
       outcome: "failed",
       reason: "runtime_unavailable",
       error: "Conversation runtime unavailable",
       runAtMs: now.getTime(),
       scheduledFor: task.scheduled_for,
+      schedulerPid: process.pid,
+      schedulerStartedAt,
     });
     return false;
   }
@@ -290,6 +329,7 @@ async function fireCronTask(
     source: "cron" as import("@/types/protocol").QueueItemSource,
     text,
     cronTaskId: task.id,
+    cronRunId,
     agentId: task.agent_id,
     conversationId: targetConversationId ?? "default",
   } as Omit<CronPromptQueueItem, "id" | "enqueuedAt">);
@@ -301,13 +341,16 @@ async function fireCronTask(
       runAt: now,
       error: "queue buffer limit",
     });
-    safeAppendCronRunLogForTask(task, {
+    safeAppendCronRunLogForCronRun(cronRunRef, {
+      action: "enqueue_failed",
       status: "error",
       outcome: "failed",
       reason: "queue_full",
       error: "queue buffer limit",
       runAtMs: now.getTime(),
       scheduledFor: task.scheduled_for,
+      schedulerPid: process.pid,
+      schedulerStartedAt,
     });
     return false;
   }
@@ -339,16 +382,27 @@ async function fireCronTask(
     });
   }
 
-  safeAppendCronRunLogForTask(task, {
-    status: "ok",
-    outcome: "queued",
-    reason: task.recurring ? "scheduled_time_matched" : "one_off_due",
-    runAtMs: now.getTime(),
-    queueItemId: queuedItem.id,
-    scheduledFor: task.scheduled_for,
-    firedAt: nowIso,
-    conversationId: targetConversationId ?? "default",
-  });
+  safeAppendCronRunLogForCronRun(
+    {
+      ...cronRunRef,
+      queueItemId: queuedItem.id,
+      conversationId: targetConversationId ?? "default",
+    },
+    {
+      action: "enqueued",
+      status: "ok",
+      outcome: "queued",
+      reason: task.recurring ? "scheduled_time_matched" : "one_off_due",
+      runAtMs: now.getTime(),
+      queueItemId: queuedItem.id,
+      scheduledFor: task.scheduled_for,
+      firedAt: nowIso,
+      conversationId: targetConversationId ?? "default",
+      queueLen: conversationRuntime.queueRuntime.length,
+      schedulerPid: process.pid,
+      schedulerStartedAt,
+    },
+  );
   emitCronsUpdated(socket, task, targetConversationId ?? "default");
   return true;
 }
@@ -510,6 +564,7 @@ function tick(
             error: err instanceof Error ? err.message : String(err),
           });
           safeAppendCronRunLogForTask(freshTask, {
+            action: "failed",
             status: "error",
             outcome: "failed",
             reason: "scheduler_error",
@@ -585,6 +640,7 @@ export function startScheduler(
   const now = new Date();
   const state: SchedulerState = {
     token,
+    startedAt: now.toISOString(),
     tickInterval: null as unknown as NodeJS.Timeout,
     gcInterval: null as unknown as NodeJS.Timeout,
     socket,

--- a/src/queue/queue-runtime.ts
+++ b/src/queue/queue-runtime.ts
@@ -65,6 +65,8 @@ export type CronPromptQueueItem = QueueItemBase & {
   text: string;
   /** Cron task ID for tracing. */
   cronTaskId: string;
+  /** Durable per-fire schedule run ID. Required for scheduler-created items. */
+  cronRunId?: string;
 };
 
 export type ModContinueQueueItem = QueueItemBase & {

--- a/src/types/cron-protocol.ts
+++ b/src/types/cron-protocol.ts
@@ -1,0 +1,107 @@
+export type CronTaskStatus = "active" | "fired" | "missed" | "cancelled";
+export type CronCancelReason = "conversation_not_found" | "expired";
+export type CronRunOutcome = "queued" | "missed" | "failed" | "skipped";
+export type CronRunReason =
+  | "scheduled_time_matched"
+  | "one_off_due"
+  | "scheduler_inactive"
+  | "started_too_late"
+  | "queue_full"
+  | "runtime_unavailable"
+  | "task_cancelled"
+  | "scheduler_error";
+
+export interface CronTask {
+  id: string;
+  agent_id: string;
+  conversation_id: string;
+  name: string;
+  description: string;
+  cron: string;
+  timezone: string;
+  recurring: boolean;
+  prompt: string;
+  status: CronTaskStatus;
+  created_at: string;
+  expires_at: string | null;
+  last_fired_at: string | null;
+  fire_count: number;
+  cancel_reason: CronCancelReason | null;
+  jitter_offset_ms: number;
+  last_run_at: string | null;
+  last_run_outcome: CronRunOutcome | null;
+  last_run_reason: CronRunReason | null;
+  last_run_error: string | null;
+  last_missed_at: string | null;
+  missed_count: number;
+  failed_count: number;
+  scheduled_for: string | null;
+  fired_at: string | null;
+  missed_at: string | null;
+}
+
+export type CronRunLogStatus = "ok" | "error" | "skipped";
+export type CronRunLogAction =
+  | "fire_started"
+  | "enqueued"
+  | "enqueue_failed"
+  | "blocked"
+  | "dequeued"
+  | "turn_started"
+  | "backend_run_started"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "dropped"
+  | "cleared"
+  | "removed"
+  | "pump_failed"
+  | "listener_closed_before_drain"
+  | "finished";
+
+export interface CronRunLogEntry {
+  ts: number;
+  jobId: string;
+  action: CronRunLogAction;
+  status?: CronRunLogStatus;
+  outcome?: CronRunOutcome;
+  reason?: CronRunReason;
+  error?: string;
+  errorClass?: string;
+  errorMessage?: string;
+  summary?: string;
+  agentId?: string;
+  conversationId?: string;
+  cronRunId?: string;
+  runId?: string;
+  backendRunId?: string;
+  batchId?: string;
+  runAtMs?: number;
+  queueItemId?: string;
+  queueLen?: number;
+  queueLenAfter?: number;
+  mergedCount?: number;
+  blockedReason?: string;
+  droppedReason?: string;
+  clearedReason?: string;
+  clearedCount?: number;
+  removedReason?: string;
+  stopReason?: string;
+  schedulerPid?: number;
+  schedulerToken?: string;
+  schedulerStartedAt?: string;
+  scheduledFor?: string | null;
+  firedAt?: string;
+  missedCount?: number;
+  windowStart?: string;
+  windowEnd?: string;
+}
+
+export interface CronRunLogPage {
+  entries: CronRunLogEntry[];
+  total: number;
+  offset: number;
+  limit: number;
+  hasMore: boolean;
+  nextOffset: number | null;
+}

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -30,6 +30,19 @@ import type {
   MessageListParams,
 } from "@letta-ai/letta-client/resources/conversations/messages";
 import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs";
+import type { CronRunLogPage, CronTask } from "./cron-protocol";
+
+export type {
+  CronCancelReason,
+  CronRunLogAction,
+  CronRunLogEntry,
+  CronRunLogPage,
+  CronRunLogStatus,
+  CronRunOutcome,
+  CronRunReason,
+  CronTask,
+  CronTaskStatus,
+} from "./cron-protocol";
 
 export type DmPolicy = "pairing" | "allowlist" | "open";
 
@@ -51,114 +64,6 @@ export interface ExperimentSnapshot {
   enabled: boolean;
   source: ExperimentSource;
   override: boolean | null;
-}
-
-export type CronTaskStatus = "active" | "fired" | "missed" | "cancelled";
-export type CronCancelReason = "conversation_not_found" | "expired";
-export type CronRunOutcome = "queued" | "missed" | "failed" | "skipped";
-export type CronRunReason =
-  | "scheduled_time_matched"
-  | "one_off_due"
-  | "scheduler_inactive"
-  | "started_too_late"
-  | "queue_full"
-  | "runtime_unavailable"
-  | "task_cancelled"
-  | "scheduler_error";
-
-export interface CronTask {
-  id: string;
-  agent_id: string;
-  conversation_id: string;
-  name: string;
-  description: string;
-  cron: string;
-  timezone: string;
-  recurring: boolean;
-  prompt: string;
-  status: CronTaskStatus;
-  created_at: string;
-  expires_at: string | null;
-  last_fired_at: string | null;
-  fire_count: number;
-  cancel_reason: CronCancelReason | null;
-  jitter_offset_ms: number;
-  last_run_at: string | null;
-  last_run_outcome: CronRunOutcome | null;
-  last_run_reason: CronRunReason | null;
-  last_run_error: string | null;
-  last_missed_at: string | null;
-  missed_count: number;
-  failed_count: number;
-  scheduled_for: string | null;
-  fired_at: string | null;
-  missed_at: string | null;
-}
-
-export type CronRunLogStatus = "ok" | "error" | "skipped";
-export type CronRunLogAction =
-  | "fire_started"
-  | "enqueued"
-  | "enqueue_failed"
-  | "blocked"
-  | "dequeued"
-  | "turn_started"
-  | "backend_run_started"
-  | "completed"
-  | "failed"
-  | "cancelled"
-  | "dropped"
-  | "cleared"
-  | "removed"
-  | "pump_failed"
-  | "listener_closed_before_drain"
-  | "finished";
-
-export interface CronRunLogEntry {
-  ts: number;
-  jobId: string;
-  action: CronRunLogAction;
-  status?: CronRunLogStatus;
-  outcome?: CronRunOutcome;
-  reason?: CronRunReason;
-  error?: string;
-  errorClass?: string;
-  errorMessage?: string;
-  summary?: string;
-  agentId?: string;
-  conversationId?: string;
-  cronRunId?: string;
-  runId?: string;
-  backendRunId?: string;
-  batchId?: string;
-  runAtMs?: number;
-  queueItemId?: string;
-  queueLen?: number;
-  queueLenAfter?: number;
-  mergedCount?: number;
-  blockedReason?: string;
-  droppedReason?: string;
-  clearedReason?: string;
-  clearedCount?: number;
-  removedReason?: string;
-  stopReason?: string;
-  schedulerPid?: number;
-  schedulerToken?: string;
-  schedulerStartedAt?: string;
-  scheduledFor?: string | null;
-  firedAt?: string;
-  missedCount?: number;
-  windowStart?: string;
-  windowEnd?: string;
-}
-
-export interface CronRunLogPage {
-  entries: CronRunLogEntry[];
-  total: number;
-  offset: number;
-  limit: number;
-  hasMore: boolean;
-  nextOffset: number | null;
 }
 
 /**

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -96,23 +96,60 @@ export interface CronTask {
 }
 
 export type CronRunLogStatus = "ok" | "error" | "skipped";
+export type CronRunLogAction =
+  | "fire_started"
+  | "enqueued"
+  | "enqueue_failed"
+  | "blocked"
+  | "dequeued"
+  | "turn_started"
+  | "backend_run_started"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "dropped"
+  | "cleared"
+  | "removed"
+  | "pump_failed"
+  | "listener_closed_before_drain"
+  | "finished";
 
 export interface CronRunLogEntry {
   ts: number;
   jobId: string;
-  action: "finished";
+  action: CronRunLogAction;
   status?: CronRunLogStatus;
   outcome?: CronRunOutcome;
   reason?: CronRunReason;
   error?: string;
+  errorClass?: string;
+  errorMessage?: string;
   summary?: string;
   agentId?: string;
   conversationId?: string;
+  cronRunId?: string;
   runId?: string;
+  backendRunId?: string;
+  batchId?: string;
   runAtMs?: number;
   queueItemId?: string;
+  queueLen?: number;
+  queueLenAfter?: number;
+  mergedCount?: number;
+  blockedReason?: string;
+  droppedReason?: string;
+  clearedReason?: string;
+  clearedCount?: number;
+  removedReason?: string;
+  stopReason?: string;
+  schedulerPid?: number;
+  schedulerToken?: string;
+  schedulerStartedAt?: string;
   scheduledFor?: string | null;
   firedAt?: string;
+  missedCount?: number;
+  windowStart?: string;
+  windowEnd?: string;
 }
 
 export interface CronRunLogPage {
@@ -1694,8 +1731,12 @@ export interface CronRunsCommand {
   limit?: number;
   /** Page offset for run-log entries. */
   offset?: number;
-  /** Optional run id filter. */
+  /** Optional generic filter matching public runId, backendRunId, or cronRunId. */
   run_id?: string;
+  /** Optional exact backend run id filter. */
+  backend_run_id?: string;
+  /** Optional exact per-fire cron run id filter. */
+  cron_run_id?: string;
 }
 
 export interface CronTriggerCommand {

--- a/src/websocket/listen-client-concurrency.test.ts
+++ b/src/websocket/listen-client-concurrency.test.ts
@@ -19,8 +19,10 @@ import {
   getReflectionTranscriptPaths,
   getReflectionTranscriptState,
 } from "@/cli/helpers/reflection-transcript";
+import { getCronRunLogPath, readCronRunLogEntries } from "@/cron/run-log";
 import { permissionMode } from "@/permissions/mode";
 import type {
+  CronPromptQueueItem,
   MessageQueueItem,
   ModContinueQueueItem,
   TaskNotificationQueueItem,
@@ -121,13 +123,29 @@ const drainHandlers = new Map<
   string,
   (abortSignal?: AbortSignal) => Promise<DrainResult>
 >();
+const drainRunIdsByConversation = new Map<string, string[]>();
+type DrainChunkCallback = (event: {
+  chunk: Record<string, unknown>;
+  shouldOutput: boolean;
+  errorInfo?: null;
+}) => void;
 const drainStreamWithResumeMock = mock(
   async (
     stream: MockStream,
     _buffers: unknown,
     _refresh: () => void,
     abortSignal?: AbortSignal,
+    _resumeCursor?: unknown,
+    onChunk?: DrainChunkCallback,
   ) => {
+    const runIds = drainRunIdsByConversation.get(stream.conversationId) ?? [];
+    for (const runId of runIds) {
+      onChunk?.({
+        chunk: { run_id: runId },
+        shouldOutput: false,
+        errorInfo: null,
+      });
+    }
     const handler = drainHandlers.get(stream.conversationId);
     if (handler) {
       return handler(abortSignal);
@@ -460,6 +478,7 @@ describe("listen-client multi-worker concurrency", () => {
     conversationMessagesStreamMock.mockClear();
     fetchRunErrorDetailMock.mockClear();
     drainHandlers.clear();
+    drainRunIdsByConversation.clear();
     __listenClientTestUtils.setActiveRuntime(null);
   });
 
@@ -1448,6 +1467,76 @@ describe("listen-client multi-worker concurrency", () => {
     expect(runtime.queueRuntime.peek().map((item) => item.id)).toEqual([
       otherMessageItem.id,
     ]);
+  });
+
+  test("consumeQueuedTurn carries cron run metadata and writes a dequeued lifecycle event", async () => {
+    const originalLettaHome = process.env.LETTA_HOME;
+    const cronHome = await mkdtemp(join(tmpdir(), "letta-cron-turn-"));
+    try {
+      process.env.LETTA_HOME = cronHome;
+      const runtime = __listenClientTestUtils.createRuntime();
+      const cronInput = {
+        kind: "cron_prompt",
+        source: "cron",
+        text: "Scheduled task text",
+        cronTaskId: "task-cron-1",
+        cronRunId: "cron-run-1",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      } satisfies Omit<CronPromptQueueItem, "id" | "enqueuedAt">;
+      const cronItem = runtime.queueRuntime.enqueue(cronInput);
+
+      if (!cronItem) {
+        throw new Error("Expected queued cron item");
+      }
+
+      const consumed = __listenClientTestUtils.consumeQueuedTurn(runtime);
+
+      expect(consumed).not.toBeNull();
+      if (!consumed) {
+        throw new Error("Expected consumed cron turn");
+      }
+      expect(consumed.queuedTurn.cronRuns).toEqual([
+        {
+          cronTaskId: "task-cron-1",
+          cronRunId: "cron-run-1",
+          queueItemId: cronItem.id,
+          batchId: consumed.dequeuedBatch.batchId,
+          agentId: "agent-1",
+          conversationId: "conv-1",
+          enqueuedAt: cronItem.enqueuedAt,
+        },
+      ]);
+      expect(consumed.queuedTurn.messages).toEqual([
+        {
+          role: "user",
+          content: [{ type: "text", text: "Scheduled task text" }],
+        },
+      ]);
+      expect(runtime.queueRuntime.length).toBe(0);
+
+      const entries = readCronRunLogEntries(getCronRunLogPath("task-cron-1"), {
+        jobId: "task-cron-1",
+        limit: 10,
+      });
+      expect(entries).toEqual([
+        expect.objectContaining({
+          action: "dequeued",
+          cronRunId: "cron-run-1",
+          queueItemId: cronItem.id,
+          batchId: consumed.dequeuedBatch.batchId,
+          queueLenAfter: 0,
+          mergedCount: 1,
+        }),
+      ]);
+    } finally {
+      if (originalLettaHome === undefined) {
+        delete process.env.LETTA_HOME;
+      } else {
+        process.env.LETTA_HOME = originalLettaHome;
+      }
+      await rm(cronHome, { recursive: true, force: true });
+    }
   });
 
   test("consumeQueuedTurn builds a user turn from a mod_continue-only batch", () => {
@@ -2494,6 +2583,94 @@ describe("listen-client multi-worker concurrency", () => {
         otid: "cm-user-otid",
       }),
     ]);
+  });
+
+  test("handleIncomingMessage writes cron turn and backend run lifecycle without prompt text", async () => {
+    const originalLettaHome = process.env.LETTA_HOME;
+    const cronHome = await mkdtemp(join(tmpdir(), "letta-cron-lifecycle-"));
+    try {
+      process.env.LETTA_HOME = cronHome;
+      const agentId = "agent-cron-lifecycle";
+      const conversationId = "conv-cron-lifecycle";
+      const listener = __listenClientTestUtils.createListenerRuntime();
+      const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
+        listener,
+        agentId,
+        conversationId,
+      );
+      const socket = new MockSocket();
+      drainRunIdsByConversation.set(conversationId, ["backend-run-cron-1"]);
+
+      await __listenClientTestUtils.handleIncomingMessage(
+        {
+          type: "message",
+          agentId,
+          conversationId,
+          cronRuns: [
+            {
+              cronTaskId: "task-cron-lifecycle",
+              cronRunId: "cron-run-lifecycle",
+              queueItemId: "q-cron-lifecycle",
+              batchId: "batch-cron-lifecycle",
+              agentId,
+              conversationId,
+            },
+          ],
+          messages: [
+            {
+              role: "user",
+              content: "secret prompt text must not be logged",
+            },
+          ],
+        },
+        socket as unknown as WebSocket,
+        runtime,
+        undefined,
+        "conn-cron-lifecycle",
+        "batch-cron-lifecycle",
+      );
+
+      const logPath = getCronRunLogPath("task-cron-lifecycle");
+      const entries = readCronRunLogEntries(logPath, {
+        jobId: "task-cron-lifecycle",
+        limit: 10,
+      });
+      expect(entries.map((entry) => entry.action)).toEqual([
+        "turn_started",
+        "backend_run_started",
+        "completed",
+      ]);
+      expect(entries).toEqual([
+        expect.objectContaining({
+          action: "turn_started",
+          cronRunId: "cron-run-lifecycle",
+          queueItemId: "q-cron-lifecycle",
+          batchId: "batch-cron-lifecycle",
+        }),
+        expect.objectContaining({
+          action: "backend_run_started",
+          cronRunId: "cron-run-lifecycle",
+          backendRunId: "backend-run-cron-1",
+          runId: "backend-run-cron-1",
+        }),
+        expect.objectContaining({
+          action: "completed",
+          cronRunId: "cron-run-lifecycle",
+          backendRunId: "backend-run-cron-1",
+          runId: "backend-run-cron-1",
+          stopReason: "end_turn",
+        }),
+      ]);
+      const rawLog = await readFile(logPath, "utf-8");
+      expect(rawLog).not.toContain("secret prompt text");
+    } finally {
+      if (originalLettaHome === undefined) {
+        delete process.env.LETTA_HOME;
+      } else {
+        process.env.LETTA_HOME = originalLettaHome;
+      }
+      await rm(cronHome, { recursive: true, force: true });
+    }
   });
 
   test("secret_apply refreshes the next user payload for the same conversation", async () => {

--- a/src/websocket/listen-client-concurrency.test.ts
+++ b/src/websocket/listen-client-concurrency.test.ts
@@ -19,10 +19,8 @@ import {
   getReflectionTranscriptPaths,
   getReflectionTranscriptState,
 } from "@/cli/helpers/reflection-transcript";
-import { getCronRunLogPath, readCronRunLogEntries } from "@/cron/run-log";
 import { permissionMode } from "@/permissions/mode";
 import type {
-  CronPromptQueueItem,
   MessageQueueItem,
   ModContinueQueueItem,
   TaskNotificationQueueItem,
@@ -123,29 +121,13 @@ const drainHandlers = new Map<
   string,
   (abortSignal?: AbortSignal) => Promise<DrainResult>
 >();
-const drainRunIdsByConversation = new Map<string, string[]>();
-type DrainChunkCallback = (event: {
-  chunk: Record<string, unknown>;
-  shouldOutput: boolean;
-  errorInfo?: null;
-}) => void;
 const drainStreamWithResumeMock = mock(
   async (
     stream: MockStream,
     _buffers: unknown,
     _refresh: () => void,
     abortSignal?: AbortSignal,
-    _resumeCursor?: unknown,
-    onChunk?: DrainChunkCallback,
   ) => {
-    const runIds = drainRunIdsByConversation.get(stream.conversationId) ?? [];
-    for (const runId of runIds) {
-      onChunk?.({
-        chunk: { run_id: runId },
-        shouldOutput: false,
-        errorInfo: null,
-      });
-    }
     const handler = drainHandlers.get(stream.conversationId);
     if (handler) {
       return handler(abortSignal);
@@ -478,7 +460,6 @@ describe("listen-client multi-worker concurrency", () => {
     conversationMessagesStreamMock.mockClear();
     fetchRunErrorDetailMock.mockClear();
     drainHandlers.clear();
-    drainRunIdsByConversation.clear();
     __listenClientTestUtils.setActiveRuntime(null);
   });
 
@@ -1467,76 +1448,6 @@ describe("listen-client multi-worker concurrency", () => {
     expect(runtime.queueRuntime.peek().map((item) => item.id)).toEqual([
       otherMessageItem.id,
     ]);
-  });
-
-  test("consumeQueuedTurn carries cron run metadata and writes a dequeued lifecycle event", async () => {
-    const originalLettaHome = process.env.LETTA_HOME;
-    const cronHome = await mkdtemp(join(tmpdir(), "letta-cron-turn-"));
-    try {
-      process.env.LETTA_HOME = cronHome;
-      const runtime = __listenClientTestUtils.createRuntime();
-      const cronInput = {
-        kind: "cron_prompt",
-        source: "cron",
-        text: "Scheduled task text",
-        cronTaskId: "task-cron-1",
-        cronRunId: "cron-run-1",
-        agentId: "agent-1",
-        conversationId: "conv-1",
-      } satisfies Omit<CronPromptQueueItem, "id" | "enqueuedAt">;
-      const cronItem = runtime.queueRuntime.enqueue(cronInput);
-
-      if (!cronItem) {
-        throw new Error("Expected queued cron item");
-      }
-
-      const consumed = __listenClientTestUtils.consumeQueuedTurn(runtime);
-
-      expect(consumed).not.toBeNull();
-      if (!consumed) {
-        throw new Error("Expected consumed cron turn");
-      }
-      expect(consumed.queuedTurn.cronRuns).toEqual([
-        {
-          cronTaskId: "task-cron-1",
-          cronRunId: "cron-run-1",
-          queueItemId: cronItem.id,
-          batchId: consumed.dequeuedBatch.batchId,
-          agentId: "agent-1",
-          conversationId: "conv-1",
-          enqueuedAt: cronItem.enqueuedAt,
-        },
-      ]);
-      expect(consumed.queuedTurn.messages).toEqual([
-        {
-          role: "user",
-          content: [{ type: "text", text: "Scheduled task text" }],
-        },
-      ]);
-      expect(runtime.queueRuntime.length).toBe(0);
-
-      const entries = readCronRunLogEntries(getCronRunLogPath("task-cron-1"), {
-        jobId: "task-cron-1",
-        limit: 10,
-      });
-      expect(entries).toEqual([
-        expect.objectContaining({
-          action: "dequeued",
-          cronRunId: "cron-run-1",
-          queueItemId: cronItem.id,
-          batchId: consumed.dequeuedBatch.batchId,
-          queueLenAfter: 0,
-          mergedCount: 1,
-        }),
-      ]);
-    } finally {
-      if (originalLettaHome === undefined) {
-        delete process.env.LETTA_HOME;
-      } else {
-        process.env.LETTA_HOME = originalLettaHome;
-      }
-      await rm(cronHome, { recursive: true, force: true });
-    }
   });
 
   test("consumeQueuedTurn builds a user turn from a mod_continue-only batch", () => {
@@ -2583,94 +2494,6 @@ describe("listen-client multi-worker concurrency", () => {
         otid: "cm-user-otid",
       }),
     ]);
-  });
-
-  test("handleIncomingMessage writes cron turn and backend run lifecycle without prompt text", async () => {
-    const originalLettaHome = process.env.LETTA_HOME;
-    const cronHome = await mkdtemp(join(tmpdir(), "letta-cron-lifecycle-"));
-    try {
-      process.env.LETTA_HOME = cronHome;
-      const agentId = "agent-cron-lifecycle";
-      const conversationId = "conv-cron-lifecycle";
-      const listener = __listenClientTestUtils.createListenerRuntime();
-      const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
-        listener,
-        agentId,
-        conversationId,
-      );
-      const socket = new MockSocket();
-      drainRunIdsByConversation.set(conversationId, ["backend-run-cron-1"]);
-
-      await __listenClientTestUtils.handleIncomingMessage(
-        {
-          type: "message",
-          agentId,
-          conversationId,
-          cronRuns: [
-            {
-              cronTaskId: "task-cron-lifecycle",
-              cronRunId: "cron-run-lifecycle",
-              queueItemId: "q-cron-lifecycle",
-              batchId: "batch-cron-lifecycle",
-              agentId,
-              conversationId,
-            },
-          ],
-          messages: [
-            {
-              role: "user",
-              content: "secret prompt text must not be logged",
-            },
-          ],
-        },
-        socket as unknown as WebSocket,
-        runtime,
-        undefined,
-        "conn-cron-lifecycle",
-        "batch-cron-lifecycle",
-      );
-
-      const logPath = getCronRunLogPath("task-cron-lifecycle");
-      const entries = readCronRunLogEntries(logPath, {
-        jobId: "task-cron-lifecycle",
-        limit: 10,
-      });
-      expect(entries.map((entry) => entry.action)).toEqual([
-        "turn_started",
-        "backend_run_started",
-        "completed",
-      ]);
-      expect(entries).toEqual([
-        expect.objectContaining({
-          action: "turn_started",
-          cronRunId: "cron-run-lifecycle",
-          queueItemId: "q-cron-lifecycle",
-          batchId: "batch-cron-lifecycle",
-        }),
-        expect.objectContaining({
-          action: "backend_run_started",
-          cronRunId: "cron-run-lifecycle",
-          backendRunId: "backend-run-cron-1",
-          runId: "backend-run-cron-1",
-        }),
-        expect.objectContaining({
-          action: "completed",
-          cronRunId: "cron-run-lifecycle",
-          backendRunId: "backend-run-cron-1",
-          runId: "backend-run-cron-1",
-          stopReason: "end_turn",
-        }),
-      ]);
-      const rawLog = await readFile(logPath, "utf-8");
-      expect(rawLog).not.toContain("secret prompt text");
-    } finally {
-      if (originalLettaHome === undefined) {
-        delete process.env.LETTA_HOME;
-      } else {
-        process.env.LETTA_HOME = originalLettaHome;
-      }
-      await rm(cronHome, { recursive: true, force: true });
-    }
   });
 
   test("secret_apply refreshes the next user payload for the same conversation", async () => {

--- a/src/websocket/listener/commands/cron.ts
+++ b/src/websocket/listener/commands/cron.ts
@@ -200,6 +200,8 @@ export async function handleCronCommand(
           limit: parsed.limit,
           offset: parsed.offset,
           runId: parsed.run_id,
+          backendRunId: parsed.backend_run_id,
+          cronRunId: parsed.cron_run_id,
         },
       );
       safeSocketSend(

--- a/src/websocket/listener/conversation-runtime.ts
+++ b/src/websocket/listener/conversation-runtime.ts
@@ -1,6 +1,10 @@
 import { QueueRuntime } from "@/queue/queue-runtime";
 import { scheduleQueueEmit } from "./protocol-outbound";
-import { getQueueItemScope, getQueueItemsScope } from "./queue";
+import {
+  getQueueItemScope,
+  getQueueItemsScope,
+  recordCronQueueLifecycleForItems,
+} from "./queue";
 import {
   evictConversationRuntimeIfIdle,
   getOrCreateConversationRuntime,
@@ -30,14 +34,39 @@ export function ensureConversationQueueRuntime(
           conversation_id: runtime.conversationId,
         });
       },
-      onCleared: (_reason, _clearedCount, items) => {
+      onCleared: (reason, clearedCount, items) => {
         runtime.pendingTurns = 0;
+        recordCronQueueLifecycleForItems(items, {
+          action: "cleared",
+          status: "skipped",
+          clearedReason: reason,
+          clearedCount,
+          queueLenAfter: 0,
+        });
         scheduleQueueEmit(listener, getQueueItemsScope(items));
         evictConversationRuntimeIfIdle(runtime);
       },
-      onDropped: (item, _reason, queueLen) => {
+      onDropped: (item, reason, queueLen) => {
         runtime.pendingTurns = queueLen;
         runtime.queuedMessagesByItemId.delete(item.id);
+        recordCronQueueLifecycleForItems([item], {
+          action: "dropped",
+          status: "skipped",
+          droppedReason: reason,
+          queueLen,
+        });
+        scheduleQueueEmit(listener, getQueueItemScope(item));
+        evictConversationRuntimeIfIdle(runtime);
+      },
+      onRemoved: (item, queueLen) => {
+        runtime.pendingTurns = queueLen;
+        runtime.queuedMessagesByItemId.delete(item.id);
+        recordCronQueueLifecycleForItems([item], {
+          action: "removed",
+          status: "skipped",
+          removedReason: "explicit_remove",
+          queueLen,
+        });
         scheduleQueueEmit(listener, getQueueItemScope(item));
         evictConversationRuntimeIfIdle(runtime);
       },

--- a/src/websocket/listener/cron-run-lifecycle.test.ts
+++ b/src/websocket/listener/cron-run-lifecycle.test.ts
@@ -20,8 +20,8 @@ import { sharedReminderProviders } from "@/reminders/engine";
 import { settingsManager } from "@/settings-manager";
 import { clearTools } from "@/tools/manager";
 import { injectQueuedSkillContent } from "@/websocket/listener/skill-injection";
-import { __listenerTurnIoTestUtils } from "@/websocket/listener/turn-io";
 import type { ConversationRuntime } from "@/websocket/listener/types";
+import { __listenerTurnIoTestUtils } from "./turn-io";
 
 type MockStream = { conversationId: string; agentId?: string };
 type DrainResult = {

--- a/src/websocket/listener/cron-run-lifecycle.test.ts
+++ b/src/websocket/listener/cron-run-lifecycle.test.ts
@@ -40,34 +40,33 @@ const defaultDrainResult: DrainResult = {
   approvals: [],
   apiDurationMs: 0,
 };
-const sendMessageStreamMock = mock(
-  async (
-    conversationId: string,
-    _messages: unknown[],
-    opts?: { agentId?: string },
-  ): Promise<MockStream> => ({ conversationId, agentId: opts?.agentId }),
-);
+async function sendMessageStreamForTest(
+  conversationId: string,
+  _messages: unknown[],
+  opts?: { agentId?: string },
+): Promise<MockStream> {
+  return { conversationId, agentId: opts?.agentId };
+}
+
 const drainRunIdsByConversation = new Map<string, string[]>();
-const drainStreamWithResumeMock = mock(
-  async (
-    stream: MockStream,
-    _buffers: unknown,
-    _refresh: () => void,
-    _abortSignal?: AbortSignal,
-    _resumeCursor?: unknown,
-    onChunk?: DrainChunkCallback,
-  ) => {
-    for (const runId of drainRunIdsByConversation.get(stream.conversationId) ??
-      []) {
-      onChunk?.({
-        chunk: { run_id: runId },
-        shouldOutput: false,
-        errorInfo: null,
-      });
-    }
-    return defaultDrainResult;
-  },
-);
+async function drainStreamWithResumeForTest(
+  stream: MockStream,
+  _buffers: unknown,
+  _refresh: () => void,
+  _abortSignal?: AbortSignal,
+  _resumeCursor?: unknown,
+  onChunk?: DrainChunkCallback,
+): Promise<DrainResult> {
+  for (const runId of drainRunIdsByConversation.get(stream.conversationId) ??
+    []) {
+    onChunk?.({
+      chunk: { run_id: runId },
+      shouldOutput: false,
+      errorInfo: null,
+    });
+  }
+  return defaultDrainResult;
+}
 const retrieveAgentMock = mock(async (agentId: string) => ({
   id: agentId,
   model: "anthropic/claude-sonnet-4",
@@ -137,16 +136,14 @@ describe("cron listener run lifecycle", () => {
     clearTools();
     permissionMode.reset();
     drainRunIdsByConversation.clear();
-    sendMessageStreamMock.mockClear();
-    drainStreamWithResumeMock.mockClear();
     retrieveAgentMock.mockClear();
     retrieveConversationMock.mockClear();
     getClientMock.mockClear();
     __listenerTurnIoTestUtils.setSendMessageStreamForTests(
-      sendMessageStreamMock as unknown as typeof sendMessageStream,
+      sendMessageStreamForTest as unknown as typeof sendMessageStream,
     );
     __listenerTurnIoTestUtils.setDrainStreamWithResumeForTests(
-      drainStreamWithResumeMock as unknown as typeof drainStreamWithResume,
+      drainStreamWithResumeForTest as unknown as typeof drainStreamWithResume,
     );
     __listenClientTestUtils.setActiveRuntime(null);
   });
@@ -165,8 +162,6 @@ describe("cron listener run lifecycle", () => {
   });
 
   afterAll(() => {
-    sendMessageStreamMock.mockReset();
-    drainStreamWithResumeMock.mockReset();
     __listenerTurnIoTestUtils.resetForTests();
     mock.restore();
   });

--- a/src/websocket/listener/cron-run-lifecycle.test.ts
+++ b/src/websocket/listener/cron-run-lifecycle.test.ts
@@ -11,6 +11,8 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import WebSocket from "ws";
+import type { sendMessageStream } from "@/agent/message";
+import type { drainStreamWithResume } from "@/cli/helpers/stream";
 import { getCronRunLogPath, readCronRunLogEntries } from "@/cron/run-log";
 import { permissionMode } from "@/permissions/mode";
 import type { CronPromptQueueItem } from "@/queue/queue-runtime";
@@ -18,6 +20,7 @@ import { sharedReminderProviders } from "@/reminders/engine";
 import { settingsManager } from "@/settings-manager";
 import { clearTools } from "@/tools/manager";
 import { injectQueuedSkillContent } from "@/websocket/listener/skill-injection";
+import { __listenerTurnIoTestUtils } from "@/websocket/listener/turn-io";
 import type { ConversationRuntime } from "@/websocket/listener/types";
 
 type MockStream = { conversationId: string; agentId?: string };
@@ -44,7 +47,6 @@ const sendMessageStreamMock = mock(
     opts?: { agentId?: string },
   ): Promise<MockStream> => ({ conversationId, agentId: opts?.agentId }),
 );
-const getStreamToolContextIdMock = mock(() => null);
 const drainRunIdsByConversation = new Map<string, string[]>();
 const drainStreamWithResumeMock = mock(
   async (
@@ -99,40 +101,6 @@ const getClientMock = mock(async () => ({
     })),
   },
 }));
-const realStreamModule = await import("@/cli/helpers/stream");
-const realDrainStreamWithResume = realStreamModule.drainStreamWithResume;
-const realAgentMessageModule = await import("@/agent/message");
-const realSendMessageStream = realAgentMessageModule.sendMessageStream;
-const realGetStreamToolContextId =
-  realAgentMessageModule.getStreamToolContextId;
-
-mock.module("@/agent/message", () => ({
-  sendMessageStream: sendMessageStreamMock,
-  getStreamToolContextId: getStreamToolContextIdMock,
-  getStreamRequestContext: () => undefined,
-  getStreamRequestStartTime: () => undefined,
-  buildConversationMessagesCreateRequestBody: (
-    conversationId: string,
-    messages: unknown[],
-    opts?: { agentId?: string; streamTokens?: boolean; background?: boolean },
-  ) => ({
-    messages,
-    streaming: true,
-    stream_tokens: opts?.streamTokens ?? true,
-    include_pings: true,
-    background: opts?.background ?? true,
-    client_skills: [],
-    client_tools: [],
-    include_compaction_messages: true,
-    ...(conversationId === "default" && opts?.agentId
-      ? { agent_id: opts.agentId }
-      : {}),
-  }),
-}));
-mock.module("@/cli/helpers/stream", () => ({
-  ...realStreamModule,
-  drainStreamWithResume: drainStreamWithResumeMock,
-}));
 mock.module("@/backend/api/client", () => ({
   getClient: getClientMock,
   getServerUrl: () => "https://example.test",
@@ -174,6 +142,12 @@ describe("cron listener run lifecycle", () => {
     retrieveAgentMock.mockClear();
     retrieveConversationMock.mockClear();
     getClientMock.mockClear();
+    __listenerTurnIoTestUtils.setSendMessageStreamForTests(
+      sendMessageStreamMock as unknown as typeof sendMessageStream,
+    );
+    __listenerTurnIoTestUtils.setDrainStreamWithResumeForTests(
+      drainStreamWithResumeMock as unknown as typeof drainStreamWithResume,
+    );
     __listenClientTestUtils.setActiveRuntime(null);
   });
 
@@ -186,23 +160,14 @@ describe("cron listener run lifecycle", () => {
       originalGetLocalProjectSettings;
     clearTools();
     permissionMode.reset();
+    __listenerTurnIoTestUtils.resetForTests();
     __listenClientTestUtils.setActiveRuntime(null);
   });
 
   afterAll(() => {
     sendMessageStreamMock.mockReset();
-    // biome-ignore lint/suspicious/noExplicitAny: restoring captured implementation behind mock.module
-    (sendMessageStreamMock as any).mockImplementation(realSendMessageStream);
-    getStreamToolContextIdMock.mockReset();
-    // biome-ignore lint/suspicious/noExplicitAny: restoring captured implementation behind mock.module
-    (getStreamToolContextIdMock as any).mockImplementation(
-      realGetStreamToolContextId,
-    );
     drainStreamWithResumeMock.mockReset();
-    // biome-ignore lint/suspicious/noExplicitAny: restoring captured implementation behind mock.module
-    (drainStreamWithResumeMock as any).mockImplementation(
-      realDrainStreamWithResume,
-    );
+    __listenerTurnIoTestUtils.resetForTests();
     mock.restore();
   });
 

--- a/src/websocket/listener/cron-run-lifecycle.test.ts
+++ b/src/websocket/listener/cron-run-lifecycle.test.ts
@@ -20,8 +20,9 @@ import { sharedReminderProviders } from "@/reminders/engine";
 import { settingsManager } from "@/settings-manager";
 import { clearTools } from "@/tools/manager";
 import { injectQueuedSkillContent } from "@/websocket/listener/skill-injection";
+import { __listenerTurnIoTestUtils as aliasTurnIoTestUtils } from "@/websocket/listener/turn-io";
 import type { ConversationRuntime } from "@/websocket/listener/types";
-import { __listenerTurnIoTestUtils } from "./turn-io";
+import { __listenerTurnIoTestUtils as relativeTurnIoTestUtils } from "./turn-io";
 
 type MockStream = { conversationId: string; agentId?: string };
 type DrainResult = {
@@ -139,12 +140,17 @@ describe("cron listener run lifecycle", () => {
     retrieveAgentMock.mockClear();
     retrieveConversationMock.mockClear();
     getClientMock.mockClear();
-    __listenerTurnIoTestUtils.setSendMessageStreamForTests(
-      sendMessageStreamForTest as unknown as typeof sendMessageStream,
-    );
-    __listenerTurnIoTestUtils.setDrainStreamWithResumeForTests(
-      drainStreamWithResumeForTest as unknown as typeof drainStreamWithResume,
-    );
+    for (const turnIoTestUtils of [
+      aliasTurnIoTestUtils,
+      relativeTurnIoTestUtils,
+    ]) {
+      turnIoTestUtils.setSendMessageStreamForTests(
+        sendMessageStreamForTest as unknown as typeof sendMessageStream,
+      );
+      turnIoTestUtils.setDrainStreamWithResumeForTests(
+        drainStreamWithResumeForTest as unknown as typeof drainStreamWithResume,
+      );
+    }
     __listenClientTestUtils.setActiveRuntime(null);
   });
 
@@ -157,12 +163,22 @@ describe("cron listener run lifecycle", () => {
       originalGetLocalProjectSettings;
     clearTools();
     permissionMode.reset();
-    __listenerTurnIoTestUtils.resetForTests();
+    for (const turnIoTestUtils of [
+      aliasTurnIoTestUtils,
+      relativeTurnIoTestUtils,
+    ]) {
+      turnIoTestUtils.resetForTests();
+    }
     __listenClientTestUtils.setActiveRuntime(null);
   });
 
   afterAll(() => {
-    __listenerTurnIoTestUtils.resetForTests();
+    for (const turnIoTestUtils of [
+      aliasTurnIoTestUtils,
+      relativeTurnIoTestUtils,
+    ]) {
+      turnIoTestUtils.resetForTests();
+    }
     mock.restore();
   });
 

--- a/src/websocket/listener/cron-run-lifecycle.test.ts
+++ b/src/websocket/listener/cron-run-lifecycle.test.ts
@@ -1,0 +1,351 @@
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import WebSocket from "ws";
+import { getCronRunLogPath, readCronRunLogEntries } from "@/cron/run-log";
+import { permissionMode } from "@/permissions/mode";
+import type { CronPromptQueueItem } from "@/queue/queue-runtime";
+import { sharedReminderProviders } from "@/reminders/engine";
+import { settingsManager } from "@/settings-manager";
+import { clearTools } from "@/tools/manager";
+import { injectQueuedSkillContent } from "@/websocket/listener/skill-injection";
+import type { ConversationRuntime } from "@/websocket/listener/types";
+
+type MockStream = { conversationId: string; agentId?: string };
+type DrainResult = {
+  stopReason: string;
+  approvals?: [];
+  apiDurationMs: number;
+};
+type DrainChunkCallback = (event: {
+  chunk: Record<string, unknown>;
+  shouldOutput: boolean;
+  errorInfo?: null;
+}) => void;
+
+const defaultDrainResult: DrainResult = {
+  stopReason: "end_turn",
+  approvals: [],
+  apiDurationMs: 0,
+};
+const sendMessageStreamMock = mock(
+  async (
+    conversationId: string,
+    _messages: unknown[],
+    opts?: { agentId?: string },
+  ): Promise<MockStream> => ({ conversationId, agentId: opts?.agentId }),
+);
+const getStreamToolContextIdMock = mock(() => null);
+const drainRunIdsByConversation = new Map<string, string[]>();
+const drainStreamWithResumeMock = mock(
+  async (
+    stream: MockStream,
+    _buffers: unknown,
+    _refresh: () => void,
+    _abortSignal?: AbortSignal,
+    _resumeCursor?: unknown,
+    onChunk?: DrainChunkCallback,
+  ) => {
+    for (const runId of drainRunIdsByConversation.get(stream.conversationId) ??
+      []) {
+      onChunk?.({
+        chunk: { run_id: runId },
+        shouldOutput: false,
+        errorInfo: null,
+      });
+    }
+    return defaultDrainResult;
+  },
+);
+const retrieveAgentMock = mock(async (agentId: string) => ({
+  id: agentId,
+  model: "anthropic/claude-sonnet-4",
+}));
+const retrieveConversationMock = mock(async (conversationId: string) => ({
+  id: conversationId,
+  model: null,
+  in_context_message_ids: [],
+}));
+const getClientMock = mock(async () => ({
+  agents: {
+    retrieve: retrieveAgentMock,
+    messages: { list: mock(async () => ({ getPaginatedItems: () => [] })) },
+  },
+  conversations: {
+    retrieve: retrieveConversationMock,
+    cancel: mock(async () => {}),
+    messages: {
+      stream: mock(
+        async (conversationId: string): Promise<MockStream> => ({
+          conversationId,
+        }),
+      ),
+    },
+  },
+  messages: { retrieve: mock(async () => null) },
+  runs: {
+    retrieve: mock(async (runId: string) => ({
+      id: runId,
+      status: "completed",
+    })),
+  },
+}));
+const realStreamModule = await import("@/cli/helpers/stream");
+const realDrainStreamWithResume = realStreamModule.drainStreamWithResume;
+const realAgentMessageModule = await import("@/agent/message");
+const realSendMessageStream = realAgentMessageModule.sendMessageStream;
+const realGetStreamToolContextId =
+  realAgentMessageModule.getStreamToolContextId;
+
+mock.module("@/agent/message", () => ({
+  sendMessageStream: sendMessageStreamMock,
+  getStreamToolContextId: getStreamToolContextIdMock,
+  getStreamRequestContext: () => undefined,
+  getStreamRequestStartTime: () => undefined,
+  buildConversationMessagesCreateRequestBody: (
+    conversationId: string,
+    messages: unknown[],
+    opts?: { agentId?: string; streamTokens?: boolean; background?: boolean },
+  ) => ({
+    messages,
+    streaming: true,
+    stream_tokens: opts?.streamTokens ?? true,
+    include_pings: true,
+    background: opts?.background ?? true,
+    client_skills: [],
+    client_tools: [],
+    include_compaction_messages: true,
+    ...(conversationId === "default" && opts?.agentId
+      ? { agent_id: opts.agentId }
+      : {}),
+  }),
+}));
+mock.module("@/cli/helpers/stream", () => ({
+  ...realStreamModule,
+  drainStreamWithResume: drainStreamWithResumeMock,
+}));
+mock.module("@/backend/api/client", () => ({
+  getClient: getClientMock,
+  getServerUrl: () => "https://example.test",
+  clearLastSDKDiagnostic: () => {},
+  consumeLastSDKDiagnostic: () => null,
+}));
+
+const listenClientModule = await import("@/websocket/listen-client");
+const { __listenClientTestUtils } = listenClientModule;
+
+class MockSocket {
+  readyState = WebSocket.OPEN;
+  sentPayloads: string[] = [];
+  send(data: string): void {
+    this.sentPayloads.push(data);
+  }
+}
+
+const origSessionContext = sharedReminderProviders["session-context"];
+const origAgentInfo = sharedReminderProviders["agent-info"];
+const originalGetLocalProjectSettings = settingsManager.getLocalProjectSettings;
+const originalGetSettings = settingsManager.getSettings;
+
+describe("cron listener run lifecycle", () => {
+  beforeEach(() => {
+    sharedReminderProviders["session-context"] = async () => null;
+    sharedReminderProviders["agent-info"] = async () => null;
+    (settingsManager as typeof settingsManager).getSettings = (() => ({
+      memoryReminderInterval: null,
+    })) as typeof settingsManager.getSettings;
+    (settingsManager as typeof settingsManager).getLocalProjectSettings = () =>
+      ({}) as ReturnType<typeof settingsManager.getLocalProjectSettings>;
+    injectQueuedSkillContent([]);
+    clearTools();
+    permissionMode.reset();
+    drainRunIdsByConversation.clear();
+    sendMessageStreamMock.mockClear();
+    drainStreamWithResumeMock.mockClear();
+    retrieveAgentMock.mockClear();
+    retrieveConversationMock.mockClear();
+    getClientMock.mockClear();
+    __listenClientTestUtils.setActiveRuntime(null);
+  });
+
+  afterEach(() => {
+    sharedReminderProviders["session-context"] = origSessionContext;
+    sharedReminderProviders["agent-info"] = origAgentInfo;
+    (settingsManager as typeof settingsManager).getSettings =
+      originalGetSettings;
+    (settingsManager as typeof settingsManager).getLocalProjectSettings =
+      originalGetLocalProjectSettings;
+    clearTools();
+    permissionMode.reset();
+    __listenClientTestUtils.setActiveRuntime(null);
+  });
+
+  afterAll(() => {
+    sendMessageStreamMock.mockReset();
+    // biome-ignore lint/suspicious/noExplicitAny: restoring captured implementation behind mock.module
+    (sendMessageStreamMock as any).mockImplementation(realSendMessageStream);
+    getStreamToolContextIdMock.mockReset();
+    // biome-ignore lint/suspicious/noExplicitAny: restoring captured implementation behind mock.module
+    (getStreamToolContextIdMock as any).mockImplementation(
+      realGetStreamToolContextId,
+    );
+    drainStreamWithResumeMock.mockReset();
+    // biome-ignore lint/suspicious/noExplicitAny: restoring captured implementation behind mock.module
+    (drainStreamWithResumeMock as any).mockImplementation(
+      realDrainStreamWithResume,
+    );
+    mock.restore();
+  });
+
+  test("consumeQueuedTurn carries cron metadata and logs dequeue", async () => {
+    const originalLettaHome = process.env.LETTA_HOME;
+    const cronHome = await mkdtemp(join(tmpdir(), "letta-cron-turn-"));
+    try {
+      process.env.LETTA_HOME = cronHome;
+      const runtime = __listenClientTestUtils.createRuntime();
+      const cronInput = {
+        kind: "cron_prompt",
+        source: "cron",
+        text: "Scheduled task text",
+        cronTaskId: "task-cron-1",
+        cronRunId: "cron-run-1",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      } satisfies Omit<CronPromptQueueItem, "id" | "enqueuedAt">;
+      const cronItem = runtime.queueRuntime.enqueue(cronInput);
+      if (!cronItem) throw new Error("Expected queued cron item");
+
+      const consumed = __listenClientTestUtils.consumeQueuedTurn(runtime);
+      if (!consumed) throw new Error("Expected consumed cron turn");
+      expect(consumed.queuedTurn.cronRuns).toEqual([
+        {
+          cronTaskId: "task-cron-1",
+          cronRunId: "cron-run-1",
+          queueItemId: cronItem.id,
+          batchId: consumed.dequeuedBatch.batchId,
+          agentId: "agent-1",
+          conversationId: "conv-1",
+          enqueuedAt: cronItem.enqueuedAt,
+        },
+      ]);
+      expect(consumed.queuedTurn.messages).toEqual([
+        {
+          role: "user",
+          content: [{ type: "text", text: "Scheduled task text" }],
+        },
+      ]);
+      expect(runtime.queueRuntime.length).toBe(0);
+      expect(
+        readCronRunLogEntries(getCronRunLogPath("task-cron-1"), {
+          jobId: "task-cron-1",
+          limit: 10,
+        }),
+      ).toEqual([
+        expect.objectContaining({
+          action: "dequeued",
+          cronRunId: "cron-run-1",
+          queueItemId: cronItem.id,
+          batchId: consumed.dequeuedBatch.batchId,
+          queueLenAfter: 0,
+          mergedCount: 1,
+        }),
+      ]);
+    } finally {
+      if (originalLettaHome === undefined) delete process.env.LETTA_HOME;
+      else process.env.LETTA_HOME = originalLettaHome;
+      await rm(cronHome, { recursive: true, force: true });
+    }
+  });
+
+  test("handleIncomingMessage logs cron turn lifecycle without prompt text", async () => {
+    const originalLettaHome = process.env.LETTA_HOME;
+    const cronHome = await mkdtemp(join(tmpdir(), "letta-cron-lifecycle-"));
+    try {
+      process.env.LETTA_HOME = cronHome;
+      const agentId = "agent-cron-lifecycle";
+      const conversationId = "conv-cron-lifecycle";
+      const listener = __listenClientTestUtils.createListenerRuntime();
+      const runtime: ConversationRuntime =
+        __listenClientTestUtils.getOrCreateConversationRuntime(
+          listener,
+          agentId,
+          conversationId,
+        );
+      drainRunIdsByConversation.set(conversationId, ["backend-run-cron-1"]);
+
+      await __listenClientTestUtils.handleIncomingMessage(
+        {
+          type: "message",
+          agentId,
+          conversationId,
+          cronRuns: [
+            {
+              cronTaskId: "task-cron-lifecycle",
+              cronRunId: "cron-run-lifecycle",
+              queueItemId: "q-cron-lifecycle",
+              batchId: "batch-cron-lifecycle",
+              agentId,
+              conversationId,
+            },
+          ],
+          messages: [
+            { role: "user", content: "secret prompt text must not be logged" },
+          ],
+        },
+        new MockSocket() as unknown as WebSocket,
+        runtime,
+        undefined,
+        "conn-cron-lifecycle",
+        "batch-cron-lifecycle",
+      );
+
+      const logPath = getCronRunLogPath("task-cron-lifecycle");
+      const entries = readCronRunLogEntries(logPath, {
+        jobId: "task-cron-lifecycle",
+        limit: 10,
+      });
+      expect(entries.map((entry) => entry.action)).toEqual([
+        "turn_started",
+        "backend_run_started",
+        "completed",
+      ]);
+      expect(entries).toEqual([
+        expect.objectContaining({
+          action: "turn_started",
+          cronRunId: "cron-run-lifecycle",
+          queueItemId: "q-cron-lifecycle",
+          batchId: "batch-cron-lifecycle",
+        }),
+        expect.objectContaining({
+          action: "backend_run_started",
+          cronRunId: "cron-run-lifecycle",
+          backendRunId: "backend-run-cron-1",
+          runId: "backend-run-cron-1",
+        }),
+        expect.objectContaining({
+          action: "completed",
+          cronRunId: "cron-run-lifecycle",
+          backendRunId: "backend-run-cron-1",
+          runId: "backend-run-cron-1",
+          stopReason: "end_turn",
+        }),
+      ]);
+      expect(await readFile(logPath, "utf-8")).not.toContain(
+        "secret prompt text",
+      );
+    } finally {
+      if (originalLettaHome === undefined) delete process.env.LETTA_HOME;
+      else process.env.LETTA_HOME = originalLettaHome;
+      await rm(cronHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/websocket/listener/cron-run-lifecycle.ts
+++ b/src/websocket/listener/cron-run-lifecycle.ts
@@ -1,0 +1,203 @@
+import {
+  type CronRunLogAction,
+  type CronRunLogRunEntryInput,
+  safeAppendCronRunLogForCronRun,
+} from "@/cron/run-log";
+import type { StopReasonType } from "@/types/protocol_v2";
+import type { IncomingMessage } from "./types";
+
+type TerminalCronRunLogAction = Extract<
+  CronRunLogAction,
+  "completed" | "failed" | "cancelled"
+>;
+
+function withBackendRunId(
+  backendRunId: string | null | undefined,
+): Pick<CronRunLogRunEntryInput, "runId" | "backendRunId"> {
+  return backendRunId ? { runId: backendRunId, backendRunId } : {};
+}
+
+export function createCronTurnRunLogger(params: {
+  msg: IncomingMessage;
+  agentId?: string;
+  conversationId: string;
+  getBatchId: () => string;
+  getBackendRunId: () => string | undefined;
+  isCancellationRequested: () => boolean;
+}) {
+  const loggedBackendRunIds = new Set<string>();
+  let terminalLogged = false;
+
+  const recordLifecycle = (
+    action: CronRunLogAction,
+    entry: Omit<CronRunLogRunEntryInput, "action">,
+  ): void => {
+    const cronRuns = params.msg.cronRuns;
+    if (!cronRuns || cronRuns.length === 0) {
+      return;
+    }
+    for (const cronRun of cronRuns) {
+      safeAppendCronRunLogForCronRun(
+        {
+          jobId: cronRun.cronTaskId,
+          cronRunId: cronRun.cronRunId,
+          queueItemId: cronRun.queueItemId,
+          agentId: cronRun.agentId ?? params.agentId,
+          conversationId: cronRun.conversationId ?? params.conversationId,
+        },
+        {
+          ...entry,
+          action,
+          batchId: entry.batchId ?? cronRun.batchId ?? params.getBatchId(),
+          queueItemId: entry.queueItemId ?? cronRun.queueItemId,
+          agentId: entry.agentId ?? cronRun.agentId ?? params.agentId,
+          conversationId:
+            entry.conversationId ??
+            cronRun.conversationId ??
+            params.conversationId,
+        },
+      );
+    }
+  };
+
+  const recordTerminal = (
+    action: TerminalCronRunLogAction,
+    entry: Omit<CronRunLogRunEntryInput, "action">,
+  ): void => {
+    if (terminalLogged) {
+      return;
+    }
+    terminalLogged = true;
+    recordLifecycle(action, entry);
+  };
+
+  const completed = (backendRunId = params.getBackendRunId()): void => {
+    recordTerminal("completed", {
+      status: "ok",
+      summary: "completed",
+      stopReason: "end_turn",
+      ...withBackendRunId(backendRunId),
+    });
+  };
+
+  const cancelled = (backendRunId = params.getBackendRunId()): void => {
+    recordTerminal("cancelled", {
+      status: "skipped",
+      summary: "cancelled",
+      stopReason: "cancelled",
+      ...withBackendRunId(backendRunId),
+    });
+  };
+
+  const failed = (options: {
+    summary: string;
+    stopReason?: StopReasonType | string;
+    error?: string | null;
+    errorClass?: string;
+    errorMessage?: string | null;
+    backendRunId?: string | null;
+  }): void => {
+    recordTerminal("failed", {
+      status: "error",
+      summary: options.summary,
+      stopReason: options.stopReason ?? "error",
+      ...(options.error ? { error: options.error } : {}),
+      ...(options.errorClass ? { errorClass: options.errorClass } : {}),
+      ...(options.errorMessage ? { errorMessage: options.errorMessage } : {}),
+      ...withBackendRunId(options.backendRunId ?? params.getBackendRunId()),
+    });
+  };
+
+  return {
+    turnStarted(): void {
+      recordLifecycle("turn_started", {
+        status: "ok",
+        batchId: params.getBatchId(),
+      });
+    },
+    backendRunStarted(backendRunId: string): void {
+      if (loggedBackendRunIds.has(backendRunId)) {
+        return;
+      }
+      loggedBackendRunIds.add(backendRunId);
+      recordLifecycle("backend_run_started", {
+        status: "ok",
+        runId: backendRunId,
+        backendRunId,
+        batchId: params.getBatchId(),
+      });
+    },
+    missingAgent(): void {
+      failed({
+        summary: "missing_agent",
+        error: "Missing agent id",
+        errorClass: "MissingAgentId",
+        errorMessage: "Missing agent id",
+      });
+    },
+    cancelled,
+    completed,
+    failed,
+    streamUnavailable(): void {
+      if (params.isCancellationRequested()) {
+        cancelled();
+        return;
+      }
+      failed({
+        summary: "stream_unavailable",
+        error: "No stream returned",
+        errorClass: "StreamUnavailable",
+        errorMessage: "No stream returned",
+      });
+    },
+    recoveryTerminal(
+      stopReason: StopReasonType | null | undefined,
+      backendRunId = params.getBackendRunId(),
+    ): void {
+      if (stopReason === "end_turn") {
+        completed(backendRunId);
+        return;
+      }
+      if (stopReason === "cancelled") {
+        cancelled(backendRunId);
+        return;
+      }
+      const summary = stopReason || "error";
+      failed({
+        summary,
+        stopReason: summary,
+        error: `Recovery continuation ended unexpectedly: ${summary}`,
+        errorClass: summary,
+        errorMessage: `Recovery continuation ended unexpectedly: ${summary}`,
+        backendRunId,
+      });
+    },
+    setupCancelled(errorMessage: string): void {
+      recordTerminal("cancelled", {
+        status: "skipped",
+        summary: "cancelled",
+        stopReason: "cancelled",
+        error: errorMessage,
+        errorClass: "CancelledSetup",
+        errorMessage,
+      });
+    },
+    unfinalizedExit(
+      stopReason: "cancelled" | "error",
+      backendRunId?: string,
+    ): void {
+      if (stopReason === "cancelled") {
+        cancelled(backendRunId);
+        return;
+      }
+      failed({
+        summary: "unfinalized_exit",
+        stopReason,
+        error: "Turn owner exited without a terminal transition",
+        errorClass: "UnfinalizedTurnExit",
+        errorMessage: "Turn owner exited without a terminal transition",
+        backendRunId,
+      });
+    },
+  };
+}

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -1084,16 +1084,7 @@ export function isCronGetCommand(value: unknown): value is CronGetCommand {
 
 export function isCronRunsCommand(value: unknown): value is CronRunsCommand {
   if (!value || typeof value !== "object") return false;
-  const c = value as {
-    type?: unknown;
-    request_id?: unknown;
-    task_id?: unknown;
-    limit?: unknown;
-    offset?: unknown;
-    run_id?: unknown;
-    backend_run_id?: unknown;
-    cron_run_id?: unknown;
-  };
+  const c = value as Record<string, unknown>;
   return (
     c.type === "cron_runs" &&
     typeof c.request_id === "string" &&

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -1091,6 +1091,8 @@ export function isCronRunsCommand(value: unknown): value is CronRunsCommand {
     limit?: unknown;
     offset?: unknown;
     run_id?: unknown;
+    backend_run_id?: unknown;
+    cron_run_id?: unknown;
   };
   return (
     c.type === "cron_runs" &&
@@ -1098,7 +1100,9 @@ export function isCronRunsCommand(value: unknown): value is CronRunsCommand {
     typeof c.task_id === "string" &&
     (c.limit === undefined || typeof c.limit === "number") &&
     (c.offset === undefined || typeof c.offset === "number") &&
-    (c.run_id === undefined || typeof c.run_id === "string")
+    (c.run_id === undefined || typeof c.run_id === "string") &&
+    (c.backend_run_id === undefined || typeof c.backend_run_id === "string") &&
+    (c.cron_run_id === undefined || typeof c.cron_run_id === "string")
   );
 }
 

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -2,6 +2,10 @@ import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agen
 import { buildClientSkillsPayload } from "@/agent/client-skills";
 import { createChannelTurnProgressBuilder } from "@/channels/progress-builder";
 import type { ChannelTurnSource } from "@/channels/types";
+import {
+  type CronRunLogRunEntryInput,
+  safeAppendCronRunLogForCronRun,
+} from "@/cron/run-log";
 import type {
   DequeuedBatch,
   QueueBlockedReason,
@@ -33,6 +37,7 @@ import { resolveRuntimeScope } from "./scope";
 import type { ListenerTransport } from "./transport";
 import type {
   ConversationRuntime,
+  CronQueuedTurnRun,
   InboundMessagePayload,
   IncomingMessage,
   StartListenerOptions,
@@ -72,6 +77,62 @@ function hasSameQueueScope(a: QueueItem, b: QueueItem): boolean {
     (a.agentId ?? null) === (b.agentId ?? null) &&
     (a.conversationId ?? null) === (b.conversationId ?? null)
   );
+}
+
+function isCronPromptWithRunId(item: QueueItem): item is Extract<
+  QueueItem,
+  { kind: "cron_prompt" }
+> & {
+  cronRunId: string;
+} {
+  return item.kind === "cron_prompt" && typeof item.cronRunId === "string";
+}
+
+export function recordCronQueueLifecycleForItems(
+  items: readonly QueueItem[],
+  entry: CronRunLogRunEntryInput,
+): void {
+  for (const item of items) {
+    if (!isCronPromptWithRunId(item)) {
+      continue;
+    }
+    safeAppendCronRunLogForCronRun(
+      {
+        jobId: item.cronTaskId,
+        cronRunId: item.cronRunId,
+        queueItemId: item.id,
+        agentId: item.agentId,
+        conversationId: item.conversationId,
+      },
+      {
+        ...entry,
+        queueItemId: entry.queueItemId ?? item.id,
+        agentId: entry.agentId ?? item.agentId,
+        conversationId: entry.conversationId ?? item.conversationId,
+      },
+    );
+  }
+}
+
+function collectCronQueuedTurnRuns(
+  batch: DequeuedBatch,
+): CronQueuedTurnRun[] | undefined {
+  const runs: CronQueuedTurnRun[] = [];
+  for (const item of batch.items) {
+    if (!isCronPromptWithRunId(item)) {
+      continue;
+    }
+    runs.push({
+      cronTaskId: item.cronTaskId,
+      cronRunId: item.cronRunId,
+      queueItemId: item.id,
+      batchId: batch.batchId,
+      agentId: item.agentId,
+      conversationId: item.conversationId,
+      enqueuedAt: item.enqueuedAt,
+    });
+  }
+  return runs.length > 0 ? runs : undefined;
 }
 
 function mergeDequeuedBatchContent(
@@ -259,6 +320,7 @@ function buildQueuedTurnMessage(
   batch: DequeuedBatch,
 ): IncomingMessage | null {
   const channelTurnSources = collectBatchChannelTurnSources(runtime, batch);
+  const cronRuns = collectCronQueuedTurnRuns(batch);
   const actingUserId = pickBatchActingUserId(batch.items);
   const primaryItem = getPrimaryQueueMessageItem(batch.items);
   if (!primaryItem) {
@@ -280,6 +342,7 @@ function buildQueuedTurnMessage(
       agentId: scopeItem?.agentId ?? runtime.agentId ?? undefined,
       conversationId: scopeItem?.conversationId ?? runtime.conversationId,
       ...(channelTurnSources ? { channelTurnSources } : {}),
+      ...(cronRuns ? { cronRuns } : {}),
       ...(actingUserId ? { actingUserId } : {}),
       messages: [
         {
@@ -324,6 +387,7 @@ function buildQueuedTurnMessage(
   return {
     ...template,
     ...(channelTurnSources ? { channelTurnSources } : {}),
+    ...(cronRuns ? { cronRuns } : {}),
     ...(actingUserId ? { actingUserId } : {}),
     messages,
   };
@@ -425,6 +489,14 @@ export function consumeQueuedTurn(runtime: ConversationRuntime): {
     return null;
   }
 
+  recordCronQueueLifecycleForItems(dequeuedBatch.items, {
+    action: "dequeued",
+    status: "ok",
+    batchId: dequeuedBatch.batchId,
+    queueLenAfter: dequeuedBatch.queueLenAfter,
+    mergedCount: dequeuedBatch.mergedCount,
+  });
+
   const queuedTurn = buildQueuedTurnMessage(runtime, dequeuedBatch);
   if (!queuedTurn) {
     return null;
@@ -471,11 +543,22 @@ async function drainQueuedMessages(
         runtime.listener !== getActiveRuntime() ||
         runtime.listener.intentionallyClosed
       ) {
+        recordCronQueueLifecycleForItems(runtime.queueRuntime.peek(), {
+          action: "listener_closed_before_drain",
+          status: "skipped",
+          queueLen: runtime.queueRuntime.length,
+        });
         return;
       }
 
       const blockedReason = computeListenerQueueBlockedReason(runtime);
       if (blockedReason) {
+        recordCronQueueLifecycleForItems(runtime.queueRuntime.peek(), {
+          action: "blocked",
+          status: "skipped",
+          blockedReason,
+          queueLen: runtime.queueRuntime.length,
+        });
         runtime.queueRuntime.tryDequeue(blockedReason);
         return;
       }
@@ -567,12 +650,24 @@ export function scheduleQueuePump(
         runtime.listener !== getActiveRuntime() ||
         runtime.listener.intentionallyClosed
       ) {
+        recordCronQueueLifecycleForItems(runtime.queueRuntime.peek(), {
+          action: "listener_closed_before_drain",
+          status: "skipped",
+          queueLen: runtime.queueRuntime.length,
+        });
         return;
       }
       await drainQueuedMessages(runtime, socket, opts, processQueuedTurn);
     })
     .catch((error: unknown) => {
       runtime.queuePumpScheduled = false;
+      recordCronQueueLifecycleForItems(runtime.queueRuntime.peek(), {
+        action: "pump_failed",
+        status: "error",
+        error: error instanceof Error ? error.message : String(error),
+        errorClass: error instanceof Error ? error.name : undefined,
+        queueLen: runtime.queueRuntime.length,
+      });
       trackBoundaryError({
         errorType: "listener_queue_pump_failed",
         error,

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -7,7 +7,7 @@ import type {
 } from "@letta-ai/letta-client/resources/agents/messages";
 import { fetchRunErrorInfo } from "@/agent/approval-recovery";
 import { getResumeDataFromBackend } from "@/agent/check-approval";
-import { sendMessageStream } from "@/agent/message";
+import type { sendMessageStream } from "@/agent/message";
 import {
   buildFreshDenialApprovals,
   extractConflictDetail,
@@ -46,6 +46,7 @@ import {
 } from "./recovery";
 import { injectQueuedSkillContent } from "./skill-injection";
 import type { ListenerTransport } from "./transport";
+import { listenerSendMessageStream } from "./turn-io";
 import type { TurnLease } from "./turn-lifecycle";
 import { setTurnLoopStatus } from "./turn-status";
 import type { ConversationRuntime } from "./types";
@@ -485,7 +486,7 @@ export async function sendMessageStreamWithRetry(
     });
 
     try {
-      return await sendMessageStream(
+      return await listenerSendMessageStream(
         conversationId,
         messages,
         currentOpts,
@@ -703,7 +704,7 @@ export async function sendApprovalContinuationWithRetry(
     });
 
     try {
-      const stream = await sendMessageStream(
+      const stream = await listenerSendMessageStream(
         conversationId,
         messages,
         currentOpts,

--- a/src/websocket/listener/turn-io.ts
+++ b/src/websocket/listener/turn-io.ts
@@ -1,0 +1,36 @@
+import type { sendMessageStream } from "@/agent/message";
+import { sendMessageStream as defaultSendMessageStream } from "@/agent/message";
+import type { drainStreamWithResume } from "@/cli/helpers/stream";
+import { drainStreamWithResume as defaultDrainStreamWithResume } from "@/cli/helpers/stream";
+
+type SendMessageStream = typeof sendMessageStream;
+type DrainStreamWithResume = typeof drainStreamWithResume;
+
+let sendMessageStreamImpl: SendMessageStream = defaultSendMessageStream;
+let drainStreamWithResumeImpl: DrainStreamWithResume =
+  defaultDrainStreamWithResume;
+
+export function listenerSendMessageStream(
+  ...args: Parameters<SendMessageStream>
+): ReturnType<SendMessageStream> {
+  return sendMessageStreamImpl(...args);
+}
+
+export function listenerDrainStreamWithResume(
+  ...args: Parameters<DrainStreamWithResume>
+): ReturnType<DrainStreamWithResume> {
+  return drainStreamWithResumeImpl(...args);
+}
+
+export const __listenerTurnIoTestUtils = {
+  setSendMessageStreamForTests(impl: SendMessageStream | null): void {
+    sendMessageStreamImpl = impl ?? defaultSendMessageStream;
+  },
+  setDrainStreamWithResumeForTests(impl: DrainStreamWithResume | null): void {
+    drainStreamWithResumeImpl = impl ?? defaultDrainStreamWithResume;
+  },
+  resetForTests(): void {
+    sendMessageStreamImpl = defaultSendMessageStream;
+    drainStreamWithResumeImpl = defaultDrainStreamWithResume;
+  },
+};

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -22,11 +22,6 @@ import {
 } from "@/cli/helpers/accumulator";
 import { getRetryStatusMessage } from "@/cli/helpers/error-formatter";
 import { drainStreamWithResume } from "@/cli/helpers/stream";
-import {
-  type CronRunLogAction,
-  type CronRunLogRunEntryInput,
-  safeAppendCronRunLogForCronRun,
-} from "@/cron/run-log";
 import { telemetry } from "@/telemetry";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
 import type { StopReasonType, StreamDelta } from "@/types/protocol_v2";
@@ -37,6 +32,7 @@ import {
   LLM_API_ERROR_MAX_RETRIES,
   PROVIDER_FALLBACK_NOTICE,
 } from "./constants";
+import { createCronTurnRunLogger } from "./cron-run-lifecycle";
 import { getConversationWorkingDirectory } from "./cwd";
 import {
   emitInterruptToolReturnMessage,
@@ -86,7 +82,6 @@ import { setTurnLoopStatus } from "./turn-status";
 import { finishListenerTurn } from "./turn-terminal";
 import { seedInboundUserTranscriptLines } from "./turn-transcript";
 import type { ConversationRuntime, IncomingMessage } from "./types";
-
 export async function handleIncomingMessage(
   msg: IncomingMessage,
   socket: ListenerTransport,
@@ -108,66 +103,21 @@ export async function handleIncomingMessage(
     normalizedAgentId,
     conversationId,
   );
-
   // Get the canonical mutable permission mode state ref for this turn.
   const turnPermissionModeState = getOrCreateConversationPermissionModeStateRef(
     runtime.listener,
     normalizedAgentId,
     conversationId,
   );
-
   const msgRunIds: string[] = [];
-  const loggedCronBackendRunIds = new Set<string>();
-  let cronTerminalLogged = false;
   let runId: string | undefined;
   let postStopApprovalRecoveryRetries = 0;
   let llmApiErrorRetries = 0;
   let emptyResponseRetries = 0;
   let lastApprovalContinuationAccepted = false;
   let activeDequeuedBatchId = dequeuedBatchId;
-
   const latestBackendRunId = (): string | undefined =>
     runId || runtime.activeRunId || msgRunIds[msgRunIds.length - 1];
-  const recordCronLifecycle = (
-    action: CronRunLogAction,
-    entry: Omit<CronRunLogRunEntryInput, "action">,
-  ): void => {
-    const cronRuns = msg.cronRuns;
-    if (!cronRuns || cronRuns.length === 0) {
-      return;
-    }
-    for (const cronRun of cronRuns) {
-      safeAppendCronRunLogForCronRun(
-        {
-          jobId: cronRun.cronTaskId,
-          cronRunId: cronRun.cronRunId,
-          queueItemId: cronRun.queueItemId,
-          agentId: cronRun.agentId ?? agentId,
-          conversationId: cronRun.conversationId ?? conversationId,
-        },
-        {
-          ...entry,
-          action,
-          batchId: entry.batchId ?? cronRun.batchId ?? activeDequeuedBatchId,
-          queueItemId: entry.queueItemId ?? cronRun.queueItemId,
-          agentId: entry.agentId ?? cronRun.agentId ?? agentId,
-          conversationId:
-            entry.conversationId ?? cronRun.conversationId ?? conversationId,
-        },
-      );
-    }
-  };
-  const recordCronTerminal = (
-    action: Extract<CronRunLogAction, "completed" | "failed" | "cancelled">,
-    entry: Omit<CronRunLogRunEntryInput, "action">,
-  ): void => {
-    if (cronTerminalLogged) {
-      return;
-    }
-    cronTerminalLogged = true;
-    recordCronLifecycle(action, entry);
-  };
-
   let lastExecutionResults: ApprovalResult[] | null = null;
   let lastExecutingToolCallIds: string[] = [];
   let lastNeedsUserInputToolCallIds: string[] = [];
@@ -175,7 +125,6 @@ export async function handleIncomingMessage(
     batchId: dequeuedBatchId,
     sources: msg.channelTurnSources,
   });
-
   const turnLease =
     existingTurnLease ??
     runtime.turnLifecycle.begin({
@@ -186,6 +135,15 @@ export async function handleIncomingMessage(
     throw new Error("Cannot continue a turn with a stale lifecycle lease");
   }
   const turnAbortSignal = turnLease.signal;
+  const cronRunLogger = createCronTurnRunLogger({
+    msg,
+    agentId,
+    conversationId,
+    getBatchId: () => activeDequeuedBatchId,
+    getBackendRunId: latestBackendRunId,
+    isCancellationRequested: () =>
+      turnAbortSignal.aborted || runtime.cancelRequested,
+  });
   let finalizedByThisInvocation = false;
   const noteFinalization = (
     transition: ReturnType<typeof finishListenerTurn>,
@@ -212,77 +170,11 @@ export async function handleIncomingMessage(
       conversationId,
     });
     if (transition.finished) {
-      const backendRunId = runId ?? latestBackendRunId();
-      recordCronTerminal("cancelled", {
-        status: "skipped",
-        summary: "cancelled",
-        stopReason: "cancelled",
-        ...(backendRunId ? { runId: backendRunId, backendRunId } : {}),
-      });
+      cronRunLogger.cancelled(runId ?? latestBackendRunId());
     }
     return true;
   };
-  const recordCronStreamUnavailable = (): void => {
-    const backendRunId = latestBackendRunId();
-    if (turnAbortSignal.aborted || runtime.cancelRequested) {
-      recordCronTerminal("cancelled", {
-        status: "skipped",
-        summary: "cancelled",
-        stopReason: "cancelled",
-        ...(backendRunId ? { runId: backendRunId, backendRunId } : {}),
-      });
-      return;
-    }
-    recordCronTerminal("failed", {
-      status: "error",
-      summary: "stream_unavailable",
-      stopReason: "error",
-      error: "No stream returned",
-      errorClass: "StreamUnavailable",
-      errorMessage: "No stream returned",
-      ...(backendRunId ? { runId: backendRunId, backendRunId } : {}),
-    });
-  };
-  const recordCronHandledRecoveryTerminal = (
-    stopReason: StopReasonType | null | undefined,
-    backendRunId: string | undefined,
-  ): void => {
-    if (stopReason === "end_turn") {
-      recordCronTerminal("completed", {
-        status: "ok",
-        summary: "completed",
-        stopReason: "end_turn",
-        ...(backendRunId ? { runId: backendRunId, backendRunId } : {}),
-      });
-      return;
-    }
-    if (stopReason === "cancelled") {
-      recordCronTerminal("cancelled", {
-        status: "skipped",
-        summary: "cancelled",
-        stopReason: "cancelled",
-        ...(backendRunId ? { runId: backendRunId, backendRunId } : {}),
-      });
-      return;
-    }
-    const effectiveStopReason = stopReason || "error";
-    const errorMessage = `Recovery continuation ended unexpectedly: ${effectiveStopReason}`;
-    recordCronTerminal("failed", {
-      status: "error",
-      summary: effectiveStopReason,
-      stopReason: effectiveStopReason,
-      error: errorMessage,
-      errorClass: effectiveStopReason,
-      errorMessage,
-      ...(backendRunId ? { runId: backendRunId, backendRunId } : {}),
-    });
-  };
-
-  recordCronLifecycle("turn_started", {
-    status: "ok",
-    batchId: activeDequeuedBatchId,
-  });
-
+  cronRunLogger.turnStarted();
   try {
     runtime.lastTerminalLoopErrorMessage = null;
     runtime.lastTerminalLoopErrorRunId = null;
@@ -299,23 +191,14 @@ export async function handleIncomingMessage(
       conversation_id: conversationId,
     });
     telemetry.setCurrentAgentId(agentId ?? null);
-
     if (!agentId) {
-      recordCronTerminal("failed", {
-        status: "error",
-        summary: "missing_agent",
-        stopReason: "error",
-        error: "Missing agent id",
-        errorClass: "MissingAgentId",
-        errorMessage: "Missing agent id",
-      });
+      cronRunLogger.missingAgent();
       finishTurn({
         stopReason: "error",
         conversationId,
       });
       return;
     }
-
     let turnToolContextId: string | null = null;
     const setup = await prepareListenerTurn({
       msg,
@@ -338,14 +221,7 @@ export async function handleIncomingMessage(
         conversationId,
       });
       if (transition.finished) {
-        recordCronTerminal("cancelled", {
-          status: "skipped",
-          summary: "cancelled",
-          stopReason: "cancelled",
-          ...(terminalRunId
-            ? { runId: terminalRunId, backendRunId: terminalRunId }
-            : {}),
-        });
+        cronRunLogger.cancelled(terminalRunId);
       }
       return;
     }
@@ -368,14 +244,7 @@ export async function handleIncomingMessage(
         abortSignal: turnAbortSignal,
       });
       runtime.lastTerminalLoopErrorMessage = formattedError ?? setup.reason;
-      recordCronTerminal("cancelled", {
-        status: "skipped",
-        summary: "cancelled",
-        stopReason: "cancelled",
-        error: runtime.lastTerminalLoopErrorMessage,
-        errorClass: "CancelledSetup",
-        errorMessage: runtime.lastTerminalLoopErrorMessage,
-      });
+      cronRunLogger.setupCancelled(runtime.lastTerminalLoopErrorMessage);
       return;
     }
     let currentInput = setup.currentInput;
@@ -407,7 +276,6 @@ export async function handleIncomingMessage(
           }
         : {}),
     });
-
     const turnInputSender = createTurnInputSender({
       conversationId,
       agentId,
@@ -418,7 +286,6 @@ export async function handleIncomingMessage(
       buildSendOptions,
       onTerminal: noteFinalization,
     });
-
     const currentInputWithSkillContent = injectQueuedSkillContent(currentInput);
     const initialSendResult = await turnInputSender.send(
       currentInputWithSkillContent,
@@ -426,7 +293,7 @@ export async function handleIncomingMessage(
     currentInput = currentInputWithSkillContent;
     const initialStream = turnInputSender.accept(initialSendResult);
     if (!initialStream) {
-      recordCronStreamUnavailable();
+      cronRunLogger.streamUnavailable();
       return;
     }
     let stream = initialStream;
@@ -440,14 +307,12 @@ export async function handleIncomingMessage(
       agent_id: agentId,
       conversation_id: conversationId,
     });
-
     turnToolContextId = getStreamToolContextId(
       stream as Stream<LettaStreamingResponse>,
     );
     let runIdSent = false;
     const buffers = createBuffers(agentId);
     seedInboundUserTranscriptLines(buffers, inboundUserTranscriptLines);
-
     while (true) {
       runIdSent = false;
       let latestErrorText: string | null = null;
@@ -465,15 +330,7 @@ export async function handleIncomingMessage(
           if (typeof maybeRunId === "string") {
             runId = maybeRunId;
             runtime.turnLifecycle.setRunId(turnLease, maybeRunId);
-            if (!loggedCronBackendRunIds.has(maybeRunId)) {
-              loggedCronBackendRunIds.add(maybeRunId);
-              recordCronLifecycle("backend_run_started", {
-                status: "ok",
-                runId: maybeRunId,
-                backendRunId: maybeRunId,
-                batchId: activeDequeuedBatchId,
-              });
-            }
+            cronRunLogger.backendRunStarted(maybeRunId);
             if (!runIdSent) {
               runIdSent = true;
               msgRunIds.push(maybeRunId);
@@ -483,7 +340,6 @@ export async function handleIncomingMessage(
               });
             }
           }
-
           if (errorInfo) {
             const recoverableApprovalErrorText =
               getApprovalToolCallDesyncErrorText(errorInfo);
@@ -514,11 +370,9 @@ export async function handleIncomingMessage(
               );
             }
           }
-
           richDraftStreamer?.handleChunk(
             chunk as unknown as LettaStreamingResponse,
           );
-
           if (shouldOutput) {
             const normalizedChunk = normalizeToolReturnWireMessage(
               chunk as unknown as Record<string, unknown>,
@@ -538,12 +392,10 @@ export async function handleIncomingMessage(
               );
             }
           }
-
           return undefined;
         },
         runtime.contextTracker,
       );
-
       const stopReason = result.stopReason;
       const approvals = result.approvals || [];
       const fallbackError = result.fallbackError ?? null;
@@ -557,7 +409,6 @@ export async function handleIncomingMessage(
         break;
       }
       lastApprovalContinuationAccepted = false;
-
       if (stopReason === "end_turn") {
         const transcriptLines = toLines(buffers);
         const completion = await completeSuccessfulListenerTurn({
@@ -588,16 +439,8 @@ export async function handleIncomingMessage(
           conversationId,
         });
         if (transition.finished) {
-          recordCronTerminal("completed", {
-            status: "ok",
-            summary: "completed",
-            stopReason: "end_turn",
-            ...(terminalRunId
-              ? { runId: terminalRunId, backendRunId: terminalRunId }
-              : {}),
-          });
+          cronRunLogger.completed(terminalRunId);
         }
-
         break;
       }
 
@@ -611,14 +454,7 @@ export async function handleIncomingMessage(
           conversationId,
         });
         if (transition.finished) {
-          recordCronTerminal("cancelled", {
-            status: "skipped",
-            summary: "cancelled",
-            stopReason: "cancelled",
-            ...(terminalRunId
-              ? { runId: terminalRunId, backendRunId: terminalRunId }
-              : {}),
-          });
+          cronRunLogger.cancelled(terminalRunId);
         }
         break;
       }
@@ -687,7 +523,7 @@ export async function handleIncomingMessage(
           currentInput = retryInputWithSkillContent;
           const retryStream = turnInputSender.accept(retrySendResult);
           if (!retryStream) {
-            recordCronStreamUnavailable();
+            cronRunLogger.streamUnavailable();
             return;
           }
           stream = retryStream;
@@ -763,7 +599,7 @@ export async function handleIncomingMessage(
           currentInput = retryInputWithSkillContent;
           const retryStream = turnInputSender.accept(retrySendResult);
           if (!retryStream) {
-            recordCronStreamUnavailable();
+            cronRunLogger.streamUnavailable();
             return;
           }
           stream = retryStream;
@@ -841,7 +677,7 @@ export async function handleIncomingMessage(
           currentInput = retryInputWithSkillContent;
           const retryStream = turnInputSender.accept(retrySendResult);
           if (!retryStream) {
-            recordCronStreamUnavailable();
+            cronRunLogger.streamUnavailable();
             return;
           }
           stream = retryStream;
@@ -875,14 +711,7 @@ export async function handleIncomingMessage(
             conversationId,
           });
           if (transition.finished) {
-            recordCronTerminal("cancelled", {
-              status: "skipped",
-              summary: "cancelled",
-              stopReason: "cancelled",
-              ...(cancelledRunId
-                ? { runId: cancelledRunId, backendRunId: cancelledRunId }
-                : {}),
-            });
+            cronRunLogger.cancelled(cancelledRunId);
           }
           break;
         }
@@ -913,16 +742,13 @@ export async function handleIncomingMessage(
         });
         runtime.lastTerminalLoopErrorMessage = formattedError ?? errorMessage;
         runtime.lastTerminalLoopErrorRunId = terminalRunId ?? null;
-        recordCronTerminal("failed", {
-          status: "error",
+        cronRunLogger.failed({
           summary: effectiveStopReason,
           stopReason: effectiveStopReason,
           error: runtime.lastTerminalLoopErrorMessage,
           errorClass: effectiveStopReason,
           errorMessage: runtime.lastTerminalLoopErrorMessage,
-          ...(terminalRunId
-            ? { runId: terminalRunId, backendRunId: terminalRunId }
-            : {}),
+          backendRunId: terminalRunId,
         });
         break;
       }
@@ -967,16 +793,13 @@ export async function handleIncomingMessage(
         runtime.lastTerminalLoopErrorMessage =
           formattedError ?? approvalResult.message;
         runtime.lastTerminalLoopErrorRunId = terminalRunId ?? null;
-        recordCronTerminal("failed", {
-          status: "error",
+        cronRunLogger.failed({
           summary: "error",
           stopReason: "error",
           error: runtime.lastTerminalLoopErrorMessage,
           errorClass: "approval_error",
           errorMessage: runtime.lastTerminalLoopErrorMessage,
-          ...(terminalRunId
-            ? { runId: terminalRunId, backendRunId: terminalRunId }
-            : {}),
+          backendRunId: terminalRunId,
         });
         return;
       }
@@ -1012,14 +835,7 @@ export async function handleIncomingMessage(
           conversationId,
         });
         if (transition.finished) {
-          recordCronTerminal("cancelled", {
-            status: "skipped",
-            summary: "cancelled",
-            stopReason: "cancelled",
-            ...(terminalRunId
-              ? { runId: terminalRunId, backendRunId: terminalRunId }
-              : {}),
-          });
+          cronRunLogger.cancelled(terminalRunId);
         }
         return;
       }
@@ -1034,7 +850,7 @@ export async function handleIncomingMessage(
           }),
         );
         if (transition.finished) {
-          recordCronHandledRecoveryTerminal(
+          cronRunLogger.recoveryTerminal(
             approvalResult.drainResult.stopReason as StopReasonType,
             terminalRunId,
           );
@@ -1096,14 +912,7 @@ export async function handleIncomingMessage(
         conversationId,
       });
       if (transition.finished) {
-        recordCronTerminal("cancelled", {
-          status: "skipped",
-          summary: "cancelled",
-          stopReason: "cancelled",
-          ...(terminalRunId
-            ? { runId: terminalRunId, backendRunId: terminalRunId }
-            : {}),
-        });
+        cronRunLogger.cancelled(terminalRunId);
       }
 
       return;
@@ -1132,16 +941,13 @@ export async function handleIncomingMessage(
     });
     runtime.lastTerminalLoopErrorMessage = formattedError ?? errorMessage;
     runtime.lastTerminalLoopErrorRunId = terminalRunId ?? null;
-    recordCronTerminal("failed", {
-      status: "error",
+    cronRunLogger.failed({
       summary: "error",
       stopReason: "error",
       error: runtime.lastTerminalLoopErrorMessage,
       errorClass: error instanceof Error ? error.name : "Error",
       errorMessage: runtime.lastTerminalLoopErrorMessage,
-      ...(terminalRunId
-        ? { runId: terminalRunId, backendRunId: terminalRunId }
-        : {}),
+      backendRunId: terminalRunId,
     });
     if (isDebugEnabled()) {
       console.error("[Listen] Error handling message:", error);
@@ -1164,28 +970,7 @@ export async function handleIncomingMessage(
         conversationId,
       });
       if (transition.finished) {
-        if (stopReason === "cancelled") {
-          recordCronTerminal("cancelled", {
-            status: "skipped",
-            summary: "cancelled",
-            stopReason,
-            ...(terminalRunId
-              ? { runId: terminalRunId, backendRunId: terminalRunId }
-              : {}),
-          });
-        } else {
-          recordCronTerminal("failed", {
-            status: "error",
-            summary: "unfinalized_exit",
-            stopReason,
-            error: "Turn owner exited without a terminal transition",
-            errorClass: "UnfinalizedTurnExit",
-            errorMessage: "Turn owner exited without a terminal transition",
-            ...(terminalRunId
-              ? { runId: terminalRunId, backendRunId: terminalRunId }
-              : {}),
-          });
-        }
+        cronRunLogger.unfinalizedExit(stopReason, terminalRunId);
       }
     }
 

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -21,7 +21,6 @@ import {
   toLines,
 } from "@/cli/helpers/accumulator";
 import { getRetryStatusMessage } from "@/cli/helpers/error-formatter";
-import { drainStreamWithResume } from "@/cli/helpers/stream";
 import { telemetry } from "@/telemetry";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
 import type { StopReasonType, StreamDelta } from "@/types/protocol_v2";
@@ -75,6 +74,7 @@ import { handleApprovalStop } from "./turn-approval";
 import { runListenerTurnCleanup } from "./turn-cleanup";
 import { completeSuccessfulListenerTurn } from "./turn-completion";
 import { releaseListenerTurnContext } from "./turn-context";
+import { listenerDrainStreamWithResume } from "./turn-io";
 import type { TurnLease } from "./turn-lifecycle";
 import { createTurnInputSender } from "./turn-send";
 import { prepareListenerTurn } from "./turn-setup";
@@ -316,7 +316,7 @@ export async function handleIncomingMessage(
     while (true) {
       runIdSent = false;
       let latestErrorText: string | null = null;
-      const result = await drainStreamWithResume(
+      const result = await listenerDrainStreamWithResume(
         stream as Stream<LettaStreamingResponse>,
         buffers,
         () => {},

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -22,6 +22,11 @@ import {
 } from "@/cli/helpers/accumulator";
 import { getRetryStatusMessage } from "@/cli/helpers/error-formatter";
 import { drainStreamWithResume } from "@/cli/helpers/stream";
+import {
+  type CronRunLogAction,
+  type CronRunLogRunEntryInput,
+  safeAppendCronRunLogForCronRun,
+} from "@/cron/run-log";
 import { telemetry } from "@/telemetry";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
 import type { StopReasonType, StreamDelta } from "@/types/protocol_v2";
@@ -112,11 +117,56 @@ export async function handleIncomingMessage(
   );
 
   const msgRunIds: string[] = [];
+  const loggedCronBackendRunIds = new Set<string>();
+  let cronTerminalLogged = false;
+  let runId: string | undefined;
   let postStopApprovalRecoveryRetries = 0;
   let llmApiErrorRetries = 0;
   let emptyResponseRetries = 0;
   let lastApprovalContinuationAccepted = false;
   let activeDequeuedBatchId = dequeuedBatchId;
+
+  const latestBackendRunId = (): string | undefined =>
+    runId || runtime.activeRunId || msgRunIds[msgRunIds.length - 1];
+  const recordCronLifecycle = (
+    action: CronRunLogAction,
+    entry: Omit<CronRunLogRunEntryInput, "action">,
+  ): void => {
+    const cronRuns = msg.cronRuns;
+    if (!cronRuns || cronRuns.length === 0) {
+      return;
+    }
+    for (const cronRun of cronRuns) {
+      safeAppendCronRunLogForCronRun(
+        {
+          jobId: cronRun.cronTaskId,
+          cronRunId: cronRun.cronRunId,
+          queueItemId: cronRun.queueItemId,
+          agentId: cronRun.agentId ?? agentId,
+          conversationId: cronRun.conversationId ?? conversationId,
+        },
+        {
+          ...entry,
+          action,
+          batchId: entry.batchId ?? cronRun.batchId ?? activeDequeuedBatchId,
+          queueItemId: entry.queueItemId ?? cronRun.queueItemId,
+          agentId: entry.agentId ?? cronRun.agentId ?? agentId,
+          conversationId:
+            entry.conversationId ?? cronRun.conversationId ?? conversationId,
+        },
+      );
+    }
+  };
+  const recordCronTerminal = (
+    action: Extract<CronRunLogAction, "completed" | "failed" | "cancelled">,
+    entry: Omit<CronRunLogRunEntryInput, "action">,
+  ): void => {
+    if (cronTerminalLogged) {
+      return;
+    }
+    cronTerminalLogged = true;
+    recordCronLifecycle(action, entry);
+  };
 
   let lastExecutionResults: ApprovalResult[] | null = null;
   let lastExecutingToolCallIds: string[] = [];
@@ -154,15 +204,84 @@ export async function handleIncomingMessage(
     ) {
       return false;
     }
-    finishTurn({
+    const transition = finishTurn({
       stopReason: "cancelled",
       socket,
       runId,
       agentId: agentId ?? null,
       conversationId,
     });
+    if (transition.finished) {
+      const backendRunId = runId ?? latestBackendRunId();
+      recordCronTerminal("cancelled", {
+        status: "skipped",
+        summary: "cancelled",
+        stopReason: "cancelled",
+        ...(backendRunId ? { runId: backendRunId, backendRunId } : {}),
+      });
+    }
     return true;
   };
+  const recordCronStreamUnavailable = (): void => {
+    const backendRunId = latestBackendRunId();
+    if (turnAbortSignal.aborted || runtime.cancelRequested) {
+      recordCronTerminal("cancelled", {
+        status: "skipped",
+        summary: "cancelled",
+        stopReason: "cancelled",
+        ...(backendRunId ? { runId: backendRunId, backendRunId } : {}),
+      });
+      return;
+    }
+    recordCronTerminal("failed", {
+      status: "error",
+      summary: "stream_unavailable",
+      stopReason: "error",
+      error: "No stream returned",
+      errorClass: "StreamUnavailable",
+      errorMessage: "No stream returned",
+      ...(backendRunId ? { runId: backendRunId, backendRunId } : {}),
+    });
+  };
+  const recordCronHandledRecoveryTerminal = (
+    stopReason: StopReasonType | null | undefined,
+    backendRunId: string | undefined,
+  ): void => {
+    if (stopReason === "end_turn") {
+      recordCronTerminal("completed", {
+        status: "ok",
+        summary: "completed",
+        stopReason: "end_turn",
+        ...(backendRunId ? { runId: backendRunId, backendRunId } : {}),
+      });
+      return;
+    }
+    if (stopReason === "cancelled") {
+      recordCronTerminal("cancelled", {
+        status: "skipped",
+        summary: "cancelled",
+        stopReason: "cancelled",
+        ...(backendRunId ? { runId: backendRunId, backendRunId } : {}),
+      });
+      return;
+    }
+    const effectiveStopReason = stopReason || "error";
+    const errorMessage = `Recovery continuation ended unexpectedly: ${effectiveStopReason}`;
+    recordCronTerminal("failed", {
+      status: "error",
+      summary: effectiveStopReason,
+      stopReason: effectiveStopReason,
+      error: errorMessage,
+      errorClass: effectiveStopReason,
+      errorMessage,
+      ...(backendRunId ? { runId: backendRunId, backendRunId } : {}),
+    });
+  };
+
+  recordCronLifecycle("turn_started", {
+    status: "ok",
+    batchId: activeDequeuedBatchId,
+  });
 
   try {
     runtime.lastTerminalLoopErrorMessage = null;
@@ -182,6 +301,14 @@ export async function handleIncomingMessage(
     telemetry.setCurrentAgentId(agentId ?? null);
 
     if (!agentId) {
+      recordCronTerminal("failed", {
+        status: "error",
+        summary: "missing_agent",
+        stopReason: "error",
+        error: "Missing agent id",
+        errorClass: "MissingAgentId",
+        errorMessage: "Missing agent id",
+      });
       finishTurn({
         stopReason: "error",
         conversationId,
@@ -203,12 +330,23 @@ export async function handleIncomingMessage(
       connectionId,
     });
     if (setup.kind === "interrupted") {
-      finishTurn({
+      const terminalRunId = latestBackendRunId();
+      const transition = finishTurn({
         stopReason: "cancelled",
         socket,
         agentId,
         conversationId,
       });
+      if (transition.finished) {
+        recordCronTerminal("cancelled", {
+          status: "skipped",
+          summary: "cancelled",
+          stopReason: "cancelled",
+          ...(terminalRunId
+            ? { runId: terminalRunId, backendRunId: terminalRunId }
+            : {}),
+        });
+      }
       return;
     }
     if (setup.kind === "cancelled") {
@@ -230,6 +368,14 @@ export async function handleIncomingMessage(
         abortSignal: turnAbortSignal,
       });
       runtime.lastTerminalLoopErrorMessage = formattedError ?? setup.reason;
+      recordCronTerminal("cancelled", {
+        status: "skipped",
+        summary: "cancelled",
+        stopReason: "cancelled",
+        error: runtime.lastTerminalLoopErrorMessage,
+        errorClass: "CancelledSetup",
+        errorMessage: runtime.lastTerminalLoopErrorMessage,
+      });
       return;
     }
     let currentInput = setup.currentInput;
@@ -280,6 +426,7 @@ export async function handleIncomingMessage(
     currentInput = currentInputWithSkillContent;
     const initialStream = turnInputSender.accept(initialSendResult);
     if (!initialStream) {
+      recordCronStreamUnavailable();
       return;
     }
     let stream = initialStream;
@@ -298,7 +445,6 @@ export async function handleIncomingMessage(
       stream as Stream<LettaStreamingResponse>,
     );
     let runIdSent = false;
-    let runId: string | undefined;
     const buffers = createBuffers(agentId);
     seedInboundUserTranscriptLines(buffers, inboundUserTranscriptLines);
 
@@ -319,6 +465,15 @@ export async function handleIncomingMessage(
           if (typeof maybeRunId === "string") {
             runId = maybeRunId;
             runtime.turnLifecycle.setRunId(turnLease, maybeRunId);
+            if (!loggedCronBackendRunIds.has(maybeRunId)) {
+              loggedCronBackendRunIds.add(maybeRunId);
+              recordCronLifecycle("backend_run_started", {
+                status: "ok",
+                runId: maybeRunId,
+                backendRunId: maybeRunId,
+                batchId: activeDequeuedBatchId,
+              });
+            }
             if (!runIdSent) {
               runIdSent = true;
               msgRunIds.push(maybeRunId);
@@ -426,23 +581,45 @@ export async function handleIncomingMessage(
         ) {
           break;
         }
-        finishTurn({
+        const terminalRunId = latestBackendRunId();
+        const transition = finishTurn({
           stopReason: "end_turn",
           agentId,
           conversationId,
         });
+        if (transition.finished) {
+          recordCronTerminal("completed", {
+            status: "ok",
+            summary: "completed",
+            stopReason: "end_turn",
+            ...(terminalRunId
+              ? { runId: terminalRunId, backendRunId: terminalRunId }
+              : {}),
+          });
+        }
 
         break;
       }
 
       if (stopReason === "cancelled") {
-        finishTurn({
+        const terminalRunId = latestBackendRunId();
+        const transition = finishTurn({
           stopReason: "cancelled",
           socket,
-          runId: runId || runtime.activeRunId,
+          runId: terminalRunId,
           agentId: agentId ?? null,
           conversationId,
         });
+        if (transition.finished) {
+          recordCronTerminal("cancelled", {
+            status: "skipped",
+            summary: "cancelled",
+            stopReason: "cancelled",
+            ...(terminalRunId
+              ? { runId: terminalRunId, backendRunId: terminalRunId }
+              : {}),
+          });
+        }
         break;
       }
 
@@ -510,6 +687,7 @@ export async function handleIncomingMessage(
           currentInput = retryInputWithSkillContent;
           const retryStream = turnInputSender.accept(retrySendResult);
           if (!retryStream) {
+            recordCronStreamUnavailable();
             return;
           }
           stream = retryStream;
@@ -585,6 +763,7 @@ export async function handleIncomingMessage(
           currentInput = retryInputWithSkillContent;
           const retryStream = turnInputSender.accept(retrySendResult);
           if (!retryStream) {
+            recordCronStreamUnavailable();
             return;
           }
           stream = retryStream;
@@ -662,6 +841,7 @@ export async function handleIncomingMessage(
           currentInput = retryInputWithSkillContent;
           const retryStream = turnInputSender.accept(retrySendResult);
           if (!retryStream) {
+            recordCronStreamUnavailable();
             return;
           }
           stream = retryStream;
@@ -686,13 +866,24 @@ export async function handleIncomingMessage(
           : (stopReason as StopReasonType) || "error";
 
         if (effectiveStopReason === "cancelled") {
-          finishTurn({
+          const cancelledRunId = latestBackendRunId();
+          const transition = finishTurn({
             stopReason: "cancelled",
             socket,
-            runId: runId || runtime.activeRunId,
+            runId: cancelledRunId,
             agentId: agentId ?? null,
             conversationId,
           });
+          if (transition.finished) {
+            recordCronTerminal("cancelled", {
+              status: "skipped",
+              summary: "cancelled",
+              stopReason: "cancelled",
+              ...(cancelledRunId
+                ? { runId: cancelledRunId, backendRunId: cancelledRunId }
+                : {}),
+            });
+          }
           break;
         }
 
@@ -722,6 +913,17 @@ export async function handleIncomingMessage(
         });
         runtime.lastTerminalLoopErrorMessage = formattedError ?? errorMessage;
         runtime.lastTerminalLoopErrorRunId = terminalRunId ?? null;
+        recordCronTerminal("failed", {
+          status: "error",
+          summary: effectiveStopReason,
+          stopReason: effectiveStopReason,
+          error: runtime.lastTerminalLoopErrorMessage,
+          errorClass: effectiveStopReason,
+          errorMessage: runtime.lastTerminalLoopErrorMessage,
+          ...(terminalRunId
+            ? { runId: terminalRunId, backendRunId: terminalRunId }
+            : {}),
+        });
         break;
       }
 
@@ -745,7 +947,7 @@ export async function handleIncomingMessage(
       });
 
       if (approvalResult.kind === "error") {
-        const terminalRunId = runId || runtime.activeRunId;
+        const terminalRunId = latestBackendRunId();
         const transition = finishTurn({
           stopReason: "error",
           agentId,
@@ -765,6 +967,17 @@ export async function handleIncomingMessage(
         runtime.lastTerminalLoopErrorMessage =
           formattedError ?? approvalResult.message;
         runtime.lastTerminalLoopErrorRunId = terminalRunId ?? null;
+        recordCronTerminal("failed", {
+          status: "error",
+          summary: "error",
+          stopReason: "error",
+          error: runtime.lastTerminalLoopErrorMessage,
+          errorClass: "approval_error",
+          errorMessage: runtime.lastTerminalLoopErrorMessage,
+          ...(terminalRunId
+            ? { runId: terminalRunId, backendRunId: terminalRunId }
+            : {}),
+        });
         return;
       }
 
@@ -790,24 +1003,42 @@ export async function handleIncomingMessage(
             conversationId,
           });
         }
-        finishTurn({
+        const terminalRunId = latestBackendRunId();
+        const transition = finishTurn({
           stopReason: "cancelled",
           socket,
-          runId: runId || runtime.activeRunId,
+          runId: terminalRunId,
           agentId,
           conversationId,
         });
+        if (transition.finished) {
+          recordCronTerminal("cancelled", {
+            status: "skipped",
+            summary: "cancelled",
+            stopReason: "cancelled",
+            ...(terminalRunId
+              ? { runId: terminalRunId, backendRunId: terminalRunId }
+              : {}),
+          });
+        }
         return;
       }
 
       if (approvalResult.kind === "terminal") {
-        noteFinalization(
+        const terminalRunId = latestBackendRunId();
+        const transition = noteFinalization(
           finalizeHandledRecoveryTurn(runtime, socket, turnLease, {
             drainResult: approvalResult.drainResult,
             agentId,
             conversationId,
           }),
         );
+        if (transition.finished) {
+          recordCronHandledRecoveryTerminal(
+            approvalResult.drainResult.stopReason as StopReasonType,
+            terminalRunId,
+          );
+        }
         return;
       }
 
@@ -856,19 +1087,30 @@ export async function handleIncomingMessage(
         }
       }
 
-      finishTurn({
+      const terminalRunId = latestBackendRunId();
+      const transition = finishTurn({
         stopReason: "cancelled",
         socket,
-        runId: runtime.activeRunId || msgRunIds[msgRunIds.length - 1],
+        runId: terminalRunId,
         agentId: agentId || null,
         conversationId,
       });
+      if (transition.finished) {
+        recordCronTerminal("cancelled", {
+          status: "skipped",
+          summary: "cancelled",
+          stopReason: "cancelled",
+          ...(terminalRunId
+            ? { runId: terminalRunId, backendRunId: terminalRunId }
+            : {}),
+        });
+      }
 
       return;
     }
 
     const errorMessage = error instanceof Error ? error.message : String(error);
-    const terminalRunId = runtime.activeRunId;
+    const terminalRunId = latestBackendRunId();
     const transition = finishTurn({
       stopReason: "error",
       agentId: agentId || null,
@@ -890,6 +1132,17 @@ export async function handleIncomingMessage(
     });
     runtime.lastTerminalLoopErrorMessage = formattedError ?? errorMessage;
     runtime.lastTerminalLoopErrorRunId = terminalRunId ?? null;
+    recordCronTerminal("failed", {
+      status: "error",
+      summary: "error",
+      stopReason: "error",
+      error: runtime.lastTerminalLoopErrorMessage,
+      errorClass: error instanceof Error ? error.name : "Error",
+      errorMessage: runtime.lastTerminalLoopErrorMessage,
+      ...(terminalRunId
+        ? { runId: terminalRunId, backendRunId: terminalRunId }
+        : {}),
+    });
     if (isDebugEnabled()) {
       console.error("[Listen] Error handling message:", error);
     }
@@ -901,13 +1154,39 @@ export async function handleIncomingMessage(
         context: "listener_turn_finalization",
         runId: runtime.activeRunId || msgRunIds[msgRunIds.length - 1],
       });
-      finishTurn({
-        stopReason: turnAbortSignal.aborted ? "cancelled" : "error",
+      const terminalRunId = latestBackendRunId();
+      const stopReason = turnAbortSignal.aborted ? "cancelled" : "error";
+      const transition = finishTurn({
+        stopReason,
         socket,
-        runId: runtime.activeRunId || msgRunIds[msgRunIds.length - 1],
+        runId: terminalRunId,
         agentId: agentId || null,
         conversationId,
       });
+      if (transition.finished) {
+        if (stopReason === "cancelled") {
+          recordCronTerminal("cancelled", {
+            status: "skipped",
+            summary: "cancelled",
+            stopReason,
+            ...(terminalRunId
+              ? { runId: terminalRunId, backendRunId: terminalRunId }
+              : {}),
+          });
+        } else {
+          recordCronTerminal("failed", {
+            status: "error",
+            summary: "unfinalized_exit",
+            stopReason,
+            error: "Turn owner exited without a terminal transition",
+            errorClass: "UnfinalizedTurnExit",
+            errorMessage: "Turn owner exited without a terminal transition",
+            ...(terminalRunId
+              ? { runId: terminalRunId, backendRunId: terminalRunId }
+              : {}),
+          });
+        }
+      }
     }
 
     richDraftStreamer?.dispose();

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -59,11 +59,23 @@ export interface StartListenerOptions {
   ) => void;
 }
 
+export interface CronQueuedTurnRun {
+  cronTaskId: string;
+  cronRunId: string;
+  queueItemId: string;
+  batchId: string;
+  agentId?: string;
+  conversationId?: string;
+  enqueuedAt?: number;
+}
+
 export interface IncomingMessage {
   type: "message";
   agentId?: string;
   conversationId?: string;
   channelTurnSources?: ChannelTurnSource[];
+  /** Local-only schedule run correlation for queued cron turns. */
+  cronRuns?: CronQueuedTurnRun[];
   clientToolAllowlist?: string[];
   externalToolScopeIds?: string[];
   messages: Array<


### PR DESCRIPTION
## Summary
- Adds a durable per-fire `cronRunId` and records local JSONL lifecycle entries from scheduler fire through queue dequeue and listener/backend terminal state.
- Expands cron run history filtering so support can query by public `run_id`, backend `backend_run_id`, or per-fire `cron_run_id`.
- Records scheduler, queue, and listener failure states (`enqueue_failed`, `blocked`, `dropped`, `cleared`, `removed`, `pump_failed`, `listener_closed_before_drain`, `failed`, `cancelled`) without writing schedule prompt text to the run log.
- Splits cron protocol types and listener lifecycle logging/tests out of oversized files and ratchets the source-size baseline down for the files that shrank.

## Root cause
Cron run history only had a coarse `finished` entry and no durable correlation key between the scheduled fire, queue item, listener turn, and backend run. If a run was queued, blocked, dropped, cancelled, or failed before a final backend result, support had to infer what happened from unrelated listener state.

## Changed behavior
- Scheduler fires now create a `cronRunId`, log `fire_started`, then log `enqueued` or `enqueue_failed` with scheduler metadata and queue state.
- Queue lifecycle callbacks log cron queue item transitions while preserving the user prompt only in the actual queued turn message.
- Listener turns carrying cron metadata log `turn_started`, deduped `backend_run_started`, and exactly one terminal `completed`, `failed`, or `cancelled` entry.
- `cron_runs` accepts exact `backend_run_id` and `cron_run_id` filters; the existing generic `run_id` filter now matches public run id, backend run id, or cron run id.
- Existing log entries with action `finished` remain readable.

## Risk and limits
- Risk class: runtime/listener plus local storage observability.
- Local observability only. Cloud telemetry dashboards and Desktop schedule UI changes are intentionally left for follow-up PRs.
- This adds logging around existing scheduler/queue/listener paths. The only non-log state change is recording a failed last-run outcome when conversation resolution throws.
- The focused listener lifecycle test mocks the backend stream boundary; it proves the listener log path and no-prompt invariant, not a live backend run.

## Tests
- `bun test src/cron/run-log.test.ts src/cron/scheduler.test.ts src/websocket/listener/cron-run-lifecycle.test.ts src/websocket/listen-client-concurrency.test.ts` — 61 pass.
- `bun run typecheck` — pass.
- `bun run check` — pass.

👾 Generated with [Letta Code](https://letta.com)
