### PR TITLE
fix(memfs): never gpg-sign harness git commits in memory repos

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -1,6 +1,6 @@
 {
   "src/agent/client-skills.test.ts": 1196,
-  "src/agent/memory-git.ts": 2324,
+  "src/agent/memory-git.ts": 2129,
   "src/backend/local-backend.test.ts": 2589,
   "src/backend/local/local-backend.ts": 1058,
   "src/backend/local/local-store.ts": 3618,

--- a/src/agent/memory-git-hooks.ts
+++ b/src/agent/memory-git-hooks.ts
@@ -1,0 +1,231 @@
+/**
+ * Git hook scripts installed into memfs memory repos.
+ *
+ * The pre-commit hook validates memory markdown frontmatter; the post-commit
+ * hook mirrors commits to an optional user-configured memory-repository
+ * remote. Both are (re)installed by the CLI harness on clone/pull/init —
+ * see memory-git.ts.
+ */
+
+import { chmodSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { debugLog } from "@/utils/debug";
+
+/**
+ * Bash pre-commit hook that validates frontmatter in memory .md files.
+ *
+ * Rules:
+ * - Frontmatter is REQUIRED (must start with ---)
+ * - Must be properly closed with ---
+ * - Required fields: description (non-empty string)
+ * - read_only is a PROTECTED field: agent cannot add, remove, or change it.
+ *   Files where HEAD has read_only: true cannot be modified at all.
+ * - Only allowed agent-editable key: description
+ * - Legacy key 'limit' is tolerated for backward compatibility
+ * - read_only may exist (from server) but agent must not change it
+ */
+export const PRE_COMMIT_HOOK_SCRIPT = `#!/usr/bin/env bash
+# Validate frontmatter in staged memory .md files
+# Installed by Letta Code CLI
+
+AGENT_EDITABLE_KEYS="description"
+PROTECTED_KEYS="read_only"
+ALL_KNOWN_KEYS="description read_only limit"
+errors=""
+
+# Skills must always be directories: skills/<name>/SKILL.md
+# Reject legacy flat skill files (both current and legacy repo layouts).
+for file in $(git diff --cached --name-only --diff-filter=ACMR | grep -E '^(memory/)?skills/[^/]+\\.md$' || true); do
+  errors="$errors\\n  $file: invalid skill path (skills must be folders). Use skills/<name>/SKILL.md"
+done
+
+# Helper: extract a frontmatter value from content
+get_fm_value() {
+  local content="$1" key="$2"
+  local closing_line
+  closing_line=$(echo "$content" | tail -n +2 | grep -n '^---$' | head -1 | cut -d: -f1)
+  [ -z "$closing_line" ] && return
+  echo "$content" | tail -n +2 | head -n $((closing_line - 1)) | grep "^$key:" | cut -d: -f2- | sed 's/^ *//;s/ *$//'
+}
+
+# Match .md files under system/ or reference/ (with optional memory/ prefix).
+# Skip skill SKILL.md files — they use a different frontmatter format.
+for file in $(git diff --cached --name-only --diff-filter=ACM | grep -E '^(memory/)?(system|reference)/.*\\.md$'); do
+  staged=$(git show ":$file")
+
+  # Frontmatter is required
+  first_line=$(echo "$staged" | head -1)
+  if [ "$first_line" != "---" ]; then
+    errors="$errors\\n  $file: missing frontmatter (must start with ---)"
+    continue
+  fi
+
+  # Check frontmatter is properly closed
+  closing_line=$(echo "$staged" | tail -n +2 | grep -n '^---$' | head -1 | cut -d: -f1)
+  if [ -z "$closing_line" ]; then
+    errors="$errors\\n  $file: frontmatter opened but never closed (missing closing ---)"
+    continue
+  fi
+
+  # Check read_only protection against HEAD version
+  head_content=$(git show "HEAD:$file" 2>/dev/null || true)
+  if [ -n "$head_content" ]; then
+    head_ro=$(get_fm_value "$head_content" "read_only")
+    if [ "$head_ro" = "true" ]; then
+      errors="$errors\\n  $file: file is read_only and cannot be modified"
+      continue
+    fi
+  fi
+
+  # Extract frontmatter lines
+  frontmatter=$(echo "$staged" | tail -n +2 | head -n $((closing_line - 1)))
+
+  # Track required fields
+  has_description=false
+
+  # Validate each line
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    # Skip YAML multiline continuation lines (indented lines that continue a previous value)
+    case "$line" in
+      " "*|$'\t'*) continue ;;
+    esac
+
+    key=$(echo "$line" | cut -d: -f1 | tr -d ' ')
+    value=$(echo "$line" | cut -d: -f2- | sed 's/^ *//;s/ *$//')
+
+    # Check key is known
+    known=false
+    for k in $ALL_KNOWN_KEYS; do
+      if [ "$key" = "$k" ]; then
+        known=true
+        break
+      fi
+    done
+    if [ "$known" = "false" ]; then
+      errors="$errors\\n  $file: unknown frontmatter key '$key' (allowed: $ALL_KNOWN_KEYS)"
+      continue
+    fi
+
+    # Check if agent is trying to modify a protected key
+    for k in $PROTECTED_KEYS; do
+      if [ "$key" = "$k" ]; then
+        # Compare against HEAD — if value changed (or key was added), reject
+        if [ -n "$head_content" ]; then
+          head_val=$(get_fm_value "$head_content" "$key")
+          if [ "$value" != "$head_val" ]; then
+            errors="$errors\\n  $file: '$key' is a protected field and cannot be changed by the agent"
+          fi
+        else
+          # New file with read_only — agent shouldn't set this
+          errors="$errors\\n  $file: '$key' is a protected field and cannot be set by the agent"
+        fi
+      fi
+    done
+
+    # Validate value types
+    case "$key" in
+      limit)
+        # Legacy field accepted for backward compatibility.
+        ;;
+      description)
+        has_description=true
+        if [ -z "$value" ]; then
+          errors="$errors\\n  $file: 'description' must not be empty"
+        fi
+        ;;
+    esac
+  done <<< "$frontmatter"
+
+  # Check required fields
+  if [ "$has_description" = "false" ]; then
+    errors="$errors\\n  $file: missing required field 'description'"
+  fi
+
+  # Check if protected keys were removed (existed in HEAD but not in staged)
+  if [ -n "$head_content" ]; then
+    for k in $PROTECTED_KEYS; do
+      head_val=$(get_fm_value "$head_content" "$k")
+      if [ -n "$head_val" ]; then
+        staged_val=$(get_fm_value "$staged" "$k")
+        if [ -z "$staged_val" ]; then
+          errors="$errors\\n  $file: '$k' is a protected field and cannot be removed by the agent"
+        fi
+      fi
+    done
+  fi
+done
+
+if [ -n "$errors" ]; then
+  echo "Frontmatter validation failed:"
+  echo -e "$errors"
+  exit 1
+fi
+`;
+
+/**
+ * Install the pre-commit hook for frontmatter validation.
+ */
+export function installPreCommitHook(dir: string): void {
+  const hooksDir = join(dir, ".git", "hooks");
+  const hookPath = join(hooksDir, "pre-commit");
+
+  if (!existsSync(hooksDir)) {
+    mkdirSync(hooksDir, { recursive: true });
+  }
+
+  writeFileSync(hookPath, PRE_COMMIT_HOOK_SCRIPT, "utf-8");
+  chmodSync(hookPath, 0o755);
+  debugLog("memfs-git", "Installed pre-commit hook");
+}
+
+/**
+ * Bash post-commit hook that pushes memfs commits to an optional additional
+ * git remote (the "memory repository" endpoint).
+ *
+ * Reads the remote URL from the repo's local git config
+ * (`letta.memoryRepository.url`). No-op when the key is unset. Push runs
+ * asynchronously in the background so commits stay fast, and failures are
+ * logged to `.git/memory-repository-push.log` without blocking the user.
+ *
+ * URL is per-repo by design: each agent's memfs repo has its own `.git/config`,
+ * so the endpoint is scoped to a single agent automatically.
+ */
+export const POST_COMMIT_HOOK_SCRIPT = `#!/usr/bin/env bash
+# Letta Code: push memfs commits to the configured memory-repository remote.
+# Installed by Letta Code CLI. Do not edit by hand — regenerated on startup.
+url=$(git config --local --get letta.memoryRepository.url 2>/dev/null)
+[ -z "$url" ] && exit 0
+branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null) || exit 0
+[ -z "$branch" ] && exit 0
+# Reflection and other harness worktrees commit on temporary branches; only the
+# main MemFS checkout should push to the optional memory repository remote.
+[ "$branch" != "main" ] && exit 0
+log="$(git rev-parse --git-dir)/memory-repository-push.log"
+(
+  {
+    printf '\\n--- %s %s on %s ---\\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$(git rev-parse --short HEAD)" "$branch"
+    git push --quiet "$url" "$branch":"$branch" 2>&1
+    echo "exit=$?"
+  } >> "$log" 2>&1
+) &
+disown 2>/dev/null || true
+exit 0
+`;
+
+/**
+ * Install the post-commit hook that pushes to `letta.memoryRepository.url`.
+ * Hook is harmless when the config key is unset (no-ops on every commit).
+ */
+export function installPostCommitHook(dir: string): void {
+  const hooksDir = join(dir, ".git", "hooks");
+  const hookPath = join(hooksDir, "post-commit");
+
+  if (!existsSync(hooksDir)) {
+    mkdirSync(hooksDir, { recursive: true });
+  }
+
+  writeFileSync(hookPath, POST_COMMIT_HOOK_SCRIPT, "utf-8");
+  chmodSync(hookPath, 0o755);
+  debugLog("memfs-git", "Installed post-commit memory-repository hook");
+}

--- a/src/agent/memory-git-signing.ts
+++ b/src/agent/memory-git-signing.ts
@@ -1,0 +1,16 @@
+/**
+ * Memory-repo commits must never be signed.
+ *
+ * Operators with a global `commit.gpgsign=true` have no signing key for the
+ * harness-managed committer identities (`<agentId>@letta.com`,
+ * `noreply@letta.com`), so any signing attempt fails with
+ * "gpg: signing failed: No secret key" and blocks memory init/commits,
+ * reflection merges, and `pull --rebase` recovery.
+ *
+ * Passed as highest-precedence `-c` config on every harness git invocation
+ * so it also covers commits git creates internally (rebase, merge).
+ */
+export const GIT_DISABLE_COMMIT_SIGNING_ARGS = [
+  "-c",
+  "commit.gpgsign=false",
+] as const;

--- a/src/agent/memory-git.postcommit.test.ts
+++ b/src/agent/memory-git.postcommit.test.ts
@@ -27,7 +27,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { POST_COMMIT_HOOK_SCRIPT } from "@/agent/memory-git";
+import { POST_COMMIT_HOOK_SCRIPT } from "@/agent/memory-git-hooks";
 
 let sourceDir: string;
 let remoteDir: string;

--- a/src/agent/memory-git.precommit.test.ts
+++ b/src/agent/memory-git.precommit.test.ts
@@ -12,7 +12,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { PRE_COMMIT_HOOK_SCRIPT } from "@/agent/memory-git";
+import { PRE_COMMIT_HOOK_SCRIPT } from "@/agent/memory-git-hooks";
 
 let tempDir: string;
 

--- a/src/agent/memory-git.signing.test.ts
+++ b/src/agent/memory-git.signing.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  commitMemoryWrite,
+  getMemoryHeadRevision,
+  initializeLocalMemoryRepo,
+} from "@/agent/memory-git";
+import {
+  createReflectionMemoryWorktree,
+  finalizeReflectionMemoryWorktree,
+} from "@/agent/memory-worktree";
+
+/**
+ * Regression tests for operator machines with commit signing enabled
+ * globally (`commit.gpgsign=true`). The agent's committer identity
+ * (`<agentId>@letta.com`) has no signing key, so any signing attempt fails
+ * with "gpg: signing failed: No secret key" and blocked memory init:
+ *
+ *   Command failed: git -c user.name=Tutor -c user.email=agent-local-...@letta.com
+ *     commit --allow-empty -m chore: initialize empty local memory
+ *   error: gpg failed to sign the data
+ *
+ * The suite points GIT_CONFIG_GLOBAL at a config that demands signing with
+ * a nonexistent gpg binary, so any signing attempt fails loudly.
+ */
+
+const AGENT_ID = "agent-local-signing-test";
+
+let tempDir: string;
+let originalGitConfigGlobal: string | undefined;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "memory-git-signing-"));
+  const globalConfigPath = join(tempDir, "gitconfig");
+  writeFileSync(
+    globalConfigPath,
+    [
+      "[commit]",
+      "\tgpgsign = true",
+      "[gpg]",
+      `\tprogram = ${join(tempDir, "nonexistent-gpg").replace(/\\/g, "/")}`,
+      "[user]",
+      "\tname = Human Operator",
+      "\temail = human@example.com",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  originalGitConfigGlobal = process.env.GIT_CONFIG_GLOBAL;
+  process.env.GIT_CONFIG_GLOBAL = globalConfigPath;
+});
+
+afterEach(() => {
+  if (originalGitConfigGlobal === undefined) {
+    delete process.env.GIT_CONFIG_GLOBAL;
+  } else {
+    process.env.GIT_CONFIG_GLOBAL = originalGitConfigGlobal;
+  }
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+/** Test-setup git runner: disables signing explicitly for seed commits. */
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", ["-c", "commit.gpgsign=false", ...args], {
+    cwd,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "test",
+      GIT_AUTHOR_EMAIL: "test@test.com",
+      GIT_COMMITTER_NAME: "test",
+      GIT_COMMITTER_EMAIL: "test@test.com",
+    },
+  });
+}
+
+const PERSONA_FILE = {
+  relativePath: "system/persona.md",
+  content: "---\ndescription: Agent persona\n---\nI am a test agent.\n",
+};
+
+describe("memory git commit signing", () => {
+  test("initializeLocalMemoryRepo creates the empty init commit when global config demands signing", async () => {
+    const memoryDir = join(tempDir, "memory-empty");
+
+    await initializeLocalMemoryRepo({
+      memoryDir,
+      agentId: AGENT_ID,
+      authorName: "Tutor",
+      files: [],
+    });
+
+    const head = await getMemoryHeadRevision(memoryDir);
+    expect(head).not.toBeNull();
+    const subject = git(memoryDir, ["log", "-1", "--pretty=%s"]).trim();
+    expect(subject).toBe("chore: initialize empty local memory");
+    // Repo-local default keeps direct `git commit` runs unsigned too.
+    const localGpgSign = git(memoryDir, [
+      "config",
+      "--local",
+      "--get",
+      "commit.gpgsign",
+    ]).trim();
+    expect(localGpgSign).toBe("false");
+  });
+
+  test("initializeLocalMemoryRepo commits seeded memory files when global config demands signing", async () => {
+    const memoryDir = join(tempDir, "memory-seeded");
+
+    await initializeLocalMemoryRepo({
+      memoryDir,
+      agentId: AGENT_ID,
+      authorName: "Tutor",
+      files: [PERSONA_FILE],
+    });
+
+    expect(existsSync(join(memoryDir, "system", "persona.md"))).toBe(true);
+    const subject = git(memoryDir, ["log", "-1", "--pretty=%s"]).trim();
+    expect(subject).toBe("chore: initialize local memory");
+    const author = git(memoryDir, ["log", "-1", "--pretty=%an <%ae>"]).trim();
+    expect(author).toBe(`Tutor <${AGENT_ID}@letta.com>`);
+  });
+
+  test("commitMemoryWrite (local sync mode) commits when global config demands signing", async () => {
+    const memoryDir = join(tempDir, "memory-write");
+    await initializeLocalMemoryRepo({
+      memoryDir,
+      agentId: AGENT_ID,
+      authorName: "Tutor",
+      files: [PERSONA_FILE],
+    });
+
+    writeFileSync(
+      join(memoryDir, "system", "persona.md"),
+      "---\ndescription: Agent persona\n---\nI am an updated test agent.\n",
+      "utf-8",
+    );
+
+    const result = await commitMemoryWrite({
+      memoryDir,
+      pathspecs: ["system/persona.md"],
+      reason: "Update persona",
+      author: {
+        agentId: AGENT_ID,
+        authorName: "Tutor",
+        authorEmail: `${AGENT_ID}@letta.com`,
+      },
+      syncMode: "local",
+    });
+
+    expect(result.committed).toBe(true);
+    expect(result.sha).toBeDefined();
+  });
+
+  test("an explicit local commit.gpgsign override is preserved, and harness commits still succeed", async () => {
+    const memoryDir = join(tempDir, "memory-override");
+    await initializeLocalMemoryRepo({
+      memoryDir,
+      agentId: AGENT_ID,
+      authorName: "Tutor",
+      files: [PERSONA_FILE],
+    });
+
+    git(memoryDir, ["config", "--local", "commit.gpgsign", "true"]);
+
+    writeFileSync(
+      join(memoryDir, "system", "persona.md"),
+      "---\ndescription: Agent persona\n---\nOverride round trip.\n",
+      "utf-8",
+    );
+    const result = await commitMemoryWrite({
+      memoryDir,
+      pathspecs: ["system/persona.md"],
+      reason: "Update persona with local override set",
+      author: {
+        agentId: AGENT_ID,
+        authorName: "Tutor",
+        authorEmail: `${AGENT_ID}@letta.com`,
+      },
+      syncMode: "local",
+    });
+
+    expect(result.committed).toBe(true);
+    // Deliberate operator override is respected (set-if-unset semantics).
+    const localGpgSign = git(memoryDir, [
+      "config",
+      "--local",
+      "--get",
+      "commit.gpgsign",
+    ]).trim();
+    expect(localGpgSign).toBe("true");
+  });
+
+  test("reflection worktree merge commits succeed when global config demands signing", async () => {
+    // Plain repo without harness-managed local config, so the merge result
+    // pins memory-worktree's own signing opt-out rather than repo config.
+    const memoryDir = join(tempDir, "agent", "memory");
+    git(tempDir, ["init", "-b", "main", memoryDir]);
+    writeFileSync(join(memoryDir, "persona.md"), "base\n", "utf-8");
+    git(memoryDir, ["add", "persona.md"]);
+    git(memoryDir, ["commit", "-m", "init"]);
+
+    const worktree = await createReflectionMemoryWorktree({
+      parentMemoryDir: memoryDir,
+    });
+
+    writeFileSync(
+      join(worktree.worktreeDir, "persona.md"),
+      "base\nreflection change\n",
+      "utf-8",
+    );
+    git(worktree.worktreeDir, ["add", "persona.md"]);
+    git(worktree.worktreeDir, ["commit", "-m", "chore: reflection update"]);
+
+    // Advance the parent so the merge is a true merge commit (the case
+    // where git attempts to sign).
+    writeFileSync(join(memoryDir, "notes.md"), "parent change\n", "utf-8");
+    git(memoryDir, ["add", "notes.md"]);
+    git(memoryDir, ["commit", "-m", "parent update"]);
+
+    const result = await finalizeReflectionMemoryWorktree(worktree, {
+      shouldMerge: true,
+    });
+
+    expect(result.status).toBe("merged");
+    expect(result.commitCount).toBe(1);
+  });
+});

