### PR TITLE
fix(listener): load agent-scoped MemFS mods [LET-9646]

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -27,7 +27,7 @@
   "src/index.ts": 2854,
   "src/mods/learning-harness.ts": 2434,
   "src/mods/mod-engine.test.ts": 2178,
-  "src/mods/mod-engine.ts": 1919,
+  "src/mods/mod-engine.ts": 1879,
   "src/mods/package-installer.test.ts": 1248,
   "src/mods/package-installer.ts": 1201,
   "src/mods/package-registry.ts": 1033,
@@ -38,7 +38,7 @@
   "src/settings-manager.ts": 2113,
   "src/tools/impl/enter-worktree.ts": 1260,
   "src/tools/impl/message-channel.ts": 1187,
-  "src/tools/manager.ts": 3293,
+  "src/tools/manager.ts": 3282,
   "src/tools/tool-execution-context.test.ts": 1422,
   "src/types/protocol_v2.ts": 2940,
   "src/websocket/listen-client-concurrency.test.ts": 3016,
@@ -48,5 +48,5 @@
   "src/websocket/listener/file-commands.ts": 1030,
   "src/websocket/listener/lifecycle.ts": 1766,
   "src/websocket/listener/protocol-inbound.ts": 2279,
-  "src/websocket/listener/protocol-outbound.ts": 1287
+  "src/websocket/listener/protocol-outbound.ts": 1284
 }

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -48,5 +48,5 @@
   "src/websocket/listener/file-commands.ts": 1030,
   "src/websocket/listener/lifecycle.ts": 1766,
   "src/websocket/listener/protocol-inbound.ts": 2279,
-  "src/websocket/listener/protocol-outbound.ts": 1284
+  "src/websocket/listener/protocol-outbound.ts": 1283
 }

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -48,5 +48,5 @@
   "src/websocket/listener/file-commands.ts": 1030,
   "src/websocket/listener/lifecycle.ts": 1766,
   "src/websocket/listener/protocol-inbound.ts": 2279,
-  "src/websocket/listener/protocol-outbound.ts": 1283
+  "src/websocket/listener/protocol-outbound.ts": 1281
 }

--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -13,11 +13,11 @@ import type { MessageCreateParams as ConversationMessageCreateParams } from "@le
 import { type Backend, getBackend } from "@/backend";
 import {
   type ClientTool,
-  type PermissionModeState,
   type PreparedToolExecutionContext,
   prepareCurrentToolExecutionContext,
   waitForToolsetReady,
 } from "@/tools/manager";
