### PR TITLE
test: isolate stateful unit suites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,7 @@ utils/         ← bottom: no domain deps
 Practical rules:
 - Prefer dependency injection or object-level stubbing over module-level mocking.
 - Don't mock broad shared modules (`settings-manager`, telemetry, etc.).
-- If a test file must use `mock.module()`, run it as a standalone `bun test` invocation separate from the main worker pool (see `scripts/run-unit-tests.cjs` for the pattern).
+- If a test file must use `mock.module()`, register it with a reason in `scripts/isolated-unit-tests.json`; `scripts/run-unit-tests.cjs` will run it in a standalone Bun process, and the mock-isolation check rejects unregistered top-level mocks.
 - If a test passes alone but fails in `bun test src/`, suspect mock leakage first.
 
 ---

--- a/scripts/check-test-mock-isolation.js
+++ b/scripts/check-test-mock-isolation.js
@@ -2,13 +2,21 @@
 
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const TESTS_DIR_ENV = "LETTA_MOCK_ISOLATION_TESTS_DIR";
 
 const rootDir = process.cwd();
+const scriptDir = dirname(fileURLToPath(import.meta.url));
 const testsDir = process.env[TESTS_DIR_ENV]
   ? resolve(process.env[TESTS_DIR_ENV])
   : join(rootDir, "src");
