### PR TITLE
fix(auth): use platform API key URL [LET-9620]

### DIFF
--- a/src/cli/app-urls.test.ts
+++ b/src/cli/app-urls.test.ts
@@ -8,15 +8,18 @@ import {
   buildAgentTerminalLink,
   buildChatUrl,
   isLocalAgentId,
-  LETTA_API_KEYS_URL,
+  LETTA_PLATFORM_API_KEYS_URL,
 } from "@/cli/helpers/app-urls";
 
 describe("app URL helpers", () => {
-  test("LETTA_API_KEYS_URL uses the project-scoped API keys page", () => {
-    expect(LETTA_API_KEYS_URL).toBe(
-      "https://app.letta.com/projects/default-project/api-keys",
+  test("LETTA_PLATFORM_API_KEYS_URL uses the externally shareable API keys page", () => {
+    expect(LETTA_PLATFORM_API_KEYS_URL).toBe(
+      "https://platform.letta.com/projects/default-project/api-keys",
     );
-    expect(LETTA_API_KEYS_URL).not.toBe("https://app.letta.com/api-keys");
+    expect(LETTA_PLATFORM_API_KEYS_URL).not.toContain("app.letta.com");
+    expect(LETTA_PLATFORM_API_KEYS_URL).not.toBe(
+      "https://app.letta.com/api-keys",
+    );
   });
 
   test("buildChatUrl links API-backed agents to the web app", () => {

--- a/src/cli/app-urls.test.ts
+++ b/src/cli/app-urls.test.ts
@@ -8,9 +8,17 @@ import {
   buildAgentTerminalLink,
   buildChatUrl,
   isLocalAgentId,
+  LETTA_API_KEYS_URL,
 } from "@/cli/helpers/app-urls";
 
 describe("app URL helpers", () => {
+  test("LETTA_API_KEYS_URL uses the project-scoped API keys page", () => {
+    expect(LETTA_API_KEYS_URL).toBe(
+      "https://app.letta.com/projects/default-project/api-keys",
+    );
+    expect(LETTA_API_KEYS_URL).not.toBe("https://app.letta.com/api-keys");
+  });
+
   test("buildChatUrl links API-backed agents to the web app", () => {
     expect(buildChatUrl("agent-123")).toBe(
       "https://app.letta.com/chat/agent-123",

--- a/src/cli/helpers/app-urls.ts
+++ b/src/cli/helpers/app-urls.ts
@@ -1,7 +1,8 @@
 import { isLocalAgentId as isLocalAgentIdShared } from "@/agent/agent-id";
 
 export const LETTA_APP_BASE_URL = "https://app.letta.com";
-export const LETTA_API_KEYS_URL = `${LETTA_APP_BASE_URL}/projects/default-project/api-keys`;
+export const LETTA_PLATFORM_BASE_URL = "https://platform.letta.com";
+export const LETTA_PLATFORM_API_KEYS_URL = `${LETTA_PLATFORM_BASE_URL}/projects/default-project/api-keys`;
 
 export function isLocalAgentId(agentId: string): boolean {
   return isLocalAgentIdShared(agentId);

--- a/src/cli/helpers/app-urls.ts
+++ b/src/cli/helpers/app-urls.ts
@@ -1,6 +1,7 @@
 import { isLocalAgentId as isLocalAgentIdShared } from "@/agent/agent-id";
 
-const APP_BASE = "https://app.letta.com";
+export const LETTA_APP_BASE_URL = "https://app.letta.com";
+export const LETTA_API_KEYS_URL = `${LETTA_APP_BASE_URL}/projects/default-project/api-keys`;
 
 export function isLocalAgentId(agentId: string): boolean {
   return isLocalAgentIdShared(agentId);
@@ -17,7 +18,7 @@ export function buildChatUrl(
     deviceId?: string;
   },
 ): string {
-  const base = `${APP_BASE}/chat/${agentId}`;
+  const base = `${LETTA_APP_BASE_URL}/chat/${agentId}`;
   const params = new URLSearchParams();
 
   if (options?.view) {
@@ -70,5 +71,5 @@ export function buildAgentTerminalLink(
  * Build a non-agent app URL (e.g. settings pages).
  */
 export function buildAppUrl(path: string): string {
-  return `${APP_BASE}${path}`;
+  return `${LETTA_APP_BASE_URL}${path}`;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ import {
   parseCsvListFlag,
   resolveImportFlagAlias,
 } from "./cli/flag-utils";
+import { LETTA_API_KEYS_URL } from "./cli/helpers/app-urls";
 import { formatErrorDetails } from "./cli/helpers/error-formatter";
 import { ensureFdPath, resolveFdPath } from "./cli/helpers/file-autocomplete";
 import type { ApprovalRequest } from "./cli/helpers/stream";
@@ -1198,8 +1199,7 @@ async function main(): Promise<void> {
 
   if (!isUsingDevBackend && !isUsingLocalBackend) {
     // Headless mode against Letta API requires an explicit LETTA_API_KEY env var.
-    // Stored OAuth credentials (interactive session tokens) are not accepted for
-    // automated/headless use — get an API key at https://app.letta.com/api-keys
+    // Stored interactive OAuth tokens are not accepted for automated/headless use.
     if (
       isHeadless &&
       baseURL === LETTA_CLOUD_API_URL &&
@@ -1209,7 +1209,7 @@ async function main(): Promise<void> {
       console.error(
         "Headless mode requires an API key set via the LETTA_API_KEY environment variable.",
       );
-      console.error("Get an API key at https://app.letta.com/api-keys");
+      console.error(`Get an API key at ${LETTA_API_KEYS_URL}`);
       process.exit(1);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ import {
   parseCsvListFlag,
   resolveImportFlagAlias,
 } from "./cli/flag-utils";
-import { LETTA_API_KEYS_URL } from "./cli/helpers/app-urls";
+import { LETTA_PLATFORM_API_KEYS_URL } from "./cli/helpers/app-urls";
 import { formatErrorDetails } from "./cli/helpers/error-formatter";
 import { ensureFdPath, resolveFdPath } from "./cli/helpers/file-autocomplete";
 import type { ApprovalRequest } from "./cli/helpers/stream";
@@ -1209,7 +1209,7 @@ async function main(): Promise<void> {
       console.error(
         "Headless mode requires an API key set via the LETTA_API_KEY environment variable.",
       );
-      console.error(`Get an API key at ${LETTA_API_KEYS_URL}`);
+      console.error(`Get an API key at ${LETTA_PLATFORM_API_KEYS_URL}`);
       process.exit(1);
     }
 

--- a/src/startup-flow.test.ts
+++ b/src/startup-flow.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { spawn } from "node:child_process";
+import { LETTA_API_KEYS_URL } from "@/cli/helpers/app-urls";
 import { createIsolatedCliTestEnv } from "@/test-utils/test-process-env";
 
 /**
@@ -173,6 +174,8 @@ describe("Startup Flow - Smoke", () => {
       expectExit: 1,
     });
     expect(result.stderr).toContain("Missing LETTA_API_KEY");
+    expect(result.stderr).toContain(`Get an API key at ${LETTA_API_KEYS_URL}`);
+    expect(result.stderr).not.toContain("https://app.letta.com/api-keys");
     expect(result.stderr).not.toContain("No recent session found");
   });
 

--- a/src/startup-flow.test.ts
+++ b/src/startup-flow.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { spawn } from "node:child_process";
-import { LETTA_API_KEYS_URL } from "@/cli/helpers/app-urls";
+import { LETTA_PLATFORM_API_KEYS_URL } from "@/cli/helpers/app-urls";
 import { createIsolatedCliTestEnv } from "@/test-utils/test-process-env";
 
 /**
@@ -174,7 +174,12 @@ describe("Startup Flow - Smoke", () => {
       expectExit: 1,
     });
     expect(result.stderr).toContain("Missing LETTA_API_KEY");
-    expect(result.stderr).toContain(`Get an API key at ${LETTA_API_KEYS_URL}`);
+    expect(result.stderr).toContain(
+      `Get an API key at ${LETTA_PLATFORM_API_KEYS_URL}`,
+    );
+    expect(result.stderr).not.toContain(
+      "https://app.letta.com/projects/default-project/api-keys",
+    );
     expect(result.stderr).not.toContain("https://app.letta.com/api-keys");
     expect(result.stderr).not.toContain("No recent session found");
   });


### PR DESCRIPTION
## Problem
LET-9620: headless Letta Cloud startup without LETTA_API_KEY told users to get an API key at `https://app.letta.com/api-keys`. That URL is stale and preserves the deprecated app host when the old relative redirect runs.

## Authoritative canonical URL source
A source audit established that the externally shareable Platform host is `https://platform.letta.com`:
- `justfile:112-137` pins `NEXT_PUBLIC_CURRENT_HOST=https://platform.letta.com` for the platform deployment.
- `helm/platform-site/values.yaml:79-84` pins the same Platform host.
- The real project-scoped API-key page is `apps/web/src/app/(logged-in)/(dashboard-like)/projects/[projectSlug]/api-keys/page.tsx`.
- The old `/api-keys` redirect is relative, so sharing it from `app.letta.com` preserves the deprecated host.

## Before / after
Before: headless missing-key guidance printed `Get an API key at https://app.letta.com/api-keys`.

After: the same guidance prints `Get an API key at https://platform.letta.com/projects/default-project/api-keys` via a shared Platform URL constant.

## Scope and intentional references left
- Updated the headless cloud missing-`LETTA_API_KEY` path only.
- Kept existing `app.letta.com` chat URL behavior unchanged.
- Added `LETTA_PLATFORM_BASE_URL` and `LETTA_PLATFORM_API_KEYS_URL` for externally shareable Platform URLs.
- Repo search for the stale API-key app-host URLs now finds only negative regression assertions that intentionally guard against reintroducing them.
- Adjacent `/login`, `LETTA_API_KEY`, and provider API-key guidance stays unchanged.

## Risk
Low. This is a user-facing guidance URL change plus helper constant extraction. The main shared-surface risk is accidentally changing existing app chat URL construction, covered by the existing app URL helper tests.

## Validation
- `bun test src/cli/app-urls.test.ts`
- `bun test src/startup-flow.test.ts`
- `bun run check`

👾 Generated with [Letta Code](https://letta.com)