### PR TITLE
feat(dream): add --prompt and --system reflection overrides

### DIFF
--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -200,6 +200,11 @@ interface BuildSubagentArgsOptions {
   promptTransport?: "argv" | "stdin";
   extraTools?: string[];
   parentAgentId?: string | null;
+  /**
+   * Replace the subagent's configured persona: pass `--system-custom <text>`
+   * to the child instead of `--system <type>`. Only applies to new agents.
+   */
+  systemPromptOverride?: string;
 }
 
 /**
@@ -237,8 +242,14 @@ export function buildSubagentArgs(
     // Don't pass --system (existing agent keeps its prompt)
     // Don't pass --model (existing agent keeps its model)
   } else {
-    // Create new agent (original behavior)
-    args.push("--new-agent", "--system", type);
+    // Create new agent (original behavior). A systemPromptOverride replaces the
+    // configured persona with a caller-supplied prompt via `--system-custom`
+    // (mutually exclusive with `--system`).
+    if (options.systemPromptOverride) {
+      args.push("--new-agent", "--system-custom", options.systemPromptOverride);
+    } else {
+      args.push("--new-agent", "--system", type);
+    }
     const subagentTags = [`type:${type}`];
     if (options.parentAgentId) {
       subagentTags.push(`parent:${options.parentAgentId}`);
@@ -336,6 +347,7 @@ async function executeSubagent(
   parentAgentIdOverride?: string,
   transcriptPath?: string,
   memoryScope?: SubagentMemoryScope,
+  systemPromptOverride?: string,
 ): Promise<SubagentResult> {
   // Check if already aborted before starting
   if (signal?.aborted) {
@@ -387,6 +399,7 @@ async function executeSubagent(
           config.fork && inheritedChannelContext
             ? ["MessageChannel"]
             : undefined,
+        systemPromptOverride,
       },
     );
 
@@ -757,6 +770,7 @@ export async function spawnSubagent(
   transcriptPath?: string,
   parentConversationId?: string,
   memoryScope?: SubagentMemoryScope,
+  systemPromptOverride?: string,
 ): Promise<SubagentResult> {
   const allConfigs = await getAllSubagentConfigs();
   const config = allConfigs[type];
@@ -867,6 +881,7 @@ export async function spawnSubagent(
     resolvedParentAgentId,
     transcriptPath,
     memoryScope,
+    systemPromptOverride,
   );
 
   return result;

--- a/src/cli/helpers/reflection-launcher.ts
+++ b/src/cli/helpers/reflection-launcher.ts
@@ -149,6 +149,14 @@ export interface ReflectionLaunchOptions {
   model?: string;
   instruction?: string;
   systemPrompt?: string;
+  /**
+   * Replace the reflection task prompt entirely (advanced). The caller owns the
+   * transcript/memory mechanics the default prompt provides ($TRANSCRIPT_PATH,
+   * $MEMORY_DIR, the commit contract).
+   */
+  reflectionPromptOverride?: string;
+  /** Replace the reflection subagent's system prompt/persona (advanced). */
+  reflectionSystemPromptOverride?: string;
   skipPendingWorktreeReminderScan?: boolean;
   completionConversationId?: string | (() => string);
   recompileByConversation: Map<string, Promise<void>>;
