### PR TITLE
feat(channels): centralized sender access control, command tiers, and /whoami

### DIFF
--- a/src/channels/README.md
+++ b/src/channels/README.md
@@ -181,11 +181,47 @@ channel command set is:
 - `/resume` — re-enable agent replies for the current routed chat.
 - `/cancel` — abort the in-progress agent turn for the current routed chat.
 - `/chat` — show the Letta web chat link for the current route.
+- `/whoami` — show the sender's access scope, tier, and runnable commands.
 - `/reflection` — start a memory reflection pass for the current route's agent
   conversation when MemFS is enabled.
 
 Slack-native slash command payloads currently exist only for `/cancel`; the rest
 are expected to be sent as normal channel messages in the relevant chat/thread.
+
+## Access control
+
+Sender access is decided centrally (`access-control.ts`) on every inbound
+message — DMs and groups, on every channel including auto-routed Slack/Discord
+traffic — before commands or routing run.
+
+Per-account fields (in `accounts.json`, snake_case):
+
+- `dm_policy` — `"open"`, `"allowlist"`, or `"pairing"` for direct messages.
+  Slack note: `"pairing"` is a legacy unenforced default on Slack and behaves
+  as `"open"`; use `"allowlist"` to restrict Slack DMs.
+- `allowed_users` — sender IDs allowed regardless of policy. `"*"` allows
+  everyone. WhatsApp/Signal entries match through identity normalization
+  (phone digits / UUID vs E.164).
+- `group_policy` — `"open"` (default, historical behavior) or `"allowlist"`,
+  which restricts group/channel senders to the allowlists below plus paired
+  users.
+- `admin_users` — enables slash-command tiers when non-empty: admins run
+  everything; other users get the read-only floor (`/help`, `/status`,
+  `/whoami`) plus `user_allowed_commands`. When unset, every allowed user has
+  full command access.
+- `user_allowed_commands` — extra commands non-admins may run.
+
+Env vars (comma-separated user IDs; merged with account config):
+
+- `LETTA_CHANNELS_ALLOWED_USERS` / `LETTA_<CHANNEL>_ALLOWED_USERS` — global /
+  per-channel allowlists. Once configured, they restrict all scopes (DMs and
+  groups) on the affected channels.
+- `LETTA_CHANNELS_ADMIN_USERS` / `LETTA_<CHANNEL>_ADMIN_USERS` — admin tiers.
+- `LETTA_CHANNELS_ALLOW_ALL_USERS=1` / `LETTA_<CHANNEL>_ALLOW_ALL_USERS=1` —
+  explicit opt-out of sender gating.
+
+Pairing approvals are a union with the allowlists: a paired sender stays
+allowed in any scope, and allowlisted senders skip the pairing handshake.
 
 ## Slack app manifest notes
 

--- a/src/channels/access-control.test.ts
+++ b/src/channels/access-control.test.ts
@@ -6,6 +6,7 @@ import {
   canonicalizeChannelCommandName,
   canRunChannelCommand,
   evaluateChannelSenderAccess,
+  floorOnlyChannelCommandGate,
   resolveChannelAccessScope,
   resolveChannelCommandGate,
 } from "@/channels/access-control";
@@ -259,6 +260,62 @@ describe("channel command tiers", () => {
   test("reflect alias canonicalizes to reflection", () => {
     expect(canonicalizeChannelCommandName("reflect")).toBe("reflection");
     expect(canonicalizeChannelCommandName("/PAUSE")).toBe("pause");
+  });
+
+  test("userAllowedCommands entries are alias-canonicalized", () => {
+    const gate = resolveChannelCommandGate({
+      account: makeAccount({
+        adminUsers: ["admin-1"],
+        userAllowedCommands: ["reflect"],
+      }),
+      channelId: "testchan",
+      senderId: "user-1",
+    });
+    expect(canRunChannelCommand(gate, "reflection")).toBe(true);
+    expect(canRunChannelCommand(gate, "reflect")).toBe(true);
+  });
+
+  test("admin matching uses channel identity normalization", () => {
+    const whatsappGate = resolveChannelCommandGate({
+      account: makeAccount({ adminUsers: ["+1234567890"] }),
+      channelId: "whatsapp",
+      senderId: "1234567890",
+    });
+    expect(whatsappGate.isAdmin).toBe(true);
+
+    const signalGate = resolveChannelCommandGate({
+      account: makeAccount({ adminUsers: ["signal:+15551234567"] }),
+      channelId: "signal",
+      senderId: "+15551234567",
+    });
+    expect(signalGate.isAdmin).toBe(true);
+
+    const exactGate = resolveChannelCommandGate({
+      account: makeAccount({ adminUsers: ["+1234567890"] }),
+      channelId: "testchan",
+      senderId: "1234567890",
+    });
+    expect(exactGate.isAdmin).toBe(false);
+  });
+
+  test("pre-pairing floor gate blocks mutating commands regardless of admins", () => {
+    const gate = floorOnlyChannelCommandGate();
+    expect(gate.enabled).toBe(true);
+    expect(canRunChannelCommand(gate, "help")).toBe(true);
+    expect(canRunChannelCommand(gate, "status")).toBe(true);
+    expect(canRunChannelCommand(gate, "whoami")).toBe(true);
+    expect(canRunChannelCommand(gate, "cancel")).toBe(false);
+    expect(canRunChannelCommand(gate, "model")).toBe(false);
+    expect(canRunChannelCommand(gate, "pause")).toBe(false);
+
+    const denial = buildChannelCommandDeniedMessage("testchan", "cancel", gate);
+    expect(denial).toContain("available after pairing completes");
+
+    const whoami = buildChannelWhoamiMessage(
+      { channel: "testchan", senderId: "user-1", chatType: "direct" },
+      gate,
+    );
+    expect(whoami).toContain("Tier: pending pairing");
   });
 });
 

