### PR TITLE
refactor(listener): borrow codex app-server transport patterns [LET-10138]

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -46,7 +46,7 @@
   "src/websocket/listener/commands/channels.ts": 1390,
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1030,
-  "src/websocket/listener/lifecycle.ts": 1762,
+  "src/websocket/listener/lifecycle.ts": 1779,
   "src/websocket/listener/protocol-inbound.ts": 2279,
-  "src/websocket/listener/protocol-outbound.ts": 1150
+  "src/websocket/listener/protocol-outbound.ts": 1128
 }

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -48,5 +48,5 @@
   "src/websocket/listener/file-commands.ts": 1030,
   "src/websocket/listener/lifecycle.ts": 1762,
   "src/websocket/listener/protocol-inbound.ts": 2279,
-  "src/websocket/listener/protocol-outbound.ts": 1278
+  "src/websocket/listener/protocol-outbound.ts": 1150
 }

--- a/src/websocket/app-server.test.ts
+++ b/src/websocket/app-server.test.ts
@@ -508,6 +508,32 @@ describe("app-server native websocket", () => {
     }
   });
 
+  test("closes the paired control channel when stream disconnects", async () => {
+    let handle: AppServerHandle | null = null;
+    try {
+      handle = await startAppServer({ listen: "ws://127.0.0.1:0" });
+
+      for (const order of ["stream-first", "control-first"] as const) {
+        const firstUrl =
+          order === "stream-first" ? handle.streamUrl : handle.controlUrl;
+        const secondUrl =
+          order === "stream-first" ? handle.controlUrl : handle.streamUrl;
+        const first = new WebSocket(firstUrl);
+        await waitForOpen(first);
+        const second = new WebSocket(secondUrl);
+        await waitForOpen(second);
+        const stream = order === "stream-first" ? first : second;
+        const control = order === "stream-first" ? second : first;
+
+        terminateClient(stream);
+        await waitForClientClose(control);
+        terminateClient(control);
+      }
+    } finally {
+      await handle?.close();
+    }
+  });
+
   test("starts a runtime over control and emits state frames over stream", async () => {
     const storageDir = await mkdtemp(join(os.tmpdir(), "letta-app-server-"));
     let handle: AppServerHandle | null = null;

--- a/src/websocket/app-server.ts
+++ b/src/websocket/app-server.ts
@@ -165,6 +165,9 @@ function attachStreamSocket(
     if (activeSession.runtime.streamSocket === socket) {
       activeSession.runtime.streamSocket = null;
       activeSession.runtime.streamTransport = null;
+      // The stream channel cannot replay or reconnect independently. Tear down
+      // control so the client re-establishes one coherent paired session.
+      terminateSocket(activeSession.controlSocket);
     }
   });
 }

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -399,6 +399,29 @@ function getParsedRuntimeScope(
   };
 }
 
+function terminateControlAfterStreamClose(
+  runtime: ListenerRuntime,
+  streamSocket: WebSocket,
+): void {
+  if (runtime.streamSocket !== streamSocket) {
+    return;
+  }
+  runtime.streamSocket = null;
+  runtime.streamTransport = null;
+
+  const controlSocket = runtime.socket;
+  if (
+    controlSocket &&
+    (controlSocket.readyState === WebSocket.OPEN ||
+      controlSocket.readyState === WebSocket.CONNECTING)
+  ) {
+    // The stream channel has no independent replay or reconnect path. Closing
+    // control tears down the paired session so its normal reconnect/bootstrap
+    // flow restores one coherent connection instead of silently losing frames.
+    controlSocket.terminate();
+  }
+}
+
 async function waitForStreamSocketOpen(
   streamSocket: WebSocket,
   runtime: ListenerRuntime,
@@ -1322,10 +1345,7 @@ export async function attachOpenListenerSocket(
         );
       }
 
-      if (runtime.streamSocket === streamSocket) {
-        runtime.streamSocket = null;
-        runtime.streamTransport = null;
-      }
+      terminateControlAfterStreamClose(runtime, streamSocket);
     });
   }
 
@@ -1732,10 +1752,7 @@ async function connectWithRetry(
         );
       }
 
-      if (runtime.streamSocket === streamSocket) {
-        runtime.streamSocket = null;
-        runtime.streamTransport = null;
-      }
+      terminateControlAfterStreamClose(runtime, streamSocket);
     });
   }
 }

--- a/src/websocket/listener/outbound-wire.test.ts
+++ b/src/websocket/listener/outbound-wire.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, test } from "bun:test";
+import WebSocket from "ws";
+import {
+  enqueueOutboundFrame,
+  getOutboundQueueStats,
+  OUTBOUND_QUEUE_LIMITS,
+  type OutboundFrame,
+  type OutboundFrameClass,
+} from "@/websocket/listener/outbound-wire";
+import type { ListenerTransport } from "@/websocket/listener/transport";
+
+/** Local-kind fake: settable buffer, records sends. */
+function makeLocalTransport(options?: { bufferedAmount?: number }) {
+  const sent: string[] = [];
+  const transport = {
+    kind: "local" as const,
+    bufferedAmount: options?.bufferedAmount ?? 0,
+    isOpen: () => true,
+    send: (data: string) => {
+      sent.push(data);
+    },
+  };
+  return { transport: transport as ListenerTransport, sent, raw: transport };
+}
+
+/** WebSocket-kind fake (no `kind` field): supports terminate for kill tests. */
+function makeWsTransport(options?: { bufferedAmount?: number }) {
+  const sent: string[] = [];
+  let terminated = false;
+  const transport = {
+    readyState: WebSocket.OPEN,
+    bufferedAmount: options?.bufferedAmount ?? 0,
+    send: (data: string) => {
+      sent.push(data);
+    },
+    terminate: () => {
+      terminated = true;
+    },
+  };
+  return {
+    transport: transport as unknown as ListenerTransport,
+    sent,
+    raw: transport,
+    wasTerminated: () => terminated,
+  };
+}
+
+function frame(
+  label: string,
+  frameClass: OutboundFrameClass,
+  options?: Partial<OutboundFrame>,
+): OutboundFrame {
+  return {
+    typeLabel: label,
+    frameClass,
+    build: () => ({ payload: label, perfKey: label }),
+    ...options,
+  };
+}
+
+describe("outbound wire queue", () => {
+  test("sends synchronously in order while the socket is healthy", () => {
+    const { transport, sent } = makeLocalTransport();
+
+    enqueueOutboundFrame(transport, frame("a", "critical"));
+    enqueueOutboundFrame(transport, frame("b", "delta"));
+    enqueueOutboundFrame(transport, frame("c", "status"));
+
+    expect(sent).toEqual(["a", "b", "c"]);
+    expect(getOutboundQueueStats(transport).queuedFrames).toBe(0);
+  });
+
+  test("build runs at drain time and a null build skips the frame", () => {
+    const { transport, sent } = makeLocalTransport();
+    let built = 0;
+
+    enqueueOutboundFrame(transport, {
+      typeLabel: "skipped",
+      frameClass: "critical",
+      build: () => {
+        built += 1;
+        return null;
+      },
+    });
+    enqueueOutboundFrame(transport, frame("kept", "critical"));
+
+    expect(built).toBe(1);
+    expect(sent).toEqual(["kept"]);
+  });
+
+  test("pauses above the high watermark and resumes via the drain poll", async () => {
+    const { transport, sent, raw } = makeLocalTransport({
+      bufferedAmount: OUTBOUND_QUEUE_LIMITS.HIGH_WATERMARK_BUFFERED_BYTES,
+    });
+
+    enqueueOutboundFrame(transport, frame("queued", "delta"));
+    expect(sent).toEqual([]);
+    expect(getOutboundQueueStats(transport).queuedFrames).toBe(1);
+
+    raw.bufferedAmount = 0;
+    await new Promise((resolve) =>
+      setTimeout(resolve, OUTBOUND_QUEUE_LIMITS.DRAIN_POLL_MS + 20),
+    );
+    expect(sent).toEqual(["queued"]);
+    expect(getOutboundQueueStats(transport).queuedFrames).toBe(0);
+  });
+
+  test("coalesces status frames latest-wins per key while queued", async () => {
+    const { transport, sent, raw } = makeLocalTransport({
+      bufferedAmount: OUTBOUND_QUEUE_LIMITS.HIGH_WATERMARK_BUFFERED_BYTES,
+    });
+
+    enqueueOutboundFrame(transport, {
+      ...frame("loop:v1", "status"),
+      coalesceKey: "update_loop_status:agent:conv",
+    });
+    enqueueOutboundFrame(transport, frame("delta:1", "delta"));
+    enqueueOutboundFrame(transport, {
+      ...frame("loop:v2", "status"),
+      coalesceKey: "update_loop_status:agent:conv",
+    });
+    enqueueOutboundFrame(transport, {
+      ...frame("device:v1", "status"),
+      coalesceKey: "update_device_status:agent:conv",
+    });
+
+    expect(getOutboundQueueStats(transport).queuedFrames).toBe(3);
+
+    raw.bufferedAmount = 0;
+    await new Promise((resolve) =>
+      setTimeout(resolve, OUTBOUND_QUEUE_LIMITS.DRAIN_POLL_MS + 20),
+    );
+    // v2 replaced v1 in place (order preserved), other keys untouched.
+    expect(sent).toEqual(["loop:v2", "delta:1", "device:v1"]);
+  });
+
+  test("drops oldest delta frames first when the queue overflows", async () => {
+    const { transport, sent, raw } = makeLocalTransport({
+      bufferedAmount: OUTBOUND_QUEUE_LIMITS.HIGH_WATERMARK_BUFFERED_BYTES,
+    });
+
+    enqueueOutboundFrame(transport, frame("critical:1", "critical"));
+    for (let i = 0; i < OUTBOUND_QUEUE_LIMITS.MAX_QUEUED_FRAMES; i += 1) {
+      enqueueOutboundFrame(transport, frame(`delta:${i}`, "delta"));
+    }
+
+    const stats = getOutboundQueueStats(transport);
+    expect(stats.queuedFrames).toBe(OUTBOUND_QUEUE_LIMITS.MAX_QUEUED_FRAMES);
+    expect(stats.droppedDelta).toBe(1);
+    expect(stats.killed).toBe(false);
+
+    raw.bufferedAmount = 0;
+    await new Promise((resolve) =>
+      setTimeout(resolve, OUTBOUND_QUEUE_LIMITS.DRAIN_POLL_MS + 20),
+    );
+    // The critical frame survived; the oldest delta (delta:0) was shed.
+    expect(sent[0]).toBe("critical:1");
+    expect(sent).not.toContain("delta:0");
+    expect(sent).toContain("delta:1");
+  });
+
+  test("terminates a websocket transport stalled past the kill threshold", () => {
+    const { transport, wasTerminated } = makeWsTransport({
+      bufferedAmount: OUTBOUND_QUEUE_LIMITS.KILL_THRESHOLD_BUFFERED_BYTES,
+    });
+
+    enqueueOutboundFrame(transport, frame("doomed", "critical"));
+
+    expect(wasTerminated()).toBe(true);
+    const stats = getOutboundQueueStats(transport);
+    expect(stats.killed).toBe(true);
+    expect(stats.queuedFrames).toBe(0);
+  });
+
+  test("terminates when the queue overflows with only critical frames", () => {
+    const { transport, wasTerminated } = makeWsTransport({
+      bufferedAmount: OUTBOUND_QUEUE_LIMITS.HIGH_WATERMARK_BUFFERED_BYTES,
+    });
+
+    for (let i = 0; i <= OUTBOUND_QUEUE_LIMITS.MAX_QUEUED_FRAMES; i += 1) {
+      enqueueOutboundFrame(transport, frame(`critical:${i}`, "critical"));
+    }
+
+    expect(wasTerminated()).toBe(true);
+    expect(getOutboundQueueStats(transport).killed).toBe(true);
+  });
+
+  test("clears the backlog when the transport closes", async () => {
+    let open = true;
+    const sent: string[] = [];
+    const transport = {
+      kind: "local" as const,
+      bufferedAmount: OUTBOUND_QUEUE_LIMITS.HIGH_WATERMARK_BUFFERED_BYTES,
+      isOpen: () => open,
+      send: (data: string) => {
+        sent.push(data);
+      },
+    } as ListenerTransport;
+
+    enqueueOutboundFrame(transport, frame("stranded", "delta"));
+    expect(getOutboundQueueStats(transport).queuedFrames).toBe(1);
+
+    open = false;
+    await new Promise((resolve) =>
+      setTimeout(resolve, OUTBOUND_QUEUE_LIMITS.DRAIN_POLL_MS + 20),
+    );
+    expect(sent).toEqual([]);
+    expect(getOutboundQueueStats(transport).queuedFrames).toBe(0);
+  });
+
+  test("a throwing send reports the error and continues with later frames", () => {
+    const sent: string[] = [];
+    let sendErrors = 0;
+    const transport = {
+      kind: "local" as const,
+      bufferedAmount: 0,
+      isOpen: () => true,
+      send: (data: string) => {
+        if (data === "boom") throw new Error("send failed");
+        sent.push(data);
+      },
+    } as ListenerTransport;
+
+    enqueueOutboundFrame(transport, {
+      ...frame("boom", "critical"),
+      onSendError: () => {
+        sendErrors += 1;
+      },
+    });
+    enqueueOutboundFrame(transport, frame("after", "critical"));
+
+    expect(sendErrors).toBe(1);
+    expect(sent).toEqual(["after"]);
+  });
+});

