### PR TITLE
refactor(app-server): support concurrent WebSocket clients

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -46,7 +46,7 @@
   "src/websocket/listener/commands/channels.ts": 1390,
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1030,
-  "src/websocket/listener/lifecycle.ts": 1731,
+  "src/websocket/listener/lifecycle.ts": 1723,
   "src/websocket/listener/protocol-inbound.ts": 2290,
-  "src/websocket/listener/protocol-outbound.ts": 1128
+  "src/websocket/listener/protocol-outbound.ts": 1102
 }

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -42,11 +42,11 @@
   "src/tools/tool-execution-context.test.ts": 1422,
   "src/types/protocol_v2.ts": 2961,
   "src/websocket/listen-client-concurrency.test.ts": 3017,
-  "src/websocket/listen-client-protocol.test.ts": 6722,
+  "src/websocket/listen-client-protocol.test.ts": 6721,
   "src/websocket/listener/commands/channels.ts": 1390,
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1030,
   "src/websocket/listener/lifecycle.ts": 1721,
   "src/websocket/listener/protocol-inbound.ts": 2290,
-  "src/websocket/listener/protocol-outbound.ts": 1102
+  "src/websocket/listener/protocol-outbound.ts": 1100
 }

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -43,10 +43,10 @@
   "src/types/protocol_v2.ts": 2961,
   "src/websocket/listen-client-concurrency.test.ts": 3017,
   "src/websocket/listen-client-protocol.test.ts": 6721,
-  "src/websocket/listener/commands/channels.ts": 1390,
+  "src/websocket/listener/commands/channels.ts": 1315,
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1030,
-  "src/websocket/listener/lifecycle.ts": 1721,
+  "src/websocket/listener/lifecycle.ts": 1668,
   "src/websocket/listener/protocol-inbound.ts": 2290,
   "src/websocket/listener/protocol-outbound.ts": 1100
 }

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -42,11 +42,11 @@
   "src/tools/tool-execution-context.test.ts": 1422,
   "src/types/protocol_v2.ts": 2961,
   "src/websocket/listen-client-concurrency.test.ts": 3017,
-  "src/websocket/listen-client-protocol.test.ts": 6723,
+  "src/websocket/listen-client-protocol.test.ts": 6722,
   "src/websocket/listener/commands/channels.ts": 1390,
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1030,
-  "src/websocket/listener/lifecycle.ts": 1723,
+  "src/websocket/listener/lifecycle.ts": 1721,
   "src/websocket/listener/protocol-inbound.ts": 2290,
   "src/websocket/listener/protocol-outbound.ts": 1102
 }

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -46,7 +46,7 @@
   "src/websocket/listener/commands/channels.ts": 1390,
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1030,
-  "src/websocket/listener/lifecycle.ts": 1779,
+  "src/websocket/listener/lifecycle.ts": 1731,
   "src/websocket/listener/protocol-inbound.ts": 2290,
   "src/websocket/listener/protocol-outbound.ts": 1128
 }

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -46,7 +46,7 @@
   "src/websocket/listener/commands/channels.ts": 1315,
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1030,
-  "src/websocket/listener/lifecycle.ts": 1668,
+  "src/websocket/listener/lifecycle.ts": 1658,
   "src/websocket/listener/protocol-inbound.ts": 2290,
   "src/websocket/listener/protocol-outbound.ts": 1100
 }

--- a/src/app-server-client.test.ts
+++ b/src/app-server-client.test.ts
@@ -131,7 +131,7 @@ describe("app-server client", () => {
         conversation_management: true,
         memory_management: true,
         runtime_start: true,
-        split_channels: true,
+        split_channels: false,
       },
     });
 
@@ -154,7 +154,7 @@ describe("app-server client", () => {
         conversation_management: true,
         memory_management: true,
         runtime_start: true,
-        split_channels: true,
+        split_channels: false,
       },
     };
 

--- a/src/app-server-client.test.ts
+++ b/src/app-server-client.test.ts
@@ -64,9 +64,9 @@ function createFakeClient() {
     WebSocket: FakeSocket,
     requestTimeoutMs: 25,
   });
-  const [control, stream] = FakeSocket.instances;
-  if (!control || !stream) throw new Error("expected two sockets");
-  return { client, control, stream };
+  const [socket] = FakeSocket.instances;
+  if (!socket) throw new Error("expected one socket");
+  return { client, control: socket, stream: socket };
 }
 
 describe("app-server client", () => {
@@ -74,16 +74,16 @@ describe("app-server client", () => {
     FakeSocket.instances = [];
   });
 
-  test("resolves control and stream websocket URLs", () => {
+  test("resolves historical channel names to the same websocket URL", () => {
     expect(resolveAppServerChannelUrl("http://127.0.0.1:4500", "control")).toBe(
-      "ws://127.0.0.1:4500/ws?channel=control",
+      "ws://127.0.0.1:4500/ws",
     );
     expect(
       resolveAppServerChannelUrl(
         "wss://example.test/ws?channel=control&token=abc",
         "stream",
       ),
-    ).toBe("wss://example.test/ws?channel=stream&token=abc");
+    ).toBe("wss://example.test/ws?token=abc");
   });
 
   test("passes capability token as websocket authorization header", () => {
@@ -92,13 +92,11 @@ describe("app-server client", () => {
       authToken: " super-secret-token\n",
       WebSocket: FakeSocket,
     });
-    const [control, stream] = FakeSocket.instances;
-    expect(control?.options).toEqual({
+    const [socket] = FakeSocket.instances;
+    expect(socket?.options).toEqual({
       headers: { Authorization: "Bearer super-secret-token" },
     });
-    expect(stream?.options).toEqual({
-      headers: { Authorization: "Bearer super-secret-token" },
-    });
+    expect(FakeSocket.instances).toHaveLength(1);
 
     expect(() =>
       createAppServerClient({
@@ -110,10 +108,9 @@ describe("app-server client", () => {
   });
 
   test("requests App Server capabilities before starting a runtime", async () => {
-    const { client, control, stream } = createFakeClient();
+    const { client, control } = createFakeClient();
     const opened = client.connect();
     control.open();
-    stream.open();
     await opened;
 
     const responsePromise = client.info();
@@ -179,11 +176,10 @@ describe("app-server client", () => {
     ).toBe(false);
   });
 
-  test("connects both sockets and resolves request_id responses", async () => {
+  test("connects one socket and resolves request_id responses", async () => {
     const { client, control, stream } = createFakeClient();
     const opened = client.connect();
     control.open();
-    stream.open();
     await opened;
 
     const seen: string[] = [];
@@ -228,29 +224,25 @@ describe("app-server client", () => {
     });
     expect(seen).toEqual([
       "control:runtime_start_response",
-      "stream:update_loop_status",
+      "control:update_loop_status",
     ]);
   });
 
-  test("notifies once when either websocket disconnects unexpectedly", async () => {
-    const { client, control, stream } = createFakeClient();
+  test("notifies once when the websocket disconnects unexpectedly", async () => {
+    const { client, control } = createFakeClient();
     control.open();
-    stream.open();
     await client.connect();
 
     const disconnects: string[] = [];
     client.onDisconnect(({ channel }) => disconnects.push(channel));
 
     control.close();
-    stream.close();
-
     expect(disconnects).toEqual(["control"]);
   });
 
   test("does not report explicit client shutdown as a disconnect", async () => {
-    const { client, control, stream } = createFakeClient();
+    const { client, control } = createFakeClient();
     control.open();
-    stream.open();
     await client.connect();
 
     const disconnects: string[] = [];
@@ -262,9 +254,8 @@ describe("app-server client", () => {
   });
 
   test("wraps sync, abort, and input commands", async () => {
-    const { client, control, stream } = createFakeClient();
+    const { client, control } = createFakeClient();
     control.open();
-    stream.open();
     await client.connect();
 
     const sent: string[] = [];
@@ -322,9 +313,8 @@ describe("app-server client", () => {
   });
 
   test("wraps conversation list requests", async () => {
-    const { client, control, stream } = createFakeClient();
+    const { client, control } = createFakeClient();
     control.open();
-    stream.open();
     await client.connect();
 
     const responsePromise = client.conversationList({
@@ -352,9 +342,8 @@ describe("app-server client", () => {
   });
 
   test("starts runtimes with external tools and responds to external tool calls", async () => {
-    const { client, control, stream } = createFakeClient();
+    const { client, control } = createFakeClient();
     control.open();
-    stream.open();
     await client.connect();
 
     const runtimeStart = client.runtimeStart({
@@ -418,7 +407,6 @@ describe("app-server client", () => {
   test("runTurn injects client message ids and resolves on stop_reason", async () => {
     const { client, control, stream } = createFakeClient();
     control.open();
-    stream.open();
     await client.connect();
 
     const runtime = { agent_id: "agent-1", conversation_id: "conv-1" };
@@ -478,7 +466,6 @@ describe("app-server client", () => {
   test("runTurn waits through intermediate requires_approval stop_reason", async () => {
     const { client, control, stream } = createFakeClient();
     control.open();
-    stream.open();
     await client.connect();
 
     const runtime = { agent_id: "agent-1", conversation_id: "conv-1" };
@@ -558,7 +545,6 @@ describe("app-server client", () => {
   test("runTurn resolves requires_approval only when listener is waiting on approval", async () => {
     const { client, control, stream } = createFakeClient();
     control.open();
-    stream.open();
     await client.connect();
 
     const runtime = { agent_id: "agent-1", conversation_id: "conv-1" };
@@ -625,7 +611,6 @@ describe("app-server client", () => {
   test("runTurn does not treat idle status alone as terminal", async () => {
     const { client, control, stream } = createFakeClient();
     control.open();
-    stream.open();
     await client.connect();
 
     const runtime = { agent_id: "agent-1", conversation_id: "conv-1" };
@@ -655,7 +640,6 @@ describe("app-server client", () => {
   test("runTurn ignores waiting-on-approval status before turn evidence", async () => {
     const { client, control, stream } = createFakeClient();
     control.open();
-    stream.open();
     await client.connect();
 
     const runtime = { agent_id: "agent-1", conversation_id: "conv-1" };
@@ -717,9 +701,8 @@ describe("app-server client", () => {
   });
 
   test("runTurn rejects concurrent turns for the same runtime", async () => {
-    const { client, control, stream } = createFakeClient();
+    const { client, control } = createFakeClient();
     control.open();
-    stream.open();
     await client.connect();
 
     const runtime = { agent_id: "agent-1", conversation_id: "conv-1" };
@@ -752,7 +735,6 @@ describe("app-server client", () => {
   test("runTurn can use guarded loop-status fallback after run evidence", async () => {
     const { client, control, stream } = createFakeClient();
     control.open();
-    stream.open();
     await client.connect();
 
     const runtime = { agent_id: "agent-1", conversation_id: "conv-1" };
@@ -798,7 +780,6 @@ describe("app-server client", () => {
   test("runTurn rejects on loop_error stream delta", async () => {
     const { client, control, stream } = createFakeClient();
     control.open();
-    stream.open();
     await client.connect();
 
     const runtime = { agent_id: "agent-1", conversation_id: "conv-1" };
@@ -831,9 +812,8 @@ describe("app-server client", () => {
   });
 
   test("supports ergonomic request construction", async () => {
-    const { client, control, stream } = createFakeClient();
+    const { client, control } = createFakeClient();
     control.open();
-    stream.open();
     await client.connect();
 
     const responsePromise = client.request("agent_list", {
@@ -898,9 +878,8 @@ describe("app-server client", () => {
   });
 
   test("times out unanswered requests", async () => {
-    const { client, control, stream } = createFakeClient();
+    const { client, control } = createFakeClient();
     control.open();
-    stream.open();
     await client.connect();
 
     await expect(

--- a/src/app-server-client.ts
+++ b/src/app-server-client.ts
@@ -37,18 +37,13 @@ export type AppServerRawResponse = Record<string, unknown> & {
 
 export type AppServerSendCommand = WsProtocolCommand | AppServerRawCommand;
 
-/**
- * Receives every parsed protocol frame from both app-server websocket channels.
- * Treat this as the primary event stream: app-server may emit replay or turn
- * updates on the same channel that sent the triggering command, not only on the
- * stream channel. The channel argument is diagnostic/routing context.
- */
+/** Receives every parsed protocol frame from the app-server WebSocket. */
 export type AppServerMessageHandler = (
   message: WsProtocolMessage,
   channel: AppServerChannel,
 ) => void;
 
-/** Called synchronously before a typed or raw command is written to the control socket. */
+/** Called synchronously before a typed or raw command is written to the socket. */
 export type AppServerSendHandler = (command: AppServerSendCommand) => void;
 
 export interface AppServerDisconnectEvent {
@@ -56,7 +51,7 @@ export interface AppServerDisconnectEvent {
   event: unknown;
 }
 
-/** Called once when either websocket closes before client.close(). */
+/** Called once when the WebSocket closes before client.close(). */
 export type AppServerDisconnectHandler = (
   disconnect: AppServerDisconnectEvent,
 ) => void;
@@ -172,13 +167,21 @@ function normalizeBaseUrl(url: string): URL {
   return parsed;
 }
 
+export function resolveAppServerUrl(url: string): string {
+  const parsed = normalizeBaseUrl(url);
+  parsed.searchParams.delete("channel");
+  return parsed.toString();
+}
+
+/**
+ * @deprecated App-server uses one bidirectional WebSocket. Both historical
+ * channel names resolve to that same socket URL.
+ */
 export function resolveAppServerChannelUrl(
   url: string,
-  channel: AppServerChannel,
+  _channel: AppServerChannel,
 ): string {
-  const parsed = normalizeBaseUrl(url);
-  parsed.searchParams.set("channel", channel);
-  return parsed.toString();
+  return resolveAppServerUrl(url);
 }
 
 function attachSocketListener(
@@ -327,7 +330,10 @@ function streamDeltaErrorMessage(message: StreamDeltaMessage): string {
 }
 
 export class AppServerClient {
+  readonly socket: AppServerSocketLike;
+  /** @deprecated Alias for socket. */
   readonly control: AppServerSocketLike;
+  /** @deprecated Alias for socket; no second stream connection is created. */
   readonly stream: AppServerSocketLike;
 
   private readonly requestTimeoutMs: number;
@@ -349,34 +355,23 @@ export class AppServerClient {
     this.requestTimeoutMs =
       options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
     const socketOptions = appServerSocketOptions(options.authToken);
-    this.control = new WebSocket(
-      resolveAppServerChannelUrl(options.url, "control"),
+    this.socket = new WebSocket(
+      resolveAppServerUrl(options.url),
       socketOptions,
     );
-    this.stream = new WebSocket(
-      resolveAppServerChannelUrl(options.url, "stream"),
-      socketOptions,
-    );
+    this.control = this.socket;
+    this.stream = this.socket;
 
-    attachSocketListener(this.control, "message", (event) => {
+    attachSocketListener(this.socket, "message", (event) => {
       this.handleMessage(event, "control");
     });
-    attachSocketListener(this.stream, "message", (event) => {
-      this.handleMessage(event, "stream");
-    });
-    attachSocketListener(this.control, "close", (event) => {
+    attachSocketListener(this.socket, "close", (event) => {
       this.handleDisconnect("control", event);
-    });
-    attachSocketListener(this.stream, "close", (event) => {
-      this.handleDisconnect("stream", event);
     });
   }
 
   async connect(): Promise<this> {
-    await Promise.all([
-      waitForSocketOpen(this.control),
-      waitForSocketOpen(this.stream),
-    ]);
+    await waitForSocketOpen(this.socket);
     return this;
   }
 
@@ -384,8 +379,7 @@ export class AppServerClient {
     if (this.explicitlyClosed) return;
     this.explicitlyClosed = true;
     this.rejectAllPending("App-server client closed");
-    this.control.close();
-    this.stream.close();
+    this.socket.close();
   }
 
   onMessage(handler: AppServerMessageHandler): () => void {
@@ -416,7 +410,7 @@ export class AppServerClient {
     for (const handler of this.sendHandlers) {
       handler(command);
     }
-    this.control.send(JSON.stringify(command));
+    this.socket.send(JSON.stringify(command));
   }
 
   /**

--- a/src/channels/slack/attachment-task.test.ts
+++ b/src/channels/slack/attachment-task.test.ts
@@ -15,6 +15,7 @@ const ATTACHMENT: ChannelMessageAttachment = {
   kind: "file",
   localPath: "/tmp/channels/slack/inbound/account-1/archive.zip",
 };
+const RUNTIME_SCOPE = { agentId: "agent-1", conversationId: "conv-slack" };
 
 beforeEach(() => {
   // Other suites exercise MessageChannel downloads and leave settled entries
@@ -31,6 +32,7 @@ test("fast downloads settle synchronously and complete the registry entry", asyn
   const result = await runSlackAttachmentDownloadTask({
     description: "Slack attachment download FLARGE",
     download: async () => ATTACHMENT,
+    runtimeScope: RUNTIME_SCOPE,
   });
 
   expect(result).toEqual({ outcome: "completed", attachment: ATTACHMENT });
@@ -40,6 +42,7 @@ test("fast downloads settle synchronously and complete the registry entry", asyn
   expect(taskId).toMatch(/^download_\d+$/);
   expect(entry?.status).toBe("completed");
   expect(entry?.exitCode).toBe(0);
+  expect(entry?.runtimeScope).toEqual(RUNTIME_SCOPE);
   expect(entry?.stdout.join("\n")).toContain(ATTACHMENT.localPath as string);
 });
 
@@ -49,6 +52,7 @@ test("failed downloads report the error and fail the registry entry", async () =
     download: async () => {
       throw new Error("HTTP 403");
     },
+    runtimeScope: RUNTIME_SCOPE,
   });
 
   expect(result).toEqual({ outcome: "failed", error: "HTTP 403" });
@@ -72,6 +76,7 @@ test("slow downloads yield a background task id and finish afterwards", async ()
   const result = await runSlackAttachmentDownloadTask({
     description: "Slack attachment download FLARGE",
     download,
+    runtimeScope: RUNTIME_SCOPE,
     yieldTimeMs: 20,
   });
 
@@ -111,6 +116,7 @@ test("killing a backgrounded download aborts the transfer and fails the entry", 
   const result = await runSlackAttachmentDownloadTask({
     description: "Slack attachment download FLARGE",
     download,
+    runtimeScope: RUNTIME_SCOPE,
     yieldTimeMs: 20,
   });
 

--- a/src/channels/slack/attachment-task.ts
+++ b/src/channels/slack/attachment-task.ts
@@ -39,6 +39,7 @@ export async function runSlackAttachmentDownloadTask(params: {
   description: string;
   download: (signal: AbortSignal) => Promise<ChannelMessageAttachment>;
   yieldTimeMs?: number;
+  runtimeScope: { agentId: string; conversationId: string };
 }): Promise<SlackAttachmentDownloadOutcome> {
   assertBackgroundProcessCapacity();
 
@@ -62,6 +63,7 @@ export async function runSlackAttachmentDownloadTask(params: {
     outputFile,
     totalStdoutLines: 0,
     totalStderrLines: 0,
+    runtimeScope: params.runtimeScope,
   };
   backgroundProcesses.set(taskId, processState);
   appendToOutputFile(outputFile, `${params.description}\n`);

--- a/src/channels/slack/message-actions.ts
+++ b/src/channels/slack/message-actions.ts
@@ -88,6 +88,10 @@ async function downloadSlackFile(
 
   const result = await runSlackAttachmentDownloadTask({
     description: `Slack attachment download ${attachmentId} from message ${messageId} in ${request.chatId}`,
+    runtimeScope: {
+      agentId: ctx.route.agentId,
+      conversationId: ctx.route.conversationId,
+    },
     download: (signal) =>
       downloadAttachment.call(ctx.adapter, {
         attachmentId,

--- a/src/cli/subcommands/app-server.ts
+++ b/src/cli/subcommands/app-server.ts
@@ -124,8 +124,7 @@ export async function runAppServerSubcommand(argv: string[]): Promise<number> {
       openaiApi,
       onListening: (info) => {
         console.log(`Listening on ${info.url}`);
-        console.log(`Control: ${info.controlUrl}`);
-        console.log(`Stream:  ${info.streamUrl}`);
+        console.log(`WebSocket: ${info.controlUrl}`);
         if (openaiApi) {
           const openaiBase = new URL(info.url);
           openaiBase.protocol = "http:";

--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -14,17 +14,15 @@
 
 import { getBackend } from "@/backend";
 import type { CronPromptQueueItem, DequeuedBatch } from "@/queue/queue-runtime";
+import { TO_SUBSCRIBERS } from "@/websocket/listener/connection";
 import { ensureConversationQueueRuntime } from "@/websocket/listener/conversation-runtime";
+import { emitProtocolV2Message } from "@/websocket/listener/protocol-outbound";
 import { scheduleQueuePump } from "@/websocket/listener/queue";
 import {
   getActiveRuntime,
   getOrCreateConversationRuntime,
-  safeEmitWsEvent,
 } from "@/websocket/listener/runtime";
-import {
-  isListenerTransportOpen,
-  type ListenerTransport,
-} from "@/websocket/listener/transport";
+import type { ListenerTransport } from "@/websocket/listener/transport";
 import type {
   IncomingMessage,
   StartListenerOptions,
@@ -141,26 +139,25 @@ function emitCronsUpdated(
   task: CronTask,
   conversationId?: string | null,
 ): void {
-  if (!isListenerTransportOpen(socket)) {
-    return;
-  }
-
+  const listener = getActiveRuntime();
+  if (!listener) return;
+  const runtimeScope = {
+    agent_id: task.agent_id,
+    conversation_id: conversationId ?? task.conversation_id ?? "default",
+  };
   const payload = {
-    type: "crons_updated",
+    type: "crons_updated" as const,
     timestamp: Date.now(),
     agent_id: task.agent_id,
-    conversation_id: conversationId ?? task.conversation_id,
+    conversation_id: runtimeScope.conversation_id,
   };
-
-  try {
-    socket.send(JSON.stringify(payload));
-    safeEmitWsEvent("send", "protocol", payload);
-  } catch (err) {
-    console.error(
-      `[Cron] Error sending crons_updated for task ${task.id}:`,
-      err instanceof Error ? err.message : err,
-    );
-  }
+  emitProtocolV2Message(
+    socket,
+    listener,
+    payload,
+    runtimeScope,
+    TO_SUBSCRIBERS,
+  );
 }
 
 // ── Core tick logic ─────────────────────────────────────────────────

--- a/src/runtime-context.ts
+++ b/src/runtime-context.ts
@@ -8,6 +8,8 @@ import { isUsableDirectory } from "./helpers/usable-directory";
 export type RuntimePermissionMode = "standard" | "acceptEdits" | "unrestricted";
 
 export interface RuntimeContextSnapshot {
+  /** Listener transport connection that owns the current turn, when present. */
+  connectionId?: string | null;
   agentId?: string | null;
   agentName?: string | null;
   conversationId?: string | null;

--- a/src/tools/bash-background.test.ts
+++ b/src/tools/bash-background.test.ts
@@ -38,14 +38,20 @@ describe.skipIf(isWindows)("Bash background tools", () => {
   });
 
   test("starts background process and returns ID in text", async () => {
+    const runtimeScope = { agentId: "agent-1", conversationId: "conv-1" };
     const result = await bash({
       command: "echo 'test'",
       description: "Test background",
       run_in_background: true,
+      parentScope: runtimeScope,
     });
 
     expect(result.content[0]?.text).toContain("background with ID:");
     expect(result.content[0]?.text).toMatch(/bash_\d+/);
+    const bashId = result.content[0]?.text.match(/bash_\d+/)?.[0];
+    expect(backgroundProcesses.get(bashId ?? "")?.runtimeScope).toEqual(
+      runtimeScope,
+    );
   });
 
   test("BashOutput retrieves output from background shell", async () => {

--- a/src/tools/exec-command.test.ts
+++ b/src/tools/exec-command.test.ts
@@ -128,14 +128,19 @@ describe.skipIf(isWindows)("Codex unified exec tools", () => {
   });
 
   test("returns session id for running command and write_stdin polls it", async () => {
+    const runtimeScope = { agentId: "agent-1", conversationId: "conv-1" };
     const first = await exec_command({
       cmd: "printf start; sleep 0.5; printf done",
       yield_time_ms: 250,
+      parentScope: runtimeScope,
     });
 
     const match = first.output.match(/Process running with session ID (\d+)/);
     expect(match?.[1]).toBeDefined();
     expect(first.output).toContain("Output:\nstart");
+    expect(backgroundProcesses.get(match?.[1] ?? "")?.runtimeScope).toEqual(
+      runtimeScope,
+    );
 
     const second = await write_stdin({
       session_id: Number(match?.[1]),

--- a/src/tools/impl/bash.ts
+++ b/src/tools/impl/bash.ts
@@ -182,6 +182,7 @@ interface BashArgs {
   signal?: AbortSignal;
   onOutput?: (chunk: string, stream: "stdout" | "stderr") => void;
   secretEnv?: Record<string, string>;
+  parentScope?: { agentId: string; conversationId: string };
 }
 
 interface BashResult {
@@ -202,6 +203,7 @@ export async function bash(args: BashArgs): Promise<BashResult> {
     signal,
     onOutput,
     secretEnv,
+    parentScope,
   } = args;
   const userCwd = getCurrentWorkingDirectory();
 
@@ -285,6 +287,7 @@ export async function bash(args: BashArgs): Promise<BashResult> {
       outputFile,
       totalStdoutLines: 0,
       totalStderrLines: 0,
+      runtimeScope: parentScope,
     });
     const bgProcess = backgroundProcesses.get(bashId);
     if (!bgProcess) {

--- a/src/tools/impl/exec-command.ts
+++ b/src/tools/impl/exec-command.ts
@@ -49,6 +49,7 @@ interface ExecCommandArgs {
   signal?: AbortSignal;
   onOutput?: (chunk: string, stream: "stdout" | "stderr") => void;
   secretEnv?: Record<string, string>;
+  parentScope?: { agentId: string; conversationId: string };
 }
 
 interface WriteStdinArgs {
@@ -702,6 +703,7 @@ async function startExecSession(args: ExecCommandArgs): Promise<ExecSession> {
     outputFile,
     totalStdoutLines: 0,
     totalStderrLines: 0,
+    runtimeScope: args.parentScope,
   });
   if (session.status !== "running") {
     scheduleBackgroundProcessCleanup(id);

--- a/src/tools/impl/process_manager.ts
+++ b/src/tools/impl/process_manager.ts
@@ -14,6 +14,11 @@ export interface BackgroundProcessHandle {
   kill(signal?: string | number): unknown;
 }
 
+export interface BackgroundRuntimeScope {
+  agentId: string;
+  conversationId: string;
+}
+
 export interface BackgroundProcess {
   process: BackgroundProcessHandle;
   command: string;
@@ -27,6 +32,7 @@ export interface BackgroundProcess {
   totalStdoutLines?: number;
   totalStderrLines?: number;
   cleanupTimer?: TimerHandle;
+  runtimeScope?: BackgroundRuntimeScope;
 }
 
 export interface BackgroundTask {
@@ -40,6 +46,7 @@ export interface BackgroundTask {
   outputFile: string;
   abortController?: AbortController;
   cleanupTimer?: TimerHandle;
+  runtimeScope?: BackgroundRuntimeScope;
 }
 
 export const backgroundProcesses = new Map<string, BackgroundProcess>();

--- a/src/tools/impl/task.ts
+++ b/src/tools/impl/task.ts
@@ -384,6 +384,7 @@ export function spawnBackgroundSubagentTask(
     startTime: new Date(),
     outputFile,
     abortController,
+    runtimeScope: resolvedParentScope,
   };
   backgroundTasks.set(taskId, bgTask);
   writeTaskTranscriptStart(outputFile, description, subagentType);

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -2849,10 +2849,7 @@ async function executeToolInner(
             },
           };
         }
-
-        // Inject secrets as environment variables instead of substituting into
-        // the command string. This prevents shell metacharacters in secrets
-        // (e.g. $$, backticks, quotes) from being interpreted by the shell.
+        // Keep secret values out of shell interpolation.
         const command = enhancedArgs.command ?? enhancedArgs.cmd;
         const secretEnv =
           typeof command === "string" ||
@@ -2862,6 +2859,9 @@ async function executeToolInner(
             : {};
         if (Object.keys(secretEnv).length > 0) {
           enhancedArgs = { ...enhancedArgs, secretEnv };
+        }
+        if (options?.parentScope) {
+          enhancedArgs = { ...enhancedArgs, parentScope: options.parentScope };
         }
       }
 

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -396,12 +396,14 @@ function filterExternalToolsByRuntimeContext(
 ): Map<string, ExternalToolDefinition> {
   return new Map(
     Array.from(externalTools.entries()).filter(([, tool]) => {
-      if (!tool.runtime) {
-        return true;
-      }
+      const matchesConnection =
+        tool.connectionId === undefined ||
+        tool.connectionId === runtimeContext.connectionId;
       return (
-        tool.runtime.agentId === runtimeContext.agentId &&
-        tool.runtime.conversationId === runtimeContext.conversationId
+        matchesConnection &&
+        (!tool.runtime ||
+          (tool.runtime.agentId === runtimeContext.agentId &&
+            tool.runtime.conversationId === runtimeContext.conversationId))
       );
     }),
   );
@@ -896,9 +898,6 @@ export interface ClientTool {
 // EXTERNAL TOOLS (SDK-side execution)
 // ═══════════════════════════════════════════════════════════════
 
-/**
- * External tool definition from SDK
- */
 export interface ExternalToolDefinition {
   name: string;
   label?: string;
@@ -906,6 +905,7 @@ export interface ExternalToolDefinition {
   parameters: Record<string, unknown>; // JSON Schema
   /** Internal registration key; model-facing calls still use name. */
   registrationKey?: string;
+  connectionId?: string;
   /** Optional visibility scope; scoped tools are hidden unless selected for a turn. */
   scopeId?: string;
   /** Optional runtime owner; runtime-owned tools are visible only in that runtime. */

--- a/src/tools/subagent-parent-id-propagation.test.ts
+++ b/src/tools/subagent-parent-id-propagation.test.ts
@@ -125,7 +125,7 @@ describe("parentScope.agentId propagation to spawnSubagent", () => {
   test("forwards parentScope as explicit positional args to spawnSubagent", async () => {
     const spawnSubagentImpl = makeSpawnStub();
 
-    spawnBackgroundSubagentTask({
+    const launched = spawnBackgroundSubagentTask({
       subagentType: "reflection",
       prompt: "Reflect",
       description: "Test",
@@ -150,6 +150,10 @@ describe("parentScope.agentId propagation to spawnSubagent", () => {
     expect(call).toBeDefined();
     expect(call?.[PARENT_ID_ARG_INDEX]).toBe(PARENT_AGENT_ID);
     expect(call?.[PARENT_CONVERSATION_ID_ARG_INDEX]).toBe("conv-xyz");
+    expect(backgroundTasks.get(launched.taskId)?.runtimeScope).toEqual({
+      agentId: PARENT_AGENT_ID,
+      conversationId: "conv-xyz",
+    });
   });
 
   test("forwards undefined parentAgentId when parentScope is omitted", async () => {

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -457,6 +457,7 @@ function parseInheritedChannelContextEnv(): InheritedChannelContextPayload | nul
 }
 
 export async function prepareToolExecutionContextForScope(params: {
+  connectionId?: string;
   agentId: string;
   conversationId?: string | null;
   overrideModel?: string | null;
@@ -475,6 +476,7 @@ export async function prepareToolExecutionContextForScope(params: {
   modAdapters?: ModAdapter[];
 }): Promise<PreparedScopeToolContext> {
   const {
+    connectionId,
     agentId,
     conversationId,
     overrideModel,
@@ -567,6 +569,7 @@ export async function prepareToolExecutionContextForScope(params: {
     modAdapters,
     agent: agent as AgentState,
     runtimeContext: {
+      connectionId,
       agentId,
       agentName: (agent as AgentState).name ?? null,
       conversationId: scopedConversationId,

--- a/src/websocket/app-server-lifecycle.test.ts
+++ b/src/websocket/app-server-lifecycle.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import WebSocket from "ws";
+import { __testSetBackend, type AgentCreateBody } from "@/backend";
+import { LocalBackend } from "@/backend/local";
+import { type AppServerHandle, startAppServer } from "@/websocket/app-server";
+import { createRuntime, stopRuntime } from "@/websocket/listener/lifecycle";
+import {
+  getActiveRuntime,
+  setActiveRuntime,
+} from "@/websocket/listener/runtime";
+
+const ORIGINAL_DISABLE_MODS = process.env.LETTA_DISABLE_MODS;
+const ORIGINAL_DISABLE_CRON = process.env.LETTA_DISABLE_CRON_SCHEDULER;
+
+function waitForOpen(socket: WebSocket): Promise<void> {
+  if (socket.readyState === WebSocket.OPEN) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    socket.once("open", resolve);
+    socket.once("error", reject);
+  });
+}
+
+function waitForClose(socket: WebSocket): Promise<void> {
+  if (socket.readyState === WebSocket.CLOSED) return Promise.resolve();
+  return new Promise((resolve) => socket.once("close", () => resolve()));
+}
+
+function waitForJsonMessage(
+  socket: WebSocket,
+  predicate: (message: Record<string, unknown>) => boolean,
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error("Timed out waiting for websocket message")),
+      10_000,
+    );
+    socket.on("message", (raw) => {
+      const message = JSON.parse(String(raw)) as Record<string, unknown>;
+      if (!predicate(message)) return;
+      clearTimeout(timeout);
+      resolve(message);
+    });
+  });
+}
+
+function closeClient(socket: WebSocket | null): void {
+  if (
+    socket?.readyState === WebSocket.OPEN ||
+    socket?.readyState === WebSocket.CONNECTING
+  ) {
+    socket.close();
+  }
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 300; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(message);
+}
+
+beforeEach(() => {
+  process.env.LETTA_DISABLE_MODS = "1";
+  process.env.LETTA_DISABLE_CRON_SCHEDULER = "1";
+});
+
+afterEach(() => {
+  __testSetBackend(null);
+  const active = getActiveRuntime();
+  if (active) {
+    stopRuntime(active, true);
+    setActiveRuntime(null);
+  }
+  if (ORIGINAL_DISABLE_MODS === undefined) {
+    delete process.env.LETTA_DISABLE_MODS;
+  } else {
+    process.env.LETTA_DISABLE_MODS = ORIGINAL_DISABLE_MODS;
+  }
+  if (ORIGINAL_DISABLE_CRON === undefined) {
+    delete process.env.LETTA_DISABLE_CRON_SCHEDULER;
+  } else {
+    process.env.LETTA_DISABLE_CRON_SCHEDULER = ORIGINAL_DISABLE_CRON;
+  }
+});
+
+describe("app-server startup lifecycle", () => {
+  test("a bind failure preserves the active runtime and a later start succeeds", async () => {
+    const occupied = createServer();
+    await new Promise<void>((resolve) =>
+      occupied.listen(0, "127.0.0.1", resolve),
+    );
+    const port = (occupied.address() as AddressInfo).port;
+    const existingRuntime = createRuntime();
+    setActiveRuntime(existingRuntime);
+    let handle: AppServerHandle | null = null;
+
+    try {
+      await expect(
+        startAppServer({ listen: `ws://127.0.0.1:${port}` }),
+      ).rejects.toMatchObject({ code: "EADDRINUSE" });
+      expect(getActiveRuntime()).toBe(existingRuntime);
+      expect(existingRuntime.intentionallyClosed).toBe(false);
+
+      await new Promise<void>((resolve, reject) =>
+        occupied.close((error) => (error ? reject(error) : resolve())),
+      );
+      handle = await startAppServer({
+        listen: `ws://127.0.0.1:${port}`,
+      });
+
+      expect(getActiveRuntime()).not.toBe(existingRuntime);
+      expect(existingRuntime.intentionallyClosed).toBe(true);
+    } finally {
+      await handle?.close();
+      if (occupied.listening) {
+        await new Promise<void>((resolve) => occupied.close(() => resolve()));
+      }
+    }
+  });
+
+  test("a rejected runtime initializer is retried by the next connection", async () => {
+    const initializeRuntime = mock(async () => {
+      if (initializeRuntime.mock.calls.length === 1) {
+        throw new Error("transient startup failure");
+      }
+    });
+    const handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      initializeRuntime,
+    });
+    let first: WebSocket | null = null;
+    let second: WebSocket | null = null;
+
+    try {
+      first = new WebSocket(handle.controlUrl);
+      await waitForClose(first);
+
+      second = new WebSocket(handle.controlUrl);
+      await waitForOpen(second);
+      const response = waitForJsonMessage(
+        second,
+        (message) =>
+          message.type === "app_server_info_response" &&
+          message.request_id === "retry-ready",
+      );
+      second.send(
+        JSON.stringify({
+          type: "app_server_info",
+          request_id: "retry-ready",
+        }),
+      );
+      await response;
+
+      expect(initializeRuntime).toHaveBeenCalledTimes(2);
+    } finally {
+      closeClient(first);
+      closeClient(second);
+      await handle.close();
+    }
+  });
+
+  test("commands received before initialization are dropped after disconnect", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "letta-init-cancel-"));
+    const backend = new LocalBackend({
+      storageDir,
+      executionMode: "deterministic",
+      memfsEnabled: false,
+    });
+    __testSetBackend(backend);
+    let resolveInitialization: (() => void) | undefined;
+    const initialization = new Promise<void>((resolve) => {
+      resolveInitialization = resolve;
+    });
+    const handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      initializeRuntime: () => initialization,
+    });
+    let client: WebSocket | null = null;
+
+    try {
+      client = new WebSocket(handle.controlUrl);
+      await waitForOpen(client);
+      client.send(
+        JSON.stringify({
+          type: "runtime_start",
+          request_id: "disconnected-start",
+          create_agent: {
+            body: {
+              name: "Must Not Be Created",
+              model: "anthropic/claude-sonnet-4-6",
+            } as AgentCreateBody,
+            pin_global: false,
+          },
+          create_conversation: {
+            body: { summary: "Disconnected initialization" },
+          },
+          recover_approvals: false,
+        }),
+      );
+      const closed = waitForClose(client);
+      client.close();
+      await closed;
+      await waitFor(
+        () => getActiveRuntime()?.connections.size === 0,
+        "server did not remove disconnected client",
+      );
+      resolveInitialization?.();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const agents = (await backend.listAgents({
+        limit: 10,
+      } as never)) as unknown as { items: unknown[] };
+      expect(agents.items).toEqual([]);
+      expect(getActiveRuntime()?.connections.size).toBe(0);
+    } finally {
+      resolveInitialization?.();
+      closeClient(client);
+      await handle.close();
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/websocket/app-server-openai-turn.ts
+++ b/src/websocket/app-server-openai-turn.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { settingsManager } from "@/settings-manager";
+import { getOrCreateProcessTransport } from "@/websocket/listener/connection";
+import { createConnectionTurnProcessor } from "@/websocket/listener/connection-lifecycle";
 import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
 import { dispatchInboundMessageWhenReady } from "@/websocket/listener/inbound-dispatch";
 import {
@@ -11,10 +13,7 @@ import {
   getActiveRuntime,
   setActiveRuntime,
 } from "@/websocket/listener/runtime";
-import {
-  type ListenerTransport,
-  LocalListenerTransport,
-} from "@/websocket/listener/transport";
+import type { ListenerTransport } from "@/websocket/listener/transport";
 import { handleIncomingMessage } from "@/websocket/listener/turn";
 import { registerTurnObserver } from "@/websocket/listener/turn-observers";
 import type {
@@ -92,7 +91,6 @@ export function runBridgeTurn(params: RunTurnParams): Promise<TurnOutcome> {
 
 const OPENAI_TURN_TIMEOUT_MS = 15 * 60 * 1000;
 
-const bridgeTransport = new LocalListenerTransport();
 let bridgeRuntimeStart: Promise<void> | null = null;
 let bridgeOwnedRuntime: ListenerRuntime | null = null;
 
@@ -179,10 +177,10 @@ async function runTurnViaListenerRuntime(
     params.agentId,
     params.conversationId,
   ).mode = "unrestricted";
-  // Frames emitted for this turn also flow to any attached WS client; the
-  // transport here is only the fallback destination when none is attached.
-  const socket: ListenerTransport =
-    listener.socket ?? listener.transport ?? bridgeTransport;
+  // The bridge is a process-originated producer, not a websocket client.
+  // Scoped frames reach explicit conversation subscribers and the observer
+  // below; they must never inherit an arbitrary app-server connection.
+  const socket: ListenerTransport = getOrCreateProcessTransport(listener);
 
   const dispatchOptions: StartListenerOptions = {
     connectionId: listener.connectionId ?? "openai-api",
@@ -196,24 +194,8 @@ async function runTurnViaListenerRuntime(
     },
   };
 
-  const processQueuedTurn: ProcessQueuedTurn = async (
-    queuedTurn,
-    dequeuedBatch,
-  ) => {
-    const queuedScope = getOrCreateScopedRuntime(
-      listener,
-      queuedTurn.agentId,
-      queuedTurn.conversationId,
-    );
-    await handleIncomingMessage(
-      queuedTurn,
-      socket,
-      queuedScope,
-      undefined,
-      dispatchOptions.connectionId,
-      dequeuedBatch.batchId,
-    );
-  };
+  const processQueuedTurn: ProcessQueuedTurn =
+    createConnectionTurnProcessor(listener);
 
   return await new Promise<TurnOutcome>((resolve) => {
     let text = "";
@@ -352,7 +334,22 @@ async function runTurnViaListenerRuntime(
         socket,
         options: dispatchOptions,
         processQueuedTurn,
-        processIncomingMessage: handleIncomingMessage,
+        processIncomingMessage: (
+          incoming,
+          incomingSocket,
+          incomingRuntime,
+          onStatusChange,
+          _connectionId,
+          batchId,
+        ) =>
+          handleIncomingMessage(
+            incoming,
+            incomingSocket,
+            incomingRuntime,
+            onStatusChange,
+            undefined,
+            batchId,
+          ),
         trackListenerError: (errorType, error) => {
           params.onLog?.(
             `OpenAI-compat listener error (${errorType}): ${

--- a/src/websocket/app-server.test.ts
+++ b/src/websocket/app-server.test.ts
@@ -20,7 +20,7 @@ import {
 } from "@/websocket/app-server-auth";
 import { getActiveRuntime } from "@/websocket/listener/runtime";
 
-const TEST_TIMEOUT_MS = 10_000;
+const TEST_TIMEOUT_MS = 30_000;
 const ORIGINAL_DISABLE_MODS = process.env.LETTA_DISABLE_MODS;
 const ORIGINAL_DISABLE_CRON = process.env.LETTA_DISABLE_CRON_SCHEDULER;
 

--- a/src/websocket/app-server.test.ts
+++ b/src/websocket/app-server.test.ts
@@ -4,9 +4,9 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import { join } from "node:path";
 import WebSocket from "ws";
-import type { AgentCreateBody } from "@/backend";
-import { __testSetBackend } from "@/backend";
+import { __testSetBackend, type AgentCreateBody } from "@/backend";
 import { LocalBackend } from "@/backend/local";
+import { settingsManager } from "@/settings-manager";
 import {
   type AppServerHandle,
   parseAppServerListenUrl,
@@ -667,13 +667,24 @@ describe("app-server native websocket", () => {
     const seenA: Record<string, unknown>[] = [];
     const seenB: Record<string, unknown>[] = [];
     try {
-      __testSetBackend(
-        new LocalBackend({
-          storageDir,
-          executionMode: "deterministic",
-          memfsEnabled: false,
-        }),
-      );
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+        memfsEnabled: false,
+      });
+      __testSetBackend(backend);
+      const createAgent = (name: string) =>
+        backend.createAgent({
+          name,
+          model: "anthropic/claude-sonnet-4-6",
+        } as AgentCreateBody);
+      const [agentA, agentB] = await Promise.all([
+        createAgent("Client A"),
+        createAgent("Client B"),
+      ]);
+      await settingsManager.initialize();
+      settingsManager.setMemfsEnabled(agentA.id, false);
+      settingsManager.setMemfsEnabled(agentB.id, false);
       handle = await startAppServer({ listen: "ws://127.0.0.1:0" });
       clientA = new WebSocket(handle.controlUrl);
       clientB = new WebSocket(handle.controlUrl);
@@ -696,31 +707,20 @@ describe("app-server native websocket", () => {
           message.type === "runtime_start_response" &&
           message.request_id === "identical-runtime-start-id",
       );
-      const runtimeStart = (name: string) =>
+      const runtimeStart = (agentId: string, name: string) =>
         JSON.stringify({
           type: "runtime_start",
           request_id: "identical-runtime-start-id",
-          create_agent: {
-            body: {
-              name,
-              model: "anthropic/claude-sonnet-4-6",
-            } as AgentCreateBody,
-            pin_global: false,
-          },
+          agent_id: agentId,
           create_conversation: { body: { summary: `${name} conversation` } },
           recover_approvals: false,
         });
-      clientA.send(runtimeStart("Client A"));
-      clientB.send(runtimeStart("Client B"));
+      clientA.send(runtimeStart(agentA.id, "Client A"));
+      clientB.send(runtimeStart(agentB.id, "Client B"));
       const [responseA, responseB] = await Promise.all([startA, startB]);
-      const runtimeA = responseA.runtime as {
-        agent_id: string;
-        conversation_id: string;
-      };
-      const runtimeB = responseB.runtime as {
-        agent_id: string;
-        conversation_id: string;
-      };
+      type RuntimeScope = { agent_id: string; conversation_id: string };
+      const runtimeA = responseA.runtime as RuntimeScope;
+      const runtimeB = responseB.runtime as RuntimeScope;
       expect(runtimeA.agent_id).not.toBe(runtimeB.agent_id);
       expect(responseA.agent).toMatchObject({ name: "Client A" });
       expect(responseB.agent).toMatchObject({ name: "Client B" });
@@ -921,7 +921,7 @@ describe("app-server native websocket", () => {
       await handle?.close();
       await rm(storageDir, { recursive: true, force: true });
     }
-  }, 20_000);
+  }, 60_000);
 
   test("starts a runtime and emits state frames over the same socket", async () => {
     const storageDir = await mkdtemp(join(os.tmpdir(), "letta-app-server-"));

--- a/src/websocket/app-server.test.ts
+++ b/src/websocket/app-server.test.ts
@@ -668,7 +668,11 @@ describe("app-server native websocket", () => {
     const seenB: Record<string, unknown>[] = [];
     try {
       __testSetBackend(
-        new LocalBackend({ storageDir, executionMode: "deterministic" }),
+        new LocalBackend({
+          storageDir,
+          executionMode: "deterministic",
+          memfsEnabled: false,
+        }),
       );
       handle = await startAppServer({ listen: "ws://127.0.0.1:0" });
       clientA = new WebSocket(handle.controlUrl);
@@ -680,7 +684,6 @@ describe("app-server native websocket", () => {
         seenB.push(JSON.parse(String(raw)) as Record<string, unknown>);
       });
       await Promise.all([waitForOpen(clientA), waitForOpen(clientB)]);
-
       const startA = waitForJsonMessage(
         clientA,
         (message) =>
@@ -735,7 +738,6 @@ describe("app-server native websocket", () => {
             message.request_id === "identical-runtime-start-id",
         ),
       ).toHaveLength(1);
-
       seenA.length = 0;
       seenB.length = 0;
       const waitForTurn = (socket: WebSocket, runtime: typeof runtimeA) =>
@@ -777,7 +779,6 @@ describe("app-server native websocket", () => {
               ?.agent_id === runtimeA.agent_id,
         ),
       ).toBe(false);
-
       const turnFinished = waitForJsonMessage(clientA, (message) => {
         const runtime = message.runtime as
           | { agent_id?: unknown; conversation_id?: unknown }

--- a/src/websocket/app-server.test.ts
+++ b/src/websocket/app-server.test.ts
@@ -568,7 +568,10 @@ describe("app-server native websocket", () => {
     let handle: AppServerHandle | null = null;
     try {
       handle = await startAppServer({ listen: "ws://127.0.0.1:0" });
-      await expectWebSocketOpenFailure(handle.streamUrl);
+      expect("streamUrl" in handle).toBe(false);
+      const legacyStreamUrl = new URL(handle.controlUrl);
+      legacyStreamUrl.searchParams.set("channel", "stream");
+      await expectWebSocketOpenFailure(legacyStreamUrl.toString());
       const legacyControlUrl = new URL(handle.controlUrl);
       legacyControlUrl.searchParams.set("channel", "control");
       await expectWebSocketOpenFailure(legacyControlUrl.toString());

--- a/src/websocket/app-server.test.ts
+++ b/src/websocket/app-server.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { createHash, createHmac } from "node:crypto";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
@@ -18,8 +18,11 @@ import {
   parseAppServerWebsocketAuthSettings,
   policyFromSettings,
 } from "@/websocket/app-server-auth";
+import { getActiveRuntime } from "@/websocket/listener/runtime";
 
-const TEST_TIMEOUT_MS = 5000;
+const TEST_TIMEOUT_MS = 10_000;
+const ORIGINAL_DISABLE_MODS = process.env.LETTA_DISABLE_MODS;
+const ORIGINAL_DISABLE_CRON = process.env.LETTA_DISABLE_CRON_SCHEDULER;
 
 function waitForOpen(socket: WebSocket): Promise<void> {
   if (socket.readyState === WebSocket.OPEN) {
@@ -204,8 +207,23 @@ function signedBearerToken(
   return `${payload}.${base64Url(signature)}`;
 }
 
+beforeEach(() => {
+  process.env.LETTA_DISABLE_MODS = "1";
+  process.env.LETTA_DISABLE_CRON_SCHEDULER = "1";
+});
+
 afterEach(() => {
   __testSetBackend(null);
+  if (ORIGINAL_DISABLE_MODS === undefined) {
+    delete process.env.LETTA_DISABLE_MODS;
+  } else {
+    process.env.LETTA_DISABLE_MODS = ORIGINAL_DISABLE_MODS;
+  }
+  if (ORIGINAL_DISABLE_CRON === undefined) {
+    delete process.env.LETTA_DISABLE_CRON_SCHEDULER;
+  } else {
+    process.env.LETTA_DISABLE_CRON_SCHEDULER = ORIGINAL_DISABLE_CRON;
+  }
 });
 
 describe("app-server native websocket", () => {
@@ -508,7 +526,7 @@ describe("app-server native websocket", () => {
         heartbeatIntervalMs: 25,
         pongTimeoutMs: 5000,
       });
-      stream = new WebSocket(handle.streamUrl);
+      stream = new WebSocket(handle.controlUrl);
       await waitForOpen(stream);
 
       // The watchdog should ping connected clients on its cadence.
@@ -535,7 +553,7 @@ describe("app-server native websocket", () => {
         heartbeatIntervalMs: 25,
         pongTimeoutMs: 1,
       });
-      stream = new WebSocket(handle.streamUrl);
+      stream = new WebSocket(handle.controlUrl);
       await waitForOpen(stream);
 
       await waitForClientClose(stream);
@@ -546,45 +564,372 @@ describe("app-server native websocket", () => {
     }
   });
 
-  test("closes the paired control channel when stream disconnects", async () => {
+  test("rejects legacy split-channel websocket URLs", async () => {
     let handle: AppServerHandle | null = null;
     try {
       handle = await startAppServer({ listen: "ws://127.0.0.1:0" });
-
-      for (const order of ["stream-first", "control-first"] as const) {
-        const firstUrl =
-          order === "stream-first" ? handle.streamUrl : handle.controlUrl;
-        const secondUrl =
-          order === "stream-first" ? handle.controlUrl : handle.streamUrl;
-        const first = new WebSocket(firstUrl);
-        await waitForOpen(first);
-        const second = new WebSocket(secondUrl);
-        await waitForOpen(second);
-        const stream = order === "stream-first" ? first : second;
-        const control = order === "stream-first" ? second : first;
-
-        terminateClient(stream);
-        await waitForClientClose(control);
-        terminateClient(control);
-      }
+      await expectWebSocketOpenFailure(handle.streamUrl);
+      const legacyControlUrl = new URL(handle.controlUrl);
+      legacyControlUrl.searchParams.set("channel", "control");
+      await expectWebSocketOpenFailure(legacyControlUrl.toString());
     } finally {
       await handle?.close();
     }
   });
 
-  test("starts a runtime over control and emits state frames over stream", async () => {
-    const storageDir = await mkdtemp(join(os.tmpdir(), "letta-app-server-"));
+  test("disconnecting one client leaves another client usable", async () => {
     let handle: AppServerHandle | null = null;
-    let control: WebSocket | null = null;
-    let stream: WebSocket | null = null;
+    let first: WebSocket | null = null;
+    let second: WebSocket | null = null;
+    try {
+      handle = await startAppServer({ listen: "ws://127.0.0.1:0" });
+      first = new WebSocket(handle.controlUrl);
+      second = new WebSocket(handle.controlUrl);
+      await Promise.all([waitForOpen(first), waitForOpen(second)]);
+
+      terminateClient(second);
+      await waitForClientClose(second);
+
+      const response = waitForJsonMessage(
+        first,
+        (message) =>
+          message.type === "app_server_info_response" &&
+          message.request_id === "peer-still-healthy",
+      );
+      first.send(
+        JSON.stringify({
+          type: "app_server_info",
+          request_id: "peer-still-healthy",
+        }),
+      );
+      expect(await response).toMatchObject({
+        type: "app_server_info_response",
+        request_id: "peer-still-healthy",
+        success: true,
+      });
+      expect(first.readyState).toBe(WebSocket.OPEN);
+    } finally {
+      closeClient(first);
+      closeClient(second);
+      await handle?.close();
+    }
+  });
+
+  test("a heartbeat reap removes only the unresponsive client", async () => {
+    let handle: AppServerHandle | null = null;
+    let first: WebSocket | null = null;
+    let second: WebSocket | null = null;
+    try {
+      handle = await startAppServer({
+        listen: "ws://127.0.0.1:0",
+        heartbeatIntervalMs: 20,
+        pongTimeoutMs: 60,
+        shouldRecordPong: (connectionId) => connectionId !== "app-server-1",
+      });
+      first = new WebSocket(handle.controlUrl);
+      second = new WebSocket(handle.controlUrl);
+      await Promise.all([waitForOpen(first), waitForOpen(second)]);
+
+      await waitForClientClose(second);
+      expect(first.readyState).toBe(WebSocket.OPEN);
+
+      const response = waitForJsonMessage(
+        first,
+        (message) =>
+          message.type === "app_server_info_response" &&
+          message.request_id === "healthy-after-reap",
+      );
+      first.send(
+        JSON.stringify({
+          type: "app_server_info",
+          request_id: "healthy-after-reap",
+        }),
+      );
+      await response;
+      expect(getActiveRuntime()?.connections.size).toBe(1);
+    } finally {
+      closeClient(first);
+      closeClient(second);
+      await handle?.close();
+    }
+  });
+
+  test("routes simultaneous clients, subscriptions, and identical ids independently", async () => {
+    const storageDir = await mkdtemp(
+      join(os.tmpdir(), "letta-app-server-multi-"),
+    );
+    let handle: AppServerHandle | null = null;
+    let clientA: WebSocket | null = null;
+    let clientB: WebSocket | null = null;
+    const seenA: Record<string, unknown>[] = [];
+    const seenB: Record<string, unknown>[] = [];
     try {
       __testSetBackend(
         new LocalBackend({ storageDir, executionMode: "deterministic" }),
       );
       handle = await startAppServer({ listen: "ws://127.0.0.1:0" });
-      stream = new WebSocket(handle.streamUrl);
+      clientA = new WebSocket(handle.controlUrl);
+      clientB = new WebSocket(handle.controlUrl);
+      clientA.on("message", (raw) => {
+        seenA.push(JSON.parse(String(raw)) as Record<string, unknown>);
+      });
+      clientB.on("message", (raw) => {
+        seenB.push(JSON.parse(String(raw)) as Record<string, unknown>);
+      });
+      await Promise.all([waitForOpen(clientA), waitForOpen(clientB)]);
+
+      const startA = waitForJsonMessage(
+        clientA,
+        (message) =>
+          message.type === "runtime_start_response" &&
+          message.request_id === "identical-runtime-start-id",
+      );
+      const startB = waitForJsonMessage(
+        clientB,
+        (message) =>
+          message.type === "runtime_start_response" &&
+          message.request_id === "identical-runtime-start-id",
+      );
+      const runtimeStart = (name: string) =>
+        JSON.stringify({
+          type: "runtime_start",
+          request_id: "identical-runtime-start-id",
+          create_agent: {
+            body: {
+              name,
+              model: "anthropic/claude-sonnet-4-6",
+            } as AgentCreateBody,
+            pin_global: false,
+          },
+          create_conversation: { body: { summary: `${name} conversation` } },
+          recover_approvals: false,
+        });
+      clientA.send(runtimeStart("Client A"));
+      clientB.send(runtimeStart("Client B"));
+      const [responseA, responseB] = await Promise.all([startA, startB]);
+      const runtimeA = responseA.runtime as {
+        agent_id: string;
+        conversation_id: string;
+      };
+      const runtimeB = responseB.runtime as {
+        agent_id: string;
+        conversation_id: string;
+      };
+      expect(runtimeA.agent_id).not.toBe(runtimeB.agent_id);
+      expect(responseA.agent).toMatchObject({ name: "Client A" });
+      expect(responseB.agent).toMatchObject({ name: "Client B" });
+      expect(
+        seenA.filter(
+          (message) =>
+            message.type === "runtime_start_response" &&
+            message.request_id === "identical-runtime-start-id",
+        ),
+      ).toHaveLength(1);
+      expect(
+        seenB.filter(
+          (message) =>
+            message.type === "runtime_start_response" &&
+            message.request_id === "identical-runtime-start-id",
+        ),
+      ).toHaveLength(1);
+
+      seenA.length = 0;
+      seenB.length = 0;
+      const waitForTurn = (socket: WebSocket, runtime: typeof runtimeA) =>
+        waitForJsonMessage(socket, (message) => {
+          const scope = message.runtime as typeof runtime | undefined;
+          const delta = message.delta as { message_type?: unknown } | undefined;
+          return (
+            message.type === "stream_delta" &&
+            scope?.agent_id === runtime.agent_id &&
+            scope?.conversation_id === runtime.conversation_id &&
+            delta?.message_type === "stop_reason"
+          );
+        });
+      const inputFor = (runtime: typeof runtimeA) =>
+        JSON.stringify({
+          type: "input",
+          runtime,
+          payload: {
+            kind: "create_message",
+            messages: [{ role: "user", content: "concurrent ping" }],
+          },
+        });
+      const concurrentA = waitForTurn(clientA, runtimeA);
+      const concurrentB = waitForTurn(clientB, runtimeB);
+      clientA.send(inputFor(runtimeA));
+      clientB.send(inputFor(runtimeB));
+      await Promise.all([concurrentA, concurrentB]);
+      expect(
+        seenA.some(
+          (message) =>
+            (message.runtime as { agent_id?: unknown } | undefined)
+              ?.agent_id === runtimeB.agent_id,
+        ),
+      ).toBe(false);
+      expect(
+        seenB.some(
+          (message) =>
+            (message.runtime as { agent_id?: unknown } | undefined)
+              ?.agent_id === runtimeA.agent_id,
+        ),
+      ).toBe(false);
+
+      const turnFinished = waitForJsonMessage(clientA, (message) => {
+        const runtime = message.runtime as
+          | { agent_id?: unknown; conversation_id?: unknown }
+          | undefined;
+        const delta = message.delta as { message_type?: unknown } | undefined;
+        return (
+          message.type === "stream_delta" &&
+          runtime?.agent_id === runtimeA.agent_id &&
+          runtime?.conversation_id === runtimeA.conversation_id &&
+          delta?.message_type === "stop_reason"
+        );
+      });
+      const managementResponse = waitForJsonMessage(
+        clientB,
+        (message) =>
+          message.type === "app_server_info_response" &&
+          message.request_id === "management-during-turn",
+      );
+      clientA.send(
+        JSON.stringify({
+          type: "input",
+          runtime: runtimeA,
+          payload: {
+            kind: "create_message",
+            messages: [{ role: "user", content: "ping" }],
+          },
+        }),
+      );
+      clientB.send(
+        JSON.stringify({
+          type: "app_server_info",
+          request_id: "management-during-turn",
+        }),
+      );
+      await Promise.all([turnFinished, managementResponse]);
+      expect(
+        seenB.some((message) => {
+          const runtime = message.runtime as { agent_id?: unknown } | undefined;
+          return runtime?.agent_id === runtimeA.agent_id;
+        }),
+      ).toBe(false);
+
+      const subscribeB = waitForJsonMessage(
+        clientB,
+        (message) =>
+          message.type === "runtime_start_response" &&
+          message.request_id === "subscribe-existing-runtime",
+      );
+      clientB.send(
+        JSON.stringify({
+          type: "runtime_start",
+          request_id: "subscribe-existing-runtime",
+          agent_id: runtimeA.agent_id,
+          conversation_id: runtimeA.conversation_id,
+          recover_approvals: false,
+        }),
+      );
+      await subscribeB;
+
+      const statusForA = waitForJsonMessage(
+        clientA,
+        (message) =>
+          message.type === "update_loop_status" &&
+          (message.runtime as { agent_id?: unknown } | undefined)?.agent_id ===
+            runtimeA.agent_id,
+      );
+      const statusForB = waitForJsonMessage(
+        clientB,
+        (message) =>
+          message.type === "update_loop_status" &&
+          (message.runtime as { agent_id?: unknown } | undefined)?.agent_id ===
+            runtimeA.agent_id,
+      );
+      const syncResponse = waitForJsonMessage(
+        clientA,
+        (message) =>
+          message.type === "sync_response" &&
+          message.request_id === "identical-direct-id",
+      );
+      const infoResponse = waitForJsonMessage(
+        clientB,
+        (message) =>
+          message.type === "app_server_info_response" &&
+          message.request_id === "identical-direct-id",
+      );
+      clientA.send(
+        JSON.stringify({
+          type: "sync",
+          request_id: "identical-direct-id",
+          runtime: runtimeA,
+          recover_approvals: false,
+          force_device_status: true,
+        }),
+      );
+      clientB.send(
+        JSON.stringify({
+          type: "app_server_info",
+          request_id: "identical-direct-id",
+        }),
+      );
+      await Promise.all([statusForA, statusForB, syncResponse, infoResponse]);
+      expect(
+        seenA.some(
+          (message) =>
+            message.type === "app_server_info_response" &&
+            message.request_id === "identical-direct-id",
+        ),
+      ).toBe(false);
+      expect(
+        seenB.some(
+          (message) =>
+            message.type === "sync_response" &&
+            message.request_id === "identical-direct-id",
+        ),
+      ).toBe(false);
+
+      expect(getActiveRuntime()?.processServicesStarted).toBe(true);
+      expect(getActiveRuntime()?.connections.size).toBe(2);
+      terminateClient(clientB);
+      await waitForClientClose(clientB);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(getActiveRuntime()?.connections.size).toBe(1);
+
+      const afterDisconnect = waitForJsonMessage(
+        clientA,
+        (message) =>
+          message.type === "app_server_info_response" &&
+          message.request_id === "client-a-survives",
+      );
+      clientA.send(
+        JSON.stringify({
+          type: "app_server_info",
+          request_id: "client-a-survives",
+        }),
+      );
+      await afterDisconnect;
+    } finally {
+      closeClient(clientA);
+      closeClient(clientB);
+      await handle?.close();
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  test("starts a runtime and emits state frames over the same socket", async () => {
+    const storageDir = await mkdtemp(join(os.tmpdir(), "letta-app-server-"));
+    let handle: AppServerHandle | null = null;
+    let control: WebSocket | null = null;
+    try {
+      __testSetBackend(
+        new LocalBackend({ storageDir, executionMode: "deterministic" }),
+      );
+      handle = await startAppServer({ listen: "ws://127.0.0.1:0" });
       control = new WebSocket(handle.controlUrl);
-      await Promise.all([waitForOpen(stream), waitForOpen(control)]);
+      await waitForOpen(control);
 
       control.send(
         JSON.stringify({
@@ -620,13 +965,13 @@ describe("app-server native websocket", () => {
       };
 
       await waitForJsonMessage(
-        stream,
+        control,
         (message) =>
           message.type === "update_device_status" &&
           JSON.stringify(message.runtime) === JSON.stringify(runtime),
       );
 
-      const loopStatus = await waitForJsonMessage(stream, (message) => {
+      const loopStatus = await waitForJsonMessage(control, (message) => {
         const loopStatus = message.loop_status as
           | { status?: unknown }
           | undefined;
@@ -644,7 +989,6 @@ describe("app-server native websocket", () => {
       });
     } finally {
       closeClient(control);
-      closeClient(stream);
       await handle?.close();
       await rm(storageDir, { recursive: true, force: true });
     }

--- a/src/websocket/app-server.ts
+++ b/src/websocket/app-server.ts
@@ -29,25 +29,18 @@ import {
   getActiveRuntime,
   setActiveRuntime,
 } from "@/websocket/listener/runtime";
-import type { ListenerRuntime } from "@/websocket/listener/types";
 
 const DEFAULT_LISTEN_URL = "ws://127.0.0.1:0";
 const DEFAULT_WS_PATH = "/ws";
-const PENDING_STREAM_TIMEOUT_MS = 5000;
 // App-server liveness watchdog. Here letta-code is the WS *server* (the client
 // is the Desktop/relay), so we use protocol-level ws.ping()/pong rather than
 // the app-level ping/pong the outbound listener uses. Ping every 30s and reap
 // any client that has not ponged within 90s (3 missed pings). A half-open
 // client connection (Desktop sleep, network switch, NAT idle timeout) never
-// emits a `close` event, which would otherwise wedge the single-occupancy
-// control channel: new control connections are rejected with 1008 while the
-// zombie session still holds `activeSession`. Terminating the dead socket
-// fires its `close` handler, clears `activeSession`, and frees the channel for
-// a reconnecting client.
+// emits a `close` event. Terminating the dead socket fires its connection-
+// scoped cleanup without disturbing healthy peers.
 const APP_SERVER_HEARTBEAT_INTERVAL_MS = 30000;
 const APP_SERVER_PONG_TIMEOUT_MS = 90000;
-
-type AppServerChannel = "control" | "stream";
 
 export interface StartAppServerOptions {
   listen?: string;
@@ -61,6 +54,8 @@ export interface StartAppServerOptions {
   heartbeatIntervalMs?: number;
   /** @internal Test override for the pong timeout before a socket is reaped (ms). */
   pongTimeoutMs?: number;
+  /** @internal Test hook for simulating one half-open client. */
+  shouldRecordPong?: (connectionId: string) => boolean;
 }
 
 export interface AppServerListeningInfo {
@@ -79,12 +74,6 @@ export interface ParsedAppServerListenUrl {
   path: string;
 }
 
-type ActiveAppServerSession = {
-  runtime: ListenerRuntime;
-  controlSocket: WebSocket;
-  streamSocket: WebSocket | null;
-};
-
 function getRequiredAddressInfo(server: Server): AddressInfo {
   const address = server.address();
   if (!address || typeof address === "string") {
@@ -93,14 +82,15 @@ function getRequiredAddressInfo(server: Server): AddressInfo {
   return address;
 }
 
-function getChannelUrl(
-  baseUrl: string,
-  path: string,
-  channel: AppServerChannel,
-): string {
+function getWebSocketUrl(baseUrl: string, path: string): string {
   const url = new URL(baseUrl);
   url.pathname = path;
-  url.searchParams.set("channel", channel);
+  return url.toString();
+}
+
+function getLegacyStreamUrl(baseUrl: string, path: string): string {
+  const url = new URL(getWebSocketUrl(baseUrl, path));
+  url.searchParams.set("channel", "stream");
   return url.toString();
 }
 
@@ -137,42 +127,6 @@ function getRequestUrl(request: IncomingMessage, host: string): URL {
   return new URL(request.url ?? "/", `http://${request.headers.host ?? host}`);
 }
 
-function getRequestChannel(url: URL): AppServerChannel | null {
-  const channel = url.searchParams.get("channel");
-  if (channel === null || channel === "" || channel === "control") {
-    return "control";
-  }
-  if (channel === "stream") {
-    return "stream";
-  }
-  return null;
-}
-
-function attachStreamSocket(
-  activeSession: ActiveAppServerSession,
-  socket: WebSocket,
-): void {
-  if (activeSession.streamSocket) {
-    closeSocket(socket, 1008, "stream channel already connected");
-    return;
-  }
-  activeSession.streamSocket = socket;
-  activeSession.runtime.streamSocket = socket;
-  activeSession.runtime.streamTransport = socket;
-  socket.on("close", () => {
-    if (activeSession.streamSocket === socket) {
-      activeSession.streamSocket = null;
-    }
-    if (activeSession.runtime.streamSocket === socket) {
-      activeSession.runtime.streamSocket = null;
-      activeSession.runtime.streamTransport = null;
-      // The stream channel cannot replay or reconnect independently. Tear down
-      // control so the client re-establishes one coherent paired session.
-      terminateSocket(activeSession.controlSocket);
-    }
-  });
-}
-
 export function parseAppServerListenUrl(
   listen: string = DEFAULT_LISTEN_URL,
 ): ParsedAppServerListenUrl {
@@ -201,64 +155,6 @@ export function parseAppServerListenUrl(
   return { host: normalizeListenHost(url.hostname), port, path };
 }
 
-async function startControlSession(params: {
-  socket: WebSocket;
-  streamSocket: WebSocket | null;
-  connectionName: string;
-  serverUrl: string;
-  onSessionCreated: (session: ActiveAppServerSession) => void;
-  onSessionClosed: () => void;
-}): Promise<ActiveAppServerSession> {
-  const existingRuntime = getActiveRuntime();
-  if (existingRuntime) {
-    stopRuntime(existingRuntime, true);
-    setActiveRuntime(null);
-  }
-
-  const runtime = createRuntime();
-  runtime.onWsEvent = undefined;
-  runtime.connectionId = `app-server-${crypto.randomUUID()}`;
-  runtime.connectionName = params.connectionName;
-  setActiveRuntime(runtime);
-  telemetry.setSurface(getListenerTelemetrySurface());
-  telemetry.init();
-
-  const startupReady = (async () => {
-    await reloadListenerModAdapter(runtime);
-    await loadTools();
-  })();
-
-  const activeSession: ActiveAppServerSession = {
-    runtime,
-    controlSocket: params.socket,
-    streamSocket: params.streamSocket,
-  };
-  params.onSessionCreated(activeSession);
-
-  await attachOpenListenerSocket(
-    runtime,
-    params.socket,
-    {
-      connectionId: runtime.connectionId ?? "app-server",
-      wsUrl: params.serverUrl,
-      supportsSplitStatusChannels: true,
-      deviceId: settingsManager.getOrCreateDeviceId(),
-      connectionName: params.connectionName,
-      onConnected: () => {},
-      onDisconnected: params.onSessionClosed,
-      onError: () => {},
-    },
-    {
-      streamSocket: params.streamSocket,
-      startHeartbeat: false,
-      startCronScheduler: true,
-      startupReady,
-    },
-  );
-
-  return activeSession;
-}
-
 export async function startAppServer(
   options: StartAppServerOptions = {},
 ): Promise<AppServerHandle> {
@@ -272,88 +168,71 @@ export async function startAppServer(
     );
   }
   const wss = new WebSocketServer({ noServer: true });
-  let activeSession: ActiveAppServerSession | null = null;
-  let pendingStreamSocket: WebSocket | null = null;
-  let pendingStreamTimeout: ReturnType<typeof setTimeout> | null = null;
   let resolvedInfo: AppServerListeningInfo | null = null;
+  let nextConnectionOrdinal = 0;
+  const existingRuntime = getActiveRuntime();
+  if (existingRuntime) {
+    stopRuntime(existingRuntime, true);
+    setActiveRuntime(null);
+  }
+  const runtime = createRuntime();
+  runtime.onWsEvent = undefined;
+  runtime.connectionId = "app-server";
+  runtime.connectionName = options.connectionName ?? hostname();
+  setActiveRuntime(runtime);
+  telemetry.setSurface(getListenerTelemetrySurface());
+  telemetry.init();
+  let startupReady: Promise<void> | null = null;
+  const getStartupReady = (): Promise<void> => {
+    startupReady ??= (async () => {
+      await reloadListenerModAdapter(runtime);
+      await loadTools();
+    })();
+    return startupReady;
+  };
   // Tracks the last time each connected client responded to a ping. Seeded on
   // connection so a freshly-accepted socket gets a full grace window before the
   // watchdog can reap it. WeakMap so entries are GC'd with their sockets.
   const lastPongAtBySocket = new WeakMap<WebSocket, number>();
 
-  const clearPendingStream = (): WebSocket | null => {
-    if (pendingStreamTimeout) {
-      clearTimeout(pendingStreamTimeout);
-      pendingStreamTimeout = null;
-    }
-    const socket = pendingStreamSocket;
-    pendingStreamSocket = null;
-    return socket;
-  };
-
-  const handleWebSocketConnection = (
-    socket: WebSocket,
-    channel: AppServerChannel,
-  ): void => {
-    // Liveness tracking for the heartbeat watchdog. Applies to both control
-    // and stream sockets. The `ws` library auto-replies to ping frames with a
-    // pong, so any client whose TCP is still alive refreshes this timestamp.
+  const handleWebSocketConnection = (socket: WebSocket): void => {
+    const connectionId = `app-server-${nextConnectionOrdinal}`;
+    nextConnectionOrdinal += 1;
+    // The `ws` library auto-replies to ping frames with a pong, so any client
+    // whose TCP is still alive refreshes this connection-scoped timestamp.
     lastPongAtBySocket.set(socket, Date.now());
     socket.on("pong", () => {
-      lastPongAtBySocket.set(socket, Date.now());
+      if (options.shouldRecordPong?.(connectionId) !== false) {
+        lastPongAtBySocket.set(socket, Date.now());
+      }
     });
 
-    if (channel === "stream") {
-      if (activeSession) {
-        attachStreamSocket(activeSession, socket);
-        return;
-      }
-      if (pendingStreamSocket) {
-        closeSocket(socket, 1008, "stream channel already pending");
-        return;
-      }
-      pendingStreamSocket = socket;
-      pendingStreamTimeout = setTimeout(() => {
-        const staleSocket = clearPendingStream();
-        closeSocket(staleSocket, 1008, "control channel did not connect");
-      }, PENDING_STREAM_TIMEOUT_MS);
-      socket.on("close", () => {
-        if (pendingStreamSocket === socket) {
-          clearPendingStream();
-        }
-      });
-      socket.on("error", (error) => {
-        options.onLog?.(`App-server stream socket error: ${error.message}`);
-      });
-      return;
-    }
-
-    if (activeSession) {
-      closeSocket(socket, 1008, "control channel already connected");
-      return;
-    }
-
-    const streamSocket = clearPendingStream();
-    void startControlSession({
+    void attachOpenListenerSocket(
+      runtime,
       socket,
-      streamSocket,
-      connectionName: options.connectionName ?? hostname(),
-      serverUrl: resolvedInfo?.url ?? options.listen ?? DEFAULT_LISTEN_URL,
-      onSessionCreated: (session) => {
-        activeSession = session;
+      {
+        connectionId,
+        wsUrl: resolvedInfo?.url ?? options.listen ?? DEFAULT_LISTEN_URL,
+        deviceId: settingsManager.getOrCreateDeviceId(),
+        connectionName: options.connectionName ?? hostname(),
+        onConnected: () => {},
+        onDisconnected: () => {},
+        onError: (error) => {
+          options.onLog?.(
+            `App-server connection ${connectionId} failed: ${error.message}`,
+          );
+        },
       },
-      onSessionClosed: () => {
-        activeSession = null;
+      {
+        startHeartbeat: false,
+        startCronScheduler: true,
+        startupReady: getStartupReady(),
       },
-    }).catch((error) => {
-      if (activeSession?.controlSocket === socket) {
-        activeSession = null;
-      }
+    ).catch((error) => {
       options.onLog?.(
-        `Failed to start app-server session: ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to start app-server connection: ${error instanceof Error ? error.message : String(error)}`,
       );
-      closeSocket(socket, 1011, "failed to start session");
-      closeSocket(streamSocket, 1011, "failed to start session");
+      closeSocket(socket, 1011, "failed to start connection");
     });
   };
 
@@ -411,9 +290,11 @@ export async function startAppServer(
       return;
     }
 
-    const channel = getRequestChannel(requestUrl);
-    if (!channel) {
-      rejectUpgrade(socket, 400, "Bad Request");
+    if (requestUrl.searchParams.has("channel")) {
+      options.onLog?.(
+        "Rejecting legacy split-channel app-server client; upgrade to a one-socket client",
+      );
+      rejectUpgrade(socket, 426, "Upgrade Required");
       return;
     }
 
@@ -439,7 +320,7 @@ export async function startAppServer(
     }
 
     wss.handleUpgrade(request, socket, head, (websocket) => {
-      handleWebSocketConnection(websocket, channel);
+      handleWebSocketConnection(websocket);
     });
   });
 
@@ -489,8 +370,8 @@ export async function startAppServer(
   const baseUrl = `ws://${listen.host}:${address.port}`;
   resolvedInfo = {
     url: baseUrl,
-    controlUrl: getChannelUrl(baseUrl, listen.path, "control"),
-    streamUrl: getChannelUrl(baseUrl, listen.path, "stream"),
+    controlUrl: getWebSocketUrl(baseUrl, listen.path),
+    streamUrl: getLegacyStreamUrl(baseUrl, listen.path),
   };
   options.onListening?.(resolvedInfo);
 
@@ -501,20 +382,12 @@ export async function startAppServer(
       if (options.openaiApi) {
         closeOpenAiBridgeRuntime();
       }
-      const streamSocket = clearPendingStream();
-      terminateSocket(streamSocket);
-      if (activeSession) {
-        const session = activeSession;
-        activeSession = null;
-        terminateSocket(session.streamSocket);
-        terminateSocket(session.controlSocket);
-        stopRuntime(session.runtime, true);
-        if (getActiveRuntime() === session.runtime) {
-          setActiveRuntime(null);
-        }
-      }
       for (const client of wss.clients) {
         terminateSocket(client);
+      }
+      stopRuntime(runtime, true);
+      if (getActiveRuntime() === runtime) {
+        setActiveRuntime(null);
       }
       await new Promise<void>((resolve, reject) => {
         wss.close();

--- a/src/websocket/app-server.ts
+++ b/src/websocket/app-server.ts
@@ -29,6 +29,7 @@ import {
   getActiveRuntime,
   setActiveRuntime,
 } from "@/websocket/listener/runtime";
+import type { ListenerRuntime } from "@/websocket/listener/types";
 
 const DEFAULT_LISTEN_URL = "ws://127.0.0.1:0";
 const DEFAULT_WS_PATH = "/ws";
@@ -56,6 +57,8 @@ export interface StartAppServerOptions {
   pongTimeoutMs?: number;
   /** @internal Test hook for simulating one half-open client. */
   shouldRecordPong?: (connectionId: string) => boolean;
+  /** @internal Test override for listener runtime initialization. */
+  initializeRuntime?: (runtime: ListenerRuntime) => Promise<void>;
 }
 
 export interface AppServerListeningInfo {
@@ -163,24 +166,29 @@ export async function startAppServer(
   const wss = new WebSocketServer({ noServer: true });
   let resolvedInfo: AppServerListeningInfo | null = null;
   let nextConnectionOrdinal = 0;
-  const existingRuntime = getActiveRuntime();
-  if (existingRuntime) {
-    stopRuntime(existingRuntime, true);
-    setActiveRuntime(null);
-  }
   const runtime = createRuntime();
   runtime.onWsEvent = undefined;
   runtime.connectionId = "app-server";
   runtime.connectionName = options.connectionName ?? hostname();
-  setActiveRuntime(runtime);
-  telemetry.setSurface(getListenerTelemetrySurface());
-  telemetry.init();
   let startupReady: Promise<void> | null = null;
   const getStartupReady = (): Promise<void> => {
-    startupReady ??= (async () => {
+    if (startupReady) {
+      return startupReady;
+    }
+    const attempt = (async () => {
+      if (options.initializeRuntime) {
+        await options.initializeRuntime(runtime);
+        return;
+      }
       await reloadListenerModAdapter(runtime);
       await loadTools();
     })();
+    startupReady = attempt;
+    void attempt.catch(() => {
+      if (startupReady === attempt) {
+        startupReady = null;
+      }
+    });
     return startupReady;
   };
   // Tracks the last time each connected client responded to a ping. Seeded on
@@ -345,19 +353,34 @@ export async function startAppServer(
     clearInterval(heartbeatInterval);
   });
 
-  await new Promise<void>((resolve, reject) => {
-    const onError = (error: Error) => {
-      server.off("listening", onListening);
-      reject(error);
-    };
-    const onListening = () => {
-      server.off("error", onError);
-      resolve();
-    };
-    server.once("error", onError);
-    server.once("listening", onListening);
-    server.listen(listen.port, listen.host);
-  });
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const onError = (error: Error) => {
+        server.off("listening", onListening);
+        reject(error);
+      };
+      const onListening = () => {
+        server.off("error", onError);
+        resolve();
+      };
+      server.once("error", onError);
+      server.once("listening", onListening);
+      server.listen(listen.port, listen.host);
+    });
+  } catch (error) {
+    clearInterval(heartbeatInterval);
+    runtime.intentionallyClosed = true;
+    throw error;
+  }
+
+  const existingRuntime = getActiveRuntime();
+  if (existingRuntime) {
+    stopRuntime(existingRuntime, true);
+    setActiveRuntime(null);
+  }
+  setActiveRuntime(runtime);
+  telemetry.setSurface(getListenerTelemetrySurface());
+  telemetry.init();
 
   const address = getRequiredAddressInfo(server);
   const baseUrl = `ws://${listen.host}:${address.port}`;
@@ -377,8 +400,8 @@ export async function startAppServer(
       for (const client of wss.clients) {
         terminateSocket(client);
       }
-      stopRuntime(runtime, true);
       if (getActiveRuntime() === runtime) {
+        stopRuntime(runtime, true);
         setActiveRuntime(null);
       }
       await new Promise<void>((resolve, reject) => {

--- a/src/websocket/app-server.ts
+++ b/src/websocket/app-server.ts
@@ -61,7 +61,6 @@ export interface StartAppServerOptions {
 export interface AppServerListeningInfo {
   url: string;
   controlUrl: string;
-  streamUrl: string;
 }
 
 export interface AppServerHandle extends AppServerListeningInfo {
@@ -85,12 +84,6 @@ function getRequiredAddressInfo(server: Server): AddressInfo {
 function getWebSocketUrl(baseUrl: string, path: string): string {
   const url = new URL(baseUrl);
   url.pathname = path;
-  return url.toString();
-}
-
-function getLegacyStreamUrl(baseUrl: string, path: string): string {
-  const url = new URL(getWebSocketUrl(baseUrl, path));
-  url.searchParams.set("channel", "stream");
   return url.toString();
 }
 
@@ -371,7 +364,6 @@ export async function startAppServer(
   resolvedInfo = {
     url: baseUrl,
     controlUrl: getWebSocketUrl(baseUrl, listen.path),
-    streamUrl: getLegacyStreamUrl(baseUrl, listen.path),
   };
   options.onListening?.(resolvedInfo);
 

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -757,13 +757,13 @@ describe("listen-client parseServerMessage", () => {
           conversation: { id: conversation.id },
           created: { agent: false, conversation: false },
         });
-
         const prepared = await prepareToolExecutionContextForModel(
           "anthropic/claude-sonnet-4",
           {
             clientToolAllowlist: ["RemoteLookup"],
             externalToolScopeIds: ["scope-1"],
             runtimeContext: {
+              connectionId: "test-connection",
               agentId: agent.id,
               conversationId: conversation.id,
             },

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -5397,7 +5397,6 @@ describe("listen-client capability-gated approval flow", () => {
       requestTestApproval(runtime, socket, turnLease, "perm-late-after-abort"),
     ).rejects.toThrow("Cancelled by user");
     expect(runtime.pendingApprovalResolvers.size).toBe(0);
-    expect(runtime.listener.approvalRuntimeKeyByRequestId.size).toBe(0);
 
     __listenClientTestUtils.setActiveRuntime(null);
   });

--- a/src/websocket/listen-client-protocol.test.ts
+++ b/src/websocket/listen-client-protocol.test.ts
@@ -4049,7 +4049,6 @@ describe("listen-client v2 status builders", () => {
   });
 
   test("buildDeviceStatus includes only active bash and task background processes", () => {
-    const runtime = __listenClientTestUtils.createRuntime();
     backgroundProcesses.clear();
     backgroundTasks.clear();
 
@@ -4083,7 +4082,7 @@ describe("listen-client v2 status builders", () => {
         outputFile: "/tmp/task_2.log",
       });
 
-      const deviceStatus = __listenClientTestUtils.buildDeviceStatus(runtime);
+      const deviceStatus = __listenClientTestUtils.buildDeviceStatus(null);
       expect(deviceStatus.background_processes).toEqual([
         {
           process_id: "task_1",

--- a/src/websocket/listen-interrupt-queue.test.ts
+++ b/src/websocket/listen-interrupt-queue.test.ts
@@ -137,6 +137,8 @@ describe("pendingApprovalBatchByToolCallId survives rejectPendingApprovalResolve
     const runtime = createRuntime();
     runtime.pendingApprovalBatchByToolCallId.set("call-1", "batch-1");
     runtime.pendingApprovalResolvers.set("perm-1", {
+      requestId: "perm-1",
+      connectionIds: new Set(["legacy"]),
       resolve: () => {},
       reject: () => {},
     });

--- a/src/websocket/listen-recovery.test.ts
+++ b/src/websocket/listen-recovery.test.ts
@@ -271,7 +271,6 @@ describe("channel control request recovery", () => {
         },
       },
     });
-    listener.approvalRuntimeKeyByRequestId.set(requestKey, runtime.key);
     let backendRecoveryCalls = 0;
 
     await recoverPendingChannelControlRequests(listener, {

--- a/src/websocket/listen-recovery.test.ts
+++ b/src/websocket/listen-recovery.test.ts
@@ -19,6 +19,8 @@ import type {
   ChannelControlRequestEvent,
 } from "@/channels/types";
 import { __listenClientTestUtils } from "@/websocket/listen-client";
+import { createConnectionRequestKey } from "@/websocket/listener/connection";
+import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
 import type { ConversationRuntime } from "@/websocket/listener/types";
 
 const {
@@ -235,6 +237,54 @@ describe("resolvePendingApprovalBatchId original behavior preserved", () => {
 });
 
 describe("channel control request recovery", () => {
+  test("recognizes a live pending approval stored under a composite key", async () => {
+    const replies: Array<{
+      chatId: string;
+      text: string;
+      replyToMessageId?: string;
+    }> = [];
+    const event = createPendingControlRequestEvent();
+    __testOverrideLoadPendingControlRequestStore(() => ({
+      requests: [event],
+    }));
+
+    const registry = new ChannelRegistry();
+    registry.registerAdapter(createAdapter(replies));
+    const listener = createListenerRuntime();
+    const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
+    const requestKey = createConnectionRequestKey("client-a", event.requestId);
+    runtime.pendingApprovalResolvers.set(requestKey, {
+      requestId: event.requestId,
+      connectionIds: new Set(["client-a"]),
+      resolve: () => {},
+      reject: () => {},
+      controlRequest: {
+        type: "control_request",
+        request_id: event.requestId,
+        request: {
+          subtype: "can_use_tool",
+          tool_name: event.toolName,
+          input: event.input,
+          tool_call_id: "tool-call-1",
+          permission_suggestions: [],
+          blocked_path: null,
+        },
+      },
+    });
+    listener.approvalRuntimeKeyByRequestId.set(requestKey, runtime.key);
+    let backendRecoveryCalls = 0;
+
+    await recoverPendingChannelControlRequests(listener, {
+      recoverApprovalStateForSync: async () => {
+        backendRecoveryCalls += 1;
+      },
+    });
+
+    expect(backendRecoveryCalls).toBe(0);
+    expect(replies).toHaveLength(1);
+    expect(registry.hasPendingControlRequest(event.requestId)).toBe(true);
+  });
+
   test("redelivers persisted channel prompts that are still pending after boot", async () => {
     const replies: Array<{
       chatId: string;

--- a/src/websocket/listener/approval.test.ts
+++ b/src/websocket/listener/approval.test.ts
@@ -7,12 +7,12 @@ import {
   resolvePendingApprovalResolver,
 } from "./approval";
 import {
-  createConnectionRequestKey,
   markListenerConnectionInitialized,
   openListenerConnection,
   subscribeListenerConnection,
 } from "./connection";
 import { cleanupListenerConnection } from "./connection-lifecycle";
+import { handleApprovalResponseInput } from "./control-inputs";
 import { getOrCreateScopedRuntime } from "./conversation-runtime";
 import { createRuntime, stopRuntime } from "./lifecycle";
 import { buildLoopStatus } from "./protocol-outbound";
@@ -153,6 +153,80 @@ describe("listener approval lifecycle", () => {
     );
   });
 
+  test("isolates identical approval ids across two conversations on one connection", async () => {
+    const listener = createRuntime();
+    const runtimeA = getOrCreateScopedRuntime(listener, "agent-1", "conv-a");
+    const runtimeB = getOrCreateScopedRuntime(listener, "agent-1", "conv-b");
+    const socket = new MockSocket();
+    openListenerConnection({
+      runtime: listener,
+      connectionId: "shared-client",
+      writer: socket,
+      options: {
+        connectionId: "shared-client",
+        wsUrl: "local://test",
+        deviceId: "test",
+        connectionName: "shared-client",
+        onConnected: () => {},
+        onDisconnected: () => {},
+        onError: () => {},
+      },
+    });
+    markListenerConnectionInitialized(listener, "shared-client");
+    subscribeListenerConnection(listener, "shared-client", {
+      agent_id: "agent-1",
+      conversation_id: "conv-a",
+    });
+    subscribeListenerConnection(listener, "shared-client", {
+      agent_id: "agent-1",
+      conversation_id: "conv-b",
+    });
+
+    const pendingA = requestApprovalOverWS(
+      runtimeA,
+      socket,
+      beginApprovalWait(runtimeA),
+      "same-request-id",
+      makeControlRequest("same-request-id"),
+    );
+    const pendingB = requestApprovalOverWS(
+      runtimeB,
+      socket,
+      beginApprovalWait(runtimeB),
+      "same-request-id",
+      makeControlRequest("same-request-id"),
+    );
+
+    expect(
+      await handleApprovalResponseInput(listener, {
+        runtime: { agent_id: "agent-1", conversation_id: "conv-b" },
+        response: makeSuccessResponse("same-request-id"),
+        connectionId: "shared-client",
+        socket,
+        opts: { connectionId: "shared-client" },
+        processQueuedTurn: async () => {},
+      }),
+    ).toBe(true);
+    await expect(pendingB).resolves.toEqual(
+      makeSuccessResponse("same-request-id"),
+    );
+    expect(runtimeA.pendingApprovalResolvers.size).toBe(1);
+
+    expect(
+      await handleApprovalResponseInput(listener, {
+        runtime: { agent_id: "agent-1", conversation_id: "conv-a" },
+        response: makeSuccessResponse("same-request-id"),
+        connectionId: "shared-client",
+        socket,
+        opts: { connectionId: "shared-client" },
+        processQueuedTurn: async () => {},
+      }),
+    ).toBe(true);
+    await expect(pendingA).resolves.toEqual(
+      makeSuccessResponse("same-request-id"),
+    );
+  });
+
   test("fans approval requests to subscribers and survives one disconnect", async () => {
     const listener = createRuntime();
     const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
@@ -256,16 +330,6 @@ describe("listener approval lifecycle", () => {
       makeControlRequest("perm-b"),
     );
 
-    expect(
-      listener.approvalRuntimeKeyByRequestId.get(
-        createConnectionRequestKey("legacy", "perm-a"),
-      ),
-    ).toBe(runtimeA.key);
-    expect(
-      listener.approvalRuntimeKeyByRequestId.get(
-        createConnectionRequestKey("legacy", "perm-b"),
-      ),
-    ).toBe(runtimeB.key);
     expect(
       resolvePendingApprovalResolver(runtimeA, makeSuccessResponse("perm-a")),
     ).toBe(true);
@@ -416,6 +480,5 @@ describe("listener approval lifecycle", () => {
 
     await expect(pending).rejects.toThrow("Cancelled by user");
     expect(runtime.pendingApprovalResolvers.size).toBe(0);
-    expect(runtime.listener.approvalRuntimeKeyByRequestId.size).toBe(0);
   });
 });

--- a/src/websocket/listener/approval.test.ts
+++ b/src/websocket/listener/approval.test.ts
@@ -6,6 +6,11 @@ import {
   requestApprovalOverWS,
   resolvePendingApprovalResolver,
 } from "./approval";
+import {
+  createConnectionRequestKey,
+  markListenerConnectionInitialized,
+  openListenerConnection,
+} from "./connection";
 import { getOrCreateScopedRuntime } from "./conversation-runtime";
 import { createRuntime, stopRuntime } from "./lifecycle";
 import { buildLoopStatus } from "./protocol-outbound";
@@ -80,6 +85,72 @@ function makeSuccessResponse(requestId: string): ApprovalResponseBody {
 }
 
 describe("listener approval lifecycle", () => {
+  test("isolates identical approval request ids by connection", async () => {
+    const listener = createRuntime();
+    const runtimeA = getOrCreateScopedRuntime(listener, "agent-1", "conv-a");
+    const runtimeB = getOrCreateScopedRuntime(listener, "agent-1", "conv-b");
+    const socketA = new MockSocket();
+    const socketB = new MockSocket();
+    for (const [connectionId, socket] of [
+      ["client-a", socketA],
+      ["client-b", socketB],
+    ] as const) {
+      openListenerConnection({
+        runtime: listener,
+        connectionId,
+        writer: socket,
+        options: {
+          connectionId,
+          wsUrl: "local://test",
+          deviceId: "test",
+          connectionName: connectionId,
+          onConnected: () => {},
+          onDisconnected: () => {},
+          onError: () => {},
+        },
+      });
+      markListenerConnectionInitialized(listener, connectionId);
+    }
+
+    const pendingA = requestApprovalOverWS(
+      runtimeA,
+      socketA,
+      beginApprovalWait(runtimeA),
+      "same-request-id",
+      makeControlRequest("same-request-id"),
+    );
+    const pendingB = requestApprovalOverWS(
+      runtimeB,
+      socketB,
+      beginApprovalWait(runtimeB),
+      "same-request-id",
+      makeControlRequest("same-request-id"),
+    );
+
+    expect(
+      resolvePendingApprovalResolver(
+        runtimeB,
+        makeSuccessResponse("same-request-id"),
+        "client-b",
+      ),
+    ).toBe(true);
+    await expect(pendingB).resolves.toEqual(
+      makeSuccessResponse("same-request-id"),
+    );
+    expect(runtimeA.pendingApprovalResolvers.size).toBe(1);
+
+    expect(
+      resolvePendingApprovalResolver(
+        runtimeA,
+        makeSuccessResponse("same-request-id"),
+        "client-a",
+      ),
+    ).toBe(true);
+    await expect(pendingA).resolves.toEqual(
+      makeSuccessResponse("same-request-id"),
+    );
+  });
+
   test("resolving an approval does not falsely finalize its enclosing turn", async () => {
     const runtime = createScopedRuntime();
     const socket = new MockSocket();
@@ -126,12 +197,16 @@ describe("listener approval lifecycle", () => {
       makeControlRequest("perm-b"),
     );
 
-    expect(listener.approvalRuntimeKeyByRequestId.get("perm-a")).toBe(
-      runtimeA.key,
-    );
-    expect(listener.approvalRuntimeKeyByRequestId.get("perm-b")).toBe(
-      runtimeB.key,
-    );
+    expect(
+      listener.approvalRuntimeKeyByRequestId.get(
+        createConnectionRequestKey("legacy", "perm-a"),
+      ),
+    ).toBe(runtimeA.key);
+    expect(
+      listener.approvalRuntimeKeyByRequestId.get(
+        createConnectionRequestKey("legacy", "perm-b"),
+      ),
+    ).toBe(runtimeB.key);
     expect(
       resolvePendingApprovalResolver(runtimeA, makeSuccessResponse("perm-a")),
     ).toBe(true);

--- a/src/websocket/listener/approval.test.ts
+++ b/src/websocket/listener/approval.test.ts
@@ -10,7 +10,9 @@ import {
   createConnectionRequestKey,
   markListenerConnectionInitialized,
   openListenerConnection,
+  subscribeListenerConnection,
 } from "./connection";
+import { cleanupListenerConnection } from "./connection-lifecycle";
 import { getOrCreateScopedRuntime } from "./conversation-runtime";
 import { createRuntime, stopRuntime } from "./lifecycle";
 import { buildLoopStatus } from "./protocol-outbound";
@@ -148,6 +150,63 @@ describe("listener approval lifecycle", () => {
     ).toBe(true);
     await expect(pendingA).resolves.toEqual(
       makeSuccessResponse("same-request-id"),
+    );
+  });
+
+  test("fans approval requests to subscribers and survives one disconnect", async () => {
+    const listener = createRuntime();
+    const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
+    const socketA = new MockSocket();
+    const socketB = new MockSocket();
+    const scope = { agent_id: "agent-1", conversation_id: "conv-1" };
+    for (const [connectionId, socket] of [
+      ["client-a", socketA],
+      ["client-b", socketB],
+    ] as const) {
+      openListenerConnection({
+        runtime: listener,
+        connectionId,
+        writer: socket,
+        options: {
+          connectionId,
+          wsUrl: "local://test",
+          deviceId: "test",
+          connectionName: connectionId,
+          onConnected: () => {},
+          onDisconnected: () => {},
+          onError: () => {},
+        },
+      });
+      markListenerConnectionInitialized(listener, connectionId);
+      subscribeListenerConnection(listener, connectionId, scope);
+    }
+
+    runtime.activeConnectionId = "client-a";
+    const pending = requestApprovalOverWS(
+      runtime,
+      socketA,
+      beginApprovalWait(runtime),
+      "shared-approval",
+      makeControlRequest("shared-approval"),
+    );
+
+    expect(socketA.sentPayloads).toHaveLength(1);
+    expect(socketB.sentPayloads).toHaveLength(1);
+    expect(runtime.pendingApprovalResolvers.size).toBe(2);
+
+    cleanupListenerConnection(listener, "client-a");
+
+    expect(runtime.turnLifecycle.currentLease?.signal.aborted).toBe(false);
+    expect(runtime.pendingApprovalResolvers.size).toBe(1);
+    expect(
+      resolvePendingApprovalResolver(
+        runtime,
+        makeSuccessResponse("shared-approval"),
+        "client-b",
+      ),
+    ).toBe(true);
+    await expect(pending).resolves.toEqual(
+      makeSuccessResponse("shared-approval"),
     );
   });
 

--- a/src/websocket/listener/approval.ts
+++ b/src/websocket/listener/approval.ts
@@ -33,7 +33,6 @@ function removePendingApproval(
   for (const [requestKey, candidate] of runtime.pendingApprovalResolvers) {
     if (candidate !== pending) continue;
     runtime.pendingApprovalResolvers.delete(requestKey);
-    runtime.listener.approvalRuntimeKeyByRequestId.delete(requestKey);
   }
   pending.connectionIds.clear();
 }
@@ -48,14 +47,12 @@ function addPendingApprovalConnection(
     pending.requestId,
   );
   runtime.pendingApprovalResolvers.delete(unownedKey);
-  runtime.listener.approvalRuntimeKeyByRequestId.delete(unownedKey);
   const requestKey = createConnectionRequestKey(
     connectionId,
     pending.requestId,
   );
   pending.connectionIds.add(connectionId);
   runtime.pendingApprovalResolvers.set(requestKey, pending);
-  runtime.listener.approvalRuntimeKeyByRequestId.set(requestKey, runtime.key);
 }
 
 function keepPendingApprovalUnowned(
@@ -67,7 +64,6 @@ function keepPendingApprovalUnowned(
     pending.requestId,
   );
   runtime.pendingApprovalResolvers.set(requestKey, pending);
-  runtime.listener.approvalRuntimeKeyByRequestId.set(requestKey, runtime.key);
 }
 
 export function hasPendingApprovalRequestId(
@@ -303,12 +299,6 @@ export function rejectPendingApprovalResolvers(
     pending.reject(new Error(reason));
   }
   runtime.pendingApprovalResolvers.clear();
-  for (const [requestId, runtimeKey] of runtime.listener
-    .approvalRuntimeKeyByRequestId) {
-    if (runtimeKey === runtime.key) {
-      runtime.listener.approvalRuntimeKeyByRequestId.delete(requestId);
-    }
-  }
   if (!runtime.isProcessing && !runtime.cancelRequested) {
     setCommandLoopStatus(runtime, "WAITING_ON_INPUT");
   }
@@ -337,7 +327,6 @@ export function rejectPendingApprovalResolversForConnection(
       pending.requestId,
     );
     runtime.pendingApprovalResolvers.delete(requestKey);
-    runtime.listener.approvalRuntimeKeyByRequestId.delete(requestKey);
     if (pending.connectionIds.size === 0) {
       // Codex keeps a thread-scoped server request alive when its last
       // subscriber disconnects and replays it to a later subscriber. The

--- a/src/websocket/listener/approval.ts
+++ b/src/websocket/listener/approval.ts
@@ -2,7 +2,10 @@ import type { ApprovalResult } from "@/agent/approval-execution";
 import type { ApprovalResponseBody, ControlRequest } from "@/types/protocol_v2";
 import {
   createConnectionRequestKey,
-  selectListenerController,
+  findListenerConnectionByTransport,
+  getSubscribedListenerConnections,
+  TO_SUBSCRIBERS,
+  toListenerConnection,
 } from "./connection";
 import {
   emitDeviceStatusIfOpen,
@@ -14,6 +17,75 @@ import { isListenerTransportOpen, type ListenerTransport } from "./transport";
 import type { TurnLease } from "./turn-lifecycle";
 import { setCommandLoopStatus, setTurnLoopStatus } from "./turn-status";
 import type { ConversationRuntime, ListenerConnectionId } from "./types";
+
+const UNOWNED_APPROVAL_CONNECTION_ID = "__unowned_approval__";
+
+function pendingApprovalEntries(
+  runtime: ConversationRuntime,
+): import("./types").PendingApprovalResolver[] {
+  return [...new Set(runtime.pendingApprovalResolvers.values())];
+}
+
+function removePendingApproval(
+  runtime: ConversationRuntime,
+  pending: import("./types").PendingApprovalResolver,
+): void {
+  for (const [requestKey, candidate] of runtime.pendingApprovalResolvers) {
+    if (candidate !== pending) continue;
+    runtime.pendingApprovalResolvers.delete(requestKey);
+    runtime.listener.approvalRuntimeKeyByRequestId.delete(requestKey);
+  }
+  pending.connectionIds.clear();
+}
+
+function addPendingApprovalConnection(
+  runtime: ConversationRuntime,
+  pending: import("./types").PendingApprovalResolver,
+  connectionId: ListenerConnectionId,
+): void {
+  const unownedKey = createConnectionRequestKey(
+    UNOWNED_APPROVAL_CONNECTION_ID,
+    pending.requestId,
+  );
+  runtime.pendingApprovalResolvers.delete(unownedKey);
+  runtime.listener.approvalRuntimeKeyByRequestId.delete(unownedKey);
+  const requestKey = createConnectionRequestKey(
+    connectionId,
+    pending.requestId,
+  );
+  pending.connectionIds.add(connectionId);
+  runtime.pendingApprovalResolvers.set(requestKey, pending);
+  runtime.listener.approvalRuntimeKeyByRequestId.set(requestKey, runtime.key);
+}
+
+function keepPendingApprovalUnowned(
+  runtime: ConversationRuntime,
+  pending: import("./types").PendingApprovalResolver,
+): void {
+  const requestKey = createConnectionRequestKey(
+    UNOWNED_APPROVAL_CONNECTION_ID,
+    pending.requestId,
+  );
+  runtime.pendingApprovalResolvers.set(requestKey, pending);
+  runtime.listener.approvalRuntimeKeyByRequestId.set(requestKey, runtime.key);
+}
+
+export function hasPendingApprovalRequestId(
+  runtime: ConversationRuntime,
+  requestId: string,
+): boolean {
+  return pendingApprovalEntries(runtime).some(
+    (pending) => pending.requestId === requestId,
+  );
+}
+
+export function getPendingApprovalRequestIds(
+  runtime: ConversationRuntime,
+): Set<string> {
+  return new Set(
+    pendingApprovalEntries(runtime).map((pending) => pending.requestId),
+  );
+}
 
 export function rememberPendingApprovalBatchIds(
   runtime: ConversationRuntime,
@@ -196,7 +268,7 @@ export function resolvePendingApprovalResolver(
   const requestKey = connectionId
     ? createConnectionRequestKey(connectionId, requestId)
     : [...runtime.pendingApprovalResolvers.entries()].find(
-        ([, candidate]) => candidate.controlRequest?.request_id === requestId,
+        ([, candidate]) => candidate.requestId === requestId,
       )?.[0];
   if (!requestKey) {
     return false;
@@ -206,8 +278,7 @@ export function resolvePendingApprovalResolver(
     return false;
   }
 
-  runtime.pendingApprovalResolvers.delete(requestKey);
-  runtime.listener.approvalRuntimeKeyByRequestId.delete(requestKey);
+  removePendingApproval(runtime, pending);
   if (runtime.pendingApprovalResolvers.size === 0 && !runtime.isProcessing) {
     setCommandLoopStatus(runtime, "WAITING_ON_INPUT");
   }
@@ -228,7 +299,7 @@ export function rejectPendingApprovalResolvers(
   runtime: ConversationRuntime,
   reason: string,
 ): void {
-  for (const [, pending] of runtime.pendingApprovalResolvers) {
+  for (const pending of pendingApprovalEntries(runtime)) {
     pending.reject(new Error(reason));
   }
   runtime.pendingApprovalResolvers.clear();
@@ -255,24 +326,50 @@ export function rejectPendingApprovalResolvers(
 export function rejectPendingApprovalResolversForConnection(
   runtime: ConversationRuntime,
   connectionId: ListenerConnectionId,
-  reason: string,
+  _reason: string,
 ): void {
-  for (const [requestKey, pending] of runtime.pendingApprovalResolvers) {
-    if (pending.connectionId !== connectionId) {
+  for (const pending of pendingApprovalEntries(runtime)) {
+    if (!pending.connectionIds.delete(connectionId)) {
       continue;
     }
+    const requestKey = createConnectionRequestKey(
+      connectionId,
+      pending.requestId,
+    );
     runtime.pendingApprovalResolvers.delete(requestKey);
     runtime.listener.approvalRuntimeKeyByRequestId.delete(requestKey);
-    pending.reject(new Error(reason));
-  }
-  if (
-    runtime.pendingApprovalResolvers.size === 0 &&
-    !runtime.isProcessing &&
-    !runtime.cancelRequested
-  ) {
-    setCommandLoopStatus(runtime, "WAITING_ON_INPUT");
+    if (pending.connectionIds.size === 0) {
+      // Codex keeps a thread-scoped server request alive when its last
+      // subscriber disconnects and replays it to a later subscriber. The
+      // listener turn's abort signal remains the authority for cancellation.
+      keepPendingApprovalUnowned(runtime, pending);
+    }
   }
   evictConversationRuntimeIfIdle(runtime);
+}
+
+export function replayPendingApprovalRequestsToConnection(
+  runtime: ConversationRuntime,
+  connectionId: ListenerConnectionId,
+): void {
+  const connection = runtime.listener.connections.get(connectionId);
+  if (!connection?.initialized || !isListenerTransportOpen(connection.writer)) {
+    return;
+  }
+  for (const pending of pendingApprovalEntries(runtime)) {
+    addPendingApprovalConnection(runtime, pending, connectionId);
+    if (!pending.controlRequest) continue;
+    emitProtocolV2Message(
+      connection.writer,
+      runtime,
+      pending.controlRequest,
+      {
+        agent_id: runtime.agentId,
+        conversation_id: runtime.conversationId,
+      },
+      toListenerConnection(connectionId),
+    );
+  }
 }
 
 export function requestApprovalOverWS(
@@ -282,18 +379,37 @@ export function requestApprovalOverWS(
   requestId: string,
   controlRequest: ControlRequest,
 ): Promise<ApprovalResponseBody> {
-  const controller = selectListenerController(
+  const scope = {
+    agent_id: runtime.agentId,
+    conversation_id: runtime.conversationId,
+  };
+  const subscribers = getSubscribedListenerConnections(runtime.listener, scope);
+  const originConnection = findListenerConnectionByTransport(
     runtime.listener,
-    {
-      agent_id: runtime.agentId,
-      conversation_id: runtime.conversationId,
-    },
     socket,
   );
-  if (!controller || !isListenerTransportOpen(controller.writer)) {
+  const connectionIds = new Set(subscribers.map((subscriber) => subscriber.id));
+  if (
+    connectionIds.size === 0 &&
+    originConnection?.initialized &&
+    isListenerTransportOpen(originConnection.writer)
+  ) {
+    connectionIds.add(originConnection.id);
+  }
+  if (
+    connectionIds.size === 0 &&
+    runtime.listener.connections.size === 0 &&
+    isListenerTransportOpen(socket)
+  ) {
+    connectionIds.add(runtime.listener.connectionId ?? "legacy");
+  }
+  if (
+    connectionIds.size === 0 &&
+    !isListenerTransportOpen(socket) &&
+    runtime.listener.connections.size === 0
+  ) {
     return Promise.reject(new Error("WebSocket not open"));
   }
-  const requestKey = createConnectionRequestKey(controller.id, requestId);
 
   const abortSignal = turnLease.signal;
   const isInterrupted = () =>
@@ -305,29 +421,33 @@ export function requestApprovalOverWS(
 
   return new Promise<ApprovalResponseBody>((resolve, reject) => {
     let settled = false;
+    const pending: import("./types").PendingApprovalResolver = {
+      requestId,
+      connectionIds,
+      resolve: (response) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanupAbortListener();
+        resolve(response);
+      },
+      reject: (error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanupAbortListener();
+        reject(error);
+      },
+      controlRequest,
+    };
     const cleanupAbortListener = () => {
       abortSignal.removeEventListener("abort", handleAbort);
     };
-    const wrappedResolve = (response: ApprovalResponseBody) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      cleanupAbortListener();
-      resolve(response);
-    };
-    const wrappedReject = (error: Error) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      cleanupAbortListener();
-      reject(error);
-    };
     const handleAbort = () => {
-      runtime.pendingApprovalResolvers.delete(requestKey);
-      runtime.listener.approvalRuntimeKeyByRequestId.delete(requestKey);
-      wrappedReject(new Error("Cancelled by user"));
+      removePendingApproval(runtime, pending);
+      pending.reject(new Error("Cancelled by user"));
     };
 
     abortSignal.addEventListener("abort", handleAbort, { once: true });
@@ -336,13 +456,13 @@ export function requestApprovalOverWS(
       return;
     }
 
-    runtime.pendingApprovalResolvers.set(requestKey, {
-      connectionId: controller.id,
-      resolve: wrappedResolve,
-      reject: wrappedReject,
-      controlRequest,
-    });
-    runtime.listener.approvalRuntimeKeyByRequestId.set(requestKey, runtime.key);
+    if (connectionIds.size === 0) {
+      keepPendingApprovalUnowned(runtime, pending);
+    } else {
+      for (const connectionId of connectionIds) {
+        addPendingApprovalConnection(runtime, pending, connectionId);
+      }
+    }
     if (isInterrupted()) {
       handleAbort();
       return;
@@ -350,14 +470,11 @@ export function requestApprovalOverWS(
     runtime.turnLifecycle.recordStopReason(turnLease, "requires_approval");
     setTurnLoopStatus(runtime, turnLease, "WAITING_ON_APPROVAL");
     emitProtocolV2Message(
-      controller.writer,
+      socket,
       runtime,
       controlRequest,
-      {
-        agent_id: runtime.agentId,
-        conversation_id: runtime.conversationId,
-      },
-      { connectionId: controller.id, subscribers: false },
+      scope,
+      TO_SUBSCRIBERS,
     );
     emitLoopStatusIfOpen(runtime.listener, {
       agent_id: runtime.agentId,

--- a/src/websocket/listener/approval.ts
+++ b/src/websocket/listener/approval.ts
@@ -1,6 +1,10 @@
 import type { ApprovalResult } from "@/agent/approval-execution";
 import type { ApprovalResponseBody, ControlRequest } from "@/types/protocol_v2";
 import {
+  createConnectionRequestKey,
+  selectListenerController,
+} from "./connection";
+import {
   emitDeviceStatusIfOpen,
   emitLoopStatusIfOpen,
   emitProtocolV2Message,
@@ -9,7 +13,7 @@ import { evictConversationRuntimeIfIdle } from "./runtime";
 import { isListenerTransportOpen, type ListenerTransport } from "./transport";
 import type { TurnLease } from "./turn-lifecycle";
 import { setCommandLoopStatus, setTurnLoopStatus } from "./turn-status";
-import type { ConversationRuntime } from "./types";
+import type { ConversationRuntime, ListenerConnectionId } from "./types";
 
 export function rememberPendingApprovalBatchIds(
   runtime: ConversationRuntime,
@@ -182,19 +186,28 @@ export function validateApprovalResultIds(
 export function resolvePendingApprovalResolver(
   runtime: ConversationRuntime,
   response: ApprovalResponseBody,
+  connectionId?: ListenerConnectionId,
 ): boolean {
   const requestId = response.request_id;
   if (typeof requestId !== "string" || requestId.length === 0) {
     return false;
   }
 
-  const pending = runtime.pendingApprovalResolvers.get(requestId);
+  const requestKey = connectionId
+    ? createConnectionRequestKey(connectionId, requestId)
+    : [...runtime.pendingApprovalResolvers.entries()].find(
+        ([, candidate]) => candidate.controlRequest?.request_id === requestId,
+      )?.[0];
+  if (!requestKey) {
+    return false;
+  }
+  const pending = runtime.pendingApprovalResolvers.get(requestKey);
   if (!pending) {
     return false;
   }
 
-  runtime.pendingApprovalResolvers.delete(requestId);
-  runtime.listener.approvalRuntimeKeyByRequestId.delete(requestId);
+  runtime.pendingApprovalResolvers.delete(requestKey);
+  runtime.listener.approvalRuntimeKeyByRequestId.delete(requestKey);
   if (runtime.pendingApprovalResolvers.size === 0 && !runtime.isProcessing) {
     setCommandLoopStatus(runtime, "WAITING_ON_INPUT");
   }
@@ -239,6 +252,29 @@ export function rejectPendingApprovalResolvers(
   evictConversationRuntimeIfIdle(runtime);
 }
 
+export function rejectPendingApprovalResolversForConnection(
+  runtime: ConversationRuntime,
+  connectionId: ListenerConnectionId,
+  reason: string,
+): void {
+  for (const [requestKey, pending] of runtime.pendingApprovalResolvers) {
+    if (pending.connectionId !== connectionId) {
+      continue;
+    }
+    runtime.pendingApprovalResolvers.delete(requestKey);
+    runtime.listener.approvalRuntimeKeyByRequestId.delete(requestKey);
+    pending.reject(new Error(reason));
+  }
+  if (
+    runtime.pendingApprovalResolvers.size === 0 &&
+    !runtime.isProcessing &&
+    !runtime.cancelRequested
+  ) {
+    setCommandLoopStatus(runtime, "WAITING_ON_INPUT");
+  }
+  evictConversationRuntimeIfIdle(runtime);
+}
+
 export function requestApprovalOverWS(
   runtime: ConversationRuntime,
   socket: ListenerTransport,
@@ -246,9 +282,18 @@ export function requestApprovalOverWS(
   requestId: string,
   controlRequest: ControlRequest,
 ): Promise<ApprovalResponseBody> {
-  if (!isListenerTransportOpen(socket)) {
+  const controller = selectListenerController(
+    runtime.listener,
+    {
+      agent_id: runtime.agentId,
+      conversation_id: runtime.conversationId,
+    },
+    socket,
+  );
+  if (!controller || !isListenerTransportOpen(controller.writer)) {
     return Promise.reject(new Error("WebSocket not open"));
   }
+  const requestKey = createConnectionRequestKey(controller.id, requestId);
 
   const abortSignal = turnLease.signal;
   const isInterrupted = () =>
@@ -280,8 +325,8 @@ export function requestApprovalOverWS(
       reject(error);
     };
     const handleAbort = () => {
-      runtime.pendingApprovalResolvers.delete(requestId);
-      runtime.listener.approvalRuntimeKeyByRequestId.delete(requestId);
+      runtime.pendingApprovalResolvers.delete(requestKey);
+      runtime.listener.approvalRuntimeKeyByRequestId.delete(requestKey);
       wrappedReject(new Error("Cancelled by user"));
     };
 
@@ -291,22 +336,29 @@ export function requestApprovalOverWS(
       return;
     }
 
-    runtime.pendingApprovalResolvers.set(requestId, {
+    runtime.pendingApprovalResolvers.set(requestKey, {
+      connectionId: controller.id,
       resolve: wrappedResolve,
       reject: wrappedReject,
       controlRequest,
     });
-    runtime.listener.approvalRuntimeKeyByRequestId.set(requestId, runtime.key);
+    runtime.listener.approvalRuntimeKeyByRequestId.set(requestKey, runtime.key);
     if (isInterrupted()) {
       handleAbort();
       return;
     }
     runtime.turnLifecycle.recordStopReason(turnLease, "requires_approval");
     setTurnLoopStatus(runtime, turnLease, "WAITING_ON_APPROVAL");
-    emitProtocolV2Message(socket, runtime, controlRequest, {
-      agent_id: runtime.agentId,
-      conversation_id: runtime.conversationId,
-    });
+    emitProtocolV2Message(
+      controller.writer,
+      runtime,
+      controlRequest,
+      {
+        agent_id: runtime.agentId,
+        conversation_id: runtime.conversationId,
+      },
+      { connectionId: controller.id, subscribers: false },
+    );
     emitLoopStatusIfOpen(runtime.listener, {
       agent_id: runtime.agentId,
       conversation_id: runtime.conversationId,

--- a/src/websocket/listener/auth-lifecycle.test.ts
+++ b/src/websocket/listener/auth-lifecycle.test.ts
@@ -11,6 +11,14 @@ import {
   stopListenerClient,
 } from "@/websocket/listen-client";
 import { __listenerAuthTestUtils } from "@/websocket/listener/auth";
+import {
+  getOrCreateProcessTransport,
+  subscribeListenerConnection,
+  TO_SUBSCRIBERS,
+} from "@/websocket/listener/connection";
+import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
+import { emitProtocolV2Message } from "@/websocket/listener/protocol-outbound";
+import { getActiveRuntime } from "@/websocket/listener/runtime";
 
 type ListenerSettings = Awaited<
   ReturnType<typeof settingsManager.getSettingsWithSecureTokens>
@@ -46,6 +54,7 @@ describe("listener auth lifecycle", () => {
   let settings: ListenerSettings;
   let connections: WebSocket[];
   let authorizations: Array<string | undefined>;
+  let received: Record<string, unknown>[][];
 
   const refreshAccessTokenMock = mock(async (): Promise<TokenResponse> => {
     throw new Error("refreshAccessToken not mocked");
@@ -89,13 +98,19 @@ describe("listener auth lifecycle", () => {
 
     connections = [];
     authorizations = [];
+    received = [];
     server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
     await new Promise<void>((resolve) => server.once("listening", resolve));
     const address = server.address() as AddressInfo;
     wsUrl = `ws://127.0.0.1:${address.port}`;
     server.on("connection", (socket, request) => {
+      const messages: Record<string, unknown>[] = [];
       connections.push(socket);
       authorizations.push(request.headers.authorization);
+      received.push(messages);
+      socket.on("message", (raw) => {
+        messages.push(JSON.parse(String(raw)) as Record<string, unknown>);
+      });
     });
   });
 
@@ -188,6 +203,81 @@ describe("listener auth lifecycle", () => {
 
     expect(authorizations[1]).toBe("Bearer refreshed-access-token");
     expect(settings.refreshToken).toBe("rotated-refresh-token");
+  });
+
+  test("preserves outbound subscriptions and event sequence across reconnect", async () => {
+    await startClient();
+    await waitFor(
+      () =>
+        getActiveRuntime()?.connections.get("connection-id")?.initialized ===
+        true,
+      "initial listener connection did not initialize",
+    );
+    const runtime = getActiveRuntime();
+    expect(runtime).not.toBeNull();
+    if (!runtime) return;
+
+    const scope = { agent_id: "agent-1", conversation_id: "conv-1" };
+    const conversationRuntime = getOrCreateScopedRuntime(
+      runtime,
+      scope.agent_id,
+      scope.conversation_id,
+    );
+    subscribeListenerConnection(runtime, "connection-id", scope);
+    emitProtocolV2Message(
+      getOrCreateProcessTransport(runtime),
+      conversationRuntime,
+      { type: "crons_updated", timestamp: 1 } as never,
+      scope,
+      TO_SUBSCRIBERS,
+    );
+    await waitFor(
+      () =>
+        received[0]?.some((message) => message.type === "crons_updated") ===
+        true,
+      "initial scoped event was not delivered",
+    );
+    const eventSeqBeforeReconnect =
+      runtime.connections.get("connection-id")?.eventSeqCounter ?? 0;
+
+    connections[0]?.close(1000, "reconnect");
+    await waitFor(
+      () =>
+        connections.length === 2 &&
+        runtime.connections.get("connection-id")?.initialized === true,
+      "listener did not reconnect",
+    );
+
+    const reconnected = runtime.connections.get("connection-id");
+    expect(reconnected?.subscriptions).toEqual(
+      new Set(["agent:agent-1::conversation:conv-1"]),
+    );
+    expect(reconnected?.eventSeqCounter).toBeGreaterThanOrEqual(
+      eventSeqBeforeReconnect,
+    );
+
+    const resumedRuntime = getOrCreateScopedRuntime(
+      runtime,
+      scope.agent_id,
+      scope.conversation_id,
+    );
+    emitProtocolV2Message(
+      getOrCreateProcessTransport(runtime),
+      resumedRuntime,
+      { type: "crons_updated", timestamp: 2 } as never,
+      scope,
+      TO_SUBSCRIBERS,
+    );
+    await waitFor(
+      () =>
+        received[1]?.some((message) => message.type === "crons_updated") ===
+        true,
+      "post-reconnect scoped event was not delivered",
+    );
+    const resumedEvent = received[1]?.find(
+      (message) => message.type === "crons_updated",
+    );
+    expect(resumedEvent?.event_seq).toBeGreaterThan(eventSeqBeforeReconnect);
   });
 
   test("does not create a socket after stop wins an in-flight refresh", async () => {

--- a/src/websocket/listener/background-process-snapshot.ts
+++ b/src/websocket/listener/background-process-snapshot.ts
@@ -1,0 +1,41 @@
+import {
+  backgroundProcesses,
+  backgroundTasks,
+} from "@/tools/impl/process_manager";
+import type { BackgroundProcessSummary } from "@/types/protocol_v2";
+
+export function buildBackgroundProcessSnapshot(): BackgroundProcessSummary[] {
+  const bashProcesses: BackgroundProcessSummary[] = Array.from(
+    backgroundProcesses.entries(),
+  )
+    .filter(([, proc]) => proc.status === "running")
+    .map(([processId, proc]) => ({
+      process_id: processId,
+      kind: "bash",
+      command: proc.command,
+      started_at_ms: proc.startTime?.getTime() ?? null,
+      status: proc.status,
+      exit_code: proc.exitCode,
+    }));
+
+  const taskProcesses: BackgroundProcessSummary[] = Array.from(
+    backgroundTasks.entries(),
+  )
+    .filter(([, task]) => task.status === "running")
+    .map(([processId, task]) => ({
+      process_id: processId,
+      kind: "agent_task",
+      task_type: task.subagentType,
+      description: task.description,
+      started_at_ms: task.startTime.getTime(),
+      status: task.status,
+      subagent_id: task.subagentId,
+      ...(task.error ? { error: task.error } : {}),
+    }));
+
+  return [...bashProcesses, ...taskProcesses].sort((a, b) => {
+    const aStart = a.started_at_ms ?? 0;
+    const bStart = b.started_at_ms ?? 0;
+    return bStart - aStart;
+  });
+}

--- a/src/websocket/listener/background-process-snapshot.ts
+++ b/src/websocket/listener/background-process-snapshot.ts
@@ -1,14 +1,39 @@
 import {
+  type BackgroundProcess,
+  type BackgroundRuntimeScope,
+  type BackgroundTask,
   backgroundProcesses,
   backgroundTasks,
 } from "@/tools/impl/process_manager";
 import type { BackgroundProcessSummary } from "@/types/protocol_v2";
 
-export function buildBackgroundProcessSnapshot(): BackgroundProcessSummary[] {
+function belongsToRuntime(
+  entry: BackgroundProcess | BackgroundTask,
+  runtimeScope: BackgroundRuntimeScope,
+): boolean {
+  return (
+    entry.runtimeScope?.agentId === runtimeScope.agentId &&
+    entry.runtimeScope.conversationId === runtimeScope.conversationId
+  );
+}
+
+export function buildBackgroundProcessSnapshot(
+  agentId?: string | null,
+  conversationId = "default",
+): BackgroundProcessSummary[] {
+  if (agentId === null) {
+    return [];
+  }
+  const runtimeScope: BackgroundRuntimeScope | undefined =
+    agentId === undefined ? undefined : { agentId, conversationId };
   const bashProcesses: BackgroundProcessSummary[] = Array.from(
     backgroundProcesses.entries(),
   )
-    .filter(([, proc]) => proc.status === "running")
+    .filter(
+      ([, proc]) =>
+        proc.status === "running" &&
+        (!runtimeScope || belongsToRuntime(proc, runtimeScope)),
+    )
     .map(([processId, proc]) => ({
       process_id: processId,
       kind: "bash",
@@ -21,7 +46,11 @@ export function buildBackgroundProcessSnapshot(): BackgroundProcessSummary[] {
   const taskProcesses: BackgroundProcessSummary[] = Array.from(
     backgroundTasks.entries(),
   )
-    .filter(([, task]) => task.status === "running")
+    .filter(
+      ([, task]) =>
+        task.status === "running" &&
+        (!runtimeScope || belongsToRuntime(task, runtimeScope)),
+    )
     .map(([processId, task]) => ({
       process_id: processId,
       kind: "agent_task",

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -14,8 +14,8 @@ import {
   handleAgentConversationManagementCommand,
   handleAgentConversationManagementProtocolCommand,
 } from "./commands/agents-conversations";
+import { handleChannelRegistryEvent } from "./commands/channel-registry-events";
 import {
-  handleChannelRegistryEvent,
   handleChannelsProtocolCommand,
   isDetachedChannelsCommand,
   setChannelsServiceLoaderOverride,
@@ -136,6 +136,8 @@ function createLegacyTestRuntime(): ConversationRuntime & {
   connectionIdsByRuntimeKey: ListenerRuntime["connectionIdsByRuntimeKey"];
   processTransport: ListenerRuntime["processTransport"];
   processServicesStarted: boolean;
+  processServicesReady: Promise<void> | null;
+  pendingExternalToolCalls: ListenerRuntime["pendingExternalToolCalls"];
   eventSeqCounter: number;
   queueEmitScheduled: boolean;
   pendingQueueEmitScope?: {
@@ -181,6 +183,8 @@ function createLegacyTestRuntime(): ConversationRuntime & {
     connectionIdsByRuntimeKey: ListenerRuntime["connectionIdsByRuntimeKey"];
     processTransport: ListenerRuntime["processTransport"];
     processServicesStarted: boolean;
+    processServicesReady: Promise<void> | null;
+    pendingExternalToolCalls: ListenerRuntime["pendingExternalToolCalls"];
     eventSeqCounter: number;
     queueEmitScheduled: boolean;
     pendingQueueEmitScope?: {
@@ -307,6 +311,18 @@ function createLegacyTestRuntime(): ConversationRuntime & {
       get: () => listener.processServicesStarted,
       set: (value: boolean) => {
         listener.processServicesStarted = value;
+      },
+    },
+    processServicesReady: {
+      get: () => listener.processServicesReady,
+      set: (value: Promise<void> | null) => {
+        listener.processServicesReady = value;
+      },
+    },
+    pendingExternalToolCalls: {
+      get: () => listener.pendingExternalToolCalls,
+      set: (value: ListenerRuntime["pendingExternalToolCalls"]) => {
+        listener.pendingExternalToolCalls = value;
       },
     },
     eventSeqCounter: {
@@ -555,7 +571,7 @@ export const __listenClientTestUtils = {
     event: Parameters<typeof handleChannelRegistryEvent>[0],
     socket: Parameters<typeof handleChannelRegistryEvent>[1],
     runtime: ListenerRuntime,
-  ) => handleChannelRegistryEvent(event, socket, runtime, safeSocketSend),
+  ) => handleChannelRegistryEvent(event, socket, runtime),
   handleAgentConversationManagementCommand: (
     parsed: Parameters<typeof handleAgentConversationManagementCommand>[0],
     socket: WebSocket,
@@ -578,6 +594,7 @@ export const __listenClientTestUtils = {
   ) =>
     handleRuntimeStartCommand(parsed, {
       socket,
+      connectionId: runtime.connectionId ?? "test-connection",
       runtime,
       safeSocketSend,
       runDetachedListenerTask,
@@ -600,6 +617,7 @@ export const __listenClientTestUtils = {
   ) =>
     handleRuntimeStartProtocolCommand(parsed, {
       socket,
+      connectionId: runtime.connectionId ?? "test-connection",
       runtime,
       safeSocketSend,
       runDetachedListenerTask,

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -136,7 +136,9 @@ function createLegacyTestRuntime(): ConversationRuntime & {
   connectionIdsByRuntimeKey: ListenerRuntime["connectionIdsByRuntimeKey"];
   processTransport: ListenerRuntime["processTransport"];
   processServicesStarted: boolean;
+  processServicesGeneration: number;
   processServicesReady: Promise<void> | null;
+  processServicesReadyGeneration: number | null;
   pendingExternalToolCalls: ListenerRuntime["pendingExternalToolCalls"];
   eventSeqCounter: number;
   queueEmitScheduled: boolean;
@@ -183,7 +185,9 @@ function createLegacyTestRuntime(): ConversationRuntime & {
     connectionIdsByRuntimeKey: ListenerRuntime["connectionIdsByRuntimeKey"];
     processTransport: ListenerRuntime["processTransport"];
     processServicesStarted: boolean;
+    processServicesGeneration: number;
     processServicesReady: Promise<void> | null;
+    processServicesReadyGeneration: number | null;
     pendingExternalToolCalls: ListenerRuntime["pendingExternalToolCalls"];
     eventSeqCounter: number;
     queueEmitScheduled: boolean;
@@ -313,10 +317,22 @@ function createLegacyTestRuntime(): ConversationRuntime & {
         listener.processServicesStarted = value;
       },
     },
+    processServicesGeneration: {
+      get: () => listener.processServicesGeneration,
+      set: (value: number) => {
+        listener.processServicesGeneration = value;
+      },
+    },
     processServicesReady: {
       get: () => listener.processServicesReady,
       set: (value: Promise<void> | null) => {
         listener.processServicesReady = value;
+      },
+    },
+    processServicesReadyGeneration: {
+      get: () => listener.processServicesReadyGeneration,
+      set: (value: number | null) => {
+        listener.processServicesReadyGeneration = value;
       },
     },
     pendingExternalToolCalls: {

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -131,6 +131,11 @@ function createLegacyTestRuntime(): ConversationRuntime & {
   connectionId: string | null;
   connectionName: string | null;
   sessionId: string;
+  nextConnectionOrdinal: number;
+  connections: ListenerRuntime["connections"];
+  connectionIdsByRuntimeKey: ListenerRuntime["connectionIdsByRuntimeKey"];
+  processTransport: ListenerRuntime["processTransport"];
+  processServicesStarted: boolean;
   eventSeqCounter: number;
   queueEmitScheduled: boolean;
   pendingQueueEmitScope?: {
@@ -172,6 +177,11 @@ function createLegacyTestRuntime(): ConversationRuntime & {
     connectionId: string | null;
     connectionName: string | null;
     sessionId: string;
+    nextConnectionOrdinal: number;
+    connections: ListenerRuntime["connections"];
+    connectionIdsByRuntimeKey: ListenerRuntime["connectionIdsByRuntimeKey"];
+    processTransport: ListenerRuntime["processTransport"];
+    processServicesStarted: boolean;
     eventSeqCounter: number;
     queueEmitScheduled: boolean;
     pendingQueueEmitScope?: {
@@ -269,6 +279,36 @@ function createLegacyTestRuntime(): ConversationRuntime & {
       get: () => listener.sessionId,
       set: (value: string) => {
         listener.sessionId = value;
+      },
+    },
+    nextConnectionOrdinal: {
+      get: () => listener.nextConnectionOrdinal,
+      set: (value: number) => {
+        listener.nextConnectionOrdinal = value;
+      },
+    },
+    connections: {
+      get: () => listener.connections,
+      set: (value: ListenerRuntime["connections"]) => {
+        listener.connections = value;
+      },
+    },
+    connectionIdsByRuntimeKey: {
+      get: () => listener.connectionIdsByRuntimeKey,
+      set: (value: ListenerRuntime["connectionIdsByRuntimeKey"]) => {
+        listener.connectionIdsByRuntimeKey = value;
+      },
+    },
+    processTransport: {
+      get: () => listener.processTransport,
+      set: (value: ListenerRuntime["processTransport"]) => {
+        listener.processTransport = value;
+      },
+    },
+    processServicesStarted: {
+      get: () => listener.processServicesStarted,
+      set: (value: boolean) => {
+        listener.processServicesStarted = value;
       },
     },
     eventSeqCounter: {

--- a/src/websocket/listener/client.ts
+++ b/src/websocket/listener/client.ts
@@ -151,7 +151,6 @@ function createLegacyTestRuntime(): ConversationRuntime & {
   hasSuccessfulConnection: boolean;
   everConnected: boolean;
   conversationRuntimes: ListenerRuntime["conversationRuntimes"];
-  approvalRuntimeKeyByRequestId: ListenerRuntime["approvalRuntimeKeyByRequestId"];
   memfsSyncedAgents: ListenerRuntime["memfsSyncedAgents"];
   secretsHydrationByAgent: ListenerRuntime["secretsHydrationByAgent"];
   secretsHydrationFreshnessByAgent: ListenerRuntime["secretsHydrationFreshnessByAgent"];
@@ -197,7 +196,6 @@ function createLegacyTestRuntime(): ConversationRuntime & {
     hasSuccessfulConnection: boolean;
     everConnected: boolean;
     conversationRuntimes: ListenerRuntime["conversationRuntimes"];
-    approvalRuntimeKeyByRequestId: ListenerRuntime["approvalRuntimeKeyByRequestId"];
     memfsSyncedAgents: ListenerRuntime["memfsSyncedAgents"];
     secretsHydrationByAgent: ListenerRuntime["secretsHydrationByAgent"];
     secretsHydrationFreshnessByAgent: ListenerRuntime["secretsHydrationFreshnessByAgent"];
@@ -388,12 +386,6 @@ function createLegacyTestRuntime(): ConversationRuntime & {
       get: () => listener.conversationRuntimes,
       set: (value: ListenerRuntime["conversationRuntimes"]) => {
         listener.conversationRuntimes = value;
-      },
-    },
-    approvalRuntimeKeyByRequestId: {
-      get: () => listener.approvalRuntimeKeyByRequestId,
-      set: (value: ListenerRuntime["approvalRuntimeKeyByRequestId"]) => {
-        listener.approvalRuntimeKeyByRequestId = value;
       },
     },
     memfsSyncedAgents: {

--- a/src/websocket/listener/commands/app-server-info.test.ts
+++ b/src/websocket/listener/commands/app-server-info.test.ts
@@ -46,7 +46,7 @@ describe("app-server info protocol", () => {
         conversation_management: true,
         memory_management: true,
         runtime_start: true,
-        split_channels: true,
+        split_channels: false,
       },
     });
   });

--- a/src/websocket/listener/commands/app-server-info.ts
+++ b/src/websocket/listener/commands/app-server-info.ts
@@ -33,7 +33,7 @@ export function buildAppServerInfoResponse(
       conversation_management: true,
       memory_management: true,
       runtime_start: true,
-      split_channels: true,
+      split_channels: false,
     },
   };
 }

--- a/src/websocket/listener/commands/channel-registry-events.ts
+++ b/src/websocket/listener/commands/channel-registry-events.ts
@@ -1,0 +1,139 @@
+import type { ChannelRegistryEvent } from "@/channels/registry-events";
+import { trackBoundaryError } from "@/telemetry/error-reporting";
+import type {
+  ChannelAccountsUpdatedMessage,
+  ChannelId,
+  ChannelPairingsUpdatedMessage,
+  ChannelsUpdatedMessage,
+  ChannelTargetsUpdatedMessage,
+} from "@/types/protocol_v2";
+import {
+  BROADCAST,
+  resolveListenerConnectionTargets,
+} from "@/websocket/listener/connection";
+import { seedConversationWorkingDirectory } from "@/websocket/listener/cwd";
+import {
+  getOrCreateConversationPermissionModeStateRef,
+  persistPermissionModeMapForRuntime,
+} from "@/websocket/listener/permission-mode";
+import { emitDeviceStatusUpdate } from "@/websocket/listener/protocol-outbound";
+import { getOrCreateConversationRuntime } from "@/websocket/listener/runtime";
+import {
+  isListenerTransportOpen,
+  type ListenerTransport,
+} from "@/websocket/listener/transport";
+import type { ListenerRuntime } from "@/websocket/listener/types";
+
+type ChannelRegistryUpdateMessage =
+  | ChannelsUpdatedMessage
+  | ChannelAccountsUpdatedMessage
+  | ChannelPairingsUpdatedMessage
+  | ChannelTargetsUpdatedMessage;
+
+function broadcastChannelRegistryUpdate(
+  runtime: ListenerRuntime,
+  origin: ListenerTransport,
+  message: ChannelRegistryUpdateMessage,
+): void {
+  const payload = JSON.stringify(message);
+  const targets = resolveListenerConnectionTargets({
+    runtime,
+    origin,
+    scope: {},
+    routing: BROADCAST,
+    streamMessage: false,
+  });
+  for (const target of targets) {
+    if (isListenerTransportOpen(target.transport)) {
+      try {
+        target.transport.send(payload);
+      } catch (error) {
+        trackBoundaryError({
+          context: "listener_channel_registry_broadcast",
+          errorType: "listener_channel_registry_send_failed",
+          error,
+        });
+      }
+    }
+  }
+}
+
+export function handleChannelRegistryEvent(
+  event: ChannelRegistryEvent,
+  transport: ListenerTransport,
+  runtime: ListenerRuntime,
+): void {
+  const broadcast = (message: ChannelRegistryUpdateMessage) =>
+    broadcastChannelRegistryUpdate(runtime, transport, message);
+
+  if (event.type === "pairings_updated") {
+    const channelId = event.channelId as ChannelId;
+    broadcast({
+      type: "channel_pairings_updated",
+      timestamp: Date.now(),
+      channel_id: channelId,
+    });
+    broadcast({
+      type: "channels_updated",
+      timestamp: Date.now(),
+      channel_id: channelId,
+    });
+    return;
+  }
+
+  if (event.type === "targets_updated") {
+    const channelId = event.channelId as ChannelId;
+    broadcast({
+      type: "channel_targets_updated",
+      timestamp: Date.now(),
+      channel_id: channelId,
+    });
+    broadcast({
+      type: "channels_updated",
+      timestamp: Date.now(),
+      channel_id: channelId,
+    });
+    return;
+  }
+
+  if (event.type === "channel_account_state_updated") {
+    const channelId = event.channelId as ChannelId;
+    broadcast({
+      type: "channel_accounts_updated",
+      timestamp: Date.now(),
+      channel_id: channelId,
+      account_id: event.accountId,
+    });
+    broadcast({
+      type: "channels_updated",
+      timestamp: Date.now(),
+      channel_id: channelId,
+    });
+    return;
+  }
+
+  const permissionModeState = getOrCreateConversationPermissionModeStateRef(
+    runtime,
+    event.agentId,
+    event.conversationId,
+  );
+  permissionModeState.mode = event.defaultPermissionMode;
+  persistPermissionModeMapForRuntime(runtime);
+
+  const seededWorkingDirectory = seedConversationWorkingDirectory(
+    runtime,
+    event.agentId,
+    event.conversationId,
+    runtime.bootWorkingDirectory,
+  );
+  if (seededWorkingDirectory) {
+    emitDeviceStatusUpdate(
+      transport,
+      getOrCreateConversationRuntime(
+        runtime,
+        event.agentId,
+        event.conversationId,
+      ),
+    );
+  }
+}

--- a/src/websocket/listener/commands/channels-events.test.ts
+++ b/src/websocket/listener/commands/channels-events.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import type { ChannelRegistryEvent } from "@/channels/registry-events";
+import {
+  getOrCreateProcessTransport,
+  markListenerConnectionInitialized,
+  openListenerConnection,
+} from "@/websocket/listener/connection";
+import { createRuntime } from "@/websocket/listener/lifecycle";
+import type { LocalTransport } from "@/websocket/listener/transport";
+import type { StartListenerOptions } from "@/websocket/listener/types";
+import { handleChannelRegistryEvent } from "./channel-registry-events";
+
+class MockTransport implements LocalTransport {
+  readonly kind = "local" as const;
+  readonly bufferedAmount = 0;
+  readonly sent: string[] = [];
+
+  isOpen(): boolean {
+    return true;
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+}
+
+function addConnection(
+  runtime: ReturnType<typeof createRuntime>,
+  connectionId: string,
+): MockTransport {
+  const transport = new MockTransport();
+  const options: StartListenerOptions = {
+    connectionId,
+    wsUrl: "local://app-server",
+    deviceId: connectionId,
+    connectionName: connectionId,
+    onConnected: () => {},
+    onDisconnected: () => {},
+    onError: () => {},
+  };
+  openListenerConnection({
+    runtime,
+    connectionId,
+    writer: transport,
+    options,
+  });
+  markListenerConnectionInitialized(runtime, connectionId);
+  return transport;
+}
+
+describe("process-originated channel registry events", () => {
+  test("broadcasts pairing, target, and account updates to every client", () => {
+    const runtime = createRuntime();
+    const clientA = addConnection(runtime, "client-a");
+    const clientB = addConnection(runtime, "client-b");
+    const processTransport = getOrCreateProcessTransport(runtime);
+    const cases: Array<{
+      event: ChannelRegistryEvent;
+      expectedTypes: string[];
+    }> = [
+      {
+        event: { type: "pairings_updated", channelId: "telegram" },
+        expectedTypes: ["channel_pairings_updated", "channels_updated"],
+      },
+      {
+        event: { type: "targets_updated", channelId: "slack" },
+        expectedTypes: ["channel_targets_updated", "channels_updated"],
+      },
+      {
+        event: {
+          type: "channel_account_state_updated",
+          channelId: "discord",
+          accountId: "bot-1",
+        },
+        expectedTypes: ["channel_accounts_updated", "channels_updated"],
+      },
+    ];
+
+    for (const { event, expectedTypes } of cases) {
+      handleChannelRegistryEvent(event, processTransport, runtime);
+
+      for (const client of [clientA, clientB]) {
+        expect(
+          client.sent.map(
+            (payload) => (JSON.parse(payload) as { type: string }).type,
+          ),
+        ).toEqual(expectedTypes);
+        client.sent.length = 0;
+      }
+    }
+  });
+});

--- a/src/websocket/listener/commands/channels.ts
+++ b/src/websocket/listener/commands/channels.ts
@@ -1,8 +1,7 @@
-import WebSocket from "ws";
+import type WebSocket from "ws";
 import { getChannelPluginConfig } from "@/channels/account-config";
 import { removeUserPlugin } from "@/channels/custom/scaffolding";
 import { getChannelPluginMetadata } from "@/channels/plugin-registry";
-import type { ChannelRegistryEvent } from "@/channels/registry-events";
 import { LEGACY_DEFAULT_CHANNEL_ID } from "@/channels/types";
 import type { DequeuedBatch } from "@/queue/queue-runtime";
 import type {
@@ -30,11 +29,6 @@ import type {
   ChannelAccountSnapshot as ProtocolChannelAccountSnapshot,
   ChannelConfigSnapshot as ProtocolChannelConfigSnapshot,
 } from "@/types/protocol_v2";
-import { seedConversationWorkingDirectory } from "@/websocket/listener/cwd";
-import {
-  getOrCreateConversationPermissionModeStateRef,
-  persistPermissionModeMapForRuntime,
-} from "@/websocket/listener/permission-mode";
 import {
   isChannelAccountBindCommand,
   isChannelAccountCreateCommand,
@@ -57,8 +51,6 @@ import {
   isChannelTargetBindCommand,
   isChannelTargetsListCommand,
 } from "@/websocket/listener/protocol-inbound";
-import { emitDeviceStatusUpdate } from "@/websocket/listener/protocol-outbound";
-import { getOrCreateConversationRuntime } from "@/websocket/listener/runtime";
 import type { ListenerTransport } from "@/websocket/listener/transport";
 import type {
   IncomingMessage,
@@ -1320,71 +1312,4 @@ export async function handleChannelsProtocolCommand(
   }
 
   return true;
-}
-
-export function handleChannelRegistryEvent(
-  event: ChannelRegistryEvent,
-  socket: ListenerTransport,
-  runtime: ListenerRuntime,
-  safeSocketSend: SafeSocketSend,
-): void {
-  if (event.type === "pairings_updated") {
-    if (socket instanceof WebSocket) {
-      emitChannelPairingsUpdated(
-        socket,
-        safeSocketSend,
-        event.channelId as ChannelId,
-      );
-      emitChannelsUpdated(socket, safeSocketSend, event.channelId as ChannelId);
-    }
-    return;
-  }
-
-  if (event.type === "targets_updated") {
-    if (socket instanceof WebSocket) {
-      emitChannelTargetsUpdated(
-        socket,
-        safeSocketSend,
-        event.channelId as ChannelId,
-      );
-      emitChannelsUpdated(socket, safeSocketSend, event.channelId as ChannelId);
-    }
-    return;
-  }
-
-  if (event.type === "channel_account_state_updated") {
-    if (socket instanceof WebSocket) {
-      emitChannelAccountsUpdated(socket, safeSocketSend, {
-        channelId: event.channelId as ChannelId,
-        accountId: event.accountId,
-      });
-      emitChannelsUpdated(socket, safeSocketSend, event.channelId as ChannelId);
-    }
-    return;
-  }
-
-  const permissionModeState = getOrCreateConversationPermissionModeStateRef(
-    runtime,
-    event.agentId,
-    event.conversationId,
-  );
-  permissionModeState.mode = event.defaultPermissionMode;
-  persistPermissionModeMapForRuntime(runtime);
-
-  const seededWorkingDirectory = seedConversationWorkingDirectory(
-    runtime,
-    event.agentId,
-    event.conversationId,
-    runtime.bootWorkingDirectory,
-  );
-  if (seededWorkingDirectory) {
-    emitDeviceStatusUpdate(
-      socket,
-      getOrCreateConversationRuntime(
-        runtime,
-        event.agentId,
-        event.conversationId,
-      ),
-    );
-  }
 }

--- a/src/websocket/listener/commands/runtime-start-skill-sources.test.ts
+++ b/src/websocket/listener/commands/runtime-start-skill-sources.test.ts
@@ -40,6 +40,7 @@ describe("runtime_start skill sources", () => {
         },
         {
           socket: {} as WebSocket,
+          connectionId: "test-connection",
           runtime: listener,
           safeSocketSend: () => true,
           runDetachedListenerTask: () => {},

--- a/src/websocket/listener/commands/runtime-start.ts
+++ b/src/websocket/listener/commands/runtime-start.ts
@@ -13,6 +13,7 @@ import { getBackend } from "@/backend";
 import { migratePermissionMode } from "@/permissions/mode";
 import { settingsManager } from "@/settings-manager";
 import type { RuntimeScope, RuntimeStartCommand } from "@/types/protocol_v2";
+import { subscribeListenerConnection } from "@/websocket/listener/connection";
 import { getBootWorkingDirectory } from "@/websocket/listener/cwd";
 import { switchConversationWorkingDirectory } from "@/websocket/listener/cwd-change";
 import { registerRuntimeExternalTools } from "@/websocket/listener/external-tools";
@@ -23,6 +24,7 @@ import {
 import { isRuntimeStartCommand } from "@/websocket/listener/protocol-inbound";
 import type {
   ConversationRuntime,
+  ListenerConnectionId,
   ListenerRuntime,
 } from "@/websocket/listener/types";
 import type {
@@ -40,6 +42,7 @@ type ReplaySyncStateForRuntime = (
 
 type RuntimeStartCommandContext = {
   socket: WebSocket;
+  connectionId?: ListenerConnectionId;
   runtime: ListenerRuntime;
   safeSocketSend: SafeSocketSend;
   runDetachedListenerTask: RunDetachedListenerTask;
@@ -294,14 +297,30 @@ export async function handleRuntimeStartCommand(
       created,
     );
     runtimeScope = buildRuntimeScope(agent, conversation);
+    const connectionId =
+      context.connectionId ?? context.runtime.connectionId ?? "legacy";
+    const assertConnectionOpen = () => {
+      if (
+        context.connectionId &&
+        (!context.runtime.connections.has(connectionId) ||
+          context.runtime.connections.get(connectionId)?.cancellation.signal
+            .aborted)
+      ) {
+        throw new Error("App-server connection closed during runtime start");
+      }
+    };
+    assertConnectionOpen();
     const scopedRuntime = context.getOrCreateScopedRuntime(
       context.runtime,
       runtimeScope.agent_id,
       runtimeScope.conversation_id,
     );
     await applyRuntimeStartState(parsed, context, runtimeScope, scopedRuntime);
+    assertConnectionOpen();
+    subscribeListenerConnection(context.runtime, connectionId, runtimeScope);
     registerRuntimeExternalTools(
       context.runtime,
+      connectionId,
       runtimeScope,
       parsed.external_tools ?? [],
     );

--- a/src/websocket/listener/commands/runtime-start.ts
+++ b/src/websocket/listener/commands/runtime-start.ts
@@ -42,7 +42,7 @@ type ReplaySyncStateForRuntime = (
 
 type RuntimeStartCommandContext = {
   socket: WebSocket;
-  connectionId?: ListenerConnectionId;
+  connectionId: ListenerConnectionId;
   runtime: ListenerRuntime;
   safeSocketSend: SafeSocketSend;
   runDetachedListenerTask: RunDetachedListenerTask;
@@ -297,11 +297,10 @@ export async function handleRuntimeStartCommand(
       created,
     );
     runtimeScope = buildRuntimeScope(agent, conversation);
-    const connectionId =
-      context.connectionId ?? context.runtime.connectionId ?? "legacy";
+    const { connectionId } = context;
     const assertConnectionOpen = () => {
       if (
-        context.connectionId &&
+        context.runtime.connections.size > 0 &&
         (!context.runtime.connections.has(connectionId) ||
           context.runtime.connections.get(connectionId)?.cancellation.signal
             .aborted)

--- a/src/websocket/listener/connection-lifecycle.test.ts
+++ b/src/websocket/listener/connection-lifecycle.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import WebSocket from "ws";
+import {
+  openListenerConnection,
+  subscribeListenerConnection,
+} from "./connection";
+import {
+  cleanupListenerConnection,
+  closeListenerRuntimeConnections,
+} from "./connection-lifecycle";
+import { createRuntime } from "./lifecycle";
+import type { StartListenerOptions } from "./types";
+
+class MockSocket {
+  readonly bufferedAmount = 0;
+  readyState = WebSocket.OPEN;
+  closeCalls = 0;
+  removeAllListenersCalls = 0;
+
+  isOpen(): boolean {
+    return this.readyState === WebSocket.OPEN;
+  }
+
+  send(_data: string): void {}
+
+  close(): void {
+    this.closeCalls += 1;
+  }
+
+  removeAllListeners(): this {
+    this.removeAllListenersCalls += 1;
+    return this;
+  }
+}
+
+function makeOptions(connectionId: string): StartListenerOptions {
+  return {
+    connectionId,
+    wsUrl: "ws://listener.test",
+    deviceId: connectionId,
+    connectionName: connectionId,
+    onConnected: () => {},
+    onDisconnected: () => {},
+    onError: () => {},
+  };
+}
+
+describe("listener connection lifecycle", () => {
+  test("connection cleanup preserves other subscribers", () => {
+    const runtime = createRuntime();
+    const socketA = new MockSocket();
+    const socketB = new MockSocket();
+    openListenerConnection({
+      runtime,
+      connectionId: "a",
+      writer: socketA as never,
+      options: makeOptions("a"),
+    });
+    openListenerConnection({
+      runtime,
+      connectionId: "b",
+      writer: socketB as never,
+      options: makeOptions("b"),
+    });
+    const scope = { agent_id: "agent-1", conversation_id: "conversation-1" };
+    subscribeListenerConnection(runtime, "a", scope);
+    subscribeListenerConnection(runtime, "b", scope);
+
+    cleanupListenerConnection(runtime, "b");
+
+    expect(runtime.connections.has("a")).toBe(true);
+    expect(runtime.connections.has("b")).toBe(false);
+    expect([...runtime.connectionIdsByRuntimeKey.values()][0]).toEqual(
+      new Set(["a"]),
+    );
+  });
+
+  test("global shutdown closes every socket and suppresses callbacks", () => {
+    const runtime = createRuntime();
+    const socketA = new MockSocket();
+    const socketB = new MockSocket();
+    openListenerConnection({
+      runtime,
+      connectionId: "a",
+      writer: socketA as never,
+      options: makeOptions("a"),
+    });
+    openListenerConnection({
+      runtime,
+      connectionId: "b",
+      writer: socketB as never,
+      options: makeOptions("b"),
+    });
+
+    closeListenerRuntimeConnections(runtime, true);
+
+    expect(runtime.connections.size).toBe(0);
+    expect(socketA.removeAllListenersCalls).toBe(1);
+    expect(socketB.removeAllListenersCalls).toBe(1);
+    expect(socketA.closeCalls).toBe(1);
+    expect(socketB.closeCalls).toBe(1);
+  });
+});

--- a/src/websocket/listener/connection-lifecycle.ts
+++ b/src/websocket/listener/connection-lifecycle.ts
@@ -3,7 +3,8 @@ import { killListenerConnectionTerminals } from "@/websocket/terminal-handler";
 import { rejectPendingApprovalResolversForConnection } from "./approval";
 import {
   closeListenerConnection,
-  selectListenerController,
+  getOrCreateProcessTransport,
+  getSubscribedListenerConnections,
 } from "./connection";
 import { getOrCreateScopedRuntime } from "./conversation-runtime";
 import { rejectPendingExternalToolCallsForConnection } from "./external-tools";
@@ -20,20 +21,26 @@ export function createConnectionTurnProcessor(
   runtime: ListenerRuntime,
 ): ProcessQueuedTurn {
   return async (queuedTurn, dequeuedBatch) => {
-    const connection = queuedTurn.connectionId
-      ? runtime.connections.get(queuedTurn.connectionId)
-      : selectListenerController(runtime, {
-          agent_id: queuedTurn.agentId,
-          conversation_id: queuedTurn.conversationId,
-        });
-    if (!connection || connection.cancellation.signal.aborted) {
-      return;
-    }
     const scopedRuntime = getOrCreateScopedRuntime(
       runtime,
       queuedTurn.agentId,
       queuedTurn.conversationId,
     );
+    if (!queuedTurn.connectionId) {
+      await handleIncomingMessage(
+        queuedTurn,
+        getOrCreateProcessTransport(runtime),
+        scopedRuntime,
+        undefined,
+        undefined,
+        dequeuedBatch.batchId,
+      );
+      return;
+    }
+    const connection = runtime.connections.get(queuedTurn.connectionId);
+    if (!connection || connection.cancellation.signal.aborted) {
+      return;
+    }
     await handleIncomingMessage(
       queuedTurn,
       connection.writer,
@@ -51,7 +58,15 @@ export function cleanupListenerConnection(
 ): void {
   for (const conversationRuntime of runtime.conversationRuntimes.values()) {
     if (conversationRuntime.activeConnectionId === connectionId) {
-      conversationRuntime.turnLifecycle.requestCancellation();
+      const hasEligibleFailover = getSubscribedListenerConnections(runtime, {
+        agent_id: conversationRuntime.agentId,
+        conversation_id: conversationRuntime.conversationId,
+      }).some((connection) => connection.id !== connectionId);
+      if (hasEligibleFailover) {
+        conversationRuntime.activeConnectionId = null;
+      } else {
+        conversationRuntime.turnLifecycle.requestCancellation();
+      }
     }
     for (const [
       itemId,

--- a/src/websocket/listener/connection-lifecycle.ts
+++ b/src/websocket/listener/connection-lifecycle.ts
@@ -1,0 +1,131 @@
+import WebSocket from "ws";
+import { killListenerConnectionTerminals } from "@/websocket/terminal-handler";
+import { rejectPendingApprovalResolversForConnection } from "./approval";
+import {
+  closeListenerConnection,
+  selectListenerController,
+} from "./connection";
+import { getOrCreateScopedRuntime } from "./conversation-runtime";
+import { rejectPendingExternalToolCallsForConnection } from "./external-tools";
+import { evictConversationRuntimeIfIdle } from "./runtime";
+import { getListenerTransportKind, type ListenerTransport } from "./transport";
+import { handleIncomingMessage } from "./turn";
+import type {
+  ListenerConnectionId,
+  ListenerRuntime,
+  ProcessQueuedTurn,
+} from "./types";
+
+export function createConnectionTurnProcessor(
+  runtime: ListenerRuntime,
+): ProcessQueuedTurn {
+  return async (queuedTurn, dequeuedBatch) => {
+    const connection = queuedTurn.connectionId
+      ? runtime.connections.get(queuedTurn.connectionId)
+      : selectListenerController(runtime, {
+          agent_id: queuedTurn.agentId,
+          conversation_id: queuedTurn.conversationId,
+        });
+    if (!connection || connection.cancellation.signal.aborted) {
+      return;
+    }
+    const scopedRuntime = getOrCreateScopedRuntime(
+      runtime,
+      queuedTurn.agentId,
+      queuedTurn.conversationId,
+    );
+    await handleIncomingMessage(
+      queuedTurn,
+      connection.writer,
+      scopedRuntime,
+      connection.options.onStatusChange,
+      connection.id,
+      dequeuedBatch.batchId,
+    );
+  };
+}
+
+export function cleanupListenerConnection(
+  runtime: ListenerRuntime,
+  connectionId: ListenerConnectionId,
+): void {
+  for (const conversationRuntime of runtime.conversationRuntimes.values()) {
+    if (conversationRuntime.activeConnectionId === connectionId) {
+      conversationRuntime.turnLifecycle.requestCancellation();
+    }
+    for (const [
+      itemId,
+      queuedMessage,
+    ] of conversationRuntime.queuedMessagesByItemId) {
+      if (queuedMessage.connectionId === connectionId) {
+        conversationRuntime.queueRuntime.removeItem(itemId);
+        conversationRuntime.queuedMessagesByItemId.delete(itemId);
+      }
+    }
+    rejectPendingApprovalResolversForConnection(
+      conversationRuntime,
+      connectionId,
+      "Listener connection closed",
+    );
+  }
+  rejectPendingExternalToolCallsForConnection(
+    runtime,
+    connectionId,
+    "Listener connection closed",
+  );
+  killListenerConnectionTerminals(connectionId);
+  const closedSubscriptionKeys = [
+    ...(runtime.connections.get(connectionId)?.subscriptions ?? []),
+  ];
+  closeListenerConnection(runtime, connectionId);
+  for (const runtimeKey of closedSubscriptionKeys) {
+    if (!runtime.connectionIdsByRuntimeKey.has(runtimeKey)) {
+      const scopedRuntime = runtime.conversationRuntimes.get(runtimeKey);
+      if (scopedRuntime) {
+        evictConversationRuntimeIfIdle(scopedRuntime);
+      }
+    }
+  }
+}
+
+export function closeListenerRuntimeConnections(
+  runtime: ListenerRuntime,
+  suppressCallbacks: boolean,
+): void {
+  const socketsToClose = new Set<WebSocket>();
+  const collectSocket = (transport: ListenerTransport | null | undefined) => {
+    if (transport && getListenerTransportKind(transport) === "websocket") {
+      socketsToClose.add(transport as WebSocket);
+    }
+  };
+  if (runtime.socket) {
+    socketsToClose.add(runtime.socket);
+  }
+  if (runtime.streamSocket) {
+    socketsToClose.add(runtime.streamSocket);
+  }
+  for (const connection of runtime.connections.values()) {
+    collectSocket(connection.writer);
+    collectSocket(connection.streamWriter);
+  }
+  for (const connectionId of [...runtime.connections.keys()]) {
+    closeListenerConnection(runtime, connectionId);
+  }
+  runtime.connectionIdsByRuntimeKey.clear();
+  runtime.socket = null;
+  runtime.transport = null;
+  runtime.streamSocket = null;
+  runtime.streamTransport = null;
+
+  for (const socket of socketsToClose) {
+    if (suppressCallbacks) {
+      socket.removeAllListeners();
+    }
+    if (
+      socket.readyState === WebSocket.OPEN ||
+      socket.readyState === WebSocket.CONNECTING
+    ) {
+      socket.close();
+    }
+  }
+}

--- a/src/websocket/listener/connection-state-sync.test.ts
+++ b/src/websocket/listener/connection-state-sync.test.ts
@@ -1,11 +1,16 @@
 import { expect, test } from "bun:test";
-import { openListenerConnection } from "./connection";
+import { isQueueBridgeConnected } from "@/utils/message-queue-bridge";
+import {
+  openListenerConnection,
+  suspendListenerConnection,
+} from "./connection";
 import { getOrCreateScopedRuntime } from "./conversation-runtime";
 import {
   createRuntime,
   startConnectedListenerRuntime,
   stopRuntime,
 } from "./lifecycle";
+import { invalidateProcessServices } from "./process-services";
 import { setActiveRuntime } from "./runtime";
 import type { LocalTransport } from "./transport";
 import type { StartListenerOptions } from "./types";
@@ -138,6 +143,100 @@ test("failed process-service initialization can be retried", async () => {
     expect(initializationAttempts).toBe(2);
     expect(runtime.processServicesStarted).toBe(true);
   } finally {
+    stopRuntime(runtime, true);
+    setActiveRuntime(null);
+  }
+});
+
+test("outbound reconnect replaces an initialization invalidated by disconnect", async () => {
+  const runtime = createRuntime();
+  const options: StartListenerOptions = {
+    connectionId: "outbound-client",
+    wsUrl: "ws://relay.test",
+    deviceId: "test-device",
+    connectionName: "outbound-client",
+    onConnected: () => {},
+    onDisconnected: () => {},
+    onError: () => {},
+  };
+  const gates: Array<() => void> = [];
+  const initializeChannels = () =>
+    new Promise<void>((resolve) => {
+      gates.push(resolve);
+    });
+  const firstTransport = new MockTransport();
+  openListenerConnection({
+    runtime,
+    connectionId: options.connectionId,
+    writer: firstTransport,
+    options,
+  });
+  setActiveRuntime(runtime);
+
+  try {
+    const firstStart = startConnectedListenerRuntime(
+      runtime,
+      firstTransport,
+      options,
+      async () => {},
+      {
+        startHeartbeat: false,
+        startCronScheduler: false,
+        emitInitialState: false,
+        wireChannelIngress: initializeChannels,
+      },
+    );
+    for (let attempt = 0; gates.length < 1 && attempt < 10; attempt += 1) {
+      await Promise.resolve();
+    }
+    expect(gates).toHaveLength(1);
+    expect(isQueueBridgeConnected()).toBe(true);
+
+    invalidateProcessServices(runtime);
+    suspendListenerConnection(runtime, options.connectionId);
+    expect(isQueueBridgeConnected()).toBe(false);
+    expect(runtime.processServicesStarted).toBe(false);
+    expect(runtime.processServicesReady).not.toBeNull();
+
+    const secondTransport = new MockTransport();
+    openListenerConnection({
+      runtime,
+      connectionId: options.connectionId,
+      writer: secondTransport,
+      options,
+    });
+    const reconnectStart = startConnectedListenerRuntime(
+      runtime,
+      secondTransport,
+      options,
+      async () => {},
+      {
+        startHeartbeat: false,
+        startCronScheduler: false,
+        emitInitialState: false,
+        wireChannelIngress: initializeChannels,
+      },
+    );
+    await Promise.resolve();
+    expect(gates).toHaveLength(1);
+
+    gates[0]?.();
+    await firstStart;
+    for (let attempt = 0; gates.length < 2 && attempt < 10; attempt += 1) {
+      await Promise.resolve();
+    }
+    expect(gates).toHaveLength(2);
+    expect(isQueueBridgeConnected()).toBe(true);
+    expect(runtime.processServicesStarted).toBe(false);
+
+    gates[1]?.();
+    await reconnectStart;
+    expect(isQueueBridgeConnected()).toBe(true);
+    expect(runtime.processServicesStarted).toBe(true);
+    expect(runtime.processServicesReady).toBeNull();
+    expect(runtime.processServicesReadyGeneration).toBeNull();
+  } finally {
+    for (const resolve of gates) resolve();
     stopRuntime(runtime, true);
     setActiveRuntime(null);
   }

--- a/src/websocket/listener/connection-state-sync.test.ts
+++ b/src/websocket/listener/connection-state-sync.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test";
+import { openListenerConnection } from "./connection";
+import { getOrCreateScopedRuntime } from "./conversation-runtime";
+import { createRuntime, startConnectedListenerRuntime } from "./lifecycle";
+import { setActiveRuntime } from "./runtime";
+import type { LocalTransport } from "./transport";
+import type { StartListenerOptions } from "./types";
+
+class MockTransport implements LocalTransport {
+  readonly kind = "local" as const;
+  readonly bufferedAmount = 0;
+  readonly sent: string[] = [];
+
+  isOpen(): boolean {
+    return true;
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+}
+
+test("an unsubscribed app-server connection receives no existing runtime state", async () => {
+  const runtime = createRuntime();
+  const transport = new MockTransport();
+  const options: StartListenerOptions = {
+    connectionId: "new-client",
+    wsUrl: "local://app-server",
+    deviceId: "test-device",
+    connectionName: "new-client",
+    onConnected: () => {},
+    onDisconnected: () => {},
+    onError: () => {},
+  };
+  getOrCreateScopedRuntime(runtime, "private-agent", "private-conversation");
+  openListenerConnection({
+    runtime,
+    connectionId: options.connectionId,
+    writer: transport,
+    options,
+  });
+  runtime.processServicesStarted = true;
+  setActiveRuntime(runtime);
+
+  try {
+    await startConnectedListenerRuntime(
+      runtime,
+      transport,
+      options,
+      async () => {},
+      {
+        startHeartbeat: false,
+        startCronScheduler: false,
+        emitInitialState: false,
+      },
+    );
+    expect(transport.sent).toEqual([]);
+  } finally {
+    setActiveRuntime(null);
+  }
+});

--- a/src/websocket/listener/connection-state-sync.test.ts
+++ b/src/websocket/listener/connection-state-sync.test.ts
@@ -1,7 +1,11 @@
 import { expect, test } from "bun:test";
 import { openListenerConnection } from "./connection";
 import { getOrCreateScopedRuntime } from "./conversation-runtime";
-import { createRuntime, startConnectedListenerRuntime } from "./lifecycle";
+import {
+  createRuntime,
+  startConnectedListenerRuntime,
+  stopRuntime,
+} from "./lifecycle";
 import { setActiveRuntime } from "./runtime";
 import type { LocalTransport } from "./transport";
 import type { StartListenerOptions } from "./types";
@@ -56,6 +60,85 @@ test("an unsubscribed app-server connection receives no existing runtime state",
     );
     expect(transport.sent).toEqual([]);
   } finally {
+    stopRuntime(runtime, true);
+    setActiveRuntime(null);
+  }
+});
+
+test("failed process-service initialization can be retried", async () => {
+  const runtime = createRuntime();
+  const firstTransport = new MockTransport();
+  const firstOptions: StartListenerOptions = {
+    connectionId: "first-client",
+    wsUrl: "local://app-server",
+    deviceId: "test-device",
+    connectionName: "first-client",
+    onConnected: () => {},
+    onDisconnected: () => {},
+    onError: () => {},
+  };
+  openListenerConnection({
+    runtime,
+    connectionId: firstOptions.connectionId,
+    writer: firstTransport,
+    options: firstOptions,
+  });
+  let initializationAttempts = 0;
+  const initializeChannels = async () => {
+    initializationAttempts += 1;
+    if (initializationAttempts === 1) {
+      throw new Error("channel recovery failed");
+    }
+  };
+  setActiveRuntime(runtime);
+
+  try {
+    await expect(
+      startConnectedListenerRuntime(
+        runtime,
+        firstTransport,
+        firstOptions,
+        async () => {},
+        {
+          startHeartbeat: false,
+          startCronScheduler: false,
+          emitInitialState: false,
+          wireChannelIngress: initializeChannels,
+        },
+      ),
+    ).rejects.toThrow("channel recovery failed");
+    expect(runtime.processServicesStarted).toBe(false);
+    expect(runtime.processServicesReady).toBeNull();
+
+    const secondTransport = new MockTransport();
+    const secondOptions = {
+      ...firstOptions,
+      connectionId: "second-client",
+      connectionName: "second-client",
+    };
+    openListenerConnection({
+      runtime,
+      connectionId: secondOptions.connectionId,
+      writer: secondTransport,
+      options: secondOptions,
+    });
+    await startConnectedListenerRuntime(
+      runtime,
+      secondTransport,
+      secondOptions,
+      async () => {},
+      {
+        startHeartbeat: false,
+        startCronScheduler: false,
+        emitInitialState: false,
+        wireChannelIngress: initializeChannels,
+      },
+    );
+
+    expect(initializationAttempts).toBe(2);
+    expect(runtime.processServicesStarted).toBe(true);
+  } finally {
+    stopRuntime(runtime, true);
     setActiveRuntime(null);
   }
 });

--- a/src/websocket/listener/connection-state-sync.ts
+++ b/src/websocket/listener/connection-state-sync.ts
@@ -1,0 +1,57 @@
+import type { RuntimeScope } from "@/types/protocol_v2";
+import { replayPendingApprovalRequestsToConnection } from "./approval";
+import {
+  findListenerConnectionByTransport,
+  toListenerConnection,
+} from "./connection";
+import {
+  emitDeviceStatusUpdate,
+  emitLoopStatusUpdate,
+  emitStateSync,
+} from "./protocol-outbound";
+import type { ListenerTransport } from "./transport";
+import type {
+  ConversationRuntime,
+  ListenerConnectionId,
+  ListenerRuntime,
+} from "./types";
+
+export function emitInitialConnectionState(
+  runtime: ListenerRuntime,
+  transport: ListenerTransport,
+  connectionId: ListenerConnectionId,
+  options: { emitInitialState?: boolean } = {},
+): void {
+  if (options.emitInitialState === false) return;
+  const routing = toListenerConnection(connectionId);
+  if (runtime.conversationRuntimes.size === 0) {
+    emitLoopStatusUpdate(transport, runtime, undefined, routing);
+    return;
+  }
+
+  for (const conversationRuntime of runtime.conversationRuntimes.values()) {
+    const scope = {
+      agent_id: conversationRuntime.agentId,
+      conversation_id: conversationRuntime.conversationId,
+    };
+    emitDeviceStatusUpdate(transport, conversationRuntime, scope, routing);
+    emitLoopStatusUpdate(transport, conversationRuntime, scope, routing);
+  }
+}
+
+export function replaySubscribedConnectionState(
+  listener: ListenerRuntime,
+  transport: ListenerTransport,
+  runtime: ConversationRuntime,
+  scope: RuntimeScope,
+  forceDeviceStatus?: boolean,
+): void {
+  const connection = findListenerConnectionByTransport(listener, transport);
+  if (connection) {
+    replayPendingApprovalRequestsToConnection(runtime, connection.id);
+  }
+  emitStateSync(transport, listener, scope, {
+    forceDeviceStatus,
+    ...(connection ? { routing: toListenerConnection(connection.id) } : {}),
+  });
+}

--- a/src/websocket/listener/connection.test.ts
+++ b/src/websocket/listener/connection.test.ts
@@ -6,8 +6,10 @@ import {
   getSubscribedListenerConnections,
   markListenerConnectionInitialized,
   openListenerConnection,
-  selectListenerController,
+  resolveListenerConnectionTargets,
   subscribeListenerConnection,
+  TO_SUBSCRIBERS,
+  toListenerConnection,
 } from "./connection";
 import { createRuntime } from "./lifecycle";
 import type { LocalTransport } from "./transport";
@@ -79,20 +81,41 @@ describe("listener connection identity", () => {
     expect(runtime.connections.get("client-c")?.subscriptions.size).toBe(0);
   });
 
-  test("selects the origin or oldest subscriber deterministically", () => {
+  test("resolves only the explicitly requested destination class", () => {
     const { runtime, writer: writerA } = addConnection("client-a");
     const { writer: writerB } = addConnection("client-b", runtime);
+    const { writer: writerC } = addConnection("client-c", runtime);
     const scope = { agent_id: "agent-1", conversation_id: "conversation-1" };
     subscribeListenerConnection(runtime, "client-a", scope);
     subscribeListenerConnection(runtime, "client-b", scope);
 
-    expect(selectListenerController(runtime, scope, writerB)?.id).toBe(
-      "client-b",
-    );
-    expect(selectListenerController(runtime, scope)?.id).toBe("client-a");
-    expect(selectListenerController(runtime, scope, writerA)?.id).toBe(
-      "client-a",
-    );
+    expect(
+      resolveListenerConnectionTargets({
+        runtime,
+        origin: writerC,
+        scope,
+        routing: TO_SUBSCRIBERS,
+        streamMessage: false,
+      }).map((target) => target.connection?.id),
+    ).toEqual(["client-a", "client-b"]);
+    expect(
+      resolveListenerConnectionTargets({
+        runtime,
+        origin: writerA,
+        scope,
+        routing: toListenerConnection("client-b"),
+        streamMessage: false,
+      }).map((target) => target.connection?.id),
+    ).toEqual(["client-b"]);
+    expect(
+      resolveListenerConnectionTargets({
+        runtime,
+        origin: writerB,
+        scope,
+        routing: { type: "Broadcast" },
+        streamMessage: false,
+      }).map((target) => target.connection?.id),
+    ).toEqual(["client-a", "client-b", "client-c"]);
   });
 
   test("closing one connection removes only its subscriptions", () => {
@@ -113,7 +136,7 @@ describe("listener connection identity", () => {
     ).toEqual(["client-a"]);
   });
 
-  test("the process transport broadcasts only to initialized live clients", () => {
+  test("the process transport rejects implicit broadcast sends", () => {
     const { runtime, writer: writerA } = addConnection("client-a");
     const writerB = new MockTransport();
     openListenerConnection({
@@ -125,10 +148,24 @@ describe("listener connection identity", () => {
     const { writer: writerC } = addConnection("client-c", runtime);
     writerC.open = false;
 
-    getOrCreateProcessTransport(runtime).send("process-event");
+    expect(() =>
+      getOrCreateProcessTransport(runtime).send("process-event"),
+    ).toThrow("cannot send an implicit message");
 
-    expect(writerA.sent).toEqual(["process-event"]);
+    expect(writerA.sent).toEqual([]);
     expect(writerB.sent).toEqual([]);
     expect(writerC.sent).toEqual([]);
+  });
+
+  test("a scoped route with no subscribers resolves to zero clients", () => {
+    const { runtime, writer } = addConnection("client-a");
+    const targets = resolveListenerConnectionTargets({
+      runtime,
+      origin: writer,
+      scope: { agent_id: "agent-2", conversation_id: "conversation-2" },
+      routing: TO_SUBSCRIBERS,
+      streamMessage: false,
+    });
+    expect(targets).toEqual([]);
   });
 });

--- a/src/websocket/listener/connection.test.ts
+++ b/src/websocket/listener/connection.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import {
+  closeListenerConnection,
+  createConnectionRequestKey,
+  getOrCreateProcessTransport,
+  getSubscribedListenerConnections,
+  markListenerConnectionInitialized,
+  openListenerConnection,
+  selectListenerController,
+  subscribeListenerConnection,
+} from "./connection";
+import { createRuntime } from "./lifecycle";
+import type { LocalTransport } from "./transport";
+import type { StartListenerOptions } from "./types";
+
+class MockTransport implements LocalTransport {
+  readonly kind = "local" as const;
+  readonly bufferedAmount = 0;
+  readonly sent: string[] = [];
+  open = true;
+
+  isOpen(): boolean {
+    return this.open;
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+}
+
+function options(connectionId: string): StartListenerOptions {
+  return {
+    connectionId,
+    wsUrl: "local://test",
+    deviceId: "test-device",
+    connectionName: connectionId,
+    onConnected: () => {},
+    onDisconnected: () => {},
+    onError: () => {},
+  };
+}
+
+function addConnection(
+  connectionId: string,
+  runtime = createRuntime(),
+): { runtime: ReturnType<typeof createRuntime>; writer: MockTransport } {
+  const writer = new MockTransport();
+  openListenerConnection({
+    runtime,
+    connectionId,
+    writer,
+    options: options(connectionId),
+  });
+  markListenerConnectionInitialized(runtime, connectionId);
+  return { runtime, writer };
+}
+
+describe("listener connection identity", () => {
+  test("correlates identical wire request ids by connection", () => {
+    expect(createConnectionRequestKey("client-a", "request-1")).not.toBe(
+      createConnectionRequestKey("client-b", "request-1"),
+    );
+  });
+
+  test("tracks multiple subscribers without choosing an owner", () => {
+    const { runtime } = addConnection("client-a");
+    addConnection("client-b", runtime);
+    addConnection("client-c", runtime);
+    const scope = { agent_id: "agent-1", conversation_id: "conversation-1" };
+
+    subscribeListenerConnection(runtime, "client-a", scope);
+    subscribeListenerConnection(runtime, "client-b", scope);
+
+    expect(
+      getSubscribedListenerConnections(runtime, scope).map(
+        (connection) => connection.id,
+      ),
+    ).toEqual(["client-a", "client-b"]);
+    expect(runtime.connections.get("client-c")?.subscriptions.size).toBe(0);
+  });
+
+  test("selects the origin or oldest subscriber deterministically", () => {
+    const { runtime, writer: writerA } = addConnection("client-a");
+    const { writer: writerB } = addConnection("client-b", runtime);
+    const scope = { agent_id: "agent-1", conversation_id: "conversation-1" };
+    subscribeListenerConnection(runtime, "client-a", scope);
+    subscribeListenerConnection(runtime, "client-b", scope);
+
+    expect(selectListenerController(runtime, scope, writerB)?.id).toBe(
+      "client-b",
+    );
+    expect(selectListenerController(runtime, scope)?.id).toBe("client-a");
+    expect(selectListenerController(runtime, scope, writerA)?.id).toBe(
+      "client-a",
+    );
+  });
+
+  test("closing one connection removes only its subscriptions", () => {
+    const { runtime } = addConnection("client-a");
+    addConnection("client-b", runtime);
+    const scope = { agent_id: "agent-1", conversation_id: "conversation-1" };
+    subscribeListenerConnection(runtime, "client-a", scope);
+    subscribeListenerConnection(runtime, "client-b", scope);
+
+    closeListenerConnection(runtime, "client-b");
+
+    expect(runtime.connections.has("client-b")).toBe(false);
+    expect(runtime.connections.has("client-a")).toBe(true);
+    expect(
+      getSubscribedListenerConnections(runtime, scope).map(
+        (connection) => connection.id,
+      ),
+    ).toEqual(["client-a"]);
+  });
+
+  test("the process transport broadcasts only to initialized live clients", () => {
+    const { runtime, writer: writerA } = addConnection("client-a");
+    const writerB = new MockTransport();
+    openListenerConnection({
+      runtime,
+      connectionId: "client-b",
+      writer: writerB,
+      options: options("client-b"),
+    });
+    const { writer: writerC } = addConnection("client-c", runtime);
+    writerC.open = false;
+
+    getOrCreateProcessTransport(runtime).send("process-event");
+
+    expect(writerA.sent).toEqual(["process-event"]);
+    expect(writerB.sent).toEqual([]);
+    expect(writerC.sent).toEqual([]);
+  });
+});

--- a/src/websocket/listener/connection.ts
+++ b/src/websocket/listener/connection.ts
@@ -1,0 +1,332 @@
+import type WebSocket from "ws";
+import { getConversationRuntimeKey, nextEventSeq } from "./runtime";
+import {
+  isListenerTransportOpen,
+  type ListenerTransport,
+  type RuntimeTransport,
+} from "./transport";
+import type {
+  ListenerConnectionId,
+  ListenerConnectionState,
+  ListenerRuntime,
+  StartListenerOptions,
+} from "./types";
+
+function socketForTransport(transport: ListenerTransport): WebSocket | null {
+  return "kind" in transport ? null : transport;
+}
+
+function refreshPrimaryConnection(runtime: ListenerRuntime): void {
+  const next = [...(runtime.connections?.values() ?? [])]
+    .filter((connection) => isListenerTransportOpen(connection.writer))
+    .sort((a, b) => a.ordinal - b.ordinal)[0];
+  runtime.transport = next?.writer ?? runtime.processTransport;
+  runtime.streamTransport = next?.streamWriter ?? null;
+  runtime.socket = next ? socketForTransport(next.writer) : null;
+  runtime.streamSocket = next?.streamWriter
+    ? socketForTransport(next.streamWriter)
+    : null;
+}
+
+export function createConnectionRequestKey(
+  connectionId: ListenerConnectionId,
+  requestId: string,
+): string {
+  return JSON.stringify([connectionId, requestId]);
+}
+
+export function openListenerConnection(params: {
+  runtime: ListenerRuntime;
+  connectionId: ListenerConnectionId;
+  writer: ListenerTransport;
+  streamWriter?: ListenerTransport | null;
+  cancellation?: AbortController;
+  options: StartListenerOptions;
+}): ListenerConnectionState {
+  const existing = params.runtime.connections?.get(params.connectionId);
+  if (existing) {
+    throw new Error(`Listener connection already open: ${params.connectionId}`);
+  }
+
+  const connection: ListenerConnectionState = {
+    id: params.connectionId,
+    ordinal: params.runtime.nextConnectionOrdinal,
+    writer: params.writer,
+    streamWriter: params.streamWriter ?? null,
+    cancellation: params.cancellation ?? new AbortController(),
+    initialized: false,
+    subscriptions: new Set(),
+    eventSeqCounter: 0,
+    options: params.options,
+  };
+  params.runtime.nextConnectionOrdinal ??= 0;
+  params.runtime.nextConnectionOrdinal += 1;
+  params.runtime.connections ??= new Map();
+  params.runtime.connectionIdsByRuntimeKey ??= new Map();
+  params.runtime.connections.set(connection.id, connection);
+  refreshPrimaryConnection(params.runtime);
+  return connection;
+}
+
+export function markListenerConnectionInitialized(
+  runtime: ListenerRuntime,
+  connectionId: ListenerConnectionId,
+): void {
+  const connection = runtime.connections?.get(connectionId);
+  if (connection) {
+    connection.initialized = true;
+  }
+}
+
+export function subscribeListenerConnection(
+  runtime: ListenerRuntime,
+  connectionId: ListenerConnectionId,
+  scope: { agent_id?: string | null; conversation_id?: string | null },
+): boolean {
+  const connection = runtime.connections?.get(connectionId);
+  if (!connection || typeof scope.agent_id !== "string") {
+    return false;
+  }
+  const runtimeKey = getConversationRuntimeKey(
+    scope.agent_id,
+    scope.conversation_id,
+  );
+  connection.subscriptions.add(runtimeKey);
+  runtime.connectionIdsByRuntimeKey ??= new Map();
+  let connectionIds = runtime.connectionIdsByRuntimeKey.get(runtimeKey);
+  if (!connectionIds) {
+    connectionIds = new Set();
+    runtime.connectionIdsByRuntimeKey.set(runtimeKey, connectionIds);
+  }
+  connectionIds.add(connectionId);
+  return true;
+}
+
+export function unsubscribeListenerConnection(
+  runtime: ListenerRuntime,
+  connectionId: ListenerConnectionId,
+  runtimeKey: string,
+): boolean {
+  const connection = runtime.connections?.get(connectionId);
+  if (!connection?.subscriptions.delete(runtimeKey)) {
+    return false;
+  }
+  const connectionIds = runtime.connectionIdsByRuntimeKey?.get(runtimeKey);
+  connectionIds?.delete(connectionId);
+  if (connectionIds?.size === 0) {
+    runtime.connectionIdsByRuntimeKey.delete(runtimeKey);
+  }
+  return true;
+}
+
+export function getSubscribedListenerConnections(
+  runtime: ListenerRuntime,
+  scope: { agent_id?: string | null; conversation_id?: string | null },
+): ListenerConnectionState[] {
+  if (typeof scope.agent_id !== "string") {
+    return [];
+  }
+  const runtimeKey = getConversationRuntimeKey(
+    scope.agent_id,
+    scope.conversation_id,
+  );
+  const connectionIds = runtime.connectionIdsByRuntimeKey?.get(runtimeKey);
+  if (!connectionIds) {
+    return [];
+  }
+  return [...connectionIds]
+    .map((connectionId) => runtime.connections?.get(connectionId))
+    .filter(
+      (connection): connection is ListenerConnectionState =>
+        connection?.initialized === true &&
+        isListenerTransportOpen(connection.writer),
+    )
+    .sort((a, b) => a.ordinal - b.ordinal);
+}
+
+export function findListenerConnectionByTransport(
+  runtime: ListenerRuntime,
+  transport: ListenerTransport,
+): ListenerConnectionState | null {
+  for (const connection of runtime.connections?.values() ?? []) {
+    if (
+      connection.writer === transport ||
+      connection.streamWriter === transport
+    ) {
+      return connection;
+    }
+  }
+  return null;
+}
+
+export interface ListenerConnectionTarget {
+  connection: ListenerConnectionState | null;
+  transport: ListenerTransport;
+}
+
+export function nextListenerConnectionEventSeq(
+  connection: ListenerConnectionState | null,
+  runtime: ListenerRuntime | null,
+): number | null {
+  if (!connection) {
+    return nextEventSeq(runtime);
+  }
+  connection.eventSeqCounter += 1;
+  return connection.eventSeqCounter;
+}
+
+export function resolveListenerConnectionTargets(params: {
+  runtime: ListenerRuntime | null;
+  origin: ListenerTransport;
+  scope: { agent_id?: string | null; conversation_id?: string | null };
+  connectionId?: ListenerConnectionId;
+  subscribers: boolean;
+  streamMessage: boolean;
+}): ListenerConnectionTarget[] {
+  const explicitConnection = params.connectionId
+    ? params.runtime?.connections.get(params.connectionId)
+    : undefined;
+  const subscribedConnections =
+    params.runtime && params.subscribers
+      ? getSubscribedListenerConnections(params.runtime, params.scope)
+      : [];
+  const originConnection = params.runtime
+    ? findListenerConnectionByTransport(params.runtime, params.origin)
+    : null;
+  const connections: Array<ListenerConnectionState | null> = explicitConnection
+    ? [explicitConnection]
+    : subscribedConnections.length > 0
+      ? subscribedConnections
+      : originConnection
+        ? [originConnection]
+        : [null];
+
+  return connections.map((connection) => {
+    const streamTransport = connection?.streamWriter;
+    if (
+      params.streamMessage &&
+      streamTransport &&
+      isListenerTransportOpen(streamTransport)
+    ) {
+      return { connection, transport: streamTransport };
+    }
+    const legacyStreamTransport = params.runtime?.streamTransport;
+    if (
+      !connection &&
+      params.streamMessage &&
+      legacyStreamTransport &&
+      isListenerTransportOpen(legacyStreamTransport)
+    ) {
+      return { connection, transport: legacyStreamTransport };
+    }
+    return { connection, transport: connection?.writer ?? params.origin };
+  });
+}
+
+/**
+ * Prefer the connection that initiated the operation. Background/channel
+ * operations use the oldest live subscriber, matching Codex's deterministic
+ * lowest-ConnectionId controller selection.
+ */
+export function selectListenerController(
+  runtime: ListenerRuntime,
+  scope: { agent_id?: string | null; conversation_id?: string | null },
+  preferredTransport?: ListenerTransport,
+): ListenerConnectionState | null {
+  if (preferredTransport) {
+    const preferred = findListenerConnectionByTransport(
+      runtime,
+      preferredTransport,
+    );
+    if (
+      preferred &&
+      preferred.initialized &&
+      isListenerTransportOpen(preferred.writer)
+    ) {
+      return preferred;
+    }
+    if (isListenerTransportOpen(preferredTransport)) {
+      return {
+        id: runtime.connectionId ?? "legacy",
+        ordinal: -1,
+        writer: preferredTransport,
+        streamWriter: null,
+        cancellation: new AbortController(),
+        initialized: true,
+        subscriptions: new Set(),
+        eventSeqCounter: runtime.eventSeqCounter,
+        options: {
+          connectionId: runtime.connectionId ?? "legacy",
+          wsUrl: "legacy://listener",
+          deviceId: "legacy",
+          connectionName: runtime.connectionName ?? "legacy",
+          onConnected: () => {},
+          onDisconnected: () => {},
+          onError: () => {},
+        },
+      };
+    }
+  }
+  return getSubscribedListenerConnections(runtime, scope)[0] ?? null;
+}
+
+export function closeListenerConnection(
+  runtime: ListenerRuntime,
+  connectionId: ListenerConnectionId,
+): ListenerConnectionState | null {
+  const connection = runtime.connections?.get(connectionId);
+  if (!connection) {
+    return null;
+  }
+  for (const runtimeKey of [...connection.subscriptions]) {
+    unsubscribeListenerConnection(runtime, connectionId, runtimeKey);
+  }
+  runtime.connections?.delete(connectionId);
+  connection.cancellation.abort();
+  refreshPrimaryConnection(runtime);
+  return connection;
+}
+
+class ProcessRuntimeTransport implements RuntimeTransport {
+  readonly kind = "runtime" as const;
+
+  constructor(private readonly runtime: ListenerRuntime) {}
+
+  get bufferedAmount(): number {
+    let total = 0;
+    for (const connection of this.runtime.connections?.values() ?? []) {
+      total += connection.writer.bufferedAmount;
+    }
+    return total;
+  }
+
+  isOpen(): boolean {
+    for (const connection of this.runtime.connections?.values() ?? []) {
+      if (
+        connection.initialized &&
+        isListenerTransportOpen(connection.writer)
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  send(data: string): void {
+    for (const connection of this.runtime.connections?.values() ?? []) {
+      if (
+        connection.initialized &&
+        isListenerTransportOpen(connection.writer)
+      ) {
+        connection.writer.send(data);
+      }
+    }
+  }
+}
+
+export function getOrCreateProcessTransport(
+  runtime: ListenerRuntime,
+): ListenerTransport {
+  runtime.processTransport ??= new ProcessRuntimeTransport(runtime);
+  return runtime.processTransport;
+}

--- a/src/websocket/listener/connection.ts
+++ b/src/websocket/listener/connection.ts
@@ -27,12 +27,34 @@ export function toListenerConnection(
   return { type: "ToConnection", connectionId };
 }
 
+type ListenerConnectionResumeState = {
+  ordinal: number;
+  subscriptions: Set<string>;
+  eventSeqCounter: number;
+};
+
+const resumeStateByRuntime = new WeakMap<
+  ListenerRuntime,
+  Map<ListenerConnectionId, ListenerConnectionResumeState>
+>();
+
+function getResumeStates(
+  runtime: ListenerRuntime,
+): Map<ListenerConnectionId, ListenerConnectionResumeState> {
+  let states = resumeStateByRuntime.get(runtime);
+  if (!states) {
+    states = new Map();
+    resumeStateByRuntime.set(runtime, states);
+  }
+  return states;
+}
+
 function socketForTransport(transport: ListenerTransport): WebSocket | null {
   return "kind" in transport ? null : transport;
 }
 
 function refreshLegacySingleConnection(runtime: ListenerRuntime): void {
-  const live = [...(runtime.connections?.values() ?? [])].filter((connection) =>
+  const live = [...runtime.connections.values()].filter((connection) =>
     isListenerTransportOpen(connection.writer),
   );
   const only = live.length === 1 ? live[0] : null;
@@ -59,27 +81,38 @@ export function openListenerConnection(params: {
   cancellation?: AbortController;
   options: StartListenerOptions;
 }): ListenerConnectionState {
-  const existing = params.runtime.connections?.get(params.connectionId);
+  const existing = params.runtime.connections.get(params.connectionId);
   if (existing) {
     throw new Error(`Listener connection already open: ${params.connectionId}`);
   }
 
+  const resumeStates = getResumeStates(params.runtime);
+  const resumed = resumeStates.get(params.connectionId);
+  resumeStates.delete(params.connectionId);
   const connection: ListenerConnectionState = {
     id: params.connectionId,
-    ordinal: params.runtime.nextConnectionOrdinal,
+    ordinal: resumed?.ordinal ?? params.runtime.nextConnectionOrdinal,
     writer: params.writer,
     streamWriter: params.streamWriter ?? null,
     cancellation: params.cancellation ?? new AbortController(),
     initialized: false,
-    subscriptions: new Set(),
-    eventSeqCounter: 0,
+    subscriptions: resumed?.subscriptions ?? new Set(),
+    eventSeqCounter: resumed?.eventSeqCounter ?? 0,
     options: params.options,
   };
-  params.runtime.nextConnectionOrdinal ??= 0;
-  params.runtime.nextConnectionOrdinal += 1;
-  params.runtime.connections ??= new Map();
-  params.runtime.connectionIdsByRuntimeKey ??= new Map();
+  if (!resumed) {
+    params.runtime.nextConnectionOrdinal += 1;
+  }
   params.runtime.connections.set(connection.id, connection);
+  for (const runtimeKey of connection.subscriptions) {
+    let connectionIds =
+      params.runtime.connectionIdsByRuntimeKey.get(runtimeKey);
+    if (!connectionIds) {
+      connectionIds = new Set();
+      params.runtime.connectionIdsByRuntimeKey.set(runtimeKey, connectionIds);
+    }
+    connectionIds.add(connection.id);
+  }
   refreshLegacySingleConnection(params.runtime);
   return connection;
 }
@@ -88,7 +121,7 @@ export function markListenerConnectionInitialized(
   runtime: ListenerRuntime,
   connectionId: ListenerConnectionId,
 ): void {
-  const connection = runtime.connections?.get(connectionId);
+  const connection = runtime.connections.get(connectionId);
   if (connection) {
     connection.initialized = true;
   }
@@ -99,7 +132,7 @@ export function subscribeListenerConnection(
   connectionId: ListenerConnectionId,
   scope: { agent_id?: string | null; conversation_id?: string | null },
 ): boolean {
-  const connection = runtime.connections?.get(connectionId);
+  const connection = runtime.connections.get(connectionId);
   if (!connection || typeof scope.agent_id !== "string") {
     return false;
   }
@@ -108,7 +141,6 @@ export function subscribeListenerConnection(
     scope.conversation_id,
   );
   connection.subscriptions.add(runtimeKey);
-  runtime.connectionIdsByRuntimeKey ??= new Map();
   let connectionIds = runtime.connectionIdsByRuntimeKey.get(runtimeKey);
   if (!connectionIds) {
     connectionIds = new Set();
@@ -123,11 +155,11 @@ export function unsubscribeListenerConnection(
   connectionId: ListenerConnectionId,
   runtimeKey: string,
 ): boolean {
-  const connection = runtime.connections?.get(connectionId);
+  const connection = runtime.connections.get(connectionId);
   if (!connection?.subscriptions.delete(runtimeKey)) {
     return false;
   }
-  const connectionIds = runtime.connectionIdsByRuntimeKey?.get(runtimeKey);
+  const connectionIds = runtime.connectionIdsByRuntimeKey.get(runtimeKey);
   connectionIds?.delete(connectionId);
   if (connectionIds?.size === 0) {
     runtime.connectionIdsByRuntimeKey.delete(runtimeKey);
@@ -146,12 +178,12 @@ export function getSubscribedListenerConnections(
     scope.agent_id,
     scope.conversation_id,
   );
-  const connectionIds = runtime.connectionIdsByRuntimeKey?.get(runtimeKey);
+  const connectionIds = runtime.connectionIdsByRuntimeKey.get(runtimeKey);
   if (!connectionIds) {
     return [];
   }
   return [...connectionIds]
-    .map((connectionId) => runtime.connections?.get(connectionId))
+    .map((connectionId) => runtime.connections.get(connectionId))
     .filter(
       (connection): connection is ListenerConnectionState =>
         connection?.initialized === true &&
@@ -164,7 +196,7 @@ export function findListenerConnectionByTransport(
   runtime: ListenerRuntime,
   transport: ListenerTransport,
 ): ListenerConnectionState | null {
-  for (const connection of runtime.connections?.values() ?? []) {
+  for (const connection of runtime.connections.values()) {
     if (
       connection.writer === transport ||
       connection.streamWriter === transport
@@ -213,7 +245,7 @@ export function resolveListenerConnectionTargets(params: {
       // single transport while the local app-server always has tracked
       // connections and therefore cannot enter this compatibility branch.
       if (
-        (runtime?.connections?.size ?? 0) === 0 &&
+        (runtime?.connections.size ?? 0) === 0 &&
         params.routing.connectionId === (runtime?.connectionId ?? "legacy")
       ) {
         connections = [null];
@@ -232,7 +264,7 @@ export function resolveListenerConnectionTargets(params: {
       // transport. This does not apply to app-server connections: once a
       // connection map exists, a scoped message with no subscribers is
       // dropped, matching Codex.
-      if ((runtime?.connections?.size ?? 0) === 0) {
+      if ((runtime?.connections.size ?? 0) === 0) {
         connections = [null];
         break;
       }
@@ -246,7 +278,7 @@ export function resolveListenerConnectionTargets(params: {
               isListenerTransportOpen(connection.writer),
           )
         : [];
-      if (connections.length === 0 && (runtime?.connections?.size ?? 0) === 0) {
+      if (connections.length === 0 && (runtime?.connections.size ?? 0) === 0) {
         connections = [null];
       }
       break;
@@ -279,17 +311,36 @@ export function closeListenerConnection(
   runtime: ListenerRuntime,
   connectionId: ListenerConnectionId,
 ): ListenerConnectionState | null {
-  const connection = runtime.connections?.get(connectionId);
+  getResumeStates(runtime).delete(connectionId);
+  const connection = runtime.connections.get(connectionId);
   if (!connection) {
     return null;
   }
   for (const runtimeKey of [...connection.subscriptions]) {
     unsubscribeListenerConnection(runtime, connectionId, runtimeKey);
   }
-  runtime.connections?.delete(connectionId);
+  runtime.connections.delete(connectionId);
   connection.cancellation.abort();
   refreshLegacySingleConnection(runtime);
   return connection;
+}
+
+export function suspendListenerConnection(
+  runtime: ListenerRuntime,
+  connectionId: ListenerConnectionId,
+): ListenerConnectionState | null {
+  const connection = runtime.connections.get(connectionId);
+  if (!connection) {
+    return null;
+  }
+  const resumeState: ListenerConnectionResumeState = {
+    ordinal: connection.ordinal,
+    subscriptions: new Set(connection.subscriptions),
+    eventSeqCounter: connection.eventSeqCounter,
+  };
+  const closed = closeListenerConnection(runtime, connectionId);
+  getResumeStates(runtime).set(connectionId, resumeState);
+  return closed;
 }
 
 class ProcessRuntimeTransport implements RuntimeTransport {
@@ -299,14 +350,14 @@ class ProcessRuntimeTransport implements RuntimeTransport {
 
   get bufferedAmount(): number {
     let total = 0;
-    for (const connection of this.runtime.connections?.values() ?? []) {
+    for (const connection of this.runtime.connections.values()) {
       total += connection.writer.bufferedAmount;
     }
     return total;
   }
 
   isOpen(): boolean {
-    for (const connection of this.runtime.connections?.values() ?? []) {
+    for (const connection of this.runtime.connections.values()) {
       if (
         connection.initialized &&
         isListenerTransportOpen(connection.writer)

--- a/src/websocket/listener/connection.ts
+++ b/src/websocket/listener/connection.ts
@@ -8,23 +8,39 @@ import {
 import type {
   ListenerConnectionId,
   ListenerConnectionState,
+  ListenerMessageRouting,
   ListenerRuntime,
   StartListenerOptions,
 } from "./types";
+
+export const TO_SUBSCRIBERS = {
+  type: "ToSubscribers",
+} as const satisfies ListenerMessageRouting;
+
+export const BROADCAST = {
+  type: "Broadcast",
+} as const satisfies ListenerMessageRouting;
+
+export function toListenerConnection(
+  connectionId: ListenerConnectionId,
+): ListenerMessageRouting {
+  return { type: "ToConnection", connectionId };
+}
 
 function socketForTransport(transport: ListenerTransport): WebSocket | null {
   return "kind" in transport ? null : transport;
 }
 
-function refreshPrimaryConnection(runtime: ListenerRuntime): void {
-  const next = [...(runtime.connections?.values() ?? [])]
-    .filter((connection) => isListenerTransportOpen(connection.writer))
-    .sort((a, b) => a.ordinal - b.ordinal)[0];
-  runtime.transport = next?.writer ?? runtime.processTransport;
-  runtime.streamTransport = next?.streamWriter ?? null;
-  runtime.socket = next ? socketForTransport(next.writer) : null;
-  runtime.streamSocket = next?.streamWriter
-    ? socketForTransport(next.streamWriter)
+function refreshLegacySingleConnection(runtime: ListenerRuntime): void {
+  const live = [...(runtime.connections?.values() ?? [])].filter((connection) =>
+    isListenerTransportOpen(connection.writer),
+  );
+  const only = live.length === 1 ? live[0] : null;
+  runtime.transport = only?.writer ?? runtime.processTransport;
+  runtime.streamTransport = only?.streamWriter ?? null;
+  runtime.socket = only ? socketForTransport(only.writer) : null;
+  runtime.streamSocket = only?.streamWriter
+    ? socketForTransport(only.streamWriter)
     : null;
 }
 
@@ -64,7 +80,7 @@ export function openListenerConnection(params: {
   params.runtime.connections ??= new Map();
   params.runtime.connectionIdsByRuntimeKey ??= new Map();
   params.runtime.connections.set(connection.id, connection);
-  refreshPrimaryConnection(params.runtime);
+  refreshLegacySingleConnection(params.runtime);
   return connection;
 }
 
@@ -179,27 +195,63 @@ export function resolveListenerConnectionTargets(params: {
   runtime: ListenerRuntime | null;
   origin: ListenerTransport;
   scope: { agent_id?: string | null; conversation_id?: string | null };
-  connectionId?: ListenerConnectionId;
-  subscribers: boolean;
+  routing: ListenerMessageRouting;
   streamMessage: boolean;
 }): ListenerConnectionTarget[] {
-  const explicitConnection = params.connectionId
-    ? params.runtime?.connections.get(params.connectionId)
-    : undefined;
-  const subscribedConnections =
-    params.runtime && params.subscribers
-      ? getSubscribedListenerConnections(params.runtime, params.scope)
-      : [];
-  const originConnection = params.runtime
-    ? findListenerConnectionByTransport(params.runtime, params.origin)
-    : null;
-  const connections: Array<ListenerConnectionState | null> = explicitConnection
-    ? [explicitConnection]
-    : subscribedConnections.length > 0
-      ? subscribedConnections
-      : originConnection
-        ? [originConnection]
-        : [null];
+  const runtime = params.runtime;
+  let connections: Array<ListenerConnectionState | null>;
+  switch (params.routing.type) {
+    case "ToConnection": {
+      const explicitConnection = runtime?.connections.get(
+        params.routing.connectionId,
+      );
+      if (explicitConnection) {
+        connections = [explicitConnection];
+        break;
+      }
+      // The outbound Cloud listener predates the connection map. Preserve its
+      // single transport while the local app-server always has tracked
+      // connections and therefore cannot enter this compatibility branch.
+      if (
+        (runtime?.connections?.size ?? 0) === 0 &&
+        params.routing.connectionId === (runtime?.connectionId ?? "legacy")
+      ) {
+        connections = [null];
+        break;
+      }
+      return [];
+    }
+    case "ToSubscribers": {
+      connections = runtime
+        ? getSubscribedListenerConnections(runtime, params.scope)
+        : [];
+      if (connections.length > 0) {
+        break;
+      }
+      // Letta's outbound Desktop listener is a single pre-subscription
+      // transport. This does not apply to app-server connections: once a
+      // connection map exists, a scoped message with no subscribers is
+      // dropped, matching Codex.
+      if ((runtime?.connections?.size ?? 0) === 0) {
+        connections = [null];
+        break;
+      }
+      return [];
+    }
+    case "Broadcast": {
+      connections = runtime
+        ? [...runtime.connections.values()].filter(
+            (connection) =>
+              connection.initialized &&
+              isListenerTransportOpen(connection.writer),
+          )
+        : [];
+      if (connections.length === 0 && (runtime?.connections?.size ?? 0) === 0) {
+        connections = [null];
+      }
+      break;
+    }
+  }
 
   return connections.map((connection) => {
     const streamTransport = connection?.streamWriter;
@@ -223,53 +275,6 @@ export function resolveListenerConnectionTargets(params: {
   });
 }
 
-/**
- * Prefer the connection that initiated the operation. Background/channel
- * operations use the oldest live subscriber, matching Codex's deterministic
- * lowest-ConnectionId controller selection.
- */
-export function selectListenerController(
-  runtime: ListenerRuntime,
-  scope: { agent_id?: string | null; conversation_id?: string | null },
-  preferredTransport?: ListenerTransport,
-): ListenerConnectionState | null {
-  if (preferredTransport) {
-    const preferred = findListenerConnectionByTransport(
-      runtime,
-      preferredTransport,
-    );
-    if (
-      preferred &&
-      preferred.initialized &&
-      isListenerTransportOpen(preferred.writer)
-    ) {
-      return preferred;
-    }
-    if (isListenerTransportOpen(preferredTransport)) {
-      return {
-        id: runtime.connectionId ?? "legacy",
-        ordinal: -1,
-        writer: preferredTransport,
-        streamWriter: null,
-        cancellation: new AbortController(),
-        initialized: true,
-        subscriptions: new Set(),
-        eventSeqCounter: runtime.eventSeqCounter,
-        options: {
-          connectionId: runtime.connectionId ?? "legacy",
-          wsUrl: "legacy://listener",
-          deviceId: "legacy",
-          connectionName: runtime.connectionName ?? "legacy",
-          onConnected: () => {},
-          onDisconnected: () => {},
-          onError: () => {},
-        },
-      };
-    }
-  }
-  return getSubscribedListenerConnections(runtime, scope)[0] ?? null;
-}
-
 export function closeListenerConnection(
   runtime: ListenerRuntime,
   connectionId: ListenerConnectionId,
@@ -283,7 +288,7 @@ export function closeListenerConnection(
   }
   runtime.connections?.delete(connectionId);
   connection.cancellation.abort();
-  refreshPrimaryConnection(runtime);
+  refreshLegacySingleConnection(runtime);
   return connection;
 }
 
@@ -313,14 +318,9 @@ class ProcessRuntimeTransport implements RuntimeTransport {
   }
 
   send(data: string): void {
-    for (const connection of this.runtime.connections?.values() ?? []) {
-      if (
-        connection.initialized &&
-        isListenerTransportOpen(connection.writer)
-      ) {
-        connection.writer.send(data);
-      }
-    }
+    throw new Error(
+      `Process runtime transport cannot send an implicit message (${data.length} bytes); resolve ToConnection, ToSubscribers, or Broadcast first`,
+    );
   }
 }
 
@@ -328,5 +328,8 @@ export function getOrCreateProcessTransport(
   runtime: ListenerRuntime,
 ): ListenerTransport {
   runtime.processTransport ??= new ProcessRuntimeTransport(runtime);
+  if (runtime.connections.size !== 1) {
+    refreshLegacySingleConnection(runtime);
+  }
   return runtime.processTransport;
 }

--- a/src/websocket/listener/control-inputs.test.ts
+++ b/src/websocket/listener/control-inputs.test.ts
@@ -3,8 +3,14 @@ import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import { join } from "node:path";
 import WebSocket from "ws";
+import {
+  markListenerConnectionInitialized,
+  openListenerConnection,
+  subscribeListenerConnection,
+} from "./connection";
 import { handleCwdChange } from "./control-inputs";
 import { getOrCreateScopedRuntime } from "./conversation-runtime";
+import { switchConversationWorkingDirectory } from "./cwd-change";
 import { createRuntime } from "./lifecycle";
 import { resetRemoteSettingsCache } from "./remote-settings";
 
@@ -73,5 +79,55 @@ describe("listener cwd change handling", () => {
     expect(runtime.reminderState.pendingSessionContextReason).toBe(
       "cwd_changed",
     );
+  });
+
+  test("automatic cwd changes reach both runtime subscribers", async () => {
+    const listener = createRuntime();
+    getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
+    const socketA = new MockSocket();
+    const socketB = new MockSocket();
+    for (const [connectionId, socket] of [
+      ["client-a", socketA],
+      ["client-b", socketB],
+    ] as const) {
+      openListenerConnection({
+        runtime: listener,
+        connectionId,
+        writer: socket as never,
+        options: {
+          connectionId,
+          wsUrl: "ws://test",
+          deviceId: connectionId,
+          connectionName: connectionId,
+          onConnected: () => {},
+          onDisconnected: () => {},
+          onError: () => {},
+        },
+      });
+      markListenerConnectionInitialized(listener, connectionId);
+      subscribeListenerConnection(listener, connectionId, {
+        agent_id: "agent-1",
+        conversation_id: "conv-1",
+      });
+    }
+
+    await switchConversationWorkingDirectory({
+      runtime: listener,
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      workingDirectory: tempHome as string,
+      updateCurrentRuntimeContext: false,
+    });
+
+    for (const socket of [socketA, socketB]) {
+      expect(socket.sentPayloads).toHaveLength(1);
+      expect(JSON.parse(socket.sentPayloads[0] ?? "{}")).toMatchObject({
+        type: "update_device_status",
+        runtime: {
+          agent_id: "agent-1",
+          conversation_id: "conv-1",
+        },
+      });
+    }
   });
 });

--- a/src/websocket/listener/control-inputs.ts
+++ b/src/websocket/listener/control-inputs.ts
@@ -12,6 +12,7 @@ import type {
 } from "@/types/protocol_v2";
 import { debugLog, isDebugEnabled } from "@/utils/debug";
 import {
+  hasPendingApprovalRequestId,
   rejectPendingApprovalResolvers,
   resolvePendingApprovalResolver,
 } from "./approval";
@@ -37,6 +38,7 @@ import { emitLoopErrorNotice } from "./recoverable-notices";
 import { resolveRecoveredApprovalResponse } from "./recovery";
 import {
   getActiveRuntime,
+  getConversationRuntime,
   getPendingControlRequestCount,
   getPendingControlRequests,
   getRecoveredApprovalStateForScope,
@@ -142,34 +144,29 @@ export function handleModeChange(
 
 function resolveRuntimeForApprovalRequest(
   listener: ListenerRuntime,
+  scope: {
+    agent_id?: string | null;
+    conversation_id?: string | null;
+  },
   requestId?: string | null,
   connectionId?: ListenerConnectionId,
 ): ConversationRuntime | null {
   if (!requestId) {
     return null;
   }
-  const requestKey = connectionId
-    ? createConnectionRequestKey(connectionId, requestId)
-    : [...listener.approvalRuntimeKeyByRequestId.keys()].find((candidate) => {
-        try {
-          const parsed = JSON.parse(candidate) as unknown;
-          return (
-            Array.isArray(parsed) &&
-            parsed.length === 2 &&
-            parsed[1] === requestId
-          );
-        } catch {
-          return candidate === requestId;
-        }
-      });
-  if (!requestKey) {
+  const runtime = getConversationRuntime(
+    listener,
+    scope.agent_id,
+    scope.conversation_id,
+  );
+  if (!runtime) {
     return null;
   }
-  const runtimeKey = listener.approvalRuntimeKeyByRequestId.get(requestKey);
-  if (!runtimeKey) {
-    return null;
+  if (connectionId) {
+    const requestKey = createConnectionRequestKey(connectionId, requestId);
+    return runtime.pendingApprovalResolvers.has(requestKey) ? runtime : null;
   }
-  return listener.conversationRuntimes.get(runtimeKey) ?? null;
+  return hasPendingApprovalRequestId(runtime, requestId) ? runtime : null;
 }
 
 export async function handleApprovalResponseInput(
@@ -191,6 +188,10 @@ export async function handleApprovalResponseInput(
   deps: {
     resolveRuntimeForApprovalRequest: (
       listener: ListenerRuntime,
+      scope: {
+        agent_id?: string | null;
+        conversation_id?: string | null;
+      },
       requestId?: string | null,
       connectionId?: ListenerConnectionId,
     ) => ConversationRuntime | null;
@@ -230,6 +231,7 @@ export async function handleApprovalResponseInput(
 ): Promise<boolean> {
   const approvalRuntime = deps.resolveRuntimeForApprovalRequest(
     listener,
+    params.runtime,
     params.response.request_id,
     params.connectionId,
   );

--- a/src/websocket/listener/control-inputs.ts
+++ b/src/websocket/listener/control-inputs.ts
@@ -15,6 +15,7 @@ import {
   rejectPendingApprovalResolvers,
   resolvePendingApprovalResolver,
 } from "./approval";
+import { createConnectionRequestKey } from "./connection";
 import { getOrCreateScopedRuntime } from "./conversation-runtime";
 import {
   bumpWorkingDirectoryRevision,
@@ -47,6 +48,7 @@ import { setCommandLoopStatus } from "./turn-status";
 import type {
   ChangeCwdMessage,
   ConversationRuntime,
+  ListenerConnectionId,
   ListenerRuntime,
   ModeChangePayload,
   ProcessQueuedTurn,
@@ -141,11 +143,29 @@ export function handleModeChange(
 function resolveRuntimeForApprovalRequest(
   listener: ListenerRuntime,
   requestId?: string | null,
+  connectionId?: ListenerConnectionId,
 ): ConversationRuntime | null {
   if (!requestId) {
     return null;
   }
-  const runtimeKey = listener.approvalRuntimeKeyByRequestId.get(requestId);
+  const requestKey = connectionId
+    ? createConnectionRequestKey(connectionId, requestId)
+    : [...listener.approvalRuntimeKeyByRequestId.keys()].find((candidate) => {
+        try {
+          const parsed = JSON.parse(candidate) as unknown;
+          return (
+            Array.isArray(parsed) &&
+            parsed.length === 2 &&
+            parsed[1] === requestId
+          );
+        } catch {
+          return candidate === requestId;
+        }
+      });
+  if (!requestKey) {
+    return null;
+  }
+  const runtimeKey = listener.approvalRuntimeKeyByRequestId.get(requestKey);
   if (!runtimeKey) {
     return null;
   }
@@ -160,6 +180,7 @@ export async function handleApprovalResponseInput(
       conversation_id?: string | null;
     };
     response: ApprovalResponseBody;
+    connectionId?: ListenerConnectionId;
     socket: ListenerTransport;
     opts: {
       onStatusChange?: StartListenerOptions["onStatusChange"];
@@ -171,10 +192,12 @@ export async function handleApprovalResponseInput(
     resolveRuntimeForApprovalRequest: (
       listener: ListenerRuntime,
       requestId?: string | null,
+      connectionId?: ListenerConnectionId,
     ) => ConversationRuntime | null;
     resolvePendingApprovalResolver: (
       runtime: ConversationRuntime,
       response: ApprovalResponseBody,
+      connectionId?: ListenerConnectionId,
     ) => boolean;
     getOrCreateScopedRuntime: (
       listener: ListenerRuntime,
@@ -208,10 +231,15 @@ export async function handleApprovalResponseInput(
   const approvalRuntime = deps.resolveRuntimeForApprovalRequest(
     listener,
     params.response.request_id,
+    params.connectionId,
   );
   if (
     approvalRuntime &&
-    deps.resolvePendingApprovalResolver(approvalRuntime, params.response)
+    deps.resolvePendingApprovalResolver(
+      approvalRuntime,
+      params.response,
+      params.connectionId,
+    )
   ) {
     deps.scheduleQueuePump(
       approvalRuntime,
@@ -260,6 +288,7 @@ export async function handleChangeDeviceStateInput(
   listener: ListenerRuntime,
   params: {
     command: ChangeDeviceStateCommand;
+    connectionId?: ListenerConnectionId;
     socket: WebSocket;
     opts: {
       onStatusChange?: StartListenerOptions["onStatusChange"];
@@ -370,6 +399,7 @@ export async function handleAbortMessageInput(
   listener: ListenerRuntime,
   params: {
     command: AbortMessageCommand;
+    connectionId?: ListenerConnectionId;
     socket: ListenerTransport;
     opts: {
       onStatusChange?: StartListenerOptions["onStatusChange"];

--- a/src/websocket/listener/conversation-runtime.ts
+++ b/src/websocket/listener/conversation-runtime.ts
@@ -56,19 +56,3 @@ export function getOrCreateScopedRuntime(
     getOrCreateConversationRuntime(listener, agentId, conversationId),
   );
 }
-
-/**
- * Fallback for unscoped task notifications (e.g., reflection/init spawned
- * outside turn processing). Picks the first ConversationRuntime that has a
- * QueueRuntime, or null if none exist.
- */
-export function findFallbackRuntime(
-  listener: ListenerRuntime,
-): ConversationRuntime | null {
-  for (const cr of listener.conversationRuntimes.values()) {
-    if (cr.queueRuntime) {
-      return cr;
-    }
-  }
-  return null;
-}

--- a/src/websocket/listener/cwd-change.ts
+++ b/src/websocket/listener/cwd-change.ts
@@ -1,6 +1,6 @@
-import type WebSocket from "ws";
 import { updateRuntimeContext } from "@/runtime-context";
 import { settingsManager } from "@/settings-manager";
+import { getOrCreateProcessTransport } from "./connection";
 import {
   getWorkingDirectoryScopeKey,
   setConversationWorkingDirectory,
@@ -8,6 +8,7 @@ import {
 import { emitDeviceStatusUpdate } from "./protocol-outbound";
 import { getConversationRuntime } from "./runtime";
 import { normalizeConversationId, normalizeCwdAgentId } from "./scope";
+import type { ListenerTransport } from "./transport";
 import type { ConversationRuntime, ListenerRuntime } from "./types";
 
 async function loadSettingsForWorkingDirectory(
@@ -59,7 +60,7 @@ export async function switchConversationWorkingDirectory(params: {
   workingDirectory: string;
   emitStatus?: boolean;
   statusRuntime?: ConversationRuntime | ListenerRuntime;
-  statusSocket?: WebSocket;
+  statusSocket?: ListenerTransport;
   updateCurrentRuntimeContext?: boolean;
 }): Promise<void> {
   const { runtime, workingDirectory } = params;
@@ -94,10 +95,11 @@ export async function switchConversationWorkingDirectory(params: {
     reminderState.pendingSessionContextReason = "cwd_changed";
   }
 
-  const statusSocket = params.statusSocket ?? runtime.socket;
-  if (params.emitStatus !== false && statusSocket) {
+  if (params.emitStatus !== false) {
+    const statusTransport =
+      params.statusSocket ?? getOrCreateProcessTransport(runtime);
     emitDeviceStatusUpdate(
-      statusSocket,
+      statusTransport,
       params.statusRuntime ?? conversationRuntime ?? runtime,
       {
         agent_id: agentId,

--- a/src/websocket/listener/external-tools.test.ts
+++ b/src/websocket/listener/external-tools.test.ts
@@ -23,14 +23,15 @@ function createMockRuntime(): {
   const runtime = {
     intentionallyClosed: false,
     pendingExternalToolCalls: new Map(),
+    connections: new Map(),
   } as unknown as ListenerRuntime;
-  runtime.socket = {
+  const writer = {
     readyState: 1,
     send(data: string) {
       const request = JSON.parse(data) as ExternalToolCallRequestMessage;
       sent.push(request);
       queueMicrotask(() => {
-        handleExternalToolCallResponseCommand(runtime, {
+        handleExternalToolCallResponseCommand(runtime, "client-1", {
           type: "external_tool_call_response",
           request_id: request.request_id,
           result: {
@@ -40,6 +41,10 @@ function createMockRuntime(): {
       });
     },
   } as unknown as WebSocket;
+  runtime.connections.set("client-1", {
+    id: "client-1",
+    writer,
+  } as never);
   return { runtime, sent };
 }
 
@@ -53,6 +58,7 @@ describe("app-server runtime_start external tool bridge", () => {
     installExternalToolBridge(runtime);
     registerRuntimeExternalTools(
       runtime,
+      "client-1",
       { agent_id: "agent-1", conversation_id: "conv-1" },
       [
         {
@@ -77,7 +83,11 @@ describe("app-server runtime_start external tool bridge", () => {
       {
         clientToolAllowlist: ["RemoteLookup"],
         externalToolScopeIds: ["scope-1"],
-        runtimeContext: { agentId: "agent-1", conversationId: "conv-1" },
+        runtimeContext: {
+          connectionId: "client-1",
+          agentId: "agent-1",
+          conversationId: "conv-1",
+        },
       },
     );
 
@@ -104,6 +114,7 @@ describe("app-server runtime_start external tool bridge", () => {
     const { runtime } = createMockRuntime();
     registerRuntimeExternalTools(
       runtime,
+      "client-1",
       { agent_id: "agent-1", conversation_id: "conv-a" },
       [
         {
@@ -120,6 +131,7 @@ describe("app-server runtime_start external tool bridge", () => {
     );
     registerRuntimeExternalTools(
       runtime,
+      "client-1",
       { agent_id: "agent-1", conversation_id: "conv-b" },
       [
         {
@@ -140,7 +152,11 @@ describe("app-server runtime_start external tool bridge", () => {
       {
         clientToolAllowlist: ["lookup_ticket"],
         externalToolScopeIds: ["search"],
-        runtimeContext: { agentId: "agent-1", conversationId: "conv-a" },
+        runtimeContext: {
+          connectionId: "client-1",
+          agentId: "agent-1",
+          conversationId: "conv-a",
+        },
       },
     );
     const preparedB = await prepareToolExecutionContextForModel(
@@ -148,7 +164,11 @@ describe("app-server runtime_start external tool bridge", () => {
       {
         clientToolAllowlist: ["lookup_ticket"],
         externalToolScopeIds: ["search"],
-        runtimeContext: { agentId: "agent-1", conversationId: "conv-b" },
+        runtimeContext: {
+          connectionId: "client-1",
+          agentId: "agent-1",
+          conversationId: "conv-b",
+        },
       },
     );
 
@@ -245,7 +265,7 @@ describe("app-server runtime_start external tool bridge", () => {
   test("repeated runtime_start registration replaces tools for that runtime", async () => {
     const { runtime } = createMockRuntime();
     const runtimeScope = { agent_id: "agent-1", conversation_id: "conv-1" };
-    registerRuntimeExternalTools(runtime, runtimeScope, [
+    registerRuntimeExternalTools(runtime, "client-1", runtimeScope, [
       {
         tools: [
           {
@@ -256,7 +276,7 @@ describe("app-server runtime_start external tool bridge", () => {
         ],
       },
     ]);
-    registerRuntimeExternalTools(runtime, runtimeScope, [
+    registerRuntimeExternalTools(runtime, "client-1", runtimeScope, [
       {
         tools: [
           {
@@ -272,7 +292,11 @@ describe("app-server runtime_start external tool bridge", () => {
       "anthropic/claude-sonnet-4",
       {
         clientToolAllowlist: ["old_tool", "new_tool"],
-        runtimeContext: { agentId: "agent-1", conversationId: "conv-1" },
+        runtimeContext: {
+          connectionId: "client-1",
+          agentId: "agent-1",
+          conversationId: "conv-1",
+        },
       },
     );
 
@@ -283,6 +307,7 @@ describe("app-server runtime_start external tool bridge", () => {
     const { runtime } = createMockRuntime();
     registerRuntimeExternalTools(
       runtime,
+      "client-1",
       { agent_id: "agent-1", conversation_id: "conv-1" },
       [
         {
@@ -303,7 +328,11 @@ describe("app-server runtime_start external tool bridge", () => {
       "anthropic/claude-sonnet-4",
       {
         clientToolAllowlist: ["runtime_only"],
-        runtimeContext: { agentId: "agent-1", conversationId: "conv-1" },
+        runtimeContext: {
+          connectionId: "client-1",
+          agentId: "agent-1",
+          conversationId: "conv-1",
+        },
       },
     );
 

--- a/src/websocket/listener/external-tools.test.ts
+++ b/src/websocket/listener/external-tools.test.ts
@@ -11,6 +11,7 @@ import {
   installExternalToolBridge,
   registerRuntimeExternalTools,
   rejectPendingExternalToolCalls,
+  rejectPendingExternalToolCallsForConnection,
 } from "@/websocket/listener/external-tools";
 import type { ListenerRuntime } from "@/websocket/listener/types";
 
@@ -162,6 +163,82 @@ describe("app-server runtime_start external tool bridge", () => {
         name: "lookup_ticket",
         description: "Lookup ticket for conversation B",
       }),
+    ]);
+  });
+
+  test("keeps same runtime tool registrations isolated by connection", async () => {
+    const { runtime } = createMockRuntime();
+    const runtimeScope = {
+      agent_id: "agent-1",
+      conversation_id: "conv-1",
+    };
+    const registerForConnection = (connectionId: string, description: string) =>
+      registerRuntimeExternalTools(runtime, connectionId, runtimeScope, [
+        {
+          scope_id: "search",
+          tools: [
+            {
+              name: "lookup_ticket",
+              description,
+              parameters: { type: "object", properties: {} },
+            },
+          ],
+        },
+      ]);
+    registerForConnection("client-a", "Lookup from client A");
+    registerForConnection("client-b", "Lookup from client B");
+
+    const preparedA = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      {
+        clientToolAllowlist: ["lookup_ticket"],
+        externalToolScopeIds: ["search"],
+        runtimeContext: {
+          connectionId: "client-a",
+          agentId: "agent-1",
+          conversationId: "conv-1",
+        },
+      },
+    );
+    const preparedB = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      {
+        clientToolAllowlist: ["lookup_ticket"],
+        externalToolScopeIds: ["search"],
+        runtimeContext: {
+          connectionId: "client-b",
+          agentId: "agent-1",
+          conversationId: "conv-1",
+        },
+      },
+    );
+
+    expect(preparedA.clientTools).toEqual([
+      expect.objectContaining({ description: "Lookup from client A" }),
+    ]);
+    expect(preparedB.clientTools).toEqual([
+      expect.objectContaining({ description: "Lookup from client B" }),
+    ]);
+
+    rejectPendingExternalToolCallsForConnection(
+      runtime,
+      "client-b",
+      "disconnected",
+    );
+    const preparedAfterDisconnect = await prepareToolExecutionContextForModel(
+      "anthropic/claude-sonnet-4",
+      {
+        clientToolAllowlist: ["lookup_ticket"],
+        externalToolScopeIds: ["search"],
+        runtimeContext: {
+          connectionId: "client-a",
+          agentId: "agent-1",
+          conversationId: "conv-1",
+        },
+      },
+    );
+    expect(preparedAfterDisconnect.clientTools).toEqual([
+      expect.objectContaining({ description: "Lookup from client A" }),
     ]);
   });
 

--- a/src/websocket/listener/external-tools.ts
+++ b/src/websocket/listener/external-tools.ts
@@ -1,4 +1,3 @@
-import type WebSocket from "ws";
 import {
   type ExternalToolDefinition,
   registerExternalTools,
@@ -12,19 +11,22 @@ import type {
   RuntimeScope,
   RuntimeStartExternalToolsGroup,
 } from "@/types/protocol_v2";
-import type { ListenerRuntime } from "@/websocket/listener/types";
+import { createConnectionRequestKey } from "@/websocket/listener/connection";
+import { isListenerTransportOpen } from "@/websocket/listener/transport";
+import type {
+  ListenerConnectionId,
+  ListenerRuntime,
+} from "@/websocket/listener/types";
 
 const EXTERNAL_TOOL_CALL_TIMEOUT_MS = 5 * 60 * 1000;
-const WEBSOCKET_OPEN = 1;
-
 const registeredToolsByRuntime = new WeakMap<
   ListenerRuntime,
   Map<string, ExternalToolDefinition[]>
 >();
-
-function isSocketOpen(socket: WebSocket | null): socket is WebSocket {
-  return socket?.readyState === WEBSOCKET_OPEN;
-}
+const connectionIdByRegistrationKey = new WeakMap<
+  ListenerRuntime,
+  Map<string, ListenerConnectionId>
+>();
 
 function getPendingExternalToolCalls(runtime: ListenerRuntime) {
   runtime.pendingExternalToolCalls ??= new Map();
@@ -40,17 +42,28 @@ function getRegisteredTools(runtime: ListenerRuntime) {
   return registeredTools;
 }
 
+function getConnectionIdsByRegistrationKey(runtime: ListenerRuntime) {
+  let controllers = connectionIdByRegistrationKey.get(runtime);
+  if (!controllers) {
+    controllers = new Map();
+    connectionIdByRegistrationKey.set(runtime, controllers);
+  }
+  return controllers;
+}
+
 function getRuntimeKey(runtime: RuntimeScope): string {
   return `${runtime.agent_id}:${runtime.conversation_id}`;
 }
 
 function getToolRegistrationKey(
+  connectionId: ListenerConnectionId,
   runtime: RuntimeScope,
   scopeId: string | undefined,
   toolName: string,
 ): string {
   return JSON.stringify([
     "runtime",
+    connectionId,
     runtime.agent_id,
     runtime.conversation_id,
     scopeId ?? null,
@@ -60,15 +73,22 @@ function getToolRegistrationKey(
 
 function toExternalToolDefinition(
   tool: ExternalToolDefinitionPayload,
+  connectionId: ListenerConnectionId,
   runtime: RuntimeScope,
   scopeId?: string,
 ): ExternalToolDefinition {
   return {
     name: tool.name,
+    ...(connectionId !== "legacy" ? { connectionId } : {}),
     ...(tool.label !== undefined ? { label: tool.label } : {}),
     description: tool.description,
     parameters: tool.parameters,
-    registrationKey: getToolRegistrationKey(runtime, scopeId, tool.name),
+    registrationKey: getToolRegistrationKey(
+      connectionId,
+      runtime,
+      scopeId,
+      tool.name,
+    ),
     ...(scopeId !== undefined ? { scopeId } : {}),
     runtime: {
       agentId: runtime.agent_id,
@@ -77,18 +97,33 @@ function toExternalToolDefinition(
   };
 }
 
-function sendJson(socket: WebSocket, payload: unknown): void {
-  socket.send(JSON.stringify(payload));
-}
-
 export function installExternalToolBridge(runtime: ListenerRuntime): void {
   setExternalToolExecutor(async (toolCallId, toolName, input, context) => {
-    const socket = runtime.socket;
-    if (!isSocketOpen(socket) || runtime.intentionallyClosed) {
+    const registrationKey = context?.tool.registrationKey;
+    const connectionId = registrationKey
+      ? getConnectionIdsByRegistrationKey(runtime).get(registrationKey)
+      : undefined;
+    const connection = connectionId
+      ? runtime.connections?.get(connectionId)
+      : undefined;
+    const legacyWriter =
+      connectionId === (runtime.connectionId ?? "legacy")
+        ? (runtime.transport ?? runtime.socket)
+        : null;
+    const writer = connection?.writer ?? legacyWriter;
+    if (
+      !writer ||
+      !isListenerTransportOpen(writer) ||
+      runtime.intentionallyClosed
+    ) {
       throw new Error("External tool controller is not connected");
     }
 
     const requestId = `external-tool-${crypto.randomUUID()}`;
+    const requestKey = createConnectionRequestKey(
+      connection?.id ?? connectionId ?? "legacy",
+      requestId,
+    );
     const toolRuntime = context?.tool.runtime;
     const requestRuntime =
       toolRuntime?.agentId && toolRuntime.conversationId
@@ -119,11 +154,12 @@ export function installExternalToolBridge(runtime: ListenerRuntime): void {
       isError: boolean;
     }>((resolve, reject) => {
       const timeout = setTimeout(() => {
-        getPendingExternalToolCalls(runtime).delete(requestId);
+        getPendingExternalToolCalls(runtime).delete(requestKey);
         reject(new Error(`External tool call timed out: ${toolName}`));
       }, EXTERNAL_TOOL_CALL_TIMEOUT_MS);
 
-      getPendingExternalToolCalls(runtime).set(requestId, {
+      getPendingExternalToolCalls(runtime).set(requestKey, {
+        connectionId: connection?.id ?? connectionId ?? "legacy",
         resolve: (response) => {
           resolve({
             content: [...response.content],
@@ -135,10 +171,10 @@ export function installExternalToolBridge(runtime: ListenerRuntime): void {
       });
 
       try {
-        sendJson(socket, request);
+        writer.send(JSON.stringify(request));
       } catch (error) {
         clearTimeout(timeout);
-        getPendingExternalToolCalls(runtime).delete(requestId);
+        getPendingExternalToolCalls(runtime).delete(requestKey);
         reject(error instanceof Error ? error : new Error(String(error)));
       }
     });
@@ -150,20 +186,63 @@ export function installExternalToolBridge(runtime: ListenerRuntime): void {
 export function registerRuntimeExternalTools(
   runtime: ListenerRuntime,
   runtimeScope: RuntimeScope,
-  groups: readonly RuntimeStartExternalToolsGroup[] = [],
+  groups?: readonly RuntimeStartExternalToolsGroup[],
+): void;
+export function registerRuntimeExternalTools(
+  runtime: ListenerRuntime,
+  connectionId: ListenerConnectionId,
+  runtimeScope: RuntimeScope,
+  groups?: readonly RuntimeStartExternalToolsGroup[],
+): void;
+export function registerRuntimeExternalTools(
+  runtime: ListenerRuntime,
+  connectionIdOrScope: ListenerConnectionId | RuntimeScope,
+  runtimeScopeOrGroups:
+    | RuntimeScope
+    | readonly RuntimeStartExternalToolsGroup[] = [],
+  explicitGroups: readonly RuntimeStartExternalToolsGroup[] = [],
 ): void {
+  const legacyCall = typeof connectionIdOrScope !== "string";
+  const connectionId = legacyCall
+    ? (runtime.connectionId ?? "legacy")
+    : connectionIdOrScope;
+  const runtimeScope = legacyCall
+    ? connectionIdOrScope
+    : (runtimeScopeOrGroups as RuntimeScope);
+  const groups = legacyCall
+    ? (runtimeScopeOrGroups as readonly RuntimeStartExternalToolsGroup[])
+    : explicitGroups;
   const registeredTools = getRegisteredTools(runtime);
-  const runtimeKey = getRuntimeKey(runtimeScope);
+  const runtimeKey = createConnectionRequestKey(
+    connectionId,
+    getRuntimeKey(runtimeScope),
+  );
   const previousTools = registeredTools.get(runtimeKey) ?? [];
   unregisterExternalTools(previousTools);
 
   const tools = groups.flatMap((group) =>
     group.tools.map((tool) =>
-      toExternalToolDefinition(tool, runtimeScope, group.scope_id),
+      toExternalToolDefinition(
+        tool,
+        connectionId,
+        runtimeScope,
+        group.scope_id,
+      ),
     ),
   );
+  const controllers = getConnectionIdsByRegistrationKey(runtime);
+  for (const tool of previousTools) {
+    if (tool.registrationKey) {
+      controllers.delete(tool.registrationKey);
+    }
+  }
   if (tools.length > 0) {
     registerExternalTools(tools);
+    for (const tool of tools) {
+      if (tool.registrationKey) {
+        controllers.set(tool.registrationKey, connectionId);
+      }
+    }
     registeredTools.set(runtimeKey, tools);
   } else {
     registeredTools.delete(runtimeKey);
@@ -173,14 +252,49 @@ export function registerRuntimeExternalTools(
 export function handleExternalToolCallResponseCommand(
   runtime: ListenerRuntime,
   command: ExternalToolCallResponseCommand,
+): boolean;
+export function handleExternalToolCallResponseCommand(
+  runtime: ListenerRuntime,
+  connectionId: ListenerConnectionId,
+  command: ExternalToolCallResponseCommand,
+): boolean;
+export function handleExternalToolCallResponseCommand(
+  runtime: ListenerRuntime,
+  connectionIdOrCommand: ListenerConnectionId | ExternalToolCallResponseCommand,
+  explicitCommand?: ExternalToolCallResponseCommand,
 ): boolean {
-  const pending = getPendingExternalToolCalls(runtime).get(command.request_id);
+  const command =
+    typeof connectionIdOrCommand === "string"
+      ? explicitCommand
+      : connectionIdOrCommand;
+  if (!command) {
+    return false;
+  }
+  const requestKey =
+    typeof connectionIdOrCommand === "string"
+      ? createConnectionRequestKey(connectionIdOrCommand, command.request_id)
+      : [...getPendingExternalToolCalls(runtime).keys()].find((candidate) => {
+          try {
+            const parsed = JSON.parse(candidate) as unknown;
+            return (
+              Array.isArray(parsed) &&
+              parsed.length === 2 &&
+              parsed[1] === command.request_id
+            );
+          } catch {
+            return candidate === command.request_id;
+          }
+        });
+  if (!requestKey) {
+    return false;
+  }
+  const pending = getPendingExternalToolCalls(runtime).get(requestKey);
   if (!pending) {
     return false;
   }
 
   clearTimeout(pending.timeout);
-  getPendingExternalToolCalls(runtime).delete(command.request_id);
+  getPendingExternalToolCalls(runtime).delete(requestKey);
 
   if (command.error !== undefined) {
     pending.reject(new Error(command.error));
@@ -194,6 +308,45 @@ export function handleExternalToolCallResponseCommand(
 
   pending.resolve(command.result);
   return true;
+}
+
+export function rejectPendingExternalToolCallsForConnection(
+  runtime: ListenerRuntime,
+  connectionId: ListenerConnectionId,
+  reason: string,
+): void {
+  const pendingExternalToolCalls = getPendingExternalToolCalls(runtime);
+  for (const [requestKey, pending] of pendingExternalToolCalls) {
+    if (pending.connectionId !== connectionId) {
+      continue;
+    }
+    clearTimeout(pending.timeout);
+    pendingExternalToolCalls.delete(requestKey);
+    pending.reject(new Error(reason));
+  }
+
+  const registeredTools = registeredToolsByRuntime.get(runtime);
+  if (!registeredTools) {
+    return;
+  }
+  const controllers = getConnectionIdsByRegistrationKey(runtime);
+  for (const [registrationScope, tools] of registeredTools) {
+    const ownedByConnection = tools.some(
+      (tool) =>
+        tool.registrationKey !== undefined &&
+        controllers.get(tool.registrationKey) === connectionId,
+    );
+    if (!ownedByConnection) {
+      continue;
+    }
+    unregisterExternalTools(tools);
+    registeredTools.delete(registrationScope);
+    for (const tool of tools) {
+      if (tool.registrationKey) {
+        controllers.delete(tool.registrationKey);
+      }
+    }
+  }
 }
 
 export function rejectPendingExternalToolCalls(
@@ -214,4 +367,5 @@ export function rejectPendingExternalToolCalls(
     }
     registeredToolsByRuntime.delete(runtime);
   }
+  connectionIdByRegistrationKey.delete(runtime);
 }

--- a/src/websocket/listener/external-tools.ts
+++ b/src/websocket/listener/external-tools.ts
@@ -29,7 +29,6 @@ const connectionIdByRegistrationKey = new WeakMap<
 >();
 
 function getPendingExternalToolCalls(runtime: ListenerRuntime) {
-  runtime.pendingExternalToolCalls ??= new Map();
   return runtime.pendingExternalToolCalls;
 }
 
@@ -79,7 +78,7 @@ function toExternalToolDefinition(
 ): ExternalToolDefinition {
   return {
     name: tool.name,
-    ...(connectionId !== "legacy" ? { connectionId } : {}),
+    connectionId,
     ...(tool.label !== undefined ? { label: tool.label } : {}),
     description: tool.description,
     parameters: tool.parameters,
@@ -104,26 +103,19 @@ export function installExternalToolBridge(runtime: ListenerRuntime): void {
       ? getConnectionIdsByRegistrationKey(runtime).get(registrationKey)
       : undefined;
     const connection = connectionId
-      ? runtime.connections?.get(connectionId)
+      ? runtime.connections.get(connectionId)
       : undefined;
-    const legacyWriter =
-      connectionId === (runtime.connectionId ?? "legacy")
-        ? (runtime.transport ?? runtime.socket)
-        : null;
-    const writer = connection?.writer ?? legacyWriter;
     if (
-      !writer ||
-      !isListenerTransportOpen(writer) ||
+      !connection ||
+      !isListenerTransportOpen(connection.writer) ||
       runtime.intentionallyClosed
     ) {
       throw new Error("External tool controller is not connected");
     }
+    const writer = connection.writer;
 
     const requestId = `external-tool-${crypto.randomUUID()}`;
-    const requestKey = createConnectionRequestKey(
-      connection?.id ?? connectionId ?? "legacy",
-      requestId,
-    );
+    const requestKey = createConnectionRequestKey(connection.id, requestId);
     const toolRuntime = context?.tool.runtime;
     const requestRuntime =
       toolRuntime?.agentId && toolRuntime.conversationId
@@ -159,7 +151,7 @@ export function installExternalToolBridge(runtime: ListenerRuntime): void {
       }, EXTERNAL_TOOL_CALL_TIMEOUT_MS);
 
       getPendingExternalToolCalls(runtime).set(requestKey, {
-        connectionId: connection?.id ?? connectionId ?? "legacy",
+        connectionId: connection.id,
         resolve: (response) => {
           resolve({
             content: [...response.content],
@@ -185,33 +177,11 @@ export function installExternalToolBridge(runtime: ListenerRuntime): void {
 
 export function registerRuntimeExternalTools(
   runtime: ListenerRuntime,
-  runtimeScope: RuntimeScope,
-  groups?: readonly RuntimeStartExternalToolsGroup[],
-): void;
-export function registerRuntimeExternalTools(
-  runtime: ListenerRuntime,
   connectionId: ListenerConnectionId,
   runtimeScope: RuntimeScope,
   groups?: readonly RuntimeStartExternalToolsGroup[],
-): void;
-export function registerRuntimeExternalTools(
-  runtime: ListenerRuntime,
-  connectionIdOrScope: ListenerConnectionId | RuntimeScope,
-  runtimeScopeOrGroups:
-    | RuntimeScope
-    | readonly RuntimeStartExternalToolsGroup[] = [],
-  explicitGroups: readonly RuntimeStartExternalToolsGroup[] = [],
 ): void {
-  const legacyCall = typeof connectionIdOrScope !== "string";
-  const connectionId = legacyCall
-    ? (runtime.connectionId ?? "legacy")
-    : connectionIdOrScope;
-  const runtimeScope = legacyCall
-    ? connectionIdOrScope
-    : (runtimeScopeOrGroups as RuntimeScope);
-  const groups = legacyCall
-    ? (runtimeScopeOrGroups as readonly RuntimeStartExternalToolsGroup[])
-    : explicitGroups;
+  const resolvedGroups = groups ?? [];
   const registeredTools = getRegisteredTools(runtime);
   const runtimeKey = createConnectionRequestKey(
     connectionId,
@@ -220,7 +190,7 @@ export function registerRuntimeExternalTools(
   const previousTools = registeredTools.get(runtimeKey) ?? [];
   unregisterExternalTools(previousTools);
 
-  const tools = groups.flatMap((group) =>
+  const tools = resolvedGroups.flatMap((group) =>
     group.tools.map((tool) =>
       toExternalToolDefinition(
         tool,
@@ -251,43 +221,13 @@ export function registerRuntimeExternalTools(
 
 export function handleExternalToolCallResponseCommand(
   runtime: ListenerRuntime,
-  command: ExternalToolCallResponseCommand,
-): boolean;
-export function handleExternalToolCallResponseCommand(
-  runtime: ListenerRuntime,
   connectionId: ListenerConnectionId,
   command: ExternalToolCallResponseCommand,
-): boolean;
-export function handleExternalToolCallResponseCommand(
-  runtime: ListenerRuntime,
-  connectionIdOrCommand: ListenerConnectionId | ExternalToolCallResponseCommand,
-  explicitCommand?: ExternalToolCallResponseCommand,
 ): boolean {
-  const command =
-    typeof connectionIdOrCommand === "string"
-      ? explicitCommand
-      : connectionIdOrCommand;
-  if (!command) {
-    return false;
-  }
-  const requestKey =
-    typeof connectionIdOrCommand === "string"
-      ? createConnectionRequestKey(connectionIdOrCommand, command.request_id)
-      : [...getPendingExternalToolCalls(runtime).keys()].find((candidate) => {
-          try {
-            const parsed = JSON.parse(candidate) as unknown;
-            return (
-              Array.isArray(parsed) &&
-              parsed.length === 2 &&
-              parsed[1] === command.request_id
-            );
-          } catch {
-            return candidate === command.request_id;
-          }
-        });
-  if (!requestKey) {
-    return false;
-  }
+  const requestKey = createConnectionRequestKey(
+    connectionId,
+    command.request_id,
+  );
   const pending = getPendingExternalToolCalls(runtime).get(requestKey);
   if (!pending) {
     return false;

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -13,10 +13,7 @@ import { createChannelTurnProgressBuilder } from "@/channels/progress-builder";
 import { getChannelRegistry } from "@/channels/registry";
 import type { ChannelTurnSource } from "@/channels/types";
 import { launchReflectionSubagent } from "@/cli/helpers/reflection-launcher";
-import {
-  startScheduler as startCronScheduler,
-  stopScheduler as stopCronScheduler,
-} from "@/cron/scheduler";
+import { startScheduler as startCronScheduler } from "@/cron/scheduler";
 import { createSharedReminderState } from "@/reminders/state";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
 import { settingsManager } from "@/settings-manager";
@@ -28,7 +25,6 @@ import {
 import { trackBoundaryError } from "@/telemetry/error-reporting";
 import { loadTools } from "@/tools/manager";
 import { isDebugEnabled } from "@/utils/debug";
-import { setMessageQueueAdder } from "@/utils/message-queue-bridge";
 import { killAllTerminals } from "@/websocket/terminal-handler";
 import {
   getPendingApprovalRequestIds,
@@ -95,7 +91,12 @@ import {
   loadPersistedPermissionModeMap,
   persistPermissionModeMapForRuntime,
 } from "./permission-mode";
-import { installProcessEventRouting } from "./process-event-routing";
+import {
+  clearProcessServices,
+  installProcessEventRouting,
+  invalidateProcessServices,
+  waitForProcessServicesSlot,
+} from "./process-services";
 import { emitDeviceStatusUpdate, emitStreamDelta } from "./protocol-outbound";
 import { scheduleQueuePump } from "./queue";
 import { recoverApprovalStateForSync } from "./recovery";
@@ -915,7 +916,9 @@ export function createRuntime(): ListenerRuntime {
     connectionIdsByRuntimeKey: new Map(),
     processTransport: null,
     processServicesStarted: false,
+    processServicesGeneration: 0,
     processServicesReady: null,
+    processServicesReadyGeneration: null,
     eventSeqCounter: 0,
     queueEmitScheduled: false,
     pendingQueueEmitScope: undefined,
@@ -950,9 +953,8 @@ export function stopRuntime(
   notifyStreamObserversRuntimeStopped(runtime);
   disposeListenerModAdapter(runtime);
   rejectPendingExternalToolCalls(runtime, "Listener runtime stopped");
-  setMessageQueueAdder(null); // Clear bridge for ALL stop paths
   runtime.intentionallyClosed = true;
-  clearRuntimeTimers(runtime);
+  invalidateProcessServices(runtime);
   for (const conversationRuntime of runtime.conversationRuntimes.values()) {
     rejectPendingApprovalResolvers(
       conversationRuntime,
@@ -966,8 +968,8 @@ export function stopRuntime(
   }
   runtime.conversationRuntimes.clear();
   closeListenerRuntimeConnections(runtime, suppressCallbacks);
-  runtime.processServicesStarted = false;
   runtime.processServicesReady = null;
+  runtime.processServicesReadyGeneration = null;
   clearListenerWarmState(runtime);
   runtime.reminderStateByConversation.clear();
   runtime.skillSourcesByConversation.clear();
@@ -1023,10 +1025,10 @@ export async function startConnectedListenerRuntime(
   if (runtime.processServicesStarted) {
     return;
   }
-  if (runtime.processServicesReady) {
-    await runtime.processServicesReady;
-    return;
-  }
+  if (!(await waitForProcessServicesSlot(runtime, opts.connectionId))) return;
+
+  const processServicesGeneration = runtime.processServicesGeneration + 1;
+  runtime.processServicesGeneration = processServicesGeneration;
   const processServicesReady = (async () => {
     const processTransport = getOrCreateProcessTransport(runtime);
 
@@ -1093,23 +1095,22 @@ export async function startConnectedListenerRuntime(
       opts as StartListenerOptions,
       processQueuedTurn,
     );
-    runtime.processServicesStarted = true;
+    if (runtime.processServicesGeneration === processServicesGeneration) {
+      runtime.processServicesStarted = true;
+    }
   })();
   runtime.processServicesReady = processServicesReady;
+  runtime.processServicesReadyGeneration = processServicesGeneration;
   try {
     await processServicesReady;
   } catch (error) {
-    runtime._unsubscribeSubagentState?.();
-    runtime._unsubscribeSubagentState = undefined;
-    runtime._unsubscribeSubagentStreamEvents?.();
-    runtime._unsubscribeSubagentStreamEvents = undefined;
-    setMessageQueueAdder(null);
-    stopCronScheduler();
-    clearRuntimeTimers(runtime);
+    if (runtime.processServicesGeneration !== processServicesGeneration) return;
+    clearProcessServices(runtime);
     throw error;
   } finally {
     if (runtime.processServicesReady === processServicesReady) {
       runtime.processServicesReady = null;
+      runtime.processServicesReadyGeneration = null;
     }
   }
 }
@@ -1518,8 +1519,7 @@ async function connectWithRetry(
 
     fileCommandSession.dispose();
 
-    // Stop cron scheduler on disconnect
-    stopCronScheduler();
+    invalidateProcessServices(runtime);
 
     // Pause channel delivery on disconnect (adapters keep polling, messages buffer).
     // On reconnect, wireChannelIngress() re-registers the handler and calls setReady().
@@ -1527,10 +1527,6 @@ async function connectWithRetry(
     if (channelRegistry) {
       channelRegistry.pause();
     }
-
-    // Clear the bridge before queue clearing to prevent a race where a task
-    // completion enqueues into a shutting-down runtime.
-    setMessageQueueAdder(null);
 
     // Single authoritative queue clear for all close paths
     // (intentional and unintentional). Must fire before early returns.
@@ -1547,13 +1543,8 @@ async function connectWithRetry(
       );
     }
 
-    clearRuntimeTimers(runtime);
     suspendListenerConnection(runtime, opts.connectionId);
     killAllTerminals();
-    runtime._unsubscribeSubagentState?.();
-    runtime._unsubscribeSubagentState = undefined;
-    runtime._unsubscribeSubagentStreamEvents?.();
-    runtime._unsubscribeSubagentStreamEvents = undefined;
     clearListenerWarmState(runtime);
     if (streamSocket) {
       streamSocket.removeAllListeners();
@@ -1567,7 +1558,6 @@ async function connectWithRetry(
     runtime.socket = null;
     runtime.streamSocket = null;
     runtime.streamTransport = null;
-    runtime.processServicesStarted = false;
     for (const conversationRuntime of runtime.conversationRuntimes.values()) {
       rejectPendingApprovalResolvers(
         conversationRuntime,

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -1,11 +1,6 @@
 import type { MessageCreate } from "@letta-ai/letta-client/resources/agents/agents";
 import WebSocket from "ws";
 import {
-  getSubagents,
-  subscribe as subscribeToSubagentState,
-  subscribeToStreamEvents as subscribeToSubagentStreamEvents,
-} from "@/agent/subagent-state";
-import {
   buildChannelCurrentModelMessage,
   buildChannelCurrentModelUnavailableMessage,
   buildChannelModelListMessage,
@@ -45,7 +40,7 @@ import {
   uniqueChannelTurnSources,
 } from "./channel-turn-session";
 import { handleReloadCommand } from "./commands";
-import { handleChannelRegistryEvent } from "./commands/channels";
+import { handleChannelRegistryEvent } from "./commands/channel-registry-events";
 import {
   applyModelUpdateForRuntime,
   buildListModelsResponse,
@@ -53,10 +48,10 @@ import {
   resolveModelForUpdate,
 } from "./commands/model-toolset";
 import {
-  closeListenerConnection,
   getOrCreateProcessTransport,
   markListenerConnectionInitialized,
   openListenerConnection,
+  suspendListenerConnection,
 } from "./connection";
 import {
   cleanupListenerConnection,
@@ -100,11 +95,8 @@ import {
   loadPersistedPermissionModeMap,
   persistPermissionModeMapForRuntime,
 } from "./permission-mode";
-import {
-  emitDeviceStatusUpdate,
-  emitStreamDelta,
-  emitSubagentStateIfOpen,
-} from "./protocol-outbound";
+import { installProcessEventRouting } from "./process-event-routing";
+import { emitDeviceStatusUpdate, emitStreamDelta } from "./protocol-outbound";
 import { scheduleQueuePump } from "./queue";
 import { recoverApprovalStateForSync } from "./recovery";
 import {
@@ -552,7 +544,7 @@ export async function wireChannelIngress(
   });
 
   registry.setEventHandler((event) => {
-    handleChannelRegistryEvent(event, socket, listener, safeSocketSend);
+    handleChannelRegistryEvent(event, socket, listener);
   });
 
   await recoverPendingChannelControlRequests(listener);
@@ -923,6 +915,7 @@ export function createRuntime(): ListenerRuntime {
     connectionIdsByRuntimeKey: new Map(),
     processTransport: null,
     processServicesStarted: false,
+    processServicesReady: null,
     eventSeqCounter: 0,
     queueEmitScheduled: false,
     pendingQueueEmitScope: undefined,
@@ -974,6 +967,7 @@ export function stopRuntime(
   runtime.conversationRuntimes.clear();
   closeListenerRuntimeConnections(runtime, suppressCallbacks);
   runtime.processServicesStarted = false;
+  runtime.processServicesReady = null;
   clearListenerWarmState(runtime);
   runtime.reminderStateByConversation.clear();
   runtime.skillSourcesByConversation.clear();
@@ -996,6 +990,7 @@ export async function startConnectedListenerRuntime(
     startCronScheduler?: boolean;
     streamTransport?: ListenerTransport | null;
     emitInitialState?: boolean;
+    wireChannelIngress?: typeof wireChannelIngress;
   } = {},
 ): Promise<void> {
   if (runtime !== getActiveRuntime() || runtime.intentionallyClosed) {
@@ -1028,155 +1023,95 @@ export async function startConnectedListenerRuntime(
   if (runtime.processServicesStarted) {
     return;
   }
-  runtime.processServicesStarted = true;
-  const processTransport = getOrCreateProcessTransport(runtime);
+  if (runtime.processServicesReady) {
+    await runtime.processServicesReady;
+    return;
+  }
+  const processServicesReady = (async () => {
+    const processTransport = getOrCreateProcessTransport(runtime);
 
-  // Subscribe to subagent state changes and emit snapshots over the listener
-  // transport. Local channel mode intentionally discards these frames.
-  runtime._unsubscribeSubagentState?.();
-  runtime._unsubscribeSubagentState = subscribeToSubagentState(() => {
-    if (runtime.conversationRuntimes.size === 0) {
-      emitSubagentStateIfOpen(runtime);
-      return;
-    }
-
-    for (const conversationRuntime of runtime.conversationRuntimes.values()) {
-      emitSubagentStateIfOpen(runtime, {
-        agent_id: conversationRuntime.agentId,
-        conversation_id: conversationRuntime.conversationId,
-      });
-    }
-  });
-
-  // Subscribe to subagent stream events and forward as tagged stream_delta.
-  runtime._unsubscribeSubagentStreamEvents?.();
-  runtime._unsubscribeSubagentStreamEvents = subscribeToSubagentStreamEvents(
-    (subagentId, event) => {
-      if (!isListenerTransportOpen(processTransport)) return;
-
-      const subagent = getSubagents().find((entry) => entry.id === subagentId);
-      if (subagent?.silent === true) {
-        // Reflection/background "silent" subagents should not stream their
-        // internal transcript into the parent conversation.
-        return;
-      }
-
-      // The event has { type: "message", message_type, ...LettaStreamingResponse }
-      // plus extra headless fields (session_id, uuid) that pass through harmlessly.
-      emitStreamDelta(
-        processTransport,
-        runtime,
-        event as unknown as import("@/types/protocol_v2").StreamDelta,
-        subagent?.parentAgentId
-          ? {
-              agent_id: subagent.parentAgentId,
-              conversation_id: subagent.parentConversationId ?? "default",
-            }
-          : undefined,
-        subagentId,
-      );
-    },
-  );
-
-  // Register the message queue bridge to route task notifications into the
-  // correct per-conversation QueueRuntime. This enables background Task
-  // completions to reach the agent in listen mode.
-  setMessageQueueAdder((queuedMessage) => {
-    if (!queuedMessage.agentId || !queuedMessage.conversationId) {
-      // A process-originated notification without a complete runtime scope
-      // cannot be routed safely in a multi-client app-server. Dropping it is
-      // preferable to selecting an arbitrary conversation.
-      return;
-    }
-    const targetRuntime = getOrCreateScopedRuntime(
+    installProcessEventRouting({
       runtime,
-      queuedMessage.agentId,
-      queuedMessage.conversationId,
-    );
-
-    if (!targetRuntime?.queueRuntime) {
-      return; // No target - notification dropped
-    }
-
-    targetRuntime.queueRuntime.enqueue({
-      kind: "task_notification",
-      source: "task_notification",
-      text: queuedMessage.text,
-      agentId: queuedMessage.agentId ?? targetRuntime.agentId ?? undefined,
-      conversationId:
-        queuedMessage.conversationId ?? targetRuntime.conversationId,
-    } as Omit<
-      import("@/queue/queue-runtime").TaskNotificationQueueItem,
-      "id" | "enqueuedAt"
-    >);
-
-    // Kick the queue pump so the notification can trigger a standalone turn
-    // (see consumeQueuedTurn notification-aware path in queue.ts).
-    scheduleQueuePump(
-      targetRuntime,
       processTransport,
-      opts as StartListenerOptions,
+      opts: opts as StartListenerOptions,
       processQueuedTurn,
-    );
-  });
+    });
 
-  if (shouldStartHeartbeat) {
-    // Seed the pong clock so the watchdog tolerates the first ping/pong
-    // round-trip before considering the peer dead.
-    runtime.lastPongAt = Date.now();
-    runtime.heartbeatInterval = setInterval(() => {
-      // Dead-peer detection. The relay replies to every `ping` with a `pong`
-      // (recorded as runtime.lastPongAt in the message router). If pongs stop
-      // arriving, the underlying TCP is likely half-open (laptop sleep,
-      // network switch, NAT/idle timeout) and will never emit a `close`
-      // event — leaving a zombie listener that the relay marks offline after
-      // ~120s while client-side tool execution silently breaks. Force a
-      // terminate so the socket's `close` handler fires and reconnects.
-      // Gated on websocket transports: the local app-server path does not run
-      // a heartbeat, and only websockets carry the relay pong round-trip.
-      if (
-        getListenerTransportKind(transport) === "websocket" &&
-        isListenerPongStale(
-          runtime.lastPongAt,
-          Date.now(),
-          LISTENER_PONG_TIMEOUT_MS,
-        )
-      ) {
-        trackListenerError(
-          "listener_pong_timeout",
-          new Error(
-            `No relay pong within ${LISTENER_PONG_TIMEOUT_MS}ms; terminating half-open socket to force reconnect`,
-          ),
+    if (shouldStartHeartbeat) {
+      // Seed the pong clock so the watchdog tolerates the first ping/pong
+      // round-trip before considering the peer dead.
+      runtime.lastPongAt = Date.now();
+      runtime.heartbeatInterval = setInterval(() => {
+        // Dead-peer detection. The relay replies to every `ping` with a `pong`
+        // (recorded as runtime.lastPongAt in the message router). If pongs stop
+        // arriving, the underlying TCP is likely half-open (laptop sleep,
+        // network switch, NAT/idle timeout) and will never emit a `close`
+        // event — leaving a zombie listener that the relay marks offline after
+        // ~120s while client-side tool execution silently breaks. Force a
+        // terminate so the socket's `close` handler fires and reconnects.
+        // Gated on websocket transports: the local app-server path does not run
+        // a heartbeat, and only websockets carry the relay pong round-trip.
+        if (
+          getListenerTransportKind(transport) === "websocket" &&
+          isListenerPongStale(
+            runtime.lastPongAt,
+            Date.now(),
+            LISTENER_PONG_TIMEOUT_MS,
+          )
+        ) {
+          trackListenerError(
+            "listener_pong_timeout",
+            new Error(
+              `No relay pong within ${LISTENER_PONG_TIMEOUT_MS}ms; terminating half-open socket to force reconnect`,
+            ),
+            "listener_heartbeat",
+          );
+          runtime.socket?.terminate();
+          return;
+        }
+
+        safeTransportSend(
+          transport,
+          { type: "ping" },
+          "listener_ping_send_failed",
           "listener_heartbeat",
         );
-        runtime.socket?.terminate();
-        return;
-      }
+      }, LISTENER_HEARTBEAT_INTERVAL_MS);
+    }
 
-      safeTransportSend(
-        transport,
-        { type: "ping" },
-        "listener_ping_send_failed",
-        "listener_heartbeat",
+    if (shouldStartCronScheduler) {
+      startCronScheduler(
+        processTransport,
+        opts as StartListenerOptions,
+        processQueuedTurn,
       );
-    }, LISTENER_HEARTBEAT_INTERVAL_MS);
-  }
+    }
 
-  if (shouldStartCronScheduler) {
-    startCronScheduler(
+    await (options.wireChannelIngress ?? wireChannelIngress)(
+      runtime,
       processTransport,
       opts as StartListenerOptions,
       processQueuedTurn,
     );
+    runtime.processServicesStarted = true;
+  })();
+  runtime.processServicesReady = processServicesReady;
+  try {
+    await processServicesReady;
+  } catch (error) {
+    runtime._unsubscribeSubagentState?.();
+    runtime._unsubscribeSubagentState = undefined;
+    runtime._unsubscribeSubagentStreamEvents?.();
+    runtime._unsubscribeSubagentStreamEvents = undefined;
+    setMessageQueueAdder(null);
+    stopCronScheduler();
+    clearRuntimeTimers(runtime);
+    throw error;
+  } finally {
+    if (runtime.processServicesReady === processServicesReady) {
+      runtime.processServicesReady = null;
+    }
   }
-
-  // Wire channel ingress (if channels are active).
-  await wireChannelIngress(
-    runtime,
-    processTransport,
-    opts as StartListenerOptions,
-    processQueuedTurn,
-  );
 }
 
 /**
@@ -1203,7 +1138,7 @@ export async function attachOpenListenerSocket(
   }
 
   const streamSocket = options.streamSocket ?? null;
-  openListenerConnection({
+  const connection = openListenerConnection({
     runtime,
     connectionId: opts.connectionId,
     writer: socket,
@@ -1242,6 +1177,12 @@ export async function attachOpenListenerSocket(
   socket.on("message", (data: WebSocket.RawData) => {
     void (async () => {
       await options.startupReady;
+      if (
+        connection.cancellation.signal.aborted ||
+        runtime.connections.get(opts.connectionId) !== connection
+      ) {
+        return;
+      }
       await handleMessage(data);
     })().catch((error) => {
       trackListenerError(
@@ -1304,6 +1245,12 @@ export async function attachOpenListenerSocket(
   }
 
   await options.startupReady;
+  if (
+    connection.cancellation.signal.aborted ||
+    runtime.connections.get(opts.connectionId) !== connection
+  ) {
+    return;
+  }
 
   const streamTransport =
     streamSocket?.readyState === WebSocket.OPEN ? streamSocket : null;
@@ -1601,7 +1548,7 @@ async function connectWithRetry(
     }
 
     clearRuntimeTimers(runtime);
-    closeListenerConnection(runtime, opts.connectionId);
+    suspendListenerConnection(runtime, opts.connectionId);
     killAllTerminals();
     runtime._unsubscribeSubagentState?.();
     runtime._unsubscribeSubagentState = undefined;

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -22,7 +22,6 @@ import {
   startScheduler as startCronScheduler,
   stopScheduler as stopCronScheduler,
 } from "@/cron/scheduler";
-import type { DequeuedBatch } from "@/queue/queue-runtime";
 import { createSharedReminderState } from "@/reminders/state";
 import { getCurrentWorkingDirectory } from "@/runtime-context";
 import { settingsManager } from "@/settings-manager";
@@ -50,6 +49,17 @@ import {
   getCurrentModelStatusForRuntime,
   resolveModelForUpdate,
 } from "./commands/model-toolset";
+import {
+  closeListenerConnection,
+  getOrCreateProcessTransport,
+  markListenerConnectionInitialized,
+  openListenerConnection,
+} from "./connection";
+import {
+  cleanupListenerConnection,
+  closeListenerRuntimeConnections,
+  createConnectionTurnProcessor,
+} from "./connection-lifecycle";
 import {
   INITIAL_RETRY_DELAY_MS,
   isListenerPongStale,
@@ -110,7 +120,6 @@ import {
   type ListenerTransport,
   LocalListenerTransport,
 } from "./transport";
-import { handleIncomingMessage } from "./turn";
 import { escapeTaskNotificationSummary } from "./turn-events";
 import type {
   ConversationRuntime,
@@ -904,6 +913,11 @@ export function createRuntime(): ListenerRuntime {
     hasSuccessfulConnection: false,
     everConnected: false,
     sessionId: `listen-${crypto.randomUUID()}`,
+    nextConnectionOrdinal: 0,
+    connections: new Map(),
+    connectionIdsByRuntimeKey: new Map(),
+    processTransport: null,
+    processServicesStarted: false,
     eventSeqCounter: 0,
     queueEmitScheduled: false,
     pendingQueueEmitScope: undefined,
@@ -955,6 +969,8 @@ export function stopRuntime(
   }
   runtime.conversationRuntimes.clear();
   runtime.approvalRuntimeKeyByRequestId.clear();
+  closeListenerRuntimeConnections(runtime, suppressCallbacks);
+  runtime.processServicesStarted = false;
   clearListenerWarmState(runtime);
   runtime.reminderStateByConversation.clear();
   runtime.skillSourcesByConversation.clear();
@@ -962,46 +978,6 @@ export function stopRuntime(
   runtime.systemPromptRecompileByConversation.clear();
   runtime.queuedSystemPromptRecompileByConversation.clear();
   stopAllWorktreeWatchers(runtime);
-  if (!runtime.socket) {
-    if (
-      runtime.streamSocket &&
-      (runtime.streamSocket.readyState === WebSocket.OPEN ||
-        runtime.streamSocket.readyState === WebSocket.CONNECTING)
-    ) {
-      runtime.streamSocket.close();
-    }
-    runtime.streamSocket = null;
-    runtime.streamTransport = null;
-    runtime.transport = null;
-    return;
-  }
-
-  const socket = runtime.socket;
-  runtime.socket = null;
-  runtime.transport = null;
-  const streamSocket = runtime.streamSocket;
-  runtime.streamSocket = null;
-  runtime.streamTransport = null;
-
-  // Stale runtimes being replaced should not emit callbacks/retries.
-  if (suppressCallbacks) {
-    socket.removeAllListeners();
-  }
-
-  if (
-    socket.readyState === WebSocket.OPEN ||
-    socket.readyState === WebSocket.CONNECTING
-  ) {
-    socket.close();
-  }
-
-  if (
-    streamSocket &&
-    (streamSocket.readyState === WebSocket.OPEN ||
-      streamSocket.readyState === WebSocket.CONNECTING)
-  ) {
-    streamSocket.close();
-  }
 }
 
 export async function startConnectedListenerRuntime(
@@ -1032,8 +1008,7 @@ export async function startConnectedListenerRuntime(
   const shouldStartCronScheduler =
     options.startCronScheduler !== false && !cronSchedulerDisabledByEnv;
 
-  runtime.transport = transport;
-  runtime.streamTransport = options.streamTransport ?? null;
+  markListenerConnectionInitialized(runtime, opts.connectionId);
   safeEmitWsEvent("recv", "lifecycle", {
     type:
       getListenerTransportKind(transport) === "websocket"
@@ -1064,6 +1039,12 @@ export async function startConnectedListenerRuntime(
     }
   }
 
+  if (runtime.processServicesStarted) {
+    return;
+  }
+  runtime.processServicesStarted = true;
+  const processTransport = getOrCreateProcessTransport(runtime);
+
   // Subscribe to subagent state changes and emit snapshots over the listener
   // transport. Local channel mode intentionally discards these frames.
   runtime._unsubscribeSubagentState?.();
@@ -1085,7 +1066,7 @@ export async function startConnectedListenerRuntime(
   runtime._unsubscribeSubagentStreamEvents?.();
   runtime._unsubscribeSubagentStreamEvents = subscribeToSubagentStreamEvents(
     (subagentId, event) => {
-      if (!isListenerTransportOpen(transport)) return;
+      if (!isListenerTransportOpen(processTransport)) return;
 
       const subagent = getSubagents().find((entry) => entry.id === subagentId);
       if (subagent?.silent === true) {
@@ -1097,7 +1078,7 @@ export async function startConnectedListenerRuntime(
       // The event has { type: "message", message_type, ...LettaStreamingResponse }
       // plus extra headless fields (session_id, uuid) that pass through harmlessly.
       emitStreamDelta(
-        transport,
+        processTransport,
         runtime,
         event as unknown as import("@/types/protocol_v2").StreamDelta,
         subagent?.parentAgentId
@@ -1144,7 +1125,7 @@ export async function startConnectedListenerRuntime(
     // (see consumeQueuedTurn notification-aware path in queue.ts).
     scheduleQueuePump(
       targetRuntime,
-      transport,
+      processTransport,
       opts as StartListenerOptions,
       processQueuedTurn,
     );
@@ -1194,7 +1175,7 @@ export async function startConnectedListenerRuntime(
 
   if (shouldStartCronScheduler) {
     startCronScheduler(
-      transport,
+      processTransport,
       opts as StartListenerOptions,
       processQueuedTurn,
     );
@@ -1203,7 +1184,7 @@ export async function startConnectedListenerRuntime(
   // Wire channel ingress (if channels are active).
   await wireChannelIngress(
     runtime,
-    transport,
+    processTransport,
     opts as StartListenerOptions,
     processQueuedTurn,
   );
@@ -1233,38 +1214,27 @@ export async function attachOpenListenerSocket(
   }
 
   const streamSocket = options.streamSocket ?? null;
+  openListenerConnection({
+    runtime,
+    connectionId: opts.connectionId,
+    writer: socket,
+    streamWriter: streamSocket,
+    options: opts,
+  });
   const fileCommandSession = createFileCommandSession({
     socket,
     safeSocketSend,
     runDetachedListenerTask,
   });
 
-  runtime.socket = socket;
-  runtime.streamSocket = streamSocket;
   installExternalToolBridge(runtime);
-  const transport = socket;
-  const processQueuedTurn: ProcessQueuedTurn = async (
-    queuedTurn: IncomingMessage,
-    dequeuedBatch: DequeuedBatch,
-  ): Promise<void> => {
-    const scopedRuntime = getOrCreateScopedRuntime(
-      runtime,
-      queuedTurn.agentId,
-      queuedTurn.conversationId,
-    );
-    await handleIncomingMessage(
-      queuedTurn,
-      transport,
-      scopedRuntime,
-      opts.onStatusChange,
-      opts.connectionId,
-      dequeuedBatch.batchId,
-    );
-  };
+  const transport: ListenerTransport = socket;
+  const processQueuedTurn = createConnectionTurnProcessor(runtime);
 
   const handleMessage = createListenerMessageHandler({
     runtime,
     socket,
+    connectionId: opts.connectionId,
     opts,
     processQueuedTurn,
     fileCommandSession,
@@ -1306,12 +1276,7 @@ export async function attachOpenListenerSocket(
       reason: reasonText,
     });
     fileCommandSession.dispose();
-    stopCronScheduler();
-    getChannelRegistry()?.pause();
-    stopRuntime(runtime, true);
-    if (getActiveRuntime() === runtime) {
-      setActiveRuntime(null);
-    }
+    cleanupListenerConnection(runtime, opts.connectionId);
     opts.onDisconnected();
   });
 
@@ -1424,24 +1389,18 @@ export async function startLocalChannelListener(
     await reloadListenerModAdapter(runtime);
     await loadTools();
     const transport = new LocalListenerTransport();
-    const processQueuedTurn: ProcessQueuedTurn = async (
-      queuedTurn: IncomingMessage,
-      dequeuedBatch: DequeuedBatch,
-    ): Promise<void> => {
-      const scopedRuntime = getOrCreateScopedRuntime(
-        runtime,
-        queuedTurn.agentId,
-        queuedTurn.conversationId,
-      );
-      await handleIncomingMessage(
-        queuedTurn,
-        transport,
-        scopedRuntime,
-        opts.onStatusChange,
-        opts.connectionId,
-        dequeuedBatch.batchId,
-      );
+    const connectionOptions: StartListenerOptions = {
+      ...opts,
+      wsUrl: "local://listener",
+      onDisconnected: () => {},
     };
+    openListenerConnection({
+      runtime,
+      connectionId: opts.connectionId,
+      writer: transport,
+      options: connectionOptions,
+    });
+    const processQueuedTurn = createConnectionTurnProcessor(runtime);
 
     await startConnectedListenerRuntime(
       runtime,
@@ -1559,30 +1518,20 @@ async function connectWithRetry(
   runtime.socket = socket;
   runtime.streamSocket = streamSocket;
   const transport = socket;
-  const processQueuedTurn: ProcessQueuedTurn = async (
-    queuedTurn: IncomingMessage,
-    dequeuedBatch: DequeuedBatch,
-  ): Promise<void> => {
-    const scopedRuntime = getOrCreateScopedRuntime(
-      runtime,
-      queuedTurn.agentId,
-      queuedTurn.conversationId,
-    );
-    await handleIncomingMessage(
-      queuedTurn,
-      transport,
-      scopedRuntime,
-      opts.onStatusChange,
-      opts.connectionId,
-      dequeuedBatch.batchId,
-    );
-  };
+  const processQueuedTurn = createConnectionTurnProcessor(runtime);
 
   socket.on("open", async () => {
     let streamTransport: ListenerTransport | null = null;
     if (streamSocket) {
       streamTransport = await waitForStreamSocketOpen(streamSocket, runtime);
     }
+    openListenerConnection({
+      runtime,
+      connectionId: opts.connectionId,
+      writer: socket,
+      streamWriter: streamTransport,
+      options: opts,
+    });
     await startConnectedListenerRuntime(
       runtime,
       transport,
@@ -1601,6 +1550,7 @@ async function connectWithRetry(
     createListenerMessageHandler({
       runtime,
       socket,
+      connectionId: opts.connectionId,
       opts,
       processQueuedTurn,
       fileCommandSession,
@@ -1661,6 +1611,7 @@ async function connectWithRetry(
     }
 
     clearRuntimeTimers(runtime);
+    closeListenerConnection(runtime, opts.connectionId);
     killAllTerminals();
     runtime._unsubscribeSubagentState?.();
     runtime._unsubscribeSubagentState = undefined;
@@ -1679,6 +1630,7 @@ async function connectWithRetry(
     runtime.socket = null;
     runtime.streamSocket = null;
     runtime.streamTransport = null;
+    runtime.processServicesStarted = false;
     for (const conversationRuntime of runtime.conversationRuntimes.values()) {
       rejectPendingApprovalResolvers(
         conversationRuntime,

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -35,7 +35,10 @@ import { loadTools } from "@/tools/manager";
 import { isDebugEnabled } from "@/utils/debug";
 import { setMessageQueueAdder } from "@/utils/message-queue-bridge";
 import { killAllTerminals } from "@/websocket/terminal-handler";
-import { rejectPendingApprovalResolvers } from "./approval";
+import {
+  getPendingApprovalRequestIds,
+  rejectPendingApprovalResolvers,
+} from "./approval";
 import { resolveListenerReconnectAuth } from "./auth";
 import {
   recoverActiveChannelTurn,
@@ -61,6 +64,10 @@ import {
   createConnectionTurnProcessor,
 } from "./connection-lifecycle";
 import {
+  emitInitialConnectionState,
+  replaySubscribedConnectionState,
+} from "./connection-state-sync";
+import {
   INITIAL_RETRY_DELAY_MS,
   isListenerPongStale,
   LISTENER_HEARTBEAT_INTERVAL_MS,
@@ -75,7 +82,6 @@ import {
 } from "./control-inputs";
 import {
   ensureConversationQueueRuntime,
-  findFallbackRuntime,
   getOrCreateScopedRuntime,
 } from "./conversation-runtime";
 import { loadPersistedCwdMap, seedConversationWorkingDirectory } from "./cwd";
@@ -96,8 +102,6 @@ import {
 } from "./permission-mode";
 import {
   emitDeviceStatusUpdate,
-  emitLoopStatusUpdate,
-  emitStateSync,
   emitStreamDelta,
   emitSubagentStateIfOpen,
 } from "./protocol-outbound";
@@ -234,7 +238,6 @@ export async function replaySyncStateForRuntime(
   );
   const recoverFn =
     opts?.recoverApprovalStateForSync ?? recoverApprovalStateForSync;
-
   if (opts?.recoverApprovals ?? true) {
     try {
       await recoverFn(syncScopedRuntime, scope);
@@ -250,9 +253,13 @@ export async function replaySyncStateForRuntime(
     }
   }
 
-  emitStateSync(socket, listenerRuntime, scope, {
-    forceDeviceStatus: opts?.forceDeviceStatus,
-  });
+  replaySubscribedConnectionState(
+    listenerRuntime,
+    socket,
+    syncScopedRuntime,
+    scope,
+    opts?.forceDeviceStatus,
+  );
   (opts?.scheduleWarmupsAfterSync ?? scheduleListenerWarmupsAfterSync)(
     listenerRuntime,
     scope,
@@ -311,9 +318,7 @@ export async function recoverPendingChannelControlRequests(
       scope.agent_id,
       scope.conversation_id,
     );
-    const livePendingRequestIds = new Set(
-      runtime.pendingApprovalResolvers.keys(),
-    );
+    const livePendingRequestIds = getPendingApprovalRequestIds(runtime);
     const shouldRecoverFromBackend = entries.some(
       (entry) => !livePendingRequestIds.has(entry.event.requestId),
     );
@@ -992,6 +997,7 @@ export async function startConnectedListenerRuntime(
     startHeartbeat?: boolean;
     startCronScheduler?: boolean;
     streamTransport?: ListenerTransport | null;
+    emitInitialState?: boolean;
   } = {},
 ): Promise<void> {
   if (runtime !== getActiveRuntime() || runtime.intentionallyClosed) {
@@ -1019,25 +1025,7 @@ export async function startConnectedListenerRuntime(
   runtime.everConnected = true;
   opts.onConnected(opts.connectionId);
 
-  if (runtime.conversationRuntimes.size === 0) {
-    // Don't emit device_status before the lookup store exists.
-    // Without a conversation runtime, the scope resolves to
-    // agent:__unknown__ which misses persisted CWD and permission
-    // mode entries. The web's sync command will create a scoped
-    // runtime and emit a properly-scoped device_status at that point.
-    emitLoopStatusUpdate(transport, runtime);
-  } else {
-    // Preserve existing per-conversation reminder and context state across
-    // pure transport reconnects; only refresh the live status snapshots here.
-    for (const conversationRuntime of runtime.conversationRuntimes.values()) {
-      const scope = {
-        agent_id: conversationRuntime.agentId,
-        conversation_id: conversationRuntime.conversationId,
-      };
-      emitDeviceStatusUpdate(transport, conversationRuntime, scope);
-      emitLoopStatusUpdate(transport, conversationRuntime, scope);
-    }
-  }
+  emitInitialConnectionState(runtime, transport, opts.connectionId, options);
 
   if (runtime.processServicesStarted) {
     return;
@@ -1096,14 +1084,17 @@ export async function startConnectedListenerRuntime(
   // correct per-conversation QueueRuntime. This enables background Task
   // completions to reach the agent in listen mode.
   setMessageQueueAdder((queuedMessage) => {
-    const targetRuntime =
-      queuedMessage.agentId && queuedMessage.conversationId
-        ? getOrCreateScopedRuntime(
-            runtime,
-            queuedMessage.agentId,
-            queuedMessage.conversationId,
-          )
-        : findFallbackRuntime(runtime);
+    if (!queuedMessage.agentId || !queuedMessage.conversationId) {
+      // A process-originated notification without a complete runtime scope
+      // cannot be routed safely in a multi-client app-server. Dropping it is
+      // preferable to selecting an arbitrary conversation.
+      return;
+    }
+    const targetRuntime = getOrCreateScopedRuntime(
+      runtime,
+      queuedMessage.agentId,
+      queuedMessage.conversationId,
+    );
 
     if (!targetRuntime?.queueRuntime) {
       return; // No target - notification dropped
@@ -1327,6 +1318,7 @@ export async function attachOpenListenerSocket(
       startHeartbeat: options.startHeartbeat ?? false,
       startCronScheduler: options.startCronScheduler ?? true,
       streamTransport,
+      emitInitialState: false,
     },
   );
 }

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -940,7 +940,6 @@ export function createRuntime(): ListenerRuntime {
     connectionId: null,
     connectionName: null,
     conversationRuntimes: new Map(),
-    approvalRuntimeKeyByRequestId: new Map(),
     memfsSyncedAgents: new Map(),
     secretsHydrationByAgent: new Map(),
     secretsHydrationFreshnessByAgent: new Map(),
@@ -973,7 +972,6 @@ export function stopRuntime(
     }
   }
   runtime.conversationRuntimes.clear();
-  runtime.approvalRuntimeKeyByRequestId.clear();
   closeListenerRuntimeConnections(runtime, suppressCallbacks);
   runtime.processServicesStarted = false;
   clearListenerWarmState(runtime);

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -35,6 +35,7 @@ import { handleRuntimeStartProtocolCommand } from "./commands/runtime-start";
 import { handleSecretsCommand } from "./commands/secrets";
 import { handleSettingsProtocolCommand } from "./commands/settings";
 import { handleSkillAgentProtocolCommand } from "./commands/skills-agents";
+import { subscribeListenerConnection } from "./connection";
 import { getBootWorkingDirectory, getExportedCwdMap } from "./cwd";
 import { handleExternalToolCallResponseCommand } from "./external-tools";
 import { dispatchInboundMessageWhenReady } from "./inbound-dispatch";
@@ -60,6 +61,7 @@ import { handleIncomingMessage } from "./turn";
 import type {
   ConversationRuntime,
   IncomingMessage,
+  ListenerConnectionId,
   ListenerRuntime,
   ProcessQueuedTurn,
   StartListenerOptions,
@@ -104,6 +106,7 @@ export type WireChannelIngress = (
 type MessageRouterParams = {
   runtime: ListenerRuntime;
   socket: WebSocket;
+  connectionId?: ListenerConnectionId;
   opts: StartListenerOptions;
   processQueuedTurn: ProcessQueuedTurn;
   fileCommandSession: FileCommandSession;
@@ -127,6 +130,7 @@ type MessageRouterParams = {
         conversation_id?: string | null;
       };
       response: ApprovalResponseBody;
+      connectionId: ListenerConnectionId;
       socket: ListenerTransport;
       opts: {
         onStatusChange?: StartListenerOptions["onStatusChange"];
@@ -139,6 +143,7 @@ type MessageRouterParams = {
     listener: ListenerRuntime,
     params: {
       command: ChangeDeviceStateCommand;
+      connectionId: ListenerConnectionId;
       socket: WebSocket;
       opts: {
         onStatusChange?: StartListenerOptions["onStatusChange"];
@@ -151,6 +156,7 @@ type MessageRouterParams = {
     listener: ListenerRuntime,
     params: {
       command: AbortMessageCommand;
+      connectionId: ListenerConnectionId;
       socket: WebSocket;
       opts: {
         onStatusChange?: StartListenerOptions["onStatusChange"];
@@ -364,6 +370,7 @@ export function createListenerMessageHandler(
   const {
     runtime,
     socket,
+    connectionId: explicitConnectionId,
     opts,
     processQueuedTurn,
     fileCommandSession,
@@ -380,6 +387,7 @@ export function createListenerMessageHandler(
     wireChannelIngress,
     processIncomingMessage = handleIncomingMessage,
   } = params;
+  const connectionId = explicitConnectionId ?? opts.connectionId;
 
   return async (data: WebSocket.RawData): Promise<void> => {
     const raw = data.toString();
@@ -420,6 +428,10 @@ export function createListenerMessageHandler(
 
       console.log(`[Listen V2] Received ${summarizeV2Command(parsed)}`);
 
+      if (parsedScope) {
+        subscribeListenerConnection(runtime, connectionId, parsedScope);
+      }
+
       if (parsed.type === "__invalid_input") {
         emitLoopErrorNotice(socket, runtime, {
           message: parsed.reason,
@@ -439,6 +451,7 @@ export function createListenerMessageHandler(
       if (
         handleRuntimeStartProtocolCommand(parsed, {
           socket,
+          connectionId,
           runtime,
           safeSocketSend,
           runDetachedListenerTask,
@@ -450,7 +463,7 @@ export function createListenerMessageHandler(
       }
 
       if (parsed.type === "external_tool_call_response") {
-        handleExternalToolCallResponseCommand(runtime, parsed);
+        handleExternalToolCallResponseCommand(runtime, connectionId, parsed);
         return;
       }
 
@@ -523,6 +536,7 @@ export function createListenerMessageHandler(
             await handleApprovalResponseInput(runtime, {
               runtime: parsed.runtime,
               response: parsed.payload,
+              connectionId,
               socket,
               opts: {
                 onStatusChange: opts.onStatusChange,
@@ -550,6 +564,7 @@ export function createListenerMessageHandler(
 
         const incoming: IncomingMessage = {
           type: "message",
+          connectionId,
           agentId: parsed.runtime.agent_id,
           conversationId: parsed.runtime.conversation_id,
           clientToolAllowlist: inputPayload.client_tool_allowlist,
@@ -620,6 +635,7 @@ export function createListenerMessageHandler(
       if (parsed.type === "change_device_state") {
         await handleChangeDeviceStateInput(runtime, {
           command: parsed,
+          connectionId,
           socket,
           opts: {
             onStatusChange: opts.onStatusChange,
@@ -652,6 +668,7 @@ export function createListenerMessageHandler(
         try {
           const aborted = await handleAbortMessageInput(runtime, {
             command: parsed,
+            connectionId,
             socket,
             opts: {
               onStatusChange: opts.onStatusChange,
@@ -910,22 +927,23 @@ export function createListenerMessageHandler(
           parsed,
           socket,
           parsed.cwd ?? getBootWorkingDirectory(runtime),
+          connectionId,
         );
         return;
       }
 
       if (parsed.type === "terminal_input") {
-        handleTerminalInput(parsed);
+        handleTerminalInput(parsed, connectionId);
         return;
       }
 
       if (parsed.type === "terminal_resize") {
-        handleTerminalResize(parsed);
+        handleTerminalResize(parsed, connectionId);
         return;
       }
 
       if (parsed.type === "terminal_kill") {
-        handleTerminalKill(parsed);
+        handleTerminalKill(parsed, connectionId);
       }
     } catch (error) {
       trackListenerError(

--- a/src/websocket/listener/process-event-routing.ts
+++ b/src/websocket/listener/process-event-routing.ts
@@ -1,0 +1,83 @@
+import {
+  getSubagents,
+  subscribe as subscribeToSubagentState,
+  subscribeToStreamEvents as subscribeToSubagentStreamEvents,
+} from "@/agent/subagent-state";
+import { setMessageQueueAdder } from "@/utils/message-queue-bridge";
+import { getOrCreateScopedRuntime } from "./conversation-runtime";
+import { emitStreamDelta, emitSubagentStateIfOpen } from "./protocol-outbound";
+import { scheduleQueuePump } from "./queue";
+import type { ListenerTransport } from "./transport";
+import { isListenerTransportOpen } from "./transport";
+import type {
+  ListenerRuntime,
+  ProcessQueuedTurn,
+  StartListenerOptions,
+} from "./types";
+
+export function installProcessEventRouting(params: {
+  runtime: ListenerRuntime;
+  processTransport: ListenerTransport;
+  opts: StartListenerOptions;
+  processQueuedTurn: ProcessQueuedTurn;
+}): void {
+  const { runtime, processTransport, opts, processQueuedTurn } = params;
+  runtime._unsubscribeSubagentState?.();
+  runtime._unsubscribeSubagentState = subscribeToSubagentState(() => {
+    if (runtime.conversationRuntimes.size === 0) {
+      emitSubagentStateIfOpen(runtime);
+      return;
+    }
+    for (const conversationRuntime of runtime.conversationRuntimes.values()) {
+      emitSubagentStateIfOpen(runtime, {
+        agent_id: conversationRuntime.agentId,
+        conversation_id: conversationRuntime.conversationId,
+      });
+    }
+  });
+
+  runtime._unsubscribeSubagentStreamEvents?.();
+  runtime._unsubscribeSubagentStreamEvents = subscribeToSubagentStreamEvents(
+    (subagentId, event) => {
+      if (!isListenerTransportOpen(processTransport)) return;
+      const subagent = getSubagents().find((entry) => entry.id === subagentId);
+      if (subagent?.silent === true) return;
+
+      emitStreamDelta(
+        processTransport,
+        runtime,
+        event as unknown as import("@/types/protocol_v2").StreamDelta,
+        subagent?.parentAgentId
+          ? {
+              agent_id: subagent.parentAgentId,
+              conversation_id: subagent.parentConversationId ?? "default",
+            }
+          : undefined,
+        subagentId,
+      );
+    },
+  );
+
+  setMessageQueueAdder((queuedMessage) => {
+    if (!queuedMessage.agentId || !queuedMessage.conversationId) return;
+    const targetRuntime = getOrCreateScopedRuntime(
+      runtime,
+      queuedMessage.agentId,
+      queuedMessage.conversationId,
+    );
+    if (!targetRuntime?.queueRuntime) return;
+
+    targetRuntime.queueRuntime.enqueue({
+      kind: "task_notification",
+      source: "task_notification",
+      text: queuedMessage.text,
+      agentId: queuedMessage.agentId ?? targetRuntime.agentId ?? undefined,
+      conversationId:
+        queuedMessage.conversationId ?? targetRuntime.conversationId,
+    } as Omit<
+      import("@/queue/queue-runtime").TaskNotificationQueueItem,
+      "id" | "enqueuedAt"
+    >);
+    scheduleQueuePump(targetRuntime, processTransport, opts, processQueuedTurn);
+  });
+}

--- a/src/websocket/listener/process-services.ts
+++ b/src/websocket/listener/process-services.ts
@@ -3,10 +3,12 @@ import {
   subscribe as subscribeToSubagentState,
   subscribeToStreamEvents as subscribeToSubagentStreamEvents,
 } from "@/agent/subagent-state";
+import { stopScheduler as stopCronScheduler } from "@/cron/scheduler";
 import { setMessageQueueAdder } from "@/utils/message-queue-bridge";
 import { getOrCreateScopedRuntime } from "./conversation-runtime";
 import { emitStreamDelta, emitSubagentStateIfOpen } from "./protocol-outbound";
 import { scheduleQueuePump } from "./queue";
+import { clearRuntimeTimers, getActiveRuntime } from "./runtime";
 import type { ListenerTransport } from "./transport";
 import { isListenerTransportOpen } from "./transport";
 import type {
@@ -80,4 +82,50 @@ export function installProcessEventRouting(params: {
     >);
     scheduleQueuePump(targetRuntime, processTransport, opts, processQueuedTurn);
   });
+}
+
+export function clearProcessServices(runtime: ListenerRuntime): void {
+  runtime._unsubscribeSubagentState?.();
+  runtime._unsubscribeSubagentState = undefined;
+  runtime._unsubscribeSubagentStreamEvents?.();
+  runtime._unsubscribeSubagentStreamEvents = undefined;
+  setMessageQueueAdder(null);
+  stopCronScheduler();
+  clearRuntimeTimers(runtime);
+  runtime.processServicesStarted = false;
+}
+
+export function invalidateProcessServices(runtime: ListenerRuntime): void {
+  runtime.processServicesGeneration += 1;
+  clearProcessServices(runtime);
+}
+
+export async function waitForProcessServicesSlot(
+  runtime: ListenerRuntime,
+  connectionId: string,
+): Promise<boolean> {
+  const initiatingConnection = runtime.connections.get(connectionId);
+  const canInitiate = () =>
+    !initiatingConnection ||
+    (runtime.connections.get(connectionId) === initiatingConnection &&
+      !initiatingConnection.cancellation.signal.aborted);
+
+  while (runtime.processServicesReady) {
+    const pending = runtime.processServicesReady;
+    const pendingGeneration = runtime.processServicesReadyGeneration;
+    try {
+      await pending;
+    } catch (error) {
+      if (pendingGeneration === runtime.processServicesGeneration) throw error;
+    }
+    if (runtime.processServicesStarted) return false;
+    if (
+      runtime !== getActiveRuntime() ||
+      runtime.intentionallyClosed ||
+      !canInitiate()
+    ) {
+      return false;
+    }
+  }
+  return canInitiate();
 }

--- a/src/websocket/listener/protocol-outbound.test.ts
+++ b/src/websocket/listener/protocol-outbound.test.ts
@@ -55,6 +55,8 @@ function createRuntime(): {
     transport: socket as never,
     streamTransport: null,
     eventSeqCounter: 0,
+    connections: new Map(),
+    connectionIdsByRuntimeKey: new Map(),
     conversationRuntimes: new Map(),
   } as unknown as ListenerRuntime;
   const runtime = {

--- a/src/websocket/listener/protocol-outbound.test.ts
+++ b/src/websocket/listener/protocol-outbound.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, test } from "bun:test";
 import WebSocket from "ws";
 import type { DequeuedBatch } from "@/queue/queue-runtime";
 import type { StreamDeltaMessage } from "@/types/protocol_v2";
+import {
+  markListenerConnectionInitialized,
+  openListenerConnection,
+  subscribeListenerConnection,
+} from "@/websocket/listener/connection";
 import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
 import { createRuntime as createListenerRuntime } from "@/websocket/listener/lifecycle";
 import { OUTBOUND_QUEUE_LIMITS } from "@/websocket/listener/outbound-wire";
@@ -91,6 +96,78 @@ describe("emitProtocolV2Message backpressure", () => {
 
     expect(socket.terminated).toBe(true);
     expect(socket.sentPayloads).toEqual([]);
+  });
+});
+
+describe("emitProtocolV2Message connection routing", () => {
+  test("fans notifications out to subscribers and honors an explicit target", () => {
+    const listener = createListenerRuntime();
+    const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
+    const socketA = new MockSocket();
+    const socketB = new MockSocket();
+    const socketC = new MockSocket();
+    const scope = { agent_id: "agent-1", conversation_id: "conv-1" };
+
+    for (const [connectionId, socket] of [
+      ["client-a", socketA],
+      ["client-b", socketB],
+      ["client-c", socketC],
+    ] as const) {
+      openListenerConnection({
+        runtime: listener,
+        connectionId,
+        writer: socket as never,
+        options: {
+          connectionId,
+          wsUrl: "ws://test",
+          deviceId: "test",
+          connectionName: connectionId,
+          onConnected: () => {},
+          onDisconnected: () => {},
+          onError: () => {},
+        },
+      });
+      markListenerConnectionInitialized(listener, connectionId);
+    }
+    subscribeListenerConnection(listener, "client-a", scope);
+    subscribeListenerConnection(listener, "client-b", scope);
+
+    emitProtocolV2Message(
+      socketC as never,
+      runtime,
+      {
+        type: "update_loop_status",
+        loop_status: { status: "WAITING_ON_INPUT", active_run_ids: [] },
+      } as never,
+      scope,
+    );
+
+    expect(socketA.sentPayloads).toHaveLength(1);
+    expect(socketB.sentPayloads).toHaveLength(1);
+    expect(socketC.sentPayloads).toHaveLength(0);
+
+    emitProtocolV2Message(
+      socketA as never,
+      runtime,
+      {
+        type: "control_request",
+        request_id: "approval-1",
+        request: {
+          subtype: "can_use_tool",
+          tool_name: "Bash",
+          input: {},
+          tool_call_id: "tool-1",
+          permission_suggestions: [],
+          blocked_path: null,
+        },
+      } as never,
+      scope,
+      { connectionId: "client-b", subscribers: false },
+    );
+
+    expect(socketA.sentPayloads).toHaveLength(1);
+    expect(socketB.sentPayloads).toHaveLength(2);
+    expect(socketC.sentPayloads).toHaveLength(0);
   });
 });
 

--- a/src/websocket/listener/protocol-outbound.test.ts
+++ b/src/websocket/listener/protocol-outbound.test.ts
@@ -6,6 +6,8 @@ import {
   markListenerConnectionInitialized,
   openListenerConnection,
   subscribeListenerConnection,
+  TO_SUBSCRIBERS,
+  toListenerConnection,
 } from "@/websocket/listener/connection";
 import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
 import { createRuntime as createListenerRuntime } from "@/websocket/listener/lifecycle";
@@ -70,13 +72,19 @@ describe("emitProtocolV2Message backpressure", () => {
     socket.bufferedAmount = OUTBOUND_QUEUE_LIMITS.HIGH_WATERMARK_BUFFERED_BYTES;
 
     for (let i = 0; i <= OUTBOUND_QUEUE_LIMITS.MAX_QUEUED_FRAMES; i += 1) {
-      emitProtocolV2Message(socket as never, runtime, {
-        type: "stream_delta",
-        delta: {
-          message_type: "assistant_message",
-          content: `delta-${i}`,
-        },
-      } as never);
+      emitProtocolV2Message(
+        socket as never,
+        runtime,
+        {
+          type: "stream_delta",
+          delta: {
+            message_type: "assistant_message",
+            content: `delta-${i}`,
+          },
+        } as never,
+        undefined,
+        TO_SUBSCRIBERS,
+      );
     }
 
     expect(socket.terminated).toBe(true);
@@ -88,10 +96,16 @@ describe("emitProtocolV2Message backpressure", () => {
     socket.bufferedAmount = OUTBOUND_QUEUE_LIMITS.HIGH_WATERMARK_BUFFERED_BYTES;
 
     for (let i = 0; i <= OUTBOUND_QUEUE_LIMITS.MAX_QUEUED_FRAMES; i += 1) {
-      emitProtocolV2Message(socket as never, runtime, {
-        type: "future_protocol_message",
-        content: `frame-${i}`,
-      } as never);
+      emitProtocolV2Message(
+        socket as never,
+        runtime,
+        {
+          type: "future_protocol_message",
+          content: `frame-${i}`,
+        } as never,
+        undefined,
+        TO_SUBSCRIBERS,
+      );
     }
 
     expect(socket.terminated).toBe(true);
@@ -140,6 +154,7 @@ describe("emitProtocolV2Message connection routing", () => {
         loop_status: { status: "WAITING_ON_INPUT", active_run_ids: [] },
       } as never,
       scope,
+      TO_SUBSCRIBERS,
     );
 
     expect(socketA.sentPayloads).toHaveLength(1);
@@ -162,12 +177,114 @@ describe("emitProtocolV2Message connection routing", () => {
         },
       } as never,
       scope,
-      { connectionId: "client-b", subscribers: false },
+      toListenerConnection("client-b"),
     );
 
     expect(socketA.sentPayloads).toHaveLength(1);
     expect(socketB.sentPayloads).toHaveLength(2);
     expect(socketC.sentPayloads).toHaveLength(0);
+  });
+
+  test("drops scoped events when the scope has no subscribers", () => {
+    const listener = createListenerRuntime();
+    const runtime = getOrCreateScopedRuntime(listener, "agent-1", "conv-1");
+    const socketA = new MockSocket();
+    const socketB = new MockSocket();
+    for (const [connectionId, socket] of [
+      ["client-a", socketA],
+      ["client-b", socketB],
+    ] as const) {
+      openListenerConnection({
+        runtime: listener,
+        connectionId,
+        writer: socket as never,
+        options: {
+          connectionId,
+          wsUrl: "ws://test",
+          deviceId: "test",
+          connectionName: connectionId,
+          onConnected: () => {},
+          onDisconnected: () => {},
+          onError: () => {},
+        },
+      });
+      markListenerConnectionInitialized(listener, connectionId);
+    }
+
+    emitProtocolV2Message(
+      socketA as never,
+      runtime,
+      {
+        type: "update_queue",
+        queue: [],
+      } as never,
+      { agent_id: "agent-1", conversation_id: "conv-1" },
+      TO_SUBSCRIBERS,
+    );
+
+    expect(socketA.sentPayloads).toEqual([]);
+    expect(socketB.sentPayloads).toEqual([]);
+  });
+
+  test("keeps cron and background snapshots inside their subscribed runtime", () => {
+    const listener = createListenerRuntime();
+    const runtimeA = getOrCreateScopedRuntime(listener, "agent-a", "conv-a");
+    const socketA = new MockSocket();
+    const socketB = new MockSocket();
+    for (const [connectionId, socket] of [
+      ["client-a", socketA],
+      ["client-b", socketB],
+    ] as const) {
+      openListenerConnection({
+        runtime: listener,
+        connectionId,
+        writer: socket as never,
+        options: {
+          connectionId,
+          wsUrl: "ws://test",
+          deviceId: "test",
+          connectionName: connectionId,
+          onConnected: () => {},
+          onDisconnected: () => {},
+          onError: () => {},
+        },
+      });
+      markListenerConnectionInitialized(listener, connectionId);
+    }
+    subscribeListenerConnection(listener, "client-a", {
+      agent_id: "agent-a",
+      conversation_id: "conv-a",
+    });
+    subscribeListenerConnection(listener, "client-b", {
+      agent_id: "agent-b",
+      conversation_id: "conv-b",
+    });
+
+    emitProtocolV2Message(
+      socketA as never,
+      runtimeA,
+      {
+        type: "crons_updated",
+        timestamp: 1,
+        agent_id: "agent-a",
+        conversation_id: "conv-a",
+      } as never,
+      { agent_id: "agent-a", conversation_id: "conv-a" },
+      TO_SUBSCRIBERS,
+    );
+    emitProtocolV2Message(
+      socketA as never,
+      runtimeA,
+      {
+        type: "update_subagent_state",
+        subagents: [],
+      } as never,
+      { agent_id: "agent-a", conversation_id: "conv-a" },
+      TO_SUBSCRIBERS,
+    );
+
+    expect(socketA.sentPayloads).toHaveLength(2);
+    expect(socketB.sentPayloads).toEqual([]);
   });
 });
 

--- a/src/websocket/listener/protocol-outbound.test.ts
+++ b/src/websocket/listener/protocol-outbound.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import WebSocket from "ws";
 import type { DequeuedBatch } from "@/queue/queue-runtime";
-import type { StreamDeltaMessage } from "@/types/protocol_v2";
+import {
+  backgroundProcesses,
+  backgroundTasks,
+} from "@/tools/impl/process_manager";
+import type {
+  DeviceStatusUpdateMessage,
+  StreamDeltaMessage,
+} from "@/types/protocol_v2";
 import {
   markListenerConnectionInitialized,
   openListenerConnection,
@@ -285,6 +292,108 @@ describe("emitProtocolV2Message connection routing", () => {
 
     expect(socketA.sentPayloads).toHaveLength(2);
     expect(socketB.sentPayloads).toEqual([]);
+  });
+
+  test("filters populated background jobs across two runtimes", () => {
+    const listener = createListenerRuntime();
+    const runtimeA = getOrCreateScopedRuntime(listener, "agent-a", "conv-a");
+    const runtimeB = getOrCreateScopedRuntime(listener, "agent-b", "conv-b");
+    const socketA = new MockSocket();
+    const socketB = new MockSocket();
+    for (const [connectionId, socket, agentId, conversationId] of [
+      ["client-a", socketA, "agent-a", "conv-a"],
+      ["client-b", socketB, "agent-b", "conv-b"],
+    ] as const) {
+      openListenerConnection({
+        runtime: listener,
+        connectionId,
+        writer: socket as never,
+        options: {
+          connectionId,
+          wsUrl: "ws://test",
+          deviceId: "test",
+          connectionName: connectionId,
+          onConnected: () => {},
+          onDisconnected: () => {},
+          onError: () => {},
+        },
+      });
+      markListenerConnectionInitialized(listener, connectionId);
+      subscribeListenerConnection(listener, connectionId, {
+        agent_id: agentId,
+        conversation_id: conversationId,
+      });
+    }
+    backgroundProcesses.clear();
+    backgroundTasks.clear();
+
+    try {
+      backgroundProcesses.set("bash-agent-a", {
+        process: { kill: () => true },
+        command: "agent-a-secret-command",
+        stdout: [],
+        stderr: [],
+        status: "running",
+        exitCode: null,
+        lastReadIndex: { stdout: 0, stderr: 0 },
+        startTime: new Date("2026-07-27T12:00:00.000Z"),
+        runtimeScope: { agentId: "agent-a", conversationId: "conv-a" },
+      });
+      backgroundTasks.set("task-agent-b", {
+        description: "Agent B task",
+        subagentType: "review",
+        subagentId: "subagent-b",
+        status: "running",
+        output: [],
+        startTime: new Date("2026-07-27T12:01:00.000Z"),
+        outputFile: "/tmp/task-agent-b.log",
+        runtimeScope: { agentId: "agent-b", conversationId: "conv-b" },
+      });
+      backgroundProcesses.set("unowned-job", {
+        process: { kill: () => true },
+        command: "legacy-unowned-command",
+        stdout: [],
+        stderr: [],
+        status: "running",
+        exitCode: null,
+        lastReadIndex: { stdout: 0, stderr: 0 },
+      });
+
+      emitDeviceStatusUpdateIfChanged(
+        socketA as never,
+        runtimeA,
+        {},
+        { force: true },
+      );
+      emitDeviceStatusUpdateIfChanged(
+        socketB as never,
+        runtimeB,
+        {},
+        { force: true },
+      );
+
+      expect(socketA.sentPayloads).toHaveLength(1);
+      expect(socketB.sentPayloads).toHaveLength(1);
+      const statusA = (
+        JSON.parse(socketA.sentPayloads[0] ?? "{}") as DeviceStatusUpdateMessage
+      ).device_status;
+      const statusB = (
+        JSON.parse(socketB.sentPayloads[0] ?? "{}") as DeviceStatusUpdateMessage
+      ).device_status;
+
+      expect(
+        statusA.background_processes.map((process) => process.process_id),
+      ).toEqual(["bash-agent-a"]);
+      expect(
+        statusB.background_processes.map((process) => process.process_id),
+      ).toEqual(["task-agent-b"]);
+      expect(JSON.stringify(statusB.background_processes)).not.toContain(
+        "agent-a-secret-command",
+      );
+    } finally {
+      backgroundProcesses.clear();
+      backgroundTasks.clear();
+    }
   });
 });
 

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -11,12 +11,7 @@ import { experimentManager } from "@/experiments/manager";
 import { permissionMode } from "@/permissions/mode";
 import type { DequeuedBatch } from "@/queue/queue-runtime";
 import { settingsManager } from "@/settings-manager";
-import {
-  backgroundProcesses,
-  backgroundTasks,
-} from "@/tools/impl/process_manager";
 import type {
-  BackgroundProcessSummary,
   DeviceStatus,
   DeviceStatusUpdateMessage,
   LoopState,
@@ -35,6 +30,7 @@ import type {
   WsProtocolMessage,
 } from "@/types/protocol_v2";
 import { isDebugEnabled } from "@/utils/debug";
+import { buildBackgroundProcessSnapshot } from "./background-process-snapshot";
 import {
   type ChannelTurnRuntimeCarrier,
   getActiveChannelTurnProgressContext,
@@ -42,6 +38,7 @@ import {
 import {
   nextListenerConnectionEventSeq,
   resolveListenerConnectionTargets,
+  TO_SUBSCRIBERS,
 } from "./connection";
 import { SYSTEM_REMINDER_RE } from "./constants";
 import { getConversationWorkingDirectory, getExportedCwdMap } from "./cwd";
@@ -165,48 +162,14 @@ function getScopeForRuntime(
   return scope ?? {};
 }
 
-export function buildBackgroundProcessSnapshot(): BackgroundProcessSummary[] {
-  const bashProcesses: BackgroundProcessSummary[] = Array.from(
-    backgroundProcesses.entries(),
-  )
-    .filter(([, proc]) => proc.status === "running")
-    .map(([processId, proc]) => ({
-      process_id: processId,
-      kind: "bash",
-      command: proc.command,
-      started_at_ms: proc.startTime?.getTime() ?? null,
-      status: proc.status,
-      exit_code: proc.exitCode,
-    }));
-
-  const taskProcesses: BackgroundProcessSummary[] = Array.from(
-    backgroundTasks.entries(),
-  )
-    .filter(([, task]) => task.status === "running")
-    .map(([processId, task]) => ({
-      process_id: processId,
-      kind: "agent_task",
-      task_type: task.subagentType,
-      description: task.description,
-      started_at_ms: task.startTime.getTime(),
-      status: task.status,
-      subagent_id: task.subagentId,
-      ...(task.error ? { error: task.error } : {}),
-    }));
-
-  return [...bashProcesses, ...taskProcesses].sort((a, b) => {
-    const aStart = a.started_at_ms ?? 0;
-    const bStart = b.started_at_ms ?? 0;
-    return bStart - aStart;
-  });
-}
-
 export function emitRuntimeStateUpdates(
   runtime: RuntimeCarrier,
-  scope?: {
-    agent_id?: string | null;
-    conversation_id?: string | null;
-  },
+  scope:
+    | {
+        agent_id?: string | null;
+        conversation_id?: string | null;
+      }
+    | undefined,
 ): void {
   emitLoopStatusIfOpen(runtime, scope);
   emitDeviceStatusIfOpen(runtime, scope);
@@ -454,11 +417,13 @@ export function emitProtocolV2Message(
     WsProtocolMessage,
     "runtime" | "event_seq" | "emitted_at" | "idempotency_key"
   >,
-  scope?: {
-    agent_id?: string | null;
-    conversation_id?: string | null;
-  },
-  routing?: ListenerMessageRouting,
+  scope:
+    | {
+        agent_id?: string | null;
+        conversation_id?: string | null;
+      }
+    | undefined,
+  routing: ListenerMessageRouting,
 ): void {
   const listener = getListenerRuntime(runtime);
   const runtimeScope = resolveRuntimeScope(
@@ -472,8 +437,7 @@ export function emitProtocolV2Message(
     runtime: listener,
     origin: socket,
     scope: runtimeScope,
-    connectionId: routing?.connectionId,
-    subscribers: routing?.subscribers !== false,
+    routing,
     streamMessage: isStreamChannelMessage(message.type),
   });
   for (const { connection, transport: targetSocket } of targets) {
@@ -541,6 +505,7 @@ export function emitDeviceStatusUpdate(
   socket: ListenerTransport,
   runtime: RuntimeCarrier,
   scope?: PartialRuntimeScope,
+  routing: ListenerMessageRouting = TO_SUBSCRIBERS,
 ): void {
   const deviceStatus = buildDeviceStatus(runtime, scope);
   recordDeviceStatus(socket, getScopeForRuntime(runtime, scope), deviceStatus);
@@ -551,7 +516,7 @@ export function emitDeviceStatusUpdate(
     type: "update_device_status",
     device_status: deviceStatus,
   };
-  emitProtocolV2Message(socket, runtime, message, scope);
+  emitProtocolV2Message(socket, runtime, message, scope, routing);
 }
 
 export function emitLoopStatusUpdate(
@@ -561,6 +526,7 @@ export function emitLoopStatusUpdate(
     agent_id?: string | null;
     conversation_id?: string | null;
   },
+  routing: ListenerMessageRouting = TO_SUBSCRIBERS,
 ): void {
   const message: Omit<
     LoopStatusUpdateMessage,
@@ -569,7 +535,7 @@ export function emitLoopStatusUpdate(
     type: "update_loop_status",
     loop_status: buildLoopStatus(runtime, scope),
   };
-  emitProtocolV2Message(socket, runtime, message, scope);
+  emitProtocolV2Message(socket, runtime, message, scope, routing);
 }
 
 export function emitLoopStatusIfOpen(
@@ -607,6 +573,7 @@ export function emitQueueUpdate(
     agent_id?: string | null;
     conversation_id?: string | null;
   },
+  routing: ListenerMessageRouting = TO_SUBSCRIBERS,
 ): void {
   const listener = getListenerRuntime(runtime);
   if (!listener) {
@@ -620,7 +587,7 @@ export function emitQueueUpdate(
     type: "update_queue",
     queue: buildQueueSnapshot(runtime, resolvedScope),
   };
-  emitProtocolV2Message(socket, runtime, message, resolvedScope);
+  emitProtocolV2Message(socket, runtime, message, resolvedScope, routing);
 }
 
 function isTextContentPart(
@@ -792,6 +759,7 @@ export function emitDeviceStatusUpdateIfChanged(
   runtime: RuntimeCarrier,
   scope?: PartialRuntimeScope,
   options?: { force?: boolean },
+  routing: ListenerMessageRouting = TO_SUBSCRIBERS,
 ): boolean {
   const resolvedScope = getScopeForRuntime(runtime, scope);
   const deviceStatus = buildDeviceStatus(runtime, resolvedScope);
@@ -807,7 +775,7 @@ export function emitDeviceStatusUpdateIfChanged(
     type: "update_device_status",
     device_status: deviceStatus,
   };
-  emitProtocolV2Message(socket, runtime, message, resolvedScope);
+  emitProtocolV2Message(socket, runtime, message, resolvedScope, routing);
   return true;
 }
 
@@ -815,18 +783,23 @@ export function emitStateSync(
   socket: ListenerTransport,
   runtime: RuntimeCarrier,
   scope: RuntimeScope,
-  options?: { forceDeviceStatus?: boolean },
+  options?: {
+    forceDeviceStatus?: boolean;
+    routing?: ListenerMessageRouting;
+  },
 ): void {
+  const routing = options?.routing ?? TO_SUBSCRIBERS;
   emitDeviceStatusUpdateIfChanged(
     socket,
     runtime,
     scope,
     options?.forceDeviceStatus ? { force: true } : undefined,
+    routing,
   );
 
-  emitLoopStatusUpdate(socket, runtime, scope);
-  emitQueueUpdate(socket, runtime, scope);
-  emitSubagentStateUpdate(socket, runtime, scope);
+  emitLoopStatusUpdate(socket, runtime, scope, routing);
+  emitQueueUpdate(socket, runtime, scope, routing);
+  emitSubagentStateUpdate(socket, runtime, scope, routing);
 }
 
 // ─────────────────────────────────────────────
@@ -904,6 +877,7 @@ export function emitSubagentStateUpdate(
     agent_id?: string | null;
     conversation_id?: string | null;
   },
+  routing: ListenerMessageRouting = TO_SUBSCRIBERS,
 ): void {
   const message: Omit<
     SubagentStateUpdateMessage,
@@ -912,7 +886,7 @@ export function emitSubagentStateUpdate(
     type: "update_subagent_state",
     subagents: buildSubagentSnapshot(runtime, scope),
   };
-  emitProtocolV2Message(socket, runtime, message, scope);
+  emitProtocolV2Message(socket, runtime, message, scope, routing);
 }
 
 export function emitSubagentStateIfOpen(
@@ -1124,5 +1098,5 @@ export function emitStreamDelta(
     delta,
     ...(subagentId ? { subagent_id: subagentId } : {}),
   };
-  emitProtocolV2Message(socket, runtime, message, scope);
+  emitProtocolV2Message(socket, runtime, message, scope, TO_SUBSCRIBERS);
 }

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -39,6 +39,10 @@ import {
   type ChannelTurnRuntimeCarrier,
   getActiveChannelTurnProgressContext,
 } from "./channel-turn-session";
+import {
+  nextListenerConnectionEventSeq,
+  resolveListenerConnectionTargets,
+} from "./connection";
 import { SYSTEM_REMINDER_RE } from "./constants";
 import { getConversationWorkingDirectory, getExportedCwdMap } from "./cwd";
 import {
@@ -54,7 +58,6 @@ import {
   getPendingControlRequests,
   getRecoveredApprovalStateForScope,
   hasInterruptedCacheForScope,
-  nextEventSeq,
   safeEmitWsEvent,
 } from "./runtime";
 import {
@@ -67,6 +70,7 @@ import { isListenerTransportOpen, type ListenerTransport } from "./transport";
 import type {
   ConversationRuntime,
   IncomingMessage,
+  ListenerMessageRouting,
   ListenerRuntime,
 } from "./types";
 
@@ -443,7 +447,6 @@ function classifyOutboundFrame(
     ? "status"
     : "critical";
 }
-
 export function emitProtocolV2Message(
   socket: ListenerTransport,
   runtime: RuntimeCarrier,
@@ -455,86 +458,83 @@ export function emitProtocolV2Message(
     agent_id?: string | null;
     conversation_id?: string | null;
   },
+  routing?: ListenerMessageRouting,
 ): void {
   const listener = getListenerRuntime(runtime);
-
-  // Route stream-type messages to the stream transport when available.
-  // Falls back to the control socket if the stream transport is not open.
-  let targetSocket: ListenerTransport = socket;
-  if (listener?.streamTransport && isStreamChannelMessage(message.type)) {
-    if (isListenerTransportOpen(listener.streamTransport)) {
-      targetSocket = listener.streamTransport;
-    }
-  }
-
   const runtimeScope = resolveRuntimeScope(
     listener,
     getScopeForRuntime(runtime, scope),
   );
   if (!runtimeScope) return;
   notifyStreamObservers(listener, message, runtimeScope);
-  if (!isListenerTransportOpen(targetSocket)) return;
-
-  // The wire layer owns queueing, backpressure, and the actual send. The
-  // envelope is built at drain time so coalesced/dropped frames never consume
-  // an event_seq and the delivered stream stays gap-free.
   const frameClass = classifyOutboundFrame(message);
-  enqueueOutboundFrame(targetSocket, {
-    typeLabel: message.type,
-    frameClass,
-    ...(frameClass === "status"
-      ? {
-          coalesceKey: `${message.type}:${runtimeScope.agent_id ?? ""}:${runtimeScope.conversation_id ?? ""}`,
+  const targets = resolveListenerConnectionTargets({
+    runtime: listener,
+    origin: socket,
+    scope: runtimeScope,
+    connectionId: routing?.connectionId,
+    subscribers: routing?.subscribers !== false,
+    streamMessage: isStreamChannelMessage(message.type),
+  });
+  for (const { connection, transport: targetSocket } of targets) {
+    if (!isListenerTransportOpen(targetSocket)) continue;
+    enqueueOutboundFrame(targetSocket, {
+      typeLabel: message.type,
+      frameClass,
+      ...(frameClass === "status"
+        ? {
+            coalesceKey: `${message.type}:${runtimeScope.agent_id ?? ""}:${runtimeScope.conversation_id ?? ""}`,
+          }
+        : {}),
+      build: () => {
+        const eventSeq = nextListenerConnectionEventSeq(connection, listener);
+        if (eventSeq === null) return null;
+        const outbound: WsProtocolMessage = {
+          ...message,
+          runtime: runtimeScope,
+          event_seq: eventSeq,
+          emitted_at: new Date().toISOString(),
+          idempotency_key: `${message.type}:${eventSeq}:${crypto.randomUUID()}`,
+        } as WsProtocolMessage;
+        let payload: string;
+        try {
+          payload = JSON.stringify(outbound);
+        } catch (error) {
+          console.error(
+            `[Listen V2] Failed to emit ${message.type} (seq=${eventSeq})`,
+            error,
+          );
+          safeEmitWsEvent("send", "lifecycle", {
+            type: "_ws_send_error",
+            message_type: message.type,
+            event_seq: eventSeq,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return null;
         }
-      : {}),
-    build: () => {
-      const eventSeq = nextEventSeq(listener);
-      if (eventSeq === null) return null;
-      const outbound: WsProtocolMessage = {
-        ...message,
-        runtime: runtimeScope,
-        event_seq: eventSeq,
-        emitted_at: new Date().toISOString(),
-        idempotency_key: `${message.type}:${eventSeq}:${crypto.randomUUID()}`,
-      } as WsProtocolMessage;
-      let payload: string;
-      try {
-        payload = JSON.stringify(outbound);
-      } catch (error) {
-        console.error(
-          `[Listen V2] Failed to emit ${message.type} (seq=${eventSeq})`,
-          error,
-        );
+        return {
+          payload,
+          perfKey: getProtocolPerfKey(message),
+          onSent: () => {
+            if (isDebugEnabled()) {
+              console.log(
+                `[Listen V2] Emitting ${message.type} (seq=${eventSeq})`,
+              );
+            }
+            safeEmitWsEvent("send", "protocol", outbound);
+          },
+        };
+      },
+      onSendError: (error) => {
+        console.error(`[Listen V2] Failed to emit ${message.type}`, error);
         safeEmitWsEvent("send", "lifecycle", {
           type: "_ws_send_error",
           message_type: message.type,
-          event_seq: eventSeq,
           error: error instanceof Error ? error.message : String(error),
         });
-        return null;
-      }
-      return {
-        payload,
-        perfKey: getProtocolPerfKey(message),
-        onSent: () => {
-          if (isDebugEnabled()) {
-            console.log(
-              `[Listen V2] Emitting ${message.type} (seq=${eventSeq})`,
-            );
-          }
-          safeEmitWsEvent("send", "protocol", outbound);
-        },
-      };
-    },
-    onSendError: (error) => {
-      console.error(`[Listen V2] Failed to emit ${message.type}`, error);
-      safeEmitWsEvent("send", "lifecycle", {
-        type: "_ws_send_error",
-        message_type: message.type,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    },
-  });
+      },
+    });
+  }
 }
 
 export function emitDeviceStatusUpdate(

--- a/src/websocket/listener/protocol-outbound.ts
+++ b/src/websocket/listener/protocol-outbound.ts
@@ -164,12 +164,7 @@ function getScopeForRuntime(
 
 export function emitRuntimeStateUpdates(
   runtime: RuntimeCarrier,
-  scope:
-    | {
-        agent_id?: string | null;
-        conversation_id?: string | null;
-      }
-    | undefined,
+  scope: PartialRuntimeScope | undefined,
 ): void {
   emitLoopStatusIfOpen(runtime, scope);
   emitDeviceStatusIfOpen(runtime, scope);
@@ -268,7 +263,10 @@ export function buildDeviceStatus(
       conversationRuntime?.currentToolsetPreference ?? toolsetPreference,
     current_loaded_tools: conversationRuntime?.currentLoadedTools ?? [],
     current_available_skills: [],
-    background_processes: buildBackgroundProcessSnapshot(),
+    background_processes: buildBackgroundProcessSnapshot(
+      scopedAgentId,
+      scopedConversationId,
+    ),
     pending_control_requests: interruptedCacheActive
       ? []
       : getPendingControlRequests(listener, scope),

--- a/src/websocket/listener/queue-no-coalesce.test.ts
+++ b/src/websocket/listener/queue-no-coalesce.test.ts
@@ -130,4 +130,36 @@ describe("queue noCoalesce batching", () => {
     expect(batch?.dequeuedBatch.items).toHaveLength(2);
     expect(consumeQueuedTurn(runtime)).toBeNull();
   });
+
+  test("messages from different connections never coalesce", () => {
+    const runtime = getOrCreateScopedRuntime(
+      createRuntime(),
+      "agent-1",
+      "conv-1",
+    );
+    for (const connectionId of ["client-a", "client-b"]) {
+      expect(
+        enqueueInboundUserMessage(runtime, {
+          type: "message",
+          connectionId,
+          agentId: "agent-1",
+          conversationId: "conv-1",
+          messages: [
+            {
+              role: "user",
+              content: connectionId,
+              client_message_id: `message-${connectionId}`,
+            },
+          ],
+        }),
+      ).toBe(true);
+    }
+
+    const first = consumeQueuedTurn(runtime);
+    const second = consumeQueuedTurn(runtime);
+    expect(first?.dequeuedBatch.items).toHaveLength(1);
+    expect(first?.queuedTurn.connectionId).toBe("client-a");
+    expect(second?.dequeuedBatch.items).toHaveLength(1);
+    expect(second?.queuedTurn.connectionId).toBe("client-b");
+  });
 });

--- a/src/websocket/listener/queue.ts
+++ b/src/websocket/listener/queue.ts
@@ -336,6 +336,7 @@ export function consumeQueuedTurn(runtime: ConversationRuntime): {
   let hasTaskNotification = false;
   let hasCronPrompt = false;
   let hasModContinue = false;
+  let batchConnectionId: string | undefined;
   let batchImageFailureMode: "strict" | "drop" | null = null;
   const isNoCoalesce = (candidate: (typeof queuedItems)[number]): boolean =>
     candidate.kind === "message" && candidate.noCoalesce === true;
@@ -353,6 +354,17 @@ export function consumeQueuedTurn(runtime: ConversationRuntime): {
     }
 
     if (item.kind === "message") {
+      const itemConnectionId = runtime.queuedMessagesByItemId.get(
+        item.id,
+      )?.connectionId;
+      if (
+        batchConnectionId !== undefined &&
+        itemConnectionId !== undefined &&
+        itemConnectionId !== batchConnectionId
+      ) {
+        break;
+      }
+      batchConnectionId ??= itemConnectionId;
       const itemImageFailureMode = getInboundImageFailureMode(
         runtime.queuedMessagesByItemId.get(item.id),
       );

--- a/src/websocket/listener/runtime.ts
+++ b/src/websocket/listener/runtime.ts
@@ -440,7 +440,9 @@ export function getPendingControlRequests(
     return requests;
   }
 
-  for (const pending of conversationRuntime.pendingApprovalResolvers.values()) {
+  for (const pending of new Set(
+    conversationRuntime.pendingApprovalResolvers.values(),
+  )) {
     const request = pending.controlRequest;
     if (!request) continue;
     requests.push({

--- a/src/websocket/listener/runtime.ts
+++ b/src/websocket/listener/runtime.ts
@@ -179,12 +179,6 @@ export function evictConversationRuntimeIfIdle(
 
   runtime.listener.conversationRuntimes.delete(runtime.key);
   scheduleWorktreeWatcherIdleStop(runtime.listener, runtime);
-  for (const [requestId, runtimeKey] of runtime.listener
-    .approvalRuntimeKeyByRequestId) {
-    if (runtimeKey === runtime.key) {
-      runtime.listener.approvalRuntimeKeyByRequestId.delete(requestId);
-    }
-  }
   if (
     runtime.listener.pendingQueueEmitScope?.agent_id === runtime.agentId &&
     normalizeConversationId(

--- a/src/websocket/listener/runtime.ts
+++ b/src/websocket/listener/runtime.ts
@@ -260,6 +260,7 @@ export function createConversationRuntime(
     conversationId: normalizedConversationId,
     skillSources: listener.skillSourcesByConversation.get(runtimeKey)?.slice(),
     activeChannelTurn: null,
+    activeConnectionId: null,
     turnLifecycle,
     messageQueue: Promise.resolve(),
     pendingApprovalResolvers: new Map(),

--- a/src/websocket/listener/transport.ts
+++ b/src/websocket/listener/transport.ts
@@ -14,7 +14,14 @@ export interface LocalTransport {
   send(data: string): void;
 }
 
-export type ListenerTransport = WebSocket | LocalTransport;
+export interface RuntimeTransport {
+  readonly kind: "runtime";
+  readonly bufferedAmount: number;
+  isOpen(): boolean;
+  send(data: string): void;
+}
+
+export type ListenerTransport = WebSocket | LocalTransport | RuntimeTransport;
 
 export class LocalListenerTransport implements LocalTransport {
   readonly kind = "local" as const;
@@ -39,6 +46,6 @@ export function isListenerTransportOpen(transport: ListenerTransport): boolean {
 
 export function getListenerTransportKind(
   transport: ListenerTransport,
-): "websocket" | "local" {
+): "websocket" | "local" | "runtime" {
   return "kind" in transport ? transport.kind : "websocket";
 }

--- a/src/websocket/listener/turn-approval.ts
+++ b/src/websocket/listener/turn-approval.ts
@@ -32,6 +32,7 @@ import {
   buildApprovalSuggestionPayload,
   classifyApprovalsWithSuggestions,
 } from "./approval-suggestions";
+import { TO_SUBSCRIBERS } from "./connection";
 import { appendQueuedTurnToInput } from "./continuation-input";
 import {
   createToolExecutionOutputEmitter,
@@ -43,6 +44,7 @@ import {
 } from "./interrupts";
 import {
   emitDequeuedUserMessage,
+  emitProtocolV2Message,
   emitRuntimeStateUpdates,
 } from "./protocol-outbound";
 import type { ProviderFallbackState } from "./provider-fallback";
@@ -55,7 +57,7 @@ import {
   sendApprovalContinuationWithRetry,
 } from "./send";
 import { injectQueuedSkillContent } from "./skill-injection";
-import { isListenerTransportOpen, type ListenerTransport } from "./transport";
+import type { ListenerTransport } from "./transport";
 import {
   createTurnInputState,
   type TurnInputState,
@@ -467,21 +469,24 @@ export async function handleApprovalStop(params: {
   // Broadcast new file content to web clients when a file-mutating tool
   // (Edit, Write, MultiEdit) writes to disk, so all windows update immediately.
   const onFileWrite = (filePath: string, content: string) => {
-    if (
-      runtime.turnLifecycle.isCurrent(turnLease) &&
-      isListenerTransportOpen(socket)
-    ) {
-      socket.send(
-        JSON.stringify({
-          type: "file_ops",
-          path: filePath,
-          cg_entries: [],
-          ops: [],
-          source: "agent",
-          document_content: content,
-        }),
-      );
-    }
+    if (!runtime.turnLifecycle.isCurrent(turnLease)) return;
+    emitProtocolV2Message(
+      socket,
+      runtime,
+      {
+        type: "file_ops",
+        path: filePath,
+        cg_entries: [],
+        ops: [],
+        source: "agent",
+        document_content: content,
+      } as never,
+      {
+        agent_id: agentId,
+        conversation_id: conversationId,
+      },
+      TO_SUBSCRIBERS,
+    );
   };
 
   let executionResults: Awaited<ReturnType<typeof executeApprovalBatch>>;

--- a/src/websocket/listener/turn-setup.ts
+++ b/src/websocket/listener/turn-setup.ts
@@ -256,6 +256,7 @@ export async function prepareListenerTurn(params: {
     agentId,
   );
   const preparedToolContext = await prepareToolExecutionContextForScope({
+    connectionId,
     agentId,
     conversationId,
     clientToolAllowlist: msg.clientToolAllowlist,

--- a/src/websocket/listener/turn.ts
+++ b/src/websocket/listener/turn.ts
@@ -167,6 +167,9 @@ async function handleIncomingMessageInner(
       origin: "message",
       workingDirectory: turnWorkingDirectory,
     });
+  if (connectionId) {
+    runtime.activeConnectionId = connectionId;
+  }
   if (!runtime.turnLifecycle.isCurrent(turnLease)) {
     throw new Error("Cannot continue a turn with a stale lifecycle lease");
   }
@@ -971,6 +974,9 @@ async function handleIncomingMessageInner(
     }
 
     richDraftStreamer?.dispose();
+    if (runtime.activeConnectionId === connectionId) {
+      runtime.activeConnectionId = null;
+    }
 
     try {
       if (finalizedByThisInvocation) {

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -144,7 +144,8 @@ export type InvalidInputCommand = {
 export type ParsedServerMessage = ServerMessage | InvalidInputCommand;
 
 export type PendingApprovalResolver = {
-  connectionId?: ListenerConnectionId;
+  requestId: string;
+  connectionIds: Set<ListenerConnectionId>;
   resolve: (response: ApprovalResponseBody) => void;
   reject: (reason: Error) => void;
   controlRequest?: ControlRequest;
@@ -215,10 +216,24 @@ export type ConversationRuntime = {
 
 export type ListenerConnectionId = string;
 
-export interface ListenerMessageRouting {
-  connectionId?: ListenerConnectionId;
-  subscribers?: boolean;
-}
+/**
+ * Explicit destination for one outbound listener message.
+ *
+ * This mirrors Codex's OutgoingEnvelope split. Scoped notifications never
+ * fall back to every connected client: ToSubscribers with an empty subscriber
+ * set is intentionally a no-op.
+ */
+export type ListenerMessageRouting =
+  | {
+      type: "ToConnection";
+      connectionId: ListenerConnectionId;
+    }
+  | {
+      type: "ToSubscribers";
+    }
+  | {
+      type: "Broadcast";
+    };
 
 /**
  * State owned by one transport connection.

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -288,8 +288,12 @@ export type ListenerRuntime = {
   processTransport: ListenerTransport | null;
   /** Process-wide services are installed once, regardless of client count. */
   processServicesStarted: boolean;
+  /** Invalidates process-service attempts that outlive an outbound connection. */
+  processServicesGeneration: number;
   /** Coalesces concurrent connection attempts while process services initialize. */
   processServicesReady: Promise<void> | null;
+  /** Generation owned by processServicesReady, or null when no attempt is active. */
+  processServicesReadyGeneration: number | null;
   eventSeqCounter: number;
   queueEmitScheduled: boolean;
   pendingQueueEmitScope?: {

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -62,6 +62,12 @@ export interface StartListenerOptions {
 
 export interface IncomingMessage {
   type: "message";
+  /**
+   * Transport connection that delivered this message. Queueing carries this
+   * identity through to the turn so approvals and other interactive requests
+   * return to the correct client even when multiple clients share a runtime.
+   */
+  connectionId?: ListenerConnectionId;
   agentId?: string;
   conversationId?: string;
   /** Queue this message as its own turn; never merge with other messages. */
@@ -107,6 +113,7 @@ export type ListenerStreamObserver = (
 ) => void;
 
 export interface PendingExternalToolCall {
+  connectionId: ListenerConnectionId;
   resolve: (result: ExternalToolCallResult) => void;
   reject: (error: Error) => void;
   timeout: ReturnType<typeof setTimeout>;
@@ -137,6 +144,7 @@ export type InvalidInputCommand = {
 export type ParsedServerMessage = ServerMessage | InvalidInputCommand;
 
 export type PendingApprovalResolver = {
+  connectionId?: ListenerConnectionId;
   resolve: (response: ApprovalResponseBody) => void;
   reject: (reason: Error) => void;
   controlRequest?: ControlRequest;
@@ -166,6 +174,8 @@ export type ConversationRuntime = {
   /** Runtime-scoped SDK override. Undefined uses the process defaults. */
   skillSources: SkillSource[] | undefined;
   activeChannelTurn: ActiveChannelTurn | null;
+  /** Connection currently executing this conversation's turn, if client-owned. */
+  activeConnectionId: ListenerConnectionId | null;
   turnLifecycle: TurnLifecycle;
   messageQueue: Promise<void>;
   pendingApprovalResolvers: Map<string, PendingApprovalResolver>;
@@ -203,6 +213,32 @@ export type ConversationRuntime = {
   contextTracker: ContextTracker;
 };
 
+export type ListenerConnectionId = string;
+
+export interface ListenerMessageRouting {
+  connectionId?: ListenerConnectionId;
+  subscribers?: boolean;
+}
+
+/**
+ * State owned by one transport connection.
+ *
+ * This mirrors Codex's ConnectionState: the process runtime owns services and
+ * conversations, while each client owns its writer, cancellation handle,
+ * initialization state, subscriptions, request resources, and event sequence.
+ */
+export type ListenerConnectionState = {
+  id: ListenerConnectionId;
+  ordinal: number;
+  writer: ListenerTransport;
+  streamWriter: ListenerTransport | null;
+  cancellation: AbortController;
+  initialized: boolean;
+  subscriptions: Set<string>;
+  eventSeqCounter: number;
+  options: StartListenerOptions;
+};
+
 export type ListenerRuntime = {
   socket: WebSocket | null;
   transport?: ListenerTransport | null;
@@ -227,6 +263,16 @@ export type ListenerRuntime = {
   /** Coalesces concurrent first-loads for one agent's scoped adapter. */
   agentModAdapterLoads?: Map<string, Promise<ModAdapter | null>>;
   sessionId: string;
+  /** Monotonic allocator used for deterministic connection ordering. */
+  nextConnectionOrdinal: number;
+  /** All currently open listener transports, keyed by explicit identity. */
+  connections: Map<ListenerConnectionId, ListenerConnectionState>;
+  /** Reverse index for Codex-style conversation subscriptions. */
+  connectionIdsByRuntimeKey: Map<string, Set<ListenerConnectionId>>;
+  /** Process-scoped transport used by scheduler/channel/background services. */
+  processTransport: ListenerTransport | null;
+  /** Process-wide services are installed once, regardless of client count. */
+  processServicesStarted: boolean;
   eventSeqCounter: number;
   queueEmitScheduled: boolean;
   pendingQueueEmitScope?: {

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -288,6 +288,8 @@ export type ListenerRuntime = {
   processTransport: ListenerTransport | null;
   /** Process-wide services are installed once, regardless of client count. */
   processServicesStarted: boolean;
+  /** Coalesces concurrent connection attempts while process services initialize. */
+  processServicesReady: Promise<void> | null;
   eventSeqCounter: number;
   queueEmitScheduled: boolean;
   pendingQueueEmitScope?: {
@@ -330,7 +332,7 @@ export type ListenerRuntime = {
   secretsHydrationFreshnessByAgent: Map<string, number>;
   /** Agent IDs whose cached secrets are stale and must re-fetch on the next hydration call. */
   secretsDirtyAgents: Set<string>;
-  pendingExternalToolCalls?: Map<string, PendingExternalToolCall>;
+  pendingExternalToolCalls: Map<string, PendingExternalToolCall>;
   /**
    * Agent metadata warmups for listen-mode reminders. The cached promise is
    * reused while the listener stays connected so first-turn reminders can join

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -317,7 +317,6 @@ export type ListenerRuntime = {
   connectionId: string | null;
   connectionName: string | null;
   conversationRuntimes: Map<string, ConversationRuntime>;
-  approvalRuntimeKeyByRequestId: Map<string, string>;
   /** Per-conversation worktree directory watchers for CWD auto-detection fallback. */
   worktreeWatcherByConversation: Map<
     string,

--- a/src/websocket/terminal-handler.ts
+++ b/src/websocket/terminal-handler.ts
@@ -24,6 +24,7 @@ interface TerminalSession {
   kill: () => void;
   pid: number;
   terminalId: string;
+  connectionId: string;
   spawnedAt: number;
 }
 
@@ -53,6 +54,10 @@ type NodePtyModule = {
 };
 
 const terminals = new Map<string, TerminalSession>();
+
+function getTerminalKey(connectionId: string, terminalId: string): string {
+  return JSON.stringify([connectionId, terminalId]);
+}
 
 function getDefaultShell(): string {
   if (os.platform() === "win32") {
@@ -106,8 +111,10 @@ function spawnBun(
   cols: number,
   rows: number,
   terminal_id: string,
+  connectionId: string,
   socket: WebSocket,
 ): TerminalSession {
+  const terminalKey = getTerminalKey(connectionId, terminal_id);
   const handleData = makeOutputBatcher((data) =>
     sendTerminalMessage(socket, { type: "terminal_output", terminal_id, data }),
   );
@@ -138,9 +145,9 @@ function spawnBun(
   }
 
   proc.exited.then((exitCode) => {
-    const current = terminals.get(terminal_id);
+    const current = terminals.get(terminalKey);
     if (current && current.pid === proc.pid) {
-      terminals.delete(terminal_id);
+      terminals.delete(terminalKey);
       sendTerminalMessage(socket, {
         type: "terminal_exited",
         terminal_id,
@@ -170,6 +177,7 @@ function spawnBun(
     },
     pid: proc.pid,
     terminalId: terminal_id,
+    connectionId,
     spawnedAt: Date.now(),
   };
 }
@@ -182,8 +190,10 @@ function spawnNodePty(
   cols: number,
   rows: number,
   terminal_id: string,
+  connectionId: string,
   socket: WebSocket,
 ): TerminalSession {
+  const terminalKey = getTerminalKey(connectionId, terminal_id);
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const pty = require("node-pty") as NodePtyModule;
 
@@ -206,9 +216,9 @@ function spawnNodePty(
   ptyProcess.onData(handleData);
 
   ptyProcess.onExit(({ exitCode }: NodePtyExitEvent) => {
-    const current = terminals.get(terminal_id);
+    const current = terminals.get(terminalKey);
     if (current && current.pid === ptyProcess.pid) {
-      terminals.delete(terminal_id);
+      terminals.delete(terminalKey);
       sendTerminalMessage(socket, {
         type: "terminal_exited",
         terminal_id,
@@ -235,6 +245,7 @@ function spawnNodePty(
     },
     pid: ptyProcess.pid,
     terminalId: terminal_id,
+    connectionId,
     spawnedAt: Date.now(),
   };
 }
@@ -245,14 +256,16 @@ export function handleTerminalSpawn(
   msg: { terminal_id: string; cols: number; rows: number },
   socket: WebSocket,
   cwd: string,
+  connectionId = "legacy",
 ): void {
   const { terminal_id, cols, rows } = msg;
+  const terminalKey = getTerminalKey(connectionId, terminal_id);
 
   // React Strict Mode fires mount→unmount→mount which produces spawn→kill→spawn
   // in rapid succession. The kill is already ignored (< 2s guard below), but the
   // second spawn would normally kill and restart. If the session is < 2s old and
   // still alive, reuse it and resend terminal_spawned instead.
-  const existing = terminals.get(terminal_id);
+  const existing = terminals.get(terminalKey);
   if (existing && Date.now() - existing.spawnedAt < 2000) {
     let alive = true;
     try {
@@ -274,10 +287,10 @@ export function handleTerminalSpawn(
     }
 
     // Session dead — fall through to spawn a fresh one
-    terminals.delete(terminal_id);
+    terminals.delete(terminalKey);
   }
 
-  killTerminal(terminal_id);
+  killTerminal(terminal_id, connectionId);
 
   const shell = getDefaultShell();
   console.log(
@@ -286,10 +299,10 @@ export function handleTerminalSpawn(
 
   try {
     const session = IS_BUN
-      ? spawnBun(shell, cwd, cols, rows, terminal_id, socket)
-      : spawnNodePty(shell, cwd, cols, rows, terminal_id, socket);
+      ? spawnBun(shell, cwd, cols, rows, terminal_id, connectionId, socket)
+      : spawnNodePty(shell, cwd, cols, rows, terminal_id, connectionId, socket);
 
-    terminals.set(terminal_id, session);
+    terminals.set(terminalKey, session);
     console.log(
       `[Terminal] Session stored for terminal_id=${terminal_id}, pid=${session.pid}`,
     );
@@ -310,45 +323,65 @@ export function handleTerminalSpawn(
   }
 }
 
-export function handleTerminalInput(msg: {
-  terminal_id: string;
-  data: string;
-}): void {
-  terminals.get(msg.terminal_id)?.write(msg.data);
+export function handleTerminalInput(
+  msg: {
+    terminal_id: string;
+    data: string;
+  },
+  connectionId = "legacy",
+): void {
+  terminals.get(getTerminalKey(connectionId, msg.terminal_id))?.write(msg.data);
 }
 
-export function handleTerminalResize(msg: {
-  terminal_id: string;
-  cols: number;
-  rows: number;
-}): void {
-  terminals.get(msg.terminal_id)?.resize(msg.cols, msg.rows);
+export function handleTerminalResize(
+  msg: {
+    terminal_id: string;
+    cols: number;
+    rows: number;
+  },
+  connectionId = "legacy",
+): void {
+  terminals
+    .get(getTerminalKey(connectionId, msg.terminal_id))
+    ?.resize(msg.cols, msg.rows);
 }
 
-export function handleTerminalKill(msg: { terminal_id: string }): void {
-  const session = terminals.get(msg.terminal_id);
+export function handleTerminalKill(
+  msg: { terminal_id: string },
+  connectionId = "legacy",
+): void {
+  const session = terminals.get(getTerminalKey(connectionId, msg.terminal_id));
   if (session && Date.now() - session.spawnedAt < 2000) {
     console.log(
       `[Terminal] Ignoring kill for recently spawned session (age=${Date.now() - session.spawnedAt}ms)`,
     );
     return;
   }
-  killTerminal(msg.terminal_id);
+  killTerminal(msg.terminal_id, connectionId);
 }
 
-function killTerminal(terminalId: string): void {
-  const session = terminals.get(terminalId);
+function killTerminal(terminalId: string, connectionId: string): void {
+  const terminalKey = getTerminalKey(connectionId, terminalId);
+  const session = terminals.get(terminalKey);
   if (session) {
     console.log(
       `[Terminal] killTerminal: terminalId=${terminalId}, pid=${session.pid}`,
     );
     session.kill();
-    terminals.delete(terminalId);
+    terminals.delete(terminalKey);
+  }
+}
+
+export function killListenerConnectionTerminals(connectionId: string): void {
+  for (const session of [...terminals.values()]) {
+    if (session.connectionId === connectionId) {
+      killTerminal(session.terminalId, connectionId);
+    }
   }
 }
 
 export function killAllTerminals(): void {
-  for (const [id] of terminals) {
-    killTerminal(id);
+  for (const session of [...terminals.values()]) {
+    killTerminal(session.terminalId, session.connectionId);
   }
 }


### PR DESCRIPTION
## What changed

This refactors the app-server listener from process-global socket ownership to explicit per-connection routing, allowing multiple clients to connect simultaneously without evicting or interfering with one another.

- Uses one bidirectional WebSocket per client.
- Correlates direct responses by connection and request ID.
- Fans runtime notifications out only to subscribers of that agent and conversation.
- Makes process-wide broadcasts explicit.
- Scopes turns, approvals, external tools, queues, terminals, heartbeat cleanup, and background-job status to the correct connection or runtime.
- Keeps process-wide services initialized once while connection resources remain independently managed.
- Updates the in-repo app-server client to use a single socket.
- Rejects legacy split-channel URLs explicitly with HTTP 426.

## Why the diff is broad

The listener previously combined process runtime state with singleton socket ownership. Separating those concerns requires connection identity to flow through every path that emits a response or owns client-specific state, including runtime startup, streaming, approvals, external tools, queue delivery, status snapshots, terminal events, and disconnect cleanup.

The implementation applies one routing model throughout the listener rather than adding a parallel compatibility path. A substantial portion of the diff is focused regression coverage for concurrent clients, identical request IDs, subscriber fanout, approval recovery, disconnect isolation, and scoped status delivery.

## Compatibility and rollout

This is an intentional breaking app-server protocol change. Clients must connect with one bidirectional socket; legacy `?channel=control|stream` endpoints return HTTP 426.

Release the server and its matching client together. Any downstream client package should be pinned to the published server/client version before its release.

## Validation

- `bun run check` — all 12 checks passed
- `bun run build` — passed
- Focused app-server/listener coverage — 197 passed
- Broader routing and approval coverage — 69 passed
- Simultaneous-client app-server integration — passed three consecutive runs
