### PR TITLE
fix(skills): keep dispatch guidance evergreen [LET-9386]

### DIFF
--- a/src/skills/builtin/dispatching-coding-agents/SKILL.md
+++ b/src/skills/builtin/dispatching-coding-agents/SKILL.md
@@ -1,229 +1,137 @@
 ---
 name: dispatching-coding-agents
-description: Dispatch stateless coding agents (Claude Code or Codex) via Bash. Use when you're stuck, need a second opinion, or need parallel research on a hard problem. They have no memory — you must provide all context.
+description: Dispatch coding agents (Claude Code or Codex) via Bash. Use when you're stuck, need a second opinion, or need parallel research on a hard problem. They do not inherit this conversation or its memory, so provide the relevant context.
 ---
 
 # Dispatching Coding Agents
 
-You can shell out to **Claude Code** (`claude`) and **Codex** (`codex`) as stateless sub-agents via Bash. They have filesystem and tool access (scope depends on sandbox/approval settings) but **zero memory** — every session starts from scratch.
+Shell out to Claude Code (`claude`) or Codex (`codex`) when an independent coding agent would help. These agents can inspect and modify the filesystem, but they do not inherit your memory or conversation context.
 
-**Default to `run_in_background: true`** on the Bash call so you can keep working while they run. Check results later with `TaskOutput`. Don't sit idle waiting for a subagent.
+Default to `run_in_background: true` on the Bash call. Keep working while the process runs, then read its result with `TaskOutput` using the returned task ID.
+
+## Before Dispatching
+
+CLI interfaces and model catalogs change. Check the installed command instead of relying on remembered flags or model names:
+
+```bash
+command -v claude && claude --version && claude --help
+command -v codex && codex --version && codex exec --help
+```
+
+Use each CLI's configured default model unless the user explicitly requests a model. If a requested model is rejected, inspect the current CLI/account configuration and use a supported option rather than guessing another versioned name.
+
+Use an absolute repository path. Claude Code inherits the shell's current directory, so change directories in the shell command. Codex supports `-C` for its working root.
 
 ## The Core Mental Model
 
-Claude Code and Codex are highly optimized coding agents, but are re-born with each new session. Think of them like a brilliant intern that showed up today. Provide them with the right instructions and context to help them succeed and avoid having to re-learn things that you've learned.
+Treat a dispatched agent like a capable new collaborator with no project history. Give it the context it cannot discover efficiently:
 
-You are the experienced manager with persistent memory of the user's preferences, the codebase, past decisions, and hard-won lessons. **Give them context, not a plan.** They won't know anything you don't tell them:
+- **Specific task**: Ask for a concrete result, not a broad topic.
+- **Repository and key files**: Include the absolute repo path and likely entry points.
+- **Relevant architecture**: Explain how the pieces connect.
+- **Constraints**: Include scope, style, safety, and user preferences.
+- **Prior work**: Describe attempted approaches and known dead ends.
+- **Expected output**: Request a diff, root-cause analysis, file list, or review verdict.
 
-- **Specific task**: Be precise about what you need — not "look into the auth system" but "trace the request flow from the messages endpoint through to the LLM call, cite files and line numbers."
-- **File paths and architecture**: Tell them exactly where to look and how pieces connect. They will wander aimlessly without this.
-- **Preferences and constraints**: Code style, error handling patterns, things the user has corrected you on. Save them from making mistakes you already learned from.
-- **What you've already tried**: If you're dispatching because you're stuck, this prevents them from rediscovering your dead ends.
+Give the agent context and constraints, not a prescribed implementation plan. Let it independently inspect the evidence and propose an approach.
 
-If a subagent needs clarification or asks a question, respond in the same session (see Session Resumption below) — don't start a new session or you'll lose the conversation context.
+## When to Dispatch
 
-## When to Dispatch (and When Not To)
+Good uses:
 
-### Dispatch for:
-- **Hard debugging** — you've been looping on a problem and need fresh eyes
-- **Second opinions** — you want validation before a risky change
-- **Parallel research** — investigate multiple hypotheses simultaneously
-- **Large-scope investigation** — tracing a flow across many files in an unfamiliar area
-- **Code review** — have another agent review your diff or plan
+- Hard debugging where fresh eyes would help
+- Independent review of a plan or diff
+- Parallel investigation of distinct hypotheses
+- Broad codebase tracing across many files
+- A contained implementation in an isolated worktree
 
-### Don't dispatch for:
-- Simple file reads, greps, or small edits — faster to do yourself
-- Anything that takes less than ~3 minutes of direct work
-- Tasks where you already know exactly what to do
-- When context transfer would take longer than just doing the task
+Work directly instead for simple reads, searches, small edits, or tasks where transferring context costs more than doing the work.
 
