### PR TITLE
feat(models): add GPT-5.6 and Grok 4.5

### DIFF
--- a/src/agent/model-tier-selection.test.ts
+++ b/src/agent/model-tier-selection.test.ts
@@ -66,6 +66,17 @@ describe("getModelInfo", () => {
       parallel_tool_calls: true,
     });
   });
+
+  test("resolves direct xAI Grok 4.5 registry metadata", () => {
+    const info = getModelInfo("grok-4.5");
+    expect(info?.handle).toBe("xai/grok-4.5");
+    expect(info?.label).toBe("Grok 4.5");
+    expect(info?.updateArgs).toMatchObject({
+      context_window: 500000,
+      max_output_tokens: 16384,
+      parallel_tool_calls: true,
+    });
+  });
 });
 
 describe("getModelInfoForLlmConfig", () => {
@@ -82,6 +93,21 @@ describe("getModelInfoForLlmConfig", () => {
       reasoning_effort: "xhigh",
     });
     expect(xhigh?.id).toBe("gpt-5.4-xhigh");
+  });
+
+  test("selects gpt-5.6 sol tier by reasoning_effort", () => {
+    const handle = "openai/gpt-5.6-sol";
+
+    const high = getModelInfoForLlmConfig(handle, { reasoning_effort: "high" });
+    expect(high?.id).toBe("gpt-5.6-sol");
+
+    const none = getModelInfoForLlmConfig(handle, { reasoning_effort: "none" });
+    expect(none?.id).toBe("gpt-5.6-sol-none");
+
+    const xhigh = getModelInfoForLlmConfig(handle, {
+      reasoning_effort: "xhigh",
+    });
+    expect(xhigh?.id).toBe("gpt-5.6-sol-xhigh");
   });
 
   test("uses ChatGPT metadata for local ChatGPT OAuth handles", () => {
@@ -178,6 +204,24 @@ describe("getReasoningTierOptionsForHandle", () => {
       "gpt-5.4-medium",
       "gpt-5.4-high",
       "gpt-5.4-xhigh",
+    ]);
+  });
+
+  test("returns ordered reasoning options for gpt-5.6 sol", () => {
+    const options = getReasoningTierOptionsForHandle("openai/gpt-5.6-sol");
+    expect(options.map((option) => option.effort)).toEqual([
+      "none",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+    expect(options.map((option) => option.modelId)).toEqual([
+      "gpt-5.6-sol-none",
+      "gpt-5.6-sol-low",
+      "gpt-5.6-sol-medium",
+      "gpt-5.6-sol",
+      "gpt-5.6-sol-xhigh",
     ]);
   });
 

--- a/src/agent/modify-local.test.ts
+++ b/src/agent/modify-local.test.ts
@@ -7,7 +7,11 @@ import { configureBackendMode, getBackend } from "@/backend/backend";
 import { createOrUpdateLocalProvider } from "@/backend/local";
 import { LOCAL_BACKEND_DIR_ENV } from "@/backend/local/paths";
 import { clearAvailableModelsCache } from "./available-models";
-import { updateAgentLLMConfig, updateConversationLLMConfig } from "./modify";
+import {
+  __modifyTestUtils,
+  updateAgentLLMConfig,
+  updateConversationLLMConfig,
+} from "./modify";
 
 async function withLocalBackendStorage<T>(
   storageDir: string,
@@ -30,6 +34,20 @@ async function withLocalBackendStorage<T>(
 }
 
 describe("local model updates", () => {
+  test("builds direct xAI model settings for xAI handles", () => {
+    expect(
+      __modifyTestUtils.buildModelSettings("xai/grok-4.5", {
+        context_window: 500000,
+        max_output_tokens: 16384,
+        parallel_tool_calls: true,
+      }),
+    ).toMatchObject({
+      provider_type: "xai",
+      parallel_tool_calls: true,
+      max_output_tokens: 16384,
+    });
+  });
+
   afterEach(() => {
     configureBackendMode("api");
     clearAvailableModelsCache();

--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -60,6 +60,8 @@ function buildModelSettings(
     modelHandle.startsWith("minimax/");
   const isZai =
     explicitProviderType === "zai" || modelHandle.startsWith("zai/");
+  const isXai =
+    explicitProviderType === "xai" || modelHandle.startsWith("xai/");
   const isGoogleAI =
     explicitProviderType === "google_ai" ||
     modelHandle.startsWith("google_ai/");
@@ -148,6 +150,13 @@ function buildModelSettings(
     // Ensure parallel_tool_calls is enabled.
     settings = {
       provider_type: "zai",
+      parallel_tool_calls: true,
+    };
+  } else if (isXai) {
+    // xAI is OpenAI-compatible on the wire, but direct xAI handles must route
+    // through provider_type=xai instead of the generic OpenAI fallback.
+    settings = {
+      provider_type: "xai",
       parallel_tool_calls: true,
     };
   } else if (isGoogleAI) {
@@ -260,6 +269,10 @@ function buildModelSettings(
 
   return settings;
 }
+
+export const __modifyTestUtils = {
+  buildModelSettings,
+};
 
 function updateArgsForModelSettings(
   updateArgs: Record<string, unknown> | undefined,

--- a/src/models.json
+++ b/src/models.json
@@ -1315,6 +1315,45 @@
       }
     },
     {
+      "id": "gpt-5.6-sol-none",
+      "handle": "openai/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol",
+      "description": "OpenAI's most capable GPT-5.6 model (no reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "none",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-low",
+      "handle": "openai/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol",
+      "description": "OpenAI's most capable GPT-5.6 model (low reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "low",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-medium",
+      "handle": "openai/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol",
+      "description": "OpenAI's most capable GPT-5.6 model (med reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "medium",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "gpt-5.6-sol",
       "handle": "openai/gpt-5.6-sol",
       "label": "GPT-5.6 Sol",
@@ -1322,6 +1361,58 @@
       "isFeatured": true,
       "updateArgs": {
         "reasoning_effort": "high",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-xhigh",
+      "handle": "openai/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol",
+      "description": "OpenAI's most capable GPT-5.6 model (max reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "xhigh",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-none",
+      "handle": "openai/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra",
+      "description": "GPT-5.6 Terra (no reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "none",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-low",
+      "handle": "openai/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra",
+      "description": "GPT-5.6 Terra (low reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "low",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-medium",
+      "handle": "openai/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra",
+      "description": "GPT-5.6 Terra (med reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "medium",
         "verbosity": "medium",
         "context_window": 1050000,
         "max_output_tokens": 128000,
@@ -1343,6 +1434,58 @@
       }
     },
     {
+      "id": "gpt-5.6-terra-xhigh",
+      "handle": "openai/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra",
+      "description": "GPT-5.6 Terra (max reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "xhigh",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-none",
+      "handle": "openai/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna",
+      "description": "GPT-5.6 Luna (no reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "none",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-low",
+      "handle": "openai/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna",
+      "description": "GPT-5.6 Luna (low reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "low",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-medium",
+      "handle": "openai/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna",
+      "description": "GPT-5.6 Luna (med reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "medium",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "gpt-5.6-luna",
       "handle": "openai/gpt-5.6-luna",
       "label": "GPT-5.6 Luna",
@@ -1350,6 +1493,19 @@
       "isFeatured": true,
       "updateArgs": {
         "reasoning_effort": "high",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-xhigh",
+      "handle": "openai/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna",
+      "description": "GPT-5.6 Luna (max reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "xhigh",
         "verbosity": "medium",
         "context_window": 1050000,
         "max_output_tokens": 128000,
@@ -1829,10 +1985,11 @@
       "id": "grok-4.5",
       "handle": "xai/grok-4.5",
       "label": "Grok 4.5",
-      "description": "xAI's Grok 4.5 model",
+      "description": "xAI's Grok 4.5 model via the direct xAI API",
       "isFeatured": true,
       "updateArgs": {
         "context_window": 500000,
+        "max_output_tokens": 16384,
         "parallel_tool_calls": true
       }
     },

--- a/src/models.json
+++ b/src/models.json
@@ -1315,6 +1315,48 @@
       }
     },
     {
+      "id": "gpt-5.6-sol",
+      "handle": "openai/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol",
+      "description": "OpenAI's most capable GPT-5.6 model (high reasoning)",
+      "isFeatured": true,
+      "updateArgs": {
+        "reasoning_effort": "high",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra",
+      "handle": "openai/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra",
+      "description": "GPT-5.6 Terra (high reasoning)",
+      "isFeatured": true,
+      "updateArgs": {
+        "reasoning_effort": "high",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna",
+      "handle": "openai/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna",
+      "description": "GPT-5.6 Luna (high reasoning)",
+      "isFeatured": true,
+      "updateArgs": {
+        "reasoning_effort": "high",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "gpt-5.5-none",
       "handle": "openai/gpt-5.5",
       "label": "GPT-5.5",
@@ -1780,6 +1822,17 @@
         "verbosity": "medium",
         "context_window": 272000,
         "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "grok-4.5",
+      "handle": "xai/grok-4.5",
+      "label": "Grok 4.5",
+      "description": "xAI's Grok 4.5 model",
+      "isFeatured": true,
+      "updateArgs": {
+        "context_window": 500000,
         "parallel_tool_calls": true
       }
     },


### PR DESCRIPTION
## Summary
- Add GPT-5.6 Sol, Terra, and Luna model presets
- Add all supported GPT-5.6 reasoning efforts: none, low, medium, high, xhigh
- Add direct xAI Grok 4.5 and route xai/* handles through provider_type=xai
- Feature the high GPT-5.6 presets and Grok 4.5 in the model list

## Test
- node JSON parse + duplicate ID check
- bun test src/agent/model-tier-selection.test.ts src/agent/modify-local.test.ts
- bun run typecheck
- pre-commit: biome, repo checks, tsc --noEmit