--- a/src/channels/access-control.test.ts
+++ b/src/channels/access-control.test.ts
@@ -1,0 +1,385 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  buildChannelCommandDeniedMessage,
+  buildChannelWhoamiMessage,
+  type ChannelAccessAccount,
+  canonicalizeChannelCommandName,
+  canRunChannelCommand,
+  evaluateChannelSenderAccess,
+  resolveChannelAccessScope,
+  resolveChannelCommandGate,
+} from "@/channels/access-control";
+import { tryHandleChannelSlashCommand } from "@/channels/commands";
+import type { ChannelAdapter, ChannelChatType } from "@/channels/types";
+
+const ENV_KEYS = [
+  "LETTA_CHANNELS_ALLOWED_USERS",
+  "LETTA_CHANNELS_ADMIN_USERS",
+  "LETTA_CHANNELS_ALLOW_ALL_USERS",
+  "LETTA_TESTCHAN_ALLOWED_USERS",
+  "LETTA_TESTCHAN_ADMIN_USERS",
+  "LETTA_TESTCHAN_ALLOW_ALL_USERS",
+];
+
+const savedEnv = new Map<string, string | undefined>(
+  ENV_KEYS.map((key) => [key, process.env[key]]),
+);
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const saved = savedEnv.get(key);
+    if (saved === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = saved;
+    }
+  }
+});
+
+function makeAccount(
+  overrides: Partial<ChannelAccessAccount> = {},
+): ChannelAccessAccount {
+  return {
+    accountId: "acct-1",
+    dmPolicy: "open",
+    allowedUsers: [],
+    ...overrides,
+  };
+}
+
+function evaluate(params: {
+  account: ChannelAccessAccount;
+  senderId?: string;
+  chatType?: ChannelChatType;
+  channelId?: string;
+}) {
+  return evaluateChannelSenderAccess({
+    account: params.account,
+    channelId: params.channelId ?? "testchan",
+    senderId: params.senderId ?? "user-1",
+    chatType: params.chatType,
+  });
+}
+
+describe("resolveChannelAccessScope", () => {
+  test("maps chat types to scopes", () => {
+    expect(resolveChannelAccessScope("channel")).toBe("group");
+    expect(resolveChannelAccessScope("direct")).toBe("dm");
+    expect(resolveChannelAccessScope(undefined)).toBe("dm");
+  });
+});
+
+describe("evaluateChannelSenderAccess — DM scope", () => {
+  test("open policy allows anyone", () => {
+    expect(evaluate({ account: makeAccount() })).toBe("allow");
+  });
+
+  test("allowlist policy denies unlisted and allows listed senders", () => {
+    const account = makeAccount({
+      dmPolicy: "allowlist",
+      allowedUsers: ["user-2"],
+    });
+    expect(evaluate({ account })).toBe("deny");
+    expect(evaluate({ account, senderId: "user-2" })).toBe("allow");
+  });
+
+  test("pairing policy asks unapproved senders to pair", () => {
+    const account = makeAccount({ dmPolicy: "pairing" });
+    expect(evaluate({ account })).toBe("pair");
+  });
+
+  test("pairing policy treats allowlisted senders as approved", () => {
+    const account = makeAccount({
+      dmPolicy: "pairing",
+      allowedUsers: ["user-1"],
+    });
+    expect(evaluate({ account })).toBe("allow");
+  });
+
+  test("admin users are implicitly allowlisted", () => {
+    const account = makeAccount({
+      dmPolicy: "allowlist",
+      adminUsers: ["user-1"],
+    });
+    expect(evaluate({ account })).toBe("allow");
+  });
+
+  test("wildcard allowlist entry allows everyone", () => {
+    const account = makeAccount({
+      dmPolicy: "allowlist",
+      allowedUsers: ["*"],
+    });
+    expect(evaluate({ account, senderId: "anyone" })).toBe("allow");
+  });
+
+  test("slack legacy pairing default behaves as open", () => {
+    const account = makeAccount({ dmPolicy: "pairing" });
+    expect(evaluate({ account, channelId: "slack" })).toBe("allow");
+  });
+
+  test("slack explicit allowlist is enforced", () => {
+    const account = makeAccount({
+      dmPolicy: "allowlist",
+      allowedUsers: ["user-2"],
+    });
+    expect(evaluate({ account, channelId: "slack" })).toBe("deny");
+  });
+});
+
+describe("evaluateChannelSenderAccess — group scope", () => {
+  test("groups stay open by default", () => {
+    const account = makeAccount({ dmPolicy: "pairing" });
+    expect(evaluate({ account, chatType: "channel" })).toBe("allow");
+  });
+
+  test("groupPolicy allowlist denies unlisted group senders silently", () => {
+    const account = makeAccount({
+      groupPolicy: "allowlist",
+      allowedUsers: ["user-2"],
+    });
+    expect(evaluate({ account, chatType: "channel" })).toBe("deny");
+    expect(evaluate({ account, chatType: "channel", senderId: "user-2" })).toBe(
+      "allow",
+    );
+  });
+
+  test("groups never receive a pair decision", () => {
+    const account = makeAccount({
+      dmPolicy: "pairing",
+      groupPolicy: "allowlist",
+    });
+    expect(evaluate({ account, chatType: "channel" })).toBe("deny");
+  });
+});
+
+describe("evaluateChannelSenderAccess — env allowlists", () => {
+  test("global env allowlist restricts every scope once configured", () => {
+    process.env.LETTA_CHANNELS_ALLOWED_USERS = "user-9";
+    const account = makeAccount();
+    expect(evaluate({ account })).toBe("deny");
+    expect(evaluate({ account, chatType: "channel" })).toBe("deny");
+    expect(evaluate({ account, senderId: "user-9" })).toBe("allow");
+    expect(evaluate({ account, chatType: "channel", senderId: "user-9" })).toBe(
+      "allow",
+    );
+  });
+
+  test("per-channel env allowlist merges with account allowlist", () => {
+    process.env.LETTA_TESTCHAN_ALLOWED_USERS = "user-7, user-8";
+    const account = makeAccount({
+      dmPolicy: "allowlist",
+      allowedUsers: ["user-2"],
+    });
+    expect(evaluate({ account, senderId: "user-7" })).toBe("allow");
+    expect(evaluate({ account, senderId: "user-2" })).toBe("allow");
+    expect(evaluate({ account, senderId: "user-3" })).toBe("deny");
+  });
+
+  test("env allowlist overrides slack legacy-open pairing default", () => {
+    process.env.LETTA_CHANNELS_ALLOWED_USERS = "user-9";
+    const account = makeAccount({ dmPolicy: "pairing" });
+    expect(evaluate({ account, channelId: "slack" })).toBe("deny");
+  });
+
+  test("allow-all env flag bypasses every restriction", () => {
+    process.env.LETTA_TESTCHAN_ALLOW_ALL_USERS = "1";
+    const account = makeAccount({
+      dmPolicy: "allowlist",
+      groupPolicy: "allowlist",
+      allowedUsers: [],
+    });
+    expect(evaluate({ account })).toBe("allow");
+    expect(evaluate({ account, chatType: "channel" })).toBe("allow");
+  });
+});
+
+describe("channel command tiers", () => {
+  test("gating is disabled until an admin is configured", () => {
+    const gate = resolveChannelCommandGate({
+      account: makeAccount(),
+      channelId: "testchan",
+      senderId: "user-1",
+    });
+    expect(gate.enabled).toBe(false);
+    expect(canRunChannelCommand(gate, "pause")).toBe(true);
+    expect(canRunChannelCommand(gate, "model")).toBe(true);
+  });
+
+  test("admins can run everything; users get the read-only floor", () => {
+    const account = makeAccount({ adminUsers: ["admin-1"] });
+    const adminGate = resolveChannelCommandGate({
+      account,
+      channelId: "testchan",
+      senderId: "admin-1",
+    });
+    expect(adminGate.isAdmin).toBe(true);
+    expect(canRunChannelCommand(adminGate, "pause")).toBe(true);
+
+    const userGate = resolveChannelCommandGate({
+      account,
+      channelId: "testchan",
+      senderId: "user-1",
+    });
+    expect(userGate.enabled).toBe(true);
+    expect(userGate.isAdmin).toBe(false);
+    expect(canRunChannelCommand(userGate, "help")).toBe(true);
+    expect(canRunChannelCommand(userGate, "status")).toBe(true);
+    expect(canRunChannelCommand(userGate, "whoami")).toBe(true);
+    expect(canRunChannelCommand(userGate, "pause")).toBe(false);
+    expect(canRunChannelCommand(userGate, "model")).toBe(false);
+  });
+
+  test("userAllowedCommands extends the floor and normalizes names", () => {
+    const account = makeAccount({
+      adminUsers: ["admin-1"],
+      userAllowedCommands: ["/Model", "cancel"],
+    });
+    const gate = resolveChannelCommandGate({
+      account,
+      channelId: "testchan",
+      senderId: "user-1",
+    });
+    expect(canRunChannelCommand(gate, "model")).toBe(true);
+    expect(canRunChannelCommand(gate, "cancel")).toBe(true);
+    expect(canRunChannelCommand(gate, "pause")).toBe(false);
+  });
+
+  test("env admin lists activate gating", () => {
+    process.env.LETTA_TESTCHAN_ADMIN_USERS = "admin-9";
+    const gate = resolveChannelCommandGate({
+      account: makeAccount(),
+      channelId: "testchan",
+      senderId: "user-1",
+    });
+    expect(gate.enabled).toBe(true);
+    expect(gate.isAdmin).toBe(false);
+    expect(canRunChannelCommand(gate, "pause")).toBe(false);
+  });
+
+  test("reflect alias canonicalizes to reflection", () => {
+    expect(canonicalizeChannelCommandName("reflect")).toBe("reflection");
+    expect(canonicalizeChannelCommandName("/PAUSE")).toBe("pause");
+  });
+});
+
+describe("whoami and denial messages", () => {
+  const msg = {
+    channel: "testchan",
+    senderId: "user-1",
+    senderName: "Sam",
+    chatType: "direct" as ChannelChatType,
+  };
+
+  test("whoami reports unrestricted tier when gating is off", () => {
+    const text = buildChannelWhoamiMessage(msg, undefined);
+    expect(text).toContain("Sam (user-1)");
+    expect(text).toContain("DM");
+    expect(text).toContain("Tier: unrestricted");
+  });
+
+  test("whoami reports user tier with runnable commands", () => {
+    const gate = resolveChannelCommandGate({
+      account: makeAccount({
+        adminUsers: ["admin-1"],
+        userAllowedCommands: ["model"],
+      }),
+      channelId: "testchan",
+      senderId: "user-1",
+    });
+    const text = buildChannelWhoamiMessage(
+      { ...msg, chatType: "channel" },
+      gate,
+    );
+    expect(text).toContain("group/channel");
+    expect(text).toContain("Tier: user");
+    expect(text).toContain("/help, /status, /whoami, /model");
+  });
+
+  test("denial message lists the runnable floor", () => {
+    const gate = resolveChannelCommandGate({
+      account: makeAccount({ adminUsers: ["admin-1"] }),
+      channelId: "testchan",
+      senderId: "user-1",
+    });
+    const text = buildChannelCommandDeniedMessage("testchan", "pause", gate);
+    expect(text).toContain("/pause is limited to admins");
+    expect(text).toContain("/help, /status, /whoami");
+  });
+});
+
+describe("tryHandleChannelSlashCommand gating", () => {
+  function makeAdapter(replies: { chatId: string; text: string }[]) {
+    return {
+      id: "testchan",
+      channelId: "testchan",
+      name: "testchan",
+      async start() {},
+      async stop() {},
+      isRunning: () => true,
+      async sendMessage() {
+        return { messageId: "sent-1" };
+      },
+      async sendDirectReply(chatId: string, text: string) {
+        replies.push({ chatId, text });
+      },
+    } as unknown as ChannelAdapter;
+  }
+
+  const baseMsg = {
+    channel: "testchan",
+    chatId: "chat-1",
+    senderId: "user-1",
+    senderName: "Sam",
+    text: "/pause",
+    timestamp: 0,
+  };
+
+  test("non-admins are blocked from gated commands", async () => {
+    const replies: { chatId: string; text: string }[] = [];
+    const gate = resolveChannelCommandGate({
+      account: makeAccount({ adminUsers: ["admin-1"] }),
+      channelId: "testchan",
+      senderId: "user-1",
+    });
+    const handled = await tryHandleChannelSlashCommand(
+      makeAdapter(replies),
+      baseMsg,
+      { commandGate: gate },
+    );
+    expect(handled).toBe(true);
+    expect(replies).toHaveLength(1);
+    expect(replies[0]?.text).toContain("limited to admins");
+  });
+
+  test("whoami stays reachable for gated users", async () => {
+    const replies: { chatId: string; text: string }[] = [];
+    const gate = resolveChannelCommandGate({
+      account: makeAccount({ adminUsers: ["admin-1"] }),
+      channelId: "testchan",
+      senderId: "user-1",
+    });
+    const handled = await tryHandleChannelSlashCommand(
+      makeAdapter(replies),
+      { ...baseMsg, text: "/whoami" },
+      { commandGate: gate },
+    );
+    expect(handled).toBe(true);
+    expect(replies[0]?.text).toContain("Tier: user");
+  });
+
+  test("admins pass the gate through to normal handling", async () => {
+    const replies: { chatId: string; text: string }[] = [];
+    const gate = resolveChannelCommandGate({
+      account: makeAccount({ adminUsers: ["admin-1"] }),
+      channelId: "testchan",
+      senderId: "admin-1",
+    });
+    const handled = await tryHandleChannelSlashCommand(
+      makeAdapter(replies),
+      { ...baseMsg, text: "/help" },
+      { commandGate: gate },
+    );
+    expect(handled).toBe(true);
+    expect(replies[0]?.text).toContain("connected to Letta Code");
+  });
+});

