### PR TITLE
docs: add Cursor Cloud specific setup instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,3 +231,14 @@ also rejects staged parent-relative imports (`../`); use the `@/` alias.
 - **`new URL("./path.ts", import.meta.url)` in tests** is not a static import and is not caught by the `@/` import codemod. Scan for `new URL(` manually when moving source files.
 - **grep exits 1 on no matches** — pre-commit hooks use `|| true` on grep pipes to prevent false failures on clean commits.
 - **macOS case-insensitive FS** — `existsSync("bash.ts")` returns `true` when `Bash.ts` exists. Rename scripts that use `existsSync` to check kebab-case targets will silently skip single-word PascalCase files. Use `git mv` for renames.
+
+---
+
+## Cursor Cloud specific instructions
+
+These notes are for cloud agents running in the pre-provisioned VM. Standard commands live in the **Reference** section above; only non-obvious caveats are captured here.
+
+- **Runtime is Bun, not Node.** `bun` is pre-installed (v1.3.0, symlinked at `/usr/local/bin/bun`) and the startup update script runs `bun install`. The base image's `node` is 22.14.0, below `engines.node >=22.19.0`, but this does **not** block dev/lint/test/run because everything goes through Bun. Don't waste time "fixing" the Node version.
+- **No OS keychain / secret-service.** The VM is headless, so the CLI logs `[secrets] WARN: System secrets not available - using fallback storage` on every run. This is expected. Credentials come from env vars/secrets (`LETTA_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`), not the keychain.
+- **`node scripts/run-unit-tests.cjs` does not finish cleanly here.** ~11 environment-sensitive tests time out or hang — those that spawn CLI/bun subprocesses or do git-worktree ops (hooks e2e, headless-subagent, reflection worktrees, `assertMemoryRepoCleanForWrite`, `memory_apply_patch`) or hit the OS keychain (`src/utils/secrets.test.ts`). ~3900+ other tests pass. For a fast, reliable green signal run specific leaf suites, e.g. `bun test src/permissions src/types src/reminders`. Failures in those spawn/keychain suites are env artifacts, not regressions.
+- **End-to-end sanity check** (needs `LETTA_API_KEY`, connects to Letta Cloud): `bun run dev --new-agent --personality tutorial -p "hello" --output-format text` creates an agent and prints its reply. The interactive TUI is `bun run dev`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for Letta Code in the Cursor Cloud VM, and documents non-obvious cloud caveats for future agents.

The only code change is an additive `## Cursor Cloud specific instructions` section in `AGENTS.md`. No application code was modified.

## Environment setup

- Installed Bun `1.3.0` (the repo's `packageManager`), symlinked to `/usr/local/bin/bun`.
- Ran `bun install` (518 packages).
- Startup update script: `bun install`.

## Verification

| Step | Command | Result |
|------|---------|--------|
| Lint | `bun run lint` | pass (6 warnings, exit 0) |
| Typecheck | `bun run typecheck` (`tsc --noEmit`) | pass |
| Unit tests | `bun test src/permissions src/types src/reminders` | 559 pass, 0 fail |
| Full runner | `node scripts/run-unit-tests.cjs` | 3919 pass; 11 env-sensitive timeouts (subprocess/git-worktree/keychain) documented in AGENTS.md |
| Dev run (headless) | `bun run dev --new-agent --personality tutorial -p "..."` | agent replied end-to-end via Letta Cloud |
| Dev run (interactive TUI) | `bun run dev` | agent replied "I'm working — and the capital of France is Paris." |

## Notes for future cloud agents (in AGENTS.md)

- Runtime is Bun, not Node; base-image Node is 22.14.0 but doesn't block anything.
- Headless VM has no OS keychain → expected `[secrets] WARN: System secrets not available` log.
- `scripts/run-unit-tests.cjs` hangs on subprocess/keychain suites; use targeted `bun test <dir>` for a fast green signal.

[letta_code_interactive_tui_demo.mp4](https://cursor.com/agents/bc-569a5216-8802-47a5-b257-b80b39436e46/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fletta_code_interactive_tui_demo.mp4)
[Agent response in TUI](https://cursor.com/agents/bc-569a5216-8802-47a5-b257-b80b39436e46/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fletta_tui_agent_response.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-569a5216-8802-47a5-b257-b80b39436e46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-569a5216-8802-47a5-b257-b80b39436e46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

