### PR TITLE
feat(models): add GPT-5.6 presets

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,11 +1,10 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@letta-ai/letta-code",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.79.6",
+        "@earendil-works/pi-ai": "^0.80.5",
         "@letta-ai/letta-client": "^1.10.2",
         "@pierre/diffs": "1.2.2",
         "@scarf/scarf": "^1.4.0",
@@ -112,7 +111,7 @@
 
     "@discoveryjs/json-ext": ["@discoveryjs/json-ext@1.1.0", "", {}, "sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.79.6", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-KGepEdgEeWDs7Imwlp96tBsO8TjSIpcDBvazsCDtHRa81+uwJI/YGetTegI52pMlKhVpJFLIGajRi4PCGC5MUg=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.5", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-+7UODYKu4o/X8sxTHG8HEV3+O+dOYKg5MeO3MJIFQ+wu65pIWDhjZGc759uWsRr79AhV7MSJEe4GWnFn4l68gw=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
@@ -178,9 +177,13 @@
 
     "@letta-ai/letta-client": ["@letta-ai/letta-client@1.10.2", "", {}, "sha512-BYAPkIl6wHYORJ+zHmlWaPSrlsMbN5YkoSnHnEUvaIJBOpa5kLwldNjzHIALcSAV19Qc0ktRoIQy0i0Vqb21yQ=="],
 
-    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" } }, "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ=="],
+    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.6", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.40.0", "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ=="],
 
     "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
 
     "@pierre/diffs": ["@pierre/diffs@1.2.2", "", { "dependencies": { "@pierre/theme": "1.0.3", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-MvWLv2oSOJOF8oYXWLdhicguHM11G/VNWu6OPR5ZETolp2NM2/KPQG3cZTnKpJ6ImqEHwvw6Gl6z2gmmy2FQmQ=="],
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "^0.79.6",
+    "@earendil-works/pi-ai": "^0.80.5",
     "@letta-ai/letta-client": "^1.10.2",
     "@pierre/diffs": "1.2.2",
     "@scarf/scarf": "^1.4.0",

--- a/src/agent/model-tier-selection.test.ts
+++ b/src/agent/model-tier-selection.test.ts
@@ -84,6 +84,48 @@ describe("getModelInfoForLlmConfig", () => {
     expect(xhigh?.id).toBe("gpt-5.4-xhigh");
   });
 
+  test("selects gpt-5.6 alias tiers by reasoning_effort", () => {
+    const handle = "openai/gpt-5.6";
+
+    const high = getModelInfoForLlmConfig(handle, { reasoning_effort: "high" });
+    expect(high?.id).toBe("gpt-5.6-high");
+    expect(high?.handle).toBe("openai/gpt-5.6");
+    expect(high?.isFeatured).toBe(true);
+    expect(high?.updateArgs).toMatchObject({
+      reasoning_effort: "high",
+      context_window: 1050000,
+      max_output_tokens: 128000,
+      parallel_tool_calls: true,
+    });
+
+    const max = getModelInfoForLlmConfig(handle, { reasoning_effort: "max" });
+    expect(max?.id).toBe("gpt-5.6-max");
+
+    const oldFeatured = getModelInfoForLlmConfig("openai/gpt-5.5", {
+      reasoning_effort: "high",
+    });
+    expect(oldFeatured?.id).toBe("gpt-5.5-high");
+    expect(oldFeatured?.isFeatured).toBeUndefined();
+  });
+
+  test("selects gpt-5.6 named variant tiers by reasoning_effort", () => {
+    expect(
+      getModelInfoForLlmConfig("openai/gpt-5.6-sol", {
+        reasoning_effort: "max",
+      })?.id,
+    ).toBe("gpt-5.6-sol-max");
+    expect(
+      getModelInfoForLlmConfig("openai/gpt-5.6-terra", {
+        reasoning_effort: "medium",
+      })?.id,
+    ).toBe("gpt-5.6-terra-medium");
+    expect(
+      getModelInfoForLlmConfig("openai/gpt-5.6-luna", {
+        reasoning_effort: "none",
+      })?.id,
+    ).toBe("gpt-5.6-luna-none");
+  });
+
   test("uses ChatGPT metadata for local ChatGPT OAuth handles", () => {
     const info = getModelInfoForLlmConfig("openai-codex/gpt-5.5", {
       reasoning_effort: "high",
@@ -179,6 +221,33 @@ describe("getReasoningTierOptionsForHandle", () => {
       "gpt-5.4-high",
       "gpt-5.4-xhigh",
     ]);
+  });
+
+  test("returns ordered reasoning options for gpt-5.6 models", () => {
+    const expectedEfforts = [
+      "none",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ] as const;
+    const handles = [
+      ["openai/gpt-5.6", "gpt-5.6"],
+      ["openai/gpt-5.6-sol", "gpt-5.6-sol"],
+      ["openai/gpt-5.6-terra", "gpt-5.6-terra"],
+      ["openai/gpt-5.6-luna", "gpt-5.6-luna"],
+    ] as const;
+
+    for (const [handle, idPrefix] of handles) {
+      const options = getReasoningTierOptionsForHandle(handle);
+      expect(options.map((option) => option.effort)).toEqual([
+        ...expectedEfforts,
+      ]);
+      expect(options.map((option) => option.modelId)).toEqual(
+        expectedEfforts.map((effort) => `${idPrefix}-${effort}`),
+      );
+    }
   });
 
   test("returns ordered reasoning options for gpt-5.3-codex", () => {

--- a/src/agent/model-tier-selection.test.ts
+++ b/src/agent/model-tier-selection.test.ts
@@ -306,6 +306,26 @@ describe("getReasoningTierOptionsForHandle", () => {
     ]);
   });
 
+  test("returns ChatGPT reasoning options for local ChatGPT OAuth gpt-5.6 named variants", () => {
+    const options = getReasoningTierOptionsForHandle(
+      "openai-codex/gpt-5.6-sol",
+    );
+    expect(options.map((option) => option.effort)).toEqual([
+      "none",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+    expect(options.map((option) => option.modelId)).toEqual([
+      "gpt-5.6-sol-plus-pro-none",
+      "gpt-5.6-sol-plus-pro-low",
+      "gpt-5.6-sol-plus-pro-medium",
+      "gpt-5.6-sol-plus-pro-high",
+      "gpt-5.6-sol-plus-pro-xhigh",
+    ]);
+  });
+
   test("returns byok reasoning options for chatgpt-plus-pro gpt-5.5-fast", () => {
     const options = getReasoningTierOptionsForHandle(
       "chatgpt-plus-pro/gpt-5.5-fast",

--- a/src/agent/modify-local.test.ts
+++ b/src/agent/modify-local.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getModel } from "@earendil-works/pi-ai";
+import { getModel } from "@earendil-works/pi-ai/compat";
 import { configureBackendMode, getBackend } from "@/backend/backend";
 import { createOrUpdateLocalProvider } from "@/backend/local";
 import { LOCAL_BACKEND_DIR_ENV } from "@/backend/local/paths";

--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -1,5 +1,5 @@
 import type { Api, Model, ThinkingLevel } from "@earendil-works/pi-ai";
-import { getModel, getModels } from "@earendil-works/pi-ai";
+import { getModel, getModels } from "@earendil-works/pi-ai/compat";
 import {
   getOAuthProvider,
   type OAuthCredentials,
@@ -7,6 +7,7 @@ import {
 import {
   getLocalOAuthApiKey,
   getLocalProviderRecordByName,
+  getLocalProviderRecordByType,
   type LocalProviderRecord,
   localProviderApiKeyFromRecord,
 } from "@/backend/local/local-provider-auth-store";
@@ -194,16 +195,35 @@ export function resolvePiProviderFromAgent(
 export function resolvePiModelFromAgent(
   model: string | undefined,
   provider: PiProvider,
+  providerType?: string,
 ): string | undefined {
-  return stripProviderHandlePrefix(model, provider);
+  const resolved = stripProviderHandlePrefix(model, provider);
+  if (resolved !== model) return resolved;
+
+  const slashIndex = model?.indexOf("/") ?? -1;
+  const spec = getPiProviderSpec(provider);
+  if (
+    slashIndex > 0 &&
+    providerType !== undefined &&
+    spec.providerTypes.includes(providerType)
+  ) {
+    return model?.slice(slashIndex + 1);
+  }
+
+  return resolved;
 }
 
 function localProviderRecord(
   providerNames: readonly string[],
   storageDir?: string,
+  providerTypes: readonly string[] = [],
 ): LocalProviderRecord | null {
   for (const providerName of providerNames) {
     const record = getLocalProviderRecordByName(providerName, storageDir);
+    if (record) return record;
+  }
+  for (const providerType of providerTypes) {
+    const record = getLocalProviderRecordByType(providerType, storageDir);
     if (record) return record;
   }
   return null;
@@ -213,6 +233,7 @@ function localProviderConnection(
   providerNames: readonly string[],
   envValue: string | undefined,
   storageDir?: string,
+  providerTypes: readonly string[] = [],
 ): {
   apiKey?: string;
   baseURL?: string;
@@ -220,7 +241,7 @@ function localProviderConnection(
   headers?: Record<string, string>;
   record?: LocalProviderRecord;
 } {
-  const record = localProviderRecord(providerNames, storageDir);
+  const record = localProviderRecord(providerNames, storageDir, providerTypes);
   return {
     apiKey: localProviderApiKeyFromRecord(record) ?? envValue,
     baseURL: record?.base_url,
@@ -497,13 +518,22 @@ export async function resolvePiModelForAgent(
     : resolvePiProviderFromAgent(concreteModelHandle, modelSettings);
   const registeredProvider = getRegisteredPiProvider(provider);
   const spec = isPiProvider(provider) ? getPiProviderSpec(provider) : undefined;
+  const storageDir = options.localProviderAuthStorageDir;
+  const preferredProviderType =
+    typeof modelSettings.provider_type === "string"
+      ? modelSettings.provider_type
+      : options.preferredProviderType;
   const modelId =
     options.model ??
     (registeredProvider
       ? stripRegisteredProviderHandlePrefix(concreteModelHandle, provider)
       : undefined) ??
     (spec
-      ? resolvePiModelFromAgent(concreteModelHandle, spec.id)
+      ? resolvePiModelFromAgent(
+          concreteModelHandle,
+          spec.id,
+          preferredProviderType,
+        )
       : undefined) ??
     registeredProvider?.config.models?.[0]?.id ??
     (spec?.defaultModel
@@ -511,12 +541,6 @@ export async function resolvePiModelForAgent(
       : undefined) ??
     process.env.LETTA_CODE_DEV_PI_MODEL ??
     "";
-  const storageDir = options.localProviderAuthStorageDir;
-  const preferredProviderType =
-    typeof modelSettings.provider_type === "string"
-      ? modelSettings.provider_type
-      : options.preferredProviderType;
-
   let connection = registeredProvider
     ? resolveRegisteredPiProviderRuntimeConnection(
         registeredProvider,
@@ -527,6 +551,7 @@ export async function resolvePiModelForAgent(
           spec.localProviderNames,
           spec.apiKeyEnv?.() ?? spec.fallbackApiKey,
           storageDir,
+          spec.providerTypes,
         )
       : {
           timeout: resolveLocalProviderTimeout({ providerIds: [provider] }),
@@ -559,6 +584,7 @@ export async function resolvePiModelForAgent(
     const oauth = await getLocalOAuthApiKey({
       providerId: spec.piProvider,
       providerNames: spec.localProviderNames,
+      providerTypes: spec.providerTypes,
       storageDir,
     });
     connection = {

--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -1,5 +1,9 @@
 import type { Api, KnownProvider, Model } from "@earendil-works/pi-ai";
-import { getEnvApiKey, getModels, getProviders } from "@earendil-works/pi-ai";
+import {
+  getEnvApiKey,
+  getModels,
+  getProviders,
+} from "@earendil-works/pi-ai/compat";
 
 export const LOCAL_CHATGPT_PROVIDER_NAME = "chatgpt-plus-pro";
 export const LOCAL_OPENAI_PROVIDER_NAME = "lc-openai";
@@ -414,10 +418,15 @@ export function resolveLocalModel(provider: PiProvider): string | undefined {
 
 function isProviderConfigured(
   provider: PiProviderSpec,
-  localProviderNames: ReadonlySet<string>,
+  localProviderIdentifiers: ReadonlySet<string>,
 ): boolean {
   return (
-    provider.localProviderNames.some((name) => localProviderNames.has(name)) ||
+    provider.localProviderNames.some((name) =>
+      localProviderIdentifiers.has(name),
+    ) ||
+    provider.providerTypes.some((providerType) =>
+      localProviderIdentifiers.has(providerType),
+    ) ||
     provider.envConfigured?.() === true
   );
 }

--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -1,18 +1,20 @@
+import type {
+  AssistantMessage,
+  AssistantMessageEvent,
+  Context,
+  Message,
+  Model,
+  SimpleStreamOptions,
+  Tool,
+  TSchema,
+  Usage,
+} from "@earendil-works/pi-ai";
 import {
-  type AssistantMessage,
-  type AssistantMessageEvent,
-  type Context,
   isContextOverflow,
-  type Message,
-  type Model,
-  type SimpleStreamOptions,
   stream,
   streamSimple,
-  type Tool,
-  type TSchema,
   Type,
-  type Usage,
-} from "@earendil-works/pi-ai";
+} from "@earendil-works/pi-ai/compat";
 import type { LocalCompactionStats } from "@/backend/local/compaction";
 import {
   emptyLocalUsage,

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -19,7 +19,7 @@ import type {
   Model,
   SimpleStreamOptions,
 } from "@earendil-works/pi-ai";
-import { getModel } from "@earendil-works/pi-ai";
+import { getModel } from "@earendil-works/pi-ai/compat";
 import type { Stream } from "@letta-ai/letta-client/core/streaming";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import type { ConversationMessageCreateBody } from "@/backend";

--- a/src/backend/local/compaction.ts
+++ b/src/backend/local/compaction.ts
@@ -1,12 +1,14 @@
+import type {
+  AssistantMessage,
+  Context,
+  Model,
+  SimpleStreamOptions,
+} from "@earendil-works/pi-ai";
 import {
-  type AssistantMessage,
-  type Context,
   complete,
   completeSimple,
   isContextOverflow,
-  type Model,
-  type SimpleStreamOptions,
-} from "@earendil-works/pi-ai";
+} from "@earendil-works/pi-ai/compat";
 import { isContextWindowOverflowError } from "@/backend/dev/context-window-overflow";
 import {
   applyPiEnvOverrides,

--- a/src/backend/local/local-message.ts
+++ b/src/backend/local/local-message.ts
@@ -3,7 +3,7 @@ import type {
   AssistantMessage,
   ImageContent,
   Message as PiMessage,
-  Provider,
+  ProviderId,
   TextContent,
   ThinkingContent,
   ToolCall,
@@ -63,7 +63,7 @@ export interface LocalAssistantMessage
   role: "assistant";
   content: (LocalTextContent | LocalThinkingContent | LocalToolCall)[];
   api: Api;
-  provider: Provider;
+  provider: ProviderId;
   model: string;
   usage: Usage;
   timestamp: number;

--- a/src/backend/local/local-model-config.ts
+++ b/src/backend/local/local-model-config.ts
@@ -1,4 +1,5 @@
-import { type Api, getModels, type Model } from "@earendil-works/pi-ai";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { getModels } from "@earendil-works/pi-ai/compat";
 import {
   DEFAULT_PI_PROVIDER,
   isUnselectedLocalModelHandle,
@@ -190,18 +191,36 @@ async function discoverOllamaModelIds(input: {
   }
 }
 
-function localProviderNamesFromRecords(
+function localProviderIdentifiersFromRecords(
   records: readonly LocalProviderRecord[],
 ): Set<string> {
-  return new Set(records.map((record) => record.name));
+  return new Set(
+    records.flatMap((record) => [record.name, record.provider_type]),
+  );
 }
 
 function providerRecordFor(
   provider: PiProvider,
   records: readonly LocalProviderRecord[],
 ): LocalProviderRecord | undefined {
-  const names = getPiProviderSpec(provider).localProviderNames;
-  return records.find((record) => names.includes(record.name));
+  const spec = getPiProviderSpec(provider);
+  return records.find(
+    (record) =>
+      spec.localProviderNames.includes(record.name) ||
+      spec.providerTypes.includes(record.provider_type),
+  );
+}
+
+function catalogHandleProviderFor(
+  provider: PiProvider,
+  records: readonly LocalProviderRecord[],
+): PiProvider | string {
+  const spec = getPiProviderSpec(provider);
+  const record = providerRecordFor(provider, records);
+  if (record && !spec.localProviderNames.includes(record.name)) {
+    return record.name;
+  }
+  return provider;
 }
 
 function isDiscoverableLocalProvider(provider: PiProvider): boolean {
@@ -256,8 +275,9 @@ export function resolveLocalProvider(storageDir?: string): PiProvider {
   );
   if (registeredProvider) return registeredProvider.providerName as PiProvider;
   return (
-    listConfiguredPiProviders(localProviderNamesFromRecords(records))[0] ??
-    DEFAULT_PI_PROVIDER
+    listConfiguredPiProviders(
+      localProviderIdentifiersFromRecords(records),
+    )[0] ?? DEFAULT_PI_PROVIDER
   );
 }
 
@@ -406,7 +426,7 @@ export async function listLocalModels(
   options: ListLocalModelsOptions = {},
 ) {
   const records = listLocalProviderRecords(storageDir);
-  const providerNames = localProviderNamesFromRecords(records);
+  const providerNames = localProviderIdentifiersFromRecords(records);
   const configured = resolveLocalModelConfig(storageDir);
   const models: LocalModelListEntry[] = [];
   const registeredProviders = listRegisteredPiProviders();
@@ -484,7 +504,18 @@ export async function listLocalModels(
     !registeredProvidersWithModels.has(configured.provider) &&
     configuredProviderIsConfigured
   ) {
-    addModel(configured.provider, configured.model);
+    const handleProvider = catalogHandleProviderFor(
+      configured.provider,
+      records,
+    );
+    const model =
+      handleProvider === configured.provider
+        ? configured.model
+        : (stripProviderHandlePrefix(configured.model, configured.provider) ??
+          configured.model);
+    addModel(handleProvider, model, {
+      modelEndpointType: localProviderTypeForModelConfig(configured.provider),
+    });
   }
   const discoveryOptions: Required<ListLocalModelsOptions> = {
     fetch: options.fetch ?? fetch,
@@ -531,8 +562,15 @@ export async function listLocalModels(
   );
 
   for (const result of discoveryResults) {
+    const handleProvider = catalogHandleProviderFor(result.provider, records);
     for (const model of result.models) {
-      addModel(result.provider, model);
+      const modelId =
+        handleProvider === result.provider
+          ? model
+          : (stripProviderHandlePrefix(model, result.provider) ?? model);
+      addModel(handleProvider, modelId, {
+        modelEndpointType: localProviderTypeForModelConfig(result.provider),
+      });
     }
   }
   return models;

--- a/src/backend/local/local-provider-auth-store.ts
+++ b/src/backend/local/local-provider-auth-store.ts
@@ -396,9 +396,14 @@ export function localOAuthAuthFromCredentials(
 function localOAuthRecord(
   providerNames: readonly string[],
   storageDir?: string,
+  providerTypes: readonly string[] = [],
 ): LocalProviderRecord | undefined {
   for (const providerName of providerNames) {
     const record = getLocalProviderRecordByName(providerName, storageDir);
+    if (record?.auth.type === "oauth") return record;
+  }
+  for (const providerType of providerTypes) {
+    const record = getLocalProviderRecordByType(providerType, storageDir);
     if (record?.auth.type === "oauth") return record;
   }
   return undefined;
@@ -407,8 +412,9 @@ function localOAuthRecord(
 export function getLocalOAuthCredentials(
   providerNames: readonly string[],
   storageDir?: string,
+  providerTypes: readonly string[] = [],
 ): OAuthCredentials | undefined {
-  const record = localOAuthRecord(providerNames, storageDir);
+  const record = localOAuthRecord(providerNames, storageDir, providerTypes);
   return record
     ? toPiOAuthCredentials(record.auth as LocalProviderOAuthAuth)
     : undefined;
@@ -417,6 +423,7 @@ export function getLocalOAuthCredentials(
 export async function getLocalOAuthApiKey(input: {
   providerId: string;
   providerNames: readonly string[];
+  providerTypes?: readonly string[];
   storageDir?: string;
 }): Promise<
   | {
@@ -425,7 +432,11 @@ export async function getLocalOAuthApiKey(input: {
     }
   | undefined
 > {
-  const record = localOAuthRecord(input.providerNames, input.storageDir);
+  const record = localOAuthRecord(
+    input.providerNames,
+    input.storageDir,
+    input.providerTypes,
+  );
   if (!record || record.auth.type !== "oauth") return undefined;
 
   const result = await getOAuthApiKey(input.providerId, {
@@ -454,6 +465,7 @@ export async function getLocalChatGPTApiKey(
   const result = await getLocalOAuthApiKey({
     providerId: "openai-codex",
     providerNames: [LOCAL_CHATGPT_PROVIDER_NAME, "openai-codex"],
+    providerTypes: ["chatgpt_oauth", "openai-codex"],
     storageDir,
   });
   return result?.apiKey;

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getModels } from "@earendil-works/pi-ai";
+import { getModels } from "@earendil-works/pi-ai/compat";
 import { getOAuthProvider } from "@earendil-works/pi-ai/oauth";
 import {
   applyPiEnvOverrides,
@@ -150,6 +150,37 @@ describe("pi model factory", () => {
         { localProviderAuthStorageDir: storageDir },
       );
 
+      expect(resolved.apiKey).toBe("chatgpt-access-token");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("resolves custom-named ChatGPT OAuth GPT-5.6 handles through provider_type", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "pi-chatgpt-custom-"));
+    try {
+      await createOrUpdateLocalProvider({
+        storageDir,
+        providerType: "chatgpt_oauth",
+        providerName: "chatgpt-personal",
+        apiKey: JSON.stringify({
+          access_token: "chatgpt-access-token",
+          id_token: "chatgpt-id-token",
+          refresh_token: "chatgpt-refresh-token",
+          account_id: "account-123",
+          expires_at: Date.now() + 60_000,
+        }),
+      });
+
+      const resolved = await resolvePiModelForAgent(
+        "chatgpt-personal/gpt-5.6-sol",
+        { provider_type: "chatgpt_oauth" },
+        { localProviderAuthStorageDir: storageDir },
+      );
+
+      expect(resolved.provider).toBe("openai-codex");
+      expect(resolved.model.id).toBe("gpt-5.6-sol");
+      expect(resolved.model.contextWindow).toBe(272000);
       expect(resolved.apiKey).toBe("chatgpt-access-token");
     } finally {
       await rm(storageDir, { recursive: true, force: true });

--- a/src/cli/components/ModelSelector-byok-custom-provider.test.tsx
+++ b/src/cli/components/ModelSelector-byok-custom-provider.test.tsx
@@ -67,6 +67,9 @@ describe("ModelSelector custom BYOK provider detection", () => {
     expect(
       registryHandleForByokAlias("chatgpt-personal/gpt-5.5", aliases),
     ).toBe("chatgpt-plus-pro/gpt-5.5");
+    expect(
+      registryHandleForByokAlias("chatgpt-personal/gpt-5.6-sol", aliases),
+    ).toBe("chatgpt-plus-pro/gpt-5.6-sol");
     expect(registryHandleForByokAlias("openai-sarah/gpt-5.5", aliases)).toBe(
       "openai/gpt-5.5",
     );

--- a/src/cli/components/ModelSelector.tsx
+++ b/src/cli/components/ModelSelector.tsx
@@ -384,10 +384,24 @@ export function ModelSelector({
   }, [forceRefreshOnMount]);
 
   useEffect(() => {
-    if (localModelCatalog) {
-      setByokProviderAliases(buildByokProviderAliases([]));
-      return;
-    }
+    if (!localModelCatalog) return;
+    const providers = Array.from(providerTypesByHandle.entries()).flatMap(
+      ([handle, providerType]) => {
+        const slashIndex = handle.indexOf("/");
+        if (slashIndex <= 0) return [];
+        return [
+          {
+            name: handle.slice(0, slashIndex),
+            provider_type: providerType,
+          },
+        ];
+      },
+    );
+    setByokProviderAliases(buildByokProviderAliases(providers, "local"));
+  }, [localModelCatalog, providerTypesByHandle]);
+
+  useEffect(() => {
+    if (localModelCatalog) return;
     (async () => {
       try {
         const providers = await listProviders();
@@ -472,7 +486,10 @@ export function ModelSelector({
 
   const modelsForBackendHandle = useCallback(
     (handle: string, includeUnknown: boolean): UiModel[] => {
-      const registryHandle = normalizeModelHandleForRegistry(handle) ?? handle;
+      const registryHandle = registryHandleForByokAlias(
+        handle,
+        byokProviderAliases,
+      );
       const baseStaticModel = pickPreferredStaticModel(registryHandle);
       const fastRegistryHandle =
         getChatGptFastRegistryHandleForModelHandle(handle);
@@ -526,7 +543,12 @@ export function ModelSelector({
 
       return result;
     },
-    [pickPreferredStaticModel, withActualHandle, withProviderTypeMetadata],
+    [
+      byokProviderAliases,
+      pickPreferredStaticModel,
+      withActualHandle,
+      withProviderTypeMetadata,
+    ],
   );
 
   // Supported models: models.json entries that are available

--- a/src/models.json
+++ b/src/models.json
@@ -1315,6 +1315,319 @@
       }
     },
     {
+      "id": "gpt-5.6-none",
+      "handle": "openai/gpt-5.6",
+      "label": "GPT-5.6",
+      "description": "OpenAI's latest frontier agentic coding model (no reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "none",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-low",
+      "handle": "openai/gpt-5.6",
+      "label": "GPT-5.6",
+      "description": "OpenAI's latest frontier agentic coding model (low reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "low",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-medium",
+      "handle": "openai/gpt-5.6",
+      "label": "GPT-5.6",
+      "description": "OpenAI's latest frontier agentic coding model (med reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "medium",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-high",
+      "handle": "openai/gpt-5.6",
+      "label": "GPT-5.6",
+      "description": "OpenAI's latest frontier agentic coding model (high reasoning)",
+      "isFeatured": true,
+      "updateArgs": {
+        "reasoning_effort": "high",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-xhigh",
+      "handle": "openai/gpt-5.6",
+      "label": "GPT-5.6",
+      "description": "OpenAI's latest frontier agentic coding model (extra-high reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "xhigh",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-max",
+      "handle": "openai/gpt-5.6",
+      "label": "GPT-5.6",
+      "description": "OpenAI's latest frontier agentic coding model (max reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "max",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-none",
+      "handle": "openai/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol",
+      "description": "GPT-5.6 Sol (no reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "none",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-low",
+      "handle": "openai/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol",
+      "description": "GPT-5.6 Sol (low reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "low",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-medium",
+      "handle": "openai/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol",
+      "description": "GPT-5.6 Sol (med reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "medium",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-high",
+      "handle": "openai/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol",
+      "description": "GPT-5.6 Sol (high reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "high",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-xhigh",
+      "handle": "openai/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol",
+      "description": "GPT-5.6 Sol (extra-high reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "xhigh",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-max",
+      "handle": "openai/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol",
+      "description": "GPT-5.6 Sol (max reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "max",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-none",
+      "handle": "openai/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra",
+      "description": "GPT-5.6 Terra (no reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "none",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-low",
+      "handle": "openai/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra",
+      "description": "GPT-5.6 Terra (low reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "low",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-medium",
+      "handle": "openai/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra",
+      "description": "GPT-5.6 Terra (med reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "medium",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-high",
+      "handle": "openai/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra",
+      "description": "GPT-5.6 Terra (high reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "high",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-xhigh",
+      "handle": "openai/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra",
+      "description": "GPT-5.6 Terra (extra-high reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "xhigh",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-max",
+      "handle": "openai/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra",
+      "description": "GPT-5.6 Terra (max reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "max",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-none",
+      "handle": "openai/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna",
+      "description": "GPT-5.6 Luna (no reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "none",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-low",
+      "handle": "openai/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna",
+      "description": "GPT-5.6 Luna (low reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "low",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-medium",
+      "handle": "openai/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna",
+      "description": "GPT-5.6 Luna (med reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "medium",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-high",
+      "handle": "openai/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna",
+      "description": "GPT-5.6 Luna (high reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "high",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-xhigh",
+      "handle": "openai/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna",
+      "description": "GPT-5.6 Luna (extra-high reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "xhigh",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-max",
+      "handle": "openai/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna",
+      "description": "GPT-5.6 Luna (max reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "max",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "gpt-5.5-none",
       "handle": "openai/gpt-5.5",
       "label": "GPT-5.5",
@@ -1358,7 +1671,6 @@
       "handle": "openai/gpt-5.5",
       "label": "GPT-5.5",
       "description": "OpenAI's most capable model (high reasoning)",
-      "isFeatured": true,
       "updateArgs": {
         "reasoning_effort": "high",
         "verbosity": "medium",

--- a/src/models.json
+++ b/src/models.json
@@ -1302,6 +1302,201 @@
       }
     },
     {
+      "id": "gpt-5.6-sol-plus-pro-none",
+      "handle": "chatgpt-plus-pro/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol (ChatGPT)",
+      "description": "GPT-5.6 Sol (no reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "none",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-plus-pro-low",
+      "handle": "chatgpt-plus-pro/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol (ChatGPT)",
+      "description": "GPT-5.6 Sol (low reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "low",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-plus-pro-medium",
+      "handle": "chatgpt-plus-pro/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol (ChatGPT)",
+      "description": "GPT-5.6 Sol (med reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "medium",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-plus-pro-high",
+      "handle": "chatgpt-plus-pro/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol (ChatGPT)",
+      "description": "GPT-5.6 Sol (high reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "high",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-plus-pro-xhigh",
+      "handle": "chatgpt-plus-pro/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol (ChatGPT)",
+      "description": "GPT-5.6 Sol (extra-high reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "xhigh",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-plus-pro-none",
+      "handle": "chatgpt-plus-pro/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra (ChatGPT)",
+      "description": "GPT-5.6 Terra (no reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "none",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-plus-pro-low",
+      "handle": "chatgpt-plus-pro/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra (ChatGPT)",
+      "description": "GPT-5.6 Terra (low reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "low",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-plus-pro-medium",
+      "handle": "chatgpt-plus-pro/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra (ChatGPT)",
+      "description": "GPT-5.6 Terra (med reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "medium",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-plus-pro-high",
+      "handle": "chatgpt-plus-pro/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra (ChatGPT)",
+      "description": "GPT-5.6 Terra (high reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "high",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-plus-pro-xhigh",
+      "handle": "chatgpt-plus-pro/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra (ChatGPT)",
+      "description": "GPT-5.6 Terra (extra-high reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "xhigh",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-plus-pro-none",
+      "handle": "chatgpt-plus-pro/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna (ChatGPT)",
+      "description": "GPT-5.6 Luna (no reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "none",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-plus-pro-low",
+      "handle": "chatgpt-plus-pro/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna (ChatGPT)",
+      "description": "GPT-5.6 Luna (low reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "low",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-plus-pro-medium",
+      "handle": "chatgpt-plus-pro/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna (ChatGPT)",
+      "description": "GPT-5.6 Luna (med reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "medium",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-plus-pro-high",
+      "handle": "chatgpt-plus-pro/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna (ChatGPT)",
+      "description": "GPT-5.6 Luna (high reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "high",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-plus-pro-xhigh",
+      "handle": "chatgpt-plus-pro/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna (ChatGPT)",
+      "description": "GPT-5.6 Luna (extra-high reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "xhigh",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "gpt-5-codex",
       "handle": "openai/gpt-5-codex",
       "label": "GPT-5-Codex",

--- a/src/providers/byok-providers.ts
+++ b/src/providers/byok-providers.ts
@@ -3,7 +3,7 @@
  * Unified module for managing custom LLM provider connections
  */
 
-import { getProviders } from "@earendil-works/pi-ai";
+import { getProviders } from "@earendil-works/pi-ai/compat";
 import { getOAuthProviders } from "@earendil-works/pi-ai/oauth";
 import {
   checkProviderApiKey as checkProviderApiKeyRequest,

--- a/src/providers/local-pi-provider-catalog.test.ts
+++ b/src/providers/local-pi-provider-catalog.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getModels, getProviders } from "@earendil-works/pi-ai";
+import { getModels, getProviders } from "@earendil-works/pi-ai/compat";
 import {
   getOAuthProvider,
   getOAuthProviders,
@@ -133,6 +133,45 @@ describe("local pi provider catalog", () => {
       expect(
         models.some((model) => model.handle === "anthropic/claude-opus-4-8"),
       ).toBe(true);
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("local ChatGPT OAuth catalog includes GPT-5.6 named models for custom provider names", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-chatgpt-56-"));
+    try {
+      setLocalOAuthProvider({
+        storageDir,
+        providerName: "chatgpt-personal",
+        providerType: "chatgpt_oauth",
+        auth: localOAuthAuthFromCredentials({
+          access: "chatgpt-access-token",
+          refresh: "chatgpt-refresh-token",
+          expires: Date.now() + 60_000,
+        }),
+      });
+
+      const models = await listLocalModels(storageDir);
+      expect(models).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            handle: "chatgpt-personal/gpt-5.6-sol",
+            model_endpoint_type: "chatgpt_oauth",
+          }),
+          expect.objectContaining({
+            handle: "chatgpt-personal/gpt-5.6-terra",
+            model_endpoint_type: "chatgpt_oauth",
+          }),
+          expect.objectContaining({
+            handle: "chatgpt-personal/gpt-5.6-luna",
+            model_endpoint_type: "chatgpt_oauth",
+          }),
+        ]),
+      );
+      expect(
+        models.some((model) => model.handle === "chatgpt-personal/gpt-5.6"),
+      ).toBe(false);
     } finally {
       await rm(storageDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- Adds OpenAI GPT-5.6 Sol alias plus Sol, Terra, and Luna presets to the Letta Code model registry.
- Exposes none, low, medium, high, xhigh, and max reasoning tiers with the documented 1.05M context window and 128k max output.
- Moves the featured OpenAI GPT preset from GPT-5.5 high to GPT-5.6 high.

Linear: LET-9550

## Test plan
- jq empty src/models.json
- bun test src/agent/model-tier-selection.test.ts
- bun test src/cli/components/ModelSelector-categories.test.tsx
- bun run typecheck
- bun run check

👾 Generated with [Letta Code](https://letta.com)