### PR TITLE
fix: update the in-flight turn tool context when EnterWorktree switches cwd in listener sessions

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -36,7 +36,7 @@
   "src/providers/chatgpt-usage-service.ts": 1115,
   "src/settings-manager.test.ts": 1669,
   "src/settings-manager.ts": 2113,
-  "src/tools/impl/enter-worktree.ts": 1265,
+  "src/tools/impl/enter-worktree.ts": 1260,
   "src/tools/impl/message-channel.ts": 1208,
   "src/tools/manager.ts": 3293,
   "src/tools/tool-execution-context.test.ts": 1422,

--- a/src/tools/enter-worktree.test.ts
+++ b/src/tools/enter-worktree.test.ts
@@ -291,6 +291,67 @@ describe("EnterWorktree tool", () => {
     }
   });
 
+  test("updates the active tool context in listener mode so same-turn tools use the new cwd", async () => {
+    const repo = await trackRepo();
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    listener.bootWorkingDirectory = repo;
+    __listenClientTestUtils.getOrCreateScopedRuntime(
+      listener,
+      "agent-1",
+      "conv-a",
+    );
+    setActiveRuntime(listener);
+    await loadSpecificTools(["EnterWorktree", "Bash"]);
+
+    const scope = {
+      agentId: "agent-1",
+      conversationId: "conv-a",
+      workingDirectory: repo,
+    };
+    const prepared = await runWithRuntimeContext(scope, () =>
+      prepareCurrentToolExecutionContext({ workingDirectory: repo }),
+    );
+
+    try {
+      const createResult = await runWithRuntimeContext(scope, () =>
+        executeTool(
+          "EnterWorktree",
+          { name: "Listener Same Turn Feature", refresh_base: false },
+          { toolContextId: prepared.contextId },
+        ),
+      );
+      expect(createResult.status).toBe("success");
+      const createdText = toolReturnText(createResult.toolReturn);
+      const worktreePath = createdText.match(/^Path: (.+)$/m)?.[1];
+      if (!worktreePath) {
+        throw new Error(
+          `Expected worktree path in tool return: ${createdText}`,
+        );
+      }
+      expect(
+        __listenClientTestUtils.getConversationWorkingDirectory(
+          listener,
+          "agent-1",
+          "conv-a",
+        ),
+      ).toBe(worktreePath);
+
+      // The regression under test: subsequent tool calls in the SAME turn
+      // resolve their cwd from the prepared execution context, which the
+      // listener branch previously never updated.
+      const pwdResult = await executeTool(
+        "Bash",
+        { command: 'node -e "console.log(process.cwd())"' },
+        { toolContextId: prepared.contextId },
+      );
+
+      expect(pwdResult.status).toBe("success");
+      expect(toolReturnText(pwdResult.toolReturn).trim()).toBe(worktreePath);
+    } finally {
+      releaseToolExecutionContext(prepared.contextId);
+    }
+  });
+
   test("fetches the remote default branch before creating the worktree", async () => {
     const repo = await trackRepo();
     const remote = await mkdtemp(

--- a/src/tools/impl/enter-worktree.ts
+++ b/src/tools/impl/enter-worktree.ts
@@ -24,6 +24,7 @@ import {
 import {
   switchConversationWorkingDirectory,
   switchCurrentRuntimeWorkingDirectory,
+  updateToolExecutionContextCwd,
 } from "@/websocket/listener/cwd-change";
 import { getActiveRuntime } from "@/websocket/listener/runtime";
 import { restartWorktreeWatcher } from "@/websocket/listener/worktree-watcher";
@@ -809,19 +810,13 @@ async function switchSessionToWorktree(params: {
       agentId: runtimeContext.agentId ?? null,
       conversationId: runtimeContext.conversationId,
     });
-    return true;
+  } else {
+    await switchCurrentRuntimeWorkingDirectory(worktreePath);
   }
-
-  await switchCurrentRuntimeWorkingDirectory(worktreePath);
-  if (params.executionContextId) {
-    const { updateToolExecutionContextWorkingDirectory } = await import(
-      "@/tools/manager"
-    );
-    updateToolExecutionContextWorkingDirectory(
-      params.executionContextId,
-      worktreePath,
-    );
-  }
+  // Both paths must refresh the captured execution context: the in-flight
+  // turn resolves tool cwds from the snapshot taken at turn start, so
+  // skipping this leaves every remaining tool call in the previous cwd.
+  await updateToolExecutionContextCwd(params.executionContextId, worktreePath);
   return true;
 }
 

--- a/src/websocket/listener/cwd-change.ts
+++ b/src/websocket/listener/cwd-change.ts
@@ -28,6 +28,30 @@ export async function switchCurrentRuntimeWorkingDirectory(
   updateRuntimeContext({ workingDirectory });
 }
 
+/**
+ * Updates a captured tool execution context so tool calls later in the SAME
+ * turn resolve the new working directory. Turns bake their cwd into the
+ * prepared execution context at turn start; without this, an in-flight turn
+ * keeps running tools in the previous directory after a cwd switch.
+ */
+export async function updateToolExecutionContextCwd(
+  executionContextId: string | undefined,
+  workingDirectory: string,
+): Promise<void> {
+  if (!executionContextId) {
+    return;
+  }
+  // Imported lazily so `@/tools/manager` does not become a static dependency
+  // of the listener cwd module.
+  const { updateToolExecutionContextWorkingDirectory } = await import(
+    "@/tools/manager"
+  );
+  updateToolExecutionContextWorkingDirectory(
+    executionContextId,
+    workingDirectory,
+  );
+}
+
 export async function switchConversationWorkingDirectory(params: {
   runtime: ListenerRuntime;
   agentId: string | null;


### PR DESCRIPTION
## Summary
- Fixes [LET-9629](https://linear.app/letta/issue/LET-9629/two-issues-with-worktrees) issue 2: in listener/WS sessions, `EnterWorktree` reported "This conversation's working directory is now this worktree" but every subsequent tool call in the **same turn** kept running in the previous directory. `cd` only lasted a single Bash call because each Bash spawns fresh from the turn's captured cwd snapshot.
- Root cause: turns bake their cwd into the prepared tool execution context at turn start. `switchSessionToWorktree`'s listener branch updated the per-conversation cwd map (so the *next* turn and device status were correct) and returned early — it never called `updateToolExecutionContextWorkingDirectory`, even though `_executionContextId` is injected into worktree tool args for exactly this purpose. The `updateRuntimeContext` call inside the switch only mutates the per-tool-call AsyncLocalStorage copy, which is discarded when the tool returns. The non-listener (TUI) path already handled this correctly.
- Fix: hoist the execution-context refresh (`updateToolExecutionContextCwd`, now in `cwd-change.ts`) so both the listener and non-listener paths update the in-flight turn snapshot.
- Adds a listener-mode regression test mirroring the existing non-listener same-turn test (verified red on unfixed code, green with the fix). Ratchets the `enter-worktree.ts` file-size baseline down (1265 → 1260).

👾 Generated with [Letta Code](https://letta.com)