### PR TITLE
fix(local): remove GPT-5.6 Luna from ChatGPT OAuth

### DIFF
--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -203,6 +203,8 @@ const PI_PROVIDER_OVERRIDES: Partial<
     providerTypes: ["chatgpt_oauth", "openai-codex"],
     handlePrefixes: ["openai-codex/", "chatgpt-plus-pro/"],
     localProviderNames: ["openai-codex", LOCAL_CHATGPT_PROVIDER_NAME],
+    catalogModelHandle: (model) =>
+      model.id === "gpt-5.6-luna" ? undefined : `openai-codex/${model.id}`,
   },
 };
 

--- a/src/cli/components/ModelSelector-byok-custom-provider.test.tsx
+++ b/src/cli/components/ModelSelector-byok-custom-provider.test.tsx
@@ -54,19 +54,13 @@ describe("ModelSelector custom BYOK provider detection", () => {
     );
   });
 
-  test("uses ChatGPT GPT-5.6 metadata with a direct fallback", () => {
+  test("uses ChatGPT GPT-5.6 metadata", () => {
     expect(
       registryHandleForBackendModel(
         "openai-codex/gpt-5.6-sol",
         "chatgpt_oauth",
       ),
     ).toBe("chatgpt-plus-pro/gpt-5.6-sol");
-    expect(
-      registryHandleForBackendModel(
-        "openai-codex/gpt-5.6-luna",
-        "chatgpt_oauth",
-      ),
-    ).toBe("openai/gpt-5.6-luna");
     expect(labelForBackendModel("GPT-5.6 Sol", "chatgpt_oauth")).toBe(
       "GPT-5.6 Sol (ChatGPT)",
     );

--- a/src/providers/local-pi-provider-catalog.test.ts
+++ b/src/providers/local-pi-provider-catalog.test.ts
@@ -138,7 +138,7 @@ describe("local pi provider catalog", () => {
     }
   });
 
-  test("local ChatGPT OAuth catalog includes GPT-5.6 named variants", async () => {
+  test("local ChatGPT OAuth catalog includes available GPT-5.6 variants", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "local-chatgpt-56-"));
     try {
       setLocalOAuthProvider({
@@ -153,7 +153,7 @@ describe("local pi provider catalog", () => {
       });
 
       const models = await listLocalModels(storageDir);
-      for (const variant of ["sol", "terra", "luna"]) {
+      for (const variant of ["sol", "terra"]) {
         expect(models).toContainEqual(
           expect.objectContaining({
             handle: `openai-codex/gpt-5.6-${variant}`,
@@ -164,6 +164,9 @@ describe("local pi provider catalog", () => {
       }
       expect(
         models.some((model) => model.handle === "openai-codex/gpt-5.6"),
+      ).toBe(false);
+      expect(
+        models.some((model) => model.handle === "openai-codex/gpt-5.6-luna"),
       ).toBe(false);
     } finally {
       await rm(storageDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Remove GPT-5.6 Luna from the ChatGPT subscription model catalog because it is unavailable through ChatGPT OAuth
- Keep GPT-5.6 Sol and Terra enabled

## Validation
- `bun test src/providers/local-pi-provider-catalog.test.ts src/cli/components/ModelSelector-byok-custom-provider.test.tsx`
- `bun run check`