### PR TITLE
feat(backend): upgrade pi-ai to 0.81.1 and adopt its auth/refresh architecture

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "@letta-ai/letta-code",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.6",
+        "@earendil-works/pi-ai": "^0.81.1",
         "@letta-ai/letta-client": "^1.10.2",
         "@letta-ai/trajectory": "^0.1.1",
         "@pierre/diffs": "1.2.2",
@@ -92,7 +92,7 @@
 
     "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1048.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.11", "@aws-sdk/nested-clients": "^3.997.9", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA=="],
 
-    "@aws-sdk/types": ["@aws-sdk/types@3.973.8", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw=="],
+    "@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
     "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.5", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ=="],
 
@@ -114,7 +114,7 @@
 
     "@discoveryjs/json-ext": ["@discoveryjs/json-ext@1.1.0", "", {}, "sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.6", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.81.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-hzHE7Z8l5mgJk+ke67Lge0rwS2+wbKJrFKl9o5M1R1rh33+cCT7D1AHz1OAtX5wFs90E1/BTGhyJRTUHaMxGvQ=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
@@ -1044,45 +1044,23 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
-    "@aws-sdk/core/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+    "@aws-crypto/crc32/@aws-sdk/types": ["@aws-sdk/types@3.973.8", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw=="],
 
-    "@aws-sdk/credential-provider-env/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+    "@aws-crypto/sha256-browser/@aws-sdk/types": ["@aws-sdk/types@3.973.8", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw=="],
 
-    "@aws-sdk/credential-provider-http/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+    "@aws-crypto/sha256-js/@aws-sdk/types": ["@aws-sdk/types@3.973.8", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw=="],
+
+    "@aws-crypto/util/@aws-sdk/types": ["@aws-sdk/types@3.973.8", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/types": ["@aws-sdk/types@3.973.8", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw=="],
 
     "@aws-sdk/credential-provider-http/@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.4.4", "", { "dependencies": { "@smithy/core": "^3.24.4", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ=="],
 
-    "@aws-sdk/credential-provider-ini/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
-
-    "@aws-sdk/credential-provider-login/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
-
-    "@aws-sdk/credential-provider-node/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
-
-    "@aws-sdk/credential-provider-process/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
-
     "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1052.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.13", "@aws-sdk/nested-clients": "^3.997.11", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-QqZNB3so7UIDxZtroc85TQaLVxdZRFm0eWM1CSR2N+b06as9TOrilvrlTZuj3guYlxMs6yLOgGxnklJ5qMYtTw=="],
-
-    "@aws-sdk/credential-provider-sso/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
-
-    "@aws-sdk/credential-provider-web-identity/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
-
-    "@aws-sdk/eventstream-handler-node/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
-
-    "@aws-sdk/middleware-eventstream/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
-
-    "@aws-sdk/middleware-websocket/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
 
     "@aws-sdk/middleware-websocket/@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.4.4", "", { "dependencies": { "@smithy/core": "^3.24.4", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ=="],
 
-    "@aws-sdk/nested-clients/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
-
     "@aws-sdk/nested-clients/@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.4.4", "", { "dependencies": { "@smithy/core": "^3.24.4", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ=="],
-
-    "@aws-sdk/signature-v4-multi-region/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
-
-    "@aws-sdk/token-providers/@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
-
-    "@aws-sdk/types/@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
 
     "@earendil-works/pi-ai/openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
 
@@ -1167,6 +1145,16 @@
     "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "@aws-crypto/crc32/@aws-sdk/types/@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
+
+    "@aws-crypto/sha256-browser/@aws-sdk/types/@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
+
+    "@aws-crypto/sha256-js/@aws-sdk/types/@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
+
+    "@aws-crypto/util/@aws-sdk/types/@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
+
+    "@aws-sdk/client-bedrock-runtime/@aws-sdk/types/@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
 
     "@pierre/diffs/shiki/@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "^0.80.6",
+    "@earendil-works/pi-ai": "^0.81.1",
     "@letta-ai/letta-client": "^1.10.2",
     "@letta-ai/trajectory": "^0.1.1",
     "@pierre/diffs": "1.2.2",

--- a/src/backend/dev/pi-llama-cpp-provider.test.ts
+++ b/src/backend/dev/pi-llama-cpp-provider.test.ts
@@ -92,9 +92,9 @@ describe("createLlamaCppPiProvider", () => {
     expect(provider.getModels()).toHaveLength(1);
 
     state.failModels = true;
-    expect(provider.refreshModels?.(testRefreshContext())).rejects.toThrow(
-      "connection refused",
-    );
+    await expect(
+      provider.refreshModels?.(testRefreshContext()),
+    ).rejects.toThrow("connection refused");
     expect(provider.getModels()).toHaveLength(1);
   });
 });

--- a/src/backend/dev/pi-llama-cpp-provider.test.ts
+++ b/src/backend/dev/pi-llama-cpp-provider.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { testRefreshContext } from "@/test-utils/pi-refresh-context";
 import { createLlamaCppPiProvider } from "./pi-llama-cpp-provider";
 
 interface FakeLlamaCppState {
@@ -39,7 +40,7 @@ describe("createLlamaCppPiProvider", () => {
         },
       }),
     });
-    await provider.refreshModels?.();
+    await provider.refreshModels?.(testRefreshContext());
 
     const model = provider.getModels()[0];
     expect(model?.provider).toBe("llama-cpp");
@@ -57,7 +58,7 @@ describe("createLlamaCppPiProvider", () => {
         props: { modalities: { vision: false } },
       }),
     });
-    await provider.refreshModels?.();
+    await provider.refreshModels?.(testRefreshContext());
     expect(provider.getModels()[0]?.input).toEqual(["text"]);
   });
 
@@ -70,11 +71,11 @@ describe("createLlamaCppPiProvider", () => {
       baseURL: "http://localhost:8080",
       fetchImpl: fakeLlamaCppFetch(state),
     });
-    await provider.refreshModels?.();
+    await provider.refreshModels?.(testRefreshContext());
     expect(provider.getModels()[0]?.input).toEqual(["text", "image"]);
 
     state.failProps = true;
-    await provider.refreshModels?.();
+    await provider.refreshModels?.(testRefreshContext());
     expect(provider.getModels()[0]?.input).toEqual(["text", "image"]);
   });
 
@@ -87,11 +88,13 @@ describe("createLlamaCppPiProvider", () => {
       baseURL: "http://localhost:8080",
       fetchImpl: fakeLlamaCppFetch(state),
     });
-    await provider.refreshModels?.();
+    await provider.refreshModels?.(testRefreshContext());
     expect(provider.getModels()).toHaveLength(1);
 
     state.failModels = true;
-    expect(provider.refreshModels?.()).rejects.toThrow("connection refused");
+    expect(provider.refreshModels?.(testRefreshContext())).rejects.toThrow(
+      "connection refused",
+    );
     expect(provider.getModels()).toHaveLength(1);
   });
 });

--- a/src/backend/dev/pi-llama-cpp-provider.ts
+++ b/src/backend/dev/pi-llama-cpp-provider.ts
@@ -1,4 +1,4 @@
-import type { Model, Provider } from "@earendil-works/pi-ai";
+import type { Provider } from "@earendil-works/pi-ai";
 import {
   createLocalEndpointPiProvider,
   type LocalEndpointDiscover,
@@ -13,7 +13,6 @@ export interface LlamaCppPiProviderOptions {
   apiKey?: string;
   fetchImpl?: typeof fetch;
   discoveryTimeoutMs?: number;
-  initialModels?: readonly Model<"openai-completions">[];
 }
 
 interface LlamaCppServerProps {
@@ -101,7 +100,6 @@ export function createLlamaCppPiProvider(
     ...(options.discoveryTimeoutMs
       ? { discoveryTimeoutMs: options.discoveryTimeoutMs }
       : {}),
-    ...(options.initialModels ? { initialModels: options.initialModels } : {}),
     discover: llamaCppDiscover,
   });
 }

--- a/src/backend/dev/pi-lmstudio-provider.test.ts
+++ b/src/backend/dev/pi-lmstudio-provider.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { testRefreshContext } from "@/test-utils/pi-refresh-context";
 import { createLmStudioPiProvider } from "./pi-lmstudio-provider";
 
 interface FakeLmStudioState {
@@ -58,7 +59,7 @@ describe("createLmStudioPiProvider", () => {
         ],
       }),
     });
-    await provider.refreshModels?.();
+    await provider.refreshModels?.(testRefreshContext());
 
     const models = provider.getModels();
     const vlm = models.find((m) => m.id === "qwen3.6-27b");
@@ -83,7 +84,7 @@ describe("createLmStudioPiProvider", () => {
         openAIModelIds: ["llava-1.6-7b"],
       }),
     });
-    await provider.refreshModels?.();
+    await provider.refreshModels?.(testRefreshContext());
     expect(provider.getModels()[0]?.input).toEqual(["text"]);
   });
 
@@ -96,11 +97,11 @@ describe("createLmStudioPiProvider", () => {
       baseURL: "http://127.0.0.1:1234",
       fetchImpl: fakeLmStudioFetch(state),
     });
-    await provider.refreshModels?.();
+    await provider.refreshModels?.(testRefreshContext());
     expect(provider.getModels()[0]?.input).toEqual(["text", "image"]);
 
     state.failNative = true;
-    await provider.refreshModels?.();
+    await provider.refreshModels?.(testRefreshContext());
     expect(provider.getModels()[0]?.input).toEqual(["text", "image"]);
   });
 
@@ -112,12 +113,12 @@ describe("createLmStudioPiProvider", () => {
       baseURL: "http://127.0.0.1:1234",
       fetchImpl: fakeLmStudioFetch(state),
     });
-    await provider.refreshModels?.();
+    await provider.refreshModels?.(testRefreshContext());
     expect(provider.getModels()).toHaveLength(1);
 
     state.failNative = true;
     state.failOpenAI = true;
-    expect(provider.refreshModels?.()).rejects.toThrow();
+    expect(provider.refreshModels?.(testRefreshContext())).rejects.toThrow();
     expect(provider.getModels()).toHaveLength(1);
   });
 });

