### PR TITLE
fix(listener): publish authoritative executing tool ids on loop state [LET-9640]

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -40,13 +40,13 @@
   "src/tools/impl/message-channel.ts": 1187,
   "src/tools/manager.ts": 3293,
   "src/tools/tool-execution-context.test.ts": 1422,
-  "src/types/protocol_v2.ts": 2932,
+  "src/types/protocol_v2.ts": 2940,
   "src/websocket/listen-client-concurrency.test.ts": 3017,
-  "src/websocket/listen-client-protocol.test.ts": 6721,
+  "src/websocket/listen-client-protocol.test.ts": 6771,
   "src/websocket/listener/commands/channels.ts": 1390,
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1030,
   "src/websocket/listener/lifecycle.ts": 1766,
   "src/websocket/listener/protocol-inbound.ts": 2279,
-  "src/websocket/listener/protocol-outbound.ts": 1279
+  "src/websocket/listener/protocol-outbound.ts": 1287
 }

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -42,7 +42,7 @@
   "src/tools/tool-execution-context.test.ts": 1422,
   "src/types/protocol_v2.ts": 2940,
   "src/websocket/listen-client-concurrency.test.ts": 3017,
-  "src/websocket/listen-client-protocol.test.ts": 6771,
+  "src/websocket/listen-client-protocol.test.ts": 6723,
   "src/websocket/listener/commands/channels.ts": 1390,
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1030,

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -520,6 +520,14 @@ export interface QueueMessage {
 export interface LoopState {
   status: LoopStatus;
   active_run_ids: string[];
+  /**
+   * Tool call ids currently executing client-side. Populated only while
+   * `status` is `EXECUTING_CLIENT_SIDE_TOOL`; empty otherwise. Lets
+   * observer UIs render an authoritative executing set that self-heals on
+   * every status frame instead of pairing client_tool_start/end lifecycle
+   * events, which are unrecoverable if a frame is lost.
+   */
+  executing_tool_call_ids: string[];
 }
 
 export interface DeviceStatusUpdateMessage extends RuntimeEnvelope {

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -4550,6 +4550,7 @@ describe("listen-client v2 status builders", () => {
     expect(outbound[1].loop_status).toEqual({
       status: "WAITING_ON_APPROVAL",
       active_run_ids: [],
+      executing_tool_call_ids: [],
     });
   });
 
@@ -4694,7 +4695,56 @@ describe("listen-client v2 status builders", () => {
     ).toEqual({
       status: "WAITING_ON_APPROVAL",
       active_run_ids: [],
+      executing_tool_call_ids: [],
     });
+  });
+
+  test("loop status carries the executing tool call ids while executing client-side tools", () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
+      listener,
+      "agent-1",
+      "conv-a",
+    );
+
+    beginTestTurn(runtime, {
+      initialStatus: "EXECUTING_CLIENT_SIDE_TOOL",
+      executingToolCallIds: ["tool-call-1", "tool-call-2"],
+    });
+
+    const loopStatus = __listenClientTestUtils.buildLoopStatus(listener, {
+      agent_id: "agent-1",
+      conversation_id: "conv-a",
+    });
+    expect(loopStatus.status).toBe("EXECUTING_CLIENT_SIDE_TOOL");
+    expect(loopStatus.executing_tool_call_ids).toEqual([
+      "tool-call-1",
+      "tool-call-2",
+    ]);
+  });
+
+  test("loop status reports an empty executing set outside client-side tool execution", () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
+      listener,
+      "agent-1",
+      "conv-a",
+    );
+
+    // Lifecycle state can retain the last executing ids (e.g. while the
+    // continuation request is in flight); the wire snapshot must not leak
+    // them once the reported status is no longer EXECUTING_CLIENT_SIDE_TOOL.
+    beginTestTurn(runtime, {
+      initialStatus: "SENDING_API_REQUEST",
+      executingToolCallIds: ["tool-call-stale"],
+    });
+
+    const loopStatus = __listenClientTestUtils.buildLoopStatus(listener, {
+      agent_id: "agent-1",
+      conversation_id: "conv-a",
+    });
+    expect(loopStatus.status).toBe("SENDING_API_REQUEST");
+    expect(loopStatus.executing_tool_call_ids).toEqual([]);
   });
 
   test("scoped queue snapshots are not suppressed just because another conversation is processing", () => {

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -4699,54 +4699,6 @@ describe("listen-client v2 status builders", () => {
     });
   });
 