@@ -401,6 +409,7 @@ export async function queuePendingReflectionWorktreeReminders(params: {
 export async function prepareReflectionMemoryWorktreeLaunch(params: {
   agentId: string;
   instruction?: string;
+  reflectionPromptOverride?: string;
 }): Promise<{
   worktree: ReflectionMemoryWorktree;
   reflectionPrompt: string;
@@ -410,11 +419,15 @@ export async function prepareReflectionMemoryWorktreeLaunch(params: {
     parentMemoryDir: memoryDir,
   });
   try {
-    const parentMemory = await buildParentMemorySnapshot(worktree.worktreeDir);
-    const reflectionPrompt = buildReflectionSubagentPrompt({
-      instruction: params.instruction,
-      parentMemory,
-    });
+    // An override replaces the whole task prompt; the caller is then responsible
+    // for referencing $TRANSCRIPT_PATH / $MEMORY_DIR, so we skip the (otherwise
+    // wasted) parent-memory snapshot in that case.
+    const reflectionPrompt =
+      params.reflectionPromptOverride ??
+      buildReflectionSubagentPrompt({
+        instruction: params.instruction,
+        parentMemory: await buildParentMemorySnapshot(worktree.worktreeDir),
+      });
     return { worktree, reflectionPrompt };
   } catch (error) {
     await finalizeReflectionMemoryWorktree(worktree, {
@@ -548,6 +561,7 @@ export async function launchReflectionSubagent(
       await prepareReflectionMemoryWorktreeLaunch({
         agentId,
         instruction: options.instruction,
+        reflectionPromptOverride: options.reflectionPromptOverride,
       });
     preparedWorktree = worktree;
 
@@ -571,6 +585,7 @@ export async function launchReflectionSubagent(
       prompt: reflectionPrompt,
       description,
       model: options.model,
+      systemPromptOverride: options.reflectionSystemPromptOverride,
       silentCompletion: true,
       transcriptPath: autoPayload.payloadPath,
       memoryScope: buildReflectionMemoryScope(worktree),

--- a/src/cli/subcommands/dream.test.ts
+++ b/src/cli/subcommands/dream.test.ts
@@ -40,6 +40,8 @@ describe("dream subcommand", () => {
       expect(output).toContain("--model");
       expect(output).toContain("--to");
       expect(output).toContain("--instruction");
+      expect(output).toContain("--prompt");
+      expect(output).toContain("--system");
     } finally {
       captured.restore();
     }
@@ -82,5 +84,17 @@ describe("dream subcommand", () => {
     const parsed = parseDreamArgs(["--model", "zai/glm-5.2"]);
 
     expect(parsed.values.model).toBe("zai/glm-5.2");
+  });
+
+  test("accepts a reflection task prompt override", () => {
+    const parsed = parseDreamArgs(["--prompt", "Distill task X notes."]);
+
+    expect(parsed.values.prompt).toBe("Distill task X notes.");
+  });
+
+  test("accepts a reflection system prompt override", () => {
+    const parsed = parseDreamArgs(["--system", "You write terse notes."]);
+
+    expect(parsed.values.system).toBe("You write terse notes.");
   });
 });

--- a/src/cli/subcommands/dream.ts
+++ b/src/cli/subcommands/dream.ts
@@ -38,6 +38,11 @@ Options:
   --timeout <seconds>         Fail if the reflection pass has not completed
                               in this many seconds (default: 1500)
   -i, --instruction <text>    Additional instruction for the reflection pass
+  --prompt <text>             Advanced: replace the reflection task prompt
+                              entirely (you supply the transcript/memory
+                              mechanics via $TRANSCRIPT_PATH and $MEMORY_DIR)
+  --system <text>             Advanced: replace the reflection subagent's
+                              system prompt
   --json                      Emit machine-readable JSON output
   -h, --help                  Show this help
 
@@ -58,6 +63,8 @@ const DREAM_OPTIONS = {
   effort: { type: "string" },
   timeout: { type: "string" },
   instruction: { type: "string", short: "i" },
+  prompt: { type: "string" },
+  system: { type: "string" },
   json: { type: "boolean" },
 } as const;
 
@@ -246,6 +253,8 @@ export async function runDreamSubcommand(argv: string[]): Promise<number> {
     description: "Reflect on recent conversations",
     model: parsed.values.model,
     instruction,
+    reflectionPromptOverride: parsed.values.prompt,
+    reflectionSystemPromptOverride: parsed.values.system,
     recompileByConversation: new Map(),
     recompileQueuedByConversation: new Set(),
     onCompletionMessage: (message, completionResult) => {

--- a/src/tools/impl/task.ts
+++ b/src/tools/impl/task.ts
@@ -74,6 +74,8 @@ export interface SpawnBackgroundSubagentTaskArgs {
   prompt: string;
   description: string;
   model?: string;
+  /** Replace the subagent's configured system prompt/persona (advanced). */
+  systemPromptOverride?: string;
   toolCallId?: string;
   existingAgentId?: string;
   existingConversationId?: string;
@@ -324,6 +326,7 @@ export function spawnBackgroundSubagentTask(
     prompt,
     description,
     model,
+    systemPromptOverride,
     toolCallId,
     existingAgentId,
     existingConversationId,
@@ -409,6 +412,7 @@ export function spawnBackgroundSubagentTask(
     transcriptPath,
     resolvedParentScope?.conversationId,
     memoryScope,
+    systemPromptOverride,
   )
     .then(async (result) => {
       bgTask.status = result.success ? "completed" : "failed";


### PR DESCRIPTION
## What

Two advanced override flags on `letta dream`, for callers (e.g. dreambench) that need to steer the reflection engine directly:

- **`--prompt <text>`** — replace the reflection **task prompt** entirely. `--instruction` stays *additive* (folded into the default prompt, subordinated to "only persist durable memory"); `--prompt` is the full-replacement escape hatch. The caller owns the mechanics: the default prompt's `$TRANSCRIPT_PATH` (read the payload) and `$MEMORY_DIR` (write + commit) env vars are still injected by the harness, so an override must reference them.
- **`--system <text>`** — replace the reflection subagent's **system prompt / persona**. Passed to the child as `--system-custom <text>` instead of the built-in `--system <type>`, so the default `reflection.md` persona (and its "durable memory, not transient task state" framing) is bypassed.

Omitting both preserves current behavior exactly.

## Motivation

`letta dream`'s reflection is doubly biased toward *general durable memory*: the `reflection.md` persona (system prompt) and the base task prompt's "only persist durable memory-worthy learnings, do not store transient task state" line. `--instruction` can't override that (it's inserted as a subordinated "focus" lens). For benchmarks/consumers that want *task-specific* distillation, these two flags provide full control without touching the default path.

## How (threaded like #3306's `--model`)

`dream.ts` (`--prompt`/`--system`) → `launchReflectionSubagent` (`reflectionPromptOverride` / `reflectionSystemPromptOverride`) →
- **task prompt:** `prepareReflectionMemoryWorktreeLaunch` uses `reflectionPromptOverride ?? buildReflectionSubagentPrompt(...)` (the builder is bypassed, incl. the parent-memory snapshot).
- **persona:** `spawnBackgroundSubagentTask({ systemPromptOverride })` → `spawnSubagent` → `executeSubagent` → `buildSubagentArgs`, which emits `--system-custom <text>` instead of `--system <type>` for new agents.

`buildReflectionSubagentPrompt` is untouched. This PR lands cleanly now that `manager.ts` is under the 1,000-line ceiling (after #3308/#3310/#3312); it adds ~15 lines there (888 total, no baseline entry).

## Notes / caveats
- `--prompt` and `--system` have no short flags (avoids clashing with `-m`/`-i`/`-h`).
- A `--prompt` override that forgets `$TRANSCRIPT_PATH`/`$MEMORY_DIR` will silently produce no memory — documented in the help text and a code comment (acceptable for the advanced/internal use case).
- `--system` replaces `reflection.md` wholesale, so its built-in guardrails/output-format go with it — that's the point.

## Test
- `bun run check` — 12/12 pass.
- `bun test src/cli/subcommands/dream.test.ts` — parse + help-text coverage for both flags.
- `bun test` on the three subagent suites (model-resolution, env-composition, parent-id-propagation) — 84/84 pass (covers `buildSubagentArgs`).