+import type { PermissionModeState } from "@/tools/permission-mode-state";
 import { debugLog, debugWarn, isDebugEnabled } from "@/utils/debug";
 import {
   assertSupportedBase64ImageMediaTypes,

--- a/src/cli/helpers/approval-classification.ts
+++ b/src/cli/helpers/approval-classification.ts
@@ -1,9 +1,6 @@
 import type { ApprovalContext } from "@/permissions/analyzer";
-import {
-  checkToolPermission,
-  getToolSchema,
-  type PermissionModeState,
-} from "@/tools/manager";
+import { checkToolPermission, getToolSchema } from "@/tools/manager";
+import type { PermissionModeState } from "@/tools/permission-mode-state";
 import { safeJsonParseOr } from "./safe-json-parse";
 import type { ApprovalRequest } from "./stream-processor";
 

--- a/src/mods/disabled-mod-adapter.ts
+++ b/src/mods/disabled-mod-adapter.ts
@@ -20,6 +20,7 @@ function createDisabledModRegistry(): LocalModRegistry {
     ownerAbortControllers: {},
     owners: {},
     permissions: {},
+    registerCapabilitiesGlobally: false,
     sources: [],
     tools: {},
     ui: {
@@ -68,6 +69,12 @@ export function createDisabledModAdapter() {
   return {
     dispose() {},
     events,
+    getAvailablePermissions() {
+      return new Map();
+    },
+    getAvailableTools() {
+      return new Map();
+    },
     getBackend() {
       return undefined;
     },

--- a/src/mods/mod-adapter.ts
+++ b/src/mods/mod-adapter.ts
@@ -11,6 +11,15 @@ import {
   type ResolveLocalModSourcesOptions,
   resolveLocalModSources,
 } from "@/mods/mod-engine";
+import {
+  filterAvailableModPermissionsRegistry,
+  type ModPermissionDefinition,
+} from "@/mods/permission-registry";
+import {
+  filterAvailableModToolsRegistry,
+  type ModToolDefinition,
+} from "@/mods/tool-registry";
+import type { ModContext } from "@/mods/types";
 import { debugLog } from "@/utils/debug";
 
 const RUNTIME_DIAGNOSTICS_WRITE_DELAY_MS = 30_000;
@@ -34,6 +43,12 @@ export interface CreateModAdapterOptions extends CreateModEngineOptions {
 export interface ModAdapter {
   dispose: () => void;
   events: ModEvents;
+  getAvailablePermissions: (
+    context?: ModContext | null,
+  ) => Map<string, ModPermissionDefinition>;
+  getAvailableTools: (
+    context?: ModContext | null,
+  ) => Map<string, ModToolDefinition>;
   getBackend: () => Backend | undefined;
   getSnapshot: () => ModAdapterSnapshot;
   engine: ModEngine;
@@ -217,6 +232,18 @@ export function createModAdapter(options: CreateModAdapterOptions): ModAdapter {
       listeners.clear();
     },
     events,
+    getAvailablePermissions(context) {
+      return filterAvailableModPermissionsRegistry(
+        new Map(Object.entries(engine.getSnapshot().permissions)),
+        context,
+      );
+    },
+    getAvailableTools(context) {
+      return filterAvailableModToolsRegistry(
+        new Map(Object.entries(engine.getSnapshot().tools)),
+        context,
+      );
+    },
     getBackend,
     getSnapshot,
     engine,

--- a/src/mods/mod-engine.ts
+++ b/src/mods/mod-engine.ts
@@ -34,19 +34,17 @@ import {
   attachDeprecatedGetContextTrap,
   recordDeprecatedContextApiSourceDiagnostics,
 } from "@/mods/deprecated-api";
-import {
-  isModFileExtension,
-  isTypeScriptModFileExtension,
-} from "@/mods/file-extensions";
+import { isTypeScriptModFileExtension } from "@/mods/file-extensions";
 import {
   appendModDiagnostic,
   recordModDiagnostic,
   recordStaleHandleUse,
 } from "@/mods/mod-diagnostics";
-import {
-  type ManagedModPackageDiagnostic,
-  resolveManagedModPackages,
-} from "@/mods/package-registry";
+import type {
+  LocalModSource,
+  ResolveLocalModSourcesOptions,
+} from "@/mods/mod-sources";
+import { resolveLocalModSources } from "@/mods/mod-sources";
 import {
   getGlobalModsDirectory,
   getLegacyGlobalExtensionsDirectory,
@@ -54,12 +52,14 @@ import {
 } from "@/mods/paths";
 import {
   getModPermissionDefinition,
+  type ModPermissionDefinition,
   registerModPermission,
   unregisterModPermission,
   unregisterModPermissionsForOwner,
 } from "@/mods/permission-registry";
 import {
   getModToolDefinition,
+  type ModToolDefinition,
   registerModTool,
   unregisterModTool,
   unregisterModToolsForOwner,
@@ -96,6 +96,12 @@ import type {
   ModTurnStartCancelResult,
   ModTurnStartEvent,
 } from "@/mods/types";
+
+export type {
+  LocalModSource,
+  ResolveLocalModSourcesOptions,
+} from "@/mods/mod-sources";
+export { resolveLocalModSources } from "@/mods/mod-sources";
 
 export const GLOBAL_MODS_DIRECTORY = getGlobalModsDirectory();
 export const LEGACY_GLOBAL_EXTENSIONS_DIRECTORY =
@@ -195,32 +201,16 @@ export interface LocalModRegistry {
   loadedPaths: string[];
   ownerAbortControllers: Record<string, AbortController>;
   owners: Record<string, ModOwner>;
-  permissions: Record<string, ModPermission>;
+  permissions: Record<string, ModPermissionDefinition>;
+  registerCapabilitiesGlobally: boolean;
   sources: LocalModSource[];
-  tools: Record<string, ModTool>;
+  tools: Record<string, ModToolDefinition>;
   ui: LocalModUiRegistry;
-}
-
-export interface LocalModSource {
-  diagnostics?: ManagedModPackageDiagnostic[];
-  files: string[];
-  legacyMigrationTargetRoot?: string;
-  managedPackageRoots?: string[];
-  root: string;
-  scope: ModSourceScope;
-  trusted: boolean;
 }
 
 interface LocalModModule {
   activate?: unknown;
   default?: unknown;
-}
-
-export interface ResolveLocalModSourcesOptions {
-  agentModsDirectory?: string;
-  cacheDirectory?: string;
-  globalModsDirectory?: string;
-  legacyGlobalExtensionsDirectory?: string;
 }
 
 export interface LoadLocalModsOptions extends ResolveLocalModSourcesOptions {
@@ -230,6 +220,7 @@ export interface LoadLocalModsOptions extends ResolveLocalModSourcesOptions {
   generation?: number;
   onChange?: () => void;
   onDiagnostic?: (diagnostic: ModDiagnostic) => void;
+  registerCapabilitiesGlobally?: boolean;
   reservedToolNames?: Iterable<string>;
 }
 
@@ -251,20 +242,8 @@ export interface CreateModEngineOptions extends ResolveLocalModSourcesOptions {
   builtinCommandIds?: Iterable<string>;
   capabilities?: ModCapabilities;
   onDiagnostic?: (diagnostic: ModDiagnostic) => void;
+  registerCapabilitiesGlobally?: boolean;
   reservedToolNames?: Iterable<string>;
-}
-
-function listModFiles(directory: string): string[] {
-  if (!existsSync(directory)) return [];
-
-  return readdirSync(directory, { withFileTypes: true })
-    .filter((entry) => {
-      if (!entry.isFile()) return false;
-      if (entry.name.startsWith(".")) return false;
-      return isModFileExtension(path.extname(entry.name));
-    })
-    .map((entry) => path.join(directory, entry.name))
-    .sort((a, b) => a.localeCompare(b));
 }
 
 function getModSourcePriority(scope: ModSourceScope): number {
@@ -298,64 +277,11 @@ function isShadowedByOwner(owner: ModOwner, existingOwner?: ModOwner): boolean {
   );
 }
 
-export function resolveLocalModSources(
-  options: ResolveLocalModSourcesOptions = {},
-): LocalModSource[] {
-  const globalModsDirectory =
-    options.globalModsDirectory ?? getGlobalModsDirectory();
-  const legacyGlobalExtensionsDirectory =
-    options.legacyGlobalExtensionsDirectory ??
-    (options.globalModsDirectory
-      ? undefined
-      : getLegacyGlobalExtensionsDirectory());
-  const managedPackages = resolveManagedModPackages(globalModsDirectory);
-  const globalDiagnostics = managedPackages.diagnostics;
-  const sources: LocalModSource[] = [];
-
-  if (
-    legacyGlobalExtensionsDirectory &&
-    path.resolve(legacyGlobalExtensionsDirectory) !==
-      path.resolve(globalModsDirectory) &&
-    existsSync(legacyGlobalExtensionsDirectory)
-  ) {
-    sources.push({
-      files: listModFiles(legacyGlobalExtensionsDirectory),
-      legacyMigrationTargetRoot: globalModsDirectory,
-      root: legacyGlobalExtensionsDirectory,
-      scope: "legacy_global",
-      trusted: true,
-    });
-  }
-
-  sources.push({
-    ...(globalDiagnostics.length > 0 ? { diagnostics: globalDiagnostics } : {}),
-    files: [...listModFiles(globalModsDirectory), ...managedPackages.files],
-    ...(managedPackages.packages.length > 0
-      ? {
-          managedPackageRoots: managedPackages.packages.map((pkg) => pkg.root),
-        }
-      : {}),
-    root: globalModsDirectory,
-    scope: "global",
-    trusted: true,
-  });
-
-  if (options.agentModsDirectory) {
-    sources.push({
-      files: listModFiles(options.agentModsDirectory),
-      root: options.agentModsDirectory,
-      scope: "agent",
-      trusted: true,
-    });
-  }
-
-  return sources;
-}
-
 function createEmptyModRegistry(
   sources: LocalModSource[],
   generation: number,
   capabilities: ModCapabilities,
+  registerCapabilitiesGlobally: boolean,
 ): LocalModRegistry {
   return {
     capabilities: cloneModCapabilities(capabilities),
@@ -368,6 +294,7 @@ function createEmptyModRegistry(
     ownerAbortControllers: {},
     owners: {},
     permissions: {},
+    registerCapabilitiesGlobally,
     sources,
     tools: {},
     ui: {
@@ -432,8 +359,10 @@ function removeOwnerCapabilities(
   registry: LocalModRegistry,
   owner: ModOwner,
 ): void {
-  unregisterPiProvidersForOwner(owner.id);
-  clearAvailableModelsCache();
+  if (registry.registerCapabilitiesGlobally) {
+    unregisterPiProvidersForOwner(owner.id);
+    clearAvailableModelsCache();
+  }
 
   for (const [id, command] of Object.entries(registry.commands)) {
     if (command.owner?.id === owner.id) {
@@ -458,13 +387,22 @@ function removeOwnerCapabilities(
     }
   }
 
+  for (const [id, permission] of Object.entries(registry.permissions)) {
+    if (permission.owner?.id === owner.id) {
+      delete registry.permissions[id];
+    }
+  }
+
   for (const [name, tool] of Object.entries(registry.tools)) {
     if (tool.owner?.id === owner.id) {
       delete registry.tools[name];
     }
   }
 
-  unregisterModToolsForOwner(owner);
+  if (registry.registerCapabilitiesGlobally) {
+    unregisterModPermissionsForOwner(owner);
+    unregisterModToolsForOwner(owner);
+  }
 
   delete registry.owners[owner.id];
 }
@@ -1074,7 +1012,9 @@ function createLettaModApi(
     const existing = registry.permissions[id];
     if (existing?.owner?.id === owner.id) {
       delete registry.permissions[id];
-      unregisterModPermission(id, owner);
+      if (registry.registerCapabilitiesGlobally) {
+        unregisterModPermission(id, owner);
+      }
       onChange();
     }
   };
@@ -1109,7 +1049,9 @@ function createLettaModApi(
     const existing = registry.tools[name];
     if (existing?.owner?.id === owner.id) {
       delete registry.tools[name];
-      unregisterModTool(name, owner);
+      if (registry.registerCapabilitiesGlobally) {
+        unregisterModTool(name, owner);
+      }
       onChange();
     }
   };
@@ -1305,12 +1247,15 @@ function createLettaModApi(
           );
         }
 
-        registry.tools[normalized.name] = normalized;
-        registerModTool({
+        const definition: ModToolDefinition = {
           ...normalized,
           activationSignal: signal,
           recordDiagnostic: recordCapabilityDiagnostic,
-        });
+        };
+        registry.tools[normalized.name] = definition;
+        if (registry.registerCapabilitiesGlobally) {
+          registerModTool(definition);
+        }
         onChange();
 
         return () => unregisterTool(normalized.name);
@@ -1357,12 +1302,15 @@ function createLettaModApi(
           );
         }
 
-        registry.permissions[normalized.id] = normalized;
-        registerModPermission({
+        const definition: ModPermissionDefinition = {
           ...normalized,
           activationSignal: signal,
           recordDiagnostic: recordCapabilityDiagnostic,
-        });
+        };
+        registry.permissions[normalized.id] = definition;
+        if (registry.registerCapabilitiesGlobally) {
+          registerModPermission(definition);
+        }
         onChange();
 
         return () => unregisterPermission(normalized.id);
@@ -1494,7 +1442,12 @@ export async function loadLocalMods(
   const generation = options.generation ?? 1;
   const builtinCommandIds = new Set([...(options.builtinCommandIds ?? [])]);
   const reservedToolNames = new Set([...(options.reservedToolNames ?? [])]);
-  const registry = createEmptyModRegistry(sources, generation, capabilities);
+  const registry = createEmptyModRegistry(
+    sources,
+    generation,
+    capabilities,
+    options.registerCapabilitiesGlobally !== false,
+  );
 
   for (const source of sources) {
     for (const diagnostic of source.diagnostics ?? []) {
@@ -1787,12 +1740,14 @@ export function disposeLocalMods(registry: LocalModRegistry): void {
     }
   }
 
-  for (const owner of Object.values(registry.owners)) {
-    unregisterPiProvidersForOwner(owner.id);
-    unregisterModPermissionsForOwner(owner);
-    unregisterModToolsForOwner(owner);
+  if (registry.registerCapabilitiesGlobally) {
+    for (const owner of Object.values(registry.owners)) {
+      unregisterPiProvidersForOwner(owner.id);
+      unregisterModPermissionsForOwner(owner);
+      unregisterModToolsForOwner(owner);
+    }
+    clearAvailableModelsCache();
   }
-  clearAvailableModelsCache();
 
   registry.commands = {};
   registry.events = {};
@@ -1808,10 +1763,13 @@ export function createModEngine(options: CreateModEngineOptions): ModEngine {
   let generation = 0;
   let disposed = false;
   const capabilities = resolveModCapabilities(modOptions.capabilities);
+  const registerCapabilitiesGlobally =
+    modOptions.registerCapabilitiesGlobally !== false;
   let activeRegistry = createEmptyModRegistry(
     resolveLocalModSources(modOptions),
     generation,
     capabilities,
+    registerCapabilitiesGlobally,
   );
   let snapshot = snapshotRegistryForReaders(activeRegistry);
   const listeners = new Set<() => void>();
@@ -1833,6 +1791,7 @@ export function createModEngine(options: CreateModEngineOptions): ModEngine {
       resolveLocalModSources(modOptions),
       loadGeneration,
       capabilities,
+      registerCapabilitiesGlobally,
     );
     publish();
 
@@ -1883,6 +1842,7 @@ export function createModEngine(options: CreateModEngineOptions): ModEngine {
         resolveLocalModSources(modOptions),
         generation,
         capabilities,
+        registerCapabilitiesGlobally,
       );
       publish();
       listeners.clear();

--- a/src/mods/mod-sources.ts
+++ b/src/mods/mod-sources.ts
@@ -1,0 +1,106 @@
+import { existsSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { isModFileExtension } from "@/mods/file-extensions";
+import {
+  type ManagedModPackageDiagnostic,
+  resolveManagedModPackages,
+} from "@/mods/package-registry";
+import {
+  getGlobalModsDirectory,
+  getLegacyGlobalExtensionsDirectory,
+} from "@/mods/paths";
+import type { ModSourceScope } from "@/mods/types";
+
+export interface LocalModSource {
+  diagnostics?: ManagedModPackageDiagnostic[];
+  files: string[];
+  legacyMigrationTargetRoot?: string;
+  managedPackageRoots?: string[];
+  root: string;
+  scope: ModSourceScope;
+  trusted: boolean;
+}
+
+export interface ResolveLocalModSourcesOptions {
+  agentModsDirectory?: string;
+  cacheDirectory?: string;
+  globalModsDirectory?: string;
+  includeGlobalMods?: boolean;
+  legacyGlobalExtensionsDirectory?: string;
+}
+
+function listModFiles(directory: string): string[] {
+  if (!existsSync(directory)) return [];
+
+  return readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => {
+      if (!entry.isFile()) return false;
+      if (entry.name.startsWith(".")) return false;
+      return isModFileExtension(path.extname(entry.name));
+    })
+    .map((entry) => path.join(directory, entry.name))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+export function resolveLocalModSources(
+  options: ResolveLocalModSourcesOptions = {},
+): LocalModSource[] {
+  const globalModsDirectory =
+    options.globalModsDirectory ?? getGlobalModsDirectory();
+  const legacyGlobalExtensionsDirectory =
+    options.legacyGlobalExtensionsDirectory ??
+    (options.globalModsDirectory
+      ? undefined
+      : getLegacyGlobalExtensionsDirectory());
+  const includeGlobalMods = options.includeGlobalMods !== false;
+  const managedPackages = includeGlobalMods
+    ? resolveManagedModPackages(globalModsDirectory)
+    : { diagnostics: [], files: [], packages: [] };
+  const sources: LocalModSource[] = [];
+
+  if (
+    includeGlobalMods &&
+    legacyGlobalExtensionsDirectory &&
+    path.resolve(legacyGlobalExtensionsDirectory) !==
+      path.resolve(globalModsDirectory) &&
+    existsSync(legacyGlobalExtensionsDirectory)
+  ) {
+    sources.push({
+      files: listModFiles(legacyGlobalExtensionsDirectory),
+      legacyMigrationTargetRoot: globalModsDirectory,
+      root: legacyGlobalExtensionsDirectory,
+      scope: "legacy_global",
+      trusted: true,
+    });
+  }
+
+  if (includeGlobalMods) {
+    sources.push({
+      ...(managedPackages.diagnostics.length > 0
+        ? { diagnostics: managedPackages.diagnostics }
+        : {}),
+      files: [...listModFiles(globalModsDirectory), ...managedPackages.files],
+      ...(managedPackages.packages.length > 0
+        ? {
+            managedPackageRoots: managedPackages.packages.map(
+              (pkg) => pkg.root,
+            ),
+          }
+        : {}),
+      root: globalModsDirectory,
+      scope: "global",
+      trusted: true,
+    });
+  }
+
+  if (options.agentModsDirectory) {
+    sources.push({
+      files: listModFiles(options.agentModsDirectory),
+      root: options.agentModsDirectory,
+      scope: "agent",
+      trusted: true,
+    });
+  }
+
+  return sources;
+}

--- a/src/mods/permission-registry.ts
+++ b/src/mods/permission-registry.ts
@@ -47,35 +47,43 @@ function getMutableModPermissionsRegistry(): Map<
   return global[MOD_PERMISSIONS_KEY];
 }
 
-export function getAvailableModPermissionsRegistry(
+export function filterAvailableModPermissionsRegistry(
+  registry: Map<string, ModPermissionDefinition>,
   context?: ModContext | null,
 ): Map<string, ModPermissionDefinition> {
   if (areModsDisabled()) return new Map();
 
   return new Map(
-    Array.from(getMutableModPermissionsRegistry().entries()).filter(
-      ([, permission]) => {
-        if (permission.activationSignal.aborted) return false;
-        try {
-          return context
-            ? (permission.isEnabled?.(
-                attachDeprecatedGetContextTrap(
-                  { ...context },
-                  permission.recordDiagnostic,
-                  "ctx.getContext",
-                ),
-              ) ?? true)
-            : true;
-        } catch (error) {
-          permission.recordDiagnostic?.({
-            capability: { id: permission.id, kind: "permission" },
-            error: toError(error),
-            phase: "permission.isEnabled",
-          });
-          return false;
-        }
-      },
-    ),
+    Array.from(registry.entries()).filter(([, permission]) => {
+      if (permission.activationSignal.aborted) return false;
+      try {
+        return context
+          ? (permission.isEnabled?.(
+              attachDeprecatedGetContextTrap(
+                { ...context },
+                permission.recordDiagnostic,
+                "ctx.getContext",
+              ),
+            ) ?? true)
+          : true;
+      } catch (error) {
+        permission.recordDiagnostic?.({
+          capability: { id: permission.id, kind: "permission" },
+          error: toError(error),
+          phase: "permission.isEnabled",
+        });
+        return false;
+      }
+    }),
+  );
+}
+
+export function getAvailableModPermissionsRegistry(
+  context?: ModContext | null,
+): Map<string, ModPermissionDefinition> {
+  return filterAvailableModPermissionsRegistry(
+    getMutableModPermissionsRegistry(),
+    context,
   );
 }
 

--- a/src/mods/tool-registry.ts
+++ b/src/mods/tool-registry.ts
@@ -38,13 +38,14 @@ function getMutableModToolsRegistry(): Map<string, ModToolDefinition> {
   return global[MOD_TOOLS_KEY];
 }
 
-export function getAvailableModToolsRegistry(
+export function filterAvailableModToolsRegistry(
+  registry: Map<string, ModToolDefinition>,
   context?: ModContext | null,
 ): Map<string, ModToolDefinition> {
   if (areModsDisabled()) return new Map();
 
   return new Map(
-    Array.from(getMutableModToolsRegistry().entries()).filter(([, tool]) => {
+    Array.from(registry.entries()).filter(([, tool]) => {
       if (tool.activationSignal.aborted) return false;
       try {
         return context
@@ -66,6 +67,12 @@ export function getAvailableModToolsRegistry(
       }
     }),
   );
+}
+
+export function getAvailableModToolsRegistry(
+  context?: ModContext | null,
+): Map<string, ModToolDefinition> {
+  return filterAvailableModToolsRegistry(getMutableModToolsRegistry(), context);
 }
 
 export function registerModTool(tool: ModToolDefinition): void {

--- a/src/permissions/checker.ts
+++ b/src/permissions/checker.ts
@@ -15,7 +15,7 @@ import {
   modToolApprovalPolicy,
 } from "@/mods/tool-registry";
 import type { ModContext } from "@/mods/types";
-import type { PermissionModeState } from "@/tools/manager";
+import type { PermissionModeState } from "@/tools/permission-mode-state";
 import { canonicalToolName, isShellToolName } from "./canonical";
 import { cliPermissions } from "./cli-permissions-instance";
 import { evaluateCrossAgentGuard, extractFilePath } from "./cross-agent-guard";

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -51,10 +51,6 @@ import type {
   ModToolStartEvent,
   ToolApprovalPolicy,
 } from "@/mods/types";
-import {
-  permissionMode as globalPermissionMode,
-  type PermissionMode,
-} from "@/permissions/mode";
 import type {
   PermissionDecision,
   PermissionRuleType,
@@ -78,6 +74,10 @@ import {
   type ModelFacingToolForm,
   serializeFunctionOnlyToolPayload,
 } from "./model-facing-tool";
+import {
+  getEffectivePermissionModeState,
+  type PermissionModeState,
+} from "./permission-mode-state";
 import {
   extractSecretEnvFromCommand,
   scrubSecretsFromString,
@@ -675,15 +675,6 @@ function getSwitchLock(): SwitchLockState {
 const toolRegistry = getRegistry();
 let toolExecutionContextCounter = 0;
 
-/**
- * Mutable, shared-by-reference permission mode state.
- * Listener mode populates this from ConversationRuntime; CLI mode uses a
- * wrapper around the global permissionMode singleton.
- */
-export type PermissionModeState = {
-  mode: PermissionMode;
-};
-
 type ToolExecutionContextSnapshot = {
   toolRegistry: ToolRegistry;
   externalTools: Map<string, ExternalToolDefinition>;
@@ -1122,23 +1113,6 @@ function buildClientToolsFromSnapshot(
   return [...builtInTools, ...externalClientTools, ...modClientTools];
 }
 
-function getEffectivePermissionModeState(
-  permissionModeState?: PermissionModeState,
-): PermissionModeState {
-  // When no scoped state is provided (local/CLI mode), create a live proxy to
-  // the global singleton.
-  return (
-    permissionModeState ?? {
-      get mode() {
-        return globalPermissionMode.getMode();
-      },
-      set mode(value: PermissionMode) {
-        globalPermissionMode.setMode(value);
-      },
-    }
-  );
-}
-
 function capturePreparedToolExecutionContext(
   snapshot: {
     toolRegistry: ToolRegistry;
@@ -1256,6 +1230,8 @@ export async function prepareCurrentToolExecutionContext(options?: {
   channelTurnSources?: ChannelTurnSource[];
   modContext?: ModContext;
   modEvents?: ModEvents;
+  modPermissions?: Map<string, ModPermissionDefinition>;
+  modTools?: Map<string, ModToolDefinition>;
 }): Promise<PreparedToolExecutionContext> {
   await waitForToolsetReady();
   const currentToolNames = maybeAppendChannelTools(
@@ -1270,8 +1246,11 @@ export async function prepareCurrentToolExecutionContext(options?: {
       externalExecutor: getExternalToolExecutor(),
       modContext: options?.modContext,
       modEvents: options?.modEvents,
-      modPermissions: getAvailableModPermissionsRegistry(options?.modContext),
-      modTools: getAvailableModToolsRegistry(options?.modContext),
+      modPermissions:
+        options?.modPermissions ??
+        getAvailableModPermissionsRegistry(options?.modContext),
+      modTools:
+        options?.modTools ?? getAvailableModToolsRegistry(options?.modContext),
     },
     options,
   );
@@ -1288,6 +1267,8 @@ export async function prepareToolExecutionContextForSpecificTools(
     channelTurnSources?: ChannelTurnSource[];
     modContext?: ModContext;
     modEvents?: ModEvents;
+    modPermissions?: Map<string, ModPermissionDefinition>;
+    modTools?: Map<string, ModToolDefinition>;
     runtimeContext?: Partial<RuntimeContextSnapshot>;
   },
 ): Promise<PreparedToolExecutionContext> {
@@ -1302,8 +1283,11 @@ export async function prepareToolExecutionContextForSpecificTools(
       externalExecutor: getExternalToolExecutor(),
       modContext: options?.modContext,
       modEvents: options?.modEvents,
-      modPermissions: getAvailableModPermissionsRegistry(options?.modContext),
-      modTools: getAvailableModToolsRegistry(options?.modContext),
+      modPermissions:
+        options?.modPermissions ??
+        getAvailableModPermissionsRegistry(options?.modContext),
+      modTools:
+        options?.modTools ?? getAvailableModToolsRegistry(options?.modContext),
     },
     options,
   );
@@ -1322,6 +1306,8 @@ export async function prepareToolExecutionContextForModel(
     channelTurnSources?: ChannelTurnSource[];
     modContext?: ModContext;
     modEvents?: ModEvents;
+    modPermissions?: Map<string, ModPermissionDefinition>;
+    modTools?: Map<string, ModToolDefinition>;
     runtimeContext?: Partial<RuntimeContextSnapshot>;
   },
 ): Promise<PreparedToolExecutionContext> {
@@ -1336,8 +1322,11 @@ export async function prepareToolExecutionContextForModel(
       externalExecutor: getExternalToolExecutor(),
       modContext: options?.modContext,
       modEvents: options?.modEvents,
-      modPermissions: getAvailableModPermissionsRegistry(options?.modContext),
-      modTools: getAvailableModToolsRegistry(options?.modContext),
+      modPermissions:
+        options?.modPermissions ??
+        getAvailableModPermissionsRegistry(options?.modContext),
+      modTools:
+        options?.modTools ?? getAvailableModToolsRegistry(options?.modContext),
     },
     options,
   );

--- a/src/tools/permission-mode-state.ts
+++ b/src/tools/permission-mode-state.ts
@@ -1,0 +1,24 @@
+import {
+  permissionMode as globalPermissionMode,
+  type PermissionMode,
+} from "@/permissions/mode";
+
+/** Mutable, shared-by-reference permission mode state. */
+export type PermissionModeState = {
+  mode: PermissionMode;
+};
+
+export function getEffectivePermissionModeState(
+  permissionModeState?: PermissionModeState,
+): PermissionModeState {
+  return (
+    permissionModeState ?? {
+      get mode() {
+        return globalPermissionMode.getMode();
+      },
+      set mode(value: PermissionMode) {
+        globalPermissionMode.setMode(value);
+      },
+    }
+  );
+}

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -11,6 +11,9 @@ import type { ChannelTurnSource, SupportedChannelId } from "@/channels/types";
 import { experimentManager } from "@/experiments/manager";
 import { buildModInvocationContext } from "@/mods/context";
 import type { ModEvents } from "@/mods/event-emitter";
+import type { ModAdapter } from "@/mods/mod-adapter";
+import type { ModPermissionDefinition } from "@/mods/permission-registry";
+import type { ModToolDefinition } from "@/mods/tool-registry";
 import type { ModContext } from "@/mods/types";
 import {
   type InheritedChannelContextPayload,
@@ -32,11 +35,11 @@ import {
   loadTools,
   OPENAI_DEFAULT_TOOLS,
   OPENAI_PASCAL_TOOLS,
-  type PermissionModeState,
   type PreparedToolExecutionContext,
   prepareToolExecutionContextForModel,
   prepareToolExecutionContextForSpecificTools,
 } from "./manager";
+import type { PermissionModeState } from "./permission-mode-state";
 import type { ToolName } from "./tool-definitions";
 
 // Toolset definitions from manager.ts (single source of truth)
@@ -109,6 +112,28 @@ export type PreparedScopeToolContext = {
   agent: AgentState | null;
 };
 
+function mergeModAdapterCapabilities(
+  adapters: ModAdapter[] | undefined,
+  context: ModContext,
+): {
+  permissions?: Map<string, ModPermissionDefinition>;
+  tools?: Map<string, ModToolDefinition>;
+} {
+  if (!adapters) return {};
+
+  const permissions = new Map<string, ModPermissionDefinition>();
+  const tools = new Map<string, ModToolDefinition>();
+  for (const adapter of adapters) {
+    for (const [id, permission] of adapter.getAvailablePermissions(context)) {
+      permissions.set(id, permission);
+    }
+    for (const [name, tool] of adapter.getAvailableTools(context)) {
+      tools.set(name, tool);
+    }
+  }
+  return { permissions, tools };
+}
+
 function getPreferredAgentModelHandle(
   agent: ScopeModelCarrier | null | undefined,
 ): string | null {
@@ -171,6 +196,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
   channelToolScope?: MessageChannelToolDiscoveryScope | null;
   modContext?: ModContext;
   modEvents?: ModEvents;
+  modAdapters?: ModAdapter[];
   runtimeContext?: Partial<RuntimeContextSnapshot>;
   agent?: AgentState | null;
 }): Promise<PreparedScopeToolContext> {
@@ -187,6 +213,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
     channelToolScope,
     modContext,
     modEvents,
+    modAdapters,
     runtimeContext,
     agent,
   } = params;
@@ -209,6 +236,10 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
       toolset: derivedToolset,
       workingDirectory,
     });
+    const modCapabilities = mergeModAdapterCapabilities(
+      modAdapters,
+      scopedModContext,
+    );
     const preparedToolContext = await prepareToolExecutionContextForModel(
       effectiveModel ?? undefined,
       {
@@ -220,6 +251,8 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
         channelToolScope,
         modContext: scopedModContext,
         modEvents,
+        modPermissions: modCapabilities.permissions,
+        modTools: modCapabilities.tools,
         runtimeContext,
       },
     );
@@ -243,6 +276,10 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
     toolset: toolsetPreference,
     workingDirectory,
   });
+  const modCapabilities = mergeModAdapterCapabilities(
+    modAdapters,
+    scopedModContext,
+  );
   const preparedToolContext = await prepareToolExecutionContextForSpecificTools(
     filterBuiltInToolNamesByClientAllowlist(
       getToolNamesForToolset(toolsetPreference, channelToolScope).filter(
@@ -258,6 +295,8 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
       channelToolScope,
       modContext: scopedModContext,
       modEvents,
+      modPermissions: modCapabilities.permissions,
+      modTools: modCapabilities.tools,
       runtimeContext,
     },
   );
@@ -431,6 +470,7 @@ export async function prepareToolExecutionContextForScope(params: {
   channelTurnSources?: import("@/channels/types").ChannelTurnSource[];
   modContext?: ModContext;
   modEvents?: ModEvents;
+  modAdapters?: ModAdapter[];
 }): Promise<PreparedScopeToolContext> {
   const {
     agentId,
@@ -447,6 +487,7 @@ export async function prepareToolExecutionContextForScope(params: {
     channelTurnSources: explicitChannelTurnSources,
     modContext,
     modEvents,
+    modAdapters,
   } = params;
 
   const backend = getBackend();
@@ -520,6 +561,7 @@ export async function prepareToolExecutionContextForScope(params: {
     permissionModeState,
     modContext,
     modEvents,
+    modAdapters,
     agent: agent as AgentState,
     runtimeContext: {
       agentId,

--- a/src/websocket/listener-warmup.test.ts
+++ b/src/websocket/listener-warmup.test.ts
@@ -1,5 +1,15 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type WebSocket from "ws";
 import { __listenClientTestUtils } from "@/websocket/listen-client";
+import { replaySyncStateForRuntime } from "@/websocket/listener/lifecycle";
+import {
+  __listenerModAdapterTestUtils,
+  disposeListenerModAdapter,
+} from "@/websocket/listener/mod-adapter";
+import type { ListenerTransport } from "@/websocket/listener/transport";
 import {
   __listenerWarmupTestUtils,
   ensureListenerWarmStateForTurn,
@@ -7,7 +17,7 @@ import {
   scheduleListenerWarmupsAfterSync,
 } from "@/websocket/listener/warmup";
 
-const memfsWarmupMock = mock(async () => {});
+const memfsWarmupMock = mock(async () => true);
 const secretsWarmupMock = mock(async () => {});
 const fetchAgentMetadataMock = mock(
   async (): Promise<ListenerAgentMetadata> => ({
@@ -18,8 +28,15 @@ const fetchAgentMetadataMock = mock(
 );
 
 describe("listener warmup scheduling", () => {
+  beforeEach(() => {
+    __listenerModAdapterTestUtils.setEnsureMemfsSyncedForAgentForTests(
+      async () => true,
+    );
+  });
+
   afterEach(() => {
     __listenerWarmupTestUtils.resetWarmupDepsForTests();
+    __listenerModAdapterTestUtils.resetForTests();
     memfsWarmupMock.mockReset();
     secretsWarmupMock.mockReset();
     fetchAgentMetadataMock.mockReset();
@@ -32,8 +49,8 @@ describe("listener warmup scheduling", () => {
 
     memfsWarmupMock.mockImplementationOnce(
       () =>
-        new Promise<void>((resolve) => {
-          resolveMemfs = resolve;
+        new Promise<boolean>((resolve) => {
+          resolveMemfs = () => resolve(true);
         }),
     );
     secretsWarmupMock.mockImplementationOnce(
@@ -87,5 +104,101 @@ describe("listener warmup scheduling", () => {
     expect(memfsWarmupMock).toHaveBeenCalledTimes(2);
     expect(secretsWarmupMock).toHaveBeenCalledTimes(2);
     expect(fetchAgentMetadataMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("advertises scoped mod commands after background warmup", async () => {
+    const root = mkdtempSync(join(tmpdir(), "letta-listener-warmup-mod-"));
+    const modsDirectory = join(root, "agent-memory", "mods");
+    mkdirSync(modsDirectory, { recursive: true });
+    writeFileSync(
+      join(modsDirectory, "warmup-command.js"),
+      `export default function activate(letta) {
+        letta.commands.register({
+          id: "warmup-command",
+          description: "Loaded after sync replay",
+          run() { return "ready"; },
+        });
+      }`,
+    );
+
+    const sentPayloads: string[] = [];
+    const transport: ListenerTransport = {
+      kind: "local",
+      bufferedAmount: 0,
+      isOpen: () => true,
+      send: (payload: string) => sentPayloads.push(payload),
+    };
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    listener.transport = transport;
+    __listenerModAdapterTestUtils.setAgentModsDirectoryResolverForTests(
+      () => modsDirectory,
+    );
+    __listenerModAdapterTestUtils.setAgentModCacheDirectoryResolverForTests(
+      () => join(root, "listener-cache"),
+    );
+    __listenerModAdapterTestUtils.setEnsureMemfsSyncedForAgentForTests(
+      async () => true,
+    );
+    __listenerWarmupTestUtils.setWarmupDepsForTests({
+      ensureMemfsSyncedForAgent: async () => true,
+      ensureSecretsHydratedForAgent: async () => {},
+      fetchListenerAgentMetadata: async () => ({
+        name: "Warmup Agent",
+        description: null,
+        lastRunAt: null,
+      }),
+    });
+
+    let warmup: Promise<ListenerAgentMetadata | null> | undefined;
+    try {
+      await replaySyncStateForRuntime(
+        listener,
+        transport as unknown as WebSocket,
+        { agent_id: "agent-warmup", conversation_id: "default" },
+        {
+          recoverApprovals: false,
+          scheduleWarmupsAfterSync: (runtime, scope) => {
+            warmup = ensureListenerWarmStateForTurn(runtime, {
+              agentId: scope.agent_id,
+              conversationId: scope.conversation_id,
+            });
+          },
+        },
+      );
+      await warmup;
+
+      const deviceStatuses = sentPayloads
+        .map((payload) => JSON.parse(payload))
+        .filter((message) => message.type === "update_device_status");
+      expect(deviceStatuses).toHaveLength(2);
+      expect(deviceStatuses[0]?.device_status.mod_commands).toBeUndefined();
+      expect(deviceStatuses[1]).toMatchObject({
+        runtime: {
+          agent_id: "agent-warmup",
+          conversation_id: "default",
+        },
+        device_status: {
+          mod_commands: [
+            {
+              id: "warmup-command",
+              description: "Loaded after sync replay",
+            },
+          ],
+        },
+      });
+
+      await ensureListenerWarmStateForTurn(listener, {
+        agentId: "agent-warmup",
+        conversationId: "default",
+      });
+      expect(
+        sentPayloads
+          .map((payload) => JSON.parse(payload))
+          .filter((message) => message.type === "update_device_status"),
+      ).toHaveLength(2);
+    } finally {
+      disposeListenerModAdapter(listener);
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/src/websocket/listener/agent-mod-isolation.test.ts
+++ b/src/websocket/listener/agent-mod-isolation.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
 import {
   mkdirSync,
@@ -47,6 +47,12 @@ function useFakeAgent(agentId: string): void {
     ),
   );
 }
+
+beforeEach(() => {
+  __listenerModAdapterTestUtils.setEnsureMemfsSyncedForAgentForTests(
+    async () => true,
+  );
+});
 
 afterEach(() => {
   __listenerModAdapterTestUtils.resetForTests();
@@ -229,6 +235,139 @@ describe("listener agent-scoped mods", () => {
     globalAdapter.dispose();
     agentAAdapter.dispose();
     agentBAdapter.dispose();
+  });
+
+  test("waits for MemFS sync before caching the agent adapter", async () => {
+    const root = createTempDir();
+    const memoryRoot = join(root, "agent-memory");
+    const modsDirectory = join(memoryRoot, "mods");
+    mkdirSync(modsDirectory, { recursive: true });
+    const modPath = join(modsDirectory, "sync-state.js");
+    const writeTool = (toolName: string): void => {
+      writeFileSync(
+        modPath,
+        `export default function activate(letta) {
+          letta.tools.register({
+            name: "${toolName}",
+            description: "MemFS sync state",
+            parameters: { type: "object", properties: {} },
+            run() { return "${toolName}"; },
+          });
+        }`,
+      );
+    };
+    writeTool("stale_before_sync");
+    execFileSync("git", ["init", "-q"], { cwd: memoryRoot });
+    execFileSync("git", ["add", "mods/sync-state.js"], { cwd: memoryRoot });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=Listener Test",
+        "-c",
+        "user.email=listener@example.com",
+        "commit",
+        "-qm",
+        "stale mod",
+      ],
+      { cwd: memoryRoot },
+    );
+
+    let resolveSync: ((succeeded: boolean) => void) | undefined;
+    let syncCalls = 0;
+    __listenerModAdapterTestUtils.setEnsureMemfsSyncedForAgentForTests(
+      async () => {
+        syncCalls += 1;
+        return new Promise<boolean>((resolve) => {
+          resolveSync = resolve;
+        });
+      },
+    );
+    __listenerModAdapterTestUtils.setAgentModsDirectoryResolverForTests(
+      () => modsDirectory,
+    );
+    __listenerModAdapterTestUtils.setAgentModCacheDirectoryResolverForTests(
+      () => join(root, "listener-cache"),
+    );
+    const listener = {
+      agentModAdapters: new Map(),
+      agentModAdapterLoads: new Map(),
+      bootWorkingDirectory: root,
+      sessionId: "listener-sync-order-test",
+    } as unknown as ListenerRuntime;
+
+    const firstLoad = ensureListenerAgentModAdapter(listener, "agent-a");
+    const joinedLoad = ensureListenerAgentModAdapter(listener, "agent-a");
+    expect(syncCalls).toBe(1);
+    expect(listener.agentModAdapters?.has("agent-a")).toBe(false);
+
+    writeTool("fresh_after_sync");
+    execFileSync("git", ["add", "mods/sync-state.js"], { cwd: memoryRoot });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=Listener Test",
+        "-c",
+        "user.email=listener@example.com",
+        "commit",
+        "-qm",
+        "synced mod",
+      ],
+      { cwd: memoryRoot },
+    );
+    resolveSync?.(true);
+
+    const [firstAdapter, joinedAdapter] = await Promise.all([
+      firstLoad,
+      joinedLoad,
+    ]);
+    expect(firstAdapter).not.toBeNull();
+    expect(joinedAdapter).toBe(firstAdapter);
+    expect(
+      Object.keys(firstAdapter?.getSnapshot().registry.tools ?? {}),
+    ).toEqual(["fresh_after_sync"]);
+    expect(
+      execFileSync("git", ["status", "--porcelain"], {
+        cwd: memoryRoot,
+        encoding: "utf8",
+      }),
+    ).toBe("");
+
+    disposeListenerModAdapter(listener);
+  });
+
+  test("does not cache an adapter when shutdown cancels an in-flight sync", async () => {
+    const root = createTempDir();
+    const modsDirectory = join(root, "agent-memory", "mods");
+    mkdirSync(modsDirectory, { recursive: true });
+    writeFileSync(
+      join(modsDirectory, "cancelled.js"),
+      "export default function activate() {}",
+    );
+    let resolveSync: ((succeeded: boolean) => void) | undefined;
+    __listenerModAdapterTestUtils.setEnsureMemfsSyncedForAgentForTests(
+      async () =>
+        new Promise<boolean>((resolve) => {
+          resolveSync = resolve;
+        }),
+    );
+    __listenerModAdapterTestUtils.setAgentModsDirectoryResolverForTests(
+      () => modsDirectory,
+    );
+    const listener = {
+      agentModAdapters: new Map(),
+      agentModAdapterLoads: new Map(),
+      bootWorkingDirectory: root,
+      sessionId: "listener-sync-cancel-test",
+    } as unknown as ListenerRuntime;
+
+    const load = ensureListenerAgentModAdapter(listener, "agent-a");
+    disposeListenerModAdapter(listener);
+    resolveSync?.(true);
+
+    await expect(load).resolves.toBeNull();
+    expect(listener.agentModAdapters?.has("agent-a")).toBe(false);
   });
 
   test("uses distinct module identity for identical stateful agent mods", async () => {

--- a/src/websocket/listener/agent-mod-isolation.test.ts
+++ b/src/websocket/listener/agent-mod-isolation.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { __testSetBackend } from "@/backend";
@@ -223,6 +229,123 @@ describe("listener agent-scoped mods", () => {
     globalAdapter.dispose();
     agentAAdapter.dispose();
     agentBAdapter.dispose();
+  });
+
+  test("uses distinct module identity for identical stateful agent mods", async () => {
+    const root = createTempDir();
+    const agentARoot = join(root, "agent-a-memory");
+    const agentBRoot = join(root, "agent-b-memory");
+    const agentADir = join(agentARoot, "mods");
+    const agentBDir = join(agentBRoot, "mods");
+    const cacheRoot = join(root, "listener-cache");
+    const source = `let activationCount = 0;
+      export default function activate(letta) {
+        activationCount += 1;
+        letta.tools.register({
+          name: "stateful_counter",
+          description: "Returns this module instance activation count",
+          parameters: { type: "object", properties: {} },
+          requiresApproval: false,
+          run() { return String(activationCount); },
+        });
+      }`;
+    const sourceTimestamp = new Date("2025-01-01T00:00:00.000Z");
+
+    for (const memoryRoot of [agentARoot, agentBRoot]) {
+      const modsDirectory = join(memoryRoot, "mods");
+      mkdirSync(modsDirectory, { recursive: true });
+      const modPath = join(modsDirectory, "stateful.js");
+      writeFileSync(modPath, source);
+      utimesSync(modPath, sourceTimestamp, sourceTimestamp);
+      execFileSync("git", ["init", "-q"], { cwd: memoryRoot });
+      execFileSync("git", ["add", "mods/stateful.js"], { cwd: memoryRoot });
+      execFileSync(
+        "git",
+        [
+          "-c",
+          "user.name=Listener Test",
+          "-c",
+          "user.email=listener@example.com",
+          "commit",
+          "-qm",
+          "stateful mod",
+        ],
+        { cwd: memoryRoot },
+      );
+    }
+
+    __listenerModAdapterTestUtils.setAgentModsDirectoryResolverForTests(
+      (agentId) =>
+        agentId === "agent-a"
+          ? agentADir
+          : agentId === "agent-b"
+            ? agentBDir
+            : null,
+    );
+    __listenerModAdapterTestUtils.setAgentModCacheDirectoryResolverForTests(
+      (agentId) => join(cacheRoot, agentId),
+    );
+    const listener = {
+      agentModAdapters: new Map(),
+      agentModAdapterLoads: new Map(),
+      bootWorkingDirectory: root,
+      sessionId: "listener-module-isolation-test",
+    } as unknown as ListenerRuntime;
+
+    const [agentAAdapter, agentBAdapter] = await Promise.all([
+      ensureListenerAgentModAdapter(listener, "agent-a"),
+      ensureListenerAgentModAdapter(listener, "agent-b"),
+    ]);
+    expect(agentAAdapter).not.toBeNull();
+    expect(agentBAdapter).not.toBeNull();
+
+    useFakeAgent("agent-a");
+    const preparedA = await prepareToolExecutionContextForScope({
+      agentId: "agent-a",
+      conversationId: "default",
+      clientToolAllowlist: ["stateful_counter"],
+      modAdapters: agentAAdapter ? [agentAAdapter] : [],
+    });
+    useFakeAgent("agent-b");
+    const preparedB = await prepareToolExecutionContextForScope({
+      agentId: "agent-b",
+      conversationId: "default",
+      clientToolAllowlist: ["stateful_counter"],
+      modAdapters: agentBAdapter ? [agentBAdapter] : [],
+    });
+
+    expect(
+      await executeTool(
+        "stateful_counter",
+        {},
+        {
+          toolContextId: preparedA.preparedToolContext.contextId,
+        },
+      ),
+    ).toMatchObject({ status: "success", toolReturn: "1" });
+    expect(
+      await executeTool(
+        "stateful_counter",
+        {},
+        {
+          toolContextId: preparedB.preparedToolContext.contextId,
+        },
+      ),
+    ).toMatchObject({ status: "success", toolReturn: "1" });
+    expect(
+      execFileSync("git", ["status", "--porcelain"], {
+        cwd: agentARoot,
+        encoding: "utf8",
+      }),
+    ).toBe("");
+    expect(
+      execFileSync("git", ["status", "--porcelain"], {
+        cwd: agentBRoot,
+        encoding: "utf8",
+      }),
+    ).toBe("");
+
+    disposeListenerModAdapter(listener);
   });
 
   test("producer caches a separate adapter and command set per agent", async () => {

--- a/src/websocket/listener/agent-mod-isolation.test.ts
+++ b/src/websocket/listener/agent-mod-isolation.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { __testSetBackend } from "@/backend";
+import { FakeHeadlessBackend } from "@/backend/dev/fake-headless-backend";
+import { clearRegisteredPiProviders } from "@/backend/dev/pi-provider-mod-registry";
+import { clearModTools, getModToolDefinition } from "@/mods/tool-registry";
+import {
+  clearCapturedToolExecutionContexts,
+  executeTool,
+} from "@/tools/manager";
+import { prepareToolExecutionContextForScope } from "@/tools/toolset";
+import {
+  __listenerModAdapterTestUtils,
+  createListenerModAdapter,
+  disposeListenerModAdapter,
+  ensureListenerAgentModAdapter,
+} from "./mod-adapter";
+import { listListenerModCommands } from "./mod-commands";
+import type { ListenerRuntime } from "./types";
+
+const tempRoots: string[] = [];
+
+function createTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "letta-listener-agent-mod-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+function useFakeAgent(agentId: string): void {
+  __testSetBackend(
+    new FakeHeadlessBackend(
+      agentId,
+      undefined,
+      {},
+      {
+        modelHandle: "anthropic/claude-sonnet-4-6",
+      },
+    ),
+  );
+}
+
+afterEach(() => {
+  __listenerModAdapterTestUtils.resetForTests();
+  clearModTools();
+  clearRegisteredPiProviders();
+  clearCapturedToolExecutionContexts();
+  __testSetBackend(null);
+  for (const dir of tempRoots.splice(0)) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe("listener agent-scoped mods", () => {
+  test("isolates MemFS mods in turn snapshots and reloads them cleanly", async () => {
+    const root = createTempDir();
+    const globalModsDir = join(root, "global-mods");
+    const agentARoot = join(root, "agent-a-memory");
+    const agentBRoot = join(root, "agent-b-memory");
+    const agentAModsDir = join(agentARoot, "mods");
+    const agentBModsDir = join(agentBRoot, "mods");
+    mkdirSync(globalModsDir, { recursive: true });
+    mkdirSync(agentAModsDir, { recursive: true });
+    mkdirSync(agentBModsDir, { recursive: true });
+
+    writeFileSync(
+      join(globalModsDir, "shared.ts"),
+      `export default function activate(letta) {
+        letta.tools.register({
+          name: "shared_listener_tool",
+          description: "Available to every listener agent",
+          parameters: { type: "object", properties: {} },
+          requiresApproval: false,
+          run() { return "shared"; },
+        });
+      }`,
+    );
+    const writeAgentMod = (
+      directory: string,
+      toolName: string,
+      result: string,
+    ) => {
+      writeFileSync(
+        join(directory, "agent-tool.ts"),
+        `export default function activate(letta) {
+          letta.tools.register({
+            name: "${toolName}",
+            description: "Agent-scoped listener tool",
+            parameters: { type: "object", properties: {} },
+            requiresApproval: false,
+            run() { return "${result}"; },
+          });
+        }`,
+      );
+    };
+    writeAgentMod(agentAModsDir, "agent_a_only", "agent-a");
+    writeAgentMod(agentBModsDir, "agent_b_only", "agent-b");
+
+    execFileSync("git", ["init", "-q"], { cwd: agentARoot });
+    execFileSync("git", ["add", "mods/agent-tool.ts"], { cwd: agentARoot });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=Listener Test",
+        "-c",
+        "user.email=listener@example.com",
+        "commit",
+        "-qm",
+        "initial mod",
+      ],
+      { cwd: agentARoot },
+    );
+
+    const globalAdapter = createListenerModAdapter({
+      cacheDirectory: join(root, "global-cache"),
+      globalModsDirectory: globalModsDir,
+    });
+    const agentAAdapter = createListenerModAdapter({
+      agentModsDirectory: agentAModsDir,
+      cacheDirectory: join(root, "agent-a-cache"),
+      includeGlobalMods: false,
+      registerCapabilitiesGlobally: false,
+    });
+    const agentBAdapter = createListenerModAdapter({
+      agentModsDirectory: agentBModsDir,
+      cacheDirectory: join(root, "agent-b-cache"),
+      includeGlobalMods: false,
+      registerCapabilitiesGlobally: false,
+    });
+    await Promise.all([
+      globalAdapter.reload(),
+      agentAAdapter.reload(),
+      agentBAdapter.reload(),
+    ]);
+
+    expect(getModToolDefinition("agent_a_only")).toBeUndefined();
+    expect(getModToolDefinition("agent_b_only")).toBeUndefined();
+    expect(
+      execFileSync("git", ["status", "--porcelain"], {
+        cwd: agentARoot,
+        encoding: "utf8",
+      }),
+    ).toBe("");
+
+    useFakeAgent("agent-a");
+    const preparedA = await prepareToolExecutionContextForScope({
+      agentId: "agent-a",
+      conversationId: "default",
+      clientToolAllowlist: [
+        "shared_listener_tool",
+        "agent_a_only",
+        "agent_b_only",
+      ],
+      modAdapters: [globalAdapter, agentAAdapter],
+    });
+    expect(preparedA.preparedToolContext.loadedToolNames).toEqual([
+      "shared_listener_tool",
+      "agent_a_only",
+    ]);
+    expect(
+      await executeTool(
+        "agent_a_only",
+        {},
+        {
+          toolContextId: preparedA.preparedToolContext.contextId,
+        },
+      ),
+    ).toMatchObject({ status: "success", toolReturn: "agent-a" });
+
+    useFakeAgent("agent-b");
+    const preparedB = await prepareToolExecutionContextForScope({
+      agentId: "agent-b",
+      conversationId: "default",
+      clientToolAllowlist: [
+        "shared_listener_tool",
+        "agent_a_only",
+        "agent_b_only",
+      ],
+      modAdapters: [globalAdapter, agentBAdapter],
+    });
+    expect(preparedB.preparedToolContext.loadedToolNames).toEqual([
+      "shared_listener_tool",
+      "agent_b_only",
+    ]);
+
+    writeAgentMod(agentAModsDir, "agent_a_reloaded", "agent-a-reloaded");
+    execFileSync("git", ["add", "mods/agent-tool.ts"], { cwd: agentARoot });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=Listener Test",
+        "-c",
+        "user.email=listener@example.com",
+        "commit",
+        "-qm",
+        "reload mod",
+      ],
+      { cwd: agentARoot },
+    );
+    await agentAAdapter.reload();
+
+    useFakeAgent("agent-a");
+    const reloadedA = await prepareToolExecutionContextForScope({
+      agentId: "agent-a",
+      conversationId: "default",
+      clientToolAllowlist: ["agent_a_only", "agent_a_reloaded"],
+      modAdapters: [globalAdapter, agentAAdapter],
+    });
+    expect(reloadedA.preparedToolContext.loadedToolNames).toEqual([
+      "agent_a_reloaded",
+    ]);
+    expect(
+      execFileSync("git", ["status", "--porcelain"], {
+        cwd: agentARoot,
+        encoding: "utf8",
+      }),
+    ).toBe("");
+
+    globalAdapter.dispose();
+    agentAAdapter.dispose();
+    agentBAdapter.dispose();
+  });
+
+  test("producer caches a separate adapter and command set per agent", async () => {
+    const root = createTempDir();
+    const agentADir = join(root, "agent-a", "mods");
+    const agentBDir = join(root, "agent-b", "mods");
+    mkdirSync(agentADir, { recursive: true });
+    mkdirSync(agentBDir, { recursive: true });
+    const writeIdentityMod = (directory: string, agent: "a" | "b"): void => {
+      writeFileSync(
+        join(directory, "identity.js"),
+        `export default function activate(letta) {
+          letta.tools.register({
+            name: "agent_${agent}_identity",
+            description: "Agent ${agent.toUpperCase()} identity",
+            parameters: { type: "object", properties: {} },
+            run() { return "${agent}"; },
+          });
+          letta.commands.register({
+            id: "agent-${agent}-command",
+            description: "Agent ${agent.toUpperCase()} command",
+            run() { return "${agent}"; },
+          });
+        }`,
+      );
+    };
+    writeIdentityMod(agentADir, "a");
+    writeIdentityMod(agentBDir, "b");
+    __listenerModAdapterTestUtils.setAgentModsDirectoryResolverForTests(
+      (agentId) =>
+        agentId === "agent-a"
+          ? agentADir
+          : agentId === "agent-b"
+            ? agentBDir
+            : null,
+    );
+    const listener = {
+      agentModAdapters: new Map(),
+      agentModAdapterLoads: new Map(),
+      bootWorkingDirectory: root,
+      sessionId: "listener-isolation-test",
+    } as unknown as ListenerRuntime;
+
+    const [agentAAdapter, duplicateAgentAAdapter, agentBAdapter] =
+      await Promise.all([
+        ensureListenerAgentModAdapter(listener, "agent-a"),
+        ensureListenerAgentModAdapter(listener, "agent-a"),
+        ensureListenerAgentModAdapter(listener, "agent-b"),
+      ]);
+
+    expect(agentAAdapter).not.toBeNull();
+    expect(duplicateAgentAAdapter).toBe(agentAAdapter);
+    expect(agentBAdapter).not.toBeNull();
+    expect(agentBAdapter).not.toBe(agentAAdapter);
+    expect(
+      Object.keys(agentAAdapter?.getSnapshot().registry.tools ?? {}),
+    ).toEqual(["agent_a_identity"]);
+    expect(
+      Object.keys(agentBAdapter?.getSnapshot().registry.tools ?? {}),
+    ).toEqual(["agent_b_identity"]);
+    expect(getModToolDefinition("agent_a_identity")).toBeUndefined();
+    expect(getModToolDefinition("agent_b_identity")).toBeUndefined();
+    expect(listListenerModCommands(listener, "agent-a")).toEqual([
+      { id: "agent-a-command", description: "Agent A command" },
+    ]);
+    expect(listListenerModCommands(listener, "agent-b")).toEqual([
+      { id: "agent-b-command", description: "Agent B command" },
+    ]);
+
+    disposeListenerModAdapter(listener);
+    expect(listener.agentModAdapters?.size).toBe(0);
+  });
+});

--- a/src/websocket/listener/commands.ts
+++ b/src/websocket/listener/commands.ts
@@ -41,7 +41,10 @@ import type {
 import { debugLog } from "@/utils/debug";
 import { markSecretsReminderRefreshPending } from "./commands/secrets";
 import { getConversationWorkingDirectory } from "./cwd";
-import { reloadListenerModAdapter } from "./mod-adapter";
+import {
+  ensureListenerAgentModAdapter,
+  reloadListenerModAdapter,
+} from "./mod-adapter";
 import { getListenerModCommand, runListenerModCommand } from "./mod-commands";
 import {
   createLifecycleMessageBase,
@@ -165,9 +168,16 @@ export async function handleExecuteCommand(
         break;
 
       default: {
+        if (conversationRuntime.agentId) {
+          await ensureListenerAgentModAdapter(
+            conversationRuntime.listener,
+            conversationRuntime.agentId,
+          );
+        }
         const modCommand = getListenerModCommand(
           conversationRuntime.listener,
           command.command_id,
+          conversationRuntime.agentId,
         );
         if (!modCommand) {
           emitSlashCommandEnd(socket, conversationRuntime, scope, {
@@ -314,7 +324,7 @@ export async function handleReloadCommand(
     );
   }
 
-  await reloadListenerModAdapter(listener);
+  await reloadListenerModAdapter(listener, conversationRuntime.agentId);
 
   if (conversationRuntime.agentId) {
     invalidateSecretsCacheForAgent(listener, conversationRuntime.agentId);

--- a/src/websocket/listener/commands/model-toolset.ts
+++ b/src/websocket/listener/commands/model-toolset.ts
@@ -30,7 +30,10 @@ import type {
   UpdateModelResponseMessage,
   UpdateToolsetResponseMessage,
 } from "@/types/protocol_v2";
-import { ensureListenerModAdapter } from "@/websocket/listener/mod-adapter";
+import {
+  createListenerModEvents,
+  ensureListenerModAdaptersForAgent,
+} from "@/websocket/listener/mod-adapter";
 import {
   isListModelsCommand,
   isUpdateModelCommand,
@@ -458,6 +461,10 @@ export async function applyModelUpdateForRuntime(params: {
 
   try {
     await ensureCorrectMemoryTool(agentId, model.handle);
+    const modAdapters = await ensureListenerModAdaptersForAgent(
+      listener,
+      agentId,
+    );
     const preparedToolContext = await prepareToolExecutionContextForScope({
       agentId,
       conversationId,
@@ -466,7 +473,8 @@ export async function applyModelUpdateForRuntime(params: {
         providerTypeFromModelSettings(modelSettings) ??
         inferProviderTypeFromRegistryHandle(model.handle) ??
         null,
-      modEvents: ensureListenerModAdapter(listener).events,
+      modAdapters,
+      modEvents: createListenerModEvents(modAdapters),
     });
     nextToolset = preparedToolContext.toolset;
     nextLoadedTools = preparedToolContext.preparedToolContext.loadedToolNames;
@@ -553,10 +561,15 @@ export async function applyToolsetUpdateForRuntime(params: {
 
   try {
     settingsManager.setToolsetPreference(agentId, toolsetPreference);
+    const modAdapters = await ensureListenerModAdaptersForAgent(
+      listener,
+      agentId,
+    );
     const preparedToolContext = await prepareToolExecutionContextForScope({
       agentId,
       conversationId,
-      modEvents: ensureListenerModAdapter(listener).events,
+      modAdapters,
+      modEvents: createListenerModEvents(modAdapters),
     });
     nextToolset = preparedToolContext.toolset;
     scopedRuntime.currentToolset = preparedToolContext.toolset;

--- a/src/websocket/listener/device-status-cache.ts
+++ b/src/websocket/listener/device-status-cache.ts
@@ -1,0 +1,41 @@
+import type { DeviceStatus } from "@/types/protocol_v2";
+import type { ListenerTransport } from "./transport";
+
+type DeviceStatusScope = {
+  agent_id?: string | null;
+  conversation_id?: string | null;
+};
+
+/** Per-transport, per-scope cache naturally released with the transport. */
+const lastDeviceStatusByTransport = new WeakMap<
+  ListenerTransport,
+  Map<string, string>
+>();
+
+export function recordDeviceStatus(
+  transport: ListenerTransport,
+  scope: DeviceStatusScope,
+  status: DeviceStatus,
+): void {
+  shouldEmitDeviceStatus(transport, scope, status, true);
+}
+
+export function shouldEmitDeviceStatus(
+  transport: ListenerTransport,
+  scope: DeviceStatusScope,
+  status: DeviceStatus,
+  force = false,
+): boolean {
+  const statusJson = JSON.stringify(status);
+  const cacheKey = `${scope.agent_id ?? ""}:${scope.conversation_id ?? ""}`;
+  let scopeCache = lastDeviceStatusByTransport.get(transport);
+  if (!scopeCache) {
+    scopeCache = new Map();
+    lastDeviceStatusByTransport.set(transport, scopeCache);
+  }
+  if (!force && scopeCache.get(cacheKey) === statusJson) {
+    return false;
+  }
+  scopeCache.set(cacheKey, statusJson);
+  return true;
+}

--- a/src/websocket/listener/memfs-sync.ts
+++ b/src/websocket/listener/memfs-sync.ts
@@ -83,28 +83,32 @@ async function syncMemfsForAgent(agentId: string): Promise<void> {
  * Concurrent callers for the same agent coalesce onto a single in-flight
  * promise so turn ordering stays deterministic.
  *
- * Non-fatal: logs a warning on failure but doesn't throw.
+ * Non-fatal: logs a warning and returns false on failure so source consumers
+ * do not read a stale checkout.
  */
 export async function ensureMemfsSyncedForAgent(
   listener: ListenerRuntime,
   agentId: string,
-): Promise<void> {
+): Promise<boolean> {
   const existing = listener.memfsSyncedAgents.get(agentId);
   if (existing) {
-    await existing;
-    return;
+    return existing;
   }
 
-  const promise = syncMemfsForAgent(agentId).catch((err) => {
-    // Non-fatal — agent can still process messages, just without local memory.
-    debugWarn(
-      "memfs-sync",
-      `Failed to sync memfs for agent ${agentId}: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    // Remove so next turn retries.
-    listener.memfsSyncedAgents.delete(agentId);
-  });
+  const promise = syncMemfsForAgent(agentId).then(
+    () => true,
+    (err) => {
+      // Non-fatal — agent can still process messages, just without local memory.
+      debugWarn(
+        "memfs-sync",
+        `Failed to sync memfs for agent ${agentId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      // Remove so next turn retries.
+      listener.memfsSyncedAgents.delete(agentId);
+      return false;
+    },
+  );
 
   listener.memfsSyncedAgents.set(agentId, promise);
-  await promise;
+  return promise;
 }

--- a/src/websocket/listener/mod-adapter.ts
+++ b/src/websocket/listener/mod-adapter.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { join } from "node:path";
 import type Letta from "@letta-ai/letta-client";
 import { getScopedMemoryFilesystemRoot } from "@/agent/memory-filesystem";
@@ -5,6 +6,7 @@ import { getBackend } from "@/backend";
 import { buildModInvocationContext } from "@/mods/context";
 import type { ModEvents } from "@/mods/event-emitter";
 import { createModAdapter, type ModAdapter } from "@/mods/mod-adapter";
+import { getModCacheDirectory } from "@/mods/paths";
 import type {
   ModCapabilities,
   ModContext,
@@ -137,7 +139,15 @@ function resolveListenerAgentModsDirectory(agentId: string): string | null {
   }
 }
 
+function resolveListenerAgentModCacheDirectory(agentId: string): string {
+  // A distinct import path gives each agent its own ESM module instance while
+  // keeping generated files outside the git-backed MemFS repository.
+  const cacheKey = createHash("sha256").update(agentId).digest("hex");
+  return join(getModCacheDirectory(), "listener-agents", cacheKey);
+}
+
 let resolveAgentModsDirectory = resolveListenerAgentModsDirectory;
+let resolveAgentModCacheDirectory = resolveListenerAgentModCacheDirectory;
 
 export async function ensureListenerAgentModAdapter(
   runtime: ListenerRuntime,
@@ -159,6 +169,7 @@ export async function ensureListenerAgentModAdapter(
   const load = (async () => {
     const adapter = createListenerModAdapter({
       agentModsDirectory,
+      cacheDirectory: resolveAgentModCacheDirectory(agentId),
       capabilities: LISTENER_AGENT_MOD_CAPABILITIES,
       includeGlobalMods: false,
       registerCapabilitiesGlobally: false,
@@ -253,8 +264,14 @@ export const __listenerModAdapterTestUtils = {
   ): void {
     resolveAgentModsDirectory = resolver;
   },
+  setAgentModCacheDirectoryResolverForTests(
+    resolver: (agentId: string) => string,
+  ): void {
+    resolveAgentModCacheDirectory = resolver;
+  },
   resetForTests(): void {
     resolveAgentModsDirectory = resolveListenerAgentModsDirectory;
+    resolveAgentModCacheDirectory = resolveListenerAgentModCacheDirectory;
   },
 };
 

--- a/src/websocket/listener/mod-adapter.ts
+++ b/src/websocket/listener/mod-adapter.ts
@@ -17,6 +17,7 @@ import type {
 import { getCurrentWorkingDirectory } from "@/runtime-context";
 import { settingsManager } from "@/settings-manager";
 import { getBootWorkingDirectory } from "./cwd";
+import { ensureMemfsSyncedForAgent } from "./memfs-sync";
 import type { ListenerRuntime } from "./types";
 
 export const LISTENER_MOD_CAPABILITIES: ModCapabilities = {
@@ -148,6 +149,7 @@ function resolveListenerAgentModCacheDirectory(agentId: string): string {
 
 let resolveAgentModsDirectory = resolveListenerAgentModsDirectory;
 let resolveAgentModCacheDirectory = resolveListenerAgentModCacheDirectory;
+let ensureAgentMemfsSynced = ensureMemfsSyncedForAgent;
 
 export async function ensureListenerAgentModAdapter(
   runtime: ListenerRuntime,
@@ -163,28 +165,42 @@ export async function ensureListenerAgentModAdapter(
   const pending = agentModAdapterLoads.get(agentId);
   if (pending) return pending;
 
-  const agentModsDirectory = resolveAgentModsDirectory(agentId);
-  if (!agentModsDirectory) return null;
-
-  const load = (async () => {
-    const adapter = createListenerModAdapter({
-      agentModsDirectory,
-      cacheDirectory: resolveAgentModCacheDirectory(agentId),
-      capabilities: LISTENER_AGENT_MOD_CAPABILITIES,
-      includeGlobalMods: false,
-      registerCapabilitiesGlobally: false,
-      sessionId: runtime.sessionId,
-      workingDirectory: runtime.bootWorkingDirectory,
-    });
+  let load: Promise<ModAdapter | null> | undefined;
+  load = (async () => {
     try {
-      await adapter.reload();
-      agentModAdapters.set(agentId, adapter);
-      return adapter;
-    } catch (error) {
-      adapter.dispose();
-      throw error;
+      const syncSucceeded = await ensureAgentMemfsSynced(runtime, agentId);
+      if (!syncSucceeded || agentModAdapterLoads.get(agentId) !== load) {
+        return null;
+      }
+
+      const agentModsDirectory = resolveAgentModsDirectory(agentId);
+      if (!agentModsDirectory) return null;
+
+      const adapter = createListenerModAdapter({
+        agentModsDirectory,
+        cacheDirectory: resolveAgentModCacheDirectory(agentId),
+        capabilities: LISTENER_AGENT_MOD_CAPABILITIES,
+        includeGlobalMods: false,
+        registerCapabilitiesGlobally: false,
+        sessionId: runtime.sessionId,
+        workingDirectory: runtime.bootWorkingDirectory,
+      });
+      try {
+        await adapter.reload();
+        if (agentModAdapterLoads.get(agentId) !== load) {
+          adapter.dispose();
+          return null;
+        }
+        agentModAdapters.set(agentId, adapter);
+        return adapter;
+      } catch (error) {
+        adapter.dispose();
+        throw error;
+      }
     } finally {
-      agentModAdapterLoads.delete(agentId);
+      if (agentModAdapterLoads.get(agentId) === load) {
+        agentModAdapterLoads.delete(agentId);
+      }
     }
   })();
 
@@ -269,9 +285,15 @@ export const __listenerModAdapterTestUtils = {
   ): void {
     resolveAgentModCacheDirectory = resolver;
   },
+  setEnsureMemfsSyncedForAgentForTests(
+    ensureSynced: typeof ensureMemfsSyncedForAgent,
+  ): void {
+    ensureAgentMemfsSynced = ensureSynced;
+  },
   resetForTests(): void {
     resolveAgentModsDirectory = resolveListenerAgentModsDirectory;
     resolveAgentModCacheDirectory = resolveListenerAgentModCacheDirectory;
+    ensureAgentMemfsSynced = ensureMemfsSyncedForAgent;
   },
 };
 

--- a/src/websocket/listener/mod-adapter.ts
+++ b/src/websocket/listener/mod-adapter.ts
@@ -1,9 +1,19 @@
+import { join } from "node:path";
 import type Letta from "@letta-ai/letta-client";
+import { getScopedMemoryFilesystemRoot } from "@/agent/memory-filesystem";
 import { getBackend } from "@/backend";
 import { buildModInvocationContext } from "@/mods/context";
+import type { ModEvents } from "@/mods/event-emitter";
 import { createModAdapter, type ModAdapter } from "@/mods/mod-adapter";
-import type { ModCapabilities, ModContext } from "@/mods/types";
+import type {
+  ModCapabilities,
+  ModContext,
+  ModEventEmissionResult,
+  ModEventMap,
+  ModEventName,
+} from "@/mods/types";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
+import { settingsManager } from "@/settings-manager";
 import { getBootWorkingDirectory } from "./cwd";
 import type { ListenerRuntime } from "./types";
 
@@ -24,11 +34,21 @@ export const LISTENER_MOD_CAPABILITIES: ModCapabilities = {
   },
 };
 
+const LISTENER_AGENT_MOD_CAPABILITIES: ModCapabilities = {
+  ...LISTENER_MOD_CAPABILITIES,
+  // Provider registration is process-global and cannot be isolated per agent.
+  providers: false,
+};
+
 export interface CreateListenerModAdapterOptions {
+  agentModsDirectory?: string;
   cacheDirectory?: string;
+  capabilities?: ModCapabilities;
   diagnosticsRootDirectory?: string;
   disabled?: boolean;
   globalModsDirectory?: string;
+  includeGlobalMods?: boolean;
+  registerCapabilitiesGlobally?: boolean;
   sessionId?: string | null;
   workingDirectory?: string | null;
 }
@@ -72,10 +92,13 @@ export function createListenerModAdapter(
   options: CreateListenerModAdapterOptions = {},
 ): ModAdapter {
   return createModAdapter({
+    ...(options.agentModsDirectory
+      ? { agentModsDirectory: options.agentModsDirectory }
+      : {}),
     ...(options.cacheDirectory
       ? { cacheDirectory: options.cacheDirectory }
       : {}),
-    capabilities: LISTENER_MOD_CAPABILITIES,
+    capabilities: options.capabilities ?? LISTENER_MOD_CAPABILITIES,
     ...(options.diagnosticsRootDirectory
       ? { diagnosticsRootDirectory: options.diagnosticsRootDirectory }
       : {}),
@@ -84,6 +107,14 @@ export function createListenerModAdapter(
     getClient: getUnavailableListenerClient,
     ...(options.globalModsDirectory
       ? { globalModsDirectory: options.globalModsDirectory }
+      : {}),
+    ...(options.includeGlobalMods !== undefined
+      ? { includeGlobalMods: options.includeGlobalMods }
+      : {}),
+    ...(options.registerCapabilitiesGlobally !== undefined
+      ? {
+          registerCapabilitiesGlobally: options.registerCapabilitiesGlobally,
+        }
       : {}),
   });
 }
@@ -96,14 +127,150 @@ export function ensureListenerModAdapter(runtime: ListenerRuntime): ModAdapter {
   return runtime.modAdapter;
 }
 
+function resolveListenerAgentModsDirectory(agentId: string): string | null {
+  try {
+    return settingsManager.isMemfsEnabled(agentId)
+      ? join(getScopedMemoryFilesystemRoot(agentId), "mods")
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+let resolveAgentModsDirectory = resolveListenerAgentModsDirectory;
+
+export async function ensureListenerAgentModAdapter(
+  runtime: ListenerRuntime,
+  agentId: string,
+): Promise<ModAdapter | null> {
+  runtime.agentModAdapters ??= new Map();
+  runtime.agentModAdapterLoads ??= new Map();
+  const agentModAdapters = runtime.agentModAdapters;
+  const agentModAdapterLoads = runtime.agentModAdapterLoads;
+  const existing = agentModAdapters.get(agentId);
+  if (existing) return existing;
+
+  const pending = agentModAdapterLoads.get(agentId);
+  if (pending) return pending;
+
+  const agentModsDirectory = resolveAgentModsDirectory(agentId);
+  if (!agentModsDirectory) return null;
+
+  const load = (async () => {
+    const adapter = createListenerModAdapter({
+      agentModsDirectory,
+      capabilities: LISTENER_AGENT_MOD_CAPABILITIES,
+      includeGlobalMods: false,
+      registerCapabilitiesGlobally: false,
+      sessionId: runtime.sessionId,
+      workingDirectory: runtime.bootWorkingDirectory,
+    });
+    try {
+      await adapter.reload();
+      agentModAdapters.set(agentId, adapter);
+      return adapter;
+    } catch (error) {
+      adapter.dispose();
+      throw error;
+    } finally {
+      agentModAdapterLoads.delete(agentId);
+    }
+  })();
+
+  agentModAdapterLoads.set(agentId, load);
+  return load;
+}
+
+export async function ensureListenerModAdaptersForAgent(
+  runtime: ListenerRuntime,
+  agentId: string,
+): Promise<ModAdapter[]> {
+  const globalAdapter = ensureListenerModAdapter(runtime);
+  const agentAdapter = await ensureListenerAgentModAdapter(runtime, agentId);
+  return agentAdapter ? [globalAdapter, agentAdapter] : [globalAdapter];
+}
+
+export function getLoadedListenerModAdapters(
+  runtime: ListenerRuntime,
+  agentId?: string | null,
+): ModAdapter[] {
+  const adapters = runtime.modAdapter ? [runtime.modAdapter] : [];
+  const agentAdapter = agentId
+    ? runtime.agentModAdapters?.get(agentId)
+    : undefined;
+  if (agentAdapter) adapters.push(agentAdapter);
+  return adapters;
+}
+
+export function createListenerModEvents(adapters: ModAdapter[]): ModEvents {
+  return {
+    async emit<TName extends ModEventName>(
+      name: TName,
+      event: ModEventMap[TName],
+      context: ModContext,
+    ) {
+      const combined: ModEventEmissionResult<TName> = {
+        diagnostics: [],
+        handlerCount: 0,
+        name,
+        results: [],
+      };
+      for (const adapter of adapters) {
+        const result = await adapter.events.emit(name, event, context);
+        combined.diagnostics.push(...result.diagnostics);
+        combined.handlerCount += result.handlerCount;
+        combined.results.push(...result.results);
+      }
+      return combined;
+    },
+  };
+}
+
 export async function reloadListenerModAdapter(
   runtime: ListenerRuntime,
+  agentId?: string | null,
 ): Promise<void> {
   const adapter = ensureListenerModAdapter(runtime);
   await adapter.reload();
+
+  if (!agentId) return;
+  const agentAdapter = runtime.agentModAdapters?.get(agentId);
+  if (!resolveAgentModsDirectory(agentId)) {
+    agentAdapter?.dispose();
+    runtime.agentModAdapters?.delete(agentId);
+    return;
+  }
+  if (agentAdapter) {
+    await agentAdapter.reload();
+    return;
+  }
+  await ensureListenerAgentModAdapter(runtime, agentId);
 }
+
+export const __listenerModAdapterTestUtils = {
+  setAgentModsDirectoryResolverForTests(
+    resolver: (agentId: string) => string | null,
+  ): void {
+    resolveAgentModsDirectory = resolver;
+  },
+  resetForTests(): void {
+    resolveAgentModsDirectory = resolveListenerAgentModsDirectory;
+  },
+};
 
 export function disposeListenerModAdapter(runtime: ListenerRuntime): void {
   runtime.modAdapter?.dispose();
   runtime.modAdapter = undefined;
+  for (const adapter of runtime.agentModAdapters?.values() ?? []) {
+    adapter.dispose();
+  }
+  runtime.agentModAdapters?.clear();
+  for (const [agentId, pending] of runtime.agentModAdapterLoads?.entries() ??
+    []) {
+    void pending.then((adapter) => {
+      adapter?.dispose();
+      runtime.agentModAdapters?.delete(agentId);
+    });
+  }
+  runtime.agentModAdapterLoads?.clear();
 }

--- a/src/websocket/listener/mod-commands.ts
+++ b/src/websocket/listener/mod-commands.ts
@@ -12,7 +12,10 @@ import type {
 } from "@/mods/types";
 import type { ModCommandInfo } from "@/types/protocol_v2";
 import { getConversationWorkingDirectory } from "./cwd";
-import { createListenerModContext } from "./mod-adapter";
+import {
+  createListenerModContext,
+  getLoadedListenerModAdapters,
+} from "./mod-adapter";
 import { getConversationPermissionModeState } from "./permission-mode";
 import type { ConversationRuntime, ListenerRuntime } from "./types";
 
@@ -23,10 +26,17 @@ import type { ConversationRuntime, ListenerRuntime } from "./types";
  */
 export function listListenerModCommands(
   runtime: ListenerRuntime,
+  agentId?: string | null,
 ): ModCommandInfo[] {
-  const registry = runtime.modAdapter?.getSnapshot().registry;
-  if (!registry) return [];
-  return Object.values(registry.commands).map((command) => ({
+  const commands = new Map<string, ModCommand>();
+  for (const adapter of getLoadedListenerModAdapters(runtime, agentId)) {
+    for (const command of Object.values(
+      adapter.getSnapshot().registry.commands,
+    )) {
+      commands.set(command.id, command);
+    }
+  }
+  return Array.from(commands.values()).map((command) => ({
     id: command.id,
     description: command.description,
     ...(command.args ? { args: command.args } : {}),
@@ -37,8 +47,13 @@ export function listListenerModCommands(
 export function getListenerModCommand(
   runtime: ListenerRuntime,
   commandId: string,
+  agentId?: string | null,
 ): ModCommand | undefined {
-  return runtime.modAdapter?.getSnapshot().registry.commands[commandId];
+  let result: ModCommand | undefined;
+  for (const adapter of getLoadedListenerModAdapters(runtime, agentId)) {
+    result = adapter.getSnapshot().registry.commands[commandId] ?? result;
+  }
+  return result;
 }
 
 /**

--- a/src/websocket/listener/protocol-outbound.test.ts
+++ b/src/websocket/listener/protocol-outbound.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from "bun:test";
 import WebSocket from "ws";
 import type { DequeuedBatch } from "@/queue/queue-runtime";
 import type { StreamDeltaMessage } from "@/types/protocol_v2";
-import { emitDequeuedUserMessage } from "@/websocket/listener/protocol-outbound";
+import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
+import { createRuntime as createListenerRuntime } from "@/websocket/listener/lifecycle";
+import {
+  emitDequeuedUserMessage,
+  emitDeviceStatusUpdateIfChanged,
+} from "@/websocket/listener/protocol-outbound";
 import type {
   ConversationRuntime,
   IncomingMessage,
@@ -183,5 +188,38 @@ describe("emitDequeuedUserMessage", () => {
     emitDequeuedUserMessage(socket as never, runtime, incoming, batch);
 
     expect(socket.sentPayloads).toHaveLength(0);
+  });
+});
+
+describe("emitDeviceStatusUpdateIfChanged", () => {
+  test("normalizes runtime scopes without cross-scope leakage", () => {
+    const listener = createListenerRuntime();
+    const runtime = getOrCreateScopedRuntime(listener, "agent-1", "default");
+    const otherRuntime = getOrCreateScopedRuntime(
+      listener,
+      "agent-2",
+      "default",
+    );
+    const socket = new MockSocket();
+    const otherSocket = new MockSocket();
+
+    expect(emitDeviceStatusUpdateIfChanged(socket as never, runtime, {})).toBe(
+      true,
+    );
+    expect(
+      emitDeviceStatusUpdateIfChanged(socket as never, runtime, {
+        agent_id: "agent-1",
+        conversation_id: "default",
+      }),
+    ).toBe(false);
+    expect(
+      emitDeviceStatusUpdateIfChanged(socket as never, otherRuntime, {}),
+    ).toBe(true);
+    expect(
+      emitDeviceStatusUpdateIfChanged(otherSocket as never, runtime, {}),
+    ).toBe(true);
+
+    expect(socket.sentPayloads).toHaveLength(2);
+    expect(otherSocket.sentPayloads).toHaveLength(1);
   });
 });

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -44,6 +44,10 @@ import {
 } from "./channel-turn-session";
 import { SYSTEM_REMINDER_RE } from "./constants";
 import { getConversationWorkingDirectory, getExportedCwdMap } from "./cwd";
+import {
+  recordDeviceStatus,
+  shouldEmitDeviceStatus,
+} from "./device-status-cache";
 import { SUPPORTED_REMOTE_COMMANDS } from "./listener-constants";
 import { listListenerModCommands } from "./mod-commands";
 import { getConversationPermissionModeState } from "./permission-mode";
@@ -697,12 +701,14 @@ export function emitDeviceStatusUpdate(
     conversation_id?: string | null;
   },
 ): void {
+  const deviceStatus = buildDeviceStatus(runtime, scope);
+  recordDeviceStatus(socket, getScopeForRuntime(runtime, scope), deviceStatus);
   const message: Omit<
     DeviceStatusUpdateMessage,
     "runtime" | "event_seq" | "emitted_at" | "idempotency_key"
   > = {
     type: "update_device_status",
-    device_status: buildDeviceStatus(runtime, scope),
+    device_status: deviceStatus,
   };
   emitProtocolV2Message(socket, runtime, message, scope);
 }
@@ -940,17 +946,26 @@ export function emitQueueUpdateIfOpen(
   }
 }
 
-/**
- * Per-transport, per-scope cache of the last emitted device-status JSON.
- * Periodic syncs can opt into this cache to avoid redundant device-status
- * frames when idle, while recovery/visibility syncs can force a full replay.
- * Keyed by transport (WeakMap) so cache is naturally cleaned up when the
- * socket closes and gets GC'd. (LET-8948)
- */
-const lastSyncDeviceStatusByTransport = new WeakMap<
-  ListenerTransport,
-  Map<string, string>
->();
+export function emitDeviceStatusUpdateIfChanged(
+  socket: ListenerTransport,
+  runtime: RuntimeCarrier,
+  scope: RuntimeScope,
+  options?: { force?: boolean },
+): boolean {
+  const deviceStatus = buildDeviceStatus(runtime, scope);
+  if (!shouldEmitDeviceStatus(socket, scope, deviceStatus, options?.force)) {
+    return false;
+  }
+  const message: Omit<
+    DeviceStatusUpdateMessage,
+    "runtime" | "event_seq" | "emitted_at" | "idempotency_key"
+  > = {
+    type: "update_device_status",
+    device_status: deviceStatus,
+  };
+  emitProtocolV2Message(socket, runtime, message, scope);
+  return true;
+}
 
 export function emitStateSync(
   socket: ListenerTransport,
@@ -958,28 +973,12 @@ export function emitStateSync(
   scope: RuntimeScope,
   options?: { forceDeviceStatus?: boolean },
 ): void {
-  const deviceStatus = buildDeviceStatus(runtime, scope);
-  const deviceStatusJson = JSON.stringify(deviceStatus);
-  const cacheKey = `${scope.agent_id ?? ""}:${scope.conversation_id ?? ""}`;
-
-  let scopeCache = lastSyncDeviceStatusByTransport.get(socket);
-  if (!scopeCache) {
-    scopeCache = new Map();
-    lastSyncDeviceStatusByTransport.set(socket, scopeCache);
-  }
-  const prev = scopeCache.get(cacheKey);
-
-  if (options?.forceDeviceStatus || deviceStatusJson !== prev) {
-    scopeCache.set(cacheKey, deviceStatusJson);
-    const message: Omit<
-      DeviceStatusUpdateMessage,
-      "runtime" | "event_seq" | "emitted_at" | "idempotency_key"
-    > = {
-      type: "update_device_status",
-      device_status: deviceStatus,
-    };
-    emitProtocolV2Message(socket, runtime, message, scope);
-  }
+  emitDeviceStatusUpdateIfChanged(
+    socket,
+    runtime,
+    scope,
+    options?.forceDeviceStatus ? { force: true } : undefined,
+  );
 
   emitLoopStatusUpdate(socket, runtime, scope);
   emitQueueUpdate(socket, runtime, scope);

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -72,14 +72,8 @@ type RuntimeCarrier = ListenerRuntime | ConversationRuntime | null;
 const GIT_CONTEXT_CACHE_TTL_MS = 15_000;
 const MAX_GIT_CONTEXT_CACHE_ENTRIES = 64;
 /**
- * Frozen copy of the supported commands list. Avoids creating a new array on
- * every `buildDeviceStatus()` call (every 5–30 s per connected web client).
- * (LET-8948)
- */
-/**
- * Pre-computed copy of the supported commands list. Avoids creating a new
- * array on every `buildDeviceStatus()` call (every 5–30 s per connected
- * web client). (LET-8948)
+ * Frozen copy of the supported commands list. Avoids allocating it for every
+ * device-status update. (LET-8948)
  */
 const FROZEN_SUPPORTED_COMMANDS: string[] = [...SUPPORTED_REMOTE_COMMANDS];
 
@@ -87,10 +81,13 @@ const FROZEN_SUPPORTED_COMMANDS: string[] = [...SUPPORTED_REMOTE_COMMANDS];
  * Mod-contributed commands for the device status, omitted entirely when no mods
  * register commands so the common case adds no field.
  */
-function buildModCommandsField(listener: ListenerRuntime): {
+function buildModCommandsField(
+  listener: ListenerRuntime,
+  agentId?: string | null,
+): {
   mod_commands?: ModCommandInfo[];
 } {
-  const modCommands = listListenerModCommands(listener);
+  const modCommands = listListenerModCommands(listener, agentId);
   return modCommands.length > 0 ? { mod_commands: modCommands } : {};
 }
 const PROTOCOL_PERF_FLUSH_INTERVAL_MS = 1_000;
@@ -502,7 +499,7 @@ export function buildDeviceStatus(
     cwd_revision: listener.workingDirectoryRevision ?? 0,
     should_doctor: systemPromptDoctorState?.should_doctor ?? false,
     supported_commands: FROZEN_SUPPORTED_COMMANDS,
-    ...buildModCommandsField(listener),
+    ...buildModCommandsField(listener, scopedAgentId),
     reflection_settings: scopedAgentId
       ? {
           agent_id: scopedAgentId,

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -72,6 +72,10 @@ import type {
 } from "./types";
 
 type RuntimeCarrier = ListenerRuntime | ConversationRuntime | null;
+type PartialRuntimeScope = {
+  agent_id?: string | null;
+  conversation_id?: string | null;
+};
 
 const GIT_CONTEXT_CACHE_TTL_MS = 15_000;
 const MAX_GIT_CONTEXT_CACHE_ENTRIES = 64;
@@ -329,14 +333,8 @@ function getListenerRuntime(runtime: RuntimeCarrier): ListenerRuntime | null {
 
 function getScopeForRuntime(
   runtime: RuntimeCarrier,
-  scope?: {
-    agent_id?: string | null;
-    conversation_id?: string | null;
-  },
-): {
-  agent_id?: string | null;
-  conversation_id?: string | null;
-} {
+  scope?: PartialRuntimeScope,
+): PartialRuntimeScope {
   if (runtime && "listener" in runtime) {
     return {
       agent_id: scope?.agent_id ?? runtime.agentId,
@@ -696,10 +694,7 @@ export function emitProtocolV2Message(
 export function emitDeviceStatusUpdate(
   socket: ListenerTransport,
   runtime: RuntimeCarrier,
-  scope?: {
-    agent_id?: string | null;
-    conversation_id?: string | null;
-  },
+  scope?: PartialRuntimeScope,
 ): void {
   const deviceStatus = buildDeviceStatus(runtime, scope);
   recordDeviceStatus(socket, getScopeForRuntime(runtime, scope), deviceStatus);
@@ -949,11 +944,14 @@ export function emitQueueUpdateIfOpen(
 export function emitDeviceStatusUpdateIfChanged(
   socket: ListenerTransport,
   runtime: RuntimeCarrier,
-  scope: RuntimeScope,
+  scope?: PartialRuntimeScope,
   options?: { force?: boolean },
 ): boolean {
-  const deviceStatus = buildDeviceStatus(runtime, scope);
-  if (!shouldEmitDeviceStatus(socket, scope, deviceStatus, options?.force)) {
+  const resolvedScope = getScopeForRuntime(runtime, scope);
+  const deviceStatus = buildDeviceStatus(runtime, resolvedScope);
+  if (
+    !shouldEmitDeviceStatus(socket, resolvedScope, deviceStatus, options?.force)
+  ) {
     return false;
   }
   const message: Omit<
@@ -963,7 +961,7 @@ export function emitDeviceStatusUpdateIfChanged(
     type: "update_device_status",
     device_status: deviceStatus,
   };
-  emitProtocolV2Message(socket, runtime, message, scope);
+  emitProtocolV2Message(socket, runtime, message, resolvedScope);
   return true;
 }
 

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -51,7 +51,10 @@ import {
   emitToolExecutionStartedEvents,
   normalizeToolReturnWireMessage,
 } from "./interrupts";
-import { ensureListenerModAdapter } from "./mod-adapter";
+import {
+  createListenerModEvents,
+  ensureListenerModAdaptersForAgent,
+} from "./mod-adapter";
 import { getOrCreateConversationPermissionModeStateRef } from "./permission-mode";
 import {
   emitCanonicalMessageDelta,
@@ -746,6 +749,13 @@ export async function resolveRecoveredApprovalResponse(
       if (!runtime.turnLifecycle.isCurrent(recoveryLease)) {
         return true;
       }
+      const modAdapters = await ensureListenerModAdaptersForAgent(
+        runtime.listener,
+        recovered.agentId,
+      );
+      if (!runtime.turnLifecycle.isCurrent(recoveryLease)) {
+        return true;
+      }
       const preparedToolContext = await prepareToolExecutionContext({
         agentId: recovered.agentId,
         conversationId: recovered.conversationId,
@@ -755,7 +765,8 @@ export async function resolveRecoveredApprovalResponse(
           recovered.agentId,
           recovered.conversationId,
         ),
-        modEvents: ensureListenerModAdapter(runtime.listener).events,
+        modAdapters,
+        modEvents: createListenerModEvents(modAdapters),
       });
       if (!runtime.turnLifecycle.isCurrent(recoveryLease)) {
         return true;

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -32,7 +32,10 @@ import {
 } from "./constants";
 import { appendQueuedTurnToInput } from "./continuation-input";
 import { getConversationWorkingDirectory } from "./cwd";
-import { ensureListenerModAdapter } from "./mod-adapter";
+import {
+  createListenerModEvents,
+  ensureListenerModAdaptersForAgent,
+} from "./mod-adapter";
 import { getOrCreateConversationPermissionModeStateRef } from "./permission-mode";
 import { emitDequeuedUserMessage, emitRetryDelta } from "./protocol-outbound";
 import {
@@ -349,6 +352,10 @@ export async function resolveStaleApprovals(
     agent_id: runtime.agentId,
     conversation_id: recoveryConversationId,
   } as const;
+  const modAdapters = await ensureListenerModAdaptersForAgent(
+    runtime.listener,
+    runtime.agentId,
+  );
   const preparedToolContext = await prepareToolExecutionContext({
     agentId: runtime.agentId,
     conversationId: recoveryConversationId,
@@ -358,7 +365,8 @@ export async function resolveStaleApprovals(
       runtime.agentId,
       runtime.conversationId,
     ),
-    modEvents: ensureListenerModAdapter(runtime.listener).events,
+    modAdapters,
+    modEvents: createListenerModEvents(modAdapters),
   });
   assertCurrentTurnLease();
   runtime.currentToolset = preparedToolContext.toolset;

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -12,6 +12,7 @@ import {
   getInteractiveApprovalKind,
   isInteractiveApprovalTool,
 } from "@/tools/interactive-policy";
+import type { PermissionModeState } from "@/tools/permission-mode-state";
 import type {
   ApprovalResponseBody,
   ApprovalResponseDecision,
@@ -150,7 +151,7 @@ export async function handleApprovalStop(params: {
   agentId: string;
   conversationId: string;
   turnWorkingDirectory: string;
-  turnPermissionModeState: import("@/tools/manager").PermissionModeState;
+  turnPermissionModeState: PermissionModeState;
   dequeuedBatchId: string;
   runId?: string;
   msgRunIds: string[];

--- a/src/websocket/listener/turn-events.ts
+++ b/src/websocket/listener/turn-events.ts
@@ -17,7 +17,8 @@ import { getListenerTelemetrySurface } from "@/telemetry";
 import type { StreamDelta } from "@/types/protocol_v2";
 import {
   createListenerModContext,
-  ensureListenerModAdapter,
+  createListenerModEvents,
+  ensureListenerModAdaptersForAgent,
 } from "./mod-adapter";
 import { emitCanonicalMessageDelta } from "./protocol-outbound";
 import type { ListenerTransport } from "./transport";
@@ -53,7 +54,10 @@ export async function emitListenerTurnStart(options: {
   cachedAgent?: AgentState | null;
 }): Promise<ListenerTurnStartEmission> {
   try {
-    const modAdapter = ensureListenerModAdapter(options.runtime);
+    const modAdapters = await ensureListenerModAdaptersForAgent(
+      options.runtime,
+      options.agentId,
+    );
     const context = createListenerModContext({
       sessionId: options.conversationId,
       workingDirectory: options.workingDirectory,
@@ -65,7 +69,11 @@ export async function emitListenerTurnStart(options: {
       conversationId: options.conversationId,
       input: options.input,
     };
-    await modAdapter.events.emit("turn_start", event, context);
+    await createListenerModEvents(modAdapters).emit(
+      "turn_start",
+      event,
+      context,
+    );
     const cancel = getTurnStartCancel(event);
     if (cancel) {
       return { cancelled: true, reason: cancel.reason };
@@ -91,7 +99,10 @@ export async function emitListenerTurnEnd(options: {
   cachedAgent?: AgentState | null;
 }): Promise<string | undefined> {
   try {
-    const modAdapter = ensureListenerModAdapter(options.runtime);
+    const modAdapters = await ensureListenerModAdaptersForAgent(
+      options.runtime,
+      options.agentId,
+    );
     const context = createListenerModContext({
       sessionId: options.conversationId,
       workingDirectory: options.workingDirectory,
@@ -110,7 +121,7 @@ export async function emitListenerTurnEnd(options: {
       stopReason: options.stopReason,
       assistantMessage: options.assistantMessage,
     };
-    await modAdapter.events.emit("turn_end", event, context);
+    await createListenerModEvents(modAdapters).emit("turn_end", event, context);
     return typeof event.continue === "string" && event.continue.length > 0
       ? event.continue
       : undefined;

--- a/src/websocket/listener/turn-setup.ts
+++ b/src/websocket/listener/turn-setup.ts
@@ -21,7 +21,10 @@ import { debugWarn, isDebugEnabled } from "@/utils/debug";
 import { detectShellContext } from "@/utils/shell-context";
 import { getInboundImageFailureModes } from "./image-policy";
 import { consumeInterruptQueue } from "./interrupts";
-import { ensureListenerModAdapter } from "./mod-adapter";
+import {
+  createListenerModEvents,
+  ensureListenerModAdaptersForAgent,
+} from "./mod-adapter";
 import type { ConversationPermissionModeState } from "./permission-mode";
 import { emitListenerTurnStart } from "./turn-events";
 import {
@@ -247,6 +250,10 @@ export async function prepareListenerTurn(params: {
   if (currentInput !== messagesToSend) {
     inboundUserTranscriptLines = buildInboundUserTranscriptLines(currentInput);
   }
+  const modAdapters = await ensureListenerModAdaptersForAgent(
+    runtime.listener,
+    agentId,
+  );
   const preparedToolContext = await prepareToolExecutionContextForScope({
     agentId,
     conversationId,
@@ -256,7 +263,8 @@ export async function prepareListenerTurn(params: {
     permissionModeState,
     cachedAgent,
     channelTurnSources: msg.channelTurnSources,
-    modEvents: ensureListenerModAdapter(runtime.listener).events,
+    modAdapters,
+    modEvents: createListenerModEvents(modAdapters),
   });
   if (isInterrupted()) {
     return { kind: "interrupted" };

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -197,8 +197,12 @@ export type ListenerRuntime = {
   hasSuccessfulConnection: boolean;
   /** True once the WS has connected at least once. Never reset to false. */
   everConnected: boolean;
-  /** Provider-only local mod adapter for desktop/listener surfaces. */
+  /** Global local mod adapter for desktop/listener surfaces. */
   modAdapter?: ModAdapter | undefined;
+  /** Isolated agent-scoped adapters loaded from each agent's MemFS. */
+  agentModAdapters?: Map<string, ModAdapter>;
+  /** Coalesces concurrent first-loads for one agent's scoped adapter. */
+  agentModAdapterLoads?: Map<string, Promise<ModAdapter | null>>;
   sessionId: string;
   eventSeqCounter: number;
   queueEmitScheduled: boolean;

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -238,7 +238,7 @@ export type ListenerRuntime = {
     import("@/websocket/listener/worktree-watcher").WorktreeWatcherState
   >;
   /** Agent IDs whose memfs repo has been cloned/pulled this session. Concurrent callers coalesce on the same promise. */
-  memfsSyncedAgents: Map<string, Promise<void>>;
+  memfsSyncedAgents: Map<string, Promise<boolean>>;
   /** Agent IDs with an in-flight secrets refresh. Concurrent callers coalesce on the same promise. */
   secretsHydrationByAgent: Map<string, Promise<void>>;
   /** Per-agent timestamp of the last successful secrets hydration. Used for freshness-based caching. */

--- a/src/websocket/listener/warmup.ts
+++ b/src/websocket/listener/warmup.ts
@@ -1,6 +1,7 @@
 import { getBackend } from "@/backend";
 import { debugWarn } from "@/utils/debug";
 import { ensureMemfsSyncedForAgent } from "./memfs-sync";
+import { ensureListenerAgentModAdapter } from "./mod-adapter";
 import { ensureSecretsHydratedForAgent } from "./secrets-sync";
 import type { ListenerRuntime } from "./types";
 
@@ -92,6 +93,7 @@ export async function ensureListenerWarmStateForTurn(
       warmupDeps.ensureSecretsHydratedForAgent(listener, agentId),
       agentMetadataPromise,
     ]);
+    await ensureListenerAgentModAdapter(listener, agentId);
   } catch (error) {
     debugWarn(
       "listener-warmup",

--- a/src/websocket/listener/warmup.ts
+++ b/src/websocket/listener/warmup.ts
@@ -2,7 +2,9 @@ import { getBackend } from "@/backend";
 import { debugWarn } from "@/utils/debug";
 import { ensureMemfsSyncedForAgent } from "./memfs-sync";
 import { ensureListenerAgentModAdapter } from "./mod-adapter";
+import { emitDeviceStatusUpdateIfChanged } from "./protocol-outbound";
 import { ensureSecretsHydratedForAgent } from "./secrets-sync";
+import { isListenerTransportOpen } from "./transport";
 import type { ListenerRuntime } from "./types";
 
 export type ListenerAgentMetadata = {
@@ -93,7 +95,17 @@ export async function ensureListenerWarmStateForTurn(
       warmupDeps.ensureSecretsHydratedForAgent(listener, agentId),
       agentMetadataPromise,
     ]);
-    await ensureListenerAgentModAdapter(listener, agentId);
+    const agentModAdapter = await ensureListenerAgentModAdapter(
+      listener,
+      agentId,
+    );
+    const transport = listener.transport ?? listener.socket;
+    if (agentModAdapter && transport && isListenerTransportOpen(transport)) {
+      emitDeviceStatusUpdateIfChanged(transport, listener, {
+        agent_id: agentId,
+        conversation_id: scope.conversationId,
+      });
+    }
   } catch (error) {
     debugWarn(
       "listener-warmup",


### PR DESCRIPTION
## Problem

The websocket listener loaded only global mods. Agent-scoped mods under `$MEMORY_DIR/mods` appeared in discovery but their tools and commands were absent from Slack and other channel turns.

## What changed

- Load a separate MemFS mod adapter per agent after listener memory sync.
- Compose global and agent-scoped tools, permissions, events, and commands into each turn without registering agent capabilities process-wide.
- Refresh the current agent adapter on `/reload` so the next turn gets a fresh tool snapshot.
- Keep transpilation caches outside the git-backed memory directory.
- Preserve the existing global-mod path and source priority behavior.

Agent-scoped provider registration remains disabled in listener mode because provider registration is process-global and cannot be isolated safely.

## Before / after

Before: an agent could install a MemFS mod and `letta mods list --agent` would find it, but listener/channel turns exposed only globally installed mods.

After: each listener turn sees global mods plus only that agent’s MemFS mods. Two agents sharing one listener cannot see or execute each other’s tools or commands.

## Risk

This touches shared mod registration and listener tool-snapshot construction. The isolated adapters retain local definitions without mutating process registries; existing adapters continue using process-global registration by default. Regression coverage exercises two simultaneous agents, reload behavior, command isolation, global mod preservation, and a clean MemFS git status.

## Validation

- `bun run check` — 12/12 checks pass
- Focused mod/listener suite — 73 tests pass
- Full `bun test` attempted — 5,053 pass, 26 skip, 28 fail in unrelated live/environment-sensitive tests (including insufficient Cloud credits); a representative tool-context failure reproduces on unchanged `main`

Linear: [LET-9646](https://linear.app/letta/issue/LET-9646/load-agent-scoped-memfs-mods-in-listener-runtimes)

Authored by Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974).

👾 Generated with [Letta Code](https://letta.com)