### PR TITLE
fix(slack): hide generic tool activity from status

### DIFF
--- a/src/channels/slack/progress.ts
+++ b/src/channels/slack/progress.ts
@@ -38,16 +38,6 @@ export function formatSlackToolNameForDisplay(toolName: string): string {
   return toolName;
 }
 
-function isSlackShellTool(toolName: string): boolean {
-  const normalized = toolName.toLowerCase();
-  return (
-    normalized === "bash" ||
-    normalized === "exec_command" ||
-    normalized === "shell_command" ||
-    normalized === "shell"
-  );
-}
-
 export function resolveSlackConcreteActivity(
   event: ChannelTurnProgressEvent,
 ): string | null {
@@ -65,12 +55,7 @@ export function resolveSlackConcreteActivity(
     return null;
   }
 
-  for (const description of [
-    event.toolTitle,
-    event.toolDetails,
-    isSlackShellTool(event.toolName) ? event.message : undefined,
-    formatSlackToolNameForDisplay(event.toolName),
-  ]) {
+  for (const description of [event.toolTitle, event.toolDetails]) {
     if (!isNonEmptyString(description)) {
       continue;
     }

--- a/src/channels/slack/status-controller.test.ts
+++ b/src/channels/slack/status-controller.test.ts
@@ -87,7 +87,16 @@ test("slack status event table: concrete descriptions replace in place and gener
     type: "progress",
     kind: "tool",
     state: "started",
-    message: "Preparing tool call",
+    message: "Preparing tool: exec_command",
+    toolName: "exec_command",
+    sources: [source],
+  });
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    kind: "tool",
+    state: "started",
+    message: "Preparing tool: Read",
+    toolName: "Read",
     sources: [source],
   });
   await adapter.handleTurnProgressEvent?.({


### PR DESCRIPTION
## Summary
- keep transient tool-start events from replacing Slack assistant status before a concrete title or description is available
- preserve the previous meaningful status instead of exposing internal labels such as `Preparing tool: exec_command`
- cover both shell and non-shell generic tool events in the status integration test

Validated with `bun test src/channels/slack/status-controller.test.ts` and `bun run check`.

👾 Generated with [Letta Code](https://letta.com)