### PR TITLE
chore: upgrade pi-ai for Claude Opus 5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "@letta-ai/letta-code",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.81.1",
+        "@earendil-works/pi-ai": "^0.82.1",
         "@letta-ai/letta-client": "^1.10.2",
         "@letta-ai/trajectory": "0.2.0",
         "@pierre/diffs": "1.2.2",
@@ -114,7 +114,7 @@
 
     "@discoveryjs/json-ext": ["@discoveryjs/json-ext@1.1.0", "", {}, "sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.81.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-hzHE7Z8l5mgJk+ke67Lge0rwS2+wbKJrFKl9o5M1R1rh33+cCT7D1AHz1OAtX5wFs90E1/BTGhyJRTUHaMxGvQ=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.82.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "^0.81.1",
+    "@earendil-works/pi-ai": "^0.82.1",
     "@letta-ai/letta-client": "^1.10.2",
     "@letta-ai/trajectory": "0.2.0",
     "@pierre/diffs": "1.2.2",

--- a/src/backend/pi-model-factory.test.ts
+++ b/src/backend/pi-model-factory.test.ts
@@ -256,13 +256,13 @@ describe("pi model factory", () => {
     }
   });
 
-  test("resolves Anthropic Opus 4.8 from the Pi model catalog", async () => {
-    const resolved = await resolvePiModelForAgent("anthropic/claude-opus-4-8", {
+  test("resolves Anthropic Opus 5 from the Pi model catalog", async () => {
+    const resolved = await resolvePiModelForAgent("anthropic/claude-opus-5", {
       provider_type: "anthropic",
     });
 
     expect(resolved.provider).toBe("anthropic");
-    expect(resolved.model.id).toBe("claude-opus-4-8");
+    expect(resolved.model.id).toBe("claude-opus-5");
     expect(resolved.model.api).toBe("anthropic-messages");
     expect(resolved.model.reasoning).toBe(true);
     expect(resolved.model.contextWindow).toBe(1000000);

--- a/src/cli/components/provider-selector.test.ts
+++ b/src/cli/components/provider-selector.test.ts
@@ -172,13 +172,15 @@ describe("ProviderSelector provider filtering", () => {
     expect(
       filterProviderConfigs(providers, "copilot").map((p) => p.id),
     ).toEqual(["github-copilot"]);
-    // pi-ai 0.81 ships subscription OAuth for radius and xai as well.
+    // Keep the subscription filter aligned with pi-ai's OAuth providers.
     expect(
       filterProviderConfigs(providers, "subscription").map((p) => p.id),
     ).toEqual([
       "anthropic-oauth",
       "github-copilot",
+      "kimi-coding",
       "openai-codex-oauth",
+      "openrouter",
       "radius",
       "xai",
     ]);

--- a/src/providers/local-pi-provider-catalog.test.ts
+++ b/src/providers/local-pi-provider-catalog.test.ts
@@ -130,7 +130,7 @@ describe("local pi provider catalog", () => {
     }
   });
 
-  test("local Anthropic catalog includes upstream Opus 4.8", async () => {
+  test("local Anthropic catalog includes upstream Opus 5", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "local-anthropic-opus-"));
     try {
       await createOrUpdateLocalProvider({
@@ -142,7 +142,7 @@ describe("local pi provider catalog", () => {
 
       const models = await listLocalModels(storageDir);
       expect(
-        models.some((model) => model.handle === "anthropic/claude-opus-4-8"),
+        models.some((model) => model.handle === "anthropic/claude-opus-5"),
       ).toBe(true);
     } finally {
       await rm(storageDir, { recursive: true, force: true });


### PR DESCRIPTION
Upgrades `@earendil-works/pi-ai` from 0.81.1 to 0.82.1, the first release whose Anthropic catalog includes `claude-opus-5`. This keeps Letta Code on the canonical upstream catalog rather than adding a separate local model definition.

The provider regressions now verify that Opus 5 is listed and resolves through the local Anthropic runtime. The expected subscription-provider set is also updated for the Kimi Coding and OpenRouter OAuth providers added upstream in pi-ai 0.82.

Validated with `bun run check`, the focused provider/OAuth suite (71 tests), and `bun run build`.

Closes #3504.