### PR TITLE
feat(cli): surface OpenRouter reasoning efforts

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -8,7 +8,7 @@
   "src/cli/app/AppCoordinator.tsx": 5204,
   "src/cli/app/AppView.tsx": 1750,
   "src/cli/app/use-approval-flow.ts": 1163,
-  "src/cli/app/use-configuration-handlers.ts": 1392,
+  "src/cli/app/use-configuration-handlers.ts": 1390,
   "src/cli/app/use-conversation-loop.ts": 2936,
   "src/cli/app/use-submit-handler.ts": 4099,
   "src/cli/components/AgentSelector.tsx": 1111,

--- a/src/agent/available-models.ts
+++ b/src/agent/available-models.ts
@@ -1,5 +1,6 @@
 import { getBackend } from "@/backend";
 import { refreshByokProviders } from "@/backend/api/providers";
+import type { ModelReasoningEffort } from "./model";
 
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -11,10 +12,16 @@ export type AvailableModel = {
   providerType?: string;
 };
 
+export type ReasoningCapabilities = {
+  supported_efforts?: ModelReasoningEffort[] | null;
+  mandatory?: boolean;
+};
+
 type CacheEntry = {
   handles: Set<string>;
   contextWindows: Map<string, number>; // handle -> max_context_window
   providerTypes: Map<string, string>; // handle -> provider_type
+  reasoningCapabilities: Map<string, ReasoningCapabilities>; // handle -> reasoning capabilities
   models: AvailableModel[];
   fetchedAt: number;
 };
@@ -84,6 +91,16 @@ export function getCachedModelProviderTypes(): Map<string, string> | null {
   return new Map(cache.providerTypes);
 }
 
+export function getCachedModelReasoningCapabilities(): Map<
+  string,
+  ReasoningCapabilities
+> | null {
+  if (!cache) {
+    return null;
+  }
+  return new Map(cache.reasoningCapabilities);
+}
+
 export function getCachedAvailableModels(): AvailableModel[] | null {
   return cache?.models.map((model) => ({ ...model })) ?? null;
 }
