### PR TITLE
feat(sandbox): export memory worker confinement launcher

### DIFF
--- a/build.js
+++ b/build.js
@@ -153,6 +153,18 @@ await Bun.build({
 });
 
 await Bun.build({
+  entrypoints: ["./src/memory-confinement.ts"],
+  outdir: "./dist",
+  target: "node",
+  format: "esm",
+  minify: false,
+  sourcemap: "external",
+  naming: {
+    entry: "memory-confinement.js",
+  },
+});
+
+await Bun.build({
   entrypoints: ["./src/app-server-client.ts"],
   outdir: "./dist",
   target: "node",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "dist/app-server-client.js.map",
     "dist/app-server-client.cjs",
     "dist/app-server-client.cjs.map",
+    "dist/memory-confinement.js",
+    "dist/memory-confinement.js.map",
     "dist/agent-presets.js",
     "dist/agent-presets.js.map",
     "dist/channels-public.js",
@@ -40,6 +42,11 @@
       "import": "./dist/app-server-client.js",
       "require": "./dist/app-server-client.cjs",
       "default": "./dist/app-server-client.js"
+    },
+    "./memory-confinement": {
+      "types": "./dist/types/memory-confinement.d.ts",
+      "import": "./dist/memory-confinement.js",
+      "default": "./dist/memory-confinement.js"
     },
     "./protocol": {
       "types": "./dist/types/types/protocol.d.ts"
@@ -159,6 +166,9 @@
       ],
       "app-server-client": [
         "./dist/types/app-server-client.d.ts"
+      ],
+      "memory-confinement": [
+        "./dist/types/memory-confinement.d.ts"
       ],
       "channels": [
         "./dist/types/channels-public.d.ts"

--- a/src/memory-confinement.test.ts
+++ b/src/memory-confinement.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { createMemoryConfinementLauncherWithAvailability } from "@/permissions/memory-confinement-launcher";
+import { canonicalizeRoot } from "@/permissions/sandbox-policy";
 import { SANDBOX_ENV_VAR } from "@/sandbox/policy";
 
 describe("memory confinement launcher", () => {
@@ -24,9 +25,11 @@ describe("memory confinement launcher", () => {
     expect(result.backend).toBe("seatbelt");
     expect(result.launcher[0]).toBe("/usr/bin/sandbox-exec");
     expect(result.launcher).toContain(process.execPath);
-    expect(result.launcher).toContain(`-DWRITABLE_0=${memoryDir}`);
     expect(result.launcher).toContain(
-      `-DWRITABLE_1=${join(dirname(memoryDir), "memory-worktrees")}`,
+      `-DWRITABLE_0=${canonicalizeRoot(memoryDir)}`,
+    );
+    expect(result.launcher).toContain(
+      `-DWRITABLE_1=${canonicalizeRoot(join(dirname(memoryDir), "memory-worktrees"))}`,
     );
     expect(result.env.PATH).toBe("/usr/bin");
     expect(result.env[SANDBOX_ENV_VAR]).toBe("seatbelt");
@@ -45,8 +48,12 @@ describe("memory confinement launcher", () => {
       { backend: "seatbelt", reason: "test" },
     );
 
-    expect(result.launcher).toContain("-DBASEWRITABLE_1=/state/local-backend");
-    expect(result.launcher).toContain("-DBASEWRITABLE_2=/state/transcripts");
+    expect(result.launcher).toContain(
+      `-DBASEWRITABLE_1=${canonicalizeRoot("/state/local-backend")}`,
+    );
+    expect(result.launcher).toContain(
+      `-DBASEWRITABLE_2=${canonicalizeRoot("/state/transcripts")}`,
+    );
   });
 
   test("fails closed without a memory root", () => {

--- a/src/memory-confinement.test.ts
+++ b/src/memory-confinement.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { createMemoryConfinementLauncherWithAvailability } from "@/permissions/memory-confinement-launcher";
+import { SANDBOX_ENV_VAR } from "@/sandbox/policy";
+
+describe("memory confinement launcher", () => {
+  test("wraps a launcher with the fail-closed Seatbelt policy", () => {
+    const memoryDir = join(
+      homedir(),
+      ".letta",
+      "agents",
+      "agent-self",
+      "memory",
+    );
+    const result = createMemoryConfinementLauncherWithAvailability(
+      {
+        launcher: [process.execPath, "letta.js", "app-server"],
+        env: { MEMORY_DIR: memoryDir, PATH: "/usr/bin" },
+      },
+      { backend: "seatbelt", reason: "test" },
+    );
+
+    expect(result.backend).toBe("seatbelt");
+    expect(result.launcher[0]).toBe("/usr/bin/sandbox-exec");
+    expect(result.launcher).toContain(process.execPath);
+    expect(result.launcher).toContain(`-DWRITABLE_0=${memoryDir}`);
+    expect(result.launcher).toContain(
+      `-DWRITABLE_1=${join(dirname(memoryDir), "memory-worktrees")}`,
+    );
+    expect(result.env.PATH).toBe("/usr/bin");
+    expect(result.env[SANDBOX_ENV_VAR]).toBe("seatbelt");
+  });
+
+  test("includes relocated harness state roots", () => {
+    const result = createMemoryConfinementLauncherWithAvailability(
+      {
+        launcher: ["node", "letta.js"],
+        env: {
+          MEMORY_DIR: "/state/memory",
+          LETTA_LOCAL_BACKEND_DIR: "/state/local-backend",
+          LETTA_TRANSCRIPT_ROOT: "/state/transcripts",
+        },
+      },
+      { backend: "seatbelt", reason: "test" },
+    );
+
+    expect(result.launcher).toContain("-DBASEWRITABLE_1=/state/local-backend");
+    expect(result.launcher).toContain("-DBASEWRITABLE_2=/state/transcripts");
+  });
+
+  test("fails closed without a memory root", () => {
+    expect(() =>
+      createMemoryConfinementLauncherWithAvailability(
+        { launcher: ["node", "letta.js"], env: {} },
+        { backend: "seatbelt", reason: "test" },
+      ),
+    ).toThrow("requires MEMORY_DIR or LETTA_MEMORY_DIR");
+  });
+
+  test("fails closed without a kernel sandbox backend", () => {
+    expect(() =>
+      createMemoryConfinementLauncherWithAvailability(
+        {
+          launcher: ["node", "letta.js"],
+          env: { MEMORY_DIR: "/state/memory" },
+        },
+        { backend: null, reason: "unsupported host" },
+      ),
+    ).toThrow("Memory confinement is unavailable: unsupported host");
+  });
+});

--- a/src/memory-confinement.ts
+++ b/src/memory-confinement.ts
@@ -1,0 +1,29 @@
+import {
+  createMemoryConfinementLauncherWithAvailability,
+  type MemoryConfinementLauncherInput,
+  type MemoryConfinementLauncherResult,
+} from "@/permissions/memory-confinement-launcher";
+import { detectSandboxBackend } from "@/sandbox/availability";
+
+export type {
+  MemoryConfinementLauncherInput,
+  MemoryConfinementLauncherResult,
+} from "@/permissions/memory-confinement-launcher";
+
+/**
+ * Wrap a process in the same fail-closed filesystem policy used by Letta
+ * Code's unattended memory subagents.
+ *
+ * The process can read the host broadly, write harness state and its own
+ * memory, and cannot read or write other agents' memory. Throws when no
+ * supported kernel sandbox is available rather than silently running with a
+ * weaker policy.
+ */
+export function createMemoryConfinementLauncher(
+  input: MemoryConfinementLauncherInput,
+): MemoryConfinementLauncherResult {
+  return createMemoryConfinementLauncherWithAvailability(
+    input,
+    detectSandboxBackend(),
+  );
+}

--- a/src/permissions/memory-confinement-launcher.ts
+++ b/src/permissions/memory-confinement-launcher.ts
@@ -1,0 +1,102 @@
+import { homedir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+
+import {
+  buildMemorySubagentSandboxPolicy,
+  getCrossBackendAgentsTreeRoots,
+} from "@/permissions/sandbox-policy";
+import type { SandboxAvailability } from "@/sandbox/availability";
+import { SANDBOX_ENV_VAR, type SandboxBackend } from "@/sandbox/policy";
+import { wrapLauncher } from "@/sandbox/wrap";
+
+export interface MemoryConfinementLauncherInput {
+  /** Command and arguments for the process that should be confined. */
+  launcher: string[];
+  /**
+   * Environment for the confined process. `MEMORY_DIR` (or
+   * `LETTA_MEMORY_DIR`) identifies the memory root that stays writable.
+   */
+  env: NodeJS.ProcessEnv;
+}
+
+export interface MemoryConfinementLauncherResult {
+  /** Sandbox wrapper followed by the original launcher. */
+  launcher: string[];
+  /** Original environment plus the nested-sandbox sentinel. */
+  env: NodeJS.ProcessEnv;
+  backend: SandboxBackend;
+}
+
+function normalizeRoot(path: string): string {
+  const trimmed = path.trim();
+  const expanded = trimmed.startsWith("~/")
+    ? join(homedir(), trimmed.slice(2))
+    : trimmed.startsWith("$HOME/")
+      ? join(homedir(), trimmed.slice(6))
+      : trimmed;
+  return resolve(expanded);
+}
+
+function resolveWritableMemoryRoots(env: NodeJS.ProcessEnv): string[] {
+  const roots = new Set<string>();
+  for (const value of [env.MEMORY_DIR, env.LETTA_MEMORY_DIR]) {
+    if (!value?.trim()) continue;
+    const root = normalizeRoot(value);
+    roots.add(root);
+    if (basename(root) === "memory") {
+      roots.add(join(dirname(root), "memory-worktrees"));
+    }
+  }
+  return [...roots];
+}
+
+function customHarnessWritableRoots(env: NodeJS.ProcessEnv): string[] {
+  return [env.LETTA_LOCAL_BACKEND_DIR, env.LETTA_TRANSCRIPT_ROOT]
+    .filter((value): value is string => Boolean(value?.trim()))
+    .map(normalizeRoot);
+}
+
+export function createMemoryConfinementLauncherWithAvailability(
+  input: MemoryConfinementLauncherInput,
+  availability: SandboxAvailability,
+): MemoryConfinementLauncherResult {
+  if (input.launcher.length === 0) {
+    throw new Error("Memory confinement requires a non-empty launcher.");
+  }
+
+  const memoryRoots = resolveWritableMemoryRoots(input.env);
+  if (memoryRoots.length === 0) {
+    throw new Error(
+      "Memory confinement requires MEMORY_DIR or LETTA_MEMORY_DIR.",
+    );
+  }
+  if (!availability.backend) {
+    throw new Error(
+      `Memory confinement is unavailable: ${availability.reason}.`,
+    );
+  }
+
+  const localBackendStorageDir =
+    input.env.LETTA_LOCAL_BACKEND_DIR?.trim() || undefined;
+  const policy = buildMemorySubagentSandboxPolicy({
+    memoryRoots,
+    agentsTreeRoots: getCrossBackendAgentsTreeRoots({
+      env: input.env,
+      localBackendStorageDir,
+    }),
+    harnessWritableRoots: customHarnessWritableRoots(input.env),
+  });
+  const launcher = wrapLauncher(input.launcher, policy, {
+    backend: availability.backend,
+    bwrapPath: availability.bwrapPath,
+  });
+  if (!launcher) {
+    throw new Error("Memory confinement could not wrap the launcher.");
+  }
+
+  return {
+    launcher,
+    env: { ...input.env, [SANDBOX_ENV_VAR]: availability.backend },
+    backend: availability.backend,
+  };
+}

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -11,6 +11,7 @@
     "src/types/protocol.ts",
     "src/types/app-server-protocol.ts",
     "src/app-server-client.ts",
+    "src/memory-confinement.ts",
     "src/agent-presets.ts",
     "src/channels-public.ts",
     "src/channels-slack.ts",


### PR DESCRIPTION
## Summary
- export a Node-only launcher that applies the existing memory-subagent filesystem policy to an SDK-owned process
- fail closed when no memory root or supported kernel sandbox is available
- preserve custom local-backend and transcript roots while keeping other agents’ memory inaccessible
- add deterministic Seatbelt coverage and package/type exports

Unblocks letta-ai/letta-agent-sdk#219 without duplicating the Seatbelt/bwrap policy in the SDK.

👾 Generated with [Letta Code](https://letta.com)