### PR TITLE
fix(permissions): preserve settings on invalid writes

### DIFF
--- a/src/permissions/loader.ts
+++ b/src/permissions/loader.ts
@@ -1,11 +1,22 @@
 // src/permissions/loader.ts
 // Load and merge permission settings from hierarchical sources
 
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { type FSWatcher, readFileSync, statSync, watch } from "node:fs";
+import {
+  chmod,
+  type FileHandle,
+  mkdir,
+  open,
+  rename,
+  rm,
+  stat,
+} from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
+import { withFileLock } from "@/utils/file-lock";
 import { exists, readFile, writeFile } from "@/utils/fs.js";
+import { isRecord } from "@/utils/type-guards";
 import { migratePermissionMode } from "./mode";
 import {
   normalizePermissionRule,
@@ -30,10 +41,12 @@ type UserSettingsPathsOptions = {
 type FileSignature =
   | {
       exists: true;
+      readable: true;
       mtimeMs: number;
       size: number;
       hash: string;
     }
+  | { exists: true; readable: false }
   | { exists: false };
 
 type PermissionCacheEntry = {
@@ -44,6 +57,13 @@ type PermissionCacheEntry = {
 
 const permissionCache = new Map<string, PermissionCacheEntry>();
 const watchers = new Map<string, FSWatcher>();
+
+export class PermissionSettingsFileError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "PermissionSettingsFileError";
+  }
+}
 
 export function getUserSettingsPaths(options: UserSettingsPathsOptions = {}): {
   canonical: string;
@@ -73,19 +93,28 @@ function getPermissionSourcePaths(workingDirectory: string): string[] {
 }
 
 function getFileSignature(path: string): FileSignature {
+  let fileStat: ReturnType<typeof statSync>;
   try {
-    const stat = statSync(path);
-    if (!stat.isFile()) {
-      return { exists: false };
-    }
+    fileStat = statSync(path);
+  } catch (error) {
+    return isMissingFileError(error)
+      ? { exists: false }
+      : { exists: true, readable: false };
+  }
+  if (!fileStat.isFile()) {
+    return { exists: true, readable: false };
+  }
+
+  try {
     return {
       exists: true,
-      mtimeMs: stat.mtimeMs,
-      size: stat.size,
+      readable: true,
+      mtimeMs: fileStat.mtimeMs,
+      size: fileStat.size,
       hash: createHash("sha256").update(readFileSync(path)).digest("hex"),
     };
   } catch {
-    return { exists: false };
+    return { exists: true, readable: false };
   }
 }
 
@@ -103,7 +132,132 @@ function signaturesEqual(
 ): boolean {
   if (!a || !b) return false;
   if (!a.exists || !b.exists) return a.exists === b.exists;
+  if (!a.readable || !b.readable) return false;
   return a.mtimeMs === b.mtimeMs && a.size === b.size && a.hash === b.hash;
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException)?.code === "ENOENT";
+}
+
+function validateSettingsFile(
+  value: unknown,
+  settingsPath: string,
+): SettingsFile {
+  if (!isRecord(value)) {
+    throw new PermissionSettingsFileError(
+      `Invalid permission settings at "${settingsPath}": expected a JSON object.`,
+    );
+  }
+
+  const permissions = value.permissions;
+  if (permissions === undefined) {
+    return value as SettingsFile;
+  }
+  if (!isRecord(permissions)) {
+    throw new PermissionSettingsFileError(
+      `Invalid permission settings at "${settingsPath}": "permissions" must be an object.`,
+    );
+  }
+
+  for (const key of [
+    "allow",
+    "deny",
+    "ask",
+    "alwaysAsk",
+    "additionalDirectories",
+  ] as const) {
+    const rules = permissions[key];
+    if (
+      rules !== undefined &&
+      (!Array.isArray(rules) ||
+        !rules.every((rule: unknown) => typeof rule === "string"))
+    ) {
+      throw new PermissionSettingsFileError(
+        `Invalid permission settings at "${settingsPath}": "permissions.${key}" must be an array of strings.`,
+      );
+    }
+  }
+  if (permissions.mode !== undefined && typeof permissions.mode !== "string") {
+    throw new PermissionSettingsFileError(
+      `Invalid permission settings at "${settingsPath}": "permissions.mode" must be a string.`,
+    );
+  }
+
+  return value as SettingsFile;
+}
+
+async function readSettingsFile(
+  settingsPath: string,
+): Promise<SettingsFile | undefined> {
+  let content: string;
+  try {
+    content = await readFile(settingsPath);
+  } catch (error) {
+    if (isMissingFileError(error)) return undefined;
+    throw new PermissionSettingsFileError(
+      `Could not read permission settings at "${settingsPath}"; refusing to ignore configured security rules.`,
+      { cause: error },
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (error) {
+    throw new PermissionSettingsFileError(
+      `Malformed JSON in permission settings at "${settingsPath}"; refusing to overwrite or ignore it.`,
+      { cause: error },
+    );
+  }
+  return validateSettingsFile(parsed, settingsPath);
+}
+
+async function existingFileMode(
+  settingsPath: string,
+): Promise<number | undefined> {
+  try {
+    return (await stat(settingsPath)).mode & 0o777;
+  } catch (error) {
+    if (isMissingFileError(error)) return undefined;
+    throw error;
+  }
+}
+
+async function writeSettingsFileAtomically(
+  settingsPath: string,
+  settings: SettingsFile,
+): Promise<void> {
+  const directoryPath = dirname(settingsPath);
+  const tempPath = join(
+    directoryPath,
+    `.${basename(settingsPath)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  const mode = await existingFileMode(settingsPath);
+  let handle: FileHandle | undefined;
+
+  try {
+    handle = await open(tempPath, "wx", mode ?? 0o600);
+    await handle.writeFile(JSON.stringify(settings, null, 2), "utf8");
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    if (mode !== undefined) {
+      await chmod(tempPath, mode);
+    }
+    await rename(tempPath, settingsPath);
+  } catch (error) {
+    try {
+      await handle?.close();
+    } catch {
+      // Preserve the original write error.
+    }
+    await rm(tempPath, { force: true }).catch(() => undefined);
+    throw new PermissionSettingsFileError(
+      `Could not atomically save permission settings at "${settingsPath}".`,
+      { cause: error },
+    );
+  }
 }
 
 function cachedEntryMatchesSources(
@@ -246,17 +400,9 @@ export async function loadPermissions(
   };
 
   for (const settingsPath of sources) {
-    try {
-      if (exists(settingsPath)) {
-        const content = await readFile(settingsPath);
-        const settings = JSON.parse(content) as SettingsFile;
-        if (settings.permissions) {
-          mergePermissions(merged, settings.permissions);
-        }
-      }
-    } catch (_error) {
-      // Silently skip files that can't be parsed
-      // (user might have invalid JSON)
+    const settings = await readSettingsFile(settingsPath);
+    if (settings?.permissions) {
+      mergePermissions(merged, settings.permissions);
     }
   }
 
@@ -356,39 +502,36 @@ export async function savePermissionRule(
       break;
   }
 
-  // Load existing settings
-  let settings: SettingsFile = {};
-  try {
-    if (exists(settingsPath)) {
-      const content = await readFile(settingsPath);
-      settings = JSON.parse(content) as SettingsFile;
-    }
-  } catch (_error) {
-    // Start with empty settings if file doesn't exist or is invalid
-  }
-
-  // Initialize permissions if needed
-  if (!settings.permissions) {
-    settings.permissions = {};
-  }
-  if (!settings.permissions[ruleType]) {
-    settings.permissions[ruleType] = [];
-  }
-
   const normalizedRule = normalizePermissionRule(rule);
+  try {
+    await mkdir(dirname(settingsPath), { recursive: true });
+    await withFileLock(`${settingsPath}.lock`, async () => {
+      const settings = (await readSettingsFile(settingsPath)) ?? {};
+      const permissions = settings.permissions ?? {};
+      settings.permissions = permissions;
+      const rules = permissions[ruleType] ?? [];
+      permissions[ruleType] = rules;
 
-  // Add rule if not already present (canonicalized comparison for alias/path variants)
-  if (
-    !settings.permissions[ruleType].some((existingRule) =>
-      permissionRulesEquivalent(existingRule, normalizedRule),
-    )
-  ) {
-    settings.permissions[ruleType].push(normalizedRule);
+      // Add rule if not already present (canonicalized comparison for alias/path variants)
+      if (
+        rules.some((existingRule) =>
+          permissionRulesEquivalent(existingRule, normalizedRule),
+        )
+      ) {
+        return;
+      }
+
+      rules.push(normalizedRule);
+      await writeSettingsFileAtomically(settingsPath, settings);
+      invalidatePermissionSource(settingsPath);
+    });
+  } catch (error) {
+    if (error instanceof PermissionSettingsFileError) throw error;
+    throw new PermissionSettingsFileError(
+      `Could not update permission settings at "${settingsPath}".`,
+      { cause: error },
+    );
   }
-
-  // Save settings
-  await writeFile(settingsPath, JSON.stringify(settings, null, 2));
-  invalidatePermissionSource(settingsPath);
 
   // If saving to .letta/settings.local.json, ensure it's gitignored
   if (scope === "local") {

--- a/src/permissions/permissions-loader.test.ts
+++ b/src/permissions/permissions-loader.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { chmod, mkdtemp, readdir, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -466,18 +466,150 @@ test("Save permission preserves other settings fields", async () => {
 // Error Handling Tests
 // ============================================================================
 
-test("Load permissions handles invalid JSON gracefully", async () => {
+test("Load permissions rejects invalid JSON instead of dropping rules", async () => {
   const projectDir = join(testDir, "project-invalid-json");
   const settingsPath = join(projectDir, ".letta", "settings.json");
+  const malformed = "{ invalid json ";
 
-  // Write invalid JSON
-  await Bun.write(settingsPath, "{ invalid json ");
+  await Bun.write(settingsPath, malformed);
 
-  const permissions = await loadPermissions(projectDir);
+  await expect(loadPermissions(projectDir)).rejects.toThrow(
+    `Malformed JSON in permission settings at "${settingsPath}"`,
+  );
+  expect(await readFile(settingsPath, "utf8")).toBe(malformed);
 
-  // Should return empty permissions instead of crashing (silently skip invalid file)
-  expect(permissions.allow).toBeDefined();
-  expect(permissions.deny).toBeDefined();
+  await Bun.write(
+    settingsPath,
+    JSON.stringify({ permissions: { deny: ["Read(.env)"] } }),
+  );
+  const repaired = await loadPermissions(projectDir);
+  expect(repaired.deny).toContain("Read(.env)");
+});
+
+test("Load permissions rejects invalid security rule shapes", async () => {
+  const projectDir = join(testDir, "project-invalid-rule-shape");
+  const settingsPath = join(projectDir, ".letta", "settings.json");
+  await Bun.write(
+    settingsPath,
+    JSON.stringify({ permissions: { deny: "Read(.env)" } }),
+  );
+
+  await expect(loadPermissions(projectDir)).rejects.toThrow(
+    '"permissions.deny" must be an array of strings',
+  );
+});
+
+test("Load permissions does not reuse a cache entry for an unreadable source", async () => {
+  if (process.platform === "win32") return;
+
+  const projectDir = join(testDir, "project-unreadable-settings");
+  const settingsPath = join(projectDir, ".letta", "settings.json");
+  await Bun.write(
+    settingsPath,
+    JSON.stringify({ permissions: { deny: ["Read(.env)"] } }),
+  );
+  expect((await loadPermissions(projectDir)).deny).toContain("Read(.env)");
+
+  await chmod(settingsPath, 0o000);
+  let filesystemEnforcesMode = false;
+  try {
+    await readFile(settingsPath, "utf8");
+  } catch {
+    filesystemEnforcesMode = true;
+  }
+
+  try {
+    if (filesystemEnforcesMode) {
+      await expect(loadPermissions(projectDir)).rejects.toThrow(
+        /Could not read permission settings/,
+      );
+    }
+  } finally {
+    await chmod(settingsPath, 0o600);
+  }
+});
+
+test("Save permission preserves malformed settings byte-for-byte", async () => {
+  const projectDir = join(testDir, "project-save-malformed");
+  const settingsPath = join(projectDir, ".letta", "settings.json");
+  const malformed =
+    '{"model":"example","permissions":{"deny":["Bash(rm:*)"]},}\n';
+  await Bun.write(settingsPath, malformed);
+
+  await expect(
+    savePermissionRule("Bash(ls:*)", "allow", "project", projectDir),
+  ).rejects.toThrow(/refusing to overwrite or ignore it/);
+  expect(await readFile(settingsPath, "utf8")).toBe(malformed);
+});
+
+test("Concurrent permission saves preserve every rule and unrelated setting", async () => {
+  const projectDir = join(testDir, "project-concurrent-save");
+  const settingsPath = join(projectDir, ".letta", "settings.json");
+  await Bun.write(
+    settingsPath,
+    JSON.stringify({
+      tokenStreaming: true,
+      permissions: { deny: ["Read(.env)"] },
+    }),
+  );
+
+  const rules = Array.from(
+    { length: 12 },
+    (_, index) => `Bash(concurrent-command-${index}:*)`,
+  );
+  await Promise.all(
+    rules.map((rule) =>
+      savePermissionRule(rule, "allow", "project", projectDir),
+    ),
+  );
+
+  const settings = JSON.parse(await readFile(settingsPath, "utf8"));
+  expect(settings.tokenStreaming).toBe(true);
+  expect(settings.permissions.deny).toEqual(["Read(.env)"]);
+  expect(settings.permissions.allow).toHaveLength(rules.length);
+  expect(settings.permissions.allow).toEqual(expect.arrayContaining(rules));
+  expect(
+    (await readdir(join(projectDir, ".letta"))).filter(
+      (name) => name.endsWith(".lock") || name.endsWith(".tmp"),
+    ),
+  ).toEqual([]);
+});
+
+test("Atomic permission save preserves the existing file mode", async () => {
+  if (process.platform === "win32") return;
+
+  const projectDir = join(testDir, "project-preserve-mode");
+  const settingsPath = join(projectDir, ".letta", "settings.json");
+  await Bun.write(settingsPath, JSON.stringify({ permissions: {} }));
+  await chmod(settingsPath, 0o640);
+
+  await savePermissionRule("Bash(ls:*)", "allow", "project", projectDir);
+
+  expect((await stat(settingsPath)).mode & 0o777).toBe(0o640);
+});
+
+test("Failed permission save leaves the existing file unchanged", async () => {
+  if (process.platform === "win32") return;
+
+  const projectDir = join(testDir, "project-write-failure");
+  const settingsDirectory = join(projectDir, ".letta");
+  const settingsPath = join(settingsDirectory, "settings.json");
+  const original = JSON.stringify({
+    tokenStreaming: true,
+    permissions: { deny: ["Read(.env)"] },
+  });
+  await Bun.write(settingsPath, original);
+  await chmod(settingsDirectory, 0o500);
+
+  try {
+    await expect(
+      savePermissionRule("Bash(ls:*)", "allow", "project", projectDir),
+    ).rejects.toThrow(/Could not update permission settings/);
+  } finally {
+    await chmod(settingsDirectory, 0o700);
+  }
+
+  expect(await readFile(settingsPath, "utf8")).toBe(original);
 });
 
 test("Load permissions handles missing permissions field", async () => {


### PR DESCRIPTION
## Summary

Make permission settings loading fail closed and make persisted permission-rule updates serialized and atomic.

A malformed, unreadable, or structurally invalid existing settings file is no longer treated as an empty policy source. `savePermissionRule()` now refuses to overwrite it, and concurrent permission saves re-read under the repository's cross-process file lock before replacing the file through a synced same-directory temporary file.

Fixes #3578.

## Root cause

`loadPermissions()` previously wrapped each hierarchical settings source in a broad catch and silently skipped every read or parse failure. A malformed source containing `deny` or `alwaysAsk` rules therefore behaved as if those security rules did not exist.

`savePermissionRule()` had the destructive counterpart:

1. initialize `settings` to `{}`;
2. try to read and parse the existing file;
3. catch every failure and keep `{}`;
4. add the new rule;
5. write the entire object over the existing path.

This could replace malformed/unreadable settings with a nearly empty object and destroy unrelated fields. The read-modify-write was also unprotected, so two concurrent permission saves could both read the same version and lose one update.

The permission cache introduced another edge case: signature failures were represented exactly like missing files. An unreadable source could therefore match a previously cached "does not exist" signature and return stale, less restrictive permissions without attempting a read.

## Implementation

### Fail-closed hierarchical loading

Permission settings now have one validated read path that distinguishes a genuinely missing file (`ENOENT`) from every existing-file failure.

Existing sources now produce a path-specific `PermissionSettingsFileError` for:

- malformed JSON;
- unreadable files and filesystem errors;
- non-object top-level JSON;
- non-object `permissions` values;
- non-string permission modes;
- rule fields that are not arrays of strings.

Errors propagate to the existing callers instead of silently applying an incomplete policy. The approval UI already formats save errors as `Failed to add permission`, and tool permission checks surface load failures through their normal error path.

Missing settings files remain valid and still produce empty/default permission collections.

### Cache safety for unreadable sources

File signatures now distinguish:

```text
missing
existing + readable + hashed
existing + unreadable/invalid file type
```

Unreadable signatures are deliberately never cache matches. This forces the validated reader to run and report the source rather than reusing a cache entry produced while the file was absent or readable.

Malformed JSON is never inserted into the permission cache. Once the user repairs the file, the next load succeeds normally.

### Serialized permission mutations

`savePermissionRule()` now:

1. creates the parent directory;
2. acquires `${settingsPath}.lock` through the existing `withFileLock()` O_EXCL lock;
3. re-reads and validates the latest file inside the critical section;
4. canonicalizes/deduplicates the new rule;
5. writes only when the rule is new;
6. invalidates the cache only after successful replacement.

The lock serializes cooperating permission-rule writers across async calls and processes, preventing two approvals from losing one another's rules.

### Atomic replacement

Writes now use a unique temporary file in the settings directory:

- the temp file is opened with `wx`;
- new files use mode `0600` subject to platform behavior;
- existing file mode bits are preserved;
- contents are written and `fsync`ed;
- the temp file is renamed over the destination;
- failed operations close and remove the temp file;
- the original path is untouched until rename succeeds.

This prevents a partial/truncated settings file if the write fails before publication. Lock files and temporary files are removed after completion.

Local-scope `.gitignore` behavior and canonical permission-rule deduplication remain unchanged.

## Security behavior

The intended behavior is deliberately fail closed:

- If a configured policy source exists but cannot be trusted, letta-code does not silently continue with fewer restrictions.
- A normal "always allow" action cannot repair or overwrite malformed JSON implicitly.
- The error includes the exact source path so the user can inspect and repair it explicitly.
- After repair, signature validation and normal hot reload resume without restarting the process.

This PR does not attempt an automatic backup/repair workflow; preserving the original bytes and requiring explicit repair avoids making assumptions about malformed user configuration.

## Tests

Added regression coverage for:

- malformed JSON rejects during load and remains byte-for-byte unchanged;
- repaired JSON loads immediately after the failed attempt;
- invalid `permissions` rule shapes reject instead of being skipped;
- an unreadable source cannot reuse a cached permission result;
- saving over malformed JSON rejects and preserves the original bytes;
- 12 concurrent permission saves preserve every rule, existing deny rules, and unrelated settings;
- successful updates leave no `.lock` or `.tmp` artifacts;
- atomic replacement preserves the existing file mode;
- a filesystem write failure leaves the existing file unchanged;
- all pre-existing load, merge, canonicalization, local-scope, and `.gitignore` behavior remains green.

Focused validation:

```sh
bun test src/permissions/permissions-loader.test.ts
```

Result: **35 passed, 0 failed**.

Full repository validation:

```sh
bun run check
```

Result: **all 12 checks passed**, including cycles, layer boundaries, exported-function style, filename casing, source size, module ownership, mock isolation, coverage policy, Biome, and TypeScript.
