### PR TITLE
fix(ci): restore memory CODEOWNERS coverage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,8 @@
 # CODEOWNERS file for letta-code repository
 # Memory filesystem and git-backed memory
-/src/agent/memoryFilesystem.ts @letta-ai/system-prompt-owners
-/src/agent/memoryGit.ts @letta-ai/system-prompt-owners
+/src/agent/memory-filesystem.ts @letta-ai/system-prompt-owners
+/src/agent/memory-git.ts @letta-ai/system-prompt-owners
+/src/agent/memory-git-*.ts @letta-ai/system-prompt-owners
 
 # WebSocket listener and protocol code
 /src/websocket/ @cpacker @4shub @kl2806 @carenthomas @christinatong01 @jnjpng

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "check:filename-casing": "node scripts/check-filename-casing.js",
     "check:file-size": "node scripts/check-source-file-size.js",
     "check:module-ownership": "node scripts/check-module-ownership.js",
+    "check:codeowners": "node --test scripts/check-codeowners-paths.test.js && node scripts/check-codeowners-paths.js",
     "check:test-mock-isolation": "bun run scripts/check-test-mock-isolation.js",
     "check:test-coverage": "node scripts/check-test-coverage.cjs",
     "check:skill-frontmatter": "node scripts/check-skill-frontmatter.js",

--- a/scripts/check-codeowners-paths.js
+++ b/scripts/check-codeowners-paths.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SKIPPED_DIRECTORIES = new Set([".git", "node_modules"]);
+
+function hasGlobSyntax(pattern) {
+  return /[*?]/.test(pattern);
+}
+
+function collectRepositoryPaths(rootDir) {
+  const paths = new Set();
+  const pending = [rootDir];
+  while (pending.length > 0) {
+    const directory = pending.pop();
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      if (SKIPPED_DIRECTORIES.has(entry.name)) continue;
+      const entryPath = join(directory, entry.name);
+      paths.add(relative(rootDir, entryPath).replaceAll("\\", "/"));
+      if (entry.isDirectory()) pending.push(entryPath);
+    }
+  }
+  return paths;
+}
+
+function literalPatternExists(repositoryPaths, pattern) {
+  const repositoryPath = pattern.replace(/^\/+/, "").replace(/\/+$/, "");
+  if (!repositoryPath) return true;
+  if (repositoryPaths.has(repositoryPath)) return true;
+
+  const isRootRelative =
+    pattern.startsWith("/") || repositoryPath.includes("/");
+  if (isRootRelative) return false;
+  return [...repositoryPaths].some(
+    (entry) => entry.split("/").at(-1) === repositoryPath,
+  );
+}
+
+export function validateCodeownersSource(source, rootDir) {
+  const repositoryPaths = collectRepositoryPaths(rootDir);
+  const errors = [];
+  let checkedLiterals = 0;
+  let skippedPatterns = 0;
+
+  for (const [index, rawLine] of source.split(/\r?\n/).entries()) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const [pattern] = line.split(/\s+/);
+    if (!pattern) continue;
+    if (hasGlobSyntax(pattern)) {
+      skippedPatterns += 1;
+      continue;
+    }
+
+    checkedLiterals += 1;
+    if (!literalPatternExists(repositoryPaths, pattern)) {
+      errors.push({ line: index + 1, pattern });
+    }
+  }
+
+  return { checkedLiterals, skippedPatterns, errors };
+}
+
+function run() {
+  const rootDir = process.cwd();
+  const codeownersPath = join(rootDir, ".github", "CODEOWNERS");
+  const result = validateCodeownersSource(
+    readFileSync(codeownersPath, "utf8"),
+    rootDir,
+  );
+
+  if (result.errors.length > 0) {
+    console.error("CODEOWNERS literal path check failed:\n");
+    for (const error of result.errors) {
+      console.error(
+        `  .github/CODEOWNERS:${error.line}: ${error.pattern} does not exist`,
+      );
+    }
+    process.exit(1);
+  }
+
+  console.log(
+    `Checked ${result.checkedLiterals} literal CODEOWNERS paths (${result.skippedPatterns} glob patterns skipped)`,
+  );
+}
+
+const scriptPath = process.argv[1] ? resolve(process.argv[1]) : "";
+if (scriptPath === fileURLToPath(import.meta.url)) run();

