### PR TITLE
fix(local): compact before output headroom is exhausted

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -2,7 +2,7 @@
   "src/agent/client-skills.test.ts": 1196,
   "src/agent/memory-git.ts": 2129,
   "src/backend/local-backend.test.ts": 2532,
-  "src/backend/local/local-backend.ts": 1030,
+  "src/backend/local/local-backend.ts": 1014,
   "src/backend/local/local-store.ts": 3594,
   "src/backend/pi-stream-adapter.test.ts": 1304,
   "src/cli/app/AppCoordinator.tsx": 5208,

--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -7,7 +7,6 @@ import type {
   SimpleStreamOptions,
   Tool,
   TSchema,
-  Usage,
 } from "@earendil-works/pi-ai";
 import { isContextOverflow, Type } from "@earendil-works/pi-ai";
 
@@ -48,9 +47,12 @@ import type {
   ProviderTurnInput,
 } from "./provider-turn-executor";
 import {
+  contextTokensFromUsage,
+  estimateProviderContextTokens,
   providerLettaChunk,
   providerLocalMessage,
   providerStreamPart,
+  shouldCompactForContextPressure,
 } from "./provider-turn-executor";
 
 const LOCAL_PROVIDER_MAX_RETRIES = 3;
@@ -65,6 +67,19 @@ export type PiStreamFunction = (
 ) => AsyncIterable<AssistantMessageEvent> & {
   result(): Promise<AssistantMessage>;
 };
+
+export interface LocalContextPressure {
+  contextTokens: number;
+  contextWindow: number;
+  phase: "preflight" | "post_turn";
+  source: "estimate" | "usage";
+}
+
+interface LocalCompactionResult {
+  uiMessages: LocalMessage[];
+  summary: string;
+  stats?: LocalCompactionStats;
+}
 
 export interface PiStreamAdapterOptions {
   stream?: PiStreamFunction;
@@ -85,14 +100,10 @@ export interface PiStreamAdapterOptions {
     summary: string;
     stats?: LocalCompactionStats;
   } | null>;
-  onContextUsage?: (
+  onContextPressure?: (
     input: ProviderTurnInput,
-    usage: Usage,
-  ) => Promise<{
-    uiMessages: LocalMessage[];
-    summary: string;
-    stats?: LocalCompactionStats;
-  } | null>;
+    pressure: LocalContextPressure,
+  ) => Promise<LocalCompactionResult | null>;
   onLlmStart?: (info: LlmStartInfo) => void | Promise<void>;
   onLlmEnd?: (info: LlmEndInfo) => void | Promise<void>;
 }
@@ -471,7 +482,7 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
   private readonly localProviderAuthStorageDir?: string;
   private readonly modelsRuntime: LocalPiModelsRuntime;
   private readonly onContextWindowOverflow?: PiStreamAdapterOptions["onContextWindowOverflow"];
-  private readonly onContextUsage?: PiStreamAdapterOptions["onContextUsage"];
+  private readonly onContextPressure?: PiStreamAdapterOptions["onContextPressure"];
   private readonly onLlmStart?: PiStreamAdapterOptions["onLlmStart"];
   private readonly onLlmEnd?: PiStreamAdapterOptions["onLlmEnd"];
 
@@ -492,7 +503,7 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
     this.abortSignal = options.abortSignal;
     this.localProviderAuthStorageDir = options.localProviderAuthStorageDir;
     this.onContextWindowOverflow = options.onContextWindowOverflow;
-    this.onContextUsage = options.onContextUsage;
+    this.onContextPressure = options.onContextPressure;
     this.onLlmStart = options.onLlmStart;
     this.onLlmEnd = options.onLlmEnd;
   }
@@ -512,6 +523,44 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
       summary: compaction.summary,
       ...(compaction.stats ? { compaction_stats: compaction.stats } : {}),
     } as never);
