### PR TITLE
fix: detect max_tokens_exceeded as context window overflow

### DIFF
--- a/src/backend/dev/context-window-overflow.ts
+++ b/src/backend/dev/context-window-overflow.ts
@@ -54,5 +54,6 @@ export function isContextWindowOverflowError(error: unknown): boolean {
     "request too large",
     "request_too_large",
     "model_context_window_exceeded",
+    "max_tokens_exceeded",
   ].some((marker) => haystack.includes(marker));
 }


### PR DESCRIPTION
## Summary

- Add `"max_tokens_exceeded"` to the overflow error pattern list in `isContextWindowOverflowError`
- This is a standard OpenAI error code used by multiple providers (OpenRouter, AIsa, Umans, and OpenAI itself) but was not recognized by Letta's overflow detection
- Without this, reactive compaction doesn't trigger when a long conversation hits the context limit on providers that return this error code, leaving the conversation in a broken state until a new conversation is started

## Context

Discovered while debugging a `max_tokens_exceeded` error from the [Umans](https://umans.ai) code gateway (an OpenAI-compatible provider registered via a [community provider mod](https://github.com/ninachaubal/letta-provider-umans)). Long-running conversations would hit the context window limit, the provider would return `max_tokens_exceeded`, but Letta's reactive compaction path didn't recognize it as an overflow error — so the conversation was stuck in a broken state.

Research shows `max_tokens_exceeded` is widely used:
- **OpenRouter** – canonical `error_type` in their [API error reference](https://openrouter.ai/docs/api_reference/errors-and-debugging)
- **AIsa** – listed as a common error code under 422 Unprocessable Entity
- **Omnigent** – included in their `CONTEXT_EXCEEDED_CODES` frozenset alongside `context_length_exceeded`
- **OpenAI** – appears in their own error handling examples (September 2024 API updates)

## Test plan

- [ ] Verify existing overflow detection tests still pass
- [ ] Verify an error containing `max_tokens_exceeded` is now classified as context window overflow

👾 Generated with [Letta Code](https://letta.com)