+const isolationManifest = JSON.parse(
+  readFileSync(join(scriptDir, "isolated-unit-tests.json"), "utf8"),
+);
+const ISOLATED_TEST_FILES = new Set(
+  isolationManifest.tests.map((entry) => entry.path),
+);
 
 const FORBIDDEN_MOCK_MODULES = new Map([
   [
@@ -33,27 +41,6 @@ const COMPLETE_EXPORT_MOCK_MODULES = new Set([
   "/channels/slack/runtime",
   "/channels/telegram/runtime",
   "/channels/discord/runtime",
-]);
-
-// Existing top-level module mocks that predate this guard. New top-level
-// internal mocks are rejected by default because they are active while Bun loads
-// other test files in the same process. Prefer dependency injection or an
-// explicit test override helper. If a new top-level mock is truly unavoidable,
-// add a file+module entry here in the same PR with a clear explanation.
-const ALLOWED_TOP_LEVEL_MOCKS = new Set([
-  "src/channels/discord-registry.test.ts::../backend/api/client",
-  "src/cli/message-search-cache-warm.test.ts::../backend/api/search",
-  "src/hooks/prompt-executor.test.ts::../backend/api/generate",
-  "src/tools/memory-apply-patch.test.ts::../backend/api/client",
-  "src/tools/memory-tool.test.ts::../backend/api/client",
-  "src/tools/toolset-client-tool-rule-cleanup.test.ts::../backend/api/client",
-  "src/tools/toolset-memfs-detach.test.ts::../backend/api/client",
-  "src/websocket/listen-client-concurrency.test.ts::../agent/approval-execution",
-  "src/websocket/listen-client-concurrency.test.ts::../agent/approval-recovery",
-  "src/websocket/listen-client-concurrency.test.ts::../agent/message",
-  "src/websocket/listen-client-concurrency.test.ts::../backend/api/client",
-  "src/websocket/listen-client-concurrency.test.ts::../cli/helpers/approvalClassification",
-  "src/websocket/listen-client-concurrency.test.ts::../cli/helpers/stream",
 ]);
 
 const mockModulePattern = /\bmock\.module\s*\(\s*(["'`])([^"'`]+)\1/g;
@@ -390,8 +377,7 @@ for (const filePath of collectTestFiles(testsDir)) {
       isRelativeInternalModule(moduleSpecifier) &&
       isTopLevelMockCall(sourceText, match.index ?? 0)
     ) {
-      const key = `${relativePath}::${moduleSpecifier}`;
-      if (!ALLOWED_TOP_LEVEL_MOCKS.has(key)) {
+      if (!ISOLATED_TEST_FILES.has(relativePath)) {
         failures.push({
           type: "top-level-mock",
           filePath: relativePath,
@@ -457,7 +443,7 @@ if (failures.length > 0) {
           `  unsafe top-level internal module mock: ${failure.moduleSpecifier}`,
         );
         console.error(
-          "  Top-level mock.module() calls are active while Bun loads other test files. Move the mock into the test/beforeEach, use dependency injection, or add an explicit test override helper.",
+          "  Top-level mock.module() calls are active while Bun loads other test files. Move the mock into the test/beforeEach, use dependency injection, or register a justified standalone process in scripts/isolated-unit-tests.json.",
         );
         break;
       case "partial-runtime-mock":
@@ -481,7 +467,7 @@ if (failures.length > 0) {
     "\nWhy this fails: Bun module mocks are process-global and can leak across files in the shared module cache.",
   );
   console.error(
-    "Prefer explicit test override helpers or dependency injection. If a module mock is unavoidable, keep it scoped and restore it with afterEach().",
+    "Prefer explicit test override helpers or dependency injection. If a module mock is unavoidable, keep it scoped and restore it with afterEach(); top-level mocks must also run in an isolated process.",
   );
   process.exit(1);
 }

--- a/scripts/isolated-unit-tests.json
+++ b/scripts/isolated-unit-tests.json
@@ -1,0 +1,64 @@
+{
+  "tests": [
+    {
+      "path": "src/channels/discord-registry.test.ts",
+      "timeoutMs": 15000,
+      "reason": "Uses a top-level Bun module mock for the backend client."
+    },
+    {
+      "path": "src/channels/discord-service.test.ts",
+      "timeoutMs": 15000,
+      "reason": "Mutates shared channel account, route, pairing, and target stores."
+    },
+    {
+      "path": "src/channels/slack/media.test.ts",
+      "timeoutMs": 15000,
+      "reason": "Imports the real media module while Slack adapter tests replace it."
+    },
+    {
+      "path": "src/cli/message-search-cache-warm.test.ts",
+      "timeoutMs": 15000,
+      "reason": "Uses a top-level Bun module mock for backend search."
+    },
+    {
+      "path": "src/hooks/prompt-executor.test.ts",
+      "timeoutMs": 15000,
+      "reason": "Uses a top-level Bun module mock for backend generation."
+    },
+    {
+      "path": "src/tools/bash.test.ts",
+      "timeoutMs": 30000,
+      "reason": "Spawns real shells and temporarily mutates process platform and PATH state."
+    },
+    {
+      "path": "src/tools/enter-worktree.test.ts",
+      "timeoutMs": 30000,
+      "reason": "Spawns real Git processes and mutates HOME, USER_CWD, cwd, and runtime singletons."
+    },
+    {
+      "path": "src/tools/memory-apply-patch.test.ts",
+      "timeoutMs": 15000,
+      "reason": "Uses a top-level Bun module mock for the backend client."
+    },
+    {
+      "path": "src/tools/memory-tool.test.ts",
+      "timeoutMs": 15000,
+      "reason": "Uses a top-level Bun module mock for the backend client."
+    },
+    {
+      "path": "src/tools/toolset-client-tool-rule-cleanup.test.ts",
+      "timeoutMs": 15000,
+      "reason": "Uses a top-level Bun module mock for the backend client."
+    },
+    {
+      "path": "src/tools/toolset-memfs-detach.test.ts",
+      "timeoutMs": 15000,
+      "reason": "Uses a top-level Bun module mock for the backend client."
+    },
+    {
+      "path": "src/websocket/listen-client-concurrency.test.ts",
+      "timeoutMs": 30000,
+      "reason": "Uses several top-level Bun module mocks and exercises real concurrent listener state."
+    }
+  ]
+}

--- a/scripts/run-unit-tests.cjs
+++ b/scripts/run-unit-tests.cjs
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
-const { execSync } = require("node:child_process");
-const { readdirSync, statSync } = require("node:fs");
+const { execFileSync } = require("node:child_process");
+const { readFileSync, readdirSync } = require("node:fs");
 const path = require("node:path");
 
 // Unit test directories — bun discovers *.test.ts / *.test.tsx within each.
-// Listed explicitly so we skip src/integration-tests (API-gated) and avoid
-// shell expansion that can exceed the Windows command-line length limit.
+// Listed explicitly so we skip src/integration-tests (API-gated).
 const dirs = [
   "src/agent",
   "src/auth",
@@ -30,23 +29,23 @@ const dirs = [
   "src/utils",
   "src/web",
   "src/websocket",
-  // Root-level test files (not inside a subdirectory)
-  "src/*.test.ts",
 ];
 
-// slack/media.test.ts imports the real media module. The adapter test harness
-// mocks that module, which in Bun 1.3.x poisons the shared module registry
-// across parallel workers. Run media tests in an isolated process first, then
-// run src/channels with every other test file.
-function findTestFiles(dir, exclude) {
+const isolationManifest = JSON.parse(
+  readFileSync(path.join(__dirname, "isolated-unit-tests.json"), "utf8"),
+);
+const isolatedTests = isolationManifest.tests;
+const isolatedPaths = new Set(isolatedTests.map((entry) => entry.path));
+
+function findTestFiles(dir) {
   const results = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      results.push(...findTestFiles(full, exclude));
+      results.push(...findTestFiles(full));
     } else if (
-      (entry.name.endsWith(".test.ts") || entry.name.endsWith(".test.tsx")) &&
-      !exclude.includes(full.replace(/\\/g, "/"))
+      entry.name.endsWith(".test.ts") ||
+      entry.name.endsWith(".test.tsx")
     ) {
       results.push(full.replace(/\\/g, "/"));
     }
@@ -54,28 +53,87 @@ function findTestFiles(dir, exclude) {
   return results;
 }
 
-const channelTestFiles = findTestFiles("src/channels", [
-  "src/channels/slack/media.test.ts",
-]);
-
-const opts = { stdio: "inherit", shell: process.platform === "win32" };
-let exitCode = 0;
-
-// Run Slack media tests in isolation first (clean module registry)
-try {
-  execSync("bun test src/channels/slack/media.test.ts --timeout 15000", opts);
-} catch (e) {
-  exitCode = e.status ?? 1;
+function findRootTestFiles(dir) {
+  return readdirSync(dir, { withFileTypes: true })
+    .filter(
+      (entry) =>
+        entry.isFile() &&
+        (entry.name.endsWith(".test.ts") || entry.name.endsWith(".test.tsx")),
+    )
+    .map((entry) => path.join(dir, entry.name).replace(/\\/g, "/"));
 }
 
-// Run everything else
-try {
-  execSync(
-    `bun test ${[...dirs, ...channelTestFiles].join(" ")} --timeout 15000`,
-    opts,
-  );
-} catch (e) {
-  exitCode = e.status ?? 1;
+const allTestFiles = [
+  ...dirs.flatMap((dir) => findTestFiles(dir)),
+  ...findTestFiles("src/channels"),
+  ...findRootTestFiles("src"),
+].sort();
+const discoveredPaths = new Set(allTestFiles);
+
+for (const entry of isolatedTests) {
+  if (!discoveredPaths.has(entry.path)) {
+    throw new Error(
+      `Isolated unit test is missing from the unit-test roots: ${entry.path}`,
+    );
+  }
+  if (!Number.isInteger(entry.timeoutMs) || entry.timeoutMs <= 0) {
+    throw new Error(`Invalid timeout for isolated unit test: ${entry.path}`);
+  }
+}
+
+function runTests(files, timeoutMs) {
+  execFileSync("bun", ["test", ...files, "--timeout", String(timeoutMs)], {
+    stdio: "inherit",
+  });
+}
+
+function chunkByCommandLength(files, maxChars = 20000) {
+  const chunks = [];
+  let chunk = [];
+  let chars = 0;
+
+  for (const file of files) {
+    const nextChars = file.length + 3;
+    if (chunk.length > 0 && chars + nextChars > maxChars) {
+      chunks.push(chunk);
+      chunk = [];
+      chars = 0;
+    }
+    chunk.push(file);
+    chars += nextChars;
+  }
+  if (chunk.length > 0) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
+let exitCode = 0;
+
+// Bun module mocks and process-global state are shared within one test process.
+// Keep the explicitly stateful suites in fresh processes so they cannot poison
+// the ordinary unit batch or inherit another suite's cwd/env/module registry.
+for (const entry of isolatedTests) {
+  try {
+    runTests([entry.path], entry.timeoutMs);
+  } catch (error) {
+    exitCode = error.status ?? 1;
+  }
+}
+
+const sharedProcessTests = allTestFiles.filter(
+  (file) => !isolatedPaths.has(file),
+);
+
+// Passing argv directly avoids cmd.exe's shorter shell command-line limit on
+// Windows. Bounded batches also stay below CreateProcess's 32k limit as the
+// suite grows.
+for (const batch of chunkByCommandLength(sharedProcessTests)) {
+  try {
+    runTests(batch, 15000);
+  } catch (error) {
+    exitCode = error.status ?? 1;
+  }
 }
 
 process.exit(exitCode);

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -41,7 +41,7 @@
   "src/tools/manager.ts": 3293,
   "src/tools/tool-execution-context.test.ts": 1422,
   "src/types/protocol_v2.ts": 2932,
-  "src/websocket/listen-client-concurrency.test.ts": 3021,
+  "src/websocket/listen-client-concurrency.test.ts": 3017,
   "src/websocket/listen-client-protocol.test.ts": 6721,
   "src/websocket/listener/commands/channels.ts": 1390,
   "src/websocket/listener/commands/memory.ts": 1114,

--- a/src/websocket/listen-client-concurrency.test.ts
+++ b/src/websocket/listen-client-concurrency.test.ts
@@ -334,13 +334,16 @@ function createDeferredDrain() {
 
 async function waitFor(
   predicate: () => boolean,
-  attempts: number = 20,
+  timeoutMs: number = 5_000,
 ): Promise<void> {
-  for (let i = 0; i < attempts; i += 1) {
-    if (predicate()) {
-      return;
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Timed out waiting for test condition after ${timeoutMs}ms`,
+      );
     }
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 1));
   }
 }
 
@@ -940,7 +943,7 @@ describe("listen-client multi-worker concurrency", () => {
       processQueuedTurn,
     );
 
-    await waitFor(() => processed.length === 2);
+    await Promise.all([runtimeA.messageQueue, runtimeB.messageQueue]);
 
     expect(processed.sort()).toEqual(["conv-a", "conv-b"]);
     expect(runtimeA.queueRuntime.length).toBe(0);
@@ -1023,7 +1026,7 @@ describe("listen-client multi-worker concurrency", () => {
       },
     );
 
-    await waitFor(() => processed.length === 1);
+    await runtime.messageQueue;
 
     const queuedPayload = processed[0]?.messages[0];
     if (!queuedPayload || !("content" in queuedPayload)) {
@@ -1132,7 +1135,7 @@ describe("listen-client multi-worker concurrency", () => {
       },
     );
 
-    await waitFor(() => processed.length === 1 && lifecycleEvents.length === 2);
+    await runtime.messageQueue;
 
     expect(processed[0]?.channelTurnSources).toEqual(channelTurnSources);
     expect(lifecycleEvents[0]).toEqual({
@@ -1212,9 +1215,7 @@ describe("listen-client multi-worker concurrency", () => {
       },
     );
 
-    await waitFor(
-      () => lifecycleEvents.length === 1 && !runtime.queuePumpActive,
-    );
+    await runtime.messageQueue;
     expect(lifecycleEvents).toEqual([
       {
         type: "processing",
@@ -1296,7 +1297,7 @@ describe("listen-client multi-worker concurrency", () => {
       },
     );
 
-    await waitFor(() => lifecycleEvents.length === 2);
+    await runtime.messageQueue;
 
     expect(lifecycleEvents[1]).toEqual({
       type: "finished",
@@ -1346,7 +1347,7 @@ describe("listen-client multi-worker concurrency", () => {
       },
     );
 
-    await waitFor(() => processed.length === 1);
+    await runtime.messageQueue;
 
     expect(processed[0]).toEqual(
       expect.objectContaining({
@@ -2105,7 +2106,7 @@ describe("listen-client multi-worker concurrency", () => {
       async () => {},
     );
 
-    await waitFor(() => runtimeB.queueRuntime.length === 0);
+    await runtimeB.messageQueue;
 
     expect(statuses).not.toContain("idle");
     expect(statuses.every((status) => status === "processing")).toBe(true);
@@ -2372,12 +2373,7 @@ describe("listen-client multi-worker concurrency", () => {
           batch.batchId,
         ),
     );
-    await waitFor(
-      () =>
-        runtime.queueRuntime.length === 0 &&
-        runtime.turnLifecycle.kind === "idle" &&
-        sendMessageStreamMock.mock.calls.length === 2,
-    );
+    await runtime.messageQueue;
 
     expect(JSON.stringify(sendMessageStreamMock.mock.calls[1]?.[1])).toContain(
       "follow up",


### PR DESCRIPTION
## Summary
- run top-level Bun module mocks and process-global Git/shell/listener suites in explicit fresh processes
- make the isolation manifest the enforced source of truth for the unit runner and mock-isolation check
- await listener queue ownership promises instead of silently timing out after 20 event-loop ticks
- keep the ordinary unit timeout at 15s; grant 30s only to real Git/shell and listener concurrency suites

## Why
The first macOS run failed only when an EnterWorktree Git-hook test hit exactly 15s. Rerunning the failed jobs on the same SHA made that test pass and moved the failure to two unrelated listener assertions. The listener helper could silently return before its condition became true, leaving a queue pump alive while the next test replaced process-global runtime and channel-registry state.

Bun module mocks are process-global as well, but the existing checker allowlisted them without ensuring the test runner actually isolated their files. This change connects those two contracts.

Failure: https://github.com/letta-ai/letta-code/actions/runs/29131254777/job/86486992771
Same-SHA rerun with moved failure: https://github.com/letta-ai/letta-code/actions/runs/29131254777/job/86488743835

## Validation
- `bun run check` (12/12)
- `bun test src/websocket/listen-client-concurrency.test.ts --rerun-each 100 --timeout 30000` (3700/3700)
- `bun test src/tools/enter-worktree.test.ts src/tools/bash.test.ts --timeout 30000` (37/37)
- `bun test src/mock-isolation-check.test.ts --rerun-each 20` (100/100)