### PR TITLE
fix(listener): prevent spawner identity inheritance [LET-10085]

### DIFF
--- a/src/websocket/listener/auth.test.ts
+++ b/src/websocket/listener/auth.test.ts
@@ -11,6 +11,10 @@ import {
   resolveListenerReconnectAuth,
   resolveListenerRegistrationOptions,
 } from "@/websocket/listener/auth";
+import {
+  __listenerIdentityTestUtils,
+  LISTENER_INSTANCE_ID_ENV,
+} from "@/websocket/listener/identity";
 
 type ListenerSettings = Awaited<
   ReturnType<typeof settingsManager.getSettingsWithSecureTokens>
@@ -35,6 +39,7 @@ describe("listener auth", () => {
   const originalConsoleWarn = console.warn;
   const originalApiKey = process.env.LETTA_API_KEY;
   const originalBaseUrl = process.env.LETTA_BASE_URL;
+  const originalListenerInstanceId = process.env[LISTENER_INSTANCE_ID_ENV];
 
   let settings: ListenerSettings;
   const updateSettingsMock = mock(() => {});
@@ -62,6 +67,8 @@ describe("listener auth", () => {
 
     delete process.env.LETTA_API_KEY;
     delete process.env.LETTA_BASE_URL;
+    delete process.env[LISTENER_INSTANCE_ID_ENV];
+    __listenerIdentityTestUtils.resetCachedSpawnerIdentity();
     console.log = mock(() => {}) as typeof console.log;
     console.warn = mock(() => {}) as typeof console.warn;
   });
@@ -84,6 +91,12 @@ describe("listener auth", () => {
       delete process.env.LETTA_BASE_URL;
     } else {
       process.env.LETTA_BASE_URL = originalBaseUrl;
+    }
+    __listenerIdentityTestUtils.resetCachedSpawnerIdentity();
+    if (originalListenerInstanceId === undefined) {
+      delete process.env[LISTENER_INSTANCE_ID_ENV];
+    } else {
+      process.env[LISTENER_INSTANCE_ID_ENV] = originalListenerInstanceId;
     }
   });
 
@@ -208,30 +221,32 @@ describe("listener auth", () => {
     expect(second.listenerInstanceId).toStartWith("listen-");
   });
 
-  test("passes a spawner-assigned identity through to registration verbatim", async () => {
-    // LET-10085: an owning spawner (Desktop) assigns its child an explicit
-    // identity so it never collides with a manual listener sharing the
-    // same display name. Manual listeners (no env) keep the legacy
-    // name-derived identity — asserted by the test above.
+  test("caches a spawner identity across registrations without exposing it to descendants", async () => {
     settings = {
       ...settings,
       env: { LETTA_API_KEY: "spawner-access-token" },
     };
-    const previous = process.env.LETTA_LISTENER_INSTANCE_ID;
-    process.env.LETTA_LISTENER_INSTANCE_ID = "desktop-primary:install-42";
-    try {
-      const options = await resolveListenerRegistrationOptions(
-        "device-id",
-        "listener-name",
-        { allowInteractiveOAuth: false, surface: "server" },
-      );
-      expect(options.listenerInstanceId).toBe("desktop-primary:install-42");
-    } finally {
-      if (previous === undefined) {
-        delete process.env.LETTA_LISTENER_INSTANCE_ID;
-      } else {
-        process.env.LETTA_LISTENER_INSTANCE_ID = previous;
-      }
-    }
+    process.env[LISTENER_INSTANCE_ID_ENV] = "desktop-primary:install-42";
+
+    const firstRegistration = resolveListenerRegistrationOptions(
+      "device-id",
+      "listener-name",
+      { allowInteractiveOAuth: false, surface: "server" },
+    );
+    // Consumption is synchronous—before authentication reaches its first
+    // await—so no concurrent hook/descendant can inherit the transport env.
+    expect(process.env[LISTENER_INSTANCE_ID_ENV]).toBeUndefined();
+    const first = await firstRegistration;
+    expect(first.listenerInstanceId).toBe("desktop-primary:install-42");
+
+    const second = await resolveListenerRegistrationOptions(
+      "device-id",
+      "different-display-name",
+      { allowInteractiveOAuth: false, surface: "server" },
+    );
+    // Re-registration retains the owner identity from process-local cache;
+    // it does not fall back to the new display-name-derived identity.
+    expect(second.listenerInstanceId).toBe("desktop-primary:install-42");
+    expect(process.env[LISTENER_INSTANCE_ID_ENV]).toBeUndefined();
   });
 });

--- a/src/websocket/listener/auth.ts
+++ b/src/websocket/listener/auth.ts
@@ -255,6 +255,10 @@ export async function resolveListenerRegistrationOptions(
   connectionName: string,
   options: ListenerRegistrationOptions = {},
 ): Promise<RegisterOptions> {
+  // Consume the startup transport variable before the first await so no
+  // authentication hook or concurrently-spawned descendant can inherit it.
+  // Re-registration reads the same process-local cache.
+  const spawnerListenerInstanceId = getSpawnerListenerInstanceId();
   const auth = await resolveListenerAuth(deviceId, connectionName, options);
   return {
     ...auth,
@@ -263,7 +267,7 @@ export async function resolveListenerRegistrationOptions(
     // A spawner-assigned identity (Desktop slots, LET-10085) wins; manual
     // listeners keep their legacy name-derived identity unchanged.
     listenerInstanceId:
-      getSpawnerListenerInstanceId() ??
+      spawnerListenerInstanceId ??
       deriveListenerInstanceId(options.surface ?? "server", connectionName),
   };
 }

--- a/src/websocket/listener/identity.test.ts
+++ b/src/websocket/listener/identity.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
+  __listenerIdentityTestUtils,
   getSpawnerListenerInstanceId,
   isValidListenerInstanceId,
   LISTENER_INSTANCE_ID_ENV,
@@ -8,10 +9,12 @@ import {
 const originalEnv = process.env[LISTENER_INSTANCE_ID_ENV];
 
 beforeEach(() => {
+  __listenerIdentityTestUtils.resetCachedSpawnerIdentity();
   delete process.env[LISTENER_INSTANCE_ID_ENV];
 });
 
 afterEach(() => {
+  __listenerIdentityTestUtils.resetCachedSpawnerIdentity();
   if (originalEnv === undefined) {
     delete process.env[LISTENER_INSTANCE_ID_ENV];
   } else {
@@ -20,19 +23,26 @@ afterEach(() => {
 });
 
 describe("getSpawnerListenerInstanceId", () => {
-  test("returns the spawner-assigned identity when set and valid", () => {
+  test("consumes and caches a valid spawner identity without leaving it inheritable", () => {
     process.env[LISTENER_INSTANCE_ID_ENV] = "desktop-primary:install-42";
+
+    expect(getSpawnerListenerInstanceId()).toBe("desktop-primary:install-42");
+    expect(process.env[LISTENER_INSTANCE_ID_ENV]).toBeUndefined();
+    // Re-registration gets the process-owned cache after the transport env
+    // variable is gone.
     expect(getSpawnerListenerInstanceId()).toBe("desktop-primary:install-42");
   });
 
-  test("returns null when unset (manual listeners keep legacy identity)", () => {
+  test("returns and caches null when unset (manual listeners keep legacy identity)", () => {
+    expect(getSpawnerListenerInstanceId()).toBeNull();
     expect(getSpawnerListenerInstanceId()).toBeNull();
   });
 
-  test("rejects invalid values instead of trusting a corrupted env var", () => {
+  test("consumes invalid values instead of exposing them to descendants", () => {
     process.env[LISTENER_INSTANCE_ID_ENV] = "bad value with spaces!";
+
     expect(getSpawnerListenerInstanceId()).toBeNull();
-    process.env[LISTENER_INSTANCE_ID_ENV] = "";
+    expect(process.env[LISTENER_INSTANCE_ID_ENV]).toBeUndefined();
     expect(getSpawnerListenerInstanceId()).toBeNull();
   });
 });

--- a/src/websocket/listener/identity.ts
+++ b/src/websocket/listener/identity.ts
@@ -38,11 +38,36 @@ export function isValidListenerInstanceId(value: string): boolean {
 }
 
 /**
- * The spawner-assigned identity for this process, or null when none was
+ * `undefined` means the startup environment has not been consumed yet.
+ * After the first read, both a valid identity and the absence of one are
+ * cached for the lifetime of this listener process.
+ */
+let cachedSpawnerListenerInstanceId: string | null | undefined;
+
+/**
+ * The spawner-assigned identity for THIS process, or null when none was
  * provided (ordinary manual listeners — legacy name-derived identity
  * applies).
+ *
+ * Consume exactly once, then delete the transport variable from process.env.
+ * Registration and re-registration use the cache; Bash, subagents, and any
+ * nested `letta server` processes inherit the sanitized environment and
+ * therefore cannot impersonate the owning listener process's relay slot.
  */
 export function getSpawnerListenerInstanceId(): string | null {
+  if (cachedSpawnerListenerInstanceId !== undefined) {
+    return cachedSpawnerListenerInstanceId;
+  }
+
   const value = process.env[LISTENER_INSTANCE_ID_ENV];
-  return value && isValidListenerInstanceId(value) ? value : null;
+  delete process.env[LISTENER_INSTANCE_ID_ENV];
+  cachedSpawnerListenerInstanceId =
+    value && isValidListenerInstanceId(value) ? value : null;
+  return cachedSpawnerListenerInstanceId;
 }
+
+export const __listenerIdentityTestUtils = {
+  resetCachedSpawnerIdentity() {
+    cachedSpawnerListenerInstanceId = undefined;
+  },
+};


### PR DESCRIPTION
## Summary
- Consume `LETTA_LISTENER_INSTANCE_ID` synchronously at the beginning of listener registration, cache it for the lifetime of the owning process, and delete it from `process.env` before authentication reaches its first await.
- Keep registration and re-registration pinned to the cached identity while shells, subagents, and nested `letta server` processes inherit a sanitized environment and therefore cannot register into the owner listener slot.
- Preserve existing manual-listener behavior when no valid spawner identity is present, including consuming invalid transport values rather than exposing them to descendants.
- Add focused regressions for synchronous env removal, stable repeated registration under a changed display name, invalid-value cleanup, and the name-derived fallback. `bun run check` passes 12/12; 11 focused listener auth/identity tests pass.

Follow-up to #3453.

👾 Generated with [Letta Code](https://letta.com)