### PR TITLE
fix(slack): preserve access to oversized attachments

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -37,7 +37,7 @@
   "src/settings-manager.test.ts": 1669,
   "src/settings-manager.ts": 2113,
   "src/tools/impl/enter-worktree.ts": 1260,
-  "src/tools/impl/message-channel.ts": 1208,
+  "src/tools/impl/message-channel.ts": 1187,
   "src/tools/manager.ts": 3293,
   "src/tools/tool-execution-context.test.ts": 1422,
   "src/types/protocol_v2.ts": 2932,

--- a/src/channels/message-channel-slack.test.ts
+++ b/src/channels/message-channel-slack.test.ts
@@ -477,6 +477,159 @@ describe("MessageChannel Slack", () => {
     });
   });
 
+  test("downloads a scoped Slack attachment through the routed adapter", async () => {
+    const registry = new ChannelRegistry();
+    const downloadAttachment = mock(async () => ({
+      id: "FLARGE",
+      name: "LandscapeTransmission.zip",
+      mimeType: "application/zip",
+      sizeBytes: 43_714_492,
+      kind: "file" as const,
+      localPath:
+        "/tmp/channels/slack/inbound/account-1/LandscapeTransmission.zip",
+    }));
+    const adapter = {
+      id: "slack:account-1",
+      channelId: "slack",
+      accountId: "account-1",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "unused" }),
+      sendDirectReply: async () => {},
+      downloadAttachment,
+    };
+
+    registry.registerAdapter(adapter);
+    setRouteInMemory("slack", {
+      accountId: "account-1",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: "1712790000.000050",
+      agentId: "agent-1",
+      conversationId: "conv-thread",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    const result = await message_channel({
+      action: "download-file",
+      channel: "slack",
+      chat_id: "C123",
+      threadId: "1712790000.000050",
+      attachmentId: "FLARGE",
+      messageId: "1712800000.000100",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "conv-thread",
+      },
+    });
+
+    expect(result).toBe(
+      "Slack attachment downloaded (local_path: /tmp/channels/slack/inbound/account-1/LandscapeTransmission.zip)",
+    );
+    expect(downloadAttachment).toHaveBeenCalledWith({
+      attachmentId: "FLARGE",
+      chatId: "C123",
+      threadId: "1712790000.000050",
+      messageId: "1712800000.000100",
+    });
+  });
+
+  test("does not infer the active route thread for channel-history attachment downloads", async () => {
+    const registry = new ChannelRegistry();
+    const downloadAttachment = mock(async () => ({
+      id: "FHISTORY",
+      name: "history.zip",
+      kind: "file" as const,
+      localPath: "/tmp/history.zip",
+    }));
+    const adapter = {
+      id: "slack:account-1",
+      channelId: "slack",
+      accountId: "account-1",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "unused" }),
+      sendDirectReply: async () => {},
+      downloadAttachment,
+    };
+    registry.registerAdapter(adapter);
+    setRouteInMemory("slack", {
+      accountId: "account-1",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: "1712800000.000100",
+      agentId: "agent-1",
+      conversationId: "conv-thread",
+      enabled: true,
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+    });
+
+    await message_channel({
+      action: "download-file",
+      channel: "slack",
+      chat_id: "C123",
+      attachmentId: "FHISTORY",
+      messageId: "1712700000.000010",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "conv-thread",
+      },
+    });
+
+    expect(downloadAttachment).toHaveBeenCalledWith({
+      attachmentId: "FHISTORY",
+      chatId: "C123",
+      threadId: null,
+      messageId: "1712700000.000010",
+    });
+  });
+
+  test("rejects Slack attachment downloads through proactive targets", async () => {
+    const registry = new ChannelRegistry();
+    const downloadAttachment = mock(async () => ({
+      id: "FLARGE",
+      kind: "file" as const,
+      localPath: "/tmp/large.zip",
+    }));
+    const adapter = {
+      id: "slack:account-1",
+      channelId: "slack",
+      accountId: "account-1",
+      name: "Slack",
+      start: async () => {},
+      stop: async () => {},
+      isRunning: () => true,
+      sendMessage: async () => ({ messageId: "unused" }),
+      sendDirectReply: async () => {},
+      downloadAttachment,
+    };
+    registry.registerAdapter(adapter);
+
+    const result = await message_channel({
+      action: "download-file",
+      channel: "slack",
+      target: "#private-channel",
+      attachmentId: "FLARGE",
+      messageId: "1712800000.000100",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "conv-thread",
+      },
+    });
+
+    expect(result).toBe(
+      "Error: Slack download-file requires chat_id from a routed channel context; target is not supported.",
+    );
+    expect(downloadAttachment).not.toHaveBeenCalled();
+  });
+
   test("supports proactive Slack sends to explicit cached targets without consulting routes", async () => {
     installChannelStateTestOverrides();
     const registry = new ChannelRegistry();

--- a/src/channels/message-tool-schema.test.ts
+++ b/src/channels/message-tool-schema.test.ts
@@ -59,8 +59,10 @@ describe("buildDynamicMessageChannelSchema", () => {
       "send",
       "react",
       "upload-file",
+      "download-file",
       "send-rich",
     ]);
+    expect(properties.attachmentId).toBeDefined();
   });
 
   test("keeps Telegram-only tool actions narrowed to Telegram-supported actions", async () => {
@@ -86,6 +88,7 @@ describe("buildDynamicMessageChannelSchema", () => {
       "react",
       "upload-file",
     ]);
+    expect(properties.attachmentId).toBeUndefined();
   });
 
   test("builds description from the same discovery result as the schema", async () => {
@@ -115,16 +118,20 @@ describe("buildDynamicMessageChannelSchema", () => {
       "Currently active channels: Slack, Telegram.",
     );
     expect(resolved.description).toContain(
-      "Available actions across the active channels: send, react, upload-file, send-rich.",
+      "Available actions across the active channels: send, react, upload-file, download-file, send-rich.",
     );
     expect(resolved.description).toContain(
       SLACK_WORK_ACKNOWLEDGEMENT_GUIDANCE_PREFIX,
+    );
+    expect(resolved.description).toContain(
+      'Use action="download-file" with channel, chat_id, attachmentId, and messageId',
     );
     expect(properties.channel?.enum).toEqual(["slack", "telegram"]);
     expect(properties.action?.enum).toEqual([
       "send",
       "react",
       "upload-file",
+      "download-file",
       "send-rich",
     ]);
   });
@@ -176,7 +183,12 @@ describe("buildDynamicMessageChannelSchema", () => {
     );
     expect(resolved.description).not.toContain("Telegram");
     expect(properties.channel?.enum).toEqual(["slack"]);
-    expect(properties.action?.enum).toEqual(["send", "react", "upload-file"]);
+    expect(properties.action?.enum).toEqual([
+      "send",
+      "react",
+      "upload-file",
+      "download-file",
+    ]);
   });
 
   test("does not add Slack work acknowledgement guidance to Telegram-only scoped descriptions", async () => {
@@ -211,6 +223,7 @@ describe("buildDynamicMessageChannelSchema", () => {
     expect(resolved.description).not.toContain(
       SLACK_WORK_ACKNOWLEDGEMENT_GUIDANCE_PREFIX,
     );
+    expect(resolved.description).not.toContain('action="download-file"');
     expect(properties.channel?.enum).toEqual(["telegram"]);
     expect(properties.action?.enum).toEqual([
       "send",

--- a/src/channels/message-tool.ts
+++ b/src/channels/message-tool.ts
@@ -145,8 +145,11 @@ function buildDynamicMessageChannelDescriptionFromDiscovery(
   const slackWorkAcknowledgement = discovery.activeChannels.includes("slack")
     ? '\n\nFor Slack requests that require nontrivial work or several tool calls, send one short MessageChannel call with action="send" before starting other tools. This gives the Slack user verbal acknowledgement and a View in web link. Do not do this for no-ops, reaction-only responses, or simple no-tool answers.'
     : "";
+  const slackAttachmentDownload = discovery.activeChannels.includes("slack")
+    ? '\n\nSlack attachments that exceed the automatic download limit include an exact recovery instruction. Use action="download-file" with channel, chat_id, attachmentId, and messageId from that instruction. The action saves the file in the normal Slack inbound attachment directory and returns its local_path.'
+    : "";
 
-  return `${description}${scopedReplyContract}${slackWorkAcknowledgement}\n\nCurrently active channels: ${channelList}. Available actions across the active channels: ${actionList}. The JSON schema reflects the currently active channel plugins.`;
+  return `${description}${scopedReplyContract}${slackWorkAcknowledgement}${slackAttachmentDownload}\n\nCurrently active channels: ${channelList}. Available actions across the active channels: ${actionList}. The JSON schema reflects the currently active channel plugins.`;
 }
 
 function pruneInactiveChannelGuidance(

--- a/src/channels/plugin-types.ts
+++ b/src/channels/plugin-types.ts
@@ -239,6 +239,7 @@ export interface ChannelMessageActionRequest {
   replyToMessageId?: string;
   threadId?: string | null;
   messageId?: string;
+  attachmentId?: string;
   emoji?: string;
   remove?: boolean;
   mediaPath?: string;

--- a/src/channels/slack/adapter-test-harness.ts
+++ b/src/channels/slack/adapter-test-harness.ts
@@ -237,6 +237,14 @@ export class FakeSlackWriteClient {
 export const resolveSlackInboundAttachmentsMock = mock(
   async (): Promise<ChannelMessageAttachment[]> => [],
 );
+export const downloadSlackAttachmentByIdMock = mock(
+  async (): Promise<ChannelMessageAttachment> => ({
+    id: "FTEST",
+    name: "attachment.bin",
+    kind: "file",
+    localPath: "/tmp/attachment.bin",
+  }),
+);
 export const resolveSlackThreadStarterMock = mock(
   async (): Promise<{
     text: string;
@@ -296,6 +304,10 @@ mock.module("./media", () => ({
   resolveSlackThreadHistory: resolveSlackThreadHistoryMock,
 }));
 
+mock.module("./attachment-download", () => ({
+  downloadSlackAttachmentById: downloadSlackAttachmentByIdMock,
+}));
+
 const adapterModule = await import("@/channels/slack/adapter");
 const accountDisplayModule = await import("@/channels/slack/account-display");
 export const createSlackAdapter = adapterModule.createSlackAdapter;
@@ -325,6 +337,13 @@ export function installSlackAdapterTestHooks(): void {
     FakeSlackWriteClient.setStatusHandler = null;
     resolveSlackInboundAttachmentsMock.mockReset();
     resolveSlackInboundAttachmentsMock.mockImplementation(async () => []);
+    downloadSlackAttachmentByIdMock.mockReset();
+    downloadSlackAttachmentByIdMock.mockImplementation(async () => ({
+      id: "FTEST",
+      name: "attachment.bin",
+      kind: "file",
+      localPath: "/tmp/attachment.bin",
+    }));
     resolveSlackThreadStarterMock.mockReset();
     resolveSlackThreadStarterMock.mockImplementation(async () => null);
     resolveSlackThreadHistoryMock.mockReset();

--- a/src/channels/slack/adapter.test.ts
+++ b/src/channels/slack/adapter.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   createSlackAdapter,
+  downloadSlackAttachmentByIdMock,
   FakeSlackApp,
   FakeSlackWriteClient,
   fetchMock,
@@ -14,6 +15,37 @@ import {
 import { buildSlackModelPickerBlocks } from "./model-picker-blocks";
 
 installSlackAdapterTestHooks();
+
+test("slack adapter downloads attachments through its authenticated app client", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+  await adapter.start();
+
+  await adapter.downloadAttachment({
+    attachmentId: "FLARGE",
+    chatId: "C123",
+    threadId: "1712790000.000050",
+    messageId: "1712800000.000100",
+  });
+
+  expect(downloadSlackAttachmentByIdMock).toHaveBeenCalledWith({
+    accountId: "slack-test-account",
+    token: "xoxb-test-token-1234567890",
+    attachmentId: "FLARGE",
+    channelId: "C123",
+    threadTs: "1712790000.000050",
+    messageTs: "1712800000.000100",
+    client: FakeSlackApp.instances[0]?.client,
+  });
+});
 
 test("slack adapter start does not re-run bolt init", async () => {
   const adapter = createSlackAdapter({

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -4,6 +4,7 @@ import { buildSlackModelPickerBlocks } from "@/channels/slack/model-picker-block
 import type {
   ChannelAdapter,
   ChannelControlRequestEvent,
+  ChannelMessageAttachment,
   ChannelModelPickerData,
   ChannelTurnLifecycleEvent,
   ChannelTurnProgressEvent,
@@ -17,6 +18,8 @@ import {
   createAgentThreadTracker,
 } from "./agent-thread-tracker";
 import { createSlackApprovalController } from "./approval-controller";
+import { downloadSlackAttachmentById } from "./attachment-download";
+import type { SlackAttachmentReadClient } from "./attachment-types";
 import { uploadSlackFile } from "./file-upload";
 import {
   createSlackInboundDebounceController,
@@ -49,15 +52,24 @@ import {
 } from "./utils";
 import { createSlackWebApiClient } from "./web-api-client";
 
+export interface SlackChannelAdapter extends ChannelAdapter {
+  downloadAttachment(params: {
+    attachmentId: string;
+    chatId: string;
+    threadId?: string | null;
+    messageId: string;
+  }): Promise<ChannelMessageAttachment>;
+}
+
 export function createSlackAdapter(
   config: SlackChannelAccount,
-): ChannelAdapter {
+): SlackChannelAdapter {
   let app: SlackApp | null = null;
   let writeClient: SlackWriteClient | null = null;
   let writeClientPromise: Promise<SlackWriteClient> | null = null;
   let running = false;
   let botUserId: string | null = null;
-  let adapter: ChannelAdapter;
+  let adapter: SlackChannelAdapter;
 
   const agentThreadTracker: AgentThreadTracker = createAgentThreadTracker();
   const debounce: SlackInboundDebounceController =
@@ -116,6 +128,24 @@ export function createSlackAdapter(
       writeClientPromise = null;
       throw error;
     }
+  }
+
+  async function downloadAttachment(params: {
+    attachmentId: string;
+    chatId: string;
+    threadId?: string | null;
+    messageId: string;
+  }): Promise<ChannelMessageAttachment> {
+    const slackApp = await ensureApp();
+    return await downloadSlackAttachmentById({
+      accountId: config.accountId,
+      token: config.botToken,
+      attachmentId: params.attachmentId,
+      channelId: params.chatId,
+      threadTs: params.threadId,
+      messageTs: params.messageId,
+      client: slackApp.client as unknown as SlackAttachmentReadClient,
+    });
   }
 
   async function sendLifecycleErrorReply(
@@ -396,6 +426,7 @@ export function createSlackAdapter(
       );
     },
     sendMessage,
+    downloadAttachment,
     sendDirectReply,
     handleControlRequestEvent,
     prepareInboundMessage: (msg, options) =>

--- a/src/channels/slack/attachment-download.ts
+++ b/src/channels/slack/attachment-download.ts
@@ -1,0 +1,100 @@
+import type { ChannelMessageAttachment } from "@/channels/types";
+import type { SlackAttachmentReadClient } from "./attachment-types";
+import { collectSlackFiles, materializeSlackAttachment } from "./media";
+
+type SlackRepliesPageMessage = {
+  ts?: string;
+  files?: unknown[];
+  attachments?: unknown[];
+};
+
+type SlackRepliesPage = {
+  messages?: SlackRepliesPageMessage[];
+  response_metadata?: { next_cursor?: string };
+};
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+async function resolveCanonicalSlackMessage(params: {
+  channelId: string;
+  threadTs?: string | null;
+  messageTs: string;
+  client: SlackAttachmentReadClient;
+}): Promise<SlackRepliesPageMessage | null> {
+  if (isNonEmptyString(params.threadTs)) {
+    let cursor: string | undefined;
+    do {
+      const response = (await params.client.conversations.replies({
+        channel: params.channelId,
+        ts: params.threadTs,
+        limit: 200,
+        inclusive: true,
+        ...(cursor ? { cursor } : {}),
+      })) as SlackRepliesPage;
+      const message = (response.messages ?? []).find(
+        (entry) => entry.ts === params.messageTs,
+      );
+      if (message) {
+        return message;
+      }
+      const nextCursor = response.response_metadata?.next_cursor;
+      cursor = isNonEmptyString(nextCursor) ? nextCursor.trim() : undefined;
+    } while (cursor);
+    return null;
+  }
+
+  const response = (await params.client.conversations.history({
+    channel: params.channelId,
+    oldest: params.messageTs,
+    latest: params.messageTs,
+    inclusive: true,
+    limit: 1,
+  })) as SlackRepliesPage;
+  return (
+    (response.messages ?? []).find((entry) => entry.ts === params.messageTs) ??
+    null
+  );
+}
+
+/**
+ * Materialize one Slack attachment from its canonical source message.
+ * Unlike automatic attachment ingestion, this explicit action has no hidden
+ * size ceiling; it streams into the same inbound directory and returns the
+ * local path. The canonical message lookup keeps file access scoped to the
+ * routed Slack chat/thread instead of trusting a bare file id.
+ */
+export async function downloadSlackAttachmentById(params: {
+  accountId: string;
+  token: string;
+  attachmentId: string;
+  channelId: string;
+  threadTs?: string | null;
+  messageTs: string;
+  client: SlackAttachmentReadClient;
+}): Promise<ChannelMessageAttachment> {
+  const message = await resolveCanonicalSlackMessage(params);
+  if (!message) {
+    throw new Error(
+      `Slack message ${params.messageTs} was not found in chat ${params.channelId}.`,
+    );
+  }
+
+  const file = collectSlackFiles(message).find(
+    (entry) => entry.id === params.attachmentId,
+  );
+  if (!file) {
+    throw new Error(
+      `Slack attachment ${params.attachmentId} is not attached to message ${params.messageTs}.`,
+    );
+  }
+
+  return await materializeSlackAttachment({
+    accountId: params.accountId,
+    token: params.token,
+    file,
+    sourceMessageId: params.messageTs,
+    sourceThreadId: params.threadTs ?? null,
+  });
+}

--- a/src/channels/slack/attachment-stream.ts
+++ b/src/channels/slack/attachment-stream.ts
@@ -1,0 +1,99 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, open, rename, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { getChannelDir } from "@/channels/config";
+
+export type SlackAttachmentDownloadFailureReason =
+  | "exceeds_auto_download_limit"
+  | "missing_download_url"
+  | "download_failed";
+
+export class SlackAttachmentDownloadError extends Error {
+  constructor(
+    readonly reason: SlackAttachmentDownloadFailureReason,
+    message: string,
+  ) {
+    super(message);
+    this.name = "SlackAttachmentDownloadError";
+  }
+}
+
+function sanitizeFileName(name: string): string {
+  const normalized = name.trim().replace(/[^\w.-]+/g, "_");
+  return normalized.length > 0 ? normalized : "attachment";
+}
+
+export async function saveSlackAttachmentStream(params: {
+  accountId: string;
+  fileName: string;
+  body: ReadableStream<Uint8Array>;
+  maxBytes?: number;
+}): Promise<{ localPath: string; sizeBytes: number }> {
+  const inboundDir = join(
+    getChannelDir("slack"),
+    "inbound",
+    sanitizeFileName(params.accountId),
+  );
+  await mkdir(inboundDir, { recursive: true });
+
+  const filePath = join(
+    inboundDir,
+    `${Date.now()}-${randomUUID()}-${sanitizeFileName(params.fileName)}`,
+  );
+  const temporaryPath = `${filePath}.partial`;
+  const fileHandle = await open(temporaryPath, "wx");
+  const reader = params.body.getReader();
+  let sizeBytes = 0;
+  let completed = false;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (!value?.byteLength) {
+        continue;
+      }
+      sizeBytes += value.byteLength;
+      if (params.maxBytes !== undefined && sizeBytes > params.maxBytes) {
+        throw new SlackAttachmentDownloadError(
+          "exceeds_auto_download_limit",
+          `Slack attachment exceeds automatic download limit (${params.maxBytes} bytes).`,
+        );
+      }
+      let offset = 0;
+      while (offset < value.byteLength) {
+        const { bytesWritten } = await fileHandle.write(
+          value,
+          offset,
+          value.byteLength - offset,
+        );
+        if (bytesWritten <= 0) {
+          throw new Error("Slack attachment write made no progress.");
+        }
+        offset += bytesWritten;
+      }
+    }
+    completed = true;
+  } finally {
+    if (!completed) {
+      await reader.cancel().catch(() => undefined);
+    }
+    try {
+      reader.releaseLock();
+    } catch {}
+    await fileHandle.close().catch(() => undefined);
+    if (!completed) {
+      await rm(temporaryPath, { force: true }).catch(() => undefined);
+    }
+  }
+
+  try {
+    await rename(temporaryPath, filePath);
+  } catch (error) {
+    await rm(temporaryPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+  return { localPath: filePath, sizeBytes };
+}

--- a/src/channels/slack/attachment-types.ts
+++ b/src/channels/slack/attachment-types.ts
@@ -1,0 +1,27 @@
+export type SlackFileLike = {
+  id?: string;
+  name?: string;
+  mimetype?: string;
+  size?: number;
+  url_private?: string;
+  url_private_download?: string;
+};
+
+export type SlackAttachmentReadClient = {
+  conversations: {
+    history(args: {
+      channel: string;
+      latest?: string;
+      oldest?: string;
+      limit?: number;
+      inclusive?: boolean;
+    }): Promise<unknown>;
+    replies(args: {
+      channel: string;
+      ts: string;
+      limit?: number;
+      inclusive?: boolean;
+      cursor?: string;
+    }): Promise<unknown>;
+  };
+};

--- a/src/channels/slack/media.test.ts
+++ b/src/channels/slack/media.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, expect, mock, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { __testOverrideChannelsRoot } from "@/channels/config";
@@ -43,6 +43,12 @@ afterEach(async () => {
 
 async function loadSlackMediaModule() {
   return import(`./media.ts?slack-media-test=${Date.now()}-${Math.random()}`);
+}
+
+async function loadSlackAttachmentDownloadModule() {
+  return import(
+    `./attachment-download.ts?slack-download-test=${Date.now()}-${Math.random()}`
+  );
 }
 
 test("resolveSlackThreadStarter falls back to forwarded Slack attachment text", async () => {
@@ -319,6 +325,66 @@ test("resolveSlackCurrentMessageAttachments hydrates files from the exact thread
   expect(fetchMock).toHaveBeenCalledTimes(1);
 });
 
+test("resolveSlackCurrentMessageAttachments preserves oversized files from the exact thread message", async () => {
+  const fetchMock = mock(async () => {
+    throw new Error("oversized canonical attachment should not be fetched");
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+  const { resolveSlackCurrentMessageAttachments } =
+    await loadSlackMediaModule();
+  const client = {
+    conversations: {
+      history: mock(async () => ({ messages: [] })),
+      replies: mock(async () => ({
+        messages: [
+          {
+            ts: "1712790000.000050",
+            text: "Thread root",
+          },
+          {
+            ts: "1712800000.000100",
+            text: "Here are the files",
+            subtype: "thread_broadcast",
+            files: [
+              {
+                id: "FLARGE",
+                name: "LandscapeTransmission.zip",
+                mimetype: "application/zip",
+                size: 43_714_492,
+                url_private_download:
+                  "https://files.slack.com/files-pri/T123-FLARGE/LandscapeTransmission.zip",
+              },
+            ],
+          },
+        ],
+      })),
+    },
+  };
+
+  const attachments = await resolveSlackCurrentMessageAttachments({
+    channelId: "C123",
+    threadTs: "1712790000.000050",
+    messageTs: "1712800000.000100",
+    client,
+    accountId: "slack-bot",
+    token: "xoxb-test-token",
+  });
+
+  expect(attachments).toEqual([
+    expect.objectContaining({
+      id: "FLARGE",
+      name: "LandscapeTransmission.zip",
+      sizeBytes: 43_714_492,
+      sourceMessageId: "1712800000.000100",
+      sourceThreadId: "1712790000.000050",
+      downloadReason: "exceeds_auto_download_limit",
+      autoDownloadLimitBytes: 20 * 1024 * 1024,
+    }),
+  ]);
+  expect(fetchMock).not.toHaveBeenCalled();
+});
+
 test("resolveSlackThreadHistory bot-only mode skips human attachment downloads", async () => {
   const fetchMock = mock(async () => {
     throw new Error("human history attachment should not be downloaded");
@@ -545,4 +611,293 @@ test("resolveSlackInboundAttachments records transcription errors when OpenAI is
     transcriptionError: "OPENAI_API_KEY not set; transcription skipped.",
   });
   expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+test("oversized Slack attachments remain visible without entering the automatic download path", async () => {
+  const fetchMock = mock(async () => {
+    throw new Error("oversized attachment should not be fetched automatically");
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+  const { resolveSlackInboundAttachments } = await loadSlackMediaModule();
+  const attachments = await resolveSlackInboundAttachments({
+    accountId: "slack-bot",
+    token: "xoxb-test-token",
+    rawEvent: {
+      ts: "1712800000.000100",
+      thread_ts: "1712790000.000050",
+      files: [
+        {
+          id: "FLARGE",
+          name: "LandscapeTransmission.zip",
+          mimetype: "application/zip",
+          size: 43_714_492,
+          url_private_download:
+            "https://files.slack.com/files-pri/T123-FLARGE/LandscapeTransmission.zip",
+        },
+      ],
+    },
+  });
+
+  expect(attachments).toEqual([
+    {
+      id: "FLARGE",
+      name: "LandscapeTransmission.zip",
+      mimeType: "application/zip",
+      sizeBytes: 43_714_492,
+      kind: "file",
+      sourceMessageId: "1712800000.000100",
+      sourceThreadId: "1712790000.000050",
+      downloadReason: "exceeds_auto_download_limit",
+      autoDownloadLimitBytes: 20 * 1024 * 1024,
+    },
+  ]);
+  expect(fetchMock).not.toHaveBeenCalled();
+});
+
+test("automatic Slack downloads enforce the limit while streaming and remove partial files", async () => {
+  const oversizedBody = new Uint8Array(20 * 1024 * 1024 + 1);
+  const fetchMock = mock(
+    async () =>
+      new Response(oversizedBody, {
+        status: 200,
+        headers: { "content-type": "application/zip" },
+      }),
+  );
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+  const { resolveSlackInboundAttachments } = await loadSlackMediaModule();
+  const attachments = await resolveSlackInboundAttachments({
+    accountId: "slack-bot",
+    token: "xoxb-test-token",
+    rawEvent: {
+      ts: "1712800000.000100",
+      files: [
+        {
+          id: "FUNSIZED",
+          name: "unknown-size.zip",
+          mimetype: "application/zip",
+          url_private_download:
+            "https://files.slack.com/files-pri/T123-FUNSIZED/unknown-size.zip",
+        },
+      ],
+    },
+  });
+
+  expect(attachments).toEqual([
+    expect.objectContaining({
+      id: "FUNSIZED",
+      downloadReason: "exceeds_auto_download_limit",
+      autoDownloadLimitBytes: 20 * 1024 * 1024,
+    }),
+  ]);
+  if (!channelsRoot) {
+    throw new Error("Expected Slack media test root");
+  }
+  const inboundDir = join(channelsRoot, "slack", "inbound", "slack-bot");
+  expect(await readdir(inboundDir)).toEqual([]);
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+test("downloadSlackAttachmentById streams an oversized file from its canonical thread message", async () => {
+  const fileBytes = new Uint8Array([1, 2, 3, 4, 5]);
+  const fetchMock = mock(
+    async () =>
+      new Response(fileBytes, {
+        status: 200,
+        headers: { "content-type": "application/zip" },
+      }),
+  );
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+  const { downloadSlackAttachmentById } =
+    await loadSlackAttachmentDownloadModule();
+  const client = {
+    conversations: {
+      history: mock(async () => ({ messages: [] })),
+      replies: mock(async () => ({
+        messages: [
+          {
+            ts: "1712790000.000050",
+            text: "Thread root",
+          },
+          {
+            ts: "1712800000.000100",
+            text: "Here is the large package",
+            files: [
+              {
+                id: "FLARGE",
+                name: "LandscapeTransmission.zip",
+                mimetype: "application/zip",
+                size: 43_714_492,
+                url_private_download:
+                  "https://files.slack.com/files-pri/T123-FLARGE/LandscapeTransmission.zip",
+              },
+            ],
+          },
+        ],
+      })),
+    },
+  };
+
+  const attachment = await downloadSlackAttachmentById({
+    accountId: "slack-bot",
+    token: "xoxb-test-token",
+    attachmentId: "FLARGE",
+    channelId: "C123",
+    threadTs: "1712790000.000050",
+    messageTs: "1712800000.000100",
+    client,
+  });
+  const localPath = attachment.localPath;
+
+  expect(attachment).toMatchObject({
+    id: "FLARGE",
+    name: "LandscapeTransmission.zip",
+    mimeType: "application/zip",
+    sizeBytes: fileBytes.byteLength,
+    kind: "file",
+    sourceMessageId: "1712800000.000100",
+    localPath: expect.stringContaining("LandscapeTransmission.zip"),
+  });
+  if (!localPath) {
+    throw new Error("Expected explicit Slack download to return localPath");
+  }
+  expect(await readFile(localPath)).toEqual(Buffer.from(fileBytes));
+  expect(client.conversations.replies).toHaveBeenCalledWith(
+    expect.objectContaining({
+      channel: "C123",
+      ts: "1712790000.000050",
+    }),
+  );
+  expect(client.conversations.history).not.toHaveBeenCalled();
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+test("downloadSlackAttachmentById materializes a canonical top-level message through history", async () => {
+  const fetchMock = mock(
+    async () =>
+      new Response(new Uint8Array([9, 8, 7]), {
+        headers: { "content-type": "application/zip" },
+      }),
+  );
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+  const { downloadSlackAttachmentById } =
+    await loadSlackAttachmentDownloadModule();
+  const client = {
+    conversations: {
+      history: mock(async () => ({
+        messages: [
+          {
+            ts: "1712700000.000010",
+            files: [
+              {
+                id: "FHISTORY",
+                name: "history.zip",
+                mimetype: "application/zip",
+                url_private_download:
+                  "https://files.slack.com/files-pri/T123-FHISTORY/history.zip",
+              },
+            ],
+          },
+        ],
+      })),
+      replies: mock(async () => ({ messages: [] })),
+    },
+  };
+
+  const attachment = await downloadSlackAttachmentById({
+    accountId: "slack-bot",
+    token: "xoxb-test-token",
+    attachmentId: "FHISTORY",
+    channelId: "C123",
+    threadTs: null,
+    messageTs: "1712700000.000010",
+    client,
+  });
+
+  expect(attachment.localPath).toContain("history.zip");
+  expect(client.conversations.replies).not.toHaveBeenCalled();
+  expect(client.conversations.history).toHaveBeenCalledWith({
+    channel: "C123",
+    oldest: "1712700000.000010",
+    latest: "1712700000.000010",
+    inclusive: true,
+    limit: 1,
+  });
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+test("downloadSlackAttachmentById rejects file ids outside the canonical source message", async () => {
+  const fetchMock = mock(async () => new Response(new Uint8Array([1])));
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+  const { downloadSlackAttachmentById } =
+    await loadSlackAttachmentDownloadModule();
+  const client = {
+    conversations: {
+      history: mock(async () => ({ messages: [] })),
+      replies: mock(async () => ({
+        messages: [
+          {
+            ts: "1712800000.000100",
+            files: [{ id: "FOTHER", name: "other.zip" }],
+          },
+        ],
+      })),
+    },
+  };
+
+  await expect(
+    downloadSlackAttachmentById({
+      accountId: "slack-bot",
+      token: "xoxb-test-token",
+      attachmentId: "FLARGE",
+      channelId: "C123",
+      threadTs: "1712790000.000050",
+      messageTs: "1712800000.000100",
+      client,
+    }),
+  ).rejects.toThrow(
+    "Slack attachment FLARGE is not attached to message 1712800000.000100.",
+  );
+  expect(fetchMock).not.toHaveBeenCalled();
+});
+
+test("downloadSlackAttachmentById does not fall back outside an explicit thread", async () => {
+  const fetchMock = mock(async () => new Response(new Uint8Array([1])));
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+  const { downloadSlackAttachmentById } =
+    await loadSlackAttachmentDownloadModule();
+  const client = {
+    conversations: {
+      history: mock(async () => ({
+        messages: [
+          {
+            ts: "1712800000.000100",
+            files: [{ id: "FLARGE", name: "outside-thread.zip" }],
+          },
+        ],
+      })),
+      replies: mock(async () => ({ messages: [] })),
+    },
+  };
+
+  await expect(
+    downloadSlackAttachmentById({
+      accountId: "slack-bot",
+      token: "xoxb-test-token",
+      attachmentId: "FLARGE",
+      channelId: "C123",
+      threadTs: "1712790000.000050",
+      messageTs: "1712800000.000100",
+      client,
+    }),
+  ).rejects.toThrow(
+    "Slack message 1712800000.000100 was not found in chat C123.",
+  );
+  expect(client.conversations.history).not.toHaveBeenCalled();
+  expect(fetchMock).not.toHaveBeenCalled();
 });

--- a/src/channels/slack/media.ts
+++ b/src/channels/slack/media.ts
@@ -1,8 +1,15 @@
-import { randomUUID } from "node:crypto";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { basename, extname, join } from "node:path";
-import { getChannelDir } from "@/channels/config";
+import { readFile } from "node:fs/promises";
+import { basename, extname } from "node:path";
 import type { ChannelMessageAttachment } from "@/channels/types";
+import {
+  SlackAttachmentDownloadError,
+  type SlackAttachmentDownloadFailureReason,
+  saveSlackAttachmentStream,
+} from "./attachment-stream";
+import type {
+  SlackAttachmentReadClient,
+  SlackFileLike,
+} from "./attachment-types";
 
 const MAX_SLACK_ATTACHMENTS = 8;
 const MAX_SLACK_ATTACHMENT_BYTES = 20 * 1024 * 1024;
@@ -11,15 +18,6 @@ const ALLOWED_SLACK_HOST_SUFFIXES = [
   "slack-edge.com",
   "slack-files.com",
 ] as const;
-
-type SlackFileLike = {
-  id?: string;
-  name?: string;
-  mimetype?: string;
-  size?: number;
-  url_private?: string;
-  url_private_download?: string;
-};
 
 type SlackAttachmentLike = {
   text?: string;
@@ -31,29 +29,12 @@ type SlackAttachmentLike = {
   files?: SlackFileLike[];
 };
 
-type SlackRepliesClient = {
-  conversations: {
-    history(args: {
-      channel: string;
-      latest?: string;
-      limit?: number;
-      inclusive?: boolean;
-    }): Promise<unknown>;
-    replies(args: {
-      channel: string;
-      ts: string;
-      limit?: number;
-      inclusive?: boolean;
-      cursor?: string;
-    }): Promise<unknown>;
-  };
-};
-
 type SlackRepliesPageMessage = {
   text?: string;
   user?: string;
   bot_id?: string;
   ts?: string;
+  thread_ts?: string;
   files?: unknown[];
   attachments?: unknown[];
 };
@@ -88,10 +69,12 @@ type SlackThreadHistoryEntryKind = "all" | "bot";
 async function mapSlackThreadMessage(
   message: SlackRepliesPageMessage,
   attachmentOptions?: SlackThreadAttachmentOptions,
+  sourceThreadId?: string,
 ): Promise<SlackThreadMessage> {
   const attachments = await resolveSlackMessageAttachments(
     message,
     attachmentOptions,
+    sourceThreadId,
   );
   return {
     text: resolveSlackThreadMessageText(message),
@@ -241,11 +224,6 @@ function assertSlackFileUrl(rawUrl: string): URL {
   return parsed;
 }
 
-function sanitizeFileName(name: string): string {
-  const normalized = name.trim().replace(/[^\w.-]+/g, "_");
-  return normalized.length > 0 ? normalized : "attachment";
-}
-
 function extensionForMimeType(mimeType?: string): string {
   switch (mimeType?.toLowerCase()) {
     case "image/png":
@@ -378,70 +356,149 @@ async function fetchWithSlackAuth(
   return fetch(resolved.href, { redirect: "follow" });
 }
 
-async function saveSlackAttachment(params: {
-  accountId: string;
-  fileName: string;
-  buffer: Buffer;
-}): Promise<string> {
-  const inboundDir = join(
-    getChannelDir("slack"),
-    "inbound",
-    sanitizeFileName(params.accountId),
-  );
-  await mkdir(inboundDir, { recursive: true });
-
-  const filePath = join(
-    inboundDir,
-    `${Date.now()}-${randomUUID()}-${sanitizeFileName(params.fileName)}`,
-  );
-  await writeFile(filePath, params.buffer);
-  return filePath;
+function resolveSlackAttachmentFileName(params: {
+  file: SlackFileLike;
+  url?: string;
+  mimeType?: string;
+}): string {
+  const hintedName =
+    params.file.name ??
+    (params.url ? basename(new URL(params.url).pathname) : undefined) ??
+    `${params.file.id ?? "attachment"}${extensionForMimeType(params.file.mimetype)}`;
+  return extname(hintedName) || !params.mimeType
+    ? hintedName
+    : `${hintedName}${extensionForMimeType(params.mimeType)}`;
 }
 
-async function downloadSlackAttachment(params: {
+function resolveSlackAttachmentMimeType(params: {
+  file: SlackFileLike;
+  fileName: string;
+  responseMimeType?: string;
+}): string | undefined {
+  const preferredMimeType =
+    params.responseMimeType && !isGenericSlackMimeType(params.responseMimeType)
+      ? params.responseMimeType
+      : params.file.mimetype && !isGenericSlackMimeType(params.file.mimetype)
+        ? params.file.mimetype
+        : undefined;
+  return resolveMimeType(params.fileName, preferredMimeType);
+}
+
+function createUndownloadedSlackAttachment(params: {
+  file: SlackFileLike;
+  sourceMessageId?: string;
+  sourceThreadId?: string | null;
+  reason: SlackAttachmentDownloadFailureReason;
+}): ChannelMessageAttachment {
+  const fileName = resolveSlackAttachmentFileName({ file: params.file });
+  const mimeType = resolveSlackAttachmentMimeType({
+    file: params.file,
+    fileName,
+  });
+  return {
+    id: params.file.id,
+    name: fileName,
+    mimeType,
+    sizeBytes: params.file.size,
+    kind: resolveAttachmentKind(mimeType),
+    sourceMessageId: params.sourceMessageId,
+    ...(params.sourceThreadId ? { sourceThreadId: params.sourceThreadId } : {}),
+    downloadReason: params.reason,
+    ...(params.reason === "exceeds_auto_download_limit"
+      ? { autoDownloadLimitBytes: MAX_SLACK_ATTACHMENT_BYTES }
+      : {}),
+  };
+}
+
+export async function materializeSlackAttachment(params: {
   accountId: string;
   token: string;
   file: SlackFileLike;
+  sourceMessageId?: string;
+  sourceThreadId?: string | null;
+  maxBytes?: number;
   transcribeVoice?: boolean;
-}): Promise<ChannelMessageAttachment | null> {
+}): Promise<ChannelMessageAttachment> {
+  if (
+    params.maxBytes !== undefined &&
+    typeof params.file.size === "number" &&
+    params.file.size > params.maxBytes
+  ) {
+    throw new SlackAttachmentDownloadError(
+      "exceeds_auto_download_limit",
+      `Slack attachment is ${params.file.size} bytes; automatic download limit is ${params.maxBytes} bytes.`,
+    );
+  }
+
   const url = params.file.url_private_download ?? params.file.url_private;
   if (!url) {
-    return null;
+    throw new SlackAttachmentDownloadError(
+      "missing_download_url",
+      "Slack attachment does not include a private download URL.",
+    );
   }
 
-  const response = await fetchWithSlackAuth(url, params.token);
+  const response = await fetchWithSlackAuth(url, params.token).catch(
+    (error) => {
+      throw new SlackAttachmentDownloadError(
+        "download_failed",
+        error instanceof Error
+          ? error.message
+          : "Slack attachment fetch failed.",
+      );
+    },
+  );
   if (!response.ok) {
-    return null;
+    throw new SlackAttachmentDownloadError(
+      "download_failed",
+      `Slack attachment fetch failed with HTTP ${response.status}.`,
+    );
   }
 
-  const arrayBuffer = await response.arrayBuffer();
-  if (arrayBuffer.byteLength > MAX_SLACK_ATTACHMENT_BYTES) {
-    return null;
+  const contentLengthHeader = response.headers.get("content-length");
+  const contentLength = contentLengthHeader
+    ? Number(contentLengthHeader)
+    : undefined;
+  if (
+    params.maxBytes !== undefined &&
+    contentLength !== undefined &&
+    Number.isFinite(contentLength) &&
+    contentLength > params.maxBytes
+  ) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new SlackAttachmentDownloadError(
+      "exceeds_auto_download_limit",
+      `Slack attachment is ${contentLength} bytes; automatic download limit is ${params.maxBytes} bytes.`,
+    );
   }
 
-  const buffer = Buffer.from(arrayBuffer);
-  const hintedName =
-    params.file.name ??
-    basename(new URL(url).pathname) ??
-    `${params.file.id ?? "attachment"}${extensionForMimeType(params.file.mimetype)}`;
   const responseMimeType =
     response.headers.get("content-type")?.split(";")[0]?.trim() || undefined;
-  const fileMimeType = params.file.mimetype;
-  const preferredMimeType =
-    responseMimeType && !isGenericSlackMimeType(responseMimeType)
-      ? responseMimeType
-      : fileMimeType && !isGenericSlackMimeType(fileMimeType)
-        ? fileMimeType
-        : undefined;
-  const mimeType = resolveMimeType(hintedName, preferredMimeType);
-  const fileName =
-    extname(hintedName) || !mimeType
-      ? hintedName
-      : `${hintedName}${extensionForMimeType(mimeType)}`;
-  const localPath = await saveSlackAttachment({
+  const hintedName = resolveSlackAttachmentFileName({
+    file: params.file,
+    url,
+  });
+  const mimeType = resolveSlackAttachmentMimeType({
+    file: params.file,
+    fileName: hintedName,
+    responseMimeType,
+  });
+  const fileName = resolveSlackAttachmentFileName({
+    file: params.file,
+    url,
+    mimeType,
+  });
+  if (!response.body) {
+    throw new SlackAttachmentDownloadError(
+      "download_failed",
+      "Slack attachment response did not include a body.",
+    );
+  }
+  const saved = await saveSlackAttachmentStream({
     accountId: params.accountId,
     fileName,
-    buffer,
+    body: response.body,
+    maxBytes: params.maxBytes,
   });
 
   const kind = resolveAttachmentKind(mimeType);
@@ -455,9 +512,11 @@ async function downloadSlackAttachment(params: {
     id: params.file.id,
     name: fileName,
     mimeType,
-    sizeBytes: buffer.byteLength,
+    sizeBytes: saved.sizeBytes,
     kind,
-    localPath,
+    localPath: saved.localPath,
+    sourceMessageId: params.sourceMessageId,
+    ...(params.sourceThreadId ? { sourceThreadId: params.sourceThreadId } : {}),
   };
 
   // Slack voice memos arrive as ordinary audio files/file_share events, so the
@@ -467,7 +526,7 @@ async function downloadSlackAttachment(params: {
       "@/channels/transcription/index"
     );
     if (isTranscriptionConfigured()) {
-      const result = await transcribeAudioFile(localPath);
+      const result = await transcribeAudioFile(saved.localPath);
       if (result.success && result.text) {
         attachment.transcription = result.text;
       } else if (result.error) {
@@ -486,7 +545,7 @@ async function downloadSlackAttachment(params: {
   return attachment;
 }
 
-function collectSlackFiles(rawEvent: unknown): SlackFileLike[] {
+export function collectSlackFiles(rawEvent: unknown): SlackFileLike[] {
   const record = asRecord(rawEvent);
   if (!record) {
     return [];
@@ -537,6 +596,8 @@ async function resolveSlackFilesAsAttachments(params: {
   accountId: string;
   token: string;
   files: SlackFileLike[];
+  sourceMessageId?: string;
+  sourceThreadId?: string | null;
   transcribeVoice?: boolean;
 }): Promise<ChannelMessageAttachment[]> {
   if (params.files.length === 0) {
@@ -544,19 +605,33 @@ async function resolveSlackFilesAsAttachments(params: {
   }
 
   const resolved = await Promise.all(
-    params.files.map((file) =>
-      downloadSlackAttachment({
-        accountId: params.accountId,
-        token: params.token,
-        file,
-        transcribeVoice: params.transcribeVoice,
-      }).catch(() => null),
-    ),
+    params.files.map(async (file) => {
+      try {
+        return await materializeSlackAttachment({
+          accountId: params.accountId,
+          token: params.token,
+          file,
+          sourceMessageId: params.sourceMessageId,
+          sourceThreadId: params.sourceThreadId,
+          maxBytes: MAX_SLACK_ATTACHMENT_BYTES,
+          transcribeVoice: params.transcribeVoice,
+        });
+      } catch (error) {
+        const reason =
+          error instanceof SlackAttachmentDownloadError
+            ? error.reason
+            : "download_failed";
+        return createUndownloadedSlackAttachment({
+          file,
+          sourceMessageId: params.sourceMessageId,
+          sourceThreadId: params.sourceThreadId,
+          reason,
+        });
+      }
+    }),
   );
 
-  return resolved.filter((attachment): attachment is ChannelMessageAttachment =>
-    Boolean(attachment),
-  );
+  return resolved;
 }
 
 function resolveSlackThreadAttachmentOptions(
@@ -592,6 +667,7 @@ function hasHydratedSlackThreadMessageContent(
 async function resolveSlackMessageAttachments(
   message: SlackRepliesPageMessage,
   attachmentOptions?: SlackThreadAttachmentOptions,
+  sourceThreadId?: string,
 ): Promise<ChannelMessageAttachment[]> {
   if (!attachmentOptions) {
     return [];
@@ -601,6 +677,10 @@ async function resolveSlackMessageAttachments(
     accountId: attachmentOptions.accountId,
     token: attachmentOptions.token,
     files: collectSlackFiles(message),
+    sourceMessageId: message.ts,
+    sourceThreadId:
+      sourceThreadId ??
+      (isNonEmptyString(message.thread_ts) ? message.thread_ts : null),
     transcribeVoice: attachmentOptions.transcribeVoice,
   });
 }
@@ -611,10 +691,15 @@ export async function resolveSlackInboundAttachments(params: {
   rawEvent: unknown;
   transcribeVoice?: boolean;
 }): Promise<ChannelMessageAttachment[]> {
+  const rawEvent = asRecord(params.rawEvent);
   return resolveSlackFilesAsAttachments({
     accountId: params.accountId,
     token: params.token,
     files: collectSlackFiles(params.rawEvent),
+    sourceMessageId: isNonEmptyString(rawEvent?.ts) ? rawEvent.ts : undefined,
+    sourceThreadId: isNonEmptyString(rawEvent?.thread_ts)
+      ? rawEvent.thread_ts
+      : null,
     transcribeVoice: params.transcribeVoice,
   });
 }
@@ -624,7 +709,7 @@ export async function resolveSlackCurrentMessageAttachments(
     channelId: string;
     threadTs: string;
     messageTs: string;
-    client: SlackRepliesClient;
+    client: SlackAttachmentReadClient;
   } & SlackThreadAttachmentParams,
 ): Promise<ChannelMessageAttachment[]> {
   const attachmentOptions = resolveSlackThreadAttachmentOptions(params);
@@ -649,7 +734,11 @@ export async function resolveSlackCurrentMessageAttachments(
         (entry) => entry.ts === params.messageTs,
       );
       if (message) {
-        return resolveSlackMessageAttachments(message, attachmentOptions);
+        return resolveSlackMessageAttachments(
+          message,
+          attachmentOptions,
+          params.threadTs,
+        );
       }
 
       const nextCursor = response.response_metadata?.next_cursor;
@@ -675,7 +764,7 @@ export async function resolveSlackThreadStarter(
   params: {
     channelId: string;
     threadTs: string;
-    client: SlackRepliesClient;
+    client: SlackAttachmentReadClient;
   } & SlackThreadAttachmentParams,
 ): Promise<SlackThreadMessage | null> {
   try {
@@ -696,7 +785,11 @@ export async function resolveSlackThreadStarter(
       return null;
     }
 
-    const mapped = await mapSlackThreadMessage(message, attachmentOptions);
+    const mapped = await mapSlackThreadMessage(
+      message,
+      attachmentOptions,
+      params.threadTs,
+    );
     return hasHydratedSlackThreadMessageContent(mapped) ? mapped : null;
   } catch {
     return null;
@@ -707,7 +800,7 @@ export async function resolveSlackThreadHistory(
   params: {
     channelId: string;
     threadTs: string;
-    client: SlackRepliesClient;
+    client: SlackAttachmentReadClient;
     currentMessageTs?: string;
     limit?: number;
     include?: SlackThreadHistoryEntryKind;
@@ -762,7 +855,7 @@ export async function resolveSlackThreadHistory(
 
     const mapped = await Promise.all(
       retained.map((message) =>
-        mapSlackThreadMessage(message, attachmentOptions),
+        mapSlackThreadMessage(message, attachmentOptions, params.threadTs),
       ),
     );
     return mapped.filter(hasHydratedSlackThreadMessageContent);
@@ -775,7 +868,7 @@ export async function resolveSlackChannelHistory(
   params: {
     channelId: string;
     beforeTs: string;
-    client: SlackRepliesClient;
+    client: SlackAttachmentReadClient;
     limit?: number;
   } & SlackThreadAttachmentParams,
 ): Promise<SlackThreadMessage[]> {

--- a/src/channels/slack/message-actions.ts
+++ b/src/channels/slack/message-actions.ts
@@ -68,10 +68,50 @@ async function reactInSlack(ctx: ChannelMessageActionContext): Promise<string> {
     : `Reaction added on slack (message_id: ${result.messageId})`;
 }
 
+async function downloadSlackFile(
+  ctx: ChannelMessageActionContext,
+): Promise<string> {
+  const { request } = ctx;
+  if (!request.attachmentId?.trim()) {
+    return "Error: Slack download-file requires attachmentId.";
+  }
+  if (!request.messageId?.trim()) {
+    return "Error: Slack download-file requires messageId from the attachment's Slack context.";
+  }
+  if (typeof ctx.adapter.downloadAttachment !== "function") {
+    return "Error: Running Slack adapter does not support attachment downloads.";
+  }
+  const attachment = await ctx.adapter.downloadAttachment({
+    attachmentId: request.attachmentId,
+    chatId: request.chatId,
+    threadId: request.threadId ?? null,
+    messageId: request.messageId,
+  });
+  if (!attachment.localPath) {
+    return `Error: Slack attachment ${request.attachmentId} was not downloaded.`;
+  }
+
+  return `Slack attachment downloaded (local_path: ${attachment.localPath})`;
+}
+
 export const slackMessageActions: ChannelMessageActionAdapter = {
   describeMessageTool() {
     return {
-      actions: ["send", "react", "upload-file"],
+      actions: ["send", "react", "upload-file", "download-file"],
+      schema: {
+        properties: {
+          attachmentId: {
+            type: "string",
+            description:
+              "Slack attachment id for action='download-file'. Copy attachment_id from the channel notification.",
+          },
+          messageId: {
+            type: "string",
+            description:
+              "Target Slack message id for action='react', or the source message id containing attachmentId for action='download-file'.",
+          },
+        },
+      },
     };
   },
 
@@ -93,6 +133,8 @@ export const slackMessageActions: ChannelMessageActionAdapter = {
         return await sendSlackMessage(ctx);
       case "react":
         return await reactInSlack(ctx);
+      case "download-file":
+        return await downloadSlackFile(ctx);
       default:
         return `Error: Action "${ctx.request.action}" is not supported on slack.`;
     }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -98,7 +98,19 @@ export interface ChannelMessageAttachment {
   mimeType?: string;
   sizeBytes?: number;
   kind: "image" | "file" | "audio" | "video";
-  localPath: string;
+  /** Local file materialized for tool access. Absent when automatic download was skipped. */
+  localPath?: string;
+  /** Platform message that contains this attachment, used for scoped on-demand downloads. */
+  sourceMessageId?: string;
+  /** Platform thread that contains this attachment, when it is thread-scoped. */
+  sourceThreadId?: string | null;
+  /** Why an attachment discovered on the platform was not downloaded automatically. */
+  downloadReason?:
+    | "exceeds_auto_download_limit"
+    | "missing_download_url"
+    | "download_failed";
+  /** Automatic download threshold that rejected this attachment, when applicable. */
+  autoDownloadLimitBytes?: number;
   imageDataBase64?: string;
   /** Best-effort speech-to-text transcription (voice memos only). */
   transcription?: string;
@@ -270,6 +282,18 @@ export interface ChannelAdapter {
 
   /** Send a message through this channel. */
   sendMessage(msg: OutboundChannelMessage): Promise<{ messageId: string }>;
+
+  /**
+   * Optionally materialize a platform attachment into the channel's local
+   * inbound directory. MessageChannel plugins expose this only when the
+   * adapter can verify the attachment against its canonical source message.
+   */
+  downloadAttachment?(params: {
+    attachmentId: string;
+    chatId: string;
+    threadId?: string | null;
+    messageId: string;
+  }): Promise<ChannelMessageAttachment>;
 
   /**
    * Optionally stream an ephemeral rich-message draft while a final rich

--- a/src/channels/xml.test.ts
+++ b/src/channels/xml.test.ts
@@ -131,6 +131,76 @@ describe("formatChannelNotification", () => {
     expect(reminder).not.toContain("ReadFileGemini");
   });
 
+  test("gives oversized Slack attachments an exact MessageChannel download instruction", () => {
+    const msg: InboundChannelMessage = {
+      channel: "slack",
+      accountId: "design-bot",
+      chatId: "C123",
+      senderId: "U123",
+      text: "Here are the assets",
+      timestamp: Date.now(),
+      messageId: "1712800000.000100",
+      threadId: "1712790000.000050",
+      chatType: "channel",
+      attachments: [
+        {
+          id: "FLARGE",
+          name: "LandscapeTransmission.zip",
+          mimeType: "application/zip",
+          sizeBytes: 43_714_492,
+          kind: "file",
+          sourceMessageId: "1712800000.000100",
+          sourceThreadId: "1712790000.000050",
+          downloadReason: "exceeds_auto_download_limit",
+          autoDownloadLimitBytes: 20 * 1024 * 1024,
+        },
+      ],
+    };
+
+    const reminder = buildChannelReminderText(msg);
+    const xml = buildChannelNotificationXml(msg);
+
+    expect(reminder).toContain('action="download-file"');
+    expect(reminder).not.toContain("attachment local_path values");
+    expect(xml).toContain('download_status="not_downloaded"');
+    expect(xml).toContain('download_reason="exceeds_auto_download_limit"');
+    expect(xml).toContain('auto_download_limit_bytes="20971520"');
+    expect(xml).toContain('attachment_id="FLARGE"');
+    expect(xml).toContain('source_thread_id="1712790000.000050"');
+    expect(xml).toContain(
+      'MessageChannel with action="download-file", channel="slack", chat_id="C123", accountId="design-bot", threadId="1712790000.000050", attachmentId="FLARGE", and messageId="1712800000.000100"',
+    );
+    expect(xml).toContain(
+      "same Slack inbound attachment directory and returns its local_path",
+    );
+    expect(xml).toContain("Do not ask the sender to reattach it.");
+  });
+
+  test("describes non-size Slack download failures as retries rather than guarantees", () => {
+    const xml = buildChannelNotificationXml({
+      channel: "slack",
+      chatId: "C123",
+      senderId: "U123",
+      text: "See file",
+      timestamp: Date.now(),
+      messageId: "1712800000.000100",
+      attachments: [
+        {
+          id: "FMISSING",
+          name: "missing.zip",
+          kind: "file",
+          sourceMessageId: "1712800000.000100",
+          downloadReason: "missing_download_url",
+        },
+      ],
+    });
+
+    expect(xml).toContain("<download-retry>");
+    expect(xml).toContain("to retry");
+    expect(xml).toContain("may return a precise error");
+    expect(xml).not.toContain("The tool downloads the file");
+  });
+
   test("adds Slack thread guidance for channel notifications", () => {
     const msg: InboundChannelMessage = {
       channel: "slack",

--- a/src/channels/xml.test.ts
+++ b/src/channels/xml.test.ts
@@ -174,6 +174,9 @@ describe("formatChannelNotification", () => {
       "same Slack inbound attachment directory and returns its local_path",
     );
     expect(xml).toContain("Do not ask the sender to reattach it.");
+    expect(xml).toContain(
+      "<download-instruction>This file is 41.7 MiB, above the 20 MiB automatic download limit. Call MessageChannel",
+    );
   });
 
   test("describes non-size Slack download failures as retries rather than guarantees", () => {

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -33,14 +33,20 @@ function escapeXmlAttribute(text: string): string {
 }
 
 function hasNotificationAttachmentPaths(msg: InboundChannelMessage): boolean {
-  if (msg.attachments?.length) {
+  if (msg.attachments?.some((attachment) => attachment.localPath)) {
     return true;
   }
-  if (msg.threadContext?.starter?.attachments?.length) {
+  if (
+    msg.threadContext?.starter?.attachments?.some(
+      (attachment) => attachment.localPath,
+    )
+  ) {
     return true;
   }
   return Boolean(
-    msg.threadContext?.history?.some((entry) => entry.attachments?.length),
+    msg.threadContext?.history?.some((entry) =>
+      entry.attachments?.some((attachment) => attachment.localPath),
+    ),
   );
 }
 
@@ -78,7 +84,7 @@ export function buildChannelReminderText(msg: InboundChannelMessage): string {
     lines.splice(
       lines.length - 2,
       0,
-      'On Slack, MessageChannel also supports action="react" with emoji + messageId, and action="upload-file" with media.',
+      'On Slack, MessageChannel also supports action="react" with emoji + messageId, action="upload-file" with media, and action="download-file" with attachmentId + messageId.',
       'For Slack requests that require nontrivial work or several tool calls, send a short MessageChannel action="send" acknowledgement before starting other tools. This gives the Slack user verbal acknowledgement and a View in web link. Do not do this for no-ops, reaction-only responses, or simple no-tool answers.',
     );
   }
@@ -121,11 +127,24 @@ export function buildChannelReminderText(msg: InboundChannelMessage): string {
   return lines.join("\n");
 }
 
-function buildAttachmentXml(attachment: ChannelMessageAttachment): string {
-  const attrs = [
-    `kind="${escapeXmlAttribute(attachment.kind)}"`,
-    `local_path="${escapeXmlAttribute(attachment.localPath)}"`,
-  ];
+type AttachmentXmlContext = {
+  channel: string;
+  accountId?: string;
+  chatId: string;
+  messageId?: string;
+};
+
+function buildAttachmentXml(
+  attachment: ChannelMessageAttachment,
+  context: AttachmentXmlContext,
+): string {
+  const attrs = [`kind="${escapeXmlAttribute(attachment.kind)}"`];
+
+  if (attachment.localPath) {
+    attrs.push(`local_path="${escapeXmlAttribute(attachment.localPath)}"`);
+  } else {
+    attrs.push('download_status="not_downloaded"');
+  }
 
   if (attachment.id) {
     attrs.push(`attachment_id="${escapeXmlAttribute(attachment.id)}"`);
@@ -139,6 +158,25 @@ function buildAttachmentXml(attachment: ChannelMessageAttachment): string {
   if (typeof attachment.sizeBytes === "number") {
     attrs.push(`size_bytes="${attachment.sizeBytes}"`);
   }
+  const sourceMessageId = attachment.sourceMessageId ?? context.messageId;
+  if (!attachment.localPath && sourceMessageId) {
+    attrs.push(`source_message_id="${escapeXmlAttribute(sourceMessageId)}"`);
+  }
+  if (!attachment.localPath && attachment.sourceThreadId) {
+    attrs.push(
+      `source_thread_id="${escapeXmlAttribute(attachment.sourceThreadId)}"`,
+    );
+  }
+  if (attachment.downloadReason) {
+    attrs.push(
+      `download_reason="${escapeXmlAttribute(attachment.downloadReason)}"`,
+    );
+  }
+  if (typeof attachment.autoDownloadLimitBytes === "number") {
+    attrs.push(
+      `auto_download_limit_bytes="${attachment.autoDownloadLimitBytes}"`,
+    );
+  }
 
   const children: string[] = [];
   if (attachment.transcription) {
@@ -150,6 +188,29 @@ function buildAttachmentXml(attachment: ChannelMessageAttachment): string {
     children.push(
       `<attempted_transcription_error>${escapeXmlText(attachment.transcriptionError)}</attempted_transcription_error>`,
     );
+  }
+  if (
+    !attachment.localPath &&
+    context.channel === "slack" &&
+    attachment.id &&
+    sourceMessageId
+  ) {
+    const accountArg = context.accountId
+      ? `, accountId="${escapeXmlAttribute(context.accountId)}"`
+      : "";
+    const threadArg = attachment.sourceThreadId
+      ? `, threadId="${escapeXmlAttribute(attachment.sourceThreadId)}"`
+      : "";
+    const action = `MessageChannel with action="download-file", channel="slack", chat_id="${escapeXmlAttribute(context.chatId)}"${accountArg}${threadArg}, attachmentId="${escapeXmlAttribute(attachment.id)}", and messageId="${escapeXmlAttribute(sourceMessageId)}"`;
+    if (attachment.downloadReason === "exceeds_auto_download_limit") {
+      children.push(
+        `<download-instruction>Call ${action}. The tool downloads the file into the same Slack inbound attachment directory and returns its local_path. Do not ask the sender to reattach it.</download-instruction>`,
+      );
+    } else {
+      children.push(
+        `<download-retry>Automatic download did not complete. Call ${action} to retry. The action may return a precise error if Slack still cannot provide the file.</download-retry>`,
+      );
+    }
   }
 
   if (children.length > 0) {
@@ -215,6 +276,7 @@ function buildReplyContextXml(msg: InboundChannelMessage): string | null {
 function buildThreadContextEntryXml(
   tagName: string,
   entry: ChannelThreadContextEntry,
+  context: Omit<AttachmentXmlContext, "messageId">,
 ): string {
   const attrs: string[] = [];
   if (entry.senderId) {
@@ -230,7 +292,12 @@ function buildThreadContextEntryXml(
   const attrString = attrs.length > 0 ? ` ${attrs.join(" ")}` : "";
   const body = [
     ...(entry.text ? [escapeXmlText(entry.text)] : []),
-    ...(entry.attachments ?? []).map(buildAttachmentXml),
+    ...(entry.attachments ?? []).map((attachment) =>
+      buildAttachmentXml(attachment, {
+        ...context,
+        messageId: entry.messageId,
+      }),
+    ),
   ].join("\n");
   return `<${tagName}${attrString}>\n${body}\n</${tagName}>`;
 }
@@ -244,7 +311,11 @@ function buildThreadContextXml(msg: InboundChannelMessage): string | null {
   const parts: string[] = [];
   if (threadContext.starter) {
     parts.push(
-      buildThreadContextEntryXml("thread-starter", threadContext.starter),
+      buildThreadContextEntryXml("thread-starter", threadContext.starter, {
+        channel: msg.channel,
+        accountId: msg.accountId,
+        chatId: msg.chatId,
+      }),
     );
   }
   const historyEntries = threadContext.history ?? [];
@@ -253,7 +324,11 @@ function buildThreadContextXml(msg: InboundChannelMessage): string | null {
       [
         "<thread-history>",
         ...historyEntries.map((entry) =>
-          buildThreadContextEntryXml("thread-message", entry),
+          buildThreadContextEntryXml("thread-message", entry, {
+            channel: msg.channel,
+            accountId: msg.accountId,
+            chatId: msg.chatId,
+          }),
         ),
         "</thread-history>",
       ].join("\n"),
@@ -310,7 +385,14 @@ export function buildChannelNotificationXml(
   const reactionXml = buildReactionXml(msg);
   const replyContextXml = buildReplyContextXml(msg);
   const threadContextXml = buildThreadContextXml(msg);
-  const attachmentXml = (msg.attachments ?? []).map(buildAttachmentXml);
+  const attachmentXml = (msg.attachments ?? []).map((attachment) =>
+    buildAttachmentXml(attachment, {
+      channel: msg.channel,
+      accountId: msg.accountId,
+      chatId: msg.chatId,
+      messageId: msg.messageId,
+    }),
+  );
   const body = [
     threadContextXml,
     replyContextXml,

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -32,6 +32,13 @@ function escapeXmlAttribute(text: string): string {
   return escapeXmlText(text).replace(/"/g, "&quot;").replace(/'/g, "&apos;");
 }
 
+function formatMebibytes(bytes: number): string {
+  const mebibytes = bytes / (1024 * 1024);
+  const rounded =
+    mebibytes >= 100 ? Math.round(mebibytes).toString() : mebibytes.toFixed(1);
+  return `${rounded.replace(/\.0$/, "")} MiB`;
+}
+
 function hasNotificationAttachmentPaths(msg: InboundChannelMessage): boolean {
   if (msg.attachments?.some((attachment) => attachment.localPath)) {
     return true;
@@ -203,8 +210,16 @@ function buildAttachmentXml(
       : "";
     const action = `MessageChannel with action="download-file", channel="slack", chat_id="${escapeXmlAttribute(context.chatId)}"${accountArg}${threadArg}, attachmentId="${escapeXmlAttribute(attachment.id)}", and messageId="${escapeXmlAttribute(sourceMessageId)}"`;
     if (attachment.downloadReason === "exceeds_auto_download_limit") {
+      const sizeNote =
+        typeof attachment.sizeBytes === "number"
+          ? `This file is ${formatMebibytes(attachment.sizeBytes)}${
+              typeof attachment.autoDownloadLimitBytes === "number"
+                ? `, above the ${formatMebibytes(attachment.autoDownloadLimitBytes)} automatic download limit`
+                : ""
+            }. `
+          : "";
       children.push(
-        `<download-instruction>Call ${action}. The tool downloads the file into the same Slack inbound attachment directory and returns its local_path. Do not ask the sender to reattach it.</download-instruction>`,
+        `<download-instruction>${sizeNote}Call ${action}. The tool downloads the file into the same Slack inbound attachment directory and returns its local_path. Do not ask the sender to reattach it.</download-instruction>`,
       );
     } else {
       children.push(

--- a/src/tools/impl/message-channel-types.ts
+++ b/src/tools/impl/message-channel-types.ts
@@ -1,0 +1,42 @@
+import type { ChannelMessageActionName } from "@/channels/plugin-types";
+import type { ChannelTurnSource, SupportedChannelId } from "@/channels/types";
+
+export interface MessageChannelArgs {
+  channel: string;
+  action: string;
+  chat_id?: string;
+  target?: string;
+  accountId?: string;
+  message?: string;
+  replyTo?: string;
+  threadId?: string;
+  messageId?: string;
+  attachmentId?: string;
+  emoji?: string;
+  remove?: boolean;
+  media?: string;
+  filename?: string;
+  title?: string;
+  /** Injected by executeTool() — NOT read from global context. */
+  parentScope?: { agentId: string; conversationId: string };
+  /** Injected by executeTool() for channel-originated turns. */
+  channelTurnSources?: ChannelTurnSource[];
+}
+
+export interface NormalizedMessageChannelInput {
+  channel: SupportedChannelId;
+  action: ChannelMessageActionName;
+  chatId?: string;
+  target?: string;
+  accountId?: string;
+  message?: string;
+  replyToMessageId?: string;
+  threadId?: string | null;
+  messageId?: string;
+  attachmentId?: string;
+  emoji?: string;
+  remove?: boolean;
+  mediaPath?: string;
+  filename?: string;
+  title?: string;
+}

--- a/src/tools/impl/message-channel.ts
+++ b/src/tools/impl/message-channel.ts
@@ -27,6 +27,10 @@ import type {
   OutboundChannelMessage,
   SupportedChannelId,
 } from "@/channels/types";
+import type {
+  MessageChannelArgs,
+  NormalizedMessageChannelInput,
+} from "./message-channel-types";
 
 const TELEGRAM_CHANNEL_ID = "telegram";
 const SIGNAL_CHANNEL_ID = "signal";
@@ -795,44 +799,6 @@ export function formatOutboundChannelMessage(
   return formatter(normalizedText);
 }
 
-interface MessageChannelArgs {
-  channel: string;
-  action: string;
-  chat_id?: string;
-  target?: string;
-  accountId?: string;
-  message?: string;
-  replyTo?: string;
-  threadId?: string;
-  messageId?: string;
-  emoji?: string;
-  remove?: boolean;
-  media?: string;
-  filename?: string;
-  title?: string;
-  /** Injected by executeTool() — NOT read from global context. */
-  parentScope?: { agentId: string; conversationId: string };
-  /** Injected by executeTool() for channel-originated turns. */
-  channelTurnSources?: ChannelTurnSource[];
-}
-
-interface NormalizedMessageChannelInput {
-  channel: SupportedChannelId;
-  action: ChannelMessageActionName;
-  chatId?: string;
-  target?: string;
-  accountId?: string;
-  message?: string;
-  replyToMessageId?: string;
-  threadId?: string | null;
-  messageId?: string;
-  emoji?: string;
-  remove?: boolean;
-  mediaPath?: string;
-  filename?: string;
-  title?: string;
-}
-
 interface ResolvedMessageChannelExecutionContext {
   request: ChannelMessageActionRequest;
   route: ChannelRoute;
@@ -933,6 +899,7 @@ function normalizeMessageChannelInput(
     replyToMessageId: firstNonEmptyString(args.replyTo),
     threadId: firstNonEmptyString(args.threadId) ?? null,
     messageId: firstNonEmptyString(args.messageId),
+    attachmentId: firstNonEmptyString(args.attachmentId),
     emoji: firstNonEmptyString(args.emoji),
     remove: firstDefinedBoolean(args.remove),
     mediaPath: firstNonEmptyString(args.media),
@@ -954,6 +921,7 @@ function buildMessageChannelRequest(
     replyToMessageId: input.replyToMessageId,
     threadId: threadId ?? input.threadId ?? null,
     messageId: input.messageId,
+    attachmentId: input.attachmentId,
     emoji: input.emoji,
     remove: input.remove,
     mediaPath: input.mediaPath,
@@ -1118,6 +1086,13 @@ export async function message_channel(
   if (typeof input === "string") {
     return input;
   }
+  if (
+    input.channel === "slack" &&
+    input.action === "download-file" &&
+    input.target
+  ) {
+    return "Error: Slack download-file requires chat_id from a routed channel context; target is not supported.";
+  }
 
   try {
     let executionContext: ResolvedMessageChannelExecutionContext | string;
@@ -1158,11 +1133,15 @@ export async function message_channel(
         accountId: resolvedAccountId,
         channelTurnSources: args.channelTurnSources,
       });
+      const requestThreadId =
+        input.action === "download-file"
+          ? input.threadId
+          : (inferredThreadId ?? route.threadId ?? input.threadId);
       executionContext = {
         request: buildMessageChannelRequest(
           input,
           input.chatId,
-          inferredThreadId ?? route.threadId ?? input.threadId,
+          requestThreadId,
         ),
         route,
         adapter,

--- a/src/tools/tool-execution-context.test.ts
+++ b/src/tools/tool-execution-context.test.ts
@@ -1095,7 +1095,7 @@ describe("tool execution context snapshot", () => {
       >
     ).action;
 
-    expect(actionParameter?.enum).toEqual(["send", "react", "upload-file"]);
+    expect(actionParameter?.enum).toContain("download-file");
   });
 
   test("captures scoped working directories per execution context", async () => {


### PR DESCRIPTION
## Summary

- preserve oversized Slack attachment metadata instead of silently dropping files above the 20 MiB automatic-download threshold
- include an exact MessageChannel download-file instruction in channel context, scoped to the routed chat, source message, and source thread
- stream explicit downloads into the existing Slack inbound directory without the automatic size threshold, while cleaning partial files on failure
- reject proactive-target downloads and verify each file against its canonical Slack message before materializing it
- cover direct events, exact thread hydration, channel-history lookup, action discovery, scope boundaries, and stream cleanup

LET-9638

👾 Generated with [Letta Code](https://letta.com)