### PR TITLE
feat: OpenAI-compatible API for App Server (--openai-api)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "lint-staged": "16.2.4",
         "madge": "^8.0.0",
         "minimatch": "^10.0.3",
+        "openai": "^6.48.0",
         "picomatch": "^2.3.1",
         "typescript": "^5.0.0",
       },
@@ -779,7 +780,7 @@
 
     "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
-    "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
+    "openai": ["openai@6.48.0", "", { "peerDependencies": { "@aws-sdk/credential-provider-node": ">=3.972.0 <4", "@smithy/hash-node": ">=4.3.0 <5", "@smithy/signature-v4": ">=5.4.0 <6", "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@aws-sdk/credential-provider-node", "@smithy/hash-node", "@smithy/signature-v4", "ws", "zod"] }, "sha512-KhVp+FyV50QrXNextvL9hIU5l6ox5HYuKQjGVk7lIqprgJol90+dQXWONV6S1lRWsKA1bXjrow8RsUT14M1hNA=="],
 
     "ora": ["ora@5.4.1", "", { "dependencies": { "bl": "^4.1.0", "chalk": "^4.1.0", "cli-cursor": "^3.1.0", "cli-spinners": "^2.5.0", "is-interactive": "^1.0.0", "is-unicode-supported": "^0.1.0", "log-symbols": "^4.1.0", "strip-ansi": "^6.0.0", "wcwidth": "^1.0.1" } }, "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ=="],
 
@@ -1074,6 +1075,8 @@
     "@aws-sdk/token-providers/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
     "@aws-sdk/types/@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
+
+    "@earendil-works/pi-ai/openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
 
     "@pierre/diffs/diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
 

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "lint-staged": "16.2.4",
     "madge": "^8.0.0",
     "minimatch": "^10.0.3",
+    "openai": "^6.48.0",
     "picomatch": "^2.3.1",
     "typescript": "^5.0.0"
   },

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -48,5 +48,5 @@
   "src/websocket/listener/file-commands.ts": 1030,
   "src/websocket/listener/lifecycle.ts": 1766,
   "src/websocket/listener/protocol-inbound.ts": 2279,
-  "src/websocket/listener/protocol-outbound.ts": 1282
+  "src/websocket/listener/protocol-outbound.ts": 1278
 }

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -46,7 +46,7 @@
   "src/websocket/listener/commands/channels.ts": 1390,
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1030,
-  "src/websocket/listener/lifecycle.ts": 1766,
+  "src/websocket/listener/lifecycle.ts": 1762,
   "src/websocket/listener/protocol-inbound.ts": 2279,
   "src/websocket/listener/protocol-outbound.ts": 1278
 }

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -179,6 +179,11 @@ export interface Backend {
     options?: ConversationCreateOptions,
   ): Promise<Awaited<ReturnType<APIClient["conversations"]["create"]>>>;
 
+  /** Optional: not all backends support deleting conversations. */
+  deleteConversation?(
+    conversationId: string,
+  ): Promise<Awaited<ReturnType<APIClient["conversations"]["delete"]>>>;
+
   updateConversation(
     conversationId: string,
     body: ConversationUpdateBody,
@@ -347,6 +352,11 @@ export class APIBackend implements Backend {
   ) {
     const client = await this.getClient();
     return client.conversations.create(body, options);
+  }
+
+  async deleteConversation(conversationId: string) {
+    const client = await this.getClient();
+    return client.conversations.delete(conversationId);
   }
 
   async updateConversation(

--- a/src/cli/subcommands/app-server.ts
+++ b/src/cli/subcommands/app-server.ts
@@ -10,6 +10,7 @@ Run the local App Server using native v2 WebSocket frames.
 
 Options:
   --listen [url]  WebSocket listen URL. Defaults to an available loopback port
+  --openai-api  Serve OpenAI-compatible /v1/models and /v1/chat/completions routes (each agent is a model)
   --ws-auth <mode>  WebSocket auth mode for non-loopback listeners. Supported: capability-token, signed-bearer-token
   --ws-token-file <path>  Absolute path to the capability-token file
   --ws-token-sha256 <hex>  Hex-encoded SHA-256 digest of the capability token
@@ -23,7 +24,8 @@ Examples:
   letta server --listen
   letta server --listen ws://127.0.0.1:4500
   letta server --listen ws://0.0.0.0:4500 --ws-auth capability-token --ws-token-file /path/to/token
-  letta server --listen ws://0.0.0.0:4500 --ws-auth signed-bearer-token --ws-shared-secret-file /path/to/secret`,
+  letta server --listen ws://0.0.0.0:4500 --ws-auth signed-bearer-token --ws-shared-secret-file /path/to/secret
+  letta server --listen ws://127.0.0.1:4500 --openai-api`,
   );
 }
 
