### PR TITLE
fix(local): ignore AppleDouble agent sidecars

### DIFF
--- a/src/backend/local/local-store-appledouble.test.ts
+++ b/src/backend/local/local-store-appledouble.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalBackend } from "@/backend/local/local-backend";
+
+describe("local agent storage", () => {
+  test("ignores macOS AppleDouble sidecars when loading agents", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-appledouble-"),
+    );
+
+    try {
+      const backend = new LocalBackend({ storageDir, memfsEnabled: false });
+      const agent = await backend.createAgent({
+        name: "AppleDouble test",
+      } as never);
+      const agentsDir = join(storageDir, "agents");
+      const agentFile = (await readdir(agentsDir)).find((file) =>
+        file.endsWith(".json"),
+      );
+      expect(agentFile).toBeDefined();
+      if (!agentFile) throw new Error("Expected a persisted agent record");
+
+      await writeFile(
+        join(agentsDir, `._${agentFile}`),
+        Buffer.from([
+          0x00, 0x05, 0x16, 0x07, 0x00, 0x02, 0x00, 0x00, 0x4d, 0x61, 0x63,
+          0x20, 0x4f, 0x53, 0x20, 0x58,
+        ]),
+      );
+
+      const reloaded = new LocalBackend({
+        storageDir,
+        memfsEnabled: false,
+      });
+      await expect(reloaded.retrieveAgent(agent.id)).resolves.toMatchObject({
+        id: agent.id,
+        name: "AppleDouble test",
+      });
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -3121,7 +3121,7 @@ export class LocalStore {
     const agentsDir = join(this.storageDir, "agents");
     if (existsSync(agentsDir)) {
       for (const file of readdirSync(agentsDir)) {
-        if (!file.endsWith(".json")) continue;
+        if (!file.endsWith(".json") || file.startsWith("._")) continue;
         const raw = readJsonFile<unknown>(join(agentsDir, file));
         const agent = normalizeAgentRecord(raw, this.defaultAgentModel);
         if (agent?.id) {


### PR DESCRIPTION
## Summary

- ignore macOS AppleDouble sidecar files when loading persisted local agent records
- keep ordinary malformed agent JSON fail-fast instead of silently dropping potentially corrupted user data
- add a focused regression test using the real AppleDouble magic number and version header

Fixes #3506.

## Why

On filesystems without native macOS extended-attribute support, including SSHFS, NFS, and SMB mounts, macOS may create a binary `._<filename>` AppleDouble companion for each persisted agent JSON file. Because the companion retains the `.json` suffix, the local store attempted to parse it as JSON and crashed before the App Server started listening.

The loader now excludes only `._`-prefixed JSON sidecars. Conversation loading is unaffected because it already requires directory entries, and normal corrupt agent records continue to surface as errors.

## Verification

- [x] `LETTA_DISABLE_MODS=1 bun test src/backend/local/local-store-appledouble.test.ts src/backend/local-backend.test.ts` — 39 passed
- [x] `bun run check` — all 12 checks passed
- [x] `bun run build`
