### PR TITLE
fix(test): disable telemetry in unit runner

### DIFF
--- a/scripts/isolated-unit-tests.json
+++ b/scripts/isolated-unit-tests.json
@@ -31,6 +31,18 @@
       "reason": "Mutates the settings singleton, keychain test overrides, HOME, and the secrets service name."
     },
     {
+      "path": "src/telemetry/flush-auth.test.ts",
+      "timeoutMs": 15000,
+      "env": { "LETTA_CODE_TELEM": "1" },
+      "reason": "Explicitly exercises telemetry emission with mocked network requests."
+    },
+    {
+      "path": "src/telemetry/flush-batching.test.ts",
+      "timeoutMs": 15000,
+      "env": { "LETTA_CODE_TELEM": "1" },
+      "reason": "Explicitly exercises telemetry batching with mocked network requests."
+    },
+    {
       "path": "src/tools/bash.test.ts",
       "timeoutMs": 30000,
       "reason": "Spawns real shells and temporarily mutates process platform and PATH state."

--- a/scripts/run-unit-tests.cjs
+++ b/scripts/run-unit-tests.cjs
@@ -82,12 +82,12 @@ for (const entry of isolatedTests) {
   }
 }
 
-function runTests(files, timeoutMs) {
+function runTests(files, timeoutMs, env = {}) {
   execFileSync("bun", ["test", ...files, "--timeout", String(timeoutMs)], {
     stdio: "inherit",
     // Unit tests must never emit product telemetry or make test fixtures look
-    // like real users. Override any inherited opt-in from the parent shell.
-    env: { ...process.env, LETTA_CODE_TELEM: "0" },
+    // like real users. Only isolated telemetry contract tests may opt back in.
+    env: { ...process.env, LETTA_CODE_TELEM: "0", ...env },
   });
 }
 
@@ -119,7 +119,7 @@ let exitCode = 0;
 // the ordinary unit batch or inherit another suite's cwd/env/module registry.
 for (const entry of isolatedTests) {
   try {
-    runTests([entry.path], entry.timeoutMs);
+    runTests([entry.path], entry.timeoutMs, entry.env);
   } catch (error) {
     exitCode = error.status ?? 1;
   }

--- a/scripts/run-unit-tests.cjs
+++ b/scripts/run-unit-tests.cjs
@@ -85,6 +85,9 @@ for (const entry of isolatedTests) {
 function runTests(files, timeoutMs) {
   execFileSync("bun", ["test", ...files, "--timeout", String(timeoutMs)], {
     stdio: "inherit",
+    // Unit tests must never emit product telemetry or make test fixtures look
+    // like real users. Override any inherited opt-in from the parent shell.
+    env: { ...process.env, LETTA_CODE_TELEM: "0" },
   });
 }
 


### PR DESCRIPTION
## Summary
- disable product telemetry by default in every Bun subprocess launched by the unit-test runner
- isolate the two network-mocked telemetry contract suites and explicitly opt them back in
- override inherited parent-shell opt-ins so ordinary test fixtures cannot be emitted as product telemetry

## Why
The historical shared test runner could accumulate 50 fixture events and trigger the real telemetry batch flush. Test isolation removed that specific trigger, but disabling telemetry at the runner boundary prevents it from returning when suites are regrouped.

## Validation
- [x] `bun run check`
- [x] telemetry contract tests: 15 passed
- [x] verified isolated and shared child processes default to `LETTA_CODE_TELEM=0` even when the parent sets it to 1
- [x] verified only isolated, fetch-mocked telemetry contract suites receive `LETTA_CODE_TELEM=1`
- [x] guarded threshold reproduction: enabled telemetry attempted one metadata send; runner-disabled telemetry queued zero events and attempted zero sends

## Risk
Unit-test subprocesses only. Direct product and integration-test telemetry behavior is unchanged.

Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

👾 Generated with [Letta Code](https://letta.com)