### PR TITLE
fix(providers): scope ChatGPT usage cache by credentials

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -34,7 +34,7 @@
   "src/permissions/checker.ts": 1009,
   "src/permissions/read-only-shell.test.ts": 1303,
   "src/permissions/read-only-shell.ts": 2009,
-  "src/providers/chatgpt-usage-service.ts": 1112,
+  "src/providers/chatgpt-usage-service.ts": 1111,
   "src/settings-manager.test.ts": 1669,
   "src/settings-manager.ts": 2112,
   "src/tools/impl/enter-worktree.ts": 1260,

--- a/src/providers/chatgpt-usage-service.test.ts
+++ b/src/providers/chatgpt-usage-service.test.ts
@@ -12,6 +12,7 @@ import {
   normalizeWhamUsageResponse,
   readChatGPTUsage,
 } from "@/providers/chatgpt-usage-service";
+import { createCredentialScopedCacheKey } from "@/providers/credential-scoped-cache";
 
 async function withEnv<T>(
   updates: Record<string, string | undefined>,
@@ -449,5 +450,243 @@ describe("ChatGPT usage service", () => {
     } finally {
       await rm(storageDir, { recursive: true, force: true });
     }
+  });
+
+  test("isolates local usage caches by storage root and reuses the same account entry", async () => {
+    const storageDirA = await mkdtemp(join(tmpdir(), "chatgpt-usage-a-"));
+    const storageDirB = await mkdtemp(join(tmpdir(), "chatgpt-usage-b-"));
+    try {
+      for (const storageDir of [storageDirA, storageDirB]) {
+        setLocalOAuthProvider({
+          storageDir,
+          providerName: LOCAL_CHATGPT_PROVIDER_NAME,
+          providerType: "chatgpt_oauth",
+          auth: {
+            type: "oauth",
+            access: "shared-storage-access",
+            refresh: "shared-storage-refresh",
+            expires: Date.now() + 60_000,
+            accountId: "shared-storage-account",
+          },
+        });
+      }
+
+      const calls: string[] = [];
+      const fetchMock = mock(
+        async (_url: Parameters<typeof fetch>[0], init?: RequestInit) => {
+          const accountId = new Headers(init?.headers).get(
+            "chatgpt-account-id",
+          );
+          calls.push(accountId ?? "missing");
+          const usedPercent = calls.length === 1 ? 11 : 22;
+          return Response.json({
+            rate_limit: {
+              primary_window: {
+                used_percent: usedPercent,
+              },
+            },
+          });
+        },
+      ) as unknown as typeof fetch;
+      const now = Date.now();
+
+      const firstA = await readChatGPTUsage({
+        target: "local",
+        storageDir: storageDirA,
+        fetch: fetchMock,
+        now: () => now,
+      });
+      const firstB = await readChatGPTUsage({
+        target: "local",
+        storageDir: storageDirB,
+        fetch: fetchMock,
+        now: () => now,
+      });
+      const secondA = await readChatGPTUsage({
+        target: "local",
+        storageDir: storageDirA,
+        fetch: fetchMock,
+        now: () => now,
+      });
+
+      expect(calls).toEqual([
+        "shared-storage-account",
+        "shared-storage-account",
+      ]);
+      expect(firstA.success && firstA.usage.primary?.usedPercent).toBe(11);
+      expect(firstB.success && firstB.usage.primary?.usedPercent).toBe(22);
+      expect(secondA).toEqual(firstA);
+    } finally {
+      await Promise.all(
+        [storageDirA, storageDirB].map((dir) =>
+          rm(dir, { recursive: true, force: true }),
+        ),
+      );
+    }
+  });
+
+  test("isolates local usage caches when the OAuth account changes", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "chatgpt-account-swap-"));
+    try {
+      const setAccount = (accountId: string) =>
+        setLocalOAuthProvider({
+          storageDir,
+          providerName: LOCAL_CHATGPT_PROVIDER_NAME,
+          providerType: "chatgpt_oauth",
+          auth: {
+            type: "oauth",
+            access: "shared-access-token",
+            refresh: "shared-refresh-token",
+            expires: Date.now() + 60_000,
+            accountId,
+          },
+        });
+      const accounts: string[] = [];
+      const fetchMock = mock(
+        async (_url: Parameters<typeof fetch>[0], init?: RequestInit) => {
+          const accountId =
+            new Headers(init?.headers).get("chatgpt-account-id") ?? "missing";
+          accounts.push(accountId);
+          return Response.json({
+            rate_limit: {
+              primary_window: {
+                used_percent: accountId === "oauth-account-a" ? 31 : 47,
+              },
+            },
+          });
+        },
+      ) as unknown as typeof fetch;
+      const now = Date.now();
+
+      setAccount("oauth-account-a");
+      const resultA = await readChatGPTUsage({
+        target: "local",
+        storageDir,
+        fetch: fetchMock,
+        now: () => now,
+      });
+      setAccount("oauth-account-b");
+      const resultB = await readChatGPTUsage({
+        target: "local",
+        storageDir,
+        fetch: fetchMock,
+        now: () => now,
+      });
+
+      expect(accounts).toEqual(["oauth-account-a", "oauth-account-b"]);
+      expect(resultA.success && resultA.usage.primary?.usedPercent).toBe(31);
+      expect(resultB.success && resultB.usage.primary?.usedPercent).toBe(47);
+    } finally {
+      await rm(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  test("isolates cloud usage caches when credentials change", async () => {
+    let apiKey = "cloud-credential-a";
+    const authorizations: string[] = [];
+    const fetchMock = mock(
+      async (_url: Parameters<typeof fetch>[0], init?: RequestInit) => {
+        const authorization =
+          new Headers(init?.headers).get("authorization") ?? "missing";
+        authorizations.push(authorization);
+        const usedPercent = authorization.endsWith("cloud-credential-a")
+          ? 14
+          : 28;
+        return Response.json({
+          providerName: "chatgpt-cache-test",
+          fetchedAt: "2026-06-18T12:00:00.000Z",
+          summary: `Usage: ${usedPercent}% used`,
+          primary: {
+            label: "primary",
+            usedPercent,
+            windowDurationMins: 300,
+            resetsAt: null,
+          },
+          secondary: null,
+          additional: [],
+        });
+      },
+    ) as unknown as typeof fetch;
+    const getSettings = async () => ({
+      env: {
+        LETTA_API_KEY: apiKey,
+        LETTA_BASE_URL: "https://cache.test.letta.com",
+      },
+      refreshToken: undefined,
+      tokenExpiresAt: undefined,
+    });
+    const now = Date.parse("2026-06-18T12:00:00Z");
+
+    await withEnv(
+      { LETTA_API_KEY: undefined, LETTA_BASE_URL: undefined },
+      async () => {
+        const resultA = await readChatGPTUsage({
+          target: "api",
+          providerName: "chatgpt-cache-test",
+          fetch: fetchMock,
+          getSettings,
+          now: () => now,
+        });
+        apiKey = "cloud-credential-b";
+        const resultB = await readChatGPTUsage({
+          target: "api",
+          providerName: "chatgpt-cache-test",
+          fetch: fetchMock,
+          getSettings,
+          now: () => now,
+        });
+        const repeatedB = await readChatGPTUsage({
+          target: "api",
+          providerName: "chatgpt-cache-test",
+          fetch: fetchMock,
+          getSettings,
+          now: () => now,
+        });
+        apiKey = "";
+        const loggedOut = await readChatGPTUsage({
+          target: "api",
+          providerName: "chatgpt-cache-test",
+          fetch: fetchMock,
+          getSettings,
+          now: () => now,
+        });
+
+        expect(resultA.success && resultA.usage.primary?.usedPercent).toBe(14);
+        expect(resultB.success && resultB.usage.primary?.usedPercent).toBe(28);
+        expect(repeatedB).toEqual(resultB);
+        expect(loggedOut).toEqual({
+          success: false,
+          error: {
+            code: "unauthorized",
+            message: "Sign in with Letta to read ChatGPT usage.",
+          },
+        });
+      },
+    );
+
+    expect(authorizations).toEqual([
+      "Bearer cloud-credential-a",
+      "Bearer cloud-credential-b",
+    ]);
+  });
+
+  test("credential-scoped cache keys are stable without exposing identity inputs", () => {
+    const rawCredential = "sk-sensitive-cloud-credential";
+    const rawAccountId = "acct-sensitive-id";
+    const rawStorageRoot = "/private/profile/alice";
+    const identity = [rawStorageRoot, rawAccountId, rawCredential];
+    const key = createCredentialScopedCacheKey("usage", identity);
+
+    expect(createCredentialScopedCacheKey("usage", identity)).toBe(key);
+    expect(
+      createCredentialScopedCacheKey("usage", [
+        rawStorageRoot,
+        rawAccountId,
+        "different-credential",
+      ]),
+    ).not.toBe(key);
+    expect(key).not.toContain(rawCredential);
+    expect(key).not.toContain(rawAccountId);
+    expect(key).not.toContain(rawStorageRoot);
   });
 });

