### PR TITLE
chore: remove Responses WebSocket experiment flag

### DIFF
--- a/scripts/dev.cjs
+++ b/scripts/dev.cjs
@@ -4,7 +4,6 @@ const { spawn } = require('node:child_process');
 
 const env = { ...process.env };
 if (!env.LETTA_DEBUG) env.LETTA_DEBUG = '1';
-if (!env.LETTA_RESPONSES_WS) env.LETTA_RESPONSES_WS = '1';
 
 const bunArgs = [
   '--loader=.md:text',

--- a/src/agent/message.ts
+++ b/src/agent/message.ts
@@ -406,9 +406,6 @@ export async function sendMessageStreamWithBackend(
   }
 
   const extraHeaders: Record<string, string> = {};
-  if (process.env.LETTA_RESPONSES_WS === "1") {
-    extraHeaders["X-Experimental-OpenAI-Responses-Websocket"] = "true";
-  }
   if (previousResponseId) {
     extraHeaders[RESPONSE_STATE_HEADER] = encodeResponseStateHeader({
       v: 1,


### PR DESCRIPTION
## Summary

- stop reading LETTA_RESPONSES_WS in Letta Code
- stop sending the experimental Responses WebSocket header
- remove the development default for the retired environment flag

After letta-ai/letta-cloud#13593 lands, streamed Responses requests are WebSocket-first on the server by default. That preserves the current WS proxy -> direct WS -> HTTP/SSE fallback chain without requiring client-side experiment plumbing.

## Dependency

- Depends on letta-ai/letta-cloud#13593 for self-hosted servers that do not already have the 100% cloud rollout middleware.

## Validation

- bun run check: all 12 checks passed, including Biome and TypeScript
- pre-commit staged-file checks: passed
