### PR TITLE
fix(providers): expose base URL field for local endpoint providers

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -14,7 +14,7 @@
   "src/cli/components/AgentSelector.tsx": 1111,
   "src/cli/components/InputRich.tsx": 2219,
   "src/cli/components/ModelSelector.tsx": 1204,
-  "src/cli/components/ProviderSelector.tsx": 1672,
+  "src/cli/components/ProviderSelector.tsx": 1682,
   "src/cli/components/ToolCallMessageRich.tsx": 1109,
   "src/cli/helpers/accumulator.ts": 1596,
   "src/cli/helpers/reflection-transcript.ts": 2080,

--- a/src/cli/components/ProviderSelector.tsx
+++ b/src/cli/components/ProviderSelector.tsx
@@ -172,9 +172,14 @@ export function fieldValuesFromProviderPlaceholders(
 ): Record<string, string> {
   if (!fields) return {};
 
+  // Optional fields stay empty so an untouched value is not persisted:
+  // e.g. leaving the Ollama base URL blank keeps env/default resolution.
   return Object.fromEntries(
     fields
-      .filter((field) => !field.secret && field.placeholder)
+      .filter(
+        (field) =>
+          !field.secret && field.placeholder && field.required !== false,
+      )
       .map((field) => [field.key, field.placeholder as string]),
   );
 }
