### PR TITLE
fix(local): isolate conversation model token settings

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -3,7 +3,7 @@
   "src/agent/memory-git.ts": 2129,
   "src/backend/local-backend.test.ts": 2534,
   "src/backend/local/local-backend.ts": 1058,
-  "src/backend/local/local-store.ts": 3618,
+  "src/backend/local/local-store.ts": 3613,
   "src/backend/pi-stream-adapter.test.ts": 1442,
   "src/cli/app/AppCoordinator.tsx": 5198,
   "src/cli/app/AppView.tsx": 1750,

--- a/src/agent/modify-local.test.ts
+++ b/src/agent/modify-local.test.ts
@@ -202,4 +202,51 @@ describe("local model updates", () => {
       await rm(storageDir, { recursive: true, force: true });
     }
   });
+
+  test("uses conversation model defaults instead of agent token settings", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-conversation-model-defaults-"),
+    );
+    try {
+      await createOrUpdateLocalProvider({
+        providerType: "anthropic",
+        providerName: "lc-anthropic",
+        apiKey: "dummy",
+        storageDir,
+      });
+
+      await withLocalBackendStorage(storageDir, async () => {
+        const backend = getBackend();
+        const agent = await backend.createAgent({
+          name: "Local",
+          model: "openai-codex/gpt-5.5",
+          model_settings: { provider_type: "chatgpt_oauth" },
+          max_tokens: 128000,
+          context_window_limit: 272000,
+        } as never);
+        const conversation = await backend.createConversation({
+          agent_id: agent.id,
+          model: "anthropic/claude-fable-5",
+          model_settings: {
+            provider_type: "anthropic",
+            effort: "medium",
+          },
+        } as never);
+        const fable = getModel("anthropic", "claude-fable-5");
+
+        expect(conversation.model_settings).toMatchObject({
+          provider_type: "anthropic",
+          effort: "medium",
+          context_window_limit: fable?.contextWindow,
+          max_tokens: fable?.maxTokens,
+        });
+        expect(
+          (conversation.model_settings as Record<string, unknown>)
+            .context_window_limit,
+        ).not.toBe(agent.llm_config?.context_window);
+      });
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -1520,11 +1520,13 @@ export class LocalStore {
     }
     this.ensureAgent(agentId);
     const conversationId = this.nextConversationId();
-    const conversation = createLocalConversationRecord(
-      conversationId,
-      agentId,
-      this.conversationSeq,
-      body,
+    const conversation = this.withConversationModelDefaults(
+      createLocalConversationRecord(
+        conversationId,
+        agentId,
+        this.conversationSeq,
+        body,
+      ),
     );
     const key = this.conversationKey(conversation.id, agentId);
     this.conversations.set(key, conversation);
@@ -1553,11 +1555,7 @@ export class LocalStore {
         body,
         currentIsoTimestamp(),
       );
-      const projected = this.applyConversationModelDefaults(
-        updated,
-        body,
-        created,
-      );
+      const projected = this.withConversationModelDefaults(updated);
       this.conversations.set(
         this.conversationKey(conversationId, created.agent_id),
         projected,
@@ -1565,10 +1563,8 @@ export class LocalStore {
       this.persistConversationState(conversationId, created.agent_id);
       return projected;
     }
-    const updated = this.applyConversationModelDefaults(
+    const updated = this.withConversationModelDefaults(
       updateLocalConversationRecord(current, body, currentIsoTimestamp()),
-      body,
-      current,
     );
     this.conversations.set(
       this.conversationKey(conversationId, current.agent_id),
@@ -1578,19 +1574,15 @@ export class LocalStore {
     return updated;
   }
 
-  private applyConversationModelDefaults(
+  private withConversationModelDefaults(
     conversation: StoredConversation,
-    body: ConversationUpdateBody,
-    previousConversation: StoredConversation,
   ): StoredConversation {
-    const requestedModel = (body as Record<string, unknown>).model;
+    const requestedModel = conversation.model;
     if (typeof requestedModel !== "string") return conversation;
     const normalizedRequestedModel = normalizeLocalModelHandle(
       requestedModel,
       isRecord(conversation.model_settings) ? conversation.model_settings : {},
     );
-    if (previousConversation.model === normalizedRequestedModel)
-      return conversation;
     const defaults = this.modelSettingsDefaultsForModel(
       normalizedRequestedModel,
     );
@@ -1600,9 +1592,10 @@ export class LocalStore {
       : {};
     return {
       ...conversation,
+      model: normalizedRequestedModel,
       model_settings: {
-        ...existingSettings,
         ...defaults,
+        ...existingSettings,
       },
     };
   }
@@ -3005,7 +2998,9 @@ export class LocalStore {
     const existing = this.conversations.get(key);
     if (existing && options.forceRefresh !== true) return existing;
 
-    const normalizedInput = normalizeStoredLocalModelRecord(input);
+    const normalizedInput = this.withConversationModelDefaults(
+      normalizeStoredLocalModelRecord(input),
+    );
     const timing = transcriptTimingForConversationDir(conversationDir);
     const requiresFullTimestampRepair =
       isSyntheticLocalTimestamp(normalizedInput.created_at) ||


### PR DESCRIPTION
## Summary
- apply local model-catalog defaults when conversation overrides are created, updated, or loaded
- keep explicit conversation settings authoritative over catalog defaults
- prevent a conversation model from inheriting an unrelated agent model context window
- add a regression test covering the Fable-on-GPT agent configuration from LET-9648

👾 Generated with [Letta Code](https://letta.com)