### PR TITLE
feat(app-server): dead-peer detection and same-credential preemption for control/stream channels

### DIFF
--- a/src/websocket/app-server.test.ts
+++ b/src/websocket/app-server.test.ts
@@ -140,6 +140,26 @@ function waitForClientPing(socket: WebSocket): Promise<void> {
   });
 }
 
+function waitForCloseEvent(
+  socket: WebSocket,
+): Promise<{ code: number; reason: string }> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error("Timed out waiting for websocket close event"));
+    }, TEST_TIMEOUT_MS);
+    const cleanup = () => {
+      clearTimeout(timeout);
+      socket.off("close", handleClose);
+    };
+    const handleClose = (code: number, reason: Buffer) => {
+      cleanup();
+      resolve({ code, reason: reason.toString() });
+    };
+    socket.once("close", handleClose);
+  });
+}
+
 function waitForClientClose(socket: WebSocket): Promise<void> {
   if (
     socket.readyState === WebSocket.CLOSED ||
@@ -542,6 +562,131 @@ describe("app-server native websocket", () => {
       expect(stream.readyState).not.toBe(WebSocket.OPEN);
     } finally {
       closeClient(stream);
+      await handle?.close();
+    }
+  });
+
+  test("preempts an existing control connection for a newer client", async () => {
+    let handle: AppServerHandle | null = null;
+    let first: WebSocket | null = null;
+    let second: WebSocket | null = null;
+    const logs: string[] = [];
+    try {
+      handle = await startAppServer({
+        listen: "ws://127.0.0.1:0",
+        onLog: (message) => logs.push(message),
+      });
+      first = new WebSocket(handle.controlUrl);
+      await waitForOpen(first);
+
+      const firstClosed = waitForCloseEvent(first);
+      second = new WebSocket(handle.controlUrl);
+      await waitForOpen(second);
+
+      expect(await firstClosed).toEqual({
+        code: 4000,
+        reason: "superseded by newer connection",
+      });
+      expect(logs).toContainEqual(
+        expect.stringContaining("superseded the active session"),
+      );
+
+      // The newcomer keeps the slot after the holder is gone.
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(second.readyState).toBe(WebSocket.OPEN);
+    } finally {
+      terminateClient(first);
+      terminateClient(second);
+      await handle?.close();
+    }
+  });
+
+  test("frees the control slot for reconnects without waiting for the dead-peer watchdog", async () => {
+    let handle: AppServerHandle | null = null;
+    let zombie: WebSocket | null = null;
+    let successor: WebSocket | null = null;
+    try {
+      // The zombie never answers protocol pings, and the watchdog timeout is
+      // far beyond the test window, so only preemption can free the slot.
+      handle = await startAppServer({
+        listen: "ws://127.0.0.1:0",
+        heartbeatIntervalMs: 25,
+        pongTimeoutMs: 60_000,
+      });
+      zombie = new WebSocket(handle.controlUrl, { autoPong: false });
+      await waitForOpen(zombie);
+
+      successor = new WebSocket(handle.controlUrl);
+      await waitForOpen(successor);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(successor.readyState).toBe(WebSocket.OPEN);
+    } finally {
+      terminateClient(zombie);
+      terminateClient(successor);
+      await handle?.close();
+    }
+  });
+
+  test("supersedes the paired session when a newer stream connection arrives", async () => {
+    let handle: AppServerHandle | null = null;
+    let control1: WebSocket | null = null;
+    let stream1: WebSocket | null = null;
+    let control2: WebSocket | null = null;
+    let stream2: WebSocket | null = null;
+    try {
+      handle = await startAppServer({ listen: "ws://127.0.0.1:0" });
+      control1 = new WebSocket(handle.controlUrl);
+      await waitForOpen(control1);
+      stream1 = new WebSocket(handle.streamUrl);
+      await waitForOpen(stream1);
+
+      const control1Closed = waitForCloseEvent(control1);
+      const stream1Closed = waitForCloseEvent(stream1);
+      stream2 = new WebSocket(handle.streamUrl);
+      await waitForOpen(stream2);
+
+      expect(await stream1Closed).toMatchObject({ code: 4000 });
+      expect(await control1Closed).toMatchObject({ code: 4000 });
+
+      // The superseding stream socket is seated as pending and pairs with the
+      // newcomer's control channel.
+      control2 = new WebSocket(handle.controlUrl);
+      await waitForOpen(control2);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(control2.readyState).toBe(WebSocket.OPEN);
+      expect(stream2.readyState).toBe(WebSocket.OPEN);
+    } finally {
+      terminateClient(control1);
+      terminateClient(stream1);
+      terminateClient(control2);
+      terminateClient(stream2);
+      await handle?.close();
+    }
+  });
+
+  test("replaces a pending stream socket with a newer stream connection", async () => {
+    let handle: AppServerHandle | null = null;
+    let stream1: WebSocket | null = null;
+    let stream2: WebSocket | null = null;
+    let control: WebSocket | null = null;
+    try {
+      handle = await startAppServer({ listen: "ws://127.0.0.1:0" });
+      stream1 = new WebSocket(handle.streamUrl);
+      await waitForOpen(stream1);
+
+      const stream1Closed = waitForCloseEvent(stream1);
+      stream2 = new WebSocket(handle.streamUrl);
+      await waitForOpen(stream2);
+      expect(await stream1Closed).toMatchObject({ code: 4000 });
+
+      control = new WebSocket(handle.controlUrl);
+      await waitForOpen(control);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(stream2.readyState).toBe(WebSocket.OPEN);
+    } finally {
+      terminateClient(stream1);
+      terminateClient(stream2);
+      terminateClient(control);
       await handle?.close();
     }
   });

--- a/src/websocket/app-server.ts
+++ b/src/websocket/app-server.ts
@@ -39,13 +39,18 @@ const PENDING_STREAM_TIMEOUT_MS = 5000;
 // the app-level ping/pong the outbound listener uses. Ping every 30s and reap
 // any client that has not ponged within 90s (3 missed pings). A half-open
 // client connection (Desktop sleep, network switch, NAT idle timeout) never
-// emits a `close` event, which would otherwise wedge the single-occupancy
-// control channel: new control connections are rejected with 1008 while the
-// zombie session still holds `activeSession`. Terminating the dead socket
-// fires its `close` handler, clears `activeSession`, and frees the channel for
-// a reconnecting client.
+// emits a `close` event, so its runtime would otherwise linger until replaced.
+// New connections do not wait for the watchdog: they preempt the zombie
+// session immediately (see SUPERSEDED_CLOSE_CODE); the watchdog reclaims the
+// runtime when no successor ever shows up.
 const APP_SERVER_HEARTBEAT_INTERVAL_MS = 30000;
 const APP_SERVER_PONG_TIMEOUT_MS = 90000;
+// Close code sent to a client whose channel slot was taken over by a newer
+// connection. The 4000-4999 range is reserved for private application use, so
+// clients can distinguish "another client superseded this session — do not
+// auto-reconnect" from transport failures (1006) and policy rejections (1008).
+const SUPERSEDED_CLOSE_CODE = 4000;
+const SUPERSEDED_CLOSE_REASON = "superseded by newer connection";
 
 type AppServerChannel = "control" | "stream";
 
@@ -291,6 +296,47 @@ export async function startAppServer(
     return socket;
   };
 
+  // Newest-wins takeover of the single-occupancy session. Both channels are
+  // single-client, and users reconnect faster than dead peers are detected
+  // (killed app, dropped mobile socket, close/connect races), so a newcomer
+  // that reaches this point supersedes the current holder instead of being
+  // rejected with 1008. This is safe against hijacking because every accepted
+  // upgrade already cleared the same auth gate as the holder: `authPolicy` is
+  // fixed for the server's lifetime, `authorizeUpgrade` runs in the upgrade
+  // handler, and unauthenticated servers only admit loopback clients without
+  // an Origin header (see #3511). If per-connection identities are ever
+  // introduced, this must start comparing the newcomer's credential strength
+  // against the holder's before preempting.
+  const preemptActiveSession = (newcomer: AppServerChannel): void => {
+    const session = activeSession;
+    if (!session) return;
+    activeSession = null;
+    options.onLog?.(
+      `App-server ${newcomer} channel connection superseded the active session; closing previous client (${SUPERSEDED_CLOSE_CODE} ${SUPERSEDED_CLOSE_REASON})`,
+    );
+    // Detach the stream socket from the runtime first so the stream-close
+    // cascade (stream close → terminate control, see attachStreamSocket and
+    // terminateControlAfterStreamClose) cannot race the graceful close below
+    // and clobber the SUPERSEDED close frame with an abrupt terminate.
+    if (
+      session.streamSocket &&
+      session.runtime.streamSocket === session.streamSocket
+    ) {
+      session.runtime.streamSocket = null;
+      session.runtime.streamTransport = null;
+    }
+    closeSocket(
+      session.controlSocket,
+      SUPERSEDED_CLOSE_CODE,
+      SUPERSEDED_CLOSE_REASON,
+    );
+    closeSocket(
+      session.streamSocket,
+      SUPERSEDED_CLOSE_CODE,
+      SUPERSEDED_CLOSE_REASON,
+    );
+  };
+
   const handleWebSocketConnection = (
     socket: WebSocket,
     channel: AppServerChannel,
@@ -304,13 +350,27 @@ export async function startAppServer(
     });
 
     if (channel === "stream") {
+      if (activeSession?.streamSocket) {
+        // The stream channel cannot be swapped under a live session without
+        // cross-pairing one client's control with another's stream, so a
+        // superseding stream connection tears down the whole paired session
+        // and is seated as pending until its own control channel arrives.
+        preemptActiveSession("stream");
+      }
       if (activeSession) {
         attachStreamSocket(activeSession, socket);
         return;
       }
       if (pendingStreamSocket) {
-        closeSocket(socket, 1008, "stream channel already pending");
-        return;
+        const staleSocket = clearPendingStream();
+        options.onLog?.(
+          `App-server stream channel connection superseded a pending stream socket (${SUPERSEDED_CLOSE_CODE} ${SUPERSEDED_CLOSE_REASON})`,
+        );
+        closeSocket(
+          staleSocket,
+          SUPERSEDED_CLOSE_CODE,
+          SUPERSEDED_CLOSE_REASON,
+        );
       }
       pendingStreamSocket = socket;
       pendingStreamTimeout = setTimeout(() => {
@@ -329,21 +389,26 @@ export async function startAppServer(
     }
 
     if (activeSession) {
-      closeSocket(socket, 1008, "control channel already connected");
-      return;
+      preemptActiveSession("control");
     }
 
     const streamSocket = clearPendingStream();
+    // Track this connection's own session so the superseded session's
+    // deferred close events cannot clear a successor's activeSession slot.
+    let ownedSession: ActiveAppServerSession | null = null;
     void startControlSession({
       socket,
       streamSocket,
       connectionName: options.connectionName ?? hostname(),
       serverUrl: resolvedInfo?.url ?? options.listen ?? DEFAULT_LISTEN_URL,
       onSessionCreated: (session) => {
+        ownedSession = session;
         activeSession = session;
       },
       onSessionClosed: () => {
-        activeSession = null;
+        if (activeSession !== null && activeSession === ownedSession) {
+          activeSession = null;
+        }
       },
     }).catch((error) => {
       if (activeSession?.controlSocket === socket) {


### PR DESCRIPTION
## Problem

The app-server accepts exactly one control-channel and one stream-channel client and rejects every extra connection with close code 1008 (`control channel already connected` / `stream channel already connected`). While building the Letta Agent SDK reference react app, three failure modes were reproduced live against this behavior:

1. **Zombie holder**: a client that dies without a close frame (crashed app, dropped mobile socket, killed proxy) keeps the slot until the dead-peer watchdog reaps it — up to 90s with the default cadence, during which every reconnect gets 1008.
2. **Close/connect race**: a closing client races its successor's connect. The close teardown has not freed `activeSession` when the successor arrives, so legitimate quick reconnects (e.g. navigation in a mobile app) get 1008.
3. **Second-tool deadlock**: any second tool in the same workflow (SDK management transport plus a session) deadlocks on the occupied slot.

## Design

**Dead-peer detection** already exists on `main` (#3143): the server pings each connected socket every 30s at the WebSocket protocol level and terminates any client without a pong for 90s, with tests. This PR does not change that cadence; it demotes the watchdog to a backstop and updates its comment accordingly.

**Newest-wins preemption** (this PR): when a new connection arrives for an occupied slot, the server closes the existing holder with **`4000` / `superseded by newer connection`** and seats the newcomer, instead of rejecting the newcomer with 1008. This matches how users actually behave — the newest client is the live one — and resolves all three failure modes without waiting on any timeout. Details:

- The 4000 close code (private-use range) lets the displaced client distinguish "another client took over — do not auto-reconnect" from transport failures (1006) and policy rejections (1008).
- A superseding **stream** connection tears down the whole paired session and is seated as pending until its own control channel arrives (5s window, pre-existing). Swapping only the stream socket under a live session would cross-pair one client's control with another's stream during two-channel reconnects.
- A newer pending stream socket likewise replaces an older pending one (previously 1008 `stream channel already pending`).
- Every preemption is logged via `onLog`.
- `onSessionClosed` now only clears `activeSession` when it still belongs to the closing connection, so the superseded session's deferred close events cannot clobber its successor's slot.

**Why preemption is unconditionally safe here (same-credential reasoning):** the auth policy is fixed for the server's lifetime and enforced in the `upgrade` handler before any connection reaches channel seating — `authorizeUpgrade` for capability-token / signed-bearer-token modes, plus the post-#3511 rule that unauthenticated servers only admit loopback clients without an Origin header. Any connection that reaches seating is therefore authenticated exactly as strongly as the current holder (or both are unauthenticated loopback). There is no accepted-but-weaker-credential case to preserve a rejection for; a code comment documents that if per-connection identities are ever introduced, preemption must start comparing credential strength.

## Behavior changes for existing clients (please review)

- **Desktop listener / SDK / any app-server client**: a second client connecting to a busy server now *displaces* the first (which receives close 4000) instead of failing fast with 1008. Two clients configured to auto-reconnect at the same server could now flap indefinitely where previously the second failed fast — clients should treat close code 4000 as "do not auto-reconnect". No in-repo code matches on the removed 1008 reasons (the 1008 handling in `listener/lifecycle.ts` is the cloud-relay path, untouched).
- The pending-stream timeout rejection (1008 `control channel did not connect`) and all upgrade-time auth rejections are unchanged.

## Tests

New tests in `src/websocket/app-server.test.ts`, following the file's existing patterns:

- quick reconnect: second control connection succeeds; first receives exactly `4000` / `superseded by newer connection`, preemption is logged
- zombie holder (client with `autoPong: false`, watchdog timeout far beyond the test window): successor connects immediately without waiting for the watchdog
- newer stream connection supersedes the paired session (both old sockets get 4000) and pairs with the newcomer's control channel
- newer pending stream socket replaces an older pending one

Verification (`HOME` isolated to a scratch dir to avoid local `~/.letta` mods):

- `bun test src/websocket/app-server.test.ts` — 16/16 pass, stable across 3 runs
- `bun test src/websocket/` — 654/655 pass; the 1 failure is pre-existing flakiness in `listen-model-update.test.ts` (5s timeouts, also fails on clean `main`, varying tests per run)
- `bun run typecheck`, `bun run lint` (19 warnings, identical on clean `main`), layer-boundary / file-size / exported-functions / test-coverage checks — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)