@@ -682,10 +687,13 @@ export function ProviderSelector({
     if (!fields) return;
 
     // Check all required fields are filled
-    const allFilled = fields.every((field) => fieldValues[field.key]?.trim());
+    const allFilled = fields.every(
+      (field) => field.required === false || fieldValues[field.key]?.trim(),
+    );
     if (!allFilled) return;
 
-    const apiKey = fieldValues.apiKey?.trim() || "";
+    const apiKey =
+      fieldValues.apiKey?.trim() || defaultProviderApiKey(provider) || "";
     const accessKey = fieldValues.accessKey?.trim();
     const region = fieldValues.region?.trim();
     const profile = fieldValues.profile?.trim();
@@ -1419,9 +1427,10 @@ export function ProviderSelector({
       ("fields" in provider ? (provider.fields as ProviderField[]) : undefined);
     if (!fields) return null;
 
-    // Check if all fields are filled
-    const allFilled = fields.every((field: ProviderField) =>
-      fieldValues[field.key]?.trim(),
+    // Check if all required fields are filled
+    const allFilled = fields.every(
+      (field: ProviderField) =>
+        field.required === false || fieldValues[field.key]?.trim(),
     );
 
     const statusText =
@@ -1482,7 +1491,8 @@ export function ProviderSelector({
                   {isFocused ? "> " : "  "}
                 </Text>
                 <Text dimColor={!isFocused} bold={isFocused}>
-                  {field.label}:
+                  {field.label}
+                  {field.required === false ? " (optional)" : ""}:
                 </Text>
                 <Text> </Text>
                 <Text

--- a/src/cli/components/provider-selector.test.ts
+++ b/src/cli/components/provider-selector.test.ts
@@ -215,6 +215,20 @@ describe("ProviderSelector multi-field defaults", () => {
       ]),
     ).toEqual({});
   });
+
+  test("does not prefill optional field placeholders", () => {
+    expect(
+      fieldValuesFromProviderPlaceholders([
+        {
+          key: "baseUrl",
+          label: "Base URL",
+          placeholder: "http://localhost:11434/v1",
+          required: false,
+        },
+        { key: "apiKey", label: "API Key", secret: true, required: false },
+      ]),
+    ).toEqual({});
+  });
 });
 
 describe("ProviderSelector connected provider actions", () => {

--- a/src/cli/subcommands/connect.ts
+++ b/src/cli/subcommands/connect.ts
@@ -124,6 +124,7 @@ function formatUsage(): string {
     "  letta connect codex --method device-code",
     "  letta connect anthropic <api_key>",
     "  letta connect openai --api-key <api_key>",
+    "  letta connect ollama --base-url http://192.168.1.50:11434/v1",
     "  letta connect lmstudio --base-url http://127.0.0.1:1234/v1 --timeout 600s",
     "  letta connect llama-cpp --base-url http://localhost:8080/v1",
     "  letta connect bedrock --method iam --access-key <id> --secret-key <key> --region <region>",

--- a/src/providers/byok-providers.ts
+++ b/src/providers/byok-providers.ts
@@ -57,6 +57,7 @@ export interface ProviderField {
   label: string;
   placeholder?: string;
   secret?: boolean; // If true, mask input like a password
+  required?: boolean; // Defaults to true when omitted
 }
 
 // Auth method definition for providers with multiple auth options
@@ -258,12 +259,21 @@ const LOCAL_EXTRA_PROVIDER_CONFIGS: readonly ByokProvider[] = [
   {
     id: "ollama",
     displayName: "Ollama (local)",
-    description: "Connect local Ollama at http://localhost:11434/v1",
+    description: "Connect Ollama at http://localhost:11434/v1 or a remote URL",
     providerType: "ollama",
     providerName: "ollama",
     providerNames: ["ollama", "lc-ollama"],
     requiresApiKey: false,
     defaultApiKey: LOCAL_PROVIDER_NO_API_KEY,
+    fields: [
+      {
+        key: "baseUrl",
+        label: "Base URL",
+        placeholder: "http://localhost:11434/v1",
+        required: false,
+      },
+      { key: "apiKey", label: "API Key", secret: true, required: false },
+    ],
   },
   {
     id: "ollama-cloud",
@@ -276,22 +286,42 @@ const LOCAL_EXTRA_PROVIDER_CONFIGS: readonly ByokProvider[] = [
   {
     id: "lmstudio",
     displayName: "LM Studio (local)",
-    description: "Connect local LM Studio at http://127.0.0.1:1234/v1",
+    description:
+      "Connect LM Studio at http://127.0.0.1:1234/v1 or a remote URL",
     providerType: LMSTUDIO_OPENAI_PROVIDER_TYPE,
     providerName: "lmstudio",
     providerNames: ["lmstudio", "lc-lmstudio"],
     requiresApiKey: false,
     defaultApiKey: LOCAL_PROVIDER_NO_API_KEY,
+    fields: [
+      {
+        key: "baseUrl",
+        label: "Base URL",
+        placeholder: "http://127.0.0.1:1234/v1",
+        required: false,
+      },
+      { key: "apiKey", label: "API Key", secret: true, required: false },
+    ],
   },
   {
     id: "llama-cpp",
     displayName: "llama.cpp (local)",
-    description: "Connect local llama.cpp at http://localhost:8080/v1",
+    description:
+      "Connect llama.cpp at http://localhost:8080/v1 or a remote URL",
     providerType: "llama_cpp",
     providerName: "llama-cpp",
     providerNames: ["llama-cpp", "lc-llama-cpp"],
     requiresApiKey: false,
     defaultApiKey: LOCAL_PROVIDER_NO_API_KEY,
+    fields: [
+      {
+        key: "baseUrl",
+        label: "Base URL",
+        placeholder: "http://localhost:8080/v1",
+        required: false,
+      },
+      { key: "apiKey", label: "API Key", secret: true, required: false },
+    ],
   },
 ];
 

--- a/src/providers/connect-provider-service.test.ts
+++ b/src/providers/connect-provider-service.test.ts
@@ -276,6 +276,70 @@ describe("connect provider service", () => {
     ]);
   });
 
+  test("serializes optional fields as not required", () => {
+    const providers: ByokProvider[] = [
+      {
+        id: "ollama",
+        displayName: "Ollama (local)",
+        description: "Connect Ollama",
+        providerType: "ollama",
+        providerName: "ollama",
+        requiresApiKey: false,
+        defaultApiKey: "not-needed",
+        fields: [
+          {
+            key: "baseUrl",
+            label: "Base URL",
+            placeholder: "http://localhost:11434/v1",
+            required: false,
+          },
+          { key: "apiKey", label: "API Key", secret: true, required: false },
+        ],
+      },
+    ];
+
+    const entries = buildConnectProviderEntries(providers, new Map(), "local");
+
+    expect(entries[0]?.fields).toEqual([
+      {
+        key: "baseUrl",
+        label: "Base URL",
+        placeholder: "http://localhost:11434/v1",
+        required: false,
+      },
+      { key: "apiKey", label: "API Key", secret: true, required: false },
+    ]);
+  });
+
+  test("resolves optional-field providers without any input", () => {
+    const provider: ByokProvider = {
+      id: "ollama",
+      displayName: "Ollama (local)",
+      description: "Connect Ollama",
+      providerType: "ollama",
+      providerName: "ollama",
+      requiresApiKey: false,
+      defaultApiKey: "not-needed",
+      fields: [
+        { key: "baseUrl", label: "Base URL", required: false },
+        { key: "apiKey", label: "API Key", secret: true, required: false },
+      ],
+    };
+
+    expect(resolveProviderConnectionFields(provider, { fields: {} })).toEqual({
+      apiKey: "not-needed",
+      options: {},
+    });
+    expect(
+      resolveProviderConnectionFields(provider, {
+        fields: { baseUrl: " http://192.168.1.20:11434/v1 " },
+      }),
+    ).toEqual({
+      apiKey: "not-needed",
+      options: { baseURL: "http://192.168.1.20:11434/v1" },
+    });
+  });
+
   test("resolves simple API key fields for saving", () => {
     const provider: ByokProvider = {
       id: "anthropic",

--- a/src/providers/connect-provider-service.ts
+++ b/src/providers/connect-provider-service.ts
@@ -116,7 +116,7 @@ function serializeFields(
     label: field.label,
     ...(field.placeholder ? { placeholder: field.placeholder } : {}),
     ...(field.secret !== undefined ? { secret: field.secret } : {}),
-    required: true,
+    required: field.required !== false,
   }));
 }
 
@@ -201,7 +201,7 @@ export function resolveProviderConnectionFields(
     input.authMethodId,
   );
   const missingField = requiredFields.find(
-    (field) => !fieldValue(input.fields, field.key),
+    (field) => field.required !== false && !fieldValue(input.fields, field.key),
   );
   if (missingField) {
     throw new Error(`Missing ${missingField.label}.`);
@@ -209,7 +209,9 @@ export function resolveProviderConnectionFields(
 
   const apiKey =
     fieldValue(input.fields, "apiKey") ?? defaultProviderApiKey(provider);
-  const apiKeyRequired = requiredFields.some((field) => field.key === "apiKey");
+  const apiKeyRequired = requiredFields.some(
+    (field) => field.key === "apiKey" && field.required !== false,
+  );
   if (!apiKey && apiKeyRequired) {
     throw new Error(`Missing ${provider.displayName} API key.`);
   }


### PR DESCRIPTION
## Summary
- The `ollama`, `lmstudio`, and `llama-cpp` local providers only advertised an API-key field over the `list_connect_providers` wire protocol, so WS clients (which render a base-URL input purely from the advertised `fields`) could not point them at a remote endpoint — e.g. an Ollama instance running on another machine over LAN. The local backend already fully supports per-provider `base_url` persistence and resolution (`record.base_url ?? env ?? default`), and `letta connect ollama --base-url ...` already worked; the gap was only in what the provider entries advertise.
- Adds optional `baseUrl` + `apiKey` fields to the three local endpoint providers, and introduces `ProviderField.required` (defaults to `true`). Optional fields serialize as `required: false`, are skipped by missing-field validation in `resolveProviderConnectionFields`, and are not prefilled from placeholders — so leaving the base URL blank keeps the existing env/default resolution instead of persisting the placeholder.
- The `/connect` multi-field UI labels optional fields `(optional)`, no longer blocks submission on them, and falls back to the provider default API key when the key field is left empty (these providers do not require a key).

## Behavior notes
- No change for existing flows: `letta connect ollama` with no args still connects with defaults; `--base-url` still works; Bedrock/OpenAI-compatible multi-field flows are unchanged (`required` defaults to true).
- Sending `connect_provider` with `fields: { baseUrl: "http://<host>:11434/v1" }` and no API key now resolves cleanly to `{ apiKey: "not-needed", options: { baseURL: ... } }`.

Reported via Discord: connecting the desktop app to a remote Ollama instance over LAN was not possible because the provider UI only offered localhost.

👾 Generated with [Letta Code](https://letta.com)