--- a/src/providers/chatgpt-usage-service.ts
+++ b/src/providers/chatgpt-usage-service.ts
@@ -1,4 +1,5 @@
 import { hostname } from "node:os";
+import { resolve } from "node:path";
 import {
   LETTA_CLOUD_API_URL,
   refreshAccessToken as refreshLettaAccessToken,
@@ -7,12 +8,14 @@ import {
 import { getLettaCodeHeaders } from "@/backend/api/http-headers";
 import {
   getLocalOAuthApiKey,
+  getLocalProviderAuthPath,
   getLocalProviderRecordByName,
   LOCAL_CHATGPT_PROVIDER_NAME,
   type LocalProviderRecord,
 } from "@/backend/local/local-provider-auth-store";
 import type { ProviderStorageTarget } from "@/providers/byok-providers";
 import { type Settings, settingsManager } from "@/settings-manager";
+import { CredentialScopedCache } from "./credential-scoped-cache";
 
 const CHATGPT_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
 const CLOUD_CHATGPT_USAGE_PATH = "/v1/providers/chatgpt-usage";
@@ -97,12 +100,9 @@ export interface ReadChatGPTUsageInput {
 
 type JsonRecord = Record<string, unknown>;
 
-type CachedUsage = {
-  expiresAt: number;
-  result: Extract<ChatGPTUsageReadResult, { success: true }>;
-};
-
-const usageCache = new Map<string, CachedUsage>();
+const usageCache = new CredentialScopedCache<
+  Extract<ChatGPTUsageReadResult, { success: true }>
+>(CACHE_TTL_MS);
 
 function asRecord(value: unknown): JsonRecord | undefined {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -799,12 +799,6 @@ async function readCloudChatGPTUsage(
   }
 
   const baseUrl = cloudBaseUrl(settings);
-  const cacheKey = `api:${baseUrl}:${providerName}`;
-  const cached = usageCache.get(cacheKey);
-  if (!input.forceRefresh && cached && cached.expiresAt > now) {
-    return cached.result;
-  }
-
   const auth = await cloudApiKey({
     settings,
     now,
@@ -819,6 +813,9 @@ async function readCloudChatGPTUsage(
       },
     };
   }
+  const cacheIdentity = [baseUrl, providerName, auth.apiKey];
+  const cached = usageCache.get("api", cacheIdentity, now, input.forceRefresh);
+  if (cached) return cached;
 
   const url = new URL(`${baseUrl}${CLOUD_CHATGPT_USAGE_PATH}`);
   url.searchParams.set("provider_name", providerName);
@@ -957,7 +954,7 @@ async function readCloudChatGPTUsage(
       success: true,
       usage,
     };
-    usageCache.set(cacheKey, { expiresAt: now + CACHE_TTL_MS, result });
+    usageCache.set("api", cacheIdentity, now, result);
     return result;
   } finally {
     clearTimeout(timeout);
@@ -991,12 +988,6 @@ export async function readChatGPTUsage(
     );
   }
 
-  const cacheKey = `${target}:${record.name}`;
-  const cached = usageCache.get(cacheKey);
-  if (!input.forceRefresh && cached && cached.expiresAt > now) {
-    return cached.result;
-  }
-
   let oauthApiKey: Awaited<ReturnType<typeof getLocalOAuthApiKey>>;
   try {
     oauthApiKey = await getLocalOAuthApiKey({
@@ -1026,6 +1017,14 @@ export async function readChatGPTUsage(
       : typeof record.auth.accountId === "string"
         ? record.auth.accountId
         : undefined;
+  const cacheIdentity = [
+    resolve(getLocalProviderAuthPath(input.storageDir)),
+    record.name,
+    accountId ?? "",
+    oauthApiKey.apiKey,
+  ];
+  const cached = usageCache.get(target, cacheIdentity, now, input.forceRefresh);
+  if (cached) return cached;
   const controller = new AbortController();
   let didTimeOut = false;
   const timeout = setTimeout(() => {
@@ -1104,7 +1103,7 @@ export async function readChatGPTUsage(
         nowMs: now,
       }),
     };
-    usageCache.set(cacheKey, { expiresAt: now + CACHE_TTL_MS, result });
+    usageCache.set(target, cacheIdentity, now, result);
     return result;
   } finally {
     clearTimeout(timeout);

--- a/src/providers/credential-scoped-cache.ts
+++ b/src/providers/credential-scoped-cache.ts
@@ -1,0 +1,45 @@
+import { createHmac, randomBytes } from "node:crypto";
+
+const CACHE_FINGERPRINT_KEY = randomBytes(32);
+
+export function createCredentialScopedCacheKey(
+  scope: string,
+  identity: readonly string[],
+): string {
+  const fingerprint = createHmac("sha256", CACHE_FINGERPRINT_KEY)
+    .update(JSON.stringify(identity))
+    .digest("base64url");
+  return `${scope}:${fingerprint}`;
+}
+
+export class CredentialScopedCache<T> {
+  readonly #entries = new Map<string, { expiresAt: number; value: T }>();
+
+  constructor(private readonly ttlMs: number) {}
+
+  get(
+    scope: string,
+    identity: readonly string[],
+    now: number,
+    bypass?: boolean,
+  ): T | undefined {
+    if (bypass) return undefined;
+    const key = createCredentialScopedCacheKey(scope, identity);
+    const cached = this.#entries.get(key);
+    if (!cached) return undefined;
+    if (cached.expiresAt > now) return cached.value;
+    this.#entries.delete(key);
+    return undefined;
+  }
+
+  set(scope: string, identity: readonly string[], now: number, value: T): void {
+    for (const [key, cached] of this.#entries) {
+      if (cached.expiresAt <= now) this.#entries.delete(key);
+    }
+    const key = createCredentialScopedCacheKey(scope, identity);
+    this.#entries.set(key, {
+      expiresAt: now + this.ttlMs,
+      value,
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #3584.

Successful ChatGPT usage responses were cached for 30 seconds under keys derived only from the target, base URL, and provider name. The cache lookup happened before credential resolution, so a long-lived process could return one account usage data after switching credentials or local storage profiles.

This change resolves the effective authentication context first and scopes every cache lookup to an opaque fingerprint of that context.

## What changed

### Credential-scoped cache keys

Added a small `CredentialScopedCache` owner that derives keys with HMAC-SHA256 using a random, process-local 256-bit key.

- Raw API keys, OAuth access tokens, account IDs, and storage paths are never stored in cache keys.
- The same identity is stable for cache reuse during the process lifetime.
- Changing any identity component creates a cache miss.
- A process-local HMAC key prevents cache fingerprints from becoming reusable unsalted credential hashes if a key is ever surfaced in diagnostics.
- Expired entries are removed opportunistically when new successful results are cached.

### Cloud/API usage

Cloud credentials are now resolved, including any required token refresh, before cache access. The identity includes:

- resolved cloud base URL;
- provider name;
- effective API/access token.

Changing credentials under the same URL and provider therefore cannot reuse the previous account cache. Removing credentials returns `unauthorized` before cache access instead of returning stale usage.

### Local OAuth usage

Local OAuth credentials and the effective ChatGPT account ID are now resolved before cache access. The identity includes:

- canonical absolute provider-auth file path, which distinguishes local storage roots/profiles;
- provider name;
- effective OAuth account ID;
- effective OAuth access token.

This isolates identical provider names across storage directories, distinguishes account replacement even if a token value is unchanged, and invalidates reuse when OAuth refresh replaces the credential.

## Invalidation behavior

Explicit cross-layer invalidation hooks are not required for correctness:

- local provider existence is checked before cache access;
- cloud authentication is resolved before cache access;
- logout/provider removal returns an auth/not-connected error before any cached success can be read;
- account or token replacement selects a different opaque key;
- inaccessible old entries expire after the existing 30-second TTL.

This avoids introducing a dependency from backend credential storage into the provider usage service.

## Tests

Added regression coverage proving:

- two local storage roots with the same provider, account ID, and token still fetch independently;
- a repeated read for the same local storage/account context uses the cache;
- changing only the OAuth account ID under the same storage root and token causes a cache miss;
- changing only cloud credentials under the same base URL/provider causes a cache miss;
- repeated reads with the same cloud credential use the cache;
- removing cloud authentication cannot return a previously cached success;
- generated cache keys are stable for one identity, change with credentials, and contain none of the raw token, account ID, or storage path.

Validation completed:

- `bun test src/providers/chatgpt-usage-service.test.ts` — 13 passed, 0 failed
- `bun run check` — all 12 checks passed

The oversized `chatgpt-usage-service.ts` baseline is also ratcheted down from 1,112 to 1,111 lines.
