### PR TITLE
feat(cli): render responsive markdown tables [LET-9563]

### DIFF
--- a/src/cli/components/AssistantMessageRich.tsx
+++ b/src/cli/components/AssistantMessageRich.tsx
@@ -46,7 +46,11 @@ export const AssistantMessage = memo(({ line }: { line: AssistantLine }) => {
         <Text>{line.isContinuation ? " " : CLI_GLYPHS.bullet}</Text>
       </Box>
       <Box flexGrow={1} width={contentWidth}>
-        <MarkdownDisplay text={normalizedText} hangingIndent={0} />
+        <MarkdownDisplay
+          text={normalizedText}
+          hangingIndent={0}
+          contentWidth={contentWidth}
+        />
       </Box>
     </Box>
   );

--- a/src/cli/components/MarkdownDisplay.tsx
+++ b/src/cli/components/MarkdownDisplay.tsx
@@ -3,6 +3,7 @@ import type React from "react";
 import stringWidth from "string-width";
 import { colors, hexToBgAnsi } from "./colors.js";
 import { InlineMarkdown } from "./InlineMarkdownRenderer.js";
+import { MarkdownTable } from "./MarkdownTable.js";
 import {
   highlightCode,
   languageFromPath,
@@ -15,7 +16,7 @@ interface MarkdownDisplayProps {
   dimColor?: boolean;
   hangingIndent?: number; // indent for wrapped lines within a paragraph
   backgroundColor?: string; // background color for all text
-  contentWidth?: number; // available width — used to pad lines to fill background
+  contentWidth?: number; // available width for responsive blocks and background padding
 }
 
 // Regex patterns for markdown elements (defined outside component to avoid re-creation)
@@ -129,97 +130,6 @@ export const MarkdownDisplay: React.FC<MarkdownDisplayProps> = ({
             `${key}-code-${lineIdx}`,
           ),
         )}
-      </Box>
-    );
-  };
-
-  // Helper function to parse table cells from a row
-  const parseTableCells = (row: string): string[] => {
-    return row
-      .slice(1, -1) // Remove leading and trailing |
-      .split("|")
-      .map((cell) => cell.trim());
-  };
-
-  // Helper function to render a table
-  const renderTable = (
-    tableLines: string[],
-    startIndex: number,
-  ): React.ReactNode => {
-    if (tableLines.length < 2 || !tableLines[0]) return null;
-
-    const headerRow = parseTableCells(tableLines[0]);
-    const bodyRows = tableLines.slice(2).map(parseTableCells); // Skip separator row
-
-    // Calculate column widths
-    const colWidths = headerRow.map((header, colIdx) => {
-      const bodyMax = bodyRows.reduce((max, row) => {
-        const cell = row[colIdx] || "";
-        return Math.max(max, cell.length);
-      }, 0);
-      return Math.max(header.length, bodyMax, 3); // Minimum 3 chars
-    });
-
-    return (
-      <Box key={`table-${startIndex}`} flexDirection="column" marginY={0}>
-        {/* Header row */}
-        <Box flexDirection="row">
-          <Text dimColor={dimColor} backgroundColor={backgroundColor}>
-            │
-          </Text>
-          {headerRow.map((cell, idx) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: static table content
-            <Box key={`h-${idx}`} flexDirection="row">
-              <Text bold dimColor={dimColor} backgroundColor={backgroundColor}>
-                {" "}
-                {cell.padEnd(colWidths[idx] ?? 3)}
-              </Text>
-              <Text dimColor={dimColor} backgroundColor={backgroundColor}>
-                {" "}
-                │
-              </Text>
-            </Box>
-          ))}
-        </Box>
-        {/* Separator */}
-        <Box flexDirection="row">
-          <Text dimColor={dimColor} backgroundColor={backgroundColor}>
-            ├
-          </Text>
-          {colWidths.map((width, idx) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: static table content
-            <Box key={`s-${idx}`} flexDirection="row">
-              <Text dimColor={dimColor} backgroundColor={backgroundColor}>
-                {"─".repeat(width + 2)}
-              </Text>
-              <Text dimColor={dimColor} backgroundColor={backgroundColor}>
-                {idx < colWidths.length - 1 ? "┼" : "┤"}
-              </Text>
-            </Box>
-          ))}
-        </Box>
-        {/* Body rows */}
-        {bodyRows.map((row, rowIdx) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: static table content
-          <Box key={`r-${rowIdx}`} flexDirection="row">
-            <Text dimColor={dimColor} backgroundColor={backgroundColor}>
-              │
-            </Text>
-            {row.map((cell, colIdx) => (
-              // biome-ignore lint/suspicious/noArrayIndexKey: static table content
-              <Box key={`c-${colIdx}`} flexDirection="row">
-                <Text dimColor={dimColor} backgroundColor={backgroundColor}>
-                  {" "}
-                  {(cell || "").padEnd(colWidths[colIdx] || 3)}
-                </Text>
-                <Text dimColor={dimColor} backgroundColor={backgroundColor}>
-                  {" "}
-                  │
-                </Text>
-              </Box>
-            ))}
-          </Box>
-        ))}
       </Box>
     );
   };
