### PR TITLE
refactor(listener): centralize turn lifecycle ownership

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -43,12 +43,11 @@
   "src/tools/tool-execution-context.test.ts": 1422,
   "src/types/protocol_v2.ts": 2932,
   "src/websocket/listen-client-concurrency.test.ts": 3021,
-  "src/websocket/listen-client-protocol.test.ts": 6734,
+  "src/websocket/listen-client-protocol.test.ts": 6721,
   "src/websocket/listener/commands/channels.ts": 1390,
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1030,
   "src/websocket/listener/lifecycle.ts": 1766,
-  "src/websocket/listener/message-router.ts": 1011,
   "src/websocket/listener/protocol-inbound.ts": 2279,
   "src/websocket/listener/protocol-outbound.ts": 1279
 }

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -42,14 +42,13 @@
   "src/tools/manager.ts": 3293,
   "src/tools/tool-execution-context.test.ts": 1422,
   "src/types/protocol_v2.ts": 2932,
-  "src/websocket/listen-client-concurrency.test.ts": 3110,
-  "src/websocket/listen-client-protocol.test.ts": 6942,
+  "src/websocket/listen-client-concurrency.test.ts": 3021,
+  "src/websocket/listen-client-protocol.test.ts": 6734,
   "src/websocket/listener/commands/channels.ts": 1390,
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1030,
-  "src/websocket/listener/lifecycle.ts": 1767,
+  "src/websocket/listener/lifecycle.ts": 1766,
   "src/websocket/listener/message-router.ts": 1011,
   "src/websocket/listener/protocol-inbound.ts": 2279,
-  "src/websocket/listener/protocol-outbound.ts": 1295,
-  "src/websocket/listener/turn.ts": 1495
+  "src/websocket/listener/protocol-outbound.ts": 1279
 }

--- a/src/cli/subcommands/listen-telemetry.test.ts
+++ b/src/cli/subcommands/listen-telemetry.test.ts
@@ -6,6 +6,13 @@ import {
 import { settingsManager } from "@/settings-manager";
 import { telemetry } from "@/telemetry";
 
+type TelemetryTestState = {
+  events: unknown[];
+  sessionEndTracked: boolean;
+};
+
+const telemetryState = telemetry as unknown as TelemetryTestState;
+
 describe("listen subcommand telemetry", () => {
   const originalLoadLocalProjectSettings =
     settingsManager.loadLocalProjectSettings;
@@ -31,6 +38,8 @@ describe("listen subcommand telemetry", () => {
 
   beforeEach(() => {
     telemetry.cleanup();
+    telemetryState.events = [];
+    telemetryState.sessionEndTracked = false;
     delete process.env.LETTA_API_KEY;
     delete process.env.LETTA_BASE_URL;
     delete process.env.LETTA_DESKTOP_MODE;

--- a/src/tools/toolset-caching.test.ts
+++ b/src/tools/toolset-caching.test.ts
@@ -20,14 +20,19 @@ describe("listener tool prep metadata reuse", () => {
   });
 
   test("listener turn passes cached agent metadata into reflection and tool prep", () => {
-    const source = readSource("../websocket/listener/turn.ts");
+    const turnSource = readSource("../websocket/listener/turn.ts");
+    const setupSource = readSource("../websocket/listener/turn-setup.ts");
+    const completionSource = readSource(
+      "../websocket/listener/turn-completion.ts",
+    );
 
-    expect(source).toContain("cachedAgent: AgentState | null = null;");
-    expect(source).toContain(
+    expect(setupSource).toContain("cachedAgent: AgentState | null = null;");
+    expect(setupSource).toContain(
       "cachedAgent = (await getBackend().retrieveAgent(",
     );
-    expect(source).toContain("buildMaybeLaunchReflectionSubagent({");
-    expect(source).toContain("cachedAgent,");
-    expect(source).toContain("prepareToolExecutionContextForScope({");
+    expect(setupSource).toContain("prepareToolExecutionContextForScope({");
+    expect(turnSource).toContain("getCachedAgent: setup.getCachedAgent,");
+    expect(completionSource).toContain("buildMaybeLaunchReflectionSubagent({");
+    expect(completionSource).toContain("cachedAgent: params.getCachedAgent(),");
   });
 });

--- a/src/websocket/helpers/listener-queue-adapter.ts
+++ b/src/websocket/helpers/listener-queue-adapter.ts
@@ -1,31 +1,23 @@
 import type { QueueBlockedReason } from "@/queue/queue-runtime";
-import type { LoopStatus } from "@/types/protocol_v2";
-
-export type ListenerQueueGatingConditions = {
-  loopStatus: LoopStatus;
-  isProcessing: boolean;
-  pendingApprovalsLen: number;
-  cancelRequested: boolean;
-  isRecoveringApprovals: boolean;
-};
+import type { TurnLifecycleSnapshot } from "@/websocket/listener/turn-lifecycle";
 
 export function getListenerBlockedReason(
-  c: ListenerQueueGatingConditions,
+  lifecycle: TurnLifecycleSnapshot,
+  pendingApprovalsLen: number,
 ): QueueBlockedReason | null {
-  if (c.cancelRequested) return "interrupt_in_progress";
-  if (c.pendingApprovalsLen > 0) return "pending_approvals";
-  if (c.isRecoveringApprovals) return "runtime_busy";
-  if (c.loopStatus === "WAITING_ON_APPROVAL") return "pending_approvals";
-  if (c.loopStatus === "EXECUTING_COMMAND") return "command_running";
-  if (
-    c.loopStatus === "SENDING_API_REQUEST" ||
-    c.loopStatus === "RETRYING_API_REQUEST" ||
-    c.loopStatus === "WAITING_FOR_API_RESPONSE" ||
-    c.loopStatus === "PROCESSING_API_RESPONSE" ||
-    c.loopStatus === "EXECUTING_CLIENT_SIDE_TOOL"
-  ) {
-    return "streaming";
+  if (lifecycle.kind === "cancelling") {
+    return "interrupt_in_progress";
   }
-  if (c.isProcessing) return "runtime_busy";
+  if (pendingApprovalsLen > 0) {
+    return "pending_approvals";
+  }
+  if (lifecycle.kind === "command") {
+    return "command_running";
+  }
+  if (lifecycle.kind === "active") {
+    return lifecycle.loopStatus === "WAITING_ON_APPROVAL"
+      ? "pending_approvals"
+      : "streaming";
+  }
   return null;
 }

--- a/src/websocket/listen-client-concurrency.test.ts
+++ b/src/websocket/listen-client-concurrency.test.ts
@@ -37,7 +37,10 @@ import { handleSecretsCommand } from "@/websocket/listener/commands/secrets";
 import { shouldProcessInboundMessageDirectly } from "@/websocket/listener/queue";
 import { resolveRecoveredApprovalResponse } from "@/websocket/listener/recovery";
 import { injectQueuedSkillContent } from "@/websocket/listener/skill-injection";
-import type { IncomingMessage } from "@/websocket/listener/types";
+import type {
+  ConversationRuntime,
+  IncomingMessage,
+} from "@/websocket/listener/types";
 
 type MockStream = {
   conversationId: string;
@@ -62,6 +65,22 @@ const defaultDrainResult: DrainResult = {
 
 const TEST_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aF9sAAAAASUVORK5CYII=";
+
+function beginTestTurn(
+  runtime: ConversationRuntime,
+  options: {
+    workingDirectory?: string;
+    initialStatus?: Parameters<
+      ConversationRuntime["turnLifecycle"]["begin"]
+    >[0]["initialStatus"];
+  } = {},
+) {
+  return runtime.turnLifecycle.begin({
+    origin: "message",
+    workingDirectory: options.workingDirectory ?? "/tmp/test-worktree",
+    ...(options.initialStatus ? { initialStatus: options.initialStatus } : {}),
+  });
+}
 
 const sendMessageStreamCalls: Array<{
   conversationId: string;
@@ -279,11 +298,7 @@ const { createListenerModAdapter } = await import(
 );
 const { sendApprovalContinuationWithRetry, sendMessageStreamWithRetry } =
   await import("@/websocket/listener/send");
-const {
-  __listenClientTestUtils,
-  requestApprovalOverWS,
-  resolvePendingApprovalResolver,
-} = listenClientModule;
+const { __listenClientTestUtils } = listenClientModule;
 
 class MockSocket {
   readyState: number;
@@ -749,137 +764,13 @@ describe("listen-client multi-worker concurrency", () => {
       "conv-b",
     );
 
-    runtimeA.isProcessing = true;
-    runtimeA.activeAbortController = new AbortController();
-    runtimeB.isProcessing = true;
-    runtimeB.activeAbortController = new AbortController();
+    const leaseA = beginTestTurn(runtimeA);
+    const leaseB = beginTestTurn(runtimeB);
+    runtimeA.turnLifecycle.requestCancellation();
 
-    runtimeA.cancelRequested = true;
-    runtimeA.activeAbortController.abort();
-
-    expect(runtimeA.activeAbortController.signal.aborted).toBe(true);
-    expect(runtimeB.activeAbortController.signal.aborted).toBe(false);
+    expect(leaseA.signal.aborted).toBe(true);
+    expect(leaseB.signal.aborted).toBe(false);
     expect(runtimeB.cancelRequested).toBe(false);
-  });
-
-  test("approval waits and resolver routing stay isolated per conversation", async () => {
-    const listener = __listenClientTestUtils.createListenerRuntime();
-    const runtimeA = __listenClientTestUtils.getOrCreateConversationRuntime(
-      listener,
-      "agent-1",
-      "conv-a",
-    );
-    const runtimeB = __listenClientTestUtils.getOrCreateConversationRuntime(
-      listener,
-      "agent-1",
-      "conv-b",
-    );
-    const socket = new MockSocket();
-
-    const pendingA = requestApprovalOverWS(
-      runtimeA,
-      socket as unknown as WebSocket,
-      "perm-a",
-      {
-        type: "control_request",
-        request_id: "perm-a",
-        request: {
-          subtype: "can_use_tool",
-          tool_name: "Bash",
-          input: {},
-          tool_call_id: "call-a",
-          permission_suggestions: [],
-          blocked_path: null,
-        },
-      },
-    );
-    const pendingB = requestApprovalOverWS(
-      runtimeB,
-      socket as unknown as WebSocket,
-      "perm-b",
-      {
-        type: "control_request",
-        request_id: "perm-b",
-        request: {
-          subtype: "can_use_tool",
-          tool_name: "Bash",
-          input: {},
-          tool_call_id: "call-b",
-          permission_suggestions: [],
-          blocked_path: null,
-        },
-      },
-    );
-
-    expect(listener.approvalRuntimeKeyByRequestId.get("perm-a")).toBe(
-      runtimeA.key,
-    );
-    expect(listener.approvalRuntimeKeyByRequestId.get("perm-b")).toBe(
-      runtimeB.key,
-    );
-
-    const statusAWhilePending = __listenClientTestUtils.buildLoopStatus(
-      listener,
-      {
-        agent_id: "agent-1",
-        conversation_id: "conv-a",
-      },
-    );
-    const statusBWhilePending = __listenClientTestUtils.buildLoopStatus(
-      listener,
-      {
-        agent_id: "agent-1",
-        conversation_id: "conv-b",
-      },
-    );
-    expect(statusAWhilePending.status).toBe("WAITING_ON_APPROVAL");
-    expect(statusBWhilePending.status).toBe("WAITING_ON_APPROVAL");
-
-    expect(
-      resolvePendingApprovalResolver(runtimeA, {
-        request_id: "perm-a",
-        decision: { behavior: "allow" },
-      }),
-    ).toBe(true);
-
-    await expect(pendingA).resolves.toMatchObject({
-      request_id: "perm-a",
-      decision: { behavior: "allow" },
-    });
-    expect(runtimeA.pendingApprovalResolvers.size).toBe(0);
-    expect(runtimeB.pendingApprovalResolvers.size).toBe(1);
-    expect(listener.approvalRuntimeKeyByRequestId.has("perm-a")).toBe(false);
-    expect(listener.approvalRuntimeKeyByRequestId.get("perm-b")).toBe(
-      runtimeB.key,
-    );
-
-    const statusAAfterResolve = __listenClientTestUtils.buildLoopStatus(
-      listener,
-      {
-        agent_id: "agent-1",
-        conversation_id: "conv-a",
-      },
-    );
-    const statusBAfterResolve = __listenClientTestUtils.buildLoopStatus(
-      listener,
-      {
-        agent_id: "agent-1",
-        conversation_id: "conv-b",
-      },
-    );
-    expect(statusAAfterResolve.status).toBe("WAITING_ON_INPUT");
-    expect(statusBAfterResolve.status).toBe("WAITING_ON_APPROVAL");
-
-    expect(
-      resolvePendingApprovalResolver(runtimeB, {
-        request_id: "perm-b",
-        decision: { behavior: "allow" },
-      }),
-    ).toBe(true);
-    await expect(pendingB).resolves.toMatchObject({
-      request_id: "perm-b",
-      decision: { behavior: "allow" },
-    });
   });
 
   test("recovered approval state does not leak across conversation scopes", () => {
@@ -1215,7 +1106,8 @@ describe("listen-client multi-worker concurrency", () => {
       } as never,
       async (queuedTurn: IncomingMessage) => {
         processed.push(queuedTurn);
-        runtime.lastStopReason = "end_turn";
+        const lease = beginTestTurn(runtime);
+        runtime.turnLifecycle.finish(lease, "end_turn");
       },
     );
 
@@ -1294,7 +1186,8 @@ describe("listen-client multi-worker concurrency", () => {
         onStatusChange: undefined,
       } as never,
       async () => {
-        runtime.lastStopReason = "requires_approval";
+        const lease = beginTestTurn(runtime);
+        runtime.turnLifecycle.finish(lease, "requires_approval");
       },
     );
 
@@ -1374,7 +1267,8 @@ describe("listen-client multi-worker concurrency", () => {
         onStatusChange: undefined,
       } as never,
       async () => {
-        runtime.lastStopReason = "error";
+        const lease = beginTestTurn(runtime);
+        runtime.turnLifecycle.finish(lease, "error");
         runtime.lastTerminalLoopErrorMessage =
           "ChatGPT usage limit reached. Resets at 1:00 PM.";
         runtime.lastTerminalLoopErrorRunId = "run-limit";
@@ -1573,8 +1467,10 @@ describe("listen-client multi-worker concurrency", () => {
     const runtime = __listenClientTestUtils.createRuntime();
     runtime.agentId = "agent-1";
     runtime.conversationId = "conv-1";
-    runtime.activeWorkingDirectory = "/tmp/project";
-    runtime.loopStatus = "WAITING_FOR_API_RESPONSE";
+    const turnLease = beginTestTurn(runtime, {
+      workingDirectory: "/tmp/project",
+      initialStatus: "WAITING_FOR_API_RESPONSE",
+    });
     const socket = new MockSocket();
     const drain = createDeferredDrain();
     drainHandlers.set("conv-1", () => drain.promise);
@@ -1628,7 +1524,7 @@ describe("listen-client multi-worker concurrency", () => {
     const recoveryPromise = __listenClientTestUtils.resolveStaleApprovals(
       runtime,
       socket as unknown as WebSocket,
-      new AbortController().signal,
+      turnLease,
       { getResumeData: getResumeDataMock },
     );
 
@@ -2136,7 +2032,7 @@ describe("listen-client multi-worker concurrency", () => {
       pendingRequestIds: new Set(["perm-sync"]),
       responsesByRequestId: new Map(),
     };
-    runtime.loopStatus = "WAITING_ON_APPROVAL";
+    beginTestTurn(runtime, { initialStatus: "WAITING_ON_APPROVAL" });
     getResumeDataMock.mockClear();
     retrieveAgentMock.mockClear();
 
@@ -2254,8 +2150,7 @@ describe("listen-client multi-worker concurrency", () => {
     const socket = new MockSocket();
     const statuses: string[] = [];
 
-    runtimeA.isProcessing = true;
-    runtimeA.loopStatus = "PROCESSING_API_RESPONSE";
+    beginTestTurn(runtimeA, { initialStatus: "PROCESSING_API_RESPONSE" });
 
     const queueInput = {
       kind: "message",
@@ -2842,11 +2737,16 @@ describe("listen-client multi-worker concurrency", () => {
     });
 
     const parentAbortController = new AbortController();
+    const turnLease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: "/tmp/test-worktree",
+      abortController: parentAbortController,
+    });
 
     const result = await __listenClientTestUtils.resolveStaleApprovals(
       runtime,
       socket as unknown as WebSocket,
-      parentAbortController.signal,
+      turnLease,
       {
         getResumeData: getResumeDataMock,
       },
@@ -2876,6 +2776,7 @@ describe("listen-client multi-worker concurrency", () => {
       "conv-approval-busy",
     );
     const socket = new MockSocket();
+    const turnLease = beginTestTurn(runtime);
 
     sendMessageStreamMock.mockRejectedValueOnce(
       new APIError(
@@ -2918,10 +2819,14 @@ describe("listen-client multi-worker concurrency", () => {
         },
         socket as unknown as WebSocket,
         runtime,
-        new AbortController().signal,
+        turnLease,
       );
 
-      expect(stream as unknown as MockStream).toEqual({
+      expect(stream.kind).toBe("stream");
+      if (stream.kind !== "stream") {
+        throw new Error("Expected approval continuation stream");
+      }
+      expect(stream.stream as unknown as MockStream).toEqual({
         conversationId: "conv-approval-busy",
         agentId: "agent-approval-busy",
       });
@@ -2962,6 +2867,7 @@ describe("listen-client multi-worker concurrency", () => {
       "conv-blocking-run",
     );
     const socket = new MockSocket();
+    const turnLease = beginTestTurn(runtime);
     const blockingRunId = "run-blocking-123";
 
     sendMessageStreamMock.mockRejectedValueOnce(
@@ -3013,10 +2919,14 @@ describe("listen-client multi-worker concurrency", () => {
         },
         socket as unknown as WebSocket,
         runtime,
-        new AbortController().signal,
+        turnLease,
       );
 
-      expect(stream as unknown as MockStream).toEqual({
+      expect(stream.kind).toBe("stream");
+      if (stream.kind !== "stream") {
+        throw new Error("Expected approval continuation stream");
+      }
+      expect(stream.stream as unknown as MockStream).toEqual({
         conversationId: "conv-blocking-run",
         agentId: "agent-blocking-run",
       });
@@ -3039,6 +2949,7 @@ describe("listen-client multi-worker concurrency", () => {
       "conv-message-blocking-run",
     );
     const socket = new MockSocket();
+    const turnLease = beginTestTurn(runtime);
     const blockingRunId = "run-message-blocking-123";
 
     sendMessageStreamMock.mockRejectedValueOnce(
@@ -3090,7 +3001,7 @@ describe("listen-client multi-worker concurrency", () => {
         },
         socket as unknown as WebSocket,
         runtime,
-        new AbortController().signal,
+        turnLease,
       );
 
       expect(stream as unknown as MockStream).toEqual({

--- a/src/websocket/listen-client-concurrency.test.ts
+++ b/src/websocket/listen-client-concurrency.test.ts
@@ -34,12 +34,15 @@ import {
   clearSecretsCache,
 } from "@/utils/secrets-store";
 import { handleSecretsCommand } from "@/websocket/listener/commands/secrets";
+import { enqueueInboundUserMessage } from "@/websocket/listener/inbound-queue";
 import { shouldProcessInboundMessageDirectly } from "@/websocket/listener/queue";
 import { resolveRecoveredApprovalResponse } from "@/websocket/listener/recovery";
+import { clearConversationRuntimeState } from "@/websocket/listener/runtime";
 import { injectQueuedSkillContent } from "@/websocket/listener/skill-injection";
 import type {
   ConversationRuntime,
   IncomingMessage,
+  RecoveredApprovalState,
 } from "@/websocket/listener/types";
 
 type MockStream = {
@@ -354,6 +357,55 @@ function makeIncomingMessage(
   };
 }
 
+function makeRecoveredApprovalState(params: {
+  agentId: string;
+  conversationId: string;
+  requestId: string;
+  toolCallId: string;
+  toolName: string;
+  toolArgs: string;
+  overrides?: Partial<RecoveredApprovalState>;
+}): RecoveredApprovalState {
+  let input: Record<string, unknown> = {};
+  try {
+    input = JSON.parse(params.toolArgs) as Record<string, unknown>;
+  } catch {}
+  return {
+    agentId: params.agentId,
+    conversationId: params.conversationId,
+    approvalsByRequestId: new Map([
+      [
+        params.requestId,
+        {
+          approval: {
+            toolCallId: params.toolCallId,
+            toolName: params.toolName,
+            toolArgs: params.toolArgs,
+          },
+          approvalContext: null,
+          controlRequest: {
+            type: "control_request",
+            request_id: params.requestId,
+            request: {
+              subtype: "can_use_tool",
+              tool_name: params.toolName,
+              input,
+              tool_call_id: params.toolCallId,
+              permission_suggestions: [],
+              blocked_path: null,
+            },
+            agent_id: params.agentId,
+            conversation_id: params.conversationId,
+          },
+        },
+      ],
+    ]),
+    pendingRequestIds: new Set([params.requestId]),
+    responsesByRequestId: new Map(),
+    ...params.overrides,
+  };
+}
+
 // Stub reminder providers that touch settingsManager/process.cwd so
 // handleIncomingMessage works without a fully initialised environment.
 // Uses the same save/restore pattern as listen-session-context.test.ts
@@ -448,16 +500,8 @@ describe("listen-client multi-worker concurrency", () => {
   });
 
   afterAll(() => {
-    // Bun's `mock.module()` swaps are process-global and are NOT undone by
-    // `mock.restore()` (which only resets mock function call history /
-    // queued return values). Subsequent test files that statically import
-    // these module paths would otherwise receive the mocked version, with
-    // any leftover `mockResolvedValueOnce(...)` values bleeding into them.
-    //
-    // Mitigation: reset the underlying mock functions and re-point them at
-    // the real implementations captured before mocking. The `mock.module`
-    // factory always returns the same wrapper object, so swapping the
-    // function reference behind it propagates to all consumers.
+    // `mock.module()` is process-global, so restore the captured real
+    // implementations behind each wrapper before other test files run.
     classifyApprovalsMock.mockReset();
     // biome-ignore lint/suspicious/noExplicitAny: real implementations have wider signatures than the narrow zero-arg mocks
     (classifyApprovalsMock as any).mockImplementation(realClassifyApprovals);
@@ -786,37 +830,14 @@ describe("listen-client multi-worker concurrency", () => {
       "conv-b",
     );
 
-    runtimeA.recoveredApprovalState = {
+    runtimeA.recoveredApprovalState = makeRecoveredApprovalState({
       agentId: "agent-1",
       conversationId: "conv-a",
-      approvalsByRequestId: new Map([
-        [
-          "perm-a",
-          {
-            approval: {
-              toolCallId: "call-a",
-              toolName: "Bash",
-              toolArgs: "{}",
-            },
-            approvalContext: null,
-            controlRequest: {
-              type: "control_request",
-              request_id: "perm-a",
-              request: {
-                subtype: "can_use_tool",
-                tool_name: "Bash",
-                input: {},
-                tool_call_id: "call-a",
-                permission_suggestions: [],
-                blocked_path: null,
-              },
-            },
-          },
-        ],
-      ]),
-      pendingRequestIds: new Set(["perm-a"]),
-      responsesByRequestId: new Map(),
-    };
+      requestId: "perm-a",
+      toolCallId: "call-a",
+      toolName: "Bash",
+      toolArgs: "{}",
+    });
 
     const loopStatusA = __listenClientTestUtils.buildLoopStatus(listener, {
       agent_id: "agent-1",
@@ -1676,39 +1697,14 @@ describe("listen-client multi-worker concurrency", () => {
     );
     const socket = new MockSocket();
 
-    runtime.recoveredApprovalState = {
+    runtime.recoveredApprovalState = makeRecoveredApprovalState({
       agentId: "agent-1",
       conversationId: "conv-recovered",
-      approvalsByRequestId: new Map([
-        [
-          "perm-recovered-1",
-          {
-            approval: {
-              toolCallId: "tool-call-recovered-1",
-              toolName: "Write",
-              toolArgs: '{"file_path":"foo.ts"}',
-            },
-            approvalContext: null,
-            controlRequest: {
-              type: "control_request",
-              request_id: "perm-recovered-1",
-              request: {
-                subtype: "can_use_tool",
-                tool_name: "Write",
-                input: { file_path: "foo.ts" },
-                tool_call_id: "tool-call-recovered-1",
-                permission_suggestions: [],
-                blocked_path: null,
-              },
-              agent_id: "agent-1",
-              conversation_id: "conv-recovered",
-            },
-          },
-        ],
-      ]),
-      pendingRequestIds: new Set(["perm-recovered-1"]),
-      responsesByRequestId: new Map(),
-    };
+      requestId: "perm-recovered-1",
+      toolCallId: "tool-call-recovered-1",
+      toolName: "Write",
+      toolArgs: '{"file_path":"foo.ts"}',
+    });
 
     queueSkillContent(
       "tool-call-recovered-1",
@@ -1889,47 +1885,25 @@ describe("listen-client multi-worker concurrency", () => {
     ];
     executeApprovalBatchMock.mockResolvedValueOnce(approvalResults as never);
 
-    runtime.recoveredApprovalState = {
+    runtime.recoveredApprovalState = makeRecoveredApprovalState({
       agentId: "agent-1",
       conversationId: "conv-mixed-recovered",
-      approvalsByRequestId: new Map([
-        [
-          "perm-tool-manual",
+      requestId: "perm-tool-manual",
+      toolCallId: manualApproval.toolCallId,
+      toolName: manualApproval.toolName,
+      toolArgs: manualApproval.toolArgs,
+      overrides: {
+        autoDecisions: [
+          { type: "approve", approval: autoAllowedApproval },
           {
-            approval: manualApproval,
-            approvalContext: null,
-            controlRequest: {
-              type: "control_request",
-              request_id: "perm-tool-manual",
-              request: {
-                subtype: "can_use_tool",
-                tool_name: "Bash",
-                input: { command: "rm -rf tmp" },
-                tool_call_id: "tool-manual",
-                permission_suggestions: [],
-                blocked_path: null,
-              },
-              agent_id: "agent-1",
-              conversation_id: "conv-mixed-recovered",
-            },
+            type: "deny",
+            approval: autoDeniedApproval,
+            reason: "blocked by policy",
           },
         ],
-      ]),
-      pendingRequestIds: new Set(["perm-tool-manual"]),
-      responsesByRequestId: new Map(),
-      autoDecisions: [
-        {
-          type: "approve",
-          approval: autoAllowedApproval,
-        },
-        {
-          type: "deny",
-          approval: autoDeniedApproval,
-          reason: "blocked by policy",
-        },
-      ],
-      allApprovals: [autoAllowedApproval, manualApproval, autoDeniedApproval],
-    };
+        allApprovals: [autoAllowedApproval, manualApproval, autoDeniedApproval],
+      },
+    });
 
     const handled = await resolveRecoveredApprovalResponse(
       runtime,
@@ -1999,39 +1973,14 @@ describe("listen-client multi-worker concurrency", () => {
       continuationEpoch: runtime.continuationEpoch,
     };
     runtime.pendingInterruptedToolCallIds = null;
-    runtime.recoveredApprovalState = {
+    runtime.recoveredApprovalState = makeRecoveredApprovalState({
       agentId: "agent-1",
       conversationId: "conv-sync",
-      approvalsByRequestId: new Map([
-        [
-          "perm-sync",
-          {
-            approval: {
-              toolCallId: "call-sync",
-              toolName: "Bash",
-              toolArgs: '{"command":"sleep 300"}',
-            },
-            approvalContext: null,
-            controlRequest: {
-              type: "control_request",
-              request_id: "perm-sync",
-              request: {
-                subtype: "can_use_tool",
-                tool_name: "Bash",
-                input: { command: "sleep 300" },
-                tool_call_id: "call-sync",
-                permission_suggestions: [],
-                blocked_path: null,
-              },
-              agent_id: "agent-1",
-              conversation_id: "conv-sync",
-            },
-          },
-        ],
-      ]),
-      pendingRequestIds: new Set(["perm-sync"]),
-      responsesByRequestId: new Map(),
-    };
+      requestId: "perm-sync",
+      toolCallId: "call-sync",
+      toolName: "Bash",
+      toolArgs: '{"command":"sleep 300"}',
+    });
     beginTestTurn(runtime, { initialStatus: "WAITING_ON_APPROVAL" });
     getResumeDataMock.mockClear();
     retrieveAgentMock.mockClear();
@@ -2083,39 +2032,14 @@ describe("listen-client multi-worker concurrency", () => {
       continuationEpoch: runtime.continuationEpoch,
     };
     runtime.pendingInterruptedToolCallIds = null;
-    runtime.recoveredApprovalState = {
+    runtime.recoveredApprovalState = makeRecoveredApprovalState({
       agentId: "agent-1",
       conversationId: "conv-stale",
-      approvalsByRequestId: new Map([
-        [
-          "perm-stale",
-          {
-            approval: {
-              toolCallId: "tool-call-stale",
-              toolName: "Bash",
-              toolArgs: '{"command":"sleep 300"}',
-            },
-            approvalContext: null,
-            controlRequest: {
-              type: "control_request",
-              request_id: "perm-stale",
-              request: {
-                subtype: "can_use_tool",
-                tool_name: "Bash",
-                input: { command: "sleep 300" },
-                tool_call_id: "tool-call-stale",
-                permission_suggestions: [],
-                blocked_path: null,
-              },
-              agent_id: "agent-1",
-              conversation_id: "conv-stale",
-            },
-          },
-        ],
-      ]),
-      pendingRequestIds: new Set(["perm-stale"]),
-      responsesByRequestId: new Map(),
-    };
+      requestId: "perm-stale",
+      toolCallId: "tool-call-stale",
+      toolName: "Bash",
+      toolArgs: '{"command":"sleep 300"}',
+    });
 
     const handled = await resolveRecoveredApprovalResponse(
       runtime,
@@ -2382,6 +2306,82 @@ describe("listen-client multi-worker concurrency", () => {
       type: "approval",
       otid: expect.any(String),
     });
+  });
+
+  test("disconnect cleanup lets an actual approval owner release and drain a follow-up", async () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    __listenClientTestUtils.setActiveRuntime(listener);
+    const runtime = __listenClientTestUtils.getOrCreateScopedRuntime(
+      listener,
+      "agent-1",
+      "conv-reset",
+    );
+    const socket = new MockSocket();
+    const resetApproval = {
+      toolCallId: "call-reset",
+      toolName: "AskUserQuestion",
+      toolArgs: "{}",
+    };
+    let drainCount = 0;
+    drainHandlers.set("conv-reset", async () => {
+      drainCount += 1;
+      return drainCount === 1
+        ? {
+            stopReason: "requires_approval",
+            approvals: [resetApproval],
+            apiDurationMs: 0,
+          }
+        : defaultDrainResult;
+    });
+    classifyApprovalsMock.mockResolvedValueOnce({
+      autoAllowed: [],
+      autoDenied: [],
+      needsUserInput: [
+        {
+          approval: resetApproval,
+          parsedArgs: {},
+          context: null,
+        },
+      ],
+    } as never);
+
+    const owner = __listenClientTestUtils.handleIncomingMessage(
+      makeIncomingMessage("agent-1", "conv-reset", "first"),
+      socket as unknown as WebSocket,
+      runtime,
+    );
+    await waitFor(() => runtime.pendingApprovalResolvers.size === 1);
+    clearConversationRuntimeState(runtime);
+    await owner;
+
+    enqueueInboundUserMessage(
+      runtime,
+      makeIncomingMessage("agent-1", "conv-reset", "follow up"),
+    );
+    __listenClientTestUtils.scheduleQueuePump(
+      runtime,
+      socket as unknown as WebSocket,
+      {} as never,
+      (queuedTurn, batch) =>
+        __listenClientTestUtils.handleIncomingMessage(
+          queuedTurn,
+          socket as unknown as WebSocket,
+          runtime,
+          undefined,
+          undefined,
+          batch.batchId,
+        ),
+    );
+    await waitFor(
+      () =>
+        runtime.queueRuntime.length === 0 &&
+        runtime.turnLifecycle.kind === "idle" &&
+        sendMessageStreamMock.mock.calls.length === 2,
+    );
+
+    expect(JSON.stringify(sendMessageStreamMock.mock.calls[1]?.[1])).toContain(
+      "follow up",
+    );
   });
 
   test("change_device_state does not prune default-state entry mid-turn", async () => {

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -36,7 +36,7 @@ import {
   clearExternalTools,
   prepareToolExecutionContextForModel,
 } from "@/tools/manager";
-import type { ApprovalResponseBody, ControlRequest } from "@/types/protocol_v2";
+import type { ControlRequest } from "@/types/protocol_v2";
 import {
   __listenClientTestUtils,
   emitInterruptedStatusDelta,
@@ -60,6 +60,36 @@ import {
   getRecoverableRetryNoticeVisibility,
   getRecoverableStatusNoticeVisibility,
 } from "@/websocket/listener/recoverable-notices";
+import type { ConversationRuntime } from "@/websocket/listener/types";
+
+function beginTestTurn(
+  runtime: ConversationRuntime,
+  options: {
+    workingDirectory?: string;
+    initialStatus?: Parameters<
+      ConversationRuntime["turnLifecycle"]["begin"]
+    >[0]["initialStatus"];
+    abortController?: AbortController;
+    runId?: string;
+    executingToolCallIds?: readonly string[];
+  } = {},
+) {
+  const lease = runtime.turnLifecycle.begin({
+    origin: "message",
+    workingDirectory: options.workingDirectory ?? "/tmp/test-worktree",
+    ...(options.initialStatus ? { initialStatus: options.initialStatus } : {}),
+    ...(options.abortController
+      ? { abortController: options.abortController }
+      : {}),
+    ...(options.executingToolCallIds
+      ? { executingToolCallIds: options.executingToolCallIds }
+      : {}),
+  });
+  if (options.runId) {
+    runtime.turnLifecycle.setRunId(lease, options.runId);
+  }
+  return lease;
+}
 
 class MockSocket {
   readyState: number;
@@ -147,13 +177,6 @@ function makeControlRequest(requestId: string): ControlRequest {
       permission_suggestions: [],
       blocked_path: null,
     },
-  };
-}
-
-function makeSuccessResponse(requestId: string): ApprovalResponseBody {
-  return {
-    request_id: requestId,
-    decision: { behavior: "allow" },
   };
 }
 
@@ -3826,143 +3849,6 @@ describe("listen-client conversation working directory", () => {
   });
 });
 
-describe("listen-client approval resolver wiring", () => {
-  test("resolved approvals do not project WAITING_ON_INPUT while the enclosing turn is still processing", () => {
-    const runtime = __listenClientTestUtils.createRuntime();
-    const socket = new MockSocket(WebSocket.OPEN);
-    runtime.isProcessing = true;
-    runtime.loopStatus = "WAITING_ON_APPROVAL";
-
-    void requestApprovalOverWS(
-      runtime,
-      socket as unknown as WebSocket,
-      "perm-status",
-      makeControlRequest("perm-status"),
-    ).catch(() => {});
-
-    expect(runtime.loopStatus).toBe("WAITING_ON_APPROVAL");
-
-    const resolved = resolvePendingApprovalResolver(runtime, {
-      request_id: "perm-status",
-      decision: { behavior: "allow" },
-    });
-
-    expect(resolved).toBe(true);
-    expect(runtime.loopStatus as string).toBe("WAITING_ON_APPROVAL");
-  });
-
-  test("resolves matching pending resolver", async () => {
-    const runtime = __listenClientTestUtils.createRuntime();
-    const socket = new MockSocket(WebSocket.OPEN);
-    const requestId = "perm-101";
-
-    const pending = requestApprovalOverWS(
-      runtime,
-      socket as unknown as WebSocket,
-      requestId,
-      makeControlRequest(requestId),
-    );
-    expect(runtime.pendingApprovalResolvers.size).toBe(1);
-
-    const resolved = resolvePendingApprovalResolver(
-      runtime,
-      makeSuccessResponse(requestId),
-    );
-    expect(resolved).toBe(true);
-    await expect(pending).resolves.toMatchObject({
-      request_id: requestId,
-      decision: { behavior: "allow" },
-    });
-    expect(runtime.pendingApprovalResolvers.size).toBe(0);
-  });
-
-  test("ignores non-matching request_id and keeps pending resolver", async () => {
-    const runtime = __listenClientTestUtils.createRuntime();
-    const socket = new MockSocket(WebSocket.OPEN);
-    const requestId = "perm-201";
-
-    const pending = requestApprovalOverWS(
-      runtime,
-      socket as unknown as WebSocket,
-      requestId,
-      makeControlRequest(requestId),
-    );
-    let settled = false;
-    void pending.then(
-      () => {
-        settled = true;
-      },
-      () => {
-        settled = true;
-      },
-    );
-
-    const resolved = resolvePendingApprovalResolver(
-      runtime,
-      makeSuccessResponse("perm-other"),
-    );
-    expect(resolved).toBe(false);
-    await Promise.resolve();
-    expect(settled).toBe(false);
-    expect(runtime.pendingApprovalResolvers.size).toBe(1);
-
-    const handledPending = pending.catch((error) => error);
-    rejectPendingApprovalResolvers(runtime, "cleanup");
-    const cleanupError = await handledPending;
-    expect(cleanupError).toBeInstanceOf(Error);
-    expect((cleanupError as Error).message).toBe("cleanup");
-  });
-
-  test("cleanup rejects all pending resolvers", async () => {
-    const runtime = __listenClientTestUtils.createRuntime();
-    const first = new Promise<ApprovalResponseBody>((resolve, reject) => {
-      runtime.pendingApprovalResolvers.set("perm-a", { resolve, reject });
-    });
-    const second = new Promise<ApprovalResponseBody>((resolve, reject) => {
-      runtime.pendingApprovalResolvers.set("perm-b", { resolve, reject });
-    });
-
-    rejectPendingApprovalResolvers(runtime, "socket closed");
-    expect(runtime.pendingApprovalResolvers.size).toBe(0);
-    await expect(first).rejects.toThrow("socket closed");
-    await expect(second).rejects.toThrow("socket closed");
-  });
-
-  test("cleanup resets WAITING_ON_INPUT instead of restoring fake processing", async () => {
-    const runtime = __listenClientTestUtils.createRuntime();
-    runtime.isProcessing = true;
-    runtime.loopStatus = "WAITING_ON_APPROVAL";
-
-    const pending = new Promise<ApprovalResponseBody>((resolve, reject) => {
-      runtime.pendingApprovalResolvers.set("perm-cleanup", { resolve, reject });
-    });
-
-    rejectPendingApprovalResolvers(runtime, "socket closed");
-
-    expect(runtime.loopStatus as string).toBe("WAITING_ON_INPUT");
-    await expect(pending).rejects.toThrow("socket closed");
-  });
-
-  test("stopRuntime rejects pending resolvers even when callbacks are suppressed", async () => {
-    const runtime = __listenClientTestUtils.createRuntime();
-    const pending = new Promise<ApprovalResponseBody>((resolve, reject) => {
-      runtime.pendingApprovalResolvers.set("perm-stop", { resolve, reject });
-    });
-    const pendingError = pending.catch((error: unknown) => error);
-    const socket = new MockSocket(WebSocket.OPEN);
-    runtime.socket = socket as unknown as WebSocket;
-
-    __listenClientTestUtils.stopRuntime(runtime, true);
-
-    expect(runtime.pendingApprovalResolvers.size).toBe(0);
-    expect(socket.removeAllListenersCalls).toBe(1);
-    expect(socket.closeCalls).toBe(1);
-    const error = await pendingError;
-    expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toContain("Listener runtime stopped");
-  });
-});
-
 describe("listen-client protocol emission", () => {
   test("does not throw when protocol emission send fails", () => {
     const runtime = __listenClientTestUtils.createRuntime();
@@ -3986,89 +3872,6 @@ describe("listen-client protocol emission", () => {
     } finally {
       console.error = originalConsoleError;
     }
-  });
-});
-
-describe("listen-client requestApprovalOverWS", () => {
-  test("rejects immediately when socket is not open", async () => {
-    const runtime = __listenClientTestUtils.createRuntime();
-    const socket = new MockSocket(WebSocket.CLOSED);
-    const requestId = "perm-closed";
-
-    await expect(
-      requestApprovalOverWS(
-        runtime,
-        socket as unknown as WebSocket,
-        requestId,
-        makeControlRequest(requestId),
-      ),
-    ).rejects.toThrow("WebSocket not open");
-    expect(runtime.pendingApprovalResolvers.size).toBe(0);
-  });
-
-  test("rejects immediately when interrupt is already active", async () => {
-    const runtime = __listenClientTestUtils.createRuntime();
-    const socket = new MockSocket(WebSocket.OPEN);
-    const requestId = "perm-cancelled";
-
-    runtime.cancelRequested = true;
-
-    await expect(
-      requestApprovalOverWS(
-        runtime,
-        socket as unknown as WebSocket,
-        requestId,
-        makeControlRequest(requestId),
-      ),
-    ).rejects.toThrow("Cancelled by user");
-    expect(runtime.pendingApprovalResolvers.size).toBe(0);
-    expect(runtime.listener.approvalRuntimeKeyByRequestId.size).toBe(0);
-  });
-
-  test("registers a pending resolver until an approval response arrives", async () => {
-    const runtime = __listenClientTestUtils.createRuntime();
-    const socket = new MockSocket(WebSocket.OPEN);
-    const requestId = "perm-send-fail";
-
-    const pending = requestApprovalOverWS(
-      runtime,
-      socket as unknown as WebSocket,
-      requestId,
-      makeControlRequest(requestId),
-    );
-
-    expect(runtime.pendingApprovalResolvers.size).toBe(1);
-    expect(
-      runtime.pendingApprovalResolvers.get(requestId)?.controlRequest,
-    ).toEqual(makeControlRequest(requestId));
-
-    rejectPendingApprovalResolvers(runtime, "cleanup");
-    await expect(pending).rejects.toThrow("cleanup");
-    expect(runtime.pendingApprovalResolvers.size).toBe(0);
-  });
-
-  test("cleans up a pending resolver if abort lands immediately after registration", async () => {
-    const runtime = __listenClientTestUtils.createRuntime();
-    const socket = new MockSocket(WebSocket.OPEN);
-    const requestId = "perm-late-abort";
-
-    runtime.activeAbortController = new AbortController();
-
-    const pending = requestApprovalOverWS(
-      runtime,
-      socket as unknown as WebSocket,
-      requestId,
-      makeControlRequest(requestId),
-    );
-
-    expect(runtime.pendingApprovalResolvers.size).toBe(1);
-
-    runtime.cancelRequested = true;
-    runtime.activeAbortController.abort();
-
-    await expect(pending).rejects.toThrow("Cancelled by user");
-    expect(runtime.pendingApprovalResolvers.size).toBe(0);
-    expect(runtime.listener.approvalRuntimeKeyByRequestId.size).toBe(0);
   });
 });
 
@@ -4316,7 +4119,7 @@ describe("listen-client v2 status builders", () => {
       "conv-b",
     );
 
-    runtimeA.isProcessing = true;
+    beginTestTurn(runtimeA);
 
     expect(__listenClientTestUtils.resolveRuntimeScope(listener)).toBeNull();
   });
@@ -4757,8 +4560,7 @@ describe("listen-client v2 status builders", () => {
 
   test("sync ignores backend recovered approvals while a live turn is already processing", async () => {
     const runtime = __listenClientTestUtils.createRuntime();
-    runtime.isProcessing = true;
-    runtime.loopStatus = "PROCESSING_API_RESPONSE";
+    beginTestTurn(runtime, { initialStatus: "PROCESSING_API_RESPONSE" });
     runtime.activeAgentId = "agent-1";
     runtime.activeConversationId = "default";
     runtime.recoveredApprovalState = {
@@ -4866,9 +4668,8 @@ describe("listen-client v2 status builders", () => {
       "conv-b",
     );
 
-    runtimeA.isProcessing = true;
-    runtimeA.loopStatus = "PROCESSING_API_RESPONSE";
-    runtimeB.loopStatus = "WAITING_ON_APPROVAL";
+    beginTestTurn(runtimeA, { initialStatus: "PROCESSING_API_RESPONSE" });
+    beginTestTurn(runtimeB, { initialStatus: "WAITING_ON_APPROVAL" });
 
     expect(
       __listenClientTestUtils.buildLoopStatus(listener, {
@@ -4894,8 +4695,7 @@ describe("listen-client v2 status builders", () => {
       "conv-b",
     );
 
-    runtimeA.isProcessing = true;
-    runtimeA.loopStatus = "PROCESSING_API_RESPONSE";
+    beginTestTurn(runtimeA, { initialStatus: "PROCESSING_API_RESPONSE" });
     const queueInput = {
       kind: "message",
       source: "user",
@@ -4942,7 +4742,7 @@ describe("listen-client cwd change handling", () => {
       );
       runtime.activeAgentId = "agent-1";
       runtime.activeConversationId = "conv-1";
-      runtime.activeWorkingDirectory = normalizedServerDir;
+      beginTestTurn(runtime, { workingDirectory: normalizedServerDir });
 
       await __listenClientTestUtils.handleCwdChange(
         {
@@ -5157,6 +4957,7 @@ describe("listen-client capability-gated approval flow", () => {
     const runtime = __listenClientTestUtils.createRuntime();
     const socket = new MockSocket(WebSocket.OPEN);
     const requestId = "perm-update-test";
+    beginTestTurn(runtime);
 
     const pending = requestApprovalOverWS(
       runtime,
@@ -5197,6 +4998,7 @@ describe("listen-client capability-gated approval flow", () => {
     const runtime = __listenClientTestUtils.createRuntime();
     const socket = new MockSocket(WebSocket.OPEN);
     const requestId = "perm-allow-comment-test";
+    beginTestTurn(runtime);
 
     const pending = requestApprovalOverWS(
       runtime,
@@ -5229,6 +5031,7 @@ describe("listen-client capability-gated approval flow", () => {
     const runtime = __listenClientTestUtils.createRuntime();
     const socket = new MockSocket(WebSocket.OPEN);
     const requestId = "perm-deny-test";
+    beginTestTurn(runtime);
 
     const pending = requestApprovalOverWS(
       runtime,
@@ -5258,6 +5061,7 @@ describe("listen-client capability-gated approval flow", () => {
     const runtime = __listenClientTestUtils.createRuntime();
     const socket = new MockSocket(WebSocket.OPEN);
     const requestId = "perm-error-test";
+    beginTestTurn(runtime);
 
     const pending = requestApprovalOverWS(
       runtime,
@@ -5288,6 +5092,7 @@ describe("listen-client capability-gated approval flow", () => {
     const socket = new MockSocket(WebSocket.OPEN);
     listener.socket = socket as unknown as WebSocket;
     const requestId = "perm-adapter-test";
+    beginTestTurn(runtime);
 
     void requestApprovalOverWS(
       runtime,
@@ -5345,8 +5150,7 @@ describe("listen-client capability-gated approval flow", () => {
     );
     const socket = new MockSocket(WebSocket.OPEN);
 
-    runtime.isProcessing = true;
-    runtime.activeRunId = "run-1";
+    beginTestTurn(runtime, { runId: "run-1" });
     void requestApprovalOverWS(
       runtime,
       socket as unknown as WebSocket,
@@ -5433,7 +5237,7 @@ describe("listen-client capability-gated approval flow", () => {
     );
   });
 
-  test("stale approval responses unlatch cancelRequested after approval-only interrupt", async () => {
+  test("stale approval responses cannot unlatch an active cancellation", async () => {
     const listener = __listenClientTestUtils.createListenerRuntime();
     const targetRuntime =
       __listenClientTestUtils.getOrCreateConversationRuntime(
@@ -5445,8 +5249,8 @@ describe("listen-client capability-gated approval flow", () => {
     const scheduleQueuePumpMock = mock(() => {});
     const resolveRecoveredApprovalResponseMock = mock(async () => false);
 
-    targetRuntime.cancelRequested = true;
-    targetRuntime.isProcessing = false;
+    beginTestTurn(targetRuntime);
+    targetRuntime.turnLifecycle.requestCancellation();
 
     const handled = await __listenClientTestUtils.handleApprovalResponseInput(
       listener,
@@ -5473,14 +5277,9 @@ describe("listen-client capability-gated approval flow", () => {
     );
 
     expect(handled).toBe(false);
-    expect(targetRuntime.cancelRequested).toBe(false);
+    expect(targetRuntime.cancelRequested).toBe(true);
     expect(resolveRecoveredApprovalResponseMock).not.toHaveBeenCalled();
-    expect(scheduleQueuePumpMock).toHaveBeenCalledWith(
-      targetRuntime,
-      socket,
-      expect.objectContaining({ connectionId: "conn-1" }),
-      expect.any(Function),
-    );
+    expect(scheduleQueuePumpMock).not.toHaveBeenCalled();
   });
 
   test("abort_message eagerly projects idle interrupted state for active turns", async () => {
@@ -5497,13 +5296,12 @@ describe("listen-client capability-gated approval flow", () => {
     const scheduleQueuePumpMock = mock(() => {});
     const cancelConversationMock = mock(async () => {});
 
-    runtime.isProcessing = true;
-    runtime.loopStatus = "PROCESSING_API_RESPONSE";
-    runtime.activeAbortController = new AbortController();
-    runtime.activeRunId = "run-active";
-    runtime.activeRunStartedAt = new Date().toISOString();
-    runtime.activeWorkingDirectory = process.cwd();
-    runtime.activeExecutingToolCallIds = ["tool-1"];
+    beginTestTurn(runtime, {
+      initialStatus: "PROCESSING_API_RESPONSE",
+      runId: "run-active",
+      workingDirectory: process.cwd(),
+      executingToolCallIds: ["tool-1"],
+    });
 
     const handled = await __listenClientTestUtils.handleAbortMessageInput(
       listener,
@@ -5530,7 +5328,7 @@ describe("listen-client capability-gated approval flow", () => {
     expect(runtime.isProcessing).toBe(false);
     expect(runtime.loopStatus as string).toBe("WAITING_ON_INPUT");
     expect(runtime.activeRunId).toBeNull();
-    expect(runtime.activeAbortController).toBeNull();
+    expect(runtime.turnLifecycle.currentLease?.signal.aborted).toBe(true);
     expect(runtime.pendingInterruptedToolCallIds).toEqual(["tool-1"]);
     expect(scheduleQueuePumpMock).toHaveBeenCalledWith(
       runtime,
@@ -5577,10 +5375,10 @@ describe("listen-client capability-gated approval flow", () => {
       "default",
     );
 
-    runtime.isProcessing = true;
-    runtime.loopStatus = "PROCESSING_API_RESPONSE";
-    runtime.activeAbortController = new AbortController();
-    runtime.activeRunId = "run-active";
+    beginTestTurn(runtime, {
+      initialStatus: "PROCESSING_API_RESPONSE",
+      runId: "run-active",
+    });
 
     const handled = await __listenClientTestUtils.handleAbortMessageInput(
       listener,
@@ -5629,7 +5427,6 @@ describe("listen-client capability-gated approval flow", () => {
     const scheduleQueuePumpMock = mock(() => {});
     const cancelConversationMock = mock(async () => {});
 
-    runtime.loopStatus = "WAITING_ON_APPROVAL";
     runtime.recoveredApprovalState = {
       agentId: "agent-1",
       conversationId: "default",
@@ -5715,7 +5512,9 @@ describe("listen-client capability-gated approval flow", () => {
     const scheduleQueuePumpMock = mock(() => {});
     const cancelConversationMock = mock(async () => {});
 
-    runtime.loopStatus = "WAITING_ON_APPROVAL";
+    const turnLease = beginTestTurn(runtime, {
+      initialStatus: "WAITING_ON_APPROVAL",
+    });
     const pending = requestApprovalOverWS(
       runtime,
       socket as unknown as WebSocket,
@@ -5744,9 +5543,18 @@ describe("listen-client capability-gated approval flow", () => {
     );
 
     expect(handled).toBe(true);
-    expect(runtime.cancelRequested).toBe(false);
+    expect(runtime.cancelRequested).toBe(true);
     await expect(pending).rejects.toThrow("Cancelled by user");
     expect(runtime.pendingApprovalResolvers.size).toBe(0);
+    __listenClientTestUtils.populateInterruptQueue(runtime, {
+      lastExecutionResults: null,
+      lastExecutingToolCallIds: [],
+      lastNeedsUserInputToolCallIds: ["call-1"],
+      agentId: "agent-1",
+      conversationId: "default",
+    });
+    runtime.turnLifecycle.finish(turnLease, "cancelled");
+    expect(runtime.cancelRequested).toBe(false);
     expect(runtime.pendingInterruptedResults).toEqual([
       {
         type: "approval",
@@ -6338,31 +6146,14 @@ describe("listen-client post-stop approval recovery policy", () => {
   });
 });
 
-describe("listen-client approval continuation recovery disposition", () => {
-  test("retries the original continuation when recovery handled nothing", () => {
-    expect(
-      __listenClientTestUtils.getApprovalContinuationRecoveryDisposition(null),
-    ).toBe("retry");
-  });
-
-  test("treats drained recovery turns as handled", () => {
-    expect(
-      __listenClientTestUtils.getApprovalContinuationRecoveryDisposition({
-        stopReason: "end_turn",
-        lastRunId: "run-1",
-        apiDurationMs: 0,
-      }),
-    ).toBe("handled");
-  });
-});
-
 describe("listen-client approval continuation run handoff", () => {
   test("clears stale active run ids once an approval continuation is accepted", () => {
     const runtime = __listenClientTestUtils.createRuntime();
-    runtime.activeRunId = "run-1";
+    const turnLease = beginTestTurn(runtime, { runId: "run-1" });
 
     __listenClientTestUtils.markAwaitingAcceptedApprovalContinuationRunId(
       runtime,
+      turnLease,
       [{ type: "approval", approvals: [] }],
     );
 
@@ -6371,10 +6162,11 @@ describe("listen-client approval continuation run handoff", () => {
 
   test("preserves active run ids for non-approval sends", () => {
     const runtime = __listenClientTestUtils.createRuntime();
-    runtime.activeRunId = "run-1";
+    const turnLease = beginTestTurn(runtime, { runId: "run-1" });
 
     __listenClientTestUtils.markAwaitingAcceptedApprovalContinuationRunId(
       runtime,
+      turnLease,
       [
         {
           role: "user",
@@ -6390,7 +6182,8 @@ describe("listen-client approval continuation run handoff", () => {
 describe("listen-client interrupt persistence normalization", () => {
   test("forces interrupted in-flight tool results to status=error when cancelRequested", () => {
     const runtime = __listenClientTestUtils.createRuntime();
-    runtime.cancelRequested = true;
+    beginTestTurn(runtime);
+    runtime.turnLifecycle.requestCancellation();
 
     const normalized =
       __listenClientTestUtils.normalizeExecutionResultsForInterruptParity(
@@ -6418,7 +6211,6 @@ describe("listen-client interrupt persistence normalization", () => {
 
   test("leaves tool status unchanged when not in cancel flow", () => {
     const runtime = __listenClientTestUtils.createRuntime();
-    runtime.cancelRequested = false;
 
     const normalized =
       __listenClientTestUtils.normalizeExecutionResultsForInterruptParity(

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -180,6 +180,21 @@ function makeControlRequest(requestId: string): ControlRequest {
   };
 }
 
+function requestTestApproval(
+  runtime: ConversationRuntime,
+  socket: MockSocket,
+  turnLease: ReturnType<typeof beginTestTurn>,
+  requestId: string,
+) {
+  return requestApprovalOverWS(
+    runtime,
+    socket as unknown as WebSocket,
+    turnLease,
+    requestId,
+    makeControlRequest(requestId),
+  );
+}
+
 describe("listen-client parseServerMessage", () => {
   test("parses valid input approval_response command", () => {
     const parsed = parseServerMessage(
@@ -4957,14 +4972,9 @@ describe("listen-client capability-gated approval flow", () => {
     const runtime = __listenClientTestUtils.createRuntime();
     const socket = new MockSocket(WebSocket.OPEN);
     const requestId = "perm-update-test";
-    beginTestTurn(runtime);
+    const turnLease = beginTestTurn(runtime);
 
-    const pending = requestApprovalOverWS(
-      runtime,
-      socket as unknown as WebSocket,
-      requestId,
-      makeControlRequest(requestId),
-    );
+    const pending = requestTestApproval(runtime, socket, turnLease, requestId);
 
     // Simulate approval_response with updated_input
     resolvePendingApprovalResolver(runtime, {
@@ -4998,14 +5008,9 @@ describe("listen-client capability-gated approval flow", () => {
     const runtime = __listenClientTestUtils.createRuntime();
     const socket = new MockSocket(WebSocket.OPEN);
     const requestId = "perm-allow-comment-test";
-    beginTestTurn(runtime);
+    const turnLease = beginTestTurn(runtime);
 
-    const pending = requestApprovalOverWS(
-      runtime,
-      socket as unknown as WebSocket,
-      requestId,
-      makeControlRequest(requestId),
-    );
+    const pending = requestTestApproval(runtime, socket, turnLease, requestId);
 
     resolvePendingApprovalResolver(runtime, {
       request_id: requestId,
@@ -5031,14 +5036,9 @@ describe("listen-client capability-gated approval flow", () => {
     const runtime = __listenClientTestUtils.createRuntime();
     const socket = new MockSocket(WebSocket.OPEN);
     const requestId = "perm-deny-test";
-    beginTestTurn(runtime);
+    const turnLease = beginTestTurn(runtime);
 
-    const pending = requestApprovalOverWS(
-      runtime,
-      socket as unknown as WebSocket,
-      requestId,
-      makeControlRequest(requestId),
-    );
+    const pending = requestTestApproval(runtime, socket, turnLease, requestId);
 
     resolvePendingApprovalResolver(runtime, {
       request_id: requestId,
@@ -5061,14 +5061,9 @@ describe("listen-client capability-gated approval flow", () => {
     const runtime = __listenClientTestUtils.createRuntime();
     const socket = new MockSocket(WebSocket.OPEN);
     const requestId = "perm-error-test";
-    beginTestTurn(runtime);
+    const turnLease = beginTestTurn(runtime);
 
-    const pending = requestApprovalOverWS(
-      runtime,
-      socket as unknown as WebSocket,
-      requestId,
-      makeControlRequest(requestId),
-    );
+    const pending = requestTestApproval(runtime, socket, turnLease, requestId);
 
     resolvePendingApprovalResolver(runtime, {
       request_id: requestId,
@@ -5092,14 +5087,11 @@ describe("listen-client capability-gated approval flow", () => {
     const socket = new MockSocket(WebSocket.OPEN);
     listener.socket = socket as unknown as WebSocket;
     const requestId = "perm-adapter-test";
-    beginTestTurn(runtime);
+    const turnLease = beginTestTurn(runtime);
 
-    void requestApprovalOverWS(
-      runtime,
-      socket as unknown as WebSocket,
-      requestId,
-      makeControlRequest(requestId),
-    ).catch(() => {});
+    void requestTestApproval(runtime, socket, turnLease, requestId).catch(
+      () => {},
+    );
 
     expect(socket.sentPayloads.length).toBeGreaterThanOrEqual(2);
     const outbound = socket.sentPayloads.map((payload) =>
@@ -5150,12 +5142,12 @@ describe("listen-client capability-gated approval flow", () => {
     );
     const socket = new MockSocket(WebSocket.OPEN);
 
-    beginTestTurn(runtime, { runId: "run-1" });
-    void requestApprovalOverWS(
+    const turnLease = beginTestTurn(runtime, { runId: "run-1" });
+    void requestTestApproval(
       runtime,
-      socket as unknown as WebSocket,
+      socket,
+      turnLease,
       "perm-interrupted",
-      makeControlRequest("perm-interrupted"),
     ).catch(() => {});
     runtime.pendingInterruptedContext = {
       agentId: "agent-1",
@@ -5375,7 +5367,7 @@ describe("listen-client capability-gated approval flow", () => {
       "default",
     );
 
-    beginTestTurn(runtime, {
+    const turnLease = beginTestTurn(runtime, {
       initialStatus: "PROCESSING_API_RESPONSE",
       runId: "run-active",
     });
@@ -5400,12 +5392,7 @@ describe("listen-client capability-gated approval flow", () => {
     expect(runtime.cancelRequested).toBe(true);
 
     await expect(
-      requestApprovalOverWS(
-        runtime,
-        socket as unknown as WebSocket,
-        "perm-late-after-abort",
-        makeControlRequest("perm-late-after-abort"),
-      ),
+      requestTestApproval(runtime, socket, turnLease, "perm-late-after-abort"),
     ).rejects.toThrow("Cancelled by user");
     expect(runtime.pendingApprovalResolvers.size).toBe(0);
     expect(runtime.listener.approvalRuntimeKeyByRequestId.size).toBe(0);
@@ -5515,11 +5502,11 @@ describe("listen-client capability-gated approval flow", () => {
     const turnLease = beginTestTurn(runtime, {
       initialStatus: "WAITING_ON_APPROVAL",
     });
-    const pending = requestApprovalOverWS(
+    const pending = requestTestApproval(
       runtime,
-      socket as unknown as WebSocket,
+      socket,
+      turnLease,
       "perm-live",
-      makeControlRequest("perm-live"),
     );
 
     const handled = await __listenClientTestUtils.handleAbortMessageInput(

--- a/src/websocket/listen-interrupt-queue.test.ts
+++ b/src/websocket/listen-interrupt-queue.test.ts
@@ -66,7 +66,7 @@ describe("ListenerRuntime interrupt queue fields", () => {
     expect(runtime.pendingInterruptedResults).toBeNull();
     expect(runtime.pendingInterruptedContext).toBeNull();
     expect(runtime.pendingInterruptedToolCallIds).toBeNull();
-    expect(runtime.activeExecutingToolCallIds).toEqual([]);
+    expect(runtime.turnLifecycle.kind).toBe("idle");
     expect(runtime.continuationEpoch).toBe(0);
   });
 });
@@ -90,7 +90,11 @@ describe("stopRuntime teardown", () => {
       continuationEpoch: 0,
     };
     runtime.pendingInterruptedToolCallIds = ["call-1"];
-    runtime.activeExecutingToolCallIds = ["call-1"];
+    runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: "/tmp/worktree",
+      executingToolCallIds: ["call-1"],
+    });
     runtime.pendingApprovalBatchByToolCallId.set("call-1", "batch-1");
 
     stopRuntime(runtime, true);
@@ -98,7 +102,7 @@ describe("stopRuntime teardown", () => {
     expect(runtime.pendingInterruptedResults).toBeNull();
     expect(runtime.pendingInterruptedContext).toBeNull();
     expect(runtime.pendingInterruptedToolCallIds).toBeNull();
-    expect(runtime.activeExecutingToolCallIds).toEqual([]);
+    expect(runtime.turnLifecycle.kind).toBe("idle");
     expect(runtime.pendingApprovalBatchByToolCallId.size).toBe(0);
   });
 
@@ -892,17 +896,12 @@ describe("cancel-induced stop reason reclassification", () => {
 
   test("runtime.lastStopReason tracks the effective value after cancel populate", () => {
     const runtime = createRuntime();
-    runtime.cancelRequested = true;
-
-    // After cancel, the production code sets:
-    //   runtime.lastStopReason = effectiveStopReason
-    // where effectiveStopReason = cancelRequested ? "cancelled" : rawStop
-    const rawFromBackend = "error";
-    const effective = computeEffectiveStopReason(
-      runtime.cancelRequested,
-      rawFromBackend,
-    );
-    runtime.lastStopReason = effective;
+    const lease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: "/tmp/worktree",
+    });
+    runtime.turnLifecycle.requestCancellation();
+    runtime.turnLifecycle.finish(lease, "cancelled");
 
     expect(runtime.lastStopReason).toBe("cancelled");
   });

--- a/src/websocket/listen-recovery.test.ts
+++ b/src/websocket/listen-recovery.test.ts
@@ -6,7 +6,6 @@
  * 2. Warm recovery: existing batch map entries → resolved to single batch ID.
  * 3. Ambiguous mapping: conflicting batch IDs → fail-closed (null).
  * 4. Idempotency: repeated resolve calls with same state → same behavior.
- * 5. isRecoveringApprovals guard prevents concurrent recovery.
  */
 import { afterEach, describe, expect, test } from "bun:test";
 import {
@@ -188,27 +187,6 @@ describe("resolveRecoveryBatchId warm path", () => {
     ]);
 
     expect(batchId).toBeNull();
-  });
-});
-
-describe("isRecoveringApprovals guard", () => {
-  test("runtime starts with isRecoveringApprovals = false", () => {
-    const runtime = createRuntime();
-    expect(runtime.isRecoveringApprovals).toBe(false);
-  });
-
-  test("guard flag prevents concurrent recovery (production pattern)", () => {
-    const runtime = createRuntime();
-
-    // Simulate first recovery in progress
-    runtime.isRecoveringApprovals = true;
-
-    // Second recovery attempt should observe guard and bail
-    expect(runtime.isRecoveringApprovals).toBe(true);
-
-    // Simulate completion
-    runtime.isRecoveringApprovals = false;
-    expect(runtime.isRecoveringApprovals).toBe(false);
   });
 });
 

--- a/src/websocket/listen-reflection-runtime.test.ts
+++ b/src/websocket/listen-reflection-runtime.test.ts
@@ -33,7 +33,6 @@ describe("listen reflection runtime state", () => {
     expect(runtime.reminderState).toBe(persistedReminderState);
     expect(runtime.contextTracker).toBe(persistedContextTracker);
 
-    runtime.isProcessing = false;
     runtime.pendingTurns = 0;
     runtime.queuePumpActive = false;
     runtime.queuePumpScheduled = false;
@@ -41,11 +40,6 @@ describe("listen reflection runtime state", () => {
     runtime.pendingInterruptedResults = null;
     runtime.pendingInterruptedContext = null;
     runtime.pendingInterruptedToolCallIds = null;
-    runtime.activeExecutingToolCallIds = [];
-    runtime.activeRunId = null;
-    runtime.activeRunStartedAt = null;
-    runtime.activeAbortController = null;
-    runtime.cancelRequested = false;
     runtime.queuedMessagesByItemId.clear();
 
     expect(evictConversationRuntimeIfIdle(runtime)).toBe(true);

--- a/src/websocket/listener-queue-adapter.test.ts
+++ b/src/websocket/listener-queue-adapter.test.ts
@@ -1,63 +1,57 @@
 import { describe, expect, test } from "bun:test";
 import { getListenerBlockedReason } from "@/websocket/helpers/listener-queue-adapter";
+import { TurnLifecycle } from "@/websocket/listener/turn-lifecycle";
 
-const allClear = {
-  loopStatus: "WAITING_ON_INPUT",
-  isProcessing: false,
-  pendingApprovalsLen: 0,
-  cancelRequested: false,
-  isRecoveringApprovals: false,
-} as const;
+function createLifecycle(): TurnLifecycle {
+  return new TurnLifecycle(() => "lease-1");
+}
 
 describe("getListenerBlockedReason", () => {
-  test("returns null when unblocked", () => {
-    expect(getListenerBlockedReason(allClear)).toBeNull();
+  test("returns null when idle", () => {
+    const lifecycle = createLifecycle();
+    expect(getListenerBlockedReason(lifecycle.snapshot(), 0)).toBeNull();
   });
 
-  test("prioritizes pending approvals", () => {
-    expect(
-      getListenerBlockedReason({ ...allClear, pendingApprovalsLen: 2 }),
-    ).toBe("pending_approvals");
+  test("maps pending approvals while otherwise idle", () => {
+    const lifecycle = createLifecycle();
+    expect(getListenerBlockedReason(lifecycle.snapshot(), 2)).toBe(
+      "pending_approvals",
+    );
   });
 
-  test("prioritizes interrupt over approval and streaming phases", () => {
-    expect(
-      getListenerBlockedReason({
-        ...allClear,
-        cancelRequested: true,
-        pendingApprovalsLen: 2,
-        loopStatus: "PROCESSING_API_RESPONSE",
-        isProcessing: true,
-      }),
-    ).toBe("interrupt_in_progress");
-  });
+  test("prioritizes cancellation over pending approvals", () => {
+    const lifecycle = createLifecycle();
+    lifecycle.begin({
+      origin: "message",
+      workingDirectory: "/tmp/worktree",
+    });
+    lifecycle.requestCancellation();
 
-  test("maps recoveries to runtime busy", () => {
-    expect(
-      getListenerBlockedReason({
-        ...allClear,
-        isRecoveringApprovals: true,
-        loopStatus: "EXECUTING_COMMAND",
-      }),
-    ).toBe("runtime_busy");
+    expect(getListenerBlockedReason(lifecycle.snapshot(), 2)).toBe(
+      "interrupt_in_progress",
+    );
   });
 
   test("maps waiting-on-approval phase to pending approvals", () => {
-    expect(
-      getListenerBlockedReason({
-        ...allClear,
-        loopStatus: "WAITING_ON_APPROVAL",
-      }),
-    ).toBe("pending_approvals");
+    const lifecycle = createLifecycle();
+    const lease = lifecycle.begin({
+      origin: "message",
+      workingDirectory: "/tmp/worktree",
+    });
+    lifecycle.setStatus(lease, "WAITING_ON_APPROVAL");
+
+    expect(getListenerBlockedReason(lifecycle.snapshot(), 0)).toBe(
+      "pending_approvals",
+    );
   });
 
   test("maps command execution to command_running", () => {
-    expect(
-      getListenerBlockedReason({
-        ...allClear,
-        loopStatus: "EXECUTING_COMMAND",
-      }),
-    ).toBe("command_running");
+    const lifecycle = createLifecycle();
+    lifecycle.startCommand();
+
+    expect(getListenerBlockedReason(lifecycle.snapshot(), 0)).toBe(
+      "command_running",
+    );
   });
 
   test.each([
@@ -66,21 +60,14 @@ describe("getListenerBlockedReason", () => {
     "WAITING_FOR_API_RESPONSE",
     "PROCESSING_API_RESPONSE",
     "EXECUTING_CLIENT_SIDE_TOOL",
-  ] as const)("maps %s to streaming", (loopStatus) => {
-    expect(
-      getListenerBlockedReason({
-        ...allClear,
-        loopStatus,
-      }),
-    ).toBe("streaming");
-  });
+  ] as const)("maps active %s to streaming", (loopStatus) => {
+    const lifecycle = createLifecycle();
+    lifecycle.begin({
+      origin: "message",
+      workingDirectory: "/tmp/worktree",
+      initialStatus: loopStatus,
+    });
 
-  test("falls back to runtime busy when processing without a specific phase", () => {
-    expect(
-      getListenerBlockedReason({
-        ...allClear,
-        isProcessing: true,
-      }),
-    ).toBe("runtime_busy");
+    expect(getListenerBlockedReason(lifecycle.snapshot(), 0)).toBe("streaming");
   });
 });

--- a/src/websocket/listener-turn-telemetry.test.ts
+++ b/src/websocket/listener-turn-telemetry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import { telemetry } from "@/telemetry";
-import { __listenerTurnTestUtils } from "@/websocket/listener/turn";
+import { __listenerTurnTestUtils } from "@/websocket/listener/turn-transcript";
 
 describe("listener turn telemetry", () => {
   test("tracks only user messages with text content", () => {

--- a/src/websocket/listener/AGENTS.md
+++ b/src/websocket/listener/AGENTS.md
@@ -1,0 +1,111 @@
+# Listener State Machine Guide
+
+This directory owns local listener orchestration. Read this file before changing
+turns, approvals, cancellation, recovery, queue gating, or status projection.
+
+## Canonical Ownership
+
+`TurnLifecycle` in `turn-lifecycle.ts` is the only owner of active-turn state.
+`ConversationRuntime` exposes read-only projections for compatibility:
+
+- `isProcessing`
+- `cancelRequested`
+- `loopStatus`
+- `activeWorkingDirectory`
+- `activeRunId`
+- `lastStopReason`
+
+Never add setters or parallel flags for these values. Add a lifecycle transition
+when a new state is genuinely required.
+
+The lifecycle states are complete and mutually exclusive:
+
+- `idle`: no local owner; queue work may start.
+- `command`: a synchronous command owns the conversation.
+- `active`: a message or approval-recovery turn owns the conversation.
+- `cancelling`: the active lease was aborted; UI projects idle, but the queue
+  remains blocked until that lease settles.
+
+## Lease Rule
+
+Every active turn has a `TurnLease`. Async state changes must carry that lease.
+Lifecycle methods ignore stale leases, so a completion from a reset/old turn
+cannot mutate a replacement turn.
+
+`clearConversationRuntimeState()` is an authoritative local reset. It aborts and
+invalidates the current lease, returns the lifecycle to `idle`, and clears
+conversation-scoped transient state. Code unwinding after reset must treat its
+lease as stale and must not repopulate state.
+
+Explicit `abort_message` is different: it calls `requestCancellation()`, which
+moves `active -> cancelling`. The turn owner later completes
+`cancelling -> idle`. Do not clear cancellation because a late approval response
+arrived.
+
+## Terminal Rule
+
+The enclosing turn owner finalizes every lease exactly once through
+`finishListenerTurn()`. Terminal helpers may prepare an outcome, but they must
+not silently finalize shared runtime state.
+
+Use discriminated results:
+
+- Approval branch: `continue | interrupted | terminal | error`
+- Approval send: `stream | terminal`
+
+Do not reintroduce `terminated: boolean`, sentinel `null`, or a result whose
+caller must guess whether another layer already finalized the turn.
+
+`requires_approval` is a continuation boundary, not a terminal turn. A pending
+approval remains inside the same active lease.
+
+## Queue And Status
+
+Queue gating consumes `turnLifecycle.snapshot()`. It must not reconstruct
+activity from a boolean chain. Protocol device/loop status reads the read-only
+runtime projections derived from that same lifecycle.
+
+Do not add queue self-healing as the primary fix for an impossible state. Find
+and repair the transition that produced the state. Defensive telemetry is fine
+after the producer path has a regression test.
+
+## Module Map
+
+- `turn-lifecycle.ts`: canonical state, leases, and transitions.
+- `turn.ts`: one-turn orchestration and the stream stop-reason loop.
+- `turn-setup.ts`: input normalization, reminders, mod start, and tool context.
+- `turn-send.ts`: initial/retry send selection and recovered terminal results.
+- `turn-approval.ts`: live approval execution and continuation branching.
+- `turn-events.ts`: mod lifecycle events and reflection launch wiring.
+- `turn-completion.ts`: successful turn-end persistence and reflection work.
+- `turn-terminal.ts`: exact-once terminal projection.
+- `turn-status.ts`: loop-status transitions and emission.
+- `turn-cleanup.ts`: post-terminal persistence and memory sync.
+- `turn-transcript.ts`: pure inbound transcript/telemetry helpers.
+- `recovery.ts`: stale and process-restart approval recovery.
+- `queue.ts`: queue ingestion and lifecycle-snapshot gating.
+
+## Investigation Checklist
+
+When logs show contradictory state:
+
+1. Separate what logs prove from the proposed event sequence.
+2. Trace the owner that acquired the lease and every return/catch/finally that
+   can release it.
+3. Search every lifecycle transition and inspect `git blame` plus `git log -S`
+   when adjacent code assumes different contracts.
+4. Reproduce the production transition sequence. Do not begin a regression test
+   by manually constructing the impossible aftermath.
+5. Verify the test fails on the buggy base and passes because the producer was
+   fixed, without relying on queue self-healing.
+
+## Test Ownership
+
+- `turn-lifecycle.test.ts`: pure transition table, exact-once, stale leases.
+- `turn-lifecycle-integration.test.ts`: cross-module producer regressions.
+- `approval.test.ts`: approval wait/resolution/cancellation ownership.
+- `listener-queue-adapter.test.ts`: queue decisions from valid snapshots.
+- `channel-turn-session.test.ts`: channel progress lifecycle fan-out.
+
+Keep new tests next to their owner and below 1,000 lines. Do not grow the legacy
+protocol/concurrency test monoliths; move focused coverage here instead.

--- a/src/websocket/listener/AGENTS.md
+++ b/src/websocket/listener/AGENTS.md
@@ -28,9 +28,14 @@ The lifecycle states are complete and mutually exclusive:
 
 ## Lease Rule
 
-Every active turn has a `TurnLease`. Async state changes must carry that lease.
-Lifecycle methods ignore stale leases, so a completion from a reset/old turn
-cannot mutate a replacement turn.
+Every active turn has a `TurnLease`. Async state changes and side effects must
+carry that exact lease. Never look up `currentLease` after an await and assume
+it still belongs to the caller. Check `isCurrent(lease)` immediately after
+awaited execution boundaries, before mutating runtime state or emitting tool,
+protocol, file, or channel events. Capture run IDs and other turn-local context
+before the await; do not read them from a replacement runtime afterward. A
+current cancelling lease may emit normalized interrupt results. A stale lease
+must emit nothing.
 
 `clearConversationRuntimeState()` is an authoritative local reset. It aborts and
 invalidates the current lease, returns the lifecycle to `idle`, and clears
@@ -81,9 +86,12 @@ after the producer path has a regression test.
 - `turn-terminal.ts`: exact-once terminal projection.
 - `turn-status.ts`: loop-status transitions and emission.
 - `turn-cleanup.ts`: post-terminal persistence and memory sync.
+- `turn-context.ts`: guarded process-context ownership release.
 - `turn-transcript.ts`: pure inbound transcript/telemetry helpers.
 - `recovery.ts`: stale and process-restart approval recovery.
 - `queue.ts`: queue ingestion and lifecycle-snapshot gating.
+- `inbound-dispatch.ts`: serialized direct-message ownership handoff.
+- `inbound-queue.ts`: lossless inbound-message queue registration.
 
 ## Investigation Checklist
 
@@ -104,6 +112,8 @@ When logs show contradictory state:
 - `turn-lifecycle.test.ts`: pure transition table, exact-once, stale leases.
 - `turn-lifecycle-integration.test.ts`: cross-module producer regressions.
 - `approval.test.ts`: approval wait/resolution/cancellation ownership.
+- `recovery-lease.test.ts`: recovered approval await/lease boundaries.
+- `message-router.test.ts`: direct-message ownership handoff and queue drain.
 - `listener-queue-adapter.test.ts`: queue decisions from valid snapshots.
 - `channel-turn-session.test.ts`: channel progress lifecycle fan-out.
 

--- a/src/websocket/listener/AGENTS.md
+++ b/src/websocket/listener/AGENTS.md
@@ -113,6 +113,7 @@ When logs show contradictory state:
 - `turn-lifecycle-integration.test.ts`: cross-module producer regressions.
 - `approval.test.ts`: approval wait/resolution/cancellation ownership.
 - `recovery-lease.test.ts`: recovered approval await/lease boundaries.
+- `send-lease.test.ts`: pre-stream recovery await/queue boundaries.
 - `message-router.test.ts`: direct-message ownership handoff and queue drain.
 - `listener-queue-adapter.test.ts`: queue decisions from valid snapshots.
 - `channel-turn-session.test.ts`: channel progress lifecycle fan-out.

--- a/src/websocket/listener/approval.test.ts
+++ b/src/websocket/listener/approval.test.ts
@@ -49,8 +49,8 @@ function createScopedRuntime(
   return getOrCreateScopedRuntime(createRuntime(), agentId, conversationId);
 }
 
-function beginApprovalWait(runtime: ConversationRuntime): void {
-  runtime.turnLifecycle.begin({
+function beginApprovalWait(runtime: ConversationRuntime) {
+  return runtime.turnLifecycle.begin({
     origin: "message",
     workingDirectory: process.cwd(),
     initialStatus: "WAITING_ON_APPROVAL",
@@ -83,10 +83,11 @@ describe("listener approval lifecycle", () => {
   test("resolving an approval does not falsely finalize its enclosing turn", async () => {
     const runtime = createScopedRuntime();
     const socket = new MockSocket();
-    beginApprovalWait(runtime);
+    const turnLease = beginApprovalWait(runtime);
     const pending = requestApprovalOverWS(
       runtime,
       socket,
+      turnLease,
       "perm-status",
       makeControlRequest("perm-status"),
     );
@@ -107,18 +108,20 @@ describe("listener approval lifecycle", () => {
     const runtimeA = getOrCreateScopedRuntime(listener, "agent-1", "conv-a");
     const runtimeB = getOrCreateScopedRuntime(listener, "agent-1", "conv-b");
     const socket = new MockSocket();
-    beginApprovalWait(runtimeA);
-    beginApprovalWait(runtimeB);
+    const turnLeaseA = beginApprovalWait(runtimeA);
+    const turnLeaseB = beginApprovalWait(runtimeB);
 
     const pendingA = requestApprovalOverWS(
       runtimeA,
       socket,
+      turnLeaseA,
       "perm-a",
       makeControlRequest("perm-a"),
     );
     const pendingB = requestApprovalOverWS(
       runtimeB,
       socket,
+      turnLeaseB,
       "perm-b",
       makeControlRequest("perm-b"),
     );
@@ -148,10 +151,11 @@ describe("listener approval lifecycle", () => {
   test("a non-matching response leaves the pending resolver intact", async () => {
     const runtime = createScopedRuntime();
     const socket = new MockSocket();
-    beginApprovalWait(runtime);
+    const turnLease = beginApprovalWait(runtime);
     const pending = requestApprovalOverWS(
       runtime,
       socket,
+      turnLease,
       "perm-1",
       makeControlRequest("perm-1"),
     );
@@ -168,10 +172,11 @@ describe("listener approval lifecycle", () => {
   test("conversation cleanup rejects approvals and resets ownership atomically", async () => {
     const runtime = createScopedRuntime();
     const socket = new MockSocket();
-    beginApprovalWait(runtime);
+    const turnLease = beginApprovalWait(runtime);
     const pending = requestApprovalOverWS(
       runtime,
       socket,
+      turnLease,
       "perm-cleanup",
       makeControlRequest("perm-cleanup"),
     );
@@ -191,10 +196,11 @@ describe("listener approval lifecycle", () => {
     const runtime = getOrCreateScopedRuntime(listener, "agent-1", "default");
     const socket = new MockSocket();
     listener.socket = socket as unknown as WebSocket;
-    beginApprovalWait(runtime);
+    const turnLease = beginApprovalWait(runtime);
     const pending = requestApprovalOverWS(
       runtime,
       socket,
+      turnLease,
       "perm-stop",
       makeControlRequest("perm-stop"),
     );
@@ -208,35 +214,65 @@ describe("listener approval lifecycle", () => {
 
   test("approval registration rejects closed and cancelling turns", async () => {
     const closedRuntime = createScopedRuntime();
+    const closedTurnLease = beginApprovalWait(closedRuntime);
     await expect(
       requestApprovalOverWS(
         closedRuntime,
         new MockSocket(WebSocket.CLOSED),
+        closedTurnLease,
         "perm-closed",
         makeControlRequest("perm-closed"),
       ),
     ).rejects.toThrow("WebSocket not open");
 
     const cancellingRuntime = createScopedRuntime();
-    beginApprovalWait(cancellingRuntime);
+    const turnLease = beginApprovalWait(cancellingRuntime);
     cancellingRuntime.turnLifecycle.requestCancellation();
     await expect(
       requestApprovalOverWS(
         cancellingRuntime,
         new MockSocket(),
+        turnLease,
         "perm-cancelled",
         makeControlRequest("perm-cancelled"),
       ),
     ).rejects.toThrow("Cancelled by user");
   });
 
+  test("a stale approval request cannot register against a replacement turn", async () => {
+    const runtime = createScopedRuntime();
+    const socket = new MockSocket();
+    const staleTurnLease = beginApprovalWait(runtime);
+    clearConversationRuntimeState(runtime);
+    const replacementTurnLease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+    });
+
+    await expect(
+      requestApprovalOverWS(
+        runtime,
+        socket,
+        staleTurnLease,
+        "perm-stale",
+        makeControlRequest("perm-stale"),
+      ),
+    ).rejects.toThrow("Cancelled by user");
+
+    expect(runtime.turnLifecycle.isCurrent(replacementTurnLease)).toBe(true);
+    expect(runtime.loopStatus).toBe("SENDING_API_REQUEST");
+    expect(runtime.pendingApprovalResolvers.size).toBe(0);
+    expect(socket.sentPayloads).toEqual([]);
+  });
+
   test("an abort after registration removes and rejects the resolver", async () => {
     const runtime = createScopedRuntime();
     const socket = new MockSocket();
-    beginApprovalWait(runtime);
+    const turnLease = beginApprovalWait(runtime);
     const pending = requestApprovalOverWS(
       runtime,
       socket,
+      turnLease,
       "perm-abort",
       makeControlRequest("perm-abort"),
     );

--- a/src/websocket/listener/approval.test.ts
+++ b/src/websocket/listener/approval.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, test } from "bun:test";
+import WebSocket from "ws";
+import type { ApprovalResponseBody, ControlRequest } from "@/types/protocol_v2";
+import {
+  rejectPendingApprovalResolvers,
+  requestApprovalOverWS,
+  resolvePendingApprovalResolver,
+} from "./approval";
+import { getOrCreateScopedRuntime } from "./conversation-runtime";
+import { createRuntime, stopRuntime } from "./lifecycle";
+import { buildLoopStatus } from "./protocol-outbound";
+import { clearConversationRuntimeState } from "./runtime";
+import type { ConversationRuntime } from "./types";
+
+class MockSocket {
+  readonly kind = "local" as const;
+  readonly bufferedAmount = 0;
+  readyState: number;
+  closeCalls = 0;
+  removeAllListenersCalls = 0;
+  sentPayloads: string[] = [];
+
+  constructor(readyState: number = WebSocket.OPEN) {
+    this.readyState = readyState;
+  }
+
+  send(data: string): void {
+    this.sentPayloads.push(data);
+  }
+
+  isOpen(): boolean {
+    return this.readyState === WebSocket.OPEN;
+  }
+
+  close(): void {
+    this.closeCalls += 1;
+  }
+
+  removeAllListeners(): this {
+    this.removeAllListenersCalls += 1;
+    return this;
+  }
+}
+
+function createScopedRuntime(
+  agentId: string = "agent-1",
+  conversationId: string = "default",
+): ConversationRuntime {
+  return getOrCreateScopedRuntime(createRuntime(), agentId, conversationId);
+}
+
+function beginApprovalWait(runtime: ConversationRuntime): void {
+  runtime.turnLifecycle.begin({
+    origin: "message",
+    workingDirectory: process.cwd(),
+    initialStatus: "WAITING_ON_APPROVAL",
+  });
+}
+
+function makeControlRequest(requestId: string): ControlRequest {
+  return {
+    type: "control_request",
+    request_id: requestId,
+    request: {
+      subtype: "can_use_tool",
+      tool_name: "Bash",
+      input: {},
+      tool_call_id: requestId.replace("perm-", "call-"),
+      permission_suggestions: [],
+      blocked_path: null,
+    },
+  };
+}
+
+function makeSuccessResponse(requestId: string): ApprovalResponseBody {
+  return {
+    request_id: requestId,
+    decision: { behavior: "allow" },
+  };
+}
+
+describe("listener approval lifecycle", () => {
+  test("resolving an approval does not falsely finalize its enclosing turn", async () => {
+    const runtime = createScopedRuntime();
+    const socket = new MockSocket();
+    beginApprovalWait(runtime);
+    const pending = requestApprovalOverWS(
+      runtime,
+      socket,
+      "perm-status",
+      makeControlRequest("perm-status"),
+    );
+
+    expect(
+      resolvePendingApprovalResolver(
+        runtime,
+        makeSuccessResponse("perm-status"),
+      ),
+    ).toBe(true);
+    await expect(pending).resolves.toEqual(makeSuccessResponse("perm-status"));
+    expect(runtime.loopStatus).toBe("WAITING_ON_APPROVAL");
+    expect(runtime.isProcessing).toBe(true);
+  });
+
+  test("approval routing and state stay isolated by conversation", async () => {
+    const listener = createRuntime();
+    const runtimeA = getOrCreateScopedRuntime(listener, "agent-1", "conv-a");
+    const runtimeB = getOrCreateScopedRuntime(listener, "agent-1", "conv-b");
+    const socket = new MockSocket();
+    beginApprovalWait(runtimeA);
+    beginApprovalWait(runtimeB);
+
+    const pendingA = requestApprovalOverWS(
+      runtimeA,
+      socket,
+      "perm-a",
+      makeControlRequest("perm-a"),
+    );
+    const pendingB = requestApprovalOverWS(
+      runtimeB,
+      socket,
+      "perm-b",
+      makeControlRequest("perm-b"),
+    );
+
+    expect(listener.approvalRuntimeKeyByRequestId.get("perm-a")).toBe(
+      runtimeA.key,
+    );
+    expect(listener.approvalRuntimeKeyByRequestId.get("perm-b")).toBe(
+      runtimeB.key,
+    );
+    expect(
+      resolvePendingApprovalResolver(runtimeA, makeSuccessResponse("perm-a")),
+    ).toBe(true);
+    await expect(pendingA).resolves.toEqual(makeSuccessResponse("perm-a"));
+    expect(runtimeB.pendingApprovalResolvers.size).toBe(1);
+    expect(
+      buildLoopStatus(listener, {
+        agent_id: "agent-1",
+        conversation_id: "conv-b",
+      }).status,
+    ).toBe("WAITING_ON_APPROVAL");
+
+    resolvePendingApprovalResolver(runtimeB, makeSuccessResponse("perm-b"));
+    await expect(pendingB).resolves.toEqual(makeSuccessResponse("perm-b"));
+  });
+
+  test("a non-matching response leaves the pending resolver intact", async () => {
+    const runtime = createScopedRuntime();
+    const socket = new MockSocket();
+    beginApprovalWait(runtime);
+    const pending = requestApprovalOverWS(
+      runtime,
+      socket,
+      "perm-1",
+      makeControlRequest("perm-1"),
+    );
+
+    expect(
+      resolvePendingApprovalResolver(runtime, makeSuccessResponse("perm-2")),
+    ).toBe(false);
+    expect(runtime.pendingApprovalResolvers.size).toBe(1);
+
+    rejectPendingApprovalResolvers(runtime, "cleanup");
+    await expect(pending).rejects.toThrow("cleanup");
+  });
+
+  test("conversation cleanup rejects approvals and resets ownership atomically", async () => {
+    const runtime = createScopedRuntime();
+    const socket = new MockSocket();
+    beginApprovalWait(runtime);
+    const pending = requestApprovalOverWS(
+      runtime,
+      socket,
+      "perm-cleanup",
+      makeControlRequest("perm-cleanup"),
+    );
+
+    rejectPendingApprovalResolvers(runtime, "socket closed");
+    clearConversationRuntimeState(runtime);
+
+    await expect(pending).rejects.toThrow("socket closed");
+    expect(runtime.turnLifecycle.kind).toBe("idle");
+    expect(runtime.isProcessing).toBe(false);
+    expect(runtime.cancelRequested).toBe(false);
+    expect(runtime.loopStatus).toBe("WAITING_ON_INPUT");
+  });
+
+  test("stopRuntime rejects pending approvals when callbacks are suppressed", async () => {
+    const listener = createRuntime();
+    const runtime = getOrCreateScopedRuntime(listener, "agent-1", "default");
+    const socket = new MockSocket();
+    listener.socket = socket as unknown as WebSocket;
+    beginApprovalWait(runtime);
+    const pending = requestApprovalOverWS(
+      runtime,
+      socket,
+      "perm-stop",
+      makeControlRequest("perm-stop"),
+    );
+
+    stopRuntime(listener, true);
+
+    await expect(pending).rejects.toThrow("Listener runtime stopped");
+    expect(socket.removeAllListenersCalls).toBe(1);
+    expect(socket.closeCalls).toBe(1);
+  });
+
+  test("approval registration rejects closed and cancelling turns", async () => {
+    const closedRuntime = createScopedRuntime();
+    await expect(
+      requestApprovalOverWS(
+        closedRuntime,
+        new MockSocket(WebSocket.CLOSED),
+        "perm-closed",
+        makeControlRequest("perm-closed"),
+      ),
+    ).rejects.toThrow("WebSocket not open");
+
+    const cancellingRuntime = createScopedRuntime();
+    beginApprovalWait(cancellingRuntime);
+    cancellingRuntime.turnLifecycle.requestCancellation();
+    await expect(
+      requestApprovalOverWS(
+        cancellingRuntime,
+        new MockSocket(),
+        "perm-cancelled",
+        makeControlRequest("perm-cancelled"),
+      ),
+    ).rejects.toThrow("Cancelled by user");
+  });
+
+  test("an abort after registration removes and rejects the resolver", async () => {
+    const runtime = createScopedRuntime();
+    const socket = new MockSocket();
+    beginApprovalWait(runtime);
+    const pending = requestApprovalOverWS(
+      runtime,
+      socket,
+      "perm-abort",
+      makeControlRequest("perm-abort"),
+    );
+
+    expect(runtime.pendingApprovalResolvers.size).toBe(1);
+    runtime.turnLifecycle.requestCancellation();
+
+    await expect(pending).rejects.toThrow("Cancelled by user");
+    expect(runtime.pendingApprovalResolvers.size).toBe(0);
+    expect(runtime.listener.approvalRuntimeKeyByRequestId.size).toBe(0);
+  });
+});

--- a/src/websocket/listener/approval.ts
+++ b/src/websocket/listener/approval.ts
@@ -7,6 +7,7 @@ import {
 } from "./protocol-outbound";
 import { evictConversationRuntimeIfIdle } from "./runtime";
 import { isListenerTransportOpen, type ListenerTransport } from "./transport";
+import type { TurnLease } from "./turn-lifecycle";
 import { setCommandLoopStatus, setTurnLoopStatus } from "./turn-status";
 import type { ConversationRuntime } from "./types";
 
@@ -241,6 +242,7 @@ export function rejectPendingApprovalResolvers(
 export function requestApprovalOverWS(
   runtime: ConversationRuntime,
   socket: ListenerTransport,
+  turnLease: TurnLease,
   requestId: string,
   controlRequest: ControlRequest,
 ): Promise<ApprovalResponseBody> {
@@ -248,10 +250,6 @@ export function requestApprovalOverWS(
     return Promise.reject(new Error("WebSocket not open"));
   }
 
-  const turnLease = runtime.turnLifecycle.currentLease;
-  if (!turnLease) {
-    return Promise.reject(new Error("No active turn for approval request"));
-  }
   const abortSignal = turnLease.signal;
   const isInterrupted = () =>
     !runtime.turnLifecycle.isCurrent(turnLease) || abortSignal.aborted;

--- a/src/websocket/listener/approval.ts
+++ b/src/websocket/listener/approval.ts
@@ -4,10 +4,10 @@ import {
   emitDeviceStatusIfOpen,
   emitLoopStatusIfOpen,
   emitProtocolV2Message,
-  setLoopStatus,
 } from "./protocol-outbound";
 import { evictConversationRuntimeIfIdle } from "./runtime";
 import { isListenerTransportOpen, type ListenerTransport } from "./transport";
+import { setCommandLoopStatus, setTurnLoopStatus } from "./turn-status";
 import type { ConversationRuntime } from "./types";
 
 export function rememberPendingApprovalBatchIds(
@@ -195,7 +195,7 @@ export function resolvePendingApprovalResolver(
   runtime.pendingApprovalResolvers.delete(requestId);
   runtime.listener.approvalRuntimeKeyByRequestId.delete(requestId);
   if (runtime.pendingApprovalResolvers.size === 0 && !runtime.isProcessing) {
-    setLoopStatus(runtime, "WAITING_ON_INPUT");
+    setCommandLoopStatus(runtime, "WAITING_ON_INPUT");
   }
   pending.resolve(response);
   emitLoopStatusIfOpen(runtime.listener, {
@@ -224,7 +224,9 @@ export function rejectPendingApprovalResolvers(
       runtime.listener.approvalRuntimeKeyByRequestId.delete(requestId);
     }
   }
-  setLoopStatus(runtime, "WAITING_ON_INPUT");
+  if (!runtime.isProcessing && !runtime.cancelRequested) {
+    setCommandLoopStatus(runtime, "WAITING_ON_INPUT");
+  }
   emitLoopStatusIfOpen(runtime.listener, {
     agent_id: runtime.agentId,
     conversation_id: runtime.conversationId,
@@ -246,9 +248,13 @@ export function requestApprovalOverWS(
     return Promise.reject(new Error("WebSocket not open"));
   }
 
-  const abortSignal = runtime.activeAbortController?.signal ?? null;
+  const turnLease = runtime.turnLifecycle.currentLease;
+  if (!turnLease) {
+    return Promise.reject(new Error("No active turn for approval request"));
+  }
+  const abortSignal = turnLease.signal;
   const isInterrupted = () =>
-    runtime.cancelRequested || abortSignal?.aborted === true;
+    !runtime.turnLifecycle.isCurrent(turnLease) || abortSignal.aborted;
 
   if (isInterrupted()) {
     return Promise.reject(new Error("Cancelled by user"));
@@ -257,7 +263,7 @@ export function requestApprovalOverWS(
   return new Promise<ApprovalResponseBody>((resolve, reject) => {
     let settled = false;
     const cleanupAbortListener = () => {
-      abortSignal?.removeEventListener("abort", handleAbort);
+      abortSignal.removeEventListener("abort", handleAbort);
     };
     const wrappedResolve = (response: ApprovalResponseBody) => {
       if (settled) {
@@ -281,7 +287,7 @@ export function requestApprovalOverWS(
       wrappedReject(new Error("Cancelled by user"));
     };
 
-    abortSignal?.addEventListener("abort", handleAbort, { once: true });
+    abortSignal.addEventListener("abort", handleAbort, { once: true });
     if (isInterrupted()) {
       handleAbort();
       return;
@@ -297,8 +303,8 @@ export function requestApprovalOverWS(
       handleAbort();
       return;
     }
-    runtime.lastStopReason = "requires_approval";
-    setLoopStatus(runtime, "WAITING_ON_APPROVAL");
+    runtime.turnLifecycle.recordStopReason(turnLease, "requires_approval");
+    setTurnLoopStatus(runtime, turnLease, "WAITING_ON_APPROVAL");
     emitProtocolV2Message(socket, runtime, controlRequest, {
       agent_id: runtime.agentId,
       conversation_id: runtime.conversationId,

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -92,7 +92,6 @@ import {
   scheduleQueuePump,
 } from "./queue";
 import {
-  getApprovalContinuationRecoveryDisposition,
   getApprovalToolCallDesyncErrorText,
   recoverApprovalStateForSync,
   shouldAttemptPostStopApprovalRecovery,
@@ -482,7 +481,6 @@ export const __listenClientTestUtils = {
   normalizeExecutionResultsForInterruptParity,
   getApprovalToolCallDesyncErrorText,
   shouldAttemptPostStopApprovalRecovery,
-  getApprovalContinuationRecoveryDisposition,
   markAwaitingAcceptedApprovalContinuationRunId,
   resolveStaleApprovals,
   normalizeMessageContentImages,

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -53,10 +53,8 @@ import {
   ensureSecretsHydratedForAgent,
   invalidateSecretsCacheForAgent,
 } from "./secrets-sync";
-import {
-  buildMaybeLaunchReflectionSubagent,
-  handleIncomingMessage,
-} from "./turn";
+import { handleIncomingMessage } from "./turn";
+import { buildMaybeLaunchReflectionSubagent } from "./turn-events";
 import type { ConversationRuntime, StartListenerOptions } from "./types";
 
 export { SUPPORTED_REMOTE_COMMANDS } from "./listener-constants";
@@ -212,11 +210,6 @@ export async function handleExecuteCommand(
       output: `Failed: ${errorMessage}`,
       success: false,
     });
-  } finally {
-    // clearConversationRuntimeState sets cancelRequested = true which
-    // permanently blocks the queue pump (getListenerBlockedReason returns
-    // "interrupt_in_progress"). Reset it so subsequent user messages drain.
-    conversationRuntime.cancelRequested = false;
   }
 }
 

--- a/src/websocket/listener/control-inputs.ts
+++ b/src/websocket/listener/control-inputs.ts
@@ -29,13 +29,11 @@ import {
   emitDeviceStatusUpdate,
   emitInterruptedStatusDelta,
   emitRuntimeStateUpdates,
-  setLoopStatus,
 } from "./protocol-outbound";
 import { scheduleQueuePump } from "./queue";
 import { emitLoopErrorNotice } from "./recoverable-notices";
 import { resolveRecoveredApprovalResponse } from "./recovery";
 import {
-  clearActiveRunState,
   getActiveRuntime,
   getPendingControlRequestCount,
   getPendingControlRequests,
@@ -44,6 +42,7 @@ import {
 import { normalizeConversationId, normalizeCwdAgentId } from "./scope";
 import type { ListenerTransport } from "./transport";
 import { handleIncomingMessage } from "./turn";
+import { setCommandLoopStatus } from "./turn-status";
 import type {
   ChangeCwdMessage,
   ConversationRuntime,
@@ -224,14 +223,7 @@ export async function handleApprovalResponseInput(
       params.runtime.agent_id,
       params.runtime.conversation_id,
     );
-  if (targetRuntime.cancelRequested && !targetRuntime.isProcessing) {
-    targetRuntime.cancelRequested = false;
-    deps.scheduleQueuePump(
-      targetRuntime,
-      params.socket,
-      params.opts as StartListenerOptions,
-      params.processQueuedTurn,
-    );
+  if (targetRuntime.cancelRequested) {
     return false;
   }
   if (
@@ -273,7 +265,7 @@ export async function handleChangeDeviceStateInput(
     getActiveRuntime: typeof getActiveRuntime;
     getOrCreateScopedRuntime: typeof getOrCreateScopedRuntime;
     getPendingControlRequestCount: typeof getPendingControlRequestCount;
-    setLoopStatus: typeof setLoopStatus;
+    setCommandLoopStatus: typeof setCommandLoopStatus;
     handleModeChange: typeof handleModeChange;
     handleCwdChange: typeof handleCwdChange;
     emitDeviceStatusUpdate: typeof emitDeviceStatusUpdate;
@@ -284,7 +276,7 @@ export async function handleChangeDeviceStateInput(
     getActiveRuntime,
     getOrCreateScopedRuntime,
     getPendingControlRequestCount,
-    setLoopStatus,
+    setCommandLoopStatus,
     handleModeChange,
     handleCwdChange,
     emitDeviceStatusUpdate,
@@ -315,11 +307,15 @@ export async function handleChangeDeviceStateInput(
     scope.conversation_id,
   );
   const shouldTrackCommand =
-    !scopedRuntime.isProcessing &&
+    scopedRuntime.turnLifecycle.kind === "idle" &&
     resolvedDeps.getPendingControlRequestCount(listener, scope) === 0;
 
   if (shouldTrackCommand) {
-    resolvedDeps.setLoopStatus(scopedRuntime, "EXECUTING_COMMAND", scope);
+    resolvedDeps.setCommandLoopStatus(
+      scopedRuntime,
+      "EXECUTING_COMMAND",
+      scope,
+    );
   }
 
   try {
@@ -347,7 +343,11 @@ export async function handleChangeDeviceStateInput(
     }
   } finally {
     if (shouldTrackCommand) {
-      resolvedDeps.setLoopStatus(scopedRuntime, "WAITING_ON_INPUT", scope);
+      resolvedDeps.setCommandLoopStatus(
+        scopedRuntime,
+        "WAITING_ON_INPUT",
+        scope,
+      );
       resolvedDeps.scheduleQueuePump(
         scopedRuntime,
         params.socket,
@@ -379,8 +379,6 @@ export async function handleAbortMessageInput(
     getRecoveredApprovalStateForScope: typeof getRecoveredApprovalStateForScope;
     stashRecoveredApprovalInterrupts: typeof stashRecoveredApprovalInterrupts;
     rejectPendingApprovalResolvers: typeof rejectPendingApprovalResolvers;
-    setLoopStatus: typeof setLoopStatus;
-    clearActiveRunState: typeof clearActiveRunState;
     emitRuntimeStateUpdates: typeof emitRuntimeStateUpdates;
     emitInterruptedStatusDelta: typeof emitInterruptedStatusDelta;
     scheduleQueuePump: typeof scheduleQueuePump;
@@ -398,8 +396,6 @@ export async function handleAbortMessageInput(
     getRecoveredApprovalStateForScope,
     stashRecoveredApprovalInterrupts,
     rejectPendingApprovalResolvers,
-    setLoopStatus,
-    clearActiveRunState,
     emitRuntimeStateUpdates,
     emitInterruptedStatusDelta,
     scheduleQueuePump,
@@ -431,25 +427,25 @@ export async function handleAbortMessageInput(
     scope.agent_id,
     scope.conversation_id,
   );
-  const hasActiveTurn = scopedRuntime.isProcessing;
+  const hasActiveTurn = scopedRuntime.turnLifecycle.kind === "active";
 
   if (!hasActiveTurn && !hasPendingApprovals) {
     return false;
   }
 
-  const interruptedRunId = scopedRuntime.activeRunId;
-  scopedRuntime.cancelRequested = true;
+  const cancellation = scopedRuntime.turnLifecycle.requestCancellation();
+  const interruptedRunId = cancellation.runId;
   const pendingRequestsSnapshot = hasPendingApprovals
     ? resolvedDeps.getPendingControlRequests(listener, scope)
     : [];
 
   if (
-    scopedRuntime.activeExecutingToolCallIds.length > 0 &&
+    cancellation.executingToolCallIds.length > 0 &&
     (!scopedRuntime.pendingInterruptedResults ||
       scopedRuntime.pendingInterruptedResults.length === 0)
   ) {
     scopedRuntime.pendingInterruptedResults =
-      scopedRuntime.activeExecutingToolCallIds.map((toolCallId) => ({
+      cancellation.executingToolCallIds.map((toolCallId) => ({
         type: "tool",
         tool_call_id: toolCallId,
         tool_return: INTERRUPTED_BY_USER,
@@ -461,7 +457,7 @@ export async function handleAbortMessageInput(
       continuationEpoch: scopedRuntime.continuationEpoch,
     };
     scopedRuntime.pendingInterruptedToolCallIds = [
-      ...scopedRuntime.activeExecutingToolCallIds,
+      ...cancellation.executingToolCallIds,
     ];
   }
 
@@ -469,7 +465,7 @@ export async function handleAbortMessageInput(
   // (e.g., background Task tools that spawn subagents)
   if (
     hasActiveTurn &&
-    scopedRuntime.activeExecutingToolCallIds.length === 0 &&
+    cancellation.executingToolCallIds.length === 0 &&
     !scopedRuntime.pendingInterruptedContext
   ) {
     scopedRuntime.pendingInterruptedContext = {
@@ -479,13 +475,6 @@ export async function handleAbortMessageInput(
     };
     // Set empty results array so hasInterruptedCacheForScope can detect the interrupt
     scopedRuntime.pendingInterruptedResults = [];
-  }
-
-  if (
-    scopedRuntime.activeAbortController &&
-    !scopedRuntime.activeAbortController.signal.aborted
-  ) {
-    scopedRuntime.activeAbortController.abort();
   }
 
   const recoveredApprovalState = resolvedDeps.getRecoveredApprovalStateForScope(
@@ -507,10 +496,6 @@ export async function handleAbortMessageInput(
   }
 
   if (hasActiveTurn) {
-    scopedRuntime.lastStopReason = "cancelled";
-    scopedRuntime.isProcessing = false;
-    resolvedDeps.clearActiveRunState(scopedRuntime);
-    resolvedDeps.setLoopStatus(scopedRuntime, "WAITING_ON_INPUT", scope);
     resolvedDeps.emitRuntimeStateUpdates(scopedRuntime, scope);
     resolvedDeps.emitInterruptedStatusDelta(params.socket, scopedRuntime, {
       runId: interruptedRunId,
@@ -543,10 +528,6 @@ export async function handleAbortMessageInput(
       agentId: scope.agent_id,
       conversationId: scope.conversation_id,
     });
-  }
-
-  if (!hasActiveTurn) {
-    scopedRuntime.cancelRequested = false;
   }
 
   const cancelConversationId = scopedRuntime.conversationId;

--- a/src/websocket/listener/inbound-dispatch.ts
+++ b/src/websocket/listener/inbound-dispatch.ts
@@ -1,0 +1,100 @@
+import { enqueueInboundUserMessage } from "./inbound-queue";
+import {
+  scheduleQueuePump,
+  shouldProcessInboundMessageDirectly,
+  shouldQueueInboundMessage,
+} from "./queue";
+import { emitListenerStatus, getActiveRuntime } from "./runtime";
+import type { ListenerTransport } from "./transport";
+import type { handleIncomingMessage } from "./turn";
+import type {
+  ConversationRuntime,
+  IncomingMessage,
+  ListenerRuntime,
+  ProcessQueuedTurn,
+  StartListenerOptions,
+} from "./types";
+
+export function dispatchInboundMessageWhenReady(params: {
+  listener: ListenerRuntime;
+  runtime: ConversationRuntime;
+  incoming: IncomingMessage;
+  socket: ListenerTransport;
+  options: StartListenerOptions;
+  processQueuedTurn: ProcessQueuedTurn;
+  processIncomingMessage: typeof handleIncomingMessage;
+  actingUserId?: string;
+  trackListenerError: (
+    errorType: string,
+    error: unknown,
+    context: string,
+  ) => void;
+}): void {
+  const {
+    listener,
+    runtime,
+    incoming,
+    socket,
+    options,
+    processQueuedTurn,
+    processIncomingMessage,
+    actingUserId,
+    trackListenerError,
+  } = params;
+
+  runtime.messageQueue = runtime.messageQueue
+    .then(async () => {
+      if (listener !== getActiveRuntime() || listener.intentionallyClosed) {
+        return;
+      }
+      if (
+        shouldQueueInboundMessage(incoming) &&
+        !shouldProcessInboundMessageDirectly(runtime, incoming)
+      ) {
+        enqueueInboundUserMessage(runtime, incoming, actingUserId);
+        scheduleQueuePump(runtime, socket, options, processQueuedTurn);
+        return;
+      }
+
+      emitListenerStatus(
+        listener,
+        options.onStatusChange,
+        options.connectionId,
+      );
+      await processIncomingMessage(
+        incoming,
+        socket,
+        runtime,
+        options.onStatusChange,
+        options.connectionId,
+      );
+      emitListenerStatus(
+        listener,
+        options.onStatusChange,
+        options.connectionId,
+      );
+      if (
+        runtime.queueRuntime.length > 0 ||
+        runtime.queuePumpScheduled ||
+        runtime.queuePumpActive
+      ) {
+        scheduleQueuePump(runtime, socket, options, processQueuedTurn);
+      }
+    })
+    .catch((error: unknown) => {
+      trackListenerError(
+        "listener_queued_input_failed",
+        error,
+        "listener_message_queue",
+      );
+      if (process.env.DEBUG) {
+        console.error("[Listen] Error handling queued input:", error);
+      }
+      emitListenerStatus(
+        listener,
+        options.onStatusChange,
+        options.connectionId,
+      );
+      scheduleQueuePump(runtime, socket, options, processQueuedTurn);
+    });
+}

--- a/src/websocket/listener/inbound-queue.ts
+++ b/src/websocket/listener/inbound-queue.ts
@@ -1,0 +1,34 @@
+import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
+import type { ConversationRuntime, IncomingMessage } from "./types";
+
+export function enqueueInboundUserMessage(
+  runtime: ConversationRuntime,
+  incoming: IncomingMessage,
+  actingUserId?: string,
+): boolean {
+  const firstUserPayload = incoming.messages.find(
+    (payload): payload is MessageCreate & { client_message_id?: string } =>
+      "content" in payload,
+  );
+  if (!firstUserPayload) {
+    return false;
+  }
+
+  const enqueuedItem = runtime.queueRuntime.enqueue({
+    kind: "message",
+    source: "user",
+    content: firstUserPayload.content,
+    clientMessageId:
+      firstUserPayload.client_message_id ?? `cm-submit-${crypto.randomUUID()}`,
+    agentId: incoming.agentId,
+    conversationId: incoming.conversationId || "default",
+    // Forwarded by cloud-api for sender attribution in multi-user sandboxes.
+    actingUserId,
+  } as Parameters<typeof runtime.queueRuntime.enqueue>[0]);
+  if (!enqueuedItem) {
+    return false;
+  }
+
+  runtime.queuedMessagesByItemId.set(enqueuedItem.id, incoming);
+  return true;
+}

--- a/src/websocket/listener/interrupts.ts
+++ b/src/websocket/listener/interrupts.ts
@@ -436,6 +436,7 @@ export function createToolExecutionOutputEmitter(
     runId?: string | null;
     agentId?: string;
     conversationId?: string;
+    shouldEmit?: () => boolean;
   },
 ): ToolExecutionOutputEmitter {
   const outputByToolCallId = new Map<string, StreamingToolOutputState>();
@@ -444,7 +445,7 @@ export function createToolExecutionOutputEmitter(
     toolCallId: string,
     outputState: StreamingToolOutputState,
   ) => {
-    if (!outputState.dirty) {
+    if (!outputState.dirty || params.shouldEmit?.() === false) {
       return;
     }
 
@@ -467,7 +468,7 @@ export function createToolExecutionOutputEmitter(
         message_type: "tool_return_message",
         id: outputState.messageId,
         date: new Date().toISOString(),
-        run_id: params.runId ?? runtime.activeRunId ?? undefined,
+        run_id: params.runId ?? undefined,
         status: "success",
         tool_call_id: toolCallId,
         tool_return: toolReturn,
@@ -504,7 +505,7 @@ export function createToolExecutionOutputEmitter(
     chunk: string,
     isStderr: boolean = false,
   ) => {
-    if (!toolCallId || chunk.length === 0) {
+    if (!toolCallId || chunk.length === 0 || params.shouldEmit?.() === false) {
       return;
     }
 

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -887,7 +887,6 @@ export function createRuntime(): ListenerRuntime {
     everConnected: false,
     sessionId: `listen-${crypto.randomUUID()}`,
     eventSeqCounter: 0,
-    lastStopReason: null,
     queueEmitScheduled: false,
     pendingQueueEmitScope: undefined,
     onWsEvent: undefined,

--- a/src/websocket/listener/message-router.test.ts
+++ b/src/websocket/listener/message-router.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import WebSocket from "ws";
+import { getOrCreateScopedRuntime } from "./conversation-runtime";
+import { createRuntime } from "./lifecycle";
+import { createListenerMessageHandler } from "./message-router";
+import { scheduleQueuePump } from "./queue";
+import { setActiveRuntime } from "./runtime";
+import type { IncomingMessage, StartListenerOptions } from "./types";
+
+class MockSocket {
+  readyState = WebSocket.OPEN;
+  sentPayloads: string[] = [];
+
+  send(payload: string): void {
+    this.sentPayloads.push(payload);
+  }
+}
+
+function makeListenerOptions(): StartListenerOptions {
+  return {
+    connectionId: "conn-test",
+    wsUrl: "wss://example.test/ws",
+    deviceId: "device-test",
+    connectionName: "listener-test",
+    onConnected: () => {},
+    onDisconnected: () => {},
+    onError: () => {},
+  };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) {
+      return;
+    }
+    await Bun.sleep(1);
+  }
+  throw new Error("Timed out waiting for listener state");
+}
+
+describe("listener message router ownership handoff", () => {
+  afterEach(() => setActiveRuntime(null));
+
+  test("a direct message that loses the idle race is queued and later drained", async () => {
+    const listener = createRuntime();
+    const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
+    const socket = new MockSocket();
+    const opts = makeListenerOptions();
+    const processIncomingMessage = mock(async () => {});
+    const processedTurns: IncomingMessage[] = [];
+    const processQueuedTurn = mock(async (queuedTurn: IncomingMessage) => {
+      processedTurns.push(queuedTurn);
+    });
+    const trackListenerError = mock(() => {});
+    let releaseMessageQueue!: () => void;
+    runtime.messageQueue = new Promise<void>((resolve) => {
+      releaseMessageQueue = resolve;
+    });
+    setActiveRuntime(listener);
+
+    const handleMessage = createListenerMessageHandler({
+      runtime: listener,
+      socket: socket as unknown as WebSocket,
+      opts,
+      processQueuedTurn,
+      fileCommandSession: { handle: () => false },
+      getParsedRuntimeScope: () => null,
+      replaySyncStateForRuntime: async () => {},
+      getOrCreateScopedRuntime: () => runtime,
+      handleApprovalResponseInput: async () => false,
+      handleChangeDeviceStateInput: async () => false,
+      handleAbortMessageInput: async () => false,
+      stampInboundUserMessageOtids: (incoming) => incoming,
+      safeSocketSend: () => true,
+      runDetachedListenerTask: () => {},
+      trackListenerError,
+      wireChannelIngress: async () => {},
+      processIncomingMessage,
+    });
+
+    await handleMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "input",
+          runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+          payload: {
+            kind: "create_message",
+            messages: [{ role: "user", content: "do not drop me" }],
+          },
+        }),
+      ),
+    );
+    const recoveryLease = runtime.turnLifecycle.begin({
+      origin: "approval_recovery",
+      workingDirectory: process.cwd(),
+    });
+
+    releaseMessageQueue();
+    await runtime.messageQueue;
+    await waitFor(
+      () => !runtime.queuePumpActive && !runtime.queuePumpScheduled,
+    );
+
+    expect(processIncomingMessage).not.toHaveBeenCalled();
+    expect(trackListenerError).not.toHaveBeenCalled();
+    expect(runtime.queueRuntime.length).toBe(1);
+    expect(runtime.queuedMessagesByItemId.size).toBe(1);
+
+    runtime.turnLifecycle.finish(recoveryLease, "end_turn");
+    scheduleQueuePump(
+      runtime,
+      socket as unknown as WebSocket,
+      opts,
+      processQueuedTurn,
+    );
+    await waitFor(
+      () => processedTurns.length === 1 && runtime.queueRuntime.length === 0,
+    );
+
+    expect(processedTurns[0]?.messages).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "do not drop me" }],
+      },
+    ]);
+    expect(runtime.queuedMessagesByItemId.size).toBe(0);
+  });
+});

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -1,4 +1,3 @@
-import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import type { ApprovalCreate } from "@letta-ai/letta-client/resources/agents/messages";
 import type WebSocket from "ws";
 import {
@@ -36,6 +35,8 @@ import { handleSecretsCommand } from "./commands/secrets";
 import { handleSettingsProtocolCommand } from "./commands/settings";
 import { handleSkillAgentProtocolCommand } from "./commands/skills-agents";
 import { handleExternalToolCallResponseCommand } from "./external-tools";
+import { dispatchInboundMessageWhenReady } from "./inbound-dispatch";
+import { enqueueInboundUserMessage } from "./inbound-queue";
 import {
   isExecuteCommandCommand,
   parseServerLifecycleMessage,
@@ -51,11 +52,7 @@ import {
   shouldQueueInboundMessage,
 } from "./queue";
 import { emitLoopErrorNotice } from "./recoverable-notices";
-import {
-  emitListenerStatus,
-  getActiveRuntime,
-  safeEmitWsEvent,
-} from "./runtime";
+import { getActiveRuntime, safeEmitWsEvent } from "./runtime";
 import type { ListenerTransport } from "./transport";
 import { handleIncomingMessage } from "./turn";
 import type {
@@ -165,6 +162,7 @@ type MessageRouterParams = {
   runDetachedListenerTask: RunDetachedListenerTask;
   trackListenerError: TrackListenerError;
   wireChannelIngress: WireChannelIngress;
+  processIncomingMessage?: typeof handleIncomingMessage;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -373,6 +371,7 @@ export function createListenerMessageHandler(
     runDetachedListenerTask,
     trackListenerError,
     wireChannelIngress,
+    processIncomingMessage = handleIncomingMessage,
   } = params;
 
   return async (data: WebSocket.RawData): Promise<void> => {
@@ -570,60 +569,17 @@ export function createListenerMessageHandler(
         const processIncomingMessageDirectly = (
           directIncoming: IncomingMessage,
         ): void => {
-          scopedRuntime.messageQueue = scopedRuntime.messageQueue
-            .then(async () => {
-              if (
-                runtime !== getActiveRuntime() ||
-                runtime.intentionallyClosed
-              ) {
-                return;
-              }
-              emitListenerStatus(
-                runtime,
-                opts.onStatusChange,
-                opts.connectionId,
-              );
-              await handleIncomingMessage(
-                directIncoming,
-                socket,
-                scopedRuntime,
-                opts.onStatusChange,
-                opts.connectionId,
-              );
-              emitListenerStatus(
-                runtime,
-                opts.onStatusChange,
-                opts.connectionId,
-              );
-              if (
-                scopedRuntime.queueRuntime.length > 0 ||
-                scopedRuntime.queuePumpScheduled ||
-                scopedRuntime.queuePumpActive
-              ) {
-                scheduleQueuePump(
-                  scopedRuntime,
-                  socket,
-                  opts,
-                  processQueuedTurn,
-                );
-              }
-            })
-            .catch((error: unknown) => {
-              trackListenerError(
-                "listener_queued_input_failed",
-                error,
-                "listener_message_queue",
-              );
-              if (process.env.DEBUG) {
-                console.error("[Listen] Error handling queued input:", error);
-              }
-              emitListenerStatus(
-                runtime,
-                opts.onStatusChange,
-                opts.connectionId,
-              );
-              scheduleQueuePump(scopedRuntime, socket, opts, processQueuedTurn);
-            });
+          dispatchInboundMessageWhenReady({
+            listener: runtime,
+            runtime: scopedRuntime,
+            incoming: directIncoming,
+            socket,
+            options: opts,
+            processQueuedTurn,
+            processIncomingMessage,
+            actingUserId: parsed.runtime.acting_user_id,
+            trackListenerError,
+          });
         };
 
         if (shouldQueueInboundMessage(incoming)) {
@@ -635,34 +591,11 @@ export function createListenerMessageHandler(
             return;
           }
 
-          const firstUserPayload = stampedIncoming.messages.find(
-            (
-              payload,
-            ): payload is MessageCreate & { client_message_id?: string } =>
-              "content" in payload,
+          enqueueInboundUserMessage(
+            scopedRuntime,
+            stampedIncoming,
+            parsed.runtime.acting_user_id,
           );
-          if (firstUserPayload) {
-            const enqueuedItem = scopedRuntime.queueRuntime.enqueue({
-              kind: "message",
-              source: "user",
-              content: firstUserPayload.content,
-              clientMessageId:
-                firstUserPayload.client_message_id ??
-                `cm-submit-${crypto.randomUUID()}`,
-              agentId: parsed.runtime.agent_id,
-              conversationId: parsed.runtime.conversation_id || "default",
-              // Forwarded by cloud-api so we can attribute the
-              // outbound createMessage to the actual sender on
-              // multi-user sandboxes. Absent on self-hosted flows.
-              actingUserId: parsed.runtime.acting_user_id,
-            } as Parameters<typeof scopedRuntime.queueRuntime.enqueue>[0]);
-            if (enqueuedItem) {
-              scopedRuntime.queuedMessagesByItemId.set(
-                enqueuedItem.id,
-                stampedIncoming,
-              );
-            }
-          }
           scheduleQueuePump(scopedRuntime, socket, opts, processQueuedTurn);
           return;
         }

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -23,7 +23,6 @@ import type {
   DeviceStatus,
   DeviceStatusUpdateMessage,
   LoopState,
-  LoopStatus,
   LoopStatusUpdateMessage,
   ModCommandInfo,
   QueueMessage,
@@ -585,21 +584,6 @@ export function buildQueueSnapshot(
     content: item.kind === "message" ? item.content : item.text,
     enqueued_at: new Date(item.enqueuedAt).toISOString(),
   }));
-}
-
-export function setLoopStatus(
-  runtime: ConversationRuntime,
-  status: LoopStatus,
-  scope?: {
-    agent_id?: string | null;
-    conversation_id?: string | null;
-  },
-): void {
-  if (runtime.loopStatus === status) {
-    return;
-  }
-  runtime.loopStatus = status;
-  emitLoopStatusIfOpen(runtime, scope);
 }
 
 /** Message types that belong on the stream channel.

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -347,19 +347,13 @@ export function shouldProcessInboundMessageDirectly(
     runtime.queuePumpScheduled ||
     runtime.pendingTurns > 0 ||
     runtime.queuedMessagesByItemId.size > 0 ||
-    runtime.isProcessing ||
-    runtime.isRecoveringApprovals ||
-    runtime.cancelRequested ||
+    runtime.turnLifecycle.kind !== "idle" ||
     runtime.pendingApprovalResolvers.size > 0 ||
     runtime.pendingApprovalBatchByToolCallId.size > 0 ||
     runtime.recoveredApprovalState !== null ||
     runtime.pendingInterruptedResults !== null ||
     runtime.pendingInterruptedContext !== null ||
-    runtime.activeExecutingToolCallIds.length > 0 ||
-    (runtime.pendingInterruptedToolCallIds?.length ?? 0) > 0 ||
-    runtime.activeRunId !== null ||
-    runtime.activeRunStartedAt !== null ||
-    runtime.activeAbortController !== null
+    (runtime.pendingInterruptedToolCallIds?.length ?? 0) > 0
   ) {
     return false;
   }
@@ -369,15 +363,12 @@ export function shouldProcessInboundMessageDirectly(
     conversation_id: runtime.conversationId,
   });
   return (
-    getListenerBlockedReason({
-      loopStatus: runtime.loopStatus,
-      isProcessing: runtime.isProcessing,
-      pendingApprovalsLen: activeScope
+    getListenerBlockedReason(
+      runtime.turnLifecycle.snapshot(),
+      activeScope
         ? getPendingControlRequestCount(runtime.listener, activeScope)
         : 0,
-      cancelRequested: runtime.cancelRequested,
-      isRecoveringApprovals: runtime.isRecoveringApprovals,
-    }) === null
+    ) === null
   );
 }
 
@@ -452,15 +443,12 @@ function computeListenerQueueBlockedReason(
     agent_id: runtime.agentId,
     conversation_id: runtime.conversationId,
   });
-  return getListenerBlockedReason({
-    loopStatus: runtime.loopStatus,
-    isProcessing: runtime.isProcessing,
-    pendingApprovalsLen: activeScope
+  return getListenerBlockedReason(
+    runtime.turnLifecycle.snapshot(),
+    activeScope
       ? getPendingControlRequestCount(runtime.listener, activeScope)
       : 0,
-    cancelRequested: runtime.cancelRequested,
-    isRecoveringApprovals: runtime.isRecoveringApprovals,
-  });
+  );
 }
 
 async function drainQueuedMessages(

--- a/src/websocket/listener/recovery-lease.test.ts
+++ b/src/websocket/listener/recovery-lease.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, mock, test } from "bun:test";
+import { getOrCreateScopedRuntime } from "./conversation-runtime";
+import { createRuntime } from "./lifecycle";
+import { resolveRecoveredApprovalResponse } from "./recovery";
+import {
+  clearConversationRuntimeState,
+  getPendingControlRequestCount,
+} from "./runtime";
+import type { ListenerTransport } from "./transport";
+import type { RecoveredApprovalState } from "./types";
+
+function createTransport(sentPayloads: string[]): ListenerTransport {
+  return {
+    kind: "local",
+    bufferedAmount: 0,
+    isOpen: () => true,
+    send: (payload: string) => sentPayloads.push(payload),
+  };
+}
+
+function createRecoveredState(
+  pendingRequestIds: Set<string> = new Set(["perm-1"]),
+): RecoveredApprovalState {
+  return {
+    agentId: "agent-1",
+    conversationId: "conv-1",
+    approvalsByRequestId: new Map([
+      [
+        "perm-1",
+        {
+          approval: {
+            toolCallId: "call-1",
+            toolName: "Bash",
+            toolArgs: '{"command":"pwd"}',
+          },
+          approvalContext: null,
+          controlRequest: {
+            type: "control_request",
+            request_id: "perm-1",
+            request: {
+              subtype: "can_use_tool",
+              tool_name: "Bash",
+              input: { command: "pwd" },
+              tool_call_id: "call-1",
+              permission_suggestions: [],
+              blocked_path: null,
+            },
+            agent_id: "agent-1",
+            conversation_id: "conv-1",
+          },
+        },
+      ],
+    ]),
+    pendingRequestIds,
+    responsesByRequestId: new Map(),
+  };
+}
+
+function createPreparedToolContext() {
+  return {
+    toolset: "codex",
+    toolsetPreference: "auto",
+    preparedToolContext: {
+      contextId: "context-1",
+      loadedToolNames: [],
+      clientTools: [],
+      clientSkills: [],
+    },
+  } as never;
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await Bun.sleep(1);
+  }
+  throw new Error("Timed out waiting for recovered approval state");
+}
+
+describe("recovered approval lease boundaries", () => {
+  test("the last pending gate is removed only after recovery owns the lifecycle", async () => {
+    const runtime = getOrCreateScopedRuntime(
+      createRuntime(),
+      "agent-1",
+      "conv-1",
+    );
+    let lifecycleKindAtDelete: string | null = null;
+    const pendingRequestIds = new (class extends Set<string> {
+      override delete(value: string): boolean {
+        lifecycleKindAtDelete = runtime.turnLifecycle.kind;
+        return super.delete(value);
+      }
+    })(["perm-1"]);
+    runtime.recoveredApprovalState = createRecoveredState(pendingRequestIds);
+    let releasePermissionWrite!: (saved: boolean) => void;
+    let permissionWriteStarted = false;
+    const permissionWrite = new Promise<boolean>((resolve) => {
+      releasePermissionWrite = resolve;
+    });
+
+    const handled = resolveRecoveredApprovalResponse(
+      runtime,
+      createTransport([]),
+      { request_id: "perm-1", decision: { behavior: "allow" } },
+      async (
+        _message,
+        _socket,
+        ownerRuntime,
+        _onStatusChange,
+        _connectionId,
+        _batchId,
+        turnLease,
+      ) => {
+        if (turnLease) ownerRuntime.turnLifecycle.finish(turnLease, "end_turn");
+      },
+      {
+        dependencies: {
+          applySuggestedPermissions: async () => {
+            permissionWriteStarted = true;
+            return permissionWrite;
+          },
+          ensureSecretsHydrated: async () => {},
+          prepareToolExecutionContext: async () => createPreparedToolContext(),
+          executeApprovalBatch: async () => [],
+        },
+      },
+    );
+    await waitFor(() => permissionWriteStarted);
+
+    expect(
+      getPendingControlRequestCount(runtime.listener, {
+        agent_id: "agent-1",
+        conversation_id: "conv-1",
+      }),
+    ).toBe(1);
+    expect(runtime.turnLifecycle.kind).toBe("idle");
+
+    releasePermissionWrite(false);
+    expect(await handled).toBe(true);
+    expect(String(lifecycleKindAtDelete)).toBe("active");
+  });
+
+  test("stale recovered tool execution emits nothing into a replacement run", async () => {
+    const runtime = getOrCreateScopedRuntime(
+      createRuntime(),
+      "agent-1",
+      "conv-1",
+    );
+    runtime.recoveredApprovalState = createRecoveredState();
+    const sentPayloads: string[] = [];
+    let executionStarted = false;
+    let resolveExecution!: (results: never[]) => void;
+    const execution = new Promise<never[]>((resolve) => {
+      resolveExecution = resolve;
+    });
+    const processTurn = mock(async () => {});
+    const handled = resolveRecoveredApprovalResponse(
+      runtime,
+      createTransport(sentPayloads),
+      { request_id: "perm-1", decision: { behavior: "allow" } },
+      processTurn,
+      {
+        dependencies: {
+          applySuggestedPermissions: async () => false,
+          ensureSecretsHydrated: async () => {},
+          prepareToolExecutionContext: async () => createPreparedToolContext(),
+          executeApprovalBatch: (async (
+            _decisions: unknown,
+            _unused: unknown,
+            options?: {
+              onStreamingOutput?: (id: string, chunk: string) => void;
+            },
+          ) => {
+            executionStarted = true;
+            const results = await execution;
+            options?.onStreamingOutput?.("call-1", "late output");
+            return results;
+          }) as never,
+        },
+      },
+    );
+    await waitFor(() => executionStarted);
+
+    clearConversationRuntimeState(runtime);
+    const replacementLease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+    });
+    runtime.turnLifecycle.setRunId(replacementLease, "replacement-run");
+    sentPayloads.length = 0;
+    resolveExecution([
+      {
+        type: "tool",
+        tool_call_id: "call-1",
+        status: "success",
+        tool_return: "ok",
+      },
+    ] as never[]);
+
+    expect(await handled).toBe(true);
+    expect(processTurn).not.toHaveBeenCalled();
+    expect(runtime.turnLifecycle.isCurrent(replacementLease)).toBe(true);
+    expect(sentPayloads).toEqual([]);
+  });
+});

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -57,20 +57,20 @@ import { getOrCreateConversationPermissionModeStateRef } from "./permission-mode
 import {
   emitCanonicalMessageDelta,
   emitDequeuedUserMessage,
-  emitInterruptedStatusDelta,
   emitLoopStatusUpdate,
   emitRuntimeStateUpdates,
-  setLoopStatus,
 } from "./protocol-outbound";
 import { consumeQueuedTurn } from "./queue";
 import { emitLoopErrorNotice } from "./recoverable-notices";
 import {
-  clearActiveRunState,
   clearRecoveredApprovalState,
   hasInterruptedCacheForScope,
 } from "./runtime";
 import { ensureSecretsHydratedForAgent } from "./secrets-sync";
 import type { ListenerTransport } from "./transport";
+import type { TurnLease } from "./turn-lifecycle";
+import { setTurnLoopStatus } from "./turn-status";
+import { finishListenerTurn } from "./turn-terminal";
 import type {
   ConversationRuntime,
   IncomingMessage,
@@ -189,7 +189,7 @@ export async function drainRecoveryStreamWithEmission(
   params: {
     agentId?: string | null;
     conversationId: string;
-    abortSignal: AbortSignal;
+    turnLease: TurnLease;
   },
 ): Promise<Awaited<ReturnType<typeof drainStreamWithResume>>> {
   let recoveryRunIdSent = false;
@@ -198,14 +198,12 @@ export async function drainRecoveryStreamWithEmission(
     recoveryStream,
     createBuffers(params.agentId || ""),
     () => {},
-    params.abortSignal,
+    params.turnLease.signal,
     undefined,
     ({ chunk, shouldOutput, errorInfo }) => {
       const maybeRunId = (chunk as { run_id?: unknown }).run_id;
       if (typeof maybeRunId === "string") {
-        if (runtime.activeRunId !== maybeRunId) {
-          runtime.activeRunId = maybeRunId;
-        }
+        runtime.turnLifecycle.setRunId(params.turnLease, maybeRunId);
         if (!recoveryRunIdSent) {
           recoveryRunIdSent = true;
           emitLoopStatusUpdate(socket, runtime, {
@@ -226,7 +224,7 @@ export async function drainRecoveryStreamWithEmission(
           agentId: params.agentId ?? undefined,
           conversationId: params.conversationId,
           errorInfo,
-          abortSignal: params.abortSignal,
+          abortSignal: params.turnLease.signal,
         });
       }
 
@@ -258,48 +256,42 @@ export async function drainRecoveryStreamWithEmission(
 export function finalizeHandledRecoveryTurn(
   runtime: ConversationRuntime,
   socket: ListenerTransport,
+  turnLease: TurnLease,
   params: {
     drainResult: Awaited<ReturnType<typeof drainStreamWithResume>>;
     agentId?: string | null;
     conversationId: string;
   },
-): void {
-  const scope = {
-    agent_id: params.agentId ?? null,
-    conversation_id: params.conversationId,
-  };
-
+): ReturnType<typeof finishListenerTurn> {
   if (params.drainResult.stopReason === "end_turn") {
-    runtime.lastStopReason = "end_turn";
-    runtime.isProcessing = false;
-    setLoopStatus(runtime, "WAITING_ON_INPUT", scope);
-    clearActiveRunState(runtime);
-    emitRuntimeStateUpdates(runtime, scope);
-    return;
+    return finishListenerTurn(runtime, turnLease, {
+      stopReason: "end_turn",
+      agentId: params.agentId,
+      conversationId: params.conversationId,
+    });
   }
 
   if (params.drainResult.stopReason === "cancelled") {
-    runtime.lastStopReason = "cancelled";
-    runtime.isProcessing = false;
-    emitInterruptedStatusDelta(socket, runtime, {
+    return finishListenerTurn(runtime, turnLease, {
+      stopReason: "cancelled",
+      socket,
       runId: runtime.activeRunId,
       agentId: params.agentId ?? undefined,
       conversationId: params.conversationId,
     });
-    setLoopStatus(runtime, "WAITING_ON_INPUT", scope);
-    clearActiveRunState(runtime);
-    emitRuntimeStateUpdates(runtime, scope);
-    return;
   }
 
   const terminalStopReason =
     (params.drainResult.stopReason as StopReasonType) || "error";
-  runtime.lastStopReason = terminalStopReason;
-  runtime.isProcessing = false;
-  setLoopStatus(runtime, "WAITING_ON_INPUT", scope);
   const runId = runtime.activeRunId;
-  clearActiveRunState(runtime);
-  emitRuntimeStateUpdates(runtime, scope);
+  const transition = finishListenerTurn(runtime, turnLease, {
+    stopReason: terminalStopReason,
+    agentId: params.agentId,
+    conversationId: params.conversationId,
+  });
+  if (!transition.finished) {
+    return transition;
+  }
   emitLoopErrorNotice(socket, runtime, {
     message: `Recovery continuation ended unexpectedly: ${terminalStopReason}`,
     stopReason: terminalStopReason,
@@ -308,12 +300,7 @@ export function finalizeHandledRecoveryTurn(
     agentId: params.agentId ?? undefined,
     conversationId: params.conversationId,
   });
-}
-
-export function getApprovalContinuationRecoveryDisposition(
-  drainResult: Awaited<ReturnType<typeof drainStreamWithResume>> | null,
-): "handled" | "retry" {
-  return drainResult ? "handled" : "retry";
+  return transition;
 }
 
 export async function debugLogApprovalResumeState(
@@ -412,10 +399,7 @@ export async function recoverApprovalStateForSync(
     runtime.agentId === scope.agent_id &&
     runtime.conversationId === scope.conversation_id;
 
-  if (
-    sameActiveScope &&
-    (runtime.isProcessing || runtime.loopStatus !== "WAITING_ON_INPUT")
-  ) {
+  if (sameActiveScope && runtime.turnLifecycle.kind !== "idle") {
     clearRecoveredApprovalState(runtime);
     return;
   }
@@ -483,6 +467,7 @@ export async function resolveRecoveredApprovalResponse(
     ) => void,
     connectionId?: string,
     dequeuedBatchId?: string,
+    existingTurnLease?: TurnLease,
   ) => Promise<void>,
   opts?: {
     onStatusChange?: (
@@ -657,56 +642,54 @@ export async function resolveRecoveredApprovalResponse(
   const shouldFinalizeRecoveredChannelTurn =
     runtime.activeChannelTurn?.contextRecovered === true;
 
+  const recoveryLease = runtime.turnLifecycle.begin({
+    origin: "approval_recovery",
+    workingDirectory,
+    initialStatus: "EXECUTING_CLIENT_SIDE_TOOL",
+    executingToolCallIds: approvedToolCallIds,
+  });
   recovered.pendingRequestIds.clear();
   emitRuntimeStateUpdates(runtime, scope);
-
-  runtime.isProcessing = true;
-  runtime.activeWorkingDirectory = workingDirectory;
-  runtime.activeExecutingToolCallIds = [...approvedToolCallIds];
-  setLoopStatus(runtime, "EXECUTING_CLIENT_SIDE_TOOL", scope);
-  emitRuntimeStateUpdates(runtime, scope);
-  emitToolExecutionStartedEvents(socket, runtime, {
-    toolCalls: approvedDecisions.map((decision) => ({
-      toolCallId: decision.approval.toolCallId,
-      toolName: decision.approval.toolName,
-      toolArgs: decision.approval.toolArgs,
-    })),
-    runId: runtime.activeRunId ?? undefined,
-    agentId: recovered.agentId,
-    conversationId: recovered.conversationId,
-  });
-  const emitToolExecutionOutput = createToolExecutionOutputEmitter(
-    socket,
-    runtime,
-    {
+  try {
+    emitToolExecutionStartedEvents(socket, runtime, {
+      toolCalls: approvedDecisions.map((decision) => ({
+        toolCallId: decision.approval.toolCallId,
+        toolName: decision.approval.toolName,
+        toolArgs: decision.approval.toolArgs,
+      })),
       runId: runtime.activeRunId ?? undefined,
       agentId: recovered.agentId,
       conversationId: recovered.conversationId,
-    },
-  );
-  const recoveryAbortController = new AbortController();
-  runtime.activeAbortController = recoveryAbortController;
-  await ensureSecretsHydratedForAgent(runtime.listener, recovered.agentId);
-  const preparedToolContext = await prepareToolExecutionContextForScope({
-    agentId: recovered.agentId,
-    conversationId: recovered.conversationId,
-    workingDirectory: runtime.activeWorkingDirectory,
-    permissionModeState: getOrCreateConversationPermissionModeStateRef(
-      runtime.listener,
-      recovered.agentId,
-      recovered.conversationId,
-    ),
-    modEvents: ensureListenerModAdapter(runtime.listener).events,
-  });
-  runtime.currentToolset = preparedToolContext.toolset;
-  runtime.currentToolsetPreference = preparedToolContext.toolsetPreference;
-  runtime.currentLoadedTools =
-    preparedToolContext.preparedToolContext.loadedToolNames;
-  try {
+    });
+    const emitToolExecutionOutput = createToolExecutionOutputEmitter(
+      socket,
+      runtime,
+      {
+        runId: runtime.activeRunId ?? undefined,
+        agentId: recovered.agentId,
+        conversationId: recovered.conversationId,
+      },
+    );
+    await ensureSecretsHydratedForAgent(runtime.listener, recovered.agentId);
+    const preparedToolContext = await prepareToolExecutionContextForScope({
+      agentId: recovered.agentId,
+      conversationId: recovered.conversationId,
+      workingDirectory,
+      permissionModeState: getOrCreateConversationPermissionModeStateRef(
+        runtime.listener,
+        recovered.agentId,
+        recovered.conversationId,
+      ),
+      modEvents: ensureListenerModAdapter(runtime.listener).events,
+    });
+    runtime.currentToolset = preparedToolContext.toolset;
+    runtime.currentToolsetPreference = preparedToolContext.toolsetPreference;
+    runtime.currentLoadedTools =
+      preparedToolContext.preparedToolContext.loadedToolNames;
     let approvalResults: Awaited<ReturnType<typeof executeApprovalBatch>>;
     try {
       approvalResults = await executeApprovalBatch(decisions, undefined, {
-        abortSignal: recoveryAbortController.signal,
+        abortSignal: recoveryLease.signal,
         onStreamingOutput: emitToolExecutionOutput,
         toolContextId: preparedToolContext.preparedToolContext.contextId,
         workingDirectory,
@@ -737,8 +720,8 @@ export async function resolveRecoveredApprovalResponse(
       "tool-return",
     );
 
-    runtime.activeAbortController = null;
-    setLoopStatus(runtime, "SENDING_API_REQUEST", scope);
+    runtime.turnLifecycle.setExecutingToolCallIds(recoveryLease, []);
+    setTurnLoopStatus(runtime, recoveryLease, "SENDING_API_REQUEST", scope);
     emitRuntimeStateUpdates(runtime, scope);
 
     const continuationMessages: Array<MessageCreate | ApprovalCreate> = [
@@ -769,6 +752,7 @@ export async function resolveRecoveredApprovalResponse(
       opts?.onStatusChange,
       opts?.connectionId,
       continuationBatchId,
+      recoveryLease,
     );
 
     if (shouldFinalizeRecoveredChannelTurn) {
@@ -796,14 +780,11 @@ export async function resolveRecoveredApprovalResponse(
       recovered.approvalsByRequestId.keys(),
     );
     recovered.responsesByRequestId.clear();
-    runtime.activeAbortController = null;
-    runtime.isProcessing = false;
-    runtime.activeExecutingToolCallIds = [];
-    setLoopStatus(runtime, "WAITING_ON_INPUT", scope);
-    clearActiveRunState(runtime);
-    emitRuntimeStateUpdates(runtime, {
-      agent_id: recovered.agentId,
-      conversation_id: recovered.conversationId,
+    finishListenerTurn(runtime, recoveryLease, {
+      stopReason: recoveryLease.signal.aborted ? "cancelled" : "error",
+      socket,
+      agentId: recovered.agentId,
+      conversationId: recovered.conversationId,
     });
     throw error;
   }

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -475,6 +475,13 @@ export async function resolveRecoveredApprovalResponse(
       connectionId: string,
     ) => void;
     connectionId?: string;
+    dependencies?: {
+      applySuggestedPermissions?: typeof applySuggestedPermissionsForApproval;
+      classifyApprovals?: typeof classifyApprovalsWithSuggestions;
+      ensureSecretsHydrated?: typeof ensureSecretsHydratedForAgent;
+      prepareToolExecutionContext?: typeof prepareToolExecutionContextForScope;
+      executeApprovalBatch?: typeof executeApprovalBatch;
+    };
   },
 ): Promise<boolean> {
   const requestId = response.request_id;
@@ -486,31 +493,56 @@ export async function resolveRecoveredApprovalResponse(
   if (!recovered?.approvalsByRequestId.has(requestId)) {
     return false;
   }
+  const dependencies = opts?.dependencies;
+  const applySuggestedPermissions =
+    dependencies?.applySuggestedPermissions ??
+    applySuggestedPermissionsForApproval;
+  const classifyApprovals =
+    dependencies?.classifyApprovals ?? classifyApprovalsWithSuggestions;
+  const ensureSecretsHydrated =
+    dependencies?.ensureSecretsHydrated ?? ensureSecretsHydratedForAgent;
+  const prepareToolExecutionContext =
+    dependencies?.prepareToolExecutionContext ??
+    prepareToolExecutionContextForScope;
+  const executeApprovals =
+    dependencies?.executeApprovalBatch ?? executeApprovalBatch;
 
-  recovered.responsesByRequestId.set(requestId, response);
-  recovered.pendingRequestIds.delete(requestId);
   const workingDirectory = getConversationWorkingDirectory(
     runtime.listener,
     recovered.agentId,
     recovered.conversationId,
   );
+  const scope = {
+    agent_id: recovered.agentId,
+    conversation_id: recovered.conversationId,
+  } as const;
   const respondedEntry = recovered.approvalsByRequestId.get(requestId);
+  let autoDecisionsToAppend: ApprovalDecision[] = [];
+  const reclassifiedRequestIds = new Set<string>();
   if (
     respondedEntry &&
     "decision" in response &&
     response.decision.behavior === "allow"
   ) {
-    const savedSuggestions = await applySuggestedPermissionsForApproval({
+    const savedSuggestions = await applySuggestedPermissions({
       decision: response.decision,
       context: respondedEntry.approvalContext,
       workingDirectory,
     });
 
-    if (savedSuggestions && recovered.pendingRequestIds.size > 0) {
+    if (
+      runtime.recoveredApprovalState !== recovered ||
+      !recovered.pendingRequestIds.has(requestId)
+    ) {
+      return true;
+    }
+
+    if (savedSuggestions && recovered.pendingRequestIds.size > 1) {
       const remainingRecoveredEntries = [...recovered.pendingRequestIds]
+        .filter((id) => id !== requestId)
         .map((id) => recovered.approvalsByRequestId.get(id))
         .filter((entry): entry is RecoveredPendingApproval => !!entry);
-      const reclassified = await classifyApprovalsWithSuggestions(
+      const reclassified = await classifyApprovals(
         remainingRecoveredEntries.map((entry) => entry.approval),
         {
           alwaysRequiresUserInput: isInteractiveApprovalTool,
@@ -530,134 +562,168 @@ export async function resolveRecoveredApprovalResponse(
         reclassified.autoAllowed.length > 0 ||
         reclassified.autoDenied.length > 0
       ) {
-        recovered.autoDecisions = [
-          ...(recovered.autoDecisions ?? []),
-          ...buildRecoveredAutoDecisions(
-            reclassified.autoAllowed,
-            reclassified.autoDenied,
-          ),
-        ];
-
+        autoDecisionsToAppend = buildRecoveredAutoDecisions(
+          reclassified.autoAllowed,
+          reclassified.autoDenied,
+        );
         const reclassifiedToolCallIds = new Set(
           [...reclassified.autoAllowed, ...reclassified.autoDenied].map(
             (entry) => entry.approval.toolCallId,
           ),
         );
-        for (const pendingId of [...recovered.pendingRequestIds]) {
+        for (const pendingId of recovered.pendingRequestIds) {
+          if (pendingId === requestId) {
+            continue;
+          }
           const pendingEntry = recovered.approvalsByRequestId.get(pendingId);
           if (
             pendingEntry &&
             reclassifiedToolCallIds.has(pendingEntry.approval.toolCallId)
           ) {
-            recovered.pendingRequestIds.delete(pendingId);
-            recovered.approvalsByRequestId.delete(pendingId);
-            recovered.responsesByRequestId.delete(pendingId);
+            reclassifiedRequestIds.add(pendingId);
           }
         }
       }
     }
   }
 
-  if (recovered.pendingRequestIds.size > 0) {
-    emitRuntimeStateUpdates(runtime, {
-      agent_id: recovered.agentId,
-      conversation_id: recovered.conversationId,
-    });
+  if (
+    runtime.recoveredApprovalState !== recovered ||
+    !recovered.pendingRequestIds.has(requestId)
+  ) {
     return true;
   }
-
-  const decisions: ApprovalDecision[] = [...(recovered.autoDecisions ?? [])];
-  for (const [id, entry] of recovered.approvalsByRequestId) {
-    const approvalResponse = recovered.responsesByRequestId.get(id);
-    if (!approvalResponse) {
-      continue;
-    }
-
-    if ("decision" in approvalResponse) {
-      const decision = approvalResponse.decision;
-      if (decision.behavior === "allow") {
-        decisions.push({
-          type: "approve",
-          approval: decision.updated_input
-            ? {
-                ...entry.approval,
-                toolArgs: JSON.stringify(decision.updated_input),
-              }
-            : entry.approval,
-          reason: decision.message,
-        });
-      } else {
-        decisions.push({
-          type: "deny",
-          approval: entry.approval,
-          reason: decision.message || "Denied via WebSocket",
-        });
-      }
-    } else {
-      decisions.push({
-        type: "deny",
-        approval: entry.approval,
-        reason: approvalResponse.error,
-      });
-    }
-  }
-
-  const scope = {
-    agent_id: recovered.agentId,
-    conversation_id: recovered.conversationId,
-  } as const;
   if (hasInterruptedCacheForScope(runtime.listener, scope)) {
     clearRecoveredApprovalState(runtime);
     emitRuntimeStateUpdates(runtime, scope);
     return true;
   }
-  const approvedDecisions = decisions.filter(
-    (decision): decision is Extract<ApprovalDecision, { type: "approve" }> =>
-      decision.type === "approve",
-  );
-  const approvedToolCallIds = approvedDecisions.map(
-    (decision) => decision.approval.toolCallId,
-  );
 
-  const activeChannelTurn = runtime.activeChannelTurn;
-  if (
-    (!activeChannelTurn || activeChannelTurn.sources.length === 0) &&
-    recovered.agentId
-  ) {
-    const recoveredSources =
-      getChannelRegistry()?.resolveTurnSourcesForScope(
-        recovered.agentId,
-        recovered.conversationId,
-      ) ?? [];
-    if (recoveredSources.length > 0) {
-      recoverActiveChannelTurn(runtime, {
-        sources: recoveredSources,
-        batchId:
-          activeChannelTurn?.batchId ??
-          `recovered-${requestId || crypto.randomUUID()}`,
-        progress: createChannelTurnProgressBuilder(),
-      });
-    }
-  }
-  const shouldFinalizeRecoveredChannelTurn =
-    runtime.activeChannelTurn?.contextRecovered === true;
+  const pendingRequestIdsAfterResponse = [
+    ...recovered.pendingRequestIds,
+  ].filter(
+    (pendingId) =>
+      pendingId !== requestId && !reclassifiedRequestIds.has(pendingId),
+  );
+  const recoveryLease =
+    pendingRequestIdsAfterResponse.length === 0
+      ? runtime.turnLifecycle.begin({
+          origin: "approval_recovery",
+          workingDirectory,
+          initialStatus: "EXECUTING_CLIENT_SIDE_TOOL",
+        })
+      : null;
+  let shouldFinalizeRecoveredChannelTurn = false;
+  let continuationFinalized = false;
 
-  const recoveryLease = runtime.turnLifecycle.begin({
-    origin: "approval_recovery",
-    workingDirectory,
-    initialStatus: "EXECUTING_CLIENT_SIDE_TOOL",
-    executingToolCallIds: approvedToolCallIds,
-  });
-  recovered.pendingRequestIds.clear();
-  emitRuntimeStateUpdates(runtime, scope);
   try {
+    recovered.responsesByRequestId.set(requestId, response);
+    recovered.pendingRequestIds.delete(requestId);
+    if (autoDecisionsToAppend.length > 0) {
+      recovered.autoDecisions = [
+        ...(recovered.autoDecisions ?? []),
+        ...autoDecisionsToAppend,
+      ];
+    }
+    for (const reclassifiedRequestId of reclassifiedRequestIds) {
+      recovered.pendingRequestIds.delete(reclassifiedRequestId);
+      recovered.approvalsByRequestId.delete(reclassifiedRequestId);
+      recovered.responsesByRequestId.delete(reclassifiedRequestId);
+    }
+
+    if (recovered.pendingRequestIds.size > 0) {
+      emitRuntimeStateUpdates(runtime, {
+        agent_id: recovered.agentId,
+        conversation_id: recovered.conversationId,
+      });
+      return true;
+    }
+
+    const decisions: ApprovalDecision[] = [...(recovered.autoDecisions ?? [])];
+    for (const [id, entry] of recovered.approvalsByRequestId) {
+      const approvalResponse = recovered.responsesByRequestId.get(id);
+      if (!approvalResponse) {
+        continue;
+      }
+
+      if ("decision" in approvalResponse) {
+        const decision = approvalResponse.decision;
+        if (decision.behavior === "allow") {
+          decisions.push({
+            type: "approve",
+            approval: decision.updated_input
+              ? {
+                  ...entry.approval,
+                  toolArgs: JSON.stringify(decision.updated_input),
+                }
+              : entry.approval,
+            reason: decision.message,
+          });
+        } else {
+          decisions.push({
+            type: "deny",
+            approval: entry.approval,
+            reason: decision.message || "Denied via WebSocket",
+          });
+        }
+      } else {
+        decisions.push({
+          type: "deny",
+          approval: entry.approval,
+          reason: approvalResponse.error,
+        });
+      }
+    }
+
+    if (!recoveryLease) {
+      throw new Error("Recovered approval continuation has no lifecycle lease");
+    }
+    const approvedDecisions = decisions.filter(
+      (decision): decision is Extract<ApprovalDecision, { type: "approve" }> =>
+        decision.type === "approve",
+    );
+    const approvedToolCallIds = approvedDecisions.map(
+      (decision) => decision.approval.toolCallId,
+    );
+
+    const activeChannelTurn = runtime.activeChannelTurn;
+    if (
+      (!activeChannelTurn || activeChannelTurn.sources.length === 0) &&
+      recovered.agentId
+    ) {
+      const recoveredSources =
+        getChannelRegistry()?.resolveTurnSourcesForScope(
+          recovered.agentId,
+          recovered.conversationId,
+        ) ?? [];
+      if (recoveredSources.length > 0) {
+        recoverActiveChannelTurn(runtime, {
+          sources: recoveredSources,
+          batchId:
+            activeChannelTurn?.batchId ??
+            `recovered-${requestId || crypto.randomUUID()}`,
+          progress: createChannelTurnProgressBuilder(),
+        });
+      }
+    }
+    shouldFinalizeRecoveredChannelTurn =
+      runtime.activeChannelTurn?.contextRecovered === true;
+
+    runtime.turnLifecycle.setExecutingToolCallIds(
+      recoveryLease,
+      approvedToolCallIds,
+    );
+    recovered.pendingRequestIds.clear();
+    emitRuntimeStateUpdates(runtime, scope);
+    const executionRunId = runtime.activeRunId ?? undefined;
+    const executionChannelTurnSources = runtime.activeChannelTurn?.sources;
     emitToolExecutionStartedEvents(socket, runtime, {
       toolCalls: approvedDecisions.map((decision) => ({
         toolCallId: decision.approval.toolCallId,
         toolName: decision.approval.toolName,
         toolArgs: decision.approval.toolArgs,
       })),
-      runId: runtime.activeRunId ?? undefined,
+      runId: executionRunId,
       agentId: recovered.agentId,
       conversationId: recovered.conversationId,
     });
@@ -665,13 +731,17 @@ export async function resolveRecoveredApprovalResponse(
       socket,
       runtime,
       {
-        runId: runtime.activeRunId ?? undefined,
+        runId: executionRunId,
         agentId: recovered.agentId,
         conversationId: recovered.conversationId,
+        shouldEmit: () => runtime.turnLifecycle.isCurrent(recoveryLease),
       },
     );
-    await ensureSecretsHydratedForAgent(runtime.listener, recovered.agentId);
-    const preparedToolContext = await prepareToolExecutionContextForScope({
+    await ensureSecretsHydrated(runtime.listener, recovered.agentId);
+    if (!runtime.turnLifecycle.isCurrent(recoveryLease)) {
+      return true;
+    }
+    const preparedToolContext = await prepareToolExecutionContext({
       agentId: recovered.agentId,
       conversationId: recovered.conversationId,
       workingDirectory,
@@ -682,13 +752,16 @@ export async function resolveRecoveredApprovalResponse(
       ),
       modEvents: ensureListenerModAdapter(runtime.listener).events,
     });
+    if (!runtime.turnLifecycle.isCurrent(recoveryLease)) {
+      return true;
+    }
     runtime.currentToolset = preparedToolContext.toolset;
     runtime.currentToolsetPreference = preparedToolContext.toolsetPreference;
     runtime.currentLoadedTools =
       preparedToolContext.preparedToolContext.loadedToolNames;
     let approvalResults: Awaited<ReturnType<typeof executeApprovalBatch>>;
     try {
-      approvalResults = await executeApprovalBatch(decisions, undefined, {
+      approvalResults = await executeApprovals(decisions, undefined, {
         abortSignal: recoveryLease.signal,
         onStreamingOutput: emitToolExecutionOutput,
         toolContextId: preparedToolContext.preparedToolContext.contextId,
@@ -700,15 +773,18 @@ export async function resolveRecoveredApprovalResponse(
                 conversationId: recovered.conversationId,
               }
             : undefined,
-        channelTurnSources: runtime.activeChannelTurn?.sources,
+        channelTurnSources: executionChannelTurnSources,
       });
     } finally {
       emitToolExecutionOutput.flush();
     }
+    if (!runtime.turnLifecycle.isCurrent(recoveryLease)) {
+      return true;
+    }
 
     emitToolExecutionFinishedEvents(socket, runtime, {
       approvals: approvalResults,
-      runId: runtime.activeRunId ?? undefined,
+      runId: executionRunId,
       agentId: recovered.agentId,
       conversationId: recovered.conversationId,
     });
@@ -716,12 +792,15 @@ export async function resolveRecoveredApprovalResponse(
       socket,
       runtime,
       approvalResults,
-      runtime.activeRunId ?? undefined,
+      executionRunId,
       "tool-return",
     );
 
     runtime.turnLifecycle.setExecutingToolCallIds(recoveryLease, []);
     setTurnLoopStatus(runtime, recoveryLease, "SENDING_API_REQUEST", scope);
+    if (!runtime.turnLifecycle.isCurrent(recoveryLease)) {
+      return true;
+    }
     emitRuntimeStateUpdates(runtime, scope);
 
     const continuationMessages: Array<MessageCreate | ApprovalCreate> = [
@@ -740,6 +819,10 @@ export async function resolveRecoveredApprovalResponse(
       emitDequeuedUserMessage(socket, runtime, queuedTurn, dequeuedBatch);
     }
 
+    if (!runtime.turnLifecycle.isCurrent(recoveryLease)) {
+      return true;
+    }
+
     await processTurn(
       {
         type: "message",
@@ -755,6 +838,14 @@ export async function resolveRecoveredApprovalResponse(
       recoveryLease,
     );
 
+    if (runtime.turnLifecycle.isCurrent(recoveryLease)) {
+      throw new Error("Recovered continuation returned without finalizing");
+    }
+    if (runtime.turnLifecycle.kind !== "idle") {
+      return true;
+    }
+    continuationFinalized = true;
+
     if (shouldFinalizeRecoveredChannelTurn) {
       await finishActiveChannelTurn(runtime, {
         lastStopReason: runtime.lastStopReason,
@@ -765,9 +856,17 @@ export async function resolveRecoveredApprovalResponse(
       });
     }
 
-    clearRecoveredApprovalState(runtime);
+    if (runtime.recoveredApprovalState === recovered) {
+      clearRecoveredApprovalState(runtime);
+    }
     return true;
   } catch (error) {
+    if (!recoveryLease || continuationFinalized) {
+      throw error;
+    }
+    if (!runtime.turnLifecycle.isCurrent(recoveryLease)) {
+      return true;
+    }
     if (shouldFinalizeRecoveredChannelTurn) {
       await finishActiveChannelTurn(runtime, {
         lastStopReason: runtime.lastStopReason,
@@ -776,10 +875,12 @@ export async function resolveRecoveredApprovalResponse(
         runId: runtime.lastTerminalLoopErrorRunId ?? undefined,
       });
     }
-    recovered.pendingRequestIds = new Set(
-      recovered.approvalsByRequestId.keys(),
-    );
-    recovered.responsesByRequestId.clear();
+    if (runtime.recoveredApprovalState === recovered) {
+      recovered.pendingRequestIds = new Set(
+        recovered.approvalsByRequestId.keys(),
+      );
+      recovered.responsesByRequestId.clear();
+    }
     finishListenerTurn(runtime, recoveryLease, {
       stopReason: recoveryLease.signal.aborted ? "cancelled" : "error",
       socket,

--- a/src/websocket/listener/runtime.ts
+++ b/src/websocket/listener/runtime.ts
@@ -7,6 +7,7 @@ import {
   resolveScopedAgentId,
   resolveScopedConversationId,
 } from "./scope";
+import { TurnLifecycle } from "./turn-lifecycle";
 import type {
   ConversationRuntime,
   ListenerRuntime,
@@ -59,8 +60,7 @@ export function evictConversationRuntimeIfIdle(
   runtime: ConversationRuntime,
 ): boolean {
   if (
-    runtime.isProcessing ||
-    runtime.isRecoveringApprovals ||
+    runtime.turnLifecycle.kind !== "idle" ||
     runtime.queuePumpActive ||
     runtime.queuePumpScheduled ||
     runtime.pendingTurns > 0 ||
@@ -69,12 +69,7 @@ export function evictConversationRuntimeIfIdle(
     runtime.recoveredApprovalState !== null ||
     runtime.pendingInterruptedResults !== null ||
     runtime.pendingInterruptedContext !== null ||
-    runtime.activeExecutingToolCallIds.length > 0 ||
     (runtime.pendingInterruptedToolCallIds?.length ?? 0) > 0 ||
-    runtime.activeRunId !== null ||
-    runtime.activeRunStartedAt !== null ||
-    runtime.activeAbortController !== null ||
-    runtime.cancelRequested ||
     runtime.queuedMessagesByItemId.size > 0 ||
     runtime.queueRuntime?.length > 0
   ) {
@@ -108,7 +103,7 @@ export function getListenerStatus(
 ): "idle" | "receiving" | "processing" {
   let hasPendingTurns = false;
   for (const runtime of listener.conversationRuntimes.values()) {
-    if (runtime.isProcessing || runtime.isRecoveringApprovals) {
+    if (runtime.isProcessing) {
       return "processing";
     }
     if (runtime.pendingTurns > 0) {
@@ -154,33 +149,44 @@ export function createConversationRuntime(
     normalizedAgentId,
     normalizedConversationId,
   );
+  const turnLifecycle = new TurnLifecycle();
   const conversationRuntime: ConversationRuntime = {
     listener,
     key: runtimeKey,
     agentId: normalizedAgentId,
     conversationId: normalizedConversationId,
     activeChannelTurn: null,
+    turnLifecycle,
     messageQueue: Promise.resolve(),
     pendingApprovalResolvers: new Map(),
     recoveredApprovalState: null,
-    lastStopReason: null,
+    get lastStopReason() {
+      return turnLifecycle.lastStopReason;
+    },
     lastTerminalLoopErrorMessage: null,
     lastTerminalLoopErrorRunId: null,
-    isProcessing: false,
-    activeWorkingDirectory: null,
+    get isProcessing() {
+      return turnLifecycle.isProcessing;
+    },
+    get activeWorkingDirectory() {
+      return turnLifecycle.activeWorkingDirectory;
+    },
     expectedWorktreePath: null,
     expectedWorktreeExpiresAt: null,
-    activeRunId: null,
-    activeRunStartedAt: null,
-    activeAbortController: null,
-    cancelRequested: false,
+    get activeRunId() {
+      return turnLifecycle.activeRunId;
+    },
+    get cancelRequested() {
+      return turnLifecycle.cancelRequested;
+    },
     queueRuntime: null as unknown as ConversationRuntime["queueRuntime"],
     queuedMessagesByItemId: new Map(),
     queuePumpActive: false,
     queuePumpScheduled: false,
     pendingTurns: 0,
-    isRecoveringApprovals: false,
-    loopStatus: "WAITING_ON_INPUT",
+    get loopStatus() {
+      return turnLifecycle.loopStatus;
+    },
     currentToolset: null,
     currentToolsetPreference: "auto",
     currentLoadedTools: [],
@@ -188,7 +194,6 @@ export function createConversationRuntime(
     pendingInterruptedResults: null,
     pendingInterruptedContext: null,
     continuationEpoch: 0,
-    activeExecutingToolCallIds: [],
     pendingInterruptedToolCallIds: null,
     reminderState:
       listener.reminderStateByConversation.get(runtimeKey) ??
@@ -235,13 +240,6 @@ export function getOrCreateConversationRuntime(
   );
 }
 
-export function clearActiveRunState(runtime: ConversationRuntime): void {
-  runtime.activeWorkingDirectory = null;
-  runtime.activeRunId = null;
-  runtime.activeRunStartedAt = null;
-  runtime.activeAbortController = null;
-}
-
 export function clearRecoveredApprovalState(
   runtime: ConversationRuntime,
 ): void {
@@ -252,24 +250,15 @@ export function clearRecoveredApprovalState(
 export function clearConversationRuntimeState(
   runtime: ConversationRuntime,
 ): void {
-  runtime.cancelRequested = true;
-  if (
-    runtime.activeAbortController &&
-    !runtime.activeAbortController.signal.aborted
-  ) {
-    runtime.activeAbortController.abort();
-  }
+  runtime.turnLifecycle.reset("cancelled");
   runtime.pendingApprovalBatchByToolCallId.clear();
   runtime.pendingInterruptedResults = null;
   runtime.pendingInterruptedContext = null;
   runtime.pendingInterruptedToolCallIds = null;
-  runtime.activeExecutingToolCallIds = [];
-  runtime.loopStatus = "WAITING_ON_INPUT";
   runtime.continuationEpoch += 1;
   runtime.pendingTurns = 0;
   runtime.queuePumpActive = false;
   runtime.queuePumpScheduled = false;
-  clearActiveRunState(runtime);
 }
 
 export function getRecoveredApprovalStateForScope(

--- a/src/websocket/listener/runtime.ts
+++ b/src/websocket/listener/runtime.ts
@@ -7,6 +7,7 @@ import {
   resolveScopedAgentId,
   resolveScopedConversationId,
 } from "./scope";
+import { releaseListenerTurnContext } from "./turn-context";
 import { TurnLifecycle } from "./turn-lifecycle";
 import type {
   ConversationRuntime,
@@ -251,6 +252,11 @@ export function clearConversationRuntimeState(
   runtime: ConversationRuntime,
 ): void {
   runtime.turnLifecycle.reset("cancelled");
+  releaseListenerTurnContext({
+    runtime,
+    agentId: runtime.agentId,
+    conversationId: runtime.conversationId,
+  });
   runtime.pendingApprovalBatchByToolCallId.clear();
   runtime.pendingInterruptedResults = null;
   runtime.pendingInterruptedContext = null;

--- a/src/websocket/listener/send-lease.test.ts
+++ b/src/websocket/listener/send-lease.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { getOrCreateScopedRuntime } from "./conversation-runtime";
+import { enqueueInboundUserMessage } from "./inbound-queue";
+import { createRuntime } from "./lifecycle";
+import { clearConversationRuntimeState } from "./runtime";
+import { resolveStaleApprovals } from "./send";
+import type { ListenerTransport } from "./transport";
+
+function createTransport(): ListenerTransport {
+  return {
+    kind: "local",
+    bufferedAmount: 0,
+    isOpen: () => true,
+    send: () => {},
+  };
+}
+
+function createPreparedToolContext() {
+  return {
+    toolset: "codex",
+    toolsetPreference: "auto",
+    preparedToolContext: {
+      contextId: "context-1",
+      loadedToolNames: [],
+      clientTools: [],
+      clientSkills: [],
+    },
+  } as never;
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await Bun.sleep(1);
+  }
+  throw new Error("Timed out waiting for stale approval preparation");
+}
+
+describe("pre-stream recovery lease boundaries", () => {
+  test("a reset during tool preparation cannot consume replacement input", async () => {
+    const runtime = getOrCreateScopedRuntime(
+      createRuntime(),
+      "agent-1",
+      "conv-1",
+    );
+    const staleLease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+      initialStatus: "WAITING_FOR_API_RESPONSE",
+    });
+    let preparationStarted = false;
+    let finishPreparation!: (value: never) => void;
+    const preparation = new Promise<never>((resolve) => {
+      finishPreparation = resolve;
+    });
+    const approval = {
+      toolCallId: "call-1",
+      toolName: "Bash",
+      toolArgs: '{"command":"pwd"}',
+    };
+    const recovery = resolveStaleApprovals(
+      runtime,
+      createTransport(),
+      staleLease,
+      {
+        retrieveAgent: async () => ({ id: "agent-1" }) as never,
+        getResumeData: async () => ({
+          pendingApproval: approval,
+          pendingApprovals: [approval],
+          messageHistory: [],
+        }),
+        prepareToolExecutionContext: (async () => {
+          preparationStarted = true;
+          return preparation;
+        }) as never,
+      },
+    );
+    await waitFor(() => preparationStarted);
+
+    clearConversationRuntimeState(runtime);
+    const replacementLease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+    });
+    enqueueInboundUserMessage(runtime, {
+      type: "message",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      messages: [{ role: "user", content: "replacement input" }],
+    });
+    finishPreparation(createPreparedToolContext());
+
+    await expect(recovery).rejects.toThrow(/Cancelled/);
+    expect(runtime.turnLifecycle.isCurrent(replacementLease)).toBe(true);
+    expect(runtime.currentToolset).toBeNull();
+    expect(runtime.queueRuntime.length).toBe(1);
+    expect(runtime.queuedMessagesByItemId.size).toBe(1);
+  });
+});

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -58,6 +58,7 @@ type MessageStreamResult = Awaited<ReturnType<typeof sendMessageStream>>;
 type RecoveryDrainResult = Awaited<
   ReturnType<typeof drainRecoveryStreamWithEmission>
 >;
+type RetrieveAgent = ReturnType<typeof getBackend>["retrieveAgent"];
 export type ApprovalContinuationSendResult =
   | { kind: "stream"; stream: NonNullable<MessageStreamResult> }
   | { kind: "terminal"; drainResult: RecoveryDrainResult };
@@ -281,22 +282,39 @@ export async function resolveStaleApprovals(
   turnLease: TurnLease,
   deps: {
     getResumeData?: typeof getResumeDataFromBackend;
+    retrieveAgent?: RetrieveAgent;
+    prepareToolExecutionContext?: typeof prepareToolExecutionContextForScope;
   } = {},
 ): Promise<Awaited<ReturnType<typeof drainRecoveryStreamWithEmission>> | null> {
   if (!runtime.agentId) return null;
 
   const getResumeDataImpl = deps.getResumeData ?? getResumeDataFromBackend;
+  const prepareToolExecutionContext =
+    deps.prepareToolExecutionContext ?? prepareToolExecutionContextForScope;
+  const assertCurrentTurnLease = () => {
+    if (
+      turnLease.signal.aborted ||
+      !runtime.turnLifecycle.isCurrent(turnLease)
+    ) {
+      throw new Error("Cancelled by user");
+    }
+  };
 
+  assertCurrentTurnLease();
   const backend = getBackend();
   let agent: Awaited<ReturnType<typeof backend.retrieveAgent>>;
   try {
-    agent = await backend.retrieveAgent(runtime.agentId);
+    agent = await (deps.retrieveAgent
+      ? deps.retrieveAgent(runtime.agentId)
+      : backend.retrieveAgent(runtime.agentId));
   } catch (err) {
+    assertCurrentTurnLease();
     if (isBackendNotFoundError(err)) {
       return null;
     }
     throw err;
   }
+  assertCurrentTurnLease();
   const requestedConversationId =
     runtime.conversationId !== "default" ? runtime.conversationId : undefined;
 
@@ -306,15 +324,16 @@ export async function resolveStaleApprovals(
       includeMessageHistory: false,
     });
   } catch (err) {
+    assertCurrentTurnLease();
     if (isBackendNotFoundError(err)) {
       return null;
     }
     throw err;
   }
+  assertCurrentTurnLease();
 
   let pendingApprovals = resumeData.pendingApprovals || [];
   if (pendingApprovals.length === 0) return null;
-  if (turnLease.signal.aborted) throw new Error("Cancelled");
 
   const recoveryConversationId = runtime.conversationId;
   const recoveryWorkingDirectory =
@@ -328,7 +347,7 @@ export async function resolveStaleApprovals(
     agent_id: runtime.agentId,
     conversation_id: recoveryConversationId,
   } as const;
-  const preparedToolContext = await prepareToolExecutionContextForScope({
+  const preparedToolContext = await prepareToolExecutionContext({
     agentId: runtime.agentId,
     conversationId: recoveryConversationId,
     workingDirectory: recoveryWorkingDirectory,
@@ -339,12 +358,14 @@ export async function resolveStaleApprovals(
     ),
     modEvents: ensureListenerModAdapter(runtime.listener).events,
   });
+  assertCurrentTurnLease();
   runtime.currentToolset = preparedToolContext.toolset;
   runtime.currentToolsetPreference = preparedToolContext.toolsetPreference;
   runtime.currentLoadedTools =
     preparedToolContext.preparedToolContext.loadedToolNames;
 
   while (pendingApprovals.length > 0) {
+    assertCurrentTurnLease();
     const recoveryBatchId = resolveRecoveryBatchId(runtime, pendingApprovals);
     if (!recoveryBatchId) {
       throw new Error(
@@ -393,6 +414,7 @@ export async function resolveStaleApprovals(
         turnLease,
         { allowApprovalRecovery: false },
       );
+      assertCurrentTurnLease();
       if (recoverySendResult.kind !== "stream") {
         throw new Error(
           "Approval recovery send resolved without a continuation stream",
@@ -412,6 +434,7 @@ export async function resolveStaleApprovals(
           turnLease,
         },
       );
+      assertCurrentTurnLease();
 
       if (drainResult.stopReason === "error") {
         throw new Error("Pre-stream approval recovery drain ended with error");

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -33,11 +33,7 @@ import {
 import { getConversationWorkingDirectory } from "./cwd";
 import { ensureListenerModAdapter } from "./mod-adapter";
 import { getOrCreateConversationPermissionModeStateRef } from "./permission-mode";
-import {
-  emitDequeuedUserMessage,
-  emitRetryDelta,
-  setLoopStatus,
-} from "./protocol-outbound";
+import { emitDequeuedUserMessage, emitRetryDelta } from "./protocol-outbound";
 import {
   maybeApplyProviderFallback,
   type ProviderFallbackState,
@@ -46,12 +42,12 @@ import { consumeQueuedTurn } from "./queue";
 import { emitRecoverableRetryNotice } from "./recoverable-notices";
 import {
   drainRecoveryStreamWithEmission,
-  finalizeHandledRecoveryTurn,
-  getApprovalContinuationRecoveryDisposition,
   isApprovalToolCallDesyncError,
 } from "./recovery";
 import { injectQueuedSkillContent } from "./skill-injection";
 import type { ListenerTransport } from "./transport";
+import type { TurnLease } from "./turn-lifecycle";
+import { setTurnLoopStatus } from "./turn-status";
 import type { ConversationRuntime } from "./types";
 
 const ACTIVE_BLOCKING_RUN_STATUSES = new Set(["created", "running"]);
@@ -59,6 +55,12 @@ const BUSY_RUN_WAIT_TIMEOUT_MS = 5 * 60 * 1000;
 const BUSY_RUN_POLL_INTERVAL_MS = 5000;
 
 type MessageStreamResult = Awaited<ReturnType<typeof sendMessageStream>>;
+type RecoveryDrainResult = Awaited<
+  ReturnType<typeof drainRecoveryStreamWithEmission>
+>;
+export type ApprovalContinuationSendResult =
+  | { kind: "stream"; stream: NonNullable<MessageStreamResult> }
+  | { kind: "terminal"; drainResult: RecoveryDrainResult };
 type BlockingRunWaitResult = "settled" | "timed_out" | "unavailable";
 
 export function isApprovalOnlyInput(
@@ -74,10 +76,11 @@ export function isApprovalOnlyInput(
 
 export function markAwaitingAcceptedApprovalContinuationRunId(
   runtime: ConversationRuntime,
+  turnLease: TurnLease,
   input: Array<MessageCreate | ApprovalCreate>,
 ): void {
   if (isApprovalOnlyInput(input)) {
-    runtime.activeRunId = null;
+    runtime.turnLifecycle.setRunId(turnLease, null);
   }
 }
 
@@ -275,7 +278,7 @@ async function tryResumeBusyConversationStream(params: {
 export async function resolveStaleApprovals(
   runtime: ConversationRuntime,
   socket: ListenerTransport,
-  abortSignal: AbortSignal,
+  turnLease: TurnLease,
   deps: {
     getResumeData?: typeof getResumeDataFromBackend;
   } = {},
@@ -311,7 +314,7 @@ export async function resolveStaleApprovals(
 
   let pendingApprovals = resumeData.pendingApprovals || [];
   if (pendingApprovals.length === 0) return null;
-  if (abortSignal.aborted) throw new Error("Cancelled");
+  if (turnLease.signal.aborted) throw new Error("Cancelled");
 
   const recoveryConversationId = runtime.conversationId;
   const recoveryWorkingDirectory =
@@ -375,7 +378,7 @@ export async function resolveStaleApprovals(
 
       const continuationMessagesWithSkillContent =
         injectQueuedSkillContent(continuationMessages);
-      const recoveryStream = await sendApprovalContinuationWithRetry(
+      const recoverySendResult = await sendApprovalContinuationWithRetry(
         recoveryConversationId,
         continuationMessagesWithSkillContent,
         {
@@ -387,16 +390,17 @@ export async function resolveStaleApprovals(
         },
         socket,
         runtime,
-        abortSignal,
+        turnLease,
         { allowApprovalRecovery: false },
       );
-      if (!recoveryStream) {
+      if (recoverySendResult.kind !== "stream") {
         throw new Error(
           "Approval recovery send resolved without a continuation stream",
         );
       }
+      const recoveryStream = recoverySendResult.stream;
 
-      setLoopStatus(runtime, "PROCESSING_API_RESPONSE", scope);
+      setTurnLoopStatus(runtime, turnLease, "PROCESSING_API_RESPONSE", scope);
 
       const drainResult = await drainRecoveryStreamWithEmission(
         recoveryStream as Stream<LettaStreamingResponse>,
@@ -405,7 +409,7 @@ export async function resolveStaleApprovals(
         {
           agentId: runtime.agentId ?? undefined,
           conversationId: recoveryConversationId,
-          abortSignal,
+          turnLease,
         },
       );
 
@@ -417,7 +421,7 @@ export async function resolveStaleApprovals(
       }
       pendingApprovals = drainResult.approvals || [];
     } finally {
-      runtime.activeExecutingToolCallIds = [];
+      runtime.turnLifecycle.setExecutingToolCallIds(turnLease, []);
     }
   }
 
@@ -434,11 +438,12 @@ export async function sendMessageStreamWithRetry(
   opts: Parameters<typeof sendMessageStream>[2],
   socket: ListenerTransport,
   runtime: ConversationRuntime,
-  abortSignal?: AbortSignal,
+  turnLease: TurnLease,
   retryOptions: {
     providerFallback?: ProviderFallbackState;
   } = {},
 ): Promise<Awaited<ReturnType<typeof sendMessageStream>>> {
+  const abortSignal = turnLease.signal;
   let transientRetries = 0;
   let conversationBusyRetries = 0;
   let preStreamRecoveryAttempts = 0;
@@ -451,8 +456,7 @@ export async function sendMessageStreamWithRetry(
     if (abortSignal?.aborted) {
       throw new Error("Cancelled by user");
     }
-    runtime.isRecoveringApprovals = false;
-    setLoopStatus(runtime, "WAITING_FOR_API_RESPONSE", {
+    setTurnLoopStatus(runtime, turnLease, "WAITING_FOR_API_RESPONSE", {
       agent_id: runtime.agentId,
       conversation_id: conversationId,
     });
@@ -491,8 +495,7 @@ export async function sendMessageStreamWithRetry(
         isApprovalToolCallDesyncError(errorDetail);
 
       if (approvalConflictDetected) {
-        runtime.isRecoveringApprovals = true;
-        setLoopStatus(runtime, "RETRYING_API_REQUEST", {
+        setTurnLoopStatus(runtime, turnLease, "RETRYING_API_REQUEST", {
           agent_id: runtime.agentId,
           conversation_id: conversationId,
         });
@@ -504,7 +507,7 @@ export async function sendMessageStreamWithRetry(
         ) {
           preStreamRecoveryAttempts++;
           try {
-            await resolveStaleApprovals(runtime, socket, abortSignal);
+            await resolveStaleApprovals(runtime, socket, turnLease);
             continue;
           } catch (_recoveryError) {
             if (abortSignal.aborted) throw new Error("Cancelled by user");
@@ -523,8 +526,7 @@ export async function sendMessageStreamWithRetry(
       }
 
       if (action === "retry_transient") {
-        runtime.isRecoveringApprovals = true;
-        setLoopStatus(runtime, "RETRYING_API_REQUEST", {
+        setTurnLoopStatus(runtime, turnLease, "RETRYING_API_REQUEST", {
           agent_id: runtime.agentId,
           conversation_id: conversationId,
         });
@@ -585,8 +587,7 @@ export async function sendMessageStreamWithRetry(
       const blockingRunId = extractConversationBusyRunId(errorDetail);
 
       if (action === "retry_conversation_busy" || blockingRunId) {
-        runtime.isRecoveringApprovals = true;
-        setLoopStatus(runtime, "RETRYING_API_REQUEST", {
+        setTurnLoopStatus(runtime, turnLease, "RETRYING_API_REQUEST", {
           agent_id: runtime.agentId,
           conversation_id: conversationId,
         });
@@ -653,12 +654,13 @@ export async function sendApprovalContinuationWithRetry(
   opts: Parameters<typeof sendMessageStream>[2],
   socket: ListenerTransport,
   runtime: ConversationRuntime,
-  abortSignal?: AbortSignal,
+  turnLease: TurnLease,
   retryOptions: {
     allowApprovalRecovery?: boolean;
     providerFallback?: ProviderFallbackState;
   } = {},
-): Promise<Awaited<ReturnType<typeof sendMessageStream>> | null> {
+): Promise<ApprovalContinuationSendResult> {
+  const abortSignal = turnLease.signal;
   const allowApprovalRecovery = retryOptions.allowApprovalRecovery ?? true;
   let transientRetries = 0;
   let conversationBusyRetries = 0;
@@ -672,14 +674,13 @@ export async function sendApprovalContinuationWithRetry(
     if (abortSignal?.aborted) {
       throw new Error("Cancelled by user");
     }
-    runtime.isRecoveringApprovals = false;
-    setLoopStatus(runtime, "WAITING_FOR_API_RESPONSE", {
+    setTurnLoopStatus(runtime, turnLease, "WAITING_FOR_API_RESPONSE", {
       agent_id: runtime.agentId,
       conversation_id: conversationId,
     });
 
     try {
-      return await sendMessageStream(
+      const stream = await sendMessageStream(
         conversationId,
         messages,
         currentOpts,
@@ -687,6 +688,7 @@ export async function sendApprovalContinuationWithRetry(
           ? { maxRetries: 0, signal: abortSignal }
           : { maxRetries: 0 },
       );
+      return { kind: "stream", stream };
     } catch (preStreamError) {
       if (abortSignal?.aborted) {
         throw new Error("Cancelled by user");
@@ -712,8 +714,7 @@ export async function sendApprovalContinuationWithRetry(
         isApprovalToolCallDesyncError(errorDetail);
 
       if (approvalConflictDetected) {
-        runtime.isRecoveringApprovals = true;
-        setLoopStatus(runtime, "RETRYING_API_REQUEST", {
+        setTurnLoopStatus(runtime, turnLease, "RETRYING_API_REQUEST", {
           agent_id: runtime.agentId,
           conversation_id: conversationId,
         });
@@ -727,19 +728,10 @@ export async function sendApprovalContinuationWithRetry(
           const drainResult = await resolveStaleApprovals(
             runtime,
             socket,
-            abortSignal,
+            turnLease,
           );
-          if (
-            drainResult &&
-            getApprovalContinuationRecoveryDisposition(drainResult) ===
-              "handled"
-          ) {
-            finalizeHandledRecoveryTurn(runtime, socket, {
-              drainResult,
-              agentId: runtime.agentId ?? undefined,
-              conversationId,
-            });
-            return null;
+          if (drainResult) {
+            return { kind: "terminal", drainResult };
           }
           continue;
         }
@@ -756,8 +748,7 @@ export async function sendApprovalContinuationWithRetry(
       }
 
       if (action === "retry_transient") {
-        runtime.isRecoveringApprovals = true;
-        setLoopStatus(runtime, "RETRYING_API_REQUEST", {
+        setTurnLoopStatus(runtime, turnLease, "RETRYING_API_REQUEST", {
           agent_id: runtime.agentId,
           conversation_id: conversationId,
         });
@@ -823,8 +814,7 @@ export async function sendApprovalContinuationWithRetry(
         if (retryBudgetAvailable) {
           conversationBusyRetries = attempt;
         }
-        runtime.isRecoveringApprovals = true;
-        setLoopStatus(runtime, "RETRYING_API_REQUEST", {
+        setTurnLoopStatus(runtime, turnLease, "RETRYING_API_REQUEST", {
           agent_id: runtime.agentId,
           conversation_id: conversationId,
         });
@@ -838,7 +828,7 @@ export async function sendApprovalContinuationWithRetry(
             "[Listen] Approval continuation pre-stream resume failed, falling back to wait/retry:",
         });
         if (resumeStream) {
-          return resumeStream;
+          return { kind: "stream", stream: resumeStream };
         }
 
         const retryDelayMs = getRetryDelayMs({

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -40,24 +40,24 @@ import {
   emitToolExecutionFinishedEvents,
   emitToolExecutionStartedEvents,
   normalizeExecutionResultsForInterruptParity,
-  populateInterruptQueue,
 } from "./interrupts";
 import {
   emitDequeuedUserMessage,
   emitRuntimeStateUpdates,
-  setLoopStatus,
 } from "./protocol-outbound";
 import type { ProviderFallbackState } from "./provider-fallback";
 import { consumeQueuedTurn } from "./queue";
-import { emitLoopErrorNotice } from "./recoverable-notices";
 import { debugLogApprovalResumeState } from "./recovery";
 import { ensureSecretsHydratedForAgent } from "./secrets-sync";
 import {
+  type ApprovalContinuationSendResult,
   markAwaitingAcceptedApprovalContinuationRunId,
   sendApprovalContinuationWithRetry,
 } from "./send";
 import { injectQueuedSkillContent } from "./skill-injection";
 import { isListenerTransportOpen, type ListenerTransport } from "./transport";
+import type { TurnLease } from "./turn-lifecycle";
+import { setTurnLoopStatus } from "./turn-status";
 import type { ConversationRuntime } from "./types";
 
 type Decision =
@@ -80,9 +80,7 @@ type Decision =
       reason: string;
     };
 
-export type ApprovalBranchResult = {
-  terminated: boolean;
-  stream: Stream<LettaStreamingResponse> | null;
+type ApprovalBranchProgress = {
   currentInput: Array<MessageCreate | ApprovalCreate>;
   dequeuedBatchId: string;
   pendingNormalizationInterruptedToolCallIds: string[];
@@ -92,6 +90,21 @@ export type ApprovalBranchResult = {
   lastNeedsUserInputToolCallIds: string[];
   lastApprovalContinuationAccepted: boolean;
 };
+
+export type ApprovalBranchResult =
+  | ({
+      kind: "continue";
+      stream: Stream<LettaStreamingResponse>;
+    } & ApprovalBranchProgress)
+  | ({ kind: "interrupted" } & ApprovalBranchProgress)
+  | ({
+      kind: "terminal";
+      drainResult: Extract<
+        ApprovalContinuationSendResult,
+        { kind: "terminal" }
+      >["drainResult"];
+    } & ApprovalBranchProgress)
+  | { kind: "error"; message: string };
 
 function getChannelApprovalSourceScopeKey(source: ChannelTurnSource): string {
   return [
@@ -140,6 +153,7 @@ export async function handleApprovalStop(params: {
   currentInput: Array<MessageCreate | ApprovalCreate>;
   pendingNormalizationInterruptedToolCallIds: string[];
   turnToolContextId: string | null;
+  turnLease: TurnLease;
   buildSendOptions: () => Parameters<
     typeof sendApprovalContinuationWithRetry
   >[2];
@@ -158,49 +172,16 @@ export async function handleApprovalStop(params: {
     msgRunIds,
     currentInput,
     turnToolContextId,
+    turnLease,
     buildSendOptions,
     providerFallback,
   } = params;
-  const abortController = runtime.activeAbortController;
-
-  if (!abortController) {
-    throw new Error("Missing active abort controller during approval handling");
-  }
+  const abortSignal = turnLease.signal;
 
   if (approvals.length === 0) {
-    runtime.lastStopReason = "error";
-    runtime.isProcessing = false;
-    setLoopStatus(runtime, "WAITING_ON_INPUT", {
-      agent_id: agentId,
-      conversation_id: conversationId,
-    });
-    runtime.activeWorkingDirectory = null;
-    runtime.activeRunId = null;
-    runtime.activeRunStartedAt = null;
-    runtime.activeAbortController = null;
-    emitRuntimeStateUpdates(runtime, {
-      agent_id: agentId,
-      conversation_id: conversationId,
-    });
-
-    emitLoopErrorNotice(socket, runtime, {
-      message: "requires_approval stop returned no approvals",
-      stopReason: "error",
-      isTerminal: true,
-      agentId,
-      conversationId,
-    });
     return {
-      terminated: true,
-      stream: null,
-      currentInput,
-      dequeuedBatchId,
-      pendingNormalizationInterruptedToolCallIds: [],
-      turnToolContextId,
-      lastExecutionResults: null,
-      lastExecutingToolCallIds: [],
-      lastNeedsUserInputToolCallIds: [],
-      lastApprovalContinuationAccepted: false,
+      kind: "error",
+      message: "requires_approval stop returned no approvals",
     };
   }
 
@@ -228,22 +209,14 @@ export async function handleApprovalStop(params: {
   let lastExecutingToolCallIds: string[] = [];
 
   const shouldInterrupt = () =>
-    abortController.signal.aborted || runtime.cancelRequested;
+    abortSignal.aborted || !runtime.turnLifecycle.isCurrent(turnLease);
 
   const interruptTermination = (
     interruptedInput: Array<MessageCreate | ApprovalCreate> = currentInput,
     interruptedBatchId: string = dequeuedBatchId,
   ): ApprovalBranchResult => {
-    populateInterruptQueue(runtime, {
-      lastExecutionResults,
-      lastExecutingToolCallIds,
-      lastNeedsUserInputToolCallIds,
-      agentId: agentId || "",
-      conversationId,
-    });
     return {
-      terminated: true,
-      stream: null,
+      kind: "interrupted",
       currentInput: interruptedInput,
       dequeuedBatchId: interruptedBatchId,
       pendingNormalizationInterruptedToolCallIds: [],
@@ -428,8 +401,11 @@ export async function handleApprovalStop(params: {
   lastExecutingToolCallIds = approvedDecisions.map(
     (decision) => decision.approval.toolCallId,
   );
-  runtime.activeExecutingToolCallIds = [...lastExecutingToolCallIds];
-  setLoopStatus(runtime, "EXECUTING_CLIENT_SIDE_TOOL", {
+  runtime.turnLifecycle.setExecutingToolCallIds(
+    turnLease,
+    lastExecutingToolCallIds,
+  );
+  setTurnLoopStatus(runtime, turnLease, "EXECUTING_CLIENT_SIDE_TOOL", {
     agent_id: agentId,
     conversation_id: conversationId,
   });
@@ -487,7 +463,7 @@ export async function handleApprovalStop(params: {
     }
     executionResults = await executeApprovalBatch(decisions, undefined, {
       toolContextId: turnToolContextId ?? undefined,
-      abortSignal: abortController.signal,
+      abortSignal,
       onStreamingOutput: emitToolExecutionOutput,
       workingDirectory: turnWorkingDirectory,
       parentScope:
@@ -555,13 +531,13 @@ export async function handleApprovalStop(params: {
     return interruptTermination(nextInputWithSkillContent, continuationBatchId);
   }
 
-  setLoopStatus(runtime, "SENDING_API_REQUEST", {
+  setTurnLoopStatus(runtime, turnLease, "SENDING_API_REQUEST", {
     agent_id: agentId,
     conversation_id: conversationId,
   });
-  let stream: Stream<LettaStreamingResponse> | null;
+  let sendResult: ApprovalContinuationSendResult;
   try {
-    stream = await sendApprovalContinuationWithRetry(
+    sendResult = await sendApprovalContinuationWithRetry(
       conversationId,
       nextInputWithSkillContent,
       {
@@ -572,7 +548,7 @@ export async function handleApprovalStop(params: {
       },
       socket,
       runtime,
-      abortController.signal,
+      turnLease,
       { providerFallback },
     );
   } catch (error) {
@@ -584,10 +560,10 @@ export async function handleApprovalStop(params: {
     }
     throw error;
   }
-  if (!stream) {
+  if (sendResult.kind === "terminal") {
     return {
-      terminated: true,
-      stream: null,
+      kind: "terminal",
+      drainResult: sendResult.drainResult,
       currentInput: nextInputWithSkillContent,
       dequeuedBatchId: continuationBatchId,
       pendingNormalizationInterruptedToolCallIds: [],
@@ -598,6 +574,7 @@ export async function handleApprovalStop(params: {
       lastApprovalContinuationAccepted: false,
     };
   }
+  const stream = sendResult.stream;
 
   clearPendingApprovalBatchIds(
     runtime,
@@ -617,20 +594,20 @@ export async function handleApprovalStop(params: {
       persistedExecutionResults,
     ),
   });
-  markAwaitingAcceptedApprovalContinuationRunId(runtime, nextInput);
-  setLoopStatus(runtime, "PROCESSING_API_RESPONSE", {
+  markAwaitingAcceptedApprovalContinuationRunId(runtime, turnLease, nextInput);
+  setTurnLoopStatus(runtime, turnLease, "PROCESSING_API_RESPONSE", {
     agent_id: agentId,
     conversation_id: conversationId,
   });
 
-  runtime.activeExecutingToolCallIds = [];
+  runtime.turnLifecycle.setExecutingToolCallIds(turnLease, []);
   emitRuntimeStateUpdates(runtime, {
     agent_id: agentId,
     conversation_id: conversationId,
   });
 
   return {
-    terminated: false,
+    kind: "continue",
     stream,
     currentInput: nextInputWithSkillContent,
     dequeuedBatchId: continuationBatchId,

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -158,6 +158,11 @@ export async function handleApprovalStop(params: {
     typeof sendApprovalContinuationWithRetry
   >[2];
   providerFallback?: ProviderFallbackState;
+  dependencies?: {
+    classifyApprovals?: typeof classifyApprovalsWithSuggestions;
+    executeApprovalBatch?: typeof executeApprovalBatch;
+    ensureSecretsHydrated?: typeof ensureSecretsHydratedForAgent;
+  };
 }): Promise<ApprovalBranchResult> {
   const {
     approvals,
@@ -175,8 +180,15 @@ export async function handleApprovalStop(params: {
     turnLease,
     buildSendOptions,
     providerFallback,
+    dependencies,
   } = params;
   const abortSignal = turnLease.signal;
+  const classifyApprovals =
+    dependencies?.classifyApprovals ?? classifyApprovalsWithSuggestions;
+  const executeApprovals =
+    dependencies?.executeApprovalBatch ?? executeApprovalBatch;
+  const ensureSecretsHydrated =
+    dependencies?.ensureSecretsHydrated ?? ensureSecretsHydratedForAgent;
 
   if (approvals.length === 0) {
     return {
@@ -188,8 +200,9 @@ export async function handleApprovalStop(params: {
   clearPendingApprovalBatchIds(runtime, approvals);
   rememberPendingApprovalBatchIds(runtime, approvals, dequeuedBatchId);
 
-  const { autoAllowed, autoDenied, needsUserInput } =
-    await classifyApprovalsWithSuggestions(approvals, {
+  const { autoAllowed, autoDenied, needsUserInput } = await classifyApprovals(
+    approvals,
+    {
       alwaysRequiresUserInput: isInteractiveApprovalTool,
       treatAskAsDeny: false,
       requireArgsForAutoApprove: true,
@@ -198,7 +211,8 @@ export async function handleApprovalStop(params: {
       permissionModeState: turnPermissionModeState,
       agentId,
       toolContextId: turnToolContextId ?? undefined,
-    });
+    },
+  );
   const continuationWasFullyAutoHandled = needsUserInput.length === 0;
 
   let pendingNeedsUserInput = [...needsUserInput];
@@ -296,6 +310,10 @@ export async function handleApprovalStop(params: {
           toolName: ac.approval.toolName,
           input: ac.parsedArgs,
         });
+        if (shouldInterrupt()) {
+          registry.clearPendingControlRequest(requestId);
+          return interruptTermination();
+        }
       }
 
       let responseBody: ApprovalResponseBody;
@@ -303,6 +321,7 @@ export async function handleApprovalStop(params: {
         responseBody = await requestApprovalOverWS(
           runtime,
           socket,
+          turnLease,
           requestId,
           controlRequest,
         );
@@ -432,6 +451,7 @@ export async function handleApprovalStop(params: {
       runId: executionRunId,
       agentId,
       conversationId,
+      shouldEmit: () => runtime.turnLifecycle.isCurrent(turnLease),
     },
   );
 
@@ -442,7 +462,10 @@ export async function handleApprovalStop(params: {
   // Broadcast new file content to web clients when a file-mutating tool
   // (Edit, Write, MultiEdit) writes to disk, so all windows update immediately.
   const onFileWrite = (filePath: string, content: string) => {
-    if (isListenerTransportOpen(socket)) {
+    if (
+      runtime.turnLifecycle.isCurrent(turnLease) &&
+      isListenerTransportOpen(socket)
+    ) {
       socket.send(
         JSON.stringify({
           type: "file_ops",
@@ -459,9 +482,12 @@ export async function handleApprovalStop(params: {
   let executionResults: Awaited<ReturnType<typeof executeApprovalBatch>>;
   try {
     if (agentId) {
-      await ensureSecretsHydratedForAgent(runtime.listener, agentId);
+      await ensureSecretsHydrated(runtime.listener, agentId);
     }
-    executionResults = await executeApprovalBatch(decisions, undefined, {
+    if (shouldInterrupt()) {
+      return interruptTermination();
+    }
+    executionResults = await executeApprovals(decisions, undefined, {
       toolContextId: turnToolContextId ?? undefined,
       abortSignal,
       onStreamingOutput: emitToolExecutionOutput,
@@ -473,6 +499,9 @@ export async function handleApprovalStop(params: {
     });
   } finally {
     emitToolExecutionOutput.flush();
+  }
+  if (!runtime.turnLifecycle.isCurrent(turnLease)) {
+    return interruptTermination();
   }
   const persistedExecutionResults = normalizeExecutionResultsForInterruptParity(
     runtime,
@@ -498,10 +527,7 @@ export async function handleApprovalStop(params: {
     socket,
     runtime,
     persistedExecutionResults,
-    runtime.activeRunId ||
-      runId ||
-      msgRunIds[msgRunIds.length - 1] ||
-      undefined,
+    executionRunId,
     "tool-return",
   );
 

--- a/src/websocket/listener/turn-cleanup.ts
+++ b/src/websocket/listener/turn-cleanup.ts
@@ -1,0 +1,72 @@
+import {
+  getConversationId,
+  getCurrentAgentId,
+  setConversationId,
+  setCurrentAgentId,
+} from "@/agent/context";
+import { runPostTurnMemorySync } from "@/reminders/memory-git-sync";
+import { enqueueMemoryGitSyncReminder } from "@/reminders/state";
+import { settingsManager } from "@/settings-manager";
+import {
+  persistPermissionModeMapForRuntime,
+  pruneConversationPermissionModeStateIfDefault,
+} from "./permission-mode";
+import { emitDeviceStatusIfOpen } from "./protocol-outbound";
+import type { ConversationRuntime } from "./types";
+
+export async function runListenerTurnCleanup(params: {
+  runtime: ConversationRuntime;
+  agentId?: string | null;
+  normalizedAgentId: string | null;
+  conversationId: string;
+}): Promise<void> {
+  const { runtime, agentId, normalizedAgentId, conversationId } = params;
+
+  pruneConversationPermissionModeStateIfDefault(
+    runtime.listener,
+    normalizedAgentId,
+    conversationId,
+  );
+  persistPermissionModeMapForRuntime(runtime.listener);
+  emitDeviceStatusIfOpen(runtime, {
+    agent_id: agentId ?? null,
+    conversation_id: conversationId,
+  });
+
+  if (agentId) {
+    await runPostTurnMemorySync({
+      agentId,
+      isEnabled: (id) => settingsManager.isMemfsEnabled(id),
+      debugLabel: "Post-turn listener memory sync",
+      enqueueReminder: (text) => {
+        enqueueMemoryGitSyncReminder(runtime.reminderState, { text });
+      },
+    });
+  }
+
+  // A replacement turn may begin while post-turn memory sync is awaiting.
+  // Its process-global tool context now owns these identifiers.
+  if (runtime.turnLifecycle.kind !== "idle") {
+    return;
+  }
+
+  try {
+    const currentConversationId = getConversationId();
+    let currentAgentId: string | null = null;
+    try {
+      currentAgentId = getCurrentAgentId();
+    } catch {
+      currentAgentId = null;
+    }
+
+    if (
+      currentAgentId === (agentId ?? null) &&
+      currentConversationId === conversationId
+    ) {
+      setCurrentAgentId(null);
+      setConversationId(null);
+    }
+  } catch {
+    // Best-effort cleanup only. Never let teardown obscure the turn result.
+  }
+}

--- a/src/websocket/listener/turn-cleanup.ts
+++ b/src/websocket/listener/turn-cleanup.ts
@@ -1,9 +1,3 @@
-import {
-  getConversationId,
-  getCurrentAgentId,
-  setConversationId,
-  setCurrentAgentId,
-} from "@/agent/context";
 import { runPostTurnMemorySync } from "@/reminders/memory-git-sync";
 import { enqueueMemoryGitSyncReminder } from "@/reminders/state";
 import { settingsManager } from "@/settings-manager";
@@ -42,31 +36,5 @@ export async function runListenerTurnCleanup(params: {
         enqueueMemoryGitSyncReminder(runtime.reminderState, { text });
       },
     });
-  }
-
-  // A replacement turn may begin while post-turn memory sync is awaiting.
-  // Its process-global tool context now owns these identifiers.
-  if (runtime.turnLifecycle.kind !== "idle") {
-    return;
-  }
-
-  try {
-    const currentConversationId = getConversationId();
-    let currentAgentId: string | null = null;
-    try {
-      currentAgentId = getCurrentAgentId();
-    } catch {
-      currentAgentId = null;
-    }
-
-    if (
-      currentAgentId === (agentId ?? null) &&
-      currentConversationId === conversationId
-    ) {
-      setCurrentAgentId(null);
-      setConversationId(null);
-    }
-  } catch {
-    // Best-effort cleanup only. Never let teardown obscure the turn result.
   }
 }

--- a/src/websocket/listener/turn-completion.ts
+++ b/src/websocket/listener/turn-completion.ts
@@ -1,0 +1,123 @@
+import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
+import { regenerateConversationDescription } from "@/agent/conversation-description";
+import type { Line } from "@/cli/helpers/accumulator";
+import { getReflectionSettings } from "@/cli/helpers/memory-reminder";
+import { maybeLaunchPostTurnReflection } from "@/cli/helpers/post-turn-reflection";
+import { queuePendingReflectionWorktreeReminders } from "@/cli/helpers/reflection-launcher";
+import { appendTranscriptDeltaJsonl } from "@/cli/helpers/reflection-transcript";
+import { settingsManager } from "@/settings-manager";
+import { debugWarn } from "@/utils/debug";
+import type { ListenerTransport } from "./transport";
+import {
+  buildMaybeLaunchReflectionSubagent,
+  emitListenerTurnEnd,
+} from "./turn-events";
+import type { ConversationRuntime } from "./types";
+
+export async function completeSuccessfulListenerTurn(params: {
+  runtime: ConversationRuntime;
+  socket: ListenerTransport;
+  agentId: string;
+  conversationId: string;
+  workingDirectory: string;
+  permissionMode: string;
+  actingUserId?: string;
+  assistantMessage?: string;
+  transcriptLines: Line[];
+  getCachedAgent: () => AgentState | null;
+  isInterrupted: () => boolean;
+}): Promise<"completed" | "interrupted"> {
+  const continueText = await emitListenerTurnEnd({
+    agentId: params.agentId,
+    conversationId: params.conversationId,
+    stopReason: "end_turn",
+    assistantMessage: params.assistantMessage,
+    runtime: params.runtime.listener,
+    workingDirectory: params.workingDirectory,
+    permissionMode: params.permissionMode,
+    cachedAgent: params.getCachedAgent(),
+  });
+  if (params.isInterrupted()) {
+    return "interrupted";
+  }
+
+  if (continueText) {
+    params.runtime.queueRuntime.enqueue({
+      kind: "mod_continue",
+      source: "system",
+      text: continueText,
+      agentId: params.agentId,
+      conversationId: params.conversationId,
+      actingUserId: params.actingUserId,
+    } as Omit<
+      import("@/queue/queue-runtime").ModContinueQueueItem,
+      "id" | "enqueuedAt"
+    >);
+  }
+
+  try {
+    if (params.transcriptLines.length > 0) {
+      await appendTranscriptDeltaJsonl(
+        params.agentId,
+        params.conversationId,
+        params.transcriptLines,
+      );
+    }
+  } catch (error) {
+    debugWarn(
+      "memory",
+      `Failed to append transcript delta: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  if (params.isInterrupted()) {
+    return "interrupted";
+  }
+
+  try {
+    const reflectionSettings = getReflectionSettings(
+      params.agentId,
+      params.workingDirectory,
+    );
+    await maybeLaunchPostTurnReflection({
+      agentId: params.agentId,
+      conversationId: params.conversationId,
+      memfsEnabled: settingsManager.isMemfsEnabled(params.agentId),
+      reflectionSettings,
+      reminderState: params.runtime.reminderState,
+      contextTracker: params.runtime.contextTracker,
+      onCompaction: () =>
+        queuePendingReflectionWorktreeReminders({
+          agentId: params.agentId,
+          conversationId: params.conversationId,
+        }),
+      launch: buildMaybeLaunchReflectionSubagent({
+        runtime: params.runtime,
+        socket: params.socket,
+        agentId: params.agentId,
+        conversationId: params.conversationId,
+        reflectionSettings,
+        cachedAgent: params.getCachedAgent(),
+      }),
+    });
+  } catch (error) {
+    debugWarn(
+      "memory",
+      `Failed to evaluate post-turn channel reflection: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  if (params.isInterrupted()) {
+    return "interrupted";
+  }
+
+  if (
+    params.runtime.contextTracker.pendingConversationDescriptionRegeneration
+  ) {
+    params.runtime.contextTracker.pendingConversationDescriptionRegeneration = false;
+    void regenerateConversationDescription(params.conversationId);
+  }
+  return "completed";
+}

--- a/src/websocket/listener/turn-context.ts
+++ b/src/websocket/listener/turn-context.ts
@@ -1,0 +1,38 @@
+import {
+  getConversationId,
+  getCurrentAgentId,
+  setConversationId,
+  setCurrentAgentId,
+} from "@/agent/context";
+import type { ConversationRuntime } from "./types";
+
+export function releaseListenerTurnContext(params: {
+  runtime: ConversationRuntime;
+  agentId?: string | null;
+  conversationId: string;
+}): void {
+  const { runtime, agentId, conversationId } = params;
+  if (runtime.turnLifecycle.kind !== "idle") {
+    return;
+  }
+
+  try {
+    const currentConversationId = getConversationId();
+    let currentAgentId: string | null = null;
+    try {
+      currentAgentId = getCurrentAgentId();
+    } catch {
+      currentAgentId = null;
+    }
+
+    if (
+      currentAgentId === (agentId ?? null) &&
+      currentConversationId === conversationId
+    ) {
+      setCurrentAgentId(null);
+      setConversationId(null);
+    }
+  } catch {
+    // Best-effort cleanup only. Never let teardown obscure the turn result.
+  }
+}

--- a/src/websocket/listener/turn-events.ts
+++ b/src/websocket/listener/turn-events.ts
@@ -1,0 +1,189 @@
+import type {
+  AgentState,
+  MessageCreate,
+} from "@letta-ai/letta-client/resources/agents/agents";
+import type { ApprovalCreate } from "@letta-ai/letta-client/resources/agents/messages";
+import type {
+  ReflectionSettings,
+  ReflectionTrigger,
+} from "@/cli/helpers/memory-reminder";
+import {
+  AUTO_REFLECTION_DESCRIPTION,
+  launchReflectionSubagent,
+} from "@/cli/helpers/reflection-launcher";
+import { getTurnStartCancel } from "@/mods/turn-start-cancel";
+import { settingsManager } from "@/settings-manager";
+import { getListenerTelemetrySurface } from "@/telemetry";
+import type { StreamDelta } from "@/types/protocol_v2";
+import {
+  createListenerModContext,
+  ensureListenerModAdapter,
+} from "./mod-adapter";
+import { emitCanonicalMessageDelta } from "./protocol-outbound";
+import type { ListenerTransport } from "./transport";
+import type { ConversationRuntime, ListenerRuntime } from "./types";
+
+function escapeTaskNotificationSummary(summary: string): string {
+  return summary
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function isTurnInputArray(
+  value: unknown,
+): value is Array<MessageCreate | ApprovalCreate> {
+  return (
+    Array.isArray(value) &&
+    value.every((item) => typeof item === "object" && item !== null)
+  );
+}
+
+export type ListenerTurnStartEmission =
+  | { cancelled: false; input: Array<MessageCreate | ApprovalCreate> }
+  | { cancelled: true; reason: string };
+
+export async function emitListenerTurnStart(options: {
+  agentId: string;
+  conversationId: string;
+  input: Array<MessageCreate | ApprovalCreate>;
+  runtime: ListenerRuntime;
+  workingDirectory: string;
+  permissionMode?: string | null;
+  cachedAgent?: AgentState | null;
+}): Promise<ListenerTurnStartEmission> {
+  try {
+    const modAdapter = ensureListenerModAdapter(options.runtime);
+    const context = createListenerModContext({
+      sessionId: options.conversationId,
+      workingDirectory: options.workingDirectory,
+      permissionMode: options.permissionMode ?? null,
+      agent: options.cachedAgent ?? null,
+    });
+    const event = {
+      agentId: options.agentId,
+      conversationId: options.conversationId,
+      input: options.input,
+    };
+    await modAdapter.events.emit("turn_start", event, context);
+    const cancel = getTurnStartCancel(event);
+    if (cancel) {
+      return { cancelled: true, reason: cancel.reason };
+    }
+    return {
+      cancelled: false,
+      input: isTurnInputArray(event.input) ? event.input : options.input,
+    };
+  } catch {
+    // Mod turn_start handlers should not block sending the turn.
+    return { cancelled: false, input: options.input };
+  }
+}
+
+export async function emitListenerTurnEnd(options: {
+  agentId: string;
+  conversationId: string;
+  stopReason: string;
+  assistantMessage?: string;
+  runtime: ListenerRuntime;
+  workingDirectory: string;
+  permissionMode?: string | null;
+  cachedAgent?: AgentState | null;
+}): Promise<string | undefined> {
+  try {
+    const modAdapter = ensureListenerModAdapter(options.runtime);
+    const context = createListenerModContext({
+      sessionId: options.conversationId,
+      workingDirectory: options.workingDirectory,
+      permissionMode: options.permissionMode ?? null,
+      agent: options.cachedAgent ?? null,
+    });
+    const event: {
+      agentId: string;
+      conversationId: string;
+      stopReason: string;
+      assistantMessage?: string;
+      continue?: string;
+    } = {
+      agentId: options.agentId,
+      conversationId: options.conversationId,
+      stopReason: options.stopReason,
+      assistantMessage: options.assistantMessage,
+    };
+    await modAdapter.events.emit("turn_end", event, context);
+    return typeof event.continue === "string" && event.continue.length > 0
+      ? event.continue
+      : undefined;
+  } catch {
+    // Mod turn_end handlers should not block turn completion.
+    return undefined;
+  }
+}
+
+export function buildMaybeLaunchReflectionSubagent(params: {
+  runtime: ConversationRuntime;
+  socket: ListenerTransport;
+  agentId: string;
+  conversationId: string;
+  reflectionSettings?: ReflectionSettings;
+  cachedAgent?: AgentState | null;
+}): (triggerSource: Exclude<ReflectionTrigger, "off">) => Promise<boolean> {
+  return async (triggerSource) => {
+    const {
+      runtime,
+      socket,
+      agentId,
+      conversationId,
+      reflectionSettings,
+      cachedAgent,
+    } = params;
+
+    if (!agentId) {
+      return false;
+    }
+
+    const result = await launchReflectionSubagent({
+      agentId,
+      conversationId,
+      memfsEnabled: settingsManager.isMemfsEnabled(agentId),
+      triggerSource,
+      skipPendingWorktreeReminderScan: triggerSource === "compaction-event",
+      reflectionSettings,
+      description: AUTO_REFLECTION_DESCRIPTION,
+      systemPrompt: cachedAgent?.system ?? undefined,
+      recompileByConversation:
+        runtime.listener.systemPromptRecompileByConversation,
+      recompileQueuedByConversation:
+        runtime.listener.queuedSystemPromptRecompileByConversation,
+      feedbackContext: {
+        surface: getListenerTelemetrySurface(),
+      },
+      onCompletionMessage: async (completionMessage, reflectionResult) => {
+        const reflectionAgentIdTag = reflectionResult.reflectionAgentId
+          ? `<reflection-agent-id>${escapeTaskNotificationSummary(
+              reflectionResult.reflectionAgentId,
+            )}</reflection-agent-id>`
+          : "";
+        const notificationXml = `<task-notification><summary>${escapeTaskNotificationSummary(
+          completionMessage,
+        )}</summary>${reflectionAgentIdTag}</task-notification>`;
+        emitCanonicalMessageDelta(
+          socket,
+          runtime,
+          {
+            type: "message",
+            id: `user-msg-${crypto.randomUUID()}`,
+            date: new Date().toISOString(),
+            message_type: "user_message",
+            content: [{ type: "text", text: notificationXml }],
+          } as StreamDelta,
+          {
+            agent_id: agentId,
+            conversation_id: conversationId,
+          },
+        );
+      },
+    });
+    return result.launched;
+  };
+}

--- a/src/websocket/listener/turn-lifecycle-integration.test.ts
+++ b/src/websocket/listener/turn-lifecycle-integration.test.ts
@@ -1,4 +1,10 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  getConversationId,
+  getCurrentAgentId,
+  setConversationId,
+  setCurrentAgentId,
+} from "@/agent/context";
 import { getOrCreateScopedRuntime } from "./conversation-runtime";
 import { createRuntime } from "./lifecycle";
 import { getOrCreateConversationPermissionModeStateRef } from "./permission-mode";
@@ -7,6 +13,7 @@ import { finalizeHandledRecoveryTurn } from "./recovery";
 import { clearConversationRuntimeState } from "./runtime";
 import type { ListenerTransport } from "./transport";
 import { handleApprovalStop } from "./turn-approval";
+import { releaseListenerTurnContext } from "./turn-context";
 import type { TurnLease } from "./turn-lifecycle";
 
 function createOpenTransport(sentPayloads: string[] = []): ListenerTransport {
@@ -33,6 +40,7 @@ async function waitForPendingApproval(
 function startQuestionApproval(
   runtime: ReturnType<typeof getOrCreateScopedRuntime>,
   turnLease: TurnLease,
+  overrides: Partial<Parameters<typeof handleApprovalStop>[0]> = {},
 ) {
   return handleApprovalStop({
     approvals: [
@@ -77,10 +85,16 @@ function startQuestionApproval(
         background: true,
         workingDirectory: process.cwd(),
       }) as never,
+    ...overrides,
   });
 }
 
 describe("listener turn lifecycle integration", () => {
+  afterEach(() => {
+    setCurrentAgentId(null);
+    setConversationId(null);
+  });
+
   test("disconnect cleanup during a live approval cannot leave stale processing ownership", async () => {
     const listener = createRuntime();
     const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
@@ -139,6 +153,85 @@ describe("listener turn lifecycle integration", () => {
     expect(runtime.isProcessing).toBe(true);
   });
 
+  test("a stale tool execution cannot emit results under a replacement run", async () => {
+    const runtime = getOrCreateScopedRuntime(
+      createRuntime(),
+      "agent-1",
+      "conv-1",
+    );
+    const staleLease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+    });
+    runtime.turnLifecycle.setRunId(staleLease, "stale-run");
+    const sentPayloads: string[] = [];
+    let executionStarted = false;
+    let resolveExecution!: (results: never[]) => void;
+    const execution = new Promise<never[]>((resolve) => {
+      resolveExecution = resolve;
+    });
+    const executeApprovalBatch = mock(
+      async (
+        _decisions: unknown,
+        _unused: unknown,
+        options?: {
+          onStreamingOutput?: (id: string, chunk: string) => void;
+          onFileWrite?: (path: string, content: string) => void;
+        },
+      ) => {
+        executionStarted = true;
+        const results = await execution;
+        options?.onStreamingOutput?.("call-1", "late output");
+        options?.onFileWrite?.("late.txt", "late content");
+        return results;
+      },
+    );
+    const approval = {
+      toolCallId: "call-1",
+      toolName: "Bash",
+      toolArgs: '{"command":"pwd"}',
+    };
+    const owner = startQuestionApproval(runtime, staleLease, {
+      approvals: [approval],
+      socket: createOpenTransport(sentPayloads),
+      dependencies: {
+        classifyApprovals: (async () => ({
+          autoAllowed: [
+            { approval, parsedArgs: { command: "pwd" }, context: null },
+          ],
+          autoDenied: [],
+          needsUserInput: [],
+        })) as never,
+        executeApprovalBatch: executeApprovalBatch as never,
+        ensureSecretsHydrated: async () => {},
+      },
+    });
+    for (let attempt = 0; attempt < 100 && !executionStarted; attempt += 1) {
+      await Bun.sleep(1);
+    }
+    expect(executionStarted).toBe(true);
+
+    clearConversationRuntimeState(runtime);
+    const replacementLease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+    });
+    runtime.turnLifecycle.setRunId(replacementLease, "replacement-run");
+    sentPayloads.length = 0;
+    resolveExecution([
+      {
+        type: "tool",
+        tool_call_id: "call-1",
+        status: "success",
+        tool_return: "ok",
+      },
+    ] as never[]);
+
+    expect((await owner).kind).toBe("interrupted");
+    expect(runtime.turnLifecycle.isCurrent(replacementLease)).toBe(true);
+    expect(sentPayloads).toEqual([]);
+  });
+
   test("a stale recovery owner cannot finish or report errors for its replacement", () => {
     const listener = createRuntime();
     const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
@@ -169,5 +262,52 @@ describe("listener turn lifecycle integration", () => {
     expect(runtime.turnLifecycle.isCurrent(replacementLease)).toBe(true);
     expect(runtime.turnLifecycle.kind).toBe("active");
     expect(sentPayloads).toEqual([]);
+  });
+
+  test("an externally reset owner releases its process context", () => {
+    const runtime = getOrCreateScopedRuntime(
+      createRuntime(),
+      "agent-1",
+      "conv-1",
+    );
+    runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+    });
+    setCurrentAgentId("agent-1");
+    setConversationId("conv-1");
+
+    clearConversationRuntimeState(runtime);
+
+    expect(() => getCurrentAgentId()).toThrow("No agent context set");
+    expect(getConversationId()).toBeNull();
+  });
+
+  test("a stale owner cannot release a replacement turn's process context", () => {
+    const runtime = getOrCreateScopedRuntime(
+      createRuntime(),
+      "agent-1",
+      "conv-1",
+    );
+    runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+    });
+    clearConversationRuntimeState(runtime);
+    runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+    });
+    setCurrentAgentId("agent-1");
+    setConversationId("conv-1");
+
+    releaseListenerTurnContext({
+      runtime,
+      agentId: "agent-1",
+      conversationId: "conv-1",
+    });
+
+    expect(getCurrentAgentId()).toBe("agent-1");
+    expect(getConversationId()).toBe("conv-1");
   });
 });

--- a/src/websocket/listener/turn-lifecycle-integration.test.ts
+++ b/src/websocket/listener/turn-lifecycle-integration.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "bun:test";
+import { getOrCreateScopedRuntime } from "./conversation-runtime";
+import { createRuntime } from "./lifecycle";
+import { getOrCreateConversationPermissionModeStateRef } from "./permission-mode";
+import { shouldProcessInboundMessageDirectly } from "./queue";
+import { finalizeHandledRecoveryTurn } from "./recovery";
+import { clearConversationRuntimeState } from "./runtime";
+import type { ListenerTransport } from "./transport";
+import { handleApprovalStop } from "./turn-approval";
+import type { TurnLease } from "./turn-lifecycle";
+
+function createOpenTransport(sentPayloads: string[] = []): ListenerTransport {
+  return {
+    kind: "local",
+    bufferedAmount: 0,
+    isOpen: () => true,
+    send: (payload: string) => sentPayloads.push(payload),
+  };
+}
+
+async function waitForPendingApproval(
+  runtime: ReturnType<typeof getOrCreateScopedRuntime>,
+): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (runtime.pendingApprovalResolvers.size > 0) {
+      return;
+    }
+    await Bun.sleep(1);
+  }
+  throw new Error("Approval request was not registered");
+}
+
+function startQuestionApproval(
+  runtime: ReturnType<typeof getOrCreateScopedRuntime>,
+  turnLease: TurnLease,
+) {
+  return handleApprovalStop({
+    approvals: [
+      {
+        toolCallId: "call-1",
+        toolName: "AskUserQuestion",
+        toolArgs: JSON.stringify({
+          questions: [
+            {
+              question: "Continue?",
+              header: "Confirm",
+              options: [
+                { label: "Yes", description: "Continue the turn" },
+                { label: "No", description: "Stop the turn" },
+              ],
+              multiSelect: false,
+            },
+          ],
+        }),
+      },
+    ],
+    runtime,
+    socket: createOpenTransport(),
+    agentId: "agent-1",
+    conversationId: "conv-1",
+    turnWorkingDirectory: process.cwd(),
+    turnPermissionModeState: getOrCreateConversationPermissionModeStateRef(
+      runtime.listener,
+      "agent-1",
+      "conv-1",
+    ),
+    dequeuedBatchId: "batch-1",
+    msgRunIds: [],
+    currentInput: [],
+    pendingNormalizationInterruptedToolCallIds: [],
+    turnToolContextId: null,
+    turnLease,
+    buildSendOptions: () =>
+      ({
+        agentId: "agent-1",
+        streamTokens: true,
+        background: true,
+        workingDirectory: process.cwd(),
+      }) as never,
+  });
+}
+
+describe("listener turn lifecycle integration", () => {
+  test("disconnect cleanup during a live approval cannot leave stale processing ownership", async () => {
+    const listener = createRuntime();
+    const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
+    const turnLease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+      initialStatus: "PROCESSING_API_RESPONSE",
+    });
+
+    const approvalResultPromise = startQuestionApproval(runtime, turnLease);
+
+    await waitForPendingApproval(runtime);
+    clearConversationRuntimeState(runtime);
+
+    const approvalResult = await approvalResultPromise;
+    expect(approvalResult.kind).toBe("interrupted");
+    expect(turnLease.signal.aborted).toBe(true);
+    expect(runtime.turnLifecycle.kind).toBe("idle");
+    expect(runtime.isProcessing).toBe(false);
+    expect(runtime.cancelRequested).toBe(false);
+    expect(runtime.loopStatus).toBe("WAITING_ON_INPUT");
+    expect(runtime.activeRunId).toBeNull();
+    expect(runtime.turnLifecycle.currentLease).toBeNull();
+    expect(runtime.pendingApprovalResolvers.size).toBe(0);
+
+    expect(
+      shouldProcessInboundMessageDirectly(runtime, {
+        type: "message",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+        messages: [{ role: "user", content: "follow up" }],
+      }),
+    ).toBe(true);
+  });
+
+  test("an old approval unwind cannot mutate a replacement turn", async () => {
+    const listener = createRuntime();
+    const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
+    const staleLease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+      initialStatus: "PROCESSING_API_RESPONSE",
+    });
+    const approvalResultPromise = startQuestionApproval(runtime, staleLease);
+
+    await waitForPendingApproval(runtime);
+    clearConversationRuntimeState(runtime);
+    const replacementLease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+    });
+
+    expect((await approvalResultPromise).kind).toBe("interrupted");
+    expect(runtime.turnLifecycle.isCurrent(replacementLease)).toBe(true);
+    expect(runtime.turnLifecycle.kind).toBe("active");
+    expect(runtime.isProcessing).toBe(true);
+  });
+
+  test("a stale recovery owner cannot finish or report errors for its replacement", () => {
+    const listener = createRuntime();
+    const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
+    const staleLease = runtime.turnLifecycle.begin({
+      origin: "approval_recovery",
+      workingDirectory: process.cwd(),
+    });
+
+    clearConversationRuntimeState(runtime);
+    const replacementLease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+    });
+    const sentPayloads: string[] = [];
+
+    const transition = finalizeHandledRecoveryTurn(
+      runtime,
+      createOpenTransport(sentPayloads),
+      staleLease,
+      {
+        drainResult: { stopReason: "error" } as never,
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      },
+    );
+
+    expect(transition.finished).toBe(false);
+    expect(runtime.turnLifecycle.isCurrent(replacementLease)).toBe(true);
+    expect(runtime.turnLifecycle.kind).toBe("active");
+    expect(sentPayloads).toEqual([]);
+  });
+});

--- a/src/websocket/listener/turn-lifecycle.test.ts
+++ b/src/websocket/listener/turn-lifecycle.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import { TurnLifecycle } from "./turn-lifecycle";
+
+describe("TurnLifecycle", () => {
+  test("projects a coherent active turn from one owned state", () => {
+    const lifecycle = new TurnLifecycle(() => "lease-1");
+    const lease = lifecycle.begin({
+      origin: "message",
+      workingDirectory: "/tmp/worktree",
+    });
+
+    expect(lifecycle.kind).toBe("active");
+    expect(lifecycle.isProcessing).toBe(true);
+    expect(lifecycle.cancelRequested).toBe(false);
+    expect(lifecycle.loopStatus).toBe("SENDING_API_REQUEST");
+    expect(lifecycle.activeWorkingDirectory).toBe("/tmp/worktree");
+    expect(lifecycle.currentLease?.signal).toBe(lease.signal);
+
+    expect(lifecycle.setRunId(lease, "run-1")).toBe(true);
+    expect(lifecycle.setExecutingToolCallIds(lease, ["tool-1", "tool-2"])).toBe(
+      true,
+    );
+    expect(lifecycle.setStatus(lease, "EXECUTING_CLIENT_SIDE_TOOL")).toBe(true);
+    expect(lifecycle.activeRunId).toBe("run-1");
+    expect(lifecycle.snapshot()).toMatchObject({
+      kind: "active",
+      executingToolCallIds: ["tool-1", "tool-2"],
+    });
+  });
+
+  test("cancellation keeps the lease blocked while projecting idle UI state", () => {
+    const lifecycle = new TurnLifecycle(() => "lease-1");
+    const lease = lifecycle.begin({
+      origin: "message",
+      workingDirectory: "/tmp/worktree",
+    });
+    lifecycle.setRunId(lease, "run-1");
+    lifecycle.setExecutingToolCallIds(lease, ["tool-1"]);
+
+    const cancellation = lifecycle.requestCancellation();
+
+    expect(cancellation).toMatchObject({
+      transitioned: true,
+      lease,
+      runId: "run-1",
+      executingToolCallIds: ["tool-1"],
+    });
+    expect(lease.signal.aborted).toBe(true);
+    expect(lifecycle.kind).toBe("cancelling");
+    expect(lifecycle.isProcessing).toBe(false);
+    expect(lifecycle.cancelRequested).toBe(true);
+    expect(lifecycle.loopStatus).toBe("WAITING_ON_INPUT");
+    expect(lifecycle.activeRunId).toBeNull();
+    expect(lifecycle.currentLease?.signal.aborted).toBe(true);
+
+    expect(lifecycle.finish(lease, "cancelled")).toEqual({
+      finished: true,
+      previousKind: "cancelling",
+      runId: "run-1",
+    });
+    expect(lifecycle.kind).toBe("idle");
+    expect(lifecycle.cancelRequested).toBe(false);
+    expect(lifecycle.lastStopReason).toBe("cancelled");
+  });
+
+  test("reset invalidates stale async owners before a replacement turn", () => {
+    let nextId = 0;
+    const lifecycle = new TurnLifecycle(() => `lease-${++nextId}`);
+    const staleLease = lifecycle.begin({
+      origin: "message",
+      workingDirectory: "/tmp/old",
+    });
+
+    expect(lifecycle.reset("cancelled").finished).toBe(true);
+    const currentLease = lifecycle.begin({
+      origin: "message",
+      workingDirectory: "/tmp/new",
+    });
+
+    expect(lifecycle.setRunId(staleLease, "stale-run")).toBe(false);
+    expect(lifecycle.setStatus(staleLease, "PROCESSING_API_RESPONSE")).toBe(
+      false,
+    );
+    expect(lifecycle.finish(staleLease, "error").finished).toBe(false);
+    expect(lifecycle.isCurrent(currentLease)).toBe(true);
+    expect(lifecycle.activeWorkingDirectory).toBe("/tmp/new");
+    expect(lifecycle.lastStopReason).toBeNull();
+  });
+
+  test("finishes a lease exactly once", () => {
+    const lifecycle = new TurnLifecycle(() => "lease-1");
+    const lease = lifecycle.begin({
+      origin: "message",
+      workingDirectory: "/tmp/worktree",
+    });
+
+    expect(lifecycle.finish(lease, "end_turn").finished).toBe(true);
+    expect(lifecycle.finish(lease, "error").finished).toBe(false);
+    expect(lifecycle.kind).toBe("idle");
+    expect(lifecycle.lastStopReason).toBe("end_turn");
+  });
+
+  test("rejects overlapping active turn ownership", () => {
+    const lifecycle = new TurnLifecycle(() => "lease-1");
+    lifecycle.begin({
+      origin: "message",
+      workingDirectory: "/tmp/worktree",
+    });
+
+    expect(() =>
+      lifecycle.begin({
+        origin: "message",
+        workingDirectory: "/tmp/other",
+      }),
+    ).toThrow("Cannot begin a turn while lifecycle is active");
+  });
+
+  test("a turn atomically takes ownership from a tracked command", () => {
+    const lifecycle = new TurnLifecycle(() => "lease-1");
+
+    expect(lifecycle.startCommand()).toBe(true);
+    expect(lifecycle.kind).toBe("command");
+    expect(lifecycle.loopStatus).toBe("EXECUTING_COMMAND");
+    expect(() =>
+      lifecycle.begin({
+        origin: "message",
+        workingDirectory: "/tmp/worktree",
+      }),
+    ).not.toThrow();
+    expect(lifecycle.startCommand()).toBe(false);
+  });
+});

--- a/src/websocket/listener/turn-lifecycle.ts
+++ b/src/websocket/listener/turn-lifecycle.ts
@@ -1,0 +1,323 @@
+import type { LoopStatus, StopReasonType } from "@/types/protocol_v2";
+
+export type ActiveTurnLoopStatus = Exclude<
+  LoopStatus,
+  "WAITING_ON_INPUT" | "EXECUTING_COMMAND"
+>;
+
+export type TurnOrigin = "message" | "approval_recovery";
+
+export type TurnLease = Readonly<{
+  id: string;
+  signal: AbortSignal;
+}>;
+
+type IdleTurnState = {
+  kind: "idle";
+  loopStatus: "WAITING_ON_INPUT";
+};
+
+type CommandTurnState = {
+  kind: "command";
+  loopStatus: "EXECUTING_COMMAND";
+};
+
+type ActiveTurnState = {
+  kind: "active";
+  origin: TurnOrigin;
+  lease: TurnLease;
+  abortController: AbortController;
+  loopStatus: ActiveTurnLoopStatus;
+  workingDirectory: string;
+  runId: string | null;
+  executingToolCallIds: readonly string[];
+};
+
+type CancellingTurnState = {
+  kind: "cancelling";
+  origin: TurnOrigin;
+  lease: TurnLease;
+  abortController: AbortController;
+  runId: string | null;
+  executingToolCallIds: readonly string[];
+  loopStatus: "WAITING_ON_INPUT";
+};
+
+type TurnState =
+  | IdleTurnState
+  | CommandTurnState
+  | ActiveTurnState
+  | CancellingTurnState;
+
+export type TurnLifecycleSnapshot =
+  | IdleTurnState
+  | CommandTurnState
+  | Omit<ActiveTurnState, "abortController">
+  | Omit<CancellingTurnState, "abortController">;
+
+export type TurnCancellationTransition = {
+  transitioned: boolean;
+  lease: TurnLease | null;
+  runId: string | null;
+  executingToolCallIds: readonly string[];
+};
+
+export type TurnFinishTransition = {
+  finished: boolean;
+  previousKind: "active" | "cancelling" | null;
+  runId: string | null;
+};
+
+const IDLE_STATE: IdleTurnState = {
+  kind: "idle",
+  loopStatus: "WAITING_ON_INPUT",
+};
+
+export class TurnLifecycle {
+  readonly #createId: () => string;
+  #state: TurnState = IDLE_STATE;
+  #lastStopReason: StopReasonType | null = null;
+
+  constructor(createId: () => string = () => crypto.randomUUID()) {
+    this.#createId = createId;
+  }
+
+  get kind(): TurnState["kind"] {
+    return this.#state.kind;
+  }
+
+  get isProcessing(): boolean {
+    return this.#state.kind === "active";
+  }
+
+  get cancelRequested(): boolean {
+    return this.#state.kind === "cancelling";
+  }
+
+  get loopStatus(): LoopStatus {
+    return this.#state.loopStatus;
+  }
+
+  get activeWorkingDirectory(): string | null {
+    return this.#state.kind === "active" ? this.#state.workingDirectory : null;
+  }
+
+  get activeRunId(): string | null {
+    return this.#state.kind === "active" ? this.#state.runId : null;
+  }
+
+  get lastStopReason(): StopReasonType | null {
+    return this.#lastStopReason;
+  }
+
+  get currentLease(): TurnLease | null {
+    return this.#state.kind === "active" || this.#state.kind === "cancelling"
+      ? this.#state.lease
+      : null;
+  }
+
+  snapshot(): TurnLifecycleSnapshot {
+    const state = this.#state;
+    if (state.kind === "active") {
+      return {
+        kind: state.kind,
+        origin: state.origin,
+        lease: state.lease,
+        loopStatus: state.loopStatus,
+        workingDirectory: state.workingDirectory,
+        runId: state.runId,
+        executingToolCallIds: [...state.executingToolCallIds],
+      };
+    }
+    if (state.kind === "cancelling") {
+      return {
+        kind: state.kind,
+        origin: state.origin,
+        lease: state.lease,
+        runId: state.runId,
+        executingToolCallIds: [...state.executingToolCallIds],
+        loopStatus: state.loopStatus,
+      };
+    }
+    return { ...state };
+  }
+
+  begin(options: {
+    origin: TurnOrigin;
+    workingDirectory: string;
+    initialStatus?: ActiveTurnLoopStatus;
+    abortController?: AbortController;
+    executingToolCallIds?: readonly string[];
+  }): TurnLease {
+    if (this.#state.kind === "active" || this.#state.kind === "cancelling") {
+      throw new Error(
+        `Cannot begin a turn while lifecycle is ${this.#state.kind}`,
+      );
+    }
+
+    const abortController = options.abortController ?? new AbortController();
+    const lease = Object.freeze({
+      id: this.#createId(),
+      signal: abortController.signal,
+    });
+    this.#state = {
+      kind: "active",
+      origin: options.origin,
+      lease,
+      abortController,
+      loopStatus: options.initialStatus ?? "SENDING_API_REQUEST",
+      workingDirectory: options.workingDirectory,
+      runId: null,
+      executingToolCallIds: [...(options.executingToolCallIds ?? [])],
+    };
+    this.#lastStopReason = null;
+    return lease;
+  }
+
+  isCurrent(lease: TurnLease): boolean {
+    return (
+      (this.#state.kind === "active" || this.#state.kind === "cancelling") &&
+      this.#state.lease.id === lease.id
+    );
+  }
+
+  setStatus(lease: TurnLease, status: ActiveTurnLoopStatus): boolean {
+    if (this.#state.kind !== "active" || !this.isCurrent(lease)) {
+      return false;
+    }
+    if (this.#state.loopStatus === status) {
+      return false;
+    }
+    this.#state = { ...this.#state, loopStatus: status };
+    return true;
+  }
+
+  setRunId(lease: TurnLease, runId: string | null): boolean {
+    if (this.#state.kind !== "active" || !this.isCurrent(lease)) {
+      return false;
+    }
+    if (this.#state.runId === runId) {
+      return false;
+    }
+    this.#state = { ...this.#state, runId };
+    return true;
+  }
+
+  setExecutingToolCallIds(
+    lease: TurnLease,
+    toolCallIds: readonly string[],
+  ): boolean {
+    if (this.#state.kind !== "active" || !this.isCurrent(lease)) {
+      return false;
+    }
+    this.#state = {
+      ...this.#state,
+      executingToolCallIds: [...toolCallIds],
+    };
+    return true;
+  }
+
+  recordStopReason(lease: TurnLease, stopReason: StopReasonType): boolean {
+    if (this.#state.kind !== "active" || !this.isCurrent(lease)) {
+      return false;
+    }
+    this.#lastStopReason = stopReason;
+    return true;
+  }
+
+  startCommand(): boolean {
+    if (this.#state.kind !== "idle") {
+      return false;
+    }
+    this.#state = {
+      kind: "command",
+      loopStatus: "EXECUTING_COMMAND",
+    };
+    return true;
+  }
+
+  finishCommand(): boolean {
+    if (this.#state.kind !== "command") {
+      return false;
+    }
+    this.#state = IDLE_STATE;
+    return true;
+  }
+
+  requestCancellation(): TurnCancellationTransition {
+    const state = this.#state;
+    if (state.kind === "cancelling") {
+      return {
+        transitioned: false,
+        lease: state.lease,
+        runId: state.runId,
+        executingToolCallIds: [...state.executingToolCallIds],
+      };
+    }
+    if (state.kind !== "active") {
+      return {
+        transitioned: false,
+        lease: null,
+        runId: null,
+        executingToolCallIds: [],
+      };
+    }
+
+    if (!state.abortController.signal.aborted) {
+      state.abortController.abort();
+    }
+    this.#lastStopReason = "cancelled";
+    this.#state = {
+      kind: "cancelling",
+      origin: state.origin,
+      lease: state.lease,
+      abortController: state.abortController,
+      runId: state.runId,
+      executingToolCallIds: [...state.executingToolCallIds],
+      loopStatus: "WAITING_ON_INPUT",
+    };
+    return {
+      transitioned: true,
+      lease: state.lease,
+      runId: state.runId,
+      executingToolCallIds: [...state.executingToolCallIds],
+    };
+  }
+
+  finish(lease: TurnLease, stopReason: StopReasonType): TurnFinishTransition {
+    const state = this.#state;
+    if (
+      (state.kind !== "active" && state.kind !== "cancelling") ||
+      state.lease.id !== lease.id
+    ) {
+      return { finished: false, previousKind: null, runId: null };
+    }
+
+    this.#lastStopReason = stopReason;
+    this.#state = IDLE_STATE;
+    return {
+      finished: true,
+      previousKind: state.kind,
+      runId: state.runId,
+    };
+  }
+
+  reset(stopReason: StopReasonType = "cancelled"): TurnFinishTransition {
+    const state = this.#state;
+    if (state.kind === "active" || state.kind === "cancelling") {
+      if (!state.abortController.signal.aborted) {
+        state.abortController.abort();
+      }
+      this.#lastStopReason = stopReason;
+      this.#state = IDLE_STATE;
+      return {
+        finished: true,
+        previousKind: state.kind,
+        runId: state.runId,
+      };
+    }
+
+    this.#state = IDLE_STATE;
+    return { finished: false, previousKind: null, runId: null };
+  }
+}

--- a/src/websocket/listener/turn-reflection.test.ts
+++ b/src/websocket/listener/turn-reflection.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { createBuffers, toLines } from "@/cli/helpers/accumulator";
-import { __listenerTurnTestUtils } from "@/websocket/listener/turn";
+import { __listenerTurnTestUtils } from "./turn-transcript";
 
 describe("post-turn listener reflection", () => {
   test("seeds inbound websocket user rows into the reflection transcript buffer", () => {
@@ -31,26 +31,22 @@ describe("post-turn listener reflection", () => {
   });
 
   test("records listener transcript rows before evaluating post-turn reflection", () => {
-    const turnPath = fileURLToPath(new URL("./turn.ts", import.meta.url));
-    const source = readFileSync(turnPath, "utf-8");
-    const endTurnIndex = source.indexOf('if (stopReason === "end_turn")');
-    const appendIndex = source.indexOf(
-      "appendTranscriptDeltaJsonl(",
-      endTurnIndex,
+    const completionPath = fileURLToPath(
+      new URL("./turn-completion.ts", import.meta.url),
     );
-    const launchIndex = source.indexOf(
-      "maybeLaunchPostTurnReflection({",
-      endTurnIndex,
-    );
+    const source = readFileSync(completionPath, "utf-8");
+    const appendIndex = source.indexOf("appendTranscriptDeltaJsonl(");
+    const launchIndex = source.indexOf("maybeLaunchPostTurnReflection({");
 
-    expect(endTurnIndex).toBeGreaterThanOrEqual(0);
-    expect(appendIndex).toBeGreaterThan(endTurnIndex);
+    expect(appendIndex).toBeGreaterThanOrEqual(0);
     expect(launchIndex).toBeGreaterThan(appendIndex);
   });
 
   test("evaluates post-turn reflection for all turns, not just channel turns", () => {
-    const turnPath = fileURLToPath(new URL("./turn.ts", import.meta.url));
-    const source = readFileSync(turnPath, "utf-8");
+    const completionPath = fileURLToPath(
+      new URL("./turn-completion.ts", import.meta.url),
+    );
+    const source = readFileSync(completionPath, "utf-8");
 
     // The channel-only gate was removed: every end_turn evaluates reflection.
     expect(source).not.toContain("hasChannelTurnSources");

--- a/src/websocket/listener/turn-send.ts
+++ b/src/websocket/listener/turn-send.ts
@@ -1,0 +1,82 @@
+import type { Stream } from "@letta-ai/letta-client/core/streaming";
+import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
+import type {
+  ApprovalCreate,
+  LettaStreamingResponse,
+} from "@letta-ai/letta-client/resources/agents/messages";
+import type { sendMessageStream } from "@/agent/message";
+import type { ProviderFallbackState } from "./provider-fallback";
+import { finalizeHandledRecoveryTurn } from "./recovery";
+import {
+  type ApprovalContinuationSendResult,
+  isApprovalOnlyInput,
+  sendApprovalContinuationWithRetry,
+  sendMessageStreamWithRetry,
+} from "./send";
+import type { ListenerTransport } from "./transport";
+import type { TurnFinishTransition, TurnLease } from "./turn-lifecycle";
+import type { ConversationRuntime } from "./types";
+
+export function createTurnInputSender(params: {
+  conversationId: string;
+  agentId: string;
+  socket: ListenerTransport;
+  runtime: ConversationRuntime;
+  turnLease: TurnLease;
+  providerFallback: ProviderFallbackState;
+  buildSendOptions: () => Parameters<typeof sendMessageStream>[2];
+  onTerminal: (transition: TurnFinishTransition) => void;
+}): {
+  send: (
+    input: Array<MessageCreate | ApprovalCreate>,
+  ) => Promise<ApprovalContinuationSendResult>;
+  accept: (
+    result: ApprovalContinuationSendResult,
+  ) => Stream<LettaStreamingResponse> | null;
+} {
+  return {
+    async send(input) {
+      if (isApprovalOnlyInput(input)) {
+        return sendApprovalContinuationWithRetry(
+          params.conversationId,
+          input,
+          params.buildSendOptions(),
+          params.socket,
+          params.runtime,
+          params.turnLease,
+          { providerFallback: params.providerFallback },
+        );
+      }
+      return {
+        kind: "stream",
+        stream: await sendMessageStreamWithRetry(
+          params.conversationId,
+          input,
+          params.buildSendOptions(),
+          params.socket,
+          params.runtime,
+          params.turnLease,
+          { providerFallback: params.providerFallback },
+        ),
+      };
+    },
+    accept(result) {
+      if (result.kind === "stream") {
+        return result.stream as Stream<LettaStreamingResponse>;
+      }
+      params.onTerminal(
+        finalizeHandledRecoveryTurn(
+          params.runtime,
+          params.socket,
+          params.turnLease,
+          {
+            drainResult: result.drainResult,
+            agentId: params.agentId,
+            conversationId: params.conversationId,
+          },
+        ),
+      );
+      return null;
+    },
+  };
+}

--- a/src/websocket/listener/turn-setup.ts
+++ b/src/websocket/listener/turn-setup.ts
@@ -1,0 +1,292 @@
+import type {
+  AgentState,
+  MessageCreate,
+} from "@letta-ai/letta-client/resources/agents/agents";
+import type { ApprovalCreate } from "@letta-ai/letta-client/resources/agents/messages";
+import {
+  setConversationId,
+  setCurrentAgentId,
+  setCurrentAgentName,
+} from "@/agent/context";
+import { getBackend } from "@/backend";
+import type { Line } from "@/cli/helpers/accumulator";
+import {
+  buildSharedReminderParts,
+  prependReminderPartsToContent,
+} from "@/reminders/engine";
+import { buildListenReminderContext } from "@/reminders/listen-context";
+import { trackBoundaryError } from "@/telemetry/error-reporting";
+import { prepareToolExecutionContextForScope } from "@/tools/toolset";
+import { debugWarn, isDebugEnabled } from "@/utils/debug";
+import { detectShellContext } from "@/utils/shell-context";
+import { consumeInterruptQueue } from "./interrupts";
+import { ensureListenerModAdapter } from "./mod-adapter";
+import type { ConversationPermissionModeState } from "./permission-mode";
+import { emitListenerTurnStart } from "./turn-events";
+import type { TurnLease } from "./turn-lifecycle";
+import {
+  buildInboundUserTranscriptLines,
+  trackListenerUserInput,
+} from "./turn-transcript";
+import type {
+  ConversationRuntime,
+  IncomingMessage,
+  StartListenerOptions,
+} from "./types";
+import { ensureListenerWarmStateForTurn } from "./warmup";
+
+type PreparedToolContext = Awaited<
+  ReturnType<typeof prepareToolExecutionContextForScope>
+>;
+
+export type ListenerTurnSetupResult =
+  | { kind: "interrupted" }
+  | { kind: "cancelled"; reason: string }
+  | {
+      kind: "ready";
+      getCachedAgent: () => AgentState | null;
+      currentInput: Array<MessageCreate | ApprovalCreate>;
+      inboundUserTranscriptLines: Line[];
+      pendingNormalizationInterruptedToolCallIds: string[];
+      preparedToolContext: PreparedToolContext;
+    };
+
+export async function prepareListenerTurn(params: {
+  msg: IncomingMessage;
+  runtime: ConversationRuntime;
+  agentId: string;
+  requestedConversationId?: string;
+  conversationId: string;
+  workingDirectory: string;
+  permissionModeState: ConversationPermissionModeState;
+  turnLease: TurnLease;
+  onStatusChange?: StartListenerOptions["onStatusChange"];
+  connectionId?: string;
+}): Promise<ListenerTurnSetupResult> {
+  const {
+    msg,
+    runtime,
+    agentId,
+    requestedConversationId,
+    conversationId,
+    workingDirectory,
+    permissionModeState,
+    turnLease,
+    onStatusChange,
+    connectionId,
+  } = params;
+  const isInterrupted = () =>
+    turnLease.signal.aborted || !runtime.turnLifecycle.isCurrent(turnLease);
+
+  let listenAgentMetadata = await ensureListenerWarmStateForTurn(
+    runtime.listener,
+    { agentId, conversationId },
+  );
+  if (isInterrupted()) {
+    return { kind: "interrupted" };
+  }
+
+  setCurrentAgentId(agentId);
+  setCurrentAgentName(listenAgentMetadata?.name ?? null);
+  setConversationId(conversationId);
+
+  if (isDebugEnabled()) {
+    console.log(
+      `[Listen] Handling message: agentId=${agentId}, requestedConversationId=${requestedConversationId}, conversationId=${conversationId}`,
+    );
+  }
+  if (connectionId) {
+    onStatusChange?.("processing", connectionId);
+  }
+
+  const { normalizeInboundMessages } = await import("./queue");
+  const normalizedMessages = await normalizeInboundMessages(
+    msg.messages,
+    undefined,
+    {
+      imageFailureMode:
+        (msg.channelTurnSources?.length ?? 0) > 0 ? "drop" : "strict",
+    },
+  );
+  if (isInterrupted()) {
+    return { kind: "interrupted" };
+  }
+  trackListenerUserInput(normalizedMessages, "unknown");
+
+  const messagesToSend: Array<MessageCreate | ApprovalCreate> = [];
+  let queuedInterruptedToolCallIds: string[] = [];
+  const consumed = consumeInterruptQueue(runtime, agentId, conversationId);
+  if (consumed) {
+    messagesToSend.push(consumed.approvalMessage);
+    queuedInterruptedToolCallIds = consumed.interruptedToolCallIds;
+  }
+  messagesToSend.push(
+    ...normalizedMessages.map((message) =>
+      "content" in message && !message.otid
+        ? {
+            ...message,
+            // Reconcile optimistic transcript rows with the canonical echo.
+            otid:
+              "client_message_id" in message &&
+              typeof message.client_message_id === "string"
+                ? message.client_message_id
+                : crypto.randomUUID(),
+          }
+        : message,
+    ),
+  );
+
+  let inboundUserTranscriptLines =
+    buildInboundUserTranscriptLines(messagesToSend);
+  const firstMessage = normalizedMessages[0];
+  const isApprovalMessage =
+    firstMessage &&
+    "type" in firstMessage &&
+    firstMessage.type === "approval" &&
+    "approvals" in firstMessage;
+  let cachedAgent: AgentState | null = null;
+
+  if (!isApprovalMessage) {
+    try {
+      try {
+        cachedAgent = (await getBackend().retrieveAgent(agentId, {
+          include: ["agent.tags"],
+        })) as AgentState;
+        const {
+          ensureLettaCodeOriginTag,
+          getMemoryPromptModeForAgent,
+          scheduleManagedSystemPromptUpdate,
+        } = await import("@/agent/system-prompt-versioning");
+        cachedAgent = await ensureLettaCodeOriginTag(cachedAgent);
+        scheduleManagedSystemPromptUpdate({
+          agent: cachedAgent,
+          memoryMode: getMemoryPromptModeForAgent(cachedAgent.id),
+          onUpdated: (updatedAgent) => {
+            cachedAgent = updatedAgent;
+          },
+        });
+      } catch (error) {
+        debugWarn(
+          "listen",
+          `Failed to ensure Letta Code agent metadata for ${agentId}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+      if (isInterrupted()) {
+        return { kind: "interrupted" };
+      }
+
+      if (!runtime.reminderState.hasSentAgentInfo && cachedAgent) {
+        listenAgentMetadata = {
+          name: cachedAgent.name ?? null,
+          description: cachedAgent.description ?? null,
+          lastRunAt:
+            (cachedAgent as { last_run_completion?: string | null })
+              .last_run_completion ?? null,
+        };
+      }
+      setCurrentAgentName(
+        listenAgentMetadata?.name ?? cachedAgent?.name ?? null,
+      );
+      const { parts: reminderParts } = await buildSharedReminderParts(
+        buildListenReminderContext({
+          agentId,
+          conversationId,
+          agentName: listenAgentMetadata?.name ?? null,
+          agentDescription: listenAgentMetadata?.description ?? null,
+          agentLastRunAt: listenAgentMetadata?.lastRunAt ?? null,
+          state: runtime.reminderState,
+          workingDirectory,
+          shellContext: detectShellContext(),
+        }),
+      );
+      if (isInterrupted()) {
+        return { kind: "interrupted" };
+      }
+
+      if (reminderParts.length > 0) {
+        for (const message of messagesToSend) {
+          if (
+            "role" in message &&
+            message.role === "user" &&
+            "content" in message
+          ) {
+            message.content = prependReminderPartsToContent(
+              message.content,
+              reminderParts,
+            );
+            break;
+          }
+        }
+      }
+    } catch (error) {
+      trackBoundaryError({
+        errorType: "listener_reminder_build_failed",
+        error,
+        context: "listener_turn_reminders",
+      });
+      if (isDebugEnabled()) {
+        console.error("[Listen] Failed to build reminder parts:", error);
+      }
+    }
+  }
+  if (isInterrupted()) {
+    return { kind: "interrupted" };
+  }
+
+  const hasUserMessage = messagesToSend.some(
+    (message) => "role" in message && message.role === "user",
+  );
+  const turnStartEmission = hasUserMessage
+    ? await emitListenerTurnStart({
+        agentId,
+        conversationId,
+        input: messagesToSend,
+        runtime: runtime.listener,
+        workingDirectory,
+        permissionMode: permissionModeState.mode,
+        cachedAgent,
+      })
+    : ({ cancelled: false, input: messagesToSend } as const);
+  if (isInterrupted()) {
+    return { kind: "interrupted" };
+  }
+  if (turnStartEmission.cancelled) {
+    return { kind: "cancelled", reason: turnStartEmission.reason };
+  }
+
+  const currentInput = turnStartEmission.input;
+  if (currentInput !== messagesToSend) {
+    inboundUserTranscriptLines = buildInboundUserTranscriptLines(currentInput);
+  }
+  const preparedToolContext = await prepareToolExecutionContextForScope({
+    agentId,
+    conversationId,
+    clientToolAllowlist: msg.clientToolAllowlist,
+    externalToolScopeIds: msg.externalToolScopeIds,
+    workingDirectory,
+    permissionModeState,
+    cachedAgent,
+    channelTurnSources: msg.channelTurnSources,
+    modEvents: ensureListenerModAdapter(runtime.listener).events,
+  });
+  if (isInterrupted()) {
+    return { kind: "interrupted" };
+  }
+
+  runtime.currentToolset = preparedToolContext.toolset;
+  runtime.currentToolsetPreference = preparedToolContext.toolsetPreference;
+  runtime.currentLoadedTools =
+    preparedToolContext.preparedToolContext.loadedToolNames;
+  return {
+    kind: "ready",
+    getCachedAgent: () => cachedAgent,
+    currentInput,
+    inboundUserTranscriptLines,
+    pendingNormalizationInterruptedToolCallIds: [
+      ...queuedInterruptedToolCallIds,
+    ],
+    preparedToolContext,
+  };
+}

--- a/src/websocket/listener/turn-status.ts
+++ b/src/websocket/listener/turn-status.ts
@@ -1,0 +1,33 @@
+import { emitLoopStatusIfOpen } from "./protocol-outbound";
+import type { ActiveTurnLoopStatus, TurnLease } from "./turn-lifecycle";
+import type { ConversationRuntime } from "./types";
+
+type RuntimeScope = {
+  agent_id?: string | null;
+  conversation_id?: string | null;
+};
+
+export function setTurnLoopStatus(
+  runtime: ConversationRuntime,
+  lease: TurnLease,
+  status: ActiveTurnLoopStatus,
+  scope?: RuntimeScope,
+): void {
+  if (runtime.turnLifecycle.setStatus(lease, status)) {
+    emitLoopStatusIfOpen(runtime, scope);
+  }
+}
+
+export function setCommandLoopStatus(
+  runtime: ConversationRuntime,
+  status: "EXECUTING_COMMAND" | "WAITING_ON_INPUT",
+  scope?: RuntimeScope,
+): void {
+  const changed =
+    status === "EXECUTING_COMMAND"
+      ? runtime.turnLifecycle.startCommand()
+      : runtime.turnLifecycle.finishCommand();
+  if (changed) {
+    emitLoopStatusIfOpen(runtime, scope);
+  }
+}

--- a/src/websocket/listener/turn-terminal.ts
+++ b/src/websocket/listener/turn-terminal.ts
@@ -1,0 +1,47 @@
+import type { StopReasonType } from "@/types/protocol_v2";
+import {
+  emitInterruptedStatusDelta,
+  emitRuntimeStateUpdates,
+} from "./protocol-outbound";
+import type { ListenerTransport } from "./transport";
+import type { TurnFinishTransition, TurnLease } from "./turn-lifecycle";
+import type { ConversationRuntime } from "./types";
+
+export function finishListenerTurn(
+  runtime: ConversationRuntime,
+  lease: TurnLease,
+  options: {
+    stopReason: StopReasonType;
+    socket?: ListenerTransport;
+    runId?: string | null;
+    agentId?: string | null;
+    conversationId: string;
+  },
+): TurnFinishTransition {
+  const transition = runtime.turnLifecycle.finish(lease, options.stopReason);
+  if (!transition.finished) {
+    return transition;
+  }
+
+  // Explicit abort projects the interrupted state when it moves the lease to
+  // cancelling. Only server-originated cancellation reaches finish from active.
+  if (
+    options.stopReason === "cancelled" &&
+    transition.previousKind === "active" &&
+    options.socket
+  ) {
+    emitInterruptedStatusDelta(options.socket, runtime, {
+      runId: options.runId ?? transition.runId,
+      agentId: options.agentId,
+      conversationId: options.conversationId,
+    });
+  }
+
+  if (transition.previousKind === "active") {
+    emitRuntimeStateUpdates(runtime, {
+      agent_id: options.agentId ?? null,
+      conversation_id: options.conversationId,
+    });
+  }
+  return transition;
+}

--- a/src/websocket/listener/turn-transcript.ts
+++ b/src/websocket/listener/turn-transcript.ts
@@ -1,0 +1,73 @@
+import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
+import type { ApprovalCreate } from "@letta-ai/letta-client/resources/agents/messages";
+import type { Buffers, Line } from "@/cli/helpers/accumulator";
+import { telemetry } from "@/telemetry";
+import { extractTelemetryInputText } from "@/telemetry/input";
+import type { InboundMessagePayload } from "./types";
+
+export function trackListenerUserInput(
+  messages: InboundMessagePayload[],
+  modelId: string,
+): void {
+  for (const message of messages) {
+    if (!("role" in message) || message.role !== "user") {
+      continue;
+    }
+    const inputText = extractTelemetryInputText(message.content);
+    if (inputText.length > 0) {
+      telemetry.trackUserInput(inputText, "user", modelId);
+    }
+  }
+}
+
+export function buildInboundUserTranscriptLines(
+  messages: Array<MessageCreate | ApprovalCreate>,
+): Line[] {
+  const lines: Line[] = [];
+  for (const message of messages) {
+    if (
+      !("role" in message) ||
+      message.role !== "user" ||
+      !("content" in message)
+    ) {
+      continue;
+    }
+    const text = extractTelemetryInputText(message.content);
+    if (text.length === 0) {
+      continue;
+    }
+    const otid =
+      "otid" in message && typeof message.otid === "string"
+        ? message.otid
+        : undefined;
+    lines.push({
+      kind: "user",
+      id: otid ? `user-${otid}` : `user-${crypto.randomUUID()}`,
+      text,
+      otid,
+    });
+  }
+  return lines;
+}
+
+export function seedInboundUserTranscriptLines(
+  buffers: Buffers,
+  lines: Line[],
+): void {
+  for (const line of lines) {
+    if (line.kind !== "user" || buffers.byId.has(line.id)) {
+      continue;
+    }
+    buffers.byId.set(line.id, line);
+    buffers.order.push(line.id);
+    if (line.otid) {
+      buffers.userLineIdByOtid.set(line.otid, line.id);
+    }
+  }
+}
+
+export const __listenerTurnTestUtils = {
+  trackListenerUserInput,
+  buildInboundUserTranscriptLines,
+  seedInboundUserTranscriptLines,
+};

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -73,6 +73,7 @@ import type { ListenerTransport } from "./transport";
 import { handleApprovalStop } from "./turn-approval";
 import { runListenerTurnCleanup } from "./turn-cleanup";
 import { completeSuccessfulListenerTurn } from "./turn-completion";
+import { releaseListenerTurnContext } from "./turn-context";
 import type { TurnLease } from "./turn-lifecycle";
 import { createTurnInputSender } from "./turn-send";
 import { prepareListenerTurn } from "./turn-setup";
@@ -911,13 +912,17 @@ export async function handleIncomingMessage(
 
     richDraftStreamer?.dispose();
 
-    if (finalizedByThisInvocation) {
-      await runListenerTurnCleanup({
-        runtime,
-        agentId,
-        normalizedAgentId,
-        conversationId,
-      });
+    try {
+      if (finalizedByThisInvocation) {
+        await runListenerTurnCleanup({
+          runtime,
+          agentId,
+          normalizedAgentId,
+          conversationId,
+        });
+      }
+    } finally {
+      releaseListenerTurnContext({ runtime, agentId, conversationId });
     }
 
     evictConversationRuntimeIfIdle(runtime);

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -1,23 +1,8 @@
 import type { Stream } from "@letta-ai/letta-client/core/streaming";
-import type {
-  AgentState,
-  MessageCreate,
-} from "@letta-ai/letta-client/resources/agents/agents";
-import type {
-  ApprovalCreate,
-  LettaStreamingResponse,
-} from "@letta-ai/letta-client/resources/agents/messages";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import type { ApprovalResult } from "@/agent/approval-execution";
 import { fetchRunErrorInfo } from "@/agent/approval-recovery";
 import { getResumeDataFromBackend } from "@/agent/check-approval";
-import {
-  getConversationId,
-  getCurrentAgentId,
-  setConversationId,
-  setCurrentAgentId,
-  setCurrentAgentName,
-} from "@/agent/context";
-import { regenerateConversationDescription } from "@/agent/conversation-description";
 import {
   getStreamToolContextId,
   type sendMessageStream,
@@ -31,42 +16,16 @@ import {
 } from "@/agent/turn-recovery-policy";
 import { getBackend } from "@/backend";
 import {
-  type Buffers,
   createBuffers,
   findLastAssistantText,
-  type Line,
   toLines,
 } from "@/cli/helpers/accumulator";
 import { getRetryStatusMessage } from "@/cli/helpers/error-formatter";
-import {
-  getReflectionSettings,
-  type ReflectionSettings,
-  type ReflectionTrigger,
-} from "@/cli/helpers/memory-reminder";
-import { maybeLaunchPostTurnReflection } from "@/cli/helpers/post-turn-reflection";
-import {
-  AUTO_REFLECTION_DESCRIPTION,
-  launchReflectionSubagent,
-  queuePendingReflectionWorktreeReminders,
-} from "@/cli/helpers/reflection-launcher";
-import { appendTranscriptDeltaJsonl } from "@/cli/helpers/reflection-transcript";
 import { drainStreamWithResume } from "@/cli/helpers/stream";
-import { getTurnStartCancel } from "@/mods/turn-start-cancel";
-import {
-  buildSharedReminderParts,
-  prependReminderPartsToContent,
-} from "@/reminders/engine";
-import { buildListenReminderContext } from "@/reminders/listen-context";
-import { runPostTurnMemorySync } from "@/reminders/memory-git-sync";
-import { enqueueMemoryGitSyncReminder } from "@/reminders/state";
-import { settingsManager } from "@/settings-manager";
-import { getListenerTelemetrySurface, telemetry } from "@/telemetry";
+import { telemetry } from "@/telemetry";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
-import { extractTelemetryInputText } from "@/telemetry/input";
-import { prepareToolExecutionContextForScope } from "@/tools/toolset";
 import type { StopReasonType, StreamDelta } from "@/types/protocol_v2";
-import { debugLog, debugWarn, isDebugEnabled } from "@/utils/debug";
-import { detectShellContext } from "@/utils/shell-context";
+import { debugLog, isDebugEnabled } from "@/utils/debug";
 import { createChannelRichDraftStreamer } from "./channel-rich-draft-streamer";
 import {
   EMPTY_RESPONSE_MAX_RETRIES,
@@ -75,30 +34,18 @@ import {
 } from "./constants";
 import { getConversationWorkingDirectory } from "./cwd";
 import {
-  consumeInterruptQueue,
   emitInterruptToolReturnMessage,
   emitToolExecutionFinishedEvents,
   getInterruptApprovalsForEmission,
   normalizeToolReturnWireMessage,
   populateInterruptQueue,
 } from "./interrupts";
-import {
-  createListenerModContext,
-  ensureListenerModAdapter,
-} from "./mod-adapter";
-import {
-  getOrCreateConversationPermissionModeStateRef,
-  persistPermissionModeMapForRuntime,
-  pruneConversationPermissionModeStateIfDefault,
-} from "./permission-mode";
+import { getOrCreateConversationPermissionModeStateRef } from "./permission-mode";
 import {
   emitCanonicalMessageDelta,
-  emitDeviceStatusIfOpen,
-  emitInterruptedStatusDelta,
   emitLoopStatusUpdate,
   emitRetryDelta,
   emitRuntimeStateUpdates,
-  setLoopStatus,
 } from "./protocol-outbound";
 import {
   createProviderFallbackState,
@@ -110,305 +57,29 @@ import {
   emitRecoverableStatusNotice,
 } from "./recoverable-notices";
 import {
+  finalizeHandledRecoveryTurn,
   getApprovalToolCallDesyncErrorText,
   isRetriablePostStopError,
   shouldAttemptPostStopApprovalRecovery,
 } from "./recovery";
 import {
-  clearActiveRunState,
   clearRecoveredApprovalStateForScope,
   evictConversationRuntimeIfIdle,
 } from "./runtime";
 import { normalizeCwdAgentId } from "./scope";
-import {
-  isApprovalOnlyInput,
-  markAwaitingAcceptedApprovalContinuationRunId,
-  sendApprovalContinuationWithRetry,
-  sendMessageStreamWithRetry,
-} from "./send";
+import { markAwaitingAcceptedApprovalContinuationRunId } from "./send";
 import { injectQueuedSkillContent } from "./skill-injection";
 import type { ListenerTransport } from "./transport";
 import { handleApprovalStop } from "./turn-approval";
-import type {
-  ConversationRuntime,
-  InboundMessagePayload,
-  IncomingMessage,
-  ListenerRuntime,
-} from "./types";
-import { ensureListenerWarmStateForTurn } from "./warmup";
-
-function trackListenerUserInput(
-  messages: InboundMessagePayload[],
-  modelId: string,
-): void {
-  for (const message of messages) {
-    if (!("role" in message) || message.role !== "user") {
-      continue;
-    }
-
-    const inputText = extractTelemetryInputText(message.content);
-    if (inputText.length === 0) {
-      continue;
-    }
-
-    telemetry.trackUserInput(inputText, "user", modelId);
-  }
-}
-
-function buildInboundUserTranscriptLines(
-  messages: Array<MessageCreate | ApprovalCreate>,
-): Line[] {
-  const lines: Line[] = [];
-
-  for (const message of messages) {
-    if (!("role" in message) || message.role !== "user") {
-      continue;
-    }
-    if (!("content" in message)) {
-      continue;
-    }
-
-    const text = extractTelemetryInputText(message.content);
-    if (text.length === 0) {
-      continue;
-    }
-
-    const otid =
-      "otid" in message && typeof message.otid === "string"
-        ? message.otid
-        : undefined;
-    const id = otid ? `user-${otid}` : `user-${crypto.randomUUID()}`;
-
-    lines.push({
-      kind: "user",
-      id,
-      text,
-      otid,
-    });
-  }
-
-  return lines;
-}
-
-function seedInboundUserTranscriptLines(buffers: Buffers, lines: Line[]): void {
-  for (const line of lines) {
-    if (line.kind !== "user") {
-      continue;
-    }
-    if (buffers.byId.has(line.id)) {
-      continue;
-    }
-    buffers.byId.set(line.id, line);
-    buffers.order.push(line.id);
-    if (line.otid) {
-      buffers.userLineIdByOtid.set(line.otid, line.id);
-    }
-  }
-}
-
-export const __listenerTurnTestUtils = {
-  trackListenerUserInput,
-  buildInboundUserTranscriptLines,
-  seedInboundUserTranscriptLines,
-};
-
-function escapeTaskNotificationSummary(summary: string): string {
-  return summary
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
-
-function isTurnInputArray(
-  value: unknown,
-): value is Array<MessageCreate | ApprovalCreate> {
-  return (
-    Array.isArray(value) &&
-    value.every((item) => typeof item === "object" && item !== null)
-  );
-}
-
-type ListenerTurnStartEmission =
-  | { cancelled: false; input: Array<MessageCreate | ApprovalCreate> }
-  | { cancelled: true; reason: string };
-
-async function emitListenerTurnStart(options: {
-  agentId: string;
-  conversationId: string;
-  input: Array<MessageCreate | ApprovalCreate>;
-  runtime: ListenerRuntime;
-  workingDirectory: string;
-  permissionMode?: string | null;
-  cachedAgent?: AgentState | null;
-}): Promise<ListenerTurnStartEmission> {
-  try {
-    const modAdapter = ensureListenerModAdapter(options.runtime);
-    const context = createListenerModContext({
-      sessionId: options.conversationId,
-      workingDirectory: options.workingDirectory,
-      permissionMode: options.permissionMode ?? null,
-      agent: options.cachedAgent ?? null,
-    });
-    const event = {
-      agentId: options.agentId,
-      conversationId: options.conversationId,
-      input: options.input,
-    };
-    await modAdapter.events.emit("turn_start", event, context);
-    const cancel = getTurnStartCancel(event);
-    if (cancel) return { cancelled: true, reason: cancel.reason };
-    return {
-      cancelled: false,
-      input: isTurnInputArray(event.input) ? event.input : options.input,
-    };
-  } catch {
-    // Mod turn_start handlers should not block sending the turn.
-    return { cancelled: false, input: options.input };
-  }
-}
-
-async function emitListenerTurnEnd(options: {
-  agentId: string;
-  conversationId: string;
-  stopReason: string;
-  assistantMessage?: string;
-  runtime: ListenerRuntime;
-  workingDirectory: string;
-  permissionMode?: string | null;
-  cachedAgent?: AgentState | null;
-}): Promise<string | undefined> {
-  try {
-    const modAdapter = ensureListenerModAdapter(options.runtime);
-    const context = createListenerModContext({
-      sessionId: options.conversationId,
-      workingDirectory: options.workingDirectory,
-      permissionMode: options.permissionMode ?? null,
-      agent: options.cachedAgent ?? null,
-    });
-    const event: {
-      agentId: string;
-      conversationId: string;
-      stopReason: string;
-      assistantMessage?: string;
-      continue?: string;
-    } = {
-      agentId: options.agentId,
-      conversationId: options.conversationId,
-      stopReason: options.stopReason,
-      assistantMessage: options.assistantMessage,
-    };
-    await modAdapter.events.emit("turn_end", event, context);
-    return typeof event.continue === "string" && event.continue.length > 0
-      ? event.continue
-      : undefined;
-  } catch {
-    // Mod turn_end handlers should not block turn completion.
-    return undefined;
-  }
-}
-
-export function buildMaybeLaunchReflectionSubagent(params: {
-  runtime: ConversationRuntime;
-  socket: ListenerTransport;
-  agentId: string;
-  conversationId: string;
-  reflectionSettings?: ReflectionSettings;
-  cachedAgent?: AgentState | null;
-}): (triggerSource: Exclude<ReflectionTrigger, "off">) => Promise<boolean> {
-  return async (triggerSource) => {
-    const {
-      runtime,
-      socket,
-      agentId,
-      conversationId,
-      reflectionSettings,
-      cachedAgent,
-    } = params;
-
-    if (!agentId) {
-      return false;
-    }
-
-    const result = await launchReflectionSubagent({
-      agentId,
-      conversationId,
-      memfsEnabled: settingsManager.isMemfsEnabled(agentId),
-      triggerSource,
-      skipPendingWorktreeReminderScan: triggerSource === "compaction-event",
-      reflectionSettings,
-      description: AUTO_REFLECTION_DESCRIPTION,
-      systemPrompt: cachedAgent?.system ?? undefined,
-      recompileByConversation:
-        runtime.listener.systemPromptRecompileByConversation,
-      recompileQueuedByConversation:
-        runtime.listener.queuedSystemPromptRecompileByConversation,
-      feedbackContext: {
-        surface: getListenerTelemetrySurface(),
-      },
-      onCompletionMessage: async (completionMessage, result) => {
-        const reflectionAgentIdTag = result.reflectionAgentId
-          ? `<reflection-agent-id>${escapeTaskNotificationSummary(
-              result.reflectionAgentId,
-            )}</reflection-agent-id>`
-          : "";
-        const notificationXml = `<task-notification><summary>${escapeTaskNotificationSummary(
-          completionMessage,
-        )}</summary>${reflectionAgentIdTag}</task-notification>`;
-        emitCanonicalMessageDelta(
-          socket,
-          runtime,
-          {
-            type: "message",
-            id: `user-msg-${crypto.randomUUID()}`,
-            date: new Date().toISOString(),
-            message_type: "user_message",
-            content: [{ type: "text", text: notificationXml }],
-          } as StreamDelta,
-          {
-            agent_id: agentId,
-            conversation_id: conversationId,
-          },
-        );
-      },
-    });
-    return result.launched;
-  };
-}
-
-function finalizeInterruptedTurn(
-  socket: ListenerTransport,
-  runtime: ConversationRuntime,
-  params: {
-    runId?: string | null;
-    agentId?: string | null;
-    conversationId: string;
-  },
-): void {
-  const scope = {
-    agent_id: params.agentId ?? null,
-    conversation_id: params.conversationId,
-  };
-  const alreadyProjected =
-    runtime.cancelRequested &&
-    !runtime.isProcessing &&
-    runtime.loopStatus === "WAITING_ON_INPUT" &&
-    runtime.activeRunId === null &&
-    runtime.activeAbortController === null;
-
-  runtime.lastStopReason = "cancelled";
-  runtime.isProcessing = false;
-
-  if (!alreadyProjected) {
-    emitInterruptedStatusDelta(socket, runtime, {
-      runId: params.runId,
-      agentId: params.agentId,
-      conversationId: params.conversationId,
-    });
-    clearActiveRunState(runtime);
-    setLoopStatus(runtime, "WAITING_ON_INPUT", scope);
-    emitRuntimeStateUpdates(runtime, scope);
-  }
-}
+import { runListenerTurnCleanup } from "./turn-cleanup";
+import { completeSuccessfulListenerTurn } from "./turn-completion";
+import type { TurnLease } from "./turn-lifecycle";
+import { createTurnInputSender } from "./turn-send";
+import { prepareListenerTurn } from "./turn-setup";
+import { setTurnLoopStatus } from "./turn-status";
+import { finishListenerTurn } from "./turn-terminal";
+import { seedInboundUserTranscriptLines } from "./turn-transcript";
+import type { ConversationRuntime, IncomingMessage } from "./types";
 
 export async function handleIncomingMessage(
   msg: IncomingMessage,
@@ -420,6 +91,7 @@ export async function handleIncomingMessage(
   ) => void,
   connectionId?: string,
   dequeuedBatchId: string = `batch-direct-${crypto.randomUUID()}`,
+  existingTurnLease?: TurnLease,
 ): Promise<void> {
   const agentId = msg.agentId;
   const requestedConversationId = msg.conversationId || undefined;
@@ -453,280 +125,120 @@ export async function handleIncomingMessage(
     sources: msg.channelTurnSources,
   });
 
-  runtime.isProcessing = true;
-  runtime.cancelRequested = false;
-  runtime.lastStopReason = null;
-  runtime.lastTerminalLoopErrorMessage = null;
-  runtime.lastTerminalLoopErrorRunId = null;
-  const turnAbortController = new AbortController();
-  runtime.activeAbortController = turnAbortController;
-  const turnAbortSignal = turnAbortController.signal;
-  runtime.activeWorkingDirectory = turnWorkingDirectory;
-  runtime.activeRunId = null;
-  runtime.activeRunStartedAt = new Date().toISOString();
-  runtime.activeExecutingToolCallIds = [];
-  setLoopStatus(runtime, "SENDING_API_REQUEST", {
-    agent_id: agentId ?? null,
-    conversation_id: conversationId,
-  });
-  clearRecoveredApprovalStateForScope(runtime.listener, {
-    agent_id: agentId ?? null,
-    conversation_id: conversationId,
-  });
-  emitRuntimeStateUpdates(runtime, {
-    agent_id: agentId ?? null,
-    conversation_id: conversationId,
-  });
+  const turnLease =
+    existingTurnLease ??
+    runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: turnWorkingDirectory,
+    });
+  if (!runtime.turnLifecycle.isCurrent(turnLease)) {
+    throw new Error("Cannot continue a turn with a stale lifecycle lease");
+  }
+  const turnAbortSignal = turnLease.signal;
+  let finalizedByThisInvocation = false;
+  const noteFinalization = (
+    transition: ReturnType<typeof finishListenerTurn>,
+  ) => {
+    if (transition.finished) {
+      finalizedByThisInvocation = true;
+    }
+    return transition;
+  };
+  const finishTurn = (options: Parameters<typeof finishListenerTurn>[2]) =>
+    noteFinalization(finishListenerTurn(runtime, turnLease, options));
+  const finishIfInterrupted = (runId?: string | null): boolean => {
+    if (
+      !turnAbortSignal.aborted &&
+      runtime.turnLifecycle.isCurrent(turnLease)
+    ) {
+      return false;
+    }
+    finishTurn({
+      stopReason: "cancelled",
+      socket,
+      runId,
+      agentId: agentId ?? null,
+      conversationId,
+    });
+    return true;
+  };
 
   try {
+    runtime.lastTerminalLoopErrorMessage = null;
+    runtime.lastTerminalLoopErrorRunId = null;
+    setTurnLoopStatus(runtime, turnLease, "SENDING_API_REQUEST", {
+      agent_id: agentId ?? null,
+      conversation_id: conversationId,
+    });
+    clearRecoveredApprovalStateForScope(runtime.listener, {
+      agent_id: agentId ?? null,
+      conversation_id: conversationId,
+    });
+    emitRuntimeStateUpdates(runtime, {
+      agent_id: agentId ?? null,
+      conversation_id: conversationId,
+    });
     telemetry.setCurrentAgentId(agentId ?? null);
 
     if (!agentId) {
-      runtime.isProcessing = false;
-      clearActiveRunState(runtime);
-      setLoopStatus(runtime, "WAITING_ON_INPUT", {
-        conversation_id: conversationId,
-      });
-      emitRuntimeStateUpdates(runtime, {
-        conversation_id: conversationId,
+      finishTurn({
+        stopReason: "error",
+        conversationId,
       });
       return;
     }
 
-    // Ensure local per-agent state is ready before reminders and tool execution.
-    let listenAgentMetadata = await ensureListenerWarmStateForTurn(
-      runtime.listener,
-      {
+    let turnToolContextId: string | null = null;
+    const setup = await prepareListenerTurn({
+      msg,
+      runtime,
+      agentId,
+      requestedConversationId,
+      conversationId,
+      workingDirectory: turnWorkingDirectory,
+      permissionModeState: turnPermissionModeState,
+      turnLease,
+      onStatusChange,
+      connectionId,
+    });
+    if (setup.kind === "interrupted") {
+      finishTurn({
+        stopReason: "cancelled",
+        socket,
         agentId,
         conversationId,
-      },
-    );
-
-    // Set agent context for tools that need it (e.g., Skill tool)
-    setCurrentAgentId(agentId);
-    setCurrentAgentName(listenAgentMetadata?.name ?? null);
-    setConversationId(conversationId);
-
-    if (isDebugEnabled()) {
-      console.log(
-        `[Listen] Handling message: agentId=${agentId}, requestedConversationId=${requestedConversationId}, conversationId=${conversationId}`,
-      );
+      });
+      return;
     }
-
-    if (connectionId) {
-      onStatusChange?.("processing", connectionId);
-    }
-
-    const { normalizeInboundMessages } = await import(
-      "@/websocket/listener/queue"
-    );
-    const normalizedMessages = await normalizeInboundMessages(
-      msg.messages,
-      undefined,
-      {
-        imageFailureMode:
-          (msg.channelTurnSources?.length ?? 0) > 0 ? "drop" : "strict",
-      },
-    );
-    trackListenerUserInput(normalizedMessages, "unknown");
-    const messagesToSend: Array<MessageCreate | ApprovalCreate> = [];
-    let turnToolContextId: string | null = null;
-    let queuedInterruptedToolCallIds: string[] = [];
-
-    const consumed = consumeInterruptQueue(
-      runtime,
-      agentId || "",
-      conversationId,
-    );
-    if (consumed) {
-      messagesToSend.push(consumed.approvalMessage);
-      queuedInterruptedToolCallIds = consumed.interruptedToolCallIds;
-    }
-
-    messagesToSend.push(
-      ...normalizedMessages.map((m) =>
-        "content" in m && !m.otid
-          ? {
-              ...m,
-              // Ensure every client-originated message carries an OTID so the
-              // echoed user_message can reconcile optimistic local transcript
-              // rows with the later canonical backend message.id.
-              otid:
-                "client_message_id" in m &&
-                typeof m.client_message_id === "string"
-                  ? m.client_message_id
-                  : crypto.randomUUID(),
-            }
-          : m,
-      ),
-    );
-    // Build transcript lines after turn_start so transformed input is shown.
-    // This is reassigned below after emitListenerTurnStart.
-    let inboundUserTranscriptLines =
-      buildInboundUserTranscriptLines(messagesToSend);
-
-    const firstMessage = normalizedMessages[0];
-    const isApprovalMessage =
-      firstMessage &&
-      "type" in firstMessage &&
-      firstMessage.type === "approval" &&
-      "approvals" in firstMessage;
-
-    let cachedAgent: AgentState | null = null;
-
-    if (!isApprovalMessage) {
-      try {
-        if (agentId) {
-          try {
-            cachedAgent = (await getBackend().retrieveAgent(agentId, {
-              include: ["agent.tags"],
-            })) as AgentState;
-
-            const {
-              ensureLettaCodeOriginTag,
-              getMemoryPromptModeForAgent,
-              scheduleManagedSystemPromptUpdate,
-            } = await import("@/agent/system-prompt-versioning");
-            cachedAgent = await ensureLettaCodeOriginTag(cachedAgent);
-            scheduleManagedSystemPromptUpdate({
-              agent: cachedAgent,
-              memoryMode: getMemoryPromptModeForAgent(cachedAgent.id),
-              onUpdated: (updatedAgent) => {
-                cachedAgent = updatedAgent;
-              },
-            });
-          } catch (error) {
-            debugWarn(
-              "listen",
-              `Failed to ensure Letta Code agent metadata for ${agentId}: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            );
-            // Best-effort only. If the fetch fails, reminder and tool prep
-            // will fall back to the existing null/placeholder behavior.
-          }
-        }
-
-        if (!runtime.reminderState.hasSentAgentInfo && cachedAgent) {
-          listenAgentMetadata = {
-            name: cachedAgent.name ?? null,
-            description: cachedAgent.description ?? null,
-            lastRunAt:
-              (cachedAgent as { last_run_completion?: string | null })
-                .last_run_completion ?? null,
-          };
-        }
-        setCurrentAgentName(
-          listenAgentMetadata?.name ?? cachedAgent?.name ?? null,
-        );
-        const { parts: reminderParts } = await buildSharedReminderParts(
-          buildListenReminderContext({
-            agentId: agentId || "",
-            conversationId,
-            agentName: listenAgentMetadata?.name ?? null,
-            agentDescription: listenAgentMetadata?.description ?? null,
-            agentLastRunAt: listenAgentMetadata?.lastRunAt ?? null,
-            state: runtime.reminderState,
-            workingDirectory: turnWorkingDirectory,
-            shellContext: detectShellContext(),
-          }),
-        );
-
-        if (reminderParts.length > 0) {
-          for (const m of messagesToSend) {
-            if ("role" in m && m.role === "user" && "content" in m) {
-              m.content = prependReminderPartsToContent(
-                m.content,
-                reminderParts,
-              );
-              break;
-            }
-          }
-        }
-      } catch (err) {
-        // Reminder injection is best-effort — failures must not prevent
-        // the user message from being sent to the agent.
-        trackBoundaryError({
-          errorType: "listener_reminder_build_failed",
-          error: err,
-          context: "listener_turn_reminders",
-        });
-        if (isDebugEnabled()) {
-          console.error("[Listen] Failed to build reminder parts:", err);
-        }
+    if (setup.kind === "cancelled") {
+      const transition = finishTurn({
+        stopReason: "cancelled",
+        agentId: agentId || null,
+        conversationId,
+      });
+      if (!transition.finished) {
+        return;
       }
-    }
-
-    // Only emit turn_start for user messages, not approval-only continuations.
-    // A mod could otherwise rewrite approval payloads and break routing.
-    const hasUserMessage = messagesToSend.some(
-      (m) => "role" in m && m.role === "user",
-    );
-    const turnStartEmission = hasUserMessage
-      ? await emitListenerTurnStart({
-          agentId,
-          conversationId,
-          input: messagesToSend,
-          runtime: runtime.listener,
-          workingDirectory: turnWorkingDirectory,
-          permissionMode: turnPermissionModeState.mode,
-          cachedAgent,
-        })
-      : ({ cancelled: false, input: messagesToSend } as const);
-
-    if (turnStartEmission.cancelled) {
-      runtime.lastStopReason = "cancelled";
-      runtime.isProcessing = false;
-      clearActiveRunState(runtime);
-      setLoopStatus(runtime, "WAITING_ON_INPUT", {
-        agent_id: agentId || null,
-        conversation_id: conversationId,
-      });
-      emitRuntimeStateUpdates(runtime, {
-        agent_id: agentId || null,
-        conversation_id: conversationId,
-      });
       const formattedError = emitLoopErrorNotice(socket, runtime, {
-        message: turnStartEmission.reason,
+        message: setup.reason,
         stopReason: "cancelled",
         isTerminal: true,
         agentId,
         conversationId,
-        cancelRequested: runtime.cancelRequested,
+        cancelRequested: turnAbortSignal.aborted,
         abortSignal: turnAbortSignal,
       });
-      runtime.lastTerminalLoopErrorMessage =
-        formattedError ?? turnStartEmission.reason;
+      runtime.lastTerminalLoopErrorMessage = formattedError ?? setup.reason;
       return;
     }
-
-    let currentInput = turnStartEmission.input;
-
-    // Rebuild transcript lines from the potentially transformed input so
-    // Desktop shows post-transform text, not the original user message.
-    if (currentInput !== messagesToSend) {
-      inboundUserTranscriptLines =
-        buildInboundUserTranscriptLines(currentInput);
-    }
-    const providerFallback = createProviderFallbackState(cachedAgent);
-    let pendingNormalizationInterruptedToolCallIds = [
-      ...queuedInterruptedToolCallIds,
-    ];
-    const preparedToolContext = await prepareToolExecutionContextForScope({
-      agentId,
-      conversationId,
-      clientToolAllowlist: msg.clientToolAllowlist,
-      externalToolScopeIds: msg.externalToolScopeIds,
-      workingDirectory: turnWorkingDirectory,
-      permissionModeState: turnPermissionModeState,
-      cachedAgent,
-      channelTurnSources: msg.channelTurnSources,
-      modEvents: ensureListenerModAdapter(runtime.listener).events,
-    });
-    runtime.currentToolset = preparedToolContext.toolset;
-    runtime.currentToolsetPreference = preparedToolContext.toolsetPreference;
-    runtime.currentLoadedTools =
-      preparedToolContext.preparedToolContext.loadedToolNames;
+    let currentInput = setup.currentInput;
+    const inboundUserTranscriptLines = setup.inboundUserTranscriptLines;
+    const providerFallback = createProviderFallbackState(
+      setup.getCachedAgent(),
+    );
+    let pendingNormalizationInterruptedToolCallIds =
+      setup.pendingNormalizationInterruptedToolCallIds;
+    const preparedToolContext = setup.preparedToolContext;
     const buildSendOptions = (): Parameters<typeof sendMessageStream>[2] => ({
       agentId,
       streamTokens: true,
@@ -738,10 +250,6 @@ export async function handleIncomingMessage(
       ...(providerFallback.overrideModel
         ? { overrideModel: providerFallback.overrideModel }
         : {}),
-      // Forward cloud-api's per-WS acting user id so the outbound
-      // createMessage HTTP call carries X-Letta-Acting-User-Id and
-      // cloud can attribute credits to the actual sender on
-      // multi-user sandboxes.
       ...(msg.actingUserId ? { actingUserId: msg.actingUserId } : {}),
       ...(pendingNormalizationInterruptedToolCallIds.length > 0
         ? {
@@ -753,35 +261,34 @@ export async function handleIncomingMessage(
         : {}),
     });
 
-    const isPureApprovalContinuation = isApprovalOnlyInput(currentInput);
-    const currentInputWithSkillContent = injectQueuedSkillContent(currentInput);
+    const turnInputSender = createTurnInputSender({
+      conversationId,
+      agentId,
+      socket,
+      runtime,
+      turnLease,
+      providerFallback,
+      buildSendOptions,
+      onTerminal: noteFinalization,
+    });
 
-    let stream = isPureApprovalContinuation
-      ? await sendApprovalContinuationWithRetry(
-          conversationId,
-          currentInputWithSkillContent,
-          buildSendOptions(),
-          socket,
-          runtime,
-          turnAbortSignal,
-          { providerFallback },
-        )
-      : await sendMessageStreamWithRetry(
-          conversationId,
-          currentInputWithSkillContent,
-          buildSendOptions(),
-          socket,
-          runtime,
-          turnAbortSignal,
-          { providerFallback },
-        );
+    const currentInputWithSkillContent = injectQueuedSkillContent(currentInput);
+    const initialSendResult = await turnInputSender.send(
+      currentInputWithSkillContent,
+    );
     currentInput = currentInputWithSkillContent;
-    if (!stream) {
+    const initialStream = turnInputSender.accept(initialSendResult);
+    if (!initialStream) {
       return;
     }
+    let stream = initialStream;
     pendingNormalizationInterruptedToolCallIds = [];
-    markAwaitingAcceptedApprovalContinuationRunId(runtime, currentInput);
-    setLoopStatus(runtime, "PROCESSING_API_RESPONSE", {
+    markAwaitingAcceptedApprovalContinuationRunId(
+      runtime,
+      turnLease,
+      currentInput,
+    );
+    setTurnLoopStatus(runtime, turnLease, "PROCESSING_API_RESPONSE", {
       agent_id: agentId,
       conversation_id: conversationId,
     });
@@ -794,7 +301,6 @@ export async function handleIncomingMessage(
     const buffers = createBuffers(agentId);
     seedInboundUserTranscriptLines(buffers, inboundUserTranscriptLines);
 
-    // eslint-disable-next-line no-constant-condition
     while (true) {
       runIdSent = false;
       let latestErrorText: string | null = null;
@@ -805,15 +311,13 @@ export async function handleIncomingMessage(
         turnAbortSignal,
         undefined,
         ({ chunk, shouldOutput, errorInfo }) => {
-          if (runtime.cancelRequested) {
+          if (turnAbortSignal.aborted) {
             return undefined;
           }
           const maybeRunId = (chunk as { run_id?: unknown }).run_id;
           if (typeof maybeRunId === "string") {
             runId = maybeRunId;
-            if (runtime.activeRunId !== maybeRunId) {
-              runtime.activeRunId = maybeRunId;
-            }
+            runtime.turnLifecycle.setRunId(turnLease, maybeRunId);
             if (!runIdSent) {
               runIdSent = true;
               msgRunIds.push(maybeRunId);
@@ -843,7 +347,7 @@ export async function handleIncomingMessage(
                 agentId,
                 conversationId,
                 errorInfo,
-                cancelRequested: runtime.cancelRequested,
+                cancelRequested: turnAbortSignal.aborted,
                 abortSignal: turnAbortSignal,
               });
             } else {
@@ -887,128 +391,53 @@ export async function handleIncomingMessage(
       const stopReason = result.stopReason;
       const approvals = result.approvals || [];
       const fallbackError = result.fallbackError ?? null;
-      if (
-        stopReason === "requires_approval" ||
-        (stopReason === "end_turn" && !runtime.cancelRequested)
-      ) {
+      if (finishIfInterrupted(runId || runtime.activeRunId)) {
+        break;
+      }
+      if (stopReason === "requires_approval" || stopReason === "end_turn") {
         await richDraftStreamer?.flushPending();
+      }
+      if (finishIfInterrupted(runId || runtime.activeRunId)) {
+        break;
       }
       lastApprovalContinuationAccepted = false;
 
-      if (stopReason === "end_turn" && runtime.cancelRequested) {
-        finalizeInterruptedTurn(socket, runtime, {
-          runId: runId || runtime.activeRunId,
-          agentId: agentId ?? null,
-          conversationId,
-        });
-        break;
-      }
-
       if (stopReason === "end_turn") {
-        const continueText = await emitListenerTurnEnd({
+        const transcriptLines = toLines(buffers);
+        const completion = await completeSuccessfulListenerTurn({
+          runtime,
+          socket,
           agentId,
           conversationId,
-          stopReason,
-          assistantMessage: findLastAssistantText(toLines(buffers)),
-          runtime: runtime.listener,
           workingDirectory: turnWorkingDirectory,
           permissionMode: turnPermissionModeState.mode,
-          cachedAgent,
+          actingUserId: msg.actingUserId,
+          assistantMessage: findLastAssistantText(transcriptLines),
+          transcriptLines,
+          getCachedAgent: setup.getCachedAgent,
+          isInterrupted: () =>
+            turnAbortSignal.aborted ||
+            !runtime.turnLifecycle.isCurrent(turnLease),
         });
-        if (continueText) {
-          // A mod asked to keep going: enqueue a follow-up turn. The post-turn
-          // re-pump runs it. The phantom user message is suppressed in
-          // emitDequeuedUserMessage so the continue stays seamless.
-          runtime.queueRuntime.enqueue({
-            kind: "mod_continue",
-            source: "system",
-            text: continueText,
-            agentId: agentId ?? undefined,
-            conversationId,
-            actingUserId: msg.actingUserId,
-          } as Omit<
-            import("@/queue/queue-runtime").ModContinueQueueItem,
-            "id" | "enqueuedAt"
-          >);
+        if (
+          completion === "interrupted" ||
+          finishIfInterrupted(runId || runtime.activeRunId)
+        ) {
+          break;
         }
-        try {
-          const transcriptLines = toLines(buffers);
-          if (transcriptLines.length > 0) {
-            await appendTranscriptDeltaJsonl(
-              agentId || "",
-              conversationId,
-              transcriptLines,
-            );
-          }
-        } catch (transcriptError) {
-          debugWarn(
-            "memory",
-            `Failed to append transcript delta: ${
-              transcriptError instanceof Error
-                ? transcriptError.message
-                : String(transcriptError)
-            }`,
-          );
-        }
-        try {
-          const reflectionSettings = getReflectionSettings(
-            agentId || undefined,
-            turnWorkingDirectory,
-          );
-          await maybeLaunchPostTurnReflection({
-            agentId,
-            conversationId,
-            memfsEnabled: Boolean(
-              agentId && settingsManager.isMemfsEnabled(agentId),
-            ),
-            reflectionSettings,
-            reminderState: runtime.reminderState,
-            contextTracker: runtime.contextTracker,
-            onCompaction: () =>
-              queuePendingReflectionWorktreeReminders({
-                agentId: agentId || "",
-                conversationId,
-              }),
-            launch: buildMaybeLaunchReflectionSubagent({
-              runtime,
-              socket,
-              agentId: agentId || "",
-              conversationId,
-              reflectionSettings,
-              cachedAgent,
-            }),
-          });
-        } catch (reflectionError) {
-          debugWarn(
-            "memory",
-            `Failed to evaluate post-turn channel reflection: ${
-              reflectionError instanceof Error
-                ? reflectionError.message
-                : String(reflectionError)
-            }`,
-          );
-        }
-        if (runtime.contextTracker.pendingConversationDescriptionRegeneration) {
-          runtime.contextTracker.pendingConversationDescriptionRegeneration = false;
-          void regenerateConversationDescription(conversationId);
-        }
-        runtime.lastStopReason = "end_turn";
-        runtime.isProcessing = false;
-        clearActiveRunState(runtime);
-        setLoopStatus(runtime, "WAITING_ON_INPUT", {
-          agent_id: agentId,
-          conversation_id: conversationId,
-        });
-        emitRuntimeStateUpdates(runtime, {
-          agent_id: agentId,
-          conversation_id: conversationId,
+        finishTurn({
+          stopReason: "end_turn",
+          agentId,
+          conversationId,
         });
 
         break;
       }
 
       if (stopReason === "cancelled") {
-        finalizeInterruptedTurn(socket, runtime, {
+        finishTurn({
+          stopReason: "cancelled",
+          socket,
           runId: runId || runtime.activeRunId,
           agentId: agentId ?? null,
           conversationId,
@@ -1021,6 +450,9 @@ export async function handleIncomingMessage(
         const runErrorInfo = lastRunId
           ? await fetchRunErrorInfo(lastRunId)
           : null;
+        if (finishIfInterrupted(lastRunId || runtime.activeRunId)) {
+          break;
+        }
         const errorDetail =
           latestErrorText ||
           runErrorInfo?.detail ||
@@ -1061,41 +493,32 @@ export async function handleIncomingMessage(
           } catch {
             currentInput = rebuildInputWithFreshDenials(currentInput, [], "");
           }
+          if (finishIfInterrupted(lastRunId || runtime.activeRunId)) {
+            break;
+          }
 
-          setLoopStatus(runtime, "SENDING_API_REQUEST", {
+          setTurnLoopStatus(runtime, turnLease, "SENDING_API_REQUEST", {
             agent_id: agentId,
             conversation_id: conversationId,
           });
-          const isPureApprovalContinuationRetry =
-            isApprovalOnlyInput(currentInput);
           const retryInputWithSkillContent =
             injectQueuedSkillContent(currentInput);
-          stream = isPureApprovalContinuationRetry
-            ? await sendApprovalContinuationWithRetry(
-                conversationId,
-                retryInputWithSkillContent,
-                buildSendOptions(),
-                socket,
-                runtime,
-                turnAbortSignal,
-                { providerFallback },
-              )
-            : await sendMessageStreamWithRetry(
-                conversationId,
-                retryInputWithSkillContent,
-                buildSendOptions(),
-                socket,
-                runtime,
-                turnAbortSignal,
-                { providerFallback },
-              );
+          const retrySendResult = await turnInputSender.send(
+            retryInputWithSkillContent,
+          );
           currentInput = retryInputWithSkillContent;
-          if (!stream) {
+          const retryStream = turnInputSender.accept(retrySendResult);
+          if (!retryStream) {
             return;
           }
+          stream = retryStream;
           pendingNormalizationInterruptedToolCallIds = [];
-          markAwaitingAcceptedApprovalContinuationRunId(runtime, currentInput);
-          setLoopStatus(runtime, "PROCESSING_API_RESPONSE", {
+          markAwaitingAcceptedApprovalContinuationRunId(
+            runtime,
+            turnLease,
+            currentInput,
+          );
+          setTurnLoopStatus(runtime, turnLease, "PROCESSING_API_RESPONSE", {
             agent_id: agentId,
             conversation_id: conversationId,
           });
@@ -1149,40 +572,28 @@ export async function handleIncomingMessage(
           }
           currentInput = refreshInputOtidsForNewRequest(currentInput);
 
-          setLoopStatus(runtime, "SENDING_API_REQUEST", {
+          setTurnLoopStatus(runtime, turnLease, "SENDING_API_REQUEST", {
             agent_id: agentId,
             conversation_id: conversationId,
           });
-          const isPureApprovalContinuationRetry =
-            isApprovalOnlyInput(currentInput);
           const retryInputWithSkillContent =
             injectQueuedSkillContent(currentInput);
-          stream = isPureApprovalContinuationRetry
-            ? await sendApprovalContinuationWithRetry(
-                conversationId,
-                retryInputWithSkillContent,
-                buildSendOptions(),
-                socket,
-                runtime,
-                turnAbortSignal,
-                { providerFallback },
-              )
-            : await sendMessageStreamWithRetry(
-                conversationId,
-                retryInputWithSkillContent,
-                buildSendOptions(),
-                socket,
-                runtime,
-                turnAbortSignal,
-                { providerFallback },
-              );
+          const retrySendResult = await turnInputSender.send(
+            retryInputWithSkillContent,
+          );
           currentInput = retryInputWithSkillContent;
-          if (!stream) {
+          const retryStream = turnInputSender.accept(retrySendResult);
+          if (!retryStream) {
             return;
           }
+          stream = retryStream;
           pendingNormalizationInterruptedToolCallIds = [];
-          markAwaitingAcceptedApprovalContinuationRunId(runtime, currentInput);
-          setLoopStatus(runtime, "PROCESSING_API_RESPONSE", {
+          markAwaitingAcceptedApprovalContinuationRunId(
+            runtime,
+            turnLease,
+            currentInput,
+          );
+          setTurnLoopStatus(runtime, turnLease, "PROCESSING_API_RESPONSE", {
             agent_id: agentId,
             conversation_id: conversationId,
           });
@@ -1197,6 +608,9 @@ export async function handleIncomingMessage(
           lastRunId,
           errorDetail,
         );
+        if (finishIfInterrupted(lastRunId || runtime.activeRunId)) {
+          break;
+        }
         if (retriable && llmApiErrorRetries < LLM_API_ERROR_MAX_RETRIES) {
           llmApiErrorRetries += 1;
           const attempt = llmApiErrorRetries;
@@ -1235,40 +649,28 @@ export async function handleIncomingMessage(
           }
           currentInput = refreshInputOtidsForNewRequest(currentInput);
 
-          setLoopStatus(runtime, "SENDING_API_REQUEST", {
+          setTurnLoopStatus(runtime, turnLease, "SENDING_API_REQUEST", {
             agent_id: agentId,
             conversation_id: conversationId,
           });
-          const isPureApprovalContinuationRetry =
-            isApprovalOnlyInput(currentInput);
           const retryInputWithSkillContent =
             injectQueuedSkillContent(currentInput);
-          stream = isPureApprovalContinuationRetry
-            ? await sendApprovalContinuationWithRetry(
-                conversationId,
-                retryInputWithSkillContent,
-                buildSendOptions(),
-                socket,
-                runtime,
-                turnAbortSignal,
-                { providerFallback },
-              )
-            : await sendMessageStreamWithRetry(
-                conversationId,
-                retryInputWithSkillContent,
-                buildSendOptions(),
-                socket,
-                runtime,
-                turnAbortSignal,
-                { providerFallback },
-              );
+          const retrySendResult = await turnInputSender.send(
+            retryInputWithSkillContent,
+          );
           currentInput = retryInputWithSkillContent;
-          if (!stream) {
+          const retryStream = turnInputSender.accept(retrySendResult);
+          if (!retryStream) {
             return;
           }
+          stream = retryStream;
           pendingNormalizationInterruptedToolCallIds = [];
-          markAwaitingAcceptedApprovalContinuationRunId(runtime, currentInput);
-          setLoopStatus(runtime, "PROCESSING_API_RESPONSE", {
+          markAwaitingAcceptedApprovalContinuationRunId(
+            runtime,
+            turnLease,
+            currentInput,
+          );
+          setTurnLoopStatus(runtime, turnLease, "PROCESSING_API_RESPONSE", {
             agent_id: agentId,
             conversation_id: conversationId,
           });
@@ -1278,12 +680,14 @@ export async function handleIncomingMessage(
           continue;
         }
 
-        const effectiveStopReason: StopReasonType = runtime.cancelRequested
+        const effectiveStopReason: StopReasonType = turnAbortSignal.aborted
           ? "cancelled"
           : (stopReason as StopReasonType) || "error";
 
         if (effectiveStopReason === "cancelled") {
-          finalizeInterruptedTurn(socket, runtime, {
+          finishTurn({
+            stopReason: "cancelled",
+            socket,
             runId: runId || runtime.activeRunId,
             agentId: agentId ?? null,
             conversationId,
@@ -1291,23 +695,19 @@ export async function handleIncomingMessage(
           break;
         }
 
-        runtime.lastStopReason = effectiveStopReason;
-        runtime.isProcessing = false;
-        clearActiveRunState(runtime);
-        setLoopStatus(runtime, "WAITING_ON_INPUT", {
-          agent_id: agentId,
-          conversation_id: conversationId,
-        });
-        emitRuntimeStateUpdates(runtime, {
-          agent_id: agentId,
-          conversation_id: conversationId,
-        });
-
         const errorMessage =
           errorDetail || `Unexpected stop reason: ${stopReason}`;
 
         const terminalRunId =
           runId || runtime.activeRunId || runErrorInfo?.run_id;
+        const transition = finishTurn({
+          stopReason: effectiveStopReason,
+          agentId,
+          conversationId,
+        });
+        if (!transition.finished) {
+          break;
+        }
         const formattedError = emitLoopErrorNotice(socket, runtime, {
           message: errorMessage,
           stopReason: effectiveStopReason,
@@ -1316,7 +716,7 @@ export async function handleIncomingMessage(
           agentId,
           conversationId,
           runErrorInfo: runErrorInfo ?? undefined,
-          cancelRequested: runtime.cancelRequested,
+          cancelRequested: turnAbortSignal.aborted,
           abortSignal: turnAbortSignal,
         });
         runtime.lastTerminalLoopErrorMessage = formattedError ?? errorMessage;
@@ -1338,13 +738,35 @@ export async function handleIncomingMessage(
         currentInput,
         pendingNormalizationInterruptedToolCallIds,
         turnToolContextId,
+        turnLease,
         buildSendOptions,
         providerFallback,
       });
-      if (approvalResult.terminated || !approvalResult.stream) {
+
+      if (approvalResult.kind === "error") {
+        const terminalRunId = runId || runtime.activeRunId;
+        const transition = finishTurn({
+          stopReason: "error",
+          agentId,
+          conversationId,
+        });
+        if (!transition.finished) {
+          return;
+        }
+        const formattedError = emitLoopErrorNotice(socket, runtime, {
+          message: approvalResult.message,
+          stopReason: "error",
+          isTerminal: true,
+          runId: terminalRunId,
+          agentId,
+          conversationId,
+        });
+        runtime.lastTerminalLoopErrorMessage =
+          formattedError ?? approvalResult.message;
+        runtime.lastTerminalLoopErrorRunId = terminalRunId ?? null;
         return;
       }
-      stream = approvalResult.stream;
+
       currentInput = approvalResult.currentInput;
       activeDequeuedBatchId = approvalResult.dequeuedBatchId;
       pendingNormalizationInterruptedToolCallIds =
@@ -1356,6 +778,39 @@ export async function handleIncomingMessage(
         approvalResult.lastNeedsUserInputToolCallIds;
       lastApprovalContinuationAccepted =
         approvalResult.lastApprovalContinuationAccepted;
+
+      if (approvalResult.kind === "interrupted") {
+        if (runtime.turnLifecycle.isCurrent(turnLease)) {
+          populateInterruptQueue(runtime, {
+            lastExecutionResults,
+            lastExecutingToolCallIds,
+            lastNeedsUserInputToolCallIds,
+            agentId: agentId || "",
+            conversationId,
+          });
+        }
+        finishTurn({
+          stopReason: "cancelled",
+          socket,
+          runId: runId || runtime.activeRunId,
+          agentId,
+          conversationId,
+        });
+        return;
+      }
+
+      if (approvalResult.kind === "terminal") {
+        noteFinalization(
+          finalizeHandledRecoveryTurn(runtime, socket, turnLease, {
+            drainResult: approvalResult.drainResult,
+            agentId,
+            conversationId,
+          }),
+        );
+        return;
+      }
+
+      stream = approvalResult.stream;
       turnToolContextId = getStreamToolContextId(
         stream as Stream<LettaStreamingResponse>,
       );
@@ -1367,8 +822,11 @@ export async function handleIncomingMessage(
       context: "listener_turn_processing",
       runId: runtime.activeRunId || msgRunIds[msgRunIds.length - 1],
     });
-    if (runtime.cancelRequested) {
-      if (!lastApprovalContinuationAccepted) {
+    if (turnAbortSignal.aborted) {
+      if (
+        runtime.turnLifecycle.isCurrent(turnLease) &&
+        !lastApprovalContinuationAccepted
+      ) {
         populateInterruptQueue(runtime, {
           lastExecutionResults,
           lastExecutingToolCallIds,
@@ -1397,7 +855,9 @@ export async function handleIncomingMessage(
         }
       }
 
-      finalizeInterruptedTurn(socket, runtime, {
+      finishTurn({
+        stopReason: "cancelled",
+        socket,
         runId: runtime.activeRunId || msgRunIds[msgRunIds.length - 1],
         agentId: agentId || null,
         conversationId,
@@ -1406,20 +866,16 @@ export async function handleIncomingMessage(
       return;
     }
 
-    runtime.lastStopReason = "error";
-    runtime.isProcessing = false;
-    clearActiveRunState(runtime);
-    setLoopStatus(runtime, "WAITING_ON_INPUT", {
-      agent_id: agentId || null,
-      conversation_id: conversationId,
-    });
-    emitRuntimeStateUpdates(runtime, {
-      agent_id: agentId || null,
-      conversation_id: conversationId,
-    });
-
     const errorMessage = error instanceof Error ? error.message : String(error);
     const terminalRunId = runtime.activeRunId;
+    const transition = finishTurn({
+      stopReason: "error",
+      agentId: agentId || null,
+      conversationId,
+    });
+    if (!transition.finished) {
+      return;
+    }
     const formattedError = emitLoopErrorNotice(socket, runtime, {
       message: errorMessage,
       stopReason: "error",
@@ -1428,7 +884,7 @@ export async function handleIncomingMessage(
       agentId: agentId || undefined,
       conversationId,
       error,
-      cancelRequested: runtime.cancelRequested,
+      cancelRequested: turnAbortSignal.aborted,
       abortSignal: turnAbortSignal,
     });
     runtime.lastTerminalLoopErrorMessage = formattedError ?? errorMessage;
@@ -1437,59 +893,33 @@ export async function handleIncomingMessage(
       console.error("[Listen] Error handling message:", error);
     }
   } finally {
-    // Prune lean defaults only at turn-finalization boundaries (never during
-    // mid-turn mode changes), then persist the canonical map.
-    richDraftStreamer?.dispose();
-
-    pruneConversationPermissionModeStateIfDefault(
-      runtime.listener,
-      normalizedAgentId,
-      conversationId,
-    );
-    persistPermissionModeMapForRuntime(runtime.listener);
-
-    // Emit device status after persistence/pruning so UI reflects the final
-    // canonical state for this scope.
-    emitDeviceStatusIfOpen(runtime, {
-      agent_id: agentId || null,
-      conversation_id: conversationId,
-    });
-
-    if (agentId) {
-      await runPostTurnMemorySync({
-        agentId,
-        isEnabled: (id) => settingsManager.isMemfsEnabled(id),
-        debugLabel: "Post-turn listener memory sync",
-        enqueueReminder: (text) => {
-          enqueueMemoryGitSyncReminder(runtime.reminderState, { text });
-        },
+    if (runtime.turnLifecycle.isCurrent(turnLease)) {
+      trackBoundaryError({
+        errorType: "listener_turn_unfinalized_exit",
+        error: new Error("Turn owner exited without a terminal transition"),
+        context: "listener_turn_finalization",
+        runId: runtime.activeRunId || msgRunIds[msgRunIds.length - 1],
+      });
+      finishTurn({
+        stopReason: turnAbortSignal.aborted ? "cancelled" : "error",
+        socket,
+        runId: runtime.activeRunId || msgRunIds[msgRunIds.length - 1],
+        agentId: agentId || null,
+        conversationId,
       });
     }
 
-    try {
-      const currentConversationId = getConversationId();
-      let currentAgentId: string | null = null;
-      try {
-        currentAgentId = getCurrentAgentId();
-      } catch {
-        currentAgentId = null;
-      }
+    richDraftStreamer?.dispose();
 
-      if (
-        currentAgentId === (agentId ?? null) &&
-        currentConversationId === conversationId
-      ) {
-        setCurrentAgentId(null);
-        setConversationId(null);
-      }
-    } catch {
-      // Best-effort cleanup only. Never let teardown obscure the turn result.
+    if (finalizedByThisInvocation) {
+      await runListenerTurnCleanup({
+        runtime,
+        agentId,
+        normalizedAgentId,
+        conversationId,
+      });
     }
 
-    runtime.activeAbortController = null;
-    runtime.cancelRequested = false;
-    runtime.isRecoveringApprovals = false;
-    runtime.activeExecutingToolCallIds = [];
     evictConversationRuntimeIfIdle(runtime);
   }
 }

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -24,10 +24,12 @@ import type {
   ExternalToolCallResult,
   LoopStatus,
   RuntimeScope,
+  StopReasonType,
   WsProtocolCommand,
 } from "@/types/protocol_v2";
 import type { ActiveChannelTurn } from "./channel-turn-session";
 import type { ListenerTransport } from "./transport";
+import type { TurnLifecycle } from "./turn-lifecycle";
 
 export interface StartListenerOptions {
   connectionId: string;
@@ -141,27 +143,25 @@ export type ConversationRuntime = {
   agentId: string | null;
   conversationId: string;
   activeChannelTurn: ActiveChannelTurn | null;
+  turnLifecycle: TurnLifecycle;
   messageQueue: Promise<void>;
   pendingApprovalResolvers: Map<string, PendingApprovalResolver>;
   recoveredApprovalState: RecoveredApprovalState | null;
-  lastStopReason: string | null;
+  readonly lastStopReason: StopReasonType | null;
   lastTerminalLoopErrorMessage: string | null;
   lastTerminalLoopErrorRunId: string | null;
-  isProcessing: boolean;
-  activeWorkingDirectory: string | null;
+  readonly isProcessing: boolean;
+  readonly activeWorkingDirectory: string | null;
   expectedWorktreePath: string | null;
   expectedWorktreeExpiresAt: number | null;
-  activeRunId: string | null;
-  activeRunStartedAt: string | null;
-  activeAbortController: AbortController | null;
-  cancelRequested: boolean;
+  readonly activeRunId: string | null;
+  readonly cancelRequested: boolean;
   queueRuntime: QueueRuntime;
   queuedMessagesByItemId: Map<string, IncomingMessage>;
   queuePumpActive: boolean;
   queuePumpScheduled: boolean;
   pendingTurns: number;
-  isRecoveringApprovals: boolean;
-  loopStatus: LoopStatus;
+  readonly loopStatus: LoopStatus;
   currentToolset: ToolsetName | null;
   currentToolsetPreference: ToolsetPreference;
   currentLoadedTools: string[];
@@ -173,7 +173,6 @@ export type ConversationRuntime = {
     continuationEpoch: number;
   } | null;
   continuationEpoch: number;
-  activeExecutingToolCallIds: string[];
   pendingInterruptedToolCallIds: string[] | null;
   /** Per-conversation reminder state (session-context, agent-info, etc.). */
   reminderState: SharedReminderState;
@@ -202,7 +201,6 @@ export type ListenerRuntime = {
   modAdapter?: ModAdapter | undefined;
   sessionId: string;
   eventSeqCounter: number;
-  lastStopReason: string | null;
   queueEmitScheduled: boolean;
   pendingQueueEmitScope?: {
     agent_id?: string | null;


### PR DESCRIPTION
## Summary

- replace the listener's parallel processing, cancellation, run, tool, and loop-status fields with one discriminated `TurnLifecycle`
- require async turn work to carry a lease, so reset/old work cannot mutate or report terminal output for a replacement turn
- make queue gating consume a valid lifecycle snapshot instead of reconstructing state from independent booleans
- make the enclosing turn owner finalize each lease exactly once; approvals and recovery now return discriminated outcomes instead of boolean/null sentinels
- split `turn.ts` by responsibility and add scoped maintainer guidance for future listener work

This addresses [LET-9566](https://linear.app/letta/issue/LET-9566/fix-drift-code-rot-issues-in-state-machine) and supersedes the symptom-level approach in #3282.

## Why

The observed contradiction was real: loop status could say idle while a stale local `isProcessing` bit kept the queue blocked. The proposed queue self-heal in #3282 would make that aftermath recoverable, but it would preserve the underlying problem: several unrelated fields were allowed to describe one ownership state, and cleanup paths could update only part of them.

This change makes the contradictory state unrepresentable. Local listener ownership is now one of:

- `idle`: no local owner
- `command`: a tracked synchronous command owns the scope
- `active`: one message or approval-recovery lease owns the turn
- `cancelling`: the lease is aborted and UI projects idle, while queue work stays blocked until the owner settles

`clearConversationRuntimeState()` is an authoritative reset: it aborts and invalidates the current lease, returns local ownership to idle, and clears transient conversation state. Explicit user abort is different: it transitions `active -> cancelling -> idle`. Server-side active-run truth remains handled by the existing 409/resume/polling paths.

## Review map

1. `turn-lifecycle.ts` and its tests define the state/lease contract.
2. `runtime.ts`, `queue.ts`, `listener-queue-adapter.ts`, and `control-inputs.ts` consume that contract.
3. `turn-terminal.ts`, `turn-approval.ts`, `send.ts`, and `recovery.ts` establish exact terminal and continuation ownership.
4. `turn-setup.ts`, `turn-send.ts`, `turn-completion.ts`, `turn-events.ts`, `turn-cleanup.ts`, and `turn-transcript.ts` are responsibility extractions from the former turn monolith.
5. `AGENTS.md` records the invariants and the evidence-first investigation checklist.

`turn.ts` falls from 1,495 lines to 925, so its oversized-file baseline exception is removed. Every new source/test file is below 1,000 lines.

## Regression coverage

- exact-once finish and overlapping-owner rejection
- disconnect cleanup during a real pending approval
- old approval unwind cannot mutate a replacement lease
- stale recovery owner cannot finish or emit errors for a replacement
- explicit cancellation stays queue-blocking until its owner settles
- approval resolution does not falsely finalize the enclosing turn
- queue decisions are tested only from valid lifecycle snapshots
- existing protocol, recovery, concurrency, interruption, and channel lifecycle behavior remains covered

## Verification

- `bun run check` (12/12)
- `HOME="$(mktemp -d)" bun test src/websocket` (509 pass)
- `bun test src/tools/toolset-caching.test.ts` (2 pass)

The clean `HOME` prevents developer-installed local mods from participating in `app-server` tests. Without it, this machine's installed statusline mod fails three tests by calling a deprecated activation API; the branch tests themselves pass cleanly.

Validated commit: `f40a0362`
