### PR TITLE
fix(slack): compact scheduled prompt messages

### DIFF
--- a/src/channels/slack/adapter.test.ts
+++ b/src/channels/slack/adapter.test.ts
@@ -571,3 +571,84 @@ test("slack adapter sendMessage renders a View on web context footnote when iden
   // Without identity: plain text, no blocks.
   expect(postCalls[1]?.[0]?.blocks).toBeUndefined();
 });
+
+test("slack adapter sendMessage compacts cron prompts at the Slack API boundary", async () => {
+  const adapter = createSlackAdapter({
+    ...slackAccountDefaults,
+    channel: "slack",
+    enabled: true,
+    mode: "socket",
+    botToken: "xoxb-test-token-1234567890",
+    appToken: "xapp-test-token-1234567890",
+    dmPolicy: "pairing",
+    allowedUsers: [],
+  });
+  await adapter.start();
+
+  const cronPrompt = [
+    'Scheduled task "Daily status" is firing.',
+    "Description: Post the morning status to Slack.",
+    "Timezone: UTC",
+    "Scheduled for: 2026-04-11T09:00:00.000+00:00[UTC]",
+    "Current time: 2026-04-11T09:00:03.000+00:00[UTC]",
+    "This is fire #3 (cron: * * * * *).",
+    "",
+    "You are running autonomously: no user is watching this turn and questions will not be answered. Deliver results through your available channels or record them in memory, and work until the task is done or genuinely blocked.",
+    "",
+    "Prompt: Check the incident queue, summarize the top risks, and post the update.",
+  ].join("\n");
+
+  await adapter.sendMessage({
+    channel: "slack",
+    accountId: "slack-test-account",
+    chatId: "C123",
+    text: cronPrompt,
+    threadId: "1712790000.000050",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  });
+
+  const writeClient = FakeSlackWriteClient.instances[0];
+  const postCalls = writeClient?.chat.postMessage.mock
+    .calls as unknown as Array<
+    Array<{
+      channel: string;
+      text: string;
+      blocks?: Array<{
+        type: string;
+        text?: { type: string; text: string };
+        elements?: Array<{ type: string; text: string }>;
+      }>;
+    }>
+  >;
+  const payload = postCalls[0]?.[0];
+  expect(payload?.text).toBe(
+    [
+      "Scheduled task fired: Daily status",
+      "Fire #3 · cron * * * * *",
+      "Scheduled for: 2026-04-11T09:00:00.000+00:00[UTC]",
+      "Prompt: Check the incident queue, summarize the top risks, and post the update.",
+    ].join("\n"),
+  );
+  expect(payload?.blocks?.[0]).toEqual({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: [
+        ":calendar: *Scheduled task fired*",
+        "*Daily status*",
+        "Post the morning status to Slack.",
+        "Fire #3 · cron `* * * * *`",
+        ":clock1: Scheduled for `2026-04-11T09:00:00.000+00:00[UTC]`",
+        "Prompt: Check the incident queue, summarize the top risks, and post the update.",
+      ].join("\n"),
+    },
+  });
+  expect(payload?.blocks?.[1]?.elements?.[0]?.text).toBe(
+    "<https://chat.letta.com/chat/agent-1?conversation=conv-1|View full scheduled prompt>",
+  );
+  expect(payload?.text).not.toContain("You are running autonomously");
+  expect(JSON.stringify(payload?.blocks)).not.toContain(
+    "You are running autonomously",
+  );
+});

--- a/src/channels/slack/adapter.test.ts
+++ b/src/channels/slack/adapter.test.ts
@@ -549,6 +549,7 @@ test("slack adapter sendMessage renders a View on web context footnote when iden
       text: string;
       blocks?: Array<{
         type: string;
+        expand?: boolean;
         text?: { type: string; text: string };
         elements?: Array<{ type: string; text: string }>;
       }>;
@@ -585,6 +586,8 @@ test("slack adapter sendMessage compacts cron prompts at the Slack API boundary"
   });
   await adapter.start();
 
