### PR TITLE
feat(skills): add Agent SDK builder guidance

### DIFF
--- a/src/skills/building-with-letta-agent-sdk-feedback.test.ts
+++ b/src/skills/building-with-letta-agent-sdk-feedback.test.ts
@@ -88,7 +88,9 @@ describe("Agent SDK feedback logger", () => {
       version: "0.5.7",
       surface: "local",
     });
-    expect(statSync(outputPath).mode & 0o777).toBe(0o600);
+    if (process.platform !== "win32") {
+      expect(statSync(outputPath).mode & 0o777).toBe(0o600);
+    }
   });
 
   test("rejects nonzero friction without a suggestion", () => {

--- a/src/skills/building-with-letta-agent-sdk-feedback.test.ts
+++ b/src/skills/building-with-letta-agent-sdk-feedback.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dir, "..", "..");
+const scriptPath = join(
+  repoRoot,
+  "src",
+  "skills",
+  "builtin",
+  "building-with-letta-agent-sdk",
+  "scripts",
+  "log-feedback.mjs",
+);
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const path of tempDirs.splice(0)) {
+    rmSync(path, { recursive: true, force: true });
+  }
+});
+
+function makeProject(): string {
+  const project = mkdtempSync(join(tmpdir(), "letta-agent-sdk-feedback-"));
+  tempDirs.push(project);
+  return project;
+}
+
+describe("Agent SDK feedback logger", () => {
+  test("appends a private JSONL record with provenance", () => {
+    const project = makeProject();
+    const result = spawnSync(
+      "node",
+      [
+        scriptPath,
+        "--project",
+        project,
+        "--surface",
+        "local",
+        "--sdk-version",
+        "0.5.7",
+        "--run-id",
+        "test-run-1",
+        "--category",
+        "lifecycle",
+        "--friction",
+        "low",
+        "--summary",
+        "Cleanup needed an explicit expectation",
+        "--expected",
+        "The session closes every owned child",
+        "--observed",
+        "The test observed the declared cleanup path",
+        "--evidence",
+        "sdk-lifecycle.test.ts: cleanup receipt",
+        "--artifact",
+        "receipt:test-cleanup-1",
+        "--command",
+        "bun test sdk-lifecycle.test.ts",
+        "--suggestion",
+        "Return a typed cleanup receipt",
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(0);
+    const outputPath = join(
+      project,
+      ".letta",
+      "letta-agent-sdk-feedback.jsonl",
+    );
+    const lines = readFileSync(outputPath, "utf8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+
+    const record = JSON.parse(lines[0] ?? "{}") as Record<string, unknown>;
+    expect(record.schemaVersion).toBe(1);
+    expect(record.category).toBe("lifecycle");
+    expect(record.friction).toBe("low");
+    expect(record.runId).toBe("test-run-1");
+    expect(record.evidence).toEqual(["sdk-lifecycle.test.ts: cleanup receipt"]);
+    expect(record.artifacts).toEqual(["receipt:test-cleanup-1"]);
+    expect(record.commands).toEqual(["bun test sdk-lifecycle.test.ts"]);
+    expect(record.sdk).toEqual({
+      package: "@letta-ai/letta-agent-sdk",
+      version: "0.5.7",
+      surface: "local",
+    });
+    expect(statSync(outputPath).mode & 0o777).toBe(0o600);
+  });
+
+  test("rejects nonzero friction without a suggestion", () => {
+    const project = makeProject();
+    const result = spawnSync(
+      "node",
+      [
+        scriptPath,
+        "--project",
+        project,
+        "--category",
+        "lifecycle",
+        "--friction",
+        "low",
+        "--summary",
+        "Cleanup was unclear",
+        "--expected",
+        "A cleanup receipt",
+        "--observed",
+        "No receipt",
+        "--evidence",
+        "Close returned without a receipt",
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "--suggestion is required when friction is nonzero",
+    );
+  });
+});

--- a/src/skills/builtin/building-with-letta-agent-sdk/SKILL.md
+++ b/src/skills/builtin/building-with-letta-agent-sdk/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: building-with-letta-agent-sdk
+description: Builds durable automations, agent-backed services, project infrastructure, and multi-agent systems with the Letta Agent SDK. Use when the user mentions the Letta Agent SDK, LettaAgentClient, @letta-ai/letta-agent-sdk, programmatic persistent agents, SDK-backed automation, client tools, MCP, Cloud/local/remote sessions, or asks an agent to build infrastructure for itself. Requires expectation-driven tests, event/effect provenance, and an agent-authored SDK feedback record after every use.
+---
+
+# Building with the Letta Agent SDK
+
+Use the Agent SDK when persistent identity, memory, conversations, tools, or
+multi-environment execution are part of the product. Do not wrap a one-shot
+function in an agent because agents are fashionable this quarter.
+
+## Before writing code
+
+1. Fetch the current official docs. The SDK changes quickly; do not implement
+   from model memory, stale snippets, or the deprecated package name.
+   - https://docs.letta.com/agent-sdk/quickstart
+   - https://docs.letta.com/agent-sdk/reference
+   - https://docs.letta.com/agent-sdk/deployment
+   - https://docs.letta.com/agent-sdk/mcp
+2. Verify the installed package and its exported types:
+
+   ```bash
+   npm view @letta-ai/letta-agent-sdk version
+   node -p "require('./node_modules/@letta-ai/letta-agent-sdk/package.json').version"
+   ```
+
+   The current package is `@letta-ai/letta-agent-sdk` and the high-level client
+   is `LettaAgentClient`. `@letta-ai/letta-code-sdk` / `LettaCodeClient` are
+   legacy surfaces. If live docs and installed types disagree, use the installed
+   types for the build and record the discrepancy as feedback.
+3. Read [design-patterns.md](references/design-patterns.md) before choosing a
+   backend, identity/thread topology, or tool boundary.
+4. Read [testing-and-provenance.md](references/testing-and-provenance.md) before
+   defining the run contract or tests.
+
+There is currently no Python Agent SDK. Use TypeScript/JavaScript or implement
+the App Server WebSocket protocol directly only when the product truly needs
+protocol-level control.
+
+## Find the automation seam
+
+Look for work where persistence changes the value:
+
+- A role should learn from repeated work rather than restart from a prompt.
+- A project needs a resident agent with durable context and a stable identity.
+- A controller needs multiple agent roles, resumable threads, or background work.
+- Application-owned data or actions should be available through narrow tools.
+- The same manual coordination or synthesis recurs often enough to deserve a
+  product contract.
+
+Write the seam in one sentence before coding:
+
+```text
+When <trigger> occurs, persistent agent <role> receives <bounded context>, may
+use <bounded capabilities>, writes <durable result>, and emits <effect receipt>.
+```
+
+If persistence, tools, or memory do not improve the workflow, use an ordinary
+function, queue worker, or script.
+
+## Define the contract
+
+Specify these before implementation:
+
+- **Product owner:** the database or service that owns users, tasks, jobs,
+  authorization, idempotency, and effect receipts.
+- **Agent owner:** the persistent agent ID and the memory that role may change.
+- **Thread owner:** which workflow gets a new conversation and which resumes an
+  existing one. Persist conversation IDs outside process memory.
+- **Execution owner:** Cloud sandbox, named remote environment, local machine,
+  or separately operated App Server.
+- **Capability boundary:** built-in tools, client tools, MCP tools, repository
+  resources, permissions, and secrets.
+- **Result boundary:** the structured result, durable write, and receipt that
+  proves the effect occurred.
+- **Retry boundary:** what can be retried safely and how the controller detects
+  a turn that may already have reached the runtime.
+
+## Build one vertical slice
+
+Install the current package and import from the current public surface:
+
+```ts
+import { LettaAgentClient } from "@letta-ai/letta-agent-sdk";
+
+const client = new LettaAgentClient({ backend: "local" });
+
+const agentId = await client.createAgent({
+  persona: "You are the persistent maintainer for this project.",
+  human: "The user expects concise evidence, explicit risks, and durable notes.",
+});
+
+await using session = client.createSession(agentId, {
+  cwd: process.cwd(),
+  permissionMode: "standard",
+});
+
+await session.send("Inspect the project and produce one bounded artifact.");
+for await (const event of session.stream()) {
+  // Persist typed events and preserve unknown event types.
+  console.log(event);
+}
+```
+
+Use this only as the shape. Re-check current docs and installed types before
+copying it. Keep the first slice small enough to exercise the complete path:
+identity, session, context, tool policy, event stream, durable result, cleanup,
+and receipt.
+
+## Prove the behavior
+
+Write expectations before the live run. At minimum, test:
+
+1. The intended agent and conversation are created or resumed.
+2. The runtime sees the intended CWD/resources, not the SDK host path by
+   accident.
+3. Allowed and denied tools match the policy.
+4. The event consumer reaches a terminal `result`, records unknown events, and
+   does not mistake assistant text for completion.
+5. Tool failure, permission denial, timeout, and restart/reconnect behavior are
+   explicit.
+6. A potentially ambiguous send is reconciled through message history before
+   retry, avoiding duplicate work.
+7. Session closure releases client tools, MCP processes, and managed runtime
+   resources according to the selected backend.
+8. The claimed product effect has an external receipt.
+
+Prefer the cheapest suitable model returned by `session.listModels()` for smoke
+tests. Do not hardcode a model handle from memory. Run expensive or externally
+mutating tests only when authorized.
+
+## Record SDK feedback every time
+
+Every use of this skill must leave one agent-authored feedback record, including
+smooth runs. Record what was expected, what actually happened, evidence, and a
+specific streamlining suggestion when friction was nonzero.
+
+Set `SKILL_DIR` to the Skill Directory shown when this skill loads, then run:
+
+```bash
+node "$SKILL_DIR/scripts/log-feedback.mjs" \
+  --project "$PWD" \
+  --surface local \
+  --category lifecycle \
+  --friction low \
+  --summary "Session cleanup behavior was not obvious" \
+  --expected "Closing the session would await all child cleanup" \
+  --observed "Synchronous close returned before MCP shutdown completed" \
+  --evidence "test/sdk-lifecycle.test.ts: closes MCP children" \
+  --suggestion "Expose or document an async disposal receipt"
+```
+
+Default output:
+
+```text
+.letta/letta-agent-sdk-feedback.jsonl
+```
+
+Do not put credentials, private prompts, customer data, full model output, or
+raw environment values in feedback. Use test names, file paths, sanitized error
+classes, event types, timings, and receipt IDs. See
+[testing-and-provenance.md](references/testing-and-provenance.md) for the schema
+and categories.
+
+When feedback reveals a repeated workflow problem, update this skill instead of
+merely appending another complaint. When it reveals an SDK product problem,
+preserve a minimal reproduction suitable for the SDK repository.
+
+## Completion gate
+
+Do not call the work complete until all are true:
+
+- The source version and backend are identified.
+- Identity, conversation, state, capability, retry, and effect ownership are
+  explicit.
+- Tests cover the declared expectations and failure paths.
+- Runtime behavior has receipts rather than only source-code claims.
+- Secrets and private context are absent from logs and feedback.
+- The feedback JSONL record exists and parses.
+- The final report names changed files, checks, runtime receipts, feedback path,
+  and remaining risk.

--- a/src/skills/builtin/building-with-letta-agent-sdk/references/design-patterns.md
+++ b/src/skills/builtin/building-with-letta-agent-sdk/references/design-patterns.md
@@ -1,0 +1,139 @@
+# Letta Agent SDK design patterns
+
+Use this reference to choose the system shape before implementation. Fetch the
+official docs again when exact options or behavior matter.
+
+## Contents
+
+- Backend selection
+- Identity and conversation topology
+- State ownership
+- Capability surfaces
+- Automation candidates
+- Vertical-slice checklist
+- Current official sources
+
+## Backend selection
+
+| Need | Backend | Agent state | Tool execution |
+|---|---|---|---|
+| Fully managed | `cloud`, no environment | Letta Cloud | Managed sandbox |
+| Cloud identity on a chosen machine | `cloud` with `environment` | Letta Cloud | Selected remote environment |
+| Fully local | `local` | Current machine | Current machine |
+| Runtime operated separately | `remote` | App Server backend | App Server machine |
+
+For Cloud sessions, a caller's `process.cwd()` is not mounted into a managed
+sandbox. Set `cwd` to a path that exists in the selected execution environment.
+For client tools and MCP, remember that the implementation runs in the Node.js
+SDK host even when the agent runs in Cloud or on a remote App Server.
+
+Use a stable environment `id` or `deviceId` for durable routing. A
+`connectionId` names one live connection and can change after reconnect.
+
+## Identity and conversation topology
+
+- Use one persistent agent identity per durable role, not per task invocation.
+- Use separate conversations for independent work streams that should not share
+  immediate turn history.
+- Resume the same conversation for a continuing workflow.
+- Store agent IDs, conversation IDs, and product role mappings in the
+  controller database. Process memory is a cache, never the owner.
+- Parallelize across different conversations or agents. Keep at most one active
+  turn per `{agentId, conversationId}` from one controller.
+
+`createSession(agentId)` starts a new conversation. `resumeSession(agentId)`
+resumes the agent's default conversation. `resumeSession(conversationId)`
+resumes that exact thread. `prompt()` creates a short-lived new conversation;
+it is a poor fit when thread continuity is the point.
+
+## State ownership
+
+The application owns:
+
+- users, projects, teams, tasks, jobs, and status
+- authorization and secrets
+- idempotency keys and retry decisions
+- durable results and effect receipts
+- runtime registry and conversation mappings
+- raw or reduced event logs needed for recovery
+
+The Letta runtime owns:
+
+- agent identity, memory, and conversation history
+- turn execution and built-in computer-use tools
+- runtime CWD and permission mode
+- streaming model/tool events
+
+Do not turn agent memory into a hidden product database. Give the agent the
+context it needs and keep authoritative business state in ordinary storage.
+
+## Capability surfaces
+
+Use built-in tools for generic computer use such as reading files, editing, and
+shell commands.
+
+Use client tools for narrow JavaScript functions owned by the SDK host. Use
+strict JSON schemas, bounded outputs, abort signals, and stable receipt IDs.
+
+Use MCP when an existing server already owns the integration. MCP connections,
+stdio children, credentials, and filesystem access live on the SDK host and are
+session-scoped.
+
+Use Cloud repositories for hosted, git-backed UTF-8 text that should be
+projected into a Cloud session. Repository resources are read-write by default,
+session cleanup is asynchronous, and concurrent sessions are not
+reference-counted. Use content-hash preconditions for concurrent writes.
+
+Use direct App Server protocol control only when the Agent SDK does not expose
+the needed lifecycle or event primitive. Product-specific actions normally
+belong in client/external tools rather than new protocol commands.
+
+Treat tool visibility as a model-facing surface, not an authorization boundary.
+The controller must enforce real authorization.
+
+## Automation candidates
+
+Good SDK candidates have one or more of these properties:
+
+- a resident project maintainer should accumulate conventions and history
+- recurring research or operations should improve from past runs
+- a workflow needs human-facing conversation plus background execution
+- several durable roles should coordinate while retaining separate identities
+- app data should be available through narrow, audited actions
+- work must resume across process or machine restarts
+
+Weak candidates:
+
+- deterministic transforms with no need for memory or judgment
+- one API call hidden behind an agent
+- high-volume stateless inference
+- tasks whose authoritative state would exist only in a prompt
+
+## Vertical-slice checklist
+
+Build one path through:
+
+1. Resolve or create the intended persistent agent.
+2. Resolve or create the intended conversation.
+3. Select execution environment and CWD explicitly.
+4. Register the smallest necessary tools and permission policy.
+5. Send one idempotently identified request.
+6. Consume and persist events through terminal result.
+7. Commit one bounded product artifact or state transition.
+8. Verify the effect outside the agent transcript.
+9. Close the session and verify cleanup behavior.
+10. Write the SDK feedback record.
+
+## Current official sources
+
+- Quickstart: https://docs.letta.com/agent-sdk/quickstart
+- API reference: https://docs.letta.com/agent-sdk/reference
+- Deployment: https://docs.letta.com/agent-sdk/deployment
+- MCP and client tools: https://docs.letta.com/agent-sdk/mcp
+- Cloud repositories: https://docs.letta.com/agent-sdk/repositories
+- App Server integration patterns:
+  https://docs.letta.com/platform/app-server/integration-patterns
+- External tools:
+  https://docs.letta.com/platform/app-server/external-tools
+- Package: https://www.npmjs.com/package/@letta-ai/letta-agent-sdk
+- Source: https://github.com/letta-ai/letta-agent-sdk

--- a/src/skills/builtin/building-with-letta-agent-sdk/references/testing-and-provenance.md
+++ b/src/skills/builtin/building-with-letta-agent-sdk/references/testing-and-provenance.md
@@ -1,0 +1,171 @@
+# Testing and provenance contract
+
+Use this contract for every Agent SDK system. The goal is to make runtime
+behavior reconstructible without leaking private context.
+
+## Contents
+
+- Expectation-first tests
+- Run manifest
+- Event log
+- Effect receipts
+- Test matrix
+- Retry and recovery
+- Feedback categories
+
+## Expectation-first tests
+
+Before a live run, state:
+
+```text
+Given <initial durable state>
+When <one SDK action occurs>
+Then <observable SDK events appear>
+And <external effect receipt proves the product result>
+And <cleanup leaves the declared final state>
+```
+
+A transcript is not an effect receipt. An assistant saying it updated a ticket
+does not prove the ticket changed.
+
+## Run manifest
+
+Persist a sanitized manifest for important runs:
+
+```json
+{
+  "schemaVersion": 1,
+  "runId": "job-123:attempt-1",
+  "startedAt": "2026-07-31T00:00:00Z",
+  "sdk": {
+    "package": "@letta-ai/letta-agent-sdk",
+    "version": "0.0.0",
+    "backend": "local"
+  },
+  "runtime": {
+    "agentId": "agent-...",
+    "conversationId": "conv-...",
+    "sessionId": "session-...",
+    "environmentSelector": "sanitized-stable-id"
+  },
+  "request": {
+    "idempotencyKey": "job-123",
+    "inputSha256": "...",
+    "resourceRefs": ["repo-id@commit"]
+  },
+  "policy": {
+    "permissionMode": "standard",
+    "allowedTools": ["lookup_ticket", "Read"]
+  }
+}
+```
+
+Hash private input rather than logging it. Do not record API keys, authorization
+headers, raw environment variables, private prompts, or customer data.
+
+## Event log
+
+Store typed SDK events as an append-only sequence when replay or diagnosis
+matters:
+
+```json
+{
+  "runId": "job-123:attempt-1",
+  "sequence": 17,
+  "receivedAt": "2026-07-31T00:00:02.345Z",
+  "type": "tool_call",
+  "agentId": "agent-...",
+  "conversationId": "conv-...",
+  "payloadSha256": "...",
+  "sanitized": {
+    "toolName": "lookup_ticket",
+    "toolCallId": "call-..."
+  }
+}
+```
+
+- Consume until terminal `result`; assistant text is not terminal state.
+- Preserve unknown event types rather than throwing them away or crashing.
+- Keep a monotonic local sequence number and receipt timestamp.
+- Record tool-call IDs, error classes, durations, and output hashes.
+- Store full payloads only when the privacy/retention contract permits it.
+
+## Effect receipts
+
+For every mutation, capture the system-of-record receipt:
+
+- database row version or transaction ID
+- API request/response ID plus read-after-write verification
+- file path, content hash, and Git commit
+- queue/job ID and terminal status
+- repository ID, file content hash, and commit SHA
+
+Correlate the effect receipt with the run ID and tool-call ID. If the external
+system offers no receipt, perform a bounded readback and hash the observed state.
+
+## Test matrix
+
+### Pure contract tests
+
+- option and schema validation
+- event reducer, including an unknown future event type
+- tool input validation and bounded output
+- authorization independent of model behavior
+- idempotency-key behavior
+- log redaction and feedback JSONL parsing
+
+### Integration tests
+
+- intended agent and conversation are selected
+- CWD/resources exist in the execution environment
+- allowed tool succeeds and denied tool is rejected
+- tool-level error remains distinct from transport failure
+- stream reaches a successful or failed terminal result
+- session close releases local children and connections
+
+### Live smoke test
+
+Use the cheapest suitable model returned by `listModels()`. Exercise one
+non-destructive end-to-end path. Capture agent/conversation/session IDs, terminal
+result, timings, and an external readback receipt.
+
+### Recovery tests
+
+- controller restart resumes the stored conversation
+- App Server reconnect re-establishes runtime and state before new work
+- expired managed sandbox creates a fresh session around the same conversation
+- timeout after a successful `send()` checks message history before retry
+- duplicate controller delivery does not duplicate the product effect
+- cleanup failure is observable and repairable
+
+## Retry and recovery
+
+Automatic retry is safe only when the SDK proves the message was not sent, such
+as a pre-send managed-sandbox expiration. After an ambiguous connection failure:
+
+1. Reconnect or resume the same conversation.
+2. Inspect conversation messages and durable product state.
+3. Reconcile the request idempotency key.
+4. Retry only if neither the turn nor its effect exists.
+
+Never clear conversation state to recover from a transport problem.
+
+## Feedback categories
+
+The bundled logger accepts:
+
+- `smooth-path`
+- `discovery`
+- `installation`
+- `types-api`
+- `lifecycle`
+- `tools-permissions`
+- `events-provenance`
+- `deployment`
+- `docs-examples`
+- `performance-cost`
+- `other`
+
+Use friction `none`, `low`, `medium`, `high`, or `blocking`. Nonzero friction
+requires a specific suggestion. Evidence should be a sanitized test name, file
+path, error class, timing, event type, or receipt ID.

--- a/src/skills/builtin/building-with-letta-agent-sdk/scripts/log-feedback.mjs
+++ b/src/skills/builtin/building-with-letta-agent-sdk/scripts/log-feedback.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import {
+  appendFileSync,
+  chmodSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+const categories = new Set([
+  "smooth-path",
+  "discovery",
+  "installation",
+  "types-api",
+  "lifecycle",
+  "tools-permissions",
+  "events-provenance",
+  "deployment",
+  "docs-examples",
+  "performance-cost",
+  "other",
+]);
+
+const frictionLevels = new Set(["none", "low", "medium", "high", "blocking"]);
+const surfaces = new Set(["cloud", "local", "remote", "app-server"]);
+const scalarKeys = new Set([
+  "category",
+  "friction",
+  "summary",
+  "expected",
+  "observed",
+  "suggestion",
+  "workaround",
+  "surface",
+  "sdk-version",
+  "run-id",
+  "project",
+  "output",
+]);
+const sensitiveValuePatterns = [
+  /\b(?:api[_ -]?key|authorization|password|secret)\s*[:=]\s*\S+/i,
+  /\bbearer\s+[a-z0-9._~+/=-]{8,}/i,
+  /\b(?:gh[opusr]_[a-z0-9]{20,}|sk-[a-z0-9_-]{20,})\b/i,
+];
+
+function usage() {
+  return `Usage:
+  node log-feedback.mjs \\
+    --category <category> \\
+    --friction <none|low|medium|high|blocking> \\
+    --summary <short summary> \\
+    --expected <expected behavior> \\
+    --observed <observed behavior> \\
+    --evidence <sanitized evidence> [--evidence <more>] \\
+    [--suggestion <specific improvement>] \\
+    [--workaround <sanitized workaround>] \\
+    [--artifact <path-or-receipt>] [--command <sanitized command>] \\
+    [--surface <cloud|local|remote|app-server>] \\
+    [--sdk-version <version>] [--run-id <id>] \\
+    [--project <path>] [--output <jsonl-path>]
+
+Categories: ${[...categories].join(", ")}
+
+Do not include credentials, authorization headers, private prompts, customer
+data, raw environment values, or full model output.`;
+}
+
+function fail(message) {
+  console.error(`Error: ${message}\n\n${usage()}`);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const values = new Map();
+  const repeated = new Map([
+    ["evidence", []],
+    ["artifact", []],
+    ["command", []],
+  ]);
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      console.log(usage());
+      process.exit(0);
+    }
+    if (!arg.startsWith("--")) fail(`Unexpected argument: ${arg}`);
+    const key = arg.slice(2);
+    if (!scalarKeys.has(key) && !repeated.has(key)) {
+      fail(`Unknown option: --${key}`);
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) fail(`Missing value for --${key}`);
+    index += 1;
+    if (repeated.has(key)) repeated.get(key).push(value);
+    else if (values.has(key)) fail(`Duplicate --${key}`);
+    else values.set(key, value);
+  }
+
+  return { values, repeated };
+}
+
+function optional(values, key) {
+  return values.get(key) || null;
+}
+
+function required(values, key) {
+  const value = values.get(key)?.trim();
+  if (!value) fail(`--${key} is required`);
+  return value;
+}
+
+function gitValue(projectPath, args) {
+  try {
+    return execFileSync("git", ["-C", projectPath, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function findSdkVersion(projectPath) {
+  let current = projectPath;
+  while (true) {
+    const packagePath = join(
+      current,
+      "node_modules",
+      "@letta-ai",
+      "letta-agent-sdk",
+      "package.json",
+    );
+    try {
+      return JSON.parse(readFileSync(packagePath, "utf8")).version ?? null;
+    } catch {
+      // Continue toward the filesystem root.
+    }
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function rejectLikelySecrets(values) {
+  for (const value of values) {
+    if (sensitiveValuePatterns.some((pattern) => pattern.test(value))) {
+      fail("Feedback appears to contain a credential or secret assignment");
+    }
+  }
+}
+
+function main() {
+  const { values, repeated } = parseArgs(process.argv.slice(2));
+  const category = required(values, "category");
+  const friction = required(values, "friction");
+  const summary = required(values, "summary");
+  const expected = required(values, "expected");
+  const observed = required(values, "observed");
+  const evidence = repeated
+    .get("evidence")
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+  if (!categories.has(category)) fail(`Unknown category: ${category}`);
+  if (!frictionLevels.has(friction))
+    fail(`Unknown friction level: ${friction}`);
+  const surface = optional(values, "surface");
+  if (surface && !surfaces.has(surface)) fail(`Unknown surface: ${surface}`);
+  if (evidence.length === 0) fail("At least one --evidence value is required");
+  if (friction !== "none" && !optional(values, "suggestion")) {
+    fail("--suggestion is required when friction is nonzero");
+  }
+  rejectLikelySecrets([
+    summary,
+    expected,
+    observed,
+    ...evidence,
+    ...repeated.get("artifact"),
+    ...repeated.get("command"),
+    ...[optional(values, "suggestion"), optional(values, "workaround")].filter(
+      Boolean,
+    ),
+  ]);
+
+  const projectInput = resolve(optional(values, "project") ?? process.cwd());
+  let projectPath;
+  try {
+    projectPath = realpathSync(projectInput);
+  } catch {
+    fail(`Project path does not exist: ${projectInput}`);
+  }
+
+  const outputPath = resolve(
+    optional(values, "output") ??
+      join(projectPath, ".letta", "letta-agent-sdk-feedback.jsonl"),
+  );
+
+  const gitRoot = gitValue(projectPath, ["rev-parse", "--show-toplevel"]);
+  const gitCommit = gitValue(projectPath, ["rev-parse", "HEAD"]);
+  const gitBranch = gitValue(projectPath, ["branch", "--show-current"]);
+  const gitStatus = gitValue(projectPath, ["status", "--porcelain=v1"]);
+
+  const record = {
+    schemaVersion: 1,
+    id: `sdk-feedback-${randomUUID()}`,
+    recordedAt: new Date().toISOString(),
+    category,
+    friction,
+    summary,
+    expected,
+    observed,
+    evidence,
+    suggestion: optional(values, "suggestion"),
+    workaround: optional(values, "workaround"),
+    artifacts: repeated.get("artifact"),
+    commands: repeated.get("command"),
+    runId: optional(values, "run-id"),
+    sdk: {
+      package: "@letta-ai/letta-agent-sdk",
+      version: optional(values, "sdk-version") ?? findSdkVersion(projectPath),
+      surface,
+    },
+    provenance: {
+      projectPath,
+      gitRoot,
+      gitCommit,
+      gitBranch,
+      gitDirty: gitStatus === null ? null : gitStatus.length > 0,
+      agentId: process.env.AGENT_ID ?? null,
+      conversationId: process.env.CONVERSATION_ID ?? null,
+      nodeVersion: process.version,
+    },
+  };
+
+  mkdirSync(dirname(outputPath), { recursive: true });
+  appendFileSync(outputPath, `${JSON.stringify(record)}\n`, { mode: 0o600 });
+  chmodSync(outputPath, 0o600);
+  console.log(`Recorded Agent SDK feedback: ${outputPath}`);
+  console.log(`Feedback ID: ${record.id}`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a bundled skill for designing durable Letta Agent SDK automations from current docs and installed types
- require explicit identity, conversation, capability, retry, testing, and effect-provenance contracts
- add a private JSONL feedback logger so each SDK use generates structured product feedback

## Validation
- `bun test src/skills/building-with-letta-agent-sdk-feedback.test.ts`
- bundled skill validator and package validator
- targeted Biome, skill-frontmatter, bundled-script, and whitespace checks
- pre-commit architectural checks, lint-staged formatting, and `tsc --noEmit`

Written by Cameron ◯ Letta Code