### PR TITLE
fix(local): stop duplicate retries after provider exhaustion

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -22,7 +22,7 @@
   "src/cli/mods/local-mod-loader.test.ts": 1043,
   "src/cli/reflection-transcript.test.ts": 1084,
   "src/cli/subcommands/skills.ts": 1264,
-  "src/headless.ts": 5243,
+  "src/headless.ts": 5231,
   "src/hooks/integration.test.ts": 1147,
   "src/index.ts": 2798,
   "src/mods/learning-harness.ts": 2434,

--- a/src/agent/approval-recovery.ts
+++ b/src/agent/approval-recovery.ts
@@ -19,6 +19,7 @@ export interface RunErrorInfo {
   error_type?: string;
   message?: string;
   detail?: string;
+  retryable?: boolean;
   run_id?: string;
 }
 
@@ -63,12 +64,14 @@ type RunErrorMetadata =
       error_type?: string;
       message?: string;
       detail?: string;
+      retryable?: boolean;
       run_id?: string;
       error?: {
         type?: string;
         error_type?: string;
         message?: string;
         detail?: string;
+        retryable?: boolean;
         run_id?: string;
       };
     }
@@ -91,12 +94,19 @@ export async function fetchRunErrorInfo(
         nestedError?.type,
       message: metaError?.message ?? nestedError?.message,
       detail: metaError?.detail ?? nestedError?.detail,
+      retryable:
+        typeof metaError?.retryable === "boolean"
+          ? metaError.retryable
+          : typeof nestedError?.retryable === "boolean"
+            ? nestedError.retryable
+            : undefined,
       run_id: metaError?.run_id ?? nestedError?.run_id ?? runId,
     };
 
-    return errorInfo.error_type || errorInfo.message || errorInfo.detail
-      ? errorInfo
-      : null;
+    const hasErrorInfo = Boolean(
+      errorInfo.error_type || errorInfo.message || errorInfo.detail,
+    );
+    return hasErrorInfo || errorInfo.retryable !== undefined ? errorInfo : null;
   } catch {
     return null;
   }

