### PR TITLE
fix(channels): clarify reused pairing code expiry

### DIFF
--- a/src/channels/pairing.test.ts
+++ b/src/channels/pairing.test.ts
@@ -8,8 +8,15 @@ import {
   getApprovedUsers,
   getPendingPairings,
   isUserApproved,
+  loadPairingStore,
   rollbackPairingApproval,
 } from "@/channels/pairing";
+import type { PairingStore } from "@/channels/types";
+
+function loadPairingStoreFixture(channelId: string, store: PairingStore): void {
+  __testOverrideLoadPairingStore(() => store);
+  loadPairingStore(channelId);
+}
 
 describe("pairing", () => {
   beforeEach(() => {
@@ -79,6 +86,149 @@ describe("pairing", () => {
     // Once consumed, a fresh request mints a new code.
     const code3 = createPairingCode("telegram", "user-1", "chat-1");
     expect(code3).not.toBe(code1);
+  });
+
+  test("reuses a pending code without retargeting chat or timestamps", () => {
+    const createdAt = new Date(Date.now() - 14 * 60_000).toISOString();
+    const expiresAt = new Date(Date.now() + 60_000).toISOString();
+    loadPairingStoreFixture("telegram", {
+      pending: [
+        {
+          accountId: "bot-a",
+          code: "ABC234",
+          senderId: "user-1",
+          senderName: "original-name",
+          chatId: "chat-original",
+          createdAt,
+          expiresAt,
+        },
+      ],
+      approved: [],
+    });
+
+    const code = createPairingCode(
+      "telegram",
+      "user-1",
+      "chat-later",
+      "later-name",
+      "bot-a",
+    );
+
+    expect(code).toBe("ABC234");
+    const pending = getPendingPairings("telegram", "bot-a");
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.chatId).toBe("chat-original");
+    expect(pending[0]?.senderName).toBe("original-name");
+    expect(pending[0]?.createdAt).toBe(createdAt);
+    expect(pending[0]?.expiresAt).toBe(expiresAt);
+  });
+
+  test("generates a new code after the existing pending code expires", () => {
+    const createdAt = new Date(Date.now() - 16 * 60_000).toISOString();
+    const expiresAt = new Date(Date.now() - 60_000).toISOString();
+    loadPairingStoreFixture("telegram", {
+      pending: [
+        {
+          accountId: "bot-a",
+          code: "XYZ789",
+          senderId: "user-1",
+          senderName: "old-name",
+          chatId: "chat-old",
+          createdAt,
+          expiresAt,
+        },
+      ],
+      approved: [],
+    });
+
+    const code = createPairingCode(
+      "telegram",
+      "user-1",
+      "chat-new",
+      "new-name",
+      "bot-a",
+    );
+
+    expect(code).not.toBe("XYZ789");
+    const pending = getPendingPairings("telegram", "bot-a");
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.code).toBe(code);
+    expect(pending[0]?.chatId).toBe("chat-new");
+    expect(pending[0]?.senderName).toBe("new-name");
+    expect(pending[0]?.createdAt).not.toBe(createdAt);
+    expect(pending[0]?.expiresAt).not.toBe(expiresAt);
+  });
+
+  test("scopes pending-code reuse by sender and account", () => {
+    const botAUser1 = createPairingCode(
+      "telegram",
+      "user-1",
+      "chat-a1",
+      "one",
+      "bot-a",
+    );
+    const botAUser2 = createPairingCode(
+      "telegram",
+      "user-2",
+      "chat-a2",
+      "two",
+      "bot-a",
+    );
+    const botBUser1 = createPairingCode(
+      "telegram",
+      "user-1",
+      "chat-b1",
+      "one-b",
+      "bot-b",
+    );
+
+    expect(
+      createPairingCode("telegram", "user-1", "ignored", "new", "bot-a"),
+    ).toBe(botAUser1);
+
+    const botAPending = getPendingPairings("telegram", "bot-a");
+    expect(botAPending).toHaveLength(2);
+    expect(botAPending[0]?.code).toBe(botAUser1);
+    expect(botAPending[0]?.senderId).toBe("user-1");
+    expect(botAPending[0]?.chatId).toBe("chat-a1");
+    expect(botAPending[1]?.code).toBe(botAUser2);
+    expect(botAPending[1]?.senderId).toBe("user-2");
+    expect(botAPending[1]?.chatId).toBe("chat-a2");
+
+    const botBPending = getPendingPairings("telegram", "bot-b");
+    expect(botBPending).toHaveLength(1);
+    expect(botBPending[0]?.code).toBe(botBUser1);
+    expect(botBPending[0]?.senderId).toBe("user-1");
+    expect(botBPending[0]?.chatId).toBe("chat-b1");
+  });
+
+  test("fails closed when duplicate pending codes are ambiguous", () => {
+    const expiresAt = new Date(Date.now() + 60_000).toISOString();
+    loadPairingStoreFixture("telegram", {
+      pending: [
+        {
+          accountId: "bot-a",
+          code: "DUP999",
+          senderId: "user-1",
+          chatId: "chat-1",
+          createdAt: new Date(Date.now() - 60_000).toISOString(),
+          expiresAt,
+        },
+        {
+          accountId: "bot-a",
+          code: "DUP999",
+          senderId: "user-2",
+          chatId: "chat-2",
+          createdAt: new Date(Date.now() - 30_000).toISOString(),
+          expiresAt,
+        },
+      ],
+      approved: [],
+    });
+
+    expect(consumePairingCode("telegram", "dup999", "bot-a")).toBeNull();
+    expect(getPendingPairings("telegram", "bot-a")).toHaveLength(2);
+    expect(getApprovedUsers("telegram", "bot-a")).toHaveLength(0);
   });
 
   test("isUserApproved returns false for unknown users", () => {

--- a/src/channels/pairing.ts
+++ b/src/channels/pairing.ts
@@ -149,6 +149,11 @@ export function createPairingCode(
   // Rate limit: reuse the sender's existing unexpired code instead of
   // minting a new one per inbound message. One live code per sender per
   // TTL window also keeps the operator-visible code stable.
+  //
+  // Keep the existing pending record as-is. Route creation consumes the
+  // original chatId; if a platform ever reports a different DM chatId for the
+  // same sender during the TTL, silently retargeting this live credential would
+  // bind it to a different surface than the one that first requested it.
   const nowMs = Date.now();
   const existing = store.pending.find(
     (p) =>

--- a/src/channels/registry-community-copy.test.ts
+++ b/src/channels/registry-community-copy.test.ts
@@ -17,7 +17,9 @@ describe("registry copy: first-party channels", () => {
       "letta channels pair --channel telegram --code ABC123 --agent <agent-id>",
     );
     expect(text).toContain("Find the target agent with: letta agents list");
-    expect(text).toContain("This code expires in 15 minutes.");
+    expect(text).toContain(
+      "This code expires 15 minutes after it was first issued.",
+    );
     expect(text).not.toContain("(community channel)");
   });
 
@@ -101,7 +103,9 @@ describe("registry copy: community channels", () => {
       "letta channels pair --channel custom-chat --code ABC123 --agent <agent-id>",
     );
     expect(text).toContain("Find the target agent with: letta agents list");
-    expect(text).toContain("This code expires in 15 minutes.");
+    expect(text).toContain(
+      "This code expires 15 minutes after it was first issued.",
+    );
     expect(text).not.toContain("open Channels >");
     expect(text).not.toContain("(community channel)");
     // Hard-stop against shipping the wrong subcommand again.

--- a/src/channels/registry-presentation.ts
+++ b/src/channels/registry-presentation.ts
@@ -62,7 +62,7 @@ export function buildPairingInstructions(
       pairingCommand,
       ...agentLookupLines,
       "",
-      "This code expires in 15 minutes.",
+      "This code expires 15 minutes after it was first issued.",
     ].join("\n");
   }
   return [
@@ -76,7 +76,7 @@ export function buildPairingInstructions(
     pairingCommand,
     ...agentLookupLines,
     "",
-    "This code expires in 15 minutes.",
+    "This code expires 15 minutes after it was first issued.",
   ].join("\n");
 }
 


### PR DESCRIPTION
## What changed

- Keep reused pairing codes tied to the original pending record, including its chat ID and timestamps, and document why a later DM identifier must not silently retarget a live credential.
- Change pairing copy from “expires in 15 minutes” to “expires 15 minutes after it was first issued,” so repeated delivery of the same code does not imply a fresh TTL.
- Cover regeneration after expiry, sender/account isolation, and duplicate-code ambiguity remaining fail-closed.

## Before / after

Before, an unexpired code was correctly reused, but every reply claimed another 15 minutes and the route-binding/scoping invariants were not explicit in tests. After, the copy describes the original issuance window and regression tests pin the existing security boundaries.

This does not add collision retries or change which chat a reused credential binds. Duplicate persisted codes still fail closed.

## Validation

- `bun test ./src/channels/pairing.test.ts ./src/channels/registry-community-copy.test.ts ./src/channels/registry-pairing.test.ts` — 28 pass
- `bun run check` — 12/12 checks pass
- Complete unit suite was also attempted. Unrelated existing failures in `settings-manager.test.ts` and `hooks/e2e.test.ts` reproduce on the base checkout; all pairing tests pass independently.

Follow-up to #3433.
