### PR TITLE
feat(local): SuperGrok OAuth for xAI Grok models

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -14,7 +14,7 @@
   "src/cli/app/use-submit-handler.ts": 4100,
   "src/cli/components/AgentSelector.tsx": 1270,
   "src/cli/components/InputRich.tsx": 2219,
-  "src/cli/components/ModelSelector.tsx": 1204,
+  "src/cli/components/ModelSelector.tsx": 1199,
   "src/cli/components/ProviderSelector.tsx": 1676,
   "src/cli/components/ToolCallMessageRich.tsx": 1109,
   "src/cli/helpers/accumulator.ts": 1596,

--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -365,6 +365,12 @@ function customOpenAICompatibleModel(input: {
   };
 }
 
+function shouldCreateDynamicOpenAICompatibleModel(
+  spec: ReturnType<typeof getPiProviderSpec>,
+): boolean {
+  return spec.localModelDiscovery === "openai-compatible";
+}
+
 function withOverrides(
   model: Model<Api>,
   overrides: {
@@ -673,18 +679,30 @@ export async function resolvePiModelForAgent(
         spec.piProvider ?? "openai",
         modelId as never,
       ) as Model<Api> | undefined;
-      if (!fallback) {
+      if (fallback) {
+        model = withOverrides(fallback, {
+          baseURL,
+          headers,
+          contextWindow,
+          maxTokens,
+        });
+      } else if (shouldCreateDynamicOpenAICompatibleModel(spec)) {
+        model = withOverrides(
+          customOpenAICompatibleModel({
+            provider: spec.id,
+            modelId,
+            baseURL: normalizedBaseURL ?? spec.defaultBaseURL ?? "",
+            contextWindow,
+            maxTokens,
+          }),
+          { headers },
+        );
+      } else {
         throw new Error(
           `Unknown model "${modelId}" for provider "${provider}". ` +
             "Check the model handle or update the model catalog.",
         );
       }
-      model = withOverrides(fallback, {
-        baseURL,
-        headers,
-        contextWindow,
-        maxTokens,
-      });
     }
   }
 

--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -10,6 +10,8 @@ import {
   type LocalProviderRecord,
   localProviderApiKeyFromRecord,
 } from "@/backend/local/local-provider-auth-store";
+// Ensure xAI Grok OAuth is registered before runtime token refresh.
+import "@/providers/xai-oauth";
 import {
   type LocalProviderTimeout,
   resolveLocalProviderTimeout,

--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -204,6 +204,12 @@ const PI_PROVIDER_OVERRIDES: Partial<
     handlePrefixes: ["openai-codex/", "chatgpt-plus-pro/"],
     localProviderNames: ["openai-codex", LOCAL_CHATGPT_PROVIDER_NAME],
   },
+  // Live-list models from api.x.ai when SuperGrok OAuth or XAI_API_KEY is
+  // configured so catalog stays current (e.g. grok-4.5) without waiting on pi-ai.
+  xai: {
+    defaultBaseURL: "https://api.x.ai/v1",
+    localModelDiscovery: "openai-compatible",
+  },
 };
 
 function defaultModelForProvider(

--- a/src/backend/local-provider-auth-store.test.ts
+++ b/src/backend/local-provider-auth-store.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createOrUpdateLocalProvider,
+  getLocalProviderRecordByName,
+  localOAuthAuthFromCredentials,
+  setLocalOAuthProvider,
+} from "@/backend/local/local-provider-auth-store";
+
+describe("local provider auth store", () => {
+  test("refuses implicit API-key to OAuth replacement", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-auth-conflict-"));
+    try {
+      await createOrUpdateLocalProvider({
+        storageDir,
+        providerType: "xai",
+        providerName: "xai",
+        apiKey: "xai-api-key",
+      });
+
+      expect(() =>
+        setLocalOAuthProvider({
+          storageDir,
+          providerName: "xai",
+          providerType: "xai",
+          auth: localOAuthAuthFromCredentials({
+            access: "xai-oauth-access",
+            refresh: "xai-oauth-refresh",
+            expires: Date.now() + 60_000,
+          }),
+        }),
+      ).toThrow(
+        'Provider "xai" is already connected with an API key. Disconnect it before connecting OAuth credentials.',
+      );
+
+      const record = getLocalProviderRecordByName("xai", storageDir);
+      expect(record?.auth).toEqual({ type: "api", key: "xai-api-key" });
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("refuses implicit OAuth to API-key replacement", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-auth-conflict-"));
+    try {
+      setLocalOAuthProvider({
+        storageDir,
+        providerName: "xai",
+        providerType: "xai",
+        auth: localOAuthAuthFromCredentials({
+          access: "xai-oauth-access",
+          refresh: "xai-oauth-refresh",
+          expires: Date.now() + 60_000,
+        }),
+      });
+
+      await expect(
+        createOrUpdateLocalProvider({
+          storageDir,
+          providerType: "xai",
+          providerName: "xai",
+          apiKey: "xai-api-key",
+        }),
+      ).rejects.toThrow(
+        'Provider "xai" is already connected with OAuth credentials. Disconnect it before connecting an API key.',
+      );
+
+      const record = getLocalProviderRecordByName("xai", storageDir);
+      expect(record?.auth.type).toBe("oauth");
+      if (record?.auth.type !== "oauth") {
+        throw new Error("Expected OAuth record");
+      }
+      expect(record.auth.access).toBe("xai-oauth-access");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/backend/local/local-model-config.ts
+++ b/src/backend/local/local-model-config.ts
@@ -31,6 +31,7 @@ import {
   resolveRegisteredPiProviderListModelsConnection,
 } from "@/backend/dev/registered-pi-provider-runtime";
 import {
+  getLocalOAuthApiKey,
   type LocalProviderRecord,
   listLocalProviderRecords,
   localProviderApiKeyFromRecord,
@@ -219,10 +220,48 @@ function isPiProviderForLocalModelHandle(
   return isPiProvider(provider);
 }
 
+/** Non-chat xAI surfaces (image/video) — omit from the agent model picker. */
+function isAgentSelectableDiscoveredModel(
+  provider: PiProvider,
+  modelId: string,
+): boolean {
+  if (provider !== "xai") return true;
+  const id = modelId.toLowerCase();
+  return !(
+    id.includes("imagine") ||
+    id.includes("image") ||
+    id.includes("video") ||
+    id.includes("tts") ||
+    id.includes("speech") ||
+    id.includes("audio")
+  );
+}
+
+async function resolveDiscoveryApiKey(
+  provider: PiProvider,
+  record: LocalProviderRecord | undefined,
+  storageDir: string | undefined,
+): Promise<string | undefined> {
+  const apiKey = localProviderApiKeyFromRecord(record);
+  if (apiKey) return apiKey;
+
+  if (record?.auth.type === "oauth") {
+    const spec = getPiProviderSpec(provider);
+    const oauth = await getLocalOAuthApiKey({
+      providerId: spec.piProvider ?? provider,
+      providerNames: spec.localProviderNames,
+      storageDir,
+    });
+    if (oauth?.apiKey) return oauth.apiKey;
+  }
+
+  return getPiProviderSpec(provider).apiKeyEnv?.();
+}
+
 async function discoverModelIdsForProvider(
   provider: PiProvider,
   records: readonly LocalProviderRecord[],
-  options: Required<ListLocalModelsOptions>,
+  options: Required<ListLocalModelsOptions> & { storageDir?: string },
 ): Promise<string[]> {
   const spec = getPiProviderSpec(provider);
   const discovery = spec.localModelDiscovery;
@@ -232,7 +271,11 @@ async function discoverModelIdsForProvider(
   const baseURL =
     record?.base_url ?? spec.baseUrlEnv?.() ?? spec.defaultBaseURL;
   if (!baseURL) return [];
-  const apiKey = localProviderApiKeyFromRecord(record) ?? spec.apiKeyEnv?.();
+  const apiKey = await resolveDiscoveryApiKey(
+    provider,
+    record,
+    options.storageDir,
+  );
   const input = {
     baseURL,
     apiKey,
@@ -240,12 +283,19 @@ async function discoverModelIdsForProvider(
     timeoutMs: options.discoveryTimeoutMs,
   };
 
+  let ids: string[];
   switch (discovery) {
     case "ollama":
-      return discoverOllamaModelIds(input);
+      ids = await discoverOllamaModelIds(input);
+      break;
     case "openai-compatible":
-      return discoverOpenAICompatibleModelIds(input);
+      ids = await discoverOpenAICompatibleModelIds(input);
+      break;
+    default:
+      return [];
   }
+
+  return ids.filter((id) => isAgentSelectableDiscoveredModel(provider, id));
 }
 
 export function resolveLocalProvider(storageDir?: string): PiProvider {
@@ -520,13 +570,36 @@ export async function listLocalModels(
         const discoveredModels = await discoverModelIdsForProvider(
           provider,
           records,
-          { ...discoveryOptions, discoveryTimeoutMs: timeoutMs },
+          {
+            ...discoveryOptions,
+            discoveryTimeoutMs: timeoutMs,
+            storageDir,
+          },
         );
+        // Remote catalogs (xAI SuperGrok) should still surface the static
+        // pi-ai defaults when the live list is partial or reordered.
+        if (
+          !isAutoDetectableLocalEndpointProvider(provider) &&
+          discoveredModels.length > 0
+        ) {
+          const catalog = listCatalogModelsForProvider(provider).map((handle) =>
+            stripProviderHandlePrefix(handle, provider),
+          );
+          const merged = [...discoveredModels];
+          for (const model of catalog) {
+            if (model && !merged.includes(model)) merged.push(model);
+          }
+          return { provider, models: merged };
+        }
         return { provider, models: discoveredModels };
       } catch {
-        // Do not surface stale guessed models when a local provider is not
-        // reachable; simply omit that provider's catalog from /model.
-        return { provider, models: [] };
+        // Local endpoints (Ollama / LM Studio): omit when unreachable.
+        // Remote API catalogs (xAI): fall back to the static pi-ai list so
+        // SuperGrok OAuth still shows models offline / on transient errors.
+        if (isAutoDetectableLocalEndpointProvider(provider)) {
+          return { provider, models: [] };
+        }
+        return { provider, models: listCatalogModelsForProvider(provider) };
       }
     }),
   );

--- a/src/backend/local/local-provider-auth-store.ts
+++ b/src/backend/local/local-provider-auth-store.ts
@@ -138,6 +138,26 @@ function providerResponse(record: LocalProviderRecord): ProviderResponse {
   };
 }
 
+function authTypeLabel(type: LocalProviderAuthType): string {
+  return type === "oauth" ? "OAuth credentials" : "an API key";
+}
+
+function assertCanWriteAuthType(input: {
+  providerName: string;
+  existing?: LocalProviderRecord;
+  nextAuthType: LocalProviderAuthType;
+}): void {
+  const existingType = input.existing?.auth.type;
+  if (!existingType || existingType === input.nextAuthType) {
+    return;
+  }
+
+  throw new Error(
+    `Provider "${input.providerName}" is already connected with ${authTypeLabel(existingType)}. ` +
+      `Disconnect it before connecting ${authTypeLabel(input.nextAuthType)}.`,
+  );
+}
+
 export function localProviderApiKeyFromRecord(
   record: LocalProviderRecord | null | undefined,
 ): string | undefined {
@@ -209,6 +229,11 @@ export async function createOrUpdateLocalProvider(input: {
     input.providerType === "chatgpt_oauth"
       ? parseChatGPTOAuth(input.apiKey)
       : { type: "api", key: input.apiKey };
+  assertCanWriteAuthType({
+    providerName: input.providerName,
+    existing,
+    nextAuthType: auth.type,
+  });
   const next: LocalProviderRecord = {
     id: existing?.id ?? providerId(input.providerName),
     name: input.providerName,
@@ -338,6 +363,11 @@ export function setLocalOAuthProvider(input: {
   const file = readAuthFile(input.storageDir);
   const now = new Date().toISOString();
   const existing = file.providers[input.providerName];
+  assertCanWriteAuthType({
+    providerName: input.providerName,
+    existing,
+    nextAuthType: "oauth",
+  });
   file.providers[input.providerName] = {
     id: existing?.id ?? providerId(input.providerName),
     name: input.providerName,

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -221,6 +221,33 @@ describe("pi model factory", () => {
     }
   });
 
+  test("resolves local xAI Grok OAuth credentials through pi OAuth providers", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "pi-xai-oauth-"));
+    try {
+      setLocalOAuthProvider({
+        storageDir,
+        providerName: "xai",
+        providerType: "xai",
+        auth: localOAuthAuthFromCredentials({
+          access: "xai-oauth-access",
+          refresh: "xai-oauth-refresh",
+          expires: Date.now() + 60_000,
+        }),
+      });
+
+      const resolved = await resolvePiModelForAgent(
+        "xai/grok-4.20-0309-reasoning",
+        { provider_type: "xai" },
+        { localProviderAuthStorageDir: storageDir },
+      );
+
+      expect(resolved.apiKey).toBe("xai-oauth-access");
+      expect(resolved.model.provider).toBe("xai");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
   test("applies pi OAuth model modifications for GitHub Copilot", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "pi-copilot-oauth-"));
     try {

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -243,6 +243,43 @@ describe("pi model factory", () => {
 
       expect(resolved.apiKey).toBe("xai-oauth-access");
       expect(resolved.model.provider).toBe("xai");
+      expect(resolved.model.contextWindow).toBe(1000000);
+      expect(resolved.model.maxTokens).toBe(30000);
+      expect(resolved.model.reasoning).toBe(true);
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("resolves live-discovered xAI Grok OAuth model handles at turn time", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "pi-xai-dynamic-oauth-"));
+    try {
+      setLocalOAuthProvider({
+        storageDir,
+        providerName: "xai",
+        providerType: "xai",
+        auth: localOAuthAuthFromCredentials({
+          access: "xai-oauth-access",
+          refresh: "xai-oauth-refresh",
+          expires: Date.now() + 60_000,
+        }),
+      });
+
+      const resolved = await resolvePiModelForAgent(
+        "xai/__letta_dynamic_smoke_model__",
+        { provider_type: "xai" },
+        { localProviderAuthStorageDir: storageDir },
+      );
+
+      expect(resolved.apiKey).toBe("xai-oauth-access");
+      expect(resolved.model).toMatchObject({
+        id: "__letta_dynamic_smoke_model__",
+        provider: "xai",
+        api: "openai-completions",
+        baseUrl: "https://api.x.ai/v1",
+        contextWindow: 128000,
+        maxTokens: 32000,
+      });
     } finally {
       await rm(storageDir, { recursive: true, force: true });
     }

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -978,7 +978,7 @@ export function AppView(props: AppViewProps) {
                         refreshDerived,
                         setCommandRunning,
                         target,
-                        onCodexConnected: (providerName) => {
+                        onLocalModelsChanged: (providerName) => {
                           markLocalModelsAvailable();
                           setModelSelectorOptions({
                             filterProvider: providerName,

--- a/src/cli/commands/connect-normalize.ts
+++ b/src/cli/commands/connect-normalize.ts
@@ -27,7 +27,26 @@ const LOCAL_ALIAS_TO_CANONICAL: Record<string, ConnectProviderCanonical> = {
   "kimi-code": "kimi-coding",
   moonshot: "moonshotai",
   bedrock: "amazon-bedrock",
+  // SuperGrok / X Premium+ subscription OAuth (local backend only for now)
+  "xai-oauth": "xai-oauth",
+  "grok-oauth": "xai-oauth",
+  "x-ai-oauth": "xai-oauth",
+  "xai-grok-oauth": "xai-oauth",
+  grok: "xai-oauth",
 };
+
+/** Tokens that only resolve under the local provider store (Phase 1 SuperGrok OAuth). */
+const LOCAL_ONLY_OAUTH_TOKENS = new Set([
+  "xai-oauth",
+  "grok-oauth",
+  "x-ai-oauth",
+  "xai-grok-oauth",
+  "grok",
+]);
+
+export function isLocalOnlyConnectProviderToken(token: string): boolean {
+  return LOCAL_ONLY_OAUTH_TOKENS.has(token.trim().toLowerCase());
+}
 
 function providerMatches(provider: ByokProvider, token: string): boolean {
   if (provider.id === token) return true;
@@ -95,15 +114,19 @@ export function listConnectProvidersForHelp(
   target: ProviderStorageTarget = defaultProviderStorageTarget(),
 ): string[] {
   const providers = getProviderConfigs(target).map((provider) => provider.id);
+  const withAliases: string[] = [];
   if (providers.includes("codex") || providers.includes("openai-codex-oauth")) {
-    return [
-      "chatgpt (alias: codex)",
-      ...providers.filter(
-        (provider) => provider !== "codex" && provider !== "openai-codex-oauth",
-      ),
-    ];
+    withAliases.push("chatgpt (alias: codex)");
   }
-  return providers;
+  for (const id of providers) {
+    if (id === "codex" || id === "openai-codex-oauth") continue;
+    if (id === "xai-oauth") {
+      withAliases.push("xai-oauth (aliases: grok-oauth, grok)");
+      continue;
+    }
+    withAliases.push(id);
+  }
+  return withAliases;
 }
 
 export function listConnectProviderTokens(

--- a/src/cli/commands/connect.test.ts
+++ b/src/cli/commands/connect.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { localModelsChangedCallback } from "@/cli/commands/connect";
+
+describe("connect command model refresh callbacks", () => {
+  test("prefers the generic local-model refresh callback", () => {
+    const calls: string[] = [];
+    const legacyCalls: string[] = [];
+    const callback = localModelsChangedCallback({
+      onLocalModelsChanged: (providerName) => calls.push(providerName),
+      onCodexConnected: (providerName) => legacyCalls.push(providerName),
+    });
+
+    callback?.("xai");
+
+    expect(calls).toEqual(["xai"]);
+    expect(legacyCalls).toEqual([]);
+  });
+
+  test("keeps the old Codex callback as a fallback", () => {
+    const calls: string[] = [];
+    const callback = localModelsChangedCallback({
+      onCodexConnected: (providerName) => calls.push(providerName),
+    });
+
+    callback?.("chatgpt-plus-pro");
+
+    expect(calls).toEqual(["chatgpt-plus-pro"]);
+  });
+});

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -58,6 +58,13 @@ export interface ConnectCommandContext {
   setCommandRunning: (running: boolean) => void;
   target?: ProviderStorageTarget;
   onCodexConnected?: (providerName: string) => void;
+  onLocalModelsChanged?: (providerName: string) => void;
+}
+
+export function localModelsChangedCallback(
+  ctx: Pick<ConnectCommandContext, "onCodexConnected" | "onLocalModelsChanged">,
+): ((providerName: string) => void) | undefined {
+  return ctx.onLocalModelsChanged ?? ctx.onCodexConnected;
 }
 
 function addCommandResult(
@@ -450,8 +457,9 @@ async function handleConnectChatGPT(
       "finished",
     );
 
-    if (ctx.onCodexConnected) {
-      setTimeout(() => ctx.onCodexConnected?.(providerName), 500);
+    const onModelsChanged = localModelsChangedCallback(ctx);
+    if (onModelsChanged) {
+      setTimeout(() => onModelsChanged(providerName), 500);
     }
   } catch (error) {
     const isCancelled = error instanceof Error && error.name === "AbortError";
@@ -530,9 +538,10 @@ async function handleConnectLocalOAuthProvider(
       "finished",
     );
 
-    if (provider.byokProvider.oauthProviderId === "openai-codex") {
+    const onModelsChanged = localModelsChangedCallback(ctx);
+    if (onModelsChanged) {
       setTimeout(
-        () => ctx.onCodexConnected?.(provider.byokProvider.providerName),
+        () => onModelsChanged(provider.byokProvider.providerName),
         500,
       );
     }

--- a/src/cli/components/ModelSelector-byok-custom-provider.test.tsx
+++ b/src/cli/components/ModelSelector-byok-custom-provider.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { getReasoningTierOptionsForHandle } from "@/agent/model";
 import {
+  applyProviderAuthPresentation,
   buildByokProviderAliases,
   isByokHandleForSelector,
   labelForBackendModel,
@@ -51,6 +52,34 @@ describe("ModelSelector custom BYOK provider detection", () => {
     expect(aliases["chatgpt-personal"]).toBe("openai-codex");
     expect(isByokHandleForSelector("chatgpt-personal/gpt-5.5", aliases)).toBe(
       true,
+    );
+  });
+
+  test("labels xAI SuperGrok OAuth models distinctly from API-key xAI", () => {
+    const base = {
+      id: "xai/grok-4.5",
+      handle: "xai/grok-4.5",
+      label: "Grok 4.5",
+      description: "xAI Grok 4.5",
+    };
+
+    const oauth = applyProviderAuthPresentation(
+      base,
+      new Map([["xai", "oauth"]]),
+    );
+    expect(oauth.label).toBe("Grok 4.5 (SuperGrok)");
+    expect(oauth.description).toContain("OAuth");
+    expect(oauth.description.toLowerCase()).toContain("subscription");
+
+    const apiKey = applyProviderAuthPresentation(
+      base,
+      new Map([["xai", "api"]]),
+    );
+    expect(apiKey.label).toBe("Grok 4.5 (API key)");
+    expect(apiKey.description).toContain("API key");
+
+    expect(applyProviderAuthPresentation(base, new Map()).label).toBe(
+      "Grok 4.5",
     );
   });
 

--- a/src/cli/components/ModelSelector-categories.test.tsx
+++ b/src/cli/components/ModelSelector-categories.test.tsx
@@ -110,6 +110,17 @@ describe("getModelCategories", () => {
       includeUnknownBackendHandleInRecommended("custom-provider/model"),
     ).toBe(false);
   });
+
+  test("xAI SuperGrok catalog handles are not local-endpoint prefixes", () => {
+    // Local OAuth catalogs still surface these via localModelCatalog in
+    // ModelSelector recommended; the helper itself stays endpoint-specific.
+    expect(includeUnknownBackendHandleInRecommended("xai/grok-4.3")).toBe(
+      false,
+    );
+    expect(includeUnknownBackendHandleInRecommended("xai/grok-build-0.1")).toBe(
+      false,
+    );
+  });
 });
 
 describe("toSelectorModelForHandle", () => {

--- a/src/cli/components/ModelSelector.tsx
+++ b/src/cli/components/ModelSelector.tsx
@@ -18,11 +18,11 @@ import {
 import {
   buildByokProviderAliases,
   isByokHandleForSelector,
-  listProviders,
 } from "@/providers/byok-providers";
 import { settingsManager } from "@/settings-manager";
 import { colors } from "./colors";
 import {
+  applyProviderAuthPresentation,
   baseHandleForByokAlias,
   filterModelsByAvailabilityForSelector,
   includeUnknownBackendHandleInRecommended,
@@ -37,6 +37,7 @@ import {
 import { OverlayShell } from "./OverlayShell";
 import { TabBar } from "./TabBar";
 import { Text } from "./Text";
+import { useModelSelectorProviders } from "./use-model-selector-providers";
 
 const VISIBLE_ITEMS = 8;
 
@@ -56,6 +57,7 @@ export type {
   UiModel,
 } from "./model-selector-helpers";
 export {
+  applyProviderAuthPresentation,
   filterModelsByAvailabilityForSelector,
   includeUnknownBackendHandleInRecommended,
   labelForBackendModel,
@@ -195,9 +197,8 @@ export function ModelSelector({
   const [refreshing, setRefreshing] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [showLoginAction, setShowLoginAction] = useState(false);
-  const [byokProviderAliases, setByokProviderAliases] = useState<
-    Record<string, string>
-  >(() => buildByokProviderAliases([]));
+  const { byokProviderAliases, providerAuthByName } =
+    useModelSelectorProviders(localModelCatalog);
 
   const mountedRef = useRef(true);
   useEffect(() => {
@@ -267,23 +268,6 @@ export function ModelSelector({
   useEffect(() => {
     loadModels.current(forceRefreshOnMount ?? false);
   }, [forceRefreshOnMount]);
-
-  useEffect(() => {
-    if (localModelCatalog) {
-      setByokProviderAliases(buildByokProviderAliases([]));
-      return;
-    }
-    (async () => {
-      try {
-        const providers = await listProviders();
-        if (!mountedRef.current) return;
-        setByokProviderAliases(buildByokProviderAliases(providers));
-      } catch {
-        if (!mountedRef.current) return;
-        setByokProviderAliases(buildByokProviderAliases([]));
-      }
-    })();
-  }, [localModelCatalog]);
 
   const pickPreferredStaticModel = useCallback(
     (handle: string, contextWindow?: number): UiModel | undefined => {
@@ -399,19 +383,24 @@ export function ModelSelector({
             }
           : null;
 
-      const result = baseModel ? [baseModel] : [];
+      const result = baseModel
+        ? [applyProviderAuthPresentation(baseModel, providerAuthByName)]
+        : [];
 
       if (fastRegistryHandle) {
         const fastStaticModel = pickPreferredStaticModel(fastRegistryHandle);
         if (fastStaticModel) {
           result.push(
-            withActualHandle(fastStaticModel, handle, fastRegistryHandle, {
-              ...((fastStaticModel.updateArgs as
-                | Record<string, unknown>
-                | undefined) ?? {}),
-              service_tier: CHATGPT_FAST_SERVICE_TIER,
-              ...withProviderTypeMetadata(handle, undefined),
-            }),
+            applyProviderAuthPresentation(
+              withActualHandle(fastStaticModel, handle, fastRegistryHandle, {
+                ...((fastStaticModel.updateArgs as
+                  | Record<string, unknown>
+                  | undefined) ?? {}),
+                service_tier: CHATGPT_FAST_SERVICE_TIER,
+                ...withProviderTypeMetadata(handle, undefined),
+              }),
+              providerAuthByName,
+            ),
           );
         }
       }
@@ -420,6 +409,7 @@ export function ModelSelector({
     },
     [
       pickPreferredStaticModel,
+      providerAuthByName,
       providerTypesByHandle,
       withActualHandle,
       withProviderTypeMetadata,
@@ -610,6 +600,9 @@ export function ModelSelector({
   // Discoverable local endpoint providers (Ollama, LM Studio, llama.cpp) do
   // not have a static models.json catalog, so include their live-discovered
   // handles here instead of hiding them until the user switches to "All".
+  // Local backend catalogs (pi-ai / OAuth providers like xAI SuperGrok) are
+  // also source-of-truth for available handles — include unknown handles so
+  // OAuth connects aren't empty on Recommended when models.json is stale.
   // Filter out letta/letta-free legacy model
   const serverRecommendedModels = useMemo(() => {
     if (!backendModelCatalog || availableHandles === undefined) return [];
@@ -618,7 +611,8 @@ export function ModelSelector({
       .flatMap((handle) =>
         modelsForBackendHandle(
           handle,
-          includeUnknownBackendHandleInRecommended(handle),
+          includeUnknownBackendHandleInRecommended(handle) ||
+            Boolean(localModelCatalog),
         ),
       );
     if (searchQuery) {
@@ -644,6 +638,7 @@ export function ModelSelector({
     return deduped;
   }, [
     backendModelCatalog,
+    localModelCatalog,
     availableHandles,
     allApiHandles,
     searchQuery,

--- a/src/cli/components/model-selector-helpers.ts
+++ b/src/cli/components/model-selector-helpers.ts
@@ -8,11 +8,18 @@ import {
 
 const CHATGPT_OAUTH_BASE_PROVIDER = "openai-codex";
 const CHATGPT_LABEL_SUFFIX_PATTERN = /\s+\(ChatGPT\)$/;
+const XAI_SUPERGROK_LABEL_SUFFIX_PATTERN = /\s+\(SuperGrok\)$/;
+const XAI_API_KEY_LABEL_SUFFIX_PATTERN = /\s+\(API key\)$/;
 const API_GATED_MODEL_HANDLES = new Set([
   "letta/auto",
   "letta/auto-fast",
   "letta/glm",
 ]);
+
+export type ProviderAuthType = "api" | "oauth";
+
+/** Local provider name / handle prefix → how that provider is authenticated. */
+export type ProviderAuthByName = ReadonlyMap<string, ProviderAuthType>;
 
 export type UiModel = {
   id: string;
@@ -102,6 +109,55 @@ export function labelForBackendModel(
     return label;
   }
   return `${label} (ChatGPT)`;
+}
+
+export function providerNameFromModelHandle(
+  handle: string,
+): string | undefined {
+  const slashIndex = handle.indexOf("/");
+  if (slashIndex <= 0) return undefined;
+  return handle.slice(0, slashIndex);
+}
+
+/**
+ * Mark local dual-auth providers (xAI SuperGrok OAuth vs API key) so /model
+ * does not look like an anonymous "xAI API" catalog when only OAuth is linked.
+ */
+export function applyProviderAuthPresentation(
+  model: UiModel,
+  authByProvider: ProviderAuthByName | undefined,
+): UiModel {
+  if (!authByProvider || authByProvider.size === 0) return model;
+
+  const providerName = providerNameFromModelHandle(model.handle);
+  if (!providerName) return model;
+
+  // xAI SuperGrok OAuth and console API key share provider_type=xai / handle prefix xai/
+  if (providerName === "xai") {
+    const authType = authByProvider.get("xai");
+    if (authType === "oauth") {
+      const label = XAI_SUPERGROK_LABEL_SUFFIX_PATTERN.test(model.label)
+        ? model.label
+        : `${model.label.replace(XAI_API_KEY_LABEL_SUFFIX_PATTERN, "")} (SuperGrok)`;
+      return {
+        ...model,
+        label,
+        description: "SuperGrok / X Premium+ subscription (OAuth — no API key)",
+      };
+    }
+    if (authType === "api") {
+      const label = XAI_API_KEY_LABEL_SUFFIX_PATTERN.test(model.label)
+        ? model.label
+        : `${model.label.replace(XAI_SUPERGROK_LABEL_SUFFIX_PATTERN, "")} (API key)`;
+      return {
+        ...model,
+        label,
+        description: "xAI console API key",
+      };
+    }
+  }
+
+  return model;
 }
 
 export function toByokSelectorModel(

--- a/src/cli/components/provider-selector.test.ts
+++ b/src/cli/components/provider-selector.test.ts
@@ -20,6 +20,7 @@ import {
   getProviderConfigs,
   type ProviderResponse,
 } from "@/providers/byok-providers";
+import { connectedRecordsForProvider } from "@/providers/provider-connections";
 
 function withEnv<T>(
   updates: Record<string, string | undefined>,
@@ -174,7 +175,12 @@ describe("ProviderSelector provider filtering", () => {
     ).toEqual(["github-copilot"]);
     expect(
       filterProviderConfigs(providers, "subscription").map((p) => p.id),
-    ).toEqual(["anthropic-oauth", "openai-codex-oauth", "github-copilot"]);
+    ).toEqual([
+      "anthropic-oauth",
+      "openai-codex-oauth",
+      "github-copilot",
+      "xai-oauth",
+    ]);
   });
 
   test("matches provider aliases and restores all providers for blank query", () => {
@@ -186,6 +192,18 @@ describe("ProviderSelector provider filtering", () => {
     expect(filterProviderConfigs(providers, "   ").length).toBe(
       providers.length,
     );
+  });
+
+  test("matches xAI API-key and OAuth provider entries separately", () => {
+    const providers = getProviderConfigs("local");
+
+    expect(filterProviderConfigs(providers, "xai").map((p) => p.id)).toEqual([
+      "xai",
+      "xai-oauth",
+    ]);
+    expect(
+      filterProviderConfigs(providers, "xai-oauth").map((p) => p.id),
+    ).toEqual(["xai-oauth"]);
   });
 });
 
@@ -284,6 +302,51 @@ describe("ProviderSelector connected provider actions", () => {
         chatgptWorkProvider,
       ]),
     ).toBe("2 connected");
+  });
+
+  test("disambiguates local xAI API-key and OAuth records by auth type", () => {
+    const xaiApi = providerById("xai");
+    const xaiOAuth = providerById("xai-oauth");
+    const apiRecord: ProviderResponse = {
+      id: "local-provider-xai",
+      name: "xai",
+      provider_type: "xai",
+      provider_category: "byok",
+      auth_type: "api",
+    };
+    const oauthRecord: ProviderResponse = {
+      ...apiRecord,
+      auth_type: "oauth",
+    };
+
+    expect(
+      connectedRecordsForProvider(
+        xaiApi,
+        new Map([["xai", apiRecord]]),
+        "local",
+      ),
+    ).toEqual([apiRecord]);
+    expect(
+      connectedRecordsForProvider(
+        xaiOAuth,
+        new Map([["xai", apiRecord]]),
+        "local",
+      ),
+    ).toEqual([]);
+    expect(
+      connectedRecordsForProvider(
+        xaiApi,
+        new Map([["xai", oauthRecord]]),
+        "local",
+      ),
+    ).toEqual([]);
+    expect(
+      connectedRecordsForProvider(
+        xaiOAuth,
+        new Map([["xai", oauthRecord]]),
+        "local",
+      ),
+    ).toEqual([oauthRecord]);
   });
 
   test("surfaces connect-another only for API ChatGPT OAuth providers", () => {

--- a/src/cli/components/use-model-selector-providers.ts
+++ b/src/cli/components/use-model-selector-providers.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+import {
+  buildByokProviderAliases,
+  listProviders,
+} from "@/providers/byok-providers";
+import type {
+  ProviderAuthByName,
+  ProviderAuthType,
+} from "./model-selector-helpers";
+
+/**
+ * Loads BYOK alias map (Constellation) or local provider auth types (local
+ * backend) for ModelSelector labeling — e.g. SuperGrok OAuth vs API key.
+ */
+export function useModelSelectorProviders(localModelCatalog?: boolean): {
+  byokProviderAliases: Record<string, string>;
+  providerAuthByName: ProviderAuthByName;
+} {
+  const [byokProviderAliases, setByokProviderAliases] = useState<
+    Record<string, string>
+  >(() => buildByokProviderAliases([]));
+  const [providerAuthByName, setProviderAuthByName] =
+    useState<ProviderAuthByName>(() => new Map());
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const providers = await listProviders(
+          localModelCatalog ? { target: "local" } : undefined,
+        );
+        if (cancelled) return;
+        if (localModelCatalog) {
+          setByokProviderAliases(buildByokProviderAliases([]));
+          const authMap = new Map<string, ProviderAuthType>();
+          for (const provider of providers) {
+            if (
+              provider.auth_type === "oauth" ||
+              provider.auth_type === "api"
+            ) {
+              authMap.set(provider.name, provider.auth_type);
+            }
+          }
+          setProviderAuthByName(authMap);
+          return;
+        }
+        setByokProviderAliases(buildByokProviderAliases(providers));
+        setProviderAuthByName(new Map());
+      } catch {
+        if (cancelled) return;
+        setByokProviderAliases(buildByokProviderAliases([]));
+        setProviderAuthByName(new Map());
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [localModelCatalog]);
+
+  return { byokProviderAliases, providerAuthByName };
+}

--- a/src/cli/connect-normalize.test.ts
+++ b/src/cli/connect-normalize.test.ts
@@ -143,6 +143,28 @@ describe("connect provider normalization", () => {
     expect(githubCopilot.byokProvider.oauthProviderId).toBe("github-copilot");
   });
 
+  test("resolves local xAI Grok OAuth aliases", () => {
+    for (const token of ["xai-oauth", "grok-oauth", "grok"] as const) {
+      const resolved = resolveConnectProvider(token, "local");
+      expect(resolved).not.toBeNull();
+      if (!resolved) throw new Error(`Expected ${token} to resolve`);
+      expect(isConnectOAuthProvider(resolved)).toBe(true);
+      expect(resolved.byokProvider.oauthProviderId).toBe("xai");
+      expect(resolved.byokId).toBe("xai-oauth");
+    }
+  });
+
+  test("does not resolve xAI Grok OAuth on the API provider store", () => {
+    expect(resolveConnectProvider("xai-oauth", "api")).toBeNull();
+    expect(resolveConnectProvider("grok-oauth", "api")).toBeNull();
+  });
+
+  test("help list labels xai-oauth aliases on local target", () => {
+    expect(listConnectProvidersForHelp("local")).toContain(
+      "xai-oauth (aliases: grok-oauth, grok)",
+    );
+  });
+
   test("uses environment keys before API-key optional defaults", () => {
     withEnv({ LMSTUDIO_API_KEY: "1234" }, () => {
       const lmstudio = resolveConnectProvider("lmstudio", "local");

--- a/src/cli/subcommands/connect.test.ts
+++ b/src/cli/subcommands/connect.test.ts
@@ -327,6 +327,17 @@ describe("connect subcommand", () => {
     return { selections, runLocalOAuthConnectFlow };
   }
 
+  test("guides users to local backend for xAI Grok OAuth on API target", async () => {
+    const { stderr, deps } = createIoDeps();
+    setProviderTarget("api");
+
+    const exitCode = await runConnectSubcommand(["xai-oauth"], deps);
+
+    expect(exitCode).toBe(1);
+    expect(stderr.join("\n")).toContain("local backend");
+    expect(stderr.join("\n")).toContain("xai-oauth");
+  });
+
   test("local codex connect defaults to the first login method option", async () => {
     const { stdout, deps } = createIoDeps();
     setProviderTarget("local");

--- a/src/cli/subcommands/connect.ts
+++ b/src/cli/subcommands/connect.ts
@@ -12,6 +12,7 @@ import {
   isConnectBedrockProvider,
   isConnectOAuthProvider,
   isConnectZaiBaseProvider,
+  isLocalOnlyConnectProviderToken,
   listConnectProvidersForHelp,
   listConnectProviderTokens,
   resolveConnectProvider,
@@ -110,18 +111,33 @@ const DEFAULT_DEPS: ConnectSubcommandDeps = {
 };
 
 function formatUsage(): string {
+  const providers = listConnectProvidersForHelp();
+  const localOnlyNote = providers.some((line) => line.startsWith("xai-oauth"))
+    ? [
+        "",
+        "xAI Grok OAuth (SuperGrok):",
+        "  letta --backend local connect xai-oauth",
+        "  letta --backend local connect grok-oauth",
+      ]
+    : [
+        "",
+        "xAI Grok OAuth (SuperGrok) requires the local backend:",
+        "  letta --backend local connect xai-oauth",
+      ];
   return [
     "Usage:",
     "  letta connect <provider> [options]",
     "",
     "Providers:",
-    `  ${listConnectProvidersForHelp().join("\n  ")}`,
+    `  ${providers.join("\n  ")}`,
+    ...localOnlyNote,
     "",
     "Examples:",
     "  letta connect chatgpt",
     "  letta connect chatgpt --name chatgpt-work",
     "  letta connect codex",
     "  letta connect codex --method device-code",
+    "  letta --backend local connect xai-oauth",
     "  letta connect anthropic <api_key>",
     "  letta connect openai --api-key <api_key>",
     "  letta connect lmstudio --base-url http://127.0.0.1:1234/v1 --timeout 600s",
@@ -231,6 +247,13 @@ export async function runConnectSubcommand(
 
   const provider = resolveConnectProvider(providerToken);
   if (!provider) {
+    if (isLocalOnlyConnectProviderToken(providerToken)) {
+      io.stderr(
+        `Provider '${providerToken}' (xAI Grok OAuth / SuperGrok) is only available on the local backend.\n` +
+          `Run: letta --backend local connect xai-oauth`,
+      );
+      return 1;
+    }
     io.stderr(
       `Unknown provider: ${providerToken}. Supported providers: ${listConnectProviderTokens().join(", ")}`,
     );
@@ -304,6 +327,46 @@ export async function runConnectSubcommand(
       io.stdout(
         `Successfully connected to ${provider.byokProvider.displayName}.`,
       );
+      if (
+        provider.target === "local" &&
+        provider.byokProvider.oauthProviderId === "xai"
+      ) {
+        try {
+          const { listLocalModels } = await import(
+            "@/backend/local/local-model-config"
+          );
+          const models = await listLocalModels();
+          const xaiModels = models
+            .map((model) => model.handle)
+            .filter(
+              (handle): handle is string =>
+                typeof handle === "string" && handle.startsWith("xai/"),
+            );
+          if (xaiModels.length > 0) {
+            io.stdout(
+              [
+                "",
+                "Available xAI models:",
+                ...xaiModels.map((handle) => `  ${handle}`),
+                "",
+                "Start local mode and pick one with /model:",
+                "  letta --backend local",
+                "  /model",
+              ].join("\n"),
+            );
+          } else {
+            io.stdout(
+              [
+                "",
+                "No xAI models were listed yet. Start local mode and press r in /model to refresh:",
+                "  letta --backend local",
+              ].join("\n"),
+            );
+          }
+        } catch {
+          // Listing is best-effort after a successful login.
+        }
+      }
       return 0;
     } catch (error) {
       io.stderr(
@@ -421,6 +484,16 @@ export async function runConnectSubcommand(
           `Missing API key for ${provider.canonical}. Pass as positional arg or --api-key.`,
         );
         return 1;
+      }
+      if (
+        provider.target === "local" &&
+        (provider.byokProvider.providerType === "xai" ||
+          provider.byokId === "xai")
+      ) {
+        io.stdout(
+          "Tip: for SuperGrok / X Premium+ subscription OAuth (no API key), run:\n" +
+            "  letta --backend local connect xai-oauth",
+        );
       }
       apiKey = await io.promptSecret(
         `${provider.byokProvider.displayName} API key: `,

--- a/src/models.json
+++ b/src/models.json
@@ -1907,7 +1907,7 @@
       "id": "gpt-5.4-pro-medium",
       "handle": "openai/gpt-5.4-pro",
       "label": "GPT-5.4 Pro",
-      "description": "GPT-5.4 Pro — max performance variant (med reasoning)",
+      "description": "GPT-5.4 Pro \u2014 max performance variant (med reasoning)",
       "updateArgs": {
         "reasoning_effort": "medium",
         "verbosity": "medium",
@@ -1920,7 +1920,7 @@
       "id": "gpt-5.4-pro-high",
       "handle": "openai/gpt-5.4-pro",
       "label": "GPT-5.4 Pro",
-      "description": "GPT-5.4 Pro — max performance variant (high reasoning)",
+      "description": "GPT-5.4 Pro \u2014 max performance variant (high reasoning)",
       "updateArgs": {
         "reasoning_effort": "high",
         "verbosity": "medium",
@@ -1933,7 +1933,7 @@
       "id": "gpt-5.4-pro-xhigh",
       "handle": "openai/gpt-5.4-pro",
       "label": "GPT-5.4 Pro",
-      "description": "GPT-5.4 Pro — max performance variant (max reasoning)",
+      "description": "GPT-5.4 Pro \u2014 max performance variant (max reasoning)",
       "updateArgs": {
         "reasoning_effort": "xhigh",
         "verbosity": "medium",
@@ -2180,10 +2180,91 @@
       "id": "grok-4.5",
       "handle": "xai/grok-4.5",
       "label": "Grok 4.5",
-      "description": "xAI's Grok 4.5 model via the direct xAI API",
+      "description": "xAI Grok 4.5",
       "isFeatured": true,
       "updateArgs": {
         "context_window": 500000,
+        "max_output_tokens": 16384,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "grok-4.3",
+      "handle": "xai/grok-4.3",
+      "label": "Grok 4.3",
+      "description": "xAI Grok 4.3",
+      "isFeatured": true,
+      "updateArgs": {
+        "context_window": 1000000,
+        "max_output_tokens": 64000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "grok-4.20-0309-reasoning",
+      "handle": "xai/grok-4.20-0309-reasoning",
+      "label": "Grok 4.20 Reasoning",
+      "description": "xAI Grok 4.20 reasoning (default local xAI model)",
+      "isFeatured": true,
+      "isDefault": true,
+      "updateArgs": {
+        "context_window": 1000000,
+        "max_output_tokens": 64000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "grok-4.20-0309-non-reasoning",
+      "handle": "xai/grok-4.20-0309-non-reasoning",
+      "label": "Grok 4.20 Non-reasoning",
+      "description": "xAI Grok 4.20 non-reasoning",
+      "updateArgs": {
+        "context_window": 1000000,
+        "max_output_tokens": 64000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "grok-build-0.1",
+      "handle": "xai/grok-build-0.1",
+      "label": "Grok Build 0.1",
+      "description": "xAI Grok Build coding model",
+      "isFeatured": true,
+      "updateArgs": {
+        "context_window": 256000,
+        "max_output_tokens": 64000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "grok-code-fast-1",
+      "handle": "xai/grok-code-fast-1",
+      "label": "Grok Code Fast 1",
+      "description": "xAI fast coding model",
+      "updateArgs": {
+        "context_window": 32768,
+        "max_output_tokens": 16000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "grok-3",
+      "handle": "xai/grok-3",
+      "label": "Grok 3",
+      "description": "xAI Grok 3",
+      "updateArgs": {
+        "context_window": 131072,
+        "max_output_tokens": 16384,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "grok-3-fast",
+      "handle": "xai/grok-3-fast",
+      "label": "Grok 3 Fast",
+      "description": "xAI Grok 3 Fast",
+      "updateArgs": {
+        "context_window": 131072,
         "max_output_tokens": 16384,
         "parallel_tool_calls": true
       }

--- a/src/providers/byok-providers.ts
+++ b/src/providers/byok-providers.ts
@@ -36,6 +36,8 @@ import {
   updateLocalProvider,
 } from "@/backend/local/local-provider-auth-store";
 import type { LocalProviderTimeout } from "@/backend/local/local-provider-timeout";
+// Registers xAI Grok OAuth into pi-ai so local /connect and token refresh work.
+import "@/providers/xai-oauth";
 
 export type { ProviderResponse } from "@/backend/api/providers";
 
@@ -327,8 +329,9 @@ function byokProviderFromPiSpec(provider: string): ByokProvider | undefined {
 }
 
 // Pi TUI exposes Anthropic in both subscription and API-key login flows.
+// xAI is dual-auth as well: SuperGrok OAuth + console API key.
 // Other OAuth providers are subscription-only in the Pi TUI.
-const PI_TUI_API_KEY_OAUTH_PROVIDER_IDS = new Set(["anthropic"]);
+const PI_TUI_API_KEY_OAUTH_PROVIDER_IDS = new Set(["anthropic", "xai"]);
 
 function localOAuthConfigId(providerId: string): string {
   if (providerId === "openai-codex") return "openai-codex-oauth";

--- a/src/providers/local-pi-provider-catalog.test.ts
+++ b/src/providers/local-pi-provider-catalog.test.ts
@@ -67,6 +67,29 @@ describe("local pi provider catalog", () => {
     }
   });
 
+  test("local /connect exposes both xAI OAuth and xAI API-key entries", () => {
+    const local = getProviderConfigs("local");
+    const xaiOAuth = local.find(
+      (provider) =>
+        provider.isOAuth === true && provider.oauthProviderId === "xai",
+    );
+    const xaiApi = local.find(
+      (provider) =>
+        provider.isOAuth !== true &&
+        (provider.id === "xai" || provider.providerType === "xai"),
+    );
+
+    expect(xaiOAuth).toBeDefined();
+    expect(xaiOAuth?.id).toBe("xai-oauth");
+    expect(xaiOAuth?.providerType).toBe("xai");
+    expect(xaiOAuth?.providerName).toBe("xai");
+    expect(xaiOAuth?.displayName).toContain("Grok OAuth");
+
+    expect(xaiApi).toBeDefined();
+    expect(xaiApi?.providerType).toBe("xai");
+    expect(getOAuthProvider("xai")?.name).toContain("Grok OAuth");
+  });
+
   test("local provider defaults point at current pi-ai catalog models", () => {
     for (const spec of PI_PROVIDER_SPECS) {
       if (!spec.piProvider) continue;

--- a/src/providers/xai-oauth.test.ts
+++ b/src/providers/xai-oauth.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, mock, test } from "bun:test";
+import { getOAuthProvider } from "@earendil-works/pi-ai/oauth";
+import {
+  assertTrustedXaiOAuthUrl,
+  ensureXaiOAuthProviderRegistered,
+  loginXaiOAuth,
+  pollXaiDeviceToken,
+  refreshXaiOAuthToken,
+  requestXaiDeviceCode,
+  XAI_OAUTH_CONFIG,
+  XAI_OAUTH_PROVIDER_ID,
+  XaiOAuthError,
+  xaiOAuthProvider,
+} from "@/providers/xai-oauth";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("xai-oauth", () => {
+  test("registers into pi-ai OAuth provider registry", () => {
+    ensureXaiOAuthProviderRegistered();
+    const provider = getOAuthProvider(XAI_OAUTH_PROVIDER_ID);
+    expect(provider?.id).toBe("xai");
+    expect(provider?.name).toBe(xaiOAuthProvider.name);
+  });
+
+  test("assertTrustedXaiOAuthUrl accepts x.ai hosts over HTTPS", () => {
+    expect(
+      assertTrustedXaiOAuthUrl("https://auth.x.ai/oauth2/token", "t"),
+    ).toBe("https://auth.x.ai/oauth2/token");
+    expect(assertTrustedXaiOAuthUrl("https://x.ai/v1/", "t")).toBe(
+      "https://x.ai/v1",
+    );
+  });
+
+  test("assertTrustedXaiOAuthUrl rejects off-origin and non-HTTPS hosts", () => {
+    expect(() =>
+      assertTrustedXaiOAuthUrl("http://auth.x.ai/token", "t"),
+    ).toThrow(XaiOAuthError);
+    expect(() =>
+      assertTrustedXaiOAuthUrl("https://evil.example/token", "t"),
+    ).toThrow(XaiOAuthError);
+    expect(() =>
+      assertTrustedXaiOAuthUrl("https://auth.x.ai.evil.com/token", "t"),
+    ).toThrow(XaiOAuthError);
+  });
+
+  test("requestXaiDeviceCode posts client_id and scope", async () => {
+    const calls: Array<{ url: string; body: string }> = [];
+    const fetchImpl = mock(async (input: string | URL, init?: RequestInit) => {
+      const url = String(input);
+      calls.push({ url, body: String(init?.body ?? "") });
+      return jsonResponse(200, {
+        device_code: "device-code",
+        user_code: "ABCD-EFGH",
+        verification_uri: "https://accounts.x.ai/oauth2/device",
+        verification_uri_complete:
+          "https://accounts.x.ai/oauth2/device?user_code=ABCD-EFGH",
+        expires_in: 1800,
+        interval: 5,
+      });
+    }) as unknown as typeof fetch;
+
+    const device = await requestXaiDeviceCode(fetchImpl);
+    expect(device.user_code).toBe("ABCD-EFGH");
+    expect(device.device_code).toBe("device-code");
+    expect(calls[0]?.url).toBe(XAI_OAUTH_CONFIG.deviceCodeUrl);
+    expect(calls[0]?.body).toContain(`client_id=${XAI_OAUTH_CONFIG.clientId}`);
+    expect(calls[0]?.body).toContain("scope=");
+  });
+
+  test("pollXaiDeviceToken waits through authorization_pending", async () => {
+    let pollCount = 0;
+    const fetchImpl = mock(async () => {
+      pollCount += 1;
+      if (pollCount === 1) {
+        return jsonResponse(400, {
+          error: "authorization_pending",
+          error_description: "waiting",
+        });
+      }
+      return jsonResponse(200, {
+        access_token: "access-1",
+        refresh_token: "refresh-1",
+        expires_in: 3600,
+        token_type: "Bearer",
+      });
+    }) as unknown as typeof fetch;
+
+    const credentials = await pollXaiDeviceToken({
+      deviceCode: "device-code",
+      tokenEndpoint: XAI_OAUTH_CONFIG.defaultTokenUrl,
+      expiresIn: 30,
+      interval: 0,
+      fetchImpl,
+    });
+
+    expect(credentials.access).toBe("access-1");
+    expect(credentials.refresh).toBe("refresh-1");
+    expect(credentials.tokenEndpoint).toBe(XAI_OAUTH_CONFIG.defaultTokenUrl);
+    expect(pollCount).toBe(2);
+  });
+
+  test("refreshXaiOAuthToken rotates tokens and preserves refresh when omitted", async () => {
+    const rotating = mock(async () =>
+      jsonResponse(200, {
+        access_token: "access-2",
+        refresh_token: "refresh-2",
+        expires_in: 7200,
+      }),
+    ) as unknown as typeof fetch;
+
+    const rotated = await refreshXaiOAuthToken(
+      {
+        access: "access-1",
+        refresh: "refresh-1",
+        expires: Date.now() - 1000,
+        tokenEndpoint: XAI_OAUTH_CONFIG.defaultTokenUrl,
+      },
+      rotating,
+    );
+    expect(rotated.access).toBe("access-2");
+    expect(rotated.refresh).toBe("refresh-2");
+
+    const stable = mock(async () =>
+      jsonResponse(200, {
+        access_token: "access-3",
+        expires_in: 3600,
+      }),
+    ) as unknown as typeof fetch;
+
+    const preserved = await refreshXaiOAuthToken(
+      {
+        access: "access-2",
+        refresh: "refresh-stable",
+        expires: Date.now() - 1000,
+      },
+      stable,
+    );
+    expect(preserved.access).toBe("access-3");
+    expect(preserved.refresh).toBe("refresh-stable");
+  });
+
+  test("refreshXaiOAuthToken maps 403 to tier denial without relogin", async () => {
+    const fetchImpl = mock(async () =>
+      jsonResponse(403, { error: "permission_denied" }),
+    ) as unknown as typeof fetch;
+
+    try {
+      await refreshXaiOAuthToken(
+        {
+          access: "a",
+          refresh: "r",
+          expires: 0,
+        },
+        fetchImpl,
+      );
+      expect.unreachable("expected refresh to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(XaiOAuthError);
+      const oauthError = error as XaiOAuthError;
+      expect(oauthError.code).toBe("xai_oauth_tier_denied");
+      expect(oauthError.reloginRequired).toBe(false);
+      expect(oauthError.message).toContain("XAI_API_KEY");
+    }
+  });
+
+  test("refreshXaiOAuthToken maps 400 invalid_grant to relogin", async () => {
+    const fetchImpl = mock(async () =>
+      jsonResponse(400, { error: "invalid_grant" }),
+    ) as unknown as typeof fetch;
+
+    try {
+      await refreshXaiOAuthToken(
+        { access: "a", refresh: "r", expires: 0 },
+        fetchImpl,
+      );
+      expect.unreachable("expected refresh to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(XaiOAuthError);
+      const oauthError = error as XaiOAuthError;
+      expect(oauthError.code).toBe("xai_refresh_failed");
+      expect(oauthError.reloginRequired).toBe(true);
+    }
+  });
+
+  test("loginXaiOAuth drives device code callbacks end-to-end", async () => {
+    const fetchImpl = mock(async (input: string | URL) => {
+      const url = String(input);
+      if (url.includes("openid-configuration")) {
+        return jsonResponse(200, {
+          authorization_endpoint: "https://auth.x.ai/oauth2/authorize",
+          token_endpoint: "https://auth.x.ai/oauth2/token",
+        });
+      }
+      if (url.includes("/device/code")) {
+        return jsonResponse(200, {
+          device_code: "dc",
+          user_code: "CODE-1",
+          verification_uri: "https://accounts.x.ai/device",
+          expires_in: 60,
+          interval: 0,
+        });
+      }
+      return jsonResponse(200, {
+        access_token: "login-access",
+        refresh_token: "login-refresh",
+        expires_in: 3600,
+      });
+    }) as unknown as typeof fetch;
+
+    const deviceCodes: Array<{ userCode: string; verificationUri: string }> =
+      [];
+    const authUrls: string[] = [];
+
+    const credentials = await loginXaiOAuth(
+      {
+        onAuth: (info) => {
+          authUrls.push(info.url);
+        },
+        onDeviceCode: (info) => {
+          deviceCodes.push({
+            userCode: info.userCode,
+            verificationUri: info.verificationUri,
+          });
+        },
+        onPrompt: async () => "",
+        onSelect: async () => undefined,
+      },
+      fetchImpl,
+    );
+
+    expect(credentials.access).toBe("login-access");
+    expect(credentials.refresh).toBe("login-refresh");
+    expect(deviceCodes).toEqual([
+      {
+        userCode: "CODE-1",
+        verificationUri: "https://accounts.x.ai/device",
+      },
+    ]);
+    expect(authUrls[0]).toBe("https://accounts.x.ai/device");
+  });
+
+  test("getApiKey returns access token", () => {
+    expect(
+      xaiOAuthProvider.getApiKey({
+        access: "tok",
+        refresh: "r",
+        expires: Date.now() + 60_000,
+      }),
+    ).toBe("tok");
+  });
+});

--- a/src/providers/xai-oauth.test.ts
+++ b/src/providers/xai-oauth.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, mock, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { getOAuthProvider } from "@earendil-works/pi-ai/oauth";
+import { getLocalProviderRecordByName } from "@/backend/local/local-provider-auth-store";
+import { runLocalOAuthConnectFlow } from "@/cli/commands/connect-local-oauth";
 import {
   assertTrustedXaiOAuthUrl,
   ensureXaiOAuthProviderRegistered,
@@ -242,7 +247,79 @@ describe("xai-oauth", () => {
         verificationUri: "https://accounts.x.ai/device",
       },
     ]);
-    expect(authUrls[0]).toBe("https://accounts.x.ai/device");
+    expect(authUrls).toEqual([]);
+  });
+
+  test("runLocalOAuthConnectFlow opens the xAI device authorization URL once", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "xai-local-oauth-flow-"));
+    const originalFetch = globalThis.fetch;
+    const originalStorageDir = process.env.LETTA_LOCAL_BACKEND_DIR;
+    try {
+      const fetchImpl = mock(async (input: string | URL) => {
+        const url = String(input);
+        if (url.includes("openid-configuration")) {
+          return jsonResponse(200, {
+            authorization_endpoint: "https://auth.x.ai/oauth2/authorize",
+            token_endpoint: "https://auth.x.ai/oauth2/token",
+          });
+        }
+        if (url.includes("/device/code")) {
+          return jsonResponse(200, {
+            device_code: "dc",
+            user_code: "CODE-1",
+            verification_uri: "https://accounts.x.ai/device",
+            verification_uri_complete:
+              "https://accounts.x.ai/device?user_code=CODE-1",
+            expires_in: 60,
+            interval: 0,
+          });
+        }
+        return jsonResponse(200, {
+          access_token: "login-access",
+          refresh_token: "login-refresh",
+          expires_in: 3600,
+        });
+      }) as unknown as typeof fetch;
+      globalThis.fetch = fetchImpl;
+      process.env.LETTA_LOCAL_BACKEND_DIR = storageDir;
+
+      const opened: string[] = [];
+      const statuses: string[] = [];
+      const result = await runLocalOAuthConnectFlow(
+        {
+          id: "xai-oauth",
+          displayName: "xAI Grok OAuth (SuperGrok)",
+          description: "Connect a subscription account",
+          providerType: "xai",
+          providerName: "xai",
+          isOAuth: true,
+          oauthProviderId: "xai",
+        },
+        {
+          onStatus: (message) => {
+            statuses.push(message);
+          },
+          openBrowser: async (url) => {
+            opened.push(url);
+          },
+        },
+      );
+
+      expect(result.providerName).toBe("xai");
+      expect(opened).toEqual(["https://accounts.x.ai/device?user_code=CODE-1"]);
+      expect(statuses.join("\n")).toContain("Enter code: CODE-1");
+      const record = getLocalProviderRecordByName("xai", storageDir);
+      expect(record?.auth.type).toBe("oauth");
+      expect(record?.provider_type).toBe("xai");
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalStorageDir === undefined) {
+        delete process.env.LETTA_LOCAL_BACKEND_DIR;
+      } else {
+        process.env.LETTA_LOCAL_BACKEND_DIR = originalStorageDir;
+      }
+      await rm(storageDir, { recursive: true, force: true });
+    }
   });
 
   test("getApiKey returns access token", () => {

--- a/src/providers/xai-oauth.ts
+++ b/src/providers/xai-oauth.ts
@@ -1,0 +1,456 @@
+/**
+ * xAI Grok OAuth (SuperGrok / X Premium+)
+ *
+ * Browser device-code login against auth.x.ai. Access tokens are used as the
+ * bearer for https://api.x.ai/v1 (same surface as API-key xAI). Public client
+ * id matches the Grok CLI / Hermes integration for MVP compatibility.
+ */
+
+import {
+  type OAuthCredentials,
+  type OAuthLoginCallbacks,
+  type OAuthProviderInterface,
+  pollOAuthDeviceCodeFlow,
+  registerOAuthProvider,
+} from "@earendil-works/pi-ai/oauth";
+
+export const XAI_OAUTH_PROVIDER_ID = "xai";
+
+export const XAI_OAUTH_CONFIG = {
+  issuer: "https://auth.x.ai",
+  clientId: "b1a00492-073a-47ea-816f-4c329264a828",
+  scope: "openid profile email offline_access grok-cli:access api:access",
+  deviceCodeUrl: "https://auth.x.ai/oauth2/device/code",
+  discoveryUrl: "https://auth.x.ai/.well-known/openid-configuration",
+  defaultTokenUrl: "https://auth.x.ai/oauth2/token",
+  inferenceBaseUrl: "https://api.x.ai/v1",
+  /** Access tokens are ~6h; refresh up to 1h early for long agent sessions. */
+  refreshSkewMs: 60 * 60 * 1000,
+} as const;
+
+export type XaiOAuthCredentials = OAuthCredentials & {
+  tokenEndpoint?: string;
+  idToken?: string;
+};
+
+export class XaiOAuthError extends Error {
+  readonly code: string;
+  readonly reloginRequired: boolean;
+
+  constructor(
+    message: string,
+    options: { code: string; reloginRequired?: boolean; cause?: unknown },
+  ) {
+    super(message, options.cause !== undefined ? { cause: options.cause } : {});
+    this.name = "XaiOAuthError";
+    this.code = options.code;
+    this.reloginRequired = options.reloginRequired ?? false;
+  }
+}
+
+function formBody(data: Record<string, string>): URLSearchParams {
+  return new URLSearchParams(data);
+}
+
+function isHttpsXaiHost(hostname: string): boolean {
+  return hostname === "x.ai" || hostname.endsWith(".x.ai");
+}
+
+export function assertTrustedXaiOAuthUrl(url: string, field: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new XaiOAuthError(`Invalid ${field}: ${url}`, {
+      code: "xai_discovery_invalid",
+    });
+  }
+  if (parsed.protocol !== "https:") {
+    throw new XaiOAuthError(
+      `${field} must use HTTPS (got ${parsed.protocol})`,
+      { code: "xai_discovery_invalid" },
+    );
+  }
+  if (!isHttpsXaiHost(parsed.hostname)) {
+    throw new XaiOAuthError(
+      `${field} host must be x.ai or *.x.ai (got ${parsed.hostname})`,
+      { code: "xai_discovery_invalid" },
+    );
+  }
+  return parsed.href.replace(/\/$/, "");
+}
+
+async function readJsonResponse(
+  response: Response,
+): Promise<Record<string, unknown>> {
+  const text = await response.text();
+  if (!text) return {};
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    throw new Error("JSON root is not an object");
+  } catch (error) {
+    throw new XaiOAuthError(
+      `xAI OAuth returned non-JSON (HTTP ${response.status}): ${text.slice(0, 200)}`,
+      { code: "xai_oauth_invalid_json", cause: error },
+    );
+  }
+}
+
+function stringField(
+  payload: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = payload[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberField(
+  payload: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const value = payload[key];
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+export async function discoverXaiTokenEndpoint(
+  fetchImpl: typeof fetch = fetch,
+): Promise<string> {
+  const response = await fetchImpl(XAI_OAUTH_CONFIG.discoveryUrl, {
+    headers: { Accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new XaiOAuthError(
+      `xAI OIDC discovery failed (HTTP ${response.status})`,
+      { code: "xai_discovery_failed" },
+    );
+  }
+  const payload = await readJsonResponse(response);
+  const tokenEndpoint = stringField(payload, "token_endpoint");
+  const authorizationEndpoint = stringField(payload, "authorization_endpoint");
+  if (!tokenEndpoint || !authorizationEndpoint) {
+    throw new XaiOAuthError("xAI OIDC discovery response incomplete", {
+      code: "xai_discovery_incomplete",
+    });
+  }
+  assertTrustedXaiOAuthUrl(authorizationEndpoint, "authorization_endpoint");
+  return assertTrustedXaiOAuthUrl(tokenEndpoint, "token_endpoint");
+}
+
+export interface XaiDeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete?: string;
+  expires_in: number;
+  interval: number;
+}
+
+export async function requestXaiDeviceCode(
+  fetchImpl: typeof fetch = fetch,
+): Promise<XaiDeviceCodeResponse> {
+  const response = await fetchImpl(XAI_OAUTH_CONFIG.deviceCodeUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+    },
+    body: formBody({
+      client_id: XAI_OAUTH_CONFIG.clientId,
+      scope: XAI_OAUTH_CONFIG.scope,
+    }),
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new XaiOAuthError(
+      `xAI device-code request failed (HTTP ${response.status})${text ? `: ${text.slice(0, 200)}` : ""}`,
+      { code: "device_code_request_failed" },
+    );
+  }
+  const payload = await readJsonResponse(response);
+  const deviceCode = stringField(payload, "device_code");
+  const userCode = stringField(payload, "user_code");
+  const verificationUri = stringField(payload, "verification_uri");
+  const expiresIn = numberField(payload, "expires_in");
+  const interval = numberField(payload, "interval");
+  if (
+    !deviceCode ||
+    !userCode ||
+    !verificationUri ||
+    expiresIn === undefined ||
+    interval === undefined
+  ) {
+    throw new XaiOAuthError(
+      "xAI device-code response missing required fields",
+      { code: "device_code_invalid" },
+    );
+  }
+  const trustedUri = assertTrustedXaiOAuthUrl(
+    verificationUri,
+    "verification_uri",
+  );
+  const complete = stringField(payload, "verification_uri_complete");
+  return {
+    device_code: deviceCode,
+    user_code: userCode,
+    verification_uri: trustedUri,
+    ...(complete
+      ? {
+          verification_uri_complete: assertTrustedXaiOAuthUrl(
+            complete,
+            "verification_uri_complete",
+          ),
+        }
+      : {}),
+    expires_in: expiresIn,
+    interval,
+  };
+}
+
+function credentialsFromTokenPayload(
+  payload: Record<string, unknown>,
+  options: {
+    tokenEndpoint: string;
+    previousRefresh?: string;
+  },
+): XaiOAuthCredentials {
+  const access = stringField(payload, "access_token");
+  if (!access) {
+    throw new XaiOAuthError("xAI token response missing access_token", {
+      code: "xai_token_invalid",
+      reloginRequired: true,
+    });
+  }
+  const refresh =
+    stringField(payload, "refresh_token") ?? options.previousRefresh ?? "";
+  if (!refresh) {
+    throw new XaiOAuthError("xAI token response missing refresh_token", {
+      code: "xai_token_invalid",
+      reloginRequired: true,
+    });
+  }
+  const expiresIn = numberField(payload, "expires_in") ?? 3600;
+  const idToken = stringField(payload, "id_token");
+  return {
+    access,
+    refresh,
+    expires: Date.now() + expiresIn * 1000 - XAI_OAUTH_CONFIG.refreshSkewMs,
+    tokenEndpoint: options.tokenEndpoint,
+    ...(idToken ? { idToken } : {}),
+  };
+}
+
+export async function pollXaiDeviceToken(input: {
+  deviceCode: string;
+  tokenEndpoint: string;
+  expiresIn: number;
+  interval: number;
+  signal?: AbortSignal;
+  fetchImpl?: typeof fetch;
+}): Promise<XaiOAuthCredentials> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const tokenEndpoint = assertTrustedXaiOAuthUrl(
+    input.tokenEndpoint,
+    "token_endpoint",
+  );
+
+  const credentials = await pollOAuthDeviceCodeFlow({
+    intervalSeconds: input.interval,
+    expiresInSeconds: input.expiresIn,
+    signal: input.signal,
+    poll: async () => {
+      const response = await fetchImpl(tokenEndpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Accept: "application/json",
+        },
+        body: formBody({
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+          client_id: XAI_OAUTH_CONFIG.clientId,
+          device_code: input.deviceCode,
+        }),
+      });
+
+      if (response.status === 200) {
+        const payload = await readJsonResponse(response);
+        return {
+          status: "complete" as const,
+          value: credentialsFromTokenPayload(payload, { tokenEndpoint }),
+        };
+      }
+
+      const payload = await readJsonResponse(response).catch(() => ({}));
+      const error = stringField(payload, "error") ?? "";
+      if (error === "authorization_pending") {
+        return { status: "pending" as const };
+      }
+      if (error === "slow_down") {
+        return { status: "slow_down" as const };
+      }
+      if (response.status === 403 || error === "access_denied") {
+        return {
+          status: "failed" as const,
+          message:
+            "xAI denied OAuth access (HTTP 403). This account may not be entitled for API/OAuth use — try an XAI_API_KEY with the xAI API-key provider, or upgrade SuperGrok.",
+        };
+      }
+      const description = stringField(payload, "error_description");
+      return {
+        status: "failed" as const,
+        message: `xAI device-code authorization failed: ${error || `HTTP ${response.status}`}${description ? ` — ${description}` : ""}`,
+      };
+    },
+  });
+  if (!credentials) {
+    throw new XaiOAuthError(
+      "xAI device-code authorization returned no tokens",
+      {
+        code: "xai_device_token_invalid",
+        reloginRequired: true,
+      },
+    );
+  }
+  return credentials;
+}
+
+export async function refreshXaiOAuthToken(
+  credentials: OAuthCredentials,
+  fetchImpl: typeof fetch = fetch,
+): Promise<XaiOAuthCredentials> {
+  const refresh = credentials.refresh;
+  if (!refresh) {
+    throw new XaiOAuthError("Missing xAI refresh token; re-authenticate.", {
+      code: "xai_auth_missing_refresh_token",
+      reloginRequired: true,
+    });
+  }
+
+  const prior = credentials as XaiOAuthCredentials;
+  const tokenEndpoint = assertTrustedXaiOAuthUrl(
+    prior.tokenEndpoint ?? XAI_OAUTH_CONFIG.defaultTokenUrl,
+    "token_endpoint",
+  );
+
+  const response = await fetchImpl(tokenEndpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+    },
+    body: formBody({
+      grant_type: "refresh_token",
+      refresh_token: refresh,
+      client_id: XAI_OAUTH_CONFIG.clientId,
+    }),
+  });
+
+  if (response.status === 403) {
+    const text = await response.text();
+    throw new XaiOAuthError(
+      `xAI token refresh failed with HTTP 403${text ? `: ${text.slice(0, 200)}` : ""}. This OAuth account is not authorized for xAI API access — xAI may restrict OAuth to specific SuperGrok tiers. Set XAI_API_KEY and connect the xAI API-key provider instead.`,
+      { code: "xai_oauth_tier_denied", reloginRequired: false },
+    );
+  }
+
+  if (response.status >= 400 && response.status < 500) {
+    const payload = await readJsonResponse(response).catch(() => ({}));
+    const error = stringField(payload, "error") ?? `HTTP ${response.status}`;
+    throw new XaiOAuthError(
+      `xAI token refresh failed: ${error}. Re-authenticate with /connect.`,
+      {
+        code: "xai_refresh_failed",
+        reloginRequired: true,
+      },
+    );
+  }
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new XaiOAuthError(
+      `xAI token refresh failed (HTTP ${response.status})${text ? `: ${text.slice(0, 200)}` : ""}`,
+      { code: "xai_refresh_failed", reloginRequired: false },
+    );
+  }
+
+  const payload = await readJsonResponse(response);
+  return credentialsFromTokenPayload(payload, {
+    tokenEndpoint,
+    previousRefresh: refresh,
+  });
+}
+
+export async function loginXaiOAuth(
+  callbacks: OAuthLoginCallbacks,
+  fetchImpl: typeof fetch = fetch,
+): Promise<XaiOAuthCredentials> {
+  callbacks.onProgress?.("Discovering xAI OAuth endpoints...");
+  let tokenEndpoint: string = XAI_OAUTH_CONFIG.defaultTokenUrl;
+  try {
+    tokenEndpoint = await discoverXaiTokenEndpoint(fetchImpl);
+  } catch {
+    // Fall back to the known production token endpoint if discovery fails.
+    tokenEndpoint = XAI_OAUTH_CONFIG.defaultTokenUrl;
+  }
+
+  callbacks.onProgress?.("Requesting xAI device code...");
+  const device = await requestXaiDeviceCode(fetchImpl);
+
+  const verificationUri =
+    device.verification_uri_complete ?? device.verification_uri;
+  callbacks.onDeviceCode({
+    userCode: device.user_code,
+    verificationUri,
+    intervalSeconds: device.interval,
+    expiresInSeconds: device.expires_in,
+  });
+  // Also emit onAuth so UIs that only handle PKCE-style callbacks still show a URL.
+  callbacks.onAuth({
+    url: verificationUri,
+    instructions: `Enter code: ${device.user_code}`,
+  });
+
+  callbacks.onProgress?.("Waiting for browser authorization...");
+  return pollXaiDeviceToken({
+    deviceCode: device.device_code,
+    tokenEndpoint,
+    expiresIn: device.expires_in,
+    interval: device.interval,
+    signal: callbacks.signal,
+    fetchImpl,
+  });
+}
+
+export function getXaiOAuthApiKey(credentials: OAuthCredentials): string {
+  return credentials.access;
+}
+
+export const xaiOAuthProvider: OAuthProviderInterface = {
+  id: XAI_OAUTH_PROVIDER_ID,
+  name: "xAI Grok OAuth (SuperGrok)",
+  async login(callbacks) {
+    return loginXaiOAuth(callbacks);
+  },
+  async refreshToken(credentials) {
+    return refreshXaiOAuthToken(credentials);
+  },
+  getApiKey(credentials) {
+    return getXaiOAuthApiKey(credentials);
+  },
+};
+
+let registered = false;
+
+/** Idempotent registration into pi-ai's OAuth provider registry. */
+export function ensureXaiOAuthProviderRegistered(): void {
+  if (registered) return;
+  registerOAuthProvider(xaiOAuthProvider);
+  registered = true;
+}
+
+// Register on import so catalog + runtime refresh always see the provider.
+ensureXaiOAuthProviderRegistered();

--- a/src/providers/xai-oauth.ts
+++ b/src/providers/xai-oauth.ts
@@ -408,11 +408,6 @@ export async function loginXaiOAuth(
     intervalSeconds: device.interval,
     expiresInSeconds: device.expires_in,
   });
-  // Also emit onAuth so UIs that only handle PKCE-style callbacks still show a URL.
-  callbacks.onAuth({
-    url: verificationUri,
-    instructions: `Enter code: ${device.user_code}`,
-  });
 
   callbacks.onProgress?.("Waiting for browser authorization...");
   return pollXaiDeviceToken({


### PR DESCRIPTION
## Summary

- Add local **xAI Grok OAuth (SuperGrok / X Premium+)** via device-code login at `auth.x.ai` (no `XAI_API_KEY` required)
- Wire dual-auth for xAI: SuperGrok OAuth + existing API-key path
- Live-list models from `api.x.ai/v1/models` when OAuth/API credentials exist (surfaces `grok-4.5`, multi-agent, etc.)
- Label SuperGrok models clearly in `/model` as `(SuperGrok)` vs `(API key)`
- CLI: `letta --backend local connect xai-oauth` (aliases: `grok-oauth`, `grok`)

## Scope

**Local backend only.** Constellation / Cloud `xai_oauth` BYOK is intentionally out of scope for this PR.

## Usage

```bash
letta --backend local connect xai-oauth
letta --backend local
# /model → Grok 4.5 (SuperGrok), etc.
```

## Test plan

- [x] `bun run check`
- [x] Unit tests for device-code OAuth, connect aliases, model catalog, SuperGrok labeling
- [x] Manual: `bun run dev -- --backend local connect xai-oauth` → browser device code → success
- [x] Manual: `/model` shows Grok models with `(SuperGrok)` labels when only OAuth is connected
- [x] Manual: `xai` API-key connect still works and labels as `(API key)`
- [x] Manual: API-mode `connect xai-oauth` points users at local backend