### PR TITLE
fix(backend): cap default Ollama context at 128K

### DIFF
--- a/src/backend/dev/pi-models-runtime.test.ts
+++ b/src/backend/dev/pi-models-runtime.test.ts
@@ -413,7 +413,7 @@ describe("LocalPiModelsRuntime + Ollama provider", () => {
     });
     const entry = listed.find((model) => model.handle === "ollama/qwen3.6:27b");
     expect(entry).toBeDefined();
-    expect(entry?.max_context_window).toBe(262144);
+    expect(entry?.max_context_window).toBe(128000);
 
     const resolved = await resolvePiModelForAgent(
       "ollama/qwen3.6:27b",
@@ -425,7 +425,7 @@ describe("LocalPiModelsRuntime + Ollama provider", () => {
     expect(resolved.model).toBe(runtime.getModel("ollama", "qwen3.6:27b")!);
     expect(resolved.model.input).toEqual(["text", "image"]);
     expect(resolved.model.reasoning).toBe(true);
-    expect(resolved.model.contextWindow).toBe(262144);
+    expect(resolved.model.contextWindow).toBe(128000);
 
     // Identity survives the real selection path: settings persisted from
     // the published model (restating its values) must not force a clone.
@@ -441,6 +441,15 @@ describe("LocalPiModelsRuntime + Ollama provider", () => {
     expect(resolvedWithSettings.model).toBe(
       runtime.getModel("ollama", "qwen3.6:27b")!,
     );
+
+    // /context-limit remains an explicit per-conversation escape hatch when
+    // the user's Ollama runtime is configured above the conservative default.
+    const resolvedWithContextOverride = await resolvePiModelForAgent(
+      "ollama/qwen3.6:27b",
+      { context_window_limit: 262144 },
+      { localProviderAuthStorageDir: storageDir, modelsRuntime: runtime },
+    );
+    expect(resolvedWithContextOverride.model.contextWindow).toBe(262144);
   });
 
   test("vision model with no name marker keeps base64 image_url in the request payload", async () => {

--- a/src/backend/dev/pi-ollama-provider.test.ts
+++ b/src/backend/dev/pi-ollama-provider.test.ts
@@ -49,6 +49,10 @@ function qwenState(): FakeOllamaState {
       },
       "smol-text:3b": {
         capabilities: ["completion", "tools"],
+        model_info: {
+          "general.architecture": "smol",
+          "smol.context_length": 32768,
+        },
       },
     },
     requests: [],
@@ -85,13 +89,14 @@ describe("createOllamaPiProvider", () => {
     expect(qwen).toBeDefined();
     expect(qwen?.input).toEqual(["text", "image"]);
     expect(qwen?.reasoning).toBe(true);
-    expect(qwen?.contextWindow).toBe(262144);
+    expect(qwen?.contextWindow).toBe(128000);
     expect(qwen?.api).toBe("openai-completions");
     expect(qwen?.baseUrl).toBe("http://localhost:11434/v1");
 
     const text = provider.getModels().find((m) => m.id === "smol-text:3b");
     expect(text?.input).toEqual(["text"]);
     expect(text?.reasoning).toBe(false);
+    expect(text?.contextWindow).toBe(32768);
   });
 
   test("skips /api/show when the tag digest is unchanged", async () => {
@@ -208,6 +213,7 @@ describe("createOllamaPiProvider as Ollama Cloud", () => {
     const qwen = provider.getModels().find((m) => m.id === "qwen3.6:27b");
     expect(qwen?.provider).toBe("ollama-cloud");
     expect(qwen?.input).toEqual(["text", "image"]);
+    expect(qwen?.contextWindow).toBe(128000);
     expect(authHeaders.every((header) => header === "Bearer cloud-key")).toBe(
       true,
     );

--- a/src/backend/dev/pi-ollama-provider.ts
+++ b/src/backend/dev/pi-ollama-provider.ts
@@ -1,6 +1,7 @@
 import type { Provider } from "@earendil-works/pi-ai";
 import {
   createLocalEndpointPiProvider,
+  LOCAL_ENDPOINT_DEFAULT_CONTEXT_WINDOW,
   type LocalEndpointDiscover,
   type LocalEndpointModelMetadata,
 } from "./pi-local-endpoint-provider";
@@ -72,12 +73,20 @@ function parseOllamaShow(
   const contextLength = architecture
     ? modelInfo?.[`${architecture}.context_length`]
     : undefined;
+  // /api/show reports the model's architectural training maximum, not the
+  // context allocated by the Ollama runner. Use the same conservative 128K
+  // harness default as pi-ai custom models; users can raise it explicitly
+  // with /context-limit when their Ollama runtime is configured for more.
+  const harnessContextLength =
+    typeof contextLength === "number" && contextLength > 0
+      ? Math.min(contextLength, LOCAL_ENDPOINT_DEFAULT_CONTEXT_WINDOW)
+      : undefined;
   return {
     id: modelId,
     vision: capabilities.includes("vision"),
     thinking: capabilities.includes("thinking"),
-    ...(typeof contextLength === "number" && contextLength > 0
-      ? { contextLength }
+    ...(harnessContextLength !== undefined
+      ? { contextLength: harnessContextLength }
       : {}),
   };
 }


### PR DESCRIPTION
## Summary
- cap Ollama architectural context metadata at a conservative 128K default for the harness
- preserve smaller reported windows and explicit `/context-limit --override` selections
- cover local and hosted Ollama discovery plus runtime model resolution

👾 Generated with [Letta Code](https://letta.com)