### PR TITLE
perf(listener): cut blocking agent fetches and memfs pull from the turn path

### DIFF
--- a/src/agent/memory-filesystem.ts
+++ b/src/agent/memory-filesystem.ts
@@ -443,6 +443,14 @@ export interface ApplyMemfsFlagsResult {
 
 export interface ApplyMemfsFlagsOptions {
   pullOnExistingRepo?: boolean;
+  /**
+   * Run the existing-repo pull without awaiting it. The caller proceeds on
+   * the current checkout while the pull refreshes it in the background —
+   * pullMemory is self-healing (ff-only → rebase → reset-to-remote) and a
+   * failed background pull is retried on the next sync. A missing repo still
+   * clones synchronously regardless of this flag.
+   */
+  backgroundPull?: boolean;
   agentTags?: string[];
   /** Skip the system prompt update (when the agent was created with the correct mode). */
   skipPromptUpdate?: boolean;
@@ -568,8 +576,24 @@ export async function applyMemfsFlags(
     if (!isGitRepo(agentId)) {
       await cloneMemoryRepo(agentId);
     } else if (options?.pullOnExistingRepo) {
-      const result = await pullMemory(agentId);
-      pullSummary = result.summary;
+      if (options.backgroundPull) {
+        void (async () => {
+          try {
+            await pullMemory(agentId);
+          } catch (error) {
+            const { debugWarn } = await import("@/utils/debug");
+            debugWarn(
+              "memfs-git",
+              `Background memory pull failed for agent ${agentId}: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            );
+          }
+        })();
+      } else {
+        const result = await pullMemory(agentId);
+        pullSummary = result.summary;
+      }
     }
 
     await seedDefaultPersonalityFiles(

--- a/src/websocket/listener-warmup.test.ts
+++ b/src/websocket/listener-warmup.test.ts
@@ -13,18 +13,34 @@ import type { ListenerTransport } from "@/websocket/listener/transport";
 import {
   __listenerWarmupTestUtils,
   ensureListenerWarmStateForTurn,
-  type ListenerAgentMetadata,
+  getListenerAgentStateForTurn,
+  invalidateListenerAgentWarmState,
+  type ListenerAgentWarmState,
   scheduleListenerWarmupsAfterSync,
+  setListenerAgentWarmState,
 } from "@/websocket/listener/warmup";
+
+function makeWarmState(
+  overrides: Partial<ListenerAgentWarmState> = {},
+): ListenerAgentWarmState {
+  const name = overrides.name ?? "Listener Agent";
+  return {
+    name,
+    description: "Warmup target",
+    lastRunAt: "2026-05-02T06:00:00.000Z",
+    agent: {
+      id: "agent-1",
+      name,
+      tags: ["origin:letta-code"],
+    } as unknown as ListenerAgentWarmState["agent"],
+    ...overrides,
+  };
+}
 
 const memfsWarmupMock = mock(async () => true);
 const secretsWarmupMock = mock(async () => {});
 const fetchAgentMetadataMock = mock(
-  async (): Promise<ListenerAgentMetadata> => ({
-    name: "Listener Agent",
-    description: "Warmup target",
-    lastRunAt: "2026-05-02T06:00:00.000Z",
-  }),
+  async (): Promise<ListenerAgentWarmState> => makeWarmState(),
 );
 
 describe("listener warmup scheduling", () => {
@@ -45,7 +61,7 @@ describe("listener warmup scheduling", () => {
   test("sync warmup joins the first turn without duplicating agent metadata fetches", async () => {
     let resolveMemfs: (() => void) | undefined;
     let resolveSecrets: (() => void) | undefined;
-    let resolveMetadata: ((value: ListenerAgentMetadata) => void) | undefined;
+    let resolveMetadata: ((value: ListenerAgentWarmState) => void) | undefined;
 
     memfsWarmupMock.mockImplementationOnce(
       () =>
@@ -61,14 +77,14 @@ describe("listener warmup scheduling", () => {
     );
     fetchAgentMetadataMock.mockImplementationOnce(
       () =>
-        new Promise<ListenerAgentMetadata>((resolve) => {
+        new Promise<ListenerAgentWarmState>((resolve) => {
           resolveMetadata = resolve;
         }),
     );
     __listenerWarmupTestUtils.setWarmupDepsForTests({
       ensureMemfsSyncedForAgent: memfsWarmupMock,
       ensureSecretsHydratedForAgent: secretsWarmupMock,
-      fetchListenerAgentMetadata: fetchAgentMetadataMock,
+      fetchListenerAgentWarmState: fetchAgentMetadataMock,
     });
 
     const listener = __listenClientTestUtils.createListenerRuntime();
@@ -83,27 +99,107 @@ describe("listener warmup scheduling", () => {
       conversationId: "default",
     });
 
-    expect(memfsWarmupMock).toHaveBeenCalledTimes(2);
+    // Secrets hydration starts immediately; memfs waits for the shared agent
+    // fetch so it can reuse the fetched (tags-included) agent state.
+    expect(memfsWarmupMock).toHaveBeenCalledTimes(0);
     expect(secretsWarmupMock).toHaveBeenCalledTimes(2);
     expect(fetchAgentMetadataMock).toHaveBeenCalledTimes(1);
+
+    const warmState = makeWarmState();
+    resolveMetadata?.(warmState);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(memfsWarmupMock).toHaveBeenCalledTimes(2);
+    expect((memfsWarmupMock.mock.calls[0] as unknown[])?.[2]).toBe(
+      warmState.agent,
+    );
 
     resolveMemfs?.();
     resolveSecrets?.();
-    resolveMetadata?.({
-      name: "Listener Agent",
-      description: "Warmup target",
-      lastRunAt: "2026-05-02T06:00:00.000Z",
-    });
 
-    await expect(turnWarmup).resolves.toEqual({
-      name: "Listener Agent",
-      description: "Warmup target",
-      lastRunAt: "2026-05-02T06:00:00.000Z",
-    });
+    await expect(turnWarmup).resolves.toEqual(warmState);
 
     expect(memfsWarmupMock).toHaveBeenCalledTimes(2);
     expect(secretsWarmupMock).toHaveBeenCalledTimes(2);
     expect(fetchAgentMetadataMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("turn agent state serves the warm cache and refreshes in the background", async () => {
+    fetchAgentMetadataMock.mockImplementation(async () => makeWarmState());
+    __listenerWarmupTestUtils.setWarmupDepsForTests({
+      ensureMemfsSyncedForAgent: memfsWarmupMock,
+      ensureSecretsHydratedForAgent: secretsWarmupMock,
+      fetchListenerAgentWarmState: fetchAgentMetadataMock,
+    });
+    const listener = __listenClientTestUtils.createListenerRuntime();
+
+    await ensureListenerWarmStateForTurn(listener, {
+      agentId: "agent-1",
+      conversationId: "default",
+    });
+    expect(fetchAgentMetadataMock).toHaveBeenCalledTimes(1);
+
+    // Cache hit: the turn gets the cached agent without a blocking fetch, and
+    // one background refresh is scheduled.
+    const refreshed = makeWarmState({ name: "Renamed Agent" });
+    fetchAgentMetadataMock.mockResolvedValueOnce(refreshed);
+    const agent = await getListenerAgentStateForTurn(listener, "agent-1");
+    expect(agent?.name).toBe("Listener Agent");
+
+    // Let the background refresh settle; the next turn sees the fresh state.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fetchAgentMetadataMock).toHaveBeenCalledTimes(2);
+    const nextAgent = await getListenerAgentStateForTurn(listener, "agent-1");
+    expect(nextAgent?.name).toBe("Renamed Agent");
+  });
+
+  test("invalidation forces the next turn to refetch agent state", async () => {
+    fetchAgentMetadataMock.mockImplementation(async () => makeWarmState());
+    __listenerWarmupTestUtils.setWarmupDepsForTests({
+      ensureMemfsSyncedForAgent: memfsWarmupMock,
+      ensureSecretsHydratedForAgent: secretsWarmupMock,
+      fetchListenerAgentWarmState: fetchAgentMetadataMock,
+    });
+    const listener = __listenClientTestUtils.createListenerRuntime();
+
+    await ensureListenerWarmStateForTurn(listener, {
+      agentId: "agent-1",
+      conversationId: "default",
+    });
+    expect(fetchAgentMetadataMock).toHaveBeenCalledTimes(1);
+
+    invalidateListenerAgentWarmState(listener, "agent-1");
+    fetchAgentMetadataMock.mockResolvedValueOnce(
+      makeWarmState({ name: "Post Update Agent" }),
+    );
+    const agent = await getListenerAgentStateForTurn(listener, "agent-1");
+    expect(agent?.name).toBe("Post Update Agent");
+    expect(fetchAgentMetadataMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("setListenerAgentWarmState replaces the cache after local mutations", async () => {
+    fetchAgentMetadataMock.mockImplementation(async () => makeWarmState());
+    __listenerWarmupTestUtils.setWarmupDepsForTests({
+      ensureMemfsSyncedForAgent: memfsWarmupMock,
+      ensureSecretsHydratedForAgent: secretsWarmupMock,
+      fetchListenerAgentWarmState: fetchAgentMetadataMock,
+    });
+    const listener = __listenClientTestUtils.createListenerRuntime();
+
+    const tagged = makeWarmState({ name: "Tagged Agent" }).agent as NonNullable<
+      ListenerAgentWarmState["agent"]
+    >;
+    setListenerAgentWarmState(listener, tagged);
+
+    // ensure... does not schedule a refresh, so the seeded state is stable.
+    const warmState = await ensureListenerWarmStateForTurn(listener, {
+      agentId: "agent-1",
+      conversationId: "default",
+    });
+    expect(warmState?.name).toBe("Tagged Agent");
+    expect(fetchAgentMetadataMock).toHaveBeenCalledTimes(0);
+
+    const agent = await getListenerAgentStateForTurn(listener, "agent-1");
+    expect(agent?.name).toBe("Tagged Agent");
   });
 
   test("advertises scoped mod commands after background warmup", async () => {
@@ -142,14 +238,11 @@ describe("listener warmup scheduling", () => {
     __listenerWarmupTestUtils.setWarmupDepsForTests({
       ensureMemfsSyncedForAgent: async () => true,
       ensureSecretsHydratedForAgent: async () => {},
-      fetchListenerAgentMetadata: async () => ({
-        name: "Warmup Agent",
-        description: null,
-        lastRunAt: null,
-      }),
+      fetchListenerAgentWarmState: async () =>
+        makeWarmState({ name: "Warmup Agent", description: null }),
     });
 
-    let warmup: Promise<ListenerAgentMetadata | null> | undefined;
+    let warmup: Promise<ListenerAgentWarmState | null> | undefined;
     try {
       await replaySyncStateForRuntime(
         listener,

--- a/src/websocket/listener/commands/model-toolset.ts
+++ b/src/websocket/listener/commands/model-toolset.ts
@@ -50,6 +50,7 @@ import type {
   ConversationRuntime,
   ListenerRuntime,
 } from "@/websocket/listener/types";
+import { invalidateListenerAgentWarmState } from "@/websocket/listener/warmup";
 import {
   buildListModelsEntries,
   findAvailableModelForPreset,
@@ -470,6 +471,11 @@ export async function applyModelUpdateForRuntime(params: {
       ).model_settings as Record<string, unknown> | null | undefined) ?? null;
     appliedTo = "conversation";
   }
+
+  // The turn path serves agent state from the warm cache; drop it so the next
+  // turn sees the new model settings (and any memory-tool changes below)
+  // instead of a stale snapshot.
+  invalidateListenerAgentWarmState(listener, agentId);
 
   const toolsetPreference = settingsManager.getToolsetPreference(agentId);
   const previousToolNames = scopedRuntime.currentLoadedTools;

--- a/src/websocket/listener/memfs-sync.ts
+++ b/src/websocket/listener/memfs-sync.ts
@@ -7,13 +7,17 @@
  * correctly — mirroring what the local headless path does during bootstrap.
  */
 
+import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import { debugLog, debugWarn } from "@/utils/debug";
 import type { ListenerRuntime } from "./types";
 
 /**
  * Core sync logic — fetches agent, checks tag, clones/pulls repo.
  */
-async function syncMemfsForAgent(agentId: string): Promise<void> {
+async function syncMemfsForAgent(
+  agentId: string,
+  cachedAgent?: AgentState | null,
+): Promise<void> {
   const { settingsManager } = await import("@/settings-manager");
   if (settingsManager.isMemfsExplicitlyDisabled(agentId)) {
     // Worker-style agent deliberately created without a memfs (e.g. dream
@@ -29,10 +33,13 @@ async function syncMemfsForAgent(agentId: string): Promise<void> {
   // `include: ["agent.tags"]` is required — without it the API can return
   // empty tags for a correctly tagged agent, which previously made the
   // listener skip the memfs clone and run the agent as a blank slate
-  // (the Prod × DeepSeek incident).
-  const agent = await getBackend().retrieveAgent(agentId, {
-    include: ["agent.tags"],
-  });
+  // (the Prod × DeepSeek incident). A caller-provided cachedAgent must come
+  // from a tags-included fetch (the warmup fetch is) for the same reason.
+  const agent =
+    cachedAgent ??
+    (await getBackend().retrieveAgent(agentId, {
+      include: ["agent.tags"],
+    }));
 
   const { GIT_MEMORY_ENABLED_TAG } = await import("@/agent/agent-tags");
   const { applyMemfsFlags, isLettaCloud } = await import(
@@ -64,8 +71,12 @@ async function syncMemfsForAgent(agentId: string): Promise<void> {
 
   debugLog("memfs-sync", `Syncing memfs for agent ${agentId}`);
 
+  // backgroundPull: an existing checkout serves the turn immediately while
+  // the pull refreshes it; only a missing repo blocks (on the clone). This
+  // keeps a slow git pull off the first-turn critical path.
   await applyMemfsFlags(agentId, undefined, {
     pullOnExistingRepo: true,
+    backgroundPull: true,
     agentTags: agent.tags,
     skipPromptUpdate: true,
   });
@@ -89,13 +100,14 @@ async function syncMemfsForAgent(agentId: string): Promise<void> {
 export async function ensureMemfsSyncedForAgent(
   listener: ListenerRuntime,
   agentId: string,
+  cachedAgent?: AgentState | null,
 ): Promise<boolean> {
   const existing = listener.memfsSyncedAgents.get(agentId);
   if (existing) {
     return existing;
   }
 
-  const promise = syncMemfsForAgent(agentId).then(
+  const promise = syncMemfsForAgent(agentId, cachedAgent).then(
     () => true,
     (err) => {
       // Non-fatal — agent can still process messages, just without local memory.

--- a/src/websocket/listener/turn-setup.ts
+++ b/src/websocket/listener/turn-setup.ts
@@ -8,7 +8,6 @@ import {
   setCurrentAgentId,
   setCurrentAgentName,
 } from "@/agent/context";
-import { getBackend } from "@/backend";
 import type { Line } from "@/cli/helpers/accumulator";
 import {
   buildSharedReminderParts,
@@ -42,7 +41,11 @@ import type {
   IncomingMessage,
   StartListenerOptions,
 } from "./types";
-import { ensureListenerWarmStateForTurn } from "./warmup";
+import {
+  ensureListenerWarmStateForTurn,
+  getListenerAgentStateForTurn,
+  setListenerAgentWarmState,
+} from "./warmup";
 
 type PreparedToolContext = Awaited<
   ReturnType<typeof prepareToolExecutionContextForScope>
@@ -132,22 +135,32 @@ export async function prepareListenerTurn(params: {
   if (!isApprovalMessage) {
     try {
       try {
-        cachedAgent = (await getBackend().retrieveAgent(agentId, {
-          include: ["agent.tags"],
-        })) as AgentState;
-        const {
-          ensureLettaCodeOriginTag,
-          getMemoryPromptModeForAgent,
-          scheduleManagedSystemPromptUpdate,
-        } = await import("@/agent/system-prompt-versioning");
-        cachedAgent = await ensureLettaCodeOriginTag(cachedAgent);
-        scheduleManagedSystemPromptUpdate({
-          agent: cachedAgent,
-          memoryMode: getMemoryPromptModeForAgent(cachedAgent.id),
-          onUpdated: (updatedAgent) => {
-            cachedAgent = updatedAgent;
-          },
-        });
+        // Served from the session warm cache (background-refreshed) instead of
+        // a blocking per-turn retrieve; headless reuses its initial agent fetch
+        // for the whole run loop the same way.
+        cachedAgent = await getListenerAgentStateForTurn(
+          runtime.listener,
+          agentId,
+        );
+        if (cachedAgent) {
+          const {
+            ensureLettaCodeOriginTag,
+            getMemoryPromptModeForAgent,
+            scheduleManagedSystemPromptUpdate,
+          } = await import("@/agent/system-prompt-versioning");
+          const taggedAgent = await ensureLettaCodeOriginTag(cachedAgent);
+          if (taggedAgent !== cachedAgent) {
+            setListenerAgentWarmState(runtime.listener, taggedAgent);
+          }
+          cachedAgent = taggedAgent;
+          scheduleManagedSystemPromptUpdate({
+            agent: cachedAgent,
+            memoryMode: getMemoryPromptModeForAgent(cachedAgent.id),
+            onUpdated: (updatedAgent) => {
+              cachedAgent = updatedAgent;
+            },
+          });
+        }
       } catch (error) {
         debugWarn(
           "listen",
@@ -167,6 +180,7 @@ export async function prepareListenerTurn(params: {
           lastRunAt:
             (cachedAgent as { last_run_completion?: string | null })
               .last_run_completion ?? null,
+          agent: cachedAgent,
         };
       }
       setCurrentAgentName(

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -270,9 +270,11 @@ export type ListenerRuntime = {
   secretsDirtyAgents: Set<string>;
   pendingExternalToolCalls?: Map<string, PendingExternalToolCall>;
   /**
-   * Agent metadata warmups for listen-mode reminders. The cached promise is
-   * reused while the listener stays connected so first-turn reminders can join
-   * an in-flight sync warmup instead of fetching agent info again.
+   * Agent warm state (reminder metadata + full agent state with tags) keyed by
+   * agent. The cached promise is reused while the listener stays connected so
+   * first-turn reminders join an in-flight sync warmup instead of fetching
+   * agent info again, and turn prep reuses the agent state instead of issuing
+   * a blocking per-turn retrieve (a background refresh keeps it converging).
    */
   agentMetadataByAgent: Map<
     string,
@@ -280,6 +282,9 @@ export type ListenerRuntime = {
       name: string | null;
       description: string | null;
       lastRunAt: string | null;
+      agent:
+        | import("@letta-ai/letta-client/resources/agents/agents").AgentState
+        | null;
     } | null>
   >;
   lastEmittedStatus: "idle" | "receiving" | "processing" | null;

--- a/src/websocket/listener/warmup.ts
+++ b/src/websocket/listener/warmup.ts
@@ -1,3 +1,4 @@
+import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import { getBackend } from "@/backend";
 import { debugWarn } from "@/utils/debug";
 import { ensureMemfsSyncedForAgent } from "./memfs-sync";
@@ -13,42 +14,54 @@ export type ListenerAgentMetadata = {
   lastRunAt: string | null;
 };
 
+export type ListenerAgentWarmState = ListenerAgentMetadata & {
+  /** Full agent state (tags included) reused by turn prep; null if unavailable. */
+  agent: AgentState | null;
+};
+
 export type ListenerWarmupScope = {
   agentId: string;
   conversationId: string;
 };
 
-function getAgentMetadataPromise(
+function getAgentWarmStatePromise(
   listener: ListenerRuntime,
   agentId: string,
-): Promise<ListenerAgentMetadata | null> | null {
+): Promise<ListenerAgentWarmState | null> | null {
   return listener.agentMetadataByAgent.get(agentId) ?? null;
 }
 
-async function fetchListenerAgentMetadata(
-  agentId: string,
-): Promise<ListenerAgentMetadata> {
-  const agent = await getBackend().retrieveAgent(agentId);
-
+function toListenerAgentWarmState(agent: AgentState): ListenerAgentWarmState {
   return {
     name: agent.name ?? null,
     description: agent.description ?? null,
     lastRunAt:
       (agent as { last_run_completion?: string | null }).last_run_completion ??
       null,
+    agent,
   };
+}
+
+async function fetchListenerAgentWarmState(
+  agentId: string,
+): Promise<ListenerAgentWarmState> {
+  const agent = (await getBackend().retrieveAgent(agentId, {
+    include: ["agent.tags"],
+  })) as AgentState;
+
+  return toListenerAgentWarmState(agent);
 }
 
 type ListenerWarmupDeps = {
   ensureMemfsSyncedForAgent: typeof ensureMemfsSyncedForAgent;
   ensureSecretsHydratedForAgent: typeof ensureSecretsHydratedForAgent;
-  fetchListenerAgentMetadata: typeof fetchListenerAgentMetadata;
+  fetchListenerAgentWarmState: typeof fetchListenerAgentWarmState;
 };
 
 const defaultWarmupDeps: ListenerWarmupDeps = {
   ensureMemfsSyncedForAgent,
   ensureSecretsHydratedForAgent,
-  fetchListenerAgentMetadata,
+  fetchListenerAgentWarmState,
 };
 
 let warmupDeps: ListenerWarmupDeps = defaultWarmupDeps;
@@ -62,17 +75,17 @@ let warmupDeps: ListenerWarmupDeps = defaultWarmupDeps;
 export async function ensureListenerWarmStateForTurn(
   listener: ListenerRuntime,
   scope: ListenerWarmupScope,
-): Promise<ListenerAgentMetadata | null> {
+): Promise<ListenerAgentWarmState | null> {
   const { agentId } = scope;
   if (!agentId) {
     return null;
   }
 
   const agentMetadataPromise =
-    getAgentMetadataPromise(listener, agentId) ??
+    getAgentWarmStatePromise(listener, agentId) ??
     (async () => {
       try {
-        return await warmupDeps.fetchListenerAgentMetadata(agentId);
+        return await warmupDeps.fetchListenerAgentWarmState(agentId);
       } catch (error) {
         debugWarn(
           "listener-warmup",
@@ -91,9 +104,16 @@ export async function ensureListenerWarmStateForTurn(
 
   try {
     await Promise.all([
-      warmupDeps.ensureMemfsSyncedForAgent(listener, agentId),
+      // Memfs reuses the warm-state agent fetch (tags included) instead of
+      // issuing its own retrieve; on a failed fetch it falls back internally.
+      agentMetadataPromise.then((warmState) =>
+        warmupDeps.ensureMemfsSyncedForAgent(
+          listener,
+          agentId,
+          warmState?.agent ?? null,
+        ),
+      ),
       warmupDeps.ensureSecretsHydratedForAgent(listener, agentId),
-      agentMetadataPromise,
     ]);
     const agentModAdapter = await ensureListenerAgentModAdapter(
       listener,
@@ -116,6 +136,89 @@ export async function ensureListenerWarmStateForTurn(
   }
 
   return agentMetadataPromise;
+}
+
+const inflightWarmStateRefreshes = new WeakMap<ListenerRuntime, Set<string>>();
+
+function scheduleListenerAgentWarmStateRefresh(
+  listener: ListenerRuntime,
+  agentId: string,
+): void {
+  let inflight = inflightWarmStateRefreshes.get(listener);
+  if (!inflight) {
+    inflight = new Set();
+    inflightWarmStateRefreshes.set(listener, inflight);
+  }
+  if (inflight.has(agentId)) {
+    return;
+  }
+  inflight.add(agentId);
+  void (async () => {
+    try {
+      const fresh = await warmupDeps.fetchListenerAgentWarmState(agentId);
+      listener.agentMetadataByAgent.set(agentId, Promise.resolve(fresh));
+    } catch (error) {
+      // Keep serving the existing cache; the next turn retries the refresh.
+      debugWarn(
+        "listener-warmup",
+        `Background agent state refresh failed for agent ${agentId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    } finally {
+      inflight.delete(agentId);
+    }
+  })();
+}
+
+/**
+ * Agent state for turn prep, served from the session cache without a blocking
+ * refetch. A background refresh runs on every cache hit so external changes
+ * converge by the next turn — the same freshness headless accepts by reusing
+ * its initial agent fetch across the whole run loop.
+ */
+export async function getListenerAgentStateForTurn(
+  listener: ListenerRuntime,
+  agentId: string,
+): Promise<AgentState | null> {
+  const cached = await getAgentWarmStatePromise(listener, agentId);
+  if (cached?.agent) {
+    scheduleListenerAgentWarmStateRefresh(listener, agentId);
+    return cached.agent;
+  }
+
+  try {
+    const fetched = await warmupDeps.fetchListenerAgentWarmState(agentId);
+    listener.agentMetadataByAgent.set(agentId, Promise.resolve(fetched));
+    return fetched.agent;
+  } catch (error) {
+    debugWarn(
+      "listener-warmup",
+      `Failed to fetch agent state for agent ${agentId}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return null;
+  }
+}
+
+/** Replace the cached warm state after a local mutation returned fresh agent state. */
+export function setListenerAgentWarmState(
+  listener: ListenerRuntime,
+  agent: AgentState,
+): void {
+  listener.agentMetadataByAgent.set(
+    agent.id,
+    Promise.resolve(toListenerAgentWarmState(agent)),
+  );
+}
+
+/** Drop the cached warm state so the next turn refetches (e.g. after a model update). */
+export function invalidateListenerAgentWarmState(
+  listener: ListenerRuntime,
+  agentId: string,
+): void {
+  listener.agentMetadataByAgent.delete(agentId);
 }
 
 /**


### PR DESCRIPTION
## Context

The scripted latency tracker (letta-cloud#11018) shows the listener adding ~15% wall-clock vs the plain CLI, concentrated on short tasks (short-loop 14.1s→19.5s, parallel-fanout 11.5s→17.7s, but long-loop only 83.9s→85.3s). That shape is fixed per-turn/per-session cost, not streaming drag. An audit of the listener turn path found blocking server round-trips headless does not pay; this PR removes the three biggest.

## Changes

**1. Per-turn agent fetch → session cache with background revalidation.**
`prepareListenerTurn` issued `retrieveAgent(include: agent.tags)` on every non-approval turn (plus a potential origin-tag fetch/update). The warm cache (`agentMetadataByAgent`) now stores the full tags-included `AgentState`; turns are served from it via `getListenerAgentStateForTurn`, which schedules a background refresh on every hit — so external changes converge by the next turn (headless accepts the same staleness by reusing its initial agent fetch for the whole run loop; server request volume is unchanged, just off the critical path). Because the cached agent carries tags, `ensureLettaCodeOriginTag` is a local no-op on the hot path.

Correctness hook: the `update_model` handler invalidates the cache after applying the update, so a model switch never runs the next turn against stale `model_settings` (provider-type resolution) or memory-tool attachments.

**2. First-turn agent fetches: 3 → 1.**
Warmup metadata, turn prep, and memfs sync each fetched the agent independently. All three now share the single warmup fetch. Memfs falls back to its own tags-included fetch only when the shared fetch failed — preserving the tags-included guarantee (see the Prod × DeepSeek blank-slate note in `memfs-sync.ts`).

**3. Memfs git pull off the first-turn critical path.**
`ensureListenerWarmStateForTurn` awaited a git pull over the network before the first turn could start — seconds when the pull is slow, and it hits every fresh session. New `backgroundPull` option on `applyMemfsFlags`, used only by the listener sync path: an **existing** repo serves the turn immediately while `pullMemory` refreshes it in the background; a **missing** repo still clones synchronously (memory tools need the checkout). Safe because `pullMemory` is already self-healing (ff-only → rebase → reset-to-remote) and pull failures were already non-fatal here. Headless, `/memfs enable`, and the cloud auto-repair path are untouched.

## Not addressed (deliberate)

- Per-turn `retrieveConversation` for model resolution in toolset prep — caching it changes cross-client model-change propagation; follow-up discussion.
- End-of-turn tail work before the idle emit — measured shape says it's local milliseconds; reordering risks interrupt-lease and mod-continue semantics.
- Relay round-trip overhead — cloud-side, not fixable in this repo.

## Tests

- `listener-warmup.test.ts`: 3 new tests (cache-hit serves without blocking fetch + background refresh converges; invalidation forces refetch; local-mutation cache replacement), and the first-turn dedupe test now asserts memfs receives the shared fetched agent.
- `bun run check` 12/12 green; `src/websocket/` suite shows only the same 4 pre-existing failures as the base commit (app-server native websocket ×3, remote-settings cwd repair); `memory-filesystem.test.ts` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)