### PR TITLE
fix(app-server): publish a consumable client contract [LET-10220]

### DIFF
--- a/build.js
+++ b/build.js
@@ -152,6 +152,18 @@ await Bun.build({
   },
 });
 
+await Bun.build({
+  entrypoints: ["./src/app-server-client.ts"],
+  outdir: "./dist",
+  target: "node",
+  format: "cjs",
+  minify: false,
+  sourcemap: "external",
+  naming: {
+    entry: "app-server-client.cjs",
+  },
+});
+
 // Browser-safe agent creation presets (personalities, prompts, tags) for
 // surfaces that create Letta Code agents through Core (e.g. the chat web app).
 await Bun.build({
@@ -216,5 +228,5 @@ console.log("   Output: dist/types/protocol.d.ts");
 
 console.log("✅ Build complete!");
 console.log(`   Output: letta.js`);
-console.log("   Output: dist/app-server-client.js");
+console.log("   Output: dist/app-server-client.js and .cjs");
 console.log(`   Size: ${(Bun.file(outputPath).size / 1024).toFixed(0)}KB`);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "vendor",
     "dist/app-server-client.js",
     "dist/app-server-client.js.map",
+    "dist/app-server-client.cjs",
+    "dist/app-server-client.cjs.map",
     "dist/agent-presets.js",
     "dist/agent-presets.js.map",
     "dist/channels-public.js",
@@ -35,7 +37,9 @@
     "./app-server-client": {
       "types": "./dist/types/app-server-client.d.ts",
       "browser": "./dist/app-server-client.js",
-      "import": "./dist/app-server-client.js"
+      "import": "./dist/app-server-client.js",
+      "require": "./dist/app-server-client.cjs",
+      "default": "./dist/app-server-client.js"
     },
     "./protocol": {
       "types": "./dist/types/types/protocol.d.ts"

--- a/src/app-server-client.test.ts
+++ b/src/app-server-client.test.ts
@@ -5,6 +5,7 @@ import {
   createAppServerClient,
   resolveAppServerChannelUrl,
 } from "./app-server-client";
+import { isAppServerInfoResponseMessage } from "./types/app-server-info";
 
 type Listener = (event: unknown) => void;
 
@@ -141,6 +142,41 @@ describe("app-server client", () => {
       backend: "local",
       protocol_version: 1,
     });
+  });
+
+  test("validates the complete App Server capability response", () => {
+    const response = {
+      type: "app_server_info_response",
+      request_id: "info-1",
+      success: true,
+      backend: "local",
+      letta_code_version: "0.29.2",
+      protocol_version: 2,
+      capabilities: {
+        agent_management: true,
+        conversation_management: true,
+        memory_management: true,
+        runtime_start: true,
+        split_channels: true,
+      },
+    };
+
+    expect(isAppServerInfoResponseMessage(response)).toBe(true);
+    expect(
+      isAppServerInfoResponseMessage({
+        ...response,
+        capabilities: {
+          ...response.capabilities,
+          split_channels: "yes",
+        },
+      }),
+    ).toBe(false);
+    expect(
+      isAppServerInfoResponseMessage({
+        ...response,
+        protocol_version: "2",
+      }),
+    ).toBe(false);
   });
 
   test("connects both sockets and resolves request_id responses", async () => {

--- a/src/app-server-client.test.ts
+++ b/src/app-server-client.test.ts
@@ -863,6 +863,9 @@ describe("app-server client", () => {
       url: "ws://127.0.0.1:4500",
       WebSocket: FakeSocket,
     });
+    const sent: string[] = [];
+    client.onSend((command) => sent.push(command.type));
+
     const pending = client.requestRaw<{ type: string; request_id: string }>(
       {
         type: "future_command",
@@ -881,6 +884,7 @@ describe("app-server client", () => {
           message.type === "future_response",
       },
     );
+    expect(sent).toEqual(["future_command"]);
 
     FakeSocket.instances[0]?.receive({
       type: "future_response",

--- a/src/app-server-client.test.ts
+++ b/src/app-server-client.test.ts
@@ -3,9 +3,9 @@ import {
   type AppServerSocketLike,
   type AppServerSocketOptions,
   createAppServerClient,
+  isAppServerInfoResponseMessage,
   resolveAppServerChannelUrl,
 } from "./app-server-client";
-import { isAppServerInfoResponseMessage } from "./types/app-server-info";
 
 type Listener = (event: unknown) => void;
 

--- a/src/app-server-client.test.ts
+++ b/src/app-server-client.test.ts
@@ -858,6 +858,41 @@ describe("app-server client", () => {
     });
   });
 
+  test("supports forward-compatible compatibility adapter requests", async () => {
+    const client = createAppServerClient({
+      url: "ws://127.0.0.1:4500",
+      WebSocket: FakeSocket,
+    });
+    const pending = client.requestRaw<{ type: string; request_id: string }>(
+      {
+        type: "future_command",
+        request_id: "future-1",
+      },
+      {
+        predicate: (
+          message,
+        ): message is {
+          type: string;
+          request_id: string;
+        } =>
+          typeof message === "object" &&
+          message !== null &&
+          "type" in message &&
+          message.type === "future_response",
+      },
+    );
+
+    FakeSocket.instances[0]?.receive({
+      type: "future_response",
+      request_id: "future-1",
+    });
+
+    await expect(pending).resolves.toEqual({
+      type: "future_response",
+      request_id: "future-1",
+    });
+  });
+
   test("times out unanswered requests", async () => {
     const { client, control, stream } = createFakeClient();
     control.open();

--- a/src/app-server-client.ts
+++ b/src/app-server-client.ts
@@ -102,6 +102,23 @@ export type AppServerRequestBody = Record<string, unknown> & {
   request_id?: string;
 };
 
+export type AppServerRawCommand = Record<string, unknown> & {
+  type: string;
+  request_id?: string;
+};
+
+export type AppServerRawResponse = Record<string, unknown> & {
+  type: string;
+  request_id?: string;
+};
+
+export interface AppServerRawRequestOptions<
+  TResponse extends AppServerRawResponse,
+> {
+  timeoutMs?: number;
+  predicate: (message: unknown) => message is TResponse;
+}
+
 type PendingRequest = {
   resolve: (message: WsProtocolMessage) => void;
   reject: (error: Error) => void;
@@ -394,6 +411,46 @@ export class AppServerClient {
       handler(command);
     }
     this.control.send(JSON.stringify(command));
+  }
+
+  /**
+   * Send a forward-compatible protocol command from a compatibility adapter.
+   * Prefer the typed wrappers above this boundary for normal product code.
+   */
+  sendRaw(command: AppServerRawCommand): void {
+    this.control.send(JSON.stringify(command));
+  }
+
+  /**
+   * Request a forward-compatible response without mirroring the full protocol
+   * union in a downstream compatibility adapter.
+   */
+  requestRaw<TResponse extends AppServerRawResponse>(
+    command: AppServerRawCommand & { request_id: string },
+    options: AppServerRawRequestOptions<TResponse>,
+  ): Promise<TResponse> {
+    const timeoutMs = options.timeoutMs ?? this.requestTimeoutMs;
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(command.request_id);
+        reject(new Error(`Timed out waiting for ${command.request_id}`));
+      }, timeoutMs);
+
+      this.pending.set(command.request_id, {
+        resolve: (message) => resolve(message as unknown as TResponse),
+        reject,
+        predicate: options.predicate,
+        timeout,
+      });
+
+      try {
+        this.sendRaw(command);
+      } catch (error) {
+        clearTimeout(timeout);
+        this.pending.delete(command.request_id);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
   }
 
   request<TMessage extends WsProtocolMessage = WsProtocolMessage>(

--- a/src/app-server-client.ts
+++ b/src/app-server-client.ts
@@ -1,3 +1,4 @@
+import { isAppServerInfoResponseMessage } from "./types/app-server-info";
 import type {
   AbortMessageCommand,
   AbortMessageResponseMessage,
@@ -465,8 +466,7 @@ export class AppServerClient {
       },
       {
         ...options,
-        predicate: (message): message is AppServerInfoResponseMessage =>
-          message.type === "app_server_info_response",
+        predicate: isAppServerInfoResponseMessage,
       },
     );
   }

--- a/src/app-server-client.ts
+++ b/src/app-server-client.ts
@@ -25,6 +25,18 @@ import type {
 
 export type AppServerChannel = "control" | "stream";
 
+export type AppServerRawCommand = Record<string, unknown> & {
+  type: string;
+  request_id?: string;
+};
+
+export type AppServerRawResponse = Record<string, unknown> & {
+  type: string;
+  request_id?: string;
+};
+
+export type AppServerSendCommand = WsProtocolCommand | AppServerRawCommand;
+
 /**
  * Receives every parsed protocol frame from both app-server websocket channels.
  * Treat this as the primary event stream: app-server may emit replay or turn
@@ -36,8 +48,8 @@ export type AppServerMessageHandler = (
   channel: AppServerChannel,
 ) => void;
 
-/** Called synchronously before a protocol command is written to the control socket. */
-export type AppServerSendHandler = (command: WsProtocolCommand) => void;
+/** Called synchronously before a typed or raw command is written to the control socket. */
+export type AppServerSendHandler = (command: AppServerSendCommand) => void;
 
 export interface AppServerDisconnectEvent {
   channel: AppServerChannel;
@@ -99,16 +111,6 @@ export type AppServerRequestCommandWithId = AppServerRequestCommand & {
 };
 
 export type AppServerRequestBody = Record<string, unknown> & {
-  request_id?: string;
-};
-
-export type AppServerRawCommand = Record<string, unknown> & {
-  type: string;
-  request_id?: string;
-};
-
-export type AppServerRawResponse = Record<string, unknown> & {
-  type: string;
   request_id?: string;
 };
 
@@ -407,6 +409,10 @@ export class AppServerClient {
   }
 
   send(command: WsProtocolCommand): void {
+    this.writeCommand(command);
+  }
+
+  private writeCommand(command: AppServerSendCommand): void {
     for (const handler of this.sendHandlers) {
       handler(command);
     }
@@ -418,7 +424,7 @@ export class AppServerClient {
    * Prefer the typed wrappers above this boundary for normal product code.
    */
   sendRaw(command: AppServerRawCommand): void {
-    this.control.send(JSON.stringify(command));
+    this.writeCommand(command);
   }
 
   /**

--- a/src/app-server-client.ts
+++ b/src/app-server-client.ts
@@ -1,4 +1,8 @@
 import { isAppServerInfoResponseMessage } from "./types/app-server-info";
+
+export type { AppServerInfoResponseMessage } from "./types/app-server-info";
+export { isAppServerInfoResponseMessage } from "./types/app-server-info";
+
 import type {
   AbortMessageCommand,
   AbortMessageResponseMessage,

--- a/src/types/app-server-info.ts
+++ b/src/types/app-server-info.ts
@@ -13,7 +13,8 @@ export interface AppServerInfoResponseMessage {
   success: true;
   backend: "local" | "api";
   letta_code_version: string;
-  protocol_version: typeof APP_SERVER_PROTOCOL_VERSION;
+  /** Wire value reported by the server; clients compare it with their supported version. */
+  protocol_version: number;
   capabilities: {
     agent_management: boolean;
     conversation_management: boolean;
@@ -21,4 +22,39 @@ export interface AppServerInfoResponseMessage {
     runtime_start: boolean;
     split_channels: boolean;
   };
+}
+
+export function isAppServerInfoResponseMessage(
+  message: unknown,
+): message is AppServerInfoResponseMessage {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return false;
+  }
+
+  const candidate = message as Record<string, unknown>;
+  const capabilities = candidate.capabilities;
+  if (
+    !capabilities ||
+    typeof capabilities !== "object" ||
+    Array.isArray(capabilities)
+  ) {
+    return false;
+  }
+
+  const capabilityRecord = capabilities as Record<string, unknown>;
+  return (
+    candidate.type === "app_server_info_response" &&
+    typeof candidate.request_id === "string" &&
+    candidate.request_id.length > 0 &&
+    candidate.success === true &&
+    (candidate.backend === "local" || candidate.backend === "api") &&
+    typeof candidate.letta_code_version === "string" &&
+    typeof candidate.protocol_version === "number" &&
+    Number.isInteger(candidate.protocol_version) &&
+    typeof capabilityRecord.agent_management === "boolean" &&
+    typeof capabilityRecord.conversation_management === "boolean" &&
+    typeof capabilityRecord.memory_management === "boolean" &&
+    typeof capabilityRecord.runtime_start === "boolean" &&
+    typeof capabilityRecord.split_channels === "boolean"
+  );
 }

--- a/src/websocket/listener/commands/app-server-info.test.ts
+++ b/src/websocket/listener/commands/app-server-info.test.ts
@@ -28,7 +28,7 @@ describe("app-server info protocol", () => {
     ).toBeNull();
   });
 
-  test("reports backend, version, and required Desktop capabilities", () => {
+  test("reports backend, version, and required client capabilities", () => {
     expect(
       buildAppServerInfoResponse(
         { type: "app_server_info", request_id: "info-2" },


### PR DESCRIPTION
## Summary

- publish the App Server client as a real ESM/CommonJS/types package entrypoint so clean Jest and Electron consumers can resolve it
- export and validate the App Server info contract, including a real numeric wire protocol version
- add a narrow, documented forward-compatibility boundary for downstream protocol adapters:
  - `sendRaw`
  - `requestRaw`
  - raw command/response types
- keep normal product integrations on the typed client methods; the raw boundary exists so Desktop can adapt compatibility endpoints without importing package internals, casting the client, or mirroring the entire evolving protocol union
- remove the private downstream Desktop reference from the public protocol tests

## Verification

- [x] `LETTA_DISABLE_MODS=1 bun test src/app-server-client.test.ts src/websocket/app-server.test.ts src/websocket/listener/commands/app-server-info.test.ts`
- [x] `bun run check`
- [x] `bun run build`
- [x] packed clean-install smoke for both `require("@letta-ai/letta-code/app-server-client")` and ESM `import()`
- [x] CI green across lint/type-check, package smoke, macOS/Linux/Windows, headless, Ollama, reflection, and Docker integration