+  }
+
+  private async compactBeforeProviderCall(
+    input: ProviderTurnInput,
+  ): Promise<LocalCompactionResult | null> {
+    if (!this.onContextPressure) return null;
+
+    const contextTokens = estimateProviderContextTokens(input);
+    if (contextTokens === undefined) return null;
+
+    // Resolve through the same per-backend Models runtime as streamOnce. The
+    // provider-published Model remains the source of truth for contextWindow;
+    // Letta owns only the harness policy deciding when to compact around it.
+    const localModel = await resolveAvailableLocalModelForTurn({
+      model: input.agent.model,
+      modelSettings: input.agent.model_settings,
+      storageDir: this.localProviderAuthStorageDir,
+      modelsRuntime: this.modelsRuntime,
+    });
+    const resolved = await resolvePiModelForAgent(
+      localModel.model,
+      localModel.modelSettings,
+      {
+        localProviderAuthStorageDir: this.localProviderAuthStorageDir,
+        modelsRuntime: this.modelsRuntime,
+      },
+    );
+    const contextWindow = resolved.model.contextWindow;
+    if (!shouldCompactForContextPressure({ contextTokens, contextWindow })) {
+      return null;
+    }
+
+    return this.onContextPressure(input, {
+      contextTokens,
+      contextWindow,
+      phase: "preflight",
+      source: "estimate",
+    });
   }
 
   private async *streamOnce(
@@ -627,6 +676,7 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
 
       let streamError: unknown;
       let finalMessage: AssistantMessage | undefined;
+      let finalLocalMessage: LocalAssistantMessage | undefined;
       for await (const part of result) {
         if (part.type === "error") {
           const error = new PiProviderError(part.error);
@@ -640,9 +690,8 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
         }
         if (part.type === "done") {
           finalMessage = part.message;
-          yield providerLocalMessage(
-            toLocalAssistantMessage(part.message, input),
-          );
+          finalLocalMessage = toLocalAssistantMessage(part.message, input);
+          yield providerLocalMessage(finalLocalMessage);
         }
         yield providerStreamPart(part);
       }
@@ -669,8 +718,31 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
       ) {
         throw new PiProviderError(finalMessage);
       }