@@ -96,8 +113,10 @@ async function fetchFromNetwork(): Promise<CacheEntry> {
   // Build context window map from API response
   const contextWindows = new Map<string, number>();
   const providerTypes = new Map<string, string>();
+  const reasoningCapabilities = new Map<string, ReasoningCapabilities>();
   const modelsByHandle = new Map<string, AvailableModel>();
   for (const model of modelsList) {
+    const modelRecord = model as unknown as Record<string, unknown>;
     if (model.handle && model.max_context_window) {
       contextWindows.set(model.handle, model.max_context_window);
     }
@@ -109,6 +128,12 @@ async function fetchFromNetwork(): Promise<CacheEntry> {
           : undefined;
     if (model.handle && providerType) {
       providerTypes.set(model.handle, providerType);
+    }
+    const capabilities = parseReasoningCapabilities(
+      modelRecord.reasoning_capabilities,
+    );
+    if (model.handle && capabilities) {
+      reasoningCapabilities.set(model.handle, capabilities);
     }
     if (model.handle) {
       const label =
@@ -136,9 +161,42 @@ async function fetchFromNetwork(): Promise<CacheEntry> {
     handles,
     contextWindows,
     providerTypes,
+    reasoningCapabilities,
     models: [...modelsByHandle.values()],
     fetchedAt: Date.now(),
   };
+}
+
+function parseReasoningCapabilities(
+  value: unknown,
+): ReasoningCapabilities | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  const supported = record.supported_efforts;
+  const supported_efforts =
+    supported === null
+      ? null
+      : Array.isArray(supported)
+        ? supported.filter(isModelReasoningEffort)
+        : undefined;
+  return {
+    ...(supported_efforts !== undefined ? { supported_efforts } : {}),
+    ...(typeof record.mandatory === "boolean"
+      ? { mandatory: record.mandatory }
+      : {}),
+  };
+}
+
+function isModelReasoningEffort(value: unknown): value is ModelReasoningEffort {
+  return (
+    value === "none" ||
+    value === "minimal" ||
+    value === "low" ||
+    value === "medium" ||
+    value === "high" ||
+    value === "xhigh" ||
+    value === "max"
+  );
 }
 
 export async function getAvailableModelHandles(options?: {

--- a/src/agent/model.ts
+++ b/src/agent/model.ts
@@ -32,6 +32,11 @@ export type ModelReasoningEffort =
   | "xhigh"
   | "max";
 
+type ReasoningCapabilities = {
+  supported_efforts?: ModelReasoningEffort[] | null;
+  mandatory?: boolean;
+};
+
 const REASONING_EFFORT_ORDER: ModelReasoningEffort[] = [
   "none",
   "minimal",
@@ -113,10 +118,17 @@ function displayRegistryHandleForServiceTier(
 export function getReasoningTierOptionsForHandle(
   modelHandle: string,
   contextWindow?: number,
+  reasoningCapabilities?: ReasoningCapabilities | null,
 ): Array<{
   effort: ModelReasoningEffort;
   modelId: string;
 }> {
+  const providerOptions = getReasoningTierOptionsFromCapabilities(
+    modelHandle,
+    reasoningCapabilities,
+  );
+  if (providerOptions.length > 0) return providerOptions;
+
   const byEffort = new Map<ModelReasoningEffort, string>();
   const registryHandle =
     normalizeModelHandleForRegistry(modelHandle) ?? modelHandle;
@@ -163,6 +175,38 @@ export function getReasoningTierOptionsForHandle(
     const modelId = byEffort.get(effort);
     return modelId ? [{ effort, modelId }] : [];
   });
+}
+
+export function getReasoningTierOptionsFromCapabilities(
+  modelHandle: string,
+  capabilities?: ReasoningCapabilities | null,
+): Array<{
+  effort: ModelReasoningEffort;
+  modelId: string;
+}> {
+  if (!capabilities) return [];
+  const supportedEfforts = new Set<ModelReasoningEffort>(
+    capabilities.supported_efforts === null
+      ? REASONING_EFFORT_ORDER
+      : (capabilities.supported_efforts ?? []),
+  );
+  return REASONING_EFFORT_ORDER.filter(
+    (effort) =>
+      supportedEfforts.has(effort) &&
+      !(capabilities.mandatory === true && effort === "none"),
+  ).map((effort) => ({ effort, modelId: modelHandle }));
+}
+
+export function getPreferredReasoningOption<
+  T extends { effort: ModelReasoningEffort },
+>(options: T[], selectedEffort: unknown): T | undefined {
+  return (
+    (typeof selectedEffort === "string"
+      ? options.find((option) => option.effort === selectedEffort)
+      : undefined) ??
+    options.find((option) => option.effort === "medium") ??
+    options[0]
+  );
 }
 
 /**

--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -93,9 +93,9 @@ function buildModelSettings(
     settings = moonshotSettings;
   } else if (isOpenAI || isOpenRouter) {
     const openaiSettings: OpenAIModelSettings = {
-      provider_type: "openai",
+      provider_type: isOpenRouter ? "openrouter" : "openai",
       parallel_tool_calls: true,
-    };
+    } as OpenAIModelSettings;
     if (isOpenAICodex) {
       (openaiSettings as Record<string, unknown>).provider_type =
         "chatgpt_oauth";

--- a/src/cli/app/use-configuration-handlers.ts
+++ b/src/cli/app/use-configuration-handlers.ts
@@ -8,6 +8,7 @@ import {
   type SetStateAction,
   useCallback,
 } from "react";
+import { getCachedModelReasoningCapabilities } from "@/agent/available-models";
 import {
   type ModelReasoningEffort,
   preservableContextWindow,
@@ -190,6 +191,7 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
       try {
         const {
           getChatGptFastRegistryHandleForModelHandle,
+          getPreferredReasoningOption: pref,
           getReasoningTierOptionsForHandle,
           normalizeModelHandleForRegistry,
           models,
@@ -346,12 +348,14 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
             : modelUpdateArgs?.enable_reasoner === false
               ? "no"
               : null;
-        const selectedContextWindow = (
-          model.updateArgs as { context_window?: number } | undefined
-        )?.context_window;
+        const selectedContextWindow =
+          Number(model.updateArgs?.context_window) || undefined;
+        const reasoningCapabilities =
+          getCachedModelReasoningCapabilities()?.get(modelHandle);
         const reasoningTierOptions = getReasoningTierOptionsForHandle(
           registryHandle,
           selectedContextWindow,
+          reasoningCapabilities,
         ).map((option) => {
           const optionModel = models.find(
             (entry) => entry.id === option.modelId,
@@ -362,6 +366,7 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
             ...((optionModel?.updateArgs as
               | Record<string, unknown>
               | undefined) ?? {}),
+            reasoning_effort: option.effort,
             ...(serviceTier !== undefined ? { service_tier: serviceTier } : {}),
             ...(providerType ? { provider_type: providerType } : {}),
           };
@@ -377,7 +382,6 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
             },
           };
         });
-
         if (
           !opts?.skipReasoningPrompt &&
           (opts?.promptReasoning || activeOverlay === "model") &&
@@ -386,13 +390,7 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
           const selectedEffort = (
             model.updateArgs as { reasoning_effort?: unknown } | undefined
           )?.reasoning_effort;
-          const preferredOption =
-            (typeof selectedEffort === "string" &&
-              reasoningTierOptions.find(
-                (option) => option.effort === selectedEffort,
-              )) ??
-            reasoningTierOptions.find((option) => option.effort === "medium") ??
-            reasoningTierOptions[0];
+          const preferredOption = pref(reasoningTierOptions, selectedEffort);
 
           if (preferredOption) {
             setModelReasoningPrompt({


### PR DESCRIPTION
Surfaces provider-reported OpenRouter reasoning effort options in the /model selector and sends the selected effort back through OpenRouter model settings.

Validated:
- bun run typecheck
- bun run check:file-size
- bunx --bun @biomejs/biome@2.2.5 check src/agent/available-models.ts src/agent/model.ts src/agent/modify.ts src/cli/app/use-configuration-handlers.ts scripts/source-file-size-baseline.json
- bun test src/agent/modify-update-model-config.test.ts src/agent/model-tier-selection.test.ts src/agent/available-models.test.ts