### PR TITLE
fix(listener): make file watcher setup disposal-safe

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -46,7 +46,6 @@
   "src/websocket/listen-client-protocol.test.ts": 6721,
   "src/websocket/listener/commands/channels.ts": 1315,
   "src/websocket/listener/commands/memory.ts": 1114,
-  "src/websocket/listener/file-commands.ts": 1030,
   "src/websocket/listener/lifecycle.ts": 1656,
   "src/websocket/listener/protocol-inbound.ts": 2293,
   "src/websocket/listener/protocol-outbound.ts": 1100

--- a/src/websocket/listener/file-commands.test.ts
+++ b/src/websocket/listener/file-commands.test.ts
@@ -4,8 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type WebSocket from "ws";
 import { createFileCommandSession } from "./file-commands";
+import type { FileWatchDependencies } from "./file-watch-session";
 
-function createHarness() {
+function createHarness(options?: {
+  loadFileWatchDependencies?: () => Promise<FileWatchDependencies>;
+}) {
   const sent: unknown[] = [];
   const tasks: Promise<void>[] = [];
   const session = createFileCommandSession({
@@ -17,6 +20,7 @@ function createHarness() {
     runDetachedListenerTask: (_commandName, task) => {
       tasks.push(task());
     },
+    loadFileWatchDependencies: options?.loadFileWatchDependencies,
   });
 
   return {
@@ -229,5 +233,38 @@ describe("listener file commands without file index", () => {
       files: [{ path: "src/target.ts", type: "file" }],
       success: true,
     });
+  });
+
+  test("disposal closes the session watcher and suppresses later file events", async () => {
+    let closeCount = 0;
+    let watchListener: ((eventType: "change" | "rename") => void) | undefined;
+    const harness = createHarness({
+      loadFileWatchDependencies: async () => ({
+        watch: (_path, _options, listener) => {
+          watchListener = listener;
+          return {
+            close: () => {
+              closeCount += 1;
+            },
+            on: () => {},
+          };
+        },
+        stat: async () => ({ mtimeMs: 1234 }),
+      }),
+    });
+
+    expect(
+      harness.session.handle({
+        type: "watch_file",
+        path: "/tmp/session-watch.txt",
+        request_id: "watch-session-disposal",
+      }),
+    ).toBe(true);
+    await harness.flush();
+    harness.session.dispose();
+    watchListener?.("change");
+
+    expect(closeCount).toBe(1);
+    expect(harness.sent).toEqual([]);
   });
 });

--- a/src/websocket/listener/file-commands.ts
+++ b/src/websocket/listener/file-commands.ts
@@ -5,6 +5,10 @@ import picomatch from "picomatch";
 import type WebSocket from "ws";
 import { trackBoundaryError } from "@/telemetry/error-reporting";
 import { readUtf8TextStrict, writeUtf8Text } from "@/utils/text-files";
