### PR TITLE
fix(slack): hydrate attachments from thread broadcast messages

### DIFF
--- a/src/channels/slack-adapter.test.ts
+++ b/src/channels/slack-adapter.test.ts
@@ -219,6 +219,9 @@ class FakeSlackWriteClient {
 const resolveSlackInboundAttachmentsMock = mock(
   async (): Promise<ChannelMessageAttachment[]> => [],
 );
+const resolveSlackCurrentMessageAttachmentsMock = mock(
+  async (): Promise<ChannelMessageAttachment[]> => [],
+);
 const resolveSlackThreadStarterMock = mock(
   async (): Promise<{
     text: string;
@@ -271,6 +274,8 @@ mock.module("./slack/runtime", () => ({
 
 mock.module("./slack/media", () => ({
   resolveSlackChannelHistory: resolveSlackChannelHistoryMock,
+  resolveSlackCurrentMessageAttachments:
+    resolveSlackCurrentMessageAttachmentsMock,
   resolveSlackInboundAttachments: resolveSlackInboundAttachmentsMock,
   resolveSlackThreadStarter: resolveSlackThreadStarterMock,
   resolveSlackThreadHistory: resolveSlackThreadHistoryMock,
@@ -309,6 +314,8 @@ beforeEach(() => {
   FakeSlackWriteClient.disableStartStream = false;
   resolveSlackInboundAttachmentsMock.mockReset();
   resolveSlackInboundAttachmentsMock.mockImplementation(async () => []);
+  resolveSlackCurrentMessageAttachmentsMock.mockReset();
+  resolveSlackCurrentMessageAttachmentsMock.mockImplementation(async () => []);
   resolveSlackThreadStarterMock.mockReset();
   resolveSlackThreadStarterMock.mockImplementation(async () => null);
   resolveSlackThreadHistoryMock.mockReset();
@@ -1272,11 +1279,6 @@ test("slack adapter rehydrates bot-authored Slack thread context on existing rou
 
   resolveSlackThreadHistoryMock.mockResolvedValueOnce([
     {
-      text: "Already-delivered human context",
-      userId: "U222",
-      ts: "1712795000.000060",
-    },
-    {
       text: "Automated deployment note since the last human turn",
       botId: "BDEPLOY",
       ts: "1712796000.000070",
@@ -1313,7 +1315,77 @@ test("slack adapter rehydrates bot-authored Slack thread context on existing rou
   ]);
   expect(resolveSlackThreadStarterMock).not.toHaveBeenCalled();
   expect(resolveSlackThreadHistoryMock).toHaveBeenCalledTimes(1);
+  expect(resolveSlackThreadHistoryMock).toHaveBeenCalledWith(
+    expect.objectContaining({ include: "bot" }),
+  );
   expect(resolveSlackChannelHistoryMock).not.toHaveBeenCalled();
+});
+
+test("slack adapter hydrates exact thread_broadcast attachments before prompt formatting", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+
+  await adapter.start();
+
+  resolveSlackCurrentMessageAttachmentsMock.mockResolvedValueOnce([
+    {
+      id: "FZIP",
+      name: "source.zip",
+      mimeType: "application/zip",
+      kind: "file",
+      localPath: "/tmp/source.zip",
+    },
+  ]);
+
+  const prepared = await adapter.prepareInboundMessage?.(
+    {
+      channel: "slack",
+      accountId: "slack-test-account",
+      chatId: "C123",
+      chatLabel: "#random",
+      senderId: "U123",
+      senderName: "Dorota",
+      text: "broadcasting files",
+      timestamp: 1712800000100,
+      messageId: "1712800000.000100",
+      threadId: "1712790000.000050",
+      chatType: "channel",
+      isMention: false,
+      raw: {
+        type: "message",
+        subtype: "thread_broadcast",
+        channel: "C123",
+        user: "U123",
+        ts: "1712800000.000100",
+        thread_ts: "1712790000.000050",
+      },
+    },
+    { isFirstRouteTurn: false },
+  );
+
+  expect(prepared?.attachments).toEqual([
+    expect.objectContaining({ id: "FZIP", localPath: "/tmp/source.zip" }),
+  ]);
+  expect(resolveSlackCurrentMessageAttachmentsMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      channelId: "C123",
+      threadTs: "1712790000.000050",
+      messageTs: "1712800000.000100",
+      accountId: "slack-test-account",
+      token: "xoxb-test-token-1234567890",
+    }),
+  );
+  expect(resolveSlackThreadHistoryMock).toHaveBeenCalledWith(
+    expect.objectContaining({ include: "bot" }),
+  );
 });
 
 test("slack adapter hydrates recent channel context, including bot-authored entries, when a mention creates a new thread", async () => {

--- a/src/channels/slack-media.test.ts
+++ b/src/channels/slack-media.test.ts
@@ -244,6 +244,150 @@ test("resolveSlackThreadHistory retains bot-authored Slack replies", async () =>
   ]);
 });
 
+test("resolveSlackCurrentMessageAttachments hydrates files from the exact thread message", async () => {
+  const fetchMock = mock(async (input: unknown, init?: RequestInit) => {
+    expect(requestUrl(input)).toBe(
+      "https://files.slack.com/files-pri/T123-FZIP/source.zip",
+    );
+    expect(init).toMatchObject({
+      headers: { Authorization: "Bearer xoxb-test-token" },
+      redirect: "manual",
+    });
+    return new Response(new Uint8Array([1, 2, 3]), {
+      status: 200,
+      headers: { "content-type": "application/zip" },
+    });
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+  const { resolveSlackCurrentMessageAttachments } =
+    await loadSlackMediaModule();
+  const client = {
+    conversations: {
+      history: mock(async () => ({ messages: [] })),
+      replies: mock(async () => ({
+        messages: [
+          {
+            ts: "1712790000.000050",
+            user: "U111",
+            text: "Thread root",
+          },
+          {
+            ts: "1712800000.000100",
+            user: "U222",
+            text: "Here are the files",
+            subtype: "thread_broadcast",
+            files: [
+              {
+                id: "FZIP",
+                name: "source.zip",
+                mimetype: "application/zip",
+                url_private_download:
+                  "https://files.slack.com/files-pri/T123-FZIP/source.zip",
+              },
+            ],
+          },
+        ],
+      })),
+    },
+  };
+
+  const attachments = await resolveSlackCurrentMessageAttachments({
+    channelId: "C123",
+    threadTs: "1712790000.000050",
+    messageTs: "1712800000.000100",
+    client,
+    accountId: "slack-bot",
+    token: "xoxb-test-token",
+  });
+
+  expect(attachments).toEqual([
+    expect.objectContaining({
+      id: "FZIP",
+      name: "source.zip",
+      mimeType: "application/zip",
+      kind: "file",
+      sizeBytes: 3,
+      localPath: expect.stringContaining("source.zip"),
+    }),
+  ]);
+  expect(client.conversations.replies).toHaveBeenCalledWith(
+    expect.objectContaining({
+      channel: "C123",
+      ts: "1712790000.000050",
+      inclusive: true,
+    }),
+  );
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+test("resolveSlackThreadHistory bot-only mode skips human attachment downloads", async () => {
+  const fetchMock = mock(async () => {
+    throw new Error("human history attachment should not be downloaded");
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+  const { resolveSlackThreadHistory } = await loadSlackMediaModule();
+  const client = {
+    conversations: {
+      history: mock(async () => ({ messages: [] })),
+      replies: mock(async () => ({
+        messages: [
+          {
+            ts: "1712790000.000050",
+            user: "U111",
+            text: "Thread root",
+          },
+          {
+            ts: "1712795000.000060",
+            user: "U222",
+            text: "Human file context already delivered",
+            files: [
+              {
+                id: "FHUMAN",
+                name: "human.png",
+                mimetype: "image/png",
+                url_private_download:
+                  "https://files.slack.com/files-pri/T123-FHUMAN/human.png",
+              },
+            ],
+          },
+          {
+            ts: "1712796000.000070",
+            bot_id: "BDEPLOY",
+            text: "Bot status update",
+          },
+          {
+            ts: "1712800000.000100",
+            user: "U333",
+            text: "Current turn",
+          },
+        ],
+      })),
+    },
+  };
+
+  await expect(
+    resolveSlackThreadHistory({
+      channelId: "C123",
+      threadTs: "1712790000.000050",
+      currentMessageTs: "1712800000.000100",
+      client,
+      include: "bot",
+      accountId: "slack-bot",
+      token: "xoxb-test-token",
+    }),
+  ).resolves.toEqual([
+    {
+      text: "Bot status update",
+      userId: undefined,
+      botId: "BDEPLOY",
+      ts: "1712796000.000070",
+    },
+  ]);
+  expect(fetchMock).not.toHaveBeenCalled();
+});
+
 test("resolveSlackChannelHistory retains bot-authored Slack messages", async () => {
   const { resolveSlackChannelHistory } = await loadSlackMediaModule();
   const client = {

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -48,6 +48,7 @@ import {
 import { trackBoundaryError } from "@/telemetry/error-reporting";
 import {
   resolveSlackChannelHistory,
+  resolveSlackCurrentMessageAttachments,
   resolveSlackInboundAttachments,
   resolveSlackThreadHistory,
   resolveSlackThreadStarter,
@@ -342,6 +343,19 @@ function resolveSlackSenderTeamId(value: unknown): string | undefined {
 
 function normalizeSlackText(text: string): string {
   return text.replace(/^(?:\s*<@[A-Z0-9]+>\s*)+/, "").trim();
+}
+
+function shouldHydrateCurrentSlackMessageAttachments(
+  msg: InboundChannelMessage,
+): boolean {
+  if (msg.attachments?.length || msg.chatType !== "channel") {
+    return false;
+  }
+  const raw = asRecord(msg.raw);
+  if (!raw) {
+    return false;
+  }
+  return raw.type === "app_mention" || raw.subtype === "thread_broadcast";
 }
 
 const IGNORED_SLACK_MESSAGE_SUBTYPES = new Set([
@@ -4443,10 +4457,13 @@ export function createSlackAdapter(
         isFirstRouteTurn &&
         msg.isMention === true &&
         msg.threadId === msg.messageId;
+      const shouldHydrateCurrentAttachments =
+        shouldHydrateCurrentSlackMessageAttachments(msg);
 
       if (
         !shouldHydrateExistingThreadContext &&
-        !shouldHydrateChannelBootstrapContext
+        !shouldHydrateChannelBootstrapContext &&
+        !shouldHydrateCurrentAttachments
       ) {
         return msg;
       }
@@ -4457,6 +4474,15 @@ export function createSlackAdapter(
         token: config.botToken,
         transcribeVoice: config.transcribeVoice === true,
       };
+      const currentAttachments = shouldHydrateCurrentAttachments
+        ? await resolveSlackCurrentMessageAttachments({
+            channelId: msg.chatId,
+            threadTs: msg.threadId,
+            messageTs: msg.messageId,
+            client: slackApp.client,
+            ...threadAttachmentParams,
+          })
+        : [];
       const starter =
         shouldHydrateExistingThreadContext && isFirstRouteTurn
           ? await resolveSlackThreadStarter({
@@ -4473,6 +4499,7 @@ export function createSlackAdapter(
             client: slackApp.client,
             currentMessageTs: msg.messageId,
             limit: INITIAL_SLACK_THREAD_HISTORY_LIMIT,
+            include: !isFirstRouteTurn ? "bot" : "all",
             ...threadAttachmentParams,
           })
         : await resolveSlackChannelHistory({
@@ -4482,16 +4509,9 @@ export function createSlackAdapter(
             limit: INITIAL_SLACK_THREAD_HISTORY_LIMIT,
             ...threadAttachmentParams,
           });
-      // Existing routed thread turns already deliver human messages into the
-      // Letta conversation. Bot-authored Slack messages are intentionally not
-      // runnable input, so rehydrate those skipped entries as context on the
-      // next human turn instead of waking the agent for every bot event.
-      const history =
-        shouldHydrateExistingThreadContext && !isFirstRouteTurn
-          ? resolvedHistory.filter((entry) => isNonEmptyString(entry.botId))
-          : resolvedHistory;
+      const history = resolvedHistory;
 
-      if (!starter && history.length === 0) {
+      if (!starter && history.length === 0 && currentAttachments.length === 0) {
         return msg;
       }
 
@@ -4526,6 +4546,9 @@ export function createSlackAdapter(
 
       return {
         ...msg,
+        ...(currentAttachments.length > 0
+          ? { attachments: currentAttachments }
+          : {}),
         threadContext: {
           label: shouldHydrateExistingThreadContext
             ? buildSlackThreadLabel(msg, starter?.text)

--- a/src/channels/slack/media.ts
+++ b/src/channels/slack/media.ts
@@ -83,6 +83,8 @@ export type SlackThreadMessage = {
   attachments?: ChannelMessageAttachment[];
 };
 
+type SlackThreadHistoryEntryKind = "all" | "bot";
+
 async function mapSlackThreadMessage(
   message: SlackRepliesPageMessage,
   attachmentOptions?: SlackThreadAttachmentOptions,
@@ -617,6 +619,52 @@ export async function resolveSlackInboundAttachments(params: {
   });
 }
 
+export async function resolveSlackCurrentMessageAttachments(
+  params: {
+    channelId: string;
+    threadTs: string;
+    messageTs: string;
+    client: SlackRepliesClient;
+  } & SlackThreadAttachmentParams,
+): Promise<ChannelMessageAttachment[]> {
+  const attachmentOptions = resolveSlackThreadAttachmentOptions(params);
+  if (!attachmentOptions) {
+    return [];
+  }
+
+  const fetchLimit = 200;
+  let cursor: string | undefined;
+
+  try {
+    do {
+      const response = (await params.client.conversations.replies({
+        channel: params.channelId,
+        ts: params.threadTs,
+        limit: fetchLimit,
+        inclusive: true,
+        ...(cursor ? { cursor } : {}),
+      })) as SlackRepliesPage;
+
+      const message = (response.messages ?? []).find(
+        (entry) => entry.ts === params.messageTs,
+      );
+      if (message) {
+        return resolveSlackMessageAttachments(message, attachmentOptions);
+      }
+
+      const nextCursor = response.response_metadata?.next_cursor;
+      cursor =
+        typeof nextCursor === "string" && nextCursor.trim().length > 0
+          ? nextCursor.trim()
+          : undefined;
+    } while (cursor);
+  } catch {
+    return [];
+  }
+
+  return [];
+}
+
 export async function readSlackAttachmentFile(
   localPath: string,
 ): Promise<Buffer> {
@@ -662,6 +710,7 @@ export async function resolveSlackThreadHistory(
     client: SlackRepliesClient;
     currentMessageTs?: string;
     limit?: number;
+    include?: SlackThreadHistoryEntryKind;
   } & SlackThreadAttachmentParams,
 ): Promise<SlackThreadMessage[]> {
   const maxMessages = params.limit ?? 20;
@@ -685,6 +734,9 @@ export async function resolveSlackThreadHistory(
       })) as SlackRepliesPage;
 
       for (const message of response.messages ?? []) {
+        if (params.include === "bot" && !isNonEmptyString(message.bot_id)) {
+          continue;
+        }
         if (!hasSlackThreadMessageContent(message, attachmentOptions)) {
           continue;
         }


### PR DESCRIPTION
## Summary

- hydrate attachments for Slack `thread_broadcast` / thin mention events by dereferencing the exact current thread message before prompt formatting
- add a bot-only thread history mode so existing routed threads no longer download human history attachments that will be filtered out
- cover exact current-message attachment hydration and bot-only history behavior with focused Slack regression tests

Validation:
- `bun test src/channels/slack-media.test.ts`
- `bun test src/channels/slack-adapter.test.ts`
- `bun run check`

Fixes LET-9536
