### PR TITLE
feat(subagents): support metadata-only overrides

### DIFF
--- a/src/agent/subagent-builtins.test.ts
+++ b/src/agent/subagent-builtins.test.ts
@@ -167,6 +167,64 @@ Custom prompt body`,
     expect(configs.reflection?.recommendedModel).toBe("zaisigno/glm-5");
   });
 
+  test("bodyless reflection config overlays model without replacing the built-in", async () => {
+    tempDir = createTempProjectDir();
+    const builtIn = (await getAllSubagentConfigs(tempDir)).reflection;
+    clearSubagentConfigCache();
+    writeCustomSubagent(
+      tempDir,
+      "reflection.md",
+      ["---", "name: reflection", "model: auto", "---"].join("\r\n"),
+    );
+
+    const config = (await getAllSubagentConfigs(tempDir)).reflection;
+    expect(config?.systemPrompt).toBe(builtIn?.systemPrompt);
+    expect(config?.description).toBe(builtIn?.description);
+    expect(config?.allowedTools).toEqual(builtIn?.allowedTools);
+    expect(config?.skills).toEqual(builtIn?.skills);
+    expect(config?.fork).toBe(builtIn?.fork);
+    expect(config?.background).toBe(builtIn?.background);
+    expect(config?.launchProfile).toBe(builtIn?.launchProfile);
+    expect(config?.recommendedModel).toBe("auto");
+    expect(config?.recommendedModelSource).toBe("user");
+  });
+
+  test("bodyless config can override explicit metadata fields", async () => {
+    tempDir = createTempProjectDir();
+    writeCustomSubagent(
+      tempDir,
+      "reflection.md",
+      `---
+name: reflection
+description: Focused reflection
+tools: Read
+model: auto
+background: false
+---`,
+    );
+
+    const config = (await getAllSubagentConfigs(tempDir)).reflection;
+    expect(config?.description).toBe("Focused reflection");
+    expect(config?.allowedTools).toEqual(["Read"]);
+    expect(config?.background).toBe(false);
+    expect(config?.launchProfile).toBe("memory-subagent");
+  });
+
+  test("ignores bodyless config without a lower-precedence definition", async () => {
+    tempDir = createTempProjectDir();
+    writeCustomSubagent(
+      tempDir,
+      "new-agent.md",
+      `---
+name: new-agent
+model: auto
+---`,
+    );
+
+    const configs = await getAllSubagentConfigs(tempDir);
+    expect(configs["new-agent"]).toBeUndefined();
+  });
+
   test("blank model field falls back to inherit", async () => {
     tempDir = createTempProjectDir();
     writeCustomSubagent(

--- a/src/agent/subagent-model-resolution.test.ts
+++ b/src/agent/subagent-model-resolution.test.ts
@@ -806,6 +806,33 @@ describe("resolveSubagentModel", () => {
     expect(result).toBe("openai/gpt-5");
   });
 
+  test("user-configured models override local parent inheritance", async () => {
+    const result = await resolveSubagentModel({
+      subagentType: "reflection",
+      recommendedModel: "auto",
+      recommendedModelSource: "user",
+      parentModelHandle: "lmstudio/local-model",
+      backendMode: "local",
+      availableHandles: new Set(["letta/auto"]),
+    });
+
+    expect(result).toBe("letta/auto");
+  });
+
+  test("explicit Task models override user-configured models", async () => {
+    const result = await resolveSubagentModel({
+      subagentType: "reflection",
+      userModel: "openai/gpt-5",
+      recommendedModel: "auto",
+      recommendedModelSource: "user",
+      parentModelHandle: "lmstudio/local-model",
+      backendMode: "local",
+      availableHandles: new Set(["letta/auto", "openai/gpt-5"]),
+    });
+
+    expect(result).toBe("openai/gpt-5");
+  });
+
   test("uses letta/auto-memory for reflection subagents with no recommended model", async () => {
     const result = await resolveSubagentModel({
       subagentType: "reflection",

--- a/src/agent/subagents/index.ts
+++ b/src/agent/subagents/index.ts
@@ -53,6 +53,7 @@ const LOCAL_MEMFS_BUILTIN_SOURCES = [
  * Subagent configuration
  */
 export type SubagentLaunchProfile = "default" | "memory-subagent";
+export type SubagentRecommendedModelSource = "builtin" | "user";
 
 /** Exact memory scope handed to a harness-created memory worktree. */
 export interface SubagentMemoryScope {
@@ -86,6 +87,8 @@ export interface SubagentConfig {
   allowedTools: string[] | "all";
   /** Recommended model - any model ID from models.json or full handle */
   recommendedModel: string;
+  /** Whether the recommended model came from bundled defaults or user config. */
+  recommendedModelSource?: SubagentRecommendedModelSource;
   /** Skills to auto-load */
   skills: string[];
   /** Whether this subagent should fork the parent conversation before launch. */
@@ -116,10 +119,14 @@ export const AGENTS_DIR = ".letta/agents";
 /**
  * Global directory for subagent files (in user's home directory)
  */
-export const GLOBAL_AGENTS_DIR = join(
-  process.env.HOME || process.env.USERPROFILE || "~",
-  ".letta/agents",
-);
+function getGlobalAgentsDir(): string {
+  return join(
+    process.env.HOME || process.env.USERPROFILE || "~",
+    ".letta/agents",
+  );
+}
+
+export const GLOBAL_AGENTS_DIR = getGlobalAgentsDir();
 
 // ============================================================================
 // Cache
@@ -188,7 +195,10 @@ function parseBackgroundDefault(background: string | undefined): boolean {
  * Validate subagent frontmatter
  * Only validates required fields - optional fields are validated at runtime where needed
  */
-function validateFrontmatter(frontmatter: Record<string, string | string[]>): {
+function validateFrontmatter(
+  frontmatter: Record<string, string | string[]>,
+  options: { requireDescription?: boolean } = {},
+): {
   valid: boolean;
   errors: string[];
 } {
@@ -205,8 +215,10 @@ function validateFrontmatter(frontmatter: Record<string, string | string[]>): {
   }
 
   const description = frontmatter.description;
-  if (!description || typeof description !== "string") {
-    errors.push("Missing required field: description");
+  if (options.requireDescription !== false) {
+    if (!description || typeof description !== "string") {
+      errors.push("Missing required field: description");
+    }
   }
 
   // Don't validate model or launchProfile here - they're handled at runtime:
@@ -216,20 +228,98 @@ function validateFrontmatter(frontmatter: Record<string, string | string[]>): {
   return { valid: errors.length === 0, errors };
 }
 
+interface ParseSubagentContentOptions {
+  inheritedConfigs?: Record<string, SubagentConfig>;
+  modelSource?: SubagentRecommendedModelSource;
+}
+
+function hasFrontmatterField(
+  frontmatter: Record<string, string | string[]>,
+  field: string,
+): boolean {
+  return Object.hasOwn(frontmatter, field);
+}
+
+function cloneAllowedTools(allowedTools: string[] | "all"): string[] | "all" {
+  return allowedTools === "all" ? "all" : [...allowedTools];
+}
+
+function applySubagentOverlay(
+  inherited: SubagentConfig,
+  frontmatter: Record<string, string | string[]>,
+  modelSource: SubagentRecommendedModelSource | undefined,
+): SubagentConfig {
+  const hasModel = hasFrontmatterField(frontmatter, "model");
+
+  return {
+    ...inherited,
+    name: frontmatter.name as string,
+    description: hasFrontmatterField(frontmatter, "description")
+      ? getStringField(frontmatter, "description") || inherited.description
+      : inherited.description,
+    systemPrompt: inherited.systemPrompt,
+    allowedTools: hasFrontmatterField(frontmatter, "tools")
+      ? parseTools(getStringField(frontmatter, "tools"))
+      : cloneAllowedTools(inherited.allowedTools),
+    recommendedModel: hasModel
+      ? getStringField(frontmatter, "model") || "inherit"
+      : inherited.recommendedModel,
+    recommendedModelSource: hasModel
+      ? modelSource
+      : inherited.recommendedModelSource,
+    skills: hasFrontmatterField(frontmatter, "skills")
+      ? parseSkills(getStringField(frontmatter, "skills"))
+      : [...inherited.skills],
+    fork: hasFrontmatterField(frontmatter, "fork")
+      ? getStringField(frontmatter, "fork")?.toLowerCase() === "true"
+      : inherited.fork,
+    background: hasFrontmatterField(frontmatter, "background")
+      ? parseBackgroundDefault(getStringField(frontmatter, "background"))
+      : inherited.background,
+    launchProfile: hasFrontmatterField(frontmatter, "launchProfile")
+      ? parseLaunchProfile(getStringField(frontmatter, "launchProfile"))
+      : inherited.launchProfile,
+  };
+}
+
 /**
  * Parse a subagent from markdown content
  */
-function parseSubagentContent(content: string): SubagentConfig {
+function parseSubagentContent(
+  content: string,
+  options: ParseSubagentContentOptions = {},
+): SubagentConfig {
   const { frontmatter, body } = parseFrontmatter(content);
 
-  // Validate frontmatter
+  const nameValidation = validateFrontmatter(frontmatter, {
+    requireDescription: false,
+  });
+  if (!nameValidation.valid) {
+    throw new Error(nameValidation.errors.join("; "));
+  }
+
+  const name = frontmatter.name as string;
+  const isBodyless = body.trim().length === 0;
+
+  if (isBodyless) {
+    const inherited = options.inheritedConfigs?.[name];
+    if (!inherited) {
+      throw new Error(
+        `Bodyless subagent overlay "${name}" requires an existing lower-precedence config`,
+      );
+    }
+
+    return applySubagentOverlay(inherited, frontmatter, options.modelSource);
+  }
+
+  // Validate frontmatter for full-replacement custom subagents.
   const validation = validateFrontmatter(frontmatter);
   if (!validation.valid) {
     throw new Error(validation.errors.join("; "));
   }
 
-  const name = frontmatter.name as string;
   const description = frontmatter.description as string;
+  const hasModel = hasFrontmatterField(frontmatter, "model");
 
   return {
     name,
@@ -237,6 +327,7 @@ function parseSubagentContent(content: string): SubagentConfig {
     systemPrompt: body,
     allowedTools: parseTools(getStringField(frontmatter, "tools")),
     recommendedModel: getStringField(frontmatter, "model") || "inherit",
+    recommendedModelSource: hasModel ? options.modelSource : undefined,
     skills: parseSkills(getStringField(frontmatter, "skills")),
     fork: getStringField(frontmatter, "fork")?.toLowerCase() === "true",
     background: parseBackgroundDefault(
@@ -253,9 +344,13 @@ function parseSubagentContent(content: string): SubagentConfig {
  */
 async function parseSubagentFile(
   filePath: string,
+  inheritedConfigs: Record<string, SubagentConfig>,
 ): Promise<SubagentConfig | null> {
   const content = await readFile(filePath, "utf-8");
-  return parseSubagentContent(content);
+  return parseSubagentContent(content, {
+    inheritedConfigs,
+    modelSource: "user",
+  });
 }
 
 /**
@@ -281,7 +376,9 @@ function getBuiltinSubagents(
 
   for (const source of sources) {
     try {
-      const config = parseSubagentContent(source);
+      const config = parseSubagentContent(source, {
+        modelSource: "builtin",
+      });
       builtins[config.name] = config;
     } catch (error) {
       // Built-in subagents should always be valid; log error but don't crash
@@ -307,7 +404,7 @@ export function getBuiltinSubagentNames(): Set<string> {
  */
 async function discoverSubagentsFromDir(
   agentsDir: string,
-  seenNames: Set<string>,
+  configsByName: Record<string, SubagentConfig>,
   subagents: SubagentConfig[],
   errors: Array<{ path: string; message: string }>,
 ): Promise<void> {
@@ -326,20 +423,17 @@ async function discoverSubagentsFromDir(
       const filePath = join(agentsDir, entry.name);
 
       try {
-        const config = await parseSubagentFile(filePath);
+        const config = await parseSubagentFile(filePath, configsByName);
         if (config) {
           // Check for duplicate names (later directories override earlier ones)
-          if (seenNames.has(config.name)) {
-            // Remove the existing one and replace with this one
-            const existingIndex = subagents.findIndex(
-              (s) => s.name === config.name,
-            );
-            if (existingIndex !== -1) {
-              subagents.splice(existingIndex, 1);
-            }
+          const existingIndex = subagents.findIndex(
+            (s) => s.name === config.name,
+          );
+          if (existingIndex !== -1) {
+            subagents.splice(existingIndex, 1);
           }
 
-          seenNames.add(config.name);
+          configsByName[config.name] = config;
           subagents.push(config);
         }
       } catch (error) {
@@ -363,15 +457,17 @@ async function discoverSubagentsFromDir(
  */
 export async function discoverSubagents(
   workingDirectory: string = process.cwd(),
+  inheritedConfigs: Record<string, SubagentConfig> = {
+    ...getBuiltinSubagents(),
+  },
 ): Promise<SubagentDiscoveryResult> {
   const errors: Array<{ path: string; message: string }> = [];
   const subagents: SubagentConfig[] = [];
-  const seenNames = new Set<string>();
 
   // First, discover from global directory (~/.letta/agents)
   await discoverSubagentsFromDir(
-    GLOBAL_AGENTS_DIR,
-    seenNames,
+    getGlobalAgentsDir(),
+    inheritedConfigs,
     subagents,
     errors,
   );
@@ -381,7 +477,7 @@ export async function discoverSubagents(
   const projectAgentsDir = join(workingDirectory, AGENTS_DIR);
   await discoverSubagentsFromDir(
     projectAgentsDir,
-    seenNames,
+    inheritedConfigs,
     subagents,
     errors,
   );
@@ -414,7 +510,10 @@ export async function getAllSubagentConfigs(
   };
 
   // Discover user-defined subagents from .letta/agents/
-  const { subagents, errors } = await discoverSubagents(workingDirectory);
+  const { subagents, errors } = await discoverSubagents(
+    workingDirectory,
+    configs,
+  );
 
   // Log any discovery errors
   for (const error of errors) {

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -858,6 +858,7 @@ export async function spawnSubagent(
     : await resolveSubagentModel({
         userModel,
         recommendedModel: config.recommendedModel,
+        recommendedModelSource: config.recommendedModelSource,
         parentModelHandle,
         billingTier,
         subagentType: type,

--- a/src/agent/subagents/subagent-model.ts
+++ b/src/agent/subagents/subagent-model.ts
@@ -111,6 +111,7 @@ function isInheritModel(model: string | null | undefined): boolean {
 export async function resolveSubagentModel(options: {
   userModel?: string;
   recommendedModel?: string;
+  recommendedModelSource?: "builtin" | "user";
   parentModelHandle?: string | null;
   billingTier?: string | null;
   availableHandles?: Set<string>;
@@ -126,6 +127,17 @@ export async function resolveSubagentModel(options: {
     : recommendedModel;
 
   if (userModel && !userRequestedInheritance) return userModel;
+
+  if (
+    options.recommendedModelSource === "user" &&
+    effectiveRecommendedModel &&
+    !isInheritModel(effectiveRecommendedModel)
+  ) {
+    const recommendedHandle = resolveModel(effectiveRecommendedModel);
+    if (recommendedHandle) {
+      return recommendedHandle;
+    }
+  }
 
   // Local backend has no server-side auto router. If the parent agent is
   // already running successfully on a local model, spawned subagents should use

--- a/src/utils/frontmatter.test.ts
+++ b/src/utils/frontmatter.test.ts
@@ -28,6 +28,25 @@ Prompt body`;
     expect(body.includes("\r")).toBe(false);
   });
 