--- a/src/backend/dev/pi-lmstudio-provider.test.ts
+++ b/src/backend/dev/pi-lmstudio-provider.test.ts
@@ -118,7 +118,9 @@ describe("createLmStudioPiProvider", () => {
 
     state.failNative = true;
     state.failOpenAI = true;
-    expect(provider.refreshModels?.(testRefreshContext())).rejects.toThrow();
+    await expect(
+      provider.refreshModels?.(testRefreshContext()),
+    ).rejects.toThrow();
     expect(provider.getModels()).toHaveLength(1);
   });
 });

--- a/src/backend/dev/pi-lmstudio-provider.ts
+++ b/src/backend/dev/pi-lmstudio-provider.ts
@@ -1,4 +1,4 @@
-import type { Model, Provider } from "@earendil-works/pi-ai";
+import type { Provider } from "@earendil-works/pi-ai";
 import {
   createLocalEndpointPiProvider,
   type LocalEndpointDiscover,
@@ -14,7 +14,6 @@ export interface LmStudioPiProviderOptions {
   apiKey?: string;
   fetchImpl?: typeof fetch;
   discoveryTimeoutMs?: number;
-  initialModels?: readonly Model<"openai-completions">[];
 }
 
 function stringArray(value: unknown): string[] {
@@ -98,7 +97,6 @@ export function createLmStudioPiProvider(
     ...(options.discoveryTimeoutMs
       ? { discoveryTimeoutMs: options.discoveryTimeoutMs }
       : {}),
-    ...(options.initialModels ? { initialModels: options.initialModels } : {}),
     discover: lmStudioDiscover,
   });
 }

--- a/src/backend/dev/pi-local-endpoint-provider.ts
+++ b/src/backend/dev/pi-local-endpoint-provider.ts
@@ -181,10 +181,15 @@ export function createLocalEndpointPiProvider(
     auth: {
       apiKey: {
         name: `${options.name} API key`,
-        resolve: async ({ credential }) => ({
-          auth: { apiKey: credential?.key ?? options.apiKey ?? "not-needed" },
-          source: options.apiKey ? "local provider record" : "keyless",
-        }),
+        // Keyless local daemons pass "not-needed" through the connection's
+        // fallback key; a remote endpoint with no key at all resolves
+        // undefined so pi-ai treats it as unconfigured.
+        resolve: async ({ credential }) => {
+          const apiKey = credential?.key ?? options.apiKey;
+          return apiKey
+            ? { auth: { apiKey }, source: "local provider record" }
+            : undefined;
+        },
       },
     },
     // Static baseline stays empty: pi-ai merges the baseline with the

--- a/src/backend/dev/pi-local-endpoint-provider.ts
+++ b/src/backend/dev/pi-local-endpoint-provider.ts
@@ -1,4 +1,8 @@
-import type { Model, Provider } from "@earendil-works/pi-ai";
+import type {
+  Model,
+  Provider,
+  RefreshModelsContext,
+} from "@earendil-works/pi-ai";
 import { createProvider } from "@earendil-works/pi-ai";
 import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 
@@ -52,8 +56,6 @@ export interface LocalEndpointPiProviderOptions {
   apiKey?: string;
   fetchImpl?: typeof fetch;
   discoveryTimeoutMs?: number;
-  /** Last-known models carried over from a replaced provider instance. */
-  initialModels?: readonly LocalEndpointModel[];
   discover: LocalEndpointDiscover;
 }
 
@@ -102,9 +104,7 @@ export function createLocalEndpointPiProvider(
     options.discoveryTimeoutMs ?? LOCAL_ENDPOINT_DISCOVERY_TIMEOUT_MS;
   const nativeBaseURL = localEndpointNativeBaseURL(options.baseURL);
   const openAIBaseURL = localEndpointOpenAIBaseURL(options.baseURL);
-  let lastKnown = new Map<string, LocalEndpointModel>(
-    (options.initialModels ?? []).map((model) => [model.id, model]),
-  );
+  let lastKnown = new Map<string, LocalEndpointModel>();
   const state = new Map<string, unknown>();
 
   async function fetchJson(
@@ -158,7 +158,10 @@ export function createLocalEndpointPiProvider(
     };
   }
 
-  async function refreshModels(): Promise<readonly LocalEndpointModel[]> {
+  async function fetchModels(
+    context: RefreshModelsContext,
+  ): Promise<readonly LocalEndpointModel[]> {
+    if (!context.allowNetwork) return [...lastKnown.values()];
     const models = await options.discover({
       fetchJson,
       nativeBaseURL,
@@ -184,8 +187,11 @@ export function createLocalEndpointPiProvider(
         }),
       },
     },
-    models: options.initialModels ?? [],
-    refreshModels,
+    // Static baseline stays empty: pi-ai merges the baseline with the
+    // dynamic overlay by id, and discovered engine models must disappear
+    // when the engine no longer lists them.
+    models: [],
+    fetchModels,
     api: openAICompletionsApi(),
   });
 }

