### PR TITLE
feat(models): add Kimi K3 presets

### DIFF
--- a/src/agent/model-catalog.test.ts
+++ b/src/agent/model-catalog.test.ts
@@ -41,7 +41,7 @@ describe("browser-safe model preset export", () => {
     });
     expect(openrouter).toMatchObject({
       handle: "openrouter/moonshotai/kimi-k3",
-      label: "Kimi K3 (OpenRouter)",
+      label: "Kimi K3",
       updateArgs: {
         context_window: 1048576,
         max_output_tokens: 131072,

--- a/src/agent/model-catalog.test.ts
+++ b/src/agent/model-catalog.test.ts
@@ -23,4 +23,30 @@ describe("browser-safe model preset export", () => {
     });
     expect("available" in (preset ?? {})).toBe(false);
   });
+
+  test("includes Kimi K3 direct and OpenRouter presets with Cloud-aligned limits", () => {
+    const direct = MODEL_PRESETS.find((entry) => entry.id === "kimi-k3");
+    const openrouter = MODEL_PRESETS.find(
+      (entry) => entry.id === "kimi-k3-openrouter",
+    );
+
+    expect(direct).toMatchObject({
+      handle: "moonshot/kimi-k3",
+      label: "Kimi K3",
+      updateArgs: {
+        context_window: 1048576,
+        max_output_tokens: 131072,
+        reasoning_effort: "max",
+      },
+    });
+    expect(openrouter).toMatchObject({
+      handle: "openrouter/moonshotai/kimi-k3",
+      label: "Kimi K3 (OpenRouter)",
+      updateArgs: {
+        context_window: 1048576,
+        max_output_tokens: 131072,
+        reasoning_effort: "max",
+      },
+    });
+  });
 });

--- a/src/agent/model-handles.ts
+++ b/src/agent/model-handles.ts
@@ -81,6 +81,9 @@ export function normalizeModelHandleForRegistry(
   if (provider === "lc-anthropic" && model.length > 0) {
     return `anthropic/${model}`;
   }
+  if (provider === "moonshotai" && model.length > 0) {
+    return `moonshot/${model}`;
+  }
   return modelHandle;
 }
 

--- a/src/agent/modify-local.test.ts
+++ b/src/agent/modify-local.test.ts
@@ -48,6 +48,20 @@ describe("local model updates", () => {
     });
   });
 