-      if (this.onContextUsage) {
-        const compaction = await this.onContextUsage(input, finalMessage.usage);
+      if (this.onContextPressure) {
+        const usageContextTokens = contextTokensFromUsage(finalMessage.usage);
+        const contextTokens =
+          usageContextTokens ??
+          estimateProviderContextTokens({
+            ...input,
+            // Provider usage includes the completed assistant response. Match
+            // that scope when we fall back to estimation; using the original
+            // pre-response input here would postpone compaction by one turn.
+            uiMessages: [
+              ...input.uiMessages,
+              finalLocalMessage ?? toLocalAssistantMessage(finalMessage, input),
+            ],
+          });
+        const contextWindow = resolved.model.contextWindow;
+        const compaction =
+          shouldCompactForContextPressure({ contextTokens, contextWindow }) &&
+          contextTokens !== undefined
+            ? await this.onContextPressure(input, {
+                contextTokens,
+                contextWindow,
+                phase: "post_turn",
+                source: usageContextTokens === undefined ? "estimate" : "usage",
+              })
+            : null;
         if (compaction) {
           yield* this.emitCompactionChunks(compaction, "context_window_limit");
         }
@@ -692,10 +764,25 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
 
   async *stream(input: ProviderTurnInput): AsyncIterable<ProviderStreamEvent> {
     let activeInput = input;
+    let preflightCompactionChecked = false;
     let contextOverflowCompactions = 0;
     let transientRetries = 0;
 
     while (true) {
+      if (!preflightCompactionChecked) {
+        // Check once per turn. If compaction still cannot make the request fit,
+        // the provider overflow path remains the bounded recovery mechanism.
+        // Reclassifying the eventual output limit itself as overflow would
+        // recreate the behavior deliberately removed in #3355.
+        preflightCompactionChecked = true;
+        const compaction = await this.compactBeforeProviderCall(activeInput);
+        if (compaction) {
+          activeInput = { ...activeInput, uiMessages: compaction.uiMessages };
+          yield* this.emitCompactionChunks(compaction, "context_window_limit");
+          continue;
+        }
+      }
+
       let emittedModelOutput = false;
       try {
         for await (const event of this.streamOnce(activeInput)) {

--- a/src/backend/dev/provider-turn-executor.ts
+++ b/src/backend/dev/provider-turn-executor.ts
@@ -30,6 +30,9 @@ import type {
 } from "./headless-turn-executor";
 import { normalizeLocalProviderError } from "./local-provider-errors";
 
+const LOCAL_CONTEXT_COMPACTION_RESERVE_TOKENS = 16_384;
+const LOCAL_SMALL_CONTEXT_COMPACTION_RESERVE_RATIO = 0.2;
+
 export interface ProviderTurnInput {
   conversationId: string;
   agentId: string;
@@ -199,6 +202,56 @@ export function estimateProviderContextTokens(
   const toolTokens = estimateSerializedTokens(input.clientTools);
   const total = systemPromptTokens + messageTokens + toolTokens;
   return total > 0 ? total : undefined;
+}
+
+/**
+ * Context pressure must be handled before the provider request, not only after
+ * an overflow. pi-ai first makes an oversized request valid by shrinking its
+ * output allowance to `contextWindow - estimatedContext - 4096`, floored at
+ * one token. A near-full request can therefore finish with `length` instead of
+ * throwing the overflow that our retry path would catch.
+ *
+ * Keep the same 16,384-token reserve as Pi's coding-agent harness, capped at
+ * 20% for small local windows. This is deliberately based on context usage,
+ * not the configured output limit: an intentionally small `max_tokens` value
+ * remains a normal provider length stop (the policy preserved by #3355).
+ *
+ * Upstream references, pinned when #3508 was fixed:
+ * - pi-ai clamp: https://github.com/earendil-works/pi/blob/cee5ff7520d8828bed9955ef00419e995d1f91e0/packages/ai/src/api/simple-options.ts#L12-L19
+ * - Pi reserve: https://github.com/earendil-works/pi/blob/cee5ff7520d8828bed9955ef00419e995d1f91e0/packages/coding-agent/src/core/compaction/compaction.ts#L128-L137
+ * - Pi threshold: https://github.com/earendil-works/pi/blob/cee5ff7520d8828bed9955ef00419e995d1f91e0/packages/coding-agent/src/core/compaction/compaction.ts#L235-L238
+ */
+export function contextCompactionThreshold(
+  contextWindow: number | undefined,
+): number | undefined {
+  if (
+    typeof contextWindow !== "number" ||
+    !Number.isFinite(contextWindow) ||
+    contextWindow <= 0
+  ) {
+    return undefined;
+  }
+
+  const reserveTokens = Math.min(
+    LOCAL_CONTEXT_COMPACTION_RESERVE_TOKENS,
+    Math.max(
+      1,
+      Math.floor(contextWindow * LOCAL_SMALL_CONTEXT_COMPACTION_RESERVE_RATIO),
+    ),
+  );
+  return Math.max(0, contextWindow - reserveTokens);
+}
+
+export function shouldCompactForContextPressure(input: {
+  contextTokens: number | undefined;
+  contextWindow: number | undefined;
+}): boolean {
+  const threshold = contextCompactionThreshold(input.contextWindow);
+  return (
+    input.contextTokens !== undefined &&
+    threshold !== undefined &&
+    input.contextTokens > threshold
+  );
 }
 
 function serializedLength(value: unknown): number {

--- a/src/backend/local-backend-context-pressure.test.ts
+++ b/src/backend/local-backend-context-pressure.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  AssistantMessage,
+  AssistantMessageEvent,
+  Context,
+} from "@earendil-works/pi-ai";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
+import type { ConversationMessageCreateBody } from "@/backend";
+import type { PiStreamFunction } from "@/backend/dev/pi-stream-adapter";
+import { LocalBackend } from "@/backend/local/local-backend";
+import { emptyLocalUsage } from "@/backend/local/local-message";
+
+function assistantMessage(text: string): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "openai-responses",
+    provider: "openai",
+    model: "gpt-5.5",
+    usage: emptyLocalUsage(),
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+}
+
+function streamFromMessage(
+  message: AssistantMessage,
+): ReturnType<PiStreamFunction> {
+  const event: AssistantMessageEvent = {
+    type: "done",
+    reason: "stop",
+    message,
+  };
+  async function* iterator() {
+    yield event;
+  }
+  return Object.assign(iterator(), {
+    result: async () => message,
+  });
+}
+
+async function collect(
+  stream: AsyncIterable<LettaStreamingResponse>,
+): Promise<LettaStreamingResponse[]> {
+  const chunks: LettaStreamingResponse[] = [];
+  for await (const chunk of stream) chunks.push(chunk);
+  return chunks;
+}
+
+describe("LocalBackend context pressure", () => {
+  test("persists preflight compaction before dispatching the provider request", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-context-pressure-"),
+    );
+    try {
+      const providerContexts: Context[] = [];
+      const stream: PiStreamFunction = (_model, context) => {
+        providerContexts.push(context);
+        return streamFromMessage(assistantMessage("provider response"));
+      };
+      const complete = async (): Promise<AssistantMessage> =>
+        assistantMessage("compacted before dispatch");
+      const backend = new LocalBackend({
+        storageDir,
+        stream,
+        complete,
+        memfsEnabled: false,
+      });
+      const agent = await backend.createAgent({
+        name: "Context Pressure",
+        model: "openai/gpt-5.5",
+        model_settings: {
+          provider_type: "openai",
+          context_window_limit: 1_000,
+        },
+      } as never);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as never);
+
+      const chunks = await collect(
+        await backend.createConversationMessageStream(conversation.id, {
+          agent_id: agent.id,
+          messages: [{ role: "user", content: "x".repeat(4_000) }],
+        } as ConversationMessageCreateBody),
+      );
+
+      expect(providerContexts).toHaveLength(1);
+      expect(providerContexts[0]?.messages).toEqual([
+        expect.objectContaining({
+          role: "user",
+          content: [
+            expect.objectContaining({
+              type: "text",
+              text: expect.stringContaining("compacted before dispatch"),
+            }),
+          ],
+        }),
+      ]);
+      expect(chunks).toContainEqual(
+        expect.objectContaining({
+          message_type: "event_message",
+          event_type: "compaction",
+          event_data: { trigger: "context_window_limit" },
+        }),
+      );
+      expect(chunks).toContainEqual(
+        expect.objectContaining({
+          message_type: "summary_message",
+          summary: "compacted before dispatch",
+        }),
+      );
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/backend/local/local-backend.ts
+++ b/src/backend/local/local-backend.ts
@@ -1,4 +1,3 @@
-import type { Usage } from "@earendil-works/pi-ai";
 import { GIT_MEMORY_ENABLED_TAG } from "@/agent/agent-tags";
 import {
   type InitializeLocalMemoryRepoFile,
@@ -18,15 +17,14 @@ import type {
 import { HeadlessBackend } from "@/backend/dev/headless-backend";
 import type { HeadlessTurnExecutor } from "@/backend/dev/headless-turn-executor";
 import { LocalPiModelsRuntime } from "@/backend/dev/pi-models-runtime";
-import type { PiStreamFunction } from "@/backend/dev/pi-stream-adapter";
+import type {
+  LocalContextPressure,
+  PiStreamFunction,
+} from "@/backend/dev/pi-stream-adapter";
 import type {
   LlmEndInfo,
   LlmStartInfo,
   ProviderTurnInput,
-} from "@/backend/dev/provider-turn-executor";
-import {
-  contextTokensFromUsage,
-  estimateProviderContextTokens,
 } from "@/backend/dev/provider-turn-executor";
 import { isRecord } from "@/utils/type-guards";
 import {
@@ -292,8 +290,8 @@ export class LocalBackend extends HeadlessBackend {
         (input, error) =>
           localBackendRef.current?.compactAfterContextOverflow(input, error) ??
           Promise.resolve(null),
-        (input, usage) =>
-          localBackendRef.current?.compactAfterContextUsage(input, usage) ??
+        (input, pressure) =>
+          localBackendRef.current?.compactForContextPressure(input, pressure) ??
           Promise.resolve(null),
         (info) =>
           localBackendRef.current?.emitLlmStart(info) ?? Promise.resolve(),
@@ -594,28 +592,14 @@ export class LocalBackend extends HeadlessBackend {
     };
   }
 
-  private async compactAfterContextUsage(
+  private async compactForContextPressure(
     input: ProviderTurnInput,
-    usage: Usage,
+    _pressure: LocalContextPressure,
   ): Promise<{
     uiMessages: LocalMessage[];
     summary: string;
     stats?: LocalCompactionStats;
   } | null> {
-    const contextTokens =
-      contextTokensFromUsage(usage) ?? estimateProviderContextTokens(input);
-    const contextWindow = this.effectiveContextWindow(
-      input.conversationId,
-      input.agentId,
-    );
-    if (
-      contextTokens === undefined ||
-      contextWindow === undefined ||
-      contextTokens <= contextWindow
-    ) {
-      return null;
-    }
-
     const result = await this.compactLocalConversation(
       input.conversationId,
       input.agentId,

--- a/src/backend/local/local-executor-factory.ts
+++ b/src/backend/local/local-executor-factory.ts
@@ -1,10 +1,10 @@
-import type { Usage } from "@earendil-works/pi-ai";
 import {
   DeterministicPongExecutor,
   type HeadlessTurnExecutor,
 } from "@/backend/dev/headless-turn-executor";
 import type { LocalPiModelsRuntime } from "@/backend/dev/pi-models-runtime";
 import {
+  type LocalContextPressure,
   PiStreamAdapter,
   type PiStreamFunction,
 } from "@/backend/dev/pi-stream-adapter";
@@ -42,9 +42,9 @@ export function createLocalExecutor(
     input: ProviderTurnInput,
     error: unknown,
   ) => ReturnType<LocalCompactionCallback>,
-  onContextUsage?: (
+  onContextPressure?: (
     input: ProviderTurnInput,
-    usage: Usage,
+    pressure: LocalContextPressure,
   ) => ReturnType<LocalCompactionCallback>,
   onLlmStart?: (info: LlmStartInfo) => void | Promise<void>,
   onLlmEnd?: (info: LlmEndInfo) => void | Promise<void>,
@@ -59,7 +59,7 @@ export function createLocalExecutor(
       localProviderAuthStorageDir: options.storageDir,
       modelsRuntime,
       onContextWindowOverflow,
-      onContextUsage,
+      onContextPressure,
       onLlmStart,
       onLlmEnd,
     }),

--- a/src/backend/pi-stream-adapter-context-pressure.test.ts
+++ b/src/backend/pi-stream-adapter-context-pressure.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  AssistantMessage,
+  AssistantMessageEvent,
+  Context,
+  Model,
+  SimpleStreamOptions,
+  Usage,
+} from "@earendil-works/pi-ai";
+import {
+  type LocalContextPressure,
+  PiStreamAdapter,
+  type PiStreamFunction,
+} from "@/backend/dev/pi-stream-adapter";
+import type {
+  ProviderStreamEvent,
+  ProviderTurnInput,
+} from "@/backend/dev/provider-turn-executor";
+import { emptyLocalUsage } from "@/backend/local/local-message";
+
+function usage(totalTokens: number, output = 100): Usage {
+  return {
+    input: Math.max(0, totalTokens - output),
+    output,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+}
+
+type CompletedStopReason = "length" | "stop" | "toolUse";
+
+function assistantMessage(
+  input: {
+    text?: string;
+    stopReason?: CompletedStopReason;
+    usage?: Usage;
+  } = {},
+): AssistantMessage & { stopReason: CompletedStopReason } {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text: input.text ?? "done" }],
+    api: "bedrock-converse-stream",
+    provider: "amazon-bedrock",
+    model: "us.anthropic.claude-sonnet-4-6",
+    usage: input.usage ?? emptyLocalUsage(),
+    stopReason: input.stopReason ?? "stop",
+    timestamp: Date.now(),
+  };
+}
+
+function streamFromMessage(
+  finalMessage: AssistantMessage & { stopReason: CompletedStopReason },
+): ReturnType<PiStreamFunction> {
+  const event: AssistantMessageEvent = {
+    type: "done",
+    reason: finalMessage.stopReason,
+    message: finalMessage,
+  };
+  async function* iterator() {
+    yield event;
+  }
+  return Object.assign(iterator(), {
+    result: async () => finalMessage,
+  });
+}
+
+function turnInput(
+  input: { content?: string; contextWindow?: number; maxTokens?: number } = {},
+): ProviderTurnInput {
+  return {
+    conversationId: "local-conv-context-pressure",
+    agentId: "agent-local-context-pressure",
+    agent: {
+      id: "agent-local-context-pressure",
+      name: "Local",
+      description: null,
+      system: "system",
+      tags: [],
+      model: "bedrock/us.anthropic.claude-sonnet-4-6",
+      model_settings: {
+        provider_type: "bedrock",
+        context_window_limit: input.contextWindow ?? 100_000,
+        ...(input.maxTokens !== undefined
+          ? { max_tokens: input.maxTokens }
+          : {}),
+      },
+    },
+    body: { messages: [] } as never,
+    history: [],
+    uiMessages: [
+      {
+        id: "ui-msg-context-pressure",
+        role: "user",
+        content: input.content ?? "hello",
+        timestamp: Date.now(),
+      },
+    ],
+    clientTools: [],
+    clientSkills: [],
+  };
+}
+
+async function collectEvents(
+  stream: AsyncIterable<ProviderStreamEvent>,
+): Promise<ProviderStreamEvent[]> {
+  const events: ProviderStreamEvent[] = [];
+  for await (const event of stream) events.push(event);
+  return events;
+}
+
+function compactionEvent(events: ProviderStreamEvent[]) {
+  return events.find(
+    (event) =>
+      event.type === "letta-chunk" &&
+      (event.chunk as { event_type?: string }).event_type === "compaction",
+  );
+}
+
+describe("PiStreamAdapter context pressure", () => {
+  test("compacts a 96k request before dispatching it into a 100k window", async () => {
+    let providerCalls = 0;
+    let providerContext: Context | undefined;
+    const pressures: LocalContextPressure[] = [];
+    const stream: PiStreamFunction = (_model, context) => {
+      providerCalls += 1;
+      providerContext = context;
+      return streamFromMessage(assistantMessage());
+    };
+    const adapter = new PiStreamAdapter({
+      stream,
+      onContextPressure: async (_input, pressure) => {
+        pressures.push(pressure);
+        if (pressure.phase !== "preflight") return null;
+        return {
+          uiMessages: [
+            {
+              id: "ui-msg-compacted",
+              role: "user",
+              content: "compacted summary",
+              timestamp: Date.now(),
+            },
+          ],
+          summary: "compacted summary",
+        };
+      },
+    });
+
+    const events = await collectEvents(
+      adapter.stream(turnInput({ content: "x".repeat(96_000 * 4) })),
+    );
+
+    expect(providerCalls).toBe(1);
+    expect(providerContext?.messages).toEqual([
+      expect.objectContaining({ role: "user", content: "compacted summary" }),
+    ]);
+    expect(pressures).toEqual([
+      {
+        contextTokens: expect.any(Number),
+        contextWindow: 100_000,
+        phase: "preflight",
+        source: "estimate",
+      },
+    ]);
+    expect(pressures[0]?.contextTokens).toBeGreaterThan(83_616);
+    expect(compactionEvent(events)).toBeDefined();
+  });
+
+  test("compacts after exact usage enters the reserve", async () => {
+    const pressures: LocalContextPressure[] = [];
+    const stream: PiStreamFunction = () =>
+      streamFromMessage(assistantMessage({ usage: usage(86_045) }));
+    const adapter = new PiStreamAdapter({
+      stream,
+      onContextPressure: async (_input, pressure) => {
+        pressures.push(pressure);
+        return pressure.phase === "post_turn"
+          ? {
+              uiMessages: [],
+              summary: "post-turn summary",
+            }
+          : null;
+      },
+    });
+
+    const events = await collectEvents(adapter.stream(turnInput()));
+
+    expect(pressures).toEqual([
+      {
+        contextTokens: 86_045,
+        contextWindow: 100_000,
+        phase: "post_turn",
+        source: "usage",
+      },
+    ]);
+    expect(compactionEvent(events)).toBeDefined();
+    expect(events.some((event) => event.type === "local-message")).toBe(true);
+  });
+
+  test("includes the completed response in the post-turn fallback estimate", async () => {
+    const pressures: LocalContextPressure[] = [];
+    const stream: PiStreamFunction = () =>
+      streamFromMessage(
+        assistantMessage({ text: "y".repeat(600), usage: emptyLocalUsage() }),
+      );
+    const adapter = new PiStreamAdapter({
+      stream,
+      onContextPressure: async (_input, pressure) => {
+        pressures.push(pressure);
+        return null;
+      },
+    });
+
+    await collectEvents(
+      adapter.stream(
+        turnInput({ content: "x".repeat(700 * 4), contextWindow: 1_000 }),
+      ),
+    );
+
+    expect(pressures).toEqual([
+      {
+        contextTokens: expect.any(Number),
+        contextWindow: 1_000,
+        phase: "post_turn",
+        source: "estimate",
+      },
+    ]);
+    expect(pressures[0]?.contextTokens).toBeGreaterThan(800);
+  });
+
+  test("does not treat an explicit one-token output limit as context pressure", async () => {
+    let capturedOptions:
+      | (SimpleStreamOptions & Record<string, unknown>)
+      | undefined;
+    let pressureCalls = 0;
+    const stream: PiStreamFunction = (
+      _model: Model<string>,
+      _context,
+      options,
+    ) => {
+      capturedOptions = options;
+      return streamFromMessage(
+        assistantMessage({ stopReason: "length", usage: usage(2, 1) }),
+      );
+    };
+    const adapter = new PiStreamAdapter({
+      stream,
+      onContextPressure: async () => {
+        pressureCalls += 1;
+        return null;
+      },
+    });
+
+    const events = await collectEvents(
+      adapter.stream(turnInput({ maxTokens: 1 })),
+    );
+
+    expect(capturedOptions?.maxTokens).toBe(1);
+    expect(pressureCalls).toBe(0);
+    expect(compactionEvent(events)).toBeUndefined();
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "provider-part",
+        part: expect.objectContaining({ type: "done", reason: "length" }),
+      }),
+    );
+  });
+});

--- a/src/backend/provider-turn-executor.test.ts
+++ b/src/backend/provider-turn-executor.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, test } from "bun:test";
 import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
 import type { HeadlessTurnExecutorInput } from "@/backend/dev/headless-turn-executor";
 import {
+  contextCompactionThreshold,
   type ProviderStreamAdapter,
   ProviderTurnExecutor,
   providerLocalMessage,
   providerStreamPart,
+  shouldCompactForContextPressure,
 } from "@/backend/dev/provider-turn-executor";
 import {
   emptyLocalUsage,
@@ -63,6 +65,29 @@ function assistantMessage(usage = emptyLocalUsage()): LocalMessage {
 }
 
 describe("ProviderTurnExecutor", () => {
+  test("reserves Pi's output headroom before the context window is full", () => {
+    expect(contextCompactionThreshold(100_000)).toBe(83_616);
+    expect(
+      shouldCompactForContextPressure({
+        contextTokens: 86_045,
+        contextWindow: 100_000,
+      }),
+    ).toBe(true);
+    expect(
+      shouldCompactForContextPressure({
+        contextTokens: 83_616,
+        contextWindow: 100_000,
+      }),
+    ).toBe(false);
+  });
+
+  test("caps the reserve for small local context windows", () => {
+    expect(contextCompactionThreshold(10_000)).toBe(8_000);
+    expect(contextCompactionThreshold(1_000)).toBe(800);
+    expect(contextCompactionThreshold(0)).toBeUndefined();
+    expect(contextCompactionThreshold(Number.NaN)).toBeUndefined();
+  });
+
   test("maps pi text, thinking, tool call, usage, and done events", async () => {
     const adapter: ProviderStreamAdapter = {
       async *stream() {


### PR DESCRIPTION
## Summary

- compact local conversations before provider dispatch once estimated context enters a reserved output-headroom band
- apply the same threshold after a turn, preferring exact provider usage and falling back to an estimate that includes the completed response
- preserve normal length stops for intentionally small configured output limits

Fixes #3508.

## Why no overflow was thrown

The missing compaction was a harness-policy gap, not primarily a llama.cpp usage bug.

The local adapter previously compacted after usage exceeded the full context window or after the provider threw a context overflow. But pi-ai makes a near-full request valid before dispatch by clamping the available output budget to:

    contextWindow - estimatedContext - 4096

with a one-token floor. For the reported 100K window and roughly 96K request, that becomes one output token. The provider therefore accepts the request and returns a legitimate length stop after one token. No overflow reaches Letta's retry path, so waiting for overflow cannot trigger compaction reliably.

This change treats context pressure as its own signal. It uses a 16,384-token reserve, matching the upstream coding harness, capped at 20% for small local windows. A 100K context therefore compacts above 83,616 tokens, before pi-ai has to collapse generation headroom.

## Relationship to #3314 and #3355

This does not restore the policy removed by #3355.

#3314 treated a reduced effective output budget as evidence of context overflow. That conflated two cases: automatic output clamping caused by a full context, and an intentionally small configured max output. #3355 correctly restored the rule that an ordinary length stop is not itself an overflow.

The new policy keeps that rule. It never classifies max output or a length stop as context pressure. It checks context usage independently, before dispatch and after completion. A regression test pins an explicit one-token max output as a normal length completion with no compaction.

## Ownership boundary

The provider-published pi-ai Model remains the source of truth for contextWindow. Letta's local harness owns only the policy for when to compact around that model metadata. This is separate from the endpoint-default fixes in #3512 and #3513: those fix which context window a discovered model publishes; this fixes what the harness does as any correctly-published window fills.

The provider-overflow recovery path remains in place as a bounded fallback if compaction cannot make a request fit.

## References

- pi-ai output clamp: https://github.com/earendil-works/pi/blob/cee5ff7520d8828bed9955ef00419e995d1f91e0/packages/ai/src/api/simple-options.ts#L12-L19
- upstream reserve policy: https://github.com/earendil-works/pi/blob/cee5ff7520d8828bed9955ef00419e995d1f91e0/packages/coding-agent/src/core/compaction/compaction.ts#L128-L137
- upstream threshold check: https://github.com/earendil-works/pi/blob/cee5ff7520d8828bed9955ef00419e995d1f91e0/packages/coding-agent/src/core/compaction/compaction.ts#L235-L238

## Verification

- 33 focused local-provider and compaction tests pass
- all 12 repository checks pass, including Biome and TypeScript

👾 Generated with [Letta Code](https://letta.com)
