### PR TITLE
feat(app-server): add OpenAI Responses API support

### DIFF
--- a/src/backend/dev/provider-turn-executor.ts
+++ b/src/backend/dev/provider-turn-executor.ts
@@ -294,12 +294,14 @@ function createUsageStatisticsChunk(
   const contextTokens = usageContextTokens ?? contextTokensEstimate;
   const cachedInputTokens = usage?.cacheRead;
   const cacheWriteTokens = usage?.cacheWrite;
+  const reasoningTokens = usage?.reasoning;
   if (
     promptTokens === undefined &&
     completionTokens === undefined &&
     totalTokens === undefined &&
     cachedInputTokens === undefined &&
     cacheWriteTokens === undefined &&
+    reasoningTokens === undefined &&
     contextTokens === undefined
   ) {
     return undefined;
@@ -316,6 +318,9 @@ function createUsageStatisticsChunk(
       : {}),
     ...(cacheWriteTokens !== undefined
       ? { cache_write_tokens: cacheWriteTokens }
+      : {}),
+    ...(reasoningTokens !== undefined
+      ? { reasoning_tokens: reasoningTokens }
       : {}),
     ...(contextTokens !== undefined ? { context_tokens: contextTokens } : {}),
   } as unknown as LettaStreamingResponse;

--- a/src/backend/provider-turn-executor.test.ts
+++ b/src/backend/provider-turn-executor.test.ts
@@ -250,6 +250,31 @@ describe("ProviderTurnExecutor", () => {
     ).toBe("end_turn");
   });
 