-  test("loop status carries the executing tool call ids while executing client-side tools", () => {
-    const listener = __listenClientTestUtils.createListenerRuntime();
-    const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
-      listener,
-      "agent-1",
-      "conv-a",
-    );
-
-    beginTestTurn(runtime, {
-      initialStatus: "EXECUTING_CLIENT_SIDE_TOOL",
-      executingToolCallIds: ["tool-call-1", "tool-call-2"],
-    });
-
-    const loopStatus = __listenClientTestUtils.buildLoopStatus(listener, {
-      agent_id: "agent-1",
-      conversation_id: "conv-a",
-    });
-    expect(loopStatus.status).toBe("EXECUTING_CLIENT_SIDE_TOOL");
-    expect(loopStatus.executing_tool_call_ids).toEqual([
-      "tool-call-1",
-      "tool-call-2",
-    ]);
-  });
-
-  test("loop status reports an empty executing set outside client-side tool execution", () => {
-    const listener = __listenClientTestUtils.createListenerRuntime();
-    const runtime = __listenClientTestUtils.getOrCreateConversationRuntime(
-      listener,
-      "agent-1",
-      "conv-a",
-    );
-
-    // Lifecycle state can retain the last executing ids (e.g. while the
-    // continuation request is in flight); the wire snapshot must not leak
-    // them once the reported status is no longer EXECUTING_CLIENT_SIDE_TOOL.
-    beginTestTurn(runtime, {
-      initialStatus: "SENDING_API_REQUEST",
-      executingToolCallIds: ["tool-call-stale"],
-    });
-
-    const loopStatus = __listenClientTestUtils.buildLoopStatus(listener, {
-      agent_id: "agent-1",
-      conversation_id: "conv-a",
-    });
-    expect(loopStatus.status).toBe("SENDING_API_REQUEST");
-    expect(loopStatus.executing_tool_call_ids).toEqual([]);
-  });
-
   test("scoped queue snapshots are not suppressed just because another conversation is processing", () => {
     const listener = __listenClientTestUtils.createListenerRuntime();
     const runtimeA = __listenClientTestUtils.getOrCreateScopedRuntime(

--- a/src/websocket/listener/interrupts.ts
+++ b/src/websocket/listener/interrupts.ts
@@ -429,6 +429,34 @@ export function emitToolExecutionFinishedEvents(
   }
 }
 
+/**
+ * Close out `client_tool_start` lifecycle events when execution throws
+ * before results exist. Without a matching `client_tool_end`, observer UIs
+ * that pair start/end events shimmer the orphaned tool call forever.
+ */
+export function emitToolExecutionAbortedEvents(
+  socket: ListenerTransport,
+  runtime: ConversationRuntime,
+  params: {
+    toolCallIds: string[];
+    runId?: string | null;
+    agentId?: string;
+    conversationId?: string;
+  },
+): void {
+  for (const toolCallId of params.toolCallIds) {
+    const delta: ClientToolEndMessage = {
+      ...createLifecycleMessageBase("client_tool_end", params.runId),
+      tool_call_id: toolCallId,
+      status: "error",
+    };
+    emitCanonicalMessageDelta(socket, runtime, delta, {
+      agent_id: params.agentId,
+      conversation_id: params.conversationId,
+    });
+  }
+}
+
 export function createToolExecutionOutputEmitter(
   socket: ListenerTransport,
   runtime: ConversationRuntime,

--- a/src/websocket/listener/loop-state-executing-tools.test.ts
+++ b/src/websocket/listener/loop-state-executing-tools.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import WebSocket from "ws";
+import { getOrCreateScopedRuntime } from "./conversation-runtime";
+import { emitToolExecutionAbortedEvents } from "./interrupts";
+import { createRuntime } from "./lifecycle";
+import { buildLoopStatus } from "./protocol-outbound";
+import type { ConversationRuntime } from "./types";
+
+class MockSocket {
+  readonly kind = "local" as const;
+  readonly bufferedAmount = 0;
+  readyState: number;
+  sentPayloads: string[] = [];
+
+  constructor(readyState: number = WebSocket.OPEN) {
+    this.readyState = readyState;
+  }
+
+  send(data: string): void {
+    this.sentPayloads.push(data);
+  }
+
+  isOpen(): boolean {
+    return this.readyState === WebSocket.OPEN;
+  }
+
+  close(): void {}
+
+  removeAllListeners(): this {
+    return this;
+  }
+}
+
+function createScopedRuntime(
+  agentId: string = "agent-1",
+  conversationId: string = "conv-a",
+): ConversationRuntime {
+  return getOrCreateScopedRuntime(createRuntime(), agentId, conversationId);
+}
+
+function beginTurn(
+  runtime: ConversationRuntime,
+  options: {
+    initialStatus?: Parameters<
+      ConversationRuntime["turnLifecycle"]["begin"]
+    >[0]["initialStatus"];
+    executingToolCallIds?: readonly string[];
+  } = {},
+) {
+  return runtime.turnLifecycle.begin({
+    origin: "message",
+    workingDirectory: "/tmp/test-worktree",
+    ...(options.initialStatus ? { initialStatus: options.initialStatus } : {}),
+    ...(options.executingToolCallIds
+      ? { executingToolCallIds: options.executingToolCallIds }
+      : {}),
+  });
+}
+
+describe("loop state executing tool call ids", () => {
+  test("carries the executing tool call ids while executing client-side tools", () => {
+    const runtime = createScopedRuntime();
+
+    beginTurn(runtime, {
+      initialStatus: "EXECUTING_CLIENT_SIDE_TOOL",
+      executingToolCallIds: ["tool-call-1", "tool-call-2"],
+    });
+
+    const loopStatus = buildLoopStatus(runtime.listener, {
+      agent_id: "agent-1",
+      conversation_id: "conv-a",
+    });
+    expect(loopStatus.status).toBe("EXECUTING_CLIENT_SIDE_TOOL");
+    expect(loopStatus.executing_tool_call_ids).toEqual([
+      "tool-call-1",
+      "tool-call-2",
+    ]);
+  });
+
+  test("reports an empty executing set outside client-side tool execution", () => {
+    const runtime = createScopedRuntime();
+
+    // Lifecycle state can retain the last executing ids (e.g. while the
+    // continuation request is in flight); the wire snapshot must not leak
+    // them once the reported status is no longer EXECUTING_CLIENT_SIDE_TOOL.
+    beginTurn(runtime, {
+      initialStatus: "SENDING_API_REQUEST",
+      executingToolCallIds: ["tool-call-stale"],
+    });
+
+    const loopStatus = buildLoopStatus(runtime.listener, {
+      agent_id: "agent-1",
+      conversation_id: "conv-a",
+    });
+    expect(loopStatus.status).toBe("SENDING_API_REQUEST");
+    expect(loopStatus.executing_tool_call_ids).toEqual([]);
+  });
+
+  test("reports an empty executing set when the conversation is idle", () => {
+    const runtime = createScopedRuntime();
+
+    const loopStatus = buildLoopStatus(runtime.listener, {
+      agent_id: "agent-1",
+      conversation_id: "conv-a",
+    });
+    expect(loopStatus.status).toBe("WAITING_ON_INPUT");
+    expect(loopStatus.executing_tool_call_ids).toEqual([]);
+  });
+});
+
+describe("emitToolExecutionAbortedEvents", () => {
+  test("emits error-status client_tool_end events for every tool call id", () => {
+    const runtime = createScopedRuntime();
+    const socket = new MockSocket();
+
+    emitToolExecutionAbortedEvents(socket, runtime, {
+      toolCallIds: ["tool-call-1", "tool-call-2"],
+      runId: "run-1",
+      agentId: "agent-1",
+      conversationId: "conv-a",
+    });
+
+    const deltas = socket.sentPayloads
+      .map((payload) => JSON.parse(payload))
+      .filter((frame) => frame.type === "stream_delta")
+      .map((frame) => frame.delta);
+    expect(deltas).toHaveLength(2);
+    for (const delta of deltas) {
+      expect(delta.message_type).toBe("client_tool_end");
+      expect(delta.status).toBe("error");
+      expect(delta.run_id).toBe("run-1");
+    }
+    expect(deltas.map((delta) => delta.tool_call_id)).toEqual([
+      "tool-call-1",
+      "tool-call-2",
+    ]);
+  });
+
+  test("emits nothing for an empty tool call id list", () => {
+    const runtime = createScopedRuntime();
+    const socket = new MockSocket();
+
+    emitToolExecutionAbortedEvents(socket, runtime, {
+      toolCallIds: [],
+      runId: "run-1",
+      agentId: "agent-1",
+      conversationId: "conv-a",
+    });
+
+    expect(socket.sentPayloads).toHaveLength(0);
+  });
+});

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -525,6 +525,7 @@ export function buildLoopStatus(
     return {
       status: "WAITING_ON_INPUT",
       active_run_ids: [],
+      executing_tool_call_ids: [],
     };
   }
   const scope = getScopeForRuntime(runtime, params);
@@ -556,6 +557,13 @@ export function buildLoopStatus(
         : conversationRuntime?.activeRunId
           ? [conversationRuntime.activeRunId]
           : [],
+    // Gate on the *reported* status so downgrades (interrupted cache) also
+    // clear the executing set, and stale runtime state never leaks into
+    // frames emitted while the loop is not executing tools.
+    executing_tool_call_ids:
+      status === "EXECUTING_CLIENT_SIDE_TOOL" && conversationRuntime
+        ? [...conversationRuntime.turnLifecycle.executingToolCallIds]
+        : [],
   };
 }
 

--- a/src/websocket/listener/recovery-lease.test.ts
+++ b/src/websocket/listener/recovery-lease.test.ts
@@ -202,4 +202,59 @@ describe("recovered approval lease boundaries", () => {
     expect(runtime.turnLifecycle.isCurrent(replacementLease)).toBe(true);
     expect(sentPayloads).toEqual([]);
   });
+
+  test("aborted recovered execution that throws still closes lifecycle starts exactly once", async () => {
+    const runtime = getOrCreateScopedRuntime(
+      createRuntime(),
+      "agent-1",
+      "conv-1",
+    );
+    runtime.recoveredApprovalState = createRecoveredState();
+    const sentPayloads: string[] = [];
+    let executionStarted = false;
+    let rejectExecution!: (error: Error) => void;
+    const execution = new Promise<never[]>((_, reject) => {
+      rejectExecution = reject;
+    });
+    const handled = resolveRecoveredApprovalResponse(
+      runtime,
+      createTransport(sentPayloads),
+      { request_id: "perm-1", decision: { behavior: "allow" } },
+      mock(async () => {}),
+      {
+        dependencies: {
+          applySuggestedPermissions: async () => false,
+          ensureSecretsHydrated: async () => {},
+          prepareToolExecutionContext: async () => createPreparedToolContext(),
+          executeApprovalBatch: (async () => {
+            executionStarted = true;
+            return execution;
+          }) as never,
+        },
+      },
+    );
+    await waitFor(() => executionStarted);
+
+    // Abort the recovery mid-execution, then have execution reject. Unlike
+    // the normal turn path, recovered approvals do not unwind through the
+    // turn.ts interrupt emission, so the recovery catch itself must close
+    // the client_tool_start lifecycle events even when aborted.
+    runtime.turnLifecycle.requestCancellation();
+    rejectExecution(new Error("tool execution crashed"));
+    await handled.catch(() => {});
+
+    const deltas = sentPayloads
+      .map((payload) => JSON.parse(payload))
+      .filter((frame) => frame.type === "stream_delta")
+      .map((frame) => frame.delta);
+    const starts = deltas.filter(
+      (delta) => delta.message_type === "client_tool_start",
+    );
+    const ends = deltas.filter(
+      (delta) => delta.message_type === "client_tool_end",
+    );
+    expect(starts.map((delta) => delta.tool_call_id)).toEqual(["call-1"]);
+    expect(ends.map((delta) => delta.tool_call_id)).toEqual(["call-1"]);
+    expect(ends[0].status).toBe("error");
+  });
 });

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -738,30 +738,33 @@ export async function resolveRecoveredApprovalResponse(
         shouldEmit: () => runtime.turnLifecycle.isCurrent(recoveryLease),
       },
     );
