### PR TITLE
fix(local): group contiguous reasoning blocks

### DIFF
--- a/src/backend/dev/provider-turn-executor.ts
+++ b/src/backend/dev/provider-turn-executor.ts
@@ -1,12 +1,19 @@
 import { randomUUID } from "node:crypto";
-import type { AssistantMessageEvent, Usage } from "@earendil-works/pi-ai";
+import type {
+  AssistantMessage,
+  AssistantMessageEvent,
+  Usage,
+} from "@earendil-works/pi-ai";
 import type { Stream } from "@letta-ai/letta-client/core/streaming";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import {
   contextTokensFromLocalUsage,
   estimateLocalContextTokens,
 } from "@/backend/local/local-context-estimate";
-import type { LocalMessage } from "@/backend/local/local-message";
+import type {
+  LocalAssistantMessage,
+  LocalMessage,
+} from "@/backend/local/local-message";
 import type {
   LocalAgentRecord,
   StoredMessage,
@@ -266,15 +273,51 @@ function errorFromAssistantEvent(part: AssistantMessageEvent): Error {
   return new Error(part.error.errorMessage ?? "Unknown local provider error");
 }
 
-function otidForContentIndex(
+type StreamedMessageType = "assistant_message" | "reasoning_message";
+
+function contentMatchesMessageType(
+  content: LocalAssistantMessage["content"][number] | undefined,
+  messageType: StreamedMessageType,
+): boolean {
+  if (!content || typeof content !== "object" || !("type" in content)) {
+    return false;
+  }
+  return messageType === "assistant_message"
+    ? content.type === "text"
+    : content.type === "thinking";
+}
+
+function contiguousContentStartIndex(
+  partial: AssistantMessage,
+  contentIndex: number,
+  messageType: StreamedMessageType,
+): number {
+  let startIndex = contentIndex;
+  while (
+    startIndex > 0 &&
+    contentMatchesMessageType(partial.content[startIndex - 1], messageType)
+  ) {
+    startIndex -= 1;
+  }
+  return startIndex;
+}
+
+function otidForContentSegment(
   otids: Map<number, string>,
   prefix: string,
   contentIndex: number,
+  partial: AssistantMessage,
+  messageType: StreamedMessageType,
 ): string {
-  const existing = otids.get(contentIndex);
+  const segmentStartIndex = contiguousContentStartIndex(
+    partial,
+    contentIndex,
+    messageType,
+  );
+  const existing = otids.get(segmentStartIndex);
   if (existing) return existing;
-  const otid = `${prefix}-${contentIndex}-${randomUUID()}`;
-  otids.set(contentIndex, otid);
+  const otid = `${prefix}-${segmentStartIndex}-${randomUUID()}`;
+  otids.set(segmentStartIndex, otid);
   return otid;
 }
 
@@ -312,10 +355,12 @@ function createProviderLettaStream(
           if (part.type === "text_delta") {
             yield {
               message_type: "assistant_message",
-              otid: otidForContentIndex(
+              otid: otidForContentSegment(
                 assistantOtids,
                 "provider-assistant",
                 part.contentIndex,
+                part.partial,
+                "assistant_message",
               ),
               content: [{ type: "text", text: part.delta }],
             } as LettaStreamingResponse;
@@ -325,10 +370,12 @@ function createProviderLettaStream(
           if (part.type === "thinking_delta") {
             yield {
               message_type: "reasoning_message",
-              otid: otidForContentIndex(
+              otid: otidForContentSegment(
                 reasoningOtids,
                 "provider-reasoning",
                 part.contentIndex,
+                part.partial,
+                "reasoning_message",
               ),
               reasoning: part.delta,
             } as LettaStreamingResponse;

--- a/src/backend/local/local-message-projection.test.ts
+++ b/src/backend/local/local-message-projection.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import type { LocalAssistantMessage } from "./local-message";
+import { projectLocalMessageToStoredMessages } from "./local-message-projection";
+
+function assistantMessage(
+  content: LocalAssistantMessage["content"],
+): LocalAssistantMessage {
+  return {
+    id: "ui-msg-1",
+    role: "assistant",
+    content,
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    model: "gpt-5.6-sol",
+    usage: {
+      input: 1,
+      output: 1,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 2,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: 0,
+  };
+}
+
+describe("projectLocalMessageToStoredMessages", () => {
+  test("groups adjacent thinking content into one reasoning message", () => {
+    const message = assistantMessage([
+      {
+        type: "thinking",
+        thinking: "First summary",
+        thinkingSignature: "signature-1",
+      },
+      {
+        type: "thinking",
+        thinking: "Second summary",
+        thinkingSignature: "signature-2",
+      },
+    ]);
+
+    const projected = projectLocalMessageToStoredMessages(
+      message,
+      "agent-1",
+      "conversation-1",
+      "2026-07-12T00:00:00.000Z",
+    );
+
+    expect(projected).toEqual([
+      expect.objectContaining({
+        id: "ui-msg-1:reasoning:0",
+        message_type: "reasoning_message",
+        reasoning: "First summary\n\nSecond summary",
+      }),
+    ]);
+    expect(message.content).toEqual([
+      expect.objectContaining({ thinkingSignature: "signature-1" }),
+      expect.objectContaining({ thinkingSignature: "signature-2" }),
+    ]);
+  });
+
+  test("keeps reasoning groups separated by assistant text", () => {
+    const projected = projectLocalMessageToStoredMessages(
+      assistantMessage([
+        { type: "thinking", thinking: "First thought" },
+        { type: "text", text: "Interleaved answer" },
+        { type: "thinking", thinking: "Second thought" },
+      ]),
+      "agent-1",
+      "conversation-1",
+      "2026-07-12T00:00:00.000Z",
+    );
+
+    expect(projected.map((message) => message.message_type)).toEqual([
+      "reasoning_message",
+      "assistant_message",
+      "reasoning_message",
+    ]);
+    expect(projected.map((message) => message.id)).toEqual([
+      "ui-msg-1:reasoning:0",
+      "ui-msg-1:assistant:1",
+      "ui-msg-1:reasoning:2",
+    ]);
+  });
+});

--- a/src/backend/local/local-message-projection.ts
+++ b/src/backend/local/local-message-projection.ts
@@ -110,20 +110,20 @@ function toolResultToStoredReturnValue(
 
 function projectThinkingContent(
   message: LocalAssistantMessage,
-  content: ThinkingContent,
-  contentIndex: number,
+  reasoning: string,
+  contentStartIndex: number,
   date: string,
   agentId: string,
   conversationId: string,
 ): StoredMessage | undefined {
-  if (content.thinking.length === 0) return undefined;
+  if (reasoning.length === 0) return undefined;
   return {
-    id: `${message.id}:reasoning:${contentIndex}`,
+    id: `${message.id}:reasoning:${contentStartIndex}`,
     date,
     agent_id: agentId,
     conversation_id: conversationId,
     message_type: "reasoning_message",
-    reasoning: content.thinking,
+    reasoning,
   } as StoredMessage;
 }
 
@@ -229,6 +229,8 @@ export function projectLocalMessageToStoredMessages(
   const messages: StoredMessage[] = [];
   let pendingTextContent: unknown[] = [];
   let pendingTextStartIndex = -1;
+  let pendingReasoningContent: string[] = [];
+  let pendingReasoningStartIndex = -1;
 
   const flushPendingText = () => {
     if (pendingTextContent.length === 0) return;
@@ -248,6 +250,22 @@ export function projectLocalMessageToStoredMessages(
     pendingTextStartIndex = -1;
   };
 
+  const flushPendingReasoning = () => {
+    if (pendingReasoningContent.length > 0) {
+      const reasoningMessage = projectThinkingContent(
+        message,
+        pendingReasoningContent.join("\n\n"),
+        pendingReasoningStartIndex,
+        date,
+        agentId,
+        conversationId,
+      );
+      if (reasoningMessage) messages.push(reasoningMessage);
+    }
+    pendingReasoningContent = [];
+    pendingReasoningStartIndex = -1;
+  };
+
   for (
     let contentIndex = 0;
     contentIndex < message.content.length;
@@ -258,20 +276,18 @@ export function projectLocalMessageToStoredMessages(
 
     if (isThinkingContent(content)) {
       flushPendingText();
-      const reasoningMessage = projectThinkingContent(
-        message,
-        content,
-        contentIndex,
-        date,
-        agentId,
-        conversationId,
-      );
-      if (reasoningMessage) messages.push(reasoningMessage);
+      if (content.thinking.length > 0) {
+        if (pendingReasoningStartIndex === -1) {
+          pendingReasoningStartIndex = contentIndex;
+        }
+        pendingReasoningContent.push(content.thinking);
+      }
       continue;
     }
 
     if (isLocalToolCallContent(content)) {
       flushPendingText();
+      flushPendingReasoning();
       messages.push(
         projectToolCallContent(message, content, date, agentId, conversationId),
       );
@@ -279,12 +295,14 @@ export function projectLocalMessageToStoredMessages(
     }
 
     if (isTextContent(content)) {
+      flushPendingReasoning();
       if (pendingTextStartIndex === -1) pendingTextStartIndex = contentIndex;
       pendingTextContent.push({ type: "text", text: content.text });
     }
   }
 
   flushPendingText();
+  flushPendingReasoning();
   return messages;
 }
 

--- a/src/backend/provider-turn-executor.test.ts
+++ b/src/backend/provider-turn-executor.test.ts
@@ -117,10 +117,20 @@ describe("ProviderTurnExecutor", () => {
     ).toBe("requires_approval");
   });
 
-  test("uses pi contentIndex to keep interleaved live blocks separate", async () => {
+  test("groups adjacent live blocks and preserves interleaved boundaries", async () => {
     const adapter: ProviderStreamAdapter = {
       async *stream() {
-        const message = assistantMessage();
+        const message = {
+          ...assistantMessage(),
+          content: [
+            { type: "text" as const, text: "first-a" },
+            { type: "text" as const, text: "first-b" },
+            { type: "thinking" as const, thinking: "think-a" },
+            { type: "thinking" as const, thinking: "think-b" },
+            { type: "text" as const, text: "second" },
+            { type: "thinking" as const, thinking: "think-c" },
+          ],
+        };
         yield providerStreamPart(
           part({
             type: "text_delta",
@@ -132,23 +142,23 @@ describe("ProviderTurnExecutor", () => {
         yield providerStreamPart(
           part({
             type: "text_delta",
-            contentIndex: 2,
-            delta: "second",
-            partial: message,
-          }),
-        );
-        yield providerStreamPart(
-          part({
-            type: "text_delta",
-            contentIndex: 0,
+            contentIndex: 1,
             delta: "first-b",
             partial: message,
           }),
         );
         yield providerStreamPart(
           part({
+            type: "text_delta",
+            contentIndex: 4,
+            delta: "second",
+            partial: message,
+          }),
+        );
+        yield providerStreamPart(
+          part({
             type: "thinking_delta",
-            contentIndex: 1,
+            contentIndex: 2,
             delta: "think-a",
             partial: message,
           }),
@@ -158,6 +168,14 @@ describe("ProviderTurnExecutor", () => {
             type: "thinking_delta",
             contentIndex: 3,
             delta: "think-b",
+            partial: message,
+          }),
+        );
+        yield providerStreamPart(
+          part({
+            type: "thinking_delta",
+            contentIndex: 5,
+            delta: "think-c",
             partial: message,
           }),
         );
@@ -173,13 +191,14 @@ describe("ProviderTurnExecutor", () => {
     const assistantOtids = chunks
       .filter((chunk) => chunk.message_type === "assistant_message")
       .map((chunk) => (chunk as { otid?: string }).otid);
-    expect(assistantOtids[0]).toBe(assistantOtids[2]);
-    expect(assistantOtids[0]).not.toBe(assistantOtids[1]);
+    expect(assistantOtids[0]).toBe(assistantOtids[1]);
+    expect(assistantOtids[0]).not.toBe(assistantOtids[2]);
 
     const reasoningOtids = chunks
       .filter((chunk) => chunk.message_type === "reasoning_message")
       .map((chunk) => (chunk as { otid?: string }).otid);
-    expect(reasoningOtids[0]).not.toBe(reasoningOtids[1]);
+    expect(reasoningOtids[0]).toBe(reasoningOtids[1]);
+    expect(reasoningOtids[0]).not.toBe(reasoningOtids[2]);
   });
 
   test("emits final local assistant messages as state-only chunks before stop_reason", async () => {


### PR DESCRIPTION
## Summary

- group adjacent provider thinking content into one visible reasoning message during local streaming and restored transcript projection
- preserve separate reasoning groups across assistant-text and tool boundaries
- keep canonical provider content and signatures unchanged while matching the established API-backed streaming contract
- add focused live-stream and persisted-projection regression coverage

Related: [LET-9607](https://linear.app/letta/issue/LET-9607/weird-stacked-thinking-issue-on-latest-desktop-build-seems-like-a-bug)

👾 Generated with [Letta Code](https://letta.com)