### PR TITLE
fix(reflection): adapt prompts for Windows shells

### DIFF
--- a/src/agent/subagent-model-resolution.test.ts
+++ b/src/agent/subagent-model-resolution.test.ts
@@ -443,15 +443,35 @@ describe("buildSubagentArgs", () => {
     expect(promptArg).toBe(longPrompt);
   });
 
-  test("injects --no-system-info-reminder and --no-skills for reflection subagents", () => {
+  test("injects --no-system-info-reminder and --no-skills for non-Windows reflection subagents", () => {
     const args = buildSubagentArgs(
       "reflection",
       { ...baseConfig, name: "reflection" },
       null,
       "hello",
+      undefined,
+      undefined,
+      undefined,
+      { platform: "linux" },
     );
 
     expect(args).toContain("--no-system-info-reminder");
+    expect(args).toContain("--no-skills");
+  });
+
+  test("keeps the Windows environment reminder for reflection subagents", () => {
+    const args = buildSubagentArgs(
+      "reflection",
+      { ...baseConfig, name: "reflection" },
+      null,
+      "hello",
+      undefined,
+      undefined,
+      undefined,
+      { platform: "win32" },
+    );
+
+    expect(args).not.toContain("--no-system-info-reminder");
     expect(args).toContain("--no-skills");
   });
 

--- a/src/agent/subagents/builtin/reflection.md
+++ b/src/agent/subagents/builtin/reflection.md
@@ -23,14 +23,16 @@ Skills are not the default. A one-off task, a fact, or a preference belongs in m
 
 You only have access to **Bash** and **Edit**. Do not call `Read`, `Write`, memory tools, recall tools, or conversation search, even if those names appear in the transcript.
 
-Your memory repo root is `$MEMORY_DIR`. Bash can expand this environment variable; Edit cannot. Keep all filesystem writes under `$MEMORY_DIR`, and run all git commands from inside `$MEMORY_DIR`. Do not inspect or modify `.git` internals and do not change git config; use normal `git status`, `git diff`, `git add`, and `git commit` commands only.
+Your memory repo root is `$MEMORY_DIR`. The terminal tool can expand environment variables; use `$MEMORY_DIR` on Unix or `$env:MEMORY_DIR` in PowerShell. Edit cannot expand either form. Keep all filesystem writes under the memory repo and run all git commands from inside it. Do not inspect or modify `.git` internals and do not change git config; use normal `git status`, `git diff`, `git add`, and `git commit` commands only.
 
-Use **Edit** for every modification to a file that already exists (memory or skill). Do not rewrite existing files with Bash heredocs, scripts, or redirection. Edit paths must be absolute paths under `$MEMORY_DIR`, never literal `$MEMORY_DIR/...` strings. To get an Edit path, resolve it with Bash first (for example, `printf "%s/system/persona.md\n" "$MEMORY_DIR"`) and then use the printed path.
+Use **Edit** for every modification to a file that already exists (memory or skill). Do not rewrite existing files with terminal heredocs, scripts, or redirection. Edit paths must be absolute paths under the memory repo, never literal `$MEMORY_DIR/...` or `$env:MEMORY_DIR/...` strings. To get an Edit path, resolve it with the terminal first (for example, `printf "%s/system/persona.md\n" "$MEMORY_DIR"` on Unix or `Join-Path $env:MEMORY_DIR "system/persona.md"` in PowerShell) and then use the printed path.
 
-Use **Bash** for reading, git, and filesystem/bulk operations — not for editing the contents of existing files:
-- Inspect transcripts with bounded reads. Run `wc -c "$TRANSCRIPT_PATH"` first; if a file is <= 15000 bytes, `cat` is okay, otherwise use targeted `head`, `tail`, `grep`, and `sed -n` snippets.
-- Inspect memory with concise commands like `find`, `grep`, `head`, and targeted `cat` from `$MEMORY_DIR`.
-- Create new files with a quoted heredoc, e.g. `cd "$MEMORY_DIR" && mkdir -p skills/example && cat > skills/example/SKILL.md <<'EOF' ... EOF`. Move, rename, or delete with `mv`, `rm`, and `mkdir -p`, always under `$MEMORY_DIR`. If a temp file is needed, put it under `$MEMORY_DIR/.tmp/` and remove it before committing.
+Use the **Bash** terminal tool for reading, git, and filesystem/bulk operations — not for editing the contents of existing files. Follow the shell semantics in the tool description; despite its name, the tool runs native PowerShell or cmd.exe on Windows.
+
+- Inspect transcripts with bounded reads. Determine file size first: on Unix, `wc -c "$TRANSCRIPT_PATH"`; in PowerShell, `(Get-Item -LiteralPath $env:TRANSCRIPT_PATH).Length`. If a file is <= 15000 bytes, a full read is okay; otherwise use targeted reads (`head`, `tail`, `grep`, and `sed -n` on Unix, or `Get-Content`, `Select-String`, and `-TotalCount` in PowerShell).
+- Inspect memory with concise, platform-native commands. Use `find`, `grep`, `head`, and targeted `cat` on Unix; use `Get-ChildItem`, `Select-String`, and `Get-Content` in PowerShell.
+- Create new files with the shell-native method. On Unix, use a quoted heredoc. In PowerShell, use a single-quoted here-string piped to `Set-Content -LiteralPath <path> -Encoding utf8`. Move, rename, or delete only under `$MEMORY_DIR` (`mv`, `rm`, and `mkdir -p` on Unix; `Move-Item`, `Remove-Item`, and `New-Item` in PowerShell). If a temp file is needed, put it under `$MEMORY_DIR/.tmp/` and remove it before committing.
+- On Windows, avoid `&&` for failure-stopping chains so the command also works with Windows PowerShell; issue dependent commands in separate tool calls or check `$LASTEXITCODE` explicitly.
 
 ## Memory Filesystem
 

--- a/src/agent/subagents/builtin/reflection.test.ts
+++ b/src/agent/subagents/builtin/reflection.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import reflectionPrompt from "./reflection.md";
+
+describe("reflection prompt shell guidance", () => {
+  test("gives native Windows alternatives for terminal operations", () => {
+    expect(reflectionPrompt).toContain(
+      "the tool runs native PowerShell or cmd.exe on Windows",
+    );
+    expect(reflectionPrompt).toContain(
+      "(Get-Item -LiteralPath $env:TRANSCRIPT_PATH).Length",
+    );
+    expect(reflectionPrompt).toContain("Join-Path $env:MEMORY_DIR");
+    expect(reflectionPrompt).toContain("Get-Content");
+    expect(reflectionPrompt).toContain("single-quoted here-string");
+    expect(reflectionPrompt).toContain(
+      "Set-Content -LiteralPath <path> -Encoding utf8",
+    );
+    expect(reflectionPrompt).toContain("check `$LASTEXITCODE` explicitly");
+  });
+});

--- a/src/agent/subagents/manager.ts
+++ b/src/agent/subagents/manager.ts
@@ -8,6 +8,7 @@
  */
 
 import { spawn } from "node:child_process";
+import { platform } from "node:os";
 import { getConversationId, getCurrentAgentId } from "@/agent/context";
 import recallSubagentPrompt from "@/agent/prompts/recall_subagent.md";
 import recallSubagentLocalPrompt from "@/agent/prompts/recall_subagent_local.md";
@@ -200,6 +201,8 @@ export function buildSubagentPrompt(
 interface BuildSubagentArgsOptions {
   backendMode?: BackendMode;
   promptTransport?: "argv" | "stdin";
+  /** Runtime platform override for launcher tests. */
+  platform?: NodeJS.Platform;
   extraTools?: string[];
   parentAgentId?: string | null;
   /**
@@ -223,6 +226,7 @@ export function buildSubagentArgs(
   options: BuildSubagentArgsOptions = {},
 ): string[] {
   const args: string[] = [];
+  const runtimePlatform = options.platform ?? platform();
   const isDeployingExisting = Boolean(
     existingAgentId || existingConversationId,
   );
@@ -265,10 +269,13 @@ export function buildSubagentArgs(
     }
 
     // Reflection-specific startup flags: match the memory_reflection training
-    // env so the trained policy sees identical prompt suffixes and skill
-    // availability at inference time as it did during training.
+    // environment everywhere except Windows. On Windows, the startup reminder
+    // identifies the native shell so the Bash-named tool's PowerShell/cmd
+    // behavior does not conflict with the reflection procedure.
     if (type === "reflection") {
-      args.push("--no-system-info-reminder");
+      if (runtimePlatform !== "win32") {
+        args.push("--no-system-info-reminder");
+      }
       args.push("--no-skills");
     }
 


### PR DESCRIPTION
## Summary
- retain the environment reminder for newly spawned Windows reflection subagents
- replace Bash-only reflection procedures with PowerShell-safe equivalents for paths, bounded reads, UTF-8 file creation, and command sequencing
- cover the Windows launch flags and reflection prompt contract

## Validation
- `npx --yes bun@1.3.0 test src/agent/subagent-model-resolution.test.ts src/agent/subagents/builtin/reflection.test.ts`
- `npx --yes bun@1.3.0 run check`