### PR TITLE
fix(slack): avoid repeated bot thread context

### DIFF
--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -447,6 +447,8 @@ export function createSlackAdapter(
         ensureApp,
         resolveUserName: ingress.resolveUserName,
         getKnownUserDisplayName: ingress.getKnownUserDisplayName,
+        getBotUserId: () => botUserId,
+        getBotId: () => botId,
       }),
     onMessage: undefined,
     onControlResponse: undefined,

--- a/src/channels/slack/media.test.ts
+++ b/src/channels/slack/media.test.ts
@@ -248,6 +248,79 @@ test("resolveSlackThreadHistory retains bot-authored Slack replies", async () =>
   ]);
 });
 
+test("resolveSlackThreadHistory returns only unrouted foreign bot replies since the last input", async () => {
+  const { resolveSlackThreadHistory } = await loadSlackMediaModule();
+  const client = {
+    conversations: {
+      history: mock(async () => ({ messages: [] })),
+      replies: mock(async () => ({
+        messages: [
+          {
+            ts: "1712790000.000050",
+            user: "U111",
+            text: "Thread root",
+          },
+          {
+            ts: "1712791000.000055",
+            bot_id: "BDEPLOY",
+            text: "Old deployment update",
+          },
+          {
+            ts: "1712795000.000060",
+            user: "U222",
+            text: "Previous human turn",
+          },
+          {
+            ts: "1712796000.000070",
+            bot_id: "BDEPLOY",
+            text: "Update before a routed bot handoff",
+          },
+          {
+            ts: "1712797000.000080",
+            bot_id: "BHANDOFF",
+            text: "<@ULETTA> investigate the failed deployment",
+          },
+          {
+            ts: "1712798000.000090",
+            bot_id: "BLETTA",
+            text: "Letta reply already stored in the conversation",
+          },
+          {
+            ts: "1712799000.000095",
+            bot_id: "BSTATUS",
+            text: "New status after the handoff",
+          },
+          {
+            ts: "1712800000.000100",
+            user: "U333",
+            text: "Current turn",
+          },
+        ],
+      })),
+    },
+  };
+
+  await expect(
+    resolveSlackThreadHistory({
+      channelId: "C123",
+      threadTs: "1712790000.000050",
+      currentMessageTs: "1712800000.000100",
+      client,
+      include: "unrouted-bot",
+      excludeBotId: "BLETTA",
+      routedBotUserId: "ULETTA",
+      acceptMentionedBots: true,
+    }),
+  ).resolves.toEqual([
+    {
+      text: "New status after the handoff",
+      userId: undefined,
+      botId: "BSTATUS",
+      ts: "1712799000.000095",
+    },
+  ]);
+});
+
 test("resolveSlackCurrentMessageAttachments hydrates files from the exact thread message", async () => {
   const fetchMock = mock(async (input: unknown, init?: RequestInit) => {
     expect(requestUrl(input)).toBe(

--- a/src/channels/slack/media.ts
+++ b/src/channels/slack/media.ts
@@ -10,6 +10,7 @@ import type {
   SlackAttachmentReadClient,
   SlackFileLike,
 } from "./attachment-types";
+import { hasSlackMention } from "./utils";
 
 const MAX_SLACK_ATTACHMENTS = 8;
 const MAX_SLACK_ATTACHMENT_BYTES = 20 * 1024 * 1024;
@@ -64,7 +65,7 @@ export type SlackThreadMessage = {
   attachments?: ChannelMessageAttachment[];
 };
 
-type SlackThreadHistoryEntryKind = "all" | "bot";
+type SlackThreadHistoryEntryKind = "all" | "bot" | "unrouted-bot";
 
 async function mapSlackThreadMessage(
   message: SlackRepliesPageMessage,
@@ -812,6 +813,9 @@ export async function resolveSlackThreadHistory(
     currentMessageTs?: string;
     limit?: number;
     include?: SlackThreadHistoryEntryKind;
+    excludeBotId?: string | null;
+    routedBotUserId?: string | null;
+    acceptMentionedBots?: boolean;
   } & SlackThreadAttachmentParams,
 ): Promise<SlackThreadMessage[]> {
   const maxMessages = params.limit ?? 20;
@@ -835,16 +839,37 @@ export async function resolveSlackThreadHistory(
       })) as SlackRepliesPage;
 
       for (const message of response.messages ?? []) {
-        if (params.include === "bot" && !isNonEmptyString(message.bot_id)) {
-          continue;
-        }
-        if (!hasSlackThreadMessageContent(message, attachmentOptions)) {
-          continue;
-        }
         if (params.currentMessageTs && message.ts === params.currentMessageTs) {
           continue;
         }
         if (message.ts === params.threadTs) {
+          continue;
+        }
+
+        const isBotMessage = isNonEmptyString(message.bot_id);
+        if (params.include === "unrouted-bot") {
+          if (!isBotMessage) {
+            retained.length = 0;
+            continue;
+          }
+          if (
+            isNonEmptyString(params.excludeBotId) &&
+            message.bot_id === params.excludeBotId
+          ) {
+            continue;
+          }
+          if (
+            params.acceptMentionedBots === true &&
+            hasSlackMention(message.text ?? "", params.routedBotUserId ?? null)
+          ) {
+            retained.length = 0;
+            continue;
+          }
+        }
+        if (params.include === "bot" && !isNonEmptyString(message.bot_id)) {
+          continue;
+        }
+        if (!hasSlackThreadMessageContent(message, attachmentOptions)) {
           continue;
         }
 

--- a/src/channels/slack/thread-context.test.ts
+++ b/src/channels/slack/thread-context.test.ts
@@ -135,8 +135,8 @@ test("slack adapter rehydrates bot-authored Slack thread context on existing rou
 
   await adapter.start();
 
-  // Bot-only filtering now happens inside resolveSlackThreadHistory via the
-  // include: "bot" parameter, so the mock models the already-filtered result.
+  // Incremental bot filtering happens inside resolveSlackThreadHistory, so the
+  // mock models the already-filtered result.
   resolveSlackThreadHistoryMock.mockResolvedValueOnce([
     {
       text: "Automated deployment note since the last human turn",
@@ -176,7 +176,12 @@ test("slack adapter rehydrates bot-authored Slack thread context on existing rou
   expect(resolveSlackThreadStarterMock).not.toHaveBeenCalled();
   expect(resolveSlackThreadHistoryMock).toHaveBeenCalledTimes(1);
   expect(resolveSlackThreadHistoryMock).toHaveBeenCalledWith(
-    expect.objectContaining({ include: "bot" }),
+    expect.objectContaining({
+      include: "unrouted-bot",
+      excludeBotId: "B0AS42PTEAX",
+      routedBotUserId: "U0AS42PTEAX",
+      acceptMentionedBots: false,
+    }),
   );
   expect(resolveSlackChannelHistoryMock).not.toHaveBeenCalled();
 });
@@ -322,6 +327,6 @@ test("slack adapter hydrates exact thread_broadcast attachments before prompt fo
     }),
   );
   expect(resolveSlackThreadHistoryMock).toHaveBeenCalledWith(
-    expect.objectContaining({ include: "bot" }),
+    expect.objectContaining({ include: "unrouted-bot" }),
   );
 });

--- a/src/channels/slack/thread-context.ts
+++ b/src/channels/slack/thread-context.ts
@@ -82,6 +82,8 @@ export async function prepareSlackInboundMessage(params: {
     userId: string | undefined,
   ) => Promise<string | undefined>;
   getKnownUserDisplayName: (userId: string) => string | undefined;
+  getBotUserId: () => string | null;
+  getBotId: () => string | null;
 }): Promise<InboundChannelMessage> {
   const { msg, config } = params;
   if (
@@ -139,7 +141,14 @@ export async function prepareSlackInboundMessage(params: {
         client: app.client,
         currentMessageTs: msg.messageId,
         limit: INITIAL_SLACK_THREAD_HISTORY_LIMIT,
-        include: !isFirstRouteTurn ? "bot" : "all",
+        include: !isFirstRouteTurn ? "unrouted-bot" : "all",
+        ...(!isFirstRouteTurn
+          ? {
+              excludeBotId: params.getBotId(),
+              routedBotUserId: params.getBotUserId(),
+              acceptMentionedBots: config.allowBots === "mentions",
+            }
+          : {}),
         ...attachmentParams,
       })
     : await resolveSlackChannelHistory({


### PR DESCRIPTION
## Summary
- exclude the Letta Slack bot from established-thread context hydration
- include only foreign bot updates since the last routed human or bot input
- preserve the existing first-route thread bootstrap and attachment behavior

This prevents prior MessageChannel replies from being copied back into every later user turn while still surfacing otherwise-unrouted bot updates.

## Testing
- bun test src/channels/slack/media.test.ts
- bun test src/channels/slack/thread-context.test.ts
- bun run check