### PR TITLE
feat(acp): ACP v1 adapter — use Letta agents from Zed and other ACP clients

### DIFF
--- a/acp/.gitignore
+++ b/acp/.gitignore
@@ -1,0 +1,34 @@
+# dependencies (bun install)
+node_modules
+
+# output
+out
+dist
+*.tgz
+
+# code coverage
+coverage
+*.lcov
+
+# logs
+logs
+_.log
+report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
+
+# dotenv environment variable files
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
+
+# caches
+.eslintcache
+.cache
+*.tsbuildinfo
+
+# IntelliJ based IDEs
+.idea
+
+# Finder (MacOS) folder config
+.DS_Store

--- a/acp/README.md
+++ b/acp/README.md
@@ -1,0 +1,99 @@
+# letta-acp
+
+An [Agent Client Protocol](https://agentclientprotocol.com) (ACP) adapter for
+Letta. It exposes a stateful Letta agent as an ACP agent over stdio, so any ACP
+client — Zed, JetBrains, marimo, or the bundled test client — can drive it.
+
+Built on [`@letta-ai/letta-agent-sdk`](https://github.com/letta-ai/letta-agent-sdk)
+(agent/session management, streaming, tool approvals) and
+[`@agentclientprotocol/sdk`](https://www.npmjs.com/package/@agentclientprotocol/sdk)
+(protocol plumbing).
+
+## ACP v1, not v2
+
+This adapter implements **protocol v1** (`protocolVersion: 1`):
+
+- v1 is the current stable wire protocol. Every shipping ACP client (including
+  Zed) negotiates v1 during `initialize`.
+- v2 exists only as an unstable schema surface (`@agentclientprotocol/sdk`
+  ships it under `experimental/v2`) that is still churning — MCP-aligned
+  content types, `auth/*` regrouping, unified session lifecycle — with no
+  stable release or client support yet.
+
+When v2 stabilizes, the migration is mostly mechanical (the SDK exposes a
+`dual-version-agent` example for serving both).
+
+## Quick start
+
+```bash
+cd acp
+bun install
+
+# smoke test with the bundled ACP client (spawns the agent over stdio)
+bun test-client.ts
+bun test-client.ts "List the files in this directory using your tools."
+```
+
+The first session creates a Letta agent and logs its id to stderr; set
+`LETTA_AGENT_ID` to that value to keep using the same agent (that's the point —
+its memory persists across sessions and editors).
+
+## Use from Zed
+
+Add to Zed's `settings.json`:
+
+```json
+{
+  "agent_servers": {
+    "Letta": {
+      "command": "bun",
+      "args": ["/path/to/letta-code/acp/src/index.ts"],
+      "env": { "LETTA_AGENT_ID": "agent-..." }
+    }
+  }
+}
+```
+
+Then open the Agent Panel, choose **Letta**, and start a thread.
+
+## Configuration
+
+| Variable | Effect |
+|----------|--------|
+| `LETTA_ACP_BACKEND` | `local` (default, SDK-managed app-server), `remote`, or `cloud` |
+| `LETTA_APP_SERVER_URL` | remote backend URL (default `ws://127.0.0.1:4500`) |
+| `LETTA_APP_SERVER_TOKEN` | remote backend auth token |
+| `LETTA_API_KEY` | cloud backend API key |
+| `LETTA_AGENT_ID` | reuse an existing agent instead of creating one |
+| `LETTA_ACP_MODEL` | model override for sessions |
+| `LETTA_ACP_PERMISSION_MODE` | `standard` (default), `acceptEdits`, `unrestricted` |
+
+## What's implemented
+
+| ACP surface | Status |
+|-------------|--------|
+| `initialize` (v1 negotiation) | ✅ |
+| `session/new` (per-session Letta conversation, cwd) | ✅ |
+| `session/prompt` (text, image, resource, resource_link) | ✅ |
+| `session/update` — message/thought chunks, tool calls, tool results | ✅ |
+| `session/request_permission` (allow once / always / reject) | ✅ |
+| `session/cancel` → `stopReason: cancelled` | ✅ |
+| `session/load` | ❌ (capability off) |
+| Client fs / terminal delegation | ❌ (tools run Letta-side) |
+
+## How it works
+
+`src/agent.ts` maps the two protocols:
+
+- Each ACP session becomes a new conversation (`client.createSession`) on one
+  underlying Letta agent, with the ACP `cwd`.
+- `session/prompt` sends the message and pumps `session.stream()`, translating
+  SDK messages (`assistant`, `reasoning`, `tool_call`, `tool_result`) into
+  `session/update` notifications.
+- Tool approvals: the SDK's `canUseTool` callback is forwarded as an ACP
+  `session/request_permission` request. One Letta-specific wrinkle: the
+  app-server transport ends the turn with a recoverable `approval_conflict`
+  result while the approval is pending, and the resumed run streams without a
+  second terminal result — so after such a result the adapter keeps pumping
+  the stream (approvals resolve concurrently over the control channel) and
+  ends the turn when the agent loop reports it is idle again.

--- a/acp/bun.lock
+++ b/acp/bun.lock
@@ -1,0 +1,551 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "acp",
+      "dependencies": {
+        "@agentclientprotocol/sdk": "^1.3.0",
+        "@letta-ai/letta-agent-sdk": "^0.2.6",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
+  },
+  "packages": {
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@1.3.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ=="],
+
+    "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.3.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
+
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1048.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.11", "@aws-sdk/credential-provider-node": "^3.972.42", "@aws-sdk/eventstream-handler-node": "^3.972.16", "@aws-sdk/middleware-eventstream": "^3.972.12", "@aws-sdk/middleware-websocket": "^3.972.19", "@aws-sdk/token-providers": "3.1048.0", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/fetch-http-handler": "^5.4.2", "@smithy/node-http-handler": "^4.7.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.976.0", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@aws-sdk/xml-builder": "^3.972.36", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.29.4", "@smithy/signature-v4": "^5.6.5", "@smithy/types": "^4.16.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-0cjRaEdlVoOrsNb9pP5q1Syyc8pXw5xSj2Np2ryReRTr9FppIIRVSdZK4lbnfmc2Hvgux/xBOUU6baB7z8//uA=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.60", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-BAkxdoe7tpDDqCghGpuOeHQRbm/2znVvOQm0AvpQbA2tbfMN46doN4zx65fv85ImP3KADwc2zQPmbrlI9MPfMg=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.62", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/fetch-http-handler": "^5.6.6", "@smithy/node-http-handler": "^4.9.6", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-g/0fGqKTb9xpKdd9AtpmV5Eo3DFKbnkpA2+w0peISSlu7NfAoWOuYBFxsu+yWBtxU89ka55ezoZBCbFaS8pjYQ=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.973.5", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/credential-provider-env": "^3.972.60", "@aws-sdk/credential-provider-http": "^3.972.62", "@aws-sdk/credential-provider-login": "^3.972.67", "@aws-sdk/credential-provider-process": "^3.972.60", "@aws-sdk/credential-provider-sso": "^3.973.4", "@aws-sdk/credential-provider-web-identity": "^3.972.66", "@aws-sdk/nested-clients": "^3.997.34", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/credential-provider-imds": "^4.4.9", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-ylubazcRfq2TVus/qXucSXeC42Qdjp5HQxTu68K/BsdMiZlcSLD1zkpoCgApXZX1Y6YJhtGGs7ZHhO/GuIgBlw=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.67", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/nested-clients": "^3.997.34", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-CCygIKJ9YbI3n84OClSaSppkgKKHVj2TGT33c6FRORZrYNZQ1POmD+ip0FLYokiJAK7sSdc3YVkOsBm90oxWMQ=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.71", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.60", "@aws-sdk/credential-provider-http": "^3.972.62", "@aws-sdk/credential-provider-ini": "^3.973.5", "@aws-sdk/credential-provider-process": "^3.972.60", "@aws-sdk/credential-provider-sso": "^3.973.4", "@aws-sdk/credential-provider-web-identity": "^3.972.66", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/credential-provider-imds": "^4.4.9", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-HIg7Q2osBzajQwL+1Vkyh2E7Gim3eTNb9RHIsOxDGjW0eZg4oEKtRs5sioCnc73ilhaOm4gX2lHVF8J7+nt2rg=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.60", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-YIo3f99hM43QdYG8hDzwGemnR/pU95b0kramqSJUTleCqaB7+HwKf7YZFHqvOgTqZTPx/mRmNIqoDRr3U0Z3Tw=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.973.4", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/nested-clients": "^3.997.34", "@aws-sdk/token-providers": "3.1092.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-BPdmL8sSBOCv4ngZ+3LHxyc3CNqDCEK37CHioCk7zGrTMY5sUtkH8q+o6qA80nn6w3/fyBPGNE7OIRlmoOxRQA=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.66", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/nested-clients": "^3.997.34", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-kSAziJboOmZmsR9/MTbiNjowl2BPes1bQuJpne4qAZ62ubi8fjfr/aupJSQje6udBoYxXTQbsL0e0kby2la3ng=="],
+
+    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.29", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-t3tKQRTVXsI2QNPE3CaNjHl0wRO9Xi3acZkAyti2RQsiFmZ9Gi0kArX2ighlRJ1BtDVuul413gThAgzyTfgmWA=="],
+
+    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.972.24", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-oykin4mDWxNOuYQ7SF1cHzgYeuFEkF4cdRwgvjFFbIklkx09qIFBiOgsORafG9sXZFO3TayMmQuAQYgADXhI8w=="],
+
+    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.972.42", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/fetch-http-handler": "^5.6.6", "@smithy/signature-v4": "^5.6.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-dw+GP8DC7QC2C8tUoK7DI8BnrNAjz8tb+uBHSrD2qJvxkCf58kTtFr98pljSrk+umU4n4HDW4eU2k7C2dWMzsg=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.34", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/signature-v4-multi-region": "^3.996.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/fetch-http-handler": "^5.6.6", "@smithy/node-http-handler": "^4.9.6", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Y9REVrSwmLM+Qy6sZJ7ofMC2S3Hr3tPP/4CzL5U1olPP7OGoF+6+Px0E49cVQBtSxJtyeLJMf0UaBErfeSahAA=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.41", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/signature-v4": "^5.6.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1048.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.11", "@aws-sdk/nested-clients": "^3.997.9", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.8", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.36", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.79.10", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-9jR23tOl0BIUdQMn70Gr72xYBpM7Xgl9Lyv7gAnU1USfkNRuYG/f/edLl+n/Dp/RafDW3JI4DF7y/GhgkORuew=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
+
+    "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "@letta-ai/letta-agent-sdk": ["@letta-ai/letta-agent-sdk@0.2.6", "", { "dependencies": { "@letta-ai/letta-code": "0.27.30" } }, "sha512-EKyjs0xL0YJF55n/Kszg7kaqIHUwIQXbj8hUbo2ytOIP7eA5NzFW6LtzF5lVUKVbVLWq5i+C+QYDtxA4gF9xhg=="],
+
+    "@letta-ai/letta-client": ["@letta-ai/letta-client@1.12.1", "", {}, "sha512-rYjXMXpkfssj7VBBX3qCp6mdpNRv6YPNrliYsjkhWoQDqGg3J9bsgIQ28ZhQTddabYxRUIwcdzuaizFx8pvZ7A=="],
+
+    "@letta-ai/letta-code": ["@letta-ai/letta-code@0.27.30", "", { "dependencies": { "@earendil-works/pi-ai": "^0.79.6", "@letta-ai/letta-client": "^1.10.2", "@pierre/diffs": "1.2.2", "@scarf/scarf": "^1.4.0", "glob": "^13.0.0", "ink-link": "^5.0.0", "node-pty": "^1.1.0", "open": "^10.2.0", "react": "18.2.0", "sharp": "^0.34.5", "shiki": "^4.0.2", "strip-ansi": "^7.2.0", "ws": "^8.19.0" }, "optionalDependencies": { "@vscode/ripgrep": "^1.17.0" }, "bin": { "letta": "letta.js" } }, "sha512-HaSKBZgDbVn45nKBZtfIrOiYF10Sny9VXoOPM5IMOrdi33XldZy1NUTODt5YPO6AgTYGDI+nPAY3itPqFKrTuw=="],
+
+    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.6", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.40.0", "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
+
+    "@pierre/diffs": ["@pierre/diffs@1.2.2", "", { "dependencies": { "@pierre/theme": "1.0.3", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-MvWLv2oSOJOF8oYXWLdhicguHM11G/VNWu6OPR5ZETolp2NM2/KPQG3cZTnKpJ6ImqEHwvw6Gl6z2gmmy2FQmQ=="],
+
+    "@pierre/theme": ["@pierre/theme@1.0.3", "", {}, "sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.2", "", {}, "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug=="],
+
+    "@scarf/scarf": ["@scarf/scarf@1.4.0", "", {}, "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ=="],
+
+    "@shikijs/core": ["@shikijs/core@4.3.1", "", { "dependencies": { "@shikijs/primitive": "4.3.1", "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.6" } }, "sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg=="],
+
+    "@shikijs/langs": ["@shikijs/langs@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1" } }, "sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ=="],
+
+    "@shikijs/primitive": ["@shikijs/primitive@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A=="],
+
+    "@shikijs/themes": ["@shikijs/themes@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1" } }, "sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA=="],
+
+    "@shikijs/transformers": ["@shikijs/transformers@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/types": "3.23.0" } }, "sha512-F9msZVxdF+krQNSdQ4V+Ja5QemeAoTQ2jxt7nJCwhDsdF1JWS3KxIQXA3lQbyKwS3J61oHRUSv4jYWv3CkaKTQ=="],
+
+    "@shikijs/types": ["@shikijs/types@4.3.1", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
+    "@smithy/core": ["@smithy/core@3.29.7", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-BiEE2bnnGoPKdlGe3L+gOYORDHFGPuYVRLP7iUow/Sflm0B4hC4XY3FC1MRuc7ltzpW2xNnXopKi34TTkULlKQ=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.12", "", { "dependencies": { "@smithy/core": "^3.29.7", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-ZZPDbl/aRp77aycuoMlo3BTayT4CE2a3uoqETYZU5ySnVbhpl5IJiY7dCZedn+ZusyDLqVv44IvKBiXd2/nK0Q=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.6.9", "", { "dependencies": { "@smithy/core": "^3.29.7", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-EJktha5m5MXCwzdXrlWyqb9UCNHNFKlg+PmTpRsdX3dncJPTiqYleM9OKj2mLgdVJHR01d2tU4alG+z2NdH5rQ=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.3", "", { "dependencies": { "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.6.8", "", { "dependencies": { "@smithy/core": "^3.29.7", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-iGBm6hIwD2MGvVRSgrjVWa4FXtXDq3akxu0DCpnkmBo0xtEHZ/siMRt7ycfZAefYr2UdywUgmGtoRLaq5u56pg=="],
+
+    "@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/hast": ["@types/hast@3.0.5", "", { "dependencies": { "@types/unist": "*" } }, "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.3", "", {}, "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg=="],
+
+    "@vscode/ripgrep": ["@vscode/ripgrep@1.18.0", "", { "optionalDependencies": { "@vscode/ripgrep-darwin-arm64": "1.18.0", "@vscode/ripgrep-darwin-x64": "1.18.0", "@vscode/ripgrep-linux-arm": "1.18.0", "@vscode/ripgrep-linux-arm64": "1.18.0", "@vscode/ripgrep-linux-ia32": "1.18.0", "@vscode/ripgrep-linux-ppc64": "1.18.0", "@vscode/ripgrep-linux-riscv64": "1.18.0", "@vscode/ripgrep-linux-s390x": "1.18.0", "@vscode/ripgrep-linux-x64": "1.18.0", "@vscode/ripgrep-win32-arm64": "1.18.0", "@vscode/ripgrep-win32-ia32": "1.18.0", "@vscode/ripgrep-win32-x64": "1.18.0" } }, "sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ=="],
+
+    "@vscode/ripgrep-darwin-arm64": ["@vscode/ripgrep-darwin-arm64@1.18.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-r3ktHSvbFycQNF6sl7sNDPocpsI7J+mEzh1IaZFkY0spm3k2Z9t8hPAeOK7+p0l6p6/swkQC14XWX01low+94Q=="],
+
+    "@vscode/ripgrep-darwin-x64": ["@vscode/ripgrep-darwin-x64@1.18.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-25b4gWbL138dGuQU244ebCKKc0q05ULBMoFSz9oAEUHNeqK/lOJViDS7DRvbDazzAzSEdan391Znks/R5mkaTQ=="],
+
+    "@vscode/ripgrep-linux-arm": ["@vscode/ripgrep-linux-arm@1.18.0", "", { "os": "linux", "cpu": "arm" }, "sha512-GDAvufNDHu8zqLEmXstalQF0Wh6wQvdsBi/Vg3Yi3CK4a8XoFXqqXVEHEZ9xQz3t0NfoSEc9JbvK9DDS6FxyxQ=="],
+
+    "@vscode/ripgrep-linux-arm64": ["@vscode/ripgrep-linux-arm64@1.18.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-lQ/5zTG++U0E3IhVgS4EPTTn/U4okncaRMM5GOFfOYZywS4nuD31GhkHbNYlDk5CuDC68+hYJ0/eQeyCKJDA+g=="],
+
+    "@vscode/ripgrep-linux-ia32": ["@vscode/ripgrep-linux-ia32@1.18.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-YWLkSUtFd4Jh5EepIhA9RJSfv3uMAVMo+2rBIGHPBnvgLrZciIs2cDKei1/p6Wc/aCzUoHyMAg2R6tw4ZCBKGg=="],
+
+    "@vscode/ripgrep-linux-ppc64": ["@vscode/ripgrep-linux-ppc64@1.18.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-quXVY8fwQ8O/lvU1yrSqSl3jlUzysRSb+AfUfCL/tRtphxsKlFvPAejryZ6vg4Bgvn8XL74xb4qMCDmWgYrT5w=="],
+
+    "@vscode/ripgrep-linux-riscv64": ["@vscode/ripgrep-linux-riscv64@1.18.0", "", { "os": "linux", "cpu": "none" }, "sha512-f5kBQBrWfQt8Q7OhSORuNDei5dkYagBj3y4jImSUXGMy8B/Ke7SltSRcUtjPv166FAFfHCAmWuZp3+cWnX2/Vw=="],
+
+    "@vscode/ripgrep-linux-s390x": ["@vscode/ripgrep-linux-s390x@1.18.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-rTOcJFGGcl2c07RUOWUo4U1ndnemKhY6A9hnMB18uk7jSgJc0d/QLBGWMWpumdtoJtpizn/wIv5mXIisJukusQ=="],
+
+    "@vscode/ripgrep-linux-x64": ["@vscode/ripgrep-linux-x64@1.18.0", "", { "os": "linux", "cpu": "x64" }, "sha512-mQ3bVrUpnD2vs7QT0vX90Lt0cnUq467uFtEktIdsJJmW296RoSULRGqWgzG1AKxyBpNDD6l4ZO4qKf6SgyC23Q=="],
+
+    "@vscode/ripgrep-win32-arm64": ["@vscode/ripgrep-win32-arm64@1.18.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-vfTIjq1OHnzUjxZcHVQAMbnggp8dpGf+0QKFOZHwWPqFwXxQC8eCWM+5NUdoJ6yrElCeMzoUTXoK/LdZaniB+Q=="],
+
+    "@vscode/ripgrep-win32-ia32": ["@vscode/ripgrep-win32-ia32@1.18.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-//rfAE+BOw5AC2EMmepmiE36jUuevtQYNQqqlw1s3m9FlRxjxEut97RkRPHAu9BG4mSojatZx+kXZXNdyI9caQ=="],
+
+    "@vscode/ripgrep-win32-x64": ["@vscode/ripgrep-win32-x64@1.18.0", "", { "os": "win32", "cpu": "x64" }, "sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
+
+    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
+
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "cli-boxes": ["cli-boxes@4.0.1", "", {}, "sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw=="],
+
+    "cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
+
+    "cli-truncate": ["cli-truncate@6.1.1", "", { "dependencies": { "slice-ansi": "^9.0.0", "string-width": "^8.2.0" } }, "sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw=="],
+
+    "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
+    "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
+
+    "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
+
+    "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
+
+    "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
+    "diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
+    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
+    "es-toolkit": ["es-toolkit@1.49.0", "", {}, "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g=="],
+
+    "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
+    "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
+    "gaxios": ["gaxios@7.2.0", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg=="],
+
+    "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
+
+    "google-auth-library": ["google-auth-library@10.9.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg=="],
+
+    "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
+
+    "has-flag": ["has-flag@5.0.1", "", {}, "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA=="],
+
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
+    "ink": ["ink@7.1.1", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.3.0", "ansi-escapes": "^7.3.0", "ansi-styles": "^6.2.3", "auto-bind": "^5.0.1", "chalk": "^5.6.2", "cli-boxes": "^4.0.1", "cli-cursor": "^4.0.0", "cli-truncate": "^6.0.0", "code-excerpt": "^4.0.0", "es-toolkit": "^1.45.1", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "scheduler": "^0.27.0", "signal-exit": "^3.0.7", "slice-ansi": "^9.0.0", "stack-utils": "^2.0.6", "string-width": "^8.2.0", "terminal-size": "^4.0.1", "type-fest": "^5.5.0", "widest-line": "^6.0.0", "wrap-ansi": "^10.0.0", "ws": "^8.20.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.2.0", "react": ">=19.2.0", "react-devtools-core": ">=6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-Y43xxa1ZSPvpmfLHcN5o+OdP8Rf8ykkNJEuKYOUNZKT8wXVNLFTtEm1nSDMQkfBH+YANF4Xuu0hhZ4ejqAtN2w=="],
+
+    "ink-link": ["ink-link@5.0.0", "", { "dependencies": { "terminal-link": "^5.0.0" }, "peerDependencies": { "ink": ">=6" } }, "sha512-TFDXc/0mwUW7LMjsr0/LeLxPVV5BnHDuDQff9RCgP4rb3R+V/4dIwGBZbCevcJZtQnVcW+Iz1LUrUbpq+UDwYA=="],
+
+    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
+    "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
+
+    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
+
+    "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
+    "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
+
+    "lru_map": ["lru_map@0.4.1", "", {}, "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
+
+    "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
+
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
+    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "node-pty": ["node-pty@1.1.0", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg=="],
+
+    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+
+    "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
+
+    "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
+
+    "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
+
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
+
+    "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
+
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+
+    "property-information": ["property-information@7.2.0", "", {}, "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg=="],
+
+    "protobufjs": ["protobufjs@7.6.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
+
+    "react": ["react@18.2.0", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ=="],
+
+    "react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
+
+    "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
+
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
+    "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
+
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
+    "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
+    "shiki": ["shiki@4.3.1", "", { "dependencies": { "@shikijs/core": "4.3.1", "@shikijs/engine-javascript": "4.3.1", "@shikijs/engine-oniguruma": "4.3.1", "@shikijs/langs": "4.3.1", "@shikijs/themes": "4.3.1", "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw=="],
+
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "slice-ansi": ["slice-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA=="],
+
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
+
+    "string-width": ["string-width@8.2.2", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg=="],
+
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
+
+    "supports-hyperlinks": ["supports-hyperlinks@4.5.0", "", { "dependencies": { "has-flag": "^5.0.1", "supports-color": "^10.2.2" } }, "sha512-ZW2OvfeCXrNTbLakPUzjQG922EeGCOteFSVoek5DKStTh898wf7zgtuFlzQN8HfZCxC3Eh02yJVrRW51hADf+w=="],
+
+    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
+
+    "terminal-link": ["terminal-link@5.0.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "supports-hyperlinks": "^4.1.0" } }, "sha512-qFAy10MTMwjzjU8U16YS4YoZD+NQLHzLssFMNqgravjbvIPNiqkGFR4yjhJfmY9R5OFU7+yHxc6y+uGHkKwLRA=="],
+
+    "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
+
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "type-fest": ["type-fest@5.8.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA=="],
+
+    "typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
+    "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
+
+    "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
+
+    "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
+
+    "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
+
+    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@aws-sdk/credential-provider-http/@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.9", "", { "dependencies": { "@smithy/core": "^3.29.7", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-xVBZ3hptB99iNO9XyWqEhC7KD9bP9UPXhuy3h5Y2ItCfBv160D9IIC/Fmmp3EbnWwit4C+KVqlSE+E29Nk/pPg=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1092.0", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/nested-clients": "^3.997.34", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-hBYUAr6iBLNFcsiWTgtBb0stdSw39VOUq4Sp4A5caCNf66BAZplWN4FleKrVpJx5li2YgdnK2DqoFSMWC642FQ=="],
+
+    "@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.9", "", { "dependencies": { "@smithy/core": "^3.29.7", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-xVBZ3hptB99iNO9XyWqEhC7KD9bP9UPXhuy3h5Y2ItCfBv160D9IIC/Fmmp3EbnWwit4C+KVqlSE+E29Nk/pPg=="],
+
+    "@pierre/diffs/shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
+
+    "@shikijs/transformers/@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
+
+    "@shikijs/transformers/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "@pierre/diffs/shiki/@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
+
+    "@pierre/diffs/shiki/@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA=="],
+
+    "@pierre/diffs/shiki/@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g=="],
+
+    "@pierre/diffs/shiki/@shikijs/langs": ["@shikijs/langs@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg=="],
+
+    "@pierre/diffs/shiki/@shikijs/themes": ["@shikijs/themes@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA=="],
+
+    "@pierre/diffs/shiki/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+  }
+}

--- a/acp/package.json
+++ b/acp/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@letta-ai/letta-acp",
+  "version": "0.1.0",
+  "description": "ACP (Agent Client Protocol) adapter for Letta agents — exposes Letta over ACP v1 so editors like Zed can drive a stateful Letta agent.",
+  "type": "module",
+  "private": true,
+  "bin": {
+    "letta-acp": "src/index.ts"
+  },
+  "scripts": {
+    "start": "bun src/index.ts",
+    "test:client": "bun test-client.ts",
+    "typecheck": "bunx tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/bun": "latest"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  },
+  "dependencies": {
+    "@agentclientprotocol/sdk": "^1.3.0",
+    "@letta-ai/letta-agent-sdk": "^0.2.6"
+  }
+}

--- a/acp/src/agent.ts
+++ b/acp/src/agent.ts
@@ -1,0 +1,486 @@
+import {
+  type AgentContext,
+  type CancelNotification,
+  type ContentBlock,
+  type InitializeRequest,
+  type InitializeResponse,
+  methods,
+  type NewSessionRequest,
+  type NewSessionResponse,
+  PROTOCOL_VERSION,
+  type PromptRequest,
+  type PromptResponse,
+  type StopReason,
+} from "@agentclientprotocol/sdk";
+import {
+  type CanUseToolResponse,
+  LettaAgentClient,
+  type LettaCodeSession,
+  type MessageContentItem,
+  type SDKMessage,
+  type SDKResultMessage,
+} from "@letta-ai/letta-agent-sdk";
+import type { LettaAcpConfig } from "./config.js";
+import { toolKind, toolLocations, toolTitle } from "./tool-info.js";
+
+interface AcpSessionState {
+  session: LettaCodeSession;
+  /** ACP context of the in-flight prompt; permission requests need it. */
+  promptContext: AgentContext | null;
+  /** Most recent tool_call streamed, to correlate permission requests. */
+  lastToolCall: { id: string; name: string } | null;
+  /** Tools the user chose "always allow" for, scoped to this session. */
+  alwaysAllowed: Set<string>;
+  cancelled: boolean;
+}
+
+type PumpOutcome =
+  | { kind: "result"; result: SDKResultMessage }
+  | { kind: "idle" }
+  | { kind: "stream_end" };
+
+const IMAGE_MEDIA_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+]);
+
+/**
+ * Bridges ACP v1 (agent side) onto a Letta agent via the Letta Agent SDK.
+ *
+ * One process serves one ACP connection. Every ACP session becomes a new
+ * Letta conversation on a single underlying Letta agent, so the agent's
+ * memory persists across sessions and editors.
+ */
+export class LettaAcpAgent {
+  private readonly config: LettaAcpConfig;
+  private readonly client: LettaAgentClient;
+  private readonly sessions = new Map<string, AcpSessionState>();
+  private agentIdPromise: Promise<string> | null = null;
+
+  constructor(config: LettaAcpConfig) {
+    this.config = config;
+    this.client = new LettaAgentClient(config.clientOptions);
+  }
+
+  async initialize(params: InitializeRequest): Promise<InitializeResponse> {
+    const requested = params.protocolVersion;
+    const protocolVersion =
+      typeof requested === "number" && requested < PROTOCOL_VERSION
+        ? requested
+        : PROTOCOL_VERSION;
+    return {
+      protocolVersion,
+      agentCapabilities: {
+        loadSession: false,
+        promptCapabilities: {
+          image: true,
+          embeddedContext: true,
+        },
+      },
+      authMethods: [],
+    };
+  }
+
+  async newSession(params: NewSessionRequest): Promise<NewSessionResponse> {
+    const agentId = await this.ensureAgent();
+    const sessionId = `sess_${crypto.randomUUID()}`;
+    const session = this.client.createSession(agentId, {
+      cwd: params.cwd,
+      model: this.config.model,
+      permissionMode: this.config.permissionMode,
+      canUseTool: (toolName, toolInput) =>
+        this.requestToolPermission(sessionId, toolName, toolInput),
+    });
+    this.sessions.set(sessionId, {
+      session,
+      promptContext: null,
+      lastToolCall: null,
+      alwaysAllowed: new Set(),
+      cancelled: false,
+    });
+    log(`session ${sessionId} -> agent ${agentId} (cwd: ${params.cwd})`);
+    return { sessionId };
+  }
+
+  async prompt(
+    params: PromptRequest,
+    cx: AgentContext,
+  ): Promise<PromptResponse> {
+    const state = this.sessions.get(params.sessionId);
+    if (!state) {
+      throw new Error(`Unknown session: ${params.sessionId}`);
+    }
+    state.promptContext = cx;
+    state.cancelled = false;
+
+    try {
+      await state.session.send(toLettaContent(params.prompt));
+      // The Letta app-server transport completes a turn with a recoverable
+      // "approval_conflict" result whenever a tool needs user approval. The
+      // approval itself resolves concurrently: the server sends a
+      // can_use_tool control request, our canUseTool callback forwards it to
+      // the ACP client, and once answered the run resumes and its events keep
+      // streaming — but with no second terminal result message. So: pump the
+      // first round to its result, then pump recovery rounds (blocking on the
+      // stream while approvals resolve) until the run goes idle.
+      let mode: "turn" | "recovery" = "turn";
+      while (true) {
+        const outcome = await this.pumpStream(
+          params.sessionId,
+          state,
+          cx,
+          mode,
+        );
+        if (state.cancelled) return { stopReason: "cancelled" };
+        switch (outcome.kind) {
+          case "result": {
+            const result = outcome.result;
+            if (!result.success && result.errorCode === "approval_conflict") {
+              mode = "recovery";
+              continue;
+            }
+            return this.toPromptResponse(state, result);
+          }
+          case "idle":
+          case "stream_end":
+            return { stopReason: "end_turn" };
+        }
+      }
+    } catch (error) {
+      if (state.cancelled) return { stopReason: "cancelled" };
+      throw error;
+    } finally {
+      state.promptContext = null;
+    }
+  }
+
+  /**
+   * Iterates one session.stream() round, forwarding events to the client.
+   * In "recovery" mode (post-approval continuation) there is no terminal
+   * result message, so loop_status transitions decide when the turn is over.
+   * Blocking on the stream while an approval is pending is fine — the
+   * canUseTool round-trip resolves concurrently over the control channel.
+   */
+  private async pumpStream(
+    sessionId: string,
+    state: AcpSessionState,
+    cx: AgentContext,
+    mode: "turn" | "recovery",
+  ): Promise<PumpOutcome> {
+    let sawActivity = false;
+    let idleStatusCount = 0;
+    for await (const message of state.session.stream()) {
+      if (message.type === "result") {
+        return { kind: "result", result: message };
+      }
+      if (message.type === "loop_status" && mode === "recovery") {
+        if (message.status === "WAITING_ON_INPUT") {
+          idleStatusCount += 1;
+          // The first idle status can be stale (queued before the resume);
+          // trust it once we've seen real activity or it repeats.
+          if (sawActivity || idleStatusCount >= 2 || state.cancelled) {
+            return { kind: "idle" };
+          }
+        }
+        continue;
+      }
+      const forwarded = await this.forwardMessage(
+        sessionId,
+        state,
+        message,
+        cx,
+      );
+      sawActivity = sawActivity || forwarded;
+    }
+    return { kind: "stream_end" };
+  }
+
+  async cancel(params: CancelNotification): Promise<void> {
+    const state = this.sessions.get(params.sessionId);
+    if (!state) return;
+    state.cancelled = true;
+    try {
+      await state.session.abort();
+    } catch (error) {
+      log(`abort failed for ${params.sessionId}: ${String(error)}`);
+    }
+  }
+
+  shutdown(): void {
+    for (const state of this.sessions.values()) {
+      try {
+        state.session.close();
+      } catch {
+        // best-effort cleanup on connection close
+      }
+    }
+    this.sessions.clear();
+  }
+
+  /**
+   * Streamed Letta SDK message -> ACP session/update notification.
+   * Returns true when the message was substantive turn activity.
+   */
+  private async forwardMessage(
+    sessionId: string,
+    state: AcpSessionState,
+    message: SDKMessage,
+    cx: AgentContext,
+  ): Promise<boolean> {
+    switch (message.type) {
+      case "init":
+        log(`turn started (agent ${message.agentId}, model ${message.model})`);
+        return false;
+      case "assistant":
+        await cx.notify(methods.client.session.update, {
+          sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: message.content },
+          },
+        });
+        return true;
+      case "reasoning":
+        await cx.notify(methods.client.session.update, {
+          sessionId,
+          update: {
+            sessionUpdate: "agent_thought_chunk",
+            content: { type: "text", text: message.content },
+          },
+        });
+        return true;
+      case "tool_call":
+        state.lastToolCall = { id: message.toolCallId, name: message.toolName };
+        await cx.notify(methods.client.session.update, {
+          sessionId,
+          update: {
+            sessionUpdate: "tool_call",
+            toolCallId: message.toolCallId,
+            title: toolTitle(message.toolName, message.toolInput),
+            kind: toolKind(message.toolName),
+            status: "in_progress",
+            rawInput: message.toolInput,
+            locations: toolLocations(message.toolInput),
+          },
+        });
+        return true;
+      case "tool_result":
+        await cx.notify(methods.client.session.update, {
+          sessionId,
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId: message.toolCallId,
+            status: message.isError ? "failed" : "completed",
+            content: [
+              {
+                type: "content",
+                content: { type: "text", text: message.content },
+              },
+            ],
+          },
+        });
+        return true;
+      case "error":
+        log(`stream error: ${message.message}`);
+        return false;
+      default:
+        // queue_update, loop_status, stream_event, retry — no ACP equivalent.
+        return false;
+    }
+  }
+
+  private toPromptResponse(
+    state: AcpSessionState,
+    result: SDKResultMessage,
+  ): PromptResponse {
+    if (result.success) {
+      return { stopReason: "end_turn" };
+    }
+    let stopReason: StopReason;
+    switch (result.errorCode) {
+      case "interrupted":
+        stopReason = "cancelled";
+        break;
+      case "max_steps":
+        stopReason = "max_turn_requests";
+        break;
+      default:
+        if (state.cancelled) {
+          stopReason = "cancelled";
+          break;
+        }
+        throw new Error(
+          result.errorDetail ?? result.error ?? "Letta turn failed",
+        );
+    }
+    return { stopReason };
+  }
+
+  /** Letta canUseTool callback -> ACP session/request_permission. */
+  private async requestToolPermission(
+    sessionId: string,
+    toolName: string,
+    toolInput: Record<string, unknown>,
+  ): Promise<CanUseToolResponse> {
+    const state = this.sessions.get(sessionId);
+    const cx = state?.promptContext;
+    if (!state || !cx) {
+      return {
+        behavior: "deny",
+        message: "No active ACP prompt to request permission from",
+      };
+    }
+    return this.resolveToolPermission(
+      sessionId,
+      state,
+      cx,
+      toolName,
+      toolInput,
+    );
+  }
+
+  private async resolveToolPermission(
+    sessionId: string,
+    state: AcpSessionState,
+    cx: AgentContext,
+    toolName: string,
+    toolInput: Record<string, unknown>,
+  ): Promise<CanUseToolResponse> {
+    log(`permission requested for ${toolName}`);
+    if (state.alwaysAllowed.has(toolName)) {
+      return { behavior: "allow", updatedInput: toolInput };
+    }
+
+    const toolCallId =
+      state.lastToolCall?.name === toolName
+        ? state.lastToolCall.id
+        : `${toolName}_${crypto.randomUUID()}`;
+    const response = await cx.request(
+      methods.client.session.requestPermission,
+      {
+        sessionId,
+        toolCall: {
+          toolCallId,
+          title: toolTitle(toolName, toolInput),
+          kind: toolKind(toolName),
+          status: "pending",
+          rawInput: toolInput,
+          locations: toolLocations(toolInput),
+        },
+        options: [
+          {
+            optionId: "allow_once",
+            name: `Allow ${toolName} once`,
+            kind: "allow_once",
+          },
+          {
+            optionId: "allow_always",
+            name: `Always allow ${toolName} this session`,
+            kind: "allow_always",
+          },
+          { optionId: "reject_once", name: "Reject", kind: "reject_once" },
+        ],
+      },
+    );
+
+    if (response.outcome.outcome === "cancelled") {
+      return {
+        behavior: "deny",
+        message: "Prompt turn was cancelled",
+        interrupt: true,
+      };
+    }
+    switch (response.outcome.optionId) {
+      case "allow_always":
+        state.alwaysAllowed.add(toolName);
+        return { behavior: "allow", updatedInput: toolInput };
+      case "allow_once":
+        return { behavior: "allow", updatedInput: toolInput };
+      default:
+        return { behavior: "deny", message: "User rejected this tool call" };
+    }
+  }
+
+  private ensureAgent(): Promise<string> {
+    if (!this.agentIdPromise) {
+      this.agentIdPromise = this.resolveAgent();
+      this.agentIdPromise.catch(() => {
+        // Allow retry on the next session/new instead of caching the failure.
+        this.agentIdPromise = null;
+      });
+    }
+    return this.agentIdPromise;
+  }
+
+  private async resolveAgent(): Promise<string> {
+    if (this.config.agentId) {
+      log(`using existing agent ${this.config.agentId}`);
+      return this.config.agentId;
+    }
+    log("creating a new Letta agent (set LETTA_AGENT_ID to reuse one)...");
+    const agentId = await this.client.createAgent({
+      name: "ACP agent",
+      description: "Letta agent driven by an ACP client (e.g. Zed)",
+      model: this.config.model,
+    });
+    log(
+      `created agent ${agentId} — set LETTA_AGENT_ID=${agentId} to keep using it`,
+    );
+    return agentId;
+  }
+}
+
+/** ACP prompt content blocks -> Letta multimodal message content. */
+export function toLettaContent(blocks: ContentBlock[]): MessageContentItem[] {
+  const content: MessageContentItem[] = [];
+  for (const block of blocks) {
+    switch (block.type) {
+      case "text":
+        content.push({ type: "text", text: block.text });
+        break;
+      case "image":
+        if (IMAGE_MEDIA_TYPES.has(block.mimeType)) {
+          content.push({
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: block.mimeType as
+                | "image/png"
+                | "image/jpeg"
+                | "image/gif"
+                | "image/webp",
+              data: block.data,
+            },
+          });
+        }
+        break;
+      case "resource_link":
+        content.push({ type: "text", text: `[Referenced file: ${block.uri}]` });
+        break;
+      case "resource": {
+        const resource = block.resource;
+        if ("text" in resource && typeof resource.text === "string") {
+          content.push({
+            type: "text",
+            text: `<context uri="${resource.uri}">\n${resource.text}\n</context>`,
+          });
+        }
+        break;
+      }
+      default:
+        // audio and future block types are not advertised in promptCapabilities
+        break;
+    }
+  }
+  if (content.length === 0) {
+    content.push({ type: "text", text: "" });
+  }
+  return content;
+}
+
+function log(message: string): void {
+  // stdout carries the ACP JSON-RPC stream; all logging goes to stderr.
+  console.error(`[letta-acp] ${message}`);
+}

--- a/acp/src/config.ts
+++ b/acp/src/config.ts
@@ -1,0 +1,67 @@
+import type {
+  LettaCodeClientOptions,
+  PermissionMode,
+} from "@letta-ai/letta-agent-sdk";
+
+export interface LettaAcpConfig {
+  /** Letta backend client options (local | remote | cloud). */
+  clientOptions: LettaCodeClientOptions;
+  /** Reuse an existing agent instead of creating one on first session. */
+  agentId?: string;
+  /** Model override for sessions (e.g. "anthropic/claude-sonnet-4"). */
+  model?: string;
+  /** Letta permission mode; tool approvals are forwarded to the ACP client. */
+  permissionMode: PermissionMode;
+}
+
+const PERMISSION_MODES: PermissionMode[] = [
+  "standard",
+  "acceptEdits",
+  "unrestricted",
+];
+
+export function configFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): LettaAcpConfig {
+  const backend = env.LETTA_ACP_BACKEND ?? "local";
+
+  let clientOptions: LettaCodeClientOptions;
+  switch (backend) {
+    case "local":
+      clientOptions = { backend: "local" };
+      break;
+    case "remote":
+      clientOptions = {
+        backend: "remote",
+        url: env.LETTA_APP_SERVER_URL ?? "ws://127.0.0.1:4500",
+        authToken: env.LETTA_APP_SERVER_TOKEN,
+      };
+      break;
+    case "cloud": {
+      const apiKey = env.LETTA_API_KEY;
+      if (!apiKey) {
+        throw new Error("LETTA_ACP_BACKEND=cloud requires LETTA_API_KEY");
+      }
+      clientOptions = { backend: "cloud", apiKey };
+      break;
+    }
+    default:
+      throw new Error(
+        `Unknown LETTA_ACP_BACKEND "${backend}" (expected local | remote | cloud)`,
+      );
+  }
+
+  const permissionMode = env.LETTA_ACP_PERMISSION_MODE ?? "standard";
+  if (!PERMISSION_MODES.includes(permissionMode as PermissionMode)) {
+    throw new Error(
+      `Unknown LETTA_ACP_PERMISSION_MODE "${permissionMode}" (expected ${PERMISSION_MODES.join(" | ")})`,
+    );
+  }
+
+  return {
+    clientOptions,
+    agentId: env.LETTA_AGENT_ID,
+    model: env.LETTA_ACP_MODEL,
+    permissionMode: permissionMode as PermissionMode,
+  };
+}

--- a/acp/src/index.ts
+++ b/acp/src/index.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env bun
+/**
+ * letta-acp — ACP v1 agent adapter for Letta.
+ *
+ * Speaks the Agent Client Protocol over stdio (newline-delimited JSON-RPC),
+ * backed by a Letta agent via @letta-ai/letta-agent-sdk.
+ *
+ * Environment:
+ *   LETTA_ACP_BACKEND          local (default) | remote | cloud
+ *   LETTA_APP_SERVER_URL       remote backend URL (default ws://127.0.0.1:4500)
+ *   LETTA_APP_SERVER_TOKEN     remote backend auth token
+ *   LETTA_API_KEY              cloud backend API key
+ *   LETTA_AGENT_ID             reuse an existing agent (recommended)
+ *   LETTA_ACP_MODEL            model override for sessions
+ *   LETTA_ACP_PERMISSION_MODE  standard (default) | acceptEdits | unrestricted
+ */
+import { Readable, Writable } from "node:stream";
+import * as acp from "@agentclientprotocol/sdk";
+import { LettaAcpAgent } from "./agent.js";
+import { configFromEnv } from "./config.js";
+
+const agent = new LettaAcpAgent(configFromEnv());
+
+const stream = acp.ndJsonStream(
+  Writable.toWeb(process.stdout),
+  Readable.toWeb(process.stdin) as unknown as ReadableStream<Uint8Array>,
+);
+
+const connection = await acp
+  .agent({ name: "letta-acp" })
+  .onRequest(acp.methods.agent.initialize, (ctx) =>
+    agent.initialize(ctx.params),
+  )
+  .onRequest(acp.methods.agent.authenticate, () => ({}))
+  .onRequest(acp.methods.agent.session.new, (ctx) =>
+    agent.newSession(ctx.params),
+  )
+  .onRequest(acp.methods.agent.session.prompt, (ctx) =>
+    agent.prompt(ctx.params, ctx.client),
+  )
+  .onNotification(acp.methods.agent.session.cancel, (ctx) =>
+    agent.cancel(ctx.params),
+  )
+  .connect(stream);
+
+await connection.closed;
+agent.shutdown();
+process.exit(0);

--- a/acp/src/tool-info.ts
+++ b/acp/src/tool-info.ts
@@ -1,0 +1,66 @@
+import type { ToolCallLocation, ToolKind } from "@agentclientprotocol/sdk";
+
+const TOOL_KINDS: Record<string, ToolKind> = {
+  Read: "read",
+  NotebookRead: "read",
+  Edit: "edit",
+  MultiEdit: "edit",
+  Write: "edit",
+  NotebookEdit: "edit",
+  Bash: "execute",
+  BashOutput: "execute",
+  KillShell: "execute",
+  Grep: "search",
+  Glob: "search",
+  WebSearch: "search",
+  WebFetch: "fetch",
+  TodoWrite: "think",
+  Task: "other",
+  Agent: "other",
+};
+
+export function toolKind(toolName: string): ToolKind {
+  return TOOL_KINDS[toolName] ?? "other";
+}
+
+/** Short human-readable title for a tool call, e.g. `Read src/index.ts`. */
+export function toolTitle(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+): string {
+  const detail =
+    firstString(toolInput, [
+      "file_path",
+      "path",
+      "notebook_path",
+      "pattern",
+      "url",
+      "query",
+      "description",
+    ]) ?? firstString(toolInput, ["command"]);
+  if (!detail) return toolName;
+  const trimmed = detail.length > 80 ? `${detail.slice(0, 77)}...` : detail;
+  return `${toolName}: ${trimmed}`;
+}
+
+/** File locations touched by a tool call, for editors that follow along. */
+export function toolLocations(
+  toolInput: Record<string, unknown>,
+): ToolCallLocation[] {
+  const path = firstString(toolInput, ["file_path", "notebook_path", "path"]);
+  if (path?.startsWith("/")) {
+    return [{ path }];
+  }
+  return [];
+}
+
+function firstString(
+  input: Record<string, unknown>,
+  keys: string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}

--- a/acp/test-client.ts
+++ b/acp/test-client.ts
@@ -1,0 +1,129 @@
+#!/usr/bin/env bun
+/**
+ * Minimal ACP client that spawns the letta-acp agent over stdio and runs a
+ * prompt turn against it, printing session updates as they stream.
+ *
+ * Usage:
+ *   bun test-client.ts                      # default smoke prompt
+ *   bun test-client.ts "your prompt here"   # custom prompt
+ *
+ * Env:
+ *   ACP_TEST_REJECT=1          reject permission requests instead of allowing
+ *   ACP_TEST_CANCEL_AFTER=ms   send session/cancel this long after prompting
+ */
+import { spawn } from "node:child_process";
+import { join } from "node:path";
+import { Readable, Writable } from "node:stream";
+import * as acp from "@agentclientprotocol/sdk";
+
+const promptText =
+  process.argv[2] ??
+  "Reply with exactly the text LETTA_ACP_OK and nothing else.";
+
+const agentPath = join(import.meta.dir, "src", "index.ts");
+const child = spawn("bun", [agentPath], {
+  stdio: ["pipe", "pipe", "inherit"],
+  env: process.env,
+});
+
+const stream = acp.ndJsonStream(
+  Writable.toWeb(child.stdin),
+  Readable.toWeb(child.stdout) as unknown as ReadableStream<Uint8Array>,
+);
+
+let sawAgentText = false;
+
+try {
+  await acp
+    .client({ name: "letta-acp-test-client" })
+    .onRequest(acp.methods.client.session.requestPermission, (ctx) => {
+      const optionId = process.env.ACP_TEST_REJECT
+        ? "reject_once"
+        : "allow_once";
+      console.log(`\n[permission] ${ctx.params.toolCall.title} -> ${optionId}`);
+      return {
+        outcome: { outcome: "selected" as const, optionId },
+      };
+    })
+    .onNotification(acp.methods.client.session.update, (ctx) => {
+      const update = ctx.params.update;
+      switch (update.sessionUpdate) {
+        case "agent_message_chunk":
+          if (update.content.type === "text") {
+            sawAgentText = true;
+            process.stdout.write(update.content.text);
+          }
+          break;
+        case "agent_thought_chunk":
+          if (update.content.type === "text") {
+            console.log(`\n[thought] ${update.content.text}`);
+          }
+          break;
+        case "tool_call":
+          console.log(`\n[tool_call] ${update.title} (${update.status})`);
+          break;
+        case "tool_call_update":
+          console.log(
+            `[tool_call_update] ${update.toolCallId}: ${update.status}`,
+          );
+          break;
+        default:
+          console.log(`\n[${update.sessionUpdate}]`);
+          break;
+      }
+    })
+    .connectWith(stream, async (ctx) => {
+      const init = await ctx.request(acp.methods.agent.initialize, {
+        protocolVersion: acp.PROTOCOL_VERSION,
+        clientCapabilities: {
+          fs: { readTextFile: false, writeTextFile: false },
+        },
+      });
+      console.log(
+        `[init] negotiated protocol v${init.protocolVersion}, capabilities: ${JSON.stringify(init.agentCapabilities)}`,
+      );
+
+      const session = await ctx.request(acp.methods.agent.session.new, {
+        cwd: process.cwd(),
+        mcpServers: [],
+      });
+      console.log(`[session] ${session.sessionId}`);
+
+      console.log(`[prompt] ${promptText}\n`);
+      const cancelAfter = Number(process.env.ACP_TEST_CANCEL_AFTER ?? 0);
+      if (cancelAfter > 0) {
+        setTimeout(() => {
+          console.log(
+            `\n[cancel] sending session/cancel after ${cancelAfter}ms`,
+          );
+          void ctx.notify(acp.methods.agent.session.cancel, {
+            sessionId: session.sessionId,
+          });
+        }, cancelAfter);
+      }
+      const result = await ctx.request(acp.methods.agent.session.prompt, {
+        sessionId: session.sessionId,
+        prompt: [{ type: "text", text: promptText }],
+      });
+      console.log(`\n\n[done] stopReason: ${result.stopReason}`);
+
+      if (cancelAfter > 0) {
+        if (result.stopReason !== "cancelled") {
+          throw new Error(
+            `Cancel test failed: expected stopReason=cancelled, got ${result.stopReason}`,
+          );
+        }
+        console.log("[ok] ACP cancel test passed");
+        return;
+      }
+      if (result.stopReason !== "end_turn" || !sawAgentText) {
+        throw new Error(
+          `Smoke test failed: stopReason=${result.stopReason}, sawAgentText=${sawAgentText}`,
+        );
+      }
+      console.log("[ok] ACP smoke test passed");
+    });
+} finally {
+  child.kill();
+}
+process.exit(0);

--- a/acp/tsconfig.json
+++ b/acp/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["bun-types"],
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts", "test-client.ts"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "lint-staged": "16.2.4",
         "madge": "^8.0.0",
         "minimatch": "^10.0.3",
+        "openai": "^6.48.0",
         "picomatch": "^2.3.1",
         "typescript": "^5.0.0",
       },
@@ -779,7 +780,7 @@
 
     "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
-    "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
+    "openai": ["openai@6.48.0", "", { "peerDependencies": { "@aws-sdk/credential-provider-node": ">=3.972.0 <4", "@smithy/hash-node": ">=4.3.0 <5", "@smithy/signature-v4": ">=5.4.0 <6", "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@aws-sdk/credential-provider-node", "@smithy/hash-node", "@smithy/signature-v4", "ws", "zod"] }, "sha512-KhVp+FyV50QrXNextvL9hIU5l6ox5HYuKQjGVk7lIqprgJol90+dQXWONV6S1lRWsKA1bXjrow8RsUT14M1hNA=="],
 
     "ora": ["ora@5.4.1", "", { "dependencies": { "bl": "^4.1.0", "chalk": "^4.1.0", "cli-cursor": "^3.1.0", "cli-spinners": "^2.5.0", "is-interactive": "^1.0.0", "is-unicode-supported": "^0.1.0", "log-symbols": "^4.1.0", "strip-ansi": "^6.0.0", "wcwidth": "^1.0.1" } }, "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ=="],
 
@@ -1074,6 +1075,8 @@
     "@aws-sdk/token-providers/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
     "@aws-sdk/types/@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
+
+    "@earendil-works/pi-ai/openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
 
     "@pierre/diffs/diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
 

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "lint-staged": "16.2.4",
     "madge": "^8.0.0",
     "minimatch": "^10.0.3",
+    "openai": "^6.48.0",
     "picomatch": "^2.3.1",
     "typescript": "^5.0.0"
   },

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -48,5 +48,5 @@
   "src/websocket/listener/file-commands.ts": 1030,
   "src/websocket/listener/lifecycle.ts": 1766,
   "src/websocket/listener/protocol-inbound.ts": 2279,
-  "src/websocket/listener/protocol-outbound.ts": 1282
+  "src/websocket/listener/protocol-outbound.ts": 1278
 }

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -46,7 +46,7 @@
   "src/websocket/listener/commands/channels.ts": 1390,
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1030,
-  "src/websocket/listener/lifecycle.ts": 1766,
+  "src/websocket/listener/lifecycle.ts": 1762,
   "src/websocket/listener/protocol-inbound.ts": 2279,
   "src/websocket/listener/protocol-outbound.ts": 1278
 }

