### PR TITLE
feat(channels): add feedback command [LET-9741]

### DIFF
--- a/src/channels/commands.test.ts
+++ b/src/channels/commands.test.ts
@@ -26,8 +26,66 @@ import {
   parseChannelSlashCommand,
   tryHandleChannelSlashCommand,
 } from "@/channels/commands";
+import {
+  __testOverrideSubmitChannelFeedback,
+  buildChannelFeedbackFailedMessage,
+  buildChannelFeedbackNoRouteMessage,
+  buildChannelFeedbackSubmittedMessage,
+  buildChannelFeedbackTooLongMessage,
+  buildChannelFeedbackUsageMessage,
+  CHANNEL_FEEDBACK_MESSAGE_MAX,
+} from "@/channels/feedback";
 import { buildSlackModelPickerBlocks } from "@/channels/slack/model-picker-blocks";
-import type { ChannelAdapter, InboundChannelMessage } from "@/channels/types";
+import type {
+  ChannelAdapter,
+  ChannelRoute,
+  InboundChannelMessage,
+} from "@/channels/types";
+
+type CapturedDirectReply = {
+  chatId: string;
+  text: string;
+  options?: Parameters<ChannelAdapter["sendDirectReply"]>[2];
+};
+
+function createReplyCapturingAdapter(
+  replies: CapturedDirectReply[],
+  channelId = "telegram",
+): ChannelAdapter {
+  return {
+    id: channelId,
+    channelId,
+    name: channelId,
+    async start() {},
+    async stop() {},
+    isRunning: () => true,
+    async sendMessage() {
+      return { messageId: "sent-1" };
+    },
+    async sendDirectReply(chatId, text, options) {
+      replies.push({ chatId, text, ...(options ? { options } : {}) });
+    },
+  };
+}
+
+function makeRoute(params: {
+  channel: string;
+  accountId: string;
+  chatId: string;
+  threadId?: string | null;
+}): ChannelRoute {
+  return {
+    accountId: params.accountId,
+    chatId: params.chatId,
+    chatType: params.threadId ? "channel" : "direct",
+    threadId: params.threadId ?? null,
+    agentId: `agent-${params.channel}`,
+    conversationId: `conv-${params.channel}`,
+    enabled: true,
+    createdAt: "2026-05-18T00:00:00.000Z",
+    updatedAt: "2026-05-18T00:00:00.000Z",
+  };
+}
 
 describe("channel slash commands", () => {
   test("parses channel slash commands with bot suffixes and args", () => {
@@ -139,6 +197,7 @@ describe("channel slash commands", () => {
       "resume",
       "cancel",
       "chat",
+      "feedback",
       "model",
       "reflection",
     ]) {
@@ -151,7 +210,7 @@ describe("channel slash commands", () => {
     expect(text).toContain("Telegram is connected to Letta Code.");
     expect(text).not.toContain("MessageChannel");
     expect(text).toContain(
-      "Supported slash commands here: /help, /status, /pause, /resume, /cancel, /chat, /model, /reflection.",
+      "Supported slash commands here: /help, /status, /pause, /resume, /cancel, /chat, /feedback, /model, /reflection.",
     );
 
     const slackText = buildChannelHelpMessage("slack");
@@ -169,6 +228,7 @@ describe("channel slash commands", () => {
     expect(slackText).toContain(
       "@agent /model <handle-or-id> - switch this thread's model",
     );
+    expect(slackText).toContain("@agent /feedback <message>");
     expect(slackText).toContain("@agent /detach");
     expect(slackText).toContain("@agent /reload");
     expect(slackText).toContain(
@@ -239,6 +299,276 @@ describe("channel slash commands", () => {
     expect(buildChannelAlreadyActiveMessage("telegram")).toContain(
       "already active",
     );
+  });
+
+  test("builds feedback command messages", () => {
+    expect(buildChannelFeedbackUsageMessage("telegram")).toContain(
+      "Usage: /feedback <message>",
+    );
+    expect(buildChannelFeedbackUsageMessage("slack")).toContain(
+      "Usage: @agent /feedback <message>",
+    );
+    expect(buildChannelFeedbackTooLongMessage("discord")).toContain(
+      "Maximum is 10,000 characters",
+    );
+    expect(buildChannelFeedbackNoRouteMessage("custom")).toContain(
+      "connected to a Letta agent conversation",
+    );
+    expect(buildChannelFeedbackSubmittedMessage("signal")).toContain(
+      "feedback submitted",
+    );
+    expect(buildChannelFeedbackFailedMessage("whatsapp")).toContain(
+      "could not submit feedback right now",
+    );
+  });
+
+  test("submits feedback through the shared route for first-party and custom channels", async () => {
+    const cases: Array<{
+      channel: string;
+      text: string;
+      expectedMessage: string;
+      isMention?: boolean;
+      threadId?: string | null;
+    }> = [
+      {
+        channel: "slack",
+        text: "/feedback Slack feedback",
+        expectedMessage: "Slack feedback",
+        isMention: true,
+        threadId: "thread-secret-slack",
+      },
+      {
+        channel: "telegram",
+        text: "/feedback Telegram feedback\nwith detail",
+        expectedMessage: "Telegram feedback\nwith detail",
+      },
+      {
+        channel: "discord",
+        text: "/feedback Discord feedback",
+        expectedMessage: "Discord feedback",
+      },
+      {
+        channel: "whatsapp",
+        text: "/feedback WhatsApp feedback",
+        expectedMessage: "WhatsApp feedback",
+      },
+      {
+        channel: "signal",
+        text: "/feedback Signal feedback",
+        expectedMessage: "Signal feedback",
+      },
+      {
+        channel: "custom",
+        text: "/feedback Custom feedback",
+        expectedMessage: "Custom feedback",
+      },
+      {
+        channel: "acme-support",
+        text: "/feedback Dynamic plugin feedback",
+        expectedMessage: "Dynamic plugin feedback",
+      },
+    ];
+    const payloads: Record<string, unknown>[] = [];
+    __testOverrideSubmitChannelFeedback(async (payload) => {
+      payloads.push(payload);
+    });
+
+    try {
+      for (const entry of cases) {
+        const replies: CapturedDirectReply[] = [];
+        const adapter = createReplyCapturingAdapter(replies, entry.channel);
+        const accountId = `acct-${entry.channel}`;
+        const chatId = `chat-secret-${entry.channel}`;
+        const route = makeRoute({
+          channel: entry.channel,
+          accountId,
+          chatId,
+          threadId: entry.threadId ?? null,
+        });
+        const msg: InboundChannelMessage = {
+          channel: entry.channel,
+          accountId,
+          chatId,
+          senderId: `sender-secret-${entry.channel}`,
+          senderName: "sender-name-secret",
+          text: entry.text,
+          timestamp: Date.now(),
+          messageId: `message-secret-${entry.channel}`,
+          threadId: entry.threadId ?? null,
+          chatType: entry.threadId ? "channel" : "direct",
+          ...(entry.isMention !== undefined
+            ? { isMention: entry.isMention }
+            : {}),
+          raw: { token: "raw-secret-token" },
+          threadContext: {
+            history: [
+              { senderId: "history-sender", text: "transcript-secret" },
+            ],
+          },
+        };
+
+        await expect(
+          tryHandleChannelSlashCommand(adapter, msg, {
+            statusContext: {
+              adapterRunning: true,
+              accountConfigured: true,
+              accountEnabled: true,
+              route,
+            },
+          }),
+        ).resolves.toBe(true);
+
+        expect(replies).toHaveLength(1);
+        expect(replies[0]?.text).toContain("feedback submitted");
+      }
+    } finally {
+      __testOverrideSubmitChannelFeedback(null);
+    }
+
+    expect(payloads).toHaveLength(cases.length);
+    for (const [index, payload] of payloads.entries()) {
+      const entry = cases[index];
+      expect(Object.keys(payload).sort()).toEqual([
+        "account_id",
+        "agent_id",
+        "channel",
+        "conversation_id",
+        "feature",
+        "message",
+        "platform",
+        "version",
+      ]);
+      expect(payload).toMatchObject({
+        message: entry?.expectedMessage,
+        feature: "letta-code-channel-feedback",
+        channel: entry?.channel,
+        account_id: `acct-${entry?.channel}`,
+        agent_id: `agent-${entry?.channel}`,
+        conversation_id: `conv-${entry?.channel}`,
+        platform: process.platform,
+      });
+    }
+
+    const serializedPayloads = JSON.stringify(payloads);
+    expect(serializedPayloads).not.toContain("sender-secret");
+    expect(serializedPayloads).not.toContain("sender-name-secret");
+    expect(serializedPayloads).not.toContain("chat-secret");
+    expect(serializedPayloads).not.toContain("thread-secret");
+    expect(serializedPayloads).not.toContain("message-secret");
+    expect(serializedPayloads).not.toContain("raw-secret-token");
+    expect(serializedPayloads).not.toContain("transcript-secret");
+    expect(serializedPayloads).not.toContain("run_id");
+    expect(serializedPayloads).not.toContain("settings");
+    expect(serializedPayloads).not.toContain("cwd");
+  });
+
+  test("validates feedback input and requires a connected route before submission", async () => {
+    let submissions = 0;
+    __testOverrideSubmitChannelFeedback(async () => {
+      submissions += 1;
+    });
+
+    try {
+      const route = makeRoute({
+        channel: "telegram",
+        accountId: "acct-telegram",
+        chatId: "chat-telegram",
+      });
+      const validationCases = [
+        {
+          text: "/feedback   ",
+          route,
+          expected: "Usage: /feedback <message>",
+        },
+        {
+          text: `/feedback ${"x".repeat(CHANNEL_FEEDBACK_MESSAGE_MAX + 1)}`,
+          route,
+          expected: "Maximum is 10,000 characters",
+        },
+        {
+          text: "/feedback useful but unpaired",
+          route: null,
+          expected: "cannot submit /feedback until this chat is connected",
+        },
+      ];
+
+      for (const validationCase of validationCases) {
+        const replies: CapturedDirectReply[] = [];
+        const adapter = createReplyCapturingAdapter(replies);
+        const msg: InboundChannelMessage = {
+          channel: "telegram",
+          accountId: "acct-telegram",
+          chatId: "chat-telegram",
+          senderId: "sender-telegram",
+          text: validationCase.text,
+          timestamp: Date.now(),
+          messageId: "msg-telegram",
+        };
+
+        await expect(
+          tryHandleChannelSlashCommand(adapter, msg, {
+            statusContext: {
+              adapterRunning: true,
+              accountConfigured: true,
+              accountEnabled: true,
+              route: validationCase.route,
+            },
+          }),
+        ).resolves.toBe(true);
+
+        expect(replies).toHaveLength(1);
+        expect(replies[0]?.text).toContain(validationCase.expected);
+      }
+    } finally {
+      __testOverrideSubmitChannelFeedback(null);
+    }
+
+    expect(submissions).toBe(0);
+  });
+
+  test("sanitizes feedback submission failures", async () => {
+    __testOverrideSubmitChannelFeedback(async () => {
+      throw new Error("secret-token raw backend exception");
+    });
+
+    try {
+      const replies: CapturedDirectReply[] = [];
+      const adapter = createReplyCapturingAdapter(replies, "discord");
+      const route = makeRoute({
+        channel: "discord",
+        accountId: "acct-discord",
+        chatId: "chat-discord",
+      });
+      const msg: InboundChannelMessage = {
+        channel: "discord",
+        accountId: "acct-discord",
+        chatId: "chat-discord",
+        senderId: "sender-discord",
+        text: "/feedback submission should fail",
+        timestamp: Date.now(),
+        messageId: "msg-discord",
+      };
+
+      await expect(
+        tryHandleChannelSlashCommand(adapter, msg, {
+          statusContext: {
+            adapterRunning: true,
+            accountConfigured: true,
+            accountEnabled: true,
+            route,
+          },
+        }),
+      ).resolves.toBe(true);
+
+      expect(replies).toHaveLength(1);
+      expect(replies[0]?.text).toBe(
+        "Discord could not submit feedback right now. Please try again later.",
+      );
+      expect(replies[0]?.text).not.toContain("secret-token");
+      expect(replies[0]?.text).not.toContain("raw backend exception");
+    } finally {
+      __testOverrideSubmitChannelFeedback(null);
+    }
   });
 
   test("builds cancel command messages", () => {
@@ -429,7 +759,7 @@ describe("channel slash commands", () => {
     expect(text).toContain("Telegram received /compact now");
     expect(text).toContain("not supported in channels yet");
     expect(text).toContain(
-      "Supported slash commands: /help, /status, /pause, /resume, /cancel, /chat, /model, /reflection.",
+      "Supported slash commands: /help, /status, /pause, /resume, /cancel, /chat, /feedback, /model, /reflection.",
     );
     expect(text).toContain("without a leading slash");
 
@@ -439,6 +769,7 @@ describe("channel slash commands", () => {
     );
     expect(slackSlashText).toContain("Supported Slack mention commands:");
     expect(slackSlashText).toContain("@agent /model <handle-or-id>");
+    expect(slackSlashText).toContain("@agent /feedback <message>");
 
     const bangCommand = parseChannelBangCommand("!pause");
     expect(bangCommand).not.toBeNull();

--- a/src/channels/commands.test.ts
+++ b/src/channels/commands.test.ts
@@ -306,7 +306,7 @@ describe("channel slash commands", () => {
       "Usage: /feedback <message>",
     );
     expect(buildChannelFeedbackUsageMessage("slack")).toContain(
-      "Usage: @agent /feedback <message>",
+      "Usage: /feedback <message>",
     );
     expect(buildChannelFeedbackTooLongMessage("discord")).toContain(
       "Maximum is 10,000 characters",

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -1,4 +1,5 @@
 import type { ListModelsResponseModelEntry } from "@/types/protocol_v2";
+import { handleChannelFeedbackCommand } from "./feedback";
 import { getChannelDisplayName } from "./plugin-registry";
 import type {
   ChannelAdapter,
@@ -115,6 +116,11 @@ const CHANNEL_SLASH_COMMANDS: ChannelSlashCommandDefinition[] = [
     name: "chat",
     kind: "direct",
     summary: "Show the Letta web chat link for this channel route.",
+  },
+  {
+    name: "feedback",
+    kind: "direct",
+    summary: "Send feedback about Letta Code from this routed chat.",
   },
   {
     name: "model",
@@ -256,6 +262,7 @@ const SLACK_MENTION_SLASH_COMMAND_EXAMPLES = [
   "@agent /model <handle-or-id>",
   "@agent /cancel",
   "@agent /chat",
+  "@agent /feedback <message>",
   "@agent /reflection",
   "@agent /detach",
   "@agent /new",
@@ -310,6 +317,7 @@ export function buildChannelHelpMessage(channelId: string): string {
       "@agent /status - show route and listener status",
       "@agent /cancel - cancel the current turn",
       "@agent /chat - show the web chat link",
+      "@agent /feedback <message> - send feedback to the Letta team from this routed thread",
       "@agent /reflection - start a memory reflection pass",
       "@agent /detach - stop replying in this thread until mentioned again",
       "@agent /new - start a fresh conversation for this thread",
@@ -877,6 +885,12 @@ export async function tryHandleChannelSlashCommand(
             msg,
             command,
             handler: options.handlers?.chat,
+          });
+        case "feedback":
+          return handleChannelFeedbackCommand({
+            msg,
+            command,
+            route: options.statusContext?.route,
           });
         case "detach":
           if (!isSlackMentionControl) {

--- a/src/channels/feedback.ts
+++ b/src/channels/feedback.ts
@@ -30,17 +30,11 @@ function channelDisplayName(channelId: string): string {
   }
 }
 
-function feedbackCommandUsage(channelId: string): string {
-  return channelId === "slack"
-    ? "@agent /feedback <message>"
-    : "/feedback <message>";
-}
-
 export function buildChannelFeedbackUsageMessage(channelId: string): string {
   const displayName = channelDisplayName(channelId);
   return [
     `${displayName} received /feedback without a message.`,
-    `Usage: ${feedbackCommandUsage(channelId)}`,
+    "Usage: /feedback <message>",
   ].join("\n\n");
 }
 
@@ -56,8 +50,8 @@ export function buildChannelFeedbackNoRouteMessage(channelId: string): string {
   const displayName = channelDisplayName(channelId);
   const instruction =
     channelId === "slack"
-      ? `Mention the app with a normal message in this chat or thread first so it can connect, then try ${feedbackCommandUsage(channelId)}.`
-      : `Send a normal message first and follow the pairing instructions, then try ${feedbackCommandUsage(channelId)}.`;
+      ? "Mention the app with a normal message in this chat or thread first so it can connect, then send /feedback <message> while mentioning the app."
+      : "Send a normal message first and follow the pairing instructions, then try /feedback <message>.";
   return [
     `${displayName} cannot submit /feedback until this chat is connected to a Letta agent conversation.`,
     instruction,

--- a/src/channels/feedback.ts
+++ b/src/channels/feedback.ts
@@ -1,0 +1,157 @@
+import { submitFeedbackMetadata } from "@/backend/api/metadata";
+import { settingsManager } from "@/settings-manager";
+import { getVersion } from "@/version";
+import { getChannelDisplayName } from "./plugin-registry";
+import type { ChannelRoute, InboundChannelMessage } from "./types";
+
+export const CHANNEL_FEEDBACK_MESSAGE_MAX = 10_000;
+
+const CHANNEL_FEEDBACK_FEATURE = "letta-code-channel-feedback";
+
+export interface ChannelFeedbackSubmission {
+  message: string;
+  channel: string;
+  accountId?: string;
+  agentId: string;
+  conversationId: string;
+}
+
+export type ChannelFeedbackMetadataSubmitter = (
+  payload: Record<string, unknown>,
+) => Promise<void>;
+
+let submitOverride: ChannelFeedbackMetadataSubmitter | null = null;
+
+function channelDisplayName(channelId: string): string {
+  try {
+    return getChannelDisplayName(channelId);
+  } catch {
+    return channelId;
+  }
+}
+
+function feedbackCommandUsage(channelId: string): string {
+  return channelId === "slack"
+    ? "@agent /feedback <message>"
+    : "/feedback <message>";
+}
+
+export function buildChannelFeedbackUsageMessage(channelId: string): string {
+  const displayName = channelDisplayName(channelId);
+  return [
+    `${displayName} received /feedback without a message.`,
+    `Usage: ${feedbackCommandUsage(channelId)}`,
+  ].join("\n\n");
+}
+
+export function buildChannelFeedbackTooLongMessage(
+  channelId: string,
+  maxLength: number = CHANNEL_FEEDBACK_MESSAGE_MAX,
+): string {
+  const displayName = channelDisplayName(channelId);
+  return `${displayName} feedback message is too long. Maximum is ${maxLength.toLocaleString()} characters.`;
+}
+
+export function buildChannelFeedbackNoRouteMessage(channelId: string): string {
+  const displayName = channelDisplayName(channelId);
+  const instruction =
+    channelId === "slack"
+      ? `Mention the app with a normal message in this chat or thread first so it can connect, then try ${feedbackCommandUsage(channelId)}.`
+      : `Send a normal message first and follow the pairing instructions, then try ${feedbackCommandUsage(channelId)}.`;
+  return [
+    `${displayName} cannot submit /feedback until this chat is connected to a Letta agent conversation.`,
+    instruction,
+  ].join("\n\n");
+}
+
+export function buildChannelFeedbackSubmittedMessage(
+  channelId: string,
+): string {
+  const displayName = channelDisplayName(channelId);
+  return `${displayName} feedback submitted. Thanks for helping improve Letta Code.`;
+}
+
+export function buildChannelFeedbackFailedMessage(channelId: string): string {
+  const displayName = channelDisplayName(channelId);
+  return `${displayName} could not submit feedback right now. Please try again later.`;
+}
+
+function withDefinedValues(
+  payload: Record<string, unknown>,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(payload).filter(([, value]) => value !== undefined),
+  );
+}
+
+export function buildChannelFeedbackPayload(
+  submission: ChannelFeedbackSubmission,
+): Record<string, unknown> {
+  return withDefinedValues({
+    message: submission.message,
+    feature: CHANNEL_FEEDBACK_FEATURE,
+    version: getVersion(),
+    platform: process.platform,
+    channel: submission.channel,
+    account_id: submission.accountId,
+    agent_id: submission.agentId,
+    conversation_id: submission.conversationId,
+  });
+}
+
+export async function submitChannelFeedback(
+  submission: ChannelFeedbackSubmission,
+): Promise<void> {
+  const payload = buildChannelFeedbackPayload(submission);
+  if (submitOverride) {
+    await submitOverride(payload);
+    return;
+  }
+
+  const settings = settingsManager.getSettings();
+  const apiKey = process.env.LETTA_API_KEY || settings.env?.LETTA_API_KEY;
+  await submitFeedbackMetadata(
+    apiKey,
+    settingsManager.getOrCreateDeviceId(),
+    payload,
+  );
+}
+
+export async function handleChannelFeedbackCommand(params: {
+  msg: InboundChannelMessage;
+  command: { args: string };
+  route?: ChannelRoute | null;
+}): Promise<string> {
+  const message = params.command.args.trim();
+  if (!message) {
+    return buildChannelFeedbackUsageMessage(params.msg.channel);
+  }
+  if (message.length > CHANNEL_FEEDBACK_MESSAGE_MAX) {
+    return buildChannelFeedbackTooLongMessage(params.msg.channel);
+  }
+
+  const route = params.route;
+  if (!route || route.enabled === false) {
+    return buildChannelFeedbackNoRouteMessage(params.msg.channel);
+  }
+
+  try {
+    const accountId = route.accountId ?? params.msg.accountId;
+    await submitChannelFeedback({
+      message,
+      channel: params.msg.channel,
+      ...(accountId !== undefined ? { accountId } : {}),
+      agentId: route.agentId,
+      conversationId: route.conversationId,
+    });
+    return buildChannelFeedbackSubmittedMessage(params.msg.channel);
+  } catch {
+    return buildChannelFeedbackFailedMessage(params.msg.channel);
+  }
+}
+
+export function __testOverrideSubmitChannelFeedback(
+  submitter: ChannelFeedbackMetadataSubmitter | null,
+): void {
+  submitOverride = submitter;
+}


### PR DESCRIPTION
## Summary
- add a shared channel-native /feedback command for first-party and dynamic/custom channels
- require an existing enabled route before submission to avoid an unauthenticated pre-pairing feedback path
- send only the user-authored message plus version, platform, channel/account, agent, and conversation metadata

## Before / after
Before: channel ingress intercepted /feedback and returned “not supported in channels yet.”

After: routed users can send /feedback <message>. Slack advertises @agent /feedback <message>; Telegram, Discord, WhatsApp, Signal, and custom channels use the shared slash-command path.

## Privacy and failure behavior
The channel payload deliberately excludes sender IDs, chat/thread/message IDs, raw events, transcripts, settings, cwd, debug logs, lifecycle errors, and secrets. Empty and over-10,000-character messages are rejected locally. Backend failures return sanitized channel copy without raw exception details.

## Validation
- bun test src/channels/commands.test.ts src/channels/registry-community-copy.test.ts — 33 passed
- bun run check — 12/12 passed
- bun test src — 5,142 passed, 26 skipped, 12 failed; 11 failures reproduced unchanged on base in websocket auth, hook E2E, remote-settings isolation, and product-status tests. The remaining prompt-parity failure passed when rerun independently on base and is order-dependent. None overlap the changed channel files.

## Scope
This validates the shared command boundary used by all adapters. It does not add adapter-specific UI or include channel transcripts in reports.

Linear: https://linear.app/letta/issue/LET-9741/make-feedback-available-in-all-channels

👾 Generated with [Letta Code](https://letta.com)