### PR TITLE
fix(cli): reject malformed numeric options

### DIFF
--- a/src/cli/flag-utils.test.ts
+++ b/src/cli/flag-utils.test.ts
@@ -27,15 +27,50 @@ describe("flag utils", () => {
     ).toBe("path.af");
   });
 
-  test("parsePositiveIntFlag validates positive integers", () => {
+  test("parsePositiveIntFlag accepts complete decimal positive integers", () => {
+    expect(
+      parsePositiveIntFlag({
+        rawValue: undefined,
+        flagName: "max-turns",
+      }),
+    ).toBeUndefined();
     expect(
       parsePositiveIntFlag({
         rawValue: "3",
         flagName: "max-turns",
       }),
     ).toBe(3);
+    expect(
+      parsePositiveIntFlag({
+        rawValue: " 42 ",
+        flagName: "max-turns",
+      }),
+    ).toBe(42);
+  });
+
+  test.each(["0", "-1", "1.5", "10junk", " ", "NaN", "9007199254740992"])(
+    "parsePositiveIntFlag rejects invalid input %p",
+    (rawValue) => {
+      expect(() =>
+        parsePositiveIntFlag({ rawValue, flagName: "max-turns" }),
+      ).toThrow("--max-turns must be a positive integer");
+    },
+  );
+
+  test("parsePositiveIntFlag enforces an explicit upper bound", () => {
+    expect(
+      parsePositiveIntFlag({
+        rawValue: "1000",
+        flagName: "limit",
+        maxValue: 1000,
+      }),
+    ).toBe(1000);
     expect(() =>
-      parsePositiveIntFlag({ rawValue: "0", flagName: "max-turns" }),
-    ).toThrow("--max-turns must be a positive integer");
+      parsePositiveIntFlag({
+        rawValue: "1001",
+        flagName: "limit",
+        maxValue: 1000,
+      }),
+    ).toThrow("--limit must be an integer between 1 and 1000");
   });
 });

