### PR TITLE
fix(local): omit unavailable GPT-5.6 Luna OAuth model

### DIFF
--- a/src/backend/local/local-model-config.ts
+++ b/src/backend/local/local-model-config.ts
@@ -402,6 +402,9 @@ export async function resolveAvailableLocalModelForTurn(input: {
   };
 }
 
+// Temporary entitlement guard: remove Luna from this set once OpenAI enables
+// it through ChatGPT OAuth and LET-9572 is resolved. Direct OpenAI Luna remains
+// available because this filter is scoped to the chatgpt_oauth provider type.
 const UNSUPPORTED_LOCAL_CHATGPT_OAUTH_MODELS = new Set(["gpt-5.6-luna"]);
 
 function shouldIncludeLocalModel(

--- a/src/backend/local/local-model-config.ts
+++ b/src/backend/local/local-model-config.ts
@@ -402,6 +402,21 @@ export async function resolveAvailableLocalModelForTurn(input: {
   };
 }
 
+const UNSUPPORTED_LOCAL_CHATGPT_OAUTH_MODELS = new Set(["gpt-5.6-luna"]);
+
+function shouldIncludeLocalModel(
+  provider: PiProvider | string,
+  model: string,
+): boolean {
+  const modelId = isPiProvider(provider)
+    ? (stripProviderHandlePrefix(model, provider) ?? model)
+    : model;
+  return !(
+    localProviderTypeForModelConfig(provider) === "chatgpt_oauth" &&
+    UNSUPPORTED_LOCAL_CHATGPT_OAUTH_MODELS.has(modelId)
+  );
+}
+
 export async function listLocalModels(
   storageDir?: string,
   options: ListLocalModelsOptions = {},
@@ -425,6 +440,7 @@ export async function listLocalModels(
       modelEndpointType?: string;
     } = {},
   ) => {
+    if (!shouldIncludeLocalModel(provider, model)) return;
     const handle =
       options.handle ??
       (typeof provider === "string" &&

--- a/src/providers/local-pi-provider-catalog.test.ts
+++ b/src/providers/local-pi-provider-catalog.test.ts
@@ -138,7 +138,7 @@ describe("local pi provider catalog", () => {
     }
   });
 
-  test("local ChatGPT OAuth catalog includes GPT-5.6 named variants", async () => {
+  test("local ChatGPT OAuth catalog includes supported GPT-5.6 variants", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "local-chatgpt-56-"));
     try {
       setLocalOAuthProvider({
@@ -153,7 +153,7 @@ describe("local pi provider catalog", () => {
       });
 
       const models = await listLocalModels(storageDir);
-      for (const variant of ["sol", "terra", "luna"]) {
+      for (const variant of ["sol", "terra"]) {
         expect(models).toContainEqual(
           expect.objectContaining({
             handle: `openai-codex/gpt-5.6-${variant}`,
@@ -162,6 +162,9 @@ describe("local pi provider catalog", () => {
           }),
         );
       }
+      expect(
+        models.some((model) => model.handle === "openai-codex/gpt-5.6-luna"),
+      ).toBe(false);
       expect(
         models.some((model) => model.handle === "openai-codex/gpt-5.6"),
       ).toBe(false);


### PR DESCRIPTION
## Summary
- Hide `openai-codex/gpt-5.6-luna` from the local ChatGPT OAuth model catalog because Luna is not available through the Codex OAuth backend.
- Preserve `openai/gpt-5.6-luna` for direct OpenAI API connections.
- Keep Sol and Terra available through local ChatGPT OAuth.

## Why

`@earendil-works/pi-ai@0.80.6` currently advertises Luna in both direct OpenAI and `openai-codex` catalogs. Live OAuth requests reach OpenAI with the correct friendly ID but are routed to an unavailable internal Luna deployment. Filtering at the Letta Code local catalog boundary avoids offering an unusable OAuth option without changing pi-ai provider payload behavior or direct OpenAI availability.

## Validation
- `bun test src/providers/local-pi-provider-catalog.test.ts` — 17 passed
- `bun run check` — 12 checks passed

Linear: LET-9550

👾 Generated with [Letta Code](https://letta.com)