### PR TITLE
feat(models): add GPT-5.6 ChatGPT OAuth presets

### DIFF
--- a/src/models.json
+++ b/src/models.json
@@ -1302,6 +1302,136 @@
       }
     },
     {
+      "id": "gpt-5.6-sol-plus-pro-none",
+      "handle": "chatgpt-plus-pro/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol (ChatGPT)",
+      "description": "GPT-5.6 Sol (no reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "none",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-plus-pro-low",
+      "handle": "chatgpt-plus-pro/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol (ChatGPT)",
+      "description": "GPT-5.6 Sol (low reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "low",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-plus-pro-medium",
+      "handle": "chatgpt-plus-pro/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol (ChatGPT)",
+      "description": "GPT-5.6 Sol (med reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "medium",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-plus-pro-high",
+      "handle": "chatgpt-plus-pro/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol (ChatGPT)",
+      "description": "GPT-5.6 Sol (high reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "high",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-sol-plus-pro-xhigh",
+      "handle": "chatgpt-plus-pro/gpt-5.6-sol",
+      "label": "GPT-5.6 Sol (ChatGPT)",
+      "description": "GPT-5.6 Sol (extra-high reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "xhigh",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-plus-pro-none",
+      "handle": "chatgpt-plus-pro/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra (ChatGPT)",
+      "description": "GPT-5.6 Terra (no reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "none",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-plus-pro-low",
+      "handle": "chatgpt-plus-pro/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra (ChatGPT)",
+      "description": "GPT-5.6 Terra (low reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "low",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-plus-pro-medium",
+      "handle": "chatgpt-plus-pro/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra (ChatGPT)",
+      "description": "GPT-5.6 Terra (med reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "medium",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-plus-pro-high",
+      "handle": "chatgpt-plus-pro/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra (ChatGPT)",
+      "description": "GPT-5.6 Terra (high reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "high",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-terra-plus-pro-xhigh",
+      "handle": "chatgpt-plus-pro/gpt-5.6-terra",
+      "label": "GPT-5.6 Terra (ChatGPT)",
+      "description": "GPT-5.6 Terra (extra-high reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "xhigh",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "gpt-5-codex",
       "handle": "openai/gpt-5-codex",
       "label": "GPT-5-Codex",


### PR DESCRIPTION
## Summary
- Add GPT-5.6 Sol and Terra presets for `chatgpt-plus-pro`
- Include Cloud-supported reasoning tiers: none, low, medium, high, and xhigh
- Intentionally defer GPT-5.6 Luna

## Validation
- `bun test src/agent/model-tier-selection.test.ts`
- `bun run check`