### PR TITLE
fix: save base_url when saving local providers

### DIFF
--- a/src/backend/local/local-provider-auth-store.test.ts
+++ b/src/backend/local/local-provider-auth-store.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createOrUpdateLocalProvider,
+  getLocalProviderRecordByName,
+  setLocalOAuthProvider,
+} from "./local-provider-auth-store";
+
+describe("local OAuth provider storage", () => {
+  const storageDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      storageDirs
+        .splice(0)
+        .map((storageDir) => rm(storageDir, { recursive: true, force: true })),
+    );
+  });
+
+  test("preserves proxy routing when OAuth credentials refresh", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "local-oauth-routing-"));
+    storageDirs.push(storageDir);
+    await createOrUpdateLocalProvider({
+      storageDir,
+      providerType: "chatgpt_oauth",
+      providerName: "chatgpt-work",
+      apiKey: JSON.stringify({
+        access_token: "old-access-token",
+        id_token: "old-id-token",
+        account_id: "account-123",
+        expires_at: Date.now() + 60_000,
+      }),
+      baseURL: "https://proxy.example.test/backend-api",
+      timeout: 30_000,
+    });
+
+    setLocalOAuthProvider({
+      storageDir,
+      providerName: "chatgpt-work",
+      providerType: "chatgpt_oauth",
+      auth: {
+        type: "oauth",
+        access: "refreshed-access-token",
+        expires: Date.now() + 120_000,
+      },
+    });
+
+    expect(
+      getLocalProviderRecordByName("chatgpt-work", storageDir),
+    ).toMatchObject({
+      base_url: "https://proxy.example.test/backend-api",
+      timeout: 30_000,
+      auth: {
+        type: "oauth",
+        access: "refreshed-access-token",
+      },
+    });
+  });
+});

