### PR TITLE
feat(whatsapp): message prefix, inbound debounce, typing indicator

### DIFF
--- a/src/channels/plugin-types.ts
+++ b/src/channels/plugin-types.ts
@@ -182,6 +182,8 @@ export interface ChannelPluginAccountPatch {
   richDraftStreaming?: boolean;
   downloadMedia?: boolean;
   mediaMaxBytes?: number;
+  messagePrefix?: string;
+  waitingBehavior?: import("./types").WhatsAppWaitingBehavior;
 }
 
 export type ChannelAccountPatch = ChannelCommonAccountPatch &

--- a/src/channels/service-account-model.ts
+++ b/src/channels/service-account-model.ts
@@ -121,6 +121,9 @@ export function createAccountFromPatch(
       transcribeVoice: normalizedPatch.transcribeVoice === true,
       downloadMedia: normalizedPatch.downloadMedia === true,
       mediaMaxBytes: normalizedPatch.mediaMaxBytes,
+      messagePrefix: normalizedPatch.messagePrefix,
+      inboundDebounceMs: normalizedPatch.inboundDebounceMs,
+      waitingBehavior: normalizedPatch.waitingBehavior,
       createdAt: now,
       updatedAt: now,
     };
@@ -280,6 +283,14 @@ export function mergeAccountPatch(
       downloadMedia:
         normalizedPatch.downloadMedia ?? existing.downloadMedia ?? false,
       mediaMaxBytes: normalizedPatch.mediaMaxBytes ?? existing.mediaMaxBytes,
+      messagePrefix:
+        normalizedPatch.messagePrefix !== undefined
+          ? normalizedPatch.messagePrefix
+          : existing.messagePrefix,
+      inboundDebounceMs:
+        normalizedPatch.inboundDebounceMs ?? existing.inboundDebounceMs,
+      waitingBehavior:
+        normalizedPatch.waitingBehavior ?? existing.waitingBehavior,
       updatedAt: nextUpdatedAt,
     };
   }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -505,6 +505,7 @@ export type SlackChannelMode = "socket";
 export type SlackAllowBotsMode = false | "mentions";
 export type TelegramGroupMode = "open" | "mention-only";
 export type WhatsAppGroupMode = "disabled" | "mention" | "open";
