### PR TITLE
fix(worktree): distinguish existing worktree switches

### DIFF
--- a/src/cli/components/EnterWorktreeResultRenderer.tsx
+++ b/src/cli/components/EnterWorktreeResultRenderer.tsx
@@ -7,6 +7,7 @@ const PREFIX_WIDTH = 5; // `  └  ` or `     `
 const LABEL_WIDTH = 8;
 
 export interface EnterWorktreeDisplayResult {
+  action: "created" | "switched";
   path?: string;
   branch?: string;
   base?: string;
@@ -18,7 +19,13 @@ export function parseEnterWorktreeResult(
 ): EnterWorktreeDisplayResult | null {
   const normalized = text.replace(/\r\n/g, "\n");
   const firstLine = normalized.split("\n").find((line) => line.trim());
-  if (firstLine?.trim() !== "Created worktree.") {
+  const action =
+    firstLine?.trim() === "Created worktree."
+      ? "created"
+      : firstLine?.trim() === "Switched to existing worktree."
+        ? "switched"
+        : null;
+  if (!action) {
     return null;
   }
 
@@ -28,6 +35,7 @@ export function parseEnterWorktreeResult(
   };
 
   const result: EnterWorktreeDisplayResult = {
+    action,
     path: field("Path"),
     branch: field("Branch"),
     base: field("Base"),
@@ -36,6 +44,9 @@ export function parseEnterWorktreeResult(
   if (
     normalized.includes(
       "This conversation's working directory is now the new worktree.",
+    ) ||
+    normalized.includes(
+      "This conversation's working directory is now this worktree.",
     )
   ) {
     result.switchedCwd = true;
@@ -103,7 +114,11 @@ export function EnterWorktreeResultRenderer({
           <Text>{`  ${CLI_GLYPHS.result}  `}</Text>
         </Box>
         <Box flexGrow={1} width={contentWidth}>
-          <Text>Created worktree</Text>
+          <Text>
+            {parsed.action === "created"
+              ? "Created worktree"
+              : "Switched to existing worktree"}
+          </Text>
         </Box>
       </Box>
       {parsed.path ? <DetailRow label="Path" value={parsed.path} /> : null}

--- a/src/cli/enter-worktree-result-renderer.test.tsx
+++ b/src/cli/enter-worktree-result-renderer.test.tsx
@@ -44,7 +44,21 @@ const enterWorktreeResult = [
   "- Read README, AGENTS.md, or other project setup docs before running commands.",
 ].join("\n");
 
-async function renderEnterWorktreeToolCall(): Promise<string> {
+const switchedWorktreeResult = [
+  "Switched to existing worktree.",
+  "",
+  "Path: /Users/loaner/dev/letta-code-prod/.letta/worktrees/render-test-worktree",
+  "Branch: letta/render-test-worktree-a90824a8",
+  "",
+  "This conversation's working directory is now this worktree.",
+  "",
+  "Next steps:",
+  "- Confirm you are in the worktree with `git status` before editing.",
+].join("\n");
+
+async function renderEnterWorktreeToolCall(
+  resultText = enterWorktreeResult,
+): Promise<string> {
   const stdout = new CaptureStream() as CaptureStream & NodeJS.WriteStream;
   const instance = render(
     <ToolCallMessage
@@ -57,7 +71,7 @@ async function renderEnterWorktreeToolCall(): Promise<string> {
           name: "render-test-worktree",
           switch_cwd: false,
         }),
-        resultText: enterWorktreeResult,
+        resultText,
         resultOk: true,
         phase: "finished",
       }}
@@ -81,6 +95,7 @@ async function renderEnterWorktreeToolCall(): Promise<string> {
 
 test("parses EnterWorktree tool result fields", () => {
   expect(parseEnterWorktreeResult(enterWorktreeResult)).toEqual({
+    action: "created",
     path: "/Users/loaner/dev/letta-code-prod/.letta/worktrees/render-test-worktree",
     branch: "letta/render-test-worktree-a90824a8",
     base: "origin/main",
@@ -103,4 +118,21 @@ test("EnterWorktree tool result renders a compact structured summary", async () 
   expect(output).toContain("unchanged");
   expect(output).not.toContain("Next steps");
   expect(output).not.toContain("Confirm you are in the new worktree");
+});
+
+test("EnterWorktree tool result identifies an existing worktree switch", async () => {
+  expect(parseEnterWorktreeResult(switchedWorktreeResult)).toEqual({
+    action: "switched",
+    path: "/Users/loaner/dev/letta-code-prod/.letta/worktrees/render-test-worktree",
+    branch: "letta/render-test-worktree-a90824a8",
+    base: undefined,
+    switchedCwd: true,
+  });
+
+  const output = await renderEnterWorktreeToolCall(switchedWorktreeResult);
+
+  expect(output).toContain("Switched to existing worktree");
+  expect(output).not.toContain("Created worktree");
+  expect(output).toContain("CWD:");
+  expect(output).toContain("switched to worktree");
 });


### PR DESCRIPTION
Existing activity label always says "Created worktree" even when the actual tool result is "Switched to existing worktree."

## Summary
- parse both newly created and existing-worktree EnterWorktree results
- render “Switched to existing worktree” instead of the misleading creation label
- cover the existing-worktree result and CWD status in renderer tests

## Testing
- `bun test src/cli/enter-worktree-result-renderer.test.tsx`
- `bun run check`