### PR TITLE
fix(cli): register OAuth flows in standalone bundle [LET-10125]

### DIFF
--- a/build.js
+++ b/build.js
@@ -74,7 +74,7 @@ if (useMagick) {
 }
 
 await Bun.build({
-  entrypoints: ["./src/index.ts"],
+  entrypoints: ["./src/standalone-entry.ts"],
   outdir: ".",
   target: "node",
   format: "esm",

--- a/src/standalone-entry.test.ts
+++ b/src/standalone-entry.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const projectRoot = process.cwd();
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+test("standalone bundle resolves statically embedded OAuth flows", async () => {
+  const tempDir = await mkdtemp(join(projectRoot, ".standalone-oauth-test-"));
+  tempDirs.push(tempDir);
+  const probePath = join(tempDir, "oauth-probe.ts");
+  const outputPath = join(tempDir, "oauth-probe.js");
+
+  await writeFile(
+    probePath,
+    `import { openaiCodexProvider } from "@earendil-works/pi-ai/providers/openai-codex";
+
+const oauth = openaiCodexProvider().auth.oauth;
+if (!oauth) throw new Error("OpenAI Codex OAuth is unavailable");
+const auth = await oauth.toAuth({
+  type: "oauth",
+  access: "standalone-oauth-token",
+  refresh: "refresh-token",
+  expires: Date.now() + 60_000,
+  accountId: "account-id",
+});
+console.log(auth.apiKey);
+`,
+  );
+
+  const result = await Bun.build({
+    entrypoints: [join(projectRoot, "src/standalone-entry.ts")],
+    outdir: tempDir,
+    naming: { entry: "oauth-probe.js" },
+    target: "node",
+    format: "esm",
+    plugins: [
+      {
+        name: "standalone-oauth-probe",
+        setup(build) {
+          build.onResolve({ filter: /^\.\/index$/ }, ({ importer }) => {
+            if (importer.endsWith("standalone-entry.ts")) {
+              return { path: probePath };
+            }
+            return undefined;
+          });
+        },
+      },
+    ],
+  });
+  expect(result.success).toBe(true);
+
+  const execution = spawnSync("node", [outputPath], {
+    cwd: tempDir,
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+
+  if (execution.status !== 0) {
+    throw new Error(
+      `Standalone OAuth probe failed with status ${execution.status}\nstdout:\n${execution.stdout}\nstderr:\n${execution.stderr}`,
+    );
+  }
+  expect(execution.stderr).toBe("");
+  expect(execution.stdout.trim()).toBe("standalone-oauth-token");
+});

--- a/src/standalone-entry.ts
+++ b/src/standalone-entry.ts
@@ -3,6 +3,8 @@ import { registerBunOAuthFlows } from "@earendil-works/pi-ai/bun-oauth";
 // pi-ai keeps Node-only OAuth implementations behind bundler-opaque imports.
 // Register the statically bundled loaders before the application imports any
 // provider runtime so the standalone letta.js never looks for sibling files.
+// This mirrors pi's standalone CLI bootstrap for the pinned pi-ai release:
+// https://github.com/earendil-works/pi/blob/20be4b18d4c57487f8993d2762bace129f0cf7c6/packages/coding-agent/src/bun/cli.ts#L2-L12
 registerBunOAuthFlows();
 
 await import("./index");

--- a/src/standalone-entry.ts
+++ b/src/standalone-entry.ts
@@ -1,0 +1,8 @@
+import { registerBunOAuthFlows } from "@earendil-works/pi-ai/bun-oauth";
+
+// pi-ai keeps Node-only OAuth implementations behind bundler-opaque imports.
+// Register the statically bundled loaders before the application imports any
+// provider runtime so the standalone letta.js never looks for sibling files.
+registerBunOAuthFlows();
+
+await import("./index");


### PR DESCRIPTION
## Summary
- route the production build through a bootstrap that registers pi-ai OAuth implementations before loading the application
- prevent the standalone `letta.js` artifact from resolving nonexistent sibling OAuth modules
- add a single-file bundle regression probe covering ChatGPT OAuth auth derivation under Node

Fixes #3482.
Linear: LET-10125.

## Upstream precedent

This follows the standalone bootstrap pattern used by the pinned pi-ai 0.81.1 release itself:

- [pi standalone CLI registers OAuth flows before dynamically importing the application](https://github.com/earendil-works/pi/blob/20be4b18d4c57487f8993d2762bace129f0cf7c6/packages/coding-agent/src/bun/cli.ts#L2-L12)
- [`registerBunOAuthFlows()` is the upstream hook for statically embedded OAuth implementations](https://github.com/earendil-works/pi/blob/20be4b18d4c57487f8993d2762bace129f0cf7c6/packages/ai/src/bun-oauth.ts#L8-L18)

The new Letta Code entrypoint intentionally uses the same registration-before-dynamic-import ordering.

## Test plan
- [x] `bun test src/standalone-entry.test.ts`
- [x] `bun run check`
- [x] build and run `letta.js` with an isolated local-backend OAuth record; auth derivation proceeds past the previous module-resolution failure

👾 Generated with [Letta Code](https://letta.com)