--- a/src/agent/memory-git.ts
+++ b/src/agent/memory-git.ts
@@ -13,7 +13,6 @@
 
 import { execFile as execFileCb } from "node:child_process";
 import {
-  chmodSync,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -34,6 +33,11 @@ import { debugLog, debugWarn } from "@/utils/debug";
 import { getUtf16Bom } from "@/utils/text-files";
 import { GIT_MEMORY_ENABLED_TAG } from "./agent-tags";
 import { getScopedMemoryFilesystemRoot } from "./memory-filesystem";
+import {
+  installPostCommitHook,
+  installPreCommitHook,
+} from "./memory-git-hooks";
+import { GIT_DISABLE_COMMIT_SIGNING_ARGS } from "./memory-git-signing";
 
 const execFile = promisify(execFileCb);
 
@@ -576,7 +580,12 @@ async function runGit(
   options?: { timeoutMs?: number },
 ): Promise<{ stdout: string; stderr: string }> {
   const authArgs = token ? buildGitAuthArgs(token) : [];
-  const allArgs = [...buildMemfsGitProxyArgs(args), ...authArgs, ...args];
+  const allArgs = [
+    ...GIT_DISABLE_COMMIT_SIGNING_ARGS,
+    ...buildMemfsGitProxyArgs(args),
+    ...authArgs,
+    ...args,
+  ];
 
   // Redact credential helper values to avoid leaking tokens in debug logs.
   let loggableArgs = args;
@@ -778,225 +787,6 @@ async function clearLocalCredentialHelper(
 }
 
 /**
- * Bash pre-commit hook that validates frontmatter in memory .md files.
- *
- * Rules:
- * - Frontmatter is REQUIRED (must start with ---)
- * - Must be properly closed with ---
- * - Required fields: description (non-empty string)
- * - read_only is a PROTECTED field: agent cannot add, remove, or change it.
- *   Files where HEAD has read_only: true cannot be modified at all.
- * - Only allowed agent-editable key: description
- * - Legacy key 'limit' is tolerated for backward compatibility
- * - read_only may exist (from server) but agent must not change it
- */
-export const PRE_COMMIT_HOOK_SCRIPT = `#!/usr/bin/env bash
-# Validate frontmatter in staged memory .md files
-# Installed by Letta Code CLI
-
-AGENT_EDITABLE_KEYS="description"
-PROTECTED_KEYS="read_only"
-ALL_KNOWN_KEYS="description read_only limit"
-errors=""
-
-# Skills must always be directories: skills/<name>/SKILL.md
-# Reject legacy flat skill files (both current and legacy repo layouts).
-for file in $(git diff --cached --name-only --diff-filter=ACMR | grep -E '^(memory/)?skills/[^/]+\\.md$' || true); do
-  errors="$errors\\n  $file: invalid skill path (skills must be folders). Use skills/<name>/SKILL.md"
-done
-
-# Helper: extract a frontmatter value from content
-get_fm_value() {
-  local content="$1" key="$2"
-  local closing_line
-  closing_line=$(echo "$content" | tail -n +2 | grep -n '^---$' | head -1 | cut -d: -f1)
-  [ -z "$closing_line" ] && return
-  echo "$content" | tail -n +2 | head -n $((closing_line - 1)) | grep "^$key:" | cut -d: -f2- | sed 's/^ *//;s/ *$//'
-}
-
-# Match .md files under system/ or reference/ (with optional memory/ prefix).
-# Skip skill SKILL.md files — they use a different frontmatter format.
-for file in $(git diff --cached --name-only --diff-filter=ACM | grep -E '^(memory/)?(system|reference)/.*\\.md$'); do
-  staged=$(git show ":$file")
-
-  # Frontmatter is required
-  first_line=$(echo "$staged" | head -1)
-  if [ "$first_line" != "---" ]; then
-    errors="$errors\\n  $file: missing frontmatter (must start with ---)"
-    continue
-  fi
-
-  # Check frontmatter is properly closed
-  closing_line=$(echo "$staged" | tail -n +2 | grep -n '^---$' | head -1 | cut -d: -f1)
-  if [ -z "$closing_line" ]; then
-    errors="$errors\\n  $file: frontmatter opened but never closed (missing closing ---)"
-    continue
-  fi
-
-  # Check read_only protection against HEAD version
-  head_content=$(git show "HEAD:$file" 2>/dev/null || true)
-  if [ -n "$head_content" ]; then
-    head_ro=$(get_fm_value "$head_content" "read_only")
-    if [ "$head_ro" = "true" ]; then
-      errors="$errors\\n  $file: file is read_only and cannot be modified"
-      continue
-    fi
-  fi
-
-  # Extract frontmatter lines
-  frontmatter=$(echo "$staged" | tail -n +2 | head -n $((closing_line - 1)))
-
-  # Track required fields
-  has_description=false
-
-  # Validate each line
-  while IFS= read -r line; do
-    [ -z "$line" ] && continue
-    # Skip YAML multiline continuation lines (indented lines that continue a previous value)
-    case "$line" in
-      " "*|$'\t'*) continue ;;
-    esac
-
-    key=$(echo "$line" | cut -d: -f1 | tr -d ' ')
-    value=$(echo "$line" | cut -d: -f2- | sed 's/^ *//;s/ *$//')
-
-    # Check key is known
-    known=false
-    for k in $ALL_KNOWN_KEYS; do
-      if [ "$key" = "$k" ]; then
-        known=true
-        break
-      fi
-    done
-    if [ "$known" = "false" ]; then
-      errors="$errors\\n  $file: unknown frontmatter key '$key' (allowed: $ALL_KNOWN_KEYS)"
-      continue
-    fi
-
-    # Check if agent is trying to modify a protected key
-    for k in $PROTECTED_KEYS; do
-      if [ "$key" = "$k" ]; then
-        # Compare against HEAD — if value changed (or key was added), reject
-        if [ -n "$head_content" ]; then
-          head_val=$(get_fm_value "$head_content" "$key")
-          if [ "$value" != "$head_val" ]; then
-            errors="$errors\\n  $file: '$key' is a protected field and cannot be changed by the agent"
-          fi
-        else
-          # New file with read_only — agent shouldn't set this
-          errors="$errors\\n  $file: '$key' is a protected field and cannot be set by the agent"
-        fi
-      fi
-    done
-
-    # Validate value types
-    case "$key" in
-      limit)
-        # Legacy field accepted for backward compatibility.
-        ;;
-      description)
-        has_description=true
-        if [ -z "$value" ]; then
-          errors="$errors\\n  $file: 'description' must not be empty"
-        fi
-        ;;
-    esac
-  done <<< "$frontmatter"
-
-  # Check required fields
-  if [ "$has_description" = "false" ]; then
-    errors="$errors\\n  $file: missing required field 'description'"
-  fi
-
-  # Check if protected keys were removed (existed in HEAD but not in staged)
-  if [ -n "$head_content" ]; then
-    for k in $PROTECTED_KEYS; do
-      head_val=$(get_fm_value "$head_content" "$k")
-      if [ -n "$head_val" ]; then
-        staged_val=$(get_fm_value "$staged" "$k")
-        if [ -z "$staged_val" ]; then
-          errors="$errors\\n  $file: '$k' is a protected field and cannot be removed by the agent"
-        fi
-      fi
-    done
-  fi
-done
-
-if [ -n "$errors" ]; then
-  echo "Frontmatter validation failed:"
-  echo -e "$errors"
-  exit 1
-fi
-`;
-
-/**
- * Install the pre-commit hook for frontmatter validation.
- */
-function installPreCommitHook(dir: string): void {
-  const hooksDir = join(dir, ".git", "hooks");
-  const hookPath = join(hooksDir, "pre-commit");
-
-  if (!existsSync(hooksDir)) {
-    mkdirSync(hooksDir, { recursive: true });
-  }
-
-  writeFileSync(hookPath, PRE_COMMIT_HOOK_SCRIPT, "utf-8");
-  chmodSync(hookPath, 0o755);
-  debugLog("memfs-git", "Installed pre-commit hook");
-}
-
-/**
- * Bash post-commit hook that pushes memfs commits to an optional additional
- * git remote (the "memory repository" endpoint).
- *
- * Reads the remote URL from the repo's local git config
- * (`letta.memoryRepository.url`). No-op when the key is unset. Push runs
- * asynchronously in the background so commits stay fast, and failures are
- * logged to `.git/memory-repository-push.log` without blocking the user.
- *
- * URL is per-repo by design: each agent's memfs repo has its own `.git/config`,
- * so the endpoint is scoped to a single agent automatically.
- */
-export const POST_COMMIT_HOOK_SCRIPT = `#!/usr/bin/env bash
-# Letta Code: push memfs commits to the configured memory-repository remote.
-# Installed by Letta Code CLI. Do not edit by hand — regenerated on startup.
-url=$(git config --local --get letta.memoryRepository.url 2>/dev/null)
-[ -z "$url" ] && exit 0
-branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null) || exit 0
-[ -z "$branch" ] && exit 0
-# Reflection and other harness worktrees commit on temporary branches; only the
-# main MemFS checkout should push to the optional memory repository remote.
-[ "$branch" != "main" ] && exit 0
-log="$(git rev-parse --git-dir)/memory-repository-push.log"
-(
-  {
-    printf '\\n--- %s %s on %s ---\\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$(git rev-parse --short HEAD)" "$branch"
-    git push --quiet "$url" "$branch":"$branch" 2>&1
-    echo "exit=$?"
-  } >> "$log" 2>&1
-) &
-disown 2>/dev/null || true
-exit 0
-`;
-
-/**
- * Install the post-commit hook that pushes to `letta.memoryRepository.url`.
- * Hook is harmless when the config key is unset (no-ops on every commit).
- */
-function installPostCommitHook(dir: string): void {
-  const hooksDir = join(dir, ".git", "hooks");
-  const hookPath = join(hooksDir, "post-commit");
-
-  if (!existsSync(hooksDir)) {
-    mkdirSync(hooksDir, { recursive: true });
-  }
-
-  writeFileSync(hookPath, POST_COMMIT_HOOK_SCRIPT, "utf-8");
-  chmodSync(hookPath, 0o755);
-  debugLog("memfs-git", "Installed post-commit memory-repository hook");
-}
-
-/**
  * Read a local-scoped git config value. Returns null when the key is unset.
  */
 async function getLocalGitConfig(
@@ -1109,6 +899,15 @@ export async function ensureLocalMemfsGitConfig(
         (await fetchAgentDisplayName(agentId)) ?? "Letta Agent";
       await setLocalGitConfig(dir, "user.name", displayName);
     }
+
+    // Default commit signing off (only when unset locally): the agent's
+    // committer identity has no signing key, so a global
+    // `commit.gpgsign=true` would break direct `git commit` runs inside
+    // the memory repo with "gpg: signing failed: No secret key".
+    const currentGpgSign = await getLocalGitConfig(dir, "commit.gpgsign");
+    if (currentGpgSign === null) {
+      await setLocalGitConfig(dir, "commit.gpgsign", "false");
+    }
   } catch (err) {
     // Identity config is nice-to-have; never block memfs startup on it.
     debugWarn(
@@ -1124,7 +923,7 @@ export async function ensureLocalMemfsGitConfig(
  * The remote URL lives in each repo's local `.git/config` under
  * `letta.memoryRepository.url`. The post-commit hook reads that key and
  * pushes to it in the background after every commit.
- * See `POST_COMMIT_HOOK_SCRIPT`.
+ * See `POST_COMMIT_HOOK_SCRIPT` in memory-git-hooks.ts.
  * ------------------------------------------------------------------ */
 
 const MEMORY_REPOSITORY_CONFIG_KEY = "letta.memoryRepository.url";
@@ -1385,6 +1184,12 @@ async function prepareLocalOnlyMemoryRepoForGitOps(
     "user.name",
     author.authorName.trim() || "Letta Agent",
   );
+  // Default commit signing off (only when unset locally) so direct
+  // `git commit` runs in the memory repo don't attempt to sign with the
+  // agent's keyless committer identity. See ensureLocalMemfsGitConfig.
+  if ((await getLocalGitConfig(memoryDir, "commit.gpgsign")) === null) {
+    await setLocalGitConfig(memoryDir, "commit.gpgsign", "false");
+  }
 }
 
 async function stageMemoryPaths(

--- a/src/agent/memory-worktree.ts
+++ b/src/agent/memory-worktree.ts
@@ -4,6 +4,7 @@ import { existsSync } from "node:fs";
 import { mkdir, realpath } from "node:fs/promises";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { promisify } from "node:util";
+import { GIT_DISABLE_COMMIT_SIGNING_ARGS } from "@/agent/memory-git-signing";
 import { debugLog } from "@/utils/debug";
 
 const execFile = promisify(execFileCb);
@@ -23,7 +24,8 @@ interface GitResult {
 
 async function runGit(cwd: string, args: string[]): Promise<GitResult> {
   try {
-    const { stdout, stderr } = await execFile("git", args, {
+    const allArgs = [...GIT_DISABLE_COMMIT_SIGNING_ARGS, ...args];
+    const { stdout, stderr } = await execFile("git", allArgs, {
       cwd,
       env: {
         ...process.env,


### PR DESCRIPTION
## Summary

- **Bug:** on machines with a global `commit.gpgsign = true`, every harness-managed memory git commit failed with `gpg: signing failed: No secret key` / `fatal: failed to write commit object`. Git selects the signing key by committer identity, and the harness commits as the agent (`<agentId>@letta.com`, or `noreply@letta.com` for reflection worktrees) — identities that have no secret key on the operator machine. Reported failure (local backend, v0.27.28, Linux):

  ```
  Command failed: git -c user.name=Tutor -c user.email=agent-local-...@letta.com commit --allow-empty -m chore: initialize empty local memory
  error: gpg failed to sign the data ... gpg: signing failed: No secret key
  ```

- **Blast radius** (all the same class): local memory repo initialization (`initializeLocalMemoryRepo`, blocks local-backend agent creation), every `commitMemoryWrite` (memory tool / memory_apply_patch / skills / personality import), commits recreated by `pull --rebase` recovery, and reflection worktree merges — where `tryRunGit` silently misclassified the signing failure as a merge conflict (`pending_conflict`).

- **Fix (critical):** prepend `-c commit.gpgsign=false` to every harness git invocation in `memory-git.ts` and `memory-worktree.ts`, via a shared `GIT_DISABLE_COMMIT_SIGNING_ARGS` in the new `memory-git-signing.ts`. Highest-precedence `-c` config also covers commits git creates internally (rebase, merge). Signing agent-authored commits with the operator's key would be wrong attribution even when a key exists.

- **Fix (complementary):** default repo-local `commit.gpgsign = false` — only when unset — in `ensureLocalMemfsGitConfig` / `prepareLocalOnlyMemoryRepoForGitOps`, so direct `git commit` runs inside the memory repo (the documented agent memory-sync workflow) work too. A deliberate local override is preserved (covered by a test).

- **Size-baseline compliance:** `memory-git.ts` is ratchet-pinned at its baseline, so the pre/post-commit hook scripts + installers moved **verbatim** (diff-verified byte-identical) to `memory-git-hooks.ts`; baseline ratcheted 2324 → 2129. No behavior change in that move.

- **Tests:** new `memory-git.signing.test.ts` simulates the failing machine via `GIT_CONFIG_GLOBAL` (`commit.gpgsign=true` + nonexistent `gpg.program`, so any signing attempt fails loudly). All 5 tests fail without the fix — including the reflection merge reproducing the `pending_conflict` misclassification — and pass with it. Existing memory git/tool suites: failure set byte-identical to the pre-existing local-env baseline (no regressions).

👾 Generated with [Letta Code](https://letta.com)

Linear: LET-9600

## Signing policy caveat

This deliberately makes harness-created commits in Letta-managed memory repositories unsigned, even when the operator's global signing configuration would otherwise work. It does not change global Git configuration, ordinary project repositories, or existing commit signatures. Direct `git commit` commands inside a memory repository default to unsigned only when `commit.gpgsign` is unset locally; an explicit repo-local override is preserved, while harness-created commits remain unsigned.

Consequently, an external memory-repository mirror that requires signed commits may reject these commits or report unsigned history. Proper support for signed MemFS history would require a dedicated harness signing identity and key rather than implicitly using the operator's key for an agent-authored commit.