+  test("parses bodyless frontmatter without a trailing newline", () => {
+    const { frontmatter, body } = parseFrontmatter(
+      "---\r\nname: reflection\r\nmodel: auto\r\n---",
+    );
+
+    expect(frontmatter.name).toBe("reflection");
+    expect(frontmatter.model).toBe("auto");
+    expect(body).toBe("");
+  });
+
+  test("preserves explicit empty fields", () => {
+    const { frontmatter } = parseFrontmatter(
+      "---\nname: reflection\nmodel:\n---",
+    );
+
+    expect(Object.hasOwn(frontmatter, "model")).toBe(true);
+    expect(frontmatter.model).toBe("");
+  });
+
   test("parses BOM + CRLF frontmatter", () => {
     const content =
       "\uFEFF---\r\nname: reflection\r\ndescription: custom reflection\r\n---\r\nPrompt body";

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -40,21 +40,28 @@ export function parseFrontmatter(content: string): {
     .replace(/\r\n/g, "\n")
     .replace(/\r/g, "\n");
 
-  const frontmatterRegex = /^---\n([\s\S]*?)\n---\n([\s\S]*)$/;
+  const frontmatterRegex = /^---\n([\s\S]*?)\n---(?:\n([\s\S]*))?$/;
   const match = normalized.match(frontmatterRegex);
 
-  if (!match || !match[1] || !match[2]) {
+  if (!match || match[1] === undefined) {
     return { frontmatter: {}, body: normalized };
   }
 
   const frontmatterText = match[1];
-  const body = match[2];
+  const body = match[2] ?? "";
   const frontmatter: Record<string, string | string[]> = {};
 
   // Parse YAML-like frontmatter (simple key: value pairs and arrays)
   const lines = frontmatterText.split("\n");
   let currentKey: string | null = null;
   let currentArray: string[] = [];
+
+  const savePendingKey = () => {
+    if (!currentKey) return;
+    frontmatter[currentKey] = currentArray.length > 0 ? currentArray : "";
+    currentKey = null;
+    currentArray = [];
+  };
 
   for (const line of lines) {
     // Check if this is an array item
@@ -64,34 +71,26 @@ export function parseFrontmatter(content: string): {
       continue;
     }
 
-    // If we were building an array, save it
-    if (currentKey && currentArray.length > 0) {
-      frontmatter[currentKey] = currentArray;
-      currentKey = null;
-      currentArray = [];
-    }
+    savePendingKey();
 
     const colonIndex = line.indexOf(":");
     if (colonIndex > 0) {
       const key = line.slice(0, colonIndex).trim();
       const value = line.slice(colonIndex + 1).trim();
-      currentKey = key;
 
       if (value) {
         // Simple key: value pair
         frontmatter[key] = value;
-        currentKey = null;
       } else {
-        // Might be starting an array
+        // Might be starting an array. If no array items follow, this is an
+        // explicit empty scalar field.
+        currentKey = key;
         currentArray = [];
       }
     }
   }
 
-  // Save any remaining array
-  if (currentKey && currentArray.length > 0) {
-    frontmatter[currentKey] = currentArray;
-  }
+  savePendingKey();
 
   return { frontmatter, body: body.trim() };
 }


### PR DESCRIPTION
## Summary
- treat bodyless custom subagent Markdown as a metadata overlay on the lower-precedence definition
- preserve bundled prompts and omitted fields while allowing focused overrides such as `model:`
- keep explicit Task models highest priority and honor user-configured models on local backends

## Example

```md
---
name: reflection
model: auto
---
```

This changes the reflection model without copying its bundled prompt, so future prompt updates continue to apply.

## Validation
- `bun test src/utils/frontmatter.test.ts src/agent/subagent-builtins.test.ts src/agent/subagent-model-resolution.test.ts` (83 pass)
- `bun run check` (12/12 pass)

👾 Generated with [Letta Code](https://letta.com)