### PR TITLE
fix(tools): scope task CRUD state by conversation

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -15,7 +15,7 @@
   "src/cli/components/InputRich.tsx": 2225,
   "src/cli/components/ModelSelector.tsx": 1262,
   "src/cli/components/ProviderSelector.tsx": 1692,
-  "src/cli/components/ToolCallMessageRich.tsx": 1109,
+  "src/cli/components/ToolCallMessageRich.tsx": 1108,
   "src/cli/helpers/accumulator.ts": 1596,
   "src/cli/helpers/reflection-transcript.ts": 1956,
   "src/cli/helpers/stream.ts": 1046,

--- a/src/cli/app/AppView.tsx
+++ b/src/cli/app/AppView.tsx
@@ -1,5 +1,3 @@
-// src/cli/app/AppView.tsx
-
 import { APIError } from "@letta-ai/letta-client/core/error";
 import type { AgentState } from "@letta-ai/letta-client/resources/agents/agents";
 import { Box } from "ink";
@@ -501,6 +499,8 @@ export function AppView(props: AppViewProps) {
         precomputedDiffs={precomputedDiffsRef.current}
         hiddenToolCallId={expandedToolCallId ?? undefined}
         lastShellToolCallId={lastShellToolCallId ?? undefined}
+        agentId={agentId}
+        conversationId={conversationId}
       />
 
       <Box flexDirection="column">
@@ -607,7 +607,6 @@ export function AppView(props: AppViewProps) {
                         ) : ln.kind === "tool_call" &&
                           ln.toolCallId &&
                           queuedIds.has(ln.toolCallId) ? (
-                          // Render stub for queued (decided but not executed) approval
                           <PendingApprovalStub
                             toolName={
                               approvalMap.get(ln.toolCallId)?.toolName ||
@@ -620,7 +619,6 @@ export function AppView(props: AppViewProps) {
                         ) : ln.kind === "tool_call" &&
                           ln.toolCallId &&
                           pendingIds.has(ln.toolCallId) ? (
-                          // Render stub for pending (undecided) approval
                           <PendingApprovalStub
                             toolName={
                               approvalMap.get(ln.toolCallId)?.toolName ||
@@ -636,6 +634,8 @@ export function AppView(props: AppViewProps) {
                             isStreaming={streaming}
                             expandedToolCallId={expandedToolCallId}
                             lastShellToolCallId={lastShellToolCallId}
+                            agentId={agentId}
+                            conversationId={conversationId}
                           />
                         ) : ln.kind === "error" ? (
                           <ErrorMessage line={ln} />

--- a/src/cli/app/StaticTranscript.tsx
+++ b/src/cli/app/StaticTranscript.tsx
@@ -25,6 +25,8 @@ export function StaticTranscript({
   precomputedDiffs,
   hiddenToolCallId,
   lastShellToolCallId,
+  agentId,
+  conversationId,
 }: {
   renderEpoch: number;
   items: StaticItem[];
@@ -33,6 +35,8 @@ export function StaticTranscript({
   showCompactionsEnabled: boolean;
   precomputedDiffs: Map<string, AdvancedDiffSuccess>;
   hiddenToolCallId?: string;
+  agentId: string;
+  conversationId: string;
   /** Used to show ctrl+o hint on the last committed tool call.
    *  Intentionally NOT included in the Static key — passing it here without
    *  keying on it means the hint shows correctly when an item first commits,
@@ -64,6 +68,8 @@ export function StaticTranscript({
                   precomputedDiffs={precomputedDiffs}
                   expandedToolCallId={hiddenToolCallId}
                   lastShellToolCallId={lastShellToolCallId}
+                  agentId={agentId}
+                  conversationId={conversationId}
                 />
               ) : item.kind === "subagent_group" ? (
                 <SubagentGroupStatic agents={item.agents} />

--- a/src/cli/components/ToolCallMessageRich.tsx
+++ b/src/cli/components/ToolCallMessageRich.tsx
@@ -8,6 +8,7 @@ import {
   parsePatchOperations,
 } from "@/cli/helpers/format-args-display.js";
 import { CLI_GLYPHS } from "@/cli/helpers/glyphs";
+import { taskCrudTodos } from "@/cli/helpers/task-crud-rendering";
 import {
   getDisplayToolName,
   isFileEditTool,
@@ -26,7 +27,6 @@ import {
 } from "@/cli/helpers/tool-name-mapping.js";
 import { formatUnifiedExecOutputForTui } from "@/cli/helpers/unified-exec-output.js";
 import { INTERRUPTED_BY_USER } from "@/constants";
-import { listTasks } from "@/tools/impl/tasks/store.js";
 import { clipToolReturn } from "@/tools/manager.js";
 import { isRecord } from "@/utils/type-guards";
 import { Text } from "./Text";
@@ -154,12 +154,16 @@ export const ToolCallMessage = memo(
     isStreaming,
     expandedToolCallId,
     lastShellToolCallId,
+    agentId,
+    conversationId,
   }: {
     line: ToolCallLine;
     precomputedDiffs?: Map<string, AdvancedDiffSuccess>;
     isStreaming?: boolean;
     expandedToolCallId?: string | null;
     lastShellToolCallId?: string | null;
+    agentId?: string;
+    conversationId?: string;
   }) => {
     const columns = useTerminalWidth();
     try {
@@ -483,16 +487,11 @@ export const ToolCallMessage = memo(
         // see the live task state instead of raw JSON.
         if (isTaskCrudTool(rawName) && line.resultOk !== false) {
           try {
-            const tasks = listTasks();
-            if (tasks.length > 0) {
-              const safeTodos = tasks.map((t) => ({
-                content: t.subject,
-                status: (t.status === "deleted" ? "completed" : t.status) as
-                  | "pending"
-                  | "in_progress"
-                  | "completed",
-                id: t.taskId,
-              }));
+            const safeTodos =
+              agentId && conversationId
+                ? taskCrudTodos({ agentId, conversationId })
+                : [];
+            if (safeTodos.length > 0) {
               return <TodoRenderer todos={safeTodos} />;
             }
           } catch {

--- a/src/cli/helpers/task-crud-rendering.test.ts
+++ b/src/cli/helpers/task-crud-rendering.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { taskCrudTodos } from "@/cli/helpers/task-crud-rendering";
+import {
+  _resetTaskStoreForTests,
+  createTask,
+  updateTask,
+} from "@/tools/impl/tasks/store";
+
+describe("task CRUD rendering", () => {
+  const scope = {
+    agentId: "agent-render",
+    conversationId: "conversation-render",
+  };
+
+  beforeEach(() => {
+    _resetTaskStoreForTests();
+  });
+
+  test("projects only the requested scope into todo rows", () => {
+    const task = createTask(scope, {
+      subject: "Visible task",
+      description: "Render this task",
+    });
+    createTask(
+      { agentId: "other-agent", conversationId: "other-conversation" },
+      {
+        subject: "Hidden task",
+        description: "Do not render this task",
+      },
+    );
+    updateTask(scope, { taskId: task.taskId, status: "in_progress" });
+
+    expect(taskCrudTodos(scope)).toEqual([
+      {
+        content: "Visible task",
+        status: "in_progress",
+        id: task.taskId,
+      },
+    ]);
+  });
+
+  test("preserves completed task status", () => {
+    const task = createTask(scope, {
+      subject: "Completed task",
+      description: "Render completed status",
+    });
+    updateTask(scope, { taskId: task.taskId, status: "completed" });
+
+    expect(taskCrudTodos(scope)).toEqual([
+      {
+        content: "Completed task",
+        status: "completed",
+        id: task.taskId,
+      },
+    ]);
+  });
+});

--- a/src/cli/helpers/task-crud-rendering.ts
+++ b/src/cli/helpers/task-crud-rendering.ts
@@ -1,0 +1,15 @@
+import { listTasks, type TaskStoreScope } from "@/tools/impl/tasks/store.js";
+
+export interface TaskCrudTodo {
+  content: string;
+  status: "pending" | "in_progress" | "completed";
+  id: string;
+}
+
+export function taskCrudTodos(scope: TaskStoreScope): TaskCrudTodo[] {
+  return listTasks(scope).map((task) => ({
+    content: task.subject,
+    status: task.status === "deleted" ? "completed" : task.status,
+    id: task.taskId,
+  }));
+}

--- a/src/tools/impl/task-create.ts
+++ b/src/tools/impl/task-create.ts
@@ -1,3 +1,4 @@
+import { requireTaskStoreScope } from "./tasks/scope.js";
 import { createTask, type TaskRecord } from "./tasks/store.js";
 import { validateRequiredParams } from "./validation.js";
 
@@ -36,7 +37,7 @@ export async function task_create(args: TaskCreateArgs): Promise<TaskRecord> {
     }
   }
 
-  return createTask({
+  return createTask(requireTaskStoreScope(), {
     subject: args.subject,
     description: args.description,
     activeForm: args.activeForm,

--- a/src/tools/impl/task-get.ts
+++ b/src/tools/impl/task-get.ts
@@ -1,3 +1,4 @@
+import { requireTaskStoreScope } from "./tasks/scope.js";
 import { getTask, type TaskRecord } from "./tasks/store.js";
 import { validateRequiredParams } from "./validation.js";
 
@@ -10,7 +11,7 @@ export async function task_get(args: TaskGetArgs): Promise<TaskRecord> {
   if (typeof args.taskId !== "string" || args.taskId.length === 0) {
     throw new Error("TaskGet: 'taskId' must be a non-empty string");
   }
-  const record = getTask(args.taskId);
+  const record = getTask(requireTaskStoreScope(), args.taskId);
   if (!record) {
     throw new Error(`TaskGet: task not found: ${args.taskId}`);
   }

--- a/src/tools/impl/task-list.ts
+++ b/src/tools/impl/task-list.ts
@@ -1,3 +1,4 @@
+import { requireTaskStoreScope } from "./tasks/scope.js";
 import { listTasks, type TaskRecord } from "./tasks/store.js";
 
 interface TaskListResult {
@@ -7,5 +8,5 @@ interface TaskListResult {
 export async function task_list(
   _args: Record<string, unknown>,
 ): Promise<TaskListResult> {
-  return { tasks: listTasks() };
+  return { tasks: listTasks(requireTaskStoreScope()) };
 }

--- a/src/tools/impl/task-update.ts
+++ b/src/tools/impl/task-update.ts
@@ -1,3 +1,4 @@
+import { requireTaskStoreScope } from "./tasks/scope.js";
 import {
   TaskNotFoundError,
   type TaskRecord,
@@ -78,7 +79,7 @@ export async function task_update(args: TaskUpdateArgs): Promise<TaskRecord> {
   const addBlockedBy = validateStringArray(args.addBlockedBy, "addBlockedBy");
 
   try {
-    return updateTask({
+    return updateTask(requireTaskStoreScope(), {
       taskId: args.taskId,
       status: args.status as TaskStatus | undefined,
       subject: args.subject,

--- a/src/tools/impl/tasks/scope.ts
+++ b/src/tools/impl/tasks/scope.ts
@@ -1,0 +1,16 @@
+import { getRuntimeContext } from "@/runtime-context";
+import type { TaskStoreScope } from "./store.js";
+
+export function requireTaskStoreScope(): TaskStoreScope {
+  const runtimeContext = getRuntimeContext();
+  const agentId = runtimeContext?.agentId;
+  const conversationId = runtimeContext?.conversationId;
+
+  if (!agentId || !conversationId) {
+    throw new Error(
+      "Task tools require an agent and conversation execution scope",
+    );
+  }
+
+  return { agentId, conversationId };
+}

--- a/src/tools/impl/tasks/store.ts
+++ b/src/tools/impl/tasks/store.ts
@@ -4,12 +4,14 @@
  * This powers TaskCreate / TaskGet / TaskList / TaskUpdate — the replacement
  * for the older stateless `TodoWrite` tool. Tasks have stable IDs, dependency
  * edges (blocks/blockedBy), optional owner, and a free-form metadata bag.
- *
- * Scope: process-lifetime. Same model as `process_manager.ts`'s background
- * task registry. A future follow-up may scope per-conversation.
  */
 
 export type TaskStatus = "pending" | "in_progress" | "completed" | "deleted";
+
+export interface TaskStoreScope {
+  agentId: string;
+  conversationId: string;
+}
 
 export interface TaskRecord {
   taskId: string;
@@ -27,13 +29,39 @@ export interface TaskRecord {
   updatedAt: number;
 }
 
-const tasks = new Map<string, TaskRecord>();
-/** Stable insertion order for TaskList */
-const insertionOrder: string[] = [];
+type ScopedTaskStore = {
+  tasks: Map<string, TaskRecord>;
+  /** Stable insertion order for TaskList */
+  insertionOrder: string[];
+};
+
+const taskStoresByAgent = new Map<string, Map<string, ScopedTaskStore>>();
 let taskIdCounter = 1;
 
 function nextTaskId(): string {
   return `task_${taskIdCounter++}`;
+}
+
+function getTaskStore(
+  scope: TaskStoreScope,
+  create: boolean,
+): ScopedTaskStore | undefined {
+  let storesByConversation = taskStoresByAgent.get(scope.agentId);
+  if (!storesByConversation) {
+    if (!create) return undefined;
+    storesByConversation = new Map();
+    taskStoresByAgent.set(scope.agentId, storesByConversation);
+  }
+
+  let store = storesByConversation.get(scope.conversationId);
+  if (!store && create) {
+    store = {
+      tasks: new Map(),
+      insertionOrder: [],
+    };
+    storesByConversation.set(scope.conversationId, store);
+  }
+  return store;
 }
 
 function cloneMetadata(
@@ -60,7 +88,14 @@ export interface CreateTaskInput {
   metadata?: Record<string, string>;
 }
 
-export function createTask(input: CreateTaskInput): TaskRecord {
+export function createTask(
+  scope: TaskStoreScope,
+  input: CreateTaskInput,
+): TaskRecord {
+  const store = getTaskStore(scope, true);
+  if (!store) {
+    throw new Error("Failed to initialize task store");
+  }
   const now = Date.now();
   const record: TaskRecord = {
     taskId: nextTaskId(),
@@ -74,13 +109,16 @@ export function createTask(input: CreateTaskInput): TaskRecord {
     createdAt: now,
     updatedAt: now,
   };
-  tasks.set(record.taskId, record);
-  insertionOrder.push(record.taskId);
+  store.tasks.set(record.taskId, record);
+  store.insertionOrder.push(record.taskId);
   return { ...record };
 }
 
-export function getTask(taskId: string): TaskRecord | undefined {
-  const t = tasks.get(taskId);
+export function getTask(
+  scope: TaskStoreScope,
+  taskId: string,
+): TaskRecord | undefined {
+  const t = getTaskStore(scope, false)?.tasks.get(taskId);
   return t ? { ...t } : undefined;
 }
 
@@ -88,10 +126,16 @@ export interface ListTasksOptions {
   includeDeleted?: boolean;
 }
 
-export function listTasks(options: ListTasksOptions = {}): TaskRecord[] {
+export function listTasks(
+  scope: TaskStoreScope,
+  options: ListTasksOptions = {},
+): TaskRecord[] {
+  const store = getTaskStore(scope, false);
+  if (!store) return [];
+
   const out: TaskRecord[] = [];
-  for (const id of insertionOrder) {
-    const t = tasks.get(id);
+  for (const id of store.insertionOrder) {
+    const t = store.tasks.get(id);
     if (!t) continue;
     if (!options.includeDeleted && t.status === "deleted") continue;
     out.push({ ...t });
@@ -118,8 +162,11 @@ export class TaskNotFoundError extends Error {
   }
 }
 
-export function updateTask(input: UpdateTaskInput): TaskRecord {
-  const existing = tasks.get(input.taskId);
+export function updateTask(
+  scope: TaskStoreScope,
+  input: UpdateTaskInput,
+): TaskRecord {
+  const existing = getTaskStore(scope, false)?.tasks.get(input.taskId);
   if (!existing) {
     throw new TaskNotFoundError(input.taskId);
   }
@@ -147,9 +194,19 @@ export function updateTask(input: UpdateTaskInput): TaskRecord {
   return { ...existing };
 }
 
+export function clearTaskStoreScope(scope: TaskStoreScope): boolean {
+  const storesByConversation = taskStoresByAgent.get(scope.agentId);
+  if (!storesByConversation) return false;
+
+  const deleted = storesByConversation.delete(scope.conversationId);
+  if (storesByConversation.size === 0) {
+    taskStoresByAgent.delete(scope.agentId);
+  }
+  return deleted;
+}
+
 /** Test-only hook to reset state between unit tests. */
 export function _resetTaskStoreForTests(): void {
-  tasks.clear();
-  insertionOrder.length = 0;
+  taskStoresByAgent.clear();
   taskIdCounter = 1;
 }

--- a/src/tools/task-crud.test.ts
+++ b/src/tools/task-crud.test.ts
@@ -1,9 +1,54 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { task_create } from "@/tools/impl/task-create";
-import { task_get } from "@/tools/impl/task-get";
-import { task_list } from "@/tools/impl/task-list";
-import { task_update } from "@/tools/impl/task-update";
-import { _resetTaskStoreForTests } from "@/tools/impl/tasks/store";
+import {
+  getRuntimeContext,
+  type RuntimeContextSnapshot,
+  runOutsideRuntimeContext,
+  runWithRuntimeContext,
+} from "@/runtime-context";
+import { task_create as taskCreateImpl } from "@/tools/impl/task-create";
+import { task_get as taskGetImpl } from "@/tools/impl/task-get";
+import { task_list as taskListImpl } from "@/tools/impl/task-list";
+import { task_update as taskUpdateImpl } from "@/tools/impl/task-update";
+import {
+  _resetTaskStoreForTests,
+  clearTaskStoreScope,
+} from "@/tools/impl/tasks/store";
+
+const DEFAULT_SCOPE = {
+  agentId: "agent-default",
+  conversationId: "conversation-default",
+} satisfies RuntimeContextSnapshot;
+
+function inTaskScope<T>(
+  fn: () => T,
+  scope: RuntimeContextSnapshot = DEFAULT_SCOPE,
+): T {
+  return runWithRuntimeContext(scope, fn);
+}
+
+function withDefaultTaskScope<T>(fn: () => T): T {
+  const runtimeContext = getRuntimeContext();
+  if (runtimeContext?.agentId && runtimeContext.conversationId) {
+    return fn();
+  }
+  return inTaskScope(fn);
+}
+
+function task_create(...args: Parameters<typeof taskCreateImpl>) {
+  return withDefaultTaskScope(() => taskCreateImpl(...args));
+}
+
+function task_get(...args: Parameters<typeof taskGetImpl>) {
+  return withDefaultTaskScope(() => taskGetImpl(...args));
+}
+
+function task_list(...args: Parameters<typeof taskListImpl>) {
+  return withDefaultTaskScope(() => taskListImpl(...args));
+}
+
+function task_update(...args: Parameters<typeof taskUpdateImpl>) {
+  return withDefaultTaskScope(() => taskUpdateImpl(...args));
+}
 
 describe("Task CRUD family", () => {
   beforeEach(() => {
@@ -45,6 +90,83 @@ describe("Task CRUD family", () => {
     await expect(task_create({ description: "x" } as never)).rejects.toThrow(
       /subject/,
     );
+  });
+
+  test("TaskCreate rejects execution without an agent/conversation scope", async () => {
+    await expect(
+      runOutsideRuntimeContext(() =>
+        taskCreateImpl({ subject: "x", description: "y" }),
+      ),
+    ).rejects.toThrow(/agent and conversation execution scope/);
+  });
+
+  test("Task CRUD isolates concurrent agent and conversation scopes", async () => {
+    const scopeA = { agentId: "agent-a", conversationId: "conversation-a" };
+    const scopeB = { agentId: "agent-b", conversationId: "conversation-b" };
+
+    const [taskA, taskB] = await Promise.all([
+      inTaskScope(
+        () => task_create({ subject: "A", description: "scope A" }),
+        scopeA,
+      ),
+      inTaskScope(
+        () => task_create({ subject: "B", description: "scope B" }),
+        scopeB,
+      ),
+    ]);
+
+    const [listA, listB] = await Promise.all([
+      inTaskScope(() => task_list({}), scopeA),
+      inTaskScope(() => task_list({}), scopeB),
+    ]);
+
+    expect(listA.tasks.map((task) => task.taskId)).toEqual([taskA.taskId]);
+    expect(listB.tasks.map((task) => task.taskId)).toEqual([taskB.taskId]);
+    await expect(
+      inTaskScope(() => task_get({ taskId: taskA.taskId }), scopeB),
+    ).rejects.toThrow(/not found/);
+    await expect(
+      inTaskScope(
+        () => task_update({ taskId: taskA.taskId, status: "completed" }),
+        scopeB,
+      ),
+    ).rejects.toThrow(/not found/);
+  });
+
+  test("Task CRUD isolates default conversations belonging to different agents", async () => {
+    const agentA = { agentId: "agent-a", conversationId: "default" };
+    const agentB = { agentId: "agent-b", conversationId: "default" };
+    const taskA = await inTaskScope(
+      () => task_create({ subject: "A", description: "agent A" }),
+      agentA,
+    );
+
+    expect((await inTaskScope(() => task_list({}), agentB)).tasks).toEqual([]);
+    await expect(
+      inTaskScope(() => task_get({ taskId: taskA.taskId }), agentB),
+    ).rejects.toThrow(/not found/);
+  });
+
+  test("clearing one task scope leaves other scopes intact", async () => {
+    const scopeA = { agentId: "agent-a", conversationId: "conversation-a" };
+    const scopeB = { agentId: "agent-b", conversationId: "conversation-b" };
+    await inTaskScope(
+      () => task_create({ subject: "A", description: "scope A" }),
+      scopeA,
+    );
+    const taskB = await inTaskScope(
+      () => task_create({ subject: "B", description: "scope B" }),
+      scopeB,
+    );
+
+    expect(clearTaskStoreScope(scopeA)).toBe(true);
+    expect((await inTaskScope(() => task_list({}), scopeA)).tasks).toEqual([]);
+    expect(
+      (await inTaskScope(() => task_list({}), scopeB)).tasks.map(
+        (task) => task.taskId,
+      ),
+    ).toEqual([taskB.taskId]);
+    expect(clearTaskStoreScope(scopeA)).toBe(false);
   });
 
   test("TaskCreate rejects non-string metadata values", async () => {

--- a/src/websocket/app-server-openai-responses.test.ts
+++ b/src/websocket/app-server-openai-responses.test.ts
@@ -2,6 +2,11 @@ import { afterEach, describe, expect, test } from "bun:test";
 import OpenAI from "openai";
 import type { Backend } from "@/backend";
 import { __testSetBackend } from "@/backend";
+import {
+  clearTaskStoreScope,
+  createTask,
+  listTasks,
+} from "@/tools/impl/tasks/store";
 import { type AppServerHandle, startAppServer } from "@/websocket/app-server";
 import {
   __testResetConversationMap,
@@ -451,6 +456,13 @@ describe("app-server Responses API", () => {
     }> = [];
     stubToolTurn((conversationId, messages) => {
       turns.push({ conversationId, messages });
+      createTask(
+        { agentId: TEST_AGENT.id, conversationId },
+        {
+          subject: `Task for ${conversationId}`,
+          description: "Verify Responses API task scope cleanup",
+        },
+      );
     });
     handle = await startAppServer({
       listen: "ws://127.0.0.1:0",
@@ -499,6 +511,24 @@ describe("app-server Responses API", () => {
       "conv-responses-3",
     ]);
     expect(deleted).toEqual(["conv-responses-2"]);
+    expect(
+      listTasks({
+        agentId: TEST_AGENT.id,
+        conversationId: "conv-responses-2",
+      }),
+    ).toEqual([]);
+    expect(
+      listTasks({
+        agentId: TEST_AGENT.id,
+        conversationId: "conv-responses-1",
+      }),
+    ).toHaveLength(2);
+    expect(
+      listTasks({
+        agentId: TEST_AGENT.id,
+        conversationId: "conv-responses-3",
+      }),
+    ).toHaveLength(1);
     expect(turns.map((turn) => turn.conversationId)).toEqual([
       "conv-responses-1",
       "conv-responses-2",
@@ -511,6 +541,14 @@ describe("app-server Responses API", () => {
       [{ role: "user", content: [{ type: "text", text: "second message" }] }],
       [{ role: "user", content: [{ type: "text", text: "separate chat" }] }],
     ]);
+    clearTaskStoreScope({
+      agentId: TEST_AGENT.id,
+      conversationId: "conv-responses-1",
+    });
+    clearTaskStoreScope({
+      agentId: TEST_AGENT.id,
+      conversationId: "conv-responses-3",
+    });
   });
 
   test("rejects stored response state until retrieval and cleanup are supported", async () => {

--- a/src/websocket/app-server-openai-responses.ts
+++ b/src/websocket/app-server-openai-responses.ts
@@ -4,6 +4,7 @@ import type {
   ServerResponse,
 } from "node:http";
 import { getBackend } from "@/backend";
+import { clearTaskStoreScope } from "@/tools/impl/tasks/store";
 import {
   chatKeyFromHeaders,
   createConversationSerialized,
@@ -655,6 +656,12 @@ export async function handleResponses(
   if (!headerChatKey) {
     void getBackend()
       .deleteConversation?.(conversationId)
+      .then(() => {
+        clearTaskStoreScope({
+          agentId: agent.id,
+          conversationId,
+        });
+      })
       .catch(() => {
         options.onLog?.(
           `OpenAI-compat failed to delete ephemeral conversation ${conversationId}`,

--- a/src/websocket/app-server-openai.test.ts
+++ b/src/websocket/app-server-openai.test.ts
@@ -2,6 +2,11 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 import type { Backend } from "@/backend";
 import { __testSetBackend } from "@/backend";
+import {
+  createTask,
+  listTasks,
+  type TaskStoreScope,
+} from "@/tools/impl/tasks/store";
 import { type AppServerHandle, startAppServer } from "@/websocket/app-server";
 import { parseAppServerWebsocketAuthSettings } from "@/websocket/app-server-auth";
 import {
@@ -185,12 +190,20 @@ describe("app-server OpenAI-compatible API", () => {
 
   test("header-less requests run statelessly with transcript replay", async () => {
     const created: string[] = [];
-    __testSetBackend(fakeBackend(created));
+    const deleted: string[] = [];
+    __testSetBackend(fakeBackend(created, deleted));
     const conversationsUsed: string[] = [];
     const messageCounts: number[] = [];
-    stubTurn((conversationId, _agentId, messages) => {
+    const taskScopes: TaskStoreScope[] = [];
+    stubTurn((conversationId, agentId, messages) => {
       conversationsUsed.push(conversationId);
       messageCounts.push(messages.length);
+      const scope = { agentId, conversationId };
+      taskScopes.push(scope);
+      createTask(scope, {
+        subject: `Task for ${conversationId}`,
+        description: "Verify ephemeral cleanup",
+      });
     });
     handle = await startAppServer({
       listen: "ws://127.0.0.1:0",
@@ -216,6 +229,11 @@ describe("app-server OpenAI-compatible API", () => {
     expect(conversationsUsed).toEqual(["conv-test-1", "conv-test-2"]);
     expect(created).toEqual(["conv-test-1", "conv-test-2"]);
     expect(messageCounts).toEqual([1, 3]);
+    expect(await waitFor(() => deleted.length === 2)).toBe(true);
+    expect(deleted).toEqual(["conv-test-1", "conv-test-2"]);
+    for (const scope of taskScopes) {
+      expect(listTasks(scope)).toEqual([]);
+    }
   });
 
   test("POST /v1/chat/completions streams SSE chunks", async () => {

--- a/src/websocket/app-server-openai.ts
+++ b/src/websocket/app-server-openai.ts
@@ -4,6 +4,7 @@ import type {
   ServerResponse,
 } from "node:http";
 import { getBackend } from "@/backend";
+import { clearTaskStoreScope } from "@/tools/impl/tasks/store";
 import { authorizeUpgrade } from "@/websocket/app-server-auth";
 import {
   chatKeyFromHeaders,
@@ -324,6 +325,12 @@ async function handleChatCompletions(
     const ephemeralConversationId = conversationId;
     void getBackend()
       .deleteConversation?.(ephemeralConversationId)
+      .then(() => {
+        clearTaskStoreScope({
+          agentId: agent.id,
+          conversationId: ephemeralConversationId,
+        });
+      })
       .catch(() => {
         options.onLog?.(
           `OpenAI-compat failed to delete ephemeral conversation ${ephemeralConversationId}`,


### PR DESCRIPTION
## Summary

Scope the `TaskCreate` / `TaskGet` / `TaskList` / `TaskUpdate` in-memory registry by both agent and conversation instead of sharing one process-global task collection.

This prevents concurrent conversations in the listener, headless runtime, TUI, and OpenAI-compatible app server from listing, reading, or updating each other's task plans.

Fixes #3577.

## Root cause

The task CRUD store previously owned one module-level `Map<string, TaskRecord>` and one insertion-order array. Every tool invocation in the process called that singleton directly, even though letta-code already executes tools inside a runtime context containing the active `agentId` and `conversationId`.

That meant:

- `TaskList` returned tasks created by unrelated conversations;
- a task ID from one conversation could be passed to `TaskGet` or `TaskUpdate` in another;
- agents whose conversation ID is the shared `"default"` value also shared task state;
- the TUI renderer independently read the same global collection, so fixing only tool writes would still render the wrong conversation's tasks.

## Implementation

### Scoped store ownership

`src/tools/impl/tasks/store.ts` now owns nested agent/conversation stores:

```text
agentId -> conversationId -> { tasks, insertionOrder }
```

Every CRUD operation requires a `TaskStoreScope`. Task IDs remain process-unique, which makes a task ID created in scope A resolve as not found in scope B rather than accidentally referring to a different local task.

The store also exposes `clearTaskStoreScope()` so lifecycle owners can remove one conversation without affecting any other scope.

### Fail-closed tool scope resolution

The new `src/tools/impl/tasks/scope.ts` resolves scope from the existing `AsyncLocalStorage` runtime context used by `executeTool()`.

Task tools now reject execution when either `agentId` or `conversationId` is absent. They do not fall back to an unscoped bucket, because that would silently recreate the original isolation bug for any call path with incomplete context.

No model-facing task schema changes are required; scope remains execution metadata rather than user-controlled tool input.

### Scoped TUI rendering

`AppView` and `StaticTranscript` pass the active agent/conversation identity to `ToolCallMessage`. Task snapshots are projected by the new `task-crud-rendering` helper, so the TUI reads exactly the same scoped store as the tool invocation.

The projection was extracted instead of growing the already oversized renderer. `ToolCallMessageRich.tsx` shrinks by one line, and its source-size baseline is ratcheted from 1109 to 1108.

### Ephemeral conversation cleanup

Headerless OpenAI-compatible Chat Completions and Responses requests create ephemeral conversations and delete them after the turn. After a successful backend deletion, these paths now clear the matching task scope as well.

Cleanup is deliberately tied to successful conversation deletion: a failed backend deletion retains both conversation and task state for consistent retry/debug behavior.

## Correctness details

- Scope includes both IDs because `conversationId === "default"` is valid for multiple agents.
- Nested maps avoid delimiter/collision issues from concatenating identifiers into one string key.
- The global task ID counter is retained only for process-wide ID uniqueness; records and list ordering are scoped.
- Clearing one scope prunes its empty per-agent map but never resets the global counter or another conversation.
- Existing CRUD validation and soft-delete semantics are unchanged.
- The change adds no dependency cycles and respects the existing layer boundaries: CLI/WebSocket surfaces may consume the lower tools layer.

## Tests

Added regression coverage for:

- concurrent task creation/listing in two runtime scopes;
- cross-scope `TaskGet` and `TaskUpdate` rejection;
- isolation between two agents using the `"default"` conversation ID;
- fail-closed execution without runtime scope;
- clearing one scope without affecting another;
- scoped TUI task projection;
- task cleanup for ephemeral Chat Completions conversations;
- cleanup of transient Responses conversations while preserving header-keyed conversation tasks.

Focused test command:

```sh
bun test src/tools/task-crud.test.ts \
  src/cli/helpers/task-crud-rendering.test.ts \
  src/websocket/app-server-openai.test.ts \
  src/websocket/app-server-openai-responses.test.ts \
  src/cli/enter-worktree-result-renderer.test.tsx
```

Result: **51 passed, 0 failed**.

Full repository validation:

```sh
bun run check
```

Result: **all 12 checks passed**, including circular dependencies, layer boundaries, source-size ratchet, module ownership, Biome, and TypeScript.
