### PR TITLE
fix(telemetry): aggregate repetitive operational events

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -38,7 +38,7 @@
   "src/settings-manager.ts": 2113,
   "src/tools/impl/enter-worktree.ts": 1260,
   "src/tools/impl/message-channel.ts": 1187,
-  "src/tools/manager.ts": 3293,
+  "src/tools/manager.ts": 3280,
   "src/tools/tool-execution-context.test.ts": 1422,
   "src/types/protocol_v2.ts": 2940,
   "src/websocket/listen-client-concurrency.test.ts": 3016,

--- a/src/telemetry/aggregation.ts
+++ b/src/telemetry/aggregation.ts
@@ -1,0 +1,316 @@
+import { createHash } from "node:crypto";
+
+const TOOL_USAGE_AGGREGATE_TOOL_NAME = "aggregate";
+const MAX_ERROR_SUMMARY_MESSAGE_LENGTH = 500;
+const MAX_ERROR_SUMMARY_FIELD_LENGTH = 120;
+const MAX_TOOL_NAME_LENGTH = 120;
+
+export const MAX_ERROR_FINGERPRINTS = 128;
+export const ERROR_SUPPRESSION_SUMMARY_INTERVAL_MS = 30 * 60 * 1000;
+export const MAX_TOOL_USAGE_DISTINCT_TOOLS = 64;
+
+export interface ToolUsageToolSummary {
+  tool_name: string;
+  call_count: number;
+  success_count: number;
+  error_count: number;
+}
+
+interface ToolUsageToolState {
+  toolName: string;
+  callCount: number;
+  successCount: number;
+  errorCount: number;
+}
+
+export interface ToolUsageAggregateState {
+  callCount: number;
+  successCount: number;
+  errorCount: number;
+  totalDurationMs: number;
+  totalResponseLength: number;
+  overflowToolCallCount: number;
+  tools: Map<string, ToolUsageToolState>;
+  agentId: string | null;
+  mixedAgentIds: boolean;
+}
+
+export interface ErrorSuppressionSummaryData {
+  error_type: string;
+  error_message: string;
+  context?: string;
+  http_status?: number;
+  model_id?: string;
+  suppressed_count?: number;
+}
+
+export interface ErrorSuppressionState {
+  summaryData: ErrorSuppressionSummaryData;
+  suppressedCount: number;
+  agentId: string | null;
+  mixedAgentIds: boolean;
+}
+
+export interface AggregateEvent<TData> {
+  data: TData;
+  agentId: string | null;
+}
+
+function toFiniteNonNegativeInteger(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  return Math.round(value);
+}
+
+function normalizeErrorFingerprintValue(
+  value: string | undefined,
+): string | null {
+  const normalized = (value ?? "").trim().replace(/\s+/g, " ");
+  return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeBoundedString(
+  value: string | undefined,
+  fallback: string,
+  maxLength: number,
+): string {
+  const normalized = normalizeErrorFingerprintValue(value) ?? fallback;
+  return normalized.length <= maxLength
+    ? normalized
+    : normalized.slice(0, maxLength);
+}
+
+function normalizeToolName(toolName: string): string {
+  return normalizeBoundedString(toolName, "unknown_tool", MAX_TOOL_NAME_LENGTH);
+}
+
+export function createErrorFingerprint(args: {
+  errorType: string;
+  errorMessage: string;
+  context?: string;
+  httpStatus?: number;
+  modelId?: string;
+}): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        context: normalizeErrorFingerprintValue(args.context),
+        error_message: normalizeErrorFingerprintValue(args.errorMessage) ?? "",
+        error_type:
+          normalizeErrorFingerprintValue(args.errorType) ?? "unknown_error",
+        http_status:
+          typeof args.httpStatus === "number" &&
+          Number.isFinite(args.httpStatus)
+            ? args.httpStatus
+            : null,
+        model_id: normalizeErrorFingerprintValue(args.modelId),
+      }),
+    )
+    .digest("hex")
+    .slice(0, 32);
+}
+
+export function recordToolUsageAggregate(
+  aggregate: ToolUsageAggregateState | null,
+  agentId: string | null,
+  toolName: string,
+  success: boolean,
+  duration: number,
+  responseLength?: number,
+): ToolUsageAggregateState {
+  const next =
+    aggregate ??
+    ({
+      callCount: 0,
+      successCount: 0,
+      errorCount: 0,
+      totalDurationMs: 0,
+      totalResponseLength: 0,
+      overflowToolCallCount: 0,
+      tools: new Map(),
+      agentId,
+      mixedAgentIds: false,
+    } satisfies ToolUsageAggregateState);
+
+  if (next.agentId !== agentId) {
+    next.mixedAgentIds = true;
+  }
+  next.callCount += 1;
+  next.totalDurationMs += toFiniteNonNegativeInteger(duration);
+  next.totalResponseLength += toFiniteNonNegativeInteger(responseLength);
+  if (success) {
+    next.successCount += 1;
+  } else {
+    next.errorCount += 1;
+  }
+
+  const normalizedToolName = normalizeToolName(toolName);
+  let tool = next.tools.get(normalizedToolName);
+  if (!tool) {
+    if (next.tools.size >= MAX_TOOL_USAGE_DISTINCT_TOOLS) {
+      next.overflowToolCallCount += 1;
+      return next;
+    }
+    tool = {
+      toolName: normalizedToolName,
+      callCount: 0,
+      successCount: 0,
+      errorCount: 0,
+    };
+    next.tools.set(normalizedToolName, tool);
+  }
+
+  tool.callCount += 1;
+  if (success) {
+    tool.successCount += 1;
+  } else {
+    tool.errorCount += 1;
+  }
+  return next;
+}
+
+export function consumeToolUsageAggregate(
+  aggregate: ToolUsageAggregateState | null,
+): AggregateEvent<{
+  tool_name: string;
+  success: boolean;
+  duration: number;
+  response_length?: number;
+  call_count: number;
+  success_count: number;
+  error_count: number;
+  tools: ToolUsageToolSummary[];
+  overflow_tool_call_count?: number;
+  tool_name_limit?: number;
+}> | null {
+  if (!aggregate || aggregate.callCount === 0) {
+    return null;
+  }
+  const tools = Array.from(aggregate.tools.values())
+    .sort(
+      (left, right) =>
+        right.callCount - left.callCount ||
+        left.toolName.localeCompare(right.toolName),
+    )
+    .map(
+      (tool): ToolUsageToolSummary => ({
+        tool_name: tool.toolName,
+        call_count: tool.callCount,
+        success_count: tool.successCount,
+        error_count: tool.errorCount,
+      }),
+    );
+
+  return {
+    data: {
+      tool_name: TOOL_USAGE_AGGREGATE_TOOL_NAME,
+      success: aggregate.errorCount === 0,
+      duration: aggregate.totalDurationMs,
+      ...(aggregate.totalResponseLength > 0
+        ? { response_length: aggregate.totalResponseLength }
+        : {}),
+      call_count: aggregate.callCount,
+      success_count: aggregate.successCount,
+      error_count: aggregate.errorCount,
+      tools,
+      ...(aggregate.overflowToolCallCount > 0
+        ? {
+            overflow_tool_call_count: aggregate.overflowToolCallCount,
+            tool_name_limit: MAX_TOOL_USAGE_DISTINCT_TOOLS,
+          }
+        : {}),
+    },
+    agentId: aggregate.mixedAgentIds ? null : aggregate.agentId,
+  };
+}
+
+export function createErrorSuppressionState(
+  data: {
+    error_type: string;
+    error_message: string;
+    context?: string;
+    http_status?: number;
+    model_id?: string;
+  },
+  agentId: string | null,
+): ErrorSuppressionState {
+  return {
+    summaryData: {
+      error_type: normalizeBoundedString(
+        data.error_type,
+        "unknown_error",
+        MAX_ERROR_SUMMARY_FIELD_LENGTH,
+      ),
+      error_message: normalizeBoundedString(
+        data.error_message,
+        "unknown error",
+        MAX_ERROR_SUMMARY_MESSAGE_LENGTH,
+      ),
+      context: data.context
+        ? normalizeBoundedString(
+            data.context,
+            "unknown_context",
+            MAX_ERROR_SUMMARY_FIELD_LENGTH,
+          )
+        : undefined,
+      http_status: data.http_status,
+      model_id: data.model_id
+        ? normalizeBoundedString(
+            data.model_id,
+            "unknown_model",
+            MAX_ERROR_SUMMARY_FIELD_LENGTH,
+          )
+        : undefined,
+    },
+    suppressedCount: 0,
+    agentId,
+    mixedAgentIds: false,
+  };
+}
+
+export function updateErrorSuppressionAgentScope(
+  state: ErrorSuppressionState,
+  agentId: string | null,
+): void {
+  if (state.agentId !== agentId) {
+    state.mixedAgentIds = true;
+  }
+}
+
+export function consumeErrorSuppressionSummary(
+  state: ErrorSuppressionState,
+): AggregateEvent<ErrorSuppressionSummaryData> | null {
+  if (state.suppressedCount <= 0) {
+    return null;
+  }
+  const data = {
+    ...state.summaryData,
+    suppressed_count: state.suppressedCount,
+  };
+  state.suppressedCount = 0;
+  return { data, agentId: state.mixedAgentIds ? null : state.agentId };
+}
+
+export function hasPendingErrorSuppressionSummaries(
+  states: Map<string, ErrorSuppressionState>,
+): boolean {
+  for (const state of states.values()) {
+    if (state.suppressedCount > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function hasDueErrorSuppressionSummary(
+  nextSummaryMs: number | null,
+  states: Map<string, ErrorSuppressionState>,
+  now = Date.now(),
+): boolean {
+  return (
+    nextSummaryMs !== null &&
+    now >= nextSummaryMs &&
+    hasPendingErrorSuppressionSummaries(states)
+  );
+}

--- a/src/telemetry/flush-auth.test.ts
+++ b/src/telemetry/flush-auth.test.ts
@@ -12,9 +12,15 @@ import {
 type TelemetryTestState = {
   events: unknown[];
   messageCount: number;
+  toolCallCount: number;
   currentAgentId: string | null;
   surface: TelemetrySurface;
   sessionEndTracked: boolean;
+  inflightFlush: Promise<void> | null;
+  MAX_BATCH_SIZE: number;
+  toolUsageAggregate: unknown | null;
+  errorSuppressionStates: Map<string, unknown>;
+  nextErrorSuppressionSummaryMs: number | null;
   isCloudUser: () => boolean;
 };
 
@@ -84,6 +90,7 @@ describe("telemetry flush auth", () => {
   const originalIsCloudUser = telemetryState.isCloudUser;
   const originalLettaApiKey = process.env.LETTA_API_KEY;
   const originalTelemetryDisabled = process.env.LETTA_TELEMETRY_DISABLED;
+  const originalLettaCodeTelem = process.env.LETTA_CODE_TELEM;
   const originalDoNotTrack = process.env.DO_NOT_TRACK;
   const originalLettaBaseUrl = process.env.LETTA_BASE_URL;
   const originalLettaDesktopDebugPanel = process.env.LETTA_DESKTOP_MODE;
@@ -117,11 +124,18 @@ describe("telemetry flush auth", () => {
     telemetry.cleanup();
     telemetryState.events = [];
     telemetryState.messageCount = 0;
+    telemetryState.toolCallCount = 0;
     telemetryState.currentAgentId = null;
     telemetryState.surface = "letta_code_tui";
     telemetryState.sessionEndTracked = false;
+    telemetryState.inflightFlush = null;
+    telemetryState.MAX_BATCH_SIZE = 50;
+    telemetryState.toolUsageAggregate = null;
+    telemetryState.errorSuppressionStates = new Map();
+    telemetryState.nextErrorSuppressionSummaryMs = null;
     deleteEnvVarCaseInsensitive("LETTA_API_KEY");
     deleteEnvVarCaseInsensitive("LETTA_TELEMETRY_DISABLED");
+    deleteEnvVarCaseInsensitive("LETTA_CODE_TELEM");
     deleteEnvVarCaseInsensitive("DO_NOT_TRACK");
     deleteEnvVarCaseInsensitive("LETTA_BASE_URL");
     deleteEnvVarCaseInsensitive("LETTA_DESKTOP_MODE");
@@ -139,6 +153,7 @@ describe("telemetry flush auth", () => {
     telemetryState.isCloudUser = originalIsCloudUser;
     restoreEnvVar("LETTA_API_KEY", originalLettaApiKey);
     restoreEnvVar("LETTA_TELEMETRY_DISABLED", originalTelemetryDisabled);
+    restoreEnvVar("LETTA_CODE_TELEM", originalLettaCodeTelem);
     restoreEnvVar("DO_NOT_TRACK", originalDoNotTrack);
     restoreEnvVar("LETTA_BASE_URL", originalLettaBaseUrl);
     restoreEnvVar("LETTA_DESKTOP_MODE", originalLettaDesktopDebugPanel);
@@ -174,6 +189,20 @@ describe("telemetry flush auth", () => {
     telemetry.trackUserInput("hello", "user", "model-1");
 
     expect(telemetryState.events).toHaveLength(0);
+  });
+
+  test("LETTA_CODE_TELEM=0 disables runtime telemetry", async () => {
+    setEnvVar("LETTA_CODE_TELEM", "0");
+
+    const fetchMock = mock(async () => new Response(null, { status: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    telemetry.trackUserInput("hello", "user", "model-1");
+    telemetry.trackToolUsage("Bash", true, 1, 1);
+    await telemetry.flush();
+
+    expect(telemetryState.events).toHaveLength(0);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("flush falls back to secure settings token when env var is absent", async () => {

--- a/src/telemetry/flush-batching.test.ts
+++ b/src/telemetry/flush-batching.test.ts
@@ -109,6 +109,47 @@ describe("telemetry flush batching", () => {
     expect(telemetryState.events).toHaveLength(0);
   });
 
+  test("flush sends session-end events queued during an in-flight request", async () => {
+    const payloads: CapturedTelemetryPayload[] = [];
+    let resolveFirst: (value: Response) => void = () => {};
+    const firstResponse = new Promise<Response>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const fetchMock = mock(
+      async (_url: string | URL | Request, init?: RequestInit) => {
+        payloads.push(
+          JSON.parse(String(init?.body ?? "{}")) as CapturedTelemetryPayload,
+        );
+        if (payloads.length === 1) {
+          return firstResponse;
+        }
+        return new Response(null, { status: 200 });
+      },
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    telemetry.trackUserInput("first", "user", "model-1");
+    const firstFlush = telemetry.flush();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    telemetry.trackToolUsage("Bash", true, 5, 10);
+    telemetry.trackSessionEnd(undefined, "exit_command");
+    const exitFlush = telemetry.flush();
+
+    resolveFirst(new Response(null, { status: 200 }));
+    await Promise.all([firstFlush, exitFlush]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(payloads[0]?.events?.map((event) => event.type)).toEqual([
+      "user_input",
+    ]);
+    expect(payloads[1]?.events?.map((event) => event.type)).toEqual([
+      "tool_usage",
+      "session_end",
+    ]);
+    expect(telemetryState.events).toHaveLength(0);
+  });
+
   test("drain awaits the in-flight flush and exits when queue is empty", async () => {
     const fetchMock = mock(async () => new Response(null, { status: 200 }));
     globalThis.fetch = fetchMock as unknown as typeof fetch;

--- a/src/telemetry/flush-batching.test.ts
+++ b/src/telemetry/flush-batching.test.ts
@@ -5,11 +5,25 @@ import { type TelemetrySurface, telemetry } from "@/telemetry";
 type TelemetryTestState = {
   events: unknown[];
   messageCount: number;
+  toolCallCount: number;
   currentAgentId: string | null;
   surface: TelemetrySurface;
   sessionEndTracked: boolean;
   inflightFlush: Promise<void> | null;
+  MAX_BATCH_SIZE: number;
+  toolUsageAggregate: unknown | null;
+  errorSuppressionStates: Map<string, unknown>;
+  nextErrorSuppressionSummaryMs: number | null;
   isCloudUser: () => boolean;
+};
+
+type CapturedTelemetryEvent = {
+  type: string;
+  data: Record<string, unknown>;
+};
+
+type CapturedTelemetryPayload = {
+  events?: CapturedTelemetryEvent[];
 };
 
 const telemetryState = telemetry as unknown as TelemetryTestState;
@@ -33,12 +47,18 @@ describe("telemetry flush batching", () => {
     telemetry.cleanup();
     telemetryState.events = [];
     telemetryState.messageCount = 0;
+    telemetryState.toolCallCount = 0;
     telemetryState.currentAgentId = null;
     telemetryState.surface = "letta_code_tui";
     telemetryState.sessionEndTracked = false;
     telemetryState.inflightFlush = null;
+    telemetryState.MAX_BATCH_SIZE = 50;
+    telemetryState.toolUsageAggregate = null;
+    telemetryState.errorSuppressionStates = new Map();
+    telemetryState.nextErrorSuppressionSummaryMs = null;
     deleteEnvVarCaseInsensitive("LETTA_API_KEY");
     deleteEnvVarCaseInsensitive("LETTA_TELEMETRY_DISABLED");
+    deleteEnvVarCaseInsensitive("LETTA_CODE_TELEM");
     deleteEnvVarCaseInsensitive("LETTA_BASE_URL");
     settingsManager.getSettings = mock(() => ({
       env: {},
@@ -151,11 +171,17 @@ describe("reflection telemetry correlation", () => {
     telemetry.cleanup();
     telemetryState.events = [];
     telemetryState.messageCount = 0;
+    telemetryState.toolCallCount = 0;
     telemetryState.currentAgentId = null;
     telemetryState.surface = "letta_code_tui";
     telemetryState.sessionEndTracked = false;
     telemetryState.inflightFlush = null;
+    telemetryState.MAX_BATCH_SIZE = 50;
+    telemetryState.toolUsageAggregate = null;
+    telemetryState.errorSuppressionStates = new Map();
+    telemetryState.nextErrorSuppressionSummaryMs = null;
     deleteEnvVarCaseInsensitive("LETTA_API_KEY");
+    deleteEnvVarCaseInsensitive("LETTA_CODE_TELEM");
     settingsManager.getSettings = mock(() => ({
       env: {},
     })) as unknown as typeof settingsManager.getSettings;
@@ -227,5 +253,410 @@ describe("reflection telemetry correlation", () => {
     expect(event.type).toBe("reflection_start");
     expect(event.data.subagent_id).toBeUndefined();
     expect(event.data.start_message_id).toBe("message-start-2");
+  });
+});
+
+describe("telemetry aggregation controls", () => {
+  const originalFetch = globalThis.fetch;
+  const originalDateNow = Date.now;
+  const originalGetSettingsWithSecureTokens =
+    settingsManager.getSettingsWithSecureTokens;
+  const originalGetSettings = settingsManager.getSettings;
+  const originalIsCloudUser = telemetryState.isCloudUser;
+
+  function resetTelemetryTestState(): void {
+    telemetry.cleanup();
+    telemetryState.events = [];
+    telemetryState.messageCount = 0;
+    telemetryState.toolCallCount = 0;
+    telemetryState.currentAgentId = null;
+    telemetryState.surface = "letta_code_tui";
+    telemetryState.sessionEndTracked = false;
+    telemetryState.inflightFlush = null;
+    telemetryState.MAX_BATCH_SIZE = 50;
+    telemetryState.toolUsageAggregate = null;
+    telemetryState.errorSuppressionStates = new Map();
+    telemetryState.nextErrorSuppressionSummaryMs = null;
+  }
+
+  function installTelemetryCapture(status = 200): {
+    payloads: CapturedTelemetryPayload[];
+    fetchMock: ReturnType<typeof mock>;
+    setStatus: (nextStatus: number) => void;
+  } {
+    const payloads: CapturedTelemetryPayload[] = [];
+    let responseStatus = status;
+    const fetchMock = mock(
+      async (_url: string | URL | Request, init?: RequestInit) => {
+        payloads.push(
+          JSON.parse(String(init?.body ?? "{}")) as CapturedTelemetryPayload,
+        );
+        return new Response(null, { status: responseStatus });
+      },
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    return {
+      payloads,
+      fetchMock,
+      setStatus: (nextStatus: number) => {
+        responseStatus = nextStatus;
+      },
+    };
+  }
+
+  function setNow(now: number): void {
+    Date.now = mock(() => now) as unknown as typeof Date.now;
+  }
+
+  beforeEach(() => {
+    resetTelemetryTestState();
+    Date.now = originalDateNow;
+    deleteEnvVarCaseInsensitive("LETTA_API_KEY");
+    deleteEnvVarCaseInsensitive("LETTA_TELEMETRY_DISABLED");
+    deleteEnvVarCaseInsensitive("LETTA_CODE_TELEM");
+    deleteEnvVarCaseInsensitive("DO_NOT_TRACK");
+    deleteEnvVarCaseInsensitive("LETTA_BASE_URL");
+    telemetryState.isCloudUser = () => true;
+    settingsManager.getSettings = mock(() => ({
+      env: {},
+    })) as unknown as typeof settingsManager.getSettings;
+    settingsManager.getSettingsWithSecureTokens = mock(async () => ({
+      env: { LETTA_API_KEY: "settings-key" },
+    })) as unknown as typeof settingsManager.getSettingsWithSecureTokens;
+  });
+
+  afterEach(() => {
+    Date.now = originalDateNow;
+    globalThis.fetch = originalFetch;
+    settingsManager.getSettingsWithSecureTokens =
+      originalGetSettingsWithSecureTokens;
+    settingsManager.getSettings = originalGetSettings;
+    telemetryState.isCloudUser = originalIsCloudUser;
+  });
+
+  test("flush collapses named tool calls into one backward-compatible aggregate event", async () => {
+    const { payloads, fetchMock } = installTelemetryCapture();
+    const longToolName = `Long ${"x".repeat(200)}`;
+    const truncatedLongToolName = longToolName.slice(0, 120);
+    telemetry.setCurrentAgentId("agent-1");
+
+    telemetry.trackToolUsage("Bash", true, 10, 100);
+    telemetry.trackToolUsage("Bash", false, 20, 50);
+    telemetry.trackToolUsage("Read", true, 5, 25);
+    telemetry.trackToolUsage("  Tool\tWith\nSpaces  ", true, 7, 0);
+    telemetry.trackToolUsage(longToolName, true, 3, 2);
+
+    expect(telemetryState.events).toHaveLength(0);
+    expect(telemetry.getToolCallCount()).toBe(5);
+
+    await telemetry.flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const events = payloads[0]?.events ?? [];
+    expect(events).toHaveLength(1);
+    const event = events[0];
+    expect(event?.type).toBe("tool_usage");
+    expect(event?.data.tool_name).toBe("aggregate");
+    expect(event?.data.success).toBe(false);
+    expect(event?.data.duration).toBe(45);
+    expect(event?.data.response_length).toBe(177);
+    expect(event?.data.call_count).toBe(5);
+    expect(event?.data.success_count).toBe(4);
+    expect(event?.data.error_count).toBe(1);
+    expect(event?.data.agent_id).toBe("agent-1");
+    expect(event?.data.tools).toEqual([
+      {
+        tool_name: "Bash",
+        call_count: 2,
+        success_count: 1,
+        error_count: 1,
+      },
+      {
+        tool_name: truncatedLongToolName,
+        call_count: 1,
+        success_count: 1,
+        error_count: 0,
+      },
+      {
+        tool_name: "Read",
+        call_count: 1,
+        success_count: 1,
+        error_count: 0,
+      },
+      {
+        tool_name: "Tool With Spaces",
+        call_count: 1,
+        success_count: 1,
+        error_count: 0,
+      },
+    ]);
+    for (const tool of event?.data.tools as Record<string, unknown>[]) {
+      expect(Object.hasOwn(tool, "duration")).toBe(false);
+      expect(Object.hasOwn(tool, "response_length")).toBe(false);
+      expect(Object.hasOwn(tool, "stderr")).toBe(false);
+      expect(Object.hasOwn(tool, "error_type")).toBe(false);
+    }
+    expect(Object.hasOwn(event?.data ?? {}, "stderr")).toBe(false);
+    expect(Object.hasOwn(event?.data ?? {}, "error_type")).toBe(false);
+    expect(Object.hasOwn(event?.data ?? {}, "tool_call_count")).toBe(false);
+    expect(Object.hasOwn(event?.data ?? {}, "total_duration_ms")).toBe(false);
+    expect(telemetryState.events).toHaveLength(0);
+  });
+
+  test("tool aggregate clamps invalid numeric inputs", async () => {
+    const { payloads } = installTelemetryCapture();
+
+    telemetry.trackToolUsage("Bash", true, Number.NaN, -5);
+    telemetry.trackToolUsage(
+      "Bash",
+      true,
+      Number.POSITIVE_INFINITY,
+      Number.NaN,
+    );
+
+    await telemetry.flush();
+
+    const event = payloads[0]?.events?.[0];
+    expect(event?.type).toBe("tool_usage");
+    expect(event?.data.duration).toBe(0);
+    expect(Object.hasOwn(event?.data ?? {}, "response_length")).toBe(false);
+    expect(event?.data.call_count).toBe(2);
+    expect(event?.data.success_count).toBe(2);
+    expect(event?.data.error_count).toBe(0);
+    expect(event?.data.tools).toEqual([
+      {
+        tool_name: "Bash",
+        call_count: 2,
+        success_count: 2,
+        error_count: 0,
+      },
+    ]);
+  });
+
+  test("tool aggregate caps retained tool names while preserving global totals", async () => {
+    const { payloads } = installTelemetryCapture();
+
+    for (let i = 0; i < 70; i += 1) {
+      telemetry.trackToolUsage(`tool_${i}`, i % 2 === 0, 1, 1);
+    }
+
+    await telemetry.flush();
+
+    const events = payloads[0]?.events ?? [];
+    expect(events).toHaveLength(1);
+    const event = events[0];
+    expect(event?.type).toBe("tool_usage");
+    expect(event?.data.call_count).toBe(70);
+    expect(event?.data.success_count).toBe(35);
+    expect(event?.data.error_count).toBe(35);
+    expect(event?.data.duration).toBe(70);
+    expect(event?.data.response_length).toBe(70);
+    expect(event?.data.overflow_tool_call_count).toBe(6);
+    expect(event?.data.tool_name_limit).toBe(64);
+    const tools = event?.data.tools as Record<string, unknown>[];
+    expect(tools).toHaveLength(64);
+    for (const tool of tools) {
+      expect(tool.tool_name).toStartWith("tool_");
+      expect(tool.call_count).toBe(1);
+      expect(Object.hasOwn(tool, "duration")).toBe(false);
+      expect(Object.hasOwn(tool, "response_length")).toBe(false);
+      expect(Object.hasOwn(tool, "stderr")).toBe(false);
+      expect(Object.hasOwn(tool, "error_type")).toBe(false);
+    }
+  });
+
+  test("session end emits pending aggregates before session_end", () => {
+    telemetry.trackToolUsage("Bash", true, 12, 34);
+    telemetry.trackError("stream_error", "same failure", "stream");
+    telemetry.trackError("stream_error", "same failure", "stream");
+
+    telemetry.trackSessionEnd(undefined, "exit_command");
+
+    expect(telemetryState.events).toHaveLength(4);
+    const events = telemetryState.events as CapturedTelemetryEvent[];
+    expect(events[0]?.type).toBe("error");
+    expect(events[1]?.type).toBe("tool_usage");
+    expect(events[1]?.data.call_count).toBe(1);
+    expect(events[2]?.type).toBe("error");
+    expect(events[2]?.data.suppressed_count).toBe(1);
+    expect(events[3]?.type).toBe("session_end");
+    expect(events[3]?.data.tool_call_count).toBe(1);
+  });
+
+  test("mixed-agent tool aggregates omit agent attribution", async () => {
+    const { payloads } = installTelemetryCapture();
+
+    telemetry.setCurrentAgentId("agent-a");
+    telemetry.trackToolUsage("Bash", true, 10, 10);
+    telemetry.setCurrentAgentId("agent-b");
+    telemetry.trackToolUsage("Read", true, 20, 20);
+
+    await telemetry.flush();
+
+    const event = payloads[0]?.events?.[0];
+    expect(event?.type).toBe("tool_usage");
+    expect(event?.data.call_count).toBe(2);
+    expect(event?.data.agent_id).toBeUndefined();
+  });
+
+  test("duplicate process-boundary errors plus repeated drain send only the first event before cadence", async () => {
+    const { payloads, fetchMock } = installTelemetryCapture();
+
+    telemetry.trackError(
+      "uncaught_exception",
+      "same process failure",
+      "process_uncaught_exception",
+    );
+    await telemetry.drain();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(payloads[0]?.events).toHaveLength(1);
+    expect(payloads[0]?.events?.[0]?.type).toBe("error");
+
+    for (let i = 0; i < 5; i += 1) {
+      telemetry.trackError(
+        "uncaught_exception",
+        "same process failure",
+        "process_uncaught_exception",
+      );
+      await telemetry.drain();
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(payloads).toHaveLength(1);
+    expect(telemetryState.events).toHaveLength(0);
+  });
+
+  test("suppressed error summaries wait for the 30 minute cadence", async () => {
+    const { payloads, fetchMock } = installTelemetryCapture();
+    const start = 1_700_000_000_000;
+    setNow(start);
+
+    telemetry.trackError("stream_error", "same failure", "stream", {
+      modelId: "model-1",
+      runId: "run-1",
+    });
+    await telemetry.flush();
+
+    telemetry.trackError("stream_error", "same failure", "stream", {
+      modelId: "model-1",
+      runId: "run-2",
+    });
+    await telemetry.flush();
+
+    setNow(start + 30 * 60 * 1000 - 1);
+    await telemetry.flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    setNow(start + 30 * 60 * 1000);
+    await telemetry.flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const summary = payloads[1]?.events?.[0];
+    expect(summary?.type).toBe("error");
+    expect(summary?.data.error_type).toBe("stream_error");
+    expect(summary?.data.error_message).toBe("same failure");
+    expect(summary?.data.context).toBe("stream");
+    expect(summary?.data.model_id).toBe("model-1");
+    expect(summary?.data.suppressed_count).toBe(1);
+    expect(summary?.data.run_id).toBeUndefined();
+    expect(summary?.data.recent_chunks).toBeUndefined();
+    expect(summary?.data.debug_log_tail).toBeUndefined();
+    expect(Object.hasOwn(summary?.data ?? {}, "error_fingerprint")).toBe(false);
+  });
+
+  test("session end emits suppressed error summaries immediately", async () => {
+    const { payloads } = installTelemetryCapture();
+
+    telemetry.trackError("stream_error", "same failure", "stream", {
+      modelId: "model-1",
+      runId: "run-1",
+    });
+    await telemetry.flush();
+
+    telemetry.trackError("stream_error", "same failure", "stream", {
+      modelId: "model-1",
+      runId: "run-2",
+    });
+    telemetry.trackError("stream_error", "same failure", "stream", {
+      modelId: "model-1",
+      runId: "run-3",
+    });
+    telemetry.trackSessionEnd(undefined, "exit_command");
+    await telemetry.flush();
+
+    const events = payloads[1]?.events ?? [];
+    expect(events).toHaveLength(2);
+    expect(events[0]?.type).toBe("error");
+    expect(events[0]?.data.suppressed_count).toBe(2);
+    expect(events[1]?.type).toBe("session_end");
+  });
+
+  test("distinct error fingerprints are not suppressed", () => {
+    const longPrefix = "x".repeat(600);
+
+    telemetry.trackError("stream_error", "first failure", "stream", {
+      modelId: "model-1",
+    });
+    telemetry.trackError("stream_error", "second failure", "stream", {
+      modelId: "model-1",
+    });
+    telemetry.trackError("stream_error", "first failure", "other_context", {
+      modelId: "model-1",
+    });
+    telemetry.trackError("stream_error", `${longPrefix}a`, "stream", {
+      modelId: "model-1",
+    });
+    telemetry.trackError("stream_error", `${longPrefix}b`, "stream", {
+      modelId: "model-1",
+    });
+
+    expect(telemetryState.events).toHaveLength(5);
+    const events = telemetryState.events as CapturedTelemetryEvent[];
+    expect(events.map((event) => event.data.error_message)).toEqual([
+      "first failure",
+      "second failure",
+      "first failure",
+      `${longPrefix}a`,
+      `${longPrefix}b`,
+    ]);
+  });
+
+  test("flush failure re-queues aggregate events for retry", async () => {
+    const { payloads, fetchMock, setStatus } = installTelemetryCapture(500);
+
+    telemetry.trackToolUsage("Bash", true, 7, 8);
+    await telemetry.flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(telemetryState.events).toHaveLength(1);
+
+    setStatus(200);
+    await telemetry.flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(payloads[1]?.events?.[0]?.data.call_count).toBe(1);
+    expect(telemetryState.events).toHaveLength(0);
+  });
+
+  test("error fingerprint state stays bounded without eviction summary events", () => {
+    telemetryState.MAX_BATCH_SIZE = 1_000;
+
+    telemetry.trackError("bounded_error", "repeat", "state_bound", {
+      modelId: "model-1",
+    });
+    telemetry.trackError("bounded_error", "repeat", "state_bound", {
+      modelId: "model-1",
+    });
+
+    for (let i = 0; i < 128; i += 1) {
+      telemetry.trackError("bounded_error", `failure ${i}`, "state_bound", {
+        modelId: "model-1",
+      });
+    }
+
+    expect(telemetryState.events).toHaveLength(129);
+    expect(telemetryState.errorSuppressionStates.size).toBeLessThanOrEqual(128);
   });
 });

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -916,7 +916,11 @@ class TelemetryManager {
       return;
     }
     if (this.inflightFlush) {
-      return this.inflightFlush;
+      await this.inflightFlush;
+      if (!this.hasPendingTelemetry()) {
+        return;
+      }
+      return this.flush(reason);
     }
 
     this.flushPendingTelemetryAggregates(reason);

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -5,6 +5,20 @@ import { getServerHealth } from "@/backend/api/health";
 import { submitTelemetryMetadata } from "@/backend/api/metadata";
 import { isLocalBackendEnvEnabled } from "@/backend/local/paths";
 import { settingsManager } from "@/settings-manager";
+import {
+  consumeErrorSuppressionSummary,
+  consumeToolUsageAggregate,
+  createErrorFingerprint,
+  createErrorSuppressionState,
+  ERROR_SUPPRESSION_SUMMARY_INTERVAL_MS,
+  type ErrorSuppressionState,
+  hasDueErrorSuppressionSummary,
+  MAX_ERROR_FINGERPRINTS,
+  recordToolUsageAggregate,
+  type ToolUsageAggregateState,
+  type ToolUsageToolSummary,
+  updateErrorSuppressionAgentScope,
+} from "@/telemetry/aggregation";
 import { debugLogFile } from "@/utils/debug";
 import { isLoopbackHostname, parseUrl } from "@/utils/url";
 import { getVersion } from "@/version";
@@ -70,8 +84,12 @@ export interface ToolUsageData {
   success: boolean;
   duration: number;
   response_length?: number;
-  error_type?: string;
-  stderr?: string;
+  call_count?: number;
+  success_count?: number;
+  error_count?: number;
+  tools?: ToolUsageToolSummary[];
+  overflow_tool_call_count?: number;
+  tool_name_limit?: number;
 }
 
 export interface ErrorData {
@@ -83,6 +101,7 @@ export interface ErrorData {
   run_id?: string;
   recent_chunks?: Record<string, unknown>[];
   debug_log_tail?: string;
+  suppressed_count?: number;
 }
 
 export interface UserInputData {
@@ -142,6 +161,17 @@ export interface ReflectionArenaVoteData {
   version?: string;
   platform?: string;
 }
+
+type TelemetryEventData =
+  | Record<string, unknown>
+  | SessionStartData
+  | SessionEndData
+  | ToolUsageData
+  | ErrorData
+  | UserInputData
+  | ReflectionStartData
+  | ReflectionEndData
+  | ReflectionArenaVoteData;
 
 export function isLettaCodeDesktopRuntime(
   env: NodeJS.ProcessEnv = process.env,
@@ -237,6 +267,8 @@ function isNonActionableError(message: string): boolean {
   );
 }
 
+export type TelemetryAggregateFlushReason = "flush" | "session_end" | "drain";
+
 class TelemetryManager {
   private events: TelemetryEvent[] = [];
   private sessionId: string;
@@ -250,8 +282,10 @@ class TelemetryManager {
   private initialized = false;
   private flushInterval: NodeJS.Timeout | null = null;
   private serverVersion: string | null = null;
-  /** Deduplicates concurrent flushes (prevents the 429 double-flush race on shutdown). */
   private inflightFlush: Promise<void> | null = null;
+  private toolUsageAggregate: ToolUsageAggregateState | null = null;
+  private errorSuppressionStates = new Map<string, ErrorSuppressionState>();
+  private nextErrorSuppressionSummaryMs: number | null = null;
 
   private async resolveTelemetryApiKey(): Promise<string | undefined> {
     if (process.env.LETTA_API_KEY) {
@@ -291,7 +325,6 @@ class TelemetryManager {
 
   private readonly FLUSH_INTERVAL_MS = 2 * 60 * 1000; // 2 minutes
   private readonly MAX_BATCH_SIZE = 50;
-  /** Max time to drain queued events on exit (bounded so we never hang the shell). */
   private readonly DRAIN_TIMEOUT_MS = 3_000;
   private sessionStatsGetter?: () => {
     totalWallMs: number;
@@ -442,33 +475,29 @@ class TelemetryManager {
     // risking hangs on exit.
   }
 
-  /**
-   * Track a telemetry event
-   */
-  private track(
+  private track(type: TelemetryEvent["type"], data: TelemetryEventData) {
+    this.enqueueEvent(type, data);
+  }
+
+  private enqueueEvent(
     type: TelemetryEvent["type"],
-    data:
-      | Record<string, unknown>
-      | SessionStartData
-      | SessionEndData
-      | ToolUsageData
-      | ErrorData
-      | UserInputData
-      | ReflectionStartData
-      | ReflectionEndData
-      | ReflectionArenaVoteData,
+    data: TelemetryEventData,
+    options: { autoFlush?: boolean; agentId?: string | null } = {},
   ) {
     if (!this.isTelemetryEnabled()) {
       return;
     }
 
+    const agentId = Object.hasOwn(options, "agentId")
+      ? options.agentId
+      : this.currentAgentId;
     const event: TelemetryEvent = {
       type,
       timestamp: new Date().toISOString(),
       data: {
         ...data,
         session_id: this.sessionId,
-        agent_id: this.currentAgentId || undefined,
+        agent_id: agentId || undefined,
         surface: this.surface,
         backend: resolveTelemetryBackend(),
       },
@@ -477,7 +506,10 @@ class TelemetryManager {
     this.events.push(event);
 
     // Flush if batch size is reached
-    if (this.events.length >= this.MAX_BATCH_SIZE) {
+    if (
+      options.autoFlush !== false &&
+      this.events.length >= this.MAX_BATCH_SIZE
+    ) {
       this.flush().catch((err) => {
         if (process.env.LETTA_DEBUG) {
           console.error("Telemetry flush error:", err);
@@ -543,30 +575,18 @@ class TelemetryManager {
     this.sessionStatsGetter = getter;
   }
 
-  /**
-   * Get the current session ID
-   */
   getSessionId(): string {
     return this.sessionId;
   }
 
-  /**
-   * Get the current message count
-   */
   getMessageCount(): number {
     return this.messageCount;
   }
 
-  /**
-   * Get the current tool call count
-   */
   getToolCallCount(): number {
     return this.toolCallCount;
   }
 
-  /**
-   * Track session start
-   */
   trackSessionStart() {
     // Extract agent ID from startup args if --agent or -a is provided
     const args = process.argv.slice(2);
@@ -587,6 +607,74 @@ class TelemetryManager {
       node_version: process.version,
     };
     this.track("session_start", data);
+  }
+
+  private flushToolUsageAggregate(): void {
+    const event = consumeToolUsageAggregate(this.toolUsageAggregate);
+    this.toolUsageAggregate = null;
+    if (event) {
+      this.enqueueEvent("tool_usage", event.data as ToolUsageData, {
+        autoFlush: false,
+        agentId: event.agentId,
+      });
+    }
+  }
+
+  private flushErrorSuppressionSummaries(): boolean {
+    let emitted = false;
+    for (const state of this.errorSuppressionStates.values()) {
+      const event = consumeErrorSuppressionSummary(state);
+      if (!event) {
+        continue;
+      }
+      this.enqueueEvent("error", event.data as ErrorData, {
+        autoFlush: false,
+        agentId: event.agentId,
+      });
+      emitted = true;
+    }
+    return emitted;
+  }
+
+  private evictOldestErrorSuppressionState(): void {
+    const oldestFingerprint = this.errorSuppressionStates.keys().next().value;
+    if (oldestFingerprint) {
+      this.errorSuppressionStates.delete(oldestFingerprint);
+    }
+  }
+
+  private flushPendingTelemetryAggregates(
+    reason: TelemetryAggregateFlushReason,
+  ): void {
+    if (!this.isTelemetryEnabled()) {
+      return;
+    }
+    this.flushToolUsageAggregate();
+
+    const forceErrorSummary = reason === "session_end";
+    if (
+      !forceErrorSummary &&
+      !hasDueErrorSuppressionSummary(
+        this.nextErrorSuppressionSummaryMs,
+        this.errorSuppressionStates,
+      )
+    ) {
+      return;
+    }
+    if (this.flushErrorSuppressionSummaries() || forceErrorSummary) {
+      this.nextErrorSuppressionSummaryMs = null;
+    }
+  }
+
+  private hasPendingTelemetry(): boolean {
+    return (
+      this.events.length > 0 ||
+      (this.toolUsageAggregate?.callCount ?? 0) > 0 ||
+      hasDueErrorSuppressionSummary(
+        this.nextErrorSuppressionSummaryMs,
+        this.errorSuppressionStates,
+      )
+    );
   }
 
   /**
@@ -646,35 +734,30 @@ class TelemetryManager {
       context_tokens: sessionStats?.usage.contextTokens,
       step_count: sessionStats?.usage.stepCount,
     };
+    this.flushPendingTelemetryAggregates("session_end");
     this.track("session_end", data);
   }
 
-  /**
-   * Track tool usage
-   */
   trackToolUsage(
     toolName: string,
     success: boolean,
     duration: number,
     responseLength?: number,
-    errorType?: string,
-    stderr?: string,
   ) {
     this.toolCallCount++;
-    const data: ToolUsageData = {
-      tool_name: toolName,
+    if (!this.isTelemetryEnabled()) {
+      return;
+    }
+    this.toolUsageAggregate = recordToolUsageAggregate(
+      this.toolUsageAggregate,
+      this.currentAgentId,
+      toolName,
       success,
       duration,
-      response_length: responseLength,
-      error_type: errorType,
-      stderr,
-    };
-    this.track("tool_usage", data);
+      responseLength,
+    );
   }
 
-  /**
-   * Track errors
-   */
   trackError(
     errorType: string,
     errorMessage: string,
@@ -686,6 +769,10 @@ class TelemetryManager {
       recentChunks?: Record<string, unknown>[];
     },
   ) {
+    if (!this.isTelemetryEnabled()) {
+      return;
+    }
+
     // Skip error telemetry for self-hosted users to avoid spamming cloud analytics
     if (!this.isCloudUser()) {
       return;
@@ -694,6 +781,29 @@ class TelemetryManager {
     // Skip non-actionable errors that create noise
     if (isNonActionableError(errorMessage)) {
       return;
+    }
+
+    const fingerprint = createErrorFingerprint({
+      errorType,
+      errorMessage,
+      context,
+      httpStatus: options?.httpStatus,
+      modelId: options?.modelId,
+    });
+    const now = Date.now();
+    const existing = this.errorSuppressionStates.get(fingerprint);
+    if (existing) {
+      existing.suppressedCount += 1;
+      updateErrorSuppressionAgentScope(existing, this.currentAgentId);
+      this.errorSuppressionStates.delete(fingerprint);
+      this.errorSuppressionStates.set(fingerprint, existing);
+      this.nextErrorSuppressionSummaryMs ??=
+        now + ERROR_SUPPRESSION_SUMMARY_INTERVAL_MS;
+      return;
+    }
+
+    if (this.errorSuppressionStates.size >= MAX_ERROR_FINGERPRINTS) {
+      this.evictOldestErrorSuppressionState();
     }
 
     const data: ErrorData = {
@@ -706,7 +816,12 @@ class TelemetryManager {
       recent_chunks: options?.recentChunks,
       debug_log_tail: debugLogFile.getTail(),
     };
-    this.track("error", data);
+
+    this.errorSuppressionStates.set(
+      fingerprint,
+      createErrorSuppressionState(data, this.currentAgentId),
+    );
+    this.enqueueEvent("error", data);
   }
 
   /**
@@ -796,11 +911,16 @@ class TelemetryManager {
   }
 
   /** Concurrent callers share one in-flight POST (prevents 429 double-flush race on shutdown). */
-  async flush(): Promise<void> {
+  async flush(reason: TelemetryAggregateFlushReason = "flush"): Promise<void> {
+    if (!this.isTelemetryEnabled()) {
+      return;
+    }
     if (this.inflightFlush) {
       return this.inflightFlush;
     }
-    if (this.events.length === 0 || !this.isTelemetryEnabled()) {
+
+    this.flushPendingTelemetryAggregates(reason);
+    if (this.events.length === 0) {
       return;
     }
 
@@ -842,12 +962,12 @@ class TelemetryManager {
     }
     const deadline = Date.now() + this.DRAIN_TIMEOUT_MS;
     // Loop in case new events arrive mid-drain (e.g. trackError from uncaughtException).
-    while (this.events.length > 0 || this.inflightFlush) {
+    while (this.hasPendingTelemetry() || this.inflightFlush) {
       if (Date.now() >= deadline) {
         return;
       }
       try {
-        await this.flush();
+        await this.flush("drain");
       } catch {
         // Swallow — already logged inside performFlush; don't block exit.
         return;

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -2496,8 +2496,6 @@ async function executeModTool(
         toolStatus === "success",
         duration,
         responseSize,
-        toolStatus === "error" ? "tool_error" : undefined,
-        stderr ? stderr.join("\n") : undefined,
       );
 
       const hookFeedback = await collectPostToolHookFeedback(
@@ -2559,14 +2557,7 @@ async function executeModTool(
         phase: "tool.run",
       });
 
-      telemetry.trackToolUsage(
-        toolName,
-        false,
-        duration,
-        errorMessage.length,
-        errorType,
-        errorMessage,
-      );
+      telemetry.trackToolUsage(toolName, false, duration, errorMessage.length);
 
       const hookFeedback = await collectPostToolHookFeedback(
         {
@@ -3006,8 +2997,6 @@ async function executeToolInner(
         toolStatus === "success",
         duration,
         responseSize,
-        toolStatus === "error" ? "tool_error" : undefined,
-        stderr ? stderr.join("\n") : undefined,
       );
 
       const hookFeedback = await collectPostToolHookFeedback(
@@ -3066,8 +3055,6 @@ async function executeToolInner(
         false,
         duration,
         errorMessage.length,
-        errorType,
-        errorMessage,
       );
 
       const hookFeedback = await collectPostToolHookFeedback(


### PR DESCRIPTION
## Summary
- replace per-call tool telemetry with one bounded aggregate per flush window while retaining per-tool usage and success counts
- report the first occurrence of an error fingerprint, then send compact suppression counts on a 30-minute cadence or at session end
- stop including per-tool stderr and error details in product telemetry

## Behavior
Tool aggregates keep the existing required event fields for compatibility and add bounded per-tool counts. Up to 64 tool names are retained per window; additional calls remain in the global totals and overflow count.

Repeated errors keep their first diagnostic event. Later matching occurrences do not trigger another request, including from process-level drain handlers. Their counts are summarized periodically without repeating run IDs, recent chunks, or debug log tails.

If a tool or error aggregate spans multiple agents in a shared listener process, it omits agent attribution rather than assigning the whole aggregate to the last active agent. Flush calls also recheck the queue after an in-flight request so aggregates added during shutdown are sent before exit.

## Limits
Distinct error fingerprints are still reported individually. The in-memory fingerprint set is bounded to 128 entries; this change targets repeated identical failures rather than sampling unrelated errors.

## Validation
- focused telemetry tests: 30 passed
- complete repository check: 12 of 12 checks passed
- full test suite: 5,115 passed and 26 skipped; 14 environment-dependent failures were outside the changed paths. A targeted run on main reproduced 13 of those failures, while the remaining local prompt parity test passed in isolation.

## Risk
The event names and existing required payload fields are unchanged. Older servers accept the aggregates using the legacy fields and may discard only the new optional per-tool breakdown until their schema is updated.

Co-authored-by: Charles Packer <packercharles@gmail.com>

👾 Generated with [Letta Code](https://letta.com)