### PR TITLE
feat(channels): expose turn context to channel plugins

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -37,7 +37,7 @@
   "src/settings-manager.test.ts": 1669,
   "src/settings-manager.ts": 2113,
   "src/tools/impl/enter-worktree.ts": 1260,
-  "src/tools/impl/message-channel.ts": 1187,
+  "src/tools/impl/message-channel.ts": 1113,
   "src/tools/manager.ts": 3282,
   "src/tools/tool-execution-context.test.ts": 1422,
   "src/types/protocol_v2.ts": 2943,

--- a/src/channels/message-channel-slack.test.ts
+++ b/src/channels/message-channel-slack.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import {
   __testOverrideLoadChannelAccounts,
   __testOverrideSaveChannelAccounts,
@@ -7,6 +7,7 @@ import {
 } from "@/channels/accounts";
 import { ChannelRegistry, getChannelRegistry } from "@/channels/registry";
 import { clearAllRoutes, setRouteInMemory } from "@/channels/routing";
+import { slackMessageActions } from "@/channels/slack/message-actions";
 import {
   __testOverrideLoadTargetStore,
   __testOverrideSaveTargetStore,
@@ -18,6 +19,7 @@ import { message_channel } from "@/tools/impl/message-channel";
 
 describe("MessageChannel Slack", () => {
   afterEach(async () => {
+    mock.restore();
     const registry = getChannelRegistry();
     if (registry) {
       await registry.stopAll();
@@ -317,6 +319,7 @@ describe("MessageChannel Slack", () => {
       updatedAt: "2026-04-11T00:00:00.000Z",
     });
 
+    const handleAction = spyOn(slackMessageActions, "handleAction");
     const result = await message_channel({
       action: "send",
       channel: "slack",
@@ -333,7 +336,7 @@ describe("MessageChannel Slack", () => {
           chatId: "C123",
           chatType: "channel",
           messageId: "1712790000.000050",
-          threadId: "1712790000.000050",
+          threadId: null,
           agentId: "agent-1",
           conversationId: "conv-channel",
         },
@@ -341,6 +344,13 @@ describe("MessageChannel Slack", () => {
     });
 
     expect(result).toContain("Message sent to slack");
+    expect(handleAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: expect.objectContaining({
+          messageId: "1712790000.000050",
+        }),
+      }),
+    );
     expect(sendMessage).toHaveBeenCalledWith({
       channel: "slack",
       accountId: "account-1",
@@ -632,7 +642,7 @@ describe("MessageChannel Slack", () => {
     expect(downloadAttachment).not.toHaveBeenCalled();
   });
 
-  test("supports proactive Slack sends to explicit cached targets without consulting routes", async () => {
+  test("supports proactive and source-aware Slack sends to explicit cached targets", async () => {
     installChannelStateTestOverrides();
     const registry = new ChannelRegistry();
 
@@ -694,6 +704,7 @@ describe("MessageChannel Slack", () => {
       lastSeenAt: "2026-04-11T00:00:00.000Z",
     });
 
+    const handleAction = spyOn(slackMessageActions, "handleAction");
     const result = await message_channel({
       action: "send",
       channel: "slack",
@@ -706,6 +717,7 @@ describe("MessageChannel Slack", () => {
     });
 
     expect(result).toContain("Message sent to slack");
+    expect(handleAction.mock.calls[0]?.[0]).not.toHaveProperty("source");
     expect(sendMessage).toHaveBeenCalledWith({
       channel: "slack",
       accountId: "account-1",
@@ -717,6 +729,35 @@ describe("MessageChannel Slack", () => {
       agentId: "agent-1",
       conversationId: "default",
     });
+
+    await message_channel({
+      action: "send",
+      channel: "slack",
+      target: "#eng",
+      message: "hello from the active turn",
+      parentScope: {
+        agentId: "agent-1",
+        conversationId: "default",
+      },
+      channelTurnSources: [
+        {
+          channel: "slack",
+          accountId: "account-1",
+          chatId: "C999",
+          chatType: "channel",
+          messageId: "source-message",
+          threadId: null,
+          agentId: "agent-1",
+          conversationId: "default",
+        },
+      ],
+    });
+
+    expect(handleAction.mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({
+        source: expect.objectContaining({ messageId: "source-message" }),
+      }),
+    );
   });
 
   test("requires accountId when multiple proactive Slack accounts are eligible", async () => {

--- a/src/channels/plugin-types.ts
+++ b/src/channels/plugin-types.ts
@@ -4,6 +4,7 @@ import type {
   ChannelChatType,
   ChannelDefaultPermissionMode,
   ChannelRoute,
+  ChannelTurnSource,
   DiscordChannelMode,
   DmPolicy,
   OutboundChannelMessage,
@@ -260,6 +261,8 @@ export interface ChannelMessageActionContext {
   request: ChannelMessageActionRequest;
   route: ChannelRoute;
   adapter: ChannelAdapter;
+  /** Unique initiating channel message when this action belongs to a channel turn. */
+  source?: ChannelTurnSource;
   /**
    * Format user-authored markdown/plain text for the target channel before the
    * plugin sends it. The shared MessageChannel tool owns cross-channel text

--- a/src/channels/processor.test.ts
+++ b/src/channels/processor.test.ts
@@ -120,15 +120,16 @@ describe("channel processor primitives", () => {
   });
 
   test("builds outbound channel messages from turn source", () => {
+    const source = {
+      channel: "slack",
+      accountId: "integration-1",
+      chatId: "C123",
+      threadId: "1700000000.000100",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+    };
     const message = buildOutboundChannelMessageFromTurnSource({
-      turnSource: {
-        channel: "slack",
-        accountId: "integration-1",
-        chatId: "C123",
-        threadId: "1700000000.000100",
-        agentId: "agent-1",
-        conversationId: "conv-1",
-      },
+      turnSource: source,
       text: "response",
     });
 
@@ -137,6 +138,7 @@ describe("channel processor primitives", () => {
       accountId: "integration-1",
       chatId: "C123",
       threadId: "1700000000.000100",
+      source,
       text: "response",
       agentId: "agent-1",
       conversationId: "conv-1",

--- a/src/channels/processor.ts
+++ b/src/channels/processor.ts
@@ -153,6 +153,7 @@ export function buildOutboundChannelMessageFromTurnSource(
     accountId: turnSource.accountId,
     chatId: turnSource.chatId,
     threadId: turnSource.threadId,
+    source: turnSource,
     text: params.text,
     agentId: turnSource.agentId,
     conversationId: turnSource.conversationId,

--- a/src/channels/progress-builder-events.test.ts
+++ b/src/channels/progress-builder-events.test.ts
@@ -1,11 +1,23 @@
 import { expect, test } from "bun:test";
 import type { StreamDelta } from "@/types/protocol_v2";
-import { createChannelTurnProgressBuilder } from "./progress-builder";
+import { createChannelTurnProgressBuilder as createRawChannelTurnProgressBuilder } from "./progress-builder";
 
 import { sanitizeChannelProgressText } from "./progress-formatting";
 
+function createPresentationProgressBuilder() {
+  const builder = createRawChannelTurnProgressBuilder();
+  return {
+    buildUpdates(delta: unknown) {
+      return builder.buildUpdates(delta).map(({ toolInput, ...update }) => {
+        void toolInput;
+        return update;
+      });
+    },
+  };
+}
+
 test("channel progress labels client-side tool execution events", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   const updates = builder.buildUpdates({
     message_type: "client_tool_start",
     run_id: "run-1",
@@ -31,7 +43,7 @@ test("channel progress labels client-side tool execution events", () => {
 });
 
 test("channel progress completes client-side tool rows from cached metadata", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   builder.buildUpdates({
     message_type: "client_tool_start",
     run_id: "run-1",
@@ -64,7 +76,7 @@ test("channel progress completes client-side tool rows from cached metadata", ()
 });
 
 test("channel progress waits for streamed exec_command descriptions", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   expect(
     builder.buildUpdates({
       message_type: "approval_request_message",
@@ -131,7 +143,7 @@ test("channel progress waits for streamed exec_command descriptions", () => {
 });
 
 test("channel progress remembers tool names across streamed Skill args", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   builder.buildUpdates({
     message_type: "approval_request_message",
     run_id: "run-1",
@@ -169,7 +181,7 @@ test("channel progress remembers tool names across streamed Skill args", () => {
 });
 
 test("channel progress renders approval request deltas as tool rows", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   const updates = builder.buildUpdates({
     message_type: "approval_request_message",
     run_id: "run-1",
@@ -199,7 +211,7 @@ test("channel progress renders approval request deltas as tool rows", () => {
 });
 
 test("channel progress extracts tool details when arguments is an object", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   const updates = builder.buildUpdates({
     message_type: "approval_request_message",
     run_id: "run-1",
@@ -229,7 +241,7 @@ test("channel progress extracts tool details when arguments is an object", () =>
 });
 
 test("channel progress falls back to shell command preview when description is missing", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   const updates = builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
@@ -259,7 +271,7 @@ test("channel progress falls back to shell command preview when description is m
 });
 
 test("channel progress resolves details from accumulated args on tool return", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
@@ -301,7 +313,7 @@ test("channel progress resolves details from accumulated args on tool return", (
 });
 
 test("channel progress builders do not share accumulated state", () => {
-  const firstBuilder = createChannelTurnProgressBuilder();
+  const firstBuilder = createPresentationProgressBuilder();
   firstBuilder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
@@ -318,7 +330,7 @@ test("channel progress builders do not share accumulated state", () => {
 
   // A different turn's builder must not see the first turn's cached
   // arguments or tool names for the same tool_call_id.
-  const secondBuilder = createChannelTurnProgressBuilder();
+  const secondBuilder = createPresentationProgressBuilder();
   expect(
     secondBuilder.buildUpdates({
       message_type: "tool_return_message",
@@ -343,7 +355,7 @@ test("channel progress builders do not share accumulated state", () => {
 });
 
 test("channel progress maps canonical parallel tool return arrays", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   const updates = builder.buildUpdates({
     message_type: "tool_return_message",
     run_id: "run-1",
@@ -390,7 +402,7 @@ test("channel progress sanitizes status text before adapters see it", () => {
 });
 
 test("channel progress maps lifecycle stream deltas to generic updates", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   expect(
     builder.buildUpdates({
       message_type: "retry",

--- a/src/channels/progress-builder-input.test.ts
+++ b/src/channels/progress-builder-input.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { createChannelTurnProgressBuilder } from "./progress-builder";
+
+describe("channel progress tool input", () => {
+  test("exposes complete structured tool input to channel adapters", () => {
+    const builder = createChannelTurnProgressBuilder();
+
+    const updates = builder.buildUpdates({
+      message_type: "tool_call_message",
+      run_id: "run-1",
+      tool_calls: [
+        {
+          tool_call_id: "call-1",
+          name: "web_search",
+          arguments: JSON.stringify({ query: "Matrix SDK" }),
+        },
+      ],
+    });
+
+    expect(updates[0]?.toolInput).toEqual({ query: "Matrix SDK" });
+  });
+
+  test("omits incomplete argument fragments until they form valid JSON", () => {
+    const builder = createChannelTurnProgressBuilder();
+
+    const first = builder.buildUpdates({
+      message_type: "tool_call_message",
+      tool_calls: {
+        tool_call_id: "call-1",
+        name: "Skill",
+        arguments: '{"skill":"custom',
+      },
+    });
+    const second = builder.buildUpdates({
+      message_type: "tool_call_message",
+      tool_calls: {
+        tool_call_id: "call-1",
+        arguments: '-adapter"}',
+      },
+    });
+
+    expect(first[0]?.toolInput).toBeUndefined();
+    expect(second[0]?.toolInput).toEqual({ skill: "custom-adapter" });
+  });
+
+  test("exposes accumulated input on terminal tool progress", () => {
+    const builder = createChannelTurnProgressBuilder();
+    builder.buildUpdates({
+      message_type: "tool_call_message",
+      tool_calls: {
+        tool_call_id: "call-1",
+        name: "update_plan",
+        arguments: '{"plan":[{"step":"Ship",',
+      },
+    });
+
+    const updates = builder.buildUpdates({
+      message_type: "tool_return_message",
+      tool_call_id: "call-1",
+      name: "update_plan",
+      arguments: '"status":"completed"}]}',
+      status: "success",
+    });
+
+    expect(updates[0]?.toolInput).toEqual({
+      plan: [{ step: "Ship", status: "completed" }],
+    });
+  });
+});

--- a/src/channels/progress-builder-tools.test.ts
+++ b/src/channels/progress-builder-tools.test.ts
@@ -1,9 +1,23 @@
 import { expect, test } from "bun:test";
 import type { StreamDelta } from "@/types/protocol_v2";
-import { createChannelTurnProgressBuilder } from "./progress-builder";
+import { createChannelTurnProgressBuilder as createRawChannelTurnProgressBuilder } from "./progress-builder";
 
-test("channel progress converts tool call deltas without leaking args", () => {
-  const builder = createChannelTurnProgressBuilder();
+function createPresentationProgressBuilder(
+  ...args: Parameters<typeof createRawChannelTurnProgressBuilder>
+) {
+  const builder = createRawChannelTurnProgressBuilder(...args);
+  return {
+    buildUpdates(delta: unknown) {
+      return builder.buildUpdates(delta).map(({ toolInput, ...update }) => {
+        void toolInput;
+        return update;
+      });
+    },
+  };
+}
+
+test("channel progress keeps tool input out of user-facing presentation fields", () => {
+  const builder = createPresentationProgressBuilder();
   const updates = builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
@@ -29,7 +43,7 @@ test("channel progress converts tool call deltas without leaking args", () => {
 });
 
 test("channel progress uses web_search query as task details", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   const updates = builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
@@ -59,7 +73,7 @@ test("channel progress uses web_search query as task details", () => {
 });
 
 test("channel progress uses Skill names as task details", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   const updates = builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
@@ -89,7 +103,7 @@ test("channel progress uses Skill names as task details", () => {
 });
 
 test("channel progress uses Skill descriptions as task details when available", () => {
-  const builder = createChannelTurnProgressBuilder({
+  const builder = createPresentationProgressBuilder({
     skillDescriptionsByName: {
       "scheduling-tasks": "Schedules reminders and recurring tasks via cron.",
     },
@@ -123,7 +137,7 @@ test("channel progress uses Skill descriptions as task details when available", 
 });
 
 test("channel progress uses cached Skill names for streamed argument fragments", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   expect(
     builder.buildUpdates({
       message_type: "tool_call_message",
@@ -173,7 +187,7 @@ test("channel progress uses cached Skill names for streamed argument fragments",
 });
 
 test("channel progress recognizes namespaced Skill tool names", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   const updates = builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
@@ -203,7 +217,7 @@ test("channel progress recognizes namespaced Skill tool names", () => {
 });
 
 test("channel progress does not duplicate singular Skill alias fragments", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   const firstFragment = {
     tool_call_id: "call-1",
     name: "Skill",
@@ -253,7 +267,7 @@ test("channel progress does not duplicate singular Skill alias fragments", () =>
 });
 
 test("channel progress previews subagent prompts", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   const updates = builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
@@ -286,7 +300,7 @@ test("channel progress previews subagent prompts", () => {
 });
 
 test("channel progress truncates subagent previews with ASCII ellipses", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   const updates = builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
@@ -307,7 +321,7 @@ test("channel progress truncates subagent previews with ASCII ellipses", () => {
 });
 
 test("channel progress keeps subagent prompt previews across streamed fragments", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   expect(
     builder.buildUpdates({
       message_type: "tool_call_message",
@@ -356,7 +370,7 @@ test("channel progress keeps subagent prompt previews across streamed fragments"
 });
 
 test("channel progress previews fetch_webpage URLs", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   const updates = builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
@@ -383,7 +397,7 @@ test("channel progress previews fetch_webpage URLs", () => {
 });
 
 test("channel progress builds file action titles with line counts", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
@@ -427,7 +441,7 @@ test("channel progress builds file action titles with line counts", () => {
 });
 
 test("channel progress builds failed file titles", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
@@ -471,7 +485,7 @@ test("channel progress builds failed file titles", () => {
 });
 
 test("channel progress keeps shell error output out of toolDetails (LET-9509)", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
@@ -518,7 +532,7 @@ test("channel progress keeps shell error output out of toolDetails (LET-9509)", 
 });
 
 test("channel progress emits only errorDetails when failed shell args never arrived", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   const updates = builder.buildUpdates({
     message_type: "tool_return_message",
     run_id: "run-1",
@@ -546,7 +560,7 @@ test("channel progress emits only errorDetails when failed shell args never arri
 });
 
 test("channel progress uses Bash descriptions as task details", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   const updates = builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",
@@ -576,7 +590,7 @@ test("channel progress uses Bash descriptions as task details", () => {
 });
 
 test("channel progress uses exec_command descriptions as task details", () => {
-  const builder = createChannelTurnProgressBuilder();
+  const builder = createPresentationProgressBuilder();
   const updates = builder.buildUpdates({
     message_type: "tool_call_message",
     run_id: "run-1",

--- a/src/channels/progress-builder.ts
+++ b/src/channels/progress-builder.ts
@@ -87,6 +87,12 @@ function toolNameForMessage(summary: ToolCallSummary | undefined): string {
   return summary?.name ? `: ${summary.name}` : "";
 }
 
+function getCompleteToolInput(
+  summary: ToolCallSummary | null | undefined,
+): Readonly<Record<string, unknown>> | undefined {
+  return parseToolArguments(summary?.argumentsText) ?? undefined;
+}
+
 /**
  * Builds sanitized channel progress updates from stream deltas for a single
  * turn. Instances accumulate fragmented tool-call arguments across deltas,
@@ -280,6 +286,7 @@ export function createChannelTurnProgressBuilder(
     for (const tool of tools) {
       const toolDetails = formatToolProgressDetails(tool, options);
       const toolTitle = formatToolProgressTitle(tool, "started");
+      const toolInput = getCompleteToolInput(tool);
       updates.push(
         withRunId(
           {
@@ -288,6 +295,7 @@ export function createChannelTurnProgressBuilder(
             message: `Preparing tool${toolNameForMessage(tool)}`,
             ...(tool.id ? { toolCallId: tool.id } : {}),
             ...(tool.name ? { toolName: tool.name } : {}),
+            ...(toolInput ? { toolInput } : {}),
             ...(toolDetails ? { toolDetails } : {}),
             ...(toolTitle ? { toolTitle } : {}),
           },
@@ -379,6 +387,7 @@ export function createChannelTurnProgressBuilder(
             toolWithAccumulatedArgs,
             status,
           );
+          const toolInput = getCompleteToolInput(toolWithAccumulatedArgs);
           updates.push(
             withRunId(
               {
@@ -387,6 +396,7 @@ export function createChannelTurnProgressBuilder(
                 message: status === "error" ? "Tool failed" : "Tool finished",
                 ...(summary.id ? { toolCallId: summary.id } : {}),
                 ...(summary.name ? { toolName: summary.name } : {}),
+                ...(toolInput ? { toolInput } : {}),
                 ...(toolDetails ? { toolDetails } : {}),
                 ...(status === "error" && errorDetails ? { errorDetails } : {}),
                 ...(toolTitle ? { toolTitle } : {}),
@@ -406,6 +416,7 @@ export function createChannelTurnProgressBuilder(
         const toolTitle = tool
           ? formatToolProgressTitle(tool, "started")
           : undefined;
+        const toolInput = getCompleteToolInput(tool);
         return [
           withRunId(
             {
@@ -414,6 +425,7 @@ export function createChannelTurnProgressBuilder(
               message: "Running tool",
               ...(tool?.id ? { toolCallId: tool.id } : {}),
               ...(tool?.name ? { toolName: tool.name } : {}),
+              ...(toolInput ? { toolInput } : {}),
               ...(toolDetails ? { toolDetails } : {}),
               ...(toolTitle ? { toolTitle } : {}),
             },
@@ -446,6 +458,7 @@ export function createChannelTurnProgressBuilder(
         const toolTitle = toolWithAccumulatedArgs
           ? formatToolProgressTitle(toolWithAccumulatedArgs, state)
           : undefined;
+        const toolInput = getCompleteToolInput(toolWithAccumulatedArgs);
         return [
           withRunId(
             {
@@ -454,6 +467,7 @@ export function createChannelTurnProgressBuilder(
               message: state === "error" ? "Tool failed" : "Tool finished",
               ...(tool?.id ? { toolCallId: tool.id } : {}),
               ...(tool?.name ? { toolName: tool.name } : {}),
+              ...(toolInput ? { toolInput } : {}),
               ...(toolDetails ? { toolDetails } : {}),
               ...(errorDetails ? { errorDetails } : {}),
               ...(toolTitle ? { toolTitle } : {}),

--- a/src/channels/turn-source.test.ts
+++ b/src/channels/turn-source.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import type { ChannelTurnSource } from "@/channels/types";
+import {
+  channelTurnSourceIdentity,
+  effectiveChannelTurnSourceThreadId,
+} from "./turn-source";
+
+function turnSource(
+  overrides: Partial<ChannelTurnSource> = {},
+): ChannelTurnSource {
+  return {
+    channel: "slack",
+    accountId: "account-1",
+    chatId: "C123",
+    chatType: "channel",
+    senderId: "U123",
+    senderTeamId: "T123",
+    messageId: "1712790000.000050",
+    threadId: null,
+    agentId: "agent-1",
+    conversationId: "conversation-1",
+    ...overrides,
+  };
+}
+
+describe("channel turn source helpers", () => {
+  test("identity includes all provenance fields", () => {
+    const source = turnSource();
+
+    expect(channelTurnSourceIdentity({ ...source })).toBe(
+      channelTurnSourceIdentity(source),
+    );
+    expect(channelTurnSourceIdentity({ ...source, senderId: "U456" })).not.toBe(
+      channelTurnSourceIdentity(source),
+    );
+    expect(
+      channelTurnSourceIdentity({ ...source, senderTeamId: "T456" }),
+    ).not.toBe(channelTurnSourceIdentity(source));
+    expect(
+      channelTurnSourceIdentity({ ...source, chatType: "direct" }),
+    ).not.toBe(channelTurnSourceIdentity(source));
+  });
+
+  test("uses Slack root messages as effective thread identifiers", () => {
+    expect(effectiveChannelTurnSourceThreadId(turnSource())).toBe(
+      "1712790000.000050",
+    );
+    expect(
+      effectiveChannelTurnSourceThreadId(turnSource({ threadId: "root-ts" })),
+    ).toBe("root-ts");
+    expect(
+      effectiveChannelTurnSourceThreadId(
+        turnSource({ channel: "telegram", threadId: null }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/channels/turn-source.ts
+++ b/src/channels/turn-source.ts
@@ -1,0 +1,30 @@
+import type { ChannelTurnSource } from "@/channels/types";
+
+/** Stable identity for comparing complete channel-turn provenance records. */
+export function channelTurnSourceIdentity(source: ChannelTurnSource): string {
+  return JSON.stringify([
+    source.channel,
+    source.accountId ?? null,
+    source.chatId,
+    source.chatType ?? null,
+    source.senderId ?? null,
+    source.senderTeamId ?? null,
+    source.messageId ?? null,
+    source.threadId ?? null,
+    source.agentId,
+    source.conversationId,
+  ]);
+}
+
+/** Thread used when routing output back to the source turn. */
+export function effectiveChannelTurnSourceThreadId(
+  source: ChannelTurnSource,
+): string | null {
+  if (source.threadId !== undefined && source.threadId !== null) {
+    return source.threadId;
+  }
+  if (source.channel === "slack" && source.chatType !== "direct") {
+    return source.messageId ?? null;
+  }
+  return null;
+}

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -437,6 +437,8 @@ export interface OutboundChannelMessage {
   parseMode?: string;
   /** Optional: rich structured message payload for channels that support it. */
   richMessage?: ChannelRichMessage;
+  /** Unique initiating channel message when this output belongs to a channel turn. */
+  source?: ChannelTurnSource;
   /** Optional: Signal-style text ranges (start:length:STYLE) for platforms that support rich text entities. */
   textStyle?: string[];
   /** Optional: attach a local file/media path for channels that support uploads. */
@@ -468,6 +470,8 @@ export interface OutboundChannelRichMessageDraft {
   threadId?: string | null;
   /** Stable non-zero platform draft identifier for animated updates. */
   draftId: number;
+  /** Unique initiating channel message when this draft belongs to a channel turn. */
+  source?: ChannelTurnSource;
   /** Rich structured message payload for the draft preview. */
   richMessage: ChannelRichMessage;
 }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -187,6 +187,11 @@ export interface ChannelTurnProgressUpdate {
   message: string;
   toolCallId?: string;
   toolName?: string;
+  /**
+   * Complete structured tool input for adapter-owned presentation. This value
+   * is not sanitized and must never be rendered directly.
+   */
+  toolInput?: Readonly<Record<string, unknown>>;
   /** Optional sanitized argument summary for expanded tool progress details. */
   toolDetails?: string;
   /**

--- a/src/tools/impl/message-channel-source.test.ts
+++ b/src/tools/impl/message-channel-source.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import type { ChannelTurnSource } from "@/channels/types";
+import {
+  resolveMessageChannelTurnSource,
+  resolveUniqueChannelTurnSource,
+} from "./message-channel-source";
+import type { NormalizedMessageChannelInput } from "./message-channel-types";
+
+function messageInput(
+  overrides: Partial<NormalizedMessageChannelInput> = {},
+): NormalizedMessageChannelInput {
+  return {
+    action: "send",
+    channel: "source-aware",
+    chatId: "chat-1",
+    threadId: null,
+    message: "hello",
+    ...overrides,
+  };
+}
+
+function turnSource(
+  overrides: Partial<ChannelTurnSource> = {},
+): ChannelTurnSource {
+  return {
+    channel: "source-aware",
+    accountId: "account-1",
+    chatId: "chat-1",
+    chatType: "channel",
+    senderId: "sender-1",
+    senderTeamId: "team-1",
+    messageId: "message-1",
+    threadId: null,
+    agentId: "agent-1",
+    conversationId: "conversation-1",
+    ...overrides,
+  };
+}
+
+const scope = { agentId: "agent-1", conversationId: "conversation-1" };
+
+describe("MessageChannel turn source resolution", () => {
+  test("collapses identical source copies", () => {
+    const source = turnSource();
+
+    expect(
+      resolveUniqueChannelTurnSource({
+        input: messageInput(),
+        scope,
+        accountId: "account-1",
+        threadId: null,
+        channelTurnSources: [source, { ...source }],
+      }),
+    ).toEqual(source);
+  });
+
+  test("fails closed for conflicting matching sources", () => {
+    expect(
+      resolveUniqueChannelTurnSource({
+        input: messageInput(),
+        scope,
+        accountId: "account-1",
+        threadId: null,
+        channelTurnSources: [
+          turnSource(),
+          turnSource({ senderId: "sender-2" }),
+        ],
+      }),
+    ).toBeUndefined();
+  });
+
+  test("preserves provenance when Slack infers a root thread", () => {
+    const source = turnSource({
+      channel: "slack",
+      chatId: "C123",
+      messageId: "1712790000.000050",
+    });
+
+    expect(
+      resolveMessageChannelTurnSource({
+        input: messageInput({ channel: "slack", chatId: "C123" }),
+        scope,
+        accountId: "account-1",
+        routeThreadId: null,
+        channelTurnSources: [source],
+      }),
+    ).toEqual({
+      threadId: "1712790000.000050",
+      source,
+    });
+  });
+});

--- a/src/tools/impl/message-channel-source.ts
+++ b/src/tools/impl/message-channel-source.ts
@@ -1,0 +1,168 @@
+import type { ChannelMessageActionRequest } from "@/channels/plugin-types";
+import {
+  channelTurnSourceIdentity,
+  effectiveChannelTurnSourceThreadId,
+} from "@/channels/turn-source";
+import type { ChannelTurnSource } from "@/channels/types";
+import type { NormalizedMessageChannelInput } from "./message-channel-types";
+
+type MessageChannelScope = { agentId: string; conversationId: string };
+
+export function buildMessageChannelRequest(
+  input: NormalizedMessageChannelInput,
+  chatId: string,
+  threadId?: string | null,
+): ChannelMessageActionRequest {
+  return {
+    action: input.action,
+    channel: input.channel,
+    chatId,
+    message: input.message,
+    replyToMessageId: input.replyToMessageId,
+    threadId: threadId ?? input.threadId ?? null,
+    messageId: input.messageId,
+    attachmentId: input.attachmentId,
+    emoji: input.emoji,
+    remove: input.remove,
+    mediaPath: input.mediaPath,
+    filename: input.filename,
+    title: input.title,
+  };
+}
+
+function sourceMatchesRoute(params: {
+  source: ChannelTurnSource;
+  input: NormalizedMessageChannelInput;
+  scope: MessageChannelScope;
+  accountId?: string;
+  threadId?: string | null;
+  /** Compare against channel routing fallbacks after thread inference. */
+  useEffectiveThreadId?: boolean;
+}): boolean {
+  const { source, input, scope } = params;
+  const sourceThreadId = params.useEffectiveThreadId
+    ? effectiveChannelTurnSourceThreadId(source)
+    : (source.threadId ?? null);
+  return (
+    source.channel === input.channel &&
+    source.chatId === input.chatId &&
+    source.agentId === scope.agentId &&
+    source.conversationId === scope.conversationId &&
+    (!params.accountId || source.accountId === params.accountId) &&
+    (params.threadId === undefined ||
+      sourceThreadId === (params.threadId ?? null))
+  );
+}
+
+/**
+ * Resolve provenance only when one distinct channel source matches the selected
+ * route. Duplicate copies collapse; conflicting sources fail closed.
+ */
+export function resolveUniqueChannelTurnSource(params: {
+  input: NormalizedMessageChannelInput;
+  scope: MessageChannelScope;
+  accountId?: string;
+  threadId?: string | null;
+  /** Compare against channel routing fallbacks after thread inference. */
+  useEffectiveThreadId?: boolean;
+  channelTurnSources?: ChannelTurnSource[];
+}): ChannelTurnSource | undefined {
+  if (!params.input.chatId) {
+    return undefined;
+  }
+
+  const matchingSources = new Map<string, ChannelTurnSource>();
+  for (const source of params.channelTurnSources ?? []) {
+    if (!sourceMatchesRoute({ ...params, source })) {
+      continue;
+    }
+    matchingSources.set(channelTurnSourceIdentity(source), source);
+    if (matchingSources.size > 1) {
+      return undefined;
+    }
+  }
+  return matchingSources.values().next().value;
+}
+
+export function inferAccountIdFromChannelTurnSources(params: {
+  input: NormalizedMessageChannelInput;
+  scope: MessageChannelScope;
+  channelTurnSources?: ChannelTurnSource[];
+}): string | undefined {
+  const chatId = params.input.chatId;
+  if (!chatId) {
+    return undefined;
+  }
+
+  const accountIds = new Set<string>();
+  for (const source of params.channelTurnSources ?? []) {
+    if (
+      source.channel !== params.input.channel ||
+      source.chatId !== chatId ||
+      source.agentId !== params.scope.agentId ||
+      source.conversationId !== params.scope.conversationId
+    ) {
+      continue;
+    }
+    if (
+      params.input.threadId !== undefined &&
+      (source.threadId ?? null) !== (params.input.threadId ?? null)
+    ) {
+      continue;
+    }
+    if (source.accountId?.trim()) {
+      accountIds.add(source.accountId.trim());
+    }
+  }
+
+  return accountIds.size === 1 ? [...accountIds][0] : undefined;
+}
+
+export function inferThreadIdFromChannelTurnSources(params: {
+  input: NormalizedMessageChannelInput;
+  scope: MessageChannelScope;
+  accountId?: string;
+  channelTurnSources?: ChannelTurnSource[];
+}): string | null | undefined {
+  if (!params.input.chatId || params.input.threadId !== null) {
+    return undefined;
+  }
+
+  const threadIds = new Set<string | null>();
+  for (const source of params.channelTurnSources ?? []) {
+    if (
+      source.channel !== params.input.channel ||
+      source.chatId !== params.input.chatId ||
+      source.agentId !== params.scope.agentId ||
+      source.conversationId !== params.scope.conversationId
+    ) {
+      continue;
+    }
+    if (params.accountId && source.accountId !== params.accountId) {
+      continue;
+    }
+    threadIds.add(effectiveChannelTurnSourceThreadId(source));
+  }
+
+  return threadIds.size === 1 ? [...threadIds][0] : undefined;
+}
+
+export function resolveMessageChannelTurnSource(params: {
+  input: NormalizedMessageChannelInput;
+  scope: MessageChannelScope;
+  accountId?: string;
+  routeThreadId?: string | null;
+  channelTurnSources?: ChannelTurnSource[];
+}): { threadId?: string | null; source?: ChannelTurnSource } {
+  const inferredThreadId = inferThreadIdFromChannelTurnSources(params);
+  const threadId =
+    params.input.action === "download-file"
+      ? params.input.threadId
+      : (inferredThreadId ?? params.routeThreadId ?? params.input.threadId);
+  const source = resolveUniqueChannelTurnSource({
+    ...params,
+    threadId,
+    useEffectiveThreadId: true,
+  });
+  return { threadId, ...(source ? { source } : {}) };
+}

--- a/src/tools/impl/message-channel.ts
+++ b/src/tools/impl/message-channel.ts
@@ -27,6 +27,12 @@ import type {
   OutboundChannelMessage,
   SupportedChannelId,
 } from "@/channels/types";
+import {
+  buildMessageChannelRequest,
+  inferAccountIdFromChannelTurnSources,
+  resolveMessageChannelTurnSource,
+  resolveUniqueChannelTurnSource,
+} from "./message-channel-source";
 import type {
   MessageChannelArgs,
   NormalizedMessageChannelInput,
@@ -804,6 +810,7 @@ interface ResolvedMessageChannelExecutionContext {
   route: ChannelRoute;
   adapter: ChannelAdapter;
   plugin: Awaited<ReturnType<typeof loadChannelPlugin>>;
+  source?: ChannelTurnSource;
 }
 
 function firstNonEmptyString(...values: unknown[]): string | undefined {
@@ -908,28 +915,6 @@ function normalizeMessageChannelInput(
   };
 }
 
-function buildMessageChannelRequest(
-  input: NormalizedMessageChannelInput,
-  chatId: string,
-  threadId?: string | null,
-): ChannelMessageActionRequest {
-  return {
-    action: input.action,
-    channel: input.channel,
-    chatId,
-    message: input.message,
-    replyToMessageId: input.replyToMessageId,
-    threadId: threadId ?? input.threadId ?? null,
-    messageId: input.messageId,
-    attachmentId: input.attachmentId,
-    emoji: input.emoji,
-    remove: input.remove,
-    mediaPath: input.mediaPath,
-    filename: input.filename,
-    title: input.title,
-  };
-}
-
 function buildSyntheticChannelRoute(params: {
   scope: { agentId: string; conversationId: string };
   accountId: string;
@@ -951,78 +936,10 @@ function buildSyntheticChannelRoute(params: {
   };
 }
 
-function inferAccountIdFromChannelTurnSources(params: {
-  input: NormalizedMessageChannelInput;
-  scope: { agentId: string; conversationId: string };
-  channelTurnSources?: ChannelTurnSource[];
-}): string | undefined {
-  const chatId = params.input.chatId;
-  if (!chatId) {
-    return undefined;
-  }
-
-  const accountIds = new Set<string>();
-  for (const source of params.channelTurnSources ?? []) {
-    if (
-      source.channel !== params.input.channel ||
-      source.chatId !== chatId ||
-      source.agentId !== params.scope.agentId ||
-      source.conversationId !== params.scope.conversationId
-    ) {
-      continue;
-    }
-    if (
-      params.input.threadId !== undefined &&
-      (source.threadId ?? null) !== (params.input.threadId ?? null)
-    ) {
-      continue;
-    }
-    if (source.accountId?.trim()) {
-      accountIds.add(source.accountId.trim());
-    }
-  }
-
-  return accountIds.size === 1 ? [...accountIds][0] : undefined;
-}
-
-function inferThreadIdFromChannelTurnSources(params: {
-  input: NormalizedMessageChannelInput;
-  scope: { agentId: string; conversationId: string };
-  accountId?: string;
-  channelTurnSources?: ChannelTurnSource[];
-}): string | null | undefined {
-  if (!params.input.chatId || params.input.threadId !== null) {
-    return undefined;
-  }
-
-  const threadIds = new Set<string | null>();
-  for (const source of params.channelTurnSources ?? []) {
-    if (
-      source.channel !== params.input.channel ||
-      source.chatId !== params.input.chatId ||
-      source.agentId !== params.scope.agentId ||
-      source.conversationId !== params.scope.conversationId
-    ) {
-      continue;
-    }
-    if (params.accountId && source.accountId !== params.accountId) {
-      continue;
-    }
-
-    const sourceThreadId = source.threadId ?? null;
-    const fallbackThreadId =
-      params.input.channel === "slack" && source.chatType !== "direct"
-        ? source.messageId
-        : null;
-    threadIds.add(sourceThreadId ?? fallbackThreadId ?? null);
-  }
-
-  return threadIds.size === 1 ? [...threadIds][0] : undefined;
-}
-
 async function resolveExplicitMessageChannelContext(params: {
   input: NormalizedMessageChannelInput;
   scope: { agentId: string; conversationId: string };
+  channelTurnSources?: ChannelTurnSource[];
 }): Promise<ResolvedMessageChannelExecutionContext | string> {
   if (params.input.channel !== "slack") {
     return `Error: Explicit MessageChannel targets are not supported on ${params.input.channel}.`;
@@ -1047,6 +964,13 @@ async function resolveExplicitMessageChannelContext(params: {
     account: eligibleAccount.account,
     target: params.input.target ?? "",
   });
+  const source = resolveUniqueChannelTurnSource({
+    input: { ...params.input, chatId: resolvedTarget.chatId },
+    scope: params.scope,
+    accountId: eligibleAccount.account.accountId,
+    threadId: resolvedTarget.threadId ?? null,
+    channelTurnSources: params.channelTurnSources,
+  });
 
   return {
     request: buildMessageChannelRequest(
@@ -1063,6 +987,7 @@ async function resolveExplicitMessageChannelContext(params: {
     }),
     adapter: eligibleAccount.adapter,
     plugin,
+    ...(source ? { source } : {}),
   };
 }
 
@@ -1127,16 +1052,14 @@ export async function message_channel(
       }
 
       const plugin = await loadChannelPlugin(input.channel);
-      const inferredThreadId = inferThreadIdFromChannelTurnSources({
-        input,
-        scope,
-        accountId: resolvedAccountId,
-        channelTurnSources: args.channelTurnSources,
-      });
-      const requestThreadId =
-        input.action === "download-file"
-          ? input.threadId
-          : (inferredThreadId ?? route.threadId ?? input.threadId);
+      const { threadId: requestThreadId, source } =
+        resolveMessageChannelTurnSource({
+          input,
+          scope,
+          accountId: route.accountId,
+          routeThreadId: route.threadId,
+          channelTurnSources: args.channelTurnSources,
+        });
       executionContext = {
         request: buildMessageChannelRequest(
           input,
@@ -1146,11 +1069,13 @@ export async function message_channel(
         route,
         adapter,
         plugin,
+        ...(source ? { source } : {}),
       };
     } else {
       executionContext = await resolveExplicitMessageChannelContext({
         input,
         scope,
+        channelTurnSources: args.channelTurnSources,
       });
     }
 
@@ -1158,7 +1083,7 @@ export async function message_channel(
       return executionContext;
     }
 
-    const { request, route, adapter, plugin } = executionContext;
+    const { request, route, adapter, plugin, source } = executionContext;
     if (!plugin.messageActions) {
       return `Error: Channel "${request.channel}" does not expose MessageChannel actions.`;
     }
@@ -1178,6 +1103,7 @@ export async function message_channel(
       request,
       route,
       adapter,
+      ...(source ? { source } : {}),
       formatText: (text) => formatOutboundChannelMessage(request.channel, text),
     });
   } catch (err) {

--- a/src/websocket/listener/channel-rich-draft-streamer.test.ts
+++ b/src/websocket/listener/channel-rich-draft-streamer.test.ts
@@ -152,6 +152,7 @@ describe("Telegram rich draft streamer", () => {
       chatId: "chat-12345",
       threadId: "42",
       draftId: expect.any(Number),
+      source: telegramSource({ threadId: "42" }),
       richMessage: { markdown: "# Draft\n\nStill gener" },
     });
   });
@@ -186,8 +187,43 @@ describe("Telegram rich draft streamer", () => {
       chatId: "chat-12345",
       threadId: null,
       draftId: expect.any(Number),
+      source: telegramSource(),
       richMessage: { markdown: "# Private default" },
     });
+  });
+
+  test("disables rich drafts for multiple distinct source messages", () => {
+    upsertTelegramAccount(true);
+    const { sendRichMessageDraft } = registerTelegramAdapter();
+
+    const streamer = createChannelRichDraftStreamer({
+      batchId: "batch-multiple-messages",
+      sources: [
+        telegramSource({ messageId: "14280" }),
+        telegramSource({ messageId: "14281" }),
+      ],
+      debounceMs: 0,
+    });
+
+    expect(streamer).toBeNull();
+    expect(sendRichMessageDraft).not.toHaveBeenCalled();
+  });
+
+  test("disables rich drafts for conflicting source metadata", () => {
+    upsertTelegramAccount(true);
+    const { sendRichMessageDraft } = registerTelegramAdapter();
+
+    const streamer = createChannelRichDraftStreamer({
+      batchId: "batch-conflicting-source",
+      sources: [
+        telegramSource({ senderId: "sender-1" }),
+        telegramSource({ senderId: "sender-2" }),
+      ],
+      debounceMs: 0,
+    });
+
+    expect(streamer).toBeNull();
+    expect(sendRichMessageDraft).not.toHaveBeenCalled();
   });
 
   test("does not stream private Telegram send args when default rich messaging is disabled", async () => {

--- a/src/websocket/listener/channel-rich-draft-streamer.ts
+++ b/src/websocket/listener/channel-rich-draft-streamer.ts
@@ -1,6 +1,7 @@
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import { getChannelAccount } from "@/channels/accounts";
 import { getChannelRegistry } from "@/channels/registry";
+import { channelTurnSourceIdentity } from "@/channels/turn-source";
 import type { ChannelAdapter, ChannelTurnSource } from "@/channels/types";
 import { getRichDraftStreamingPolicy } from "@/channels/types";
 import { debugLog, debugWarn } from "@/utils/debug";
@@ -122,22 +123,22 @@ function resolveSingleChannelDraftSource(
     return null;
   }
 
-  const byRoute = new Map<string, ChannelDraftSource>();
+  const distinctSources = new Map<string, ChannelDraftSource>();
   for (const source of candidateSources) {
-    byRoute.set(
-      [
-        source.channel,
-        source.accountId.trim(),
-        source.chatId,
-        source.threadId ?? "",
-        source.agentId,
-        source.conversationId,
-      ].join(":"),
-      { ...source, accountId: source.accountId.trim() },
+    const normalizedSource = {
+      ...source,
+      accountId: source.accountId.trim(),
+    };
+    distinctSources.set(
+      channelTurnSourceIdentity(normalizedSource),
+      normalizedSource,
     );
+    if (distinctSources.size > 1) {
+      return null;
+    }
   }
 
-  return byRoute.size === 1 ? ([...byRoute.values()][0] ?? null) : null;
+  return distinctSources.values().next().value ?? null;
 }
 
 class ChannelRichDraftStreamerImpl implements ChannelRichDraftStreamer {
@@ -355,6 +356,7 @@ class ChannelRichDraftStreamerImpl implements ChannelRichDraftStreamer {
       chatId: this.source.chatId,
       threadId: this.source.threadId ?? null,
       draftId: state.draftId,
+      source: this.source,
       richMessage: { markdown: message },
     };
 


### PR DESCRIPTION
## Summary

- Preserve the unique initiating `ChannelTurnSource` through `MessageChannel` action contexts, outbound messages, and rich-message drafts.
- Resolve provenance structurally and fail closed when multiple distinct inbound sources match the selected route.
- Expose complete parsed `toolInput` on tool progress events so trusted channel adapters can own platform-specific presentation without adding channel policy to core.

## Why

Custom channel adapters currently lose context that core already has:

- A `MessageChannel` send or rich draft cannot reliably identify the inbound message that initiated the turn. Adapters therefore cannot safely choose reply/thread behavior or reconcile a draft with its final message when turns overlap.
- Progress adapters receive sanitized core presentation fields, but not the structured tool input needed to derive their own titles and details.

This change exposes those facts while leaving behavior in the adapter. Core does not infer platform-specific reply, edit, reconciliation, or progress-label policy.

## Design

### Turn-source provenance

- Reuses the existing `ChannelTurnSource` domain type.
- Includes channel/account, chat and sender metadata, message/thread identity, agent, and conversation in structural identity.
- Collapses duplicate copies of the same source.
- Omits provenance when matching is ambiguous or conflicting.
- Handles effective Slack root-thread identity after route inference.
- Propagates the exact source selected by `MessageChannel` into rich drafts and final outbound messages.

### Structured progress input

- Adds optional `toolInput` to `ChannelTurnProgressUpdate` / `ChannelTurnProgressEvent`.
- Emits it only after tool arguments form complete valid JSON, including accumulated terminal updates.
- Omits incomplete streamed fragments.
- Documents that input is unsanitized and must not be rendered directly.
- Preserves existing `toolTitle` and `toolDetails` behavior for compatibility.

## Validation

- `bun run check` — 12/12 checks passed.
- 36 focused provenance, progress-input, Slack routing, and rich-draft tests passed.
- External custom-channel compatibility suite — 320 tests passed.
- Full local unit run — 5,006 passed and 25 skipped. Nine unrelated App Server websocket/hook E2E failures reproduced unchanged on clean `upstream/main` in the same environment.
