### PR TITLE
fix(channels): roll back timed-out account startups

### DIFF
--- a/src/channels/account-lifecycle.test.ts
+++ b/src/channels/account-lifecycle.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, expect, test } from "bun:test";
+import { stopChannelAccountLive } from "@/channels/service";
+import { __testOverrideChannelAccountStartupTimeout } from "@/channels/service-accounts";
+import type { ChannelAdapter } from "@/channels/types";
+import {
+  createChannelAccountLive,
+  FakeBot,
+  getChannelAccountSnapshot,
+  getChannelRegistry,
+  installTelegramAdapterTestHooks,
+  startChannelAccountLive,
+} from "./telegram/adapter-test-harness";
+
+installTelegramAdapterTestHooks();
+
+interface StartGate {
+  release: () => void;
+}
+
+function delayNextTelegramStart(): StartGate {
+  let release = (): void => {};
+  const pending = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  FakeBot.nextStartImpl = async (options, botInfo) => {
+    await pending;
+    await options?.onStart?.(
+      botInfo ?? {
+        username: "test_bot",
+        id: 12345,
+      },
+    );
+  };
+  return { release };
+}
+
+function createDisabledTelegramAccount(accountId: string): void {
+  createChannelAccountLive(
+    "telegram",
+    {
+      displayName: accountId,
+      enabled: false,
+      token: "test-token",
+      dmPolicy: "pairing",
+    },
+    { accountId },
+  );
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(message);
+    await new Promise((resolve) => setTimeout(resolve, 2));
+  }
+}
+
+function registeredAdapter(accountId: string): ChannelAdapter | null {
+  return getChannelRegistry()?.getAdapter("telegram", accountId) ?? null;
+}
+
+afterEach(() => {
+  __testOverrideChannelAccountStartupTimeout(undefined);
+});
+
+test("a timed-out channel startup cannot leave its adapter live", async () => {
+  __testOverrideChannelAccountStartupTimeout(20);
+  const gate = delayNextTelegramStart();
+  const accountId = "telegram-timeout";
+  createDisabledTelegramAccount(accountId);
+
+  const startup = startChannelAccountLive("telegram", accountId);
+  await waitFor(
+    () => registeredAdapter(accountId) !== null,
+    "Timed out waiting for the pending adapter to register",
+  );
+  const staleAdapter = registeredAdapter(accountId);
+  expect(staleAdapter).not.toBeNull();
+
+  await expect(startup).rejects.toThrow(
+    `Timed out starting telegram account "${accountId}"`,
+  );
+  expect(getChannelAccountSnapshot("telegram", accountId)).toEqual(
+    expect.objectContaining({ enabled: false, running: false }),
+  );
+  expect(registeredAdapter(accountId)).toBeNull();
+
+  gate.release();
+  await waitFor(
+    () => staleAdapter?.isRunning() === false,
+    "The stale adapter remained running after its start completed",
+  );
+  expect(registeredAdapter(accountId)).toBeNull();
+});
+
+test("late cleanup from a timed-out start does not stop a retry", async () => {
+  __testOverrideChannelAccountStartupTimeout(20);
+  const firstGate = delayNextTelegramStart();
+  const accountId = "telegram-timeout-retry";
+  createDisabledTelegramAccount(accountId);
+
+  const firstStartup = startChannelAccountLive("telegram", accountId);
+  await waitFor(
+    () => registeredAdapter(accountId) !== null,
+    "Timed out waiting for the first adapter to register",
+  );
+  const staleAdapter = registeredAdapter(accountId);
+  await expect(firstStartup).rejects.toThrow("Timed out starting telegram");
+
+  FakeBot.nextStartImpl = async (options, botInfo) => {
+    await options?.onStart?.(
+      botInfo ?? {
+        username: "test_bot",
+        id: 12345,
+      },
+    );
+  };
+  await startChannelAccountLive("telegram", accountId);
+  const retryAdapter = registeredAdapter(accountId);
+  expect(retryAdapter).not.toBeNull();
+  expect(retryAdapter).not.toBe(staleAdapter);
+  expect(retryAdapter?.isRunning()).toBe(true);
+
+  firstGate.release();
+  await waitFor(
+    () => staleAdapter?.isRunning() === false,
+    "The stale adapter was not stopped after late completion",
+  );
+  expect(registeredAdapter(accountId)).toBe(retryAdapter);
+  expect(retryAdapter?.isRunning()).toBe(true);
+  expect(getChannelAccountSnapshot("telegram", accountId)).toEqual(
+    expect.objectContaining({ enabled: true, running: true }),
+  );
+});
+
+test("a concurrent stop supersedes an in-flight startup", async () => {
+  __testOverrideChannelAccountStartupTimeout(500);
+  const gate = delayNextTelegramStart();
+  const accountId = "telegram-concurrent-stop";
+  createDisabledTelegramAccount(accountId);
+
+  const startup = startChannelAccountLive("telegram", accountId);
+  await waitFor(
+    () => registeredAdapter(accountId) !== null,
+    "Timed out waiting for the pending adapter to register",
+  );
+  const staleAdapter = registeredAdapter(accountId);
+
+  const stopped = await stopChannelAccountLive("telegram", accountId);
+  expect(stopped).toEqual(
+    expect.objectContaining({ enabled: false, running: false }),
+  );
+  expect(registeredAdapter(accountId)).toBeNull();
+
+  gate.release();
+  await expect(startup).rejects.toThrow("superseded");
+  await waitFor(
+    () => staleAdapter?.isRunning() === false,
+    "The stopped startup became live after completing",
+  );
+  expect(registeredAdapter(accountId)).toBeNull();
+  expect(getChannelAccountSnapshot("telegram", accountId)).toEqual(
+    expect.objectContaining({ enabled: false, running: false }),
+  );
+});

