### PR TITLE
fix(skills): fetch Letta docs directly

### DIFF
--- a/src/skills/builtin/letta-guide/SKILL.md
+++ b/src/skills/builtin/letta-guide/SKILL.md
@@ -19,16 +19,33 @@ how to answer questions about Letta correctly.
    backend-aware active configuration report. Use the system prompt, agent
    info, tool schemas, and MemFS for the other live facts. Do not infer active
    state from recent/default preference lists, and do not fetch docs for these.
-2. **Fetch the docs index.** For product questions, fetch
-   `https://docs.letta.com/llms.txt` — a curated index of every current
-   documentation page with descriptions. Pick the most relevant page URLs.
-3. **Fetch the specific pages.** Append `/index.md` to any docs URL for the
-   canonical LLM-friendly markdown version (e.g.
-   `https://docs.letta.com/configuration/models/index.md`). Read the page,
-   then answer. Cite the doc URL(s) you used so the user can go deeper.
-4. **If the docs are unreachable**, say so explicitly, give your best answer,
-   and clearly mark it as possibly out of date with a link to
-   https://docs.letta.com. Never silently fall back to memory.
+2. **Fetch the docs index directly.** For product questions, run:
+
+   ```bash
+   node <SKILL_DIR>/scripts/fetch-letta-docs.mjs
+   ```
+
+   The helper retrieves `https://docs.letta.com/llms.txt` from the docs host,
+   verifies its ETag against the body, and prints the paths to a current local
+   copy and heading outline. Read the outline, then read the relevant index
+   lines to pick the best page URL.
+3. **Fetch the specific page directly.** Pass the exact canonical URL from the
+   index back to the same helper, for example:
+
+   ```bash
+   node <SKILL_DIR>/scripts/fetch-letta-docs.mjs \
+     --docs-url "https://docs.letta.com/configuration/models/index.md"
+   ```
+
+   Read the returned docs path before running the helper for another URL. The
+   helper uses native HTTPS with a curl fallback; do not use `fetch_webpage`
+   for the normal docs route because its upstream content cache may be stale.
+   Cite the public doc URL so the user can go deeper.
+4. **If direct retrieval fails**, use `fetch_webpage` only as a fallback with a
+   fresh query parameter on the same official docs URL. Disclose that the
+   fallback may be stale. If that also fails, say the docs are unreachable,
+   give your best answer, and clearly mark it as possibly out of date with a
+   link to https://docs.letta.com. Never silently fall back to memory.
 
 ## Hard rules
 
@@ -68,9 +85,9 @@ rather than leaving the user stuck.
 
 ## Caching
 
