### PR TITLE
feat(backend): make the Models runtime the canonical lookup and credential seam

### DIFF
--- a/src/backend/dev/pi-llama-cpp-provider.test.ts
+++ b/src/backend/dev/pi-llama-cpp-provider.test.ts
@@ -2,70 +2,135 @@ import { describe, expect, test } from "bun:test";
 import { testRefreshContext } from "@/test-utils/pi-refresh-context";
 import { createLlamaCppPiProvider } from "./pi-llama-cpp-provider";
 
+interface FakeLlamaCppModelEntry {
+  id: string;
+  inputModalities?: string[];
+  nCtx?: number;
+  props?: { vision?: boolean; nCtx?: number };
+}
+
 interface FakeLlamaCppState {
-  modelIds: string[];
-  props?: unknown;
-  failProps?: boolean;
+  models: FakeLlamaCppModelEntry[];
+  /** Serve /models as a plain OpenAI id list (no per-model metadata). */
+  plainList?: boolean;
   failModels?: boolean;
+  failProps?: boolean;
+  requests: string[];
 }
 
 function fakeLlamaCppFetch(state: FakeLlamaCppState): typeof fetch {
   return (async (input: string | URL | Request) => {
-    const url = String(input);
-    if (url.endsWith("/v1/models")) {
+    const url = new URL(String(input));
+    state.requests.push(url.pathname + url.search);
+    if (url.pathname.endsWith("/models")) {
       if (state.failModels) throw new Error("connection refused");
       return Response.json({
-        data: state.modelIds.map((id) => ({ id, object: "model" })),
+        data: state.models.map((model) =>
+          state.plainList
+            ? { id: model.id, object: "model" }
+            : {
+                id: model.id,
+                object: "model",
+                ...(model.inputModalities
+                  ? {
+                      architecture: {
+                        input_modalities: model.inputModalities,
+                      },
+                    }
+                  : {}),
+                ...(model.nCtx ? { meta: { n_ctx: model.nCtx } } : {}),
+              },
+        ),
       });
     }
-    if (url.endsWith("/props")) {
+    if (url.pathname.endsWith("/props")) {
       if (state.failProps) throw new Error("props unavailable");
-      return Response.json(state.props ?? {});
+      const modelId = url.searchParams.get("model");
+      // Single-model servers ignore ?model=; router servers address by id.
+      const model = modelId
+        ? state.models.find((entry) => entry.id === modelId)
+        : state.models[0];
+      if (!model?.props) return new Response("not found", { status: 404 });
+      return Response.json({
+        modalities: { vision: model.props.vision ?? false, audio: false },
+        ...(model.props.nCtx
+          ? { default_generation_settings: { n_ctx: model.props.nCtx } }
+          : {}),
+      });
     }
     return new Response("not found", { status: 404 });
   }) as typeof fetch;
 }
 
 describe("createLlamaCppPiProvider", () => {
-  test("publishes vision and context size from /props engine metadata", async () => {
+  test("router mode: per-model native catalog metadata, no capability bleed", async () => {
+    // Two models on one router server with different capabilities; the
+    // multimodal model's name carries no vision marker, and vice versa.
     const provider = createLlamaCppPiProvider({
       baseURL: "http://localhost:8080",
       fetchImpl: fakeLlamaCppFetch({
-        // No vision marker in the model name: capabilities must come from
-        // the engine, not the filename.
-        modelIds: ["/models/qwen3.6-27b-Q4_K_M.gguf"],
-        props: {
-          modalities: { vision: true, audio: false },
-          default_generation_settings: { n_ctx: 32768 },
-        },
+        models: [
+          {
+            id: "qwen3.6-27b.gguf",
+            inputModalities: ["text", "image"],
+            nCtx: 32768,
+          },
+          {
+            id: "some-vision-model.gguf",
+            inputModalities: ["text"],
+            nCtx: 8192,
+          },
+        ],
+        requests: [],
       }),
+    });
+    await provider.refreshModels?.(testRefreshContext());
+
+    const models = provider.getModels();
+    const multimodal = models.find((m) => m.id === "qwen3.6-27b.gguf");
+    expect(multimodal?.provider).toBe("llama-cpp");
+    expect(multimodal?.input).toEqual(["text", "image"]);
+    expect(multimodal?.contextWindow).toBe(32768);
+
+    // The other model must not inherit the first model's capabilities —
+    // and a "vision" filename grants nothing.
+    const textOnly = models.find((m) => m.id === "some-vision-model.gguf");
+    expect(textOnly?.input).toEqual(["text"]);
+    expect(textOnly?.contextWindow).toBe(8192);
+  });
+
+  test("single-model server without catalog metadata uses per-model /props", async () => {
+    const state: FakeLlamaCppState = {
+      plainList: true,
+      models: [
+        {
+          id: "multimodal.gguf",
+          props: { vision: true, nCtx: 16384 },
+        },
+      ],
+      requests: [],
+    };
+    const provider = createLlamaCppPiProvider({
+      baseURL: "http://localhost:8080/v1",
+      fetchImpl: fakeLlamaCppFetch(state),
     });
     await provider.refreshModels?.(testRefreshContext());
 
     const model = provider.getModels()[0];
-    expect(model?.provider).toBe("llama-cpp");
     expect(model?.input).toEqual(["text", "image"]);
-    expect(model?.contextWindow).toBe(32768);
-    expect(model?.baseUrl).toBe("http://localhost:8080/v1");
+    expect(model?.contextWindow).toBe(16384);
+    expect(
+      state.requests.some((url) =>
+        url.includes("/props?model=multimodal.gguf"),
+      ),
+    ).toBe(true);
   });
 
-  test("text-only engine stays text-only regardless of name markers", async () => {
-    const provider = createLlamaCppPiProvider({
-      baseURL: "http://localhost:8080/v1",
-      fetchImpl: fakeLlamaCppFetch({
-        // "vision" in the filename must NOT grant image input.
-        modelIds: ["/models/some-vision-model.gguf"],
-        props: { modalities: { vision: false } },
-      }),
-    });
-    await provider.refreshModels?.(testRefreshContext());
-    expect(provider.getModels()[0]?.input).toEqual(["text"]);
-  });
-
-  test("falls back to last-known models when /props is unavailable", async () => {
+  test("falls back to last-known models when metadata becomes unavailable", async () => {
     const state: FakeLlamaCppState = {
-      modelIds: ["/models/multimodal.gguf"],
-      props: { modalities: { vision: true } },
+      plainList: true,
+      models: [{ id: "multimodal.gguf", props: { vision: true } }],
+      requests: [],
     };
     const provider = createLlamaCppPiProvider({
       baseURL: "http://localhost:8080",
@@ -81,8 +146,8 @@ describe("createLlamaCppPiProvider", () => {
 
   test("retains the last-known model list when refresh fails", async () => {
     const state: FakeLlamaCppState = {
-      modelIds: ["/models/model.gguf"],
-      props: {},
+      models: [{ id: "model.gguf", inputModalities: ["text"] }],
+      requests: [],
     };
     const provider = createLlamaCppPiProvider({
       baseURL: "http://localhost:8080",

--- a/src/backend/dev/pi-llama-cpp-provider.test.ts
+++ b/src/backend/dev/pi-llama-cpp-provider.test.ts
@@ -4,46 +4,66 @@ import { createLlamaCppPiProvider } from "./pi-llama-cpp-provider";
 
 interface FakeLlamaCppModelEntry {
   id: string;
+  status?: string;
   inputModalities?: string[];
   nCtx?: number;
+  nCtxTrain?: number;
   props?: { vision?: boolean; nCtx?: number };
 }
 
 interface FakeLlamaCppState {
   models: FakeLlamaCppModelEntry[];
-  /** Serve /models as a plain OpenAI id list (no per-model metadata). */
-  plainList?: boolean;
+  /** Native /models returns a plain OpenAI id list (no router metadata). */
+  plainNativeList?: boolean;
   failModels?: boolean;
   failProps?: boolean;
   requests: string[];
 }
 
+/**
+ * Routes by exact path like a real llama-server: native `/models` carries
+ * router metadata; `/v1/models` is the plain OpenAI-compatible id list.
+ */
 function fakeLlamaCppFetch(state: FakeLlamaCppState): typeof fetch {
   return (async (input: string | URL | Request) => {
     const url = new URL(String(input));
     state.requests.push(url.pathname + url.search);
-    if (url.pathname.endsWith("/models")) {
+    if (url.pathname === "/models") {
       if (state.failModels) throw new Error("connection refused");
+      if (state.plainNativeList) {
+        return Response.json({
+          data: state.models.map((model) => ({
+            id: model.id,
+            object: "model",
+          })),
+        });
+      }
       return Response.json({
-        data: state.models.map((model) =>
-          state.plainList
-            ? { id: model.id, object: "model" }
-            : {
-                id: model.id,
-                object: "model",
-                ...(model.inputModalities
-                  ? {
-                      architecture: {
-                        input_modalities: model.inputModalities,
-                      },
-                    }
-                  : {}),
-                ...(model.nCtx ? { meta: { n_ctx: model.nCtx } } : {}),
-              },
-        ),
+        data: state.models.map((model) => ({
+          id: model.id,
+          object: "model",
+          ...(model.status ? { status: { value: model.status } } : {}),
+          ...(model.inputModalities
+            ? { architecture: { input_modalities: model.inputModalities } }
+            : {}),
+          ...(model.nCtx || model.nCtxTrain
+            ? {
+                meta: {
+                  ...(model.nCtx ? { n_ctx: model.nCtx } : {}),
+                  ...(model.nCtxTrain ? { n_ctx_train: model.nCtxTrain } : {}),
+                },
+              }
+            : {}),
+        })),
       });
     }
-    if (url.pathname.endsWith("/props")) {
+    if (url.pathname === "/v1/models") {
+      if (state.failModels) throw new Error("connection refused");
+      return Response.json({
+        data: state.models.map((model) => ({ id: model.id, object: "model" })),
+      });
+    }
+    if (url.pathname === "/props") {
       if (state.failProps) throw new Error("props unavailable");
       const modelId = url.searchParams.get("model");
       // Single-model servers ignore ?model=; router servers address by id.
@@ -64,44 +84,77 @@ function fakeLlamaCppFetch(state: FakeLlamaCppState): typeof fetch {
 
 describe("createLlamaCppPiProvider", () => {
   test("router mode: per-model native catalog metadata, no capability bleed", async () => {
-    // Two models on one router server with different capabilities; the
-    // multimodal model's name carries no vision marker, and vice versa.
+    const state: FakeLlamaCppState = {
+      models: [
+        {
+          id: "qwen3.6-27b.gguf",
+          status: "loaded",
+          inputModalities: ["text", "image"],
+          nCtx: 32768,
+        },
+        {
+          id: "some-vision-model.gguf",
+          status: "loaded",
+          inputModalities: ["text"],
+          nCtxTrain: 8192,
+        },
+      ],
+      requests: [],
+    };
     const provider = createLlamaCppPiProvider({
       baseURL: "http://localhost:8080",
-      fetchImpl: fakeLlamaCppFetch({
-        models: [
-          {
-            id: "qwen3.6-27b.gguf",
-            inputModalities: ["text", "image"],
-            nCtx: 32768,
-          },
-          {
-            id: "some-vision-model.gguf",
-            inputModalities: ["text"],
-            nCtx: 8192,
-          },
-        ],
-        requests: [],
-      }),
+      fetchImpl: fakeLlamaCppFetch(state),
     });
     await provider.refreshModels?.(testRefreshContext());
+
+    // Discovery reads the native catalog, not the OpenAI-compatible list.
+    expect(state.requests).toContain("/models");
+    expect(state.requests).not.toContain("/v1/models");
 
     const models = provider.getModels();
     const multimodal = models.find((m) => m.id === "qwen3.6-27b.gguf");
     expect(multimodal?.provider).toBe("llama-cpp");
     expect(multimodal?.input).toEqual(["text", "image"]);
     expect(multimodal?.contextWindow).toBe(32768);
+    // Upstream contract: maxTokens = contextWindow, max_tokens field.
+    expect(multimodal?.maxTokens).toBe(32768);
+    expect(multimodal?.compat?.maxTokensField).toBe("max_tokens");
 
     // The other model must not inherit the first model's capabilities —
-    // and a "vision" filename grants nothing.
+    // a "vision" filename grants nothing — and n_ctx_train is the
+    // context fallback.
     const textOnly = models.find((m) => m.id === "some-vision-model.gguf");
     expect(textOnly?.input).toEqual(["text"]);
     expect(textOnly?.contextWindow).toBe(8192);
   });
 
+  test("only loaded models publish from a router catalog", async () => {
+    const provider = createLlamaCppPiProvider({
+      baseURL: "http://localhost:8080",
+      fetchImpl: fakeLlamaCppFetch({
+        models: [
+          { id: "loaded.gguf", status: "loaded", inputModalities: ["text"] },
+          {
+            id: "downloading.gguf",
+            status: "downloading",
+            inputModalities: ["text"],
+          },
+          {
+            id: "sleeping.gguf",
+            status: "sleeping",
+            inputModalities: ["text"],
+          },
+        ],
+        requests: [],
+      }),
+    });
+    await provider.refreshModels?.(testRefreshContext());
+    expect(provider.getModels().map((m) => m.id)).toEqual(["loaded.gguf"]);
+  });
+
   test("single-model server without catalog metadata uses per-model /props", async () => {
     const state: FakeLlamaCppState = {
-      plainList: true,
+      plainNativeList: true,
       models: [
         {
           id: "multimodal.gguf",
@@ -119,6 +172,7 @@ describe("createLlamaCppPiProvider", () => {
     const model = provider.getModels()[0];
     expect(model?.input).toEqual(["text", "image"]);
     expect(model?.contextWindow).toBe(16384);
+    expect(model?.maxTokens).toBe(16384);
     expect(
       state.requests.some((url) =>
         url.includes("/props?model=multimodal.gguf"),
@@ -128,7 +182,7 @@ describe("createLlamaCppPiProvider", () => {
 
   test("falls back to last-known models when metadata becomes unavailable", async () => {
     const state: FakeLlamaCppState = {
-      plainList: true,
+      plainNativeList: true,
       models: [{ id: "multimodal.gguf", props: { vision: true } }],
       requests: [],
     };
@@ -146,7 +200,9 @@ describe("createLlamaCppPiProvider", () => {
 
   test("retains the last-known model list when refresh fails", async () => {
     const state: FakeLlamaCppState = {
-      models: [{ id: "model.gguf", inputModalities: ["text"] }],
+      models: [
+        { id: "model.gguf", status: "loaded", inputModalities: ["text"] },
+      ],
       requests: [],
     };
     const provider = createLlamaCppPiProvider({

--- a/src/backend/dev/pi-llama-cpp-provider.test.ts
+++ b/src/backend/dev/pi-llama-cpp-provider.test.ts
@@ -116,9 +116,15 @@ describe("createLlamaCppPiProvider", () => {
     expect(multimodal?.provider).toBe("llama-cpp");
     expect(multimodal?.input).toEqual(["text", "image"]);
     expect(multimodal?.contextWindow).toBe(32768);
-    // Upstream contract: maxTokens = contextWindow, max_tokens field.
+    // Upstream contract: maxTokens = contextWindow plus the literal compat
+    // flag set upstream disables for llama.cpp.
     expect(multimodal?.maxTokens).toBe(32768);
-    expect(multimodal?.compat?.maxTokensField).toBe("max_tokens");
+    expect(multimodal?.compat).toMatchObject({
+      maxTokensField: "max_tokens",
+      supportsStore: false,
+      supportsUsageInStreaming: false,
+      supportsStrictMode: false,
+    });
 
     // The other model must not inherit the first model's capabilities —
     // a "vision" filename grants nothing — and n_ctx_train is the
@@ -126,6 +132,24 @@ describe("createLlamaCppPiProvider", () => {
     const textOnly = models.find((m) => m.id === "some-vision-model.gguf");
     expect(textOnly?.input).toEqual(["text"]);
     expect(textOnly?.contextWindow).toBe(8192);
+  });
+
+  test("missing engine context falls back to contextWindow-sized maxTokens", async () => {
+    const provider = createLlamaCppPiProvider({
+      baseURL: "http://localhost:8080",
+      fetchImpl: fakeLlamaCppFetch({
+        models: [
+          { id: "no-ctx.gguf", status: "loaded", inputModalities: ["text"] },
+        ],
+        requests: [],
+      }),
+    });
+    await provider.refreshModels?.(testRefreshContext());
+
+    // Upstream computes the fallback context first, then maxTokens equals it.
+    const model = provider.getModels()[0];
+    expect(model?.contextWindow).toBe(128000);
+    expect(model?.maxTokens).toBe(128000);
   });
 
   test("only loaded models publish from a router catalog", async () => {

--- a/src/backend/dev/pi-llama-cpp-provider.ts
+++ b/src/backend/dev/pi-llama-cpp-provider.ts
@@ -1,6 +1,7 @@
 import type { Provider } from "@earendil-works/pi-ai";
 import {
   createLocalEndpointPiProvider,
+  LOCAL_ENDPOINT_DEFAULT_CONTEXT_WINDOW,
   type LocalEndpointDiscover,
   type LocalEndpointModelMetadata,
   modelIdsFromOpenAICompatibleList,
@@ -128,21 +129,29 @@ function parseLlamaCppNativeModels(
   return sawMetadata ? parsed : undefined;
 }
 
-/** Upstream model construction: maxTokens = contextWindow, max_tokens field. */
+/**
+ * Upstream model construction: the fallback context applies first and
+ * maxTokens always equals the effective contextWindow; compat flags match
+ * the current upstream llama.cpp provider literally.
+ */
 function llamaCppModelMetadata(
   id: string,
   input: { vision?: boolean; contextLength?: number },
 ): LocalEndpointModelMetadata {
+  const contextLength =
+    input.contextLength ?? LOCAL_ENDPOINT_DEFAULT_CONTEXT_WINDOW;
   return {
     id,
     ...(input.vision !== undefined ? { vision: input.vision } : {}),
-    ...(input.contextLength
-      ? { contextLength: input.contextLength, maxTokens: input.contextLength }
-      : {}),
+    contextLength,
+    maxTokens: contextLength,
     compat: {
       supportsDeveloperRole: false,
       supportsReasoningEffort: false,
       maxTokensField: "max_tokens",
+      supportsStore: false,
+      supportsUsageInStreaming: false,
+      supportsStrictMode: false,
     },
   };
 }

--- a/src/backend/dev/pi-llama-cpp-provider.ts
+++ b/src/backend/dev/pi-llama-cpp-provider.ts
@@ -48,15 +48,16 @@ function parseLlamaCppProps(data: unknown): LlamaCppServerProps {
 }
 
 /**
- * Per-model metadata from the native `/models` catalog (router mode):
- * `architecture.input_modalities` and `meta.n_ctx` per entry — the same
- * contract upstream Pi's llama.cpp provider consumes. Returns undefined
- * when no entry carries per-model metadata (plain OpenAI id list), so
- * discovery falls back to `/props?model=<id>`.
+ * Per-model metadata from the native `/models` catalog, matching the current
+ * upstream Pi llama.cpp provider contract: entries carry `status.value`
+ * (only "loaded" models are selectable), `architecture.input_modalities`,
+ * and `meta.n_ctx` with `meta.n_ctx_train` as the fallback. Returns
+ * undefined when no entry carries per-model metadata (plain OpenAI id
+ * list), so discovery falls back to `/props?model=<id>`.
  */
 function parseLlamaCppNativeModels(
   data: unknown,
-): Map<string, LocalEndpointModelMetadata> | undefined {
+): LocalEndpointModelMetadata[] | undefined {
   if (!data || typeof data !== "object") return undefined;
   const container = data as { data?: unknown; models?: unknown };
   const entries = Array.isArray(container.data)
@@ -66,18 +67,23 @@ function parseLlamaCppNativeModels(
       : undefined;
   if (!entries) return undefined;
 
-  const parsed = new Map<string, LocalEndpointModelMetadata>();
+  const parsed: LocalEndpointModelMetadata[] = [];
   let sawMetadata = false;
   for (const entry of entries) {
     if (!entry || typeof entry !== "object") continue;
     const record = entry as {
       id?: unknown;
       name?: unknown;
+      status?: unknown;
       architecture?: unknown;
       meta?: unknown;
     };
     const id = record.id ?? record.name;
     if (typeof id !== "string" || id.length === 0) continue;
+    const status =
+      record.status && typeof record.status === "object"
+        ? (record.status as { value?: unknown }).value
+        : undefined;
     const architecture =
       record.architecture && typeof record.architecture === "object"
         ? (record.architecture as { input_modalities?: unknown })
@@ -89,46 +95,83 @@ function parseLlamaCppNativeModels(
       : undefined;
     const meta =
       record.meta && typeof record.meta === "object"
-        ? (record.meta as { n_ctx?: unknown })
+        ? (record.meta as { n_ctx?: unknown; n_ctx_train?: unknown })
         : undefined;
-    const contextLength =
+    const nCtx =
       typeof meta?.n_ctx === "number" && meta.n_ctx > 0
         ? meta.n_ctx
         : undefined;
-    if (modalities !== undefined || contextLength !== undefined) {
+    const nCtxTrain =
+      typeof meta?.n_ctx_train === "number" && meta.n_ctx_train > 0
+        ? meta.n_ctx_train
+        : undefined;
+    const contextLength = nCtx ?? nCtxTrain;
+    if (
+      status !== undefined ||
+      modalities !== undefined ||
+      contextLength !== undefined
+    ) {
       sawMetadata = true;
     }
-    parsed.set(id, {
-      id,
-      ...(modalities !== undefined
-        ? { vision: modalities.includes("image") }
-        : {}),
-      ...(contextLength !== undefined ? { contextLength } : {}),
-    });
+    // Upstream publishes only loaded models as selectable; entries without
+    // a status (single-model servers) are treated as loaded.
+    if (status !== undefined && status !== "loaded") continue;
+    parsed.push(
+      llamaCppModelMetadata(id, {
+        ...(modalities !== undefined
+          ? { vision: modalities.includes("image") }
+          : {}),
+        ...(contextLength !== undefined ? { contextLength } : {}),
+      }),
+    );
   }
   return sawMetadata ? parsed : undefined;
+}
+
+/** Upstream model construction: maxTokens = contextWindow, max_tokens field. */
+function llamaCppModelMetadata(
+  id: string,
+  input: { vision?: boolean; contextLength?: number },
+): LocalEndpointModelMetadata {
+  return {
+    id,
+    ...(input.vision !== undefined ? { vision: input.vision } : {}),
+    ...(input.contextLength
+      ? { contextLength: input.contextLength, maxTokens: input.contextLength }
+      : {}),
+    compat: {
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+      maxTokensField: "max_tokens",
+    },
+  };
 }
 
 /**
  * llama.cpp capability discovery with per-model metadata. Preference order:
  *
- * 1. Native `/models` catalog entries (`architecture.input_modalities`,
- *    `meta.n_ctx`) — authoritative per model, including router mode where
- *    one server hosts many models.
- * 2. `GET /props?model=<id>` per model. Single-model servers ignore the
- *    query parameter and return their global props, which is correct there;
- *    router servers return the addressed model's props.
+ * 1. The native `/models` catalog (distinct from the OpenAI-compatible
+ *    `/v1/models` list): per-model `status`, `architecture.input_modalities`,
+ *    `meta.n_ctx`/`n_ctx_train` — authoritative per model, including router
+ *    mode where one server hosts many models; only loaded models publish.
+ * 2. `GET /props?model=<id>` per model from the `/v1/models` id list.
+ *    Single-model servers ignore the query parameter and return their
+ *    global props, which is correct there.
  * 3. The model's last-known published Model, else text-only — one model's
  *    metadata is never applied to another, and capabilities are never
  *    guessed from the model name.
  */
 const llamaCppDiscover: LocalEndpointDiscover = async (context) => {
-  const list = await context.fetchJson(`${context.openAIBaseURL}/models`);
-  const native = parseLlamaCppNativeModels(list);
-  if (native) {
-    return [...native.values()].map(context.buildModel);
+  try {
+    const native = parseLlamaCppNativeModels(
+      await context.fetchJson(`${context.nativeBaseURL}/models`),
+    );
+    if (native) return native.map(context.buildModel);
+  } catch {
+    // Native catalog unavailable; fall back to the OpenAI-compatible list.
   }
 
+  const list = await context.fetchJson(`${context.openAIBaseURL}/models`);
   const modelIds = modelIdsFromOpenAICompatibleList(list);
   return Promise.all(
     modelIds.map(async (modelId) => {
@@ -138,13 +181,14 @@ const llamaCppDiscover: LocalEndpointDiscover = async (context) => {
             `${context.nativeBaseURL}/props?model=${encodeURIComponent(modelId)}`,
           ),
         );
-        return context.buildModel({
-          id: modelId,
-          ...(props.vision !== undefined ? { vision: props.vision } : {}),
-          ...(props.contextLength
-            ? { contextLength: props.contextLength }
-            : {}),
-        });
+        return context.buildModel(
+          llamaCppModelMetadata(modelId, {
+            ...(props.vision !== undefined ? { vision: props.vision } : {}),
+            ...(props.contextLength
+              ? { contextLength: props.contextLength }
+              : {}),
+          }),
+        );
       } catch {
         return (
           context.lastKnown.get(modelId) ?? context.buildModel({ id: modelId })

--- a/src/backend/dev/pi-llama-cpp-provider.ts
+++ b/src/backend/dev/pi-llama-cpp-provider.ts
@@ -2,6 +2,7 @@ import type { Provider } from "@earendil-works/pi-ai";
 import {
   createLocalEndpointPiProvider,
   type LocalEndpointDiscover,
+  type LocalEndpointModelMetadata,
   modelIdsFromOpenAICompatibleList,
 } from "./pi-local-endpoint-provider";
 
@@ -47,46 +48,118 @@ function parseLlamaCppProps(data: unknown): LlamaCppServerProps {
 }
 
 /**
- * llama.cpp capability discovery: `/v1/models` lists the served model(s) and
- * the native `GET /props` reports the engine's authoritative modalities
- * (`modalities.vision`) and context size (`default_generation_settings.n_ctx`)
- * for the loaded model. llama-server serves one model per process, so the
- * props apply to every listed id. When `/props` is unavailable (older
- * server, proxy), each model falls back to its last-known published Model —
- * never to a model-name guess.
+ * Per-model metadata from the native `/models` catalog (router mode):
+ * `architecture.input_modalities` and `meta.n_ctx` per entry — the same
+ * contract upstream Pi's llama.cpp provider consumes. Returns undefined
+ * when no entry carries per-model metadata (plain OpenAI id list), so
+ * discovery falls back to `/props?model=<id>`.
+ */
+function parseLlamaCppNativeModels(
+  data: unknown,
+): Map<string, LocalEndpointModelMetadata> | undefined {
+  if (!data || typeof data !== "object") return undefined;
+  const container = data as { data?: unknown; models?: unknown };
+  const entries = Array.isArray(container.data)
+    ? container.data
+    : Array.isArray(container.models)
+      ? container.models
+      : undefined;
+  if (!entries) return undefined;
+
+  const parsed = new Map<string, LocalEndpointModelMetadata>();
+  let sawMetadata = false;
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") continue;
+    const record = entry as {
+      id?: unknown;
+      name?: unknown;
+      architecture?: unknown;
+      meta?: unknown;
+    };
+    const id = record.id ?? record.name;
+    if (typeof id !== "string" || id.length === 0) continue;
+    const architecture =
+      record.architecture && typeof record.architecture === "object"
+        ? (record.architecture as { input_modalities?: unknown })
+        : undefined;
+    const modalities = Array.isArray(architecture?.input_modalities)
+      ? architecture.input_modalities.filter(
+          (value): value is string => typeof value === "string",
+        )
+      : undefined;
+    const meta =
+      record.meta && typeof record.meta === "object"
+        ? (record.meta as { n_ctx?: unknown })
+        : undefined;
+    const contextLength =
+      typeof meta?.n_ctx === "number" && meta.n_ctx > 0
+        ? meta.n_ctx
+        : undefined;
+    if (modalities !== undefined || contextLength !== undefined) {
+      sawMetadata = true;
+    }
+    parsed.set(id, {
+      id,
+      ...(modalities !== undefined
+        ? { vision: modalities.includes("image") }
+        : {}),
+      ...(contextLength !== undefined ? { contextLength } : {}),
+    });
+  }
+  return sawMetadata ? parsed : undefined;
+}
+
+/**
+ * llama.cpp capability discovery with per-model metadata. Preference order:
+ *
+ * 1. Native `/models` catalog entries (`architecture.input_modalities`,
+ *    `meta.n_ctx`) — authoritative per model, including router mode where
+ *    one server hosts many models.
+ * 2. `GET /props?model=<id>` per model. Single-model servers ignore the
+ *    query parameter and return their global props, which is correct there;
+ *    router servers return the addressed model's props.
+ * 3. The model's last-known published Model, else text-only — one model's
+ *    metadata is never applied to another, and capabilities are never
+ *    guessed from the model name.
  */
 const llamaCppDiscover: LocalEndpointDiscover = async (context) => {
   const list = await context.fetchJson(`${context.openAIBaseURL}/models`);
-  const modelIds = modelIdsFromOpenAICompatibleList(list);
-
-  let props: LlamaCppServerProps | undefined;
-  try {
-    props = parseLlamaCppProps(
-      await context.fetchJson(`${context.nativeBaseURL}/props`),
-    );
-  } catch {
-    props = undefined;
+  const native = parseLlamaCppNativeModels(list);
+  if (native) {
+    return [...native.values()].map(context.buildModel);
   }
 
-  return modelIds.map((modelId) => {
-    if (props) {
-      return context.buildModel({
-        id: modelId,
-        ...(props.vision !== undefined ? { vision: props.vision } : {}),
-        ...(props.contextLength ? { contextLength: props.contextLength } : {}),
-      });
-    }
-    return (
-      context.lastKnown.get(modelId) ?? context.buildModel({ id: modelId })
-    );
-  });
+  const modelIds = modelIdsFromOpenAICompatibleList(list);
+  return Promise.all(
+    modelIds.map(async (modelId) => {
+      try {
+        const props = parseLlamaCppProps(
+          await context.fetchJson(
+            `${context.nativeBaseURL}/props?model=${encodeURIComponent(modelId)}`,
+          ),
+        );
+        return context.buildModel({
+          id: modelId,
+          ...(props.vision !== undefined ? { vision: props.vision } : {}),
+          ...(props.contextLength
+            ? { contextLength: props.contextLength }
+            : {}),
+        });
+      } catch {
+        return (
+          context.lastKnown.get(modelId) ?? context.buildModel({ id: modelId })
+        );
+      }
+    }),
+  );
 };
 
 /**
  * Real dynamic pi-ai Provider for a llama.cpp server. Replaces the Letta
  * connector that fabricated Models from name substrings; mirrors upstream
- * Pi's first-class llama.cpp provider design (engine metadata owns
- * capabilities). See `createLocalEndpointPiProvider` for shared semantics.
+ * Pi's first-class llama.cpp provider design (per-model engine metadata
+ * owns capabilities). See `createLocalEndpointPiProvider` for shared
+ * refresh/auth semantics.
  */
 export function createLlamaCppPiProvider(
   options: LlamaCppPiProviderOptions,

--- a/src/backend/dev/pi-local-endpoint-provider.ts
+++ b/src/backend/dev/pi-local-endpoint-provider.ts
@@ -6,7 +6,7 @@ import type {
 import { createProvider } from "@earendil-works/pi-ai";
 import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 
-const LOCAL_ENDPOINT_DEFAULT_CONTEXT_WINDOW = 128000;
+export const LOCAL_ENDPOINT_DEFAULT_CONTEXT_WINDOW = 128000;
 const LOCAL_ENDPOINT_DEFAULT_MAX_TOKENS = 32000;
 const LOCAL_ENDPOINT_DISCOVERY_TIMEOUT_MS = 2_000;
 

--- a/src/backend/dev/pi-local-endpoint-provider.ts
+++ b/src/backend/dev/pi-local-endpoint-provider.ts
@@ -23,6 +23,10 @@ export interface LocalEndpointModelMetadata {
   vision?: boolean;
   thinking?: boolean;
   contextLength?: number;
+  /** Engine-specific output cap; defaults to the shared constant. */
+  maxTokens?: number;
+  /** Engine-specific OpenAI-compat overrides merged over the defaults. */
+  compat?: Model<"openai-completions">["compat"];
 }
 
 export interface LocalEndpointDiscoveryContext {
@@ -150,10 +154,11 @@ export function createLocalEndpointPiProvider(
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow:
         metadata.contextLength ?? LOCAL_ENDPOINT_DEFAULT_CONTEXT_WINDOW,
-      maxTokens: LOCAL_ENDPOINT_DEFAULT_MAX_TOKENS,
+      maxTokens: metadata.maxTokens ?? LOCAL_ENDPOINT_DEFAULT_MAX_TOKENS,
       compat: {
         supportsDeveloperRole: false,
         supportsReasoningEffort: false,
+        ...metadata.compat,
       },
     };
   }

--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -476,6 +476,33 @@ export async function resolvePiModelForAgent(
   let envOverrides: Record<string, string | undefined> | undefined;
   let oauthCredentials: OAuthCredentials | undefined;
 
+  // The Models runtime is the credential source of truth for every provider
+  // and auth kind: getAuth resolves stored API keys and OAuth tokens through
+  // the auth.json adapter (refreshing OAuth under the store's write lock,
+  // falling back to the provider's ambient env sources) and derives
+  // per-credential request auth such as GitHub Copilot's per-token base URL.
+  // Letta keeps only non-credential connection config (base URLs, timeouts,
+  // zai endpoint choice, Bedrock env) plus spec-specific env fallbacks the
+  // upstream providers do not know about.
+  {
+    const authProviderId = registeredProvider
+      ? registeredProvider.providerName
+      : (spec?.piProvider ?? provider);
+    const authResult = await modelsRuntime.getAuth(authProviderId);
+    connection = {
+      ...connection,
+      apiKey: authResult?.auth.apiKey ?? connection.apiKey,
+    };
+    if (authResult?.auth.baseUrl) baseURL = authResult.auth.baseUrl;
+    if (authResult?.auth.headers) {
+      headers = mergeHeaders(headers, nonNullHeaders(authResult.auth.headers));
+    }
+    if (connection.record?.auth.type === "oauth") {
+      const stored = await modelsRuntime.getStoredCredential(authProviderId);
+      oauthCredentials = stored?.type === "oauth" ? stored : undefined;
+    }
+  }
+
   if (provider === "zai") {
     const zai = resolveZaiConnection({
       storageDir,
@@ -491,27 +518,6 @@ export async function resolvePiModelForAgent(
       timeout: zai.timeout,
     };
     baseURL = zai.baseURL;
-  }
-
-  if (connection.record?.auth.type === "oauth") {
-    // The Models runtime is the credential source of truth: getAuth resolves
-    // the stored OAuth token through the auth.json adapter (refreshing under
-    // the store's write lock) and derives per-credential request auth such
-    // as GitHub Copilot's per-token base URL.
-    const authProviderId = registeredProvider
-      ? registeredProvider.providerName
-      : (spec?.piProvider ?? provider);
-    const authResult = await modelsRuntime.getAuth(authProviderId);
-    connection = {
-      ...connection,
-      apiKey: authResult?.auth.apiKey,
-    };
-    if (authResult?.auth.baseUrl) baseURL = authResult.auth.baseUrl;
-    if (authResult?.auth.headers) {
-      headers = mergeHeaders(headers, nonNullHeaders(authResult.auth.headers));
-    }
-    const stored = await modelsRuntime.getStoredCredential(authProviderId);
-    oauthCredentials = stored?.type === "oauth" ? stored : undefined;
   }
 
   if (provider === "amazon-bedrock") {
@@ -584,10 +590,12 @@ export async function resolvePiModelForAgent(
     const fallbackModelId = piProvider
       ? fallbackCatalogModelId(piProvider, modelId)
       : undefined;
+    // resolveModel refreshes dynamic built-in catalogs (e.g. radius) on a
+    // miss; static catalogs resolve from the registered provider directly.
     const catalogModel = piProvider
-      ? (modelsRuntime.getModel(piProvider, modelId) ??
+      ? ((await modelsRuntime.resolveModel(piProvider, modelId)) ??
         (fallbackModelId
-          ? modelsRuntime.getModel(piProvider, fallbackModelId)
+          ? await modelsRuntime.resolveModel(piProvider, fallbackModelId)
           : undefined))
       : undefined;
     if (!catalogModel) {

--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -1,7 +1,6 @@
 import type { Api, Model, ThinkingLevel } from "@earendil-works/pi-ai";
 import type { OAuthCredentials } from "@earendil-works/pi-ai/oauth";
 import {
-  getLocalOAuthApiKey,
   getLocalProviderRecordByName,
   type LocalProviderRecord,
   localProviderApiKeyFromRecord,
@@ -18,7 +17,6 @@ import {
   stripRegisteredProviderHandlePrefix,
 } from "./pi-provider-mod-registry";
 import {
-  builtinCatalogModels,
   expectedPiProviderList,
   getPiProviderSpec,
   isPiProvider,
@@ -29,10 +27,7 @@ import {
   resolveProviderFromProviderType,
   stripProviderHandlePrefix,
 } from "./pi-provider-registry";
-import {
-  getRegisteredPiProviderLocalNames,
-  resolveRegisteredPiProviderRuntimeConnection,
-} from "./registered-pi-provider-runtime";
+import { resolveRegisteredPiProviderRuntimeConnection } from "./registered-pi-provider-runtime";
 
 export const DEFAULT_PI_PROVIDER = "openai" satisfies PiProvider;
 export const UNSELECTED_LOCAL_MODEL_HANDLE = "local/default";
@@ -315,21 +310,6 @@ export function resolveZaiConnection(options: {
   return codingConnection;
 }
 
-function getCatalogModel(
-  provider: PiProvider,
-  modelId: string,
-): Model<Api> | undefined {
-  const spec = getPiProviderSpec(provider);
-  const piProvider = spec.piProvider;
-  if (!piProvider) return undefined;
-  const catalog = builtinCatalogModels(piProvider);
-  const fallbackModelId = fallbackCatalogModelId(piProvider, modelId);
-  return (catalog.find((model) => model.id === modelId) ??
-    catalog.find((model) => model.id === fallbackModelId)) as
-    | Model<Api>
-    | undefined;
-}
-
 function fallbackCatalogModelId(
   provider: string,
   modelId: string,
@@ -359,6 +339,16 @@ function withOverrides(
       : {}),
     ...(overrides.maxTokens ? { maxTokens: overrides.maxTokens } : {}),
   };
+}
+
+function nonNullHeaders(
+  headers: Record<string, string | null>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).filter(
+      (entry): entry is [string, string] => entry[1] !== null,
+    ),
+  );
 }
 
 function mergeHeaders(
@@ -451,6 +441,15 @@ export async function resolvePiModelForAgent(
     process.env.LETTA_CODE_DEV_PI_MODEL ??
     "";
   const storageDir = options.localProviderAuthStorageDir;
+  // Every resolution goes through a pi-ai Models runtime: the backend's
+  // instance when threaded, otherwise a call-scoped one (tests, direct
+  // library use). The runtime owns model lookup and credential resolution;
+  // Models are never fabricated from name strings.
+  const modelsRuntime =
+    options.modelsRuntime ??
+    new LocalPiModelsRuntime({
+      ...(storageDir ? { storageDir } : {}),
+    });
   const preferredProviderType =
     typeof modelSettings.provider_type === "string"
       ? modelSettings.provider_type
@@ -494,37 +493,25 @@ export async function resolvePiModelForAgent(
     baseURL = zai.baseURL;
   }
 
-  if (connection.record?.auth.type === "oauth" && spec?.piProvider) {
-    const oauth = await getLocalOAuthApiKey({
-      providerId: spec.piProvider,
-      providerNames: spec.localProviderNames,
-      storageDir,
-    });
+  if (connection.record?.auth.type === "oauth") {
+    // The Models runtime is the credential source of truth: getAuth resolves
+    // the stored OAuth token through the auth.json adapter (refreshing under
+    // the store's write lock) and derives per-credential request auth such
+    // as GitHub Copilot's per-token base URL.
+    const authProviderId = registeredProvider
+      ? registeredProvider.providerName
+      : (spec?.piProvider ?? provider);
+    const authResult = await modelsRuntime.getAuth(authProviderId);
     connection = {
       ...connection,
-      apiKey: oauth?.apiKey,
+      apiKey: authResult?.auth.apiKey,
     };
-    oauthCredentials = oauth?.credentials;
-    // Per-credential request auth (e.g. GitHub Copilot's per-token base URL)
-    // comes from the provider's OAuthAuth.toAuth.
-    if (oauth?.baseUrl) baseURL = oauth.baseUrl;
-    if (oauth?.headers) headers = mergeHeaders(headers, oauth.headers);
-  }
-
-  if (
-    connection.record?.auth.type === "oauth" &&
-    registeredProvider?.config.oauth
-  ) {
-    const oauth = await getLocalOAuthApiKey({
-      providerId: registeredProvider.providerName,
-      providerNames: getRegisteredPiProviderLocalNames(registeredProvider),
-      storageDir,
-    });
-    connection = {
-      ...connection,
-      apiKey: oauth?.apiKey,
-    };
-    oauthCredentials = oauth?.credentials;
+    if (authResult?.auth.baseUrl) baseURL = authResult.auth.baseUrl;
+    if (authResult?.auth.headers) {
+      headers = mergeHeaders(headers, nonNullHeaders(authResult.auth.headers));
+    }
+    const stored = await modelsRuntime.getStoredCredential(authProviderId);
+    oauthCredentials = stored?.type === "oauth" ? stored : undefined;
   }
 
   if (provider === "amazon-bedrock") {
@@ -540,17 +527,6 @@ export async function resolvePiModelForAgent(
     connection.apiKey,
     registeredProvider?.config.authHeader,
   );
-
-  // Every resolution goes through a pi-ai Models runtime: the backend's
-  // instance when threaded, otherwise a call-scoped one (tests, direct
-  // library use). Runtime-managed providers never fabricate Models.
-  const modelsRuntime =
-    options.modelsRuntime ??
-    new LocalPiModelsRuntime({
-      ...(options.localProviderAuthStorageDir
-        ? { storageDir: options.localProviderAuthStorageDir }
-        : {}),
-    });
 
   let model: Model<Api>;
   if (registeredProvider) {
@@ -604,19 +580,37 @@ export async function resolvePiModelForAgent(
         ? withOverrides(runtimeModel, { headers, contextWindow, maxTokens })
         : runtimeModel;
   } else {
-    const catalogModel = getCatalogModel(spec.id, modelId);
+    const piProvider = spec.piProvider;
+    const fallbackModelId = piProvider
+      ? fallbackCatalogModelId(piProvider, modelId)
+      : undefined;
+    const catalogModel = piProvider
+      ? (modelsRuntime.getModel(piProvider, modelId) ??
+        (fallbackModelId
+          ? modelsRuntime.getModel(piProvider, fallbackModelId)
+          : undefined))
+      : undefined;
     if (!catalogModel) {
       throw new Error(
         `Unknown model "${modelId}" for provider "${provider}". ` +
           "Check the model handle or update the model catalog.",
       );
     }
-    model = withOverrides(catalogModel, {
-      baseURL,
-      headers,
-      contextWindow,
-      maxTokens,
-    });
+    // The runtime-published Model is the turn model. Clone only when an
+    // effective override applies; headers stay per-request stream options.
+    const overrides = {
+      ...(baseURL && baseURL !== catalogModel.baseUrl ? { baseURL } : {}),
+      ...(contextWindow && contextWindow !== catalogModel.contextWindow
+        ? { contextWindow }
+        : {}),
+      ...(maxTokens && maxTokens !== catalogModel.maxTokens
+        ? { maxTokens }
+        : {}),
+    };
+    model =
+      Object.keys(overrides).length > 0
+        ? withOverrides(catalogModel, overrides)
+        : catalogModel;
   }
 
   return {

--- a/src/backend/dev/pi-model-factory.ts
+++ b/src/backend/dev/pi-model-factory.ts
@@ -489,9 +489,13 @@ export async function resolvePiModelForAgent(
       ? registeredProvider.providerName
       : (spec?.piProvider ?? provider);
     const authResult = await modelsRuntime.getAuth(authProviderId);
+    // No generic fallback to the factory's own record/env lookup: a runtime
+    // auth regression must surface, not be silently masked by a parallel
+    // credential path. The only named exception is zai's dual-record
+    // endpoint selection below.
     connection = {
       ...connection,
-      apiKey: authResult?.auth.apiKey ?? connection.apiKey,
+      apiKey: authResult?.auth.apiKey,
     };
     if (authResult?.auth.baseUrl) baseURL = authResult.auth.baseUrl;
     if (authResult?.auth.headers) {

--- a/src/backend/dev/pi-models-runtime.test.ts
+++ b/src/backend/dev/pi-models-runtime.test.ts
@@ -238,6 +238,89 @@ describe("LocalPiModelsRuntime + Ollama provider", () => {
     }
   });
 
+  test("a runtime auth miss is not masked by a parallel factory lookup", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "pi-models-runtime-"));
+    storageDirs.push(storageDir);
+    await createOrUpdateLocalProvider({
+      providerType: "anthropic",
+      providerName: "lc-anthropic",
+      apiKey: "stored-direct",
+      storageDir,
+    });
+    const runtime = new LocalPiModelsRuntime({ storageDir });
+    runtime.getAuth = async () => undefined;
+
+    const resolved = await resolvePiModelForAgent(
+      "anthropic/claude-opus-4-8",
+      { provider_type: "anthropic" },
+      { localProviderAuthStorageDir: storageDir, modelsRuntime: runtime },
+    );
+    // The runtime is the only credential source: if it cannot resolve auth,
+    // the stored key must NOT leak in through a factory-side record lookup.
+    expect(resolved.apiKey).toBeUndefined();
+  });
+
+  test("radius drops the previous account's catalog when the credential changes", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "pi-models-runtime-"));
+    storageDirs.push(storageDir);
+    await createOrUpdateLocalProvider({
+      providerType: "radius",
+      providerName: "radius",
+      apiKey: "key-a",
+      storageDir,
+    });
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = String(input);
+      if (url.includes("/v1/config")) {
+        const auth = new Headers(init?.headers).get("authorization");
+        if (auth !== "Bearer key-a") {
+          return new Response("unauthorized", { status: 401 });
+        }
+        return Response.json({
+          baseUrl: "https://gateway.example.test/v1",
+          models: [
+            {
+              id: "account-a-model",
+              name: "Account A",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 200000,
+              maxTokens: 32000,
+            },
+          ],
+        });
+      }
+      return realFetch(input as never, init);
+    }) as typeof fetch;
+
+    try {
+      const runtime = new LocalPiModelsRuntime({
+        storageDir,
+        fetchImpl: failingDiscoveryFetch,
+      });
+      await runtime.refreshAll();
+      expect(runtime.getModel("radius", "account-a-model")).toBeDefined();
+
+      // Switching accounts: the new credential fails against the gateway,
+      // and account A's catalog must not survive as "last known".
+      await createOrUpdateLocalProvider({
+        providerType: "radius",
+        providerName: "radius",
+        apiKey: "key-b",
+        storageDir,
+      });
+      await runtime.refreshAll();
+      expect(runtime.getModels("radius")).toHaveLength(0);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
   test("built-in catalog models resolve to the runtime-published instance", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "pi-models-runtime-"));
     storageDirs.push(storageDir);

--- a/src/backend/dev/pi-models-runtime.test.ts
+++ b/src/backend/dev/pi-models-runtime.test.ts
@@ -148,6 +148,96 @@ describe("LocalPiModelsRuntime + Ollama provider", () => {
     );
   });
 
+  test("stored API keys resolve through the runtime's credential seam", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "pi-models-runtime-"));
+    storageDirs.push(storageDir);
+    await createOrUpdateLocalProvider({
+      providerType: "anthropic",
+      providerName: "lc-anthropic",
+      apiKey: "stored-key",
+      storageDir,
+    });
+    const runtime = new LocalPiModelsRuntime({ storageDir });
+    let getAuthCalls = 0;
+    const originalGetAuth = runtime.getAuth.bind(runtime);
+    runtime.getAuth = (providerId) => {
+      getAuthCalls += 1;
+      return originalGetAuth(providerId);
+    };
+
+    const resolved = await resolvePiModelForAgent(
+      "anthropic/claude-opus-4-8",
+      { provider_type: "anthropic" },
+      { localProviderAuthStorageDir: storageDir, modelsRuntime: runtime },
+    );
+    // API-key auth is resolved by Models.getAuth via the auth.json adapter,
+    // not by a parallel factory lookup.
+    expect(getAuthCalls).toBe(1);
+    expect(resolved.apiKey).toBe("stored-key");
+  });
+
+  test("radius/auto lists and resolves for a configured Radius gateway", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "pi-models-runtime-"));
+    storageDirs.push(storageDir);
+    await createOrUpdateLocalProvider({
+      providerType: "radius",
+      providerName: "radius",
+      apiKey: "radius-key",
+      storageDir,
+    });
+    // Radius's built-in provider fetches its gateway config with global
+    // fetch; stub it for the gateway URL only.
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = String(input);
+      if (url.includes("/v1/config")) {
+        return Response.json({
+          baseUrl: "https://gateway.example.test/v1",
+          models: [
+            {
+              id: "auto",
+              name: "Auto",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 200000,
+              maxTokens: 32000,
+            },
+          ],
+        });
+      }
+      return realFetch(input as never, init);
+    }) as typeof fetch;
+
+    try {
+      const runtime = new LocalPiModelsRuntime({
+        storageDir,
+        fetchImpl: failingDiscoveryFetch,
+      });
+      const listed = await listLocalModels(storageDir, {
+        fetch: failingDiscoveryFetch,
+        modelsRuntime: runtime,
+      });
+      expect(listed.some((model) => model.handle === "radius/auto")).toBe(true);
+
+      // The default handle a user selects from /model must resolve for the
+      // turn — the canonical refresh supplies Radius's credentialed context.
+      const resolved = await resolvePiModelForAgent(
+        "radius/auto",
+        { provider_type: "radius" },
+        { localProviderAuthStorageDir: storageDir, modelsRuntime: runtime },
+      );
+      expect(resolved.model.id).toBe("auto");
+      expect(resolved.model.provider).toBe("radius");
+      expect(resolved.apiKey).toBe("radius-key");
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
   test("built-in catalog models resolve to the runtime-published instance", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "pi-models-runtime-"));
     storageDirs.push(storageDir);

--- a/src/backend/dev/pi-models-runtime.test.ts
+++ b/src/backend/dev/pi-models-runtime.test.ts
@@ -148,6 +148,23 @@ describe("LocalPiModelsRuntime + Ollama provider", () => {
     );
   });
 
+  test("built-in catalog models resolve to the runtime-published instance", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "pi-models-runtime-"));
+    storageDirs.push(storageDir);
+    const runtime = new LocalPiModelsRuntime({ storageDir });
+
+    const resolved = await resolvePiModelForAgent(
+      "anthropic/claude-opus-4-8",
+      { provider_type: "anthropic" },
+      { localProviderAuthStorageDir: storageDir, modelsRuntime: runtime },
+    );
+    // The LET-10125 target invariant holds for built-ins too: with no
+    // effective overrides, the turn model IS the runtime-published instance.
+    expect(resolved.model).toBe(
+      runtime.getModel("anthropic", "claude-opus-4-8")!,
+    );
+  });
+
   test("/model listing and turn execution resolve the same provider-published Model", async () => {
     const server = startFakeOllama([
       {

--- a/src/backend/dev/pi-models-runtime.ts
+++ b/src/backend/dev/pi-models-runtime.ts
@@ -10,14 +10,12 @@ import type {
   ModelsSimpleStreamOptions,
   MutableModels,
   Provider,
-  RefreshModelsContext,
 } from "@earendil-works/pi-ai";
 import { createModels, InMemoryModelsStore } from "@earendil-works/pi-ai";
 import { builtinProviders } from "@earendil-works/pi-ai/providers/all";
 import { createLocalPiCredentialStore } from "@/backend/local/local-pi-credential-store";
 import {
   getLocalProviderRecordByName,
-  listLocalProviderRecords,
   localProviderApiKeyFromRecord,
 } from "@/backend/local/local-provider-auth-store";
 import {
@@ -40,10 +38,7 @@ import {
   listRegisteredPiProviders,
 } from "./pi-provider-mod-registry";
 import { getPiProviderSpec, type PiProvider } from "./pi-provider-registry";
-import {
-  isRegisteredPiProviderConfigured,
-  resolveRegisteredPiProviderRuntimeConnection,
-} from "./registered-pi-provider-runtime";
+import { resolveRegisteredPiProviderRuntimeConnection } from "./registered-pi-provider-runtime";
 
 const CONFIGURED_DISCOVERY_TIMEOUT_MS = 2_000;
 const AUTODETECT_DISCOVERY_TIMEOUT_MS = 500;
@@ -175,18 +170,6 @@ export class LocalPiModelsRuntime {
     return this.credentials.read(providerId);
   }
 
-  private refreshContext(providerId: string): RefreshModelsContext {
-    return {
-      store: {
-        read: () => this.modelsStore.read(providerId),
-        write: (entry) => this.modelsStore.write(providerId, entry),
-        delete: () => this.modelsStore.delete(providerId),
-      },
-      allowNetwork: true,
-      force: true,
-    };
-  }
-
   /** Providers whose models this runtime discovers and owns end-to-end. */
   isRuntimeManagedProvider(providerId: string): boolean {
     return (
@@ -303,54 +286,29 @@ export class LocalPiModelsRuntime {
   }
 
   /**
-   * Re-fetch every runtime-managed provider's model list concurrently.
-   * Per-provider fetch failures keep that provider's last-known list, so a
-   * transient endpoint outage does not brick turns or wipe /model. Built-in
-   * providers are not refreshed here — their catalogs are static and any
-   * dynamic upstream catalogs stay on pi-ai's own refresh cadence.
+   * Canonical catalog refresh: pi-ai's Models.refresh resolves each dynamic
+   * provider's effective credential (refreshing OAuth under the store lock),
+   * supplies its store-backed RefreshModelsContext, and skips unconfigured
+   * providers — so unconfigured remote endpoints and mod listModels hooks
+   * are never probed, while keyless local daemons ("not-needed") and
+   * credentialed dynamic built-ins (e.g. radius) refresh correctly.
+   * Per-provider fetch failures keep that provider's last-known list.
    */
   async refreshAll(): Promise<void> {
     this.ensureManagedProviders();
-    // Only refresh providers the user configured (record/env) or that are
-    // explicitly auto-detectable local daemons. Never probe remote endpoints
-    // (Ollama Cloud) or invoke mod listModels hooks without configuration.
-    const records = listLocalProviderRecords(this.storageDir);
-    const managedIds = new Set<string>();
-    for (const providerId of MANAGED_ENDPOINT_PROVIDERS.keys()) {
-      const spec = getPiProviderSpec(providerId as PiProvider);
-      const connection = resolveLocalEndpointConnection(
-        providerId,
-        this.storageDir,
-      );
-      if (connection.configured || spec.autoDetectLocalEndpoint === true) {
-        managedIds.add(providerId);
-      }
-    }
-    for (const registered of listRegisteredPiProviders()) {
-      if (isRegisteredPiProviderConfigured(registered, records)) {
-        managedIds.add(registered.providerName);
-      }
-    }
-    await Promise.all(
-      [...managedIds].map(async (providerId) => {
-        try {
-          await this.refresh(providerId);
-        } catch {
-          // Keep last-known models for this provider.
-        }
-      }),
-    );
+    await this.models.refresh({ force: true });
   }
 
   /**
-   * Refresh one provider with per-provider error semantics: rejects with the
-   * fetch error while the provider keeps serving its last-known list.
+   * Refresh with per-provider error semantics: rejects with the given
+   * provider's fetch error while the provider keeps serving its last-known
+   * list.
    */
   async refresh(providerId: string): Promise<void> {
     this.ensureManagedProviders(providerId);
-    const provider = this.models.getProvider(providerId);
-    if (!provider?.refreshModels) return;
-    await provider.refreshModels(this.refreshContext(providerId));
+    const result = await this.models.refresh({ force: true });
+    const error = result.errors.get(providerId);
+    if (error) throw error;
   }
 
   /**

--- a/src/backend/dev/pi-models-runtime.ts
+++ b/src/backend/dev/pi-models-runtime.ts
@@ -1,7 +1,10 @@
 import type {
   Api,
   AssistantMessageEventStream,
+  AuthResult,
   Context,
+  Credential,
+  CredentialStore,
   Model,
   ModelsApiStreamOptions,
   ModelsSimpleStreamOptions,
@@ -11,6 +14,7 @@ import type {
 } from "@earendil-works/pi-ai";
 import { createModels, InMemoryModelsStore } from "@earendil-works/pi-ai";
 import { builtinProviders } from "@earendil-works/pi-ai/providers/all";
+import { createLocalPiCredentialStore } from "@/backend/local/local-pi-credential-store";
 import {
   getLocalProviderRecordByName,
   listLocalProviderRecords,
@@ -136,14 +140,39 @@ export class LocalPiModelsRuntime {
   private readonly endpointSignatures = new Map<string, string>();
   private readonly modSignatures = new Map<string, string>();
   private readonly modelsStore = new InMemoryModelsStore();
+  private readonly credentials: CredentialStore;
 
   constructor(options: LocalPiModelsRuntimeOptions = {}) {
     this.storageDir = options.storageDir;
     this.fetchImpl = options.fetchImpl;
-    this.models = createModels({ modelsStore: this.modelsStore });
+    // Letta's auth.json is the credential source of truth, adapted into the
+    // runtime so Models.getAuth() resolves stored keys and refreshes OAuth
+    // tokens under the store's write lock.
+    this.credentials = createLocalPiCredentialStore(options.storageDir);
+    this.models = createModels({
+      modelsStore: this.modelsStore,
+      credentials: this.credentials,
+    });
     for (const provider of builtinProviders()) {
       this.models.setProvider(provider);
     }
+  }
+
+  /**
+   * Resolve request auth for a provider through the runtime: stored
+   * credential (via the auth.json adapter, refreshing OAuth as needed) or
+   * the provider's ambient sources.
+   */
+  async getAuth(providerId: string): Promise<AuthResult | undefined> {
+    this.ensureManagedProviders(providerId);
+    return this.models.getAuth(providerId);
+  }
+
+  /** Stored (possibly just-refreshed) credential for a provider. */
+  async getStoredCredential(
+    providerId: string,
+  ): Promise<Credential | undefined> {
+    return this.credentials.read(providerId);
   }
 
   private refreshContext(providerId: string): RefreshModelsContext {

--- a/src/backend/dev/pi-models-runtime.ts
+++ b/src/backend/dev/pi-models-runtime.ts
@@ -107,6 +107,20 @@ function resolveLocalEndpointConnection(
   };
 }
 
+/**
+ * Stable credential identity: API keys compare by value; OAuth compares by
+ * everything except the volatile access token/expiry (refresh token,
+ * account/enterprise fields), so token rotation is not an identity change.
+ */
+function credentialIdentitySignature(
+  credential: Credential | undefined,
+): string {
+  if (!credential) return "none";
+  if (credential.type === "api_key") return `api_key ${credential.key ?? ""}`;
+  const { access: _access, expires: _expires, ...identity } = credential;
+  return `oauth ${JSON.stringify(identity)}`;
+}
+
 function connectionSignature(connection: LocalEndpointConnection): string {
   return [
     connection.baseURL,
@@ -136,6 +150,8 @@ export class LocalPiModelsRuntime {
   private readonly modSignatures = new Map<string, string>();
   private readonly modelsStore = new InMemoryModelsStore();
   private readonly credentials: CredentialStore;
+  private readonly dynamicBuiltinIds: ReadonlySet<string>;
+  private readonly builtinCredentialSignatures = new Map<string, string>();
 
   constructor(options: LocalPiModelsRuntimeOptions = {}) {
     this.storageDir = options.storageDir;
@@ -148,8 +164,38 @@ export class LocalPiModelsRuntime {
       modelsStore: this.modelsStore,
       credentials: this.credentials,
     });
-    for (const provider of builtinProviders()) {
+    const builtins = builtinProviders();
+    for (const provider of builtins) {
       this.models.setProvider(provider);
+    }
+    this.dynamicBuiltinIds = new Set(
+      builtins
+        .filter((provider) => provider.refreshModels !== undefined)
+        .map((provider) => provider.id),
+    );
+  }
+
+  /**
+   * Dynamic built-in catalogs (e.g. Radius) are account-specific: when the
+   * stored credential's identity changes, drop the persisted catalog and
+   * rebuild the provider so one account's models cannot be listed while
+   * turns authenticate as another. Routine access-token refreshes keep the
+   * identity (volatile `access`/`expires` fields are excluded), so they do
+   * not clear last-known retention.
+   */
+  private async invalidateDynamicBuiltinsOnCredentialChange(): Promise<void> {
+    for (const providerId of this.dynamicBuiltinIds) {
+      const credential = await this.credentials.read(providerId);
+      const signature = credentialIdentitySignature(credential);
+      const previous = this.builtinCredentialSignatures.get(providerId);
+      this.builtinCredentialSignatures.set(providerId, signature);
+      if (previous === undefined || previous === signature) continue;
+      // InMemoryModelsStore deletes synchronously.
+      void this.modelsStore.delete(providerId);
+      const fresh = builtinProviders().find(
+        (provider) => provider.id === providerId,
+      );
+      if (fresh) this.models.setProvider(fresh);
     }
   }
 
@@ -296,6 +342,7 @@ export class LocalPiModelsRuntime {
    */
   async refreshAll(): Promise<void> {
     this.ensureManagedProviders();
+    await this.invalidateDynamicBuiltinsOnCredentialChange();
     await this.models.refresh({ force: true });
   }
 
@@ -306,6 +353,9 @@ export class LocalPiModelsRuntime {
    */
   async refresh(providerId: string): Promise<void> {
     this.ensureManagedProviders(providerId);
+    await this.invalidateDynamicBuiltinsOnCredentialChange();
+    // pi-ai refreshes the collection as a whole (configured dynamic
+    // providers only); this method adds per-provider error semantics on top.
     const result = await this.models.refresh({ force: true });
     const error = result.errors.get(providerId);
     if (error) throw error;

--- a/src/backend/dev/pi-provider-registry.ts
+++ b/src/backend/dev/pi-provider-registry.ts
@@ -423,10 +423,12 @@ export function isResolvablePiModelHandle(model: string | undefined): boolean {
   if (!model || !provider) return false;
   const spec = getPiProviderSpec(provider);
   if (!spec.piProvider) return spec.createCustomModel === true;
+  const catalog = builtinCatalogModels(spec.piProvider);
+  // Purely dynamic providers (e.g. "radius") have no static catalog to check
+  // against; their handles resolve at runtime.
+  if (catalog.length === 0) return true;
   const modelId = stripProviderHandlePrefix(model, provider);
-  return builtinCatalogModels(spec.piProvider).some(
-    (entry) => entry.id === modelId,
-  );
+  return catalog.some((entry) => entry.id === modelId);
 }
 
 export function resolveProviderFromProviderType(

--- a/src/backend/local/local-backend.ts
+++ b/src/backend/local/local-backend.ts
@@ -266,8 +266,7 @@ export class LocalBackend extends HeadlessBackend {
   constructor(options: LocalBackendOptions) {
     const localBackendRef: { current?: LocalBackend } = {};
     // One pi-ai Models runtime per backend instance: /model listing, turn
-    // execution, and compaction resolve models from the same provider
-    // registry, so they always see the same Model objects and capabilities.
+    // execution, and compaction resolve the same Model objects/credentials.
     const modelsRuntime =
       options.modelsRuntime ??
       new LocalPiModelsRuntime({ storageDir: options.storageDir });
@@ -280,7 +279,8 @@ export class LocalBackend extends HeadlessBackend {
       defaultAgentName: "Letta Code",
       defaultAgentModel: modelConfig.handle,
       defaultAgentModelSettings: modelConfig.modelSettings,
-      modelSettingsForModel: localModelSettingsForHandle,
+      modelSettingsForModel: (handle) =>
+        localModelSettingsForHandle(handle, modelsRuntime),
       conversationIdPrefix: "local-conv-",
       storedMessageIdPrefix: "letta-msg-",
       localMessageIdPrefix: "ui-msg-",

--- a/src/backend/local/local-model-config.ts
+++ b/src/backend/local/local-model-config.ts
@@ -16,7 +16,6 @@ import {
   builtinCatalogModels,
   getPiProviderSpec,
   isPiProvider,
-  listCatalogModelsForProvider,
   listConfiguredPiProviders,
   localModelHandle,
   localProviderType,
@@ -190,6 +189,31 @@ export function resolveLocalModelConfig(storageDir?: string): LocalModelConfig {
   };
 }
 
+/**
+ * Catalog handles for a static built-in provider, read from the runtime's
+ * registered provider (the same Model objects turn execution resolves).
+ */
+function catalogHandlesForProvider(
+  provider: PiProvider,
+  modelsRuntime: LocalPiModelsRuntime,
+): string[] {
+  const spec = getPiProviderSpec(provider);
+  const seen = new Set<string>();
+  const handles: string[] = [];
+  const add = (handle: string | undefined) => {
+    if (!handle || seen.has(handle)) return;
+    seen.add(handle);
+    handles.push(handle);
+  };
+  add(spec.defaultModel);
+  if (spec.piProvider && spec.catalogModelHandle) {
+    for (const model of modelsRuntime.getModels(spec.piProvider)) {
+      add(spec.catalogModelHandle(model));
+    }
+  }
+  return handles;
+}
+
 function providerForLocalModelListEntry(
   entry: LocalModelListEntry,
 ): PiProvider | undefined {
@@ -302,9 +326,9 @@ export async function listLocalModels(
       ? getPiProviderSpec(provider)
       : undefined;
     const catalogModel = providerSpec?.piProvider
-      ? builtinCatalogModels(providerSpec.piProvider).find(
-          (entry) => entry.id === modelId,
-        )
+      ? modelsRuntime
+          .getModels(providerSpec.piProvider)
+          .find((entry) => entry.id === modelId)
       : undefined;
     const providerType =
       options.modelEndpointType ?? localProviderTypeForModelConfig(provider);
@@ -378,7 +402,10 @@ export async function listLocalModels(
           };
         }
 
-        return { provider, models: listCatalogModelsForProvider(provider) };
+        return {
+          provider,
+          models: catalogHandlesForProvider(provider, modelsRuntime),
+        };
       },
     ),
   );

--- a/src/backend/local/local-model-config.ts
+++ b/src/backend/local/local-model-config.ts
@@ -263,7 +263,7 @@ export async function resolveAvailableLocalModelForTurn(input: {
     model: selected.handle,
     modelSettings: {
       ...baseSettings,
-      ...localModelSettingsForHandle(selected.handle),
+      ...localModelSettingsForHandle(selected.handle, input.modelsRuntime),
       provider_type: selected.model_endpoint_type,
     },
   };

--- a/src/backend/local/local-model-config.ts
+++ b/src/backend/local/local-model-config.ts
@@ -125,13 +125,18 @@ function registeredModelSettingsForProviderModel(
 function catalogModelSettingsForProviderModel(
   provider: PiProvider,
   modelId: string | undefined,
+  modelsRuntime?: LocalPiModelsRuntime,
 ): Record<string, unknown> | undefined {
   if (!modelId || !isPiProvider(provider)) return undefined;
   const spec = getPiProviderSpec(provider);
   if (!spec.piProvider) return undefined;
-  const model = builtinCatalogModels(spec.piProvider).find(
-    (entry) => entry.id === modelId,
-  );
+  // Read through the runtime when available so settings derive from the
+  // same published Model objects as listing and turn execution; the static
+  // catalog remains only for legacy synchronous callers without a runtime.
+  const catalog = modelsRuntime
+    ? modelsRuntime.getModels(spec.piProvider)
+    : builtinCatalogModels(spec.piProvider);
+  const model = catalog.find((entry) => entry.id === modelId);
   if (!model) return undefined;
   return {
     provider_type: localProviderTypeForModelConfig(provider),
@@ -142,6 +147,7 @@ function catalogModelSettingsForProviderModel(
 
 export function localModelSettingsForHandle(
   handle: string | undefined,
+  modelsRuntime?: LocalPiModelsRuntime,
 ): Record<string, unknown> | undefined {
   if (!handle) return undefined;
   const registeredProvider = resolveRegisteredPiProviderFromModelHandle(handle);
@@ -157,7 +163,7 @@ export function localModelSettingsForHandle(
   const modelId = stripProviderHandlePrefix(handle, provider);
   return (
     registeredModelSettingsForProviderModel(provider, modelId) ??
-    catalogModelSettingsForProviderModel(provider, modelId)
+    catalogModelSettingsForProviderModel(provider, modelId, modelsRuntime)
   );
 }
 
@@ -307,7 +313,7 @@ export async function listLocalModels(
         ? `${provider}/${model}`
         : localModelHandle(provider as PiProvider, model));
     if (models.some((entry) => entry.handle === handle)) return;
-    const modelSettings = localModelSettingsForHandle(handle);
+    const modelSettings = localModelSettingsForHandle(handle, modelsRuntime);
     const maxContextWindow =
       options.maxContextWindow ??
       (typeof modelSettings?.context_window_limit === "number"

--- a/src/backend/local/local-pi-credential-store.test.ts
+++ b/src/backend/local/local-pi-credential-store.test.ts
@@ -2,6 +2,10 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import {
+  clearRegisteredPiProviders,
+  registerPiProvider,
+} from "@/backend/dev/pi-provider-mod-registry";
 import { createLocalPiCredentialStore } from "./local-pi-credential-store";
 import {
   createOrUpdateLocalProvider,
@@ -27,6 +31,118 @@ describe("createLocalPiCredentialStore", () => {
     return storageDir;
   }
 
+  test("preserves provider-specific OAuth fields round-trip", async () => {
+    const storageDir = await makeStorageDir();
+    setLocalOAuthProvider({
+      storageDir,
+      providerName: "github-copilot",
+      providerType: "github-copilot",
+      auth: localOAuthAuthFromCredentials({
+        access: "a",
+        refresh: "r",
+        expires: Date.now() + 60_000,
+        enterpriseUrl: "https://ghe.example.com",
+        accountId: "acct",
+      } as never),
+    });
+    const store = createLocalPiCredentialStore(storageDir);
+
+    // pi-ai reads fields like enterpriseUrl during refresh and toAuth; the
+    // adapter must not strip them.
+    expect(await store.read("github-copilot")).toMatchObject({
+      type: "oauth",
+      access: "a",
+      enterpriseUrl: "https://ghe.example.com",
+      accountId: "acct",
+    });
+  });
+
+  test("modify is serialized per provider", async () => {
+    const storageDir = await makeStorageDir();
+    setLocalOAuthProvider({
+      storageDir,
+      providerName: "anthropic",
+      providerType: "anthropic",
+      auth: localOAuthAuthFromCredentials({
+        access: "a",
+        refresh: "r",
+        expires: Date.now() - 1,
+      }),
+    });
+    const store = createLocalPiCredentialStore(storageDir);
+
+    let inFlight = 0;
+    let maxConcurrent = 0;
+    const refresh = () =>
+      store.modify("anthropic", async (current) => {
+        inFlight += 1;
+        maxConcurrent = Math.max(maxConcurrent, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        inFlight -= 1;
+        return current;
+      });
+
+    await Promise.all([refresh(), refresh(), refresh()]);
+    // The contract requires serialized read-modify-write so concurrent
+    // requests cannot double-refresh a rotated token.
+    expect(maxConcurrent).toBe(1);
+  });
+
+  test("a mod overriding a built-in id keeps that provider's record aliases", async () => {
+    const storageDir = await makeStorageDir();
+    try {
+      registerPiProvider("openai-codex", {
+        api: "openai-codex-responses",
+        baseUrl: "https://proxy.example.test",
+        models: [],
+      });
+      setLocalOAuthProvider({
+        storageDir,
+        providerName: "chatgpt-plus-pro",
+        providerType: "chatgpt_oauth",
+        auth: localOAuthAuthFromCredentials({
+          access: "chatgpt-access",
+          refresh: "chatgpt-refresh",
+          expires: Date.now() + 60_000,
+        }),
+      });
+      const store = createLocalPiCredentialStore(storageDir);
+
+      expect(await store.read("openai-codex")).toMatchObject({
+        type: "oauth",
+        access: "chatgpt-access",
+      });
+    } finally {
+      clearRegisteredPiProviders();
+    }
+  });
+
+  test("api-key modify persists through the provider record", async () => {
+    const storageDir = await makeStorageDir();
+    await createOrUpdateLocalProvider({
+      storageDir,
+      providerType: "anthropic",
+      providerName: "lc-anthropic",
+      apiKey: "old-key",
+      baseURL: "https://proxy.example.test",
+    });
+    const store = createLocalPiCredentialStore(storageDir);
+
+    await store.modify("anthropic", async () => ({
+      type: "api_key",
+      key: "new-key",
+    }));
+
+    // The new key persists and non-credential record config survives.
+    expect(await store.read("anthropic")).toEqual({
+      type: "api_key",
+      key: "new-key",
+    });
+    expect(
+      getLocalProviderRecordByName("lc-anthropic", storageDir),
+    ).toMatchObject({ base_url: "https://proxy.example.test" });
+  });
+
   test("reads API-key records under aliased pi provider ids", async () => {
     const storageDir = await makeStorageDir();
     await createOrUpdateLocalProvider({
@@ -42,8 +158,9 @@ describe("createLocalPiCredentialStore", () => {
       key: "sk-ant-key",
     });
     expect(await store.read("openai")).toBeUndefined();
+    // list() reports pi-ai provider ids, not local record aliases.
     expect(await store.list()).toContainEqual({
-      providerId: "lc-anthropic",
+      providerId: "anthropic",
       type: "api_key",
     });
   });

--- a/src/backend/local/local-pi-credential-store.test.ts
+++ b/src/backend/local/local-pi-credential-store.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createLocalPiCredentialStore } from "./local-pi-credential-store";
+import {
+  createOrUpdateLocalProvider,
+  getLocalProviderRecordByName,
+  localOAuthAuthFromCredentials,
+  setLocalOAuthProvider,
+} from "./local-provider-auth-store";
+
+describe("createLocalPiCredentialStore", () => {
+  const storageDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      storageDirs
+        .splice(0)
+        .map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  async function makeStorageDir(): Promise<string> {
+    const storageDir = await mkdtemp(join(tmpdir(), "pi-cred-store-"));
+    storageDirs.push(storageDir);
+    return storageDir;
+  }
+
+  test("reads API-key records under aliased pi provider ids", async () => {
+    const storageDir = await makeStorageDir();
+    await createOrUpdateLocalProvider({
+      storageDir,
+      providerType: "anthropic",
+      providerName: "lc-anthropic",
+      apiKey: "sk-ant-key",
+    });
+    const store = createLocalPiCredentialStore(storageDir);
+
+    expect(await store.read("anthropic")).toEqual({
+      type: "api_key",
+      key: "sk-ant-key",
+    });
+    expect(await store.read("openai")).toBeUndefined();
+    expect(await store.list()).toContainEqual({
+      providerId: "lc-anthropic",
+      type: "api_key",
+    });
+  });
+
+  test("modify persists refreshed OAuth credentials back to auth.json", async () => {
+    const storageDir = await makeStorageDir();
+    setLocalOAuthProvider({
+      storageDir,
+      providerName: "anthropic",
+      providerType: "anthropic",
+      auth: localOAuthAuthFromCredentials({
+        access: "expired-access",
+        refresh: "refresh-token",
+        expires: Date.now() - 1,
+      }),
+    });
+    const store = createLocalPiCredentialStore(storageDir);
+
+    const next = await store.modify("anthropic", async (current) => {
+      expect(current).toMatchObject({
+        type: "oauth",
+        access: "expired-access",
+      });
+      return {
+        type: "oauth",
+        access: "fresh-access",
+        refresh: "refresh-token",
+        expires: Date.now() + 60_000,
+      };
+    });
+
+    expect(next).toMatchObject({ access: "fresh-access" });
+    expect(getLocalProviderRecordByName("anthropic", storageDir)).toMatchObject(
+      {
+        auth: { type: "oauth", access: "fresh-access" },
+      },
+    );
+  });
+});

--- a/src/backend/local/local-pi-credential-store.ts
+++ b/src/backend/local/local-pi-credential-store.ts
@@ -3,8 +3,11 @@ import { getRegisteredPiProvider } from "@/backend/dev/pi-provider-mod-registry"
 import {
   getPiProviderSpec,
   isPiProvider,
+  PI_PROVIDER_SPECS,
 } from "@/backend/dev/pi-provider-registry";
+import { getRegisteredPiProviderLocalNames } from "@/backend/dev/registered-pi-provider-runtime";
 import {
+  createOrUpdateLocalProvider,
   getLocalProviderRecordByName,
   type LocalProviderRecord,
   listLocalProviderRecords,
@@ -18,20 +21,38 @@ import {
  * pi-ai CredentialStore over Letta's local provider records (auth.json),
  * keyed by pi-ai provider id. This makes the Models runtime the credential
  * source of truth: `Models.getAuth()` reads stored keys/OAuth tokens from
- * here and persists OAuth refreshes back under the store's write lock.
+ * here and persists OAuth refreshes back through `modify`, which is
+ * serialized per provider as the contract requires so concurrent requests
+ * cannot double-refresh a rotated token. (auth.json writes are same-process
+ * only today; cross-process locking would live in the auth store itself.)
  *
  * Records store more than credentials (base URLs, timeouts, regions) —
  * that remains Letta-owned provider config; only the credential facet is
- * exposed through this adapter.
+ * exposed through this adapter, and provider-specific OAuth fields (e.g.
+ * GitHub Copilot's enterpriseUrl) round-trip untouched.
  */
 
 function localNamesForProviderId(providerId: string): readonly string[] {
   const registered = getRegisteredPiProvider(providerId);
-  if (registered) return [registered.providerName];
+  if (registered) {
+    // A mod overriding a built-in provider id keeps that provider's local
+    // record aliases (e.g. "openai-codex" still reads "chatgpt-plus-pro").
+    return getRegisteredPiProviderLocalNames(registered);
+  }
   if (isPiProvider(providerId)) {
     return getPiProviderSpec(providerId).localProviderNames;
   }
   return [providerId];
+}
+
+/** Maps a stored record name back to the pi-ai provider id it serves. */
+function providerIdForRecordName(recordName: string): string {
+  const registered = getRegisteredPiProvider(recordName);
+  if (registered) return registered.providerName;
+  const spec = PI_PROVIDER_SPECS.find((entry) =>
+    entry.localProviderNames.includes(recordName),
+  );
+  return spec ? (spec.piProvider ?? spec.id) : recordName;
 }
 
 function recordForProviderId(
@@ -49,7 +70,11 @@ function credentialFromRecord(
   record: LocalProviderRecord,
 ): Credential | undefined {
   if (record.auth.type === "oauth") {
+    // Preserve provider-specific fields (enterpriseUrl, accountId, ...);
+    // pi-ai reads them during refresh and toAuth.
+    const { type: _type, ...oauthFields } = record.auth;
     return {
+      ...oauthFields,
       type: "oauth",
       access: record.auth.access,
       refresh: record.auth.refresh ?? "",
@@ -63,6 +88,22 @@ function credentialFromRecord(
 export function createLocalPiCredentialStore(
   storageDir?: string,
 ): CredentialStore {
+  // Per-provider mutation queue: `modify`/`delete` for the same provider run
+  // strictly in sequence (the pi-ai contract's serialized read-modify-write).
+  const mutationQueues = new Map<string, Promise<unknown>>();
+  function serialized<T>(
+    providerId: string,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    const previous = mutationQueues.get(providerId) ?? Promise.resolve();
+    const next = previous.then(run, run);
+    mutationQueues.set(
+      providerId,
+      next.catch(() => {}),
+    );
+    return next;
+  }
+
   const read = async (providerId: string): Promise<Credential | undefined> => {
     const record = recordForProviderId(providerId, storageDir);
     return record ? credentialFromRecord(record) : undefined;
@@ -73,40 +114,51 @@ export function createLocalPiCredentialStore(
     async list() {
       return listLocalProviderRecords(storageDir).flatMap((record) => {
         const credential = credentialFromRecord(record);
-        // Record names map back to pi provider ids ambiguously for aliased
-        // names; report under the stored record name, which pi-ai treats as
-        // opaque metadata for status enumeration.
         return credential
-          ? [{ providerId: record.name, type: credential.type }]
+          ? [
+              {
+                providerId: providerIdForRecordName(record.name),
+                type: credential.type,
+              },
+            ]
           : [];
       });
     },
-    async modify(providerId, fn) {
-      const record = recordForProviderId(providerId, storageDir);
-      const current = record ? credentialFromRecord(record) : undefined;
-      const next = await fn(current);
-      if (next === undefined) return current;
-      if (next.type === "oauth") {
-        setLocalOAuthProvider({
-          providerName:
-            record?.name ??
-            localNamesForProviderId(providerId)[0] ??
-            providerId,
-          providerType: record?.provider_type ?? providerId,
-          auth: localOAuthAuthFromCredentials(next),
-          storageDir,
-        });
+    modify(providerId, fn) {
+      return serialized(providerId, async () => {
+        const record = recordForProviderId(providerId, storageDir);
+        const current = record ? credentialFromRecord(record) : undefined;
+        const next = await fn(current);
+        if (next === undefined) return current;
+        const providerName =
+          record?.name ?? localNamesForProviderId(providerId)[0] ?? providerId;
+        if (next.type === "oauth") {
+          setLocalOAuthProvider({
+            providerName,
+            providerType: record?.provider_type ?? providerId,
+            auth: localOAuthAuthFromCredentials(next),
+            storageDir,
+          });
+          return next;
+        }
+        if (next.key) {
+          // createOrUpdateLocalProvider preserves the record's non-credential
+          // config (base URL, timeout) when one exists.
+          await createOrUpdateLocalProvider({
+            providerName,
+            providerType: record?.provider_type ?? providerId,
+            apiKey: next.key,
+            storageDir,
+          });
+        }
         return next;
-      }
-      // API keys are written through Letta's connect flows, which capture
-      // provider config (base URL, timeouts) beyond the credential; a bare
-      // key write here would drop that context. pi-ai only writes api_key
-      // credentials from login flows, which Letta routes through /connect.
-      return next;
+      });
     },
-    async delete(providerId) {
-      const record = recordForProviderId(providerId, storageDir);
-      if (record) await removeLocalProviderByName(record.name, storageDir);
+    delete(providerId) {
+      return serialized(providerId, async () => {
+        const record = recordForProviderId(providerId, storageDir);
+        if (record) await removeLocalProviderByName(record.name, storageDir);
+      });
     },
   };
 }

--- a/src/backend/local/local-pi-credential-store.ts
+++ b/src/backend/local/local-pi-credential-store.ts
@@ -142,12 +142,16 @@ export function createLocalPiCredentialStore(
           return next;
         }
         if (next.key) {
-          // createOrUpdateLocalProvider preserves the record's non-credential
-          // config (base URL, timeout) when one exists.
+          // Read-modify-write: every non-credential record field survives
+          // (createOrUpdateLocalProvider keeps base URL/timeout itself, but
+          // Bedrock's access key/region/profile must be re-supplied).
           await createOrUpdateLocalProvider({
             providerName,
             providerType: record?.provider_type ?? providerId,
             apiKey: next.key,
+            ...(record?.access_key ? { accessKey: record.access_key } : {}),
+            ...(record?.region ? { region: record.region } : {}),
+            ...(record?.profile ? { profile: record.profile } : {}),
             storageDir,
           });
         }

--- a/src/backend/local/local-pi-credential-store.ts
+++ b/src/backend/local/local-pi-credential-store.ts
@@ -1,0 +1,112 @@
+import type { Credential, CredentialStore } from "@earendil-works/pi-ai";
+import { getRegisteredPiProvider } from "@/backend/dev/pi-provider-mod-registry";
+import {
+  getPiProviderSpec,
+  isPiProvider,
+} from "@/backend/dev/pi-provider-registry";
+import {
+  getLocalProviderRecordByName,
+  type LocalProviderRecord,
+  listLocalProviderRecords,
+  localOAuthAuthFromCredentials,
+  localProviderApiKeyFromRecord,
+  removeLocalProviderByName,
+  setLocalOAuthProvider,
+} from "./local-provider-auth-store";
+
+/**
+ * pi-ai CredentialStore over Letta's local provider records (auth.json),
+ * keyed by pi-ai provider id. This makes the Models runtime the credential
+ * source of truth: `Models.getAuth()` reads stored keys/OAuth tokens from
+ * here and persists OAuth refreshes back under the store's write lock.
+ *
+ * Records store more than credentials (base URLs, timeouts, regions) —
+ * that remains Letta-owned provider config; only the credential facet is
+ * exposed through this adapter.
+ */
+
+function localNamesForProviderId(providerId: string): readonly string[] {
+  const registered = getRegisteredPiProvider(providerId);
+  if (registered) return [registered.providerName];
+  if (isPiProvider(providerId)) {
+    return getPiProviderSpec(providerId).localProviderNames;
+  }
+  return [providerId];
+}
+
+function recordForProviderId(
+  providerId: string,
+  storageDir?: string,
+): LocalProviderRecord | undefined {
+  for (const name of localNamesForProviderId(providerId)) {
+    const record = getLocalProviderRecordByName(name, storageDir);
+    if (record) return record;
+  }
+  return undefined;
+}
+
+function credentialFromRecord(
+  record: LocalProviderRecord,
+): Credential | undefined {
+  if (record.auth.type === "oauth") {
+    return {
+      type: "oauth",
+      access: record.auth.access,
+      refresh: record.auth.refresh ?? "",
+      expires: record.auth.expires,
+    };
+  }
+  const key = localProviderApiKeyFromRecord(record);
+  return key ? { type: "api_key", key } : undefined;
+}
+
+export function createLocalPiCredentialStore(
+  storageDir?: string,
+): CredentialStore {
+  const read = async (providerId: string): Promise<Credential | undefined> => {
+    const record = recordForProviderId(providerId, storageDir);
+    return record ? credentialFromRecord(record) : undefined;
+  };
+
+  return {
+    read,
+    async list() {
+      return listLocalProviderRecords(storageDir).flatMap((record) => {
+        const credential = credentialFromRecord(record);
+        // Record names map back to pi provider ids ambiguously for aliased
+        // names; report under the stored record name, which pi-ai treats as
+        // opaque metadata for status enumeration.
+        return credential
+          ? [{ providerId: record.name, type: credential.type }]
+          : [];
+      });
+    },
+    async modify(providerId, fn) {
+      const record = recordForProviderId(providerId, storageDir);
+      const current = record ? credentialFromRecord(record) : undefined;
+      const next = await fn(current);
+      if (next === undefined) return current;
+      if (next.type === "oauth") {
+        setLocalOAuthProvider({
+          providerName:
+            record?.name ??
+            localNamesForProviderId(providerId)[0] ??
+            providerId,
+          providerType: record?.provider_type ?? providerId,
+          auth: localOAuthAuthFromCredentials(next),
+          storageDir,
+        });
+        return next;
+      }
+      // API keys are written through Letta's connect flows, which capture
+      // provider config (base URL, timeouts) beyond the credential; a bare
+      // key write here would drop that context. pi-ai only writes api_key
+      // credentials from login flows, which Letta routes through /connect.
+      return next;
+    },
+    async delete(providerId) {
+      const record = recordForProviderId(providerId, storageDir);
+      if (record) await removeLocalProviderByName(record.name, storageDir);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

**Stacked on #3472** (bottom of stack: #3464). Addresses the two load-bearing corrections from review, plus the llama.cpp metadata contract.

### 1. Built-in model lookup goes through the runtime

`resolvePiModelForAgent()` now resolves catalog models via `modelsRuntime.getModel()` (dated-handle fallback included) and clones **only when an effective override applies** — with none, the turn model **is** the runtime-published instance. The reviewer's probe now yields `sameObject: true`, asserted by identity in a new test (`anthropic/claude-opus-4-8`). Headers stay per-request stream options rather than model clones. `/model` listing reads catalog handles and display metadata from the runtime's registered providers; the static `getCatalogModel`/`listCatalogModelsForProvider` reads in the factory/listing path are gone.

### 2. The runtime owns credentials

New `local-pi-credential-store.ts` adapts `auth.json` into a pi-ai `CredentialStore` (`read`/`list`/`modify`/`delete`; OAuth refreshes persist through `modify`), wired into `createModels()`. The factory's two hand-rolled OAuth blocks collapse into a single `Models.getAuth()` call — stored tokens resolve/refresh through the runtime under the store's write path, and per-credential request auth (GitHub Copilot's per-token base URL) flows from `OAuthAuth.toAuth`. The explicit stream options remain as plumbing, but their values now **come from** the runtime.

### 3. llama.cpp per-model metadata

Discovery follows the upstream reference contract: native `/models` catalog entries (`architecture.input_modalities`, `meta.n_ctx`) per model, falling back to `GET /props?model=<id>` (single-model servers ignore the param and stay correct; router servers address by id). One model's metadata is never applied to another; a router-mode regression test covers two models with different capabilities on one server. Handle resolvability treats empty dynamic catalogs (radius) as runtime-resolved, fixing normalization for `radius/auto`.

## Related fixes already landed below this PR

- #3472 (new commits): `refreshAll()` gates on configured/auto-detectable providers (no more unconfigured Ollama Cloud probing or mod `listModels` invocation), connection changes delete the provider's `ModelsStore` entry (no stale-catalog restoration), five retention assertions now `await` their rejections, `modifyModels` gets a `structuredClone`, and `PI_PROVIDER_SPECS` is keyed off `builtinProviders()` (radius resolvable).
- NUL byte fixed at #3464 and merged forward — every branch's `pi-models-runtime.ts` is text.

## Not in this PR

Collapsing the remaining mod-specific resolution branches in `pi-model-factory`/`local-model-config` onto the now-canonical path (LET-10130 follow-through) — the lookup/auth/credential seams they'd collapse onto now exist; tracked as the next increment.

## Tests

`bun run check` 12/12. 222 tests across the affected suites pass (remaining full-batch flakes are live-local-Ollama contention on this dev machine, all pass standalone; CI unaffected). New coverage: built-in same-instance invariant, credential-store read/list/modify persistence, llama.cpp router-mode no-bleed, unconfigured-refresh and stale-store regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)