### PR TITLE
feat(cron): route letta cron through durable Cloud schedules by default [LET-9692] [LET-9820] [LET-9821]

### DIFF
--- a/src/agent/prompts/letta.md
+++ b/src/agent/prompts/letta.md
@@ -120,6 +120,8 @@ Creating crons:
 - Recurring monitoring/heartbeat: `letta cron add --name <short-name> --description <description> --prompt <future-message> --every "2h"` or `--cron "0 9 * * *"`
 Always include `--name`, `--description`, and `--prompt`. `$AGENT_ID` is automatically injected into the shell environment, and `letta cron` uses it by default, so you do not need to specify which agent to invoke unless overriding the current agent intentionally.
 
+Where crons run: for cloud agents, schedules default to durable Cloud schedules that fire from the cloud and execute in your managed cloud sandbox — they survive local shutdown, so this is the right default. If the scheduled work must run on the specific machine you are on right now (e.g. it needs this device's filesystem or local services), pass `--runner local`; local schedules only fire while a Letta session is running on that device.
+
 # Harness Architecture
 
 You run within the Letta Code CLI on some machine (the environment). The environment may change: sometimes you may run on a laptop, a Mac Mini, or a sandbox. Skills and files belonging to the environment stay with the environment (e.g. `AGENTS.md` or `.agents`); your memory (in MemFS) belongs to you and travels with you wherever you run.

--- a/src/agent/prompts/letta.md
+++ b/src/agent/prompts/letta.md
@@ -120,7 +120,7 @@ Creating crons:
 - Recurring monitoring/heartbeat: `letta cron add --name <short-name> --description <description> --prompt <future-message> --every "2h"` or `--cron "0 9 * * *"`
 Always include `--name`, `--description`, and `--prompt`. `$AGENT_ID` is automatically injected into the shell environment, and `letta cron` uses it by default, so you do not need to specify which agent to invoke unless overriding the current agent intentionally.
 
-Where crons run: for cloud agents, schedules default to durable Cloud schedules that fire from the cloud and execute in your managed cloud sandbox — they survive local shutdown, so this is the right default. If the scheduled work must run on the specific machine you are on right now (e.g. it needs this device's filesystem or local services), pass `--runner local`; local schedules only fire while a Letta session is running on that device.
+Where crons run: for cloud agents, schedules default to durable Cloud schedules that fire from the cloud and execute in your managed cloud sandbox — they survive local shutdown, so this is the right default. If the scheduled work must run on a specific machine (e.g. it needs that device's filesystem or local services), add `--target-device <deviceId>` (from `letta environments list`) to keep the durable Cloud schedule but execute on that device, with sandbox fallback if it is offline. Use `--runner local` only when that fallback is unacceptable; local schedules only fire while a Letta session is running on that device.
 
 # Harness Architecture
 

--- a/src/backend/api/schedules.ts
+++ b/src/backend/api/schedules.ts
@@ -28,12 +28,19 @@ export interface CreateCloudScheduleInput {
   conversation_id?: string;
   messages: CloudScheduleMessage[];
   schedule: CloudScheduleSpec;
+  /**
+   * Optional execution target: a registered environment deviceId (e.g. a
+   * Railway/VPS listener). When the device is offline at fire time, the
+   * cloud worker falls back to the agent's managed sandbox.
+   */
+  target_device_id?: string;
 }
 
 export interface CreateCloudScheduleResponse {
   id: string;
   next_scheduled_at?: string;
   use_sandbox: boolean;
+  target_device_id?: string | null;
 }
 
 export interface CloudSchedule {
@@ -46,6 +53,7 @@ export interface CloudSchedule {
   schedule: CloudScheduleSpec;
   next_scheduled_time: string | null;
   use_sandbox: boolean;
+  target_device_id?: string | null;
   created_at?: string;
 }
 

--- a/src/backend/api/schedules.ts
+++ b/src/backend/api/schedules.ts
@@ -1,0 +1,149 @@
+/**
+ * Cloud schedules client (`/v1/agents/:agent_id/schedule` endpoints).
+ *
+ * These routes are served by the Letta API (cloud-api), not the OSS core
+ * server. Cloud schedules are durable: the schedule definition lives in the
+ * Letta API's database and fires from a cloud worker, which injects the
+ * scheduled turn into the agent's managed cloud sandbox (`use_sandbox: true`).
+ * They survive local process/device/sandbox termination, unlike runtime-local
+ * crons in ~/.letta/crons.json.
+ */
+
+import { apiRequest } from "./request";
+
+// ── Wire types (mirror the cloud scheduledMessages contract) ────────
+
+export type CloudScheduleSpec =
+  | { type: "recurring"; cron_expression: string }
+  | { type: "one-time"; scheduled_at: number };
+
+export interface CloudScheduleMessage {
+  role: string;
+  content: unknown;
+}
+
+export interface CreateCloudScheduleInput {
+  name: string;
+  description: string;
+  conversation_id?: string;
+  messages: CloudScheduleMessage[];
+  schedule: CloudScheduleSpec;
+}
+
+export interface CreateCloudScheduleResponse {
+  id: string;
+  next_scheduled_at?: string;
+  use_sandbox: boolean;
+}
+
+export interface CloudSchedule {
+  id: string;
+  agent_id: string;
+  name?: string | null;
+  description?: string | null;
+  conversation_id?: string | null;
+  message: { messages?: CloudScheduleMessage[] } & Record<string, unknown>;
+  schedule: CloudScheduleSpec;
+  next_scheduled_time: string | null;
+  use_sandbox: boolean;
+  created_at?: string;
+}
+
+export interface ListCloudSchedulesResponse {
+  scheduled_messages: CloudSchedule[];
+  has_next_page: boolean;
+}
+
+export interface CloudScheduleHistoryEntry {
+  id: string;
+  scheduled_message_id: string;
+  status: "success" | "failed";
+  response: Record<string, unknown> | null;
+  run_id: string | null;
+  sent_at: string;
+}
+
+export interface ListCloudScheduleHistoryResponse {
+  history: CloudScheduleHistoryEntry[];
+  has_next_page: boolean;
+  next_offset: number | null;
+}
+
+// ── Requests ────────────────────────────────────────────────────────
+
+function schedulePath(agentId: string): string {
+  return `/v1/agents/${encodeURIComponent(agentId)}/schedule`;
+}
+
+export async function createCloudSchedule(
+  agentId: string,
+  input: CreateCloudScheduleInput,
+): Promise<CreateCloudScheduleResponse> {
+  return apiRequest<CreateCloudScheduleResponse>(
+    "POST",
+    schedulePath(agentId),
+    {
+      ...input,
+      // The only harness-capable execution target the cloud worker supports
+      // today is the agent's own managed sandbox. Named remote targets are
+      // future work (LET-9821).
+      use_sandbox: true,
+    },
+  );
+}
+
+export async function listCloudSchedules(
+  agentId: string,
+  options: { limit?: number; after?: string } = {},
+): Promise<ListCloudSchedulesResponse> {
+  return apiRequest<ListCloudSchedulesResponse>(
+    "GET",
+    schedulePath(agentId),
+    undefined,
+    {
+      query: {
+        limit: options.limit ?? 100,
+        after: options.after,
+      },
+    },
+  );
+}
+
+export async function getCloudSchedule(
+  agentId: string,
+  scheduleId: string,
+): Promise<CloudSchedule> {
+  return apiRequest<CloudSchedule>(
+    "GET",
+    `${schedulePath(agentId)}/${encodeURIComponent(scheduleId)}`,
+  );
+}
+
+export async function deleteCloudSchedule(
+  agentId: string,
+  scheduleId: string,
+): Promise<void> {
+  await apiRequest<{ success: boolean }>(
+    "DELETE",
+    `${schedulePath(agentId)}/${encodeURIComponent(scheduleId)}`,
+    {},
+  );
+}
+
+export async function listCloudScheduleHistory(
+  agentId: string,
+  scheduleId: string,
+  options: { limit?: number; offset?: number } = {},
+): Promise<ListCloudScheduleHistoryResponse> {
+  return apiRequest<ListCloudScheduleHistoryResponse>(
+    "GET",
+    `${schedulePath(agentId)}/${encodeURIComponent(scheduleId)}/history`,
+    undefined,
+    {
+      query: {
+        limit: options.limit,
+        offset: options.offset,
+      },
+    },
+  );
+}

--- a/src/backend/api/schedules.ts
+++ b/src/backend/api/schedules.ts
@@ -4,8 +4,10 @@
  * These routes are served by the Letta API (cloud-api), not the OSS core
  * server. Cloud schedules are durable: the schedule definition lives in the
  * Letta API's database and fires from a cloud worker, which injects the
- * scheduled turn into the agent's managed cloud sandbox (`use_sandbox: true`).
- * They survive local process/device/sandbox termination, unlike runtime-local
+ * scheduled turn into the agent's managed cloud sandbox (`use_sandbox: true`)
+ * or, when `target_device_id` is set, into that registered device's live
+ * listener (sandbox fallback when the device is offline). Either way they
+ * survive local process/device/sandbox termination, unlike runtime-local
  * crons in ~/.letta/crons.json.
  */
 
@@ -92,9 +94,10 @@ export async function createCloudSchedule(
     schedulePath(agentId),
     {
       ...input,
-      // The only harness-capable execution target the cloud worker supports
-      // today is the agent's own managed sandbox. Named remote targets are
-      // future work (LET-9821).
+      // Cloud schedules created by the CLI always use harness delivery:
+      // execution runs in the agent's managed sandbox, or on the device named
+      // by `target_device_id` (LET-9821) with sandbox fallback when offline.
+      // The server requires use_sandbox for device targets either way.
       use_sandbox: true,
     },
   );

--- a/src/cli/subcommands/cron-runner.test.ts
+++ b/src/cli/subcommands/cron-runner.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildCloudScheduleInput,
   CLOUD_CRON_UTC_NOTE,
+  CLOUD_DEVICE_FALLBACK_NOTE,
   resolveCronRunner,
 } from "./cron-runner";
 
@@ -166,5 +167,37 @@ describe("buildCloudScheduleInput", () => {
     expect(built.input.conversation_id).toBe("default");
     expect(built.input.name).toBe("test-task");
     expect(built.input.description).toBe("a test task");
+  });
+
+  test("target device rides as target_device_id with a fallback note", () => {
+    const built = buildCloudScheduleInput({
+      ...base,
+      cron: "*/5 * * * *",
+      recurring: true,
+      targetDeviceId: "device-railway-1",
+    });
+    expect(built.input.target_device_id).toBe("device-railway-1");
+    expect(built.notes).toContain(CLOUD_DEVICE_FALLBACK_NOTE);
+  });
+
+  test("untargeted schedules omit target_device_id entirely", () => {
+    const built = buildCloudScheduleInput({
+      ...base,
+      cron: "*/5 * * * *",
+      recurring: true,
+    });
+    expect("target_device_id" in built.input).toBe(false);
+    expect(built.notes).not.toContain(CLOUD_DEVICE_FALLBACK_NOTE);
+  });
+
+  test("whitespace-only target device is treated as absent", () => {
+    const built = buildCloudScheduleInput({
+      ...base,
+      cron: "*/5 * * * *",
+      recurring: true,
+      targetDeviceId: "   ",
+    });
+    expect("target_device_id" in built.input).toBe(false);
+    expect(built.notes).not.toContain(CLOUD_DEVICE_FALLBACK_NOTE);
   });
 });

--- a/src/cli/subcommands/cron-runner.test.ts
+++ b/src/cli/subcommands/cron-runner.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildCloudScheduleInput,
+  CLOUD_CRON_UTC_NOTE,
+  resolveCronRunner,
+} from "./cron-runner";
+
+describe("resolveCronRunner", () => {
+  test("cloud agent defaults to cloud runner when server supports schedules", () => {
+    const result = resolveCronRunner({
+      agentId: "agent-123",
+      backendMode: "api",
+      cloudSchedulesSupported: true,
+    });
+    expect(result).toMatchObject({ runner: "cloud" });
+  });
+
+  test("cloud agent resolves to cloud candidate pre-probe", () => {
+    // Default policy is agent-identity based, not environment based: a cloud
+    // agent scheduled from a VPS/laptop/sandbox still gets the cloud runner.
+    const result = resolveCronRunner({
+      agentId: "agent-abc",
+      backendMode: "api",
+    });
+    expect(result).toMatchObject({ runner: "cloud" });
+  });
+
+  test("--runner local overrides the cloud default", () => {
+    const result = resolveCronRunner({
+      explicit: "local",
+      agentId: "agent-123",
+      backendMode: "api",
+      cloudSchedulesSupported: true,
+    });
+    expect(result).toMatchObject({ runner: "local" });
+  });
+
+  test("local-backend agent defaults to local runner", () => {
+    const result = resolveCronRunner({
+      agentId: "agent-local-123",
+      backendMode: "api",
+    });
+    expect(result).toMatchObject({ runner: "local" });
+  });
+
+  test("local backend mode defaults to local runner", () => {
+    const result = resolveCronRunner({
+      agentId: "agent-123",
+      backendMode: "local",
+    });
+    expect(result).toMatchObject({ runner: "local" });
+  });
+
+  test("server without schedule routes defaults to local runner", () => {
+    const result = resolveCronRunner({
+      agentId: "agent-123",
+      backendMode: "api",
+      cloudSchedulesSupported: false,
+    });
+    expect(result).toMatchObject({ runner: "local" });
+  });
+
+  test("--runner cloud errors for local-backend agents", () => {
+    const result = resolveCronRunner({
+      explicit: "cloud",
+      agentId: "agent-local-123",
+      backendMode: "api",
+    });
+    expect("error" in result).toBe(true);
+  });
+
+  test("--runner cloud errors in local backend mode", () => {
+    const result = resolveCronRunner({
+      explicit: "cloud",
+      agentId: "agent-123",
+      backendMode: "local",
+    });
+    expect("error" in result).toBe(true);
+  });
+
+  test("--runner cloud errors when server lacks schedule routes", () => {
+    const result = resolveCronRunner({
+      explicit: "cloud",
+      agentId: "agent-123",
+      backendMode: "api",
+      cloudSchedulesSupported: false,
+    });
+    expect("error" in result).toBe(true);
+  });
+
+  test("--runner cloud is honored for cloud agents", () => {
+    const result = resolveCronRunner({
+      explicit: "cloud",
+      agentId: "agent-123",
+      backendMode: "api",
+      cloudSchedulesSupported: true,
+    });
+    expect(result).toMatchObject({ runner: "cloud" });
+  });
+
+  test("invalid --runner value errors", () => {
+    const result = resolveCronRunner({
+      explicit: "remote",
+      agentId: "agent-123",
+      backendMode: "api",
+    });
+    expect("error" in result).toBe(true);
+  });
+});
+
+describe("buildCloudScheduleInput", () => {
+  const base = {
+    name: "test-task",
+    description: "a test task",
+    prompt: "do the thing",
+    conversationId: "default",
+  };
+
+  test("recurring schedule maps to cron_expression with UTC note", () => {
+    const built = buildCloudScheduleInput({
+      ...base,
+      cron: "0 9 * * *",
+      recurring: true,
+    });
+    expect(built.input.schedule).toEqual({
+      type: "recurring",
+      cron_expression: "0 9 * * *",
+    });
+    expect(built.notes).toContain(CLOUD_CRON_UTC_NOTE);
+  });
+
+  test("one-shot schedule maps to scheduled_at timestamp", () => {
+    const when = new Date(Date.now() + 60_000);
+    const built = buildCloudScheduleInput({
+      ...base,
+      cron: "30 15 17 7 *",
+      recurring: false,
+      scheduledFor: when,
+    });
+    expect(built.input.schedule).toEqual({
+      type: "one-time",
+      scheduled_at: when.getTime(),
+    });
+    expect(built.notes).toHaveLength(0);
+  });
+
+  test("one-shot without a resolved time throws", () => {
+    expect(() =>
+      buildCloudScheduleInput({
+        ...base,
+        cron: "30 15 17 7 *",
+        recurring: false,
+      }),
+    ).toThrow();
+  });
+
+  test("prompt rides as a single user message", () => {
+    const built = buildCloudScheduleInput({
+      ...base,
+      cron: "*/5 * * * *",
+      recurring: true,
+    });
+    expect(built.input.messages).toEqual([
+      { role: "user", content: "do the thing" },
+    ]);
+    expect(built.input.conversation_id).toBe("default");
+    expect(built.input.name).toBe("test-task");
+    expect(built.input.description).toBe("a test task");
+  });
+});

