### PR TITLE
fix(agent): opt out of assistant message conversion

### DIFF
--- a/src/agent/message-client-skills.test.ts
+++ b/src/agent/message-client-skills.test.ts
@@ -33,3 +33,16 @@ describe("buildConversationMessagesCreateRequestBody client_skills", () => {
     ]);
   });
 });
+
+describe("buildConversationMessagesCreateRequestBody use_assistant_message", () => {
+  test("opts out of assistant message conversion", () => {
+    const body = buildConversationMessagesCreateRequestBody(
+      "conversation-1",
+      [{ type: "message", role: "user", content: "hello" }],
+      {},
+      [],
+    );
+
+    expect(body.use_assistant_message).toBe(false);
+  });
+});

--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -271,6 +271,7 @@ function buildRequestBodyFromPreparedMessages(
     client_skills: clientSkills,
     client_tools: clientTools,
     include_compaction_messages: true,
+    use_assistant_message: false,
     ...(opts.overrideModel ? { override_model: opts.overrideModel } : {}),
     ...(isDefaultConversation ? { agent_id: opts.agentId } : {}),
   };


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Summary
- Adds use_assistant_message: false to the single Letta Code conversation request-body builder.
- Covers CLI, Desktop environment listeners, and channel turns that all send through this boundary.
- Adds a focused regression on the generated request body.

## Why
Core still defaults the deprecated assistant-message conversion mode to true. If a modern agent has the legacy send_message tool attached, omitting this field can cause the tool payload to be projected as another assistant response.

## Scope
This is the Letta Code half of LET-9712 PR0. It does not remove the Core/API field or change public SDK defaults. Companion Cloud/UI containment: https://github.com/letta-ai/letta-cloud/pull/13037

## Validation
- bun test src/agent/message-client-skills.test.ts
- bun run check: 12 of 12 checks passed

👾 Generated by Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)