### PR TITLE
fix(auth): handle transient OAuth responses

### DIFF
--- a/src/auth/oauth-network-errors.test.ts
+++ b/src/auth/oauth-network-errors.test.ts
@@ -14,6 +14,35 @@ function makeFetchFailure(message: string, code?: string): Error {
   return new TypeError("fetch failed", { cause });
 }
 
+function makeHtmlGatewayError(headers?: Record<string, string>): Response {
+  return new Response(
+    "<!DOCTYPE html><html><title>Bad Gateway body marker</title></html>",
+    {
+      status: 502,
+      headers: {
+        "Content-Type": "text/html; charset=utf-8",
+        ...headers,
+      },
+    },
+  );
+}
+
+function makeJsonTransientError(headers?: Record<string, string>): Response {
+  return new Response(
+    JSON.stringify({
+      error: "temporarily_unavailable",
+      error_description: "JSON transient body marker",
+    }),
+    {
+      status: 503,
+      headers: {
+        "Content-Type": "application/json",
+        ...headers,
+      },
+    },
+  );
+}
+
 afterEach(() => {
   globalThis.fetch = originalFetch;
 });
@@ -38,6 +67,160 @@ describe("OAuth network errors", () => {
         "Check your network, DNS, proxy, VPN, or TLS settings.",
       );
     }
