### PR TITLE
fix(channels): harden pairing code generation

### DIFF
--- a/src/channels/pairing.test.ts
+++ b/src/channels/pairing.test.ts
@@ -67,15 +67,18 @@ describe("pairing", () => {
     expect(result).not.toBeNull();
   });
 
-  test("replaces existing pending code for same user", () => {
+  test("reuses the unexpired pending code for the same user", () => {
     const code1 = createPairingCode("telegram", "user-1", "chat-1");
     const code2 = createPairingCode("telegram", "user-1", "chat-1");
 
-    expect(code1).not.toBe(code2);
+    // Rate limit: repeated messages do not mint new codes while the
+    // sender's existing code is still valid.
+    expect(code1).toBe(code2);
+    expect(consumePairingCode("telegram", code1)).not.toBeNull();
 
-    // Only the new code should work
-    expect(consumePairingCode("telegram", code1)).toBeNull();
-    expect(consumePairingCode("telegram", code2)).not.toBeNull();
+    // Once consumed, a fresh request mints a new code.
+    const code3 = createPairingCode("telegram", "user-1", "chat-1");
+    expect(code3).not.toBe(code1);
   });
 
   test("isUserApproved returns false for unknown users", () => {

--- a/src/channels/pairing.ts
+++ b/src/channels/pairing.ts
@@ -10,6 +10,7 @@
  * Reference: earlier pairing-store implementation
  */
 
+import { randomInt } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { LEGACY_CHANNEL_ACCOUNT_ID } from "./accounts";
 import { getChannelDir, getChannelPairingPath } from "./config";
@@ -105,7 +106,9 @@ function savePairingStore(channelId: string): void {
 function generateCode(length = 6): string {
   let code = "";
   for (let i = 0; i < length; i++) {
-    code += CODE_CHARS[Math.floor(Math.random() * CODE_CHARS.length)];
+    // Cryptographic randomness: pairing codes are an authorization
+    // credential, so they must not be predictable.
+    code += CODE_CHARS[randomInt(CODE_CHARS.length)];
   }
   return code;
 }
@@ -143,7 +146,21 @@ export function createPairingCode(
   const store = getStore(channelId);
   const normalizedAccountId = normalizeAccountId(accountId);
 
-  // Remove any existing pending code for this user
+  // Rate limit: reuse the sender's existing unexpired code instead of
+  // minting a new one per inbound message. One live code per sender per
+  // TTL window also keeps the operator-visible code stable.
+  const nowMs = Date.now();
+  const existing = store.pending.find(
+    (p) =>
+      p.senderId === userId &&
+      normalizeAccountId(p.accountId) === normalizedAccountId &&
+      new Date(p.expiresAt).getTime() > nowMs,
+  );
+  if (existing) {
+    return existing.code;
+  }
+
+  // Remove any existing (expired) code for this user
   store.pending = store.pending.filter(
     (p) =>
       !(


### PR DESCRIPTION
Follow-up to #3430.

- Generate pairing codes with `crypto.randomInt` instead of `Math.random()` — codes are an authorization credential and must not be predictable.
- Reuse a sender's existing unexpired pending code instead of minting a fresh one on every inbound message. This rate-limits code generation per sender and keeps the operator-visible code stable for the full 15-minute TTL; a new code is only minted after consumption or expiry.

Updated the pairing tests accordingly (the old "replaces existing pending code" case asserted the regenerate-per-message behavior; it now covers reuse-until-consumed). All 778 channel tests pass.