### PR TITLE
fix(local): preserve user message correlation ids

### DIFF
--- a/src/backend/local/local-message-correlation.test.ts
+++ b/src/backend/local/local-message-correlation.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  ConversationMessageCreateBody,
+  ConversationMessageListBody,
+} from "@/backend";
+import { LocalStore } from "@/backend/local/local-store";
+
+const temporaryDirectories: string[] = [];
+
+async function createStorageDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "local-message-correlation-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) =>
+      rm(directory, {
+        recursive: true,
+        force: true,
+      }),
+    ),
+  );
+});
+
+describe("local user message correlation", () => {
+  test("preserves the inbound otid through projection and transcript reload", async () => {
+    const storageDir = await createStorageDirectory();
+    const agentId = "agent-local-correlation";
+    const otid = "desktop-user-message-1";
+    const store = new LocalStore(agentId, { storageDir });
+
+    store.appendTurnInput("default", {
+      agent_id: agentId,
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+          otid,
+          client_message_id: otid,
+        },
+      ],
+    } as unknown as ConversationMessageCreateBody);
+
+    expect(store.listLocalMessages("default", agentId)).toEqual([
+      expect.objectContaining({ role: "user", otid }),
+    ]);
+    expect(
+      store.listConversationMessages("default", {
+        agent_id: agentId,
+        order: "asc",
+      } as ConversationMessageListBody),
+    ).toEqual([
+      expect.objectContaining({ message_type: "user_message", otid }),
+    ]);
+
+    const reloaded = new LocalStore(agentId, { storageDir });
+    expect(
+      reloaded.listConversationMessages("default", {
+        agent_id: agentId,
+        order: "asc",
+      } as ConversationMessageListBody),
+    ).toEqual([
+      expect.objectContaining({ message_type: "user_message", otid }),
+    ]);
+  });
+});

--- a/src/backend/local/local-message-correlation.test.ts
+++ b/src/backend/local/local-message-correlation.test.ts
@@ -32,6 +32,7 @@ describe("local user message correlation", () => {
     const storageDir = await createStorageDirectory();
     const agentId = "agent-local-correlation";
     const otid = "desktop-user-message-1";
+    const clientMessageId = "transport-user-message-1";
     const store = new LocalStore(agentId, { storageDir });
 
     store.appendTurnInput("default", {
@@ -41,7 +42,7 @@ describe("local user message correlation", () => {
           role: "user",
           content: [{ type: "text", text: "hello" }],
           otid,
-          client_message_id: otid,
+          client_message_id: clientMessageId,
         },
       ],
     } as unknown as ConversationMessageCreateBody);
@@ -66,6 +67,37 @@ describe("local user message correlation", () => {
       } as ConversationMessageListBody),
     ).toEqual([
       expect.objectContaining({ message_type: "user_message", otid }),
+    ]);
+  });
+
+  test("seeds the otid from client_message_id when otid is absent", async () => {
+    const storageDir = await createStorageDirectory();
+    const agentId = "agent-local-client-correlation";
+    const clientMessageId = "transport-user-message-2";
+    const store = new LocalStore(agentId, { storageDir });
+
+    store.appendTurnInput("default", {
+      agent_id: agentId,
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "hello from an older sender" }],
+          client_message_id: clientMessageId,
+        },
+      ],
+    } as unknown as ConversationMessageCreateBody);
+
+    const reloaded = new LocalStore(agentId, { storageDir });
+    expect(
+      reloaded.listConversationMessages("default", {
+        agent_id: agentId,
+        order: "asc",
+      } as ConversationMessageListBody),
+    ).toEqual([
+      expect.objectContaining({
+        message_type: "user_message",
+        otid: clientMessageId,
+      }),
     ]);
   });
 });

--- a/src/backend/local/local-message-projection.ts
+++ b/src/backend/local/local-message-projection.ts
@@ -210,6 +210,7 @@ export function projectLocalMessageToStoredMessages(
         message_type: "user_message",
         role: "user",
         content: userContentToStoredContent(message.content),
+        ...(message.otid ? { otid: message.otid } : {}),
       } as StoredMessage,
     ];
   }

--- a/src/backend/local/local-message.ts
+++ b/src/backend/local/local-message.ts
@@ -54,6 +54,7 @@ export interface LocalUserMessage
   extends Omit<UserMessage, "timestamp">,
     LocalMessageBase {
   role: "user";
+  otid?: string;
   timestamp: number;
 }
 

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -1946,11 +1946,11 @@ export class LocalStore {
     message: Record<string, unknown>,
   ): LocalMessage {
     const conversation = this.ensureConversation(conversationId, agentId);
-    const id = this.nextLocalMessageId();
     const date = this.currentLocalMessageDate();
     const localMessage: LocalMessage = {
-      id,
+      id: this.nextLocalMessageId(),
       role: "user",
+      otid: optionalString(message.otid ?? message.client_message_id),
       metadata: {
         created_at: date,
         updated_at: date,


### PR DESCRIPTION
## Summary

- preserve the inbound `otid` on persisted local user messages, falling back to `client_message_id` for older senders
- return that correlation ID from the local conversation-message projection so optimistic Desktop messages reconcile with their canonical rows
- cover explicit OTID precedence, the transport-ID fallback, immediate projection, and transcript reload behavior

## Root cause

Desktop optimistically renders an outbound user message keyed by `otid`. Cloud-backed messages echo that ID, but the local backend discarded it while converting turn input into its local transcript model. The subsequent canonical fetch therefore looked like a second message even though only one user row and one turn were persisted.

## Identifier contract

`otid` remains the canonical request/message-lineage identifier. `client_message_id` is used only as the documented device/queue seed when an explicit OTID is absent; it is not persisted as a second transcript identity.

## Verification

- `bun run check` (12/12)
- `bun test src/backend/local/local-message-correlation.test.ts src/backend/local-backend.test.ts src/backend/local/compaction.test.ts src/backend/provider-turn-executor.test.ts` (49/49)