### PR TITLE
fix(local): prevent one-token llama.cpp responses

### DIFF
--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -53,6 +53,19 @@ export function isUnselectedLocalModelHandle(model: unknown): boolean {
   );
 }
 
+function normalizeOpenAICompatibleLocalModelHandle(
+  model: string | undefined,
+): string | undefined {
+  if (!model?.startsWith("openai/")) return model;
+  const nestedHandle = model.slice("openai/".length);
+  const nestedProvider = resolveProviderFromModelHandle(nestedHandle);
+  if (!nestedProvider) return model;
+  return getPiProviderSpec(nestedProvider).localModelDiscovery ===
+    "openai-compatible"
+    ? nestedHandle
+    : model;
+}
+
 function settingString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
@@ -495,9 +508,9 @@ export async function resolvePiModelForAgent(
   modelSettings: PiModelSettings = {},
   options: PiModelFactoryOptions = {},
 ): Promise<ResolvedPiModel> {
-  const concreteModelHandle = isUnselectedLocalModelHandle(modelHandle)
-    ? undefined
-    : modelHandle;
+  const concreteModelHandle = normalizeOpenAICompatibleLocalModelHandle(
+    isUnselectedLocalModelHandle(modelHandle) ? undefined : modelHandle,
+  );
   const provider = options.provider
     ? resolvePiProvider(options.provider)
     : resolvePiProviderFromAgent(concreteModelHandle, modelSettings);

--- a/src/backend/dev/pi-output-budget.test.ts
+++ b/src/backend/dev/pi-output-budget.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  AssistantMessage,
+  AssistantMessageEvent,
+  Model,
+} from "@earendil-works/pi-ai";
+import {
+  PiStreamAdapter,
+  type PiStreamFunction,
+} from "@/backend/dev/pi-stream-adapter";
+import type {
+  ProviderStreamEvent,
+  ProviderTurnInput,
+} from "@/backend/dev/provider-turn-executor";
+import { emptyLocalUsage } from "@/backend/local/local-message";
+
+function completedStream(model: Model<string>): ReturnType<PiStreamFunction> {
+  const finalMessage: AssistantMessage = {
+    role: "assistant",
+    content: [{ type: "text", text: "done" }],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: emptyLocalUsage(),
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+  const done: AssistantMessageEvent = {
+    type: "done",
+    reason: "stop",
+    message: finalMessage,
+  };
+  async function* iterator() {
+    yield done;
+  }
+  return Object.assign(iterator(), {
+    result: async () => finalMessage,
+  });
+}
+
+async function collectEvents(
+  events: AsyncIterable<ProviderStreamEvent>,
+): Promise<ProviderStreamEvent[]> {
+  const collected: ProviderStreamEvent[] = [];
+  for await (const event of events) collected.push(event);
+  return collected;
+}
+
+function llamaInput(content: string): ProviderTurnInput {
+  return {
+    conversationId: "local-conv-budget",
+    agentId: "agent-local-budget",
+    agent: {
+      id: "agent-local-budget",
+      name: "Local",
+      description: null,
+      system: "system",
+      tags: [],
+      model:
+        "llama.cpp/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive-IQ4_XS.gguf",
+      model_settings: {
+        provider_type: "llama_cpp",
+        context_window_limit: 128000,
+        max_tokens: 32000,
+      },
+    },
+    body: { messages: [] } as never,
+    history: [],
+    uiMessages: [
+      {
+        id: "ui-msg-budget",
+        role: "user",
+        content,
+        timestamp: Date.now(),
+      },
+    ],
+    clientTools: [],
+    clientSkills: [],
+  };
+}
+
+describe("pi output budget", () => {
+  test("compacts instead of silently clamping a 128k llama.cpp turn to one token", async () => {
+    let providerCalls = 0;
+    let overflowError: unknown;
+    const stream: PiStreamFunction = (model) => {
+      providerCalls += 1;
+      return completedStream(model);
+    };
+    const adapter = new PiStreamAdapter({
+      stream,
+      onContextWindowOverflow: async (_input, error) => {
+        overflowError = error;
+        return {
+          uiMessages: [
+            {
+              id: "ui-msg-compacted",
+              role: "user",
+              content: "small",
+              timestamp: Date.now(),
+            },
+          ],
+          summary: "compacted near-limit context",
+        };
+      },
+    });
+
+    const nearLimitContent = "x".repeat((128000 - 4096) * 4);
+    const events = await collectEvents(
+      adapter.stream(llamaInput(nearLimitContent)),
+    );
+
+    expect(providerCalls).toBe(1);
+    expect(String(overflowError)).toContain("leaves only 1 output token");
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "letta-chunk",
+        chunk: expect.objectContaining({
+          message_type: "event_message",
+          event_type: "compaction",
+        }),
+      }),
+    );
+    expect(events.some((event) => event.type === "local-message")).toBe(true);
+  });
+});

