### PR TITLE
fix(listener): prevent duplicate standalone listeners [LET-9772]

### DIFF
--- a/src/cli/subcommands/listen-single-instance.test.ts
+++ b/src/cli/subcommands/listen-single-instance.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { runListenSubcommand } from "@/cli/subcommands/listen";
+import { settingsManager } from "@/settings-manager";
+import { telemetry } from "@/telemetry";
+import { deriveListenerInstanceId } from "@/websocket/listen-register";
+import { acquireManualListenerLock } from "@/websocket/listener/manual-instance-lock";
+
+describe("standalone listener single-instance wiring", () => {
+  const originalInitialize = settingsManager.initialize;
+  const originalLoadLocalProjectSettings =
+    settingsManager.loadLocalProjectSettings;
+  const originalSetListenerEnvName = settingsManager.setListenerEnvName;
+  const originalGetOrCreateDeviceId = settingsManager.getOrCreateDeviceId;
+  const originalGetSettingsWithSecureTokens =
+    settingsManager.getSettingsWithSecureTokens;
+  const originalConsoleError = console.error;
+  const originalConsoleLog = console.log;
+  const originalHome = process.env.HOME;
+  const originalApiKey = process.env.LETTA_API_KEY;
+  const originalBaseUrl = process.env.LETTA_BASE_URL;
+  const originalSpawnerIdentity = process.env.LETTA_LISTENER_INSTANCE_ID;
+  const originalDesktopMode = process.env.LETTA_DESKTOP_MODE;
+
+  let tempHome: string;
+  let errors: string[];
+
+  beforeEach(async () => {
+    tempHome = await mkdtemp(path.join(tmpdir(), "letta-listener-wiring-"));
+    errors = [];
+    process.env.HOME = tempHome;
+    process.env.LETTA_API_KEY = "test-api-key";
+    delete process.env.LETTA_BASE_URL;
+    delete process.env.LETTA_LISTENER_INSTANCE_ID;
+    delete process.env.LETTA_DESKTOP_MODE;
+
+    settingsManager.initialize = mock(
+      async () => {},
+    ) as typeof settingsManager.initialize;
+    settingsManager.loadLocalProjectSettings = mock(async () => ({
+      lastAgent: null,
+    })) as unknown as typeof settingsManager.loadLocalProjectSettings;
+    settingsManager.setListenerEnvName = mock(
+      () => {},
+    ) as typeof settingsManager.setListenerEnvName;
+    settingsManager.getOrCreateDeviceId = mock(
+      () => "device-test",
+    ) as typeof settingsManager.getOrCreateDeviceId;
+    settingsManager.getSettingsWithSecureTokens = mock(async () => ({
+      env: {},
+    })) as unknown as typeof settingsManager.getSettingsWithSecureTokens;
+
+    console.error = mock((...args: unknown[]) => {
+      errors.push(args.map(String).join(" "));
+    }) as typeof console.error;
+    console.log = mock(() => {}) as typeof console.log;
+  });
+
+  afterEach(async () => {
+    settingsManager.initialize = originalInitialize;
+    settingsManager.loadLocalProjectSettings = originalLoadLocalProjectSettings;
+    settingsManager.setListenerEnvName = originalSetListenerEnvName;
+    settingsManager.getOrCreateDeviceId = originalGetOrCreateDeviceId;
+    settingsManager.getSettingsWithSecureTokens =
+      originalGetSettingsWithSecureTokens;
+    console.error = originalConsoleError;
+    console.log = originalConsoleLog;
+    telemetry.cleanup();
+
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalApiKey === undefined) delete process.env.LETTA_API_KEY;
+    else process.env.LETTA_API_KEY = originalApiKey;
+    if (originalBaseUrl === undefined) delete process.env.LETTA_BASE_URL;
+    else process.env.LETTA_BASE_URL = originalBaseUrl;
+    if (originalSpawnerIdentity === undefined) {
+      delete process.env.LETTA_LISTENER_INSTANCE_ID;
+    } else {
+      process.env.LETTA_LISTENER_INSTANCE_ID = originalSpawnerIdentity;
+    }
+    if (originalDesktopMode === undefined) {
+      delete process.env.LETTA_DESKTOP_MODE;
+    } else {
+      process.env.LETTA_DESKTOP_MODE = originalDesktopMode;
+    }
+
+    await rm(tempHome, { recursive: true, force: true });
+  });
+
+  function scope() {
+    return {
+      serverUrl: "https://api.letta.com",
+      deviceId: "device-test",
+      listenerInstanceId: deriveListenerInstanceId("server", "ci-env"),
+    };
+  }
+
+  test("rejects a duplicate before channel adapters or Cloud registration start", async () => {
+    const incumbent = await acquireManualListenerLock(scope(), {
+      lockRoot: path.join(tempHome, ".letta"),
+      ownerToken: "incumbent",
+    });
+    try {
+      const exitCode = await runListenSubcommand([
+        "--env-name",
+        "ci-env",
+        "--channels",
+        "slack",
+      ]);
+
+      expect(exitCode).toBe(1);
+      expect(errors.join("\n")).toContain("already running");
+      expect(errors.join("\n")).toContain(`pid ${process.pid}`);
+    } finally {
+      await incumbent.release();
+    }
+  });
+
+  test("releases ownership when startup fails after acquisition", async () => {
+    const exitCode = await runListenSubcommand([
+      "--env-name",
+      "ci-env",
+      "--channels",
+      "not-a-channel",
+      "--install-channel-runtimes",
+    ]);
+    expect(exitCode).toBe(1);
+
+    const replacement = await acquireManualListenerLock(scope(), {
+      lockRoot: path.join(tempHome, ".letta"),
+      ownerToken: "replacement",
+    });
+    await replacement.release();
+  });
+
+  test("leaves legacy Desktop-managed children outside the manual guard", async () => {
+    const incumbent = await acquireManualListenerLock(scope(), {
+      lockRoot: path.join(tempHome, ".letta"),
+      ownerToken: "manual-incumbent",
+    });
+    process.env.LETTA_DESKTOP_MODE = "1";
+
+    try {
+      const exitCode = await runListenSubcommand([
+        "--env-name",
+        "ci-env",
+        "--channels",
+        "not-a-channel",
+        "--install-channel-runtimes",
+      ]);
+
+      expect(exitCode).toBe(1);
+      expect(errors.join("\n")).toContain('Unknown channel "not-a-channel"');
+      expect(errors.join("\n")).not.toContain("already running");
+    } finally {
+      await incumbent.release();
+    }
+  });
+});

