### PR TITLE
fix(slack): put model picker on its own row

### DIFF
--- a/src/channels/commands.test.ts
+++ b/src/channels/commands.test.ts
@@ -699,15 +699,40 @@ describe("channel slash commands", () => {
     });
 
     expect(blocks).toBeDefined();
-    const selectBlock = blocks?.[1] as Record<string, unknown> | undefined;
-    const accessory = selectBlock?.accessory as
-      | { action_id?: string; type?: string; options?: unknown[] }
+    const currentBlock = blocks?.[0] as Record<string, unknown> | undefined;
+    const explanatoryBlock = blocks?.[1] as Record<string, unknown> | undefined;
+    const actionsBlock = blocks?.[2] as Record<string, unknown> | undefined;
+    const contextBlock = blocks?.[3] as Record<string, unknown> | undefined;
+    const elements = actionsBlock?.elements as
+      | Array<{
+          action_id?: string;
+          type?: string;
+          options?: Array<{ value?: string }>;
+        }>
       | undefined;
-    expect(selectBlock?.type).toBe("section");
-    expect(accessory?.type).toBe("static_select");
-    expect(accessory?.action_id).toBe("letta_channel_model_select");
-    expect(accessory?.options).toHaveLength(2);
-    expect(JSON.stringify(blocks)).toContain("Current conversation model");
+    const selectElement = elements?.[0];
+
+    expect(currentBlock?.type).toBe("section");
+    expect(JSON.stringify(currentBlock)).toContain(
+      "Current conversation model",
+    );
+    expect(explanatoryBlock).toMatchObject({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "Choose a model for this routed conversation:",
+      },
+    });
+    expect(explanatoryBlock).not.toHaveProperty("accessory");
+    expect(actionsBlock?.type).toBe("actions");
+    expect(elements).toHaveLength(1);
+    expect(selectElement?.type).toBe("static_select");
+    expect(selectElement?.action_id).toBe("letta_channel_model_select");
+    expect(selectElement?.options?.map((option) => option.value)).toEqual([
+      "sonnet",
+      "gpt",
+    ]);
+    expect(contextBlock?.type).toBe("context");
     expect(JSON.stringify(blocks)).toContain("Claude Sonnet 4.6");
   });
 

--- a/src/channels/slack/model-picker-blocks.ts
+++ b/src/channels/slack/model-picker-blocks.ts
@@ -149,17 +149,22 @@ export function buildSlackModelPickerBlocks(
         type: "mrkdwn",
         text: "Choose a model for this routed conversation:",
       },
-      accessory: {
-        type: "static_select",
-        action_id: SLACK_MODEL_SELECT_ACTION_ID,
-        placeholder: {
-          type: "plain_text",
-          text: "Select a model",
-          emoji: true,
+    },
+    {
+      type: "actions",
+      elements: [
+        {
+          type: "static_select",
+          action_id: SLACK_MODEL_SELECT_ACTION_ID,
+          placeholder: {
+            type: "plain_text",
+            text: "Select a model",
+            emoji: true,
+          },
+          options,
+          ...(initialOption ? { initial_option: initialOption } : {}),
         },
-        options,
-        ...(initialOption ? { initial_option: initialOption } : {}),
-      },
+      ],
     },
     {
       type: "context",


### PR DESCRIPTION
## Problem

Slack rendered the `/model` dropdown as an accessory to the explanatory text, squeezing it into a narrow column on the right.

## Change

Render the explanatory text as its own section, then place the existing `static_select` in a separate actions block beneath it. Selection handling, model order, initial selection, and text fallback are unchanged.

## Before / after

- Before: text and dropdown shared one row; the dropdown was narrow.
- After: the dropdown gets its own row beneath the text.

## Risk

Low. This only changes the Block Kit layout for the Slack model picker. Tests assert the exact block order and preserve model option ordering.

## Validation

- `bun test src/channels/commands.test.ts src/channels/slack/adapter.test.ts` (35 passed)
- `bun run check` (12/12 checks passed)
- `bun run typecheck`

Requested by Cameron in Slack.