--- a/scripts/check-codeowners-paths.test.js
+++ b/scripts/check-codeowners-paths.test.js
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, test } from "node:test";
+import { validateCodeownersSource } from "./check-codeowners-paths.js";
+
+const tempRoots = [];
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function createRepository() {
+  const root = mkdtempSync(join(tmpdir(), "codeowners-check-"));
+  tempRoots.push(root);
+  mkdirSync(join(root, "src", "nested"), { recursive: true });
+  mkdirSync(join(root, "docs"), { recursive: true });
+  writeFileSync(join(root, "src", "owned.ts"), "export {};\n");
+  writeFileSync(join(root, "src", "nested", "NOTICE"), "notice\n");
+  return root;
+}
+
+describe("CODEOWNERS literal path validation", () => {
+  test("accepts existing root-relative files and directories", () => {
+    const root = createRepository();
+    const result = validateCodeownersSource(
+      ["/src/owned.ts @owner", "/src/nested/ @owner", "/docs/ @owner"].join(
+        "\n",
+      ),
+      root,
+    );
+
+    assert.deepEqual(result, {
+      checkedLiterals: 3,
+      skippedPatterns: 0,
+      errors: [],
+    });
+  });
+
+  test("reports stale literal paths with their source line", () => {
+    const root = createRepository();
+    const result = validateCodeownersSource(
+      ["# comment", "", "/src/renamed.ts @owner"].join("\n"),
+      root,
+    );
+
+    assert.deepEqual(result.errors, [{ line: 3, pattern: "/src/renamed.ts" }]);
+  });
+
+  test("skips glob rules instead of requiring a literal match", () => {
+    const root = createRepository();
+    const result = validateCodeownersSource(
+      ["/src/**/*.ts @owner", "/generated/file?.js @owner"].join("\n"),
+      root,
+    );
+
+    assert.equal(result.checkedLiterals, 0);
+    assert.equal(result.skippedPatterns, 2);
+    assert.deepEqual(result.errors, []);
+  });
+
+  test("accepts an unanchored literal name found below the root", () => {
+    const root = createRepository();
+    const result = validateCodeownersSource("NOTICE @owner", root);
+
+    assert.deepEqual(result.errors, []);
+    assert.equal(result.checkedLiterals, 1);
+  });
+
+  test("requires exact path casing on case-insensitive filesystems", () => {
+    const root = createRepository();
+    const result = validateCodeownersSource("/src/Owned.ts @owner", root);
+
+    assert.deepEqual(result.errors, [{ line: 1, pattern: "/src/Owned.ts" }]);
+  });
+});

--- a/scripts/check.js
+++ b/scripts/check.js
@@ -19,6 +19,7 @@ const checks = [
   { name: "filename casing", script: ["check:filename-casing"] },
   { name: "source file size", script: ["check:file-size"] },
   { name: "module ownership", script: ["check:module-ownership"] },
+  { name: "CODEOWNERS paths", script: ["check:codeowners"] },
   { name: "test mock isolation", script: ["check:test-mock-isolation"] },
   { name: "test coverage", script: ["check:test-coverage"] },
   { name: "skill frontmatter", script: ["check:skill-frontmatter"] },


### PR DESCRIPTION
## Summary

Fixes #3585.

The memory filesystem and git implementation entries in `.github/CODEOWNERS` still referenced pre-rename camelCase filenames. GitHub silently ignored those unmatched paths, so changes to durable memory storage could bypass the intended `@letta-ai/system-prompt-owners` review request.

This PR restores the ownership rules and adds a repository check that catches stale literal CODEOWNERS paths after future moves or renames.

## Ownership changes

Replaced the stale entries with the current implementation paths:

- `/src/agent/memory-filesystem.ts`
- `/src/agent/memory-git.ts`

Also added the deliberately scoped rule:

- `/src/agent/memory-git-*.ts`

That rule covers the extracted git implementation modules currently owned with the core implementation:

- `memory-git-config-lock.ts`
- `memory-git-hooks.ts`
- `memory-git-signing.ts`

It does not sweep in dot-named tests such as `memory-git.auth.test.ts` or `memory-git.retry.test.ts`.

## Regression prevention

Added `scripts/check-codeowners-paths.js` and wired it into `bun run check` as the new `CODEOWNERS paths` gate.

The validator:

- parses non-comment CODEOWNERS entries with source line numbers;
- verifies literal root-relative files and directory rules against the repository tree;
- supports unanchored literal names by looking for an exact filename anywhere in the tree;
- skips supported `*` and `?` glob rules instead of incorrectly requiring them to name one literal path;
- compares exact directory-entry spelling instead of relying on `existsSync()`, so case mistakes fail even on case-insensitive macOS filesystems;
- excludes `.git` and `node_modules` while walking the tree;
- reports each stale entry as `.github/CODEOWNERS:<line>: <pattern> does not exist`.

Bracket ranges are intentionally not classified as valid CODEOWNERS globs because GitHub CODEOWNERS does not support that gitignore feature.

## Tests

Added five Node test-runner cases covering:

- existing root-relative files and directories;
- stale literal paths with accurate line numbers;
- supported glob skipping;
- unanchored literal names below the repository root;
- exact-case enforcement on case-insensitive filesystems.

The package-level `check:codeowners` command runs both the validator tests and validation of the real `.github/CODEOWNERS` file.

Validation completed:

- `bun run check:codeowners` — 5 passed, 0 failed; 11 literal paths checked and 1 glob skipped
- `bun run check` — all 13 checks passed
