### PR TITLE
chore: add channels code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,9 @@
 # WebSocket listener and protocol code
 /src/websocket/ @cpacker @4shub @kl2806 @carenthomas @christinatong01 @jnjpng
 
+# Channel integrations and shared channel runtime
+/src/channels/ @cpacker @just-cameron
+
 # Headless mode runtime
 /src/headless.ts @cpacker @4shub @kl2806 @devanshrj @sarahwooders @jnjpng @carenthomas
 


### PR DESCRIPTION
## Summary

- Add `@just-cameron` and `@cpacker` as co-owners for `src/channels/`.
- Route channel reviews to maintainers with substantial subsystem history.
- Keep adjacent CLI, WebSocket listener, backend, and tool surfaces under their existing ownership rules; this does not include either `listen.ts` entrypoint.

## Why

Cameron has 23 authored commits on `main` under `src/channels/`, spanning Telegram, Discord, WhatsApp, shared commands, routing, interaction, and message delivery. Adding explicit co-ownership improves review routing without creating a sole-owner bottleneck.

This changes review ownership only. It does not bypass the repository requirement for peer approval on author-owned PRs.

## Validation

- [x] `git diff --check`
- [x] Verified both GitHub owner handles resolve
- [x] Pre-commit checks, including TypeScript, passed
- [x] Confirmed the diff only changes `.github/CODEOWNERS`

👾 Generated with [Letta Code](https://letta.com)