@@ -60,6 +62,7 @@ export async function runAppServerSubcommand(argv: string[]): Promise<number> {
       options: {
         help: { type: "boolean", short: "h" },
         listen: { type: "string" },
+        "openai-api": { type: "boolean" },
         "ws-auth": { type: "string" },
         "ws-token-file": { type: "string" },
         "ws-token-sha256": { type: "string" },
@@ -111,16 +114,23 @@ export async function runAppServerSubcommand(argv: string[]): Promise<number> {
           : undefined,
     });
 
+    const openaiApi = parsed.values["openai-api"] === true;
     const handle = await startAppServer({
       listen:
         typeof parsed.values.listen === "string"
           ? parsed.values.listen
           : undefined,
       websocketAuth,
+      openaiApi,
       onListening: (info) => {
         console.log(`Listening on ${info.url}`);
         console.log(`Control: ${info.controlUrl}`);
         console.log(`Stream:  ${info.streamUrl}`);
+        if (openaiApi) {
+          const openaiBase = new URL(info.url);
+          openaiBase.protocol = "http:";
+          console.log(`OpenAI:  ${openaiBase.origin}/v1`);
+        }
       },
       onLog: (message) => {
         console.error(message);

--- a/src/cli/subcommands/server.ts
+++ b/src/cli/subcommands/server.ts
@@ -20,6 +20,7 @@ Remote environment options:
 
 App Server options:
   --listen [url]  Accept App Server connections. If URL is omitted, binds to an available loopback port
+  --openai-api  Serve OpenAI-compatible /v1/models and /v1/chat/completions routes (each agent is a model)
   --ws-auth <mode>  Authentication for non-loopback listeners: capability-token or signed-bearer-token
   --ws-token-file <path>  Absolute path to the capability-token file
   --ws-token-sha256 <hex>  Hex-encoded SHA-256 digest of the capability token

--- a/src/queue/queue-runtime.ts
+++ b/src/queue/queue-runtime.ts
@@ -41,6 +41,12 @@ export type MessageQueueItem = QueueItemBase & {
   kind: "message";
   /** Full multimodal content — string or content-part array. */
   content: MessageCreate["content"];
+  /**
+   * Never merge this item with other queued messages. Set by request-scoped
+   * producers (e.g. the OpenAI-compat HTTP bridge) where each message must
+   * run as its own turn so its correlated client request can settle.
+   */
+  noCoalesce?: boolean;
 };
 
 export type TaskNotificationQueueItem = QueueItemBase & {

--- a/src/websocket/app-server-openai-sdk.test.ts
+++ b/src/websocket/app-server-openai-sdk.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
+import OpenAI from "openai";
+import type { Backend } from "@/backend";
+import { __testSetBackend } from "@/backend";
+import { type AppServerHandle, startAppServer } from "@/websocket/app-server";
+import { parseAppServerWebsocketAuthSettings } from "@/websocket/app-server-auth";
+import { __testSetSendMessageStreamImpl } from "@/websocket/app-server-openai";
+
+// Conformance tests: drive the /v1 routes through the real OpenAI SDK
+// instead of raw fetch, proving an unmodified OpenAI client round-trips
+// against the App Server. Wire-format assertions live in
+// app-server-openai.test.ts; these assert client-level compatibility.
+
+const TEST_AGENTS = [
+  { id: "agent-local-111", name: "memo" },
+  { id: "agent-local-222", name: "patch" },
+];
+
+function fakeBackend(): Backend {
+  return {
+    listAgents: async () => TEST_AGENTS,
+  } as unknown as Backend;
+}
+
+function stubTurnStream(): void {
+  const chunks = [
+    { message_type: "assistant_message", content: "Hello " },
+    { message_type: "assistant_message", content: "world" },
+    {
+      message_type: "usage_statistics",
+      prompt_tokens: 11,
+      completion_tokens: 7,
+      total_tokens: 18,
+    },
+    { message_type: "stop_reason", stop_reason: "end_turn" },
+  ] as unknown as LettaStreamingResponse[];
+  __testSetSendMessageStreamImpl(async () => {
+    return (async function* () {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    })();
+  });
+}
+
+function sdkClient(handle: AppServerHandle, apiKey = "unused"): OpenAI {
+  const url = new URL(handle.url);
+  url.protocol = "http:";
+  return new OpenAI({ baseURL: `${url.origin}/v1`, apiKey });
+}
+
+describe("app-server OpenAI SDK conformance", () => {
+  let handle: AppServerHandle | null = null;
+
+  afterEach(async () => {
+    __testSetSendMessageStreamImpl(null);
+    __testSetBackend(null);
+    if (handle) {
+      await handle.close();
+      handle = null;
+    }
+  });
+
+  test("models.list returns agents", async () => {
+    __testSetBackend(fakeBackend());
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const models = await sdkClient(handle).models.list();
+    const ids = models.data.map((model) => model.id);
+    expect(ids).toEqual(["memo", "patch"]);
+  });
+
+  test("chat.completions.create round-trips (non-streaming)", async () => {
+    __testSetBackend(fakeBackend());
+    stubTurnStream();
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const completion = await sdkClient(handle).chat.completions.create({
+      model: "memo",
+      messages: [{ role: "user", content: "say hello" }],
+    });
+    expect(completion.choices[0]?.message.content).toBe("Hello world");
+    expect(completion.choices[0]?.finish_reason).toBe("stop");
+    expect(completion.usage?.total_tokens).toBe(18);
+  });
+
+  test("chat.completions.create streams via the SDK", async () => {
+    __testSetBackend(fakeBackend());
+    stubTurnStream();
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const stream = await sdkClient(handle).chat.completions.create({
+      model: "patch",
+      messages: [{ role: "user", content: "say hello" }],
+      stream: true,
+    });
+    let text = "";
+    let finishReason: string | null = null;
+    for await (const chunk of stream) {
+      text += chunk.choices[0]?.delta.content ?? "";
+      finishReason = chunk.choices[0]?.finish_reason ?? finishReason;
+    }
+    expect(text).toBe("Hello world");
+    expect(finishReason).toBe("stop");
+  });
+
+  test("SDK receives 401 as APIError with bad token", async () => {
+    __testSetBackend(fakeBackend());
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+      websocketAuth: parseAppServerWebsocketAuthSettings({
+        wsAuth: "capability-token",
+        wsTokenSha256:
+          "a7f6237e747a7a7d8ba94e0b8e64ba1c369b071b6f13905c0d55221b0a8b6a1c",
+      }),
+    });
+
+    // Explicit try/catch rather than expect(...).rejects: the SDK's lazy
+    // PagePromise thenable defers the request in a way bun's rejects
+    // matcher does not observe.
+    const client = sdkClient(handle, "wrong-token");
+    let status: number | null = null;
+    try {
+      await client.models.list();
+    } catch (error) {
+      status = (error as { status?: number }).status ?? null;
+    }
+    expect(status).toBe(401);
+  });
+});

--- a/src/websocket/app-server-openai-sdk.test.ts
+++ b/src/websocket/app-server-openai-sdk.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import OpenAI from "openai";
 import type { Backend } from "@/backend";
 import { __testSetBackend } from "@/backend";
@@ -7,7 +6,7 @@ import { type AppServerHandle, startAppServer } from "@/websocket/app-server";
 import { parseAppServerWebsocketAuthSettings } from "@/websocket/app-server-auth";
 import {
   __testResetConversationMap,
-  __testSetSendMessageStreamImpl,
+  __testSetRunTurnImpl,
 } from "@/websocket/app-server-openai";
 
 // Conformance tests: drive the /v1 routes through the real OpenAI SDK
@@ -33,23 +32,14 @@ function fakeBackend(): Backend {
 }
 
 function stubTurnStream(): void {
-  const chunks = [
-    { message_type: "assistant_message", content: "Hello " },
-    { message_type: "assistant_message", content: "world" },
-    {
-      message_type: "usage_statistics",
-      prompt_tokens: 11,
-      completion_tokens: 7,
-      total_tokens: 18,
-    },
-    { message_type: "stop_reason", stop_reason: "end_turn" },
-  ] as unknown as LettaStreamingResponse[];
-  __testSetSendMessageStreamImpl(async () => {
-    return (async function* () {
-      for (const chunk of chunks) {
-        yield chunk;
-      }
-    })();
+  __testSetRunTurnImpl(async ({ onAssistantText }) => {
+    onAssistantText?.("Hello ");
+    onAssistantText?.("world");
+    return {
+      text: "Hello world",
+      usage: { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 },
+      error: null,
+    };
   });
 }
 
@@ -63,7 +53,7 @@ describe("app-server OpenAI SDK conformance", () => {
   let handle: AppServerHandle | null = null;
 
   afterEach(async () => {
-    __testSetSendMessageStreamImpl(null);
+    __testSetRunTurnImpl(null);
     __testResetConversationMap();
     __testSetBackend(null);
     if (handle) {

--- a/src/websocket/app-server-openai-sdk.test.ts
+++ b/src/websocket/app-server-openai-sdk.test.ts
@@ -5,7 +5,10 @@ import type { Backend } from "@/backend";
 import { __testSetBackend } from "@/backend";
 import { type AppServerHandle, startAppServer } from "@/websocket/app-server";
 import { parseAppServerWebsocketAuthSettings } from "@/websocket/app-server-auth";
-import { __testSetSendMessageStreamImpl } from "@/websocket/app-server-openai";
+import {
+  __testResetConversationMap,
+  __testSetSendMessageStreamImpl,
+} from "@/websocket/app-server-openai";
 
 // Conformance tests: drive the /v1 routes through the real OpenAI SDK
 // instead of raw fetch, proving an unmodified OpenAI client round-trips
@@ -17,9 +20,15 @@ const TEST_AGENTS = [
   { id: "agent-local-222", name: "patch" },
 ];
 
+let conversationCounter = 0;
+
 function fakeBackend(): Backend {
   return {
     listAgents: async () => TEST_AGENTS,
+    createConversation: async (body: { agent_id: string }) => {
+      conversationCounter += 1;
+      return { id: `conv-sdk-${conversationCounter}`, agent_id: body.agent_id };
+    },
   } as unknown as Backend;
 }
 
@@ -55,6 +64,7 @@ describe("app-server OpenAI SDK conformance", () => {
 
   afterEach(async () => {
     __testSetSendMessageStreamImpl(null);
+    __testResetConversationMap();
     __testSetBackend(null);
     if (handle) {
       await handle.close();

--- a/src/websocket/app-server-openai-turn.ts
+++ b/src/websocket/app-server-openai-turn.ts
@@ -2,9 +2,15 @@ import { randomUUID } from "node:crypto";
 import { settingsManager } from "@/settings-manager";
 import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
 import { dispatchInboundMessageWhenReady } from "@/websocket/listener/inbound-dispatch";
-import { startLocalChannelListener } from "@/websocket/listener/lifecycle";
+import {
+  startLocalChannelListener,
+  stopRuntime,
+} from "@/websocket/listener/lifecycle";
 import { getOrCreateConversationPermissionModeStateRef } from "@/websocket/listener/permission-mode";
-import { getActiveRuntime } from "@/websocket/listener/runtime";
+import {
+  getActiveRuntime,
+  setActiveRuntime,
+} from "@/websocket/listener/runtime";
 import {
   type ListenerTransport,
   LocalListenerTransport,
@@ -88,6 +94,23 @@ const OPENAI_TURN_TIMEOUT_MS = 15 * 60 * 1000;
 
 const bridgeTransport = new LocalListenerTransport();
 let bridgeRuntimeStart: Promise<void> | null = null;
+let bridgeOwnedRuntime: ListenerRuntime | null = null;
+
+/**
+ * Stop the listener runtime the bridge started, if it still owns it. Called
+ * from AppServerHandle.close(): a WS-session runtime is closed by its own
+ * socket lifecycle, but a bridge-started (socket-free) runtime has no other
+ * owner and would otherwise outlive the server, keeping cron and channel
+ * lifecycles running.
+ */
+export function closeOpenAiBridgeRuntime(): void {
+  const runtime = bridgeOwnedRuntime;
+  bridgeOwnedRuntime = null;
+  if (!runtime || runtime.intentionallyClosed) return;
+  if (getActiveRuntime() !== runtime) return;
+  stopRuntime(runtime, true);
+  setActiveRuntime(null);
+}
 
 /**
  * Reuse the active listener runtime when one exists (a connected WS control
@@ -119,6 +142,7 @@ async function ensureListenerRuntime(
   if (!runtime || runtime.intentionallyClosed) {
     throw new Error("failed to start listener runtime for OpenAI-compat API");
   }
+  bridgeOwnedRuntime = runtime;
   return runtime;
 }
 
@@ -314,6 +338,10 @@ async function runTurnViaListenerRuntime(
       type: "message",
       agentId: params.agentId,
       conversationId: params.conversationId,
+      // Each HTTP request settles from its own turn: batching two requests
+      // would strand the second observer (only the first OTID survives a
+      // merged batch) and answer the first with both prompts.
+      noCoalesce: true,
       messages: params.messages,
     };
     try {

--- a/src/websocket/app-server-openai-turn.ts
+++ b/src/websocket/app-server-openai-turn.ts
@@ -1,0 +1,340 @@
+import { randomUUID } from "node:crypto";
+import { settingsManager } from "@/settings-manager";
+import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
+import { dispatchInboundMessageWhenReady } from "@/websocket/listener/inbound-dispatch";
+import { startLocalChannelListener } from "@/websocket/listener/lifecycle";
+import { getOrCreateConversationPermissionModeStateRef } from "@/websocket/listener/permission-mode";
+import { getActiveRuntime } from "@/websocket/listener/runtime";
+import {
+  type ListenerTransport,
+  LocalListenerTransport,
+} from "@/websocket/listener/transport";
+import { handleIncomingMessage } from "@/websocket/listener/turn";
+import { registerTurnObserver } from "@/websocket/listener/turn-observers";
+import type {
+  IncomingMessage as ListenerIncomingMessage,
+  ListenerRuntime,
+  ListenerStreamObserver,
+  ProcessQueuedTurn,
+  StartListenerOptions,
+} from "@/websocket/listener/types";
+
+export interface OpenAiUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+}
+
+export type UserContentPart =
+  | { type: "text"; text: string }
+  | {
+      type: "image";
+      source:
+        | { type: "base64"; media_type: string; data: string }
+        | { type: "url"; url: string };
+    };
+
+export interface TurnOutcome {
+  text: string;
+  usage: OpenAiUsage;
+  error: string | null;
+}
+
+export interface BridgeTurnMessage {
+  role: "user" | "assistant";
+  content: UserContentPart[];
+  otid: string;
+}
+
+interface RunTurnParams {
+  agentId: string;
+  conversationId: string;
+  /** Full input for the turn: the newest message in stateful mode, or the
+   * replayed client transcript in stateless mode. */
+  messages: BridgeTurnMessage[];
+  /** OTID of a message in this turn, used to correlate the listener turn
+   * lifecycle with this request. */
+  correlationOtid: string;
+  onAssistantText?: (text: string) => void;
+  onLog?: (message: string) => void;
+}
+
+type RunTurnImpl = (params: RunTurnParams) => Promise<TurnOutcome>;
+
+let runTurnImpl: RunTurnImpl = runTurnViaListenerRuntime;
+
+/** @internal Test seam mirroring __testSetBackend. */
+export function __testSetRunTurnImpl(impl: RunTurnImpl | null): void {
+  runTurnImpl = impl ?? runTurnViaListenerRuntime;
+}
+
+/** Stable entry point used by the HTTP handler; tests swap the impl. */
+export function runBridgeTurn(params: RunTurnParams): Promise<TurnOutcome> {
+  return runTurnImpl(params);
+}
+
+// ---------------------------------------------------------------------------
+// Turn execution over the listener v2 runtime.
+//
+// The bridge runs turns through the same dispatch path as WebSocket clients
+// (queueing → turn processor → tools/mods/permissions) and observes the
+// resulting v2 protocol stream via the runtime's in-process stream
+// observers, converting chat-completions requests into protocol inputs and
+// protocol events back into chat-completions outputs — the HTTP analogue of
+// a messaging channel.
+// ---------------------------------------------------------------------------
+
+const OPENAI_TURN_TIMEOUT_MS = 15 * 60 * 1000;
+
+const bridgeTransport = new LocalListenerTransport();
+let bridgeRuntimeStart: Promise<void> | null = null;
+
+/**
+ * Reuse the active listener runtime when one exists (a connected WS control
+ * session or channels runtime); otherwise start a socket-free local runtime,
+ * exactly like `letta server --channels` does. If a WS control client
+ * connects later it replaces the bridge-owned runtime, and subsequent
+ * requests transparently use the new active runtime.
+ */
+async function ensureListenerRuntime(
+  onLog?: (message: string) => void,
+): Promise<ListenerRuntime> {
+  const active = getActiveRuntime();
+  if (active && !active.intentionallyClosed) return active;
+
+  bridgeRuntimeStart ??= startLocalChannelListener({
+    connectionId: `openai-api-${randomUUID()}`,
+    deviceId: settingsManager.getOrCreateDeviceId(),
+    connectionName: "openai-api",
+    onConnected: () => {},
+    onError: (error) => {
+      onLog?.(`OpenAI-compat runtime error: ${error.message}`);
+    },
+  }).finally(() => {
+    bridgeRuntimeStart = null;
+  });
+  await bridgeRuntimeStart;
+
+  const runtime = getActiveRuntime();
+  if (!runtime || runtime.intentionallyClosed) {
+    throw new Error("failed to start listener runtime for OpenAI-compat API");
+  }
+  return runtime;
+}
+
+function extractDeltaText(delta: unknown): string {
+  const content = (
+    delta as { content?: string | Array<{ text?: string }> | null }
+  ).content;
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) =>
+      part && typeof part === "object" && typeof part.text === "string"
+        ? part.text
+        : "",
+    )
+    .join("");
+}
+
+async function runTurnViaListenerRuntime(
+  params: RunTurnParams,
+): Promise<TurnOutcome> {
+  const listener = await ensureListenerRuntime(params.onLog);
+  const scopedRuntime = getOrCreateScopedRuntime(
+    listener,
+    params.agentId,
+    params.conversationId,
+  );
+  // No interactive approver exists on this surface, so bridge conversations
+  // run unrestricted (Hermes-style: the API is opt-in and bearer-gated and
+  // exposes the agent's full toolset). Approvals that still arise finish the
+  // turn with an explanatory reply instead of hanging.
+  getOrCreateConversationPermissionModeStateRef(
+    listener,
+    params.agentId,
+    params.conversationId,
+  ).mode = "unrestricted";
+  // Frames emitted for this turn also flow to any attached WS client; the
+  // transport here is only the fallback destination when none is attached.
+  const socket: ListenerTransport =
+    listener.socket ?? listener.transport ?? bridgeTransport;
+
+  const dispatchOptions: StartListenerOptions = {
+    connectionId: listener.connectionId ?? "openai-api",
+    wsUrl: "",
+    deviceId: settingsManager.getOrCreateDeviceId(),
+    connectionName: listener.connectionName ?? "openai-api",
+    onConnected: () => {},
+    onDisconnected: () => {},
+    onError: (error) => {
+      params.onLog?.(`OpenAI-compat turn error: ${error.message}`);
+    },
+  };
+
+  const processQueuedTurn: ProcessQueuedTurn = async (
+    queuedTurn,
+    dequeuedBatch,
+  ) => {
+    const queuedScope = getOrCreateScopedRuntime(
+      listener,
+      queuedTurn.agentId,
+      queuedTurn.conversationId,
+    );
+    await handleIncomingMessage(
+      queuedTurn,
+      socket,
+      queuedScope,
+      undefined,
+      dispatchOptions.connectionId,
+      dequeuedBatch.batchId,
+    );
+  };
+
+  return await new Promise<TurnOutcome>((resolve) => {
+    let text = "";
+    let usage: OpenAiUsage = {
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+    };
+    // The request settles from ITS OWN turn's lifecycle (turn-observers,
+    // keyed by OTID), never from raw stream events: stop_reason ends a
+    // stream segment before the listener decides on retries/approvals, and
+    // usage can arrive after it. Stream deltas are accumulated only while
+    // this request's turn is active, so queued requests and WS-initiated
+    // turns in the same conversation never bleed into this response.
+    let turnActive = false;
+    let recordedError: string | null = null;
+    let settled = false;
+    let unregisterTurnObserver: () => void = () => {};
+    if (!listener.streamObservers) {
+      listener.streamObservers = new Set();
+    }
+    const observers = listener.streamObservers;
+
+    const finish = (error: string | null): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      observers.delete(observer);
+      unregisterTurnObserver();
+      resolve({ text, usage, error });
+    };
+
+    const observer: ListenerStreamObserver = (message) => {
+      if (message.type === "runtime_stopped") {
+        finish(
+          recordedError ??
+            "server runtime was replaced while the request was in flight",
+        );
+        return;
+      }
+      if (message.runtime.agent_id !== params.agentId) return;
+      if (message.runtime.conversation_id !== params.conversationId) return;
+      if (!turnActive) return;
+      if (message.type === "update_loop_status") {
+        // The turn paused for interactive input this surface cannot provide.
+        const status = (message as { loop_status?: { status?: string } })
+          .loop_status?.status;
+        if (status === "WAITING_ON_APPROVAL") {
+          if (!text) {
+            const note =
+              "The agent attempted a tool call that requires interactive approval, which this API does not support.";
+            text = note;
+            params.onAssistantText?.(note);
+          }
+          finish(null);
+        }
+        return;
+      }
+      if (message.type !== "stream_delta" || message.subagent_id) return;
+      const delta = (message as { delta?: { message_type?: string } }).delta;
+      if (!delta) return;
+      switch (delta.message_type) {
+        case "assistant_message": {
+          const piece = extractDeltaText(delta);
+          if (piece) {
+            text += piece;
+            // New assistant output after a recorded error means the
+            // listener retried successfully; the error is stale.
+            recordedError = null;
+            params.onAssistantText?.(piece);
+          }
+          return;
+        }
+        case "usage_statistics": {
+          const stats = delta as {
+            prompt_tokens?: number;
+            completion_tokens?: number;
+            total_tokens?: number;
+          };
+          usage = {
+            prompt_tokens: stats.prompt_tokens ?? 0,
+            completion_tokens: stats.completion_tokens ?? 0,
+            total_tokens: stats.total_tokens ?? 0,
+          };
+          return;
+        }
+        case "loop_error": {
+          // Recorded, not settled: the listener may still retry. The turn
+          // lifecycle end decides the final outcome.
+          const loopError = delta as {
+            is_terminal?: boolean;
+            message?: string;
+          };
+          if (loopError.is_terminal !== false) {
+            recordedError = loopError.message ?? "agent turn failed";
+          }
+          return;
+        }
+        case "error_message":
+          recordedError =
+            (delta as { message?: string }).message ?? "agent turn failed";
+          return;
+        default:
+          return;
+      }
+    };
+    observers.add(observer);
+    unregisterTurnObserver = registerTurnObserver(params.correlationOtid, {
+      onStarted: () => {
+        turnActive = true;
+      },
+      onFinished: () => {
+        finish(recordedError);
+      },
+    });
+    const timer = setTimeout(
+      () => finish(recordedError ?? "agent turn timed out"),
+      OPENAI_TURN_TIMEOUT_MS,
+    );
+
+    const incoming: ListenerIncomingMessage = {
+      type: "message",
+      agentId: params.agentId,
+      conversationId: params.conversationId,
+      messages: params.messages,
+    };
+    try {
+      dispatchInboundMessageWhenReady({
+        listener,
+        runtime: scopedRuntime,
+        incoming,
+        socket,
+        options: dispatchOptions,
+        processQueuedTurn,
+        processIncomingMessage: handleIncomingMessage,
+        trackListenerError: (errorType, error) => {
+          params.onLog?.(
+            `OpenAI-compat listener error (${errorType}): ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        },
+      });
+    } catch (error) {
+      finish(error instanceof Error ? error.message : String(error));
+    }
+  });
+}

--- a/src/websocket/app-server-openai.test.ts
+++ b/src/websocket/app-server-openai.test.ts
@@ -384,7 +384,7 @@ describe("app-server OpenAI-compatible API", () => {
         method: "POST",
         headers: {
           "content-type": "application/json",
-          "x-openwebui-chat-id": chatKey,
+          "x-letta-chat-key": chatKey,
         },
         body: JSON.stringify({ model: "memo", messages }),
       });
@@ -406,6 +406,45 @@ describe("app-server OpenAI-compatible API", () => {
       "conv-test-1",
     ]);
     expect(created.length).toBe(2);
+  });
+
+  test("openwebui chat id is honored only for streaming requests", async () => {
+    const created: string[] = [];
+    __testSetBackend(fakeBackend(created));
+    const conversationsUsed: string[] = [];
+    stubTurn((conversationId) => {
+      conversationsUsed.push(conversationId);
+    });
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const send = (stream: boolean) =>
+      fetch(httpUrl(handle as AppServerHandle, "/v1/chat/completions"), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-openwebui-chat-id": "webui-chat",
+        },
+        body: JSON.stringify({
+          model: "memo",
+          messages: [{ role: "user", content: "hi" }],
+          stream,
+        }),
+      });
+
+    // Streaming chat messages pin the conversation; non-streaming task
+    // requests (title/tags generation) run statelessly despite the header.
+    await send(true);
+    await send(true);
+    await send(false);
+
+    expect(conversationsUsed).toEqual([
+      "conv-test-1",
+      "conv-test-1",
+      "conv-test-2",
+    ]);
   });
 
   test("stateful header mode sends only the newest message", async () => {

--- a/src/websocket/app-server-openai.test.ts
+++ b/src/websocket/app-server-openai.test.ts
@@ -38,18 +38,24 @@ function sha256Hex(value: string): string {
 }
 
 function stubTurn(
-  onCall?: (conversationId: string, agentId: string) => void,
+  onCall?: (
+    conversationId: string,
+    agentId: string,
+    messages: unknown[],
+  ) => void,
 ): void {
-  __testSetRunTurnImpl(async ({ agentId, conversationId, onAssistantText }) => {
-    onCall?.(conversationId, agentId);
-    onAssistantText?.("Hello ");
-    onAssistantText?.("world");
-    return {
-      text: "Hello world",
-      usage: { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 },
-      error: null,
-    };
-  });
+  __testSetRunTurnImpl(
+    async ({ agentId, conversationId, messages, onAssistantText }) => {
+      onCall?.(conversationId, agentId, messages);
+      onAssistantText?.("Hello ");
+      onAssistantText?.("world");
+      return {
+        text: "Hello world",
+        usage: { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 },
+        error: null,
+      };
+    },
+  );
 }
 
 function httpUrl(handle: AppServerHandle, path: string): string {
@@ -164,12 +170,14 @@ describe("app-server OpenAI-compatible API", () => {
     expect(captured.agent).toBe("agent-local-111");
   });
 
-  test("client chats map to distinct, sticky Letta conversations", async () => {
+  test("header-less requests run statelessly with transcript replay", async () => {
     const created: string[] = [];
     __testSetBackend(fakeBackend(created));
     const conversationsUsed: string[] = [];
-    stubTurn((conversationId) => {
+    const messageCounts: number[] = [];
+    stubTurn((conversationId, _agentId, messages) => {
       conversationsUsed.push(conversationId);
+      messageCounts.push(messages.length);
     });
     handle = await startAppServer({
       listen: "ws://127.0.0.1:0",
@@ -183,25 +191,18 @@ describe("app-server OpenAI-compatible API", () => {
         body: JSON.stringify({ model: "memo", messages }),
       });
 
-    // Chat A, first message: creates a fresh conversation.
+    // Without a stable chat identity there is no server-side reuse: every
+    // request gets a fresh conversation and the transcript is replayed.
     await send([{ role: "user", content: "first chat" }]);
-    // Chat A, second message: client resends the transcript, which now
-    // includes the reply ("Hello world") — must map back to the same
-    // conversation without creating a new one.
     await send([
       { role: "user", content: "first chat" },
       { role: "assistant", content: "Hello world" },
       { role: "user", content: "follow-up" },
     ]);
-    // Chat B, first message: a different thread gets its own conversation.
-    await send([{ role: "user", content: "second chat" }]);
 
-    expect(conversationsUsed).toEqual([
-      "conv-test-1",
-      "conv-test-1",
-      "conv-test-2",
-    ]);
+    expect(conversationsUsed).toEqual(["conv-test-1", "conv-test-2"]);
     expect(created).toEqual(["conv-test-1", "conv-test-2"]);
+    expect(messageCounts).toEqual([1, 3]);
   });
 
   test("POST /v1/chat/completions streams SSE chunks", async () => {
@@ -407,11 +408,40 @@ describe("app-server OpenAI-compatible API", () => {
     expect(created.length).toBe(2);
   });
 
+  test("stateful header mode sends only the newest message", async () => {
+    __testSetBackend(fakeBackend());
+    const messageCounts: number[] = [];
+    stubTurn((_conversationId, _agentId, messages) => {
+      messageCounts.push(messages.length);
+    });
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    await fetch(httpUrl(handle, "/v1/chat/completions"), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-letta-chat-key": "pinned-chat",
+      },
+      body: JSON.stringify({
+        model: "memo",
+        messages: [
+          { role: "user", content: "Hello" },
+          { role: "assistant", content: "Hello world" },
+          { role: "user", content: "follow-up" },
+        ],
+      }),
+    });
+    expect(messageCounts).toEqual([1]);
+  });
+
   test("image_url parts pass through as Letta image content", async () => {
     __testSetBackend(fakeBackend());
     let capturedContent: unknown = null;
-    __testSetRunTurnImpl(async ({ userContent, onAssistantText }) => {
-      capturedContent = userContent;
+    __testSetRunTurnImpl(async ({ messages, onAssistantText }) => {
+      capturedContent = (messages[0] as { content: unknown }).content;
       onAssistantText?.("I see it");
       return {
         text: "I see it",

--- a/src/websocket/app-server-openai.test.ts
+++ b/src/websocket/app-server-openai.test.ts
@@ -272,6 +272,74 @@ describe("app-server OpenAI-compatible API", () => {
     expect(body.error.code).toBe("model_not_found");
   });
 
+  test("concurrent new chats serialize conversation creation per agent", async () => {
+    const created: string[] = [];
+    let inFlight = 0;
+    __testSetBackend({
+      listAgents: async () => TEST_AGENTS,
+      createConversation: async (body: { agent_id: string }) => {
+        inFlight += 1;
+        if (inFlight > 1) {
+          inFlight -= 1;
+          throw new Error("concurrent createConversation detected");
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        inFlight -= 1;
+        const id = `conv-test-${created.length + 1}`;
+        created.push(id);
+        return { id, agent_id: body.agent_id };
+      },
+    } as unknown as Backend);
+    stubTurn();
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const send = (text: string) =>
+      fetch(httpUrl(handle as AppServerHandle, "/v1/chat/completions"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "memo",
+          messages: [{ role: "user", content: text }],
+        }),
+      });
+    const responses = await Promise.all([
+      send("chat one"),
+      send("chat two"),
+      send("chat three"),
+    ]);
+    expect(responses.map((r) => r.status)).toEqual([200, 200, 200]);
+    expect(created.length).toBe(3);
+  });
+
+  test("conversation creation failure returns 500, not default fallback", async () => {
+    __testSetBackend({
+      listAgents: async () => TEST_AGENTS,
+      createConversation: async () => {
+        throw new Error("could not lock config file .git/config");
+      },
+    } as unknown as Backend);
+    stubTurn();
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const response = await fetch(httpUrl(handle, "/v1/chat/completions"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "memo",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as { error: { type: string } };
+    expect(body.error.type).toBe("server_error");
+  });
+
   test("image_url parts pass through as Letta image content", async () => {
     __testSetBackend(fakeBackend());
     let capturedContent: unknown = null;

--- a/src/websocket/app-server-openai.test.ts
+++ b/src/websocket/app-server-openai.test.ts
@@ -340,6 +340,73 @@ describe("app-server OpenAI-compatible API", () => {
     expect(body.error.type).toBe("server_error");
   });
 
+  test("two chats starting with identical messages get distinct conversations", async () => {
+    const created: string[] = [];
+    __testSetBackend(fakeBackend(created));
+    const conversationsUsed: string[] = [];
+    stubTurn((conversationId) => {
+      conversationsUsed.push(conversationId);
+    });
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const send = () =>
+      fetch(httpUrl(handle as AppServerHandle, "/v1/chat/completions"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "memo",
+          messages: [{ role: "user", content: "Hello" }],
+        }),
+      });
+    await send();
+    await send();
+    expect(conversationsUsed).toEqual(["conv-test-1", "conv-test-2"]);
+  });
+
+  test("chat-key header pins chat identity across identical transcripts", async () => {
+    const created: string[] = [];
+    __testSetBackend(fakeBackend(created));
+    const conversationsUsed: string[] = [];
+    stubTurn((conversationId) => {
+      conversationsUsed.push(conversationId);
+    });
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const send = (chatKey: string, messages: unknown[]) =>
+      fetch(httpUrl(handle as AppServerHandle, "/v1/chat/completions"), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-openwebui-chat-id": chatKey,
+        },
+        body: JSON.stringify({ model: "memo", messages }),
+      });
+
+    // Two chats with byte-identical transcripts but different chat ids.
+    await send("chat-a", [{ role: "user", content: "Hello" }]);
+    await send("chat-b", [{ role: "user", content: "Hello" }]);
+    // Follow-up in chat-a with an identical transcript to what chat-b
+    // would resend — the header, not the transcript, decides.
+    await send("chat-a", [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hello world" },
+      { role: "user", content: "follow-up" },
+    ]);
+
+    expect(conversationsUsed).toEqual([
+      "conv-test-1",
+      "conv-test-2",
+      "conv-test-1",
+    ]);
+    expect(created.length).toBe(2);
+  });
+
   test("image_url parts pass through as Letta image content", async () => {
     __testSetBackend(fakeBackend());
     let capturedContent: unknown = null;

--- a/src/websocket/app-server-openai.test.ts
+++ b/src/websocket/app-server-openai.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
+import type { Backend } from "@/backend";
+import { __testSetBackend } from "@/backend";
+import { type AppServerHandle, startAppServer } from "@/websocket/app-server";
+import { parseAppServerWebsocketAuthSettings } from "@/websocket/app-server-auth";
+import { __testSetSendMessageStreamImpl } from "@/websocket/app-server-openai";
+
+const TEST_AGENTS = [
+  {
+    id: "agent-local-111",
+    name: "memo",
+    created_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "agent-local-222",
+    name: "patch",
+    created_at: "2026-01-02T00:00:00Z",
+  },
+];
+
+function fakeBackend(): Backend {
+  return {
+    listAgents: async () => TEST_AGENTS,
+  } as unknown as Backend;
+}
+
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function fakeTurnChunks(): LettaStreamingResponse[] {
+  return [
+    {
+      message_type: "reasoning_message",
+      reasoning: "thinking...",
+    },
+    {
+      message_type: "assistant_message",
+      content: "Hello ",
+    },
+    {
+      message_type: "assistant_message",
+      content: [{ type: "text", text: "world" }],
+    },
+    {
+      message_type: "usage_statistics",
+      prompt_tokens: 11,
+      completion_tokens: 7,
+      total_tokens: 18,
+    },
+    {
+      message_type: "stop_reason",
+      stop_reason: "end_turn",
+    },
+  ] as unknown as LettaStreamingResponse[];
+}
+
+function stubTurnStream(
+  chunks: LettaStreamingResponse[],
+  onCall?: (conversationId: string, agentId: string | undefined) => void,
+): void {
+  __testSetSendMessageStreamImpl(async (conversationId, _messages, opts) => {
+    onCall?.(conversationId, opts?.agentId);
+    return (async function* () {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    })();
+  });
+}
+
+function httpUrl(handle: AppServerHandle, path: string): string {
+  const url = new URL(handle.url);
+  url.protocol = "http:";
+  return `${url.origin}${path}`;
+}
+
+describe("app-server OpenAI-compatible API", () => {
+  let handle: AppServerHandle | null = null;
+
+  afterEach(async () => {
+    __testSetSendMessageStreamImpl(null);
+    __testSetBackend(null);
+    if (handle) {
+      await handle.close();
+      handle = null;
+    }
+  });
+
+  test("routes are 404 when --openai-api is not set", async () => {
+    __testSetBackend(fakeBackend());
+    handle = await startAppServer({ listen: "ws://127.0.0.1:0" });
+    const response = await fetch(httpUrl(handle, "/v1/models"));
+    expect(response.status).toBe(404);
+  });
+
+  test("GET /v1/models lists agents as models", async () => {
+    __testSetBackend(fakeBackend());
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+    const response = await fetch(httpUrl(handle, "/v1/models"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      object: string;
+      data: Array<{ id: string; object: string; owned_by: string }>;
+    };
+    expect(body.object).toBe("list");
+    expect(body.data.map((model) => model.id)).toEqual(["memo", "patch"]);
+    expect(body.data[0]?.object).toBe("model");
+    expect(body.data[0]?.owned_by).toBe("letta");
+  });
+
+  test("honors capability-token auth on /v1 routes", async () => {
+    __testSetBackend(fakeBackend());
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+      websocketAuth: parseAppServerWebsocketAuthSettings({
+        wsAuth: "capability-token",
+        wsTokenSha256: sha256Hex("super-secret-token"),
+      }),
+    });
+
+    const unauthorized = await fetch(httpUrl(handle, "/v1/models"));
+    expect(unauthorized.status).toBe(401);
+
+    const wrongToken = await fetch(httpUrl(handle, "/v1/models"), {
+      headers: { authorization: "Bearer wrong-token" },
+    });
+    expect(wrongToken.status).toBe(401);
+
+    const authorized = await fetch(httpUrl(handle, "/v1/models"), {
+      headers: { authorization: "Bearer super-secret-token" },
+    });
+    expect(authorized.status).toBe(200);
+  });
+
+  test("POST /v1/chat/completions aggregates a turn (non-streaming)", async () => {
+    __testSetBackend(fakeBackend());
+    const captured = { conversation: "", agent: "" };
+    stubTurnStream(fakeTurnChunks(), (conversationId, agentId) => {
+      captured.conversation = conversationId;
+      captured.agent = agentId ?? "";
+    });
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const response = await fetch(httpUrl(handle, "/v1/chat/completions"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "memo",
+        messages: [
+          { role: "system", content: "be helpful" },
+          { role: "user", content: "say hello" },
+        ],
+      }),
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      object: string;
+      model: string;
+      choices: Array<{
+        message: { role: string; content: string };
+        finish_reason: string;
+      }>;
+      usage: { prompt_tokens: number; total_tokens: number };
+    };
+    expect(body.object).toBe("chat.completion");
+    expect(body.model).toBe("memo");
+    expect(body.choices[0]?.message.content).toBe("Hello world");
+    expect(body.choices[0]?.finish_reason).toBe("stop");
+    expect(body.usage.prompt_tokens).toBe(11);
+    expect(body.usage.total_tokens).toBe(18);
+    expect(captured.conversation).toBe("default");
+    expect(captured.agent).toBe("agent-local-111");
+  });
+
+  test("POST /v1/chat/completions streams SSE chunks", async () => {
+    __testSetBackend(fakeBackend());
+    stubTurnStream(fakeTurnChunks());
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const response = await fetch(httpUrl(handle, "/v1/chat/completions"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        // Resolving by agent id (rather than name) must also work.
+        model: "agent-local-222",
+        messages: [{ role: "user", content: "say hello" }],
+        stream: true,
+      }),
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+
+    const raw = await response.text();
+    const events = raw
+      .split("\n\n")
+      .filter(Boolean)
+      .map((line) => line.replace(/^data: /, ""));
+    expect(events.at(-1)).toBe("[DONE]");
+
+    const parsed = events.slice(0, -1).map(
+      (event) =>
+        JSON.parse(event) as {
+          object: string;
+          choices: Array<{
+            delta: { role?: string; content?: string };
+            finish_reason: string | null;
+          }>;
+        },
+    );
+    expect(parsed[0]?.choices[0]?.delta.role).toBe("assistant");
+    const text = parsed
+      .map((chunk) => chunk.choices[0]?.delta.content ?? "")
+      .join("");
+    expect(text).toBe("Hello world");
+    expect(parsed.at(-1)?.choices[0]?.finish_reason).toBe("stop");
+  });
+
+  test("unknown model returns 404 model_not_found", async () => {
+    __testSetBackend(fakeBackend());
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const response = await fetch(httpUrl(handle, "/v1/chat/completions"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "does-not-exist",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(response.status).toBe(404);
+    const body = (await response.json()) as {
+      error: { code: string | null };
+    };
+    expect(body.error.code).toBe("model_not_found");
+  });
+
+  test("missing user text returns 400", async () => {
+    __testSetBackend(fakeBackend());
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const response = await fetch(httpUrl(handle, "/v1/chat/completions"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "memo",
+        messages: [{ role: "system", content: "no user message" }],
+      }),
+    });
+    expect(response.status).toBe(400);
+  });
+});

--- a/src/websocket/app-server-openai.test.ts
+++ b/src/websocket/app-server-openai.test.ts
@@ -1,13 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import type { Backend } from "@/backend";
 import { __testSetBackend } from "@/backend";
 import { type AppServerHandle, startAppServer } from "@/websocket/app-server";
 import { parseAppServerWebsocketAuthSettings } from "@/websocket/app-server-auth";
 import {
   __testResetConversationMap,
-  __testSetSendMessageStreamImpl,
+  __testSetRunTurnImpl,
 } from "@/websocket/app-server-openai";
 
 const TEST_AGENTS = [
@@ -38,44 +37,18 @@ function sha256Hex(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
-function fakeTurnChunks(): LettaStreamingResponse[] {
-  return [
-    {
-      message_type: "reasoning_message",
-      reasoning: "thinking...",
-    },
-    {
-      message_type: "assistant_message",
-      content: "Hello ",
-    },
-    {
-      message_type: "assistant_message",
-      content: [{ type: "text", text: "world" }],
-    },
-    {
-      message_type: "usage_statistics",
-      prompt_tokens: 11,
-      completion_tokens: 7,
-      total_tokens: 18,
-    },
-    {
-      message_type: "stop_reason",
-      stop_reason: "end_turn",
-    },
-  ] as unknown as LettaStreamingResponse[];
-}
-
-function stubTurnStream(
-  chunks: LettaStreamingResponse[],
-  onCall?: (conversationId: string, agentId: string | undefined) => void,
+function stubTurn(
+  onCall?: (conversationId: string, agentId: string) => void,
 ): void {
-  __testSetSendMessageStreamImpl(async (conversationId, _messages, opts) => {
-    onCall?.(conversationId, opts?.agentId);
-    return (async function* () {
-      for (const chunk of chunks) {
-        yield chunk;
-      }
-    })();
+  __testSetRunTurnImpl(async ({ agentId, conversationId, onAssistantText }) => {
+    onCall?.(conversationId, agentId);
+    onAssistantText?.("Hello ");
+    onAssistantText?.("world");
+    return {
+      text: "Hello world",
+      usage: { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 },
+      error: null,
+    };
   });
 }
 
@@ -89,7 +62,7 @@ describe("app-server OpenAI-compatible API", () => {
   let handle: AppServerHandle | null = null;
 
   afterEach(async () => {
-    __testSetSendMessageStreamImpl(null);
+    __testSetRunTurnImpl(null);
     __testResetConversationMap();
     __testSetBackend(null);
     if (handle) {
@@ -151,9 +124,9 @@ describe("app-server OpenAI-compatible API", () => {
   test("POST /v1/chat/completions aggregates a turn (non-streaming)", async () => {
     __testSetBackend(fakeBackend());
     const captured = { conversation: "", agent: "" };
-    stubTurnStream(fakeTurnChunks(), (conversationId, agentId) => {
+    stubTurn((conversationId, agentId) => {
       captured.conversation = conversationId;
-      captured.agent = agentId ?? "";
+      captured.agent = agentId;
     });
     handle = await startAppServer({
       listen: "ws://127.0.0.1:0",
@@ -195,7 +168,7 @@ describe("app-server OpenAI-compatible API", () => {
     const created: string[] = [];
     __testSetBackend(fakeBackend(created));
     const conversationsUsed: string[] = [];
-    stubTurnStream(fakeTurnChunks(), (conversationId) => {
+    stubTurn((conversationId) => {
       conversationsUsed.push(conversationId);
     });
     handle = await startAppServer({
@@ -233,7 +206,7 @@ describe("app-server OpenAI-compatible API", () => {
 
   test("POST /v1/chat/completions streams SSE chunks", async () => {
     __testSetBackend(fakeBackend());
-    stubTurnStream(fakeTurnChunks());
+    stubTurn();
     handle = await startAppServer({
       listen: "ws://127.0.0.1:0",
       openaiApi: true,

--- a/src/websocket/app-server-openai.test.ts
+++ b/src/websocket/app-server-openai.test.ts
@@ -22,7 +22,7 @@ const TEST_AGENTS = [
   },
 ];
 
-function fakeBackend(created: string[] = []): Backend {
+function fakeBackend(created: string[] = [], deleted: string[] = []): Backend {
   return {
     listAgents: async () => TEST_AGENTS,
     createConversation: async (body: { agent_id: string }) => {
@@ -30,7 +30,20 @@ function fakeBackend(created: string[] = []): Backend {
       created.push(id);
       return { id, agent_id: body.agent_id };
     },
+    deleteConversation: async (conversationId: string) => {
+      deleted.push(conversationId);
+      return {};
+    },
   } as unknown as Backend;
+}
+
+async function waitFor(predicate: () => boolean, ms = 2000): Promise<boolean> {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  return predicate();
 }
 
 function sha256Hex(value: string): string {
@@ -551,6 +564,71 @@ describe("app-server OpenAI-compatible API", () => {
     expect((await send()).status).toBe(500);
     expect((await send()).status).toBe(200);
     expect(runs).toBe(2);
+  });
+
+  test("idempotent replays allocate no conversation", async () => {
+    const created: string[] = [];
+    __testSetBackend(fakeBackend(created));
+    stubTurn();
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const send = () =>
+      fetch(httpUrl(handle as AppServerHandle, "/v1/chat/completions"), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "idempotency-key": "alloc-check",
+        },
+        body: JSON.stringify({
+          model: "memo",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      });
+
+    await send();
+    expect(created.length).toBe(1);
+    await send();
+    // The replay consulted the cache before allocating anything.
+    expect(created.length).toBe(1);
+  });
+
+  test("headerless conversations are deleted after the turn settles", async () => {
+    const created: string[] = [];
+    const deleted: string[] = [];
+    __testSetBackend(fakeBackend(created, deleted));
+    stubTurn();
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    await fetch(httpUrl(handle, "/v1/chat/completions"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "memo",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(await waitFor(() => deleted.includes("conv-test-1"))).toBe(true);
+
+    // Header-keyed conversations persist: they ARE the chat's state.
+    await fetch(httpUrl(handle, "/v1/chat/completions"), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-letta-chat-key": "sticky-chat",
+      },
+      body: JSON.stringify({
+        model: "memo",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(deleted).toEqual(["conv-test-1"]);
   });
 
   test("image_url parts pass through as Letta image content", async () => {

--- a/src/websocket/app-server-openai.test.ts
+++ b/src/websocket/app-server-openai.test.ts
@@ -437,6 +437,83 @@ describe("app-server OpenAI-compatible API", () => {
     expect(messageCounts).toEqual([1]);
   });
 
+  test("Idempotency-Key replays the original outcome without re-running", async () => {
+    __testSetBackend(fakeBackend());
+    let runs = 0;
+    __testSetRunTurnImpl(async ({ onAssistantText }) => {
+      runs += 1;
+      onAssistantText?.("Hello world");
+      return {
+        text: "Hello world",
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        error: null,
+      };
+    });
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const send = (key: string) =>
+      fetch(httpUrl(handle as AppServerHandle, "/v1/chat/completions"), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "idempotency-key": key,
+        },
+        body: JSON.stringify({
+          model: "memo",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      });
+
+    const first = (await (await send("retry-1")).json()) as {
+      choices: Array<{ message: { content: string } }>;
+    };
+    const replay = (await (await send("retry-1")).json()) as {
+      choices: Array<{ message: { content: string } }>;
+    };
+    await send("retry-2");
+
+    expect(first.choices[0]?.message.content).toBe("Hello world");
+    expect(replay.choices[0]?.message.content).toBe("Hello world");
+    expect(runs).toBe(2);
+  });
+
+  test("failed idempotent outcomes are evicted so retries re-run", async () => {
+    __testSetBackend(fakeBackend());
+    let runs = 0;
+    __testSetRunTurnImpl(async () => {
+      runs += 1;
+      return {
+        text: "",
+        usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+        error: runs === 1 ? "transient failure" : null,
+      };
+    });
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const send = () =>
+      fetch(httpUrl(handle as AppServerHandle, "/v1/chat/completions"), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "idempotency-key": "retry-after-error",
+        },
+        body: JSON.stringify({
+          model: "memo",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      });
+
+    expect((await send()).status).toBe(500);
+    expect((await send()).status).toBe(200);
+    expect(runs).toBe(2);
+  });
+
   test("image_url parts pass through as Letta image content", async () => {
     __testSetBackend(fakeBackend());
     let capturedContent: unknown = null;

--- a/src/websocket/app-server-openai.test.ts
+++ b/src/websocket/app-server-openai.test.ts
@@ -5,7 +5,10 @@ import type { Backend } from "@/backend";
 import { __testSetBackend } from "@/backend";
 import { type AppServerHandle, startAppServer } from "@/websocket/app-server";
 import { parseAppServerWebsocketAuthSettings } from "@/websocket/app-server-auth";
-import { __testSetSendMessageStreamImpl } from "@/websocket/app-server-openai";
+import {
+  __testResetConversationMap,
+  __testSetSendMessageStreamImpl,
+} from "@/websocket/app-server-openai";
 
 const TEST_AGENTS = [
   {
@@ -20,9 +23,14 @@ const TEST_AGENTS = [
   },
 ];
 
-function fakeBackend(): Backend {
+function fakeBackend(created: string[] = []): Backend {
   return {
     listAgents: async () => TEST_AGENTS,
+    createConversation: async (body: { agent_id: string }) => {
+      const id = `conv-test-${created.length + 1}`;
+      created.push(id);
+      return { id, agent_id: body.agent_id };
+    },
   } as unknown as Backend;
 }
 
@@ -82,6 +90,7 @@ describe("app-server OpenAI-compatible API", () => {
 
   afterEach(async () => {
     __testSetSendMessageStreamImpl(null);
+    __testResetConversationMap();
     __testSetBackend(null);
     if (handle) {
       await handle.close();
@@ -178,8 +187,48 @@ describe("app-server OpenAI-compatible API", () => {
     expect(body.choices[0]?.finish_reason).toBe("stop");
     expect(body.usage.prompt_tokens).toBe(11);
     expect(body.usage.total_tokens).toBe(18);
-    expect(captured.conversation).toBe("default");
+    expect(captured.conversation).toBe("conv-test-1");
     expect(captured.agent).toBe("agent-local-111");
+  });
+
+  test("client chats map to distinct, sticky Letta conversations", async () => {
+    const created: string[] = [];
+    __testSetBackend(fakeBackend(created));
+    const conversationsUsed: string[] = [];
+    stubTurnStream(fakeTurnChunks(), (conversationId) => {
+      conversationsUsed.push(conversationId);
+    });
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const send = async (messages: unknown[]) =>
+      fetch(httpUrl(handle as AppServerHandle, "/v1/chat/completions"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "memo", messages }),
+      });
+
+    // Chat A, first message: creates a fresh conversation.
+    await send([{ role: "user", content: "first chat" }]);
+    // Chat A, second message: client resends the transcript, which now
+    // includes the reply ("Hello world") — must map back to the same
+    // conversation without creating a new one.
+    await send([
+      { role: "user", content: "first chat" },
+      { role: "assistant", content: "Hello world" },
+      { role: "user", content: "follow-up" },
+    ]);
+    // Chat B, first message: a different thread gets its own conversation.
+    await send([{ role: "user", content: "second chat" }]);
+
+    expect(conversationsUsed).toEqual([
+      "conv-test-1",
+      "conv-test-1",
+      "conv-test-2",
+    ]);
+    expect(created).toEqual(["conv-test-1", "conv-test-2"]);
   });
 
   test("POST /v1/chat/completions streams SSE chunks", async () => {

--- a/src/websocket/app-server-openai.test.ts
+++ b/src/websocket/app-server-openai.test.ts
@@ -272,6 +272,56 @@ describe("app-server OpenAI-compatible API", () => {
     expect(body.error.code).toBe("model_not_found");
   });
 
+  test("image_url parts pass through as Letta image content", async () => {
+    __testSetBackend(fakeBackend());
+    let capturedContent: unknown = null;
+    __testSetRunTurnImpl(async ({ userContent, onAssistantText }) => {
+      capturedContent = userContent;
+      onAssistantText?.("I see it");
+      return {
+        text: "I see it",
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        error: null,
+      };
+    });
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const response = await fetch(httpUrl(handle, "/v1/chat/completions"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "memo",
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "what is in this image?" },
+              {
+                type: "image_url",
+                image_url: { url: "data:image/png;base64,iVBORw0KGgo=" },
+              },
+            ],
+          },
+        ],
+      }),
+    });
+    expect(response.status).toBe(200);
+    expect(capturedContent).toEqual([
+      { type: "text", text: "what is in this image?" },
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: "iVBORw0KGgo=",
+        },
+      },
+    ]);
+  });
+
   test("missing user text returns 400", async () => {
     __testSetBackend(fakeBackend());
     handle = await startAppServer({

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import type {
   IncomingMessage as HttpIncomingMessage,
   ServerResponse,
@@ -19,6 +19,7 @@ import {
   LocalListenerTransport,
 } from "@/websocket/listener/transport";
 import { handleIncomingMessage } from "@/websocket/listener/turn";
+import { registerTurnObserver } from "@/websocket/listener/turn-observers";
 import type {
   IncomingMessage as ListenerIncomingMessage,
   ListenerRuntime,
@@ -28,11 +29,12 @@ import type {
 } from "@/websocket/listener/types";
 
 // OpenAI-compatible surface for the App Server. Each Letta agent is
-// advertised as a "model"; a chat completion request routes the last user
-// message into a Letta conversation on that agent. The resent client-side
-// history is not replayed into the agent — server-side state is
-// authoritative — but it IS used as a fingerprint to keep each client-side
-// chat pinned to its own Letta conversation across stateless requests.
+// advertised as a "model". Conversation identity is explicit or absent:
+// clients that send a stable chat id header get a pinned Letta conversation
+// that receives only the newest message (stateful mode); header-less clients
+// are served statelessly — every request runs in a fresh conversation with
+// the client's transcript replayed — because identical transcripts are
+// indistinguishable and transcript fingerprinting cross-wires them.
 const MODELS_PATH = "/v1/models";
 const CHAT_COMPLETIONS_PATH = "/v1/chat/completions";
 const MAX_REQUEST_BODY_BYTES = 20 * 1024 * 1024;
@@ -48,10 +50,21 @@ interface TurnOutcome {
   error: string | null;
 }
 
+interface BridgeTurnMessage {
+  role: "user" | "assistant";
+  content: UserContentPart[];
+  otid: string;
+}
+
 interface RunTurnParams {
   agentId: string;
   conversationId: string;
-  userContent: UserContentPart[];
+  /** Full input for the turn: the newest message in stateful mode, or the
+   * replayed client transcript in stateless mode. */
+  messages: BridgeTurnMessage[];
+  /** OTID of a message in this turn, used to correlate the listener turn
+   * lifecycle with this request. */
+  correlationOtid: string;
   onAssistantText?: (text: string) => void;
   onLog?: (message: string) => void;
 }
@@ -243,17 +256,36 @@ async function listAgentEntries(): Promise<AgentModelEntry[]> {
   return getPageItems<AgentModelEntry>(page);
 }
 
-async function handleListModels(response: ServerResponse): Promise<void> {
-  const agents = await listAgentEntries();
-  // Advertise the agent name when it is unambiguous; fall back to the agent
-  // id for duplicate names so every listed model id resolves to one agent.
+/**
+ * One collision-free advertised-id map, used by both listing and
+ * resolution. An agent name is advertised only when it is unique among
+ * names AND does not equal any agent id — otherwise the agent id is
+ * advertised — so every advertised id resolves to exactly one agent and
+ * raw agent-id lookups can never be shadowed by another agent's name.
+ */
+function buildAdvertisedModelMap(
+  agents: AgentModelEntry[],
+): Map<string, AgentModelEntry> {
+  const ids = new Set(agents.map((agent) => agent.id));
   const nameCounts = new Map<string, number>();
   for (const agent of agents) {
     if (!agent.name) continue;
     nameCounts.set(agent.name, (nameCounts.get(agent.name) ?? 0) + 1);
   }
-  const data = agents.map((agent) => ({
-    id: agent.name && nameCounts.get(agent.name) === 1 ? agent.name : agent.id,
+  const advertised = new Map<string, AgentModelEntry>();
+  for (const agent of agents) {
+    const useName =
+      agent.name && nameCounts.get(agent.name) === 1 && !ids.has(agent.name);
+    const id = useName && agent.name ? agent.name : agent.id;
+    if (!advertised.has(id)) advertised.set(id, agent);
+  }
+  return advertised;
+}
+
+async function handleListModels(response: ServerResponse): Promise<void> {
+  const advertised = buildAdvertisedModelMap(await listAgentEntries());
+  const data = [...advertised.entries()].map(([id, agent]) => ({
+    id,
     object: "model" as const,
     created: toModelCreatedTimestamp(agent.created_at),
     owned_by: "letta",
@@ -266,27 +298,17 @@ async function resolveAgentForModel(
 ): Promise<AgentModelEntry | null> {
   const agents = await listAgentEntries();
   return (
+    buildAdvertisedModelMap(agents).get(model) ??
     agents.find((agent) => agent.id === model) ??
-    agents.find((agent) => agent.name === model) ??
     null
   );
 }
 
-// Conversation continuity across stateless chat-completions requests.
-// The protocol carries no thread id, so a client chat is identified by a
-// fingerprint of its transcript prefix (the user/assistant turns before
-// the message being sent). A first message has an empty prefix and starts
-// a fresh Letta conversation; after each completed turn we also store the
-// fingerprint of the transcript including the new reply, which is exactly
-// the prefix the client will resend on its next message in that chat.
-// Bounded FIFO map: long-idle chats fall out and start a new conversation.
+// Conversation continuity for header-keyed chats. Clients that supply a
+// stable chat identity get a pinned Letta conversation; the bounded FIFO
+// map evicts long-idle chats, which then start a fresh conversation.
 const MAX_TRACKED_TRANSCRIPTS = 4096;
 const conversationIdByTranscript = new Map<string, string>();
-
-interface TranscriptTurn {
-  role: string;
-  text: string;
-}
 
 function rememberConversation(key: string, conversationId: string): void {
   conversationIdByTranscript.delete(key);
@@ -296,35 +318,6 @@ function rememberConversation(key: string, conversationId: string): void {
     if (oldest === undefined) break;
     conversationIdByTranscript.delete(oldest);
   }
-}
-
-function transcriptFingerprint(
-  agentId: string,
-  turns: TranscriptTurn[],
-): string {
-  const hash = createHash("sha256");
-  hash.update(agentId);
-  for (const turn of turns) {
-    hash.update("\0");
-    hash.update(turn.role);
-    hash.update("\0");
-    hash.update(turn.text);
-  }
-  return hash.digest("hex");
-}
-
-/** User/assistant turns with text content, in order; system turns are
- * excluded because clients vary them independently of the thread. */
-function normalizeTranscript(messages: OpenAiChatMessage[]): TranscriptTurn[] {
-  const turns: TranscriptTurn[] = [];
-  for (const message of messages) {
-    if (message.role !== "user" && message.role !== "assistant") continue;
-    turns.push({
-      role: message.role,
-      text: extractTextContent(message.content),
-    });
-  }
-  return turns;
 }
 
 // Conversation creation is serialized per agent: concurrent creations race
@@ -355,19 +348,19 @@ async function createConversationWithRetry(agentId: string): Promise<string> {
   throw lastError;
 }
 
-async function resolveConversationId(
+/** Serialized per-agent conversation creation (see note above). The
+ * optional reuseKey is re-checked after the queue drains so a concurrent
+ * request with the same key reuses the conversation it created. */
+async function createConversationSerialized(
   agentId: string,
-  prefixKey: string,
+  reuseKey?: string,
 ): Promise<string> {
-  const existing = conversationIdByTranscript.get(prefixKey);
-  if (existing) return existing;
   const tail = conversationCreateTailByAgent.get(agentId) ?? Promise.resolve();
   const creation = tail.then(async () => {
-    // Re-check after the queue drains: a concurrent request with the same
-    // key (e.g. a double-send from a header-keyed chat) may have created
-    // and remembered the conversation while this one waited.
-    const raced = conversationIdByTranscript.get(prefixKey);
-    if (raced) return raced;
+    if (reuseKey) {
+      const raced = conversationIdByTranscript.get(reuseKey);
+      if (raced) return raced;
+    }
     return await createConversationWithRetry(agentId);
   });
   const settled = creation.then(
@@ -381,6 +374,15 @@ async function resolveConversationId(
     }
   });
   return await creation;
+}
+
+async function resolveConversationId(
+  agentId: string,
+  chatKey: string,
+): Promise<string> {
+  const existing = conversationIdByTranscript.get(chatKey);
+  if (existing) return existing;
+  return await createConversationSerialized(agentId, chatKey);
 }
 
 // Clients that know their chat identity can pin it explicitly instead of
@@ -525,7 +527,16 @@ async function runTurnViaListenerRuntime(
       completion_tokens: 0,
       total_tokens: 0,
     };
+    // The request settles from ITS OWN turn's lifecycle (turn-observers,
+    // keyed by OTID), never from raw stream events: stop_reason ends a
+    // stream segment before the listener decides on retries/approvals, and
+    // usage can arrive after it. Stream deltas are accumulated only while
+    // this request's turn is active, so queued requests and WS-initiated
+    // turns in the same conversation never bleed into this response.
+    let turnActive = false;
+    let recordedError: string | null = null;
     let settled = false;
+    let unregisterTurnObserver: () => void = () => {};
     if (!listener.streamObservers) {
       listener.streamObservers = new Set();
     }
@@ -536,12 +547,21 @@ async function runTurnViaListenerRuntime(
       settled = true;
       clearTimeout(timer);
       observers.delete(observer);
+      unregisterTurnObserver();
       resolve({ text, usage, error });
     };
 
     const observer: ListenerStreamObserver = (message) => {
+      if (message.type === "runtime_stopped") {
+        finish(
+          recordedError ??
+            "server runtime was replaced while the request was in flight",
+        );
+        return;
+      }
       if (message.runtime.agent_id !== params.agentId) return;
       if (message.runtime.conversation_id !== params.conversationId) return;
+      if (!turnActive) return;
       if (message.type === "update_loop_status") {
         // The turn paused for interactive input this surface cannot provide.
         const status = (message as { loop_status?: { status?: string } })
@@ -582,38 +602,37 @@ async function runTurnViaListenerRuntime(
           };
           return;
         }
-        case "stop_reason": {
-          const stopReason = (delta as { stop_reason?: string }).stop_reason;
-          // requires_approval ends a stream segment, not the turn: the turn
-          // processor evaluates the approval (auto-approving under the
-          // conversation's permission mode) and continues. Keep observing;
-          // a WAITING_ON_APPROVAL loop status marks a truly stuck turn.
-          if (stopReason === "requires_approval") return;
-          finish(null);
-          return;
-        }
         case "loop_error": {
+          // Recorded, not settled: the listener may still retry. The turn
+          // lifecycle end decides the final outcome.
           const loopError = delta as {
             is_terminal?: boolean;
             message?: string;
           };
           if (loopError.is_terminal !== false) {
-            finish(loopError.message ?? "agent turn failed");
+            recordedError = loopError.message ?? "agent turn failed";
           }
           return;
         }
         case "error_message":
-          finish(
-            (delta as { message?: string }).message ?? "agent turn failed",
-          );
+          recordedError =
+            (delta as { message?: string }).message ?? "agent turn failed";
           return;
         default:
           return;
       }
     };
     observers.add(observer);
+    unregisterTurnObserver = registerTurnObserver(params.correlationOtid, {
+      onStarted: () => {
+        turnActive = true;
+      },
+      onFinished: () => {
+        finish(recordedError);
+      },
+    });
     const timer = setTimeout(
-      () => finish("agent turn timed out"),
+      () => finish(recordedError ?? "agent turn timed out"),
       OPENAI_TURN_TIMEOUT_MS,
     );
 
@@ -621,13 +640,7 @@ async function runTurnViaListenerRuntime(
       type: "message",
       agentId: params.agentId,
       conversationId: params.conversationId,
-      messages: [
-        {
-          role: "user",
-          content: params.userContent,
-          otid: randomUUID(),
-        },
-      ],
+      messages: params.messages,
     };
     try {
       dispatchInboundMessageWhenReady({
@@ -706,12 +719,6 @@ async function handleChatCompletions(
     return;
   }
 
-  const transcript = normalizeTranscript(body.messages);
-  const lastUserIndex = transcript.findLastIndex(
-    (turn) => turn.role === "user",
-  );
-  const userText =
-    (lastUserIndex >= 0 && transcript[lastUserIndex]?.text) || "";
   const lastUserMessage = [...body.messages]
     .reverse()
     .find((message) => message.role === "user");
@@ -738,18 +745,20 @@ async function handleChatCompletions(
     return;
   }
 
-  const prefixTurns = transcript.slice(0, lastUserIndex);
+  // Stateful mode requires a stable chat identity from the client; without
+  // one, identical transcripts are indistinguishable and any reuse
+  // heuristic can cross-wire chats. Header-less requests run statelessly:
+  // a fresh conversation per request, with the client transcript replayed.
   const headerChatKey = chatKeyFromHeaders(request);
-  const prefixKey = headerChatKey
-    ? `chat-key:${agent.id}:${headerChatKey}`
-    : transcriptFingerprint(agent.id, prefixTurns);
   let conversationId: string;
   try {
-    conversationId = await resolveConversationId(agent.id, prefixKey);
     if (headerChatKey) {
-      // Header keys are stable chat identities: pin them immediately so a
-      // concurrent request for the same chat reuses this conversation.
-      rememberConversation(prefixKey, conversationId);
+      const chatKey = `chat-key:${agent.id}:${headerChatKey}`;
+      conversationId = await resolveConversationId(agent.id, chatKey);
+      // Pin immediately so concurrent requests for this chat reuse it.
+      rememberConversation(chatKey, conversationId);
+    } else {
+      conversationId = await createConversationSerialized(agent.id);
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -759,6 +768,40 @@ async function handleChatCompletions(
       500,
       "failed to create a conversation for this chat",
       "server_error",
+    );
+    return;
+  }
+
+  const turnMessages: BridgeTurnMessage[] = [];
+  if (headerChatKey) {
+    turnMessages.push({
+      role: "user",
+      content: userContent,
+      otid: randomUUID(),
+    });
+  } else {
+    for (const message of body.messages) {
+      if (message.role !== "user" && message.role !== "assistant") continue;
+      let content: UserContentPart[];
+      if (message === lastUserMessage) {
+        content = userContent;
+      } else if (message.role === "user") {
+        content = extractUserContentParts(message.content);
+      } else {
+        const replyText = extractTextContent(message.content);
+        content = replyText ? [{ type: "text", text: replyText }] : [];
+      }
+      if (content.length === 0) continue;
+      turnMessages.push({ role: message.role, content, otid: randomUUID() });
+    }
+  }
+  const correlationOtid = turnMessages.at(-1)?.otid;
+  if (!correlationOtid) {
+    sendOpenAiError(
+      response,
+      400,
+      "the messages array must include usable content",
+      "invalid_request_error",
     );
     return;
   }
@@ -793,7 +836,8 @@ async function handleChatCompletions(
     outcome = await runTurnImpl({
       agentId: agent.id,
       conversationId,
-      userContent,
+      messages: turnMessages,
+      correlationOtid,
       onLog: options.onLog,
       onAssistantText: streaming
         ? (piece) => {
@@ -824,31 +868,6 @@ async function handleChatCompletions(
   const streamError = outcome.error;
 
   if (clientClosed) return;
-
-  if (!streamError) {
-    // Map the prefix itself (so a regenerate of the same message reuses
-    // this conversation) and the transcript including the new reply (the
-    // prefix the client resends on its next message in this chat). The
-    // EMPTY prefix is shared by every brand-new chat and must never be
-    // remembered — doing so would funnel all new chats into one
-    // conversation. Header-keyed chats are already pinned by their stable
-    // key and skip transcript bookkeeping entirely.
-    if (headerChatKey) {
-      rememberConversation(prefixKey, conversationId);
-    } else {
-      if (prefixTurns.length > 0) {
-        rememberConversation(prefixKey, conversationId);
-      }
-      rememberConversation(
-        transcriptFingerprint(agent.id, [
-          ...prefixTurns,
-          { role: "user", text: userText },
-          { role: "assistant", text: fullText },
-        ]),
-        conversationId,
-      );
-    }
-  }
 
   if (streaming) {
     if (streamError) {

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -362,7 +362,14 @@ async function resolveConversationId(
   const existing = conversationIdByTranscript.get(prefixKey);
   if (existing) return existing;
   const tail = conversationCreateTailByAgent.get(agentId) ?? Promise.resolve();
-  const creation = tail.then(() => createConversationWithRetry(agentId));
+  const creation = tail.then(async () => {
+    // Re-check after the queue drains: a concurrent request with the same
+    // key (e.g. a double-send from a header-keyed chat) may have created
+    // and remembered the conversation while this one waited.
+    const raced = conversationIdByTranscript.get(prefixKey);
+    if (raced) return raced;
+    return await createConversationWithRetry(agentId);
+  });
   const settled = creation.then(
     () => undefined,
     () => undefined,
@@ -374,6 +381,23 @@ async function resolveConversationId(
     }
   });
   return await creation;
+}
+
+// Clients that know their chat identity can pin it explicitly instead of
+// relying on transcript fingerprints, which collide when two chats have
+// byte-identical transcripts (e.g. both start "Hello" and get the same
+// verbatim reply). Open WebUI sends X-OpenWebUI-Chat-Id when
+// ENABLE_FORWARD_USER_INFO_HEADERS is on; X-Letta-Chat-Key is the generic
+// escape hatch for other clients.
+const CHAT_KEY_HEADERS = ["x-letta-chat-key", "x-openwebui-chat-id"] as const;
+
+function chatKeyFromHeaders(request: HttpIncomingMessage): string | null {
+  for (const name of CHAT_KEY_HEADERS) {
+    const value = request.headers[name];
+    if (typeof value === "string" && value) return value;
+    if (Array.isArray(value) && value[0]) return value[0];
+  }
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -715,10 +739,18 @@ async function handleChatCompletions(
   }
 
   const prefixTurns = transcript.slice(0, lastUserIndex);
-  const prefixKey = transcriptFingerprint(agent.id, prefixTurns);
+  const headerChatKey = chatKeyFromHeaders(request);
+  const prefixKey = headerChatKey
+    ? `chat-key:${agent.id}:${headerChatKey}`
+    : transcriptFingerprint(agent.id, prefixTurns);
   let conversationId: string;
   try {
     conversationId = await resolveConversationId(agent.id, prefixKey);
+    if (headerChatKey) {
+      // Header keys are stable chat identities: pin them immediately so a
+      // concurrent request for the same chat reuses this conversation.
+      rememberConversation(prefixKey, conversationId);
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     options.onLog?.(`OpenAI-compat failed to create conversation: ${message}`);
@@ -799,18 +831,23 @@ async function handleChatCompletions(
     // prefix the client resends on its next message in this chat). The
     // EMPTY prefix is shared by every brand-new chat and must never be
     // remembered — doing so would funnel all new chats into one
-    // conversation.
-    if (prefixTurns.length > 0) {
+    // conversation. Header-keyed chats are already pinned by their stable
+    // key and skip transcript bookkeeping entirely.
+    if (headerChatKey) {
       rememberConversation(prefixKey, conversationId);
+    } else {
+      if (prefixTurns.length > 0) {
+        rememberConversation(prefixKey, conversationId);
+      }
+      rememberConversation(
+        transcriptFingerprint(agent.id, [
+          ...prefixTurns,
+          { role: "user", text: userText },
+          { role: "assistant", text: fullText },
+        ]),
+        conversationId,
+      );
     }
-    rememberConversation(
-      transcriptFingerprint(agent.id, [
-        ...prefixTurns,
-        { role: "user", text: userText },
-        { role: "assistant", text: fullText },
-      ]),
-      conversationId,
-    );
   }
 
   if (streaming) {

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -1,0 +1,456 @@
+import { randomUUID } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
+import { sendMessageStream } from "@/agent/message";
+import { getBackend } from "@/backend";
+import {
+  authorizeUpgrade,
+  type WebsocketAuthPolicy,
+} from "@/websocket/app-server-auth";
+
+// OpenAI-compatible surface for the App Server. Each Letta agent is
+// advertised as a "model"; a chat completion request routes the last user
+// message into that agent's default conversation. The resent client-side
+// history is intentionally ignored — the agent's own server-side memory and
+// conversation state are authoritative.
+const MODELS_PATH = "/v1/models";
+const CHAT_COMPLETIONS_PATH = "/v1/chat/completions";
+const MAX_REQUEST_BODY_BYTES = 20 * 1024 * 1024;
+
+export interface OpenAiCompatOptions {
+  authPolicy: WebsocketAuthPolicy;
+  onLog?: (message: string) => void;
+}
+
+type SendMessageStreamImpl = (
+  ...args: Parameters<typeof sendMessageStream>
+) => Promise<AsyncIterable<LettaStreamingResponse>>;
+
+let sendMessageStreamImpl: SendMessageStreamImpl = sendMessageStream;
+
+/** @internal Test seam mirroring __testSetBackend. */
+export function __testSetSendMessageStreamImpl(
+  impl: SendMessageStreamImpl | null,
+): void {
+  sendMessageStreamImpl = impl ?? sendMessageStream;
+}
+
+interface OpenAiChatMessagePart {
+  type?: string;
+  text?: string;
+}
+
+interface OpenAiChatMessage {
+  role?: string;
+  content?: string | OpenAiChatMessagePart[] | null;
+}
+
+interface OpenAiChatCompletionRequest {
+  model?: string;
+  messages?: OpenAiChatMessage[];
+  stream?: boolean;
+}
+
+interface OpenAiUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+}
+
+export function isOpenAiCompatPath(pathname: string): boolean {
+  return pathname === MODELS_PATH || pathname === CHAT_COMPLETIONS_PATH;
+}
+
+function sendJson(
+  response: ServerResponse,
+  statusCode: number,
+  body: unknown,
+): void {
+  const payload = JSON.stringify(body);
+  response.writeHead(statusCode, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(payload),
+  });
+  response.end(payload);
+}
+
+function sendOpenAiError(
+  response: ServerResponse,
+  statusCode: number,
+  message: string,
+  type: string,
+  code: string | null = null,
+): void {
+  sendJson(response, statusCode, {
+    error: { message, type, param: null, code },
+  });
+}
+
+async function readJsonBody(request: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buffer.length;
+    if (total > MAX_REQUEST_BODY_BYTES) {
+      throw new Error("request body too large");
+    }
+    chunks.push(buffer);
+  }
+  const raw = Buffer.concat(chunks).toString("utf8");
+  if (!raw) return {};
+  return JSON.parse(raw);
+}
+
+function extractTextContent(
+  content: string | OpenAiChatMessagePart[] | null | undefined,
+): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) =>
+      part && part.type === "text" && typeof part.text === "string"
+        ? part.text
+        : "",
+    )
+    .filter(Boolean)
+    .join("\n");
+}
+
+function extractAssistantText(chunk: LettaStreamingResponse): string {
+  const content = (
+    chunk as { content?: string | Array<{ text?: string }> | null }
+  ).content;
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) =>
+      part && typeof part === "object" && typeof part.text === "string"
+        ? part.text
+        : "",
+    )
+    .join("");
+}
+
+function toModelCreatedTimestamp(createdAt: unknown): number {
+  if (typeof createdAt === "string") {
+    const ms = new Date(createdAt).getTime();
+    if (Number.isFinite(ms)) return Math.floor(ms / 1000);
+  }
+  return 0;
+}
+
+interface AgentModelEntry {
+  id: string;
+  name?: string | null;
+  created_at?: string;
+}
+
+function getPageItems<T>(page: unknown): T[] {
+  if (Array.isArray(page)) return page as T[];
+  if (page && typeof page === "object") {
+    const candidate = page as {
+      getPaginatedItems?: () => T[];
+      items?: T[];
+    };
+    if (typeof candidate.getPaginatedItems === "function") {
+      return candidate.getPaginatedItems();
+    }
+    if (Array.isArray(candidate.items)) {
+      return candidate.items;
+    }
+  }
+  return [];
+}
+
+async function listAgentEntries(): Promise<AgentModelEntry[]> {
+  const page = await getBackend().listAgents({});
+  return getPageItems<AgentModelEntry>(page);
+}
+
+async function handleListModels(response: ServerResponse): Promise<void> {
+  const agents = await listAgentEntries();
+  // Advertise the agent name when it is unambiguous; fall back to the agent
+  // id for duplicate names so every listed model id resolves to one agent.
+  const nameCounts = new Map<string, number>();
+  for (const agent of agents) {
+    if (!agent.name) continue;
+    nameCounts.set(agent.name, (nameCounts.get(agent.name) ?? 0) + 1);
+  }
+  const data = agents.map((agent) => ({
+    id: agent.name && nameCounts.get(agent.name) === 1 ? agent.name : agent.id,
+    object: "model" as const,
+    created: toModelCreatedTimestamp(agent.created_at),
+    owned_by: "letta",
+  }));
+  sendJson(response, 200, { object: "list", data });
+}
+
+async function resolveAgentForModel(
+  model: string,
+): Promise<AgentModelEntry | null> {
+  const agents = await listAgentEntries();
+  return (
+    agents.find((agent) => agent.id === model) ??
+    agents.find((agent) => agent.name === model) ??
+    null
+  );
+}
+
+function chatCompletionChunk(
+  id: string,
+  created: number,
+  model: string,
+  delta: Record<string, unknown>,
+  finishReason: string | null,
+): string {
+  return `data: ${JSON.stringify({
+    id,
+    object: "chat.completion.chunk",
+    created,
+    model,
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  })}\n\n`;
+}
+
+async function handleChatCompletions(
+  request: IncomingMessage,
+  response: ServerResponse,
+  options: OpenAiCompatOptions,
+): Promise<void> {
+  let body: OpenAiChatCompletionRequest;
+  try {
+    body = (await readJsonBody(request)) as OpenAiChatCompletionRequest;
+  } catch (error) {
+    sendOpenAiError(
+      response,
+      400,
+      error instanceof Error ? error.message : "invalid JSON body",
+      "invalid_request_error",
+    );
+    return;
+  }
+
+  if (typeof body.model !== "string" || body.model.length === 0) {
+    sendOpenAiError(
+      response,
+      400,
+      "you must provide a model parameter",
+      "invalid_request_error",
+    );
+    return;
+  }
+  if (!Array.isArray(body.messages) || body.messages.length === 0) {
+    sendOpenAiError(
+      response,
+      400,
+      "you must provide a non-empty messages array",
+      "invalid_request_error",
+    );
+    return;
+  }
+
+  const lastUserMessage = [...body.messages]
+    .reverse()
+    .find((message) => message.role === "user");
+  const userText = extractTextContent(lastUserMessage?.content);
+  if (!userText) {
+    sendOpenAiError(
+      response,
+      400,
+      "the messages array must include a user message with text content",
+      "invalid_request_error",
+    );
+    return;
+  }
+
+  const agent = await resolveAgentForModel(body.model);
+  if (!agent) {
+    sendOpenAiError(
+      response,
+      404,
+      `The model '${body.model}' does not exist. Use GET /v1/models to list available agents.`,
+      "invalid_request_error",
+      "model_not_found",
+    );
+    return;
+  }
+
+  const completionId = `chatcmpl-${randomUUID()}`;
+  const created = Math.floor(Date.now() / 1000);
+  const streaming = body.stream === true;
+  let clientClosed = false;
+  response.on("close", () => {
+    clientClosed = true;
+  });
+
+  let stream: AsyncIterable<LettaStreamingResponse>;
+  try {
+    stream = await sendMessageStreamImpl(
+      "default",
+      [
+        {
+          role: "user",
+          content: [{ type: "text", text: userText }],
+          otid: randomUUID(),
+        },
+      ],
+      { agentId: agent.id, streamTokens: true, background: true },
+    );
+  } catch (error) {
+    options.onLog?.(
+      `OpenAI-compat chat completion failed to start: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    sendOpenAiError(
+      response,
+      500,
+      "failed to start agent turn",
+      "server_error",
+    );
+    return;
+  }
+
+  if (streaming) {
+    response.writeHead(200, {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+    });
+    response.write(
+      chatCompletionChunk(
+        completionId,
+        created,
+        body.model,
+        { role: "assistant", content: "" },
+        null,
+      ),
+    );
+  }
+
+  let fullText = "";
+  let usage: OpenAiUsage = {
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    total_tokens: 0,
+  };
+  let streamError: string | null = null;
+
+  try {
+    for await (const chunk of stream) {
+      if (clientClosed) break;
+      const messageType = (chunk as { message_type?: string }).message_type;
+      if (messageType === "assistant_message") {
+        const text = extractAssistantText(chunk);
+        if (!text) continue;
+        fullText += text;
+        if (streaming) {
+          response.write(
+            chatCompletionChunk(
+              completionId,
+              created,
+              body.model,
+              { content: text },
+              null,
+            ),
+          );
+        }
+      } else if (messageType === "usage_statistics") {
+        const stats = chunk as {
+          prompt_tokens?: number;
+          completion_tokens?: number;
+          total_tokens?: number;
+        };
+        usage = {
+          prompt_tokens: stats.prompt_tokens ?? 0,
+          completion_tokens: stats.completion_tokens ?? 0,
+          total_tokens: stats.total_tokens ?? 0,
+        };
+      } else if (messageType === "error_message") {
+        streamError =
+          (chunk as { message?: string }).message ?? "agent turn failed";
+        break;
+      } else if (messageType === "stop_reason") {
+        break;
+      }
+    }
+  } catch (error) {
+    streamError = error instanceof Error ? error.message : String(error);
+  }
+
+  if (clientClosed) return;
+
+  if (streaming) {
+    if (streamError) {
+      options.onLog?.(`OpenAI-compat stream error: ${streamError}`);
+      response.write(
+        `data: ${JSON.stringify({
+          error: { message: streamError, type: "server_error" },
+        })}\n\n`,
+      );
+    } else {
+      response.write(
+        chatCompletionChunk(completionId, created, body.model, {}, "stop"),
+      );
+    }
+    response.write("data: [DONE]\n\n");
+    response.end();
+    return;
+  }
+
+  if (streamError) {
+    options.onLog?.(`OpenAI-compat stream error: ${streamError}`);
+    sendOpenAiError(response, 500, streamError, "server_error");
+    return;
+  }
+
+  sendJson(response, 200, {
+    id: completionId,
+    object: "chat.completion",
+    created,
+    model: body.model,
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content: fullText },
+        finish_reason: "stop",
+      },
+    ],
+    usage,
+  });
+}
+
+export async function handleOpenAiCompatRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  options: OpenAiCompatOptions,
+): Promise<void> {
+  const authError = authorizeUpgrade(request.headers, options.authPolicy);
+  if (authError) {
+    options.onLog?.(`Rejecting OpenAI-compat request: ${authError.message}`);
+    sendOpenAiError(response, 401, authError.message, "authentication_error");
+    return;
+  }
+
+  const pathname = new URL(request.url ?? "/", "http://localhost").pathname;
+  try {
+    if (pathname === MODELS_PATH && request.method === "GET") {
+      await handleListModels(response);
+      return;
+    }
+    if (pathname === CHAT_COMPLETIONS_PATH && request.method === "POST") {
+      await handleChatCompletions(request, response, options);
+      return;
+    }
+    sendOpenAiError(response, 404, "unknown endpoint", "invalid_request_error");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    options.onLog?.(`OpenAI-compat request failed: ${message}`);
+    if (!response.headersSent) {
+      sendOpenAiError(response, 500, message, "server_error");
+    } else {
+      response.end();
+    }
+  }
+}

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -327,26 +327,53 @@ function normalizeTranscript(messages: OpenAiChatMessage[]): TranscriptTurn[] {
   return turns;
 }
 
+// Conversation creation is serialized per agent: concurrent creations race
+// on initializing the agent's local memory repository (transient git config
+// lock failures). Failures propagate to the caller as a 500 — routing into
+// the shared "default" conversation instead would cross-wire client chats.
+const conversationCreateTailByAgent = new Map<string, Promise<void>>();
+const CONVERSATION_CREATE_RETRIES = 2;
+const CONVERSATION_CREATE_RETRY_DELAY_MS = 200;
+
+async function createConversationWithRetry(agentId: string): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= CONVERSATION_CREATE_RETRIES; attempt++) {
+    if (attempt > 0) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, CONVERSATION_CREATE_RETRY_DELAY_MS * attempt),
+      );
+    }
+    try {
+      const conversation = await getBackend().createConversation({
+        agent_id: agentId,
+      });
+      return conversation.id;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
+
 async function resolveConversationId(
   agentId: string,
   prefixKey: string,
-  onLog?: (message: string) => void,
 ): Promise<string> {
   const existing = conversationIdByTranscript.get(prefixKey);
   if (existing) return existing;
-  try {
-    const conversation = await getBackend().createConversation({
-      agent_id: agentId,
-    });
-    return conversation.id;
-  } catch (error) {
-    onLog?.(
-      `OpenAI-compat failed to create conversation, using default: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
-    return "default";
-  }
+  const tail = conversationCreateTailByAgent.get(agentId) ?? Promise.resolve();
+  const creation = tail.then(() => createConversationWithRetry(agentId));
+  const settled = creation.then(
+    () => undefined,
+    () => undefined,
+  );
+  conversationCreateTailByAgent.set(agentId, settled);
+  void settled.then(() => {
+    if (conversationCreateTailByAgent.get(agentId) === settled) {
+      conversationCreateTailByAgent.delete(agentId);
+    }
+  });
+  return await creation;
 }
 
 // ---------------------------------------------------------------------------
@@ -689,11 +716,20 @@ async function handleChatCompletions(
 
   const prefixTurns = transcript.slice(0, lastUserIndex);
   const prefixKey = transcriptFingerprint(agent.id, prefixTurns);
-  const conversationId = await resolveConversationId(
-    agent.id,
-    prefixKey,
-    options.onLog,
-  );
+  let conversationId: string;
+  try {
+    conversationId = await resolveConversationId(agent.id, prefixKey);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    options.onLog?.(`OpenAI-compat failed to create conversation: ${message}`);
+    sendOpenAiError(
+      response,
+      500,
+      "failed to create a conversation for this chat",
+      "server_error",
+    );
+    return;
+  }
 
   const completionId = `chatcmpl-${randomUUID()}`;
   const created = Math.floor(Date.now() / 1000);

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import { sendMessageStream } from "@/agent/message";
@@ -10,9 +10,10 @@ import {
 
 // OpenAI-compatible surface for the App Server. Each Letta agent is
 // advertised as a "model"; a chat completion request routes the last user
-// message into that agent's default conversation. The resent client-side
-// history is intentionally ignored — the agent's own server-side memory and
-// conversation state are authoritative.
+// message into a Letta conversation on that agent. The resent client-side
+// history is not replayed into the agent — server-side state is
+// authoritative — but it IS used as a fingerprint to keep each client-side
+// chat pinned to its own Letta conversation across stateless requests.
 const MODELS_PATH = "/v1/models";
 const CHAT_COMPLETIONS_PATH = "/v1/chat/completions";
 const MAX_REQUEST_BODY_BYTES = 20 * 1024 * 1024;
@@ -33,6 +34,11 @@ export function __testSetSendMessageStreamImpl(
   impl: SendMessageStreamImpl | null,
 ): void {
   sendMessageStreamImpl = impl ?? sendMessageStream;
+}
+
+/** @internal Clears the transcript→conversation map between tests. */
+export function __testResetConversationMap(): void {
+  conversationIdByTranscript.clear();
 }
 
 interface OpenAiChatMessagePart {
@@ -197,6 +203,83 @@ async function resolveAgentForModel(
   );
 }
 
+// Conversation continuity across stateless chat-completions requests.
+// The protocol carries no thread id, so a client chat is identified by a
+// fingerprint of its transcript prefix (the user/assistant turns before
+// the message being sent). A first message has an empty prefix and starts
+// a fresh Letta conversation; after each completed turn we also store the
+// fingerprint of the transcript including the new reply, which is exactly
+// the prefix the client will resend on its next message in that chat.
+// Bounded FIFO map: long-idle chats fall out and start a new conversation.
+const MAX_TRACKED_TRANSCRIPTS = 4096;
+const conversationIdByTranscript = new Map<string, string>();
+
+interface TranscriptTurn {
+  role: string;
+  text: string;
+}
+
+function rememberConversation(key: string, conversationId: string): void {
+  conversationIdByTranscript.delete(key);
+  conversationIdByTranscript.set(key, conversationId);
+  while (conversationIdByTranscript.size > MAX_TRACKED_TRANSCRIPTS) {
+    const oldest = conversationIdByTranscript.keys().next().value;
+    if (oldest === undefined) break;
+    conversationIdByTranscript.delete(oldest);
+  }
+}
+
+function transcriptFingerprint(
+  agentId: string,
+  turns: TranscriptTurn[],
+): string {
+  const hash = createHash("sha256");
+  hash.update(agentId);
+  for (const turn of turns) {
+    hash.update("\0");
+    hash.update(turn.role);
+    hash.update("\0");
+    hash.update(turn.text);
+  }
+  return hash.digest("hex");
+}
+
+/** User/assistant turns with text content, in order; system turns are
+ * excluded because clients vary them independently of the thread. */
+function normalizeTranscript(messages: OpenAiChatMessage[]): TranscriptTurn[] {
+  const turns: TranscriptTurn[] = [];
+  for (const message of messages) {
+    if (message.role !== "user" && message.role !== "assistant") continue;
+    turns.push({
+      role: message.role,
+      text: extractTextContent(message.content),
+    });
+  }
+  return turns;
+}
+
+async function resolveConversationId(
+  agentId: string,
+  prefixKey: string,
+  onLog?: (message: string) => void,
+): Promise<string> {
+  const existing = conversationIdByTranscript.get(prefixKey);
+  if (existing) return existing;
+  try {
+    const conversation = await getBackend().createConversation({
+      agent_id: agentId,
+    });
+    return conversation.id;
+  } catch (error) {
+    onLog?.(
+      `OpenAI-compat failed to create conversation, using default: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return "default";
+  }
+}
+
 function chatCompletionChunk(
   id: string,
   created: number,
@@ -250,10 +333,11 @@ async function handleChatCompletions(
     return;
   }
 
-  const lastUserMessage = [...body.messages]
-    .reverse()
-    .find((message) => message.role === "user");
-  const userText = extractTextContent(lastUserMessage?.content);
+  const transcript = normalizeTranscript(body.messages);
+  const lastUserIndex = transcript.findLastIndex(
+    (turn) => turn.role === "user",
+  );
+  const userText = lastUserIndex >= 0 ? transcript[lastUserIndex]?.text : "";
   if (!userText) {
     sendOpenAiError(
       response,
@@ -276,6 +360,14 @@ async function handleChatCompletions(
     return;
   }
 
+  const prefixTurns = transcript.slice(0, lastUserIndex);
+  const prefixKey = transcriptFingerprint(agent.id, prefixTurns);
+  const conversationId = await resolveConversationId(
+    agent.id,
+    prefixKey,
+    options.onLog,
+  );
+
   const completionId = `chatcmpl-${randomUUID()}`;
   const created = Math.floor(Date.now() / 1000);
   const streaming = body.stream === true;
@@ -287,7 +379,7 @@ async function handleChatCompletions(
   let stream: AsyncIterable<LettaStreamingResponse>;
   try {
     stream = await sendMessageStreamImpl(
-      "default",
+      conversationId,
       [
         {
           role: "user",
@@ -380,6 +472,26 @@ async function handleChatCompletions(
   }
 
   if (clientClosed) return;
+
+  if (!streamError) {
+    // Map the prefix itself (so a regenerate of the same message reuses
+    // this conversation) and the transcript including the new reply (the
+    // prefix the client resends on its next message in this chat). The
+    // EMPTY prefix is shared by every brand-new chat and must never be
+    // remembered — doing so would funnel all new chats into one
+    // conversation.
+    if (prefixTurns.length > 0) {
+      rememberConversation(prefixKey, conversationId);
+    }
+    rememberConversation(
+      transcriptFingerprint(agent.id, [
+        ...prefixTurns,
+        { role: "user", text: userText },
+        { role: "assistant", text: fullText },
+      ]),
+      conversationId,
+    );
+  }
 
   if (streaming) {
     if (streamError) {

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -192,8 +192,24 @@ function getPageItems<T>(page: unknown): T[] {
   return [];
 }
 
+const MAX_LISTED_AGENTS = 1000;
+
 async function listAgentEntries(): Promise<AgentModelEntry[]> {
-  const page = await getBackend().listAgents({});
+  const page = await getBackend().listAgents({ limit: MAX_LISTED_AGENTS });
+  if (Array.isArray(page)) return page as AgentModelEntry[];
+  // SDK pages are async-iterable across ALL pages; a first-page-only read
+  // silently drops agents once the list exceeds one page.
+  const iterable = page as unknown as {
+    [Symbol.asyncIterator]?: () => AsyncIterator<AgentModelEntry>;
+  };
+  if (typeof iterable[Symbol.asyncIterator] === "function") {
+    const items: AgentModelEntry[] = [];
+    for await (const item of iterable as AsyncIterable<AgentModelEntry>) {
+      items.push(item);
+      if (items.length >= MAX_LISTED_AGENTS) break;
+    }
+    return items;
+  }
   return getPageItems<AgentModelEntry>(page);
 }
 
@@ -483,60 +499,75 @@ async function handleChatCompletions(
   // heuristic can cross-wire chats. Header-less requests run statelessly:
   // a fresh conversation per request, with the client transcript replayed.
   const headerChatKey = chatKeyFromHeaders(request, body.stream === true);
-  let conversationId: string;
-  try {
-    if (headerChatKey) {
-      const chatKey = `chat-key:${agent.id}:${headerChatKey}`;
-      conversationId = await resolveConversationId(agent.id, chatKey);
-      // Pin immediately so concurrent requests for this chat reuse it.
-      rememberConversation(chatKey, conversationId);
-    } else {
-      conversationId = await createConversationSerialized(agent.id);
-    }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    options.onLog?.(`OpenAI-compat failed to create conversation: ${message}`);
-    sendOpenAiError(
-      response,
-      500,
-      "failed to create a conversation for this chat",
-      "server_error",
-    );
-    return;
-  }
+  const idempotencyHeader = idempotencyKeyFromHeaders(request);
+  const idempotencyKey = idempotencyHeader
+    ? `${agent.id}:${headerChatKey ?? ""}:${idempotencyHeader}`
+    : null;
+  // Consult the idempotency cache BEFORE any allocation: a replay must not
+  // create (and orphan) a conversation for a turn that will never run.
+  const replayPromise = idempotencyKey
+    ? outcomeByIdempotencyKey.get(idempotencyKey)
+    : undefined;
 
+  let conversationId: string | null = null;
   const turnMessages: BridgeTurnMessage[] = [];
-  if (headerChatKey) {
-    turnMessages.push({
-      role: "user",
-      content: userContent,
-      otid: randomUUID(),
-    });
-  } else {
-    for (const message of body.messages) {
-      if (message.role !== "user" && message.role !== "assistant") continue;
-      let content: UserContentPart[];
-      if (message === lastUserMessage) {
-        content = userContent;
-      } else if (message.role === "user") {
-        content = extractUserContentParts(message.content);
+  let correlationOtid: string | null = null;
+  if (!replayPromise) {
+    try {
+      if (headerChatKey) {
+        const chatKey = `chat-key:${agent.id}:${headerChatKey}`;
+        conversationId = await resolveConversationId(agent.id, chatKey);
+        // Pin immediately so concurrent requests for this chat reuse it.
+        rememberConversation(chatKey, conversationId);
       } else {
-        const replyText = extractTextContent(message.content);
-        content = replyText ? [{ type: "text", text: replyText }] : [];
+        conversationId = await createConversationSerialized(agent.id);
       }
-      if (content.length === 0) continue;
-      turnMessages.push({ role: message.role, content, otid: randomUUID() });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      options.onLog?.(
+        `OpenAI-compat failed to create conversation: ${message}`,
+      );
+      sendOpenAiError(
+        response,
+        500,
+        "failed to create a conversation for this chat",
+        "server_error",
+      );
+      return;
     }
-  }
-  const correlationOtid = turnMessages.at(-1)?.otid;
-  if (!correlationOtid) {
-    sendOpenAiError(
-      response,
-      400,
-      "the messages array must include usable content",
-      "invalid_request_error",
-    );
-    return;
+
+    if (headerChatKey) {
+      turnMessages.push({
+        role: "user",
+        content: userContent,
+        otid: randomUUID(),
+      });
+    } else {
+      for (const message of body.messages) {
+        if (message.role !== "user" && message.role !== "assistant") continue;
+        let content: UserContentPart[];
+        if (message === lastUserMessage) {
+          content = userContent;
+        } else if (message.role === "user") {
+          content = extractUserContentParts(message.content);
+        } else {
+          const replyText = extractTextContent(message.content);
+          content = replyText ? [{ type: "text", text: replyText }] : [];
+        }
+        if (content.length === 0) continue;
+        turnMessages.push({ role: message.role, content, otid: randomUUID() });
+      }
+    }
+    correlationOtid = turnMessages.at(-1)?.otid ?? null;
+    if (!correlationOtid) {
+      sendOpenAiError(
+        response,
+        400,
+        "the messages array must include usable content",
+        "invalid_request_error",
+      );
+      return;
+    }
   }
 
   const completionId = `chatcmpl-${randomUUID()}`;
@@ -564,23 +595,16 @@ async function handleChatCompletions(
     );
   }
 
-  const idempotencyHeader = idempotencyKeyFromHeaders(request);
-  const idempotencyKey = idempotencyHeader
-    ? `${agent.id}:${headerChatKey ?? ""}:${idempotencyHeader}`
-    : null;
-
   let outcome: TurnOutcome;
   try {
-    let turnPromise = idempotencyKey
-      ? outcomeByIdempotencyKey.get(idempotencyKey)
-      : undefined;
+    let turnPromise = replayPromise;
     const ownsTurn = !turnPromise;
     if (!turnPromise) {
       turnPromise = runBridgeTurn({
         agentId: agent.id,
-        conversationId,
+        conversationId: conversationId as string,
         messages: turnMessages,
-        correlationOtid,
+        correlationOtid: correlationOtid as string,
         onLog: options.onLog,
         onAssistantText: streaming
           ? (piece) => {
@@ -627,6 +651,20 @@ async function handleChatCompletions(
   const fullText = outcome.text;
   const usage = outcome.usage;
   const streamError = outcome.error;
+
+  // Headerless requests are stateless: their conversation exists only to
+  // host this turn, so remove it best-effort once the turn has settled.
+  // Header-keyed conversations persist — they ARE the chat's state.
+  if (!headerChatKey && conversationId) {
+    const ephemeralConversationId = conversationId;
+    void getBackend()
+      .deleteConversation?.(ephemeralConversationId)
+      .catch(() => {
+        options.onLog?.(
+          `OpenAI-compat failed to delete ephemeral conversation ${ephemeralConversationId}`,
+        );
+      });
+  }
 
   if (clientClosed) return;
 

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -51,7 +51,7 @@ interface TurnOutcome {
 interface RunTurnParams {
   agentId: string;
   conversationId: string;
-  userText: string;
+  userContent: UserContentPart[];
   onAssistantText?: (text: string) => void;
   onLog?: (message: string) => void;
 }
@@ -73,12 +73,22 @@ export function __testResetConversationMap(): void {
 interface OpenAiChatMessagePart {
   type?: string;
   text?: string;
+  image_url?: { url?: string } | string;
 }
 
 interface OpenAiChatMessage {
   role?: string;
   content?: string | OpenAiChatMessagePart[] | null;
 }
+
+type UserContentPart =
+  | { type: "text"; text: string }
+  | {
+      type: "image";
+      source:
+        | { type: "base64"; media_type: string; data: string }
+        | { type: "url"; url: string };
+    };
 
 interface OpenAiChatCompletionRequest {
   model?: string;
@@ -150,6 +160,51 @@ function extractTextContent(
     )
     .filter(Boolean)
     .join("\n");
+}
+
+const IMAGE_DATA_URL_RE = /^data:([^;,]+);base64,(.+)$/;
+
+function toImagePart(rawUrl: string): UserContentPart | null {
+  const match = IMAGE_DATA_URL_RE.exec(rawUrl);
+  if (match?.[1] && match[2]) {
+    return {
+      type: "image",
+      source: { type: "base64", media_type: match[1], data: match[2] },
+    };
+  }
+  if (/^https?:\/\//.test(rawUrl)) {
+    return { type: "image", source: { type: "url", url: rawUrl } };
+  }
+  return null;
+}
+
+/** OpenAI user content → Letta content parts (text and image_url). */
+function extractUserContentParts(
+  content: string | OpenAiChatMessagePart[] | null | undefined,
+): UserContentPart[] {
+  if (typeof content === "string") {
+    return content ? [{ type: "text", text: content }] : [];
+  }
+  if (!Array.isArray(content)) return [];
+  const parts: UserContentPart[] = [];
+  for (const part of content) {
+    if (!part || typeof part !== "object") continue;
+    if (part.type === "text" && typeof part.text === "string" && part.text) {
+      parts.push({ type: "text", text: part.text });
+      continue;
+    }
+    if (part.type === "image_url") {
+      const raw =
+        typeof part.image_url === "string"
+          ? part.image_url
+          : part.image_url?.url;
+      if (typeof raw === "string") {
+        const image = toImagePart(raw);
+        if (image) parts.push(image);
+      }
+    }
+  }
+  return parts;
 }
 
 function toModelCreatedTimestamp(createdAt: unknown): number {
@@ -518,7 +573,7 @@ async function runTurnViaListenerRuntime(
       messages: [
         {
           role: "user",
-          content: [{ type: "text", text: params.userText }],
+          content: params.userContent,
           otid: randomUUID(),
         },
       ],
@@ -604,12 +659,17 @@ async function handleChatCompletions(
   const lastUserIndex = transcript.findLastIndex(
     (turn) => turn.role === "user",
   );
-  const userText = lastUserIndex >= 0 ? transcript[lastUserIndex]?.text : "";
-  if (!userText) {
+  const userText =
+    (lastUserIndex >= 0 && transcript[lastUserIndex]?.text) || "";
+  const lastUserMessage = [...body.messages]
+    .reverse()
+    .find((message) => message.role === "user");
+  const userContent = extractUserContentParts(lastUserMessage?.content);
+  if (userContent.length === 0) {
     sendOpenAiError(
       response,
       400,
-      "the messages array must include a user message with text content",
+      "the messages array must include a user message with text or image content",
       "invalid_request_error",
     );
     return;
@@ -665,7 +725,7 @@ async function handleChatCompletions(
     outcome = await runTurnImpl({
       agentId: agent.id,
       conversationId,
-      userText: userText ?? "",
+      userContent,
       onLog: options.onLog,
       onAssistantText: streaming
         ? (piece) => {

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -332,15 +332,31 @@ async function resolveConversationId(
 // verbatim reply). Open WebUI sends X-OpenWebUI-Chat-Id when
 // ENABLE_FORWARD_USER_INFO_HEADERS is on; X-Letta-Chat-Key is the generic
 // escape hatch for other clients.
-const CHAT_KEY_HEADERS = ["x-letta-chat-key", "x-openwebui-chat-id"] as const;
-
-function chatKeyFromHeaders(request: HttpIncomingMessage): string | null {
-  for (const name of CHAT_KEY_HEADERS) {
-    const value = request.headers[name];
-    if (typeof value === "string" && value) return value;
-    if (Array.isArray(value) && value[0]) return value[0];
-  }
+function headerValue(
+  request: HttpIncomingMessage,
+  name: string,
+): string | null {
+  const value = request.headers[name];
+  if (typeof value === "string" && value) return value;
+  if (Array.isArray(value) && value[0]) return value[0];
   return null;
+}
+
+/**
+ * X-Letta-Chat-Key always pins chat identity. X-OpenWebUI-Chat-Id is
+ * honored only for streaming requests: Open WebUI's real chat messages
+ * always stream, while its background task requests (title/tags/follow-up
+ * generation) are non-streaming yet carry the same chat id — honoring
+ * those would route task prompts into the user's pinned conversation.
+ */
+function chatKeyFromHeaders(
+  request: HttpIncomingMessage,
+  streaming: boolean,
+): string | null {
+  const explicit = headerValue(request, "x-letta-chat-key");
+  if (explicit) return explicit;
+  if (!streaming) return null;
+  return headerValue(request, "x-openwebui-chat-id");
 }
 
 // Retry idempotency: a client retry carrying the same Idempotency-Key
@@ -355,9 +371,8 @@ function idempotencyKeyFromHeaders(
   request: HttpIncomingMessage,
 ): string | null {
   for (const name of IDEMPOTENCY_HEADERS) {
-    const value = request.headers[name];
-    if (typeof value === "string" && value) return value;
-    if (Array.isArray(value) && value[0]) return value[0];
+    const value = headerValue(request, name);
+    if (value) return value;
   }
   return null;
 }
@@ -467,7 +482,7 @@ async function handleChatCompletions(
   // one, identical transcripts are indistinguishable and any reuse
   // heuristic can cross-wire chats. Header-less requests run statelessly:
   // a fresh conversation per request, with the client transcript replayed.
-  const headerChatKey = chatKeyFromHeaders(request);
+  const headerChatKey = chatKeyFromHeaders(request, body.stream === true);
   let conversationId: string;
   try {
     if (headerChatKey) {

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -1,12 +1,31 @@
 import { createHash, randomUUID } from "node:crypto";
-import type { IncomingMessage, ServerResponse } from "node:http";
-import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
-import { sendMessageStream } from "@/agent/message";
+import type {
+  IncomingMessage as HttpIncomingMessage,
+  ServerResponse,
+} from "node:http";
 import { getBackend } from "@/backend";
+import { settingsManager } from "@/settings-manager";
 import {
   authorizeUpgrade,
   type WebsocketAuthPolicy,
 } from "@/websocket/app-server-auth";
+import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
+import { dispatchInboundMessageWhenReady } from "@/websocket/listener/inbound-dispatch";
+import { startLocalChannelListener } from "@/websocket/listener/lifecycle";
+import { getOrCreateConversationPermissionModeStateRef } from "@/websocket/listener/permission-mode";
+import { getActiveRuntime } from "@/websocket/listener/runtime";
+import {
+  type ListenerTransport,
+  LocalListenerTransport,
+} from "@/websocket/listener/transport";
+import { handleIncomingMessage } from "@/websocket/listener/turn";
+import type {
+  IncomingMessage as ListenerIncomingMessage,
+  ListenerRuntime,
+  ListenerStreamObserver,
+  ProcessQueuedTurn,
+  StartListenerOptions,
+} from "@/websocket/listener/types";
 
 // OpenAI-compatible surface for the App Server. Each Letta agent is
 // advertised as a "model"; a chat completion request routes the last user
@@ -23,17 +42,27 @@ export interface OpenAiCompatOptions {
   onLog?: (message: string) => void;
 }
 
-type SendMessageStreamImpl = (
-  ...args: Parameters<typeof sendMessageStream>
-) => Promise<AsyncIterable<LettaStreamingResponse>>;
+interface TurnOutcome {
+  text: string;
+  usage: OpenAiUsage;
+  error: string | null;
+}
 
-let sendMessageStreamImpl: SendMessageStreamImpl = sendMessageStream;
+interface RunTurnParams {
+  agentId: string;
+  conversationId: string;
+  userText: string;
+  onAssistantText?: (text: string) => void;
+  onLog?: (message: string) => void;
+}
+
+type RunTurnImpl = (params: RunTurnParams) => Promise<TurnOutcome>;
+
+let runTurnImpl: RunTurnImpl = runTurnViaListenerRuntime;
 
 /** @internal Test seam mirroring __testSetBackend. */
-export function __testSetSendMessageStreamImpl(
-  impl: SendMessageStreamImpl | null,
-): void {
-  sendMessageStreamImpl = impl ?? sendMessageStream;
+export function __testSetRunTurnImpl(impl: RunTurnImpl | null): void {
+  runTurnImpl = impl ?? runTurnViaListenerRuntime;
 }
 
 /** @internal Clears the transcript→conversation map between tests. */
@@ -92,7 +121,7 @@ function sendOpenAiError(
   });
 }
 
-async function readJsonBody(request: IncomingMessage): Promise<unknown> {
+async function readJsonBody(request: HttpIncomingMessage): Promise<unknown> {
   const chunks: Buffer[] = [];
   let total = 0;
   for await (const chunk of request) {
@@ -121,21 +150,6 @@ function extractTextContent(
     )
     .filter(Boolean)
     .join("\n");
-}
-
-function extractAssistantText(chunk: LettaStreamingResponse): string {
-  const content = (
-    chunk as { content?: string | Array<{ text?: string }> | null }
-  ).content;
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  return content
-    .map((part) =>
-      part && typeof part === "object" && typeof part.text === "string"
-        ? part.text
-        : "",
-    )
-    .join("");
 }
 
 function toModelCreatedTimestamp(createdAt: unknown): number {
@@ -280,6 +294,258 @@ async function resolveConversationId(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Turn execution over the listener v2 runtime.
+//
+// The bridge runs turns through the same dispatch path as WebSocket clients
+// (queueing → turn processor → tools/mods/permissions) and observes the
+// resulting v2 protocol stream via the runtime's in-process stream
+// observers, converting chat-completions requests into protocol inputs and
+// protocol events back into chat-completions outputs — the HTTP analogue of
+// a messaging channel.
+// ---------------------------------------------------------------------------
+
+const OPENAI_TURN_TIMEOUT_MS = 15 * 60 * 1000;
+
+const bridgeTransport = new LocalListenerTransport();
+let bridgeRuntimeStart: Promise<void> | null = null;
+
+/**
+ * Reuse the active listener runtime when one exists (a connected WS control
+ * session or channels runtime); otherwise start a socket-free local runtime,
+ * exactly like `letta server --channels` does. If a WS control client
+ * connects later it replaces the bridge-owned runtime, and subsequent
+ * requests transparently use the new active runtime.
+ */
+async function ensureListenerRuntime(
+  onLog?: (message: string) => void,
+): Promise<ListenerRuntime> {
+  const active = getActiveRuntime();
+  if (active && !active.intentionallyClosed) return active;
+
+  bridgeRuntimeStart ??= startLocalChannelListener({
+    connectionId: `openai-api-${randomUUID()}`,
+    deviceId: settingsManager.getOrCreateDeviceId(),
+    connectionName: "openai-api",
+    onConnected: () => {},
+    onError: (error) => {
+      onLog?.(`OpenAI-compat runtime error: ${error.message}`);
+    },
+  }).finally(() => {
+    bridgeRuntimeStart = null;
+  });
+  await bridgeRuntimeStart;
+
+  const runtime = getActiveRuntime();
+  if (!runtime || runtime.intentionallyClosed) {
+    throw new Error("failed to start listener runtime for OpenAI-compat API");
+  }
+  return runtime;
+}
+
+function extractDeltaText(delta: unknown): string {
+  const content = (
+    delta as { content?: string | Array<{ text?: string }> | null }
+  ).content;
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) =>
+      part && typeof part === "object" && typeof part.text === "string"
+        ? part.text
+        : "",
+    )
+    .join("");
+}
+
+async function runTurnViaListenerRuntime(
+  params: RunTurnParams,
+): Promise<TurnOutcome> {
+  const listener = await ensureListenerRuntime(params.onLog);
+  const scopedRuntime = getOrCreateScopedRuntime(
+    listener,
+    params.agentId,
+    params.conversationId,
+  );
+  // No interactive approver exists on this surface, so bridge conversations
+  // run unrestricted (Hermes-style: the API is opt-in and bearer-gated and
+  // exposes the agent's full toolset). Approvals that still arise finish the
+  // turn with an explanatory reply instead of hanging.
+  getOrCreateConversationPermissionModeStateRef(
+    listener,
+    params.agentId,
+    params.conversationId,
+  ).mode = "unrestricted";
+  // Frames emitted for this turn also flow to any attached WS client; the
+  // transport here is only the fallback destination when none is attached.
+  const socket: ListenerTransport =
+    listener.socket ?? listener.transport ?? bridgeTransport;
+
+  const dispatchOptions: StartListenerOptions = {
+    connectionId: listener.connectionId ?? "openai-api",
+    wsUrl: "",
+    deviceId: settingsManager.getOrCreateDeviceId(),
+    connectionName: listener.connectionName ?? "openai-api",
+    onConnected: () => {},
+    onDisconnected: () => {},
+    onError: (error) => {
+      params.onLog?.(`OpenAI-compat turn error: ${error.message}`);
+    },
+  };
+
+  const processQueuedTurn: ProcessQueuedTurn = async (
+    queuedTurn,
+    dequeuedBatch,
+  ) => {
+    const queuedScope = getOrCreateScopedRuntime(
+      listener,
+      queuedTurn.agentId,
+      queuedTurn.conversationId,
+    );
+    await handleIncomingMessage(
+      queuedTurn,
+      socket,
+      queuedScope,
+      undefined,
+      dispatchOptions.connectionId,
+      dequeuedBatch.batchId,
+    );
+  };
+
+  return await new Promise<TurnOutcome>((resolve) => {
+    let text = "";
+    let usage: OpenAiUsage = {
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+    };
+    let settled = false;
+    if (!listener.streamObservers) {
+      listener.streamObservers = new Set();
+    }
+    const observers = listener.streamObservers;
+
+    const finish = (error: string | null): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      observers.delete(observer);
+      resolve({ text, usage, error });
+    };
+
+    const observer: ListenerStreamObserver = (message) => {
+      if (message.runtime.agent_id !== params.agentId) return;
+      if (message.runtime.conversation_id !== params.conversationId) return;
+      if (message.type === "update_loop_status") {
+        // The turn paused for interactive input this surface cannot provide.
+        const status = (message as { loop_status?: { status?: string } })
+          .loop_status?.status;
+        if (status === "WAITING_ON_APPROVAL") {
+          if (!text) {
+            const note =
+              "The agent attempted a tool call that requires interactive approval, which this API does not support.";
+            text = note;
+            params.onAssistantText?.(note);
+          }
+          finish(null);
+        }
+        return;
+      }
+      if (message.type !== "stream_delta" || message.subagent_id) return;
+      const delta = (message as { delta?: { message_type?: string } }).delta;
+      if (!delta) return;
+      switch (delta.message_type) {
+        case "assistant_message": {
+          const piece = extractDeltaText(delta);
+          if (piece) {
+            text += piece;
+            params.onAssistantText?.(piece);
+          }
+          return;
+        }
+        case "usage_statistics": {
+          const stats = delta as {
+            prompt_tokens?: number;
+            completion_tokens?: number;
+            total_tokens?: number;
+          };
+          usage = {
+            prompt_tokens: stats.prompt_tokens ?? 0,
+            completion_tokens: stats.completion_tokens ?? 0,
+            total_tokens: stats.total_tokens ?? 0,
+          };
+          return;
+        }
+        case "stop_reason": {
+          const stopReason = (delta as { stop_reason?: string }).stop_reason;
+          // requires_approval ends a stream segment, not the turn: the turn
+          // processor evaluates the approval (auto-approving under the
+          // conversation's permission mode) and continues. Keep observing;
+          // a WAITING_ON_APPROVAL loop status marks a truly stuck turn.
+          if (stopReason === "requires_approval") return;
+          finish(null);
+          return;
+        }
+        case "loop_error": {
+          const loopError = delta as {
+            is_terminal?: boolean;
+            message?: string;
+          };
+          if (loopError.is_terminal !== false) {
+            finish(loopError.message ?? "agent turn failed");
+          }
+          return;
+        }
+        case "error_message":
+          finish(
+            (delta as { message?: string }).message ?? "agent turn failed",
+          );
+          return;
+        default:
+          return;
+      }
+    };
+    observers.add(observer);
+    const timer = setTimeout(
+      () => finish("agent turn timed out"),
+      OPENAI_TURN_TIMEOUT_MS,
+    );
+
+    const incoming: ListenerIncomingMessage = {
+      type: "message",
+      agentId: params.agentId,
+      conversationId: params.conversationId,
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: params.userText }],
+          otid: randomUUID(),
+        },
+      ],
+    };
+    try {
+      dispatchInboundMessageWhenReady({
+        listener,
+        runtime: scopedRuntime,
+        incoming,
+        socket,
+        options: dispatchOptions,
+        processQueuedTurn,
+        processIncomingMessage: handleIncomingMessage,
+        trackListenerError: (errorType, error) => {
+          params.onLog?.(
+            `OpenAI-compat listener error (${errorType}): ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        },
+      });
+    } catch (error) {
+      finish(error instanceof Error ? error.message : String(error));
+    }
+  });
+}
+
 function chatCompletionChunk(
   id: string,
   created: number,
@@ -297,7 +563,7 @@ function chatCompletionChunk(
 }
 
 async function handleChatCompletions(
-  request: IncomingMessage,
+  request: HttpIncomingMessage,
   response: ServerResponse,
   options: OpenAiCompatOptions,
 ): Promise<void> {
@@ -323,6 +589,7 @@ async function handleChatCompletions(
     );
     return;
   }
+  const model = body.model;
   if (!Array.isArray(body.messages) || body.messages.length === 0) {
     sendOpenAiError(
       response,
@@ -348,12 +615,12 @@ async function handleChatCompletions(
     return;
   }
 
-  const agent = await resolveAgentForModel(body.model);
+  const agent = await resolveAgentForModel(model);
   if (!agent) {
     sendOpenAiError(
       response,
       404,
-      `The model '${body.model}' does not exist. Use GET /v1/models to list available agents.`,
+      `The model '${model}' does not exist. Use GET /v1/models to list available agents.`,
       "invalid_request_error",
       "model_not_found",
     );
@@ -376,34 +643,6 @@ async function handleChatCompletions(
     clientClosed = true;
   });
 
-  let stream: AsyncIterable<LettaStreamingResponse>;
-  try {
-    stream = await sendMessageStreamImpl(
-      conversationId,
-      [
-        {
-          role: "user",
-          content: [{ type: "text", text: userText }],
-          otid: randomUUID(),
-        },
-      ],
-      { agentId: agent.id, streamTokens: true, background: true },
-    );
-  } catch (error) {
-    options.onLog?.(
-      `OpenAI-compat chat completion failed to start: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
-    sendOpenAiError(
-      response,
-      500,
-      "failed to start agent turn",
-      "server_error",
-    );
-    return;
-  }
-
   if (streaming) {
     response.writeHead(200, {
       "content-type": "text/event-stream",
@@ -414,62 +653,47 @@ async function handleChatCompletions(
       chatCompletionChunk(
         completionId,
         created,
-        body.model,
+        model,
         { role: "assistant", content: "" },
         null,
       ),
     );
   }
 
-  let fullText = "";
-  let usage: OpenAiUsage = {
-    prompt_tokens: 0,
-    completion_tokens: 0,
-    total_tokens: 0,
-  };
-  let streamError: string | null = null;
-
+  let outcome: TurnOutcome;
   try {
-    for await (const chunk of stream) {
-      if (clientClosed) break;
-      const messageType = (chunk as { message_type?: string }).message_type;
-      if (messageType === "assistant_message") {
-        const text = extractAssistantText(chunk);
-        if (!text) continue;
-        fullText += text;
-        if (streaming) {
-          response.write(
-            chatCompletionChunk(
-              completionId,
-              created,
-              body.model,
-              { content: text },
-              null,
-            ),
-          );
-        }
-      } else if (messageType === "usage_statistics") {
-        const stats = chunk as {
-          prompt_tokens?: number;
-          completion_tokens?: number;
-          total_tokens?: number;
-        };
-        usage = {
-          prompt_tokens: stats.prompt_tokens ?? 0,
-          completion_tokens: stats.completion_tokens ?? 0,
-          total_tokens: stats.total_tokens ?? 0,
-        };
-      } else if (messageType === "error_message") {
-        streamError =
-          (chunk as { message?: string }).message ?? "agent turn failed";
-        break;
-      } else if (messageType === "stop_reason") {
-        break;
-      }
-    }
+    outcome = await runTurnImpl({
+      agentId: agent.id,
+      conversationId,
+      userText: userText ?? "",
+      onLog: options.onLog,
+      onAssistantText: streaming
+        ? (piece) => {
+            if (clientClosed) return;
+            response.write(
+              chatCompletionChunk(
+                completionId,
+                created,
+                model,
+                { content: piece },
+                null,
+              ),
+            );
+          }
+        : undefined,
+    });
   } catch (error) {
-    streamError = error instanceof Error ? error.message : String(error);
+    const message = error instanceof Error ? error.message : String(error);
+    options.onLog?.(`OpenAI-compat chat completion failed: ${message}`);
+    outcome = {
+      text: "",
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+      error: "failed to run agent turn",
+    };
   }
+  const fullText = outcome.text;
+  const usage = outcome.usage;
+  const streamError = outcome.error;
 
   if (clientClosed) return;
 
@@ -503,7 +727,7 @@ async function handleChatCompletions(
       );
     } else {
       response.write(
-        chatCompletionChunk(completionId, created, body.model, {}, "stop"),
+        chatCompletionChunk(completionId, created, model, {}, "stop"),
       );
     }
     response.write("data: [DONE]\n\n");
@@ -521,7 +745,7 @@ async function handleChatCompletions(
     id: completionId,
     object: "chat.completion",
     created,
-    model: body.model,
+    model,
     choices: [
       {
         index: 0,
@@ -534,7 +758,7 @@ async function handleChatCompletions(
 }
 
 export async function handleOpenAiCompatRequest(
-  request: IncomingMessage,
+  request: HttpIncomingMessage,
   response: ServerResponse,
   options: OpenAiCompatOptions,
 ): Promise<void> {

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -4,29 +4,24 @@ import type {
   ServerResponse,
 } from "node:http";
 import { getBackend } from "@/backend";
-import { settingsManager } from "@/settings-manager";
 import {
   authorizeUpgrade,
   type WebsocketAuthPolicy,
 } from "@/websocket/app-server-auth";
-import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
-import { dispatchInboundMessageWhenReady } from "@/websocket/listener/inbound-dispatch";
-import { startLocalChannelListener } from "@/websocket/listener/lifecycle";
-import { getOrCreateConversationPermissionModeStateRef } from "@/websocket/listener/permission-mode";
-import { getActiveRuntime } from "@/websocket/listener/runtime";
 import {
-  type ListenerTransport,
-  LocalListenerTransport,
-} from "@/websocket/listener/transport";
-import { handleIncomingMessage } from "@/websocket/listener/turn";
-import { registerTurnObserver } from "@/websocket/listener/turn-observers";
-import type {
-  IncomingMessage as ListenerIncomingMessage,
-  ListenerRuntime,
-  ListenerStreamObserver,
-  ProcessQueuedTurn,
-  StartListenerOptions,
-} from "@/websocket/listener/types";
+  type BridgeTurnMessage,
+  runBridgeTurn,
+  type TurnOutcome,
+  type UserContentPart,
+} from "@/websocket/app-server-openai-turn";
+
+export { __testSetRunTurnImpl } from "@/websocket/app-server-openai-turn";
+
+/** @internal Clears chat-key and idempotency maps between tests. */
+export function __testResetConversationMap(): void {
+  conversationIdByTranscript.clear();
+  outcomeByIdempotencyKey.clear();
+}
 
 // OpenAI-compatible surface for the App Server. Each Letta agent is
 // advertised as a "model". Conversation identity is explicit or absent:
@@ -44,45 +39,6 @@ export interface OpenAiCompatOptions {
   onLog?: (message: string) => void;
 }
 
-interface TurnOutcome {
-  text: string;
-  usage: OpenAiUsage;
-  error: string | null;
-}
-
-interface BridgeTurnMessage {
-  role: "user" | "assistant";
-  content: UserContentPart[];
-  otid: string;
-}
-
-interface RunTurnParams {
-  agentId: string;
-  conversationId: string;
-  /** Full input for the turn: the newest message in stateful mode, or the
-   * replayed client transcript in stateless mode. */
-  messages: BridgeTurnMessage[];
-  /** OTID of a message in this turn, used to correlate the listener turn
-   * lifecycle with this request. */
-  correlationOtid: string;
-  onAssistantText?: (text: string) => void;
-  onLog?: (message: string) => void;
-}
-
-type RunTurnImpl = (params: RunTurnParams) => Promise<TurnOutcome>;
-
-let runTurnImpl: RunTurnImpl = runTurnViaListenerRuntime;
-
-/** @internal Test seam mirroring __testSetBackend. */
-export function __testSetRunTurnImpl(impl: RunTurnImpl | null): void {
-  runTurnImpl = impl ?? runTurnViaListenerRuntime;
-}
-
-/** @internal Clears the transcript→conversation map between tests. */
-export function __testResetConversationMap(): void {
-  conversationIdByTranscript.clear();
-}
-
 interface OpenAiChatMessagePart {
   type?: string;
   text?: string;
@@ -94,25 +50,10 @@ interface OpenAiChatMessage {
   content?: string | OpenAiChatMessagePart[] | null;
 }
 
-type UserContentPart =
-  | { type: "text"; text: string }
-  | {
-      type: "image";
-      source:
-        | { type: "base64"; media_type: string; data: string }
-        | { type: "url"; url: string };
-    };
-
 interface OpenAiChatCompletionRequest {
   model?: string;
   messages?: OpenAiChatMessage[];
   stream?: boolean;
-}
-
-interface OpenAiUsage {
-  prompt_tokens: number;
-  completion_tokens: number;
-  total_tokens: number;
 }
 
 export function isOpenAiCompatPath(pathname: string): boolean {
@@ -402,267 +343,44 @@ function chatKeyFromHeaders(request: HttpIncomingMessage): string | null {
   return null;
 }
 
-// ---------------------------------------------------------------------------
-// Turn execution over the listener v2 runtime.
-//
-// The bridge runs turns through the same dispatch path as WebSocket clients
-// (queueing → turn processor → tools/mods/permissions) and observes the
-// resulting v2 protocol stream via the runtime's in-process stream
-// observers, converting chat-completions requests into protocol inputs and
-// protocol events back into chat-completions outputs — the HTTP analogue of
-// a messaging channel.
-// ---------------------------------------------------------------------------
+// Retry idempotency: a client retry carrying the same Idempotency-Key
+// reuses the original request's outcome instead of running (and appending)
+// the message again. In-flight duplicates share the same turn; failed
+// outcomes are evicted so an intentional retry after an error re-runs.
+const IDEMPOTENCY_HEADERS = ["idempotency-key", "x-idempotency-key"] as const;
+const MAX_IDEMPOTENT_OUTCOMES = 1024;
+const outcomeByIdempotencyKey = new Map<string, Promise<TurnOutcome>>();
 
-const OPENAI_TURN_TIMEOUT_MS = 15 * 60 * 1000;
-
-const bridgeTransport = new LocalListenerTransport();
-let bridgeRuntimeStart: Promise<void> | null = null;
-
-/**
- * Reuse the active listener runtime when one exists (a connected WS control
- * session or channels runtime); otherwise start a socket-free local runtime,
- * exactly like `letta server --channels` does. If a WS control client
- * connects later it replaces the bridge-owned runtime, and subsequent
- * requests transparently use the new active runtime.
- */
-async function ensureListenerRuntime(
-  onLog?: (message: string) => void,
-): Promise<ListenerRuntime> {
-  const active = getActiveRuntime();
-  if (active && !active.intentionallyClosed) return active;
-
-  bridgeRuntimeStart ??= startLocalChannelListener({
-    connectionId: `openai-api-${randomUUID()}`,
-    deviceId: settingsManager.getOrCreateDeviceId(),
-    connectionName: "openai-api",
-    onConnected: () => {},
-    onError: (error) => {
-      onLog?.(`OpenAI-compat runtime error: ${error.message}`);
-    },
-  }).finally(() => {
-    bridgeRuntimeStart = null;
-  });
-  await bridgeRuntimeStart;
-
-  const runtime = getActiveRuntime();
-  if (!runtime || runtime.intentionallyClosed) {
-    throw new Error("failed to start listener runtime for OpenAI-compat API");
+function idempotencyKeyFromHeaders(
+  request: HttpIncomingMessage,
+): string | null {
+  for (const name of IDEMPOTENCY_HEADERS) {
+    const value = request.headers[name];
+    if (typeof value === "string" && value) return value;
+    if (Array.isArray(value) && value[0]) return value[0];
   }
-  return runtime;
+  return null;
 }
 
-function extractDeltaText(delta: unknown): string {
-  const content = (
-    delta as { content?: string | Array<{ text?: string }> | null }
-  ).content;
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  return content
-    .map((part) =>
-      part && typeof part === "object" && typeof part.text === "string"
-        ? part.text
-        : "",
-    )
-    .join("");
-}
-
-async function runTurnViaListenerRuntime(
-  params: RunTurnParams,
-): Promise<TurnOutcome> {
-  const listener = await ensureListenerRuntime(params.onLog);
-  const scopedRuntime = getOrCreateScopedRuntime(
-    listener,
-    params.agentId,
-    params.conversationId,
-  );
-  // No interactive approver exists on this surface, so bridge conversations
-  // run unrestricted (Hermes-style: the API is opt-in and bearer-gated and
-  // exposes the agent's full toolset). Approvals that still arise finish the
-  // turn with an explanatory reply instead of hanging.
-  getOrCreateConversationPermissionModeStateRef(
-    listener,
-    params.agentId,
-    params.conversationId,
-  ).mode = "unrestricted";
-  // Frames emitted for this turn also flow to any attached WS client; the
-  // transport here is only the fallback destination when none is attached.
-  const socket: ListenerTransport =
-    listener.socket ?? listener.transport ?? bridgeTransport;
-
-  const dispatchOptions: StartListenerOptions = {
-    connectionId: listener.connectionId ?? "openai-api",
-    wsUrl: "",
-    deviceId: settingsManager.getOrCreateDeviceId(),
-    connectionName: listener.connectionName ?? "openai-api",
-    onConnected: () => {},
-    onDisconnected: () => {},
-    onError: (error) => {
-      params.onLog?.(`OpenAI-compat turn error: ${error.message}`);
-    },
-  };
-
-  const processQueuedTurn: ProcessQueuedTurn = async (
-    queuedTurn,
-    dequeuedBatch,
-  ) => {
-    const queuedScope = getOrCreateScopedRuntime(
-      listener,
-      queuedTurn.agentId,
-      queuedTurn.conversationId,
-    );
-    await handleIncomingMessage(
-      queuedTurn,
-      socket,
-      queuedScope,
-      undefined,
-      dispatchOptions.connectionId,
-      dequeuedBatch.batchId,
-    );
-  };
-
-  return await new Promise<TurnOutcome>((resolve) => {
-    let text = "";
-    let usage: OpenAiUsage = {
-      prompt_tokens: 0,
-      completion_tokens: 0,
-      total_tokens: 0,
-    };
-    // The request settles from ITS OWN turn's lifecycle (turn-observers,
-    // keyed by OTID), never from raw stream events: stop_reason ends a
-    // stream segment before the listener decides on retries/approvals, and
-    // usage can arrive after it. Stream deltas are accumulated only while
-    // this request's turn is active, so queued requests and WS-initiated
-    // turns in the same conversation never bleed into this response.
-    let turnActive = false;
-    let recordedError: string | null = null;
-    let settled = false;
-    let unregisterTurnObserver: () => void = () => {};
-    if (!listener.streamObservers) {
-      listener.streamObservers = new Set();
+function rememberIdempotentOutcome(
+  key: string,
+  promise: Promise<TurnOutcome>,
+): void {
+  outcomeByIdempotencyKey.delete(key);
+  outcomeByIdempotencyKey.set(key, promise);
+  while (outcomeByIdempotencyKey.size > MAX_IDEMPOTENT_OUTCOMES) {
+    const oldest = outcomeByIdempotencyKey.keys().next().value;
+    if (oldest === undefined) break;
+    outcomeByIdempotencyKey.delete(oldest);
+  }
+  const evict = () => {
+    if (outcomeByIdempotencyKey.get(key) === promise) {
+      outcomeByIdempotencyKey.delete(key);
     }
-    const observers = listener.streamObservers;
-
-    const finish = (error: string | null): void => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      observers.delete(observer);
-      unregisterTurnObserver();
-      resolve({ text, usage, error });
-    };
-
-    const observer: ListenerStreamObserver = (message) => {
-      if (message.type === "runtime_stopped") {
-        finish(
-          recordedError ??
-            "server runtime was replaced while the request was in flight",
-        );
-        return;
-      }
-      if (message.runtime.agent_id !== params.agentId) return;
-      if (message.runtime.conversation_id !== params.conversationId) return;
-      if (!turnActive) return;
-      if (message.type === "update_loop_status") {
-        // The turn paused for interactive input this surface cannot provide.
-        const status = (message as { loop_status?: { status?: string } })
-          .loop_status?.status;
-        if (status === "WAITING_ON_APPROVAL") {
-          if (!text) {
-            const note =
-              "The agent attempted a tool call that requires interactive approval, which this API does not support.";
-            text = note;
-            params.onAssistantText?.(note);
-          }
-          finish(null);
-        }
-        return;
-      }
-      if (message.type !== "stream_delta" || message.subagent_id) return;
-      const delta = (message as { delta?: { message_type?: string } }).delta;
-      if (!delta) return;
-      switch (delta.message_type) {
-        case "assistant_message": {
-          const piece = extractDeltaText(delta);
-          if (piece) {
-            text += piece;
-            params.onAssistantText?.(piece);
-          }
-          return;
-        }
-        case "usage_statistics": {
-          const stats = delta as {
-            prompt_tokens?: number;
-            completion_tokens?: number;
-            total_tokens?: number;
-          };
-          usage = {
-            prompt_tokens: stats.prompt_tokens ?? 0,
-            completion_tokens: stats.completion_tokens ?? 0,
-            total_tokens: stats.total_tokens ?? 0,
-          };
-          return;
-        }
-        case "loop_error": {
-          // Recorded, not settled: the listener may still retry. The turn
-          // lifecycle end decides the final outcome.
-          const loopError = delta as {
-            is_terminal?: boolean;
-            message?: string;
-          };
-          if (loopError.is_terminal !== false) {
-            recordedError = loopError.message ?? "agent turn failed";
-          }
-          return;
-        }
-        case "error_message":
-          recordedError =
-            (delta as { message?: string }).message ?? "agent turn failed";
-          return;
-        default:
-          return;
-      }
-    };
-    observers.add(observer);
-    unregisterTurnObserver = registerTurnObserver(params.correlationOtid, {
-      onStarted: () => {
-        turnActive = true;
-      },
-      onFinished: () => {
-        finish(recordedError);
-      },
-    });
-    const timer = setTimeout(
-      () => finish(recordedError ?? "agent turn timed out"),
-      OPENAI_TURN_TIMEOUT_MS,
-    );
-
-    const incoming: ListenerIncomingMessage = {
-      type: "message",
-      agentId: params.agentId,
-      conversationId: params.conversationId,
-      messages: params.messages,
-    };
-    try {
-      dispatchInboundMessageWhenReady({
-        listener,
-        runtime: scopedRuntime,
-        incoming,
-        socket,
-        options: dispatchOptions,
-        processQueuedTurn,
-        processIncomingMessage: handleIncomingMessage,
-        trackListenerError: (errorType, error) => {
-          params.onLog?.(
-            `OpenAI-compat listener error (${errorType}): ${
-              error instanceof Error ? error.message : String(error)
-            }`,
-          );
-        },
-      });
-    } catch (error) {
-      finish(error instanceof Error ? error.message : String(error));
-    }
-  });
+  };
+  promise.then((outcome) => {
+    if (outcome.error) evict();
+  }, evict);
 }
 
 function chatCompletionChunk(
@@ -831,29 +549,57 @@ async function handleChatCompletions(
     );
   }
 
+  const idempotencyHeader = idempotencyKeyFromHeaders(request);
+  const idempotencyKey = idempotencyHeader
+    ? `${agent.id}:${headerChatKey ?? ""}:${idempotencyHeader}`
+    : null;
+
   let outcome: TurnOutcome;
   try {
-    outcome = await runTurnImpl({
-      agentId: agent.id,
-      conversationId,
-      messages: turnMessages,
-      correlationOtid,
-      onLog: options.onLog,
-      onAssistantText: streaming
-        ? (piece) => {
-            if (clientClosed) return;
-            response.write(
-              chatCompletionChunk(
-                completionId,
-                created,
-                model,
-                { content: piece },
-                null,
-              ),
-            );
-          }
-        : undefined,
-    });
+    let turnPromise = idempotencyKey
+      ? outcomeByIdempotencyKey.get(idempotencyKey)
+      : undefined;
+    const ownsTurn = !turnPromise;
+    if (!turnPromise) {
+      turnPromise = runBridgeTurn({
+        agentId: agent.id,
+        conversationId,
+        messages: turnMessages,
+        correlationOtid,
+        onLog: options.onLog,
+        onAssistantText: streaming
+          ? (piece) => {
+              if (clientClosed) return;
+              response.write(
+                chatCompletionChunk(
+                  completionId,
+                  created,
+                  model,
+                  { content: piece },
+                  null,
+                ),
+              );
+            }
+          : undefined,
+      });
+      if (idempotencyKey) {
+        rememberIdempotentOutcome(idempotencyKey, turnPromise);
+      }
+    }
+    outcome = await turnPromise;
+    // Replayed outcomes stream their text as one chunk: the incremental
+    // pieces went to the original request's response.
+    if (!ownsTurn && streaming && outcome.text && !clientClosed) {
+      response.write(
+        chatCompletionChunk(
+          completionId,
+          created,
+          model,
+          { content: outcome.text },
+          null,
+        ),
+      );
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     options.onLog?.(`OpenAI-compat chat completion failed: ${message}`);

--- a/src/websocket/app-server.ts
+++ b/src/websocket/app-server.ts
@@ -17,6 +17,7 @@ import {
   handleOpenAiCompatRequest,
   isOpenAiCompatPath,
 } from "@/websocket/app-server-openai";
+import { closeOpenAiBridgeRuntime } from "@/websocket/app-server-openai-turn";
 import {
   attachOpenListenerSocket,
   createRuntime,
@@ -474,6 +475,9 @@ export async function startAppServer(
     ...resolvedInfo,
     close: async () => {
       clearInterval(heartbeatInterval);
+      if (options.openaiApi) {
+        closeOpenAiBridgeRuntime();
+      }
       const streamSocket = clearPendingStream();
       terminateSocket(streamSocket);
       if (activeSession) {

--- a/src/websocket/app-server.ts
+++ b/src/websocket/app-server.ts
@@ -14,6 +14,10 @@ import {
   policyFromSettings,
 } from "@/websocket/app-server-auth";
 import {
+  handleOpenAiCompatRequest,
+  isOpenAiCompatPath,
+} from "@/websocket/app-server-openai";
+import {
   attachOpenListenerSocket,
   createRuntime,
   stopRuntime,
@@ -47,6 +51,8 @@ export interface StartAppServerOptions {
   listen?: string;
   websocketAuth?: AppServerWebsocketAuthSettings;
   connectionName?: string;
+  /** Serve OpenAI-compatible /v1/models and /v1/chat/completions routes. */
+  openaiApi?: boolean;
   onListening?: (info: AppServerListeningInfo) => void;
   onLog?: (message: string) => void;
   /** @internal Test override for the liveness ping cadence (ms). */
@@ -365,6 +371,13 @@ export async function startAppServer(
     if (requestUrl.pathname === "/healthz") {
       response.writeHead(200, { "content-type": "text/plain" });
       response.end("ok\n");
+      return;
+    }
+    if (options.openaiApi && isOpenAiCompatPath(requestUrl.pathname)) {
+      void handleOpenAiCompatRequest(request, response, {
+        authPolicy,
+        onLog: options.onLog,
+      });
       return;
     }
     response.writeHead(404);

--- a/src/websocket/listener/inbound-queue.ts
+++ b/src/websocket/listener/inbound-queue.ts
@@ -22,6 +22,7 @@ export function enqueueInboundUserMessage(
       firstUserPayload.client_message_id ?? `cm-submit-${crypto.randomUUID()}`,
     agentId: incoming.agentId,
     conversationId: incoming.conversationId || "default",
+    ...(incoming.noCoalesce ? { noCoalesce: true } : {}),
     // Forwarded by cloud-api for sender attribution in multi-user sandboxes.
     actingUserId,
   } as Parameters<typeof runtime.queueRuntime.enqueue>[0]);

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -103,6 +103,7 @@ import {
   safeEmitWsEvent,
   setActiveRuntime,
 } from "./runtime";
+import { notifyStreamObserversRuntimeStopped } from "./stream-observers";
 import {
   getListenerTransportKind,
   isListenerTransportOpen,
@@ -110,6 +111,7 @@ import {
   LocalListenerTransport,
 } from "./transport";
 import { handleIncomingMessage } from "./turn";
+import { escapeTaskNotificationSummary } from "./turn-events";
 import type {
   ConversationRuntime,
   IncomingMessage,
@@ -122,13 +124,6 @@ import {
   scheduleListenerWarmupsAfterSync,
 } from "./warmup";
 import { stopAllWorktreeWatchers } from "./worktree-watcher";
-
-function escapeTaskNotificationSummary(summary: string): string {
-  return summary
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
 
 function trackListenerError(
   errorType: string,
@@ -918,6 +913,7 @@ export function stopRuntime(
   runtime: ListenerRuntime,
   suppressCallbacks: boolean,
 ): void {
+  notifyStreamObserversRuntimeStopped(runtime);
   disposeListenerModAdapter(runtime);
   rejectPendingExternalToolCalls(runtime, "Listener runtime stopped");
   setMessageQueueAdder(null); // Clear bridge for ALL stop paths

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -64,6 +64,7 @@ import {
   resolveScopedAgentId,
   resolveScopedConversationId,
 } from "./scope";
+import { notifyStreamObservers } from "./stream-observers";
 import { isListenerTransportOpen, type ListenerTransport } from "./transport";
 import type {
   ConversationRuntime,
@@ -631,20 +632,15 @@ export function emitProtocolV2Message(
     }
   }
 
-  if (!isListenerTransportOpen(targetSocket)) {
-    return;
-  }
   const runtimeScope = resolveRuntimeScope(
     listener,
     getScopeForRuntime(runtime, scope),
   );
-  if (!runtimeScope) {
-    return;
-  }
+  if (!runtimeScope) return;
+  notifyStreamObservers(listener, message, runtimeScope);
+  if (!isListenerTransportOpen(targetSocket)) return;
   const eventSeq = nextEventSeq(listener);
-  if (eventSeq === null) {
-    return;
-  }
+  if (eventSeq === null) return;
   const outbound: WsProtocolMessage = {
     ...message,
     runtime: runtimeScope,

--- a/src/websocket/listener/queue-no-coalesce.test.ts
+++ b/src/websocket/listener/queue-no-coalesce.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import { getOrCreateScopedRuntime } from "./conversation-runtime";
+import { enqueueInboundUserMessage } from "./inbound-queue";
+import { createRuntime } from "./lifecycle";
+import { consumeQueuedTurn } from "./queue";
+import type { IncomingMessage } from "./types";
+
+function bridgeMessage(text: string, otid: string): IncomingMessage {
+  return {
+    type: "message",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+    noCoalesce: true,
+    messages: [
+      {
+        role: "user",
+        content: [{ type: "text", text }],
+        otid,
+        client_message_id: otid,
+      },
+    ],
+  };
+}
+
+describe("queue noCoalesce batching", () => {
+  test("noCoalesce messages drain as single-item batches with their own OTIDs", () => {
+    // Through the REAL queue path (enqueue → consumeQueuedTurn →
+    // buildQueuedTurnMessage): without noCoalesce, two same-scope messages
+    // merge into one batch that carries only the first request's OTID,
+    // which strands the second request's turn correlation.
+    const runtime = getOrCreateScopedRuntime(
+      createRuntime(),
+      "agent-1",
+      "conv-1",
+    );
+    expect(
+      enqueueInboundUserMessage(runtime, bridgeMessage("first", "otid-first")),
+    ).toBe(true);
+    expect(
+      enqueueInboundUserMessage(
+        runtime,
+        bridgeMessage("second", "otid-second"),
+      ),
+    ).toBe(true);
+
+    const first = consumeQueuedTurn(runtime);
+    expect(first?.dequeuedBatch.items).toHaveLength(1);
+    expect(first?.queuedTurn.messages).toHaveLength(1);
+    expect(first?.queuedTurn.messages[0]).toMatchObject({
+      otid: "otid-first",
+    });
+
+    const second = consumeQueuedTurn(runtime);
+    expect(second?.dequeuedBatch.items).toHaveLength(1);
+    expect(second?.queuedTurn.messages[0]).toMatchObject({
+      otid: "otid-second",
+    });
+
+    expect(consumeQueuedTurn(runtime)).toBeNull();
+  });
+
+  test("a noCoalesce message never joins a preceding coalescable batch", () => {
+    const runtime = getOrCreateScopedRuntime(
+      createRuntime(),
+      "agent-1",
+      "conv-1",
+    );
+    const plain: IncomingMessage = {
+      type: "message",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "plain" }],
+          otid: "otid-plain",
+          client_message_id: "otid-plain",
+        },
+      ],
+    };
+    expect(enqueueInboundUserMessage(runtime, plain)).toBe(true);
+    expect(
+      enqueueInboundUserMessage(
+        runtime,
+        bridgeMessage("bridge", "otid-bridge"),
+      ),
+    ).toBe(true);
+
+    const first = consumeQueuedTurn(runtime);
+    expect(first?.dequeuedBatch.items).toHaveLength(1);
+    expect(first?.queuedTurn.messages[0]).toMatchObject({
+      otid: "otid-plain",
+    });
+
+    const second = consumeQueuedTurn(runtime);
+    expect(second?.dequeuedBatch.items).toHaveLength(1);
+    expect(second?.queuedTurn.messages[0]).toMatchObject({
+      otid: "otid-bridge",
+    });
+  });
+
+  test("plain messages still coalesce (existing behavior unchanged)", () => {
+    const runtime = getOrCreateScopedRuntime(
+      createRuntime(),
+      "agent-1",
+      "conv-1",
+    );
+    for (const [text, otid] of [
+      ["one", "otid-one"],
+      ["two", "otid-two"],
+    ] as const) {
+      expect(
+        enqueueInboundUserMessage(runtime, {
+          type: "message",
+          agentId: "agent-1",
+          conversationId: "conv-1",
+          messages: [
+            {
+              role: "user",
+              content: [{ type: "text", text }],
+              otid,
+              client_message_id: otid,
+            },
+          ],
+        }),
+      ).toBe(true);
+    }
+
+    const batch = consumeQueuedTurn(runtime);
+    expect(batch?.dequeuedBatch.items).toHaveLength(2);
+    expect(consumeQueuedTurn(runtime)).toBeNull();
+  });
+});

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -337,11 +337,18 @@ export function consumeQueuedTurn(runtime: ConversationRuntime): {
   let hasCronPrompt = false;
   let hasModContinue = false;
   let batchImageFailureMode: "strict" | "drop" | null = null;
+  const isNoCoalesce = (candidate: (typeof queuedItems)[number]): boolean =>
+    candidate.kind === "message" && candidate.noCoalesce === true;
   for (const item of queuedItems) {
     if (
       !isCoalescable(item.kind) ||
       !hasSameQueueScope(firstQueuedItem, item)
     ) {
+      break;
+    }
+    // noCoalesce items run as single-item batches: one never joins an
+    // existing batch, and nothing joins a batch it started.
+    if (queueLen > 0 && (isNoCoalesce(item) || isNoCoalesce(firstQueuedItem))) {
       break;
     }
 

--- a/src/websocket/listener/stream-observers.ts
+++ b/src/websocket/listener/stream-observers.ts
@@ -1,0 +1,26 @@
+import type { ListenerRuntime, ObservedProtocolV2Message } from "./types";
+
+/**
+ * Notify in-process observers (e.g. the OpenAI-compat HTTP bridge) of an
+ * outbound v2 protocol message. Observers consume protocol messages without
+ * owning a transport, so callers must notify before any socket-open gate: a
+ * closed or absent socket must not starve them.
+ */
+export function notifyStreamObservers(
+  listener: ListenerRuntime | null,
+  message: Record<string, unknown>,
+  runtimeScope: ObservedProtocolV2Message["runtime"],
+): void {
+  if (!listener?.streamObservers?.size) return;
+  const observed = {
+    ...message,
+    runtime: runtimeScope,
+  } as ObservedProtocolV2Message;
+  for (const observer of listener.streamObservers) {
+    try {
+      observer(observed);
+    } catch (error) {
+      console.error("[Listen V2] Stream observer failed", error);
+    }
+  }
+}

--- a/src/websocket/listener/stream-observers.ts
+++ b/src/websocket/listener/stream-observers.ts
@@ -24,3 +24,27 @@ export function notifyStreamObservers(
     }
   }
 }
+
+/**
+ * Deliver a synthetic terminal event when a runtime is stopped (e.g. a WS
+ * control client replacing a bridge-owned runtime). Without this, in-flight
+ * observers would wait on turns that will never emit again. The observer set
+ * is cleared afterwards: the runtime is dead.
+ */
+export function notifyStreamObserversRuntimeStopped(
+  listener: ListenerRuntime,
+): void {
+  if (!listener.streamObservers?.size) return;
+  const observed = {
+    type: "runtime_stopped",
+    runtime: {},
+  } as ObservedProtocolV2Message;
+  for (const observer of [...listener.streamObservers]) {
+    try {
+      observer(observed);
+    } catch (error) {
+      console.error("[Listen V2] Stream observer failed on stop", error);
+    }
+  }
+  listener.streamObservers.clear();
+}

--- a/src/websocket/listener/turn-events.ts
+++ b/src/websocket/listener/turn-events.ts
@@ -24,7 +24,7 @@ import { emitCanonicalMessageDelta } from "./protocol-outbound";
 import type { ListenerTransport } from "./transport";
 import type { ConversationRuntime, ListenerRuntime } from "./types";
 
-function escapeTaskNotificationSummary(summary: string): string {
+export function escapeTaskNotificationSummary(summary: string): string {
   return summary
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")

--- a/src/websocket/listener/turn-observers.test.ts
+++ b/src/websocket/listener/turn-observers.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { notifyStreamObserversRuntimeStopped } from "./stream-observers";
+import {
+  notifyTurnFinished,
+  notifyTurnStarted,
+  registerTurnObserver,
+} from "./turn-observers";
+import type { IncomingMessage, ListenerRuntime } from "./types";
+
+function incoming(otids: Array<string | undefined>): IncomingMessage {
+  return {
+    type: "message",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+    messages: otids.map((otid) => ({
+      role: "user" as const,
+      content: "hi",
+      ...(otid ? { otid } : {}),
+    })),
+  };
+}
+
+describe("turn observers", () => {
+  test("notifies hooks for matching OTIDs only", () => {
+    const events: string[] = [];
+    const unregister = registerTurnObserver("otid-a", {
+      onStarted: () => events.push("started"),
+      onFinished: () => events.push("finished"),
+    });
+
+    notifyTurnStarted(incoming(["otid-other"]));
+    notifyTurnFinished(incoming(["otid-other"]));
+    expect(events).toEqual([]);
+
+    notifyTurnStarted(incoming(["otid-a"]));
+    notifyTurnFinished(incoming(["otid-a"]));
+    expect(events).toEqual(["started", "finished"]);
+
+    unregister();
+    notifyTurnStarted(incoming(["otid-a"]));
+    expect(events).toEqual(["started", "finished"]);
+  });
+
+  test("matches any OTID in a batched turn", () => {
+    const events: string[] = [];
+    const unregister = registerTurnObserver("otid-b", {
+      onFinished: () => events.push("finished"),
+    });
+    notifyTurnFinished(incoming(["otid-x", "otid-b"]));
+    expect(events).toEqual(["finished"]);
+    unregister();
+  });
+});
+
+describe("runtime-stopped stream notification", () => {
+  test("notifies all observers with a terminal event and clears the set", () => {
+    const seen: string[] = [];
+    const listener = {
+      streamObservers: new Set([
+        (message: { type: string }) => seen.push(`a:${message.type}`),
+        (message: { type: string }) => seen.push(`b:${message.type}`),
+      ]),
+    } as unknown as ListenerRuntime;
+
+    notifyStreamObserversRuntimeStopped(listener);
+    expect(seen).toEqual(["a:runtime_stopped", "b:runtime_stopped"]);
+    expect(listener.streamObservers?.size).toBe(0);
+  });
+});

--- a/src/websocket/listener/turn-observers.ts
+++ b/src/websocket/listener/turn-observers.ts
@@ -1,0 +1,61 @@
+import type { IncomingMessage } from "./types";
+
+/**
+ * Turn lifecycle observers keyed by message OTID.
+ *
+ * In-process protocol consumers (e.g. the OpenAI-compat HTTP bridge) need to
+ * know when the specific turn carrying THEIR message starts and finishes.
+ * Closure identity cannot provide this: the queue pump drains queued turns
+ * with whichever processQueuedTurn closure scheduled it, so a turn may be
+ * processed by another caller's closure. The turn processor itself notifies
+ * this registry for every turn, keyed by the OTIDs of the messages it
+ * carries, making correlation independent of the dispatch path.
+ */
+export interface TurnLifecycleHooks {
+  onStarted?: () => void;
+  onFinished: () => void;
+}
+
+const hooksByOtid = new Map<string, TurnLifecycleHooks>();
+
+/** Returns an unregister function. */
+export function registerTurnObserver(
+  otid: string,
+  hooks: TurnLifecycleHooks,
+): () => void {
+  hooksByOtid.set(otid, hooks);
+  return () => {
+    if (hooksByOtid.get(otid) === hooks) {
+      hooksByOtid.delete(otid);
+    }
+  };
+}
+
+function otidsOf(msg: IncomingMessage): string[] {
+  const otids: string[] = [];
+  for (const message of msg.messages) {
+    const otid = (message as { otid?: string | null }).otid;
+    if (typeof otid === "string" && otid) otids.push(otid);
+  }
+  return otids;
+}
+
+export function notifyTurnStarted(msg: IncomingMessage): void {
+  for (const otid of otidsOf(msg)) {
+    try {
+      hooksByOtid.get(otid)?.onStarted?.();
+    } catch (error) {
+      console.error("[Listen V2] Turn observer onStarted failed", error);
+    }
+  }
+}
+
+export function notifyTurnFinished(msg: IncomingMessage): void {
+  for (const otid of otidsOf(msg)) {
+    try {
+      hooksByOtid.get(otid)?.onFinished();
+    } catch (error) {
+      console.error("[Listen V2] Turn observer onFinished failed", error);
+    }
+  }
+}

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -78,6 +78,7 @@ import {
   updateTurnInputMessagesPreservingOtids,
 } from "./turn-input-state";
 import type { TurnLease } from "./turn-lifecycle";
+import { notifyTurnFinished, notifyTurnStarted } from "./turn-observers";
 import { createTurnInputSender } from "./turn-send";
 import { prepareListenerTurn } from "./turn-setup";
 import { setTurnLoopStatus } from "./turn-status";
@@ -86,6 +87,36 @@ import { seedInboundUserTranscriptLines } from "./turn-transcript";
 import type { ConversationRuntime, IncomingMessage } from "./types";
 
 export async function handleIncomingMessage(
+  msg: IncomingMessage,
+  socket: ListenerTransport,
+  runtime: ConversationRuntime,
+  onStatusChange?: (
+    status: "idle" | "receiving" | "processing",
+    connectionId: string,
+  ) => void,
+  connectionId?: string,
+  dequeuedBatchId: string = `batch-direct-${crypto.randomUUID()}`,
+  existingTurnLease?: TurnLease,
+): Promise<void> {
+  // Notify OTID-keyed turn observers (see turn-observers.ts) around the
+  // whole turn, regardless of which dispatch closure invoked it.
+  notifyTurnStarted(msg);
+  try {
+    await handleIncomingMessageInner(
+      msg,
+      socket,
+      runtime,
+      onStatusChange,
+      connectionId,
+      dequeuedBatchId,
+      existingTurnLease,
+    );
+  } finally {
+    notifyTurnFinished(msg);
+  }
+}
+
+async function handleIncomingMessageInner(
   msg: IncomingMessage,
   socket: ListenerTransport,
   runtime: ConversationRuntime,

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -86,6 +86,22 @@ export type ProcessQueuedTurn = (
   dequeuedBatch: DequeuedBatch,
 ) => Promise<void>;
 
+/**
+ * An outbound v2 protocol message as delivered to in-process stream
+ * observers: the pre-envelope message payload plus its resolved runtime
+ * scope (agent/conversation) and optional subagent attribution.
+ */
+export interface ObservedProtocolV2Message {
+  type: string;
+  runtime: { agent_id?: string | null; conversation_id?: string | null };
+  subagent_id?: string;
+  [key: string]: unknown;
+}
+
+export type ListenerStreamObserver = (
+  message: ObservedProtocolV2Message,
+) => void;
+
 export interface PendingExternalToolCall {
   resolve: (result: ExternalToolCallResult) => void;
   reject: (error: Error) => void;
@@ -265,6 +281,13 @@ export type ListenerRuntime = {
     } | null>
   >;
   lastEmittedStatus: "idle" | "receiving" | "processing" | null;
+  /**
+   * In-process observers of outbound v2 protocol messages (e.g. the
+   * OpenAI-compat HTTP bridge). Each observer receives every emitted message
+   * with its resolved runtime scope, independent of socket routing, so
+   * protocol consumers can exist without owning a WebSocket.
+   */
+  streamObservers?: Set<ListenerStreamObserver>;
   /** Unsubscribe from subagent state store (set on socket open, cleared on close). */
   _unsubscribeSubagentState?: (() => void) | undefined;
   /** Unsubscribe from subagent stream events (set on socket open, cleared on close). */

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -64,6 +64,8 @@ export interface IncomingMessage {
   type: "message";
   agentId?: string;
   conversationId?: string;
+  /** Queue this message as its own turn; never merge with other messages. */
+  noCoalesce?: boolean;
   channelTurnSources?: ChannelTurnSource[];
   clientToolAllowlist?: string[];
   externalToolScopeIds?: string[];


### PR DESCRIPTION
## Summary

Adds an OpenAI-compatible HTTP API to the App Server, enabled with a new flag:

```bash
letta server --backend local --listen ws://0.0.0.0:4500 --openai-api
```

This lets any OpenAI-compatible frontend or SDK — Open WebUI, LibreChat, LobeChat, the OpenAI Python/JS SDKs — talk to a self-hosted Letta server by pointing the base URL at `http://host:4500/v1`.

### Endpoints

- **`GET /v1/models`** — lists agents as models. Unique agent names are advertised as model ids (so pickers show `memo`, `Tutor`, …); duplicate names fall back to the agent id so every listed id resolves unambiguously.
- **`POST /v1/chat/completions`** — routes the **last user message** into a Letta conversation on the resolved agent. The client-resent history is not replayed into the agent (server-side memory and state are authoritative), but it is fingerprinted to keep each client-side chat pinned to its own Letta conversation: a first message starts a fresh conversation, and after each turn the transcript-plus-reply is mapped to that conversation — exactly the prefix the client resends next. Supports `"stream": true` with standard `chat.completion.chunk` SSE events, non-streaming aggregation with usage stats, and `image_url` content parts (data: URLs → base64 image sources, http(s) → url sources) for vision input.

### Architecture: a seam over the v2 runtime

The bridge is the HTTP analogue of a messaging channel — it converts chat-completions inputs into v2 runtime turns and v2 protocol events back into chat-completions outputs:

- **Inbound**: requests dispatch through the same path as WebSocket clients (`dispatchInboundMessageWhenReady` → queue pump → turn processor), so **tools, mods, skills, permissions, and per-conversation queueing all apply**. Tool calls execute inside the harness; verified live with real shell-tool round-trips.
- **Outbound**: a new in-process **stream-observer seam** (`stream-observers.ts`): `emitProtocolV2Message` notifies registered observers with each outbound protocol message and its resolved runtime scope, independent of socket routing. The bridge subscribes per-turn and translates `stream_delta` / `update_loop_status` events into SSE chunks. This seam is reusable by any future in-process protocol consumer.
- **Runtime lifecycle**: with no WS control session, the bridge starts a socket-free runtime via `startLocalChannelListener` (same as `letta server --channels`). When a control client is attached, its runtime is reused — and the client sees bridge-initiated turns on its stream channel.
- **Approvals**: bridge conversations run with permission mode `unrestricted` — there is no interactive approver on this surface, and the API is opt-in and bearer-gated (full toolset behind the API key). `requires_approval` stream segments are non-terminal (the turn processor evaluates and continues); if a turn does end up `WAITING_ON_APPROVAL`, the request completes with an explanatory reply instead of hanging.
- **Auth**: `/v1` routes reuse the existing WebSocket bearer policy (capability-token / signed-bearer-token) via `authorizeUpgrade`. Off by default; without `--openai-api` the routes 404.

## Testing

- 12 tests across `app-server-openai.test.ts` (wire format: flag off ⇒ 404, model listing, auth accept/reject, non-streaming aggregation, conversation stickiness/isolation, SSE shape, `model_not_found`, missing user text) and `app-server-openai-sdk.test.ts` (conformance through the real `openai` client: models.list, non-streaming + streaming create, 401 as APIError).
- Verified live from source against the local backend with real inference:
  - **shell tool execution through the API returns real command output** (`echo harness-test-$((6*7))` → `harness-test-42`)
  - streaming SSE, conversation continuity (code-phrase recall) and isolation across chats
  - image input: data-URL PNG/JPEG through the API (correct vision answers), including a 10 MB photo over streaming
  - concurrent new chats: three simultaneous first messages all complete with no conversation-creation races
  - wrong bearer token ⇒ 401
  - **Open WebUI (current release) end-to-end, user-confirmed**: agents in the model picker, streamed chats, tool-using turns, image uploads (vision replies), per-sidebar-chat Letta conversations, persistence across refresh
- `bun run check`: all checks pass except pre-existing biome errors on `main` in two untouched files; the websocket suite's `remote-settings.test.ts` failure is pre-existing on `main` (real-HOME settings cache pollution across test files) and passes in isolation.

## Follow-ups (out of scope)

- `/v1/responses` (OpenAI's stateful API) maps more faithfully onto Letta conversations (`previous_response_id` ↔ conversation) than fingerprinting.
- Optional custom SSE events for tool progress (e.g. `letta.tool.progress`) so clients can render live tool activity — the observer seam already surfaces the events; only the SSE translation is missing.
- Interactive approval bridging (render approval requests as assistant text and parse replies, like the channels' interactive flow) if `unrestricted` is too permissive for some deployments.
- Heuristic for frontend task requests (Open WebUI title generation creates one-off conversations; configuring a separate task model avoids it).
- Docs: the self-hosting page in letta-docs should gain an Open WebUI section once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBzTAACqizoyQcAZyrPoz8


