### PR TITLE
feat: add OpenAI-compatible provider connection

### DIFF
--- a/src/backend/api/providers.ts
+++ b/src/backend/api/providers.ts
@@ -35,6 +35,7 @@ export async function checkProviderApiKey(
   accessKey?: string,
   region?: string,
   profile?: string,
+  baseURL?: string,
 ): Promise<void> {
   await apiRequest<{ message: string }>("POST", "/v1/providers/check", {
     provider_type: providerType,
@@ -42,6 +43,7 @@ export async function checkProviderApiKey(
     ...(accessKey && { access_key: accessKey }),
     ...(region && { region }),
     ...(profile && { profile }),
+    ...(baseURL && { base_url: baseURL }),
   });
 }
 
@@ -52,6 +54,7 @@ export async function createProvider(
   accessKey?: string,
   region?: string,
   profile?: string,
+  baseURL?: string,
 ): Promise<ProviderResponse> {
   return apiRequest<ProviderResponse>("POST", "/v1/providers", {
     name: providerName,
@@ -60,6 +63,7 @@ export async function createProvider(
     ...(accessKey && { access_key: accessKey }),
     ...(region && { region }),
     ...(profile && { profile }),
+    ...(baseURL && { base_url: baseURL }),
   });
 }
 
@@ -69,12 +73,14 @@ export async function updateProvider(
   accessKey?: string,
   region?: string,
   profile?: string,
+  baseURL?: string,
 ): Promise<ProviderResponse> {
   return apiRequest<ProviderResponse>("PATCH", `/v1/providers/${providerId}`, {
     api_key: apiKey,
     ...(accessKey && { access_key: accessKey }),
     ...(region && { region }),
     ...(profile && { profile }),
+    ...(baseURL && { base_url: baseURL }),
   });
 }
 
@@ -89,10 +95,18 @@ export async function createOrUpdateProvider(
   accessKey?: string,
   region?: string,
   profile?: string,
+  baseURL?: string,
 ): Promise<ProviderResponse> {
   const existing = await getProviderByName(providerName);
   if (existing) {
-    return updateProvider(existing.id, apiKey, accessKey, region, profile);
+    return updateProvider(
+      existing.id,
+      apiKey,
+      accessKey,
+      region,
+      profile,
+      baseURL,
+    );
   }
   return createProvider(
     providerType,
@@ -101,6 +115,7 @@ export async function createOrUpdateProvider(
     accessKey,
     region,
     profile,
+    baseURL,
   );
 }
 

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -580,7 +580,7 @@ async function handleConnectApiKeyProvider(
       undefined,
       undefined,
       undefined,
-      { target: ctx.target },
+      { target: ctx.target, connection: options },
     );
 
     updateCommandResult(

--- a/src/cli/connect-normalize.test.ts
+++ b/src/cli/connect-normalize.test.ts
@@ -64,6 +64,19 @@ describe("connect provider normalization", () => {
     expect(isConnectApiKeyProvider(openrouter)).toBe(true);
   });
 
+  test("resolves OpenAI-compatible API provider", () => {
+    const resolved = resolveConnectProvider("openai-compatible", "api");
+
+    if (!resolved) {
+      throw new Error("Expected openai-compatible provider to resolve");
+    }
+
+    expect(resolved.canonical).toBe("openai-compatible");
+    expect(resolved.byokProvider.providerType).toBe("openai");
+    expect(resolved.byokProvider.providerName).toBe("lc-openai-compatible");
+    expect(isConnectApiKeyProvider(resolved)).toBe(true);
+  });
+
   test("resolves bedrock as non-api-key provider", () => {
     const bedrock = resolveConnectProvider("bedrock", "api");
     if (!bedrock) {

--- a/src/providers/byok-providers.ts
+++ b/src/providers/byok-providers.ts
@@ -48,6 +48,7 @@ export interface ProviderConnectionOptions {
 
 export interface ProviderOperationOptions {
   target?: ProviderStorageTarget;
+  connection?: ProviderConnectionOptions;
 }
 
 // Field definition for multi-field providers (like Bedrock)
@@ -132,6 +133,21 @@ export const CONSTELLATION_BYOK_PROVIDERS: readonly ByokProvider[] = [
     description: "Connect an OpenAI API key",
     providerType: "openai",
     providerName: "lc-openai",
+  },
+  {
+    id: "openai-compatible",
+    displayName: "OpenAI-compatible API",
+    description: "Connect an OpenAI-compatible Chat Completions endpoint",
+    providerType: "openai",
+    providerName: "lc-openai-compatible",
+    fields: [
+      { key: "apiKey", label: "API Key", secret: true },
+      {
+        key: "baseUrl",
+        label: "Base URL",
+        placeholder: "https://proxy.example.com/v1",
+      },
+    ],
   },
   {
     id: "zai",
@@ -626,6 +642,7 @@ export async function checkProviderApiKey(
     accessKey,
     region,
     profile,
+    options.connection?.baseURL,
   );
 }
 
@@ -661,6 +678,7 @@ export async function createProvider(
     accessKey,
     region,
     profile,
+    options.baseURL,
   );
 }
 
@@ -689,7 +707,14 @@ export async function updateProvider(
       options,
     );
   }
-  return updateProviderRequest(providerId, apiKey, accessKey, region, profile);
+  return updateProviderRequest(
+    providerId,
+    apiKey,
+    accessKey,
+    region,
+    profile,
+    options.baseURL,
+  );
 }
 
 /**
@@ -739,6 +764,7 @@ export async function createOrUpdateProvider(
     accessKey,
     region,
     profile,
+    options.baseURL,
   );
 }
 

--- a/src/providers/connect-provider-service.test.ts
+++ b/src/providers/connect-provider-service.test.ts
@@ -232,9 +232,46 @@ describe("connect provider service", () => {
         label: "AWS Access Keys",
         description: "Enter access keys manually",
         fields: [
-          { key: "accessKey", label: "Access key" },
-          { key: "apiKey", label: "Secret key", secret: true },
+          { key: "accessKey", label: "Access key", required: true },
+          {
+            key: "apiKey",
+            label: "Secret key",
+            secret: true,
+            required: true,
+          },
         ],
+      },
+    ]);
+  });
+
+  test("serializes custom OpenAI-compatible fields", () => {
+    const providers: ByokProvider[] = [
+      {
+        id: "openai-compatible",
+        displayName: "OpenAI-compatible API",
+        description: "Connect an OpenAI-compatible endpoint",
+        providerType: "openai",
+        providerName: "lc-openai-compatible",
+        fields: [
+          { key: "apiKey", label: "API Key", secret: true },
+          {
+            key: "baseUrl",
+            label: "Base URL",
+            placeholder: "https://proxy.example.com/v1",
+          },
+        ],
+      },
+    ];
+
+    const entries = buildConnectProviderEntries(providers, new Map(), "api");
+
+    expect(entries[0]?.fields).toEqual([
+      { key: "apiKey", label: "API Key", secret: true, required: true },
+      {
+        key: "baseUrl",
+        label: "Base URL",
+        placeholder: "https://proxy.example.com/v1",
+        required: true,
       },
     ]);
   });

--- a/src/providers/connect-provider-service.ts
+++ b/src/providers/connect-provider-service.ts
@@ -116,6 +116,7 @@ function serializeFields(
     label: field.label,
     ...(field.placeholder ? { placeholder: field.placeholder } : {}),
     ...(field.secret !== undefined ? { secret: field.secret } : {}),
+    required: true,
   }));
 }
 
@@ -310,7 +311,7 @@ export async function connectProvider<TTarget extends ProviderStorageTarget>(
     resolved.accessKey,
     resolved.region,
     resolved.profile,
-    { target: input.target },
+    { target: input.target, connection: resolved.options },
   );
   await createOrUpdateProvider(
     provider.providerType,


### PR DESCRIPTION
## Summary
- add OpenAI-compatible API to the connect provider list
- collect and forward base URL when checking/saving API providers
- mark custom provider fields as required for dropdown forms

## Test
- bun test src/cli/connect-normalize.test.ts src/providers/connect-provider-service.test.ts
- bun run check