### PR TITLE
fix(subagents): stop losing subagent results to silent stdout truncation

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -22,7 +22,7 @@
   "src/cli/mods/local-mod-loader.test.ts": 1043,
   "src/cli/reflection-transcript.test.ts": 1118,
   "src/cli/subcommands/skills.ts": 1264,
-  "src/headless.ts": 5238,
+  "src/headless.ts": 5230,
   "src/hooks/integration.test.ts": 1147,
   "src/index.ts": 2854,
   "src/mods/learning-harness.ts": 2434,

--- a/src/agent/subagent-retry-parent-scope.test.ts
+++ b/src/agent/subagent-retry-parent-scope.test.ts
@@ -16,3 +16,24 @@ describe("executeSubagent provider fallback wiring", () => {
     expect(retryCallMatch).toBeTruthy();
   });
 });
+
+describe("executeSubagent lost-output retry wiring", () => {
+  const retryCallPattern =
+    /return executeSubagent\(\s*type,\s*config,\s*model,\s*userPrompt,\s*subagentId,\s*true,\s*\/\/ Mark as retry to prevent infinite loops\s*signal,\s*existingAgentId,\s*existingConversationId,\s*maxTurns,\s*parentAgentIdOverride,\s*transcriptPath,\s*memoryScope,\s*systemPromptOverride,\s*\);/gs;
+
+  test("retries once with the original payload when the child reports lost stdout or its output looks truncated", () => {
+    const retryCalls = managerSource.match(retryCallPattern);
+
+    // One retry site for the stderr lost-stdout marker (non-zero exit) and
+    // one for a clean exit whose stdout ends mid-line without a result.
+    expect(retryCalls).toHaveLength(2);
+  });
+
+  test("both lost-output retries are guarded by isRetry", () => {
+    const guardedSites = managerSource.match(
+      /if \(!isRetry && isSubagentStdoutLostError\(stderr\)\)|if \(!isRetry && looksLikeTruncatedStreamJson\(stdout\)\)/gs,
+    );
+
+    expect(guardedSites).toHaveLength(2);
+  });
+});

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -258,7 +258,7 @@ export function buildSubagentArgs(
     }
     args.push("--tags", subagentTags.join(","));
     // Newly spawned subagents are stateless (non-memfs). The headless