--- a/src/cli/subcommands/app-server.ts
+++ b/src/cli/subcommands/app-server.ts
@@ -10,6 +10,7 @@ Run the local App Server using native v2 WebSocket frames.
 
 Options:
   --listen [url]  WebSocket listen URL. Defaults to an available loopback port
+  --openai-api  Serve OpenAI-compatible /v1/models and /v1/chat/completions routes (each agent is a model)
   --ws-auth <mode>  WebSocket auth mode for non-loopback listeners. Supported: capability-token, signed-bearer-token
   --ws-token-file <path>  Absolute path to the capability-token file
   --ws-token-sha256 <hex>  Hex-encoded SHA-256 digest of the capability token
@@ -23,7 +24,8 @@ Examples:
   letta server --listen
   letta server --listen ws://127.0.0.1:4500
   letta server --listen ws://0.0.0.0:4500 --ws-auth capability-token --ws-token-file /path/to/token
-  letta server --listen ws://0.0.0.0:4500 --ws-auth signed-bearer-token --ws-shared-secret-file /path/to/secret`,
+  letta server --listen ws://0.0.0.0:4500 --ws-auth signed-bearer-token --ws-shared-secret-file /path/to/secret
+  letta server --listen ws://127.0.0.1:4500 --openai-api`,
   );
 }
 
