### PR TITLE
fix(local): use native model inventory with curated presets [LET-9598]

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "src/agent/client-skills.test.ts": 1196,
   "src/agent/memory-git.ts": 2324,
-  "src/backend/local-backend.test.ts": 2589,
+  "src/backend/local-backend.test.ts": 2534,
   "src/backend/local/local-backend.ts": 1058,
   "src/backend/local/local-store.ts": 3618,
   "src/backend/pi-stream-adapter.test.ts": 1442,

--- a/src/agent/available-models-backend.test.ts
+++ b/src/agent/available-models-backend.test.ts
@@ -21,6 +21,12 @@ describe("available models backend wiring", () => {
     expect(result.source).toBe("network");
     expect(Array.from(result.handles)).toEqual(["dev/fake-headless"]);
     expect(result.providerTypes.get("dev/fake-headless")).toBe("openai");
+    expect(result.models).toEqual([
+      expect.objectContaining({
+        handle: "dev/fake-headless",
+        providerType: "openai",
+      }),
+    ]);
     expect(await getModelProviderType("dev/fake-headless")).toBe("openai");
   });
 });

--- a/src/agent/available-models.test.ts
+++ b/src/agent/available-models.test.ts
@@ -19,8 +19,12 @@ import { FakeHeadlessBackend } from "@/backend/dev/fake-headless-backend";
  */
 
 type FakeModel = {
+  display_name?: string;
   handle: string;
   max_context_window?: number;
+  max_tokens?: number;
+  model?: string;
+  name?: string;
   provider_type?: string;
 };
 
