### PR TITLE
fix(headless): rebuild stale approval input on resync

### DIFF
--- a/src/agent/approval-recovery.ts
+++ b/src/agent/approval-recovery.ts
@@ -2,11 +2,18 @@
  * Approval recovery helpers.
  *
  * Pure policy logic lives in `./turn-recovery-policy.ts` and is re-exported
- * here for backward compatibility. This module keeps only the async/side-effect
- * helper (`fetchRunErrorDetail`) that requires network access.
+ * here for backward compatibility. Async helpers that require backend access
+ * stay in this module.
  */
 
+import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
+import type { ApprovalCreate } from "@letta-ai/letta-client/resources/agents/messages";
+import { getResumeDataFromBackend } from "@/agent/check-approval";
 import { getBackend } from "@/backend";
+import {
+  rebuildInputWithFreshDenials,
+  STALE_APPROVAL_RECOVERY_DENIAL_REASON,
+} from "./turn-recovery-policy";
 
 export interface RunErrorInfo {
   error_type?: string;
@@ -100,4 +107,26 @@ export async function fetchRunErrorDetail(
 ): Promise<string | null> {
   const errorInfo = await fetchRunErrorInfo(runId);
   return errorInfo?.detail ?? errorInfo?.message ?? null;
+}
+
+export async function rebuildInputForApprovalResync(
+  agentId: string,
+  conversationId: string,
+  currentInput: Array<MessageCreate | ApprovalCreate>,
+): Promise<Array<MessageCreate | ApprovalCreate>> {
+  const backend = getBackend();
+  const agent = await backend.retrieveAgent(agentId);
+  const { pendingApprovals } = await getResumeDataFromBackend(
+    agent,
+    conversationId,
+  );
+  const rebuilt = rebuildInputWithFreshDenials(
+    currentInput,
+    pendingApprovals ?? [],
+    STALE_APPROVAL_RECOVERY_DENIAL_REASON,
+  );
+  if (rebuilt.length === 0) {
+    throw new Error("Approval resync produced no retryable input");
+  }
+  return rebuilt;
 }

--- a/src/headless-approval-recovery.test.ts
+++ b/src/headless-approval-recovery.test.ts
@@ -122,4 +122,18 @@ describe("headless approval recovery wiring", () => {
     expect(helperSegment).toContain("conversationId: params.conversationId,");
     expect(helperSegment).toContain("preparedToolContext:");
   });
+
+  test("invalid-ID recovery replaces stale input before retrying", () => {
+    const start = source.indexOf("const invalidIdsDetected =");
+    const end = source.indexOf("// Unexpected stop reason", start);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    const segment = source.slice(start, end);
+    expect(segment).toContain(
+      "currentInput = await rebuildInputForApprovalResync(",
+    );
+    expect(segment).not.toContain("await resolveAllPendingApprovals();");
+  });
 });

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -30,6 +30,7 @@ import {
   isEmptyResponseRetryable,
   isInvalidToolCallIdsError,
   parseRetryAfterHeaderMs,
+  rebuildInputForApprovalResync,
   refreshInputOtidsForNewRequest,
   STALE_APPROVAL_RECOVERY_DENIAL_REASON,
   shouldRetryRunMetadataError,
@@ -3179,12 +3180,9 @@ ${SYSTEM_REMINDER_CLOSE}
         }
       }
 
-      // "Invalid tool call IDs" means server HAS pending approvals but with different IDs.
-      // Fetch the actual pending approvals and process them before retrying.
       const invalidIdsDetected =
         isInvalidToolCallIdsError(detailFromRun) ||
         isInvalidToolCallIdsError(latestErrorText);
-
       if (invalidIdsDetected) {
         if (outputFormat === "stream-json") {
           const recoveryMsg: RecoveryMessage = {
@@ -3204,16 +3202,18 @@ ${SYSTEM_REMINDER_CLOSE}
         }
 
         try {
-          // Fetch and process actual pending approvals from server
-          await resolveAllPendingApprovals();
-          // After processing, continue to next iteration (fresh state)
+          currentInput = await rebuildInputForApprovalResync(
+            agent.id,
+            conversationId,
+            currentInput,
+          );
           continue;
         } catch {
-          // If fetch fails, exit with error
+          // If reconciliation fails, exit instead of retrying stale input.
           if (outputFormat === "stream-json") {
             const errorMsg: ErrorMessage = {
               type: "error",
-              message: "Failed to fetch pending approvals for resync",
+              message: "Failed to reconcile pending approvals for resync",
               stop_reason: stopReason,
               run_id: lastRunId ?? undefined,
               session_id: sessionId,
@@ -3221,7 +3221,7 @@ ${SYSTEM_REMINDER_CLOSE}
             };
             await writeWireMessageAsync(errorMsg);
           } else {
-            console.error("Failed to fetch pending approvals for resync");
+            console.error("Failed to reconcile pending approvals for resync");
           }
           await exitHeadless(1, "headless_approval_resync_failed");
         }


### PR DESCRIPTION
## Summary

- rebuild headless retry input from authoritative pending approvals after invalid tool-call-ID errors
- strip stale approval payloads while preserving regular messages and refreshing OTIDs
- fail safely if reconciliation produces no retryable input
- add regression wiring coverage preventing out-of-band resolution from leaving stale `currentInput`

## Root cause

The post-stream invalid-ID handler called `resolveAllPendingApprovals()` out of band, then continued with the unchanged stale `currentInput`. The next loop could resend the old approval after the server had cleared the real pending approval, producing `No tool call is currently awaiting approval`.

## Validation

- `bun test src/headless-approval-recovery.test.ts src/agent/turn-recovery-policy.test.ts src/agent/check-approval.test.ts`
- `bun run check`