### PR TITLE
fix(slack): stop download-file from wedging turns on slow or stalled transfers

### DIFF
--- a/src/channels/message-channel-slack.test.ts
+++ b/src/channels/message-channel-slack.test.ts
@@ -535,6 +535,7 @@ describe("MessageChannel Slack", () => {
       chatId: "C123",
       threadId: "1712790000.000050",
       messageId: "1712800000.000100",
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -588,6 +589,7 @@ describe("MessageChannel Slack", () => {
       chatId: "C123",
       threadId: null,
       messageId: "1712700000.000010",
+      signal: expect.any(AbortSignal),
     });
   });
 

--- a/src/channels/message-tool-schema.test.ts
+++ b/src/channels/message-tool-schema.test.ts
@@ -126,6 +126,9 @@ describe("buildDynamicMessageChannelSchema", () => {
     expect(resolved.description).toContain(
       'Use action="download-file" with channel, chat_id, attachmentId, and messageId',
     );
+    expect(resolved.description).toContain(
+      "TaskOutput (block: true, timeout: 600000)",
+    );
     expect(properties.channel?.enum).toEqual(["slack", "telegram"]);
     expect(properties.action?.enum).toEqual([
       "send",

--- a/src/channels/message-tool.ts
+++ b/src/channels/message-tool.ts
@@ -146,7 +146,7 @@ function buildDynamicMessageChannelDescriptionFromDiscovery(
     ? '\n\nFor Slack requests that require nontrivial work or several tool calls, send one short MessageChannel call with action="send" before starting other tools. This gives the Slack user verbal acknowledgement and a View in web link. Do not do this for no-ops, reaction-only responses, or simple no-tool answers.'
     : "";
   const slackAttachmentDownload = discovery.activeChannels.includes("slack")
-    ? '\n\nSlack attachments that exceed the automatic download limit include an exact recovery instruction. Use action="download-file" with channel, chat_id, attachmentId, and messageId from that instruction. The action saves the file in the normal Slack inbound attachment directory and returns its local_path.'
+    ? '\n\nSlack attachments that exceed the automatic download limit include an exact recovery instruction. Use action="download-file" with channel, chat_id, attachmentId, and messageId from that instruction. The action saves the file in the normal Slack inbound attachment directory and returns its local_path. Downloads that outlast the synchronous window return a task_id instead; wait for the local_path with TaskOutput (block: true) or cancel with TaskStop.'
     : "";
 
   return `${description}${scopedReplyContract}${slackWorkAcknowledgement}${slackAttachmentDownload}\n\nCurrently active channels: ${channelList}. Available actions across the active channels: ${actionList}. The JSON schema reflects the currently active channel plugins.`;

--- a/src/channels/message-tool.ts
+++ b/src/channels/message-tool.ts
@@ -146,7 +146,7 @@ function buildDynamicMessageChannelDescriptionFromDiscovery(
     ? '\n\nFor Slack requests that require nontrivial work or several tool calls, send one short MessageChannel call with action="send" before starting other tools. This gives the Slack user verbal acknowledgement and a View in web link. Do not do this for no-ops, reaction-only responses, or simple no-tool answers.'
     : "";
   const slackAttachmentDownload = discovery.activeChannels.includes("slack")
-    ? '\n\nSlack attachments that exceed the automatic download limit include an exact recovery instruction. Use action="download-file" with channel, chat_id, attachmentId, and messageId from that instruction. The action saves the file in the normal Slack inbound attachment directory and returns its local_path. Downloads that outlast the synchronous window return a task_id instead; wait for the local_path with TaskOutput (block: true) or cancel with TaskStop.'
+    ? '\n\nSlack attachments that exceed the automatic download limit include an exact recovery instruction. Use action="download-file" with channel, chat_id, attachmentId, and messageId from that instruction. The action saves the file in the normal Slack inbound attachment directory and returns its local_path. Downloads that outlast the synchronous window return a task_id instead; wait for the local_path with TaskOutput (block: true, timeout: 600000) or cancel with TaskStop.'
     : "";
 
   return `${description}${scopedReplyContract}${slackWorkAcknowledgement}${slackAttachmentDownload}\n\nCurrently active channels: ${channelList}. Available actions across the active channels: ${actionList}. The JSON schema reflects the currently active channel plugins.`;

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -58,6 +58,7 @@ export interface SlackChannelAdapter extends ChannelAdapter {
     chatId: string;
     threadId?: string | null;
     messageId: string;
+    signal?: AbortSignal;
   }): Promise<ChannelMessageAttachment>;
 }
 
@@ -137,6 +138,7 @@ export function createSlackAdapter(
     chatId: string;
     threadId?: string | null;
     messageId: string;
+    signal?: AbortSignal;
   }): Promise<ChannelMessageAttachment> {
     const slackApp = await ensureApp();
     return await downloadSlackAttachmentById({
@@ -147,6 +149,7 @@ export function createSlackAdapter(
       threadTs: params.threadId,
       messageTs: params.messageId,
       client: slackApp.client as unknown as SlackAttachmentReadClient,
+      signal: params.signal,
     });
   }
 

--- a/src/channels/slack/attachment-download.ts
+++ b/src/channels/slack/attachment-download.ts
@@ -73,6 +73,7 @@ export async function downloadSlackAttachmentById(params: {
   threadTs?: string | null;
   messageTs: string;
   client: SlackAttachmentReadClient;
+  signal?: AbortSignal;
 }): Promise<ChannelMessageAttachment> {
   const message = await resolveCanonicalSlackMessage(params);
   if (!message) {
@@ -96,5 +97,6 @@ export async function downloadSlackAttachmentById(params: {
     file,
     sourceMessageId: params.messageTs,
     sourceThreadId: params.threadTs ?? null,
+    signal: params.signal,
   });
 }

--- a/src/channels/slack/attachment-stream.test.ts
+++ b/src/channels/slack/attachment-stream.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { __testOverrideChannelsRoot } from "@/channels/config";
+import {
+  SlackAttachmentDownloadError,
+  saveSlackAttachmentStream,
+} from "./attachment-stream";
+
+let channelsRoot: string | null = null;
+
+beforeEach(async () => {
+  channelsRoot = await mkdtemp(join(tmpdir(), "letta-slack-stream-"));
+  __testOverrideChannelsRoot(channelsRoot);
+});
+
+afterEach(async () => {
+  __testOverrideChannelsRoot(null);
+  if (channelsRoot) {
+    await rm(channelsRoot, { recursive: true, force: true });
+    channelsRoot = null;
+  }
+});
+
+async function listInboundFiles(): Promise<string[]> {
+  if (!channelsRoot) {
+    throw new Error("Expected Slack stream test root");
+  }
+  const inboundDir = join(channelsRoot, "slack", "inbound", "account-1");
+  return await readdir(inboundDir);
+}
+
+test("a stalled stream fails with a read-idle timeout and removes the partial file", async () => {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new Uint8Array([1, 2, 3]));
+      // Never enqueue again and never close: a dead TCP stream.
+    },
+  });
+
+  await expect(
+    saveSlackAttachmentStream({
+      accountId: "account-1",
+      fileName: "archive.zip",
+      body,
+      readIdleTimeoutMs: 25,
+    }),
+  ).rejects.toMatchObject({
+    name: "SlackAttachmentDownloadError",
+    reason: "download_failed",
+    message: expect.stringContaining("stalled"),
+  });
+  expect(await listInboundFiles()).toEqual([]);
+});
+
+test("aborting the signal fails the stream and removes the partial file", async () => {
+  const abortController = new AbortController();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new Uint8Array([1, 2, 3]));
+    },
+  });
+
+  const savePromise = saveSlackAttachmentStream({
+    accountId: "account-1",
+    fileName: "archive.zip",
+    body,
+    signal: abortController.signal,
+  });
+  abortController.abort();
+
+  await expect(savePromise).rejects.toMatchObject({
+    name: "SlackAttachmentDownloadError",
+    reason: "download_failed",
+    message: expect.stringContaining("aborted"),
+  });
+  expect(await listInboundFiles()).toEqual([]);
+});
+
+test("a healthy stream still saves within the idle window", async () => {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new Uint8Array([1, 2, 3]));
+      controller.enqueue(new Uint8Array([4, 5]));
+      controller.close();
+    },
+  });
+
+  const saved = await saveSlackAttachmentStream({
+    accountId: "account-1",
+    fileName: "archive.zip",
+    body,
+    readIdleTimeoutMs: 25,
+  });
+
+  expect(saved.sizeBytes).toBe(5);
+  expect(saved.localPath.endsWith("archive.zip")).toBe(true);
+  expect(await listInboundFiles()).toHaveLength(1);
+});
+
+test("SlackAttachmentDownloadError keeps its reason across the stream seam", () => {
+  const error = new SlackAttachmentDownloadError(
+    "download_failed",
+    "Slack attachment download stalled (no data received for 25ms).",
+  );
+  expect(error.reason).toBe("download_failed");
+});