+export type WhatsAppWaitingBehavior = "off" | "typing_indicator";
 export type SignalGroupMode = "disabled" | "mention" | "open";
 
 export interface ChannelAccountBinding {
@@ -647,6 +648,12 @@ export interface WhatsAppChannelConfig {
   downloadMedia?: boolean;
   /** Maximum inbound media bytes to download. Undefined uses channel default. */
   mediaMaxBytes?: number;
+  /** Optional prefix prepended to outbound agent text messages. */
+  messagePrefix?: string;
+  /** Optional debounce window (ms) for inbound messages. Default 0 (disabled). Clamped to 0..10000. */
+  inboundDebounceMs?: number;
+  /** UX feedback while the agent is generating a response. Default "off". */
+  waitingBehavior?: WhatsAppWaitingBehavior;
 }
 
 export interface SignalChannelConfig {
@@ -826,6 +833,12 @@ export interface WhatsAppChannelAccount extends ChannelAccountBase {
   downloadMedia?: boolean;
   /** Maximum inbound media bytes to download. Undefined uses channel default. */
   mediaMaxBytes?: number;
+  /** Optional prefix prepended to outbound agent text messages. */
+  messagePrefix?: string;
+  /** Optional debounce window (ms) for inbound messages. Default 0 (disabled). Clamped to 0..10000. */
+  inboundDebounceMs?: number;
+  /** UX feedback while the agent is generating a response. Default "off". */
+  waitingBehavior?: WhatsAppWaitingBehavior;
 }
 
 export interface SignalChannelAccount extends ChannelAccountBase {

--- a/src/channels/whatsapp-adapter.test.ts
+++ b/src/channels/whatsapp-adapter.test.ts
@@ -1,8 +1,106 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { InboundChannelMessage } from "@/channels/types";
 import {
   createWhatsAppAdapter,
   isWhatsAppConflictDisconnect,
 } from "@/channels/whatsapp/adapter";
+
+// ── Mock socket infrastructure ───────────────────────────────────
+// The adapter's start() → connect() calls createWhatsAppSocket and
+// loadWhatsAppModule. We mock both so tests can drive the adapter into
+// a "running" state with a controllable socket.
+
+let lastSendMessageArgs:
+  | { jid: string; payload: Record<string, unknown>; options?: Record<string, unknown> }
+  | null = null;
+let presenceUpdateCalls: Array<{ presence: string; jid: string }> = [];
+let messagesUpsertHandler:
+  | ((payload: unknown) => void)
+  | null = null;
+
+function resetMockState(): void {
+  lastSendMessageArgs = null;
+  presenceUpdateCalls = [];
+  messagesUpsertHandler = null;
+}
+
+// Mock socket object shared across tests.
+function makeMockSocket() {
+  return {
+    ev: {
+      on: (event: string, handler: (payload?: unknown) => void) => {
+        if (event === "messages.upsert") {
+          messagesUpsertHandler = handler as (payload: unknown) => void;
+        }
+      },
+    },
+    ws: { close: () => {} },
+    user: { id: "15551234567@s.whatsapp.net", lid: null },
+    sendMessage: async (
+      jid: string,
+      payload: Record<string, unknown>,
+      options?: Record<string, unknown>,
+    ) => {
+      lastSendMessageArgs = { jid, payload, options };
+      return { key: { id: "sent-msg-id" }, message: payload };
+    },
+    sendPresenceUpdate: async (presence: string, jid?: string) => {
+      presenceUpdateCalls.push({ presence, jid: jid ?? "" });
+    },
+    groupMetadata: async () => ({ subject: "Test Group" }),
+  };
+}
+
+mock.module("@/channels/whatsapp/session", () => ({
+  createWhatsAppSocket: async (params: {
+    onConnectionUpdate?: (update: Record<string, unknown>) => void;
+  }) => {
+    const sock = makeMockSocket();
+    // Fire "open" connection update so the adapter transitions to connected.
+    if (params.onConnectionUpdate) {
+      params.onConnectionUpdate({ connection: "open" });
+    }
+    return {
+      sock,
+      saveCreds: async () => {},
+      DisconnectReason: {},
+      release: () => {},
+    };
+  },
+  getWhatsAppAuthDir: (accountId: string) =>
+    `/tmp/whatsapp-test/${accountId}`,
+}));
+
+mock.module("@/channels/whatsapp/runtime", () => ({
+  loadWhatsAppModule: async () => ({
+    downloadContentFromMessage: async () => {
+      throw new Error("not used in adapter tests");
+    },
+  }),
+  loadQrCodeTerminalModule: async () => ({}),
+}));
+
+function makeAccount(overrides: Record<string, unknown> = {}) {
+  return {
+    channel: "whatsapp" as const,
+    accountId: "main",
+    enabled: true,
+    dmPolicy: "pairing" as const,
+    allowedUsers: [],
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+    agentId: "agent-whatsapp",
+    selfChatMode: true,
+    groupMode: "disabled" as const,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  resetMockState();
+});
+
+// ── Existing helper tests ────────────────────────────────────────
 
 describe("WhatsApp adapter helpers", () => {
   test("detects session conflict disconnects by message", () => {
@@ -33,18 +131,7 @@ describe("WhatsApp adapter helpers", () => {
   });
 
   test("implements turn lifecycle event handling", async () => {
-    const adapter = createWhatsAppAdapter({
-      channel: "whatsapp",
-      accountId: "main",
-      enabled: true,
-      dmPolicy: "pairing",
-      allowedUsers: [],
-      createdAt: new Date(0).toISOString(),
-      updatedAt: new Date(0).toISOString(),
-      agentId: "agent-whatsapp",
-      selfChatMode: true,
-      groupMode: "disabled",
-    });
+    const adapter = createWhatsAppAdapter(makeAccount());
 
     expect(adapter.handleTurnLifecycleEvent).toBeTypeOf("function");
 
@@ -67,5 +154,307 @@ describe("WhatsApp adapter helpers", () => {
         ],
       }),
     ).resolves.toBeUndefined();
+  });
+});
+
+// ── Message prefix tests ────────────────────────────────────────
+
+describe("WhatsApp adapter message prefix", () => {
+  test("sendMessage prepends account.messagePrefix to text", async () => {
+    const adapter = createWhatsAppAdapter(
+      makeAccount({ messagePrefix: "🤖 " }),
+    );
+    await adapter.start();
+
+    await adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: "main",
+      chatId: "15551234567@s.whatsapp.net",
+      text: "Hello world",
+    });
+
+    expect(lastSendMessageArgs).not.toBeNull();
+    expect(lastSendMessageArgs!.payload).toEqual({ text: "🤖 Hello world" });
+
+    await adapter.stop();
+  });
+
+  test("sendMessage does not prepend prefix when messagePrefix is undefined", async () => {
+    const adapter = createWhatsAppAdapter(makeAccount());
+    await adapter.start();
+
+    await adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: "main",
+      chatId: "15551234567@s.whatsapp.net",
+      text: "Hello world",
+    });
+
+    expect(lastSendMessageArgs).not.toBeNull();
+    expect(lastSendMessageArgs!.payload).toEqual({ text: "Hello world" });
+
+    await adapter.stop();
+  });
+
+  test("sendDirectReply prepends account.messagePrefix to text", async () => {
+    const adapter = createWhatsAppAdapter(
+      makeAccount({ messagePrefix: "🤖 " }),
+    );
+    await adapter.start();
+
+    await adapter.sendDirectReply("15551234567@s.whatsapp.net", "Hi there");
+
+    expect(lastSendMessageArgs).not.toBeNull();
+    expect(lastSendMessageArgs!.payload).toEqual({ text: "🤖 Hi there" });
+
+    await adapter.stop();
+  });
+
+  test("sendDirectReply does not prepend prefix when undefined", async () => {
+    const adapter = createWhatsAppAdapter(makeAccount());
+    await adapter.start();
+
+    await adapter.sendDirectReply("15551234567@s.whatsapp.net", "Hi there");
+
+    expect(lastSendMessageArgs).not.toBeNull();
+    expect(lastSendMessageArgs!.payload).toEqual({ text: "Hi there" });
+
+    await adapter.stop();
+  });
+});
+
+// ── Typing indicator tests ──────────────────────────────────────
+
+describe("WhatsApp adapter typing indicator", () => {
+  test("typing starts on 'processing' lifecycle event when waitingBehavior is typing_indicator", async () => {
+    const adapter = createWhatsAppAdapter(
+      makeAccount({ waitingBehavior: "typing_indicator" }),
+    );
+    await adapter.start();
+    presenceUpdateCalls = [];
+
+    await adapter.handleTurnLifecycleEvent?.({
+      type: "processing",
+      batchId: "batch-1",
+      sources: [
+        {
+          channel: "whatsapp",
+          accountId: "main",
+          chatId: "15551234567@s.whatsapp.net",
+          messageId: "msg-1",
+          agentId: "agent-whatsapp",
+          conversationId: "conv-whatsapp",
+        },
+      ],
+    });
+
+    expect(presenceUpdateCalls).toContainEqual({
+      presence: "composing",
+      jid: "15551234567@s.whatsapp.net",
+    });
+
+    await adapter.stop();
+  });
+
+  test("typing clears on 'finished' lifecycle event (sends 'paused')", async () => {
+    const adapter = createWhatsAppAdapter(
+      makeAccount({ waitingBehavior: "typing_indicator" }),
+    );
+    await adapter.start();
+    presenceUpdateCalls = [];
+
+    // Start typing first.
+    await adapter.handleTurnLifecycleEvent?.({
+      type: "processing",
+      batchId: "batch-1",
+      sources: [
+        {
+          channel: "whatsapp",
+          accountId: "main",
+          chatId: "15551234567@s.whatsapp.net",
+          messageId: "msg-1",
+          agentId: "agent-whatsapp",
+          conversationId: "conv-whatsapp",
+        },
+      ],
+    });
+
+    // Now finish.
+    presenceUpdateCalls = [];
+    await adapter.handleTurnLifecycleEvent?.({
+      type: "finished",
+      batchId: "batch-1",
+      outcome: "completed",
+      stopReason: "end_turn",
+      sources: [
+        {
+          channel: "whatsapp",
+          accountId: "main",
+          chatId: "15551234567@s.whatsapp.net",
+          messageId: "msg-1",
+          agentId: "agent-whatsapp",
+          conversationId: "conv-whatsapp",
+        },
+      ],
+    });
+
+    expect(presenceUpdateCalls).toContainEqual({
+      presence: "paused",
+      jid: "15551234567@s.whatsapp.net",
+    });
+
+    await adapter.stop();
+  });
+
+  test("typing is not started when waitingBehavior is 'off'", async () => {
+    const adapter = createWhatsAppAdapter(
+      makeAccount({ waitingBehavior: "off" }),
+    );
+    await adapter.start();
+    presenceUpdateCalls = [];
+
+    await adapter.handleTurnLifecycleEvent?.({
+      type: "processing",
+      batchId: "batch-1",
+      sources: [
+        {
+          channel: "whatsapp",
+          accountId: "main",
+          chatId: "15551234567@s.whatsapp.net",
+          messageId: "msg-1",
+          agentId: "agent-whatsapp",
+          conversationId: "conv-whatsapp",
+        },
+      ],
+    });
+
+    expect(presenceUpdateCalls).toHaveLength(0);
+
+    await adapter.stop();
+  });
+
+  test("typing is not started when waitingBehavior is undefined", async () => {
+    const adapter = createWhatsAppAdapter(makeAccount());
+    await adapter.start();
+    presenceUpdateCalls = [];
+
+    await adapter.handleTurnLifecycleEvent?.({
+      type: "processing",
+      batchId: "batch-1",
+      sources: [
+        {
+          channel: "whatsapp",
+          accountId: "main",
+          chatId: "15551234567@s.whatsapp.net",
+          messageId: "msg-1",
+          agentId: "agent-whatsapp",
+          conversationId: "conv-whatsapp",
+        },
+      ],
+    });
+
+    expect(presenceUpdateCalls).toHaveLength(0);
+
+    await adapter.stop();
+  });
+
+  test("'queued' lifecycle event does not start typing", async () => {
+    const adapter = createWhatsAppAdapter(
+      makeAccount({ waitingBehavior: "typing_indicator" }),
+    );
+    await adapter.start();
+    presenceUpdateCalls = [];
+
+    // "queued" events have a single `source`, not `sources`.
+    await adapter.handleTurnLifecycleEvent?.({
+      type: "queued",
+      source: {
+        channel: "whatsapp",
+        accountId: "main",
+        chatId: "15551234567@s.whatsapp.net",
+        messageId: "msg-1",
+        agentId: "agent-whatsapp",
+        conversationId: "conv-whatsapp",
+      },
+    });
+
+    expect(presenceUpdateCalls).toHaveLength(0);
+
+    await adapter.stop();
+  });
+});
+
+// ── Inbound debounce tests ──────────────────────────────────────
+
+function makeUpsertEvent(
+  text: string,
+  messageId: string,
+  remoteJid = "15551234567@s.whatsapp.net",
+) {
+  return {
+    type: "notify",
+    messages: [
+      {
+        key: { remoteJid, id: messageId, fromMe: false },
+        message: { conversation: text },
+        messageTimestamp: Math.floor(Date.now() / 1000),
+        pushName: "TestUser",
+      },
+    ],
+  };
+}
+
+describe("WhatsApp adapter inbound debounce", () => {
+  test("two rapid text messages get combined into one dispatch", async () => {
+    const adapter = createWhatsAppAdapter(
+      makeAccount({ inboundDebounceMs: 50, selfChatMode: false }),
+    );
+
+    const received: InboundChannelMessage[] = [];
+    adapter.onMessage = async (msg: InboundChannelMessage) => {
+      received.push(msg);
+    };
+
+    await adapter.start();
+    expect(messagesUpsertHandler).not.toBeNull();
+
+    // Send two rapid messages.
+    messagesUpsertHandler!(makeUpsertEvent("Hello", "msg-a"));
+    messagesUpsertHandler!(makeUpsertEvent("World", "msg-b"));
+
+    // Wait for debounce window to flush.
+    await new Promise((resolve) => setTimeout(resolve, 120));
+
+    expect(received).toHaveLength(1);
+    expect(received[0]!.text).toBe("Hello\nWorld");
+
+    await adapter.stop();
+  });
+
+  test("debounce is disabled (0ms) by default — each message dispatches immediately", async () => {
+    const adapter = createWhatsAppAdapter(
+      makeAccount({ selfChatMode: false }),
+    );
+
+    const received: InboundChannelMessage[] = [];
+    adapter.onMessage = async (msg: InboundChannelMessage) => {
+      received.push(msg);
+    };
+
+    await adapter.start();
+    expect(messagesUpsertHandler).not.toBeNull();
+
+    messagesUpsertHandler!(makeUpsertEvent("First", "msg-c"));
+    // With debounceMs=0, flush should be immediate.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    messagesUpsertHandler!(makeUpsertEvent("Second", "msg-d"));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(received).toHaveLength(2);
+    expect(received[0]!.text).toBe("First");
+    expect(received[1]!.text).toBe("Second");
+
+    await adapter.stop();
   });
 });

