### PR TITLE
fix(app-server): honor runtime skill sources

### DIFF
--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -10,6 +10,7 @@ import type {
   LettaStreamingResponse,
 } from "@letta-ai/letta-client/resources/agents/messages";
 import type { MessageCreateParams as ConversationMessageCreateParams } from "@letta-ai/letta-client/resources/conversations/messages";
+import type { SkillSource } from "@/agent/skill-sources";
 import { type Backend, getBackend } from "@/backend";
 import {
   type ClientTool,
@@ -190,6 +191,8 @@ export type SendMessageStreamOptions = {
   /** Per-conversation permission mode state. When provided, tool execution uses
    *  this scoped state instead of the global permissionMode singleton. */
   permissionModeState?: PermissionModeState;
+  /** Per-request skill sources. An empty array disables client skills. */
+  skillSources?: SkillSource[];
   /**
    * Per-request model override. Uses backend request-scoped override_model and
    * does not mutate agent/conversation persisted model configuration.
@@ -346,7 +349,7 @@ export async function sendMessageStreamWithBackend(
   const { clientSkills, errors: clientSkillDiscoveryErrors } =
     await buildClientSkillsPayload({
       agentId: opts.agentId,
-      skillSources: getSkillSources(),
+      skillSources: opts.skillSources ?? getSkillSources(),
     });
 
   const resolvedConversationId = conversationId;

--- a/src/agent/send-message-stream-skill-sources.test.ts
+++ b/src/agent/send-message-stream-skill-sources.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import type { Stream } from "@letta-ai/letta-client/core/streaming";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
+import type { MessageCreateParams } from "@letta-ai/letta-client/resources/conversations/messages";
+import type { Backend } from "@/backend";
+import { sendMessageStreamWithBackend } from "./message";
+
+describe("sendMessageStream skill sources", () => {
+  test("sends no client skills when the runtime override is empty", async () => {
+    let recordedBody: MessageCreateParams | undefined;
+    const stream = {
+      async *[Symbol.asyncIterator]() {},
+    } as unknown as Stream<LettaStreamingResponse>;
+    const backend = {
+      createConversationMessageStream: async (
+        _conversationId: string,
+        body: MessageCreateParams,
+      ) => {
+        recordedBody = body;
+        return stream;
+      },
+    } as unknown as Backend;
+
+    await sendMessageStreamWithBackend(
+      backend,
+      "conv-no-skills",
+      [{ role: "user", content: "Reflect on this trajectory." }],
+      {
+        streamTokens: true,
+        background: true,
+        skillSources: [],
+        preparedToolContext: {
+          contextId: "ctx-no-skills",
+          clientTools: [],
+          loadedToolNames: [],
+        },
+      },
+    );
+
+    expect(recordedBody?.client_skills).toEqual([]);
+  });
+});

--- a/src/agent/skill-sources.ts
+++ b/src/agent/skill-sources.ts
@@ -27,6 +27,13 @@ function isSkillSource(value: string): value is SkillSource {
   return ALL_SKILL_SOURCES.includes(value as SkillSource);
 }
 
+export function isSkillSourceArray(value: unknown): value is SkillSource[] {
+  return (
+    Array.isArray(value) &&
+    value.every((item) => typeof item === "string" && isSkillSource(item))
+  );
+}
+
 function normalizeSkillSources(sources: SkillSource[]): SkillSource[] {
   const sourceSet = new Set(sources);
   return ALL_SKILL_SOURCES.filter((source) => sourceSet.has(source));

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -1,6 +1,7 @@
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import { resolveModel } from "@/agent/model";
 import { resolveModelHandleFromLlmConfig } from "@/agent/model-handles";
+import type { SkillSource } from "@/agent/skill-sources";
 import { getBackend } from "@/backend";
 import { getClient } from "@/backend/api/client";
 import type { MessageChannelToolDiscoveryScope } from "@/channels/message-tool";
@@ -427,6 +428,7 @@ export async function prepareToolExecutionContextForScope(params: {
   externalToolScopeIds?: string[];
   workingDirectory?: string;
   permissionModeState?: PermissionModeState;
+  skillSources?: SkillSource[];
   cachedAgent?: AgentState | null;
   channelTurnSources?: import("@/channels/types").ChannelTurnSource[];
   modContext?: ModContext;
@@ -443,6 +445,7 @@ export async function prepareToolExecutionContextForScope(params: {
     externalToolScopeIds,
     workingDirectory,
     permissionModeState,
+    skillSources,
     cachedAgent,
     channelTurnSources: explicitChannelTurnSources,
     modContext,
@@ -526,6 +529,7 @@ export async function prepareToolExecutionContextForScope(params: {
       agentName: (agent as AgentState).name ?? null,
       conversationId: scopedConversationId,
       workingDirectory,
+      ...(skillSources !== undefined ? { skillSources } : {}),
       ...(channelToolScope.channels.length > 0 ? { channelToolScope } : {}),
       ...(inheritedChannelTurnSources.length > 0
         ? { channelTurnSources: inheritedChannelTurnSources }

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -822,7 +822,6 @@ export interface RuntimeStartExternalToolsGroup {
   scope_id?: string;
   tools: readonly ExternalToolDefinitionPayload[];
 }
-
 export interface RuntimeStartCommand {
   type: "runtime_start";
   /** Echoed back in the response for request correlation. */
@@ -839,6 +838,7 @@ export interface RuntimeStartCommand {
   cwd?: string | null;
   /** Initial permission mode for this runtime scope. */
   mode?: DevicePermissionMode;
+  skill_sources?: readonly ("bundled" | "global" | "agent" | "project")[];
   /** Optional client metadata for diagnostics/future protocol negotiation. */
   client_info?: RuntimeStartClientInfo;
   /** Whether to probe backend state for stale pending approvals before replaying state. Defaults to true. */

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -122,6 +122,7 @@ function createLegacyTestRuntime(): ConversationRuntime & {
   socket: WebSocket | null;
   workingDirectoryByConversation: Map<string, string>;
   permissionModeByConversation: ListenerRuntime["permissionModeByConversation"];
+  skillSourcesByConversation: ListenerRuntime["skillSourcesByConversation"];
   reminderStateByConversation: ListenerRuntime["reminderStateByConversation"];
   contextTrackerByConversation: ListenerRuntime["contextTrackerByConversation"];
   systemPromptRecompileByConversation: ListenerRuntime["systemPromptRecompileByConversation"];
@@ -162,6 +163,7 @@ function createLegacyTestRuntime(): ConversationRuntime & {
     socket: WebSocket | null;
     workingDirectoryByConversation: Map<string, string>;
     permissionModeByConversation: ListenerRuntime["permissionModeByConversation"];
+    skillSourcesByConversation: ListenerRuntime["skillSourcesByConversation"];
     reminderStateByConversation: ListenerRuntime["reminderStateByConversation"];
     contextTrackerByConversation: ListenerRuntime["contextTrackerByConversation"];
     systemPromptRecompileByConversation: ListenerRuntime["systemPromptRecompileByConversation"];
@@ -211,6 +213,12 @@ function createLegacyTestRuntime(): ConversationRuntime & {
       get: () => listener.permissionModeByConversation,
       set: (value: ListenerRuntime["permissionModeByConversation"]) => {
         listener.permissionModeByConversation = value;
+      },
+    },
+    skillSourcesByConversation: {
+      get: () => listener.skillSourcesByConversation,
+      set: (value: ListenerRuntime["skillSourcesByConversation"]) => {
+        listener.skillSourcesByConversation = value;
       },
     },
     reminderStateByConversation: {

--- a/src/websocket/listener/commands/runtime-start-skill-sources.test.ts
+++ b/src/websocket/listener/commands/runtime-start-skill-sources.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type WebSocket from "ws";
+import { __testSetBackend, type AgentCreateBody } from "@/backend";
+import { LocalBackend } from "@/backend/local";
+import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
+import { createRuntime } from "@/websocket/listener/lifecycle";
+import { evictConversationRuntimeIfIdle } from "@/websocket/listener/runtime";
+import { handleRuntimeStartCommand } from "./runtime-start";
+
+describe("runtime_start skill sources", () => {
+  afterEach(() => {
+    __testSetBackend(null);
+  });
+
+  test("keeps an empty override across idle runtime eviction", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "runtime-skills-"));
+    try {
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+      });
+      __testSetBackend(backend);
+      const agent = await backend.createAgent({
+        name: "Skill-less SDK worker",
+        model: "anthropic/claude-sonnet-4-6",
+      } as AgentCreateBody);
+      const listener = createRuntime();
+
+      await handleRuntimeStartCommand(
+        {
+          type: "runtime_start",
+          request_id: "runtime-no-skills",
+          agent_id: agent.id,
+          conversation_id: "default",
+          skill_sources: [],
+          recover_approvals: false,
+        },
+        {
+          socket: {} as WebSocket,
+          runtime: listener,
+          safeSocketSend: () => true,
+          runDetachedListenerTask: () => {},
+          getOrCreateScopedRuntime,
+          replaySyncStateForRuntime: async () => {},
+        },
+      );
+
+      const scoped = getOrCreateScopedRuntime(listener, agent.id, "default");
+      expect(scoped.skillSources).toEqual([]);
+      expect(listener.skillSourcesByConversation.get(scoped.key)).toEqual([]);
+      expect(evictConversationRuntimeIfIdle(scoped)).toBe(true);
+
+      const restored = getOrCreateScopedRuntime(listener, agent.id, "default");
+      expect(restored).not.toBe(scoped);
+      expect(restored.skillSources).toEqual([]);
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/websocket/listener/commands/runtime-start.ts
+++ b/src/websocket/listener/commands/runtime-start.ts
@@ -198,6 +198,18 @@ async function applyRuntimeStartState(
   scope: RuntimeScope,
   scopedRuntime: ConversationRuntime,
 ): Promise<void> {
+  if (parsed.skill_sources === undefined) {
+    scopedRuntime.skillSources = undefined;
+    context.runtime.skillSourcesByConversation.delete(scopedRuntime.key);
+  } else {
+    const skillSources = [...new Set(parsed.skill_sources)];
+    scopedRuntime.skillSources = skillSources;
+    context.runtime.skillSourcesByConversation.set(
+      scopedRuntime.key,
+      skillSources,
+    );
+  }
+
   if (parsed.mode) {
     const mode = migratePermissionMode(parsed.mode);
     if (!mode) {

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -872,7 +872,6 @@ export function enqueueChannelTurn(
 
   return enqueuedItem;
 }
-
 export function createRuntime(): ListenerRuntime {
   const bootWorkingDirectory = getCurrentWorkingDirectory();
   return {
@@ -896,6 +895,7 @@ export function createRuntime(): ListenerRuntime {
     workingDirectoryByConversation: loadPersistedCwdMap(),
     worktreeWatcherByConversation: new Map(),
     permissionModeByConversation: loadPersistedPermissionModeMap(),
+    skillSourcesByConversation: new Map(),
     reminderStateByConversation: new Map(),
     contextTrackerByConversation: new Map(),
     systemPromptRecompileByConversation: new Map(),
@@ -938,11 +938,11 @@ export function stopRuntime(
   runtime.approvalRuntimeKeyByRequestId.clear();
   clearListenerWarmState(runtime);
   runtime.reminderStateByConversation.clear();
+  runtime.skillSourcesByConversation.clear();
   runtime.contextTrackerByConversation.clear();
   runtime.systemPromptRecompileByConversation.clear();
   runtime.queuedSystemPromptRecompileByConversation.clear();
   stopAllWorktreeWatchers(runtime);
-
   if (!runtime.socket) {
     if (
       runtime.streamSocket &&

--- a/src/websocket/listener/protocol-inbound.test.ts
+++ b/src/websocket/listener/protocol-inbound.test.ts
@@ -29,6 +29,7 @@ describe("agent/conversation management protocol-inbound validators", () => {
       create_conversation: { body: { summary: "New conversation" } },
       cwd: "/tmp/project",
       mode: "acceptEdits",
+      skill_sources: [],
       client_info: { name: "test", title: "Test", version: "1.0.0" },
       external_tools: [
         {
@@ -127,6 +128,12 @@ describe("agent/conversation management protocol-inbound validators", () => {
       request_id: "r0",
       agent_id: "agent-1",
       mode: "bad",
+    },
+    {
+      type: "runtime_start",
+      request_id: "r0",
+      agent_id: "agent-1",
+      skill_sources: ["bundled", "invalid"],
     },
     {
       type: "runtime_start",

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -1,4 +1,5 @@
 import type WebSocket from "ws";
+import { isSkillSourceArray } from "@/agent/skill-sources";
 import { isValidChannelPluginConfigPayload } from "@/channels/account-config";
 import { isSupportedChannelId } from "@/channels/plugin-registry";
 import type { ExperimentId } from "@/experiments/types";
@@ -120,7 +121,6 @@ function isStringArray(value: unknown): value is string[] {
     Array.isArray(value) && value.every((item) => typeof item === "string")
   );
 }
-
 function isStringRecord(value: unknown): value is Record<string, string> {
   return (
     !!value &&
@@ -419,7 +419,6 @@ function isRuntimeStartCreateConversationOptions(value: unknown): boolean {
   if (!isObjectRecord(value)) return false;
   return value.body === undefined || isObjectRecord(value.body);
 }
-
 function isRuntimeStartClientInfo(value: unknown): boolean {
   if (!isObjectRecord(value)) return false;
   return (
@@ -447,7 +446,6 @@ function isRuntimeStartExternalToolsGroup(value: unknown): boolean {
     value.tools.every(isExternalToolDefinitionPayload)
   );
 }
-
 export function isRuntimeStartCommand(
   value: unknown,
 ): value is RuntimeStartCommand {
@@ -461,6 +459,7 @@ export function isRuntimeStartCommand(
     create_conversation?: unknown;
     cwd?: unknown;
     mode?: unknown;
+    skill_sources?: unknown;
     client_info?: unknown;
     recover_approvals?: unknown;
     force_device_status?: unknown;
@@ -478,6 +477,7 @@ export function isRuntimeStartCommand(
       isRuntimeStartCreateConversationOptions(c.create_conversation)) &&
     (c.cwd === undefined || c.cwd === null || typeof c.cwd === "string") &&
     (c.mode === undefined || isDevicePermissionMode(c.mode)) &&
+    (c.skill_sources === undefined || isSkillSourceArray(c.skill_sources)) &&
     (c.client_info === undefined || isRuntimeStartClientInfo(c.client_info)) &&
     (c.recover_approvals === undefined ||
       typeof c.recover_approvals === "boolean") &&

--- a/src/websocket/listener/runtime.ts
+++ b/src/websocket/listener/runtime.ts
@@ -156,6 +156,7 @@ export function createConversationRuntime(
     key: runtimeKey,
     agentId: normalizedAgentId,
     conversationId: normalizedConversationId,
+    skillSources: listener.skillSourcesByConversation.get(runtimeKey)?.slice(),
     activeChannelTurn: null,
     turnLifecycle,
     messageQueue: Promise.resolve(),

--- a/src/websocket/listener/turn-setup.ts
+++ b/src/websocket/listener/turn-setup.ts
@@ -254,6 +254,7 @@ export async function prepareListenerTurn(params: {
     externalToolScopeIds: msg.externalToolScopeIds,
     workingDirectory,
     permissionModeState,
+    skillSources: runtime.skillSources,
     cachedAgent,
     channelTurnSources: msg.channelTurnSources,
     modEvents: ensureListenerModAdapter(runtime.listener).events,

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -249,6 +249,9 @@ export async function handleIncomingMessage(
       background: true,
       workingDirectory: turnWorkingDirectory,
       permissionModeState: turnPermissionModeState,
+      ...(runtime.skillSources !== undefined
+        ? { skillSources: runtime.skillSources }
+        : {}),
       preparedToolContext: preparedToolContext.preparedToolContext,
       ...(turnInput.imageFailureModesByMessageOtid
         ? {

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -5,6 +5,7 @@ import type {
   ApprovalDecision,
   ApprovalResult,
 } from "@/agent/approval-execution";
+import type { SkillSource } from "@/agent/skill-sources";
 import type { ChannelTurnSource } from "@/channels/types";
 import type { ContextTracker } from "@/cli/helpers/context-tracker";
 import type { ApprovalRequest } from "@/cli/helpers/stream";
@@ -142,6 +143,8 @@ export type ConversationRuntime = {
   key: string;
   agentId: string | null;
   conversationId: string;
+  /** Runtime-scoped SDK override. Undefined uses the process defaults. */
+  skillSources: SkillSource[] | undefined;
   activeChannelTurn: ActiveChannelTurn | null;
   turnLifecycle: TurnLifecycle;
   messageQueue: Promise<void>;
@@ -217,6 +220,8 @@ export type ListenerRuntime = {
     string,
     import("@/websocket/listener/permission-mode").ConversationPermissionModeState
   >;
+  /** Per-conversation skill overrides survive idle ConversationRuntime eviction. */
+  skillSourcesByConversation: Map<string, SkillSource[]>;
   /** Per-conversation reminder state survives ConversationRuntime eviction. */
   reminderStateByConversation: Map<string, SharedReminderState>;
   /** Per-conversation context tracker survives ConversationRuntime eviction. */


### PR DESCRIPTION
## Summary

- accept and validate skill_sources on app-server runtime_start commands
- keep the override conversation-scoped across idle runtime eviction
- pass the override through tool preparation and client_skills generation so an empty array disables all skills

## Why

The Letta Agent SDK already sends skill_sources: [] for stateless reflection and aggregation workers, but the app-server receiver ignored the field. Those workers therefore inherited bundled, global, agent, and project skills.

## Validation

- bun run check
- bun test src/websocket/listener/protocol-inbound.test.ts src/websocket/listener/commands/runtime-start-skill-sources.test.ts src/agent/send-message-stream-skill-sources.test.ts