-## Choosing an Agent and Model
+## Prompt Template
 
-Different agents have different strengths. Track what works in your memory over time — your own observations are more valuable than these defaults.
-
-### Categories
-
-**Codex:**
-- `gpt-5.3-codex` — Frontier reasoning. Best for the hardest debugging and complex tasks.
-  - Strengths: Best reasoning, excellent at debugging, best option for the hardest tasks
-  - Weaknesses: Slow with long trajectories, compactions can destroy trajectories
-- `gpt-5.4` — Latest frontier model. Fast and general-purpose.
-  - Strengths: Easier for humans to understand, general-purpose, faster
-  - Weaknesses: More likely to make silly errors than gpt-5.3-codex
-
-**Claude Code:**
-- `opus` — Excellent writer. Best for docs, refactors, open-ended tasks, and vague instructions.
-  - Strengths: Excellent writer, understands vague instructions, excellent for coding but also general-purpose
-  - Weaknesses: Tends to generate "slop", writing excessive quantities of code unnecessarily. Can hang on large repos.
-
-### Cost and speed tradeoffs
-- Frontier models (`gpt-5.3-codex`, Opus) are slower and more expensive — use for tasks that justify it
-- Fast models (`gpt-5.4`) are good for quick checks and simple tasks
-- Use `--max-budget-usd N` (Claude Code) to cap spend on exploratory tasks
-
-### Known quirks
-- **Claude Code can hang on large repos** with unrestricted tools — consider `--allowedTools "Read Grep Glob"` (no Bash) and shorter timeouts for research tasks
-- **Codex compactions can destroy long trajectories** — for very long tasks, prefer multiple shorter sessions over one marathon
-- **Opus tends to over-generate** — produces more code than necessary. Good for exploration, verify before applying.
-
-## Prompting Subagents
-
-### Prompt template
-```
-TASK: [one-sentence summary]
+```text
+TASK: [one-sentence objective]
 
 CONTEXT:
-- Repo: [path]
-- Key files: [list specific files and what they contain]
-- Architecture: [brief relevant context]
+- Repo: [absolute path]
+- Key files: [specific paths and responsibilities]
+- Architecture: [relevant flow]
 
 WHAT TO DO:
-[what you need done — be precise, but let them figure out the approach]
+[precise investigation or implementation request]
 
 CONSTRAINTS:
