### PR TITLE
fix(local): recover truncated JSONL transcript tails

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -3,7 +3,7 @@
   "src/agent/memory-git.ts": 2128,
   "src/backend/local-backend.test.ts": 2532,
   "src/backend/local/local-backend.ts": 1014,
-  "src/backend/local/local-store.ts": 3594,
+  "src/backend/local/local-store.ts": 3558,
   "src/backend/pi-stream-adapter.test.ts": 1304,
   "src/cli/app/AppCoordinator.tsx": 5203,
   "src/cli/app/AppView.tsx": 1735,

--- a/src/backend/local/local-store.ts
+++ b/src/backend/local/local-store.ts
@@ -69,6 +69,11 @@ import {
 } from "./local-stream-chunks";
 import type { LocalAgentRecord, StoredMessage } from "./local-types";
 import type { LocalCompiledSystemPrompt } from "./system-prompt-compilation";
+import {
+  readLocalTranscriptJsonl,
+  readLocalTranscriptJsonlSuffix,
+  repairLocalTranscriptJsonlTail,
+} from "./transcript-jsonl";
 export type { LocalAgentRecord, StoredMessage };
 
 type StoredConversation = Conversation & {
@@ -564,48 +569,6 @@ function jsonl<T>(items: readonly T[]): string {
 function readJsonFile<T>(path: string): T | undefined {
   if (!existsSync(path)) return undefined;
   return JSON.parse(readFileSync(path, "utf8")) as T;
-}
-
-function readJsonlFile<T>(path: string): T[] {
-  if (!existsSync(path)) return [];
-  return readFileSync(path, "utf8")
-    .split("\n")
-    .filter((line) => line.trim().length > 0)
-    .map((line) => JSON.parse(line) as T);
-}
-
-function readJsonlFileSuffix<T>(
-  path: string,
-  maxBytes: number,
-): { items: T[]; reachedStart: boolean } {
-  if (!existsSync(path)) return { items: [], reachedStart: true };
-  const size = statSync(path).size;
-  if (size === 0) return { items: [], reachedStart: true };
-
-  const bytesToRead = Math.min(size, Math.max(1, maxBytes));
-  const start = size - bytesToRead;
-  const buffer = Buffer.alloc(bytesToRead);
-  const fd = openSync(path, "r");
-  try {
-    readSync(fd, buffer, 0, bytesToRead, start);
-  } finally {
-    closeSync(fd);
-  }
-
-  let text = buffer.toString("utf8");
-  const reachedStart = start === 0;
-  if (!reachedStart) {
-    const firstNewline = text.indexOf("\n");
-    text = firstNewline >= 0 ? text.slice(firstNewline + 1) : "";
-  }
-
-  return {
-    items: text
-      .split("\n")
-      .filter((line) => line.trim().length > 0)
-      .map((line) => JSON.parse(line) as T),
-    reachedStart,
-  };
 }
 
 export const LOCAL_TRANSCRIPT_LEGACY_SCHEMA_VERSION = 1;
@@ -2537,7 +2500,7 @@ export class LocalStore {
     const before = getCursor(body, "before");
     let maxBytes = 64 * 1024;
     for (;;) {
-      const tail = readJsonlFileSuffix<unknown>(
+      const tail = readLocalTranscriptJsonlSuffix<unknown>(
         metadata.messagesPath,
         maxBytes,
       );
@@ -2664,7 +2627,7 @@ export class LocalStore {
 
     let maxBytes = 64 * 1024;
     for (;;) {
-      const tail = readJsonlFileSuffix<unknown>(
+      const tail = readLocalTranscriptJsonlSuffix<unknown>(
         metadata.messagesPath,
         maxBytes,
       );
@@ -2723,7 +2686,7 @@ export class LocalStore {
       return;
     }
 
-    const rawRows = readJsonlFile<unknown>(metadata.messagesPath);
+    const rawRows = readLocalTranscriptJsonl<unknown>(metadata.messagesPath);
     const conversation = this.conversations.get(key);
     const transcript = localTranscriptRowsResult(
       rawRows,
@@ -3384,6 +3347,7 @@ export class LocalStore {
     conversation: StoredConversation,
     messagesPath: string,
   ): void {
+    repairLocalTranscriptJsonlTail(messagesPath);
     if (existsSync(messagesPath) && statSync(messagesPath).size > 0) return;
     writeFileSync(
       messagesPath,

--- a/src/backend/local/transcript-jsonl.integration.test.ts
+++ b/src/backend/local/transcript-jsonl.integration.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { appendFile, mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ConversationMessageCreateBody } from "@/backend";
+import { LocalBackend } from "@/backend/local/local-backend";
+
+async function drain(stream: AsyncIterable<unknown>): Promise<void> {
+  for await (const _chunk of stream) {
+    // drain
+  }
+}
+
+function pageItems<T>(value: T[] | { getPaginatedItems(): T[] }): T[] {
+  return Array.isArray(value) ? value : value.getPaginatedItems();
+}
+
+function conversationDirectory(
+  storageDir: string,
+  conversationId: string,
+): string {
+  const key = Buffer.from(`conversation:${conversationId}`).toString(
+    "base64url",
+  );
+  return join(storageDir, "conversations", key);
+}
+
+describe("local transcript JSONL recovery", () => {
+  test("loads history and preserves a damaged tail before the next append", async () => {
+    const storageDir = await mkdtemp(
+      join(tmpdir(), "local-backend-partial-tail-"),
+    );
+    try {
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+        memfsEnabled: false,
+      });
+      const agent = await backend.createAgent({ name: "Local" } as never);
+      const conversation = await backend.createConversation({
+        agent_id: agent.id,
+      } as never);
+      await drain(
+        await backend.createConversationMessageStream(conversation.id, {
+          agent_id: agent.id,
+          messages: [{ role: "user", content: "durable transcript message" }],
+        } as ConversationMessageCreateBody),
+      );
+
+      const conversationDir = conversationDirectory(
+        storageDir,
+        conversation.id,
+      );
+      await appendFile(
+        join(conversationDir, "messages.jsonl"),
+        '{"id":"partial"',
+      );
+
+      const reloaded = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+        memfsEnabled: false,
+      });
+      const recoveredMessages = pageItems(
+        await reloaded.listConversationMessages(conversation.id, {
+          agent_id: agent.id,
+          order: "asc",
+        } as never),
+      );
+      expect(JSON.stringify(recoveredMessages)).toContain(
+        "durable transcript message",
+      );
+
+      await drain(
+        await reloaded.createConversationMessageStream(conversation.id, {
+          agent_id: agent.id,
+          messages: [{ role: "user", content: "message after recovery" }],
+        } as ConversationMessageCreateBody),
+      );
+      const backupName = (await readdir(conversationDir)).find((name) =>
+        name.startsWith("messages.jsonl.corrupt-tail-backup-"),
+      );
+      expect(backupName).toBeString();
+      expect(
+        await readFile(join(conversationDir, backupName ?? ""), "utf8"),
+      ).toEndWith('{"id":"partial"');
+
+      const reloadedAfterRepair = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+        memfsEnabled: false,
+      });
+      const repairedMessages = pageItems(
+        await reloadedAfterRepair.listConversationMessages(conversation.id, {
+          agent_id: agent.id,
+          order: "asc",
+        } as never),
+      );
+      expect(JSON.stringify(repairedMessages)).toContain(
+        "durable transcript message",
+      );
+      expect(JSON.stringify(repairedMessages)).toContain(
+        "message after recovery",
+      );
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/backend/local/transcript-jsonl.test.ts
+++ b/src/backend/local/transcript-jsonl.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  LocalTranscriptJsonlCorruptionError,
+  readLocalTranscriptJsonl,
+  readLocalTranscriptJsonlSuffix,
+  repairLocalTranscriptJsonlTail,
+} from "./transcript-jsonl";
+
+let testDir: string | undefined;
+
+function transcriptPath(): string {
+  testDir ??= mkdtempSync(join(tmpdir(), "local-transcript-jsonl-"));
+  return join(testDir, "messages.jsonl");
+}
+
+afterEach(() => {
+  if (testDir) {
+    rmSync(testDir, { recursive: true, force: true });
+    testDir = undefined;
+  }
+});
+
+describe("local transcript JSONL", () => {
+  test("keeps valid rows before an incomplete trailing row", () => {
+    const path = transcriptPath();
+    writeFileSync(path, '{"id":"one"}\n{"id":"two"}\n{"id":"partial"');
+
+    expect(readLocalTranscriptJsonl<{ id: string }>(path)).toEqual([
+      { id: "one" },
+      { id: "two" },
+    ]);
+  });
+
+  test("reports committed corruption with path, line, and byte offset", () => {
+    const path = transcriptPath();
+    const firstRow = '{"id":"one"}\n';
+    writeFileSync(path, `${firstRow}not-json\n{"id":"three"}\n`);
+
+    try {
+      readLocalTranscriptJsonl(path);
+      throw new Error("Expected transcript corruption to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(LocalTranscriptJsonlCorruptionError);
+      expect(error).toMatchObject({
+        path,
+        lineNumber: 2,
+        byteOffset: Buffer.byteLength(firstRow),
+      });
+      expect(String(error)).toContain("Malformed transcript JSONL");
+      expect(String(error)).toContain("line 2");
+    }
+  });
+
+  test("suffix reads discard a clipped UTF-8 row and ignore a partial tail", () => {
+    const path = transcriptPath();
+    const firstRow = `${JSON.stringify({ id: "one", text: "before 😀 after" })}\n`;
+    const secondRow = `${JSON.stringify({ id: "two" })}\n`;
+    const partialTail = Buffer.from(
+      '{"id":"partial","text":"\xf0\x9f',
+      "binary",
+    );
+    const content = Buffer.concat([
+      Buffer.from(firstRow),
+      Buffer.from(secondRow),
+      partialTail,
+    ]);
+    writeFileSync(path, content);
+
+    const emojiByteOffset = content.indexOf(Buffer.from("😀"));
+    const suffix = readLocalTranscriptJsonlSuffix<{ id: string }>(
+      path,
+      content.length - emojiByteOffset - 1,
+    );
+
+    expect(suffix).toEqual({
+      items: [{ id: "two" }],
+      reachedStart: false,
+    });
+  });
+
+  test("repair backs up the original bytes before truncating a partial tail", () => {
+    const path = transcriptPath();
+    const validContent = '{"id":"one"}\n{"id":"two"}\n';
+    const originalContent = `${validContent}{"id":"partial"`;
+    writeFileSync(path, originalContent);
+
+    const result = repairLocalTranscriptJsonlTail(path);
+
+    expect(result.repaired).toBe(true);
+    expect(result.backupPath).toBeString();
+    expect(readFileSync(result.backupPath ?? "", "utf8")).toBe(originalContent);
+    expect(readFileSync(path, "utf8")).toBe(validContent);
+    expect(readLocalTranscriptJsonl(path)).toEqual([
+      { id: "one" },
+      { id: "two" },
+    ]);
+  });
+
+  test("repair preserves and terminates a complete final row", () => {
+    const path = transcriptPath();
+    writeFileSync(path, '{"id":"one"}');
+
+    expect(readLocalTranscriptJsonl(path)).toEqual([{ id: "one" }]);
+    expect(repairLocalTranscriptJsonlTail(path)).toEqual({ repaired: true });
+    expect(readFileSync(path, "utf8")).toBe('{"id":"one"}\n');
+  });
+});

--- a/src/backend/local/transcript-jsonl.ts
+++ b/src/backend/local/transcript-jsonl.ts
@@ -1,0 +1,276 @@
+import {
+  appendFileSync,
+  closeSync,
+  copyFileSync,
+  existsSync,
+  openSync,
+  readFileSync,
+  readSync,
+  statSync,
+  truncateSync,
+} from "node:fs";
+
+interface TrailingFragment {
+  byteOffset: number;
+  byteLength: number;
+  lineNumber?: number;
+}
+
+interface ParsedJsonl<T> {
+  items: T[];
+  trailingFragment?: TrailingFragment;
+}
+
+const warnedTrailingFragments = new Map<string, string>();
+
+export interface LocalTranscriptJsonlSuffix<T> {
+  items: T[];
+  reachedStart: boolean;
+}
+
+export interface LocalTranscriptJsonlRepairResult {
+  repaired: boolean;
+  backupPath?: string;
+}
+
+export class LocalTranscriptJsonlCorruptionError extends Error {
+  readonly path: string;
+  readonly byteOffset: number;
+  readonly lineNumber?: number;
+
+  constructor(input: {
+    path: string;
+    byteOffset: number;
+    lineNumber?: number;
+    cause: unknown;
+  }) {
+    const location =
+      input.lineNumber === undefined
+        ? `byte offset ${input.byteOffset}`
+        : `line ${input.lineNumber}, byte offset ${input.byteOffset}`;
+    const detail =
+      input.cause instanceof Error ? input.cause.message : String(input.cause);
+    super(
+      `Malformed transcript JSONL in ${input.path} at ${location}: ${detail}`,
+    );
+    this.name = "LocalTranscriptJsonlCorruptionError";
+    this.path = input.path;
+    this.byteOffset = input.byteOffset;
+    this.lineNumber = input.lineNumber;
+  }
+}
+
+function isJsonWhitespace(buffer: Buffer): boolean {
+  for (const byte of buffer) {
+    if (byte !== 0x09 && byte !== 0x0a && byte !== 0x0d && byte !== 0x20) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function parseJsonlBuffer<T>(input: {
+  path: string;
+  buffer: Buffer;
+  baseByteOffset: number;
+  firstLineNumber?: number;
+}): ParsedJsonl<T> {
+  const items: T[] = [];
+  let rowStart = 0;
+  let lineNumber = input.firstLineNumber;
+
+  const parseCommittedRow = (rowEnd: number): void => {
+    const row = input.buffer.subarray(rowStart, rowEnd);
+    if (!isJsonWhitespace(row)) {
+      try {
+        items.push(JSON.parse(row.toString("utf8")) as T);
+      } catch (cause) {
+        throw new LocalTranscriptJsonlCorruptionError({
+          path: input.path,
+          byteOffset: input.baseByteOffset + rowStart,
+          lineNumber,
+          cause,
+        });
+      }
+    }
+    rowStart = rowEnd + 1;
+    if (lineNumber !== undefined) {
+      lineNumber += 1;
+    }
+  };
+
+  for (let index = 0; index < input.buffer.length; index++) {
+    if (input.buffer[index] === 0x0a) {
+      parseCommittedRow(index);
+    }
+  }
+
+  const finalRow = input.buffer.subarray(rowStart);
+  if (isJsonWhitespace(finalRow)) {
+    return { items };
+  }
+
+  try {
+    items.push(JSON.parse(finalRow.toString("utf8")) as T);
+    return { items };
+  } catch {
+    return {
+      items,
+      trailingFragment: {
+        byteOffset: input.baseByteOffset + rowStart,
+        byteLength: finalRow.length,
+        lineNumber,
+      },
+    };
+  }
+}
+
+function trailingFragmentLocation(fragment: TrailingFragment): string {
+  return fragment.lineNumber === undefined
+    ? `byte offset ${fragment.byteOffset}`
+    : `line ${fragment.lineNumber}, byte offset ${fragment.byteOffset}`;
+}
+
+function warnAboutTrailingFragment(
+  path: string,
+  fragment: TrailingFragment,
+): void {
+  const signature = `${fragment.byteOffset}:${fragment.byteLength}`;
+  if (warnedTrailingFragments.get(path) === signature) return;
+  warnedTrailingFragments.set(path, signature);
+  console.warn(
+    [
+      `Ignoring an incomplete trailing transcript row in ${path} at ${trailingFragmentLocation(fragment)}.`,
+      "Valid preceding rows remain available.",
+      "The damaged bytes will be backed up before the next transcript append.",
+    ].join(" "),
+  );
+}
+
+function readFullJsonl<T>(path: string): ParsedJsonl<T> {
+  return parseJsonlBuffer<T>({
+    path,
+    buffer: readFileSync(path),
+    baseByteOffset: 0,
+    firstLineNumber: 1,
+  });
+}
+
+function readFinalPhysicalRow(path: string): {
+  buffer: Buffer;
+  byteOffset: number;
+} {
+  const size = statSync(path).size;
+  if (size === 0) return { buffer: Buffer.alloc(0), byteOffset: 0 };
+
+  const fd = openSync(path, "r");
+  const chunks: Buffer[] = [];
+  let position = size;
+  let byteOffset = 0;
+  try {
+    while (position > 0) {
+      const bytesToRead = Math.min(position, 64 * 1024);
+      const chunkStart = position - bytesToRead;
+      const chunk = Buffer.alloc(bytesToRead);
+      readSync(fd, chunk, 0, bytesToRead, chunkStart);
+      const lastNewline = chunk.lastIndexOf(0x0a);
+      if (lastNewline >= 0) {
+        chunks.unshift(chunk.subarray(lastNewline + 1));
+        byteOffset = chunkStart + lastNewline + 1;
+        break;
+      }
+      chunks.unshift(chunk);
+      position = chunkStart;
+    }
+  } finally {
+    closeSync(fd);
+  }
+
+  return { buffer: Buffer.concat(chunks), byteOffset };
+}
+
+export function readLocalTranscriptJsonl<T>(path: string): T[] {
+  if (!existsSync(path)) return [];
+  const parsed = readFullJsonl<T>(path);
+  if (parsed.trailingFragment) {
+    warnAboutTrailingFragment(path, parsed.trailingFragment);
+  } else {
+    warnedTrailingFragments.delete(path);
+  }
+  return parsed.items;
+}
+
+export function readLocalTranscriptJsonlSuffix<T>(
+  path: string,
+  maxBytes: number,
+): LocalTranscriptJsonlSuffix<T> {
+  if (!existsSync(path)) return { items: [], reachedStart: true };
+  const size = statSync(path).size;
+  if (size === 0) return { items: [], reachedStart: true };
+
+  const bytesToRead = Math.min(size, Math.max(1, maxBytes));
+  const start = size - bytesToRead;
+  const buffer = Buffer.alloc(bytesToRead);
+  const fd = openSync(path, "r");
+  try {
+    readSync(fd, buffer, 0, bytesToRead, start);
+  } finally {
+    closeSync(fd);
+  }
+
+  const reachedStart = start === 0;
+  let content = buffer;
+  let contentByteOffset = start;
+  if (!reachedStart) {
+    const firstNewline = buffer.indexOf(0x0a);
+    if (firstNewline < 0) {
+      return { items: [], reachedStart };
+    }
+    content = buffer.subarray(firstNewline + 1);
+    contentByteOffset += firstNewline + 1;
+  }
+
+  const parsed = parseJsonlBuffer<T>({
+    path,
+    buffer: content,
+    baseByteOffset: contentByteOffset,
+    ...(reachedStart ? { firstLineNumber: 1 } : {}),
+  });
+  if (parsed.trailingFragment) {
+    warnAboutTrailingFragment(path, parsed.trailingFragment);
+  } else {
+    warnedTrailingFragments.delete(path);
+  }
+  return { items: parsed.items, reachedStart };
+}
+
+export function repairLocalTranscriptJsonlTail(
+  path: string,
+): LocalTranscriptJsonlRepairResult {
+  if (!existsSync(path)) return { repaired: false };
+  const finalRow = readFinalPhysicalRow(path);
+  if (isJsonWhitespace(finalRow.buffer)) return { repaired: false };
+  try {
+    JSON.parse(finalRow.buffer.toString("utf8"));
+    appendFileSync(path, "\n");
+    return { repaired: true };
+  } catch {
+    // A non-newline-terminated invalid final row is the only corruption this
+    // repair path may remove. Committed rows are validated by normal readers.
+  }
+
+  const backupPrefix = `${path}.corrupt-tail-backup-${Date.now()}`;
+  let backupPath = backupPrefix;
+  let collisionIndex = 1;
+  while (existsSync(backupPath)) {
+    backupPath = `${backupPrefix}-${collisionIndex}`;
+    collisionIndex += 1;
+  }
+  copyFileSync(path, backupPath);
+  truncateSync(path, finalRow.byteOffset);
+  warnedTrailingFragments.delete(path);
+  console.warn(
+    `Removed an incomplete trailing transcript row from ${path}; the original bytes are preserved in ${backupPath}.`,
+  );
+  return { repaired: true, backupPath };
+}

--- a/src/backend/local/transcript-migration.ts
+++ b/src/backend/local/transcript-migration.ts
@@ -17,6 +17,7 @@ import {
   LOCAL_TRANSCRIPT_SCHEMA_VERSION,
   type LocalTranscriptManifest,
 } from "./local-store";
+import { readLocalTranscriptJsonl } from "./transcript-jsonl";
 
 export interface LocalTranscriptMigrationResult {
   storageDir: string;
@@ -32,14 +33,6 @@ export interface LocalTranscriptMigrationResult {
     reason: string;
   }>;
   dryRun: boolean;
-}
-
-function readJsonl(path: string): unknown[] {
-  if (!existsSync(path)) return [];
-  return readFileSync(path, "utf8")
-    .split("\n")
-    .filter((line) => line.trim().length > 0)
-    .map((line) => JSON.parse(line));
 }
 
 function isLegacyUiMessage(value: unknown): value is Record<string, unknown> {
@@ -451,7 +444,7 @@ export function migrateLocalBackendTranscripts(input: {
     const hasLegacyPiManifest =
       existingManifest?.message_format ===
       LOCAL_TRANSCRIPT_LEGACY_MESSAGE_FORMAT;
-    const legacyMessages = readJsonl(messagesPath);
+    const legacyMessages = readLocalTranscriptJsonl<unknown>(messagesPath);
     const hasLegacyUiRows = legacyMessages.some(isLegacyUiMessage);
     if (hasManifest && !hasLegacyUiRows && !hasLegacyPiManifest) {
       result.skipped.push({ conversationDir, reason: "already-versioned" });

--- a/src/backend/local/transcript-search.ts
+++ b/src/backend/local/transcript-search.ts
@@ -13,6 +13,7 @@ import {
   type LocalTranscriptManifest,
 } from "./local-store";
 import type { StoredMessage } from "./local-types";
+import { readLocalTranscriptJsonl } from "./transcript-jsonl";
 
 export type LocalTranscriptSearchBody = {
   query?: unknown;
@@ -53,18 +54,6 @@ function readJsonFile<T>(path: string): T | undefined {
     return JSON.parse(readFileSync(path, "utf8")) as T;
   } catch {
     return undefined;
-  }
-}
-
-function readJsonlFile(path: string): unknown[] {
-  if (!existsSync(path)) return [];
-  try {
-    return readFileSync(path, "utf8")
-      .split("\n")
-      .filter((line) => line.trim().length > 0)
-      .map((line) => JSON.parse(line) as unknown);
-  } catch {
-    return [];
   }
 }
 
@@ -362,7 +351,7 @@ function collectConversationMessages(input: {
     return [];
 
   const messagesPath = join(conversationDir, "messages.jsonl");
-  const rows = readJsonlFile(messagesPath);
+  const rows = readLocalTranscriptJsonl<unknown>(messagesPath);
   if (rows.length === 0) return [];
   const manifest = readJsonFile<LocalTranscriptManifest>(
     join(conversationDir, "manifest.json"),

--- a/src/backend/message-search.test.ts
+++ b/src/backend/message-search.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
@@ -341,6 +341,19 @@ describe("message search backend routing", () => {
       expect(results).toHaveLength(1);
       expect(results[0]?.message_id).toBe("legacy-msg-1");
 
+      await appendFile(
+        join(conversationDir, "messages.jsonl"),
+        '{"id":"partial"',
+      );
+      const recoveredResults = searchLocalTranscriptMessages(storageDir, {
+        query: "LEGACY_LOCAL_NEEDLE",
+        agent_id: "agent-legacy",
+        conversation_id: "legacy-conv",
+        limit: 10,
+      });
+      expect(recoveredResults).toHaveLength(1);
+      expect(recoveredResults[0]?.message_id).toBe("legacy-msg-1");
+
       const futureResults = searchLocalTranscriptMessages(storageDir, {
         query: "LEGACY_LOCAL_NEEDLE",
         agent_id: "agent-legacy",
@@ -348,6 +361,16 @@ describe("message search backend routing", () => {
         limit: 10,
       });
       expect(futureResults).toHaveLength(0);
+
+      await appendFile(join(conversationDir, "messages.jsonl"), "\n");
+      expect(() =>
+        searchLocalTranscriptMessages(storageDir, {
+          query: "LEGACY_LOCAL_NEEDLE",
+          agent_id: "agent-legacy",
+          conversation_id: "legacy-conv",
+          limit: 10,
+        }),
+      ).toThrow("line 2");
     } finally {
       await rm(storageDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Fixes #3580.

Local transcript loading, suffix reads, migration, and search each parsed `messages.jsonl` independently. A single interrupted final append caused full history loading to throw, while search caught the same parse failure at file scope and silently returned no messages at all.

This PR gives all local transcript consumers one byte-aware JSONL implementation with deliberately narrow recovery semantics:

- an invalid, non-newline-terminated final physical row is treated as an interrupted append;
- all valid preceding rows remain readable and searchable;
- any malformed newline-committed row still throws an actionable corruption error;
- the next append preserves the original file before removing the incomplete tail.

## What changed

### Shared transcript JSONL owner

Added `src/backend/local/transcript-jsonl.ts` and routed these consumers through it:

- full transcript loads in `LocalStore`;
- bounded suffix reads used by descending history and direct message lookup;
- local transcript search;
- transcript migration.

The parser operates on `Buffer` byte ranges rather than splitting a decoded string. This keeps byte offsets accurate and lets suffix reads discard a clipped initial row before UTF-8 decoding, including when the byte window begins inside a multibyte character.

### Narrow corruption handling

Rows terminated by a newline are considered committed. If one cannot be parsed, `LocalTranscriptJsonlCorruptionError` includes:

- the transcript path;
- the one-based line number when the read starts at the file beginning;
- the exact byte offset;
- the underlying JSON parse message.

Search no longer wraps the entire JSONL parse in a blanket catch, so committed corruption is surfaced instead of being converted into an empty conversation.

Only an invalid final row without a terminating newline is recoverable. The reader returns preceding records and emits a deduplicated warning describing the file and recovery behavior. A complete final JSON value without a newline remains readable and is terminated before a later append.

### Safe append recovery

Before appending a transcript entry, the store examines only the final physical row, avoiding an O(file size) parse on every message append.

For an incomplete tail it:

1. copies the complete original `messages.jsonl` to a uniquely named `messages.jsonl.corrupt-tail-backup-*` sidecar;
2. truncates the active file to the exact starting byte of the damaged row;
3. appends the new record normally.

The copy must succeed before truncation occurs. The backup therefore preserves both every durable row and the exact damaged bytes for inspection or manual recovery.

### Repository maintenance

Extracting the duplicated readers reduced `local-store.ts` from 3,594 to 3,558 lines, so the source-size baseline is lowered in the same change. The new tests live in responsibility-sized adjacent files rather than growing the already grandfathered `local-backend.test.ts`.

## Tests

Added coverage for:

- full reads preserving valid rows before a partial final row;
- committed middle-row corruption reporting path, line, and byte offset;
- suffix reads that start inside a UTF-8 sequence and end with a partial record;
- exact original-byte backup before tail truncation;
- complete final JSON without a newline being preserved and safely delimited;
- local history remaining available after a partial append;
- the next append repairing the file, creating the backup, and remaining readable after another reload;
- search finding durable messages before a partial tail;
- search surfacing a committed malformed row instead of returning no results.

Validation completed:

- focused JSONL, integration, and search tests: 11 passed;
- existing local-backend transcript suite: 38 passed;
- total focused/regression tests: 49 passed;
- `bun run check`: all 12 repository checks passed.

## Scope

This does not attempt to guess around committed mid-file corruption or silently skip arbitrary bad rows. Those cases remain failures because continuing across them could hide lost ordering, parent links, or transcript state. Recovery is limited to the crash-consistent case produced by an interrupted final append.