--- a/src/cli/subcommands/cron-runner.ts
+++ b/src/cli/subcommands/cron-runner.ts
@@ -104,6 +104,8 @@ export interface BuildCloudScheduleParams {
   cron: string;
   recurring: boolean;
   scheduledFor?: Date;
+  /** Optional registered device to execute on (offline → sandbox fallback). */
+  targetDeviceId?: string;
 }
 
 export interface BuiltCloudSchedule {
@@ -115,6 +117,7 @@ export interface BuiltCloudSchedule {
     schedule:
       | { type: "recurring"; cron_expression: string }
       | { type: "one-time"; scheduled_at: number };
+    target_device_id?: string;
   };
   /** Caveats to surface in CLI output. */
   notes: string[];
@@ -127,6 +130,9 @@ export interface BuiltCloudSchedule {
  */
 export const CLOUD_CRON_UTC_NOTE =
   "Recurring Cloud schedules currently interpret cron expressions in UTC (timezone support is tracked in LET-9815).";
+
+export const CLOUD_DEVICE_FALLBACK_NOTE =
+  "If the target device is offline when the schedule fires, execution falls back to the agent's cloud sandbox.";
 
 export function buildCloudScheduleInput(
   params: BuildCloudScheduleParams,
@@ -145,6 +151,11 @@ export function buildCloudScheduleInput(
     schedule = { type: "one-time", scheduled_at: scheduledAt };
   }
 
+  const targetDeviceId = params.targetDeviceId?.trim();
+  if (targetDeviceId) {
+    notes.push(CLOUD_DEVICE_FALLBACK_NOTE);
+  }
+
   return {
     input: {
       name: params.name,
@@ -152,6 +163,7 @@ export function buildCloudScheduleInput(
       ...(params.conversationId && { conversation_id: params.conversationId }),
       messages: [{ role: "user", content: params.prompt }],
       schedule,
+      ...(targetDeviceId && { target_device_id: targetDeviceId }),
     },
     notes,
   };

--- a/src/cli/subcommands/cron-runner.ts
+++ b/src/cli/subcommands/cron-runner.ts
@@ -1,0 +1,158 @@
+/**
+ * Cron runner resolution for `letta cron` (LET-9692).
+ *
+ * Two runners own scheduled tasks:
+ * - "local": the runtime-local scheduler (~/.letta/crons.json), executed by
+ *   the WS listener process on this device. Dies with the device/sandbox.
+ * - "cloud": durable Cloud schedules (`/v1/agents/:id/schedule`), fired by a
+ *   cloud worker into the agent's managed cloud sandbox.
+ *
+ * Default policy: cloud agents get the cloud runner everywhere (laptop, VPS,
+ * managed sandbox) — durability is the default. `--runner local` is the
+ * explicit opt-in for schedules that must execute on a specific machine
+ * (e.g. they need that device's filesystem). Local-backend agents
+ * (`agent-local-*`) always use the local runner, and servers that don't serve
+ * the Cloud schedule routes (self-hosted OSS core) fall back to it.
+ *
+ * Cloud support is determined by probing the schedule route, not by
+ * inspecting the base URL: managed sandboxes and Desktop sessions point
+ * LETTA_BASE_URL at a localhost proxy that forwards to the Letta API, so URL
+ * shape says nothing about capability.
+ */
+
+export type CronRunner = "local" | "cloud";
+
+export const CLOUD_EXECUTION_TARGET = "cloud-sandbox";
+
+export interface ResolveCronRunnerParams {
+  /** Explicit `--runner` flag value, if provided. */
+  explicit?: string;
+  agentId: string;
+  /** Active backend mode ("api" | "local"). */
+  backendMode: "api" | "local";
+  /**
+   * Whether the configured server serves the Cloud schedule routes, when
+   * known (from probing `GET /v1/agents/:id/schedule`). Omit for the
+   * pre-probe pass: cloud-eligible agents then resolve to "cloud" as a
+   * candidate, and the caller re-resolves once support is known.
+   */
+  cloudSchedulesSupported?: boolean;
+}
+
+export type ResolveCronRunnerResult =
+  | { runner: CronRunner; reason: string }
+  | { error: string };
+
+function isLocalAgent(agentId: string): boolean {
+  return agentId.startsWith("agent-local-");
+}
+
+export function resolveCronRunner(
+  params: ResolveCronRunnerParams,
+): ResolveCronRunnerResult {
+  const { explicit, agentId, backendMode, cloudSchedulesSupported } = params;
+
+  if (explicit !== undefined && explicit !== "local" && explicit !== "cloud") {
+    return {
+      error: `invalid --runner "${explicit}". Expected "local" or "cloud".`,
+    };
+  }
+
+  if (explicit === "local") {
+    return { runner: "local", reason: "explicit --runner local" };
+  }
+
+  if (backendMode === "local" || isLocalAgent(agentId)) {
+    if (explicit === "cloud") {
+      return {
+        error:
+          "Cloud schedules are not available for local-backend agents. Use --runner local.",
+      };
+    }
+    return { runner: "local", reason: "local-backend agent" };
+  }
+
+  if (cloudSchedulesSupported === false) {
+    if (explicit === "cloud") {
+      return {
+        error:
+          "This Letta server does not serve Cloud schedule routes (self-hosted?). Use --runner local.",
+      };
+    }
+    return {
+      runner: "local",
+      reason: "server does not support Cloud schedules",
+    };
+  }
+
+  return {
+    runner: "cloud",
+    reason:
+      explicit === "cloud"
+        ? "explicit --runner cloud"
+        : "cloud agent defaults to durable Cloud schedules",
+  };
+}
+
+// ── Cloud payload mapping ───────────────────────────────────────────
+
+export interface BuildCloudScheduleParams {
+  name: string;
+  description: string;
+  prompt: string;
+  conversationId: string;
+  cron: string;
+  recurring: boolean;
+  scheduledFor?: Date;
+}
+
+export interface BuiltCloudSchedule {
+  input: {
+    name: string;
+    description: string;
+    conversation_id?: string;
+    messages: Array<{ role: string; content: string }>;
+    schedule:
+      | { type: "recurring"; cron_expression: string }
+      | { type: "one-time"; scheduled_at: number };
+  };
+  /** Caveats to surface in CLI output. */
+  notes: string[];
+}
+
+/**
+ * Recurring Cloud schedules currently parse bare cron expressions in the
+ * cloud worker's timezone (UTC) — the contract has no IANA timezone field
+ * yet (LET-9815). Surface that so agents/users aren't surprised.
+ */
+export const CLOUD_CRON_UTC_NOTE =
+  "Recurring Cloud schedules currently interpret cron expressions in UTC (timezone support is tracked in LET-9815).";
+
+export function buildCloudScheduleInput(
+  params: BuildCloudScheduleParams,
+): BuiltCloudSchedule {
+  const notes: string[] = [];
+
+  let schedule: BuiltCloudSchedule["input"]["schedule"];
+  if (params.recurring) {
+    schedule = { type: "recurring", cron_expression: params.cron };
+    notes.push(CLOUD_CRON_UTC_NOTE);
+  } else {
+    const scheduledAt = params.scheduledFor?.getTime();
+    if (!scheduledAt || Number.isNaN(scheduledAt)) {
+      throw new Error("One-shot Cloud schedules require a resolved --at time.");
+    }
+    schedule = { type: "one-time", scheduled_at: scheduledAt };
+  }
+
+  return {
+    input: {
+      name: params.name,
+      description: params.description,
+      ...(params.conversationId && { conversation_id: params.conversationId }),
+      messages: [{ role: "user", content: params.prompt }],
+      schedule,
+    },
+    notes,
+  };
+}

--- a/src/cli/subcommands/cron.ts
+++ b/src/cli/subcommands/cron.ts
@@ -2,17 +2,35 @@
  * `letta cron` CLI subcommand.
  *
  * Usage:
- *   letta cron add --prompt <text> --every <interval> [--agent <id>] [--conversation <id>]
- *   letta cron add --prompt <text> --at <time> [--once] [--agent <id>]
- *   letta cron add --prompt <text> --cron <expr> [--agent <id>]
- *   letta cron list [--agent <id>] [--conversation <id>]
- *   letta cron get <id>
- *   letta cron runs --id <id>
- *   letta cron delete <id>
- *   letta cron delete --all [--agent <id>]
+ *   letta cron add --prompt <text> --every <interval> [--agent <id>] [--conversation <id>] [--runner local|cloud]
+ *   letta cron add --prompt <text> --at <time> [--once] [--agent <id>] [--runner local|cloud]
+ *   letta cron add --prompt <text> --cron <expr> [--agent <id>] [--runner local|cloud]
+ *   letta cron list [--agent <id>] [--conversation <id>] [--runner local|cloud]
+ *   letta cron get <id> [--runner local|cloud]
+ *   letta cron runs --id <id> [--runner local|cloud]
+ *   letta cron delete <id> [--runner local|cloud]
+ *   letta cron delete --all [--agent <id>] [--runner local|cloud]
+ *
+ * Runners (LET-9692):
+ * - "cloud" (default for cloud agents): durable Cloud schedules stored by the
+ *   Letta API and executed in the agent's managed cloud sandbox.
+ * - "local": runtime-local tasks in ~/.letta/crons.json, executed by the WS
+ *   listener on this device. Default for local-backend agents and self-hosted
+ *   servers; explicit opt-in (--runner local) for schedules that must run on
+ *   this specific machine.
  */
 
 import { parseArgs } from "node:util";
+import { ApiRequestError } from "@/backend/api/request";
+import {
+  type CloudSchedule,
+  createCloudSchedule,
+  deleteCloudSchedule,
+  getCloudSchedule,
+  listCloudScheduleHistory,
+  listCloudSchedules,
+} from "@/backend/api/schedules";
+import { resolveBackendMode } from "@/backend/backend-mode";
 import {
   addTask,
   deleteAllTasks,
@@ -25,6 +43,12 @@ import {
   parseEvery,
   readCronRunLogEntriesPage,
 } from "@/cron";
+import {
+  buildCloudScheduleInput,
+  CLOUD_EXECUTION_TARGET,
+  type CronRunner,
+  resolveCronRunner,
+} from "./cron-runner";
 
 // ── Usage ───────────────────────────────────────────────────────────
 
@@ -36,10 +60,10 @@ Usage:
   letta cron add --prompt <text> --at <time> [--once] [options]
   letta cron add --prompt <text> --cron <expr> [options]
   letta cron list [options]
-  letta cron get <id>
-  letta cron runs --id <id> [--limit <n>]
-  letta cron delete <id>
-  letta cron delete --all [--agent <id>]
+  letta cron get <id> [--runner local|cloud]
+  letta cron runs --id <id> [--limit <n>] [--runner local|cloud]
+  letta cron delete <id> [--runner local|cloud]
+  letta cron delete --all [--agent <id>] [--runner local|cloud]
 
 Add options:
   --prompt <text>        Prompt to send to the agent (required)
@@ -49,10 +73,18 @@ Add options:
   --cron <expr>          Raw 5-field cron expression
   --agent <id>           Agent ID (defaults to LETTA_AGENT_ID)
   --conversation <id>    Conversation ID (defaults to LETTA_CONVERSATION_ID or "default")
+  --runner <runner>      Where the schedule lives and fires:
+                           cloud - durable Cloud schedule; executes in the
+                                   agent's managed cloud sandbox (default for
+                                   cloud agents)
+                           local - this device's scheduler (~/.letta/crons.json);
+                                   only fires while a session runs here (default
+                                   for local-backend agents / self-hosted)
 
 List/filter options:
   --agent <id>           Filter by agent ID
   --conversation <id>    Filter by conversation ID
+  --runner <runner>      Only show tasks owned by this runner
 
 Delete options:
   --all                  Delete all tasks for the given agent
@@ -79,7 +111,10 @@ const CRON_OPTIONS = {
   id: { type: "string" },
   limit: { type: "string" },
   "run-id": { type: "string" },
+  runner: { type: "string" },
 } as const;
+
+type CronArgValues = ReturnType<typeof parseCronArgs>["values"];
 
 function parseCronArgs(argv: string[]) {
   return parseArgs({
@@ -98,9 +133,102 @@ function getConversationId(fromArgs?: string): string {
   return fromArgs || process.env.LETTA_CONVERSATION_ID || "default";
 }
 
+// ── Runner resolution ───────────────────────────────────────────────
+
+/**
+ * Probe whether the configured server serves the Cloud schedule routes.
+ * Managed sandboxes and Desktop sessions point LETTA_BASE_URL at a localhost
+ * proxy that forwards to the Letta API, so this is a capability probe rather
+ * than a URL-shape check. A 404/405 means the route doesn't exist (self-hosted
+ * OSS core); any other response (including auth errors) means the route is
+ * there and real requests will surface their own errors.
+ */
+async function probeCloudScheduleSupport(agentId: string): Promise<boolean> {
+  try {
+    await listCloudSchedules(agentId, { limit: 1 });
+    return true;
+  } catch (err) {
+    if (
+      err instanceof ApiRequestError &&
+      (err.status === 404 || err.status === 405)
+    ) {
+      return false;
+    }
+    return true;
+  }
+}
+
+/**
+ * The local runner path never needs settings, so the cron subcommand does not
+ * initialize them upfront; every cloud API call does (server URL + auth).
+ * Idempotent — safe to call before each cloud request.
+ */
+async function ensureSettingsForCloud(): Promise<void> {
+  const { settingsManager } = await import("@/settings-manager");
+  await settingsManager.initialize();
+}
+
+async function getRunnerForAgent(
+  explicit: string | undefined,
+  agentId: string,
+): Promise<{ runner: CronRunner; reason: string } | { error: string }> {
+  const backendMode = resolveBackendMode();
+
+  // Cheap pass first: explicit local, local-backend agents, and invalid flag
+  // values resolve without touching settings or the network.
+  const preliminary = resolveCronRunner({ explicit, agentId, backendMode });
+  if ("error" in preliminary || preliminary.runner === "local") {
+    return preliminary;
+  }
+
+  await ensureSettingsForCloud();
+  const cloudSchedulesSupported = await probeCloudScheduleSupport(agentId);
+  return resolveCronRunner({
+    explicit,
+    agentId,
+    backendMode,
+    cloudSchedulesSupported,
+  });
+}
+
+function isRunnerFlagValid(value: string | undefined): boolean {
+  return value === undefined || value === "local" || value === "cloud";
+}
+
+// ── Cloud output mapping ────────────────────────────────────────────
+
+function extractPromptFromCloudSchedule(
+  schedule: CloudSchedule,
+): string | null {
+  const messages = schedule.message?.messages;
+  if (!Array.isArray(messages)) return null;
+  const first = messages[0];
+  if (!first || typeof first.content !== "string") return null;
+  return first.content;
+}
+
+function formatCloudScheduleOutput(
+  schedule: CloudSchedule,
+): Record<string, unknown> {
+  return {
+    id: schedule.id,
+    runner: "cloud",
+    execution_target: CLOUD_EXECUTION_TARGET,
+    agent_id: schedule.agent_id,
+    conversation_id: schedule.conversation_id ?? "default",
+    name: schedule.name ?? null,
+    description: schedule.description ?? null,
+    prompt: extractPromptFromCloudSchedule(schedule),
+    schedule: schedule.schedule,
+    recurring: schedule.schedule.type === "recurring",
+    next_scheduled_time: schedule.next_scheduled_time,
+    created_at: schedule.created_at ?? null,
+  };
+}
+
 // ── Handlers ────────────────────────────────────────────────────────
 
-function handleAdd(values: ReturnType<typeof parseCronArgs>["values"]): number {
+async function handleAdd(values: CronArgValues): Promise<number> {
   const name = values.name;
   if (!name || typeof name !== "string") {
     console.error("Error: --name is required.");
@@ -188,6 +316,26 @@ function handleAdd(values: ReturnType<typeof parseCronArgs>["values"]): number {
     return 1;
   }
 
+  const resolved = await getRunnerForAgent(values.runner, agentId);
+  if ("error" in resolved) {
+    console.error(`Error: ${resolved.error}`);
+    return 1;
+  }
+
+  if (resolved.runner === "cloud") {
+    return handleCloudAdd({
+      agentId,
+      conversationId,
+      name,
+      description,
+      prompt,
+      cron,
+      recurring,
+      scheduledFor,
+      note,
+    });
+  }
+
   try {
     const result = addTask({
       agent_id: agentId,
@@ -202,6 +350,7 @@ function handleAdd(values: ReturnType<typeof parseCronArgs>["values"]): number {
 
     const output: Record<string, unknown> = {
       id: result.task.id,
+      runner: "local",
       status: result.task.status,
       cron: result.task.cron,
       recurring: result.task.recurring,
@@ -224,6 +373,9 @@ function handleAdd(values: ReturnType<typeof parseCronArgs>["values"]): number {
     }
 
     console.log(JSON.stringify(output, null, 2));
+    console.error(
+      "Created local schedule: it only fires while a Letta session is running on this device.",
+    );
     return 0;
   } catch (err) {
     console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
@@ -231,41 +383,201 @@ function handleAdd(values: ReturnType<typeof parseCronArgs>["values"]): number {
   }
 }
 
-function handleList(
-  values: ReturnType<typeof parseCronArgs>["values"],
-): number {
+interface CloudAddParams {
+  agentId: string;
+  conversationId: string;
+  name: string;
+  description: string;
+  prompt: string;
+  cron: string;
+  recurring: boolean;
+  scheduledFor?: Date;
+  note?: string;
+}
+
+async function handleCloudAdd(params: CloudAddParams): Promise<number> {
+  let built: ReturnType<typeof buildCloudScheduleInput>;
+  try {
+    built = buildCloudScheduleInput({
+      name: params.name,
+      description: params.description,
+      prompt: params.prompt,
+      conversationId: params.conversationId,
+      cron: params.cron,
+      recurring: params.recurring,
+      scheduledFor: params.scheduledFor,
+    });
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+
+  try {
+    const result = await createCloudSchedule(params.agentId, built.input);
+
+    const output: Record<string, unknown> = {
+      id: result.id,
+      runner: "cloud",
+      execution_target: CLOUD_EXECUTION_TARGET,
+      agent_id: params.agentId,
+      conversation_id: params.conversationId,
+      recurring: params.recurring,
+      schedule: built.input.schedule,
+      ...(result.next_scheduled_at && {
+        next_scheduled_at: result.next_scheduled_at,
+      }),
+    };
+
+    const notes = [...built.notes];
+    if (params.note) notes.unshift(params.note);
+    if (notes.length > 0) {
+      output.notes = notes;
+    }
+
+    console.log(JSON.stringify(output, null, 2));
+    console.error(
+      "Created Cloud schedule: it fires from the cloud and runs in this agent's managed cloud sandbox (survives local shutdown).",
+    );
+    return 0;
+  } catch (err) {
+    // Deliberately no fallback to the local runner: silently degrading to an
+    // ephemeral device-local schedule is the failure mode LET-9692 fixes.
+    console.error(
+      `Error: failed to create Cloud schedule: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    console.error(
+      "No schedule was created. Retry, or pass --runner local to schedule on this device instead.",
+    );
+    return 1;
+  }
+}
+
+async function handleList(values: CronArgValues): Promise<number> {
+  if (!isRunnerFlagValid(values.runner)) {
+    console.error(
+      `Error: invalid --runner "${values.runner}". Expected "local" or "cloud".`,
+    );
+    return 1;
+  }
+
   const agentId = values.agent || process.env.LETTA_AGENT_ID || undefined;
   const conversationId = values.conversation || undefined;
 
-  const tasks = listTasks({
-    agent_id: agentId,
-    conversation_id: conversationId,
-  });
+  const includeLocal = values.runner !== "cloud";
+  const includeCloud = values.runner !== "local";
 
-  console.log(JSON.stringify(tasks, null, 2));
+  const output: Array<Record<string, unknown>> = [];
+
+  if (includeLocal) {
+    const tasks = listTasks({
+      agent_id: agentId,
+      conversation_id: conversationId,
+    });
+    for (const task of tasks) {
+      output.push({ ...task, runner: "local" });
+    }
+  }
+
+  if (includeCloud && agentId) {
+    const resolved = await getRunnerForAgent(undefined, agentId);
+    const cloudCapable = !("error" in resolved) && resolved.runner === "cloud";
+    const cloudExplicit = values.runner === "cloud";
+
+    if (cloudCapable || cloudExplicit) {
+      try {
+        const response = await listCloudSchedules(agentId);
+        for (const schedule of response.scheduled_messages) {
+          if (
+            conversationId &&
+            (schedule.conversation_id ?? "default") !== conversationId
+          ) {
+            continue;
+          }
+          output.push(formatCloudScheduleOutput(schedule));
+        }
+      } catch (err) {
+        console.error(
+          `Warning: failed to list Cloud schedules: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        if (cloudExplicit) {
+          return 1;
+        }
+      }
+    }
+  } else if (includeCloud && values.runner === "cloud" && !agentId) {
+    console.error(
+      "Error: --agent or LETTA_AGENT_ID required to list Cloud schedules.",
+    );
+    return 1;
+  }
+
+  console.log(JSON.stringify(output, null, 2));
   return 0;
 }
 
-function handleGet(positionals: string[]): number {
+async function handleGet(
+  values: CronArgValues,
+  positionals: string[],
+): Promise<number> {
+  if (!isRunnerFlagValid(values.runner)) {
+    console.error(
+      `Error: invalid --runner "${values.runner}". Expected "local" or "cloud".`,
+    );
+    return 1;
+  }
+
   const taskId = positionals[1];
   if (!taskId) {
     console.error("Error: task ID required. Usage: letta cron get <id>");
     return 1;
   }
 
-  const task = getTask(taskId);
-  if (!task) {
-    console.error(`Error: task ${taskId} not found.`);
+  // Local store is a cheap file read; check it first unless --runner cloud.
+  if (values.runner !== "cloud") {
+    const task = getTask(taskId);
+    if (task) {
+      console.log(JSON.stringify({ ...task, runner: "local" }, null, 2));
+      return 0;
+    }
+    if (values.runner === "local") {
+      console.error(`Error: task ${taskId} not found.`);
+      return 1;
+    }
+  }
+
+  const agentId = getAgentId(values.agent);
+  if (!agentId) {
+    console.error(
+      `Error: task ${taskId} not found locally, and --agent or LETTA_AGENT_ID is required to look up Cloud schedules.`,
+    );
     return 1;
   }
 
-  console.log(JSON.stringify(task, null, 2));
-  return 0;
+  try {
+    await ensureSettingsForCloud();
+    const schedule = await getCloudSchedule(agentId, taskId);
+    console.log(JSON.stringify(formatCloudScheduleOutput(schedule), null, 2));
+    return 0;
+  } catch (err) {
+    if (err instanceof ApiRequestError && err.status === 404) {
+      console.error(`Error: task ${taskId} not found.`);
+    } else {
+      console.error(
+        `Error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    return 1;
+  }
 }
 
-function handleRuns(
-  values: ReturnType<typeof parseCronArgs>["values"],
-): number {
+async function handleRuns(values: CronArgValues): Promise<number> {
+  if (!isRunnerFlagValid(values.runner)) {
+    console.error(
+      `Error: invalid --runner "${values.runner}". Expected "local" or "cloud".`,
+    );
+    return 1;
+  }
+
   const id = values.id;
   if (!id || typeof id !== "string") {
     console.error("Error: --id is required. Usage: letta cron runs --id <id>");
@@ -276,14 +588,52 @@ function handleRuns(
   const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : 50;
   const runId = values["run-id"];
 
+  // Local run log first (cheap file read) unless --runner cloud.
+  if (values.runner !== "cloud" && getTask(id)) {
+    try {
+      const logPath = getCronRunLogPath(id);
+      const page = readCronRunLogEntriesPage(logPath, {
+        jobId: id,
+        limit,
+        ...(typeof runId === "string" && runId.trim() ? { runId } : {}),
+      });
+      console.log(JSON.stringify(page, null, 2));
+      return 0;
+    } catch (err) {
+      console.error(
+        `Error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return 1;
+    }
+  }
+
+  if (values.runner === "local") {
+    console.error(`Error: task ${id} not found.`);
+    return 1;
+  }
+
+  const agentId = getAgentId(values.agent);
+  if (!agentId) {
+    console.error(
+      `Error: task ${id} not found locally, and --agent or LETTA_AGENT_ID is required to look up Cloud schedule runs.`,
+    );
+    return 1;
+  }
+
   try {
-    const logPath = getCronRunLogPath(id);
-    const page = readCronRunLogEntriesPage(logPath, {
-      jobId: id,
-      limit,
-      ...(typeof runId === "string" && runId.trim() ? { runId } : {}),
-    });
-    console.log(JSON.stringify(page, null, 2));
+    await ensureSettingsForCloud();
+    const response = await listCloudScheduleHistory(agentId, id, { limit });
+    console.log(
+      JSON.stringify(
+        {
+          runner: "cloud",
+          entries: response.history,
+          has_next_page: response.has_next_page,
+        },
+        null,
+        2,
+      ),
+    );
     return 0;
   } catch (err) {
     console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
@@ -291,19 +641,19 @@ function handleRuns(
   }
 }
 
-function handleDelete(
-  values: ReturnType<typeof parseCronArgs>["values"],
+async function handleDelete(
+  values: CronArgValues,
   positionals: string[],
-): number {
+): Promise<number> {
+  if (!isRunnerFlagValid(values.runner)) {
+    console.error(
+      `Error: invalid --runner "${values.runner}". Expected "local" or "cloud".`,
+    );
+    return 1;
+  }
+
   if (values.all) {
-    const agentId = getAgentId(values.agent);
-    if (!agentId) {
-      console.error("Error: --agent or LETTA_AGENT_ID required with --all.");
-      return 1;
-    }
-    const count = deleteAllTasks(agentId);
-    console.log(JSON.stringify({ deleted: count, agent_id: agentId }));
-    return 0;
+    return handleDeleteAll(values);
   }
 
   const taskId = positionals[1];
@@ -314,13 +664,94 @@ function handleDelete(
     return 1;
   }
 
-  const found = deleteTask(taskId);
-  if (!found) {
-    console.error(`Error: task ${taskId} not found.`);
+  if (values.runner !== "cloud") {
+    const found = deleteTask(taskId);
+    if (found) {
+      console.log(JSON.stringify({ deleted: taskId, runner: "local" }));
+      return 0;
+    }
+    if (values.runner === "local") {
+      console.error(`Error: task ${taskId} not found.`);
+      return 1;
+    }
+  }
+
+  const agentId = getAgentId(values.agent);
+  if (!agentId) {
+    console.error(
+      `Error: task ${taskId} not found locally, and --agent or LETTA_AGENT_ID is required to delete Cloud schedules.`,
+    );
     return 1;
   }
 
-  console.log(JSON.stringify({ deleted: taskId }));
+  try {
+    await ensureSettingsForCloud();
+    // Verify existence first: the cloud delete endpoint is a soft-delete
+    // update that reports success even for unknown IDs.
+    await getCloudSchedule(agentId, taskId);
+    await deleteCloudSchedule(agentId, taskId);
+    console.log(JSON.stringify({ deleted: taskId, runner: "cloud" }));
+    return 0;
+  } catch (err) {
+    if (err instanceof ApiRequestError && err.status === 404) {
+      console.error(`Error: task ${taskId} not found.`);
+    } else {
+      console.error(
+        `Error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    return 1;
+  }
+}
+
+async function handleDeleteAll(values: CronArgValues): Promise<number> {
+  const agentId = getAgentId(values.agent);
+  if (!agentId) {
+    console.error("Error: --agent or LETTA_AGENT_ID required with --all.");
+    return 1;
+  }
+
+  const includeLocal = values.runner !== "cloud";
+  const includeCloud = values.runner !== "local";
+
+  let localDeleted = 0;
+  if (includeLocal) {
+    localDeleted = deleteAllTasks(agentId);
+  }
+
+  let cloudDeleted = 0;
+  if (includeCloud) {
+    const resolved = await getRunnerForAgent(undefined, agentId);
+    const cloudCapable = !("error" in resolved) && resolved.runner === "cloud";
+    const cloudExplicit = values.runner === "cloud";
+
+    if (cloudCapable || cloudExplicit) {
+      try {
+        const response = await listCloudSchedules(agentId);
+        for (const schedule of response.scheduled_messages) {
+          await deleteCloudSchedule(agentId, schedule.id);
+          cloudDeleted += 1;
+        }
+      } catch (err) {
+        console.error(
+          `Error: failed to delete Cloud schedules: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        console.error(
+          `Deleted so far: ${localDeleted} local, ${cloudDeleted} cloud.`,
+        );
+        return 1;
+      }
+    }
+  }
+
+  console.log(
+    JSON.stringify({
+      deleted: localDeleted + cloudDeleted,
+      local_deleted: localDeleted,
+      cloud_deleted: cloudDeleted,
+      agent_id: agentId,
+    }),
+  );
   return 0;
 }
 
@@ -348,7 +779,7 @@ export async function runCronSubcommand(argv: string[]): Promise<number> {
     case "list":
       return handleList(parsed.values);
     case "get":
-      return handleGet(parsed.positionals);
+      return handleGet(parsed.values, parsed.positionals);
     case "runs":
       return handleRuns(parsed.values);
     case "delete":

--- a/src/cli/subcommands/cron.ts
+++ b/src/cli/subcommands/cron.ts
@@ -80,6 +80,10 @@ Add options:
                            local - this device's scheduler (~/.letta/crons.json);
                                    only fires while a session runs here (default
                                    for local-backend agents / self-hosted)
+  --target-device <id>   (cloud runner only) Execute on a registered remote
+                         device (deviceId from \`letta environments list\`)
+                         instead of the agent's cloud sandbox. Falls back to
+                         the sandbox if the device is offline at fire time.
 
 List/filter options:
   --agent <id>           Filter by agent ID
@@ -112,6 +116,7 @@ const CRON_OPTIONS = {
   limit: { type: "string" },
   "run-id": { type: "string" },
   runner: { type: "string" },
+  "target-device": { type: "string" },
 } as const;
 
 type CronArgValues = ReturnType<typeof parseCronArgs>["values"];
@@ -210,10 +215,12 @@ function extractPromptFromCloudSchedule(
 function formatCloudScheduleOutput(
   schedule: CloudSchedule,
 ): Record<string, unknown> {
+  const targetDeviceId = schedule.target_device_id ?? null;
   return {
     id: schedule.id,
     runner: "cloud",
-    execution_target: CLOUD_EXECUTION_TARGET,
+    execution_target: targetDeviceId ?? CLOUD_EXECUTION_TARGET,
+    ...(targetDeviceId && { target_device_id: targetDeviceId }),
     agent_id: schedule.agent_id,
     conversation_id: schedule.conversation_id ?? "default",
     name: schedule.name ?? null,
@@ -316,9 +323,22 @@ async function handleAdd(values: CronArgValues): Promise<number> {
     return 1;
   }
 
+  const targetDeviceId = values["target-device"]?.trim() || undefined;
+
   const resolved = await getRunnerForAgent(values.runner, agentId);
   if ("error" in resolved) {
     console.error(`Error: ${resolved.error}`);
+    return 1;
+  }
+
+  // Device targets are a Cloud-schedule feature: the cloud worker delivers
+  // to the named device's listener (sandbox fallback when offline). A local
+  // task already runs on the device that owns it, so the flag is meaningless
+  // (and likely a mistake) for the local runner.
+  if (targetDeviceId && resolved.runner !== "cloud") {
+    console.error(
+      "Error: --target-device requires the cloud runner. Run `letta cron add` on the target device itself (with --runner local) to schedule there locally.",
+    );
     return 1;
   }
 
@@ -333,6 +353,7 @@ async function handleAdd(values: CronArgValues): Promise<number> {
       recurring,
       scheduledFor,
       note,
+      targetDeviceId,
     });
   }
 
@@ -393,6 +414,7 @@ interface CloudAddParams {
   recurring: boolean;
   scheduledFor?: Date;
   note?: string;
+  targetDeviceId?: string;
 }
 
 async function handleCloudAdd(params: CloudAddParams): Promise<number> {
@@ -406,6 +428,7 @@ async function handleCloudAdd(params: CloudAddParams): Promise<number> {
       cron: params.cron,
       recurring: params.recurring,
       scheduledFor: params.scheduledFor,
+      targetDeviceId: params.targetDeviceId,
     });
   } catch (err) {
     console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
@@ -415,10 +438,14 @@ async function handleCloudAdd(params: CloudAddParams): Promise<number> {
   try {
     const result = await createCloudSchedule(params.agentId, built.input);
 
+    const targetDeviceId =
+      result.target_device_id ?? built.input.target_device_id ?? null;
+
     const output: Record<string, unknown> = {
       id: result.id,
       runner: "cloud",
-      execution_target: CLOUD_EXECUTION_TARGET,
+      execution_target: targetDeviceId ?? CLOUD_EXECUTION_TARGET,
+      ...(targetDeviceId && { target_device_id: targetDeviceId }),
       agent_id: params.agentId,
       conversation_id: params.conversationId,
       recurring: params.recurring,
@@ -436,7 +463,9 @@ async function handleCloudAdd(params: CloudAddParams): Promise<number> {
 
     console.log(JSON.stringify(output, null, 2));
     console.error(
-      "Created Cloud schedule: it fires from the cloud and runs in this agent's managed cloud sandbox (survives local shutdown).",
+      targetDeviceId
+        ? `Created Cloud schedule: it fires from the cloud and runs on device "${targetDeviceId}" (sandbox fallback if offline).`
+        : "Created Cloud schedule: it fires from the cloud and runs in this agent's managed cloud sandbox (survives local shutdown).",
     );
     return 0;
   } catch (err) {

--- a/src/skills/builtin/scheduling-tasks/SKILL.md
+++ b/src/skills/builtin/scheduling-tasks/SKILL.md
@@ -21,11 +21,19 @@ There are two schedule runners, selected with the optional `--runner local|cloud
 - **`cloud`** (default for cloud agents): a durable Cloud schedule stored by the Letta API. It fires from the cloud and executes in the agent's managed cloud sandbox, so it survives local shutdown — the device, sandbox, or session that created it can disappear and the schedule still fires.
 - **`local`**: a device-local task in `~/.letta/crons.json`, executed by the Letta session on that device. It only fires while a session is running there, and it dies with the device's local state.
 
-You normally don't need the flag — the default does the right thing. Use `--runner local` only when the scheduled work must run on the specific machine you are on right now, e.g. it needs that device's filesystem, local services, or credentials (a Railway/VPS machine, a specific laptop). Local-backend agents (`agent-local-*`) and self-hosted servers always use the local runner.
+You normally don't need the flag — the default does the right thing. Local-backend agents (`agent-local-*`) and self-hosted servers always use the local runner.
+
+If the scheduled work must run on a **specific machine** (it needs that device's filesystem, local services, or credentials — e.g. a Railway/VPS machine), prefer a Cloud schedule targeting that device:
+
+```bash
+letta cron add ... --target-device <deviceId>
+```
+
+The deviceId comes from `letta environments list`. The schedule stays durable in the cloud; if the device is offline when it fires, execution falls back to the agent's cloud sandbox. Use `--runner local` (run on the target machine itself) only when that sandbox fallback is unacceptable — a local task never runs anywhere but its own device.
 
 Notes for the cloud runner:
 
-- The schedule executes in the agent's cloud sandbox, not on the device where you created it.
+- Untargeted schedules execute in the agent's cloud sandbox, not on the device where you created them; `--target-device` executes on the named device with sandbox fallback.
 - Recurring `--cron` expressions are currently interpreted in UTC (the CLI output includes a note about this). `--at` and `--every` are unaffected.
 - If creating a Cloud schedule fails, no schedule is created — there is no silent fallback to local storage. Retry, or pass `--runner local` deliberately.
 
@@ -62,6 +70,7 @@ letta cron add --name <short-name> --description <text> --prompt <text> <schedul
 | `--agent <id>` | Agent ID (defaults to `LETTA_AGENT_ID` from the current shell/session) |
 | `--conversation <id>` | Conversation ID (defaults to `LETTA_CONVERSATION_ID` from the current shell/session, otherwise `"default"`) |
 | `--runner <runner>` | `cloud` or `local` — see "Where Schedules Run" above (defaults to `cloud` for cloud agents) |
+| `--target-device <id>` | (cloud runner only) Execute on a registered remote device instead of the agent's sandbox; falls back to the sandbox if the device is offline |
 
 ### Listing Tasks
 

--- a/src/skills/builtin/scheduling-tasks/SKILL.md
+++ b/src/skills/builtin/scheduling-tasks/SKILL.md
@@ -14,6 +14,21 @@ This skill lets you create, list, and manage scheduled tasks using the `letta cr
 - User wants a one-shot delayed message ("in 30 minutes, check on X")
 - User wants to see or cancel existing scheduled tasks
 
+## Where Schedules Run (`--runner`)
+
+There are two schedule runners, selected with the optional `--runner local|cloud` flag:
+
+- **`cloud`** (default for cloud agents): a durable Cloud schedule stored by the Letta API. It fires from the cloud and executes in the agent's managed cloud sandbox, so it survives local shutdown — the device, sandbox, or session that created it can disappear and the schedule still fires.
+- **`local`**: a device-local task in `~/.letta/crons.json`, executed by the Letta session on that device. It only fires while a session is running there, and it dies with the device's local state.
+
+You normally don't need the flag — the default does the right thing. Use `--runner local` only when the scheduled work must run on the specific machine you are on right now, e.g. it needs that device's filesystem, local services, or credentials (a Railway/VPS machine, a specific laptop). Local-backend agents (`agent-local-*`) and self-hosted servers always use the local runner.
+
+Notes for the cloud runner:
+
+- The schedule executes in the agent's cloud sandbox, not on the device where you created it.
+- Recurring `--cron` expressions are currently interpreted in UTC (the CLI output includes a note about this). `--at` and `--every` are unaffected.
+- If creating a Cloud schedule fails, no schedule is created — there is no silent fallback to local storage. Retry, or pass `--runner local` deliberately.
+
 ## CLI Usage
 
 All commands go through `letta cron` via the Bash tool. Output is JSON.
@@ -46,6 +61,7 @@ letta cron add --name <short-name> --description <text> --prompt <text> <schedul
 |------|-------------|
 | `--agent <id>` | Agent ID (defaults to `LETTA_AGENT_ID` from the current shell/session) |
 | `--conversation <id>` | Conversation ID (defaults to `LETTA_CONVERSATION_ID` from the current shell/session, otherwise `"default"`) |
+| `--runner <runner>` | `cloud` or `local` — see "Where Schedules Run" above (defaults to `cloud` for cloud agents) |
 
 ### Listing Tasks
 
@@ -172,10 +188,10 @@ Include context about what the user originally asked for, so you can give a help
 
 - **Minimum granularity**: 1 minute. Intervals under 60 seconds are rounded up.
 - **Recurring tasks**: No longer auto-expire. They remain active until explicitly cancelled.
-- **One-shot cleanup**: One-shot tasks are garbage-collected 24 hours after firing.
-- **Timezone**: Tasks use the user's local timezone by default.
+- **One-shot cleanup (local runner)**: One-shot local tasks are garbage-collected 24 hours after firing.
+- **Timezone**: Local-runner tasks use the user's local timezone. Cloud-runner recurring `--cron` expressions are currently interpreted in UTC.
 - **Default binding precedence**: `letta cron add` uses `--agent` / `--conversation` first, then falls back to `LETTA_AGENT_ID` / `LETTA_CONVERSATION_ID`, then finally uses `"default"` for the conversation if no env var is present.
-- **Scheduler requirement**: Tasks only fire while a Letta session is running (a WS listener must be active). If no session is running, tasks will be marked as missed.
+- **Local scheduler requirement**: Local-runner tasks only fire while a Letta session is running on that device (a WS listener must be active). If no session is running, tasks will be marked as missed. Cloud-runner schedules fire from the cloud regardless.
 - **`--at` for specific times**: `--at "3:00pm"` schedules a one-shot. If the time has already passed today, it schedules for tomorrow.
 - **`--every` for daily**: `--every 1d` fires daily at midnight. For a specific time of day, use `--cron` instead (e.g. `--cron "0 9 * * *"` for 9am daily).
 


### PR DESCRIPTION
## Summary

- `letta cron` previously always wrote runtime-local tasks to `~/.letta/crons.json`, which silently die with the device/sandbox that created them (LET-9692). Cloud agents now default to durable Cloud schedules (`/v1/agents/:id/schedule`), which fire from the cloud and execute inside the agent's managed cloud sandbox — surviving local shutdown.
- New `--runner local|cloud` flag on `add`/`list`/`get`/`runs`/`delete`. The default is `cloud` for cloud agents everywhere (laptop, VPS, managed sandbox); `local` remains the default for local-backend agents (`agent-local-*`) and servers without the Cloud schedule routes, and is the explicit opt-in for schedules that must run on a specific machine.
- New `--target-device <deviceId>` on `add` (cloud runner only, LET-9821): keeps the durable cloud-owned timer but executes on a named registered device (from `letta environments list`), with automatic fallback to the agent's sandbox if the device is offline at fire time. Backend support landed in the receiving service and is deployed. With `--runner local` the flag errors — a local task already runs on the device that owns it.
- Cloud support is detected by probing the schedule route rather than matching the base URL: managed sandboxes and Desktop sessions point `LETTA_BASE_URL` at a localhost proxy that forwards to the Letta API, so URL shape says nothing about capability.
- `list`/`get`/`runs`/`delete` operate across both runners and tag every task with a `runner` field (plus `target_device_id`/`execution_target` for device-targeted schedules); cloud `runs` map to the schedule history endpoint. `delete --all` reports per-runner counts.
- Failure to create a Cloud schedule is a hard error with no silent fallback to ephemeral local storage (the exact failure mode this ticket fixes).
- Recurring cloud cron expressions surface a note that they are currently interpreted in UTC until the schedule contract gains an IANA timezone field (LET-9815).
- Agent guidance updated (LET-9820): the scheduling-tasks skill gains a "Where Schedules Run" section, and device-pinned work is steered toward `--target-device` Cloud schedules, reserving `--runner local` for when the sandbox fallback is unacceptable. The system prompt's cron section matches. Local-runner-specific notes (local timezone, session-must-be-running, 24h GC) are labeled as such.

## Verification

- `bun run check` (all 12 pass); 18 unit tests for runner resolution + payload mapping (`cron-runner.test.ts`) incl. device-target mapping/notes/whitespace handling; existing cron suite and prompt-asset tests pass.
- Live smoke tests against the Letta API through a Desktop localhost proxy:
  - default `add` created a Cloud schedule (`runner: "cloud"`, sandbox target), `list` merged local + cloud tasks, `get`/`runs`/`delete` round-tripped, `--runner local` still writes device-local tasks, `--runner cloud` errors for `agent-local-*` agents, deleted IDs return not-found.
  - `--target-device` with a registered org device created a device-targeted Cloud schedule (`execution_target` = deviceId, fallback note in output), `get` echoed the target, delete cleaned up; an unregistered deviceId surfaced the server's 404 with no schedule created; `--target-device` + `--runner local` errors.

👾 Generated with [Letta Code](https://letta.com)