### PR TITLE
feat(models): fix new Opus and Sonnet model xhigh reasoning tiers

### DIFF
--- a/src/agent/model-tier-selection.test.ts
+++ b/src/agent/model-tier-selection.test.ts
@@ -50,6 +50,18 @@ describe("getModelInfo", () => {
     });
   });
 
+  test.each([
+    "opus-5-low",
+    "opus-5-medium",
+    "opus-5",
+    "opus-5-xhigh",
+    "opus-5-max",
+  ])("sets an explicit 200k context window for %s", (modelId) => {
+    expect(getModelInfo(modelId)?.updateArgs).toMatchObject({
+      context_window: 200000,
+    });
+  });
+
   test("preserves Bedrock Opus 4.7", () => {
     const info = getModelInfo("bedrock-opus-4.7");
     expect(info?.handle).toBe("bedrock/us.anthropic.claude-opus-4-7");

--- a/src/agent/model-tier-selection.test.ts
+++ b/src/agent/model-tier-selection.test.ts
@@ -481,6 +481,7 @@ describe("getReasoningTierOptionsForHandle", () => {
       "medium",
       "high",
       "xhigh",
+      "max",
     ]);
     expect(options.map((option) => option.modelId)).toEqual([
       "sonnet-5-no-reasoning",
@@ -488,6 +489,25 @@ describe("getReasoningTierOptionsForHandle", () => {
       "sonnet-5-medium",
       "sonnet",
       "sonnet-5-xhigh",
+      "sonnet-5-max",
+    ]);
+  });
+
+  test("returns distinct xhigh and max options for anthropic opus 5", () => {
+    const options = getReasoningTierOptionsForHandle("anthropic/claude-opus-5");
+    expect(options.map((option) => option.effort)).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
+    expect(options.map((option) => option.modelId)).toEqual([
+      "opus-5-low",
+      "opus-5-medium",
+      "opus-5",
+      "opus-5-xhigh",
+      "opus-5-max",
     ]);
   });
 

--- a/src/agent/modify-local.test.ts
+++ b/src/agent/modify-local.test.ts
@@ -72,6 +72,20 @@ describe("local model updates", () => {
     });
   });
 
