### PR TITLE
feat(channels): allow explicit Discord bot handoffs

### DIFF
--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -13,6 +13,7 @@ import {
   getChannelSecret,
   setChannelSecret,
 } from "./credential-store";
+import { normalizeDiscordAllowBotsMode } from "./discord/bot-policy";
 import { normalizeSlackAllowBotsMode } from "./slack/bot-policy";
 import type {
   ChannelAccount,
@@ -328,6 +329,9 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
     );
     (next as DiscordChannelAccount).defaultPermissionMode =
       (migrated as ChannelDefaultPermissionMode | null) ?? "standard";
+    (next as DiscordChannelAccount).allowBots = normalizeDiscordAllowBotsMode(
+      (next as DiscordChannelAccount).allowBots,
+    );
 
     // Compatibility migration: existing accounts created before this field was
     // persisted auto-threaded on mentions by default. Keep that behavior for
@@ -404,6 +408,7 @@ function makeDefaultLegacyAccount(
         : undefined,
       autoThreadOnMention: config.autoThreadOnMention ?? true,
       threadPolicyByChannel: config.threadPolicyByChannel,
+      allowBots: config.allowBots ?? false,
       agentId: null,
       defaultPermissionMode: config.defaultPermissionMode ?? "standard",
       createdAt: now,

--- a/src/channels/config.ts
+++ b/src/channels/config.ts
@@ -9,6 +9,10 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { migratePermissionMode } from "@/permissions/mode";
+import {
+  isValidDiscordAllowBotsConfigValue,
+  normalizeDiscordAllowBotsMode,
+} from "./discord/bot-policy";
 import { normalizeSlackAllowBotsMode } from "./slack/bot-policy";
 import type {
   ChannelConfig,
@@ -198,6 +202,10 @@ function parseSignalGroupMode(value: unknown): SignalGroupMode {
 
 const discordConfigCodec: ChannelConfigCodec<DiscordChannelConfig> = {
   parse(parsed) {
+    if (!isValidDiscordAllowBotsConfigValue(parsed.allow_bots)) {
+      throw new Error("Invalid Discord allow_bots config");
+    }
+
     const rawAllowedChannels = parsed.allowed_channels;
     let allowedChannels: DiscordChannelConfig["allowedChannels"];
     if (Array.isArray(rawAllowedChannels)) {
@@ -222,6 +230,7 @@ const discordConfigCodec: ChannelConfigCodec<DiscordChannelConfig> = {
       dmPolicy: (parsed.dm_policy as DmPolicy) ?? "pairing",
       allowedUsers: (parsed.allowed_users as string[]) ?? [],
       allowedChannels,
+      allowBots: normalizeDiscordAllowBotsMode(parsed.allow_bots),
       transcribeVoice: parsed.transcribe_voice === true,
       autoThreadOnMention:
         typeof parsed.auto_thread_on_mention === "boolean"

--- a/src/channels/discord-config.test.ts
+++ b/src/channels/discord-config.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  __testOverrideChannelsRoot,
+  readChannelConfig,
+} from "@/channels/config";
+
+let root: string | null = null;
+
+function clearRoot(): void {
+  __testOverrideChannelsRoot(null);
+  if (root) {
+    rmSync(root, { recursive: true, force: true });
+    root = null;
+  }
+}
+
+afterEach(() => {
+  clearRoot();
+});
+
+function writeDiscordConfig(lines: string[]): void {
+  clearRoot();
+  root = mkdtempSync(join(tmpdir(), "discord-config-"));
+  const discordDir = join(root, "discord");
+  mkdirSync(discordDir, { recursive: true });
+  writeFileSync(join(discordDir, "config.yaml"), `${lines.join("\n")}\n`);
+  __testOverrideChannelsRoot(root);
+}
+
+describe("Discord channel config", () => {
+  test("loads guarded bot ingress mode from legacy yaml config", () => {
+    writeDiscordConfig([
+      "enabled: true",
+      "token: discord-token",
+      "dm_policy: pairing",
+      "allow_bots: mentions",
+    ]);
+
+    expect(readChannelConfig("discord")).toEqual(
+      expect.objectContaining({
+        channel: "discord",
+        allowBots: "mentions",
+      }),
+    );
+  });
+
+  test("rejects unsafe bot ingress modes from legacy yaml config", () => {
+    for (const rawValue of ["true", "all"]) {
+      writeDiscordConfig([
+        "enabled: true",
+        "token: discord-token",
+        `allow_bots: ${rawValue}`,
+      ]);
+
+      expect(readChannelConfig("discord")).toBeNull();
+    }
+  });
+});

--- a/src/channels/discord-service.test.ts
+++ b/src/channels/discord-service.test.ts
@@ -35,6 +35,7 @@ import {
   __testOverrideSaveTargetStore,
   clearTargetStores,
 } from "@/channels/targets";
+import type { DiscordChannelAccount } from "@/channels/types";
 import { isDiscordChannelAccount } from "@/channels/types";
 
 describe("discord channel service", () => {
@@ -585,5 +586,89 @@ describe("discord channel service", () => {
     expect(saved?.thread_policy_by_channel).toEqual({ "channel-gamma": false });
     // Should NOT have threadPolicyByChannel (camelCase)
     expect(saved?.threadPolicyByChannel).toBeUndefined();
+  });
+
+  test("live account helpers preserve bot ingress settings in snapshots", () => {
+    const created = createChannelAccountLive(
+      "discord",
+      {
+        displayName: "Discord Main",
+        enabled: true,
+        dmPolicy: "pairing",
+        config: {
+          token: "discord-token",
+          agent_id: null,
+          allowed_channels: { "channel-open": "open" },
+          allow_bots: "mentions",
+        },
+      },
+      { accountId: "discord-main" },
+    );
+
+    expect(created).toEqual(
+      expect.objectContaining({
+        accountId: "discord-main",
+        allowBots: "mentions",
+        config: expect.objectContaining({
+          allow_bots: "mentions",
+        }),
+      }),
+    );
+
+    const updated = updateChannelAccountLive("discord", "discord-main", {
+      config: {
+        allow_bots: false,
+      },
+    });
+
+    expect(updated).toEqual(
+      expect.objectContaining({
+        accountId: "discord-main",
+        allowBots: false,
+        config: expect.objectContaining({
+          allow_bots: false,
+        }),
+      }),
+    );
+
+    expect(getChannelConfigSnapshot("discord", "discord-main")).toEqual(
+      expect.objectContaining({
+        accountId: "discord-main",
+        allowBots: false,
+        config: expect.objectContaining({
+          allow_bots: false,
+        }),
+      }),
+    );
+  });
+
+  test("loaded accounts normalize persisted allow_bots settings", () => {
+    clearChannelAccountStores();
+    __testOverrideLoadChannelAccounts(() => [
+      {
+        channel: "discord",
+        accountId: "persisted-discord",
+        displayName: "Persisted Discord",
+        enabled: true,
+        token: "discord-token",
+        agentId: null,
+        defaultPermissionMode: "standard",
+        dmPolicy: "pairing",
+        allowedUsers: [],
+        allowedChannels: [],
+        allow_bots: "mentions",
+        createdAt: "2026-07-20T00:00:00.000Z",
+        updatedAt: "2026-07-20T00:00:00.000Z",
+      } as unknown as DiscordChannelAccount,
+    ]);
+    __testOverrideSaveChannelAccounts(() => {});
+
+    expect(getChannelAccountSnapshot("discord", "persisted-discord")).toEqual(
+      expect.objectContaining({
+        accountId: "persisted-discord",
+        allowBots: "mentions",
+        config: expect.objectContaining({ allow_bots: "mentions" }),
+      }),
+    );
   });
 });

--- a/src/channels/discord/account-config.test.ts
+++ b/src/channels/discord/account-config.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import type { DiscordChannelAccount } from "@/channels/types";
+import { discordAccountConfigAdapter } from "./account-config";
+
+function makeDiscordAccount(
+  overrides: Partial<DiscordChannelAccount> = {},
+): DiscordChannelAccount {
+  return {
+    channel: "discord",
+    accountId: "discord-main",
+    displayName: "Discord Main",
+    enabled: true,
+    token: "discord-token",
+    agentId: null,
+    defaultPermissionMode: "standard",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+    allowedChannels: { "channel-open": "open" },
+    autoThreadOnMention: false,
+    threadPolicyByChannel: {},
+    acknowledgeMessageReaction: false,
+    removeStaleRoutes: false,
+    allowBots: false,
+    createdAt: "2026-07-20T00:00:00.000Z",
+    updatedAt: "2026-07-20T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("discordAccountConfigAdapter", () => {
+  test("accepts only the guarded allow_bots modes", () => {
+    expect(
+      discordAccountConfigAdapter.isValidConfig({ allow_bots: false }),
+    ).toBe(true);
+    expect(
+      discordAccountConfigAdapter.isValidConfig({ allow_bots: "mentions" }),
+    ).toBe(true);
+
+    expect(
+      discordAccountConfigAdapter.isValidConfig({ allow_bots: true }),
+    ).toBe(false);
+    expect(
+      discordAccountConfigAdapter.isValidConfig({ allow_bots: "all" }),
+    ).toBe(false);
+    expect(
+      discordAccountConfigAdapter.isValidConfig({ allow_bots: null }),
+    ).toBe(false);
+  });
+
+  test("round-trips allow_bots through account patches and snapshots", () => {
+    expect(
+      discordAccountConfigAdapter.toAccountPatch({ allow_bots: "mentions" }),
+    ).toEqual(expect.objectContaining({ allowBots: "mentions" }));
+    expect(
+      discordAccountConfigAdapter.toAccountPatch({ allow_bots: false }),
+    ).toEqual(expect.objectContaining({ allowBots: false }));
+
+    expect(
+      discordAccountConfigAdapter.toAccountConfig(
+        makeDiscordAccount({ allowBots: "mentions" }),
+      ),
+    ).toEqual(expect.objectContaining({ allow_bots: "mentions" }));
+    expect(
+      discordAccountConfigAdapter.toConfigSnapshotConfig(makeDiscordAccount()),
+    ).toEqual(expect.objectContaining({ allow_bots: false }));
+  });
+});

--- a/src/channels/discord/account-config.ts
+++ b/src/channels/discord/account-config.ts
@@ -5,11 +5,16 @@ import type {
   DiscordChannelMode,
 } from "@/channels/types";
 import { migratePermissionMode } from "@/permissions/mode";
+import {
+  isValidDiscordAllowBotsConfigValue,
+  normalizeDiscordAllowBotsMode,
+} from "./bot-policy";
 
 const DISCORD_CONFIG_KEYS = new Set([
   "token",
   "agent_id",
   "allowed_channels",
+  "allow_bots",
   "default_permission_mode",
   "transcribe_voice",
   "auto_thread_on_mention",
@@ -105,6 +110,8 @@ export const discordAccountConfigAdapter: ChannelAccountConfigAdapter<DiscordCha
         (config.agent_id === undefined || isNullableString(config.agent_id)) &&
         (config.allowed_channels === undefined ||
           isAllowedChannels(config.allowed_channels)) &&
+        (config.allow_bots === undefined ||
+          isValidDiscordAllowBotsConfigValue(config.allow_bots)) &&
         (config.default_permission_mode === undefined ||
           isDefaultPermissionMode(config.default_permission_mode)) &&
         (config.transcribe_voice === undefined ||
@@ -150,6 +157,11 @@ export const discordAccountConfigAdapter: ChannelAccountConfigAdapter<DiscordCha
             ) as ChannelDefaultPermissionMode)
           : undefined,
         allowedChannels,
+        allowBots:
+          config.allow_bots !== undefined &&
+          isValidDiscordAllowBotsConfigValue(config.allow_bots)
+            ? normalizeDiscordAllowBotsMode(config.allow_bots)
+            : undefined,
         transcribeVoice: isBoolean(config.transcribe_voice)
           ? config.transcribe_voice
           : undefined,
@@ -184,6 +196,7 @@ export const discordAccountConfigAdapter: ChannelAccountConfigAdapter<DiscordCha
         agent_id: account.agentId,
         default_permission_mode: account.defaultPermissionMode ?? "standard",
         allowed_channels: serializeAllowedChannels(account.allowedChannels),
+        allow_bots: account.allowBots ?? false,
         transcribe_voice: account.transcribeVoice === true,
         auto_thread_on_mention: account.autoThreadOnMention ?? false,
         thread_policy_by_channel: account.threadPolicyByChannel ?? {},
@@ -200,6 +213,7 @@ export const discordAccountConfigAdapter: ChannelAccountConfigAdapter<DiscordCha
         agent_id: account.agentId,
         default_permission_mode: account.defaultPermissionMode ?? "standard",
         allowed_channels: serializeAllowedChannels(account.allowedChannels),
+        allow_bots: account.allowBots ?? false,
         transcribe_voice: account.transcribeVoice === true,
         auto_thread_on_mention: account.autoThreadOnMention ?? false,
         thread_policy_by_channel: account.threadPolicyByChannel ?? {},

--- a/src/channels/discord/adapter.ts
+++ b/src/channels/discord/adapter.ts
@@ -8,6 +8,10 @@ import type {
   OutboundChannelMessage,
 } from "@/channels/types";
 import {
+  hasExplicitDiscordUserMention,
+  shouldAcceptDiscordInboundBotMessage,
+} from "./bot-policy";
+import {
   isDiscordGuildChannelAllowed,
   resolveDiscordChannelMode,
 } from "./channel-gating";
@@ -487,16 +491,27 @@ export function createDiscordAdapter(
       client.on("messageCreate", async (message: DiscordMessage) => {
         if (!adapter.onMessage) return;
 
-        // Ignore bot messages (including self)
-        if (message.author.bot) return;
-
         const content = (message.content ?? "").trim();
         const userId = message.author.id;
         if (!userId) return;
 
+        const effectiveBotUserId = botUserId ?? client?.user?.id ?? null;
         const chatType = resolveDiscordChatType(message.guildId);
         const isThread = isThreadMessage(message);
         const wasMentioned = chatType === "channel" && hasBotMention(message);
+        if (
+          !shouldAcceptDiscordInboundBotMessage({
+            message,
+            allowBots: config.allowBots,
+            botUserId: effectiveBotUserId,
+            wasExplicitlyMentioned: hasExplicitDiscordUserMention(
+              message,
+              effectiveBotUserId,
+            ),
+          })
+        ) {
+          return;
+        }
 
         // ── DM handling ──────────────────────────────────────────
         if (chatType === "direct") {
@@ -528,7 +543,9 @@ export function createDiscordAdapter(
             await adapter.onMessage(inbound);
           } catch (error) {
             console.error("[Discord] Error handling DM:", error);
-            await notifyDiscordDeliveryError(message, error);
+            if (!message.author.bot) {
+              await notifyDiscordDeliveryError(message, error);
+            }
           }
           return;
         }
@@ -624,7 +641,9 @@ export function createDiscordAdapter(
           await adapter.onMessage(inbound);
         } catch (error) {
           console.error("[Discord] Error handling guild message:", error);
-          await notifyDiscordDeliveryError(message, error);
+          if (!message.author.bot) {
+            await notifyDiscordDeliveryError(message, error);
+          }
         }
       });
 

--- a/src/channels/discord/adapter.ts
+++ b/src/channels/discord/adapter.ts
@@ -498,16 +498,16 @@ export function createDiscordAdapter(
         const effectiveBotUserId = botUserId ?? client?.user?.id ?? null;
         const chatType = resolveDiscordChatType(message.guildId);
         const isThread = isThreadMessage(message);
-        const wasMentioned = chatType === "channel" && hasBotMention(message);
+        const hasParsedBotMention = hasBotMention(message);
+        const wasMentioned = chatType === "channel" && hasParsedBotMention;
         if (
           !shouldAcceptDiscordInboundBotMessage({
             message,
             allowBots: config.allowBots,
             botUserId: effectiveBotUserId,
-            wasExplicitlyMentioned: hasExplicitDiscordUserMention(
-              message,
-              effectiveBotUserId,
-            ),
+            wasExplicitlyMentioned:
+              hasParsedBotMention &&
+              hasExplicitDiscordUserMention(message, effectiveBotUserId),
           })
         ) {
           return;

--- a/src/channels/discord/bot-ingress.test.ts
+++ b/src/channels/discord/bot-ingress.test.ts
@@ -1,0 +1,426 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createDiscordAdapter } from "@/channels/discord/adapter";
+import { __testOverrideLoadDiscordModule } from "@/channels/discord/runtime";
+import type {
+  ChannelAdapter,
+  DiscordChannelAccount,
+  InboundChannelMessage,
+} from "@/channels/types";
+
+interface DiscordTestMessage {
+  id: string;
+  content: string;
+  channelId: string;
+  guildId: string | null;
+  author: {
+    id: string;
+    username: string;
+    globalName: string;
+    bot: boolean;
+  };
+  member: { displayName: string };
+  channel: {
+    name: string;
+    parentId: string | null;
+    isThread: () => boolean;
+    send?: (options: unknown) => Promise<{ id: string }>;
+  };
+  mentions: { has: (user: unknown) => boolean };
+  attachments: Map<string, never>;
+  createdTimestamp: number;
+}
+
+class FakeDiscordClient {
+  static instances: FakeDiscordClient[] = [];
+
+  readonly user = {
+    id: "bot-user",
+    username: "Loop",
+    tag: "Loop#0001",
+    bot: true,
+  };
+
+  readonly login = mock(async (_token: string) => {
+    await this.onceHandlers.get("ready")?.();
+  });
+  readonly destroy = mock(() => {});
+  private readonly handlers = new Map<
+    string,
+    (...args: unknown[]) => unknown
+  >();
+  private readonly onceHandlers = new Map<
+    string,
+    (...args: unknown[]) => unknown
+  >();
+
+  constructor(_options: { intents: unknown[]; partials?: unknown[] }) {
+    FakeDiscordClient.instances.push(this);
+  }
+
+  once(event: string, handler: (...args: unknown[]) => unknown): this {
+    this.onceHandlers.set(event, handler);
+    return this;
+  }
+
+  on(event: string, handler: (...args: unknown[]) => unknown): this {
+    this.handlers.set(event, handler);
+    return this;
+  }
+
+  async emitMessageCreate(message: DiscordTestMessage): Promise<void> {
+    const handler = this.handlers.get("messageCreate");
+    if (!handler) {
+      throw new Error("messageCreate handler was not registered");
+    }
+    await handler(message);
+  }
+}
+
+function createFakeDiscordRuntime() {
+  return {
+    Client: FakeDiscordClient,
+    GatewayIntentBits: {
+      Guilds: "Guilds",
+      GuildMessages: "GuildMessages",
+      GuildMessageReactions: "GuildMessageReactions",
+      MessageContent: "MessageContent",
+      DirectMessages: "DirectMessages",
+      DirectMessageReactions: "DirectMessageReactions",
+    },
+    Partials: {
+      Channel: "Channel",
+      Message: "Message",
+      Reaction: "Reaction",
+      User: "User",
+    },
+  };
+}
+
+const discordAccountDefaults: Omit<DiscordChannelAccount, "allowedChannels"> = {
+  channel: "discord",
+  accountId: "discord-bot",
+  enabled: true,
+  token: "discord-token",
+  agentId: "agent-1",
+  defaultPermissionMode: "standard",
+  dmPolicy: "pairing",
+  allowedUsers: [],
+  createdAt: "2026-04-11T00:00:00.000Z",
+  updatedAt: "2026-04-11T00:00:00.000Z",
+};
+
+const activeAdapters: ChannelAdapter[] = [];
+
+function createDiscordMessage(
+  overrides: {
+    id?: string;
+    content?: string;
+    channelId?: string;
+    guildId?: string | null;
+    parentChannelId?: string | null;
+    isThread?: boolean;
+    mentioned?: boolean;
+    authorId?: string;
+    authorUsername?: string;
+    authorGlobalName?: string;
+    authorBot?: boolean;
+  } = {},
+): DiscordTestMessage {
+  const channelId = overrides.channelId ?? "channel-open";
+  const authorGlobalName = overrides.authorGlobalName ?? "Cameron";
+  const guildId =
+    "guildId" in overrides ? (overrides.guildId ?? null) : "guild-1";
+  return {
+    id: overrides.id ?? `${channelId}-message`,
+    content: overrides.content ?? "ambient hello",
+    channelId,
+    guildId,
+    author: {
+      id: overrides.authorId ?? "user-1",
+      username: overrides.authorUsername ?? "cameron",
+      globalName: authorGlobalName,
+      bot: overrides.authorBot ?? false,
+    },
+    member: { displayName: authorGlobalName },
+    channel: {
+      name: channelId,
+      parentId: overrides.parentChannelId ?? null,
+      isThread: () => overrides.isThread ?? false,
+    },
+    mentions: { has: () => overrides.mentioned ?? false },
+    attachments: new Map<string, never>(),
+    createdTimestamp: 1712800000000,
+  };
+}
+
+async function startAdapterWithDeliveries(
+  allowedChannels: DiscordChannelAccount["allowedChannels"],
+  accountOverrides: Partial<DiscordChannelAccount> = {},
+): Promise<{
+  client: FakeDiscordClient;
+  deliveries: InboundChannelMessage[];
+}> {
+  const adapter = createDiscordAdapter({
+    ...discordAccountDefaults,
+    ...accountOverrides,
+    allowedChannels,
+  });
+  activeAdapters.push(adapter);
+  const deliveries: InboundChannelMessage[] = [];
+  adapter.onMessage = async (message) => {
+    deliveries.push(message);
+  };
+
+  await adapter.start();
+  const client = FakeDiscordClient.instances.at(-1);
+  if (!client) {
+    throw new Error("Discord client was not created");
+  }
+  return { client, deliveries };
+}
+
+beforeEach(() => {
+  FakeDiscordClient.instances.length = 0;
+  activeAdapters.length = 0;
+  __testOverrideLoadDiscordModule(async () => createFakeDiscordRuntime());
+});
+
+afterEach(async () => {
+  for (const adapter of activeAdapters.splice(0)) {
+    await adapter.stop();
+  }
+  __testOverrideLoadDiscordModule(null);
+  FakeDiscordClient.instances.length = 0;
+});
+
+describe("Discord adapter bot ingress", () => {
+  test("drops foreign bot guild messages by default even when mentioned", async () => {
+    const { client, deliveries } = await startAdapterWithDeliveries({
+      "channel-open": "open",
+    });
+
+    await client.emitMessageCreate(
+      createDiscordMessage({
+        id: "msg-bot-default",
+        channelId: "channel-open",
+        content: "<@bot-user> please loop",
+        mentioned: true,
+        authorId: "foreign-bot",
+        authorUsername: "workerbot",
+        authorGlobalName: "Worker Bot",
+        authorBot: true,
+      }),
+    );
+
+    expect(deliveries).toHaveLength(0);
+  });
+
+  test("accepts explicitly mentioned foreign bot guild messages when enabled", async () => {
+    const { client, deliveries } = await startAdapterWithDeliveries(
+      ["channel-mention"],
+      { allowBots: "mentions" },
+    );
+
+    await client.emitMessageCreate(
+      createDiscordMessage({
+        id: "msg-bot-mentioned",
+        channelId: "channel-mention",
+        content: "<@bot-user> investigate this",
+        mentioned: true,
+        authorId: "foreign-bot",
+        authorUsername: "workerbot",
+        authorGlobalName: "Worker Bot",
+        authorBot: true,
+      }),
+    );
+
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]).toMatchObject({
+      chatId: "channel-mention",
+      senderId: "foreign-bot",
+      senderName: "Worker Bot",
+      text: "investigate this",
+      isMention: true,
+      isOpenChannel: false,
+    });
+  });
+
+  test("does not treat Discord reply-ping metadata as a foreign bot mention", async () => {
+    const { client, deliveries } = await startAdapterWithDeliveries(
+      { "channel-open": "open" },
+      { allowBots: "mentions" },
+    );
+
+    await client.emitMessageCreate(
+      createDiscordMessage({
+        id: "msg-bot-reply-ping",
+        channelId: "channel-open",
+        content: "reply metadata only",
+        mentioned: true,
+        authorId: "foreign-bot",
+        authorUsername: "workerbot",
+        authorGlobalName: "Worker Bot",
+        authorBot: true,
+      }),
+    );
+
+    expect(deliveries).toHaveLength(0);
+  });
+
+  test("preserves human mention semantics when Discord reports a mention", async () => {
+    const { client, deliveries } = await startAdapterWithDeliveries([
+      "channel-mention",
+    ]);
+
+    await client.emitMessageCreate(
+      createDiscordMessage({
+        id: "msg-human-reply-ping",
+        channelId: "channel-mention",
+        content: "reply metadata only",
+        mentioned: true,
+      }),
+    );
+
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]).toMatchObject({
+      text: "reply metadata only",
+      senderId: "user-1",
+      isMention: true,
+    });
+  });
+
+  test("always suppresses the receiving bot's own Discord messages", async () => {
+    const { client, deliveries } = await startAdapterWithDeliveries(
+      { "channel-open": "open" },
+      { allowBots: "mentions" },
+    );
+
+    await client.emitMessageCreate(
+      createDiscordMessage({
+        id: "msg-self-bot",
+        channelId: "channel-open",
+        content: "<@bot-user> self loop",
+        mentioned: true,
+        authorId: "bot-user",
+        authorUsername: "Loop",
+        authorGlobalName: "Loop",
+        authorBot: true,
+      }),
+    );
+
+    expect(deliveries).toHaveLength(0);
+  });
+
+  test("does not treat a Discord DM from a foreign bot as an implicit mention", async () => {
+    const { client, deliveries } = await startAdapterWithDeliveries([], {
+      allowBots: "mentions",
+    });
+
+    await client.emitMessageCreate(
+      createDiscordMessage({
+        id: "msg-bot-dm",
+        channelId: "dm-1",
+        guildId: null,
+        content: "hello in dm",
+        authorId: "foreign-bot",
+        authorUsername: "workerbot",
+        authorGlobalName: "Worker Bot",
+        authorBot: true,
+      }),
+    );
+
+    expect(deliveries).toHaveLength(0);
+  });
+
+  test("accepts explicitly mentioned foreign bot DMs when enabled", async () => {
+    const { client, deliveries } = await startAdapterWithDeliveries([], {
+      allowBots: "mentions",
+    });
+
+    await client.emitMessageCreate(
+      createDiscordMessage({
+        id: "msg-bot-dm-mentioned",
+        channelId: "dm-1",
+        guildId: null,
+        content: "<@bot-user> hello in dm",
+        authorId: "foreign-bot",
+        authorUsername: "workerbot",
+        authorGlobalName: "Worker Bot",
+        authorBot: true,
+      }),
+    );
+
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]).toMatchObject({
+      chatId: "dm-1",
+      chatType: "direct",
+      senderId: "foreign-bot",
+      senderName: "Worker Bot",
+      text: "<@bot-user> hello in dm",
+      isMention: false,
+    });
+  });
+
+  test("does not treat thread participation as an implicit foreign bot mention", async () => {
+    const { client, deliveries } = await startAdapterWithDeliveries(
+      { "parent-open": "open" },
+      { allowBots: "mentions" },
+    );
+
+    await client.emitMessageCreate(
+      createDiscordMessage({
+        id: "msg-bot-thread",
+        channelId: "thread-1",
+        parentChannelId: "parent-open",
+        isThread: true,
+        content: "thread follow-up",
+        authorId: "foreign-bot",
+        authorUsername: "workerbot",
+        authorGlobalName: "Worker Bot",
+        authorBot: true,
+      }),
+    );
+
+    expect(deliveries).toHaveLength(0);
+  });
+
+  test("does not send delivery-failure replies to bot-authored guild messages", async () => {
+    const adapter = createDiscordAdapter({
+      ...discordAccountDefaults,
+      allowedChannels: { "channel-open": "open" },
+      allowBots: "mentions",
+    });
+    activeAdapters.push(adapter);
+    adapter.onMessage = async () => {
+      throw new Error("bot delivery failed");
+    };
+
+    const originalConsoleError = console.error;
+    console.error = () => {};
+    try {
+      await adapter.start();
+      const client = FakeDiscordClient.instances.at(-1);
+      if (!client) {
+        throw new Error("Discord client was not created");
+      }
+      const send = mock(async (_options: unknown) => ({ id: "error-reply" }));
+      const message = createDiscordMessage({
+        id: "msg-bot-error",
+        channelId: "channel-open",
+        content: "<@bot-user> crash",
+        mentioned: true,
+        authorId: "foreign-bot",
+        authorUsername: "workerbot",
+        authorGlobalName: "Worker Bot",
+        authorBot: true,
+      });
+      message.channel.send = send;
+
+      await client.emitMessageCreate(message);
+
+      expect(send).not.toHaveBeenCalled();
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+});

--- a/src/channels/discord/bot-ingress.test.ts
+++ b/src/channels/discord/bot-ingress.test.ts
@@ -267,6 +267,28 @@ describe("Discord adapter bot ingress", () => {
     expect(deliveries).toHaveLength(0);
   });
 
+  test("does not accept suppressed mention markup in open guild channels", async () => {
+    const { client, deliveries } = await startAdapterWithDeliveries(
+      { "channel-open": "open" },
+      { allowBots: "mentions" },
+    );
+
+    await client.emitMessageCreate(
+      createDiscordMessage({
+        id: "msg-bot-suppressed-mention",
+        channelId: "channel-open",
+        content: "<@bot-user> mention-shaped text only",
+        mentioned: false,
+        authorId: "foreign-bot",
+        authorUsername: "workerbot",
+        authorGlobalName: "Worker Bot",
+        authorBot: true,
+      }),
+    );
+
+    expect(deliveries).toHaveLength(0);
+  });
+
   test("preserves human mention semantics when Discord reports a mention", async () => {
     const { client, deliveries } = await startAdapterWithDeliveries([
       "channel-mention",
@@ -343,6 +365,7 @@ describe("Discord adapter bot ingress", () => {
         channelId: "dm-1",
         guildId: null,
         content: "<@bot-user> hello in dm",
+        mentioned: true,
         authorId: "foreign-bot",
         authorUsername: "workerbot",
         authorGlobalName: "Worker Bot",
@@ -359,6 +382,28 @@ describe("Discord adapter bot ingress", () => {
       text: "<@bot-user> hello in dm",
       isMention: false,
     });
+  });
+
+  test("does not accept suppressed mention markup in Discord DMs", async () => {
+    const { client, deliveries } = await startAdapterWithDeliveries([], {
+      allowBots: "mentions",
+    });
+
+    await client.emitMessageCreate(
+      createDiscordMessage({
+        id: "msg-bot-dm-suppressed-mention",
+        channelId: "dm-1",
+        guildId: null,
+        content: "<@bot-user> mention-shaped text only",
+        mentioned: false,
+        authorId: "foreign-bot",
+        authorUsername: "workerbot",
+        authorGlobalName: "Worker Bot",
+        authorBot: true,
+      }),
+    );
+
+    expect(deliveries).toHaveLength(0);
   });
 
   test("does not treat thread participation as an implicit foreign bot mention", async () => {

--- a/src/channels/discord/bot-policy.test.ts
+++ b/src/channels/discord/bot-policy.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import {
+  hasExplicitDiscordUserMention,
+  isValidDiscordAllowBotsConfigValue,
+  normalizeDiscordAllowBotsMode,
+  shouldAcceptDiscordInboundBotMessage,
+} from "./bot-policy";
+
+describe("Discord bot ingress policy", () => {
+  test("normalizes and validates the allow_bots protocol value", () => {
+    expect(isValidDiscordAllowBotsConfigValue(undefined)).toBe(true);
+    expect(isValidDiscordAllowBotsConfigValue(false)).toBe(true);
+    expect(isValidDiscordAllowBotsConfigValue("mentions")).toBe(true);
+    expect(isValidDiscordAllowBotsConfigValue(true)).toBe(false);
+    expect(isValidDiscordAllowBotsConfigValue("all")).toBe(false);
+    expect(isValidDiscordAllowBotsConfigValue("true")).toBe(false);
+
+    expect(normalizeDiscordAllowBotsMode(undefined)).toBe(false);
+    expect(normalizeDiscordAllowBotsMode(false)).toBe(false);
+    expect(normalizeDiscordAllowBotsMode("mentions")).toBe("mentions");
+  });
+
+  test("matches only real mention markup for the receiving bot user id", () => {
+    expect(
+      hasExplicitDiscordUserMention({ content: "hey <@bot-user>" }, "bot-user"),
+    ).toBe(true);
+    expect(
+      hasExplicitDiscordUserMention(
+        { content: "hey <@!bot-user>" },
+        "bot-user",
+      ),
+    ).toBe(true);
+    expect(
+      hasExplicitDiscordUserMention(
+        { content: "reply-ping metadata only" },
+        "bot-user",
+      ),
+    ).toBe(false);
+    expect(
+      hasExplicitDiscordUserMention(
+        { content: "hey <@other-bot>" },
+        "bot-user",
+      ),
+    ).toBe(false);
+  });
+
+  test("keeps humans, suppresses self, and only admits foreign bots on explicit mentions", () => {
+    expect(
+      shouldAcceptDiscordInboundBotMessage({
+        message: { author: { id: "human", bot: false }, content: "ambient" },
+        allowBots: false,
+        botUserId: "bot-user",
+        wasExplicitlyMentioned: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldAcceptDiscordInboundBotMessage({
+        message: {
+          author: { id: "bot-user", bot: true },
+          content: "<@bot-user>",
+        },
+        allowBots: "mentions",
+        botUserId: "bot-user",
+        wasExplicitlyMentioned: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldAcceptDiscordInboundBotMessage({
+        message: {
+          author: { id: "foreign-bot", bot: true },
+          content: "<@bot-user>",
+        },
+        allowBots: false,
+        botUserId: "bot-user",
+        wasExplicitlyMentioned: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldAcceptDiscordInboundBotMessage({
+        message: {
+          author: { id: "foreign-bot", bot: true },
+          content: "metadata",
+        },
+        allowBots: "mentions",
+        botUserId: "bot-user",
+        wasExplicitlyMentioned: false,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldAcceptDiscordInboundBotMessage({
+        message: {
+          author: { id: "foreign-bot", bot: true },
+          content: "<@bot-user>",
+        },
+        allowBots: "mentions",
+        botUserId: "bot-user",
+        wasExplicitlyMentioned: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/channels/discord/bot-policy.ts
+++ b/src/channels/discord/bot-policy.ts
@@ -1,0 +1,54 @@
+import type { DiscordAllowBotsMode } from "@/channels/types";
+
+interface DiscordBotPolicyMessage {
+  content?: unknown;
+  author?: {
+    id?: unknown;
+    bot?: unknown;
+  } | null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+export function isValidDiscordAllowBotsConfigValue(
+  value: unknown,
+): value is DiscordAllowBotsMode | undefined {
+  return value === undefined || value === false || value === "mentions";
+}
+
+export function normalizeDiscordAllowBotsMode(
+  value: unknown,
+): DiscordAllowBotsMode {
+  return value === "mentions" ? "mentions" : false;
+}
+
+export function hasExplicitDiscordUserMention(
+  message: Pick<DiscordBotPolicyMessage, "content">,
+  userId: string | null | undefined,
+): boolean {
+  if (!isNonEmptyString(userId) || typeof message.content !== "string") {
+    return false;
+  }
+  return (
+    message.content.includes(`<@${userId}>`) ||
+    message.content.includes(`<@!${userId}>`)
+  );
+}
+
+export function shouldAcceptDiscordInboundBotMessage(input: {
+  message: DiscordBotPolicyMessage;
+  allowBots?: DiscordAllowBotsMode;
+  botUserId: string | null;
+  wasExplicitlyMentioned: boolean;
+}): boolean {
+  const author = input.message.author;
+  if (author?.bot !== true) return true;
+
+  if (isNonEmptyString(input.botUserId) && author.id === input.botUserId) {
+    return false;
+  }
+
+  return input.allowBots === "mentions" && input.wasExplicitlyMentioned;
+}

--- a/src/channels/plugin-types.ts
+++ b/src/channels/plugin-types.ts
@@ -1,6 +1,7 @@
 import type {
   ChannelAccount,
   ChannelAdapter,
+  ChannelAllowBotsMode,
   ChannelChatType,
   ChannelDefaultPermissionMode,
   ChannelRoute,
@@ -8,7 +9,6 @@ import type {
   DmPolicy,
   OutboundChannelMessage,
   SignalGroupMode,
-  SlackAllowBotsMode,
   SlackChannelMode,
   TelegramGroupMode,
   WhatsAppGroupMode,
@@ -169,7 +169,7 @@ export interface ChannelPluginAccountPatch {
   threadPolicyByChannel?: Record<string, boolean>;
   acknowledgeMessageReaction?: boolean;
   listenMode?: boolean;
-  allowBots?: SlackAllowBotsMode;
+  allowBots?: ChannelAllowBotsMode;
   removeStaleRoutes?: boolean;
   inboundDebounceMs?: number;
   selfChatMode?: boolean;

--- a/src/channels/service-account-model.ts
+++ b/src/channels/service-account-model.ts
@@ -96,6 +96,7 @@ export function createAccountFromPatch(
       allowedChannels: normalizedPatch.allowedChannels ?? [],
       autoThreadOnMention: normalizedPatch.autoThreadOnMention ?? false,
       threadPolicyByChannel: normalizedPatch.threadPolicyByChannel,
+      allowBots: normalizedPatch.allowBots ?? false,
       acknowledgeMessageReaction: normalizedPatch.acknowledgeMessageReaction,
       removeStaleRoutes: normalizedPatch.removeStaleRoutes,
       inboundDebounceMs: normalizedPatch.inboundDebounceMs,
@@ -246,6 +247,7 @@ export function mergeAccountPatch(
         normalizedPatch.autoThreadOnMention ?? existing.autoThreadOnMention,
       threadPolicyByChannel:
         normalizedPatch.threadPolicyByChannel ?? existing.threadPolicyByChannel,
+      allowBots: normalizedPatch.allowBots ?? existing.allowBots ?? false,
       acknowledgeMessageReaction:
         normalizedPatch.acknowledgeMessageReaction ??
         existing.acknowledgeMessageReaction,

--- a/src/channels/service-snapshots.ts
+++ b/src/channels/service-snapshots.ts
@@ -169,6 +169,7 @@ export function toAccountSnapshot(
       autoThreadOnMention: account.autoThreadOnMention ?? false,
       threadPolicyByChannel: account.threadPolicyByChannel ?? {},
       acknowledgeMessageReaction: account.acknowledgeMessageReaction ?? false,
+      allowBots: account.allowBots ?? false,
       removeStaleRoutes: account.removeStaleRoutes ?? false,
       inboundDebounceMs: account.inboundDebounceMs,
       createdAt: account.createdAt,
@@ -363,6 +364,7 @@ export function getChannelConfigSnapshot(
       autoThreadOnMention: account.autoThreadOnMention ?? false,
       threadPolicyByChannel: account.threadPolicyByChannel ?? {},
       acknowledgeMessageReaction: account.acknowledgeMessageReaction ?? false,
+      allowBots: account.allowBots ?? false,
       removeStaleRoutes: account.removeStaleRoutes ?? false,
       inboundDebounceMs: account.inboundDebounceMs,
     };

--- a/src/channels/service-types.ts
+++ b/src/channels/service-types.ts
@@ -1,10 +1,10 @@
 import type { ChannelProtocolConfig } from "./plugin-types";
 import type {
+  ChannelAllowBotsMode,
   ChannelDefaultPermissionMode,
   DiscordChannelMode,
   DmPolicy,
   SignalGroupMode,
-  SlackAllowBotsMode,
   SlackChannelMode,
   TelegramGroupMode,
   WhatsAppGroupMode,
@@ -43,7 +43,7 @@ export interface ChannelConfigSnapshot {
   threadPolicyByChannel?: Record<string, boolean>;
   acknowledgeMessageReaction?: boolean;
   listenMode?: boolean;
-  allowBots?: SlackAllowBotsMode;
+  allowBots?: ChannelAllowBotsMode;
   removeStaleRoutes?: boolean;
   inboundDebounceMs?: number;
   selfChatMode?: boolean;
@@ -123,7 +123,7 @@ export interface ChannelAccountSnapshot {
   threadPolicyByChannel?: Record<string, boolean>;
   acknowledgeMessageReaction?: boolean;
   listenMode?: boolean;
-  allowBots?: SlackAllowBotsMode;
+  allowBots?: ChannelAllowBotsMode;
   removeStaleRoutes?: boolean;
   inboundDebounceMs?: number;
   selfChatMode?: boolean;

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -503,7 +503,9 @@ export interface ChannelRoute {
 
 export type DmPolicy = "pairing" | "allowlist" | "open";
 export type SlackChannelMode = "socket";
-export type SlackAllowBotsMode = false | "mentions";
+export type ChannelAllowBotsMode = false | "mentions";
+export type SlackAllowBotsMode = ChannelAllowBotsMode;
+export type DiscordAllowBotsMode = ChannelAllowBotsMode;
 export type TelegramGroupMode = "open" | "mention-only";
 export type WhatsAppGroupMode = "disabled" | "mention" | "open";
 export type SignalGroupMode = "disabled" | "mention" | "open";
@@ -626,6 +628,12 @@ export interface DiscordChannelConfig {
    * Clamped to `0..10000`.
    */
   inboundDebounceMs?: number;
+  /**
+   * Bot-authored inbound policy. Default false drops bot messages. "mentions"
+   * accepts only explicit foreign bot mentions. There is intentionally no
+   * accept-all mode until Letta has a shared pair-loop guard.
+   */
+  allowBots?: DiscordAllowBotsMode;
 }
 
 export interface WhatsAppChannelConfig {
@@ -807,6 +815,12 @@ export interface DiscordChannelAccount extends ChannelAccountBase {
    * Clamped to `0..10000`.
    */
   inboundDebounceMs?: number;
+  /**
+   * Bot-authored inbound policy. Default false drops bot messages. "mentions"
+   * accepts only explicit foreign bot mentions. There is intentionally no
+   * accept-all mode until Letta has a shared pair-loop guard.
+   */
+  allowBots?: DiscordAllowBotsMode;
 }
 
 export interface WhatsAppChannelAccount extends ChannelAccountBase {


### PR DESCRIPTION
## Summary

- Add opt-in Discord bot ingress with `allow_bots: "mentions"`.
- Accept foreign bot messages only when Discord reports a parsed mention **and** the content contains explicit `<@id>` / `<@!id>` markup.
- Always suppress self messages, reply-ping-only traffic, suppressed mentions, ambient bot DMs/threads, and automatic delivery-error replies to bot authors.
- Persist the setting through legacy config, account create/update, reload, and channel snapshots.

## Before / after

Before, the first-party Discord adapter dropped every bot-authored message at ingress. Bot-to-bot handoffs required a custom adapter.

After, operators can enable explicit handoffs per Discord account. Existing accounts remain off by default, and human-authored routing is unchanged.

```yaml
allow_bots: mentions
```

## Safety and limits

- There is intentionally no accept-all mode until Letta has shared pair-loop protection.
- Discord reply-ping metadata does not count as an explicit bot mention.
- Mention-shaped text sent with Discord mention parsing suppressed does not trigger the agent.
- Bot-origin delivery failures are logged but do not post another bot message into the channel.
- This adds the account/config surface; it does not add another question to the interactive setup wizard.

## Validation

- `bun run check` — 12/12 checks passed.
- Focused Discord policy, adapter, config, and persistence tests — 40 passed.
- Independent adversarial review — verified after tightening admission to require parsed mention metadata plus explicit markup.
- Complete isolated unit runner was exercised on both head and base. Head had no branch-only failures: the same 9 environment-sensitive App Server WebSocket / hook E2E failures occurred on base, and base had one additional unrelated `list_dir` failure.

No live Discord gateway smoke was run; the adapter boundary is covered with the injected Discord runtime used by the existing first-party tests.

## Tracking

- [LET-9873](https://linear.app/letta/issue/LET-9873/allow-explicitly-mentioned-discord-bots-to-trigger-agents-safely)
- Follow-up: [LET-9912](https://linear.app/letta/issue/LET-9912/add-shared-bot-pair-loop-protection-for-channel-adapters) tracks the shared Slack/Discord bot-pair circuit breaker required before any accept-all mode.
- [Discord request](https://discord.com/channels/1161736243340640419/1162172996715290694/1528268062032400556)

_Opened by Overlord (`agent-c2adbf5c-8419-4211-8cd8-3740db164974`)._