--- a/src/cli/subcommands/listen.tsx
+++ b/src/cli/subcommands/listen.tsx
@@ -32,6 +32,14 @@ import {
   MissingListenerApiKeyError,
   resolveListenerRegistrationOptions,
 } from "@/websocket/listener/auth";
+import { getSpawnerListenerInstanceId } from "@/websocket/listener/identity";
+import {
+  acquireManualListenerLock,
+  ManualListenerAlreadyRunningError,
+  type ManualListenerLockHandle,
+  ManualListenerLockUnavailableError,
+  shouldAcquireManualListenerLock,
+} from "@/websocket/listener/manual-instance-lock";
 import { flushRemoteSettingsWrites } from "@/websocket/listener/remote-settings";
 
 type ListenerProcessAnchor = {
@@ -277,6 +285,21 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
   // SIGTERM from the desktop app only kills the listener process itself,
   // orphaning its descendants which accumulate over time.
   let isShuttingDown = false;
+  let manualListenerLock: ManualListenerLockHandle | null = null;
+  const releaseManualListenerLock = async (): Promise<void> => {
+    const lock = manualListenerLock;
+    manualListenerLock = null;
+    if (!lock) return;
+    try {
+      await lock.release();
+    } catch (error) {
+      console.error(
+        `Failed to release listener lock ${lock.lockPath}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  };
   const handleShutdownSignal = async (
     signal: "SIGINT" | "SIGHUP" | "SIGTERM",
   ): Promise<void> => {
@@ -299,6 +322,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
       // Best-effort cleanup — don't block exit
     }
     await flushRemoteSettingsWrites();
+    await releaseManualListenerLock();
     await flushListenerTelemetryEnd(`listener_${signal.toLowerCase()}`);
     process.exit(0);
   };
@@ -322,6 +346,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
       // Best effort — don't block exit on channel cleanup failure
     }
     await flushRemoteSettingsWrites();
+    await releaseManualListenerLock();
     await flushListenerTelemetryEnd(exitReason);
     process.exit(code);
   };
@@ -349,42 +374,6 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
           restoreAgentScope,
         })
       : [];
-
-  if (channelNames.length > 0) {
-    if (values.channels && values["install-channel-runtimes"]) {
-      const { ensureChannelRuntimeInstalled } = await import(
-        "@/channels/runtime-deps"
-      );
-      const { isSupportedChannelId } = await import(
-        "@/channels/plugin-registry"
-      );
-
-      for (const channelName of channelNames) {
-        if (!isSupportedChannelId(channelName)) {
-          console.error(
-            `Unknown channel "${channelName}" passed to --channels.`,
-          );
-          return 1;
-        }
-        await ensureChannelRuntimeInstalled(channelName);
-      }
-    }
-
-    const { initializeChannels } = await import("@/channels/registry");
-    try {
-      await initializeChannels(channelNames, {
-        failOnStartupError: Boolean(values.channels),
-        restoreAgentScope,
-        logger: debugMode
-          ? (message) => console.log(`[${formatTimestamp()}] ${message}`)
-          : undefined,
-      });
-    } catch (error) {
-      console.error(error instanceof Error ? error.message : String(error));
-      await flushListenerTelemetryEnd("listener_channel_start_failed");
-      return 1;
-    }
-  }
 
   // Determine connection name
   let connectionName: string;
@@ -446,6 +435,117 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
       return 1;
     }
 
+    let registerOptions: RegisterOptions | null = null;
+    if (startupMode.kind === "remote") {
+      try {
+        registerOptions = await resolveListenerRegistrationOptions(
+          deviceId,
+          connectionName,
+        );
+      } catch (authErr) {
+        if (authErr instanceof MissingListenerApiKeyError) {
+          console.error("Error: LETTA_API_KEY not found");
+          console.error(
+            "Set your API key with: export LETTA_API_KEY=<your-key>",
+          );
+          await flushListenerTelemetryEnd("listener_missing_api_key");
+          return 1;
+        }
+
+        console.error(
+          "OAuth login failed:",
+          authErr instanceof Error ? authErr.message : String(authErr),
+        );
+        await flushListenerTelemetryEnd("listener_oauth_failed");
+        return 1;
+      }
+
+      // A spawner owns Desktop child lifecycle. Standalone `letta server`
+      // and its `letta remote` alias instead claim their exact local
+      // registration slot before starting channel adapters or registering.
+      if (
+        shouldAcquireManualListenerLock(
+          getSpawnerListenerInstanceId(),
+          process.env.LETTA_DESKTOP_MODE === "1",
+        )
+      ) {
+        const listenerInstanceId = registerOptions.listenerInstanceId;
+        if (!listenerInstanceId) {
+          throw new Error("Listener registration identity was not resolved.");
+        }
+        try {
+          manualListenerLock = await acquireManualListenerLock({
+            serverUrl: registerOptions.serverUrl,
+            deviceId,
+            listenerInstanceId,
+          });
+        } catch (lockError) {
+          if (lockError instanceof ManualListenerAlreadyRunningError) {
+            console.error(
+              `A letta server for environment "${connectionName}" is already running on this machine (pid ${lockError.holderPid}).`,
+            );
+            console.error(
+              "Stop that process, or choose a different logical listener with --env-name.",
+            );
+            console.error(`Lock: ${lockError.lockPath}`);
+            await flushListenerTelemetryEnd("listener_already_running");
+            return 1;
+          }
+          if (lockError instanceof ManualListenerLockUnavailableError) {
+            console.error(
+              `Could not establish listener ownership: ${lockError.message}`,
+            );
+            console.error(
+              "No listener was started. Resolve the lock-file error and retry.",
+            );
+            await flushListenerTelemetryEnd("listener_lock_unavailable");
+            return 1;
+          }
+          throw lockError;
+        }
+      }
+    }
+
+    // Start channel adapters only after remote listener ownership is known.
+    // A rejected duplicate must not briefly bind Slack/Telegram runtimes.
+    if (channelNames.length > 0) {
+      if (values.channels && values["install-channel-runtimes"]) {
+        const { ensureChannelRuntimeInstalled } = await import(
+          "@/channels/runtime-deps"
+        );
+        const { isSupportedChannelId } = await import(
+          "@/channels/plugin-registry"
+        );
+
+        for (const channelName of channelNames) {
+          if (!isSupportedChannelId(channelName)) {
+            console.error(
+              `Unknown channel "${channelName}" passed to --channels.`,
+            );
+            await releaseManualListenerLock();
+            return 1;
+          }
+          await ensureChannelRuntimeInstalled(channelName);
+        }
+      }
+
+      const { initializeChannels } = await import("@/channels/registry");
+      try {
+        await initializeChannels(channelNames, {
+          failOnStartupError: Boolean(values.channels),
+          restoreAgentScope,
+          logger: debugMode
+            ? (message) => console.log(`[${formatTimestamp()}] ${message}`)
+            : undefined,
+        });
+      } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error));
+        await releaseManualListenerLock();
+        await flushListenerTelemetryEnd("listener_channel_start_failed");
+        return 1;
+      }
+    }
+
     sessionLog.log(`Session started (debug=${debugMode})`);
     sessionLog.log(`deviceId: ${deviceId}`);
     sessionLog.log(`connectionName: ${connectionName}`);
@@ -498,27 +598,10 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
       return createListenerProcessAnchorPromise();
     }
 
-    let registerOptions: RegisterOptions;
-
-    try {
-      registerOptions = await resolveListenerRegistrationOptions(
-        deviceId,
-        connectionName,
+    if (!registerOptions) {
+      throw new Error(
+        "Remote listener registration options were not resolved.",
       );
-    } catch (authErr) {
-      if (authErr instanceof MissingListenerApiKeyError) {
-        console.error("Error: LETTA_API_KEY not found");
-        console.error("Set your API key with: export LETTA_API_KEY=<your-key>");
-        await flushListenerTelemetryEnd("listener_missing_api_key");
-        return 1;
-      }
-
-      console.error(
-        "OAuth login failed:",
-        authErr instanceof Error ? authErr.message : String(authErr),
-      );
-      await flushListenerTelemetryEnd("listener_oauth_failed");
-      return 1;
     }
 
     if (debugMode) {
@@ -783,6 +866,7 @@ export async function runListenSubcommand(argv: string[]): Promise<number> {
     sessionLog.log(`FATAL: ${msg}`);
     console.error(`Failed to start listener: ${msg}`);
     await flushRemoteSettingsWrites();
+    await releaseManualListenerLock();
     await flushListenerTelemetryEnd("listener_start_failed");
     return 1;
   }

--- a/src/websocket/listener/identity.ts
+++ b/src/websocket/listener/identity.ts
@@ -14,11 +14,10 @@
  * verbatim, giving Desktop children relay slots that can never collide
  * with manual listeners or other installations.
  *
- * Manual listener identity behavior is deliberately UNCHANGED (legacy
- * name-derived ids). Duplicate manual `letta server`/`/listen` processes
- * are a separate, pre-existing problem — if evidence shows they need a
- * local single-run guard, that is a follow-up with a session-owned lock
- * API, not part of this fix suite.
+ * Manual listener identity behavior remains unchanged (legacy name-derived
+ * ids). Standalone `letta server`/`letta remote` processes use that exact id
+ * for their local single-instance guard; in-app `/listen` remains a separate
+ * surface and is not part of that guard.
  */
 
 /**

--- a/src/websocket/listener/manual-instance-lock.test.ts
+++ b/src/websocket/listener/manual-instance-lock.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  acquireManualListenerLock,
+  getManualListenerScopeHash,
+  ManualListenerAlreadyRunningError,
+  type ManualListenerLockScope,
+  ManualListenerLockUnavailableError,
+  normalizeManualListenerServerUrl,
+  shouldAcquireManualListenerLock,
+} from "@/websocket/listener/manual-instance-lock";
+
+const SCOPE: ManualListenerLockScope = {
+  serverUrl: "https://api.letta.com/",
+  deviceId: "device-1",
+  listenerInstanceId: "server-instance-1",
+};
+
+describe("manual listener instance lock", () => {
+  let lockRoot: string;
+  let alivePids: Set<number>;
+
+  beforeEach(async () => {
+    lockRoot = await mkdtemp(path.join(tmpdir(), "letta-listener-lock-"));
+    alivePids = new Set();
+  });
+
+  afterEach(async () => {
+    await rm(lockRoot, { recursive: true, force: true });
+  });
+
+  function acquire(
+    scope: ManualListenerLockScope,
+    processId: number,
+    ownerToken: string,
+  ) {
+    alivePids.add(processId);
+    return acquireManualListenerLock(scope, {
+      lockRoot,
+      processId,
+      ownerToken,
+      isProcessAlive: (pid) => alivePids.has(pid),
+    });
+  }
+
+  test("normalizes equivalent server URLs into the same lock scope", () => {
+    expect(
+      normalizeManualListenerServerUrl(" HTTPS://API.LETTA.COM:443/ "),
+    ).toBe("https://api.letta.com");
+    expect(getManualListenerScopeHash(SCOPE)).toBe(
+      getManualListenerScopeHash({
+        ...SCOPE,
+        serverUrl: "HTTPS://API.LETTA.COM:443",
+      }),
+    );
+  });
+
+  test("applies only to standalone listeners, not spawner-owned children", () => {
+    expect(shouldAcquireManualListenerLock(null, false)).toBe(true);
+    expect(
+      shouldAcquireManualListenerLock("desktop-primary:installation-1", true),
+    ).toBe(false);
+    expect(shouldAcquireManualListenerLock(null, true)).toBe(false);
+  });
+
+  test("blocks a second live process for the same registration slot", async () => {
+    const incumbent = await acquire(SCOPE, 101, "owner-101");
+
+    await expect(acquire(SCOPE, 202, "owner-202")).rejects.toEqual(
+      expect.objectContaining({
+        name: "ManualListenerAlreadyRunningError",
+        holderPid: 101,
+      }),
+    );
+
+    await incumbent.release();
+    const replacement = await acquire(SCOPE, 202, "owner-202-retry");
+    await replacement.release();
+  });
+
+  test("allows distinct local registration slots to coexist", async () => {
+    const handles = await Promise.all([
+      acquire(SCOPE, 101, "owner-a"),
+      acquire({ ...SCOPE, deviceId: "device-2" }, 102, "owner-b"),
+      acquire(
+        { ...SCOPE, listenerInstanceId: "server-instance-2" },
+        103,
+        "owner-c",
+      ),
+      acquire(
+        { ...SCOPE, serverUrl: "https://self-hosted.example.com" },
+        104,
+        "owner-d",
+      ),
+    ]);
+
+    await Promise.all(handles.map((handle) => handle.release()));
+  });
+
+  test("has exactly one winner across concurrent claims", async () => {
+    const claims = await Promise.allSettled(
+      Array.from({ length: 8 }, (_, index) =>
+        acquire(SCOPE, 1000 + index, `owner-${index}`),
+      ),
+    );
+
+    const winners = claims.filter((claim) => claim.status === "fulfilled");
+    const losers = claims.filter((claim) => claim.status === "rejected");
+    expect(winners).toHaveLength(1);
+    expect(losers).toHaveLength(7);
+    for (const loser of losers) {
+      if (loser.status === "rejected") {
+        expect(loser.reason).toBeInstanceOf(ManualListenerAlreadyRunningError);
+      }
+    }
+    if (winners[0]?.status === "fulfilled") {
+      await winners[0].value.release();
+    }
+  });
+
+  test("reclaims a dead owner without letting its stale release delete the replacement", async () => {
+    const stale = await acquire(SCOPE, 101, "owner-stale");
+    alivePids.delete(101);
+
+    const replacement = await acquire(SCOPE, 202, "owner-replacement");
+    await stale.release();
+
+    await expect(acquire(SCOPE, 303, "owner-third")).rejects.toEqual(
+      expect.objectContaining({ holderPid: 202 }),
+    );
+    await replacement.release();
+  });
+
+  test("fails closed on a corrupt incumbent record", async () => {
+    const scopeHash = getManualListenerScopeHash(SCOPE);
+    const listenersDir = path.join(lockRoot, "listeners");
+    await acquireManualListenerLock(SCOPE, {
+      lockRoot,
+      processId: 101,
+      ownerToken: "owner-initial",
+      isProcessAlive: () => true,
+    }).then(async (handle) => {
+      await unlink(handle.lockPath);
+      await writeFile(handle.lockPath, "not-json", "utf-8");
+    });
+
+    await expect(acquire(SCOPE, 202, "owner-202")).rejects.toBeInstanceOf(
+      ManualListenerLockUnavailableError,
+    );
+    expect(
+      await readFile(
+        path.join(listenersDir, `manual-${scopeHash}.lock`),
+        "utf-8",
+      ),
+    ).toBe("not-json");
+  });
+
+  test("fails closed when the lock root cannot be created", async () => {
+    const blockedRoot = path.join(lockRoot, "not-a-directory");
+    await writeFile(blockedRoot, "blocked", "utf-8");
+
+    await expect(
+      acquireManualListenerLock(SCOPE, {
+        lockRoot: blockedRoot,
+        processId: 101,
+        ownerToken: "owner-101",
+        isProcessAlive: () => false,
+      }),
+    ).rejects.toBeInstanceOf(ManualListenerLockUnavailableError);
+  });
+});

--- a/src/websocket/listener/manual-instance-lock.ts
+++ b/src/websocket/listener/manual-instance-lock.ts
@@ -1,0 +1,390 @@
+/**
+ * Local single-instance ownership for standalone remote listeners.
+ *
+ * Two `letta server` processes launched from the same machine currently derive
+ * the same listener instance id from their environment name. If both register,
+ * they rotate the same Cloud connection lease. This lock stops the second
+ * local process before registration. It never signals the incumbent.
+ *
+ * Desktop-owned children are out of scope: their spawner supplies distinct
+ * listener identities and owns their lifecycle.
+ */
+
+import { createHash, randomUUID } from "node:crypto";
+import { link, mkdir, readFile, rm, unlink, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+
+export interface ManualListenerLockScope {
+  serverUrl: string;
+  deviceId: string;
+  listenerInstanceId: string;
+}
+
+export interface ManualListenerLockHandle {
+  lockPath: string;
+  release: () => Promise<void>;
+}
+
+interface ManualListenerLockRecord {
+  version: 1;
+  pid: number;
+  ownerToken: string;
+  acquiredAt: string;
+  scopeHash: string;
+}
+
+interface ManualListenerLockDeps {
+  lockRoot: string;
+  processId: number;
+  ownerToken: string;
+  isProcessAlive: (pid: number) => boolean;
+}
+
+const RECOVERY_MAX_DEPTH = 64;
+
+export class ManualListenerAlreadyRunningError extends Error {
+  readonly holderPid: number;
+  readonly lockPath: string;
+
+  constructor(holderPid: number, lockPath: string) {
+    super(`A matching listener is already running (pid ${holderPid}).`);
+    this.name = "ManualListenerAlreadyRunningError";
+    this.holderPid = holderPid;
+    this.lockPath = lockPath;
+  }
+}
+
+export class ManualListenerLockUnavailableError extends Error {
+  readonly lockPath: string;
+
+  constructor(message: string, lockPath: string) {
+    super(message);
+    this.name = "ManualListenerLockUnavailableError";
+    this.lockPath = lockPath;
+  }
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === code
+  );
+}
+
+function defaultIsProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // Only ESRCH proves that the owner is gone. Permission and unfamiliar
+    // platform failures stay fail-closed and report the lock as held.
+    return !hasErrorCode(error, "ESRCH");
+  }
+}
+
+function getDefaultLockRoot(): string {
+  // The device id used in the registration key is stored under this same
+  // HOME-scoped `.letta` directory. An unrelated LETTA_HOME override must not
+  // split locks for processes that still share that device identity.
+  return path.join(process.env.HOME || homedir(), ".letta");
+}
+
+export function normalizeManualListenerServerUrl(serverUrl: string): string {
+  const trimmed = serverUrl.trim();
+  try {
+    const parsed = new URL(trimmed);
+    parsed.hash = "";
+    parsed.search = "";
+    return parsed.toString().replace(/\/+$/, "");
+  } catch {
+    return trimmed.replace(/\/+$/, "");
+  }
+}
+
+export function shouldAcquireManualListenerLock(
+  spawnerListenerInstanceId: string | null,
+  isDesktopSpawn: boolean,
+): boolean {
+  // Preserve compatibility if this letta-code version is ever bundled by an
+  // older Desktop that sets LETTA_DESKTOP_MODE but not the explicit identity
+  // added by LET-10085. Desktop must never enter the generic manual guard.
+  return spawnerListenerInstanceId === null && !isDesktopSpawn;
+}
+
+export function getManualListenerScopeHash(
+  scope: ManualListenerLockScope,
+): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify([
+        normalizeManualListenerServerUrl(scope.serverUrl),
+        scope.deviceId,
+        scope.listenerInstanceId,
+      ]),
+    )
+    .digest("hex");
+}
+
+function parseLockRecord(
+  raw: string,
+  expectedScopeHash: string,
+): ManualListenerLockRecord | null {
+  try {
+    const parsed = JSON.parse(raw) as Partial<ManualListenerLockRecord>;
+    if (
+      parsed.version !== 1 ||
+      !Number.isSafeInteger(parsed.pid) ||
+      (parsed.pid ?? 0) <= 0 ||
+      typeof parsed.ownerToken !== "string" ||
+      parsed.ownerToken.length === 0 ||
+      typeof parsed.acquiredAt !== "string" ||
+      parsed.scopeHash !== expectedScopeHash
+    ) {
+      return null;
+    }
+    return parsed as ManualListenerLockRecord;
+  } catch {
+    return null;
+  }
+}
+
+async function publishInitializedFile(
+  targetPath: string,
+  contents: string,
+): Promise<unknown> {
+  const candidatePath = path.join(
+    path.dirname(targetPath),
+    `.manual-listener-lock-${randomUUID()}.candidate`,
+  );
+  let publicationError: unknown;
+  try {
+    await writeFile(candidatePath, contents, { flag: "wx" });
+    await link(candidatePath, targetPath);
+  } catch (error) {
+    publicationError = error;
+  }
+  await rm(candidatePath, { force: true }).catch(() => {});
+  return publicationError;
+}
+
+function getRecoveryClaimPath(
+  lockPath: string,
+  staleContents: string,
+  depth: number,
+): string {
+  const staleHash = createHash("sha256").update(staleContents).digest("hex");
+  return `${lockPath}.recover.${staleHash}.${depth}`;
+}
+
+async function cleanupRecoveryClaims(
+  lockPath: string,
+  staleContents: string,
+  deepestClaim: number,
+): Promise<void> {
+  for (let depth = deepestClaim; depth >= 0; depth--) {
+    await rm(getRecoveryClaimPath(lockPath, staleContents, depth), {
+      force: true,
+    }).catch(() => {});
+  }
+}
+
+async function recoverDeadOwner(
+  lockPath: string,
+  staleContents: string,
+  recoveryOwnerContents: string,
+  scopeHash: string,
+  deps: ManualListenerLockDeps,
+): Promise<boolean> {
+  let ownedClaimDepth = -1;
+  try {
+    for (let depth = 0; depth < RECOVERY_MAX_DEPTH; depth++) {
+      const claimPath = getRecoveryClaimPath(lockPath, staleContents, depth);
+      const claimError = await publishInitializedFile(
+        claimPath,
+        recoveryOwnerContents,
+      );
+      if (claimError === undefined) {
+        ownedClaimDepth = depth;
+        break;
+      }
+      if (!hasErrorCode(claimError, "EEXIST")) {
+        throw new ManualListenerLockUnavailableError(
+          `Could not safely claim stale listener lock recovery: ${
+            claimError instanceof Error
+              ? claimError.message
+              : String(claimError)
+          }`,
+          lockPath,
+        );
+      }
+
+      let claimContents: string;
+      try {
+        claimContents = await readFile(claimPath, "utf-8");
+      } catch (error) {
+        if (hasErrorCode(error, "ENOENT")) {
+          continue;
+        }
+        throw new ManualListenerLockUnavailableError(
+          "Could not inspect the listener lock recovery owner.",
+          lockPath,
+        );
+      }
+      const claimOwner = parseLockRecord(claimContents, scopeHash);
+      if (!claimOwner) {
+        throw new ManualListenerLockUnavailableError(
+          `Listener lock recovery record is invalid: ${claimPath}`,
+          lockPath,
+        );
+      }
+      if (deps.isProcessAlive(claimOwner.pid)) {
+        return false;
+      }
+    }
+
+    if (ownedClaimDepth === -1) {
+      throw new ManualListenerLockUnavailableError(
+        "Listener lock recovery claim chain was exhausted.",
+        lockPath,
+      );
+    }
+
+    let currentContents: string;
+    try {
+      currentContents = await readFile(lockPath, "utf-8");
+    } catch (error) {
+      return hasErrorCode(error, "ENOENT");
+    }
+    if (currentContents !== staleContents) {
+      return true;
+    }
+    await unlink(lockPath);
+    return true;
+  } finally {
+    if (ownedClaimDepth !== -1) {
+      await cleanupRecoveryClaims(lockPath, staleContents, ownedClaimDepth);
+    }
+  }
+}
+
+/**
+ * Claim the local slot used by a standalone remote listener.
+ *
+ * The initialized-record hard-link publication makes acquisition atomic. A
+ * dead owner is reclaimed through a content-scoped recovery claim so two
+ * simultaneous recoverers cannot unlink a newer generation.
+ */
+export async function acquireManualListenerLock(
+  scope: ManualListenerLockScope,
+  overrides: Partial<ManualListenerLockDeps> = {},
+): Promise<ManualListenerLockHandle> {
+  const scopeHash = getManualListenerScopeHash(scope);
+  const deps: ManualListenerLockDeps = {
+    lockRoot: getDefaultLockRoot(),
+    processId: process.pid,
+    ownerToken: randomUUID(),
+    isProcessAlive: defaultIsProcessAlive,
+    ...overrides,
+  };
+  const listenerLockDir = path.join(deps.lockRoot, "listeners");
+  const lockPath = path.join(listenerLockDir, `manual-${scopeHash}.lock`);
+  const ownerRecord: ManualListenerLockRecord = {
+    version: 1,
+    pid: deps.processId,
+    ownerToken: deps.ownerToken,
+    acquiredAt: new Date().toISOString(),
+    scopeHash,
+  };
+  const ownerContents = JSON.stringify(ownerRecord);
+
+  try {
+    await mkdir(listenerLockDir, { recursive: true });
+  } catch (error) {
+    throw new ManualListenerLockUnavailableError(
+      `Could not create the listener lock directory: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      lockPath,
+    );
+  }
+
+  while (true) {
+    const publicationError = await publishInitializedFile(
+      lockPath,
+      ownerContents,
+    );
+    if (publicationError === undefined) {
+      let released = false;
+      return {
+        lockPath,
+        release: async () => {
+          if (released) return;
+          let currentContents: string;
+          try {
+            currentContents = await readFile(lockPath, "utf-8");
+          } catch (error) {
+            if (hasErrorCode(error, "ENOENT")) {
+              released = true;
+              return;
+            }
+            throw error;
+          }
+          if (currentContents === ownerContents) {
+            await unlink(lockPath);
+          }
+          released = true;
+        },
+      };
+    }
+    if (!hasErrorCode(publicationError, "EEXIST")) {
+      throw new ManualListenerLockUnavailableError(
+        `Could not publish the listener lock: ${
+          publicationError instanceof Error
+            ? publicationError.message
+            : String(publicationError)
+        }`,
+        lockPath,
+      );
+    }
+
+    let incumbentContents: string;
+    try {
+      incumbentContents = await readFile(lockPath, "utf-8");
+    } catch (error) {
+      if (hasErrorCode(error, "ENOENT")) {
+        continue;
+      }
+      throw new ManualListenerLockUnavailableError(
+        "Could not inspect the existing listener lock.",
+        lockPath,
+      );
+    }
+    const incumbent = parseLockRecord(incumbentContents, scopeHash);
+    if (!incumbent) {
+      throw new ManualListenerLockUnavailableError(
+        `Listener lock is corrupt or belongs to an incompatible version: ${lockPath}`,
+        lockPath,
+      );
+    }
+    if (deps.isProcessAlive(incumbent.pid)) {
+      throw new ManualListenerAlreadyRunningError(incumbent.pid, lockPath);
+    }
+
+    const recovered = await recoverDeadOwner(
+      lockPath,
+      incumbentContents,
+      ownerContents,
+      scopeHash,
+      deps,
+    );
+    if (!recovered) {
+      throw new ManualListenerLockUnavailableError(
+        `Another process is recovering the listener lock: ${lockPath}`,
+        lockPath,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Why

The Desktop lifecycle work does not cover terminal-only deployments such as Overlord. Two standalone `letta server` processes on one machine can currently derive the same `(server, device, listenerInstanceId)` registration slot and both register it, causing connection-lease contention.

## What changed

- Claim a local lock for the exact registration slot before starting channel adapters or registering with Cloud.
- Reject the newcomer with the incumbent PID and remediation; never signal or replace the incumbent.
- Publish initialized locks atomically and safely reclaim dead owners without allowing a stale release/recovery to remove a newer generation.
- Fail closed on corrupt locks or filesystem failures.
- Release ownership on startup failure, terminal listener callbacks, and process shutdown signals.
- Keep Desktop/spawner-owned children outside this guard, including the legacy `LETTA_DESKTOP_MODE` compatibility path.

## Deliberate scope

- No relay, Redis, or server-protocol changes.
- No process killing or persisted manual-listener identity changes.
- No behavior change for in-app `/listen`.
- Different local slots and listeners on different machines still coexist.
- Reconnect/run resumption remains separate work.

## Rollout note

Already-running listeners from an older release do not own this lock. Stop old standalone listener processes once before starting the first upgraded listener; subsequent duplicate starts are guarded automatically and crash leftovers are reclaimed.

## Validation

- 11 focused lock/wiring tests pass.
- 165 CLI-subcommand tests pass.
- `bun run check`: 12/12 pass.
- Manual two-process probe: equivalent server URLs contend, the second process is rejected with the first PID, and a lock left by a killed owner is reclaimed.

Linear: https://linear.app/letta/issue/LET-9772/trace-recurrent-stale-approval-interruptions-across-channel-runs