--- a/src/backend/dev/pi-output-budget.ts
+++ b/src/backend/dev/pi-output-budget.ts
@@ -1,0 +1,26 @@
+import type { Api, Context, Model } from "@earendil-works/pi-ai";
+import { clampMaxTokensToContext } from "@earendil-works/pi-ai/api/simple-options";
+
+// Match pi-ai's minimum non-thinking output allowance. Its separate 4k safety
+// reserve can otherwise leave a nominally successful turn with one token.
+const MIN_VIABLE_OUTPUT_TOKENS = 1024;
+
+export function assertViablePiOutputBudget(
+  model: Model<Api>,
+  context: Context,
+  requestedMaxTokens?: number,
+): void {
+  // The regression is proven for llama.cpp. Other providers retain their
+  // existing provider-error and oversized-transport recovery semantics.
+  if (model.provider !== "llama-cpp") return;
+  const requested = requestedMaxTokens ?? model.maxTokens;
+  if (!Number.isFinite(requested) || requested <= 0) return;
+
+  const clamped = clampMaxTokensToContext(model, context, requested);
+  const minimum = Math.min(requested, MIN_VIABLE_OUTPUT_TOKENS);
+  if (clamped >= minimum) return;
+
+  throw new Error(
+    `Context window of ${model.contextWindow} tokens leaves only ${clamped} output token${clamped === 1 ? "" : "s"}; at least ${minimum} are required. Compact the conversation or increase the context window.`,
+  );
+}

--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -38,6 +38,7 @@ import {
   reasoningForSettings,
   resolvePiModelForAgent,
 } from "./pi-model-factory";
+import { assertViablePiOutputBudget } from "./pi-output-budget";
 import type {
   LlmEndErrorInfo,
   LlmEndInfo,
@@ -782,6 +783,7 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
         messageCount: context.messages.length,
         contextWindow: resolved.model.contextWindow,
       });
+      assertViablePiOutputBudget(resolved.model, context, options.maxTokens);
       const result = this.runStream(
         resolved.model as Model<string>,
         context,

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -579,7 +579,7 @@ describe("pi model factory", () => {
     }
   });
 
-  test("normalizes local OpenAI-compatible provider base URLs for runtime", async () => {
+  test("normalizes wrapped llama.cpp handles and custom base URLs", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "pi-llama-cpp-base-url-"));
     try {
       await createOrUpdateLocalProvider({
@@ -590,13 +590,35 @@ describe("pi model factory", () => {
         baseURL: "http://localhost:8088/",
       });
 
-      const resolved = await resolvePiModelForAgent(
+      const native = await resolvePiModelForAgent(
         "llama.cpp/local-model",
-        { provider_type: "llama_cpp" },
+        {
+          provider_type: "llama_cpp",
+          context_window_limit: 128000,
+          max_tokens: 32000,
+        },
+        { localProviderAuthStorageDir: storageDir },
+      );
+      const wrapped = await resolvePiModelForAgent(
+        "openai/llama.cpp/local-model",
+        {
+          provider_type: "llama_cpp",
+          context_window_limit: 128000,
+          max_tokens: 32000,
+        },
         { localProviderAuthStorageDir: storageDir },
       );
 
-      expect(resolved.model.baseUrl).toBe("http://localhost:8088/v1");
+      expect(native.provider).toBe("llama-cpp");
+      expect(wrapped).toEqual(native);
+      expect(native.model).toMatchObject({
+        id: "local-model",
+        api: "openai-completions",
+        provider: "llama-cpp",
+        baseUrl: "http://localhost:8088/v1",
+        contextWindow: 128000,
+        maxTokens: 32000,
+      });
     } finally {
       await rm(storageDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Problem

CLI 0.28.0 can complete a llama.cpp turn after one thinking token. The `@earendil-works/pi-ai@0.80.6` upgrade began clamping every simple request to:

```
contextWindow - estimatedContext - 4096
```

and floors the result to one. A near-limit 128k llama.cpp context therefore sends `max_tokens: 1`, looks successful, and never enters Letta Code's overflow/compaction path.

The related handle audit also found that `openai/llama.cpp/<model>` resolves as an OpenAI catalog model while `llama.cpp/<model>` correctly uses the configured llama.cpp endpoint.

## Fix

- Compute the exact clamp through pi-ai's own `clampMaxTokensToContext()` before llama.cpp requests.
- Route output budgets below a viable minimum through the existing context-overflow compaction path. If compaction cannot help, surface an actionable context-window error instead of a one-token success.
- Canonicalize an `openai/` wrapper only when its nested handle belongs to a known local OpenAI-compatible provider.
- Keep ordinary OpenAI handles and every other provider's retry/compaction behavior unchanged.

The `/compat` facade introduced in the dependency bump is not causal: both the compatibility API and the new `Models` API reach the same clamp. Removing the temporary facade remains a separate provider-runtime migration.

## Validation

- `bun test src/backend/local-backend.test.ts src/backend/dev/pi-output-budget.test.ts src/backend/pi-model-factory.test.ts src/backend/pi-stream-adapter.test.ts` (81 passed)
- `bun run check` (12/12 passed)

Linear: LET-9585
Linear: LET-9586