### PR TITLE
fix(app-server): return pagination metadata from conversation_messages_list

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -40,7 +40,7 @@
   "src/tools/impl/message-channel.ts": 1187,
   "src/tools/manager.ts": 3281,
   "src/tools/tool-execution-context.test.ts": 1422,
-  "src/types/protocol_v2.ts": 2961,
+  "src/types/protocol_v2.ts": 2963,
   "src/websocket/listen-client-concurrency.test.ts": 3017,
   "src/websocket/listen-client-protocol.test.ts": 6723,
   "src/websocket/listener/commands/channels.ts": 1390,

--- a/src/backend/api-backend.test.ts
+++ b/src/backend/api-backend.test.ts
@@ -320,6 +320,20 @@ describe("APIBackend", () => {
     );
 
     await backend.listConversationMessages("conv-1", {
+      before: "message-default-order-page",
+      limit: 10,
+    });
+    expect(listConversationMessagesMock).toHaveBeenLastCalledWith(
+      "conv-1",
+      {
+        after: "message-default-order-page",
+        before: undefined,
+        limit: 10,
+      },
+      undefined,
+    );
+
+    await backend.listConversationMessages("conv-1", {
       before: "message-older-page",
       order: "asc",
       limit: 10,

--- a/src/backend/api-backend.test.ts
+++ b/src/backend/api-backend.test.ts
@@ -296,4 +296,58 @@ describe("APIBackend", () => {
       agentId: "agent-1",
     });
   });
+
+  test("normalizes descending message cursors to chronological before and after", async () => {
+    const backend = new APIBackend({
+      getClient: getClientMock as unknown as () => Promise<APIClient>,
+      forkConversation: forkConversationMock,
+    });
+
+    await backend.listConversationMessages("conv-1", {
+      before: "message-older-page",
+      order: "desc",
+      limit: 10,
+    });
+    expect(listConversationMessagesMock).toHaveBeenLastCalledWith(
+      "conv-1",
+      {
+        after: "message-older-page",
+        before: undefined,
+        order: "desc",
+        limit: 10,
+      },
+      undefined,
+    );
+
+    await backend.listConversationMessages("conv-1", {
+      before: "message-older-page",
+      order: "asc",
+      limit: 10,
+    });
+    expect(listConversationMessagesMock).toHaveBeenLastCalledWith(
+      "conv-1",
+      {
+        before: "message-older-page",
+        order: "asc",
+        limit: 10,
+      },
+      undefined,
+    );
+
+    await backend.listConversationMessages("conv-1", {
+      after: "message-newer-page",
+      order: "desc",
+      limit: 10,
+    });
+    expect(listConversationMessagesMock).toHaveBeenLastCalledWith(
+      "conv-1",
+      {
+        after: undefined,
+        before: "message-newer-page",
+        order: "desc",
+        limit: 10,
+      },
+      undefined,
+    );
+  });
 });

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -94,6 +94,23 @@ export type ConversationMessageListParams = Parameters<
 export type ConversationMessageListBody = ConversationMessageListParams[1];
 export type ConversationMessageListOptions = ConversationMessageListParams[2];
 
+function toApiConversationMessageListBody(
+  body?: ConversationMessageListBody,
+): ConversationMessageListBody | undefined {
+  if (!body || body.order !== "desc" || (!body.before && !body.after)) {
+    return body;
+  }
+
+  // The Backend contract uses chronological cursors: before always means older
+  // and after always means newer. The API interprets them relative to sort order,
+  // so descending requests need their cursor keys swapped at this boundary.
+  return {
+    ...body,
+    before: body.after,
+    after: body.before,
+  };
+}
+
 export type ConversationMessageCompactParams = Parameters<
   APIClient["conversations"]["messages"]["compact"]
 >;
