### PR TITLE
fix(local): resolve wrapped catalog and registered provider handles

### DIFF
--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -58,6 +58,9 @@ function normalizeOpenAICompatibleLocalModelHandle(
 ): string | undefined {
   if (!model?.startsWith("openai/")) return model;
   const nestedHandle = model.slice("openai/".length);
+  if (resolveRegisteredPiProviderFromModelHandle(nestedHandle)) {
+    return nestedHandle;
+  }
   const nestedProvider = resolveProviderFromModelHandle(nestedHandle);
   if (!nestedProvider) return model;
   const nestedSpec = getPiProviderSpec(nestedProvider);

--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -60,8 +60,9 @@ function normalizeOpenAICompatibleLocalModelHandle(
   const nestedHandle = model.slice("openai/".length);
   const nestedProvider = resolveProviderFromModelHandle(nestedHandle);
   if (!nestedProvider) return model;
-  return getPiProviderSpec(nestedProvider).localModelDiscovery ===
-    "openai-compatible"
+  const nestedSpec = getPiProviderSpec(nestedProvider);
+  return nestedSpec.piProvider !== undefined ||
+    nestedSpec.localModelDiscovery === "openai-compatible"
     ? nestedHandle
     : model;
 }

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -624,6 +624,20 @@ describe("pi model factory", () => {
     }
   });
 
+  test("normalizes wrapped OpenCode Go catalog handles", async () => {
+    const resolved = await resolvePiModelForAgent(
+      "openai/opencode-go/deepseek-v4-flash",
+      { provider_type: "openai" },
+    );
+
+    expect(resolved.provider).toBe("opencode-go");
+    expect(resolved.model).toMatchObject({
+      id: "deepseek-v4-flash",
+      provider: "opencode-go",
+      baseUrl: "https://opencode.ai/zen/go/v1",
+    });
+  });
+
   test("does not let local no-key placeholders mask LM Studio env API keys", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "pi-lmstudio-env-key-"));
     try {

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -638,6 +638,44 @@ describe("pi model factory", () => {
     });
   });
 
+  test("normalizes wrapped registered provider handles", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "pi-registered-provider-handle-"),
+    );
+    try {
+      registerPiProvider("bifrost-openai", {
+        api: "openai-completions",
+        apiKey: "test",
+        baseUrl: "http://bifrost.invalid/v1",
+        listModels: () => [
+          {
+            id: "opencode-go/deepseek-v4-flash",
+            name: "DeepSeek V4 Flash via Bifrost",
+            reasoning: true,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 128000,
+            maxTokens: 8192,
+          },
+        ],
+      });
+
+      const resolved = await resolvePiModelForAgent(
+        "openai/bifrost-openai/opencode-go/deepseek-v4-flash",
+        { provider_type: "openai" },
+        { localProviderAuthStorageDir: storageDir },
+      );
+
+      expect(resolved.model).toMatchObject({
+        id: "opencode-go/deepseek-v4-flash",
+        provider: "bifrost-openai",
+        baseUrl: "http://bifrost.invalid/v1",
+      });
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
   test("does not let local no-key placeholders mask LM Studio env API keys", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "pi-lmstudio-env-key-"));
     try {


### PR DESCRIPTION
## Summary

- **Unwrap `openai/` prefix for built-in catalog providers** (e.g. `opencode-go`) so their provider identity survives legacy model-handle reconstruction.
- **Unwrap `openai/` prefix for mod-registered providers** (e.g. Bifrost) so dynamically registered providers route correctly instead of falling back to `openai`.

## Problem

`buildModelSettings()` in `src/agent/modify.ts` has no case for providers outside its hardcoded list. Any unrecognized provider hits an `else` fallback that stamps `provider_type: "openai"`. This stale type persists into conversation/agent state.

At turn time, `normalizeOpenAICompatibleLocalModelHandle()` only unwrapped the `openai/` prefix for providers with `localModelDiscovery === "openai-compatible"` (LM Studio, llama.cpp, Ollama). Built-in catalog providers and mod-registered providers were left wrapped, producing:

```
Unknown model "opencode-go/deepseek-v4-flash" for provider "openai"
Unknown model "bifrost-openai/opencode-go/deepseek-v4-flash" for provider "openai"
```

## Fix

Two conditions added to `normalizeOpenAICompatibleLocalModelHandle()` in `src/backend/dev/pi-model-factory.ts`:

1. **Catalog providers** — unwrap when `spec.piProvider !== undefined`.
2. **Mod-registered providers** — unwrap when `resolveRegisteredPiProviderFromModelHandle(nestedHandle)` succeeds.

## Test plan

- [x] `normalizes wrapped OpenCode Go catalog handles` — `openai/opencode-go/deepseek-v4-flash` → provider `opencode-go`
- [x] `normalizes wrapped registered provider handles` — `openai/bifrost-openai/opencode-go/deepseek-v4-flash` → provider `bifrost-openai`
- [x] Existing `normalizes wrapped llama.cpp handles` still passes
- [x] `tsc --noEmit` clean
- [x] `biome check` clean

👾 Generated with [Letta Code](https://letta.com)
