### PR TITLE
feat(models): add direct xAI Grok 4.5

### DIFF
--- a/src/agent/model-tier-selection.test.ts
+++ b/src/agent/model-tier-selection.test.ts
@@ -33,6 +33,17 @@ describe("getModelInfo", () => {
     });
   });
 
+  test("resolves direct xAI Grok 4.5 registry metadata", () => {
+    const info = getModelInfo("grok-4.5");
+    expect(info?.handle).toBe("xai/grok-4.5");
+    expect(info?.label).toBe("Grok 4.5");
+    expect(info?.updateArgs).toMatchObject({
+      context_window: 500000,
+      max_output_tokens: 16384,
+      parallel_tool_calls: true,
+    });
+  });
+
   test("resolves Fable 5 1M registry metadata", () => {
     const info = getModelInfo("fable-1m");
     expect(info?.handle).toBe("anthropic/claude-fable-5");

--- a/src/agent/modify-local.test.ts
+++ b/src/agent/modify-local.test.ts
@@ -7,7 +7,11 @@ import { configureBackendMode, getBackend } from "@/backend/backend";
 import { createOrUpdateLocalProvider } from "@/backend/local";
 import { LOCAL_BACKEND_DIR_ENV } from "@/backend/local/paths";
 import { clearAvailableModelsCache } from "./available-models";
-import { updateAgentLLMConfig, updateConversationLLMConfig } from "./modify";
+import {
+  __modifyTestUtils,
+  updateAgentLLMConfig,
+  updateConversationLLMConfig,
+} from "./modify";
 
 async function withLocalBackendStorage<T>(
   storageDir: string,
@@ -30,6 +34,20 @@ async function withLocalBackendStorage<T>(
 }
 
 describe("local model updates", () => {
+  test("builds direct xAI model settings for xAI handles", () => {
+    expect(
+      __modifyTestUtils.buildModelSettings("xai/grok-4.5", {
+        context_window: 500000,
+        max_output_tokens: 16384,
+        parallel_tool_calls: true,
+      }),
+    ).toMatchObject({
+      provider_type: "xai",
+      parallel_tool_calls: true,
+      max_output_tokens: 16384,
+    });
+  });
+
   afterEach(() => {
     configureBackendMode("api");
     clearAvailableModelsCache();

--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -60,6 +60,8 @@ function buildModelSettings(
     modelHandle.startsWith("minimax/");
   const isZai =
     explicitProviderType === "zai" || modelHandle.startsWith("zai/");
+  const isXai =
+    explicitProviderType === "xai" || modelHandle.startsWith("xai/");
   const isGoogleAI =
     explicitProviderType === "google_ai" ||
     modelHandle.startsWith("google_ai/");
@@ -148,6 +150,13 @@ function buildModelSettings(
     // Ensure parallel_tool_calls is enabled.
     settings = {
       provider_type: "zai",
+      parallel_tool_calls: true,
+    };
+  } else if (isXai) {
+    // xAI is OpenAI-compatible on the wire, but the backend must route through
+    // provider_type=xai so direct xAI handles do not fall back to OpenAI.
+    settings = {
+      provider_type: "xai",
       parallel_tool_calls: true,
     };
   } else if (isGoogleAI) {
@@ -260,6 +269,10 @@ function buildModelSettings(
 
   return settings;
 }
+
+export const __modifyTestUtils = {
+  buildModelSettings,
+};
 
 function updateArgsForModelSettings(
   updateArgs: Record<string, unknown> | undefined,

--- a/src/models.json
+++ b/src/models.json
@@ -1796,6 +1796,18 @@
       "isFeatured": true
     },
     {
+      "id": "grok-4.5",
+      "handle": "xai/grok-4.5",
+      "label": "Grok 4.5",
+      "description": "xAI's Grok 4.5 model via the direct xAI API",
+      "updateArgs": {
+        "context_window": 500000,
+        "max_output_tokens": 16384,
+        "parallel_tool_calls": true
+      },
+      "isFeatured": true
+    },
+    {
       "id": "glm-5.2",
       "handle": "zai/glm-5.2",
       "label": "GLM-5.2",


### PR DESCRIPTION
## Summary
- Add a Letta Code model registry preset for direct xAI Grok 4.5.
- Route xai/* model handles through provider_type=xai so they do not fall back to OpenAI-compatible generic routing.
- Keep this direct xAI only. No OpenRouter preset is added.

## Source
- Linear: LET-9548
- Cloud/Core support PR: https://github.com/letta-ai/letta-cloud/pull/12845
- Official source: https://docs.x.ai/docs/models
- Official source: https://docs.x.ai/docs/guides/chat

## Test plan
- bun test src/agent/model-tier-selection.test.ts
- bun test src/agent/model-tier-selection.test.ts src/agent/modify-local.test.ts
- bun run check

## Notes
- This client preset depends on Cloud/Core exposing and pricing xai/grok-4.5 before production users can select it successfully.

👾 Generated with [Letta Code](https://letta.com)