### PR TITLE
feat(dream): allow reflection model override

### DIFF
--- a/src/cli/helpers/reflection-launcher.ts
+++ b/src/cli/helpers/reflection-launcher.ts
@@ -145,6 +145,8 @@ export interface ReflectionLaunchOptions {
   triggerSource: ReflectionLaunchTriggerSource;
   reflectionSettings?: ReflectionSettings;
   description: string;
+  /** Explicit model for this reflection subagent, if requested by the caller. */
+  model?: string;
   instruction?: string;
   systemPrompt?: string;
   skipPendingWorktreeReminderScan?: boolean;
@@ -568,6 +570,7 @@ export async function launchReflectionSubagent(
       subagentType: "reflection",
       prompt: reflectionPrompt,
       description,
+      model: options.model,
       silentCompletion: true,
       transcriptPath: autoPayload.payloadPath,
       memoryScope: buildReflectionMemoryScope(worktree),

--- a/src/cli/subcommands/dream.test.ts
+++ b/src/cli/subcommands/dream.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { runDreamSubcommand } from "./dream";
+import { parseDreamArgs, runDreamSubcommand } from "./dream";
 
 function captureConsole(): {
   errors: string[];
@@ -37,6 +37,7 @@ describe("dream subcommand", () => {
       expect(output).toContain("letta dream");
       expect(output).toContain("--memory");
       expect(output).toContain("--from");
+      expect(output).toContain("--model");
       expect(output).toContain("--to");
       expect(output).toContain("--instruction");
     } finally {
@@ -75,5 +76,11 @@ describe("dream subcommand", () => {
     } finally {
       captured.restore();
     }
+  });
+
+  test("accepts an explicit reflection model", () => {
+    const parsed = parseDreamArgs(["--model", "zai/glm-5.2"]);
+
+    expect(parsed.values.model).toBe("zai/glm-5.2");
   });
 });

--- a/src/cli/subcommands/dream.ts
+++ b/src/cli/subcommands/dream.ts
@@ -30,6 +30,8 @@ Options:
                               the agent's primary "default" history), or an
                               external source, e.g. openhands:<conversation-dir>
                               or transcript:./rows.jsonl
+  -m, --model <handle>        Model for the reflection subagent (default:
+                              letta/auto-memory)
   --to <path>                 Maintain a doc (e.g. ./AGENTS.md) from memory;
                               the agent edits it in place, using judgment
   --effort <level>            Reflection effort (reserved; not yet implemented)
@@ -51,6 +53,7 @@ const DREAM_OPTIONS = {
   help: { type: "boolean", short: "h" },
   memory: { type: "string" },
   from: { type: "string" },
+  model: { type: "string", short: "m" },
   to: { type: "string" },
   effort: { type: "string" },
   timeout: { type: "string" },
@@ -60,7 +63,7 @@ const DREAM_OPTIONS = {
 
 const DEFAULT_TIMEOUT_SECONDS = 1500;
 
-function parseDreamArgs(argv: string[]) {
+export function parseDreamArgs(argv: string[]) {
   return parseArgs({
     args: argv,
     options: DREAM_OPTIONS,
@@ -241,6 +244,7 @@ export async function runDreamSubcommand(argv: string[]): Promise<number> {
     memfsEnabled: true,
     triggerSource: "manual",
     description: "Reflect on recent conversations",
+    model: parsed.values.model,
     instruction,
     recompileByConversation: new Map(),
     recompileQueuedByConversation: new Set(),
@@ -253,6 +257,7 @@ export async function runDreamSubcommand(argv: string[]): Promise<number> {
     },
     feedbackContext: {
       surface: "letta_code_cli",
+      model: parsed.values.model,
     },
   });
 


### PR DESCRIPTION
## Summary
- add `-m, --model <handle>` to `letta dream`
- forward the requested model through the reflection launcher to the existing model-aware background-subagent task boundary
- preserve current omitted-model behavior (`letta/auto-memory`) and record an explicit selection in reflection telemetry

## Motivation
`letta dream` currently always uses the API reflection default, `letta/auto-memory`. With this change:

```bash
letta dream --memory <agent-id> --from transcript:./rows.jsonl --model zai/glm-5.2
```

runs the reflection subagent on the requested model without mutating the target agent model.

## Testing
- `bun test src/cli/subcommands/dream.test.ts src/agent/subagent-model-resolution.test.ts`
- `bun run check` (all 12 checks passed)

👾 Generated with [Letta Code](https://letta.com)