### PR TITLE
fix: route web links to current surfaces

### DIFF
--- a/src/agent/subagent-retry-parent-scope.test.ts
+++ b/src/agent/subagent-retry-parent-scope.test.ts
@@ -10,7 +10,7 @@ const managerSource = readFileSync(
 describe("executeSubagent provider fallback wiring", () => {
   test("forwards parentAgentIdOverride through the provider retry call", () => {
     const retryCallMatch = managerSource.match(
-      /return executeSubagent\(\s*type,\s*config,\s*primaryModel,\s*userPrompt,\s*baseURL,\s*subagentId,\s*true,\s*\/\/ Mark as retry to prevent infinite loops\s*signal,\s*undefined,\s*\/\/ existingAgentId\s*undefined,\s*\/\/ existingConversationId\s*maxTurns,\s*parentAgentIdOverride,\s*transcriptPath,\s*\);/s,
+      /return executeSubagent\(\s*type,\s*config,\s*primaryModel,\s*userPrompt,\s*subagentId,\s*true,\s*\/\/ Mark as retry to prevent infinite loops\s*signal,\s*undefined,\s*\/\/ existingAgentId\s*undefined,\s*\/\/ existingConversationId\s*maxTurns,\s*parentAgentIdOverride,\s*transcriptPath,\s*\);/s,
     );
 
     expect(retryCallMatch).toBeTruthy();

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -326,7 +326,6 @@ async function executeSubagent(
   config: SubagentConfig,
   model: string | null,
   userPrompt: string,
-  baseURL: string,
   subagentId: string,
   isRetry = false,
   signal?: AbortSignal,
@@ -559,7 +558,6 @@ async function executeSubagent(
             config,
             primaryModel,
             userPrompt,
-            baseURL,
             subagentId,
             true, // Mark as retry to prevent infinite loops
             signal,
@@ -649,25 +647,6 @@ async function executeSubagent(
       error: getErrorMessage(error),
     };
   }
-}
-
-/**
- * Get the base URL for constructing agent links
- */
-function getBaseURL(): string {
-  const settings = settingsManager.getSettings();
-
-  const baseURL =
-    process.env.LETTA_BASE_URL ||
-    settings.env?.LETTA_BASE_URL ||
-    "https://api.letta.com";
-
-  // Convert API URL to web UI URL if using hosted service
-  if (baseURL === "https://api.letta.com") {
-    return "https://app.letta.com";
-  }
-
-  return baseURL;
 }
 
 /**
@@ -814,8 +793,6 @@ export async function spawnSubagent(
         subagentType: type,
         backendMode,
       });
-  const baseURL = getBaseURL();
-
   // Build the prompt with system reminder for deployed agents
   let finalPrompt = prompt;
   if (isDeployingExisting && resolvedParentAgentId) {
@@ -857,7 +834,6 @@ export async function spawnSubagent(
     config,
     model,
     finalPrompt,
-    baseURL,
     subagentId,
     false,
     signal,

--- a/src/channels/commands.test.ts
+++ b/src/channels/commands.test.ts
@@ -269,7 +269,7 @@ describe("channel slash commands", () => {
       buildChannelChatLinkMessage(
         "slack",
         route,
-        "https://app.letta.com/chat/agent-1?conversation=conv-1",
+        "https://chat.letta.com/chat/agent-1?conversation=conv-1",
       ),
     ).toContain("Slack chat for this route");
     expect(buildChannelChatUnavailableMessage("telegram", route)).toContain(

--- a/src/channels/lifecycle-error.test.ts
+++ b/src/channels/lifecycle-error.test.ts
@@ -60,7 +60,7 @@ describe("formatChannelLifecycleErrorMessage", () => {
           run_id: "run-123",
         },
       }),
-      "View agent: \x1b]8;;https://app.letta.com/chat/agent-1?conversation=conv-1\x1b\\agent-1\x1b]8;;\x1b\\ (run: run-123)",
+      "View agent: \x1b]8;;https://chat.letta.com/chat/agent-1?conversation=conv-1\x1b\\agent-1\x1b]8;;\x1b\\ (run: run-123)",
     ].join("\n");
 
     const message = formatChannelLifecycleErrorMessage(rawError);
@@ -115,7 +115,7 @@ describe("sanitizeChannelLifecycleErrorText", () => {
   test("removes terminal hyperlink lines from generic channel errors", () => {
     const rawError =
       "Usage limit reached.\n" +
-      "View agent: \x1b]8;;https://app.letta.com/chat/agent-1\x1b\\agent-1\x1b]8;;\x1b\\ (run: run-abc)";
+      "View agent: \x1b]8;;https://chat.letta.com/chat/agent-1\x1b\\agent-1\x1b]8;;\x1b\\ (run: run-abc)";
 
     expect(sanitizeChannelLifecycleErrorText(rawError)).toBe(
       "Usage limit reached.",

--- a/src/channels/registry-command-routing.test.ts
+++ b/src/channels/registry-command-routing.test.ts
@@ -652,7 +652,7 @@ describe("ChannelRegistry command routing", () => {
 
     expect(delivered).toHaveLength(0);
     expect(replies[0]?.text).toContain(
-      "https://app.letta.com/chat/agent-1?conversation=conv-1",
+      "https://chat.letta.com/chat/agent-1?conversation=conv-1",
     );
     expect(replies[0]?.text).toContain("Conversation: conv-1.");
   });

--- a/src/channels/telegram-adapter-lifecycle.test.ts
+++ b/src/channels/telegram-adapter-lifecycle.test.ts
@@ -177,7 +177,7 @@ test("telegram adapter prettifies conversation-busy lifecycle errors", async () 
         run_id: "run-123",
       },
     }),
-    "View agent: \x1b]8;;https://app.letta.com/chat/agent-1?conversation=conv-1\x1b\\agent-1\x1b]8;;\x1b\\ (run: run-123)",
+    "View agent: \x1b]8;;https://chat.letta.com/chat/agent-1?conversation=conv-1\x1b\\agent-1\x1b]8;;\x1b\\ (run: run-123)",
   ].join("\n");
 
   await adapter.start();
@@ -238,7 +238,7 @@ test("telegram lifecycle report button submits sanitized error metadata", async 
         run_id: "run-456",
       },
     }),
-    "View agent: \x1b]8;;https://app.letta.com/chat/agent-1?conversation=conv-1\x1b\\agent-1\x1b]8;;\x1b\\ (run: run-456)",
+    "View agent: \x1b]8;;https://chat.letta.com/chat/agent-1?conversation=conv-1\x1b\\agent-1\x1b]8;;\x1b\\ (run: run-456)",
   ].join("\n");
 
   await adapter.start();

--- a/src/cli/app-urls.test.ts
+++ b/src/cli/app-urls.test.ts
@@ -7,20 +7,22 @@ import {
   buildAgentReference,
   buildAgentTerminalLink,
   buildChatUrl,
+  buildChatWebUrl,
+  buildPlatformUrl,
   isLocalAgentId,
 } from "@/cli/helpers/app-urls";
 
 describe("app URL helpers", () => {
   test("buildChatUrl links API-backed agents to the web app", () => {
     expect(buildChatUrl("agent-123")).toBe(
-      "https://app.letta.com/chat/agent-123",
+      "https://chat.letta.com/chat/agent-123",
     );
   });
 
   test("buildAgentReference links API-backed agents to the web app", () => {
     expect(
       buildAgentReference("agent-123", { conversationId: "conv-123" }),
-    ).toBe("https://app.letta.com/chat/agent-123?conversation=conv-123");
+    ).toBe("https://chat.letta.com/chat/agent-123?conversation=conv-123");
   });
 
   test("buildAgentReference displays local-backend agents by ID", () => {
@@ -50,7 +52,7 @@ describe("app URL helpers", () => {
   test("buildAgentTerminalLink only hyperlinks API-backed agents", () => {
     expect(buildAgentTerminalLink("agent-local-abc")).toBe("agent-local-abc");
     expect(buildAgentTerminalLink("agent-abc")).toBe(
-      "\x1b]8;;https://app.letta.com/chat/agent-abc\x1b\\agent-abc\x1b]8;;\x1b\\",
+      "\x1b]8;;https://chat.letta.com/chat/agent-abc\x1b\\agent-abc\x1b]8;;\x1b\\",
     );
   });
 
@@ -58,6 +60,15 @@ describe("app URL helpers", () => {
     const targetUrl = buildChatUrl("agent-abc");
     expect(buildAgentTerminalLink("agent-abc", undefined, "memories")).toBe(
       `\x1b]8;;${targetUrl}\x1b\\memories\x1b]8;;\x1b\\`,
+    );
+  });
+
+  test("builds non-agent URLs for their owning surface", () => {
+    expect(buildChatWebUrl("/preferences/usage")).toBe(
+      "https://chat.letta.com/preferences/usage",
+    );
+    expect(buildPlatformUrl("/api-keys")).toBe(
+      "https://platform.letta.com/api-keys",
     );
   });
 });

--- a/src/cli/app-urls.test.ts
+++ b/src/cli/app-urls.test.ts
@@ -10,6 +10,7 @@ import {
   buildChatWebUrl,
   buildPlatformUrl,
   isLocalAgentId,
+  LETTA_CHAT_API_KEYS_URL,
 } from "@/cli/helpers/app-urls";
 
 describe("app URL helpers", () => {
@@ -67,8 +68,11 @@ describe("app URL helpers", () => {
     expect(buildChatWebUrl("/preferences/usage")).toBe(
       "https://chat.letta.com/preferences/usage",
     );
-    expect(buildPlatformUrl("/api-keys")).toBe(
-      "https://platform.letta.com/api-keys",
+    expect(LETTA_CHAT_API_KEYS_URL).toBe(
+      "https://chat.letta.com/preferences/api-keys",
+    );
+    expect(buildPlatformUrl("/projects/default-project/agents")).toBe(
+      "https://platform.letta.com/projects/default-project/agents",
     );
   });
 });

--- a/src/cli/commands/install-github-app.ts
+++ b/src/cli/commands/install-github-app.ts
@@ -271,7 +271,7 @@ export function buildInstallPrBody(workflowPath: string): string {
     "",
     "You can also specify a particular agent: `@letta-code [--agent agent-xxx]`",
     "",
-    "View agent runs and conversations at [app.letta.com](https://app.letta.com).",
+    "Chat with your agent at [chat.letta.com](https://chat.letta.com).",
     "",
     "### Important Notes",
     "",

--- a/src/cli/components/AgentInfoBar.tsx
+++ b/src/cli/components/AgentInfoBar.tsx
@@ -4,8 +4,8 @@ import { memo, useMemo } from "react";
 import stringWidth from "string-width";
 import type { ModelReasoningEffort } from "@/agent/model";
 import {
-  buildAppUrl,
   buildChatUrl,
+  buildChatWebUrl,
   isLocalAgentId,
 } from "@/cli/helpers/app-urls";
 import { shouldHideReasoningForModelDisplay } from "@/cli/helpers/startup-model-display";
@@ -123,7 +123,7 @@ export const AgentInfoBar = memo(function AgentInfoBar({
     showCloudLinks && agentId && agentId !== "loading"
       ? buildChatUrl(agentId, { conversationId })
       : "";
-  const usageUrl = buildAppUrl("/settings/organization/usage");
+  const usageUrl = buildChatWebUrl("/preferences/usage");
   const showBottomBar = agentId && agentId !== "loading";
   const reasoningLabel = shouldHideReasoningForModelDisplay(currentModel)
     ? null

--- a/src/cli/components/SessionStats.tsx
+++ b/src/cli/components/SessionStats.tsx
@@ -1,5 +1,5 @@
 import type { SessionStatsSnapshot } from "@/agent/stats";
-import { buildAppUrl } from "@/cli/helpers/app-urls";
+import { buildChatWebUrl } from "@/cli/helpers/app-urls";
 import { formatCompact } from "@/cli/helpers/format";
 
 export function formatDuration(ms: number): string {
@@ -67,7 +67,7 @@ export function formatUsageStats({
 
     outputLines.push(
       `Plan: [${balance.billing_tier}]`,
-      buildAppUrl("/settings/organization/usage"),
+      buildChatWebUrl("/preferences/usage"),
       "",
       `Available credits:     ◎${formatNumber(totalCredits)} ($${toDollars(totalCredits)})`,
       `Monthly credits:       ◎${formatNumber(monthlyCredits)} ($${toDollars(monthlyCredits)})`,

--- a/src/cli/display/product-status/default.test.ts
+++ b/src/cli/display/product-status/default.test.ts
@@ -138,7 +138,7 @@ describe("defaultProductStatusPanel", () => {
   });
 
   test("renders clickable link when agentUrl is provided and not tmux", () => {
-    const agentUrl = "https://app.letta.com/chat/agent-reflection";
+    const agentUrl = "https://chat.letta.com/chat/agent-reflection";
     const panel = createDefaultProductStatusPanel({ agentUrl });
     const lines = renderModPanelLines(
       panel,
@@ -163,7 +163,7 @@ describe("defaultProductStatusPanel", () => {
   });
 
   test("does not render URL as plain text in tmux", () => {
-    const agentUrl = "https://app.letta.com/chat/agent-reflection";
+    const agentUrl = "https://chat.letta.com/chat/agent-reflection";
     const originalTmux = process.env.TMUX;
     process.env.TMUX = "1";
     try {

--- a/src/cli/error-formatter.test.ts
+++ b/src/cli/error-formatter.test.ts
@@ -526,7 +526,7 @@ describe("formatErrorDetails", () => {
     const message = formatErrorDetails(error, "agent-1", "conv-1");
 
     expect(message).toContain(
-      "\x1b]8;;https://app.letta.com/chat/agent-1?conversation=conv-1\x1b\\agent-1\x1b]8;;\x1b\\",
+      "\x1b]8;;https://chat.letta.com/chat/agent-1?conversation=conv-1\x1b\\agent-1\x1b]8;;\x1b\\",
     );
   });
 
@@ -566,7 +566,7 @@ describe("formatErrorDetails", () => {
     });
 
     expect(message).toContain(
-      "\x1b]8;;https://app.letta.com/chat/agent-1?conversation=conv-1\x1b\\agent-1\x1b]8;;\x1b\\",
+      "\x1b]8;;https://chat.letta.com/chat/agent-1?conversation=conv-1\x1b\\agent-1\x1b]8;;\x1b\\",
     );
   });
 

--- a/src/cli/helpers/app-urls.ts
+++ b/src/cli/helpers/app-urls.ts
@@ -1,6 +1,7 @@
 import { isLocalAgentId as isLocalAgentIdShared } from "@/agent/agent-id";
 
-const APP_BASE = "https://app.letta.com";
+const CHAT_BASE = "https://chat.letta.com";
+const PLATFORM_BASE = "https://platform.letta.com";
 
 export function isLocalAgentId(agentId: string): boolean {
   return isLocalAgentIdShared(agentId);
@@ -17,7 +18,7 @@ export function buildChatUrl(
     deviceId?: string;
   },
 ): string {
-  const base = `${APP_BASE}/chat/${agentId}`;
+  const base = `${CHAT_BASE}/chat/${agentId}`;
   const params = new URLSearchParams();
 
   if (options?.view) {
@@ -35,8 +36,8 @@ export function buildChatUrl(
 }
 
 /**
- * Build a user-facing agent reference. API-backed agents can link to the app,
- * but local-backend agents are not available at app.letta.com, so show the ID.
+ * Build a user-facing agent reference. API-backed agents can link to Chat,
+ * but local-backend agents are not available there, so show the ID.
  */
 export function buildAgentReference(
   agentId: string,
@@ -67,8 +68,15 @@ export function buildAgentTerminalLink(
 }
 
 /**
- * Build a non-agent app URL (e.g. settings pages).
+ * Build a URL for a Chat preference or other non-agent Chat page.
  */
-export function buildAppUrl(path: string): string {
-  return `${APP_BASE}${path}`;
+export function buildChatWebUrl(path: string): string {
+  return `${CHAT_BASE}${path}`;
+}
+
+/**
+ * Build a URL for developer and management pages on Letta Platform.
+ */
+export function buildPlatformUrl(path: string): string {
+  return `${PLATFORM_BASE}${path}`;
 }

--- a/src/cli/helpers/app-urls.ts
+++ b/src/cli/helpers/app-urls.ts
@@ -3,6 +3,8 @@ import { isLocalAgentId as isLocalAgentIdShared } from "@/agent/agent-id";
 const CHAT_BASE = "https://chat.letta.com";
 const PLATFORM_BASE = "https://platform.letta.com";
 
+export const LETTA_CHAT_API_KEYS_URL = `${CHAT_BASE}/preferences/api-keys`;
+
 export function isLocalAgentId(agentId: string): boolean {
   return isLocalAgentIdShared(agentId);
 }

--- a/src/cli/helpers/error-formatter.ts
+++ b/src/cli/helpers/error-formatter.ts
@@ -3,12 +3,16 @@ import {
   formatConversationBusyErrorMessage,
   isConversationBusyErrorText,
 } from "@/utils/conversation-busy-error";
-import { buildAgentTerminalLink, buildAppUrl } from "./app-urls";
+import {
+  buildAgentTerminalLink,
+  buildChatWebUrl,
+  buildPlatformUrl,
+} from "./app-urls";
 import { getErrorContext } from "./error-context";
 import { checkZaiError } from "./zai-errors";
 
-const LETTA_USAGE_URL = buildAppUrl("/settings/organization/usage");
-const LETTA_AGENTS_URL = buildAppUrl("/projects/default-project/agents");
+const LETTA_USAGE_URL = buildChatWebUrl("/preferences/usage");
+const LETTA_AGENTS_URL = buildPlatformUrl("/projects/default-project/agents");
 
 export type ErrorDisplaySurface = "plain" | "terminal";
 

--- a/src/cli/install-github-app.test.ts
+++ b/src/cli/install-github-app.test.ts
@@ -97,7 +97,7 @@ describe("install-github-app helpers", () => {
     expect(body).toContain(".github/workflows/letta.yml");
     expect(body).toContain("@letta-code");
     expect(body).toContain("stateful");
-    expect(body).toContain("app.letta.com");
+    expect(body).toContain("chat.letta.com");
     expect(body).toContain("letta-code-action");
   });
 });
@@ -271,12 +271,12 @@ describe("success screen content", () => {
     secretAction: "set",
     agentId: "agent-aaaabbbb-cccc-dddd-eeee-ffffffffffff",
     agentUrl:
-      "https://app.letta.com/chat/agent-aaaabbbb-cccc-dddd-eeee-ffffffffffff",
+      "https://chat.letta.com/chat/agent-aaaabbbb-cccc-dddd-eeee-ffffffffffff",
   };
 
-  test("agentUrl points to app.letta.com chat", () => {
+  test("agentUrl points to chat.letta.com", () => {
     expect(baseResult.agentUrl).toBe(
-      `https://app.letta.com/chat/${baseResult.agentId}`,
+      `https://chat.letta.com/chat/${baseResult.agentId}`,
     );
   });
 
@@ -363,13 +363,13 @@ describe("success screen content", () => {
 
   test("agent URL uses correct chat format for any agent ID", () => {
     const agentId = "agent-12345678-abcd-efgh-ijkl-123456789012";
-    const expectedUrl = `https://app.letta.com/chat/${agentId}`;
+    const expectedUrl = `https://chat.letta.com/chat/${agentId}`;
 
     // This mirrors the logic in installGithubApp
-    const agentUrl = agentId ? `https://app.letta.com/chat/${agentId}` : null;
+    const agentUrl = agentId ? `https://chat.letta.com/chat/${agentId}` : null;
 
     expect(agentUrl).toBe(expectedUrl);
-    expect(agentUrl).toContain("app.letta.com/chat/");
+    expect(agentUrl).toContain("chat.letta.com/chat/");
     expect(agentUrl).toContain(agentId);
   });
 });

--- a/src/cli/memory-subagent-recompile.test.ts
+++ b/src/cli/memory-subagent-recompile.test.ts
@@ -203,7 +203,7 @@ describe("memory subagent recompile handling", () => {
     );
 
     expect(message).toBe(
-      "\x1b]8;;https://app.letta.com/chat/agent-reflection\x1b\\Dreamed\x1b]8;;\x1b\\ and made some memories.",
+      "\x1b]8;;https://chat.letta.com/chat/agent-reflection\x1b\\Dreamed\x1b]8;;\x1b\\ and made some memories.",
     );
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1199,7 +1199,7 @@ async function main(): Promise<void> {
   if (!isUsingDevBackend && !isUsingLocalBackend) {
     // Headless mode against Letta API requires an explicit LETTA_API_KEY env var.
     // Stored OAuth credentials (interactive session tokens) are not accepted for
-    // automated/headless use — get an API key at https://app.letta.com/api-keys
+    // automated/headless use — get an API key at https://platform.letta.com/api-keys
     if (
       isHeadless &&
       baseURL === LETTA_CLOUD_API_URL &&
@@ -1209,7 +1209,7 @@ async function main(): Promise<void> {
       console.error(
         "Headless mode requires an API key set via the LETTA_API_KEY environment variable.",
       );
-      console.error("Get an API key at https://app.letta.com/api-keys");
+      console.error("Get an API key at https://platform.letta.com/api-keys");
       process.exit(1);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ import {
   parseCsvListFlag,
   resolveImportFlagAlias,
 } from "./cli/flag-utils";
+import { LETTA_CHAT_API_KEYS_URL } from "./cli/helpers/app-urls";
 import { formatErrorDetails } from "./cli/helpers/error-formatter";
 import { ensureFdPath, resolveFdPath } from "./cli/helpers/file-autocomplete";
 import type { ApprovalRequest } from "./cli/helpers/stream";
@@ -1198,8 +1199,7 @@ async function main(): Promise<void> {
 
   if (!isUsingDevBackend && !isUsingLocalBackend) {
     // Headless mode against Letta API requires an explicit LETTA_API_KEY env var.
-    // Stored OAuth credentials (interactive session tokens) are not accepted for
-    // automated/headless use — get an API key at https://platform.letta.com/api-keys
+    // Stored interactive OAuth tokens are not accepted for automated/headless use.
     if (
       isHeadless &&
       baseURL === LETTA_CLOUD_API_URL &&
@@ -1209,7 +1209,7 @@ async function main(): Promise<void> {
       console.error(
         "Headless mode requires an API key set via the LETTA_API_KEY environment variable.",
       );
-      console.error("Get an API key at https://platform.letta.com/api-keys");
+      console.error(`Get an API key at ${LETTA_CHAT_API_KEYS_URL}`);
       process.exit(1);
     }
 

--- a/src/skills/builtin/creating-mods/references/ui.md
+++ b/src/skills/builtin/creating-mods/references/ui.md
@@ -77,7 +77,7 @@ Checklist:
 
 - Open a panel with `order: 1`, not an additive panel.
 - Read active hidden background agents from `ctx.backgroundAgents`; filter by `status` (`pending`/`running`).
-- Use `agent.agentId` to build `https://app.letta.com/chat/${agent.agentId}`.
+- Use `agent.agentId` to build `https://chat.letta.com/chat/${agent.agentId}`.
 - If the user asks for the full URL, render visible text; do not use `ctx.link()` because it hides the URL behind OSC-8.
 - If preserving animation, own the timer and call `panel.update()`; clean up timer and panel in the disposer.
 - Keep `render()` pure: do not call diagnostics or mutate external state from render.
@@ -95,7 +95,7 @@ const panel = letta.ui.openPanel({
     if (!agent) return "";
 
     const url = agent.agentId
-      ? `https://app.letta.com/chat/${agent.agentId}`
+      ? `https://chat.letta.com/chat/${agent.agentId}`
       : null;
     // Render spinner/label/elapsed, plus visible URL if requested.
   },

--- a/src/startup-flow.test.ts
+++ b/src/startup-flow.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { spawn } from "node:child_process";
+import { LETTA_CHAT_API_KEYS_URL } from "@/cli/helpers/app-urls";
 import { createIsolatedCliTestEnv } from "@/test-utils/test-process-env";
 
 /**
@@ -173,6 +174,10 @@ describe("Startup Flow - Smoke", () => {
       expectExit: 1,
     });
     expect(result.stderr).toContain("Missing LETTA_API_KEY");
+    expect(result.stderr).toContain(
+      `Get an API key at ${LETTA_CHAT_API_KEYS_URL}`,
+    );
+    expect(result.stderr).not.toContain("https://app.letta.com/api-keys");
     expect(result.stderr).not.toContain("No recent session found");
   });
 

--- a/src/tools/task-background-helper.test.ts
+++ b/src/tools/task-background-helper.test.ts
@@ -480,7 +480,7 @@ describe("waitForBackgroundSubagentLink", () => {
 
     setTimeout(() => {
       updateSubagent("subagent-link-1", {
-        agentURL: "https://app.letta.com/chat/agent-123",
+        agentURL: "https://chat.letta.com/chat/agent-123",
       });
     }, 20);
 
@@ -508,7 +508,7 @@ describe("waitForBackgroundSubagentLink", () => {
     setTimeout(() => {
       updateSubagent("subagent-link-3", {
         agentId: "agent-123",
-        agentURL: "https://app.letta.com/chat/agent-123",
+        agentURL: "https://chat.letta.com/chat/agent-123",
       });
     }, 20);
 

--- a/src/web/memory-viewer-template.txt
+++ b/src/web/memory-viewer-template.txt
@@ -1057,13 +1057,16 @@ html.dark .warning-badge { background: hsl(42, 30%, 18%); color: hsl(42, 80%, 70
   var agentIdEl = document.getElementById('agent-id');
   agentIdEl.textContent = agentId;
   if (agentId) {
-    var adeBase;
-    if (serverUrl) {
-      adeBase = serverUrl.replace(/\/v1\/?$/, '').replace('api.letta.com', 'app.letta.com');
+    var chatBase;
+    var normalizedServerUrl = serverUrl.replace(/\/+$/, '');
+    if (normalizedServerUrl === 'https://api.letta.com' || normalizedServerUrl === 'https://api.letta.com/v1') {
+      chatBase = 'https://chat.letta.com';
+    } else if (normalizedServerUrl) {
+      chatBase = normalizedServerUrl.replace(/\/v1$/, '');
     } else {
-      adeBase = 'https://app.letta.com';
+      chatBase = 'https://chat.letta.com';
     }
-    agentIdEl.href = adeBase + '/chat/' + encodeURIComponent(agentId);
+    agentIdEl.href = chatBase + '/chat/' + encodeURIComponent(agentId);
     agentIdEl.target = '_blank';
   }
   document.getElementById('generated-at').textContent = 'Generated ' + new Date(DATA.generatedAt).toLocaleString();


### PR DESCRIPTION
## Summary

- sends agent, conversation, usage, and API-key links directly to their current Chat routes
- sends bulk agent-management links directly to Platform
- keeps the legacy host only for OAuth and device authorization
- updates Memory Palace, channel, subagent, error, status, and GitHub workflow links
- routes headless missing-key recovery through a shared Chat API-key URL constant
- adds a startup regression assertion so the deprecated app.letta.com API-key URL cannot return

Linear: LET-9608, LET-9620

## Validation

- `bun test src/cli/app-urls.test.ts`
- `bun test src/startup-flow.test.ts`
- `bun run check`

👾 Generated with [Letta Code](https://letta.com)