### PR TITLE
fix(reflection): honor configured model on local backends

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,6 +219,7 @@ also rejects staged parent-relative imports (`../`); use the `@/` alias.
 |----------|--------|
 | `LETTA_DEBUG=1` | Verbose debug output (default in `bun run dev`) |
 | `LETTA_DEBUG=0` | Suppress debug output even in dev mode |
+| `LETTA_REFLECTION_MODEL=<handle>` | Override the model used by automatic reflection/sleep-time subagents |
 | `LETTA_LOCAL_BACKEND_EXPERIMENTAL=1` | Enable local in-process backend |
 | `LETTA_LOCAL_BACKEND_EXECUTOR=deterministic` | Use fake deterministic executor (for tests) |
 

--- a/src/agent/subagent-model-resolution.test.ts
+++ b/src/agent/subagent-model-resolution.test.ts
@@ -769,7 +769,7 @@ describe("resolveSubagentModel", () => {
     expect(result).toBe("letta/auto-memory");
   });
 
-  test("local backend subagents inherit the active parent model", async () => {
+  test("local backend reflection inherits the active parent model by default", async () => {
     const result = await resolveSubagentModel({
       subagentType: "reflection",
       recommendedModel: "inherit",
@@ -779,6 +779,31 @@ describe("resolveSubagentModel", () => {
     });
 
     expect(result).toBe("chatgpt-plus-pro/gpt-5.5");
+  });
+
+  test("local backend honors a configured reflection model override", async () => {
+    const result = await resolveSubagentModel({
+      subagentType: "reflection",
+      recommendedModel: "minimax-m3",
+      parentModelHandle: "chatgpt-plus-pro/gpt-5.5",
+      backendMode: "local",
+      availableHandles: new Set(["minimax-m3"]),
+    });
+
+    expect(result).toBe("minimax/MiniMax-M3");
+  });
+
+  test("environment reflection override takes precedence over subagent config", async () => {
+    const result = await resolveSubagentModel({
+      subagentType: "reflection",
+      recommendedModel: "inherit",
+      reflectionModelOverride: "minimax-m3",
+      parentModelHandle: "chatgpt-plus-pro/gpt-5.5",
+      backendMode: "local",
+      availableHandles: new Set(["minimax/MiniMax-M3"]),
+    });
+
+    expect(result).toBe("minimax/MiniMax-M3");
   });
 
   test("local backend inherits parent model for non-reflection subagents", async () => {

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -806,6 +806,7 @@ export async function spawnSubagent(
         billingTier,
         subagentType: type,
         backendMode,
+        reflectionModelOverride: process.env.LETTA_REFLECTION_MODEL,
       });
   // Build the prompt with system reminder for deployed agents
   let finalPrompt = prompt;

--- a/src/agent/subagents/subagent-model.ts
+++ b/src/agent/subagents/subagent-model.ts
@@ -116,6 +116,7 @@ export async function resolveSubagentModel(options: {
   availableHandles?: Set<string>;
   subagentType?: string;
   backendMode?: BackendMode;
+  reflectionModelOverride?: string;
 }): Promise<string | null> {
   const { userModel, recommendedModel, parentModelHandle, billingTier } =
     options;
@@ -127,26 +128,35 @@ export async function resolveSubagentModel(options: {
 
   if (userModel && !userRequestedInheritance) return userModel;
 
-  // Local backend has no server-side auto router. If the parent agent is
-  // already running successfully on a local model, spawned subagents should use
-  // that exact model instead of resolving auto/auto-memory to a provider
-  // default that may not match the active session.
-  if (options.backendMode === "local" && parentModelHandle) {
-    return parentModelHandle;
-  }
-
   if (options.subagentType === "reflection") {
+    // Reflection can be overridden globally for automatic sleep-time launches,
+    // or through .letta/agents/reflection.md. Honor either explicit choice even
+    // on local backends; "inherit" still uses the active parent model below.
+    const configuredReflectionModel =
+      options.reflectionModelOverride ?? effectiveRecommendedModel;
     if (
-      effectiveRecommendedModel &&
-      !isInheritModel(effectiveRecommendedModel)
+      configuredReflectionModel &&
+      !isInheritModel(configuredReflectionModel)
     ) {
-      const recommendedHandle = resolveModel(effectiveRecommendedModel);
+      const recommendedHandle = resolveModel(configuredReflectionModel);
       if (recommendedHandle) {
         return recommendedHandle;
       }
     }
 
+    if (options.backendMode === "local" && parentModelHandle) {
+      return parentModelHandle;
+    }
+
     return "letta/auto-memory";
+  }
+
+  // Local backend has no server-side auto router. If the parent agent is
+  // already running successfully on a local model, spawned subagents should use
+  // that exact model instead of resolving auto to a provider default that may
+  // not match the active session.
+  if (options.backendMode === "local" && parentModelHandle) {
+    return parentModelHandle;
   }
 
   let recommendedHandle: string | null = null;


### PR DESCRIPTION
## Summary
- allow automatic reflection/sleep-time agents to use `LETTA_REFLECTION_MODEL`
- honor explicit reflection model recommendations before local parent-model inheritance
- preserve existing inheritance behavior when no override is configured

## Why
Local-backend subagents currently return the active parent model before resolving reflection-specific configuration. This makes sleep-time agents consume the same model as the primary agent even when operators configure a cheaper memory model.

## Test plan
- [x] `bun test src/agent/subagent-model-resolution.test.ts` (65 tests)
- [x] `bun run typecheck`
- [x] `git diff --check`
- [x] live deployment with `LETTA_REFLECTION_MODEL=minimax-m3` on local App Server and listener services

👾 Generated with [Letta Code](https://letta.com)