### PR TITLE
fix(cli): clarify context-limit reset for uncatalogued models

### DIFF
--- a/src/agent/max-context.test.ts
+++ b/src/agent/max-context.test.ts
@@ -155,7 +155,7 @@ describe("max context command helpers", () => {
     }
   });
 
-  test("fails reset when no model.json default exists", async () => {
+  test("explains reset fallback for custom models without model.json defaults", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "max-context-custom-"));
     try {
       const backend = new LocalBackend({
@@ -174,10 +174,28 @@ describe("max context command helpers", () => {
           conversationId: "default",
           args: "",
           currentModelHandle: "custom/model",
+          currentContextWindow: 131_072,
         }),
       ).rejects.toThrow(
-        "No default value for max context window found in model.json",
+        "No catalog default for model custom/model, so reset is unavailable. Pass an explicit value: /context-limit 131072.",
       );
+
+      const explicitResult = await applySetMaxContext({
+        agentId: agent.id,
+        conversationId: "default",
+        args: "131072",
+        currentModelHandle: "custom/model",
+      });
+      expect(explicitResult.contextWindow).toBe(131_072);
+      expect(explicitResult.reset).toBe(false);
+      expect(explicitResult.appliedTo).toBe("agent");
+      expect(
+        (
+          (await backend.retrieveAgent(agent.id)) as {
+            llm_config?: { context_window?: number };
+          }
+        ).llm_config?.context_window,
+      ).toBe(131_072);
     } finally {
       await rm(storageDir, { recursive: true, force: true });
     }

--- a/src/agent/max-context.ts
+++ b/src/agent/max-context.ts
@@ -233,6 +233,22 @@ function validateRequestedContextWindow(params: {
   }
 }
 
+function formatMissingContextWindowDefaultError(params: {
+  modelHandle?: string | null;
+  currentContextWindow?: number | null;
+}): string {
+  const modelDescription = params.modelHandle
+    ? `model ${params.modelHandle}`
+    : "the current model";
+  const suggestedValue =
+    typeof params.currentContextWindow === "number" &&
+    Number.isSafeInteger(params.currentContextWindow) &&
+    params.currentContextWindow > 0
+      ? String(params.currentContextWindow)
+      : "<tokens>";
+  return `No catalog default for ${modelDescription}, so reset is unavailable. Pass an explicit value: /context-limit ${suggestedValue}.`;
+}
+
 export async function applySetMaxContext(params: {
   agentId: string;
   conversationId: string;
@@ -288,7 +304,11 @@ export async function applySetMaxContext(params: {
   const contextWindow = reset ? modelDefault.contextWindow : parsed.value;
   if (contextWindow === undefined || contextWindow === null) {
     throw new Error(
-      "No default value for max context window found in model.json",
+      formatMissingContextWindowDefaultError({
+        modelHandle: effectiveModelHandle,
+        currentContextWindow:
+          effectiveContextWindow ?? effectiveLlmConfig?.context_window ?? null,
+      }),
     );
   }
 

--- a/src/channels/discord-service.test.ts
+++ b/src/channels/discord-service.test.ts
@@ -7,6 +7,10 @@ import {
   loadChannelAccounts,
 } from "@/channels/accounts";
 import {
+  __setActiveChannelCredentialsStoreModeForTests,
+  __setChannelSecretStoreOverrideForTests,
+} from "@/channels/credential-store";
+import {
   __testOverrideLoadPairingStore,
   __testOverrideSavePairingStore,
   clearPairingStores,
@@ -43,6 +47,8 @@ describe("discord channel service", () => {
     clearAllRoutes();
     clearPairingStores();
     clearTargetStores();
+    __setActiveChannelCredentialsStoreModeForTests(null);
+    __setChannelSecretStoreOverrideForTests(null);
     __testOverrideLoadChannelAccounts(null);
     __testOverrideSaveChannelAccounts(null);
     __testOverrideLoadRoutes(null);
@@ -56,6 +62,7 @@ describe("discord channel service", () => {
 
   beforeEach(() => {
     resetState();
+    __setActiveChannelCredentialsStoreModeForTests("file");
     __testOverrideLoadChannelAccounts(() => []);
     __testOverrideSaveChannelAccounts(() => {});
     __testOverrideLoadRoutes(() => null);

--- a/src/channels/discord-service.test.ts
+++ b/src/channels/discord-service.test.ts
@@ -7,10 +7,6 @@ import {
   loadChannelAccounts,
 } from "@/channels/accounts";
 import {
-  __setActiveChannelCredentialsStoreModeForTests,
-  __setChannelSecretStoreOverrideForTests,
-} from "@/channels/credential-store";
-import {
   __testOverrideLoadPairingStore,
   __testOverrideSavePairingStore,
   clearPairingStores,
@@ -47,8 +43,6 @@ describe("discord channel service", () => {
     clearAllRoutes();
     clearPairingStores();
     clearTargetStores();
-    __setActiveChannelCredentialsStoreModeForTests(null);
-    __setChannelSecretStoreOverrideForTests(null);
     __testOverrideLoadChannelAccounts(null);
     __testOverrideSaveChannelAccounts(null);
     __testOverrideLoadRoutes(null);
@@ -62,7 +56,6 @@ describe("discord channel service", () => {
 
   beforeEach(() => {
     resetState();
-    __setActiveChannelCredentialsStoreModeForTests("file");
     __testOverrideLoadChannelAccounts(() => []);
     __testOverrideSaveChannelAccounts(() => {});
     __testOverrideLoadRoutes(() => null);


### PR DESCRIPTION
## Summary
- LET-9658: replace the bare `/context-limit` reset missing-catalog error with user-facing guidance that reset is unavailable when no catalog default exists.
- Suggest an explicit `/context-limit` value when the current context window is known, otherwise show `/context-limit <tokens>`.
- Extend max-context coverage to assert the new copy and the existing explicit numeric path for uncatalogued models.

## Root cause
`resolveModelJsonContextWindow()` returns no default for uncatalogued model handles. The bare reset path then threw an implementation-oriented `model.json` error, while explicit numeric values already worked because there is no catalog upper-bound default to validate against.

## Validation
- [x] `bun test --cwd /Users/lettamate/letta-code/.letta/worktrees/LET-9658-context-limit-reset src/agent/max-context.test.ts`
- [x] `bun run --cwd /Users/lettamate/letta-code/.letta/worktrees/LET-9658-context-limit-reset check`

## Limits
- This does not add catalog fallbacks or infer provider defaults for custom models.
- Catalog-backed reset behavior and explicit numeric validation are otherwise unchanged.

👾 Generated with [Letta Code](https://letta.com)