### PR TITLE
fix(local): preserve provider length stop reasons

### DIFF
--- a/src/backend/dev/provider-turn-executor.ts
+++ b/src/backend/dev/provider-turn-executor.ts
@@ -411,7 +411,9 @@ function createProviderLettaStream(
               stop_reason:
                 sawToolCall || part.reason === "toolUse"
                   ? "requires_approval"
-                  : "end_turn",
+                  : part.reason === "length"
+                    ? "max_tokens_exceeded"
+                    : "end_turn",
             } as LettaStreamingResponse;
             continue;
           }

--- a/src/backend/provider-turn-executor.test.ts
+++ b/src/backend/provider-turn-executor.test.ts
@@ -225,6 +225,28 @@ describe("ProviderTurnExecutor", () => {
     ).toBe("end_turn");
   });
 
+  test("maps pi length completions to max_tokens_exceeded", async () => {
+    const finalMessage = {
+      ...assistantMessage(),
+      content: [],
+      stopReason: "length" as const,
+    };
+    const adapter: ProviderStreamAdapter = {
+      async *stream() {
+        yield providerStreamPart(
+          part({ type: "done", reason: "length", message: finalMessage }),
+        );
+      },
+    };
+
+    const chunks = await collect(
+      await new ProviderTurnExecutor(adapter).execute(input()),
+    );
+    expect(
+      (chunks.at(-1) as { stop_reason?: string } | undefined)?.stop_reason,
+    ).toBe("max_tokens_exceeded");
+  });
+
   test("emits estimated context_tokens when provider usage is empty", async () => {
     const finalMessage = assistantMessage();
     const adapter: ProviderStreamAdapter = {


### PR DESCRIPTION
## Summary
- map Pi length completions to max_tokens_exceeded instead of end_turn
- preserve tool-call precedence for approval stops
- match both Letta agent-loop runtimes and surface truncated local responses instead of silent empty turns
- add a regression test for the empty length completion observed in LET-9648

👾 Generated with [Letta Code](https://letta.com)