--- a/src/channels/slack/attachment-stream.ts
+++ b/src/channels/slack/attachment-stream.ts
@@ -54,7 +54,6 @@ async function readWithIdleTimeout(
             ),
           );
         }, idleTimeoutMs);
-        timeoutHandle.unref?.();
         if (signal) {
           onAbort = () =>
             reject(

--- a/src/channels/slack/attachment-stream.ts
+++ b/src/channels/slack/attachment-stream.ts
@@ -23,11 +23,68 @@ function sanitizeFileName(name: string): string {
   return normalized.length > 0 ? normalized : "attachment";
 }
 
+/**
+ * Slack file downloads must never wedge a turn on a dead TCP stream: a read
+ * that produces no data within this window fails the download instead of
+ * waiting forever. Mirrors OpenClaw's Slack media read-idle timeout.
+ */
+export const SLACK_ATTACHMENT_READ_IDLE_TIMEOUT_MS = 60_000;
+
+async function readWithIdleTimeout(
+  reader: { read(): Promise<{ done: boolean; value?: Uint8Array }> },
+  idleTimeoutMs: number,
+  signal?: AbortSignal,
+): Promise<{ done: boolean; value?: Uint8Array }> {
+  if (signal?.aborted) {
+    throw new SlackAttachmentDownloadError(
+      "download_failed",
+      "Slack attachment download was aborted.",
+    );
+  }
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  let onAbort: (() => void) | undefined;
+  try {
+    return await new Promise<{ done: boolean; value?: Uint8Array }>(
+      (resolve, reject) => {
+        timeoutHandle = setTimeout(() => {
+          reject(
+            new SlackAttachmentDownloadError(
+              "download_failed",
+              `Slack attachment download stalled (no data received for ${idleTimeoutMs}ms).`,
+            ),
+          );
+        }, idleTimeoutMs);
+        timeoutHandle.unref?.();
+        if (signal) {
+          onAbort = () =>
+            reject(
+              new SlackAttachmentDownloadError(
+                "download_failed",
+                "Slack attachment download was aborted.",
+              ),
+            );
+          signal.addEventListener("abort", onAbort, { once: true });
+        }
+        reader.read().then(resolve, reject);
+      },
+    );
+  } finally {
+    if (timeoutHandle !== undefined) {
+      clearTimeout(timeoutHandle);
+    }
+    if (signal && onAbort) {
+      signal.removeEventListener("abort", onAbort);
+    }
+  }
+}
+
 export async function saveSlackAttachmentStream(params: {
   accountId: string;
   fileName: string;
   body: ReadableStream<Uint8Array>;
   maxBytes?: number;
+  signal?: AbortSignal;
+  readIdleTimeoutMs?: number;
 }): Promise<{ localPath: string; sizeBytes: number }> {
   const inboundDir = join(
     getChannelDir("slack"),
@@ -43,12 +100,18 @@ export async function saveSlackAttachmentStream(params: {
   const temporaryPath = `${filePath}.partial`;
   const fileHandle = await open(temporaryPath, "wx");
   const reader = params.body.getReader();
+  const readIdleTimeoutMs =
+    params.readIdleTimeoutMs ?? SLACK_ATTACHMENT_READ_IDLE_TIMEOUT_MS;
   let sizeBytes = 0;
   let completed = false;
 
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      const { done, value } = await readWithIdleTimeout(
+        reader,
+        readIdleTimeoutMs,
+        params.signal,
+      );
       if (done) {
         break;
       }

--- a/src/channels/slack/attachment-task.test.ts
+++ b/src/channels/slack/attachment-task.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import type { ChannelMessageAttachment } from "@/channels/types";
+import {
+  __resetBackgroundOutputDirForTests,
+  backgroundProcesses,
+} from "@/tools/impl/process_manager";
+import { runSlackAttachmentDownloadTask } from "./attachment-task";
+
+const ATTACHMENT: ChannelMessageAttachment = {
+  id: "FLARGE",
+  name: "archive.zip",
+  mimeType: "application/zip",
+  sizeBytes: 5,
+  kind: "file",
+  localPath: "/tmp/channels/slack/inbound/account-1/archive.zip",
+};
+
+beforeEach(() => {
+  // Other suites exercise MessageChannel downloads and leave settled entries
+  // in the shared registry; start each test from a clean slate.
+  backgroundProcesses.clear();
+});
+
+afterEach(() => {
+  backgroundProcesses.clear();
+  __resetBackgroundOutputDirForTests();
+});
+
+test("fast downloads settle synchronously and complete the registry entry", async () => {
+  const result = await runSlackAttachmentDownloadTask({
+    description: "Slack attachment download FLARGE",
+    download: async () => ATTACHMENT,
+  });
+
+  expect(result).toEqual({ outcome: "completed", attachment: ATTACHMENT });
+  const entries = [...backgroundProcesses.entries()];
+  expect(entries).toHaveLength(1);
+  const [taskId, entry] = entries[0] ?? [];
+  expect(taskId).toMatch(/^download_\d+$/);
+  expect(entry?.status).toBe("completed");
+  expect(entry?.exitCode).toBe(0);
+  expect(entry?.stdout.join("\n")).toContain(ATTACHMENT.localPath as string);
+});
+
+test("failed downloads report the error and fail the registry entry", async () => {
+  const result = await runSlackAttachmentDownloadTask({
+    description: "Slack attachment download FLARGE",
+    download: async () => {
+      throw new Error("HTTP 403");
+    },
+  });
+
+  expect(result).toEqual({ outcome: "failed", error: "HTTP 403" });
+  const entry = [...backgroundProcesses.values()][0];
+  expect(entry?.status).toBe("failed");
+  expect(entry?.exitCode).toBe(1);
+  expect(entry?.stderr.join("\n")).toContain("HTTP 403");
+});
+
+test("slow downloads yield a background task id and finish afterwards", async () => {
+  let resolveDownload: (attachment: ChannelMessageAttachment) => void = () => {
+    throw new Error("download was never started");
+  };
+  const download = mock(
+    (_signal: AbortSignal) =>
+      new Promise<ChannelMessageAttachment>((resolve) => {
+        resolveDownload = resolve;
+      }),
+  );
+
+  const result = await runSlackAttachmentDownloadTask({
+    description: "Slack attachment download FLARGE",
+    download,
+    yieldTimeMs: 20,
+  });
+
+  if (result.outcome !== "backgrounded") {
+    throw new Error(`Expected backgrounded outcome, got ${result.outcome}`);
+  }
+  expect(result.taskId).toMatch(/^download_\d+$/);
+
+  const entry = backgroundProcesses.get(result.taskId);
+  expect(entry?.status).toBe("running");
+
+  resolveDownload(ATTACHMENT);
+  await Bun.sleep(1);
+
+  const settled = backgroundProcesses.get(result.taskId);
+  expect(settled?.status).toBe("completed");
+  expect(settled?.stdout.join("\n")).toContain(ATTACHMENT.localPath as string);
+  expect(readFileSync(settled?.outputFile as string, "utf-8")).toContain(
+    ATTACHMENT.localPath as string,
+  );
+});
+
+test("killing a backgrounded download aborts the transfer and fails the entry", async () => {
+  let abortSeen = false;
+  const download = (signal: AbortSignal) =>
+    new Promise<ChannelMessageAttachment>((_resolve, reject) => {
+      signal.addEventListener(
+        "abort",
+        () => {
+          abortSeen = true;
+          reject(new Error("Slack attachment download was aborted."));
+        },
+        { once: true },
+      );
+    });
+
+  const result = await runSlackAttachmentDownloadTask({
+    description: "Slack attachment download FLARGE",
+    download,
+    yieldTimeMs: 20,
+  });
+
+  if (result.outcome !== "backgrounded") {
+    throw new Error(`Expected backgrounded outcome, got ${result.outcome}`);
+  }
+
+  const entry = backgroundProcesses.get(result.taskId);
+  entry?.process.kill("SIGTERM");
+  await Bun.sleep(1);
+
+  expect(abortSeen).toBe(true);
+  const settled = backgroundProcesses.get(result.taskId);
+  expect(settled?.status).toBe("failed");
+  expect(settled?.stderr.join("\n")).toContain("aborted");
+});

--- a/src/channels/slack/attachment-task.ts
+++ b/src/channels/slack/attachment-task.ts
@@ -1,0 +1,116 @@
+import type { ChannelMessageAttachment } from "@/channels/types";
+import {
+  appendBackgroundProcessOutput,
+  appendToOutputFile,
+  assertBackgroundProcessCapacity,
+  backgroundProcesses,
+  createBackgroundOutputFile,
+  getNextDownloadId,
+  scheduleBackgroundProcessCleanup,
+} from "@/tools/impl/process_manager";
+
+/**
+ * How long an explicit Slack attachment download may run inside the tool call
+ * before it yields to a background task. Mirrors the Codex-toolset
+ * exec_command yield pattern: fast downloads stay a single round-trip, slow
+ * ones return a task id instead of wedging the turn on MessageChannel.
+ */
+export const SLACK_ATTACHMENT_DOWNLOAD_YIELD_MS = 10_000;
+
+export type SlackAttachmentDownloadOutcome =
+  | { outcome: "completed"; attachment: ChannelMessageAttachment }
+  | { outcome: "failed"; error: string }
+  | { outcome: "backgrounded"; taskId: string };
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Run a Slack attachment download with a bounded synchronous window.
+ *
+ * The download is registered in the shared background-process registry up
+ * front so TaskOutput/TaskStop and the listener status snapshot see it from
+ * the first byte. If it settles within the yield window the entry completes
+ * immediately and the caller gets the direct result; otherwise the caller
+ * gets the task id while the transfer keeps streaming in-process.
+ */
+export async function runSlackAttachmentDownloadTask(params: {
+  description: string;
+  download: (signal: AbortSignal) => Promise<ChannelMessageAttachment>;
+  yieldTimeMs?: number;
+}): Promise<SlackAttachmentDownloadOutcome> {
+  assertBackgroundProcessCapacity();
+
+  const taskId = getNextDownloadId();
+  const outputFile = createBackgroundOutputFile(taskId);
+  const abortController = new AbortController();
+  const processState = {
+    process: {
+      kill: () => {
+        abortController.abort();
+        return true;
+      },
+    },
+    command: params.description,
+    stdout: [] as string[],
+    stderr: [] as string[],
+    status: "running" as "running" | "completed" | "failed",
+    exitCode: null as number | null,
+    lastReadIndex: { stdout: 0, stderr: 0 },
+    startTime: new Date(),
+    outputFile,
+    totalStdoutLines: 0,
+    totalStderrLines: 0,
+  };
+  backgroundProcesses.set(taskId, processState);
+  appendToOutputFile(outputFile, `${params.description}\n`);
+
+  const downloadPromise = params
+    .download(abortController.signal)
+    .then((attachment) => {
+      const line = `Slack attachment downloaded (local_path: ${attachment.localPath})`;
+      processState.status = "completed";
+      processState.exitCode = 0;
+      appendBackgroundProcessOutput(processState, "stdout", line);
+      appendToOutputFile(outputFile, `${line}\n`);
+      scheduleBackgroundProcessCleanup(taskId);
+      return { outcome: "completed" as const, attachment };
+    })
+    .catch((error: unknown) => {
+      const message = toErrorMessage(error);
+      processState.status = "failed";
+      processState.exitCode = 1;
+      appendBackgroundProcessOutput(
+        processState,
+        "stderr",
+        `Slack attachment download failed: ${message}`,
+      );
+      appendToOutputFile(
+        outputFile,
+        `Slack attachment download failed: ${message}\n`,
+      );
+      scheduleBackgroundProcessCleanup(taskId);
+      return { outcome: "failed" as const, error: message };
+    });
+
+  const yieldTimeMs = params.yieldTimeMs ?? SLACK_ATTACHMENT_DOWNLOAD_YIELD_MS;
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const yieldPromise = new Promise<SlackAttachmentDownloadOutcome>(
+    (resolve) => {
+      timeoutHandle = setTimeout(
+        () => resolve({ outcome: "backgrounded", taskId }),
+        yieldTimeMs,
+      );
+      timeoutHandle.unref?.();
+    },
+  );
+
+  try {
+    return await Promise.race([downloadPromise, yieldPromise]);
+  } finally {
+    if (timeoutHandle !== undefined) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}

--- a/src/channels/slack/attachment-task.ts
+++ b/src/channels/slack/attachment-task.ts
@@ -102,7 +102,6 @@ export async function runSlackAttachmentDownloadTask(params: {
         () => resolve({ outcome: "backgrounded", taskId }),
         yieldTimeMs,
       );
-      timeoutHandle.unref?.();
     },
   );
 

--- a/src/channels/slack/media.ts
+++ b/src/channels/slack/media.ts
@@ -327,6 +327,7 @@ function resolveAttachmentKind(
 async function fetchWithSlackAuth(
   url: string,
   token: string,
+  signal?: AbortSignal,
 ): Promise<Response> {
   const parsed = assertSlackFileUrl(url);
   const authHeaders = { Authorization: `Bearer ${token}` };
@@ -334,6 +335,7 @@ async function fetchWithSlackAuth(
   const initial = await fetch(parsed.href, {
     headers: authHeaders,
     redirect: "manual",
+    ...(signal ? { signal } : {}),
   });
 
   if (initial.status < 300 || initial.status >= 400) {
@@ -350,10 +352,14 @@ async function fetchWithSlackAuth(
     return fetch(resolved.href, {
       headers: authHeaders,
       redirect: "follow",
+      ...(signal ? { signal } : {}),
     });
   }
 
-  return fetch(resolved.href, { redirect: "follow" });
+  return fetch(resolved.href, {
+    redirect: "follow",
+    ...(signal ? { signal } : {}),
+  });
 }
 
 function resolveSlackAttachmentFileName(params: {
@@ -418,6 +424,7 @@ export async function materializeSlackAttachment(params: {
   sourceThreadId?: string | null;
   maxBytes?: number;
   transcribeVoice?: boolean;
+  signal?: AbortSignal;
 }): Promise<ChannelMessageAttachment> {
   if (
     params.maxBytes !== undefined &&
@@ -438,16 +445,16 @@ export async function materializeSlackAttachment(params: {
     );
   }
 
-  const response = await fetchWithSlackAuth(url, params.token).catch(
-    (error) => {
-      throw new SlackAttachmentDownloadError(
-        "download_failed",
-        error instanceof Error
-          ? error.message
-          : "Slack attachment fetch failed.",
-      );
-    },
-  );
+  const response = await fetchWithSlackAuth(
+    url,
+    params.token,
+    params.signal,
+  ).catch((error) => {
+    throw new SlackAttachmentDownloadError(
+      "download_failed",
+      error instanceof Error ? error.message : "Slack attachment fetch failed.",
+    );
+  });
   if (!response.ok) {
     throw new SlackAttachmentDownloadError(
       "download_failed",
@@ -499,6 +506,7 @@ export async function materializeSlackAttachment(params: {
     fileName,
     body: response.body,
     maxBytes: params.maxBytes,
+    signal: params.signal,
   });
 
   const kind = resolveAttachmentKind(mimeType);

--- a/src/channels/slack/message-actions.ts
+++ b/src/channels/slack/message-actions.ts
@@ -104,7 +104,7 @@ async function downloadSlackFile(
   if (result.outcome === "backgrounded") {
     return [
       `Slack attachment download is still running in the background (task_id: ${result.taskId}).`,
-      `Check on it with TaskOutput (task_id: ${result.taskId}, block: true) to wait for the local_path, or TaskStop to cancel.`,
+      `Check on it with TaskOutput (task_id: ${result.taskId}, block: true, timeout: 600000) to wait for the local_path, or TaskStop to cancel.`,
       "You will not be notified automatically when it finishes.",
     ].join(" ");
   }

--- a/src/channels/slack/message-actions.ts
+++ b/src/channels/slack/message-actions.ts
@@ -3,6 +3,7 @@ import type {
   ChannelMessageActionContext,
 } from "@/channels/plugin-types";
 import type { SlackChannelAccount } from "@/channels/types";
+import { runSlackAttachmentDownloadTask } from "./attachment-task";
 import { resolveSlackMessageTarget } from "./target-resolution";
 
 async function sendSlackMessage(
@@ -72,26 +73,46 @@ async function downloadSlackFile(
   ctx: ChannelMessageActionContext,
 ): Promise<string> {
   const { request } = ctx;
-  if (!request.attachmentId?.trim()) {
+  const attachmentId = request.attachmentId?.trim();
+  if (!attachmentId) {
     return "Error: Slack download-file requires attachmentId.";
   }
-  if (!request.messageId?.trim()) {
+  const messageId = request.messageId?.trim();
+  if (!messageId) {
     return "Error: Slack download-file requires messageId from the attachment's Slack context.";
   }
-  if (typeof ctx.adapter.downloadAttachment !== "function") {
+  const downloadAttachment = ctx.adapter.downloadAttachment;
+  if (typeof downloadAttachment !== "function") {
     return "Error: Running Slack adapter does not support attachment downloads.";
   }
-  const attachment = await ctx.adapter.downloadAttachment({
-    attachmentId: request.attachmentId,
-    chatId: request.chatId,
-    threadId: request.threadId ?? null,
-    messageId: request.messageId,
+
+  const result = await runSlackAttachmentDownloadTask({
+    description: `Slack attachment download ${attachmentId} from message ${messageId} in ${request.chatId}`,
+    download: (signal) =>
+      downloadAttachment.call(ctx.adapter, {
+        attachmentId,
+        chatId: request.chatId,
+        threadId: request.threadId ?? null,
+        messageId,
+        signal,
+      }),
   });
-  if (!attachment.localPath) {
-    return `Error: Slack attachment ${request.attachmentId} was not downloaded.`;
+
+  if (result.outcome === "failed") {
+    return `Error: Slack attachment download failed: ${result.error}`;
+  }
+  if (result.outcome === "backgrounded") {
+    return [
+      `Slack attachment download is still running in the background (task_id: ${result.taskId}).`,
+      `Check on it with TaskOutput (task_id: ${result.taskId}, block: true) to wait for the local_path, or TaskStop to cancel.`,
+      "You will not be notified automatically when it finishes.",
+    ].join(" ");
+  }
+  if (!result.attachment.localPath) {
+    return `Error: Slack attachment ${attachmentId} was not downloaded.`;
   }
 
-  return `Slack attachment downloaded (local_path: ${attachment.localPath})`;
+  return `Slack attachment downloaded (local_path: ${result.attachment.localPath})`;
 }
 
 export const slackMessageActions: ChannelMessageActionAdapter = {

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -293,6 +293,7 @@ export interface ChannelAdapter {
     chatId: string;
     threadId?: string | null;
     messageId: string;
+    signal?: AbortSignal;
   }): Promise<ChannelMessageAttachment>;
 
   /**

--- a/src/channels/xml.test.ts
+++ b/src/channels/xml.test.ts
@@ -173,6 +173,7 @@ describe("formatChannelNotification", () => {
     expect(xml).toContain(
       "same Slack inbound attachment directory and returns its local_path",
     );
+    expect(xml).toContain("TaskOutput (block: true, timeout: 600000)");
     expect(xml).toContain("Do not ask the sender to reattach it.");
     expect(xml).toContain(
       "<download-instruction>This file is 41.7 MiB, above the 20 MiB automatic download limit. Call MessageChannel",

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -219,7 +219,7 @@ function buildAttachmentXml(
             }. `
           : "";
       children.push(
-        `<download-instruction>${sizeNote}Call ${action}. The tool downloads the file into the same Slack inbound attachment directory and returns its local_path. Large downloads return a task_id instead of blocking; wait for the local_path with TaskOutput (block: true). Do not ask the sender to reattach it.</download-instruction>`,
+        `<download-instruction>${sizeNote}Call ${action}. The tool downloads the file into the same Slack inbound attachment directory and returns its local_path. Large downloads return a task_id instead of blocking; wait for the local_path with TaskOutput (block: true, timeout: 600000). Do not ask the sender to reattach it.</download-instruction>`,
       );
     } else {
       children.push(

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -219,7 +219,7 @@ function buildAttachmentXml(
             }. `
           : "";
       children.push(
-        `<download-instruction>${sizeNote}Call ${action}. The tool downloads the file into the same Slack inbound attachment directory and returns its local_path. Do not ask the sender to reattach it.</download-instruction>`,
+        `<download-instruction>${sizeNote}Call ${action}. The tool downloads the file into the same Slack inbound attachment directory and returns its local_path. Large downloads return a task_id instead of blocking; wait for the local_path with TaskOutput (block: true). Do not ask the sender to reattach it.</download-instruction>`,
       );
     } else {
       children.push(

--- a/src/tools/impl/process_manager.ts
+++ b/src/tools/impl/process_manager.ts
@@ -60,6 +60,11 @@ export function getNextTaskId() {
   return `task_${taskIdCounter++}`;
 }
 
+let downloadIdCounter = 1;
+export function getNextDownloadId() {
+  return `download_${downloadIdCounter++}`;
+}
+
 interface BackgroundRetentionConfig {
   completedEntryTtlMs: number;
   maxProcessLinesPerStream: number;


### PR DESCRIPTION
## Summary

- Explicit Slack attachment downloads (`MessageChannel action="download-file"`) ran fully synchronously inside the tool call with no timeout of any kind: a large zip held the turn for the entire transfer, and a dead TCP stream hung it forever (LET-9773). The reference implementation avoided this with a hard size cap plus fetch timeouts; the oversized-attachment work (#3345) intentionally removed the cap for explicit downloads but did not replace those protections.
- Downloads now run through a bounded synchronous window, following the same yield pattern as `exec_command`: if the transfer settles within 10s the tool returns `local_path` in one round trip exactly as before; otherwise it returns a `download_N` task id and the transfer keeps streaming in the background. The task registers in the shared background-process registry, so `TaskOutput` (blocking or polling) retrieves the result, `TaskStop` aborts the transfer mid-stream, and the listener device-status snapshot lists it like any other background process.
- The attachment stream gains a 60s read-idle timeout: a read that produces no data within the window fails the download with a precise stall error instead of waiting forever. Abort and stall both clean up the `.partial` file. There is still deliberately no size ceiling on explicit downloads.
- Channel-context and tool-description guidance now tell the agent that long downloads return a `task_id` and to wait for the `local_path` with blocking `TaskOutput` (background completion does not notify in listener sessions).

## Behavior

| Case | Before | After |
| --- | --- | --- |
| Small/fast file | returns `local_path` | unchanged, same message |
| Large file | tool call blocks for entire transfer | yields `task_id` after 10s, transfer continues in background |
| Dead/stalled stream | turn hangs forever | fails after 60s of no data, partial file removed |
| Cancel | impossible | `TaskStop` aborts the fetch |

LET-9773

👾 Generated with [Letta Code](https://letta.com)