### PR TITLE
feat: export reusable Slack channel primitives

### DIFF
--- a/build.js
+++ b/build.js
@@ -5,12 +5,61 @@
  * Bundles TypeScript source into a single JavaScript file
  */
 
-import { cpSync, existsSync, readFileSync, rmSync } from "node:fs";
-import { dirname, join } from "node:path";
+import {
+  cpSync,
+  existsSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+
+function walkFiles(root) {
+  const entries = readdirSync(root);
+  const files = [];
+  for (const entry of entries) {
+    const path = join(root, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      files.push(...walkFiles(path));
+      continue;
+    }
+    files.push(path);
+  }
+  return files;
+}
+
+function toDeclarationSpecifier(fromFile, targetRoot, aliasPath) {
+  const targetPath = join(targetRoot, aliasPath);
+  const relativePath = relative(dirname(fromFile), targetPath).replaceAll(
+    "\\",
+    "/",
+  );
+  return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
+}
+
+function rewriteDeclarationAliases(typesRoot) {
+  for (const file of walkFiles(typesRoot)) {
+    if (!file.endsWith(".d.ts")) {
+      continue;
+    }
+    const source = readFileSync(file, "utf-8");
+    const rewritten = source.replace(
+      /(["'])@\/([^"']+)\1/g,
+      (_match, quote, aliasPath) =>
+        `${quote}${toDeclarationSpecifier(file, typesRoot, aliasPath)}${quote}`,
+    );
+    if (rewritten !== source) {
+      writeFileSync(file, rewritten);
+    }
+  }
+}
 
 // Read version from package.json
 const pkg = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf-8"));
@@ -110,6 +159,30 @@ await Bun.build({
   },
 });
 
+await Bun.build({
+  entrypoints: ["./src/channels-public.ts"],
+  outdir: "./dist",
+  target: "browser",
+  format: "esm",
+  minify: false,
+  sourcemap: "external",
+  naming: {
+    entry: "channels-public.js",
+  },
+});
+
+await Bun.build({
+  entrypoints: ["./src/channels-slack.ts"],
+  outdir: "./dist",
+  target: "browser",
+  format: "esm",
+  minify: false,
+  sourcemap: "external",
+  naming: {
+    entry: "channels-slack.js",
+  },
+});
+
 // Copy bundled skills to skills/ directory for shipping
 const bundledSkillsSrc = join(__dirname, "src/skills/builtin");
 const bundledSkillsDst = join(__dirname, "skills");
@@ -126,6 +199,7 @@ if (existsSync(bundledSkillsSrc)) {
 // Generate type declarations for wire types export
 console.log("📝 Generating type declarations...");
 await Bun.$`bunx tsc -p tsconfig.types.json`;
+rewriteDeclarationAliases(join(__dirname, "dist/types"));
 console.log("   Output: dist/types/protocol.d.ts");
 
 console.log("✅ Build complete!");

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "dist/app-server-client.js.map",
     "dist/agent-presets.js",
     "dist/agent-presets.js.map",
+    "dist/channels-public.js",
+    "dist/channels-public.js.map",
+    "dist/channels-slack.js",
+    "dist/channels-slack.js.map",
     "dist/types",
     "docs"
   ],
@@ -35,7 +39,18 @@
     },
     "./agent-presets": {
       "types": "./dist/types/agent-presets.d.ts",
-      "import": "./dist/agent-presets.js"
+      "import": "./dist/agent-presets.js",
+      "default": "./dist/agent-presets.js"
+    },
+    "./channels": {
+      "types": "./dist/types/channels-public.d.ts",
+      "import": "./dist/channels-public.js",
+      "default": "./dist/channels-public.js"
+    },
+    "./channels/slack": {
+      "types": "./dist/types/channels-slack.d.ts",
+      "import": "./dist/channels-slack.js",
+      "default": "./dist/channels-slack.js"
     }
   },
   "repository": {
@@ -125,6 +140,12 @@
       ],
       "app-server-client": [
         "./dist/types/app-server-client.d.ts"
+      ],
+      "channels": [
+        "./dist/types/channels-public.d.ts"
+      ],
+      "channels/slack": [
+        "./dist/types/channels-slack.d.ts"
       ],
       "protocol": [
         "./dist/types/protocol.d.ts"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     },
     "./app-server-client": {
       "types": "./dist/types/app-server-client.d.ts",
+      "browser": "./dist/app-server-client.js",
       "import": "./dist/app-server-client.js"
     },
     "./protocol": {
@@ -39,16 +40,25 @@
     },
     "./agent-presets": {
       "types": "./dist/types/agent-presets.d.ts",
+      "browser": "./dist/agent-presets.js",
+      "import": "./dist/agent-presets.js",
+      "default": "./dist/agent-presets.js"
+    },
+    "./dist/agent-presets.js": {
+      "types": "./dist/types/agent-presets.d.ts",
+      "browser": "./dist/agent-presets.js",
       "import": "./dist/agent-presets.js",
       "default": "./dist/agent-presets.js"
     },
     "./channels": {
       "types": "./dist/types/channels-public.d.ts",
+      "browser": "./dist/channels-public.js",
       "import": "./dist/channels-public.js",
       "default": "./dist/channels-public.js"
     },
     "./channels/slack": {
       "types": "./dist/types/channels-slack.d.ts",
+      "browser": "./dist/channels-slack.js",
       "import": "./dist/channels-slack.js",
       "default": "./dist/channels-slack.js"
     }

--- a/src/channels-public.ts
+++ b/src/channels-public.ts
@@ -1,0 +1,50 @@
+export type {
+  CollectLettaSseAssistantTextOptions,
+  CollectLettaSseAssistantTextResult,
+  FormatLettaStreamCoreErrorOptions,
+  LettaStreamErrorParams,
+} from "./channels/core-stream";
+export {
+  collectLettaSseAssistantText,
+  formatLettaStreamCoreErrorForChannel,
+  LETTA_STREAM_NO_ASSISTANT_MESSAGE_ERROR,
+  LettaStreamCoreError,
+  LettaStreamNoAssistantMessageError,
+} from "./channels/core-stream";
+export type {
+  ChannelMessageActionAdapter,
+  ChannelMessageActionContext,
+  ChannelMessageActionRequest,
+  ChannelResolvedMessageTarget,
+} from "./channels/plugin-types";
+export type {
+  BuildChannelTurnSourceParams,
+  BuildOutboundChannelMessageFromTurnSourceParams,
+  ChannelBatchMessage,
+  FormatBatchedChannelMessagesParams,
+  FormatInboundChannelMessageParams,
+} from "./channels/processor";
+export {
+  buildChannelTurnSource,
+  buildOutboundChannelMessageFromTurnSource,
+  formatBatchedChannelMessagesForAgent,
+  formatInboundChannelMessageForAgent,
+} from "./channels/processor";
+export {
+  type ChannelTurnProgressBuilder,
+  createChannelTurnProgressBuilder,
+} from "./channels/progress-builder";
+export type {
+  ChannelAdapter,
+  ChannelChatType,
+  ChannelControlRequestEvent,
+  ChannelModelPickerData,
+  ChannelRoute,
+  ChannelThreadContext,
+  ChannelThreadContextEntry,
+  ChannelTurnLifecycleEvent,
+  ChannelTurnProgressEvent,
+  ChannelTurnSource,
+  InboundChannelMessage,
+  OutboundChannelMessage,
+} from "./channels/types";

--- a/src/channels-slack.ts
+++ b/src/channels-slack.ts
@@ -1,0 +1,28 @@
+export {
+  resolveSlackConcreteActivity,
+  SLACK_ASSISTANT_STARTUP_STATUS,
+  SLACK_ASSISTANT_WORKING_STATUS,
+} from "./channels/slack/progress";
+export {
+  normalizeSlackReactionName,
+  normalizeSlackText,
+  resolveSlackChatType,
+  resolveSlackOutboundThreadTs,
+  slackTimestampToMillis,
+} from "./channels/slack/public-utils";
+export type {
+  CreateSlackChannelSenderParams,
+  SlackChannelSender,
+  SlackDirectReplyParams,
+  SlackSenderClient,
+  SlackSenderMessageResult,
+  SlackSenderPostMessageParams,
+  SlackSenderPostMessageResult,
+  SlackSenderReactionParams,
+} from "./channels/slack/sender";
+export { createSlackChannelSender } from "./channels/slack/sender";
+export type {
+  SlackStatusController,
+  SlackStatusWriteClient,
+} from "./channels/slack/status-controller";
+export { createSlackStatusController } from "./channels/slack/status-controller";

