### PR TITLE
fix(models): disable Kimi K3 reasoning controls

### DIFF
--- a/src/agent/model-catalog.test.ts
+++ b/src/agent/model-catalog.test.ts
@@ -36,7 +36,6 @@ describe("browser-safe model preset export", () => {
       updateArgs: {
         context_window: 1048576,
         max_output_tokens: 131072,
-        reasoning_effort: "max",
       },
     });
     expect(openrouter).toMatchObject({
@@ -45,8 +44,9 @@ describe("browser-safe model preset export", () => {
       updateArgs: {
         context_window: 1048576,
         max_output_tokens: 131072,
-        reasoning_effort: "max",
       },
     });
+    expect(direct?.updateArgs?.reasoning_effort).toBeUndefined();
+    expect(openrouter?.updateArgs?.reasoning_effort).toBeUndefined();
   });
 });

--- a/src/agent/modify-local.test.ts
+++ b/src/agent/modify-local.test.ts
@@ -48,16 +48,14 @@ describe("local model updates", () => {
     });
   });
 
-  test("builds direct Moonshot K3 settings with top-level max reasoning", () => {
+  test("builds direct Moonshot K3 settings without client reasoning controls", () => {
     expect(
       __modifyTestUtils.buildModelSettings("moonshot/kimi-k3", {
-        reasoning_effort: "max",
         max_output_tokens: 131072,
       }),
     ).toMatchObject({
       provider_type: "moonshot",
       parallel_tool_calls: true,
-      reasoning_effort: "max",
       max_output_tokens: 131072,
     });
   });

--- a/src/cli/app/model-config.test.ts
+++ b/src/cli/app/model-config.test.ts
@@ -61,24 +61,12 @@ describe("model config helpers", () => {
     ).toBe("max");
   });
 
-  test("derives Kimi K3 max from Moonshot model settings", () => {
+  test("does not expose Moonshot reasoning controls", () => {
     expect(
       deriveReasoningEffort(
         {
           provider_type: "moonshot",
           reasoning_effort: "max",
-        } as never,
-        null,
-      ),
-    ).toBe("max");
-  });
-
-  test("does not expose unsupported Moonshot reasoning tiers", () => {
-    expect(
-      deriveReasoningEffort(
-        {
-          provider_type: "moonshot",
-          reasoning_effort: "low",
         } as never,
         null,
       ),

--- a/src/cli/app/model-config.ts
+++ b/src/cli/app/model-config.ts
@@ -40,13 +40,6 @@ export function deriveReasoningEffort(
         return re;
     }
 
-    // Moonshot: top-level reasoning_effort field
-    if (providerType === "moonshot" || providerType === "moonshotai") {
-      const effort = (modelSettings as { reasoning_effort?: string | null })
-        .reasoning_effort;
-      if (effort === "max") return effort;
-    }
-
     // Anthropic/Bedrock: effort field
     if (providerType === "anthropic" || providerType === "bedrock") {
       const effort = (modelSettings as { effort?: string | null }).effort;

--- a/src/cli/components/ModelSelector-availability.test.tsx
+++ b/src/cli/components/ModelSelector-availability.test.tsx
@@ -70,8 +70,8 @@ describe("ModelSelector availability gating", () => {
       "openrouter/moonshotai/kimi-k3",
     ]);
     expect(result.map((m) => m.updateArgs?.reasoning_effort)).toEqual([
-      "max",
-      "max",
+      undefined,
+      undefined,
     ]);
   });
 });

--- a/src/models.json
+++ b/src/models.json
@@ -2348,7 +2348,6 @@
       "updateArgs": {
         "context_window": 1048576,
         "max_output_tokens": 131072,
-        "reasoning_effort": "max",
         "parallel_tool_calls": true
       }
     },
@@ -2360,7 +2359,6 @@
       "updateArgs": {
         "context_window": 1048576,
         "max_output_tokens": 131072,
-        "reasoning_effort": "max",
         "parallel_tool_calls": true
       }
     },


### PR DESCRIPTION
## What changed

- remove client-side reasoning controls from the direct Moonshot and OpenRouter Kimi K3 presets
- stop deriving a selectable Moonshot reasoning tier in the TUI
- keep Kimi K3 reasoning fixed at max in Core, where provider-specific request shaping already enforces it

## Why

Kimi K3 currently only supports max reasoning and always thinks. Sending `reasoning_effort: max` through the OpenAI-shaped agent model settings fails schema validation before the model can be selected.

Follow-up to #3384.

## Validation

- `bun test src/agent/model-catalog.test.ts src/agent/modify-local.test.ts src/cli/app/model-config.test.ts src/cli/components/ModelSelector-availability.test.tsx`
- `bun run check`