### PR TITLE
feat(cron): bind channel targets before scheduled turns

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -47,6 +47,6 @@
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1030,
   "src/websocket/listener/lifecycle.ts": 1779,
-  "src/websocket/listener/protocol-inbound.ts": 2290,
+  "src/websocket/listener/protocol-inbound.ts": 2137,
   "src/websocket/listener/protocol-outbound.ts": 1128
 }

--- a/src/channels/service-accounts.ts
+++ b/src/channels/service-accounts.ts
@@ -14,16 +14,13 @@ import {
   createAccountFromPatch,
   mergeAccountPatch,
 } from "./service-account-model";
-import {
-  assertSupportedChannelId,
-  getErrorMessage,
-  refreshLoadedMessageChannelTool,
-} from "./service-shared";
+import { assertSupportedChannelId, getErrorMessage } from "./service-shared";
 import {
   isAccountConfigured,
   resolveChannelAccountDisplayName,
   toAccountSnapshot,
 } from "./service-snapshots";
+import { refreshLoadedMessageChannelTool } from "./service-tools";
 import type { ChannelAccountSnapshot } from "./service-types";
 import { loadTargetStore, removeChannelTargetsForAccount } from "./targets";
 import type { ChannelAccount } from "./types";

--- a/src/channels/service-route-bindings.test.ts
+++ b/src/channels/service-route-bindings.test.ts
@@ -1,0 +1,338 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  __testOverrideLoadChannelAccounts,
+  __testOverrideSaveChannelAccounts,
+  clearChannelAccountStores,
+  getChannelAccount,
+  upsertChannelAccount,
+} from "@/channels/accounts";
+import {
+  __testOverrideLoadRoutes,
+  __testOverrideSaveRoutes,
+  addRoute,
+  clearAllRoutes,
+  getRoute,
+} from "@/channels/routing";
+import {
+  updateChannelRoutesLive,
+  validateChannelRouteTargets,
+} from "@/channels/service-route-bindings";
+import type {
+  ChannelRoute,
+  SlackChannelAccount,
+  TelegramChannelAccount,
+} from "@/channels/types";
+
+function resetState(): void {
+  clearChannelAccountStores();
+  clearAllRoutes();
+  __testOverrideLoadChannelAccounts(null);
+  __testOverrideSaveChannelAccounts(null);
+  __testOverrideLoadRoutes(null);
+  __testOverrideSaveRoutes(null);
+}
+
+beforeEach(() => {
+  resetState();
+  __testOverrideLoadChannelAccounts(() => []);
+  __testOverrideSaveChannelAccounts(() => {});
+  __testOverrideLoadRoutes(() => null);
+  __testOverrideSaveRoutes(() => {});
+});
+
+afterEach(() => {
+  resetState();
+});
+
+function seedSlackAccount(accountId: string): void {
+  upsertChannelAccount("slack", {
+    channel: "slack",
+    accountId,
+    displayName: `Slack ${accountId}`,
+    enabled: true,
+    mode: "socket",
+    botToken: `xoxb-${accountId}`,
+    appToken: `xapp-${accountId}`,
+    agentId: null,
+    dmPolicy: "open",
+    allowedUsers: [],
+    defaultPermissionMode: "standard",
+    createdAt: "2026-04-11T00:00:00.000Z",
+    updatedAt: "2026-04-11T00:00:00.000Z",
+  } satisfies SlackChannelAccount);
+}
+
+function seedTelegramAccount(accountId: string): void {
+  upsertChannelAccount("telegram", {
+    channel: "telegram",
+    accountId,
+    displayName: `Telegram ${accountId}`,
+    enabled: true,
+    token: `telegram-${accountId}`,
+    binding: {
+      agentId: "agent-old",
+      conversationId: "conv-old",
+    },
+    dmPolicy: "open",
+    allowedUsers: [],
+    createdAt: "2026-04-11T00:00:00.000Z",
+    updatedAt: "2026-04-11T00:00:00.000Z",
+  } satisfies TelegramChannelAccount);
+}
+
+function addSlackRoute(
+  route: Partial<ChannelRoute> & { chatId: string },
+): void {
+  const { chatId, ...overrides } = route;
+  addRoute("slack", {
+    accountId: "docsbot",
+    chatId,
+    chatType: "channel",
+    threadId: null,
+    agentId: "agent-old",
+    conversationId: "conv-old",
+    enabled: true,
+    outboundEnabled: true,
+    createdAt: "2026-04-11T00:00:00.000Z",
+    updatedAt: "2026-04-11T00:00:00.000Z",
+    ...overrides,
+  });
+}
+
+describe("updateChannelRoutesLive", () => {
+  test("rolls back an existing route when a later route save fails", () => {
+    seedSlackAccount("docsbot");
+    seedSlackAccount("backupbot");
+    addSlackRoute({
+      chatId: "C-existing",
+      chatType: "channel",
+      threadId: "1712790000.000100",
+      outboundEnabled: false,
+      detached: true,
+      createdAt: "2026-04-10T00:00:00.000Z",
+      updatedAt: "2026-04-10T01:00:00.000Z",
+    });
+
+    let saveCalls = 0;
+    __testOverrideSaveRoutes(() => {
+      saveCalls += 1;
+      if (saveCalls === 2) {
+        throw new Error("ENOSPC: no space left");
+      }
+    });
+
+    expect(() =>
+      updateChannelRoutesLive(
+        [
+          {
+            channelId: "slack",
+            accountId: "docsbot",
+            chatId: "C-existing",
+          },
+          {
+            channelId: "slack",
+            accountId: "backupbot",
+            chatId: "C-new-fails",
+          },
+        ],
+        "agent-new",
+        "conv-new",
+      ),
+    ).toThrow(/rolled back/i);
+
+    expect(
+      getRoute("slack", "C-existing", "docsbot", "1712790000.000100"),
+    ).toEqual(
+      expect.objectContaining({
+        accountId: "docsbot",
+        chatId: "C-existing",
+        chatType: "channel",
+        threadId: "1712790000.000100",
+        agentId: "agent-old",
+        conversationId: "conv-old",
+        outboundEnabled: false,
+        detached: true,
+        createdAt: "2026-04-10T00:00:00.000Z",
+        updatedAt: "2026-04-10T01:00:00.000Z",
+      }),
+    );
+    expect(getRoute("slack", "C-new-fails", "backupbot")).toBeNull();
+  });
+
+  test("removes a newly-created earlier route when a later route save fails", () => {
+    seedSlackAccount("docsbot");
+    seedSlackAccount("backupbot");
+
+    let saveCalls = 0;
+    __testOverrideSaveRoutes(() => {
+      saveCalls += 1;
+      if (saveCalls === 2) {
+        throw new Error("EIO: disk write failed");
+      }
+    });
+
+    expect(() =>
+      updateChannelRoutesLive(
+        [
+          {
+            channelId: "slack",
+            accountId: "docsbot",
+            chatId: "C-created",
+          },
+          {
+            channelId: "slack",
+            accountId: "backupbot",
+            chatId: "C-fails",
+          },
+        ],
+        "agent-new",
+        "conv-new",
+      ),
+    ).toThrow(/rolled back/i);
+
+    expect(getRoute("slack", "C-created", "docsbot")).toBeNull();
+    expect(getRoute("slack", "C-fails", "backupbot")).toBeNull();
+  });
+
+  test("dedupes duplicate targets before mutating", () => {
+    seedSlackAccount("docsbot");
+    let saveCalls = 0;
+    __testOverrideSaveRoutes(() => {
+      saveCalls += 1;
+    });
+
+    const snapshots = updateChannelRoutesLive(
+      [
+        {
+          channelId: "slack",
+          accountId: "docsbot",
+          chatId: "C-dedupe",
+        },
+        {
+          channelId: "slack",
+          accountId: "docsbot",
+          chatId: "C-dedupe",
+        },
+      ],
+      "agent-new",
+      "conv-new",
+    );
+
+    expect(snapshots).toHaveLength(1);
+    expect(saveCalls).toBe(1);
+    expect(getRoute("slack", "C-dedupe", "docsbot")).toMatchObject({
+      agentId: "agent-new",
+      conversationId: "conv-new",
+    });
+  });
+
+  test("rolls back Telegram account binding with the route batch", () => {
+    seedTelegramAccount("telegram-bot");
+    seedSlackAccount("docsbot");
+
+    let saveCalls = 0;
+    __testOverrideSaveRoutes(() => {
+      saveCalls += 1;
+      if (saveCalls === 2) {
+        throw new Error("EIO: disk write failed");
+      }
+    });
+
+    expect(() =>
+      updateChannelRoutesLive(
+        [
+          {
+            channelId: "telegram",
+            accountId: "telegram-bot",
+            chatId: "8450770457",
+          },
+          {
+            channelId: "slack",
+            accountId: "docsbot",
+            chatId: "C-fails",
+          },
+        ],
+        "agent-new",
+        "conv-new",
+      ),
+    ).toThrow(/rolled back/i);
+
+    expect(getRoute("telegram", "8450770457", "telegram-bot")).toBeNull();
+    expect(getRoute("slack", "C-fails", "docsbot")).toBeNull();
+    expect(getChannelAccount("telegram", "telegram-bot")).toMatchObject({
+      binding: {
+        agentId: "agent-old",
+        conversationId: "conv-old",
+      },
+    });
+  });
+
+  test("binds the root route without moving sibling thread routes", () => {
+    seedSlackAccount("docsbot");
+    addSlackRoute({ chatId: "C-with-threads", threadId: null });
+    addSlackRoute({
+      chatId: "C-with-threads",
+      threadId: "1712790000.000100",
+      conversationId: "conv-thread",
+    });
+
+    updateChannelRoutesLive(
+      [
+        {
+          channelId: "slack",
+          accountId: "docsbot",
+          chatId: "C-with-threads",
+          threadId: null,
+        },
+      ],
+      "agent-new",
+      "conv-new",
+    );
+
+    expect(getRoute("slack", "C-with-threads", "docsbot", null)).toMatchObject({
+      agentId: "agent-new",
+      conversationId: "conv-new",
+    });
+    expect(
+      getRoute("slack", "C-with-threads", "docsbot", "1712790000.000100"),
+    ).toMatchObject({
+      agentId: "agent-old",
+      conversationId: "conv-thread",
+    });
+  });
+
+  test("rejects a stale explicit account before scheduling work", () => {
+    addSlackRoute({ chatId: "C-stale", accountId: "deleted-account" });
+
+    expect(() =>
+      validateChannelRouteTargets([
+        {
+          channelId: "slack",
+          accountId: "deleted-account",
+          chatId: "C-stale",
+          threadId: null,
+        },
+      ]),
+    ).toThrow(/was not found/i);
+  });
+
+  test("rejects routes that are disabled for outbound messaging", () => {
+    seedSlackAccount("docsbot");
+    addSlackRoute({
+      chatId: "C-listen-only",
+      threadId: null,
+      outboundEnabled: false,
+    });
+
+    expect(() =>
+      validateChannelRouteTargets([
+        {
+          channelId: "slack",
+          accountId: "docsbot",
+          chatId: "C-listen-only",
+          threadId: null,
+        },
+      ]),
+    ).toThrow(/not enabled for outbound/i);
+  });
+});

