### PR TITLE
fix(cli): separate adjacent reasoning headings [LET-10146]

### DIFF
--- a/src/cli/helpers/accumulator.ts
+++ b/src/cli/helpers/accumulator.ts
@@ -908,11 +908,11 @@ function trySplitContent(
   return true;
 }
 
-// OpenAI reasoning summaries can start a new `**Section Title**\n\n` block inside the
-// same otid without a leading separator. Insert the missing blank line so markdown
-// renders the title as a new paragraph instead of gluing it to the previous sentence.
+// Restore missing blank lines between adjacent OpenAI reasoning summary headings.
 function normalizeReasoningSectionBoundaries(text: string): string {
-  return text.replace(/([^\n])(\*\*[^*\n]+\*\*\n\n)/g, "$1\n\n$2");
+  return text
+    .replace(/\*\*\*\*/g, "**\n\n**")
+    .replace(/([^\n])(\*\*[^*\n]+\*\*\n\n)/g, "$1\n\n$2");
 }
 
 // Feed one SDK chunk; mutate buffers in place.

--- a/src/cli/helpers/context-tracker-accumulator.test.ts
+++ b/src/cli/helpers/context-tracker-accumulator.test.ts
@@ -521,6 +521,33 @@ describe("accumulator usage statistics", () => {
     );
   });
 
+  test("separates adjacent final reasoning headings before finalization", () => {
+    const buffers = createBuffers();
+
+    onChunk(buffers, {
+      message_type: "reasoning_message",
+      id: "reasoning-msg-final-heading",
+      otid: "reasoning-otid-final-heading",
+      reasoning: "**Planning protocol build error handling**",
+    } as unknown as LettaStreamingResponse);
+
+    onChunk(buffers, {
+      message_type: "reasoning_message",
+      id: "reasoning-msg-final-heading",
+      otid: "reasoning-otid-final-heading",
+      reasoning: "**Evaluating event sequence handling**",
+    } as unknown as LettaStreamingResponse);
+
+    markCurrentLineAsFinished(buffers);
+
+    const line = buffers.byId.get("reasoning-msg-final-heading");
+    expect(line?.kind).toBe("reasoning");
+    expect(line && "text" in line ? line.text : "").toBe(
+      "**Planning protocol build error handling**\n\n**Evaluating event sequence handling**",
+    );
+    expect(line && "phase" in line ? line.phase : "").toBe("finished");
+  });
+
   test("retrofits a blank line when a streamed reasoning heading spans multiple chunks", () => {
     const buffers = createBuffers();
 


### PR DESCRIPTION
## Summary
- repair adjacent streamed reasoning heading markers immediately instead of waiting for a later paragraph separator
- prevent final GPT reasoning headings from freezing into malformed Markdown when the stream ends
- add regression coverage for the exact two-chunk sequence followed by finalization
- verified with the focused 23-test accumulator suite and all 12 repository checks

👾 Generated with [Letta Code](https://letta.com)