### PR TITLE
fix(subagents): fall back when subagent cwd was deleted mid-session

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "src/agent/client-skills.test.ts": 1196,
   "src/agent/memory-git.ts": 2324,
-  "src/agent/subagents/manager.ts": 1577,
+  "src/agent/subagents/manager.ts": 1556,
   "src/backend/local-backend.test.ts": 2589,
   "src/backend/local/local-backend.ts": 1058,
   "src/backend/local/local-store.ts": 3629,

--- a/src/agent/subagent-model-resolution.test.ts
+++ b/src/agent/subagent-model-resolution.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import type { SubagentConfig } from "@/agent/subagents";
 import {
@@ -12,8 +14,8 @@ import {
   recallPromptForBackend,
   resolveSubagentLauncher,
   resolveSubagentModel,
-  resolveSubagentWorkingDirectory,
 } from "@/agent/subagents/manager";
+import { resolveSubagentWorkingDirectory } from "@/agent/subagents/working-directory";
 
 describe("recallPromptForBackend", () => {
   test("uses separate API and local recall prompts", () => {
@@ -184,15 +186,37 @@ describe("resolveSubagentLauncher", () => {
 });
 
 describe("resolveSubagentWorkingDirectory", () => {
+  const liveDirs: string[] = [];
+
+  const makeLiveDir = (prefix: string): string => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), prefix));
+    liveDirs.push(dir);
+    return dir;
+  };
+
+  // A path that existed once (e.g. a git worktree) and was deleted mid-session.
+  const makeDeletedDir = (prefix: string): string => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), prefix));
+    rmSync(dir, { recursive: true, force: true });
+    return dir;
+  };
+
+  afterAll(() => {
+    for (const dir of liveDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("prefers USER_CWD when present", () => {
+    const userCwd = makeLiveDir("subagent-user-cwd-");
     const cwd = resolveSubagentWorkingDirectory(
       {
-        USER_CWD: "/tmp/fixture-dir",
+        USER_CWD: userCwd,
       } as NodeJS.ProcessEnv,
       "/tmp/repo-root",
     );
 
-    expect(cwd).toBe("/tmp/fixture-dir");
+    expect(cwd).toBe(userCwd);
   });
 
   test("falls back to process cwd when USER_CWD is absent", () => {
@@ -204,7 +228,20 @@ describe("resolveSubagentWorkingDirectory", () => {
     expect(cwd).toBe("/tmp/repo-root");
   });
 
+  test("falls back to process cwd when USER_CWD no longer exists", () => {
+    const staleCwd = makeDeletedDir("subagent-stale-cwd-");
+    const cwd = resolveSubagentWorkingDirectory(
+      {
+        USER_CWD: staleCwd,
+      } as NodeJS.ProcessEnv,
+      "/tmp/repo-root",
+    );
+
+    expect(cwd).toBe("/tmp/repo-root");
+  });
+
   test("reflection subagents with the memory-subagent profile run from the inherited parent memory root", () => {
+    const memoryRoot = makeLiveDir("subagent-memory-root-");
     const cwd = resolveSubagentWorkingDirectory(
       {
         USER_CWD: "/tmp/project-root",
@@ -213,17 +250,36 @@ describe("resolveSubagentWorkingDirectory", () => {
       {
         subagentType: "reflection",
         launchProfile: "memory-subagent",
-        inheritedPrimaryRoot: "/Users/test/.letta/agents/agent-parent/memory",
+        inheritedPrimaryRoot: memoryRoot,
       },
     );
 
-    expect(cwd).toBe("/Users/test/.letta/agents/agent-parent/memory");
+    expect(cwd).toBe(memoryRoot);
+  });
+
+  test("reflection subagents fall back past an inherited memory root that no longer exists", () => {
+    const staleMemoryRoot = makeDeletedDir("subagent-stale-memory-root-");
+    const userCwd = makeLiveDir("subagent-user-cwd-");
+    const cwd = resolveSubagentWorkingDirectory(
+      {
+        USER_CWD: userCwd,
+      } as NodeJS.ProcessEnv,
+      "/tmp/fallback-root",
+      {
+        subagentType: "reflection",
+        launchProfile: "memory-subagent",
+        inheritedPrimaryRoot: staleMemoryRoot,
+      },
+    );
+
+    expect(cwd).toBe(userCwd);
   });
 
   test("reflection subagents with memoryScope run from USER_CWD while MEMORY_DIR points at the worktree", () => {
+    const userCwd = makeLiveDir("subagent-project-root-");
     const cwd = resolveSubagentWorkingDirectory(
       {
-        USER_CWD: "/tmp/project-root",
+        USER_CWD: userCwd,
       } as NodeJS.ProcessEnv,
       "/tmp/fallback-root",
       {
@@ -240,13 +296,38 @@ describe("resolveSubagentWorkingDirectory", () => {
       },
     );
 
-    expect(cwd).toBe("/tmp/project-root");
+    expect(cwd).toBe(userCwd);
+  });
+
+  test("reflection subagents with memoryScope fall back when USER_CWD was deleted mid-session", () => {
+    const staleCwd = makeDeletedDir("subagent-stale-worktree-");
+    const cwd = resolveSubagentWorkingDirectory(
+      {
+        USER_CWD: staleCwd,
+      } as NodeJS.ProcessEnv,
+      "/tmp/fallback-root",
+      {
+        subagentType: "reflection",
+        launchProfile: "memory-subagent",
+        inheritedPrimaryRoot: "/Users/test/.letta/agents/agent-parent/memory",
+        memoryScope: {
+          primaryRoot:
+            "/Users/test/.letta/agents/agent-parent/memory-worktrees/reflection-123",
+          writableRoots: [
+            "/Users/test/.letta/agents/agent-parent/memory-worktrees/reflection-123",
+          ],
+        },
+      },
+    );
+
+    expect(cwd).toBe("/tmp/fallback-root");
   });
 
   test("non-reflection subagents still prefer USER_CWD", () => {
+    const userCwd = makeLiveDir("subagent-project-root-");
     const cwd = resolveSubagentWorkingDirectory(
       {
-        USER_CWD: "/tmp/project-root",
+        USER_CWD: userCwd,
       } as NodeJS.ProcessEnv,
       "/tmp/fallback-root",
       {
@@ -256,7 +337,7 @@ describe("resolveSubagentWorkingDirectory", () => {
       },
     );
 
-    expect(cwd).toBe("/tmp/project-root");
+    expect(cwd).toBe(userCwd);
   });
 });
 

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -20,6 +20,10 @@ import {
 } from "@/agent/subagent-state.js";
 import { wrapSubagentLauncher } from "@/agent/subagents/sandbox";
 import {
+  resolveSubagentWorkingDirectory,
+  type SubagentMemoryScope,
+} from "@/agent/subagents/working-directory";
+import {
   type BackendMode,
   getBackend,
   getLocalBackendStorageDir,
@@ -96,12 +100,6 @@ export interface SubagentResult {
   totalTokens?: number;
   stepCount?: number;
   durationMs?: number;
-}
-
-export interface SubagentMemoryScope {
-  primaryRoot: string | null;
-  writableRoots: string[];
-  readonlyRoots?: string[];
 }
 
 /**
@@ -580,37 +578,6 @@ interface ResolveSubagentLauncherOptions {
 interface SubagentLauncher {
   command: string;
   args: string[];
-}
-
-export function resolveSubagentWorkingDirectory(
-  env: NodeJS.ProcessEnv = process.env,
-  fallbackCwd: string = getCurrentWorkingDirectory(),
-  options: {
-    subagentType?: string;
-    launchProfile?: SubagentLaunchProfile;
-    inheritedPrimaryRoot?: string | null;
-    memoryScope?: SubagentMemoryScope;
-  } = {},
-): string {
-  if (
-    options.subagentType === "reflection" &&
-    options.launchProfile === "memory-subagent" &&
-    options.memoryScope
-  ) {
-    return env.USER_CWD || fallbackCwd;
-  }
-
-  const primaryRoot =
-    options.memoryScope?.primaryRoot ?? options.inheritedPrimaryRoot;
-  if (
-    options.subagentType === "reflection" &&
-    options.launchProfile === "memory-subagent" &&
-    primaryRoot
-  ) {
-    return primaryRoot;
-  }
-
-  return env.USER_CWD || fallbackCwd;
 }
 
 export function resolveSubagentLauncher(
@@ -1221,10 +1188,15 @@ async function executeSubagent(
       stderrChunks.push(data);
     });
 
-    // Wait for process to complete
+    // Wait for process to complete. Spawn failures (e.g. deleted cwd) emit
+    // "error" without "close" and land here as a null exit code.
+    let spawnError: Error | null = null;
     const exitCode = await new Promise<number | null>((resolve) => {
       proc.on("close", resolve);
-      proc.on("error", () => resolve(null));
+      proc.on("error", (error) => {
+        spawnError = error;
+        resolve(null);
+      });
     });
 
     // Ensure the trailing partial line is processed before completing.
@@ -1277,7 +1249,14 @@ async function executeSubagent(
       }
 
       const propagatedError = state.finalError?.trim();
-      const fallbackError = stderr || `Subagent exited with code ${exitCode}`;
+      const fallbackError = spawnError
+        ? `Subagent process failed to start: ${getErrorMessage(spawnError)} (cwd: ${subagentWorkingDirectory})`
+        : stderr || `Subagent exited with code ${exitCode}`;
+      debugWarn(
+        "subagent",
+        `Subagent ${subagentId} (agentId=${state.agentId}) failed: ${propagatedError || fallbackError}. ` +
+          `exitCode=${exitCode}, stderr=${stderr.length} bytes`,
+      );
 
       return {
         agentId: state.agentId || "",

--- a/src/agent/subagents/working-directory.ts
+++ b/src/agent/subagents/working-directory.ts
@@ -1,0 +1,63 @@
+import { isUsableDirectory } from "@/helpers/usable-directory";
+import { getCurrentWorkingDirectory } from "@/runtime-context";
+import { debugWarn } from "@/utils/debug";
+import type { SubagentLaunchProfile } from ".";
+
+export interface SubagentMemoryScope {
+  primaryRoot: string | null;
+  writableRoots: string[];
+  readonlyRoots?: string[];
+}
+
+/**
+ * USER_CWD is captured at session start and can be deleted mid-session
+ * (e.g. `git worktree remove`); spawning a child with a dead cwd fails
+ * with ENOENT before the subagent runs.
+ */
+function pickUsableSubagentCwd(
+  candidate: string | undefined | null,
+  fallbackCwd: string,
+): string {
+  if (candidate && isUsableDirectory(candidate)) {
+    return candidate;
+  }
+  if (candidate) {
+    debugWarn(
+      "subagent",
+      `Subagent working directory ${candidate} no longer exists; falling back to ${fallbackCwd}`,
+    );
+  }
+  return fallbackCwd;
+}
+
+export function resolveSubagentWorkingDirectory(
+  env: NodeJS.ProcessEnv = process.env,
+  fallbackCwd: string = getCurrentWorkingDirectory(),
+  options: {
+    subagentType?: string;
+    launchProfile?: SubagentLaunchProfile;
+    inheritedPrimaryRoot?: string | null;
+    memoryScope?: SubagentMemoryScope;
+  } = {},
+): string {
+  if (
+    options.subagentType === "reflection" &&
+    options.launchProfile === "memory-subagent" &&
+    options.memoryScope
+  ) {
+    return pickUsableSubagentCwd(env.USER_CWD, fallbackCwd);
+  }
+
+  const primaryRoot =
+    options.memoryScope?.primaryRoot ?? options.inheritedPrimaryRoot;
+  if (
+    options.subagentType === "reflection" &&
+    options.launchProfile === "memory-subagent" &&
+    primaryRoot &&
+    isUsableDirectory(primaryRoot)
+  ) {
+    return primaryRoot;
+  }
+
+  return pickUsableSubagentCwd(env.USER_CWD, fallbackCwd);
+}

--- a/src/tools/impl/task.ts
+++ b/src/tools/impl/task.ts
@@ -18,10 +18,8 @@ import {
   discoverSubagents,
   getAllSubagentConfigs,
 } from "@/agent/subagents";
-import {
-  type SubagentMemoryScope,
-  spawnSubagent,
-} from "@/agent/subagents/manager";
+import { spawnSubagent } from "@/agent/subagents/manager";
+import type { SubagentMemoryScope } from "@/agent/subagents/working-directory";
 import { getBackend } from "@/backend";
 import { runSubagentStopHooks } from "@/hooks";
 import { getCurrentWorkingDirectory } from "@/runtime-context";

--- a/src/tools/subagent-parent-id-propagation.test.ts
+++ b/src/tools/subagent-parent-id-propagation.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SubagentState } from "@/agent/subagent-state";
 import { clearAllSubagents } from "@/agent/subagent-state";
-import type { SubagentMemoryScope } from "@/agent/subagents/manager";
+import type { SubagentMemoryScope } from "@/agent/subagents/working-directory";
 import {
   __resetBackgroundRetentionConfigForTests,
   backgroundTasks,


### PR DESCRIPTION
## Summary

Subagents are spawned with `cwd` taken from `USER_CWD`, captured at session start — or at `EnterWorktree`, which migrates the session anchor into the new worktree — and never re-validated. (The anchor is mirrored in `process.env.USER_CWD`, the process cwd, and runtime context; the env copy takes precedence at spawn and is the only one never validated — `getCurrentWorkingDirectory` already validates the runtime-context copy.) If that directory is deleted mid-session, every subsequent subagent spawn fails with ENOENT before the child executes an instruction, and the failure is invisible: a spawn failure emits `error` without `close` (a bare `null` exit code), the non-zero-exit branch returned without logging, and the reflection finalizer — inspecting the freshly created **memory** worktree that the dead child never got to write to — finds it clean with zero commits and reports `no_changes`, which renders as *"Dreamed; no durable memory changes were needed."*

### Field incident

A session entered a worktree for a multi-file editing pass (`EnterWorktree` migrated the anchor). Eighteen minutes later the user asked the agent to stop using worktrees and work in the main checkout. The agent complied at the only layer it could reach — folded the changes onto main with raw git and removed the worktree — but there is no inverse of `EnterWorktree`, so the session anchor was left pointing at a deleted directory. Every reflection after that died at spawn: 20 consecutive `Subagent exited with code null` failures, each rendered as a benign no-op. Because failed reflections never advance the reflected-through pointer, the step-count trigger re-fired at every turn end, and memory consolidation silently stalled — the unreflected transcript backlog grew to 71 steps while the agent's direct memory writes continued to mask the gap. Recovery ultimately required the user to manually re-point the session's working directory in the desktop app; the agent had no operation available to repair its own anchor.

## Changes

- **`src/agent/subagents/working-directory.ts`** (new module; `manager.ts` is at its file-size baseline): `resolveSubagentWorkingDirectory` moved out and now validates every candidate cwd with `isUsableDirectory`, falling back with a `debugWarn` — the same read-time validate-and-fall-back pattern as #3099 and as `getCurrentWorkingDirectory` itself.
- **`src/agent/subagents/manager.ts`**: capture the spawn `error` and report `Subagent process failed to start: <error> (cwd: <dir>)` instead of a bare null exit; add a `debugWarn` to the previously silent non-zero-exit branch (the observability gap #3024 — closed as stale — also addressed).

## Scope notes for reviewers

This is deliberately the **backstop half** of the fix: it makes a dead anchor survivable and attributable at every consumer, including non-cooperative deletions (#3253 is the same class on the Bash-tool surface). The intent-restoring half is design-level, so recording the observations rather than prescribing:

- `enter_worktree` holds the previous cwd only transiently (for lock bookkeeping), not as anchor provenance — and git's own worktree→parent linkage is destroyed by the removal itself. Recording `{current, parentCheckout}` would make an `ExitWorktree`/re-anchor operation well-defined; today, honoring "stop using this worktree" is only expressible as filesystem surgery below the layer that owns the anchor, which is exactly what stranded it.
- The reflection agent's prompt contract addresses everything via `$MEMORY_DIR`; its cwd is consumed only for project-settings resolution. Whether memory-profile children should pin to the harness-owned memory scope directory (giving up per-project settings) or keep the project cwd with this PR's fallback is a policy question — as is whether project-profile subagents would prefer fail-fast-with-context over running from a fallback directory.
- A failure-aware backoff for the step-count trigger may be worth considering separately; with the cause fixed and failures now loud, per-turn retry is reasonable for transient errors.

## Test plan

- [x] `bun test src/agent/subagent-model-resolution.test.ts` — existing cwd-resolution tests converted to real temp dirs; three new tests cover a deleted `USER_CWD` (with and without `memoryScope`, mirroring the field incident) and a deleted inherited memory root
- [x] `bun test src/tools/subagent-parent-id-propagation.test.ts src/headless-bidirectional-reflection.test.ts src/agent/memory-worktree.test.ts src/cli/memory-subagent-recompile.test.ts` — 87 pass / 0 fail
- [x] `bun run typecheck`, `bun run lint` (changed files), `check:cycles`, `check:boundaries`, `check:file-size` (baseline ratcheted 1577 → 1556), `check:module-ownership`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
