### PR TITLE
fix(listener): fence remote interrupt cancellation [LET-10216]

### DIFF
--- a/src/backend/api-backend.test.ts
+++ b/src/backend/api-backend.test.ts
@@ -70,6 +70,11 @@ const streamConversationMessagesMock = mock(
 const cancelConversationMock = mock(async (_conversationId: string) => ({
   status: "cancelled",
 }));
+const cancelRunMock = mock(
+  async (_agentId: string, _body: { run_ids: string[] }) => ({
+    "run-1": "cancelled",
+  }),
+);
 const retrieveRunMock = mock(async (_runId: string) => ({
   id: "run-1",
   metadata: {},
@@ -89,6 +94,7 @@ const getClientMock = mock(async () => ({
     update: updateAgentMock,
     messages: {
       list: listAgentMessagesMock,
+      cancel: cancelRunMock,
     },
   },
   conversations: {
@@ -142,6 +148,7 @@ describe("APIBackend", () => {
     createMessageStreamMock.mockClear();
     streamConversationMessagesMock.mockClear();
     cancelConversationMock.mockClear();
+    cancelRunMock.mockClear();
     retrieveRunMock.mockClear();
     streamRunMessagesMock.mockClear();
     forkConversationMock.mockClear();
@@ -225,11 +232,12 @@ describe("APIBackend", () => {
     });
     await backend.streamConversationMessages("conv-1", streamBody);
     await backend.cancelConversation("conv-1");
+    await backend.cancelRun("agent-1", "run-1");
     await backend.retrieveRun("run-1");
     await backend.streamRunMessages("run-1", runStreamBody);
     await backend.forkConversation("conv-1", { agentId: "agent-1" });
 
-    expect(getClientMock).toHaveBeenCalledTimes(16);
+    expect(getClientMock).toHaveBeenCalledTimes(17);
     expect(retrieveAgentMock).toHaveBeenCalledWith("agent-1", {
       include: ["agent.tools"],
     });
@@ -275,6 +283,9 @@ describe("APIBackend", () => {
       undefined,
     );
     expect(cancelConversationMock).toHaveBeenCalledWith("conv-1");
+    expect(cancelRunMock).toHaveBeenCalledWith("agent-1", {
+      run_ids: ["run-1"],
+    });
     expect(retrieveRunMock).toHaveBeenCalledWith("run-1");
     expect(streamRunMessagesMock).toHaveBeenCalledWith(
       "run-1",

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -253,6 +253,11 @@ export interface Backend {
     conversationIdOrAgentId: string,
   ): Promise<Awaited<ReturnType<APIClient["conversations"]["cancel"]>>>;
 
+  cancelRun(
+    agentId: string,
+    runId: string,
+  ): Promise<Awaited<ReturnType<APIClient["agents"]["messages"]["cancel"]>>>;
+
   retrieveRun(
     runId: string,
   ): Promise<Awaited<ReturnType<APIClient["runs"]["retrieve"]>>>;
@@ -464,6 +469,11 @@ export class APIBackend implements Backend {
   async cancelConversation(conversationIdOrAgentId: string) {
     const client = await this.getClient();
     return client.conversations.cancel(conversationIdOrAgentId);
+  }
+
+  async cancelRun(agentId: string, runId: string) {
+    const client = await this.getClient();
+    return client.agents.messages.cancel(agentId, { run_ids: [runId] });
   }
 
   async retrieveRun(runId: string) {

--- a/src/backend/dev/fake-headless-backend.ts
+++ b/src/backend/dev/fake-headless-backend.ts
@@ -390,6 +390,28 @@ export class HeadlessBackend implements Backend {
     return { status: "cancelled" } as never;
   }
 
+  async cancelRun(...args: Parameters<Backend["cancelRun"]>) {
+    const [agentId, runId] = args;
+    const run = this.runs.get(runId);
+    if (!run || run.agent_id !== agentId || isTerminalRun(run)) {
+      return { [runId]: "failed" } as never;
+    }
+
+    if (run.conversation_id) {
+      this.store.settleInterruptedToolCalls(run.conversation_id, { agentId });
+    } else {
+      this.store.settleInterruptedToolCalls(agentId);
+    }
+    const controller = this.runControllerByRunId.get(runId);
+    this.recordRunChunk(runId, {
+      message_type: "stop_reason",
+      stop_reason: "cancelled",
+    } as LettaStreamingResponse);
+    this.completeRun(runId, "cancelled");
+    controller?.abort();
+    return { [runId]: "cancelled" } as never;
+  }
+
   async retrieveRun(runId: string) {
     const run = this.runs.get(runId);
     if (!run) throw new LocalBackendNotFoundError("Run", runId);

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -5288,7 +5288,7 @@ describe("listen-client capability-gated approval flow", () => {
       "default",
     );
     const scheduleQueuePumpMock = mock(() => {});
-    const cancelConversationMock = mock(async () => {});
+    const cancelRunMock = mock(async () => {});
 
     beginTestTurn(runtime, {
       initialStatus: "PROCESSING_API_RESPONSE",
@@ -5313,7 +5313,7 @@ describe("listen-client capability-gated approval flow", () => {
       },
       {
         scheduleQueuePump: scheduleQueuePumpMock,
-        cancelConversation: cancelConversationMock,
+        cancelRun: cancelRunMock,
       },
     );
 
@@ -5330,7 +5330,7 @@ describe("listen-client capability-gated approval flow", () => {
       expect.objectContaining({ connectionId: "conn-1" }),
       expect.any(Function),
     );
-    expect(cancelConversationMock).toHaveBeenCalledWith("agent-1", "default");
+    expect(cancelRunMock).toHaveBeenCalledWith("agent-1", "run-active");
 
     const outbound = socket.sentPayloads.map((payload) => JSON.parse(payload));
     const interruptedStatus = outbound.find(

--- a/src/websocket/listener/control-inputs-interrupt.test.ts
+++ b/src/websocket/listener/control-inputs-interrupt.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { handleAbortMessageInput } from "./control-inputs";
+import { getOrCreateScopedRuntime } from "./conversation-runtime";
+import { enqueueInboundUserMessage } from "./inbound-queue";
+import { createRuntime } from "./lifecycle";
+import { scheduleQueuePump } from "./queue";
+import { setActiveRuntime } from "./runtime";
+import type { ListenerTransport } from "./transport";
+import { finishListenerTurn } from "./turn-terminal";
+import type { IncomingMessage, StartListenerOptions } from "./types";
+
+function createOpenTransport(): ListenerTransport {
+  return {
+    kind: "local",
+    bufferedAmount: 0,
+    isOpen: () => true,
+    send: () => {},
+  };
+}
+
+function createDeferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+} {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) {
+      return;
+    }
+    await Bun.sleep(1);
+  }
+  throw new Error("Timed out waiting for listener interrupt state");
+}
+
+describe("listener interrupt queue handoff", () => {
+  afterEach(() => setActiveRuntime(null));
+
+  test("does not release the next turn before cancellation fallback settles", async () => {
+    const listener = createRuntime();
+    const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
+    const socket = createOpenTransport();
+    const options = {} as StartListenerOptions;
+    const oldLease = runtime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+    });
+    runtime.turnLifecycle.setRunId(oldLease, "run-old");
+    const cancellation = createDeferred();
+    const cancelRun = mock(async (_agentId: string, _runId: string) => {
+      throw new Error("run-scoped cancellation unavailable");
+    });
+    const cancelConversation = mock(
+      async (_agentId: string, _conversationId: string) => cancellation.promise,
+    );
+    const processedTurns: IncomingMessage[] = [];
+    const processQueuedTurn = mock(async (incoming: IncomingMessage) => {
+      processedTurns.push(incoming);
+    });
+    setActiveRuntime(listener);
+
+    expect(
+      await handleAbortMessageInput(
+        listener,
+        {
+          command: {
+            type: "abort_message",
+            runtime: {
+              agent_id: "agent-1",
+              conversation_id: "conv-1",
+            },
+            run_id: "run-old",
+          },
+          socket,
+          opts: options,
+          processQueuedTurn,
+        },
+        { cancelRun, cancelConversation },
+      ),
+    ).toBe(true);
+
+    const queued = enqueueInboundUserMessage(runtime, {
+      type: "message",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      messages: [{ role: "user", content: "kill the looping subagent" }],
+    });
+    expect(queued).toBe(true);
+    scheduleQueuePump(runtime, socket, options, processQueuedTurn);
+
+    expect(
+      finishListenerTurn(runtime, oldLease, {
+        stopReason: "cancelled",
+        socket,
+        runId: "run-old",
+        agentId: "agent-1",
+        conversationId: "conv-1",
+      }).finished,
+    ).toBe(true);
+
+    await waitFor(
+      () => !runtime.queuePumpActive && !runtime.queuePumpScheduled,
+    );
+    expect(runtime.turnLifecycle.kind).toBe("cancelling");
+    expect(runtime.queueRuntime.length).toBe(1);
+    expect(processedTurns).toEqual([]);
+    expect(cancelRun).toHaveBeenCalledWith("agent-1", "run-old");
+    expect(cancelConversation).toHaveBeenCalledWith("agent-1", "conv-1");
+
+    cancellation.resolve();
+    await waitFor(
+      () =>
+        runtime.turnLifecycle.kind === "idle" &&
+        runtime.queueRuntime.length === 0 &&
+        processedTurns.length === 1,
+    );
+
+    expect(processedTurns[0]?.messages).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "kill the looping subagent" }],
+      },
+    ]);
+    expect(cancelRun).toHaveBeenCalledTimes(1);
+    expect(cancelConversation).toHaveBeenCalledTimes(1);
+    expect(processQueuedTurn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/websocket/listener/control-inputs.ts
+++ b/src/websocket/listener/control-inputs.ts
@@ -392,6 +392,7 @@ export async function handleAbortMessageInput(
       agentId: string,
       conversationId: string,
     ) => Promise<void>;
+    cancelRun: (agentId: string, runId: string) => Promise<void>;
   }> = {},
 ): Promise<boolean> {
   const resolvedDeps = {
@@ -411,6 +412,12 @@ export async function handleAbortMessageInput(
           ? agentId
           : conversationId;
       await getBackend().cancelConversation(cancelId);
+    },
+    cancelRun: async (agentId: string, runId: string) => {
+      const result = await getBackend().cancelRun(agentId, runId);
+      if (result[runId] !== "cancelled") {
+        throw new Error(`Backend did not cancel run ${runId}`);
+      }
     },
     ...deps,
   };
@@ -439,7 +446,9 @@ export async function handleAbortMessageInput(
     return false;
   }
 
-  const cancellation = scopedRuntime.turnLifecycle.requestCancellation();
+  const cancellation = scopedRuntime.turnLifecycle.requestCancellation({
+    waitForExternalSettlement: hasActiveTurn && Boolean(scopedRuntime.agentId),
+  });
   const interruptedRunId = cancellation.runId;
   const pendingRequestsSnapshot = hasPendingApprovals
     ? resolvedDeps.getPendingControlRequests(listener, scope)
@@ -539,10 +548,39 @@ export async function handleAbortMessageInput(
   const cancelConversationId = scopedRuntime.conversationId;
   const cancelAgentId = scopedRuntime.agentId;
   if (cancelAgentId) {
-    void resolvedDeps
-      .cancelConversation(cancelAgentId, cancelConversationId)
+    const cancelRunId = interruptedRunId ?? params.command.run_id ?? null;
+    // Target the interrupted run when possible so this abort can never select
+    // a replacement turn. Older backends may reject run-scoped cancellation;
+    // the lifecycle fence also makes the conversation-wide fallback safe.
+    const backendCancellation = cancelRunId
+      ? resolvedDeps
+          .cancelRun(cancelAgentId, cancelRunId)
+          .catch(() =>
+            resolvedDeps.cancelConversation(
+              cancelAgentId,
+              cancelConversationId,
+            ),
+          )
+      : resolvedDeps.cancelConversation(cancelAgentId, cancelConversationId);
+    void backendCancellation
       .catch(() => {
         // Fire-and-forget
+      })
+      .finally(() => {
+        if (!cancellation.lease) {
+          return;
+        }
+        const settlement = scopedRuntime.turnLifecycle.settleCancellation(
+          cancellation.lease,
+        );
+        if (settlement.released) {
+          resolvedDeps.scheduleQueuePump(
+            scopedRuntime,
+            params.socket,
+            params.opts as StartListenerOptions,
+            params.processQueuedTurn,
+          );
+        }
       });
   }
 

--- a/src/websocket/listener/turn-lifecycle.test.ts
+++ b/src/websocket/listener/turn-lifecycle.test.ts
@@ -63,6 +63,53 @@ describe("TurnLifecycle", () => {
     expect(lifecycle.lastStopReason).toBe("cancelled");
   });
 
+  test("cancellation waits for both its owner and external cleanup", () => {
+    const lifecycle = new TurnLifecycle(() => "lease-1");
+    const lease = lifecycle.begin({
+      origin: "message",
+      workingDirectory: "/tmp/worktree",
+    });
+
+    lifecycle.requestCancellation({ waitForExternalSettlement: true });
+    expect(lifecycle.finish(lease, "cancelled")).toEqual({
+      finished: true,
+      previousKind: "cancelling",
+      runId: null,
+    });
+    expect(lifecycle.kind).toBe("cancelling");
+    expect(lifecycle.isCurrent(lease)).toBe(false);
+    expect(lifecycle.currentLease).toBeNull();
+    expect(lifecycle.finish(lease, "cancelled").finished).toBe(false);
+
+    expect(lifecycle.settleCancellation(lease)).toEqual({
+      settled: true,
+      released: true,
+    });
+    expect(lifecycle.kind).toBe("idle");
+    expect(lifecycle.settleCancellation(lease)).toEqual({
+      settled: false,
+      released: false,
+    });
+  });
+
+  test("external cleanup may settle before the cancelling owner finishes", () => {
+    const lifecycle = new TurnLifecycle(() => "lease-1");
+    const lease = lifecycle.begin({
+      origin: "message",
+      workingDirectory: "/tmp/worktree",
+    });
+
+    lifecycle.requestCancellation({ waitForExternalSettlement: true });
+    expect(lifecycle.settleCancellation(lease)).toEqual({
+      settled: true,
+      released: false,
+    });
+    expect(lifecycle.kind).toBe("cancelling");
+
+    expect(lifecycle.finish(lease, "cancelled").finished).toBe(true);
+    expect(lifecycle.kind).toBe("idle");
+  });
+
   test("reset invalidates stale async owners before a replacement turn", () => {
     let nextId = 0;
     const lifecycle = new TurnLifecycle(() => `lease-${++nextId}`);

--- a/src/websocket/listener/turn-lifecycle.ts
+++ b/src/websocket/listener/turn-lifecycle.ts
@@ -41,6 +41,8 @@ type CancellingTurnState = {
   runId: string | null;
   executingToolCallIds: readonly string[];
   loopStatus: "WAITING_ON_INPUT";
+  ownerFinished: boolean;
+  externalSettlementPending: boolean;
 };
 
 type TurnState =
@@ -53,13 +55,21 @@ export type TurnLifecycleSnapshot =
   | IdleTurnState
   | CommandTurnState
   | Omit<ActiveTurnState, "abortController">
-  | Omit<CancellingTurnState, "abortController">;
+  | Omit<
+      CancellingTurnState,
+      "abortController" | "ownerFinished" | "externalSettlementPending"
+    >;
 
 export type TurnCancellationTransition = {
   transitioned: boolean;
   lease: TurnLease | null;
   runId: string | null;
   executingToolCallIds: readonly string[];
+};
+
+export type TurnCancellationSettlementTransition = {
+  settled: boolean;
+  released: boolean;
 };
 
 export type TurnFinishTransition = {
@@ -117,9 +127,13 @@ export class TurnLifecycle {
   }
 
   get currentLease(): TurnLease | null {
-    return this.#state.kind === "active" || this.#state.kind === "cancelling"
-      ? this.#state.lease
-      : null;
+    if (this.#state.kind === "active") {
+      return this.#state.lease;
+    }
+    if (this.#state.kind === "cancelling" && !this.#state.ownerFinished) {
+      return this.#state.lease;
+    }
+    return null;
   }
 
   snapshot(): TurnLifecycleSnapshot {
@@ -183,6 +197,7 @@ export class TurnLifecycle {
   isCurrent(lease: TurnLease): boolean {
     return (
       (this.#state.kind === "active" || this.#state.kind === "cancelling") &&
+      (this.#state.kind !== "cancelling" || !this.#state.ownerFinished) &&
       this.#state.lease.id === lease.id
     );
   }
@@ -250,7 +265,9 @@ export class TurnLifecycle {
     return true;
   }
 
-  requestCancellation(): TurnCancellationTransition {
+  requestCancellation(options?: {
+    waitForExternalSettlement?: boolean;
+  }): TurnCancellationTransition {
     const state = this.#state;
     if (state.kind === "cancelling") {
       return {
@@ -281,6 +298,8 @@ export class TurnLifecycle {
       runId: state.runId,
       executingToolCallIds: [...state.executingToolCallIds],
       loopStatus: "WAITING_ON_INPUT",
+      ownerFinished: false,
+      externalSettlementPending: options?.waitForExternalSettlement === true,
     };
     return {
       transitioned: true,
@@ -294,18 +313,48 @@ export class TurnLifecycle {
     const state = this.#state;
     if (
       (state.kind !== "active" && state.kind !== "cancelling") ||
-      state.lease.id !== lease.id
+      state.lease.id !== lease.id ||
+      (state.kind === "cancelling" && state.ownerFinished)
     ) {
       return { finished: false, previousKind: null, runId: null };
     }
 
     this.#lastStopReason = stopReason;
-    this.#state = IDLE_STATE;
+    if (state.kind === "cancelling" && state.externalSettlementPending) {
+      this.#state = {
+        ...state,
+        ownerFinished: true,
+      };
+    } else {
+      this.#state = IDLE_STATE;
+    }
     return {
       finished: true,
       previousKind: state.kind,
       runId: state.runId,
     };
+  }
+
+  settleCancellation(lease: TurnLease): TurnCancellationSettlementTransition {
+    const state = this.#state;
+    if (
+      state.kind !== "cancelling" ||
+      state.lease.id !== lease.id ||
+      !state.externalSettlementPending
+    ) {
+      return { settled: false, released: false };
+    }
+
+    if (state.ownerFinished) {
+      this.#state = IDLE_STATE;
+      return { settled: true, released: true };
+    }
+
+    this.#state = {
+      ...state,
+      externalSettlementPending: false,
+    };
+    return { settled: true, released: false };
   }
 
   reset(stopReason: StopReasonType = "cancelled"): TurnFinishTransition {


### PR DESCRIPTION
## Summary

Fixes [LET-10216](https://linear.app/letta/issue/LET-10216/enter-on-frozen-tool-call-interrupt-i-ends-up-with-iui-sandwich).

Remote interrupts now preserve the same high-level invariant as the TUI: an interrupt belongs to the active turn, and its cleanup cannot affect the next submitted turn.

- prefer run-scoped backend cancellation using the interrupted run ID already carried by the listener/Desktop protocol
- fall back to conversation-wide cancellation for compatibility, while keeping that fallback behind the same fence
- keep `TurnLifecycle` queue-blocking until both the local turn owner unwinds and backend cancellation settles; the UI can still project idle immediately
- add exact-run cancellation to the backend abstraction and local backend implementation

Previously, the listener fired conversation cancellation without awaiting it. Desktop released its deferred user input as soon as the listener projected idle, so a delayed conversation-wide cancel could enumerate and cancel the replacement run, producing the I/U/I sequence.

## Tests

- regression test holds cancellation unresolved, finishes the interrupted owner, and proves queued input remains blocked until cancellation settles
- regression also covers the conversation-wide compatibility fallback and verifies the replacement turn starts exactly once
- lifecycle ordering tests cover backend-first and owner-first settlement
- API backend test verifies exact `run_ids` cancellation
- `bun run check` (12/12 checks pass)
- focused listener/backend tests and pre-commit checks pass
