### PR TITLE
fix(cron): rename --target-device to --computer to match docs terminology

### DIFF
--- a/src/agent/prompts/letta.md
+++ b/src/agent/prompts/letta.md
@@ -120,7 +120,7 @@ Creating crons:
 - Recurring monitoring/heartbeat: `letta cron add --name <short-name> --description <description> --prompt <future-message> --every "2h"` or `--cron "0 9 * * *"`
 Always include `--name`, `--description`, and `--prompt`. `$AGENT_ID` is automatically injected into the shell environment, and `letta cron` uses it by default, so you do not need to specify which agent to invoke unless overriding the current agent intentionally.
 
-Where crons run: for cloud agents, schedules default to durable Cloud schedules that fire from the cloud and execute in your managed cloud sandbox — they survive local shutdown, so this is the right default. If the scheduled work must run on a specific machine (e.g. it needs that device's filesystem or local services), add `--target-device <deviceId>` (from `letta environments list`) to keep the durable Cloud schedule but execute on that device, with sandbox fallback if it is offline. Use `--runner local` only when that fallback is unacceptable; local schedules only fire while a Letta session is running on that device.
+Where crons run: for cloud agents, schedules default to durable Cloud schedules that fire from the cloud and execute in your cloud sandbox — they survive local shutdown, so this is the right default. If the scheduled work must run on a specific computer (e.g. it needs that computer's filesystem or local services), add `--computer <deviceId>` (from `letta environments list`) to keep the durable Cloud schedule but execute on that computer, with sandbox fallback if it is offline. Use `--runner local` only when that fallback is unacceptable; local schedules only fire while a Letta session is running on that computer.
 
 # Harness Architecture
 

--- a/src/cli/subcommands/cron-runner.test.ts
+++ b/src/cli/subcommands/cron-runner.test.ts
@@ -191,7 +191,7 @@ describe("buildCloudScheduleInput", () => {
     expect(built.notes).not.toContain(CLOUD_DEVICE_FALLBACK_NOTE);
   });
 
-  test("whitespace-only target device is treated as absent", () => {
+  test("whitespace-only computer target is treated as absent", () => {
     const built = buildCloudScheduleInput({
       ...base,
       cron: "*/5 * * * *",
@@ -222,7 +222,7 @@ describe("validateTargetDevice", () => {
     });
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error).toContain("Omit --target-device");
+      expect(result.error).toContain("Omit --computer");
     }
   });
 
@@ -230,18 +230,18 @@ describe("validateTargetDevice", () => {
     const result = validateTargetDevice("local", null);
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error).toContain("letta remote");
+      expect(result.error).toContain("letta server");
     }
   });
 
-  test("desktop-local connection is rejected with letta remote guidance", () => {
+  test("desktop-local connection is rejected with connect guidance", () => {
     const result = validateTargetDevice("07fca6a1-device", {
       organizationId: "local",
     });
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error).toContain("letta remote");
-      expect(result.error).toContain("desktop-local");
+      expect(result.error).toContain("letta server");
+      expect(result.error).toContain("local desktop connection");
     }
   });
 });

--- a/src/cli/subcommands/cron-runner.ts
+++ b/src/cli/subcommands/cron-runner.ts
@@ -109,7 +109,7 @@ const SYNTHETIC_LOCAL_PLACEHOLDER_ID = "local";
 export type TargetDeviceValidity = { ok: true } | { ok: false; error: string };
 
 /**
- * Pre-validate a `--target-device` value against its resolved environment
+ * Pre-validate a `--computer` value against its resolved environment
  * entry, catching entries that appear in `letta environments list` but are
  * not valid Cloud-schedule targets. In Desktop/local-proxy contexts the list
  * merges desktop-local listener connections (organizationId "local" — they
@@ -129,7 +129,7 @@ export function validateTargetDevice(
     return {
       ok: false,
       error:
-        '"Cloud" is the default execution target, not a device. Omit --target-device to run in the agent\'s cloud sandbox.',
+        '"Cloud" is the default execution target, not a computer. Omit --computer to run in the agent\'s cloud sandbox.',
     };
   }
 
@@ -137,14 +137,14 @@ export function validateTargetDevice(
     return {
       ok: false,
       error:
-        '"local" is a placeholder entry, not a registered device. Run `letta remote` on the machine you want to target, then use its deviceId.',
+        '"local" is a placeholder entry, not a connected computer. Run `letta server` on the machine you want to target, then use its deviceId.',
     };
   }
 
   if (environment?.organizationId === "local") {
     return {
       ok: false,
-      error: `Device ${deviceId} is a desktop-local connection, not a registered remote. Cloud schedules can only target devices registered with the Letta API — run \`letta remote\` on that machine to register it.`,
+      error: `Device ${deviceId} is this computer's local desktop connection, not a computer connected to your Letta account. Cloud schedules can only target connected computers — run \`letta server\` on that machine (or enable remote access in the desktop app) to connect it.`,
     };
   }
 
@@ -161,7 +161,7 @@ export interface BuildCloudScheduleParams {
   cron: string;
   recurring: boolean;
   scheduledFor?: Date;
-  /** Optional registered device to execute on (offline → sandbox fallback). */
+  /** Optional connected computer to execute on (offline → sandbox fallback). */
   targetDeviceId?: string;
 }
 