--- a/src/backend/local/local-provider-auth-store.ts
+++ b/src/backend/local/local-provider-auth-store.ts
@@ -328,6 +328,8 @@ export function setLocalOAuthProvider(input: {
   providerType: string;
   auth: LocalProviderOAuthAuth;
   storageDir?: string;
+  baseURL?: string;
+  timeout?: LocalProviderTimeout;
 }): void {
   if (!isLocalProviderTypeSupported(input.providerType)) {
     throw new Error(
@@ -344,6 +346,14 @@ export function setLocalOAuthProvider(input: {
     provider_type: input.providerType,
     provider_category: "byok",
     auth: input.auth,
+    ...((input.baseURL ?? existing?.base_url)
+      ? { base_url: input.baseURL ?? existing?.base_url }
+      : {}),
+    ...(input.timeout !== undefined
+      ? { timeout: input.timeout }
+      : existing?.timeout !== undefined
+        ? { timeout: existing.timeout }
+        : {}),
     created_at: existing?.created_at ?? now,
     updated_at: now,
   };

--- a/src/cli/commands/connect-local-oauth.test.ts
+++ b/src/cli/commands/connect-local-oauth.test.ts
@@ -8,6 +8,7 @@ import {
   type PiProviderOAuthLoginCallbacks,
   registerPiProvider,
 } from "@/backend/dev/pi-provider-mod-registry";
+import { getLocalProviderRecordByName } from "@/backend/local/local-provider-auth-store";
 import { runLocalOAuthConnectFlow } from "@/cli/commands/connect-local-oauth";
 import type { ByokProvider } from "@/providers/byok-providers";
 
@@ -108,5 +109,22 @@ describe("runLocalOAuthConnectFlow select prompts", () => {
 
     expect(selectedMethod).toBe("device_code");
     expect(result.providerName).toBe(FAKE_PROVIDER_ID);
+  });
+
+  test("persists proxy connection options with OAuth credentials", async () => {
+    await runLocalOAuthConnectFlow(FAKE_BYOK_PROVIDER, {
+      onStatus: () => {},
+      openBrowser: async () => {},
+      baseURL: "http://proxy.example.test",
+      timeout: 30_000,
+    });
+
+    expect(
+      getLocalProviderRecordByName(FAKE_PROVIDER_ID, storageDir),
+    ).toMatchObject({
+      base_url: "http://proxy.example.test",
+      timeout: 30_000,
+      auth: { type: "oauth" },
+    });
   });
 });

--- a/src/cli/commands/connect-local-oauth.ts
+++ b/src/cli/commands/connect-local-oauth.ts
@@ -7,6 +7,7 @@ import {
   localOAuthAuthFromCredentials,
   setLocalOAuthProvider,
 } from "@/backend/local/local-provider-auth-store";
+import type { LocalProviderTimeout } from "@/backend/local/local-provider-timeout";
 import type { ByokProvider } from "@/providers/byok-providers";
 import { openOAuthBrowser } from "./connect-oauth-core";
 
@@ -17,6 +18,8 @@ export interface LocalOAuthConnectCallbacks {
   onSelect?: (prompt: OAuthSelectPrompt) => Promise<string | undefined>;
   openBrowser?: (authorizationUrl: string) => Promise<void>;
   signal?: AbortSignal;
+  baseURL?: string;
+  timeout?: LocalProviderTimeout;
 }
 
 interface OAuthDeviceCodeInfo {
@@ -101,6 +104,8 @@ export async function runLocalOAuthConnectFlow(
     providerName: provider.providerName,
     providerType: provider.providerType,
     auth: localOAuthAuthFromCredentials(credentials),
+    baseURL: callbacks.baseURL,
+    timeout: callbacks.timeout,
   });
 
   return { providerName: provider.providerName };

--- a/src/cli/subcommands/connect.test.ts
+++ b/src/cli/subcommands/connect.test.ts
@@ -318,13 +318,21 @@ describe("connect subcommand", () => {
 
   function createLocalOAuthFlowMock() {
     const selections: (string | undefined)[] = [];
+    const connectionOptions: Array<{
+      baseURL?: string;
+      timeout?: number | false;
+    }> = [];
     const runLocalOAuthConnectFlow = mock(
       async (_provider: unknown, callbacks: LocalOAuthConnectCallbacks) => {
         selections.push(await callbacks.onSelect?.(CODEX_LOGIN_SELECT_PROMPT));
+        connectionOptions.push({
+          baseURL: callbacks.baseURL,
+          timeout: callbacks.timeout,
+        });
         return { providerName: "chatgpt-plus-pro" };
       },
     );
-    return { selections, runLocalOAuthConnectFlow };
+    return { selections, connectionOptions, runLocalOAuthConnectFlow };
   }
 
   test("local codex connect defaults to the first login method option", async () => {
@@ -355,6 +363,29 @@ describe("connect subcommand", () => {
 
     expect(exitCode).toBe(0);
     expect(selections).toEqual(["device_code"]);
+  });
+
+  test("passes proxy connection options to local OAuth providers", async () => {
+    const { deps } = createIoDeps();
+    setProviderTarget("local");
+    const { connectionOptions, runLocalOAuthConnectFlow } =
+      createLocalOAuthFlowMock();
+
+    const exitCode = await runConnectSubcommand(
+      [
+        "anthropic-oauth",
+        "--base-url",
+        "http://proxy.example.test",
+        "--timeout",
+        "30s",
+      ],
+      { ...deps, runLocalOAuthConnectFlow },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(connectionOptions).toEqual([
+      { baseURL: "http://proxy.example.test", timeout: 30_000 },
+    ]);
   });
 
   test("local codex connect rejects unknown --method values", async () => {

--- a/src/cli/subcommands/connect.ts
+++ b/src/cli/subcommands/connect.ts
@@ -270,7 +270,16 @@ export async function runConnectSubcommand(
       }
 
       const loginMethod = readStringOption(parsed.values.method);
+      let connectionOptions: ProviderConnectionOptions;
+      try {
+        connectionOptions = connectionOptionsFromArgs(parsed.values);
+      } catch (error) {
+        io.stderr(getErrorMessage(error));
+        return 1;
+      }
       await io.runLocalOAuthConnectFlow(provider.byokProvider, {
+        baseURL: connectionOptions.baseURL,
+        timeout: connectionOptions.timeout,
         onStatus: (status) => io.stdout(status),
         onPrompt: async (prompt) => {
           if (prompt.allowEmpty && !io.isTTY()) return "";


### PR DESCRIPTION
When using a proxy like Tailscale Aperture, it's necessary to save `base_url` when adding a new conector.

Eg:

```bash
letta --backend local connect anthropic-oauth --base-url http://aperture.<tailscale>.ts.net
letta --backend local connect chatgpt --base-url http://aperture.<tailscale>.ts.net
```

Note that the `base_url` for Codex/OpenAI doesn't work yet, I'll have a fix for it in another PR.