### PR TITLE
fix(listener): clear stale processing state

### DIFF
--- a/src/websocket/listener-runtime-state.test.ts
+++ b/src/websocket/listener-runtime-state.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { MessageQueueItem } from "@/queue/queue-runtime";
+import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
+import { createRuntime } from "@/websocket/listener/lifecycle";
+import { scheduleQueuePump } from "@/websocket/listener/queue";
+import {
+  clearConversationRuntimeState,
+  clearStaleProcessingFlagIfIdle,
+  setActiveRuntime,
+} from "@/websocket/listener/runtime";
+import type { ListenerTransport } from "@/websocket/listener/transport";
+import type {
+  ConversationRuntime,
+  IncomingMessage,
+  StartListenerOptions,
+} from "@/websocket/listener/types";
+
+function createLocalTransport(): {
+  transport: ListenerTransport;
+  sentPayloads: string[];
+} {
+  const sentPayloads: string[] = [];
+  return {
+    sentPayloads,
+    transport: {
+      kind: "local",
+      bufferedAmount: 0,
+      isOpen: () => true,
+      send: (data: string) => {
+        sentPayloads.push(data);
+      },
+    },
+  };
+}
+
+function createScopedRuntime(): ConversationRuntime {
+  const listener = createRuntime();
+  return getOrCreateScopedRuntime(listener, "agent-1", "default");
+}
+
+function createStartListenerOptions(): StartListenerOptions {
+  return {
+    connectionId: "conn-1",
+    wsUrl: "ws://localhost/test",
+    deviceId: "device-1",
+    connectionName: "test-listener",
+    onConnected: () => {},
+    onDisconnected: () => {},
+    onError: () => {},
+  };
+}
+
+function enqueueUserMessage(
+  runtime: ConversationRuntime,
+  content: string,
+): IncomingMessage {
+  const queueItem: Omit<MessageQueueItem, "id" | "enqueuedAt"> = {
+    kind: "message",
+    source: "user",
+    content,
+    agentId: runtime.agentId ?? undefined,
+    conversationId: runtime.conversationId,
+  };
+  const item = runtime.queueRuntime.enqueue(queueItem);
+  if (!item) {
+    throw new Error("failed to enqueue test message");
+  }
+
+  const incoming: IncomingMessage = {
+    type: "message",
+    agentId: runtime.agentId ?? undefined,
+    conversationId: runtime.conversationId,
+    messages: [{ role: "user", content }],
+  };
+  runtime.queuedMessagesByItemId.set(item.id, incoming);
+  return incoming;
+}
+
+afterEach(() => {
+  setActiveRuntime(null);
+});
+
+describe("listener conversation runtime cleanup", () => {
+  test("clearConversationRuntimeState clears processing ownership and recovery flags", () => {
+    const runtime = createScopedRuntime();
+    const abortController = new AbortController();
+
+    runtime.isProcessing = true;
+    runtime.isRecoveringApprovals = true;
+    runtime.loopStatus = "RETRYING_API_REQUEST";
+    runtime.activeAbortController = abortController;
+    runtime.activeRunId = "run-1";
+    runtime.activeRunStartedAt = new Date().toISOString();
+    runtime.activeWorkingDirectory = "/tmp/letta-test";
+    runtime.activeExecutingToolCallIds = ["tool-1"];
+    runtime.pendingApprovalBatchByToolCallId.set("tool-1", "approval-1");
+    runtime.pendingInterruptedResults = [];
+    runtime.pendingInterruptedContext = {
+      agentId: "agent-1",
+      conversationId: "default",
+      continuationEpoch: runtime.continuationEpoch,
+    };
+    runtime.pendingInterruptedToolCallIds = ["tool-1"];
+    runtime.pendingTurns = 1;
+    runtime.queuePumpActive = true;
+    runtime.queuePumpScheduled = true;
+
+    clearConversationRuntimeState(runtime);
+
+    expect(abortController.signal.aborted).toBe(true);
+    expect(runtime.cancelRequested).toBe(true);
+    expect(runtime.isProcessing).toBe(false);
+    expect(runtime.isRecoveringApprovals).toBe(false);
+    expect(runtime.loopStatus as string).toBe("WAITING_ON_INPUT");
+    expect(runtime.activeWorkingDirectory).toBeNull();
+    expect(runtime.activeRunId).toBeNull();
+    expect(runtime.activeRunStartedAt).toBeNull();
+    expect(runtime.activeAbortController).toBeNull();
+    expect(runtime.activeExecutingToolCallIds).toEqual([]);
+    expect(runtime.pendingApprovalBatchByToolCallId.size).toBe(0);
+    expect(runtime.pendingInterruptedResults).toBeNull();
+    expect(runtime.pendingInterruptedContext).toBeNull();
+    expect(runtime.pendingInterruptedToolCallIds).toBeNull();
+    expect(runtime.pendingTurns).toBe(0);
+    expect(runtime.queuePumpActive).toBe(false);
+    expect(runtime.queuePumpScheduled).toBe(false);
+  });
+
+  test("stale processing guard preserves active local work", () => {
+    const runtime = createScopedRuntime();
+
+    runtime.isProcessing = true;
+    runtime.loopStatus = "WAITING_ON_INPUT";
+    runtime.activeAbortController = new AbortController();
+    runtime.activeRunId = "run-still-active";
+    runtime.activeRunStartedAt = new Date().toISOString();
+
+    const cleared = clearStaleProcessingFlagIfIdle(runtime, 0);
+
+    expect(cleared).toBe(false);
+    expect(runtime.isProcessing).toBe(true);
+  });
+
+  test("queue pump self-heals an idle split-brain processing flag and drains follow-up", async () => {
+    const runtime = createScopedRuntime();
+    const { transport } = createLocalTransport();
+    setActiveRuntime(runtime.listener);
+    enqueueUserMessage(runtime, "follow up after retry");
+
+    runtime.isProcessing = true;
+    runtime.isRecoveringApprovals = false;
+    runtime.loopStatus = "WAITING_ON_INPUT";
+    runtime.cancelRequested = false;
+    runtime.activeWorkingDirectory = null;
+    runtime.activeRunId = null;
+    runtime.activeRunStartedAt = null;
+    runtime.activeAbortController = null;
+    runtime.activeExecutingToolCallIds = [];
+
+    const processedTurns: IncomingMessage[] = [];
+    scheduleQueuePump(
+      runtime,
+      transport,
+      createStartListenerOptions(),
+      async (queuedTurn) => {
+        processedTurns.push(queuedTurn);
+      },
+    );
+
+    await runtime.messageQueue;
+
+    expect(runtime.isProcessing).toBe(false);
+    expect(runtime.queueRuntime.length).toBe(0);
+    expect(runtime.pendingTurns).toBe(0);
+    expect(processedTurns).toHaveLength(1);
+    expect(processedTurns[0]?.messages[0]).toMatchObject({
+      role: "user",
+      content: [{ type: "text", text: "follow up after retry" }],
+    });
+  });
+
+  test("cleanup path does not leave a runtime_busy gate after the interrupt latch is released", async () => {
+    const runtime = createScopedRuntime();
+    const { transport } = createLocalTransport();
+    setActiveRuntime(runtime.listener);
+
+    runtime.isProcessing = true;
+    runtime.isRecoveringApprovals = true;
+    runtime.loopStatus = "RETRYING_API_REQUEST";
+    runtime.activeAbortController = new AbortController();
+    runtime.activeRunId = "run-retry";
+    runtime.activeRunStartedAt = new Date().toISOString();
+    runtime.activeWorkingDirectory = "/tmp/letta-test";
+    runtime.activeExecutingToolCallIds = ["tool-1"];
+
+    clearConversationRuntimeState(runtime);
+    runtime.cancelRequested = false;
+    enqueueUserMessage(runtime, "follow up after cleanup");
+
+    const processedTurns: IncomingMessage[] = [];
+    scheduleQueuePump(
+      runtime,
+      transport,
+      createStartListenerOptions(),
+      async (queuedTurn) => {
+        processedTurns.push(queuedTurn);
+      },
+    );
+
+    await runtime.messageQueue;
+
+    expect(runtime.isProcessing).toBe(false);
+    expect(runtime.isRecoveringApprovals).toBe(false);
+    expect(runtime.queueRuntime.length).toBe(0);
+    expect(processedTurns).toHaveLength(1);
+    expect(processedTurns[0]?.messages[0]).toMatchObject({
+      role: "user",
+      content: [{ type: "text", text: "follow up after cleanup" }],
+    });
+  });
+});

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -19,6 +19,7 @@ import {
 import { getListenerBlockedReason } from "@/websocket/helpers/listener-queue-adapter";
 import { emitDequeuedUserMessage } from "./protocol-outbound";
 import {
+  clearStaleProcessingFlagIfIdle,
   emitListenerStatus,
   evictConversationRuntimeIfIdle,
   getActiveRuntime,
@@ -393,6 +394,15 @@ export function shouldProcessInboundMessageDirectly(
     return false;
   }
 
+  const activeScope = resolveRuntimeScope(runtime.listener, {
+    agent_id: runtime.agentId,
+    conversation_id: runtime.conversationId,
+  });
+  const pendingControlRequestCount = activeScope
+    ? getPendingControlRequestCount(runtime.listener, activeScope)
+    : 0;
+  clearStaleProcessingFlagIfIdle(runtime, pendingControlRequestCount);
+
   if (
     runtime.queueRuntime.length > 0 ||
     runtime.queuePumpActive ||
@@ -416,17 +426,11 @@ export function shouldProcessInboundMessageDirectly(
     return false;
   }
 
-  const activeScope = resolveRuntimeScope(runtime.listener, {
-    agent_id: runtime.agentId,
-    conversation_id: runtime.conversationId,
-  });
   return (
     getListenerBlockedReason({
       loopStatus: runtime.loopStatus,
       isProcessing: runtime.isProcessing,
-      pendingApprovalsLen: activeScope
-        ? getPendingControlRequestCount(runtime.listener, activeScope)
-        : 0,
+      pendingApprovalsLen: pendingControlRequestCount,
       cancelRequested: runtime.cancelRequested,
       isRecoveringApprovals: runtime.isRecoveringApprovals,
     }) === null
@@ -504,12 +508,15 @@ function computeListenerQueueBlockedReason(
     agent_id: runtime.agentId,
     conversation_id: runtime.conversationId,
   });
+  const pendingControlRequestCount = activeScope
+    ? getPendingControlRequestCount(runtime.listener, activeScope)
+    : 0;
+  clearStaleProcessingFlagIfIdle(runtime, pendingControlRequestCount);
+
   return getListenerBlockedReason({
     loopStatus: runtime.loopStatus,
     isProcessing: runtime.isProcessing,
-    pendingApprovalsLen: activeScope
-      ? getPendingControlRequestCount(runtime.listener, activeScope)
-      : 0,
+    pendingApprovalsLen: pendingControlRequestCount,
     cancelRequested: runtime.cancelRequested,
     isRecoveringApprovals: runtime.isRecoveringApprovals,
   });

--- a/src/websocket/listener/runtime.ts
+++ b/src/websocket/listener/runtime.ts
@@ -1,6 +1,7 @@
 import { createContextTracker } from "@/cli/helpers/context-tracker";
 import { createSharedReminderState } from "@/reminders/state";
 import type { PendingControlRequest } from "@/types/protocol_v2";
+import { debugWarn } from "@/utils/debug";
 import {
   normalizeConversationId,
   normalizeCwdAgentId,
@@ -244,6 +245,16 @@ export function clearActiveRunState(runtime: ConversationRuntime): void {
   runtime.activeAbortController = null;
 }
 
+export function markConversationRuntimeIdle(
+  runtime: ConversationRuntime,
+): void {
+  runtime.isProcessing = false;
+  runtime.isRecoveringApprovals = false;
+  runtime.activeExecutingToolCallIds = [];
+  runtime.loopStatus = "WAITING_ON_INPUT";
+  clearActiveRunState(runtime);
+}
+
 export function clearRecoveredApprovalState(
   runtime: ConversationRuntime,
 ): void {
@@ -265,13 +276,50 @@ export function clearConversationRuntimeState(
   runtime.pendingInterruptedResults = null;
   runtime.pendingInterruptedContext = null;
   runtime.pendingInterruptedToolCallIds = null;
-  runtime.activeExecutingToolCallIds = [];
-  runtime.loopStatus = "WAITING_ON_INPUT";
   runtime.continuationEpoch += 1;
   runtime.pendingTurns = 0;
   runtime.queuePumpActive = false;
   runtime.queuePumpScheduled = false;
-  clearActiveRunState(runtime);
+  markConversationRuntimeIdle(runtime);
+}
+
+// Defensive queue recovery: if an earlier cleanup path already returned the
+// conversation to an idle loop state and cleared every active-work handle, a
+// stale processing bit should not permanently block queued turns.
+export function clearStaleProcessingFlagIfIdle(
+  runtime: ConversationRuntime,
+  pendingControlRequestCount: number,
+): boolean {
+  if (
+    !runtime.isProcessing ||
+    runtime.loopStatus !== "WAITING_ON_INPUT" ||
+    runtime.cancelRequested ||
+    runtime.isRecoveringApprovals ||
+    pendingControlRequestCount > 0 ||
+    runtime.pendingApprovalResolvers.size > 0 ||
+    runtime.pendingApprovalBatchByToolCallId.size > 0 ||
+    runtime.recoveredApprovalState !== null ||
+    runtime.pendingInterruptedResults !== null ||
+    runtime.pendingInterruptedContext !== null ||
+    (runtime.pendingInterruptedToolCallIds?.length ?? 0) > 0 ||
+    runtime.activeExecutingToolCallIds.length > 0 ||
+    runtime.activeWorkingDirectory !== null ||
+    runtime.activeRunId !== null ||
+    runtime.activeRunStartedAt !== null ||
+    runtime.activeAbortController !== null
+  ) {
+    return false;
+  }
+
+  debugWarn(
+    "listener",
+    "Clearing stale processing flag for idle conversation runtime %s/%s (queueLen=%d)",
+    runtime.agentId ?? "unknown-agent",
+    runtime.conversationId,
+    runtime.queueRuntime?.length ?? 0,
+  );
+  runtime.isProcessing = false;
+  return true;
 }
 
 export function getRecoveredApprovalStateForScope(


### PR DESCRIPTION
Linear: LET-9543

Authored by Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974).

## Summary
- Release local listener processing ownership when runtime cleanup returns a conversation to idle.
- Add a narrow queue recovery guard for the stale idle split-brain state that can otherwise block follow-up turns as runtime_busy.
- Add focused listener runtime tests for cleanup, guard safety, and queued follow-up drain.

## Risk and limits
- isProcessing remains local listener ownership, not server truth.
- Server-side active run conflicts still rely on the existing 409/run polling path.
- The guard only clears when there is no active run, abort controller, executing tool, pending approval/control/interrupted state, cancel latch, or recovery state.
- This does not add a live downstream provider retry integration test; coverage is at the listener runtime and queue boundary that wedged.

## Validation
- bun test src/websocket/listener-runtime-state.test.ts src/websocket/listener-queue-adapter.test.ts src/websocket/listen-client-protocol.test.ts
  - 185 pass
- bun run check
  - 10 checks passed

👾 Generated with [Letta Code](https://letta.com)