### PR TITLE
fix(listener): avoid false pong timeouts under event-loop stalls [LET-9601]

### DIFF
--- a/src/websocket/listener/heartbeat.test.ts
+++ b/src/websocket/listener/heartbeat.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { createMissedPongWatchdog } from "./heartbeat";
+
+describe("listener heartbeat watchdog", () => {
+  test("does not treat a delayed first interval as missed peer responses", () => {
+    const watchdog = createMissedPongWatchdog(3);
+
+    expect(watchdog.shouldTerminate(0)).toBe(false);
+    watchdog.recordPing(120_000);
+
+    expect(watchdog.shouldTerminate(0)).toBe(false);
+  });
+
+  test("terminates only after the configured number of unanswered probes", () => {
+    const watchdog = createMissedPongWatchdog(3);
+
+    for (const sentAt of [30_000, 60_000, 90_000]) {
+      expect(watchdog.shouldTerminate(0)).toBe(false);
+      watchdog.recordPing(sentAt);
+    }
+
+    expect(watchdog.shouldTerminate(0)).toBe(true);
+  });
+
+  test("a pong at or after the latest ping resets the missed-probe count", () => {
+    const watchdog = createMissedPongWatchdog(3);
+
+    watchdog.recordPing(30_000);
+    watchdog.recordPing(60_000);
+    expect(watchdog.shouldTerminate(60_000)).toBe(false);
+
+    watchdog.recordPing(90_000);
+    watchdog.recordPing(120_000);
+    expect(watchdog.shouldTerminate(120_000)).toBe(false);
+  });
+});

--- a/src/websocket/listener/heartbeat.ts
+++ b/src/websocket/listener/heartbeat.ts
@@ -1,30 +1,72 @@
 import {
-  isListenerPongStale,
   LISTENER_HEARTBEAT_INTERVAL_MS,
   LISTENER_PONG_TIMEOUT_MS,
 } from "./constants";
 import { getListenerTransportKind, type ListenerTransport } from "./transport";
 import type { ListenerRuntime } from "./types";
 
+export interface MissedPongWatchdog {
+  shouldTerminate(lastPongAt: number | null): boolean;
+  recordPing(sentAt: number): void;
+}
+
+/**
+ * Count actual unanswered heartbeat probes instead of elapsed wall time.
+ *
+ * A wall-clock-only watchdog cannot distinguish a dead peer from a locally
+ * starved event loop. If the interval callback itself is delayed beyond the
+ * timeout (CPU saturation, sleep/wake), it otherwise kills a healthy socket
+ * before giving the peer a fresh ping to answer.
+ */
+export function createMissedPongWatchdog(
+  maxUnansweredPings: number,
+): MissedPongWatchdog {
+  let lastPingAt: number | null = null;
+  let unansweredPings = 0;
+
+  return {
+    shouldTerminate(lastPongAt) {
+      if (
+        lastPingAt !== null &&
+        lastPongAt !== null &&
+        lastPongAt >= lastPingAt
+      ) {
+        unansweredPings = 0;
+      }
+      return unansweredPings >= maxUnansweredPings;
+    },
+    recordPing(sentAt) {
+      lastPingAt = sentAt;
+      unansweredPings += 1;
+    },
+  };
+}
+
 export function startConnectionHeartbeat(
   runtime: ListenerRuntime,
   transport: ListenerTransport,
   onStale: () => void,
-  sendPing: () => void,
+  sendPing: () => boolean,
 ): void {
   runtime.lastPongAt = Date.now();
+  const maxUnansweredPings = Math.max(
+    1,
+    Math.ceil(LISTENER_PONG_TIMEOUT_MS / LISTENER_HEARTBEAT_INTERVAL_MS),
+  );
+  const watchdog = createMissedPongWatchdog(maxUnansweredPings);
+
   runtime.heartbeatInterval = setInterval(() => {
     if (
       getListenerTransportKind(transport) === "websocket" &&
-      isListenerPongStale(
-        runtime.lastPongAt,
-        Date.now(),
-        LISTENER_PONG_TIMEOUT_MS,
-      )
+      watchdog.shouldTerminate(runtime.lastPongAt)
     ) {
       onStale();
       return;
     }
-    sendPing();
+
+    const sentAt = Date.now();
+    if (sendPing()) {
+      watchdog.recordPing(sentAt);
+    }
   }, LISTENER_HEARTBEAT_INTERVAL_MS);
 }

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -1048,7 +1048,7 @@ export async function startConnectedListenerRuntime(
         runtime.socket?.terminate();
       },
       () => {
-        safeTransportSend(
+        return safeTransportSend(
           transport,
           { type: "ping" },
           "listener_ping_send_failed",


### PR DESCRIPTION
## Summary

- make the outbound listener watchdog count actual unanswered ping probes instead of elapsed wall-clock time
- give a healthy relay a fresh ping after local event-loop starvation or sleep/wake before declaring it stale
- retain the existing three-missed-heartbeat threshold under normal scheduling

## Why

A live Desktop incident on LC 0.29.9 showed all active conversations pause at the same instant while the listener PID remained alive. The local remote-session log records one shared listener reconnect at 19:22:33. Immediately beforehand, Electron's nominal 60-second monitor callback was delayed 117 seconds (19:19:56 to 19:21:53), longer than `LISTENER_PONG_TIMEOUT_MS` (90 seconds).

The current watchdog compares `Date.now()` to the old pong timestamp before sending a new ping. When its own interval is delayed beyond 90 seconds by CPU/event-loop starvation, it therefore terminates a healthy shared socket immediately. The normal close path then clears every conversation runtime; #3522 preserves those runtimes, and this stacked change prevents the false-positive socket recycle in the first place.

The watchdog now advances only when a ping was actually sent and resets when a pong acknowledges the latest probe. A delayed first tick sends a probe rather than treating elapsed local scheduling time as three missed peer responses.

## Stack

- Base: #3522 — preserve in-flight turns across real relay reconnects
- Companion Desktop load fix: letta-ai/letta-cloud#13437 removes the redundant 1 Hz recovery sync loop that contributed to the starvation

## Validation

- `bun test --isolate src/websocket/listener/heartbeat.test.ts src/websocket/listener/auth-lifecycle.test.ts src/websocket/listener/auth-lifecycle-approval-reconnect.test.ts` — 16 passed
- `bun run check` — TypeScript and 11/12 checks passed; the initial Biome failure was this branch's formatting and was corrected by the commit hook. Targeted Biome check passes.
- pre-commit checks passed

Linear: https://linear.app/letta/issue/LET-9601/crazy-fps-dropping-happening-on-latest-desktop-build