--- a/src/channels/account-lifecycle.ts
+++ b/src/channels/account-lifecycle.ts
@@ -1,0 +1,106 @@
+import type { ChannelAdapter } from "./types";
+
+interface AccountLifecycleIdentity {
+  key: string;
+  channelId: string;
+  accountId: string;
+}
+
+interface CurrentAccountLifecycle extends AccountLifecycleIdentity {
+  generation: number;
+  signal?: AbortSignal;
+}
+
+function abortError(
+  signal: AbortSignal,
+  channelId: string,
+  accountId: string,
+): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new Error(`Starting ${channelId}/${accountId} was cancelled.`);
+}
+
+export class ChannelAccountLifecycle {
+  private readonly generations = new Map<string, number>();
+  private shuttingDown = false;
+
+  constructor(
+    private readonly unregisterAdapterIfCurrent: (
+      key: string,
+      adapter: ChannelAdapter,
+    ) => void,
+  ) {}
+
+  begin(key: string): number {
+    const generation = (this.generations.get(key) ?? 0) + 1;
+    this.generations.set(key, generation);
+    return generation;
+  }
+
+  assertCurrent(input: CurrentAccountLifecycle): void {
+    if (input.signal?.aborted) {
+      throw abortError(input.signal, input.channelId, input.accountId);
+    }
+    if (
+      this.shuttingDown ||
+      this.generations.get(input.key) !== input.generation
+    ) {
+      throw new Error(
+        `Starting ${input.channelId}/${input.accountId} was superseded by a newer lifecycle operation.`,
+      );
+    }
+  }
+
+  async awaitStep<T>(
+    promise: Promise<T>,
+    signal: AbortSignal | undefined,
+    identity: AccountLifecycleIdentity,
+  ): Promise<T> {
+    if (!signal) return promise;
+    if (signal.aborted) {
+      throw abortError(signal, identity.channelId, identity.accountId);
+    }
+
+    let abortHandler: (() => void) | undefined;
+    const aborted = new Promise<never>((_, reject) => {
+      abortHandler = () => {
+        reject(abortError(signal, identity.channelId, identity.accountId));
+      };
+      signal.addEventListener("abort", abortHandler, { once: true });
+    });
+    try {
+      return await Promise.race([promise, aborted]);
+    } finally {
+      if (abortHandler) {
+        signal.removeEventListener("abort", abortHandler);
+      }
+    }
+  }
+
+  retire(
+    key: string,
+    adapter: ChannelAdapter,
+    startPromise: Promise<void> | undefined,
+  ): void {
+    this.unregisterAdapterIfCurrent(key, adapter);
+    const stopQuietly = async (): Promise<void> => {
+      try {
+        await adapter.stop();
+      } catch {
+        // Best-effort cleanup; a late start completion retries stop below.
+      } finally {
+        this.unregisterAdapterIfCurrent(key, adapter);
+      }
+    };
+
+    void stopQuietly();
+    if (startPromise) {
+      void startPromise.then(stopQuietly, stopQuietly);
+    }
+  }
+
+  shutdown(): void {
+    this.shuttingDown = true;
+  }
+}

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -9,6 +9,7 @@
  * 4. Buffered messages flush through the registered onMessage handler
  */
 
