### PR TITLE
feat(models): add GPT-5.6 ChatGPT plan presets

### DIFF
--- a/src/agent/model-tier-selection.test.ts
+++ b/src/agent/model-tier-selection.test.ts
@@ -77,6 +77,11 @@ describe("getModelInfo", () => {
       parallel_tool_calls: true,
     });
   });
+
+  test("does not feature GPT-5.5 presets", () => {
+    expect(getModelInfo("gpt-5.5-high")?.isFeatured).not.toBe(true);
+    expect(getModelInfo("gpt-5.5-plus-pro-high")?.isFeatured).not.toBe(true);
+  });
 });
 
 describe("getModelInfoForLlmConfig", () => {
@@ -109,6 +114,26 @@ describe("getModelInfoForLlmConfig", () => {
     });
     expect(xhigh?.id).toBe("gpt-5.6-sol-xhigh");
   });
+
+  for (const variant of ["sol", "terra", "luna"] as const) {
+    test(`uses ChatGPT metadata for GPT-5.6 ${variant}`, () => {
+      const info = getModelInfoForLlmConfig(`openai-codex/gpt-5.6-${variant}`, {
+        reasoning_effort: "high",
+      });
+      expect(info?.id).toBe(`gpt-5.6-${variant}-plus-pro-high`);
+      expect(info?.label).toBe(
+        `GPT-5.6 ${variant[0]?.toUpperCase()}${variant.slice(1)} (ChatGPT)`,
+      );
+      expect(info?.isFeatured).toBe(true);
+      expect(info?.updateArgs).toMatchObject({
+        context_window: 272000,
+        max_output_tokens: 128000,
+        reasoning_effort: "high",
+        verbosity: "low",
+        parallel_tool_calls: true,
+      });
+    });
+  }
 
   test("uses ChatGPT metadata for local ChatGPT OAuth handles", () => {
     const info = getModelInfoForLlmConfig("openai-codex/gpt-5.5", {
@@ -225,6 +250,31 @@ describe("getReasoningTierOptionsForHandle", () => {
     ]);
   });
 
+  for (const variant of ["sol", "terra", "luna"] as const) {
+    test(`returns ChatGPT reasoning options for gpt-5.6 ${variant}`, () => {
+      const options = getReasoningTierOptionsForHandle(
+        `chatgpt-plus-pro/gpt-5.6-${variant}`,
+      );
+      expect(options.map((option) => option.effort)).toEqual([
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+      ]);
+      expect(options.map((option) => option.modelId)).toEqual([
+        `gpt-5.6-${variant}-plus-pro-none`,
+        `gpt-5.6-${variant}-plus-pro-low`,
+        `gpt-5.6-${variant}-plus-pro-medium`,
+        `gpt-5.6-${variant}-plus-pro-high`,
+        `gpt-5.6-${variant}-plus-pro-xhigh`,
+      ]);
+      expect(
+        getReasoningTierOptionsForHandle(`openai-codex/gpt-5.6-${variant}`),
+      ).toEqual(options);
+    });
+  }
+
   test("returns ordered reasoning options for gpt-5.3-codex", () => {
     const options = getReasoningTierOptionsForHandle("openai/gpt-5.3-codex");
     expect(options.map((option) => option.effort)).toEqual([
@@ -320,6 +370,16 @@ describe("getReasoningTierOptionsForHandle", () => {
     expect(
       getReasoningTierOptionsForHandle("openai-codex/gpt-5.5-fast"),
     ).toEqual([]);
+  });
+
+  test("does not synthesize unlisted GPT-5.6 ChatGPT fast tiers", () => {
+    for (const variant of ["sol", "terra", "luna"] as const) {
+      expect(
+        getChatGptFastRegistryHandleForModelHandle(
+          `openai-codex/gpt-5.6-${variant}`,
+        ),
+      ).toBeNull();
+    }
   });
 
   test("returns reasoning options for anthropic sonnet 4.6", () => {

--- a/src/models.json
+++ b/src/models.json
@@ -54,6 +54,402 @@
       "isFeatured": true
     },
     {
+      "id": "gpt-5.6-sol-none",
+      "handle": "openai/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol",
+      "description": "OpenAI's most capable GPT-5.6 model (no reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "none",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-low",
+      "handle": "openai/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol",
+      "description": "OpenAI's most capable GPT-5.6 model (low reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "low",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-medium",
+      "handle": "openai/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol",
+      "description": "OpenAI's most capable GPT-5.6 model (med reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "medium",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol",
+      "handle": "openai/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol",
+      "description": "OpenAI's most capable GPT-5.6 model (high reasoning)",
+      "isFeatured": true,
+      "updateArgs": {
+        "reasoning_effort": "high",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-xhigh",
+      "handle": "openai/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol",
+      "description": "OpenAI's most capable GPT-5.6 model (max reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "xhigh",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-none",
+      "handle": "openai/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra",
+      "description": "GPT-5.6 Terra (no reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "none",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-low",
+      "handle": "openai/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra",
+      "description": "GPT-5.6 Terra (low reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "low",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-medium",
+      "handle": "openai/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra",
+      "description": "GPT-5.6 Terra (med reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "medium",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra",
+      "handle": "openai/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra",
+      "description": "GPT-5.6 Terra (high reasoning)",
+      "isFeatured": true,
+      "updateArgs": {
+        "reasoning_effort": "high",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-xhigh",
+      "handle": "openai/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra",
+      "description": "GPT-5.6 Terra (max reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "xhigh",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-none",
+      "handle": "openai/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna",
+      "description": "GPT-5.6 Luna (no reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "none",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-low",
+      "handle": "openai/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna",
+      "description": "GPT-5.6 Luna (low reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "low",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-medium",
+      "handle": "openai/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna",
+      "description": "GPT-5.6 Luna (med reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "medium",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna",
+      "handle": "openai/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna",
+      "description": "GPT-5.6 Luna (high reasoning)",
+      "isFeatured": true,
+      "updateArgs": {
+        "reasoning_effort": "high",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-xhigh",
+      "handle": "openai/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna",
+      "description": "GPT-5.6 Luna (max reasoning)",
+      "updateArgs": {
+        "reasoning_effort": "xhigh",
+        "verbosity": "medium",
+        "context_window": 1050000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-plus-pro-none",
+      "handle": "chatgpt-plus-pro/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol (ChatGPT)",
+      "description": "GPT-5.6 Sol (no reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "none",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-plus-pro-low",
+      "handle": "chatgpt-plus-pro/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol (ChatGPT)",
+      "description": "GPT-5.6 Sol (low reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "low",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-plus-pro-medium",
+      "handle": "chatgpt-plus-pro/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol (ChatGPT)",
+      "description": "GPT-5.6 Sol (med reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "medium",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-plus-pro-high",
+      "handle": "chatgpt-plus-pro/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol (ChatGPT)",
+      "description": "GPT-5.6 Sol (high reasoning) via ChatGPT Plus/Pro",
+      "isFeatured": true,
+      "updateArgs": {
+        "reasoning_effort": "high",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-plus-pro-xhigh",
+      "handle": "chatgpt-plus-pro/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol (ChatGPT)",
+      "description": "GPT-5.6 Sol (max reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "xhigh",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-plus-pro-none",
+      "handle": "chatgpt-plus-pro/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra (ChatGPT)",
+      "description": "GPT-5.6 Terra (no reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "none",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-plus-pro-low",
+      "handle": "chatgpt-plus-pro/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra (ChatGPT)",
+      "description": "GPT-5.6 Terra (low reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "low",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-plus-pro-medium",
+      "handle": "chatgpt-plus-pro/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra (ChatGPT)",
+      "description": "GPT-5.6 Terra (med reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "medium",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-plus-pro-high",
+      "handle": "chatgpt-plus-pro/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra (ChatGPT)",
+      "description": "GPT-5.6 Terra (high reasoning) via ChatGPT Plus/Pro",
+      "isFeatured": true,
+      "updateArgs": {
+        "reasoning_effort": "high",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-plus-pro-xhigh",
+      "handle": "chatgpt-plus-pro/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra (ChatGPT)",
+      "description": "GPT-5.6 Terra (max reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "xhigh",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-plus-pro-none",
+      "handle": "chatgpt-plus-pro/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna (ChatGPT)",
+      "description": "GPT-5.6 Luna (no reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "none",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-plus-pro-low",
+      "handle": "chatgpt-plus-pro/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna (ChatGPT)",
+      "description": "GPT-5.6 Luna (low reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "low",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-plus-pro-medium",
+      "handle": "chatgpt-plus-pro/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna (ChatGPT)",
+      "description": "GPT-5.6 Luna (med reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "medium",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-plus-pro-high",
+      "handle": "chatgpt-plus-pro/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna (ChatGPT)",
+      "description": "GPT-5.6 Luna (high reasoning) via ChatGPT Plus/Pro",
+      "isFeatured": true,
+      "updateArgs": {
+        "reasoning_effort": "high",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-plus-pro-xhigh",
+      "handle": "chatgpt-plus-pro/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna (ChatGPT)",
+      "description": "GPT-5.6 Luna (max reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "xhigh",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "fable",
       "handle": "anthropic/claude-fable-5",
       "label": "Fable 5",
@@ -915,7 +1311,6 @@
       "handle": "chatgpt-plus-pro/gpt-5.5",
       "label": "GPT-5.5 (ChatGPT)",
       "description": "OpenAI's most capable model (high reasoning) via ChatGPT Plus/Pro",
-      "isFeatured": true,
       "updateArgs": {
         "reasoning_effort": "high",
         "verbosity": "low",
@@ -1315,204 +1710,6 @@
       }
     },
     {
-      "id": "gpt-5.6-sol-none",
-      "handle": "openai/gpt-5.6-sol",
-      "label": "GPT-5.6 Sol",
-      "description": "OpenAI's most capable GPT-5.6 model (no reasoning)",
-      "updateArgs": {
-        "reasoning_effort": "none",
-        "verbosity": "medium",
-        "context_window": 1050000,
-        "max_output_tokens": 128000,
-        "parallel_tool_calls": true
-      }
-    },
-    {
-      "id": "gpt-5.6-sol-low",
-      "handle": "openai/gpt-5.6-sol",
-      "label": "GPT-5.6 Sol",
-      "description": "OpenAI's most capable GPT-5.6 model (low reasoning)",
-      "updateArgs": {
-        "reasoning_effort": "low",
-        "verbosity": "medium",
-        "context_window": 1050000,
-        "max_output_tokens": 128000,
-        "parallel_tool_calls": true
-      }
-    },
-    {
-      "id": "gpt-5.6-sol-medium",
-      "handle": "openai/gpt-5.6-sol",
-      "label": "GPT-5.6 Sol",
-      "description": "OpenAI's most capable GPT-5.6 model (med reasoning)",
-      "updateArgs": {
-        "reasoning_effort": "medium",
-        "verbosity": "medium",
-        "context_window": 1050000,
-        "max_output_tokens": 128000,
-        "parallel_tool_calls": true
-      }
-    },
-    {
-      "id": "gpt-5.6-sol",
-      "handle": "openai/gpt-5.6-sol",
-      "label": "GPT-5.6 Sol",
-      "description": "OpenAI's most capable GPT-5.6 model (high reasoning)",
-      "isFeatured": true,
-      "updateArgs": {
-        "reasoning_effort": "high",
-        "verbosity": "medium",
-        "context_window": 1050000,
-        "max_output_tokens": 128000,
-        "parallel_tool_calls": true
-      }
-    },
-    {
-      "id": "gpt-5.6-sol-xhigh",
-      "handle": "openai/gpt-5.6-sol",
-      "label": "GPT-5.6 Sol",
-      "description": "OpenAI's most capable GPT-5.6 model (max reasoning)",
-      "updateArgs": {
-        "reasoning_effort": "xhigh",
-        "verbosity": "medium",
-        "context_window": 1050000,
-        "max_output_tokens": 128000,
-        "parallel_tool_calls": true
-      }
-    },
-    {
-      "id": "gpt-5.6-terra-none",
-      "handle": "openai/gpt-5.6-terra",
-      "label": "GPT-5.6 Terra",
-      "description": "GPT-5.6 Terra (no reasoning)",
-      "updateArgs": {
-        "reasoning_effort": "none",
-        "verbosity": "medium",
-        "context_window": 1050000,
-        "max_output_tokens": 128000,
-        "parallel_tool_calls": true
-      }
-    },
-    {
-      "id": "gpt-5.6-terra-low",
-      "handle": "openai/gpt-5.6-terra",
-      "label": "GPT-5.6 Terra",
-      "description": "GPT-5.6 Terra (low reasoning)",
-      "updateArgs": {
-        "reasoning_effort": "low",
-        "verbosity": "medium",
-        "context_window": 1050000,
-        "max_output_tokens": 128000,
-        "parallel_tool_calls": true
-      }
-    },
-    {
-      "id": "gpt-5.6-terra-medium",
-      "handle": "openai/gpt-5.6-terra",
-      "label": "GPT-5.6 Terra",
-      "description": "GPT-5.6 Terra (med reasoning)",
-      "updateArgs": {
-        "reasoning_effort": "medium",
-        "verbosity": "medium",
-        "context_window": 1050000,
-        "max_output_tokens": 128000,
-        "parallel_tool_calls": true
-      }
-    },
-    {
-      "id": "gpt-5.6-terra",
-      "handle": "openai/gpt-5.6-terra",
-      "label": "GPT-5.6 Terra",
-      "description": "GPT-5.6 Terra (high reasoning)",
-      "isFeatured": true,
-      "updateArgs": {
-        "reasoning_effort": "high",
-        "verbosity": "medium",
-        "context_window": 1050000,
-        "max_output_tokens": 128000,
-        "parallel_tool_calls": true
-      }
-    },
-    {
-      "id": "gpt-5.6-terra-xhigh",
-      "handle": "openai/gpt-5.6-terra",
-      "label": "GPT-5.6 Terra",
-      "description": "GPT-5.6 Terra (max reasoning)",
-      "updateArgs": {
-        "reasoning_effort": "xhigh",
-        "verbosity": "medium",
-        "context_window": 1050000,
-        "max_output_tokens": 128000,
-        "parallel_tool_calls": true
-      }
-    },
-    {
-      "id": "gpt-5.6-luna-none",
-      "handle": "openai/gpt-5.6-luna",
-      "label": "GPT-5.6 Luna",
-      "description": "GPT-5.6 Luna (no reasoning)",
-      "updateArgs": {
-        "reasoning_effort": "none",
-        "verbosity": "medium",
-        "context_window": 1050000,
-        "max_output_tokens": 128000,
-        "parallel_tool_calls": true
-      }
-    },
-    {
-      "id": "gpt-5.6-luna-low",
-      "handle": "openai/gpt-5.6-luna",
-      "label": "GPT-5.6 Luna",
-      "description": "GPT-5.6 Luna (low reasoning)",
-      "updateArgs": {
-        "reasoning_effort": "low",
-        "verbosity": "medium",
-        "context_window": 1050000,
-        "max_output_tokens": 128000,
-        "parallel_tool_calls": true
-      }
-    },
-    {
-      "id": "gpt-5.6-luna-medium",
-      "handle": "openai/gpt-5.6-luna",
-      "label": "GPT-5.6 Luna",
-      "description": "GPT-5.6 Luna (med reasoning)",
-      "updateArgs": {
-        "reasoning_effort": "medium",
-        "verbosity": "medium",
-        "context_window": 1050000,
-        "max_output_tokens": 128000,
-        "parallel_tool_calls": true
-      }
-    },
-    {
-      "id": "gpt-5.6-luna",
-      "handle": "openai/gpt-5.6-luna",
-      "label": "GPT-5.6 Luna",
-      "description": "GPT-5.6 Luna (high reasoning)",
-      "isFeatured": true,
-      "updateArgs": {
-        "reasoning_effort": "high",
-        "verbosity": "medium",
-        "context_window": 1050000,
-        "max_output_tokens": 128000,
-        "parallel_tool_calls": true
-      }
-    },
-    {
-      "id": "gpt-5.6-luna-xhigh",
-      "handle": "openai/gpt-5.6-luna",
-      "label": "GPT-5.6 Luna",
-      "description": "GPT-5.6 Luna (max reasoning)",
-      "updateArgs": {
-        "reasoning_effort": "xhigh",
-        "verbosity": "medium",
-        "context_window": 1050000,
-        "max_output_tokens": 128000,
-        "parallel_tool_calls": true
-      }
-    },
-    {
       "id": "gpt-5.5-none",
       "handle": "openai/gpt-5.5",
       "label": "GPT-5.5",
@@ -1556,7 +1753,6 @@
       "handle": "openai/gpt-5.5",
       "label": "GPT-5.5",
       "description": "OpenAI's most capable model (high reasoning)",
-      "isFeatured": true,
       "updateArgs": {
         "reasoning_effort": "high",
         "verbosity": "medium",


### PR DESCRIPTION
## Summary

- add ChatGPT Plus/Pro presets for GPT-5.6 Sol, Terra, and Luna across all supported reasoning tiers
- rank hosted and ChatGPT-plan GPT-5.6 models Sol → Terra → Luna ahead of Anthropic featured models
- remove featured status from hosted and ChatGPT-plan GPT-5.5 presets
- cover Codex OAuth normalization and avoid synthesizing unlisted GPT-5.6 fast tiers

## Validation

- `bun test src/agent/model-tier-selection.test.ts`
- `bun run check`
