### PR TITLE
fix(listener): recover stalled split stream reconnects

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -47,7 +47,7 @@
   "src/websocket/listener/commands/channels.ts": 1315,
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1030,
-  "src/websocket/listener/lifecycle.ts": 1618,
+  "src/websocket/listener/lifecycle.ts": 1617,
   "src/websocket/listener/protocol-inbound.ts": 2293,
   "src/websocket/listener/protocol-outbound.ts": 1100
 }

--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -47,7 +47,7 @@
   "src/websocket/listener/commands/channels.ts": 1315,
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1030,
-  "src/websocket/listener/lifecycle.ts": 1656,
+  "src/websocket/listener/lifecycle.ts": 1618,
   "src/websocket/listener/protocol-inbound.ts": 2293,
   "src/websocket/listener/protocol-outbound.ts": 1100
 }

--- a/src/websocket/listener/constants.ts
+++ b/src/websocket/listener/constants.ts
@@ -1,6 +1,11 @@
 export const MAX_RETRY_DURATION_MS = 5 * 60 * 1000; // 5 minutes
 export const INITIAL_RETRY_DELAY_MS = 1000; // 1 second
 export const MAX_RETRY_DELAY_MS = 30000; // 30 seconds
+// Split listener pairs are only usable once both control and stream sockets
+// complete their opening handshake. If the stream upgrade makes no progress,
+// tear down the incomplete pair and let the normal reconnect path build a
+// coherent replacement instead of awaiting the stream socket forever.
+export const LISTENER_STREAM_OPEN_TIMEOUT_MS = 30000; // 30 seconds
 
 // Listener heartbeat: app-level ping/pong over the cloud relay. Each `ping`
 // refreshes the environment's lastHeartbeat (the relay marks an env offline

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -1446,7 +1446,6 @@ async function connectWithRetry(
         streamSocket,
         error,
         trackListenerError,
-        onError: opts.onError,
       });
     });
   });

--- a/src/websocket/listener/lifecycle.ts
+++ b/src/websocket/listener/lifecycle.ts
@@ -110,6 +110,13 @@ import {
   safeEmitWsEvent,
   setActiveRuntime,
 } from "./runtime";