--- a/src/cli/flag-utils.ts
+++ b/src/cli/flag-utils.ts
@@ -1,3 +1,9 @@
+export const CLI_NUMERIC_OPTION_MAX = {
+  pageSize: 1000,
+  pageCount: 1000,
+  timeoutSeconds: 86_400,
+} as const;
+
 export function parseCsvListFlag(
   value: string | undefined,
 ): string[] | undefined {
@@ -45,16 +51,26 @@ export function resolveImportFlagAlias(options: {
 export function parsePositiveIntFlag(options: {
   rawValue: string | undefined;
   flagName: string;
+  maxValue?: number;
 }): number | undefined {
-  const { rawValue, flagName } = options;
+  const { rawValue, flagName, maxValue = Number.MAX_SAFE_INTEGER } = options;
   if (rawValue === undefined) {
     return undefined;
   }
-  const parsed = Number.parseInt(rawValue, 10);
-  if (Number.isNaN(parsed) || parsed <= 0) {
-    throw new Error(
-      `--${flagName} must be a positive integer, got: ${rawValue}`,
-    );
+
+  const trimmed = rawValue.trim();
+  const parsed = Number(trimmed);
+  if (
+    !/^\d+$/.test(trimmed) ||
+    !Number.isSafeInteger(parsed) ||
+    parsed < 1 ||
+    parsed > maxValue
+  ) {
+    const expected =
+      maxValue === Number.MAX_SAFE_INTEGER
+        ? "a positive integer"
+        : `an integer between 1 and ${maxValue}`;
+    throw new Error(`--${flagName} must be ${expected}, got: ${rawValue}`);
   }
   return parsed;
 }

--- a/src/cli/subcommands/agents.test.ts
+++ b/src/cli/subcommands/agents.test.ts
@@ -1,5 +1,33 @@
-import { describe, expect, test } from "bun:test";
-import { buildAgentConfigReport } from "@/cli/subcommands/agents";
+import { describe, expect, spyOn, test } from "bun:test";
+import {
+  buildAgentConfigReport,
+  runAgentsSubcommand,
+} from "@/cli/subcommands/agents";
+
+describe("agents list numeric options", () => {
+  test.each(["0", "-5", "1.5", "10junk", " ", "9007199254740992", "1001"])(
+    "rejects invalid limit %p before initialization",
+    async (limit) => {
+      const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+      try {
+        const code = await runAgentsSubcommand([
+          "list",
+          limit.startsWith("-") ? `--limit=${limit}` : "--limit",
+          ...(limit.startsWith("-") ? [] : [limit]),
+        ]);
+
+        expect(code).toBe(1);
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            "--limit must be an integer between 1 and 1000",
+          ),
+        );
+      } finally {
+        errorSpy.mockRestore();
+      }
+    },
+  );
+});
 
 describe("buildAgentConfigReport", () => {
   test("reports agent defaults and redacts credential fields", () => {

--- a/src/cli/subcommands/agents.ts
+++ b/src/cli/subcommands/agents.ts
@@ -8,6 +8,7 @@ import {
 } from "@/agent/personality";
 import { resolvePersonalityId } from "@/agent/personality-presets";
 import { getBackend } from "@/backend";
+import { CLI_NUMERIC_OPTION_MAX, parsePositiveIntFlag } from "@/cli/flag-utils";
 import { listSharedAgentsForCurrentUser } from "@/cli/helpers/shared-agent-listing";
 import { settingsManager } from "@/settings-manager";
 
@@ -33,7 +34,7 @@ List Options:
   --match-all-tags      Require ALL tags (default: ANY)
   --include-blocks      Include agent.blocks in response
   --shared              List agents shared with the current user
-  --limit <n>           Max results (default: 20)
+  --limit <n>           Max results (1-1000; default: 20)
 
 Create Options:
   --name <name>         Agent name (default: "Letta Code")
@@ -50,12 +51,6 @@ Notes:
   - Uses CLI auth; override with LETTA_API_KEY/LETTA_BASE_URL if needed.
 `.trim(),
   );
-}
-
-function parseLimit(value: unknown, fallback: number): number {
-  if (typeof value !== "string" || value.length === 0) return fallback;
-  const parsed = Number.parseInt(value, 10);
-  return Number.isNaN(parsed) ? fallback : parsed;
 }
 
 function parseTags(value: unknown): string[] | undefined {
@@ -371,6 +366,19 @@ async function runConfigAction(
 async function runListAction(
   values: ReturnType<typeof parseAgentsArgs>["values"],
 ): Promise<number> {
+  let limit: number;
+  try {
+    limit =
+      parsePositiveIntFlag({
+        rawValue: values.limit,
+        flagName: "limit",
+        maxValue: CLI_NUMERIC_OPTION_MAX.pageSize,
+      }) ?? 20;
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : error}`);
+    return 1;
+  }
+
   await settingsManager.initialize();
 
   if (values.shared) {
@@ -387,7 +395,7 @@ async function runListAction(
 
     try {
       const result = await listSharedAgentsForCurrentUser({
-        limit: parseLimit(values.limit, 20),
+        limit,
         order: "desc",
         orderBy: "last_run_completion",
         queryText: typeof values.query === "string" ? values.query : undefined,
@@ -401,7 +409,7 @@ async function runListAction(
   }
 
   const params: AgentListParams = {
-    limit: parseLimit(values.limit, 20),
+    limit,
   };
 
   if (typeof values.name === "string") {

--- a/src/cli/subcommands/dream.test.ts
+++ b/src/cli/subcommands/dream.test.ts
@@ -80,6 +80,26 @@ describe("dream subcommand", () => {
     }
   });
 
+  test.each(["0", "-1", "1.5", "30seconds", " ", "9007199254740992", "86401"])(
+    "rejects invalid timeout %p",
+    async (timeout) => {
+      const captured = captureConsole();
+      try {
+        const exitCode = await runDreamSubcommand([
+          timeout.startsWith("-") ? `--timeout=${timeout}` : "--timeout",
+          ...(timeout.startsWith("-") ? [] : [timeout]),
+        ]);
+
+        expect(exitCode).toBe(1);
+        expect(captured.errors.join("\n")).toContain(
+          "--timeout must be an integer between 1 and 86400",
+        );
+      } finally {
+        captured.restore();
+      }
+    },
+  );
+
   test("accepts an explicit reflection model", () => {
     const parsed = parseDreamArgs(["--model", "zai/glm-5.2"]);
 

--- a/src/cli/subcommands/dream.ts
+++ b/src/cli/subcommands/dream.ts
@@ -1,4 +1,5 @@
 import { parseArgs } from "node:util";
+import { CLI_NUMERIC_OPTION_MAX, parsePositiveIntFlag } from "@/cli/flag-utils";
 import {
   type ParsedSource,
   parseFromSource,
@@ -36,7 +37,7 @@ Options:
                               the agent edits it in place, using judgment
   --effort <level>            Reflection effort (reserved; not yet implemented)
   --timeout <seconds>         Fail if the reflection pass has not completed
-                              in this many seconds (default: 1500)
+                              in 1-86400 seconds (default: 1500)
   -i, --instruction <text>    Additional instruction for the reflection pass
   --prompt <text>             Advanced: replace the reflection task prompt
                               entirely (you supply the transcript/memory
@@ -145,13 +146,17 @@ export async function runDreamSubcommand(argv: string[]): Promise<number> {
     );
   }
 
-  let timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
-  if (parsed.values.timeout) {
-    timeoutSeconds = Number.parseInt(parsed.values.timeout, 10);
-    if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0) {
-      console.error(`Error: Invalid --timeout "${parsed.values.timeout}"`);
-      return 1;
-    }
+  let timeoutSeconds: number;
+  try {
+    timeoutSeconds =
+      parsePositiveIntFlag({
+        rawValue: parsed.values.timeout,
+        flagName: "timeout",
+        maxValue: CLI_NUMERIC_OPTION_MAX.timeoutSeconds,
+      }) ?? DEFAULT_TIMEOUT_SECONDS;
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : error}`);
+    return 1;
   }
 
   await settingsManager.initialize();

--- a/src/cli/subcommands/environments.test.ts
+++ b/src/cli/subcommands/environments.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, mock, spyOn, test } from "bun:test";
+import { runEnvironmentsSubcommand } from "@/cli/subcommands/environments";
+
+describe("environments list numeric options", () => {
+  test.each(["0", "-1", "1.5", "10junk", " ", "9007199254740992", "1001"])(
+    "rejects invalid limit %p before initialization",
+    async (limit) => {
+      const initializeSettings = mock(() => Promise.resolve());
+      const listEnvironments = mock(() =>
+        Promise.resolve({ connections: [], hasMore: false }),
+      );
+      const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+      try {
+        const code = await runEnvironmentsSubcommand(
+          [
+            "list",
+            limit.startsWith("-") ? `--limit=${limit}` : "--limit",
+            ...(limit.startsWith("-") ? [] : [limit]),
+          ],
+          { initializeSettings, listEnvironments: listEnvironments as never },
+        );
+
+        expect(code).toBe(1);
+        expect(initializeSettings).not.toHaveBeenCalled();
+        expect(listEnvironments).not.toHaveBeenCalled();
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            "--limit must be an integer between 1 and 1000",
+          ),
+        );
+      } finally {
+        errorSpy.mockRestore();
+      }
+    },
+  );
+});

--- a/src/cli/subcommands/environments.ts
+++ b/src/cli/subcommands/environments.ts
@@ -3,6 +3,7 @@ import {
   type EnvironmentConnection,
   listEnvironments,
 } from "@/backend/api/environments";
+import { CLI_NUMERIC_OPTION_MAX, parsePositiveIntFlag } from "@/cli/flag-utils";
 import { settingsManager } from "@/settings-manager";
 import { getVersion } from "@/version.ts";
 
@@ -27,7 +28,7 @@ Aliases:
   letta envs current
 
 List options:
-  --limit <n>       Max results (default: 50)
+  --limit <n>       Max results (1-1000; default: 50)
   --after <id>      Pagination cursor from a previous environment id
   --online-only     Only include environments with a fresh active connection
 
@@ -40,12 +41,6 @@ Notes:
     to route a message through a specific registered environment.
 `.trim(),
   );
-}
-
-function parseLimit(value: unknown, fallback: number): number {
-  if (typeof value !== "string" || value.length === 0) return fallback;
-  const parsed = Number.parseInt(value, 10);
-  return Number.isNaN(parsed) ? fallback : parsed;
 }
 
 function isOnline(environment: EnvironmentConnection): boolean {
@@ -160,6 +155,21 @@ export async function runEnvironmentsSubcommand(
     return 1;
   }
 
+  let limit = 50;
+  if (action === "list") {
+    try {
+      limit =
+        parsePositiveIntFlag({
+          rawValue: parsed.values.limit,
+          flagName: "limit",
+          maxValue: CLI_NUMERIC_OPTION_MAX.pageSize,
+        }) ?? 50;
+    } catch (error) {
+      console.error(`Error: ${error instanceof Error ? error.message : error}`);
+      return 1;
+    }
+  }
+
   await (deps.initializeSettings ?? (() => settingsManager.initialize()))();
   const list = deps.listEnvironments ?? listEnvironments;
   const deviceId = settingsManager.getOrCreateDeviceId();
@@ -192,7 +202,6 @@ export async function runEnvironmentsSubcommand(
     return 0;
   }
 
-  const limit = parseLimit(parsed.values.limit, 50);
   const onlineOnly = parsed.values["online-only"] ?? false;
   const result = await list({
     limit,

--- a/src/cli/subcommands/messages.test.ts
+++ b/src/cli/subcommands/messages.test.ts
@@ -173,4 +173,35 @@ describe("messages subcommand conversation scoping", () => {
       capture.restore();
     }
   });
+
+  test.each([
+    ["search", "--limit", "10junk"],
+    ["list", "--limit", "-1"],
+    ["transcript", "--limit", "0"],
+    ["transcript", "--max-pages", "1.5"],
+    ["transcript", "--max-pages", "1001"],
+  ])(
+    "%s rejects invalid numeric option before initialization",
+    async (action, flag, value) => {
+      const capture = captureConsole();
+      try {
+        const code = await runMessages([
+          action,
+          value.startsWith("-") ? `${flag}=${value}` : flag,
+          ...(value.startsWith("-") ? [] : [value]),
+        ]);
+
+        expect(code).toBe(1);
+        expect(initializeSettingsMock).not.toHaveBeenCalled();
+        expect(searchMessagesForBackendMock).not.toHaveBeenCalled();
+        expect(backendMock.listAgentMessages).not.toHaveBeenCalled();
+        expect(backendMock.listConversationMessages).not.toHaveBeenCalled();
+        expect(capture.stderr.join("\n")).toContain(
+          `${flag} must be an integer between 1 and 1000`,
+        );
+      } finally {
+        capture.restore();
+      }
+    },
+  );
 });

--- a/src/cli/subcommands/messages.ts
+++ b/src/cli/subcommands/messages.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { parseArgs } from "node:util";
 import { getBackend } from "@/backend";
 import { searchMessagesForBackend } from "@/backend/message-search";
+import { CLI_NUMERIC_OPTION_MAX, parsePositiveIntFlag } from "@/cli/flag-utils";
 import { settingsManager } from "@/settings-manager";
 
 type SearchMode = "vector" | "fts" | "hybrid";
@@ -55,7 +56,7 @@ Search options:
   --mode <mode>         Search mode: vector, fts, hybrid (default: hybrid)
   --start-date <date>   Filter messages after this date (ISO format)
   --end-date <date>     Filter messages before this date (ISO format)
-  --limit <n>           Max results (default: 10)
+  --limit <n>           Max results (1-1000; default: 10)
   --all-agents          Search all agents, not just current agent
   --agent <id>          Explicit agent ID (overrides LETTA_AGENT_ID)
   --agent-id <id>       Alias for --agent
@@ -70,7 +71,7 @@ List options:
   --after <message-id>  Cursor: get messages after this ID
   --before <message-id> Cursor: get messages before this ID
   --order <asc|desc>    Sort order (default: desc = newest first)
-  --limit <n>           Max results (default: 20)
+  --limit <n>           Max results (1-1000; default: 20)
   --start-date <date>   Client-side filter: after this date (ISO format)
   --end-date <date>     Client-side filter: before this date (ISO format)
 
@@ -79,8 +80,8 @@ Transcript options:
   --conversation-id <id> Alias for --conversation
   --agent <id>           Required when conversation is "default"
   --agent-id <id>        Alias for --agent
-  --limit <n>            Page size while fetching (default: 100)
-  --max-pages <n>        Max pagination pages to fetch (default: 200)
+  --limit <n>            Page size while fetching (1-1000; default: 100)
+  --max-pages <n>        Max pages to fetch (1-1000; default: 200)
   --out <path>           Write transcript text to file
   --output <path>        Alias for --out
 
@@ -90,12 +91,6 @@ Notes:
   - For agent-to-agent messaging, use: letta -p --from-agent <sender-id> --agent <target-id> "message"
 `.trim(),
   );
-}
-
-function parseLimit(value: unknown, fallback: number): number {
-  if (typeof value !== "string" || value.length === 0) return fallback;
-  const parsed = Number.parseInt(value, 10);
-  return Number.isNaN(parsed) ? fallback : parsed;
 }
 
 function parseMode(value: unknown): SearchMode | undefined {
@@ -181,6 +176,32 @@ export async function runMessagesSubcommand(
   if (parsed.values.help || !action || action === "help") {
     printUsage();
     return 0;
+  }
+
+  let limit: number | undefined;
+  let maxPages: number | undefined;
+  try {
+    if (action === "search" || action === "list" || action === "transcript") {
+      const defaultLimit =
+        action === "search" ? 10 : action === "list" ? 20 : 100;
+      limit =
+        parsePositiveIntFlag({
+          rawValue: parsed.values.limit,
+          flagName: "limit",
+          maxValue: CLI_NUMERIC_OPTION_MAX.pageSize,
+        }) ?? defaultLimit;
+    }
+    if (action === "transcript") {
+      maxPages =
+        parsePositiveIntFlag({
+          rawValue: parsed.values["max-pages"],
+          flagName: "max-pages",
+          maxValue: CLI_NUMERIC_OPTION_MAX.pageCount,
+        }) ?? 200;
+    }
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : error}`);
+    return 1;
   }
 
   try {
@@ -392,7 +413,7 @@ export async function runMessagesSubcommand(
         search_mode: parseMode(parsed.values.mode) ?? "hybrid",
         start_date: parsed.values["start-date"],
         end_date: parsed.values["end-date"],
-        limit: parseLimit(parsed.values.limit, 10),
+        limit: limit ?? 10,
         ...(scopedAgentId ? { agent_id: scopedAgentId } : {}),
         ...(typeof conversationId === "string"
           ? { conversation_id: conversationId }
@@ -428,7 +449,7 @@ export async function runMessagesSubcommand(
         return 1;
       }
       const listBody = {
-        limit: parseLimit(parsed.values.limit, 20),
+        limit: limit ?? 20,
         after: parsed.values.after,
         before: parsed.values.before,
         order,
@@ -491,15 +512,15 @@ export async function runMessagesSubcommand(
         return 1;
       }
 
-      const pageLimit = Math.max(1, parseLimit(parsed.values.limit, 100));
-      const maxPages = Math.max(1, parseLimit(parsed.values["max-pages"], 200));
+      const pageLimit = limit ?? 100;
+      const pageCount = maxPages ?? 200;
       const outputPathRaw = parsed.values.out || parsed.values.output;
 
       const messages = await fetchConversationMessages(
         conversationId,
         agentId || undefined,
         pageLimit,
-        maxPages,
+        pageCount,
       );
 
       const transcript = messages


### PR DESCRIPTION
## Summary

Fixes the CLI numeric-option parsing paths described in #3586.

The agents, environments, and messages subcommands previously used three copies of a `parseInt()`-based helper. That accepted numeric prefixes such as `10junk`, allowed zero and negative pagination values, and silently replaced fully nonnumeric user input with a default. The dream timeout performed a separate partial validation and therefore accepted values such as `30seconds`.

This PR routes those options through the existing shared CLI integer-flag owner and makes its parsing strict:

- require the entire trimmed value to contain decimal digits;
- require a JavaScript safe integer greater than zero;
- enforce explicit command bounds;
- use defaults only when an option is omitted;
- return an actionable error and exit code 1 for supplied invalid values.

## Bounds

- pagination page sizes (`--limit`): 1 through 1,000;
- transcript pagination (`--max-pages`): 1 through 1,000;
- dream reflection timeout (`--timeout`): 1 through 86,400 seconds.

The CLI help now documents these ranges next to each option.

## Implementation details

- Strengthens `parsePositiveIntFlag()` instead of introducing another numeric parser. Existing callers retain `undefined` for an omitted flag, while malformed prefixes, fractions, unsafe integers, and out-of-range values now throw a consistent validation error.
- Removes the duplicated `parseLimit()` implementations from agents, environments, and messages.
- Parses numeric values before settings initialization and backend construction. Invalid input therefore cannot authenticate, initialize settings, or issue an API request.
- Keeps each command's existing omitted-value defaults: agents 20, environments 50, message search 10, message list 20, transcript page size 100, transcript max pages 200, and dream timeout 1,500 seconds.

## Tests

Added table-driven coverage for:

- valid complete integers, surrounding whitespace, omitted values, and upper boundaries;
- zero and negative values;
- decimals;
- trailing junk;
- whitespace-only and `NaN` input;
- integers beyond `Number.MAX_SAFE_INTEGER`;
- values above each explicit command limit;
- early failure before settings initialization or message/environment backend calls.

Validation performed:

- `bun test src/cli/flag-utils.test.ts src/cli/subcommands/agents.test.ts src/cli/subcommands/environments.test.ts src/cli/subcommands/messages.test.ts src/cli/subcommands/dream.test.ts` (52 passed)
- `bun run check` (all 12 checks passed)

Closes #3586
