### PR TITLE
fix(listener): reuse OAuth auth during reconnect

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -46,7 +46,7 @@
   "src/websocket/listener/commands/channels.ts": 1390,
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1030,
-  "src/websocket/listener/lifecycle.ts": 1766,
+  "src/websocket/listener/lifecycle.ts": 1760,
   "src/websocket/listener/protocol-inbound.ts": 2279,
   "src/websocket/listener/protocol-outbound.ts": 1279
 }

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -10,12 +10,6 @@ import { Box, render, Text } from "ink";
 import TextInput from "ink-text-input";
 import type React from "react";
 import { useState } from "react";
-import {
-  LETTA_CLOUD_API_URL,
-  pollForToken,
-  refreshAccessToken,
-  requestDeviceCode,
-} from "@/auth/oauth";
 import { isLocalBackendEnvEnabled } from "@/backend/local/paths";
 import {
   type ChannelRestoreAgentScope,
@@ -29,12 +23,16 @@ import { settingsManager } from "@/settings-manager";
 import { getListenerTelemetrySurface, telemetry } from "@/telemetry";
 import { RemoteSessionLog } from "@/websocket/listen-log";
 import {
-  deriveListenerInstanceId,
   type RegisterOptions,
   registerWithCloudRetry,
 } from "@/websocket/listen-register";
-
-const LISTENER_TOKEN_REFRESH_WINDOW_MS = 5 * 60 * 1000;
+import {
+  __listenerAuthTestUtils,
+  getListenerServerUrl,
+  isCloudListenerServerUrl,
+  MissingListenerApiKeyError,
+  resolveListenerRegistrationOptions,
+} from "@/websocket/listener/auth";
 
 type ListenerProcessAnchor = {
   close: () => void;
@@ -46,33 +44,6 @@ type CreateListenerProcessAnchor = () => ListenerProcessAnchor;
 // Without a retained reference, the MessageChannel anchor could be garbage
 // collected even though it is intended to hold channel-only listeners open.
 const activeListenerProcessAnchors = new Set<ListenerProcessAnchor>();
-
-type ListenerOAuthDeps = {
-  LETTA_CLOUD_API_URL: string;
-  pollForToken: typeof pollForToken;
-  refreshAccessToken: typeof refreshAccessToken;
-  requestDeviceCode: typeof requestDeviceCode;
-};
-
-const defaultListenerOAuthDeps: ListenerOAuthDeps = {
-  LETTA_CLOUD_API_URL,
-  pollForToken,
-  refreshAccessToken,
-  requestDeviceCode,
-};
-
-let listenerOAuthDepsOverride: ListenerOAuthDeps | null = null;
-
-function getListenerOAuthDeps(): ListenerOAuthDeps {
-  return listenerOAuthDepsOverride ?? defaultListenerOAuthDeps;
-}
-
-class MissingListenerApiKeyError extends Error {
-  constructor() {
-    super("LETTA_API_KEY not found");
-    this.name = "MissingListenerApiKeyError";
-  }
-}
 
 /**
  * Interactive prompt for environment name
@@ -143,17 +114,6 @@ async function flushListenerTelemetryEnd(exitReason: string): Promise<void> {
   }
 }
 
-function getListenerServerUrl(settings: {
-  env?: Record<string, string>;
-}): string {
-  const oauthDeps = getListenerOAuthDeps();
-  return (
-    process.env.LETTA_BASE_URL ||
-    settings.env?.LETTA_BASE_URL ||
-    oauthDeps.LETTA_CLOUD_API_URL
-  );
-}
-
 type ListenerStartupMode =
   | { kind: "remote"; serverUrl: string }
   | {
@@ -162,17 +122,6 @@ type ListenerStartupMode =
       backend: "local" | "self-hosted";
     }
   | { kind: "unsupported-self-hosted"; serverUrl: string };
-
-function normalizeListenerBaseUrl(url: string): string {
-  return url.trim().replace(/\/+$/, "");
-}
-
-function isCloudListenerServerUrl(serverUrl: string): boolean {
-  return (
-    normalizeListenerBaseUrl(serverUrl) ===
-    normalizeListenerBaseUrl(getListenerOAuthDeps().LETTA_CLOUD_API_URL)
-  );
-}
 
 async function resolveListenerStartupMode(
   channelNames: string[],
@@ -225,147 +174,13 @@ function resolveChannelRestoreAgentScope(
   );
 }
 
-async function refreshListenerAccessToken(
-  settings: Awaited<
-    ReturnType<typeof settingsManager.getSettingsWithSecureTokens>
-  >,
-  deviceId: string,
-  connectionName: string,
-): Promise<string> {
-  const oauthDeps = getListenerOAuthDeps();
-  const now = Date.now();
-
-  console.log("Access token expired, refreshing...");
-
-  const tokens = await oauthDeps.refreshAccessToken(
-    settings.refreshToken as string,
-    deviceId,
-    connectionName,
-  );
-
-  settingsManager.updateSettings({
-    env: { LETTA_API_KEY: tokens.access_token },
-    tokenExpiresAt: now + tokens.expires_in * 1000,
-    ...(tokens.refresh_token ? { refreshToken: tokens.refresh_token } : {}),
-  });
-  await settingsManager.flush();
-
-  console.log("Token refreshed successfully.");
-
-  return tokens.access_token;
-}
-
-async function runListenerOAuthLogin(
-  deviceId: string,
-  connectionName: string,
-): Promise<string> {
-  const oauthDeps = getListenerOAuthDeps();
-  console.log("No API key found. Starting OAuth login...\n");
-
-  const deviceData = await oauthDeps.requestDeviceCode();
-
-  console.log(
-    `To authenticate, visit: ${deviceData.verification_uri_complete}`,
-  );
-  console.log(`Your code: ${deviceData.user_code}\n`);
-  console.log("Waiting for authorization...\n");
-
-  const tokens = await oauthDeps.pollForToken(
-    deviceData.device_code,
-    deviceData.interval,
-    deviceData.expires_in,
-    deviceId,
-    connectionName,
-  );
-  const now = Date.now();
-
-  settingsManager.updateSettings({
-    env: { LETTA_API_KEY: tokens.access_token },
-    tokenExpiresAt: now + tokens.expires_in * 1000,
-    ...(tokens.refresh_token ? { refreshToken: tokens.refresh_token } : {}),
-  });
-  await settingsManager.flush();
-
-  console.log("Authenticated successfully.\n");
-
-  return tokens.access_token;
-}
-
-async function resolveListenerRegistrationOptions(
-  deviceId: string,
-  connectionName: string,
-): Promise<RegisterOptions> {
-  const settings = await settingsManager.getSettingsWithSecureTokens();
-  const serverUrl = getListenerServerUrl(settings);
-  const envApiKey = process.env.LETTA_API_KEY;
-
-  if (envApiKey) {
-    return {
-      serverUrl,
-      apiKey: envApiKey,
-      deviceId,
-      connectionName,
-      listenerInstanceId: deriveListenerInstanceId("server", connectionName),
-    };
-  }
-
-  let apiKey = settings.env?.LETTA_API_KEY;
-
-  if (isCloudListenerServerUrl(serverUrl)) {
-    const expiresAt = settings.tokenExpiresAt;
-    if (settings.refreshToken && expiresAt) {
-      const now = Date.now();
-      if (!apiKey || now >= expiresAt - LISTENER_TOKEN_REFRESH_WINDOW_MS) {
-        try {
-          apiKey = await refreshListenerAccessToken(
-            settings,
-            deviceId,
-            connectionName,
-          );
-        } catch (refreshErr) {
-          console.warn(
-            "Token refresh failed:",
-            refreshErr instanceof Error
-              ? refreshErr.message
-              : String(refreshErr),
-          );
-          apiKey = undefined;
-        }
-      }
-    }
-
-    if (!apiKey) {
-      apiKey = await runListenerOAuthLogin(deviceId, connectionName);
-    }
-  }
-
-  if (!apiKey) {
-    throw new MissingListenerApiKeyError();
-  }
-
-  return {
-    serverUrl,
-    apiKey,
-    deviceId,
-    connectionName,
-    listenerInstanceId: deriveListenerInstanceId("server", connectionName),
-  };
-}
-
 export const __listenSubcommandTestUtils = {
   createListenerProcessAnchorPromise,
   flushListenerTelemetryEnd,
   getListenerServerUrl,
   resolveListenerStartupMode,
   resolveListenerRegistrationOptions,
-  setOAuthDepsForTests(overrides: Partial<ListenerOAuthDeps> | null) {
-    listenerOAuthDepsOverride = overrides
-      ? {
-          ...defaultListenerOAuthDeps,
-          ...overrides,
-        }
-      : null;
-  },
+  setOAuthDepsForTests: __listenerAuthTestUtils.setOAuthDepsForTests,
 };
 
 const LISTEN_OPTIONS = {

--- a/src/websocket/listener/auth-reconnect.test.ts
+++ b/src/websocket/listener/auth-reconnect.test.ts
@@ -1,0 +1,356 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import WebSocket from "ws";
+import type { DeviceCodeResponse, TokenResponse } from "@/auth/oauth";
+import { settingsManager } from "@/settings-manager";
+import {
+  __listenClientTestUtils,
+  startListenerClient,
+  stopListenerClient,
+} from "@/websocket/listen-client";
+import { __listenerAuthTestUtils } from "./auth";
+
+type ListenerTestSettings = Partial<
+  Awaited<ReturnType<typeof settingsManager.getSettingsWithSecureTokens>>
+> & {
+  env?: Record<string, string>;
+  refreshToken?: string;
+  tokenExpiresAt?: number;
+};
+
+type SocketRequest = {
+  url: string;
+  authorization: string;
+};
+
+class FakeListenerSocket extends EventEmitter {
+  readyState: number = WebSocket.CONNECTING;
+  readonly sent: unknown[] = [];
+  readonly send = mock((payload: unknown) => {
+    this.sent.push(payload);
+  });
+  readonly close = mock(() => {
+    this.closeFromServer(1000);
+  });
+  readonly terminate = mock(() => {
+    this.closeFromServer(1006);
+  });
+
+  open(): void {
+    this.readyState = WebSocket.OPEN;
+    this.emit("open");
+  }
+
+  closeFromServer(code: number, reason = ""): void {
+    if (this.readyState === WebSocket.CLOSED) {
+      return;
+    }
+    this.readyState = WebSocket.CLOSED;
+    this.emit("close", code, Buffer.from(reason));
+  }
+}
+
+function nextTurn(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    if (predicate()) {
+      return;
+    }
+    await nextTurn();
+  }
+  throw new Error(message);
+}
+
+describe("listener reconnect auth", () => {
+  const originalGetSettingsWithSecureTokens =
+    settingsManager.getSettingsWithSecureTokens;
+  const originalUpdateSettings = settingsManager.updateSettings;
+  const originalFlush = settingsManager.flush;
+  const originalGetOrCreateDeviceId = settingsManager.getOrCreateDeviceId;
+  const originalConsoleLog = console.log;
+  const originalConsoleWarn = console.warn;
+  const originalApiKey = process.env.LETTA_API_KEY;
+  const originalBaseUrl = process.env.LETTA_BASE_URL;
+  const originalDisableCron = process.env.LETTA_DISABLE_CRON_SCHEDULER;
+
+  let settingsState: ListenerTestSettings;
+  let sockets: FakeListenerSocket[];
+  let socketRequests: SocketRequest[];
+
+  const refreshAccessTokenMock = mock(async (): Promise<TokenResponse> => {
+    throw new Error("refreshAccessToken not mocked");
+  });
+  const requestDeviceCodeMock = mock(async (): Promise<DeviceCodeResponse> => {
+    throw new Error("requestDeviceCode not mocked");
+  });
+  const pollForTokenMock = mock(async (): Promise<TokenResponse> => {
+    throw new Error("pollForToken not mocked");
+  });
+  const updateSettingsMock = mock(() => {});
+  const flushMock = mock(async () => {});
+
+  beforeEach(() => {
+    sockets = [];
+    socketRequests = [];
+    settingsState = {
+      env: {
+        LETTA_API_KEY: "initial-access-token",
+      },
+      refreshToken: "refresh-token",
+      tokenExpiresAt: Date.now() + 60 * 60 * 1000,
+    };
+
+    refreshAccessTokenMock.mockReset();
+    requestDeviceCodeMock.mockReset();
+    pollForTokenMock.mockReset();
+    updateSettingsMock.mockReset();
+    flushMock.mockReset();
+
+    __listenerAuthTestUtils.setOAuthDepsForTests({
+      LETTA_CLOUD_API_URL: "https://api.letta.com",
+      refreshAccessToken: refreshAccessTokenMock,
+      requestDeviceCode: requestDeviceCodeMock,
+      pollForToken: pollForTokenMock,
+    });
+    __listenerAuthTestUtils.clearInFlightRefreshesForTests();
+
+    settingsManager.getSettingsWithSecureTokens = mock(
+      async () =>
+        settingsState as Awaited<
+          ReturnType<typeof settingsManager.getSettingsWithSecureTokens>
+        >,
+    ) as unknown as typeof settingsManager.getSettingsWithSecureTokens;
+    settingsManager.updateSettings =
+      updateSettingsMock as typeof settingsManager.updateSettings;
+    settingsManager.flush = flushMock as typeof settingsManager.flush;
+    settingsManager.getOrCreateDeviceId = mock(
+      () => "device-id-for-telemetry",
+    ) as typeof settingsManager.getOrCreateDeviceId;
+
+    __listenClientTestUtils.setListenerWebSocketFactoryForTests(
+      (url, options) => {
+        const socket = new FakeListenerSocket();
+        socketRequests.push({
+          url,
+          authorization: options.headers.Authorization,
+        });
+        sockets.push(socket);
+        return socket as unknown as WebSocket;
+      },
+    );
+
+    delete process.env.LETTA_API_KEY;
+    delete process.env.LETTA_BASE_URL;
+    process.env.LETTA_DISABLE_CRON_SCHEDULER = "1";
+
+    console.log = mock(() => {}) as typeof console.log;
+    console.warn = mock(() => {}) as typeof console.warn;
+  });
+
+  afterEach(() => {
+    stopListenerClient();
+    __listenClientTestUtils.setListenerWebSocketFactoryForTests(null);
+    __listenClientTestUtils.setActiveRuntime(null);
+    __listenerAuthTestUtils.setOAuthDepsForTests(null);
+    __listenerAuthTestUtils.clearInFlightRefreshesForTests();
+
+    settingsManager.getSettingsWithSecureTokens =
+      originalGetSettingsWithSecureTokens;
+    settingsManager.updateSettings = originalUpdateSettings;
+    settingsManager.flush = originalFlush;
+    settingsManager.getOrCreateDeviceId = originalGetOrCreateDeviceId;
+
+    console.log = originalConsoleLog;
+    console.warn = originalConsoleWarn;
+
+    if (originalApiKey === undefined) {
+      delete process.env.LETTA_API_KEY;
+    } else {
+      process.env.LETTA_API_KEY = originalApiKey;
+    }
+
+    if (originalBaseUrl === undefined) {
+      delete process.env.LETTA_BASE_URL;
+    } else {
+      process.env.LETTA_BASE_URL = originalBaseUrl;
+    }
+
+    if (originalDisableCron === undefined) {
+      delete process.env.LETTA_DISABLE_CRON_SCHEDULER;
+    } else {
+      process.env.LETTA_DISABLE_CRON_SCHEDULER = originalDisableCron;
+    }
+  });
+
+  function startClient(
+    overrides: Partial<Parameters<typeof startListenerClient>[0]> = {},
+  ) {
+    return startListenerClient({
+      connectionId: "conn-1",
+      wsUrl: "wss://api.letta.com/v1/environments/ws/conn-1",
+      deviceId: "device-1",
+      connectionName: "listener-env",
+      onConnected: mock(() => {}),
+      onDisconnected: mock(() => {}),
+      onNeedsReregister: mock(() => {}),
+      onError: mock((_error: Error) => {}),
+      ...overrides,
+    });
+  }
+
+  test("refreshes missing saved access credentials during ordinary reconnect", async () => {
+    const onError = mock((_error: Error) => {});
+    const onNeedsReregister = mock(() => {});
+
+    await startClient({ onError, onNeedsReregister });
+    expect(socketRequests).toHaveLength(1);
+    expect(socketRequests[0]?.authorization).toBe(
+      "Bearer initial-access-token",
+    );
+
+    sockets[0]?.open();
+    await nextTurn();
+
+    settingsState = {
+      env: {},
+      refreshToken: "refresh-token",
+    };
+    refreshAccessTokenMock.mockImplementation(async () => ({
+      access_token: "refreshed-access-token",
+      refresh_token: "rotated-refresh-token",
+      token_type: "Bearer",
+      expires_in: 3600,
+    }));
+
+    sockets[0]?.closeFromServer(1000, "ordinary close");
+
+    await waitFor(
+      () => socketRequests.length === 2,
+      "listener did not reconnect with refreshed credentials",
+    );
+
+    expect(refreshAccessTokenMock).toHaveBeenCalledWith(
+      "refresh-token",
+      "device-1",
+      "listener-env",
+    );
+    expect(updateSettingsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: { LETTA_API_KEY: "refreshed-access-token" },
+        refreshToken: "rotated-refresh-token",
+        tokenExpiresAt: expect.any(Number),
+      }),
+    );
+    expect(flushMock).toHaveBeenCalledTimes(1);
+    expect(socketRequests[1]?.authorization).toBe(
+      "Bearer refreshed-access-token",
+    );
+    expect(requestDeviceCodeMock).not.toHaveBeenCalled();
+    expect(onNeedsReregister).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  test("routes missing credentials after abnormal reconnect into re-registration", async () => {
+    const onError = mock((_error: Error) => {});
+    const onNeedsReregister = mock(() => {});
+
+    await startClient({ onError, onNeedsReregister });
+    sockets[0]?.open();
+    await nextTurn();
+
+    settingsState = {
+      env: {},
+    };
+
+    sockets[0]?.closeFromServer(1006, "abnormal close");
+
+    await waitFor(
+      () => onNeedsReregister.mock.calls.length === 1,
+      "listener did not request re-registration for missing credentials",
+    );
+
+    expect(socketRequests).toHaveLength(1);
+    expect(refreshAccessTokenMock).not.toHaveBeenCalled();
+    expect(requestDeviceCodeMock).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  test("refreshes expired saved access credentials during reconnect", async () => {
+    await startClient();
+    sockets[0]?.open();
+    await nextTurn();
+
+    settingsState = {
+      env: {
+        LETTA_API_KEY: "expired-access-token",
+      },
+      refreshToken: "refresh-token",
+      tokenExpiresAt: Date.now() - 1000,
+    };
+    refreshAccessTokenMock.mockImplementation(async () => ({
+      access_token: "fresh-expired-token",
+      refresh_token: "fresh-rotated-refresh-token",
+      token_type: "Bearer",
+      expires_in: 7200,
+    }));
+
+    sockets[0]?.closeFromServer(1000, "expired token close");
+
+    await waitFor(
+      () => socketRequests.length === 2,
+      "listener did not reconnect after refreshing expired credentials",
+    );
+
+    expect(socketRequests[1]?.authorization).toBe("Bearer fresh-expired-token");
+    expect(updateSettingsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: { LETTA_API_KEY: "fresh-expired-token" },
+        refreshToken: "fresh-rotated-refresh-token",
+        tokenExpiresAt: expect.any(Number),
+      }),
+    );
+    expect(requestDeviceCodeMock).not.toHaveBeenCalled();
+  });
+
+  test("reports revoked refresh credentials once without retrying silently", async () => {
+    const onError = mock((_error: Error) => {});
+    const onNeedsReregister = mock(() => {});
+
+    await startClient({ onError, onNeedsReregister });
+    sockets[0]?.open();
+    await nextTurn();
+
+    settingsState = {
+      env: {
+        LETTA_API_KEY: "expired-access-token",
+      },
+      refreshToken: "revoked-refresh-token",
+      tokenExpiresAt: Date.now() - 1000,
+    };
+    refreshAccessTokenMock.mockRejectedValue(new Error("invalid_grant"));
+
+    sockets[0]?.closeFromServer(1000, "revoked refresh close");
+
+    await waitFor(
+      () => onError.mock.calls.length === 1,
+      "listener did not surface revoked refresh credentials",
+    );
+
+    expect(refreshAccessTokenMock).toHaveBeenCalledTimes(1);
+    expect(socketRequests).toHaveLength(1);
+    expect(onNeedsReregister).not.toHaveBeenCalled();
+    expect(requestDeviceCodeMock).not.toHaveBeenCalled();
+    const error = onError.mock.calls[0]?.[0];
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain(
+      "Saved Letta Cloud credentials could not be refreshed: invalid_grant",
+    );
+    expect((error as Error).message).toContain("Run letta server again");
+  });
+});

--- a/src/websocket/listener/auth.ts
+++ b/src/websocket/listener/auth.ts
@@ -1,0 +1,282 @@
+import {
+  LETTA_CLOUD_API_URL,
+  pollForToken,
+  refreshAccessToken,
+  requestDeviceCode,
+} from "@/auth/oauth";
+import { settingsManager } from "@/settings-manager";
+import {
+  deriveListenerInstanceId,
+  type RegisterOptions,
+} from "@/websocket/listen-register";
+
+const LISTENER_TOKEN_REFRESH_WINDOW_MS = 5 * 60 * 1000;
+
+type ListenerSettings = Awaited<
+  ReturnType<typeof settingsManager.getSettingsWithSecureTokens>
+>;
+
+type ListenerOAuthDeps = {
+  LETTA_CLOUD_API_URL: string;
+  pollForToken: typeof pollForToken;
+  refreshAccessToken: typeof refreshAccessToken;
+  requestDeviceCode: typeof requestDeviceCode;
+};
+
+const defaultListenerOAuthDeps: ListenerOAuthDeps = {
+  LETTA_CLOUD_API_URL,
+  pollForToken,
+  refreshAccessToken,
+  requestDeviceCode,
+};
+
+let listenerOAuthDepsOverride: ListenerOAuthDeps | null = null;
+const listenerTokenRefreshes = new Map<string, Promise<string>>();
+
+function getListenerOAuthDeps(): ListenerOAuthDeps {
+  return listenerOAuthDepsOverride ?? defaultListenerOAuthDeps;
+}
+
+export class MissingListenerApiKeyError extends Error {
+  constructor() {
+    super("LETTA_API_KEY not found");
+    this.name = "MissingListenerApiKeyError";
+  }
+}
+
+export class ListenerTokenRefreshError extends Error {
+  readonly refreshError: unknown;
+
+  constructor(refreshError: unknown) {
+    const message =
+      refreshError instanceof Error
+        ? refreshError.message
+        : String(refreshError);
+    super(
+      `Saved Letta Cloud credentials could not be refreshed: ${message}. Run letta server again to sign in, or set LETTA_API_KEY.`,
+    );
+    this.name = "ListenerTokenRefreshError";
+    this.refreshError = refreshError;
+  }
+}
+
+export function getListenerServerUrl(settings: {
+  env?: Record<string, string>;
+}): string {
+  const oauthDeps = getListenerOAuthDeps();
+  return (
+    process.env.LETTA_BASE_URL ||
+    settings.env?.LETTA_BASE_URL ||
+    oauthDeps.LETTA_CLOUD_API_URL
+  );
+}
+
+function normalizeListenerBaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+export function isCloudListenerServerUrl(serverUrl: string): boolean {
+  return (
+    normalizeListenerBaseUrl(serverUrl) ===
+    normalizeListenerBaseUrl(getListenerOAuthDeps().LETTA_CLOUD_API_URL)
+  );
+}
+
+function shouldRefreshListenerAccessToken(
+  settings: ListenerSettings,
+  apiKey: string | undefined,
+): boolean {
+  if (!settings.refreshToken) {
+    return false;
+  }
+
+  if (!apiKey) {
+    return true;
+  }
+
+  const expiresAt = settings.tokenExpiresAt;
+  if (!expiresAt) {
+    return false;
+  }
+
+  return Date.now() >= expiresAt - LISTENER_TOKEN_REFRESH_WINDOW_MS;
+}
+
+async function refreshListenerAccessToken(
+  settings: ListenerSettings,
+  deviceId: string,
+  connectionName: string,
+): Promise<string> {
+  const refreshToken = settings.refreshToken;
+  if (!refreshToken) {
+    throw new MissingListenerApiKeyError();
+  }
+
+  const refreshKey = `${refreshToken}\0${deviceId}\0${connectionName}`;
+  const existingRefresh = listenerTokenRefreshes.get(refreshKey);
+  if (existingRefresh) {
+    return await existingRefresh;
+  }
+
+  const refreshPromise = (async () => {
+    const oauthDeps = getListenerOAuthDeps();
+    const now = Date.now();
+
+    console.log("Access token expired, refreshing...");
+
+    const tokens = await oauthDeps.refreshAccessToken(
+      refreshToken,
+      deviceId,
+      connectionName,
+    );
+
+    settingsManager.updateSettings({
+      env: { LETTA_API_KEY: tokens.access_token },
+      tokenExpiresAt: now + tokens.expires_in * 1000,
+      ...(tokens.refresh_token ? { refreshToken: tokens.refresh_token } : {}),
+    });
+    await settingsManager.flush();
+
+    console.log("Token refreshed successfully.");
+
+    return tokens.access_token;
+  })();
+
+  listenerTokenRefreshes.set(refreshKey, refreshPromise);
+  try {
+    return await refreshPromise;
+  } finally {
+    listenerTokenRefreshes.delete(refreshKey);
+  }
+}
+
+async function runListenerOAuthLogin(
+  deviceId: string,
+  connectionName: string,
+): Promise<string> {
+  const oauthDeps = getListenerOAuthDeps();
+  console.log("No API key found. Starting OAuth login...\n");
+
+  const deviceData = await oauthDeps.requestDeviceCode();
+
+  console.log(
+    `To authenticate, visit: ${deviceData.verification_uri_complete}`,
+  );
+  console.log(`Your code: ${deviceData.user_code}\n`);
+  console.log("Waiting for authorization...\n");
+
+  const tokens = await oauthDeps.pollForToken(
+    deviceData.device_code,
+    deviceData.interval,
+    deviceData.expires_in,
+    deviceId,
+    connectionName,
+  );
+  const now = Date.now();
+
+  settingsManager.updateSettings({
+    env: { LETTA_API_KEY: tokens.access_token },
+    tokenExpiresAt: now + tokens.expires_in * 1000,
+    ...(tokens.refresh_token ? { refreshToken: tokens.refresh_token } : {}),
+  });
+  await settingsManager.flush();
+
+  console.log("Authenticated successfully.\n");
+
+  return tokens.access_token;
+}
+
+export async function resolveListenerRegistrationOptions(
+  deviceId: string,
+  connectionName: string,
+  options: { allowInteractiveOAuth?: boolean } = {},
+): Promise<RegisterOptions> {
+  const allowInteractiveOAuth = options.allowInteractiveOAuth ?? true;
+  const settings = await settingsManager.getSettingsWithSecureTokens();
+  const serverUrl = getListenerServerUrl(settings);
+  const envApiKey = process.env.LETTA_API_KEY;
+
+  if (envApiKey) {
+    return {
+      serverUrl,
+      apiKey: envApiKey,
+      deviceId,
+      connectionName,
+      listenerInstanceId: deriveListenerInstanceId("server", connectionName),
+    };
+  }
+
+  let apiKey = settings.env?.LETTA_API_KEY;
+
+  if (isCloudListenerServerUrl(serverUrl)) {
+    if (shouldRefreshListenerAccessToken(settings, apiKey)) {
+      try {
+        apiKey = await refreshListenerAccessToken(
+          settings,
+          deviceId,
+          connectionName,
+        );
+      } catch (refreshErr) {
+        if (!allowInteractiveOAuth) {
+          throw new ListenerTokenRefreshError(refreshErr);
+        }
+
+        console.warn(
+          "Token refresh failed:",
+          refreshErr instanceof Error ? refreshErr.message : String(refreshErr),
+        );
+        apiKey = undefined;
+      }
+    }
+
+    if (!apiKey && allowInteractiveOAuth) {
+      apiKey = await runListenerOAuthLogin(deviceId, connectionName);
+    }
+  }
+
+  if (!apiKey) {
+    throw new MissingListenerApiKeyError();
+  }
+
+  return {
+    serverUrl,
+    apiKey,
+    deviceId,
+    connectionName,
+    listenerInstanceId: deriveListenerInstanceId("server", connectionName),
+  };
+}
+
+export async function resolveListenerReconnectApiKey(
+  deviceId: string,
+  connectionName: string,
+  onMissingCredentials?: () => void,
+): Promise<string | null> {
+  try {
+    return (
+      await resolveListenerRegistrationOptions(deviceId, connectionName, {
+        allowInteractiveOAuth: false,
+      })
+    ).apiKey;
+  } catch (error) {
+    if (error instanceof MissingListenerApiKeyError && onMissingCredentials) {
+      onMissingCredentials();
+      return null;
+    }
+    throw error;
+  }
+}
+
+export const __listenerAuthTestUtils = {
+  setOAuthDepsForTests(overrides: Partial<ListenerOAuthDeps> | null) {
+    listenerOAuthDepsOverride = overrides
+      ? {
+          ...defaultListenerOAuthDeps,
+          ...overrides,
+        }
+      : null;
+  },
+  clearInFlightRefreshesForTests() {
+    listenerTokenRefreshes.clear();
+  },
+};

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -113,6 +113,7 @@ import type {
   ListenerRuntime,
   StartListenerOptions,
 } from "./types";
+import { setListenerWebSocketFactoryForTests } from "./websocket-factory";
 
 function asListenerRuntimeForTests(
   runtime: ListenerRuntime | ConversationRuntime,
@@ -454,6 +455,7 @@ export const __listenClientTestUtils = {
     suppressCallbacks: boolean,
   ) => stopRuntime(asListenerRuntimeForTests(runtime), suppressCallbacks),
   setActiveRuntime,
+  setListenerWebSocketFactoryForTests,
   getListenerStatus,
   getOrCreateConversationRuntime,
   resolveRuntimeScope,

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -37,6 +37,7 @@ import { isDebugEnabled } from "@/utils/debug";
 import { setMessageQueueAdder } from "@/utils/message-queue-bridge";
 import { killAllTerminals } from "@/websocket/terminal-handler";
 import { rejectPendingApprovalResolvers } from "./approval";
+import { resolveListenerReconnectApiKey } from "./auth";
 import {
   recoverActiveChannelTurn,
   uniqueChannelTurnSources,
@@ -120,6 +121,7 @@ import {
   clearListenerWarmState,
   scheduleListenerWarmupsAfterSync,
 } from "./warmup";
+import { createAuthenticatedListenerWebSocket } from "./websocket-factory";
 import { stopAllWorktreeWatchers } from "./worktree-watcher";
 
 function escapeTaskNotificationSummary(summary: string): string {
@@ -1496,12 +1498,12 @@ async function connectWithRetry(
     await loadTools();
   }
 
-  const settings = await settingsManager.getSettingsWithSecureTokens();
-  const apiKey = process.env.LETTA_API_KEY || settings.env?.LETTA_API_KEY;
-
-  if (!apiKey) {
-    throw new Error("Missing LETTA_API_KEY");
-  }
+  const apiKey = await resolveListenerReconnectApiKey(
+    opts.deviceId,
+    opts.connectionName,
+    runtime.everConnected ? opts.onNeedsReregister : undefined,
+  );
+  if (!apiKey) return;
 
   const url = new URL(opts.wsUrl);
   url.searchParams.set("deviceId", opts.deviceId);
@@ -1520,18 +1522,10 @@ async function connectWithRetry(
     streamUrl.searchParams.set("channel", "stream");
   }
 
-  const socket = new WebSocket(url.toString(), {
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-    },
-  });
+  const socket = createAuthenticatedListenerWebSocket(url.toString(), apiKey);
 
   const streamSocket = streamUrl
-    ? new WebSocket(streamUrl.toString(), {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-        },
-      })
+    ? createAuthenticatedListenerWebSocket(streamUrl.toString(), apiKey)
     : null;
 
   const fileCommandSession = createFileCommandSession({

--- a/src/websocket/listener/websocket-factory.ts
+++ b/src/websocket/listener/websocket-factory.ts
@@ -1,0 +1,28 @@
+import WebSocket from "ws";
+
+type ListenerWebSocketFactory = (
+  url: string,
+  options: { headers: { Authorization: string } },
+) => WebSocket;
+
+const defaultListenerWebSocketFactory: ListenerWebSocketFactory = (
+  url,
+  options,
+) => new WebSocket(url, options);
+
+let listenerWebSocketFactory = defaultListenerWebSocketFactory;
+
+export function createAuthenticatedListenerWebSocket(
+  url: string,
+  apiKey: string,
+): WebSocket {
+  return listenerWebSocketFactory(url, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+}
+
+export function setListenerWebSocketFactoryForTests(
+  factory: ListenerWebSocketFactory | null,
+): void {
+  listenerWebSocketFactory = factory ?? defaultListenerWebSocketFactory;
+}


### PR DESCRIPTION
## Context
LET-9624: listener reconnects could bypass the OAuth-aware listener auth resolver and read only `LETTA_API_KEY` directly from env/settings. If the saved access token was missing or expired but a refresh token existed, reconnect could fail with the raw `Missing LETTA_API_KEY` path instead of refreshing.

## Root cause
`connectWithRetry()` in `src/websocket/listener/lifecycle.ts` owned the reconnect WebSocket creation but performed its own direct API-key lookup. Initial registration and explicit re-registration used the richer resolver in `listen.tsx`, so reconnect had a different auth path.

## What changed
- Moved listener auth resolution into `src/websocket/listener/auth.ts` so initial registration, re-registration, and reconnect share the same env/settings/OAuth refresh semantics.
- Added non-interactive reconnect auth resolution: reconnect refreshes saved Cloud credentials when possible, never starts device OAuth itself, and routes missing credentials after a prior connection to the existing re-registration callback.
- Added refresh coalescing keyed by refresh token/device/name to avoid duplicate concurrent refresh calls for the same listener credentials.
- Added an explicit `ListenerTokenRefreshError` for non-interactive refresh failures so revoked/invalid refresh credentials surface once instead of silently looping or falling into device OAuth.
- Added a small WebSocket factory seam for lifecycle tests without broad module mocking.

## Changed-behavior matrix
- Env `LETTA_API_KEY`: still wins through the shared resolver.
- Saved Cloud access token: still used when valid.
- Missing saved access token + refresh token on ordinary reconnect: refreshes and reconnects with the new bearer token.
- Expired saved access token + rotated refresh token on reconnect: refreshes, persists the rotated refresh token, and reconnects.
- Missing key + no refresh token after abnormal reconnect: invokes existing re-registration flow instead of throwing raw `Missing LETTA_API_KEY` from lifecycle.
- Invalid/revoked refresh token during reconnect: reports one actionable error and does not start interactive OAuth or retry silently.
- Self-hosted/Desktop proxy startup classification remains in the CLI startup mode path; the shared resolver still only starts OAuth for Cloud URLs.

## Tests
- `bun test src/cli/subcommands/listen-auth.test.ts src/websocket/listener/auth-reconnect.test.ts`
- `bun run check`

## Limits / risk
- Tests use a fake WebSocket factory and OAuth dependency overrides, not a live Cloud WebSocket or real OAuth device flow.
- Invalid refresh credentials are intentionally not auto-recovered by reconnect; the user gets an actionable sign-in/API-key error instead.
- The old helper tests still cover initial CLI auth precedence and self-hosted/Desktop startup mode behavior; the new tests cover production `startListenerClient` close/reconnect flow for normal and abnormal closes.

👾 Generated with [Letta Code](https://letta.com)