### PR TITLE
fix(model-selector): rename the "Letta API" tab to "Recommended"

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -13,7 +13,7 @@
   "src/cli/app/use-submit-handler.ts": 4099,
   "src/cli/components/AgentSelector.tsx": 1270,
   "src/cli/components/InputRich.tsx": 2219,
-  "src/cli/components/ModelSelector.tsx": 1204,
+  "src/cli/components/ModelSelector.tsx": 1206,
   "src/cli/components/ProviderSelector.tsx": 1676,
   "src/cli/components/ToolCallMessageRich.tsx": 1109,
   "src/cli/helpers/accumulator.ts": 1596,

--- a/src/cli/components/ModelSelector.tsx
+++ b/src/cli/components/ModelSelector.tsx
@@ -1002,7 +1002,9 @@ export function ModelSelector({
 
   const getCategoryLabel = (cat: ModelCategory) => {
     if (cat === "recents") return `Recents [${recentModels.length}]`;
-    if (cat === "supported") return `Letta API [${supportedModels.length}]`;
+    // "supported" has no provider-category filter (connected-BYOK models like
+    // ChatGPT handles appear too), so it must not be labeled "Letta API".
+    if (cat === "supported") return `Recommended [${supportedModels.length}]`;
     if (cat === "byok") return `BYOK [${byokModels.length}]`;
     if (cat === "byok-all") return `BYOK (all) [${byokAllModels.length}]`;
     if (cat === "server-recommended")
@@ -1025,7 +1027,7 @@ export function ModelSelector({
     if (cat === "supported") {
       return isFreeTier
         ? "Upgrade your account to access more models"
-        : "Recommended Letta API models currently available for this account";
+        : "Recommended models currently available for this account";
     }
     if (cat === "byok")
       return "Recommended models via your connected API keys (use /connect to add more)";


### PR DESCRIPTION
## Summary

- The first `/model` tab ("supported") is availability-filtered curated presets with **no provider-category filter** — connected-BYOK models (e.g. ChatGPT Plus/Pro handles after `/connect`) appear there alongside Letta-hosted models. Labeling it "Letta API [n]" promised a category the tab does not enforce; subscription-billed "(ChatGPT)" rows under that header read as a billing bug.
- Renames the tab and subtitle to "Recommended [n]" / "Recommended models currently available for this account" — which is what the tab actually shows, and matches the existing self-hosted/local tab naming (`Recommended` / `All models`).
- The genuinely non-BYOK view is and remains the "Letta API (all)" tab (built via `isByokHandleForSelector`), unchanged.

No behavior change — label/subtitle strings plus a clarifying comment only.

## Test plan

- [x] `bun run check` (12/12)
- [x] `bun test src/cli/components/` (62 pass)
- [ ] Visual: `/model` on a cloud agent shows `Recents / Recommended / Letta API (all) / BYOK / BYOK (all)`