### PR TITLE
fix(cron): resolve new conversation targets in listener

### DIFF
--- a/src/websocket/listener/message-router.test.ts
+++ b/src/websocket/listener/message-router.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import WebSocket from "ws";
+import { ACTING_USER_ID_HEADER } from "@/agent/acting-user";
+import { __testSetBackend, type Backend } from "@/backend/backend";
+import { FakeHeadlessBackend } from "@/backend/dev/fake-headless-backend";
+import { openListenerConnection } from "./connection";
 import { getOrCreateScopedRuntime } from "./conversation-runtime";
 import { createRuntime } from "./lifecycle";
 import { createListenerMessageHandler } from "./message-router";
 import { scheduleQueuePump } from "./queue";
-import { setActiveRuntime } from "./runtime";
+import { getConversationRuntimeKey, setActiveRuntime } from "./runtime";
 import type { IncomingMessage, StartListenerOptions } from "./types";
 
 class MockSocket {
@@ -13,6 +17,47 @@ class MockSocket {
 
   send(payload: string): void {
     this.sentPayloads.push(payload);
+  }
+}
+
+class RecordingHeadlessBackend extends FakeHeadlessBackend {
+  readonly createConversationCalls: Array<{
+    body: Parameters<Backend["createConversation"]>[0];
+    options: Parameters<Backend["createConversation"]>[1];
+    id: string;
+  }> = [];
+
+  override async createConversation(
+    body: Parameters<Backend["createConversation"]>[0],
+    options?: Parameters<Backend["createConversation"]>[1],
+  ) {
+    const conversation = await super.createConversation(body);
+    this.createConversationCalls.push({ body, options, id: conversation.id });
+    return conversation;
+  }
+}
+
+class BlockingConversationBackend extends RecordingHeadlessBackend {
+  private markStarted!: () => void;
+  private releaseCreation!: () => void;
+  readonly started = new Promise<void>((resolve) => {
+    this.markStarted = resolve;
+  });
+  private readonly creationGate = new Promise<void>((resolve) => {
+    this.releaseCreation = resolve;
+  });
+
+  release(): void {
+    this.releaseCreation();
+  }
+
+  override async createConversation(
+    body: Parameters<Backend["createConversation"]>[0],
+    options?: Parameters<Backend["createConversation"]>[1],
+  ) {
+    this.markStarted();
+    await this.creationGate;
+    return super.createConversation(body, options);
   }
 }
 
@@ -38,8 +83,294 @@ async function waitFor(predicate: () => boolean): Promise<void> {
   throw new Error("Timed out waiting for listener state");
 }
 
+function getParsedRuntimeScopeForTest(parsed: unknown) {
+  if (!parsed || typeof parsed !== "object" || !("runtime" in parsed)) {
+    return null;
+  }
+  const runtime = (
+    parsed as { runtime?: { agent_id?: unknown; conversation_id?: unknown } }
+  ).runtime;
+  if (
+    typeof runtime?.agent_id !== "string" ||
+    typeof runtime.conversation_id !== "string"
+  ) {
+    return null;
+  }
+  return {
+    agent_id: runtime.agent_id,
+    conversation_id: runtime.conversation_id,
+  };
+}
+
 describe("listener message router ownership handoff", () => {
-  afterEach(() => setActiveRuntime(null));
+  afterEach(() => {
+    __testSetBackend(null);
+    setActiveRuntime(null);
+  });
+
+  test("resolves create_message conversation new to fresh conversations before dispatch", async () => {
+    const backend = new RecordingHeadlessBackend();
+    __testSetBackend(backend);
+    const listener = createRuntime();
+    const socket = new MockSocket();
+    const opts = makeListenerOptions();
+    openListenerConnection({
+      runtime: listener,
+      connectionId: opts.connectionId,
+      writer: socket as unknown as WebSocket,
+      options: opts,
+    });
+    const processedTurns: IncomingMessage[] = [];
+    const processIncomingMessage = mock(async (incoming: IncomingMessage) => {
+      processedTurns.push(incoming);
+    });
+    const getOrCreateScopedRuntimeMock = mock(
+      (
+        runtime: Parameters<typeof getOrCreateScopedRuntime>[0],
+        agentId: Parameters<typeof getOrCreateScopedRuntime>[1],
+        conversationId: Parameters<typeof getOrCreateScopedRuntime>[2],
+      ) => getOrCreateScopedRuntime(runtime, agentId, conversationId),
+    );
+    const trackListenerError = mock(() => {});
+    setActiveRuntime(listener);
+
+    const handleMessage = createListenerMessageHandler({
+      runtime: listener,
+      socket: socket as unknown as WebSocket,
+      opts,
+      processQueuedTurn: mock(async () => {}),
+      fileCommandSession: { handle: () => false },
+      getParsedRuntimeScope: getParsedRuntimeScopeForTest,
+      replaySyncStateForRuntime: async () => {},
+      getOrCreateScopedRuntime: getOrCreateScopedRuntimeMock,
+      handleApprovalResponseInput: async () => false,
+      handleChangeDeviceStateInput: async () => false,
+      handleAbortMessageInput: async () => false,
+      stampInboundUserMessageOtids: (incoming) => incoming,
+      safeSocketSend: () => true,
+      runDetachedListenerTask: () => {},
+      trackListenerError,
+      wireChannelIngress: async () => {},
+      processIncomingMessage,
+    });
+
+    await handleMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "input",
+          runtime: {
+            agent_id: "agent-1",
+            conversation_id: "new",
+            acting_user_id: "user-1",
+          },
+          payload: {
+            kind: "create_message",
+            messages: [{ role: "user", content: "first scheduled turn" }],
+          },
+        }),
+      ),
+    );
+    await waitFor(() => processedTurns.length === 1);
+
+    await handleMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "input",
+          runtime: { agent_id: "agent-1", conversation_id: "new" },
+          payload: {
+            kind: "create_message",
+            messages: [{ role: "user", content: "second scheduled turn" }],
+          },
+        }),
+      ),
+    );
+    await waitFor(() => processedTurns.length === 2);
+
+    expect(trackListenerError).not.toHaveBeenCalled();
+    expect(backend.createConversationCalls).toHaveLength(2);
+    expect(backend.createConversationCalls[0]?.body).toMatchObject({
+      agent_id: "agent-1",
+    });
+    expect(backend.createConversationCalls[0]?.options).toEqual({
+      headers: { [ACTING_USER_ID_HEADER]: "user-1" },
+    });
+    expect(backend.createConversationCalls[1]?.body).toMatchObject({
+      agent_id: "agent-1",
+    });
+    expect(backend.createConversationCalls[1]?.options).toBeUndefined();
+
+    const firstConversationId = backend.createConversationCalls[0]?.id;
+    const secondConversationId = backend.createConversationCalls[1]?.id;
+    expect(firstConversationId).toBeTruthy();
+    expect(secondConversationId).toBeTruthy();
+    expect(firstConversationId).not.toBe("new");
+    expect(secondConversationId).not.toBe("new");
+    expect(secondConversationId).not.toBe(firstConversationId);
+    expect(processedTurns.map((turn) => turn.conversationId)).toEqual([
+      firstConversationId,
+      secondConversationId,
+    ]);
+    expect(
+      getOrCreateScopedRuntimeMock.mock.calls.map((call) => call[2]),
+    ).toEqual([firstConversationId, secondConversationId]);
+    expect(
+      listener.connectionIdsByRuntimeKey.has(
+        getConversationRuntimeKey("agent-1", "new"),
+      ),
+    ).toBe(false);
+    expect(
+      listener.connectionIdsByRuntimeKey
+        .get(getConversationRuntimeKey("agent-1", firstConversationId))
+        ?.has(opts.connectionId),
+    ).toBe(true);
+    expect(
+      listener.connectionIdsByRuntimeKey
+        .get(getConversationRuntimeKey("agent-1", secondConversationId))
+        ?.has(opts.connectionId),
+    ).toBe(true);
+  });
+
+  test("does not dispatch a resolved new conversation after runtime replacement", async () => {
+    const backend = new BlockingConversationBackend();
+    __testSetBackend(backend);
+    const listener = createRuntime();
+    const socket = new MockSocket();
+    const opts = makeListenerOptions();
+    openListenerConnection({
+      runtime: listener,
+      connectionId: opts.connectionId,
+      writer: socket as unknown as WebSocket,
+      options: opts,
+    });
+    const processIncomingMessage = mock(async () => {});
+    const getOrCreateScopedRuntimeMock = mock(
+      (
+        runtime: Parameters<typeof getOrCreateScopedRuntime>[0],
+        agentId: Parameters<typeof getOrCreateScopedRuntime>[1],
+        conversationId: Parameters<typeof getOrCreateScopedRuntime>[2],
+      ) => getOrCreateScopedRuntime(runtime, agentId, conversationId),
+    );
+    setActiveRuntime(listener);
+
+    const handleMessage = createListenerMessageHandler({
+      runtime: listener,
+      socket: socket as unknown as WebSocket,
+      opts,
+      processQueuedTurn: mock(async () => {}),
+      fileCommandSession: { handle: () => false },
+      getParsedRuntimeScope: getParsedRuntimeScopeForTest,
+      replaySyncStateForRuntime: async () => {},
+      getOrCreateScopedRuntime: getOrCreateScopedRuntimeMock,
+      handleApprovalResponseInput: async () => false,
+      handleChangeDeviceStateInput: async () => false,
+      handleAbortMessageInput: async () => false,
+      stampInboundUserMessageOtids: (incoming) => incoming,
+      safeSocketSend: () => true,
+      runDetachedListenerTask: () => {},
+      trackListenerError: mock(() => {}),
+      wireChannelIngress: async () => {},
+      processIncomingMessage,
+    });
+
+    const handling = handleMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "input",
+          runtime: { agent_id: "agent-1", conversation_id: "new" },
+          payload: {
+            kind: "create_message",
+            messages: [{ role: "user", content: "superseded scheduled turn" }],
+          },
+        }),
+      ),
+    );
+    await backend.started;
+    setActiveRuntime(null);
+    backend.release();
+    await handling;
+
+    expect(backend.createConversationCalls).toHaveLength(1);
+    expect(processIncomingMessage).not.toHaveBeenCalled();
+    expect(getOrCreateScopedRuntimeMock).not.toHaveBeenCalled();
+    expect(listener.connectionIdsByRuntimeKey.size).toBe(0);
+  });
+
+  test("keeps explicit and default create_message conversation ids unchanged", async () => {
+    const backend = new RecordingHeadlessBackend();
+    __testSetBackend(backend);
+    const listener = createRuntime();
+    const socket = new MockSocket();
+    const opts = makeListenerOptions();
+    const processedTurns: IncomingMessage[] = [];
+    const processIncomingMessage = mock(async (incoming: IncomingMessage) => {
+      processedTurns.push(incoming);
+    });
+    const getOrCreateScopedRuntimeMock = mock(
+      (
+        runtime: Parameters<typeof getOrCreateScopedRuntime>[0],
+        agentId: Parameters<typeof getOrCreateScopedRuntime>[1],
+        conversationId: Parameters<typeof getOrCreateScopedRuntime>[2],
+      ) => getOrCreateScopedRuntime(runtime, agentId, conversationId),
+    );
+    const trackListenerError = mock(() => {});
+    setActiveRuntime(listener);
+
+    const handleMessage = createListenerMessageHandler({
+      runtime: listener,
+      socket: socket as unknown as WebSocket,
+      opts,
+      processQueuedTurn: mock(async () => {}),
+      fileCommandSession: { handle: () => false },
+      getParsedRuntimeScope: getParsedRuntimeScopeForTest,
+      replaySyncStateForRuntime: async () => {},
+      getOrCreateScopedRuntime: getOrCreateScopedRuntimeMock,
+      handleApprovalResponseInput: async () => false,
+      handleChangeDeviceStateInput: async () => false,
+      handleAbortMessageInput: async () => false,
+      stampInboundUserMessageOtids: (incoming) => incoming,
+      safeSocketSend: () => true,
+      runDetachedListenerTask: () => {},
+      trackListenerError,
+      wireChannelIngress: async () => {},
+      processIncomingMessage,
+    });
+
+    await handleMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "input",
+          runtime: { agent_id: "agent-1", conversation_id: "conv-explicit" },
+          payload: {
+            kind: "create_message",
+            messages: [{ role: "user", content: "explicit" }],
+          },
+        }),
+      ),
+    );
+    await handleMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "input",
+          runtime: { agent_id: "agent-1", conversation_id: "default" },
+          payload: {
+            kind: "create_message",
+            messages: [{ role: "user", content: "default" }],
+          },
+        }),
+      ),
+    );
+    await waitFor(() => processedTurns.length === 2);
+
+    expect(trackListenerError).not.toHaveBeenCalled();
+    expect(backend.createConversationCalls).toHaveLength(0);
+    expect(processedTurns.map((turn) => turn.conversationId)).toEqual([
+      "conv-explicit",
+      "default",
+    ]);
+    expect(
+      getOrCreateScopedRuntimeMock.mock.calls.map((call) => call[2]),
+    ).toEqual(["conv-explicit", "default"]);
+  });
 
   test("a direct message that loses the idle race is queued and later drained", async () => {
     const listener = createRuntime();

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -1,4 +1,3 @@
-import type { ApprovalCreate } from "@letta-ai/letta-client/resources/agents/messages";
 import type WebSocket from "ws";
 import {
   estimateSystemPromptTokensFromMemoryDir,
@@ -40,6 +39,10 @@ import { getBootWorkingDirectory, getExportedCwdMap } from "./cwd";
 import { handleExternalToolCallResponseCommand } from "./external-tools";
 import { dispatchInboundMessageWhenReady } from "./inbound-dispatch";
 import { enqueueInboundUserMessage } from "./inbound-queue";
+import {
+  isNewConversationCreateMessageInput,
+  resolveCreateMessageRuntimeScope,
+} from "./new-conversation-sentinel";
 import {
   isExecuteCommandCommand,
   parseServerLifecycleMessage,
@@ -428,7 +431,7 @@ export function createListenerMessageHandler(
 
       console.log(`[Listen V2] Received ${summarizeV2Command(parsed)}`);
 
-      if (parsedScope) {
+      if (parsedScope && !isNewConversationCreateMessageInput(parsed)) {
         subscribeListenerConnection(runtime, connectionId, parsedScope);
       }
 
@@ -562,20 +565,13 @@ export function createListenerMessageHandler(
           return;
         }
 
-        const incoming: IncomingMessage = {
-          type: "message",
-          connectionId,
-          agentId: parsed.runtime.agent_id,
-          conversationId: parsed.runtime.conversation_id,
-          clientToolAllowlist: inputPayload.client_tool_allowlist,
-          externalToolScopeIds: inputPayload.external_tool_scope_ids,
-          excludeInteractiveTools: inputPayload.exclude_interactive_tools,
-          messages: inputPayload.messages,
-        };
-        const hasApprovalPayload = incoming.messages.some(
-          (payload): payload is ApprovalCreate =>
-            "type" in payload && payload.type === "approval",
-        );
+        const hasApprovalPayload = inputPayload.messages.some((payload) => {
+          if (!isRecord(payload)) {
+            return false;
+          }
+          const payloadType = (payload as Record<string, unknown>).type;
+          return payloadType === "approval";
+        });
         if (hasApprovalPayload) {
           emitLoopErrorNotice(socket, runtime, {
             message:
@@ -587,6 +583,33 @@ export function createListenerMessageHandler(
           });
           return;
         }
+
+        const createsConversation = isNewConversationCreateMessageInput(parsed);
+        const resolvedRuntime = createsConversation
+          ? await resolveCreateMessageRuntimeScope(parsed.runtime)
+          : parsed.runtime;
+        if (
+          createsConversation &&
+          (runtime !== getActiveRuntime() || runtime.intentionallyClosed)
+        ) {
+          console.log(
+            "[Listen V2] Dropping input after conversation creation: runtime mismatch or closed",
+          );
+          return;
+        }
+        parsedScope = resolvedRuntime;
+        subscribeListenerConnection(runtime, connectionId, resolvedRuntime);
+
+        const incoming: IncomingMessage = {
+          type: "message",
+          connectionId,
+          agentId: resolvedRuntime.agent_id,
+          conversationId: resolvedRuntime.conversation_id,
+          clientToolAllowlist: inputPayload.client_tool_allowlist,
+          externalToolScopeIds: inputPayload.external_tool_scope_ids,
+          excludeInteractiveTools: inputPayload.exclude_interactive_tools,
+          messages: inputPayload.messages,
+        };
 
         const scopedRuntime = getOrCreateScopedRuntime(
           runtime,
@@ -605,7 +628,7 @@ export function createListenerMessageHandler(
             options: opts,
             processQueuedTurn,
             processIncomingMessage,
-            actingUserId: parsed.runtime.acting_user_id,
+            actingUserId: resolvedRuntime.acting_user_id,
             trackListenerError,
           });
         };
@@ -622,7 +645,7 @@ export function createListenerMessageHandler(
           enqueueInboundUserMessage(
             scopedRuntime,
             stampedIncoming,
-            parsed.runtime.acting_user_id,
+            resolvedRuntime.acting_user_id,
           );
           scheduleQueuePump(scopedRuntime, socket, opts, processQueuedTurn);
           return;

--- a/src/websocket/listener/new-conversation-sentinel.ts
+++ b/src/websocket/listener/new-conversation-sentinel.ts
@@ -1,0 +1,42 @@
+import { actingUserRequestOptions } from "@/agent/acting-user";
+import { getBackend } from "@/backend/backend";
+
+// Cloud schedules persist this target so the execution listener can resolve it per fire.
+const NEW_CONVERSATION_TARGET = "new";
+
+export type InputRuntimeScope = {
+  agent_id: string;
+  conversation_id: string;
+  acting_user_id?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isNewConversationCreateMessageInput(parsed: unknown): boolean {
+  if (!isRecord(parsed) || parsed.type !== "input") {
+    return false;
+  }
+  if (!isRecord(parsed.runtime) || !isRecord(parsed.payload)) {
+    return false;
+  }
+  return (
+    parsed.payload.kind === "create_message" &&
+    parsed.runtime.conversation_id === NEW_CONVERSATION_TARGET
+  );
+}
+
+export async function resolveCreateMessageRuntimeScope(
+  runtimeScope: InputRuntimeScope,
+): Promise<InputRuntimeScope> {
+  if (runtimeScope.conversation_id !== NEW_CONVERSATION_TARGET) {
+    return runtimeScope;
+  }
+
+  const conversation = await getBackend().createConversation(
+    { agent_id: runtimeScope.agent_id },
+    actingUserRequestOptions(runtimeScope.acting_user_id),
+  );
+  return { ...runtimeScope, conversation_id: conversation.id };
+}


### PR DESCRIPTION
## Summary
- resolve the reserved `new` conversation target before listener runtime selection
- create a fresh concrete conversation for every scheduled input while preserving acting-user attribution
- keep explicit conversation IDs and `default` routing unchanged

## Why
Durable schedules persist `new` as a per-fire target. The listener previously treated it as a concrete conversation ID, so the handoff could succeed while the scheduled prompt never reached a valid conversation.

## Before / after
Before: `input.kind=create_message` selected a runtime scoped to `conversation_id: "new"` and forwarded that invalid ID downstream.

After: the listener creates a conversation through the normal backend path, subscribes the connection to the returned ID, and dispatches the original prompt into that concrete runtime.

## Risk and limits
- only `create_message` inputs with the exact reserved target `new` take the new path
- explicit IDs, `default`, approval inputs, and normal message queueing retain their existing behavior
- a runtime superseded during conversation creation does not receive the stale turn
- not live-tested against a managed Cloud schedule; the regression test exercises the listener frame and routing boundary directly

## Test plan
- [x] `bun test src/websocket/listener/message-router.test.ts` (4 passed)
- [x] regression test fails against the parent implementation and passes with this commit
- [x] `bun run check` (12 checks passed)
- [x] `node scripts/run-unit-tests.cjs` (660 passed; 7 pre-existing `app-server.test.ts` WebSocket failures reproduced unchanged on the parent under Bun 1.3.13)

Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

👾 Generated with [Letta Code](https://letta.com)