@@ -60,6 +62,7 @@ export async function runAppServerSubcommand(argv: string[]): Promise<number> {
       options: {
         help: { type: "boolean", short: "h" },
         listen: { type: "string" },
+        "openai-api": { type: "boolean" },
         "ws-auth": { type: "string" },
         "ws-token-file": { type: "string" },
         "ws-token-sha256": { type: "string" },
@@ -111,16 +114,23 @@ export async function runAppServerSubcommand(argv: string[]): Promise<number> {
           : undefined,
     });
 
+    const openaiApi = parsed.values["openai-api"] === true;
     const handle = await startAppServer({
       listen:
         typeof parsed.values.listen === "string"
           ? parsed.values.listen
           : undefined,
       websocketAuth,
+      openaiApi,
       onListening: (info) => {
         console.log(`Listening on ${info.url}`);
         console.log(`Control: ${info.controlUrl}`);
         console.log(`Stream:  ${info.streamUrl}`);
+        if (openaiApi) {
+          const openaiBase = new URL(info.url);
+          openaiBase.protocol = "http:";
+          console.log(`OpenAI:  ${openaiBase.origin}/v1`);
+        }
       },
       onLog: (message) => {
         console.error(message);

--- a/src/cli/subcommands/server.ts
+++ b/src/cli/subcommands/server.ts
@@ -20,6 +20,7 @@ Remote environment options:
 
 App Server options:
   --listen [url]  Accept App Server connections. If URL is omitted, binds to an available loopback port
+  --openai-api  Serve OpenAI-compatible /v1/models and /v1/chat/completions routes (each agent is a model)
   --ws-auth <mode>  Authentication for non-loopback listeners: capability-token or signed-bearer-token
   --ws-token-file <path>  Absolute path to the capability-token file
   --ws-token-sha256 <hex>  Hex-encoded SHA-256 digest of the capability token

--- a/src/websocket/app-server-openai-sdk.test.ts
+++ b/src/websocket/app-server-openai-sdk.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
+import OpenAI from "openai";
+import type { Backend } from "@/backend";
+import { __testSetBackend } from "@/backend";
+import { type AppServerHandle, startAppServer } from "@/websocket/app-server";
+import { parseAppServerWebsocketAuthSettings } from "@/websocket/app-server-auth";
+import { __testSetSendMessageStreamImpl } from "@/websocket/app-server-openai";
+
+// Conformance tests: drive the /v1 routes through the real OpenAI SDK
+// instead of raw fetch, proving an unmodified OpenAI client round-trips
+// against the App Server. Wire-format assertions live in
+// app-server-openai.test.ts; these assert client-level compatibility.
+
+const TEST_AGENTS = [
+  { id: "agent-local-111", name: "memo" },
+  { id: "agent-local-222", name: "patch" },
+];
+
+function fakeBackend(): Backend {
+  return {
+    listAgents: async () => TEST_AGENTS,
+  } as unknown as Backend;
+}
+
+function stubTurnStream(): void {
+  const chunks = [
+    { message_type: "assistant_message", content: "Hello " },
+    { message_type: "assistant_message", content: "world" },
+    {
+      message_type: "usage_statistics",
+      prompt_tokens: 11,
+      completion_tokens: 7,
+      total_tokens: 18,
+    },
+    { message_type: "stop_reason", stop_reason: "end_turn" },
+  ] as unknown as LettaStreamingResponse[];
+  __testSetSendMessageStreamImpl(async () => {
+    return (async function* () {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    })();
+  });
+}
+
+function sdkClient(handle: AppServerHandle, apiKey = "unused"): OpenAI {
+  const url = new URL(handle.url);
+  url.protocol = "http:";
+  return new OpenAI({ baseURL: `${url.origin}/v1`, apiKey });
+}
+
+describe("app-server OpenAI SDK conformance", () => {
+  let handle: AppServerHandle | null = null;
+
+  afterEach(async () => {
+    __testSetSendMessageStreamImpl(null);
+    __testSetBackend(null);
+    if (handle) {
+      await handle.close();
+      handle = null;
+    }
+  });
+
+  test("models.list returns agents", async () => {
+    __testSetBackend(fakeBackend());
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const models = await sdkClient(handle).models.list();
+    const ids = models.data.map((model) => model.id);
+    expect(ids).toEqual(["memo", "patch"]);
+  });
+
+  test("chat.completions.create round-trips (non-streaming)", async () => {
+    __testSetBackend(fakeBackend());
+    stubTurnStream();
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const completion = await sdkClient(handle).chat.completions.create({
+      model: "memo",
+      messages: [{ role: "user", content: "say hello" }],
+    });
+    expect(completion.choices[0]?.message.content).toBe("Hello world");
+    expect(completion.choices[0]?.finish_reason).toBe("stop");
+    expect(completion.usage?.total_tokens).toBe(18);
+  });
+
+  test("chat.completions.create streams via the SDK", async () => {
+    __testSetBackend(fakeBackend());
+    stubTurnStream();
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const stream = await sdkClient(handle).chat.completions.create({
+      model: "patch",
+      messages: [{ role: "user", content: "say hello" }],
+      stream: true,
+    });
+    let text = "";
+    let finishReason: string | null = null;
+    for await (const chunk of stream) {
+      text += chunk.choices[0]?.delta.content ?? "";
+      finishReason = chunk.choices[0]?.finish_reason ?? finishReason;
+    }
+    expect(text).toBe("Hello world");
+    expect(finishReason).toBe("stop");
+  });
+
+  test("SDK receives 401 as APIError with bad token", async () => {
+    __testSetBackend(fakeBackend());
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+      websocketAuth: parseAppServerWebsocketAuthSettings({
+        wsAuth: "capability-token",
+        wsTokenSha256:
+          "a7f6237e747a7a7d8ba94e0b8e64ba1c369b071b6f13905c0d55221b0a8b6a1c",
+      }),
+    });
+
+    // Explicit try/catch rather than expect(...).rejects: the SDK's lazy
+    // PagePromise thenable defers the request in a way bun's rejects
+    // matcher does not observe.
+    const client = sdkClient(handle, "wrong-token");
+    let status: number | null = null;
+    try {
+      await client.models.list();
+    } catch (error) {
+      status = (error as { status?: number }).status ?? null;
+    }
+    expect(status).toBe(401);
+  });
+});

--- a/src/websocket/app-server-openai-sdk.test.ts
+++ b/src/websocket/app-server-openai-sdk.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import OpenAI from "openai";
 import type { Backend } from "@/backend";
 import { __testSetBackend } from "@/backend";
@@ -7,7 +6,7 @@ import { type AppServerHandle, startAppServer } from "@/websocket/app-server";
 import { parseAppServerWebsocketAuthSettings } from "@/websocket/app-server-auth";
 import {
   __testResetConversationMap,
-  __testSetSendMessageStreamImpl,
+  __testSetRunTurnImpl,
 } from "@/websocket/app-server-openai";
 
 // Conformance tests: drive the /v1 routes through the real OpenAI SDK
@@ -33,23 +32,14 @@ function fakeBackend(): Backend {
 }
 
 function stubTurnStream(): void {
-  const chunks = [
-    { message_type: "assistant_message", content: "Hello " },
-    { message_type: "assistant_message", content: "world" },
-    {
-      message_type: "usage_statistics",
-      prompt_tokens: 11,
-      completion_tokens: 7,
-      total_tokens: 18,
-    },
-    { message_type: "stop_reason", stop_reason: "end_turn" },
-  ] as unknown as LettaStreamingResponse[];
-  __testSetSendMessageStreamImpl(async () => {
-    return (async function* () {
-      for (const chunk of chunks) {
-        yield chunk;
-      }
-    })();
+  __testSetRunTurnImpl(async ({ onAssistantText }) => {
+    onAssistantText?.("Hello ");
+    onAssistantText?.("world");
+    return {
+      text: "Hello world",
+      usage: { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 },
+      error: null,
+    };
   });
 }
 
@@ -63,7 +53,7 @@ describe("app-server OpenAI SDK conformance", () => {
   let handle: AppServerHandle | null = null;
 
   afterEach(async () => {
-    __testSetSendMessageStreamImpl(null);
+    __testSetRunTurnImpl(null);
     __testResetConversationMap();
     __testSetBackend(null);
     if (handle) {

--- a/src/websocket/app-server-openai-sdk.test.ts
+++ b/src/websocket/app-server-openai-sdk.test.ts
@@ -5,7 +5,10 @@ import type { Backend } from "@/backend";
 import { __testSetBackend } from "@/backend";
 import { type AppServerHandle, startAppServer } from "@/websocket/app-server";
 import { parseAppServerWebsocketAuthSettings } from "@/websocket/app-server-auth";
-import { __testSetSendMessageStreamImpl } from "@/websocket/app-server-openai";
+import {
+  __testResetConversationMap,
+  __testSetSendMessageStreamImpl,
+} from "@/websocket/app-server-openai";
 
 // Conformance tests: drive the /v1 routes through the real OpenAI SDK
 // instead of raw fetch, proving an unmodified OpenAI client round-trips
@@ -17,9 +20,15 @@ const TEST_AGENTS = [
   { id: "agent-local-222", name: "patch" },
 ];
 
+let conversationCounter = 0;
+
 function fakeBackend(): Backend {
   return {
     listAgents: async () => TEST_AGENTS,
+    createConversation: async (body: { agent_id: string }) => {
+      conversationCounter += 1;
+      return { id: `conv-sdk-${conversationCounter}`, agent_id: body.agent_id };
+    },
   } as unknown as Backend;
 }
 
@@ -55,6 +64,7 @@ describe("app-server OpenAI SDK conformance", () => {
 
   afterEach(async () => {
     __testSetSendMessageStreamImpl(null);
+    __testResetConversationMap();
     __testSetBackend(null);
     if (handle) {
       await handle.close();

--- a/src/websocket/app-server-openai-turn.ts
+++ b/src/websocket/app-server-openai-turn.ts
@@ -1,0 +1,340 @@
+import { randomUUID } from "node:crypto";
+import { settingsManager } from "@/settings-manager";
+import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
+import { dispatchInboundMessageWhenReady } from "@/websocket/listener/inbound-dispatch";
+import { startLocalChannelListener } from "@/websocket/listener/lifecycle";
+import { getOrCreateConversationPermissionModeStateRef } from "@/websocket/listener/permission-mode";
+import { getActiveRuntime } from "@/websocket/listener/runtime";
+import {
+  type ListenerTransport,
+  LocalListenerTransport,
+} from "@/websocket/listener/transport";
+import { handleIncomingMessage } from "@/websocket/listener/turn";
+import { registerTurnObserver } from "@/websocket/listener/turn-observers";
+import type {
+  IncomingMessage as ListenerIncomingMessage,
+  ListenerRuntime,
+  ListenerStreamObserver,
+  ProcessQueuedTurn,
+  StartListenerOptions,
+} from "@/websocket/listener/types";
+
+export interface OpenAiUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+}
+
+export type UserContentPart =
+  | { type: "text"; text: string }
+  | {
+      type: "image";
+      source:
+        | { type: "base64"; media_type: string; data: string }
+        | { type: "url"; url: string };
+    };
+
+export interface TurnOutcome {
+  text: string;
+  usage: OpenAiUsage;
+  error: string | null;
+}
+
+export interface BridgeTurnMessage {
+  role: "user" | "assistant";
+  content: UserContentPart[];
+  otid: string;
+}
+
+interface RunTurnParams {
+  agentId: string;
+  conversationId: string;
+  /** Full input for the turn: the newest message in stateful mode, or the
+   * replayed client transcript in stateless mode. */
+  messages: BridgeTurnMessage[];
+  /** OTID of a message in this turn, used to correlate the listener turn
+   * lifecycle with this request. */
+  correlationOtid: string;
+  onAssistantText?: (text: string) => void;
+  onLog?: (message: string) => void;
+}
+
+type RunTurnImpl = (params: RunTurnParams) => Promise<TurnOutcome>;
+
+let runTurnImpl: RunTurnImpl = runTurnViaListenerRuntime;
+
+/** @internal Test seam mirroring __testSetBackend. */
+export function __testSetRunTurnImpl(impl: RunTurnImpl | null): void {
+  runTurnImpl = impl ?? runTurnViaListenerRuntime;
+}
+
+/** Stable entry point used by the HTTP handler; tests swap the impl. */
+export function runBridgeTurn(params: RunTurnParams): Promise<TurnOutcome> {
+  return runTurnImpl(params);
+}
+
+// ---------------------------------------------------------------------------
+// Turn execution over the listener v2 runtime.
+//
+// The bridge runs turns through the same dispatch path as WebSocket clients
+// (queueing → turn processor → tools/mods/permissions) and observes the
+// resulting v2 protocol stream via the runtime's in-process stream
+// observers, converting chat-completions requests into protocol inputs and
+// protocol events back into chat-completions outputs — the HTTP analogue of
+// a messaging channel.
+// ---------------------------------------------------------------------------
+
+const OPENAI_TURN_TIMEOUT_MS = 15 * 60 * 1000;
+
+const bridgeTransport = new LocalListenerTransport();
+let bridgeRuntimeStart: Promise<void> | null = null;
+
+/**
+ * Reuse the active listener runtime when one exists (a connected WS control
+ * session or channels runtime); otherwise start a socket-free local runtime,
+ * exactly like `letta server --channels` does. If a WS control client
+ * connects later it replaces the bridge-owned runtime, and subsequent
+ * requests transparently use the new active runtime.
+ */
+async function ensureListenerRuntime(
+  onLog?: (message: string) => void,
+): Promise<ListenerRuntime> {
+  const active = getActiveRuntime();
+  if (active && !active.intentionallyClosed) return active;
+
+  bridgeRuntimeStart ??= startLocalChannelListener({
+    connectionId: `openai-api-${randomUUID()}`,
+    deviceId: settingsManager.getOrCreateDeviceId(),
+    connectionName: "openai-api",
+    onConnected: () => {},
+    onError: (error) => {
+      onLog?.(`OpenAI-compat runtime error: ${error.message}`);
+    },
+  }).finally(() => {
+    bridgeRuntimeStart = null;
+  });
+  await bridgeRuntimeStart;
+
+  const runtime = getActiveRuntime();
+  if (!runtime || runtime.intentionallyClosed) {
+    throw new Error("failed to start listener runtime for OpenAI-compat API");
+  }
+  return runtime;
+}
+
+function extractDeltaText(delta: unknown): string {
+  const content = (
+    delta as { content?: string | Array<{ text?: string }> | null }
+  ).content;
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) =>
+      part && typeof part === "object" && typeof part.text === "string"
+        ? part.text
+        : "",
+    )
+    .join("");
+}
+
+async function runTurnViaListenerRuntime(
+  params: RunTurnParams,
+): Promise<TurnOutcome> {
+  const listener = await ensureListenerRuntime(params.onLog);
+  const scopedRuntime = getOrCreateScopedRuntime(
+    listener,
+    params.agentId,
+    params.conversationId,
+  );
+  // No interactive approver exists on this surface, so bridge conversations
+  // run unrestricted (Hermes-style: the API is opt-in and bearer-gated and
+  // exposes the agent's full toolset). Approvals that still arise finish the
+  // turn with an explanatory reply instead of hanging.
+  getOrCreateConversationPermissionModeStateRef(
+    listener,
+    params.agentId,
+    params.conversationId,
+  ).mode = "unrestricted";
+  // Frames emitted for this turn also flow to any attached WS client; the
+  // transport here is only the fallback destination when none is attached.
+  const socket: ListenerTransport =
+    listener.socket ?? listener.transport ?? bridgeTransport;
+
+  const dispatchOptions: StartListenerOptions = {
+    connectionId: listener.connectionId ?? "openai-api",
+    wsUrl: "",
+    deviceId: settingsManager.getOrCreateDeviceId(),
+    connectionName: listener.connectionName ?? "openai-api",
+    onConnected: () => {},
+    onDisconnected: () => {},
+    onError: (error) => {
+      params.onLog?.(`OpenAI-compat turn error: ${error.message}`);
+    },
+  };
+
+  const processQueuedTurn: ProcessQueuedTurn = async (
+    queuedTurn,
+    dequeuedBatch,
+  ) => {
+    const queuedScope = getOrCreateScopedRuntime(
+      listener,
+      queuedTurn.agentId,
+      queuedTurn.conversationId,
+    );
+    await handleIncomingMessage(
+      queuedTurn,
+      socket,
+      queuedScope,
+      undefined,
+      dispatchOptions.connectionId,
+      dequeuedBatch.batchId,
+    );
+  };
+
+  return await new Promise<TurnOutcome>((resolve) => {
+    let text = "";
+    let usage: OpenAiUsage = {
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+    };
+    // The request settles from ITS OWN turn's lifecycle (turn-observers,
+    // keyed by OTID), never from raw stream events: stop_reason ends a
+    // stream segment before the listener decides on retries/approvals, and
+    // usage can arrive after it. Stream deltas are accumulated only while
+    // this request's turn is active, so queued requests and WS-initiated
+    // turns in the same conversation never bleed into this response.
+    let turnActive = false;
+    let recordedError: string | null = null;
+    let settled = false;
+    let unregisterTurnObserver: () => void = () => {};
+    if (!listener.streamObservers) {
+      listener.streamObservers = new Set();
+    }
+    const observers = listener.streamObservers;
+
+    const finish = (error: string | null): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      observers.delete(observer);
+      unregisterTurnObserver();
+      resolve({ text, usage, error });
+    };
+
+    const observer: ListenerStreamObserver = (message) => {
+      if (message.type === "runtime_stopped") {
+        finish(
+          recordedError ??
+            "server runtime was replaced while the request was in flight",
+        );
+        return;
+      }
+      if (message.runtime.agent_id !== params.agentId) return;
+      if (message.runtime.conversation_id !== params.conversationId) return;
+      if (!turnActive) return;
+      if (message.type === "update_loop_status") {
+        // The turn paused for interactive input this surface cannot provide.
+        const status = (message as { loop_status?: { status?: string } })
+          .loop_status?.status;
+        if (status === "WAITING_ON_APPROVAL") {
+          if (!text) {
+            const note =
+              "The agent attempted a tool call that requires interactive approval, which this API does not support.";
+            text = note;
+            params.onAssistantText?.(note);
+          }
+          finish(null);
+        }
+        return;
+      }
+      if (message.type !== "stream_delta" || message.subagent_id) return;
+      const delta = (message as { delta?: { message_type?: string } }).delta;
+      if (!delta) return;
+      switch (delta.message_type) {
+        case "assistant_message": {
+          const piece = extractDeltaText(delta);
+          if (piece) {
+            text += piece;
+            // New assistant output after a recorded error means the
+            // listener retried successfully; the error is stale.
+            recordedError = null;
+            params.onAssistantText?.(piece);
+          }
+          return;
+        }
+        case "usage_statistics": {
+          const stats = delta as {
+            prompt_tokens?: number;
+            completion_tokens?: number;
+            total_tokens?: number;
+          };
+          usage = {
+            prompt_tokens: stats.prompt_tokens ?? 0,
+            completion_tokens: stats.completion_tokens ?? 0,
+            total_tokens: stats.total_tokens ?? 0,
+          };
+          return;
+        }
+        case "loop_error": {
+          // Recorded, not settled: the listener may still retry. The turn
+          // lifecycle end decides the final outcome.
+          const loopError = delta as {
+            is_terminal?: boolean;
+            message?: string;
+          };
+          if (loopError.is_terminal !== false) {
+            recordedError = loopError.message ?? "agent turn failed";
+          }
+          return;
+        }
+        case "error_message":
+          recordedError =
+            (delta as { message?: string }).message ?? "agent turn failed";
+          return;
+        default:
+          return;
+      }
+    };
+    observers.add(observer);
+    unregisterTurnObserver = registerTurnObserver(params.correlationOtid, {
+      onStarted: () => {
+        turnActive = true;
+      },
+      onFinished: () => {
+        finish(recordedError);
+      },
+    });
+    const timer = setTimeout(
+      () => finish(recordedError ?? "agent turn timed out"),
+      OPENAI_TURN_TIMEOUT_MS,
+    );
+
+    const incoming: ListenerIncomingMessage = {
+      type: "message",
+      agentId: params.agentId,
+      conversationId: params.conversationId,
+      messages: params.messages,
+    };
+    try {
+      dispatchInboundMessageWhenReady({
+        listener,
+        runtime: scopedRuntime,
+        incoming,
+        socket,
+        options: dispatchOptions,
+        processQueuedTurn,
+        processIncomingMessage: handleIncomingMessage,
+        trackListenerError: (errorType, error) => {
+          params.onLog?.(
+            `OpenAI-compat listener error (${errorType}): ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        },
+      });
+    } catch (error) {
+      finish(error instanceof Error ? error.message : String(error));
+    }
+  });
+}

--- a/src/websocket/app-server-openai.test.ts
+++ b/src/websocket/app-server-openai.test.ts
@@ -384,7 +384,7 @@ describe("app-server OpenAI-compatible API", () => {
         method: "POST",
         headers: {
           "content-type": "application/json",
-          "x-openwebui-chat-id": chatKey,
+          "x-letta-chat-key": chatKey,
         },
         body: JSON.stringify({ model: "memo", messages }),
       });
@@ -406,6 +406,45 @@ describe("app-server OpenAI-compatible API", () => {
       "conv-test-1",
     ]);
     expect(created.length).toBe(2);
+  });
+
+  test("openwebui chat id is honored only for streaming requests", async () => {
+    const created: string[] = [];
+    __testSetBackend(fakeBackend(created));
+    const conversationsUsed: string[] = [];
+    stubTurn((conversationId) => {
+      conversationsUsed.push(conversationId);
+    });
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const send = (stream: boolean) =>
+      fetch(httpUrl(handle as AppServerHandle, "/v1/chat/completions"), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-openwebui-chat-id": "webui-chat",
+        },
+        body: JSON.stringify({
+          model: "memo",
+          messages: [{ role: "user", content: "hi" }],
+          stream,
+        }),
+      });
+
+    // Streaming chat messages pin the conversation; non-streaming task
+    // requests (title/tags generation) run statelessly despite the header.
+    await send(true);
+    await send(true);
+    await send(false);
+
+    expect(conversationsUsed).toEqual([
+      "conv-test-1",
+      "conv-test-1",
+      "conv-test-2",
+    ]);
   });
 
   test("stateful header mode sends only the newest message", async () => {

--- a/src/websocket/app-server-openai.test.ts
+++ b/src/websocket/app-server-openai.test.ts
@@ -38,18 +38,24 @@ function sha256Hex(value: string): string {
 }
 
 function stubTurn(
-  onCall?: (conversationId: string, agentId: string) => void,
+  onCall?: (
+    conversationId: string,
+    agentId: string,
+    messages: unknown[],
+  ) => void,
 ): void {
-  __testSetRunTurnImpl(async ({ agentId, conversationId, onAssistantText }) => {
-    onCall?.(conversationId, agentId);
-    onAssistantText?.("Hello ");
-    onAssistantText?.("world");
-    return {
-      text: "Hello world",
-      usage: { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 },
-      error: null,
-    };
-  });
+  __testSetRunTurnImpl(
+    async ({ agentId, conversationId, messages, onAssistantText }) => {
+      onCall?.(conversationId, agentId, messages);
+      onAssistantText?.("Hello ");
+      onAssistantText?.("world");
+      return {
+        text: "Hello world",
+        usage: { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 },
+        error: null,
+      };
+    },
+  );
 }
 
 function httpUrl(handle: AppServerHandle, path: string): string {
@@ -164,12 +170,14 @@ describe("app-server OpenAI-compatible API", () => {
     expect(captured.agent).toBe("agent-local-111");
   });
 
-  test("client chats map to distinct, sticky Letta conversations", async () => {
+  test("header-less requests run statelessly with transcript replay", async () => {
     const created: string[] = [];
     __testSetBackend(fakeBackend(created));
     const conversationsUsed: string[] = [];
-    stubTurn((conversationId) => {
+    const messageCounts: number[] = [];
+    stubTurn((conversationId, _agentId, messages) => {
       conversationsUsed.push(conversationId);
+      messageCounts.push(messages.length);
     });
     handle = await startAppServer({
       listen: "ws://127.0.0.1:0",
@@ -183,25 +191,18 @@ describe("app-server OpenAI-compatible API", () => {
         body: JSON.stringify({ model: "memo", messages }),
       });
 
-    // Chat A, first message: creates a fresh conversation.
+    // Without a stable chat identity there is no server-side reuse: every
+    // request gets a fresh conversation and the transcript is replayed.
     await send([{ role: "user", content: "first chat" }]);
-    // Chat A, second message: client resends the transcript, which now
-    // includes the reply ("Hello world") — must map back to the same
-    // conversation without creating a new one.
     await send([
       { role: "user", content: "first chat" },
       { role: "assistant", content: "Hello world" },
       { role: "user", content: "follow-up" },
     ]);
-    // Chat B, first message: a different thread gets its own conversation.
-    await send([{ role: "user", content: "second chat" }]);
 
-    expect(conversationsUsed).toEqual([
-      "conv-test-1",
-      "conv-test-1",
-      "conv-test-2",
-    ]);
+    expect(conversationsUsed).toEqual(["conv-test-1", "conv-test-2"]);
     expect(created).toEqual(["conv-test-1", "conv-test-2"]);
+    expect(messageCounts).toEqual([1, 3]);
   });
 
   test("POST /v1/chat/completions streams SSE chunks", async () => {
@@ -407,11 +408,40 @@ describe("app-server OpenAI-compatible API", () => {
     expect(created.length).toBe(2);
   });
 
+  test("stateful header mode sends only the newest message", async () => {
+    __testSetBackend(fakeBackend());
+    const messageCounts: number[] = [];
+    stubTurn((_conversationId, _agentId, messages) => {
+      messageCounts.push(messages.length);
+    });
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    await fetch(httpUrl(handle, "/v1/chat/completions"), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-letta-chat-key": "pinned-chat",
+      },
+      body: JSON.stringify({
+        model: "memo",
+        messages: [
+          { role: "user", content: "Hello" },
+          { role: "assistant", content: "Hello world" },
+          { role: "user", content: "follow-up" },
+        ],
+      }),
+    });
+    expect(messageCounts).toEqual([1]);
+  });
+
   test("image_url parts pass through as Letta image content", async () => {
     __testSetBackend(fakeBackend());
     let capturedContent: unknown = null;
-    __testSetRunTurnImpl(async ({ userContent, onAssistantText }) => {
-      capturedContent = userContent;
+    __testSetRunTurnImpl(async ({ messages, onAssistantText }) => {
+      capturedContent = (messages[0] as { content: unknown }).content;
       onAssistantText?.("I see it");
       return {
         text: "I see it",

--- a/src/websocket/app-server-openai.test.ts
+++ b/src/websocket/app-server-openai.test.ts
@@ -272,6 +272,74 @@ describe("app-server OpenAI-compatible API", () => {
     expect(body.error.code).toBe("model_not_found");
   });
 
+  test("concurrent new chats serialize conversation creation per agent", async () => {
+    const created: string[] = [];
+    let inFlight = 0;
+    __testSetBackend({
+      listAgents: async () => TEST_AGENTS,
+      createConversation: async (body: { agent_id: string }) => {
+        inFlight += 1;
+        if (inFlight > 1) {
+          inFlight -= 1;
+          throw new Error("concurrent createConversation detected");
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        inFlight -= 1;
+        const id = `conv-test-${created.length + 1}`;
+        created.push(id);
+        return { id, agent_id: body.agent_id };
+      },
+    } as unknown as Backend);
+    stubTurn();
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const send = (text: string) =>
+      fetch(httpUrl(handle as AppServerHandle, "/v1/chat/completions"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "memo",
+          messages: [{ role: "user", content: text }],
+        }),
+      });
+    const responses = await Promise.all([
+      send("chat one"),
+      send("chat two"),
+      send("chat three"),
+    ]);
+    expect(responses.map((r) => r.status)).toEqual([200, 200, 200]);
+    expect(created.length).toBe(3);
+  });
+
+  test("conversation creation failure returns 500, not default fallback", async () => {
+    __testSetBackend({
+      listAgents: async () => TEST_AGENTS,
+      createConversation: async () => {
+        throw new Error("could not lock config file .git/config");
+      },
+    } as unknown as Backend);
+    stubTurn();
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const response = await fetch(httpUrl(handle, "/v1/chat/completions"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "memo",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as { error: { type: string } };
+    expect(body.error.type).toBe("server_error");
+  });
+
   test("image_url parts pass through as Letta image content", async () => {
     __testSetBackend(fakeBackend());
     let capturedContent: unknown = null;

--- a/src/websocket/app-server-openai.test.ts
+++ b/src/websocket/app-server-openai.test.ts
@@ -340,6 +340,73 @@ describe("app-server OpenAI-compatible API", () => {
     expect(body.error.type).toBe("server_error");
   });
 
+  test("two chats starting with identical messages get distinct conversations", async () => {
+    const created: string[] = [];
+    __testSetBackend(fakeBackend(created));
+    const conversationsUsed: string[] = [];
+    stubTurn((conversationId) => {
+      conversationsUsed.push(conversationId);
+    });
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const send = () =>
+      fetch(httpUrl(handle as AppServerHandle, "/v1/chat/completions"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "memo",
+          messages: [{ role: "user", content: "Hello" }],
+        }),
+      });
+    await send();
+    await send();
+    expect(conversationsUsed).toEqual(["conv-test-1", "conv-test-2"]);
+  });
+
+  test("chat-key header pins chat identity across identical transcripts", async () => {
+    const created: string[] = [];
+    __testSetBackend(fakeBackend(created));
+    const conversationsUsed: string[] = [];
+    stubTurn((conversationId) => {
+      conversationsUsed.push(conversationId);
+    });
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const send = (chatKey: string, messages: unknown[]) =>
+      fetch(httpUrl(handle as AppServerHandle, "/v1/chat/completions"), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-openwebui-chat-id": chatKey,
+        },
+        body: JSON.stringify({ model: "memo", messages }),
+      });
+
+    // Two chats with byte-identical transcripts but different chat ids.
+    await send("chat-a", [{ role: "user", content: "Hello" }]);
+    await send("chat-b", [{ role: "user", content: "Hello" }]);
+    // Follow-up in chat-a with an identical transcript to what chat-b
+    // would resend — the header, not the transcript, decides.
+    await send("chat-a", [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hello world" },
+      { role: "user", content: "follow-up" },
+    ]);
+
+    expect(conversationsUsed).toEqual([
+      "conv-test-1",
+      "conv-test-2",
+      "conv-test-1",
+    ]);
+    expect(created.length).toBe(2);
+  });
+
   test("image_url parts pass through as Letta image content", async () => {
     __testSetBackend(fakeBackend());
     let capturedContent: unknown = null;

--- a/src/websocket/app-server-openai.test.ts
+++ b/src/websocket/app-server-openai.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
+import type { Backend } from "@/backend";
+import { __testSetBackend } from "@/backend";
+import { type AppServerHandle, startAppServer } from "@/websocket/app-server";
+import { parseAppServerWebsocketAuthSettings } from "@/websocket/app-server-auth";
+import { __testSetSendMessageStreamImpl } from "@/websocket/app-server-openai";
+
+const TEST_AGENTS = [
+  {
+    id: "agent-local-111",
+    name: "memo",
+    created_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "agent-local-222",
+    name: "patch",
+    created_at: "2026-01-02T00:00:00Z",
+  },
+];
+
+function fakeBackend(): Backend {
+  return {
+    listAgents: async () => TEST_AGENTS,
+  } as unknown as Backend;
+}
+
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function fakeTurnChunks(): LettaStreamingResponse[] {
+  return [
+    {
+      message_type: "reasoning_message",
+      reasoning: "thinking...",
+    },
+    {
+      message_type: "assistant_message",
+      content: "Hello ",
+    },
+    {
+      message_type: "assistant_message",
+      content: [{ type: "text", text: "world" }],
+    },
+    {
+      message_type: "usage_statistics",
+      prompt_tokens: 11,
+      completion_tokens: 7,
+      total_tokens: 18,
+    },
+    {
+      message_type: "stop_reason",
+      stop_reason: "end_turn",
+    },
+  ] as unknown as LettaStreamingResponse[];
+}
+
+function stubTurnStream(
+  chunks: LettaStreamingResponse[],
+  onCall?: (conversationId: string, agentId: string | undefined) => void,
+): void {
+  __testSetSendMessageStreamImpl(async (conversationId, _messages, opts) => {
+    onCall?.(conversationId, opts?.agentId);
+    return (async function* () {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    })();
+  });
+}
+
+function httpUrl(handle: AppServerHandle, path: string): string {
+  const url = new URL(handle.url);
+  url.protocol = "http:";
+  return `${url.origin}${path}`;
+}
+
+describe("app-server OpenAI-compatible API", () => {
+  let handle: AppServerHandle | null = null;
+
+  afterEach(async () => {
+    __testSetSendMessageStreamImpl(null);
+    __testSetBackend(null);
+    if (handle) {
+      await handle.close();
+      handle = null;
+    }
+  });
+
+  test("routes are 404 when --openai-api is not set", async () => {
+    __testSetBackend(fakeBackend());
+    handle = await startAppServer({ listen: "ws://127.0.0.1:0" });
+    const response = await fetch(httpUrl(handle, "/v1/models"));
+    expect(response.status).toBe(404);
+  });
+
+  test("GET /v1/models lists agents as models", async () => {
+    __testSetBackend(fakeBackend());
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+    const response = await fetch(httpUrl(handle, "/v1/models"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      object: string;
+      data: Array<{ id: string; object: string; owned_by: string }>;
+    };
+    expect(body.object).toBe("list");
+    expect(body.data.map((model) => model.id)).toEqual(["memo", "patch"]);
+    expect(body.data[0]?.object).toBe("model");
+    expect(body.data[0]?.owned_by).toBe("letta");
+  });
+
+  test("honors capability-token auth on /v1 routes", async () => {
+    __testSetBackend(fakeBackend());
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+      websocketAuth: parseAppServerWebsocketAuthSettings({
+        wsAuth: "capability-token",
+        wsTokenSha256: sha256Hex("super-secret-token"),
+      }),
+    });
+
+    const unauthorized = await fetch(httpUrl(handle, "/v1/models"));
+    expect(unauthorized.status).toBe(401);
+
+    const wrongToken = await fetch(httpUrl(handle, "/v1/models"), {
+      headers: { authorization: "Bearer wrong-token" },
+    });
+    expect(wrongToken.status).toBe(401);
+
+    const authorized = await fetch(httpUrl(handle, "/v1/models"), {
+      headers: { authorization: "Bearer super-secret-token" },
+    });
+    expect(authorized.status).toBe(200);
+  });
+
+  test("POST /v1/chat/completions aggregates a turn (non-streaming)", async () => {
+    __testSetBackend(fakeBackend());
+    const captured = { conversation: "", agent: "" };
+    stubTurnStream(fakeTurnChunks(), (conversationId, agentId) => {
+      captured.conversation = conversationId;
+      captured.agent = agentId ?? "";
+    });
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const response = await fetch(httpUrl(handle, "/v1/chat/completions"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "memo",
+        messages: [
+          { role: "system", content: "be helpful" },
+          { role: "user", content: "say hello" },
+        ],
+      }),
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      object: string;
+      model: string;
+      choices: Array<{
+        message: { role: string; content: string };
+        finish_reason: string;
+      }>;
+      usage: { prompt_tokens: number; total_tokens: number };
+    };
+    expect(body.object).toBe("chat.completion");
+    expect(body.model).toBe("memo");
+    expect(body.choices[0]?.message.content).toBe("Hello world");
+    expect(body.choices[0]?.finish_reason).toBe("stop");
+    expect(body.usage.prompt_tokens).toBe(11);
+    expect(body.usage.total_tokens).toBe(18);
+    expect(captured.conversation).toBe("default");
+    expect(captured.agent).toBe("agent-local-111");
+  });
+
+  test("POST /v1/chat/completions streams SSE chunks", async () => {
+    __testSetBackend(fakeBackend());
+    stubTurnStream(fakeTurnChunks());
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const response = await fetch(httpUrl(handle, "/v1/chat/completions"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        // Resolving by agent id (rather than name) must also work.
+        model: "agent-local-222",
+        messages: [{ role: "user", content: "say hello" }],
+        stream: true,
+      }),
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+
+    const raw = await response.text();
+    const events = raw
+      .split("\n\n")
+      .filter(Boolean)
+      .map((line) => line.replace(/^data: /, ""));
+    expect(events.at(-1)).toBe("[DONE]");
+
+    const parsed = events.slice(0, -1).map(
+      (event) =>
+        JSON.parse(event) as {
+          object: string;
+          choices: Array<{
+            delta: { role?: string; content?: string };
+            finish_reason: string | null;
+          }>;
+        },
+    );
+    expect(parsed[0]?.choices[0]?.delta.role).toBe("assistant");
+    const text = parsed
+      .map((chunk) => chunk.choices[0]?.delta.content ?? "")
+      .join("");
+    expect(text).toBe("Hello world");
+    expect(parsed.at(-1)?.choices[0]?.finish_reason).toBe("stop");
+  });
+
+  test("unknown model returns 404 model_not_found", async () => {
+    __testSetBackend(fakeBackend());
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const response = await fetch(httpUrl(handle, "/v1/chat/completions"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "does-not-exist",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(response.status).toBe(404);
+    const body = (await response.json()) as {
+      error: { code: string | null };
+    };
+    expect(body.error.code).toBe("model_not_found");
+  });
+
+  test("missing user text returns 400", async () => {
+    __testSetBackend(fakeBackend());
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const response = await fetch(httpUrl(handle, "/v1/chat/completions"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "memo",
+        messages: [{ role: "system", content: "no user message" }],
+      }),
+    });
+    expect(response.status).toBe(400);
+  });
+});

--- a/src/websocket/app-server-openai.test.ts
+++ b/src/websocket/app-server-openai.test.ts
@@ -1,13 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import type { Backend } from "@/backend";
 import { __testSetBackend } from "@/backend";
 import { type AppServerHandle, startAppServer } from "@/websocket/app-server";
 import { parseAppServerWebsocketAuthSettings } from "@/websocket/app-server-auth";
 import {
   __testResetConversationMap,
-  __testSetSendMessageStreamImpl,
+  __testSetRunTurnImpl,
 } from "@/websocket/app-server-openai";
 
 const TEST_AGENTS = [
@@ -38,44 +37,18 @@ function sha256Hex(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
-function fakeTurnChunks(): LettaStreamingResponse[] {
-  return [
-    {
-      message_type: "reasoning_message",
-      reasoning: "thinking...",
-    },
-    {
-      message_type: "assistant_message",
-      content: "Hello ",
-    },
-    {
-      message_type: "assistant_message",
-      content: [{ type: "text", text: "world" }],
-    },
-    {
-      message_type: "usage_statistics",
-      prompt_tokens: 11,
-      completion_tokens: 7,
-      total_tokens: 18,
-    },
-    {
-      message_type: "stop_reason",
-      stop_reason: "end_turn",
-    },
-  ] as unknown as LettaStreamingResponse[];
-}
-
-function stubTurnStream(
-  chunks: LettaStreamingResponse[],
-  onCall?: (conversationId: string, agentId: string | undefined) => void,
+function stubTurn(
+  onCall?: (conversationId: string, agentId: string) => void,
 ): void {
-  __testSetSendMessageStreamImpl(async (conversationId, _messages, opts) => {
-    onCall?.(conversationId, opts?.agentId);
-    return (async function* () {
-      for (const chunk of chunks) {
-        yield chunk;
-      }
-    })();
+  __testSetRunTurnImpl(async ({ agentId, conversationId, onAssistantText }) => {
+    onCall?.(conversationId, agentId);
+    onAssistantText?.("Hello ");
+    onAssistantText?.("world");
+    return {
+      text: "Hello world",
+      usage: { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 },
+      error: null,
+    };
   });
 }
 
@@ -89,7 +62,7 @@ describe("app-server OpenAI-compatible API", () => {
   let handle: AppServerHandle | null = null;
 
   afterEach(async () => {
-    __testSetSendMessageStreamImpl(null);
+    __testSetRunTurnImpl(null);
     __testResetConversationMap();
     __testSetBackend(null);
     if (handle) {
@@ -151,9 +124,9 @@ describe("app-server OpenAI-compatible API", () => {
   test("POST /v1/chat/completions aggregates a turn (non-streaming)", async () => {
     __testSetBackend(fakeBackend());
     const captured = { conversation: "", agent: "" };
-    stubTurnStream(fakeTurnChunks(), (conversationId, agentId) => {
+    stubTurn((conversationId, agentId) => {
       captured.conversation = conversationId;
-      captured.agent = agentId ?? "";
+      captured.agent = agentId;
     });
     handle = await startAppServer({
       listen: "ws://127.0.0.1:0",
@@ -195,7 +168,7 @@ describe("app-server OpenAI-compatible API", () => {
     const created: string[] = [];
     __testSetBackend(fakeBackend(created));
     const conversationsUsed: string[] = [];
-    stubTurnStream(fakeTurnChunks(), (conversationId) => {
+    stubTurn((conversationId) => {
       conversationsUsed.push(conversationId);
     });
     handle = await startAppServer({
@@ -233,7 +206,7 @@ describe("app-server OpenAI-compatible API", () => {
 
   test("POST /v1/chat/completions streams SSE chunks", async () => {
     __testSetBackend(fakeBackend());
-    stubTurnStream(fakeTurnChunks());
+    stubTurn();
     handle = await startAppServer({
       listen: "ws://127.0.0.1:0",
       openaiApi: true,

--- a/src/websocket/app-server-openai.test.ts
+++ b/src/websocket/app-server-openai.test.ts
@@ -437,6 +437,83 @@ describe("app-server OpenAI-compatible API", () => {
     expect(messageCounts).toEqual([1]);
   });
 
+  test("Idempotency-Key replays the original outcome without re-running", async () => {
+    __testSetBackend(fakeBackend());
+    let runs = 0;
+    __testSetRunTurnImpl(async ({ onAssistantText }) => {
+      runs += 1;
+      onAssistantText?.("Hello world");
+      return {
+        text: "Hello world",
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        error: null,
+      };
+    });
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const send = (key: string) =>
+      fetch(httpUrl(handle as AppServerHandle, "/v1/chat/completions"), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "idempotency-key": key,
+        },
+        body: JSON.stringify({
+          model: "memo",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      });
+
+    const first = (await (await send("retry-1")).json()) as {
+      choices: Array<{ message: { content: string } }>;
+    };
+    const replay = (await (await send("retry-1")).json()) as {
+      choices: Array<{ message: { content: string } }>;
+    };
+    await send("retry-2");
+
+    expect(first.choices[0]?.message.content).toBe("Hello world");
+    expect(replay.choices[0]?.message.content).toBe("Hello world");
+    expect(runs).toBe(2);
+  });
+
+  test("failed idempotent outcomes are evicted so retries re-run", async () => {
+    __testSetBackend(fakeBackend());
+    let runs = 0;
+    __testSetRunTurnImpl(async () => {
+      runs += 1;
+      return {
+        text: "",
+        usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+        error: runs === 1 ? "transient failure" : null,
+      };
+    });
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const send = () =>
+      fetch(httpUrl(handle as AppServerHandle, "/v1/chat/completions"), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "idempotency-key": "retry-after-error",
+        },
+        body: JSON.stringify({
+          model: "memo",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      });
+
+    expect((await send()).status).toBe(500);
+    expect((await send()).status).toBe(200);
+    expect(runs).toBe(2);
+  });
+
   test("image_url parts pass through as Letta image content", async () => {
     __testSetBackend(fakeBackend());
     let capturedContent: unknown = null;

--- a/src/websocket/app-server-openai.test.ts
+++ b/src/websocket/app-server-openai.test.ts
@@ -5,7 +5,10 @@ import type { Backend } from "@/backend";
 import { __testSetBackend } from "@/backend";
 import { type AppServerHandle, startAppServer } from "@/websocket/app-server";
 import { parseAppServerWebsocketAuthSettings } from "@/websocket/app-server-auth";
-import { __testSetSendMessageStreamImpl } from "@/websocket/app-server-openai";
+import {
+  __testResetConversationMap,
+  __testSetSendMessageStreamImpl,
+} from "@/websocket/app-server-openai";
 
 const TEST_AGENTS = [
   {
@@ -20,9 +23,14 @@ const TEST_AGENTS = [
   },
 ];
 
-function fakeBackend(): Backend {
+function fakeBackend(created: string[] = []): Backend {
   return {
     listAgents: async () => TEST_AGENTS,
+    createConversation: async (body: { agent_id: string }) => {
+      const id = `conv-test-${created.length + 1}`;
+      created.push(id);
+      return { id, agent_id: body.agent_id };
+    },
   } as unknown as Backend;
 }
 
@@ -82,6 +90,7 @@ describe("app-server OpenAI-compatible API", () => {
 
   afterEach(async () => {
     __testSetSendMessageStreamImpl(null);
+    __testResetConversationMap();
     __testSetBackend(null);
     if (handle) {
       await handle.close();
@@ -178,8 +187,48 @@ describe("app-server OpenAI-compatible API", () => {
     expect(body.choices[0]?.finish_reason).toBe("stop");
     expect(body.usage.prompt_tokens).toBe(11);
     expect(body.usage.total_tokens).toBe(18);
-    expect(captured.conversation).toBe("default");
+    expect(captured.conversation).toBe("conv-test-1");
     expect(captured.agent).toBe("agent-local-111");
+  });
+
+  test("client chats map to distinct, sticky Letta conversations", async () => {
+    const created: string[] = [];
+    __testSetBackend(fakeBackend(created));
+    const conversationsUsed: string[] = [];
+    stubTurnStream(fakeTurnChunks(), (conversationId) => {
+      conversationsUsed.push(conversationId);
+    });
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const send = async (messages: unknown[]) =>
+      fetch(httpUrl(handle as AppServerHandle, "/v1/chat/completions"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "memo", messages }),
+      });
+
+    // Chat A, first message: creates a fresh conversation.
+    await send([{ role: "user", content: "first chat" }]);
+    // Chat A, second message: client resends the transcript, which now
+    // includes the reply ("Hello world") — must map back to the same
+    // conversation without creating a new one.
+    await send([
+      { role: "user", content: "first chat" },
+      { role: "assistant", content: "Hello world" },
+      { role: "user", content: "follow-up" },
+    ]);
+    // Chat B, first message: a different thread gets its own conversation.
+    await send([{ role: "user", content: "second chat" }]);
+
+    expect(conversationsUsed).toEqual([
+      "conv-test-1",
+      "conv-test-1",
+      "conv-test-2",
+    ]);
+    expect(created).toEqual(["conv-test-1", "conv-test-2"]);
   });
 
   test("POST /v1/chat/completions streams SSE chunks", async () => {

--- a/src/websocket/app-server-openai.test.ts
+++ b/src/websocket/app-server-openai.test.ts
@@ -272,6 +272,56 @@ describe("app-server OpenAI-compatible API", () => {
     expect(body.error.code).toBe("model_not_found");
   });
 
+  test("image_url parts pass through as Letta image content", async () => {
+    __testSetBackend(fakeBackend());
+    let capturedContent: unknown = null;
+    __testSetRunTurnImpl(async ({ userContent, onAssistantText }) => {
+      capturedContent = userContent;
+      onAssistantText?.("I see it");
+      return {
+        text: "I see it",
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        error: null,
+      };
+    });
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const response = await fetch(httpUrl(handle, "/v1/chat/completions"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "memo",
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "what is in this image?" },
+              {
+                type: "image_url",
+                image_url: { url: "data:image/png;base64,iVBORw0KGgo=" },
+              },
+            ],
+          },
+        ],
+      }),
+    });
+    expect(response.status).toBe(200);
+    expect(capturedContent).toEqual([
+      { type: "text", text: "what is in this image?" },
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: "iVBORw0KGgo=",
+        },
+      },
+    ]);
+  });
+
   test("missing user text returns 400", async () => {
     __testSetBackend(fakeBackend());
     handle = await startAppServer({

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import type {
   IncomingMessage as HttpIncomingMessage,
   ServerResponse,
@@ -19,6 +19,7 @@ import {
   LocalListenerTransport,
 } from "@/websocket/listener/transport";
 import { handleIncomingMessage } from "@/websocket/listener/turn";
+import { registerTurnObserver } from "@/websocket/listener/turn-observers";
 import type {
   IncomingMessage as ListenerIncomingMessage,
   ListenerRuntime,
@@ -28,11 +29,12 @@ import type {
 } from "@/websocket/listener/types";
 
 // OpenAI-compatible surface for the App Server. Each Letta agent is
-// advertised as a "model"; a chat completion request routes the last user
-// message into a Letta conversation on that agent. The resent client-side
-// history is not replayed into the agent — server-side state is
-// authoritative — but it IS used as a fingerprint to keep each client-side
-// chat pinned to its own Letta conversation across stateless requests.
+// advertised as a "model". Conversation identity is explicit or absent:
+// clients that send a stable chat id header get a pinned Letta conversation
+// that receives only the newest message (stateful mode); header-less clients
+// are served statelessly — every request runs in a fresh conversation with
+// the client's transcript replayed — because identical transcripts are
+// indistinguishable and transcript fingerprinting cross-wires them.
 const MODELS_PATH = "/v1/models";
 const CHAT_COMPLETIONS_PATH = "/v1/chat/completions";
 const MAX_REQUEST_BODY_BYTES = 20 * 1024 * 1024;
@@ -48,10 +50,21 @@ interface TurnOutcome {
   error: string | null;
 }
 
+interface BridgeTurnMessage {
+  role: "user" | "assistant";
+  content: UserContentPart[];
+  otid: string;
+}
+
 interface RunTurnParams {
   agentId: string;
   conversationId: string;
-  userContent: UserContentPart[];
+  /** Full input for the turn: the newest message in stateful mode, or the
+   * replayed client transcript in stateless mode. */
+  messages: BridgeTurnMessage[];
+  /** OTID of a message in this turn, used to correlate the listener turn
+   * lifecycle with this request. */
+  correlationOtid: string;
   onAssistantText?: (text: string) => void;
   onLog?: (message: string) => void;
 }
@@ -243,17 +256,36 @@ async function listAgentEntries(): Promise<AgentModelEntry[]> {
   return getPageItems<AgentModelEntry>(page);
 }
 
-async function handleListModels(response: ServerResponse): Promise<void> {
-  const agents = await listAgentEntries();
-  // Advertise the agent name when it is unambiguous; fall back to the agent
-  // id for duplicate names so every listed model id resolves to one agent.
+/**
+ * One collision-free advertised-id map, used by both listing and
+ * resolution. An agent name is advertised only when it is unique among
+ * names AND does not equal any agent id — otherwise the agent id is
+ * advertised — so every advertised id resolves to exactly one agent and
+ * raw agent-id lookups can never be shadowed by another agent's name.
+ */
+function buildAdvertisedModelMap(
+  agents: AgentModelEntry[],
+): Map<string, AgentModelEntry> {
+  const ids = new Set(agents.map((agent) => agent.id));
   const nameCounts = new Map<string, number>();
   for (const agent of agents) {
     if (!agent.name) continue;
     nameCounts.set(agent.name, (nameCounts.get(agent.name) ?? 0) + 1);
   }
-  const data = agents.map((agent) => ({
-    id: agent.name && nameCounts.get(agent.name) === 1 ? agent.name : agent.id,
+  const advertised = new Map<string, AgentModelEntry>();
+  for (const agent of agents) {
+    const useName =
+      agent.name && nameCounts.get(agent.name) === 1 && !ids.has(agent.name);
+    const id = useName && agent.name ? agent.name : agent.id;
+    if (!advertised.has(id)) advertised.set(id, agent);
+  }
+  return advertised;
+}
+
+async function handleListModels(response: ServerResponse): Promise<void> {
+  const advertised = buildAdvertisedModelMap(await listAgentEntries());
+  const data = [...advertised.entries()].map(([id, agent]) => ({
+    id,
     object: "model" as const,
     created: toModelCreatedTimestamp(agent.created_at),
     owned_by: "letta",
@@ -266,27 +298,17 @@ async function resolveAgentForModel(
 ): Promise<AgentModelEntry | null> {
   const agents = await listAgentEntries();
   return (
+    buildAdvertisedModelMap(agents).get(model) ??
     agents.find((agent) => agent.id === model) ??
-    agents.find((agent) => agent.name === model) ??
     null
   );
 }
 
-// Conversation continuity across stateless chat-completions requests.
-// The protocol carries no thread id, so a client chat is identified by a
-// fingerprint of its transcript prefix (the user/assistant turns before
-// the message being sent). A first message has an empty prefix and starts
-// a fresh Letta conversation; after each completed turn we also store the
-// fingerprint of the transcript including the new reply, which is exactly
-// the prefix the client will resend on its next message in that chat.
-// Bounded FIFO map: long-idle chats fall out and start a new conversation.
+// Conversation continuity for header-keyed chats. Clients that supply a
+// stable chat identity get a pinned Letta conversation; the bounded FIFO
+// map evicts long-idle chats, which then start a fresh conversation.
 const MAX_TRACKED_TRANSCRIPTS = 4096;
 const conversationIdByTranscript = new Map<string, string>();
-
-interface TranscriptTurn {
-  role: string;
-  text: string;
-}
 
 function rememberConversation(key: string, conversationId: string): void {
   conversationIdByTranscript.delete(key);
@@ -296,35 +318,6 @@ function rememberConversation(key: string, conversationId: string): void {
     if (oldest === undefined) break;
     conversationIdByTranscript.delete(oldest);
   }
-}
-
-function transcriptFingerprint(
-  agentId: string,
-  turns: TranscriptTurn[],
-): string {
-  const hash = createHash("sha256");
-  hash.update(agentId);
-  for (const turn of turns) {
-    hash.update("\0");
-    hash.update(turn.role);
-    hash.update("\0");
-    hash.update(turn.text);
-  }
-  return hash.digest("hex");
-}
-
-/** User/assistant turns with text content, in order; system turns are
- * excluded because clients vary them independently of the thread. */
-function normalizeTranscript(messages: OpenAiChatMessage[]): TranscriptTurn[] {
-  const turns: TranscriptTurn[] = [];
-  for (const message of messages) {
-    if (message.role !== "user" && message.role !== "assistant") continue;
-    turns.push({
-      role: message.role,
-      text: extractTextContent(message.content),
-    });
-  }
-  return turns;
 }
 
 // Conversation creation is serialized per agent: concurrent creations race
@@ -355,19 +348,19 @@ async function createConversationWithRetry(agentId: string): Promise<string> {
   throw lastError;
 }
 
-async function resolveConversationId(
+/** Serialized per-agent conversation creation (see note above). The
+ * optional reuseKey is re-checked after the queue drains so a concurrent
+ * request with the same key reuses the conversation it created. */
+async function createConversationSerialized(
   agentId: string,
-  prefixKey: string,
+  reuseKey?: string,
 ): Promise<string> {
-  const existing = conversationIdByTranscript.get(prefixKey);
-  if (existing) return existing;
   const tail = conversationCreateTailByAgent.get(agentId) ?? Promise.resolve();
   const creation = tail.then(async () => {
-    // Re-check after the queue drains: a concurrent request with the same
-    // key (e.g. a double-send from a header-keyed chat) may have created
-    // and remembered the conversation while this one waited.
-    const raced = conversationIdByTranscript.get(prefixKey);
-    if (raced) return raced;
+    if (reuseKey) {
+      const raced = conversationIdByTranscript.get(reuseKey);
+      if (raced) return raced;
+    }
     return await createConversationWithRetry(agentId);
   });
   const settled = creation.then(
@@ -381,6 +374,15 @@ async function resolveConversationId(
     }
   });
   return await creation;
+}
+
+async function resolveConversationId(
+  agentId: string,
+  chatKey: string,
+): Promise<string> {
+  const existing = conversationIdByTranscript.get(chatKey);
+  if (existing) return existing;
+  return await createConversationSerialized(agentId, chatKey);
 }
 
 // Clients that know their chat identity can pin it explicitly instead of
@@ -525,7 +527,16 @@ async function runTurnViaListenerRuntime(
       completion_tokens: 0,
       total_tokens: 0,
     };
+    // The request settles from ITS OWN turn's lifecycle (turn-observers,
+    // keyed by OTID), never from raw stream events: stop_reason ends a
+    // stream segment before the listener decides on retries/approvals, and
+    // usage can arrive after it. Stream deltas are accumulated only while
+    // this request's turn is active, so queued requests and WS-initiated
+    // turns in the same conversation never bleed into this response.
+    let turnActive = false;
+    let recordedError: string | null = null;
     let settled = false;
+    let unregisterTurnObserver: () => void = () => {};
     if (!listener.streamObservers) {
       listener.streamObservers = new Set();
     }
@@ -536,12 +547,21 @@ async function runTurnViaListenerRuntime(
       settled = true;
       clearTimeout(timer);
       observers.delete(observer);
+      unregisterTurnObserver();
       resolve({ text, usage, error });
     };
 
     const observer: ListenerStreamObserver = (message) => {
+      if (message.type === "runtime_stopped") {
+        finish(
+          recordedError ??
+            "server runtime was replaced while the request was in flight",
+        );
+        return;
+      }
       if (message.runtime.agent_id !== params.agentId) return;
       if (message.runtime.conversation_id !== params.conversationId) return;
+      if (!turnActive) return;
       if (message.type === "update_loop_status") {
         // The turn paused for interactive input this surface cannot provide.
         const status = (message as { loop_status?: { status?: string } })
@@ -582,38 +602,37 @@ async function runTurnViaListenerRuntime(
           };
           return;
         }
-        case "stop_reason": {
-          const stopReason = (delta as { stop_reason?: string }).stop_reason;
-          // requires_approval ends a stream segment, not the turn: the turn
-          // processor evaluates the approval (auto-approving under the
-          // conversation's permission mode) and continues. Keep observing;
-          // a WAITING_ON_APPROVAL loop status marks a truly stuck turn.
-          if (stopReason === "requires_approval") return;
-          finish(null);
-          return;
-        }
         case "loop_error": {
+          // Recorded, not settled: the listener may still retry. The turn
+          // lifecycle end decides the final outcome.
           const loopError = delta as {
             is_terminal?: boolean;
             message?: string;
           };
           if (loopError.is_terminal !== false) {
-            finish(loopError.message ?? "agent turn failed");
+            recordedError = loopError.message ?? "agent turn failed";
           }
           return;
         }
         case "error_message":
-          finish(
-            (delta as { message?: string }).message ?? "agent turn failed",
-          );
+          recordedError =
+            (delta as { message?: string }).message ?? "agent turn failed";
           return;
         default:
           return;
       }
     };
     observers.add(observer);
+    unregisterTurnObserver = registerTurnObserver(params.correlationOtid, {
+      onStarted: () => {
+        turnActive = true;
+      },
+      onFinished: () => {
+        finish(recordedError);
+      },
+    });
     const timer = setTimeout(
-      () => finish("agent turn timed out"),
+      () => finish(recordedError ?? "agent turn timed out"),
       OPENAI_TURN_TIMEOUT_MS,
     );
 
@@ -621,13 +640,7 @@ async function runTurnViaListenerRuntime(
       type: "message",
       agentId: params.agentId,
       conversationId: params.conversationId,
-      messages: [
-        {
-          role: "user",
-          content: params.userContent,
-          otid: randomUUID(),
-        },
-      ],
+      messages: params.messages,
     };
     try {
       dispatchInboundMessageWhenReady({
@@ -706,12 +719,6 @@ async function handleChatCompletions(
     return;
   }
 
-  const transcript = normalizeTranscript(body.messages);
-  const lastUserIndex = transcript.findLastIndex(
-    (turn) => turn.role === "user",
-  );
-  const userText =
-    (lastUserIndex >= 0 && transcript[lastUserIndex]?.text) || "";
   const lastUserMessage = [...body.messages]
     .reverse()
     .find((message) => message.role === "user");
@@ -738,18 +745,20 @@ async function handleChatCompletions(
     return;
   }
 
-  const prefixTurns = transcript.slice(0, lastUserIndex);
+  // Stateful mode requires a stable chat identity from the client; without
+  // one, identical transcripts are indistinguishable and any reuse
+  // heuristic can cross-wire chats. Header-less requests run statelessly:
+  // a fresh conversation per request, with the client transcript replayed.
   const headerChatKey = chatKeyFromHeaders(request);
-  const prefixKey = headerChatKey
-    ? `chat-key:${agent.id}:${headerChatKey}`
-    : transcriptFingerprint(agent.id, prefixTurns);
   let conversationId: string;
   try {
-    conversationId = await resolveConversationId(agent.id, prefixKey);
     if (headerChatKey) {
-      // Header keys are stable chat identities: pin them immediately so a
-      // concurrent request for the same chat reuses this conversation.
-      rememberConversation(prefixKey, conversationId);
+      const chatKey = `chat-key:${agent.id}:${headerChatKey}`;
+      conversationId = await resolveConversationId(agent.id, chatKey);
+      // Pin immediately so concurrent requests for this chat reuse it.
+      rememberConversation(chatKey, conversationId);
+    } else {
+      conversationId = await createConversationSerialized(agent.id);
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -759,6 +768,40 @@ async function handleChatCompletions(
       500,
       "failed to create a conversation for this chat",
       "server_error",
+    );
+    return;
+  }
+
+  const turnMessages: BridgeTurnMessage[] = [];
+  if (headerChatKey) {
+    turnMessages.push({
+      role: "user",
+      content: userContent,
+      otid: randomUUID(),
+    });
+  } else {
+    for (const message of body.messages) {
+      if (message.role !== "user" && message.role !== "assistant") continue;
+      let content: UserContentPart[];
+      if (message === lastUserMessage) {
+        content = userContent;
+      } else if (message.role === "user") {
+        content = extractUserContentParts(message.content);
+      } else {
+        const replyText = extractTextContent(message.content);
+        content = replyText ? [{ type: "text", text: replyText }] : [];
+      }
+      if (content.length === 0) continue;
+      turnMessages.push({ role: message.role, content, otid: randomUUID() });
+    }
+  }
+  const correlationOtid = turnMessages.at(-1)?.otid;
+  if (!correlationOtid) {
+    sendOpenAiError(
+      response,
+      400,
+      "the messages array must include usable content",
+      "invalid_request_error",
     );
     return;
   }
@@ -793,7 +836,8 @@ async function handleChatCompletions(
     outcome = await runTurnImpl({
       agentId: agent.id,
       conversationId,
-      userContent,
+      messages: turnMessages,
+      correlationOtid,
       onLog: options.onLog,
       onAssistantText: streaming
         ? (piece) => {
@@ -824,31 +868,6 @@ async function handleChatCompletions(
   const streamError = outcome.error;
 
   if (clientClosed) return;
-
-  if (!streamError) {
-    // Map the prefix itself (so a regenerate of the same message reuses
-    // this conversation) and the transcript including the new reply (the
-    // prefix the client resends on its next message in this chat). The
-    // EMPTY prefix is shared by every brand-new chat and must never be
-    // remembered — doing so would funnel all new chats into one
-    // conversation. Header-keyed chats are already pinned by their stable
-    // key and skip transcript bookkeeping entirely.
-    if (headerChatKey) {
-      rememberConversation(prefixKey, conversationId);
-    } else {
-      if (prefixTurns.length > 0) {
-        rememberConversation(prefixKey, conversationId);
-      }
-      rememberConversation(
-        transcriptFingerprint(agent.id, [
-          ...prefixTurns,
-          { role: "user", text: userText },
-          { role: "assistant", text: fullText },
-        ]),
-        conversationId,
-      );
-    }
-  }
 
   if (streaming) {
     if (streamError) {

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -362,7 +362,14 @@ async function resolveConversationId(
   const existing = conversationIdByTranscript.get(prefixKey);
   if (existing) return existing;
   const tail = conversationCreateTailByAgent.get(agentId) ?? Promise.resolve();
-  const creation = tail.then(() => createConversationWithRetry(agentId));
+  const creation = tail.then(async () => {
+    // Re-check after the queue drains: a concurrent request with the same
+    // key (e.g. a double-send from a header-keyed chat) may have created
+    // and remembered the conversation while this one waited.
+    const raced = conversationIdByTranscript.get(prefixKey);
+    if (raced) return raced;
+    return await createConversationWithRetry(agentId);
+  });
   const settled = creation.then(
     () => undefined,
     () => undefined,
@@ -374,6 +381,23 @@ async function resolveConversationId(
     }
   });
   return await creation;
+}
+
+// Clients that know their chat identity can pin it explicitly instead of
+// relying on transcript fingerprints, which collide when two chats have
+// byte-identical transcripts (e.g. both start "Hello" and get the same
+// verbatim reply). Open WebUI sends X-OpenWebUI-Chat-Id when
+// ENABLE_FORWARD_USER_INFO_HEADERS is on; X-Letta-Chat-Key is the generic
+// escape hatch for other clients.
+const CHAT_KEY_HEADERS = ["x-letta-chat-key", "x-openwebui-chat-id"] as const;
+
+function chatKeyFromHeaders(request: HttpIncomingMessage): string | null {
+  for (const name of CHAT_KEY_HEADERS) {
+    const value = request.headers[name];
+    if (typeof value === "string" && value) return value;
+    if (Array.isArray(value) && value[0]) return value[0];
+  }
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -715,10 +739,18 @@ async function handleChatCompletions(
   }
 
   const prefixTurns = transcript.slice(0, lastUserIndex);
-  const prefixKey = transcriptFingerprint(agent.id, prefixTurns);
+  const headerChatKey = chatKeyFromHeaders(request);
+  const prefixKey = headerChatKey
+    ? `chat-key:${agent.id}:${headerChatKey}`
+    : transcriptFingerprint(agent.id, prefixTurns);
   let conversationId: string;
   try {
     conversationId = await resolveConversationId(agent.id, prefixKey);
+    if (headerChatKey) {
+      // Header keys are stable chat identities: pin them immediately so a
+      // concurrent request for the same chat reuses this conversation.
+      rememberConversation(prefixKey, conversationId);
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     options.onLog?.(`OpenAI-compat failed to create conversation: ${message}`);
@@ -799,18 +831,23 @@ async function handleChatCompletions(
     // prefix the client resends on its next message in this chat). The
     // EMPTY prefix is shared by every brand-new chat and must never be
     // remembered — doing so would funnel all new chats into one
-    // conversation.
-    if (prefixTurns.length > 0) {
+    // conversation. Header-keyed chats are already pinned by their stable
+    // key and skip transcript bookkeeping entirely.
+    if (headerChatKey) {
       rememberConversation(prefixKey, conversationId);
+    } else {
+      if (prefixTurns.length > 0) {
+        rememberConversation(prefixKey, conversationId);
+      }
+      rememberConversation(
+        transcriptFingerprint(agent.id, [
+          ...prefixTurns,
+          { role: "user", text: userText },
+          { role: "assistant", text: fullText },
+        ]),
+        conversationId,
+      );
     }
-    rememberConversation(
-      transcriptFingerprint(agent.id, [
-        ...prefixTurns,
-        { role: "user", text: userText },
-        { role: "assistant", text: fullText },
-      ]),
-      conversationId,
-    );
   }
 
   if (streaming) {

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -1,0 +1,456 @@
+import { randomUUID } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
+import { sendMessageStream } from "@/agent/message";
+import { getBackend } from "@/backend";
+import {
+  authorizeUpgrade,
+  type WebsocketAuthPolicy,
+} from "@/websocket/app-server-auth";
+
+// OpenAI-compatible surface for the App Server. Each Letta agent is
+// advertised as a "model"; a chat completion request routes the last user
+// message into that agent's default conversation. The resent client-side
+// history is intentionally ignored — the agent's own server-side memory and
+// conversation state are authoritative.
+const MODELS_PATH = "/v1/models";
+const CHAT_COMPLETIONS_PATH = "/v1/chat/completions";
+const MAX_REQUEST_BODY_BYTES = 20 * 1024 * 1024;
+
+export interface OpenAiCompatOptions {
+  authPolicy: WebsocketAuthPolicy;
+  onLog?: (message: string) => void;
+}
+
+type SendMessageStreamImpl = (
+  ...args: Parameters<typeof sendMessageStream>
+) => Promise<AsyncIterable<LettaStreamingResponse>>;
+
+let sendMessageStreamImpl: SendMessageStreamImpl = sendMessageStream;
+
+/** @internal Test seam mirroring __testSetBackend. */
+export function __testSetSendMessageStreamImpl(
+  impl: SendMessageStreamImpl | null,
+): void {
+  sendMessageStreamImpl = impl ?? sendMessageStream;
+}
+
+interface OpenAiChatMessagePart {
+  type?: string;
+  text?: string;
+}
+
+interface OpenAiChatMessage {
+  role?: string;
+  content?: string | OpenAiChatMessagePart[] | null;
+}
+
+interface OpenAiChatCompletionRequest {
+  model?: string;
+  messages?: OpenAiChatMessage[];
+  stream?: boolean;
+}
+
+interface OpenAiUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+}
+
+export function isOpenAiCompatPath(pathname: string): boolean {
+  return pathname === MODELS_PATH || pathname === CHAT_COMPLETIONS_PATH;
+}
+
+function sendJson(
+  response: ServerResponse,
+  statusCode: number,
+  body: unknown,
+): void {
+  const payload = JSON.stringify(body);
+  response.writeHead(statusCode, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(payload),
+  });
+  response.end(payload);
+}
+
+function sendOpenAiError(
+  response: ServerResponse,
+  statusCode: number,
+  message: string,
+  type: string,
+  code: string | null = null,
+): void {
+  sendJson(response, statusCode, {
+    error: { message, type, param: null, code },
+  });
+}
+
+async function readJsonBody(request: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buffer.length;
+    if (total > MAX_REQUEST_BODY_BYTES) {
+      throw new Error("request body too large");
+    }
+    chunks.push(buffer);
+  }
+  const raw = Buffer.concat(chunks).toString("utf8");
+  if (!raw) return {};
+  return JSON.parse(raw);
+}
+
+function extractTextContent(
+  content: string | OpenAiChatMessagePart[] | null | undefined,
+): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) =>
+      part && part.type === "text" && typeof part.text === "string"
+        ? part.text
+        : "",
+    )
+    .filter(Boolean)
+    .join("\n");
+}
+
+function extractAssistantText(chunk: LettaStreamingResponse): string {
+  const content = (
+    chunk as { content?: string | Array<{ text?: string }> | null }
+  ).content;
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) =>
+      part && typeof part === "object" && typeof part.text === "string"
+        ? part.text
+        : "",
+    )
+    .join("");
+}
+
+function toModelCreatedTimestamp(createdAt: unknown): number {
+  if (typeof createdAt === "string") {
+    const ms = new Date(createdAt).getTime();
+    if (Number.isFinite(ms)) return Math.floor(ms / 1000);
+  }
+  return 0;
+}
+
+interface AgentModelEntry {
+  id: string;
+  name?: string | null;
+  created_at?: string;
+}
+
+function getPageItems<T>(page: unknown): T[] {
+  if (Array.isArray(page)) return page as T[];
+  if (page && typeof page === "object") {
+    const candidate = page as {
+      getPaginatedItems?: () => T[];
+      items?: T[];
+    };
+    if (typeof candidate.getPaginatedItems === "function") {
+      return candidate.getPaginatedItems();
+    }
+    if (Array.isArray(candidate.items)) {
+      return candidate.items;
+    }
+  }
+  return [];
+}
+
+async function listAgentEntries(): Promise<AgentModelEntry[]> {
+  const page = await getBackend().listAgents({});
+  return getPageItems<AgentModelEntry>(page);
+}
+
+async function handleListModels(response: ServerResponse): Promise<void> {
+  const agents = await listAgentEntries();
+  // Advertise the agent name when it is unambiguous; fall back to the agent
+  // id for duplicate names so every listed model id resolves to one agent.
+  const nameCounts = new Map<string, number>();
+  for (const agent of agents) {
+    if (!agent.name) continue;
+    nameCounts.set(agent.name, (nameCounts.get(agent.name) ?? 0) + 1);
+  }
+  const data = agents.map((agent) => ({
+    id: agent.name && nameCounts.get(agent.name) === 1 ? agent.name : agent.id,
+    object: "model" as const,
+    created: toModelCreatedTimestamp(agent.created_at),
+    owned_by: "letta",
+  }));
+  sendJson(response, 200, { object: "list", data });
+}
+
+async function resolveAgentForModel(
+  model: string,
+): Promise<AgentModelEntry | null> {
+  const agents = await listAgentEntries();
+  return (
+    agents.find((agent) => agent.id === model) ??
+    agents.find((agent) => agent.name === model) ??
+    null
+  );
+}
+
+function chatCompletionChunk(
+  id: string,
+  created: number,
+  model: string,
+  delta: Record<string, unknown>,
+  finishReason: string | null,
+): string {
+  return `data: ${JSON.stringify({
+    id,
+    object: "chat.completion.chunk",
+    created,
+    model,
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  })}\n\n`;
+}
+
+async function handleChatCompletions(
+  request: IncomingMessage,
+  response: ServerResponse,
+  options: OpenAiCompatOptions,
+): Promise<void> {
+  let body: OpenAiChatCompletionRequest;
+  try {
+    body = (await readJsonBody(request)) as OpenAiChatCompletionRequest;
+  } catch (error) {
+    sendOpenAiError(
+      response,
+      400,
+      error instanceof Error ? error.message : "invalid JSON body",
+      "invalid_request_error",
+    );
+    return;
+  }
+
+  if (typeof body.model !== "string" || body.model.length === 0) {
+    sendOpenAiError(
+      response,
+      400,
+      "you must provide a model parameter",
+      "invalid_request_error",
+    );
+    return;
+  }
+  if (!Array.isArray(body.messages) || body.messages.length === 0) {
+    sendOpenAiError(
+      response,
+      400,
+      "you must provide a non-empty messages array",
+      "invalid_request_error",
+    );
+    return;
+  }
+
+  const lastUserMessage = [...body.messages]
+    .reverse()
+    .find((message) => message.role === "user");
+  const userText = extractTextContent(lastUserMessage?.content);
+  if (!userText) {
+    sendOpenAiError(
+      response,
+      400,
+      "the messages array must include a user message with text content",
+      "invalid_request_error",
+    );
+    return;
+  }
+
+  const agent = await resolveAgentForModel(body.model);
+  if (!agent) {
+    sendOpenAiError(
+      response,
+      404,
+      `The model '${body.model}' does not exist. Use GET /v1/models to list available agents.`,
+      "invalid_request_error",
+      "model_not_found",
+    );
+    return;
+  }
+
+  const completionId = `chatcmpl-${randomUUID()}`;
+  const created = Math.floor(Date.now() / 1000);
+  const streaming = body.stream === true;
+  let clientClosed = false;
+  response.on("close", () => {
+    clientClosed = true;
+  });
+
+  let stream: AsyncIterable<LettaStreamingResponse>;
+  try {
+    stream = await sendMessageStreamImpl(
+      "default",
+      [
+        {
+          role: "user",
+          content: [{ type: "text", text: userText }],
+          otid: randomUUID(),
+        },
+      ],
+      { agentId: agent.id, streamTokens: true, background: true },
+    );
+  } catch (error) {
+    options.onLog?.(
+      `OpenAI-compat chat completion failed to start: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    sendOpenAiError(
+      response,
+      500,
+      "failed to start agent turn",
+      "server_error",
+    );
+    return;
+  }
+
+  if (streaming) {
+    response.writeHead(200, {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+    });
+    response.write(
+      chatCompletionChunk(
+        completionId,
+        created,
+        body.model,
+        { role: "assistant", content: "" },
+        null,
+      ),
+    );
+  }
+
+  let fullText = "";
+  let usage: OpenAiUsage = {
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    total_tokens: 0,
+  };
+  let streamError: string | null = null;
+
+  try {
+    for await (const chunk of stream) {
+      if (clientClosed) break;
+      const messageType = (chunk as { message_type?: string }).message_type;
+      if (messageType === "assistant_message") {
+        const text = extractAssistantText(chunk);
+        if (!text) continue;
+        fullText += text;
+        if (streaming) {
+          response.write(
+            chatCompletionChunk(
+              completionId,
+              created,
+              body.model,
+              { content: text },
+              null,
+            ),
+          );
+        }
+      } else if (messageType === "usage_statistics") {
+        const stats = chunk as {
+          prompt_tokens?: number;
+          completion_tokens?: number;
+          total_tokens?: number;
+        };
+        usage = {
+          prompt_tokens: stats.prompt_tokens ?? 0,
+          completion_tokens: stats.completion_tokens ?? 0,
+          total_tokens: stats.total_tokens ?? 0,
+        };
+      } else if (messageType === "error_message") {
+        streamError =
+          (chunk as { message?: string }).message ?? "agent turn failed";
+        break;
+      } else if (messageType === "stop_reason") {
+        break;
+      }
+    }
+  } catch (error) {
+    streamError = error instanceof Error ? error.message : String(error);
+  }
+
+  if (clientClosed) return;
+
+  if (streaming) {
+    if (streamError) {
+      options.onLog?.(`OpenAI-compat stream error: ${streamError}`);
+      response.write(
+        `data: ${JSON.stringify({
+          error: { message: streamError, type: "server_error" },
+        })}\n\n`,
+      );
+    } else {
+      response.write(
+        chatCompletionChunk(completionId, created, body.model, {}, "stop"),
+      );
+    }
+    response.write("data: [DONE]\n\n");
+    response.end();
+    return;
+  }
+
+  if (streamError) {
+    options.onLog?.(`OpenAI-compat stream error: ${streamError}`);
+    sendOpenAiError(response, 500, streamError, "server_error");
+    return;
+  }
+
+  sendJson(response, 200, {
+    id: completionId,
+    object: "chat.completion",
+    created,
+    model: body.model,
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content: fullText },
+        finish_reason: "stop",
+      },
+    ],
+    usage,
+  });
+}
+
+export async function handleOpenAiCompatRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  options: OpenAiCompatOptions,
+): Promise<void> {
+  const authError = authorizeUpgrade(request.headers, options.authPolicy);
+  if (authError) {
+    options.onLog?.(`Rejecting OpenAI-compat request: ${authError.message}`);
+    sendOpenAiError(response, 401, authError.message, "authentication_error");
+    return;
+  }
+
+  const pathname = new URL(request.url ?? "/", "http://localhost").pathname;
+  try {
+    if (pathname === MODELS_PATH && request.method === "GET") {
+      await handleListModels(response);
+      return;
+    }
+    if (pathname === CHAT_COMPLETIONS_PATH && request.method === "POST") {
+      await handleChatCompletions(request, response, options);
+      return;
+    }
+    sendOpenAiError(response, 404, "unknown endpoint", "invalid_request_error");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    options.onLog?.(`OpenAI-compat request failed: ${message}`);
+    if (!response.headersSent) {
+      sendOpenAiError(response, 500, message, "server_error");
+    } else {
+      response.end();
+    }
+  }
+}

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -327,26 +327,53 @@ function normalizeTranscript(messages: OpenAiChatMessage[]): TranscriptTurn[] {
   return turns;
 }
 
+// Conversation creation is serialized per agent: concurrent creations race
+// on initializing the agent's local memory repository (transient git config
+// lock failures). Failures propagate to the caller as a 500 — routing into
+// the shared "default" conversation instead would cross-wire client chats.
+const conversationCreateTailByAgent = new Map<string, Promise<void>>();
+const CONVERSATION_CREATE_RETRIES = 2;
+const CONVERSATION_CREATE_RETRY_DELAY_MS = 200;
+
+async function createConversationWithRetry(agentId: string): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= CONVERSATION_CREATE_RETRIES; attempt++) {
+    if (attempt > 0) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, CONVERSATION_CREATE_RETRY_DELAY_MS * attempt),
+      );
+    }
+    try {
+      const conversation = await getBackend().createConversation({
+        agent_id: agentId,
+      });
+      return conversation.id;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
+
 async function resolveConversationId(
   agentId: string,
   prefixKey: string,
-  onLog?: (message: string) => void,
 ): Promise<string> {
   const existing = conversationIdByTranscript.get(prefixKey);
   if (existing) return existing;
-  try {
-    const conversation = await getBackend().createConversation({
-      agent_id: agentId,
-    });
-    return conversation.id;
-  } catch (error) {
-    onLog?.(
-      `OpenAI-compat failed to create conversation, using default: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
-    return "default";
-  }
+  const tail = conversationCreateTailByAgent.get(agentId) ?? Promise.resolve();
+  const creation = tail.then(() => createConversationWithRetry(agentId));
+  const settled = creation.then(
+    () => undefined,
+    () => undefined,
+  );
+  conversationCreateTailByAgent.set(agentId, settled);
+  void settled.then(() => {
+    if (conversationCreateTailByAgent.get(agentId) === settled) {
+      conversationCreateTailByAgent.delete(agentId);
+    }
+  });
+  return await creation;
 }
 
 // ---------------------------------------------------------------------------
@@ -689,11 +716,20 @@ async function handleChatCompletions(
 
   const prefixTurns = transcript.slice(0, lastUserIndex);
   const prefixKey = transcriptFingerprint(agent.id, prefixTurns);
-  const conversationId = await resolveConversationId(
-    agent.id,
-    prefixKey,
-    options.onLog,
-  );
+  let conversationId: string;
+  try {
+    conversationId = await resolveConversationId(agent.id, prefixKey);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    options.onLog?.(`OpenAI-compat failed to create conversation: ${message}`);
+    sendOpenAiError(
+      response,
+      500,
+      "failed to create a conversation for this chat",
+      "server_error",
+    );
+    return;
+  }
 
   const completionId = `chatcmpl-${randomUUID()}`;
   const created = Math.floor(Date.now() / 1000);

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import { sendMessageStream } from "@/agent/message";
@@ -10,9 +10,10 @@ import {
 
 // OpenAI-compatible surface for the App Server. Each Letta agent is
 // advertised as a "model"; a chat completion request routes the last user
-// message into that agent's default conversation. The resent client-side
-// history is intentionally ignored — the agent's own server-side memory and
-// conversation state are authoritative.
+// message into a Letta conversation on that agent. The resent client-side
+// history is not replayed into the agent — server-side state is
+// authoritative — but it IS used as a fingerprint to keep each client-side
+// chat pinned to its own Letta conversation across stateless requests.
 const MODELS_PATH = "/v1/models";
 const CHAT_COMPLETIONS_PATH = "/v1/chat/completions";
 const MAX_REQUEST_BODY_BYTES = 20 * 1024 * 1024;
@@ -33,6 +34,11 @@ export function __testSetSendMessageStreamImpl(
   impl: SendMessageStreamImpl | null,
 ): void {
   sendMessageStreamImpl = impl ?? sendMessageStream;
+}
+
+/** @internal Clears the transcript→conversation map between tests. */
+export function __testResetConversationMap(): void {
+  conversationIdByTranscript.clear();
 }
 
 interface OpenAiChatMessagePart {
@@ -197,6 +203,83 @@ async function resolveAgentForModel(
   );
 }
 
+// Conversation continuity across stateless chat-completions requests.
+// The protocol carries no thread id, so a client chat is identified by a
+// fingerprint of its transcript prefix (the user/assistant turns before
+// the message being sent). A first message has an empty prefix and starts
+// a fresh Letta conversation; after each completed turn we also store the
+// fingerprint of the transcript including the new reply, which is exactly
+// the prefix the client will resend on its next message in that chat.
+// Bounded FIFO map: long-idle chats fall out and start a new conversation.
+const MAX_TRACKED_TRANSCRIPTS = 4096;
+const conversationIdByTranscript = new Map<string, string>();
+
+interface TranscriptTurn {
+  role: string;
+  text: string;
+}
+
+function rememberConversation(key: string, conversationId: string): void {
+  conversationIdByTranscript.delete(key);
+  conversationIdByTranscript.set(key, conversationId);
+  while (conversationIdByTranscript.size > MAX_TRACKED_TRANSCRIPTS) {
+    const oldest = conversationIdByTranscript.keys().next().value;
+    if (oldest === undefined) break;
+    conversationIdByTranscript.delete(oldest);
+  }
+}
+
+function transcriptFingerprint(
+  agentId: string,
+  turns: TranscriptTurn[],
+): string {
+  const hash = createHash("sha256");
+  hash.update(agentId);
+  for (const turn of turns) {
+    hash.update("\0");
+    hash.update(turn.role);
+    hash.update("\0");
+    hash.update(turn.text);
+  }
+  return hash.digest("hex");
+}
+
+/** User/assistant turns with text content, in order; system turns are
+ * excluded because clients vary them independently of the thread. */
+function normalizeTranscript(messages: OpenAiChatMessage[]): TranscriptTurn[] {
+  const turns: TranscriptTurn[] = [];
+  for (const message of messages) {
+    if (message.role !== "user" && message.role !== "assistant") continue;
+    turns.push({
+      role: message.role,
+      text: extractTextContent(message.content),
+    });
+  }
+  return turns;
+}
+
+async function resolveConversationId(
+  agentId: string,
+  prefixKey: string,
+  onLog?: (message: string) => void,
+): Promise<string> {
+  const existing = conversationIdByTranscript.get(prefixKey);
+  if (existing) return existing;
+  try {
+    const conversation = await getBackend().createConversation({
+      agent_id: agentId,
+    });
+    return conversation.id;
+  } catch (error) {
+    onLog?.(
+      `OpenAI-compat failed to create conversation, using default: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return "default";
+  }
+}
+
 function chatCompletionChunk(
   id: string,
   created: number,
@@ -250,10 +333,11 @@ async function handleChatCompletions(
     return;
   }
 
-  const lastUserMessage = [...body.messages]
-    .reverse()
-    .find((message) => message.role === "user");
-  const userText = extractTextContent(lastUserMessage?.content);
+  const transcript = normalizeTranscript(body.messages);
+  const lastUserIndex = transcript.findLastIndex(
+    (turn) => turn.role === "user",
+  );
+  const userText = lastUserIndex >= 0 ? transcript[lastUserIndex]?.text : "";
   if (!userText) {
     sendOpenAiError(
       response,
@@ -276,6 +360,14 @@ async function handleChatCompletions(
     return;
   }
 
+  const prefixTurns = transcript.slice(0, lastUserIndex);
+  const prefixKey = transcriptFingerprint(agent.id, prefixTurns);
+  const conversationId = await resolveConversationId(
+    agent.id,
+    prefixKey,
+    options.onLog,
+  );
+
   const completionId = `chatcmpl-${randomUUID()}`;
   const created = Math.floor(Date.now() / 1000);
   const streaming = body.stream === true;
@@ -287,7 +379,7 @@ async function handleChatCompletions(
   let stream: AsyncIterable<LettaStreamingResponse>;
   try {
     stream = await sendMessageStreamImpl(
-      "default",
+      conversationId,
       [
         {
           role: "user",
@@ -380,6 +472,26 @@ async function handleChatCompletions(
   }
 
   if (clientClosed) return;
+
+  if (!streamError) {
+    // Map the prefix itself (so a regenerate of the same message reuses
+    // this conversation) and the transcript including the new reply (the
+    // prefix the client resends on its next message in this chat). The
+    // EMPTY prefix is shared by every brand-new chat and must never be
+    // remembered — doing so would funnel all new chats into one
+    // conversation.
+    if (prefixTurns.length > 0) {
+      rememberConversation(prefixKey, conversationId);
+    }
+    rememberConversation(
+      transcriptFingerprint(agent.id, [
+        ...prefixTurns,
+        { role: "user", text: userText },
+        { role: "assistant", text: fullText },
+      ]),
+      conversationId,
+    );
+  }
 
   if (streaming) {
     if (streamError) {

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -51,7 +51,7 @@ interface TurnOutcome {
 interface RunTurnParams {
   agentId: string;
   conversationId: string;
-  userText: string;
+  userContent: UserContentPart[];
   onAssistantText?: (text: string) => void;
   onLog?: (message: string) => void;
 }
@@ -73,12 +73,22 @@ export function __testResetConversationMap(): void {
 interface OpenAiChatMessagePart {
   type?: string;
   text?: string;
+  image_url?: { url?: string } | string;
 }
 
 interface OpenAiChatMessage {
   role?: string;
   content?: string | OpenAiChatMessagePart[] | null;
 }
+
+type UserContentPart =
+  | { type: "text"; text: string }
+  | {
+      type: "image";
+      source:
+        | { type: "base64"; media_type: string; data: string }
+        | { type: "url"; url: string };
+    };
 
 interface OpenAiChatCompletionRequest {
   model?: string;
@@ -150,6 +160,51 @@ function extractTextContent(
     )
     .filter(Boolean)
     .join("\n");
+}
+
+const IMAGE_DATA_URL_RE = /^data:([^;,]+);base64,(.+)$/;
+
+function toImagePart(rawUrl: string): UserContentPart | null {
+  const match = IMAGE_DATA_URL_RE.exec(rawUrl);
+  if (match?.[1] && match[2]) {
+    return {
+      type: "image",
+      source: { type: "base64", media_type: match[1], data: match[2] },
+    };
+  }
+  if (/^https?:\/\//.test(rawUrl)) {
+    return { type: "image", source: { type: "url", url: rawUrl } };
+  }
+  return null;
+}
+
+/** OpenAI user content → Letta content parts (text and image_url). */
+function extractUserContentParts(
+  content: string | OpenAiChatMessagePart[] | null | undefined,
+): UserContentPart[] {
+  if (typeof content === "string") {
+    return content ? [{ type: "text", text: content }] : [];
+  }
+  if (!Array.isArray(content)) return [];
+  const parts: UserContentPart[] = [];
+  for (const part of content) {
+    if (!part || typeof part !== "object") continue;
+    if (part.type === "text" && typeof part.text === "string" && part.text) {
+      parts.push({ type: "text", text: part.text });
+      continue;
+    }
+    if (part.type === "image_url") {
+      const raw =
+        typeof part.image_url === "string"
+          ? part.image_url
+          : part.image_url?.url;
+      if (typeof raw === "string") {
+        const image = toImagePart(raw);
+        if (image) parts.push(image);
+      }
+    }
+  }
+  return parts;
 }
 
 function toModelCreatedTimestamp(createdAt: unknown): number {
@@ -518,7 +573,7 @@ async function runTurnViaListenerRuntime(
       messages: [
         {
           role: "user",
-          content: [{ type: "text", text: params.userText }],
+          content: params.userContent,
           otid: randomUUID(),
         },
       ],
@@ -604,12 +659,17 @@ async function handleChatCompletions(
   const lastUserIndex = transcript.findLastIndex(
     (turn) => turn.role === "user",
   );
-  const userText = lastUserIndex >= 0 ? transcript[lastUserIndex]?.text : "";
-  if (!userText) {
+  const userText =
+    (lastUserIndex >= 0 && transcript[lastUserIndex]?.text) || "";
+  const lastUserMessage = [...body.messages]
+    .reverse()
+    .find((message) => message.role === "user");
+  const userContent = extractUserContentParts(lastUserMessage?.content);
+  if (userContent.length === 0) {
     sendOpenAiError(
       response,
       400,
-      "the messages array must include a user message with text content",
+      "the messages array must include a user message with text or image content",
       "invalid_request_error",
     );
     return;
@@ -665,7 +725,7 @@ async function handleChatCompletions(
     outcome = await runTurnImpl({
       agentId: agent.id,
       conversationId,
-      userText: userText ?? "",
+      userContent,
       onLog: options.onLog,
       onAssistantText: streaming
         ? (piece) => {

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -332,15 +332,31 @@ async function resolveConversationId(
 // verbatim reply). Open WebUI sends X-OpenWebUI-Chat-Id when
 // ENABLE_FORWARD_USER_INFO_HEADERS is on; X-Letta-Chat-Key is the generic
 // escape hatch for other clients.
-const CHAT_KEY_HEADERS = ["x-letta-chat-key", "x-openwebui-chat-id"] as const;
-
-function chatKeyFromHeaders(request: HttpIncomingMessage): string | null {
-  for (const name of CHAT_KEY_HEADERS) {
-    const value = request.headers[name];
-    if (typeof value === "string" && value) return value;
-    if (Array.isArray(value) && value[0]) return value[0];
-  }
+function headerValue(
+  request: HttpIncomingMessage,
+  name: string,
+): string | null {
+  const value = request.headers[name];
+  if (typeof value === "string" && value) return value;
+  if (Array.isArray(value) && value[0]) return value[0];
   return null;
+}
+
+/**
+ * X-Letta-Chat-Key always pins chat identity. X-OpenWebUI-Chat-Id is
+ * honored only for streaming requests: Open WebUI's real chat messages
+ * always stream, while its background task requests (title/tags/follow-up
+ * generation) are non-streaming yet carry the same chat id — honoring
+ * those would route task prompts into the user's pinned conversation.
+ */
+function chatKeyFromHeaders(
+  request: HttpIncomingMessage,
+  streaming: boolean,
+): string | null {
+  const explicit = headerValue(request, "x-letta-chat-key");
+  if (explicit) return explicit;
+  if (!streaming) return null;
+  return headerValue(request, "x-openwebui-chat-id");
 }
 
 // Retry idempotency: a client retry carrying the same Idempotency-Key
@@ -355,9 +371,8 @@ function idempotencyKeyFromHeaders(
   request: HttpIncomingMessage,
 ): string | null {
   for (const name of IDEMPOTENCY_HEADERS) {
-    const value = request.headers[name];
-    if (typeof value === "string" && value) return value;
-    if (Array.isArray(value) && value[0]) return value[0];
+    const value = headerValue(request, name);
+    if (value) return value;
   }
   return null;
 }
@@ -467,7 +482,7 @@ async function handleChatCompletions(
   // one, identical transcripts are indistinguishable and any reuse
   // heuristic can cross-wire chats. Header-less requests run statelessly:
   // a fresh conversation per request, with the client transcript replayed.
-  const headerChatKey = chatKeyFromHeaders(request);
+  const headerChatKey = chatKeyFromHeaders(request, body.stream === true);
   let conversationId: string;
   try {
     if (headerChatKey) {

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -1,12 +1,31 @@
 import { createHash, randomUUID } from "node:crypto";
-import type { IncomingMessage, ServerResponse } from "node:http";
-import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
-import { sendMessageStream } from "@/agent/message";
+import type {
+  IncomingMessage as HttpIncomingMessage,
+  ServerResponse,
+} from "node:http";
 import { getBackend } from "@/backend";
+import { settingsManager } from "@/settings-manager";
 import {
   authorizeUpgrade,
   type WebsocketAuthPolicy,
 } from "@/websocket/app-server-auth";
+import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
+import { dispatchInboundMessageWhenReady } from "@/websocket/listener/inbound-dispatch";
+import { startLocalChannelListener } from "@/websocket/listener/lifecycle";
+import { getOrCreateConversationPermissionModeStateRef } from "@/websocket/listener/permission-mode";
+import { getActiveRuntime } from "@/websocket/listener/runtime";
+import {
+  type ListenerTransport,
+  LocalListenerTransport,
+} from "@/websocket/listener/transport";
+import { handleIncomingMessage } from "@/websocket/listener/turn";
+import type {
+  IncomingMessage as ListenerIncomingMessage,
+  ListenerRuntime,
+  ListenerStreamObserver,
+  ProcessQueuedTurn,
+  StartListenerOptions,
+} from "@/websocket/listener/types";
 
 // OpenAI-compatible surface for the App Server. Each Letta agent is
 // advertised as a "model"; a chat completion request routes the last user
@@ -23,17 +42,27 @@ export interface OpenAiCompatOptions {
   onLog?: (message: string) => void;
 }
 
-type SendMessageStreamImpl = (
-  ...args: Parameters<typeof sendMessageStream>
-) => Promise<AsyncIterable<LettaStreamingResponse>>;
+interface TurnOutcome {
+  text: string;
+  usage: OpenAiUsage;
+  error: string | null;
+}
 
-let sendMessageStreamImpl: SendMessageStreamImpl = sendMessageStream;
+interface RunTurnParams {
+  agentId: string;
+  conversationId: string;
+  userText: string;
+  onAssistantText?: (text: string) => void;
+  onLog?: (message: string) => void;
+}
+
+type RunTurnImpl = (params: RunTurnParams) => Promise<TurnOutcome>;
+
+let runTurnImpl: RunTurnImpl = runTurnViaListenerRuntime;
 
 /** @internal Test seam mirroring __testSetBackend. */
-export function __testSetSendMessageStreamImpl(
-  impl: SendMessageStreamImpl | null,
-): void {
-  sendMessageStreamImpl = impl ?? sendMessageStream;
+export function __testSetRunTurnImpl(impl: RunTurnImpl | null): void {
+  runTurnImpl = impl ?? runTurnViaListenerRuntime;
 }
 
 /** @internal Clears the transcript→conversation map between tests. */
@@ -92,7 +121,7 @@ function sendOpenAiError(
   });
 }
 
-async function readJsonBody(request: IncomingMessage): Promise<unknown> {
+async function readJsonBody(request: HttpIncomingMessage): Promise<unknown> {
   const chunks: Buffer[] = [];
   let total = 0;
   for await (const chunk of request) {
@@ -121,21 +150,6 @@ function extractTextContent(
     )
     .filter(Boolean)
     .join("\n");
-}
-
-function extractAssistantText(chunk: LettaStreamingResponse): string {
-  const content = (
-    chunk as { content?: string | Array<{ text?: string }> | null }
-  ).content;
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  return content
-    .map((part) =>
-      part && typeof part === "object" && typeof part.text === "string"
-        ? part.text
-        : "",
-    )
-    .join("");
 }
 
 function toModelCreatedTimestamp(createdAt: unknown): number {
@@ -280,6 +294,258 @@ async function resolveConversationId(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Turn execution over the listener v2 runtime.
+//
+// The bridge runs turns through the same dispatch path as WebSocket clients
+// (queueing → turn processor → tools/mods/permissions) and observes the
+// resulting v2 protocol stream via the runtime's in-process stream
+// observers, converting chat-completions requests into protocol inputs and
+// protocol events back into chat-completions outputs — the HTTP analogue of
+// a messaging channel.
+// ---------------------------------------------------------------------------
+
+const OPENAI_TURN_TIMEOUT_MS = 15 * 60 * 1000;
+
+const bridgeTransport = new LocalListenerTransport();
+let bridgeRuntimeStart: Promise<void> | null = null;
+
+/**
+ * Reuse the active listener runtime when one exists (a connected WS control
+ * session or channels runtime); otherwise start a socket-free local runtime,
+ * exactly like `letta server --channels` does. If a WS control client
+ * connects later it replaces the bridge-owned runtime, and subsequent
+ * requests transparently use the new active runtime.
+ */
+async function ensureListenerRuntime(
+  onLog?: (message: string) => void,
+): Promise<ListenerRuntime> {
+  const active = getActiveRuntime();
+  if (active && !active.intentionallyClosed) return active;
+
+  bridgeRuntimeStart ??= startLocalChannelListener({
+    connectionId: `openai-api-${randomUUID()}`,
+    deviceId: settingsManager.getOrCreateDeviceId(),
+    connectionName: "openai-api",
+    onConnected: () => {},
+    onError: (error) => {
+      onLog?.(`OpenAI-compat runtime error: ${error.message}`);
+    },
+  }).finally(() => {
+    bridgeRuntimeStart = null;
+  });
+  await bridgeRuntimeStart;
+
+  const runtime = getActiveRuntime();
+  if (!runtime || runtime.intentionallyClosed) {
+    throw new Error("failed to start listener runtime for OpenAI-compat API");
+  }
+  return runtime;
+}
+
+function extractDeltaText(delta: unknown): string {
+  const content = (
+    delta as { content?: string | Array<{ text?: string }> | null }
+  ).content;
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) =>
+      part && typeof part === "object" && typeof part.text === "string"
+        ? part.text
+        : "",
+    )
+    .join("");
+}
+
+async function runTurnViaListenerRuntime(
+  params: RunTurnParams,
+): Promise<TurnOutcome> {
+  const listener = await ensureListenerRuntime(params.onLog);
+  const scopedRuntime = getOrCreateScopedRuntime(
+    listener,
+    params.agentId,
+    params.conversationId,
+  );
+  // No interactive approver exists on this surface, so bridge conversations
+  // run unrestricted (Hermes-style: the API is opt-in and bearer-gated and
+  // exposes the agent's full toolset). Approvals that still arise finish the
+  // turn with an explanatory reply instead of hanging.
+  getOrCreateConversationPermissionModeStateRef(
+    listener,
+    params.agentId,
+    params.conversationId,
+  ).mode = "unrestricted";
+  // Frames emitted for this turn also flow to any attached WS client; the
+  // transport here is only the fallback destination when none is attached.
+  const socket: ListenerTransport =
+    listener.socket ?? listener.transport ?? bridgeTransport;
+
+  const dispatchOptions: StartListenerOptions = {
+    connectionId: listener.connectionId ?? "openai-api",
+    wsUrl: "",
+    deviceId: settingsManager.getOrCreateDeviceId(),
+    connectionName: listener.connectionName ?? "openai-api",
+    onConnected: () => {},
+    onDisconnected: () => {},
+    onError: (error) => {
+      params.onLog?.(`OpenAI-compat turn error: ${error.message}`);
+    },
+  };
+
+  const processQueuedTurn: ProcessQueuedTurn = async (
+    queuedTurn,
+    dequeuedBatch,
+  ) => {
+    const queuedScope = getOrCreateScopedRuntime(
+      listener,
+      queuedTurn.agentId,
+      queuedTurn.conversationId,
+    );
+    await handleIncomingMessage(
+      queuedTurn,
+      socket,
+      queuedScope,
+      undefined,
+      dispatchOptions.connectionId,
+      dequeuedBatch.batchId,
+    );
+  };
+
+  return await new Promise<TurnOutcome>((resolve) => {
+    let text = "";
+    let usage: OpenAiUsage = {
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+    };
+    let settled = false;
+    if (!listener.streamObservers) {
+      listener.streamObservers = new Set();
+    }
+    const observers = listener.streamObservers;
+
+    const finish = (error: string | null): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      observers.delete(observer);
+      resolve({ text, usage, error });
+    };
+
+    const observer: ListenerStreamObserver = (message) => {
+      if (message.runtime.agent_id !== params.agentId) return;
+      if (message.runtime.conversation_id !== params.conversationId) return;
+      if (message.type === "update_loop_status") {
+        // The turn paused for interactive input this surface cannot provide.
+        const status = (message as { loop_status?: { status?: string } })
+          .loop_status?.status;
+        if (status === "WAITING_ON_APPROVAL") {
+          if (!text) {
+            const note =
+              "The agent attempted a tool call that requires interactive approval, which this API does not support.";
+            text = note;
+            params.onAssistantText?.(note);
+          }
+          finish(null);
+        }
+        return;
+      }
+      if (message.type !== "stream_delta" || message.subagent_id) return;
+      const delta = (message as { delta?: { message_type?: string } }).delta;
+      if (!delta) return;
+      switch (delta.message_type) {
+        case "assistant_message": {
+          const piece = extractDeltaText(delta);
+          if (piece) {
+            text += piece;
+            params.onAssistantText?.(piece);
+          }
+          return;
+        }
+        case "usage_statistics": {
+          const stats = delta as {
+            prompt_tokens?: number;
+            completion_tokens?: number;
+            total_tokens?: number;
+          };
+          usage = {
+            prompt_tokens: stats.prompt_tokens ?? 0,
+            completion_tokens: stats.completion_tokens ?? 0,
+            total_tokens: stats.total_tokens ?? 0,
+          };
+          return;
+        }
+        case "stop_reason": {
+          const stopReason = (delta as { stop_reason?: string }).stop_reason;
+          // requires_approval ends a stream segment, not the turn: the turn
+          // processor evaluates the approval (auto-approving under the
+          // conversation's permission mode) and continues. Keep observing;
+          // a WAITING_ON_APPROVAL loop status marks a truly stuck turn.
+          if (stopReason === "requires_approval") return;
+          finish(null);
+          return;
+        }
+        case "loop_error": {
+          const loopError = delta as {
+            is_terminal?: boolean;
+            message?: string;
+          };
+          if (loopError.is_terminal !== false) {
+            finish(loopError.message ?? "agent turn failed");
+          }
+          return;
+        }
+        case "error_message":
+          finish(
+            (delta as { message?: string }).message ?? "agent turn failed",
+          );
+          return;
+        default:
+          return;
+      }
+    };
+    observers.add(observer);
+    const timer = setTimeout(
+      () => finish("agent turn timed out"),
+      OPENAI_TURN_TIMEOUT_MS,
+    );
+
+    const incoming: ListenerIncomingMessage = {
+      type: "message",
+      agentId: params.agentId,
+      conversationId: params.conversationId,
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: params.userText }],
+          otid: randomUUID(),
+        },
+      ],
+    };
+    try {
+      dispatchInboundMessageWhenReady({
+        listener,
+        runtime: scopedRuntime,
+        incoming,
+        socket,
+        options: dispatchOptions,
+        processQueuedTurn,
+        processIncomingMessage: handleIncomingMessage,
+        trackListenerError: (errorType, error) => {
+          params.onLog?.(
+            `OpenAI-compat listener error (${errorType}): ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        },
+      });
+    } catch (error) {
+      finish(error instanceof Error ? error.message : String(error));
+    }
+  });
+}
+
 function chatCompletionChunk(
   id: string,
   created: number,
@@ -297,7 +563,7 @@ function chatCompletionChunk(
 }
 
 async function handleChatCompletions(
-  request: IncomingMessage,
+  request: HttpIncomingMessage,
   response: ServerResponse,
   options: OpenAiCompatOptions,
 ): Promise<void> {
@@ -323,6 +589,7 @@ async function handleChatCompletions(
     );
     return;
   }
+  const model = body.model;
   if (!Array.isArray(body.messages) || body.messages.length === 0) {
     sendOpenAiError(
       response,
@@ -348,12 +615,12 @@ async function handleChatCompletions(
     return;
   }
 
-  const agent = await resolveAgentForModel(body.model);
+  const agent = await resolveAgentForModel(model);
   if (!agent) {
     sendOpenAiError(
       response,
       404,
-      `The model '${body.model}' does not exist. Use GET /v1/models to list available agents.`,
+      `The model '${model}' does not exist. Use GET /v1/models to list available agents.`,
       "invalid_request_error",
       "model_not_found",
     );
@@ -376,34 +643,6 @@ async function handleChatCompletions(
     clientClosed = true;
   });
 
-  let stream: AsyncIterable<LettaStreamingResponse>;
-  try {
-    stream = await sendMessageStreamImpl(
-      conversationId,
-      [
-        {
-          role: "user",
-          content: [{ type: "text", text: userText }],
-          otid: randomUUID(),
-        },
-      ],
-      { agentId: agent.id, streamTokens: true, background: true },
-    );
-  } catch (error) {
-    options.onLog?.(
-      `OpenAI-compat chat completion failed to start: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
-    sendOpenAiError(
-      response,
-      500,
-      "failed to start agent turn",
-      "server_error",
-    );
-    return;
-  }
-
   if (streaming) {
     response.writeHead(200, {
       "content-type": "text/event-stream",
@@ -414,62 +653,47 @@ async function handleChatCompletions(
       chatCompletionChunk(
         completionId,
         created,
-        body.model,
+        model,
         { role: "assistant", content: "" },
         null,
       ),
     );
   }
 
-  let fullText = "";
-  let usage: OpenAiUsage = {
-    prompt_tokens: 0,
-    completion_tokens: 0,
-    total_tokens: 0,
-  };
-  let streamError: string | null = null;
-
+  let outcome: TurnOutcome;
   try {
-    for await (const chunk of stream) {
-      if (clientClosed) break;
-      const messageType = (chunk as { message_type?: string }).message_type;
-      if (messageType === "assistant_message") {
-        const text = extractAssistantText(chunk);
-        if (!text) continue;
-        fullText += text;
-        if (streaming) {
-          response.write(
-            chatCompletionChunk(
-              completionId,
-              created,
-              body.model,
-              { content: text },
-              null,
-            ),
-          );
-        }
-      } else if (messageType === "usage_statistics") {
-        const stats = chunk as {
-          prompt_tokens?: number;
-          completion_tokens?: number;
-          total_tokens?: number;
-        };
-        usage = {
-          prompt_tokens: stats.prompt_tokens ?? 0,
-          completion_tokens: stats.completion_tokens ?? 0,
-          total_tokens: stats.total_tokens ?? 0,
-        };
-      } else if (messageType === "error_message") {
-        streamError =
-          (chunk as { message?: string }).message ?? "agent turn failed";
-        break;
-      } else if (messageType === "stop_reason") {
-        break;
-      }
-    }
+    outcome = await runTurnImpl({
+      agentId: agent.id,
+      conversationId,
+      userText: userText ?? "",
+      onLog: options.onLog,
+      onAssistantText: streaming
+        ? (piece) => {
+            if (clientClosed) return;
+            response.write(
+              chatCompletionChunk(
+                completionId,
+                created,
+                model,
+                { content: piece },
+                null,
+              ),
+            );
+          }
+        : undefined,
+    });
   } catch (error) {
-    streamError = error instanceof Error ? error.message : String(error);
+    const message = error instanceof Error ? error.message : String(error);
+    options.onLog?.(`OpenAI-compat chat completion failed: ${message}`);
+    outcome = {
+      text: "",
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+      error: "failed to run agent turn",
+    };
   }
+  const fullText = outcome.text;
+  const usage = outcome.usage;
+  const streamError = outcome.error;
 
   if (clientClosed) return;
 
@@ -503,7 +727,7 @@ async function handleChatCompletions(
       );
     } else {
       response.write(
-        chatCompletionChunk(completionId, created, body.model, {}, "stop"),
+        chatCompletionChunk(completionId, created, model, {}, "stop"),
       );
     }
     response.write("data: [DONE]\n\n");
@@ -521,7 +745,7 @@ async function handleChatCompletions(
     id: completionId,
     object: "chat.completion",
     created,
-    model: body.model,
+    model,
     choices: [
       {
         index: 0,
@@ -534,7 +758,7 @@ async function handleChatCompletions(
 }
 
 export async function handleOpenAiCompatRequest(
-  request: IncomingMessage,
+  request: HttpIncomingMessage,
   response: ServerResponse,
   options: OpenAiCompatOptions,
 ): Promise<void> {

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -4,29 +4,24 @@ import type {
   ServerResponse,
 } from "node:http";
 import { getBackend } from "@/backend";
-import { settingsManager } from "@/settings-manager";
 import {
   authorizeUpgrade,
   type WebsocketAuthPolicy,
 } from "@/websocket/app-server-auth";
-import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
-import { dispatchInboundMessageWhenReady } from "@/websocket/listener/inbound-dispatch";
-import { startLocalChannelListener } from "@/websocket/listener/lifecycle";
-import { getOrCreateConversationPermissionModeStateRef } from "@/websocket/listener/permission-mode";
-import { getActiveRuntime } from "@/websocket/listener/runtime";
 import {
-  type ListenerTransport,
-  LocalListenerTransport,
-} from "@/websocket/listener/transport";
-import { handleIncomingMessage } from "@/websocket/listener/turn";
-import { registerTurnObserver } from "@/websocket/listener/turn-observers";
-import type {
-  IncomingMessage as ListenerIncomingMessage,
-  ListenerRuntime,
-  ListenerStreamObserver,
-  ProcessQueuedTurn,
-  StartListenerOptions,
-} from "@/websocket/listener/types";
+  type BridgeTurnMessage,
+  runBridgeTurn,
+  type TurnOutcome,
+  type UserContentPart,
+} from "@/websocket/app-server-openai-turn";
+
+export { __testSetRunTurnImpl } from "@/websocket/app-server-openai-turn";
+
+/** @internal Clears chat-key and idempotency maps between tests. */
+export function __testResetConversationMap(): void {
+  conversationIdByTranscript.clear();
+  outcomeByIdempotencyKey.clear();
+}
 
 // OpenAI-compatible surface for the App Server. Each Letta agent is
 // advertised as a "model". Conversation identity is explicit or absent:
@@ -44,45 +39,6 @@ export interface OpenAiCompatOptions {
   onLog?: (message: string) => void;
 }
 
-interface TurnOutcome {
-  text: string;
-  usage: OpenAiUsage;
-  error: string | null;
-}
-
-interface BridgeTurnMessage {
-  role: "user" | "assistant";
-  content: UserContentPart[];
-  otid: string;
-}
-
-interface RunTurnParams {
-  agentId: string;
-  conversationId: string;
-  /** Full input for the turn: the newest message in stateful mode, or the
-   * replayed client transcript in stateless mode. */
-  messages: BridgeTurnMessage[];
-  /** OTID of a message in this turn, used to correlate the listener turn
-   * lifecycle with this request. */
-  correlationOtid: string;
-  onAssistantText?: (text: string) => void;
-  onLog?: (message: string) => void;
-}
-
-type RunTurnImpl = (params: RunTurnParams) => Promise<TurnOutcome>;
-
-let runTurnImpl: RunTurnImpl = runTurnViaListenerRuntime;
-
-/** @internal Test seam mirroring __testSetBackend. */
-export function __testSetRunTurnImpl(impl: RunTurnImpl | null): void {
-  runTurnImpl = impl ?? runTurnViaListenerRuntime;
-}
-
-/** @internal Clears the transcript→conversation map between tests. */
-export function __testResetConversationMap(): void {
-  conversationIdByTranscript.clear();
-}
-
 interface OpenAiChatMessagePart {
   type?: string;
   text?: string;
@@ -94,25 +50,10 @@ interface OpenAiChatMessage {
   content?: string | OpenAiChatMessagePart[] | null;
 }
 
-type UserContentPart =
-  | { type: "text"; text: string }
-  | {
-      type: "image";
-      source:
-        | { type: "base64"; media_type: string; data: string }
-        | { type: "url"; url: string };
-    };
-
 interface OpenAiChatCompletionRequest {
   model?: string;
   messages?: OpenAiChatMessage[];
   stream?: boolean;
-}
-
-interface OpenAiUsage {
-  prompt_tokens: number;
-  completion_tokens: number;
-  total_tokens: number;
 }
 
 export function isOpenAiCompatPath(pathname: string): boolean {
@@ -402,267 +343,44 @@ function chatKeyFromHeaders(request: HttpIncomingMessage): string | null {
   return null;
 }
 
-// ---------------------------------------------------------------------------
-// Turn execution over the listener v2 runtime.
-//
-// The bridge runs turns through the same dispatch path as WebSocket clients
-// (queueing → turn processor → tools/mods/permissions) and observes the
-// resulting v2 protocol stream via the runtime's in-process stream
-// observers, converting chat-completions requests into protocol inputs and
-// protocol events back into chat-completions outputs — the HTTP analogue of
-// a messaging channel.
-// ---------------------------------------------------------------------------
+// Retry idempotency: a client retry carrying the same Idempotency-Key
+// reuses the original request's outcome instead of running (and appending)
+// the message again. In-flight duplicates share the same turn; failed
+// outcomes are evicted so an intentional retry after an error re-runs.
+const IDEMPOTENCY_HEADERS = ["idempotency-key", "x-idempotency-key"] as const;
+const MAX_IDEMPOTENT_OUTCOMES = 1024;
+const outcomeByIdempotencyKey = new Map<string, Promise<TurnOutcome>>();
 
-const OPENAI_TURN_TIMEOUT_MS = 15 * 60 * 1000;
-
-const bridgeTransport = new LocalListenerTransport();
-let bridgeRuntimeStart: Promise<void> | null = null;
-
-/**
- * Reuse the active listener runtime when one exists (a connected WS control
- * session or channels runtime); otherwise start a socket-free local runtime,
- * exactly like `letta server --channels` does. If a WS control client
- * connects later it replaces the bridge-owned runtime, and subsequent
- * requests transparently use the new active runtime.
- */
-async function ensureListenerRuntime(
-  onLog?: (message: string) => void,
-): Promise<ListenerRuntime> {
-  const active = getActiveRuntime();
-  if (active && !active.intentionallyClosed) return active;
-
-  bridgeRuntimeStart ??= startLocalChannelListener({
-    connectionId: `openai-api-${randomUUID()}`,
-    deviceId: settingsManager.getOrCreateDeviceId(),
-    connectionName: "openai-api",
-    onConnected: () => {},
-    onError: (error) => {
-      onLog?.(`OpenAI-compat runtime error: ${error.message}`);
-    },
-  }).finally(() => {
-    bridgeRuntimeStart = null;
-  });
-  await bridgeRuntimeStart;
-
-  const runtime = getActiveRuntime();
-  if (!runtime || runtime.intentionallyClosed) {
-    throw new Error("failed to start listener runtime for OpenAI-compat API");
+function idempotencyKeyFromHeaders(
+  request: HttpIncomingMessage,
+): string | null {
+  for (const name of IDEMPOTENCY_HEADERS) {
+    const value = request.headers[name];
+    if (typeof value === "string" && value) return value;
+    if (Array.isArray(value) && value[0]) return value[0];
   }
-  return runtime;
+  return null;
 }
 
-function extractDeltaText(delta: unknown): string {
-  const content = (
-    delta as { content?: string | Array<{ text?: string }> | null }
-  ).content;
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  return content
-    .map((part) =>
-      part && typeof part === "object" && typeof part.text === "string"
-        ? part.text
-        : "",
-    )
-    .join("");
-}
-
-async function runTurnViaListenerRuntime(
-  params: RunTurnParams,
-): Promise<TurnOutcome> {
-  const listener = await ensureListenerRuntime(params.onLog);
-  const scopedRuntime = getOrCreateScopedRuntime(
-    listener,
-    params.agentId,
-    params.conversationId,
-  );
-  // No interactive approver exists on this surface, so bridge conversations
-  // run unrestricted (Hermes-style: the API is opt-in and bearer-gated and
-  // exposes the agent's full toolset). Approvals that still arise finish the
-  // turn with an explanatory reply instead of hanging.
-  getOrCreateConversationPermissionModeStateRef(
-    listener,
-    params.agentId,
-    params.conversationId,
-  ).mode = "unrestricted";
-  // Frames emitted for this turn also flow to any attached WS client; the
-  // transport here is only the fallback destination when none is attached.
-  const socket: ListenerTransport =
-    listener.socket ?? listener.transport ?? bridgeTransport;
-
-  const dispatchOptions: StartListenerOptions = {
-    connectionId: listener.connectionId ?? "openai-api",
-    wsUrl: "",
-    deviceId: settingsManager.getOrCreateDeviceId(),
-    connectionName: listener.connectionName ?? "openai-api",
-    onConnected: () => {},
-    onDisconnected: () => {},
-    onError: (error) => {
-      params.onLog?.(`OpenAI-compat turn error: ${error.message}`);
-    },
-  };
-
-  const processQueuedTurn: ProcessQueuedTurn = async (
-    queuedTurn,
-    dequeuedBatch,
-  ) => {
-    const queuedScope = getOrCreateScopedRuntime(
-      listener,
-      queuedTurn.agentId,
-      queuedTurn.conversationId,
-    );
-    await handleIncomingMessage(
-      queuedTurn,
-      socket,
-      queuedScope,
-      undefined,
-      dispatchOptions.connectionId,
-      dequeuedBatch.batchId,
-    );
-  };
-
-  return await new Promise<TurnOutcome>((resolve) => {
-    let text = "";
-    let usage: OpenAiUsage = {
-      prompt_tokens: 0,
-      completion_tokens: 0,
-      total_tokens: 0,
-    };
-    // The request settles from ITS OWN turn's lifecycle (turn-observers,
-    // keyed by OTID), never from raw stream events: stop_reason ends a
-    // stream segment before the listener decides on retries/approvals, and
-    // usage can arrive after it. Stream deltas are accumulated only while
-    // this request's turn is active, so queued requests and WS-initiated
-    // turns in the same conversation never bleed into this response.
-    let turnActive = false;
-    let recordedError: string | null = null;
-    let settled = false;
-    let unregisterTurnObserver: () => void = () => {};
-    if (!listener.streamObservers) {
-      listener.streamObservers = new Set();
+function rememberIdempotentOutcome(
+  key: string,
+  promise: Promise<TurnOutcome>,
+): void {
+  outcomeByIdempotencyKey.delete(key);
+  outcomeByIdempotencyKey.set(key, promise);
+  while (outcomeByIdempotencyKey.size > MAX_IDEMPOTENT_OUTCOMES) {
+    const oldest = outcomeByIdempotencyKey.keys().next().value;
+    if (oldest === undefined) break;
+    outcomeByIdempotencyKey.delete(oldest);
+  }
+  const evict = () => {
+    if (outcomeByIdempotencyKey.get(key) === promise) {
+      outcomeByIdempotencyKey.delete(key);
     }
-    const observers = listener.streamObservers;
-
-    const finish = (error: string | null): void => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      observers.delete(observer);
-      unregisterTurnObserver();
-      resolve({ text, usage, error });
-    };
-
-    const observer: ListenerStreamObserver = (message) => {
-      if (message.type === "runtime_stopped") {
-        finish(
-          recordedError ??
-            "server runtime was replaced while the request was in flight",
-        );
-        return;
-      }
-      if (message.runtime.agent_id !== params.agentId) return;
-      if (message.runtime.conversation_id !== params.conversationId) return;
-      if (!turnActive) return;
-      if (message.type === "update_loop_status") {
-        // The turn paused for interactive input this surface cannot provide.
-        const status = (message as { loop_status?: { status?: string } })
-          .loop_status?.status;
-        if (status === "WAITING_ON_APPROVAL") {
-          if (!text) {
-            const note =
-              "The agent attempted a tool call that requires interactive approval, which this API does not support.";
-            text = note;
-            params.onAssistantText?.(note);
-          }
-          finish(null);
-        }
-        return;
-      }
-      if (message.type !== "stream_delta" || message.subagent_id) return;
-      const delta = (message as { delta?: { message_type?: string } }).delta;
-      if (!delta) return;
-      switch (delta.message_type) {
-        case "assistant_message": {
-          const piece = extractDeltaText(delta);
-          if (piece) {
-            text += piece;
-            params.onAssistantText?.(piece);
-          }
-          return;
-        }
-        case "usage_statistics": {
-          const stats = delta as {
-            prompt_tokens?: number;
-            completion_tokens?: number;
-            total_tokens?: number;
-          };
-          usage = {
-            prompt_tokens: stats.prompt_tokens ?? 0,
-            completion_tokens: stats.completion_tokens ?? 0,
-            total_tokens: stats.total_tokens ?? 0,
-          };
-          return;
-        }
-        case "loop_error": {
-          // Recorded, not settled: the listener may still retry. The turn
-          // lifecycle end decides the final outcome.
-          const loopError = delta as {
-            is_terminal?: boolean;
-            message?: string;
-          };
-          if (loopError.is_terminal !== false) {
-            recordedError = loopError.message ?? "agent turn failed";
-          }
-          return;
-        }
-        case "error_message":
-          recordedError =
-            (delta as { message?: string }).message ?? "agent turn failed";
-          return;
-        default:
-          return;
-      }
-    };
-    observers.add(observer);
-    unregisterTurnObserver = registerTurnObserver(params.correlationOtid, {
-      onStarted: () => {
-        turnActive = true;
-      },
-      onFinished: () => {
-        finish(recordedError);
-      },
-    });
-    const timer = setTimeout(
-      () => finish(recordedError ?? "agent turn timed out"),
-      OPENAI_TURN_TIMEOUT_MS,
-    );
-
-    const incoming: ListenerIncomingMessage = {
-      type: "message",
-      agentId: params.agentId,
-      conversationId: params.conversationId,
-      messages: params.messages,
-    };
-    try {
-      dispatchInboundMessageWhenReady({
-        listener,
-        runtime: scopedRuntime,
-        incoming,
-        socket,
-        options: dispatchOptions,
-        processQueuedTurn,
-        processIncomingMessage: handleIncomingMessage,
-        trackListenerError: (errorType, error) => {
-          params.onLog?.(
-            `OpenAI-compat listener error (${errorType}): ${
-              error instanceof Error ? error.message : String(error)
-            }`,
-          );
-        },
-      });
-    } catch (error) {
-      finish(error instanceof Error ? error.message : String(error));
-    }
-  });
+  };
+  promise.then((outcome) => {
+    if (outcome.error) evict();
+  }, evict);
 }
 
 function chatCompletionChunk(
@@ -831,29 +549,57 @@ async function handleChatCompletions(
     );
   }
 
+  const idempotencyHeader = idempotencyKeyFromHeaders(request);
+  const idempotencyKey = idempotencyHeader
+    ? `${agent.id}:${headerChatKey ?? ""}:${idempotencyHeader}`
+    : null;
+
   let outcome: TurnOutcome;
   try {
-    outcome = await runTurnImpl({
-      agentId: agent.id,
-      conversationId,
-      messages: turnMessages,
-      correlationOtid,
-      onLog: options.onLog,
-      onAssistantText: streaming
-        ? (piece) => {
-            if (clientClosed) return;
-            response.write(
-              chatCompletionChunk(
-                completionId,
-                created,
-                model,
-                { content: piece },
-                null,
-              ),
-            );
-          }
-        : undefined,
-    });
+    let turnPromise = idempotencyKey
+      ? outcomeByIdempotencyKey.get(idempotencyKey)
+      : undefined;
+    const ownsTurn = !turnPromise;
+    if (!turnPromise) {
+      turnPromise = runBridgeTurn({
+        agentId: agent.id,
+        conversationId,
+        messages: turnMessages,
+        correlationOtid,
+        onLog: options.onLog,
+        onAssistantText: streaming
+          ? (piece) => {
+              if (clientClosed) return;
+              response.write(
+                chatCompletionChunk(
+                  completionId,
+                  created,
+                  model,
+                  { content: piece },
+                  null,
+                ),
+              );
+            }
+          : undefined,
+      });
+      if (idempotencyKey) {
+        rememberIdempotentOutcome(idempotencyKey, turnPromise);
+      }
+    }
+    outcome = await turnPromise;
+    // Replayed outcomes stream their text as one chunk: the incremental
+    // pieces went to the original request's response.
+    if (!ownsTurn && streaming && outcome.text && !clientClosed) {
+      response.write(
+        chatCompletionChunk(
+          completionId,
+          created,
+          model,
+          { content: outcome.text },
+          null,
+        ),
+      );
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     options.onLog?.(`OpenAI-compat chat completion failed: ${message}`);

--- a/src/websocket/app-server.ts
+++ b/src/websocket/app-server.ts
@@ -14,6 +14,10 @@ import {
   policyFromSettings,
 } from "@/websocket/app-server-auth";
 import {
+  handleOpenAiCompatRequest,
+  isOpenAiCompatPath,
+} from "@/websocket/app-server-openai";
+import {
   attachOpenListenerSocket,
   createRuntime,
   stopRuntime,
@@ -47,6 +51,8 @@ export interface StartAppServerOptions {
   listen?: string;
   websocketAuth?: AppServerWebsocketAuthSettings;
   connectionName?: string;
+  /** Serve OpenAI-compatible /v1/models and /v1/chat/completions routes. */
+  openaiApi?: boolean;
   onListening?: (info: AppServerListeningInfo) => void;
   onLog?: (message: string) => void;
   /** @internal Test override for the liveness ping cadence (ms). */
@@ -365,6 +371,13 @@ export async function startAppServer(
     if (requestUrl.pathname === "/healthz") {
       response.writeHead(200, { "content-type": "text/plain" });
       response.end("ok\n");
+      return;
+    }
+    if (options.openaiApi && isOpenAiCompatPath(requestUrl.pathname)) {
+      void handleOpenAiCompatRequest(request, response, {
+        authPolicy,
+        onLog: options.onLog,
+      });
       return;
     }
     response.writeHead(404);

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -103,6 +103,7 @@ import {
   safeEmitWsEvent,
   setActiveRuntime,
 } from "./runtime";
+import { notifyStreamObserversRuntimeStopped } from "./stream-observers";
 import {
   getListenerTransportKind,
   isListenerTransportOpen,
@@ -110,6 +111,7 @@ import {
   LocalListenerTransport,
 } from "./transport";
 import { handleIncomingMessage } from "./turn";
+import { escapeTaskNotificationSummary } from "./turn-events";
 import type {
   ConversationRuntime,
   IncomingMessage,
@@ -122,13 +124,6 @@ import {
   scheduleListenerWarmupsAfterSync,
 } from "./warmup";
 import { stopAllWorktreeWatchers } from "./worktree-watcher";
-
-function escapeTaskNotificationSummary(summary: string): string {
-  return summary
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
 
 function trackListenerError(
   errorType: string,
@@ -918,6 +913,7 @@ export function stopRuntime(
   runtime: ListenerRuntime,
   suppressCallbacks: boolean,
 ): void {
+  notifyStreamObserversRuntimeStopped(runtime);
   disposeListenerModAdapter(runtime);
   rejectPendingExternalToolCalls(runtime, "Listener runtime stopped");
   setMessageQueueAdder(null); // Clear bridge for ALL stop paths

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -64,6 +64,7 @@ import {
   resolveScopedAgentId,
   resolveScopedConversationId,
 } from "./scope";
+import { notifyStreamObservers } from "./stream-observers";
 import { isListenerTransportOpen, type ListenerTransport } from "./transport";
 import type {
   ConversationRuntime,
@@ -631,20 +632,15 @@ export function emitProtocolV2Message(
     }
   }
 
-  if (!isListenerTransportOpen(targetSocket)) {
-    return;
-  }
   const runtimeScope = resolveRuntimeScope(
     listener,
     getScopeForRuntime(runtime, scope),
   );
-  if (!runtimeScope) {
-    return;
-  }
+  if (!runtimeScope) return;
+  notifyStreamObservers(listener, message, runtimeScope);
+  if (!isListenerTransportOpen(targetSocket)) return;
   const eventSeq = nextEventSeq(listener);
-  if (eventSeq === null) {
-    return;
-  }
+  if (eventSeq === null) return;
   const outbound: WsProtocolMessage = {
     ...message,
     runtime: runtimeScope,

--- a/src/websocket/listener/stream-observers.ts
+++ b/src/websocket/listener/stream-observers.ts
@@ -1,0 +1,26 @@
+import type { ListenerRuntime, ObservedProtocolV2Message } from "./types";
+
+/**
+ * Notify in-process observers (e.g. the OpenAI-compat HTTP bridge) of an
+ * outbound v2 protocol message. Observers consume protocol messages without
+ * owning a transport, so callers must notify before any socket-open gate: a
+ * closed or absent socket must not starve them.
+ */
+export function notifyStreamObservers(
+  listener: ListenerRuntime | null,
+  message: Record<string, unknown>,
+  runtimeScope: ObservedProtocolV2Message["runtime"],
+): void {
+  if (!listener?.streamObservers?.size) return;
+  const observed = {
+    ...message,
+    runtime: runtimeScope,
+  } as ObservedProtocolV2Message;
+  for (const observer of listener.streamObservers) {
+    try {
+      observer(observed);
+    } catch (error) {
+      console.error("[Listen V2] Stream observer failed", error);
+    }
+  }
+}

--- a/src/websocket/listener/stream-observers.ts
+++ b/src/websocket/listener/stream-observers.ts
@@ -24,3 +24,27 @@ export function notifyStreamObservers(
     }
   }
 }
+
+/**
+ * Deliver a synthetic terminal event when a runtime is stopped (e.g. a WS
+ * control client replacing a bridge-owned runtime). Without this, in-flight
+ * observers would wait on turns that will never emit again. The observer set
+ * is cleared afterwards: the runtime is dead.
+ */
+export function notifyStreamObserversRuntimeStopped(
+  listener: ListenerRuntime,
+): void {
+  if (!listener.streamObservers?.size) return;
+  const observed = {
+    type: "runtime_stopped",
+    runtime: {},
+  } as ObservedProtocolV2Message;
+  for (const observer of [...listener.streamObservers]) {
+    try {
+      observer(observed);
+    } catch (error) {
+      console.error("[Listen V2] Stream observer failed on stop", error);
+    }
+  }
+  listener.streamObservers.clear();
+}

--- a/src/websocket/listener/turn-events.ts
+++ b/src/websocket/listener/turn-events.ts
@@ -24,7 +24,7 @@ import { emitCanonicalMessageDelta } from "./protocol-outbound";
 import type { ListenerTransport } from "./transport";
 import type { ConversationRuntime, ListenerRuntime } from "./types";
 
-function escapeTaskNotificationSummary(summary: string): string {
+export function escapeTaskNotificationSummary(summary: string): string {
   return summary
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")

--- a/src/websocket/listener/turn-observers.test.ts
+++ b/src/websocket/listener/turn-observers.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { notifyStreamObserversRuntimeStopped } from "./stream-observers";
+import {
+  notifyTurnFinished,
+  notifyTurnStarted,
+  registerTurnObserver,
+} from "./turn-observers";
+import type { IncomingMessage, ListenerRuntime } from "./types";
+
+function incoming(otids: Array<string | undefined>): IncomingMessage {
+  return {
+    type: "message",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+    messages: otids.map((otid) => ({
+      role: "user" as const,
+      content: "hi",
+      ...(otid ? { otid } : {}),
+    })),
+  };
+}
+
+describe("turn observers", () => {
+  test("notifies hooks for matching OTIDs only", () => {
+    const events: string[] = [];
+    const unregister = registerTurnObserver("otid-a", {
+      onStarted: () => events.push("started"),
+      onFinished: () => events.push("finished"),
+    });
+
+    notifyTurnStarted(incoming(["otid-other"]));
+    notifyTurnFinished(incoming(["otid-other"]));
+    expect(events).toEqual([]);
+
+    notifyTurnStarted(incoming(["otid-a"]));
+    notifyTurnFinished(incoming(["otid-a"]));
+    expect(events).toEqual(["started", "finished"]);
+
+    unregister();
+    notifyTurnStarted(incoming(["otid-a"]));
+    expect(events).toEqual(["started", "finished"]);
+  });
+
+  test("matches any OTID in a batched turn", () => {
+    const events: string[] = [];
+    const unregister = registerTurnObserver("otid-b", {
+      onFinished: () => events.push("finished"),
+    });
+    notifyTurnFinished(incoming(["otid-x", "otid-b"]));
+    expect(events).toEqual(["finished"]);
+    unregister();
+  });
+});
+
+describe("runtime-stopped stream notification", () => {
+  test("notifies all observers with a terminal event and clears the set", () => {
+    const seen: string[] = [];
+    const listener = {
+      streamObservers: new Set([
+        (message: { type: string }) => seen.push(`a:${message.type}`),
+        (message: { type: string }) => seen.push(`b:${message.type}`),
+      ]),
+    } as unknown as ListenerRuntime;
+
+    notifyStreamObserversRuntimeStopped(listener);
+    expect(seen).toEqual(["a:runtime_stopped", "b:runtime_stopped"]);
+    expect(listener.streamObservers?.size).toBe(0);
+  });
+});

--- a/src/websocket/listener/turn-observers.ts
+++ b/src/websocket/listener/turn-observers.ts
@@ -1,0 +1,61 @@
+import type { IncomingMessage } from "./types";
+
+/**
+ * Turn lifecycle observers keyed by message OTID.
+ *
+ * In-process protocol consumers (e.g. the OpenAI-compat HTTP bridge) need to
+ * know when the specific turn carrying THEIR message starts and finishes.
+ * Closure identity cannot provide this: the queue pump drains queued turns
+ * with whichever processQueuedTurn closure scheduled it, so a turn may be
+ * processed by another caller's closure. The turn processor itself notifies
+ * this registry for every turn, keyed by the OTIDs of the messages it
+ * carries, making correlation independent of the dispatch path.
+ */
+export interface TurnLifecycleHooks {
+  onStarted?: () => void;
+  onFinished: () => void;
+}
+
+const hooksByOtid = new Map<string, TurnLifecycleHooks>();
+
+/** Returns an unregister function. */
+export function registerTurnObserver(
+  otid: string,
+  hooks: TurnLifecycleHooks,
+): () => void {
+  hooksByOtid.set(otid, hooks);
+  return () => {
+    if (hooksByOtid.get(otid) === hooks) {
+      hooksByOtid.delete(otid);
+    }
+  };
+}
+
+function otidsOf(msg: IncomingMessage): string[] {
+  const otids: string[] = [];
+  for (const message of msg.messages) {
+    const otid = (message as { otid?: string | null }).otid;
+    if (typeof otid === "string" && otid) otids.push(otid);
+  }
+  return otids;
+}
+
+export function notifyTurnStarted(msg: IncomingMessage): void {
+  for (const otid of otidsOf(msg)) {
+    try {
+      hooksByOtid.get(otid)?.onStarted?.();
+    } catch (error) {
+      console.error("[Listen V2] Turn observer onStarted failed", error);
+    }
+  }
+}
+
+export function notifyTurnFinished(msg: IncomingMessage): void {
+  for (const otid of otidsOf(msg)) {
+    try {
+      hooksByOtid.get(otid)?.onFinished();
+    } catch (error) {
+      console.error("[Listen V2] Turn observer onFinished failed", error);
+    }
+  }
+}

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -78,6 +78,7 @@ import {
   updateTurnInputMessagesPreservingOtids,
 } from "./turn-input-state";
 import type { TurnLease } from "./turn-lifecycle";
+import { notifyTurnFinished, notifyTurnStarted } from "./turn-observers";
 import { createTurnInputSender } from "./turn-send";
 import { prepareListenerTurn } from "./turn-setup";
 import { setTurnLoopStatus } from "./turn-status";
@@ -86,6 +87,36 @@ import { seedInboundUserTranscriptLines } from "./turn-transcript";
 import type { ConversationRuntime, IncomingMessage } from "./types";
 
 export async function handleIncomingMessage(
+  msg: IncomingMessage,
+  socket: ListenerTransport,
+  runtime: ConversationRuntime,
+  onStatusChange?: (
+    status: "idle" | "receiving" | "processing",
+    connectionId: string,
+  ) => void,
+  connectionId?: string,
+  dequeuedBatchId: string = `batch-direct-${crypto.randomUUID()}`,
+  existingTurnLease?: TurnLease,
+): Promise<void> {
+  // Notify OTID-keyed turn observers (see turn-observers.ts) around the
+  // whole turn, regardless of which dispatch closure invoked it.
+  notifyTurnStarted(msg);
+  try {
+    await handleIncomingMessageInner(
+      msg,
+      socket,
+      runtime,
+      onStatusChange,
+      connectionId,
+      dequeuedBatchId,
+      existingTurnLease,
+    );
+  } finally {
+    notifyTurnFinished(msg);
+  }
+}
+
+async function handleIncomingMessageInner(
   msg: IncomingMessage,
   socket: ListenerTransport,
   runtime: ConversationRuntime,

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -86,6 +86,22 @@ export type ProcessQueuedTurn = (
   dequeuedBatch: DequeuedBatch,
 ) => Promise<void>;
 
+/**
+ * An outbound v2 protocol message as delivered to in-process stream
+ * observers: the pre-envelope message payload plus its resolved runtime
+ * scope (agent/conversation) and optional subagent attribution.
+ */
+export interface ObservedProtocolV2Message {
+  type: string;
+  runtime: { agent_id?: string | null; conversation_id?: string | null };
+  subagent_id?: string;
+  [key: string]: unknown;
+}
+
+export type ListenerStreamObserver = (
+  message: ObservedProtocolV2Message,
+) => void;
+
 export interface PendingExternalToolCall {
   resolve: (result: ExternalToolCallResult) => void;
   reject: (error: Error) => void;
@@ -265,6 +281,13 @@ export type ListenerRuntime = {
     } | null>
   >;
   lastEmittedStatus: "idle" | "receiving" | "processing" | null;
+  /**
+   * In-process observers of outbound v2 protocol messages (e.g. the
+   * OpenAI-compat HTTP bridge). Each observer receives every emitted message
+   * with its resolved runtime scope, independent of socket routing, so
+   * protocol consumers can exist without owning a WebSocket.
+   */
+  streamObservers?: Set<ListenerStreamObserver>;
   /** Unsubscribe from subagent state store (set on socket open, cleared on close). */
   _unsubscribeSubagentState?: (() => void) | undefined;
   /** Unsubscribe from subagent stream events (set on socket open, cleared on close). */


### PR DESCRIPTION
## What

A self-contained package at `acp/` that exposes a Letta agent as an [Agent Client Protocol](https://agentclientprotocol.com) agent over stdio, so ACP clients (Zed, JetBrains, marimo, …) can drive a stateful Letta agent. Built on `@letta-ai/letta-agent-sdk` + the official `@agentclientprotocol/sdk`.

## Why protocol v1 (not v2)

- v1 is the only stable ACP wire protocol; every shipping client (including Zed) negotiates `protocolVersion: 1`.
- v2 exists only as an unstable schema surface (`@agentclientprotocol/sdk` ships it under `experimental/v2`) — MCP-aligned content types, `auth/*` regrouping, unified session lifecycle — with no stable release or client support yet.
- When v2 stabilizes, migration is mostly mechanical (the SDK includes a `dual-version-agent` example for serving both).

## How it maps

- Each ACP session → a new conversation (`createSession`) on **one underlying Letta agent**, rooted at the ACP `cwd`, so the agent's memory persists across sessions and editors.
- SDK stream messages → `session/update`: `assistant` → message chunks, `reasoning` → thought chunks, `tool_call`/`tool_result` → tool call updates with kind, title, and file locations.
- The SDK's `canUseTool` callback → ACP `session/request_permission` (allow once / always allow this session / reject).
- `session/cancel` → `session.abort()` → `stopReason: cancelled`.

### The approval_conflict wrinkle

The app-server transport ends a turn with a recoverable `approval_conflict` result whenever a tool needs user approval; the approval resolves concurrently over the control channel, and the resumed run streams **without a second terminal result message**. The adapter therefore pumps recovery stream rounds after such a result and ends the turn when the agent loop reports idle (`WAITING_ON_INPUT`). Worth noting for SDK consumers generally: the plain `send()`/`stream()` pattern cannot complete an approval-gated turn on its own.

## Choosing which Letta agent

ACP has no native "pick an agent" step — one server = one agent from the client's perspective. The adapter resolves its agent at launch:

- `LETTA_AGENT_ID` set → all sessions use that agent (recommended; persistent memory).
- Unset → it creates an agent on first session and logs the id to stderr.

To use multiple Letta agents from Zed, add one `agent_servers` entry per agent — Zed's agent picker then acts as the agent selector:

```json
"agent_servers": {
  "Letta (Zed)":  { "command": "bun", "args": ["<repo>/acp/src/index.ts"], "env": { "LETTA_AGENT_ID": "agent-..." } },
  "Letta (Docs)": { "command": "bun", "args": ["<repo>/acp/src/index.ts"], "env": { "LETTA_AGENT_ID": "agent-..." } }
}
```

Possible follow-up: advertise Letta agents as ACP session modes in the `session/new` response, giving an in-editor agent dropdown without touching settings.

Other config: `LETTA_ACP_BACKEND` (`local` default / `remote` / `cloud`), `LETTA_ACP_MODEL`, `LETTA_ACP_PERMISSION_MODE` (`standard` / `acceptEdits` / `unrestricted`). See `acp/README.md`.

## Testing

Verified end-to-end against a real local Letta agent using the bundled ACP test client (`bun test-client.ts`, built on the same official SDK):

- prompt/response: v1 negotiation → session → streamed reply → `end_turn`
- tool call + approval: permission round-trip, file created, tool call `completed` (~7.5s)
- rejection: tool call `failed`, no side effect, graceful finish
- cancellation: `session/cancel` mid-turn → `stopReason: cancelled`

Also verified the exact Zed spawn shape (absolute paths, foreign cwd, raw JSON-RPC on stdio) returns a correct `initialize` response.