### PR TITLE
fix(channels): make transient failures actionable [LET-10012]

### DIFF
--- a/src/channels/lifecycle-error.test.ts
+++ b/src/channels/lifecycle-error.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, test } from "bun:test";
 import {
   CHANNEL_LIFECYCLE_APPROVAL_PENDING_MESSAGE,
   CHANNEL_LIFECYCLE_CONVERSATION_BUSY_TITLE,
+  CHANNEL_LIFECYCLE_DATABASE_LOCK_MESSAGE,
   CHANNEL_LIFECYCLE_FALLBACK_ERROR_MESSAGE,
-  CHANNEL_LIFECYCLE_LETTA_CLOUD_BUSY_MESSAGE,
   extractChannelLifecycleRunId,
   formatChannelLifecycleErrorMessage,
   normalizeChannelLifecycleErrorMessage,
@@ -39,17 +39,14 @@ describe("normalizeChannelLifecycleErrorMessage", () => {
       "SQLSTATE 55P03 context",
       'psycopg.errors.LockNotAvailable: could not obtain lock on row in relation "steps" SQLSTATE: 55P03',
     ],
-  ])(
-    "replaces %s details with Letta Cloud busy guidance",
-    (_label, rawError) => {
-      const message = normalizeChannelLifecycleErrorMessage(rawError);
+  ])("replaces %s details with database lock guidance", (_label, rawError) => {
+    const message = normalizeChannelLifecycleErrorMessage(rawError);
 
-      expect(message).toBe(CHANNEL_LIFECYCLE_LETTA_CLOUD_BUSY_MESSAGE);
-      expect(message).not.toContain("55P03");
-      expect(message).not.toContain("canceling statement");
-      expect(message).not.toContain("steps");
-    },
-  );
+    expect(message).toBe(CHANNEL_LIFECYCLE_DATABASE_LOCK_MESSAGE);
+    expect(message).not.toContain("55P03");
+    expect(message).not.toContain("canceling statement");
+    expect(message).not.toContain("steps");
+  });
 
   test("keeps ordinary non-Postgres lock timeout details", () => {
     expect(
@@ -130,7 +127,7 @@ describe("formatChannelLifecycleErrorMessage", () => {
     ).not.toContain("```");
   });
 
-  test("formats Letta Cloud busy guidance without database internals", () => {
+  test("formats database lock guidance without database internals", () => {
     const message = formatChannelLifecycleErrorMessage(
       "sqlalchemy.exc.OperationalError: SQLSTATE: 55P03 while updating steps",
       { codeBlock: true, runId: "run-47960fe9" },
@@ -138,7 +135,7 @@ describe("formatChannelLifecycleErrorMessage", () => {
 
     expect(message).toBe(
       "Turn failed:\n" +
-        `${CHANNEL_LIFECYCLE_LETTA_CLOUD_BUSY_MESSAGE}\n\n` +
+        `${CHANNEL_LIFECYCLE_DATABASE_LOCK_MESSAGE}\n\n` +
         "Run ID: run-47960fe9",
     );
     expect(message).not.toContain("```");

--- a/src/channels/lifecycle-error.test.ts
+++ b/src/channels/lifecycle-error.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, test } from "bun:test";
 import {
   CHANNEL_LIFECYCLE_APPROVAL_PENDING_MESSAGE,
   CHANNEL_LIFECYCLE_CONVERSATION_BUSY_TITLE,
-  CHANNEL_LIFECYCLE_DATABASE_LOCK_MESSAGE,
   CHANNEL_LIFECYCLE_FALLBACK_ERROR_MESSAGE,
+  CHANNEL_LIFECYCLE_TRANSIENT_ERROR_MESSAGE,
   extractChannelLifecycleRunId,
   formatChannelLifecycleErrorMessage,
   normalizeChannelLifecycleErrorMessage,
@@ -39,14 +39,19 @@ describe("normalizeChannelLifecycleErrorMessage", () => {
       "SQLSTATE 55P03 context",
       'psycopg.errors.LockNotAvailable: could not obtain lock on row in relation "steps" SQLSTATE: 55P03',
     ],
-  ])("replaces %s details with database lock guidance", (_label, rawError) => {
-    const message = normalizeChannelLifecycleErrorMessage(rawError);
+  ])(
+    "replaces %s details with transient retry guidance",
+    (_label, rawError) => {
+      const message = normalizeChannelLifecycleErrorMessage(rawError);
 
-    expect(message).toBe(CHANNEL_LIFECYCLE_DATABASE_LOCK_MESSAGE);
-    expect(message).not.toContain("55P03");
-    expect(message).not.toContain("canceling statement");
-    expect(message).not.toContain("steps");
-  });
+      expect(message).toBe(CHANNEL_LIFECYCLE_TRANSIENT_ERROR_MESSAGE);
+      expect(message).not.toContain("database");
+      expect(message).not.toContain("lock");
+      expect(message).not.toContain("55P03");
+      expect(message).not.toContain("canceling statement");
+      expect(message).not.toContain("steps");
+    },
+  );
 
   test("keeps ordinary non-Postgres lock timeout details", () => {
     expect(
@@ -127,7 +132,7 @@ describe("formatChannelLifecycleErrorMessage", () => {
     ).not.toContain("```");
   });
 
-  test("formats database lock guidance without database internals", () => {
+  test("formats transient guidance without database internals", () => {
     const message = formatChannelLifecycleErrorMessage(
       "sqlalchemy.exc.OperationalError: SQLSTATE: 55P03 while updating steps",
       { codeBlock: true, runId: "run-47960fe9" },
@@ -135,7 +140,7 @@ describe("formatChannelLifecycleErrorMessage", () => {
 
     expect(message).toBe(
       "Turn failed:\n" +
-        `${CHANNEL_LIFECYCLE_DATABASE_LOCK_MESSAGE}\n\n` +
+        `${CHANNEL_LIFECYCLE_TRANSIENT_ERROR_MESSAGE}\n\n` +
         "Run ID: run-47960fe9",
     );
     expect(message).not.toContain("```");

--- a/src/channels/lifecycle-error.test.ts
+++ b/src/channels/lifecycle-error.test.ts
@@ -3,6 +3,7 @@ import {
   CHANNEL_LIFECYCLE_APPROVAL_PENDING_MESSAGE,
   CHANNEL_LIFECYCLE_CONVERSATION_BUSY_TITLE,
   CHANNEL_LIFECYCLE_FALLBACK_ERROR_MESSAGE,
+  CHANNEL_LIFECYCLE_LETTA_CLOUD_BUSY_MESSAGE,
   extractChannelLifecycleRunId,
   formatChannelLifecycleErrorMessage,
   normalizeChannelLifecycleErrorMessage,
@@ -22,6 +23,40 @@ describe("normalizeChannelLifecycleErrorMessage", () => {
     expect(
       normalizeChannelLifecycleErrorMessage("Unexpected stop reason: error"),
     ).toBe(CHANNEL_LIFECYCLE_FALLBACK_ERROR_MESSAGE);
+  });
+
+  test.each([
+    ["raw Postgres lock timeout", "canceling statement due to lock timeout"],
+    [
+      "SQLAlchemy psycopg lock timeout",
+      [
+        "sqlalchemy.exc.OperationalError: (psycopg.errors.LockNotAvailable) canceling statement due to lock timeout",
+        "[SQL: UPDATE steps SET status=$1 WHERE steps.id = $2]",
+        "(Background on this error at: https://sqlalche.me/e/20/e3q8)",
+      ].join("\n"),
+    ],
+    [
+      "SQLSTATE 55P03 context",
+      'psycopg.errors.LockNotAvailable: could not obtain lock on row in relation "steps" SQLSTATE: 55P03',
+    ],
+  ])(
+    "replaces %s details with Letta Cloud busy guidance",
+    (_label, rawError) => {
+      const message = normalizeChannelLifecycleErrorMessage(rawError);
+
+      expect(message).toBe(CHANNEL_LIFECYCLE_LETTA_CLOUD_BUSY_MESSAGE);
+      expect(message).not.toContain("55P03");
+      expect(message).not.toContain("canceling statement");
+      expect(message).not.toContain("steps");
+    },
+  );
+
+  test("keeps ordinary non-Postgres lock timeout details", () => {
+    expect(
+      normalizeChannelLifecycleErrorMessage(
+        "File lock timeout: /tmp/local.lock",
+      ),
+    ).toBe("File lock timeout: /tmp/local.lock");
   });
 
   test("replaces stuck approval conflicts with channel-safe guidance", () => {
@@ -93,6 +128,22 @@ describe("formatChannelLifecycleErrorMessage", () => {
         { codeBlock: true },
       ),
     ).not.toContain("```");
+  });
+
+  test("formats Letta Cloud busy guidance without database internals", () => {
+    const message = formatChannelLifecycleErrorMessage(
+      "sqlalchemy.exc.OperationalError: SQLSTATE: 55P03 while updating steps",
+      { codeBlock: true, runId: "run-47960fe9" },
+    );
+
+    expect(message).toBe(
+      "Turn failed:\n" +
+        `${CHANNEL_LIFECYCLE_LETTA_CLOUD_BUSY_MESSAGE}\n\n` +
+        "Run ID: run-47960fe9",
+    );
+    expect(message).not.toContain("```");
+    expect(message).not.toContain("55P03");
+    expect(message).not.toContain("steps");
   });
 
   test("appends explicit run IDs to generic channel errors", () => {

--- a/src/channels/lifecycle-error.ts
+++ b/src/channels/lifecycle-error.ts
@@ -16,6 +16,14 @@ const APPROVAL_PENDING_ERROR_PATTERNS = [
   /approve or deny the pending request/i,
 ];
 
+const LETTA_CLOUD_DATABASE_LOCK_TIMEOUT_PATTERN =
+  /\bcancel(?:l)?ing statement due to lock timeout\b/i;
+const POSTGRES_LOCK_NOT_AVAILABLE_CODE_PATTERN = /\b55P03\b/i;
+const POSTGRES_LOCK_NOT_AVAILABLE_SQLSTATE_PATTERN =
+  /\b(?:sqlstate|pgcode)\s*[:=]?\s*["']?55P03\b/i;
+const POSTGRES_LOCK_NOT_AVAILABLE_CONTEXT_PATTERN =
+  /\b(?:postgres(?:ql)?|psycopg|sqlalchemy|lock[_ -]?not[_ -]?available|lock timeout)\b/i;
+
 const RUN_ID_PATTERNS = [
   /"run_id"\s*:\s*"([^"\\]+)"/i,
   /\brun[_\s-]?id\b["']?\s*[:=]\s*["']?([A-Za-z0-9_-]+)/i,
@@ -25,6 +33,7 @@ const RUN_ID_PATTERNS = [
 export type ChannelLifecycleErrorKind =
   | "approval_pending"
   | "conversation_busy"
+  | "letta_cloud_busy"
   | "generic";
 
 export interface ChannelLifecycleErrorDisplayOptions {
@@ -50,6 +59,9 @@ export const CHANNEL_LIFECYCLE_FALLBACK_ERROR_MESSAGE =
 
 export const CHANNEL_LIFECYCLE_APPROVAL_PENDING_MESSAGE =
   "The agent is still waiting on a tool approval from an earlier turn. Please approve or deny that pending request, then send your message again.";
+
+export const CHANNEL_LIFECYCLE_LETTA_CLOUD_BUSY_MESSAGE =
+  "Letta Cloud was temporarily busy, so the turn could not finish. Please try again.";
 
 export const CHANNEL_LIFECYCLE_CONVERSATION_BUSY_TITLE =
   CONVERSATION_BUSY_TITLE;
@@ -143,6 +155,15 @@ function truncateLifecycleMessage(text: string, maxLength: number): string {
   return `${text.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
 }
 
+function isLettaCloudDatabaseLockErrorText(errorText: string): boolean {
+  return (
+    LETTA_CLOUD_DATABASE_LOCK_TIMEOUT_PATTERN.test(errorText) ||
+    POSTGRES_LOCK_NOT_AVAILABLE_SQLSTATE_PATTERN.test(errorText) ||
+    (POSTGRES_LOCK_NOT_AVAILABLE_CODE_PATTERN.test(errorText) &&
+      POSTGRES_LOCK_NOT_AVAILABLE_CONTEXT_PATTERN.test(errorText))
+  );
+}
+
 export function getChannelLifecycleErrorDisplay(
   errorText: string | null | undefined,
   options: ChannelLifecycleErrorDisplayOptions = {},
@@ -156,6 +177,15 @@ export function getChannelLifecycleErrorDisplay(
       kind: "generic",
       title: "Turn failed",
       body: CHANNEL_LIFECYCLE_FALLBACK_ERROR_MESSAGE,
+      runId,
+    };
+  }
+
+  if (isLettaCloudDatabaseLockErrorText(normalized)) {
+    return {
+      kind: "letta_cloud_busy",
+      title: "Turn failed",
+      body: CHANNEL_LIFECYCLE_LETTA_CLOUD_BUSY_MESSAGE,
       runId,
     };
   }
@@ -205,6 +235,14 @@ export function formatChannelLifecycleErrorMessage(
 
   if (display.kind === "conversation_busy") {
     const lines = [display.title, body];
+    if (display.runId) {
+      lines.push("", `Run ID: ${display.runId}`);
+    }
+    return lines.join("\n");
+  }
+
+  if (display.kind === "letta_cloud_busy") {
+    const lines = [`${display.title}:`, body];
     if (display.runId) {
       lines.push("", `Run ID: ${display.runId}`);
     }

--- a/src/channels/lifecycle-error.ts
+++ b/src/channels/lifecycle-error.ts
@@ -60,8 +60,8 @@ export const CHANNEL_LIFECYCLE_FALLBACK_ERROR_MESSAGE =
 export const CHANNEL_LIFECYCLE_APPROVAL_PENDING_MESSAGE =
   "The agent is still waiting on a tool approval from an earlier turn. Please approve or deny that pending request, then send your message again.";
 
-export const CHANNEL_LIFECYCLE_DATABASE_LOCK_MESSAGE =
-  "A temporary database lock interrupted this turn. Please try again.";
+export const CHANNEL_LIFECYCLE_TRANSIENT_ERROR_MESSAGE =
+  "A temporary error interrupted this turn. Please try again.";
 
 export const CHANNEL_LIFECYCLE_CONVERSATION_BUSY_TITLE =
   CONVERSATION_BUSY_TITLE;
@@ -185,7 +185,7 @@ export function getChannelLifecycleErrorDisplay(
     return {
       kind: "database_lock_timeout",
       title: "Turn failed",
-      body: CHANNEL_LIFECYCLE_DATABASE_LOCK_MESSAGE,
+      body: CHANNEL_LIFECYCLE_TRANSIENT_ERROR_MESSAGE,
       runId,
     };
   }

--- a/src/channels/lifecycle-error.ts
+++ b/src/channels/lifecycle-error.ts
@@ -16,7 +16,7 @@ const APPROVAL_PENDING_ERROR_PATTERNS = [
   /approve or deny the pending request/i,
 ];
 
-const LETTA_CLOUD_DATABASE_LOCK_TIMEOUT_PATTERN =
+const DATABASE_LOCK_TIMEOUT_PATTERN =
   /\bcancel(?:l)?ing statement due to lock timeout\b/i;
 const POSTGRES_LOCK_NOT_AVAILABLE_CODE_PATTERN = /\b55P03\b/i;
 const POSTGRES_LOCK_NOT_AVAILABLE_SQLSTATE_PATTERN =
@@ -33,7 +33,7 @@ const RUN_ID_PATTERNS = [
 export type ChannelLifecycleErrorKind =
   | "approval_pending"
   | "conversation_busy"
-  | "letta_cloud_busy"
+  | "database_lock_timeout"
   | "generic";
 
 export interface ChannelLifecycleErrorDisplayOptions {
@@ -60,8 +60,8 @@ export const CHANNEL_LIFECYCLE_FALLBACK_ERROR_MESSAGE =
 export const CHANNEL_LIFECYCLE_APPROVAL_PENDING_MESSAGE =
   "The agent is still waiting on a tool approval from an earlier turn. Please approve or deny that pending request, then send your message again.";
 
-export const CHANNEL_LIFECYCLE_LETTA_CLOUD_BUSY_MESSAGE =
-  "Letta Cloud was temporarily busy, so the turn could not finish. Please try again.";
+export const CHANNEL_LIFECYCLE_DATABASE_LOCK_MESSAGE =
+  "A temporary database lock interrupted this turn. Please try again.";
 
 export const CHANNEL_LIFECYCLE_CONVERSATION_BUSY_TITLE =
   CONVERSATION_BUSY_TITLE;
@@ -155,9 +155,9 @@ function truncateLifecycleMessage(text: string, maxLength: number): string {
   return `${text.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
 }
 
-function isLettaCloudDatabaseLockErrorText(errorText: string): boolean {
+function isDatabaseLockErrorText(errorText: string): boolean {
   return (
-    LETTA_CLOUD_DATABASE_LOCK_TIMEOUT_PATTERN.test(errorText) ||
+    DATABASE_LOCK_TIMEOUT_PATTERN.test(errorText) ||
     POSTGRES_LOCK_NOT_AVAILABLE_SQLSTATE_PATTERN.test(errorText) ||
     (POSTGRES_LOCK_NOT_AVAILABLE_CODE_PATTERN.test(errorText) &&
       POSTGRES_LOCK_NOT_AVAILABLE_CONTEXT_PATTERN.test(errorText))
@@ -181,11 +181,11 @@ export function getChannelLifecycleErrorDisplay(
     };
   }
 
-  if (isLettaCloudDatabaseLockErrorText(normalized)) {
+  if (isDatabaseLockErrorText(normalized)) {
     return {
-      kind: "letta_cloud_busy",
+      kind: "database_lock_timeout",
       title: "Turn failed",
-      body: CHANNEL_LIFECYCLE_LETTA_CLOUD_BUSY_MESSAGE,
+      body: CHANNEL_LIFECYCLE_DATABASE_LOCK_MESSAGE,
       runId,
     };
   }
@@ -241,7 +241,7 @@ export function formatChannelLifecycleErrorMessage(
     return lines.join("\n");
   }
 
-  if (display.kind === "letta_cloud_busy") {
+  if (display.kind === "database_lock_timeout") {
     const lines = [`${display.title}:`, body];
     if (display.runId) {
       lines.push("", `Run ID: ${display.runId}`);


### PR DESCRIPTION
## Problem

Cloud-backed channel turns can surface raw PostgreSQL lock errors such as `canceling statement due to lock timeout`. That exposes internal details without telling the user whether retrying is appropriate.

## Approach

- Recognize the known retryable PostgreSQL lock-timeout variants in the shared channel lifecycle formatter.
- Replace the internal diagnosis with channel-safe guidance: `A temporary error interrupted this turn. Please try again.`
- Keep the run ID for support correlation.
- Keep unrelated lock errors, such as local file-lock failures, unchanged.

The shared formatter covers Slack, Discord, Telegram, and WhatsApp rather than adding a Slack-only exception.

## Before / after

Before:

```
canceling statement due to lock timeout
```

After:

```
Turn failed:
A temporary error interrupted this turn. Please try again.
```

## Limits and risk

This is user-facing containment only; it does not resolve the underlying database contention, which is tracked separately in LET-10013. Matching is limited to the exact PostgreSQL timeout text or `55P03` with database-lock context, with a negative regression for ordinary file-lock messages.

## Validation

- `bun test src/channels/lifecycle-error.test.ts` — 14 passed
- `bun run check` — all 12 checks passed

Linear: LET-10012
