### PR TITLE
fix(local): normalize endpoint context defaults

### DIFF
--- a/src/backend/dev/pi-llama-cpp-provider.test.ts
+++ b/src/backend/dev/pi-llama-cpp-provider.test.ts
@@ -106,6 +106,12 @@ describe("createLlamaCppPiProvider", () => {
           inputModalities: ["text"],
           nCtxTrain: 8192,
         },
+        {
+          id: "large-context.gguf",
+          status: "loaded",
+          inputModalities: ["text"],
+          nCtx: 262144,
+        },
       ],
       requests: [],
     };
@@ -141,6 +147,11 @@ describe("createLlamaCppPiProvider", () => {
     const textOnly = models.find((m) => m.id === "some-vision-model.gguf");
     expect(textOnly?.input).toEqual(["text"]);
     expect(textOnly?.contextWindow).toBe(8192);
+    expect(textOnly?.maxTokens).toBe(8192);
+
+    const largeContext = models.find((m) => m.id === "large-context.gguf");
+    expect(largeContext?.contextWindow).toBe(128000);
+    expect(largeContext?.maxTokens).toBe(128000);
   });
 
   test("missing engine context falls back to contextWindow-sized maxTokens", async () => {

--- a/src/backend/dev/pi-llama-cpp-provider.ts
+++ b/src/backend/dev/pi-llama-cpp-provider.ts
@@ -137,9 +137,10 @@ function parseLlamaCppNativeModels(
 }
 
 /**
- * Upstream model construction: the fallback context applies first and
- * maxTokens always equals the effective contextWindow; compat flags match
- * the current upstream llama.cpp provider literally.
+ * Upstream model construction: the engine context applies first and
+ * maxTokens tracks it; the shared provider then applies Letta's conservative
+ * harness default to both values. Compat flags match the current upstream
+ * llama.cpp provider literally.
  */
 function llamaCppModelMetadata(
   id: string,

--- a/src/backend/dev/pi-lmstudio-provider.test.ts
+++ b/src/backend/dev/pi-lmstudio-provider.test.ts
@@ -42,14 +42,25 @@ describe("createLmStudioPiProvider", () => {
             id: "qwen3.6-27b",
             object: "model",
             type: "vlm",
+            state: "loaded",
+            loaded_context_length: 81920,
             max_context_length: 262144,
           },
           {
             id: "smol-text-3b",
             object: "model",
             type: "llm",
+            state: "not-loaded",
             capabilities: ["tool_use"],
             max_context_length: 8192,
+          },
+          {
+            id: "large-unloaded-27b",
+            object: "model",
+            type: "llm",
+            state: "not-loaded",
+            loaded_context_length: 32768,
+            max_context_length: 262144,
           },
           {
             id: "text-embedding-nomic",
@@ -66,11 +77,19 @@ describe("createLmStudioPiProvider", () => {
     const vlm = models.find((m) => m.id === "qwen3.6-27b");
     expect(vlm?.provider).toBe("lmstudio");
     expect(vlm?.input).toEqual(["text", "image"]);
-    expect(vlm?.contextWindow).toBe(262144);
+    // LM Studio exposes both the loaded runtime allocation and the model's
+    // architectural maximum; the running allocation is authoritative.
+    expect(vlm?.contextWindow).toBe(81920);
 
     const llm = models.find((m) => m.id === "smol-text-3b");
     expect(llm?.input).toEqual(["text"]);
     expect(llm?.contextWindow).toBe(8192);
+    expect(llm?.maxTokens).toBe(8192);
+
+    const unloaded = models.find((m) => m.id === "large-unloaded-27b");
+    // A stale loaded_context_length on an unloaded entry must not win; its
+    // architectural maximum falls back to the conservative harness default.
+    expect(unloaded?.contextWindow).toBe(128000);
 
     // Embedding models are excluded from the chat model list.
     expect(models.some((m) => m.id === "text-embedding-nomic")).toBe(false);

--- a/src/backend/dev/pi-lmstudio-provider.ts
+++ b/src/backend/dev/pi-lmstudio-provider.ts
@@ -32,14 +32,27 @@ function parseLmStudioModels(data: unknown): LocalEndpointModelMetadata[] {
     const record = entry as {
       id?: unknown;
       type?: unknown;
+      state?: unknown;
       capabilities?: unknown;
+      loaded_context_length?: unknown;
       max_context_length?: unknown;
     };
     if (typeof record.id !== "string" || record.id.length === 0) continue;
     // Embedding models are not chat models; keep them out of /model.
     if (record.type === "embeddings") continue;
     const capabilities = stringArray(record.capabilities);
-    const contextLength = record.max_context_length;
+    const loadedContextLength =
+      record.state === "loaded" &&
+      typeof record.loaded_context_length === "number" &&
+      record.loaded_context_length > 0
+        ? record.loaded_context_length
+        : undefined;
+    const maxContextLength =
+      typeof record.max_context_length === "number" &&
+      record.max_context_length > 0
+        ? record.max_context_length
+        : undefined;
+    const contextLength = loadedContextLength ?? maxContextLength;
     models.push({
       id: record.id,
       vision: record.type === "vlm" || capabilities.includes("vision"),
@@ -56,8 +69,10 @@ function parseLmStudioModels(data: unknown): LocalEndpointModelMetadata[] {
  * LM Studio capability discovery: the native REST API
  * (`GET /api/v0/models`) reports each downloaded model's authoritative
  * metadata — `type` (`"vlm"` = vision-language model), an optional
- * `capabilities` array, and `max_context_length`. When the native API is
- * unavailable (older LM Studio), discovery falls back to the
+ * `capabilities` array, the loaded runtime window, and the architectural
+ * maximum. A loaded runtime window takes precedence before the shared
+ * provider applies its conservative harness default. When the native API
+ * is unavailable (older LM Studio), discovery falls back to the
  * OpenAI-compatible `/v1/models` id list and each model keeps its
  * last-known published Model or is published text-only — capabilities are
  * explicitly unknown, never guessed from the model id.

--- a/src/backend/dev/pi-local-endpoint-provider.ts
+++ b/src/backend/dev/pi-local-endpoint-provider.ts
@@ -22,6 +22,7 @@ export interface LocalEndpointModelMetadata {
   id: string;
   vision?: boolean;
   thinking?: boolean;
+  /** Engine-reported available window; the shared builder applies its default cap. */
   contextLength?: number;
   /** Engine-specific output cap; defaults to the shared constant. */
   maxTokens?: number;
@@ -151,6 +152,17 @@ export function createLocalEndpointPiProvider(
   function buildModel(
     metadata: LocalEndpointModelMetadata,
   ): LocalEndpointModel {
+    // Engine catalogs mix loaded runtime windows with architectural maxima.
+    // Publish a conservative harness default either way; an explicit
+    // /context-limit setting can still clone the Model with a larger window.
+    const contextWindow = Math.min(
+      metadata.contextLength ?? LOCAL_ENDPOINT_DEFAULT_CONTEXT_WINDOW,
+      LOCAL_ENDPOINT_DEFAULT_CONTEXT_WINDOW,
+    );
+    const maxTokens = Math.min(
+      metadata.maxTokens ?? LOCAL_ENDPOINT_DEFAULT_MAX_TOKENS,
+      contextWindow,
+    );
     return {
       id: metadata.id,
       name: metadata.id,
@@ -160,9 +172,8 @@ export function createLocalEndpointPiProvider(
       reasoning: metadata.thinking === true,
       input: metadata.vision === true ? ["text", "image"] : ["text"],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow:
-        metadata.contextLength ?? LOCAL_ENDPOINT_DEFAULT_CONTEXT_WINDOW,
-      maxTokens: metadata.maxTokens ?? LOCAL_ENDPOINT_DEFAULT_MAX_TOKENS,
+      contextWindow,
+      maxTokens,
       compat: {
         supportsDeveloperRole: false,
         supportsReasoningEffort: false,

--- a/src/backend/dev/pi-models-runtime.test.ts
+++ b/src/backend/dev/pi-models-runtime.test.ts
@@ -444,12 +444,12 @@ describe("LocalPiModelsRuntime + Ollama provider", () => {
 
     // /context-limit remains an explicit per-conversation escape hatch when
     // the user's Ollama runtime is configured above the conservative default.
-    const resolvedWithContextOverride = await resolvePiModelForAgent(
+    const resolvedWithExplicitContext = await resolvePiModelForAgent(
       "ollama/qwen3.6:27b",
       { context_window_limit: 262144 },
       { localProviderAuthStorageDir: storageDir, modelsRuntime: runtime },
     );
-    expect(resolvedWithContextOverride.model.contextWindow).toBe(262144);
+    expect(resolvedWithExplicitContext.model.contextWindow).toBe(262144);
   });
 
   test("vision model with no name marker keeps base64 image_url in the request payload", async () => {

--- a/src/backend/dev/pi-ollama-provider.ts
+++ b/src/backend/dev/pi-ollama-provider.ts
@@ -1,7 +1,6 @@
 import type { Provider } from "@earendil-works/pi-ai";
 import {
   createLocalEndpointPiProvider,
-  LOCAL_ENDPOINT_DEFAULT_CONTEXT_WINDOW,
   type LocalEndpointDiscover,
   type LocalEndpointModelMetadata,
 } from "./pi-local-endpoint-provider";
@@ -73,20 +72,12 @@ function parseOllamaShow(
   const contextLength = architecture
     ? modelInfo?.[`${architecture}.context_length`]
     : undefined;
-  // /api/show reports the model's architectural training maximum, not the
-  // context allocated by the Ollama runner. Use the same conservative 128K
-  // harness default as pi-ai custom models; users can raise it explicitly
-  // with /context-limit when their Ollama runtime is configured for more.
-  const harnessContextLength =
-    typeof contextLength === "number" && contextLength > 0
-      ? Math.min(contextLength, LOCAL_ENDPOINT_DEFAULT_CONTEXT_WINDOW)
-      : undefined;
   return {
     id: modelId,
     vision: capabilities.includes("vision"),
     thinking: capabilities.includes("thinking"),
-    ...(harnessContextLength !== undefined
-      ? { contextLength: harnessContextLength }
+    ...(typeof contextLength === "number" && contextLength > 0
+      ? { contextLength }
       : {}),
   };
 }
@@ -95,7 +86,8 @@ function parseOllamaShow(
  * Ollama capability discovery: `/api/tags` lists installed models and
  * `POST /api/show` reports authoritative capabilities per model
  * (`["completion", "vision", "tools", "thinking"]`) plus engine context
- * length. Model names are never consulted for capabilities.
+ * maximum. The shared provider applies the conservative harness default;
+ * model names are never consulted for capabilities.
  */
 const ollamaDiscover: LocalEndpointDiscover = async (context) => {
   const tags = await context.fetchJson(`${context.nativeBaseURL}/api/tags`);


### PR DESCRIPTION
## Summary
- apply the conservative 128K harness default consistently across Ollama, LM Studio, and llama.cpp while preserving smaller engine windows
- prefer LM Studio `loaded_context_length` for running models before falling back to the architectural maximum
- keep fresh output limits within the effective context while preserving explicit `/context-limit` selections

Related: #3508 exposes the same fresh-model metadata invariant; its streamed-usage and auto-compaction failures remain separate.

👾 Generated with [Letta Code](https://letta.com)