### PR TITLE
feat(agent-presets): export model presentation presets

### DIFF
--- a/src/agent-presets.ts
+++ b/src/agent-presets.ts
@@ -24,6 +24,10 @@ export {
   LETTA_CODE_AGENT_TYPE,
 } from "./agent/create-agent-request";
 export {
+  MODEL_PRESETS,
+  type ModelPreset,
+} from "./agent/model-catalog";
+export {
   DEFAULT_CREATE_AGENT_PERSONALITIES,
   type DefaultCreateAgentPersonalityId,
   getPersonalityOption,

--- a/src/agent/model-catalog.test.ts
+++ b/src/agent/model-catalog.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { MODEL_PRESETS, type ModelPreset } from "@/agent-presets";
+import { models } from "./model-catalog";
+
+describe("browser-safe model preset export", () => {
+  test("exposes the same curated catalog used by the CLI", () => {
+    expect(MODEL_PRESETS).toBe(models);
+    expect(MODEL_PRESETS.length).toBeGreaterThan(0);
+  });
+
+  test("includes presentation metadata and settings without claiming availability", () => {
+    const preset: ModelPreset | undefined = MODEL_PRESETS.find(
+      (entry) => entry.id === "gpt-5.6-sol-plus-pro-high",
+    );
+
+    expect(preset).toMatchObject({
+      handle: "chatgpt-plus-pro/gpt-5.6-sol",
+      label: "GPT-5.6 Sol (ChatGPT)",
+      isFeatured: true,
+      updateArgs: {
+        reasoning_effort: "high",
+      },
+    });
+    expect("available" in (preset ?? {})).toBe(false);
+  });
+});

--- a/src/agent/model-catalog.ts
+++ b/src/agent/model-catalog.ts
@@ -12,6 +12,35 @@ import modelsData from "@/models.json";
 export const models = modelsData.models;
 
 /**
+ * Browser-safe presentation metadata for a curated Letta Code model preset.
+ *
+ * This is deliberately not an availability contract: connected providers,
+ * local/custom models, and organization-specific hosted inventory remain
+ * runtime concerns. Consumers may use presets for labels, descriptions,
+ * ordering, and known settings while live API/device inventory decides what
+ * is actually selectable.
+ */
+export interface ModelPreset {
+  readonly id: string;
+  readonly handle: string;
+  readonly label: string;
+  readonly description: string;
+  readonly shortLabel?: string;
+  readonly isDefault?: boolean;
+  readonly isFeatured?: boolean;
+  readonly free?: boolean;
+  readonly updateArgs?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Curated model presentation presets bundled with Letta Code.
+ *
+ * Runtime model inventory is authoritative for availability. This export is
+ * a readonly view over the same catalog used by the CLI's model resolver.
+ */
+export const MODEL_PRESETS: readonly ModelPreset[] = models;
+
+/**
  * Resolve a model by ID or handle
  * @param modelIdentifier - Can be either a model ID (e.g., "opus-4.5") or a full handle (e.g., "anthropic/claude-opus-4-5")
  * @returns The model handle if found, null otherwise


### PR DESCRIPTION
## Summary

- expose the curated model preset catalog through the existing browser-safe agent-presets package entry
- provide a stable readonly ModelPreset contract for labels, descriptions, featured state, and known settings
- name and document the export as presentation presets so consumers do not mistake the static catalog for live model availability
- verify the built ESM package exposes the expected ChatGPT preset metadata while preserving the existing agent creation builder
- add focused package-surface tests; bun run check passes all 12 checks

Linear: LET-9606

👾 Generated with [Letta Code](https://letta.com)