### PR TITLE
feat(models): restore GPT-5.6 Luna ChatGPT OAuth

### DIFF
--- a/src/agent/model-catalog.test.ts
+++ b/src/agent/model-catalog.test.ts
@@ -10,12 +10,12 @@ describe("browser-safe model preset export", () => {
 
   test("includes presentation metadata and settings without claiming availability", () => {
     const preset: ModelPreset | undefined = MODEL_PRESETS.find(
-      (entry) => entry.id === "gpt-5.6-sol-plus-pro-high",
+      (entry) => entry.id === "gpt-5.6-luna-plus-pro-high",
     );
 
     expect(preset).toMatchObject({
-      handle: "chatgpt-plus-pro/gpt-5.6-sol",
-      label: "GPT-5.6 Sol (ChatGPT)",
+      handle: "chatgpt-plus-pro/gpt-5.6-luna",
+      label: "GPT-5.6 Luna (ChatGPT)",
       isFeatured: true,
       updateArgs: {
         reasoning_effort: "high",

--- a/src/agent/model-tier-selection.test.ts
+++ b/src/agent/model-tier-selection.test.ts
@@ -78,6 +78,7 @@ describe("getModelInfo", () => {
       "gpt-5.6-luna",
       "gpt-5.6-sol-plus-pro-high",
       "gpt-5.6-terra-plus-pro-high",
+      "gpt-5.6-luna-plus-pro-high",
       "fable",
       "opus",
     ];
@@ -87,7 +88,6 @@ describe("getModelInfo", () => {
     );
     expect(featuredIds).not.toContain("gpt-5.5-high");
     expect(featuredIds).not.toContain("gpt-5.5-plus-pro-high");
-    expect(featuredIds).not.toContain("gpt-5.6-luna-plus-pro-high");
   });
 
   test("resolves direct xAI Grok 4.5 registry metadata", () => {
@@ -144,6 +144,12 @@ describe("getModelInfoForLlmConfig", () => {
     });
     expect(info?.id).toBe("gpt-5.5-plus-pro-high");
     expect(info?.label).toBe("GPT-5.5 (ChatGPT)");
+
+    const lunaInfo = getModelInfoForLlmConfig("openai-codex/gpt-5.6-luna", {
+      reasoning_effort: "high",
+    });
+    expect(lunaInfo?.id).toBe("gpt-5.6-luna-plus-pro-high");
+    expect(lunaInfo?.label).toBe("GPT-5.6 Luna (ChatGPT)");
   });
 
   test("uses Fast ChatGPT metadata when local ChatGPT service tier is priority", () => {
@@ -312,25 +318,27 @@ describe("getReasoningTierOptionsForHandle", () => {
   });
 
   test("returns distinct xhigh and max options for local ChatGPT OAuth GPT-5.6", () => {
-    const options = getReasoningTierOptionsForHandle(
-      "openai-codex/gpt-5.6-sol",
-    );
-    expect(options.map((option) => option.effort)).toEqual([
-      "none",
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max",
-    ]);
-    expect(options.map((option) => option.modelId)).toEqual([
-      "gpt-5.6-sol-plus-pro-none",
-      "gpt-5.6-sol-plus-pro-low",
-      "gpt-5.6-sol-plus-pro-medium",
-      "gpt-5.6-sol-plus-pro-high",
-      "gpt-5.6-sol-plus-pro-xhigh",
-      "gpt-5.6-sol-plus-pro-max",
-    ]);
+    for (const variant of ["sol", "terra", "luna"] as const) {
+      const options = getReasoningTierOptionsForHandle(
+        `openai-codex/gpt-5.6-${variant}`,
+      );
+      expect(options.map((option) => option.effort)).toEqual([
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+      ]);
+      expect(options.map((option) => option.modelId)).toEqual([
+        `gpt-5.6-${variant}-plus-pro-none`,
+        `gpt-5.6-${variant}-plus-pro-low`,
+        `gpt-5.6-${variant}-plus-pro-medium`,
+        `gpt-5.6-${variant}-plus-pro-high`,
+        `gpt-5.6-${variant}-plus-pro-xhigh`,
+        `gpt-5.6-${variant}-plus-pro-max`,
+      ]);
+    }
   });
 
   test("returns byok reasoning options for chatgpt-plus-pro gpt-5.5-fast", () => {

--- a/src/backend/local/local-model-config.ts
+++ b/src/backend/local/local-model-config.ts
@@ -406,24 +406,6 @@ export async function resolveAvailableLocalModelForTurn(input: {
   };
 }
 
-// Temporary entitlement guard: remove Luna from this set once OpenAI enables
-// it through ChatGPT OAuth and LET-9572 is resolved. Direct OpenAI Luna remains
-// available because this filter is scoped to the chatgpt_oauth provider type.
-const UNSUPPORTED_LOCAL_CHATGPT_OAUTH_MODELS = new Set(["gpt-5.6-luna"]);
-
-function shouldIncludeLocalModel(
-  provider: PiProvider | string,
-  model: string,
-): boolean {
-  const modelId = isPiProvider(provider)
-    ? (stripProviderHandlePrefix(model, provider) ?? model)
-    : model;
-  return !(
-    localProviderTypeForModelConfig(provider) === "chatgpt_oauth" &&
-    UNSUPPORTED_LOCAL_CHATGPT_OAUTH_MODELS.has(modelId)
-  );
-}
-
 export async function listLocalModels(
   storageDir?: string,
   options: ListLocalModelsOptions = {},
@@ -449,7 +431,6 @@ export async function listLocalModels(
       name?: string;
     } = {},
   ) => {
-    if (!shouldIncludeLocalModel(provider, model)) return;
     const handle =
       options.handle ??
       (typeof provider === "string" &&

--- a/src/cli/components/ModelSelector-byok-custom-provider.test.tsx
+++ b/src/cli/components/ModelSelector-byok-custom-provider.test.tsx
@@ -54,7 +54,7 @@ describe("ModelSelector custom BYOK provider detection", () => {
     );
   });
 
-  test("uses ChatGPT GPT-5.6 metadata with a direct fallback", () => {
+  test("uses ChatGPT GPT-5.6 metadata for available variants", () => {
     expect(
       registryHandleForBackendModel(
         "openai-codex/gpt-5.6-sol",
@@ -66,7 +66,7 @@ describe("ModelSelector custom BYOK provider detection", () => {
         "openai-codex/gpt-5.6-luna",
         "chatgpt_oauth",
       ),
-    ).toBe("openai/gpt-5.6-luna");
+    ).toBe("chatgpt-plus-pro/gpt-5.6-luna");
     expect(labelForBackendModel("GPT-5.6 Sol", "chatgpt_oauth")).toBe(
       "GPT-5.6 Sol (ChatGPT)",
     );

--- a/src/models.json
+++ b/src/models.json
@@ -449,6 +449,85 @@
       }
     },
     {
+      "id": "gpt-5.6-luna-plus-pro-none",
+      "handle": "chatgpt-plus-pro/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna (ChatGPT)",
+      "description": "GPT-5.6 Luna (no reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "none",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-plus-pro-low",
+      "handle": "chatgpt-plus-pro/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna (ChatGPT)",
+      "description": "GPT-5.6 Luna (low reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "low",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-plus-pro-medium",
+      "handle": "chatgpt-plus-pro/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna (ChatGPT)",
+      "description": "GPT-5.6 Luna (med reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "medium",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-plus-pro-high",
+      "handle": "chatgpt-plus-pro/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna (ChatGPT)",
+      "description": "GPT-5.6 Luna (high reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "high",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      },
+      "isFeatured": true
+    },
+    {
+      "id": "gpt-5.6-luna-plus-pro-xhigh",
+      "handle": "chatgpt-plus-pro/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna (ChatGPT)",
+      "description": "GPT-5.6 Luna (extra-high reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "xhigh",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "gpt-5.6-luna-plus-pro-max",
+      "handle": "chatgpt-plus-pro/gpt-5.6-luna",
+      "label": "GPT-5.6 Luna (ChatGPT)",
+      "description": "GPT-5.6 Luna (max reasoning) via ChatGPT Plus/Pro",
+      "updateArgs": {
+        "reasoning_effort": "max",
+        "verbosity": "low",
+        "context_window": 272000,
+        "max_output_tokens": 128000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "fable",
       "handle": "anthropic/claude-fable-5",
       "label": "Fable 5",

--- a/src/providers/local-pi-provider-catalog.test.ts
+++ b/src/providers/local-pi-provider-catalog.test.ts
@@ -138,7 +138,7 @@ describe("local pi provider catalog", () => {
     }
   });
 
-  test("local ChatGPT OAuth catalog includes supported GPT-5.6 variants", async () => {
+  test("local ChatGPT OAuth catalog includes GPT-5.6 named variants", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "local-chatgpt-56-"));
     try {
       setLocalOAuthProvider({
@@ -153,7 +153,7 @@ describe("local pi provider catalog", () => {
       });
 
       const models = await listLocalModels(storageDir);
-      for (const variant of ["sol", "terra"]) {
+      for (const variant of ["sol", "terra", "luna"]) {
         expect(models).toContainEqual(
           expect.objectContaining({
             handle: `openai-codex/gpt-5.6-${variant}`,
@@ -162,9 +162,6 @@ describe("local pi provider catalog", () => {
           }),
         );
       }
-      expect(
-        models.some((model) => model.handle === "openai-codex/gpt-5.6-luna"),
-      ).toBe(false);
       expect(
         models.some((model) => model.handle === "openai-codex/gpt-5.6"),
       ).toBe(false);


### PR DESCRIPTION
## Summary
- Add GPT-5.6 Luna ChatGPT Plus and Pro presets omitted by #3297.
- Remove the temporary local ChatGPT OAuth Luna filter introduced by #3304.
- Keep direct OpenAI Luna behavior unchanged.

## Before / after
Before: Luna remained hidden from ChatGPT OAuth and the local catalog after an upstream model-not-found response.
After: once the paired Cloud allowlist change is deployed, Luna is selectable again through ChatGPT OAuth with the same reasoning tiers as Sol and Terra.

## Validation
- An installed 0.28.5/API-backend probe confirmed the upstream ChatGPT OAuth transport now accepts Luna (`LUNA_OK`); a fresh Terra control returned `TERRA_OK`. This did not exercise this PR branch.
- Branch local-backend runtime attempt reached the restored Luna path but could not authenticate because this machine has no local `openai-codex` credential.
- Branch Cloud/API new-agent attempt currently returns `400 Not Found` while paired Cloud PR #12959 is not deployed.
- `bun test src/agent/model-catalog.test.ts src/agent/model-tier-selection.test.ts src/providers/local-pi-provider-catalog.test.ts` — 67 passed.
- `bun run check` — 12 checks passed.
- Commit hooks passed Biome and TypeScript checks.

## Dependency
Do not merge/release this PR ahead of letta-ai/letta-cloud#12959 deployment. After that deployment, rerun a real Luna ChatGPT OAuth send from this branch before merge.

## Risk
The change re-exposes a model whose upstream entitlement was previously unavailable. Registry metadata follows the existing Sol and Terra ChatGPT preset shape, but branch-level end-to-end validation remains blocked on the paired Cloud allowlist deployment.

Linear: https://linear.app/letta/issue/LET-9572/gpt-56-luna-is-currently-non-functional-through-chatgpt-oauth

👾 Generated with [Letta Code](https://letta.com)