@@ -387,10 +297,15 @@ export const MarkdownDisplay: React.FC<MarkdownDisplayProps> = ({
       }
       // Also accept separator-only lines
       if (tableLines.length >= 2) {
-        const tableElement = renderTable(tableLines, index);
-        if (tableElement) {
-          contentBlocks.push(tableElement);
-        }
+        contentBlocks.push(
+          <MarkdownTable
+            key={`table-${index}`}
+            tableLines={tableLines}
+            contentWidth={contentWidth}
+            dimColor={dimColor}
+            backgroundColor={backgroundColor}
+          />,
+        );
         index = tableIdx;
         continue;
       }

--- a/src/cli/components/MarkdownTable.test.tsx
+++ b/src/cli/components/MarkdownTable.test.tsx
@@ -166,7 +166,7 @@ test("prose-heavy tables fall back to records when columns become cramped", () =
   expect(layoutMarkdownTable(issue, 42).mode).toBe("stacked-records");
 });
 
-test("rendered tables use Codex-style row separators instead of boxes", async () => {
+test("rendered tables use borderless row separators instead of boxes", async () => {
   const output = await renderMarkdown(
     [
       "| Name | Status |",

--- a/src/cli/components/MarkdownTable.test.tsx
+++ b/src/cli/components/MarkdownTable.test.tsx
@@ -1,0 +1,185 @@
+import { expect, test } from "bun:test";
+import { Readable, Writable } from "node:stream";
+import { render } from "ink";
+import stripAnsi from "strip-ansi";
+import { MarkdownDisplay } from "./MarkdownDisplay.js";
+import {
+  layoutMarkdownTable,
+  parseMarkdownTable,
+  splitMarkdownTableRow,
+  tableCellDisplayText,
+} from "./MarkdownTable.js";
+
+class CaptureStream extends Writable {
+  columns: number;
+  rows = 24;
+  isTTY = true;
+  chunks: string[] = [];
+
+  constructor(columns: number) {
+    super();
+    this.columns = columns;
+  }
+
+  override _write(
+    chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ) {
+    this.chunks.push(String(chunk));
+    callback();
+  }
+}
+
+function createInputStream(): NodeJS.ReadStream {
+  const input = new Readable({ read() {} }) as NodeJS.ReadStream;
+  input.isTTY = true;
+  input.setRawMode = () => input;
+  input.ref = () => input;
+  input.unref = () => input;
+  return input;
+}
+
+async function renderMarkdown(
+  markdown: string,
+  contentWidth: number,
+): Promise<string> {
+  const stdout = new CaptureStream(contentWidth) as CaptureStream &
+    NodeJS.WriteStream;
+  const instance = render(
+    <MarkdownDisplay text={markdown} contentWidth={contentWidth} />,
+    {
+      stdout,
+      stdin: createInputStream(),
+      debug: false,
+      patchConsole: false,
+      exitOnCtrlC: false,
+    },
+  );
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  instance.unmount();
+  instance.cleanup();
+  return stripAnsi(stdout.chunks.join(""));
+}
+
+function requireParsedTable(lines: string[]) {
+  const table = parseMarkdownTable(lines);
+  if (!table) throw new Error("Expected a valid Markdown table");
+  return table;
+}
+
+const issueTable = [
+  "| Area | #3292 | #3294/current main |",
+  "|---|---|---|",
+  "| ChatGPT Sol/Terra presets | Adds them | Already merged separately in main |",
+  "| ChatGPT Luna preset | Adds full static preset | #3294 consumes and extends them |",
+  "| Reasoning tiers | Stops at xhigh, labeling it Max | Distinguishes xhigh from true max, matching pi-ai 0.80.6 |",
+  "| Local runtime support | None | Upgrades pi-ai, catalogs models, and updates streaming/compaction |",
+  "| Picker behavior | Adds normalization tests | Fixes metadata mapping, Recents, labels, and reasoning selection |",
+  "| Model ordering | Reorders featured models and demotes GPT-5.5 | Not part of #3294 |",
+];
+
+test("table parser preserves escaped and code-span pipes", () => {
+  expect(splitMarkdownTableRow("| escaped\\|pipe | `a|b` | value |")).toEqual([
+    "escaped|pipe",
+    "`a|b`",
+    "value",
+  ]);
+});
+
+test("table parser reads GFM column alignment", () => {
+  const table = parseMarkdownTable([
+    "| Left | Center | Right |",
+    "|:---|:---:|---:|",
+    "| one | two | three |",
+  ]);
+
+  expect(table?.alignments).toEqual(["left", "center", "right"]);
+  expect(table?.rows).toEqual([["one", "two", "three"]]);
+});
+
+test("table measurements use displayed inline markdown text", () => {
+  expect(tableCellDisplayText("**Bold** and `code`")).toBe("Bold and code");
+  expect(tableCellDisplayText("[label](https://example.com)")).toBe(
+    "label (https://example.com)",
+  );
+});
+
+test("compact tables remain grids when they fit", () => {
+  const table = requireParsedTable([
+    "| Status | Count |",
+    "|---|---:|",
+    "| Ready | 4 |",
+    "| Done | 12 |",
+  ]);
+  const layout = layoutMarkdownTable(table, 80);
+
+  expect(layout.mode).toBe("grid");
+  if (layout.mode === "grid") {
+    const renderedWidth =
+      layout.columnWidths.reduce((total, width) => total + width + 2, 0) + 2;
+    expect(renderedWidth).toBeLessThanOrEqual(80);
+  }
+});
+
+test("wide Unicode cells stay within the grid width budget", () => {
+  const table = requireParsedTable([
+    "| Name | Status |",
+    "|---|---|",
+    "| 東京 | ✅ Ready |",
+    "| München | Complete |",
+  ]);
+  const layout = layoutMarkdownTable(table, 32);
+
+  expect(layout.mode).toBe("grid");
+  if (layout.mode === "grid") {
+    const renderedWidth =
+      layout.columnWidths.reduce((total, width) => total + width + 2, 0) + 2;
+    expect(renderedWidth).toBeLessThanOrEqual(32);
+  }
+});
+
+test("the issue table keeps readable columns at a normal width", () => {
+  const table = requireParsedTable(issueTable);
+  const layout = layoutMarkdownTable(table, 120);
+
+  expect(layout.mode).toBe("grid");
+  if (layout.mode === "grid") {
+    const renderedWidth =
+      layout.columnWidths.reduce((total, width) => total + width + 2, 0) +
+      (layout.columnWidths.length - 1) * 2;
+    expect(renderedWidth).toBeLessThanOrEqual(120);
+    expect(layout.columnWidths[0]).toBeLessThan(layout.columnWidths[2] ?? 0);
+  }
+});
+
+test("prose-heavy tables fall back to records when columns become cramped", () => {
+  const issue = requireParsedTable(issueTable);
+  const pathHeavy = requireParsedTable([
+    "| Path | Description |",
+    "|---|---|",
+    "| /workspace/very-long-directory/generated/artifact.json | Copies generated artifacts into the destination directory after validation completes |",
+  ]);
+
+  expect(layoutMarkdownTable(pathHeavy, 50).mode).toBe("aligned-records");
+  expect(layoutMarkdownTable(issue, 42).mode).toBe("stacked-records");
+});
+
+test("rendered tables use Codex-style row separators instead of boxes", async () => {
+  const output = await renderMarkdown(
+    [
+      "| Name | Status |",
+      "|---|---|",
+      "| Alpha | Ready |",
+      "| Beta | Done |",
+    ].join("\n"),
+    80,
+  );
+
+  expect(output).toContain("Name");
+  expect(output).toContain("━");
+  expect(output).toContain("─");
+  expect(output).not.toContain("│");
+  expect(output).not.toContain("┼");
+});

--- a/src/cli/components/MarkdownTable.tsx
+++ b/src/cli/components/MarkdownTable.tsx
@@ -1,0 +1,656 @@
+import { Box } from "ink";
+import type React from "react";
+import stringWidth from "string-width";
+import { colors } from "./colors.js";
+import { InlineMarkdown } from "./InlineMarkdownRenderer.js";
+import { Text } from "./Text";
+
+const COLUMN_GAP = 2;
+const CELL_PADDING = 1;
+const MIN_COLUMN_WIDTH = 3;
+const EXPANSIVE_COLUMN_FLOOR = 16;
+const MIN_SCANNABLE_EXPANSIVE_WIDTH = 12;
+const CRAMPED_EXPANSIVE_CELL_LINES = 4;
+const CATASTROPHIC_NARRATIVE_CELL_LINES = 7;
+const FIELD_LEADING_PADDING = 1;
+const FIELD_GAP = 2;
+const MIN_ALIGNED_COMPACT_VALUE_WIDTH = 12;
+const MIN_ALIGNED_EXPANSIVE_VALUE_WIDTH = 24;
+
+export type TableAlignment = "left" | "center" | "right";
+type TableColumnKind = "compact" | "narrative" | "token-heavy";
+
+export interface ParsedMarkdownTable {
+  headers: string[];
+  alignments: TableAlignment[];
+  rows: string[][];
+}
+
+interface TableColumnMetrics {
+  maxWidth: number;
+  headerTokenWidth: number;
+  bodyTokenWidth: number;
+  kind: TableColumnKind;
+}
+
+export type MarkdownTableLayout =
+  | { mode: "grid"; columnWidths: number[] }
+  | { mode: "aligned-records"; labelWidth: number }
+  | { mode: "stacked-records"; labelWidth: number };
+
+interface MarkdownTableProps {
+  tableLines: string[];
+  contentWidth?: number;
+  dimColor?: boolean;
+  backgroundColor?: string;
+}
+
+function countBackticks(value: string, start: number): number {
+  let count = 0;
+  while (value[start + count] === "`") count++;
+  return count;
+}
+
+export function splitMarkdownTableRow(row: string): string[] {
+  let source = row.trim();
+  if (source.startsWith("|")) source = source.slice(1);
+  if (source.endsWith("|")) source = source.slice(0, -1);
+
+  const cells: string[] = [];
+  let current = "";
+  let codeFenceLength = 0;
+
+  for (let index = 0; index < source.length; index++) {
+    const character = source[index] ?? "";
+    if (character === "\\" && source[index + 1] === "|") {
+      current += "|";
+      index++;
+      continue;
+    }
+    if (character === "`") {
+      const runLength = countBackticks(source, index);
+      if (codeFenceLength === 0) codeFenceLength = runLength;
+      else if (runLength === codeFenceLength) codeFenceLength = 0;
+      current += "`".repeat(runLength);
+      index += runLength - 1;
+      continue;
+    }
+    if (character === "|" && codeFenceLength === 0) {
+      cells.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += character;
+  }
+
+  cells.push(current.trim());
+  return cells;
+}
+
+function alignmentFromDelimiter(delimiter: string): TableAlignment {
+  const value = delimiter.trim();
+  if (value.startsWith(":") && value.endsWith(":")) return "center";
+  if (value.endsWith(":")) return "right";
+  return "left";
+}
+
+function normalizeRow(row: string[], columnCount: number): string[] {
+  return Array.from({ length: columnCount }, (_, index) => row[index] ?? "");
+}
+
+export function parseMarkdownTable(
+  tableLines: string[],
+): ParsedMarkdownTable | null {
+  const headerLine = tableLines[0];
+  const delimiterLine = tableLines[1];
+  if (!headerLine || !delimiterLine) return null;
+
+  const headers = splitMarkdownTableRow(headerLine);
+  if (headers.length === 0) return null;
+  const delimiters = splitMarkdownTableRow(delimiterLine);
+  if (delimiters.length !== headers.length) return null;
+
+  return {
+    headers,
+    alignments: delimiters.map(alignmentFromDelimiter),
+    rows: tableLines
+      .slice(2)
+      .map(splitMarkdownTableRow)
+      .map((row) => normalizeRow(row, headers.length)),
+  };
+}
+
+export function tableCellDisplayText(value: string): string {
+  return value
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1 ($2)")
+    .replace(/(`+)(.*?)\1/g, "$2")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/~~([^~]+)~~/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/\\([\\|`*~[\]])/g, "$1");
+}
+
+function displayWidth(value: string): number {
+  return stringWidth(tableCellDisplayText(value));
+}
+
+function longestTokenWidth(value: string): number {
+  return tableCellDisplayText(value)
+    .split(/\s+/)
+    .reduce((maximum, token) => Math.max(maximum, stringWidth(token)), 0);
+}
+
+function collectColumnMetrics(
+  table: ParsedMarkdownTable,
+): TableColumnMetrics[] {
+  return table.headers.map((header, column) => {
+    const bodyValues = table.rows.map((row) => row[column] ?? "");
+    const nonEmptyValues = bodyValues.filter(
+      (value) => value.trim().length > 0,
+    );
+    const bodyTokens = nonEmptyValues.flatMap((value) =>
+      tableCellDisplayText(value).split(/\s+/).filter(Boolean),
+    );
+    const longTokenCount = bodyTokens.filter(
+      (token) => stringWidth(token) >= 20,
+    ).length;
+    const totalWords = nonEmptyValues.reduce(
+      (total, value) =>
+        total + tableCellDisplayText(value).split(/\s+/).filter(Boolean).length,
+      0,
+    );
+    const totalWidth = nonEmptyValues.reduce(
+      (total, value) => total + displayWidth(value),
+      0,
+    );
+    const averageWords =
+      nonEmptyValues.length > 0
+        ? totalWords / nonEmptyValues.length
+        : tableCellDisplayText(header).split(/\s+/).filter(Boolean).length;
+    const averageWidth =
+      nonEmptyValues.length > 0
+        ? totalWidth / nonEmptyValues.length
+        : displayWidth(header);
+    const kind: TableColumnKind =
+      longTokenCount > 0 && longTokenCount >= bodyTokens.length - longTokenCount
+        ? "token-heavy"
+        : averageWords >= 4 || averageWidth >= 28
+          ? "narrative"
+          : "compact";
+
+    return {
+      maxWidth: bodyValues.reduce(
+        (maximum, value) => Math.max(maximum, displayWidth(value)),
+        Math.max(displayWidth(header), MIN_COLUMN_WIDTH),
+      ),
+      headerTokenWidth: longestTokenWidth(header),
+      bodyTokenWidth: bodyValues.reduce(
+        (maximum, value) => Math.max(maximum, longestTokenWidth(value)),
+        0,
+      ),
+      kind,
+    };
+  });
+}
+
+function preferredColumnFloor(metrics: TableColumnMetrics): number {
+  const target =
+    metrics.kind === "compact"
+      ? Math.max(metrics.headerTokenWidth, Math.min(metrics.bodyTokenWidth, 16))
+      : EXPANSIVE_COLUMN_FLOOR;
+  return Math.max(MIN_COLUMN_WIDTH, Math.min(target, metrics.maxWidth));
+}
+
+function shrinkPriority(kind: TableColumnKind): number {
+  if (kind === "token-heavy") return 0;
+  if (kind === "narrative") return 1;
+  return 2;
+}
+
+function allocateColumnWidths(
+  metrics: TableColumnMetrics[],
+  availableWidth: number | undefined,
+): number[] | null {
+  const widths = metrics.map((column) => column.maxWidth);
+  if (availableWidth === undefined) return widths;
+  if (availableWidth < metrics.length * MIN_COLUMN_WIDTH) return null;
+
+  const floors = metrics.map(preferredColumnFloor);
+  let floorTotal = floors.reduce((total, width) => total + width, 0);
+  while (floorTotal > availableWidth) {
+    let candidate = -1;
+    for (let index = 0; index < floors.length; index++) {
+      if ((floors[index] ?? 0) <= MIN_COLUMN_WIDTH) continue;
+      if (
+        candidate === -1 ||
+        shrinkPriority(metrics[index]?.kind ?? "compact") <
+          shrinkPriority(metrics[candidate]?.kind ?? "compact") ||
+        (shrinkPriority(metrics[index]?.kind ?? "compact") ===
+          shrinkPriority(metrics[candidate]?.kind ?? "compact") &&
+          (floors[index] ?? 0) > (floors[candidate] ?? 0))
+      ) {
+        candidate = index;
+      }
+    }
+    if (candidate === -1) break;
+    floors[candidate] = (floors[candidate] ?? MIN_COLUMN_WIDTH) - 1;
+    floorTotal--;
+  }
+
+  let totalWidth = widths.reduce((total, width) => total + width, 0);
+  while (totalWidth > availableWidth) {
+    let candidate = -1;
+    for (let index = 0; index < widths.length; index++) {
+      const slack = (widths[index] ?? 0) - (floors[index] ?? 0);
+      if (slack <= 0) continue;
+      if (
+        candidate === -1 ||
+        shrinkPriority(metrics[index]?.kind ?? "compact") <
+          shrinkPriority(metrics[candidate]?.kind ?? "compact") ||
+        (shrinkPriority(metrics[index]?.kind ?? "compact") ===
+          shrinkPriority(metrics[candidate]?.kind ?? "compact") &&
+          slack > (widths[candidate] ?? 0) - (floors[candidate] ?? 0))
+      ) {
+        candidate = index;
+      }
+    }
+    if (candidate === -1) return null;
+    widths[candidate] = (widths[candidate] ?? MIN_COLUMN_WIDTH) - 1;
+    totalWidth--;
+  }
+
+  return widths;
+}
+
+function hardWrappedTokenLines(token: string, width: number): number {
+  return Math.max(1, Math.ceil(stringWidth(token) / Math.max(1, width)));
+}
+
+function wrappedLineCount(value: string, width: number): number {
+  const words = tableCellDisplayText(value).split(/\s+/).filter(Boolean);
+  if (words.length === 0) return 1;
+
+  let lines = 1;
+  let currentWidth = 0;
+  for (const word of words) {
+    const wordWidth = stringWidth(word);
+    if (wordWidth > width) {
+      if (currentWidth > 0) lines++;
+      lines += hardWrappedTokenLines(word, width) - 1;
+      currentWidth = wordWidth % width;
+      continue;
+    }
+    const nextWidth =
+      currentWidth === 0 ? wordWidth : currentWidth + 1 + wordWidth;
+    if (nextWidth > width) {
+      lines++;
+      currentWidth = wordWidth;
+    } else {
+      currentWidth = nextWidth;
+    }
+  }
+  return lines;
+}
+
+function rowNeedsRecordLayout(
+  row: string[],
+  widths: number[],
+  metrics: TableColumnMetrics[],
+): boolean {
+  const fragmented = row.some((cell, column) => {
+    const width = widths[column] ?? MIN_COLUMN_WIDTH;
+    const hasWideToken = tableCellDisplayText(cell)
+      .split(/\s+/)
+      .some((token) => stringWidth(token) > width);
+    const kind = metrics[column]?.kind ?? "compact";
+    if (kind === "compact") return hasWideToken;
+    if (kind === "token-heavy") {
+      return width < MIN_SCANNABLE_EXPANSIVE_WIDTH && hasWideToken;
+    }
+    return false;
+  });
+  if (fragmented) return true;
+
+  const expansiveCells = row
+    .map((cell, column) => ({
+      kind: metrics[column]?.kind ?? "compact",
+      width: widths[column] ?? MIN_COLUMN_WIDTH,
+      lines: wrappedLineCount(cell, widths[column] ?? MIN_COLUMN_WIDTH),
+    }))
+    .filter((cell) => cell.kind !== "compact");
+
+  return (
+    expansiveCells.filter((cell) => cell.lines >= CRAMPED_EXPANSIVE_CELL_LINES)
+      .length >= 2 ||
+    expansiveCells.some(
+      (cell) =>
+        cell.kind === "narrative" &&
+        cell.width < MIN_SCANNABLE_EXPANSIVE_WIDTH &&
+        cell.lines >= CATASTROPHIC_NARRATIVE_CELL_LINES,
+    )
+  );
+}
+
+function shouldRenderRecords(
+  table: ParsedMarkdownTable,
+  widths: number[],
+  metrics: TableColumnMetrics[],
+): boolean {
+  if (table.rows.length === 0) return false;
+  const affectedRows = table.rows.filter((row) =>
+    rowNeedsRecordLayout(row, widths, metrics),
+  ).length;
+  const threshold =
+    table.rows.length === 1 ? 1 : Math.max(2, Math.ceil(table.rows.length / 3));
+  return affectedRows >= threshold;
+}
+
+function recordLayout(
+  table: ParsedMarkdownTable,
+  metrics: TableColumnMetrics[],
+  contentWidth: number | undefined,
+): MarkdownTableLayout {
+  const labelWidth = table.headers.reduce(
+    (maximum, header) => Math.max(maximum, displayWidth(header)),
+    0,
+  );
+  const minimumValueWidth = metrics.some((column) => column.kind !== "compact")
+    ? MIN_ALIGNED_EXPANSIVE_VALUE_WIDTH
+    : MIN_ALIGNED_COMPACT_VALUE_WIDTH;
+  const aligned =
+    contentWidth === undefined ||
+    FIELD_LEADING_PADDING + labelWidth + FIELD_GAP + minimumValueWidth <=
+      contentWidth;
+  return {
+    mode: aligned ? "aligned-records" : "stacked-records",
+    labelWidth,
+  };
+}
+
+export function layoutMarkdownTable(
+  table: ParsedMarkdownTable,
+  contentWidth?: number,
+): MarkdownTableLayout {
+  const metrics = collectColumnMetrics(table);
+  const overhead =
+    table.headers.length * CELL_PADDING * 2 +
+    Math.max(0, table.headers.length - 1) * COLUMN_GAP;
+  const availableWidth =
+    contentWidth === undefined
+      ? undefined
+      : Math.max(0, contentWidth - overhead);
+  const columnWidths = allocateColumnWidths(metrics, availableWidth);
+
+  if (
+    columnWidths === null ||
+    shouldRenderRecords(table, columnWidths, metrics)
+  ) {
+    return recordLayout(table, metrics, contentWidth);
+  }
+  return { mode: "grid", columnWidths };
+}
+
+function alignmentPadding(
+  value: string,
+  width: number,
+  alignment: TableAlignment,
+): { left: string; right: string } {
+  const remaining = Math.max(0, width - displayWidth(value));
+  if (alignment === "right") {
+    return { left: " ".repeat(remaining), right: "" };
+  }
+  if (alignment === "center") {
+    const left = Math.floor(remaining / 2);
+    return { left: " ".repeat(left), right: " ".repeat(remaining - left) };
+  }
+  return { left: "", right: " ".repeat(remaining) };
+}
+
+function TableCell({
+  value,
+  width,
+  alignment,
+  bold,
+  color,
+  dimColor,
+  backgroundColor,
+}: {
+  value: string;
+  width: number;
+  alignment: TableAlignment;
+  bold?: boolean;
+  color?: string;
+  dimColor?: boolean;
+  backgroundColor?: string;
+}) {
+  const padding =
+    displayWidth(value) <= width
+      ? alignmentPadding(value, width, alignment)
+      : { left: "", right: "" };
+  return (
+    <Box
+      width={width + CELL_PADDING * 2}
+      paddingX={CELL_PADDING}
+      flexShrink={0}
+    >
+      <Text
+        wrap="wrap"
+        bold={bold}
+        color={color}
+        dimColor={dimColor}
+        backgroundColor={backgroundColor}
+      >
+        {padding.left}
+        <InlineMarkdown
+          text={value || " "}
+          dimColor={dimColor}
+          backgroundColor={backgroundColor}
+        />
+        {padding.right}
+      </Text>
+    </Box>
+  );
+}
+
+function ColumnGap() {
+  return <Box width={COLUMN_GAP} flexShrink={0} />;
+}
+
+function GridTable({
+  table,
+  columnWidths,
+  dimColor,
+  backgroundColor,
+}: {
+  table: ParsedMarkdownTable;
+  columnWidths: number[];
+  dimColor?: boolean;
+  backgroundColor?: string;
+}) {
+  const separator = (character: string) =>
+    columnWidths
+      .map((width) => character.repeat(width + CELL_PADDING * 2))
+      .join(" ".repeat(COLUMN_GAP));
+  const renderRow = (row: string[], rowIndex: number, isHeader: boolean) => (
+    <Box key={`${isHeader ? "header" : "row"}-${rowIndex}`} flexDirection="row">
+      {row.map((value, column) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: table columns are static within one render
+        <Box key={`column-${column}`} flexDirection="row" flexShrink={0}>
+          {column > 0 ? <ColumnGap /> : null}
+          <TableCell
+            value={value}
+            width={columnWidths[column] ?? MIN_COLUMN_WIDTH}
+            alignment={table.alignments[column] ?? "left"}
+            bold={isHeader}
+            color={isHeader ? colors.heading.secondary : undefined}
+            dimColor={dimColor}
+            backgroundColor={backgroundColor}
+          />
+        </Box>
+      ))}
+    </Box>
+  );
+
+  return (
+    <Box flexDirection="column">
+      {renderRow(table.headers, 0, true)}
+      <Text dimColor backgroundColor={backgroundColor}>
+        {separator("━")}
+      </Text>
+      {table.rows.map((row, rowIndex) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: table rows are static within one render
+        <Box key={`record-${rowIndex}`} flexDirection="column">
+          {renderRow(row, rowIndex, false)}
+          {rowIndex + 1 < table.rows.length ? (
+            <Text dimColor backgroundColor={backgroundColor}>
+              {separator("─")}
+            </Text>
+          ) : null}
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+function RecordSeparator({
+  width,
+  backgroundColor,
+}: {
+  width?: number;
+  backgroundColor?: string;
+}) {
+  return (
+    <Text dimColor backgroundColor={backgroundColor}>
+      {"─".repeat(Math.max(1, width ?? 40))}
+    </Text>
+  );
+}
+
+function RecordTable({
+  table,
+  layout,
+  contentWidth,
+  dimColor,
+  backgroundColor,
+}: {
+  table: ParsedMarkdownTable;
+  layout: Extract<
+    MarkdownTableLayout,
+    { mode: "aligned-records" | "stacked-records" }
+  >;
+  contentWidth?: number;
+  dimColor?: boolean;
+  backgroundColor?: string;
+}) {
+  return (
+    <Box flexDirection="column">
+      {table.rows.map((row, rowIndex) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: table rows are static within one render
+        <Box key={`record-${rowIndex}`} flexDirection="column">
+          {row.map((value, column) => {
+            const header = table.headers[column] ?? `Column ${column + 1}`;
+            if (layout.mode === "aligned-records") {
+              return (
+                // biome-ignore lint/suspicious/noArrayIndexKey: table fields are static within one render
+                <Box key={`field-${column}`} flexDirection="row">
+                  <Box width={FIELD_LEADING_PADDING} flexShrink={0} />
+                  <Box width={layout.labelWidth + FIELD_GAP} flexShrink={0}>
+                    <Text
+                      bold
+                      color={colors.heading.secondary}
+                      backgroundColor={backgroundColor}
+                    >
+                      <InlineMarkdown
+                        text={header}
+                        backgroundColor={backgroundColor}
+                      />
+                    </Text>
+                  </Box>
+                  <Box flexGrow={1} flexShrink={1}>
+                    <Text
+                      wrap="wrap"
+                      dimColor={dimColor}
+                      backgroundColor={backgroundColor}
+                    >
+                      <InlineMarkdown
+                        text={value || " "}
+                        dimColor={dimColor}
+                        backgroundColor={backgroundColor}
+                      />
+                    </Text>
+                  </Box>
+                </Box>
+              );
+            }
+            return (
+              // biome-ignore lint/suspicious/noArrayIndexKey: table fields are static within one render
+              <Box key={`field-${column}`} flexDirection="column">
+                <Box paddingLeft={FIELD_LEADING_PADDING}>
+                  <Text
+                    bold
+                    color={colors.heading.secondary}
+                    backgroundColor={backgroundColor}
+                  >
+                    <InlineMarkdown
+                      text={header}
+                      backgroundColor={backgroundColor}
+                    />
+                  </Text>
+                </Box>
+                <Box paddingLeft={2}>
+                  <Text
+                    wrap="wrap"
+                    dimColor={dimColor}
+                    backgroundColor={backgroundColor}
+                  >
+                    <InlineMarkdown
+                      text={value || " "}
+                      dimColor={dimColor}
+                      backgroundColor={backgroundColor}
+                    />
+                  </Text>
+                </Box>
+              </Box>
+            );
+          })}
+          {rowIndex + 1 < table.rows.length ? (
+            <RecordSeparator
+              width={contentWidth}
+              backgroundColor={backgroundColor}
+            />
+          ) : null}
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+export function MarkdownTable({
+  tableLines,
+  contentWidth,
+  dimColor,
+  backgroundColor,
+}: MarkdownTableProps): React.ReactNode {
+  const table = parseMarkdownTable(tableLines);
+  if (!table) return null;
+  const layout = layoutMarkdownTable(table, contentWidth);
+  if (layout.mode === "grid") {
+    return (
+      <GridTable
+        table={table}
+        columnWidths={layout.columnWidths}
+        dimColor={dimColor}
+        backgroundColor={backgroundColor}
+      />
+    );
+  }
+  return (
+    <RecordTable
+      table={table}
+      layout={layout}
+      contentWidth={contentWidth}
+      dimColor={dimColor}
+      backgroundColor={backgroundColor}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- size Markdown tables from their displayed content and the assistant viewport instead of relying on Ink to collapse oversized rows
- render readable tables as lightweight row-separated grids, then switch cramped content to aligned or stacked key/value records
- preserve inline formatting, GFM alignment, escaped pipes, and Unicode display widths with focused width-regression coverage
- validated with the Markdown rendering tests and the full bun run check suite

👾 Generated with [Letta Code](https://letta.com)