+  });
+
+  test("requestDeviceCode retries non-JSON server responses before actionable error", async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(makeHtmlGatewayError({ "cf-ray": "abc123-SJC" })),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    let failure: unknown;
+    try {
+      await requestDeviceCode();
+    } catch (error) {
+      failure = error;
+    }
+
+    const message =
+      failure instanceof Error ? failure.message : String(failure);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(message).toContain(
+      "Failed to request device code from app.letta.com",
+    );
+    expect(message).toContain("HTTP 502");
+    expect(message).toContain("media type text/html");
+    expect(message).toContain("request id cf-ray=abc123-SJC");
+    expect(message).toContain("Try again later");
+    expect(message).not.toContain("<!DOCTYPE");
+    expect(message).not.toContain("Bad Gateway body marker");
+    expect(message).not.toContain("Unexpected token");
+  });
+
+  test("requestDeviceCode retries JSON 5xx before safe actionable error", async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(makeJsonTransientError({ "x-request-id": "req-503" })),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    let failure: unknown;
+    try {
+      await requestDeviceCode();
+    } catch (error) {
+      failure = error;
+    }
+
+    const message =
+      failure instanceof Error ? failure.message : String(failure);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(message).toContain(
+      "Failed to request device code from app.letta.com",
+    );
+    expect(message).toContain("received transient OAuth response");
+    expect(message).toContain("HTTP 503");
+    expect(message).toContain("media type application/json");
+    expect(message).toContain("request id x-request-id=req-503");
+    expect(message).not.toContain("temporarily_unavailable");
+    expect(message).not.toContain("JSON transient body marker");
+  });
+
+  test("pollForToken recovers from bounded transient response failures", async () => {
+    let calls = 0;
+    const fetchMock = mock(() => {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.resolve(makeHtmlGatewayError());
+      }
+
+      if (calls === 2) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: "authorization_pending" }), {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+
+      if (calls === 3 || calls === 4) {
+        return Promise.resolve(makeJsonTransientError());
+      }
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            access_token: "access-token",
+            refresh_token: "refresh-token",
+            token_type: "Bearer",
+            expires_in: 3600,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      pollForToken("device-code", 0, 60, "device-id"),
+    ).resolves.toMatchObject({ access_token: "access-token" });
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+
+  test("pollForToken bounds persistent non-JSON response failures", async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(
+        makeHtmlGatewayError({ "x-vercel-id": "sfo1::iad1::oauth123" }),
+      ),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    let failure: unknown;
+    try {
+      await pollForToken("device-code", 0, 60, "device-id");
+    } catch (error) {
+      failure = error;
+    }
+
+    const message =
+      failure instanceof Error ? failure.message : String(failure);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(message).toContain(
+      "Failed to poll for OAuth token from app.letta.com",
+    );
+    expect(message).toContain("HTTP 502");
+    expect(message).toContain("media type text/html");
+    expect(message).toContain("request id x-vercel-id=sfo1::iad1::oauth123");
+    expect(message).not.toContain("<!DOCTYPE");
+    expect(message).not.toContain("Bad Gateway body marker");
+    expect(message).not.toContain("Unexpected token");
+  });
+
+  test("pollForToken bounds persistent JSON transient response failures", async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(
+        makeJsonTransientError({ "x-request-id": "poll-json-503" }),
+      ),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    let failure: unknown;
+    try {
+      await pollForToken("device-code", 0, 60, "device-id");
+    } catch (error) {
+      failure = error;
+    }
+
+    const message =
+      failure instanceof Error ? failure.message : String(failure);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(message).toContain(
+      "Failed to poll for OAuth token from app.letta.com",
+    );
+    expect(message).toContain("received transient OAuth response");
+    expect(message).toContain("HTTP 503");
+    expect(message).toContain("media type application/json");
+    expect(message).toContain("request id x-request-id=poll-json-503");
+    expect(message).not.toContain("temporarily_unavailable");
+    expect(message).not.toContain("JSON transient body marker");
   });
 
   test("pollForToken explains that browser auth may have succeeded", async () => {

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -147,6 +147,120 @@ function extractOAuthTransportDetail(error: Error): string | null {
   return detail;
 }
 
+const DEVICE_CODE_REQUEST_MAX_ATTEMPTS = 2;
+const DEVICE_CODE_RETRY_DELAY_MS = 100;
+const TOKEN_POLL_RESPONSE_FAILURE_LIMIT = 2;
+const OAUTH_REQUEST_ID_HEADERS = [
+  "cf-ray",
+  "x-request-id",
+  "x-vercel-id",
+] as const;
+
+class OAuthTransientResponseError extends Error {
+  readonly responseKind: "malformed JSON" | "non-JSON" | "transient HTTP";
+  readonly status: number;
+
+  constructor(
+    action: string,
+    response: Response,
+    responseKind: "malformed JSON" | "non-JSON" | "transient HTTP",
+  ) {
+    const mediaType = getOAuthResponseMediaType(response);
+    const requestId = getOAuthResponseRequestId(response);
+    const mediaTypeText = mediaType ? `, media type ${mediaType}` : "";
+    const requestIdText = requestId ? `, request id ${requestId}` : "";
+    const supportHint = requestId
+      ? "Try again later; if this persists, contact Letta support with this request ID."
+      : "Try again later; if this persists, contact Letta support.";
+    const responseDescription =
+      responseKind === "transient HTTP"
+        ? "transient OAuth response"
+        : `${responseKind} OAuth response`;
+
+    super(
+      `Failed to ${action} from ${getOAuthAuthHost()}: received ${responseDescription} (HTTP ${response.status}${mediaTypeText}${requestIdText}). ${supportHint}`,
+    );
+    this.name = "OAuthTransientResponseError";
+    this.responseKind = responseKind;
+    this.status = response.status;
+  }
+}
+
+function getOAuthResponseMediaType(response: Response): string | null {
+  const contentType = response.headers.get("content-type")?.trim();
+  if (!contentType) {
+    return null;
+  }
+
+  return contentType.split(";", 1)[0]?.trim().toLowerCase() || null;
+}
+
+function isOAuthJsonMediaType(mediaType: string): boolean {
+  return mediaType === "application/json" || mediaType.endsWith("+json");
+}
+
+function sanitizeOAuthRequestId(value: string | null): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const sanitized = trimmed.replace(/[^A-Za-z0-9._:-]/g, "").slice(0, 128);
+  return sanitized.length > 0 ? sanitized : null;
+}
+
+function getOAuthResponseRequestId(response: Response): string | null {
+  for (const header of OAUTH_REQUEST_ID_HEADERS) {
+    const value = sanitizeOAuthRequestId(response.headers.get(header));
+    if (value) {
+      return `${header}=${value}`;
+    }
+  }
+
+  return null;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+function isTransientOAuthResponseStatus(status: number): boolean {
+  return status === 408 || status === 429 || status >= 500;
+}
+
+async function cancelOAuthResponseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Best-effort only: never read or surface the body in OAuth errors.
+  }
+}
+
+async function parseOAuthJsonResponse(
+  response: Response,
+  action: string,
+): Promise<unknown> {
+  const mediaType = getOAuthResponseMediaType(response);
+  if (mediaType && !isOAuthJsonMediaType(mediaType)) {
+    await cancelOAuthResponseBody(response);
+    throw new OAuthTransientResponseError(action, response, "non-JSON");
+  }
+
+  try {
+    return await response.json();
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw error;
+    }
+
+    throw new OAuthTransientResponseError(action, response, "malformed JSON");
+  }
+}
+
+function waitForOAuthRetry(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function toOAuthActionError(
   action: string,
   error: unknown,
@@ -176,29 +290,59 @@ function toOAuthActionError(
  */
 export async function requestDeviceCode(): Promise<DeviceCodeResponse> {
   const authHost = getOAuthAuthHost();
-  try {
-    const response = await fetch(
-      `${OAUTH_CONFIG.authBaseUrl}/api/oauth/device/code`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          client_id: OAUTH_CONFIG.clientId,
-        }),
-      },
-    );
 
-    if (!response.ok) {
-      const error = (await response.json()) as OAuthError;
-      throw new Error(
-        `Failed to request device code from ${authHost}: ${error.error_description || error.error}`,
+  for (
+    let attempt = 1;
+    attempt <= DEVICE_CODE_REQUEST_MAX_ATTEMPTS;
+    attempt++
+  ) {
+    try {
+      const response = await fetch(
+        `${OAUTH_CONFIG.authBaseUrl}/api/oauth/device/code`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            client_id: OAUTH_CONFIG.clientId,
+          }),
+        },
       );
-    }
 
-    return (await response.json()) as DeviceCodeResponse;
-  } catch (error) {
-    throw toOAuthActionError("request device code", error);
+      const result = await parseOAuthJsonResponse(
+        response,
+        "request device code",
+      );
+
+      if (!response.ok) {
+        if (isTransientOAuthResponseStatus(response.status)) {
+          throw new OAuthTransientResponseError(
+            "request device code",
+            response,
+            "transient HTTP",
+          );
+        }
+
+        const error = result as OAuthError;
+        throw new Error(
+          `Failed to request device code from ${authHost}: ${error.error_description || error.error}`,
+        );
+      }
+
+      return result as DeviceCodeResponse;
+    } catch (error) {
+      if (
+        error instanceof OAuthTransientResponseError &&
+        attempt < DEVICE_CODE_REQUEST_MAX_ATTEMPTS
+      ) {
+        await waitForOAuthRetry(DEVICE_CODE_RETRY_DELAY_MS);
+        continue;
+      }
+
+      throw toOAuthActionError("request device code", error);
+    }
   }