+  test.each(["anthropic/claude-opus-5", "anthropic/claude-sonnet-5"])(
+    "preserves distinct xhigh for %s",
+    (modelHandle) => {
+      expect(
+        __modifyTestUtils.buildModelSettings(modelHandle, {
+          reasoning_effort: "xhigh",
+        }),
+      ).toMatchObject({
+        provider_type: "anthropic",
+        effort: "xhigh",
+      });
+    },
+  );
+
   test("stores provider-default reasoning explicitly for custom OpenAI providers", () => {
     expect(
       __modifyTestUtils.buildModelSettings("custom/claude-opus-4-6", {

--- a/src/agent/modify.ts
+++ b/src/agent/modify.ts
@@ -26,6 +26,8 @@ type ModelSettings =
 function supportsDistinctAnthropicXHighEffort(modelHandle: string): boolean {
   return (
     modelHandle.includes("claude-fable-5") ||
+    modelHandle.includes("claude-opus-5") ||
+    modelHandle.includes("claude-sonnet-5") ||
     modelHandle.includes("claude-opus-4-7") ||
     modelHandle.includes("claude-opus-4-8")
   );
@@ -132,7 +134,7 @@ function buildModelSettings(
     if (effort === "low" || effort === "medium" || effort === "high") {
       anthropicSettings.effort = effort;
     } else if (effort === "xhigh") {
-      // "xhigh" is distinct on Fable and Opus 4.7+; older Anthropic models map it to backend "max".
+      // Preserve distinct xhigh on supported newer Anthropic models; legacy models map it to backend max.
       (anthropicSettings as Record<string, unknown>).effort = hasDistinctXHigh
         ? "xhigh"
         : "max";

--- a/src/cli/app/use-configuration-handlers.ts
+++ b/src/cli/app/use-configuration-handlers.ts
@@ -350,9 +350,9 @@ export function useConfigurationHandlers(ctx: ConfigurationHandlersContext) {
         const isOpenAICompatibleProxy =
           modelUpdateArgs?.[OPENAI_COMPATIBLE_PROXY_UPDATE_ARG] === true &&
           providerType === "openai";
-        const usesDistinctXHighLabel = /Fable 5|Opus 4\.[78]|GPT-5\.6/.test(
-          model.label,
-        );
+        // Keep picker labels aligned with models that preserve xhigh separately from max.
+        const usesDistinctXHighLabel =
+          /Fable 5|Opus 4\.[78]|Opus 5|Sonnet 5|GPT-5\.6/.test(model.label);
         const reasoningLevel =
           isOpenAICompatibleProxy && rawReasoningEffort === null
             ? "default"

--- a/src/cli/app/use-reasoning-cycle.ts
+++ b/src/cli/app/use-reasoning-cycle.ts
@@ -45,6 +45,8 @@ type ReasoningCycleDesired = {
 function supportsDistinctAnthropicXHighEffort(modelHandle: string): boolean {
   return (
     modelHandle.includes("claude-fable-5") ||
+    modelHandle.includes("claude-opus-5") ||
+    modelHandle.includes("claude-sonnet-5") ||
     modelHandle.includes("claude-opus-4-7") ||
     modelHandle.includes("claude-opus-4-8")
   );
@@ -591,7 +593,7 @@ export function useReasoningCycle(ctx: ReasoningCycleContext) {
             ms.provider_type === "anthropic" ||
             ms.provider_type === "bedrock"
           ) {
-            // "xhigh" is distinct on Fable and Opus 4.7+; older Anthropic models map it to backend "max".
+            // Preserve distinct xhigh on supported newer Anthropic models; legacy models map it to backend max.
             return {
               ...prev,
               model_settings: {

--- a/src/models.json
+++ b/src/models.json
@@ -897,6 +897,68 @@
       }
     },
     {
+      "id": "opus-5",
+      "handle": "anthropic/claude-opus-5",
+      "label": "Opus 5",
+      "description": "Opus 5 (high reasoning)",
+      "updateArgs": {
+        "max_output_tokens": 128000,
+        "enable_reasoner": true,
+        "reasoning_effort": "high",
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "opus-5-low",
+      "handle": "anthropic/claude-opus-5",
+      "label": "Opus 5",
+      "description": "Opus 5 (low reasoning)",
+      "updateArgs": {
+        "max_output_tokens": 128000,
+        "enable_reasoner": true,
+        "reasoning_effort": "low",
+        "max_reasoning_tokens": 4000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "opus-5-medium",
+      "handle": "anthropic/claude-opus-5",
+      "label": "Opus 5",
+      "description": "Opus 5 (med reasoning)",
+      "updateArgs": {
+        "max_output_tokens": 128000,
+        "enable_reasoner": true,
+        "reasoning_effort": "medium",
+        "max_reasoning_tokens": 12000,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "opus-5-xhigh",
+      "handle": "anthropic/claude-opus-5",
+      "label": "Opus 5",
+      "description": "Opus 5 (extra-high reasoning)",
+      "updateArgs": {
+        "max_output_tokens": 128000,
+        "enable_reasoner": true,
+        "reasoning_effort": "xhigh",
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "opus-5-max",
+      "handle": "anthropic/claude-opus-5",
+      "label": "Opus 5",
+      "description": "Opus 5 (max reasoning)",
+      "updateArgs": {
+        "max_output_tokens": 128000,
+        "enable_reasoner": true,
+        "reasoning_effort": "max",
+        "parallel_tool_calls": true
+      }
+    },
+    {
       "id": "opus",
       "handle": "anthropic/claude-opus-4-8",
       "label": "Opus 4.8",
@@ -1170,11 +1232,24 @@
       "id": "sonnet-5-xhigh",
       "handle": "anthropic/claude-sonnet-5",
       "label": "Sonnet 5",
-      "description": "Sonnet 5 (max reasoning)",
+      "description": "Sonnet 5 (extra-high reasoning)",
       "updateArgs": {
         "context_window": 1000000,
         "max_output_tokens": 128000,
         "reasoning_effort": "xhigh",
+        "enable_reasoner": true,
+        "parallel_tool_calls": true
+      }
+    },
+    {
+      "id": "sonnet-5-max",
+      "handle": "anthropic/claude-sonnet-5",
+      "label": "Sonnet 5",
+      "description": "Sonnet 5 (max reasoning)",
+      "updateArgs": {
+        "context_window": 1000000,
+        "max_output_tokens": 128000,
+        "reasoning_effort": "max",
         "enable_reasoner": true,
         "parallel_tool_calls": true
       }

--- a/src/models.json
+++ b/src/models.json
@@ -902,6 +902,7 @@
       "label": "Opus 5",
       "description": "Opus 5 (high reasoning)",
       "updateArgs": {
+        "context_window": 200000,
         "max_output_tokens": 128000,
         "enable_reasoner": true,
         "reasoning_effort": "high",
@@ -914,6 +915,7 @@
       "label": "Opus 5",
       "description": "Opus 5 (low reasoning)",
       "updateArgs": {
+        "context_window": 200000,
         "max_output_tokens": 128000,
         "enable_reasoner": true,
         "reasoning_effort": "low",
@@ -927,6 +929,7 @@
       "label": "Opus 5",
       "description": "Opus 5 (med reasoning)",
       "updateArgs": {
+        "context_window": 200000,
         "max_output_tokens": 128000,
         "enable_reasoner": true,
         "reasoning_effort": "medium",
@@ -940,6 +943,7 @@
       "label": "Opus 5",
       "description": "Opus 5 (extra-high reasoning)",
       "updateArgs": {
+        "context_window": 200000,
         "max_output_tokens": 128000,
         "enable_reasoner": true,
         "reasoning_effort": "xhigh",
@@ -952,6 +956,7 @@
       "label": "Opus 5",
       "description": "Opus 5 (max reasoning)",
       "updateArgs": {
+        "context_window": 200000,
         "max_output_tokens": 128000,
         "enable_reasoner": true,
         "reasoning_effort": "max",


### PR DESCRIPTION
## Summary
- add low, medium, high, xhigh, and max presets for Opus 5 plus a distinct max preset for Sonnet 5
- preserve xhigh separately from max when building and cycling Anthropic model settings
- label and test the distinct xhigh/max tiers in model selection

## Test plan
- [x] `bun test src/agent/modify-local.test.ts src/agent/model-tier-selection.test.ts`
- [x] `bun run check`
- [x] verify a Sonnet 5 xhigh agent-audit run sends `output_config.effort: "xhigh"` in production traces

👾 Generated with [Letta Code](https://letta.com)