-    // entrypoint derives this from LETTA_CODE_AGENT_ROLE=subagent â€” no CLI
+    // entrypoint derives this from LETTA_CODE_AGENT_ROLE=subagent — no CLI
     // flag needed, and no user-facing opt-out exists.
     if (model) {
       args.push("--model", model);
@@ -380,7 +380,7 @@ async function executeSubagent(
       try {
         parentAgentId = getCurrentAgentId();
       } catch {
-        // Context not available â€” subagent will have no parent scope.
+        // Context not available — subagent will have no parent scope.
       }
     }
 
@@ -587,7 +587,7 @@ async function executeSubagent(
 
       // The child lost its stdout stream before it could deliver the result
       // envelope (it exits non-zero with a marker on stderr). The stream is
-      // gone but the payload is retryable â€” respawn once.
+      // gone but the payload is retryable — respawn once.
       if (!isRetry && isSubagentStdoutLostError(stderr)) {
         debugWarn(
           "subagent",
@@ -656,7 +656,7 @@ async function executeSubagent(
       };
     }
 
-    // No result or error captured during streaming â€” this is unusual
+    // No result or error captured during streaming — this is unusual
     debugWarn(
       "subagent",
       `Subagent ${subagentId} (agentId=${state.agentId}) exited cleanly (exitCode=${exitCode}) ` +
@@ -680,7 +680,7 @@ async function executeSubagent(
       );
       // A clean exit whose stream ends mid-line means the result envelope was
       // truncated in transit even though the child believed it succeeded
-      // (observed under high parallel fan-out, #3257) â€” respawn once instead
+      // (observed under high parallel fan-out, #3257) — respawn once instead
       // of dropping the response. Other parse failures (e.g. well-formed but
       // unexpected output) are not retried: the child may have already
       // performed side effects, so only unambiguous truncation is worth it.
@@ -747,13 +747,13 @@ function buildForkSystemReminder(
   if (subagentType === "recall") {
     const recallPrompt = recallPromptForBackend(backendMode);
     return `${SYSTEM_REMINDER_OPEN}
-You have been forked from the primary conversational thread to run as an independent subagent. The fork only exists so you can see the parent agent's conversation trajectory in-context as reference â€” you are NOT the primary agent and do not share its tools.
+You have been forked from the primary conversational thread to run as an independent subagent. The fork only exists so you can see the parent agent's conversation trajectory in-context as reference — you are NOT the primary agent and do not share its tools.
 
 **Your sole task is now to search previous conversation history and provide a report. Ignore any existing ongoing tasks.** Do not attempt to continue, finish, or act on anything the primary agent was in the middle of doing.
 
 Your toolset is limited to Bash, Read, and TaskOutput. You cannot edit files, run skills, dispatch further tasks, or take any action beyond searching messages and returning a report.
 
-You CANNOT ask questions mid-execution â€” all instructions are provided upfront.
+You CANNOT ask questions mid-execution — all instructions are provided upfront.
 Your final message will be returned to the caller.
 
 ${recallPrompt}
@@ -763,13 +763,13 @@ ${SYSTEM_REMINDER_CLOSE}
   }
 
   return `${SYSTEM_REMINDER_OPEN}
-You have been forked from the primary conversational thread to run as an independent subagent. The fork only exists so you can see the parent agent's conversation trajectory in-context as reference â€” you are NOT the primary agent and do not share its full toolset.
+You have been forked from the primary conversational thread to run as an independent subagent. The fork only exists so you can see the parent agent's conversation trajectory in-context as reference — you are NOT the primary agent and do not share its full toolset.
 
 **Your sole task is the one described in the user message below. Ignore any existing ongoing tasks from the inherited trajectory.** Do not attempt to continue, finish, or act on anything the primary agent was in the middle of doing.
 
 You have a scoped toolset that may differ from the primary agent's. Stay within it; don't assume you have the primary's full tool access.
 
-You CANNOT ask questions mid-execution â€” all instructions are provided upfront.
+You CANNOT ask questions mid-execution — all instructions are provided upfront.
 Your final message will be returned to the caller.
 ${SYSTEM_REMINDER_CLOSE}
 
@@ -834,7 +834,7 @@ export async function spawnSubagent(
     try {
       resolvedParentAgentId = getCurrentAgentId();
     } catch {
-      // Context unavailable â€” carry forward undefined.
+      // Context unavailable — carry forward undefined.
     }
   }
   let resolvedParentConversationId = parentConversationId;
@@ -842,7 +842,7 @@ export async function spawnSubagent(
     try {
       resolvedParentConversationId = getConversationId() ?? undefined;
     } catch {
-      // Context unavailable â€” carry forward undefined.
+      // Context unavailable — carry forward undefined.
     }
   }
   const { handle: parentModelHandle, agent: parentAgent } =

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -34,6 +34,7 @@ import {
 import { settingsManager } from "@/settings-manager";
 import { debugLog, debugWarn } from "@/utils/debug";
 import { getErrorMessage } from "@/utils/error";
+import { isSubagentStdoutLostError } from "@/utils/subagent-stdout-failure";
 import {
   getAllSubagentConfigs,
   type SubagentConfig,
@@ -59,6 +60,7 @@ import {
 } from "./subagent-model";
 import {
   type ExecutionState,
+  looksLikeTruncatedStreamJson,
   parseResultFromStdout,
   processStreamEvent,
 } from "./subagent-stream";
@@ -256,7 +258,7 @@ export function buildSubagentArgs(
     }
     args.push("--tags", subagentTags.join(","));
     // Newly spawned subagents are stateless (non-memfs). The headless
-    // entrypoint derives this from LETTA_CODE_AGENT_ROLE=subagent — no CLI
+    // entrypoint derives this from LETTA_CODE_AGENT_ROLE=subagent â€” no CLI
     // flag needed, and no user-facing opt-out exists.
     if (model) {
       args.push("--model", model);
@@ -378,7 +380,7 @@ async function executeSubagent(
       try {
         parentAgentId = getCurrentAgentId();
       } catch {
-        // Context not available — subagent will have no parent scope.
+        // Context not available â€” subagent will have no parent scope.
       }
     }
 
@@ -583,6 +585,32 @@ async function executeSubagent(
         }
       }
 
+      // The child lost its stdout stream before it could deliver the result
+      // envelope (it exits non-zero with a marker on stderr). The stream is
+      // gone but the payload is retryable â€” respawn once.
+      if (!isRetry && isSubagentStdoutLostError(stderr)) {
+        debugWarn(
+          "subagent",
+          `Subagent ${subagentId} lost stdout before its result envelope; retrying once`,
+        );
+        return executeSubagent(
+          type,
+          config,
+          model,
+          userPrompt,
+          subagentId,
+          true, // Mark as retry to prevent infinite loops
+          signal,
+          existingAgentId,
+          existingConversationId,
+          maxTurns,
+          parentAgentIdOverride,
+          transcriptPath,
+          memoryScope,
+          systemPromptOverride,
+        );
+      }
+
       const propagatedError = state.finalError?.trim();
       const fallbackError = stderr || `Subagent exited with code ${exitCode}`;
 
@@ -628,7 +656,7 @@ async function executeSubagent(
       };
     }
 
-    // No result or error captured during streaming — this is unusual
+    // No result or error captured during streaming â€” this is unusual
     debugWarn(
       "subagent",
       `Subagent ${subagentId} (agentId=${state.agentId}) exited cleanly (exitCode=${exitCode}) ` +
@@ -650,6 +678,34 @@ async function executeSubagent(
         `parseResultFromStdout failed for ${subagentId}: ${result.error}. ` +
           `stdout first 500 chars: ${stdout.slice(0, 500)}`,
       );
+      // A clean exit whose stream ends mid-line means the result envelope was
+      // truncated in transit even though the child believed it succeeded
+      // (observed under high parallel fan-out, #3257) â€” respawn once instead
+      // of dropping the response. Other parse failures (e.g. well-formed but
+      // unexpected output) are not retried: the child may have already
+      // performed side effects, so only unambiguous truncation is worth it.
+      if (!isRetry && looksLikeTruncatedStreamJson(stdout)) {
+        debugWarn(
+          "subagent",
+          `Subagent ${subagentId} stdout ends mid-line with no result envelope; retrying once`,
+        );
+        return executeSubagent(
+          type,
+          config,
+          model,
+          userPrompt,
+          subagentId,
+          true, // Mark as retry to prevent infinite loops
+          signal,
+          existingAgentId,
+          existingConversationId,
+          maxTurns,
+          parentAgentIdOverride,
+          transcriptPath,
+          memoryScope,
+          systemPromptOverride,
+        );
+      }
     }
     return result;
   } catch (error) {
@@ -691,13 +747,13 @@ function buildForkSystemReminder(
   if (subagentType === "recall") {
     const recallPrompt = recallPromptForBackend(backendMode);
     return `${SYSTEM_REMINDER_OPEN}
-You have been forked from the primary conversational thread to run as an independent subagent. The fork only exists so you can see the parent agent's conversation trajectory in-context as reference — you are NOT the primary agent and do not share its tools.
+You have been forked from the primary conversational thread to run as an independent subagent. The fork only exists so you can see the parent agent's conversation trajectory in-context as reference â€” you are NOT the primary agent and do not share its tools.
 
 **Your sole task is now to search previous conversation history and provide a report. Ignore any existing ongoing tasks.** Do not attempt to continue, finish, or act on anything the primary agent was in the middle of doing.
 
 Your toolset is limited to Bash, Read, and TaskOutput. You cannot edit files, run skills, dispatch further tasks, or take any action beyond searching messages and returning a report.
 
-You CANNOT ask questions mid-execution — all instructions are provided upfront.
+You CANNOT ask questions mid-execution â€” all instructions are provided upfront.
 Your final message will be returned to the caller.
 
 ${recallPrompt}
@@ -707,13 +763,13 @@ ${SYSTEM_REMINDER_CLOSE}
   }
 
   return `${SYSTEM_REMINDER_OPEN}
-You have been forked from the primary conversational thread to run as an independent subagent. The fork only exists so you can see the parent agent's conversation trajectory in-context as reference — you are NOT the primary agent and do not share its full toolset.
+You have been forked from the primary conversational thread to run as an independent subagent. The fork only exists so you can see the parent agent's conversation trajectory in-context as reference â€” you are NOT the primary agent and do not share its full toolset.
 
 **Your sole task is the one described in the user message below. Ignore any existing ongoing tasks from the inherited trajectory.** Do not attempt to continue, finish, or act on anything the primary agent was in the middle of doing.
 
 You have a scoped toolset that may differ from the primary agent's. Stay within it; don't assume you have the primary's full tool access.
 
-You CANNOT ask questions mid-execution — all instructions are provided upfront.
+You CANNOT ask questions mid-execution â€” all instructions are provided upfront.
 Your final message will be returned to the caller.
 ${SYSTEM_REMINDER_CLOSE}
 
@@ -778,7 +834,7 @@ export async function spawnSubagent(
     try {
       resolvedParentAgentId = getCurrentAgentId();
     } catch {
-      // Context unavailable — carry forward undefined.
+      // Context unavailable â€” carry forward undefined.
     }
   }
   let resolvedParentConversationId = parentConversationId;
@@ -786,7 +842,7 @@ export async function spawnSubagent(
     try {
       resolvedParentConversationId = getConversationId() ?? undefined;
     } catch {
-      // Context unavailable — carry forward undefined.
+      // Context unavailable â€” carry forward undefined.
     }
   }
   const { handle: parentModelHandle, agent: parentAgent } =

--- a/src/agent/subagents/subagent-stream.test.ts
+++ b/src/agent/subagents/subagent-stream.test.ts
@@ -34,6 +34,14 @@ describe("looksLikeTruncatedStreamJson", () => {
     expect(looksLikeTruncatedStreamJson(`${initLine}\n`)).toBe(false);
   });
 
+  test("does not flag a complete non-JSON line", () => {
+    // An invalid protocol line is not evidence of truncation when its line
+    // terminator arrived. Retrying here could duplicate subagent side effects.
+    expect(looksLikeTruncatedStreamJson(`${initLine}\nplain-text-log\n`)).toBe(
+      false,
+    );
+  });
+
   test("does not flag empty output", () => {
     expect(looksLikeTruncatedStreamJson("")).toBe(false);
     expect(looksLikeTruncatedStreamJson("\n\n")).toBe(false);

--- a/src/agent/subagents/subagent-stream.test.ts
+++ b/src/agent/subagents/subagent-stream.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { looksLikeTruncatedStreamJson } from "./subagent-stream";
+
+const initLine = JSON.stringify({
+  type: "system",
+  subtype: "init",
+  agent_id: "agent-1",
+});
+const resultLine = JSON.stringify({
+  type: "result",
+  result: "done",
+  is_error: false,
+});
+
+describe("looksLikeTruncatedStreamJson", () => {
+  test("detects a result envelope cut mid-line", () => {
+    const truncated = `${initLine}\n${resultLine.slice(0, resultLine.length - 25)}`;
+    expect(looksLikeTruncatedStreamJson(truncated)).toBe(true);
+  });
+
+  test("detects a partial line even when it is the only output", () => {
+    expect(looksLikeTruncatedStreamJson('{"type":"result","resu')).toBe(true);
+  });
+
+  test("does not flag a complete stream ending in a result envelope", () => {
+    expect(looksLikeTruncatedStreamJson(`${initLine}\n${resultLine}\n`)).toBe(
+      false,
+    );
+  });
+
+  test("does not flag complete-but-unexpected JSON output", () => {
+    // Last line parses fine — this is a wrong-shape stream, not truncation,
+    // so retrying could double side effects for no reason.
+    expect(looksLikeTruncatedStreamJson(`${initLine}\n`)).toBe(false);
+  });
+
+  test("does not flag empty output", () => {
+    expect(looksLikeTruncatedStreamJson("")).toBe(false);
+    expect(looksLikeTruncatedStreamJson("\n\n")).toBe(false);
+  });
+
+  test("handles CRLF line endings", () => {
+    const truncated = `${initLine}\r\n${resultLine.slice(0, 10)}`;
+    expect(looksLikeTruncatedStreamJson(truncated)).toBe(true);
+    expect(
+      looksLikeTruncatedStreamJson(`${initLine}\r\n${resultLine}\r\n`),
+    ).toBe(false);
+  });
+});

--- a/src/agent/subagents/subagent-stream.ts
+++ b/src/agent/subagents/subagent-stream.ts
@@ -184,6 +184,26 @@ export function processStreamEvent(
 }
 
 /**
+ * Whether a subagent's stream-json stdout ends mid-line: the final line is
+ * non-empty but not valid JSON. A healthy stream ends with a complete result
+ * envelope, so a partial trailing line is unambiguous evidence the tail was
+ * truncated in transit (#3257). Complete-but-unexpected output (last line
+ * parses, or stdout is empty) is NOT treated as truncation — the child may
+ * have already performed side effects, so callers only retry the clear case.
+ */
+export function looksLikeTruncatedStreamJson(stdout: string): boolean {
+  const lines = stdout.trim().split("\n");
+  const lastLine = (lines[lines.length - 1] ?? "").trim();
+  if (lastLine.length === 0) return false;
+  try {
+    JSON.parse(lastLine);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+/**
  * Parse the final result from stdout if not captured during streaming
  */
 export function parseResultFromStdout(

--- a/src/agent/subagents/subagent-stream.ts
+++ b/src/agent/subagents/subagent-stream.ts
@@ -184,15 +184,16 @@ export function processStreamEvent(
 }
 
 /**
- * Whether a subagent's stream-json stdout ends mid-line: the final line is
- * non-empty but not valid JSON. A healthy stream ends with a complete result
- * envelope, so a partial trailing line is unambiguous evidence the tail was
- * truncated in transit (#3257). Complete-but-unexpected output (last line
- * parses, or stdout is empty) is NOT treated as truncation — the child may
- * have already performed side effects, so callers only retry the clear case.
+ * Whether a subagent's stream-json stdout ends mid-line: the final segment has
+ * no line terminator and is non-empty but not valid JSON. A healthy stream ends
+ * with a complete result envelope, so a partial trailing line is unambiguous
+ * evidence the tail was truncated in transit (#3257). Complete-but-unexpected
+ * output (the final line parses, has a terminator, or stdout is empty) is NOT
+ * treated as truncation — the child may have already performed side effects,
+ * so callers only retry the clear case.
  */
 export function looksLikeTruncatedStreamJson(stdout: string): boolean {
-  const lines = stdout.trim().split("\n");
+  const lines = stdout.split(/\r?\n/);
   const lastLine = (lines[lines.length - 1] ?? "").trim();
   if (lastLine.length === 0) return false;
   try {

--- a/src/headless-subagent-stdout-loss.test.ts
+++ b/src/headless-subagent-stdout-loss.test.ts
@@ -1,0 +1,392 @@
+// End-to-end regression test for #3257: a subagent child whose stdout stream
+// is lost before the final result envelope must be retried once by the parent
+// with the original spawn arguments, instead of surfacing a truncated-output
+// parse failure.
+//
+// The harness runs the real CLI headless against an in-process mock
+// OpenAI-compatible provider that forces one Agent tool call. The subagent
+// child binary is overridden (LETTA_CODE_BIN) with a script that simulates
+// the failure on its first spawn and succeeds on the second, so the whole
+// spawn → detect-loss → retry → collect-result path is exercised for real.
+import { afterAll, describe, expect, test } from "bun:test";
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createIsolatedCliTestEnv } from "@/test-utils/test-process-env";
+import { SUBAGENT_STDOUT_LOST_MARKER } from "@/utils/subagent-stdout-failure";
+
+type ChildFailMode = "truncate-result" | "stderr-marker";
+
+interface ScenarioSummary {
+  code: number | null;
+  spawnArgvs: string[][];
+  toolResults: string;
+  stdoutTail: string;
+  stderrTail: string;
+}
+
+const cliProcesses = new Set<ChildProcessWithoutNullStreams>();
+const tempRoots: string[] = [];
+
+afterAll(async () => {
+  for (const child of cliProcesses) {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGTERM");
+    }
+  }
+  await Promise.all(
+    tempRoots.map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("headless subagent stdout loss", () => {
+  test("retries once and recovers the report when the child's stream is truncated mid-result", async () => {
+    const summary = await runStdoutLossScenario("truncate-result");
+
+    expect(summary.code, formatSummary(summary)).toBe(0);
+    // Exactly one retry: the isRetry guard must prevent further respawns.
+    expect(summary.spawnArgvs, formatSummary(summary)).toHaveLength(2);
+    // The retry must preserve the original spawn arguments verbatim.
+    expect(summary.spawnArgvs[1]).toEqual(summary.spawnArgvs[0]);
+    // The recovered report reaches the model as a successful tool result.
+    expect(summary.toolResults, formatSummary(summary)).toContain(
+      "SUBAGENT-REPORT-OK",
+    );
+    expect(summary.toolResults, formatSummary(summary)).not.toContain(
+      "Failed to parse subagent output",
+    );
+  }, 90_000);
+
+  test("retries once and recovers the report when the child exits 1 with the stdout-lost marker", async () => {
+    const summary = await runStdoutLossScenario("stderr-marker");
+
+    expect(summary.code, formatSummary(summary)).toBe(0);
+    expect(summary.spawnArgvs, formatSummary(summary)).toHaveLength(2);
+    expect(summary.spawnArgvs[1]).toEqual(summary.spawnArgvs[0]);
+    expect(summary.toolResults, formatSummary(summary)).toContain(
+      "SUBAGENT-REPORT-OK",
+    );
+  }, 90_000);
+});
+
+async function runStdoutLossScenario(
+  mode: ChildFailMode,
+): Promise<ScenarioSummary> {
+  // Canonicalize the temp root: on macOS tmpdir() is a symlink
+  // (/var/folders -> /private/var/folders), and the spawned CLI's
+  // process.cwd() resolves to the real path while USER_CWD would carry the
+  // symlink path — the mismatch makes local project settings load under one
+  // path and get looked up under the other, crashing startup.
+  const tmpRoot = realpathSync(
+    await mkdtemp(join(tmpdir(), "letta-subagent-stdout-loss-")),
+  );
+  tempRoots.push(tmpRoot);
+  const homeDir = join(tmpRoot, "home");
+  const projectDir = join(tmpRoot, "project");
+  const localBackendDir = join(tmpRoot, "local-backend");
+  const childStateDir = join(tmpRoot, "child-state");
+  mkdirSync(homeDir, { recursive: true });
+  mkdirSync(projectDir, { recursive: true });
+  mkdirSync(localBackendDir, { recursive: true });
+  mkdirSync(childStateDir, { recursive: true });
+
+  const childScript = join(tmpRoot, "mock-subagent-child.ts");
+  writeFileSync(childScript, buildMockChildScript());
+
+  const provider = startMockProvider();
+
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const cliEntry = join(repoRoot, "src", "index.ts");
+  const child = spawn(
+    process.execPath,
+    [
+      "--loader=.md:text",
+      "--loader=.mdx:text",
+      "--loader=.txt:text",
+      "run",
+      cliEntry,
+      "--backend",
+      "local",
+      "--yolo",
+      "--memfs-startup",
+      "skip",
+      "--output-format",
+      "text",
+      "-p",
+      "spawn a subagent to produce the test report",
+    ],
+    {
+      cwd: projectDir,
+      env: createIsolatedCliTestEnv({
+        HOME: homeDir,
+        USERPROFILE: homeDir,
+        LETTA_LOCAL_BACKEND_DIR: localBackendDir,
+        LMSTUDIO_BASE_URL: `http://127.0.0.1:${provider.port}/v1`,
+        LETTA_CODE_BIN: process.execPath,
+        LETTA_CODE_BIN_ARGS_JSON: JSON.stringify(["run", childScript]),
+        CHILD_STATE_DIR: childStateDir,
+        CHILD_FAIL_MODE: mode,
+        LETTA_FS_SANDBOX: "0",
+        USER_CWD: projectDir,
+        NO_COLOR: "1",
+        DO_NOT_TRACK: "1",
+      }),
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+  cliProcesses.add(child);
+  child.stdin.end();
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk.toString();
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk.toString();
+  });
+
+  const timeout = setTimeout(() => {
+    child.kill("SIGTERM");
+  }, 80_000);
+
+  const code = await new Promise<number | null>((resolvePromise) => {
+    child.on("exit", (exitCode) => {
+      clearTimeout(timeout);
+      cliProcesses.delete(child);
+      resolvePromise(exitCode);
+    });
+  });
+
+  provider.server.stop(true);
+
+  return {
+    code,
+    spawnArgvs: readSpawnArgvs(childStateDir),
+    toolResults: provider.toolResults.join("\n"),
+    stdoutTail: tail(stdout),
+    stderrTail: tail(stderr),
+  };
+}
+
+/**
+ * The script standing in for the spawned subagent CLI (via LETTA_CODE_BIN).
+ * First spawn simulates #3257 according to CHILD_FAIL_MODE:
+ *   - truncate-result: emits the result envelope cut mid-JSON and exits 0
+ *     (the child believed it succeeded; the parent sees a truncated stream).
+ *   - stderr-marker: exits 1 with the stdout-lost marker on stderr (the
+ *     child detected the loss, as src/utils/headless-stdout-guard.ts does).
+ * Later spawns emit a complete result envelope. Every spawn records its argv
+ * so the test can assert the retry preserved the original arguments.
+ */
+function buildMockChildScript(): string {
+  return `
+import { appendFileSync, existsSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const stateDir = process.env.CHILD_STATE_DIR ?? "";
+const failMode = process.env.CHILD_FAIL_MODE ?? "truncate-result";
+
+// Drain the prompt the parent writes to stdin.
+await new Response(Bun.stdin.stream()).text().catch(() => "");
+
+appendFileSync(
+  join(stateDir, "spawns.jsonl"),
+  \`\${JSON.stringify(process.argv.slice(2))}\\n\`,
+);
+
+const initLine = JSON.stringify({
+  type: "system",
+  subtype: "init",
+  session_id: "mock-child-session",
+  agent_id: "agent-mock-child",
+  conversation_id: "conv-mock-child",
+});
+const resultLine = JSON.stringify({
+  type: "result",
+  subtype: "success",
+  result: "SUBAGENT-REPORT-OK",
+  is_error: false,
+  duration_ms: 5,
+  num_turns: 1,
+  usage: { total_tokens: 10, step_count: 1 },
+});
+
+function writeAll(text) {
+  return new Promise((resolve) => {
+    process.stdout.write(text, () => resolve());
+  });
+}
+
+const firstSpawnMarker = join(stateDir, "first-spawn.marker");
+if (!existsSync(firstSpawnMarker)) {
+  writeFileSync(firstSpawnMarker, "1\\n");
+  if (failMode === "stderr-marker") {
+    console.error(${JSON.stringify(`${SUBAGENT_STDOUT_LOST_MARKER} (test-injected)`)});
+    process.exit(1);
+  }
+  // Truncate the result envelope mid-JSON, no trailing newline.
+  await writeAll(\`\${initLine}\\n\${resultLine.slice(0, resultLine.length - 25)}\`);
+  process.exit(0);
+}
+
+await writeAll(\`\${initLine}\\n\${resultLine}\\n\`);
+process.exit(0);
+`;
+}
+
+/**
+ * Minimal OpenAI-compatible SSE provider: the first chat round forces one
+ * Agent tool call, later rounds record the tool results the CLI sends back
+ * and finish the turn.
+ */
+function startMockProvider(): {
+  server: ReturnType<typeof Bun.serve>;
+  port: number;
+  toolResults: string[];
+} {
+  let chatRequests = 0;
+  const toolResults: string[] = [];
+
+  const server = Bun.serve({
+    port: 0,
+    idleTimeout: 120,
+    async fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname.endsWith("/models")) {
+        return Response.json({
+          object: "list",
+          data: [{ id: "gpt-4", object: "model" }],
+        });
+      }
+      if (!url.pathname.endsWith("/chat/completions")) {
+        return new Response("not found", { status: 404 });
+      }
+
+      chatRequests += 1;
+      const round = chatRequests;
+      const body = (await req.json()) as {
+        tools?: Array<{ function?: { name?: string } }>;
+        messages?: Array<{ role?: string; content?: unknown }>;
+      };
+      const agentToolName = (body.tools ?? [])
+        .map((t) => t.function?.name)
+        .find((name) => name === "Agent" || name === "Task");
+      for (const message of body.messages ?? []) {
+        if (message.role === "tool") {
+          toolResults.push(JSON.stringify(message.content));
+        }
+      }
+
+      const base = {
+        id: `chatcmpl-${round}`,
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "gpt-4",
+      };
+      const chunks =
+        round === 1 && agentToolName
+          ? [
+              {
+                ...base,
+                choices: [
+                  {
+                    index: 0,
+                    delta: {
+                      role: "assistant",
+                      tool_calls: [
+                        {
+                          index: 0,
+                          id: "call_subagent_1",
+                          type: "function",
+                          function: {
+                            name: agentToolName,
+                            arguments: JSON.stringify({
+                              description: "run test subagent",
+                              prompt: "produce the test report",
+                              subagent_type: "general-purpose",
+                              run_in_background: false,
+                            }),
+                          },
+                        },
+                      ],
+                    },
+                    finish_reason: null,
+                  },
+                ],
+              },
+              {
+                ...base,
+                choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+                usage: {
+                  prompt_tokens: 10,
+                  completion_tokens: 5,
+                  total_tokens: 15,
+                },
+              },
+            ]
+          : [
+              {
+                ...base,
+                choices: [
+                  {
+                    index: 0,
+                    delta: { role: "assistant", content: "provider-done" },
+                    finish_reason: null,
+                  },
+                ],
+              },
+              {
+                ...base,
+                choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+                usage: {
+                  prompt_tokens: 10,
+                  completion_tokens: 5,
+                  total_tokens: 15,
+                },
+              },
+            ];
+
+      const stream = new ReadableStream({
+        start(controller) {
+          for (const chunk of chunks) {
+            controller.enqueue(`data: ${JSON.stringify(chunk)}\n\n`);
+          }
+          controller.enqueue("data: [DONE]\n\n");
+          controller.close();
+        },
+      });
+      return new Response(stream, {
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+        },
+      });
+    },
+  });
+
+  return { server, port: server.port ?? 0, toolResults };
+}
+
+function readSpawnArgvs(childStateDir: string): string[][] {
+  try {
+    return readFileSync(join(childStateDir, "spawns.jsonl"), "utf-8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+  } catch {
+    return [];
+  }
+}
+
+function tail(text: string): string {
+  return text.split("\n").slice(-40).join("\n");
+}
+
+function formatSummary(summary: ScenarioSummary): string {
+  return JSON.stringify(summary, null, 2);
+}

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -12,12 +12,14 @@ import type { StopReasonType } from "@letta-ai/letta-client/resources/runs/runs"
 import { getTerminalTelemetrySurface, telemetry } from "@/telemetry";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
 import { extractTelemetryInputText } from "@/telemetry/input";
+import { installHeadlessStdoutGuard } from "@/utils/headless-stdout-guard";
 import {
   type QueuedMessage,
   setMessageQueueAdder,
 } from "@/utils/message-queue-bridge";
 import { detectShellContext } from "@/utils/shell-context";
 import { createSigintAbortSignal } from "@/utils/sigint-abort";
+import { reportSubagentStdoutLoss } from "@/utils/subagent-stdout-failure";
 import { isAgentIdCompatibleWithBackend } from "./agent/agent-id";
 import type { ApprovalResult } from "./agent/approval-execution";
 import {
@@ -957,24 +959,9 @@ export async function handleHeadlessCommand(
   const inputFormat = values["input-format"];
   const isBidirectionalMode = inputFormat === "stream-json";
 
-  // If headless output is being piped and the downstream closes early (e.g.
-  // `| head`), Node will throw EPIPE on stdout writes. Treat this as a normal
-  // termination rather than crashing with a stack trace.
-  //
-  // Note: this must be registered before any `console.log` in headless mode.
-  process.stdout.on("error", (err: unknown) => {
-    const code =
-      typeof err === "object" && err !== null && "code" in err
-        ? (err as { code?: unknown }).code
-        : undefined;
-
-    if (code === "EPIPE") {
-      process.exit(0);
-    }
-
-    // Re-throw unknown stdout errors so they surface during tests/debugging.
-    throw err;
-  });
+  // Handle stdout errors (early-closing pipes, lost subagent streams) before
+  // any `console.log` in headless mode.
+  installHeadlessStdoutGuard();
 
   // Get prompt from either positional args or stdin (unless in bidirectional mode)
   let prompt = positionals.slice(2).join(" ");
@@ -3620,7 +3607,12 @@ ${SYSTEM_REMINDER_CLOSE}
       usage,
       uuid: resultUuid,
     };
-    await writeWireMessageAsync(resultEvent);
+    if (!(await writeWireMessageAsync(resultEvent))) {
+      // stdout died before the result envelope went out; consumers (e.g. a
+      // parent subagent manager) must see a failure, not a clean empty exit.
+      reportSubagentStdoutLoss();
+      await exitHeadless(1, "headless_result_write_lost");
+    }
   } else {
     // text format (default)
     if (!resultText || resultText === "No assistant response found") {

--- a/src/stream-json-writer.test.ts
+++ b/src/stream-json-writer.test.ts
@@ -107,4 +107,58 @@ describe("writeWireMessage", () => {
     await pending;
     expect(resolved).toBe(true);
   });
+
+  test("async writer resolves true when the write lands", async () => {
+    const stdoutWrite = mock(
+      (
+        _chunk: string | Uint8Array,
+        callback?: (error?: Error | null) => void,
+      ) => {
+        callback?.();
+        return true;
+      },
+    );
+    process.stdout.write =
+      stdoutWrite as unknown as typeof process.stdout.write;
+
+    const msg: ControlRequest = {
+      type: "control_request",
+      request_id: "req-written",
+      request: { subtype: "interrupt" },
+    };
+
+    await expect(writeWireMessageAsync(msg)).resolves.toBe(true);
+    expect(stdoutWrite).toHaveBeenCalledTimes(1);
+  });
+
+  test("async writer resolves false without writing when stdout is destroyed", async () => {
+    const stdoutWrite = mock(
+      (
+        _chunk: string | Uint8Array,
+        callback?: (error?: Error | null) => void,
+      ) => {
+        callback?.();
+        return true;
+      },
+    );
+    process.stdout.write =
+      stdoutWrite as unknown as typeof process.stdout.write;
+    Object.defineProperty(process.stdout, "destroyed", {
+      value: true,
+      configurable: true,
+    });
+
+    try {
+      const msg: ControlRequest = {
+        type: "control_request",
+        request_id: "req-dropped",
+        request: { subtype: "interrupt" },
+      };
+
+      await expect(writeWireMessageAsync(msg)).resolves.toBe(false);
+      expect(stdoutWrite).not.toHaveBeenCalled();
+    } finally {
+      Reflect.deleteProperty(process.stdout, "destroyed");
+    }
+  });
 });

--- a/src/stream-json-writer.ts
+++ b/src/stream-json-writer.ts
@@ -32,12 +32,21 @@ export function writeWireMessage(msg: WireMessage): void {
   console.log(JSON.stringify(stampWireMessage(msg)));
 }
 
-export async function writeWireMessageAsync(msg: WireMessage): Promise<void> {
+/**
+ * Returns whether the line was actually written: `false` means stdout was
+ * already destroyed or ended, so the message never reached the wire. Callers
+ * emitting a message that downstream consumers depend on (e.g. the final
+ * result envelope a subagent parent parses) must check the return value
+ * instead of treating a silent drop as success.
+ */
+export async function writeWireMessageAsync(
+  msg: WireMessage,
+): Promise<boolean> {
   const line = `${JSON.stringify(stampWireMessage(msg))}\n`;
 
-  await new Promise<void>((resolve, reject) => {
+  return await new Promise<boolean>((resolve, reject) => {
     if (process.stdout.destroyed || process.stdout.writableEnded) {
-      resolve();
+      resolve(false);
       return;
     }
 
@@ -46,7 +55,7 @@ export async function writeWireMessageAsync(msg: WireMessage): Promise<void> {
         reject(error);
         return;
       }
-      resolve();
+      resolve(true);
     });
   });
 }

--- a/src/utils/headless-stdout-guard.test.ts
+++ b/src/utils/headless-stdout-guard.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { SUBAGENT_STDOUT_LOST_MARKER } from "@/utils/subagent-stdout-failure";
+
+const guardUrl = new URL("./headless-stdout-guard.ts", import.meta.url).href;
+
+function runWithStdoutError(options: {
+  env?: Record<string, string>;
+  code?: string;
+}): { status: number | null; stderr: string } {
+  const script = [
+    `const { installHeadlessStdoutGuard } = await import(${JSON.stringify(guardUrl)});`,
+    "installHeadlessStdoutGuard();",
+    `process.stdout.emit("error", Object.assign(new Error("stream failed"), { code: ${JSON.stringify(options.code ?? "EPIPE")} }));`,
+    // Only reached if the handler neither exited nor threw.
+    "process.exit(42);",
+  ].join("\n");
+
+  const result = spawnSync(process.execPath, ["-e", script], {
+    cwd: process.cwd(),
+    env: { ...process.env, LETTA_PARENT_AGENT_ID: "", ...options.env },
+    encoding: "utf-8",
+    timeout: 15_000,
+  });
+  return { status: result.status, stderr: result.stderr ?? "" };
+}
+
+describe("installHeadlessStdoutGuard", () => {
+  test("subagent child exits 1 with the marker flushed to stderr", () => {
+    const { status, stderr } = runWithStdoutError({
+      env: { LETTA_PARENT_AGENT_ID: "agent-parent-1" },
+    });
+    expect(status).toBe(1);
+    expect(stderr).toContain(SUBAGENT_STDOUT_LOST_MARKER);
+    expect(stderr).toContain("EPIPE");
+  });
+
+  test("non-subagent EPIPE stays a clean exit 0", () => {
+    const { status, stderr } = runWithStdoutError({});
+    expect(status).toBe(0);
+    expect(stderr).not.toContain(SUBAGENT_STDOUT_LOST_MARKER);
+  });
+
+  test("subagent child reports non-EPIPE stdout errors too", () => {
+    const { status, stderr } = runWithStdoutError({
+      env: { LETTA_PARENT_AGENT_ID: "agent-parent-1" },
+      code: "ERR_STREAM_DESTROYED",
+    });
+    expect(status).toBe(1);
+    expect(stderr).toContain(SUBAGENT_STDOUT_LOST_MARKER);
+    expect(stderr).toContain("ERR_STREAM_DESTROYED");
+  });
+});

--- a/src/utils/headless-stdout-guard.ts
+++ b/src/utils/headless-stdout-guard.ts
@@ -1,0 +1,37 @@
+import { reportSubagentStdoutLoss } from "@/utils/subagent-stdout-failure";
+
+/**
+ * Install the process-level stdout error handler for headless mode. Must be
+ * registered before any headless output is written.
+ *
+ * If headless output is being piped and the downstream closes early (e.g.
+ * `| head`), Node will throw EPIPE on stdout writes. Treat this as a normal
+ * termination rather than crashing with a stack trace.
+ *
+ * A subagent child is the exception: once its stdout is gone it can never
+ * deliver its result envelope, and a clean exit would make the parent parse
+ * a truncated stream (#3257). Exit non-zero with a marker on stderr so the
+ * parent retries the spawn instead. Rethrowing wouldn't surface this — the
+ * global uncaughtException handler swallows the rethrow and the process
+ * would still exit 0 later.
+ */
+export function installHeadlessStdoutGuard(): void {
+  process.stdout.on("error", (err: unknown) => {
+    const code =
+      typeof err === "object" && err !== null && "code" in err
+        ? (err as { code?: unknown }).code
+        : undefined;
+
+    if (process.env.LETTA_PARENT_AGENT_ID) {
+      reportSubagentStdoutLoss(code ?? err);
+      process.exit(1);
+    }
+
+    if (code === "EPIPE") {
+      process.exit(0);
+    }
+
+    // Re-throw unknown stdout errors so they surface during tests/debugging.
+    throw err;
+  });
+}

--- a/src/utils/subagent-stdout-failure.test.ts
+++ b/src/utils/subagent-stdout-failure.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isSubagentStdoutLostError,
+  SUBAGENT_STDOUT_LOST_MARKER,
+} from "@/utils/subagent-stdout-failure";
+
+describe("isSubagentStdoutLostError", () => {
+  test("matches the marker with surrounding stderr noise", () => {
+    const stderr = `some warning\n${SUBAGENT_STDOUT_LOST_MARKER} (EPIPE)\n`;
+    expect(isSubagentStdoutLostError(stderr)).toBe(true);
+  });
+
+  test("does not match unrelated stderr", () => {
+    expect(isSubagentStdoutLostError("Subagent exited with code 1")).toBe(
+      false,
+    );
+    expect(isSubagentStdoutLostError("")).toBe(false);
+  });
+});

--- a/src/utils/subagent-stdout-failure.ts
+++ b/src/utils/subagent-stdout-failure.ts
@@ -1,0 +1,28 @@
+import { writeSync } from "node:fs";
+import { getErrorMessage } from "@/utils/error";
+
+// Marker emitted on stderr by a headless subagent child whose stdout stream
+// failed before the final result envelope could be written. The parent
+// subagent manager matches on it to retry the spawn once instead of
+// surfacing a truncated-output parse failure.
+export const SUBAGENT_STDOUT_LOST_MARKER =
+  "headless stdout stream failed before the final result was written";
+
+export function isSubagentStdoutLostError(stderr: string): boolean {
+  return stderr.includes(SUBAGENT_STDOUT_LOST_MARKER);
+}
+
+/**
+ * Write the stdout-lost marker to stderr synchronously. Callers exit the
+ * process right after reporting, so an async `console.error` could be
+ * truncated the same way the stdout stream was — `writeSync` to fd 2
+ * guarantees the marker is flushed before `process.exit` runs.
+ */
+export function reportSubagentStdoutLoss(detail?: unknown): void {
+  const suffix = detail === undefined ? "" : ` (${getErrorMessage(detail)})`;
+  try {
+    writeSync(2, `${SUBAGENT_STDOUT_LOST_MARKER}${suffix}\n`);
+  } catch {
+    // stderr is gone too; there is nowhere left to report.
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes #3257 (regression continuation of #2213): under parallel `Agent` tool fan-out, long subagent responses could be dropped with `Failed to parse subagent output: Unexpected end of JSON input`, with no recovery path.
- Root cause is child-side, not a parent read race — the parent's chunk accumulation and `close`-event handling are correct. A subagent child whose stdout write fails mid-run could exit 0 with the tail of its stream (including the result envelope) never delivered:
  - the headless stdout `EPIPE` handler calls `process.exit(0)` immediately, discarding queued output;
  - non-EPIPE stdout errors are rethrown from the `error` listener, but the global `uncaughtException` handler swallows them, so the process limps on with a destroyed stdout;
  - once stdout is destroyed, the guards in `writeWireMessageAsync`/`flushAndExit` silently resolve without writing — so the final result envelope is dropped and the child still exits 0.
- Child fix: when running as a subagent (`LETTA_PARENT_AGENT_ID` set), any stdout error exits 1 with a marker on stderr; `writeWireMessageAsync` now returns whether the line actually reached stdout, and an unwritten result envelope becomes a non-zero exit instead of a silent success. Plain `letta -p | head` behavior (EPIPE → exit 0) is unchanged.
- Parent fix (the retry path #3257 asks for): `executeSubagent` respawns once — guarded by the existing `isRetry` flag — when the child reports lost stdout, or when a clean exit leaves the stdout fallback parse failing.

## Reproduction / verification

Built a local harness: a mock OpenAI-compatible provider makes the CLI fire an `Agent` tool call, and `LETTA_CODE_BIN` points the subagent spawn at a mock child that emits a truncated result line and exits 0 on its first spawn (the exact failure mode), then behaves on the next spawn:

- **Before:** 1 child spawn; tool result = `subagent_status=error … Failed to parse subagent output: JSON Parse error: Unterminated string`
- **After:** 2 child spawns (one retry); tool result = `subagent_status=success` with the full report delivered

## Test plan

- [x] New: `writeWireMessageAsync` returns `true` when the write lands, `false` (without writing) when stdout is destroyed (`src/stream-json-writer.test.ts`)
- [x] New: both lost-output retry sites forward the original payload (incl. `existingAgentId`/`existingConversationId`/`memoryScope`) and are `isRetry`-guarded (`src/agent/subagent-retry-parent-scope.test.ts`)
- [x] New: stderr marker matcher unit tests (`src/utils/subagent-stdout-failure.test.ts`)
- [x] Mutation check: with the fix stashed, exactly the 4 new tests fail
- [x] `bun run check` — all 10 checks pass
- [x] Full unit suite: no regressions vs baseline (3 extra failures were load flakes — pass in isolation)

## AI disclosure

Per the disclosure policy proposed in #3139: this fix was developed with AI assistance (Claude Code). The root-cause analysis, implementation, repro harness, and tests were AI-assisted; I reviewed, ran, and verified everything locally before submitting.

cc @devanshrj — same repro-harness approach as #3239. One design note: the parent retry re-runs the subagent task from scratch (mirroring the existing provider-fallback retry), so a side-effectful subagent would run twice in the rare lost-stdout case; happy to gate the retry on something stricter if you'd prefer.