+
+  throw new Error("Failed to request device code from unreachable OAuth path");
 }
 
 /**
@@ -215,6 +359,7 @@ export async function pollForToken(
   const startTime = Date.now();
   const expiresInMs = expiresIn * 1000;
   let pollInterval = interval * 1000;
+  let consecutiveResponseFailures = 0;
 
   const sleep = async (ms: number) => {
     if (!signal) {
@@ -266,7 +411,10 @@ export async function pollForToken(
         },
       );
 
-      const result = await response.json();
+      const result = await parseOAuthJsonResponse(
+        response,
+        "poll for OAuth token",
+      );
 
       if (response.ok) {
         return result as TokenResponse;
@@ -276,12 +424,14 @@ export async function pollForToken(
 
       if (error.error === "authorization_pending") {
         // User hasn't authorized yet, keep polling
+        consecutiveResponseFailures = 0;
         continue;
       }
 
       if (error.error === "slow_down") {
         // We're polling too fast, increase interval by 5 seconds
         pollInterval += 5000;
+        consecutiveResponseFailures = 0;
         continue;
       }
 
@@ -293,8 +443,23 @@ export async function pollForToken(
         throw new Error("Device code expired");
       }
 
+      if (isTransientOAuthResponseStatus(response.status)) {
+        throw new OAuthTransientResponseError(
+          "poll for OAuth token",
+          response,
+          "transient HTTP",
+        );
+      }
+
       throw new Error(`OAuth error: ${error.error_description || error.error}`);
     } catch (error) {
+      if (error instanceof OAuthTransientResponseError) {
+        consecutiveResponseFailures += 1;
+        if (consecutiveResponseFailures <= TOKEN_POLL_RESPONSE_FAILURE_LIMIT) {
+          continue;
+        }
+      }
+
       trackBoundaryError({
         errorType: "oauth_token_poll_failed",
         error,


### PR DESCRIPTION
## Problem

The `/login` device flow assumed every OAuth response was JSON. When an edge or upstream service returned an HTML error page, the CLI exposed the parser exception (`Unexpected token '<'`) instead of the HTTP failure.

## What changed

- Parse device-code and token-poll responses defensively without surfacing response bodies.
- Include only safe diagnostics: auth host, HTTP status, media type, and a sanitized request ID when available.
- Retry device-code creation once and tolerate two consecutive transient token-poll responses before showing the actionable error.
- Preserve `authorization_pending`, `slow_down`, denial, expiry, timeout, transport-error, and cancellation behavior.

## Scope and risk

This is client defense-in-depth for the login device flow; it does not claim to identify or fix the transient upstream HTML producer. Refresh and revoke paths are unchanged. A retried device-code request can leave one unused short-lived code if the first request succeeded upstream but its response was corrupted.

## Validation

- `bun test src/auth/oauth-network-errors.test.ts` — 12 passed
- `bun run check` — 12/12 checks passed
- The five new regression cases fail against `origin/main` and pass on this branch.
- Real TUI fault injection: two HTML `502 text/html` device-code responses triggered one bounded retry, then rendered the safe HTTP/media/request-ID error; the response-body sentinel and raw parser text were absent.
- Full `bun test` — 5,267 passed, 26 skipped; 12 unrelated environment/existing failures. Eleven reproduced on the base commit, and the remaining API parity probe passed on rerun.

Linear: [LET-9888](https://linear.app/letta/issue/LET-9888/tui-login-exposes-raw-html-json-parse-errors-instead-of-an-actionable)

