### PR TITLE
refactor(subagents): extract model resolution into subagent-model.ts

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "src/agent/client-skills.test.ts": 1196,
   "src/agent/memory-git.ts": 2324,
-  "src/agent/subagents/manager.ts": 1577,
+  "src/agent/subagents/manager.ts": 1357,
   "src/backend/local-backend.test.ts": 2589,
   "src/backend/local/local-backend.ts": 1058,
   "src/backend/local/local-store.ts": 3629,

--- a/src/agent/subagent-model-resolution.test.ts
+++ b/src/agent/subagent-model-resolution.test.ts
@@ -8,12 +8,14 @@ import {
 import {
   buildSubagentArgs,
   buildSubagentPrompt,
-  getModelHandleFromAgent,
   recallPromptForBackend,
   resolveSubagentLauncher,
-  resolveSubagentModel,
   resolveSubagentWorkingDirectory,
 } from "@/agent/subagents/manager";
+import {
+  getModelHandleFromAgent,
+  resolveSubagentModel,
+} from "@/agent/subagents/subagent-model";
 
 describe("recallPromptForBackend", () => {
   test("uses separate API and local recall prompts", () => {

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -8,9 +8,7 @@
  */
 
 import { spawn } from "node:child_process";
-import { getAvailableModelHandles } from "@/agent/available-models";
 import { getConversationId, getCurrentAgentId } from "@/agent/context";
-import { getDefaultModelForTier, resolveModel } from "@/agent/model";
 import recallSubagentPrompt from "@/agent/prompts/recall_subagent.md";
 import recallSubagentLocalPrompt from "@/agent/prompts/recall_subagent_local.md";
 import {
@@ -24,7 +22,6 @@ import {
   getBackend,
   getLocalBackendStorageDir,
 } from "@/backend";
-import { getBillingTier } from "@/backend/api/metadata";
 import { getLocalBackendMemoryFilesystemRoot } from "@/backend/local/paths";
 import { buildAgentReference } from "@/cli/helpers/app-urls";
 import {
@@ -59,6 +56,11 @@ import {
   REFLECTION_STARTUP_CONTEXT_CHAR_LIMIT,
   REFLECTION_STARTUP_CONTEXT_TOKEN_LIMIT,
 } from "./context-budget";
+import {
+  getCurrentBillingTier,
+  getPrimaryAgentModelHandle,
+  resolveSubagentModel,
+} from "./subagent-model";
 
 // ============================================================================
 // Constants
@@ -125,68 +127,6 @@ interface ExecutionState {
 // ============================================================================
 
 /**
- * Get the primary agent's model ID
- * Fetches from API and resolves to a known model ID
- */
-export function getModelHandleFromAgent(agent: {
-  model?: string | null;
-  model_settings?: { provider_type?: unknown } | null;
-  llm_config?: { model_endpoint_type?: string | null; model?: string | null };
-}): string | null {
-  const directModel = agent.model;
-  if (directModel?.includes("/")) {
-    return directModel;
-  }
-  const settingsProvider = agent.model_settings?.provider_type;
-  if (typeof settingsProvider === "string" && directModel) {
-    return `${settingsProvider}/${directModel}`;
-  }
-  const endpoint = agent.llm_config?.model_endpoint_type;
-  const model = agent.llm_config?.model;
-  if (endpoint && model) {
-    return `${endpoint}/${model}`;
-  }
-  return directModel || model || null;
-}
-
-async function getPrimaryAgentModelHandle(
-  scope: { agentId?: string | null; conversationId?: string | null } = {},
-): Promise<{
-  handle: string | null;
-  agent: {
-    model?: string | null;
-    name?: string | null;
-    model_settings?: { provider_type?: unknown } | null;
-    llm_config?: { model_endpoint_type?: string | null; model?: string | null };
-  } | null;
-}> {
-  try {
-    const agentId = scope.agentId ?? getCurrentAgentId();
-    const agent = await getBackend().retrieveAgent(agentId);
-    const conversationId = scope.conversationId;
-    if (conversationId && conversationId !== "default") {
-      try {
-        const conversation =
-          await getBackend().retrieveConversation(conversationId);
-        const conversationHandle = getModelHandleFromAgent(conversation);
-        if (conversationHandle) {
-          return { handle: conversationHandle, agent };
-        }
-      } catch {
-        // Fall back to the agent default if the conversation is not available.
-      }
-    }
-    return { handle: getModelHandleFromAgent(agent), agent };
-  } catch {
-    return { handle: null, agent: null };
-  }
-}
-
-async function getCurrentBillingTier(): Promise<string | null> {
-  return getBillingTier();
-}
-
-/**
  * Check if an error message indicates an unsupported provider
  */
 function isProviderNotSupportedError(errorOutput: string): boolean {
@@ -195,166 +135,6 @@ function isProviderNotSupportedError(errorOutput: string): boolean {
     errorOutput.includes("is not supported") &&
     errorOutput.includes("supported providers:")
   );
-}
-
-const BYOK_PROVIDER_TO_BASE: Record<string, string> = {
-  "lc-anthropic": "anthropic",
-  "lc-openai": "openai",
-  "lc-zai": "zai",
-  "lc-gemini": "google_ai",
-  "lc-openrouter": "openrouter",
-  "lc-minimax": "minimax",
-  "lc-bedrock": "bedrock",
-  "chatgpt-plus-pro": "chatgpt-plus-pro",
-};
-
-function getProviderPrefix(handle: string): string | null {
-  const slashIndex = handle.indexOf("/");
-  if (slashIndex === -1) return null;
-  return handle.slice(0, slashIndex);
-}
-
-function swapProviderPrefix(
-  parentHandle: string,
-  recommendedHandle: string,
-): string | null {
-  const parentProvider = getProviderPrefix(parentHandle);
-  if (!parentProvider) return null;
-
-  const baseProvider = BYOK_PROVIDER_TO_BASE[parentProvider];
-  if (!baseProvider) return null;
-
-  const recommendedProvider = getProviderPrefix(recommendedHandle);
-  if (!recommendedProvider || recommendedProvider !== baseProvider) return null;
-
-  const modelPortion = recommendedHandle.slice(recommendedProvider.length + 1);
-  return `${parentProvider}/${modelPortion}`;
-}
-
-function isInheritModel(model: string | null | undefined): boolean {
-  return model?.trim().toLowerCase() === "inherit";
-}
-
-export async function resolveSubagentModel(options: {
-  userModel?: string;
-  recommendedModel?: string;
-  parentModelHandle?: string | null;
-  billingTier?: string | null;
-  availableHandles?: Set<string>;
-  subagentType?: string;
-  backendMode?: BackendMode;
-}): Promise<string | null> {
-  const { userModel, recommendedModel, parentModelHandle, billingTier } =
-    options;
-  const isFreeTier = billingTier?.toLowerCase() === "free";
-  const userRequestedInheritance = isInheritModel(userModel);
-  const effectiveRecommendedModel = userRequestedInheritance
-    ? "inherit"
-    : recommendedModel;
-
-  if (userModel && !userRequestedInheritance) return userModel;
-
-  // Local backend has no server-side auto router. If the parent agent is
-  // already running successfully on a local model, spawned subagents should use
-  // that exact model instead of resolving auto/auto-memory to a provider
-  // default that may not match the active session.
-  if (options.backendMode === "local" && parentModelHandle) {
-    return parentModelHandle;
-  }
-
-  if (options.subagentType === "reflection") {
-    if (
-      effectiveRecommendedModel &&
-      !isInheritModel(effectiveRecommendedModel)
-    ) {
-      const recommendedHandle = resolveModel(effectiveRecommendedModel);
-      if (recommendedHandle) {
-        return recommendedHandle;
-      }
-    }
-
-    return "letta/auto-memory";
-  }
-
-  let recommendedHandle: string | null = null;
-  if (effectiveRecommendedModel && !isInheritModel(effectiveRecommendedModel)) {
-    recommendedHandle = resolveModel(effectiveRecommendedModel);
-  }
-
-  let availableHandles: Set<string> | null = options.availableHandles ?? null;
-  const isAvailable = async (handle: string): Promise<boolean> => {
-    try {
-      if (!availableHandles) {
-        const result = await getAvailableModelHandles();
-        availableHandles = result.handles;
-      }
-      return availableHandles.has(handle);
-    } catch {
-      return false;
-    }
-  };
-
-  // Free-tier default for subagents: auto-fast, when available.
-  const freeTierDefaultHandle = isFreeTier ? resolveModel("auto-fast") : null;
-  if (freeTierDefaultHandle && (await isAvailable(freeTierDefaultHandle))) {
-    return freeTierDefaultHandle;
-  }
-
-  // Free-tier fallback default: auto, when available.
-  if (isFreeTier) {
-    const defaultHandle = getDefaultModelForTier(billingTier);
-    if (defaultHandle && (await isAvailable(defaultHandle))) {
-      return defaultHandle;
-    }
-  }
-
-  if (parentModelHandle) {
-    const parentProvider = getProviderPrefix(parentModelHandle);
-    const parentBaseProvider = parentProvider
-      ? BYOK_PROVIDER_TO_BASE[parentProvider]
-      : null;
-    const parentIsByok = !!parentBaseProvider;
-
-    if (recommendedHandle) {
-      const recommendedProvider = getProviderPrefix(recommendedHandle);
-
-      if (parentIsByok) {
-        if (recommendedProvider === parentProvider) {
-          if (await isAvailable(recommendedHandle)) {
-            return recommendedHandle;
-          }
-        } else {
-          const swapped = swapProviderPrefix(
-            parentModelHandle,
-            recommendedHandle,
-          );
-          if (swapped && (await isAvailable(swapped))) {
-            return swapped;
-          }
-        }
-
-        return parentModelHandle;
-      }
-
-      if (await isAvailable(recommendedHandle)) {
-        return recommendedHandle;
-      }
-    }
-
-    return parentModelHandle;
-  }
-
-  if (recommendedHandle && (await isAvailable(recommendedHandle))) {
-    return recommendedHandle;
-  }
-
-  // Non-free fallback default: auto, when available.
-  const defaultHandle = getDefaultModelForTier(billingTier);
-  if (defaultHandle && (await isAvailable(defaultHandle))) {
-    return defaultHandle;
-  }
-
-  return recommendedHandle;
 }
 
 /**

--- a/src/agent/subagents/subagent-model.ts
+++ b/src/agent/subagents/subagent-model.ts
@@ -1,0 +1,231 @@
+// Model resolution for spawned subagents: decide which model handle a subagent
+// should run on, given the user's request, the subagent config's recommended
+// model, the parent agent's active model, and the account's billing tier.
+//
+// Extracted from `manager.ts` so this self-contained resolution logic (and its
+// tests) live on their own. It depends only on lower-level model/backend
+// helpers, never back on the subagent manager.
+
+import { getAvailableModelHandles } from "@/agent/available-models";
+import { getCurrentAgentId } from "@/agent/context";
+import { getDefaultModelForTier, resolveModel } from "@/agent/model";
+import { type BackendMode, getBackend } from "@/backend";
+import { getBillingTier } from "@/backend/api/metadata";
+
+export function getModelHandleFromAgent(agent: {
+  model?: string | null;
+  model_settings?: { provider_type?: unknown } | null;
+  llm_config?: { model_endpoint_type?: string | null; model?: string | null };
+}): string | null {
+  const directModel = agent.model;
+  if (directModel?.includes("/")) {
+    return directModel;
+  }
+  const settingsProvider = agent.model_settings?.provider_type;
+  if (typeof settingsProvider === "string" && directModel) {
+    return `${settingsProvider}/${directModel}`;
+  }
+  const endpoint = agent.llm_config?.model_endpoint_type;
+  const model = agent.llm_config?.model;
+  if (endpoint && model) {
+    return `${endpoint}/${model}`;
+  }
+  return directModel || model || null;
+}
+
+export async function getPrimaryAgentModelHandle(
+  scope: { agentId?: string | null; conversationId?: string | null } = {},
+): Promise<{
+  handle: string | null;
+  agent: {
+    model?: string | null;
+    name?: string | null;
+    model_settings?: { provider_type?: unknown } | null;
+    llm_config?: { model_endpoint_type?: string | null; model?: string | null };
+  } | null;
+}> {
+  try {
+    const agentId = scope.agentId ?? getCurrentAgentId();
+    const agent = await getBackend().retrieveAgent(agentId);
+    const conversationId = scope.conversationId;
+    if (conversationId && conversationId !== "default") {
+      try {
+        const conversation =
+          await getBackend().retrieveConversation(conversationId);
+        const conversationHandle = getModelHandleFromAgent(conversation);
+        if (conversationHandle) {
+          return { handle: conversationHandle, agent };
+        }
+      } catch {
+        // Fall back to the agent default if the conversation is not available.
+      }
+    }
+    return { handle: getModelHandleFromAgent(agent), agent };
+  } catch {
+    return { handle: null, agent: null };
+  }
+}
+
+export async function getCurrentBillingTier(): Promise<string | null> {
+  return getBillingTier();
+}
+
+const BYOK_PROVIDER_TO_BASE: Record<string, string> = {
+  "lc-anthropic": "anthropic",
+  "lc-openai": "openai",
+  "lc-zai": "zai",
+  "lc-gemini": "google_ai",
+  "lc-openrouter": "openrouter",
+  "lc-minimax": "minimax",
+  "lc-bedrock": "bedrock",
+  "chatgpt-plus-pro": "chatgpt-plus-pro",
+};
+
+function getProviderPrefix(handle: string): string | null {
+  const slashIndex = handle.indexOf("/");
+  if (slashIndex === -1) return null;
+  return handle.slice(0, slashIndex);
+}
+
+function swapProviderPrefix(
+  parentHandle: string,
+  recommendedHandle: string,
+): string | null {
+  const parentProvider = getProviderPrefix(parentHandle);
+  if (!parentProvider) return null;
+
+  const baseProvider = BYOK_PROVIDER_TO_BASE[parentProvider];
+  if (!baseProvider) return null;
+
+  const recommendedProvider = getProviderPrefix(recommendedHandle);
+  if (!recommendedProvider || recommendedProvider !== baseProvider) return null;
+
+  const modelPortion = recommendedHandle.slice(recommendedProvider.length + 1);
+  return `${parentProvider}/${modelPortion}`;
+}
+
+function isInheritModel(model: string | null | undefined): boolean {
+  return model?.trim().toLowerCase() === "inherit";
+}
+
+export async function resolveSubagentModel(options: {
+  userModel?: string;
+  recommendedModel?: string;
+  parentModelHandle?: string | null;
+  billingTier?: string | null;
+  availableHandles?: Set<string>;
+  subagentType?: string;
+  backendMode?: BackendMode;
+}): Promise<string | null> {
+  const { userModel, recommendedModel, parentModelHandle, billingTier } =
+    options;
+  const isFreeTier = billingTier?.toLowerCase() === "free";
+  const userRequestedInheritance = isInheritModel(userModel);
+  const effectiveRecommendedModel = userRequestedInheritance
+    ? "inherit"
+    : recommendedModel;
+
+  if (userModel && !userRequestedInheritance) return userModel;
+
+  // Local backend has no server-side auto router. If the parent agent is
+  // already running successfully on a local model, spawned subagents should use
+  // that exact model instead of resolving auto/auto-memory to a provider
+  // default that may not match the active session.
+  if (options.backendMode === "local" && parentModelHandle) {
+    return parentModelHandle;
+  }
+
+  if (options.subagentType === "reflection") {
+    if (
+      effectiveRecommendedModel &&
+      !isInheritModel(effectiveRecommendedModel)
+    ) {
+      const recommendedHandle = resolveModel(effectiveRecommendedModel);
+      if (recommendedHandle) {
+        return recommendedHandle;
+      }
+    }
+
+    return "letta/auto-memory";
+  }
+
+  let recommendedHandle: string | null = null;
+  if (effectiveRecommendedModel && !isInheritModel(effectiveRecommendedModel)) {
+    recommendedHandle = resolveModel(effectiveRecommendedModel);
+  }
+
+  let availableHandles: Set<string> | null = options.availableHandles ?? null;
+  const isAvailable = async (handle: string): Promise<boolean> => {
+    try {
+      if (!availableHandles) {
+        const result = await getAvailableModelHandles();
+        availableHandles = result.handles;
+      }
+      return availableHandles.has(handle);
+    } catch {
+      return false;
+    }
+  };
+
+  // Free-tier default for subagents: auto-fast, when available.
+  const freeTierDefaultHandle = isFreeTier ? resolveModel("auto-fast") : null;
+  if (freeTierDefaultHandle && (await isAvailable(freeTierDefaultHandle))) {
+    return freeTierDefaultHandle;
+  }
+
+  // Free-tier fallback default: auto, when available.
+  if (isFreeTier) {
+    const defaultHandle = getDefaultModelForTier(billingTier);
+    if (defaultHandle && (await isAvailable(defaultHandle))) {
+      return defaultHandle;
+    }
+  }
+
+  if (parentModelHandle) {
+    const parentProvider = getProviderPrefix(parentModelHandle);
+    const parentBaseProvider = parentProvider
+      ? BYOK_PROVIDER_TO_BASE[parentProvider]
+      : null;
+    const parentIsByok = !!parentBaseProvider;
+
+    if (recommendedHandle) {
+      const recommendedProvider = getProviderPrefix(recommendedHandle);
+
+      if (parentIsByok) {
+        if (recommendedProvider === parentProvider) {
+          if (await isAvailable(recommendedHandle)) {
+            return recommendedHandle;
+          }
+        } else {
+          const swapped = swapProviderPrefix(
+            parentModelHandle,
+            recommendedHandle,
+          );
+          if (swapped && (await isAvailable(swapped))) {
+            return swapped;
+          }
+        }
+
+        return parentModelHandle;
+      }
+
+      if (await isAvailable(recommendedHandle)) {
+        return recommendedHandle;
+      }
+    }
+
+    return parentModelHandle;
+  }
+
+  if (recommendedHandle && (await isAvailable(recommendedHandle))) {
+    return recommendedHandle;
+  }
+
+  // Non-free fallback default: auto, when available.
+  const defaultHandle = getDefaultModelForTier(billingTier);
+  if (defaultHandle && (await isAvailable(defaultHandle))) {
+    return defaultHandle;
+  }
+
+  return recommendedHandle;
+}


### PR DESCRIPTION
## What

Extracts the subagent **model-resolution** logic out of the oversized `manager.ts` into a new, self-contained `src/agent/subagents/subagent-model.ts`:

- `getModelHandleFromAgent`, `getPrimaryAgentModelHandle`, `getCurrentBillingTier`, `resolveSubagentModel`
- the provider/inherit helpers (`BYOK_PROVIDER_TO_BASE`, `getProviderPrefix`, `swapProviderPrefix`, `isInheritModel`) — kept private to the new module

**Pure move, no behavior change.**

## Why

`manager.ts` is well over the 1,000-line ceiling (baselined at 1577). Model resolution is one of several independent concerns bolted onto it, and it's the cleanest to peel off first: it depends only on lower-level model/backend helpers (`resolveModel`, `getAvailableModelHandles`, `getDefaultModelForTier`, `getBackend`, `getBillingTier`, `getCurrentAgentId`) and is **not** imported back by `manager` — so no circular dependency. It also already had its own test suite (`subagent-model-resolution.test.ts`), which now targets the module directly.

This is a first, standalone step; more of `manager.ts` (stream parsing, launcher/env) can be split later.

## Notes

- `isProviderNotSupportedError` stays in `manager.ts` — it's used by `executeSubagent`'s retry path, not model resolution.
- Importers (`manager.ts`, the resolution test) import from the new module directly — no re-export barrel (respects the module-ownership rule).
- `manager.ts` size baseline ratcheted down **1577 → 1357**.

## Test
- `bun run check` — 12/12 pass (cycles, boundaries, module-ownership, size, tsc, biome, …)
- `bun test src/agent/subagent-model-resolution.test.ts` — 63/63 pass