### PR TITLE
fix: resume thread title

### DIFF
--- a/src/agent/check-approval-resume-data.test.ts
+++ b/src/agent/check-approval-resume-data.test.ts
@@ -525,6 +525,7 @@ describe("getResumeData", () => {
     const sameDate = "2026-01-01T00:00:02.000Z";
     const conversationsRetrieve = mock(async () => ({
       in_context_message_ids: ["provider-msg-2"],
+      summary: "my-custom-conversation",
     }));
     const conversationsList = mock(async () => ({
       getPaginatedItems: () => [
@@ -581,6 +582,7 @@ describe("getResumeData", () => {
       "tool_return_message",
       "assistant_message",
     ]);
+    expect(resume.conversation?.summary).toBe("my-custom-conversation");
   });
 
   test("default conversation backfill orders equal-timestamp local tool messages before assistant text", async () => {

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -348,6 +348,7 @@ export function App({
   agentId: initialAgentId,
   agentState: initialAgentState,
   conversationId: initialConversationId,
+  conversationSummary: initialConversationSummary = null,
   loadingState = "ready",
   continueSession = false,
   startupApproval = null,
@@ -402,12 +403,10 @@ export function App({
   }, [agentState]);
 
   const projectDirectory = process.cwd();
-
   const [conversationId, setConversationId] = useState(initialConversationId);
-  const [conversationSummary, setConversationSummary] = useState<string | null>(
-    null,
+  const [conversationSummary, setConversationSummary] = useState(
+    initialConversationSummary,
   );
-
   // Keep a ref to the current agentId for use in callbacks that need the latest value
   const agentIdRef = useRef(agentId);
   useEffect(() => {
@@ -4514,7 +4513,6 @@ export function App({
           output: "Processing queued conversation switch...",
           phase: "running",
         });
-
         // Execute the conversation switch asynchronously
         (async () => {
           setCommandRunning(true);
@@ -4528,19 +4526,21 @@ export function App({
                   action.conversationId,
                 );
 
+                const resumedSummary =
+                  resumeData.conversation?.summary?.trim() || undefined;
                 setConversationIdAndRef(action.conversationId);
                 setConversationAutoTitleEligibility(false);
-
+                setConversationSummary(resumedSummary ?? null);
                 pendingConversationSwitchRef.current = {
                   origin: "resume-selector",
                   conversationId: action.conversationId,
                   isDefault: action.conversationId === "default",
                   messageCount: resumeData.messageHistory.length,
+                  summary: resumedSummary,
                   messageHistory: resumeData.messageHistory,
                 };
 
                 settingsManager.persistSession(agentId, action.conversationId);
-
                 // Reset context tokens for new conversation
                 resetContextHistory(contextTrackerRef.current);
                 resetBootstrapReminderState();

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -1218,12 +1218,13 @@ export function AppView(props: AppViewProps) {
                         agentState,
                         convId,
                       );
-
+                      const resumedSummary =
+                        selectorContext?.summary ??
+                        (resumeData.conversation?.summary?.trim() || undefined);
                       // Only update state after validation succeeds
                       setConversationIdAndRef(convId);
                       setConversationAutoTitleEligibility(false);
-                      setConversationSummary(selectorContext?.summary ?? null);
-
+                      setConversationSummary(resumedSummary ?? null);
                       pendingConversationSwitchRef.current = {
                         origin: "resume-selector",
                         conversationId: convId,
@@ -1231,12 +1232,10 @@ export function AppView(props: AppViewProps) {
                         messageCount:
                           selectorContext?.messageCount ??
                           resumeData.messageHistory.length,
-                        summary: selectorContext?.summary,
+                        summary: resumedSummary,
                         messageHistory: resumeData.messageHistory,
                       };
-
                       settingsManager.persistSession(agentId, convId);
-
                       // Build success command with agent + conversation info
                       const currentAgentName =
                         agentState.name || "Unnamed Agent";
@@ -1490,20 +1489,21 @@ export function AppView(props: AppViewProps) {
                         agentState,
                         actualTargetConv,
                       );
-
+                      const resumedSummary =
+                        resumeData.conversation?.summary?.trim() || undefined;
                       setConversationIdAndRef(actualTargetConv);
                       setConversationAutoTitleEligibility(false);
-
+                      setConversationSummary(resumedSummary ?? null);
                       pendingConversationSwitchRef.current = {
                         origin: "search",
                         conversationId: actualTargetConv,
                         isDefault: actualTargetConv === "default",
                         messageCount: resumeData.messageHistory.length,
+                        summary: resumedSummary,
                         messageHistory: resumeData.messageHistory,
                         searchQuery: searchContext?.query,
                         searchMessage: searchContext?.message,
                       };
-
                       settingsManager.persistSession(agentId, actualTargetConv);
 
                       const currentAgentName =

--- a/src/cli/app/submit-navigation-commands.ts
+++ b/src/cli/app/submit-navigation-commands.ts
@@ -35,6 +35,7 @@ type NavigationCommandContext = {
   setCommandRunning: (value: boolean) => void;
   setConversationAutoTitleEligibility: (enabled: boolean) => void;
   setConversationIdAndRef: (nextConversationId: string) => void;
+  setConversationSummary: (summary: string | null) => void;
   setLines: Dispatch<SetStateAction<Line[]>>;
   setSearchQuery: Dispatch<SetStateAction<string>>;
   setStaticItems: Dispatch<SetStateAction<StaticItem[]>>;
@@ -68,6 +69,7 @@ export async function handleNavigationCommand(
     setCommandRunning,
     setConversationAutoTitleEligibility,
     setConversationIdAndRef,
+    setConversationSummary,
     setLines,
     setSearchQuery,
     setStaticItems,
@@ -127,14 +129,18 @@ export async function handleNavigationCommand(
             targetConvId,
           );
 
+          const resumedSummary =
+            resumeData.conversation?.summary?.trim() || undefined;
           setConversationIdAndRef(targetConvId);
           setConversationAutoTitleEligibility(false);
+          setConversationSummary(resumedSummary ?? null);
 
           pendingConversationSwitchRef.current = {
             origin: "resume-direct",
             conversationId: targetConvId,
             isDefault: targetConvId === "default",
             messageCount: resumeData.messageHistory.length,
+            summary: resumedSummary,
             messageHistory: resumeData.messageHistory,
           };
 

--- a/src/cli/app/types.ts
+++ b/src/cli/app/types.ts
@@ -33,6 +33,7 @@ export type AppProps = {
   agentId: string;
   agentState?: AgentState | null;
   conversationId: string; // Required: created at startup
+  conversationSummary?: string | null;
   loadingState?: AppLoadingState;
   continueSession?: boolean;
   startupApproval?: ApprovalRequest | null; // Deprecated: use startupApprovals

--- a/src/cli/app/use-conversation-switching.ts
+++ b/src/cli/app/use-conversation-switching.ts
@@ -369,16 +369,19 @@ export function useConversationSwitching(ctx: ConversationSwitchingContext) {
           conversationId,
         );
 
+        const resumedSummary =
+          resumeData.conversation?.summary?.trim() || undefined;
         await maybeCarryOverActiveConversationModel(conversationId);
         setConversationIdAndRef(conversationId);
         setConversationAutoTitleEligibility(false);
-        setConversationSummary(null);
+        setConversationSummary(resumedSummary ?? null);
 
         pendingConversationSwitchRef.current = {
           origin: "fork",
           conversationId,
           isDefault: false,
           messageCount: resumeData.messageHistory.length,
+          summary: resumedSummary,
           messageHistory: resumeData.messageHistory,
         };
 

--- a/src/cli/app/use-submit-handler.ts
+++ b/src/cli/app/use-submit-handler.ts
@@ -2533,7 +2533,6 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           }
           return { submitted: true };
         }
-
         // Special handling for /agents command - routed through navigation commands.
         const navigationCommandResult = await handleNavigationCommand(trimmed, {
           agentId,
@@ -2553,6 +2552,7 @@ export function useSubmitHandler(ctx: SubmitHandlerContext) {
           setCommandRunning,
           setConversationAutoTitleEligibility,
           setConversationIdAndRef,
+          setConversationSummary,
           setLines,
           setSearchQuery,
           setStaticItems,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2694,7 +2694,6 @@ async function main(): Promise<void> {
     const startupConversationTitleEligible = !isResumedConversation(
       resumeData?.conversation,
     );
-
     if (!agentId || !conversationId) {
       return React.createElement(App, {
         agentId: "loading",
@@ -2724,6 +2723,7 @@ async function main(): Promise<void> {
       agentId,
       agentState,
       conversationId,
+      conversationSummary: resumeData?.conversation?.summary?.trim() || null,
       loadingState: appLoadingState,
       continueSession: isResumingSession,
       startupApproval: resumeData?.pendingApproval ?? null,


### PR DESCRIPTION
Previosuly when resuming the thread title showed the conversation id even if it was renamed to show a friendly name.