-- [any preferences, patterns to follow, things to avoid]
-- [what you've already tried, if dispatching because stuck]
+- [scope and project conventions]
+- [user preferences]
+- [attempts or dead ends]
 
 OUTPUT:
-[what you want back — a diff, a list of files, a root cause analysis, etc.]
+[exact result to return]
 ```
 
-### What makes a good prompt
-- **Be specific about files** — "look at `src/agent/message.ts` lines 40-80" not "look at the message handling code"
-- **State the output format** — "return a bullet list of findings" vs. leaving it open-ended
-- **Include constraints** — if the user prefers certain patterns, say so explicitly
-- **Provide what you've tried** — when dispatching because you're stuck, this prevents them from repeating your dead ends
-
-## Dispatch Patterns
-
-### Parallel research — multiple perspectives
-Run Claude Code and Codex simultaneously on the same question via separate Bash calls in a single message (use `run_in_background: true`). Compare results for higher confidence.
-
-### Background dispatch — keep working while they run
-Use `run_in_background: true` on the Bash call to dispatch async. Continue your own work, then check results with `TaskOutput` when ready.
-
-### Deep investigation — frontier models
-For hard problems, use the strongest available models:
-```bash
-codex exec "YOUR PROMPT" -m gpt-5.3-codex --full-auto -C /path/to/repo
-```
-
-Claude Code does not support a `-C` working-directory flag. Run the Bash tool with its `workdir` set to the target repo, or `cd /path/to/repo && claude ...` inside the shell command. Use `--add-dir` only to grant access to additional directories outside the current working directory.
-
-### Code review — cross-agent validation
-Have one agent write code or create a plan, then dispatch another to review:
-```bash
-# Codex has a native review command:
-codex review --uncommitted    # Review all local changes
-codex exec review "Focus on error handling and edge cases" -m gpt-5.4 --full-auto
-
-# Claude Code — pass the diff inline:
-claude -p "Review the following diff for correctness, edge cases, and missed error handling:\n\n$(git diff)" \
-  --model opus --dangerously-skip-permissions
-```
-
-### Get outside feedback on your work
-Write your plan or analysis to a file, then ask a subagent to critique it:
-```bash
-# Run this from the target repo, or set the Bash tool's workdir to the repo.
-claude -p "Read /tmp/my-plan.md and critique it. What am I missing? What could go wrong?" \
-  --model opus --dangerously-skip-permissions
-```
-
-## Handling Failures
-
-- **Timeout**: If an agent times out (especially Claude Code on large repos), try: (1) a shorter, more focused prompt, (2) restricting tools with `--allowedTools`, (3) switching to Codex which handles large repos better
-- **Garbage output**: If results are incoherent, the prompt was probably too vague. Rewrite with more specific file paths and clearer instructions.
-- **Session errors**: Claude Code can hit "stale approval from interrupted session" — `--dangerously-skip-permissions` prevents this. If Codex errors, start a fresh `exec` session.
-- **Compaction mid-task**: If a Codex session runs long enough to compact, it may lose earlier context. Break long tasks into smaller sequential sessions.
-
-## CLI Reference
+## Durable Invocation Patterns
 
 ### Claude Code
 
+Run from the target repository and request structured output so the session ID is available for follow-up:
+
 ```bash
-claude -p "YOUR PROMPT" --model MODEL --dangerously-skip-permissions
+cd "/absolute/path/to/repo" && claude -p "YOUR PROMPT" --output-format json
 ```
 
-| Flag | Purpose |
-|------|---------|
-| `-p` / `--print` | Non-interactive mode, prints response and exits |
-| `--dangerously-skip-permissions` | Skip approval prompts (prevents stale approval errors on timeout) |
-| `--model MODEL` | Alias (`sonnet`, `opus`) or full name (`claude-sonnet-4-6`) |
-| `--effort LEVEL` | `low`, `medium`, `high` — controls reasoning depth |
-| `--append-system-prompt "..."` | Inject additional system instructions |
-| `--allowedTools "Bash Edit Read"` | Restrict available tools |
-| `--max-budget-usd N` | Cap spend for the invocation |
-| `--add-dir DIR` | Allow access to an additional directory; does not change the working directory |
-| `--output-format json` | Structured output with `session_id`, `cost_usd`, `duration_ms` |
-
-Set Claude Code's working directory via the surrounding shell/tool invocation, not a Claude flag. In Letta Code, pass `workdir` to the Bash tool. In a raw shell, use `cd /path/to/repo && claude ...`.
+For read-only research, inspect `claude --help` and restrict its tools to the current read/search tool names. For implementation, use the permission mode appropriate to the surrounding environment. Permission bypass is appropriate only when the process is already isolated by a sandbox or disposable worktree and the task warrants unrestricted execution.
 
 ### Codex
 
+Use a read-only sandbox for investigation:
+
 ```bash
-codex exec "YOUR PROMPT" -m gpt-5.3-codex --full-auto
+codex exec -C "/absolute/path/to/repo" --sandbox read-only --json "YOUR PROMPT"
 ```
 
-| Flag | Purpose |
-|------|---------|
-| `exec` | Non-interactive mode |
-| `-m MODEL` | `gpt-5.3-codex` (frontier), `gpt-5.4` (fast), `gpt-5.3-codex-spark` (ultra-fast), `gpt-5.2-codex`, `gpt-5.2` |
-| `--full-auto` | Auto-approve all commands in sandbox |
-| `-C DIR` | Set working directory |
-| `--search` | Enable web search tool |
-| `review` | Native code review — `codex review --uncommitted` or `codex exec review "prompt"` |
+Use a writable sandbox for implementation in an isolated worktree:
 
-## Session Management
-
-Both CLIs persist full session data (tool calls, reasoning, files read) to disk. The Bash output you see is just the final summary — the local session file is much richer.
-
-### Session storage paths
-
-**Claude Code:** `~/.claude/projects/<encoded-path>/<session-id>.jsonl`
-- `<encoded-path>` = working directory with `/` replaced by `-` (e.g. `/Users/foo/repos/bar` becomes `-Users-foo-repos-bar`)
-- Use `--output-format json` to get the `session_id` in the response
-
-**Codex:** `~/.codex/sessions/<year>/<month>/<day>/rollout-*-<session-id>.jsonl`
-- Session ID is printed in output header: `session id: <uuid>`
-- Extract with: `grep "^session id:" output | awk '{print $3}'`
-
-### Resuming sessions
-
-Use session resumption to continue a line of investigation without re-providing all context:
-
-**Claude Code:**
 ```bash
-claude -r SESSION_ID -p "Follow up: now check if..."    # Resume by ID
-claude -c -p "Also check..."                             # Continue most recent
-claude -r SESSION_ID --fork-session -p "Try differently" # Fork (new ID, keeps history)
+codex exec -C "/absolute/path/to/repo" --sandbox workspace-write --json "YOUR PROMPT"
 ```
 
-**Codex:**
+Check `codex exec --help` before adding optional approval, search, or model flags. Prefer the current explicit sandbox controls over deprecated convenience flags.
+
+### Parallel research
+
+Launch separate Bash calls in one message with `run_in_background: true`. Give each agent the same evidence but a distinct hypothesis or review angle, then compare their conclusions against the source yourself.
+
+### Code review
+
+Codex has a native non-interactive review command. Confirm its current options first:
+
 ```bash
-codex exec resume SESSION_ID "Follow up prompt"  # Resume by ID (non-interactive)
-codex exec resume --last "Follow up prompt"      # Resume most recent (non-interactive)
-codex resume SESSION_ID "Follow up prompt"       # Resume by ID (interactive)
-codex resume --last "Follow up prompt"           # Resume most recent (interactive)
-codex fork SESSION_ID "Try a different approach" # Fork session (interactive)
+codex review --help
+cd "/absolute/path/to/repo" && codex review --uncommitted
 ```
 
-Note: `codex exec resume` works non-interactively. `codex resume` and `codex fork` are interactive only.
+Claude Code can review from the working tree directly; tell it to inspect `git diff` rather than embedding a potentially large diff in the shell command.
 
-### When to analyze past sessions
+## Sessions and Follow-up
 
-**Don't** run `history-analyzer` after every dispatch — your reflection agent already captures insights naturally, and single-session analysis produces overly detailed notes.
+Preserve the session identifier from structured output. Resume the same session when asking a follow-up so the dispatched agent retains what it already inspected:
 
-**Do** use `history-analyzer` for **bulk migration** when bootstrapping memory from months of accumulated history (e.g. during `/init`). See the `initializing-memory` skill's historical session analysis reference.
+```bash
+cd "/absolute/path/to/repo" && claude -r SESSION_ID -p "Follow-up prompt" --output-format json
+cd "/absolute/path/to/repo" && codex exec resume --json SESSION_ID "Follow-up prompt"
+```
 
-Direct uses for session files:
-- **Resume** an investigation (see above)
-- **Review** what an agent actually did (read the JSONL file directly)
-- **Bulk migration** when setting up a new agent
+Run the corresponding `--help` command if the installed CLI rejects a resume form. Do not infer a session ID by scraping private on-disk storage layouts.
 
-## Timeouts
+## Handling Failures
 
-Set Bash timeouts appropriate to the task:
-- Quick checks / reviews: `timeout: 120000` (2 min)
-- Research / analysis: `timeout: 300000` (5 min)
-- Implementation: `timeout: 600000` (10 min)
+Classify the failure before retrying:
+
+- **Command missing**: Report which CLI is unavailable or dispatch the other one.
+- **Unknown/deprecated option**: Re-read the installed command's `--help` and rebuild the invocation from supported flags.
+- **Unsupported model**: Remove the model override or use an option verified for the current account.
+- **Authentication, quota, or service error**: Preserve the exact error; changing the prompt will not fix it.
+- **Timeout**: Inspect partial output, narrow the task, and resume the same session when possible.
+- **Poor result**: Add missing files, constraints, prior attempts, and a more precise output contract.
+
+A launched process is not proof of a successful dispatch. Verify that it completed an agent turn and returned the requested output before relying on its conclusions.

--- a/src/skills/builtin/dispatching-coding-agents/SKILL.md
+++ b/src/skills/builtin/dispatching-coding-agents/SKILL.md
@@ -1,137 +1,223 @@
 ---
 name: dispatching-coding-agents
-description: Dispatch coding agents (Claude Code or Codex) via Bash. Use when you're stuck, need a second opinion, or need parallel research on a hard problem. They do not inherit this conversation or its memory, so provide the relevant context.
+description: Dispatch stateless coding agents (Claude Code or Codex) via Bash. Use when you're stuck, need a second opinion, or need parallel research on a hard problem. They have no memory — you must provide all context.
 ---
 
 # Dispatching Coding Agents
 
-Shell out to Claude Code (`claude`) or Codex (`codex`) when an independent coding agent would help. These agents can inspect and modify the filesystem, but they do not inherit your memory or conversation context.
+You can shell out to **Claude Code** (`claude`) and **Codex** (`codex`) as stateless sub-agents via Bash. They have filesystem and tool access (scope depends on sandbox/approval settings) but **zero memory** — every session starts from scratch.
 
-Default to `run_in_background: true` on the Bash call. Keep working while the process runs, then read its result with `TaskOutput` using the returned task ID.
-
-## Before Dispatching
-
-CLI interfaces and model catalogs change. Check the installed command instead of relying on remembered flags or model names:
-
-```bash
-command -v claude && claude --version && claude --help
-command -v codex && codex --version && codex exec --help
-```
-
-Use each CLI's configured default model unless the user explicitly requests a model. If a requested model is rejected, inspect the current CLI/account configuration and use a supported option rather than guessing another versioned name.
-
-Use an absolute repository path. Claude Code inherits the shell's current directory, so change directories in the shell command. Codex supports `-C` for its working root.
+**Default to `run_in_background: true`** on the Bash call so you can keep working while they run. Check results later with `TaskOutput`. Don't sit idle waiting for a subagent.
 
 ## The Core Mental Model
 
-Treat a dispatched agent like a capable new collaborator with no project history. Give it the context it cannot discover efficiently:
+Claude Code and Codex are highly optimized coding agents, but are re-born with each new session. Think of them like a brilliant intern that showed up today. Provide them with the right instructions and context to help them succeed and avoid having to re-learn things that you've learned.
 
-- **Specific task**: Ask for a concrete result, not a broad topic.
-- **Repository and key files**: Include the absolute repo path and likely entry points.
-- **Relevant architecture**: Explain how the pieces connect.
-- **Constraints**: Include scope, style, safety, and user preferences.
-- **Prior work**: Describe attempted approaches and known dead ends.
-- **Expected output**: Request a diff, root-cause analysis, file list, or review verdict.
+You are the experienced manager with persistent memory of the user's preferences, the codebase, past decisions, and hard-won lessons. **Give them context, not a plan.** They won't know anything you don't tell them:
 
-Give the agent context and constraints, not a prescribed implementation plan. Let it independently inspect the evidence and propose an approach.
+- **Specific task**: Be precise about what you need — not "look into the auth system" but "trace the request flow from the messages endpoint through to the LLM call, cite files and line numbers."
+- **File paths and architecture**: Tell them exactly where to look and how pieces connect. They will wander aimlessly without this.
+- **Preferences and constraints**: Code style, error handling patterns, things the user has corrected you on. Save them from making mistakes you already learned from.
+- **What you've already tried**: If you're dispatching because you're stuck, this prevents them from rediscovering your dead ends.
 
-## When to Dispatch
+If a subagent needs clarification or asks a question, respond in the same session (see Session Resumption below) — don't start a new session or you'll lose the conversation context.
 
-Good uses:
+## When to Dispatch (and When Not To)
 
-- Hard debugging where fresh eyes would help
-- Independent review of a plan or diff
-- Parallel investigation of distinct hypotheses
-- Broad codebase tracing across many files
-- A contained implementation in an isolated worktree
+### Dispatch for:
+- **Hard debugging** — you've been looping on a problem and need fresh eyes
+- **Second opinions** — you want validation before a risky change
+- **Parallel research** — investigate multiple hypotheses simultaneously
+- **Large-scope investigation** — tracing a flow across many files in an unfamiliar area
+- **Code review** — have another agent review your diff or plan
 
-Work directly instead for simple reads, searches, small edits, or tasks where transferring context costs more than doing the work.
+### Don't dispatch for:
+- Simple file reads, greps, or small edits — faster to do yourself
+- Anything that takes less than ~3 minutes of direct work
+- Tasks where you already know exactly what to do
+- When context transfer would take longer than just doing the task
 
-## Prompt Template
+## Choosing an Agent and Model
 
-```text
-TASK: [one-sentence objective]
+Different agents have different strengths. Track what works in your memory over time — your own observations are more valuable than these defaults.
+
+### Categories
+
+**Codex:**
+- Use the configured default model. Model catalogs and account access change frequently, so only pass `--model` when the user explicitly requests one.
+- If a requested model is rejected, inspect the installed CLI and account configuration rather than guessing another model name.
+
+**Claude Code:**
+- `opus` — Excellent writer. Best for docs, refactors, open-ended tasks, and vague instructions.
+  - Strengths: Excellent writer, understands vague instructions, excellent for coding but also general-purpose
+  - Weaknesses: Tends to generate "slop", writing excessive quantities of code unnecessarily. Can hang on large repos.
+
+### Cost and speed tradeoffs
+- Use each CLI's configured default model unless the task requires a model the user explicitly requested
+- Use `--max-budget-usd N` (Claude Code) to cap spend on exploratory tasks
+
+### Known quirks
+- **Claude Code can hang on large repos** with unrestricted tools — consider `--allowedTools "Read Grep Glob"` (no Bash) and shorter timeouts for research tasks
+- **Codex compactions can destroy long trajectories** — for very long tasks, prefer multiple shorter sessions over one marathon
+- **Opus tends to over-generate** — produces more code than necessary. Good for exploration, verify before applying.
+
+## Prompting Subagents
+
+### Prompt template
+```
+TASK: [one-sentence summary]
 
 CONTEXT:
-- Repo: [absolute path]
-- Key files: [specific paths and responsibilities]
-- Architecture: [relevant flow]
+- Repo: [path]
+- Key files: [list specific files and what they contain]
+- Architecture: [brief relevant context]
 
 WHAT TO DO:
-[precise investigation or implementation request]
+[what you need done — be precise, but let them figure out the approach]
 
 CONSTRAINTS:
-- [scope and project conventions]
-- [user preferences]
-- [attempts or dead ends]
+- [any preferences, patterns to follow, things to avoid]
+- [what you've already tried, if dispatching because stuck]
 
 OUTPUT:
-[exact result to return]
+[what you want back — a diff, a list of files, a root cause analysis, etc.]
 ```
 
-## Durable Invocation Patterns
+### What makes a good prompt
+- **Be specific about files** — "look at `src/agent/message.ts` lines 40-80" not "look at the message handling code"
+- **State the output format** — "return a bullet list of findings" vs. leaving it open-ended
+- **Include constraints** — if the user prefers certain patterns, say so explicitly
+- **Provide what you've tried** — when dispatching because you're stuck, this prevents them from repeating your dead ends
 
-### Claude Code
+## Dispatch Patterns
 
-Run from the target repository and request structured output so the session ID is available for follow-up:
+### Parallel research — multiple perspectives
+Run Claude Code and Codex simultaneously on the same question via separate Bash calls in a single message (use `run_in_background: true`). Compare results for higher confidence.
 
+### Background dispatch — keep working while they run
+Use `run_in_background: true` on the Bash call to dispatch async. Continue your own work, then check results with `TaskOutput` when ready.
+
+### Deep investigation
+For hard problems, use the configured model in a writable sandbox:
 ```bash
-cd "/absolute/path/to/repo" && claude -p "YOUR PROMPT" --output-format json
+codex exec "YOUR PROMPT" --sandbox workspace-write -C /path/to/repo
 ```
 
-For read-only research, inspect `claude --help` and restrict its tools to the current read/search tool names. For implementation, use the permission mode appropriate to the surrounding environment. Permission bypass is appropriate only when the process is already isolated by a sandbox or disposable worktree and the task warrants unrestricted execution.
+Claude Code does not support a `-C` working-directory flag. Use `cd /path/to/repo && claude ...` inside the Bash command. Use `--add-dir` only to grant access to additional directories outside the current working directory.
 
-### Codex
-
-Use a read-only sandbox for investigation:
-
+### Code review — cross-agent validation
+Have one agent write code or create a plan, then dispatch another to review:
 ```bash
-codex exec -C "/absolute/path/to/repo" --sandbox read-only --json "YOUR PROMPT"
+# Codex has a native review command:
+codex review --uncommitted    # Review all local changes
+codex exec review "Focus on error handling and edge cases"
+
+# Claude Code — pass the diff inline:
+claude -p "Review the following diff for correctness, edge cases, and missed error handling:\n\n$(git diff)" \
+  --model opus --dangerously-skip-permissions
 ```
 
-Use a writable sandbox for implementation in an isolated worktree:
-
+### Get outside feedback on your work
+Write your plan or analysis to a file, then ask a subagent to critique it:
 ```bash
-codex exec -C "/absolute/path/to/repo" --sandbox workspace-write --json "YOUR PROMPT"
+cd /path/to/repo && claude -p "Read /tmp/my-plan.md and critique it. What am I missing? What could go wrong?" \
+  --model opus --dangerously-skip-permissions
 ```
-
-Check `codex exec --help` before adding optional approval, search, or model flags. Prefer the current explicit sandbox controls over deprecated convenience flags.
-
-### Parallel research
-
-Launch separate Bash calls in one message with `run_in_background: true`. Give each agent the same evidence but a distinct hypothesis or review angle, then compare their conclusions against the source yourself.
-
-### Code review
-
-Codex has a native non-interactive review command. Confirm its current options first:
-
-```bash
-codex review --help
-cd "/absolute/path/to/repo" && codex review --uncommitted
-```
-
-Claude Code can review from the working tree directly; tell it to inspect `git diff` rather than embedding a potentially large diff in the shell command.
-
-## Sessions and Follow-up
-
-Preserve the session identifier from structured output. Resume the same session when asking a follow-up so the dispatched agent retains what it already inspected:
-
-```bash
-cd "/absolute/path/to/repo" && claude -r SESSION_ID -p "Follow-up prompt" --output-format json
-cd "/absolute/path/to/repo" && codex exec resume --json SESSION_ID "Follow-up prompt"
-```
-
-Run the corresponding `--help` command if the installed CLI rejects a resume form. Do not infer a session ID by scraping private on-disk storage layouts.
 
 ## Handling Failures
 
-Classify the failure before retrying:
+- **Timeout**: If an agent times out (especially Claude Code on large repos), try: (1) a shorter, more focused prompt, (2) restricting tools with `--allowedTools`, (3) switching to Codex which handles large repos better
+- **Garbage output**: If results are incoherent, the prompt was probably too vague. Rewrite with more specific file paths and clearer instructions.
+- **Session errors**: Claude Code can hit "stale approval from interrupted session" — `--dangerously-skip-permissions` prevents this. If Codex errors, start a fresh `exec` session.
+- **Compaction mid-task**: If a Codex session runs long enough to compact, it may lose earlier context. Break long tasks into smaller sequential sessions.
 
-- **Command missing**: Report which CLI is unavailable or dispatch the other one.
-- **Unknown/deprecated option**: Re-read the installed command's `--help` and rebuild the invocation from supported flags.
-- **Unsupported model**: Remove the model override or use an option verified for the current account.
-- **Authentication, quota, or service error**: Preserve the exact error; changing the prompt will not fix it.
-- **Timeout**: Inspect partial output, narrow the task, and resume the same session when possible.
-- **Poor result**: Add missing files, constraints, prior attempts, and a more precise output contract.
+## CLI Reference
 
-A launched process is not proof of a successful dispatch. Verify that it completed an agent turn and returned the requested output before relying on its conclusions.
+### Claude Code
+
+```bash
+claude -p "YOUR PROMPT" --model MODEL --dangerously-skip-permissions
+```
+
+| Flag | Purpose |
+|------|---------|
+| `-p` / `--print` | Non-interactive mode, prints response and exits |
+| `--dangerously-skip-permissions` | Skip approval prompts (prevents stale approval errors on timeout) |
+| `--model MODEL` | Alias or model name accepted by the installed CLI; omit to use the configured default |
+| `--effort LEVEL` | `low`, `medium`, `high` — controls reasoning depth |
+| `--append-system-prompt "..."` | Inject additional system instructions |
+| `--allowedTools "Bash Edit Read"` | Restrict available tools |
+| `--max-budget-usd N` | Cap spend for the invocation |
+| `--add-dir DIR` | Allow access to an additional directory; does not change the working directory |
+| `--output-format json` | Structured output with `session_id`, `cost_usd`, `duration_ms` |
+
+Set Claude Code's working directory with `cd /path/to/repo && claude ...` in the Bash command, not with a Claude flag.
+
+### Codex
+
+```bash
+codex exec "YOUR PROMPT" --sandbox workspace-write
+```
+
+| Flag | Purpose |
+|------|---------|
+| `exec` | Non-interactive mode |
+| `-m MODEL` | Model accepted by the installed CLI; omit to use the configured default |
+| `--sandbox MODE` | Select a read-only or writable sandbox |
+| `-C DIR` | Set working directory |
+| `--search` | Enable web search tool |
+| `review` | Native code review — `codex review --uncommitted` or `codex exec review "prompt"` |
+
+## Session Management
+
+Both CLIs persist full session data (tool calls, reasoning, files read) to disk. The Bash output you see is just the final summary — the local session file is much richer.
+
+### Session storage paths
+
+**Claude Code:** `~/.claude/projects/<encoded-path>/<session-id>.jsonl`
+- `<encoded-path>` = working directory with `/` replaced by `-` (e.g. `/Users/foo/repos/bar` becomes `-Users-foo-repos-bar`)
+- Use `--output-format json` to get the `session_id` in the response
+
+**Codex:** `~/.codex/sessions/<year>/<month>/<day>/rollout-*-<session-id>.jsonl`
+- Session ID is printed in output header: `session id: <uuid>`
+- Extract with: `grep "^session id:" output | awk '{print $3}'`
+
+### Resuming sessions
+
+Use session resumption to continue a line of investigation without re-providing all context:
+
+**Claude Code:**
+```bash
+claude -r SESSION_ID -p "Follow up: now check if..."    # Resume by ID
+claude -c -p "Also check..."                             # Continue most recent
+claude -r SESSION_ID --fork-session -p "Try differently" # Fork (new ID, keeps history)
+```
+
+**Codex:**
+```bash
+codex exec resume SESSION_ID "Follow up prompt"  # Resume by ID (non-interactive)
+codex exec resume --last "Follow up prompt"      # Resume most recent (non-interactive)
+codex resume SESSION_ID "Follow up prompt"       # Resume by ID (interactive)
+codex resume --last "Follow up prompt"           # Resume most recent (interactive)
+codex fork SESSION_ID "Try a different approach" # Fork session (interactive)
+```
+
+Note: `codex exec resume` works non-interactively. `codex resume` and `codex fork` are interactive only.
+
+### When to analyze past sessions
+
+**Don't** run `history-analyzer` after every dispatch — your reflection agent already captures insights naturally, and single-session analysis produces overly detailed notes.
+
+**Do** use `history-analyzer` for **bulk migration** when bootstrapping memory from months of accumulated history (e.g. during `/init`). See the `initializing-memory` skill's historical session analysis reference.
+
+Direct uses for session files:
+- **Resume** an investigation (see above)
+- **Review** what an agent actually did (read the JSONL file directly)
+- **Bulk migration** when setting up a new agent
+
+## Timeouts
+
+Set Bash timeouts appropriate to the task:
+- Quick checks / reviews: `timeout: 120000` (2 min)
+- Research / analysis: `timeout: 300000` (5 min)
+- Implementation: `timeout: 600000` (10 min)

--- a/src/skills/dispatching-coding-agents.test.ts
+++ b/src/skills/dispatching-coding-agents.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const skill = readFileSync(
+  join(
+    process.cwd(),
+    "src",
+    "skills",
+    "builtin",
+    "dispatching-coding-agents",
+    "SKILL.md",
+  ),
+  "utf8",
+);
+
+describe("dispatching-coding-agents skill", () => {
+  test("uses runtime CLI discovery instead of versioned model guidance", () => {
+    expect(skill).toContain("command -v claude && claude --version");
+    expect(skill).toContain("command -v codex && codex --version");
+    expect(skill).toContain("configured default model");
+    expect(skill).not.toMatch(/\bgpt-\d/i);
+    expect(skill).not.toMatch(/\bclaude-[a-z][a-z0-9-]*-\d/i);
+    expect(skill).not.toContain("latest frontier");
+  });
+
+  test("documents durable working-directory and sandbox controls", () => {
+    expect(skill).toContain(
+      'cd "/absolute/path/to/repo" && claude -p "YOUR PROMPT" --output-format json',
+    );
+    expect(skill).toContain(
+      'codex exec -C "/absolute/path/to/repo" --sandbox read-only --json "YOUR PROMPT"',
+    );
+    expect(skill).toContain(
+      'codex exec -C "/absolute/path/to/repo" --sandbox workspace-write --json "YOUR PROMPT"',
+    );
+    expect(skill).not.toContain("--full-auto");
+    expect(skill).not.toMatch(/Bash tool.{0,40}`workdir`/i);
+  });
+
+  test("requires successful turn completion and conditional permission bypass", () => {
+    expect(skill).toContain(
+      "Permission bypass is appropriate only when the process is already isolated",
+    );
+    expect(skill).toContain(
+      "A launched process is not proof of a successful dispatch.",
+    );
+    expect(skill).toContain("completed an agent turn");
+  });
+});

--- a/src/skills/dispatching-coding-agents.test.ts
+++ b/src/skills/dispatching-coding-agents.test.ts
@@ -15,36 +15,17 @@ const skill = readFileSync(
 );
 
 describe("dispatching-coding-agents skill", () => {
-  test("uses runtime CLI discovery instead of versioned model guidance", () => {
-    expect(skill).toContain("command -v claude && claude --version");
-    expect(skill).toContain("command -v codex && codex --version");
+  test("uses configured defaults instead of versioned model guidance", () => {
     expect(skill).toContain("configured default model");
     expect(skill).not.toMatch(/\bgpt-\d/i);
     expect(skill).not.toMatch(/\bclaude-[a-z][a-z0-9-]*-\d/i);
-    expect(skill).not.toContain("latest frontier");
   });
 
-  test("documents durable working-directory and sandbox controls", () => {
+  test("avoids deprecated Codex flags and nonexistent Bash options", () => {
     expect(skill).toContain(
-      'cd "/absolute/path/to/repo" && claude -p "YOUR PROMPT" --output-format json',
-    );
-    expect(skill).toContain(
-      'codex exec -C "/absolute/path/to/repo" --sandbox read-only --json "YOUR PROMPT"',
-    );
-    expect(skill).toContain(
-      'codex exec -C "/absolute/path/to/repo" --sandbox workspace-write --json "YOUR PROMPT"',
+      'codex exec "YOUR PROMPT" --sandbox workspace-write',
     );
     expect(skill).not.toContain("--full-auto");
     expect(skill).not.toMatch(/Bash tool.{0,40}`workdir`/i);
-  });
-
-  test("requires successful turn completion and conditional permission bypass", () => {
-    expect(skill).toContain(
-      "Permission bypass is appropriate only when the process is already isolated",
-    );
-    expect(skill).toContain(
-      "A launched process is not proof of a successful dispatch.",
-    );
-    expect(skill).toContain("completed an agent turn");
   });
 });


### PR DESCRIPTION
## Summary
- replace stale model IDs with configured defaults and remove the deprecated invocation flag
- correct working-directory guidance and add focused regression coverage for those failure modes

## Test plan
- [x] `bun test src/skills/dispatching-coding-agents.test.ts`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)