### PR TITLE
ci: dispatch downstream CLI version bump on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,3 +183,22 @@ jobs:
           generate_release_notes: true
           files: letta.js
           fail_on_unmatched_files: true
+
+      # Propagate the release downstream: dispatch the packaging bump
+      # workflow with the exact version so bundled copies of the CLI never
+      # silently lag behind published releases. Non-blocking: a failed
+      # dispatch must not fail the release (a scheduled fallback run on the
+      # receiving side picks up missed versions).
+      - name: Dispatch downstream CLI bump
+        if: steps.detect.outputs.should_publish == 'true' && steps.version.outputs.is_prerelease == 'false'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.AMELIA_GITHUB_TOKEN }}
+          TARGET_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # Brief wait so the npm registry has propagated the new version
+          # before the bump workflow tries to resolve it into lockfiles.
+          sleep 60
+          gh workflow run bump-code-desktop-letta-code.yml \
+            --repo letta-ai/letta-cloud \
+            -f letta_code_version="$TARGET_VERSION"


### PR DESCRIPTION
## Summary

- Published releases only propagate into downstream packaging when a bump workflow is manually dispatched, so bundled copies of the CLI can silently lag several releases behind the latest publish.
- The release workflow now dispatches that bump workflow automatically with the exact published version after each successful non-prerelease publish, using an existing cross-repo credential (same one the tools-sync workflow uses).
- Non-blocking (`continue-on-error`): a failed dispatch cannot fail the release. A scheduled fallback run on the receiving side picks up any missed versions.
- 60s pre-dispatch wait gives the npm registry time to propagate so the receiving workflow can resolve the new version into lockfiles.

👾 Generated with [Letta Code](https://letta.com)