--- a/src/agent/turn-recovery-policy.test.ts
+++ b/src/agent/turn-recovery-policy.test.ts
@@ -287,6 +287,15 @@ describe("provider detail retry helpers", () => {
     expect(
       shouldRetryPostStreamRunError({
         stopReason: "llm_api_error",
+        errorType: "llm_error",
+        detail:
+          'Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"You can retry your request."}}',
+        retryable: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRetryPostStreamRunError({
+        stopReason: "llm_api_error",
         detail: "unclassified provider transport failure",
       }),
     ).toBe(true);

--- a/src/backend/dev/local-provider-errors.ts
+++ b/src/backend/dev/local-provider-errors.ts
@@ -15,6 +15,31 @@ export interface LocalProviderErrorInfo {
   stop_reason: "llm_api_error" | "error";
 }
 
+export class LocalProviderRetryExhaustedError extends Error {
+  readonly attempts: number;
+  readonly detail: string;
+
+  constructor(cause: unknown, attempts: number) {
+    const causeMessage = fallbackErrorMessage(cause);
+    super(
+      `Local provider retry budget exhausted after ${attempts} attempts: ${causeMessage}`,
+    );
+    this.name = "LocalProviderRetryExhaustedError";
+    this.attempts = attempts;
+    this.detail = localProviderErrorDetail(cause);
+    (this as Error & { cause?: unknown }).cause = cause;
+  }
+}
+
+function isLocalProviderRetryExhaustedError(
+  error: unknown,
+): error is LocalProviderRetryExhaustedError {
+  return (
+    error instanceof LocalProviderRetryExhaustedError ||
+    (isRecord(error) && error.name === "LocalProviderRetryExhaustedError")
+  );
+}
+
 const LOCAL_PROVIDER_MAX_RETRY_DELAY_MS = 60_000;
 const RETRYABLE_LOCAL_PROVIDER_DETAIL_PATTERNS = [
   "server_error",
@@ -162,6 +187,7 @@ function statusCode(error: unknown): number | undefined {
 
 export function isRetryableLocalProviderError(error: unknown): boolean {
   if (isContextWindowOverflowError(error)) return false;
+  if (isLocalProviderRetryExhaustedError(error)) return false;
 
   const detail = localProviderErrorDetail(error);
   const status = statusCode(error);
@@ -192,9 +218,20 @@ function isLikelyProviderError(error: unknown, retryable: boolean): boolean {
 export function normalizeLocalProviderError(
   error: unknown,
 ): LocalProviderErrorInfo {
-  const retryable = isRetryableLocalProviderError(error);
   const detail = localProviderErrorDetail(error);
   const message = fallbackErrorMessage(error);
+
+  if (isLocalProviderRetryExhaustedError(error)) {
+    return {
+      message,
+      detail,
+      error_type: "llm_error",
+      retryable: false,
+      stop_reason: "llm_api_error",
+    };
+  }
+
+  const retryable = isRetryableLocalProviderError(error);
   const isProviderError = isLikelyProviderError(error, retryable);
   return {
     message,
@@ -228,7 +265,35 @@ export function localProviderRetryDelayMs(
   );
 }
 
+function isOpenAICodexProviderError(error: unknown): boolean {
+  if (!isRecord(error) || !isRecord(error.assistant)) return false;
+  return (
+    error.assistant.provider === "openai-codex" ||
+    error.assistant.api === "openai-codex-responses"
+  );
+}
+
+function openAICodexRetryMessage(error: unknown): string | undefined {
+  if (!isOpenAICodexProviderError(error)) return undefined;
+  const message = fallbackErrorMessage(error);
+  const webSocketClose = message.match(/WebSocket closed(?:\s+(\d+))?/i);
+  if (webSocketClose) {
+    const code = webSocketClose[1] ? ` (${webSocketClose[1]})` : "";
+    return `OpenAI Codex WebSocket closed${code}`;
+  }
+
+  if (/\bCodex error\b/i.test(message)) {
+    const backendCode =
+      message.match(/"code"\s*:\s*"([^"]+)"/)?.[1] ??
+      message.match(/"type"\s*:\s*"([^"]+)"/)?.[1];
+    return `OpenAI Codex backend ${backendCode ?? "error"}`;
+  }
+
+  return undefined;
+}
+
 export function localProviderRetryMessage(error: unknown): string {
   const status = statusCode(error);
-  return `${status !== undefined ? `HTTP ${status}: ` : ""}${fallbackErrorMessage(error)}`;
+  const message = openAICodexRetryMessage(error) ?? fallbackErrorMessage(error);
+  return `${status !== undefined ? `HTTP ${status}: ` : ""}${message}`;
 }

--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -650,6 +650,7 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
     const restoreEnv = applyPiEnvOverrides(resolved.envOverrides);
     const llmStartedAt = Date.now();
     let llmEnded = false;
+    let emittedModelOutput = false;
     const emitLlmEnd = async (
       info: Omit<
         LlmEndInfo,
@@ -683,6 +684,8 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
       let finalMessage: AssistantMessage | undefined;
       let finalLocalMessage: LocalAssistantMessage | undefined;
       for await (const part of result) {
+        const providerEvent = providerStreamPart(part);
+        if (isModelOutputEvent(providerEvent)) emittedModelOutput = true;
         if (part.type === "error") {
           const error = new PiProviderError(part.error);
           if (
@@ -698,7 +701,7 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
           finalLocalMessage = toLocalAssistantMessage(part.message, input);
           yield providerLocalMessage(finalLocalMessage);
         }
-        yield providerStreamPart(part);
+        yield providerEvent;
       }
 
       if (streamError) throw streamError;
@@ -757,6 +760,7 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
         const endError = llmEndErrorFromError(error, {
           forceNonRetryable:
             retryOptions.terminalRetryableProviderFailure &&
+            !emittedModelOutput &&
             isRetryableLocalProviderError(error),
         });
         await emitLlmEnd({

--- a/src/backend/dev/pi-stream-adapter.ts
+++ b/src/backend/dev/pi-stream-adapter.ts
@@ -24,6 +24,7 @@ import { isRecord } from "@/utils/type-guards";
 import { isContextWindowOverflowError } from "./context-window-overflow";
 import {
   isRetryableLocalProviderError,
+  LocalProviderRetryExhaustedError,
   localProviderRetryDelayMs,
   localProviderRetryMessage,
   normalizeLocalProviderError,
@@ -453,7 +454,10 @@ function isModelOutputEvent(event: ProviderStreamEvent): boolean {
   }
 }
 
-function llmEndErrorFromError(error: unknown): {
+function llmEndErrorFromError(
+  error: unknown,
+  options: { forceNonRetryable?: boolean } = {},
+): {
   error: LlmEndErrorInfo;
   stopReason: string;
 } {
@@ -463,7 +467,7 @@ function llmEndErrorFromError(error: unknown): {
       message: info.message,
       detail: info.detail,
       errorType: info.error_type,
-      retryable: info.retryable,
+      retryable: options.forceNonRetryable ? false : info.retryable,
     },
     stopReason: info.stop_reason,
   };
@@ -565,6 +569,7 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
 
   private async *streamOnce(
     input: ProviderTurnInput,
+    retryOptions: { terminalRetryableProviderFailure?: boolean } = {},
   ): AsyncIterable<ProviderStreamEvent> {
     const tools = toPiTools(input.clientTools);
     const localModel = await resolveAvailableLocalModelForTurn({
@@ -749,7 +754,11 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
       }
     } catch (error) {
       if (!llmEnded) {
-        const endError = llmEndErrorFromError(error);
+        const endError = llmEndErrorFromError(error, {
+          forceNonRetryable:
+            retryOptions.terminalRetryableProviderFailure &&
+            isRetryableLocalProviderError(error),
+        });
         await emitLlmEnd({
           stopReason: endError.stopReason,
           usage: null,
@@ -785,7 +794,10 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
 
       let emittedModelOutput = false;
       try {
-        for await (const event of this.streamOnce(activeInput)) {
+        for await (const event of this.streamOnce(activeInput, {
+          terminalRetryableProviderFailure:
+            transientRetries >= LOCAL_PROVIDER_MAX_RETRIES,
+        })) {
           if (isModelOutputEvent(event)) emittedModelOutput = true;
           yield event;
         }
@@ -895,12 +907,15 @@ export class PiStreamAdapter implements ProviderStreamAdapter {
           }
         }
 
-        if (
-          emittedModelOutput ||
-          transientRetries >= LOCAL_PROVIDER_MAX_RETRIES ||
-          !retryableTransportError
-        ) {
+        if (emittedModelOutput || !retryableTransportError) {
           throw error;
+        }
+
+        if (transientRetries >= LOCAL_PROVIDER_MAX_RETRIES) {
+          throw new LocalProviderRetryExhaustedError(
+            error,
+            transientRetries + 1,
+          );
         }
 
         transientRetries += 1;

--- a/src/backend/local-provider-errors.test.ts
+++ b/src/backend/local-provider-errors.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
   isRetryableLocalProviderError,
+  LocalProviderRetryExhaustedError,
+  localProviderRetryMessage,
   normalizeLocalProviderError,
 } from "@/backend/dev/local-provider-errors";
 
@@ -39,5 +41,46 @@ describe("LocalProviderErrors", () => {
       retryable: false,
       stop_reason: "error",
     });
+  });
+
+  test("marks exhausted local provider retry budgets as non-outer-retryable LLM errors", () => {
+    const cause = new Error("WebSocket closed 1006 Connection ended");
+    const error = new LocalProviderRetryExhaustedError(cause, 4);
+
+    expect(isRetryableLocalProviderError(error)).toBe(false);
+    expect(normalizeLocalProviderError(error)).toMatchObject({
+      error_type: "llm_error",
+      retryable: false,
+      stop_reason: "llm_api_error",
+    });
+    expect(normalizeLocalProviderError(error).detail).toContain(
+      "WebSocket closed 1006 Connection ended",
+    );
+  });
+
+  test("labels Codex backend and WebSocket retries without exposing raw payloads", () => {
+    const codexError = (message: string) => ({
+      message,
+      assistant: {
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+      },
+    });
+
+    expect(
+      localProviderRetryMessage(
+        codexError(
+          'Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"You can retry your request."}}',
+        ),
+      ),
+    ).toBe("OpenAI Codex backend server_error");
+    expect(
+      localProviderRetryMessage(
+        codexError("WebSocket closed 1006 Connection ended"),
+      ),
+    ).toBe("OpenAI Codex WebSocket closed (1006)");
+    expect(localProviderRetryMessage(new Error("fetch failed"))).toBe(
+      "fetch failed",
+    );
   });
 });

--- a/src/backend/pi-stream-retry-budget.test.ts
+++ b/src/backend/pi-stream-retry-budget.test.ts
@@ -1,0 +1,120 @@
+import { expect, test } from "bun:test";
+import type {
+  AssistantMessage,
+  AssistantMessageEvent,
+} from "@earendil-works/pi-ai";
+import {
+  LocalProviderRetryExhaustedError,
+  normalizeLocalProviderError,
+} from "@/backend/dev/local-provider-errors";
+import {
+  PiStreamAdapter,
+  type PiStreamFunction,
+} from "@/backend/dev/pi-stream-adapter";
+import type {
+  LlmEndInfo,
+  ProviderStreamEvent,
+  ProviderTurnInput,
+} from "@/backend/dev/provider-turn-executor";
+import { emptyLocalUsage } from "@/backend/local/local-message";
+
+function assistantErrorMessage(): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [],
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    model: "gpt-5.6-sol",
+    usage: emptyLocalUsage(),
+    stopReason: "error",
+    errorMessage: "WebSocket closed 1006 Connection ended\nretry-after-ms: 0",
+    timestamp: Date.now(),
+  };
+}
+
+function streamFromError(
+  error: AssistantMessage,
+): ReturnType<PiStreamFunction> {
+  async function* iterator() {
+    yield { type: "error", reason: "error", error } as AssistantMessageEvent;
+  }
+  return Object.assign(iterator(), { result: async () => error });
+}
+
+function input(): ProviderTurnInput {
+  return {
+    conversationId: "local-conv-retry-budget",
+    agentId: "agent-local-retry-budget",
+    agent: {
+      id: "agent-local-retry-budget",
+      name: "Local",
+      description: null,
+      system: "system",
+      tags: [],
+      model: "openai-codex/gpt-5.6-sol",
+      model_settings: { provider_type: "chatgpt_oauth" },
+    },
+    body: { messages: [] } as never,
+    history: [],
+    uiMessages: [
+      {
+        id: "ui-msg-retry-budget",
+        role: "user",
+        content: "hello",
+        timestamp: Date.now(),
+      },
+    ],
+    clientTools: [],
+    clientSkills: [],
+  };
+}
+
+test("exhausted local provider retries suppress outer turn retries", async () => {
+  let calls = 0;
+  const stream: PiStreamFunction = () => {
+    calls += 1;
+    return streamFromError(assistantErrorMessage());
+  };
+  const llmEnds: LlmEndInfo[] = [];
+  const adapter = new PiStreamAdapter({
+    stream,
+    onLlmEnd: (info) => {
+      llmEnds.push(info);
+    },
+  });
+  const events: ProviderStreamEvent[] = [];
+  let thrown: unknown;
+
+  try {
+    for await (const event of adapter.stream(input())) events.push(event);
+  } catch (error) {
+    thrown = error;
+  }
+
+  expect(calls).toBe(4);
+  expect(thrown).toBeInstanceOf(LocalProviderRetryExhaustedError);
+  expect(normalizeLocalProviderError(thrown)).toMatchObject({
+    error_type: "llm_error",
+    retryable: false,
+    stop_reason: "llm_api_error",
+  });
+  expect(llmEnds.at(-1)?.error).toMatchObject({
+    errorType: "llm_error",
+    retryable: false,
+  });
+  const retryEvents = events.filter(
+    (event) =>
+      event.type === "letta-chunk" &&
+      (event.chunk as { event_type?: string }).event_type === "retry",
+  );
+  expect(retryEvents).toHaveLength(3);
+  expect(retryEvents[0]).toMatchObject({
+    chunk: {
+      event_data: {
+        attempt: 1,
+        max_attempts: 3,
+        message: "OpenAI Codex WebSocket closed (1006)",
+      },
+    },
+  });
+});

--- a/src/backend/pi-stream-retry-budget.test.ts
+++ b/src/backend/pi-stream-retry-budget.test.ts
@@ -34,8 +34,17 @@ function assistantErrorMessage(): AssistantMessage {
 
 function streamFromError(
   error: AssistantMessage,
+  options: { emitModelOutput?: boolean } = {},
 ): ReturnType<PiStreamFunction> {
   async function* iterator() {
+    if (options.emitModelOutput) {
+      yield {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "partial",
+        partial: error,
+      } as AssistantMessageEvent;
+    }
     yield { type: "error", reason: "error", error } as AssistantMessageEvent;
   }
   return Object.assign(iterator(), { result: async () => error });
@@ -117,4 +126,35 @@ test("exhausted local provider retries suppress outer turn retries", async () =>
       },
     },
   });
+});
+
+test("keeps final failures retryable when the provider emitted model output", async () => {
+  let calls = 0;
+  const stream: PiStreamFunction = () => {
+    calls += 1;
+    return streamFromError(assistantErrorMessage(), {
+      emitModelOutput: calls === 4,
+    });
+  };
+  const llmEnds: LlmEndInfo[] = [];
+  const adapter = new PiStreamAdapter({
+    stream,
+    onLlmEnd: (info) => {
+      llmEnds.push(info);
+    },
+  });
+  let thrown: unknown;
+
+  try {
+    for await (const _event of adapter.stream(input())) {
+      // Drain the stream so the final provider error is observed.
+    }
+  } catch (error) {
+    thrown = error;
+  }
+
+  expect(calls).toBe(4);
+  expect(thrown).not.toBeInstanceOf(LocalProviderRetryExhaustedError);
+  expect(normalizeLocalProviderError(thrown).retryable).toBe(true);
+  expect(llmEnds.at(-1)?.error?.retryable).toBe(true);
 });

--- a/src/headless-approval-recovery.test.ts
+++ b/src/headless-approval-recovery.test.ts
@@ -136,4 +136,19 @@ describe("headless approval recovery wiring", () => {
     );
     expect(segment).not.toContain("await resolveAllPendingApprovals();");
   });
+
+  test("direct llm_api_error retry path honors run retryable metadata", () => {
+    const start = source.indexOf(
+      "// Case 3: Transient LLM API error - retry with exponential backoff up to a limit",
+    );
+    const end = source.indexOf("const invalidIdsDetected =", start);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    const segment = source.slice(start, end);
+    expect(segment).toContain("shouldRetryPostStreamRunError({");
+    expect(segment).toContain("retryable: initialRunErrorInfo?.retryable");
+    expect(segment).toContain('stopReason === "llm_api_error"');
+  });
 });

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -25,7 +25,7 @@ import type { ApprovalResult } from "./agent/approval-execution";
 import {
   buildFreshDenialApprovals,
   extractConflictDetail,
-  fetchRunErrorDetail,
+  fetchRunErrorInfo,
   getPreStreamErrorAction,
   getRetryDelayMs,
   isApprovalPendingError,
@@ -35,6 +35,7 @@ import {
   rebuildInputForApprovalResync,
   refreshInputOtidsForNewRequest,
   STALE_APPROVAL_RECOVERY_DENIAL_REASON,
+  shouldRetryPostStreamRunError,
   shouldRetryRunMetadataError,
 } from "./agent/approval-recovery";
 import { handleBootstrapSessionState } from "./agent/bootstrap-handler";
@@ -3110,11 +3111,21 @@ ${SYSTEM_REMINDER_CLOSE}
         }
       }
 
-      // Fetch run error detail for invalid tool call ID detection
-      const detailFromRun = await fetchRunErrorDetail(lastRunId);
+      // Fetch run error detail for invalid tool call ID detection and retry metadata
+      const initialRunErrorInfo = await fetchRunErrorInfo(lastRunId);
+      const detailFromRun =
+        initialRunErrorInfo?.detail ?? initialRunErrorInfo?.message ?? null;
 
       // Case 3: Transient LLM API error - retry with exponential backoff up to a limit
-      if (stopReason === "llm_api_error") {
+      if (
+        stopReason === "llm_api_error" &&
+        shouldRetryPostStreamRunError({
+          stopReason,
+          errorType: initialRunErrorInfo?.error_type,
+          detail: detailFromRun ?? latestErrorText,
+          retryable: initialRunErrorInfo?.retryable,
+        })
+      ) {
         if (llmApiErrorRetries < LLM_API_ERROR_MAX_RETRIES) {
           const attempt = llmApiErrorRetries + 1;
           llmApiErrorRetries = attempt;
@@ -3248,33 +3259,10 @@ ${SYSTEM_REMINDER_CLOSE}
         // Fall through to error display
       } else if (llmApiErrorRetries < LLM_API_ERROR_MAX_RETRIES) {
         try {
-          let errorType: string | undefined;
-          let detail = detailFromRun ?? latestErrorText ?? "";
-          let explicitRetryable: boolean | undefined;
-
-          if (lastRunId) {
-            const run = await getBackend().retrieveRun(lastRunId);
-            const metaError = run.metadata?.error as
-              | {
-                  error_type?: string;
-                  message?: string;
-                  detail?: string;
-                  retryable?: boolean;
-                  // Handle nested error structure (error.error) that can occur in some edge cases
-                  error?: {
-                    error_type?: string;
-                    detail?: string;
-                    retryable?: boolean;
-                  };
-                }
-              | undefined;
-
-            // Check for llm_error at top level or nested (handles error.error nesting)
-            errorType = metaError?.error_type ?? metaError?.error?.error_type;
-            detail = metaError?.detail ?? metaError?.error?.detail ?? detail;
-            explicitRetryable =
-              metaError?.retryable ?? metaError?.error?.retryable;
-          }
+          const errorType: string | undefined = initialRunErrorInfo?.error_type;
+          const detail = detailFromRun ?? latestErrorText ?? "";
+          const explicitRetryable: boolean | undefined =
+            initialRunErrorInfo?.retryable;
 
           // Special handling for empty response errors (Opus 4.6 SADs)
           // Empty LLM response retry (e.g. Opus 4.6 occasionally returns no content).


### PR DESCRIPTION
## Problem

A transient Local provider failure could consume the provider adapter retry budget, finish as `llm_api_error`, and then be retried again by the outer CLI/headless/listener loop. Four adapter attempts across four runs allowed up to 16 provider calls and made upstream outages look like long stalls.

## What changed

- Mark a Local run explicitly non-retryable after all four pre-output provider attempts are exhausted, so outer clients stop instead of restarting the turn.
- Preserve outer recovery when the provider emitted partial model output or the failure did not exhaust the adapter budget.
- Render Codex retries as backend or WebSocket failures while retaining attempt, maximum-attempt, and delay metadata.
- Carry explicit retryability through shared run-error metadata, including the headless path.

## Limits and risk

This does not fix OpenAI availability. It bounds Letta-side amplification and makes active retries legible. The behavior change is limited to Local provider failures that exhaust the adapter before any model output; hosted/API retry behavior is unchanged.

## Test plan

- [x] `bun run check`
- [x] `bun test src/backend/pi-stream-retry-budget.test.ts src/backend/pi-stream-adapter.test.ts src/backend/local-provider-errors.test.ts src/agent/turn-recovery-policy.test.ts src/cli/retry.test.ts src/websocket/recovery.test.ts src/headless-approval-recovery.test.ts src/backend/fake-headless-backend.test.ts`
- [x] Adversarial review of adapter exhaustion, partial-output behavior, persisted retry metadata, and CLI/headless/listener consumers

👾 Generated with [Letta Code](https://letta.com)