### PR TITLE
fix(cli): expose cloud as the backend name

### DIFF
--- a/src/auth/setup-ui.tsx
+++ b/src/auth/setup-ui.tsx
@@ -81,7 +81,7 @@ export function SetupUI({
       settingsManager.updateSettings({ preferredBackendMode: "local" });
       await settingsManager.flush();
       setDoneMessage(
-        "Local mode enabled. Agents you create now will be stored on this device. To sign into Letta Cloud later, run `letta setup` or `letta backend api`.",
+        "Local mode enabled. Agents you create now will be stored on this device. To sign into Letta Cloud later, run `letta setup` or `letta backend cloud`.",
       );
       setMode("done");
       setTimeout(() => onComplete({ kind: "local" }), 500);

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -150,8 +150,9 @@ describe("shared CLI arg schema", () => {
     expect(parsed.values["no-mods"]).toBe(true);
   });
 
-  test("validates backend mode values", () => {
+  test("normalizes cloud backend mode and preserves the api compatibility alias", () => {
     expect(parseBackendModeFlag(undefined)).toBeUndefined();
+    expect(parseBackendModeFlag("cloud")).toBe("api");
     expect(parseBackendModeFlag("api")).toBe("api");
     expect(parseBackendModeFlag("local")).toBe("local");
     expect(() => parseBackendModeFlag("server")).toThrow(
@@ -159,10 +160,14 @@ describe("shared CLI arg schema", () => {
     );
   });
 
-  test("extracts backend flag before routing subcommands", () => {
+  test("extracts and normalizes backend flags before routing subcommands", () => {
     expect(
       extractBackendFlag(["--backend", "local", "connect", "help"]),
     ).toEqual({ backend: "local", args: ["connect", "help"] });
+    expect(extractBackendFlag(["connect", "help", "--backend=cloud"])).toEqual({
+      backend: "api",
+      args: ["connect", "help"],
+    });
     expect(extractBackendFlag(["connect", "help", "--backend=api"])).toEqual({
       backend: "api",
       args: ["connect", "help"],

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -127,7 +127,7 @@ export const CLI_FLAG_CATALOG = {
     mode: "both",
     help: {
       argLabel: "<mode>",
-      description: 'Backend mode: "api" or "local"',
+      description: 'Backend mode: "cloud" or "local"',
     },
   },
   tools: { parser: { type: "string" }, mode: "both" },
@@ -401,9 +401,10 @@ export function parseBackendModeFlag(
   value: string | undefined,
 ): CliBackendMode | undefined {
   if (value === undefined) return undefined;
-  if (value === "api" || value === "local") return value;
+  if (value === "cloud" || value === "api") return "api";
+  if (value === "local") return "local";
   throw new Error(
-    `Invalid --backend value "${value}". Expected "api" or "local".`,
+    `Invalid --backend value "${value}". Expected "cloud" or "local".`,
   );
 }
 
@@ -421,7 +422,7 @@ export function extractBackendFlag(args: string[]): {
       const value = args[index + 1];
       if (value === undefined) {
         throw new Error(
-          'Missing value for --backend. Expected "api" or "local".',
+          'Missing value for --backend. Expected "cloud" or "local".',
         );
       }
       backend = parseBackendModeFlag(value);

--- a/src/cli/commands/mods.test.ts
+++ b/src/cli/commands/mods.test.ts
@@ -59,7 +59,7 @@ describe("/mods command", () => {
 
   test("parses built-in learn target with model options", () => {
     const parsed = parseModsCommand(
-      "/mods learn memory-citations --model current --backend api --candidate-file-name learned.ts",
+      "/mods learn memory-citations --model current --backend cloud --candidate-file-name learned.ts",
       "anthropic/claude-sonnet-4",
     );
 
@@ -67,7 +67,7 @@ describe("/mods command", () => {
     if (parsed?.command !== "learn") return;
     expect(parsed.learn.targetLabel).toBe("memory-citations");
     expect(parsed.learn.options.model).toBe("anthropic/claude-sonnet-4");
-    expect(parsed.learn.options.backend).toBe("api");
+    expect(parsed.learn.options.backend).toBe("cloud");
     expect(parsed.learn.options.candidateFileName).toBe("learned.ts");
     expect(parsed.learn.env?.name).toContain("Memory citation");
   });

--- a/src/cli/commands/mods.ts
+++ b/src/cli/commands/mods.ts
@@ -101,7 +101,7 @@ function formatModsUsage(error?: string): string {
     "  --model <handle>              Model for generation and eval (default: auto)",
     "  --generation-model <handle>   Model for candidate generation",
     "  --eval-model <handle>         Model for headless eval",
-    "  --backend <api|local>          Backend flag forwarded to headless runs",
+    "  --backend <cloud|local>        Backend flag forwarded to headless runs",
     "  --candidate <path>            Evaluate an existing candidate instead of generating",
     "  --candidates <n>              Run N optimization iterations for one learned mod (default: 5)",
     "  --scenario-limit <n>          Evaluate only the first N scenarios (fast smoke testing)",

--- a/src/cli/local-first-setup-wiring.test.ts
+++ b/src/cli/local-first-setup-wiring.test.ts
@@ -21,7 +21,7 @@ describe("local-first setup wiring", () => {
       'settingsManager.updateSettings({ preferredBackendMode: "local" })',
     );
     expect(source).toContain("letta setup");
-    expect(source).toContain("letta backend api");
+    expect(source).toContain("letta backend cloud");
     expect(source).toContain("Agents you create are local to");
     expect(source).toContain("chat.letta.com");
     expect(source).toContain("Welcome to Letta Code");
@@ -184,7 +184,7 @@ describe("local-first setup wiring", () => {
 
     expect(router).toContain('case "backend"');
     expect(router).toContain('case "setup"');
-    expect(backendCommand).toContain("letta backend api");
+    expect(backendCommand).toContain("letta backend cloud");
     expect(backendCommand).toContain("letta backend local");
     expect(backendCommand).toContain("resolveStartupBackendDisplay");
     expect(backendCommand).toContain("Proceed locally selected");

--- a/src/cli/subcommands/backend.ts
+++ b/src/cli/subcommands/backend.ts
@@ -7,12 +7,12 @@ function printUsage(): void {
     `
 Usage:
   letta backend              Show the saved default backend
-  letta backend api          Use Letta Cloud by default
+  letta backend cloud        Use Letta Cloud by default
   letta backend local        Use local mode by default
   letta setup                Re-run the interactive setup menu
 
-Use --backend api or --backend local for a one-off override without changing
-the saved default.
+Use --backend cloud or --backend local for a one-off override without changing
+the saved default. The legacy api name remains supported for compatibility.
 `.trim(),
   );
 }
@@ -21,6 +21,10 @@ type StartupBackendDisplay = CliBackendMode | "setup";
 
 function formatBackendName(mode: CliBackendMode | undefined): string {
   return mode === "local" ? "local mode" : "Letta Cloud";
+}
+
+function formatBackendMode(mode: CliBackendMode): "cloud" | "local" {
+  return mode === "api" ? "cloud" : "local";
 }
 
 async function resolveStartupBackendDisplay(): Promise<StartupBackendDisplay> {
@@ -58,14 +62,16 @@ export async function runBackendSubcommand(argv: string[]): Promise<number> {
     if (mode === "setup") {
       console.log("Default backend: setup menu (Proceed locally selected)");
       console.log(
-        "Run `letta` to choose, or `letta backend api` / `letta backend local` to save a default.",
+        "Run `letta` to choose, or `letta backend cloud` / `letta backend local` to save a default.",
       );
       return 0;
     }
 
-    console.log(`Default backend: ${formatBackendName(mode)} (${mode})`);
     console.log(
-      "Run `letta backend api` or `letta backend local` to change it.",
+      `Default backend: ${formatBackendName(mode)} (${formatBackendMode(mode)})`,
+    );
+    console.log(
+      "Run `letta backend cloud` or `letta backend local` to change it.",
     );
     return 0;
   }
@@ -100,7 +106,7 @@ export async function runBackendSubcommand(argv: string[]): Promise<number> {
     console.log("Agents you create by default will be stored on this device.");
   }
   console.log(
-    "Use `--backend api` or `--backend local` for a one-off override.",
+    "Use `--backend cloud` or `--backend local` for a one-off override.",
   );
 
   return 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -215,7 +215,7 @@ SUBCOMMANDS
   letta install <thing> [--agent <id> | -n <name>]
   letta skills list [--agent <id> | -n <name>]
   letta skills delete <skill_name> --agent <id>
-  letta backend [api|local]
+  letta backend [cloud|local]
   letta local-backend migrate-transcripts [--storage-dir <path>] [--dry-run]
 
 BEHAVIOR


### PR DESCRIPTION
## Summary
- make `cloud` the canonical public value for `--backend` and `letta backend`
- normalize `cloud` to the existing internal API backend mode while retaining `api` as a compatibility alias
- update setup guidance, command output, help text, and focused tests
- pair the CLI terminology change with [letta-docs#81](https://github.com/letta-ai/letta-docs/pull/81)

Validated with `bun run check` and 31 focused tests.

👾 Generated with [Letta Code](https://letta.com)