--- a/src/channels-slack.ts
+++ b/src/channels-slack.ts
@@ -1,3 +1,21 @@
+export type {
+  ResolveSlackAppMentionIngressPolicyParams,
+  ResolveSlackMessageIngressPolicyParams,
+  SlackAppMentionEventLike,
+  SlackAppMentionIngressAccepted,
+  SlackAppMentionIngressPolicy,
+  SlackInboundMessageEventLike,
+  SlackIngressIgnored,
+  SlackIngressIgnoreReason,
+  SlackMessageIngressAccepted,
+  SlackMessageIngressPolicy,
+} from "./channels/slack/ingress-policy";
+export {
+  isProcessableSlackInboundMessage,
+  resolveSlackAppMentionIngressPolicy,
+  resolveSlackMessageIngressPolicy,
+  shouldSkipSlackMessageByLastSeen,
+} from "./channels/slack/ingress-policy";
 export {
   resolveSlackConcreteActivity,
   SLACK_ASSISTANT_STARTUP_STATUS,

--- a/src/channels/core-stream.test.ts
+++ b/src/channels/core-stream.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import {
+  collectLettaSseAssistantText,
+  formatLettaStreamCoreErrorForChannel,
+  LettaStreamCoreError,
+  LettaStreamNoAssistantMessageError,
+} from "@/channels/core-stream";
+
+function streamFromText(text: string): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(text));
+      controller.close();
+    },
+  });
+}
+
+describe("core stream helpers", () => {
+  test("collects assistant text from Letta SSE frames", async () => {
+    const result = await collectLettaSseAssistantText(
+      streamFromText(
+        [
+          'data: {"message_type":"ping"}',
+          "",
+          'data: {"message_type":"assistant_message","content":[{"type":"text","text":"hello"}]}',
+          "",
+          'data: {"message_type":"assistant_message","content":"world"}',
+          "",
+          'data: {"message_type":"stop_reason","stop_reason":"end_turn"}',
+          "",
+          "data: [DONE]",
+          "",
+        ].join("\n"),
+      ),
+    );
+
+    expect(result).toEqual({
+      text: "hello world",
+      chunkCount: 2,
+      stopReason: "end_turn",
+    });
+  });
+
+  test("throws structured Core stream errors", async () => {
+    await expect(
+      collectLettaSseAssistantText(
+        streamFromText(
+          [
+            "event: error",
+            'data: {"message_type":"error_message","error_type":"llm_authentication","message":"Authentication failed","detail":"bad key","run_id":"run-1"}',
+            "",
+            "data: [DONE]",
+            "",
+          ].join("\n"),
+        ),
+      ),
+    ).rejects.toMatchObject({
+      name: "LettaStreamCoreError",
+      errorType: "llm_authentication",
+      message: "Authentication failed",
+      detail: "bad key",
+      runId: "run-1",
+    });
+  });
+
+  test("throws when no assistant message is present", async () => {
+    await expect(
+      collectLettaSseAssistantText(
+        streamFromText(
+          [
+            'data: {"message_type":"ping"}',
+            "",
+            'data: {"message_type":"stop_reason","stop_reason":"end_turn"}',
+            "",
+            "data: [DONE]",
+            "",
+          ].join("\n"),
+        ),
+      ),
+    ).rejects.toBeInstanceOf(LettaStreamNoAssistantMessageError);
+  });
+
+  test("formats Core stream errors for channel delivery", () => {
+    const error = new LettaStreamCoreError({
+      errorType: "llm_authentication",
+      message: "Authentication failed with the LLM model provider.",
+      detail:
+        "UNAUTHENTICATED: Authentication failed with OpenAI: Error code: 401 - invalid key",
+      runId: "run-1",
+    });
+
+    expect(formatLettaStreamCoreErrorForChannel(error)).toBe(
+      "Authentication failed with the LLM model provider.\nUNAUTHENTICATED: Authentication failed with OpenAI: Error code: 401 - invalid key",
+    );
+    expect(
+      formatLettaStreamCoreErrorForChannel(error, { includeDetail: false }),
+    ).toBe("Authentication failed with the LLM model provider.");
+  });
+});

