### PR TITLE
fix(cron): include authoritative time in scheduled prompts [LET-9650]

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -5,7 +5,7 @@
   "src/backend/local/local-backend.ts": 1058,
   "src/backend/local/local-store.ts": 3618,
   "src/backend/pi-stream-adapter.test.ts": 1442,
-  "src/cli/app/AppCoordinator.tsx": 5198,
+  "src/cli/app/AppCoordinator.tsx": 5196,
   "src/cli/app/AppView.tsx": 1750,
   "src/cli/app/use-approval-flow.ts": 1163,
   "src/cli/app/use-configuration-handlers.ts": 1383,

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -141,6 +141,7 @@ import {
   useLocalModAdapter,
 } from "@/cli/mods/use-local-mod-adapter";
 import {
+  getIntendedCronOccurrence,
   getTask,
   handleMissedOneShot,
   isProcessAlive,
@@ -148,6 +149,7 @@ import {
   safeAppendCronRunLogForTask,
   shouldFireTask,
   updateTask,
+  wrapCronPrompt,
 } from "@/cron";
 import { experimentManager } from "@/experiments/manager";
 import { runSessionEndHooks, runSessionStartHooks } from "@/hooks";
@@ -1540,6 +1542,7 @@ export function App({
 
         if (shouldFireTask(task, now)) {
           firedThisMinute.add(task.id);
+          const intendedOccurrence = getIntendedCronOccurrence(task, now);
 
           // Apply jitter delay for recurring tasks (same as WS scheduler)
           const jitterMs = task.recurring ? task.jitter_offset_ms : 0;
@@ -1549,17 +1552,12 @@ export function App({
             const freshTask = getTask(taskId);
             if (!freshTask || freshTask.status !== "active") return;
 
-            // Format as plain text for the TUI — no <system-reminder> wrapper
-            // (the WS scheduler uses wrapCronPrompt with XML, but the TUI
-            // renders user messages as-is, so XML shows up raw)
-            const text = [
-              `Scheduled task "${freshTask.name}" is firing.`,
-              freshTask.recurring
-                ? `This is fire #${freshTask.fire_count + 1} (cron: ${freshTask.cron}).`
-                : `This is a one-off scheduled task.`,
-              "",
-              freshTask.prompt,
-            ].join("\n");
+            const schedulerNow = new Date();
+            // Use the same user-visible prompt formatter as the WS scheduler.
+            const text = wrapCronPrompt(freshTask, {
+              intendedOccurrence,
+              schedulerNow,
+            });
             addToMessageQueue({
               kind: "user",
               text,
@@ -1568,7 +1566,7 @@ export function App({
             });
 
             // Update task state
-            const nowIso = new Date().toISOString();
+            const nowIso = schedulerNow.toISOString();
             if (freshTask.recurring) {
               updateTask(freshTask.id, (t) => {
                 t.last_fired_at = nowIso;
@@ -1585,7 +1583,7 @@ export function App({
 
             safeAppendCronRunLogForTask(freshTask, {
               status: "ok",
-              runAtMs: now.getTime(),
+              runAtMs: schedulerNow.getTime(),
               scheduledFor: freshTask.scheduled_for,
               firedAt: nowIso,
             });

--- a/src/cron/index.ts
+++ b/src/cron/index.ts
@@ -49,6 +49,10 @@ export {
   safeAppendCronRunLogForTask,
 } from "./run-log";
 export {
+  type CronPromptTiming,
+  formatCronPrompt,
+  formatTimezoneQualifiedIso,
+  getIntendedCronOccurrence,
   handleMissedOneShot,
   shouldFireTask,
   wrapCronPrompt,

--- a/src/cron/prompt.ts
+++ b/src/cron/prompt.ts
@@ -1,0 +1,165 @@
+import type { CronTask } from "./cron-file";
+
+export interface CronPromptTiming {
+  /** The schedule occurrence that caused this turn to fire. */
+  intendedOccurrence: Date;
+  /** Authoritative time captured by the scheduler when the turn is enqueued. */
+  schedulerNow: Date;
+}
+
+interface ZonedDateTimeParts {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+}
+
+function pad(value: number, width: number): string {
+  return String(value).padStart(width, "0");
+}
+
+function formatOffset(minutes: number): string {
+  const sign = minutes >= 0 ? "+" : "-";
+  const abs = Math.abs(minutes);
+  return `${sign}${pad(Math.floor(abs / 60), 2)}:${pad(abs % 60, 2)}`;
+}
+
+function getLocalDateTimeParts(date: Date): ZonedDateTimeParts {
+  return {
+    year: date.getFullYear(),
+    month: date.getMonth() + 1,
+    day: date.getDate(),
+    hour: date.getHours(),
+    minute: date.getMinutes(),
+    second: date.getSeconds(),
+  };
+}
+
+function isValidTimezone(timezone: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getSystemTimezone(): string | null {
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  if (!timezone || !isValidTimezone(timezone)) {
+    return null;
+  }
+  return timezone;
+}
+
+function getEffectiveTimezone(timezone: string): string | null {
+  const trimmed = timezone.trim();
+  if (trimmed && isValidTimezone(trimmed)) {
+    return trimmed;
+  }
+  return getSystemTimezone();
+}
+
+function formatTimezoneDisplay(timezone: string): string {
+  const trimmed = timezone.trim();
+  if (!trimmed) {
+    return "local time";
+  }
+  if (isValidTimezone(trimmed)) {
+    return trimmed;
+  }
+  return `${trimmed} (invalid; using local time)`;
+}
+
+function getZonedDateTimeParts(
+  date: Date,
+  timezone: string,
+): ZonedDateTimeParts {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    calendar: "iso8601",
+    numberingSystem: "latn",
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+  const parts = new Map(
+    formatter.formatToParts(date).map((part) => [part.type, part.value]),
+  );
+
+  return {
+    year: Number.parseInt(parts.get("year") ?? "0", 10),
+    month: Number.parseInt(parts.get("month") ?? "1", 10),
+    day: Number.parseInt(parts.get("day") ?? "1", 10),
+    hour: Number.parseInt(parts.get("hour") ?? "0", 10),
+    minute: Number.parseInt(parts.get("minute") ?? "0", 10),
+    second: Number.parseInt(parts.get("second") ?? "0", 10),
+  };
+}
+
+export function formatTimezoneQualifiedIso(
+  date: Date,
+  timezone: string,
+): string {
+  const effectiveTimezone = getEffectiveTimezone(timezone);
+  const parts = effectiveTimezone
+    ? getZonedDateTimeParts(date, effectiveTimezone)
+    : getLocalDateTimeParts(date);
+  const millis = date.getMilliseconds();
+  const zonedAsUtcMs = Date.UTC(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    parts.hour,
+    parts.minute,
+    parts.second,
+    millis,
+  );
+  const offsetMinutes = Math.round((zonedAsUtcMs - date.getTime()) / 60_000);
+
+  return `${pad(parts.year, 4)}-${pad(parts.month, 2)}-${pad(parts.day, 2)}T${pad(parts.hour, 2)}:${pad(parts.minute, 2)}:${pad(parts.second, 2)}.${pad(millis, 3)}${formatOffset(offsetMinutes)}[${effectiveTimezone ?? "local"}]`;
+}
+
+export function getIntendedCronOccurrence(
+  task: Pick<CronTask, "recurring" | "scheduled_for">,
+  matchedAt: Date,
+): Date {
+  if (!task.recurring && task.scheduled_for) {
+    const scheduledFor = new Date(task.scheduled_for);
+    if (Number.isFinite(scheduledFor.getTime())) {
+      return scheduledFor;
+    }
+  }
+
+  const occurrence = new Date(matchedAt);
+  occurrence.setSeconds(0, 0);
+  return occurrence;
+}
+
+export function formatCronPrompt(
+  task: CronTask,
+  timing: CronPromptTiming,
+): string {
+  const timezone = typeof task.timezone === "string" ? task.timezone : "";
+  const lines = [
+    `Scheduled task "${task.name}" is firing.`,
+    `Description: ${task.description}`,
+    `Timezone: ${formatTimezoneDisplay(timezone)}`,
+    `Scheduled for: ${formatTimezoneQualifiedIso(timing.intendedOccurrence, timezone)}`,
+    `Current time: ${formatTimezoneQualifiedIso(timing.schedulerNow, timezone)}`,
+    task.recurring
+      ? `This is fire #${task.fire_count + 1} (cron: ${task.cron}).`
+      : "This is a one-off scheduled task.",
+    "",
+    "You are running autonomously: no user is watching this turn and questions will not be answered. Deliver results through your available channels or record them in memory, and work until the task is done or genuinely blocked.",
+    "",
+    `Prompt: ${task.prompt}`,
+  ];
+  return lines.join("\n");
+}

--- a/src/cron/scheduler.test.ts
+++ b/src/cron/scheduler.test.ts
@@ -10,7 +10,12 @@ import {
 } from "@/cron/cron-file";
 import { cronMatchesTime } from "@/cron/parse-interval";
 import { getCronRunLogPath, readCronRunLogEntries } from "@/cron/run-log";
-import { handleMissedOneShot, wrapCronPrompt } from "@/cron/scheduler";
+import {
+  formatCronPrompt,
+  getIntendedCronOccurrence,
+  handleMissedOneShot,
+  wrapCronPrompt,
+} from "@/cron/scheduler";
 
 // ── Test setup ──────────────────────────────────────────────────────
 
@@ -46,6 +51,28 @@ function makeInput(overrides: Partial<AddTaskInput> = {}): AddTaskInput {
     recurring: true,
     ...overrides,
   };
+}
+
+function pad(value: number, width: number): string {
+  return String(value).padStart(width, "0");
+}
+
+function expectedLocalTimezoneSuffix(): string {
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  if (!timezone) return "local";
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone });
+    return timezone;
+  } catch {
+    return "local";
+  }
+}
+
+function formatExpectedLocalIso(date: Date): string {
+  const offsetMinutes = -date.getTimezoneOffset();
+  const sign = offsetMinutes >= 0 ? "+" : "-";
+  const absOffset = Math.abs(offsetMinutes);
+  return `${pad(date.getFullYear(), 4)}-${pad(date.getMonth() + 1, 2)}-${pad(date.getDate(), 2)}T${pad(date.getHours(), 2)}:${pad(date.getMinutes(), 2)}:${pad(date.getSeconds(), 2)}.${pad(date.getMilliseconds(), 3)}${sign}${pad(Math.floor(absOffset / 60), 2)}:${pad(absOffset % 60, 2)}[${expectedLocalTimezoneSuffix()}]`;
 }
 
 // ── shouldFireTask logic tests ──────────────────────────────────────
@@ -128,21 +155,100 @@ describe("per-minute deduplication", () => {
 // ── Task lifecycle tests ────────────────────────────────────────────
 
 describe("task lifecycle", () => {
-  test("cron prompt is visible user message text", () => {
-    const { task } = addTask(makeInput());
+  test("delayed recurring prompt keeps Scheduled for at matched minute and Current time later", () => {
+    const { task } = addTask(
+      makeInput({ cron: "5 0 * * *", timezone: "America/St_Johns" }),
+    );
+    const taskAtFire = { ...task, fire_count: 7 };
+    const intendedOccurrence = getIntendedCronOccurrence(
+      taskAtFire,
+      new Date("2026-06-01T02:35:17.999Z"),
+    );
+    const schedulerNow = new Date("2026-06-01T02:35:42.123Z");
 
-    expect(wrapCronPrompt(task)).toBe(
+    expect(
+      wrapCronPrompt(taskAtFire, { intendedOccurrence, schedulerNow }),
+    ).toBe(
       [
         'Scheduled task "Test task" is firing.',
         "Description: A test cron task",
-        "This is fire #1 (cron: */5 * * * *).",
+        "Timezone: America/St_Johns",
+        "Scheduled for: 2026-06-01T00:05:00.000-02:30[America/St_Johns]",
+        "Current time: 2026-06-01T00:05:42.123-02:30[America/St_Johns]",
+        "This is fire #8 (cron: 5 0 * * *).",
         "",
         "You are running autonomously: no user is watching this turn and questions will not be answered. Deliver results through your available channels or record them in memory, and work until the task is done or genuinely blocked.",
         "",
         "Prompt: echo hello",
       ].join("\n"),
     );
-    expect(wrapCronPrompt(task)).not.toContain("<system-reminder>");
+    expect(
+      wrapCronPrompt(taskAtFire, { intendedOccurrence, schedulerNow }),
+    ).not.toContain("<system-reminder>");
+  });
+
+  test("cron prompt includes intended one-shot occurrence near local midnight", () => {
+    const scheduledFor = new Date("2026-01-01T18:20:30.456Z");
+    const { task } = addTask(
+      makeInput({
+        recurring: false,
+        scheduled_for: scheduledFor,
+        timezone: "Asia/Kathmandu",
+      }),
+    );
+    const schedulerNow = new Date("2026-01-01T18:19:45.000Z");
+    const intendedOccurrence = getIntendedCronOccurrence(task, schedulerNow);
+
+    expect(wrapCronPrompt(task, { intendedOccurrence, schedulerNow })).toBe(
+      [
+        'Scheduled task "Test task" is firing.',
+        "Description: A test cron task",
+        "Timezone: Asia/Kathmandu",
+        "Scheduled for: 2026-01-02T00:05:30.456+05:45[Asia/Kathmandu]",
+        "Current time: 2026-01-02T00:04:45.000+05:45[Asia/Kathmandu]",
+        "This is a one-off scheduled task.",
+        "",
+        "You are running autonomously: no user is watching this turn and questions will not be answered. Deliver results through your available channels or record them in memory, and work until the task is done or genuinely blocked.",
+        "",
+        "Prompt: echo hello",
+      ].join("\n"),
+    );
+  });
+
+  test("cron prompt falls back to local time for legacy invalid timezones", () => {
+    const { task } = addTask(
+      makeInput({ cron: "5 0 * * *", timezone: "Not/A_Zone" }),
+    );
+    const matchedAt = new Date("2026-06-01T02:35:17.999Z");
+    const schedulerNow = new Date("2026-06-01T02:35:42.123Z");
+    const intendedOccurrence = getIntendedCronOccurrence(task, matchedAt);
+
+    const prompt = wrapCronPrompt(task, { intendedOccurrence, schedulerNow });
+
+    expect(prompt).toContain(
+      "Timezone: Not/A_Zone (invalid; using local time)",
+    );
+    expect(prompt).toContain(
+      `Scheduled for: ${formatExpectedLocalIso(intendedOccurrence)}`,
+    );
+    expect(prompt).toContain(
+      `Current time: ${formatExpectedLocalIso(schedulerNow)}`,
+    );
+  });
+
+  test("WS wrapper and TUI shared formatter produce identical prompt text", () => {
+    const { task } = addTask(
+      makeInput({ cron: "30 23 * * *", timezone: "Europe/Paris" }),
+    );
+    const timing = {
+      intendedOccurrence: getIntendedCronOccurrence(
+        task,
+        new Date("2026-03-27T22:30:59.999Z"),
+      ),
+      schedulerNow: new Date("2026-03-27T22:31:08.250Z"),
+    };
+
+    expect(formatCronPrompt(task, timing)).toBe(wrapCronPrompt(task, timing));
   });
 
   test("new recurring task starts with fire_count 0", () => {

--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -43,7 +43,19 @@ import {
   verifySchedulerLease,
 } from "./cron-file";
 import { cronMatchesTime } from "./parse-interval";
+import {
+  type CronPromptTiming,
+  formatCronPrompt,
+  getIntendedCronOccurrence,
+} from "./prompt";
 import { safeAppendCronRunLogForTask } from "./run-log";
+
+export {
+  type CronPromptTiming,
+  formatCronPrompt,
+  formatTimezoneQualifiedIso,
+  getIntendedCronOccurrence,
+} from "./prompt";
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -99,19 +111,11 @@ export function minuteKey(date: Date): string {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}T${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
 }
 
-export function wrapCronPrompt(task: CronTask): string {
-  const lines = [
-    `Scheduled task "${task.name}" is firing.`,
-    `Description: ${task.description}`,
-    task.recurring
-      ? `This is fire #${task.fire_count + 1} (cron: ${task.cron}).`
-      : `This is a one-off scheduled task.`,
-    "",
-    "You are running autonomously: no user is watching this turn and questions will not be answered. Deliver results through your available channels or record them in memory, and work until the task is done or genuinely blocked.",
-    "",
-    `Prompt: ${task.prompt}`,
-  ];
-  return lines.join("\n");
+export function wrapCronPrompt(
+  task: CronTask,
+  timing: CronPromptTiming,
+): string {
+  return formatCronPrompt(task, timing);
 }
 
 function getCronConversationSummary(task: CronTask): string {
@@ -214,7 +218,7 @@ export function shouldFireTask(task: CronTask, now: Date): boolean {
 
 async function fireCronTask(
   task: CronTask,
-  now: Date,
+  timing: CronPromptTiming,
   socket: ListenerTransport,
   opts: StartListenerOptions,
   processQueuedTurn: ProcessQueuedTurn,
@@ -224,7 +228,7 @@ async function fireCronTask(
     setLastRunOutcome(task.id, {
       outcome: "failed",
       reason: "runtime_unavailable",
-      runAt: now,
+      runAt: timing.schedulerNow,
       error: "No active runtime",
     });
     safeAppendCronRunLogForTask(task, {
@@ -232,7 +236,7 @@ async function fireCronTask(
       outcome: "failed",
       reason: "runtime_unavailable",
       error: "No active runtime",
-      runAtMs: now.getTime(),
+      runAtMs: timing.schedulerNow.getTime(),
       scheduledFor: task.scheduled_for,
     });
     return false;
@@ -246,7 +250,7 @@ async function fireCronTask(
       status: "error",
       error:
         err instanceof Error ? err.message : "failed to resolve conversation",
-      runAtMs: now.getTime(),
+      runAtMs: timing.schedulerNow.getTime(),
       scheduledFor: task.scheduled_for,
     });
     return false;
@@ -262,7 +266,7 @@ async function fireCronTask(
     setLastRunOutcome(task.id, {
       outcome: "failed",
       reason: "runtime_unavailable",
-      runAt: now,
+      runAt: timing.schedulerNow,
       error: "Conversation runtime unavailable",
     });
     safeAppendCronRunLogForTask(task, {
@@ -270,7 +274,7 @@ async function fireCronTask(
       outcome: "failed",
       reason: "runtime_unavailable",
       error: "Conversation runtime unavailable",
-      runAtMs: now.getTime(),
+      runAtMs: timing.schedulerNow.getTime(),
       scheduledFor: task.scheduled_for,
     });
     return false;
@@ -283,7 +287,7 @@ async function fireCronTask(
     rawRuntime,
   );
 
-  const text = wrapCronPrompt(task);
+  const text = wrapCronPrompt(task, timing);
 
   const queuedItem = conversationRuntime.queueRuntime.enqueue({
     kind: "cron_prompt",
@@ -298,7 +302,7 @@ async function fireCronTask(
     setLastRunOutcome(task.id, {
       outcome: "failed",
       reason: "queue_full",
-      runAt: now,
+      runAt: timing.schedulerNow,
       error: "queue buffer limit",
     });
     safeAppendCronRunLogForTask(task, {
@@ -306,7 +310,7 @@ async function fireCronTask(
       outcome: "failed",
       reason: "queue_full",
       error: "queue buffer limit",
-      runAtMs: now.getTime(),
+      runAtMs: timing.schedulerNow.getTime(),
       scheduledFor: task.scheduled_for,
     });
     return false;
@@ -315,7 +319,7 @@ async function fireCronTask(
   scheduleQueuePump(conversationRuntime, socket, opts, processQueuedTurn);
 
   // Update task state
-  const nowIso = now.toISOString();
+  const nowIso = timing.schedulerNow.toISOString();
   if (task.recurring) {
     updateTask(task.id, (t) => {
       t.last_fired_at = nowIso;
@@ -343,7 +347,7 @@ async function fireCronTask(
     status: "ok",
     outcome: "queued",
     reason: task.recurring ? "scheduled_time_matched" : "one_off_due",
-    runAtMs: now.getTime(),
+    runAtMs: timing.schedulerNow.getTime(),
     queueItemId: queuedItem.id,
     scheduledFor: task.scheduled_for,
     firedAt: nowIso,
@@ -423,10 +427,13 @@ export async function runCronTaskNow(taskId: string): Promise<{
     };
   }
 
-  const now = new Date();
+  const schedulerNow = new Date();
   const fired = await fireCronTask(
     task,
-    now,
+    {
+      intendedOccurrence: getIntendedCronOccurrence(task, schedulerNow),
+      schedulerNow,
+    },
     ctx.socket,
     ctx.opts,
     ctx.processQueuedTurn,
@@ -460,8 +467,8 @@ function tick(
     return;
   }
 
-  const now = new Date();
-  const currentMinuteKey = minuteKey(now);
+  const matchedAt = new Date();
+  const currentMinuteKey = minuteKey(matchedAt);
 
   // Reset per-minute dedup when minute changes
   if (currentMinuteKey !== state.lastMinuteKey) {
@@ -475,13 +482,14 @@ function tick(
     if (task.status !== "active") continue;
 
     // Handle missed one-shots (skip firing if marked missed)
-    if (handleMissedOneShot(task, now)) continue;
+    if (handleMissedOneShot(task, matchedAt)) continue;
 
     // Per-minute dedup
     if (state.firedThisMinute.has(task.id)) continue;
 
-    if (shouldFireTask(task, now)) {
+    if (shouldFireTask(task, matchedAt)) {
       state.firedThisMinute.add(task.id);
+      const intendedOccurrence = getIntendedCronOccurrence(task, matchedAt);
 
       // Apply jitter as a real delay for recurring tasks so that tasks with
       // different jitter values actually fire at different times.
@@ -495,9 +503,10 @@ function tick(
         const freshTask = getTask(taskId);
         if (!freshTask || freshTask.status !== "active") return;
 
+        const schedulerNow = new Date();
         void fireCronTask(
           freshTask,
-          now,
+          { intendedOccurrence, schedulerNow },
           socket,
           opts,
           processQueuedTurn,
@@ -506,7 +515,7 @@ function tick(
           setLastRunOutcome(freshTask.id, {
             outcome: "failed",
             reason: "scheduler_error",
-            runAt: now,
+            runAt: schedulerNow,
             error: err instanceof Error ? err.message : String(err),
           });
           safeAppendCronRunLogForTask(freshTask, {
@@ -514,7 +523,7 @@ function tick(
             outcome: "failed",
             reason: "scheduler_error",
             error: err instanceof Error ? err.message : String(err),
-            runAtMs: now.getTime(),
+            runAtMs: schedulerNow.getTime(),
             scheduledFor: freshTask.scheduled_for,
           });
         });


### PR DESCRIPTION
## Summary
- include the configured timezone, intended schedule occurrence, and authoritative current time in every scheduled turn
- share one formatter between the WS scheduler and TUI shadow scheduler
- preserve the matched occurrence across recurring-task jitter while recording actual enqueue time separately

## Before / after
Before, agents received only the cron expression and fire count, so they could infer the wrong calendar date. After, recurring and one-shot prompts carry timezone-qualified Scheduled for and Current time values directly in the retained user message.

## Risk and limits
The main risk is timezone conversion around local midnight, non-hour offsets, delayed execution, and malformed legacy timezone data. Fixed-clock tests cover those cases. This does not add a rendered Ink integration test; both scheduler paths call the same formatter and are covered by type checking.

## Test plan
- [x] bun test src/cron/scheduler.test.ts src/cron/cron-file.test.ts src/websocket/listener/protocol-outbound.test.ts
- [x] bun run check

👾 Generated with [Letta Code](https://letta.com)