### PR TITLE
fix(channels): compact persisted channel reminders

### DIFF
--- a/src/agent/send-message-stream-channel-envelope.test.ts
+++ b/src/agent/send-message-stream-channel-envelope.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { Stream } from "@letta-ai/letta-client/core/streaming";
+import type { LettaStreamingResponse } from "@letta-ai/letta-client/resources/agents/messages";
+import type { MessageCreateParams } from "@letta-ai/letta-client/resources/conversations/messages";
+import type { Backend } from "@/backend";
+import { clearDynamicMessageChannelToolCache } from "@/channels/message-tool";
+import { ChannelRegistry, getChannelRegistry } from "@/channels/registry";
+import type { ChannelAdapter, InboundChannelMessage } from "@/channels/types";
+import { formatChannelNotification } from "@/channels/xml";
+import {
+  clearCapturedToolExecutionContexts,
+  clearTools,
+  prepareToolExecutionContextForModel,
+} from "@/tools/manager";
+import { sendMessageStreamWithBackend } from "./message";
+
+function createRunningSlackAdapter(): ChannelAdapter {
+  return {
+    id: "slack:acct-slack",
+    channelId: "slack",
+    accountId: "acct-slack",
+    name: "Slack",
+    start: async () => {},
+    stop: async () => {},
+    isRunning: () => true,
+    sendMessage: async () => ({ messageId: "msg-1" }),
+    sendDirectReply: async () => {},
+  };
+}
+
+describe("channel request envelope", () => {
+  afterEach(async () => {
+    const registry = getChannelRegistry();
+    if (registry) {
+      await registry.stopAll();
+    }
+    clearDynamicMessageChannelToolCache();
+    clearCapturedToolExecutionContexts();
+    clearTools();
+  });
+
+  test("sends a compact Slack reminder with reply guidance in MessageChannel", async () => {
+    const registry = new ChannelRegistry();
+    registry.registerAdapter(createRunningSlackAdapter());
+
+    const inboundMessage: InboundChannelMessage = {
+      channel: "slack",
+      accountId: "acct-slack",
+      chatId: "C123",
+      chatType: "channel",
+      senderId: "U123",
+      senderName: "Cameron",
+      messageId: "1712800000.000100",
+      threadId: "1712790000.000050",
+      text: "Can you investigate this?",
+      timestamp: Date.now(),
+    };
+    const preparedToolContext = await prepareToolExecutionContextForModel(
+      "anthropic/claude-opus-4-1-20250805",
+      {
+        clientToolAllowlist: ["MessageChannel"],
+        channelToolScope: {
+          channels: [{ channelId: "slack", accountId: "acct-slack" }],
+        },
+      },
+    );
+
+    let recordedBody: MessageCreateParams | undefined;
+    const stream = {
+      async *[Symbol.asyncIterator]() {},
+    } as unknown as Stream<LettaStreamingResponse>;
+    const backend = {
+      createConversationMessageStream: async (
+        _conversationId: string,
+        body: MessageCreateParams,
+      ) => {
+        recordedBody = body;
+        return stream;
+      },
+    } as unknown as Backend;
+
+    await sendMessageStreamWithBackend(
+      backend,
+      "conv-slack",
+      [{ role: "user", content: formatChannelNotification(inboundMessage) }],
+      {
+        streamTokens: true,
+        background: true,
+        skillSources: [],
+        preparedToolContext,
+      },
+    );
+
+    const requestText = JSON.stringify(recordedBody?.messages);
+    const messageChannel = recordedBody?.client_tools?.find(
+      (tool) => tool.name === "MessageChannel",
+    );
+    const replyGuidance =
+      "Replies to routed Slack threads stay in the current thread automatically.";
+
+    expect(requestText).toContain("External slack turn.");
+    expect(requestText).toContain('source=\\"slack\\"');
+    expect(requestText).toContain('chat_id=\\"C123\\"');
+    expect(requestText).toContain('thread_id=\\"1712790000.000050\\"');
+    expect(requestText).not.toContain(replyGuidance);
+    expect(requestText).not.toContain('action=\\"react\\"');
+
+    expect(messageChannel).toBeDefined();
+    if (!messageChannel?.description) {
+      throw new Error("MessageChannel tool is missing its description");
+    }
+    expect(messageChannel.description).toContain(replyGuidance);
+    expect(messageChannel.description.split(replyGuidance)).toHaveLength(2);
+    expect(messageChannel.description).toContain(
+      "For Slack requests that require nontrivial work or several tool calls",
+    );
+  });
+});