--- a/src/channels/core-stream.ts
+++ b/src/channels/core-stream.ts
@@ -1,0 +1,254 @@
+import type { ChannelTurnProgressUpdate } from "./types";
+
+export interface LettaStreamErrorParams {
+  errorType?: string;
+  message: string;
+  detail?: string;
+  runId?: string;
+}
+
+export interface CollectLettaSseAssistantTextResult {
+  text: string;
+  chunkCount: number;
+  stopReason?: string;
+}
+
+export interface CollectLettaSseAssistantTextOptions {
+  onDelta?: (delta: unknown) => void | Promise<void>;
+  onProgressUpdate?: (
+    update: ChannelTurnProgressUpdate,
+  ) => void | Promise<void>;
+  progressBuilder?: {
+    buildUpdates(delta: unknown): ChannelTurnProgressUpdate[];
+  };
+}
+
+export interface FormatLettaStreamCoreErrorOptions {
+  includeDetail?: boolean;
+}
+
+interface LettaSseTextContentPart {
+  type: "text";
+  text: string;
+  signature?: string;
+}
+
+interface LettaSseAssistantMessage {
+  message_type: "assistant_message";
+  content?: string | LettaSseTextContentPart[];
+}
+
+interface LettaSseErrorMessage {
+  message_type: "error_message";
+  error_type?: string;
+  message?: string;
+  detail?: string;
+  run_id?: string;
+}
+
+interface LettaSseStopReasonMessage {
+  message_type: "stop_reason";
+  stop_reason?: string;
+}
+
+export const LETTA_STREAM_NO_ASSISTANT_MESSAGE_ERROR =
+  "No assistant message received in stream";
+
+export class LettaStreamCoreError extends Error {
+  readonly errorType?: string;
+  readonly detail?: string;
+  readonly runId?: string;
+
+  constructor(params: LettaStreamErrorParams) {
+    super(params.message);
+    this.name = "LettaStreamCoreError";
+    this.errorType = params.errorType;
+    this.detail = params.detail;
+    this.runId = params.runId;
+  }
+}
+
+export class LettaStreamNoAssistantMessageError extends Error {
+  constructor() {
+    super(LETTA_STREAM_NO_ASSISTANT_MESSAGE_ERROR);
+    this.name = "LettaStreamNoAssistantMessageError";
+  }
+}
+
+function normalizeErrorLine(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function formatLettaStreamCoreErrorForChannel(
+  error: LettaStreamCoreError,
+  options: FormatLettaStreamCoreErrorOptions = {},
+): string {
+  const message =
+    normalizeErrorLine(error.message) ?? "Core failed to generate a response.";
+  const detail = normalizeErrorLine(error.detail);
+
+  if (options.includeDetail === false || !detail || detail === message) {
+    return message;
+  }
+
+  return `${message}\n${detail}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+function isOptionalString(value: unknown): value is string | undefined {
+  return typeof value === "undefined" || typeof value === "string";
+}
+
+function isLettaSseTextContentPart(
+  value: unknown,
+): value is LettaSseTextContentPart {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    value.type === "text" &&
+    typeof value.text === "string" &&
+    isOptionalString(value.signature)
+  );
+}
+
+function isLettaSseAssistantMessage(
+  value: unknown,
+): value is LettaSseAssistantMessage {
+  if (!isRecord(value) || value.message_type !== "assistant_message") {
+    return false;
+  }
+  const content = value.content;
+  return (
+    typeof content === "undefined" ||
+    typeof content === "string" ||
+    (Array.isArray(content) && content.every(isLettaSseTextContentPart))
+  );
+}
+
+function isLettaSseErrorMessage(value: unknown): value is LettaSseErrorMessage {
+  if (!isRecord(value) || value.message_type !== "error_message") {
+    return false;
+  }
+  return (
+    isOptionalString(value.error_type) &&
+    isOptionalString(value.message) &&
+    isOptionalString(value.detail) &&
+    isOptionalString(value.run_id)
+  );
+}
+
+function isLettaSseStopReasonMessage(
+  value: unknown,
+): value is LettaSseStopReasonMessage {
+  if (!isRecord(value) || value.message_type !== "stop_reason") {
+    return false;
+  }
+  return isOptionalString(value.stop_reason);
+}
+
+function coreErrorFromMessage(
+  message: LettaSseErrorMessage,
+): LettaStreamCoreError {
+  return new LettaStreamCoreError({
+    errorType: message.error_type,
+    message: message.message ?? "Core failed to generate a response.",
+    detail: message.detail,
+    runId: message.run_id,
+  });
+}
+
+function collectAssistantContent(message: LettaSseAssistantMessage): string[] {
+  if (typeof message.content === "string") {
+    return [message.content];
+  }
+  if (Array.isArray(message.content)) {
+    return message.content.map((part) => part.text);
+  }
+  return [];
+}
+
+export async function collectLettaSseAssistantText(
+  body: ReadableStream<Uint8Array>,
+  options: CollectLettaSseAssistantTextOptions = {},
+): Promise<CollectLettaSseAssistantTextResult> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  const assistantMessages: string[] = [];
+  let stopReason: string | undefined;
+
+  async function processData(data: string): Promise<void> {
+    if (data === "[DONE]") {
+      return;
+    }
+
+    const parsed: unknown = JSON.parse(data);
+    await options.onDelta?.(parsed);
+    const progressUpdates = options.progressBuilder?.buildUpdates(parsed) ?? [];
+    for (const update of progressUpdates) {
+      await options.onProgressUpdate?.(update);
+    }
+
+    if (isLettaSseErrorMessage(parsed)) {
+      throw coreErrorFromMessage(parsed);
+    }
+    if (isLettaSseAssistantMessage(parsed)) {
+      assistantMessages.push(...collectAssistantContent(parsed));
+      return;
+    }
+    if (isLettaSseStopReasonMessage(parsed)) {
+      stopReason = parsed.stop_reason;
+    }
+  }
+
+  async function processLine(line: string): Promise<void> {
+    if (!line.trim() || !line.startsWith("data: ")) {
+      return;
+    }
+    await processData(line.slice(6));
+  }
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+
+      if (done) {
+        break;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        await processLine(line);
+      }
+    }
+
+    const flushed = decoder.decode();
+    if (flushed) {
+      buffer += flushed;
+    }
+    if (buffer) {
+      await processLine(buffer);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const text = assistantMessages.join(" ").trim();
+  if (!text) {
+    throw new LettaStreamNoAssistantMessageError();
+  }
+
+  return {
+    text,
+    chunkCount: assistantMessages.length,
+    stopReason,
+  };
+}

--- a/src/channels/processor.test.ts
+++ b/src/channels/processor.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildChannelTurnSource,
+  buildOutboundChannelMessageFromTurnSource,
+  formatBatchedChannelMessagesForAgent,
+  formatInboundChannelMessageForAgent,
+} from "@/channels/processor";
+import type { ChannelRoute, InboundChannelMessage } from "@/channels/types";
+
+describe("channel processor primitives", () => {
+  test("builds channel turn source from an inbound message and route", () => {
+    const message: InboundChannelMessage = {
+      channel: "slack",
+      accountId: "integration-1",
+      chatId: "C123",
+      senderId: "U123",
+      senderTeamId: "T123",
+      text: "hello",
+      timestamp: 1_700_000_000_000,
+      messageId: "1712790000.000050",
+      threadId: "1712790000.000000",
+      chatType: "channel",
+    };
+    const route: ChannelRoute = {
+      accountId: "integration-1",
+      chatId: "C123",
+      chatType: "channel",
+      threadId: "1712790000.000000",
+      agentId: "agent-1",
+      conversationId: "conversation-1",
+      enabled: true,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    };
+
+    expect(buildChannelTurnSource({ message, route })).toEqual({
+      channel: "slack",
+      accountId: "integration-1",
+      chatId: "C123",
+      chatType: "channel",
+      senderId: "U123",
+      senderTeamId: "T123",
+      messageId: "1712790000.000050",
+      threadId: "1712790000.000000",
+      agentId: "agent-1",
+      conversationId: "conversation-1",
+    });
+  });
+
+  test("formats inbound channel messages with thread context", () => {
+    const message: InboundChannelMessage = {
+      channel: "slack",
+      accountId: "integration-1",
+      chatId: "C123",
+      chatLabel: "#eng",
+      senderId: "U123",
+      senderName: "Shub",
+      text: "current message",
+      timestamp: Date.UTC(2026, 0, 1),
+      messageId: "2",
+      threadId: "1",
+      chatType: "channel",
+      threadContext: {
+        label: "Slack thread",
+        starter: {
+          messageId: "1",
+          senderId: "U456",
+          senderName: "Alice",
+          text: "starter",
+        },
+        history: [
+          {
+            messageId: "1.5",
+            senderId: "U789",
+            senderName: "Bob",
+            text: "history",
+          },
+        ],
+      },
+    };
+
+    expect(formatInboundChannelMessageForAgent({ message })).toBe(
+      "--- Slack thread ---\n" +
+        "starter: [Alice:U456]<1>:starter\n" +
+        "[Bob:U789]<1.5>:history\n" +
+        "--- End Thread Context ---\n\n" +
+        "[slack:#eng][Shub:U123]<2026-01-01T00:00:00.000Z>:current message",
+    );
+  });
+
+  test("formats batched channel messages without adding duplicate sender wrappers", () => {
+    const text = formatBatchedChannelMessagesForAgent({
+      messages: [
+        {
+          text: "[slack:#general][Ada:U123]<2026-01-01T00:00:00.000Z>:hello",
+          channelTurnSource: {
+            channel: "slack",
+            chatId: "C123",
+            agentId: "agent-1",
+            conversationId: "conv-1",
+          },
+        },
+        {
+          text: "[slack:#general][Bob:U456]<2026-01-01T00:00:01.000Z>:world",
+          channelTurnSource: {
+            channel: "slack",
+            chatId: "C123",
+            agentId: "agent-1",
+            conversationId: "conv-1",
+          },
+        },
+      ],
+    });
+
+    expect(text).toBe(
+      "--- Batched Channel Messages (2) ---\n" +
+        "[slack:#general][Ada:U123]<2026-01-01T00:00:00.000Z>:hello\n" +
+        "[slack:#general][Bob:U456]<2026-01-01T00:00:01.000Z>:world\n" +
+        "--- End Batched Channel Messages ---",
+    );
+  });
+
+  test("builds outbound channel messages from turn source", () => {
+    const message = buildOutboundChannelMessageFromTurnSource({
+      turnSource: {
+        channel: "slack",
+        accountId: "integration-1",
+        chatId: "C123",
+        threadId: "1700000000.000100",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      },
+      text: "response",
+    });
+
+    expect(message).toEqual({
+      channel: "slack",
+      accountId: "integration-1",
+      chatId: "C123",
+      threadId: "1700000000.000100",
+      text: "response",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+    });
+  });
+});

--- a/src/channels/processor.ts
+++ b/src/channels/processor.ts
@@ -1,0 +1,160 @@
+import type {
+  ChannelRoute,
+  ChannelThreadContext,
+  ChannelThreadContextEntry,
+  ChannelTurnSource,
+  InboundChannelMessage,
+  OutboundChannelMessage,
+} from "./types";
+
+export interface BuildChannelTurnSourceParams {
+  message: InboundChannelMessage;
+  route: ChannelRoute;
+}
+
+export interface FormatInboundChannelMessageParams {
+  message: InboundChannelMessage;
+}
+
+export interface ChannelBatchMessage {
+  text: string;
+  senderId?: string;
+  senderName?: string;
+  timestamp?: string | number;
+  channelTurnSource?: ChannelTurnSource;
+}
+
+export interface FormatBatchedChannelMessagesParams {
+  messages: ChannelBatchMessage[];
+}
+
+export interface BuildOutboundChannelMessageFromTurnSourceParams {
+  turnSource: ChannelTurnSource;
+  text: string;
+}
+
+function formatSenderLabel(entry: ChannelThreadContextEntry): string {
+  const senderName = entry.senderName?.trim();
+  const senderId = entry.senderId?.trim();
+  if (senderName && senderId && senderName !== senderId) {
+    return `${senderName}:${senderId}`;
+  }
+  if (senderName) {
+    return senderName;
+  }
+  if (senderId) {
+    return senderId;
+  }
+  return "unknown";
+}
+
+function formatThreadContextEntry(entry: ChannelThreadContextEntry): string {
+  const messageId = entry.messageId ? `<${entry.messageId}>` : "";
+  return `[${formatSenderLabel(entry)}]${messageId}:${entry.text}`;
+}
+
+function formatThreadContext(context: ChannelThreadContext): string {
+  const lines: string[] = [];
+  const label = context.label?.trim();
+  lines.push(label ? `--- ${label} ---` : "--- Thread Context ---");
+  if (context.starter) {
+    lines.push(`starter: ${formatThreadContextEntry(context.starter)}`);
+  }
+  for (const entry of context.history ?? []) {
+    lines.push(formatThreadContextEntry(entry));
+  }
+  lines.push("--- End Thread Context ---");
+  return `${lines.join("\n")}\n\n`;
+}
+
+function formatInboundSender(message: InboundChannelMessage): string {
+  const senderName = message.senderName?.trim();
+  if (senderName && senderName !== message.senderId) {
+    return `${senderName}:${message.senderId}`;
+  }
+  return message.senderId;
+}
+
+export function buildChannelTurnSource(
+  params: BuildChannelTurnSourceParams,
+): ChannelTurnSource {
+  const { message, route } = params;
+  return {
+    channel: message.channel,
+    accountId: message.accountId ?? route.accountId,
+    chatId: message.chatId,
+    chatType: message.chatType ?? route.chatType,
+    senderId: message.senderId,
+    senderTeamId: message.senderTeamId,
+    messageId: message.messageId,
+    threadId: message.threadId ?? route.threadId ?? null,
+    agentId: route.agentId,
+    conversationId: route.conversationId,
+  };
+}
+
+export function formatInboundChannelMessageForAgent(
+  params: FormatInboundChannelMessageParams,
+): string {
+  const { message } = params;
+  const context = message.threadContext
+    ? formatThreadContext(message.threadContext)
+    : "";
+  const chatLabel = message.chatLabel?.trim() || message.chatId;
+  const timestamp = new Date(message.timestamp).toISOString();
+  const prefix = `[${message.channel}:${chatLabel}][${formatInboundSender(
+    message,
+  )}]<${timestamp}>:`;
+  return `${context}${prefix}${message.text}`;
+}
+
+function formatLegacyBatchedSender(message: ChannelBatchMessage): string {
+  const senderName = message.senderName?.trim();
+  const senderId = message.senderId?.trim() ?? "unknown";
+  if (senderName && senderName !== senderId) {
+    return `${senderName}:${senderId}`;
+  }
+  return senderId;
+}
+
+export function formatBatchedChannelMessagesForAgent(
+  params: FormatBatchedChannelMessagesParams,
+): string {
+  const { messages } = params;
+  if (messages.length === 0) {
+    return "";
+  }
+  const firstMessage = messages[0];
+  if (messages.length === 1 && firstMessage) {
+    return firstMessage.text;
+  }
+
+  if (messages.every((message) => message.channelTurnSource)) {
+    const formatted = messages.map((message) => message.text).join("\n");
+    return `--- Batched Channel Messages (${messages.length}) ---\n${formatted}\n--- End Batched Channel Messages ---`;
+  }
+
+  const formatted = messages
+    .map((message) => {
+      const timestamp = message.timestamp ?? "unknown";
+      return `[user@${formatLegacyBatchedSender(message)}]<${timestamp}>:${message.text}`;
+    })
+    .join("\n");
+
+  return `--- Batched Messages (${messages.length}) ---\n${formatted}\n--- End Batched Messages ---`;
+}
+
+export function buildOutboundChannelMessageFromTurnSource(
+  params: BuildOutboundChannelMessageFromTurnSourceParams,
+): OutboundChannelMessage {
+  const { turnSource } = params;
+  return {
+    channel: turnSource.channel,
+    accountId: turnSource.accountId,
+    chatId: turnSource.chatId,
+    threadId: turnSource.threadId,
+    text: params.text,
+    agentId: turnSource.agentId,
+    conversationId: turnSource.conversationId,
+  };
+}

--- a/src/channels/progress-builder.ts
+++ b/src/channels/progress-builder.ts
@@ -1,4 +1,3 @@
-import type { StreamDelta } from "@/types/protocol_v2";
 import {
   asRecord,
   type ChannelTurnProgressBuilderOptions,
@@ -95,7 +94,7 @@ function toolNameForMessage(summary: ToolCallSummary | undefined): string {
  * drop it when the turn finishes) rather than shared across conversations.
  */
 export type ChannelTurnProgressBuilder = {
-  buildUpdates(delta: StreamDelta): ChannelTurnProgressUpdate[];
+  buildUpdates(delta: unknown): ChannelTurnProgressUpdate[];
 };
 
 export function createChannelTurnProgressBuilder(
@@ -299,7 +298,7 @@ export function createChannelTurnProgressBuilder(
     return updates;
   }
 
-  function buildUpdates(delta: StreamDelta): ChannelTurnProgressUpdate[] {
+  function buildUpdates(delta: unknown): ChannelTurnProgressUpdate[] {
     const record = asRecord(delta);
     if (!record) {
       return [];

--- a/src/channels/progress-formatting.ts
+++ b/src/channels/progress-formatting.ts
@@ -1,15 +1,3 @@
-import { basename } from "node:path";
-import {
-  isFileEditTool,
-  isFileReadTool,
-  isFileWriteTool,
-  isGlobTool,
-  isSearchTool,
-  isShellTool,
-  isTaskTool,
-  isWebSearchTool,
-} from "@/cli/helpers/tool-name-mapping";
-
 const MAX_PROGRESS_TEXT_LENGTH = 140;
 export const MAX_PROGRESS_DETAILS_LENGTH = 180;
 const MAX_SHELL_PROGRESS_DETAILS_LENGTH = 64;
@@ -20,6 +8,82 @@ const SECRET_ASSIGNMENT_RE =
   /\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASS|API[_-]?KEY|ACCESS[_-]?KEY)[A-Z0-9_]*)\s*=\s*("[^"]*"|'[^']*'|\S+)/gi;
 const SECRET_JSON_RE =
   /(["']?(?:token|secret|password|api[_-]?key|access[_-]?key)["']?\s*[:=]\s*)("[^"]*"|'[^']*'|\S+)/gi;
+
+function isTaskTool(name: string): boolean {
+  return (
+    name === "Task" || name === "task" || name === "Agent" || name === "agent"
+  );
+}
+
+function isShellTool(name: string): boolean {
+  const normalized = name.toLowerCase();
+  return (
+    normalized === "bash" ||
+    normalized === "exec_command" ||
+    normalized === "shell_command" ||
+    normalized === "shell" ||
+    normalized === "runshellcommand"
+  );
+}
+
+function isWebSearchTool(name: string): boolean {
+  const normalized = name.toLowerCase();
+  return normalized === "web_search" || normalized === "websearch";
+}
+
+function isSearchTool(name: string): boolean {
+  const normalized = name.toLowerCase();
+  return (
+    normalized === "grep" ||
+    normalized === "grep_files" ||
+    normalized === "grepfiles" ||
+    normalized === "search_file_content" ||
+    normalized === "searchfilecontent"
+  );
+}
+
+function isGlobTool(name: string): boolean {
+  const normalized = name.toLowerCase();
+  return normalized === "glob" || normalized === "glob_gemini";
+}
+
+function isFileReadTool(name: string): boolean {
+  const normalized = name.toLowerCase();
+  return (
+    normalized === "read" ||
+    normalized === "read_file" ||
+    normalized === "readfile" ||
+    normalized === "read_file_gemini" ||
+    normalized === "readfilegemini"
+  );
+}
+
+function isFileWriteTool(name: string): boolean {
+  const normalized = name.toLowerCase();
+  return (
+    normalized === "write" ||
+    normalized === "write_file" ||
+    normalized === "writefile" ||
+    normalized === "write_file_gemini" ||
+    normalized === "writefilegemini"
+  );
+}
+
+function isFileEditTool(name: string): boolean {
+  const normalized = name.toLowerCase();
+  return (
+    normalized === "edit" ||
+    normalized === "multi_edit" ||
+    normalized === "multiedit" ||
+    normalized === "replace" ||
+    normalized === "apply_patch" ||
+    normalized === "applypatch"
+  );
+}
+
+function getPathBaseName(filePath: string): string {
+  return filePath.split(/[\\/]/).filter(Boolean).pop() ?? filePath;
+}
 
 export function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object"
@@ -351,7 +415,7 @@ function formatProgressFileName(
   if (!filePath) {
     return undefined;
   }
-  const fileName = basename(filePath) || filePath;
+  const fileName = getPathBaseName(filePath) || filePath;
   return (
     sanitizeChannelProgressText(fileName, MAX_PROGRESS_DETAILS_LENGTH) ||
     undefined

--- a/src/channels/slack/ingress-controller.ts
+++ b/src/channels/slack/ingress-controller.ts
@@ -7,11 +7,12 @@ import type {
   SlackChannelAccount,
 } from "@/channels/types";
 import type { AgentThreadTracker } from "./agent-thread-tracker";
-import {
-  isSlackBotAuthoredInboundMessage,
-  shouldAcceptSlackInboundBotMessage,
-} from "./bot-policy";
+import { shouldAcceptSlackInboundBotMessage } from "./bot-policy";
 import type { SlackInboundDebounceController } from "./inbound-debounce";
+import {
+  resolveSlackAppMentionIngressPolicy,
+  resolveSlackMessageIngressPolicy,
+} from "./ingress-policy";
 import type {
   SlackCommandPayload,
   SlackDebounceRawInput,
@@ -22,10 +23,7 @@ import {
   asRecord,
   firstNonEmptyString,
   getSlackActionRecord,
-  hasSlackMention,
   isNonEmptyString,
-  isProcessableSlackInboundMessage,
-  normalizeSlackText,
   resolveSlackActionChannelId,
   resolveSlackActionMessageId,
   resolveSlackActionThreadId,
@@ -173,122 +171,110 @@ export function createSlackIngressController(params: {
       if (!params.getAdapter().onMessage) return;
       const rawMessage = asRecord(message);
       const channelId = rawMessage?.channel;
-      if (
-        !rawMessage ||
-        !isNonEmptyString(channelId) ||
-        !isProcessableSlackInboundMessage(rawMessage)
-      ) {
+      if (!rawMessage || !isNonEmptyString(channelId)) {
         return;
       }
 
-      const text = isNonEmptyString(rawMessage.text) ? rawMessage.text : "";
-      const wasMentioned = hasSlackMention(text, params.getBotUserId());
+      const basePolicy = resolveSlackMessageIngressPolicy({
+        message: rawMessage,
+        botUserId: params.getBotUserId(),
+      });
+      if (!basePolicy.shouldRoute) return;
       if (
         !shouldAcceptInboundMessageByBotPolicy({
           message: rawMessage,
-          wasMentioned,
+          wasMentioned: basePolicy.wasMentioned,
         })
       ) {
         return;
       }
-      const senderId = firstNonEmptyString(rawMessage.user, rawMessage.bot_id);
-      if (!senderId) return;
       const attachments = await resolveSlackInboundAttachments({
         accountId: config.accountId,
         token: config.botToken,
         rawEvent: message,
         transcribeVoice: config.transcribeVoice === true,
       });
-      const chatType = resolveSlackChatType(channelId);
-      const threadId =
-        chatType === "direct"
-          ? (firstNonEmptyString(rawMessage.thread_ts) ?? null)
-          : (firstNonEmptyString(rawMessage.thread_ts, rawMessage.ts) ?? null);
-      rememberMessageThread(rawMessage.ts, threadId);
       const senderName = await resolveInboundSenderName(
         app,
-        rawMessage.user,
-        rawMessage.bot_id,
+        basePolicy.senderUserId,
+        basePolicy.senderBotId,
       );
       const isAgentThread =
-        chatType === "channel" &&
-        isNonEmptyString(threadId) &&
-        params.agentThreadTracker.has(channelId, threadId);
-      const isBotAuthored = isSlackBotAuthoredInboundMessage(rawMessage);
-      const effectiveMention = isBotAuthored
-        ? wasMentioned
-        : wasMentioned || isAgentThread;
+        basePolicy.chatType === "channel" &&
+        isNonEmptyString(basePolicy.threadId) &&
+        params.agentThreadTracker.has(channelId, basePolicy.threadId);
+      const policy = resolveSlackMessageIngressPolicy({
+        message: rawMessage,
+        botUserId: params.getBotUserId(),
+        isAgentThread,
+      });
+      if (!policy.shouldRoute) return;
+      rememberMessageThread(policy.messageId, policy.threadId);
 
-      if (chatType === "direct") {
-        const seenKey = `${channelId}:${rawMessage.ts}`;
-        if (markIngressMessageSeen(channelId, rawMessage.ts)) return;
+      if (policy.chatType === "direct") {
+        const seenKey = `${channelId}:${policy.messageId}`;
+        if (markIngressMessageSeen(channelId, policy.messageId)) return;
         params.debounce.rememberAppMentionRetry(seenKey);
         await dispatchInbound(
           {
             channel: "slack",
             accountId: config.accountId,
             chatId: channelId,
-            senderId,
+            senderId: policy.senderId,
             senderTeamId: resolveSlackSenderTeamId(rawMessage),
             senderName,
-            text: wasMentioned ? normalizeSlackText(text) : text,
-            timestamp: slackTimestampToMillis(rawMessage.ts),
-            messageId: rawMessage.ts,
-            threadId,
+            text: policy.text,
+            timestamp: slackTimestampToMillis(policy.messageId),
+            messageId: policy.messageId,
+            threadId: policy.threadId,
             chatType: "direct",
-            isMention: wasMentioned,
+            isMention: policy.wasMentioned,
             attachments,
             raw: message,
           },
           rawMessage as SlackDebounceRawInput,
           "message",
-          wasMentioned,
+          policy.wasMentioned,
           "DM message",
         );
         return;
       }
 
-      if (!isNonEmptyString(rawMessage.thread_ts)) return;
-      const seenKey = `${channelId}:${rawMessage.ts}`;
-      if (markIngressMessageSeen(channelId, rawMessage.ts)) return;
+      const seenKey = `${channelId}:${policy.messageId}`;
+      if (markIngressMessageSeen(channelId, policy.messageId)) return;
       params.debounce.rememberAppMentionRetry(seenKey);
       await dispatchInbound(
         {
           channel: "slack",
           accountId: config.accountId,
           chatId: channelId,
-          senderId,
+          senderId: policy.senderId,
           senderTeamId: resolveSlackSenderTeamId(rawMessage),
           senderName,
           chatLabel: channelId,
-          text: wasMentioned ? normalizeSlackText(text) : text,
-          timestamp: slackTimestampToMillis(rawMessage.ts),
-          messageId: rawMessage.ts,
-          threadId,
+          text: policy.text,
+          timestamp: slackTimestampToMillis(policy.messageId),
+          messageId: policy.messageId,
+          threadId: policy.threadId,
           chatType: "channel",
-          isMention: effectiveMention,
+          isMention: policy.effectiveMention,
           attachments,
           raw: message,
         },
         rawMessage as SlackDebounceRawInput,
         "message",
-        effectiveMention,
+        policy.effectiveMention,
         "threaded channel message",
       );
     });
 
     app.event("app_mention", async ({ event }) => {
       const rawEvent = asRecord(event);
-      const channelId = rawEvent?.channel;
-      const ts = rawEvent?.ts;
-      const senderId = firstNonEmptyString(rawEvent?.user, rawEvent?.bot_id);
-      if (
-        !params.getAdapter().onMessage ||
-        !rawEvent ||
-        !isNonEmptyString(channelId) ||
-        !isNonEmptyString(ts) ||
-        !senderId
-      ) {
+      if (!params.getAdapter().onMessage || !rawEvent) {
+        return;
+      }
+      const policy = resolveSlackAppMentionIngressPolicy({ event: rawEvent });
+      if (!policy.shouldRoute) {
         return;
       }
       if (
@@ -299,34 +285,31 @@ export function createSlackIngressController(params: {
       ) {
         return;
       }
-      const threadId = firstNonEmptyString(rawEvent.thread_ts, ts) ?? ts;
-      const seenKey = `${channelId}:${ts}`;
+      const seenKey = `${policy.channelId}:${policy.messageId}`;
       if (
-        markIngressMessageSeen(channelId, ts) &&
+        markIngressMessageSeen(policy.channelId, policy.messageId) &&
         !params.debounce.consumeAppMentionRetry(seenKey)
       ) {
         return;
       }
-      rememberMessageThread(ts, threadId);
+      rememberMessageThread(policy.messageId, policy.threadId);
       await dispatchInbound(
         {
           channel: "slack",
           accountId: config.accountId,
-          chatId: channelId,
-          senderId,
+          chatId: policy.channelId,
+          senderId: policy.senderId,
           senderTeamId: resolveSlackSenderTeamId(rawEvent),
           senderName: await resolveInboundSenderName(
             app,
             firstNonEmptyString(rawEvent.user),
             firstNonEmptyString(rawEvent.bot_id),
           ),
-          chatLabel: channelId,
-          text: normalizeSlackText(
-            isNonEmptyString(rawEvent.text) ? rawEvent.text : "",
-          ),
-          timestamp: slackTimestampToMillis(ts),
-          messageId: ts,
-          threadId,
+          chatLabel: policy.channelId,
+          text: policy.text,
+          timestamp: slackTimestampToMillis(policy.messageId),
+          messageId: policy.messageId,
+          threadId: policy.threadId,
           chatType: "channel",
           isMention: true,
           attachments: await resolveSlackInboundAttachments({

--- a/src/channels/slack/ingress-policy.ts
+++ b/src/channels/slack/ingress-policy.ts
@@ -1,0 +1,269 @@
+import {
+  firstNonEmptyString,
+  isNonEmptyString,
+  normalizeSlackText,
+  resolveSlackChatType,
+} from "./public-utils";
+
+const IGNORED_SLACK_MESSAGE_SUBTYPES = new Set([
+  "assistant_app_thread",
+  "channel_archive",
+  "channel_convert_to_private",
+  "channel_convert_to_public",
+  "channel_join",
+  "channel_leave",
+  "channel_name",
+  "channel_posting_permissions",
+  "channel_purpose",
+  "channel_topic",
+  "channel_unarchive",
+  "document_mention",
+  "ekm_access_denied",
+  "file_comment",
+  "group_archive",
+  "group_join",
+  "group_leave",
+  "group_name",
+  "group_purpose",
+  "group_topic",
+  "group_unarchive",
+  "pinned_item",
+  "reminder_add",
+  "unpinned_item",
+]);
+
+const WRAPPER_SLACK_MESSAGE_SUBTYPES = new Set([
+  "message_changed",
+  "message_deleted",
+  "message_replied",
+]);
+
+export interface SlackInboundMessageEventLike {
+  channel?: unknown;
+  user?: unknown;
+  bot_id?: unknown;
+  ts?: unknown;
+  text?: unknown;
+  thread_ts?: unknown;
+  subtype?: unknown;
+  hidden?: boolean;
+  message?: unknown;
+}
+
+export interface SlackAppMentionEventLike {
+  channel?: unknown;
+  user?: unknown;
+  bot_id?: unknown;
+  ts?: unknown;
+  text?: unknown;
+  thread_ts?: unknown;
+}
+
+export interface ResolveSlackMessageIngressPolicyParams {
+  message: SlackInboundMessageEventLike;
+  botUserId?: string | null;
+  isAgentThread?: boolean;
+}
+
+export interface ResolveSlackAppMentionIngressPolicyParams {
+  event: SlackAppMentionEventLike;
+}
+
+export interface SlackMessageIngressAccepted {
+  shouldRoute: true;
+  channelId: string;
+  senderId: string;
+  senderUserId?: string;
+  senderBotId?: string;
+  messageId: string;
+  threadId: string | null;
+  chatType: "direct" | "channel";
+  text: string;
+  rawText: string;
+  wasMentioned: boolean;
+  effectiveMention: boolean;
+  isAgentThread: boolean;
+}
+
+export interface SlackAppMentionIngressAccepted {
+  shouldRoute: true;
+  channelId: string;
+  senderId: string;
+  senderUserId?: string;
+  senderBotId?: string;
+  messageId: string;
+  threadId: string;
+  chatType: "channel";
+  text: string;
+  rawText: string;
+  wasMentioned: true;
+  effectiveMention: true;
+  isAgentThread: false;
+}
+
+export type SlackIngressIgnoreReason =
+  | "missing_channel"
+  | "missing_sender"
+  | "missing_timestamp"
+  | "hidden_message"
+  | "ignored_subtype"
+  | "wrapper_message"
+  | "top_level_channel_message";
+
+export interface SlackIngressIgnored {
+  shouldRoute: false;
+  reason: SlackIngressIgnoreReason;
+}
+
+export type SlackMessageIngressPolicy =
+  | SlackMessageIngressAccepted
+  | SlackIngressIgnored;
+
+export type SlackAppMentionIngressPolicy =
+  | SlackAppMentionIngressAccepted
+  | SlackIngressIgnored;
+
+function hasRecordValue(value: unknown): boolean {
+  return value !== null && typeof value === "object";
+}
+
+function hasSlackMention(
+  text: string,
+  userId: string | null | undefined,
+): boolean {
+  return (
+    isNonEmptyString(text) &&
+    isNonEmptyString(userId) &&
+    (text.includes(`<@${userId}>`) || text.includes(`<@${userId}|`))
+  );
+}
+
+function isBotAuthoredMessage(message: SlackInboundMessageEventLike): boolean {
+  return isNonEmptyString(message.bot_id) || message.subtype === "bot_message";
+}
+
+function resolveMessageSubtypeIgnoreReason(
+  message: SlackInboundMessageEventLike,
+): SlackIngressIgnoreReason | null {
+  const subtype = isNonEmptyString(message.subtype) ? message.subtype : null;
+  if (!subtype) {
+    return null;
+  }
+  if (IGNORED_SLACK_MESSAGE_SUBTYPES.has(subtype)) {
+    return "ignored_subtype";
+  }
+  if (
+    WRAPPER_SLACK_MESSAGE_SUBTYPES.has(subtype) &&
+    hasRecordValue(message.message)
+  ) {
+    return "wrapper_message";
+  }
+  return null;
+}
+
+export function isProcessableSlackInboundMessage(
+  message: SlackInboundMessageEventLike,
+): boolean {
+  return resolveSlackMessageIngressPolicy({ message }).shouldRoute;
+}
+
+export function shouldSkipSlackMessageByLastSeen(params: {
+  lastSeenMessageTs?: string | null;
+  messageTs: string;
+}): boolean {
+  return Boolean(
+    params.lastSeenMessageTs && params.lastSeenMessageTs >= params.messageTs,
+  );
+}
+
+export function resolveSlackMessageIngressPolicy(
+  params: ResolveSlackMessageIngressPolicyParams,
+): SlackMessageIngressPolicy {
+  const { message } = params;
+  if (!isNonEmptyString(message.channel)) {
+    return { shouldRoute: false, reason: "missing_channel" };
+  }
+  const senderId = firstNonEmptyString(message.user, message.bot_id);
+  if (!senderId) {
+    return { shouldRoute: false, reason: "missing_sender" };
+  }
+  if (!isNonEmptyString(message.ts)) {
+    return { shouldRoute: false, reason: "missing_timestamp" };
+  }
+  if (message.hidden === true) {
+    return { shouldRoute: false, reason: "hidden_message" };
+  }
+
+  const subtypeIgnoreReason = resolveMessageSubtypeIgnoreReason(message);
+  if (subtypeIgnoreReason) {
+    return { shouldRoute: false, reason: subtypeIgnoreReason };
+  }
+
+  const chatType = resolveSlackChatType(message.channel);
+  const threadId =
+    chatType === "direct"
+      ? (firstNonEmptyString(message.thread_ts) ?? null)
+      : (firstNonEmptyString(message.thread_ts, message.ts) ?? null);
+
+  if (chatType === "channel" && !isNonEmptyString(message.thread_ts)) {
+    return { shouldRoute: false, reason: "top_level_channel_message" };
+  }
+
+  const rawText = isNonEmptyString(message.text) ? message.text : "";
+  const wasMentioned = hasSlackMention(rawText, params.botUserId);
+  const isAgentThread = params.isAgentThread === true;
+  const effectiveMention = isBotAuthoredMessage(message)
+    ? wasMentioned
+    : wasMentioned || isAgentThread;
+
+  return {
+    shouldRoute: true,
+    channelId: message.channel,
+    senderId,
+    ...(isNonEmptyString(message.user) ? { senderUserId: message.user } : {}),
+    ...(isNonEmptyString(message.bot_id)
+      ? { senderBotId: message.bot_id }
+      : {}),
+    messageId: message.ts,
+    threadId,
+    chatType,
+    text: wasMentioned ? normalizeSlackText(rawText) : rawText,
+    rawText,
+    wasMentioned,
+    effectiveMention,
+    isAgentThread,
+  };
+}
+
+export function resolveSlackAppMentionIngressPolicy(
+  params: ResolveSlackAppMentionIngressPolicyParams,
+): SlackAppMentionIngressPolicy {
+  const { event } = params;
+  if (!isNonEmptyString(event.channel)) {
+    return { shouldRoute: false, reason: "missing_channel" };
+  }
+  const senderId = firstNonEmptyString(event.user, event.bot_id);
+  if (!senderId) {
+    return { shouldRoute: false, reason: "missing_sender" };
+  }
+  if (!isNonEmptyString(event.ts)) {
+    return { shouldRoute: false, reason: "missing_timestamp" };
+  }
+
+  const rawText = isNonEmptyString(event.text) ? event.text : "";
+  return {
+    shouldRoute: true,
+    channelId: event.channel,
+    senderId,
+    ...(isNonEmptyString(event.user) ? { senderUserId: event.user } : {}),
+    ...(isNonEmptyString(event.bot_id) ? { senderBotId: event.bot_id } : {}),
+    messageId: event.ts,
+    threadId: firstNonEmptyString(event.thread_ts, event.ts) ?? event.ts,
+    chatType: "channel",
+    text: normalizeSlackText(rawText),
+    rawText,
+    wasMentioned: true,
+    effectiveMention: true,
+    isAgentThread: false,
+  };
+}

--- a/src/channels/slack/presentation.ts
+++ b/src/channels/slack/presentation.ts
@@ -1,28 +1,26 @@
 import { isLocalAgentId } from "@/agent/agent-id";
 import { normalizeChannelLifecycleErrorMessage } from "@/channels/lifecycle-error";
-import {
-  sanitizeChannelProgressCore,
-  truncateChannelProgressText,
-} from "@/channels/progress-formatting";
-import type {
-  ChannelControlRequestEvent,
-  ChannelTurnProgressEvent,
-} from "@/channels/types";
-import {
-  getDisplayToolName,
-  isShellTool,
-  isTaskTool,
-} from "@/cli/helpers/tool-name-mapping";
+import { truncateChannelProgressText } from "@/channels/progress-formatting";
+import type { ChannelControlRequestEvent } from "@/channels/types";
 import type { SlackApprovalActionPayload, SlackBlock } from "./internal-types";
-import { isNonEmptyString } from "./utils";
 
-export const SLACK_ASSISTANT_STARTUP_STATUS = "is thinking...";
-export const SLACK_ASSISTANT_WORKING_STATUS = "is working...";
+export {
+  formatSlackToolNameForDisplay,
+  resolveSlackConcreteActivity,
+  SLACK_ASSISTANT_STARTUP_STATUS,
+  SLACK_ASSISTANT_WORKING_STATUS,
+  sanitizeSlackStatusText,
+} from "./progress";
+
+import {
+  formatSlackToolNameForDisplay,
+  sanitizeSlackStatusText,
+} from "./progress";
+import { isNonEmptyString } from "./utils";
 export const SLACK_APPROVAL_ACTION_ID = "letta_channel_approval";
 
 const SLACK_MARKDOWN_BLOCK_TEXT_MAX = 12_000;
 const SLACK_LIFECYCLE_ERROR_TEXT_MAX = 3_000;
-const SLACK_STATUS_TEXT_MAX = 300;
 
 function buildSlackChatUrl(
   agentId: string,
@@ -79,56 +77,6 @@ export function buildSlackReplyBlocksWithFootnote(
     elements: [{ type: "mrkdwn", text: footnote }],
   });
   return blocks;
-}
-
-function sanitizeSlackStatusText(text: string, maxLength: number): string {
-  const normalized = sanitizeChannelProgressCore(text)
-    .replace(/[<>]/g, "")
-    .replace(/&/g, "and")
-    .replace(/\s+/g, " ")
-    .trim();
-  return truncateChannelProgressText(normalized, maxLength, "...");
-}
-
-function formatSlackToolNameForDisplay(toolName: string): string {
-  return isTaskTool(toolName) ? "Subagent" : getDisplayToolName(toolName);
-}
-
-export function resolveSlackConcreteActivity(
-  event: ChannelTurnProgressEvent,
-): string | null {
-  if (event.kind === "command" && isNonEmptyString(event.command)) {
-    return sanitizeSlackStatusText(
-      formatSlackToolNameForDisplay(event.command),
-      SLACK_STATUS_TEXT_MAX,
-    );
-  }
-  if (
-    event.kind !== "tool" ||
-    !isNonEmptyString(event.toolName) ||
-    event.toolName.toLowerCase() === "messagechannel"
-  ) {
-    return null;
-  }
-
-  for (const description of [
-    event.toolTitle,
-    event.toolDetails,
-    isShellTool(event.toolName) ? event.message : undefined,
-    formatSlackToolNameForDisplay(event.toolName),
-  ]) {
-    if (!isNonEmptyString(description)) {
-      continue;
-    }
-    const sanitized = sanitizeSlackStatusText(
-      description,
-      SLACK_STATUS_TEXT_MAX,
-    );
-    if (sanitized) {
-      return sanitized;
-    }
-  }
-  return null;
 }
 
 export function formatSlackControlRequestBlocks(

--- a/src/channels/slack/progress.ts
+++ b/src/channels/slack/progress.ts
@@ -1,0 +1,86 @@
+import {
+  sanitizeChannelProgressCore,
+  truncateChannelProgressText,
+} from "@/channels/progress-formatting";
+import type { ChannelTurnProgressEvent } from "@/channels/types";
+import { isNonEmptyString } from "./public-utils";
+
+export const SLACK_ASSISTANT_STARTUP_STATUS = "is thinking...";
+export const SLACK_ASSISTANT_WORKING_STATUS = "is working...";
+
+const SLACK_STATUS_TEXT_MAX = 300;
+
+export function sanitizeSlackStatusText(
+  text: string,
+  maxLength: number,
+): string {
+  const normalized = sanitizeChannelProgressCore(text)
+    .replace(/[<>]/g, "")
+    .replace(/&/g, "and")
+    .replace(/\s+/g, " ")
+    .trim();
+  return truncateChannelProgressText(normalized, maxLength, "...");
+}
+
+export function formatSlackToolNameForDisplay(toolName: string): string {
+  if (toolName === "Task" || toolName === "task" || toolName === "Agent") {
+    return "Subagent";
+  }
+  if (
+    toolName === "Bash" ||
+    toolName === "bash" ||
+    toolName === "exec_command" ||
+    toolName === "shell_command" ||
+    toolName === "ShellCommand"
+  ) {
+    return "Bash";
+  }
+  return toolName;
+}
+
+function isSlackShellTool(toolName: string): boolean {
+  const normalized = toolName.toLowerCase();
+  return (
+    normalized === "bash" ||
+    normalized === "exec_command" ||
+    normalized === "shell_command" ||
+    normalized === "shell"
+  );
+}
+
+export function resolveSlackConcreteActivity(
+  event: ChannelTurnProgressEvent,
+): string | null {
+  if (event.kind === "command" && isNonEmptyString(event.command)) {
+    return sanitizeSlackStatusText(
+      formatSlackToolNameForDisplay(event.command),
+      SLACK_STATUS_TEXT_MAX,
+    );
+  }
+  if (
+    event.kind !== "tool" ||
+    !isNonEmptyString(event.toolName) ||
+    event.toolName.toLowerCase() === "messagechannel"
+  ) {
+    return null;
+  }
+
+  for (const description of [
+    event.toolTitle,
+    event.toolDetails,
+    isSlackShellTool(event.toolName) ? event.message : undefined,
+    formatSlackToolNameForDisplay(event.toolName),
+  ]) {
+    if (!isNonEmptyString(description)) {
+      continue;
+    }
+    const sanitized = sanitizeSlackStatusText(
+      description,
+      SLACK_STATUS_TEXT_MAX,
+    );
+    if (sanitized) {
+      return sanitized;
+    }
+  }
+  return null;
+}

--- a/src/channels/slack/public-utils.ts
+++ b/src/channels/slack/public-utils.ts
@@ -1,0 +1,61 @@
+import type {
+  ChannelTurnSource,
+  OutboundChannelMessage,
+} from "@/channels/types";
+
+export function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+export function firstNonEmptyString(...values: unknown[]): string | undefined {
+  return values.find(isNonEmptyString);
+}
+
+export function normalizeSlackText(text: string): string {
+  return text.replace(/^(?:\s*<@[A-Z0-9]+>\s*)+/, "").trim();
+}
+
+export function resolveSlackChatType(chatId: string): "direct" | "channel" {
+  return chatId.startsWith("D") ? "direct" : "channel";
+}
+
+export function resolveSlackSourceThreadTs(
+  source: ChannelTurnSource,
+): string | undefined {
+  if (
+    source.chatType === "direct" ||
+    resolveSlackChatType(source.chatId) === "direct"
+  ) {
+    return firstNonEmptyString(source.threadId);
+  }
+  return firstNonEmptyString(source.threadId, source.messageId);
+}
+
+export function resolveSlackProgressThreadTs(
+  source: ChannelTurnSource,
+): string | undefined {
+  if (
+    source.chatType === "direct" ||
+    resolveSlackChatType(source.chatId) === "direct"
+  ) {
+    return firstNonEmptyString(source.threadId, source.messageId);
+  }
+  return resolveSlackSourceThreadTs(source);
+}
+
+export function resolveSlackOutboundThreadTs(
+  msg: Pick<OutboundChannelMessage, "chatId" | "threadId" | "replyToMessageId">,
+): string | undefined {
+  if (resolveSlackChatType(msg.chatId) === "direct") {
+    return firstNonEmptyString(msg.threadId);
+  }
+  return firstNonEmptyString(msg.threadId, msg.replyToMessageId);
+}
+
+export function normalizeSlackReactionName(value: string): string {
+  return value.trim().replace(/^:+|:+$/g, "");
+}
+
+export function slackTimestampToMillis(value: string): number {
+  return Math.round(Number.parseFloat(value) * 1000);
+}

--- a/src/channels/slack/sender.test.ts
+++ b/src/channels/slack/sender.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  SlackSenderPostMessageParams,
+  SlackSenderPostMessageResult,
+  SlackSenderReactionParams,
+} from "@/channels/slack/sender";
+import { createSlackChannelSender } from "@/channels/slack/sender";
+import type { OutboundChannelMessage } from "@/channels/types";
+
+class FakeSlackSenderClient {
+  postMessages: SlackSenderPostMessageParams[] = [];
+  addedReactions: SlackSenderReactionParams[] = [];
+  removedReactions: SlackSenderReactionParams[] = [];
+
+  async postMessage(
+    params: SlackSenderPostMessageParams,
+  ): Promise<SlackSenderPostMessageResult> {
+    this.postMessages.push(params);
+    return { messageId: "1712790000.000050" };
+  }
+
+  async addReaction(params: SlackSenderReactionParams): Promise<void> {
+    this.addedReactions.push(params);
+  }
+
+  async removeReaction(params: SlackSenderReactionParams): Promise<void> {
+    this.removedReactions.push(params);
+  }
+}
+
+describe("Slack channel sender", () => {
+  test("posts threaded channel messages", async () => {
+    const client = new FakeSlackSenderClient();
+    const sender = createSlackChannelSender({ client });
+    const message: OutboundChannelMessage = {
+      channel: "slack",
+      accountId: "integration-1",
+      chatId: "C123",
+      threadId: "1712790000.000000",
+      text: "hello",
+    };
+
+    await expect(sender.sendMessage(message)).resolves.toEqual({
+      messageId: "1712790000.000050",
+    });
+    expect(client.postMessages).toEqual([
+      {
+        channel: "C123",
+        text: "hello",
+        threadTs: "1712790000.000000",
+      },
+    ]);
+  });
+
+  test("adds Slack reactions", async () => {
+    const client = new FakeSlackSenderClient();
+    const sender = createSlackChannelSender({ client });
+    const message: OutboundChannelMessage = {
+      channel: "slack",
+      chatId: "C123",
+      text: "",
+      targetMessageId: "1712790000.000000",
+      reaction: ":eyes:",
+    };
+
+    await expect(sender.sendMessage(message)).resolves.toEqual({
+      messageId: "1712790000.000000",
+    });
+    expect(client.addedReactions).toEqual([
+      {
+        channel: "C123",
+        timestamp: "1712790000.000000",
+        name: "eyes",
+      },
+    ]);
+  });
+});

--- a/src/channels/slack/sender.ts
+++ b/src/channels/slack/sender.ts
@@ -1,0 +1,127 @@
+import type { OutboundChannelMessage } from "@/channels/types";
+import {
+  normalizeSlackReactionName,
+  resolveSlackOutboundThreadTs,
+} from "./public-utils";
+
+export interface SlackSenderPostMessageParams {
+  channel: string;
+  text: string;
+  threadTs?: string;
+  blocks?: unknown[];
+}
+
+export interface SlackSenderPostMessageResult {
+  messageId: string;
+}
+
+export interface SlackSenderMessageResult {
+  messageId: string;
+}
+
+export interface SlackSenderReactionParams {
+  channel: string;
+  timestamp: string;
+  name: string;
+}
+
+export interface SlackSenderClient {
+  postMessage(
+    params: SlackSenderPostMessageParams,
+  ): Promise<SlackSenderPostMessageResult>;
+  addReaction?(params: SlackSenderReactionParams): Promise<void>;
+  removeReaction?(params: SlackSenderReactionParams): Promise<void>;
+}
+
+export interface SlackChannelSender {
+  sendMessage(
+    message: OutboundChannelMessage,
+  ): Promise<SlackSenderMessageResult>;
+  sendDirectReply(params: SlackDirectReplyParams): Promise<void>;
+}
+
+export interface SlackDirectReplyParams {
+  chatId: string;
+  text: string;
+  replyToMessageId?: string;
+  threadId?: string | null;
+  blocks?: unknown[];
+}
+
+export interface CreateSlackChannelSenderParams {
+  client: SlackSenderClient;
+}
+
+async function sendSlackReaction(
+  client: SlackSenderClient,
+  message: OutboundChannelMessage,
+): Promise<SlackSenderMessageResult> {
+  const targetMessageId = message.targetMessageId ?? message.replyToMessageId;
+  if (!targetMessageId) {
+    throw new Error(
+      "Slack reactions require message_id (or reply_to_message_id) to identify the target message.",
+    );
+  }
+  const name = normalizeSlackReactionName(message.reaction ?? "");
+  if (!name) {
+    throw new Error("Slack reaction emoji cannot be empty.");
+  }
+  const params: SlackSenderReactionParams = {
+    channel: message.chatId,
+    timestamp: targetMessageId,
+    name,
+  };
+  if (message.removeReaction) {
+    if (!client.removeReaction) {
+      throw new Error(
+        "Slack sender client does not support removing reactions.",
+      );
+    }
+    await client.removeReaction(params);
+  } else {
+    if (!client.addReaction) {
+      throw new Error("Slack sender client does not support adding reactions.");
+    }
+    await client.addReaction(params);
+  }
+  return { messageId: targetMessageId };
+}
+
+export function createSlackChannelSender(
+  params: CreateSlackChannelSenderParams,
+): SlackChannelSender {
+  const { client } = params;
+  return {
+    async sendMessage(
+      message: OutboundChannelMessage,
+    ): Promise<SlackSenderMessageResult> {
+      if (message.reaction) {
+        return await sendSlackReaction(client, message);
+      }
+      const threadTs = resolveSlackOutboundThreadTs({
+        chatId: message.chatId,
+        threadId: message.threadId,
+        replyToMessageId: message.replyToMessageId,
+      });
+      return await client.postMessage({
+        channel: message.chatId,
+        text: message.text,
+        ...(threadTs ? { threadTs } : {}),
+      });
+    },
+
+    async sendDirectReply(params: SlackDirectReplyParams): Promise<void> {
+      const threadTs = resolveSlackOutboundThreadTs({
+        chatId: params.chatId,
+        threadId: params.threadId,
+        replyToMessageId: params.replyToMessageId,
+      });
+      await client.postMessage({
+        channel: params.chatId,
+        text: params.text,
+        ...(params.blocks ? { blocks: params.blocks } : {}),
+        ...(threadTs ? { threadTs } : {}),
+      });
+    },
+  };
+}

--- a/src/channels/slack/status-controller.ts
+++ b/src/channels/slack/status-controller.ts
@@ -2,16 +2,28 @@ import type {
   ChannelTurnSource,
   OutboundChannelMessage,
 } from "@/channels/types";
-import type { SlackWriteClient } from "./internal-types";
 import {
   firstNonEmptyString,
   isNonEmptyString,
   resolveSlackChatType,
   resolveSlackProgressThreadTs,
   resolveSlackSourceThreadTs,
-} from "./utils";
+} from "./public-utils";
 
 const SLACK_ASSISTANT_STATUS_KEEPALIVE_MS = 90_000;
+
+export interface SlackStatusWriteClient {
+  assistant?: {
+    threads?: {
+      setStatus?: (args: {
+        channel_id: string;
+        thread_ts: string;
+        status: string;
+        loading_messages?: string[];
+      }) => Promise<unknown>;
+    };
+  };
+}
 
 export type AgentConvSlackState = {
   isThinkingActive: boolean;
@@ -42,7 +54,7 @@ export type SlackStatusController = {
 
 export function createSlackStatusController(params: {
   ensureApp: () => Promise<unknown>;
-  ensureWriteClient: () => Promise<SlackWriteClient>;
+  ensureWriteClient: () => Promise<SlackStatusWriteClient>;
   resolveKnownThreadRoot: (messageId: string) => string;
 }): SlackStatusController {
   const stateByConversation = new Map<string, AgentConvSlackState>();

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -12,6 +12,8 @@
     "src/types/app-server-protocol.ts",
     "src/app-server-client.ts",
     "src/agent-presets.ts",
+    "src/channels-public.ts",
+    "src/channels-slack.ts",
     "src/types/md.d.ts",
     "src/types/mdx.d.ts",
     "src/types/txt.d.ts"


### PR DESCRIPTION
## Summary

This PR exports reusable Letta Code channel primitives so Cloud Slack can stay thin and reuse Letta Code's Slack/channel semantics instead of duplicating them in `letta-cloud`.

It includes three related pieces:

1. **Public channel primitive exports**
   - Adds package subpath exports for:
     - `@letta-ai/letta-code/channels`
     - `@letta-ai/letta-code/channels/slack`
     - `@letta-ai/letta-code/agent-presets`
   - Adds `typesVersions` mappings so TypeScript consumers resolve the generated declarations.
   - Builds browser-safe bundles into `dist/` for Cloud/web consumers.

2. **Slack runtime primitives**
   - Exposes Slack sender/status/progress helpers that Cloud can call while it still uses the transitional direct-Core path.
   - Shared primitives include outbound Slack message construction, assistant thread status handling, progress/activity mapping, and stream collection/error helpers.

3. **Shared Slack ingress policy**
   - Adds pure Slack event-processing helpers in `src/channels/slack/ingress-policy.ts` and exports them from `@letta-ai/letta-code/channels/slack`:
     - `resolveSlackMessageIngressPolicy`
     - `resolveSlackAppMentionIngressPolicy`
     - `shouldSkipSlackMessageByLastSeen`
     - `isProcessableSlackInboundMessage`
   - Refactors Letta Code's own Slack ingress controller to use these helpers, so Cloud consumes the same policy LC uses internally.

## Why

Cloud Slack currently needs to handle webhooks, persist Cloud route metadata, and queue work into Cloud infrastructure. But Cloud should not independently reimplement Slack message semantics, stream parsing, progress statuses, or channel formatting.

This PR moves the reusable, pure parts into `letta-code` so Cloud can:

- use LC's Slack message filtering/subtype policy
- normalize app mentions the same way LC does
- share direct-vs-channel thread ID semantics
- avoid double-processing duplicate Slack deliveries
- preserve LC's agent-participated thread behavior
- keep Cloud-specific DB/Redis/Sandbox responsibilities in Cloud

## Reviewer notes

### `agent-presets` export

`@letta-ai/letta-code/agent-presets` is used by Cloud/web. The package export now includes `browser`, `import`, and `default` entries. There is also a temporary compatibility export for `./dist/agent-presets.js` because Turbopack can cache/resolve stale alias paths while developing locally.

### Type declarations

The source still uses `@/` aliases internally to satisfy repo import rules. `build.js` rewrites those aliases in generated `.d.ts` files under `dist/types` so external package consumers do not see unresolved `@/` specifiers.

### Slack ingress policy extraction

`ingress-policy.ts` is intentionally pure and does not import Slack Bolt, adapters, media helpers, or Cloud code. It only takes event-like objects and returns routing/filtering decisions.

Letta Code's existing Slack ingress controller still owns:

- Slack Bolt registration
- media attachment hydration
- debounce controller interaction
- adapter dispatch
- in-memory `agentThreadTracker`

Cloud owns:

- webhook ACKs
- integration/credential lookup
- persisted `channel_routes`
- Redis/Lettuce queueing
- transitional direct-Core dispatch

### Cloud behavior enabled by this export

The paired Cloud PR can now use these helpers to support:

- `app_mention` creating/using a Slack thread route
- unmentioned follow-up replies in an existing Slack channel thread continuing the same conversation
- direct-message (`message.im`) ingress using the same LC message policy
- duplicate/older event drops via `shouldSkipSlackMessageByLastSeen`

## Validation

Ran locally:

```bash
bun tsc --noEmit
bunx --bun @biomejs/biome@2.2.5 check src/channels/slack/ingress-policy.ts src/channels/slack/ingress-controller.ts src/channels-slack.ts
bun run build
```

Also verified from `letta-cloud` that the new package exports resolve:

```bash
node --input-type=module -e "const m = await import('@letta-ai/letta-code/channels/slack'); console.log(typeof m.resolveSlackMessageIngressPolicy, typeof m.resolveSlackAppMentionIngressPolicy, typeof m.shouldSkipSlackMessageByLastSeen)"
# function function function
```

## Related Cloud work

Cloud branch consuming this PR: `letta/analyze-slack-integration-reuse-60504975`

Cloud Slack app config must subscribe to these Slack Events API bot events for the new behavior to fire:

- `app_mention`
- `message.channels`
- `message.im`
