### PR TITLE
feat(cli): unify App Server under letta server

### DIFF
--- a/src/cli/subcommands/app-server.ts
+++ b/src/cli/subcommands/app-server.ts
@@ -4,12 +4,12 @@ import { parseAppServerWebsocketAuthSettings } from "@/websocket/app-server-auth
 
 function printAppServerHelp(): void {
   console.log(
-    `Usage: letta app-server [--listen <url>]
+    `Usage: letta server --listen [url]
 
-Run a local Letta Code app-server using native v2 websocket frames.
+Run the local App Server using native v2 WebSocket frames.
 
 Options:
-  --listen <url>  WebSocket listen URL. Defaults to ws://127.0.0.1:0
+  --listen [url]  WebSocket listen URL. Defaults to an available loopback port
   --ws-auth <mode>  WebSocket auth mode for non-loopback listeners. Supported: capability-token, signed-bearer-token
   --ws-token-file <path>  Absolute path to the capability-token file
   --ws-token-sha256 <hex>  Hex-encoded SHA-256 digest of the capability token
@@ -20,10 +20,10 @@ Options:
   -h, --help      Show this help message
 
 Examples:
-  letta app-server
-  letta app-server --listen ws://127.0.0.1:4500
-  letta app-server --listen ws://0.0.0.0:4500 --ws-auth capability-token --ws-token-file /path/to/token
-  letta app-server --listen ws://0.0.0.0:4500 --ws-auth signed-bearer-token --ws-shared-secret-file /path/to/secret`,
+  letta server --listen
+  letta server --listen ws://127.0.0.1:4500
+  letta server --listen ws://0.0.0.0:4500 --ws-auth capability-token --ws-token-file /path/to/token
+  letta server --listen ws://0.0.0.0:4500 --ws-auth signed-bearer-token --ws-shared-secret-file /path/to/secret`,
   );
 }
 