-    await ensureSecretsHydrated(runtime.listener, recovered.agentId);
-    if (!runtime.turnLifecycle.isCurrent(recoveryLease)) {
-      return true;
-    }
-    const preparedToolContext = await prepareToolExecutionContext({
-      agentId: recovered.agentId,
-      conversationId: recovered.conversationId,
-      workingDirectory,
-      permissionModeState: getOrCreateConversationPermissionModeStateRef(
-        runtime.listener,
-        recovered.agentId,
-        recovered.conversationId,
-      ),
-      modEvents: ensureListenerModAdapter(runtime.listener).events,
-    });
-    if (!runtime.turnLifecycle.isCurrent(recoveryLease)) {
-      return true;
-    }
-    runtime.currentToolset = preparedToolContext.toolset;
-    runtime.currentToolsetPreference = preparedToolContext.toolsetPreference;
-    runtime.currentLoadedTools =
-      preparedToolContext.preparedToolContext.loadedToolNames;
     let approvalResults: Awaited<ReturnType<typeof executeApprovalBatch>>;
     try {
+      // Hydration and tool-context preparation sit inside the try: they run
+      // after the client_tool_start events above, so a throw here would
+      // otherwise leave those lifecycle events orphaned.
+      await ensureSecretsHydrated(runtime.listener, recovered.agentId);
+      if (!runtime.turnLifecycle.isCurrent(recoveryLease)) {
+        return true;
+      }
+      const preparedToolContext = await prepareToolExecutionContext({
+        agentId: recovered.agentId,
+        conversationId: recovered.conversationId,
+        workingDirectory,
+        permissionModeState: getOrCreateConversationPermissionModeStateRef(
+          runtime.listener,
+          recovered.agentId,
+          recovered.conversationId,
+        ),
+        modEvents: ensureListenerModAdapter(runtime.listener).events,
+      });
+      if (!runtime.turnLifecycle.isCurrent(recoveryLease)) {
+        return true;
+      }
+      runtime.currentToolset = preparedToolContext.toolset;
+      runtime.currentToolsetPreference = preparedToolContext.toolsetPreference;
+      runtime.currentLoadedTools =
+        preparedToolContext.preparedToolContext.loadedToolNames;
       approvalResults = await executeApprovals(decisions, undefined, {
         abortSignal: recoveryLease.signal,
         onStreamingOutput: emitToolExecutionOutput,
@@ -780,12 +783,22 @@ export async function resolveRecoveredApprovalResponse(
       // Execution threw before results exist, so the finished-events
       // emission below never runs. Close the client_tool_start lifecycle
       // events explicitly or observer UIs shimmer these tool calls forever.
-      emitToolExecutionAbortedEvents(socket, runtime, {
-        toolCallIds: approvedToolCallIds,
-        runId: executionRunId,
-        agentId: recovered.agentId,
-        conversationId: recovered.conversationId,
-      });
+      // Flush buffered tool output first so no progress frame lands after
+      // the terminal end events. Skip emission when this owner lost the
+      // recovery lease or the recovery was aborted: the interrupt path or
+      // the replacement runtime owns terminal state then.
+      emitToolExecutionOutput.flush();
+      if (
+        runtime.turnLifecycle.isCurrent(recoveryLease) &&
+        !recoveryLease.signal.aborted
+      ) {
+        emitToolExecutionAbortedEvents(socket, runtime, {
+          toolCallIds: approvedToolCallIds,
+          runId: executionRunId,
+          agentId: recovered.agentId,
+          conversationId: recovered.conversationId,
+        });
+      }
       throw error;
     } finally {
       emitToolExecutionOutput.flush();

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -48,6 +48,7 @@ import { getConversationWorkingDirectory } from "./cwd";
 import {
   createToolExecutionOutputEmitter,
   emitInterruptToolReturnMessage,
+  emitToolExecutionAbortedEvents,
   emitToolExecutionFinishedEvents,
   emitToolExecutionStartedEvents,
   normalizeToolReturnWireMessage,
@@ -775,6 +776,17 @@ export async function resolveRecoveredApprovalResponse(
             : undefined,
         channelTurnSources: executionChannelTurnSources,
       });
+    } catch (error) {
+      // Execution threw before results exist, so the finished-events
+      // emission below never runs. Close the client_tool_start lifecycle
+      // events explicitly or observer UIs shimmer these tool calls forever.
+      emitToolExecutionAbortedEvents(socket, runtime, {
+        toolCallIds: approvedToolCallIds,
+        runId: executionRunId,
+        agentId: recovered.agentId,
+        conversationId: recovered.conversationId,
+      });
+      throw error;
     } finally {
       emitToolExecutionOutput.flush();
     }

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -784,14 +784,15 @@ export async function resolveRecoveredApprovalResponse(
       // emission below never runs. Close the client_tool_start lifecycle
       // events explicitly or observer UIs shimmer these tool calls forever.
       // Flush buffered tool output first so no progress frame lands after
-      // the terminal end events. Skip emission when this owner lost the
-      // recovery lease or the recovery was aborted: the interrupt path or
-      // the replacement runtime owns terminal state then.
+      // the terminal end events. Gate only on lease ownership: unlike the
+      // normal turn path, recovered approvals do not unwind through the
+      // turn.ts interrupt emission, so an aborted recovery that throws has
+      // no other owner for these terminal events (the outer catch below
+      // finalizes the lease without emitting ends). isCurrent stays true
+      // while the lease is cancelling, so abort+throw still emits exactly
+      // once; only a replacement owner suppresses emission.
       emitToolExecutionOutput.flush();
-      if (
-        runtime.turnLifecycle.isCurrent(recoveryLease) &&
-        !recoveryLease.signal.aborted
-      ) {
+      if (runtime.turnLifecycle.isCurrent(recoveryLease)) {
         emitToolExecutionAbortedEvents(socket, runtime, {
           toolCallIds: approvedToolCallIds,
           runId: executionRunId,

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -502,12 +502,20 @@ export async function handleApprovalStop(params: {
     // Execution threw before results exist, so the normal finished-events
     // emission below never runs. Close the client_tool_start lifecycle
     // events explicitly or observer UIs shimmer these tool calls forever.
-    emitToolExecutionAbortedEvents(socket, runtime, {
-      toolCallIds: lastExecutingToolCallIds,
-      runId: executionRunId,
-      agentId,
-      conversationId,
-    });
+    // Flush buffered tool output first so no progress frame lands after
+    // the terminal end events. Skip emission when this owner lost the
+    // turn lease (a replacement runtime owns terminal state now) or when
+    // an interrupt is in flight (the interrupt path emits finished events
+    // from the interrupted-results cache).
+    emitToolExecutionOutput.flush();
+    if (!shouldInterrupt()) {
+      emitToolExecutionAbortedEvents(socket, runtime, {
+        toolCallIds: lastExecutingToolCallIds,
+        runId: executionRunId,
+        agentId,
+        conversationId,
+      });
+    }
     throw error;
   } finally {
     emitToolExecutionOutput.flush();

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -37,6 +37,7 @@ import {
 import {
   createToolExecutionOutputEmitter,
   emitInterruptToolReturnMessage,
+  emitToolExecutionAbortedEvents,
   emitToolExecutionFinishedEvents,
   emitToolExecutionStartedEvents,
   normalizeExecutionResultsForInterruptParity,
@@ -497,6 +498,17 @@ export async function handleApprovalStop(params: {
       channelTurnSources: runtime.activeChannelTurn?.sources,
       onFileWrite,
     });
+  } catch (error) {
+    // Execution threw before results exist, so the normal finished-events
+    // emission below never runs. Close the client_tool_start lifecycle
+    // events explicitly or observer UIs shimmer these tool calls forever.
+    emitToolExecutionAbortedEvents(socket, runtime, {
+      toolCallIds: lastExecutingToolCallIds,
+      runId: executionRunId,
+      agentId,
+      conversationId,
+    });
+    throw error;
   } finally {
     emitToolExecutionOutput.flush();
   }

--- a/src/websocket/listener/turn-lifecycle.ts
+++ b/src/websocket/listener/turn-lifecycle.ts
@@ -106,6 +106,12 @@ export class TurnLifecycle {
     return this.#state.kind === "active" ? this.#state.runId : null;
   }
 
+  get executingToolCallIds(): readonly string[] {
+    return this.#state.kind === "active" || this.#state.kind === "cancelling"
+      ? this.#state.executingToolCallIds
+      : [];
+  }
+
   get lastStopReason(): StopReasonType | null {
     return this.#lastStopReason;
   }


### PR DESCRIPTION
## Summary

- Publish the authoritative executing-tool set on `LoopState` as `executing_tool_call_ids`, gated on the reported status so downgrades (interrupted cache) also clear it.
- Close `client_tool_start` lifecycle events with error-status `client_tool_end` events when tool execution throws — guarded on current lease ownership and no in-flight interrupt, with buffered output flushed before the terminal events.
- Move recovered-approval secrets hydration and tool-context preparation inside the try so a throw there cannot orphan already-emitted start events.

## Why

Observer UIs derive the executing-tool shimmer set by pairing `client_tool_start`/`client_tool_end` lifecycle events. Those frames ride an at-most-once relay with no lifecycle replay, so a single lost end event orphans its start forever: the old tool row re-shimmers during every later execution phase, and a lost status transition can hide the busy indicator for the entire run of a silent long-running tool (LET-9640, reopened).

With `executing_tool_call_ids` on every loop status frame, observer state self-heals on each status transition and periodic sync instead of depending on unrepairable event pairing. The throw-path fixes remove the largest producers of orphaned starts at the source. Older observer UIs ignore the extra field; newer UIs fall back to event pairing when the field is absent.

Review follow-ups (commit 3): the catch-path end emission is now guarded so stale turn owners cannot emit terminal events into a replacement runtime, and thrown aborts defer to the interrupt path (which already emits finished events from the interrupted-results cache — emitting from the catch too would double-close). Output is flushed before the terminal events since catch runs before finally.

## Validation

- `bun run check` green (12/12).
- New per-module suite `src/websocket/listener/loop-state-executing-tools.test.ts` (5 tests: populated set during `EXECUTING_CLIENT_SIDE_TOOL`, empty outside it and when idle, aborted-events emission shape, empty-list no-op) — placed next to the owning modules per `src/websocket/listener/AGENTS.md` instead of growing the legacy protocol test monolith.
- `listen-client-protocol.test.ts` (157) and `approval.test.ts` pass; `listen-client-concurrency.test.ts` fails identically on clean origin/main in this environment (pre-existing sandbox baseline, verified by stash-compare).

Linear: https://linear.app/letta/issue/LET-9640

👾 Generated with [Letta Code](https://letta.com)
