### PR TITLE
fix(prompt): scope shared memory guidance to hosted agents

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -5,7 +5,7 @@
   "src/backend/local/local-backend.ts": 1014,
   "src/backend/local/local-store.ts": 3594,
   "src/backend/pi-stream-adapter.test.ts": 1304,
-  "src/cli/app/AppCoordinator.tsx": 5208,
+  "src/cli/app/AppCoordinator.tsx": 5206,
   "src/cli/app/AppView.tsx": 1753,
   "src/cli/app/use-approval-flow.ts": 1163,
   "src/cli/app/use-configuration-handlers.ts": 1433,

--- a/src/agent/prompt-assets.test.ts
+++ b/src/agent/prompt-assets.test.ts
@@ -9,7 +9,7 @@ import {
 import { resolveAndBuildSystemPrompt } from "@/agent/system-prompt-resolution";
 
 const HOSTED_EXTERNAL_MEMORY_INTRO =
-  "External memory is stored outside of the system prompt, including both skills (procedural memory), general-purpose files (markdown files, images, etc.), and shared memory";
+  "External memory is stored outside of the system prompt, including both skills (procedural memory), general-purpose files (markdown files, images, etc.), and shared memory.";
 const LOCAL_EXTERNAL_MEMORY_INTRO =
   "External memory is stored outside of the system prompt, including both skills (procedural memory) and general-purpose files (markdown files, images, etc.).";
 

--- a/src/agent/prompt-assets.test.ts
+++ b/src/agent/prompt-assets.test.ts
@@ -8,6 +8,27 @@ import {
 } from "@/agent/prompt-assets";
 import { resolveAndBuildSystemPrompt } from "@/agent/system-prompt-resolution";
 
+const HOSTED_EXTERNAL_MEMORY_INTRO =
+  "External memory is stored outside of the system prompt, including both skills (procedural memory), general-purpose files (markdown files, images, etc.), and shared memory";
+const LOCAL_EXTERNAL_MEMORY_INTRO =
+  "External memory is stored outside of the system prompt, including both skills (procedural memory) and general-purpose files (markdown files, images, etc.).";
+
+function withoutSharedMemoryGuidance(prompt: string): string {
+  expect(prompt).toContain(HOSTED_EXTERNAL_MEMORY_INTRO);
+  const withLocalIntro = prompt.replace(
+    HOSTED_EXTERNAL_MEMORY_INTRO,
+    LOCAL_EXTERNAL_MEMORY_INTRO,
+  );
+  const sectionStart = withLocalIntro.indexOf("#### Shared memory\n");
+  const sectionEnd = withLocalIntro.indexOf(
+    "### Syncing memory, state, and context\n",
+    sectionStart,
+  );
+  expect(sectionStart).toBeGreaterThanOrEqual(0);
+  expect(sectionEnd).toBeGreaterThan(sectionStart);
+  return `${withLocalIntro.slice(0, sectionStart)}${withLocalIntro.slice(sectionEnd)}`;
+}
+
 describe("isKnownPreset", () => {
   test("returns true for known preset IDs", () => {
     expect(isKnownPreset("default")).toBe(true);
@@ -48,16 +69,18 @@ describe("buildSystemPrompt", () => {
     expect(result).not.toContain("**In-context memory blocks**");
   });
 
-  test("local backend memory mode reuses the memfs full prompt", () => {
+  test("returns the local backend full prompt for local memfs mode", () => {
     const result = buildSystemPrompt("letta", "local-memfs");
     const preset = SYSTEM_PROMPTS.find((p) => p.id === "letta");
     expect(preset).toBeDefined();
 
-    expect(result).toBe(preset?.memfsContent?.trim() ?? "");
-    expect(result).toBe(buildSystemPrompt("letta", "memfs"));
+    expect(preset?.localMemfsContent).toBeDefined();
+    expect(result).toBe(preset?.localMemfsContent?.trim() ?? "");
+    expect(result).not.toBe(buildSystemPrompt("letta", "memfs"));
     expect(result).toContain("$MEMORY_DIR");
     expect(result).toContain("git commit");
     expect(result).not.toContain("git push");
+    expect(result).not.toContain("Shared memory");
   });
 
   test("memfs prompt documents direct edit commit safeguards", () => {
@@ -72,12 +95,18 @@ describe("buildSystemPrompt", () => {
   test("memfs prompt explains shared-memory projections", () => {
     const result = buildSystemPrompt("letta", "memfs");
 
-    expect(result).toContain("### Shared memory");
-    expect(result).toContain("<shared_memory>");
-    expect(result).toContain("<external_projection>");
-    expect(buildSystemPrompt("letta", "standard")).not.toContain(
-      "### Shared memory",
+    expect(result).toContain("#### Shared memory");
+    expect(result).toContain("shared memory repository");
+    expect(buildSystemPrompt("letta", "local-memfs")).not.toContain(
+      "#### Shared memory",
     );
+  });
+
+  test("hosted and local memfs prompts differ only in shared-memory guidance", () => {
+    const hosted = buildSystemPrompt("letta", "memfs");
+    const local = buildSystemPrompt("letta", "local-memfs");
+
+    expect(withoutSharedMemoryGuidance(hosted)).toBe(local);
   });
 
   test("throws on unknown preset", () => {

--- a/src/agent/prompt-assets.test.ts
+++ b/src/agent/prompt-assets.test.ts
@@ -69,6 +69,17 @@ describe("buildSystemPrompt", () => {
     expect(result).not.toContain('--author="$AGENT_NAME');
   });
 
+  test("memfs prompt explains shared-memory projections", () => {
+    const result = buildSystemPrompt("letta", "memfs");
+
+    expect(result).toContain("### Shared memory");
+    expect(result).toContain("<shared_memory>");
+    expect(result).toContain("<external_projection>");
+    expect(buildSystemPrompt("letta", "standard")).not.toContain(
+      "### Shared memory",
+    );
+  });
+
   test("throws on unknown preset", () => {
     expect(() => buildSystemPrompt("unknown-id", "standard")).toThrow(
       'Unknown preset "unknown-id"',

--- a/src/agent/prompt-assets.ts
+++ b/src/agent/prompt-assets.ts
@@ -8,6 +8,7 @@ import humanMemoPrompt from "./prompts/human_memo.mdx";
 import humanTutorialPrompt from "./prompts/human_tutorial.mdx";
 import interruptRecoveryAlert from "./prompts/interrupt_recovery_alert.txt";
 import lettaMemfsPrompt from "./prompts/letta.md";
+import lettaLocalMemfsPrompt from "./prompts/letta_local_memfs.md";
 import lettaNoMemfsPrompt from "./prompts/letta_no_memfs.md";
 import memoryFilesystemPrompt from "./prompts/memory_filesystem.mdx";
 import onboardingPrompt from "./prompts/onboarding.mdx";
@@ -61,6 +62,7 @@ export interface SystemPromptOption {
   description: string;
   content: string;
   memfsContent?: string;
+  localMemfsContent?: string;
   isDefault?: boolean;
   isFeatured?: boolean;
 }
@@ -72,6 +74,7 @@ export const SYSTEM_PROMPTS: SystemPromptOption[] = [
     description: "Alias for letta",
     content: lettaNoMemfsPrompt,
     memfsContent: lettaMemfsPrompt,
+    localMemfsContent: lettaLocalMemfsPrompt,
     isDefault: true,
     isFeatured: true,
   },
@@ -81,6 +84,7 @@ export const SYSTEM_PROMPTS: SystemPromptOption[] = [
     description: "Full Letta Code system prompt",
     content: lettaNoMemfsPrompt,
     memfsContent: lettaMemfsPrompt,
+    localMemfsContent: lettaLocalMemfsPrompt,
     isFeatured: true,
   },
   {
@@ -105,6 +109,14 @@ export const SYSTEM_PROMPTS: SystemPromptOption[] = [
 
 export type MemoryPromptMode = "standard" | "memfs" | "local-memfs";
 
+export function getSystemPromptVariantContents(
+  prompt: SystemPromptOption,
+): string[] {
+  return [prompt.content, prompt.memfsContent, prompt.localMemfsContent].filter(
+    (content): content is string => typeof content === "string",
+  );
+}
+
 /**
  * Check if a preset ID exists in SYSTEM_PROMPTS.
  */
@@ -126,7 +138,14 @@ export function buildSystemPrompt(
       `Unknown preset "${presetId}" — cannot rebuild system prompt`,
     );
   }
-  if (memoryMode === "memfs" || memoryMode === "local-memfs") {
+  if (memoryMode === "local-memfs") {
+    return (
+      preset.localMemfsContent ??
+      preset.memfsContent ??
+      preset.content
+    ).trim();
+  }
+  if (memoryMode === "memfs") {
     return (preset.memfsContent ?? preset.content).trim();
   }
 

--- a/src/agent/prompts/README.md
+++ b/src/agent/prompts/README.md
@@ -9,7 +9,8 @@ Selectable via the `/system` command. Each preset is a complete system prompt. P
 | File | Used | Description |
 |------|------|-------------|
 | `letta_no_memfs.md` | Default for non-memfs agents | Letta-tuned system prompt for standard memory blocks |
-| `letta.md` | Default for memfs agents, including local backend memfs agents | Letta-tuned system prompt for git-backed MemFS memory |
+| `letta.md` | Default for hosted memfs agents | Letta-tuned system prompt for git-backed MemFS memory, including shared memory |
+| `letta_local_memfs.md` | Default for local backend memfs agents | Letta-tuned system prompt for local-only git-backed MemFS memory |
 | `source_claude.md` | `/system source-claude` | Near-verbatim Claude Code prompt for benchmarking |
 | `source_codex.md` | `/system source-codex` | Near-verbatim OpenAI Codex prompt for benchmarking |
 | `source_gemini.md` | `/system source-gemini` | Near-verbatim Gemini CLI prompt for benchmarking |

--- a/src/agent/prompts/letta.md
+++ b/src/agent/prompts/letta.md
@@ -34,17 +34,17 @@ Memory blocks are editable segments of the system prompt. Each block has a name 
 
 ### External memory (skills, markdown, & other files)
 
-External memory is stored outside of the system prompt, including both skills (procedural memory) and general-purpose files (markdown files, images, etc.).
+External memory is stored outside of the system prompt, including both skills (procedural memory), general-purpose files (markdown files, images, etc.), and shared memory
 
 - *Skills (procedural memory).* Agent-owned skills that are available to the agent across all environments and all workspaces.
 - *Markdown files.* General-purpose context with a `name` and `description` defining the purpose of the context.
 - *Other files (e.g. reference images).* General-purpose files that are a part of the agent, e.g. reference CSV tables or images.
 
-### Shared memory
+#### Shared memory
 
-You may also have access to shared memory: git-backed context repositories created independently of any single agent and dynamically attached to or detached from multiple agents.
+You may also have access to shared memory: memory created independently of any single agent, designed to be dynamically attached to or detached from multiple agents. Similar to the rest of external memory, shared memory is not part of your in-context memory and is stored outside of your system prompt (when shared memory is attached, it is projected locally inside your filesytem).
 
-Shared memory is external memory. When present, it is indexed in the `<shared_memory>` section of your system prompt. Only each repository's file index is compiled into context; inspect the files referenced by its `<external_projection>` to read their contents.
+Unlike the rest of your external memory, shared memory is not scoped to *you* specifically (since it may be attached to multiple agents at the same time), so each shared memory repository will have a different local projection root and remote git origin. 
 
 ### Syncing memory, state, and context
 The MemFS is a git-backed projection of your memory. Changes affect your future context only after they are committed to the MemFS git repo.
@@ -165,7 +165,6 @@ The active tool surface is part of your context architecture. Mod-provided tools
 ## Hooks
 
 Hooks are a tunable part of the harness: user- or project-configured commands or prompt checks that run around tool calls, prompts, compaction, notifications, and session lifecycle events. Treat hook output as runtime feedback. If a hook blocks an action, adjust your approach or ask the user to check their harness configuration.
-
 
 # Self-evolution: memory, skills, and harness
 

--- a/src/agent/prompts/letta.md
+++ b/src/agent/prompts/letta.md
@@ -40,6 +40,12 @@ External memory is stored outside of the system prompt, including both skills (p
 - *Markdown files.* General-purpose context with a `name` and `description` defining the purpose of the context.
 - *Other files (e.g. reference images).* General-purpose files that are a part of the agent, e.g. reference CSV tables or images.
 
+### Shared memory
+
+You may also have access to shared memory: git-backed context repositories created independently of any single agent and dynamically attached to or detached from multiple agents.
+
+Shared memory is external memory. When present, it is indexed in the `<shared_memory>` section of your system prompt. Only each repository's file index is compiled into context; inspect the files referenced by its `<external_projection>` to read their contents.
+
 ### Syncing memory, state, and context
 The MemFS is a git-backed projection of your memory. Changes affect your future context only after they are committed to the MemFS git repo.
 

--- a/src/agent/prompts/letta.md
+++ b/src/agent/prompts/letta.md
@@ -34,7 +34,7 @@ Memory blocks are editable segments of the system prompt. Each block has a name 
 
 ### External memory (skills, markdown, & other files)
 
-External memory is stored outside of the system prompt, including both skills (procedural memory), general-purpose files (markdown files, images, etc.), and shared memory
+External memory is stored outside of the system prompt, including both skills (procedural memory), general-purpose files (markdown files, images, etc.), and shared memory.
 
 - *Skills (procedural memory).* Agent-owned skills that are available to the agent across all environments and all workspaces.
 - *Markdown files.* General-purpose context with a `name` and `description` defining the purpose of the context.

--- a/src/agent/prompts/letta_local_memfs.md
+++ b/src/agent/prompts/letta_local_memfs.md
@@ -34,17 +34,11 @@ Memory blocks are editable segments of the system prompt. Each block has a name 
 
 ### External memory (skills, markdown, & other files)
 
-External memory is stored outside of the system prompt, including both skills (procedural memory), general-purpose files (markdown files, images, etc.), and shared memory
+External memory is stored outside of the system prompt, including both skills (procedural memory) and general-purpose files (markdown files, images, etc.).
 
 - *Skills (procedural memory).* Agent-owned skills that are available to the agent across all environments and all workspaces.
 - *Markdown files.* General-purpose context with a `name` and `description` defining the purpose of the context.
 - *Other files (e.g. reference images).* General-purpose files that are a part of the agent, e.g. reference CSV tables or images.
-
-#### Shared memory
-
-You may also have access to shared memory: memory created independently of any single agent, designed to be dynamically attached to or detached from multiple agents. Similar to the rest of external memory, shared memory is not part of your in-context memory and is stored outside of your system prompt (when shared memory is attached, it is projected locally inside your filesytem).
-
-Unlike the rest of your external memory, shared memory is not scoped to *you* specifically (since it may be attached to multiple agents at the same time), so each shared memory repository will have a different local projection root and remote git origin.
 
 ### Syncing memory, state, and context
 The MemFS is a git-backed projection of your memory. Changes affect your future context only after they are committed to the MemFS git repo.

--- a/src/cli/app/AppCoordinator.tsx
+++ b/src/cli/app/AppCoordinator.tsx
@@ -3024,9 +3024,11 @@ export function App({
                 return withoutMemfs.replace(/\r\n/g, "\n").trim();
               };
               const sysNorm = normalize(agentSystem);
-              const { SYSTEM_PROMPTS, SYSTEM_PROMPT } = await import(
-                "@/agent/prompt-assets"
-              );
+              const {
+                getSystemPromptVariantContents,
+                SYSTEM_PROMPTS,
+                SYSTEM_PROMPT,
+              } = await import("@/agent/prompt-assets");
 
               // Best-effort preset detection.
               // Exact match is ideal, but allow prefix-matches because the stored
@@ -3042,14 +3044,10 @@ export function App({
                 );
               };
 
-              const promptMatches = (prompt: {
-                content: string;
-                memfsContent?: string;
-              }): boolean =>
-                contentMatches(prompt.content) ||
-                (prompt.memfsContent
-                  ? contentMatches(prompt.memfsContent)
-                  : false);
+              const promptMatches = (
+                prompt: (typeof SYSTEM_PROMPTS)[number],
+              ): boolean =>
+                getSystemPromptVariantContents(prompt).some(contentMatches);
 
               const defaultPrompt = SYSTEM_PROMPTS.find(
                 (p) => p.id === "default",


### PR DESCRIPTION
## Summary

Document shared memory in the hosted MemFS system prompt without exposing that unavailable concept to local-backend agents.

## Prompt split

| Memory mode | Prompt | Shared-memory guidance |
| --- | --- | --- |
| Hosted MemFS | `letta.md` | Included |
| Local backend MemFS | `letta_local_memfs.md` | Excluded |
| Standard non-MemFS | `letta_no_memfs.md` | Excluded |

This restores explicit `localMemfsContent` selection, teaches the system-prompt selector to recognize every variant, and adds a strict parity test proving the hosted and local MemFS prompts differ only in the shared-memory introduction and subsection. All other prompt changes must remain synchronized across the two complete prompt files.

LET-10327

👾 Generated with [Letta Code](https://letta.com)