@@ -388,7 +405,11 @@ export class APIBackend implements Backend {
     options?: ConversationMessageListOptions,
   ) {
     const client = await this.getClient();
-    return client.conversations.messages.list(conversationId, body, options);
+    return client.conversations.messages.list(
+      conversationId,
+      toApiConversationMessageListBody(body),
+      options,
+    );
   }
 
   async compactConversationMessages(

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -93,11 +93,13 @@ export type ConversationMessageListParams = Parameters<
 >;
 export type ConversationMessageListBody = ConversationMessageListParams[1];
 export type ConversationMessageListOptions = ConversationMessageListParams[2];
+export const DEFAULT_CONVERSATION_MESSAGE_ORDER = "desc";
 
 function toApiConversationMessageListBody(
   body?: ConversationMessageListBody,
 ): ConversationMessageListBody | undefined {
-  if (!body || body.order !== "desc" || (!body.before && !body.after)) {
+  const order = body?.order ?? DEFAULT_CONVERSATION_MESSAGE_ORDER;
+  if (!body || order !== "desc" || (!body.before && !body.after)) {
     return body;
   }
 

--- a/src/types/app-server-protocol.test.ts
+++ b/src/types/app-server-protocol.test.ts
@@ -97,6 +97,8 @@ describe("app-server protocol export", () => {
         request_id: "req",
         success: true,
         messages: [],
+        next_before: null,
+        has_more: false,
       },
       {
         type: "conversation_compact_response",

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -2333,6 +2333,8 @@ export interface ConversationMessagesListResponseMessage {
   request_id: string;
   success: boolean;
   messages: LettaMessage[];
+  next_before: string | null; // Oldest message ID, for loading older history.
+  has_more: boolean; // Whether messages older than `next_before` exist.
   error?: string;
 }
 

--- a/src/websocket/listener/commands/agents-conversations.test.ts
+++ b/src/websocket/listener/commands/agents-conversations.test.ts
@@ -131,7 +131,6 @@ describe("listConversationMessagePage", () => {
     for (;;) {
       const result = await listConversationMessagePage(backend, "conv-1", {
         ...(before ? { before } : {}),
-        order: "desc",
         limit: 3,
       });
       collected.push(

--- a/src/websocket/listener/commands/agents-conversations.test.ts
+++ b/src/websocket/listener/commands/agents-conversations.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { Backend } from "@/backend";
+import { listConversationMessagePage } from "@/websocket/listener/commands/agents-conversations";
+
+type MessageBackend = Pick<Backend, "listConversationMessages">;
+
+function page(messages: unknown[]) {
+  return { getPaginatedItems: () => messages };
+}
+
+function backendWithPages(...pages: unknown[][]): {
+  backend: MessageBackend;
+  listMessages: ReturnType<typeof mock>;
+} {
+  const listMessages = mock(async () => page(pages.shift() ?? []));
+  return {
+    backend: {
+      listConversationMessages:
+        listMessages as unknown as MessageBackend["listConversationMessages"],
+    },
+    listMessages,
+  };
+}
+
+describe("listConversationMessagePage", () => {
+  test("returns a partial final page without probing", async () => {
+    const { backend, listMessages } = backendWithPages([
+      { id: "message-3" },
+      { id: "message-2" },
+    ]);
+
+    const result = await listConversationMessagePage(backend, "conv-1", {
+      order: "desc",
+      limit: 3,
+    });
+
+    expect(result).toEqual({
+      messages: [{ id: "message-3" }, { id: "message-2" }],
+      nextBefore: "message-2",
+      hasMore: false,
+    });
+    expect(listMessages).toHaveBeenCalledTimes(1);
+  });
+
+  test("trims an overfilled backend page and reports more history", async () => {
+    const { backend, listMessages } = backendWithPages([
+      { id: "message-4" },
+      { id: "message-3" },
+      { id: "message-2" },
+    ]);
+
+    const result = await listConversationMessagePage(backend, "conv-1", {
+      order: "desc",
+      limit: 2,
+    });
+
+    expect(result).toEqual({
+      messages: [{ id: "message-4" }, { id: "message-3" }],
+      nextBefore: "message-3",
+      hasMore: true,
+    });
+    expect(listMessages).toHaveBeenCalledTimes(1);
+  });
+
+  test("probes an exactly full page with its oldest message id", async () => {
+    const { backend, listMessages } = backendWithPages(
+      [{ id: "message-4" }, { id: "message-3" }],
+      [{ id: "message-2" }],
+    );
+
+    const result = await listConversationMessagePage(backend, "conv-1", {
+      before: "message-5",
+      order: "desc",
+      limit: 2,
+    });
+
+    expect(result.hasMore).toBe(true);
+    expect(result.nextBefore).toBe("message-3");
+    expect(listMessages).toHaveBeenNthCalledWith(2, "conv-1", {
+      before: "message-3",
+      after: undefined,
+      order: "desc",
+      limit: 1,
+    });
+  });
+
+  test("uses the first item as the oldest id for ascending pages", async () => {
+    const { backend, listMessages } = backendWithPages(
+      [{ id: "message-2" }, { id: "message-3" }],
+      [],
+    );
+
+    const result = await listConversationMessagePage(backend, "conv-1", {
+      order: "asc",
+      limit: 2,
+    });
+
+    expect(result.nextBefore).toBe("message-2");
+    expect(result.hasMore).toBe(false);
+    expect(listMessages).toHaveBeenNthCalledWith(2, "conv-1", {
+      before: "message-2",
+      after: undefined,
+      order: "desc",
+      limit: 1,
+    });
+  });
+
+  test("walks multiple descending pages without duplicates", async () => {
+    const allMessages = Array.from({ length: 7 }, (_, index) => ({
+      id: `message-${index + 1}`,
+    }));
+    const listMessages = mock(
+      async (
+        _conversationId: string,
+        query: { before?: string; limit?: number },
+      ) => {
+        const end = query.before
+          ? allMessages.findIndex((message) => message.id === query.before)
+          : allMessages.length;
+        const start = Math.max(0, end - (query.limit ?? 50));
+        return page(allMessages.slice(start, end).reverse());
+      },
+    );
+    const backend: MessageBackend = {
+      listConversationMessages:
+        listMessages as unknown as MessageBackend["listConversationMessages"],
+    };
+    const collected: string[] = [];
+    let before: string | undefined;
+
+    for (;;) {
+      const result = await listConversationMessagePage(backend, "conv-1", {
+        ...(before ? { before } : {}),
+        order: "desc",
+        limit: 3,
+      });
+      collected.push(
+        ...result.messages.map((message) => (message as { id: string }).id),
+      );
+      if (!result.hasMore) break;
+      expect(result.nextBefore).not.toBeNull();
+      before = result.nextBefore ?? undefined;
+    }
+
+    expect(collected).toEqual([
+      "message-7",
+      "message-6",
+      "message-5",
+      "message-4",
+      "message-3",
+      "message-2",
+      "message-1",
+    ]);
+    expect(new Set(collected).size).toBe(collected.length);
+  });
+});

--- a/src/websocket/listener/commands/agents-conversations.ts
+++ b/src/websocket/listener/commands/agents-conversations.ts
@@ -1,6 +1,10 @@
 import type WebSocket from "ws";
 import { actingUserRequestOptions } from "@/agent/acting-user";
-import { getBackend } from "@/backend";
+import {
+  type Backend,
+  type ConversationMessageListBody,
+  getBackend,
+} from "@/backend";
 import type {
   AgentCreateCommand,
   AgentDeleteCommand,
@@ -73,6 +77,57 @@ function getPageItems<T>(page: unknown): T[] {
     }
   }
   return [];
+}
+
+type ConversationMessagePage = {
+  messages: unknown[];
+  nextBefore: string | null;
+  hasMore: boolean;
+};
+
+function messageId(message: unknown): string | null {
+  if (!message || typeof message !== "object") return null;
+  const id = (message as { id?: unknown }).id;
+  return typeof id === "string" && id.length > 0 ? id : null;
+}
+
+export async function listConversationMessagePage(
+  backend: Pick<Backend, "listConversationMessages">,
+  conversationId: string,
+  query: ConversationMessageListBody = {},
+): Promise<ConversationMessagePage> {
+  const normalizedQuery = query ?? {};
+  const limit = normalizedQuery.limit ?? 50;
+  const order = normalizedQuery.order === "asc" ? "asc" : "desc";
+  const page = await backend.listConversationMessages(
+    conversationId,
+    normalizedQuery,
+  );
+  const untrimmedMessages = getPageItems(page);
+  const messages = untrimmedMessages.slice(0, limit);
+  const oldestMessage =
+    order === "asc" ? messages[0] : messages[messages.length - 1];
+  const nextBefore = messageId(oldestMessage);
+
+  if (!nextBefore || messages.length < limit) {
+    return { messages, nextBefore, hasMore: false };
+  }
+  if (untrimmedMessages.length > limit) {
+    return { messages, nextBefore, hasMore: true };
+  }
+
+  const probe = await backend.listConversationMessages(conversationId, {
+    ...normalizedQuery,
+    after: undefined,
+    before: nextBefore,
+    order: "desc",
+    limit: 1,
+  });
+  return {
+    messages,
+    nextBefore,
+    hasMore: getPageItems(probe).length > 0,
+  };
 }
 
 export async function handleAgentConversationManagementCommand(
@@ -457,7 +512,8 @@ export async function handleAgentConversationManagementCommand(
 
   if (parsed.type === "conversation_messages_list") {
     try {
-      const page = await backend.listConversationMessages(
+      const page = await listConversationMessagePage(
+        backend,
         parsed.conversation_id,
         parsed.query,
       );
@@ -467,7 +523,9 @@ export async function handleAgentConversationManagementCommand(
           type: "conversation_messages_list_response",
           request_id: parsed.request_id,
           success: true,
-          messages: getPageItems(page),
+          messages: page.messages,
+          next_before: page.nextBefore,
+          has_more: page.hasMore,
         },
         "listener_conversation_management_send_failed",
         "listener_conversation_management",
@@ -480,6 +538,8 @@ export async function handleAgentConversationManagementCommand(
           request_id: parsed.request_id,
           success: false,
           messages: [],
+          next_before: null,
+          has_more: false,
           error: getErrorMessage(error, "Failed to list conversation messages"),
         },
         "listener_conversation_management_send_failed",

--- a/src/websocket/listener/commands/agents-conversations.ts
+++ b/src/websocket/listener/commands/agents-conversations.ts
@@ -3,6 +3,7 @@ import { actingUserRequestOptions } from "@/agent/acting-user";
 import {
   type Backend,
   type ConversationMessageListBody,
+  DEFAULT_CONVERSATION_MESSAGE_ORDER,
   getBackend,
 } from "@/backend";
 import type {
@@ -98,7 +99,7 @@ export async function listConversationMessagePage(
 ): Promise<ConversationMessagePage> {
   const normalizedQuery = query ?? {};
   const limit = normalizedQuery.limit ?? 50;
-  const order = normalizedQuery.order === "asc" ? "asc" : "desc";
+  const order = normalizedQuery.order ?? DEFAULT_CONVERSATION_MESSAGE_ORDER;
   const page = await backend.listConversationMessages(
     conversationId,
     normalizedQuery,


### PR DESCRIPTION
## Summary
- `conversation_messages_list_response` carried only the raw message page — no cursor, no more-history signal — so external clients building history backfill had no reliable way to walk older pages (reported by a mobile SDK consumer).
- Add `next_before` (oldest message ID in the page) and `has_more` to the response, computed by a shared `listConversationMessagePage()` helper: it trims overfilled backend pages, and probes with `limit: 1` only when a page is exactly full, so the common partial-page case costs no extra request.
- Normalize cursor semantics at the `APIBackend` boundary: the `Backend` contract (and the local backend) treat `before`/`after` chronologically (`before` = older, always), while the REST API interprets them relative to sort order. Descending requests now swap cursor keys before reaching the generated client, so all backends present the same chronological contract.
- Tests: page-walk regression (multiple descending pages, no duplicates, correct `has_more` progression), overfilled/exact/partial page trimming, ascending oldest-ID selection, and cursor-normalization assertions for both orders.

👾 Generated with [Letta Code](https://letta.com)