--- a/src/channels/message-tool-schema.test.ts
+++ b/src/channels/message-tool-schema.test.ts
@@ -12,7 +12,7 @@ const SLACK_WORK_ACKNOWLEDGEMENT_GUIDANCE_PREFIX =
   "For Slack requests that require nontrivial work or several tool calls";
 
 function createRunningAdapter(
-  channelId: "slack" | "telegram",
+  channelId: string,
   accountId: string,
 ): ChannelAdapter {
   return {
@@ -124,6 +124,9 @@ describe("buildDynamicMessageChannelSchema", () => {
       SLACK_WORK_ACKNOWLEDGEMENT_GUIDANCE_PREFIX,
     );
     expect(resolved.description).toContain(
+      'On Slack, this tool also supports action="react"',
+    );
+    expect(resolved.description).toContain(
       'Use action="download-file" with channel, chat_id, attachmentId, and messageId',
     );
     expect(resolved.description).toContain(
@@ -184,6 +187,9 @@ describe("buildDynamicMessageChannelSchema", () => {
     expect(resolved.description).toContain(
       SLACK_WORK_ACKNOWLEDGEMENT_GUIDANCE_PREFIX,
     );
+    expect(resolved.description).toContain(
+      "Replies to routed Slack threads stay in the current thread automatically.",
+    );
     expect(resolved.description).not.toContain("Telegram");
     expect(properties.channel?.enum).toEqual(["slack"]);
     expect(properties.action?.enum).toEqual([
@@ -192,6 +198,37 @@ describe("buildDynamicMessageChannelSchema", () => {
       "upload-file",
       "download-file",
     ]);
+  });
+
+  test("moves channel-specific reply guidance into the tool description", async () => {
+    const registry = new ChannelRegistry();
+    registry.registerAdapter(createRunningAdapter("discord", "acct-discord"));
+    registry.registerAdapter(createRunningAdapter("whatsapp", "acct-whatsapp"));
+    registry.registerAdapter(createRunningAdapter("signal", "acct-signal"));
+
+    const resolved = await buildDynamicMessageChannelToolDefinition(
+      "Base MessageChannel description.",
+      {
+        type: "object",
+        properties: {
+          action: { type: "string" },
+          channel: { type: "string" },
+          chat_id: { type: "string" },
+        },
+        required: ["action", "channel", "chat_id"],
+        additionalProperties: false,
+      },
+    );
+
+    expect(resolved.description).toContain(
+      "Discord reactions accept native Unicode emoji",
+    );
+    expect(resolved.description).toContain(
+      "Voice memo/audio uploads must be Ogg/Opus",
+    );
+    expect(resolved.description).toContain(
+      "Replies are sent as the linked Signal account",
+    );
   });
 
   test("does not add Slack work acknowledgement guidance to Telegram-only scoped descriptions", async () => {

--- a/src/channels/message-tool.ts
+++ b/src/channels/message-tool.ts
@@ -148,8 +148,31 @@ function buildDynamicMessageChannelDescriptionFromDiscovery(
   const slackAttachmentDownload = discovery.activeChannels.includes("slack")
     ? '\n\nSlack attachments that exceed the automatic download limit include an exact recovery instruction. Use action="download-file" with channel, chat_id, attachmentId, and messageId from that instruction. The action saves the file in the normal Slack inbound attachment directory and returns its local_path. Downloads that outlast the synchronous window return a task_id instead; wait for the local_path with TaskOutput (block: true, timeout: 600000) or cancel with TaskStop.'
     : "";
+  const slackThreadGuidance =
+    scopedChannels.length > 0 && discovery.activeChannels.includes("slack")
+      ? "\n\nReplies to routed Slack threads stay in the current thread automatically."
+      : "";
+  const telegramTopicGuidance =
+    scopedChannels.length > 0 && discovery.activeChannels.includes("telegram")
+      ? "\n\nReplies to routed Telegram topics stay in the current topic automatically."
+      : "";
+  const slackCapabilities = discovery.activeChannels.includes("slack")
+    ? '\n\nOn Slack, this tool also supports action="react" with emoji + messageId, action="upload-file" with media, and action="download-file" with attachmentId + messageId.'
+    : "";
+  const telegramCapabilities = discovery.activeChannels.includes("telegram")
+    ? '\n\nOn Telegram, this tool also supports action="react" with emoji + messageId and action="upload-file" with media.'
+    : "";
+  const discordCapabilities = discovery.activeChannels.includes("discord")
+    ? '\n\nOn Discord, this tool also supports action="react" with emoji + messageId and action="upload-file" with media. Discord reactions accept native Unicode emoji and custom emoji syntax like <:name:id>.'
+    : "";
+  const whatsappCapabilities = discovery.activeChannels.includes("whatsapp")
+    ? '\n\nOn WhatsApp, this tool also supports action="react" with emoji + messageId and action="upload-file" with media. Voice memo/audio uploads must be Ogg/Opus (.ogg, .oga, or .opus), not MP3/M4A/WAV. Replies are sent as the linked WhatsApp number.'
+    : "";
+  const signalCapabilities = discovery.activeChannels.includes("signal")
+    ? '\n\nOn Signal, this tool also supports action="react" with emoji + messageId and action="upload-file" with media. Replies are sent as the linked Signal account through signal-cli-rest-api.'
+    : "";
 
-  return `${description}${scopedReplyContract}${slackWorkAcknowledgement}${slackAttachmentDownload}\n\nCurrently active channels: ${channelList}. Available actions across the active channels: ${actionList}. The JSON schema reflects the currently active channel plugins.`;
+  return `${description}${scopedReplyContract}${slackThreadGuidance}${telegramTopicGuidance}${slackCapabilities}${slackWorkAcknowledgement}${slackAttachmentDownload}${telegramCapabilities}${discordCapabilities}${whatsappCapabilities}${signalCapabilities}\n\nCurrently active channels: ${channelList}. Available actions across the active channels: ${actionList}. The JSON schema reflects the currently active channel plugins.`;
 }
 
 function pruneInactiveChannelGuidance(

--- a/src/channels/telegram-adapter-runtime.test.ts
+++ b/src/channels/telegram-adapter-runtime.test.ts
@@ -109,7 +109,7 @@ test("telegram channel starts through service and routes inbound topic messages 
   });
   const content = (deliveries[0] as { content: Array<{ text: string }> })
     .content;
-  expect(content[0]?.text).toContain("external telegram turn");
+  expect(content[0]?.text).toContain("External telegram turn");
   expect(content[1]?.text).toContain('source="telegram"');
   expect(content[1]?.text).toContain('chat_id="-100123"');
   expect(content[1]?.text).toContain('account_id="telegram-e2e"');

--- a/src/channels/xml-discord.test.ts
+++ b/src/channels/xml-discord.test.ts
@@ -20,7 +20,7 @@ describe("discord xml", () => {
     expect(xml).toContain('source="discord"');
   });
 
-  test("reminder text includes discord-specific capability hints", () => {
+  test("keeps discord capability hints out of the compact reminder", () => {
     const message: InboundChannelMessage = {
       channel: "discord",
       chatId: "channel-123",
@@ -31,11 +31,12 @@ describe("discord xml", () => {
       timestamp: Date.now(),
     };
     const reminder = buildChannelReminderText(message);
-    expect(reminder).toContain("discord");
-    expect(reminder.toLowerCase()).toContain("react");
-    expect(reminder).toContain("upload-file");
-    expect(reminder).toContain("native Unicode emoji");
-    expect(reminder).toContain("<:name:id>");
+    expect(reminder).toContain("External discord turn");
+    expect(reminder).toContain("scoped MessageChannel instructions");
+    expect(reminder).not.toContain("react");
+    expect(reminder).not.toContain("upload-file");
+    expect(reminder).not.toContain("native Unicode emoji");
+    expect(reminder).not.toContain("<:name:id>");
   });
 
   test("thread metadata appears in XML as thread_id", () => {

--- a/src/channels/xml.test.ts
+++ b/src/channels/xml.test.ts
@@ -7,9 +7,6 @@ import {
   formatChannelNotification,
 } from "@/channels/xml";
 
-const SLACK_WORK_ACKNOWLEDGEMENT_GUIDANCE_PREFIX =
-  "For Slack requests that require nontrivial work or several tool calls";
-
 function expectTextParts(
   content: MessageCreate["content"],
 ): [{ type: "text"; text: string }, { type: "text"; text: string }] {
@@ -51,7 +48,7 @@ describe("formatChannelNotification", () => {
     expect(notificationPart.text).toContain("</channel-notification>");
   });
 
-  test("builds a reminder part describing reply semantics", () => {
+  test("builds a compact reminder and leaves reply semantics to the scoped tool", () => {
     const msg: InboundChannelMessage = {
       channel: "telegram",
       chatId: "12345",
@@ -63,30 +60,16 @@ describe("formatChannelNotification", () => {
     const reminder = buildChannelReminderText(msg);
 
     expect(reminder).toContain("<system-reminder>");
-    expect(reminder).toContain(
-      "Plain assistant text is not delivered to the user.",
-    );
-    expect(reminder).toContain(
-      'If you should reply to the external user, use MessageChannel with action="send", channel="telegram", and chat_id="12345"',
-    );
-    expect(reminder).toContain(
-      "If no user-visible response is appropriate, do not call MessageChannel. Do not send an empty acknowledgement.",
-    );
-    expect(reminder).toContain(
-      'For lightweight acknowledgement, prefer MessageChannel action="react" when supported.',
-    );
-    expect(reminder).toContain(
-      "If the useful response belongs later, schedule the follow-up instead of sending a placeholder.",
-    );
-    expect(reminder).not.toContain(SLACK_WORK_ACKNOWLEDGEMENT_GUIDANCE_PREFIX);
-    expect(reminder).toContain(
-      "Do not produce a plain text assistant response as the user-visible reply.",
-    );
-    expect(reminder).toContain('action="react"');
+    expect(reminder).toContain("External telegram turn.");
+    expect(reminder).toContain("Plain assistant text is not delivered");
+    expect(reminder).toContain("scoped MessageChannel instructions");
     expect(reminder).toContain("Current local time on this device:");
+    expect(reminder).not.toContain('chat_id="12345"');
+    expect(reminder).not.toContain('action="react"');
+    expect(reminder.length).toBeLessThan(400);
   });
 
-  test("includes account id in notification xml without requiring it in reminder", () => {
+  test("keeps account and chat routing in notification xml rather than the reminder", () => {
     const msg: InboundChannelMessage = {
       channel: "telegram",
       accountId: "account-1",
@@ -99,10 +82,9 @@ describe("formatChannelNotification", () => {
     const reminder = buildChannelReminderText(msg);
     const xml = buildChannelNotificationXml(msg);
 
-    expect(reminder).toContain(
-      'If you should reply to the external user, use MessageChannel with action="send", channel="telegram", and chat_id="12345"',
-    );
+    expect(reminder).not.toContain('chat_id="12345"');
     expect(reminder).not.toContain('accountId="account-1"');
+    expect(xml).toContain('chat_id="12345"');
     expect(xml).toContain('account_id="account-1"');
   });
 
@@ -160,7 +142,7 @@ describe("formatChannelNotification", () => {
     const reminder = buildChannelReminderText(msg);
     const xml = buildChannelNotificationXml(msg);
 
-    expect(reminder).toContain('action="download-file"');
+    expect(reminder).not.toContain('action="download-file"');
     expect(reminder).not.toContain("attachment local_path values");
     expect(xml).toContain('download_status="not_downloaded"');
     expect(xml).toContain('download_reason="exceeds_auto_download_limit"');
@@ -205,7 +187,7 @@ describe("formatChannelNotification", () => {
     expect(xml).not.toContain("The tool downloads the file");
   });
 
-  test("adds Slack thread guidance for channel notifications", () => {
+  test("keeps Slack thread and acknowledgement guidance out of persisted reminders", () => {
     const msg: InboundChannelMessage = {
       channel: "slack",
       chatId: "C123",
@@ -219,15 +201,16 @@ describe("formatChannelNotification", () => {
 
     const reminder = buildChannelReminderText(msg);
 
-    expect(reminder).toContain("stay in the same Slack thread automatically");
-    expect(reminder).toContain(SLACK_WORK_ACKNOWLEDGEMENT_GUIDANCE_PREFIX);
-    expect(reminder).toContain(
-      'send a short MessageChannel action="send" acknowledgement before starting other tools',
+    expect(reminder).not.toContain(
+      "stay in the same Slack thread automatically",
+    );
+    expect(reminder).not.toContain(
+      "For Slack requests that require nontrivial work",
     );
     expect(reminder).not.toContain("reply_to_message_id");
   });
 
-  test("adds WhatsApp media guidance for voice memo uploads", () => {
+  test("keeps WhatsApp media guidance out of persisted reminders", () => {
     const msg: InboundChannelMessage = {
       channel: "whatsapp",
       chatId: "15551234567@s.whatsapp.net",
@@ -238,9 +221,9 @@ describe("formatChannelNotification", () => {
 
     const reminder = buildChannelReminderText(msg);
 
-    expect(reminder).toContain("Ogg/Opus");
-    expect(reminder).toContain(".ogg");
-    expect(reminder).toContain("not MP3/M4A/WAV");
+    expect(reminder).not.toContain("Ogg/Opus");
+    expect(reminder).not.toContain(".ogg");
+    expect(reminder).not.toContain("not MP3/M4A/WAV");
   });
 
   test("escapes XML special characters in notification text without over-escaping quotes", () => {

--- a/src/channels/xml.ts
+++ b/src/channels/xml.ts
@@ -63,66 +63,14 @@ function hasNotificationAttachmentPaths(msg: InboundChannelMessage): boolean {
 export function buildChannelReminderText(msg: InboundChannelMessage): string {
   const localTime = escapeXmlText(getLocalTime());
   const escapedChannel = escapeXmlText(msg.channel);
-  const escapedChatId = escapeXmlText(msg.chatId);
-  const threadLine =
-    (msg.channel === "slack" || msg.channel === "telegram") &&
-    msg.chatType === "channel" &&
-    (msg.threadId ?? msg.messageId)?.trim()
-      ? `Replies sent with MessageChannel will stay in the same ${msg.channel === "telegram" ? "Telegram topic" : "Slack thread"} automatically.`
-      : null;
 
   const lines = [
     SYSTEM_REMINDER_OPEN,
-    `This is an external ${escapedChannel} turn. Plain assistant text is not delivered to the user.`,
-    `If you should reply to the external user, use MessageChannel with action="send", channel="${escapedChannel}", and chat_id="${escapedChatId}". Put the user-visible reply in message.`,
-    "If no user-visible response is appropriate, do not call MessageChannel. Do not send an empty acknowledgement.",
-    'For lightweight acknowledgement, prefer MessageChannel action="react" when supported. If the useful response belongs later, schedule the follow-up instead of sending a placeholder.',
-    "Do not produce a plain text assistant response as the user-visible reply.",
-    "On supported channels, MessageChannel can also send proactively using channel + target (and accountId when needed).",
-    "Only pass replyTo if you intentionally want the platform's quote/reply UI.",
+    `External ${escapedChannel} turn. Plain assistant text is not delivered; follow the scoped MessageChannel instructions to respond.`,
     `Current local time on this device: ${localTime}`,
     SYSTEM_REMINDER_CLOSE,
   ];
 
-  if (threadLine) {
-    lines.splice(lines.length - 2, 0, threadLine);
-  }
-  if (msg.channel === "slack") {
-    lines.splice(
-      lines.length - 2,
-      0,
-      'On Slack, MessageChannel also supports action="react" with emoji + messageId, action="upload-file" with media, and action="download-file" with attachmentId + messageId.',
-      'For Slack requests that require nontrivial work or several tool calls, send a short MessageChannel action="send" acknowledgement before starting other tools. This gives the Slack user verbal acknowledgement and a View in web link. Do not do this for no-ops, reaction-only responses, or simple no-tool answers.',
-    );
-  }
-  if (msg.channel === "telegram") {
-    lines.splice(
-      lines.length - 2,
-      0,
-      'On Telegram, MessageChannel also supports action="react" with emoji + messageId, and action="upload-file" with media.',
-    );
-  }
-  if (msg.channel === "discord") {
-    lines.splice(
-      lines.length - 2,
-      0,
-      'On Discord, MessageChannel also supports action="react" with emoji + messageId, and action="upload-file" with media. Discord reactions accept native Unicode emoji and custom emoji syntax like <:name:id>.',
-    );
-  }
-  if (msg.channel === "whatsapp") {
-    lines.splice(
-      lines.length - 2,
-      0,
-      'On WhatsApp, MessageChannel also supports action="react" with emoji + messageId, and action="upload-file" with media. Voice memo/audio uploads must be Ogg/Opus (.ogg, .oga, or .opus), not MP3/M4A/WAV. Replies are sent as the linked WhatsApp number.',
-    );
-  }
-  if (msg.channel === "signal") {
-    lines.splice(
-      lines.length - 2,
-      0,
-      'On Signal, MessageChannel also supports action="react" with emoji + messageId, and action="upload-file" with media. Replies are sent as the linked Signal account through signal-cli-rest-api.',
-    );
-  }
   if (hasNotificationAttachmentPaths(msg)) {
     lines.splice(
       lines.length - 2,


### PR DESCRIPTION
## Summary
- reduce the reminder persisted with every inbound channel message to a short external-turn marker plus local time
- move channel-specific reply, thread, media, and acknowledgement guidance into the scoped MessageChannel tool description
- keep notification routing metadata and per-attachment recovery instructions unchanged

The change applies to every channel using the shared formatter. Representative reminders drop from roughly 900-1,500 characters to about 230 characters per turn.

## Testing
- bun test src/channels/xml.test.ts src/channels/message-tool-schema.test.ts
- bun run check