--- a/src/channels/service-route-bindings.ts
+++ b/src/channels/service-route-bindings.ts
@@ -1,0 +1,395 @@
+import {
+  getChannelAccount,
+  LEGACY_CHANNEL_ACCOUNT_ID,
+  upsertChannelAccount,
+} from "./accounts";
+import {
+  addRoute,
+  getRoutesForChannel,
+  loadRoutes,
+  removeRoute,
+  removeRouteInMemory,
+  setRouteInMemory,
+} from "./routing";
+import {
+  assertSupportedChannelId,
+  getErrorMessage,
+  getSelectedChannelAccount,
+} from "./service-shared";
+import type { ChannelRouteSnapshot } from "./service-types";
+import type { ChannelAccount, ChannelRoute } from "./types";
+import { isTelegramChannelAccount } from "./types";
+
+export interface ChannelRouteBindingTarget {
+  channelId: string;
+  chatId: string;
+  accountId?: string;
+  threadId?: string | null;
+}
+
+interface PreparedRouteBinding {
+  target: ChannelRouteBindingTarget;
+  resolvedAccountId?: string;
+  existingRoute: ChannelRoute | null;
+  existingAccount: ChannelAccount | null;
+}
+
+function getSelectedRouteByChatId(
+  channelId: string,
+  chatId: string,
+  accountId?: string,
+  threadId?: string | null,
+): ChannelRoute | null {
+  const matches = getRoutesForChannel(channelId, accountId).filter(
+    (route) =>
+      route.chatId === chatId &&
+      (threadId === undefined
+        ? true
+        : (route.threadId ?? null) === (threadId ?? null)),
+  );
+  if (matches.length === 0) {
+    return null;
+  }
+  if (matches.length === 1) {
+    return matches[0] ?? null;
+  }
+
+  throw new Error(
+    `Channel "${channelId}" has multiple routes for chat "${chatId}". Specify account_id.`,
+  );
+}
+
+function toRouteSnapshot(
+  channelId: string,
+  route: ChannelRoute,
+): ChannelRouteSnapshot {
+  return {
+    channelId,
+    accountId: route.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID,
+    chatId: route.chatId,
+    chatType: route.chatType,
+    threadId: route.threadId ?? null,
+    agentId: route.agentId,
+    conversationId: route.conversationId,
+    enabled: route.enabled,
+    outboundEnabled: route.outboundEnabled !== false,
+    createdAt: route.createdAt,
+    updatedAt: route.updatedAt ?? route.createdAt,
+  };
+}
+
+function cloneRoute(route: ChannelRoute): ChannelRoute {
+  return { ...route };
+}
+
+function cloneChannelAccount(account: ChannelAccount): ChannelAccount {
+  return structuredClone(account);
+}
+
+function routeBindingKey(binding: PreparedRouteBinding): string {
+  const threadId =
+    binding.target.threadId === undefined
+      ? (binding.existingRoute?.threadId ?? "__root__")
+      : (binding.target.threadId ?? "__root__");
+  return [
+    binding.target.channelId,
+    binding.resolvedAccountId ?? "",
+    binding.target.chatId,
+    threadId,
+  ].join("\0");
+}
+
+function prepareRouteBinding(
+  target: ChannelRouteBindingTarget,
+): PreparedRouteBinding {
+  assertSupportedChannelId(target.channelId);
+  loadRoutes(target.channelId);
+
+  const existingRoute = getSelectedRouteByChatId(
+    target.channelId,
+    target.chatId,
+    target.accountId,
+    target.threadId,
+  );
+  const selectedAccount = existingRoute
+    ? null
+    : getSelectedChannelAccount(target.channelId, target.accountId);
+  if (!existingRoute && !selectedAccount) {
+    throw new Error(
+      target.accountId
+        ? `Channel account "${target.accountId}" was not found for ${target.channelId}.`
+        : `Channel "${target.channelId}" is not configured. Configure it first.`,
+    );
+  }
+
+  const resolvedAccountId =
+    existingRoute?.accountId ?? selectedAccount?.accountId ?? target.accountId;
+  const existingAccount = resolvedAccountId
+    ? getChannelAccount(target.channelId, resolvedAccountId)
+    : null;
+
+  if (!existingRoute && !existingAccount) {
+    throw new Error(
+      `Channel account "${resolvedAccountId}" was not found for ${target.channelId}.`,
+    );
+  }
+
+  return {
+    target,
+    resolvedAccountId,
+    existingRoute: existingRoute ? cloneRoute(existingRoute) : null,
+    existingAccount: existingAccount
+      ? cloneChannelAccount(existingAccount)
+      : null,
+  };
+}
+
+function restoreAppliedRouteBindings(
+  applied: PreparedRouteBinding[],
+): string[] {
+  const rollbackErrors: string[] = [];
+
+  for (const binding of applied.toReversed()) {
+    const { target, resolvedAccountId, existingRoute, existingAccount } =
+      binding;
+    try {
+      if (existingRoute) {
+        addRoute(target.channelId, existingRoute);
+      } else {
+        removeRoute(
+          target.channelId,
+          target.chatId,
+          resolvedAccountId,
+          target.threadId ?? null,
+        );
+      }
+    } catch (rollbackError) {
+      rollbackErrors.push(
+        getErrorMessage(rollbackError, "Route rollback failed"),
+      );
+    }
+
+    if (existingAccount && isTelegramChannelAccount(existingAccount)) {
+      try {
+        upsertChannelAccount(target.channelId, existingAccount);
+      } catch (rollbackError) {
+        rollbackErrors.push(
+          getErrorMessage(rollbackError, "Account rollback failed"),
+        );
+      }
+    }
+  }
+
+  return rollbackErrors;
+}
+
+function rollbackAppliedRouteBindings(
+  applied: PreparedRouteBinding[],
+  cause: unknown,
+): never {
+  const rollbackErrors = restoreAppliedRouteBindings(applied);
+
+  const rollbackSuffix =
+    rollbackErrors.length > 0
+      ? ` Rollback errors: ${rollbackErrors.join("; ")}`
+      : " Changes were rolled back.";
+  throw new Error(
+    `Failed to update channel routes: ${getErrorMessage(
+      cause,
+      "Failed to update route",
+    )}.${rollbackSuffix}`,
+    { cause },
+  );
+}
+
+export function updateChannelRouteLive(
+  channelId: string,
+  chatId: string,
+  agentId: string,
+  conversationId: string,
+  accountId?: string,
+  threadId?: string | null,
+): ChannelRouteSnapshot {
+  const binding = prepareRouteBinding({
+    channelId,
+    chatId,
+    accountId,
+    threadId,
+  });
+  const { resolvedAccountId, existingRoute, existingAccount } = binding;
+
+  if (existingAccount && isTelegramChannelAccount(existingAccount)) {
+    upsertChannelAccount(channelId, {
+      ...existingAccount,
+      binding: {
+        agentId,
+        conversationId,
+      },
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  const updatedRoute: ChannelRoute = {
+    ...(existingRoute ?? {
+      accountId: resolvedAccountId,
+      chatId,
+      ...(threadId !== undefined ? { threadId } : {}),
+      enabled: true,
+      createdAt: new Date().toISOString(),
+    }),
+    agentId,
+    conversationId,
+    outboundEnabled: existingRoute?.outboundEnabled ?? true,
+    updatedAt: new Date().toISOString(),
+  };
+
+  try {
+    addRoute(channelId, updatedRoute);
+  } catch (error) {
+    removeRouteInMemory(
+      channelId,
+      chatId,
+      resolvedAccountId,
+      existingRoute ? (existingRoute.threadId ?? null) : threadId,
+    );
+    if (existingRoute) {
+      setRouteInMemory(channelId, existingRoute);
+    }
+
+    if (existingAccount && isTelegramChannelAccount(existingAccount)) {
+      try {
+        upsertChannelAccount(channelId, existingAccount);
+      } catch (rollbackError) {
+        throw new Error(
+          `Failed to update channel route: ${getErrorMessage(
+            error,
+            "Failed to save route",
+          )}. Failed to restore account binding: ${getErrorMessage(
+            rollbackError,
+            "Account rollback failed",
+          )}`,
+        );
+      }
+    }
+
+    throw new Error(
+      `Failed to update channel route: ${getErrorMessage(
+        error,
+        "Failed to save route",
+      )}. Changes were rolled back.`,
+    );
+  }
+
+  return toRouteSnapshot(channelId, updatedRoute);
+}
+
+function prepareRouteBindings(
+  targets: ChannelRouteBindingTarget[],
+): PreparedRouteBinding[] {
+  const dedupedBindings: PreparedRouteBinding[] = [];
+  const seen = new Set<string>();
+
+  for (const target of targets) {
+    const binding = prepareRouteBinding(target);
+    const key = routeBindingKey(binding);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    dedupedBindings.push(binding);
+  }
+
+  return dedupedBindings;
+}
+
+export function withChannelRouteBindingsLive<T>(
+  targets: ChannelRouteBindingTarget[],
+  agentId: string,
+  conversationId: string,
+  operation: (snapshots: ChannelRouteSnapshot[]) => T,
+  rollbackResult?: (result: T) => boolean,
+): T {
+  const bindings = prepareRouteBindings(targets);
+  const applied: PreparedRouteBinding[] = [];
+  const snapshots: ChannelRouteSnapshot[] = [];
+  try {
+    for (const binding of bindings) {
+      const snapshot = updateChannelRouteLive(
+        binding.target.channelId,
+        binding.target.chatId,
+        agentId,
+        conversationId,
+        binding.resolvedAccountId,
+        binding.target.threadId,
+      );
+      applied.push(binding);
+      snapshots.push(snapshot);
+    }
+  } catch (error) {
+    rollbackAppliedRouteBindings(applied, error);
+  }
+
+  let result: T;
+  try {
+    result = operation(snapshots);
+  } catch (error) {
+    rollbackAppliedRouteBindings(applied, error);
+  }
+
+  if (rollbackResult?.(result)) {
+    const rollbackErrors = restoreAppliedRouteBindings(applied);
+    if (rollbackErrors.length > 0) {
+      throw new Error(
+        `Channel route rollback failed: ${rollbackErrors.join("; ")}`,
+      );
+    }
+  }
+
+  return result;
+}
+
+export function updateChannelRoutesLive(
+  targets: ChannelRouteBindingTarget[],
+  agentId: string,
+  conversationId: string,
+): ChannelRouteSnapshot[] {
+  return withChannelRouteBindingsLive(
+    targets,
+    agentId,
+    conversationId,
+    (snapshots) => snapshots,
+  );
+}
+
+export function validateChannelRouteTargets(
+  targets: ChannelRouteBindingTarget[],
+): ChannelRouteBindingTarget[] {
+  const validatedTargets: ChannelRouteBindingTarget[] = [];
+  for (const target of targets) {
+    const binding = prepareRouteBinding(target);
+    if (target.accountId && !binding.existingAccount) {
+      throw new Error(
+        `Channel account "${target.accountId}" was not found for ${target.channelId}.`,
+      );
+    }
+    if (binding.existingAccount && !binding.existingAccount.enabled) {
+      throw new Error(
+        `Channel account "${binding.resolvedAccountId}" is disabled for ${target.channelId}.`,
+      );
+    }
+    if (
+      binding.existingRoute &&
+      (!binding.existingRoute.enabled ||
+        binding.existingRoute.outboundEnabled === false)
+    ) {
+      throw new Error(
+        `Channel route "${target.chatId}" is not enabled for outbound messaging.`,
+      );
+    }
+    validatedTargets.push({
+      ...target,
+      ...(binding.resolvedAccountId
+        ? { accountId: binding.resolvedAccountId }
+        : {}),
+    });
+  }
+  return validatedTargets;
+}

--- a/src/channels/service-routes.ts
+++ b/src/channels/service-routes.ts
@@ -1,8 +1,4 @@
-import {
-  getChannelAccount,
-  LEGACY_CHANNEL_ACCOUNT_ID,
-  upsertChannelAccount,
-} from "./accounts";
+import { LEGACY_CHANNEL_ACCOUNT_ID } from "./accounts";
 import { getPendingPairings, loadPairingStore } from "./pairing";
 import { completePairing } from "./registry";
 import {
@@ -12,13 +8,8 @@ import {
   loadRoutes,
   removeRoute,
   removeRouteInMemory,
-  setRouteInMemory,
 } from "./routing";
-import {
-  assertSupportedChannelId,
-  getErrorMessage,
-  getSelectedChannelAccount,
-} from "./service-shared";
+import { assertSupportedChannelId, getErrorMessage } from "./service-shared";
 import type {
   ChannelRouteSnapshot,
   ChannelTargetSnapshot,
@@ -35,7 +26,8 @@ import type {
   ChannelRoute,
   PendingPairing,
 } from "./types";
-import { isTelegramChannelAccount } from "./types";
+
+export { updateChannelRouteLive } from "./service-route-bindings";
 
 function getSelectedRouteByChatId(
   channelId: string,
@@ -276,104 +268,6 @@ export function bindChannelTarget(
     chatId: route.chatId,
     route: toRouteSnapshot(channelId, route),
   };
-}
-
-export function updateChannelRouteLive(
-  channelId: string,
-  chatId: string,
-  agentId: string,
-  conversationId: string,
-  accountId?: string,
-): ChannelRouteSnapshot {
-  assertSupportedChannelId(channelId);
-  loadRoutes(channelId);
-
-  const existingRoute = getSelectedRouteByChatId(channelId, chatId, accountId);
-  const selectedAccount = existingRoute
-    ? null
-    : getSelectedChannelAccount(channelId, accountId);
-  if (!existingRoute && !selectedAccount) {
-    throw new Error(
-      accountId
-        ? `Channel account "${accountId}" was not found for ${channelId}.`
-        : `Channel "${channelId}" is not configured. Configure it first.`,
-    );
-  }
-
-  const resolvedAccountId =
-    existingRoute?.accountId ?? selectedAccount?.accountId ?? accountId;
-  const existingAccount = resolvedAccountId
-    ? getChannelAccount(channelId, resolvedAccountId)
-    : null;
-
-  if (!existingRoute && !existingAccount) {
-    throw new Error(
-      `Channel account "${resolvedAccountId}" was not found for ${channelId}.`,
-    );
-  }
-
-  if (existingAccount && isTelegramChannelAccount(existingAccount)) {
-    upsertChannelAccount(channelId, {
-      ...existingAccount,
-      binding: {
-        agentId,
-        conversationId,
-      },
-      updatedAt: new Date().toISOString(),
-    });
-  }
-
-  const updatedRoute: ChannelRoute = {
-    ...(existingRoute ?? {
-      accountId: resolvedAccountId,
-      chatId,
-      enabled: true,
-      createdAt: new Date().toISOString(),
-    }),
-    agentId,
-    conversationId,
-    outboundEnabled: existingRoute?.outboundEnabled ?? true,
-    updatedAt: new Date().toISOString(),
-  };
-
-  try {
-    addRoute(channelId, updatedRoute);
-  } catch (error) {
-    removeRouteInMemory(
-      channelId,
-      chatId,
-      resolvedAccountId,
-      existingRoute?.threadId,
-    );
-    if (existingRoute) {
-      setRouteInMemory(channelId, existingRoute);
-    }
-
-    if (existingAccount && isTelegramChannelAccount(existingAccount)) {
-      try {
-        upsertChannelAccount(channelId, existingAccount);
-      } catch (rollbackError) {
-        throw new Error(
-          `Failed to update channel route: ${getErrorMessage(
-            error,
-            "Failed to save route",
-          )}. Failed to restore account binding: ${getErrorMessage(
-            rollbackError,
-            "Account rollback failed",
-          )}`,
-        );
-      }
-    }
-
-    throw new Error(
-      `Failed to update channel route: ${getErrorMessage(
-        error,
-        "Failed to save route",
-      )}. Changes were rolled back.`,
-    );
-  }
-
-  return toRouteSnapshot(channelId, updatedRoute);
 }
 
 export function listChannelRouteSnapshots(params?: {

--- a/src/channels/service-runtime.ts
+++ b/src/channels/service-runtime.ts
@@ -16,13 +16,13 @@ import {
 import {
   assertSupportedChannelId,
   getSelectedChannelAccountWithSecrets,
-  refreshLoadedMessageChannelTool,
 } from "./service-shared";
 import {
   getChannelConfigSnapshotWithSecrets,
   isAccountConfigured,
   listChannelSummaries,
 } from "./service-snapshots";
+import { refreshLoadedMessageChannelTool } from "./service-tools";
 import type { ChannelConfigSnapshot, ChannelSummary } from "./service-types";
 import {
   isDiscordChannelAccount,

--- a/src/channels/service-shared.ts
+++ b/src/channels/service-shared.ts
@@ -1,4 +1,3 @@
-import { refreshDynamicChannelToolsInLoadedRegistry } from "@/tools/manager";
 import {
   getChannelAccount,
   getChannelAccountWithSecrets,
@@ -7,10 +6,6 @@ import {
 } from "./accounts";
 import { isSupportedChannelId } from "./plugin-registry";
 import type { ChannelAccount, SupportedChannelId } from "./types";
-
-export async function refreshLoadedMessageChannelTool(): Promise<void> {
-  await refreshDynamicChannelToolsInLoadedRegistry();
-}
 
 export function assertSupportedChannelId(
   channelId: string,

--- a/src/channels/service-tools.ts
+++ b/src/channels/service-tools.ts
@@ -1,0 +1,5 @@
+import { refreshDynamicChannelToolsInLoadedRegistry } from "@/tools/manager";
+
+export async function refreshLoadedMessageChannelTool(): Promise<void> {
+  await refreshDynamicChannelToolsInLoadedRegistry();
+}

--- a/src/cron/channel-targets.test.ts
+++ b/src/cron/channel-targets.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import {
+  __testOverrideLoadChannelAccounts,
+  __testOverrideSaveChannelAccounts,
+  clearChannelAccountStores,
+  upsertChannelAccount,
+} from "@/channels/accounts";
+import {
+  __testOverrideLoadRoutes,
+  __testOverrideSaveRoutes,
+  clearAllRoutes,
+  getRoute,
+} from "@/channels/routing";
+import type { SlackChannelAccount } from "@/channels/types";
+import { type CronPromptQueueItem, QueueRuntime } from "@/queue/queue-runtime";
+import {
+  enqueueCronPromptWithChannelTargets,
+  validateCronChannelTargets,
+} from "./channel-targets";
+import { addTask, type CronTask } from "./cron-file";
+
+const TEST_DIR = path.join(import.meta.dir, ".test-cron-channel-targets");
+const originalLettaHome = process.env.LETTA_HOME;
+
+function resetState(): void {
+  clearChannelAccountStores();
+  clearAllRoutes();
+  __testOverrideLoadChannelAccounts(null);
+  __testOverrideSaveChannelAccounts(null);
+  __testOverrideLoadRoutes(null);
+  __testOverrideSaveRoutes(null);
+}
+
+beforeEach(() => {
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  mkdirSync(TEST_DIR, { recursive: true });
+  process.env.LETTA_HOME = TEST_DIR;
+  resetState();
+  __testOverrideLoadChannelAccounts(() => []);
+  __testOverrideSaveChannelAccounts(() => {});
+  __testOverrideLoadRoutes(() => null);
+  __testOverrideSaveRoutes(() => {});
+});
+
+afterEach(() => {
+  resetState();
+  if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  if (originalLettaHome) process.env.LETTA_HOME = originalLettaHome;
+  else delete process.env.LETTA_HOME;
+});
+
+function seedSlackAccount(accountId: string): void {
+  upsertChannelAccount("slack", {
+    channel: "slack",
+    accountId,
+    displayName: `Slack ${accountId}`,
+    enabled: true,
+    mode: "socket",
+    botToken: `xoxb-${accountId}`,
+    appToken: `xapp-${accountId}`,
+    agentId: null,
+    dmPolicy: "open",
+    allowedUsers: [],
+    defaultPermissionMode: "standard",
+    createdAt: "2026-04-11T00:00:00.000Z",
+    updatedAt: "2026-04-11T00:00:00.000Z",
+  } satisfies SlackChannelAccount);
+}
+
+function makeTask(targets: NonNullable<CronTask["channel_targets"]>): CronTask {
+  return addTask({
+    agent_id: "agent-1",
+    conversation_id: "new",
+    name: "Daily check-in",
+    description: "",
+    cron: "0 9 * * *",
+    timezone: "UTC",
+    recurring: true,
+    prompt: "Check in",
+    channel_targets: targets,
+  }).task;
+}
+
+function enqueueForConversation(
+  queueRuntime: QueueRuntime,
+  task: CronTask,
+  conversationId: string,
+) {
+  return enqueueCronPromptWithChannelTargets({
+    queueRuntime,
+    task,
+    conversationId,
+    getAdapter: () => ({ isRunning: () => true }),
+    queueItem: {
+      kind: "cron_prompt",
+      source: "cron",
+      text: "scheduled prompt",
+      cronTaskId: task.id,
+      agentId: task.agent_id,
+      conversationId,
+    },
+  });
+}
+
+describe("cron channel targets", () => {
+  test("validates before conversation creation without moving routes", () => {
+    seedSlackAccount("workspace-1");
+    const task = makeTask([
+      {
+        channel_id: "slack",
+        account_id: "workspace-1",
+        chat_id: "C123",
+      },
+    ]);
+
+    validateCronChannelTargets(task, () => ({ isRunning: () => true }));
+
+    expect(getRoute("slack", "C123", "workspace-1", null)).toBeNull();
+  });
+
+  test("resolves an omitted account id before checking runtime readiness", () => {
+    seedSlackAccount("workspace-1");
+    const task = makeTask([
+      {
+        channel_id: "slack",
+        chat_id: "C123",
+      },
+    ]);
+    const checkedAccountIds: Array<string | undefined> = [];
+
+    validateCronChannelTargets(task, (_channelId, accountId) => {
+      checkedAccountIds.push(accountId);
+      return { isRunning: () => true };
+    });
+
+    expect(checkedAccountIds).toEqual(["workspace-1"]);
+  });
+
+  test("binds every target before the queued prompt can be consumed", () => {
+    seedSlackAccount("workspace-1");
+    seedSlackAccount("workspace-2");
+    const task = makeTask([
+      {
+        channel_id: "slack",
+        account_id: "workspace-1",
+        chat_id: "C123",
+      },
+      {
+        channel_id: "slack",
+        account_id: "workspace-2",
+        chat_id: "C456",
+      },
+    ]);
+    const queueRuntime = new QueueRuntime();
+
+    const queuedItem = enqueueForConversation(
+      queueRuntime,
+      task,
+      "conv-created",
+    );
+
+    expect(queuedItem).not.toBeNull();
+    expect(getRoute("slack", "C123", "workspace-1", null)).toMatchObject({
+      agentId: "agent-1",
+      conversationId: "conv-created",
+    });
+    expect(getRoute("slack", "C456", "workspace-2", null)).toMatchObject({
+      agentId: "agent-1",
+      conversationId: "conv-created",
+    });
+    expect(queueRuntime.tryDequeue(null)?.items).toEqual([
+      expect.objectContaining({
+        id: queuedItem?.id,
+        conversationId: "conv-created",
+      }),
+    ]);
+  });
+
+  test("removes the queued prompt and rolls routes back when binding fails", () => {
+    seedSlackAccount("workspace-1");
+    seedSlackAccount("workspace-2");
+    const task = makeTask([
+      {
+        channel_id: "slack",
+        account_id: "workspace-1",
+        chat_id: "C123",
+      },
+      {
+        channel_id: "slack",
+        account_id: "workspace-2",
+        chat_id: "C456",
+      },
+    ]);
+    const queueRuntime = new QueueRuntime();
+    let saveCalls = 0;
+    __testOverrideSaveRoutes(() => {
+      saveCalls += 1;
+      if (saveCalls === 2) throw new Error("EIO: disk write failed");
+    });
+
+    expect(() =>
+      enqueueForConversation(queueRuntime, task, "conv-created"),
+    ).toThrow(/rolled back/i);
+
+    expect(queueRuntime.length).toBe(0);
+    expect(getRoute("slack", "C123", "workspace-1", null)).toBeNull();
+    expect(getRoute("slack", "C456", "workspace-2", null)).toBeNull();
+  });
+
+  test("restores routes and preserves the existing queue when the queue is full", () => {
+    seedSlackAccount("workspace-1");
+    const task = makeTask([
+      {
+        channel_id: "slack",
+        account_id: "workspace-1",
+        chat_id: "C123",
+      },
+    ]);
+    const queueRuntime = new QueueRuntime({ maxItems: 1, hardMaxItems: 1 });
+    const existingItem = queueRuntime.enqueue({
+      kind: "cron_prompt",
+      source: "cron",
+      text: "already queued",
+      cronTaskId: "existing-task",
+      agentId: "agent-1",
+      conversationId: "conv-existing",
+    } as Omit<CronPromptQueueItem, "id" | "enqueuedAt">);
+    if (!existingItem) throw new Error("expected initial queued item");
+
+    expect(
+      enqueueForConversation(queueRuntime, task, "conv-created"),
+    ).toBeNull();
+
+    expect(queueRuntime.items).toHaveLength(1);
+    expect(queueRuntime.items[0]?.id).toBe(existingItem.id);
+    expect(getRoute("slack", "C123", "workspace-1", null)).toBeNull();
+  });
+
+  test("does not bind or enqueue when a selected channel runtime is stopped", () => {
+    seedSlackAccount("workspace-1");
+    const task = makeTask([
+      {
+        channel_id: "slack",
+        account_id: "workspace-1",
+        chat_id: "C123",
+      },
+    ]);
+    const queueRuntime = new QueueRuntime();
+
+    expect(() =>
+      validateCronChannelTargets(task, () => ({ isRunning: () => false })),
+    ).toThrow(/not running/i);
+    expect(() =>
+      enqueueCronPromptWithChannelTargets({
+        queueRuntime,
+        task,
+        conversationId: "conv-created",
+        getAdapter: () => ({ isRunning: () => false }),
+        queueItem: {
+          kind: "cron_prompt",
+          source: "cron",
+          text: "scheduled prompt",
+          cronTaskId: task.id,
+          agentId: task.agent_id,
+          conversationId: "conv-created",
+        },
+      }),
+    ).toThrow(/not running/i);
+
+    expect(queueRuntime.length).toBe(0);
+    expect(getRoute("slack", "C123", "workspace-1", null)).toBeNull();
+  });
+});

--- a/src/cron/channel-targets.ts
+++ b/src/cron/channel-targets.ts
@@ -1,0 +1,72 @@
+import {
+  type ChannelRouteBindingTarget,
+  validateChannelRouteTargets,
+  withChannelRouteBindingsLive,
+} from "@/channels/service-route-bindings";
+import type { CronPromptQueueItem, QueueRuntime } from "@/queue/queue-runtime";
+import type { CronTask } from "./cron-file";
+
+type CronChannelAdapterLookup = (
+  channelId: string,
+  accountId?: string,
+) => { isRunning(): boolean } | null;
+
+function getCronChannelRouteTargets(task: CronTask) {
+  return (task.channel_targets ?? []).map((target) => ({
+    channelId: target.channel_id,
+    accountId: target.account_id,
+    chatId: target.chat_id,
+    threadId: null,
+  }));
+}
+
+function assertCronChannelAdaptersRunning(
+  targets: ChannelRouteBindingTarget[],
+  getAdapter: CronChannelAdapterLookup,
+): void {
+  for (const target of targets) {
+    if (!getAdapter(target.channelId, target.accountId)?.isRunning()) {
+      throw new Error(
+        `Channel account "${target.accountId ?? "default"}" is not running for ${target.channelId}.`,
+      );
+    }
+  }
+}
+
+export function validateCronChannelTargets(
+  task: CronTask,
+  getAdapter: CronChannelAdapterLookup,
+): void {
+  const targets = validateChannelRouteTargets(getCronChannelRouteTargets(task));
+  assertCronChannelAdaptersRunning(targets, getAdapter);
+}
+
+export function enqueueCronPromptWithChannelTargets(params: {
+  queueRuntime: QueueRuntime;
+  queueItem: Omit<CronPromptQueueItem, "id" | "enqueuedAt">;
+  task: CronTask;
+  conversationId: string;
+  getAdapter: CronChannelAdapterLookup;
+}): CronPromptQueueItem | null {
+  const targets = validateChannelRouteTargets(
+    getCronChannelRouteTargets(params.task),
+  );
+  if (targets.length === 0) {
+    return params.queueRuntime.enqueue(
+      params.queueItem,
+    ) as CronPromptQueueItem | null;
+  }
+
+  assertCronChannelAdaptersRunning(targets, params.getAdapter);
+
+  return withChannelRouteBindingsLive(
+    targets,
+    params.task.agent_id,
+    params.conversationId,
+    () =>
+      params.queueRuntime.enqueue(
+        params.queueItem,
+      ) as CronPromptQueueItem | null,
+    (queuedItem) => queuedItem === null,
+  );
+}

--- a/src/cron/cron-file.test.ts
+++ b/src/cron/cron-file.test.ts
@@ -98,6 +98,87 @@ describe("addTask", () => {
     expect(result.task.conversation_id).toBe("new");
   });
 
+  test("persists channel targets only when provided", () => {
+    const legacy = addTask(makeInput());
+    expect(legacy.task.channel_targets).toBeUndefined();
+
+    const result = addTask(
+      makeInput({
+        channel_targets: [
+          {
+            channel_id: "discord",
+            account_id: "acct-1",
+            chat_id: "chat-1",
+            label: "Ops room",
+          },
+          {
+            channel_id: "discord",
+            chat_id: "chat-2",
+          },
+        ],
+      }),
+    );
+
+    expect(result.task.channel_targets).toEqual([
+      {
+        channel_id: "discord",
+        account_id: "acct-1",
+        chat_id: "chat-1",
+        label: "Ops room",
+      },
+      {
+        channel_id: "discord",
+        chat_id: "chat-2",
+      },
+    ]);
+    expect(getTask(legacy.task.id)?.channel_targets).toBeUndefined();
+    expect(getTask(result.task.id)?.channel_targets).toEqual(
+      result.task.channel_targets,
+    );
+  });
+
+  test("normalizes empty persisted channel target arrays away", () => {
+    const { task } = addTask(makeInput());
+    const data = readCronFile();
+    const persistedTask = data.tasks.find(
+      (candidate) => candidate.id === task.id,
+    );
+    if (!persistedTask) throw new Error("expected persisted task");
+    persistedTask.channel_targets = [];
+    writeFileSync(_CRON_PATH, JSON.stringify(data, null, 2));
+
+    expect(readCronFile().tasks[0]?.channel_targets).toBeUndefined();
+  });
+
+  test("updates and clears persisted channel targets", () => {
+    const { task } = addTask(makeInput());
+
+    expect(
+      updateTask(task.id, (current) => {
+        current.channel_targets = [
+          {
+            channel_id: "slack",
+            account_id: "workspace-1",
+            chat_id: "C123",
+          },
+        ];
+      })?.channel_targets,
+    ).toEqual([
+      {
+        channel_id: "slack",
+        account_id: "workspace-1",
+        chat_id: "C123",
+      },
+    ]);
+
+    expect(
+      updateTask(task.id, (current) => {
+        current.channel_targets = [];
+      })?.channel_targets,
+    ).toBeUndefined();
+    expect(getTask(task.id)?.channel_targets).toBeUndefined();
+  });
+
   test("creates a one-shot task", () => {
     const scheduledFor = new Date(Date.now() + 60000);
     const result = addTask(

--- a/src/cron/cron-file.ts
+++ b/src/cron/cron-file.ts
@@ -19,6 +19,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import type { CronChannelTarget } from "@/types/cron-channel-target";
 import { estimatePeriodMs, isValidCron } from "./parse-interval";
 
 // ── Types ───────────────────────────────────────────────────────────
@@ -36,6 +37,8 @@ export type CronRunReason =
   | "task_cancelled"
   | "invalid_cron"
   | "scheduler_error";
+
+export type { CronChannelTarget } from "@/types/cron-channel-target";
 
 export interface SchedulerOwner {
   pid: number;
@@ -56,6 +59,8 @@ export interface CronTask {
    * - any other string: enqueue into that existing conversation id
    */
   conversation_id: string;
+  /** Optional channel destinations to bind before the scheduled turn starts. */
+  channel_targets?: CronChannelTarget[];
 
   // Metadata
   name: string;
@@ -139,8 +144,47 @@ function emptyFile(): CronFileData {
   };
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeCronChannelTargets(
+  value: unknown,
+): CronChannelTarget[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+
+  const targets: CronChannelTarget[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry)) continue;
+    if (typeof entry.channel_id !== "string") continue;
+    if (typeof entry.chat_id !== "string" || entry.chat_id.length === 0) {
+      continue;
+    }
+    if (
+      entry.account_id !== undefined &&
+      typeof entry.account_id !== "string"
+    ) {
+      continue;
+    }
+    if (entry.label !== undefined && typeof entry.label !== "string") {
+      continue;
+    }
+
+    targets.push({
+      channel_id: entry.channel_id,
+      ...(entry.account_id !== undefined
+        ? { account_id: entry.account_id }
+        : {}),
+      chat_id: entry.chat_id,
+      ...(entry.label !== undefined ? { label: entry.label } : {}),
+    });
+  }
+
+  return targets.length > 0 ? targets : undefined;
+}
+
 function normalizeTask(task: CronTask): CronTask {
-  return {
+  const normalized: CronTask = {
     ...task,
     last_run_at: task.last_run_at ?? null,
     last_run_outcome: task.last_run_outcome ?? null,
@@ -150,6 +194,15 @@ function normalizeTask(task: CronTask): CronTask {
     missed_count: task.missed_count ?? 0,
     failed_count: task.failed_count ?? 0,
   };
+  const channelTargets = normalizeCronChannelTargets(
+    (task as { channel_targets?: unknown }).channel_targets,
+  );
+  if (channelTargets) {
+    normalized.channel_targets = channelTargets;
+  } else {
+    delete normalized.channel_targets;
+  }
+  return normalized;
 }
 
 function normalizeCronFileData(data: CronFileData): CronFileData {
@@ -485,6 +538,7 @@ export interface AddTaskInput {
   timezone?: string;
   recurring: boolean;
   prompt: string;
+  channel_targets?: CronChannelTarget[];
   scheduled_for?: Date; // for one-shots
 }
 
@@ -518,11 +572,13 @@ export function addTask(input: AddTaskInput): AddTaskResult {
     const taskId = generateTaskId();
     const timezone =
       input.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const channelTargets = normalizeCronChannelTargets(input.channel_targets);
 
     const task: CronTask = {
       id: taskId,
       agent_id: agentId,
       conversation_id: conversationId,
+      ...(channelTargets ? { channel_targets: channelTargets } : {}),
       name: input.name,
       description: input.description,
       cron: input.cron,
@@ -712,7 +768,9 @@ export function updateTask(
 ): CronTask | null {
   return withLock(() => {
     const data = readCronFile();
-    const task = data.tasks.find((t) => t.id === taskId);
+    const taskIndex = data.tasks.findIndex((t) => t.id === taskId);
+    if (taskIndex === -1) return null;
+    const task = data.tasks[taskIndex];
     if (!task) return null;
     const originalCron = task.cron;
     updater(task);
@@ -724,8 +782,10 @@ export function updateTask(
       task.last_run_reason = null;
       task.last_run_error = null;
     }
+    const normalizedTask = normalizeTask(task);
+    data.tasks[taskIndex] = normalizedTask;
     writeCronFile(data);
-    return { ...task };
+    return { ...normalizedTask };
   });
 }
 

--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -13,6 +13,7 @@
  */
 
 import { getBackend } from "@/backend";
+import { getChannelRegistry } from "@/channels/registry";
 import type { CronPromptQueueItem, DequeuedBatch } from "@/queue/queue-runtime";
 import { ensureConversationQueueRuntime } from "@/websocket/listener/conversation-runtime";
 import { scheduleQueuePump } from "@/websocket/listener/queue";
@@ -29,6 +30,10 @@ import type {
   IncomingMessage,
   StartListenerOptions,
 } from "@/websocket/listener/types";
+import {
+  enqueueCronPromptWithChannelTargets,
+  validateCronChannelTargets,
+} from "./channel-targets";
 import {
   type CronRunOutcome,
   type CronRunReason,
@@ -63,6 +68,10 @@ type ProcessQueuedTurn = (
   queuedTurn: IncomingMessage,
   dequeuedBatch: DequeuedBatch,
 ) => Promise<void>;
+
+function getCronChannelAdapter(channelId: string, accountId?: string) {
+  return getChannelRegistry()?.getAdapter(channelId, accountId) ?? null;
+}
 
 interface SchedulerState {
   token: string;
@@ -161,6 +170,10 @@ function emitCronsUpdated(
       err instanceof Error ? err.message : err,
     );
   }
+}
+
+function getErrorText(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback;
 }
 
 // ── Core tick logic ─────────────────────────────────────────────────
@@ -281,6 +294,27 @@ async function fireCronTask(
     return false;
   }
 
+  try {
+    validateCronChannelTargets(task, getCronChannelAdapter);
+  } catch (err) {
+    const error = getErrorText(err, "failed to validate cron channel target");
+    setLastRunOutcome(task.id, {
+      outcome: "failed",
+      reason: "scheduler_error",
+      runAt: timing.schedulerNow,
+      error,
+    });
+    safeAppendCronRunLogForTask(task, {
+      status: "error",
+      outcome: "failed",
+      reason: "scheduler_error",
+      error,
+      runAtMs: timing.schedulerNow.getTime(),
+      scheduledFor: task.scheduled_for,
+    });
+    return false;
+  }
+
   let targetConversationId: string | undefined;
   try {
     targetConversationId = await resolveCronFireConversationId(task);
@@ -295,6 +329,7 @@ async function fireCronTask(
     return false;
   }
 
+  const runtimeConversationId = targetConversationId ?? "default";
   const rawRuntime = getOrCreateConversationRuntime(
     listener,
     task.agent_id,
@@ -328,14 +363,41 @@ async function fireCronTask(
 
   const text = wrapCronPrompt(task, timing);
 
-  const queuedItem = conversationRuntime.queueRuntime.enqueue({
-    kind: "cron_prompt",
-    source: "cron" as import("@/types/protocol").QueueItemSource,
-    text,
-    cronTaskId: task.id,
-    agentId: task.agent_id,
-    conversationId: targetConversationId ?? "default",
-  } as Omit<CronPromptQueueItem, "id" | "enqueuedAt">);
+  let queuedItem: CronPromptQueueItem | null;
+  try {
+    queuedItem = enqueueCronPromptWithChannelTargets({
+      queueRuntime: conversationRuntime.queueRuntime,
+      queueItem: {
+        kind: "cron_prompt",
+        source: "cron",
+        text,
+        cronTaskId: task.id,
+        agentId: task.agent_id,
+        conversationId: runtimeConversationId,
+      },
+      task,
+      conversationId: runtimeConversationId,
+      getAdapter: getCronChannelAdapter,
+    });
+  } catch (err) {
+    const error = getErrorText(err, "failed to bind cron channel target");
+    setLastRunOutcome(task.id, {
+      outcome: "failed",
+      reason: "scheduler_error",
+      runAt: timing.schedulerNow,
+      error,
+    });
+    safeAppendCronRunLogForTask(task, {
+      status: "error",
+      outcome: "failed",
+      reason: "scheduler_error",
+      error,
+      runAtMs: timing.schedulerNow.getTime(),
+      scheduledFor: task.scheduled_for,
+      conversationId: runtimeConversationId,
+    });
+    return false;
+  }
 
   if (!queuedItem) {
     setLastRunOutcome(task.id, {
@@ -390,9 +452,9 @@ async function fireCronTask(
     queueItemId: queuedItem.id,
     scheduledFor: task.scheduled_for,
     firedAt: nowIso,
-    conversationId: targetConversationId ?? "default",
+    conversationId: runtimeConversationId,
   });
-  emitCronsUpdated(socket, task, targetConversationId ?? "default");
+  emitCronsUpdated(socket, task, runtimeConversationId);
   return true;
 }
 

--- a/src/types/cron-channel-target.ts
+++ b/src/types/cron-channel-target.ts
@@ -1,0 +1,6 @@
+export interface CronChannelTarget {
+  channel_id: string;
+  account_id?: string;
+  chat_id: string;
+  label?: string;
+}

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -75,6 +75,7 @@ export interface CronTask {
   id: string;
   agent_id: string;
   conversation_id: string;
+  channel_targets?: import("./cron-channel-target").CronChannelTarget[];
   name: string;
   description: string;
   cron: string;
@@ -1689,7 +1690,6 @@ export interface CronListCommand {
   /** Optional conversation filter. */
   conversation_id?: string;
 }
-
 export interface CronAddCommand {
   type: "cron_add";
   /** Echoed back in the response for request correlation. */
@@ -1702,6 +1702,7 @@ export interface CronAddCommand {
    * - any other string: existing conversation id
    */
   conversation_id?: string;
+  channel_targets?: import("./cron-channel-target").CronChannelTarget[];
   name: string;
   description: string;
   cron: string;
@@ -1711,7 +1712,6 @@ export interface CronAddCommand {
   /** Optional ISO timestamp for one-shot tasks. */
   scheduled_for?: string | null;
 }
-
 export interface CronGetCommand {
   type: "cron_get";
   /** Echoed back in the response for request correlation. */
@@ -1731,7 +1731,6 @@ export interface CronRunsCommand {
   /** Optional run id filter. */
   run_id?: string;
 }
-
 export interface CronTriggerCommand {
   type: "cron_trigger";
   /** Echoed back in the response for request correlation. */
@@ -1747,6 +1746,7 @@ export interface CronUpdateCommand {
   name?: string;
   description?: string;
   conversation_id?: string;
+  channel_targets?: import("./cron-channel-target").CronChannelTarget[];
   cron?: string;
   timezone?: string;
   recurring?: boolean;

--- a/src/websocket/listener/commands/cron.ts
+++ b/src/websocket/listener/commands/cron.ts
@@ -29,7 +29,7 @@ import {
   isCronRunsCommand,
   isCronTriggerCommand,
   isCronUpdateCommand,
-} from "@/websocket/listener/protocol-inbound";
+} from "@/websocket/listener/protocol-inbound-cron";
 import type { RunDetachedListenerTask, SafeSocketSend } from "./types";
 
 export type CronCommand =
@@ -124,6 +124,7 @@ export async function handleCronCommand(
         timezone: parsed.timezone,
         recurring: parsed.recurring,
         prompt: parsed.prompt,
+        channel_targets: parsed.channel_targets,
         scheduled_for: scheduledFor,
       });
       safeSocketSend(
@@ -284,6 +285,13 @@ export async function handleCronCommand(
         }
         if (parsed.conversation_id !== undefined) {
           current.conversation_id = parsed.conversation_id;
+        }
+        if (parsed.channel_targets !== undefined) {
+          if (parsed.channel_targets.length > 0) {
+            current.channel_targets = parsed.channel_targets;
+          } else {
+            delete current.channel_targets;
+          }
         }
         if (parsed.cron !== undefined) current.cron = parsed.cron;
         if (parsed.timezone !== undefined) current.timezone = parsed.timezone;

--- a/src/websocket/listener/protocol-inbound-cron.test.ts
+++ b/src/websocket/listener/protocol-inbound-cron.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isCronAddCommand,
+  isCronUpdateCommand,
+} from "@/websocket/listener/protocol-inbound-cron";
+
+describe("cron channel target protocol", () => {
+  test("accepts valid cron channel targets and rejects invalid ones", () => {
+    expect(
+      isCronAddCommand({
+        type: "cron_add",
+        request_id: "cron-add-1",
+        agent_id: "agent-1",
+        conversation_id: "default",
+        name: "Test task",
+        description: "A test cron task",
+        channel_targets: [
+          {
+            channel_id: "discord",
+            account_id: "acct-1",
+            chat_id: "chat-1",
+            label: "Ops room",
+          },
+        ],
+        cron: "*/5 * * * *",
+        recurring: true,
+        prompt: "hello",
+      }),
+    ).toBe(true);
+
+    expect(
+      isCronUpdateCommand({
+        type: "cron_update",
+        request_id: "cron-update-1",
+        task_id: "cron-1",
+        channel_targets: [],
+      }),
+    ).toBe(true);
+
+    expect(
+      isCronAddCommand({
+        type: "cron_add",
+        request_id: "cron-add-bad-1",
+        agent_id: "agent-1",
+        conversation_id: "default",
+        name: "Bad cron",
+        description: "Bad target",
+        channel_targets: [{ channel_id: "discord", chat_id: "" }],
+        cron: "*/5 * * * *",
+        recurring: true,
+        prompt: "hello",
+      }),
+    ).toBe(false);
+
+    expect(
+      isCronUpdateCommand({
+        type: "cron_update",
+        request_id: "cron-update-bad-1",
+        task_id: "cron-1",
+        channel_targets: [
+          {
+            channel_id: "unsupported-channel",
+            chat_id: "chat-1",
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/websocket/listener/protocol-inbound-cron.ts
+++ b/src/websocket/listener/protocol-inbound-cron.ts
@@ -1,0 +1,146 @@
+import { isSupportedChannelId } from "@/channels/plugin-registry";
+import type { CronChannelTarget } from "@/types/cron-channel-target";
+import type {
+  CronAddCommand,
+  CronDeleteAllCommand,
+  CronDeleteCommand,
+  CronGetCommand,
+  CronListCommand,
+  CronRunsCommand,
+  CronTriggerCommand,
+  CronUpdateCommand,
+} from "@/types/protocol_v2";
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isCronChannelTarget(value: unknown): value is CronChannelTarget {
+  if (!isObjectRecord(value)) return false;
+  return (
+    typeof value.channel_id === "string" &&
+    isSupportedChannelId(value.channel_id) &&
+    (value.account_id === undefined || typeof value.account_id === "string") &&
+    typeof value.chat_id === "string" &&
+    value.chat_id.length > 0 &&
+    (value.label === undefined || typeof value.label === "string")
+  );
+}
+
+export function isCronChannelTargetArray(
+  value: unknown,
+): value is CronChannelTarget[] {
+  return Array.isArray(value) && value.every(isCronChannelTarget);
+}
+
+export function isCronListCommand(value: unknown): value is CronListCommand {
+  if (!isObjectRecord(value)) return false;
+  return (
+    value.type === "cron_list" &&
+    typeof value.request_id === "string" &&
+    (value.agent_id === undefined || typeof value.agent_id === "string") &&
+    (value.conversation_id === undefined ||
+      typeof value.conversation_id === "string")
+  );
+}
+
+export function isCronAddCommand(value: unknown): value is CronAddCommand {
+  if (!isObjectRecord(value)) return false;
+  return (
+    value.type === "cron_add" &&
+    typeof value.request_id === "string" &&
+    typeof value.agent_id === "string" &&
+    (value.conversation_id === undefined ||
+      typeof value.conversation_id === "string") &&
+    typeof value.name === "string" &&
+    typeof value.description === "string" &&
+    typeof value.cron === "string" &&
+    (value.timezone === undefined || typeof value.timezone === "string") &&
+    typeof value.recurring === "boolean" &&
+    typeof value.prompt === "string" &&
+    (value.channel_targets === undefined ||
+      isCronChannelTargetArray(value.channel_targets)) &&
+    (value.scheduled_for === undefined ||
+      value.scheduled_for === null ||
+      typeof value.scheduled_for === "string")
+  );
+}
+
+export function isCronGetCommand(value: unknown): value is CronGetCommand {
+  if (!isObjectRecord(value)) return false;
+  return (
+    value.type === "cron_get" &&
+    typeof value.request_id === "string" &&
+    typeof value.task_id === "string"
+  );
+}
+
+export function isCronRunsCommand(value: unknown): value is CronRunsCommand {
+  if (!isObjectRecord(value)) return false;
+  return (
+    value.type === "cron_runs" &&
+    typeof value.request_id === "string" &&
+    typeof value.task_id === "string" &&
+    (value.limit === undefined || typeof value.limit === "number") &&
+    (value.offset === undefined || typeof value.offset === "number") &&
+    (value.run_id === undefined || typeof value.run_id === "string")
+  );
+}
+
+export function isCronTriggerCommand(
+  value: unknown,
+): value is CronTriggerCommand {
+  if (!isObjectRecord(value)) return false;
+  return (
+    value.type === "cron_trigger" &&
+    typeof value.request_id === "string" &&
+    typeof value.task_id === "string"
+  );
+}
+
+export function isCronUpdateCommand(
+  value: unknown,
+): value is CronUpdateCommand {
+  if (!isObjectRecord(value)) return false;
+  return (
+    value.type === "cron_update" &&
+    typeof value.request_id === "string" &&
+    typeof value.task_id === "string" &&
+    (value.name === undefined || typeof value.name === "string") &&
+    (value.description === undefined ||
+      typeof value.description === "string") &&
+    (value.conversation_id === undefined ||
+      typeof value.conversation_id === "string") &&
+    (value.channel_targets === undefined ||
+      isCronChannelTargetArray(value.channel_targets)) &&
+    (value.cron === undefined || typeof value.cron === "string") &&
+    (value.timezone === undefined || typeof value.timezone === "string") &&
+    (value.recurring === undefined || typeof value.recurring === "boolean") &&
+    (value.prompt === undefined || typeof value.prompt === "string") &&
+    (value.scheduled_for === undefined ||
+      value.scheduled_for === null ||
+      typeof value.scheduled_for === "string")
+  );
+}
+
+export function isCronDeleteCommand(
+  value: unknown,
+): value is CronDeleteCommand {
+  if (!isObjectRecord(value)) return false;
+  return (
+    value.type === "cron_delete" &&
+    typeof value.request_id === "string" &&
+    typeof value.task_id === "string"
+  );
+}
+
+export function isCronDeleteAllCommand(
+  value: unknown,
+): value is CronDeleteAllCommand {
+  if (!isObjectRecord(value)) return false;
+  return (
+    value.type === "cron_delete_all" &&
+    typeof value.request_id === "string" &&
+    typeof value.agent_id === "string"
+  );
+}

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -42,14 +42,6 @@ import type {
   ConversationRetrieveCommand,
   ConversationUpdateCommand,
   CreateAgentCommand,
-  CronAddCommand,
-  CronDeleteAllCommand,
-  CronDeleteCommand,
-  CronGetCommand,
-  CronListCommand,
-  CronRunsCommand,
-  CronTriggerCommand,
-  CronUpdateCommand,
   DeleteMemoryFileCommand,
   DisconnectProviderCommand,
   EditFileCommand,
@@ -113,7 +105,28 @@ import {
   isAppServerInfoCommand,
   isConversationForkCommand,
 } from "./management-protocol-inbound";
+import {
+  isCronAddCommand,
+  isCronDeleteAllCommand,
+  isCronDeleteCommand,
+  isCronGetCommand,
+  isCronListCommand,
+  isCronRunsCommand,
+  isCronTriggerCommand,
+  isCronUpdateCommand,
+} from "./protocol-inbound-cron";
 import type { InvalidInputCommand, ParsedServerMessage } from "./types";
+
+export {
+  isCronAddCommand,
+  isCronDeleteAllCommand,
+  isCronDeleteCommand,
+  isCronGetCommand,
+  isCronListCommand,
+  isCronRunsCommand,
+  isCronTriggerCommand,
+  isCronUpdateCommand,
+} from "./protocol-inbound-cron";
 
 export type ServerLifecycleMessage = {
   type: "pong";
@@ -1044,172 +1057,6 @@ export function isUpdateToolsetCommand(
     typeof c.request_id === "string" &&
     isRuntimeScope(c.runtime) &&
     typeof c.toolset_preference === "string"
-  );
-}
-
-export function isCronListCommand(value: unknown): value is CronListCommand {
-  if (!value || typeof value !== "object") return false;
-  const c = value as {
-    type?: unknown;
-    request_id?: unknown;
-    agent_id?: unknown;
-    conversation_id?: unknown;
-  };
-  return (
-    c.type === "cron_list" &&
-    typeof c.request_id === "string" &&
-    (c.agent_id === undefined || typeof c.agent_id === "string") &&
-    (c.conversation_id === undefined || typeof c.conversation_id === "string")
-  );
-}
-
-export function isCronAddCommand(value: unknown): value is CronAddCommand {
-  if (!value || typeof value !== "object") return false;
-  const c = value as {
-    type?: unknown;
-    request_id?: unknown;
-    agent_id?: unknown;
-    conversation_id?: unknown;
-    name?: unknown;
-    description?: unknown;
-    cron?: unknown;
-    timezone?: unknown;
-    recurring?: unknown;
-    prompt?: unknown;
-    scheduled_for?: unknown;
-  };
-  return (
-    c.type === "cron_add" &&
-    typeof c.request_id === "string" &&
-    typeof c.agent_id === "string" &&
-    (c.conversation_id === undefined ||
-      typeof c.conversation_id === "string") &&
-    typeof c.name === "string" &&
-    typeof c.description === "string" &&
-    typeof c.cron === "string" &&
-    (c.timezone === undefined || typeof c.timezone === "string") &&
-    typeof c.recurring === "boolean" &&
-    typeof c.prompt === "string" &&
-    (c.scheduled_for === undefined ||
-      c.scheduled_for === null ||
-      typeof c.scheduled_for === "string")
-  );
-}
-
-export function isCronGetCommand(value: unknown): value is CronGetCommand {
-  if (!value || typeof value !== "object") return false;
-  const c = value as {
-    type?: unknown;
-    request_id?: unknown;
-    task_id?: unknown;
-  };
-  return (
-    c.type === "cron_get" &&
-    typeof c.request_id === "string" &&
-    typeof c.task_id === "string"
-  );
-}
-
-export function isCronRunsCommand(value: unknown): value is CronRunsCommand {
-  if (!value || typeof value !== "object") return false;
-  const c = value as {
-    type?: unknown;
-    request_id?: unknown;
-    task_id?: unknown;
-    limit?: unknown;
-    offset?: unknown;
-    run_id?: unknown;
-  };
-  return (
-    c.type === "cron_runs" &&
-    typeof c.request_id === "string" &&
-    typeof c.task_id === "string" &&
-    (c.limit === undefined || typeof c.limit === "number") &&
-    (c.offset === undefined || typeof c.offset === "number") &&
-    (c.run_id === undefined || typeof c.run_id === "string")
-  );
-}
-
-export function isCronTriggerCommand(
-  value: unknown,
-): value is CronTriggerCommand {
-  if (!value || typeof value !== "object") return false;
-  const c = value as {
-    type?: unknown;
-    request_id?: unknown;
-    task_id?: unknown;
-  };
-  return (
-    c.type === "cron_trigger" &&
-    typeof c.request_id === "string" &&
-    typeof c.task_id === "string"
-  );
-}
-
-export function isCronUpdateCommand(
-  value: unknown,
-): value is CronUpdateCommand {
-  if (!value || typeof value !== "object") return false;
-  const c = value as {
-    type?: unknown;
-    request_id?: unknown;
-    task_id?: unknown;
-    name?: unknown;
-    description?: unknown;
-    conversation_id?: unknown;
-    cron?: unknown;
-    timezone?: unknown;
-    recurring?: unknown;
-    prompt?: unknown;
-    scheduled_for?: unknown;
-  };
-  return (
-    c.type === "cron_update" &&
-    typeof c.request_id === "string" &&
-    typeof c.task_id === "string" &&
-    (c.name === undefined || typeof c.name === "string") &&
-    (c.description === undefined || typeof c.description === "string") &&
-    (c.conversation_id === undefined ||
-      typeof c.conversation_id === "string") &&
-    (c.cron === undefined || typeof c.cron === "string") &&
-    (c.timezone === undefined || typeof c.timezone === "string") &&
-    (c.recurring === undefined || typeof c.recurring === "boolean") &&
-    (c.prompt === undefined || typeof c.prompt === "string") &&
-    (c.scheduled_for === undefined ||
-      c.scheduled_for === null ||
-      typeof c.scheduled_for === "string")
-  );
-}
-
-export function isCronDeleteCommand(
-  value: unknown,
-): value is CronDeleteCommand {
-  if (!value || typeof value !== "object") return false;
-  const c = value as {
-    type?: unknown;
-    request_id?: unknown;
-    task_id?: unknown;
-  };
-  return (
-    c.type === "cron_delete" &&
-    typeof c.request_id === "string" &&
-    typeof c.task_id === "string"
-  );
-}
-
-export function isCronDeleteAllCommand(
-  value: unknown,
-): value is CronDeleteAllCommand {
-  if (!value || typeof value !== "object") return false;
-  const c = value as {
-    type?: unknown;
-    request_id?: unknown;
-    agent_id?: unknown;
-  };
-  return (
-    c.type === "cron_delete_all" &&
-    typeof c.request_id === "string" &&
-    typeof c.agent_id === "string"
   );
 }
 


### PR DESCRIPTION
## Summary
- persist optional channel destinations on local schedules and validate them on the listener protocol
- for each fire, validate that selected channel runtimes are active, create the requested conversation, then atomically move all selected root routes before the prompt can run
- preserve legacy schedules without channel targets and support replacing or clearing target selections

## Behavior
A schedule can target multiple channel destinations. `new` schedules create a fresh conversation on each fire and move those routes to it before the queued turn starts, so the turn receives the normal route-scoped `MessageChannel` tool. If an adapter is stopped, a route is outbound-disabled, the queue is full, or any route write fails, the prompt does not run and prior queue/route/account state is restored.

Thread-specific destinations are intentionally not supported; schedule targets bind root chats/channels.

## Validation
- `bun run typecheck`
- `bun test src/channels/service-route-bindings.test.ts src/cron/channel-targets.test.ts src/cron/cron-file.test.ts src/websocket/listener/protocol-inbound-cron.test.ts src/websocket/listen-client-protocol.test.ts` (206 passed)
- `bun run lint` (clean; 6 pre-existing warnings)
- `bun run check:cycles`
- `bun run check:boundaries`
- `bun run check:module-ownership`
- `bun run check:file-size`
- `bun run check:test-mock-isolation`

👾 Generated with [Letta Code](https://letta.com)