--- a/src/websocket/listener/outbound-wire.test.ts
+++ b/src/websocket/listener/outbound-wire.test.ts
@@ -24,7 +24,10 @@ function makeLocalTransport(options?: { bufferedAmount?: number }) {
 }
 
 /** WebSocket-kind fake (no `kind` field): supports terminate for kill tests. */
-function makeWsTransport(options?: { bufferedAmount?: number }) {
+function makeWsTransport(options?: {
+  bufferedAmount?: number;
+  bufferedAmountAfterSend?: number;
+}) {
   const sent: string[] = [];
   let terminated = false;
   const transport = {
@@ -32,6 +35,9 @@ function makeWsTransport(options?: { bufferedAmount?: number }) {
     bufferedAmount: options?.bufferedAmount ?? 0,
     send: (data: string) => {
       sent.push(data);
+      if (options?.bufferedAmountAfterSend !== undefined) {
+        transport.bufferedAmount = options.bufferedAmountAfterSend;
+      }
     },
     terminate: () => {
       terminated = true;
@@ -63,7 +69,7 @@ describe("outbound wire queue", () => {
     const { transport, sent } = makeLocalTransport();
 
     enqueueOutboundFrame(transport, frame("a", "critical"));
-    enqueueOutboundFrame(transport, frame("b", "delta"));
+    enqueueOutboundFrame(transport, frame("b", "critical"));
     enqueueOutboundFrame(transport, frame("c", "status"));
 
     expect(sent).toEqual(["a", "b", "c"]);
@@ -93,7 +99,7 @@ describe("outbound wire queue", () => {
       bufferedAmount: OUTBOUND_QUEUE_LIMITS.HIGH_WATERMARK_BUFFERED_BYTES,
     });
 
-    enqueueOutboundFrame(transport, frame("queued", "delta"));
+    enqueueOutboundFrame(transport, frame("queued", "critical"));
     expect(sent).toEqual([]);
     expect(getOutboundQueueStats(transport).queuedFrames).toBe(1);
 
@@ -114,7 +120,7 @@ describe("outbound wire queue", () => {
       ...frame("loop:v1", "status"),
       coalesceKey: "update_loop_status:agent:conv",
     });
-    enqueueOutboundFrame(transport, frame("delta:1", "delta"));
+    enqueueOutboundFrame(transport, frame("delta:1", "critical"));
     enqueueOutboundFrame(transport, {
       ...frame("loop:v2", "status"),
       coalesceKey: "update_loop_status:agent:conv",
@@ -134,29 +140,24 @@ describe("outbound wire queue", () => {
     expect(sent).toEqual(["loop:v2", "delta:1", "device:v1"]);
   });
 
-  test("drops oldest delta frames first when the queue overflows", async () => {
-    const { transport, sent, raw } = makeLocalTransport({
+  test("terminates instead of dropping unreplayable frames on overflow", () => {
+    const { transport, wasTerminated } = makeWsTransport({
       bufferedAmount: OUTBOUND_QUEUE_LIMITS.HIGH_WATERMARK_BUFFERED_BYTES,
     });
 
-    enqueueOutboundFrame(transport, frame("critical:1", "critical"));
     for (let i = 0; i < OUTBOUND_QUEUE_LIMITS.MAX_QUEUED_FRAMES; i += 1) {
-      enqueueOutboundFrame(transport, frame(`delta:${i}`, "delta"));
+      enqueueOutboundFrame(
+        transport,
+        frame(`status:${i}`, "status", { coalesceKey: `scope:${i}` }),
+      );
     }
+    enqueueOutboundFrame(transport, frame("stream-delta", "critical"));
 
-    const stats = getOutboundQueueStats(transport);
-    expect(stats.queuedFrames).toBe(OUTBOUND_QUEUE_LIMITS.MAX_QUEUED_FRAMES);
-    expect(stats.droppedDelta).toBe(1);
-    expect(stats.killed).toBe(false);
-
-    raw.bufferedAmount = 0;
-    await new Promise((resolve) =>
-      setTimeout(resolve, OUTBOUND_QUEUE_LIMITS.DRAIN_POLL_MS + 20),
-    );
-    // The critical frame survived; the oldest delta (delta:0) was shed.
-    expect(sent[0]).toBe("critical:1");
-    expect(sent).not.toContain("delta:0");
-    expect(sent).toContain("delta:1");
+    expect(wasTerminated()).toBe(true);
+    expect(getOutboundQueueStats(transport)).toEqual({
+      queuedFrames: 0,
+      killed: true,
+    });
   });
 
   test("terminates a websocket transport stalled past the kill threshold", () => {
@@ -170,6 +171,19 @@ describe("outbound wire queue", () => {
     const stats = getOutboundQueueStats(transport);
     expect(stats.killed).toBe(true);
     expect(stats.queuedFrames).toBe(0);
+  });
+
+  test("enforces the kill threshold after the final socket write", () => {
+    const { transport, sent, wasTerminated } = makeWsTransport({
+      bufferedAmountAfterSend:
+        OUTBOUND_QUEUE_LIMITS.KILL_THRESHOLD_BUFFERED_BYTES,
+    });
+
+    enqueueOutboundFrame(transport, frame("final", "critical"));
+
+    expect(sent).toEqual(["final"]);
+    expect(wasTerminated()).toBe(true);
+    expect(getOutboundQueueStats(transport).killed).toBe(true);
   });
 
   test("terminates when the queue overflows with only critical frames", () => {
@@ -197,7 +211,7 @@ describe("outbound wire queue", () => {
       },
     } as ListenerTransport;
 
-    enqueueOutboundFrame(transport, frame("stranded", "delta"));
+    enqueueOutboundFrame(transport, frame("stranded", "critical"));
     expect(getOutboundQueueStats(transport).queuedFrames).toBe(1);
 
     open = false;
@@ -208,7 +222,7 @@ describe("outbound wire queue", () => {
     expect(getOutboundQueueStats(transport).queuedFrames).toBe(0);
   });
 
-  test("a throwing send reports the error and continues with later frames", () => {
+  test("a throwing send kills the queue instead of skipping a frame", () => {
     const sent: string[] = [];
     let sendErrors = 0;
     const transport = {
@@ -230,6 +244,7 @@ describe("outbound wire queue", () => {
     enqueueOutboundFrame(transport, frame("after", "critical"));
 
     expect(sendErrors).toBe(1);
-    expect(sent).toEqual(["after"]);
+    expect(sent).toEqual([]);
+    expect(getOutboundQueueStats(transport).killed).toBe(true);
   });
 });

--- a/src/websocket/listener/outbound-wire.ts
+++ b/src/websocket/listener/outbound-wire.ts
@@ -10,17 +10,15 @@
  * Design (borrowed from codex app-server, adapted to our topology — see
  * LET-10138): producers never interact with socket state; they enqueue into a
  * bounded queue drained by this module against `bufferedAmount` watermarks.
- * Codex disconnects a slow client on overflow, which works for N direct
- * clients; the listener has a single socket to the cloud relay, so overflow
- * degrades by frame class instead — snapshot ("status") frames coalesce
- * latest-wins, streaming text ("delta") frames drop oldest-first, and
- * turn-critical frames are never dropped. A socket stalled past the kill
- * threshold is terminated so the existing reconnect + sync-replay machinery
- * can restore a clean stream.
+ * Snapshot ("status") frames coalesce latest-wins while queued. All other
+ * frames are retained while the connection remains viable. If the bounded
+ * queue fills or the socket stalls, the transport is terminated instead of
+ * silently dropping stream deltas that the listener cannot replay. This
+ * follows Codex's disconnect-slow-client policy.
  *
  * Frames are serialized (and take their event_seq) inside `build()` at drain
- * time, so coalesced or dropped frames never consume sequence numbers and the
- * wire stream stays gap-free.
+ * time, so frames superseded or skipped before build do not consume sequence
+ * numbers.
  */
 
 import { appendFileSync, mkdirSync } from "node:fs";
@@ -33,16 +31,14 @@ import {
 } from "./transport";
 
 /**
- * How a frame degrades under backpressure.
- * - "critical": never dropped (tool returns, approvals, stop reasons,
- *   command responses). If only critical frames remain and the queue is
- *   still over capacity, the transport is considered stalled and killed.
+ * How a frame behaves under backpressure.
+ * - "critical": never dropped. If the queue reaches capacity, the transport
+ *   is considered stalled and terminated.
  * - "status": snapshot semantics — a newer frame with the same coalesceKey
  *   fully supersedes a queued one (loop status, device status, queue state).
- * - "delta": streaming text chunks; oldest are dropped first under pressure.
- *   The client recovers full content on the next sync replay.
+ *   A status frame without a newer replacement is still never dropped.
  */
-export type OutboundFrameClass = "critical" | "status" | "delta";
+export type OutboundFrameClass = "critical" | "status";
 
 export interface OutboundFrame {
   /** Message type label for logs/telemetry (not parsed). */
@@ -64,13 +60,11 @@ export interface OutboundFrame {
 /**
  * Queue and watermark limits.
  *
- * MAX_QUEUED_FRAMES follows codex's bounded-channel approach (they use 128
+ * MAX_QUEUED_FRAMES follows Codex's bounded-channel approach (they use 128
  * per connection); we allow more headroom because one relay socket carries
  * every conversation and status frames coalesce away. HIGH_WATERMARK pauses
  * draining while the socket's own buffer is congested; KILL_THRESHOLD treats
- * the socket as stalled — terminating it hands recovery to the reconnect +
- * sync-replay path, which restores state cleanly (codex's disconnect-slow-
- * client policy adapted to a single-pipe topology).
+ * the socket as stalled and terminates the paired connection.
  */
 export const OUTBOUND_QUEUE_LIMITS = {
   MAX_QUEUED_FRAMES: 512,
@@ -83,7 +77,6 @@ type OutboundQueueState = {
   frames: OutboundFrame[];
   pollTimer: ReturnType<typeof setTimeout> | null;
   draining: boolean;
-  droppedByClass: { status: number; delta: number };
   killed: boolean;
 };
 
@@ -96,7 +89,6 @@ function getQueueState(transport: ListenerTransport): OutboundQueueState {
       frames: [],
       pollTimer: null,
       draining: false,
-      droppedByClass: { status: 0, delta: 0 },
       killed: false,
     };
     queueByTransport.set(transport, state);
@@ -116,9 +108,7 @@ function terminateStalledTransport(
     state.pollTimer = null;
   }
   recordOutboundQueuePerf("queue:killed", 1);
-  console.error(
-    `[Listen Wire] Terminating stalled transport (${reason}); reconnect will resync`,
-  );
+  console.error(`[Listen Wire] Terminating stalled transport (${reason})`);
   if (getListenerTransportKind(transport) === "websocket") {
     const ws = transport as { terminate?: () => void; close?: () => void };
     try {
@@ -127,28 +117,6 @@ function terminateStalledTransport(
       // Socket already dead — reconnect logic owns it from here.
     }
   }
-}
-
-function dropOneFrameForCapacity(
-  transport: ListenerTransport,
-  state: OutboundQueueState,
-): void {
-  const dropOldestOfClass = (frameClass: OutboundFrameClass): boolean => {
-    const index = state.frames.findIndex((f) => f.frameClass === frameClass);
-    if (index === -1) return false;
-    const [dropped] = state.frames.splice(index, 1);
-    if (dropped && dropped.frameClass !== "critical") {
-      state.droppedByClass[dropped.frameClass] += 1;
-      recordOutboundQueuePerf(`queue:dropped:${dropped.frameClass}`, 1);
-    }
-    return true;
-  };
-
-  if (dropOldestOfClass("delta")) return;
-  if (dropOldestOfClass("status")) return;
-  // Only critical frames remain and the queue is over capacity: the consumer
-  // is not making progress. Reconnect + sync replay recovers all state.
-  terminateStalledTransport(transport, state, "queue full of critical frames");
 }
 
 /**
@@ -177,9 +145,9 @@ export function enqueueOutboundFrame(
   }
 
   state.frames.push(frame);
-  while (state.frames.length > OUTBOUND_QUEUE_LIMITS.MAX_QUEUED_FRAMES) {
-    dropOneFrameForCapacity(transport, state);
-    if (state.killed) return;
+  if (state.frames.length > OUTBOUND_QUEUE_LIMITS.MAX_QUEUED_FRAMES) {
+    terminateStalledTransport(transport, state, "outbound queue full");
+    return;
   }
   drainOutboundQueue(transport, state);
 }
@@ -205,7 +173,7 @@ function drainOutboundQueue(
   try {
     while (state.frames.length > 0) {
       if (!isListenerTransportOpen(transport)) {
-        // Closed socket: drop the backlog; reconnect sync-replay restores state.
+        // The connection is already lost; queued wire frames can no longer be delivered.
         state.frames = [];
         return;
       }
@@ -227,7 +195,8 @@ function drainOutboundQueue(
         built = frame.build();
       } catch (error) {
         frame.onSendError?.(error);
-        continue;
+        terminateStalledTransport(transport, state, "frame build failed");
+        return;
       }
       if (!built) continue;
       const stringifyMs = PERF_ENABLED ? performance.now() - buildStartedAt : 0;
@@ -236,27 +205,37 @@ function drainOutboundQueue(
         transport.send(built.payload);
       } catch (error) {
         frame.onSendError?.(error);
-        continue;
+        terminateStalledTransport(transport, state, "socket write failed");
+        return;
       }
+      const bufferedAfter = transport.bufferedAmount;
       if (PERF_ENABLED) {
         recordWirePerfSample(built.perfKey, {
           bytes: Buffer.byteLength(built.payload),
           stringifyMs,
           sendMs: performance.now() - sendStartedAt,
           bufferedBefore: buffered,
-          bufferedAfter: transport.bufferedAmount,
+          bufferedAfter,
         });
       }
       built.onSent?.();
-    }
-
-    const dropped = state.droppedByClass;
-    if (dropped.delta > 0 || dropped.status > 0) {
-      debugWarn(
-        "listen-wire",
-        `Outbound backpressure dropped frames before catching up (delta=${dropped.delta}, status=${dropped.status}); client resyncs on next replay`,
-      );
-      state.droppedByClass = { status: 0, delta: 0 };
+      if (
+        bufferedAfter >= OUTBOUND_QUEUE_LIMITS.KILL_THRESHOLD_BUFFERED_BYTES
+      ) {
+        terminateStalledTransport(
+          transport,
+          state,
+          "socket buffer exceeded kill threshold",
+        );
+        return;
+      }
+      if (
+        state.frames.length > 0 &&
+        bufferedAfter >= OUTBOUND_QUEUE_LIMITS.HIGH_WATERMARK_BUFFERED_BYTES
+      ) {
+        scheduleDrainPoll(transport, state);
+        return;
+      }
     }
   } finally {
     state.draining = false;
@@ -266,15 +245,11 @@ function drainOutboundQueue(
 /** Test/diagnostic visibility into a transport's queue. */
 export function getOutboundQueueStats(transport: ListenerTransport): {
   queuedFrames: number;
-  droppedDelta: number;
-  droppedStatus: number;
   killed: boolean;
 } {
   const state = queueByTransport.get(transport);
   return {
     queuedFrames: state?.frames.length ?? 0,
-    droppedDelta: state?.droppedByClass.delta ?? 0,
-    droppedStatus: state?.droppedByClass.status ?? 0,
     killed: state?.killed ?? false,
   };
 }

--- a/src/websocket/listener/outbound-wire.ts
+++ b/src/websocket/listener/outbound-wire.ts
@@ -1,0 +1,484 @@
+/**
+ * Transport-level outbound wire layer for the listener.
+ *
+ * Owns everything between "a protocol message is ready to leave" and the
+ * socket: the bounded per-transport queue, backpressure policy, and wire perf
+ * telemetry. Message-level concerns (envelope shape, event_seq semantics,
+ * frame classification) stay in protocol-outbound.ts, which hands this module
+ * pre-classified frames with a deferred `build()`.
+ *
+ * Design (borrowed from codex app-server, adapted to our topology — see
+ * LET-10138): producers never interact with socket state; they enqueue into a
+ * bounded queue drained by this module against `bufferedAmount` watermarks.
+ * Codex disconnects a slow client on overflow, which works for N direct
+ * clients; the listener has a single socket to the cloud relay, so overflow
+ * degrades by frame class instead — snapshot ("status") frames coalesce
+ * latest-wins, streaming text ("delta") frames drop oldest-first, and
+ * turn-critical frames are never dropped. A socket stalled past the kill
+ * threshold is terminated so the existing reconnect + sync-replay machinery
+ * can restore a clean stream.
+ *
+ * Frames are serialized (and take their event_seq) inside `build()` at drain
+ * time, so coalesced or dropped frames never consume sequence numbers and the
+ * wire stream stays gap-free.
+ */
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { debugWarn, isDebugEnabled } from "@/utils/debug";
+import {
+  getListenerTransportKind,
+  isListenerTransportOpen,
+  type ListenerTransport,
+} from "./transport";
+
+/**
+ * How a frame degrades under backpressure.
+ * - "critical": never dropped (tool returns, approvals, stop reasons,
+ *   command responses). If only critical frames remain and the queue is
+ *   still over capacity, the transport is considered stalled and killed.
+ * - "status": snapshot semantics — a newer frame with the same coalesceKey
+ *   fully supersedes a queued one (loop status, device status, queue state).
+ * - "delta": streaming text chunks; oldest are dropped first under pressure.
+ *   The client recovers full content on the next sync replay.
+ */
+export type OutboundFrameClass = "critical" | "status" | "delta";
+
+export interface OutboundFrame {
+  /** Message type label for logs/telemetry (not parsed). */
+  typeLabel: string;
+  frameClass: OutboundFrameClass;
+  /** Required for "status" frames: queued frame with the same key is replaced. */
+  coalesceKey?: string;
+  /**
+   * Serialize the frame. Runs at drain time, immediately before the socket
+   * write. Return null to skip the frame (e.g. sequence numbering became
+   * unavailable). Must be side-effect free until the frame is actually sent;
+   * post-send effects belong in `onSent`.
+   */
+  build(): { payload: string; perfKey: string; onSent?: () => void } | null;
+  /** Called if the socket write throws. */
+  onSendError?(error: unknown): void;
+}
+
+/**
+ * Queue and watermark limits.
+ *
+ * MAX_QUEUED_FRAMES follows codex's bounded-channel approach (they use 128
+ * per connection); we allow more headroom because one relay socket carries
+ * every conversation and status frames coalesce away. HIGH_WATERMARK pauses
+ * draining while the socket's own buffer is congested; KILL_THRESHOLD treats
+ * the socket as stalled — terminating it hands recovery to the reconnect +
+ * sync-replay path, which restores state cleanly (codex's disconnect-slow-
+ * client policy adapted to a single-pipe topology).
+ */
+export const OUTBOUND_QUEUE_LIMITS = {
+  MAX_QUEUED_FRAMES: 512,
+  HIGH_WATERMARK_BUFFERED_BYTES: 512 * 1024,
+  KILL_THRESHOLD_BUFFERED_BYTES: 16 * 1024 * 1024,
+  DRAIN_POLL_MS: 50,
+} as const;
+
+type OutboundQueueState = {
+  frames: OutboundFrame[];
+  pollTimer: ReturnType<typeof setTimeout> | null;
+  draining: boolean;
+  droppedByClass: { status: number; delta: number };
+  killed: boolean;
+};
+
+const queueByTransport = new WeakMap<ListenerTransport, OutboundQueueState>();
+
+function getQueueState(transport: ListenerTransport): OutboundQueueState {
+  let state = queueByTransport.get(transport);
+  if (!state) {
+    state = {
+      frames: [],
+      pollTimer: null,
+      draining: false,
+      droppedByClass: { status: 0, delta: 0 },
+      killed: false,
+    };
+    queueByTransport.set(transport, state);
+  }
+  return state;
+}
+
+function terminateStalledTransport(
+  transport: ListenerTransport,
+  state: OutboundQueueState,
+  reason: string,
+): void {
+  state.killed = true;
+  state.frames = [];
+  if (state.pollTimer) {
+    clearTimeout(state.pollTimer);
+    state.pollTimer = null;
+  }
+  recordOutboundQueuePerf("queue:killed", 1);
+  console.error(
+    `[Listen Wire] Terminating stalled transport (${reason}); reconnect will resync`,
+  );
+  if (getListenerTransportKind(transport) === "websocket") {
+    const ws = transport as { terminate?: () => void; close?: () => void };
+    try {
+      ws.terminate ? ws.terminate() : ws.close?.();
+    } catch {
+      // Socket already dead — reconnect logic owns it from here.
+    }
+  }
+}
+
+function dropOneFrameForCapacity(
+  transport: ListenerTransport,
+  state: OutboundQueueState,
+): void {
+  const dropOldestOfClass = (frameClass: OutboundFrameClass): boolean => {
+    const index = state.frames.findIndex((f) => f.frameClass === frameClass);
+    if (index === -1) return false;
+    const [dropped] = state.frames.splice(index, 1);
+    if (dropped && dropped.frameClass !== "critical") {
+      state.droppedByClass[dropped.frameClass] += 1;
+      recordOutboundQueuePerf(`queue:dropped:${dropped.frameClass}`, 1);
+    }
+    return true;
+  };
+
+  if (dropOldestOfClass("delta")) return;
+  if (dropOldestOfClass("status")) return;
+  // Only critical frames remain and the queue is over capacity: the consumer
+  // is not making progress. Reconnect + sync replay recovers all state.
+  terminateStalledTransport(transport, state, "queue full of critical frames");
+}
+
+/**
+ * Enqueue a frame and drain as far as the socket allows. When the socket is
+ * healthy this sends synchronously in the same tick (identical behavior to
+ * the pre-queue direct send); the queue only forms under backpressure.
+ */
+export function enqueueOutboundFrame(
+  transport: ListenerTransport,
+  frame: OutboundFrame,
+): void {
+  const state = getQueueState(transport);
+  if (state.killed) return;
+
+  if (frame.frameClass === "status" && frame.coalesceKey) {
+    const index = state.frames.findIndex(
+      (f) => f.frameClass === "status" && f.coalesceKey === frame.coalesceKey,
+    );
+    if (index !== -1) {
+      // Snapshot semantics: replace in place so queue position (and fairness
+      // relative to other frames) is preserved.
+      state.frames[index] = frame;
+      drainOutboundQueue(transport, state);
+      return;
+    }
+  }
+
+  state.frames.push(frame);
+  while (state.frames.length > OUTBOUND_QUEUE_LIMITS.MAX_QUEUED_FRAMES) {
+    dropOneFrameForCapacity(transport, state);
+    if (state.killed) return;
+  }
+  drainOutboundQueue(transport, state);
+}
+
+function scheduleDrainPoll(
+  transport: ListenerTransport,
+  state: OutboundQueueState,
+): void {
+  if (state.pollTimer) return;
+  state.pollTimer = setTimeout(() => {
+    state.pollTimer = null;
+    drainOutboundQueue(transport, state);
+  }, OUTBOUND_QUEUE_LIMITS.DRAIN_POLL_MS);
+  (state.pollTimer as { unref?: () => void }).unref?.();
+}
+
+function drainOutboundQueue(
+  transport: ListenerTransport,
+  state: OutboundQueueState,
+): void {
+  if (state.draining || state.killed) return;
+  state.draining = true;
+  try {
+    while (state.frames.length > 0) {
+      if (!isListenerTransportOpen(transport)) {
+        // Closed socket: drop the backlog; reconnect sync-replay restores state.
+        state.frames = [];
+        return;
+      }
+      const buffered = transport.bufferedAmount;
+      if (buffered >= OUTBOUND_QUEUE_LIMITS.KILL_THRESHOLD_BUFFERED_BYTES) {
+        terminateStalledTransport(transport, state, "socket buffer stalled");
+        return;
+      }
+      if (buffered >= OUTBOUND_QUEUE_LIMITS.HIGH_WATERMARK_BUFFERED_BYTES) {
+        scheduleDrainPoll(transport, state);
+        return;
+      }
+
+      const frame = state.frames.shift();
+      if (!frame) return;
+      const buildStartedAt = PERF_ENABLED ? performance.now() : 0;
+      let built: ReturnType<OutboundFrame["build"]>;
+      try {
+        built = frame.build();
+      } catch (error) {
+        frame.onSendError?.(error);
+        continue;
+      }
+      if (!built) continue;
+      const stringifyMs = PERF_ENABLED ? performance.now() - buildStartedAt : 0;
+      const sendStartedAt = PERF_ENABLED ? performance.now() : 0;
+      try {
+        transport.send(built.payload);
+      } catch (error) {
+        frame.onSendError?.(error);
+        continue;
+      }
+      if (PERF_ENABLED) {
+        recordWirePerfSample(built.perfKey, {
+          bytes: Buffer.byteLength(built.payload),
+          stringifyMs,
+          sendMs: performance.now() - sendStartedAt,
+          bufferedBefore: buffered,
+          bufferedAfter: transport.bufferedAmount,
+        });
+      }
+      built.onSent?.();
+    }
+
+    const dropped = state.droppedByClass;
+    if (dropped.delta > 0 || dropped.status > 0) {
+      debugWarn(
+        "listen-wire",
+        `Outbound backpressure dropped frames before catching up (delta=${dropped.delta}, status=${dropped.status}); client resyncs on next replay`,
+      );
+      state.droppedByClass = { status: 0, delta: 0 };
+    }
+  } finally {
+    state.draining = false;
+  }
+}
+
+/** Test/diagnostic visibility into a transport's queue. */
+export function getOutboundQueueStats(transport: ListenerTransport): {
+  queuedFrames: number;
+  droppedDelta: number;
+  droppedStatus: number;
+  killed: boolean;
+} {
+  const state = queueByTransport.get(transport);
+  return {
+    queuedFrames: state?.frames.length ?? 0,
+    droppedDelta: state?.droppedByClass.delta ?? 0,
+    droppedStatus: state?.droppedByClass.status ?? 0,
+    killed: state?.killed ?? false,
+  };
+}
+
+// ----- Wire perf telemetry (moved from protocol-outbound.ts) -----
+// Aggregates per-message-type send metrics into 1s windows, flushed to stderr
+// or LETTA_LISTENER_PERF_FILE when LETTA_LISTENER_PERF is enabled.
+
+const PERF_FLUSH_INTERVAL_MS = 1_000;
+const PERF_ENV_VALUES = new Set(["1", "true", "yes"]);
+const PERF_ENABLED = PERF_ENV_VALUES.has(
+  (process.env.LETTA_LISTENER_PERF ?? "").toLowerCase(),
+);
+const PERF_FILE = process.env.LETTA_LISTENER_PERF_FILE?.trim() || null;
+
+type WirePerfBucket = {
+  count: number;
+  bytes: number;
+  stringifyMs: number;
+  sendMs: number;
+  maxBufferedBefore: number;
+  maxBufferedAfter: number;
+};
+
+const wirePerfBuckets = new Map<string, WirePerfBucket>();
+let wirePerfFlushTimer: ReturnType<typeof setTimeout> | null = null;
+let wirePerfWindowStartedAt = 0;
+let wirePerfFileDirEnsured: string | null = null;
+let wirePerfFileWarningEmitted = false;
+
+function scheduleWirePerfFlush(): void {
+  if (wirePerfFlushTimer) {
+    return;
+  }
+  wirePerfFlushTimer = setTimeout(() => {
+    wirePerfFlushTimer = null;
+    flushWirePerfTelemetry();
+  }, PERF_FLUSH_INTERVAL_MS);
+  (wirePerfFlushTimer as { unref?: () => void }).unref?.();
+}
+
+function recordWirePerfSample(
+  key: string,
+  sample: {
+    bytes: number;
+    stringifyMs: number;
+    sendMs: number;
+    bufferedBefore: number;
+    bufferedAfter: number;
+  },
+): void {
+  if (wirePerfWindowStartedAt === 0) {
+    wirePerfWindowStartedAt = Date.now();
+  }
+  const bucket = wirePerfBuckets.get(key) ?? {
+    count: 0,
+    bytes: 0,
+    stringifyMs: 0,
+    sendMs: 0,
+    maxBufferedBefore: 0,
+    maxBufferedAfter: 0,
+  };
+  bucket.count += 1;
+  bucket.bytes += sample.bytes;
+  bucket.stringifyMs += sample.stringifyMs;
+  bucket.sendMs += sample.sendMs;
+  bucket.maxBufferedBefore = Math.max(
+    bucket.maxBufferedBefore,
+    sample.bufferedBefore,
+  );
+  bucket.maxBufferedAfter = Math.max(
+    bucket.maxBufferedAfter,
+    sample.bufferedAfter,
+  );
+  wirePerfBuckets.set(key, bucket);
+  scheduleWirePerfFlush();
+}
+
+/** Queue events (drops, kills) surface in the same perf windows as sends. */
+function recordOutboundQueuePerf(key: string, count: number): void {
+  if (!PERF_ENABLED) {
+    if (isDebugEnabled()) {
+      debugWarn("listen-wire", `outbound queue event: ${key} (+${count})`);
+    }
+    return;
+  }
+  recordWirePerfSample(key, {
+    bytes: 0,
+    stringifyMs: 0,
+    sendMs: 0,
+    bufferedBefore: 0,
+    bufferedAfter: 0,
+  });
+}
+
+function writeWirePerfFile(
+  record: {
+    ts: string;
+    event: "protocol_emit";
+    window_ms: number;
+    totals: WirePerfBucket;
+    buckets: Record<
+      string,
+      WirePerfBucket & {
+        avg_bytes: number;
+        avg_stringify_ms: number;
+        avg_send_ms: number;
+      }
+    >;
+  },
+  fallbackLine: string,
+): void {
+  const filePath = PERF_FILE;
+  if (!filePath) {
+    console.error(fallbackLine);
+    return;
+  }
+
+  try {
+    const dir = dirname(filePath);
+    if (wirePerfFileDirEnsured !== dir) {
+      mkdirSync(dir, { recursive: true });
+      wirePerfFileDirEnsured = dir;
+    }
+    appendFileSync(filePath, `${JSON.stringify(record)}\n`, {
+      encoding: "utf8",
+    });
+  } catch (error) {
+    if (!wirePerfFileWarningEmitted) {
+      wirePerfFileWarningEmitted = true;
+      console.error(
+        `[Listen Perf] Failed to write LETTA_LISTENER_PERF_FILE=${filePath}`,
+        error,
+      );
+    }
+    console.error(fallbackLine);
+  }
+}
+
+function flushWirePerfTelemetry(): void {
+  if (wirePerfBuckets.size === 0) {
+    wirePerfWindowStartedAt = 0;
+    return;
+  }
+  const windowMs = Math.max(1, Date.now() - wirePerfWindowStartedAt);
+  const totals: WirePerfBucket = {
+    count: 0,
+    bytes: 0,
+    stringifyMs: 0,
+    sendMs: 0,
+    maxBufferedBefore: 0,
+    maxBufferedAfter: 0,
+  };
+  const buckets: Record<
+    string,
+    WirePerfBucket & {
+      avg_bytes: number;
+      avg_stringify_ms: number;
+      avg_send_ms: number;
+    }
+  > = {};
+  const parts = [...wirePerfBuckets.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, bucket]) => {
+      totals.count += bucket.count;
+      totals.bytes += bucket.bytes;
+      totals.stringifyMs += bucket.stringifyMs;
+      totals.sendMs += bucket.sendMs;
+      totals.maxBufferedBefore = Math.max(
+        totals.maxBufferedBefore,
+        bucket.maxBufferedBefore,
+      );
+      totals.maxBufferedAfter = Math.max(
+        totals.maxBufferedAfter,
+        bucket.maxBufferedAfter,
+      );
+      buckets[key] = {
+        ...bucket,
+        avg_bytes: bucket.count > 0 ? bucket.bytes / bucket.count : 0,
+        avg_stringify_ms:
+          bucket.count > 0 ? bucket.stringifyMs / bucket.count : 0,
+        avg_send_ms: bucket.count > 0 ? bucket.sendMs / bucket.count : 0,
+      };
+
+      const stringifyMs = bucket.stringifyMs.toFixed(2);
+      const sendMs = bucket.sendMs.toFixed(2);
+      return `${key}{count=${bucket.count},bytes=${bucket.bytes},stringify_ms=${stringifyMs},send_ms=${sendMs},max_buffered_before=${bucket.maxBufferedBefore},max_buffered_after=${bucket.maxBufferedAfter}}`;
+    });
+  writeWirePerfFile(
+    {
+      ts: new Date().toISOString(),
+      event: "protocol_emit",
+      window_ms: windowMs,
+      totals,
+      buckets,
+    },
+    `[Listen Perf] protocol_emit window_ms=${windowMs} ${parts.join(" ")}`,
+  );
+  wirePerfBuckets.clear();
+  wirePerfWindowStartedAt = 0;
+}
+
+export const __outboundWireTestUtils = {
+  clearTransportQueue(transport: ListenerTransport): void {
+    queueByTransport.delete(transport);
+  },
+};

--- a/src/websocket/listener/protocol-outbound.test.ts
+++ b/src/websocket/listener/protocol-outbound.test.ts
@@ -4,9 +4,11 @@ import type { DequeuedBatch } from "@/queue/queue-runtime";
 import type { StreamDeltaMessage } from "@/types/protocol_v2";
 import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
 import { createRuntime as createListenerRuntime } from "@/websocket/listener/lifecycle";
+import { OUTBOUND_QUEUE_LIMITS } from "@/websocket/listener/outbound-wire";
 import {
   emitDequeuedUserMessage,
   emitDeviceStatusUpdateIfChanged,
+  emitProtocolV2Message,
 } from "@/websocket/listener/protocol-outbound";
 import type {
   ConversationRuntime,
@@ -18,9 +20,14 @@ class MockSocket {
   readyState = WebSocket.OPEN;
   bufferedAmount = 0;
   sentPayloads: string[] = [];
+  terminated = false;
 
   send(data: string): void {
     this.sentPayloads.push(data);
+  }
+
+  terminate(): void {
+    this.terminated = true;
   }
 }
 
@@ -51,6 +58,41 @@ function parseOnlyStreamDelta(socket: MockSocket): StreamDeltaMessage {
   expect(message.type).toBe("stream_delta");
   return message as StreamDeltaMessage;
 }
+
+describe("emitProtocolV2Message backpressure", () => {
+  test("never sheds stream deltas that snapshots cannot replay", () => {
+    const { runtime, socket } = createRuntime();
+    socket.bufferedAmount = OUTBOUND_QUEUE_LIMITS.HIGH_WATERMARK_BUFFERED_BYTES;
+
+    for (let i = 0; i <= OUTBOUND_QUEUE_LIMITS.MAX_QUEUED_FRAMES; i += 1) {
+      emitProtocolV2Message(socket as never, runtime, {
+        type: "stream_delta",
+        delta: {
+          message_type: "assistant_message",
+          content: `delta-${i}`,
+        },
+      } as never);
+    }
+
+    expect(socket.terminated).toBe(true);
+    expect(socket.sentPayloads).toEqual([]);
+  });
+
+  test("treats future protocol frame types as lossless by default", () => {
+    const { runtime, socket } = createRuntime();
+    socket.bufferedAmount = OUTBOUND_QUEUE_LIMITS.HIGH_WATERMARK_BUFFERED_BYTES;
+
+    for (let i = 0; i <= OUTBOUND_QUEUE_LIMITS.MAX_QUEUED_FRAMES; i += 1) {
+      emitProtocolV2Message(socket as never, runtime, {
+        type: "future_protocol_message",
+        content: `frame-${i}`,
+      } as never);
+    }
+
+    expect(socket.terminated).toBe(true);
+    expect(socket.sentPayloads).toEqual([]);
+  });
+});
 
 describe("emitDequeuedUserMessage", () => {
   test("emits cron_prompt-only turns as visible scheduled task user messages", () => {

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -425,20 +425,6 @@ function isStreamChannelMessage(type: string): boolean {
   return STREAM_CHANNEL_MESSAGE_TYPES.has(type);
 }
 
-/**
- * Stream-delta inner message types that must never be dropped under
- * backpressure: they carry turn state the client cannot reconstruct from a
- * later delta (tool lifecycle, approvals, terminal reasons). Text/reasoning
- * deltas are recoverable via sync replay and may be shed instead.
- */
-const CRITICAL_STREAM_DELTA_MESSAGE_TYPES: ReadonlySet<string> = new Set([
-  "approval_request_message",
-  "tool_call_message",
-  "tool_return_message",
-  "stop_reason",
-  "usage_statistics",
-]);
-
 /** Snapshot-style messages: a newer frame for the same scope supersedes a queued one. */
 const COALESCABLE_STATUS_MESSAGE_TYPES: ReadonlySet<string> = new Set([
   "update_device_status",
@@ -453,14 +439,6 @@ function classifyOutboundFrame(
     "runtime" | "event_seq" | "emitted_at" | "idempotency_key"
   >,
 ): OutboundFrameClass {
-  if (message.type === "stream_delta" && "delta" in message) {
-    const delta = message.delta as { message_type?: unknown };
-    return CRITICAL_STREAM_DELTA_MESSAGE_TYPES.has(
-      String(delta.message_type ?? ""),
-    )
-      ? "critical"
-      : "delta";
-  }
   return COALESCABLE_STATUS_MESSAGE_TYPES.has(message.type)
     ? "status"
     : "critical";

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -1,6 +1,3 @@
-import { appendFileSync, mkdirSync } from "node:fs";
-import { dirname } from "node:path";
-import { performance } from "node:perf_hooks";
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import { getScopedMemoryFilesystemRoot } from "@/agent/memory-filesystem";
@@ -50,6 +47,7 @@ import {
 } from "./device-status-cache";
 import { SUPPORTED_REMOTE_COMMANDS } from "./listener-constants";
 import { listListenerModCommands } from "./mod-commands";
+import { enqueueOutboundFrame, type OutboundFrameClass } from "./outbound-wire";
 import { getConversationPermissionModeState } from "./permission-mode";
 import {
   getConversationRuntime,
@@ -99,28 +97,6 @@ function buildModCommandsField(
   const modCommands = listListenerModCommands(listener, agentId);
   return modCommands.length > 0 ? { mod_commands: modCommands } : {};
 }
-const PROTOCOL_PERF_FLUSH_INTERVAL_MS = 1_000;
-const PROTOCOL_PERF_ENV_VALUES = new Set(["1", "true", "yes"]);
-const PROTOCOL_PERF_ENABLED = PROTOCOL_PERF_ENV_VALUES.has(
-  (process.env.LETTA_LISTENER_PERF ?? "").toLowerCase(),
-);
-const PROTOCOL_PERF_FILE = process.env.LETTA_LISTENER_PERF_FILE?.trim() || null;
-
-type ProtocolPerfBucket = {
-  count: number;
-  bytes: number;
-  stringifyMs: number;
-  sendMs: number;
-  maxBufferedBefore: number;
-  maxBufferedAfter: number;
-};
-
-const protocolPerfBuckets = new Map<string, ProtocolPerfBucket>();
-let protocolPerfFlushTimer: ReturnType<typeof setTimeout> | null = null;
-let protocolPerfWindowStartedAt = 0;
-let protocolPerfFileDirEnsured: string | null = null;
-let protocolPerfFileWarningEmitted = false;
-
 function getProtocolPerfKey(
   message: Omit<
     WsProtocolMessage,
@@ -132,166 +108,6 @@ function getProtocolPerfKey(
     return `${message.type}:${String(delta.message_type ?? "unknown")}`;
   }
   return message.type;
-}
-
-function scheduleProtocolPerfFlush(): void {
-  if (protocolPerfFlushTimer) {
-    return;
-  }
-  protocolPerfFlushTimer = setTimeout(() => {
-    protocolPerfFlushTimer = null;
-    flushProtocolPerfTelemetry();
-  }, PROTOCOL_PERF_FLUSH_INTERVAL_MS);
-  const timerWithUnref = protocolPerfFlushTimer as ReturnType<
-    typeof setTimeout
-  > & {
-    unref?: () => void;
-  };
-  timerWithUnref.unref?.();
-}
-
-function recordProtocolPerfTelemetry(
-  key: string,
-  sample: {
-    bytes: number;
-    stringifyMs: number;
-    sendMs: number;
-    bufferedBefore: number;
-    bufferedAfter: number;
-  },
-): void {
-  if (protocolPerfWindowStartedAt === 0) {
-    protocolPerfWindowStartedAt = Date.now();
-  }
-  const bucket = protocolPerfBuckets.get(key) ?? {
-    count: 0,
-    bytes: 0,
-    stringifyMs: 0,
-    sendMs: 0,
-    maxBufferedBefore: 0,
-    maxBufferedAfter: 0,
-  };
-  bucket.count += 1;
-  bucket.bytes += sample.bytes;
-  bucket.stringifyMs += sample.stringifyMs;
-  bucket.sendMs += sample.sendMs;
-  bucket.maxBufferedBefore = Math.max(
-    bucket.maxBufferedBefore,
-    sample.bufferedBefore,
-  );
-  bucket.maxBufferedAfter = Math.max(
-    bucket.maxBufferedAfter,
-    sample.bufferedAfter,
-  );
-  protocolPerfBuckets.set(key, bucket);
-  scheduleProtocolPerfFlush();
-}
-
-function writeProtocolPerfFile(
-  record: {
-    ts: string;
-    event: "protocol_emit";
-    window_ms: number;
-    totals: ProtocolPerfBucket;
-    buckets: Record<
-      string,
-      ProtocolPerfBucket & {
-        avg_bytes: number;
-        avg_stringify_ms: number;
-        avg_send_ms: number;
-      }
-    >;
-  },
-  fallbackLine: string,
-): void {
-  const filePath = PROTOCOL_PERF_FILE;
-  if (!filePath) {
-    console.error(fallbackLine);
-    return;
-  }
-
-  try {
-    const dir = dirname(filePath);
-    if (protocolPerfFileDirEnsured !== dir) {
-      mkdirSync(dir, { recursive: true });
-      protocolPerfFileDirEnsured = dir;
-    }
-    appendFileSync(filePath, `${JSON.stringify(record)}\n`, {
-      encoding: "utf8",
-    });
-  } catch (error) {
-    if (!protocolPerfFileWarningEmitted) {
-      protocolPerfFileWarningEmitted = true;
-      console.error(
-        `[Listen Perf] Failed to write LETTA_LISTENER_PERF_FILE=${filePath}`,
-        error,
-      );
-    }
-    console.error(fallbackLine);
-  }
-}
-
-function flushProtocolPerfTelemetry(): void {
-  if (protocolPerfBuckets.size === 0) {
-    protocolPerfWindowStartedAt = 0;
-    return;
-  }
-  const windowMs = Math.max(1, Date.now() - protocolPerfWindowStartedAt);
-  const totals: ProtocolPerfBucket = {
-    count: 0,
-    bytes: 0,
-    stringifyMs: 0,
-    sendMs: 0,
-    maxBufferedBefore: 0,
-    maxBufferedAfter: 0,
-  };
-  const buckets: Record<
-    string,
-    ProtocolPerfBucket & {
-      avg_bytes: number;
-      avg_stringify_ms: number;
-      avg_send_ms: number;
-    }
-  > = {};
-  const parts = [...protocolPerfBuckets.entries()]
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([key, bucket]) => {
-      totals.count += bucket.count;
-      totals.bytes += bucket.bytes;
-      totals.stringifyMs += bucket.stringifyMs;
-      totals.sendMs += bucket.sendMs;
-      totals.maxBufferedBefore = Math.max(
-        totals.maxBufferedBefore,
-        bucket.maxBufferedBefore,
-      );
-      totals.maxBufferedAfter = Math.max(
-        totals.maxBufferedAfter,
-        bucket.maxBufferedAfter,
-      );
-      buckets[key] = {
-        ...bucket,
-        avg_bytes: bucket.count > 0 ? bucket.bytes / bucket.count : 0,
-        avg_stringify_ms:
-          bucket.count > 0 ? bucket.stringifyMs / bucket.count : 0,
-        avg_send_ms: bucket.count > 0 ? bucket.sendMs / bucket.count : 0,
-      };
-
-      const stringifyMs = bucket.stringifyMs.toFixed(2);
-      const sendMs = bucket.sendMs.toFixed(2);
-      return `${key}{count=${bucket.count},bytes=${bucket.bytes},stringify_ms=${stringifyMs},send_ms=${sendMs},max_buffered_before=${bucket.maxBufferedBefore},max_buffered_after=${bucket.maxBufferedAfter}}`;
-    });
-  writeProtocolPerfFile(
-    {
-      ts: new Date().toISOString(),
-      event: "protocol_emit",
-      window_ms: windowMs,
-      totals,
-      buckets,
-    },
-    `[Listen Perf] protocol_emit window_ms=${windowMs} ${parts.join(" ")}`,
-  );
-  protocolPerfBuckets.clear();
-  protocolPerfWindowStartedAt = 0;
 }
 
 const gitContextCache = new Map<
@@ -609,6 +425,47 @@ function isStreamChannelMessage(type: string): boolean {
   return STREAM_CHANNEL_MESSAGE_TYPES.has(type);
 }
 
+/**
+ * Stream-delta inner message types that must never be dropped under
+ * backpressure: they carry turn state the client cannot reconstruct from a
+ * later delta (tool lifecycle, approvals, terminal reasons). Text/reasoning
+ * deltas are recoverable via sync replay and may be shed instead.
+ */
+const CRITICAL_STREAM_DELTA_MESSAGE_TYPES: ReadonlySet<string> = new Set([
+  "approval_request_message",
+  "tool_call_message",
+  "tool_return_message",
+  "stop_reason",
+  "usage_statistics",
+]);
+
+/** Snapshot-style messages: a newer frame for the same scope supersedes a queued one. */
+const COALESCABLE_STATUS_MESSAGE_TYPES: ReadonlySet<string> = new Set([
+  "update_device_status",
+  "update_loop_status",
+  "update_queue",
+  "update_subagent_state",
+]);
+
+function classifyOutboundFrame(
+  message: Omit<
+    WsProtocolMessage,
+    "runtime" | "event_seq" | "emitted_at" | "idempotency_key"
+  >,
+): OutboundFrameClass {
+  if (message.type === "stream_delta" && "delta" in message) {
+    const delta = message.delta as { message_type?: unknown };
+    return CRITICAL_STREAM_DELTA_MESSAGE_TYPES.has(
+      String(delta.message_type ?? ""),
+    )
+      ? "critical"
+      : "delta";
+  }
+  return COALESCABLE_STATUS_MESSAGE_TYPES.has(message.type)
+    ? "status"
+    : "critical";
+}
+
 export function emitProtocolV2Message(
   socket: ListenerTransport,
   runtime: RuntimeCarrier,
@@ -639,52 +496,67 @@ export function emitProtocolV2Message(
   if (!runtimeScope) return;
   notifyStreamObservers(listener, message, runtimeScope);
   if (!isListenerTransportOpen(targetSocket)) return;
-  const eventSeq = nextEventSeq(listener);
-  if (eventSeq === null) return;
-  const outbound: WsProtocolMessage = {
-    ...message,
-    runtime: runtimeScope,
-    event_seq: eventSeq,
-    emitted_at: new Date().toISOString(),
-    idempotency_key: `${message.type}:${eventSeq}:${crypto.randomUUID()}`,
-  } as WsProtocolMessage;
-  const perfEnabled = PROTOCOL_PERF_ENABLED;
-  const stringifyStartedAt = perfEnabled ? performance.now() : 0;
-  let payload: string;
-  try {
-    payload = JSON.stringify(outbound);
-    const stringifyMs = perfEnabled
-      ? performance.now() - stringifyStartedAt
-      : 0;
-    const bufferedBefore = perfEnabled ? targetSocket.bufferedAmount : 0;
-    const sendStartedAt = perfEnabled ? performance.now() : 0;
-    targetSocket.send(payload);
-    if (perfEnabled) {
-      recordProtocolPerfTelemetry(getProtocolPerfKey(message), {
-        bytes: Buffer.byteLength(payload),
-        stringifyMs,
-        sendMs: performance.now() - sendStartedAt,
-        bufferedBefore,
-        bufferedAfter: targetSocket.bufferedAmount,
+
+  // The wire layer owns queueing, backpressure, and the actual send. The
+  // envelope is built at drain time so coalesced/dropped frames never consume
+  // an event_seq and the delivered stream stays gap-free.
+  const frameClass = classifyOutboundFrame(message);
+  enqueueOutboundFrame(targetSocket, {
+    typeLabel: message.type,
+    frameClass,
+    ...(frameClass === "status"
+      ? {
+          coalesceKey: `${message.type}:${runtimeScope.agent_id ?? ""}:${runtimeScope.conversation_id ?? ""}`,
+        }
+      : {}),
+    build: () => {
+      const eventSeq = nextEventSeq(listener);
+      if (eventSeq === null) return null;
+      const outbound: WsProtocolMessage = {
+        ...message,
+        runtime: runtimeScope,
+        event_seq: eventSeq,
+        emitted_at: new Date().toISOString(),
+        idempotency_key: `${message.type}:${eventSeq}:${crypto.randomUUID()}`,
+      } as WsProtocolMessage;
+      let payload: string;
+      try {
+        payload = JSON.stringify(outbound);
+      } catch (error) {
+        console.error(
+          `[Listen V2] Failed to emit ${message.type} (seq=${eventSeq})`,
+          error,
+        );
+        safeEmitWsEvent("send", "lifecycle", {
+          type: "_ws_send_error",
+          message_type: message.type,
+          event_seq: eventSeq,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return null;
+      }
+      return {
+        payload,
+        perfKey: getProtocolPerfKey(message),
+        onSent: () => {
+          if (isDebugEnabled()) {
+            console.log(
+              `[Listen V2] Emitting ${message.type} (seq=${eventSeq})`,
+            );
+          }
+          safeEmitWsEvent("send", "protocol", outbound);
+        },
+      };
+    },
+    onSendError: (error) => {
+      console.error(`[Listen V2] Failed to emit ${message.type}`, error);
+      safeEmitWsEvent("send", "lifecycle", {
+        type: "_ws_send_error",
+        message_type: message.type,
+        error: error instanceof Error ? error.message : String(error),
       });
-    }
-  } catch (error) {
-    console.error(
-      `[Listen V2] Failed to emit ${message.type} (seq=${eventSeq})`,
-      error,
-    );
-    safeEmitWsEvent("send", "lifecycle", {
-      type: "_ws_send_error",
-      message_type: message.type,
-      event_seq: eventSeq,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return;
-  }
-  if (isDebugEnabled()) {
-    console.log(`[Listen V2] Emitting ${message.type} (seq=${eventSeq})`);
-  }
-  safeEmitWsEvent("send", "protocol", outbound);
+    },
+  });
 }
 
 export function emitDeviceStatusUpdate(

--- a/src/websocket/listener/runtime.test.ts
+++ b/src/websocket/listener/runtime.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import { __listenClientTestUtils } from "@/websocket/listen-client";
+import { getWorkingDirectoryScopeKey } from "@/websocket/listener/cwd";
+import {
+  __watcherIdleStopTestUtils,
+  createConversationRuntime,
+  evictConversationRuntimeIfIdle,
+} from "@/websocket/listener/runtime";
+import type { ListenerRuntime } from "@/websocket/listener/types";
+
+const AGENT_ID = "agent-runtime-eviction";
+const CONVERSATION_ID = "conv-runtime-eviction";
+
+function seedWatcher(listener: ListenerRuntime): {
+  scopeKey: string;
+  wasAborted: () => boolean;
+} {
+  const scopeKey = getWorkingDirectoryScopeKey(AGENT_ID, CONVERSATION_ID);
+  const abort = new AbortController();
+  listener.worktreeWatcherByConversation.set(scopeKey, {
+    abort,
+    watchedDir: "/tmp/worktrees",
+  });
+  return { scopeKey, wasAborted: () => abort.signal.aborted };
+}
+
+describe("conversation runtime eviction and worktree watcher idle stop", () => {
+  test("eviction schedules an idle stop instead of killing the watcher", () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const { scopeKey, wasAborted } = seedWatcher(listener);
+    const runtime = createConversationRuntime(
+      listener,
+      AGENT_ID,
+      CONVERSATION_ID,
+    );
+
+    expect(evictConversationRuntimeIfIdle(runtime)).toBe(true);
+
+    // Watchers track worktree changes between turns for attached clients, so
+    // routine post-turn eviction must not stop them immediately.
+    expect(wasAborted()).toBe(false);
+    expect(listener.worktreeWatcherByConversation.has(scopeKey)).toBe(true);
+    expect(__watcherIdleStopTestUtils.hasPending(listener, scopeKey)).toBe(
+      true,
+    );
+
+    __watcherIdleStopTestUtils.firePending(listener);
+    expect(wasAborted()).toBe(true);
+    expect(listener.worktreeWatcherByConversation.has(scopeKey)).toBe(false);
+  });
+
+  test("recreating the runtime cancels the pending watcher stop", () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const { scopeKey, wasAborted } = seedWatcher(listener);
+    const runtime = createConversationRuntime(
+      listener,
+      AGENT_ID,
+      CONVERSATION_ID,
+    );
+
+    expect(evictConversationRuntimeIfIdle(runtime)).toBe(true);
+    expect(__watcherIdleStopTestUtils.hasPending(listener, scopeKey)).toBe(
+      true,
+    );
+
+    // Conversation becomes active again before the TTL elapses.
+    createConversationRuntime(listener, AGENT_ID, CONVERSATION_ID);
+    expect(__watcherIdleStopTestUtils.hasPending(listener, scopeKey)).toBe(
+      false,
+    );
+
+    __watcherIdleStopTestUtils.firePending(listener);
+    expect(wasAborted()).toBe(false);
+    expect(listener.worktreeWatcherByConversation.has(scopeKey)).toBe(true);
+  });
+
+  test("a stale idle stop does not kill a replacement watcher", () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const { scopeKey } = seedWatcher(listener);
+    const runtime = createConversationRuntime(
+      listener,
+      AGENT_ID,
+      CONVERSATION_ID,
+    );
+    expect(evictConversationRuntimeIfIdle(runtime)).toBe(true);
+
+    // A CWD change replaces the watcher after eviction was scheduled.
+    const replacementAbort = new AbortController();
+    listener.worktreeWatcherByConversation.set(scopeKey, {
+      abort: replacementAbort,
+      watchedDir: "/tmp/worktrees-2",
+    });
+
+    __watcherIdleStopTestUtils.firePending(listener);
+    expect(replacementAbort.signal.aborted).toBe(false);
+    expect(listener.worktreeWatcherByConversation.has(scopeKey)).toBe(true);
+  });
+
+  test("eviction refuses while the conversation has pending work", () => {
+    const listener = __listenClientTestUtils.createListenerRuntime();
+    const runtime = createConversationRuntime(
+      listener,
+      AGENT_ID,
+      CONVERSATION_ID,
+    );
+    runtime.pendingTurns = 1;
+
+    expect(evictConversationRuntimeIfIdle(runtime)).toBe(false);
+    expect(listener.conversationRuntimes.has(runtime.key)).toBe(true);
+  });
+});

--- a/src/websocket/listener/runtime.ts
+++ b/src/websocket/listener/runtime.ts
@@ -1,6 +1,7 @@
 import { createContextTracker } from "@/cli/helpers/context-tracker";
 import { createSharedReminderState } from "@/reminders/state";
 import type { PendingControlRequest } from "@/types/protocol_v2";
+import { getWorkingDirectoryScopeKey } from "./cwd";
 import {
   normalizeConversationId,
   normalizeCwdAgentId,
@@ -57,6 +58,101 @@ export function clearRuntimeTimers(runtime: ListenerRuntime): void {
   }
 }
 
+/**
+ * How long an evicted conversation's worktree watcher may stay alive waiting
+ * for the conversation to come back. Runtime eviction is routine (it fires
+ * after every quiescent turn), and the watcher's job is to track worktree
+ * changes for an attached client *between* turns — so it must survive
+ * eviction, but not for the life of the process. Without this, one live
+ * fs.watch loop accumulates per conversation ever touched (LET-10138).
+ */
+export const WORKTREE_WATCHER_IDLE_STOP_MS = 30 * 60 * 1000;
+
+type WatcherIdleStop = {
+  timer: ReturnType<typeof setTimeout>;
+  /** Structural view of WorktreeWatcherState; a type import would cycle. */
+  watcher: { abort: AbortController };
+};
+
+const watcherIdleStopsByListener = new WeakMap<
+  ListenerRuntime,
+  Map<string, WatcherIdleStop>
+>();
+
+function scheduleWorktreeWatcherIdleStop(
+  listener: ListenerRuntime,
+  runtime: ConversationRuntime,
+): void {
+  const scopeKey = getWorkingDirectoryScopeKey(
+    runtime.agentId,
+    runtime.conversationId,
+  );
+  const watcher = listener.worktreeWatcherByConversation.get(scopeKey);
+  if (!watcher) return;
+
+  let stops = watcherIdleStopsByListener.get(listener);
+  if (!stops) {
+    stops = new Map();
+    watcherIdleStopsByListener.set(listener, stops);
+  }
+  const existing = stops.get(scopeKey);
+  if (existing) {
+    if (existing.watcher === watcher) return;
+    clearTimeout(existing.timer);
+  }
+
+  const timer = setTimeout(() => {
+    fireWatcherIdleStop(listener, scopeKey, watcher);
+  }, WORKTREE_WATCHER_IDLE_STOP_MS);
+  (timer as { unref?: () => void }).unref?.();
+  stops.set(scopeKey, { timer, watcher });
+}
+
+function fireWatcherIdleStop(
+  listener: ListenerRuntime,
+  scopeKey: string,
+  watcher: WatcherIdleStop["watcher"],
+): void {
+  watcherIdleStopsByListener.get(listener)?.delete(scopeKey);
+  // Only stop the watcher this timer was scheduled for; a CWD change may
+  // have replaced it with a fresh one that is still in use.
+  if (listener.worktreeWatcherByConversation.get(scopeKey) === watcher) {
+    watcher.abort.abort();
+    listener.worktreeWatcherByConversation.delete(scopeKey);
+  }
+}
+
+export const __watcherIdleStopTestUtils = {
+  /** Fire every pending idle stop immediately (tests cannot wait 30 minutes). */
+  firePending(listener: ListenerRuntime): void {
+    const stops = watcherIdleStopsByListener.get(listener);
+    if (!stops) return;
+    for (const [scopeKey, pending] of [...stops.entries()]) {
+      clearTimeout(pending.timer);
+      fireWatcherIdleStop(listener, scopeKey, pending.watcher);
+    }
+  },
+  hasPending(listener: ListenerRuntime, scopeKey: string): boolean {
+    return watcherIdleStopsByListener.get(listener)?.has(scopeKey) ?? false;
+  },
+};
+
+/** The conversation is active again: keep its worktree watcher running. */
+function cancelWorktreeWatcherIdleStop(
+  listener: ListenerRuntime,
+  agentId?: string | null,
+  conversationId?: string | null,
+): void {
+  const stops = watcherIdleStopsByListener.get(listener);
+  if (!stops) return;
+  const scopeKey = getWorkingDirectoryScopeKey(agentId, conversationId);
+  const pending = stops.get(scopeKey);
+  if (pending) {
+    clearTimeout(pending.timer);
+    stops.delete(scopeKey);
+  }
+}
+
 export function evictConversationRuntimeIfIdle(
   runtime: ConversationRuntime,
 ): boolean {
@@ -82,6 +178,7 @@ export function evictConversationRuntimeIfIdle(
   }
 
   runtime.listener.conversationRuntimes.delete(runtime.key);
+  scheduleWorktreeWatcherIdleStop(runtime.listener, runtime);
   for (const [requestId, runtimeKey] of runtime.listener
     .approvalRuntimeKeyByRequestId) {
     if (runtimeKey === runtime.key) {
@@ -147,6 +244,11 @@ export function createConversationRuntime(
   const normalizedAgentId = normalizeCwdAgentId(agentId);
   const normalizedConversationId = normalizeConversationId(conversationId);
   const runtimeKey = getConversationRuntimeKey(
+    normalizedAgentId,
+    normalizedConversationId,
+  );
+  cancelWorktreeWatcherIdleStop(
+    listener,
     normalizedAgentId,
     normalizedConversationId,
   );


### PR DESCRIPTION
Fixes LET-10138

Adopts the load-bearing performance patterns from codex's app-server (audited at `codex-rs/app-server`; full comparison in the Linear issue), adapted to the listener's single-relay-socket topology. One commit per logical diff.

## Commit 1 — bounded outbound wire queue with backpressure policy

The listener sent every stream delta, status update, and tool event with an unconditional `socket.send()`; `bufferedAmount` was recorded for telemetry but never acted on. When the consumer slows (e.g. a desktop renderer dragging under a long session's history), the WS buffer grows unboundedly and every frame queues behind the backlog — the amplifier behind "desktop gets slower over time."

New `outbound-wire.ts` module owns everything between "message ready" and the socket, borrowing codex's structure (producers never touch socket state; a single owner applies send policy):

- **Bounded per-transport queue** drained against `bufferedAmount` watermarks (pause at 512KB, poll to resume). When the socket is healthy the drain sends synchronously in the same tick — identical to the old direct-send path; the queue only forms under pressure.
- **Frame-class degradation instead of codex's disconnect-slow-client** (they can drop one of N direct clients; we have one pipe to the relay, so disconnect = session kill). Snapshot frames (`update_loop_status`/`update_device_status`/`update_queue`/`update_subagent_state`) coalesce latest-wins per scope; streaming text/reasoning deltas shed oldest-first past 512 queued frames; turn-critical frames (tool calls/returns, approvals, stop reasons, command traffic) are never dropped.
- **Stalled-socket kill switch**: past 16MB buffered (or a queue full of nothing but critical frames), the transport is terminated so the existing reconnect + sync-replay machinery restores a clean stream — codex's policy adapted to our topology.
- **Gap-free sequencing**: frames serialize and take their `event_seq` at drain time, so coalesced/dropped frames never consume sequence numbers.
- Wire perf telemetry moves out of `protocol-outbound.ts` into the new module; queue drops/kills surface in the same perf windows. `protocol-outbound.ts` keeps message-level concerns only and shrinks 1278 → 1150 lines (baseline ratcheted).

## Commit 2 — stop worktree watchers after conversations go idle

Conversation runtimes already evict on quiescence (the audit's "never evicted" claim was wrong — `evictConversationRuntimeIfIdle` runs after every quiescent turn), but each conversation's worktree watcher (a live `fs.watch` loop) was only stopped on explicit CWD change or listener shutdown — one accumulated per conversation touched, forever. Eviction now schedules a 30-minute idle stop, cancelled if the conversation becomes active again; a fired stop only aborts the exact watcher it was scheduled for.

## Deliberately not in this PR

- **Client notification opt-out** (codex's per-connection method suppression): needs a `protocol_v2` field plus desktop-side adoption — belongs in a coordinated protocol/desktop change, not as dead listener-side code here. Tracked in LET-10138.
- Reflection transcript growth and desktop renderer virtualization (separate fixes, see issue).

## Tests

- `outbound-wire.test.ts` (9 tests): in-order synchronous delivery on healthy sockets, drain-time build with null-skip, watermark pause/resume, latest-wins status coalescing, oldest-first delta shedding with critical preservation, kill on stalled socket, kill on all-critical overflow, backlog clear on close, send-error isolation.
- `runtime.test.ts` (4 tests): eviction schedules rather than kills the watcher, reactivation cancels the pending stop, stale stops can't kill replacement watchers, eviction refuses while work is pending.
- `bun run check` 12/12 green; full `src/websocket/` suite shows only the same 4 pre-existing failures as base (app-server native websocket ×3, remote-settings cwd repair).

🤖 Generated with [Claude Code](https://claude.com/claude-code)