+  test("builds direct Moonshot K3 settings with top-level max reasoning", () => {
+    expect(
+      __modifyTestUtils.buildModelSettings("moonshot/kimi-k3", {
+        reasoning_effort: "max",
+        max_output_tokens: 131072,
+      }),
+    ).toMatchObject({
+      provider_type: "moonshot",
+      parallel_tool_calls: true,
+      reasoning_effort: "max",
+      max_output_tokens: 131072,
+    });
+  });
+
   test("stores GPT-5.6 max separately from xhigh for local providers", () => {
     expect(
       __modifyTestUtils.buildModelSettings("openai-codex/gpt-5.6-sol", {

--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -59,6 +59,11 @@ function buildModelSettings(
     modelHandle.startsWith("lc-anthropic/") ||
     modelHandle.startsWith("claude-pro-max/") ||
     modelHandle.startsWith("minimax/");
+  const isMoonshot =
+    explicitProviderType === "moonshot" ||
+    explicitProviderType === "moonshotai" ||
+    modelHandle.startsWith("moonshot/") ||
+    modelHandle.startsWith("moonshotai/");
   const isZai =
     explicitProviderType === "zai" || modelHandle.startsWith("zai/");
   const isXai =
@@ -77,7 +82,16 @@ function buildModelSettings(
 
   let settings: ModelSettings;
 
-  if (isOpenAI || isOpenRouter) {
+  if (isMoonshot) {
+    const moonshotSettings: Record<string, unknown> = {
+      provider_type: "moonshot",
+      parallel_tool_calls: true,
+    };
+    if (typeof updateArgs?.reasoning_effort === "string") {
+      moonshotSettings.reasoning_effort = updateArgs.reasoning_effort;
+    }
+    settings = moonshotSettings;
+  } else if (isOpenAI || isOpenRouter) {
     const openaiSettings: OpenAIModelSettings = {
       provider_type: "openai",
       parallel_tool_calls: true,

--- a/src/cli/app/model-config.test.ts
+++ b/src/cli/app/model-config.test.ts
@@ -72,4 +72,16 @@ describe("model config helpers", () => {
       ),
     ).toBe("max");
   });
+
+  test("does not expose unsupported Moonshot reasoning tiers", () => {
+    expect(
+      deriveReasoningEffort(
+        {
+          provider_type: "moonshot",
+          reasoning_effort: "low",
+        } as never,
+        null,
+      ),
+    ).toBeNull();
+  });
 });

--- a/src/cli/app/model-config.test.ts
+++ b/src/cli/app/model-config.test.ts
@@ -22,6 +22,24 @@ describe("model config helpers", () => {
     });
   });
 
+  test("maps Kimi K3 direct and OpenRouter handles to backend llm_config fields", () => {
+    expect(
+      mapHandleToLlmConfigPatch("moonshot/kimi-k3") as Record<string, unknown>,
+    ).toEqual({
+      model: "kimi-k3",
+      model_endpoint_type: "moonshot",
+    });
+    expect(
+      mapHandleToLlmConfigPatch("openrouter/moonshotai/kimi-k3") as Record<
+        string,
+        unknown
+      >,
+    ).toEqual({
+      model: "moonshotai/kimi-k3",
+      model_endpoint_type: "openrouter",
+    });
+  });
+
   test("extracts provider type from model settings and update args", () => {
     expect(
       providerTypeFromModelSettings({ provider_type: "chatgpt_oauth" }),
@@ -37,6 +55,18 @@ describe("model config helpers", () => {
         {
           provider_type: "chatgpt_oauth",
           reasoning: { reasoning_effort: "max" },
+        } as never,
+        null,
+      ),
+    ).toBe("max");
+  });
+
+  test("derives Kimi K3 max from Moonshot model settings", () => {
+    expect(
+      deriveReasoningEffort(
+        {
+          provider_type: "moonshot",
+          reasoning_effort: "max",
         } as never,
         null,
       ),

--- a/src/cli/app/model-config.ts
+++ b/src/cli/app/model-config.ts
@@ -40,6 +40,23 @@ export function deriveReasoningEffort(
         return re;
     }
 
+    // Moonshot: top-level reasoning_effort field
+    if (providerType === "moonshot" || providerType === "moonshotai") {
+      const effort = (modelSettings as { reasoning_effort?: string | null })
+        .reasoning_effort;
+      if (
+        effort === "none" ||
+        effort === "minimal" ||
+        effort === "low" ||
+        effort === "medium" ||
+        effort === "high" ||
+        effort === "xhigh" ||
+        effort === "max"
+      ) {
+        return effort;
+      }
+    }
+
     // Anthropic/Bedrock: effort field
     if (providerType === "anthropic" || providerType === "bedrock") {
       const effort = (modelSettings as { effort?: string | null }).effort;

--- a/src/cli/app/model-config.ts
+++ b/src/cli/app/model-config.ts
@@ -44,17 +44,7 @@ export function deriveReasoningEffort(
     if (providerType === "moonshot" || providerType === "moonshotai") {
       const effort = (modelSettings as { reasoning_effort?: string | null })
         .reasoning_effort;
-      if (
-        effort === "none" ||
-        effort === "minimal" ||
-        effort === "low" ||
-        effort === "medium" ||
-        effort === "high" ||
-        effort === "xhigh" ||
-        effort === "max"
-      ) {
-        return effort;
-      }
+      if (effort === "max") return effort;
     }
 
     // Anthropic/Bedrock: effort field

--- a/src/cli/components/ModelSelector-availability.test.tsx
+++ b/src/cli/components/ModelSelector-availability.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { models } from "@/agent/model";
 import { filterModelsByAvailabilityForSelector } from "@/cli/components/ModelSelector";
 
 type StubModel = { handle: string; label: string };
@@ -55,5 +56,22 @@ describe("ModelSelector availability gating", () => {
     ]);
     expect(shownResult.map((m) => m.handle)).toContain("letta/auto");
     expect(shownResult.map((m) => m.handle)).toContain("letta/glm");
+  });
+
+  test("includes Kimi K3 presets only when the API catalog exposes those handles", () => {
+    const result = filterModelsByAvailabilityForSelector(
+      models,
+      new Set(["moonshot/kimi-k3", "openrouter/moonshotai/kimi-k3"]),
+      [],
+    );
+
+    expect(result.map((m) => m.handle)).toEqual([
+      "moonshot/kimi-k3",
+      "openrouter/moonshotai/kimi-k3",
+    ]);
+    expect(result.map((m) => m.updateArgs?.reasoning_effort)).toEqual([
+      "max",
+      "max",
+    ]);
   });
 });

--- a/src/cli/components/ModelSelector-byok-custom-provider.test.tsx
+++ b/src/cli/components/ModelSelector-byok-custom-provider.test.tsx
@@ -93,6 +93,9 @@ describe("ModelSelector custom BYOK provider detection", () => {
     expect(registryHandleForByokAlias("openai-sarah/gpt-5.5", aliases)).toBe(
       "openai/gpt-5.5",
     );
+    expect(registryHandleForByokAlias("lc-moonshot/kimi-k3", aliases)).toBe(
+      "moonshot/kimi-k3",
+    );
 
     const reasoningOptions = getReasoningTierOptionsForHandle(
       registryHandleForByokAlias("chatgpt-personal/gpt-5.5", aliases),

--- a/src/models.json
+++ b/src/models.json
@@ -2355,8 +2355,8 @@
     {
       "id": "kimi-k3-openrouter",
       "handle": "openrouter/moonshotai/kimi-k3",
-      "label": "Kimi K3 (OpenRouter)",
-      "description": "Moonshot AI's Kimi K3 model served through OpenRouter",
+      "label": "Kimi K3",
+      "description": "Moonshot AI's Kimi K3 model for long-context agentic coding and reasoning tasks",
       "updateArgs": {
         "context_window": 1048576,
         "max_output_tokens": 131072,

--- a/src/models.json
+++ b/src/models.json
@@ -2340,6 +2340,31 @@
       }
     },
     {
+      "id": "kimi-k3",
+      "handle": "moonshot/kimi-k3",
+      "label": "Kimi K3",
+      "description": "Moonshot AI's Kimi K3 model for long-context agentic coding and reasoning tasks",
+      "isFeatured": true,
+      "updateArgs": {
+        "context_window": 1048576,
+        "max_output_tokens": 131072,
+        "reasoning_effort": "max",
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "kimi-k3-openrouter",
+      "handle": "openrouter/moonshotai/kimi-k3",
+      "label": "Kimi K3 (OpenRouter)",
+      "description": "Moonshot AI's Kimi K3 model served through OpenRouter",
+      "updateArgs": {
+        "context_window": 1048576,
+        "max_output_tokens": 131072,
+        "reasoning_effort": "max",
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "kimi-k2.7",
       "handle": "openrouter/moonshotai/kimi-k2.7-code",
       "label": "Kimi K2.7 Code",


### PR DESCRIPTION
## Summary
- Adds direct Moonshot `moonshot/kimi-k3` and OpenRouter `openrouter/moonshotai/kimi-k3` presets with Cloud-aligned 1M context, 128K output, max reasoning, and parallel tool calls.
- Sends direct Moonshot settings with provider_type `moonshot` and top-level `reasoning_effort`, and reads the same field back for current-model display.
- Normalizes `moonshotai/...` registry aliases so BYOK/local Moonshot handles can resolve the Kimi K3 preset metadata.

## Risk / review notes
- Provider/API surface: direct Moonshot uses a different model_settings shape than OpenAI/OpenRouter. Tests cover direct settings build, current-state derivation, alias registry resolution, selector availability gating, and llm_config handle mapping.
- OpenRouter Kimi K3 still uses the existing OpenAI/OpenRouter `reasoning.reasoning_effort` settings path. This PR does not add pricing display because the CLI catalog has no cost fields.
- Cloud PR 13081 currently uses 1048576 context and 131072 max output; this PR mirrors those code constants.

## Test plan
- [x] `bun test src/agent/model-catalog.test.ts src/agent/modify-local.test.ts src/cli/app/model-config.test.ts src/cli/components/ModelSelector-availability.test.tsx src/cli/components/ModelSelector-byok-custom-provider.test.tsx`
- [x] `bun run typecheck`
- [x] `bunx --bun @biomejs/biome@2.2.5 check <changed files>`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)