@@ -35,7 +35,7 @@ async function waitForShutdown(close: () => Promise<void>): Promise<number> {
       shuttingDown = true;
       void close()
         .then(() => {
-          console.log(`\nStopped app-server (${signal}).`);
+          console.log(`\nStopped App Server (${signal}).`);
           resolve(0);
         })
         .catch((error) => {

--- a/src/cli/subcommands/router.test.ts
+++ b/src/cli/subcommands/router.test.ts
@@ -28,7 +28,7 @@ describe("subcommand router", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("routes app-server help without starting the server", async () => {
+  test("shows unified server help without starting a server", async () => {
     const messages: string[] = [];
     const originalLog = console.log;
     console.log = (message?: unknown) => {
@@ -36,12 +36,43 @@ describe("subcommand router", () => {
     };
 
     try {
+      const exitCode = await runSubcommand(["server", "--help"]);
+
+      expect(exitCode).toBe(0);
+      expect(messages.join("\n")).toContain("letta server [remote options]");
+      expect(messages.join("\n")).toContain(
+        "letta server --listen [url] [App Server options]",
+      );
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
+  test("keeps app-server as a deprecated alias", async () => {
+    const messages: string[] = [];
+    const warnings: string[] = [];
+    const originalLog = console.log;
+    const originalError = console.error;
+    console.log = (message?: unknown) => {
+      messages.push(String(message));
+    };
+    console.error = (message?: unknown) => {
+      warnings.push(String(message));
+    };
+
+    try {
       const exitCode = await runSubcommand(["app-server", "--help"]);
 
       expect(exitCode).toBe(0);
-      expect(messages.join("\n")).toContain("Usage: letta app-server");
+      expect(messages.join("\n")).toContain(
+        "letta server --listen [url] [App Server options]",
+      );
+      expect(warnings).toEqual([
+        "Warning: `letta app-server` is deprecated. Use `letta server --listen` instead.",
+      ]);
     } finally {
       console.log = originalLog;
+      console.error = originalError;
     }
   });
 

--- a/src/cli/subcommands/router.ts
+++ b/src/cli/subcommands/router.ts
@@ -1,5 +1,4 @@
 import { runAgentsSubcommand } from "./agents";
-import { runAppServerSubcommand } from "./app-server";
 import { runBackendSubcommand } from "./backend";
 import { runChannelsSubcommand } from "./channels";
 import { runConnectSubcommand } from "./connect";
@@ -11,6 +10,7 @@ import { runLocalBackendSubcommand } from "./local-backend";
 import { runMemorySubcommand } from "./memory";
 import { runMessagesSubcommand } from "./messages";
 import { runModsSubcommand } from "./mods";
+import { asLegacyAppServerCommand, runServerSubcommand } from "./server";
 import { runSetupSubcommand } from "./setup";
 import { runInstallSubcommand, runSkillsSubcommand } from "./skills";
 
@@ -70,7 +70,10 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
     case "agents":
       return runAgentsSubcommand(rest);
     case "app-server":
-      return runAppServerSubcommand(rest);
+      console.error(
+        "Warning: `letta app-server` is deprecated. Use `letta server --listen` instead.",
+      );
+      return runServerSubcommand(asLegacyAppServerCommand(rest));
     case "messages":
       return runMessagesSubcommand(rest);
     case "environments":
@@ -79,6 +82,7 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
     case "mods":
       return runModsSubcommand(rest);
     case "server":
+      return runServerSubcommand(rest);
     case "remote": // alias
       return runListenSubcommand(rest);
     case "connect":

--- a/src/cli/subcommands/server.test.ts
+++ b/src/cli/subcommands/server.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import {
+  asLegacyAppServerCommand,
+  resolveServerCommand,
+} from "@/cli/subcommands/server";
+
+describe("server subcommand routing", () => {
+  test("keeps the default remote environment mode", () => {
+    expect(resolveServerCommand([])).toEqual({ kind: "remote", argv: [] });
+    expect(resolveServerCommand(["--channels", "slack"])).toEqual({
+      kind: "remote",
+      argv: ["--channels", "slack"],
+    });
+  });
+
+  test("uses a bare --listen flag for App Server on an available port", () => {
+    expect(resolveServerCommand(["--listen"])).toEqual({
+      kind: "app-server",
+      argv: [],
+    });
+    expect(
+      resolveServerCommand(["--listen", "--ws-auth", "capability-token"]),
+    ).toEqual({
+      kind: "app-server",
+      argv: ["--ws-auth", "capability-token"],
+    });
+  });
+
+  test("accepts space-separated and equals-form listen URLs", () => {
+    const expected: ReturnType<typeof resolveServerCommand> = {
+      kind: "app-server",
+      argv: ["--listen", "ws://127.0.0.1:4500"],
+    };
+
+    expect(resolveServerCommand(["--listen", "ws://127.0.0.1:4500"])).toEqual(
+      expected,
+    );
+    expect(resolveServerCommand(["--listen=ws://127.0.0.1:4500"])).toEqual(
+      expected,
+    );
+  });
+
+  test("rejects ambiguous listen arguments", () => {
+    expect(() =>
+      resolveServerCommand(["--listen", "--listen=ws://127.0.0.1:4500"]),
+    ).toThrow("--listen may only be specified once");
+    expect(() => resolveServerCommand(["--listen="])).toThrow(
+      "--listen= requires a URL",
+    );
+  });
+
+  test("rejects remote environment options in App Server mode", () => {
+    expect(() =>
+      resolveServerCommand(["--listen", "--env-name", "work-laptop"]),
+    ).toThrow("--env-name cannot be used with --listen");
+    expect(() =>
+      resolveServerCommand(["--channels=slack", "--listen"]),
+    ).toThrow("--channels cannot be used with --listen");
+  });
+
+  test("maps the legacy command to App Server mode", () => {
+    expect(asLegacyAppServerCommand([])).toEqual(["--listen"]);
+    expect(asLegacyAppServerCommand(["--help"])).toEqual([
+      "--listen",
+      "--help",
+    ]);
+    expect(
+      asLegacyAppServerCommand(["--listen", "ws://127.0.0.1:4500"]),
+    ).toEqual(["--listen", "ws://127.0.0.1:4500"]);
+  });
+});

--- a/src/cli/subcommands/server.ts
+++ b/src/cli/subcommands/server.ts
@@ -1,0 +1,125 @@
+import { runAppServerSubcommand } from "@/cli/subcommands/app-server";
+import { runListenSubcommand } from "@/cli/subcommands/listen.tsx";
+
+type ServerCommand =
+  | { kind: "remote"; argv: string[] }
+  | { kind: "app-server"; argv: string[] };
+
+function printServerHelp(): void {
+  console.log(`Usage:
+  letta server [remote options]
+  letta server --listen [url] [App Server options]
+
+Run the local agent server as a remote environment, with messaging channels, or as an App Server.
+
+Remote environment options:
+  --env-name <name>  Friendly name for this environment (uses hostname if not provided)
+  --channels <list>  Comma-separated channel names to enable (e.g. telegram)
+  --install-channel-runtimes  Install missing runtime dependencies for selected channels
+  --debug  Log WebSocket events instead of showing the interactive status UI
+
+App Server options:
+  --listen [url]  Accept App Server connections. If URL is omitted, binds to an available loopback port
+  --ws-auth <mode>  Authentication for non-loopback listeners: capability-token or signed-bearer-token
+  --ws-token-file <path>  Absolute path to the capability-token file
+  --ws-token-sha256 <hex>  Hex-encoded SHA-256 digest of the capability token
+  --ws-shared-secret-file <path>  Absolute path to the shared secret file for signed JWT bearer tokens
+  --ws-issuer <issuer>  Expected issuer for signed JWT bearer tokens
+  --ws-audience <audience>  Expected audience for signed JWT bearer tokens
+  --ws-max-clock-skew-seconds <seconds>  Maximum signed-token clock skew
+
+Common options:
+  -h, --help  Show this help message
+
+Examples:
+  letta server
+  letta server --env-name "work-laptop"
+  letta server --channels telegram
+  letta server --listen
+  letta server --listen ws://127.0.0.1:4500
+  letta server --listen ws://0.0.0.0:4500 --ws-auth capability-token --ws-token-file /path/to/token`);
+}
+
+function isListenOption(arg: string): boolean {
+  return arg === "--listen" || arg.startsWith("--listen=");
+}
+
+export function resolveServerCommand(argv: string[]): ServerCommand {
+  const appServerArgv: string[] = [];
+  let foundListen = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === undefined) break;
+
+    if (!isListenOption(arg)) {
+      appServerArgv.push(arg);
+      continue;
+    }
+
+    if (foundListen) {
+      throw new Error("--listen may only be specified once");
+    }
+    foundListen = true;
+
+    if (arg.startsWith("--listen=")) {
+      const listenUrl = arg.slice("--listen=".length);
+      if (!listenUrl) {
+        throw new Error(
+          "--listen= requires a URL; use bare --listen for an available loopback port",
+        );
+      }
+      appServerArgv.push("--listen", listenUrl);
+      continue;
+    }
+
+    const possibleUrl = argv[index + 1];
+    if (possibleUrl && !possibleUrl.startsWith("-")) {
+      appServerArgv.push("--listen", possibleUrl);
+      index += 1;
+    }
+  }
+
+  if (foundListen) {
+    const conflictingOption = argv.find(
+      (arg) =>
+        arg === "--env-name" ||
+        arg.startsWith("--env-name=") ||
+        arg === "--channels" ||
+        arg.startsWith("--channels="),
+    );
+    if (conflictingOption) {
+      throw new Error(
+        `${conflictingOption.split("=")[0]} cannot be used with --listen`,
+      );
+    }
+    return { kind: "app-server", argv: appServerArgv };
+  }
+
+  return { kind: "remote", argv };
+}
+
+export function asLegacyAppServerCommand(argv: string[]): string[] {
+  return argv.some(isListenOption) ? argv : ["--listen", ...argv];
+}
+
+export async function runServerSubcommand(argv: string[]): Promise<number> {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    printServerHelp();
+    return 0;
+  }
+
+  let command: ServerCommand;
+  try {
+    command = resolveServerCommand(argv);
+  } catch (error) {
+    console.error(error instanceof Error ? `Error: ${error.message}` : error);
+    return 1;
+  }
+
+  if (command.kind === "app-server") {
+    return runAppServerSubcommand(command.argv);
+  }
+
+  return runListenSubcommand(command.argv);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,7 +179,7 @@ USAGE
   letta environments ... List available remote environments (JSON-only)
   letta messages ...    Messages subcommands (JSON-only)
   letta mods ...        List and manage local mods
-  letta app-server ...  Run local app-server websocket transport
+  letta server ...      Run a remote environment, channels, or the App Server
   letta connect ...     Connect providers from terminal
   letta backend ...     Show or set the default backend
   letta setup           Re-run first-run setup
@@ -210,7 +210,7 @@ SUBCOMMANDS
   letta mods enable <package-spec>
   letta mods disable <package-spec>
   letta mods remove <package-spec>
-  letta app-server [--listen ws://127.0.0.1:4500]
+  letta server [--env-name <name> | --listen [url]] [options]
   letta connect <provider> [options]
   letta install <thing> [--agent <id> | -n <name>]
   letta skills list [--agent <id> | -n <name>]


### PR DESCRIPTION
## Summary
- add `letta server --listen [url]` as the App Server mode, with bare `--listen` selecting an available loopback port
- preserve existing remote-environment and channel behavior when `--listen` is absent, with clear validation for incompatible options
- retain `letta app-server` as a deprecated compatibility alias that warns on stderr and delegates to the new command
- update CLI help and cover both routing modes with unit tests

Validated with `bun run check`, targeted subcommand tests, and a live bare-`--listen` startup smoke test.

👾 Generated with [Letta Code](https://letta.com)