+import { ChannelAccountLifecycle } from "./account-lifecycle";
 import {
   getChannelAccountWithSecrets,
   hydrateChannelAccountSecrets,
@@ -100,6 +101,7 @@ export function getActiveChannelIds(): string[] {
 
 type ChannelStartupOptions = {
   logger?: ChannelStartupLogger;
+  signal?: AbortSignal;
 };
 
 export interface ChannelStartupFailure {
@@ -159,6 +161,9 @@ export function formatChannelStartupFailures(
 
 export class ChannelRegistry {
   private readonly adapters = new Map<string, ChannelAdapter>();
+  private readonly accountLifecycle = new ChannelAccountLifecycle(
+    (key, adapter) => this.unregisterAdapterIfCurrent(key, adapter),
+  );
   private ready = false;
   private messageHandler: ChannelMessageHandler | null = null;
   private eventHandler: ((event: ChannelRegistryEvent) => void) | null = null;
@@ -249,6 +254,15 @@ export class ChannelRegistry {
     accountId = LEGACY_CHANNEL_ACCOUNT_ID,
   ): ChannelAdapter | null {
     return this.adapters.get(this.getAdapterKey(channelId, accountId)) ?? null;
+  }
+
+  private unregisterAdapterIfCurrent(
+    key: string,
+    adapter: ChannelAdapter,
+  ): void {
+    if (this.adapters.get(key) === adapter) {
+      this.adapters.delete(key);
+    }
   }
 
   getActiveChannelIds(): string[] {
@@ -560,8 +574,26 @@ export class ChannelRegistry {
     accountId: string,
     options?: ChannelStartupOptions,
   ): Promise<boolean> {
+    const key = this.getAdapterKey(channelId, accountId);
+    const identity = { key, channelId, accountId };
+    const generation = this.accountLifecycle.begin(key);
+    const awaitStep = <T>(promise: Promise<T>): Promise<T> =>
+      this.accountLifecycle.awaitStep(promise, options?.signal, identity);
+    const assertCurrent = (): void => {
+      this.accountLifecycle.assertCurrent({
+        ...identity,
+        generation,
+        signal: options?.signal,
+      });
+    };
+    let adapter: ChannelAdapter | undefined;
+    let startPromise: Promise<void> | undefined;
+
     logChannelStartup(options?.logger, `starting ${channelId}/${accountId}`);
-    const account = await getChannelAccountWithSecrets(channelId, accountId);
+    const account = await awaitStep(
+      getChannelAccountWithSecrets(channelId, accountId),
+    );
+    assertCurrent();
     if (!account) {
       logChannelStartup(
         options?.logger,
@@ -572,11 +604,12 @@ export class ChannelRegistry {
 
     if (isSignalChannelAccount(account)) {
       const conflict = findSignalBaseUrlConflictForStart(
-        (await listChannelAccountsWithSecrets("signal")).filter(
+        (await awaitStep(listChannelAccountsWithSecrets("signal"))).filter(
           isSignalChannelAccount,
         ),
         account,
       );
+      assertCurrent();
       if (conflict) {
         const error = buildSignalBaseUrlConflictError(conflict);
         logChannelStartup(options?.logger, error);
@@ -593,31 +626,46 @@ export class ChannelRegistry {
     loadTargetStore(channelId);
 
     const existing = this.getAdapter(channelId, accountId);
-    if (existing?.isRunning()) {
+    if (existing) {
       logChannelStartup(
         options?.logger,
         `stopping existing adapter for ${channelId}/${accountId}`,
       );
-      await existing.stop();
+      this.unregisterAdapterIfCurrent(key, existing);
+      try {
+        await awaitStep(existing.stop());
+      } catch (error) {
+        this.accountLifecycle.retire(key, existing, undefined);
+        throw error;
+      }
     }
-    this.adapters.delete(this.getAdapterKey(channelId, accountId));
+    assertCurrent();
 
     logChannelStartup(
       options?.logger,
       `loading plugin for ${account.channel}/${accountId}`,
     );
-    const plugin = await loadChannelPlugin(account.channel);
+    const plugin = await awaitStep(loadChannelPlugin(account.channel));
+    assertCurrent();
     logChannelStartup(
       options?.logger,
       `creating adapter for ${account.channel}/${accountId}`,
     );
-    const adapter = await plugin.createAdapter(account);
-    this.registerAdapter(adapter);
-    logChannelStartup(
-      options?.logger,
-      `starting adapter for ${account.channel}/${accountId}`,
-    );
-    await adapter.start({ logger: options?.logger });
+    adapter = await awaitStep(Promise.resolve(plugin.createAdapter(account)));
+    try {
+      assertCurrent();
+      this.registerAdapter(adapter);
+      logChannelStartup(
+        options?.logger,
+        `starting adapter for ${account.channel}/${accountId}`,
+      );
+      startPromise = adapter.start({ logger: options?.logger });
+      await awaitStep(startPromise);
+      assertCurrent();
+    } catch (error) {
+      this.accountLifecycle.retire(key, adapter, startPromise);
+      throw error;
+    }
     logChannelStartup(
       options?.logger,
       `started adapter for ${account.channel}/${accountId}`,
@@ -634,15 +682,13 @@ export class ChannelRegistry {
     }
 
     for (const adapter of adapters) {
-      if (adapter.isRunning()) {
-        await adapter.stop();
-      }
-      this.adapters.delete(
-        this.getAdapterKey(
-          adapter.channelId ?? adapter.id,
-          adapter.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID,
-        ),
+      const key = this.getAdapterKey(
+        adapter.channelId ?? adapter.id,
+        adapter.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID,
       );
+      this.accountLifecycle.begin(key);
+      this.unregisterAdapterIfCurrent(key, adapter);
+      await adapter.stop();
     }
 
     return true;
@@ -652,14 +698,14 @@ export class ChannelRegistry {
     channelId: string,
     accountId: string,
   ): Promise<boolean> {
+    const key = this.getAdapterKey(channelId, accountId);
+    this.accountLifecycle.begin(key);
     const adapter = this.getAdapter(channelId, accountId);
     if (!adapter) {
       return false;
     }
-    if (adapter.isRunning()) {
-      await adapter.stop();
-    }
-    this.adapters.delete(this.getAdapterKey(channelId, accountId));
+    this.unregisterAdapterIfCurrent(key, adapter);
+    await adapter.stop();
     return true;
   }
 
@@ -694,11 +740,16 @@ export class ChannelRegistry {
    * Only called on actual process shutdown, NOT on WS disconnect.
    */
   async stopAll(): Promise<void> {
+    this.accountLifecycle.shutdown();
     for (const adapter of Array.from(this.adapters.values())) {
-      if (adapter.isRunning()) {
-        await adapter.stop();
-      }
+      const key = this.getAdapterKey(
+        adapter.channelId ?? adapter.id,
+        adapter.accountId ?? LEGACY_CHANNEL_ACCOUNT_ID,
+      );
+      this.accountLifecycle.begin(key);
+      await adapter.stop();
     }
+    this.adapters.clear();
     this.ready = false;
     this.messageHandler = null;
     this.eventHandler = null;

--- a/src/channels/service-accounts.ts
+++ b/src/channels/service-accounts.ts
@@ -35,6 +35,37 @@ import {
   isWhatsAppChannelAccount,
 } from "./types";
 
+const DEFAULT_CHANNEL_ACCOUNT_STARTUP_TIMEOUT_MS = 10_000;
+let channelAccountStartupTimeoutOverrideMs: number | undefined;
+const channelAccountLifecycleGenerations = new Map<string, number>();
+
+export function __testOverrideChannelAccountStartupTimeout(
+  timeoutMs: number | undefined,
+): void {
+  channelAccountStartupTimeoutOverrideMs = timeoutMs;
+}
+
+function beginChannelAccountLifecycle(
+  channelId: string,
+  accountId: string,
+): number {
+  const key = `${channelId}:${accountId}`;
+  const generation = (channelAccountLifecycleGenerations.get(key) ?? 0) + 1;
+  channelAccountLifecycleGenerations.set(key, generation);
+  return generation;
+}
+
+function isCurrentChannelAccountLifecycle(
+  channelId: string,
+  accountId: string,
+  generation: number,
+): boolean {
+  return (
+    channelAccountLifecycleGenerations.get(`${channelId}:${accountId}`) ===
+    generation
+  );
+}
+
 export function createChannelAccountLive(
   channelId: string,
   patch: ChannelAccountPatch,
@@ -311,6 +342,10 @@ export async function startChannelAccountLive(
   accountId: string,
 ): Promise<ChannelAccountSnapshot> {
   assertSupportedChannelId(channelId);
+  const lifecycleGeneration = beginChannelAccountLifecycle(
+    channelId,
+    accountId,
+  );
   const existing = await getChannelAccountWithSecrets(channelId, accountId);
   if (!existing) {
     throw new Error(
@@ -346,31 +381,48 @@ export async function startChannelAccountLive(
     });
   }
 
+  const startupController = new AbortController();
+  const startupTimeoutMs =
+    channelAccountStartupTimeoutOverrideMs ??
+    DEFAULT_CHANNEL_ACCOUNT_STARTUP_TIMEOUT_MS;
   let startupTimeout: ReturnType<typeof setTimeout> | undefined;
   try {
-    await Promise.race([
-      ensureChannelRegistry().startChannelAccount(channelId, accountId),
-      new Promise<never>((_, reject) => {
-        startupTimeout = setTimeout(() => {
-          reject(
-            new Error(
-              `Timed out starting ${channelId} account "${accountId}". Check the credentials and try again.`,
-            ),
-          );
-        }, 10_000);
-      }),
-    ]);
-  } catch (error) {
-    upsertChannelAccount(channelId, {
-      ...existing,
-      enabled: false,
-      updatedAt: new Date().toISOString(),
+    startupTimeout = setTimeout(() => {
+      startupController.abort(
+        new Error(
+          `Timed out starting ${channelId} account "${accountId}". Check the credentials and try again.`,
+        ),
+      );
+    }, startupTimeoutMs);
+    await ensureChannelRegistry().startChannelAccount(channelId, accountId, {
+      signal: startupController.signal,
     });
+  } catch (error) {
+    if (
+      isCurrentChannelAccountLifecycle(
+        channelId,
+        accountId,
+        lifecycleGeneration,
+      )
+    ) {
+      upsertChannelAccount(channelId, {
+        ...existing,
+        enabled: false,
+        updatedAt: new Date().toISOString(),
+      });
+    }
     throw error;
   } finally {
     if (startupTimeout) {
       clearTimeout(startupTimeout);
     }
+  }
+  if (
+    !isCurrentChannelAccountLifecycle(channelId, accountId, lifecycleGeneration)
+  ) {
+    throw new Error(
+      `Starting ${channelId}/${accountId} was superseded by a newer lifecycle operation.`,
+    );
   }
   const snapshot = await refreshChannelAccountDisplayNameLive(
     channelId,
@@ -379,6 +431,13 @@ export async function startChannelAccountLive(
       force: channelId === "slack" || channelId === "discord",
     },
   );
+  if (
+    !isCurrentChannelAccountLifecycle(channelId, accountId, lifecycleGeneration)
+  ) {
+    throw new Error(
+      `Starting ${channelId}/${accountId} was superseded by a newer lifecycle operation.`,
+    );
+  }
   await refreshLoadedMessageChannelTool();
   return snapshot;
 }
@@ -388,6 +447,7 @@ export async function stopChannelAccountLive(
   accountId: string,
 ): Promise<ChannelAccountSnapshot> {
   assertSupportedChannelId(channelId);
+  beginChannelAccountLifecycle(channelId, accountId);
   const existing = await getChannelAccountWithSecrets(channelId, accountId);
   if (!existing) {
     throw new Error(
@@ -413,6 +473,7 @@ export async function removeChannelAccountLive(
   accountId: string,
 ): Promise<boolean> {
   assertSupportedChannelId(channelId);
+  beginChannelAccountLifecycle(channelId, accountId);
   const existing = getChannelAccount(channelId, accountId);
   if (!existing) {
     return false;


### PR DESCRIPTION
## Summary

Fixes #3581.

`startChannelAccountLive()` previously raced registry startup against a timer that had no connection to the operation it timed out. When the timer rejected, persisted state was changed back to disabled, but the registry still owned a registered adapter and its `start()` promise could later resolve into a live integration.

This PR makes timeout a real lifecycle cancellation boundary and orders all account start/stop operations with per-account generations. A startup that times out or is superseded is immediately unpublished, stopped best-effort, and stopped again if its original `start()` later settles. Cleanup is identity-checked so an old attempt cannot remove or stop a newer retry adapter.

## What changed

### Timeout now reaches the registry

`startChannelAccountLive()` now creates an `AbortController` for the existing 10-second deadline and passes its signal to `ChannelRegistry.startChannelAccount()`.

The registry races the signal at each asynchronous startup boundary:

- loading account secrets;
- Signal conflict discovery;
- stopping an existing account adapter;
- loading the channel plugin;
- creating the adapter;
- starting the adapter.

The original timeout error is carried as the abort reason, preserving the existing actionable user-facing message.

### Per-account lifecycle generations

Added a focused `ChannelAccountLifecycle` owner for generation and retirement state. Every start receives a generation for its `(channelId, accountId)` key. The registry verifies that generation after each asynchronous step and before reporting startup success.

These operations invalidate older generations:

- a newer account start;
- `stopChannelAccount()`;
- whole-channel `stopChannel()`;
- registry shutdown via `stopAll()`.

This makes a concurrent stop deterministic even when it arrives before adapter creation or while `adapter.start()` is pending.

### Identity-safe stale cleanup

When startup fails, times out, or becomes stale, cleanup:

1. unregisters the adapter only if the registry still maps that exact adapter instance;
2. calls `stop()` immediately as a best-effort cancellation;
3. observes the original startup promise;
4. calls `stop()` again after late resolution/rejection;
5. repeats identity-checked unregistration.

The second stop is required for adapters whose first `stop()` is a no-op while startup has not yet marked itself running. Crucially, cleanup retains the old adapter object and never looks up the key and stops whatever happens to be there later, so a successful retry is unaffected.

Adapters are also removed from the registry before stop is awaited. Callers and snapshots therefore cannot observe a disabled account as registered/live while slow cleanup completes.

### Persisted-state race protection

The service layer now tracks its own account lifecycle generation. A stale start failure only rolls persisted `enabled` state back when it is still the newest service operation.

Without this guard, an older start superseded by a retry could reject later and overwrite the retry state back to disabled even though the new adapter succeeded. Stop and remove operations also advance this generation, and startup rechecks it around display-name refresh before returning success.

### Existing failure cleanup

The same retirement path now unregisters adapters after ordinary startup failures, not only timeouts. Stop paths call `stop()` for registered pending adapters even when `isRunning()` is still false, allowing adapters with in-progress initialization to cancel early.

## Tests

Added real delayed Telegram adapter lifecycle tests covering:

- service timeout disables persistent state and immediately unregisters the pending adapter;
- a delayed `start()` resolving after timeout is stopped and cannot re-register;
- a retry after timeout remains registered and running after stale cleanup executes;
- stale failure rollback does not overwrite the retry enabled state;
- a concurrent stop supersedes pending startup and leaves registry and persistence disabled.

Validation completed:

- race-specific, registry lifecycle, and Telegram runtime tests: 30 passed;
- complete `src/channels` suite: 816 passed, 1 intentional live-network test skipped, 0 failed;
- `bun run check`: all 12 repository checks passed;
- `registry.ts` remains below the enforced source ceiling at 977 lines after extracting lifecycle ownership.

## Concurrency semantics

For one account key, the newest lifecycle operation wins. Cleanup from an older operation may only act on the adapter instance created by that operation. Operations for different account keys remain independent and are not globally serialized.

The adapter interface is unchanged. Existing adapters can continue implementing their own startup timeouts/cancellation, while the registry generation guard provides the cross-adapter safety boundary required by the service-level timeout.