### PR TITLE
fix(local): show on-demand llama.cpp router models

### DIFF
--- a/src/backend/dev/pi-llama-cpp-provider.test.ts
+++ b/src/backend/dev/pi-llama-cpp-provider.test.ts
@@ -5,6 +5,7 @@ import { createLlamaCppPiProvider } from "./pi-llama-cpp-provider";
 interface FakeLlamaCppModelEntry {
   id: string;
   status?: string;
+  failed?: boolean;
   inputModalities?: string[];
   nCtx?: number;
   nCtxTrain?: number;
@@ -42,7 +43,14 @@ function fakeLlamaCppFetch(state: FakeLlamaCppState): typeof fetch {
         data: state.models.map((model) => ({
           id: model.id,
           object: "model",
-          ...(model.status ? { status: { value: model.status } } : {}),
+          ...(model.status
+            ? {
+                status: {
+                  value: model.status,
+                  ...(model.failed ? { failed: true } : {}),
+                },
+              }
+            : {}),
           ...(model.inputModalities
             ? { architecture: { input_modalities: model.inputModalities } }
             : {}),
@@ -154,20 +162,36 @@ describe("createLlamaCppPiProvider", () => {
     expect(model?.maxTokens).toBe(128000);
   });
 
-  test("only loaded models publish from a router catalog", async () => {
+  test("publishes router models that can serve on demand", async () => {
     const provider = createLlamaCppPiProvider({
       baseURL: "http://localhost:8080",
       fetchImpl: fakeLlamaCppFetch({
         models: [
           { id: "loaded.gguf", status: "loaded", inputModalities: ["text"] },
           {
-            id: "downloading.gguf",
-            status: "downloading",
+            id: "unloaded.gguf",
+            status: "unloaded",
             inputModalities: ["text"],
           },
           {
             id: "sleeping.gguf",
             status: "sleeping",
+            inputModalities: ["text"],
+          },
+          {
+            id: "loading.gguf",
+            status: "loading",
+            inputModalities: ["text"],
+          },
+          {
+            id: "downloading.gguf",
+            status: "downloading",
+            inputModalities: ["text"],
+          },
+          {
+            id: "failed.gguf",
+            status: "unloaded",
+            failed: true,
             inputModalities: ["text"],
           },
         ],
@@ -176,7 +200,11 @@ describe("createLlamaCppPiProvider", () => {
     });
     const refreshContext = testRefreshContext();
     await provider.refreshModels?.(refreshContext);
-    expect(provider.getModels().map((m) => m.id)).toEqual(["loaded.gguf"]);
+    expect(provider.getModels().map((m) => m.id)).toEqual([
+      "loaded.gguf",
+      "unloaded.gguf",
+      "sleeping.gguf",
+    ]);
   });
 
   test("single-model server without catalog metadata uses per-model /props", async () => {

--- a/src/backend/dev/pi-llama-cpp-provider.ts
+++ b/src/backend/dev/pi-llama-cpp-provider.ts
@@ -114,11 +114,10 @@ function parseLlamaCppNativeModels(
     ) {
       sawMetadata = true;
     }
-    // The upstream provider exposes unloaded models through a separate
-    // management command. Letta Code's model picker is the only selection
-    // surface, so also publish states
-    // that llama.cpp can serve transparently: sleeping models wake on request,
-    // and non-failed unloaded models load on demand in the default router mode.
+    // The upstream provider exposes unloaded models through a separate management
+    // command. Letta Code's model picker is the only selection surface, so also
+    // publish states that llama.cpp can serve transparently: sleeping models wake
+    // on request, and non-failed unloaded models load on demand in router mode.
     const selectable =
       status === undefined ||
       status === "loaded" ||

--- a/src/backend/dev/pi-llama-cpp-provider.ts
+++ b/src/backend/dev/pi-llama-cpp-provider.ts
@@ -49,12 +49,11 @@ function parseLlamaCppProps(data: unknown): LlamaCppServerProps {
 }
 
 /**
- * Per-model metadata from the native `/models` catalog, matching the current
- * upstream Pi llama.cpp provider contract: entries carry `status.value`
- * (only "loaded" models are selectable), `architecture.input_modalities`,
- * and `meta.n_ctx` with `meta.n_ctx_train` as the fallback. Returns
- * undefined when no entry carries per-model metadata (plain OpenAI id
- * list), so discovery falls back to `/props?model=<id>`.
+ * Per-model metadata from the native `/models` catalog: entries carry
+ * `status.value`, `architecture.input_modalities`, and `meta.n_ctx` with
+ * `meta.n_ctx_train` as the fallback. Returns undefined when no entry carries
+ * per-model metadata (plain OpenAI id list), so discovery falls back to
+ * `/props?model=<id>`.
  */
 function parseLlamaCppNativeModels(
   data: unknown,
@@ -81,10 +80,11 @@ function parseLlamaCppNativeModels(
     };
     const id = record.id ?? record.name;
     if (typeof id !== "string" || id.length === 0) continue;
-    const status =
+    const statusRecord =
       record.status && typeof record.status === "object"
-        ? (record.status as { value?: unknown }).value
+        ? (record.status as { value?: unknown; failed?: unknown })
         : undefined;
+    const status = statusRecord?.value;
     const architecture =
       record.architecture && typeof record.architecture === "object"
         ? (record.architecture as { input_modalities?: unknown })
@@ -114,9 +114,17 @@ function parseLlamaCppNativeModels(
     ) {
       sawMetadata = true;
     }
-    // Upstream publishes only loaded models as selectable; entries without
-    // a status (single-model servers) are treated as loaded.
-    if (status !== undefined && status !== "loaded") continue;
+    // The upstream provider exposes unloaded models through a separate
+    // management command. Letta Code's model picker is the only selection
+    // surface, so also publish states
+    // that llama.cpp can serve transparently: sleeping models wake on request,
+    // and non-failed unloaded models load on demand in the default router mode.
+    const selectable =
+      status === undefined ||
+      status === "loaded" ||
+      status === "sleeping" ||
+      (status === "unloaded" && statusRecord?.failed !== true);
+    if (!selectable) continue;
     parsed.push(
       llamaCppModelMetadata(id, {
         ...(modalities !== undefined
@@ -162,7 +170,7 @@ function llamaCppModelMetadata(
  * 1. The native `/models` catalog (distinct from the OpenAI-compatible
  *    `/v1/models` list): per-model `status`, `architecture.input_modalities`,
  *    `meta.n_ctx`/`n_ctx_train` — authoritative per model, including router
- *    mode where one server hosts many models; only loaded models publish.
+ *    mode where one server hosts many on-demand models.
  * 2. `GET /props?model=<id>` per model from the `/v1/models` id list.
  *    Single-model servers ignore the query parameter and return their
  *    global props, which is correct there.

--- a/src/backend/dev/pi-models-runtime.test.ts
+++ b/src/backend/dev/pi-models-runtime.test.ts
@@ -643,6 +643,60 @@ describe("LocalPiModelsRuntime + Ollama provider", () => {
     expect(resolved.model.input).toEqual(["text", "image"]);
   });
 
+  test("unloaded llama.cpp router models preserve provider identity from listing through turns", async () => {
+    const requests: string[] = [];
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        requests.push(url.pathname);
+        if (url.pathname === "/models") {
+          return Response.json({
+            data: [
+              {
+                id: "Qwen3.6-27B",
+                status: { value: "unloaded" },
+                architecture: { input_modalities: ["text", "image"] },
+                meta: { n_ctx: 32768 },
+              },
+            ],
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    servers.push({ url: "", chatBodies: [], stop: () => server.stop(true) });
+    const storageDir = await mkdtemp(join(tmpdir(), "pi-models-runtime-"));
+    storageDirs.push(storageDir);
+    await createOrUpdateLocalProvider({
+      providerType: "llama_cpp",
+      providerName: "llama-cpp",
+      apiKey: "not-needed",
+      baseURL: `http://localhost:${server.port}`,
+      storageDir,
+    });
+    const runtime = new LocalPiModelsRuntime({ storageDir });
+
+    const listed = await listLocalModels(storageDir, {
+      fetch: failingDiscoveryFetch,
+      modelsRuntime: runtime,
+    });
+    const entry = listed.find(
+      (model) => model.handle === "llama.cpp/Qwen3.6-27B",
+    );
+    expect(entry?.max_context_window).toBe(32768);
+
+    const published = runtime.getModel("llama-cpp", "Qwen3.6-27B")!;
+    const resolved = await resolvePiModelForAgent(
+      "llama.cpp/Qwen3.6-27B",
+      {},
+      { localProviderAuthStorageDir: storageDir, modelsRuntime: runtime },
+    );
+    expect(resolved.model).toBe(published);
+    expect(resolved.model.input).toEqual(["text", "image"]);
+    expect(requests).not.toContain("/v1/models");
+  });
+
   test("refreshAll never probes unconfigured remote endpoints or mods", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "pi-models-runtime-"));
     storageDirs.push(storageDir);


### PR DESCRIPTION
## Summary

- show healthy unloaded llama.cpp router presets in the model picker so the router can load them on demand
- keep sleeping models selectable while continuing to hide loading, downloading, and failed entries
- preserve the provider-ownership invariant: listing and turn execution consume the same complete Model instance built from native engine metadata
- add regression coverage for every router status and preserve the existing single-model behavior

Fixes #3493.

👾 Generated with [Letta Code](https://letta.com)