--- a/src/backend/dev/pi-mod-provider.test.ts
+++ b/src/backend/dev/pi-mod-provider.test.ts
@@ -91,9 +91,9 @@ describe("createModPiProvider", () => {
     ).toEqual(["text", "image"]);
 
     fail = true;
-    expect(provider.refreshModels?.(testRefreshContext())).rejects.toThrow(
-      "endpoint down",
-    );
+    await expect(
+      provider.refreshModels?.(testRefreshContext()),
+    ).rejects.toThrow("endpoint down");
     expect(provider.getModels().map((m) => m.id)).toEqual([
       "static-seed",
       "dynamic-1",

--- a/src/backend/dev/pi-mod-provider.test.ts
+++ b/src/backend/dev/pi-mod-provider.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { testRefreshContext } from "@/test-utils/pi-refresh-context";
 import { createModPiProvider } from "./pi-mod-provider";
 import { resolvePiModelForAgent } from "./pi-model-factory";
 import { LocalPiModelsRuntime } from "./pi-models-runtime";
@@ -78,13 +79,25 @@ describe("createModPiProvider", () => {
     // Static declaration seeds the list before the first refresh.
     expect(provider.getModels().map((m) => m.id)).toEqual(["static-seed"]);
 
-    await provider.refreshModels?.();
-    expect(provider.getModels().map((m) => m.id)).toEqual(["dynamic-1"]);
-    expect(provider.getModels()[0]?.input).toEqual(["text", "image"]);
+    // pi-ai 0.81 merges the static baseline with the dynamic overlay by id;
+    // discoveries extend the declared baseline rather than replacing it.
+    await provider.refreshModels?.(testRefreshContext());
+    expect(provider.getModels().map((m) => m.id)).toEqual([
+      "static-seed",
+      "dynamic-1",
+    ]);
+    expect(
+      provider.getModels().find((m) => m.id === "dynamic-1")?.input,
+    ).toEqual(["text", "image"]);
 
     fail = true;
-    expect(provider.refreshModels?.()).rejects.toThrow("endpoint down");
-    expect(provider.getModels().map((m) => m.id)).toEqual(["dynamic-1"]);
+    expect(provider.refreshModels?.(testRefreshContext())).rejects.toThrow(
+      "endpoint down",
+    );
+    expect(provider.getModels().map((m) => m.id)).toEqual([
+      "static-seed",
+      "dynamic-1",
+    ]);
   });
 });
 
@@ -129,7 +142,8 @@ describe("LocalPiModelsRuntime mod provider integration", () => {
     expect(runtime.getModel(PROVIDER, "v2-model")?.baseUrl).toBe(
       "https://api.acme.test/v2",
     );
-    expect(runtime.getModels("anthropic")).toBe(builtinBefore);
+    expect(runtime.getModels("anthropic")[0]).toBe(builtinBefore[0]!);
+    expect(runtime.getModels("anthropic")).toHaveLength(builtinBefore.length);
 
     unregisterPiProvider(PROVIDER);
     expect(runtime.isRuntimeManagedProvider(PROVIDER)).toBe(false);

--- a/src/backend/dev/pi-mod-provider.ts
+++ b/src/backend/dev/pi-mod-provider.ts
@@ -2,6 +2,7 @@ import type { Api, Model, Provider } from "@earendil-works/pi-ai";
 import { createProvider } from "@earendil-works/pi-ai";
 import { listLocalProviderRecords } from "@/backend/local/local-provider-auth-store";
 import { knownApiStreams } from "./pi-api-streams";
+import { modOAuthAuth } from "./pi-oauth";
 import type {
   PiProviderModelRegistration,
   PiProviderRegistration,
@@ -94,7 +95,7 @@ export function createModPiProvider(options: ModPiProviderOptions): Provider {
 
   // Only providers with a listModels hook are dynamic; static registrations
   // publish their declared models and never refresh.
-  const refreshModels = config.listModels
+  const fetchModels = config.listModels
     ? async (): Promise<readonly Model<Api>[]> => {
         const listConnection =
           await resolveRegisteredPiProviderListModelsConnection(registered, {
@@ -122,14 +123,21 @@ export function createModPiProvider(options: ModPiProviderOptions): Provider {
             credential?.key ??
             resolveRegisteredPiProviderRuntimeConnection(registered, storageDir)
               .apiKey;
-          return apiKey
-            ? { auth: { apiKey }, source: "local provider record" }
-            : undefined;
+          if (apiKey) {
+            return { auth: { apiKey }, source: "local provider record" };
+          }
+          // connect:false mods are explicitly keyless — report configured so
+          // the Models runtime refreshes them (mirrors
+          // isRegisteredPiProviderConfigured).
+          return config.connect === false ? { auth: {} } : undefined;
         },
       },
+      ...(config.oauth
+        ? { oauth: modOAuthAuth(providerName, config.oauth) }
+        : {}),
     },
     models: staticModels,
-    ...(refreshModels ? { refreshModels } : {}),
+    ...(fetchModels ? { fetchModels } : {}),
     api: knownApiStreams(),
   });
 }

--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -565,12 +565,13 @@ export async function resolvePiModelForAgent(
         `Unknown model "${modelId}" for registered provider "${provider}".`,
       );
     }
-    // Copy before handing to the mod's modifyModels so a mutating mod cannot
-    // corrupt the provider-published instance.
+    // Deep-copy before handing to the mod's modifyModels so a mutating mod
+    // cannot corrupt the provider-published instance (including nested
+    // arrays/objects like input, cost, and compat).
     const oauthModel =
       oauthCredentials && registeredProvider.config.oauth?.modifyModels
         ? (registeredProvider.config.oauth.modifyModels(
-            [{ ...runtimeModel }],
+            [structuredClone(runtimeModel)],
             oauthCredentials,
           )[0] ?? runtimeModel)
         : runtimeModel;

--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -1,12 +1,5 @@
 import type { Api, Model, ThinkingLevel } from "@earendil-works/pi-ai";
-import {
-  getOAuthProvider,
-  type OAuthCredentials,
-} from "@earendil-works/pi-ai/oauth";
-import {
-  getBuiltinModel,
-  getBuiltinModels,
-} from "@earendil-works/pi-ai/providers/all";
+import type { OAuthCredentials } from "@earendil-works/pi-ai/oauth";
 import {
   getLocalOAuthApiKey,
   getLocalProviderRecordByName,
@@ -25,6 +18,7 @@ import {
   stripRegisteredProviderHandlePrefix,
 } from "./pi-provider-mod-registry";
 import {
+  builtinCatalogModels,
   expectedPiProviderList,
   getPiProviderSpec,
   isPiProvider,
@@ -324,22 +318,16 @@ export function resolveZaiConnection(options: {
 function getCatalogModel(
   provider: PiProvider,
   modelId: string,
-  oauthCredentials?: OAuthCredentials,
 ): Model<Api> | undefined {
   const spec = getPiProviderSpec(provider);
   const piProvider = spec.piProvider;
   if (!piProvider) return undefined;
-  const catalog = getBuiltinModels(piProvider);
+  const catalog = builtinCatalogModels(piProvider);
   const fallbackModelId = fallbackCatalogModelId(piProvider, modelId);
-  const model = (catalog.find((model) => model.id === modelId) ??
+  return (catalog.find((model) => model.id === modelId) ??
     catalog.find((model) => model.id === fallbackModelId)) as
     | Model<Api>
     | undefined;
-  if (!model || !oauthCredentials) return model;
-
-  const oauthProvider = getOAuthProvider(piProvider);
-  return (oauthProvider?.modifyModels?.([model], oauthCredentials)[0] ??
-    model) as Model<Api>;
 }
 
 function fallbackCatalogModelId(
@@ -517,6 +505,10 @@ export async function resolvePiModelForAgent(
       apiKey: oauth?.apiKey,
     };
     oauthCredentials = oauth?.credentials;
+    // Per-credential request auth (e.g. GitHub Copilot's per-token base URL)
+    // comes from the provider's OAuthAuth.toAuth.
+    if (oauth?.baseUrl) baseURL = oauth.baseUrl;
+    if (oauth?.headers) headers = mergeHeaders(headers, oauth.headers);
   }
 
   if (
@@ -611,32 +603,19 @@ export async function resolvePiModelForAgent(
         ? withOverrides(runtimeModel, { headers, contextWindow, maxTokens })
         : runtimeModel;
   } else {
-    const catalogModel = getCatalogModel(spec.id, modelId, oauthCredentials);
-    if (catalogModel) {
-      model = withOverrides(catalogModel, {
-        baseURL,
-        headers,
-        contextWindow,
-        maxTokens,
-      });
-    } else {
-      const fallback = getBuiltinModel(
-        spec.piProvider ?? "openai",
-        modelId as never,
-      ) as Model<Api> | undefined;
-      if (!fallback) {
-        throw new Error(
-          `Unknown model "${modelId}" for provider "${provider}". ` +
-            "Check the model handle or update the model catalog.",
-        );
-      }
-      model = withOverrides(fallback, {
-        baseURL,
-        headers,
-        contextWindow,
-        maxTokens,
-      });
+    const catalogModel = getCatalogModel(spec.id, modelId);
+    if (!catalogModel) {
+      throw new Error(
+        `Unknown model "${modelId}" for provider "${provider}". ` +
+          "Check the model handle or update the model catalog.",
+      );
     }
+    model = withOverrides(catalogModel, {
+      baseURL,
+      headers,
+      contextWindow,
+      maxTokens,
+    });
   }
 
   return {

--- a/src/backend/dev/pi-models-runtime.test.ts
+++ b/src/backend/dev/pi-models-runtime.test.ts
@@ -344,6 +344,55 @@ describe("LocalPiModelsRuntime + Ollama provider", () => {
     expect(resolved.model.input).toEqual(["text", "image"]);
   });
 
+  test("refreshAll never probes unconfigured remote endpoints or mods", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "pi-models-runtime-"));
+    storageDirs.push(storageDir);
+    const requested: string[] = [];
+    const recordingFetch = (async (input: string | URL | Request) => {
+      requested.push(String(input));
+      throw new Error("no endpoint in tests");
+    }) as unknown as typeof fetch;
+    const runtime = new LocalPiModelsRuntime({
+      storageDir,
+      fetchImpl: recordingFetch,
+    });
+
+    await runtime.refreshAll();
+
+    // Auto-detectable local daemons may be probed; the remote Ollama Cloud
+    // endpoint must not be touched without a configured record/env key.
+    expect(requested.some((url) => url.includes("ollama.com"))).toBe(false);
+  });
+
+  test("endpoint change drops the stored catalog instead of restoring stale models", async () => {
+    const serverA = startFakeOllama([
+      { id: "model-a:1b", capabilities: ["completion"] },
+    ]);
+    servers.push(serverA);
+    const storageDir = await setupOllamaStorage(serverA.url, storageDirs);
+    const runtime = new LocalPiModelsRuntime({ storageDir });
+
+    await runtime.refresh("ollama");
+    expect(runtime.getModel("ollama", "model-a:1b")).toBeDefined();
+
+    // Reconfigure to an endpoint that is offline: the old endpoint's catalog
+    // must not be restored from the models store by the failed refresh.
+    const serverB = startFakeOllama([]);
+    const deadUrl = serverB.url;
+    serverB.stop();
+    await createOrUpdateLocalProvider({
+      providerType: "ollama",
+      providerName: "ollama",
+      apiKey: "not-needed",
+      baseURL: deadUrl,
+      storageDir,
+    });
+
+    expect(runtime.getModels("ollama")).toHaveLength(0);
+    await expect(runtime.refresh("ollama")).rejects.toThrow();
+    expect(runtime.getModels("ollama")).toHaveLength(0);
+  });
+
   test("refresh failure retains last-known models and turns still resolve", async () => {
     const server = startFakeOllama([
       {
@@ -358,7 +407,7 @@ describe("LocalPiModelsRuntime + Ollama provider", () => {
     await runtime.refresh("ollama");
     server.stop();
 
-    expect(runtime.refresh("ollama")).rejects.toThrow();
+    await expect(runtime.refresh("ollama")).rejects.toThrow();
     // /model keeps the last-known list rather than dropping the provider.
     const listed = await listLocalModels(storageDir, {
       fetch: failingDiscoveryFetch,

--- a/src/backend/dev/pi-models-runtime.test.ts
+++ b/src/backend/dev/pi-models-runtime.test.ts
@@ -288,7 +288,8 @@ describe("LocalPiModelsRuntime + Ollama provider", () => {
     ]);
     expect(runtime.getModel("ollama", "model-a:1b")).toBeUndefined();
     // Other providers are untouched by the Ollama connection change.
-    expect(runtime.getModels("anthropic")).toBe(builtinBefore);
+    expect(runtime.getModels("anthropic")[0]).toBe(builtinBefore[0]!);
+    expect(runtime.getModels("anthropic")).toHaveLength(builtinBefore.length);
   });
 
   test("llama.cpp models resolve through the runtime with /props capabilities", async () => {

--- a/src/backend/dev/pi-models-runtime.ts
+++ b/src/backend/dev/pi-models-runtime.ts
@@ -13,6 +13,7 @@ import { createModels, InMemoryModelsStore } from "@earendil-works/pi-ai";
 import { builtinProviders } from "@earendil-works/pi-ai/providers/all";
 import {
   getLocalProviderRecordByName,
+  listLocalProviderRecords,
   localProviderApiKeyFromRecord,
 } from "@/backend/local/local-provider-auth-store";
 import {
@@ -35,7 +36,10 @@ import {
   listRegisteredPiProviders,
 } from "./pi-provider-mod-registry";
 import { getPiProviderSpec, type PiProvider } from "./pi-provider-registry";
-import { resolveRegisteredPiProviderRuntimeConnection } from "./registered-pi-provider-runtime";
+import {
+  isRegisteredPiProviderConfigured,
+  resolveRegisteredPiProviderRuntimeConnection,
+} from "./registered-pi-provider-runtime";
 
 const CONFIGURED_DISCOVERY_TIMEOUT_MS = 2_000;
 const AUTODETECT_DISCOVERY_TIMEOUT_MS = 500;
@@ -174,6 +178,7 @@ export class LocalPiModelsRuntime {
     if (!registered) {
       if (this.modSignatures.delete(providerId)) {
         this.models.deleteProvider(providerId);
+        void this.modelsStore.delete(providerId);
       }
       return false;
     }
@@ -186,11 +191,15 @@ export class LocalPiModelsRuntime {
       connection.baseURL ?? "",
       connection.apiKey ?? "",
     ].join(" ");
+    const previousSignature = this.modSignatures.get(providerId);
     if (
-      this.modSignatures.get(providerId) === signature &&
+      previousSignature === signature &&
       this.models.getProvider(providerId)
     ) {
       return true;
+    }
+    if (previousSignature !== undefined && previousSignature !== signature) {
+      void this.modelsStore.delete(providerId);
     }
     this.models.setProvider(
       createModPiProvider({
@@ -210,15 +219,19 @@ export class LocalPiModelsRuntime {
       this.storageDir,
     );
     const signature = connectionSignature(connection);
+    const previousSignature = this.endpointSignatures.get(providerId);
     if (
-      this.endpointSignatures.get(providerId) === signature &&
+      previousSignature === signature &&
       this.models.getProvider(providerId)
     ) {
       return;
     }
-    // Connection changed: replace only this provider. The fresh instance
-    // starts with no models so stale discovery from the old endpoint cannot
-    // leak; the next refresh() repopulates from the new endpoint.
+    // Connection changed: replace only this provider and drop its persisted
+    // catalog, so stale discovery from the old endpoint cannot be restored
+    // by the next refresh. (InMemoryModelsStore deletes synchronously.)
+    if (previousSignature !== undefined && previousSignature !== signature) {
+      void this.modelsStore.delete(providerId);
+    }
     this.models.setProvider(
       create({
         baseURL: connection.baseURL,
@@ -269,10 +282,26 @@ export class LocalPiModelsRuntime {
    */
   async refreshAll(): Promise<void> {
     this.ensureManagedProviders();
-    const managedIds = new Set([
-      ...MANAGED_ENDPOINT_PROVIDERS.keys(),
-      ...listRegisteredPiProviders().map((provider) => provider.providerName),
-    ]);
+    // Only refresh providers the user configured (record/env) or that are
+    // explicitly auto-detectable local daemons. Never probe remote endpoints
+    // (Ollama Cloud) or invoke mod listModels hooks without configuration.
+    const records = listLocalProviderRecords(this.storageDir);
+    const managedIds = new Set<string>();
+    for (const providerId of MANAGED_ENDPOINT_PROVIDERS.keys()) {
+      const spec = getPiProviderSpec(providerId as PiProvider);
+      const connection = resolveLocalEndpointConnection(
+        providerId,
+        this.storageDir,
+      );
+      if (connection.configured || spec.autoDetectLocalEndpoint === true) {
+        managedIds.add(providerId);
+      }
+    }
+    for (const registered of listRegisteredPiProviders()) {
+      if (isRegisteredPiProviderConfigured(registered, records)) {
+        managedIds.add(registered.providerName);
+      }
+    }
     await Promise.all(
       [...managedIds].map(async (providerId) => {
         try {

--- a/src/backend/dev/pi-models-runtime.ts
+++ b/src/backend/dev/pi-models-runtime.ts
@@ -1,14 +1,15 @@
 import type {
   Api,
-  ApiStreamOptions,
   AssistantMessageEventStream,
   Context,
   Model,
+  ModelsApiStreamOptions,
+  ModelsSimpleStreamOptions,
   MutableModels,
   Provider,
-  SimpleStreamOptions,
+  RefreshModelsContext,
 } from "@earendil-works/pi-ai";
-import { createModels } from "@earendil-works/pi-ai";
+import { createModels, InMemoryModelsStore } from "@earendil-works/pi-ai";
 import { builtinProviders } from "@earendil-works/pi-ai/providers/all";
 import {
   getLocalProviderRecordByName,
@@ -130,14 +131,27 @@ export class LocalPiModelsRuntime {
   private readonly fetchImpl?: typeof fetch;
   private readonly endpointSignatures = new Map<string, string>();
   private readonly modSignatures = new Map<string, string>();
+  private readonly modelsStore = new InMemoryModelsStore();
 
   constructor(options: LocalPiModelsRuntimeOptions = {}) {
     this.storageDir = options.storageDir;
     this.fetchImpl = options.fetchImpl;
-    this.models = createModels();
+    this.models = createModels({ modelsStore: this.modelsStore });
     for (const provider of builtinProviders()) {
       this.models.setProvider(provider);
     }
+  }
+
+  private refreshContext(providerId: string): RefreshModelsContext {
+    return {
+      store: {
+        read: () => this.modelsStore.read(providerId),
+        write: (entry) => this.modelsStore.write(providerId, entry),
+        delete: () => this.modelsStore.delete(providerId),
+      },
+      allowNetwork: true,
+      force: true,
+    };
   }
 
   /** Providers whose models this runtime discovers and owns end-to-end. */
@@ -247,13 +261,38 @@ export class LocalPiModelsRuntime {
   }
 
   /**
-   * Re-fetch a dynamic provider's model list. Rejects on fetch failure; the
-   * provider keeps serving its last-known list so a transient endpoint outage
-   * does not brick turns or wipe /model.
+   * Re-fetch every runtime-managed provider's model list concurrently.
+   * Per-provider fetch failures keep that provider's last-known list, so a
+   * transient endpoint outage does not brick turns or wipe /model. Built-in
+   * providers are not refreshed here — their catalogs are static and any
+   * dynamic upstream catalogs stay on pi-ai's own refresh cadence.
+   */
+  async refreshAll(): Promise<void> {
+    this.ensureManagedProviders();
+    const managedIds = new Set([
+      ...MANAGED_ENDPOINT_PROVIDERS.keys(),
+      ...listRegisteredPiProviders().map((provider) => provider.providerName),
+    ]);
+    await Promise.all(
+      [...managedIds].map(async (providerId) => {
+        try {
+          await this.refresh(providerId);
+        } catch {
+          // Keep last-known models for this provider.
+        }
+      }),
+    );
+  }
+
+  /**
+   * Refresh one provider with per-provider error semantics: rejects with the
+   * fetch error while the provider keeps serving its last-known list.
    */
   async refresh(providerId: string): Promise<void> {
     this.ensureManagedProviders(providerId);
-    await this.models.refresh(providerId);
+    const provider = this.models.getProvider(providerId);
+    if (!provider?.refreshModels) return;
+    await provider.refreshModels(this.refreshContext(providerId));
   }
 
   /**
@@ -278,7 +317,7 @@ export class LocalPiModelsRuntime {
   stream<TApi extends Api>(
     model: Model<TApi>,
     context: Context,
-    options?: ApiStreamOptions<TApi>,
+    options?: ModelsApiStreamOptions<TApi>,
   ): AssistantMessageEventStream {
     this.ensureManagedProviders((model as Model<Api>).provider);
     return this.models.stream(model, context, options);
@@ -287,7 +326,7 @@ export class LocalPiModelsRuntime {
   streamSimple(
     model: Model<Api>,
     context: Context,
-    options?: SimpleStreamOptions,
+    options?: ModelsSimpleStreamOptions,
   ): AssistantMessageEventStream {
     this.ensureManagedProviders(model.provider);
     return this.models.streamSimple(model, context, options);

--- a/src/backend/dev/pi-oauth.ts
+++ b/src/backend/dev/pi-oauth.ts
@@ -1,0 +1,107 @@
+import type { AuthInteraction, OAuthAuth } from "@earendil-works/pi-ai";
+import type {
+  OAuthLoginCallbacks,
+  OAuthPrompt,
+  OAuthSelectPrompt,
+} from "@earendil-works/pi-ai/oauth";
+import { builtinProviders } from "@earendil-works/pi-ai/providers/all";
+import {
+  getRegisteredPiProvider,
+  type PiProviderOAuthConfig,
+} from "./pi-provider-mod-registry";
+
+/**
+ * pi-ai 0.81 removed the standalone OAuth registry: OAuth flows live on
+ * `Provider.auth.oauth`. This module is the lookup seam for Letta's local
+ * OAuth glue (login flows, token refresh in the auth store): built-in
+ * providers expose their `OAuthAuth` directly, and mod-registered providers
+ * get their legacy `PiProviderOAuthConfig` adapted onto the same interface.
+ */
+
+let builtinOAuth: Map<string, OAuthAuth> | undefined;
+
+function builtinOAuthAuths(): Map<string, OAuthAuth> {
+  builtinOAuth ??= new Map(
+    builtinProviders().flatMap((provider) =>
+      provider.auth.oauth ? [[provider.id, provider.auth.oauth] as const] : [],
+    ),
+  );
+  return builtinOAuth;
+}
+
+/** Legacy extension-callback surface driven from a pi-ai AuthInteraction. */
+function legacyCallbacksFromInteraction(
+  interaction: AuthInteraction,
+): OAuthLoginCallbacks {
+  return {
+    ...(interaction.signal ? { signal: interaction.signal } : {}),
+    onAuth: (info) =>
+      interaction.notify({
+        type: "auth_url",
+        url: info.url,
+        ...(info.instructions ? { instructions: info.instructions } : {}),
+      }),
+    onDeviceCode: (info) =>
+      interaction.notify({ type: "device_code", ...info }),
+    onProgress: (message) => interaction.notify({ type: "progress", message }),
+    onPrompt: (prompt: OAuthPrompt) =>
+      interaction.prompt({
+        type: "text",
+        message: prompt.message,
+        ...(prompt.placeholder ? { placeholder: prompt.placeholder } : {}),
+      }),
+    onSelect: (prompt: OAuthSelectPrompt) =>
+      interaction.prompt({
+        type: "select",
+        message: prompt.message,
+        options: prompt.options.map((option) => ({
+          id: option.id,
+          label: option.label,
+        })),
+      }),
+  };
+}
+
+/** Adapts a mod's declarative OAuth config onto pi-ai's OAuthAuth. */
+export function modOAuthAuth(
+  providerName: string,
+  config: PiProviderOAuthConfig,
+): OAuthAuth {
+  return {
+    name: config.name ?? providerName,
+    login: async (interaction) => ({
+      type: "oauth",
+      ...(await config.login(legacyCallbacksFromInteraction(interaction))),
+    }),
+    refresh: async (credential) => ({
+      type: "oauth",
+      ...(await config.refreshToken(credential)),
+    }),
+    toAuth: async (credential) => ({ apiKey: config.getApiKey(credential) }),
+  };
+}
+
+/**
+ * OAuth implementation for a provider id: mod registration first (matching
+ * the resolution order everywhere else), then built-in pi-ai providers.
+ */
+export function getProviderOAuthAuth(
+  providerId: string,
+): OAuthAuth | undefined {
+  const registered = getRegisteredPiProvider(providerId);
+  if (registered?.config.oauth) {
+    return modOAuthAuth(registered.providerName, registered.config.oauth);
+  }
+  return builtinOAuthAuths().get(providerId);
+}
+
+/** Built-in providers that support subscription (OAuth) login. */
+export function listBuiltinOAuthProviders(): Array<{
+  id: string;
+  name: string;
+}> {
+  return [...builtinOAuthAuths()].map(([id, oauth]) => ({
+    id,
+    name: oauth.name,
+  }));
+}

--- a/src/backend/dev/pi-ollama-provider.test.ts
+++ b/src/backend/dev/pi-ollama-provider.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { testRefreshContext } from "@/test-utils/pi-refresh-context";
 import { localEndpointNativeBaseURL } from "./pi-local-endpoint-provider";
 import { createOllamaPiProvider } from "./pi-ollama-provider";
 
@@ -77,7 +78,7 @@ describe("createOllamaPiProvider", () => {
     });
 
     expect(provider.getModels()).toHaveLength(0);
-    await provider.refreshModels?.();
+    await provider.refreshModels?.(testRefreshContext());
 
     const qwen = provider.getModels().find((m) => m.id === "qwen3.6:27b");
     expect(qwen).toBeDefined();
@@ -107,13 +108,13 @@ describe("createOllamaPiProvider", () => {
       fetchImpl: fakeOllamaFetch(state),
     });
 
-    await provider.refreshModels?.();
+    await provider.refreshModels?.(testRefreshContext());
     const showCalls = () =>
       state.requests.filter((url) => url.endsWith("/api/show")).length;
     expect(showCalls()).toBe(1);
 
     // Unchanged digest: refresh reuses the published Model, no metadata read.
-    await provider.refreshModels?.();
+    await provider.refreshModels?.(testRefreshContext());
     expect(showCalls()).toBe(1);
     expect(
       provider.getModels().find((m) => m.id === "qwen3.6:27b")?.input,
@@ -121,7 +122,7 @@ describe("createOllamaPiProvider", () => {
 
     // New digest (model updated): metadata is re-read.
     state.tags = { models: [{ name: "qwen3.6:27b", digest: "sha256-bbb" }] };
-    await provider.refreshModels?.();
+    await provider.refreshModels?.(testRefreshContext());
     expect(showCalls()).toBe(2);
   });
 
@@ -131,11 +132,13 @@ describe("createOllamaPiProvider", () => {
       baseURL: "http://localhost:11434",
       fetchImpl: fakeOllamaFetch(state),
     });
-    await provider.refreshModels?.();
+    await provider.refreshModels?.(testRefreshContext());
     expect(provider.getModels()).toHaveLength(2);
 
     state.failTags = true;
-    expect(provider.refreshModels?.()).rejects.toThrow("connection refused");
+    expect(provider.refreshModels?.(testRefreshContext())).rejects.toThrow(
+      "connection refused",
+    );
     expect(provider.getModels()).toHaveLength(2);
     expect(
       provider.getModels().find((m) => m.id === "qwen3.6:27b")?.input,
@@ -148,10 +151,10 @@ describe("createOllamaPiProvider", () => {
       baseURL: "http://localhost:11434",
       fetchImpl: fakeOllamaFetch(state),
     });
-    await provider.refreshModels?.();
+    await provider.refreshModels?.(testRefreshContext());
 
     state.failShowFor = new Set(["qwen3.6:27b"]);
-    await provider.refreshModels?.();
+    await provider.refreshModels?.(testRefreshContext());
     expect(
       provider.getModels().find((m) => m.id === "qwen3.6:27b")?.input,
     ).toEqual(["text", "image"]);
@@ -164,7 +167,7 @@ describe("createOllamaPiProvider", () => {
       baseURL: "http://localhost:11434",
       fetchImpl: fakeOllamaFetch(state),
     });
-    await provider.refreshModels?.();
+    await provider.refreshModels?.(testRefreshContext());
     expect(
       provider.getModels().find((m) => m.id === "qwen3.6:27b")?.input,
     ).toEqual(["text"]);
@@ -195,7 +198,7 @@ describe("createOllamaPiProvider as Ollama Cloud", () => {
     expect(provider.id).toBe("ollama-cloud");
     expect(provider.name).toBe("Ollama Cloud");
 
-    await provider.refreshModels?.();
+    await provider.refreshModels?.(testRefreshContext());
     const qwen = provider.getModels().find((m) => m.id === "qwen3.6:27b");
     expect(qwen?.provider).toBe("ollama-cloud");
     expect(qwen?.input).toEqual(["text", "image"]);
@@ -216,7 +219,7 @@ describe("defaults when engine metadata is missing", () => {
       baseURL: "http://localhost:11434",
       fetchImpl: fakeOllamaFetch(state),
     });
-    await provider.refreshModels?.();
+    await provider.refreshModels?.(testRefreshContext());
     const model = provider.getModels().find((m) => m.id === "some-model");
     expect(model?.contextWindow).toBe(128000);
     expect(model?.input).toEqual(["text"]);

--- a/src/backend/dev/pi-ollama-provider.test.ts
+++ b/src/backend/dev/pi-ollama-provider.test.ts
@@ -136,9 +136,9 @@ describe("createOllamaPiProvider", () => {
     expect(provider.getModels()).toHaveLength(2);
 
     state.failTags = true;
-    expect(provider.refreshModels?.(testRefreshContext())).rejects.toThrow(
-      "connection refused",
-    );
+    await expect(
+      provider.refreshModels?.(testRefreshContext()),
+    ).rejects.toThrow("connection refused");
     expect(provider.getModels()).toHaveLength(2);
     expect(
       provider.getModels().find((m) => m.id === "qwen3.6:27b")?.input,

--- a/src/backend/dev/pi-ollama-provider.ts
+++ b/src/backend/dev/pi-ollama-provider.ts
@@ -1,4 +1,4 @@
-import type { Model, Provider } from "@earendil-works/pi-ai";
+import type { Provider } from "@earendil-works/pi-ai";
 import {
   createLocalEndpointPiProvider,
   type LocalEndpointDiscover,
@@ -14,7 +14,6 @@ export interface OllamaPiProviderOptions {
   apiKey?: string;
   fetchImpl?: typeof fetch;
   discoveryTimeoutMs?: number;
-  initialModels?: readonly Model<"openai-completions">[];
   /** Defaults to the local Ollama provider; Ollama Cloud reuses this factory. */
   providerId?: string;
   name?: string;
@@ -145,7 +144,6 @@ export function createOllamaPiProvider(
     ...(options.discoveryTimeoutMs
       ? { discoveryTimeoutMs: options.discoveryTimeoutMs }
       : {}),
-    ...(options.initialModels ? { initialModels: options.initialModels } : {}),
     discover: ollamaDiscover,
   });
 }

--- a/src/backend/dev/pi-provider-mod-registry.ts
+++ b/src/backend/dev/pi-provider-mod-registry.ts
@@ -1,9 +1,4 @@
-import {
-  registerOAuthProvider,
-  unregisterOAuthProvider,
-} from "@earendil-works/pi-ai/oauth";
 import type {
-  PiProviderOAuthLoginCallbacks,
   PiProviderRegistration,
   RegisteredPiProvider,
 } from "./pi-provider-mod-types";
@@ -67,45 +62,6 @@ export function subscribePiProviderRegistry(
   };
 }
 
-function registerPiOAuthProvider(
-  providerName: string,
-  config: PiProviderRegistration,
-): void {
-  unregisterOAuthProvider(providerName);
-  if (!config.oauth) return;
-  registerOAuthProvider({
-    id: providerName,
-    name: config.oauth.name ?? config.name ?? providerName,
-    login: (callbacks) =>
-      config.oauth?.login(callbacks as PiProviderOAuthLoginCallbacks) ??
-      Promise.reject(
-        new Error(`Provider "${providerName}" OAuth is not registered`),
-      ),
-    refreshToken: (credentials) => {
-      if (!config.oauth) {
-        throw new Error(`Provider "${providerName}" OAuth is not registered`);
-      }
-      return config.oauth.refreshToken(credentials);
-    },
-    getApiKey: (credentials) => {
-      if (!config.oauth) {
-        throw new Error(`Provider "${providerName}" OAuth is not registered`);
-      }
-      return config.oauth.getApiKey(credentials);
-    },
-    ...(config.oauth.modifyModels
-      ? {
-          modifyModels: (models, credentials) =>
-            config.oauth?.modifyModels?.(models, credentials) ?? models,
-        }
-      : {}),
-  });
-}
-
-function unregisterPiOAuthProvider(providerName: string): void {
-  unregisterOAuthProvider(providerName);
-}
-
 export function registerPiProvider(
   providerName: string,
   config: PiProviderRegistration,
@@ -120,7 +76,6 @@ export function registerPiProvider(
   };
   registeredProviders.set(providerName, registered);
   bumpProviderRevision(providerName);
-  registerPiOAuthProvider(providerName, registered.config);
   notifyRegistryListeners();
   return getRegisteredPiProvider(providerName) as RegisteredPiProvider;
 }
@@ -134,7 +89,6 @@ export function unregisterPiProvider(
   if (ownerId && existing.ownerId && existing.ownerId !== ownerId) return;
   registeredProviders.delete(providerName);
   bumpProviderRevision(providerName);
-  unregisterPiOAuthProvider(providerName);
   notifyRegistryListeners();
 }
 
@@ -144,7 +98,6 @@ export function unregisterPiProvidersForOwner(ownerId: string): void {
     if (provider.ownerId === ownerId) {
       registeredProviders.delete(providerName);
       bumpProviderRevision(providerName);
-      unregisterPiOAuthProvider(providerName);
       changed = true;
     }
   }
@@ -155,7 +108,6 @@ export function clearRegisteredPiProviders(): void {
   if (registeredProviders.size === 0) return;
   for (const providerName of registeredProviders.keys()) {
     bumpProviderRevision(providerName);
-    unregisterPiOAuthProvider(providerName);
   }
   registeredProviders.clear();
   notifyRegistryListeners();

--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -3,8 +3,8 @@ import type { Api, KnownProvider, Model } from "@earendil-works/pi-ai";
 // /compat import in the local backend (tracked upstream).
 import { getEnvApiKey } from "@earendil-works/pi-ai/compat";
 import {
+  builtinProviders,
   getBuiltinModels,
-  getBuiltinProviders,
 } from "@earendil-works/pi-ai/providers/all";
 
 export const LOCAL_CHATGPT_PROVIDER_NAME = "chatgpt-plus-pro";
@@ -115,6 +115,7 @@ export const PI_TUI_DEFAULT_MODEL_IDS: Partial<Record<KnownProvider, string>> =
     openai: "gpt-5.5",
     "azure-openai-responses": "gpt-5.4",
     "openai-codex": "gpt-5.5",
+    radius: "auto",
     nvidia: "nvidia/nemotron-3-super-120b-a12b",
     deepseek: "deepseek-v4-pro",
     google: "gemini-3.1-pro-preview",
@@ -349,7 +350,12 @@ const LOCAL_ENDPOINT_PROVIDER_SPECS: readonly PiProviderSpec[] = [
 ];
 
 export const PI_PROVIDER_SPECS: readonly PiProviderSpec[] = [
-  ...getBuiltinProviders().map(makePiProviderSpec),
+  // Keyed off the provider collection (builtinProviders), not the generated
+  // static catalog: purely dynamic providers (e.g. "radius") have a factory
+  // but no catalog entry.
+  ...builtinProviders().map((provider) =>
+    makePiProviderSpec(provider.id as KnownProvider),
+  ),
   ...LOCAL_ENDPOINT_PROVIDER_SPECS,
 ];
 

--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -68,6 +68,21 @@ interface PiProviderOverride {
   catalogModelHandle?: (model: Model<Api>) => string | undefined;
 }
 
+/**
+ * Static catalog models for a provider. Some pi-ai providers (e.g. "radius")
+ * have purely dynamic catalogs and no generated MODELS entry; they read as
+ * an empty catalog here.
+ */
+export function builtinCatalogModels(
+  provider: KnownProvider,
+): readonly Model<Api>[] {
+  try {
+    return (getBuiltinModels(provider as never) ?? []) as readonly Model<Api>[];
+  } catch {
+    return [];
+  }
+}
+
 function hasEnvValue(value: string | undefined): boolean {
   return typeof value === "string" && value.length > 0;
 }
@@ -95,20 +110,23 @@ const PI_PROVIDER_ALIASES: Record<string, PiProvider> = {
 export const PI_TUI_DEFAULT_MODEL_IDS: Partial<Record<KnownProvider, string>> =
   {
     "amazon-bedrock": "us.anthropic.claude-opus-4-6-v1",
-    anthropic: "claude-opus-4-7",
-    openai: "gpt-5.4",
+    "ant-ling": "Ring-2.6-1T",
+    anthropic: "claude-opus-4-8",
+    openai: "gpt-5.5",
     "azure-openai-responses": "gpt-5.4",
     "openai-codex": "gpt-5.5",
+    nvidia: "nvidia/nemotron-3-super-120b-a12b",
     deepseek: "deepseek-v4-pro",
     google: "gemini-3.1-pro-preview",
     "google-vertex": "gemini-3.1-pro-preview",
     "github-copilot": "gpt-5.4",
     openrouter: "moonshotai/kimi-k2.6",
     "vercel-ai-gateway": "zai/glm-5.1",
-    xai: "grok-4.20-0309-reasoning",
+    xai: "grok-4.5",
     groq: "openai/gpt-oss-120b",
     cerebras: "zai-glm-4.7",
-    zai: "glm-5.2",
+    zai: "glm-5.1",
+    "zai-coding-cn": "glm-5.1",
     mistral: "devstral-medium-latest",
     minimax: "MiniMax-M2.7",
     "minimax-cn": "MiniMax-M2.7",
@@ -122,6 +140,8 @@ export const PI_TUI_DEFAULT_MODEL_IDS: Partial<Record<KnownProvider, string>> =
     "kimi-coding": "kimi-for-coding",
     "cloudflare-workers-ai": "@cf/moonshotai/kimi-k2.6",
     "cloudflare-ai-gateway": "workers-ai/@cf/moonshotai/kimi-k2.6",
+    "qwen-token-plan": "qwen3.7-max",
+    "qwen-token-plan-cn": "qwen3.7-max",
     xiaomi: "mimo-v2.5-pro",
     "xiaomi-token-plan-cn": "mimo-v2.5-pro",
     "xiaomi-token-plan-ams": "mimo-v2.5-pro",
@@ -131,11 +151,7 @@ export const PI_TUI_DEFAULT_MODEL_IDS: Partial<Record<KnownProvider, string>> =
 // These pi-ai providers are intentionally absent from Pi TUI's
 // `defaultModelPerProvider`. Keep the omission explicit so newly added pi-ai
 // providers cannot silently inherit catalog-order defaults without review.
-export const PI_TUI_DEFAULTLESS_PROVIDER_IDS: ReadonlySet<string> = new Set([
-  "ant-ling",
-  "nvidia",
-  "zai-coding-cn",
-]);
+export const PI_TUI_DEFAULTLESS_PROVIDER_IDS: ReadonlySet<string> = new Set([]);
 
 const PI_PROVIDER_OVERRIDES: Partial<
   Record<KnownProvider, PiProviderOverride>
@@ -221,7 +237,7 @@ function defaultModelForProvider(
   if (piTuiDefault) return `${handlePrefix}${piTuiDefault}`;
   // Match Pi TUI's no-explicit-default behavior for providers omitted from its
   // default map: use catalog order as the generic fallback.
-  const model = getBuiltinModels(provider)[0] as Model<Api> | undefined;
+  const model = builtinCatalogModels(provider)[0];
   return model ? `${handlePrefix}${model.id}` : `${handlePrefix}model`;
 }
 
@@ -402,7 +418,7 @@ export function isResolvablePiModelHandle(model: string | undefined): boolean {
   const spec = getPiProviderSpec(provider);
   if (!spec.piProvider) return spec.createCustomModel === true;
   const modelId = stripProviderHandlePrefix(model, provider);
-  return getBuiltinModels(spec.piProvider).some(
+  return builtinCatalogModels(spec.piProvider).some(
     (entry) => entry.id === modelId,
   );
 }
@@ -473,7 +489,7 @@ export function listCatalogModelsForProvider(provider: PiProvider): string[] {
 
   add(spec.defaultModel);
   if (spec.piProvider && spec.catalogModelHandle) {
-    for (const model of getBuiltinModels(spec.piProvider)) {
+    for (const model of builtinCatalogModels(spec.piProvider)) {
       add(spec.catalogModelHandle(model as Model<Api>));
     }
   }

--- a/src/backend/local-backend.test.ts
+++ b/src/backend/local-backend.test.ts
@@ -1140,7 +1140,7 @@ describe("local backend pi transcript", () => {
       (model) => model.handle,
     );
     const zaiHandles = handles.filter((handle) => handle.startsWith("zai/"));
-    expect(zaiHandles[0]).toBe("zai/glm-5.2");
+    expect(zaiHandles[0]).toBe("zai/glm-5.1");
     expect(handles).toContain("zai/glm-4.5-air");
     expect(handles).toContain("zai/glm-5.2");
     expect(handles).toContain("zai/glm-5.1");

--- a/src/backend/local/local-model-config.ts
+++ b/src/backend/local/local-model-config.ts
@@ -1,5 +1,4 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
-import { getBuiltinModels } from "@earendil-works/pi-ai/providers/all";
 import {
   DEFAULT_PI_PROVIDER,
   isUnselectedLocalModelHandle,
@@ -14,6 +13,7 @@ import {
   stripRegisteredProviderHandlePrefix,
 } from "@/backend/dev/pi-provider-mod-registry";
 import {
+  builtinCatalogModels,
   getPiProviderSpec,
   isPiProvider,
   listCatalogModelsForProvider,
@@ -130,7 +130,7 @@ function catalogModelSettingsForProviderModel(
   if (!modelId || !isPiProvider(provider)) return undefined;
   const spec = getPiProviderSpec(provider);
   if (!spec.piProvider) return undefined;
-  const model = (getBuiltinModels(spec.piProvider) as Model<Api>[]).find(
+  const model = builtinCatalogModels(spec.piProvider).find(
     (entry) => entry.id === modelId,
   );
   if (!model) return undefined;
@@ -254,6 +254,9 @@ export async function listLocalModels(
     });
   const records = listLocalProviderRecords(storageDir);
   const providerNames = localProviderNamesFromRecords(records);
+  // One collection-wide refresh (pi-ai 0.81 semantics): configured dynamic
+  // providers re-fetch, per-provider failures keep last-known lists.
+  await modelsRuntime.refreshAll();
   const configured = resolveLocalModelConfig(storageDir);
   const models: LocalModelListEntry[] = [];
   const registeredProviders = listRegisteredPiProviders();
@@ -299,7 +302,7 @@ export async function listLocalModels(
       ? getPiProviderSpec(provider)
       : undefined;
     const catalogModel = providerSpec?.piProvider
-      ? (getBuiltinModels(providerSpec.piProvider) as Model<Api>[]).find(
+      ? builtinCatalogModels(providerSpec.piProvider).find(
           (entry) => entry.id === modelId,
         )
       : undefined;
@@ -320,14 +323,9 @@ export async function listLocalModels(
 
   for (const provider of registeredProviders) {
     if (!isRegisteredPiProviderConfigured(provider, records)) continue;
-    // The mod's provider in the Models runtime owns discovery. Refresh
-    // failure retains its last-known list, which is seeded from the static
-    // registration.
-    try {
-      await modelsRuntime.refresh(provider.providerName);
-    } catch {
-      // Keep last-known models.
-    }
+    // The mod's provider in the Models runtime owns discovery; the refresh
+    // above already re-fetched it (failure retains the last-known list,
+    // seeded from the static registration).
     for (const model of modelsRuntime.getModels(provider.providerName)) {
       addModel(provider.providerName, model.id, {
         handle: `${provider.providerName}/${model.id}`,
@@ -373,12 +371,6 @@ export async function listLocalModels(
         }
 
         if (modelsRuntime.isRuntimeManagedProvider(provider)) {
-          try {
-            await modelsRuntime.refresh(provider);
-          } catch {
-            // Refresh failure retains the provider's last-known model list
-            // instead of dropping it from /model.
-          }
           return {
             provider,
             models: [],

--- a/src/backend/local/local-provider-auth-store.ts
+++ b/src/backend/local/local-provider-auth-store.ts
@@ -6,11 +6,9 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
-import {
-  getOAuthApiKey,
-  type OAuthCredentials,
-} from "@earendil-works/pi-ai/oauth";
+import type { OAuthCredentials } from "@earendil-works/pi-ai/oauth";
 import type { ProviderResponse } from "@/backend/api/providers";
+import { getProviderOAuthAuth } from "@/backend/dev/pi-oauth";
 import { getRegisteredPiProvider } from "@/backend/dev/pi-provider-mod-registry";
 import {
   LOCAL_CHATGPT_PROVIDER_NAME,
@@ -432,18 +430,28 @@ export async function getLocalOAuthApiKey(input: {
   | {
       apiKey: string;
       credentials: OAuthCredentials;
+      baseUrl?: string;
+      headers?: Record<string, string>;
     }
   | undefined
 > {
   const record = localOAuthRecord(input.providerNames, input.storageDir);
   if (!record || record.auth.type !== "oauth") return undefined;
 
-  const result = await getOAuthApiKey(input.providerId, {
-    [input.providerId]: toPiOAuthCredentials(record.auth),
-  });
-  if (!result) return undefined;
+  // pi-ai 0.81: OAuth lives on the provider (Provider.auth.oauth). Refresh
+  // expired tokens through the provider's own flow, then derive request auth
+  // (apiKey plus per-credential baseUrl/headers, e.g. GitHub Copilot).
+  const oauth = getProviderOAuthAuth(input.providerId);
+  if (!oauth) return undefined;
 
-  const nextAuth = toLocalOAuthAuth(result.newCredentials, record.auth);
+  let credentials = toPiOAuthCredentials(record.auth);
+  if (Date.now() >= credentials.expires) {
+    credentials = await oauth.refresh({ type: "oauth", ...credentials });
+  }
+  const modelAuth = await oauth.toAuth({ type: "oauth", ...credentials });
+  if (!modelAuth.apiKey) return undefined;
+
+  const nextAuth = toLocalOAuthAuth(credentials, record.auth);
   if (!localOAuthAuthEquals(nextAuth, record.auth)) {
     setLocalOAuthProvider({
       providerName: record.name,
@@ -452,9 +460,18 @@ export async function getLocalOAuthApiKey(input: {
       storageDir: input.storageDir,
     });
   }
+  const headers = modelAuth.headers
+    ? Object.fromEntries(
+        Object.entries(modelAuth.headers).filter(
+          (entry): entry is [string, string] => entry[1] !== null,
+        ),
+      )
+    : undefined;
   return {
-    apiKey: result.apiKey,
-    credentials: result.newCredentials,
+    apiKey: modelAuth.apiKey,
+    credentials,
+    ...(modelAuth.baseUrl ? { baseUrl: modelAuth.baseUrl } : {}),
+    ...(headers && Object.keys(headers).length > 0 ? { headers } : {}),
   };
 }
 

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -3,7 +3,6 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
-import { getOAuthProvider } from "@earendil-works/pi-ai/oauth";
 import { getBuiltinModels as getModels } from "@earendil-works/pi-ai/providers/all";
 import {
   applyPiEnvOverrides,
@@ -11,6 +10,7 @@ import {
   resolvePiModelForAgent,
 } from "@/backend/dev/pi-model-factory";
 import { LocalPiModelsRuntime } from "@/backend/dev/pi-models-runtime";
+import { getProviderOAuthAuth } from "@/backend/dev/pi-oauth";
 import {
   clearRegisteredPiProviders,
   registerPiProvider,
@@ -183,7 +183,7 @@ describe("pi model factory", () => {
 
       expect(resolved.provider).toBe("openai-codex");
       expect(resolved.model.id).toBe("gpt-5.6-sol");
-      expect(resolved.model.contextWindow).toBe(372000);
+      expect(resolved.model.contextWindow).toBe(272000);
       expect(getSupportedThinkingLevels(resolved.model)).toContain("max");
       expect(
         reasoningForSettings(
@@ -521,7 +521,7 @@ describe("pi model factory", () => {
         { localProviderAuthStorageDir: storageDir },
       );
 
-      expect(getOAuthProvider("kilo")?.name).toBe("Kilo");
+      expect(getProviderOAuthAuth("kilo")?.name).toBe("Kilo");
       expect(refreshes).toHaveLength(1);
       expect(resolved.apiKey).toBe("oauth:refreshed-token");
       expect(resolved.model).toMatchObject({

--- a/src/cli/commands/connect-local-oauth.ts
+++ b/src/cli/commands/connect-local-oauth.ts
@@ -1,8 +1,9 @@
-import {
-  getOAuthProvider,
-  type OAuthPrompt,
-  type OAuthSelectPrompt,
+import type { AuthInteraction, AuthPrompt } from "@earendil-works/pi-ai";
+import type {
+  OAuthPrompt,
+  OAuthSelectPrompt,
 } from "@earendil-works/pi-ai/oauth";
+import { getProviderOAuthAuth } from "@/backend/dev/pi-oauth";
 import {
   localOAuthAuthFromCredentials,
   setLocalOAuthProvider,
@@ -22,11 +23,6 @@ export interface LocalOAuthConnectCallbacks {
   timeout?: LocalProviderTimeout;
 }
 
-interface OAuthDeviceCodeInfo {
-  verificationUri: string;
-  userCode: string;
-}
-
 function localOAuthProviderId(provider: ByokProvider): string {
   const providerId = provider.oauthProviderId;
   if (!providerId) {
@@ -35,20 +31,27 @@ function localOAuthProviderId(provider: ByokProvider): string {
   return providerId;
 }
 
-async function defaultPrompt(
-  providerName: string,
-  prompt: OAuthPrompt,
-): Promise<string> {
-  if (prompt.allowEmpty) return "";
-  throw new Error(`${providerName} requires input: ${prompt.message}`);
-}
-
-async function defaultSelect(
-  prompt: OAuthSelectPrompt,
-): Promise<string | undefined> {
+async function defaultSelect(prompt: AuthPrompt): Promise<string> {
   // pi-ai providers list their default option first (e.g. OpenAI Codex
   // browser login), so auto-select it when the caller has no selection UI.
-  return prompt.options[0]?.id;
+  if (prompt.type !== "select") return "";
+  return prompt.options[0]?.id ?? "";
+}
+
+/**
+ * A prompt raced against an out-of-band resolution (e.g. an OAuth callback
+ * server racing a manual-code prompt): with no UI to answer it, wait until
+ * pi-ai cancels the prompt because the other path won.
+ */
+function waitForPromptCancellation(prompt: AuthPrompt): Promise<string> {
+  return new Promise((_resolve, reject) => {
+    const abort = () => reject(new DOMException("Aborted", "AbortError"));
+    if (prompt.signal?.aborted) {
+      abort();
+      return;
+    }
+    prompt.signal?.addEventListener("abort", abort, { once: true });
+  });
 }
 
 export async function runLocalOAuthConnectFlow(
@@ -56,54 +59,75 @@ export async function runLocalOAuthConnectFlow(
   callbacks: LocalOAuthConnectCallbacks,
 ): Promise<{ providerName: string }> {
   const providerId = localOAuthProviderId(provider);
-  const oauthProvider = getOAuthProvider(providerId);
-  if (!oauthProvider) {
+  const oauth = getProviderOAuthAuth(providerId);
+  if (!oauth) {
     throw new Error(`Unknown OAuth provider: ${providerId}`);
   }
 
   const browserOpener = callbacks.openBrowser ?? openOAuthBrowser;
-  await callbacks.onStatus(`Starting ${oauthProvider.name} login...`);
+  await callbacks.onStatus(`Starting ${oauth.name} login...`);
 
-  const loginCallbacks = {
-    signal: callbacks.signal,
-    onAuth: (info) => {
-      const status = [
-        `Open this URL to authenticate ${oauthProvider.name}:`,
-        "",
-        info.url,
-        ...(info.instructions ? ["", info.instructions] : []),
-      ].join("\n");
-      void Promise.resolve(callbacks.onStatus(status));
-      void browserOpener(info.url);
+  const interaction: AuthInteraction = {
+    ...(callbacks.signal ? { signal: callbacks.signal } : {}),
+    notify: (event) => {
+      switch (event.type) {
+        case "auth_url": {
+          const status = [
+            `Open this URL to authenticate ${oauth.name}:`,
+            "",
+            event.url,
+            ...(event.instructions ? ["", event.instructions] : []),
+          ].join("\n");
+          void Promise.resolve(callbacks.onStatus(status));
+          void browserOpener(event.url);
+          return;
+        }
+        case "device_code": {
+          const status = [
+            `Open this URL to authenticate ${oauth.name}:`,
+            "",
+            event.verificationUri,
+            "",
+            `Enter code: ${event.userCode}`,
+          ].join("\n");
+          void Promise.resolve(callbacks.onStatus(status));
+          void browserOpener(event.verificationUri);
+          return;
+        }
+        default:
+          void Promise.resolve(callbacks.onStatus(event.message));
+      }
     },
-    onPrompt: (prompt) =>
-      callbacks.onPrompt?.(prompt) ?? defaultPrompt(oauthProvider.name, prompt),
-    onProgress: (message) => {
-      void Promise.resolve(callbacks.onStatus(message));
+    prompt: async (prompt) => {
+      if (prompt.type === "select") {
+        const answer = await callbacks.onSelect?.({
+          message: prompt.message,
+          options: prompt.options.map((option) => ({
+            id: option.id,
+            label: option.label,
+          })),
+        });
+        return answer ?? defaultSelect(prompt);
+      }
+      if (callbacks.onPrompt) {
+        return callbacks.onPrompt({
+          message: prompt.message,
+          ...(prompt.placeholder ? { placeholder: prompt.placeholder } : {}),
+        });
+      }
+      if (prompt.type === "manual_code" && prompt.signal) {
+        return waitForPromptCancellation(prompt);
+      }
+      throw new Error(`${oauth.name} requires input: ${prompt.message}`);
     },
-    onSelect: (prompt) => callbacks.onSelect?.(prompt) ?? defaultSelect(prompt),
-  } as Parameters<typeof oauthProvider.login>[0] & {
-    onDeviceCode?: (info: OAuthDeviceCodeInfo) => void;
   };
 
-  loginCallbacks.onDeviceCode = (info) => {
-    const status = [
-      `Open this URL to authenticate ${oauthProvider.name}:`,
-      "",
-      info.verificationUri,
-      "",
-      `Enter code: ${info.userCode}`,
-    ].join("\n");
-    void Promise.resolve(callbacks.onStatus(status));
-    void browserOpener(info.verificationUri);
-  };
-
-  const credentials = await oauthProvider.login(loginCallbacks);
+  const credential = await oauth.login(interaction);
 
   setLocalOAuthProvider({
     providerName: provider.providerName,
     providerType: provider.providerType,
-    auth: localOAuthAuthFromCredentials(credentials),
+    auth: localOAuthAuthFromCredentials(credential),
     baseURL: callbacks.baseURL,
     timeout: callbacks.timeout,
   });

--- a/src/cli/subcommands/connect.test.ts
+++ b/src/cli/subcommands/connect.test.ts
@@ -428,7 +428,7 @@ describe("connect subcommand", () => {
 
     expect(exitCode).toBe(1);
     expect(stderr.join("\n")).toContain(
-      "Unknown ChatGPT Plus/Pro (Codex Subscription) login method: carrier-pigeon",
+      "Unknown OpenAI (ChatGPT Plus/Pro) login method: carrier-pigeon",
     );
     expect(stderr.join("\n")).toContain("Available: browser, device_code");
   });

--- a/src/providers/byok-providers.ts
+++ b/src/providers/byok-providers.ts
@@ -3,7 +3,6 @@
  * Unified module for managing custom LLM provider connections
  */
 
-import { getOAuthProviders } from "@earendil-works/pi-ai/oauth";
 import { getBuiltinProviders } from "@earendil-works/pi-ai/providers/all";
 import {
   checkProviderApiKey as checkProviderApiKeyRequest,
@@ -17,6 +16,7 @@ import {
   updateProvider as updateProviderRequest,
 } from "@/backend/api/providers";
 import { getBackend } from "@/backend/backend";
+import { listBuiltinOAuthProviders } from "@/backend/dev/pi-oauth";
 import { listRegisteredPiProviders } from "@/backend/dev/pi-provider-mod-registry";
 import {
   getPiProviderSpec,
@@ -372,7 +372,7 @@ function localOAuthProviderConfigs(): ByokProvider[] {
   const registeredProviderIds = new Set(
     listRegisteredPiProviders().map((provider) => provider.providerName),
   );
-  return getOAuthProviders()
+  return listBuiltinOAuthProviders()
     .filter((provider) => !registeredProviderIds.has(provider.id))
     .map((provider) => {
       const spec = PI_PROVIDER_SPECS.find(
@@ -400,7 +400,7 @@ function localOAuthProviderConfigs(): ByokProvider[] {
 
 function localApiKeyProviderIds(): string[] {
   const oauthProviderIds = new Set(
-    getOAuthProviders().map((provider) => provider.id),
+    listBuiltinOAuthProviders().map((provider) => provider.id),
   );
   return getBuiltinProviders().filter(
     (provider) =>

--- a/src/providers/local-pi-provider-catalog.test.ts
+++ b/src/providers/local-pi-provider-catalog.test.ts
@@ -3,13 +3,13 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
-  getOAuthProvider,
-  getOAuthProviders,
-} from "@earendil-works/pi-ai/oauth";
-import {
   getBuiltinModels as getModels,
   getBuiltinProviders as getProviders,
 } from "@earendil-works/pi-ai/providers/all";
+import {
+  getProviderOAuthAuth,
+  listBuiltinOAuthProviders,
+} from "@/backend/dev/pi-oauth";
 import {
   clearRegisteredPiProviders,
   registerPiProvider,
@@ -65,7 +65,7 @@ describe("local pi provider catalog", () => {
         .map((provider) => provider.oauthProviderId),
     );
 
-    for (const provider of getOAuthProviders()) {
+    for (const provider of listBuiltinOAuthProviders()) {
       expect(localOAuthProviderIds.has(provider.id)).toBe(true);
     }
   });
@@ -76,9 +76,15 @@ describe("local pi provider catalog", () => {
       expect(spec.defaultModel).toBeDefined();
       if (!spec.defaultModel) continue;
       const modelId = spec.defaultModel.split("/").slice(1).join("/");
-      expect(
-        getModels(spec.piProvider).some((model) => model.id === modelId),
-      ).toBe(true);
+      // Providers with purely dynamic catalogs (e.g. "radius") have no
+      // generated models; their TUI default cannot be catalog-checked.
+      if (getModels(spec.piProvider as never)?.length) {
+        expect(
+          getModels(spec.piProvider as never).some(
+            (model) => model.id === modelId,
+          ),
+        ).toBe(true);
+      }
     }
   });
 
@@ -160,7 +166,7 @@ describe("local pi provider catalog", () => {
         expect(models).toContainEqual(
           expect.objectContaining({
             handle: `openai-codex/gpt-5.6-${variant}`,
-            max_context_window: 372000,
+            max_context_window: 272000,
             model_endpoint_type: "chatgpt_oauth",
           }),
         );
@@ -286,7 +292,7 @@ describe("local pi provider catalog", () => {
       ],
     });
 
-    expect(getOAuthProvider("kilo")?.name).toBe("Kilo");
+    expect(getProviderOAuthAuth("kilo")?.name).toBe("Kilo");
 
     const provider = getProviderConfigs("local").find(
       (candidate) => candidate.id === "kilo",
@@ -335,7 +341,7 @@ describe("local pi provider catalog", () => {
       ],
     });
 
-    expect(getOAuthProvider("kilo")?.name).toBe("Kilo");
+    expect(getProviderOAuthAuth("kilo")?.name).toBe("Kilo");
     expect(
       getProviderConfigs("local").some((provider) => provider.id === "kilo"),
     ).toBe(false);

--- a/src/providers/local-pi-provider-catalog.test.ts
+++ b/src/providers/local-pi-provider-catalog.test.ts
@@ -95,11 +95,13 @@ describe("local pi provider catalog", () => {
       const spec = PI_PROVIDER_SPECS.find((entry) => entry.id === provider);
       expect(spec).toBeDefined();
       expect(spec?.defaultModel).toBe(`${spec?.handlePrefixes[0]}${modelId}`);
-      expect(
-        getModels(provider as Parameters<typeof getModels>[0]).some(
-          (model) => model.id === modelId,
-        ),
-      ).toBe(true);
+      // Purely dynamic providers (e.g. "radius") have no generated catalog;
+      // their TUI default cannot be catalog-checked.
+      const catalog =
+        getModels(provider as Parameters<typeof getModels>[0]) ?? [];
+      if (catalog.length > 0) {
+        expect(catalog.some((model) => model.id === modelId)).toBe(true);
+      }
     }
   });
 

--- a/src/test-utils/pi-refresh-context.ts
+++ b/src/test-utils/pi-refresh-context.ts
@@ -1,0 +1,26 @@
+import type { RefreshModelsContext } from "@earendil-works/pi-ai";
+
+/**
+ * Minimal pi-ai RefreshModelsContext for driving `provider.refreshModels()`
+ * directly in tests (production refreshes go through the Models runtime,
+ * which supplies a real store-backed context).
+ */
+export function testRefreshContext(): RefreshModelsContext {
+  const entries = new Map<string, unknown>();
+  return {
+    allowNetwork: true,
+    force: true,
+    store: {
+      read: async () =>
+        entries.get("entry") as
+          | Awaited<ReturnType<RefreshModelsContext["store"]["read"]>>
+          | undefined,
+      write: async (entry) => {
+        entries.set("entry", entry);
+      },
+      delete: async () => {
+        entries.delete("entry");
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Summary

**Stacked on #3468** (top of the LET-10125 stack). Upgrades `@earendil-works/pi-ai` 0.80.6 → **0.81.1** (latest) — split into its own PR deliberately, since the last pi-ai bump rode silently inside a feature PR (#3294) and froze us on `/compat` for months.

0.81 is a second architecture wave, and this PR adopts it rather than shimming it:

### Refresh/persistence model
- Dynamic catalogs move to `fetchModels(context)` with **store-backed persistence**; `LocalPiModelsRuntime` owns a `ModelsStore` and drives `refreshModels` per managed provider (one collection-wide `refreshAll()` per `/model` listing), preserving per-provider error semantics and last-known retention. Built-in providers stay on their own cadence.
- Upstream now **merges static baseline + dynamic overlay by id**: local endpoint providers publish an empty baseline (uninstalled engine models must disappear; the `initialModels` carry-over option is deleted as a stale-baseline trap), and mod static registrations become a baseline the `listModels` overlay extends.

### OAuth: registry deleted upstream, provider-owned now
- pi-ai removed the standalone OAuth registry; OAuth lives on `Provider.auth.oauth` (`login(AuthInteraction)` / `refresh` / `toAuth`). New `pi-oauth.ts` is the bridge: builtin providers expose their `OAuthAuth` directly, mod `PiProviderOAuthConfig` adapts onto it (legacy extension callback types are upstream-preserved), token refresh in the local auth store goes through the provider's `refresh`/`toAuth`, and `/connect` drives an `AuthInteraction`.
- Per-credential base URLs/headers (GitHub Copilot) now flow from `toAuth()` instead of the removed `modifyModels` — connection auth stays per-request stream options, never baked into published Models.

### Catalog sync
- Pi TUI default-model mirror synced to coding-agent 0.81.1 (anthropic → claude-opus-4-8, openai → gpt-5.5, xai → grok-4.5, zai → glm-5.1; ant-ling/nvidia/zai-coding-cn/qwen-token-plan gain defaults; the defaultless review set is now empty). `radius` is a `KnownProvider` without a builtin factory and stays unmapped.
- `builtinCatalogModels()` tolerates providers absent from the generated catalog; test expectations updated for upstream catalog drift (gpt-5.6 context 272k, zai default handle, upstream OAuth display names).

### Verified upstream gaps (why two residual items stay)
Checked against the 0.81.1 tarball: `env-api-keys` is still exported **only** via `/compat` (our single allowlisted import), there is still no default-model runtime API, and the library ships **no** llama.cpp/Ollama/LM Studio providers (Pi's llama.cpp provider lives in its coding-agent app) — so our local-endpoint factories remain necessary at latest. These stay as upstream asks.

## Tests
`bun run check` 12/12. 247 tests across the affected suites (backend, providers, connect flows, modify-local) pass. New `test-utils/pi-refresh-context.ts` drives `refreshModels(context)` directly in provider unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)