### PR TITLE
fix(tools): clamp total tool return size before it reaches the model

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -38,7 +38,7 @@
   "src/settings-manager.ts": 2113,
   "src/tools/impl/enter-worktree.ts": 1260,
   "src/tools/impl/message-channel.ts": 1187,
-  "src/tools/manager.ts": 3282,
+  "src/tools/manager.ts": 3281,
   "src/tools/tool-execution-context.test.ts": 1422,
   "src/types/protocol_v2.ts": 2943,
   "src/websocket/listen-client-concurrency.test.ts": 3017,

--- a/src/tools/impl/read.ts
+++ b/src/tools/impl/read.ts
@@ -11,7 +11,7 @@ import { expandFilePath } from "@/utils/file-path";
 import { resizeImageIfNeeded } from "@/utils/image-resize.js";
 import { getUtf16Bom, readUtf8TextStrict } from "@/utils/text-files";
 import { OVERFLOW_CONFIG, writeOverflowFile } from "./overflow.js";
-import { LIMITS } from "./truncation.js";
+import { LIMITS, truncateByChars } from "./truncation.js";
 import { validateRequiredParams } from "./validation.js";
 
 interface ReadArgs {
@@ -164,6 +164,17 @@ function formatWithLineNumbers(
 
   let result = formattedLines.join("\n");
 
+  // Apply total-character clamp (Claude Code applies the same 30K class of
+  // limit as bash/task output). Line and per-line caps alone allow up to
+  // ~4M chars (2,000 lines x 2,000 chars) in a single read.
+  let wasTruncatedByTotalChars = false;
+  if (result.length > LIMITS.READ_OUTPUT_CHARS) {
+    wasTruncatedByTotalChars = true;
+    // Overflow is written below from the raw file content, so skip the
+    // overflow write here (no workingDirectory passed).
+    result = truncateByChars(result, LIMITS.READ_OUTPUT_CHARS, "Read").content;
+  }
+
   // Add truncation notices if applicable
   const notices: string[] = [];
   const wasTruncatedByLineCount = actualEndLine < originalLineCount;
@@ -171,7 +182,9 @@ function formatWithLineNumbers(
   // Write to overflow file if content was truncated and overflow is enabled
   let overflowPath: string | undefined;
   if (
-    (wasTruncatedByLineCount || linesWereTruncatedInLength) &&
+    (wasTruncatedByLineCount ||
+      linesWereTruncatedInLength ||
+      wasTruncatedByTotalChars) &&
     OVERFLOW_CONFIG.ENABLED &&
     workingDirectory
   ) {
@@ -193,6 +206,12 @@ function formatWithLineNumbers(
   if (linesWereTruncatedInLength) {
     notices.push(
       `\n\n[Some lines exceeded ${LIMITS.READ_MAX_CHARS_PER_LINE.toLocaleString()} characters and were truncated.]`,
+    );
+  }
+
+  if (wasTruncatedByTotalChars) {
+    notices.push(
+      `\n\n[Use offset and limit parameters to read the file in smaller sections.]`,
     );
   }
 

--- a/src/tools/impl/tool-return-clamp.ts
+++ b/src/tools/impl/tool-return-clamp.ts
@@ -1,0 +1,49 @@
+/**
+ * Backstop clamp for model-facing tool returns.
+ *
+ * Individual tools apply their own limits (see LIMITS in truncation.ts), but
+ * several never bound the total size of the string they return: the Read
+ * variants cap lines and chars-per-line only, Glob/LS/grep_files cap item
+ * counts only, Memory/Skill return file bodies verbatim, and external/MCP and
+ * mod tools can return arbitrarily large output. This module clamps any tool
+ * return that slipped past those per-tool limits before it reaches the model,
+ * writing the full content to an overflow file so nothing is lost.
+ */
+
+import type {
+  ImageContent,
+  TextContent,
+} from "@letta-ai/letta-client/resources/agents/messages";
+import { getCurrentWorkingDirectory } from "@/runtime-context";
+import { LIMITS, truncateByChars } from "./truncation.js";
+
+type ClampableToolReturn = string | Array<TextContent | ImageContent>;
+
+function clampText(text: string, toolName: string): string {
+  if (text.length <= LIMITS.TOOL_RETURN_MAX_CHARS) {
+    return text;
+  }
+  return truncateByChars(text, LIMITS.TOOL_RETURN_MAX_CHARS, toolName, {
+    workingDirectory: getCurrentWorkingDirectory(),
+    toolName,
+  }).content;
+}
+
+/**
+ * Bound the total size of a tool return. Strings are clamped directly;
+ * multimodal arrays have each text block clamped while image blocks pass
+ * through untouched.
+ */
+export function clampToolReturnContent(
+  content: ClampableToolReturn,
+  toolName: string,
+): ClampableToolReturn {
+  if (typeof content === "string") {
+    return clampText(content, toolName);
+  }
+  return content.map((block) =>
+    block.type === "text"
+      ? { ...block, text: clampText(block.text, toolName) }
+      : block,
+  );
+}

--- a/src/tools/impl/truncation.ts
+++ b/src/tools/impl/truncation.ts
@@ -16,11 +16,18 @@ export const LIMITS = {
   // File reading limits
   READ_MAX_LINES: 2_000, // Max lines per file read
   READ_MAX_CHARS_PER_LINE: 2_000, // Max characters per line
+  READ_OUTPUT_CHARS: 30_000, // 30K total characters for file read output
 
   // Search/discovery limits
   GREP_OUTPUT_CHARS: 10_000, // Max characters for grep results
   GLOB_MAX_FILES: 2_000, // Max number of file paths
   LS_MAX_ENTRIES: 1_000, // Max directory entries
+
+  // Backstop for any model-facing tool return that doesn't apply its own
+  // clamp (MCP/external tools, mod tools, item-count-limited tools, etc.).
+  // Slightly above BASH_OUTPUT_CHARS so outputs already clamped by a tool
+  // (30K + truncation notice) pass through unchanged.
+  TOOL_RETURN_MAX_CHARS: 32_000,
 } as const;
 
 /**

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -68,6 +68,7 @@ import { debugLog } from "@/utils/debug";
 import { refreshAndListSecrets } from "@/utils/secrets-store";
 import { isRecord } from "@/utils/type-guards";
 import { toolFilter } from "./filter";
+import { clampToolReturnContent } from "./impl/tool-return-clamp";
 import {
   functionToolForm,
   type JsonSchema,
@@ -1053,7 +1054,10 @@ export async function executeExternalTool(
       .join("\n");
 
     return {
-      toolReturn: textContent || JSON.stringify(result.content),
+      toolReturn: clampToolReturnContent(
+        textContent || JSON.stringify(result.content),
+        toolName,
+      ),
       status: result.isError ? "error" : "success",
     };
   } catch (error) {
@@ -2470,10 +2474,13 @@ async function executeModTool(
         redactions,
       );
       const toolStatus = getModToolStatus(result);
-      const flattenedResponse = scrubModToolReturnContent(
-        flattenToolResponse(result),
-        options.scopedAgentId,
-        redactions,
+      const flattenedResponse = clampToolReturnContent(
+        scrubModToolReturnContent(
+          flattenToolResponse(result),
+          options.scopedAgentId,
+          redactions,
+        ),
+        toolName,
       );
       const responseSize =
         typeof flattenedResponse === "string"
@@ -2752,20 +2759,8 @@ async function executeToolInner(
   }
 
   const internalName = resolveInternalToolName(name, activeRegistry);
-  if (!internalName) {
-    const availableTools = [
-      ...Array.from(activeRegistry.keys()),
-      ...Array.from(activeExternalTools.keys()),
-      ...Array.from(activeModTools.keys()),
-    ];
-    return {
-      toolReturn: `Tool not found: ${name}. Available tools: ${availableTools.join(", ")}`,
-      status: "error",
-    };
-  }
-
-  const tool = activeRegistry.get(internalName);
-  if (!tool) {
+  const tool = internalName ? activeRegistry.get(internalName) : undefined;
+  if (!internalName || !tool) {
     const availableTools = [
       ...Array.from(activeRegistry.keys()),
       ...Array.from(activeExternalTools.keys()),
@@ -2985,6 +2980,11 @@ async function executeToolInner(
         }
       }
 
+      flattenedResponse = clampToolReturnContent(
+        flattenedResponse,
+        internalName,
+      );
+
       // Track tool usage (calculate size for multimodal content)
       const responseSize =
         typeof flattenedResponse === "string"
@@ -3023,7 +3023,6 @@ async function executeToolInner(
         hookFeedback,
       );
 
-      // Return the full response (truncation happens in UI layer only)
       return {
         toolReturn: finalToolReturn,
         status: toolStatus,

--- a/src/tools/read.test.ts
+++ b/src/tools/read.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
 import sharp from "sharp";
 import { SYSTEM_REMINDER_OPEN } from "@/constants";
 import { TestDirectory } from "@/test-utils/test-fs";
@@ -75,6 +76,49 @@ describe("Read tool", () => {
     expect(result.content).toContain("Line 1");
     expect(result.content).toContain("Line 2");
     expect(result.content).not.toContain("Line 3");
+  });
+
+  test("clamps total output characters and points at overflow file", async () => {
+    testDir = new TestDirectory();
+    // 1,500 lines x ~120 chars ≈ 180K chars: under the 2,000-line and
+    // 2,000-chars-per-line caps, but far over the 30K total-character clamp.
+    // This is the exact shape of the bug where one Read returned 100K+ chars.
+    const line = "x".repeat(119);
+    const content = Array.from({ length: 1_500 }, () => line).join("\n");
+    const file = testDir.createFile("wide.txt", content);
+
+    const result = await read({ file_path: file, offset: 1, limit: 2000 });
+
+    expect(typeof result.content).toBe("string");
+    const text = result.content as string;
+    expect(text.length).toBeLessThan(31_000);
+    expect(text).toContain("[Output truncated: showing");
+    expect(text).toContain(
+      "[Use offset and limit parameters to read the file in smaller sections.]",
+    );
+    expect(text).toContain("[Full file content written to:");
+
+    // Overflow file holds the full raw content; clean it up.
+    const match = text.match(/Full file content written to: (.+\.txt)/);
+    expect(match).toBeDefined();
+    if (match?.[1]) {
+      expect(fs.existsSync(match[1])).toBe(true);
+      expect(fs.readFileSync(match[1], "utf-8")).toBe(content);
+      fs.unlinkSync(match[1]);
+    }
+  });
+
+  test("does not clamp reads under the total-character limit", async () => {
+    testDir = new TestDirectory();
+    const content = Array.from({ length: 100 }, (_, i) => `line ${i}`).join(
+      "\n",
+    );
+    const file = testDir.createFile("small.txt", content);
+
+    const result = await read({ file_path: file });
+
+    expect(result.content).not.toContain("[Output truncated");
+    expect(result.content).not.toContain("[Full file content written to:");
   });
 
   test("detects binary files and throws error", async () => {

--- a/src/tools/tool-return-clamp.test.ts
+++ b/src/tools/tool-return-clamp.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import type {
+  ImageContent,
+  TextContent,
+} from "@letta-ai/letta-client/resources/agents/messages";
+import { clampToolReturnContent } from "@/tools/impl/tool-return-clamp";
+import { LIMITS } from "@/tools/impl/truncation";
+
+function cleanupOverflowFile(clamped: string): void {
+  const match = clamped.match(/Full output written to: (.+\.txt)/);
+  if (match?.[1] && fs.existsSync(match[1])) {
+    fs.unlinkSync(match[1]);
+  }
+}
+
+describe("clampToolReturnContent", () => {
+  test("returns short strings unchanged", () => {
+    const content = "regular tool output";
+    expect(clampToolReturnContent(content, "SomeTool")).toBe(content);
+  });
+
+  test("passes through output already clamped by a per-tool 30K limit", () => {
+    // Bash/Task clamp to 30K then append a notice; the backstop must not
+    // re-truncate that.
+    const alreadyClamped = `${"b".repeat(30_000)}\n\n[Output truncated: showing 30,000 of 100,000 characters.]`;
+    expect(clampToolReturnContent(alreadyClamped, "Bash")).toBe(alreadyClamped);
+  });
+
+  test("clamps oversized strings and writes an overflow file", () => {
+    const big = "a".repeat(LIMITS.TOOL_RETURN_MAX_CHARS + 50_000);
+    const clamped = clampToolReturnContent(big, "SomeMcpTool") as string;
+
+    expect(clamped.length).toBeLessThan(LIMITS.TOOL_RETURN_MAX_CHARS + 1_000);
+    expect(clamped).toContain("[Output truncated: showing");
+
+    const match = clamped.match(/Full output written to: (.+\.txt)/);
+    expect(match).toBeDefined();
+    if (match?.[1]) {
+      expect(fs.existsSync(match[1])).toBe(true);
+      expect(fs.readFileSync(match[1], "utf-8").length).toBe(big.length);
+    }
+    cleanupOverflowFile(clamped);
+  });
+
+  test("clamps text blocks in multimodal content, leaves images untouched", () => {
+    const image: ImageContent = {
+      type: "image",
+      source: { type: "base64", media_type: "image/png", data: "abc123" },
+    };
+    const bigText: TextContent = {
+      type: "text",
+      text: "c".repeat(LIMITS.TOOL_RETURN_MAX_CHARS + 10_000),
+    };
+
+    const result = clampToolReturnContent([bigText, image], "SomeTool");
+
+    expect(Array.isArray(result)).toBe(true);
+    if (Array.isArray(result)) {
+      const [text, img] = result;
+      if (text?.type !== "text") throw new Error("expected text block");
+      expect(text.text.length).toBeLessThan(
+        LIMITS.TOOL_RETURN_MAX_CHARS + 1_000,
+      );
+      expect(text.text).toContain("[Output truncated: showing");
+      expect(img).toEqual(image);
+      cleanupOverflowFile(text.text);
+    }
+  });
+});

--- a/src/tools/truncation.test.ts
+++ b/src/tools/truncation.test.ts
@@ -162,9 +162,15 @@ describe("truncation utilities", () => {
       expect(LIMITS.BASH_OUTPUT_CHARS).toBe(30_000);
       expect(LIMITS.READ_MAX_LINES).toBe(2_000);
       expect(LIMITS.READ_MAX_CHARS_PER_LINE).toBe(2_000);
+      expect(LIMITS.READ_OUTPUT_CHARS).toBe(30_000);
       expect(LIMITS.GREP_OUTPUT_CHARS).toBe(10_000);
       expect(LIMITS.GLOB_MAX_FILES).toBe(2_000);
       expect(LIMITS.LS_MAX_ENTRIES).toBe(1_000);
+      // Backstop must sit above per-tool clamps so already-clamped output
+      // (30K + truncation notice) passes through unchanged.
+      expect(LIMITS.TOOL_RETURN_MAX_CHARS).toBeGreaterThan(
+        LIMITS.BASH_OUTPUT_CHARS + 500,
+      );
     });
   });
 });


### PR DESCRIPTION
## Problem

One production Read call returned **100,253 chars** — it included an overflow-file reference but never truncated the selected slice. Root cause: the 30K total-character clamp is opt-in per tool, and Read never opted in.

An audit of all toolsets found the gap is wider than Read:

| Path | Limit today | Total-size bound? |
|---|---|---|
| Bash / Shell / Task | 30K chars | ✅ |
| Grep | 10K chars | ✅ |
| Read (+ gemini/LSP/codex variants) | 2,000 lines × 2,000 chars/line | ❌ (~4M chars possible) |
| Glob / LS / grep_files | item counts only | ❌ |
| Memory / Skill | none | ❌ |
| External / MCP tools | none | ❌ |
| Mod tools | none | ❌ |

The comment at the tool-execution return path said "truncation happens in UI layer only" — that assumption was the bug; nothing model-facing was ever bounded.

## Fix

1. **Read** (`src/tools/impl/read.ts`): formatted output is now clamped at a new `LIMITS.READ_OUTPUT_CHARS` (30K), matching the Bash/Task ceiling. The overflow file still receives the full raw content, and the notice tells the model to page with `offset`/`limit`. `read_file_gemini` and `read_lsp` wrap `read()` and inherit the fix.
2. **Universal backstop** (new `src/tools/impl/tool-return-clamp.ts`): `clampToolReturnContent` is applied at the three model-facing return choke points in `manager.ts` — built-in flatten path, mod tools, and external/MCP tools. It clamps strings and multimodal text blocks (images pass through) at `LIMITS.TOOL_RETURN_MAX_CHARS` (32K — deliberately above 30K + truncation notice, so output already clamped by a tool passes through instead of being double-truncated), writing overflow files. Telemetry `responseSize` now reflects the clamped size.
3. **Size baseline**: `manager.ts` is pinned at its baseline, so the added clamp calls are offset by deduplicating the two identical "Tool not found" blocks; net −1 line, baseline ratcheted down.

## Tests

- Regression test reproducing the incident shape (`offset=1, limit=2000`, file under line caps but ~180K chars): now returns <31K with a working overflow reference containing the full content.
- Unit tests for the clamp module, including the already-clamped-passthrough and multimodal cases.
- `bun run check` fully green; all `src/tools/` tests (662) plus websocket listener / mod / headless suites that exercise the tool manager pass.

## Known follow-up

Overflow files are written before secret scrubbing on some paths (pre-existing for Bash; also true for the new backstop on the external-tool path). Follow-up PR will scrub secrets from overflow file content too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)