### PR TITLE
fix(listener): preserve OAuth credentials across reconnects [LET-9624]

### DIFF
--- a/scripts/isolated-unit-tests.json
+++ b/scripts/isolated-unit-tests.json
@@ -26,6 +26,11 @@
       "reason": "Uses a top-level Bun module mock for backend generation."
     },
     {
+      "path": "src/settings-manager-auth-cache.test.ts",
+      "timeoutMs": 15000,
+      "reason": "Mutates the settings singleton, keychain test overrides, HOME, and the secrets service name."
+    },
+    {
       "path": "src/tools/bash.test.ts",
       "timeoutMs": 30000,
       "reason": "Spawns real shells and temporarily mutates process platform and PATH state."
@@ -59,6 +64,11 @@
       "path": "src/websocket/listen-client-concurrency.test.ts",
       "timeoutMs": 30000,
       "reason": "Uses several top-level Bun module mocks and exercises real concurrent listener state."
+    },
+    {
+      "path": "src/websocket/listener/auth-lifecycle.test.ts",
+      "timeoutMs": 30000,
+      "reason": "Exercises real WebSockets while mutating listener, settings, HOME, and process environment state."
     }
   ]
 }

--- a/src/auth/oauth-network-errors.test.ts
+++ b/src/auth/oauth-network-errors.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import {
+  OAuthRefreshError,
   pollForToken,
   refreshAccessToken,
   requestDeviceCode,
@@ -67,11 +68,55 @@ describe("OAuth network errors", () => {
       ),
     ) as unknown as typeof fetch;
 
-    await expect(
-      refreshAccessToken("refresh-token", "device-id", "device-name"),
-    ).rejects.toThrow(
+    let refreshError: unknown;
+    try {
+      await refreshAccessToken("refresh-token", "device-id", "device-name");
+    } catch (error) {
+      refreshError = error;
+    }
+    expect(refreshError).toBeInstanceOf(OAuthRefreshError);
+    expect((refreshError as OAuthRefreshError).message).toContain(
       "Failed to refresh access token from app.letta.com: certificate has expired (CERT_HAS_EXPIRED).",
     );
+    expect((refreshError as OAuthRefreshError).retryable).toBe(true);
+  });
+
+  test("refreshAccessToken distinguishes revoked credentials from server failures", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: "invalid_grant" }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    ) as unknown as typeof fetch;
+
+    try {
+      await refreshAccessToken("revoked", "device-id");
+      throw new Error("Expected revoked refresh to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(OAuthRefreshError);
+      expect((error as OAuthRefreshError).retryable).toBe(false);
+      expect((error as OAuthRefreshError).oauthCode).toBe("invalid_grant");
+    }
+
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: "temporarily_unavailable" }), {
+          status: 503,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    ) as unknown as typeof fetch;
+
+    try {
+      await refreshAccessToken("valid", "device-id");
+      throw new Error("Expected server failure to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(OAuthRefreshError);
+      expect((error as OAuthRefreshError).retryable).toBe(true);
+      expect((error as OAuthRefreshError).status).toBe(503);
+    }
   });
 
   test("validateCredentialsWithResult classifies authentication failures", async () => {

--- a/src/auth/oauth-refresh.test.ts
+++ b/src/auth/oauth-refresh.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { TokenResponse } from "@/auth/oauth";
+import { refreshAccessTokenSingleFlight } from "@/auth/oauth-refresh";
+
+describe("refreshAccessTokenSingleFlight", () => {
+  test("coalesces refreshes for the same rotating credential", async () => {
+    let resolveRefresh: ((tokens: TokenResponse) => void) | undefined;
+    const refresh = mock(
+      () =>
+        new Promise<TokenResponse>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+
+    const first = refreshAccessTokenSingleFlight(
+      "refresh-token",
+      "device-id",
+      "listener-name",
+      refresh,
+    );
+    const second = refreshAccessTokenSingleFlight(
+      "refresh-token",
+      "device-id",
+      "hostname",
+      refresh,
+    );
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    resolveRefresh?.({
+      access_token: "new-access-token",
+      refresh_token: "new-refresh-token",
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+
+    expect(await first).toEqual(await second);
+  });
+});

--- a/src/auth/oauth-refresh.ts
+++ b/src/auth/oauth-refresh.ts
@@ -1,0 +1,28 @@
+import { refreshAccessToken, type TokenResponse } from "@/auth/oauth";
+
+type RefreshAccessToken = typeof refreshAccessToken;
+
+const inFlightRefreshes = new Map<string, Promise<TokenResponse>>();
+
+export async function refreshAccessTokenSingleFlight(
+  refreshToken: string,
+  deviceId: string,
+  deviceName?: string,
+  refresh: RefreshAccessToken = refreshAccessToken,
+): Promise<TokenResponse> {
+  const refreshKey = `${refreshToken}\0${deviceId}`;
+  const existing = inFlightRefreshes.get(refreshKey);
+  if (existing) {
+    return await existing;
+  }
+
+  const pending = refresh(refreshToken, deviceId, deviceName);
+  inFlightRefreshes.set(refreshKey, pending);
+  try {
+    return await pending;
+  } finally {
+    if (inFlightRefreshes.get(refreshKey) === pending) {
+      inFlightRefreshes.delete(refreshKey);
+    }
+  }
+}

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -38,6 +38,28 @@ export interface OAuthError {
   error_description?: string;
 }
 
+export class OAuthRefreshError extends Error {
+  readonly retryable: boolean;
+  readonly status?: number;
+  readonly oauthCode?: string;
+
+  constructor(
+    message: string,
+    options: {
+      retryable: boolean;
+      status?: number;
+      oauthCode?: string;
+      cause?: unknown;
+    },
+  ) {
+    super(message, { cause: options.cause });
+    this.name = "OAuthRefreshError";
+    this.retryable = options.retryable;
+    this.status = options.status;
+    this.oauthCode = options.oauthCode;
+  }
+}
+
 export type CredentialValidationFailureReason =
   | "invalid_credentials"
   | "network_error"
@@ -318,14 +340,29 @@ export async function refreshAccessToken(
 
     if (!response.ok) {
       const error = (await response.json()) as OAuthError;
-      throw new Error(
+      throw new OAuthRefreshError(
         `Failed to refresh access token from ${authHost}: ${error.error_description || error.error}`,
+        {
+          retryable:
+            response.status === 408 ||
+            response.status === 429 ||
+            response.status >= 500,
+          status: response.status,
+          oauthCode: error.error,
+        },
       );
     }
 
     return (await response.json()) as TokenResponse;
   } catch (error) {
-    throw toOAuthActionError("refresh access token", error);
+    if (error instanceof OAuthRefreshError) {
+      throw error;
+    }
+    const actionError = toOAuthActionError("refresh access token", error);
+    throw new OAuthRefreshError(actionError.message, {
+      retryable: true,
+      cause: error,
+    });
   }
 }
 

--- a/src/backend/api/client.ts
+++ b/src/backend/api/client.ts
@@ -1,6 +1,7 @@
 import { hostname } from "node:os";
 import Letta from "@letta-ai/letta-client";
-import { LETTA_CLOUD_API_URL, refreshAccessToken } from "@/auth/oauth";
+import { LETTA_CLOUD_API_URL } from "@/auth/oauth";
+import { refreshAccessTokenSingleFlight } from "@/auth/oauth-refresh";
 import { type Settings, settingsManager } from "@/settings-manager";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
 import { isDebugEnabled } from "@/utils/debug";
@@ -213,7 +214,7 @@ export async function getClient() {
         const deviceId = settingsManager.getOrCreateDeviceId();
         const deviceName = hostname();
 
-        const tokens = await refreshAccessToken(
+        const tokens = await refreshAccessTokenSingleFlight(
           settings.refreshToken,
           deviceId,
           deviceName,

--- a/src/cli/commands/listen.ts
+++ b/src/cli/commands/listen.ts
@@ -4,15 +4,12 @@
  */
 
 import { hostname } from "node:os";
-import { getServerUrl } from "@/backend/api/client";
 import type { Buffers, Line } from "@/cli/helpers/accumulator";
 import { buildAgentReference } from "@/cli/helpers/app-urls";
 import { settingsManager } from "@/settings-manager";
 import { getErrorMessage } from "@/utils/error";
-import {
-  deriveListenerInstanceId,
-  registerWithCloudRetry,
-} from "@/websocket/listen-register";
+import { registerWithCloudRetry } from "@/websocket/listen-register";
+import { resolveListenerRegistrationOptions } from "@/websocket/listener/auth";
 
 // tiny helper for unique ids
 function uid(prefix: string) {
@@ -217,43 +214,29 @@ export async function handleListen(
       "running",
     );
 
-    // Register with cloud to get connectionId
-    const serverUrl = getServerUrl();
-    const settings = await settingsManager.getSettingsWithSecureTokens();
-    const apiKey = process.env.LETTA_API_KEY || settings.env?.LETTA_API_KEY;
-
-    if (!apiKey) {
-      throw new Error("Missing LETTA_API_KEY");
-    }
+    const resolveRegisterOptions = () =>
+      resolveListenerRegistrationOptions(deviceId, connectionName, {
+        allowInteractiveOAuth: false,
+        surface: "listen",
+      });
 
     // Register with cloud, retrying transient failures with a bounded backoff.
+    const registerOptions = await resolveRegisterOptions();
     const { connectionId, wsUrl, supportsSplitStatusChannels } =
-      await registerWithCloudRetry(
-        {
-          serverUrl,
-          apiKey,
-          deviceId,
-          connectionName,
-          listenerInstanceId: deriveListenerInstanceId(
-            "listen",
-            connectionName,
-          ),
+      await registerWithCloudRetry(registerOptions, {
+        onRetry: (attempt, delayMs, error) => {
+          updateCommandResult(
+            ctx.buffersRef,
+            ctx.refreshDerived,
+            cmdId,
+            msg,
+            `Registering listener "${connectionName}"...\n` +
+              `Retry ${attempt} in ${Math.round(delayMs / 1000)}s: ${error.message}`,
+            true,
+            "running",
+          );
         },
-        {
-          onRetry: (attempt, delayMs, error) => {
-            updateCommandResult(
-              ctx.buffersRef,
-              ctx.refreshDerived,
-              cmdId,
-              msg,
-              `Registering listener "${connectionName}"...\n` +
-                `Retry ${attempt} in ${Math.round(delayMs / 1000)}s: ${error.message}`,
-              true,
-              "running",
-            );
-          },
-        },
-      );
+      });
 
     updateCommandResult(
       ctx.buffersRef,
@@ -348,17 +331,9 @@ export async function handleListen(
           );
 
           try {
+            const nextRegisterOptions = await resolveRegisterOptions();
             const reregisterResult = await registerWithCloudRetry(
-              {
-                serverUrl,
-                apiKey,
-                deviceId,
-                connectionName,
-                listenerInstanceId: deriveListenerInstanceId(
-                  "listen",
-                  connectionName,
-                ),
-              },
+              nextRegisterOptions,
               {
                 maxDurationMs: Infinity,
                 onRetry: (attempt, delayMs, error) => {

--- a/src/cli/subcommands/listen-auth.test.ts
+++ b/src/cli/subcommands/listen-auth.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import type { DeviceCodeResponse, TokenResponse } from "@/auth/oauth";
+import {
+  type DeviceCodeResponse,
+  OAuthRefreshError,
+  type TokenResponse,
+} from "@/auth/oauth";
 import { settingsManager } from "@/settings-manager";
+import { __listenerAuthTestUtils } from "@/websocket/listener/auth";
 
 const refreshAccessTokenMock = mock(async (): Promise<TokenResponse> => {
   throw new Error("refreshAccessToken not mocked");
@@ -32,7 +37,7 @@ describe("listen subcommand auth resolution", () => {
     refreshAccessTokenMock.mockReset();
     requestDeviceCodeMock.mockReset();
     pollForTokenMock.mockReset();
-    __listenSubcommandTestUtils.setOAuthDepsForTests({
+    __listenerAuthTestUtils.setOAuthDepsForTests({
       LETTA_CLOUD_API_URL: "https://api.letta.com",
       refreshAccessToken: refreshAccessTokenMock,
       requestDeviceCode: requestDeviceCodeMock,
@@ -88,7 +93,7 @@ describe("listen subcommand auth resolution", () => {
     } else {
       process.env.LETTA_LOCAL_BACKEND_EXPERIMENTAL = originalLocalBackend;
     }
-    __listenSubcommandTestUtils.setOAuthDepsForTests(null);
+    __listenerAuthTestUtils.setOAuthDepsForTests(null);
   });
 
   test("prefers explicit LETTA_API_KEY over saved OAuth credentials", async () => {
@@ -183,7 +188,13 @@ describe("listen subcommand auth resolution", () => {
       updateSettingsMock as typeof settingsManager.updateSettings;
     settingsManager.flush = flushMock as typeof settingsManager.flush;
 
-    refreshAccessTokenMock.mockRejectedValue(new Error("refresh broke"));
+    refreshAccessTokenMock.mockRejectedValue(
+      new OAuthRefreshError("refresh token revoked", {
+        retryable: false,
+        status: 400,
+        oauthCode: "invalid_grant",
+      }),
+    );
     requestDeviceCodeMock.mockImplementation(async () => ({
       device_code: "device-code",
       user_code: "ABC123",

--- a/src/cli/subcommands/listen-telemetry.test.ts
+++ b/src/cli/subcommands/listen-telemetry.test.ts
@@ -1,10 +1,8 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import {
-  __listenSubcommandTestUtils,
-  runListenSubcommand,
-} from "@/cli/subcommands/listen";
+import { runListenSubcommand } from "@/cli/subcommands/listen";
 import { settingsManager } from "@/settings-manager";
 import { telemetry } from "@/telemetry";
+import { __listenerAuthTestUtils } from "@/websocket/listener/auth";
 
 type TelemetryTestState = {
   events: unknown[];
@@ -47,7 +45,7 @@ describe("listen subcommand telemetry", () => {
     delete process.env.LETTA_RESTORE_CHANNEL_AGENT_SCOPE;
     delete process.env.LETTA_RESTORE_ENABLED_CHANNELS_AGENT_SCOPE;
     delete process.env.IGNORE_SELF_HOSTED_LISTENER_ERROR;
-    __listenSubcommandTestUtils.setOAuthDepsForTests({
+    __listenerAuthTestUtils.setOAuthDepsForTests({
       LETTA_CLOUD_API_URL: "https://api.letta.com",
     });
 
@@ -116,7 +114,7 @@ describe("listen subcommand telemetry", () => {
         originalIgnoreSelfHostedListenerError;
     }
 
-    __listenSubcommandTestUtils.setOAuthDepsForTests(null);
+    __listenerAuthTestUtils.setOAuthDepsForTests(null);
     telemetry.trackSessionEnd = originalTrackSessionEnd;
     telemetry.flush = originalFlush;
   });

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -10,12 +10,6 @@ import { Box, render, Text } from "ink";
 import TextInput from "ink-text-input";
 import type React from "react";
 import { useState } from "react";
-import {
-  LETTA_CLOUD_API_URL,
-  pollForToken,
-  refreshAccessToken,
-  requestDeviceCode,
-} from "@/auth/oauth";
 import { isLocalBackendEnvEnabled } from "@/backend/local/paths";
 import {
   type ChannelRestoreAgentScope,
@@ -29,12 +23,15 @@ import { settingsManager } from "@/settings-manager";
 import { getListenerTelemetrySurface, telemetry } from "@/telemetry";
 import { RemoteSessionLog } from "@/websocket/listen-log";
 import {
-  deriveListenerInstanceId,
   type RegisterOptions,
   registerWithCloudRetry,
 } from "@/websocket/listen-register";
-
-const LISTENER_TOKEN_REFRESH_WINDOW_MS = 5 * 60 * 1000;
+import {
+  getListenerServerUrl,
+  isCloudListenerServerUrl,
+  MissingListenerApiKeyError,
+  resolveListenerRegistrationOptions,
+} from "@/websocket/listener/auth";
 
 type ListenerProcessAnchor = {
   close: () => void;
@@ -46,33 +43,6 @@ type CreateListenerProcessAnchor = () => ListenerProcessAnchor;
 // Without a retained reference, the MessageChannel anchor could be garbage
 // collected even though it is intended to hold channel-only listeners open.
 const activeListenerProcessAnchors = new Set<ListenerProcessAnchor>();
-
-type ListenerOAuthDeps = {
-  LETTA_CLOUD_API_URL: string;
-  pollForToken: typeof pollForToken;
-  refreshAccessToken: typeof refreshAccessToken;
-  requestDeviceCode: typeof requestDeviceCode;
-};
-
-const defaultListenerOAuthDeps: ListenerOAuthDeps = {
-  LETTA_CLOUD_API_URL,
-  pollForToken,
-  refreshAccessToken,
-  requestDeviceCode,
-};
-
-let listenerOAuthDepsOverride: ListenerOAuthDeps | null = null;
-
-function getListenerOAuthDeps(): ListenerOAuthDeps {
-  return listenerOAuthDepsOverride ?? defaultListenerOAuthDeps;
-}
-
-class MissingListenerApiKeyError extends Error {
-  constructor() {
-    super("LETTA_API_KEY not found");
-    this.name = "MissingListenerApiKeyError";
-  }
-}
 
 /**
  * Interactive prompt for environment name
@@ -143,17 +113,6 @@ async function flushListenerTelemetryEnd(exitReason: string): Promise<void> {
   }
 }
 
-function getListenerServerUrl(settings: {
-  env?: Record<string, string>;
-}): string {
-  const oauthDeps = getListenerOAuthDeps();
-  return (
-    process.env.LETTA_BASE_URL ||
-    settings.env?.LETTA_BASE_URL ||
-    oauthDeps.LETTA_CLOUD_API_URL
-  );
-}
-
 type ListenerStartupMode =
   | { kind: "remote"; serverUrl: string }
   | {
@@ -162,17 +121,6 @@ type ListenerStartupMode =
       backend: "local" | "self-hosted";
     }
   | { kind: "unsupported-self-hosted"; serverUrl: string };
-
-function normalizeListenerBaseUrl(url: string): string {
-  return url.trim().replace(/\/+$/, "");
-}
-
-function isCloudListenerServerUrl(serverUrl: string): boolean {
-  return (
-    normalizeListenerBaseUrl(serverUrl) ===
-    normalizeListenerBaseUrl(getListenerOAuthDeps().LETTA_CLOUD_API_URL)
-  );
-}
 
 async function resolveListenerStartupMode(
   channelNames: string[],
@@ -225,147 +173,12 @@ function resolveChannelRestoreAgentScope(
   );
 }
 
-async function refreshListenerAccessToken(
-  settings: Awaited<
-    ReturnType<typeof settingsManager.getSettingsWithSecureTokens>
-  >,
-  deviceId: string,
-  connectionName: string,
-): Promise<string> {
-  const oauthDeps = getListenerOAuthDeps();
-  const now = Date.now();
-
-  console.log("Access token expired, refreshing...");
-
-  const tokens = await oauthDeps.refreshAccessToken(
-    settings.refreshToken as string,
-    deviceId,
-    connectionName,
-  );
-
-  settingsManager.updateSettings({
-    env: { LETTA_API_KEY: tokens.access_token },
-    tokenExpiresAt: now + tokens.expires_in * 1000,
-    ...(tokens.refresh_token ? { refreshToken: tokens.refresh_token } : {}),
-  });
-  await settingsManager.flush();
-
-  console.log("Token refreshed successfully.");
-
-  return tokens.access_token;
-}
-
-async function runListenerOAuthLogin(
-  deviceId: string,
-  connectionName: string,
-): Promise<string> {
-  const oauthDeps = getListenerOAuthDeps();
-  console.log("No API key found. Starting OAuth login...\n");
-
-  const deviceData = await oauthDeps.requestDeviceCode();
-
-  console.log(
-    `To authenticate, visit: ${deviceData.verification_uri_complete}`,
-  );
-  console.log(`Your code: ${deviceData.user_code}\n`);
-  console.log("Waiting for authorization...\n");
-
-  const tokens = await oauthDeps.pollForToken(
-    deviceData.device_code,
-    deviceData.interval,
-    deviceData.expires_in,
-    deviceId,
-    connectionName,
-  );
-  const now = Date.now();
-
-  settingsManager.updateSettings({
-    env: { LETTA_API_KEY: tokens.access_token },
-    tokenExpiresAt: now + tokens.expires_in * 1000,
-    ...(tokens.refresh_token ? { refreshToken: tokens.refresh_token } : {}),
-  });
-  await settingsManager.flush();
-
-  console.log("Authenticated successfully.\n");
-
-  return tokens.access_token;
-}
-
-async function resolveListenerRegistrationOptions(
-  deviceId: string,
-  connectionName: string,
-): Promise<RegisterOptions> {
-  const settings = await settingsManager.getSettingsWithSecureTokens();
-  const serverUrl = getListenerServerUrl(settings);
-  const envApiKey = process.env.LETTA_API_KEY;
-
-  if (envApiKey) {
-    return {
-      serverUrl,
-      apiKey: envApiKey,
-      deviceId,
-      connectionName,
-      listenerInstanceId: deriveListenerInstanceId("server", connectionName),
-    };
-  }
-
-  let apiKey = settings.env?.LETTA_API_KEY;
-
-  if (isCloudListenerServerUrl(serverUrl)) {
-    const expiresAt = settings.tokenExpiresAt;
-    if (settings.refreshToken && expiresAt) {
-      const now = Date.now();
-      if (!apiKey || now >= expiresAt - LISTENER_TOKEN_REFRESH_WINDOW_MS) {
-        try {
-          apiKey = await refreshListenerAccessToken(
-            settings,
-            deviceId,
-            connectionName,
-          );
-        } catch (refreshErr) {
-          console.warn(
-            "Token refresh failed:",
-            refreshErr instanceof Error
-              ? refreshErr.message
-              : String(refreshErr),
-          );
-          apiKey = undefined;
-        }
-      }
-    }
-
-    if (!apiKey) {
-      apiKey = await runListenerOAuthLogin(deviceId, connectionName);
-    }
-  }
-
-  if (!apiKey) {
-    throw new MissingListenerApiKeyError();
-  }
-
-  return {
-    serverUrl,
-    apiKey,
-    deviceId,
-    connectionName,
-    listenerInstanceId: deriveListenerInstanceId("server", connectionName),
-  };
-}
-
 export const __listenSubcommandTestUtils = {
   createListenerProcessAnchorPromise,
   flushListenerTelemetryEnd,
   getListenerServerUrl,
   resolveListenerStartupMode,
   resolveListenerRegistrationOptions,
-  setOAuthDepsForTests(overrides: Partial<ListenerOAuthDeps> | null) {
-    listenerOAuthDepsOverride = overrides
-      ? {
-          ...defaultListenerOAuthDeps,
-          ...overrides,
-        }
-      : null;
-  },
 };
 
 const LISTEN_OPTIONS = {

--- a/src/settings-manager-auth-cache.test.ts
+++ b/src/settings-manager-auth-cache.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { settingsManager } from "@/settings-manager";
+import {
+  __setSecretGetOverrideForTests,
+  setServiceName,
+} from "@/utils/secrets";
+
+describe("settings auth cache", () => {
+  const originalHome = process.env.HOME;
+  const originalIsKeychainAvailable =
+    settingsManager.isKeychainAvailable.bind(settingsManager);
+  let testHome: string;
+
+  beforeEach(async () => {
+    await settingsManager.reset();
+    testHome = await mkdtemp(join(tmpdir(), "letta-auth-cache-"));
+    process.env.HOME = testHome;
+    setServiceName("letta-code-auth-cache-test");
+    await settingsManager.initialize();
+    settingsManager.isKeychainAvailable = async () => true;
+  });
+
+  afterEach(async () => {
+    settingsManager.isKeychainAvailable = originalIsKeychainAvailable;
+    __setSecretGetOverrideForTests(null);
+    await settingsManager.reset();
+    await rm(testHome, { recursive: true, force: true });
+    process.env.HOME = originalHome;
+    setServiceName("letta-code");
+  });
+
+  test("preserves cached tokens when a later keychain read fails", async () => {
+    __setSecretGetOverrideForTests(async ({ name }) => {
+      if (name === "letta-api-key") return "sk-listener-cache";
+      if (name === "letta-refresh-token") return "rt-listener-cache";
+      return null;
+    });
+    await settingsManager.getSettingsWithSecureTokens();
+
+    __setSecretGetOverrideForTests(async () => {
+      throw new Error("User interaction is not allowed");
+    });
+
+    const settings = await settingsManager.getSettingsWithSecureTokens();
+    expect(settings.env?.LETTA_API_KEY).toBe("sk-listener-cache");
+    expect(settings.refreshToken).toBe("rt-listener-cache");
+  });
+});

--- a/src/settings-manager.ts
+++ b/src/settings-manager.ts
@@ -574,7 +574,7 @@ class SettingsManager {
    */
   async getSettingsWithSecureTokens(): Promise<Settings> {
     const baseSettings = this.getSettings();
-    let secureTokens: SecureTokens = { ...this.secureTokensCache };
+    const secureTokens: SecureTokens = { ...this.secureTokensCache };
 
     // Bun 1.3.0 can crash when keychain reads happen while AsyncLocalStorage
     // runtime scope is active. Reuse cached tokens in that case and let callers
@@ -582,10 +582,10 @@ class SettingsManager {
     if (!getRuntimeContext()) {
       const secretsAvailable = await this.isKeychainAvailable();
       if (secretsAvailable) {
-        secureTokens = {
-          ...secureTokens,
-          ...(await this.getSecureTokens()),
-        };
+        const storedTokens = await this.getSecureTokens();
+        secureTokens.apiKey = storedTokens.apiKey ?? secureTokens.apiKey;
+        secureTokens.refreshToken =
+          storedTokens.refreshToken ?? secureTokens.refreshToken;
       }
     }
 

--- a/src/websocket/listener/auth-lifecycle.test.ts
+++ b/src/websocket/listener/auth-lifecycle.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { WebSocket, WebSocketServer } from "ws";
+import { OAuthRefreshError, type TokenResponse } from "@/auth/oauth";
+import { settingsManager } from "@/settings-manager";
+import {
+  startListenerClient,
+  stopListenerClient,
+} from "@/websocket/listen-client";
+import { __listenerAuthTestUtils } from "@/websocket/listener/auth";
+
+type ListenerSettings = Awaited<
+  ReturnType<typeof settingsManager.getSettingsWithSecureTokens>
+>;
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 300; attempt++) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(message);
+}
+
+describe("listener auth lifecycle", () => {
+  const originalHome = process.env.HOME;
+  const originalDisableCron = process.env.LETTA_DISABLE_CRON_SCHEDULER;
+  const originalDisableMods = process.env.LETTA_DISABLE_MODS;
+  const originalApiKey = process.env.LETTA_API_KEY;
+  const originalBaseUrl = process.env.LETTA_BASE_URL;
+  const originalGetSettingsWithSecureTokens =
+    settingsManager.getSettingsWithSecureTokens;
+  const originalUpdateSettings = settingsManager.updateSettings;
+  const originalFlush = settingsManager.flush;
+
+  let testHome: string;
+  let server: WebSocketServer;
+  let wsUrl: string;
+  let settings: ListenerSettings;
+  let connections: WebSocket[];
+  let authorizations: Array<string | undefined>;
+
+  const refreshAccessTokenMock = mock(async (): Promise<TokenResponse> => {
+    throw new Error("refreshAccessToken not mocked");
+  });
+
+  beforeEach(async () => {
+    stopListenerClient();
+    await settingsManager.reset();
+    testHome = await mkdtemp(join(tmpdir(), "letta-listener-auth-"));
+    process.env.HOME = testHome;
+    process.env.LETTA_DISABLE_CRON_SCHEDULER = "1";
+    process.env.LETTA_DISABLE_MODS = "1";
+    delete process.env.LETTA_API_KEY;
+    delete process.env.LETTA_BASE_URL;
+    await settingsManager.initialize();
+
+    settings = {
+      ...settingsManager.getSettings(),
+      env: { LETTA_API_KEY: "initial-access-token" },
+      refreshToken: "refresh-token",
+      tokenExpiresAt: Date.now() + 60 * 60 * 1000,
+    };
+    refreshAccessTokenMock.mockReset();
+    __listenerAuthTestUtils.setOAuthDepsForTests({
+      LETTA_CLOUD_API_URL: "https://api.letta.com",
+      refreshAccessToken: refreshAccessTokenMock,
+    });
+    settingsManager.getSettingsWithSecureTokens = mock(
+      async () => settings,
+    ) as typeof settingsManager.getSettingsWithSecureTokens;
+    settingsManager.updateSettings = mock((updates) => {
+      settings = {
+        ...settings,
+        ...updates,
+        env: { ...settings.env, ...updates.env },
+      };
+    }) as typeof settingsManager.updateSettings;
+    settingsManager.flush = mock(
+      async () => {},
+    ) as typeof settingsManager.flush;
+
+    connections = [];
+    authorizations = [];
+    server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await new Promise<void>((resolve) => server.once("listening", resolve));
+    const address = server.address() as AddressInfo;
+    wsUrl = `ws://127.0.0.1:${address.port}`;
+    server.on("connection", (socket, request) => {
+      connections.push(socket);
+      authorizations.push(request.headers.authorization);
+    });
+  });
+
+  afterEach(async () => {
+    stopListenerClient();
+    await Promise.all(
+      [...server.clients].map(
+        (connection) =>
+          new Promise<void>((resolve) => {
+            if (connection.readyState === WebSocket.CLOSED) {
+              resolve();
+              return;
+            }
+            connection.once("close", () => resolve());
+            connection.terminate();
+          }),
+      ),
+    );
+    server.close();
+    __listenerAuthTestUtils.setOAuthDepsForTests(null);
+    settingsManager.getSettingsWithSecureTokens =
+      originalGetSettingsWithSecureTokens;
+    settingsManager.updateSettings = originalUpdateSettings;
+    settingsManager.flush = originalFlush;
+    await settingsManager.reset();
+    await rm(testHome, { recursive: true, force: true });
+
+    process.env.HOME = originalHome;
+    if (originalDisableCron === undefined) {
+      delete process.env.LETTA_DISABLE_CRON_SCHEDULER;
+    } else {
+      process.env.LETTA_DISABLE_CRON_SCHEDULER = originalDisableCron;
+    }
+    if (originalDisableMods === undefined) {
+      delete process.env.LETTA_DISABLE_MODS;
+    } else {
+      process.env.LETTA_DISABLE_MODS = originalDisableMods;
+    }
+    if (originalApiKey === undefined) {
+      delete process.env.LETTA_API_KEY;
+    } else {
+      process.env.LETTA_API_KEY = originalApiKey;
+    }
+    if (originalBaseUrl === undefined) {
+      delete process.env.LETTA_BASE_URL;
+    } else {
+      process.env.LETTA_BASE_URL = originalBaseUrl;
+    }
+  });
+
+  function startClient(overrides: { onError?: (error: Error) => void } = {}) {
+    return startListenerClient({
+      connectionId: "connection-id",
+      wsUrl,
+      deviceId: "device-id",
+      connectionName: "listener-name",
+      onConnected: mock(() => {}),
+      onDisconnected: mock(() => {}),
+      onNeedsReregister: mock(() => {}),
+      onError: overrides.onError ?? mock(() => {}),
+    });
+  }
+
+  test("refreshes missing credentials on a real socket reconnect", async () => {
+    await startClient();
+    await waitFor(
+      () => connections.length === 1,
+      "initial socket did not open",
+    );
+    expect(authorizations[0]).toBe("Bearer initial-access-token");
+
+    settings = {
+      ...settings,
+      env: {},
+      refreshToken: "refresh-token",
+      tokenExpiresAt: undefined,
+    };
+    refreshAccessTokenMock.mockResolvedValue({
+      access_token: "refreshed-access-token",
+      refresh_token: "rotated-refresh-token",
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+
+    connections[0]?.close(1000, "reconnect");
+    await waitFor(
+      () => connections.length === 2,
+      "listener did not reconnect with refreshed credentials",
+    );
+
+    expect(authorizations[1]).toBe("Bearer refreshed-access-token");
+    expect(settings.refreshToken).toBe("rotated-refresh-token");
+  });
+
+  test("does not create a socket after stop wins an in-flight refresh", async () => {
+    settings = {
+      ...settings,
+      env: {},
+      refreshToken: "refresh-token",
+      tokenExpiresAt: undefined,
+    };
+    let resolveRefresh: ((tokens: TokenResponse) => void) | undefined;
+    refreshAccessTokenMock.mockImplementation(
+      () =>
+        new Promise<TokenResponse>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+
+    const starting = startClient();
+    await waitFor(
+      () => refreshAccessTokenMock.mock.calls.length === 1,
+      "listener did not begin refreshing credentials",
+    );
+
+    stopListenerClient();
+    resolveRefresh?.({
+      access_token: "late-access-token",
+      refresh_token: "late-refresh-token",
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+    await starting;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(connections).toHaveLength(0);
+  });
+
+  test("retries a transient refresh failure instead of terminating", async () => {
+    const onError = mock(() => {});
+    await startClient({ onError });
+    await waitFor(
+      () => connections.length === 1,
+      "initial socket did not open",
+    );
+
+    settings = {
+      ...settings,
+      env: { LETTA_API_KEY: "expired-access-token" },
+      tokenExpiresAt: Date.now() - 1,
+    };
+    refreshAccessTokenMock
+      .mockRejectedValueOnce(
+        new OAuthRefreshError("auth service unavailable", {
+          retryable: true,
+          status: 503,
+        }),
+      )
+      .mockResolvedValueOnce({
+        access_token: "recovered-access-token",
+        refresh_token: "recovered-refresh-token",
+        token_type: "Bearer",
+        expires_in: 3600,
+      });
+
+    connections[0]?.close(1000, "reconnect");
+    await waitFor(
+      () => connections.length === 2,
+      "listener did not retry the transient refresh failure",
+    );
+
+    expect(authorizations[1]).toBe("Bearer recovered-access-token");
+    expect(refreshAccessTokenMock).toHaveBeenCalledTimes(2);
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/src/websocket/listener/auth.test.ts
+++ b/src/websocket/listener/auth.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  type DeviceCodeResponse,
+  OAuthRefreshError,
+  type TokenResponse,
+} from "@/auth/oauth";
+import { settingsManager } from "@/settings-manager";
+import {
+  __listenerAuthTestUtils,
+  ListenerReauthenticationRequiredError,
+  resolveListenerReconnectAuth,
+  resolveListenerRegistrationOptions,
+} from "@/websocket/listener/auth";
+
+type ListenerSettings = Awaited<
+  ReturnType<typeof settingsManager.getSettingsWithSecureTokens>
+>;
+
+const refreshAccessTokenMock = mock(async (): Promise<TokenResponse> => {
+  throw new Error("refreshAccessToken not mocked");
+});
+const requestDeviceCodeMock = mock(async (): Promise<DeviceCodeResponse> => {
+  throw new Error("requestDeviceCode not mocked");
+});
+const pollForTokenMock = mock(async (): Promise<TokenResponse> => {
+  throw new Error("pollForToken not mocked");
+});
+
+describe("listener auth", () => {
+  const originalGetSettingsWithSecureTokens =
+    settingsManager.getSettingsWithSecureTokens;
+  const originalUpdateSettings = settingsManager.updateSettings;
+  const originalFlush = settingsManager.flush;
+  const originalConsoleLog = console.log;
+  const originalConsoleWarn = console.warn;
+  const originalApiKey = process.env.LETTA_API_KEY;
+  const originalBaseUrl = process.env.LETTA_BASE_URL;
+
+  let settings: ListenerSettings;
+  const updateSettingsMock = mock(() => {});
+  const flushMock = mock(async () => {});
+
+  beforeEach(() => {
+    settings = { env: {} } as ListenerSettings;
+    refreshAccessTokenMock.mockReset();
+    requestDeviceCodeMock.mockReset();
+    pollForTokenMock.mockReset();
+    updateSettingsMock.mockReset();
+    flushMock.mockReset();
+    __listenerAuthTestUtils.setOAuthDepsForTests({
+      LETTA_CLOUD_API_URL: "https://api.letta.com",
+      refreshAccessToken: refreshAccessTokenMock,
+      requestDeviceCode: requestDeviceCodeMock,
+      pollForToken: pollForTokenMock,
+    });
+    settingsManager.getSettingsWithSecureTokens = mock(
+      async () => settings,
+    ) as typeof settingsManager.getSettingsWithSecureTokens;
+    settingsManager.updateSettings =
+      updateSettingsMock as typeof settingsManager.updateSettings;
+    settingsManager.flush = flushMock as typeof settingsManager.flush;
+
+    delete process.env.LETTA_API_KEY;
+    delete process.env.LETTA_BASE_URL;
+    console.log = mock(() => {}) as typeof console.log;
+    console.warn = mock(() => {}) as typeof console.warn;
+  });
+
+  afterEach(() => {
+    settingsManager.getSettingsWithSecureTokens =
+      originalGetSettingsWithSecureTokens;
+    settingsManager.updateSettings = originalUpdateSettings;
+    settingsManager.flush = originalFlush;
+    __listenerAuthTestUtils.setOAuthDepsForTests(null);
+    console.log = originalConsoleLog;
+    console.warn = originalConsoleWarn;
+
+    if (originalApiKey === undefined) {
+      delete process.env.LETTA_API_KEY;
+    } else {
+      process.env.LETTA_API_KEY = originalApiKey;
+    }
+    if (originalBaseUrl === undefined) {
+      delete process.env.LETTA_BASE_URL;
+    } else {
+      process.env.LETTA_BASE_URL = originalBaseUrl;
+    }
+  });
+
+  test("refreshes a missing access token and persists refresh rotation", async () => {
+    settings = {
+      ...settings,
+      env: {},
+      refreshToken: "refresh-token",
+    };
+    refreshAccessTokenMock.mockResolvedValue({
+      access_token: "new-access-token",
+      refresh_token: "rotated-refresh-token",
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+
+    expect(
+      await resolveListenerReconnectAuth({
+        deviceId: "device-id",
+        connectionName: "listener-name",
+      }),
+    ).toEqual({ kind: "ready", apiKey: "new-access-token" });
+    expect(updateSettingsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: { LETTA_API_KEY: "new-access-token" },
+        refreshToken: "rotated-refresh-token",
+        tokenExpiresAt: expect.any(Number),
+      }),
+    );
+    expect(flushMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("keeps a still-valid token when proactive refresh fails transiently", async () => {
+    settings = {
+      ...settings,
+      env: { LETTA_API_KEY: "still-valid" },
+      refreshToken: "refresh-token",
+      tokenExpiresAt: Date.now() + 60_000,
+    };
+    refreshAccessTokenMock.mockRejectedValue(
+      new OAuthRefreshError("auth service unavailable", {
+        retryable: true,
+        status: 503,
+      }),
+    );
+
+    expect(
+      await resolveListenerReconnectAuth({
+        deviceId: "device-id",
+        connectionName: "listener-name",
+      }),
+    ).toEqual({ kind: "ready", apiKey: "still-valid" });
+    expect(requestDeviceCodeMock).not.toHaveBeenCalled();
+  });
+
+  test("marks transient refresh failure retryable after access expires", async () => {
+    settings = {
+      ...settings,
+      env: { LETTA_API_KEY: "expired" },
+      refreshToken: "refresh-token",
+      tokenExpiresAt: Date.now() - 1,
+    };
+    refreshAccessTokenMock.mockRejectedValue(
+      new OAuthRefreshError("network unavailable", { retryable: true }),
+    );
+
+    expect(
+      await resolveListenerReconnectAuth({
+        deviceId: "device-id",
+        connectionName: "listener-name",
+      }),
+    ).toEqual({ kind: "retry" });
+  });
+
+  test("surfaces revoked refresh credentials without starting device OAuth", async () => {
+    settings = {
+      ...settings,
+      env: { LETTA_API_KEY: "expired" },
+      refreshToken: "revoked-refresh-token",
+      tokenExpiresAt: Date.now() - 1,
+    };
+    refreshAccessTokenMock.mockRejectedValue(
+      new OAuthRefreshError("invalid_grant", {
+        retryable: false,
+        status: 400,
+        oauthCode: "invalid_grant",
+      }),
+    );
+
+    await expect(
+      resolveListenerReconnectAuth({
+        deviceId: "device-id",
+        connectionName: "listener-name",
+      }),
+    ).rejects.toBeInstanceOf(ListenerReauthenticationRequiredError);
+    expect(requestDeviceCodeMock).not.toHaveBeenCalled();
+  });
+
+  test("builds fresh in-app registration options from current credentials", async () => {
+    settings = {
+      ...settings,
+      env: { LETTA_API_KEY: "first-access-token" },
+    };
+    const first = await resolveListenerRegistrationOptions(
+      "device-id",
+      "listener-name",
+      { allowInteractiveOAuth: false, surface: "listen" },
+    );
+
+    settings = {
+      ...settings,
+      env: { LETTA_API_KEY: "refreshed-access-token" },
+    };
+    const second = await resolveListenerRegistrationOptions(
+      "device-id",
+      "listener-name",
+      { allowInteractiveOAuth: false, surface: "listen" },
+    );
+
+    expect(first.apiKey).toBe("first-access-token");
+    expect(second.apiKey).toBe("refreshed-access-token");
+    expect(second.listenerInstanceId).toStartWith("listen-");
+  });
+});

--- a/src/websocket/listener/auth.ts
+++ b/src/websocket/listener/auth.ts
@@ -1,0 +1,296 @@
+import {
+  LETTA_CLOUD_API_URL,
+  OAuthRefreshError,
+  pollForToken,
+  refreshAccessToken,
+  requestDeviceCode,
+} from "@/auth/oauth";
+import { refreshAccessTokenSingleFlight } from "@/auth/oauth-refresh";
+import { settingsManager } from "@/settings-manager";
+import {
+  deriveListenerInstanceId,
+  type RegisterOptions,
+} from "@/websocket/listen-register";
+import type { StartListenerOptions } from "@/websocket/listener/types";
+
+const LISTENER_TOKEN_REFRESH_WINDOW_MS = 5 * 60 * 1000;
+
+type ListenerSettings = Awaited<
+  ReturnType<typeof settingsManager.getSettingsWithSecureTokens>
+>;
+
+type ListenerOAuthDeps = {
+  LETTA_CLOUD_API_URL: string;
+  pollForToken: typeof pollForToken;
+  refreshAccessToken: typeof refreshAccessToken;
+  requestDeviceCode: typeof requestDeviceCode;
+};
+
+type ListenerAuthOptions = {
+  allowInteractiveOAuth?: boolean;
+};
+
+type ListenerRegistrationOptions = ListenerAuthOptions & {
+  surface?: "server" | "listen";
+};
+
+const defaultListenerOAuthDeps: ListenerOAuthDeps = {
+  LETTA_CLOUD_API_URL,
+  pollForToken,
+  refreshAccessToken,
+  requestDeviceCode,
+};
+
+let listenerOAuthDepsOverride: ListenerOAuthDeps | null = null;
+
+function getListenerOAuthDeps(): ListenerOAuthDeps {
+  return listenerOAuthDepsOverride ?? defaultListenerOAuthDeps;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export class MissingListenerApiKeyError extends Error {
+  constructor() {
+    super("LETTA_API_KEY not found");
+    this.name = "MissingListenerApiKeyError";
+  }
+}
+
+class ListenerAuthRetryableError extends Error {
+  constructor(refreshError: unknown) {
+    super(
+      `Could not refresh listener credentials: ${errorMessage(refreshError)}`,
+    );
+    this.name = "ListenerAuthRetryableError";
+  }
+}
+
+export class ListenerReauthenticationRequiredError extends Error {
+  constructor(refreshError?: unknown) {
+    const detail = refreshError ? `: ${errorMessage(refreshError)}` : "";
+    super(
+      `Saved Letta API credentials require reauthentication${detail}. Run letta to sign in again, or set LETTA_API_KEY.`,
+    );
+    this.name = "ListenerReauthenticationRequiredError";
+  }
+}
+
+export function getListenerServerUrl(settings: {
+  env?: Record<string, string>;
+}): string {
+  return (
+    process.env.LETTA_BASE_URL ||
+    settings.env?.LETTA_BASE_URL ||
+    getListenerOAuthDeps().LETTA_CLOUD_API_URL
+  );
+}
+
+function normalizeListenerBaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+export function isCloudListenerServerUrl(serverUrl: string): boolean {
+  return (
+    normalizeListenerBaseUrl(serverUrl) ===
+    normalizeListenerBaseUrl(getListenerOAuthDeps().LETTA_CLOUD_API_URL)
+  );
+}
+
+function shouldRefreshListenerAccessToken(
+  settings: ListenerSettings,
+  apiKey: string | undefined,
+): boolean {
+  if (!settings.refreshToken) {
+    return false;
+  }
+  if (!apiKey) {
+    return true;
+  }
+  return (
+    settings.tokenExpiresAt !== undefined &&
+    Date.now() >= settings.tokenExpiresAt - LISTENER_TOKEN_REFRESH_WINDOW_MS
+  );
+}
+
+function isAccessTokenStillValid(
+  settings: ListenerSettings,
+  apiKey: string | undefined,
+): apiKey is string {
+  return Boolean(
+    apiKey &&
+      (settings.tokenExpiresAt === undefined ||
+        Date.now() < settings.tokenExpiresAt),
+  );
+}
+
+async function refreshListenerAccessToken(
+  settings: ListenerSettings,
+  deviceId: string,
+  connectionName: string,
+): Promise<string> {
+  if (!settings.refreshToken) {
+    throw new MissingListenerApiKeyError();
+  }
+
+  const now = Date.now();
+  console.log("Access token expired, refreshing...");
+
+  const tokens = await refreshAccessTokenSingleFlight(
+    settings.refreshToken,
+    deviceId,
+    connectionName,
+    getListenerOAuthDeps().refreshAccessToken,
+  );
+
+  settingsManager.updateSettings({
+    env: { LETTA_API_KEY: tokens.access_token },
+    refreshToken: tokens.refresh_token ?? settings.refreshToken,
+    tokenExpiresAt: now + tokens.expires_in * 1000,
+  });
+  await settingsManager.flush();
+
+  console.log("Token refreshed successfully.");
+  return tokens.access_token;
+}
+
+async function runListenerOAuthLogin(
+  deviceId: string,
+  connectionName: string,
+): Promise<string> {
+  const oauthDeps = getListenerOAuthDeps();
+  console.log("No API key found. Starting OAuth login...\n");
+
+  const deviceData = await oauthDeps.requestDeviceCode();
+  console.log(
+    `To authenticate, visit: ${deviceData.verification_uri_complete}`,
+  );
+  console.log(`Your code: ${deviceData.user_code}\n`);
+  console.log("Waiting for authorization...\n");
+
+  const tokens = await oauthDeps.pollForToken(
+    deviceData.device_code,
+    deviceData.interval,
+    deviceData.expires_in,
+    deviceId,
+    connectionName,
+  );
+  const now = Date.now();
+
+  settingsManager.updateSettings({
+    env: { LETTA_API_KEY: tokens.access_token },
+    ...(tokens.refresh_token ? { refreshToken: tokens.refresh_token } : {}),
+    tokenExpiresAt: now + tokens.expires_in * 1000,
+  });
+  await settingsManager.flush();
+
+  console.log("Authenticated successfully.\n");
+  return tokens.access_token;
+}
+
+async function resolveListenerAuth(
+  deviceId: string,
+  connectionName: string,
+  options: ListenerAuthOptions,
+): Promise<{ serverUrl: string; apiKey: string }> {
+  const allowInteractiveOAuth = options.allowInteractiveOAuth ?? true;
+  const settings = await settingsManager.getSettingsWithSecureTokens();
+  const serverUrl = getListenerServerUrl(settings);
+  const envApiKey = process.env.LETTA_API_KEY;
+
+  if (envApiKey) {
+    return { serverUrl, apiKey: envApiKey };
+  }
+
+  let apiKey = settings.env?.LETTA_API_KEY;
+  if (!isCloudListenerServerUrl(serverUrl)) {
+    if (!apiKey) {
+      throw new MissingListenerApiKeyError();
+    }
+    return { serverUrl, apiKey };
+  }
+
+  if (shouldRefreshListenerAccessToken(settings, apiKey)) {
+    try {
+      apiKey = await refreshListenerAccessToken(
+        settings,
+        deviceId,
+        connectionName,
+      );
+    } catch (refreshError) {
+      const retryable =
+        !(refreshError instanceof OAuthRefreshError) || refreshError.retryable;
+      if (retryable && isAccessTokenStillValid(settings, apiKey)) {
+        console.warn(
+          `Token refresh failed; using the current access token: ${errorMessage(refreshError)}`,
+        );
+        return { serverUrl, apiKey };
+      }
+      if (retryable) {
+        throw new ListenerAuthRetryableError(refreshError);
+      }
+      if (!allowInteractiveOAuth) {
+        throw new ListenerReauthenticationRequiredError(refreshError);
+      }
+
+      console.warn(`Token refresh failed: ${errorMessage(refreshError)}`);
+      apiKey = undefined;
+    }
+  }
+
+  if (!apiKey) {
+    if (!allowInteractiveOAuth) {
+      throw new ListenerReauthenticationRequiredError();
+    }
+    apiKey = await runListenerOAuthLogin(deviceId, connectionName);
+  }
+
+  return { serverUrl, apiKey };
+}
+
+export async function resolveListenerRegistrationOptions(
+  deviceId: string,
+  connectionName: string,
+  options: ListenerRegistrationOptions = {},
+): Promise<RegisterOptions> {
+  const auth = await resolveListenerAuth(deviceId, connectionName, options);
+  return {
+    ...auth,
+    deviceId,
+    connectionName,
+    listenerInstanceId: deriveListenerInstanceId(
+      options.surface ?? "server",
+      connectionName,
+    ),
+  };
+}
+
+export async function resolveListenerReconnectAuth(
+  options: Pick<StartListenerOptions, "deviceId" | "connectionName">,
+): Promise<{ kind: "ready"; apiKey: string } | { kind: "retry" }> {
+  try {
+    const auth = await resolveListenerAuth(
+      options.deviceId,
+      options.connectionName,
+      { allowInteractiveOAuth: false },
+    );
+    return { kind: "ready", apiKey: auth.apiKey };
+  } catch (error) {
+    if (error instanceof ListenerAuthRetryableError) {
+      return { kind: "retry" };
+    }
+    throw error;
+  }
+}
+
+export const __listenerAuthTestUtils = {
+  setOAuthDepsForTests(overrides: Partial<ListenerOAuthDeps> | null) {
+    listenerOAuthDepsOverride = overrides
+      ? {
+          ...defaultListenerOAuthDeps,
+          ...overrides,
+        }
+      : null;
+  },
+};

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -37,6 +37,7 @@ import { isDebugEnabled } from "@/utils/debug";
 import { setMessageQueueAdder } from "@/utils/message-queue-bridge";
 import { killAllTerminals } from "@/websocket/terminal-handler";
 import { rejectPendingApprovalResolvers } from "./approval";
+import { resolveListenerReconnectAuth } from "./auth";
 import {
   recoverActiveChannelTurn,
   uniqueChannelTurnSources,
@@ -1442,9 +1443,7 @@ export async function startLocalChannelListener(
   }
 }
 
-/**
- * Connect to WebSocket with exponential backoff retry.
- */
+/** Connect to WebSocket with exponential backoff retry. */
 async function connectWithRetry(
   runtime: ListenerRuntime,
   opts: StartListenerOptions,
@@ -1496,12 +1495,13 @@ async function connectWithRetry(
     await loadTools();
   }
 
-  const settings = await settingsManager.getSettingsWithSecureTokens();
-  const apiKey = process.env.LETTA_API_KEY || settings.env?.LETTA_API_KEY;
-
-  if (!apiKey) {
-    throw new Error("Missing LETTA_API_KEY");
+  const auth = await resolveListenerReconnectAuth(opts);
+  if (auth.kind === "retry")
+    return connectWithRetry(runtime, opts, attempt + 1, startTime);
+  if (runtime !== getActiveRuntime() || runtime.intentionallyClosed) {
+    return;
   }
+  const apiKey = auth.apiKey;
 
   const url = new URL(opts.wsUrl);
   url.searchParams.set("deviceId", opts.deviceId);


### PR DESCRIPTION
## Summary
- resolve listener credentials through one cache-first OAuth path for startup, reconnect, and re-registration
- preserve cached secure tokens across transient keychain failures and coalesce rotating refreshes with the API client
- keep a still-valid access token on transient proactive-refresh failure, retry expired-token failures with listener backoff, and surface revoked credentials as reauthentication
- prevent a stopped or replaced listener from opening a socket after an awaited refresh
- cover keychain fallback, refresh classification/coalescing, fresh re-registration credentials, real WebSocket reconnects, transient retry, and stop-during-refresh

Supersedes #3337.

👾 Generated with [Letta Code](https://letta.com)