### PR TITLE
fix(slack): enforce loading message limit

### DIFF
--- a/src/channels/slack/adapter-test-harness.ts
+++ b/src/channels/slack/adapter-test-harness.ts
@@ -208,6 +208,17 @@ export class FakeSlackWriteClient {
   readonly assistant = {
     threads: {
       setStatus: mock(async (args: Record<string, unknown>) => {
+        const loadingMessages = args.loading_messages;
+        if (
+          Array.isArray(loadingMessages) &&
+          loadingMessages.some(
+            (message) => typeof message === "string" && message.length > 50,
+          )
+        ) {
+          throw new Error(
+            "invalid_arguments: loading_messages entries must be 50 characters or fewer",
+          );
+        }
         return FakeSlackWriteClient.setStatusHandler
           ? FakeSlackWriteClient.setStatusHandler(args)
           : { ok: true };

--- a/src/channels/slack/progress.ts
+++ b/src/channels/slack/progress.ts
@@ -8,7 +8,7 @@ import { isNonEmptyString } from "./public-utils";
 export const SLACK_ASSISTANT_STARTUP_STATUS = "is thinking...";
 export const SLACK_ASSISTANT_WORKING_STATUS = "is working...";
 
-const SLACK_STATUS_TEXT_MAX = 300;
+const SLACK_LOADING_MESSAGE_MAX = 50;
 
 export function sanitizeSlackStatusText(
   text: string,
@@ -44,7 +44,7 @@ export function resolveSlackConcreteActivity(
   if (event.kind === "command" && isNonEmptyString(event.command)) {
     return sanitizeSlackStatusText(
       formatSlackToolNameForDisplay(event.command),
-      SLACK_STATUS_TEXT_MAX,
+      SLACK_LOADING_MESSAGE_MAX,
     );
   }
   if (
@@ -61,7 +61,7 @@ export function resolveSlackConcreteActivity(
     }
     const sanitized = sanitizeSlackStatusText(
       description,
-      SLACK_STATUS_TEXT_MAX,
+      SLACK_LOADING_MESSAGE_MAX,
     );
     if (sanitized) {
       return sanitized;

--- a/src/channels/slack/status-controller.test.ts
+++ b/src/channels/slack/status-controller.test.ts
@@ -127,6 +127,40 @@ test("slack status event table: concrete descriptions replace in place and gener
   );
 });
 
+test("slack loading messages respect the API's 50-character limit", async () => {
+  const adapter = await createStartedSlackAdapter();
+  const source = createSlackTurnSource();
+
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    kind: "tool",
+    state: "started",
+    message: "Running tool",
+    toolName: "Bash",
+    toolDetails: "a".repeat(50),
+    sources: [source],
+  });
+  await adapter.handleTurnProgressEvent?.({
+    type: "progress",
+    kind: "tool",
+    state: "started",
+    message: "Running tool",
+    toolName: "Bash",
+    toolDetails: "b".repeat(51),
+    sources: [source],
+  });
+
+  const client = getSlackWriteClient();
+  expect(client.assistant.threads.setStatus).toHaveBeenNthCalledWith(
+    1,
+    expect.objectContaining({ loading_messages: ["a".repeat(50)] }),
+  );
+  expect(client.assistant.threads.setStatus).toHaveBeenNthCalledWith(
+    2,
+    expect.objectContaining({ loading_messages: [`${"b".repeat(47)}...`] }),
+  );
+});
+
 test("slack status event table: concurrent title swaps are sent in event order", async () => {
   const adapter = await createStartedSlackAdapter();
   const source = createSlackTurnSource();


### PR DESCRIPTION
## Summary
- cap assistant loading messages at Slack’s 50-character API limit so long tool activity no longer causes invalid_arguments failures
- make the Slack test client reject oversized loading messages and cover both the 50- and 51-character boundaries
- verified with the focused status tests and the full check suite

👾 Generated with [Letta Code](https://letta.com)