+  const scheduledPrompt =
+    "Check the incident queue, summarize the top risks, and post the update.";
   const cronPrompt = [
     'Scheduled task "Daily status" is firing.',
     "Description: Post the morning status to Slack.",
@@ -595,7 +598,7 @@ test("slack adapter sendMessage compacts cron prompts at the Slack API boundary"
     "",
     "You are running autonomously: no user is watching this turn and questions will not be answered. Deliver results through your available channels or record them in memory, and work until the task is done or genuinely blocked.",
     "",
-    "Prompt: Check the incident queue, summarize the top risks, and post the update.",
+    `Prompt: ${scheduledPrompt}`,
   ].join("\n");
 
   await adapter.sendMessage({
@@ -616,6 +619,7 @@ test("slack adapter sendMessage compacts cron prompts at the Slack API boundary"
       text: string;
       blocks?: Array<{
         type: string;
+        expand?: boolean;
         text?: { type: string; text: string };
         elements?: Array<{ type: string; text: string }>;
       }>;
@@ -632,6 +636,7 @@ test("slack adapter sendMessage compacts cron prompts at the Slack API boundary"
   );
   expect(payload?.blocks?.[0]).toEqual({
     type: "section",
+    expand: false,
     text: {
       type: "mrkdwn",
       text: [
@@ -640,11 +645,18 @@ test("slack adapter sendMessage compacts cron prompts at the Slack API boundary"
         "Post the morning status to Slack.",
         "Fire #3 · cron `* * * * *`",
         ":clock1: Scheduled for `2026-04-11T09:00:00.000+00:00[UTC]`",
-        "Prompt: Check the incident queue, summarize the top risks, and post the update.",
       ].join("\n"),
     },
   });
-  expect(payload?.blocks?.[1]?.elements?.[0]?.text).toBe(
+  expect(payload?.blocks?.[1]).toEqual({
+    type: "section",
+    expand: false,
+    text: {
+      type: "mrkdwn",
+      text: `*Full scheduled prompt:*\n${scheduledPrompt}`,
+    },
+  });
+  expect(payload?.blocks?.[2]?.elements?.[0]?.text).toBe(
     "<https://chat.letta.com/chat/agent-1?conversation=conv-1|View full scheduled prompt>",
   );
   expect(payload?.text).not.toContain("You are running autonomously");

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -280,9 +280,7 @@ export function createSlackAdapter(
             conversationId: msg.conversationId,
           })
         : "";
-    const blocks = footnote
-      ? buildSlackReplyBlocksWithFootnote(msg.text, footnote)
-      : undefined;
+    const blocks = buildSlackReplyBlocksWithFootnote(msg.text, footnote);
     const text = blocks ? formatSlackReplyTextFallback(msg.text) : msg.text;
     const response = await client.chat.postMessage({
       channel: msg.chatId,

--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -32,6 +32,7 @@ import {
   buildSlackReplyBlocksWithFootnote,
   formatSlackControlRequestBlocks,
   formatSlackLifecycleErrorMessage,
+  formatSlackReplyTextFallback,
   resolveSlackConcreteActivity,
   SLACK_ASSISTANT_STARTUP_STATUS,
   SLACK_ASSISTANT_WORKING_STATUS,
@@ -282,9 +283,10 @@ export function createSlackAdapter(
     const blocks = footnote
       ? buildSlackReplyBlocksWithFootnote(msg.text, footnote)
       : undefined;
+    const text = blocks ? formatSlackReplyTextFallback(msg.text) : msg.text;
     const response = await client.chat.postMessage({
       channel: msg.chatId,
-      text: msg.text,
+      text,
       ...(blocks ? { blocks } : {}),
       ...(threadTs ? { thread_ts: threadTs } : {}),
     });

--- a/src/channels/slack/internal-types.ts
+++ b/src/channels/slack/internal-types.ts
@@ -137,6 +137,7 @@ export type SlackBlock =
       type: "section";
       text: SlackTextObject;
       accessory?: SlackBlockElement;
+      expand?: boolean;
     }
   | {
       type: "markdown";

--- a/src/channels/slack/presentation.ts
+++ b/src/channels/slack/presentation.ts
@@ -20,7 +20,173 @@ import { isNonEmptyString } from "./utils";
 export const SLACK_APPROVAL_ACTION_ID = "letta_channel_approval";
 
 const SLACK_MARKDOWN_BLOCK_TEXT_MAX = 12_000;
+const SLACK_SECTION_BLOCK_TEXT_MAX = 3_000;
 const SLACK_LIFECYCLE_ERROR_TEXT_MAX = 3_000;
+const SLACK_SCHEDULED_PROMPT_PREVIEW_MAX = 360;
+const CRON_PROMPT_AUTONOMOUS_NOTICE =
+  "You are running autonomously: no user is watching this turn and questions will not be answered. Deliver results through your available channels or record them in memory, and work until the task is done or genuinely blocked.";
+
+type ParsedSlackCronPrompt = {
+  taskName: string;
+  description?: string;
+  scheduledFor: string;
+  recurrence: string;
+  prompt: string;
+};
+
+function compactSlackPreviewText(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function escapeSlackMrkdwnText(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function formatSlackInlineCode(text: string): string {
+  return `\`${escapeSlackMrkdwnText(text).replace(/`/g, "'")}\``;
+}
+
+function getCronPromptField(
+  lines: string[],
+  prefix: string,
+): string | undefined {
+  const line = lines.find((candidate) => candidate.startsWith(prefix));
+  const value = line?.slice(prefix.length).trim();
+  return value ? value : undefined;
+}
+
+function formatCronPromptRecurrence(line: string): string | null {
+  const recurring = /^This is fire #(\d+) \(cron: (.+)\)\.$/.exec(line);
+  if (recurring) {
+    return `Fire #${recurring[1]} · cron ${formatSlackInlineCode(recurring[2] ?? "")}`;
+  }
+  if (line === "This is a one-off scheduled task.") {
+    return "One-off scheduled task";
+  }
+  return null;
+}
+
+function parseSlackCronPrompt(text: string): ParsedSlackCronPrompt | null {
+  const normalized = text.trim();
+  const promptMarker = "\nPrompt: ";
+  const promptIndex = normalized.indexOf(promptMarker);
+  if (promptIndex < 0) return null;
+
+  const header = normalized.slice(0, promptIndex);
+  const prompt = normalized.slice(promptIndex + promptMarker.length).trim();
+  if (!prompt || !header.includes(CRON_PROMPT_AUTONOMOUS_NOTICE)) {
+    return null;
+  }
+
+  const lines = header.split(/\r?\n/).map((line) => line.trim());
+  const titleMatch = /^Scheduled task "(.+)" is firing\.$/.exec(lines[0] ?? "");
+  if (!titleMatch) return null;
+
+  const scheduledFor = getCronPromptField(lines, "Scheduled for:");
+  const currentTime = getCronPromptField(lines, "Current time:");
+  const recurrenceLine = lines.find((line) =>
+    /^(This is fire #\d+ \(cron: .+\)\.|This is a one-off scheduled task\.)$/.test(
+      line,
+    ),
+  );
+  const recurrence = recurrenceLine
+    ? formatCronPromptRecurrence(recurrenceLine)
+    : null;
+  if (!scheduledFor || !currentTime || !recurrence) return null;
+
+  return {
+    taskName: titleMatch[1] ?? "scheduled task",
+    description: getCronPromptField(lines, "Description:"),
+    scheduledFor,
+    recurrence,
+    prompt,
+  };
+}
+
+function extractSlackFootnoteUrl(footnote: string): string | null {
+  const match = /^<([^|>]+)\|[^>]+>$/.exec(footnote.trim());
+  return match?.[1] ?? null;
+}
+
+function formatSlackCronPromptFallback(parsed: ParsedSlackCronPrompt): string {
+  const promptPreview = truncateChannelProgressText(
+    compactSlackPreviewText(parsed.prompt),
+    SLACK_SCHEDULED_PROMPT_PREVIEW_MAX,
+    "...",
+  );
+  return [
+    `Scheduled task fired: ${parsed.taskName}`,
+    parsed.recurrence.replace(/`/g, ""),
+    `Scheduled for: ${parsed.scheduledFor}`,
+    `Prompt: ${promptPreview}`,
+  ].join("\n");
+}
+
+function buildSlackCronPromptBlocks(
+  text: string,
+  footnote: string,
+): SlackBlock[] | null {
+  const parsed = parseSlackCronPrompt(text);
+  if (!parsed) return null;
+
+  const promptPreview = truncateChannelProgressText(
+    compactSlackPreviewText(parsed.prompt),
+    SLACK_SCHEDULED_PROMPT_PREVIEW_MAX,
+    "...",
+  );
+  const descriptionPreview = parsed.description
+    ? truncateChannelProgressText(
+        compactSlackPreviewText(parsed.description),
+        180,
+        "...",
+      )
+    : "";
+  const summaryLines = [
+    `:calendar: *Scheduled task fired*`,
+    `*${escapeSlackMrkdwnText(parsed.taskName)}*`,
+    descriptionPreview ? escapeSlackMrkdwnText(descriptionPreview) : null,
+    parsed.recurrence,
+    `:clock1: Scheduled for ${formatSlackInlineCode(parsed.scheduledFor)}`,
+    `Prompt: ${escapeSlackMrkdwnText(promptPreview)}`,
+  ].filter((line): line is string => Boolean(line));
+
+  const blocks: SlackBlock[] = [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: truncateChannelProgressText(
+          summaryLines.join("\n"),
+          SLACK_SECTION_BLOCK_TEXT_MAX,
+          "...",
+        ),
+      },
+    },
+  ];
+
+  const footnoteUrl = extractSlackFootnoteUrl(footnote);
+  if (footnoteUrl) {
+    blocks.push({
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: `<${footnoteUrl}|View full scheduled prompt>`,
+        },
+      ],
+    });
+  } else if (footnote.trim()) {
+    blocks.push({
+      type: "context",
+      elements: [{ type: "mrkdwn", text: footnote }],
+    });
+  }
+
+  return blocks;
+}
 
 function buildSlackChatUrl(
   agentId: string,
@@ -43,10 +209,20 @@ export function buildSlackChatFootnote(identity: {
   return chatUrl ? `<${chatUrl}|View on web>` : "";
 }
 
+export function formatSlackReplyTextFallback(text: string): string {
+  const parsed = parseSlackCronPrompt(text);
+  return parsed ? formatSlackCronPromptFallback(parsed) : text;
+}
+
 export function buildSlackReplyBlocksWithFootnote(
   text: string,
   footnote: string,
 ): SlackBlock[] | undefined {
+  const cronPromptBlocks = buildSlackCronPromptBlocks(text, footnote);
+  if (cronPromptBlocks) {
+    return cronPromptBlocks;
+  }
+
   const chunks: string[] = [];
   let remaining = text;
   while (remaining.length > 0) {

--- a/src/channels/slack/presentation.ts
+++ b/src/channels/slack/presentation.ts
@@ -23,6 +23,7 @@ const SLACK_MARKDOWN_BLOCK_TEXT_MAX = 12_000;
 const SLACK_SECTION_BLOCK_TEXT_MAX = 3_000;
 const SLACK_LIFECYCLE_ERROR_TEXT_MAX = 3_000;
 const SLACK_SCHEDULED_PROMPT_PREVIEW_MAX = 360;
+const SLACK_SCHEDULED_PROMPT_LABEL = "*Full scheduled prompt:*\n";
 const CRON_PROMPT_AUTONOMOUS_NOTICE =
   "You are running autonomously: no user is watching this turn and questions will not be answered. Deliver results through your available channels or record them in memory, and work until the task is done or genuinely blocked.";
 
@@ -47,6 +48,26 @@ function escapeSlackMrkdwnText(text: string): string {
 
 function formatSlackInlineCode(text: string): string {
   return `\`${escapeSlackMrkdwnText(text).replace(/`/g, "'")}\``;
+}
+
+function splitEscapedSlackMrkdwnText(
+  text: string,
+  maxLength: number,
+): string[] {
+  const chunks: string[] = [];
+  let chunk = "";
+  for (const char of text) {
+    const escaped = escapeSlackMrkdwnText(char);
+    if (chunk && chunk.length + escaped.length > maxLength) {
+      chunks.push(chunk);
+      chunk = "";
+    }
+    chunk += escaped;
+  }
+  if (chunk) {
+    chunks.push(chunk);
+  }
+  return chunks;
 }
 
 function getCronPromptField(
@@ -132,11 +153,6 @@ function buildSlackCronPromptBlocks(
   const parsed = parseSlackCronPrompt(text);
   if (!parsed) return null;
 
-  const promptPreview = truncateChannelProgressText(
-    compactSlackPreviewText(parsed.prompt),
-    SLACK_SCHEDULED_PROMPT_PREVIEW_MAX,
-    "...",
-  );
   const descriptionPreview = parsed.description
     ? truncateChannelProgressText(
         compactSlackPreviewText(parsed.description),
@@ -150,12 +166,16 @@ function buildSlackCronPromptBlocks(
     descriptionPreview ? escapeSlackMrkdwnText(descriptionPreview) : null,
     parsed.recurrence,
     `:clock1: Scheduled for ${formatSlackInlineCode(parsed.scheduledFor)}`,
-    `Prompt: ${escapeSlackMrkdwnText(promptPreview)}`,
   ].filter((line): line is string => Boolean(line));
 
+  const promptChunks = splitEscapedSlackMrkdwnText(
+    parsed.prompt,
+    SLACK_SECTION_BLOCK_TEXT_MAX - SLACK_SCHEDULED_PROMPT_LABEL.length,
+  );
   const blocks: SlackBlock[] = [
     {
       type: "section",
+      expand: false,
       text: {
         type: "mrkdwn",
         text: truncateChannelProgressText(
@@ -165,6 +185,16 @@ function buildSlackCronPromptBlocks(
         ),
       },
     },
+    ...promptChunks.map(
+      (chunk, index): SlackBlock => ({
+        type: "section",
+        expand: false,
+        text: {
+          type: "mrkdwn",
+          text: index === 0 ? `${SLACK_SCHEDULED_PROMPT_LABEL}${chunk}` : chunk,
+        },
+      }),
+    ),
   ];
 
   const footnoteUrl = extractSlackFootnoteUrl(footnote);
@@ -221,6 +251,9 @@ export function buildSlackReplyBlocksWithFootnote(
   const cronPromptBlocks = buildSlackCronPromptBlocks(text, footnote);
   if (cronPromptBlocks) {
     return cronPromptBlocks;
+  }
+  if (!footnote.trim()) {
+    return undefined;
   }
 
   const chunks: string[] = [];

--- a/src/channels/slack/sender.test.ts
+++ b/src/channels/slack/sender.test.ts
@@ -28,6 +28,62 @@ class FakeSlackSenderClient {
   }
 }
 
+const CRON_PROMPT_AUTONOMOUS_NOTICE =
+  "You are running autonomously: no user is watching this turn and questions will not be answered. Deliver results through your available channels or record them in memory, and work until the task is done or genuinely blocked.";
+const FULL_SCHEDULED_PROMPT_LABEL = "*Full scheduled prompt:*\n";
+
+type TestSlackSectionBlock = {
+  type: "section";
+  expand?: boolean;
+  text: { type: "mrkdwn" | "plain_text"; text: string };
+};
+
+function buildTestCronPrompt(prompt: string): string {
+  return [
+    'Scheduled task "Daily status" is firing.',
+    "Description: Post the morning status to Slack.",
+    "Timezone: UTC",
+    "Scheduled for: 2026-04-11T09:00:00.000+00:00[UTC]",
+    "Current time: 2026-04-11T09:00:03.000+00:00[UTC]",
+    "This is fire #3 (cron: * * * * *).",
+    "",
+    CRON_PROMPT_AUTONOMOUS_NOTICE,
+    "",
+    `Prompt: ${prompt}`,
+  ].join("\n");
+}
+
+function escapeSlackMrkdwnForTest(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function scheduledSectionBlocks(
+  blocks: unknown[] | undefined,
+): TestSlackSectionBlock[] {
+  return (blocks ?? []).filter(
+    (block): block is TestSlackSectionBlock =>
+      typeof block === "object" &&
+      block !== null &&
+      "type" in block &&
+      block.type === "section",
+  );
+}
+
+function renderedScheduledPrompt(blocks: unknown[] | undefined): string {
+  const promptSections = scheduledSectionBlocks(blocks).slice(1);
+  return promptSections
+    .map((block, index) => {
+      const text = block.text.text;
+      return index === 0
+        ? text.slice(FULL_SCHEDULED_PROMPT_LABEL.length)
+        : text;
+    })
+    .join("");
+}
+
 describe("Slack channel sender", () => {
   test("posts threaded channel messages", async () => {
     const client = new FakeSlackSenderClient();
@@ -95,18 +151,9 @@ describe("Slack channel sender", () => {
   test("renders cron prompts as compact scheduled blocks", async () => {
     const client = new FakeSlackSenderClient();
     const sender = createSlackChannelSender({ client });
-    const cronPrompt = [
-      'Scheduled task "Daily status" is firing.',
-      "Description: Post the morning status to Slack.",
-      "Timezone: UTC",
-      "Scheduled for: 2026-04-11T09:00:00.000+00:00[UTC]",
-      "Current time: 2026-04-11T09:00:03.000+00:00[UTC]",
-      "This is fire #3 (cron: * * * * *).",
-      "",
-      "You are running autonomously: no user is watching this turn and questions will not be answered. Deliver results through your available channels or record them in memory, and work until the task is done or genuinely blocked.",
-      "",
-      "Prompt: Check the incident queue, summarize the top risks, and post the update.",
-    ].join("\n");
+    const scheduledPrompt =
+      "Check the incident queue, summarize the top risks, and post the update.";
+    const cronPrompt = buildTestCronPrompt(scheduledPrompt);
     const message: OutboundChannelMessage = {
       channel: "slack",
       accountId: "integration-1",
@@ -130,6 +177,7 @@ describe("Slack channel sender", () => {
     expect(client.postMessages[0]?.blocks).toEqual([
       {
         type: "section",
+        expand: false,
         text: {
           type: "mrkdwn",
           text: [
@@ -138,8 +186,15 @@ describe("Slack channel sender", () => {
             "Post the morning status to Slack.",
             "Fire #3 · cron `* * * * *`",
             ":clock1: Scheduled for `2026-04-11T09:00:00.000+00:00[UTC]`",
-            "Prompt: Check the incident queue, summarize the top risks, and post the update.",
           ].join("\n"),
+        },
+      },
+      {
+        type: "section",
+        expand: false,
+        text: {
+          type: "mrkdwn",
+          text: `${FULL_SCHEDULED_PROMPT_LABEL}${scheduledPrompt}`,
         },
       },
       {
@@ -161,6 +216,113 @@ describe("Slack channel sender", () => {
     expect(JSON.stringify(client.postMessages[0]?.blocks)).not.toContain(
       "Description:",
     );
+  });
+
+  test("renders cron prompts as scheduled blocks without web identity", async () => {
+    const client = new FakeSlackSenderClient();
+    const sender = createSlackChannelSender({ client });
+    const scheduledPrompt = "Post a concise heartbeat.";
+
+    await sender.sendMessage({
+      channel: "slack",
+      accountId: "integration-1",
+      chatId: "C123",
+      text: buildTestCronPrompt(scheduledPrompt),
+    });
+
+    expect(client.postMessages[0]?.text).toBe(
+      [
+        "Scheduled task fired: Daily status",
+        "Fire #3 · cron * * * * *",
+        "Scheduled for: 2026-04-11T09:00:00.000+00:00[UTC]",
+        "Prompt: Post a concise heartbeat.",
+      ].join("\n"),
+    );
+    expect(client.postMessages[0]?.blocks).toEqual([
+      expect.objectContaining({ type: "section", expand: false }),
+      {
+        type: "section",
+        expand: false,
+        text: {
+          type: "mrkdwn",
+          text: `${FULL_SCHEDULED_PROMPT_LABEL}${scheduledPrompt}`,
+        },
+      },
+    ]);
+  });
+
+  test("renders full long cron prompts in expandable section chunks", async () => {
+    const client = new FakeSlackSenderClient();
+    const sender = createSlackChannelSender({ client });
+    const longPrompt = [
+      "Inspect & report <all> blockers.",
+      "x".repeat(3_100),
+      "Finish with > done.",
+    ].join("\n");
+
+    await sender.sendMessage({
+      channel: "slack",
+      accountId: "integration-1",
+      chatId: "C123",
+      text: buildTestCronPrompt(longPrompt),
+      agentId: "agent-123",
+      conversationId: "conversation-456",
+    });
+
+    const payload = client.postMessages[0];
+    const sections = scheduledSectionBlocks(payload?.blocks);
+    const promptSections = sections.slice(1);
+    expect(sections.length).toBeGreaterThan(2);
+    expect(sections.every((section) => section.expand === false)).toBe(true);
+    expect(sections.every((section) => section.text.text.length <= 3_000)).toBe(
+      true,
+    );
+    expect(
+      promptSections[0]?.text.text.startsWith(FULL_SCHEDULED_PROMPT_LABEL),
+    ).toBe(true);
+    expect(renderedScheduledPrompt(payload?.blocks)).toBe(
+      escapeSlackMrkdwnForTest(longPrompt),
+    );
+    expect(payload?.text).toContain("Scheduled task fired: Daily status");
+    expect(payload?.text).toContain("Prompt: Inspect & report <all> blockers.");
+    expect(payload?.text).toContain("...");
+    expect(payload?.text.length).toBeLessThan(600);
+  });
+
+  test("keeps malformed cron-looking messages on normal Slack blocks", async () => {
+    const client = new FakeSlackSenderClient();
+    const sender = createSlackChannelSender({ client });
+    const malformedCronPrompt = [
+      'Scheduled task "Daily status" is firing.',
+      "Scheduled for: 2026-04-11T09:00:00.000+00:00[UTC]",
+      "Prompt: Missing the rest of the cron prompt envelope.",
+    ].join("\n");
+
+    await sender.sendMessage({
+      channel: "slack",
+      accountId: "integration-1",
+      chatId: "C123",
+      text: malformedCronPrompt,
+      agentId: "agent-123",
+      conversationId: "conversation-456",
+    });
+
+    expect(client.postMessages[0]?.text).toBe(malformedCronPrompt);
+    expect(client.postMessages[0]?.blocks).toEqual([
+      {
+        type: "markdown",
+        text: malformedCronPrompt,
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: "<https://chat.letta.com/chat/agent-123?conversation=conversation-456|View on web>",
+          },
+        ],
+      },
+    ]);
   });
 
   test("adds Slack reactions", async () => {

--- a/src/channels/slack/sender.test.ts
+++ b/src/channels/slack/sender.test.ts
@@ -92,6 +92,77 @@ describe("Slack channel sender", () => {
     ]);
   });
 
+  test("renders cron prompts as compact scheduled blocks", async () => {
+    const client = new FakeSlackSenderClient();
+    const sender = createSlackChannelSender({ client });
+    const cronPrompt = [
+      'Scheduled task "Daily status" is firing.',
+      "Description: Post the morning status to Slack.",
+      "Timezone: UTC",
+      "Scheduled for: 2026-04-11T09:00:00.000+00:00[UTC]",
+      "Current time: 2026-04-11T09:00:03.000+00:00[UTC]",
+      "This is fire #3 (cron: * * * * *).",
+      "",
+      "You are running autonomously: no user is watching this turn and questions will not be answered. Deliver results through your available channels or record them in memory, and work until the task is done or genuinely blocked.",
+      "",
+      "Prompt: Check the incident queue, summarize the top risks, and post the update.",
+    ].join("\n");
+    const message: OutboundChannelMessage = {
+      channel: "slack",
+      accountId: "integration-1",
+      chatId: "C123",
+      threadId: "1712790000.000000",
+      text: cronPrompt,
+      agentId: "agent-123",
+      conversationId: "conversation-456",
+    };
+
+    await sender.sendMessage(message);
+
+    expect(client.postMessages[0]?.text).toBe(
+      [
+        "Scheduled task fired: Daily status",
+        "Fire #3 · cron * * * * *",
+        "Scheduled for: 2026-04-11T09:00:00.000+00:00[UTC]",
+        "Prompt: Check the incident queue, summarize the top risks, and post the update.",
+      ].join("\n"),
+    );
+    expect(client.postMessages[0]?.blocks).toEqual([
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: [
+            ":calendar: *Scheduled task fired*",
+            "*Daily status*",
+            "Post the morning status to Slack.",
+            "Fire #3 · cron `* * * * *`",
+            ":clock1: Scheduled for `2026-04-11T09:00:00.000+00:00[UTC]`",
+            "Prompt: Check the incident queue, summarize the top risks, and post the update.",
+          ].join("\n"),
+        },
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: "<https://chat.letta.com/chat/agent-123?conversation=conversation-456|View full scheduled prompt>",
+          },
+        ],
+      },
+    ]);
+    expect(client.postMessages[0]?.text).not.toContain(
+      "You are running autonomously",
+    );
+    expect(JSON.stringify(client.postMessages[0]?.blocks)).not.toContain(
+      "You are running autonomously",
+    );
+    expect(JSON.stringify(client.postMessages[0]?.blocks)).not.toContain(
+      "Description:",
+    );
+  });
+
   test("adds Slack reactions", async () => {
     const client = new FakeSlackSenderClient();
     const sender = createSlackChannelSender({ client });

--- a/src/channels/slack/sender.ts
+++ b/src/channels/slack/sender.ts
@@ -95,17 +95,13 @@ async function sendSlackReaction(
 function buildSlackOutboundBlocks(
   message: OutboundChannelMessage,
 ): unknown[] | undefined {
-  if (!message.agentId || !message.conversationId) {
-    return undefined;
-  }
-
-  const footnote = buildSlackChatFootnote({
-    agentId: message.agentId,
-    conversationId: message.conversationId,
-  });
-  if (!footnote) {
-    return undefined;
-  }
+  const footnote =
+    message.agentId && message.conversationId
+      ? buildSlackChatFootnote({
+          agentId: message.agentId,
+          conversationId: message.conversationId,
+        })
+      : "";
 
   return buildSlackReplyBlocksWithFootnote(message.text, footnote);
 }

--- a/src/channels/slack/sender.ts
+++ b/src/channels/slack/sender.ts
@@ -2,6 +2,7 @@ import type { OutboundChannelMessage } from "@/channels/types";
 import {
   buildSlackChatFootnote,
   buildSlackReplyBlocksWithFootnote,
+  formatSlackReplyTextFallback,
 } from "./presentation";
 import {
   normalizeSlackReactionName,
@@ -126,9 +127,12 @@ export function createSlackChannelSender(
         replyToMessageId: message.replyToMessageId,
       });
       const blocks = buildSlackOutboundBlocks(message);
+      const text = blocks
+        ? formatSlackReplyTextFallback(message.text)
+        : message.text;
       return await client.postMessage({
         channel: message.chatId,
-        text: message.text,
+        text,
         ...(blocks ? { blocks } : {}),
         ...(threadTs ? { threadTs } : {}),
       });


### PR DESCRIPTION
## Summary
- Detect cron scheduler prompts in Slack presentation formatting and render them as scheduled-task cards instead of ordinary assistant markdown.
- Keep the icon-bearing scheduled-task summary compact, then include the full scheduled prompt in Slack `section` blocks with `expand: false`; prompt content is escaped for mrkdwn and split so each section stays under Slack’s 3,000-character section text limit.
- Keep the top-level Slack fallback `text` compact for notifications while preserving existing formatting for ordinary and malformed messages.

## Context
Scheduled turns arrive at the Slack outbound path as the full cron prompt text from `formatCronPrompt`. Without source-aware formatting, Slack could expose scheduler metadata and autonomous-turn boilerplate as if it were the assistant reply.

## Root cause
`buildSlackReplyBlocksWithFootnote` only chunked reply text and appended a web footnote. It had no cron-prompt path that separated the scheduled-task summary from the prompt content or used Slack’s native section expansion behavior.

## Behavior matrix
- Cron prompt with agent/conversation identity: compact scheduled summary section, full scheduled prompt section(s), compact fallback text, and a secondary `View full scheduled prompt` web link.
- Cron prompt without web identity: compact scheduled summary plus full scheduled prompt section(s), with no web footnote.
- Long scheduled prompts: escaped prompt text is split across multiple `section` blocks; every scheduled section carries `expand: false` and stays at or below 3,000 characters.
- Ordinary assistant reply with identity: existing markdown chunks and `View on web` footnote remain unchanged.
- Message without identity-backed blocks and not a cron prompt: top-level Slack text remains the original message text and no blocks are emitted.
- Malformed or non-cron text: parser returns null and normal Slack formatting is used.

## Slack expansion limit
The in-Slack expansion mechanism is Slack’s native handling for `section` blocks with `expand: false`/omitted. Long prompt sections may render behind Slack’s native `see more` control, but Slack does not provide a deterministic collapsed-by-default control for short section text. Short prompts can render fully in Slack.

## Validation
- `bun test src/channels/slack/sender.test.ts`
- `bun test src/channels/slack/adapter.test.ts`
- `bun run check`

## Limits and risk
- Detection intentionally keys off the current `formatCronPrompt` shape. If that format changes, Slack falls back to ordinary reply formatting rather than compacting unrelated text.
- No live Slack screenshot was captured in this branch; tests assert the real Slack API payloads at both sender and adapter boundaries, including full prompt content and 3,000-character section splitting.

👾 Generated with [Letta Code](https://letta.com)