-Cache fetched pages under the Letta home directory: `~/.letta/docs-cache/`
-(Windows: `%USERPROFILE%\.letta\docs-cache\`). Resolve `~` to an absolute
-path before passing paths to file tools — they do not expand it. Reuse cached
-pages within a session; refetch `llms.txt` when the cached copy is older than
-about a day.
+The helper owns the cache. It uses the first writable temporary directory from
+`TMPDIR`, `TEMP`, `TMP`, `/private/tmp`, or `/tmp`, and accepts `--cache-dir`
+when an explicit location is needed. Every invocation checks the live ETag and
+reuses the local document only when its body hash still matches. Do not create
+or manage a second cache yourself.
 

--- a/src/skills/builtin/letta-guide/scripts/fetch-letta-docs.mjs
+++ b/src/skills/builtin/letta-guide/scripts/fetch-letta-docs.mjs
@@ -1,0 +1,440 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import {
+  access,
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+const DEFAULT_DOCS_URL = "https://docs.letta.com/llms.txt";
+const CACHE_DIRECTORY_NAME = "letta-docs-cache";
+const DOCUMENT_NAME = "letta-docs.md";
+const OUTLINE_NAME = "letta-docs.outline.md";
+const USER_AGENT = "letta-guide";
+const runFile = promisify(execFile);
+
+class DocsFetchError extends Error {
+  constructor(message, cause) {
+    super(message, cause ? { cause } : undefined);
+    this.name = "DocsFetchError";
+  }
+}
+
+function bodyDigest(body) {
+  return createHash("md5").update(body).digest("hex");
+}
+
+function hasProxyEnvironment() {
+  return ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"].some(
+    (key) => Boolean(process.env[key]),
+  );
+}
+
+function temporaryFile(directory, extension) {
+  return path.join(
+    directory,
+    `.letta-docs-${process.pid}-${Date.now()}-${randomBytes(5).toString("hex")}${extension}`,
+  );
+}
+
+function parseHeaderDump(raw) {
+  const responseBlocks = raw
+    .replace(/\r\n/g, "\n")
+    .trim()
+    .split(/\n\n+/)
+    .filter((block) => block.startsWith("HTTP/"));
+  const finalBlock = responseBlocks.at(-1);
+  if (!finalBlock) {
+    throw new DocsFetchError("curl returned no HTTP response headers.");
+  }
+
+  const [statusLine, ...lines] = finalBlock.split("\n");
+  const status = Number(/^HTTP\/\S+\s+(\d{3})/.exec(statusLine)?.[1]);
+  if (!Number.isInteger(status)) {
+    throw new DocsFetchError(
+      `curl returned an invalid status line: ${statusLine}`,
+    );
+  }
+
+  const headers = new Map();
+  for (const line of lines) {
+    const separator = line.indexOf(":");
+    if (separator < 1) continue;
+    headers.set(
+      line.slice(0, separator).trim().toLowerCase(),
+      line.slice(separator + 1).trim(),
+    );
+  }
+  return { headers, status };
+}
+
+async function curlRequest(url, method, cacheDirectory, timeoutMs) {
+  const headersFile = temporaryFile(cacheDirectory, ".headers");
+  const bodyFile = temporaryFile(cacheDirectory, ".body");
+  const executables =
+    process.platform === "win32" ? ["curl.exe", "curl"] : ["curl"];
+  const argumentsList = [
+    "--silent",
+    "--show-error",
+    "--location",
+    "--dump-header",
+    headersFile,
+    "--output",
+    bodyFile,
+    "--user-agent",
+    USER_AGENT,
+    "--max-time",
+    String(Math.max(1, Math.ceil(timeoutMs / 1000))),
+    ...(method === "HEAD" ? ["--head"] : ["--request", method]),
+    url,
+  ];
+
+  let failure;
+  for (const executable of executables) {
+    try {
+      await runFile(executable, argumentsList, { windowsHide: true });
+      const [rawHeaders, body] = await Promise.all([
+        readFile(headersFile, "utf8"),
+        readFile(bodyFile, "utf8"),
+      ]);
+      return { ...parseHeaderDump(rawHeaders), body };
+    } catch (error) {
+      failure = error;
+      if (error?.code !== "ENOENT") break;
+    } finally {
+      await Promise.all([
+        rm(headersFile, { force: true }),
+        rm(bodyFile, { force: true }),
+      ]);
+    }
+  }
+  throw new DocsFetchError(
+    failure?.code === "ENOENT"
+      ? "curl is unavailable in this environment."
+      : `curl could not ${method} ${url}.`,
+    failure,
+  );
+}
+
+async function nodeRequest(url, method, _cacheDirectory, timeoutMs) {
+  if (typeof fetch !== "function") {
+    throw new DocsFetchError("Native fetch requires Node.js 18 or newer.");
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, {
+      method,
+      headers: { "User-Agent": USER_AGENT },
+      redirect: "follow",
+      signal: controller.signal,
+    });
+    const headers = new Map();
+    response.headers.forEach((value, key) => {
+      headers.set(key.toLowerCase(), value);
+    });
+    return {
+      body: method === "HEAD" ? "" : await response.text(),
+      headers,
+      status: response.status,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function requestDocument(url, method, cacheDirectory, timeoutMs) {
+  const transports = hasProxyEnvironment()
+    ? [curlRequest, nodeRequest]
+    : [nodeRequest, curlRequest];
+  let failure;
+  for (const transport of transports) {
+    try {
+      const result = await transport(url, method, cacheDirectory, timeoutMs);
+      if (result.status < 200 || result.status >= 300) {
+        throw new DocsFetchError(
+          `${method} ${url} failed with HTTP ${result.status}.`,
+        );
+      }
+      return result;
+    } catch (error) {
+      failure = error;
+    }
+  }
+  throw new DocsFetchError(`${method} ${url} could not be fetched.`, failure);
+}
+
+function digestFromEtag(headers) {
+  const etag = headers.get("etag") ?? "";
+  const digest = /^(?:W\/)?"([a-f0-9]{32})"$/i.exec(etag)?.[1];
+  if (!digest) {
+    throw new DocsFetchError(
+      "Letta docs response is missing a content-MD5 ETag.",
+    );
+  }
+  return digest.toLowerCase();
+}
+
+async function nearestExistingDirectory(candidate) {
+  let current = path.resolve(candidate);
+  while (true) {
+    try {
+      return (await stat(current)).isDirectory() ? current : null;
+    } catch (error) {
+      if (error?.code !== "ENOENT") return null;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+async function writableCacheDirectory(candidate) {
+  if (!candidate) return null;
+  const resolved = path.resolve(candidate);
+  try {
+    const existing = await stat(resolved);
+    if (!existing.isDirectory()) return null;
+  } catch (error) {
+    if (error?.code !== "ENOENT") return null;
+  }
+  const existingParent = await nearestExistingDirectory(resolved);
+  if (!existingParent) return null;
+  try {
+    await access(existingParent, fsConstants.W_OK | fsConstants.X_OK);
+    return resolved;
+  } catch {
+    return null;
+  }
+}
+
+async function selectCacheDirectory(override) {
+  if (override) return writableCacheDirectory(override);
+  const candidates = [process.env.TMPDIR, process.env.TEMP, process.env.TMP]
+    .filter(Boolean)
+    .map((directory) => path.join(directory, CACHE_DIRECTORY_NAME));
+  if (process.platform !== "win32") {
+    candidates.push(
+      path.join("/private/tmp", CACHE_DIRECTORY_NAME),
+      path.join("/tmp", CACHE_DIRECTORY_NAME),
+    );
+  }
+  for (const candidate of new Set(candidates)) {
+    const usable = await writableCacheDirectory(candidate);
+    if (usable) return usable;
+  }
+  return null;
+}
+
+async function atomicWrite(destination, contents) {
+  const temporary = temporaryFile(
+    path.dirname(destination),
+    `.${path.basename(destination)}.tmp`,
+  );
+  await writeFile(temporary, contents, "utf8");
+  await rename(temporary, destination);
+}
+
+function createOutline(markdown) {
+  const lines = markdown.replace(/\r\n/g, "\n").split("\n");
+  if (lines.at(-1) === "") lines.pop();
+  const entries = [];
+  let fenced = false;
+  lines.forEach((line, index) => {
+    if (/^\s*(?:```|~~~)/.test(line)) {
+      fenced = !fenced;
+      return;
+    }
+    if (fenced) return;
+    const heading = /^(#{2,3})\s+(.+?)\s*$/.exec(line);
+    if (!heading) return;
+    entries.push({
+      level: heading[1].length,
+      title: heading[2]
+        .replace(/\s+#+\s*$/, "")
+        .replace(/\s+/g, " ")
+        .trim(),
+      start: index + 1,
+      end: lines.length,
+    });
+  });
+  entries.forEach((entry, index) => {
+    const nextPeer = entries
+      .slice(index + 1)
+      .find((candidate) => candidate.level <= entry.level);
+    if (nextPeer) entry.end = nextPeer.start - 1;
+  });
+
+  const lowestLevel = entries.length
+    ? Math.min(...entries.map((entry) => entry.level))
+    : 2;
+  const text = entries.length
+    ? entries
+        .map(
+          (entry) =>
+            `${"  ".repeat(entry.level - lowestLevel)}- ${entry.title} (lines ${entry.start}-${entry.end})`,
+        )
+        .join("\n")
+    : "No markdown headings found.";
+  return {
+    headingCount: entries.length,
+    lineCount: lines.length,
+    markdown: `# Letta Docs Outline\n\n${text}\n`,
+  };
+}
+
+async function cachedBody(documentPath, expectedDigest) {
+  try {
+    const body = await readFile(documentPath, "utf8");
+    return bodyDigest(body) === expectedDigest ? body : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchLettaDocs({
+  docsUrl = DEFAULT_DOCS_URL,
+  cacheDir,
+  timeoutMs = 30000,
+} = {}) {
+  const selectedCache = await selectCacheDirectory(cacheDir);
+  if (!selectedCache) {
+    throw new DocsFetchError(
+      "No writable docs cache is available; pass --cache-dir to override.",
+    );
+  }
+  await mkdir(selectedCache, { recursive: true });
+
+  const documentPath = path.join(selectedCache, DOCUMENT_NAME);
+  const outlinePath = path.join(selectedCache, OUTLINE_NAME);
+  const head = await requestDocument(docsUrl, "HEAD", selectedCache, timeoutMs);
+  const expectedDigest = digestFromEtag(head.headers);
+  let body = await cachedBody(documentPath, expectedDigest);
+  const cacheStatus = body === null ? "updated" : "hit";
+
+  if (body === null) {
+    const get = await requestDocument(docsUrl, "GET", selectedCache, timeoutMs);
+    const getDigest = digestFromEtag(get.headers);
+    if (getDigest !== expectedDigest) {
+      throw new DocsFetchError(
+        `ETag changed between HEAD and GET for ${docsUrl}.`,
+      );
+    }
+    if (bodyDigest(get.body) !== expectedDigest) {
+      throw new DocsFetchError(
+        `ETag did not match the fetched body for ${docsUrl}.`,
+      );
+    }
+    body = get.body;
+    await atomicWrite(documentPath, body);
+  }
+
+  const outline = createOutline(body);
+  await atomicWrite(outlinePath, outline.markdown);
+  return {
+    outline: outline.markdown,
+    status: {
+      docsUrl,
+      etagMd5: expectedDigest,
+      fetchedMd5: bodyDigest(body),
+      contentMatchesEtag: true,
+      cacheStatus,
+      cacheDir: selectedCache,
+      docsPath: documentPath,
+      outlinePath,
+      checkedAt: new Date().toISOString(),
+      lineCount: outline.lineCount,
+      headingCount: outline.headingCount,
+    },
+  };
+}
+
+function parseArguments(argv) {
+  const result = {
+    docsUrl: DEFAULT_DOCS_URL,
+    cacheDir: undefined,
+    timeoutMs: 30000,
+    statusJson: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === "--docs-url") result.docsUrl = argv[++index];
+    else if (value === "--cache-dir") result.cacheDir = argv[++index];
+    else if (value === "--timeout-ms") result.timeoutMs = Number(argv[++index]);
+    else if (value === "--status-json") result.statusJson = true;
+    else throw new DocsFetchError(`Unknown argument: ${value}`);
+  }
+  if (!result.docsUrl) throw new DocsFetchError("--docs-url cannot be empty.");
+  if (!Number.isFinite(result.timeoutMs) || result.timeoutMs <= 0) {
+    throw new DocsFetchError("--timeout-ms must be a positive number.");
+  }
+  return result;
+}
+
+function outputFor(status, outline) {
+  return [
+    `Docs path: ${status.docsPath}`,
+    `Outline path: ${status.outlinePath}`,
+    status.cacheStatus === "hit"
+      ? "Docs status: local document was already current."
+      : "Docs status: local document was updated.",
+    "",
+    outline,
+  ].join("\n");
+}
+
+function errorChain(error) {
+  const messages = [];
+  let current = error;
+  while (current) {
+    messages.push(
+      current instanceof Error
+        ? `${current.name}: ${current.message}`
+        : String(current),
+    );
+    current = current?.cause;
+  }
+  return messages.join("\nCaused by: ");
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  const result = await fetchLettaDocs(options);
+  process.stdout.write(outputFor(result.status, result.outline));
+  if (options.statusJson) console.error(JSON.stringify(result.status));
+}
+
+if (
+  process.argv[1] &&
+  pathToFileURL(process.argv[1]).href === import.meta.url
+) {
+  main().catch((error) => {
+    console.error(`Error: ${error.message}`);
+    if (hasProxyEnvironment()) {
+      console.error(
+        "Hint: proxy variables are set, so curl is tried before native fetch.",
+      );
+    } else if (typeof fetch !== "function") {
+      console.error("Hint: install curl or use Node.js 18 or newer.");
+    } else if (process.platform === "win32") {
+      console.error("Hint: use a cache directory under %TEMP% or %TMP%.");
+    }
+    console.error("");
+    console.error("Details:");
+    console.error(errorChain(error));
+    process.exitCode = 1;
+  });
+}
+
+export { DEFAULT_DOCS_URL, createOutline, fetchLettaDocs };

--- a/src/skills/letta-guide-fetch-docs.test.ts
+++ b/src/skills/letta-guide-fetch-docs.test.ts
@@ -1,0 +1,286 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const repoRoot = process.cwd();
+const skillDir = join(repoRoot, "src", "skills", "builtin", "letta-guide");
+const fetchDocsScript = join(skillDir, "scripts", "fetch-letta-docs.mjs");
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "letta-guide-docs-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function md5(value: string): string {
+  return createHash("md5").update(value).digest("hex");
+}
+
+async function runScript(
+  args: string[],
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const env = { ...process.env };
+  for (const key of [
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "http_proxy",
+    "https_proxy",
+  ]) {
+    delete env[key];
+  }
+  const processHandle = Bun.spawn({
+    cmd: ["node", fetchDocsScript, ...args],
+    cwd: repoRoot,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    processHandle.exited,
+    new Response(processHandle.stdout).text(),
+    new Response(processHandle.stderr).text(),
+  ]);
+  return { exitCode, stdout, stderr };
+}
+
+type DocsServerState = {
+  body: string;
+  etagOverride?: string;
+  omitEtag?: boolean;
+  weakEtag?: boolean;
+};
+
+async function withDocsServer<T>(
+  state: DocsServerState,
+  run: (url: string, requests: string[]) => Promise<T>,
+): Promise<T> {
+  const requests: string[] = [];
+  const server = createServer((request, response) => {
+    requests.push(request.method ?? "");
+    response.statusCode = 200;
+    response.setHeader("content-type", "text/markdown; charset=utf-8");
+    if (!state.omitEtag) {
+      const weakPrefix = state.weakEtag ? "W/" : "";
+      response.setHeader(
+        "etag",
+        `${weakPrefix}"${state.etagOverride ?? md5(state.body)}"`,
+      );
+    }
+    if (request.method === "HEAD") {
+      response.end();
+      return;
+    }
+    response.end(state.body);
+  });
+  const url = await new Promise<string>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("server did not bind a TCP port"));
+        return;
+      }
+      resolve(`http://127.0.0.1:${address.port}/llms.txt`);
+    });
+  });
+  try {
+    return await run(url, requests);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function statusFromStderr(stderr: string): Record<string, unknown> {
+  return JSON.parse(stderr.trim()) as Record<string, unknown>;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop() ?? "", { recursive: true, force: true });
+  }
+});
+
+describe("fetch-letta-docs", () => {
+  test("fetches, verifies, caches, and outlines the current docs index", async () => {
+    const cacheDir = makeTempDir();
+    const body = `# Letta
+
+## Configuration
+
+- [Models](https://docs.letta.com/configuration/models/index.md)
+
+### Providers
+
+Details.
+
+\`\`\`
+## Hidden example
+\`\`\`
+`;
+
+    await withDocsServer({ body, weakEtag: true }, async (url, requests) => {
+      const first = await runScript([
+        "--docs-url",
+        url,
+        "--cache-dir",
+        cacheDir,
+        "--status-json",
+      ]);
+      expect(first.exitCode).toBe(0);
+      expect(first.stdout).toContain(
+        "Docs status: local document was updated.",
+      );
+      expect(first.stdout).toContain("Configuration (lines 3-");
+      expect(first.stdout).toContain("Providers (lines 7-");
+      expect(first.stdout).not.toContain("Hidden example");
+      expect(requests).toEqual(["HEAD", "GET"]);
+
+      const status = statusFromStderr(first.stderr);
+      expect(status).toMatchObject({
+        docsUrl: url,
+        etagMd5: md5(body),
+        fetchedMd5: md5(body),
+        contentMatchesEtag: true,
+        cacheStatus: "updated",
+      });
+      expect(readFileSync(status.docsPath as string, "utf8")).toBe(body);
+
+      requests.length = 0;
+      const second = await runScript([
+        "--docs-url",
+        url,
+        "--cache-dir",
+        cacheDir,
+        "--status-json",
+      ]);
+      expect(second.exitCode).toBe(0);
+      expect(second.stdout).toContain(
+        "Docs status: local document was already current.",
+      );
+      expect(statusFromStderr(second.stderr)).toMatchObject({
+        cacheStatus: "hit",
+        fetchedMd5: md5(body),
+      });
+      expect(requests).toEqual(["HEAD"]);
+    });
+  }, 15_000);
+
+  test("refetches when the remote ETag changes", async () => {
+    const cacheDir = makeTempDir();
+    const state = { body: "# Letta\n\n## Old\n" };
+    await withDocsServer(state, async (url, requests) => {
+      const first = await runScript([
+        "--docs-url",
+        url,
+        "--cache-dir",
+        cacheDir,
+        "--status-json",
+      ]);
+      expect(first.exitCode).toBe(0);
+
+      state.body = "# Letta\n\n## New\n";
+      requests.length = 0;
+      const second = await runScript([
+        "--docs-url",
+        url,
+        "--cache-dir",
+        cacheDir,
+        "--status-json",
+      ]);
+      expect(second.exitCode).toBe(0);
+      expect(statusFromStderr(second.stderr)).toMatchObject({
+        etagMd5: md5(state.body),
+        cacheStatus: "updated",
+      });
+      expect(requests).toEqual(["HEAD", "GET"]);
+      expect(second.stdout).toContain("New (lines 3-3)");
+    });
+  });
+
+  test("refetches when the local cache is corrupt", async () => {
+    const cacheDir = makeTempDir();
+    const body = "# Letta\n\n## Current\n";
+    await withDocsServer({ body }, async (url, requests) => {
+      const first = await runScript([
+        "--docs-url",
+        url,
+        "--cache-dir",
+        cacheDir,
+        "--status-json",
+      ]);
+      expect(first.exitCode).toBe(0);
+      const status = statusFromStderr(first.stderr);
+      writeFileSync(status.docsPath as string, "corrupt", "utf8");
+
+      requests.length = 0;
+      const second = await runScript([
+        "--docs-url",
+        url,
+        "--cache-dir",
+        cacheDir,
+      ]);
+      expect(second.exitCode).toBe(0);
+      expect(requests).toEqual(["HEAD", "GET"]);
+      expect(readFileSync(status.docsPath as string, "utf8")).toBe(body);
+    });
+  });
+
+  test("rejects a body that does not match the response ETag", async () => {
+    const cacheDir = makeTempDir();
+    const body = "# Letta\n\n## Current\n";
+    await withDocsServer(
+      { body, etagOverride: "00000000000000000000000000000000" },
+      async (url) => {
+        const result = await runScript([
+          "--docs-url",
+          url,
+          "--cache-dir",
+          cacheDir,
+        ]);
+        expect(result.exitCode).toBe(1);
+        expect(result.stdout).toBe("");
+        expect(result.stderr).toContain("ETag did not match the fetched body");
+      },
+    );
+  });
+
+  test("rejects responses without a content-MD5 ETag", async () => {
+    const cacheDir = makeTempDir();
+    await withDocsServer(
+      { body: "# Letta\n", omitEtag: true },
+      async (url, requests) => {
+        const result = await runScript([
+          "--docs-url",
+          url,
+          "--cache-dir",
+          cacheDir,
+        ]);
+        expect(result.exitCode).toBe(1);
+        expect(result.stdout).toBe("");
+        expect(result.stderr).toContain(
+          "Letta docs response is missing a content-MD5 ETag",
+        );
+        expect(requests).toEqual(["HEAD"]);
+      },
+    );
+  });
+
+  test("letta-guide uses direct verified retrieval before web fetch fallback", () => {
+    const skill = readFileSync(join(skillDir, "SKILL.md"), "utf8");
+    expect(skill).toContain("node <SKILL_DIR>/scripts/fetch-letta-docs.mjs");
+    expect(skill).toContain('--docs-url "https://docs.letta.com/');
+    expect(skill).toContain(
+      "do not use `fetch_webpage`\n   for the normal docs route",
+    );
+    expect(skill).toContain(
+      "use `fetch_webpage` only as a fallback with a\n   fresh query parameter",
+    );
+    expect(skill).not.toContain("~/.letta/docs-cache/");
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces `letta-guide`’s normal server-side web-fetch route with a bundled direct-fetch helper for the official docs index and selected canonical pages.
- Verifies each response’s ETag against the body, validates cached content before reuse, writes updates atomically, and emits a heading outline for targeted reads.
- Uses native Node fetch with redirect and timeout handling, falls back to curl when needed, honors proxy environments, and selects a writable cross-platform temporary cache.
- Keeps `fetch_webpage` only as a disclosed cache-busted fallback when direct retrieval fails.
- Covers cache updates and hits, weak ETags, remote changes, corrupt local cache, body-integrity failures, missing ETags, and skill routing.

Validated against the live docs index and models page, all 12 repository checks, 27 focused Tutor/helper tests, and a fresh Tutor run that followed the direct index → canonical page route without calling `fetch_webpage`.

Stacked on #3442.

👾 Generated with [Letta Code](https://letta.com)