### PR TITLE
fix(slack): reuse channel reply blocks in sender

### DIFF
--- a/src/channels/slack/sender.test.ts
+++ b/src/channels/slack/sender.test.ts
@@ -52,6 +52,46 @@ describe("Slack channel sender", () => {
     ]);
   });
 
+  test("uses Slack reply blocks with web footnote for cloud agent responses", async () => {
+    const client = new FakeSlackSenderClient();
+    const sender = createSlackChannelSender({ client });
+    const message: OutboundChannelMessage = {
+      channel: "slack",
+      accountId: "integration-1",
+      chatId: "C123",
+      threadId: "1712790000.000000",
+      text: "hello from cloud",
+      agentId: "agent-123",
+      conversationId: "conversation-456",
+    };
+
+    await expect(sender.sendMessage(message)).resolves.toEqual({
+      messageId: "1712790000.000050",
+    });
+    expect(client.postMessages).toEqual([
+      {
+        channel: "C123",
+        text: "hello from cloud",
+        threadTs: "1712790000.000000",
+        blocks: [
+          {
+            type: "markdown",
+            text: "hello from cloud",
+          },
+          {
+            type: "context",
+            elements: [
+              {
+                type: "mrkdwn",
+                text: "<https://chat.letta.com/chat/agent-123?conversation=conversation-456|View on web>",
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
   test("adds Slack reactions", async () => {
     const client = new FakeSlackSenderClient();
     const sender = createSlackChannelSender({ client });

--- a/src/channels/slack/sender.ts
+++ b/src/channels/slack/sender.ts
@@ -1,5 +1,9 @@
 import type { OutboundChannelMessage } from "@/channels/types";
 import {
+  buildSlackChatFootnote,
+  buildSlackReplyBlocksWithFootnote,
+} from "./presentation";
+import {
   normalizeSlackReactionName,
   resolveSlackOutboundThreadTs,
 } from "./public-utils";
@@ -87,6 +91,24 @@ async function sendSlackReaction(
   return { messageId: targetMessageId };
 }
 
+function buildSlackOutboundBlocks(
+  message: OutboundChannelMessage,
+): unknown[] | undefined {
+  if (!message.agentId || !message.conversationId) {
+    return undefined;
+  }
+
+  const footnote = buildSlackChatFootnote({
+    agentId: message.agentId,
+    conversationId: message.conversationId,
+  });
+  if (!footnote) {
+    return undefined;
+  }
+
+  return buildSlackReplyBlocksWithFootnote(message.text, footnote);
+}
+
 export function createSlackChannelSender(
   params: CreateSlackChannelSenderParams,
 ): SlackChannelSender {
@@ -103,9 +125,11 @@ export function createSlackChannelSender(
         threadId: message.threadId,
         replyToMessageId: message.replyToMessageId,
       });
+      const blocks = buildSlackOutboundBlocks(message);
       return await client.postMessage({
         channel: message.chatId,
         text: message.text,
+        ...(blocks ? { blocks } : {}),
         ...(threadTs ? { threadTs } : {}),
       });
     },


### PR DESCRIPTION
Make the exported Slack channel sender use the same reply-block footnote formatting as the runtime Slack adapter so external callers, including Lettuce, share the final response presentation path.

👾 Generated with [Letta Code](https://letta.com)