### PR TITLE
fix(app-server): allow authenticated native websocket origins

### DIFF
--- a/src/cli/subcommands/app-server.ts
+++ b/src/cli/subcommands/app-server.ts
@@ -11,7 +11,7 @@ Run the local App Server using native v2 WebSocket frames.
 Options:
   --listen [url]  WebSocket listen URL. Defaults to an available loopback port
   --openai-api  Serve OpenAI-compatible /v1/models and /v1/chat/completions routes (each agent is a model)
-  --ws-auth <mode>  WebSocket auth mode for non-loopback listeners. Supported: capability-token, signed-bearer-token
+  --ws-auth <mode>  WebSocket auth for non-loopback listeners and Origin-bearing native clients. Supported: capability-token, signed-bearer-token
   --ws-token-file <path>  Absolute path to the capability-token file
   --ws-token-sha256 <hex>  Hex-encoded SHA-256 digest of the capability token
   --ws-shared-secret-file <path>  Absolute path to the shared secret file for signed JWT bearer tokens

--- a/src/cli/subcommands/server.ts
+++ b/src/cli/subcommands/server.ts
@@ -21,7 +21,7 @@ Remote environment options:
 App Server options:
   --listen [url]  Accept App Server connections. If URL is omitted, binds to an available loopback port
   --openai-api  Serve OpenAI-compatible /v1/models and /v1/chat/completions routes (each agent is a model)
-  --ws-auth <mode>  Authentication for non-loopback listeners: capability-token or signed-bearer-token
+  --ws-auth <mode>  Authentication for non-loopback listeners and Origin-bearing native clients: capability-token or signed-bearer-token
   --ws-token-file <path>  Absolute path to the capability-token file
   --ws-token-sha256 <hex>  Hex-encoded SHA-256 digest of the capability token
   --ws-shared-secret-file <path>  Absolute path to the shared secret file for signed JWT bearer tokens

--- a/src/websocket/app-server.test.ts
+++ b/src/websocket/app-server.test.ts
@@ -365,13 +365,22 @@ describe("app-server native websocket", () => {
     }
   });
 
-  test("rejects browser-origin websocket upgrades", async () => {
+  test("rejects origin-bearing websocket upgrades without auth", async () => {
     let handle: AppServerHandle | null = null;
+    const logs: string[] = [];
     try {
-      handle = await startAppServer({ listen: "ws://127.0.0.1:0" });
+      handle = await startAppServer({
+        listen: "ws://127.0.0.1:0",
+        onLog: (message) => logs.push(message),
+      });
       await expectWebSocketOpenFailure(handle.controlUrl, {
         Origin: "https://evil.example",
       });
+      await expectWebSocketOpenFailure(handle.controlUrl, { Origin: "" });
+      expect(logs).toEqual([
+        expect.stringContaining("--ws-auth capability-token"),
+        expect.stringContaining("--ws-auth capability-token"),
+      ]);
     } finally {
       await handle?.close();
     }
@@ -423,10 +432,14 @@ describe("app-server native websocket", () => {
       await expectWebSocketOpenFailure(controlUrl);
       await expectWebSocketOpenFailure(controlUrl, {
         Authorization: "Bearer wrong-token",
+        Origin: "http://localhost:8081",
       });
 
       control = new WebSocket(controlUrl, {
-        headers: { Authorization: "Bearer super-secret-token" },
+        headers: {
+          Authorization: "Bearer super-secret-token",
+          Origin: "http://localhost:8081",
+        },
       });
       await waitForOpen(control);
     } finally {
@@ -464,6 +477,7 @@ describe("app-server native websocket", () => {
       });
       await expectWebSocketOpenFailure(controlUrl, {
         Authorization: `Bearer ${expiredToken}`,
+        Origin: "http://localhost:8081",
       });
 
       const validToken = signedBearerToken(sharedSecret, {
@@ -472,7 +486,10 @@ describe("app-server native websocket", () => {
         aud: "codex-app-server",
       });
       control = new WebSocket(controlUrl, {
-        headers: { Authorization: `Bearer ${validToken}` },
+        headers: {
+          Authorization: `Bearer ${validToken}`,
+          Origin: "http://localhost:8081",
+        },
       });
       await waitForOpen(control);
     } finally {

--- a/src/websocket/app-server.ts
+++ b/src/websocket/app-server.ts
@@ -406,14 +406,6 @@ export async function startAppServer(
 
   server.on("upgrade", (request, socket, head) => {
     const requestUrl = getRequestUrl(request, listen.host);
-    if (request.headers.origin) {
-      options.onLog?.(
-        `Rejecting app-server websocket request with Origin header: ${request.url ?? "/"}`,
-      );
-      rejectUpgrade(socket, 403, "Forbidden");
-      return;
-    }
-
     if (requestUrl.pathname !== listen.path && requestUrl.pathname !== "/") {
       rejectUpgrade(socket, 404, "Not Found");
       return;
@@ -431,6 +423,18 @@ export async function startAppServer(
         `Rejecting app-server websocket client: ${authError.message}`,
       );
       rejectUpgrade(socket, authError.statusCode, authError.message);
+      return;
+    }
+
+    // Browser WebSocket APIs cannot set Authorization headers, while native
+    // clients such as React Native may send both Authorization and Origin.
+    // authorizeUpgrade() also returns null when auth is disabled, so require
+    // an actual configured policy before treating the request as authenticated.
+    if (request.headers.origin !== undefined && authPolicy.mode === undefined) {
+      options.onLog?.(
+        `Rejecting unauthenticated app-server websocket request with Origin header: ${request.url ?? "/"}; native clients such as React Native must configure --ws-auth capability-token or --ws-auth signed-bearer-token`,
+      );
+      rejectUpgrade(socket, 403, "Forbidden");
       return;
     }
 


### PR DESCRIPTION
## Summary

- allow WebSocket upgrades carrying an Origin header only after a configured capability token or signed bearer token validates
- preserve the browser-CSRF guard for tokenless loopback servers, including requests with an empty Origin value
- keep invalid or missing bearer tokens rejected before the Origin exception is considered
- make the CLI guidance and rejection log explain that Origin-bearing native clients such as React Native must enable WebSocket auth

## Why

React Native's native WebSocket stacks send an Origin header, even though the connection does not come from browser JavaScript. The App Server currently rejects every Origin-bearing upgrade before checking Authorization, so an authenticated React Native client cannot connect.

Browser WebSocket JavaScript cannot set an Authorization header, while React Native can supply one through its native constructor options. A successfully validated bearer token therefore provides the distinction needed here without weakening the drive-by browser protection:

| Upgrade | Result |
| --- | --- |
| no Origin, tokenless loopback | allowed as before |
| Origin, no auth policy | 403 |
| Origin, missing/invalid bearer token | 401 |
| Origin, valid capability token | allowed |
| Origin, valid signed bearer token | allowed |

This intentionally does not add an Origin allowlist or enable browser clients. An allowlist is a separate concern for a future browser-compatible authentication flow.

One subtlety: authorizeUpgrade returns success when no auth policy is configured because authentication is optional on loopback. The new check therefore requires both a configured auth policy and successful validation before allowing an Origin-bearing request.

## React Native usage

React Native consumers still need to pass Authorization through the platform's third WebSocket constructor argument. The Letta Agent SDK exposes createReactNativeWebSocketConstructor for that adaptation.

## Verification

- [x] LETTA_DISABLE_MODS=1 bun test src/websocket/app-server.test.ts src/cli/subcommands/server.test.ts src/cli/subcommands/router.test.ts
- [x] bun run check
- [x] bun run build