+  test("includes provider reasoning tokens in usage statistics", async () => {
+    const finalMessage = assistantMessage({
+      ...emptyLocalUsage(),
+      input: 100,
+      output: 40,
+      totalTokens: 140,
+      reasoning: 24,
+    });
+    const adapter: ProviderStreamAdapter = {
+      async *stream() {
+        yield providerStreamPart(
+          part({ type: "done", reason: "stop", message: finalMessage }),
+        );
+      },
+    };
+
+    const chunks = await collect(
+      await new ProviderTurnExecutor(adapter).execute(input()),
+    );
+    const usage = chunks.find(
+      (chunk) => chunk.message_type === "usage_statistics",
+    ) as { reasoning_tokens?: number } | undefined;
+    expect(usage?.reasoning_tokens).toBe(24);
+  });
+
   test("maps pi length completions to max_tokens_exceeded", async () => {
     const finalMessage = {
       ...assistantMessage(),

--- a/src/cli/subcommands/app-server.ts
+++ b/src/cli/subcommands/app-server.ts
@@ -10,7 +10,7 @@ Run the local App Server using native v2 WebSocket frames.
 
 Options:
   --listen [url]  WebSocket listen URL. Defaults to an available loopback port
-  --openai-api  Serve OpenAI-compatible /v1/models and /v1/chat/completions routes (each agent is a model)
+  --openai-api  Serve OpenAI-compatible /v1/models, /v1/chat/completions, and /v1/responses routes (each agent is a model)
   --ws-auth <mode>  WebSocket auth for non-loopback listeners and Origin-bearing native clients. Supported: capability-token, signed-bearer-token
   --ws-token-file <path>  Absolute path to the capability-token file
   --ws-token-sha256 <hex>  Hex-encoded SHA-256 digest of the capability token

--- a/src/cli/subcommands/server.ts
+++ b/src/cli/subcommands/server.ts
@@ -20,7 +20,7 @@ Remote environment options:
 
 App Server options:
   --listen [url]  Accept App Server connections. If URL is omitted, binds to an available loopback port
-  --openai-api  Serve OpenAI-compatible /v1/models and /v1/chat/completions routes (each agent is a model)
+  --openai-api  Serve OpenAI-compatible /v1/models, /v1/chat/completions, and /v1/responses routes (each agent is a model)
   --ws-auth <mode>  Authentication for non-loopback listeners and Origin-bearing native clients: capability-token or signed-bearer-token
   --ws-token-file <path>  Absolute path to the capability-token file
   --ws-token-sha256 <hex>  Hex-encoded SHA-256 digest of the capability token

--- a/src/websocket/app-server-openai-common.ts
+++ b/src/websocket/app-server-openai-common.ts
@@ -354,6 +354,12 @@ export function chatKeyFromHeaders(
   const explicit = headerValue(request, "x-letta-chat-key");
   if (explicit) return explicit;
   if (!streaming) return null;
+  return openWebUiChatIdFromHeaders(request);
+}
+
+export function openWebUiChatIdFromHeaders(
+  request: HttpIncomingMessage,
+): string | null {
   return headerValue(request, "x-openwebui-chat-id");
 }
 

--- a/src/websocket/app-server-openai-common.ts
+++ b/src/websocket/app-server-openai-common.ts
@@ -1,0 +1,409 @@
+import type {
+  IncomingMessage as HttpIncomingMessage,
+  ServerResponse,
+} from "node:http";
+import { getBackend } from "@/backend";
+import type { WebsocketAuthPolicy } from "@/websocket/app-server-auth";
+import type {
+  TurnOutcome,
+  UserContentPart,
+} from "@/websocket/app-server-openai-turn";
+
+const MAX_REQUEST_BODY_BYTES = 20 * 1024 * 1024;
+
+export interface OpenAiCompatOptions {
+  authPolicy: WebsocketAuthPolicy;
+  onLog?: (message: string) => void;
+}
+
+export interface OpenAiChatMessagePart {
+  type?: string;
+  text?: string;
+  image_url?: { url?: string } | string;
+}
+
+export interface OpenAiChatMessage {
+  role?: string;
+  content?: string | OpenAiChatMessagePart[] | null;
+}
+
+export function sendJson(
+  response: ServerResponse,
+  statusCode: number,
+  body: unknown,
+): void {
+  const payload = JSON.stringify(body);
+  response.writeHead(statusCode, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(payload),
+  });
+  response.end(payload);
+}
+
+export function sendOpenAiError(
+  response: ServerResponse,
+  statusCode: number,
+  message: string,
+  type: string,
+  code: string | null = null,
+): void {
+  sendJson(response, statusCode, {
+    error: { message, type, param: null, code },
+  });
+}
+
+export async function readJsonBody(
+  request: HttpIncomingMessage,
+): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buffer.length;
+    if (total > MAX_REQUEST_BODY_BYTES) {
+      throw new Error("request body too large");
+    }
+    chunks.push(buffer);
+  }
+  const raw = Buffer.concat(chunks).toString("utf8");
+  if (!raw) return {};
+  return JSON.parse(raw);
+}
+
+export function extractTextContent(
+  content: string | OpenAiChatMessagePart[] | null | undefined,
+): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) =>
+      part &&
+      (part.type === "text" ||
+        part.type === "input_text" ||
+        part.type === "output_text") &&
+      typeof part.text === "string"
+        ? part.text
+        : "",
+    )
+    .filter(Boolean)
+    .join("\n");
+}
+
+const IMAGE_DATA_URL_RE = /^data:([^;,]+);base64,(.+)$/;
+
+function toImagePart(rawUrl: string): UserContentPart | null {
+  const match = IMAGE_DATA_URL_RE.exec(rawUrl);
+  if (match?.[1] && match[2]) {
+    return {
+      type: "image",
+      source: { type: "base64", media_type: match[1], data: match[2] },
+    };
+  }
+  if (/^https?:\/\//.test(rawUrl)) {
+    return { type: "image", source: { type: "url", url: rawUrl } };
+  }
+  return null;
+}
+
+/** OpenAI user content → Letta content parts (text and image_url). */
+export function extractUserContentParts(
+  content: string | OpenAiChatMessagePart[] | null | undefined,
+): UserContentPart[] {
+  if (typeof content === "string") {
+    return content ? [{ type: "text", text: content }] : [];
+  }
+  if (!Array.isArray(content)) return [];
+  const parts: UserContentPart[] = [];
+  for (const part of content) {
+    if (!part || typeof part !== "object") continue;
+    if (
+      (part.type === "text" || part.type === "input_text") &&
+      typeof part.text === "string" &&
+      part.text
+    ) {
+      parts.push({ type: "text", text: part.text });
+      continue;
+    }
+    if (part.type === "image_url" || part.type === "input_image") {
+      const raw =
+        typeof part.image_url === "string"
+          ? part.image_url
+          : part.image_url?.url;
+      if (typeof raw === "string") {
+        const image = toImagePart(raw);
+        if (image) parts.push(image);
+      }
+    }
+  }
+  return parts;
+}
+
+function toModelCreatedTimestamp(createdAt: unknown): number {
+  if (typeof createdAt === "string") {
+    const ms = new Date(createdAt).getTime();
+    if (Number.isFinite(ms)) return Math.floor(ms / 1000);
+  }
+  return 0;
+}
+
+export interface AgentModelEntry {
+  id: string;
+  name?: string | null;
+  created_at?: string;
+}
+
+function getPageItems<T>(page: unknown): T[] {
+  if (Array.isArray(page)) return page as T[];
+  if (page && typeof page === "object") {
+    const candidate = page as {
+      getPaginatedItems?: () => T[];
+      items?: T[];
+    };
+    if (typeof candidate.getPaginatedItems === "function") {
+      return candidate.getPaginatedItems();
+    }
+    if (Array.isArray(candidate.items)) {
+      return candidate.items;
+    }
+  }
+  return [];
+}
+
+const MAX_LISTED_AGENTS = 1000;
+
+async function listAgentEntries(): Promise<AgentModelEntry[]> {
+  const page = await getBackend().listAgents({ limit: MAX_LISTED_AGENTS });
+  if (Array.isArray(page)) return page as AgentModelEntry[];
+  // SDK pages are async-iterable across ALL pages; a first-page-only read
+  // silently drops agents once the list exceeds one page.
+  const iterable = page as unknown as {
+    [Symbol.asyncIterator]?: () => AsyncIterator<AgentModelEntry>;
+  };
+  if (typeof iterable[Symbol.asyncIterator] === "function") {
+    const items: AgentModelEntry[] = [];
+    for await (const item of iterable as AsyncIterable<AgentModelEntry>) {
+      items.push(item);
+      if (items.length >= MAX_LISTED_AGENTS) break;
+    }
+    return items;
+  }
+  return getPageItems<AgentModelEntry>(page);
+}
+
+/**
+ * One collision-free advertised-id map, used by both listing and
+ * resolution. An agent name is advertised only when it is unique among
+ * names AND does not equal any agent id — otherwise the agent id is
+ * advertised — so every advertised id resolves to exactly one agent and
+ * raw agent-id lookups can never be shadowed by another agent's name.
+ */
+function buildAdvertisedModelMap(
+  agents: AgentModelEntry[],
+): Map<string, AgentModelEntry> {
+  const ids = new Set(agents.map((agent) => agent.id));
+  const nameCounts = new Map<string, number>();
+  for (const agent of agents) {
+    if (!agent.name) continue;
+    nameCounts.set(agent.name, (nameCounts.get(agent.name) ?? 0) + 1);
+  }
+  const advertised = new Map<string, AgentModelEntry>();
+  for (const agent of agents) {
+    const useName =
+      agent.name && nameCounts.get(agent.name) === 1 && !ids.has(agent.name);
+    const id = useName && agent.name ? agent.name : agent.id;
+    if (!advertised.has(id)) advertised.set(id, agent);
+  }
+  return advertised;
+}
+
+export async function handleListModels(
+  response: ServerResponse,
+): Promise<void> {
+  const advertised = buildAdvertisedModelMap(await listAgentEntries());
+  const data = [...advertised.entries()].map(([id, agent]) => ({
+    id,
+    object: "model" as const,
+    created: toModelCreatedTimestamp(agent.created_at),
+    owned_by: "letta",
+  }));
+  sendJson(response, 200, { object: "list", data });
+}
+
+export async function resolveAgentForModel(
+  model: string,
+): Promise<AgentModelEntry | null> {
+  const agents = await listAgentEntries();
+  return (
+    buildAdvertisedModelMap(agents).get(model) ??
+    agents.find((agent) => agent.id === model) ??
+    null
+  );
+}
+
+// Conversation continuity for header-keyed chats. Clients that supply a
+// stable chat identity get a pinned Letta conversation; the bounded FIFO
+// map evicts long-idle chats, which then start a fresh conversation.
+const MAX_TRACKED_TRANSCRIPTS = 4096;
+const conversationIdByTranscript = new Map<string, string>();
+
+export function rememberConversation(
+  key: string,
+  conversationId: string,
+): void {
+  conversationIdByTranscript.delete(key);
+  conversationIdByTranscript.set(key, conversationId);
+  while (conversationIdByTranscript.size > MAX_TRACKED_TRANSCRIPTS) {
+    const oldest = conversationIdByTranscript.keys().next().value;
+    if (oldest === undefined) break;
+    conversationIdByTranscript.delete(oldest);
+  }
+}
+
+// Conversation creation is serialized per agent: concurrent creations race
+// on initializing the agent's local memory repository (transient git config
+// lock failures). Failures propagate to the caller as a 500 — routing into
+// the shared "default" conversation instead would cross-wire client chats.
+const conversationCreateTailByAgent = new Map<string, Promise<void>>();
+const CONVERSATION_CREATE_RETRIES = 2;
+const CONVERSATION_CREATE_RETRY_DELAY_MS = 200;
+
+async function createConversationWithRetry(agentId: string): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= CONVERSATION_CREATE_RETRIES; attempt++) {
+    if (attempt > 0) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, CONVERSATION_CREATE_RETRY_DELAY_MS * attempt),
+      );
+    }
+    try {
+      const conversation = await getBackend().createConversation({
+        agent_id: agentId,
+      });
+      return conversation.id;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
+
+/** Serialized per-agent conversation creation (see note above). The
+ * optional reuseKey is re-checked after the queue drains so a concurrent
+ * request with the same key reuses the conversation it created. */
+export async function createConversationSerialized(
+  agentId: string,
+  reuseKey?: string,
+): Promise<string> {
+  const tail = conversationCreateTailByAgent.get(agentId) ?? Promise.resolve();
+  const creation = tail.then(async () => {
+    if (reuseKey) {
+      const raced = conversationIdByTranscript.get(reuseKey);
+      if (raced) return raced;
+    }
+    return await createConversationWithRetry(agentId);
+  });
+  const settled = creation.then(
+    () => undefined,
+    () => undefined,
+  );
+  conversationCreateTailByAgent.set(agentId, settled);
+  void settled.then(() => {
+    if (conversationCreateTailByAgent.get(agentId) === settled) {
+      conversationCreateTailByAgent.delete(agentId);
+    }
+  });
+  return await creation;
+}
+
+export async function resolveConversationId(
+  agentId: string,
+  chatKey: string,
+): Promise<string> {
+  const existing = conversationIdByTranscript.get(chatKey);
+  if (existing) return existing;
+  return await createConversationSerialized(agentId, chatKey);
+}
+
+// Clients that know their chat identity can pin it explicitly instead of
+// relying on transcript fingerprints, which collide when two chats have
+// byte-identical transcripts (e.g. both start "Hello" and get the same
+// verbatim reply). Open WebUI sends X-OpenWebUI-Chat-Id when
+// ENABLE_FORWARD_USER_INFO_HEADERS is on; X-Letta-Chat-Key is the generic
+// escape hatch for other clients.
+function headerValue(
+  request: HttpIncomingMessage,
+  name: string,
+): string | null {
+  const value = request.headers[name];
+  if (typeof value === "string" && value) return value;
+  if (Array.isArray(value) && value[0]) return value[0];
+  return null;
+}
+
+/**
+ * X-Letta-Chat-Key always pins chat identity. X-OpenWebUI-Chat-Id is
+ * honored only for streaming requests: Open WebUI's real chat messages
+ * always stream, while its background task requests (title/tags/follow-up
+ * generation) are non-streaming yet carry the same chat id — honoring
+ * those would route task prompts into the user's pinned conversation.
+ */
+export function chatKeyFromHeaders(
+  request: HttpIncomingMessage,
+  streaming: boolean,
+): string | null {
+  const explicit = headerValue(request, "x-letta-chat-key");
+  if (explicit) return explicit;
+  if (!streaming) return null;
+  return headerValue(request, "x-openwebui-chat-id");
+}
+
+// Retry idempotency: a client retry carrying the same Idempotency-Key
+// reuses the original request's outcome instead of running (and appending)
+// the message again. In-flight duplicates share the same turn; failed
+// outcomes are evicted so an intentional retry after an error re-runs.
+const IDEMPOTENCY_HEADERS = ["idempotency-key", "x-idempotency-key"] as const;
+const MAX_IDEMPOTENT_OUTCOMES = 1024;
+const outcomeByIdempotencyKey = new Map<string, Promise<TurnOutcome>>();
+
+export function idempotencyKeyFromHeaders(
+  request: HttpIncomingMessage,
+): string | null {
+  for (const name of IDEMPOTENCY_HEADERS) {
+    const value = headerValue(request, name);
+    if (value) return value;
+  }
+  return null;
+}
+
+export function rememberIdempotentOutcome(
+  key: string,
+  promise: Promise<TurnOutcome>,
+): void {
+  outcomeByIdempotencyKey.delete(key);
+  outcomeByIdempotencyKey.set(key, promise);
+  while (outcomeByIdempotencyKey.size > MAX_IDEMPOTENT_OUTCOMES) {
+    const oldest = outcomeByIdempotencyKey.keys().next().value;
+    if (oldest === undefined) break;
+    outcomeByIdempotencyKey.delete(oldest);
+  }
+  const evict = () => {
+    if (outcomeByIdempotencyKey.get(key) === promise) {
+      outcomeByIdempotencyKey.delete(key);
+    }
+  };
+  promise.then((outcome) => {
+    if (outcome.error) evict();
+  }, evict);
+}
+
+export function getIdempotentOutcome(
+  key: string,
+): Promise<TurnOutcome> | undefined {
+  return outcomeByIdempotencyKey.get(key);
+}
+
+/** @internal Clears chat-key and idempotency maps between tests. */
+export function resetOpenAiCompatState(): void {
+  conversationIdByTranscript.clear();
+  outcomeByIdempotencyKey.clear();
+}

--- a/src/websocket/app-server-openai-responses.test.ts
+++ b/src/websocket/app-server-openai-responses.test.ts
@@ -336,6 +336,65 @@ describe("app-server Responses API", () => {
     expect(messageCounts).toEqual([1, 1]);
   });
 
+  test("Open WebUI chat ids isolate sessions and continue messages", async () => {
+    const created: string[] = [];
+    __testSetBackend(fakeBackend(created));
+    const turns: Array<{
+      conversationId: string;
+      messages: unknown[];
+    }> = [];
+    stubToolTurn((conversationId, messages) => {
+      turns.push({ conversationId, messages });
+    });
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+    const server = handle;
+
+    const sendOpenWebUiMessage = async (
+      chatId: string,
+      input: unknown,
+    ): Promise<number> => {
+      const response = await fetch(httpUrl(server, "/v1/responses"), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-openwebui-chat-id": chatId,
+        },
+        body: JSON.stringify({
+          model: "Tutor (Letta Agent)",
+          input,
+          stream: true,
+        }),
+      });
+      await response.text();
+      return response.status;
+    };
+
+    expect(await sendOpenWebUiMessage("chat-a", "first message")).toBe(200);
+    expect(
+      await sendOpenWebUiMessage("chat-a", [
+        { type: "message", role: "user", content: "first message" },
+        { type: "message", role: "assistant", content: "first reply" },
+        { type: "message", role: "user", content: "second message" },
+      ]),
+    ).toBe(200);
+    expect(await sendOpenWebUiMessage("chat-b", "separate chat")).toBe(200);
+
+    expect(created).toEqual(["conv-responses-1", "conv-responses-2"]);
+    expect(turns.map((turn) => turn.conversationId)).toEqual([
+      "conv-responses-1",
+      "conv-responses-1",
+      "conv-responses-2",
+    ]);
+    expect(turns.map((turn) => turn.messages)).toMatchObject([
+      [{ role: "user", content: [{ type: "text", text: "first message" }] }],
+      [{ role: "user", content: [{ type: "text", text: "second message" }] }],
+      [{ role: "user", content: [{ type: "text", text: "separate chat" }] }],
+    ]);
+  });
+
   test("rejects unknown previous_response_id", async () => {
     __testSetBackend(fakeBackend());
     stubToolTurn();

--- a/src/websocket/app-server-openai-responses.test.ts
+++ b/src/websocket/app-server-openai-responses.test.ts
@@ -401,44 +401,40 @@ describe("app-server Responses API", () => {
     expect(result.output_text).toBe("I examined the project.");
   });
 
-  test("store plus previous_response_id continues the same conversation", async () => {
-    const created: string[] = [];
-    __testSetBackend(fakeBackend(created));
-    const conversations: string[] = [];
-    const messageCounts: number[] = [];
-    stubToolTurn((conversationId, messages) => {
-      conversations.push(conversationId);
-      messageCounts.push(messages.length);
+  test("applies Responses instructions to the user turn", async () => {
+    __testSetBackend(fakeBackend());
+    let capturedMessages: unknown[] = [];
+    stubToolTurn((_conversationId, messages) => {
+      capturedMessages = messages;
     });
     handle = await startAppServer({
       listen: "ws://127.0.0.1:0",
       openaiApi: true,
     });
 
-    const first = await fetch(httpUrl(handle, "/v1/responses"), {
+    const response = await fetch(httpUrl(handle, "/v1/responses"), {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         model: "Tutor (Letta Agent)",
-        input: "Learn this project.",
-      }),
-    });
-    const firstBody = (await first.json()) as { id: string };
-
-    const second = await fetch(httpUrl(handle, "/v1/responses"), {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        model: "Tutor (Letta Agent)",
-        input: "What did you learn?",
-        previous_response_id: firstBody.id,
+        instructions: "Answer in one sentence.",
+        input: "Inspect the project.",
       }),
     });
 
-    expect(second.status).toBe(200);
-    expect(created).toEqual(["conv-responses-1"]);
-    expect(conversations).toEqual(["conv-responses-1", "conv-responses-1"]);
-    expect(messageCounts).toEqual([1, 1]);
+    expect(response.status).toBe(200);
+    expect(capturedMessages).toMatchObject([
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "<system-reminder>\nAnswer in one sentence.\n</system-reminder>\n\n",
+          },
+          { type: "text", text: "Inspect the project." },
+        ],
+      },
+    ]);
   });
 
   test("Open WebUI chat ids isolate sessions and continue messages", async () => {
@@ -513,26 +509,30 @@ describe("app-server Responses API", () => {
     ]);
   });
 
-  test("rejects unknown previous_response_id", async () => {
+  test("rejects stored response state until retrieval and cleanup are supported", async () => {
     __testSetBackend(fakeBackend());
-    stubToolTurn();
     handle = await startAppServer({
       listen: "ws://127.0.0.1:0",
       openaiApi: true,
     });
 
-    const response = await fetch(httpUrl(handle, "/v1/responses"), {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        model: "Tutor (Letta Agent)",
-        input: "Hello",
-        previous_response_id: "resp_missing",
-      }),
-    });
-    expect(response.status).toBe(404);
-    const body = (await response.json()) as { error: { code: string } };
-    expect(body.error.code).toBe("previous_response_not_found");
+    for (const unsupported of [
+      { store: true },
+      { previous_response_id: "resp_previous" },
+    ]) {
+      const response = await fetch(httpUrl(handle, "/v1/responses"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "Tutor (Letta Agent)",
+          input: "Hello",
+          ...unsupported,
+        }),
+      });
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: { code: string } };
+      expect(body.error.code).toBe("unsupported_parameter");
+    }
   });
 
   test("requires user input", async () => {

--- a/src/websocket/app-server-openai-responses.test.ts
+++ b/src/websocket/app-server-openai-responses.test.ts
@@ -70,6 +70,41 @@ function stubToolTurn(
   );
 }
 
+function stubReasoningTurn(): void {
+  __testSetRunTurnImpl(
+    async ({ onAssistantText, onReasoningText, onToolEvent }) => {
+      onReasoningText?.("Inspect the ");
+      onReasoningText?.("workspace.");
+      onToolEvent?.({
+        type: "tool_call_start",
+        tool_call_id: "call_reasoning_1",
+        tool_name: "Bash",
+      });
+      onToolEvent?.({
+        type: "tool_call_complete",
+        tool_call_id: "call_reasoning_1",
+        tool_name: "Bash",
+        arguments: '{"command":"pwd"}',
+        output: "/workspace/letta-code\n",
+        success: true,
+      });
+      onReasoningText?.("Use the result.");
+      onAssistantText?.("Done.");
+      return {
+        text: "Done.",
+        reasoning: "Inspect the workspace.Use the result.",
+        usage: {
+          prompt_tokens: 21,
+          completion_tokens: 16,
+          total_tokens: 37,
+          reasoning_tokens: 7,
+        },
+        error: null,
+      };
+    },
+  );
+}
+
 describe("app-server Responses API", () => {
   let handle: AppServerHandle | null = null;
 
@@ -108,7 +143,7 @@ describe("app-server Responses API", () => {
       object: string;
       status: string;
       output: Array<Record<string, unknown>>;
-      usage: Record<string, number>;
+      usage: Record<string, unknown>;
     };
     expect(body.id).toStartWith("resp_");
     expect(body.object).toBe("response");
@@ -143,6 +178,7 @@ describe("app-server Responses API", () => {
       input_tokens: 21,
       output_tokens: 9,
       total_tokens: 30,
+      output_tokens_details: { reasoning_tokens: 0 },
     });
     await new Promise((resolve) => setTimeout(resolve, 20));
     expect(deleted).toEqual(["conv-responses-1"]);
@@ -207,6 +243,75 @@ describe("app-server Responses API", () => {
     expect(completed.status).toBe("completed");
     expect(completed.output[1]?.type).toBe("function_call_output");
     expect(completed.output[2]?.type).toBe("message");
+  });
+
+  test("streams native reasoning items and reports reasoning tokens", async () => {
+    __testSetBackend(fakeBackend());
+    stubReasoningTurn();
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const response = await fetch(httpUrl(handle, "/v1/responses"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "Tutor (Letta Agent)",
+        input: "Inspect the repo.",
+        stream: true,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const events = (await response.text())
+      .split("\n")
+      .filter((line) => line.startsWith("data: "))
+      .map((line) => JSON.parse(line.slice(6)) as Record<string, unknown>);
+    expect(
+      events
+        .map((event) => event.type)
+        .filter(
+          (type) => typeof type === "string" && type.includes("reasoning"),
+        ),
+    ).toEqual([
+      "response.reasoning_summary_part.added",
+      "response.reasoning_summary_text.delta",
+      "response.reasoning_summary_text.delta",
+      "response.reasoning_summary_text.done",
+      "response.reasoning_summary_part.done",
+      "response.reasoning_summary_part.added",
+      "response.reasoning_summary_text.delta",
+      "response.reasoning_summary_text.done",
+      "response.reasoning_summary_part.done",
+    ]);
+    const completed = events.at(-1)?.response as {
+      output: Array<Record<string, unknown>>;
+      usage: Record<string, unknown>;
+    };
+    expect(completed.output.map((item) => item.type)).toEqual([
+      "reasoning",
+      "function_call",
+      "function_call_output",
+      "reasoning",
+      "message",
+    ]);
+    expect(completed.output[0]).toMatchObject({
+      type: "reasoning",
+      status: "completed",
+      summary: [{ type: "summary_text", text: "Inspect the workspace." }],
+    });
+    expect(completed.output[3]).toMatchObject({
+      type: "reasoning",
+      status: "completed",
+      summary: [{ type: "summary_text", text: "Use the result." }],
+    });
+    expect(completed.usage).toMatchObject({
+      input_tokens: 21,
+      output_tokens: 16,
+      total_tokens: 37,
+      output_tokens_details: { reasoning_tokens: 7 },
+    });
   });
 
   test("preserves assistant text ordering around a server-side tool call", async () => {

--- a/src/websocket/app-server-openai-responses.test.ts
+++ b/src/websocket/app-server-openai-responses.test.ts
@@ -1,0 +1,314 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import OpenAI from "openai";
+import type { Backend } from "@/backend";
+import { __testSetBackend } from "@/backend";
+import { type AppServerHandle, startAppServer } from "@/websocket/app-server";
+import {
+  __testResetConversationMap,
+  __testSetRunTurnImpl,
+} from "@/websocket/app-server-openai";
+
+const TEST_AGENT = {
+  id: "agent-local-tutor",
+  name: "Tutor (Letta Agent)",
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+function fakeBackend(created: string[] = [], deleted: string[] = []): Backend {
+  return {
+    listAgents: async () => [TEST_AGENT],
+    createConversation: async () => {
+      const id = `conv-responses-${created.length + 1}`;
+      created.push(id);
+      return { id, agent_id: TEST_AGENT.id };
+    },
+    deleteConversation: async (conversationId: string) => {
+      deleted.push(conversationId);
+      return {};
+    },
+  } as unknown as Backend;
+}
+
+function httpUrl(handle: AppServerHandle, path: string): string {
+  const url = new URL(handle.url);
+  url.protocol = "http:";
+  return `${url.origin}${path}`;
+}
+
+function stubToolTurn(
+  capture?: (conversationId: string, messages: unknown[]) => void,
+): void {
+  __testSetRunTurnImpl(
+    async ({ conversationId, messages, onAssistantText, onToolEvent }) => {
+      capture?.(conversationId, messages);
+      onToolEvent?.({
+        type: "tool_call_start",
+        tool_call_id: "call_bash_1",
+        tool_name: "Bash",
+      });
+      onToolEvent?.({
+        type: "tool_call_arguments_delta",
+        tool_call_id: "call_bash_1",
+        arguments_delta: '{"command":"pwd"}',
+      });
+      onToolEvent?.({
+        type: "tool_call_complete",
+        tool_call_id: "call_bash_1",
+        tool_name: "Bash",
+        arguments: '{"command":"pwd"}',
+        output: "/workspace/letta-code\n",
+        success: true,
+      });
+      onAssistantText?.("I examined ");
+      onAssistantText?.("the project.");
+      return {
+        text: "I examined the project.",
+        usage: { prompt_tokens: 21, completion_tokens: 9, total_tokens: 30 },
+        error: null,
+      };
+    },
+  );
+}
+
+describe("app-server Responses API", () => {
+  let handle: AppServerHandle | null = null;
+
+  afterEach(async () => {
+    __testSetRunTurnImpl(null);
+    __testResetConversationMap();
+    __testSetBackend(null);
+    if (handle) {
+      await handle.close();
+      handle = null;
+    }
+  });
+
+  test("POST /v1/responses returns completed server-side tool traces", async () => {
+    const deleted: string[] = [];
+    __testSetBackend(fakeBackend([], deleted));
+    stubToolTurn();
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const response = await fetch(httpUrl(handle, "/v1/responses"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "Tutor (Letta Agent)",
+        input: "Examine the current directory.",
+        store: false,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      id: string;
+      object: string;
+      status: string;
+      output: Array<Record<string, unknown>>;
+      usage: Record<string, number>;
+    };
+    expect(body.id).toStartWith("resp_");
+    expect(body.object).toBe("response");
+    expect(body.status).toBe("completed");
+    expect(body.output).toHaveLength(3);
+    expect(body.output[0]).toMatchObject({
+      type: "function_call",
+      call_id: "call_bash_1",
+      name: "Bash",
+      arguments: '{"command":"pwd"}',
+      status: "completed",
+    });
+    expect(body.output[1]).toMatchObject({
+      type: "function_call_output",
+      call_id: "call_bash_1",
+      status: "completed",
+      output: [{ type: "input_text", text: "/workspace/letta-code\n" }],
+    });
+    expect(body.output[2]).toMatchObject({
+      type: "message",
+      status: "completed",
+      role: "assistant",
+      content: [
+        {
+          type: "output_text",
+          text: "I examined the project.",
+          annotations: [],
+        },
+      ],
+    });
+    expect(body.usage).toEqual({
+      input_tokens: 21,
+      output_tokens: 9,
+      total_tokens: 30,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(deleted).toEqual(["conv-responses-1"]);
+  });
+
+  test("POST /v1/responses streams spec-native tool and text events", async () => {
+    __testSetBackend(fakeBackend());
+    stubToolTurn();
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const response = await fetch(httpUrl(handle, "/v1/responses"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "Tutor (Letta Agent)",
+        input: [
+          {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "Inspect the repo." }],
+          },
+        ],
+        stream: true,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    const stream = await response.text();
+    const events = stream
+      .split("\n")
+      .filter((line) => line.startsWith("data: "))
+      .map((line) => JSON.parse(line.slice(6)) as Record<string, unknown>);
+    expect(events.map((event) => event.type)).toEqual([
+      "response.created",
+      "response.in_progress",
+      "response.output_item.added",
+      "response.function_call_arguments.delta",
+      "response.function_call_arguments.done",
+      "response.output_item.done",
+      "response.output_item.added",
+      "response.output_item.done",
+      "response.output_item.added",
+      "response.content_part.added",
+      "response.output_text.delta",
+      "response.output_text.delta",
+      "response.output_text.done",
+      "response.content_part.done",
+      "response.output_item.done",
+      "response.completed",
+    ]);
+    expect(events.map((event) => event.sequence_number)).toEqual(
+      events.map((_, index) => index),
+    );
+    const completed = events.at(-1)?.response as {
+      status: string;
+      output: Array<Record<string, unknown>>;
+    };
+    expect(completed.status).toBe("completed");
+    expect(completed.output[1]?.type).toBe("function_call_output");
+    expect(completed.output[2]?.type).toBe("message");
+  });
+
+  test("works through the official OpenAI Responses SDK", async () => {
+    __testSetBackend(fakeBackend());
+    stubToolTurn();
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+    const client = new OpenAI({
+      apiKey: "not-needed",
+      baseURL: httpUrl(handle, "/v1"),
+    });
+
+    const result = await client.responses.create({
+      model: "Tutor (Letta Agent)",
+      input: "Inspect the repo.",
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.output.map((item) => item.type)).toEqual([
+      "function_call",
+      "function_call_output",
+      "message",
+    ]);
+    expect(result.output_text).toBe("I examined the project.");
+  });
+
+  test("store plus previous_response_id continues the same conversation", async () => {
+    const created: string[] = [];
+    __testSetBackend(fakeBackend(created));
+    const conversations: string[] = [];
+    const messageCounts: number[] = [];
+    stubToolTurn((conversationId, messages) => {
+      conversations.push(conversationId);
+      messageCounts.push(messages.length);
+    });
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const first = await fetch(httpUrl(handle, "/v1/responses"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "Tutor (Letta Agent)",
+        input: "Learn this project.",
+      }),
+    });
+    const firstBody = (await first.json()) as { id: string };
+
+    const second = await fetch(httpUrl(handle, "/v1/responses"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "Tutor (Letta Agent)",
+        input: "What did you learn?",
+        previous_response_id: firstBody.id,
+      }),
+    });
+
+    expect(second.status).toBe(200);
+    expect(created).toEqual(["conv-responses-1"]);
+    expect(conversations).toEqual(["conv-responses-1", "conv-responses-1"]);
+    expect(messageCounts).toEqual([1, 1]);
+  });
+
+  test("rejects unknown previous_response_id", async () => {
+    __testSetBackend(fakeBackend());
+    stubToolTurn();
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const response = await fetch(httpUrl(handle, "/v1/responses"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "Tutor (Letta Agent)",
+        input: "Hello",
+        previous_response_id: "resp_missing",
+      }),
+    });
+    expect(response.status).toBe(404);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("previous_response_not_found");
+  });
+
+  test("requires user input", async () => {
+    __testSetBackend(fakeBackend());
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const response = await fetch(httpUrl(handle, "/v1/responses"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "Tutor (Letta Agent)", input: [] }),
+    });
+    expect(response.status).toBe(400);
+  });
+});

--- a/src/websocket/app-server-openai-responses.test.ts
+++ b/src/websocket/app-server-openai-responses.test.ts
@@ -209,6 +209,67 @@ describe("app-server Responses API", () => {
     expect(completed.output[2]?.type).toBe("message");
   });
 
+  test("preserves assistant text ordering around a server-side tool call", async () => {
+    __testSetBackend(fakeBackend());
+    __testSetRunTurnImpl(async ({ onAssistantText, onToolEvent }) => {
+      onAssistantText?.("Let me check that.");
+      onToolEvent?.({
+        type: "tool_call_start",
+        tool_call_id: "call_ordered",
+        tool_name: "Bash",
+      });
+      onToolEvent?.({
+        type: "tool_call_arguments_delta",
+        tool_call_id: "call_ordered",
+        arguments_delta: '{"command":"pwd"}',
+      });
+      onToolEvent?.({
+        type: "tool_call_complete",
+        tool_call_id: "call_ordered",
+        tool_name: "Bash",
+        arguments: '{"command":"pwd"}',
+        output: "/workspace",
+        success: true,
+      });
+      onAssistantText?.("The directory is /workspace.");
+      return {
+        text: "Let me check that.The directory is /workspace.",
+        usage: { prompt_tokens: 4, completion_tokens: 8, total_tokens: 12 },
+        error: null,
+      };
+    });
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const response = await fetch(httpUrl(handle, "/v1/responses"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "Tutor (Letta Agent)",
+        input: "Where are you running?",
+      }),
+    });
+    const body = (await response.json()) as {
+      output: Array<{
+        type: string;
+        content?: Array<{ text?: string }>;
+      }>;
+    };
+
+    expect(body.output.map((item) => item.type)).toEqual([
+      "message",
+      "function_call",
+      "function_call_output",
+      "message",
+    ]);
+    expect(body.output[0]?.content?.[0]?.text).toBe("Let me check that.");
+    expect(body.output[3]?.content?.[0]?.text).toBe(
+      "The directory is /workspace.",
+    );
+  });
+
   test("works through the official OpenAI Responses SDK", async () => {
     __testSetBackend(fakeBackend());
     stubToolTurn();

--- a/src/websocket/app-server-openai-responses.test.ts
+++ b/src/websocket/app-server-openai-responses.test.ts
@@ -418,7 +418,11 @@ describe("app-server Responses API", () => {
       body: JSON.stringify({
         model: "Tutor (Letta Agent)",
         instructions: "Answer in one sentence.",
-        input: "Inspect the project.",
+        input: [
+          { type: "message", role: "developer", content: "Be concise." },
+          { type: "message", role: "system", content: "Use plain text." },
+          { type: "message", role: "user", content: "Inspect the project." },
+        ],
       }),
     });
 
@@ -429,7 +433,7 @@ describe("app-server Responses API", () => {
         content: [
           {
             type: "text",
-            text: "<system-reminder>\nAnswer in one sentence.\n</system-reminder>\n\n",
+            text: "<system-reminder>\nAnswer in one sentence.\n\nBe concise.\n\nUse plain text.\n</system-reminder>\n\n",
           },
           { type: "text", text: "Inspect the project." },
         ],

--- a/src/websocket/app-server-openai-responses.test.ts
+++ b/src/websocket/app-server-openai-responses.test.ts
@@ -338,7 +338,8 @@ describe("app-server Responses API", () => {
 
   test("Open WebUI chat ids isolate sessions and continue messages", async () => {
     const created: string[] = [];
-    __testSetBackend(fakeBackend(created));
+    const deleted: string[] = [];
+    __testSetBackend(fakeBackend(created, deleted));
     const turns: Array<{
       conversationId: string;
       messages: unknown[];
@@ -355,6 +356,7 @@ describe("app-server Responses API", () => {
     const sendOpenWebUiMessage = async (
       chatId: string,
       input: unknown,
+      stream = true,
     ): Promise<number> => {
       const response = await fetch(httpUrl(server, "/v1/responses"), {
         method: "POST",
@@ -365,7 +367,7 @@ describe("app-server Responses API", () => {
         body: JSON.stringify({
           model: "Tutor (Letta Agent)",
           input,
-          stream: true,
+          stream,
         }),
       });
       await response.text();
@@ -373,6 +375,9 @@ describe("app-server Responses API", () => {
     };
 
     expect(await sendOpenWebUiMessage("chat-a", "first message")).toBe(200);
+    expect(
+      await sendOpenWebUiMessage("chat-a", "generate a title", false),
+    ).toBe(200);
     expect(
       await sendOpenWebUiMessage("chat-a", [
         { type: "message", role: "user", content: "first message" },
@@ -382,14 +387,22 @@ describe("app-server Responses API", () => {
     ).toBe(200);
     expect(await sendOpenWebUiMessage("chat-b", "separate chat")).toBe(200);
 
-    expect(created).toEqual(["conv-responses-1", "conv-responses-2"]);
-    expect(turns.map((turn) => turn.conversationId)).toEqual([
-      "conv-responses-1",
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(created).toEqual([
       "conv-responses-1",
       "conv-responses-2",
+      "conv-responses-3",
+    ]);
+    expect(deleted).toEqual(["conv-responses-2"]);
+    expect(turns.map((turn) => turn.conversationId)).toEqual([
+      "conv-responses-1",
+      "conv-responses-2",
+      "conv-responses-1",
+      "conv-responses-3",
     ]);
     expect(turns.map((turn) => turn.messages)).toMatchObject([
       [{ role: "user", content: [{ type: "text", text: "first message" }] }],
+      [{ role: "user", content: [{ type: "text", text: "generate a title" }] }],
       [{ role: "user", content: [{ type: "text", text: "second message" }] }],
       [{ role: "user", content: [{ type: "text", text: "separate chat" }] }],
     ]);

--- a/src/websocket/app-server-openai-responses.ts
+++ b/src/websocket/app-server-openai-responses.ts
@@ -1,0 +1,606 @@
+import { randomUUID } from "node:crypto";
+import type {
+  IncomingMessage as HttpIncomingMessage,
+  ServerResponse,
+} from "node:http";
+import { getBackend } from "@/backend";
+import {
+  chatKeyFromHeaders,
+  createConversationSerialized,
+  extractTextContent,
+  extractUserContentParts,
+  type OpenAiChatMessage,
+  type OpenAiCompatOptions,
+  readJsonBody,
+  rememberConversation,
+  resolveAgentForModel,
+  resolveConversationId,
+  sendJson,
+  sendOpenAiError,
+} from "@/websocket/app-server-openai-common";
+import type { ToolCallEvent } from "@/websocket/app-server-openai-tools";
+import {
+  type BridgeTurnMessage,
+  runBridgeTurn,
+  type TurnOutcome,
+  type UserContentPart,
+} from "@/websocket/app-server-openai-turn";
+
+export const RESPONSES_PATH = "/v1/responses";
+
+interface ResponsesContentPart {
+  type?: string;
+  text?: string;
+  image_url?: { url?: string } | string;
+}
+
+interface ResponsesInputItem {
+  type?: string;
+  role?: string;
+  content?: string | ResponsesContentPart[] | null;
+}
+
+interface ResponsesRequest {
+  model?: string;
+  input?: string | ResponsesInputItem[];
+  instructions?: string | null;
+  previous_response_id?: string | null;
+  store?: boolean;
+  stream?: boolean;
+}
+
+interface FunctionCallItem {
+  type: "function_call";
+  id: string;
+  call_id: string;
+  name: string;
+  arguments: string;
+  status: "in_progress" | "completed" | "failed";
+}
+
+interface FunctionCallOutputItem {
+  type: "function_call_output";
+  id: string;
+  call_id: string;
+  output: Array<{ type: "input_text"; text: string }>;
+  status: "completed" | "failed";
+}
+
+interface MessageItem {
+  type: "message";
+  id: string;
+  status: "in_progress" | "completed";
+  role: "assistant";
+  content: Array<{
+    type: "output_text";
+    text: string;
+    annotations: unknown[];
+  }>;
+}
+
+type ResponseOutputItem =
+  | FunctionCallItem
+  | FunctionCallOutputItem
+  | MessageItem;
+
+interface StoredResponseState {
+  agentId: string;
+  conversationId: string;
+}
+
+const MAX_STORED_RESPONSES = 4096;
+const storedResponseState = new Map<string, StoredResponseState>();
+
+/** @internal Reset Responses API state between tests. */
+export function resetResponsesState(): void {
+  storedResponseState.clear();
+}
+
+function rememberResponseState(
+  responseId: string,
+  state: StoredResponseState,
+): void {
+  storedResponseState.delete(responseId);
+  storedResponseState.set(responseId, state);
+  while (storedResponseState.size > MAX_STORED_RESPONSES) {
+    const oldest = storedResponseState.keys().next().value;
+    if (oldest === undefined) break;
+    storedResponseState.delete(oldest);
+  }
+}
+
+function normalizeInput(input: ResponsesRequest["input"]): OpenAiChatMessage[] {
+  if (typeof input === "string") {
+    return input ? [{ role: "user", content: input }] : [];
+  }
+  if (!Array.isArray(input)) return [];
+  const messages: OpenAiChatMessage[] = [];
+  for (const item of input) {
+    if (!item || item.type !== "message") continue;
+    if (item.role !== "user" && item.role !== "assistant") continue;
+    messages.push({ role: item.role, content: item.content });
+  }
+  return messages;
+}
+
+function toBridgeMessages(
+  messages: OpenAiChatMessage[],
+  stateful: boolean,
+): { messages: BridgeTurnMessage[]; correlationOtid: string | null } {
+  const lastUserMessage = [...messages]
+    .reverse()
+    .find((message) => message.role === "user");
+  const lastUserContent = extractUserContentParts(lastUserMessage?.content);
+  if (lastUserContent.length === 0) {
+    return { messages: [], correlationOtid: null };
+  }
+
+  if (stateful) {
+    const otid = randomUUID();
+    return {
+      messages: [{ role: "user", content: lastUserContent, otid }],
+      correlationOtid: otid,
+    };
+  }
+
+  const bridgeMessages: BridgeTurnMessage[] = [];
+  for (const message of messages) {
+    let content: UserContentPart[];
+    if (message === lastUserMessage) {
+      content = lastUserContent;
+    } else if (message.role === "user") {
+      content = extractUserContentParts(message.content);
+    } else {
+      const text = extractTextContent(message.content);
+      content = text ? [{ type: "text", text }] : [];
+    }
+    if (content.length === 0) continue;
+    bridgeMessages.push({
+      role: message.role as "user" | "assistant",
+      content,
+      otid: randomUUID(),
+    });
+  }
+  return {
+    messages: bridgeMessages,
+    correlationOtid: bridgeMessages.at(-1)?.otid ?? null,
+  };
+}
+
+function responseUsage(usage: TurnOutcome["usage"]): Record<string, number> {
+  return {
+    input_tokens: usage.prompt_tokens,
+    output_tokens: usage.completion_tokens,
+    total_tokens: usage.total_tokens,
+  };
+}
+
+function makeResponse(
+  responseId: string,
+  createdAt: number,
+  model: string,
+  status: "in_progress" | "completed" | "failed",
+  output: ResponseOutputItem[],
+  outcome?: TurnOutcome,
+): Record<string, unknown> {
+  return {
+    id: responseId,
+    object: "response",
+    created_at: createdAt,
+    status,
+    model,
+    output,
+    error:
+      status === "failed"
+        ? {
+            code: "server_error",
+            message: outcome?.error ?? "agent turn failed",
+          }
+        : null,
+    incomplete_details: null,
+    usage: outcome ? responseUsage(outcome.usage) : null,
+  };
+}
+
+class ResponseOutputBuilder {
+  readonly output: ResponseOutputItem[] = [];
+  private readonly calls = new Map<
+    string,
+    { item: FunctionCallItem; index: number }
+  >();
+  private message: { item: MessageItem; index: number } | null = null;
+
+  constructor(
+    private readonly emit?: (event: Record<string, unknown>) => void,
+  ) {}
+
+  addText(delta: string): void {
+    const message = this.ensureMessage();
+    const part = message.item.content[0];
+    if (part) part.text += delta;
+    this.emit?.({
+      type: "response.output_text.delta",
+      output_index: message.index,
+      content_index: 0,
+      item_id: message.item.id,
+      delta,
+    });
+  }
+
+  addToolEvent(event: ToolCallEvent): void {
+    if (event.type === "tool_call_start") {
+      this.ensureToolCall(event.tool_call_id, event.tool_name ?? "tool");
+      return;
+    }
+    if (event.type === "tool_call_arguments_delta") {
+      const call = this.ensureToolCall(event.tool_call_id, "tool");
+      call.item.arguments += event.arguments_delta;
+      this.emit?.({
+        type: "response.function_call_arguments.delta",
+        output_index: call.index,
+        item_id: call.item.id,
+        delta: event.arguments_delta,
+      });
+      return;
+    }
+
+    const call = this.ensureToolCall(
+      event.tool_call_id,
+      event.tool_name ?? "tool",
+    );
+    call.item.name = event.tool_name ?? call.item.name;
+    call.item.arguments = event.arguments;
+    call.item.status = event.success ? "completed" : "failed";
+    this.emit?.({
+      type: "response.function_call_arguments.done",
+      output_index: call.index,
+      item_id: call.item.id,
+      name: call.item.name,
+      arguments: call.item.arguments,
+    });
+    this.emit?.({
+      type: "response.output_item.done",
+      output_index: call.index,
+      item: call.item,
+    });
+
+    const result: FunctionCallOutputItem = {
+      type: "function_call_output",
+      id: `fco_${randomUUID()}`,
+      call_id: event.tool_call_id,
+      output: [{ type: "input_text", text: event.output }],
+      status: event.success ? "completed" : "failed",
+    };
+    const outputIndex = this.output.length;
+    this.output.push(result);
+    this.emit?.({
+      type: "response.output_item.added",
+      output_index: outputIndex,
+      item: result,
+    });
+    this.emit?.({
+      type: "response.output_item.done",
+      output_index: outputIndex,
+      item: result,
+    });
+  }
+
+  finishText(): void {
+    if (!this.message) return;
+    const { item, index } = this.message;
+    item.status = "completed";
+    const part = item.content[0];
+    if (!part) return;
+    this.emit?.({
+      type: "response.output_text.done",
+      output_index: index,
+      content_index: 0,
+      item_id: item.id,
+      text: part.text,
+    });
+    this.emit?.({
+      type: "response.content_part.done",
+      output_index: index,
+      content_index: 0,
+      item_id: item.id,
+      part,
+    });
+    this.emit?.({
+      type: "response.output_item.done",
+      output_index: index,
+      item,
+    });
+  }
+
+  private ensureMessage(): { item: MessageItem; index: number } {
+    if (this.message) return this.message;
+    const item: MessageItem = {
+      type: "message",
+      id: `msg_${randomUUID()}`,
+      status: "in_progress",
+      role: "assistant",
+      content: [{ type: "output_text", text: "", annotations: [] }],
+    };
+    const index = this.output.length;
+    this.output.push(item);
+    this.message = { item, index };
+    this.emit?.({
+      type: "response.output_item.added",
+      output_index: index,
+      item: { ...item, content: [] },
+    });
+    this.emit?.({
+      type: "response.content_part.added",
+      output_index: index,
+      content_index: 0,
+      item_id: item.id,
+      part: item.content[0],
+    });
+    return this.message;
+  }
+
+  private ensureToolCall(
+    callId: string,
+    name: string,
+  ): { item: FunctionCallItem; index: number } {
+    const existing = this.calls.get(callId);
+    if (existing) {
+      if (existing.item.name === "tool" && name !== "tool") {
+        existing.item.name = name;
+      }
+      return existing;
+    }
+    const item: FunctionCallItem = {
+      type: "function_call",
+      id: `fc_${randomUUID()}`,
+      call_id: callId,
+      name,
+      arguments: "",
+      status: "in_progress",
+    };
+    const index = this.output.length;
+    this.output.push(item);
+    const state = { item, index };
+    this.calls.set(callId, state);
+    this.emit?.({
+      type: "response.output_item.added",
+      output_index: index,
+      item,
+    });
+    return state;
+  }
+}
+
+function writeSseEvent(
+  response: ServerResponse,
+  sequenceNumber: number,
+  event: Record<string, unknown>,
+): void {
+  const payload = { sequence_number: sequenceNumber, ...event };
+  response.write(`event: ${String(event.type)}\n`);
+  response.write(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+export async function handleResponses(
+  request: HttpIncomingMessage,
+  response: ServerResponse,
+  options: OpenAiCompatOptions,
+): Promise<void> {
+  let body: ResponsesRequest;
+  try {
+    body = (await readJsonBody(request)) as ResponsesRequest;
+  } catch (error) {
+    sendOpenAiError(
+      response,
+      400,
+      error instanceof Error ? error.message : "invalid JSON body",
+      "invalid_request_error",
+    );
+    return;
+  }
+  if (!body.model) {
+    sendOpenAiError(
+      response,
+      400,
+      "you must provide a model parameter",
+      "invalid_request_error",
+    );
+    return;
+  }
+  const agent = await resolveAgentForModel(body.model);
+  if (!agent) {
+    sendOpenAiError(
+      response,
+      404,
+      `The model '${body.model}' does not exist. Use GET /v1/models to list available agents.`,
+      "invalid_request_error",
+      "model_not_found",
+    );
+    return;
+  }
+
+  const input = normalizeInput(body.input);
+  const previous = body.previous_response_id
+    ? storedResponseState.get(body.previous_response_id)
+    : undefined;
+  if (body.previous_response_id && !previous) {
+    sendOpenAiError(
+      response,
+      404,
+      `Previous response '${body.previous_response_id}' was not found.`,
+      "invalid_request_error",
+      "previous_response_not_found",
+    );
+    return;
+  }
+  if (previous && previous.agentId !== agent.id) {
+    sendOpenAiError(
+      response,
+      400,
+      "previous_response_id belongs to a different model",
+      "invalid_request_error",
+    );
+    return;
+  }
+
+  const headerChatKey = chatKeyFromHeaders(request, body.stream === true);
+  const stateful = Boolean(previous || headerChatKey);
+  const prepared = toBridgeMessages(input, stateful);
+  if (!prepared.correlationOtid) {
+    sendOpenAiError(
+      response,
+      400,
+      "input must include a user message with text or image content",
+      "invalid_request_error",
+    );
+    return;
+  }
+
+  let conversationId: string;
+  try {
+    if (previous) {
+      conversationId = previous.conversationId;
+    } else if (headerChatKey) {
+      const key = `chat-key:${agent.id}:${headerChatKey}`;
+      conversationId = await resolveConversationId(agent.id, key);
+      rememberConversation(key, conversationId);
+    } else {
+      conversationId = await createConversationSerialized(agent.id);
+    }
+  } catch (error) {
+    options.onLog?.(
+      `OpenAI-compat failed to create conversation: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    sendOpenAiError(
+      response,
+      500,
+      "failed to create a conversation for this response",
+      "server_error",
+    );
+    return;
+  }
+
+  const responseId = `resp_${randomUUID()}`;
+  const createdAt = Math.floor(Date.now() / 1000);
+  const streaming = body.stream === true;
+  let sequenceNumber = 0;
+  let clientClosed = false;
+  response.on("close", () => {
+    clientClosed = true;
+  });
+  const emit = streaming
+    ? (event: Record<string, unknown>) => {
+        if (clientClosed) return;
+        writeSseEvent(response, sequenceNumber++, event);
+      }
+    : undefined;
+  const builder = new ResponseOutputBuilder(emit);
+
+  if (streaming) {
+    response.writeHead(200, {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+    });
+    emit?.({
+      type: "response.created",
+      response: makeResponse(
+        responseId,
+        createdAt,
+        body.model,
+        "in_progress",
+        [],
+      ),
+    });
+    emit?.({
+      type: "response.in_progress",
+      response: makeResponse(
+        responseId,
+        createdAt,
+        body.model,
+        "in_progress",
+        [],
+      ),
+    });
+  }
+
+  let outcome: TurnOutcome;
+  try {
+    outcome = await runBridgeTurn({
+      agentId: agent.id,
+      conversationId,
+      messages: prepared.messages,
+      correlationOtid: prepared.correlationOtid,
+      onLog: options.onLog,
+      onAssistantText: (delta) => builder.addText(delta),
+      onToolEvent: (event) => builder.addToolEvent(event),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    options.onLog?.(`OpenAI Responses turn failed: ${message}`);
+    outcome = {
+      text: "",
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+      error: "failed to run agent turn",
+    };
+  }
+
+  // Idempotent/replayed test seams can return an outcome without invoking
+  // callbacks. Reconstruct output from the completed outcome in that case.
+  if (builder.output.length === 0) {
+    for (const event of outcome.toolEvents ?? []) builder.addToolEvent(event);
+    if (outcome.text) builder.addText(outcome.text);
+  }
+  builder.finishText();
+
+  // OpenAI Responses are stored by default; `store: false` opts out.
+  const shouldStore =
+    body.store !== false || Boolean(headerChatKey || previous);
+  if (shouldStore && !outcome.error) {
+    rememberResponseState(responseId, { agentId: agent.id, conversationId });
+  } else if (!headerChatKey && !previous) {
+    void getBackend()
+      .deleteConversation?.(conversationId)
+      .catch(() => {
+        options.onLog?.(
+          `OpenAI-compat failed to delete ephemeral conversation ${conversationId}`,
+        );
+      });
+  }
+
+  if (clientClosed) return;
+  if (outcome.error) {
+    const failed = makeResponse(
+      responseId,
+      createdAt,
+      body.model,
+      "failed",
+      builder.output,
+      outcome,
+    );
+    if (streaming) {
+      emit?.({ type: "response.failed", response: failed });
+      response.end();
+    } else {
+      sendJson(response, 500, failed);
+    }
+    return;
+  }
+
+  const completed = makeResponse(
+    responseId,
+    createdAt,
+    body.model,
+    "completed",
+    builder.output,
+    outcome,
+  );
+  if (streaming) {
+    emit?.({ type: "response.completed", response: completed });
+    response.end();
+  } else {
+    sendJson(response, 200, completed);
+  }
+}

--- a/src/websocket/app-server-openai-responses.ts
+++ b/src/websocket/app-server-openai-responses.ts
@@ -11,7 +11,6 @@ import {
   extractUserContentParts,
   type OpenAiChatMessage,
   type OpenAiCompatOptions,
-  openWebUiChatIdFromHeaders,
   readJsonBody,
   rememberConversation,
   resolveAgentForModel,
@@ -56,7 +55,7 @@ interface FunctionCallItem {
   call_id: string;
   name: string;
   arguments: string;
-  status: "in_progress" | "completed" | "failed";
+  status: "in_progress" | "completed" | "incomplete";
 }
 
 interface FunctionCallOutputItem {
@@ -64,7 +63,7 @@ interface FunctionCallOutputItem {
   id: string;
   call_id: string;
   output: Array<{ type: "input_text"; text: string }>;
-  status: "completed" | "failed";
+  status: "completed" | "incomplete";
 }
 
 interface MessageItem {
@@ -91,32 +90,6 @@ type ResponseOutputItem =
   | FunctionCallOutputItem
   | ReasoningItem
   | MessageItem;
-
-interface StoredResponseState {
-  agentId: string;
-  conversationId: string;
-}
-
-const MAX_STORED_RESPONSES = 4096;
-const storedResponseState = new Map<string, StoredResponseState>();
-
-/** @internal Reset Responses API state between tests. */
-export function resetResponsesState(): void {
-  storedResponseState.clear();
-}
-
-function rememberResponseState(
-  responseId: string,
-  state: StoredResponseState,
-): void {
-  storedResponseState.delete(responseId);
-  storedResponseState.set(responseId, state);
-  while (storedResponseState.size > MAX_STORED_RESPONSES) {
-    const oldest = storedResponseState.keys().next().value;
-    if (oldest === undefined) break;
-    storedResponseState.delete(oldest);
-  }
-}
 
 function normalizeInput(input: ResponsesRequest["input"]): OpenAiChatMessage[] {
   if (typeof input === "string") {
@@ -174,6 +147,22 @@ function toBridgeMessages(
     messages: bridgeMessages,
     correlationOtid: bridgeMessages.at(-1)?.otid ?? null,
   };
+}
+
+function applyInstructions(
+  messages: BridgeTurnMessage[],
+  instructions: string | null | undefined,
+): void {
+  const text = instructions?.trim();
+  if (!text) return;
+  const userMessage = [...messages]
+    .reverse()
+    .find((message) => message.role === "user");
+  if (!userMessage) return;
+  userMessage.content.unshift({
+    type: "text",
+    text: `<system-reminder>\n${text}\n</system-reminder>\n\n`,
+  });
 }
 
 function responseUsage(usage: TurnOutcome["usage"]): Record<string, unknown> {
@@ -280,7 +269,7 @@ class ResponseOutputBuilder {
     );
     call.item.name = event.tool_name ?? call.item.name;
     call.item.arguments = event.arguments;
-    call.item.status = event.success ? "completed" : "failed";
+    call.item.status = event.success ? "completed" : "incomplete";
     this.emit?.({
       type: "response.function_call_arguments.done",
       output_index: call.index,
@@ -300,7 +289,7 @@ class ResponseOutputBuilder {
       id: `fco_${randomUUID()}`,
       call_id: event.tool_call_id,
       output: [{ type: "input_text", text: event.output }],
-      status: event.success ? "completed" : "failed",
+      status: event.success ? "completed" : "incomplete",
     };
     const outputIndex = this.output.length;
     this.output.push(result);
@@ -510,35 +499,32 @@ export async function handleResponses(
     return;
   }
 
-  const input = normalizeInput(body.input);
-  const previous = body.previous_response_id
-    ? storedResponseState.get(body.previous_response_id)
-    : undefined;
-  if (body.previous_response_id && !previous) {
-    sendOpenAiError(
-      response,
-      404,
-      `Previous response '${body.previous_response_id}' was not found.`,
-      "invalid_request_error",
-      "previous_response_not_found",
-    );
-    return;
-  }
-  if (previous && previous.agentId !== agent.id) {
+  if (body.store === true) {
     sendOpenAiError(
       response,
       400,
-      "previous_response_id belongs to a different model",
+      "stored Responses are not supported; use a stable chat identity header for conversation continuity",
       "invalid_request_error",
+      "unsupported_parameter",
+    );
+    return;
+  }
+  if (body.previous_response_id) {
+    sendOpenAiError(
+      response,
+      400,
+      "previous_response_id is not supported; send the conversation input or a stable chat identity header",
+      "invalid_request_error",
+      "unsupported_parameter",
     );
     return;
   }
 
+  const input = normalizeInput(body.input);
   const streaming = body.stream === true;
-  const openWebUiChatId = openWebUiChatIdFromHeaders(request);
   const headerChatKey = chatKeyFromHeaders(request, streaming);
-  const stateful = Boolean(previous || headerChatKey);
-  const prepared = toBridgeMessages(input, stateful);
+  const prepared = toBridgeMessages(input, Boolean(headerChatKey));
+  applyInstructions(prepared.messages, body.instructions);
   if (!prepared.correlationOtid) {
     sendOpenAiError(
       response,
@@ -551,9 +537,7 @@ export async function handleResponses(
 
   let conversationId: string;
   try {
-    if (previous) {
-      conversationId = previous.conversationId;
-    } else if (headerChatKey) {
+    if (headerChatKey) {
       const key = `chat-key:${agent.id}:${headerChatKey}`;
       conversationId = await resolveConversationId(agent.id, key);
       rememberConversation(key, conversationId);
@@ -640,27 +624,17 @@ export async function handleResponses(
     };
   }
 
-  // Idempotent/replayed test seams can return an outcome without invoking
-  // callbacks. Reconstruct output from the completed outcome in that case.
+  // Test seams may return a completed outcome without invoking callbacks.
   if (builder.output.length === 0) {
     if (outcome.reasoning) builder.addReasoning(outcome.reasoning);
-    for (const event of outcome.toolEvents ?? []) builder.addToolEvent(event);
     if (outcome.text) builder.addText(outcome.text);
   }
   builder.finish();
 
-  // OpenAI Responses are stored by default; `store: false` opts out. Open
-  // WebUI's non-streaming title/tag/follow-up jobs carry the parent chat id,
-  // but are deliberately not part of that chat. Keep those task conversations
-  // ephemeral unless the caller explicitly asks to store them.
-  const openWebUiBackgroundRequest = Boolean(openWebUiChatId) && !streaming;
-  const shouldStore =
-    body.store === true ||
-    (!openWebUiBackgroundRequest && body.store !== false) ||
-    Boolean(headerChatKey || previous);
-  if (shouldStore && !outcome.error) {
-    rememberResponseState(responseId, { agentId: agent.id, conversationId });
-  } else if (!headerChatKey && !previous) {
+  // Header-less requests replay the supplied input into a fresh conversation.
+  // The endpoint does not expose response retrieval, so retaining that
+  // internal conversation would only create unreachable state.
+  if (!headerChatKey) {
     void getBackend()
       .deleteConversation?.(conversationId)
       .catch(() => {

--- a/src/websocket/app-server-openai-responses.ts
+++ b/src/websocket/app-server-openai-responses.ts
@@ -11,6 +11,7 @@ import {
   extractUserContentParts,
   type OpenAiChatMessage,
   type OpenAiCompatOptions,
+  openWebUiChatIdFromHeaders,
   readJsonBody,
   rememberConversation,
   resolveAgentForModel,
@@ -446,7 +447,9 @@ export async function handleResponses(
     return;
   }
 
-  const headerChatKey = chatKeyFromHeaders(request, body.stream === true);
+  const streaming = body.stream === true;
+  const openWebUiChatId = openWebUiChatIdFromHeaders(request);
+  const headerChatKey = chatKeyFromHeaders(request, streaming);
   const stateful = Boolean(previous || headerChatKey);
   const prepared = toBridgeMessages(input, stateful);
   if (!prepared.correlationOtid) {
@@ -487,7 +490,6 @@ export async function handleResponses(
 
   const responseId = `resp_${randomUUID()}`;
   const createdAt = Math.floor(Date.now() / 1000);
-  const streaming = body.stream === true;
   let sequenceNumber = 0;
   let clientClosed = false;
   response.on("close", () => {
@@ -558,9 +560,15 @@ export async function handleResponses(
   }
   builder.finishText();
 
-  // OpenAI Responses are stored by default; `store: false` opts out.
+  // OpenAI Responses are stored by default; `store: false` opts out. Open
+  // WebUI's non-streaming title/tag/follow-up jobs carry the parent chat id,
+  // but are deliberately not part of that chat. Keep those task conversations
+  // ephemeral unless the caller explicitly asks to store them.
+  const openWebUiBackgroundRequest = Boolean(openWebUiChatId) && !streaming;
   const shouldStore =
-    body.store !== false || Boolean(headerChatKey || previous);
+    body.store === true ||
+    (!openWebUiBackgroundRequest && body.store !== false) ||
+    Boolean(headerChatKey || previous);
   if (shouldStore && !outcome.error) {
     rememberResponseState(responseId, { agentId: agent.id, conversationId });
   } else if (!headerChatKey && !previous) {

--- a/src/websocket/app-server-openai-responses.ts
+++ b/src/websocket/app-server-openai-responses.ts
@@ -229,6 +229,7 @@ class ResponseOutputBuilder {
 
   addToolEvent(event: ToolCallEvent): void {
     if (event.type === "tool_call_start") {
+      this.finishText();
       this.ensureToolCall(event.tool_call_id, event.tool_name ?? "tool");
       return;
     }
@@ -264,6 +265,7 @@ class ResponseOutputBuilder {
       item: call.item,
     });
 
+    this.finishText();
     const result: FunctionCallOutputItem = {
       type: "function_call_output",
       id: `fco_${randomUUID()}`,
@@ -288,6 +290,7 @@ class ResponseOutputBuilder {
   finishText(): void {
     if (!this.message) return;
     const { item, index } = this.message;
+    this.message = null;
     item.status = "completed";
     const part = item.content[0];
     if (!part) return;

--- a/src/websocket/app-server-openai-responses.ts
+++ b/src/websocket/app-server-openai-responses.ts
@@ -79,9 +79,17 @@ interface MessageItem {
   }>;
 }
 
+interface ReasoningItem {
+  type: "reasoning";
+  id: string;
+  status: "in_progress" | "completed";
+  summary: Array<{ type: "summary_text"; text: string }>;
+}
+
 type ResponseOutputItem =
   | FunctionCallItem
   | FunctionCallOutputItem
+  | ReasoningItem
   | MessageItem;
 
 interface StoredResponseState {
@@ -168,11 +176,14 @@ function toBridgeMessages(
   };
 }
 
-function responseUsage(usage: TurnOutcome["usage"]): Record<string, number> {
+function responseUsage(usage: TurnOutcome["usage"]): Record<string, unknown> {
   return {
     input_tokens: usage.prompt_tokens,
     output_tokens: usage.completion_tokens,
     total_tokens: usage.total_tokens,
+    output_tokens_details: {
+      reasoning_tokens: usage.reasoning_tokens ?? 0,
+    },
   };
 }
 
@@ -210,12 +221,14 @@ class ResponseOutputBuilder {
     { item: FunctionCallItem; index: number }
   >();
   private message: { item: MessageItem; index: number } | null = null;
+  private reasoning: { item: ReasoningItem; index: number } | null = null;
 
   constructor(
     private readonly emit?: (event: Record<string, unknown>) => void,
   ) {}
 
   addText(delta: string): void {
+    this.finishReasoning();
     const message = this.ensureMessage();
     const part = message.item.content[0];
     if (part) part.text += delta;
@@ -228,7 +241,22 @@ class ResponseOutputBuilder {
     });
   }
 
+  addReasoning(delta: string): void {
+    this.finishText();
+    const reasoning = this.ensureReasoning();
+    const part = reasoning.item.summary[0];
+    if (part) part.text += delta;
+    this.emit?.({
+      type: "response.reasoning_summary_text.delta",
+      output_index: reasoning.index,
+      summary_index: 0,
+      item_id: reasoning.item.id,
+      delta,
+    });
+  }
+
   addToolEvent(event: ToolCallEvent): void {
+    this.finishReasoning();
     if (event.type === "tool_call_start") {
       this.finishText();
       this.ensureToolCall(event.tool_call_id, event.tool_name ?? "tool");
@@ -316,6 +344,39 @@ class ResponseOutputBuilder {
     });
   }
 
+  finishReasoning(): void {
+    if (!this.reasoning) return;
+    const { item, index } = this.reasoning;
+    this.reasoning = null;
+    item.status = "completed";
+    const part = item.summary[0];
+    if (!part) return;
+    this.emit?.({
+      type: "response.reasoning_summary_text.done",
+      output_index: index,
+      summary_index: 0,
+      item_id: item.id,
+      text: part.text,
+    });
+    this.emit?.({
+      type: "response.reasoning_summary_part.done",
+      output_index: index,
+      summary_index: 0,
+      item_id: item.id,
+      part,
+    });
+    this.emit?.({
+      type: "response.output_item.done",
+      output_index: index,
+      item,
+    });
+  }
+
+  finish(): void {
+    this.finishReasoning();
+    this.finishText();
+  }
+
   private ensureMessage(): { item: MessageItem; index: number } {
     if (this.message) return this.message;
     const item: MessageItem = {
@@ -341,6 +402,32 @@ class ResponseOutputBuilder {
       part: item.content[0],
     });
     return this.message;
+  }
+
+  private ensureReasoning(): { item: ReasoningItem; index: number } {
+    if (this.reasoning) return this.reasoning;
+    const item: ReasoningItem = {
+      type: "reasoning",
+      id: `rs_${randomUUID()}`,
+      status: "in_progress",
+      summary: [{ type: "summary_text", text: "" }],
+    };
+    const index = this.output.length;
+    this.output.push(item);
+    this.reasoning = { item, index };
+    this.emit?.({
+      type: "response.output_item.added",
+      output_index: index,
+      item: { ...item, summary: [] },
+    });
+    this.emit?.({
+      type: "response.reasoning_summary_part.added",
+      output_index: index,
+      summary_index: 0,
+      item_id: item.id,
+      part: item.summary[0],
+    });
+    return this.reasoning;
   }
 
   private ensureToolCall(
@@ -540,6 +627,7 @@ export async function handleResponses(
       correlationOtid: prepared.correlationOtid,
       onLog: options.onLog,
       onAssistantText: (delta) => builder.addText(delta),
+      onReasoningText: (delta) => builder.addReasoning(delta),
       onToolEvent: (event) => builder.addToolEvent(event),
     });
   } catch (error) {
@@ -555,10 +643,11 @@ export async function handleResponses(
   // Idempotent/replayed test seams can return an outcome without invoking
   // callbacks. Reconstruct output from the completed outcome in that case.
   if (builder.output.length === 0) {
+    if (outcome.reasoning) builder.addReasoning(outcome.reasoning);
     for (const event of outcome.toolEvents ?? []) builder.addToolEvent(event);
     if (outcome.text) builder.addText(outcome.text);
   }
-  builder.finishText();
+  builder.finish();
 
   // OpenAI Responses are stored by default; `store: false` opts out. Open
   // WebUI's non-streaming title/tag/follow-up jobs carry the parent chat id,

--- a/src/websocket/app-server-openai-responses.ts
+++ b/src/websocket/app-server-openai-responses.ts
@@ -149,11 +149,26 @@ function toBridgeMessages(
   };
 }
 
+function inputInstructions(input: ResponsesRequest["input"]): string[] {
+  if (!Array.isArray(input)) return [];
+  return input
+    .filter(
+      (item) =>
+        item?.type === "message" &&
+        (item.role === "system" || item.role === "developer"),
+    )
+    .map((item) => extractTextContent(item.content))
+    .filter(Boolean);
+}
+
 function applyInstructions(
   messages: BridgeTurnMessage[],
-  instructions: string | null | undefined,
+  instructions: Array<string | null | undefined>,
 ): void {
-  const text = instructions?.trim();
+  const text = instructions
+    .map((instruction) => instruction?.trim())
+    .filter(Boolean)
+    .join("\n\n");
   if (!text) return;
   const userMessage = [...messages]
     .reverse()
@@ -524,7 +539,10 @@ export async function handleResponses(
   const streaming = body.stream === true;
   const headerChatKey = chatKeyFromHeaders(request, streaming);
   const prepared = toBridgeMessages(input, Boolean(headerChatKey));
-  applyInstructions(prepared.messages, body.instructions);
+  applyInstructions(prepared.messages, [
+    body.instructions,
+    ...inputInstructions(body.input),
+  ]);
   if (!prepared.correlationOtid) {
     sendOpenAiError(
       response,

--- a/src/websocket/app-server-openai-tools.test.ts
+++ b/src/websocket/app-server-openai-tools.test.ts
@@ -1,0 +1,483 @@
+import { describe, expect, test } from "bun:test";
+import type { StreamDelta } from "@/types/protocol_v2";
+import {
+  collectToolLifecycleEvents,
+  createToolLifecycleTracker,
+  type ToolCallEvent,
+  type ToolLifecycleCallback,
+} from "@/websocket/app-server-openai-tools";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Build a `tool_call_message` StreamDelta. */
+function toolCallDelta(
+  toolCallId: string,
+  name: string | null,
+  args: string | null,
+  extra?: Record<string, unknown>,
+): StreamDelta {
+  return {
+    type: "message",
+    message_type: "tool_call_message",
+    id: `msg-${toolCallId}`,
+    date: new Date().toISOString(),
+    tool_call: {
+      ...(name !== null ? { name } : {}),
+      tool_call_id: toolCallId,
+      ...(args !== null ? { arguments: args } : {}),
+    },
+    ...extra,
+  } as unknown as StreamDelta;
+}
+
+/** Build an `approval_request_message` StreamDelta. */
+function approvalRequestDelta(
+  toolCallId: string,
+  name: string | null,
+  args: string | null,
+): StreamDelta {
+  return {
+    type: "message",
+    message_type: "approval_request_message",
+    id: `msg-approval-${toolCallId}`,
+    date: new Date().toISOString(),
+    tool_call: {
+      ...(name !== null ? { name } : {}),
+      tool_call_id: toolCallId,
+      ...(args !== null ? { arguments: args } : {}),
+    },
+  } as unknown as StreamDelta;
+}
+
+/** Build a `tool_return_message` StreamDelta with singular fields. */
+function toolReturnDelta(
+  toolCallId: string,
+  status: "success" | "error",
+  toolReturn: string,
+): StreamDelta {
+  return {
+    type: "message",
+    message_type: "tool_return_message",
+    id: `msg-return-${toolCallId}`,
+    date: new Date().toISOString(),
+    tool_call_id: toolCallId,
+    status,
+    tool_return: toolReturn,
+  } as unknown as StreamDelta;
+}
+
+/** Build a `tool_return_message` StreamDelta with plural `tool_returns`. */
+function toolReturnPluralDelta(
+  returns: Array<{
+    tool_call_id: string;
+    status: "success" | "error";
+    tool_return: string;
+  }>,
+): StreamDelta {
+  return {
+    type: "message",
+    message_type: "tool_return_message",
+    id: `msg-return-plural-${crypto.randomUUID()}`,
+    date: new Date().toISOString(),
+    tool_returns: returns,
+  } as unknown as StreamDelta;
+}
+
+/** Build a non-tool StreamDelta (e.g. assistant message). */
+function assistantDelta(text: string): StreamDelta {
+  return {
+    type: "message",
+    message_type: "assistant_message",
+    id: `msg-assistant-${crypto.randomUUID()}`,
+    date: new Date().toISOString(),
+    content: text,
+  } as unknown as StreamDelta;
+}
+
+function eventTypes(events: ToolCallEvent[]): string[] {
+  return events.map((e) => e.type);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("createToolLifecycleTracker", () => {
+  test("emits start, arguments_delta, and complete for a single tool call", () => {
+    const events = collectToolLifecycleEvents([
+      toolCallDelta("call-1", "Bash", '{"command":"ls"}'),
+      toolReturnDelta("call-1", "success", "file1\nfile2"),
+    ]);
+
+    expect(eventTypes(events)).toEqual([
+      "tool_call_start",
+      "tool_call_arguments_delta",
+      "tool_call_complete",
+    ]);
+
+    const start = events[0] as Extract<
+      ToolCallEvent,
+      { type: "tool_call_start" }
+    >;
+    expect(start).toMatchObject({
+      type: "tool_call_start",
+      tool_call_id: "call-1",
+      tool_name: "Bash",
+    });
+
+    const argsDelta = events[1] as Extract<
+      ToolCallEvent,
+      { type: "tool_call_arguments_delta" }
+    >;
+    expect(argsDelta).toMatchObject({
+      type: "tool_call_arguments_delta",
+      tool_call_id: "call-1",
+      arguments_delta: '{"command":"ls"}',
+    });
+
+    const complete = events[2] as Extract<
+      ToolCallEvent,
+      { type: "tool_call_complete" }
+    >;
+    expect(complete).toMatchObject({
+      type: "tool_call_complete",
+      tool_call_id: "call-1",
+      tool_name: "Bash",
+      arguments: '{"command":"ls"}',
+      output: "file1\nfile2",
+      success: true,
+    });
+  });
+
+  test("aggregates partial arguments across multiple tool_call_messages", () => {
+    const events = collectToolLifecycleEvents([
+      toolCallDelta("call-1", "Bash", '{"command":'),
+      toolCallDelta("call-1", null, '"ls"}'),
+      toolReturnDelta("call-1", "success", "done"),
+    ]);
+
+    const argDeltas = events.filter(
+      (e): e is Extract<ToolCallEvent, { type: "tool_call_arguments_delta" }> =>
+        e.type === "tool_call_arguments_delta",
+    );
+    expect(argDeltas).toHaveLength(2);
+    expect(argDeltas[0]?.arguments_delta).toBe('{"command":');
+    expect(argDeltas[1]?.arguments_delta).toBe('"ls"}');
+
+    const complete = events.find(
+      (e): e is Extract<ToolCallEvent, { type: "tool_call_complete" }> =>
+        e.type === "tool_call_complete",
+    );
+    expect(complete?.arguments).toBe('{"command":"ls"}');
+  });
+
+  test("emits start only once even if multiple fragments arrive", () => {
+    const events = collectToolLifecycleEvents([
+      toolCallDelta("call-1", "Bash", '{"command":"ls"}'),
+      toolCallDelta("call-1", null, '{"cwd":"/tmp"}'),
+      toolReturnDelta("call-1", "success", "ok"),
+    ]);
+
+    const starts = events.filter((e) => e.type === "tool_call_start");
+    expect(starts).toHaveLength(1);
+  });
+
+  test("handles approval_request_message the same as tool_call_message", () => {
+    const events = collectToolLifecycleEvents([
+      approvalRequestDelta("call-2", "Read", '{"path":"/etc/hosts"}'),
+      toolReturnDelta("call-2", "success", "127.0.0.1 localhost"),
+    ]);
+
+    expect(eventTypes(events)).toEqual([
+      "tool_call_start",
+      "tool_call_arguments_delta",
+      "tool_call_complete",
+    ]);
+
+    const start = events[0] as Extract<
+      ToolCallEvent,
+      { type: "tool_call_start" }
+    >;
+    expect(start.tool_name).toBe("Read");
+  });
+
+  test("handles plural tool_returns in a single tool_return_message", () => {
+    const events = collectToolLifecycleEvents([
+      toolCallDelta("call-a", "Bash", '{"command":"ls"}'),
+      toolCallDelta("call-b", "Read", '{"path":"file.txt"}'),
+      toolReturnPluralDelta([
+        { tool_call_id: "call-a", status: "success", tool_return: "out-a" },
+        { tool_call_id: "call-b", status: "error", tool_return: "err-b" },
+      ]),
+    ]);
+
+    const completes = events.filter((e) => e.type === "tool_call_complete");
+    expect(completes).toHaveLength(2);
+
+    const completeA = completes.find(
+      (e): e is Extract<ToolCallEvent, { type: "tool_call_complete" }> =>
+        e.type === "tool_call_complete" && e.tool_call_id === "call-a",
+    );
+    expect(completeA).toMatchObject({
+      tool_call_id: "call-a",
+      output: "out-a",
+      success: true,
+      arguments: '{"command":"ls"}',
+    });
+
+    const completeB = completes.find(
+      (e): e is Extract<ToolCallEvent, { type: "tool_call_complete" }> =>
+        e.type === "tool_call_complete" && e.tool_call_id === "call-b",
+    );
+    expect(completeB).toMatchObject({
+      tool_call_id: "call-b",
+      output: "err-b",
+      success: false,
+      arguments: '{"path":"file.txt"}',
+    });
+  });
+
+  test("avoids duplicate complete events for repeated tool_return_messages", () => {
+    const events = collectToolLifecycleEvents([
+      toolCallDelta("call-1", "Bash", '{"command":"ls"}'),
+      toolReturnDelta("call-1", "success", "first"),
+      toolReturnDelta("call-1", "success", "second"),
+    ]);
+
+    const completes = events.filter((e) => e.type === "tool_call_complete");
+    expect(completes).toHaveLength(1);
+    expect((completes[0] as { output: string }).output).toBe("first");
+  });
+
+  test("ignores tool_call_message fragments that arrive after completion", () => {
+    const events = collectToolLifecycleEvents([
+      toolCallDelta("call-1", "Bash", '{"command":"ls"}'),
+      toolReturnDelta("call-1", "success", "done"),
+      toolCallDelta("call-1", null, '{"extra":true}'),
+    ]);
+
+    const argDeltas = events.filter(
+      (e) => e.type === "tool_call_arguments_delta",
+    );
+    expect(argDeltas).toHaveLength(1);
+    expect(argDeltas[0]?.arguments_delta).toBe('{"command":"ls"}');
+  });
+
+  test("ignores non-tool StreamDelta types", () => {
+    const events = collectToolLifecycleEvents([
+      assistantDelta("hello world"),
+      toolCallDelta("call-1", "Bash", "{}"),
+      toolReturnDelta("call-1", "success", "ok"),
+    ]);
+
+    // Only the tool call events should be present, not anything from
+    // the assistant message.
+    expect(events).toHaveLength(3);
+    expect(eventTypes(events)).toEqual([
+      "tool_call_start",
+      "tool_call_arguments_delta",
+      "tool_call_complete",
+    ]);
+  });
+
+  test("handles tool_call_message with tool_calls array", () => {
+    const delta: StreamDelta = {
+      type: "message",
+      message_type: "tool_call_message",
+      id: "msg-multi",
+      date: new Date().toISOString(),
+      tool_calls: [
+        { name: "Bash", tool_call_id: "call-x", arguments: '{"command":"ls"}' },
+        { name: "Read", tool_call_id: "call-y", arguments: '{"path":"f"}' },
+      ],
+    } as unknown as StreamDelta;
+
+    const events = collectToolLifecycleEvents([
+      delta,
+      toolReturnPluralDelta([
+        { tool_call_id: "call-x", status: "success", tool_return: "x-out" },
+        { tool_call_id: "call-y", status: "success", tool_return: "y-out" },
+      ]),
+    ]);
+
+    const starts = events.filter((e) => e.type === "tool_call_start");
+    expect(starts).toHaveLength(2);
+    expect((starts[0] as { tool_call_id: string }).tool_call_id).toBe("call-x");
+    expect((starts[1] as { tool_call_id: string })?.tool_call_id).toBe(
+      "call-y",
+    );
+  });
+
+  test("handles tool_call_message with null/absent name in first fragment", () => {
+    const events = collectToolLifecycleEvents([
+      toolCallDelta("call-1", null, '{"command":"ls"}'),
+      toolReturnDelta("call-1", "success", "ok"),
+    ]);
+
+    const start = events[0] as Extract<
+      ToolCallEvent,
+      { type: "tool_call_start" }
+    >;
+    expect(start.tool_name).toBeNull();
+  });
+
+  test("handles tool_return with multimodal content parts", () => {
+    const delta: StreamDelta = {
+      type: "message",
+      message_type: "tool_return_message",
+      id: "msg-return-mm",
+      date: new Date().toISOString(),
+      tool_call_id: "call-1",
+      status: "success",
+      tool_return: [
+        { type: "text", text: "line1" },
+        { type: "text", text: "line2" },
+      ],
+    } as unknown as StreamDelta;
+
+    const events = collectToolLifecycleEvents([
+      toolCallDelta("call-1", "Bash", "{}"),
+      delta,
+    ]);
+
+    const complete = events.find(
+      (e): e is Extract<ToolCallEvent, { type: "tool_call_complete" }> =>
+        e.type === "tool_call_complete",
+    );
+    expect(complete?.output).toBe("line1\nline2");
+  });
+
+  test("handles tool_return with null tool_return value", () => {
+    const delta: StreamDelta = {
+      type: "message",
+      message_type: "tool_return_message",
+      id: "msg-return-null",
+      date: new Date().toISOString(),
+      tool_call_id: "call-1",
+      status: "success",
+      tool_return: null,
+    } as unknown as StreamDelta;
+
+    const events = collectToolLifecycleEvents([
+      toolCallDelta("call-1", "Bash", "{}"),
+      delta,
+    ]);
+
+    const complete = events.find(
+      (e): e is Extract<ToolCallEvent, { type: "tool_call_complete" }> =>
+        e.type === "tool_call_complete",
+    );
+    expect(complete?.output).toBe("");
+  });
+
+  test("dispose stops event emission", () => {
+    const collected: ToolCallEvent[] = [];
+    const tracker = createToolLifecycleTracker((event) => {
+      collected.push(event);
+    });
+
+    tracker.process(toolCallDelta("call-1", "Bash", "{}"));
+    expect(collected).toHaveLength(2); // start + arguments_delta
+
+    tracker.dispose();
+
+    tracker.process(toolReturnDelta("call-1", "success", "ok"));
+    expect(collected).toHaveLength(2); // no new events after dispose
+  });
+
+  test("failPending completes unfinished calls as errors", () => {
+    const collected: ToolCallEvent[] = [];
+    const tracker = createToolLifecycleTracker((event) => {
+      collected.push(event);
+    });
+    tracker.process(toolCallDelta("call-1", "Bash", "{}"));
+
+    tracker.failPending("interactive approval is not supported");
+    tracker.failPending("duplicate");
+
+    expect(collected.at(-1)).toMatchObject({
+      type: "tool_call_complete",
+      tool_call_id: "call-1",
+      output: "interactive approval is not supported",
+      success: false,
+    });
+    expect(
+      collected.filter((event) => event.type === "tool_call_complete"),
+    ).toHaveLength(1);
+  });
+
+  test("callback is invoked synchronously during process", () => {
+    const order: string[] = [];
+    const callback: ToolLifecycleCallback = (event) => {
+      order.push(event.type);
+    };
+    const tracker = createToolLifecycleTracker(callback);
+
+    tracker.process(toolCallDelta("call-1", "Bash", '{"command":"ls"}'));
+    tracker.process(toolReturnDelta("call-1", "success", "done"));
+    tracker.dispose();
+
+    expect(order).toEqual([
+      "tool_call_start",
+      "tool_call_arguments_delta",
+      "tool_call_complete",
+    ]);
+  });
+
+  test("handles multiple independent tool calls interleaved", () => {
+    const events = collectToolLifecycleEvents([
+      toolCallDelta("call-a", "Bash", '{"command":"ls"}'),
+      toolCallDelta("call-b", "Read", '{"path":"f"}'),
+      toolReturnDelta("call-a", "success", "a-out"),
+      toolReturnDelta("call-b", "error", "b-err"),
+    ]);
+
+    const starts = events.filter((e) => e.type === "tool_call_start");
+    expect(starts).toHaveLength(2);
+
+    const completes = events.filter((e) => e.type === "tool_call_complete");
+    expect(completes).toHaveLength(2);
+
+    const completeA = completes.find(
+      (e): e is Extract<ToolCallEvent, { type: "tool_call_complete" }> =>
+        e.type === "tool_call_complete" && e.tool_call_id === "call-a",
+    );
+    expect(completeA?.success).toBe(true);
+
+    const completeB = completes.find(
+      (e): e is Extract<ToolCallEvent, { type: "tool_call_complete" }> =>
+        e.type === "tool_call_complete" && e.tool_call_id === "call-b",
+    );
+    expect(completeB?.success).toBe(false);
+  });
+
+  test("tool_call_message with empty arguments does not emit arguments_delta", () => {
+    const events = collectToolLifecycleEvents([
+      toolCallDelta("call-1", "Bash", null),
+      toolReturnDelta("call-1", "success", "ok"),
+    ]);
+
+    expect(eventTypes(events)).toEqual([
+      "tool_call_start",
+      "tool_call_complete",
+    ]);
+  });
+
+  test("tool_call_message with empty string arguments emits arguments_delta", () => {
+    const events = collectToolLifecycleEvents([
+      toolCallDelta("call-1", "Bash", ""),
+      toolReturnDelta("call-1", "success", "ok"),
+    ]);
+
+    // Empty string is still a valid (if empty) arguments fragment.
+    const argDeltas = events.filter(
+      (e) => e.type === "tool_call_arguments_delta",
+    );
+    expect(argDeltas).toHaveLength(1);
+    expect((argDeltas[0] as { arguments_delta: string })?.arguments_delta).toBe(
+      "",
+    );
+  });
+});

--- a/src/websocket/app-server-openai-tools.test.ts
+++ b/src/websocket/app-server-openai-tools.test.ts
@@ -85,6 +85,29 @@ function toolReturnPluralDelta(
   } as unknown as StreamDelta;
 }
 
+function clientToolStartDelta(toolCallId: string, name: string): StreamDelta {
+  return {
+    message_type: "client_tool_start",
+    id: `client-start-${toolCallId}`,
+    date: new Date().toISOString(),
+    tool_call_id: toolCallId,
+    tool_name: name,
+  } as StreamDelta;
+}
+
+function clientToolEndDelta(
+  toolCallId: string,
+  status: "success" | "error",
+): StreamDelta {
+  return {
+    message_type: "client_tool_end",
+    id: `client-end-${toolCallId}`,
+    date: new Date().toISOString(),
+    tool_call_id: toolCallId,
+    status,
+  } as StreamDelta;
+}
+
 /** Build a non-tool StreamDelta (e.g. assistant message). */
 function assistantDelta(text: string): StreamDelta {
   return {
@@ -249,6 +272,45 @@ describe("createToolLifecycleTracker", () => {
     const completes = events.filter((e) => e.type === "tool_call_complete");
     expect(completes).toHaveLength(1);
     expect((completes[0] as { output: string }).output).toBe("first");
+  });
+
+  test("waits for the terminal client-tool result instead of completing from progress snapshots", () => {
+    const events = collectToolLifecycleEvents([
+      toolCallDelta("call-stream", "Bash", '{"command":"build"}'),
+      clientToolStartDelta("call-stream", "Bash"),
+      toolReturnDelta("call-stream", "success", "building 10%"),
+      toolReturnDelta("call-stream", "success", "building 90%"),
+      clientToolEndDelta("call-stream", "success"),
+      toolReturnDelta("call-stream", "success", "build complete"),
+    ]);
+
+    const completes = events.filter(
+      (
+        event,
+      ): event is Extract<ToolCallEvent, { type: "tool_call_complete" }> =>
+        event.type === "tool_call_complete",
+    );
+    expect(completes).toHaveLength(1);
+    expect(completes[0]).toMatchObject({
+      output: "build complete",
+      success: true,
+    });
+  });
+
+  test("uses the terminal client-tool failure instead of an earlier successful snapshot", () => {
+    const events = collectToolLifecycleEvents([
+      toolCallDelta("call-fail", "Bash", '{"command":"build"}'),
+      clientToolStartDelta("call-fail", "Bash"),
+      toolReturnDelta("call-fail", "success", "building 10%"),
+      clientToolEndDelta("call-fail", "error"),
+      toolReturnDelta("call-fail", "error", "compiler failed"),
+    ]);
+
+    expect(events.at(-1)).toMatchObject({
+      type: "tool_call_complete",
+      output: "compiler failed",
+      success: false,
+    });
   });
 
   test("ignores tool_call_message fragments that arrive after completion", () => {

--- a/src/websocket/app-server-openai-tools.ts
+++ b/src/websocket/app-server-openai-tools.ts
@@ -1,0 +1,481 @@
+/**
+ * Tool lifecycle exposure for the OpenAI Responses API handler.
+ *
+ * The app-server's native WS stream emits `stream_delta` messages whose
+ * `delta` payloads are `StreamDelta` values (see `@/types/protocol_v2`).
+ * When the delta is a `MessageDelta` — i.e. a `LettaStreamingResponse`
+ * chunk — it may carry `tool_call_message`, `approval_request_message`,
+ * or `tool_return_message` payloads that describe the full lifecycle of a
+ * tool call:
+ *
+ *   1. `tool_call_message` / `approval_request_message` — the LLM requests
+ *      a tool call. Arguments may arrive in fragments (partial JSON via
+ *      `ToolCallDelta`), so multiple messages can share the same
+ *      `tool_call_id`.
+ *   2. `tool_return_message` — the tool has finished executing. The result
+ *      may be singular (`tool_call_id` + `status` + `tool_return`) or
+ *      plural (`tool_returns: ToolReturn[]`).
+ *
+ * This module aggregates those fragments and exposes a typed callback
+ * surface so an HTTP Responses handler can observe:
+ *
+ *   - **start** — emitted once per `tool_call_id` when the first
+ *     `tool_call_message` or `approval_request_message` for that id
+ *     arrives.
+ *   - **arguments_delta** — emitted for each incremental arguments
+ *     fragment (including the first message if it already carries
+ *     arguments).
+ *   - **complete** — emitted once per `tool_call_id` when the matching
+ *     `tool_return_message` arrives, carrying the final accumulated
+ *     arguments, output, and success/error status.
+ *
+ * Duplicate events are suppressed: a second `tool_return_message` for an
+ * already-completed call does not re-emit `complete`, and a
+ * `tool_call_message` that arrives after completion is ignored.
+ *
+ * The module is transport-agnostic: it accepts already-decoded
+ * `StreamDelta` values and does not touch sockets. This keeps it
+ * testable without WS infrastructure and compatible with both the
+ * chat-completions and Responses-API surfaces.
+ */
+
+import type { StreamDelta } from "@/types/protocol_v2";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Event types
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Emitted once per `tool_call_id` when the first `tool_call_message` or
+ * `approval_request_message` for that call arrives. Carries the tool
+ * name if it was already present in the first fragment.
+ */
+export interface ToolCallStartEvent {
+  type: "tool_call_start";
+  tool_call_id: string;
+  tool_name: string | null;
+}
+
+/**
+ * Emitted for each incremental arguments fragment. The `arguments_delta`
+ * is the raw string fragment as it appeared on the wire (may be partial
+ * JSON). Concatenating all deltas for a `tool_call_id` yields the full
+ * arguments string.
+ */
+export interface ToolCallArgumentsDeltaEvent {
+  type: "tool_call_arguments_delta";
+  tool_call_id: string;
+  arguments_delta: string;
+}
+
+/**
+ * Emitted once per `tool_call_id` when the matching `tool_return_message`
+ * arrives. Carries the final accumulated arguments, the tool output
+ * (stringified if multimodal), and whether the tool succeeded or erred.
+ */
+export interface ToolCallCompleteEvent {
+  type: "tool_call_complete";
+  tool_call_id: string;
+  tool_name: string | null;
+  arguments: string;
+  output: string;
+  success: boolean;
+}
+
+/**
+ * Union of all tool lifecycle events.
+ */
+export type ToolCallEvent =
+  | ToolCallStartEvent
+  | ToolCallArgumentsDeltaEvent
+  | ToolCallCompleteEvent;
+
+/**
+ * Callback invoked for every tool lifecycle event.
+ */
+export type ToolLifecycleCallback = (event: ToolCallEvent) => void;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Internal tracking state
+// ─────────────────────────────────────────────────────────────────────────
+
+interface ToolCallState {
+  toolCallId: string;
+  name: string | null;
+  arguments: string;
+  started: boolean;
+  completed: boolean;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Wire-shape helpers (operate on plain records, no Letta client dep)
+// ─────────────────────────────────────────────────────────────────────────
+
+type UnknownRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): UnknownRecord | null {
+  return value !== null && typeof value === "object"
+    ? (value as UnknownRecord)
+    : null;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Extract tool-call fragments from a `tool_call_message` or
+ * `approval_request_message` wire record. Handles both the deprecated
+ * singular `tool_call` field and the `tool_calls` array, and supports
+ * `ToolCallDelta` (partial) payloads where `name` or `arguments` may be
+ * absent/null.
+ *
+ * Mirrors the extraction logic in `channel-rich-draft-streamer.ts` so
+ * both consumers agree on how to read the wire format.
+ */
+function extractToolCallFragments(record: UnknownRecord | null): Array<{
+  toolCallId: string;
+  name: string | null;
+  argumentsDelta: string | null;
+}> {
+  if (!record) {
+    return [];
+  }
+
+  const rawToolCalls = Array.isArray(record.tool_calls)
+    ? record.tool_calls
+    : record.tool_call
+      ? [record.tool_call]
+      : [];
+
+  const fragments: Array<{
+    toolCallId: string;
+    name: string | null;
+    argumentsDelta: string | null;
+  }> = [];
+
+  for (const rawToolCall of rawToolCalls) {
+    const toolCall = asRecord(rawToolCall);
+    if (!toolCall) {
+      continue;
+    }
+    const toolCallId = stringValue(toolCall.tool_call_id);
+    if (!toolCallId) {
+      continue;
+    }
+    const name = stringValue(toolCall.name) ?? null;
+    const argumentsDelta = stringValue(toolCall.arguments) ?? null;
+    fragments.push({ toolCallId, name, argumentsDelta });
+  }
+
+  return fragments;
+}
+
+/**
+ * Normalise a `tool_return` value to a display string. Accepts plain
+ * strings, arrays of `{ type: "text", text: string }` content parts,
+ * and arbitrary objects (JSON-stringified as a fallback).
+ */
+function normalizeToolReturnOutput(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    const textParts = value
+      .filter(
+        (part: unknown): part is { type: string; text: string } =>
+          part !== null &&
+          typeof part === "object" &&
+          "type" in part &&
+          (part as { type: unknown }).type === "text" &&
+          "text" in part &&
+          typeof (part as { text: unknown }).text === "string",
+      )
+      .map((part) => part.text);
+    if (textParts.length > 0) {
+      return textParts.join("\n");
+    }
+  }
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    "type" in value &&
+    (value as { type: unknown }).type === "text" &&
+    "text" in value &&
+    typeof (value as { text: unknown }).text === "string"
+  ) {
+    return (value as { text: string }).text;
+  }
+  if (value === null || value === undefined) {
+    return "";
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Extract canonical tool returns from a `tool_return_message` wire record.
+ * Handles both the plural `tool_returns` array and the deprecated
+ * singular `tool_call_id` / `status` / `tool_return` fields.
+ *
+ * Mirrors `extractCanonicalToolReturnsFromWire` in `interrupts.ts`.
+ */
+function extractToolReturns(record: UnknownRecord | null): Array<{
+  toolCallId: string;
+  status: "success" | "error";
+  output: string;
+}> {
+  if (!record) {
+    return [];
+  }
+
+  const results: Array<{
+    toolCallId: string;
+    status: "success" | "error";
+    output: string;
+  }> = [];
+
+  // Plural form: tool_returns array
+  const toolReturnsValue = record.tool_returns;
+  if (Array.isArray(toolReturnsValue)) {
+    for (const raw of toolReturnsValue) {
+      const rec = asRecord(raw);
+      if (!rec) {
+        continue;
+      }
+      const toolCallId = stringValue(rec.tool_call_id);
+      const status = asToolReturnStatus(rec.status);
+      if (!toolCallId || !status) {
+        continue;
+      }
+      results.push({
+        toolCallId,
+        status,
+        output: normalizeToolReturnOutput(rec.tool_return),
+      });
+    }
+    if (results.length > 0) {
+      return results;
+    }
+  }
+
+  // Singular form: top-level tool_call_id + status + tool_return
+  const topLevelToolCallId = stringValue(record.tool_call_id);
+  const topLevelStatus = asToolReturnStatus(record.status);
+  if (!topLevelToolCallId || !topLevelStatus) {
+    return [];
+  }
+  return [
+    {
+      toolCallId: topLevelToolCallId,
+      status: topLevelStatus,
+      output: normalizeToolReturnOutput(record.tool_return),
+    },
+  ];
+}
+
+function asToolReturnStatus(value: unknown): "success" | "error" | null {
+  if (value === "success" || value === "error") {
+    return value;
+  }
+  return null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Tool lifecycle tracker
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Stateful tracker that aggregates partial tool-call and tool-return
+ * messages and emits structured lifecycle events via a callback.
+ *
+ * Create one tracker per turn (or per stream) and feed it every
+ * `StreamDelta` via {@link ToolLifecycleTracker.process}. The tracker
+ * is single-use: once {@link ToolLifecycleTracker.dispose} is called it
+ * stops emitting.
+ */
+export interface ToolLifecycleTracker {
+  /**
+   * Inspect a single `StreamDelta` and emit zero or more lifecycle
+   * events. Only `MessageDelta` payloads whose `message_type` is
+   * `tool_call_message`, `approval_request_message`, or
+   * `tool_return_message` are processed; all other deltas are ignored.
+   */
+  process(delta: StreamDelta): void;
+
+  /** Complete every started call without a return as failed. */
+  failPending(output: string): void;
+
+  /**
+   * Release all internal state. After calling this, `process` becomes
+   * a no-op.
+   */
+  dispose(): void;
+}
+
+/**
+ * Create a {@link ToolLifecycleTracker} that emits events through the
+ * provided callback.
+ *
+ * @param onEvent - Callback invoked for each lifecycle event.
+ */
+export function createToolLifecycleTracker(
+  onEvent: ToolLifecycleCallback,
+): ToolLifecycleTracker {
+  const calls = new Map<string, ToolCallState>();
+  const completedIds = new Set<string>();
+  let disposed = false;
+
+  function getOrCreate(toolCallId: string): ToolCallState {
+    const existing = calls.get(toolCallId);
+    if (existing) {
+      return existing;
+    }
+    const state: ToolCallState = {
+      toolCallId,
+      name: null,
+      arguments: "",
+      started: false,
+      completed: false,
+    };
+    calls.set(toolCallId, state);
+    return state;
+  }
+
+  function handleToolCallFragment(
+    toolCallId: string,
+    name: string | null,
+    argumentsDelta: string | null,
+  ): void {
+    if (completedIds.has(toolCallId)) {
+      return;
+    }
+    const state = getOrCreate(toolCallId);
+
+    // Emit start once per tool_call_id.
+    if (!state.started) {
+      state.started = true;
+      if (name) {
+        state.name = name;
+      }
+      onEvent({
+        type: "tool_call_start",
+        tool_call_id: toolCallId,
+        tool_name: state.name,
+      });
+    } else if (name && !state.name) {
+      // A later fragment may carry the name if the first one didn't.
+      state.name = name;
+    }
+
+    // Emit arguments delta if present (non-null, including empty string).
+    if (argumentsDelta !== null) {
+      state.arguments += argumentsDelta;
+      onEvent({
+        type: "tool_call_arguments_delta",
+        tool_call_id: toolCallId,
+        arguments_delta: argumentsDelta,
+      });
+    }
+  }
+
+  function handleToolReturn(
+    toolCallId: string,
+    status: "success" | "error",
+    output: string,
+  ): void {
+    if (completedIds.has(toolCallId)) {
+      return;
+    }
+    completedIds.add(toolCallId);
+
+    const state = getOrCreate(toolCallId);
+    state.completed = true;
+
+    onEvent({
+      type: "tool_call_complete",
+      tool_call_id: toolCallId,
+      tool_name: state.name,
+      arguments: state.arguments,
+      output,
+      success: status === "success",
+    });
+  }
+
+  function process(delta: StreamDelta): void {
+    if (disposed) {
+      return;
+    }
+
+    // Only MessageDelta (a LettaStreamingResponse chunk wrapped as
+    // { type: "message" }) carries tool_call/tool_return payloads.
+    // Other StreamDelta variants (ClientToolStartMessage, etc.) do not
+    // have a `type` field, so we check via a safe cast.
+    if ((delta as { type?: unknown }).type !== "message") {
+      return;
+    }
+
+    const record = delta as unknown as UnknownRecord;
+    const messageType = stringValue(record.message_type);
+
+    if (
+      messageType === "tool_call_message" ||
+      messageType === "approval_request_message"
+    ) {
+      for (const fragment of extractToolCallFragments(record)) {
+        handleToolCallFragment(
+          fragment.toolCallId,
+          fragment.name,
+          fragment.argumentsDelta,
+        );
+      }
+      return;
+    }
+
+    if (messageType === "tool_return_message") {
+      for (const result of extractToolReturns(record)) {
+        handleToolReturn(result.toolCallId, result.status, result.output);
+      }
+      return;
+    }
+  }
+
+  function dispose(): void {
+    disposed = true;
+    calls.clear();
+    completedIds.clear();
+  }
+
+  function failPending(output: string): void {
+    if (disposed) return;
+    for (const state of calls.values()) {
+      if (!state.completed) {
+        handleToolReturn(state.toolCallId, "error", output);
+      }
+    }
+  }
+
+  return { process, failPending, dispose };
+}
+
+/**
+ * Convenience wrapper: process an array of `StreamDelta` values through
+ * a fresh tracker, collecting all emitted events into an array. Useful
+ * for testing and one-shot batch processing.
+ */
+export function collectToolLifecycleEvents(
+  deltas: Iterable<StreamDelta>,
+): ToolCallEvent[] {
+  const events: ToolCallEvent[] = [];
+  const tracker = createToolLifecycleTracker((event) => {
+    events.push(event);
+  });
+  for (const delta of deltas) {
+    tracker.process(delta);
+  }
+  tracker.dispose();
+  return events;
+}

--- a/src/websocket/app-server-openai-tools.ts
+++ b/src/websocket/app-server-openai-tools.ts
@@ -12,9 +12,11 @@
  *      a tool call. Arguments may arrive in fragments (partial JSON via
  *      `ToolCallDelta`), so multiple messages can share the same
  *      `tool_call_id`.
- *   2. `tool_return_message` — the tool has finished executing. The result
- *      may be singular (`tool_call_id` + `status` + `tool_return`) or
- *      plural (`tool_returns: ToolReturn[]`).
+ *   2. `tool_return_message` — server-side tools emit a terminal result;
+ *      client-side tools may emit repeated output snapshots before their
+ *      `client_tool_end` and canonical final return. Results may be singular
+ *      (`tool_call_id` + `status` + `tool_return`) or plural
+ *      (`tool_returns: ToolReturn[]`).
  *
  * This module aggregates those fragments and exposes a typed callback
  * surface so an HTTP Responses handler can observe:
@@ -25,12 +27,11 @@
  *   - **arguments_delta** — emitted for each incremental arguments
  *     fragment (including the first message if it already carries
  *     arguments).
- *   - **complete** — emitted once per `tool_call_id` when the matching
- *     `tool_return_message` arrives, carrying the final accumulated
- *     arguments, output, and success/error status.
+ *   - **complete** — emitted once per `tool_call_id` from the authoritative
+ *     terminal return, carrying the final accumulated arguments, output, and
+ *     success/error status. Client-side progress snapshots remain nonterminal.
  *
- * Duplicate events are suppressed: a second `tool_return_message` for an
- * already-completed call does not re-emit `complete`, and a
+ * Events after an authoritative terminal result are suppressed, and a
  * `tool_call_message` that arrives after completion is ignored.
  *
  * The module is transport-agnostic: it accepts already-decoded
@@ -105,6 +106,8 @@ interface ToolCallState {
   arguments: string;
   started: boolean;
   completed: boolean;
+  clientManaged: boolean;
+  terminalStatus: "success" | "error" | null;
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -340,6 +343,8 @@ export function createToolLifecycleTracker(
       arguments: "",
       started: false,
       completed: false,
+      clientManaged: false,
+      terminalStatus: null,
     };
     calls.set(toolCallId, state);
     return state;
@@ -410,16 +415,31 @@ export function createToolLifecycleTracker(
       return;
     }
 
-    // Only MessageDelta (a LettaStreamingResponse chunk wrapped as
-    // { type: "message" }) carries tool_call/tool_return payloads.
-    // Other StreamDelta variants (ClientToolStartMessage, etc.) do not
-    // have a `type` field, so we check via a safe cast.
-    if ((delta as { type?: unknown }).type !== "message") {
+    const record = delta as unknown as UnknownRecord;
+    const messageType = stringValue(record.message_type);
+    const toolCallId = stringValue(record.tool_call_id);
+
+    // Client-executed tools emit repeated tool_return_message snapshots while
+    // running. The client_tool_end followed by the canonical final return is
+    // the terminal edge; treating the first snapshot as terminal truncates
+    // output and can hide a later failure.
+    if (messageType === "client_tool_start" && toolCallId) {
+      const state = getOrCreate(toolCallId);
+      state.clientManaged = true;
+      if (!state.name) state.name = stringValue(record.tool_name) ?? null;
+      return;
+    }
+    if (messageType === "client_tool_end" && toolCallId) {
+      const state = getOrCreate(toolCallId);
+      state.clientManaged = true;
+      state.terminalStatus = asToolReturnStatus(record.status);
       return;
     }
 
-    const record = delta as unknown as UnknownRecord;
-    const messageType = stringValue(record.message_type);
+    // Only MessageDelta payloads carry tool_call/tool_return messages.
+    if ((delta as { type?: unknown }).type !== "message") {
+      return;
+    }
 
     if (
       messageType === "tool_call_message" ||
@@ -437,7 +457,18 @@ export function createToolLifecycleTracker(
 
     if (messageType === "tool_return_message") {
       for (const result of extractToolReturns(record)) {
-        handleToolReturn(result.toolCallId, result.status, result.output);
+        const state = getOrCreate(result.toolCallId);
+        if (!state.clientManaged) {
+          handleToolReturn(result.toolCallId, result.status, result.output);
+          continue;
+        }
+        if (state.terminalStatus) {
+          handleToolReturn(
+            result.toolCallId,
+            state.terminalStatus,
+            result.output,
+          );
+        }
       }
       return;
     }

--- a/src/websocket/app-server-openai-turn.ts
+++ b/src/websocket/app-server-openai-turn.ts
@@ -3,7 +3,6 @@ import { settingsManager } from "@/settings-manager";
 import type { StreamDelta } from "@/types/protocol_v2";
 import {
   createToolLifecycleTracker,
-  type ToolCallEvent,
   type ToolLifecycleCallback,
 } from "@/websocket/app-server-openai-tools";
 import { getOrCreateProcessTransport } from "@/websocket/listener/connection";
@@ -51,7 +50,6 @@ export interface TurnOutcome {
   reasoning?: string;
   usage: OpenAiUsage;
   error: string | null;
-  toolEvents?: ToolCallEvent[];
 }
 
 export interface BridgeTurnMessage {
@@ -241,13 +239,11 @@ async function runTurnViaListenerRuntime(
     // turns in the same conversation never bleed into this response.
     let turnActive = false;
     let recordedError: string | null = null;
-    const toolEvents: ToolCallEvent[] = [];
     let settled = false;
     let unregisterTurnObserver: () => void = () => {};
-    const toolTracker = createToolLifecycleTracker((event) => {
-      toolEvents.push(event);
-      params.onToolEvent?.(event);
-    });
+    const toolTracker = params.onToolEvent
+      ? createToolLifecycleTracker(params.onToolEvent)
+      : null;
     if (!listener.streamObservers) {
       listener.streamObservers = new Set();
     }
@@ -256,12 +252,12 @@ async function runTurnViaListenerRuntime(
     const finish = (error: string | null): void => {
       if (settled) return;
       settled = true;
-      if (error) toolTracker.failPending(error);
+      if (error) toolTracker?.failPending(error);
       clearTimeout(timer);
       observers.delete(observer);
       unregisterTurnObserver();
-      toolTracker.dispose();
-      resolve({ text, reasoning, usage, error, toolEvents });
+      toolTracker?.dispose();
+      resolve({ text, reasoning, usage, error });
     };
 
     const observer: ListenerStreamObserver = (message) => {
@@ -282,7 +278,7 @@ async function runTurnViaListenerRuntime(
         if (status === "WAITING_ON_APPROVAL") {
           const note =
             "The agent attempted a tool call that requires interactive approval, which this API does not support.";
-          toolTracker.failPending(note);
+          toolTracker?.failPending(note);
           if (!text) {
             text = note;
             params.onAssistantText?.(note);
@@ -294,7 +290,7 @@ async function runTurnViaListenerRuntime(
       if (message.type !== "stream_delta" || message.subagent_id) return;
       const delta = (message as { delta?: { message_type?: string } }).delta;
       if (!delta) return;
-      toolTracker.process(delta as StreamDelta);
+      toolTracker?.process(delta as StreamDelta);
       switch (delta.message_type) {
         case "reasoning_message": {
           const piece = extractReasoningText(delta);
@@ -375,8 +371,7 @@ async function runTurnViaListenerRuntime(
       // merged batch) and answer the first with both prompts.
       noCoalesce: true,
       // HTTP clients cannot surface Letta Code's interactive overlays. Keep
-      // AskUserQuestion and other runtime-input tools out of this turn so the
-      // agent asks for missing information in ordinary assistant text.
+      // those tools out so the agent asks in ordinary assistant text.
       excludeInteractiveTools: true,
       messages: params.messages,
     };

--- a/src/websocket/app-server-openai-turn.ts
+++ b/src/websocket/app-server-openai-turn.ts
@@ -341,6 +341,10 @@ async function runTurnViaListenerRuntime(
       // would strand the second observer (only the first OTID survives a
       // merged batch) and answer the first with both prompts.
       noCoalesce: true,
+      // HTTP clients cannot surface Letta Code's interactive overlays. Keep
+      // AskUserQuestion and other runtime-input tools out of this turn so the
+      // agent asks for missing information in ordinary assistant text.
+      excludeInteractiveTools: true,
       messages: params.messages,
     };
     try {

--- a/src/websocket/app-server-openai-turn.ts
+++ b/src/websocket/app-server-openai-turn.ts
@@ -1,5 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { settingsManager } from "@/settings-manager";
+import type { StreamDelta } from "@/types/protocol_v2";
+import {
+  createToolLifecycleTracker,
+  type ToolCallEvent,
+  type ToolLifecycleCallback,
+} from "@/websocket/app-server-openai-tools";
 import { getOrCreateProcessTransport } from "@/websocket/listener/connection";
 import { createConnectionTurnProcessor } from "@/websocket/listener/connection-lifecycle";
 import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
@@ -43,6 +49,7 @@ export interface TurnOutcome {
   text: string;
   usage: OpenAiUsage;
   error: string | null;
+  toolEvents?: ToolCallEvent[];
 }
 
 export interface BridgeTurnMessage {
@@ -51,7 +58,7 @@ export interface BridgeTurnMessage {
   otid: string;
 }
 
-interface RunTurnParams {
+export interface RunTurnParams {
   agentId: string;
   conversationId: string;
   /** Full input for the turn: the newest message in stateful mode, or the
@@ -61,6 +68,7 @@ interface RunTurnParams {
    * lifecycle with this request. */
   correlationOtid: string;
   onAssistantText?: (text: string) => void;
+  onToolEvent?: ToolLifecycleCallback;
   onLog?: (message: string) => void;
 }
 
@@ -212,8 +220,13 @@ async function runTurnViaListenerRuntime(
     // turns in the same conversation never bleed into this response.
     let turnActive = false;
     let recordedError: string | null = null;
+    const toolEvents: ToolCallEvent[] = [];
     let settled = false;
     let unregisterTurnObserver: () => void = () => {};
+    const toolTracker = createToolLifecycleTracker((event) => {
+      toolEvents.push(event);
+      params.onToolEvent?.(event);
+    });
     if (!listener.streamObservers) {
       listener.streamObservers = new Set();
     }
@@ -222,10 +235,12 @@ async function runTurnViaListenerRuntime(
     const finish = (error: string | null): void => {
       if (settled) return;
       settled = true;
+      if (error) toolTracker.failPending(error);
       clearTimeout(timer);
       observers.delete(observer);
       unregisterTurnObserver();
-      resolve({ text, usage, error });
+      toolTracker.dispose();
+      resolve({ text, usage, error, toolEvents });
     };
 
     const observer: ListenerStreamObserver = (message) => {
@@ -244,9 +259,10 @@ async function runTurnViaListenerRuntime(
         const status = (message as { loop_status?: { status?: string } })
           .loop_status?.status;
         if (status === "WAITING_ON_APPROVAL") {
+          const note =
+            "The agent attempted a tool call that requires interactive approval, which this API does not support.";
+          toolTracker.failPending(note);
           if (!text) {
-            const note =
-              "The agent attempted a tool call that requires interactive approval, which this API does not support.";
             text = note;
             params.onAssistantText?.(note);
           }
@@ -257,6 +273,7 @@ async function runTurnViaListenerRuntime(
       if (message.type !== "stream_delta" || message.subagent_id) return;
       const delta = (message as { delta?: { message_type?: string } }).delta;
       if (!delta) return;
+      toolTracker.process(delta as StreamDelta);
       switch (delta.message_type) {
         case "assistant_message": {
           const piece = extractDeltaText(delta);

--- a/src/websocket/app-server-openai-turn.ts
+++ b/src/websocket/app-server-openai-turn.ts
@@ -34,6 +34,7 @@ export interface OpenAiUsage {
   prompt_tokens: number;
   completion_tokens: number;
   total_tokens: number;
+  reasoning_tokens?: number;
 }
 
 export type UserContentPart =
@@ -47,6 +48,7 @@ export type UserContentPart =
 
 export interface TurnOutcome {
   text: string;
+  reasoning?: string;
   usage: OpenAiUsage;
   error: string | null;
   toolEvents?: ToolCallEvent[];
@@ -68,6 +70,7 @@ export interface RunTurnParams {
    * lifecycle with this request. */
   correlationOtid: string;
   onAssistantText?: (text: string) => void;
+  onReasoningText?: (text: string) => void;
   onToolEvent?: ToolLifecycleCallback;
   onLog?: (message: string) => void;
 }
@@ -167,6 +170,23 @@ function extractDeltaText(delta: unknown): string {
     .join("");
 }
 
+function extractReasoningText(delta: unknown): string {
+  const reasoning = (
+    delta as { reasoning?: string | Array<{ text?: string }> | null }
+  ).reasoning;
+  if (typeof reasoning === "string") return reasoning;
+  if (Array.isArray(reasoning)) {
+    return reasoning
+      .map((part) =>
+        part && typeof part === "object" && typeof part.text === "string"
+          ? part.text
+          : "",
+      )
+      .join("");
+  }
+  return extractDeltaText(delta);
+}
+
 async function runTurnViaListenerRuntime(
   params: RunTurnParams,
 ): Promise<TurnOutcome> {
@@ -207,6 +227,7 @@ async function runTurnViaListenerRuntime(
 
   return await new Promise<TurnOutcome>((resolve) => {
     let text = "";
+    let reasoning = "";
     let usage: OpenAiUsage = {
       prompt_tokens: 0,
       completion_tokens: 0,
@@ -240,7 +261,7 @@ async function runTurnViaListenerRuntime(
       observers.delete(observer);
       unregisterTurnObserver();
       toolTracker.dispose();
-      resolve({ text, usage, error, toolEvents });
+      resolve({ text, reasoning, usage, error, toolEvents });
     };
 
     const observer: ListenerStreamObserver = (message) => {
@@ -275,6 +296,14 @@ async function runTurnViaListenerRuntime(
       if (!delta) return;
       toolTracker.process(delta as StreamDelta);
       switch (delta.message_type) {
+        case "reasoning_message": {
+          const piece = extractReasoningText(delta);
+          if (piece) {
+            reasoning += piece;
+            params.onReasoningText?.(piece);
+          }
+          return;
+        }
         case "assistant_message": {
           const piece = extractDeltaText(delta);
           if (piece) {
@@ -291,11 +320,15 @@ async function runTurnViaListenerRuntime(
             prompt_tokens?: number;
             completion_tokens?: number;
             total_tokens?: number;
+            reasoning_tokens?: number;
           };
           usage = {
             prompt_tokens: stats.prompt_tokens ?? 0,
             completion_tokens: stats.completion_tokens ?? 0,
             total_tokens: stats.total_tokens ?? 0,
+            ...(stats.reasoning_tokens !== undefined
+              ? { reasoning_tokens: stats.reasoning_tokens }
+              : {}),
           };
           return;
         }

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -305,7 +305,18 @@ async function handleChatCompletions(
     };
   }
   const fullText = outcome.text;
-  const usage = outcome.usage;
+  const usage = {
+    prompt_tokens: outcome.usage.prompt_tokens,
+    completion_tokens: outcome.usage.completion_tokens,
+    total_tokens: outcome.usage.total_tokens,
+    ...(outcome.usage.reasoning_tokens !== undefined
+      ? {
+          completion_tokens_details: {
+            reasoning_tokens: outcome.usage.reasoning_tokens,
+          },
+        }
+      : {}),
+  };
   const streamError = outcome.error;
 
   // Headerless requests are stateless: their conversation exists only to

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -27,7 +27,6 @@ import {
 import {
   handleResponses,
   RESPONSES_PATH,
-  resetResponsesState,
 } from "@/websocket/app-server-openai-responses";
 import {
   type BridgeTurnMessage,
@@ -41,7 +40,6 @@ export { __testSetRunTurnImpl } from "@/websocket/app-server-openai-turn";
 /** @internal Clears chat-key and idempotency maps between tests. */
 export function __testResetConversationMap(): void {
   resetOpenAiCompatState();
-  resetResponsesState();
 }
 
 // OpenAI-compatible surface for the App Server. Each Letta agent is

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -4,10 +4,31 @@ import type {
   ServerResponse,
 } from "node:http";
 import { getBackend } from "@/backend";
+import { authorizeUpgrade } from "@/websocket/app-server-auth";
 import {
-  authorizeUpgrade,
-  type WebsocketAuthPolicy,
-} from "@/websocket/app-server-auth";
+  chatKeyFromHeaders,
+  createConversationSerialized,
+  extractTextContent,
+  extractUserContentParts,
+  getIdempotentOutcome,
+  handleListModels,
+  idempotencyKeyFromHeaders,
+  type OpenAiChatMessage,
+  type OpenAiCompatOptions,
+  readJsonBody,
+  rememberConversation,
+  rememberIdempotentOutcome,
+  resetOpenAiCompatState,
+  resolveAgentForModel,
+  resolveConversationId,
+  sendJson,
+  sendOpenAiError,
+} from "@/websocket/app-server-openai-common";
+import {
+  handleResponses,
+  RESPONSES_PATH,
+  resetResponsesState,
+} from "@/websocket/app-server-openai-responses";
 import {
   type BridgeTurnMessage,
   runBridgeTurn,
@@ -19,8 +40,8 @@ export { __testSetRunTurnImpl } from "@/websocket/app-server-openai-turn";
 
 /** @internal Clears chat-key and idempotency maps between tests. */
 export function __testResetConversationMap(): void {
-  conversationIdByTranscript.clear();
-  outcomeByIdempotencyKey.clear();
+  resetOpenAiCompatState();
+  resetResponsesState();
 }
 
 // OpenAI-compatible surface for the App Server. Each Letta agent is
@@ -32,23 +53,8 @@ export function __testResetConversationMap(): void {
 // indistinguishable and transcript fingerprinting cross-wires them.
 const MODELS_PATH = "/v1/models";
 const CHAT_COMPLETIONS_PATH = "/v1/chat/completions";
-const MAX_REQUEST_BODY_BYTES = 20 * 1024 * 1024;
 
-export interface OpenAiCompatOptions {
-  authPolicy: WebsocketAuthPolicy;
-  onLog?: (message: string) => void;
-}
-
-interface OpenAiChatMessagePart {
-  type?: string;
-  text?: string;
-  image_url?: { url?: string } | string;
-}
-
-interface OpenAiChatMessage {
-  role?: string;
-  content?: string | OpenAiChatMessagePart[] | null;
-}
+export type { OpenAiCompatOptions } from "@/websocket/app-server-openai-common";
 
 interface OpenAiChatCompletionRequest {
   model?: string;
@@ -57,361 +63,11 @@ interface OpenAiChatCompletionRequest {
 }
 
 export function isOpenAiCompatPath(pathname: string): boolean {
-  return pathname === MODELS_PATH || pathname === CHAT_COMPLETIONS_PATH;
-}
-
-function sendJson(
-  response: ServerResponse,
-  statusCode: number,
-  body: unknown,
-): void {
-  const payload = JSON.stringify(body);
-  response.writeHead(statusCode, {
-    "content-type": "application/json",
-    "content-length": Buffer.byteLength(payload),
-  });
-  response.end(payload);
-}
-
-function sendOpenAiError(
-  response: ServerResponse,
-  statusCode: number,
-  message: string,
-  type: string,
-  code: string | null = null,
-): void {
-  sendJson(response, statusCode, {
-    error: { message, type, param: null, code },
-  });
-}
-
-async function readJsonBody(request: HttpIncomingMessage): Promise<unknown> {
-  const chunks: Buffer[] = [];
-  let total = 0;
-  for await (const chunk of request) {
-    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-    total += buffer.length;
-    if (total > MAX_REQUEST_BODY_BYTES) {
-      throw new Error("request body too large");
-    }
-    chunks.push(buffer);
-  }
-  const raw = Buffer.concat(chunks).toString("utf8");
-  if (!raw) return {};
-  return JSON.parse(raw);
-}
-
-function extractTextContent(
-  content: string | OpenAiChatMessagePart[] | null | undefined,
-): string {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  return content
-    .map((part) =>
-      part && part.type === "text" && typeof part.text === "string"
-        ? part.text
-        : "",
-    )
-    .filter(Boolean)
-    .join("\n");
-}
-
-const IMAGE_DATA_URL_RE = /^data:([^;,]+);base64,(.+)$/;
-
-function toImagePart(rawUrl: string): UserContentPart | null {
-  const match = IMAGE_DATA_URL_RE.exec(rawUrl);
-  if (match?.[1] && match[2]) {
-    return {
-      type: "image",
-      source: { type: "base64", media_type: match[1], data: match[2] },
-    };
-  }
-  if (/^https?:\/\//.test(rawUrl)) {
-    return { type: "image", source: { type: "url", url: rawUrl } };
-  }
-  return null;
-}
-
-/** OpenAI user content → Letta content parts (text and image_url). */
-function extractUserContentParts(
-  content: string | OpenAiChatMessagePart[] | null | undefined,
-): UserContentPart[] {
-  if (typeof content === "string") {
-    return content ? [{ type: "text", text: content }] : [];
-  }
-  if (!Array.isArray(content)) return [];
-  const parts: UserContentPart[] = [];
-  for (const part of content) {
-    if (!part || typeof part !== "object") continue;
-    if (part.type === "text" && typeof part.text === "string" && part.text) {
-      parts.push({ type: "text", text: part.text });
-      continue;
-    }
-    if (part.type === "image_url") {
-      const raw =
-        typeof part.image_url === "string"
-          ? part.image_url
-          : part.image_url?.url;
-      if (typeof raw === "string") {
-        const image = toImagePart(raw);
-        if (image) parts.push(image);
-      }
-    }
-  }
-  return parts;
-}
-
-function toModelCreatedTimestamp(createdAt: unknown): number {
-  if (typeof createdAt === "string") {
-    const ms = new Date(createdAt).getTime();
-    if (Number.isFinite(ms)) return Math.floor(ms / 1000);
-  }
-  return 0;
-}
-
-interface AgentModelEntry {
-  id: string;
-  name?: string | null;
-  created_at?: string;
-}
-
-function getPageItems<T>(page: unknown): T[] {
-  if (Array.isArray(page)) return page as T[];
-  if (page && typeof page === "object") {
-    const candidate = page as {
-      getPaginatedItems?: () => T[];
-      items?: T[];
-    };
-    if (typeof candidate.getPaginatedItems === "function") {
-      return candidate.getPaginatedItems();
-    }
-    if (Array.isArray(candidate.items)) {
-      return candidate.items;
-    }
-  }
-  return [];
-}
-
-const MAX_LISTED_AGENTS = 1000;
-
-async function listAgentEntries(): Promise<AgentModelEntry[]> {
-  const page = await getBackend().listAgents({ limit: MAX_LISTED_AGENTS });
-  if (Array.isArray(page)) return page as AgentModelEntry[];
-  // SDK pages are async-iterable across ALL pages; a first-page-only read
-  // silently drops agents once the list exceeds one page.
-  const iterable = page as unknown as {
-    [Symbol.asyncIterator]?: () => AsyncIterator<AgentModelEntry>;
-  };
-  if (typeof iterable[Symbol.asyncIterator] === "function") {
-    const items: AgentModelEntry[] = [];
-    for await (const item of iterable as AsyncIterable<AgentModelEntry>) {
-      items.push(item);
-      if (items.length >= MAX_LISTED_AGENTS) break;
-    }
-    return items;
-  }
-  return getPageItems<AgentModelEntry>(page);
-}
-
-/**
- * One collision-free advertised-id map, used by both listing and
- * resolution. An agent name is advertised only when it is unique among
- * names AND does not equal any agent id — otherwise the agent id is
- * advertised — so every advertised id resolves to exactly one agent and
- * raw agent-id lookups can never be shadowed by another agent's name.
- */
-function buildAdvertisedModelMap(
-  agents: AgentModelEntry[],
-): Map<string, AgentModelEntry> {
-  const ids = new Set(agents.map((agent) => agent.id));
-  const nameCounts = new Map<string, number>();
-  for (const agent of agents) {
-    if (!agent.name) continue;
-    nameCounts.set(agent.name, (nameCounts.get(agent.name) ?? 0) + 1);
-  }
-  const advertised = new Map<string, AgentModelEntry>();
-  for (const agent of agents) {
-    const useName =
-      agent.name && nameCounts.get(agent.name) === 1 && !ids.has(agent.name);
-    const id = useName && agent.name ? agent.name : agent.id;
-    if (!advertised.has(id)) advertised.set(id, agent);
-  }
-  return advertised;
-}
-
-async function handleListModels(response: ServerResponse): Promise<void> {
-  const advertised = buildAdvertisedModelMap(await listAgentEntries());
-  const data = [...advertised.entries()].map(([id, agent]) => ({
-    id,
-    object: "model" as const,
-    created: toModelCreatedTimestamp(agent.created_at),
-    owned_by: "letta",
-  }));
-  sendJson(response, 200, { object: "list", data });
-}
-
-async function resolveAgentForModel(
-  model: string,
-): Promise<AgentModelEntry | null> {
-  const agents = await listAgentEntries();
   return (
-    buildAdvertisedModelMap(agents).get(model) ??
-    agents.find((agent) => agent.id === model) ??
-    null
+    pathname === MODELS_PATH ||
+    pathname === CHAT_COMPLETIONS_PATH ||
+    pathname === RESPONSES_PATH
   );
-}
-
-// Conversation continuity for header-keyed chats. Clients that supply a
-// stable chat identity get a pinned Letta conversation; the bounded FIFO
-// map evicts long-idle chats, which then start a fresh conversation.
-const MAX_TRACKED_TRANSCRIPTS = 4096;
-const conversationIdByTranscript = new Map<string, string>();
-
-function rememberConversation(key: string, conversationId: string): void {
-  conversationIdByTranscript.delete(key);
-  conversationIdByTranscript.set(key, conversationId);
-  while (conversationIdByTranscript.size > MAX_TRACKED_TRANSCRIPTS) {
-    const oldest = conversationIdByTranscript.keys().next().value;
-    if (oldest === undefined) break;
-    conversationIdByTranscript.delete(oldest);
-  }
-}
-
-// Conversation creation is serialized per agent: concurrent creations race
-// on initializing the agent's local memory repository (transient git config
-// lock failures). Failures propagate to the caller as a 500 — routing into
-// the shared "default" conversation instead would cross-wire client chats.
-const conversationCreateTailByAgent = new Map<string, Promise<void>>();
-const CONVERSATION_CREATE_RETRIES = 2;
-const CONVERSATION_CREATE_RETRY_DELAY_MS = 200;
-
-async function createConversationWithRetry(agentId: string): Promise<string> {
-  let lastError: unknown;
-  for (let attempt = 0; attempt <= CONVERSATION_CREATE_RETRIES; attempt++) {
-    if (attempt > 0) {
-      await new Promise((resolve) =>
-        setTimeout(resolve, CONVERSATION_CREATE_RETRY_DELAY_MS * attempt),
-      );
-    }
-    try {
-      const conversation = await getBackend().createConversation({
-        agent_id: agentId,
-      });
-      return conversation.id;
-    } catch (error) {
-      lastError = error;
-    }
-  }
-  throw lastError;
-}
-
-/** Serialized per-agent conversation creation (see note above). The
- * optional reuseKey is re-checked after the queue drains so a concurrent
- * request with the same key reuses the conversation it created. */
-async function createConversationSerialized(
-  agentId: string,
-  reuseKey?: string,
-): Promise<string> {
-  const tail = conversationCreateTailByAgent.get(agentId) ?? Promise.resolve();
-  const creation = tail.then(async () => {
-    if (reuseKey) {
-      const raced = conversationIdByTranscript.get(reuseKey);
-      if (raced) return raced;
-    }
-    return await createConversationWithRetry(agentId);
-  });
-  const settled = creation.then(
-    () => undefined,
-    () => undefined,
-  );
-  conversationCreateTailByAgent.set(agentId, settled);
-  void settled.then(() => {
-    if (conversationCreateTailByAgent.get(agentId) === settled) {
-      conversationCreateTailByAgent.delete(agentId);
-    }
-  });
-  return await creation;
-}
-
-async function resolveConversationId(
-  agentId: string,
-  chatKey: string,
-): Promise<string> {
-  const existing = conversationIdByTranscript.get(chatKey);
-  if (existing) return existing;
-  return await createConversationSerialized(agentId, chatKey);
-}
-
-// Clients that know their chat identity can pin it explicitly instead of
-// relying on transcript fingerprints, which collide when two chats have
-// byte-identical transcripts (e.g. both start "Hello" and get the same
-// verbatim reply). Open WebUI sends X-OpenWebUI-Chat-Id when
-// ENABLE_FORWARD_USER_INFO_HEADERS is on; X-Letta-Chat-Key is the generic
-// escape hatch for other clients.
-function headerValue(
-  request: HttpIncomingMessage,
-  name: string,
-): string | null {
-  const value = request.headers[name];
-  if (typeof value === "string" && value) return value;
-  if (Array.isArray(value) && value[0]) return value[0];
-  return null;
-}
-
-/**
- * X-Letta-Chat-Key always pins chat identity. X-OpenWebUI-Chat-Id is
- * honored only for streaming requests: Open WebUI's real chat messages
- * always stream, while its background task requests (title/tags/follow-up
- * generation) are non-streaming yet carry the same chat id — honoring
- * those would route task prompts into the user's pinned conversation.
- */
-function chatKeyFromHeaders(
-  request: HttpIncomingMessage,
-  streaming: boolean,
-): string | null {
-  const explicit = headerValue(request, "x-letta-chat-key");
-  if (explicit) return explicit;
-  if (!streaming) return null;
-  return headerValue(request, "x-openwebui-chat-id");
-}
-
-// Retry idempotency: a client retry carrying the same Idempotency-Key
-// reuses the original request's outcome instead of running (and appending)
-// the message again. In-flight duplicates share the same turn; failed
-// outcomes are evicted so an intentional retry after an error re-runs.
-const IDEMPOTENCY_HEADERS = ["idempotency-key", "x-idempotency-key"] as const;
-const MAX_IDEMPOTENT_OUTCOMES = 1024;
-const outcomeByIdempotencyKey = new Map<string, Promise<TurnOutcome>>();
-
-function idempotencyKeyFromHeaders(
-  request: HttpIncomingMessage,
-): string | null {
-  for (const name of IDEMPOTENCY_HEADERS) {
-    const value = headerValue(request, name);
-    if (value) return value;
-  }
-  return null;
-}
-
-function rememberIdempotentOutcome(
-  key: string,
-  promise: Promise<TurnOutcome>,
-): void {
-  outcomeByIdempotencyKey.delete(key);
-  outcomeByIdempotencyKey.set(key, promise);
-  while (outcomeByIdempotencyKey.size > MAX_IDEMPOTENT_OUTCOMES) {
-    const oldest = outcomeByIdempotencyKey.keys().next().value;
-    if (oldest === undefined) break;
-    outcomeByIdempotencyKey.delete(oldest);
-  }
-  const evict = () => {
-    if (outcomeByIdempotencyKey.get(key) === promise) {
-      outcomeByIdempotencyKey.delete(key);
-    }
-  };
-  promise.then((outcome) => {
-    if (outcome.error) evict();
-  }, evict);
 }
 
 function chatCompletionChunk(
@@ -506,7 +162,7 @@ async function handleChatCompletions(
   // Consult the idempotency cache BEFORE any allocation: a replay must not
   // create (and orphan) a conversation for a turn that will never run.
   const replayPromise = idempotencyKey
-    ? outcomeByIdempotencyKey.get(idempotencyKey)
+    ? getIdempotentOutcome(idempotencyKey)
     : undefined;
 
   let conversationId: string | null = null;
@@ -728,6 +384,10 @@ export async function handleOpenAiCompatRequest(
     }
     if (pathname === CHAT_COMPLETIONS_PATH && request.method === "POST") {
       await handleChatCompletions(request, response, options);
+      return;
+    }
+    if (pathname === RESPONSES_PATH && request.method === "POST") {
+      await handleResponses(request, response, options);
       return;
     }
     sendOpenAiError(response, 404, "unknown endpoint", "invalid_request_error");

--- a/src/websocket/app-server.ts
+++ b/src/websocket/app-server.ts
@@ -47,7 +47,7 @@ export interface StartAppServerOptions {
   listen?: string;
   websocketAuth?: AppServerWebsocketAuthSettings;
   connectionName?: string;
-  /** Serve OpenAI-compatible /v1/models and /v1/chat/completions routes. */
+  /** Serve OpenAI-compatible models, Chat Completions, and Responses routes. */
   openaiApi?: boolean;
   onListening?: (info: AppServerListeningInfo) => void;
   onLog?: (message: string) => void;


### PR DESCRIPTION
## Summary
<img width="931" height="534" alt="image" src="https://github.com/user-attachments/assets/89684ff5-7d68-4eca-9064-348f8b1dc369" />

- add authenticated `POST /v1/responses` support behind `--openai-api`, with streaming and non-streaming response objects
- translate native Letta tool-call and tool-return deltas into Responses `function_call` and `function_call_output` items, so clients such as Open WebUI can render server-side tool execution without attempting to execute those tools themselves
- support text/image inputs, Open WebUI chat-key continuity, default response storage, and `previous_response_id` continuation
- extract shared OpenAI compatibility helpers so Chat Completions and Responses use the same model resolution, input conversion, auth, and conversation behavior
- cover the endpoint through raw HTTP and the official OpenAI SDK, plus partial, plural, failed, and duplicated tool lifecycle events

## Validation

- `bun test src/websocket/app-server-openai-tools.test.ts src/websocket/app-server-openai-responses.test.ts src/websocket/app-server-openai.test.ts` (43 pass)
- `bun test src/websocket/app-server.test.ts src/websocket/app-server-openai.test.ts src/websocket/app-server-openai-tools.test.ts src/websocket/app-server-openai-responses.test.ts` (57 pass)
- `bun test src/cli/subcommands/server.test.ts src/cli/subcommands/app-server.test.ts` (6 pass)
- `bun run typecheck`
- Biome check on all changed files
- `git diff --check`