--- a/src/channels/whatsapp-typing.test.ts
+++ b/src/channels/whatsapp-typing.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, test } from "bun:test";
+
+import { whatsappAccountConfigAdapter } from "@/channels/whatsapp/account-config";
+import type { WhatsAppChannelAccount } from "@/channels/types";
+
+function makeWhatsAppAccount(
+  overrides: Partial<WhatsAppChannelAccount> = {},
+): WhatsAppChannelAccount {
+  return {
+    channel: "whatsapp",
+    accountId: "acct-whatsapp",
+    displayName: "WhatsApp",
+    enabled: true,
+    dmPolicy: "pairing",
+    allowedUsers: [],
+    agentId: "agent-whatsapp",
+    selfChatMode: true,
+    groupMode: "disabled",
+    transcribeVoice: false,
+    downloadMedia: false,
+    createdAt: "2026-06-14T00:00:00.000Z",
+    updatedAt: "2026-06-14T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("whatsappAccountConfigAdapter message_prefix", () => {
+  test("accepts and round-trips a string prefix", () => {
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({
+        message_prefix: "🤖 ",
+      }),
+    ).toBe(true);
+    expect(
+      whatsappAccountConfigAdapter.toAccountPatch({
+        message_prefix: "🤖 ",
+      }),
+    ).toMatchObject({ messagePrefix: "🤖 " });
+  });
+
+  test("rejects non-string values", () => {
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({ message_prefix: 123 }),
+    ).toBe(false);
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({ message_prefix: true }),
+    ).toBe(false);
+  });
+
+  test("undefined preserves backward compat (not in patch)", () => {
+    expect(whatsappAccountConfigAdapter.isValidConfig({})).toBe(true);
+    expect(
+      whatsappAccountConfigAdapter.toAccountPatch({}).messagePrefix,
+    ).toBeUndefined();
+  });
+
+  test("surfaces in account config snapshot", () => {
+    expect(
+      whatsappAccountConfigAdapter.toAccountConfig(
+        makeWhatsAppAccount({ messagePrefix: "✨ " }),
+      ),
+    ).toMatchObject({ message_prefix: "✨ " });
+    expect(
+      whatsappAccountConfigAdapter.toConfigSnapshotConfig(
+        makeWhatsAppAccount({ messagePrefix: "✨ " }),
+      ),
+    ).toMatchObject({ message_prefix: "✨ " });
+  });
+
+  test("omits message_prefix from snapshot when undefined", () => {
+    expect(
+      whatsappAccountConfigAdapter.toAccountConfig(makeWhatsAppAccount())
+        .message_prefix,
+    ).toBeUndefined();
+  });
+});
+
+describe("whatsappAccountConfigAdapter inbound_debounce_ms", () => {
+  test("accepts 0 (disabled default)", () => {
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({ inbound_debounce_ms: 0 }),
+    ).toBe(true);
+    expect(
+      whatsappAccountConfigAdapter.toAccountPatch({ inbound_debounce_ms: 0 }),
+    ).toMatchObject({ inboundDebounceMs: 0 });
+  });
+
+  test("accepts values within 0..10000", () => {
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({ inbound_debounce_ms: 500 }),
+    ).toBe(true);
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({
+        inbound_debounce_ms: 10000,
+      }),
+    ).toBe(true);
+    expect(
+      whatsappAccountConfigAdapter.toAccountPatch({ inbound_debounce_ms: 750 }),
+    ).toMatchObject({ inboundDebounceMs: 750 });
+  });
+
+  test("truncates fractional values", () => {
+    expect(
+      whatsappAccountConfigAdapter.toAccountPatch({ inbound_debounce_ms: 750.9 }),
+    ).toMatchObject({ inboundDebounceMs: 750 });
+  });
+
+  test("rejects values above 10000", () => {
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({ inbound_debounce_ms: 10001 }),
+    ).toBe(false);
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({ inbound_debounce_ms: 99999 }),
+    ).toBe(false);
+  });
+
+  test("rejects negative values", () => {
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({ inbound_debounce_ms: -1 }),
+    ).toBe(false);
+  });
+
+  test("rejects non-number values", () => {
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({
+        inbound_debounce_ms: "500",
+      }),
+    ).toBe(false);
+  });
+
+  test("undefined preserves backward compat", () => {
+    expect(
+      whatsappAccountConfigAdapter.toAccountPatch({}).inboundDebounceMs,
+    ).toBeUndefined();
+  });
+
+  test("surfaces in account config snapshot", () => {
+    expect(
+      whatsappAccountConfigAdapter.toAccountConfig(
+        makeWhatsAppAccount({ inboundDebounceMs: 2000 }),
+      ),
+    ).toMatchObject({ inbound_debounce_ms: 2000 });
+  });
+});
+
+describe("whatsappAccountConfigAdapter waiting_behavior", () => {
+  test("accepts 'off'", () => {
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({ waiting_behavior: "off" }),
+    ).toBe(true);
+    expect(
+      whatsappAccountConfigAdapter.toAccountPatch({
+        waiting_behavior: "off",
+      }),
+    ).toMatchObject({ waitingBehavior: "off" });
+  });
+
+  test("accepts 'typing_indicator'", () => {
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({
+        waiting_behavior: "typing_indicator",
+      }),
+    ).toBe(true);
+    expect(
+      whatsappAccountConfigAdapter.toAccountPatch({
+        waiting_behavior: "typing_indicator",
+      }),
+    ).toMatchObject({ waitingBehavior: "typing_indicator" });
+  });
+
+  test("rejects 'message' (not in scope)", () => {
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({
+        waiting_behavior: "message",
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects unknown string values", () => {
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({
+        waiting_behavior: "something_else",
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects non-string values", () => {
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({ waiting_behavior: 1 }),
+    ).toBe(false);
+  });
+
+  test("undefined preserves backward compat (defaults to 'off' at runtime)", () => {
+    expect(
+      whatsappAccountConfigAdapter.toAccountPatch({}).waitingBehavior,
+    ).toBeUndefined();
+  });
+
+  test("surfaces in account config snapshot", () => {
+    expect(
+      whatsappAccountConfigAdapter.toAccountConfig(
+        makeWhatsAppAccount({ waitingBehavior: "typing_indicator" }),
+      ),
+    ).toMatchObject({ waiting_behavior: "typing_indicator" });
+  });
+});
+
+describe("whatsappAccountConfigAdapter combined round-trip", () => {
+  test("all three keys round-trip snake_case → camelCase → snake_case", () => {
+    const snakeConfig = {
+      message_prefix: "🤖 ",
+      inbound_debounce_ms: 1500,
+      waiting_behavior: "typing_indicator" as const,
+    };
+
+    // Validate
+    expect(whatsappAccountConfigAdapter.isValidConfig(snakeConfig)).toBe(true);
+
+    // toAccountPatch: snake → camel
+    const patch = whatsappAccountConfigAdapter.toAccountPatch(snakeConfig);
+    expect(patch).toMatchObject({
+      messagePrefix: "🤖 ",
+      inboundDebounceMs: 1500,
+      waitingBehavior: "typing_indicator",
+    });
+
+    // Build an account from the patch, then toAccountConfig: camel → snake
+    const account = makeWhatsAppAccount({
+      messagePrefix: patch.messagePrefix,
+      inboundDebounceMs: patch.inboundDebounceMs,
+      waitingBehavior: patch.waitingBehavior,
+    });
+    const roundTripped = whatsappAccountConfigAdapter.toAccountConfig(account);
+    expect(roundTripped).toMatchObject(snakeConfig);
+
+    // Config snapshot matches too
+    const snapshot =
+      whatsappAccountConfigAdapter.toConfigSnapshotConfig(account);
+    expect(snapshot).toMatchObject(snakeConfig);
+  });
+
+  test("unknown config keys are rejected", () => {
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({
+        message_prefix: "🤖 ",
+        unknown_key: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/channels/whatsapp/account-config.ts
+++ b/src/channels/whatsapp/account-config.ts
@@ -2,6 +2,7 @@ import type { ChannelAccountConfigAdapter } from "@/channels/plugin-types";
 import type {
   WhatsAppChannelAccount,
   WhatsAppGroupMode,
+  WhatsAppWaitingBehavior,
 } from "@/channels/types";
 import { toWhatsAppConnectionConfig } from "./state";
 
@@ -14,7 +15,14 @@ const WHATSAPP_CONFIG_KEYS = new Set([
   "transcribe_voice",
   "download_media",
   "media_max_bytes",
+  "message_prefix",
+  "inbound_debounce_ms",
+  "waiting_behavior",
 ]);
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
 
 function isNullableString(value: unknown): value is string | null {
   return value === null || typeof value === "string";
@@ -36,6 +44,16 @@ function isGroupMode(value: unknown): value is WhatsAppGroupMode {
 
 function isPositiveNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function isNonNegativeNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function isWaitingBehavior(
+  value: unknown,
+): value is WhatsAppWaitingBehavior {
+  return value === "off" || value === "typing_indicator";
 }
 
 export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppChannelAccount> =
@@ -60,7 +78,14 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         (config.download_media === undefined ||
           isBoolean(config.download_media)) &&
         (config.media_max_bytes === undefined ||
-          isPositiveNumber(config.media_max_bytes))
+          isPositiveNumber(config.media_max_bytes)) &&
+        (config.message_prefix === undefined ||
+          isString(config.message_prefix)) &&
+        (config.inbound_debounce_ms === undefined ||
+          (isNonNegativeNumber(config.inbound_debounce_ms) &&
+            config.inbound_debounce_ms <= 10000)) &&
+        (config.waiting_behavior === undefined ||
+          isWaitingBehavior(config.waiting_behavior))
       );
     },
 
@@ -90,6 +115,17 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         mediaMaxBytes: isPositiveNumber(config.media_max_bytes)
           ? config.media_max_bytes
           : undefined,
+        messagePrefix: isString(config.message_prefix)
+          ? config.message_prefix
+          : undefined,
+        inboundDebounceMs:
+          isNonNegativeNumber(config.inbound_debounce_ms) &&
+          config.inbound_debounce_ms <= 10000
+            ? Math.trunc(config.inbound_debounce_ms)
+            : undefined,
+        waitingBehavior: isWaitingBehavior(config.waiting_behavior)
+          ? config.waiting_behavior
+          : undefined,
       };
     },
 
@@ -103,6 +139,9 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         transcribe_voice: account.transcribeVoice === true,
         download_media: account.downloadMedia === true,
         media_max_bytes: account.mediaMaxBytes,
+        message_prefix: account.messagePrefix,
+        inbound_debounce_ms: account.inboundDebounceMs,
+        waiting_behavior: account.waitingBehavior,
         ...toWhatsAppConnectionConfig(account.accountId),
       };
     },
@@ -117,6 +156,9 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         transcribe_voice: account.transcribeVoice === true,
         download_media: account.downloadMedia === true,
         media_max_bytes: account.mediaMaxBytes,
+        message_prefix: account.messagePrefix,
+        inbound_debounce_ms: account.inboundDebounceMs,
+        waiting_behavior: account.waitingBehavior,
         ...toWhatsAppConnectionConfig(account.accountId),
       };
     },

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -1,3 +1,7 @@
+import {
+  createInboundDebouncer,
+  type InboundDebouncer,
+} from "@/channels/inbound-debounce";
 import { formatChannelControlRequestPrompt } from "@/channels/interactive";
 import { formatChannelLifecycleErrorMessage } from "@/channels/lifecycle-error";
 import type {
@@ -36,9 +40,17 @@ const DEDUPE_MAX_SIZE = 5000;
 const RECONNECT_MAX_MS = 30_000;
 const MAX_MENTION_PATTERN_LENGTH = 256;
 const MENTION_MATCH_TEXT_MAX_LENGTH = 2000;
+const WHATSAPP_TYPING_REFRESH_MS = 12_000;
+const WHATSAPP_TYPING_MAX_MS = 5 * 60 * 1000;
 
 type EventEmitterLike = {
   on?: (event: string, handler: (payload: unknown) => void) => void;
+};
+
+type WhatsAppTypingEntry = {
+  sourceKeys: Set<string>;
+  timer: ReturnType<typeof setInterval>;
+  timeout: ReturnType<typeof setTimeout>;
 };
 
 type WhatsAppSocket = {
@@ -208,6 +220,142 @@ export function createWhatsAppAdapter(
   const seenMessageIds = new Set<string>();
   const lidToJid = new Map<string, string>();
   const messageStore = new Map<string, unknown>();
+  const typingByChatId = new Map<string, WhatsAppTypingEntry>();
+
+  // ── Typing indicator helpers ────────────────────────────────────
+  // Per-chat entry with source-key refcount, refresh interval, and
+  // max-lifetime timeout. Only active when waitingBehavior ===
+  // "typing_indicator".
+
+  function getTypingSourceKey(source: ChannelTurnSource): string | null {
+    if (source.channel !== CHANNEL_ID) return null;
+    const chatId = source.chatId;
+    if (!chatId) return null;
+    return [
+      source.accountId ?? "",
+      chatId,
+      source.messageId ?? "",
+      source.agentId,
+      source.conversationId,
+    ].join(":");
+  }
+
+  function clearTypingForChat(chatId: string): void {
+    const entry = typingByChatId.get(chatId);
+    if (!entry) return;
+    clearInterval(entry.timer);
+    clearTimeout(entry.timeout);
+    typingByChatId.delete(chatId);
+  }
+
+  function clearAllTyping(): void {
+    for (const entry of typingByChatId.values()) {
+      clearInterval(entry.timer);
+      clearTimeout(entry.timeout);
+    }
+    typingByChatId.clear();
+  }
+
+  function startTypingForSource(source: ChannelTurnSource): void {
+    const chatId = source.chatId;
+    const sourceKey = getTypingSourceKey(source);
+    if (!chatId || !sourceKey) return;
+
+    const existing = typingByChatId.get(chatId);
+    if (existing) {
+      existing.sourceKeys.add(sourceKey);
+      return;
+    }
+
+    // Use chatId as-is for the typing jid — do NOT use LID resolution.
+    // PR 1 handles LID presence resolution separately.
+    try {
+      void sock?.sendPresenceUpdate?.("composing", chatId);
+    } catch {
+      // Best-effort; presence failures are non-fatal.
+    }
+    const timer = setInterval(() => {
+      if (!running) return;
+      try {
+        void sock?.sendPresenceUpdate?.("composing", chatId);
+      } catch {
+        // Best-effort.
+      }
+    }, WHATSAPP_TYPING_REFRESH_MS);
+    const timeout = setTimeout(() => {
+      clearTypingForChat(chatId);
+    }, WHATSAPP_TYPING_MAX_MS);
+    if (typeof (timer as { unref?: () => void }).unref === "function") {
+      (timer as { unref?: () => void }).unref?.();
+    }
+    if (typeof (timeout as { unref?: () => void }).unref === "function") {
+      (timeout as { unref?: () => void }).unref?.();
+    }
+    typingByChatId.set(chatId, {
+      sourceKeys: new Set([sourceKey]),
+      timer,
+      timeout,
+    });
+  }
+
+  function stopTypingForSource(source: ChannelTurnSource): void {
+    const chatId = source.chatId;
+    const sourceKey = getTypingSourceKey(source);
+    if (!chatId || !sourceKey) return;
+
+    const entry = typingByChatId.get(chatId);
+    if (!entry) return;
+    entry.sourceKeys.delete(sourceKey);
+    if (entry.sourceKeys.size === 0) {
+      clearTypingForChat(chatId);
+    }
+  }
+
+  function stopTypingPresence(chatId: string): void {
+    try {
+      void sock?.sendPresenceUpdate?.("paused", chatId);
+    } catch {
+      // Best-effort.
+    }
+  }
+
+  // ── Inbound debouncer ──────────────────────────────────────────
+  // Batches back-to-back messages into a single dispatch.
+  // Voice notes, attachments, and reactions bypass the debounce (always
+  // dispatched immediately). Disabled when inboundDebounceMs is 0/undefined.
+
+  const debouncer: InboundDebouncer<{ inbound: InboundChannelMessage }> =
+    createInboundDebouncer<{ inbound: InboundChannelMessage }>({
+      debounceMs: Math.max(0, Math.min(account.inboundDebounceMs ?? 0, 10000)),
+      buildKey: ({ inbound }) =>
+        `${account.accountId}:${inbound.chatId ?? ""}`,
+      shouldDebounce: ({ inbound }) => {
+        if (inbound.attachments && inbound.attachments.length > 0)
+          return false;
+        if (inbound.text && inbound.text.length > 0) return true;
+        return false;
+      },
+      onFlush: async (entries) => {
+        const last = entries[entries.length - 1];
+        if (!last || !adapter.onMessage) return;
+        const combinedText = entries
+          .map((e) => (e.inbound.text ?? "").trim())
+          .filter(Boolean)
+          .join("\n");
+        const merged: InboundChannelMessage = {
+          ...last.inbound,
+          text: combinedText,
+        };
+        try {
+          await adapter.onMessage(merged);
+        } catch (err) {
+          console.error(
+            `[WhatsApp:${account.accountId}] debounced dispatch failed:`,
+            err instanceof Error ? err.message : err,
+          );
+        }
+      },
+    });
 
   function rememberSeen(id: string): boolean {
     if (seenMessageIds.has(id)) return true;
@@ -485,7 +633,7 @@ export function createWhatsAppAdapter(
       console.log(
         `[WhatsApp:${account.accountId}] inbound chatId=${chatId} sender=${senderId} text="${preview(body)}"`,
       );
-      await adapter.onMessage?.(inbound);
+      await debouncer.enqueue({ inbound });
     }
   }
 
@@ -520,6 +668,7 @@ export function createWhatsAppAdapter(
     },
 
     async stop() {
+      clearAllTyping();
       if (!running) return;
       stopping = true;
       running = false;
@@ -561,10 +710,21 @@ export function createWhatsAppAdapter(
         rememberSent(id, result);
         return { messageId: id };
       }
-      try {
-        await sock?.sendPresenceUpdate?.("composing", targetJid);
-      } catch {
-        // Presence is best-effort.
+      // Stop typing immediately before sending the reply. The refresh
+      // interval can otherwise fire a final "composing" presence between
+      // the reply landing and the "finished" lifecycle event arriving,
+      // causing a brief typing blip after the answer.
+      if (msg.chatId && typingByChatId.has(msg.chatId)) {
+        clearTypingForChat(msg.chatId);
+        stopTypingPresence(msg.chatId);
+      }
+      if (
+        account.messagePrefix &&
+        msg.text?.trim() &&
+        !msg.reaction &&
+        !msg.removeReaction
+      ) {
+        msg = { ...msg, text: account.messagePrefix + msg.text };
       }
       const payload = buildWhatsAppOutboundPayload(msg);
       const result = await sendToWhatsApp(
@@ -586,9 +746,12 @@ export function createWhatsAppAdapter(
         lidToJid,
         sock,
       });
+      const prefixed = account.messagePrefix
+        ? account.messagePrefix + text
+        : text;
       const result = await sendToWhatsApp(
         targetJid,
-        { text },
+        { text: prefixed },
         buildQuotedOptions(targetJid, options?.replyToMessageId),
       );
       rememberSent(result.key?.id ?? "", result);
@@ -608,13 +771,40 @@ export function createWhatsAppAdapter(
     async handleTurnLifecycleEvent(
       event: ChannelTurnLifecycleEvent,
     ): Promise<void> {
-      if (!running || event.type !== "finished") return;
+      if (!running) return;
+
+      // "processing" = the agent turn has actually started. Start typing.
+      if (event.type === "processing") {
+        if (account.waitingBehavior !== "typing_indicator") return;
+        for (const source of event.sources) {
+          startTypingForSource(source);
+        }
+        return;
+      }
+
+      // "queued" = waiting for prior turns to finish; no typing yet.
+      if (event.type === "queued") return;
+
+      // "finished" = stop typing for all sources, then handle error replies.
+      const finishedSources = event.sources;
+      const chatsToStopPresence = new Set<string>();
+      for (const source of finishedSources) {
+        const wasActive = typingByChatId.has(source.chatId);
+        stopTypingForSource(source);
+        if (wasActive && !typingByChatId.has(source.chatId)) {
+          chatsToStopPresence.add(source.chatId);
+        }
+      }
+      // Best-effort: send "paused" presence to clear the typing indicator.
+      for (const chatId of chatsToStopPresence) {
+        stopTypingPresence(chatId);
+      }
 
       const errorText = event.outcome === "error" ? event.error?.trim() : null;
       if (!errorText) return;
 
       const uniqueSources = new Map<string, ChannelTurnSource>();
-      for (const source of event.sources) {
+      for (const source of finishedSources) {
         const key = getLifecycleErrorReplyKey(source);
         if (!key || uniqueSources.has(key)) continue;
         uniqueSources.set(key, source);


### PR DESCRIPTION
> [!CAUTION]
> **SUPERSEDED HEAD — DO NOT REVIEW OR MERGE.**
>
> The current remote head (`b26b2ebe`) is the old three-feature bundle and fails current review/type gates. It has been replaced locally by three independently reviewed branches based directly on canonical identity PR #3395 (`2c801028`):
>
> - debounce + receipt ownership: `1e47db35`
> - lifecycle typing: `24158088`
> - message prefix: `8e00ac96`
>
> Combined checkpoint `d7c60a59` passes 193/193 WhatsApp tests, 12/12 checks, and the mandatory Arrakis live gate. Nothing has been pushed. After #3395 merges and publication is explicitly authorized, this PR is intended to become **debounce/receipts only**; typing and prefix will be submitted separately.

## Historical description of the superseded head

Three config-driven features:
- `message_prefix`: optional emoji/text prepended to outbound messages
- `inbound_debounce_ms`: batches rapid-fire messages into one agent turn
- `waiting_behavior`: typing indicator while agent is generating

37 tests passed on that historical branch.

👾 Generated with [Letta Code](https://letta.com)