@@ -189,7 +189,7 @@ export const CLOUD_CRON_UTC_NOTE =
   "Recurring Cloud schedules currently interpret cron expressions in UTC (timezone support is tracked in LET-9815).";
 
 export const CLOUD_DEVICE_FALLBACK_NOTE =
-  "If the target device is offline when the schedule fires, execution falls back to the agent's cloud sandbox.";
+  "If the target computer is offline when the schedule fires, execution falls back to the agent's cloud sandbox.";
 
 export function buildCloudScheduleInput(
   params: BuildCloudScheduleParams,

--- a/src/cli/subcommands/cron.ts
+++ b/src/cli/subcommands/cron.ts
@@ -81,10 +81,11 @@ Add options:
                            local - this device's scheduler (~/.letta/crons.json);
                                    only fires while a session runs here (default
                                    for local-backend agents / self-hosted)
-  --target-device <id>   (cloud runner only) Execute on a registered remote
-                         device (deviceId from \`letta environments list\`)
-                         instead of the agent's cloud sandbox. Falls back to
-                         the sandbox if the device is offline at fire time.
+  --computer <id>        (cloud runner only) Execute on one of your
+                         connected computers (deviceId from
+                         \`letta environments list\`) instead of the agent's
+                         cloud sandbox. Falls back to the sandbox if the
+                         computer is offline at fire time.
 
 List/filter options:
   --agent <id>           Filter by agent ID
@@ -117,7 +118,7 @@ const CRON_OPTIONS = {
   limit: { type: "string" },
   "run-id": { type: "string" },
   runner: { type: "string" },
-  "target-device": { type: "string" },
+  computer: { type: "string" },
 } as const;
 
 type CronArgValues = ReturnType<typeof parseCronArgs>["values"];
@@ -202,7 +203,7 @@ function isRunnerFlagValid(value: string | undefined): boolean {
 }
 
 /**
- * Best-effort lookup of a --target-device id in the environments registry
+ * Best-effort lookup of a --computer deviceId in the environments registry
  * (through the same base URL the schedule request will use, so Desktop's
  * merged local+cloud view is what gets validated). Returns null when the
  * lookup fails or the device is unknown — the server-side registry check on
@@ -344,7 +345,7 @@ async function handleAdd(values: CronArgValues): Promise<number> {
     return 1;
   }
 
-  const targetDeviceId = values["target-device"]?.trim() || undefined;
+  const targetDeviceId = values.computer?.trim() || undefined;
 
   const resolved = await getRunnerForAgent(values.runner, agentId);
   if ("error" in resolved) {
@@ -358,7 +359,7 @@ async function handleAdd(values: CronArgValues): Promise<number> {
   // (and likely a mistake) for the local runner.
   if (targetDeviceId && resolved.runner !== "cloud") {
     console.error(
-      "Error: --target-device requires the cloud runner. Run `letta cron add` on the target device itself (with --runner local) to schedule there locally.",
+      "Error: --computer requires the cloud runner. Run `letta cron add` on the target computer itself (with --runner local) to schedule there locally.",
     );
     return 1;
   }
@@ -500,7 +501,7 @@ async function handleCloudAdd(params: CloudAddParams): Promise<number> {
     console.log(JSON.stringify(output, null, 2));
     console.error(
       targetDeviceId
-        ? `Created Cloud schedule: it fires from the cloud and runs on device "${targetDeviceId}" (sandbox fallback if offline).`
+        ? `Created Cloud schedule: it fires from the cloud and runs on computer "${targetDeviceId}" (sandbox fallback if offline).`
         : "Created Cloud schedule: it fires from the cloud and runs in this agent's managed cloud sandbox (survives local shutdown).",
     );
     return 0;

--- a/src/skills/builtin/scheduling-tasks/SKILL.md
+++ b/src/skills/builtin/scheduling-tasks/SKILL.md
@@ -18,22 +18,22 @@ This skill lets you create, list, and manage scheduled tasks using the `letta cr
 
 There are two schedule runners, selected with the optional `--runner local|cloud` flag:
 
-- **`cloud`** (default for cloud agents): a durable Cloud schedule stored by the Letta API. It fires from the cloud and executes in the agent's managed cloud sandbox, so it survives local shutdown — the device, sandbox, or session that created it can disappear and the schedule still fires.
-- **`local`**: a device-local task in `~/.letta/crons.json`, executed by the Letta session on that device. It only fires while a session is running there, and it dies with the device's local state.
+- **`cloud`** (default for cloud agents): a durable Cloud schedule stored by the Letta API. It fires from the cloud and executes in the agent's cloud sandbox, so it survives local shutdown — the computer, sandbox, or session that created it can disappear and the schedule still fires.
+- **`local`**: a task local to the current computer (`~/.letta/crons.json`), executed by the Letta session running there. It only fires while a session is running on that computer, and it dies with that computer's local state.
 
 You normally don't need the flag — the default does the right thing. Local-backend agents (`agent-local-*`) and self-hosted servers always use the local runner.
 
-If the scheduled work must run on a **specific machine** (it needs that device's filesystem, local services, or credentials — e.g. a Railway/VPS machine), prefer a Cloud schedule targeting that device:
+If the scheduled work must run on a **specific computer** (it needs that computer's filesystem, local services, or credentials — e.g. a bring-your-own machine like a Railway/VPS box or a home workstation), prefer a Cloud schedule that executes on that computer:
 
 ```bash
-letta cron add ... --target-device <deviceId>
+letta cron add ... --computer <deviceId>
 ```
 
-The deviceId comes from `letta environments list`. The schedule stays durable in the cloud; if the device is offline when it fires, execution falls back to the agent's cloud sandbox. Use `--runner local` (run on the target machine itself) only when that sandbox fallback is unacceptable — a local task never runs anywhere but its own device.
+The deviceId comes from `letta environments list`. The computer must be connected to your Letta account (run `letta server` on it, or enable remote access in the desktop app). The schedule stays durable in the cloud; if the computer is offline when it fires, execution falls back to the agent's cloud sandbox. Use `--runner local` (run on the target computer itself) only when that sandbox fallback is unacceptable — a local task never runs anywhere but its own computer.
 
 Notes for the cloud runner:
 
-- Untargeted schedules execute in the agent's cloud sandbox, not on the device where you created them; `--target-device` executes on the named device with sandbox fallback.
+- Untargeted schedules execute in the agent's cloud sandbox, not on the computer where you created them; `--computer` executes on the named computer with sandbox fallback.
 - Recurring `--cron` expressions are currently interpreted in UTC (the CLI output includes a note about this). `--at` and `--every` are unaffected.
 - If creating a Cloud schedule fails, no schedule is created — there is no silent fallback to local storage. Retry, or pass `--runner local` deliberately.
 
@@ -70,7 +70,7 @@ letta cron add --name <short-name> --description <text> --prompt <text> <schedul
 | `--agent <id>` | Agent ID (defaults to `LETTA_AGENT_ID` from the current shell/session) |
 | `--conversation <id>` | Conversation ID (defaults to `LETTA_CONVERSATION_ID` from the current shell/session, otherwise `"default"`) |
 | `--runner <runner>` | `cloud` or `local` — see "Where Schedules Run" above (defaults to `cloud` for cloud agents) |
-| `--target-device <id>` | (cloud runner only) Execute on a registered remote device instead of the agent's sandbox; falls back to the sandbox if the device is offline |
+| `--computer <id>` | (cloud runner only) Execute on a connected computer instead of the agent's sandbox; falls back to the sandbox if the computer is offline |
 
 ### Listing Tasks
 
@@ -200,7 +200,7 @@ Include context about what the user originally asked for, so you can give a help
 - **One-shot cleanup (local runner)**: One-shot local tasks are garbage-collected 24 hours after firing.
 - **Timezone**: Local-runner tasks use the user's local timezone. Cloud-runner recurring `--cron` expressions are currently interpreted in UTC.
 - **Default binding precedence**: `letta cron add` uses `--agent` / `--conversation` first, then falls back to `LETTA_AGENT_ID` / `LETTA_CONVERSATION_ID`, then finally uses `"default"` for the conversation if no env var is present.
-- **Local scheduler requirement**: Local-runner tasks only fire while a Letta session is running on that device (a WS listener must be active). If no session is running, tasks will be marked as missed. Cloud-runner schedules fire from the cloud regardless.
+- **Local scheduler requirement**: Local-runner tasks only fire while a Letta session is running on that computer (a WS listener must be active). If no session is running, tasks will be marked as missed. Cloud-runner schedules fire from the cloud regardless.
 - **`--at` for specific times**: `--at "3:00pm"` schedules a one-shot. If the time has already passed today, it schedules for tomorrow.
 - **`--every` for daily**: `--every 1d` fires daily at midnight. For a specific time of day, use `--cron` instead (e.g. `--cron "0 9 * * *"` for 9am daily).
 


### PR DESCRIPTION
## Summary

- The docs describe execution environments as **computers** ([Computers](https://docs.letta.com/letta-agent/computers)), with "bring your own machine" for user-connected remotes and `letta server` / desktop "Allow remote access" as the canonical connect paths. The cron execution-target flag from #3407/#3428 predates that alignment and used "device" vocabulary.
- Renames `--target-device <id>` → `--computer <id>` on `letta cron add`. The flag is unreleased (0.28.13 on npm is `5c236cb3`, before #3407 merged), so no alias/deprecation shim is needed.
- Error and guidance prose now says "computer" / "connected to your Letta account" / `letta server` instead of "device" / "registered remote" / `letta remote`; the scheduling-tasks skill and the system prompt cron section match.
- No wire changes: the API field stays `target_device_id` and the value is still the deviceId from `letta environments list`.

## Verification

- 23 unit tests pass; `bun run check` all green.
- Live against the Letta API: `--computer` with a desktop-local connection, the synthetic Cloud row, and `--runner local` each produce the new guidance; happy path unchanged.

👾 Generated with [Letta Code](https://letta.com)