+import {
+  createFileWatchSession,
+  type LoadFileWatchDependencies,
+} from "./file-watch-session";
 import { runGrepInFiles } from "./grep-in-files";
 import {
   isEditFileCommand,
@@ -412,36 +416,27 @@ export function createFileCommandSession(params: {
   socket: WebSocket;
   safeSocketSend: SafeSocketSend;
   runDetachedListenerTask: RunDetachedListenerTask;
+  loadFileWatchDependencies?: LoadFileWatchDependencies;
 }): {
   handle: (parsed: unknown) => boolean;
   dispose: () => void;
 } {
   const { socket, safeSocketSend, runDetachedListenerTask } = params;
-
-  // File watchers are keyed by absolute path and ref-counted so multiple
-  // windows watching the same file share one fs.watch() handle.
-  const fileWatchers = new Map<
-    string,
-    { watcher: import("node:fs").FSWatcher; refCount: number }
-  >();
-  // Debounce timers for fs.watch events; macOS/FSEvents can fire multiple
-  // rapid events for a single save.
-  const watchDebounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
-  // Paths where unwatch_file arrived while the watch_file async task was still
-  // in flight. The task checks this set after its await and bails if present.
-  const cancelledWatches = new Set<string>();
+  const fileWatchSession = createFileWatchSession({
+    loadDependencies: params.loadFileWatchDependencies,
+    runDetachedTask: (task) => runDetachedListenerTask("watch_file", task),
+    emitFileChanged: (path, lastModified) => {
+      safeSocketSend(
+        socket,
+        { type: "file_changed", path, lastModified },
+        "listener_file_changed_send_failed",
+        "listener_watch_file",
+      );
+    },
+  });
 
   const dispose = (): void => {
-    for (const { watcher } of fileWatchers.values()) {
-      watcher.close();
-    }
-    fileWatchers.clear();
-
-    for (const timer of watchDebounceTimers.values()) {
-      clearTimeout(timer);
-    }
-    watchDebounceTimers.clear();
-    cancelledWatches.clear();
+    fileWatchSession.dispose();
   };
 
   const handle = (parsed: unknown): boolean => {
@@ -830,88 +825,12 @@ export function createFileCommandSession(params: {
 
     // File watching (no runtime scope required)
     if (isWatchFileCommand(parsed)) {
-      runDetachedListenerTask("watch_file", async () => {
-        const existing = fileWatchers.get(parsed.path);
-        if (existing) {
-          existing.refCount++;
-          return;
-        }
-        try {
-          const { watch } = await import("node:fs");
-          const { stat } = await import("node:fs/promises");
-          // Check if unwatch arrived while we were awaiting imports
-          if (cancelledWatches.delete(parsed.path)) return;
-          const watcher = watch(
-            parsed.path,
-            { persistent: false },
-            (eventType) => {
-              // Handle both "change" (normal write) and "rename" (atomic
-              // write-then-rename, common on Linux). We stat() the original
-              // path -- if it still exists the content was updated; if not
-              // the file was deleted and the catch handler cleans up.
-              if (eventType !== "change" && eventType !== "rename") return;
-              // Debounce: macOS/FSEvents can fire multiple rapid events
-              // for a single save. Collapse into one file_changed push.
-              const existing = watchDebounceTimers.get(parsed.path);
-              if (existing) clearTimeout(existing);
-              watchDebounceTimers.set(
-                parsed.path,
-                setTimeout(() => {
-                  watchDebounceTimers.delete(parsed.path);
-                  stat(parsed.path)
-                    .then((s) => {
-                      safeSocketSend(
-                        socket,
-                        {
-                          type: "file_changed",
-                          path: parsed.path,
-                          lastModified: Math.round(s.mtimeMs),
-                        },
-                        "listener_file_changed_send_failed",
-                        "listener_watch_file",
-                      );
-                    })
-                    .catch(() => {
-                      // File deleted -- stop watching
-                      const entry = fileWatchers.get(parsed.path);
-                      if (entry) {
-                        entry.watcher.close();
-                        fileWatchers.delete(parsed.path);
-                      }
-                    });
-                }, 150),
-              );
-            },
-          );
-          watcher.on("error", () => {
-            watcher.close();
-            fileWatchers.delete(parsed.path);
-          });
-          fileWatchers.set(parsed.path, { watcher, refCount: 1 });
-        } catch {
-          // fs.watch not supported or path invalid -- silently ignore
-        }
-      });
+      fileWatchSession.watchFile(parsed.path);
       return true;
     }
 
     if (isUnwatchFileCommand(parsed)) {
-      const entry = fileWatchers.get(parsed.path);
-      if (entry) {
-        entry.refCount--;
-        if (entry.refCount <= 0) {
-          entry.watcher.close();
-          fileWatchers.delete(parsed.path);
-        }
-      } else {
-        // watch_file async task may still be in flight -- mark for cancel
-        cancelledWatches.add(parsed.path);
-      }
-      const timer = watchDebounceTimers.get(parsed.path);
-      if (timer) {
-        clearTimeout(timer);
-        watchDebounceTimers.delete(parsed.path);
-      }
+      fileWatchSession.unwatchFile(parsed.path);
       return true;
     }
 

--- a/src/websocket/listener/file-watch-session.test.ts
+++ b/src/websocket/listener/file-watch-session.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createFileWatchSession,
+  type FileCommandWatcher,
+  type FileWatchDependencies,
+} from "./file-watch-session";
+
+class FakeWatcher implements FileCommandWatcher {
+  closeCount = 0;
+  errorListener: (() => void) | undefined;
+
+  close(): void {
+    this.closeCount += 1;
+  }
+
+  on(_event: "error", listener: () => void): this {
+    this.errorListener = listener;
+    return this;
+  }
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve(value) {
+      if (!resolvePromise) throw new Error("Deferred promise is not ready");
+      resolvePromise(value);
+    },
+  };
+}
+
+function createDependencies(options?: {
+  beforeWatch?: () => void;
+  stat?: FileWatchDependencies["stat"];
+}): {
+  dependencies: FileWatchDependencies;
+  watchers: FakeWatcher[];
+  emitWatchEvent: (eventType: "change" | "rename") => void;
+} {
+  const watchers: FakeWatcher[] = [];
+  let watchListener: ((eventType: "change" | "rename") => void) | undefined;
+  return {
+    watchers,
+    dependencies: {
+      watch: (_path, _watchOptions, listener) => {
+        options?.beforeWatch?.();
+        watchListener = listener;
+        const watcher = new FakeWatcher();
+        watchers.push(watcher);
+        return watcher;
+      },
+      stat: options?.stat ?? (async () => ({ mtimeMs: 1234.4 })),
+    },
+    emitWatchEvent(eventType) {
+      if (!watchListener) throw new Error("No watcher has been created");
+      watchListener(eventType);
+    },
+  };
+}
+
+function createTaskCollector(): {
+  runDetachedTask: (task: () => Promise<void>) => void;
+  flush: () => Promise<void>;
+} {
+  const tasks: Promise<void>[] = [];
+  return {
+    runDetachedTask(task) {
+      tasks.push(task());
+    },
+    async flush() {
+      await Promise.all(tasks);
+    },
+  };
+}
+
+describe("file watch session lifecycle", () => {
+  test("disposal while setup is suspended prevents watcher creation", async () => {
+    const dependencyLoad = deferred<FileWatchDependencies>();
+    const fake = createDependencies();
+    const tasks = createTaskCollector();
+    const session = createFileWatchSession({
+      emitFileChanged: () => {},
+      runDetachedTask: tasks.runDetachedTask,
+      loadDependencies: () => dependencyLoad.promise,
+    });
+
+    session.watchFile("/tmp/suspended.txt");
+    session.dispose();
+    dependencyLoad.resolve(fake.dependencies);
+    await tasks.flush();
+
+    expect(fake.watchers).toHaveLength(0);
+  });
+
+  test("closes a watcher created at the disposal boundary exactly once", async () => {
+    const tasks = createTaskCollector();
+    let session: ReturnType<typeof createFileWatchSession>;
+    const fake = createDependencies({ beforeWatch: () => session.dispose() });
+    session = createFileWatchSession({
+      emitFileChanged: () => {},
+      runDetachedTask: tasks.runDetachedTask,
+      loadDependencies: async () => fake.dependencies,
+    });
+
+    session.watchFile("/tmp/boundary.txt");
+    await tasks.flush();
+    session.dispose();
+
+    expect(fake.watchers).toHaveLength(1);
+    expect(fake.watchers[0]?.closeCount).toBe(1);
+  });
+
+  test("does not emit a file change when disposal races with stat", async () => {
+    const statResult = deferred<{ mtimeMs: number }>();
+    let statStarted = false;
+    const fake = createDependencies({
+      stat: async () => {
+        statStarted = true;
+        return statResult.promise;
+      },
+    });
+    const tasks = createTaskCollector();
+    const emitted: Array<{ path: string; lastModified: number }> = [];
+    const session = createFileWatchSession({
+      emitFileChanged: (path, lastModified) =>
+        emitted.push({ path, lastModified }),
+      runDetachedTask: tasks.runDetachedTask,
+      loadDependencies: async () => fake.dependencies,
+      debounceMs: 0,
+    });
+
+    session.watchFile("/tmp/changed.txt");
+    await tasks.flush();
+    fake.emitWatchEvent("change");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(statStarted).toBe(true);
+
+    session.dispose();
+    statResult.resolve({ mtimeMs: 4567.8 });
+    await Promise.resolve();
+
+    expect(emitted).toEqual([]);
+    expect(fake.watchers[0]?.closeCount).toBe(1);
+  });
+
+  test("emits a rounded modification time for an active watcher", async () => {
+    const fake = createDependencies();
+    const tasks = createTaskCollector();
+    const emitted: Array<{ path: string; lastModified: number }> = [];
+    const session = createFileWatchSession({
+      emitFileChanged: (path, lastModified) =>
+        emitted.push({ path, lastModified }),
+      runDetachedTask: tasks.runDetachedTask,
+      loadDependencies: async () => fake.dependencies,
+      debounceMs: 0,
+    });
+
+    session.watchFile("/tmp/active-change.txt");
+    await tasks.flush();
+    fake.emitWatchEvent("rename");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await Promise.resolve();
+
+    expect(emitted).toEqual([
+      { path: "/tmp/active-change.txt", lastModified: 1234 },
+    ]);
+    session.dispose();
+  });
+
+  test("unwatch during suspended setup cancels watcher creation", async () => {
+    const dependencyLoad = deferred<FileWatchDependencies>();
+    const fake = createDependencies();
+    const tasks = createTaskCollector();
+    const session = createFileWatchSession({
+      emitFileChanged: () => {},
+      runDetachedTask: tasks.runDetachedTask,
+      loadDependencies: () => dependencyLoad.promise,
+    });
+
+    session.watchFile("/tmp/cancelled.txt");
+    session.unwatchFile("/tmp/cancelled.txt");
+    dependencyLoad.resolve(fake.dependencies);
+    await tasks.flush();
+
+    expect(fake.watchers).toHaveLength(0);
+  });
+
+  test("ref-counts duplicate requests that arrive during setup", async () => {
+    const dependencyLoad = deferred<FileWatchDependencies>();
+    const fake = createDependencies();
+    const tasks = createTaskCollector();
+    const session = createFileWatchSession({
+      emitFileChanged: () => {},
+      runDetachedTask: tasks.runDetachedTask,
+      loadDependencies: () => dependencyLoad.promise,
+    });
+
+    session.watchFile("/tmp/shared.txt");
+    session.watchFile("/tmp/shared.txt");
+    session.unwatchFile("/tmp/shared.txt");
+    dependencyLoad.resolve(fake.dependencies);
+    await tasks.flush();
+
+    expect(fake.watchers).toHaveLength(1);
+    expect(fake.watchers[0]?.closeCount).toBe(0);
+    session.unwatchFile("/tmp/shared.txt");
+    expect(fake.watchers[0]?.closeCount).toBe(1);
+  });
+
+  test("closes active watchers idempotently on repeated disposal", async () => {
+    const fake = createDependencies();
+    const tasks = createTaskCollector();
+    const session = createFileWatchSession({
+      emitFileChanged: () => {},
+      runDetachedTask: tasks.runDetachedTask,
+      loadDependencies: async () => fake.dependencies,
+    });
+
+    session.watchFile("/tmp/active.txt");
+    await tasks.flush();
+    session.dispose();
+    session.dispose();
+    fake.watchers[0]?.errorListener?.();
+
+    expect(fake.watchers[0]?.closeCount).toBe(1);
+  });
+});

--- a/src/websocket/listener/file-watch-session.ts
+++ b/src/websocket/listener/file-watch-session.ts
@@ -1,0 +1,193 @@
+export interface FileCommandWatcher {
+  close: () => void;
+  on: (event: "error", listener: () => void) => unknown;
+}
+
+export interface FileWatchDependencies {
+  watch: (
+    path: string,
+    options: { persistent: false },
+    listener: (eventType: "change" | "rename") => void,
+  ) => FileCommandWatcher;
+  stat: (path: string) => Promise<{ mtimeMs: number }>;
+}
+
+export type LoadFileWatchDependencies = () => Promise<FileWatchDependencies>;
+
+interface PendingWatch {
+  cancelled: boolean;
+  refCount: number;
+}
+
+interface ActiveWatch {
+  watcher: FileCommandWatcher;
+  refCount: number;
+}
+
+interface FileWatchSessionParams {
+  emitFileChanged: (path: string, lastModified: number) => void;
+  runDetachedTask: (task: () => Promise<void>) => void;
+  loadDependencies?: LoadFileWatchDependencies;
+  debounceMs?: number;
+}
+
+async function loadNodeFileWatchDependencies(): Promise<FileWatchDependencies> {
+  const [{ watch }, { stat }] = await Promise.all([
+    import("node:fs"),
+    import("node:fs/promises"),
+  ]);
+  return { watch, stat };
+}
+
+export function createFileWatchSession(params: FileWatchSessionParams): {
+  watchFile: (path: string) => void;
+  unwatchFile: (path: string) => void;
+  dispose: () => void;
+} {
+  const activeWatches = new Map<string, ActiveWatch>();
+  const pendingWatches = new Map<string, PendingWatch>();
+  const debounceTimers = new Map<
+    string,
+    { timer: ReturnType<typeof setTimeout>; watcher: FileCommandWatcher }
+  >();
+  const closedWatchers = new WeakSet<FileCommandWatcher>();
+  const loadDependencies =
+    params.loadDependencies ?? loadNodeFileWatchDependencies;
+  const debounceMs = params.debounceMs ?? 150;
+  let disposed = false;
+
+  function closeWatcher(watcher: FileCommandWatcher): void {
+    if (closedWatchers.has(watcher)) return;
+    closedWatchers.add(watcher);
+    watcher.close();
+  }
+
+  function clearDebounce(path: string, watcher?: FileCommandWatcher): void {
+    const entry = debounceTimers.get(path);
+    if (!entry || (watcher && entry.watcher !== watcher)) return;
+    clearTimeout(entry.timer);
+    debounceTimers.delete(path);
+  }
+
+  function dispose(): void {
+    if (disposed) return;
+    disposed = true;
+
+    for (const { watcher } of activeWatches.values()) closeWatcher(watcher);
+    activeWatches.clear();
+    for (const pending of pendingWatches.values()) pending.cancelled = true;
+    pendingWatches.clear();
+    for (const { timer } of debounceTimers.values()) clearTimeout(timer);
+    debounceTimers.clear();
+  }
+
+  function watchFile(path: string): void {
+    if (disposed) return;
+
+    const active = activeWatches.get(path);
+    if (active) {
+      active.refCount += 1;
+      return;
+    }
+
+    const pending = pendingWatches.get(path);
+    if (pending && !pending.cancelled) {
+      pending.refCount += 1;
+      return;
+    }
+
+    const setup: PendingWatch = { cancelled: false, refCount: 1 };
+    pendingWatches.set(path, setup);
+    params.runDetachedTask(async () => {
+      let watcher: FileCommandWatcher | undefined;
+      try {
+        const dependencies = await loadDependencies();
+        if (disposed || setup.cancelled) return;
+
+        watcher = dependencies.watch(
+          path,
+          { persistent: false },
+          (eventType) => {
+            const current = activeWatches.get(path);
+            if (
+              disposed ||
+              !watcher ||
+              current?.watcher !== watcher ||
+              (eventType !== "change" && eventType !== "rename")
+            ) {
+              return;
+            }
+            clearDebounce(path, watcher);
+            const timer = setTimeout(() => {
+              if (debounceTimers.get(path)?.timer !== timer) return;
+              debounceTimers.delete(path);
+              if (disposed) return;
+              void dependencies
+                .stat(path)
+                .then((fileStat) => {
+                  const current = activeWatches.get(path);
+                  if (disposed || current?.watcher !== watcher) return;
+                  params.emitFileChanged(path, Math.round(fileStat.mtimeMs));
+                })
+                .catch(() => {
+                  const current = activeWatches.get(path);
+                  if (current?.watcher !== watcher || !watcher) return;
+                  closeWatcher(watcher);
+                  activeWatches.delete(path);
+                });
+            }, debounceMs);
+            debounceTimers.set(path, {
+              watcher,
+              timer,
+            });
+          },
+        );
+
+        if (disposed || setup.cancelled) {
+          closeWatcher(watcher);
+          return;
+        }
+
+        watcher.on("error", () => {
+          if (!watcher) return;
+          closeWatcher(watcher);
+          const current = activeWatches.get(path);
+          if (current?.watcher === watcher) activeWatches.delete(path);
+          clearDebounce(path, watcher);
+        });
+
+        if (disposed || setup.cancelled) {
+          closeWatcher(watcher);
+          return;
+        }
+        activeWatches.set(path, { watcher, refCount: setup.refCount });
+      } catch {
+        if (watcher) closeWatcher(watcher);
+      } finally {
+        if (pendingWatches.get(path) === setup) pendingWatches.delete(path);
+      }
+    });
+  }
+
+  function unwatchFile(path: string): void {
+    if (disposed) return;
+
+    const active = activeWatches.get(path);
+    if (active) {
+      active.refCount -= 1;
+      if (active.refCount <= 0) {
+        closeWatcher(active.watcher);
+        activeWatches.delete(path);
+      }
+    } else {
+      const pending = pendingWatches.get(path);
+      if (pending && !pending.cancelled) {
+        pending.refCount -= 1;
+        if (pending.refCount <= 0) pending.cancelled = true;
+      }
+    }
+    clearDebounce(path, active?.watcher);
+  }
+
+  return { watchFile, unwatchFile, dispose };
+}


### PR DESCRIPTION
## Summary

Fixes #3583.

A listener session could be disposed while detached `watch_file` setup was awaiting its dynamic filesystem imports. Because disposal only closed watchers already present in the active map, the setup could resume afterward, create a new `fs.watch()` handle, and retain the dead socket/session indefinitely.

This change moves watcher ownership into a dedicated lifecycle object with explicit active, pending, and disposed states.

## What changed

- Added a per-session disposed latch that is set before resource cleanup begins.
- Track pending watcher setup synchronously, before detached work starts.
- Check disposal and cancellation immediately after dependency loading, after `watch()` creates a resource, and after the error listener is registered.
- Immediately close a watcher if disposal or unwatch races with synchronous resource creation.
- Make watcher closure idempotent so disposal, unwatch, setup rollback, filesystem errors, and deletion cleanup cannot close the same handle more than once.
- Guard watcher callbacks, debounce timers, asynchronous `stat()` completion, and `file_changed` delivery against disposed or replaced watchers.
- Scope debounce entries to the watcher instance so late events from an old watcher cannot clear or replace a newer watcher timer for the same path.
- Preserve explicit `unwatch_file` cancellation while setup is suspended.
- Ref-count duplicate `watch_file` requests even when both arrive before asynchronous setup completes. This also prevents concurrent setup from creating and leaking two handles for the same path.
- Keep `createFileCommandSession()` as the protocol owner while delegating watcher resource ownership to `file-watch-session.ts` through an injectable dependency loader.

## Lifecycle guarantees

After `dispose()` begins:

- a suspended setup cannot call `watch()`;
- a watcher created at the disposal boundary is closed immediately;
- no new debounce timer is created;
- a pending `stat()` result cannot emit `file_changed`;
- repeated disposal or late watcher errors do not double-close handles.

The dependency loader is injectable only at the session boundary, which lets the race windows be tested deterministically without module-level mocks or real OS watchers.

## Tests

Added deterministic coverage for:

- disposal while dependency loading is suspended;
- disposal synchronously at the `watch()` creation boundary;
- suppression of `file_changed` when disposal races with `stat()` completion;
- normal rounded modification-time delivery for an active watcher;
- explicit unwatch during suspended setup;
- duplicate request ref-counting during setup;
- idempotent closure across repeated disposal and late error callbacks;
- public `createFileCommandSession()` wiring from disposal to watcher close and socket-send suppression.

Validation completed:

- `bun test src/websocket/listener/file-watch-session.test.ts src/websocket/listener/file-commands.test.ts` — 12 passed, 0 failed
- `bun run check` — all 12 checks passed

## Structural cleanup

Extracting watcher ownership reduced `src/websocket/listener/file-commands.ts` from 1,030 to 949 lines. The file is now below the repository limit, so its oversized source baseline entry is removed.