@@ -35,6 +39,7 @@ class AvailableModelsTestBackend extends FakeHeadlessBackend {
 const {
   clearAvailableModelsCache,
   getAvailableModelHandles,
+  getCachedAvailableModels,
   getCachedModelHandles,
 } = await import("@/agent/available-models");
 
@@ -115,6 +120,31 @@ describe("available-models cache semantics", () => {
     const forced = await getAvailableModelHandles({ forceRefresh: true });
     expect(forced.source).toBe("network");
     expect([...forced.handles]).toEqual(["openai/gpt-4o", "zai/glm-4.6"]);
+  });
+
+  test("carries backend model descriptors for catalog rendering", async () => {
+    listModelsImpl = async () => [
+      {
+        handle: "opencode/deepseek-v4-flash-free",
+        display_name: "DeepSeek V4 Flash Free",
+        max_context_window: 200000,
+        max_tokens: 32000,
+        provider_type: "opencode",
+      },
+    ];
+
+    const result = await getAvailableModelHandles();
+
+    expect(result.models).toEqual([
+      {
+        handle: "opencode/deepseek-v4-flash-free",
+        label: "DeepSeek V4 Flash Free",
+        maxContextWindow: 200000,
+        maxOutputTokens: 32000,
+        providerType: "opencode",
+      },
+    ]);
+    expect(getCachedAvailableModels()).toEqual(result.models);
   });
 
   test("clearAvailableModelsCache drops the inflight fetch so the next call refetches", async () => {

--- a/src/agent/available-models.ts
+++ b/src/agent/available-models.ts
@@ -3,10 +3,19 @@ import { refreshByokProviders } from "@/backend/api/providers";
 
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
+export type AvailableModel = {
+  handle: string;
+  label: string;
+  maxContextWindow?: number;
+  maxOutputTokens?: number;
+  providerType?: string;
+};
+
 type CacheEntry = {
   handles: Set<string>;
   contextWindows: Map<string, number>; // handle -> max_context_window
   providerTypes: Map<string, string>; // handle -> provider_type
+  models: AvailableModel[];
   fetchedAt: number;
 };
 
@@ -24,6 +33,7 @@ function isFresh(now = Date.now()) {
 export type AvailableModelHandlesResult = {
   handles: Set<string>;
   providerTypes: Map<string, string>;
+  models: AvailableModel[];
   source: "cache" | "network";
   fetchedAt: number;
 };
@@ -74,6 +84,10 @@ export function getCachedModelProviderTypes(): Map<string, string> | null {
   return new Map(cache.providerTypes);
 }
 
+export function getCachedAvailableModels(): AvailableModel[] | null {
+  return cache?.models.map((model) => ({ ...model })) ?? null;
+}
+
 async function fetchFromNetwork(): Promise<CacheEntry> {
   const modelsList = await getBackend().listModels();
   const handles = new Set(
@@ -82,6 +96,7 @@ async function fetchFromNetwork(): Promise<CacheEntry> {
   // Build context window map from API response
   const contextWindows = new Map<string, number>();
   const providerTypes = new Map<string, string>();
+  const modelsByHandle = new Map<string, AvailableModel>();
   for (const model of modelsList) {
     if (model.handle && model.max_context_window) {
       contextWindows.set(model.handle, model.max_context_window);
@@ -95,8 +110,35 @@ async function fetchFromNetwork(): Promise<CacheEntry> {
     if (model.handle && providerType) {
       providerTypes.set(model.handle, providerType);
     }
+    if (model.handle) {
+      const label =
+        (typeof model.display_name === "string" && model.display_name) ||
+        (typeof model.name === "string" && model.name) ||
+        (typeof model.model === "string" && model.model) ||
+        model.handle;
+      const availableModel = {
+        handle: model.handle,
+        label,
+        ...(typeof model.max_context_window === "number"
+          ? { maxContextWindow: model.max_context_window }
+          : {}),
+        ...(typeof model.max_tokens === "number"
+          ? { maxOutputTokens: model.max_tokens }
+          : {}),
+        ...(providerType ? { providerType } : {}),
+      };
+      if (!modelsByHandle.has(model.handle)) {
+        modelsByHandle.set(model.handle, availableModel);
+      }
+    }
   }
-  return { handles, contextWindows, providerTypes, fetchedAt: Date.now() };
+  return {
+    handles,
+    contextWindows,
+    providerTypes,
+    models: [...modelsByHandle.values()],
+    fetchedAt: Date.now(),
+  };
 }
 
 export async function getAvailableModelHandles(options?: {
@@ -109,6 +151,7 @@ export async function getAvailableModelHandles(options?: {
     return {
       handles: cache.handles,
       providerTypes: cache.providerTypes,
+      models: cache.models,
       source: "cache",
       fetchedAt: cache.fetchedAt,
     };
@@ -119,6 +162,7 @@ export async function getAvailableModelHandles(options?: {
     return {
       handles: entry.handles,
       providerTypes: entry.providerTypes,
+      models: entry.models,
       source: "network",
       fetchedAt: entry.fetchedAt,
     };
@@ -154,6 +198,7 @@ export async function getAvailableModelHandles(options?: {
   return {
     handles: entry.handles,
     providerTypes: entry.providerTypes,
+    models: entry.models,
     source: "network",
     fetchedAt: entry.fetchedAt,
   };

--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -194,6 +194,11 @@ const PI_PROVIDER_OVERRIDES: Partial<
       hasEnvValue(process.env.GOOGLE_GENERATIVE_AI_API_KEY) ||
       getEnvApiKey("google") !== undefined,
   },
+  "google-vertex": {
+    providerTypes: ["google-vertex", "google_vertex"],
+    handlePrefixes: ["google-vertex/", "google_vertex/"],
+    localProviderNames: ["google-vertex", "google_vertex"],
+  },
   "amazon-bedrock": {
     providerTypes: ["amazon-bedrock", "bedrock"],
     handlePrefixes: ["amazon-bedrock/", "bedrock/"],
@@ -378,6 +383,24 @@ export function resolveProviderFromModelHandle(
   return PI_PROVIDER_SPECS.find((provider) =>
     provider.handlePrefixes.some((prefix) => model.startsWith(prefix)),
   )?.id;
+}
+
+export function resolvePiModelIdentity(
+  model: string | undefined,
+): string | undefined {
+  const provider = resolveProviderFromModelHandle(model);
+  if (!model || !provider) return undefined;
+  const modelId = stripProviderHandlePrefix(model, provider);
+  return modelId ? `${provider}/${modelId}` : undefined;
+}
+
+export function isResolvablePiModelHandle(model: string | undefined): boolean {
+  const provider = resolveProviderFromModelHandle(model);
+  if (!model || !provider) return false;
+  const spec = getPiProviderSpec(provider);
+  if (!spec.piProvider) return spec.createCustomModel === true;
+  const modelId = stripProviderHandlePrefix(model, provider);
+  return getModels(spec.piProvider).some((entry) => entry.id === modelId);
 }
 
 export function resolveProviderFromProviderType(

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -1344,61 +1344,6 @@ describe("local backend pi transcript", () => {
     expect(handles).not.toContain("ollama/llama2");
   });
 
-  test("lists mod-registered local provider models with context windows", async () => {
-    registerPiProvider("lmstudio", {
-      baseUrl: "http://localhost:8000/v1",
-      apiKey: "not-needed",
-      api: "openai-completions",
-      models: [
-        {
-          id: "gemma-4-26B-A4B-it-oQ6",
-          name: "Gemma 4 VLM",
-          reasoning: true,
-          input: ["text", "image"],
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          contextWindow: 256000,
-          maxTokens: 8192,
-        },
-      ],
-    });
-    const storageDir = await mkdtemp(
-      join(tmpdir(), "local-backend-pi-registered-provider-"),
-    );
-    await createOrUpdateLocalProvider({
-      providerType: "lmstudio",
-      providerName: "lc-lmstudio",
-      apiKey: "not-needed",
-      baseURL: "http://127.0.0.1:1234/v1",
-      storageDir,
-    });
-    const calls: string[] = [];
-    const fetchImpl = (async (input: unknown) => {
-      calls.push(typeof input === "string" ? input : String(input));
-      return new Response(
-        JSON.stringify({ data: [{ id: "heuristic-only-model" }] }),
-        { headers: { "content-type": "application/json" } },
-      );
-    }) as unknown as typeof fetch;
-
-    const models = await listLocalModels(storageDir, { fetch: fetchImpl });
-
-    expect(calls).toEqual(
-      expect.arrayContaining([
-        "http://localhost:11434/v1/models",
-        "http://localhost:8080/v1/models",
-      ]),
-    );
-    expect(models).toContainEqual({
-      handle: "lmstudio/gemma-4-26B-A4B-it-oQ6",
-      max_context_window: 256000,
-      model: "lmstudio/gemma-4-26B-A4B-it-oQ6",
-      model_endpoint_type: "lmstudio",
-    });
-    expect(models.map((model) => model.handle)).not.toContain(
-      "lmstudio/heuristic-only-model",
-    );
-  });
-
   test("uses mod-registered context windows for local agent state", async () => {
     registerPiProvider("lmstudio", {
       baseUrl: "http://localhost:8000/v1",

--- a/src/backend/local/local-model-config.test.ts
+++ b/src/backend/local/local-model-config.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  clearRegisteredPiProviders,
+  registerPiProvider,
+} from "@/backend/dev/pi-provider-mod-registry";
+import { listLocalModels } from "@/backend/local/local-model-config";
+import { createOrUpdateLocalProvider } from "@/backend/local/local-provider-auth-store";
+
+describe("local model catalog", () => {
+  afterEach(() => {
+    clearRegisteredPiProviders();
+  });
+
+  test("projects configured Pi models with native display metadata", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-opencode-catalog-"));
+    try {
+      await createOrUpdateLocalProvider({
+        storageDir,
+        providerType: "opencode",
+        providerName: "opencode",
+        apiKey: "test-key",
+      });
+      const fetchImpl = (async () =>
+        new Response("not found", { status: 404 })) as unknown as typeof fetch;
+
+      const entry = (
+        await listLocalModels(storageDir, { fetch: fetchImpl })
+      ).find((model) => model.handle === "opencode/deepseek-v4-flash-free");
+
+      expect(entry).toMatchObject({
+        display_name: "DeepSeek V4 Flash Free",
+        handle: "opencode/deepseek-v4-flash-free",
+        max_context_window: 200000,
+        max_tokens: 128000,
+        model_endpoint_type: "opencode",
+        name: "DeepSeek V4 Flash Free",
+        provider_type: "opencode",
+      });
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("uses registered model metadata instead of endpoint heuristics", async () => {
+    registerPiProvider("lmstudio", {
+      baseUrl: "http://localhost:8000/v1",
+      apiKey: "not-needed",
+      api: "openai-completions",
+      models: [
+        {
+          id: "gemma-4-26B-A4B-it-oQ6",
+          name: "Gemma 4 VLM",
+          reasoning: true,
+          input: ["text", "image"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 256000,
+          maxTokens: 8192,
+        },
+      ],
+    });
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-registered-provider-catalog-"),
+    );
+    try {
+      await createOrUpdateLocalProvider({
+        providerType: "lmstudio",
+        providerName: "lc-lmstudio",
+        apiKey: "not-needed",
+        baseURL: "http://127.0.0.1:1234/v1",
+        storageDir,
+      });
+      const fetchImpl = (async () =>
+        new Response(
+          JSON.stringify({ data: [{ id: "heuristic-only-model" }] }),
+          { headers: { "content-type": "application/json" } },
+        )) as unknown as typeof fetch;
+
+      const models = await listLocalModels(storageDir, { fetch: fetchImpl });
+
+      expect(models).toContainEqual(
+        expect.objectContaining({
+          display_name: "Gemma 4 VLM",
+          handle: "lmstudio/gemma-4-26B-A4B-it-oQ6",
+          max_context_window: 256000,
+          max_tokens: 8192,
+          model_endpoint_type: "lmstudio",
+          provider_type: "lmstudio",
+        }),
+      );
+      expect(models.map((model) => model.handle)).not.toContain(
+        "lmstudio/heuristic-only-model",
+      );
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/backend/local/local-model-config.ts
+++ b/src/backend/local/local-model-config.ts
@@ -46,10 +46,14 @@ export interface LocalModelConfig {
 export { UNSELECTED_LOCAL_MODEL_HANDLE };
 
 interface LocalModelListEntry {
+  display_name: string;
   handle: string;
   max_context_window?: number;
+  max_tokens?: number;
   model: string;
   model_endpoint_type: string;
+  name: string;
+  provider_type: string;
 }
 
 interface ListLocalModelsOptions {
@@ -440,7 +444,9 @@ export async function listLocalModels(
     options: {
       handle?: string;
       maxContextWindow?: number;
+      maxOutputTokens?: number;
       modelEndpointType?: string;
+      name?: string;
     } = {},
   ) => {
     if (!shouldIncludeLocalModel(provider, model)) return;
@@ -457,12 +463,35 @@ export async function listLocalModels(
       (typeof modelSettings?.context_window_limit === "number"
         ? modelSettings.context_window_limit
         : undefined);
+    const maxOutputTokens =
+      options.maxOutputTokens ??
+      (typeof modelSettings?.max_tokens === "number"
+        ? modelSettings.max_tokens
+        : undefined);
+    const modelId =
+      typeof provider === "string" && isPiProvider(provider)
+        ? (stripProviderHandlePrefix(handle, provider) ?? model)
+        : model;
+    const providerSpec = isPiProvider(provider)
+      ? getPiProviderSpec(provider)
+      : undefined;
+    const catalogModel = providerSpec?.piProvider
+      ? (getModels(providerSpec.piProvider) as Model<Api>[]).find(
+          (entry) => entry.id === modelId,
+        )
+      : undefined;
+    const providerType =
+      options.modelEndpointType ?? localProviderTypeForModelConfig(provider);
+    const name = options.name ?? catalogModel?.name ?? modelId;
     models.push({
+      display_name: name,
       handle,
       ...(maxContextWindow ? { max_context_window: maxContextWindow } : {}),
+      ...(maxOutputTokens ? { max_tokens: maxOutputTokens } : {}),
       model: handle,
-      model_endpoint_type:
-        options.modelEndpointType ?? localProviderTypeForModelConfig(provider),
+      model_endpoint_type: providerType,
+      name,
+      provider_type: providerType,
     });
   };
 
@@ -479,7 +508,9 @@ export async function listLocalModels(
         addModel(provider.providerName, model.id, {
           handle: `${provider.providerName}/${model.id}`,
           maxContextWindow: model.contextWindow,
+          maxOutputTokens: model.maxTokens,
           modelEndpointType: provider.providerName,
+          name: model.name,
         });
       }
     } catch {
@@ -487,7 +518,9 @@ export async function listLocalModels(
         addModel(provider.providerName, model.id, {
           handle: `${provider.providerName}/${model.id}`,
           maxContextWindow: model.contextWindow,
+          maxOutputTokens: model.maxTokens,
           modelEndpointType: provider.providerName,
+          name: model.name,
         });
       }
     }

--- a/src/backend/local/local-model-normalization.test.ts
+++ b/src/backend/local/local-model-normalization.test.ts
@@ -1,9 +1,22 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { resolvePiModelForAgent } from "@/backend/dev/pi-model-factory";
+import {
+  clearRegisteredPiProviders,
+  registerPiProvider,
+} from "@/backend/dev/pi-provider-mod-registry";
+import {
+  listCatalogModelsForProvider,
+  localModelHandle,
+  PI_PROVIDER_SPECS,
+} from "@/backend/dev/pi-provider-registry";
 import { LocalBackend } from "@/backend/local/local-backend";
-import { localLlmConfigModelPatch } from "@/backend/local/local-model-normalization";
+import {
+  localLlmConfigModelPatch,
+  normalizeLocalModelHandle,
+} from "@/backend/local/local-model-normalization";
 
 function localConversationDir(
   storageDir: string,
@@ -17,6 +30,86 @@ function localConversationDir(
 }
 
 describe("local model normalization", () => {
+  afterEach(() => {
+    clearRegisteredPiProviders();
+  });
+
+  test("preserves Pi catalog handles over stale legacy OpenAI metadata", () => {
+    const handle = "opencode/deepseek-v4-flash-free";
+
+    expect(
+      normalizeLocalModelHandle(
+        handle,
+        { provider_type: "openai" },
+        { model_endpoint_type: "openai" },
+      ),
+    ).toBe(handle);
+  });
+
+  test("runs a stored native Pi handle despite stale provider metadata", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-opencode-handle-"));
+    try {
+      const handle = "opencode/deepseek-v4-flash-free";
+      const backend = new LocalBackend({ storageDir, memfsEnabled: false });
+      const agent = await backend.createAgent({
+        name: "Local",
+        model: handle,
+        model_settings: { provider_type: "openai" },
+      } as never);
+
+      expect(agent.model).toBe(handle);
+      const resolved = await resolvePiModelForAgent(
+        agent.model ?? undefined,
+        agent.model_settings ?? {},
+        { localProviderAuthStorageDir: storageDir },
+      );
+      expect(resolved.provider).toBe("opencode");
+      expect(resolved.model.id).toBe("deepseek-v4-flash-free");
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("preserves a representative handle for every built-in Pi provider", () => {
+    for (const provider of PI_PROVIDER_SPECS) {
+      const handle = provider.piProvider
+        ? listCatalogModelsForProvider(provider.id)[0]
+        : provider.createCustomModel
+          ? localModelHandle(provider.id, "custom-model")
+          : undefined;
+      if (!handle) continue;
+
+      expect(
+        normalizeLocalModelHandle(handle, { provider_type: "openai" }),
+      ).toBe(handle);
+    }
+  });
+
+  test("preserves handles owned by registered provider mods", () => {
+    registerPiProvider("custom-provider", {
+      baseUrl: "http://localhost:8000/v1",
+      apiKey: "not-needed",
+      api: "openai-completions",
+      models: [
+        {
+          id: "custom-model",
+          name: "Custom Model",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 32000,
+          maxTokens: 4096,
+        },
+      ],
+    });
+
+    expect(
+      normalizeLocalModelHandle("custom-provider/custom-model", {
+        provider_type: "openai",
+      }),
+    ).toBe("custom-provider/custom-model");
+  });
+
   test("projects canonical provider metadata for local agents", async () => {
     const storageDir = await mkdtemp(
       join(tmpdir(), "local-backend-anthropic-llm-config-"),

--- a/src/backend/local/local-model-normalization.ts
+++ b/src/backend/local/local-model-normalization.ts
@@ -2,6 +2,8 @@ import {
   mapModelHandleToLlmConfigPatch,
   resolveModelHandleFromLlmConfig,
 } from "@/agent/model-handles";
+import { resolveRegisteredPiProviderFromModelHandle } from "@/backend/dev/pi-provider-mod-registry";
+import { isResolvablePiModelHandle } from "@/backend/dev/pi-provider-registry";
 import { isRecord } from "@/utils/type-guards";
 
 export function supportedModelSettingsFromBody(
@@ -41,6 +43,12 @@ export function normalizeLocalModelHandle(
   modelSettings?: Record<string, unknown>,
   legacyLlmConfig?: Record<string, unknown>,
 ): string {
+  if (
+    isResolvablePiModelHandle(model) ||
+    resolveRegisteredPiProviderFromModelHandle(model)
+  ) {
+    return model;
+  }
   const providerType = providerTypeFromModelSettings(modelSettings);
   const legacyEndpointType = legacyLlmConfig?.model_endpoint_type;
   return (

--- a/src/providers/local-pi-provider-catalog.test.ts
+++ b/src/providers/local-pi-provider-catalog.test.ts
@@ -374,12 +374,17 @@ describe("local pi provider catalog", () => {
 
       const models = await listLocalModels(storageDir);
 
-      expect(models).toContainEqual({
-        handle: "kilo/dynamic-kilo-code",
-        max_context_window: 128000,
-        model: "kilo/dynamic-kilo-code",
-        model_endpoint_type: "kilo",
-      });
+      expect(models).toContainEqual(
+        expect.objectContaining({
+          display_name: "Dynamic Kilo Code",
+          handle: "kilo/dynamic-kilo-code",
+          max_context_window: 128000,
+          max_tokens: 8192,
+          model: "kilo/dynamic-kilo-code",
+          model_endpoint_type: "kilo",
+          provider_type: "kilo",
+        }),
+      );
       expect(connections).toEqual([
         {
           id: "kilo",
@@ -438,12 +443,17 @@ describe("local pi provider catalog", () => {
 
       const models = await listLocalModels(storageDir);
 
-      expect(models).toContainEqual({
-        handle: "kilo/oauth-kilo-code",
-        max_context_window: 128000,
-        model: "kilo/oauth-kilo-code",
-        model_endpoint_type: "kilo",
-      });
+      expect(models).toContainEqual(
+        expect.objectContaining({
+          display_name: "OAuth Kilo Code",
+          handle: "kilo/oauth-kilo-code",
+          max_context_window: 128000,
+          max_tokens: 8192,
+          model: "kilo/oauth-kilo-code",
+          model_endpoint_type: "kilo",
+          provider_type: "kilo",
+        }),
+      );
       expect(connections).toEqual([
         {
           id: "kilo",

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -22,9 +22,9 @@ import {
 } from "./commands/channels";
 import { handleCronCommand } from "./commands/cron";
 import { handleListMemoryCommand } from "./commands/memory";
+import { buildListModelsEntries } from "./commands/model-catalog";
 import {
   applyModelUpdateForRuntime,
-  buildListModelsEntries,
   buildListModelsResponse,
   buildModelUpdateStatusMessage,
   getCurrentModelStatusForRuntime,

--- a/src/websocket/listener/commands/model-catalog.test.ts
+++ b/src/websocket/listener/commands/model-catalog.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+import type { AvailableModel } from "@/agent/available-models";
+import { models } from "@/agent/model";
+import {
+  buildListModelsEntries,
+  findAvailableModelForPreset,
+} from "./model-catalog";
+
+describe("listener model catalog", () => {
+  test("preserves models.json as the ordered preset overlay", () => {
+    const entries = buildListModelsEntries();
+
+    expect(entries).toHaveLength(models.length);
+    expect(entries[0]).toMatchObject({
+      id: models[0]?.id,
+      handle: models[0]?.handle,
+      label: models[0]?.label,
+      description: models[0]?.description,
+    });
+  });
+
+  test("appends backend-native models absent from models.json", () => {
+    const nativeModel: AvailableModel = {
+      handle: "opencode/deepseek-v4-flash-free",
+      label: "DeepSeek V4 Flash Free",
+      maxContextWindow: 200000,
+      maxOutputTokens: 128000,
+      providerType: "opencode",
+    };
+
+    const entries = buildListModelsEntries([nativeModel]);
+
+    expect(entries.at(-1)).toEqual({
+      id: nativeModel.handle,
+      handle: nativeModel.handle,
+      label: nativeModel.label,
+      description: "",
+    });
+  });
+
+  test("keeps curated variants instead of adding a duplicate native row", () => {
+    const variantsByHandle = new Map<string, (typeof models)[number][]>();
+    for (const model of models) {
+      const variants = variantsByHandle.get(model.handle) ?? [];
+      variants.push(model);
+      variantsByHandle.set(model.handle, variants);
+    }
+    const variants = [...variantsByHandle.values()].find(
+      (entries) => entries.length > 1,
+    );
+    expect(variants).toBeDefined();
+    const handle = variants?.[0]?.handle ?? "";
+
+    const entries = buildListModelsEntries([{ handle, label: "Native label" }]);
+
+    expect(entries.filter((entry) => entry.handle === handle)).toHaveLength(
+      variants?.length ?? 0,
+    );
+    expect(
+      entries.some(
+        (entry) => entry.id === handle && entry.label === "Native label",
+      ),
+    ).toBe(false);
+  });
+
+  test("projects curated presets onto an equivalent native Pi handle", () => {
+    const presetHandle = "google_ai/gemini-3.5-flash";
+    const nativeModel: AvailableModel = {
+      handle: "google/gemini-3.5-flash",
+      label: "Gemini 3.5 Flash",
+      providerType: "google",
+    };
+    const presets = models.filter((model) => model.handle === presetHandle);
+    expect(presets.length).toBeGreaterThan(0);
+
+    const entries = buildListModelsEntries([nativeModel]);
+    const projected = entries.filter(
+      (entry) => entry.handle === nativeModel.handle,
+    );
+
+    expect(projected.map((entry) => entry.id)).toEqual(
+      presets.map((preset) => preset.id),
+    );
+    expect(projected.map((entry) => entry.updateArgs)).toEqual(
+      presets.map((preset) => preset.updateArgs),
+    );
+    expect(findAvailableModelForPreset(presetHandle, [nativeModel])).toEqual(
+      nativeModel,
+    );
+    const vertexModel: AvailableModel = {
+      handle: "google-vertex/gemini-3.1-pro-preview",
+      label: "Gemini 3.1 Pro",
+    };
+    expect(
+      findAvailableModelForPreset("google_vertex/gemini-3.1-pro-preview", [
+        vertexModel,
+      ]),
+    ).toEqual(vertexModel);
+  });
+
+  test("does not apply another provider's presets to the same model name", () => {
+    const nativeModel: AvailableModel = {
+      handle: "opencode/claude-fable-5",
+      label: "Claude Fable 5 (OpenCode)",
+      providerType: "opencode",
+    };
+
+    const entries = buildListModelsEntries([nativeModel]);
+
+    expect(
+      entries.filter((entry) => entry.handle === nativeModel.handle),
+    ).toEqual([
+      {
+        id: nativeModel.handle,
+        handle: nativeModel.handle,
+        label: nativeModel.label,
+        description: "",
+      },
+    ]);
+  });
+});

--- a/src/websocket/listener/commands/model-catalog.ts
+++ b/src/websocket/listener/commands/model-catalog.ts
@@ -1,0 +1,73 @@
+import type { AvailableModel } from "@/agent/available-models";
+import { models } from "@/agent/model";
+import { resolvePiModelIdentity } from "@/backend/dev/pi-provider-registry";
+import type { ListModelsResponseModelEntry } from "@/types/protocol_v2";
+
+function buildPresetEntry(
+  model: (typeof models)[number],
+): ListModelsResponseModelEntry {
+  return {
+    id: model.id,
+    handle: model.handle,
+    label: model.label,
+    description: model.description,
+    ...(typeof model.isDefault === "boolean"
+      ? { isDefault: model.isDefault }
+      : {}),
+    ...(typeof model.isFeatured === "boolean"
+      ? { isFeatured: model.isFeatured }
+      : {}),
+    ...(typeof model.free === "boolean" ? { free: model.free } : {}),
+    ...(model.updateArgs && typeof model.updateArgs === "object"
+      ? { updateArgs: model.updateArgs as Record<string, unknown> }
+      : {}),
+  };
+}
+
+function buildNativeEntry(model: AvailableModel): ListModelsResponseModelEntry {
+  return {
+    id: model.handle,
+    handle: model.handle,
+    label: model.label,
+    description: "",
+  };
+}
+
+function modelIdentity(handle: string): string {
+  return resolvePiModelIdentity(handle) ?? handle;
+}
+
+export function findAvailableModelForPreset(
+  presetHandle: string,
+  availableModels: readonly AvailableModel[],
+): AvailableModel | undefined {
+  return (
+    availableModels.find((model) => model.handle === presetHandle) ??
+    availableModels.find(
+      (model) => modelIdentity(model.handle) === modelIdentity(presetHandle),
+    )
+  );
+}
+
+export function buildListModelsEntries(
+  availableModels: readonly AvailableModel[] = [],
+): ListModelsResponseModelEntry[] {
+  const presetEntries = models.map((model) => {
+    const entry = buildPresetEntry(model);
+    const availableModel = findAvailableModelForPreset(
+      entry.handle,
+      availableModels,
+    );
+    return availableModel ? { ...entry, handle: availableModel.handle } : entry;
+  });
+  const presetHandles = new Set(presetEntries.map((entry) => entry.handle));
+  const nativeHandles = new Set<string>();
+  const nativeEntries = availableModels.flatMap((model) => {
+    if (nativeHandles.has(model.handle) || presetHandles.has(model.handle)) {
+      return [];
+    }
+    nativeHandles.add(model.handle);
+    return [buildNativeEntry(model)];
+  });
+  return [...presetEntries, ...nativeEntries];
+}

--- a/src/websocket/listener/commands/model-toolset.test.ts
+++ b/src/websocket/listener/commands/model-toolset.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  clearAvailableModelsCache,
+  getAvailableModelHandles,
+} from "@/agent/available-models";
+import { models } from "@/agent/model";
+import type { Backend } from "@/backend";
+import { __testSetBackend } from "@/backend";
+import { FakeHeadlessBackend } from "@/backend/dev/fake-headless-backend";
+import {
+  buildListModelsResponse,
+  resolveModelForUpdate,
+} from "./model-toolset";
+
+class NativeCatalogBackend extends FakeHeadlessBackend {
+  override async listModels(): ReturnType<Backend["listModels"]> {
+    return [
+      {
+        handle: "opencode/deepseek-v4-flash-free",
+        display_name: "DeepSeek V4 Flash Free",
+        max_context_window: 200000,
+        max_tokens: 128000,
+        provider_type: "opencode",
+      },
+      {
+        handle: "google/gemini-3.5-flash",
+        display_name: "Gemini 3.5 Flash",
+        max_context_window: 1000000,
+        max_tokens: 65536,
+        provider_type: "google",
+      },
+    ] as never;
+  }
+}
+
+describe("listener native model selection", () => {
+  afterEach(() => {
+    clearAvailableModelsCache();
+    __testSetBackend(null);
+  });
+
+  test("resolves a backend-native list_models id from the cached catalog", async () => {
+    __testSetBackend(new NativeCatalogBackend());
+    await getAvailableModelHandles();
+
+    expect(
+      resolveModelForUpdate({
+        model_id: "opencode/deepseek-v4-flash-free",
+      }),
+    ).toEqual({
+      id: "opencode/deepseek-v4-flash-free",
+      handle: "opencode/deepseek-v4-flash-free",
+      label: "DeepSeek V4 Flash Free",
+      updateArgs: undefined,
+    });
+  });
+
+  test("includes backend-native rows in the full list_models response", async () => {
+    __testSetBackend(new NativeCatalogBackend());
+
+    const response = await buildListModelsResponse("models-1");
+
+    expect(response.available_handles).toContain(
+      "opencode/deepseek-v4-flash-free",
+    );
+    expect(response.entries).toContainEqual({
+      id: "opencode/deepseek-v4-flash-free",
+      handle: "opencode/deepseek-v4-flash-free",
+      label: "DeepSeek V4 Flash Free",
+      description: "",
+    });
+  });
+
+  test("preserves a native handle id if the availability cache was cleared", () => {
+    expect(
+      resolveModelForUpdate({
+        model_id: "opencode/deepseek-v4-flash-free",
+      }),
+    ).toEqual({
+      id: "opencode/deepseek-v4-flash-free",
+      handle: "opencode/deepseek-v4-flash-free",
+      label: "opencode/deepseek-v4-flash-free",
+      updateArgs: undefined,
+    });
+  });
+
+  test("applies a curated preset to the equivalent native Pi handle", async () => {
+    __testSetBackend(new NativeCatalogBackend());
+    await getAvailableModelHandles();
+    const preset = models.find(
+      (model) => model.handle === "google_ai/gemini-3.5-flash",
+    );
+    expect(preset).toBeDefined();
+
+    const resolved = resolveModelForUpdate({ model_id: preset?.id });
+
+    expect(resolved).toMatchObject({
+      id: preset?.id,
+      handle: "google/gemini-3.5-flash",
+      label: preset?.label,
+      updateArgs: { provider_type: "google" },
+    });
+  });
+});

--- a/src/websocket/listener/commands/model-toolset.ts
+++ b/src/websocket/listener/commands/model-toolset.ts
@@ -1,5 +1,8 @@
 import type WebSocket from "ws";
-import { getAvailableModelHandles } from "@/agent/available-models";
+import {
+  getAvailableModelHandles,
+  getCachedAvailableModels,
+} from "@/agent/available-models";
 import {
   getModelInfo,
   models,
@@ -24,7 +27,6 @@ import {
 import { formatToolsetName } from "@/tools/toolset-labels";
 import type {
   ListModelsResponseMessage,
-  ListModelsResponseModelEntry,
   UpdateModelResponseMessage,
   UpdateToolsetResponseMessage,
 } from "@/types/protocol_v2";
@@ -43,6 +45,10 @@ import type {
   ConversationRuntime,
   ListenerRuntime,
 } from "@/websocket/listener/types";
+import {
+  buildListModelsEntries,
+  findAvailableModelForPreset,
+} from "./model-catalog";
 import type {
   GetOrCreateScopedRuntime,
   RunDetachedListenerTask,
@@ -202,6 +208,7 @@ export function resolveModelForUpdate(payload: {
   model_id?: string;
   model_handle?: string;
 }): ResolvedModelForUpdate | null {
+  const availableModels = getCachedAvailableModels() ?? [];
   if (typeof payload.model_id === "string" && payload.model_id.length > 0) {
     const byId = getModelInfo(payload.model_id);
     if (byId) {
@@ -219,20 +226,41 @@ export function resolveModelForUpdate(payload: {
           ? ({ ...byId.updateArgs } as Record<string, unknown>)
           : undefined;
       const providerType = inferProviderTypeFromRegistryHandle(byId.handle);
+      const availableModel = findAvailableModelForPreset(
+        byId.handle,
+        availableModels,
+      );
       if (
-        explicitHandle &&
+        (explicitHandle || availableModel) &&
         updateArgs &&
-        providerType &&
+        (availableModel?.providerType || providerType) &&
         typeof updateArgs.provider_type !== "string"
       ) {
-        updateArgs.provider_type = providerType;
+        updateArgs.provider_type = availableModel?.providerType ?? providerType;
       }
 
       return {
         id: byId.id,
-        handle: explicitHandle ?? byId.handle,
+        handle: explicitHandle ?? availableModel?.handle ?? byId.handle,
         label: byId.label,
         updateArgs,
+      };
+    }
+
+    const nativeModel = availableModels.find(
+      (model) => model.handle === payload.model_id,
+    );
+    if (nativeModel || payload.model_id.includes("/")) {
+      const explicitHandle =
+        typeof payload.model_handle === "string" &&
+        payload.model_handle.length > 0
+          ? payload.model_handle
+          : null;
+      return {
+        id: payload.model_id,
+        handle: explicitHandle ?? payload.model_id,
+        label: nativeModel?.label ?? payload.model_id,
+        updateArgs: undefined,
       };
     }
   }
@@ -255,10 +283,13 @@ export function resolveModelForUpdate(payload: {
       };
     }
 
+    const nativeModel = availableModels.find(
+      (model) => model.handle === payload.model_handle,
+    );
     return {
       id: payload.model_handle,
       handle: payload.model_handle,
-      label: payload.model_handle,
+      label: nativeModel?.label ?? payload.model_handle,
       updateArgs: undefined,
     };
   }
@@ -572,25 +603,6 @@ export async function applyToolsetUpdateForRuntime(params: {
   };
 }
 
-export function buildListModelsEntries(): ListModelsResponseModelEntry[] {
-  return models.map((model) => ({
-    id: model.id,
-    handle: model.handle,
-    label: model.label,
-    description: model.description,
-    ...(typeof model.isDefault === "boolean"
-      ? { isDefault: model.isDefault }
-      : {}),
-    ...(typeof model.isFeatured === "boolean"
-      ? { isFeatured: model.isFeatured }
-      : {}),
-    ...(typeof model.free === "boolean" ? { free: model.free } : {}),
-    ...(model.updateArgs && typeof model.updateArgs === "object"
-      ? { updateArgs: model.updateArgs as Record<string, unknown> }
-      : {}),
-  }));
-}
-
 /**
  * Build the full list_models_response payload, including availability data.
  * Fetches available handles and BYOK provider aliases in parallel (best-effort).
@@ -599,8 +611,6 @@ export async function buildListModelsResponse(
   requestId: string,
   options: { forceRefresh?: boolean } = {},
 ): Promise<ListModelsResponseMessage> {
-  const entries = buildListModelsEntries();
-
   const [handlesResult, providersResult] = await Promise.allSettled([
     // User-initiated refreshes bypass the availability cache: within the
     // cache TTL a stale snapshot would otherwise make every "Refresh model
@@ -615,6 +625,9 @@ export async function buildListModelsResponse(
     handlesResult.status === "fulfilled"
       ? [...handlesResult.value.handles]
       : null;
+  const entries = buildListModelsEntries(
+    handlesResult.status === "fulfilled" ? handlesResult.value.models : [],
+  );
 
   // listProviders already degrades to [] on failure, but handle rejection too
   const providers =


### PR DESCRIPTION
## Summary

- preserve model handles already resolvable by the Pi catalog or a registered provider mod before consulting legacy endpoint metadata
- carry backend model descriptors through the availability cache and include models absent from `models.json` in `list_models`
- treat `models.json` as an ordered preset overlay, including provider-alias projection and multiple reasoning/context variants
- keep native handles selectable by `model_id` and preserve native display/context/output metadata
- move the affected catalog test out of the oversized local backend test file and ratchet its size baseline down

## Why

A valid Pi-only model could arrive with stale legacy `provider_type: openai` metadata. Local normalization then rewrote the canonical handle into an invalid nested OpenAI handle before Pi resolved it.

The listing path had the same architectural inversion: the backend inventory and curated preset catalog were returned as separate truths, so a model absent from `models.json` could be runnable but impossible to select. This makes the backend catalog authoritative for availability while retaining `models.json` labels, ordering, featured state, and recommended settings where a matching preset exists.

Provider aliases are matched by canonical Pi provider plus model ID, never by basename, so presets project across equivalent handles without leaking settings between providers.

## Validation

- `bun run check` - 12/12 checks passed
- focused local catalog, normalization, availability, and listener tests - 38 passed
- broader model/listener protocol suites - 188 passed
- full `bun test` run - 5,061 passed, 23 skipped; 10 environment-sensitive startup/app-server failures from persisted local state and an installed legacy mod, outside this diff

Linear: https://linear.app/letta/issue/LET-9598/fix-local-model-listing

## Follow-up

This fixes catalog ownership and selection without expanding `models.json` into a Pi mirror. Migrating the remaining Pi streaming/auth calls from the compatibility import surface to a single native model collection can remain a separate mechanical follow-up.