### PR TITLE
fix(subagents): inherit parent model when recommended model is an auto router alias

### DIFF
--- a/src/agent/subagent-model-resolution.test.ts
+++ b/src/agent/subagent-model-resolution.test.ts
@@ -648,6 +648,46 @@ describe("resolveSubagentModel", () => {
     expect(result).toBe("anthropic/test-model");
   });
 
+  test("recommended auto router alias inherits parent model instead", async () => {
+    const result = await resolveSubagentModel({
+      recommendedModel: "auto",
+      parentModelHandle: "openai/gpt-5.4-mini",
+      availableHandles: new Set(["letta/auto", "openai/gpt-5.4-mini"]),
+    });
+
+    expect(result).toBe("openai/gpt-5.4-mini");
+  });
+
+  test("recommended auto-fast router alias inherits parent model instead", async () => {
+    const result = await resolveSubagentModel({
+      recommendedModel: "auto-fast",
+      parentModelHandle: "anthropic/parent-model",
+      availableHandles: new Set(["letta/auto-fast", "anthropic/parent-model"]),
+    });
+
+    expect(result).toBe("anthropic/parent-model");
+  });
+
+  test("recommended auto router alias is used when no parent model exists", async () => {
+    const result = await resolveSubagentModel({
+      recommendedModel: "auto",
+      availableHandles: new Set(["letta/auto"]),
+    });
+
+    expect(result).toBe("letta/auto");
+  });
+
+  test("free tier keeps auto-fast default despite parent model", async () => {
+    const result = await resolveSubagentModel({
+      recommendedModel: "auto",
+      billingTier: "free",
+      parentModelHandle: "openai/gpt-5.4-mini",
+      availableHandles: new Set(["letta/auto-fast", "openai/gpt-5.4-mini"]),
+    });
+
+    expect(result).toBe("letta/auto-fast");
+  });
+
   test("explicit user model overrides all other resolution", async () => {
     const result = await resolveSubagentModel({
       userModel: "lc-openrouter/custom-model",

--- a/src/agent/subagents/subagent-model.ts
+++ b/src/agent/subagents/subagent-model.ts
@@ -108,6 +108,19 @@ function isInheritModel(model: string | null | undefined): boolean {
   return model?.trim().toLowerCase() === "inherit";
 }
 
+// Server-side router aliases. A subagent recommending one of these means
+// "let the system pick", so it must not override a parent's selected model.
+const ROUTER_ALIAS_HANDLES = new Set([
+  "letta/auto",
+  "letta/auto-fast",
+  "letta/auto-chat",
+  "letta/auto-memory",
+]);
+
+function isRouterAliasHandle(handle: string): boolean {
+  return ROUTER_ALIAS_HANDLES.has(handle);
+}
+
 export async function resolveSubagentModel(options: {
   userModel?: string;
   recommendedModel?: string;
@@ -209,7 +222,13 @@ export async function resolveSubagentModel(options: {
         return parentModelHandle;
       }
 
-      if (await isAvailable(recommendedHandle)) {
+      // A recommended router alias (e.g. a subagent pinned to `model: auto`)
+      // means "let the system pick" - it must not beat a parent that has an
+      // explicitly selected model. Inherit the parent's model instead.
+      if (
+        !isRouterAliasHandle(recommendedHandle) &&
+        (await isAvailable(recommendedHandle))
+      ) {
         return recommendedHandle;
       }
     }

--- a/src/skills/builtin/initializing-memory/SKILL.md
+++ b/src/skills/builtin/initializing-memory/SKILL.md
@@ -239,7 +239,7 @@ The goal is to extract user personality, preferences, coding patterns, and proje
 #### Prerequisites
 
 - `letta.js` must be built (`bun run build`) — subagents spawn via this binary
-- Use `subagent_type: "history-analyzer"` — cheaper model (sonnet), has `bypassPermissions`, creates its own worktree
+- Use `subagent_type: "history-analyzer"` — inherits the session's selected model, has `bypassPermissions`, creates its own worktree
 - The `history-analyzer` subagent has data format docs inlined (Claude/Codex JSONL field mappings, jq queries)
 
 #### Steps


### PR DESCRIPTION
## Summary

- Fixes #3248: `/init` history-analyzer subagents (and any builtin whose frontmatter pins `model: auto`) ran on the server-side auto router's pick (e.g. `gpt-5.4`) instead of the session's selected model (e.g. `gpt-5.4-mini`).
- Root cause: `resolveSubagentModel` treats any non-`inherit` recommended model as an explicit pin that beats parent inheritance. Since #1436 switched builtin subagents to `model: auto`, the resolved `letta/auto` handle is always available, so for cloud non-BYOK parents the parent's model was unreachable — contradicting the Task tool's documented contract ("If not specified, inherits from parent"). Local-backend and BYOK parents already inherit; cloud non-BYOK was the remaining gap.
- Fix: treat a recommended model that resolves to a router alias (`letta/auto`, `letta/auto-fast`, `letta/auto-chat`, `letta/auto-memory`) as non-pinning — prefer the parent's model when one exists. The alias still applies when no parent model is set, free-tier defaults (`auto-fast`/`auto`) are unchanged, and the reflection carve-out is untouched.
- Also updates a stale note in the initializing-memory skill that still described history-analyzer as pinned to a "cheaper model (sonnet)" (pre-#1436).

## Test plan

- [x] 4 new tests in `src/agent/subagent-model-resolution.test.ts`: `auto` + parent → parent; `auto-fast` + parent → parent; `auto` with no parent → `letta/auto` (alias preserved); free tier + parent → `letta/auto-fast` (default preserved)
- [x] Mutation check: with the fix stashed, exactly the two new inheritance tests fail; behavior-preservation tests pass on both old and new code
- [x] Full `resolveSubagentModel` suite (67 tests) + `subagent-builtins` + `init-background-subagent` pass
- [x] `bun run check` — all 10 checks pass
- [x] Full unit suite: no regressions vs the Windows baseline (all failures are known pre-existing symlink/websocket/keychain/startup-flow categories)

## AI disclosure

Per the disclosure policy proposed in #3139: this fix was developed with AI assistance (Claude Code). The root-cause analysis, implementation, and tests were AI-assisted; I reviewed, ran, and verified everything locally before submitting.

cc @devanshrj — follows the same shape as #3239; happy to adjust if you'd rather fix this at the frontmatter level (`model: inherit` on history-analyzer) instead of in the resolver.