### PR TITLE
fix(cli): isolate image processing diagnostics [LET-9916]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ package-lock.json
 bin/
 letta.js
 letta.js.map
+image-resize-worker.js
+image-resize-worker.js.map
 /skills/
 .DS_Store
 

--- a/build.js
+++ b/build.js
@@ -104,6 +104,18 @@ await Bun.build({
   features: features,
 });
 
+await Bun.build({
+  entrypoints: ["./src/utils/image-resize-worker.ts"],
+  outdir: ".",
+  target: "node",
+  format: "esm",
+  minify: false,
+  sourcemap: "external",
+  naming: {
+    entry: "image-resize-worker.js",
+  },
+});
+
 // Add shebang to output file
 const outputPath = join(__dirname, "letta.js");
 let content = readFileSync(outputPath, "utf-8");

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "LICENSE",
     "README.md",
     "letta.js",
+    "image-resize-worker.js",
     "scripts",
     "skills",
     "vendor",

--- a/src/cli/image-resize.test.ts
+++ b/src/cli/image-resize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -73,6 +73,26 @@ describe("resizeImageIfNeeded", () => {
     expect(metadata.width).toBe(120);
     expect(metadata.height).toBe(200);
     expect(metadata.orientation).toBeUndefined();
+  });
+
+  test("captures image worker stderr instead of writing it to the terminal", () => {
+    const imageResizeUrl = new URL("../utils/image-resize.ts", import.meta.url)
+      .href;
+    const script = `
+      import { resizeImageIfNeeded } from ${JSON.stringify(imageResizeUrl)};
+      try {
+        await resizeImageIfNeeded(Buffer.from("not an image"), "image/png");
+      } catch (error) {
+        process.stdout.write(error instanceof Error ? error.message : String(error));
+      }
+    `;
+    const result = spawnSync(process.execPath, ["-e", script], {
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("unsupported image format");
   });
 
   test("rejects images whose input pixel count exceeds the safety limit", async () => {

--- a/src/utils/image-resize-worker.ts
+++ b/src/utils/image-resize-worker.ts
@@ -1,0 +1,28 @@
+import { resizeImageIfNeeded } from "@/utils/image-resize.sharp";
+
+async function readInput(): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+async function main(): Promise<void> {
+  const inputMediaType = process.argv[2];
+  if (!inputMediaType) {
+    throw new Error("Image media type is required");
+  }
+
+  const buffer = await readInput();
+  const result = await resizeImageIfNeeded(buffer, inputMediaType);
+  process.stdout.write(JSON.stringify(result));
+}
+
+try {
+  await main();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(message);
+  process.exitCode = 1;
+}

--- a/src/utils/image-resize.ts
+++ b/src/utils/image-resize.ts
@@ -1,7 +1,10 @@
 // Image resizing utilities for clipboard paste
 // Follows Codex CLI's approach (codex-rs/utils/image/src/lib.rs)
 
-import { isHeicMediaType } from "./image-resize.shared";
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { isHeicMediaType, type ResizeResult } from "./image-resize.shared";
 
 export type { ResizeResult } from "./image-resize.shared";
 export {
@@ -21,26 +24,110 @@ declare const __USE_MAGICK__: boolean | undefined;
 const useMagick =
   typeof __USE_MAGICK__ !== "undefined" && __USE_MAGICK__ === true;
 
-const backendResizeImageIfNeeded = useMagick
+const magickResizeImageIfNeeded = useMagick
   ? (await import("@/utils/image-resize.magick.js")).resizeImageIfNeeded
-  : (await import("@/utils/image-resize.sharp.js")).resizeImageIfNeeded;
+  : null;
+
+function resolveImageWorkerPath(): string {
+  const sourceWorkerPath = fileURLToPath(
+    new URL("./image-resize-worker.ts", import.meta.url),
+  );
+  if (existsSync(sourceWorkerPath)) {
+    return sourceWorkerPath;
+  }
+  return fileURLToPath(new URL("./image-resize-worker.js", import.meta.url));
+}
+
+// Keep Sharp/libvips outside the Ink process: native GLib diagnostics write
+// directly to the process stderr and cannot be intercepted at the JS layer.
+function resizeWithSharpWorker(
+  buffer: Buffer,
+  inputMediaType: string,
+): Promise<ResizeResult> {
+  return new Promise((resolve, reject) => {
+    const workerPath = resolveImageWorkerPath();
+    const child = spawn(process.execPath, [workerPath, inputMediaType], {
+      shell: false,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let processError: Error | null = null;
+    let stdinError: Error | null = null;
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdoutChunks.push(chunk);
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderrChunks.push(chunk);
+    });
+    child.stdin.on("error", (error) => {
+      stdinError = error;
+    });
+    child.on("error", (error) => {
+      processError = error;
+    });
+    child.on("close", (exitCode, signal) => {
+      const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
+      if (processError) {
+        reject(
+          new Error(`Failed to launch image worker: ${processError.message}`),
+        );
+        return;
+      }
+      if (exitCode !== 0) {
+        const reason = stderr
+          ? stderr
+          : `Image worker exited ${signal ? `from signal ${signal}` : `with code ${String(exitCode)}`}`;
+        reject(new Error(reason));
+        return;
+      }
+      if (stdinError) {
+        reject(
+          new Error(`Failed to send image to worker: ${stdinError.message}`),
+        );
+        return;
+      }
+
+      const stdout = Buffer.concat(stdoutChunks).toString("utf8");
+      try {
+        resolve(JSON.parse(stdout) as ResizeResult);
+      } catch {
+        reject(new Error("Image worker returned an invalid response"));
+      }
+    });
+
+    child.stdin.end(buffer);
+  });
+}
+
+async function resizeWithConfiguredBackend(
+  buffer: Buffer,
+  inputMediaType: string,
+): Promise<ResizeResult> {
+  if (magickResizeImageIfNeeded) {
+    return await magickResizeImageIfNeeded(buffer, inputMediaType);
+  }
+  return await resizeWithSharpWorker(buffer, inputMediaType);
+}
 
 export async function resizeImageIfNeeded(
   buffer: Buffer,
   inputMediaType: string,
-) {
+): Promise<ResizeResult> {
   if (process.platform === "darwin" && isHeicMediaType(inputMediaType)) {
     try {
       const { convertHeicToJpegWithSips } = await import(
         "@/utils/image-resize.sips.js"
       );
       const convertedBuffer = await convertHeicToJpegWithSips(buffer);
-      return await backendResizeImageIfNeeded(convertedBuffer, "image/jpeg");
+      return await resizeWithConfiguredBackend(convertedBuffer, "image/jpeg");
     } catch {
       // Fall through to the configured backend so non-sips environments still
       // get the existing behavior.
     }
   }
 
-  return await backendResizeImageIfNeeded(buffer, inputMediaType);
+  return await resizeWithConfiguredBackend(buffer, inputMediaType);
 }


### PR DESCRIPTION
## Summary
- run Sharp-based image normalization in a dedicated worker process so native GTK/GLib diagnostics cannot write to the CLI terminal
- capture worker stderr for real processing failures while preserving the existing ImageMagick and HEIC behavior
- ship the worker alongside the main bundle and cover stderr isolation plus the image-read regression suite

Linear: LET-9916

👾 Generated with [Letta Code](https://letta.com)