### PR TITLE
fix(cli): point users at --backend local for local-only connect providers

### DIFF
--- a/src/cli/subcommands/connect.test.ts
+++ b/src/cli/subcommands/connect.test.ts
@@ -79,6 +79,34 @@ describe("connect subcommand", () => {
     setProviderTarget("api");
   });
 
+  test("suggests --backend local for local-only providers on the API backend", async () => {
+    const { stderr, deps } = createIoDeps();
+
+    const exitCode = await runConnectSubcommand(
+      ["ollama", "--base-url", "http://192.168.1.50:11434/v1"],
+      deps,
+    );
+
+    expect(exitCode).toBe(1);
+    const output = stderr.join("\n");
+    expect(output).toContain(
+      'Provider "ollama" is only available with the local backend.',
+    );
+    expect(output).toContain(
+      "letta --backend local connect ollama --base-url http://192.168.1.50:11434/v1",
+    );
+    expect(deps.checkProviderApiKey).not.toHaveBeenCalled();
+  });
+
+  test("still reports unknown providers that exist on no backend", async () => {
+    const { stderr, deps } = createIoDeps();
+
+    const exitCode = await runConnectSubcommand(["not-a-provider"], deps);
+
+    expect(exitCode).toBe(1);
+    expect(stderr.join("\n")).toContain("Unknown provider: not-a-provider.");
+  });
+
   test("runs OAuth flow for codex alias", async () => {
     const { stdout, deps } = createIoDeps();
 

--- a/src/cli/subcommands/connect.ts
+++ b/src/cli/subcommands/connect.ts
@@ -231,6 +231,14 @@ export async function runConnectSubcommand(
 
   const provider = resolveConnectProvider(providerToken);
   if (!provider) {
+    const localProvider = resolveConnectProvider(providerToken, "local");
+    if (localProvider) {
+      io.stderr(
+        `Provider "${providerToken}" is only available with the local backend.\n` +
+          `Retry with: letta --backend local connect ${argv.join(" ")}`,
+      );
+      return 1;
+    }
     io.stderr(
       `Unknown provider: ${providerToken}. Supported providers: ${listConnectProviderTokens().join(", ")}`,
     );


### PR DESCRIPTION
## Summary
- `letta connect ollama` on the default API backend fails with `Unknown provider: ollama. Supported providers: chatgpt (alias: codex), anthropic, ...` because the local endpoint providers (`ollama`, `lmstudio`, `llama-cpp`) only exist in the local provider catalog. A user hit this verbatim on Discord today (LET-10094) and only recovered because an external AI assistant guessed `letta --backend local connect ollama --base-url ...` for them.
- When provider resolution fails against the active backend but the token resolves against the local catalog, print an actionable error instead: the provider is local-only, plus the exact retry command with the original arguments preserved (`Retry with: letta --backend local connect ollama --base-url http://<host>:11434/v1`).
- Genuinely unknown tokens keep the existing "Unknown provider" message.

`connect` is in `subcommandNeedsEarlyBackendMode`, and `extractBackendFlag` strips `--backend <mode>` from anywhere in argv before subcommand routing, so the suggested command works as printed.

Related: #3456 (base URL field for local endpoint providers), LET-10094.

👾 Generated with [Letta Code](https://letta.com)