### PR TITLE
fix: preserve image policy across turn retries [LET-9618]

### DIFF
--- a/src/websocket/listener/continuation-input.test.ts
+++ b/src/websocket/listener/continuation-input.test.ts
@@ -5,13 +5,15 @@ describe("queued continuation input", () => {
   test("appends queued channel images with their best-effort failure policy", () => {
     const queuedOtid = "cm-queued-channel-image";
     const result = appendQueuedTurnToInput(
-      [
-        {
-          type: "approval",
-          approvals: [],
-          otid: "approval-1",
-        },
-      ],
+      {
+        messages: [
+          {
+            type: "approval",
+            approvals: [],
+            otid: "approval-1",
+          },
+        ],
+      },
       {
         type: "message",
         agentId: "agent-1",
@@ -45,8 +47,8 @@ describe("queued continuation input", () => {
       },
     );
 
-    expect(result.input).toHaveLength(2);
-    expect(result.input[1]).toMatchObject({
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[1]).toMatchObject({
       role: "user",
       otid: queuedOtid,
     });
@@ -56,18 +58,21 @@ describe("queued continuation input", () => {
   });
 
   test("keeps interactive queued input strict by default", () => {
-    const result = appendQueuedTurnToInput([], {
-      type: "message",
-      agentId: "agent-1",
-      conversationId: "conv-1",
-      messages: [
-        {
-          role: "user",
-          content: "queued follow-up",
-          otid: "cm-interactive",
-        },
-      ],
-    });
+    const result = appendQueuedTurnToInput(
+      { messages: [] },
+      {
+        type: "message",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+        messages: [
+          {
+            role: "user",
+            content: "queued follow-up",
+            otid: "cm-interactive",
+          },
+        ],
+      },
+    );
 
     expect(result.imageFailureModesByMessageOtid).toBeUndefined();
   });

--- a/src/websocket/listener/continuation-input.ts
+++ b/src/websocket/listener/continuation-input.ts
@@ -1,18 +1,17 @@
-import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
-import type { ApprovalCreate } from "@letta-ai/letta-client/resources/agents/messages";
-import type { ImageFailureModesByMessageOtid } from "@/utils/message-image-normalization";
+import { mergeImageFailureModesByMessageOtid } from "@/utils/message-image-normalization";
 import { getInboundImageFailureModes } from "./image-policy";
+import { createTurnInputState, type TurnInputState } from "./turn-input-state";
 import type { IncomingMessage } from "./types";
 
 export function appendQueuedTurnToInput(
-  input: Array<MessageCreate | ApprovalCreate>,
+  state: TurnInputState,
   queuedTurn: IncomingMessage,
-): {
-  input: Array<MessageCreate | ApprovalCreate>;
-  imageFailureModesByMessageOtid?: ImageFailureModesByMessageOtid;
-} {
-  return {
-    input: [...input, ...queuedTurn.messages],
-    imageFailureModesByMessageOtid: getInboundImageFailureModes(queuedTurn),
-  };
+): TurnInputState {
+  return createTurnInputState(
+    [...state.messages, ...queuedTurn.messages],
+    mergeImageFailureModesByMessageOtid(
+      state.imageFailureModesByMessageOtid,
+      getInboundImageFailureModes(queuedTurn),
+    ),
+  );
 }

--- a/src/websocket/listener/recovery.ts
+++ b/src/websocket/listener/recovery.ts
@@ -1,10 +1,6 @@
 import { APIError } from "@letta-ai/letta-client/core/error";
 import type { Stream } from "@letta-ai/letta-client/core/streaming";
-import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
-import type {
-  ApprovalCreate,
-  LettaStreamingResponse,
-} from "@letta-ai/letta-client/resources/agents/messages";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import {
   type ApprovalDecision,
   executeApprovalBatch,
@@ -71,6 +67,7 @@ import {
 } from "./runtime";
 import { ensureSecretsHydratedForAgent } from "./secrets-sync";
 import type { ListenerTransport } from "./transport";
+import { createTurnInputState } from "./turn-input-state";
 import type { TurnLease } from "./turn-lifecycle";
 import { setTurnLoopStatus } from "./turn-status";
 import { finishListenerTurn } from "./turn-terminal";
@@ -831,23 +828,23 @@ export async function resolveRecoveredApprovalResponse(
     }
     emitRuntimeStateUpdates(runtime, scope);
 
-    let continuationMessages: Array<MessageCreate | ApprovalCreate> = [
+    let continuationInput = createTurnInputState([
       {
         type: "approval",
         approvals: approvalResults,
         otid: crypto.randomUUID(),
       },
-    ];
+    ]);
     let continuationBatchId = `batch-recovered-${crypto.randomUUID()}`;
     let queuedChannelTurnSources: ChannelTurnSource[] | undefined;
     const consumedQueuedTurn = consumeQueuedTurn(runtime);
     if (consumedQueuedTurn) {
       const { dequeuedBatch, queuedTurn } = consumedQueuedTurn;
       continuationBatchId = dequeuedBatch.batchId;
-      continuationMessages = appendQueuedTurnToInput(
-        continuationMessages,
+      continuationInput = appendQueuedTurnToInput(
+        continuationInput,
         queuedTurn,
-      ).input;
+      );
       queuedChannelTurnSources = queuedTurn.channelTurnSources;
       emitDequeuedUserMessage(socket, runtime, queuedTurn, dequeuedBatch);
     }
@@ -861,7 +858,7 @@ export async function resolveRecoveredApprovalResponse(
         type: "message",
         agentId: recovered.agentId,
         conversationId: recovered.conversationId,
-        messages: continuationMessages,
+        messages: continuationInput.messages,
         ...(queuedChannelTurnSources?.length
           ? { channelTurnSources: queuedChannelTurnSources }
           : {}),

--- a/src/websocket/listener/send.ts
+++ b/src/websocket/listener/send.ts
@@ -20,7 +20,6 @@ import {
 import { type ConversationMessageStreamBody, getBackend } from "@/backend";
 import { getRetryStatusMessage } from "@/cli/helpers/error-formatter";
 import { prepareToolExecutionContextForScope } from "@/tools/toolset";
-import type { ImageFailureModesByMessageOtid } from "@/utils/message-image-normalization";
 import { createStreamAbortRelay } from "@/utils/stream-abort-relay";
 import {
   rememberPendingApprovalBatchIds,
@@ -48,6 +47,7 @@ import {
 } from "./recovery";
 import { injectQueuedSkillContent } from "./skill-injection";
 import type { ListenerTransport } from "./transport";
+import { createTurnInputState } from "./turn-input-state";
 import type { TurnLease } from "./turn-lifecycle";
 import { setTurnLoopStatus } from "./turn-status";
 import type { ConversationRuntime } from "./types";
@@ -385,28 +385,26 @@ export async function resolveStaleApprovals(
     }
 
     try {
-      let continuationMessages: Array<MessageCreate | ApprovalCreate> = [
+      let continuationInput = createTurnInputState([
         {
           type: "approval",
           approvals: approvalResults,
           otid: crypto.randomUUID(),
         },
-      ];
-      let queuedImageFailureModes: ImageFailureModesByMessageOtid | undefined;
+      ]);
       const consumedQueuedTurn = consumeQueuedTurn(runtime);
       if (consumedQueuedTurn) {
         const { dequeuedBatch, queuedTurn } = consumedQueuedTurn;
-        const appended = appendQueuedTurnToInput(
-          continuationMessages,
+        continuationInput = appendQueuedTurnToInput(
+          continuationInput,
           queuedTurn,
         );
-        continuationMessages = appended.input;
-        queuedImageFailureModes = appended.imageFailureModesByMessageOtid;
         emitDequeuedUserMessage(socket, runtime, queuedTurn, dequeuedBatch);
       }
 
-      const continuationMessagesWithSkillContent =
-        injectQueuedSkillContent(continuationMessages);
+      const continuationMessagesWithSkillContent = injectQueuedSkillContent(
+        continuationInput.messages,
+      );
       const recoverySendResult = await sendApprovalContinuationWithRetry(
         recoveryConversationId,
         continuationMessagesWithSkillContent,
@@ -416,8 +414,11 @@ export async function resolveStaleApprovals(
           background: true,
           workingDirectory: recoveryWorkingDirectory,
           preparedToolContext: preparedToolContext.preparedToolContext,
-          ...(queuedImageFailureModes
-            ? { imageFailureModesByMessageOtid: queuedImageFailureModes }
+          ...(continuationInput.imageFailureModesByMessageOtid
+            ? {
+                imageFailureModesByMessageOtid:
+                  continuationInput.imageFailureModesByMessageOtid,
+              }
             : {}),
         },
         socket,

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -1,9 +1,5 @@
 import type { Stream } from "@letta-ai/letta-client/core/streaming";
-import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
-import type {
-  ApprovalCreate,
-  LettaStreamingResponse,
-} from "@letta-ai/letta-client/resources/agents/messages";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import {
   type ApprovalResult,
   executeApprovalBatch,
@@ -21,10 +17,7 @@ import type {
   ApprovalResponseDecision,
   ControlRequest,
 } from "@/types/protocol_v2";
-import {
-  type ImageFailureModesByMessageOtid,
-  mergeImageFailureModesByMessageOtid,
-} from "@/utils/message-image-normalization";
+import { mergeImageFailureModesByMessageOtid } from "@/utils/message-image-normalization";
 import {
   clearPendingApprovalBatchIds,
   collectApprovalResultToolCallIds,
@@ -62,6 +55,11 @@ import {
 } from "./send";
 import { injectQueuedSkillContent } from "./skill-injection";
 import { isListenerTransportOpen, type ListenerTransport } from "./transport";
+import {
+  createTurnInputState,
+  type TurnInputState,
+  updateTurnInputMessagesPreservingOtids,
+} from "./turn-input-state";
 import type { TurnLease } from "./turn-lifecycle";
 import { setTurnLoopStatus } from "./turn-status";
 import type { ConversationRuntime } from "./types";
@@ -87,7 +85,7 @@ type Decision =
     };
 
 type ApprovalBranchProgress = {
-  currentInput: Array<MessageCreate | ApprovalCreate>;
+  turnInput: TurnInputState;
   dequeuedBatchId: string;
   pendingNormalizationInterruptedToolCallIds: string[];
   turnToolContextId: string | null;
@@ -156,7 +154,7 @@ export async function handleApprovalStop(params: {
   dequeuedBatchId: string;
   runId?: string;
   msgRunIds: string[];
-  currentInput: Array<MessageCreate | ApprovalCreate>;
+  turnInput: TurnInputState;
   pendingNormalizationInterruptedToolCallIds: string[];
   turnToolContextId: string | null;
   turnLease: TurnLease;
@@ -181,7 +179,7 @@ export async function handleApprovalStop(params: {
     dequeuedBatchId,
     runId,
     msgRunIds,
-    currentInput,
+    turnInput,
     turnToolContextId,
     turnLease,
     buildSendOptions,
@@ -232,12 +230,12 @@ export async function handleApprovalStop(params: {
     abortSignal.aborted || !runtime.turnLifecycle.isCurrent(turnLease);
 
   const interruptTermination = (
-    interruptedInput: Array<MessageCreate | ApprovalCreate> = currentInput,
+    interruptedTurnInput: TurnInputState = turnInput,
     interruptedBatchId: string = dequeuedBatchId,
   ): ApprovalBranchResult => {
     return {
       kind: "interrupted",
-      currentInput: interruptedInput,
+      turnInput: interruptedTurnInput,
       dequeuedBatchId: interruptedBatchId,
       pendingNormalizationInterruptedToolCallIds: [],
       turnToolContextId,
@@ -560,29 +558,32 @@ export async function handleApprovalStop(params: {
     return interruptTermination();
   }
 
-  let nextInput: Array<MessageCreate | ApprovalCreate> = [
+  let nextTurnInput = createTurnInputState([
     {
       type: "approval",
       approvals: persistedExecutionResults,
       otid: crypto.randomUUID(),
     },
-  ];
+  ]);
   let continuationBatchId = dequeuedBatchId;
-  let queuedImageFailureModes: ImageFailureModesByMessageOtid | undefined;
   const consumedQueuedTurn = consumeQueuedTurn(runtime);
   if (consumedQueuedTurn) {
     const { dequeuedBatch, queuedTurn } = consumedQueuedTurn;
     continuationBatchId = dequeuedBatch.batchId;
-    const appended = appendQueuedTurnToInput(nextInput, queuedTurn);
-    nextInput = appended.input;
-    queuedImageFailureModes = appended.imageFailureModesByMessageOtid;
+    nextTurnInput = appendQueuedTurnToInput(nextTurnInput, queuedTurn);
     emitDequeuedUserMessage(socket, runtime, queuedTurn, dequeuedBatch);
   }
 
-  const nextInputWithSkillContent = injectQueuedSkillContent(nextInput);
+  const nextInputWithSkillContent = injectQueuedSkillContent(
+    nextTurnInput.messages,
+  );
+  nextTurnInput = updateTurnInputMessagesPreservingOtids(
+    nextTurnInput,
+    nextInputWithSkillContent,
+  );
 
   if (shouldInterrupt()) {
-    return interruptTermination(nextInputWithSkillContent, continuationBatchId);
+    return interruptTermination(nextTurnInput, continuationBatchId);
   }
 
   setTurnLoopStatus(runtime, turnLease, "SENDING_API_REQUEST", {
@@ -594,7 +595,7 @@ export async function handleApprovalStop(params: {
     const sendOptions = buildSendOptions() ?? {};
     const imageFailureModesByMessageOtid = mergeImageFailureModesByMessageOtid(
       sendOptions.imageFailureModesByMessageOtid,
-      queuedImageFailureModes,
+      nextTurnInput.imageFailureModesByMessageOtid,
     );
     sendResult = await sendApprovalContinuationWithRetry(
       conversationId,
@@ -615,10 +616,7 @@ export async function handleApprovalStop(params: {
     );
   } catch (error) {
     if (shouldInterrupt()) {
-      return interruptTermination(
-        nextInputWithSkillContent,
-        continuationBatchId,
-      );
+      return interruptTermination(nextTurnInput, continuationBatchId);
     }
     throw error;
   }
@@ -626,7 +624,7 @@ export async function handleApprovalStop(params: {
     return {
       kind: "terminal",
       drainResult: sendResult.drainResult,
-      currentInput: nextInputWithSkillContent,
+      turnInput: nextTurnInput,
       dequeuedBatchId: continuationBatchId,
       pendingNormalizationInterruptedToolCallIds: [],
       turnToolContextId,
@@ -656,7 +654,11 @@ export async function handleApprovalStop(params: {
       persistedExecutionResults,
     ),
   });
-  markAwaitingAcceptedApprovalContinuationRunId(runtime, turnLease, nextInput);
+  markAwaitingAcceptedApprovalContinuationRunId(
+    runtime,
+    turnLease,
+    nextTurnInput.messages,
+  );
   setTurnLoopStatus(runtime, turnLease, "PROCESSING_API_RESPONSE", {
     agent_id: agentId,
     conversation_id: conversationId,
@@ -671,7 +673,7 @@ export async function handleApprovalStop(params: {
   return {
     kind: "continue",
     stream,
-    currentInput: nextInputWithSkillContent,
+    turnInput: nextTurnInput,
     dequeuedBatchId: continuationBatchId,
     pendingNormalizationInterruptedToolCallIds: [],
     turnToolContextId: null,

--- a/src/websocket/listener/turn-input-state.test.ts
+++ b/src/websocket/listener/turn-input-state.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeMessageImageParts } from "@/utils/message-image-normalization";
+import {
+  createTurnInputState,
+  ensureTurnInputMessageOtids,
+  rebuildTurnInputWithFreshDenials,
+  refreshTurnInputOtidsForNewRequest,
+} from "./turn-input-state";
+
+describe("listener turn input state", () => {
+  test("assigns identities to messages introduced by turn transforms", () => {
+    const messages = ensureTurnInputMessageOtids([
+      {
+        role: "user",
+        content: "mod-introduced channel message",
+      },
+    ]);
+
+    expect(messages[0]?.otid).toBeString();
+  });
+
+  test("moves image failure policy to refreshed message OTIDs", () => {
+    const state = refreshTurnInputOtidsForNewRequest(
+      createTurnInputState(
+        [
+          {
+            role: "user",
+            content: "channel attachment",
+            otid: "original-channel-otid",
+          },
+        ],
+        { "original-channel-otid": "drop" },
+      ),
+    );
+
+    const refreshedOtid = state.messages[0]?.otid;
+    expect(refreshedOtid).toBeString();
+    expect(refreshedOtid).not.toBe("original-channel-otid");
+    expect(state.imageFailureModesByMessageOtid).toEqual({
+      [refreshedOtid as string]: "drop",
+    });
+  });
+
+  test("keeps channel image preparation best-effort after an OTID refresh", async () => {
+    const state = refreshTurnInputOtidsForNewRequest(
+      createTurnInputState(
+        [
+          {
+            role: "user",
+            content: [
+              {
+                type: "image",
+                source: {
+                  type: "base64",
+                  media_type: "image/png",
+                  data: "not-an-image",
+                },
+              },
+            ],
+            otid: "original-channel-otid",
+          },
+        ],
+        { "original-channel-otid": "drop" },
+      ),
+    );
+
+    const normalized = await normalizeMessageImageParts(state.messages, {
+      failureModesByMessageOtid: state.imageFailureModesByMessageOtid,
+      resize: async () => {
+        throw new Error("unsupported image");
+      },
+    });
+
+    expect(normalized[0]).toMatchObject({ content: [] });
+  });
+
+  test("preserves message policy while replacing stale approvals", () => {
+    const state = rebuildTurnInputWithFreshDenials(
+      createTurnInputState(
+        [
+          {
+            type: "approval",
+            approvals: [],
+            otid: "stale-approval-otid",
+          },
+          {
+            role: "user",
+            content: "queued channel attachment",
+            otid: "original-channel-otid",
+          },
+        ],
+        { "original-channel-otid": "drop" },
+      ),
+      [
+        {
+          toolCallId: "tool-call-1",
+          toolName: "Bash",
+          toolArgs: '{"command":"pwd"}',
+        },
+      ],
+      "stale approval",
+    );
+
+    expect(state.messages).toHaveLength(2);
+    expect(state.messages[0]).toMatchObject({ type: "approval" });
+    const refreshedOtid = state.messages[1]?.otid;
+    expect(refreshedOtid).toBeString();
+    expect(refreshedOtid).not.toBe("original-channel-otid");
+    expect(state.imageFailureModesByMessageOtid).toEqual({
+      [refreshedOtid as string]: "drop",
+    });
+  });
+});

--- a/src/websocket/listener/turn-input-state.ts
+++ b/src/websocket/listener/turn-input-state.ts
@@ -1,0 +1,143 @@
+import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
+import type { ApprovalCreate } from "@letta-ai/letta-client/resources/agents/messages";
+import {
+  type PendingApprovalInfo,
+  rebuildInputWithFreshDenials,
+  refreshInputOtidsForNewRequest,
+} from "@/agent/turn-recovery-policy";
+import type { ImageFailureModesByMessageOtid } from "@/utils/message-image-normalization";
+
+export type TurnInputState = {
+  messages: Array<MessageCreate | ApprovalCreate>;
+  imageFailureModesByMessageOtid?: ImageFailureModesByMessageOtid;
+};
+
+export function ensureTurnInputMessageOtids(
+  messages: Array<MessageCreate | ApprovalCreate>,
+): Array<MessageCreate | ApprovalCreate> {
+  let didChange = false;
+  const messagesWithOtids = messages.map((message) => {
+    if (!("content" in message) || message.otid) {
+      return message;
+    }
+
+    didChange = true;
+    return {
+      ...message,
+      // Reconcile optimistic transcript rows with the canonical echo.
+      otid:
+        "client_message_id" in message &&
+        typeof message.client_message_id === "string"
+          ? message.client_message_id
+          : crypto.randomUUID(),
+    };
+  });
+
+  return didChange ? messagesWithOtids : messages;
+}
+
+export function createTurnInputState(
+  messages: Array<MessageCreate | ApprovalCreate>,
+  imageFailureModesByMessageOtid?: ImageFailureModesByMessageOtid,
+): TurnInputState {
+  return {
+    messages,
+    ...(imageFailureModesByMessageOtid
+      ? { imageFailureModesByMessageOtid }
+      : {}),
+  };
+}
+
+export function updateTurnInputMessagesPreservingOtids(
+  state: TurnInputState,
+  messages: Array<MessageCreate | ApprovalCreate>,
+): TurnInputState {
+  if (state.imageFailureModesByMessageOtid) {
+    const nextOtids = new Set(messages.map((message) => message.otid));
+    for (const otid of Object.keys(state.imageFailureModesByMessageOtid)) {
+      if (!nextOtids.has(otid)) {
+        throw new Error(
+          `Cannot preserve image failure policy for missing message OTID: ${otid}`,
+        );
+      }
+    }
+  }
+  return createTurnInputState(messages, state.imageFailureModesByMessageOtid);
+}
+
+export function refreshTurnInputOtidsForNewRequest(
+  state: TurnInputState,
+): TurnInputState {
+  const refreshedMessages = refreshInputOtidsForNewRequest(state.messages);
+  return createTurnInputState(
+    refreshedMessages,
+    remapImageFailureModesByPosition(
+      state.messages,
+      refreshedMessages,
+      state.imageFailureModesByMessageOtid,
+    ),
+  );
+}
+
+export function rebuildTurnInputWithFreshDenials(
+  state: TurnInputState,
+  serverApprovals: PendingApprovalInfo[],
+  denialReason: string,
+): TurnInputState {
+  const rebuiltMessages = rebuildInputWithFreshDenials(
+    state.messages,
+    serverApprovals,
+    denialReason,
+  );
+  return createTurnInputState(
+    rebuiltMessages,
+    remapImageFailureModesByPosition(
+      getContentMessages(state.messages),
+      getContentMessages(rebuiltMessages),
+      state.imageFailureModesByMessageOtid,
+    ),
+  );
+}
+
+function getContentMessages(
+  messages: Array<MessageCreate | ApprovalCreate>,
+): MessageCreate[] {
+  return messages.filter(
+    (message): message is MessageCreate => "content" in message,
+  );
+}
+
+function remapImageFailureModesByPosition(
+  previousMessages: Array<MessageCreate | ApprovalCreate>,
+  nextMessages: Array<MessageCreate | ApprovalCreate>,
+  previousModes?: ImageFailureModesByMessageOtid,
+): ImageFailureModesByMessageOtid | undefined {
+  if (!previousModes) {
+    return undefined;
+  }
+  if (previousMessages.length !== nextMessages.length) {
+    throw new Error(
+      "Cannot remap image failure policy across non-corresponding message lists",
+    );
+  }
+
+  const remappedEntries: Array<
+    [string, ImageFailureModesByMessageOtid[string]]
+  > = [];
+  for (const [index, previousMessage] of previousMessages.entries()) {
+    const nextMessage = nextMessages[index];
+    const previousOtid = previousMessage?.otid;
+    const nextOtid = nextMessage?.otid;
+    if (typeof previousOtid !== "string" || typeof nextOtid !== "string") {
+      continue;
+    }
+    const previousMode = previousModes[previousOtid];
+    if (previousMode) {
+      remappedEntries.push([nextOtid, previousMode]);
+    }
+  }
+
+  return remappedEntries.length > 0
+    ? Object.fromEntries(remappedEntries)
+    : undefined;
+}

--- a/src/websocket/listener/turn-lifecycle-integration.test.ts
+++ b/src/websocket/listener/turn-lifecycle-integration.test.ts
@@ -74,7 +74,7 @@ function startQuestionApproval(
     ),
     dequeuedBatchId: "batch-1",
     msgRunIds: [],
-    currentInput: [],
+    turnInput: { messages: [] },
     pendingNormalizationInterruptedToolCallIds: [],
     turnToolContextId: null,
     turnLease,

--- a/src/websocket/listener/turn-setup.ts
+++ b/src/websocket/listener/turn-setup.ts
@@ -18,13 +18,17 @@ import { buildListenReminderContext } from "@/reminders/listen-context";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
 import { prepareToolExecutionContextForScope } from "@/tools/toolset";
 import { debugWarn, isDebugEnabled } from "@/utils/debug";
-import type { ImageFailureModesByMessageOtid } from "@/utils/message-image-normalization";
 import { detectShellContext } from "@/utils/shell-context";
 import { getInboundImageFailureModes } from "./image-policy";
 import { consumeInterruptQueue } from "./interrupts";
 import { ensureListenerModAdapter } from "./mod-adapter";
 import type { ConversationPermissionModeState } from "./permission-mode";
 import { emitListenerTurnStart } from "./turn-events";
+import {
+  createTurnInputState,
+  ensureTurnInputMessageOtids,
+  type TurnInputState,
+} from "./turn-input-state";
 import type { TurnLease } from "./turn-lifecycle";
 import {
   buildInboundUserTranscriptLines,
@@ -47,8 +51,7 @@ export type ListenerTurnSetupResult =
   | {
       kind: "ready";
       getCachedAgent: () => AgentState | null;
-      currentInput: Array<MessageCreate | ApprovalCreate>;
-      imageFailureModesByMessageOtid?: ImageFailureModesByMessageOtid;
+      turnInput: TurnInputState;
       inboundUserTranscriptLines: Line[];
       pendingNormalizationInterruptedToolCallIds: string[];
       preparedToolContext: PreparedToolContext;
@@ -111,26 +114,7 @@ export async function prepareListenerTurn(params: {
     messagesToSend.push(consumed.approvalMessage);
     queuedInterruptedToolCallIds = consumed.interruptedToolCallIds;
   }
-  messagesToSend.push(
-    ...msg.messages.map((message) =>
-      "content" in message && !message.otid
-        ? {
-            ...message,
-            // Reconcile optimistic transcript rows with the canonical echo.
-            otid:
-              "client_message_id" in message &&
-              typeof message.client_message_id === "string"
-                ? message.client_message_id
-                : crypto.randomUUID(),
-          }
-        : message,
-    ),
-  );
-
-  const imageFailureModesByMessageOtid = getInboundImageFailureModes({
-    channelTurnSources: msg.channelTurnSources,
-    messages: messagesToSend,
-  });
+  messagesToSend.push(...ensureTurnInputMessageOtids(msg.messages));
 
   let inboundUserTranscriptLines =
     buildInboundUserTranscriptLines(messagesToSend);
@@ -252,7 +236,14 @@ export async function prepareListenerTurn(params: {
     return { kind: "cancelled", reason: turnStartEmission.reason };
   }
 
-  const currentInput = turnStartEmission.input;
+  const currentInput = ensureTurnInputMessageOtids(turnStartEmission.input);
+  const turnInput = createTurnInputState(
+    currentInput,
+    getInboundImageFailureModes({
+      channelTurnSources: msg.channelTurnSources,
+      messages: currentInput,
+    }),
+  );
   if (currentInput !== messagesToSend) {
     inboundUserTranscriptLines = buildInboundUserTranscriptLines(currentInput);
   }
@@ -278,8 +269,7 @@ export async function prepareListenerTurn(params: {
   return {
     kind: "ready",
     getCachedAgent: () => cachedAgent,
-    currentInput,
-    imageFailureModesByMessageOtid,
+    turnInput,
     inboundUserTranscriptLines,
     pendingNormalizationInterruptedToolCallIds: [
       ...queuedInterruptedToolCallIds,

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -11,8 +11,6 @@ import {
   getRetryDelayMs,
   isEmptyResponseRetryable,
   normalizeStreamErrorTypeToStopReason,
-  rebuildInputWithFreshDenials,
-  refreshInputOtidsForNewRequest,
 } from "@/agent/turn-recovery-policy";
 import { getBackend } from "@/backend";
 import {
@@ -74,6 +72,11 @@ import { handleApprovalStop } from "./turn-approval";
 import { runListenerTurnCleanup } from "./turn-cleanup";
 import { completeSuccessfulListenerTurn } from "./turn-completion";
 import { releaseListenerTurnContext } from "./turn-context";
+import {
+  rebuildTurnInputWithFreshDenials,
+  refreshTurnInputOtidsForNewRequest,
+  updateTurnInputMessagesPreservingOtids,
+} from "./turn-input-state";
 import type { TurnLease } from "./turn-lifecycle";
 import { createTurnInputSender } from "./turn-send";
 import { prepareListenerTurn } from "./turn-setup";
@@ -232,7 +235,7 @@ export async function handleIncomingMessage(
       runtime.lastTerminalLoopErrorMessage = formattedError ?? setup.reason;
       return;
     }
-    let currentInput = setup.currentInput;
+    let turnInput = setup.turnInput;
     const inboundUserTranscriptLines = setup.inboundUserTranscriptLines;
     const providerFallback = createProviderFallbackState(
       setup.getCachedAgent(),
@@ -247,10 +250,10 @@ export async function handleIncomingMessage(
       workingDirectory: turnWorkingDirectory,
       permissionModeState: turnPermissionModeState,
       preparedToolContext: preparedToolContext.preparedToolContext,
-      ...(setup.imageFailureModesByMessageOtid
+      ...(turnInput.imageFailureModesByMessageOtid
         ? {
             imageFailureModesByMessageOtid:
-              setup.imageFailureModesByMessageOtid,
+              turnInput.imageFailureModesByMessageOtid,
           }
         : {}),
       ...(providerFallback.overrideModel
@@ -278,11 +281,16 @@ export async function handleIncomingMessage(
       onTerminal: noteFinalization,
     });
 
-    const currentInputWithSkillContent = injectQueuedSkillContent(currentInput);
+    const currentInputWithSkillContent = injectQueuedSkillContent(
+      turnInput.messages,
+    );
     const initialSendResult = await turnInputSender.send(
       currentInputWithSkillContent,
     );
-    currentInput = currentInputWithSkillContent;
+    turnInput = updateTurnInputMessagesPreservingOtids(
+      turnInput,
+      currentInputWithSkillContent,
+    );
     const initialStream = turnInputSender.accept(initialSendResult);
     if (!initialStream) {
       return;
@@ -292,7 +300,7 @@ export async function handleIncomingMessage(
     markAwaitingAcceptedApprovalContinuationRunId(
       runtime,
       turnLease,
-      currentInput,
+      turnInput.messages,
     );
     setTurnLoopStatus(runtime, turnLease, "PROCESSING_API_RESPONSE", {
       agent_id: agentId,
@@ -491,13 +499,13 @@ export async function handleIncomingMessage(
             const agent = await getBackend().retrieveAgent(agentId || "");
             const { pendingApprovals: existingApprovals } =
               await getResumeDataFromBackend(agent, requestedConversationId);
-            currentInput = rebuildInputWithFreshDenials(
-              currentInput,
+            turnInput = rebuildTurnInputWithFreshDenials(
+              turnInput,
               existingApprovals ?? [],
               "Auto-denied: stale approval from interrupted session",
             );
           } catch {
-            currentInput = rebuildInputWithFreshDenials(currentInput, [], "");
+            turnInput = rebuildTurnInputWithFreshDenials(turnInput, [], "");
           }
           if (finishIfInterrupted(lastRunId || runtime.activeRunId)) {
             break;
@@ -507,12 +515,16 @@ export async function handleIncomingMessage(
             agent_id: agentId,
             conversation_id: conversationId,
           });
-          const retryInputWithSkillContent =
-            injectQueuedSkillContent(currentInput);
+          const retryInputWithSkillContent = injectQueuedSkillContent(
+            turnInput.messages,
+          );
           const retrySendResult = await turnInputSender.send(
             retryInputWithSkillContent,
           );
-          currentInput = retryInputWithSkillContent;
+          turnInput = updateTurnInputMessagesPreservingOtids(
+            turnInput,
+            retryInputWithSkillContent,
+          );
           const retryStream = turnInputSender.accept(retrySendResult);
           if (!retryStream) {
             return;
@@ -522,7 +534,7 @@ export async function handleIncomingMessage(
           markAwaitingAcceptedApprovalContinuationRunId(
             runtime,
             turnLease,
-            currentInput,
+            turnInput.messages,
           );
           setTurnLoopStatus(runtime, turnLease, "PROCESSING_API_RESPONSE", {
             agent_id: agentId,
@@ -550,15 +562,15 @@ export async function handleIncomingMessage(
           });
 
           if (attempt >= EMPTY_RESPONSE_MAX_RETRIES) {
-            currentInput = [
-              ...currentInput,
+            turnInput = updateTurnInputMessagesPreservingOtids(turnInput, [
+              ...turnInput.messages,
               {
                 type: "message" as const,
                 role: "system" as const,
                 content:
                   "<system-reminder>The previous response was empty. Please provide a response with either text content or a tool call.</system-reminder>",
               },
-            ];
+            ]);
           }
 
           emitRetryDelta(socket, runtime, {
@@ -576,18 +588,22 @@ export async function handleIncomingMessage(
           if (turnAbortSignal.aborted) {
             throw new Error("Cancelled by user");
           }
-          currentInput = refreshInputOtidsForNewRequest(currentInput);
+          turnInput = refreshTurnInputOtidsForNewRequest(turnInput);
 
           setTurnLoopStatus(runtime, turnLease, "SENDING_API_REQUEST", {
             agent_id: agentId,
             conversation_id: conversationId,
           });
-          const retryInputWithSkillContent =
-            injectQueuedSkillContent(currentInput);
+          const retryInputWithSkillContent = injectQueuedSkillContent(
+            turnInput.messages,
+          );
           const retrySendResult = await turnInputSender.send(
             retryInputWithSkillContent,
           );
-          currentInput = retryInputWithSkillContent;
+          turnInput = updateTurnInputMessagesPreservingOtids(
+            turnInput,
+            retryInputWithSkillContent,
+          );
           const retryStream = turnInputSender.accept(retrySendResult);
           if (!retryStream) {
             return;
@@ -597,7 +613,7 @@ export async function handleIncomingMessage(
           markAwaitingAcceptedApprovalContinuationRunId(
             runtime,
             turnLease,
-            currentInput,
+            turnInput.messages,
           );
           setTurnLoopStatus(runtime, turnLease, "PROCESSING_API_RESPONSE", {
             agent_id: agentId,
@@ -653,18 +669,22 @@ export async function handleIncomingMessage(
           if (turnAbortSignal.aborted) {
             throw new Error("Cancelled by user");
           }
-          currentInput = refreshInputOtidsForNewRequest(currentInput);
+          turnInput = refreshTurnInputOtidsForNewRequest(turnInput);
 
           setTurnLoopStatus(runtime, turnLease, "SENDING_API_REQUEST", {
             agent_id: agentId,
             conversation_id: conversationId,
           });
-          const retryInputWithSkillContent =
-            injectQueuedSkillContent(currentInput);
+          const retryInputWithSkillContent = injectQueuedSkillContent(
+            turnInput.messages,
+          );
           const retrySendResult = await turnInputSender.send(
             retryInputWithSkillContent,
           );
-          currentInput = retryInputWithSkillContent;
+          turnInput = updateTurnInputMessagesPreservingOtids(
+            turnInput,
+            retryInputWithSkillContent,
+          );
           const retryStream = turnInputSender.accept(retrySendResult);
           if (!retryStream) {
             return;
@@ -674,7 +694,7 @@ export async function handleIncomingMessage(
           markAwaitingAcceptedApprovalContinuationRunId(
             runtime,
             turnLease,
-            currentInput,
+            turnInput.messages,
           );
           setTurnLoopStatus(runtime, turnLease, "PROCESSING_API_RESPONSE", {
             agent_id: agentId,
@@ -741,7 +761,7 @@ export async function handleIncomingMessage(
         dequeuedBatchId: activeDequeuedBatchId,
         runId,
         msgRunIds,
-        currentInput,
+        turnInput,
         pendingNormalizationInterruptedToolCallIds,
         turnToolContextId,
         turnLease,
@@ -773,7 +793,7 @@ export async function handleIncomingMessage(
         return;
       }
 
-      currentInput = approvalResult.currentInput;
+      turnInput = approvalResult.turnInput;
       activeDequeuedBatchId = approvalResult.dequeuedBatchId;
       pendingNormalizationInterruptedToolCallIds =
         approvalResult.pendingNormalizationInterruptedToolCallIds;


### PR DESCRIPTION
## Summary

- make listener turn messages and per-message image failure policy travel together as `TurnInputState`
- remap channel `drop` policy whenever retry/recovery refreshes message OTIDs
- preserve policy through stale-approval denial rebuilds and queued approval continuations
- assign OTIDs after `turn_start` transforms before deriving channel policy
- use the same state abstraction in live, pre-stream recovery, and recovered-approval paths

## Context

A fresh-context review of #3357 found that post-stop retry/recovery regenerated message OTIDs while reusing a policy map keyed by the previous OTIDs. An invalid channel image was dropped on the first request, then became strict on retry and could abort empty-response/provider recovery. The same lifetime issue affected queued channel messages appended to approval continuations.

This follow-up keeps policy provenance coupled to the current input and makes OTID-preserving versus OTID-replacing transformations explicit. Normalization itself remains centralized at the backend send boundary from #3357.

## Independent review

The reviewer reproduced the original failure, then re-reviewed this remediation from a separate context and reported no findings. It verified initial `turn_start` replacement, empty/provider retry, stale-denial rebuild, queued approval continuation, pre-stream recovery, and recovered-approval paths.

## Verification

- `bun run check` (12/12 checks pass)
- 58 reviewer-focused tests plus direct corrupt-image probes
- regression tests cover post-transform OTID assignment, policy remapping on retry, corrupt-image drop after refresh, and stale-denial rebuilds

Fixes follow-up for LET-9618.

Linear: https://linear.app/letta/issue/LET-9618/gpt-fable-size-error