### PR TITLE
fix(channels): prompt Slack acknowledgements for long work

### DIFF
--- a/src/channels/message-tool-schema.test.ts
+++ b/src/channels/message-tool-schema.test.ts
@@ -8,6 +8,9 @@ import {
 import { ChannelRegistry, getChannelRegistry } from "@/channels/registry";
 import type { ChannelAdapter } from "@/channels/types";
 
+const SLACK_WORK_ACKNOWLEDGEMENT_GUIDANCE_PREFIX =
+  "For Slack requests that require nontrivial work or several tool calls";
+
 function createRunningAdapter(
   channelId: "slack" | "telegram",
   accountId: string,
@@ -114,7 +117,9 @@ describe("buildDynamicMessageChannelSchema", () => {
     expect(resolved.description).toContain(
       "Available actions across the active channels: send, react, upload-file, send-rich.",
     );
-    expect(resolved.description).not.toContain("View in web link");
+    expect(resolved.description).toContain(
+      SLACK_WORK_ACKNOWLEDGEMENT_GUIDANCE_PREFIX,
+    );
     expect(properties.channel?.enum).toEqual(["slack", "telegram"]);
     expect(properties.action?.enum).toEqual([
       "send",
@@ -167,9 +172,8 @@ describe("buildDynamicMessageChannelSchema", () => {
       "If the useful response belongs later, schedule the follow-up instead of sending a placeholder.",
     );
     expect(resolved.description).toContain(
-      'For Slack requests that require nontrivial work or several tool calls, send one short MessageChannel call with action="send" before starting other tools.',
+      SLACK_WORK_ACKNOWLEDGEMENT_GUIDANCE_PREFIX,
     );
-    expect(resolved.description).toContain("View in web link.");
     expect(resolved.description).not.toContain("Telegram");
     expect(properties.channel?.enum).toEqual(["slack"]);
     expect(properties.action?.enum).toEqual(["send", "react", "upload-file"]);
@@ -205,9 +209,8 @@ describe("buildDynamicMessageChannelSchema", () => {
       "Currently active channels: Telegram.",
     );
     expect(resolved.description).not.toContain(
-      "For Slack requests that require nontrivial work",
+      SLACK_WORK_ACKNOWLEDGEMENT_GUIDANCE_PREFIX,
     );
-    expect(resolved.description).not.toContain("View in web link");
     expect(properties.channel?.enum).toEqual(["telegram"]);
     expect(properties.action?.enum).toEqual([
       "send",

--- a/src/channels/message-tool-schema.test.ts
+++ b/src/channels/message-tool-schema.test.ts
@@ -114,6 +114,7 @@ describe("buildDynamicMessageChannelSchema", () => {
     expect(resolved.description).toContain(
       "Available actions across the active channels: send, react, upload-file, send-rich.",
     );
+    expect(resolved.description).not.toContain("View in web link");
     expect(properties.channel?.enum).toEqual(["slack", "telegram"]);
     expect(properties.action?.enum).toEqual([
       "send",
@@ -165,8 +166,54 @@ describe("buildDynamicMessageChannelSchema", () => {
     expect(resolved.description).toContain(
       "If the useful response belongs later, schedule the follow-up instead of sending a placeholder.",
     );
+    expect(resolved.description).toContain(
+      'For Slack requests that require nontrivial work or several tool calls, send one short MessageChannel call with action="send" before starting other tools.',
+    );
+    expect(resolved.description).toContain("View in web link.");
     expect(resolved.description).not.toContain("Telegram");
     expect(properties.channel?.enum).toEqual(["slack"]);
     expect(properties.action?.enum).toEqual(["send", "react", "upload-file"]);
+  });
+
+  test("does not add Slack work acknowledgement guidance to Telegram-only scoped descriptions", async () => {
+    const registry = new ChannelRegistry();
+    registry.registerAdapter(createRunningAdapter("slack", "acct-slack"));
+    registry.registerAdapter(createRunningAdapter("telegram", "acct-telegram"));
+
+    const resolved = await buildDynamicMessageChannelToolDefinition(
+      "Base MessageChannel description.",
+      {
+        type: "object",
+        properties: {
+          action: { type: "string" },
+          channel: { type: "string" },
+          chat_id: { type: "string" },
+        },
+        required: ["action", "channel", "chat_id"],
+        additionalProperties: false,
+      },
+      {
+        channels: [{ channelId: "telegram", accountId: "acct-telegram" }],
+      },
+    );
+
+    const properties = resolved.schema.properties as Record<
+      string,
+      { enum?: string[] }
+    >;
+    expect(resolved.description).toContain(
+      "Currently active channels: Telegram.",
+    );
+    expect(resolved.description).not.toContain(
+      "For Slack requests that require nontrivial work",
+    );
+    expect(resolved.description).not.toContain("View in web link");
+    expect(properties.channel?.enum).toEqual(["telegram"]);
+    expect(properties.action?.enum).toEqual([
+      "send",
+      "send-rich",
+      "react",
+      "upload-file",
+    ]);
   });
 });

--- a/src/channels/message-tool.ts
+++ b/src/channels/message-tool.ts
@@ -142,9 +142,7 @@ function buildDynamicMessageChannelDescriptionFromDiscovery(
     scopedChannels.length > 0
       ? '\n\nThis tool is currently scoped to a routed external channel turn. Plain assistant text is not delivered to that external user. If a user-visible reply is appropriate, your final action for the turn must be one MessageChannel call with action="send", channel from the notification, chat_id from the notification, and message containing the reply. If no user-visible response is appropriate, do not call MessageChannel and do not send an empty acknowledgement. For lightweight acknowledgement, prefer action="react" when supported. If the useful response belongs later, schedule the follow-up instead of sending a placeholder.'
       : "";
-  const slackWorkAcknowledgement = scopedChannels.some(
-    ({ channelId }) => channelId === "slack",
-  )
+  const slackWorkAcknowledgement = discovery.activeChannels.includes("slack")
     ? '\n\nFor Slack requests that require nontrivial work or several tool calls, send one short MessageChannel call with action="send" before starting other tools. This gives the Slack user verbal acknowledgement and a View in web link. Do not do this for no-ops, reaction-only responses, or simple no-tool answers.'
     : "";
 

--- a/src/channels/message-tool.ts
+++ b/src/channels/message-tool.ts
@@ -137,12 +137,18 @@ function buildDynamicMessageChannelDescriptionFromDiscovery(
     .join(", ");
   const actionList = discovery.actions.join(", ");
 
+  const scopedChannels = scope?.channels ?? [];
   const scopedReplyContract =
-    scope && scope.channels.length > 0
+    scopedChannels.length > 0
       ? '\n\nThis tool is currently scoped to a routed external channel turn. Plain assistant text is not delivered to that external user. If a user-visible reply is appropriate, your final action for the turn must be one MessageChannel call with action="send", channel from the notification, chat_id from the notification, and message containing the reply. If no user-visible response is appropriate, do not call MessageChannel and do not send an empty acknowledgement. For lightweight acknowledgement, prefer action="react" when supported. If the useful response belongs later, schedule the follow-up instead of sending a placeholder.'
       : "";
+  const slackWorkAcknowledgement = scopedChannels.some(
+    ({ channelId }) => channelId === "slack",
+  )
+    ? '\n\nFor Slack requests that require nontrivial work or several tool calls, send one short MessageChannel call with action="send" before starting other tools. This gives the Slack user verbal acknowledgement and a View in web link. Do not do this for no-ops, reaction-only responses, or simple no-tool answers.'
+    : "";
 
-  return `${description}${scopedReplyContract}\n\nCurrently active channels: ${channelList}. Available actions across the active channels: ${actionList}. The JSON schema reflects the currently active channel plugins.`;
+  return `${description}${scopedReplyContract}${slackWorkAcknowledgement}\n\nCurrently active channels: ${channelList}. Available actions across the active channels: ${actionList}. The JSON schema reflects the currently active channel plugins.`;
 }
 
 function pruneInactiveChannelGuidance(

--- a/src/channels/xml.test.ts
+++ b/src/channels/xml.test.ts
@@ -75,6 +75,7 @@ describe("formatChannelNotification", () => {
     expect(reminder).toContain(
       "If the useful response belongs later, schedule the follow-up instead of sending a placeholder.",
     );
+    expect(reminder).not.toContain("View in web link");
     expect(reminder).toContain(
       "Do not produce a plain text assistant response as the user-visible reply.",
     );
@@ -142,6 +143,10 @@ describe("formatChannelNotification", () => {
     const reminder = buildChannelReminderText(msg);
 
     expect(reminder).toContain("stay in the same Slack thread automatically");
+    expect(reminder).toContain(
+      'send a short MessageChannel action="send" acknowledgement before starting other tools',
+    );
+    expect(reminder).toContain("View in web link");
     expect(reminder).not.toContain("reply_to_message_id");
   });
 

--- a/src/channels/xml.test.ts
+++ b/src/channels/xml.test.ts
@@ -7,6 +7,9 @@ import {
   formatChannelNotification,
 } from "@/channels/xml";
 
+const SLACK_WORK_ACKNOWLEDGEMENT_GUIDANCE_PREFIX =
+  "For Slack requests that require nontrivial work or several tool calls";
+
 function expectTextParts(
   content: MessageCreate["content"],
 ): [{ type: "text"; text: string }, { type: "text"; text: string }] {
@@ -75,7 +78,7 @@ describe("formatChannelNotification", () => {
     expect(reminder).toContain(
       "If the useful response belongs later, schedule the follow-up instead of sending a placeholder.",
     );
-    expect(reminder).not.toContain("View in web link");
+    expect(reminder).not.toContain(SLACK_WORK_ACKNOWLEDGEMENT_GUIDANCE_PREFIX);
     expect(reminder).toContain(
       "Do not produce a plain text assistant response as the user-visible reply.",
     );
@@ -143,10 +146,10 @@ describe("formatChannelNotification", () => {
     const reminder = buildChannelReminderText(msg);
 
     expect(reminder).toContain("stay in the same Slack thread automatically");
+    expect(reminder).toContain(SLACK_WORK_ACKNOWLEDGEMENT_GUIDANCE_PREFIX);
     expect(reminder).toContain(
       'send a short MessageChannel action="send" acknowledgement before starting other tools',
     );
-    expect(reminder).toContain("View in web link");
     expect(reminder).not.toContain("reply_to_message_id");
   });
 

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -79,6 +79,7 @@ export function buildChannelReminderText(msg: InboundChannelMessage): string {
       lines.length - 2,
       0,
       'On Slack, MessageChannel also supports action="react" with emoji + messageId, and action="upload-file" with media.',
+      'For Slack requests that require nontrivial work or several tool calls, send a short MessageChannel action="send" acknowledgement before starting other tools. This gives the Slack user verbal acknowledgement and a View in web link. Do not do this for no-ops, reaction-only responses, or simple no-tool answers.',
     );
   }
   if (msg.channel === "telegram") {


### PR DESCRIPTION
## Summary
- Current scoping behavior: `MessageChannel` definitions are rebuilt from active/scoped channel discovery; scoped conversations get the external-channel reply contract, and channel notification reminders are built from the inbound channel. This change injects the new acknowledgement prompt whenever the resolved `MessageChannel` discovery includes Slack, and in Slack channel reminders.
- Before: Slack turns explained how to send replies and lightweight reactions, but did not tell agents to send a visible `action="send"` acknowledgement before longer tool work.
- After: resolved Slack tool definitions and Slack reminders now ask for a short `action="send"` acknowledgement before nontrivial or multi-tool work, while excluding no-ops, reaction-only responses, and simple no-tool answers.

## Risk
- Prompt-only change; no `MessageChannel` execution behavior or JSON schema shape changes.
- Main risk is over-acknowledgement on Slack. The wording is narrowed to nontrivial/multi-tool Slack work, and tests assert the guidance appears for unscoped multi-channel discovery with Slack, remains for scoped Slack discovery, and stays absent for Telegram-only scoped descriptions and Telegram reminders.

## Validation
- `bun test --cwd /tmp/letta-code-slack-request-ack src/channels/message-tool-schema.test.ts src/channels/xml.test.ts --timeout 15000`
- `bunx --bun @biomejs/biome@2.2.5 check /tmp/letta-code-slack-request-ack/src/channels/message-tool.ts /tmp/letta-code-slack-request-ack/src/channels/xml.ts /tmp/letta-code-slack-request-ack/src/channels/message-tool-schema.test.ts /tmp/letta-code-slack-request-ack/src/channels/xml.test.ts`
- `bun run --cwd /tmp/letta-code-slack-request-ack typecheck`

👾 Generated with [Letta Code](https://letta.com)