### PR TITLE
fix(channels): preserve unresolved secret refs

### DIFF
--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -159,16 +159,6 @@ function markSecretRef(account: ChannelAccount, fieldPath: string): void {
   };
 }
 
-function unmarkSecretRef(account: ChannelAccount, fieldPath: string): void {
-  const refs = getSecretRefs(account);
-  delete refs[fieldPath];
-  if (Object.keys(refs).length === 0) {
-    delete (account as ChannelAccountWithSecretRefs)[CHANNEL_SECRET_REFS_KEY];
-    return;
-  }
-  (account as ChannelAccountWithSecretRefs)[CHANNEL_SECRET_REFS_KEY] = refs;
-}
-
 function applySecretPlaceholders(account: ChannelAccount): void {
   const refs = getSecretRefs(account);
   for (const fieldPath of Object.keys(refs)) {
@@ -603,7 +593,6 @@ export async function hydrateChannelAccountSecrets(
   }
 
   let migratedPlaintextSecrets = false;
-  let removedMissingSecretRefs = false;
 
   for (const account of store.accounts) {
     for (const fieldPath of getSecretFieldPaths(account)) {
@@ -626,17 +615,13 @@ export async function hydrateChannelAccountSecrets(
           );
           if (storedValue) {
             setSecretValueOnAccount(account, fieldPath, storedValue);
-          } else {
-            unmarkSecretRef(account, fieldPath);
-            setSecretValueOnAccount(account, fieldPath, "");
-            removedMissingSecretRefs = true;
           }
         }
       }
     }
   }
 
-  if (migratedPlaintextSecrets || removedMissingSecretRefs) {
+  if (migratedPlaintextSecrets) {
     saveChannelAccounts(channelId);
     await flushPendingChannelSecretWrites();
   }

--- a/src/channels/credential-store.test.ts
+++ b/src/channels/credential-store.test.ts
@@ -26,7 +26,10 @@ import {
   buildChannelSecretName,
   getActiveChannelCredentialsStoreMode,
 } from "@/channels/credential-store";
-import type { SlackChannelAccount } from "@/channels/types";
+import type {
+  SlackChannelAccount,
+  TelegramChannelAccount,
+} from "@/channels/types";
 
 function readAccountsFile(root: string, channelId: string): unknown {
   return JSON.parse(
@@ -48,6 +51,27 @@ function makeSlackAccount(): SlackChannelAccount {
     allowedUsers: [],
     createdAt: "2026-05-26T00:00:00.000Z",
     updatedAt: "2026-05-26T00:00:00.000Z",
+  };
+}
+
+function makeTelegramAccountWithSecretRef(): Record<string, unknown> {
+  return {
+    channel: "telegram",
+    accountId: "telegram-account",
+    enabled: true,
+    dmPolicy: "pairing",
+    allowedUsers: [],
+    binding: {
+      agentId: null,
+      conversationId: null,
+    },
+    transcribe_voice: false,
+    rich_private_chat_default: true,
+    createdAt: "2026-05-26T00:00:00.000Z",
+    updatedAt: "2026-05-26T00:00:00.000Z",
+    __letta_secret_refs: {
+      token: true,
+    },
   };
 }
 
@@ -141,6 +165,40 @@ describe("channel credential storage", () => {
     expect(persistedText).not.toContain("xoxb-secret");
     expect(persistedText).not.toContain("xapp-secret");
     expect(persistedText).toContain("__letta_secret_refs");
+  });
+
+  test("keyring mode preserves unresolved Telegram token refs on restart", async () => {
+    __setActiveChannelCredentialsStoreModeForTests("keyring");
+    mkdirSync(join(channelsRoot, "telegram"), { recursive: true });
+    const accountsPath = join(channelsRoot, "telegram", "accounts.json");
+    writeFileSync(
+      accountsPath,
+      `${JSON.stringify(
+        { accounts: [makeTelegramAccountWithSecretRef()] },
+        null,
+        2,
+      )}\n`,
+    );
+    const beforeHydration = readFileSync(accountsPath, "utf-8");
+
+    await hydrateChannelAccountSecrets("telegram");
+
+    expect(readFileSync(accountsPath, "utf-8")).toBe(beforeHydration);
+    const persisted = readAccountsFile(channelsRoot, "telegram") as {
+      accounts: Array<Record<string, unknown>>;
+    };
+    expect(persisted.accounts[0]).toMatchObject({
+      __letta_secret_refs: {
+        token: true,
+      },
+    });
+    expect(persisted.accounts[0]).not.toHaveProperty("token", "");
+
+    const hydrated = (await getChannelAccountWithSecrets(
+      "telegram",
+      "telegram-account",
+    )) as TelegramChannelAccount | null;
+    expect(hydrated?.token).toBe("__letta_channel_secret_present__");
   });
 
   test("deleting an account removes keyring secrets", async () => {


### PR DESCRIPTION
## Summary
- preserve keyring-backed channel secret refs when restart hydration cannot read the referenced secret
- stop rewriting the account file with an empty Telegram token
- add a real accounts.json regression for LET-9461

## Scope
This replaces #3270 with the narrow fix for the original restart/hydration failure. It does not change blank settings-save policy, plugin secrets, mutation locking, or account transaction behavior.

## Proof
The regression fails on current main because hydration removes `__letta_secret_refs.token` and persists `token: ""`. It passes with this patch and verifies the account file remains byte-for-byte unchanged.

## Validation
- `bun test src/channels/credential-store.test.ts src/websocket/listen-client-channel-accounts.test.ts` — 14 pass
- `bun run check` — 12 checks pass

Linear: LET-9461

👾 Generated with [Letta Code](https://letta.com)