+import {
+  handleListenerSocketOpenFailure,
+  isCurrentSocketPair,
+  prepareSplitStreamTransport,
+  shouldHandleControlSocketClose,
+  terminateControlAfterStreamClose,
+} from "./split-stream-lifecycle";
 import { notifyStreamObserversRuntimeStopped } from "./stream-observers";
 import {
   getListenerTransportKind,
@@ -404,74 +411,6 @@ function getParsedRuntimeScope(
         ? runtime.conversation_id
         : "default",
   };
-}
-
-function terminateControlAfterStreamClose(
-  runtime: ListenerRuntime,
-  streamSocket: WebSocket,
-  code: number,
-  reason: Buffer,
-): void {
-  if (runtime.streamSocket !== streamSocket) {
-    return;
-  }
-  if (code === 1000 && reason.toString() === "Replaced by new connection") {
-    runtime.intentionallyClosed = true;
-  }
-  runtime.streamSocket = null;
-  runtime.streamTransport = null;
-
-  const controlSocket = runtime.socket;
-  if (
-    controlSocket &&
-    (controlSocket.readyState === WebSocket.OPEN ||
-      controlSocket.readyState === WebSocket.CONNECTING)
-  ) {
-    // The stream channel has no independent replay or reconnect path. Closing
-    // control tears down the paired session so its normal reconnect/bootstrap
-    // flow restores one coherent connection instead of silently losing frames.
-    controlSocket.terminate();
-  }
-}
-
-async function waitForStreamSocketOpen(
-  streamSocket: WebSocket,
-  runtime: ListenerRuntime,
-): Promise<ListenerTransport | null> {
-  if (streamSocket.readyState === WebSocket.OPEN) {
-    runtime.streamTransport = streamSocket;
-    return streamSocket;
-  }
-
-  if (
-    streamSocket.readyState === WebSocket.CLOSING ||
-    streamSocket.readyState === WebSocket.CLOSED
-  ) {
-    return null;
-  }
-
-  return await new Promise<ListenerTransport | null>((resolve) => {
-    const handleOpen = () => {
-      cleanup();
-      runtime.streamTransport = streamSocket;
-      resolve(streamSocket);
-    };
-
-    const handleFailure = () => {
-      cleanup();
-      resolve(null);
-    };
-
-    const cleanup = () => {
-      streamSocket.off("open", handleOpen);
-      streamSocket.off("error", handleFailure);
-      streamSocket.off("close", handleFailure);
-    };
-
-    streamSocket.once("open", handleOpen);
-    streamSocket.once("error", handleFailure);
-    streamSocket.once("close", handleFailure);
-  });
 }
 
 /**
@@ -1202,7 +1141,10 @@ export async function attachOpenListenerSocket(
   });
 
   socket.on("close", (code: number, reason: Buffer) => {
-    if (runtime !== getActiveRuntime()) {
+    if (
+      runtime !== getActiveRuntime() ||
+      runtime.connections.get(opts.connectionId) !== connection
+    ) {
       return;
     }
 
@@ -1464,29 +1406,49 @@ async function connectWithRetry(
   const transport = socket;
   const processQueuedTurn = createConnectionTurnProcessor(runtime);
 
-  socket.on("open", async () => {
-    let streamTransport: ListenerTransport | null = null;
-    if (streamSocket) {
-      streamTransport = await waitForStreamSocketOpen(streamSocket, runtime);
-    }
-    openListenerConnection({
-      runtime,
-      connectionId: opts.connectionId,
-      writer: socket,
-      streamWriter: streamTransport,
-      options: opts,
+  socket.on("open", () => {
+    void (async () => {
+      const streamOpen = await prepareSplitStreamTransport({
+        runtime,
+        controlSocket: socket,
+        streamSocket,
+        trackListenerError,
+      });
+      if (streamOpen.kind !== "ready") {
+        return;
+      }
+      const streamTransport = streamOpen.transport;
+      if (!isCurrentSocketPair(runtime, socket, streamSocket)) {
+        return;
+      }
+      openListenerConnection({
+        runtime,
+        connectionId: opts.connectionId,
+        writer: socket,
+        streamWriter: streamTransport,
+        options: opts,
+      });
+      await startConnectedListenerRuntime(
+        runtime,
+        transport,
+        opts,
+        processQueuedTurn,
+        {
+          startHeartbeat: true,
+          startCronScheduler: true,
+          streamTransport,
+        },
+      );
+    })().catch((error) => {
+      handleListenerSocketOpenFailure({
+        runtime,
+        controlSocket: socket,
+        streamSocket,
+        error,
+        trackListenerError,
+        onError: opts.onError,
+      });
     });
-    await startConnectedListenerRuntime(
-      runtime,
-      transport,
-      opts,
-      processQueuedTurn,
-      {
-        startHeartbeat: true,
-        startCronScheduler: true,
-        streamTransport,
-      },
-    );
   });
 
   socket.on(
@@ -1513,7 +1475,7 @@ async function connectWithRetry(
   );
 
   socket.on("close", (code: number, reason: Buffer) => {
-    if (runtime !== getActiveRuntime()) {
+    if (!shouldHandleControlSocketClose(runtime, socket, opts.connectionId)) {
       return;
     }
 

--- a/src/websocket/listener/split-stream-lifecycle.test.ts
+++ b/src/websocket/listener/split-stream-lifecycle.test.ts
@@ -52,6 +52,7 @@ describe("split stream listener lifecycle", () => {
   let connections: WebSocket[];
   let connectionChannels: Array<string | null>;
   let hangNextStreamUpgrade: boolean;
+  let rejectNextStreamUpgrade: boolean;
   let streamUpgradeAttempts: number;
   let stalledUpgradeSockets: Set<Duplex>;
 
@@ -89,6 +90,7 @@ describe("split stream listener lifecycle", () => {
     connections = [];
     connectionChannels = [];
     hangNextStreamUpgrade = false;
+    rejectNextStreamUpgrade = false;
     streamUpgradeAttempts = 0;
     stalledUpgradeSockets = new Set();
     server = new WebSocketServer({ noServer: true });
@@ -103,6 +105,15 @@ describe("split stream listener lifecycle", () => {
           stalledUpgradeSockets.add(socket);
           socket.once("close", () => stalledUpgradeSockets.delete(socket));
           socket.on("error", () => {});
+          return;
+        }
+        if (rejectNextStreamUpgrade) {
+          rejectNextStreamUpgrade = false;
+          socket.end(
+            "HTTP/1.1 503 Service Unavailable\r\n" +
+              "Connection: close\r\n" +
+              "Content-Length: 0\r\n\r\n",
+          );
           return;
         }
       }
@@ -234,6 +245,45 @@ describe("split stream listener lifecycle", () => {
     }
     return -1;
   }
+
+  test("split stream upgrade rejection retries the paired listener sockets", async () => {
+    process.env.LETTA_LISTENER_STREAM_OPEN_TIMEOUT_MS = "1000";
+    const onConnected = mock(() => {});
+    const onDisconnected = mock(() => {});
+    const onNeedsReregister = mock(() => {});
+    const onError = mock(() => {});
+    await startClient({
+      onConnected,
+      onDisconnected,
+      onNeedsReregister,
+      onError,
+    });
+    await waitFor(
+      () =>
+        countConnectionsForChannel("control") === 1 &&
+        countConnectionsForChannel("stream") === 1,
+      "initial split sockets did not open",
+    );
+    const listener = getActiveRuntime();
+    expect(listener).not.toBeNull();
+
+    rejectNextStreamUpgrade = true;
+    const initialControlIndex = lastConnectionIndexForChannel("control");
+    connections[initialControlIndex]?.terminate();
+    await waitFor(
+      () =>
+        countConnectionsForChannel("control") === 3 &&
+        countConnectionsForChannel("stream") === 2 &&
+        streamUpgradeAttempts === 3 &&
+        onConnected.mock.calls.length === 2,
+      "listener did not retry after the split stream upgrade was rejected",
+    );
+
+    expect(getActiveRuntime()).toBe(listener);
+    expect(onDisconnected).not.toHaveBeenCalled();
+    expect(onNeedsReregister).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
 
   test("split stream handshake stall retries without clearing runtime turn state", async () => {
     process.env.LETTA_LISTENER_STREAM_OPEN_TIMEOUT_MS = "25";

--- a/src/websocket/listener/split-stream-lifecycle.test.ts
+++ b/src/websocket/listener/split-stream-lifecycle.test.ts
@@ -286,6 +286,58 @@ describe("split stream listener lifecycle", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
+  test("current split open handler failure reconnects without onError", async () => {
+    process.env.LETTA_LISTENER_STREAM_OPEN_TIMEOUT_MS = "1000";
+    const onConnected = mock(() => {});
+    const onDisconnected = mock(() => {});
+    const onNeedsReregister = mock(() => {});
+    const onError = mock(() => {});
+    await startClient({
+      onConnected,
+      onDisconnected,
+      onNeedsReregister,
+      onError,
+    });
+    await waitFor(
+      () =>
+        countConnectionsForChannel("control") === 1 &&
+        countConnectionsForChannel("stream") === 1 &&
+        onConnected.mock.calls.length === 1,
+      "initial split sockets did not open",
+    );
+    const listener = getActiveRuntime();
+    const failedControlSocket = listener?.socket;
+    const failedStreamSocket = listener?.streamSocket ?? null;
+    if (!listener || !failedControlSocket || !failedStreamSocket) {
+      throw new Error("initial split socket pair missing");
+    }
+
+    const trackOpenFailure = mock(() => {});
+    handleListenerSocketOpenFailure({
+      runtime: listener,
+      controlSocket: failedControlSocket,
+      streamSocket: failedStreamSocket,
+      error: new Error("split open handler failed"),
+      trackListenerError: trackOpenFailure,
+    });
+
+    expect(trackOpenFailure).toHaveBeenCalledTimes(1);
+    await waitFor(
+      () =>
+        countConnectionsForChannel("control") === 2 &&
+        countConnectionsForChannel("stream") === 2 &&
+        onConnected.mock.calls.length === 2,
+      "listener did not reconnect after split open handler failure",
+    );
+
+    expect(getActiveRuntime()).toBe(listener);
+    expect(listener.socket).not.toBe(failedControlSocket);
+    expect(listener.streamSocket).not.toBe(failedStreamSocket);
+    expect(onDisconnected).not.toHaveBeenCalled();
+    expect(onNeedsReregister).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   test("split stream handshake stall retries without clearing runtime turn state", async () => {
     process.env.LETTA_LISTENER_STREAM_OPEN_TIMEOUT_MS = "25";
     const onConnected = mock(() => {});

--- a/src/websocket/listener/split-stream-lifecycle.test.ts
+++ b/src/websocket/listener/split-stream-lifecycle.test.ts
@@ -1,0 +1,360 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer, type Server as HttpServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Duplex } from "node:stream";
+import { WebSocket, WebSocketServer } from "ws";
+import { settingsManager } from "@/settings-manager";
+import type { ControlRequest } from "@/types/protocol_v2";
+import {
+  startListenerClient,
+  stopListenerClient,
+} from "@/websocket/listen-client";
+import { requestApprovalOverWS } from "@/websocket/listener/approval";
+import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
+import { getActiveRuntime } from "@/websocket/listener/runtime";
+
+type ListenerSettings = Awaited<
+  ReturnType<typeof settingsManager.getSettingsWithSecureTokens>
+>;
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 300; attempt++) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(message);
+}
+
+describe("split stream listener lifecycle", () => {
+  const originalHome = process.env.HOME;
+  const originalDisableCron = process.env.LETTA_DISABLE_CRON_SCHEDULER;
+  const originalDisableMods = process.env.LETTA_DISABLE_MODS;
+  const originalApiKey = process.env.LETTA_API_KEY;
+  const originalBaseUrl = process.env.LETTA_BASE_URL;
+  const originalStreamOpenTimeout =
+    process.env.LETTA_LISTENER_STREAM_OPEN_TIMEOUT_MS;
+  const originalGetSettingsWithSecureTokens =
+    settingsManager.getSettingsWithSecureTokens;
+  const originalUpdateSettings = settingsManager.updateSettings;
+  const originalFlush = settingsManager.flush;
+
+  let testHome: string;
+  let settings: ListenerSettings;
+  let httpServer: HttpServer;
+  let server: WebSocketServer;
+  let wsUrl: string;
+  let connections: WebSocket[];
+  let connectionChannels: Array<string | null>;
+  let hangNextStreamUpgrade: boolean;
+  let streamUpgradeAttempts: number;
+  let stalledUpgradeSockets: Set<Duplex>;
+
+  beforeEach(async () => {
+    stopListenerClient();
+    await settingsManager.reset();
+    testHome = await mkdtemp(join(tmpdir(), "letta-split-stream-"));
+    process.env.HOME = testHome;
+    process.env.LETTA_DISABLE_CRON_SCHEDULER = "1";
+    process.env.LETTA_DISABLE_MODS = "1";
+    delete process.env.LETTA_API_KEY;
+    delete process.env.LETTA_BASE_URL;
+    await settingsManager.initialize();
+
+    settings = {
+      ...settingsManager.getSettings(),
+      env: { LETTA_API_KEY: "initial-access-token" },
+      refreshToken: "refresh-token",
+      tokenExpiresAt: Date.now() + 60 * 60 * 1000,
+    };
+    settingsManager.getSettingsWithSecureTokens = mock(
+      async () => settings,
+    ) as typeof settingsManager.getSettingsWithSecureTokens;
+    settingsManager.updateSettings = mock((updates) => {
+      settings = {
+        ...settings,
+        ...updates,
+        env: { ...settings.env, ...updates.env },
+      };
+    }) as typeof settingsManager.updateSettings;
+    settingsManager.flush = mock(
+      async () => {},
+    ) as typeof settingsManager.flush;
+
+    connections = [];
+    connectionChannels = [];
+    hangNextStreamUpgrade = false;
+    streamUpgradeAttempts = 0;
+    stalledUpgradeSockets = new Set();
+    server = new WebSocketServer({ noServer: true });
+    httpServer = createServer();
+    httpServer.on("upgrade", (request, socket, head) => {
+      const requestUrl = new URL(request.url ?? "/", "ws://127.0.0.1");
+      const channel = requestUrl.searchParams.get("channel");
+      if (channel === "stream") {
+        streamUpgradeAttempts += 1;
+        if (hangNextStreamUpgrade) {
+          hangNextStreamUpgrade = false;
+          stalledUpgradeSockets.add(socket);
+          socket.once("close", () => stalledUpgradeSockets.delete(socket));
+          socket.on("error", () => {});
+          return;
+        }
+      }
+      server.handleUpgrade(request, socket, head, (upgradedSocket) => {
+        server.emit("connection", upgradedSocket, request);
+      });
+    });
+    await new Promise<void>((resolve) =>
+      httpServer.listen(0, "127.0.0.1", resolve),
+    );
+    const address = httpServer.address() as AddressInfo;
+    wsUrl = `ws://127.0.0.1:${address.port}`;
+    server.on("connection", (socket, request) => {
+      connections.push(socket);
+      const requestUrl = new URL(request.url ?? "/", "ws://127.0.0.1");
+      connectionChannels.push(requestUrl.searchParams.get("channel"));
+    });
+  });
+
+  afterEach(async () => {
+    stopListenerClient();
+    for (const socket of stalledUpgradeSockets) socket.destroy();
+    await Promise.all(
+      [...server.clients].map(
+        (connection) =>
+          new Promise<void>((resolve) => {
+            if (connection.readyState === WebSocket.CLOSED) {
+              resolve();
+              return;
+            }
+            connection.once("close", () => resolve());
+            connection.terminate();
+          }),
+      ),
+    );
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(resolve, 100);
+      server.close(() => {
+        clearTimeout(timeout);
+        resolve();
+      });
+    });
+    httpServer.closeAllConnections?.();
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(resolve, 100);
+      httpServer.close(() => {
+        clearTimeout(timeout);
+        resolve();
+      });
+    });
+
+    settingsManager.getSettingsWithSecureTokens =
+      originalGetSettingsWithSecureTokens;
+    settingsManager.updateSettings = originalUpdateSettings;
+    settingsManager.flush = originalFlush;
+    await settingsManager.reset();
+    await rm(testHome, { recursive: true, force: true });
+
+    process.env.HOME = originalHome;
+    if (originalDisableCron === undefined) {
+      delete process.env.LETTA_DISABLE_CRON_SCHEDULER;
+    } else {
+      process.env.LETTA_DISABLE_CRON_SCHEDULER = originalDisableCron;
+    }
+    if (originalDisableMods === undefined) {
+      delete process.env.LETTA_DISABLE_MODS;
+    } else {
+      process.env.LETTA_DISABLE_MODS = originalDisableMods;
+    }
+    if (originalApiKey === undefined) {
+      delete process.env.LETTA_API_KEY;
+    } else {
+      process.env.LETTA_API_KEY = originalApiKey;
+    }
+    if (originalBaseUrl === undefined) {
+      delete process.env.LETTA_BASE_URL;
+    } else {
+      process.env.LETTA_BASE_URL = originalBaseUrl;
+    }
+    if (originalStreamOpenTimeout === undefined) {
+      delete process.env.LETTA_LISTENER_STREAM_OPEN_TIMEOUT_MS;
+    } else {
+      process.env.LETTA_LISTENER_STREAM_OPEN_TIMEOUT_MS =
+        originalStreamOpenTimeout;
+    }
+  });
+
+  function startClient(overrides: {
+    onConnected?: (connectionId?: string) => void;
+    onDisconnected?: () => void;
+    onNeedsReregister?: () => void;
+    onError?: (error: Error) => void;
+  }) {
+    return startListenerClient({
+      connectionId: "connection-id",
+      wsUrl,
+      deviceId: "device-id",
+      connectionName: "listener-name",
+      supportsSplitStatusChannels: true,
+      onConnected: overrides.onConnected ?? mock(() => {}),
+      onDisconnected: overrides.onDisconnected ?? mock(() => {}),
+      onNeedsReregister: overrides.onNeedsReregister ?? mock(() => {}),
+      onError: overrides.onError ?? mock(() => {}),
+    });
+  }
+
+  function makeControlRequest(requestId: string): ControlRequest {
+    return {
+      type: "control_request",
+      request_id: requestId,
+      request: {
+        subtype: "can_use_tool",
+        tool_name: "Bash",
+        input: {},
+        tool_call_id: requestId.replace("perm-", "call-"),
+        permission_suggestions: [],
+        blocked_path: null,
+      },
+    };
+  }
+
+  function countConnectionsForChannel(channel: string): number {
+    return connectionChannels.filter((value) => value === channel).length;
+  }
+
+  function lastConnectionIndexForChannel(channel: string): number {
+    for (let index = connectionChannels.length - 1; index >= 0; index -= 1) {
+      if (connectionChannels[index] === channel) return index;
+    }
+    return -1;
+  }
+
+  test("split stream handshake stall retries without clearing runtime turn state", async () => {
+    process.env.LETTA_LISTENER_STREAM_OPEN_TIMEOUT_MS = "25";
+    const onConnected = mock(() => {});
+    const onDisconnected = mock(() => {});
+    const onNeedsReregister = mock(() => {});
+    const onError = mock(() => {});
+    await startClient({
+      onConnected,
+      onDisconnected,
+      onNeedsReregister,
+      onError,
+    });
+    await waitFor(
+      () =>
+        countConnectionsForChannel("control") === 1 &&
+        countConnectionsForChannel("stream") === 1,
+      "initial split sockets did not open",
+    );
+    expect(onConnected).toHaveBeenCalledTimes(1);
+
+    const listener = getActiveRuntime();
+    expect(listener).not.toBeNull();
+    if (!listener?.transport) {
+      throw new Error("listener transport missing after connect");
+    }
+    const capturedTransport = listener.transport;
+    const conversationRuntime = getOrCreateScopedRuntime(
+      listener,
+      "agent-1",
+      "conv-1",
+    );
+    const turnLease = conversationRuntime.turnLifecycle.begin({
+      origin: "message",
+      workingDirectory: process.cwd(),
+      initialStatus: "EXECUTING_CLIENT_SIDE_TOOL",
+      executingToolCallIds: ["call-1"],
+    });
+    conversationRuntime.turnLifecycle.setRunId(turnLease, "run-1");
+    conversationRuntime.queueRuntime.enqueue({
+      kind: "message",
+      source: "user",
+      content: "queued during stalled stream reconnect",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+    } as Parameters<typeof conversationRuntime.queueRuntime.enqueue>[0]);
+    const pendingApproval = requestApprovalOverWS(
+      conversationRuntime,
+      capturedTransport,
+      turnLease,
+      "perm-stream-stall",
+      makeControlRequest("perm-stream-stall"),
+    );
+    const approvalResult = pendingApproval.then(
+      (value) => ({ ok: true as const, value }),
+      (error) => ({ ok: false as const, error }),
+    );
+    await waitFor(
+      () => conversationRuntime.pendingApprovalResolvers.size === 1,
+      "approval resolver was not registered",
+    );
+
+    hangNextStreamUpgrade = true;
+    const initialControlIndex = lastConnectionIndexForChannel("control");
+    connections[initialControlIndex]?.terminate();
+    await waitFor(
+      () =>
+        countConnectionsForChannel("control") === 2 &&
+        streamUpgradeAttempts === 2,
+      "replacement control did not open with stalled stream handshake",
+    );
+    expect(onConnected).toHaveBeenCalledTimes(1);
+
+    await waitFor(
+      () =>
+        countConnectionsForChannel("control") === 3 &&
+        countConnectionsForChannel("stream") === 2 &&
+        streamUpgradeAttempts === 3 &&
+        stalledUpgradeSockets.size === 0 &&
+        onConnected.mock.calls.length === 2,
+      "listener did not retry after stalled split stream handshake",
+    );
+
+    expect(getActiveRuntime()).toBe(listener);
+    expect(conversationRuntime.turnLifecycle.kind).toBe("active");
+    expect(conversationRuntime.loopStatus).toBe("WAITING_ON_APPROVAL");
+    expect(conversationRuntime.queueRuntime.length).toBe(1);
+    expect(conversationRuntime.pendingApprovalResolvers.size).toBe(1);
+    expect(onDisconnected).not.toHaveBeenCalled();
+    expect(onNeedsReregister).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+
+    const controlCountAfterRecovery = countConnectionsForChannel("control");
+    const streamCountAfterRecovery = countConnectionsForChannel("stream");
+    await new Promise((resolve) => setTimeout(resolve, 75));
+    expect(countConnectionsForChannel("control")).toBe(
+      controlCountAfterRecovery,
+    );
+    expect(countConnectionsForChannel("stream")).toBe(streamCountAfterRecovery);
+
+    const finalControlIndex = lastConnectionIndexForChannel("control");
+    connections[finalControlIndex]?.send(
+      JSON.stringify({
+        type: "input",
+        runtime: { agent_id: "agent-1", conversation_id: "conv-1" },
+        payload: {
+          kind: "approval_response",
+          request_id: "perm-stream-stall",
+          decision: { behavior: "allow" },
+        },
+      }),
+    );
+    expect(await approvalResult).toMatchObject({
+      ok: true,
+      value: {
+        request_id: "perm-stream-stall",
+        decision: { behavior: "allow" },
+      },
+    });
+    expect(conversationRuntime.pendingApprovalResolvers.size).toBe(0);
+
+    conversationRuntime.turnLifecycle.finish(turnLease, "end_turn");
+  });
+});

--- a/src/websocket/listener/split-stream-lifecycle.test.ts
+++ b/src/websocket/listener/split-stream-lifecycle.test.ts
@@ -15,6 +15,7 @@ import {
 import { requestApprovalOverWS } from "@/websocket/listener/approval";
 import { getOrCreateScopedRuntime } from "@/websocket/listener/conversation-runtime";
 import { getActiveRuntime } from "@/websocket/listener/runtime";
+import { handleListenerSocketOpenFailure } from "@/websocket/listener/split-stream-lifecycle";
 
 type ListenerSettings = Awaited<
   ReturnType<typeof settingsManager.getSettingsWithSecureTokens>
@@ -347,6 +348,11 @@ describe("split stream listener lifecycle", () => {
     );
 
     hangNextStreamUpgrade = true;
+    const staleControlSocket = listener.socket;
+    const staleStreamSocket = listener.streamSocket ?? null;
+    if (!staleControlSocket || !staleStreamSocket) {
+      throw new Error("initial split socket pair missing");
+    }
     const initialControlIndex = lastConnectionIndexForChannel("control");
     connections[initialControlIndex]?.terminate();
     await waitFor(
@@ -374,6 +380,21 @@ describe("split stream listener lifecycle", () => {
     expect(conversationRuntime.pendingApprovalResolvers.size).toBe(1);
     expect(onDisconnected).not.toHaveBeenCalled();
     expect(onNeedsReregister).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+
+    const recoveredControlSocket = listener.socket;
+    const recoveredStreamSocket = listener.streamSocket;
+    const trackStaleFailure = mock(() => {});
+    handleListenerSocketOpenFailure({
+      runtime: listener,
+      controlSocket: staleControlSocket,
+      streamSocket: staleStreamSocket,
+      error: new Error("late failure from stale open handler"),
+      trackListenerError: trackStaleFailure,
+    });
+    expect(trackStaleFailure).not.toHaveBeenCalled();
+    expect(listener.socket).toBe(recoveredControlSocket);
+    expect(listener.streamSocket).toBe(recoveredStreamSocket);
     expect(onError).not.toHaveBeenCalled();
 
     const controlCountAfterRecovery = countConnectionsForChannel("control");

--- a/src/websocket/listener/split-stream-lifecycle.ts
+++ b/src/websocket/listener/split-stream-lifecycle.ts
@@ -208,15 +208,16 @@ export function handleListenerSocketOpenFailure({
   streamSocket,
   error,
   trackListenerError,
-  onError,
 }: {
   runtime: ListenerRuntime;
   controlSocket: WebSocket;
   streamSocket: WebSocket | null;
   error: unknown;
   trackListenerError: TrackListenerError;
-  onError: (error: Error) => void;
 }): void {
+  if (!isCurrentSocketPair(runtime, controlSocket, streamSocket)) {
+    return;
+  }
   trackListenerError(
     "listener_open_handler_failed",
     error,
@@ -226,5 +227,4 @@ export function handleListenerSocketOpenFailure({
     console.error("[Listen] WebSocket open handler failed:", error);
   }
   terminateCurrentSocketPair(runtime, controlSocket, streamSocket);
-  onError(error instanceof Error ? error : new Error(String(error)));
 }

--- a/src/websocket/listener/split-stream-lifecycle.ts
+++ b/src/websocket/listener/split-stream-lifecycle.ts
@@ -1,0 +1,230 @@
+import { WebSocket } from "ws";
+import { isDebugEnabled } from "@/utils/debug";
+import { LISTENER_STREAM_OPEN_TIMEOUT_MS } from "./constants";
+import { getActiveRuntime } from "./runtime";
+import type { ListenerTransport } from "./transport";
+import type { ListenerRuntime } from "./types";
+
+type TrackListenerError = (
+  errorType: string,
+  error: unknown,
+  context: string,
+) => void;
+
+type StreamSocketOpenResult =
+  | { status: "open"; transport: ListenerTransport }
+  | { status: "closed" }
+  | { status: "timed_out"; timeoutMs: number };
+
+export type SplitStreamOpenOutcome =
+  | { kind: "ready"; transport: ListenerTransport | null }
+  | { kind: "stale" };
+
+function terminateSocketIfOpenOrConnecting(socket: WebSocket | null): void {
+  if (
+    socket &&
+    (socket.readyState === WebSocket.OPEN ||
+      socket.readyState === WebSocket.CONNECTING)
+  ) {
+    socket.terminate();
+  }
+}
+
+export function isCurrentSocketPair(
+  runtime: ListenerRuntime,
+  controlSocket: WebSocket,
+  streamSocket: WebSocket | null,
+): boolean {
+  return (
+    runtime === getActiveRuntime() &&
+    !runtime.intentionallyClosed &&
+    runtime.socket === controlSocket &&
+    runtime.streamSocket === streamSocket
+  );
+}
+
+export function shouldHandleControlSocketClose(
+  runtime: ListenerRuntime,
+  controlSocket: WebSocket,
+  connectionId: string,
+): boolean {
+  return (
+    runtime === getActiveRuntime() &&
+    (runtime.socket === controlSocket ||
+      runtime.connections.get(connectionId)?.writer === controlSocket)
+  );
+}
+
+function terminateCurrentSocketPair(
+  runtime: ListenerRuntime,
+  controlSocket: WebSocket,
+  streamSocket: WebSocket | null,
+): void {
+  if (!isCurrentSocketPair(runtime, controlSocket, streamSocket)) {
+    return;
+  }
+  runtime.streamTransport = null;
+  terminateSocketIfOpenOrConnecting(streamSocket);
+  terminateSocketIfOpenOrConnecting(controlSocket);
+}
+
+export function terminateControlAfterStreamClose(
+  runtime: ListenerRuntime,
+  streamSocket: WebSocket,
+  code: number,
+  reason: Buffer,
+): void {
+  if (runtime.streamSocket !== streamSocket) {
+    return;
+  }
+  if (code === 1000 && reason.toString() === "Replaced by new connection") {
+    runtime.intentionallyClosed = true;
+  }
+  runtime.streamSocket = null;
+  runtime.streamTransport = null;
+
+  // The stream channel has no independent replay or reconnect path. Closing
+  // control tears down the paired session so its normal reconnect/bootstrap
+  // flow restores one coherent connection instead of silently losing frames.
+  terminateSocketIfOpenOrConnecting(runtime.socket);
+}
+
+function getStreamOpenTimeoutMs(): number {
+  const override = process.env.LETTA_LISTENER_STREAM_OPEN_TIMEOUT_MS;
+  if (override !== undefined) {
+    const parsed = Number(override);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return LISTENER_STREAM_OPEN_TIMEOUT_MS;
+}
+
+async function waitForStreamSocketOpen(
+  streamSocket: WebSocket,
+): Promise<StreamSocketOpenResult> {
+  if (streamSocket.readyState === WebSocket.OPEN) {
+    return { status: "open", transport: streamSocket };
+  }
+
+  if (
+    streamSocket.readyState === WebSocket.CLOSING ||
+    streamSocket.readyState === WebSocket.CLOSED
+  ) {
+    return { status: "closed" };
+  }
+
+  const timeoutMs = getStreamOpenTimeoutMs();
+  return await new Promise<StreamSocketOpenResult>((resolve) => {
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    let settled = false;
+
+    function cleanup() {
+      streamSocket.off("open", handleOpen);
+      streamSocket.off("error", handleFailure);
+      streamSocket.off("close", handleFailure);
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = null;
+      }
+    }
+
+    function settle(result: StreamSocketOpenResult) {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve(result);
+    }
+
+    function handleOpen() {
+      settle({ status: "open", transport: streamSocket });
+    }
+
+    function handleFailure() {
+      settle({ status: "closed" });
+    }
+
+    timeout = setTimeout(() => {
+      settle({ status: "timed_out", timeoutMs });
+    }, timeoutMs);
+    timeout.unref?.();
+
+    streamSocket.once("open", handleOpen);
+    streamSocket.once("error", handleFailure);
+    streamSocket.once("close", handleFailure);
+  });
+}
+
+export async function prepareSplitStreamTransport({
+  runtime,
+  controlSocket,
+  streamSocket,
+  trackListenerError,
+}: {
+  runtime: ListenerRuntime;
+  controlSocket: WebSocket;
+  streamSocket: WebSocket | null;
+  trackListenerError: TrackListenerError;
+}): Promise<SplitStreamOpenOutcome> {
+  if (!isCurrentSocketPair(runtime, controlSocket, streamSocket)) {
+    return { kind: "stale" };
+  }
+  if (!streamSocket) {
+    return { kind: "ready", transport: null };
+  }
+
+  const result = await waitForStreamSocketOpen(streamSocket);
+  if (!isCurrentSocketPair(runtime, controlSocket, streamSocket)) {
+    return { kind: "stale" };
+  }
+  if (result.status !== "open") {
+    const message =
+      result.status === "timed_out"
+        ? `Stream WebSocket did not open within ${result.timeoutMs}ms; reconnecting paired listener sockets`
+        : "Stream WebSocket closed before the paired listener sockets finished opening; reconnecting paired listener sockets";
+    trackListenerError(
+      result.status === "timed_out"
+        ? "listener_stream_open_timeout"
+        : "listener_stream_open_failed",
+      new Error(message),
+      "listener_stream_socket_open",
+    );
+    if (isDebugEnabled()) {
+      console.error(`[Listen] ${message}`);
+    }
+    terminateCurrentSocketPair(runtime, controlSocket, streamSocket);
+    return { kind: "stale" };
+  }
+
+  runtime.streamTransport = result.transport;
+  return { kind: "ready", transport: result.transport };
+}
+
+export function handleListenerSocketOpenFailure({
+  runtime,
+  controlSocket,
+  streamSocket,
+  error,
+  trackListenerError,
+  onError,
+}: {
+  runtime: ListenerRuntime;
+  controlSocket: WebSocket;
+  streamSocket: WebSocket | null;
+  error: unknown;
+  trackListenerError: TrackListenerError;
+  onError: (error: Error) => void;
+}): void {
+  trackListenerError(
+    "listener_open_handler_failed",
+    error,
+    "listener_socket_open",
+  );
+  if (isDebugEnabled()) {
+    console.error("[Listen] WebSocket open handler failed:", error);
+  }
+  terminateCurrentSocketPair(runtime, controlSocket, streamSocket);
+  onError(error instanceof Error ? error : new Error(String(error)));
+}


### PR DESCRIPTION
## Summary
- Adds a bounded split-stream open path: if the control socket opens but the stream socket closes, errors, or never completes its handshake, the paired sockets are torn down and the normal reconnect loop builds a coherent replacement.
- Guards stale listener socket close/open callbacks so an old control socket cannot clear active runtime or connection state after a newer connection has taken over.
- Extracts split-stream lifecycle helpers out of the oversized listener lifecycle file and ratchets the lifecycle baseline down.

## Root cause
The split listener open handler awaited the stream socket indefinitely before registering the listener connection. If the relay accepted/opened control but the stream upgrade stalled before WebSocket open/close/error, the listener had no settled path back into reconnect. Adjacent stale close handlers also only checked the active runtime, not whether the closing socket still owned the current connection.

## Changed behavior matrix
- Control opens, stream opens: connection startup proceeds normally with the stream transport.
- Control opens, stream closes/errors before open: the incomplete pair is terminated and retried.
- Control opens, stream handshake stalls: after `LISTENER_STREAM_OPEN_TIMEOUT_MS` (30s default, test overrideable), the incomplete pair is terminated and retried.
- Stale control/socket callbacks: ignored unless they still match the active runtime and current connection/socket pair.
- Terminal closes remain terminal: intentional stop, `1008`, and `1000 Replaced by new connection` still follow the existing terminal teardown paths.

## Recovery expectations
A stalled split-stream reconnect recovers through the existing reconnect loop without replacing the `ListenerRuntime`, so active turn lifecycle, queue state, and pending approval resolvers remain available for the recovered control socket. The regression resolves an approval after the stalled stream retry to prove that path.

## Regression proof
- On parent `ed3fec21`, the stalled-handshake test fails with `listener did not retry after stalled split stream handshake` because the stream-open wait never settles.
- On this branch, both the hung-handshake and rejected-upgrade producer paths reconnect successfully; the isolated listener suite passes 342 tests.

## Limits and risk
- This is listener/runtime lifecycle code; rollback is the commit revert, but it would restore the possible indefinite stream-handshake stall.
- I validated the listener directory with `--isolate`; the non-isolated directory run has pre-existing remote-settings global state leakage unrelated to this change.

## Test plan
- [x] `bun test src/websocket/listener/split-stream-lifecycle.test.ts`
- [x] `bun test src/websocket/listener/auth-lifecycle.test.ts`
- [x] `bun test src/websocket/listener/auth-lifecycle-approval-reconnect.test.ts`
- [x] `bun test --isolate src/websocket/listener`
- [x] `bun run check`

👾 Generated with [Letta Code](https://letta.com)