### PR TITLE
fix(cron): pre-validate --target-device against non-targetable list entries [LET-9904]

### DIFF
--- a/src/cli/subcommands/cron-runner.test.ts
+++ b/src/cli/subcommands/cron-runner.test.ts
@@ -4,6 +4,7 @@ import {
   CLOUD_CRON_UTC_NOTE,
   CLOUD_DEVICE_FALLBACK_NOTE,
   resolveCronRunner,
+  validateTargetDevice,
 } from "./cron-runner";
 
 describe("resolveCronRunner", () => {
@@ -199,5 +200,48 @@ describe("buildCloudScheduleInput", () => {
     });
     expect("target_device_id" in built.input).toBe(false);
     expect(built.notes).not.toContain(CLOUD_DEVICE_FALLBACK_NOTE);
+  });
+});
+
+describe("validateTargetDevice", () => {
+  test("registered remote device passes", () => {
+    const result = validateTargetDevice("device-railway-1", {
+      organizationId: "org-abc",
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("unknown device (no local entry) passes through to server validation", () => {
+    const result = validateTargetDevice("device-unknown", null);
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("synthetic Cloud row is rejected with omit guidance", () => {
+    const result = validateTargetDevice("__letta_cloud__", {
+      organizationId: "local",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("Omit --target-device");
+    }
+  });
+
+  test("synthetic local placeholder is rejected", () => {
+    const result = validateTargetDevice("local", null);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("letta remote");
+    }
+  });
+
+  test("desktop-local connection is rejected with letta remote guidance", () => {
+    const result = validateTargetDevice("07fca6a1-device", {
+      organizationId: "local",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("letta remote");
+      expect(result.error).toContain("desktop-local");
+    }
   });
 });

--- a/src/cli/subcommands/cron-runner.ts
+++ b/src/cli/subcommands/cron-runner.ts
@@ -94,6 +94,63 @@ export function resolveCronRunner(
   };
 }
 
+// ── Target device pre-validation ────────────────────────────────────
+
+/**
+ * Synthetic ids the Desktop environment proxy injects into
+ * `letta environments list` responses. Neither is a targetable device:
+ * - "__letta_cloud__": the synthetic "Cloud" row (the default sandbox target)
+ * - "local": the synthetic offline placeholder when no local device is registered
+ * Values mirror CLOUD_DEVICE_ID / LOCAL_CONNECTION_ID in the desktop app.
+ */
+const SYNTHETIC_CLOUD_DEVICE_ID = "__letta_cloud__";
+const SYNTHETIC_LOCAL_PLACEHOLDER_ID = "local";
+
+export type TargetDeviceValidity = { ok: true } | { ok: false; error: string };
+
+/**
+ * Pre-validate a `--target-device` value against its resolved environment
+ * entry, catching entries that appear in `letta environments list` but are
+ * not valid Cloud-schedule targets. In Desktop/local-proxy contexts the list
+ * merges desktop-local listener connections (organizationId "local" — they
+ * exist only in the local proxy, not the Letta API's environments registry)
+ * and a synthetic Cloud row. Targeting either would earn an unhelpful server
+ * 404; fail earlier with an actionable message instead.
+ *
+ * `environment` is null when the device wasn't found locally — that case is
+ * allowed through so the server's own registry check stays the backstop
+ * (the local list may be unavailable or incomplete).
+ */
+export function validateTargetDevice(
+  deviceId: string,
+  environment: { organizationId?: string } | null,
+): TargetDeviceValidity {
+  if (deviceId === SYNTHETIC_CLOUD_DEVICE_ID) {
+    return {
+      ok: false,
+      error:
+        '"Cloud" is the default execution target, not a device. Omit --target-device to run in the agent\'s cloud sandbox.',
+    };
+  }
+
+  if (deviceId === SYNTHETIC_LOCAL_PLACEHOLDER_ID) {
+    return {
+      ok: false,
+      error:
+        '"local" is a placeholder entry, not a registered device. Run `letta remote` on the machine you want to target, then use its deviceId.',
+    };
+  }
+
+  if (environment?.organizationId === "local") {
+    return {
+      ok: false,
+      error: `Device ${deviceId} is a desktop-local connection, not a registered remote. Cloud schedules can only target devices registered with the Letta API — run \`letta remote\` on that machine to register it.`,
+    };
+  }
+
+  return { ok: true };
+}
+
 // ── Cloud payload mapping ───────────────────────────────────────────
 
 export interface BuildCloudScheduleParams {

--- a/src/cli/subcommands/cron.ts
+++ b/src/cli/subcommands/cron.ts
@@ -48,6 +48,7 @@ import {
   CLOUD_EXECUTION_TARGET,
   type CronRunner,
   resolveCronRunner,
+  validateTargetDevice,
 } from "./cron-runner";
 
 // ── Usage ───────────────────────────────────────────────────────────
@@ -200,6 +201,26 @@ function isRunnerFlagValid(value: string | undefined): boolean {
   return value === undefined || value === "local" || value === "cloud";
 }
 
+/**
+ * Best-effort lookup of a --target-device id in the environments registry
+ * (through the same base URL the schedule request will use, so Desktop's
+ * merged local+cloud view is what gets validated). Returns null when the
+ * lookup fails or the device is unknown — the server-side registry check on
+ * schedule create remains the backstop for those cases.
+ */
+async function lookupEnvironmentForTarget(
+  deviceId: string,
+): Promise<{ organizationId?: string } | null> {
+  try {
+    const { getEnvironmentConnection } = await import(
+      "@/backend/api/environments"
+    );
+    return await getEnvironmentConnection(deviceId);
+  } catch {
+    return null;
+  }
+}
+
 // ── Cloud output mapping ────────────────────────────────────────────
 
 function extractPromptFromCloudSchedule(
@@ -340,6 +361,21 @@ async function handleAdd(values: CronArgValues): Promise<number> {
       "Error: --target-device requires the cloud runner. Run `letta cron add` on the target device itself (with --runner local) to schedule there locally.",
     );
     return 1;
+  }
+
+  // Pre-validate the target against the environments list: it can contain
+  // entries that are not valid Cloud-schedule targets (synthetic Cloud row,
+  // desktop-local connections). Catch those with an actionable error before
+  // hitting the server's registry 404.
+  if (targetDeviceId) {
+    const validity = validateTargetDevice(
+      targetDeviceId,
+      await lookupEnvironmentForTarget(targetDeviceId),
+    );
+    if (!validity.ok) {
+      console.error(`Error: ${validity.error}`);
+      return 1;
+    }
   }
 
   if (resolved.runner === "cloud") {


### PR DESCRIPTION
## Summary

- Follow-up to #3407: `letta cron add --target-device` tells users to get deviceIds from `letta environments list`, but in Desktop/local-proxy contexts that list merges entries that are **not** valid Cloud-schedule targets — desktop-local listener connections (`organizationId: "local"`, which exist only in the local proxy's Redis view, not the Letta API's environments registry), the synthetic Cloud row (`__letta_cloud__`), and the synthetic offline `local` placeholder. Targeting one surfaced an unhelpful server 404 for a device the user could see in the list.
- `cron add` now pre-validates the target by resolving it through the same base URL the schedule request will use, and fails with actionable guidance: desktop-local connections and the `local` placeholder point at `letta remote` registration; the Cloud row says to omit the flag (it is the default target).
- Unknown deviceIds (no local entry) deliberately still pass through to schedule creation so the server-side registry check remains the backstop — the lookup is best-effort and never blocks on its own failure.

## Verification

- 5 new unit tests for `validateTargetDevice` (registered remote passes, unknown passes through, Cloud row / local placeholder / desktop-local connection rejected with the right guidance); 23 total in `cron-runner.test.ts`, `bun run check` all green.
- Live against the Letta API through the Desktop proxy: my own desktop-local deviceId now gets the `letta remote` guidance (previously the raw 404), `__letta_cloud__` gets the omit guidance, a totally unknown id still surfaces the server 404 backstop, and a genuinely registered org device still creates (schedule verified then deleted).

👾 Generated with [Letta Code](https://letta.com)