--- a/src/channels/access-control.ts
+++ b/src/channels/access-control.ts
@@ -1,0 +1,365 @@
+import { isUserApproved, loadPairingStore } from "./pairing";
+import { getChannelDisplayName } from "./plugin-registry";
+import { signalAllowedUsersIncludes } from "./signal/target";
+import type {
+  ChannelChatType,
+  ChannelGroupSenderPolicy,
+  DmPolicy,
+} from "./types";
+import { allowedUsersIncludes as whatsappAllowedUsersIncludes } from "./whatsapp/jid";
+
+/**
+ * Centralized sender access control for channel inbound traffic.
+ *
+ * Modeled on the Hermes gateway's authorization layer: one decision
+ * function consulted on every inbound message (DMs and groups), an
+ * env-var allowlist axis that works across all channels, and an
+ * opt-in admin/user command tier that stays disabled until an
+ * operator lists at least one admin.
+ */
+
+// ── Scope ─────────────────────────────────────────────────────────
+
+export type ChannelAccessScope = "dm" | "group";
+
+export function resolveChannelAccessScope(
+  chatType: ChannelChatType | undefined,
+): ChannelAccessScope {
+  return chatType === "channel" ? "group" : "dm";
+}
+
+// ── Env-var allowlists ────────────────────────────────────────────
+
+const GLOBAL_ALLOWED_USERS_ENV = "LETTA_CHANNELS_ALLOWED_USERS";
+const GLOBAL_ADMIN_USERS_ENV = "LETTA_CHANNELS_ADMIN_USERS";
+const GLOBAL_ALLOW_ALL_ENV = "LETTA_CHANNELS_ALLOW_ALL_USERS";
+
+function channelEnvKey(channelId: string, suffix: string): string {
+  const normalized = channelId.toUpperCase().replace(/[^A-Z0-9]+/g, "_");
+  return `LETTA_${normalized}_${suffix}`;
+}
+
+function parseUserList(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function isEnvFlagEnabled(raw: string | undefined): boolean {
+  const normalized = (raw ?? "").trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
+/** Union of the global and per-channel allowed-user env vars. */
+export function getChannelEnvAllowedUsers(channelId: string): string[] {
+  return [
+    ...parseUserList(process.env[GLOBAL_ALLOWED_USERS_ENV]),
+    ...parseUserList(process.env[channelEnvKey(channelId, "ALLOWED_USERS")]),
+  ];
+}
+
+/** Union of the global and per-channel admin-user env vars. */
+export function getChannelEnvAdminUsers(channelId: string): string[] {
+  return [
+    ...parseUserList(process.env[GLOBAL_ADMIN_USERS_ENV]),
+    ...parseUserList(process.env[channelEnvKey(channelId, "ADMIN_USERS")]),
+  ];
+}
+
+/** Explicit opt-out of sender gating (LETTA_CHANNELS_ALLOW_ALL_USERS=1). */
+export function isChannelAllowAllUsersEnabled(channelId: string): boolean {
+  return (
+    isEnvFlagEnabled(process.env[GLOBAL_ALLOW_ALL_ENV]) ||
+    isEnvFlagEnabled(process.env[channelEnvKey(channelId, "ALLOW_ALL_USERS")])
+  );
+}
+
+// ── Sender access decisions ───────────────────────────────────────
+
+/**
+ * Minimal structural view of a channel account used for access
+ * decisions, satisfied by every ChannelAccount variant including
+ * custom plugin accounts.
+ */
+export interface ChannelAccessAccount {
+  accountId: string;
+  dmPolicy: DmPolicy;
+  allowedUsers: string[];
+  groupPolicy?: ChannelGroupSenderPolicy;
+  adminUsers?: string[];
+  userAllowedCommands?: string[];
+}
+
+export type ChannelSenderAccessDecision = "allow" | "deny" | "pair";
+
+export interface ChannelSenderAccessInput {
+  account: ChannelAccessAccount;
+  channelId: string;
+  senderId: string;
+  chatType: ChannelChatType | undefined;
+}
+
+function effectiveAllowedUsers(
+  account: ChannelAccessAccount,
+  channelId: string,
+): string[] {
+  return [
+    ...account.allowedUsers,
+    ...(account.adminUsers ?? []),
+    ...getChannelEnvAllowedUsers(channelId),
+    ...getChannelEnvAdminUsers(channelId),
+  ];
+}
+
+/**
+ * Channel-aware allowlist membership. WhatsApp and Signal identities
+ * have multiple representations (JID vs phone digits, UUID vs E.164),
+ * so those channels match through their normalizing helpers.
+ */
+function allowlistMatches(
+  channelId: string,
+  allowed: string[],
+  senderId: string,
+): boolean {
+  if (allowed.includes("*")) {
+    return true;
+  }
+  if (!senderId) {
+    return false;
+  }
+  if (channelId === "whatsapp") {
+    return whatsappAllowedUsersIncludes(allowed, senderId);
+  }
+  if (channelId === "signal") {
+    return signalAllowedUsersIncludes(allowed, senderId);
+  }
+  return allowed.includes(senderId);
+}
+
+function isPairedApproved(
+  channelId: string,
+  senderId: string,
+  accountId: string,
+): boolean {
+  if (isUserApproved(channelId, senderId, accountId)) {
+    return true;
+  }
+  // Reload from disk on miss so standalone CLI pairing approvals apply
+  // without a listener restart (mirrors the historical DM pairing path).
+  loadPairingStore(channelId);
+  return isUserApproved(channelId, senderId, accountId);
+}
+
+/**
+ * Decide whether an inbound sender may reach the agent.
+ *
+ * Order of checks, most permissive first:
+ * 1. Allow-all env flag → allow.
+ * 2. Sender in the effective allowlist (account allowedUsers + adminUsers
+ *    + env allowlists, `*` wildcard supported) → allow.
+ * 3. Sender approved via pairing → allow (pairing grants are a union
+ *    with the allowlist, not an alternative).
+ * 4. Otherwise the scope policy decides:
+ *    - group: `groupPolicy: "allowlist"` denies; an env allowlist being
+ *      configured also denies (a configured allowlist restricts
+ *      everywhere); default stays open for backwards compatibility.
+ *    - dm: `dmPolicy` semantics — open allows (unless an env allowlist
+ *      is configured), allowlist denies, pairing asks for a code.
+ *
+ * Slack exception: Slack DM `dmPolicy: "pairing"` is a legacy default
+ * that was never enforced (the workspace membership is the trust
+ * boundary and there is no Slack pairing UX), so it behaves as "open".
+ * Explicit `dmPolicy: "allowlist"` and env allowlists ARE enforced.
+ */
+export function evaluateChannelSenderAccess(
+  input: ChannelSenderAccessInput,
+): ChannelSenderAccessDecision {
+  const { account, channelId, senderId, chatType } = input;
+
+  if (isChannelAllowAllUsersEnabled(channelId)) {
+    return "allow";
+  }
+
+  const allowed = effectiveAllowedUsers(account, channelId);
+  if (allowlistMatches(channelId, allowed, senderId)) {
+    return "allow";
+  }
+
+  const envAllowlistConfigured =
+    getChannelEnvAllowedUsers(channelId).length > 0;
+  const scope = resolveChannelAccessScope(chatType);
+
+  const restrictive =
+    envAllowlistConfigured ||
+    (scope === "group"
+      ? (account.groupPolicy ?? "open") === "allowlist"
+      : account.dmPolicy !== "open");
+  if (!restrictive) {
+    return "allow";
+  }
+
+  if (senderId && isPairedApproved(channelId, senderId, account.accountId)) {
+    return "allow";
+  }
+
+  if (scope === "group") {
+    return "deny";
+  }
+
+  if (account.dmPolicy === "pairing" && !envAllowlistConfigured) {
+    // Slack never enforced its legacy "pairing" default and has no
+    // pairing reply surface; keep workspace membership as the boundary.
+    return channelId === "slack" ? "allow" : "pair";
+  }
+
+  return "deny";
+}
+
+const ACCESS_DENIED_NOUNS: Record<string, string> = {
+  slack: "Slack app",
+  discord: "Discord bot",
+  whatsapp: "WhatsApp account",
+  signal: "Signal account",
+};
+
+export function buildChannelAccessDeniedMessage(channelId: string): string {
+  const noun = ACCESS_DENIED_NOUNS[channelId] ?? "bot";
+  return `You are not on the allowed users list for this ${noun}.`;
+}
+
+// ── Admin/user command tiers ──────────────────────────────────────
+
+/**
+ * Read-only commands that stay reachable for every allowed user even
+ * when command gating is enabled. Anything an operator lists in
+ * `userAllowedCommands` is added on top; the floor is never removed.
+ */
+export const CHANNEL_COMMAND_FLOOR = ["help", "status", "whoami"] as const;
+
+export interface ChannelCommandGate {
+  /** Gating is active only when at least one admin is configured. */
+  enabled: boolean;
+  isAdmin: boolean;
+  /** Normalized extra commands non-admins may run (floor excluded). */
+  allowedCommands: string[];
+}
+
+function normalizeCommandName(name: string): string {
+  return name.trim().replace(/^\/+/, "").toLowerCase();
+}
+
+/** Resolve command aliases to the canonical name used for gating. */
+export function canonicalizeChannelCommandName(name: string): string {
+  const normalized = normalizeCommandName(name);
+  return normalized === "reflect" ? "reflection" : normalized;
+}
+
+/**
+ * Resolve the command tier for a sender. Mirrors Hermes's backward
+ * compatibility rule: when no admin is configured for the account (or
+ * via env), gating is disabled and every allowed user has full access.
+ */
+export function resolveChannelCommandGate(params: {
+  account: ChannelAccessAccount;
+  channelId: string;
+  senderId: string;
+}): ChannelCommandGate {
+  const admins = [
+    ...(params.account.adminUsers ?? []),
+    ...getChannelEnvAdminUsers(params.channelId),
+  ].filter((entry) => entry.length > 0);
+  const enabled = admins.length > 0;
+  const allowedCommands = (params.account.userAllowedCommands ?? [])
+    .map(normalizeCommandName)
+    .filter((name) => name.length > 0);
+  return {
+    enabled,
+    isAdmin:
+      !enabled || (!!params.senderId && admins.includes(params.senderId)),
+    allowedCommands,
+  };
+}
+
+export function canRunChannelCommand(
+  gate: ChannelCommandGate,
+  commandName: string,
+): boolean {
+  if (!gate.enabled || gate.isAdmin) {
+    return true;
+  }
+  const normalized = normalizeCommandName(commandName);
+  return (
+    (CHANNEL_COMMAND_FLOOR as readonly string[]).includes(normalized) ||
+    gate.allowedCommands.includes(normalized)
+  );
+}
+
+function runnableCommandsForUser(gate: ChannelCommandGate): string[] {
+  const seen = new Set<string>();
+  const runnable: string[] = [];
+  for (const name of [...CHANNEL_COMMAND_FLOOR, ...gate.allowedCommands]) {
+    if (!seen.has(name)) {
+      seen.add(name);
+      runnable.push(name);
+    }
+  }
+  return runnable;
+}
+
+function channelDisplayName(channelId: string): string {
+  try {
+    return getChannelDisplayName(channelId);
+  } catch {
+    return channelId;
+  }
+}
+
+export function buildChannelCommandDeniedMessage(
+  channelId: string,
+  commandName: string,
+  gate: ChannelCommandGate,
+): string {
+  const runnable = runnableCommandsForUser(gate)
+    .map((name) => `/${name}`)
+    .join(", ");
+  return [
+    `${channelDisplayName(channelId)}: /${normalizeCommandName(commandName)} is limited to admins here.`,
+    `Commands you can run: ${runnable}. Use /whoami to see your access.`,
+  ].join("\n");
+}
+
+export function buildChannelWhoamiMessage(
+  msg: {
+    channel: string;
+    senderId: string;
+    senderName?: string;
+    chatType?: ChannelChatType;
+  },
+  gate?: ChannelCommandGate,
+): string {
+  const scope =
+    resolveChannelAccessScope(msg.chatType) === "dm" ? "DM" : "group/channel";
+  const who = msg.senderName
+    ? `${msg.senderName} (${msg.senderId})`
+    : msg.senderId;
+  const lines = [
+    `You — ${channelDisplayName(msg.channel)} (${scope})`,
+    `User ID: ${who}`,
+  ];
+  if (!gate || !gate.enabled) {
+    lines.push(
+      "Tier: unrestricted (no admin list configured for this account)",
+      "Commands: all available",
+    );
+  } else if (gate.isAdmin) {
+    lines.push("Tier: admin", "Commands: all available");
+  } else {
+    const runnable = runnableCommandsForUser(gate)
+      .map((name) => `/${name}`)
+      .join(", ");
+    lines.push("Tier: user", `Commands you can run: ${runnable}`);
+  }
+  return lines.join("\n");
+}

--- a/src/channels/access-control.ts
+++ b/src/channels/access-control.ts
@@ -244,6 +244,23 @@ export interface ChannelCommandGate {
   isAdmin: boolean;
   /** Normalized extra commands non-admins may run (floor excluded). */
   allowedCommands: string[];
+  /** True when the sender still needs to pair; changes denial wording. */
+  pairingPending?: boolean;
+}
+
+/**
+ * Gate limiting a sender to the read-only floor. Applied to senders in
+ * the pairing handshake regardless of whether admin tiers are enabled,
+ * so a not-yet-paired DM sender cannot run mutating commands against a
+ * pre-existing route.
+ */
+export function floorOnlyChannelCommandGate(): ChannelCommandGate {
+  return {
+    enabled: true,
+    isAdmin: false,
+    allowedCommands: [],
+    pairingPending: true,
+  };
 }
 
 function normalizeCommandName(name: string): string {
@@ -272,12 +289,14 @@ export function resolveChannelCommandGate(params: {
   ].filter((entry) => entry.length > 0);
   const enabled = admins.length > 0;
   const allowedCommands = (params.account.userAllowedCommands ?? [])
-    .map(normalizeCommandName)
+    .map(canonicalizeChannelCommandName)
     .filter((name) => name.length > 0);
   return {
     enabled,
+    // Channel-aware matching so e.g. a WhatsApp admin configured as a
+    // phone number is recognized when messages arrive with a JID sender.
     isAdmin:
-      !enabled || (!!params.senderId && admins.includes(params.senderId)),
+      !enabled || allowlistMatches(params.channelId, admins, params.senderId),
     allowedCommands,
   };
 }
@@ -289,10 +308,10 @@ export function canRunChannelCommand(
   if (!gate.enabled || gate.isAdmin) {
     return true;
   }
-  const normalized = normalizeCommandName(commandName);
+  const canonical = canonicalizeChannelCommandName(commandName);
   return (
-    (CHANNEL_COMMAND_FLOOR as readonly string[]).includes(normalized) ||
-    gate.allowedCommands.includes(normalized)
+    (CHANNEL_COMMAND_FLOOR as readonly string[]).includes(canonical) ||
+    gate.allowedCommands.includes(canonical)
   );
 }
 
@@ -324,8 +343,11 @@ export function buildChannelCommandDeniedMessage(
   const runnable = runnableCommandsForUser(gate)
     .map((name) => `/${name}`)
     .join(", ");
+  const restriction = gate.pairingPending
+    ? "is available after pairing completes"
+    : "is limited to admins here";
   return [
-    `${channelDisplayName(channelId)}: /${normalizeCommandName(commandName)} is limited to admins here.`,
+    `${channelDisplayName(channelId)}: /${normalizeCommandName(commandName)} ${restriction}.`,
     `Commands you can run: ${runnable}. Use /whoami to see your access.`,
   ].join("\n");
 }
@@ -353,6 +375,11 @@ export function buildChannelWhoamiMessage(
       "Tier: unrestricted (no admin list configured for this account)",
       "Commands: all available",
     );
+  } else if (gate.pairingPending) {
+    const runnable = runnableCommandsForUser(gate)
+      .map((name) => `/${name}`)
+      .join(", ");
+    lines.push("Tier: pending pairing", `Commands you can run: ${runnable}`);
   } else if (gate.isAdmin) {
     lines.push("Tier: admin", "Commands: all available");
   } else {

--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -44,9 +44,12 @@ import {
  */
 const SNAKE_TO_CAMEL: Record<string, string> = {
   account_uuid: "accountUuid",
+  admin_users: "adminUsers",
   allowed_channels: "allowedChannels",
   allowed_groups: "allowedGroups",
   allow_bots: "allowBots",
+  group_policy: "groupPolicy",
+  user_allowed_commands: "userAllowedCommands",
   auto_thread_on_mention: "autoThreadOnMention",
   base_url: "baseUrl",
   acknowledge_message_reaction: "acknowledgeMessageReaction",
@@ -208,6 +211,13 @@ function cloneAccount<T extends ChannelAccount>(account: T): T {
     ...account,
     allowedUsers: [...account.allowedUsers],
   } as T;
+
+  if (account.adminUsers) {
+    cloned.adminUsers = [...account.adminUsers];
+  }
+  if (account.userAllowedCommands) {
+    cloned.userAllowedCommands = [...account.userAllowedCommands];
+  }
 
   if (isTelegramChannelAccount(account)) {
     (cloned as TelegramChannelAccount).binding = { ...account.binding };

--- a/src/channels/commands.test.ts
+++ b/src/channels/commands.test.ts
@@ -210,7 +210,7 @@ describe("channel slash commands", () => {
     expect(text).toContain("Telegram is connected to Letta Code.");
     expect(text).not.toContain("MessageChannel");
     expect(text).toContain(
-      "Supported slash commands here: /help, /status, /pause, /resume, /cancel, /chat, /feedback, /model, /reflection.",
+      "Supported slash commands here: /help, /status, /whoami, /pause, /resume, /cancel, /chat, /feedback, /model, /reflection.",
     );
 
     const slackText = buildChannelHelpMessage("slack");
@@ -759,7 +759,7 @@ describe("channel slash commands", () => {
     expect(text).toContain("Telegram received /compact now");
     expect(text).toContain("not supported in channels yet");
     expect(text).toContain(
-      "Supported slash commands: /help, /status, /pause, /resume, /cancel, /chat, /feedback, /model, /reflection.",
+      "Supported slash commands: /help, /status, /whoami, /pause, /resume, /cancel, /chat, /feedback, /model, /reflection.",
     );
     expect(text).toContain("without a leading slash");
 

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -1,4 +1,11 @@
 import type { ListModelsResponseModelEntry } from "@/types/protocol_v2";
+import {
+  buildChannelCommandDeniedMessage,
+  buildChannelWhoamiMessage,
+  type ChannelCommandGate,
+  canonicalizeChannelCommandName,
+  canRunChannelCommand,
+} from "./access-control";
 import { handleChannelFeedbackCommand } from "./feedback";
 import { getChannelDisplayName } from "./plugin-registry";
 import type {
@@ -84,6 +91,8 @@ export type ChannelSlashCommandOptions = {
   statusContext?: ChannelStatusContext;
   handlers?: ChannelSlashCommandHandlers;
   enableBangCommands?: boolean;
+  /** Admin/user tier gate for this sender; undefined disables gating. */
+  commandGate?: ChannelCommandGate;
 };
 
 const CHANNEL_SLASH_COMMANDS: ChannelSlashCommandDefinition[] = [
@@ -96,6 +105,11 @@ const CHANNEL_SLASH_COMMANDS: ChannelSlashCommandDefinition[] = [
     name: "status",
     kind: "direct",
     summary: "Show this chat's channel connection status.",
+  },
+  {
+    name: "whoami",
+    kind: "direct",
+    summary: "Show your access tier and runnable commands here.",
   },
   {
     name: "pause",
@@ -257,6 +271,7 @@ function supportedCommandsText(prefix: "/" | "!" = "/"): string {
 const SLACK_MENTION_SLASH_COMMAND_EXAMPLES = [
   "@agent /help",
   "@agent /status",
+  "@agent /whoami",
   "@agent /model",
   "@agent /model list",
   "@agent /model <handle-or-id>",
@@ -847,11 +862,30 @@ export async function tryHandleChannelSlashCommand(
     return true;
   }
 
+  const canonicalName = canonicalizeChannelCommandName(command.name);
+  if (
+    options.commandGate &&
+    !canRunChannelCommand(options.commandGate, canonicalName)
+  ) {
+    await adapter.sendDirectReply(
+      msg.chatId,
+      buildChannelCommandDeniedMessage(
+        msg.channel,
+        canonicalName,
+        options.commandGate,
+      ),
+      msg.threadId ? { replyToMessageId: msg.threadId } : undefined,
+    );
+    return true;
+  }
+
   const reply = normalizeDirectReplyPayload(
     await (async () => {
       switch (command.name) {
         case "help":
           return buildChannelHelpMessage(msg.channel);
+        case "whoami":
+          return buildChannelWhoamiMessage(msg, options.commandGate);
         case "status":
           return buildChannelStatusMessage(
             msg,

--- a/src/channels/discord-registry.test.ts
+++ b/src/channels/discord-registry.test.ts
@@ -384,6 +384,52 @@ describe("discord channel registry", () => {
     ]);
   });
 
+  test("admin users pass the Discord DM allowlist and auto-route", async () => {
+    clearChannelAccountStores();
+    __testOverrideLoadChannelAccounts(() => [
+      {
+        channel: "discord",
+        accountId: "discord-bot",
+        enabled: true,
+        token: "discord-token",
+        agentId: "agent-1",
+        defaultPermissionMode: "standard",
+        dmPolicy: "allowlist",
+        allowedUsers: ["user-2"],
+        adminUsers: ["user-1"],
+        createdAt: "2026-04-11T00:00:00.000Z",
+        updatedAt: "2026-04-11T00:00:00.000Z",
+      },
+    ]);
+
+    const { ChannelRegistry } = await import("@/channels/registry");
+    const registry = new ChannelRegistry();
+    const replies: Array<{ chatId: string; text: string }> = [];
+    const adapter = createAdapter(replies);
+    registry.registerAdapter(adapter);
+
+    const deliveries: unknown[] = [];
+    registry.setMessageHandler((delivery) => {
+      deliveries.push(delivery);
+    });
+    registry.setReady();
+
+    await adapter.onMessage?.(
+      createInboundMessage({
+        chatId: "dm-1",
+        threadId: null,
+        chatType: "direct",
+        isMention: false,
+        messageId: "dm-msg-1",
+      }),
+    );
+
+    expect(replies).toHaveLength(0);
+    expect(createConversation).toHaveBeenCalledTimes(1);
+    expect(getRoute("discord", "dm-1", "discord-bot")).not.toBe(null);
+    expect(deliveries).toHaveLength(1);
+  });
+
   test("keeps explicit Discord pairing DMs on the pairing flow with the account agent", async () => {
     const { ChannelRegistry } = await import("@/channels/registry");
     const registry = new ChannelRegistry();

--- a/src/channels/registry-controls.test.ts
+++ b/src/channels/registry-controls.test.ts
@@ -290,6 +290,41 @@ describe("pending channel control requests", () => {
     });
   });
 
+  test("text control replies from other senders never resolve the prompt", async () => {
+    __testOverrideLoadChannelAccounts(() => []);
+    const registry = new ChannelRegistry();
+    const replies: Array<{ chatId: string; text: string }> = [];
+    const adapter = createAdapter(replies);
+    registry.registerAdapter(adapter);
+
+    const deliveries: unknown[] = [];
+    registry.setMessageHandler((delivery) => {
+      deliveries.push(delivery);
+    });
+    const approvalResponses: unknown[] = [];
+    registry.setApprovalResponseHandler(async (params) => {
+      approvalResponses.push(params);
+      return true;
+    });
+
+    const baseEvent = createPendingControlRequestEvent();
+    await registry.registerPendingControlRequest({
+      ...baseEvent,
+      source: { ...baseEvent.source, senderId: "U123" },
+    });
+
+    // A different participant in the same chat/thread cannot answer the
+    // prompt; their reply falls through to normal ingress handling.
+    await adapter.onMessage?.(createInboundMessage("2", { senderId: "U999" }));
+    expect(approvalResponses).toHaveLength(0);
+    expect(deliveries).toHaveLength(0);
+
+    // The initiating sender's reply still resolves the pending prompt.
+    await adapter.onMessage?.(createInboundMessage("2"));
+    expect(approvalResponses).toHaveLength(1);
+    __testOverrideLoadChannelAccounts(null);
+  });
+
   test("native approval controls resolve the exact request and enforce the initiating sender", async () => {
     const registry = new ChannelRegistry();
     const adapter = createAdapter([]);

--- a/src/channels/registry-controls.ts
+++ b/src/channels/registry-controls.ts
@@ -226,6 +226,17 @@ export class ChannelControlRequests {
       return false;
     }
 
+    // Same ownership rule as handleNativeResponse: only the sender the
+    // prompt was created for may answer it. Messages from other chat
+    // participants fall through to normal ingress handling instead of
+    // being consumed as an approval response.
+    if (
+      pending.event.source.senderId &&
+      pending.event.source.senderId !== msg.senderId
+    ) {
+      return false;
+    }
+
     if (
       msg.channel === "slack" &&
       pending.event.kind === "generic_tool_approval"

--- a/src/channels/registry-inbound.ts
+++ b/src/channels/registry-inbound.ts
@@ -1,7 +1,13 @@
+import {
+  buildChannelAccessDeniedMessage,
+  evaluateChannelSenderAccess,
+  resolveChannelAccessScope,
+  resolveChannelCommandGate,
+} from "./access-control";
 import { getChannelAccount, LEGACY_CHANNEL_ACCOUNT_ID } from "./accounts";
 import { tryHandleChannelSlashCommand } from "./commands";
 import { isDiscordGuildChannelAllowed } from "./discord/channel-gating";
-import { createPairingCode, isUserApproved, loadPairingStore } from "./pairing";
+import { createPairingCode } from "./pairing";
 import type { ChannelCommandRouter } from "./registry-commands";
 import type { ChannelControlRequests } from "./registry-controls";
 import type { ChannelRegistryEvent } from "./registry-events";
@@ -51,6 +57,35 @@ export function createChannelInboundRouter(deps: {
     }
 
     const config = getChannelAccount(msg.channel, accountId);
+
+    // Sender access gate: one decision for every surface (DMs, groups,
+    // and every channel's auto-route path). "pair" senders continue so
+    // read-only slash commands still work before pairing completes; the
+    // pairing-code flow below handles their normal messages.
+    const senderAccess = config
+      ? evaluateChannelSenderAccess({
+          account: config,
+          channelId: msg.channel,
+          senderId: msg.senderId,
+          chatType: msg.chatType,
+        })
+      : null;
+    if (senderAccess === "deny") {
+      if (msg.reaction) {
+        return;
+      }
+      if (resolveChannelAccessScope(msg.chatType) === "dm") {
+        await adapter.sendDirectReply(
+          msg.chatId,
+          buildChannelAccessDeniedMessage(msg.channel),
+        );
+      } else {
+        console.log(
+          `[channels] Dropped ${msg.channel} group message from unauthorized sender ${msg.senderId} in chat ${msg.chatId}`,
+        );
+      }
+      return;
+    }
 
     if (
       deps.commands.shouldDropUnroutedSlackThreadInput(msg, accountId, config)
@@ -106,6 +141,13 @@ export function createChannelInboundRouter(deps: {
             deps.commands.handlePauseResumeSlashCommand("resume", msg),
         },
         enableBangCommands: msg.channel === "slack" && msg.isMention === true,
+        commandGate: config
+          ? resolveChannelCommandGate({
+              account: config,
+              channelId: msg.channel,
+              senderId: msg.senderId,
+            })
+          : undefined,
       })
     ) {
       return;
@@ -295,49 +337,32 @@ export function createChannelInboundRouter(deps: {
       return;
     }
 
-    // 1. Check pairing/allowlist policy
-    if (config.dmPolicy === "allowlist") {
-      if (!config.allowedUsers.includes(msg.senderId)) {
-        if (msg.reaction) {
-          return;
-        }
-        await adapter.sendDirectReply(
-          msg.chatId,
-          "You are not on the allowed users list for this bot.",
-        );
+    // 1. Pairing handshake: the sender access gate above already allowed
+    // allowlisted/approved senders and denied blocked ones; "pair" means
+    // this DM sender still needs a pairing code.
+    if (senderAccess === "pair") {
+      if (msg.reaction) {
         return;
       }
-    } else if (config.dmPolicy === "pairing") {
-      // Reload pairing store from disk on miss (allows standalone CLI pairing)
-      if (!isUserApproved(msg.channel, msg.senderId, accountId)) {
-        loadPairingStore(msg.channel);
-      }
-      if (!isUserApproved(msg.channel, msg.senderId, accountId)) {
-        if (msg.reaction) {
-          return;
-        }
-        // Generate pairing code
-        const code = createPairingCode(
-          msg.channel,
-          msg.senderId,
-          msg.chatId,
-          msg.senderName,
-          accountId,
-        );
-        deps.emitEvent({
-          type: "pairings_updated",
-          channelId: msg.channel,
-        });
-        await adapter.sendDirectReply(
-          msg.chatId,
-          buildPairingInstructions(msg.channel, code, {
-            agentId: getConfiguredAgentId(config),
-          }),
-        );
-        return;
-      }
+      const code = createPairingCode(
+        msg.channel,
+        msg.senderId,
+        msg.chatId,
+        msg.senderName,
+        accountId,
+      );
+      deps.emitEvent({
+        type: "pairings_updated",
+        channelId: msg.channel,
+      });
+      await adapter.sendDirectReply(
+        msg.chatId,
+        buildPairingInstructions(msg.channel, code, {
+          agentId: getConfiguredAgentId(config),
+        }),
+      );
+      return;
     }
-    // dm_policy === "open" → skip check
 
     // 2. Route lookup (reload from disk on miss — allows standalone CLI pairing)
     let route = getRouteFromStore(

--- a/src/channels/registry-inbound.ts
+++ b/src/channels/registry-inbound.ts
@@ -1,6 +1,7 @@
 import {
   buildChannelAccessDeniedMessage,
   evaluateChannelSenderAccess,
+  floorOnlyChannelCommandGate,
   resolveChannelAccessScope,
   resolveChannelCommandGate,
 } from "./access-control";
@@ -52,14 +53,13 @@ export function createChannelInboundRouter(deps: {
     const accountId = msg.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID;
     const adapter = deps.getAdapter(msg.channel, accountId);
     if (!adapter) return;
-    if (await deps.controls.tryHandleInbound(adapter, msg)) {
-      return;
-    }
 
     const config = getChannelAccount(msg.channel, accountId);
 
     // Sender access gate: one decision for every surface (DMs, groups,
-    // and every channel's auto-route path). "pair" senders continue so
+    // and every channel's auto-route path), evaluated before control
+    // responses and slash commands so unauthorized senders cannot answer
+    // approval prompts or run commands. "pair" senders continue so
     // read-only slash commands still work before pairing completes; the
     // pairing-code flow below handles their normal messages.
     const senderAccess = config
@@ -84,6 +84,10 @@ export function createChannelInboundRouter(deps: {
           `[channels] Dropped ${msg.channel} group message from unauthorized sender ${msg.senderId} in chat ${msg.chatId}`,
         );
       }
+      return;
+    }
+
+    if (await deps.controls.tryHandleInbound(adapter, msg)) {
       return;
     }
 
@@ -142,11 +146,13 @@ export function createChannelInboundRouter(deps: {
         },
         enableBangCommands: msg.channel === "slack" && msg.isMention === true,
         commandGate: config
-          ? resolveChannelCommandGate({
-              account: config,
-              channelId: msg.channel,
-              senderId: msg.senderId,
-            })
+          ? senderAccess === "pair"
+            ? floorOnlyChannelCommandGate()
+            : resolveChannelCommandGate({
+                account: config,
+                channelId: msg.channel,
+                senderId: msg.senderId,
+              })
           : undefined,
       })
     ) {

--- a/src/channels/registry-routes.ts
+++ b/src/channels/registry-routes.ts
@@ -11,7 +11,6 @@ import {
   buildWhatsAppConversationSummary,
 } from "./registry-presentation";
 import { addRoute, getRoute as getRouteFromStore, loadRoutes } from "./routing";
-import { signalAllowedUsersIncludes } from "./signal/target";
 import { loadTargetStore, upsertChannelTarget } from "./targets";
 import type {
   ChannelAdapter,
@@ -23,7 +22,6 @@ import type {
   TelegramChannelAccount,
   WhatsAppChannelAccount,
 } from "./types";
-import { allowedUsersIncludes } from "./whatsapp/jid";
 
 export function createChannelRouteProvisioner(deps: {
   emitEvent: (event: ChannelRegistryEvent) => void;
@@ -102,19 +100,8 @@ export function createChannelRouteProvisioner(deps: {
       return null;
     }
 
-    if (msg.chatType === "direct") {
-      if (
-        config.dmPolicy === "allowlist" &&
-        !config.allowedUsers.includes(msg.senderId)
-      ) {
-        await adapter.sendDirectReply(
-          msg.chatId,
-          "You are not on the allowed users list for this Slack app.",
-          buildDirectReplyOptions(msg),
-        );
-        return null;
-      }
-    }
+    // Sender access (dmPolicy/allowedUsers, admin and env grants, pairing)
+    // is enforced centrally in registry-inbound before provisioning runs.
 
     const accountId = msg.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID;
     const routeThreadId =
@@ -345,17 +332,7 @@ export function createChannelRouteProvisioner(deps: {
       return null;
     }
 
-    if (
-      msg.chatType === "direct" &&
-      config.dmPolicy === "allowlist" &&
-      !config.allowedUsers.includes(msg.senderId)
-    ) {
-      await adapter.sendDirectReply(
-        msg.chatId,
-        "You are not on the allowed users list for this Discord bot.",
-      );
-      return null;
-    }
+    // Sender access is enforced centrally in registry-inbound.
 
     const accountId = msg.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID;
     const routeThreadId = msg.threadId ?? null;
@@ -440,17 +417,7 @@ export function createChannelRouteProvisioner(deps: {
       return null;
     }
 
-    if (
-      msg.chatType === "direct" &&
-      config.dmPolicy === "allowlist" &&
-      !allowedUsersIncludes(config.allowedUsers, msg.senderId)
-    ) {
-      await adapter.sendDirectReply(
-        msg.chatId,
-        "You are not on the allowed users list for this WhatsApp account.",
-      );
-      return null;
-    }
+    // Sender access is enforced centrally in registry-inbound.
 
     const accountId = msg.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID;
     let route = getRouteFromStore(msg.channel, msg.chatId, accountId, null);
@@ -536,19 +503,7 @@ export function createChannelRouteProvisioner(deps: {
       return null;
     }
 
-    if (
-      msg.chatType === "direct" &&
-      config.dmPolicy === "allowlist" &&
-      !signalAllowedUsersIncludes(config.allowedUsers, msg.senderId)
-    ) {
-      if (!msg.reaction) {
-        await adapter.sendDirectReply(
-          msg.chatId,
-          "You are not on the allowed users list for this Signal account.",
-        );
-      }
-      return null;
-    }
+    // Sender access is enforced centrally in registry-inbound.
 
     const accountId = msg.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID;
     let route = getRouteFromStore(msg.channel, msg.chatId, accountId, null);

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -502,6 +502,13 @@ export interface ChannelRoute {
 // ── Config ────────────────────────────────────────────────────────
 
 export type DmPolicy = "pairing" | "allowlist" | "open";
+/**
+ * Group/channel-scope sender policy. "open" preserves the historical
+ * behavior (any participant of an allowed group/channel can talk to the
+ * agent). "allowlist" restricts group senders to allowedUsers/adminUsers,
+ * paired users, and env-var allowlists.
+ */
+export type ChannelGroupSenderPolicy = "open" | "allowlist";
 export type SlackChannelMode = "socket";
 export type SlackAllowBotsMode = false | "mentions";
 export type TelegramGroupMode = "open" | "mention-only";
@@ -519,6 +526,24 @@ interface ChannelAccountBase {
   enabled: boolean;
   dmPolicy: DmPolicy;
   allowedUsers: string[];
+  /**
+   * Sender policy for group/channel-scope messages. Default "open"
+   * (historical behavior). "allowlist" restricts group senders to
+   * allowedUsers/adminUsers, paired users, and env allowlists.
+   * Slack note: dmPolicy "pairing" is a legacy unenforced default and
+   * behaves as "open" for Slack DMs; use "allowlist" to restrict.
+   */
+  groupPolicy?: ChannelGroupSenderPolicy;
+  /**
+   * Admin user IDs for slash-command tiers. When set (non-empty),
+   * command gating activates: non-admins may only run the read-only
+   * floor (/help, /status, /whoami) plus userAllowedCommands. When
+   * unset, every allowed user has full command access (historical
+   * behavior).
+   */
+  adminUsers?: string[];
+  /** Extra slash commands (no leading slash) non-admins may run. */
+  userAllowedCommands?: string[];
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary

Closes several access-control gaps in the messaging channels: allowlists were only enforced on the DM fall-through path, any group participant could run control commands, and there was no way to inspect one's own access.

- **Uniform sender gating** — a new `src/channels/access-control.ts` module makes one access decision per inbound message, now covering Slack, Telegram groups, Discord guild/DM auto-routing, WhatsApp, Signal, and custom channels. WhatsApp/Signal allowlist matching reuses the existing identity-normalization helpers (JID↔phone, UUID↔E.164), and per-channel denial messages are unchanged.
- **Group sender policy** — new opt-in `group_policy: "allowlist"` account field restricts group/channel senders to allowlisted, admin, or paired users. Default `"open"` preserves existing behavior.
- **Admin/user command tiers** — new `admin_users` + `user_allowed_commands` account fields. Gating activates only when at least one admin is configured (existing installs unaffected); non-admins then get a read-only floor (`/help`, `/status`, `/whoami`) plus explicitly allowed commands. Previously any participant in a routed chat could `/pause`, `/cancel`, `/model`, etc.
- **`/whoami`** — reports sender ID, scope (DM vs group/channel), tier, and runnable commands on every channel.
- **Env-var allowlists** — `LETTA_CHANNELS_ALLOWED_USERS` / `LETTA_<CHANNEL>_ALLOWED_USERS` (+ `_ADMIN_USERS` variants, `LETTA_CHANNELS_ALLOW_ALL_USERS` opt-out) merge with account config; once configured they restrict every scope on the affected channels.
- Pairing grants are a union with allowlists: allowlisted senders skip the pairing handshake, and paired users stay allowed in groups.

Backcompat notes: Slack's `dm_policy: "pairing"` is a legacy default that was never enforced and has no pairing reply surface, so it behaves as `"open"` (documented); explicit `"allowlist"` and env allowlists are enforced. Groups stay open unless `group_policy` or an env allowlist is configured.

## Test plan

- New `src/channels/access-control.test.ts` (24 cases): scope resolution, all dm/group policy combinations, Slack legacy behavior, env allowlist arming/merging, allow-all flags, wildcard entries, admin tiers, command-floor gating, whoami/denial messages, and end-to-end slash-command gating.
- Full channel suite: 772 pass / 0 fail.
- `bun run check`: all 12 checks pass.