### PR TITLE
feat(whatsapp): canonicalize LID identities

### DIFF
--- a/src/channels/whatsapp-jid.test.ts
+++ b/src/channels/whatsapp-jid.test.ts
@@ -54,11 +54,11 @@ describe("WhatsApp JID helpers", () => {
   });
 
   test("refuses to send to unresolved LIDs", () => {
-    expect(() => resolveSendJid({ chatId: "abc@lid" })).toThrow(/unresolved/i);
+    expect(() => resolveSendJid({ chatId: "123@lid" })).toThrow(/unresolved/i);
     expect(
       resolveSendJid({
-        chatId: "abc@lid",
-        lidToJid: new Map([["abc@lid", "15551234567@s.whatsapp.net"]]),
+        chatId: "123@lid",
+        resolveLid: () => "15551234567@s.whatsapp.net",
       }),
     ).toBe("15551234567@s.whatsapp.net");
   });

--- a/src/channels/whatsapp-registry.test.ts
+++ b/src/channels/whatsapp-registry.test.ts
@@ -116,7 +116,6 @@ async function makeHarness(
         sendCount += 1;
         return { key: { id: `outbound-${sendCount}` } };
       },
-      async readMessages() {},
     };
     return {
       sock: socket,

--- a/src/channels/whatsapp-registry.test.ts
+++ b/src/channels/whatsapp-registry.test.ts
@@ -1,0 +1,307 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  __testOverrideLoadChannelAccounts,
+  __testOverrideSaveChannelAccounts,
+  clearChannelAccountStores,
+} from "@/channels/accounts";
+import {
+  __testOverrideLoadPairingStore,
+  __testOverrideSavePairingStore,
+  clearPairingStores,
+  getApprovedUsers,
+  getPendingPairings,
+} from "@/channels/pairing";
+import {
+  ChannelRegistry,
+  completePairing,
+  getChannelRegistry,
+} from "@/channels/registry";
+import type { ChannelInboundDelivery } from "@/channels/registry-handlers";
+import {
+  __testOverrideLoadRoutes,
+  __testOverrideSaveRoutes,
+  addRoute,
+  clearAllRoutes,
+  getRoutesForChannel,
+} from "@/channels/routing";
+import type { WhatsAppChannelAccount } from "@/channels/types";
+import {
+  createWhatsAppAdapter,
+  type WhatsAppAdapterDependencies,
+} from "@/channels/whatsapp/adapter";
+import {
+  WHATSAPP_LID_SUFFIX,
+  WHATSAPP_PHONE_SUFFIX,
+} from "@/channels/whatsapp/jid";
+import { createLidStore } from "@/channels/whatsapp/lid-store";
+
+const ACCESS_ENV_KEYS = [
+  "LETTA_CHANNELS_ALLOWED_USERS",
+  "LETTA_CHANNELS_ADMIN_USERS",
+  "LETTA_CHANNELS_ALLOW_ALL_USERS",
+  "LETTA_WHATSAPP_ALLOWED_USERS",
+  "LETTA_WHATSAPP_ADMIN_USERS",
+  "LETTA_WHATSAPP_ALLOW_ALL_USERS",
+] as const;
+
+const ACCOUNT_ID = "registry-whatsapp";
+const CANONICAL_PHONE = "15550000999";
+const CANONICAL_PHONE_JID = `${CANONICAL_PHONE}${WHATSAPP_PHONE_SUFFIX}`;
+const RAW_LID = `90000123${WHATSAPP_LID_SUFFIX}`;
+const SELF_PHONE_JID = `15550000001${WHATSAPP_PHONE_SUFFIX}`;
+const SELF_LID = `70000001${WHATSAPP_LID_SUFFIX}`;
+const ROUTE_AGENT = "agent-registry-proof";
+const ROUTE_CONVERSATION = "conversation-registry-proof";
+
+type RegistryHarness = {
+  deliveries: ChannelInboundDelivery[];
+  sendCount: number;
+  emit: (messages: Record<string, unknown>[]) => Promise<void>;
+};
+
+function makeAccount(
+  overrides: Partial<WhatsAppChannelAccount> = {},
+): WhatsAppChannelAccount {
+  return {
+    channel: "whatsapp",
+    accountId: ACCOUNT_ID,
+    enabled: true,
+    dmPolicy: "pairing",
+    allowedUsers: [],
+    agentId: null,
+    selfChatMode: false,
+    groupMode: "open",
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+    ...overrides,
+  };
+}
+
+function makeMessage(
+  remoteJid: string,
+  id: string,
+  key: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    key: { remoteJid, id, ...key },
+    message: { conversation: "hello" },
+    messageTimestamp: Math.floor(Date.now() / 1000),
+  };
+}
+
+async function makeHarness(
+  account: WhatsAppChannelAccount,
+  lidPath: string,
+): Promise<RegistryHarness> {
+  const upsertHandlers: Array<(payload: unknown) => unknown> = [];
+  const deliveries: ChannelInboundDelivery[] = [];
+  let sendCount = 0;
+
+  const createSocket: NonNullable<
+    WhatsAppAdapterDependencies["createSocket"]
+  > = async () => {
+    const socket = {
+      ev: {
+        on(event: string, handler: (payload: unknown) => void) {
+          if (event === "messages.upsert") upsertHandlers.push(handler);
+        },
+      },
+      ws: { close() {} },
+      user: { id: SELF_PHONE_JID, lid: SELF_LID },
+      async sendMessage() {
+        sendCount += 1;
+        return { key: { id: `outbound-${sendCount}` } };
+      },
+      async readMessages() {},
+    };
+    return {
+      sock: socket,
+      saveCreds: async () => undefined,
+      DisconnectReason: {},
+      release: () => undefined,
+    };
+  };
+
+  const adapter = createWhatsAppAdapter(account, {
+    createSocket,
+    loadRuntimeModule: async () => ({}),
+    lidStore: createLidStore(lidPath),
+  });
+  const registry = new ChannelRegistry();
+  registry.registerAdapter(adapter);
+  registry.setMessageHandler((delivery) => {
+    deliveries.push(delivery);
+  });
+  registry.setReady();
+  await adapter.start();
+
+  return {
+    deliveries,
+    get sendCount() {
+      return sendCount;
+    },
+    async emit(messages) {
+      const handler = upsertHandlers.at(-1);
+      if (!handler) throw new Error("messages.upsert handler was not captured");
+      await handler({ type: "notify", messages });
+    },
+  };
+}
+
+function clearStores(): void {
+  clearChannelAccountStores();
+  clearAllRoutes();
+  clearPairingStores();
+}
+
+function installCleanStores(): void {
+  clearStores();
+
+  __testOverrideLoadChannelAccounts(() => []);
+  __testOverrideSaveChannelAccounts(() => {});
+  __testOverrideLoadRoutes(() => null);
+  __testOverrideSaveRoutes(() => {});
+  __testOverrideLoadPairingStore(() => null);
+  __testOverrideSavePairingStore(() => {});
+}
+
+function restoreStores(): void {
+  clearStores();
+
+  __testOverrideLoadChannelAccounts(null);
+  __testOverrideSaveChannelAccounts(null);
+  __testOverrideLoadRoutes(null);
+  __testOverrideSaveRoutes(null);
+  __testOverrideLoadPairingStore(null);
+  __testOverrideSavePairingStore(null);
+}
+
+describe("WhatsApp canonical identity through ChannelRegistry", () => {
+  let tempDir = "";
+  let savedEnvironment = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    savedEnvironment = new Map(
+      ACCESS_ENV_KEYS.map((key) => [key, process.env[key]]),
+    );
+    for (const key of ACCESS_ENV_KEYS) delete process.env[key];
+    tempDir = mkdtempSync(join(tmpdir(), "whatsapp-registry-test-"));
+    installCleanStores();
+  });
+
+  afterEach(async () => {
+    const registry = getChannelRegistry();
+    if (registry) await registry.stopAll();
+    restoreStores();
+    for (const key of ACCESS_ENV_KEYS) {
+      const value = savedEnvironment.get(key);
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test("allowlist and route converge across LID and PN forms", async () => {
+    const account = makeAccount({ allowedUsers: [CANONICAL_PHONE] });
+    __testOverrideLoadChannelAccounts(() => [account]);
+    addRoute("whatsapp", {
+      accountId: ACCOUNT_ID,
+      chatId: CANONICAL_PHONE_JID,
+      chatType: "direct",
+      threadId: null,
+      agentId: ROUTE_AGENT,
+      conversationId: ROUTE_CONVERSATION,
+      enabled: true,
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    });
+
+    const harness = await makeHarness(account, join(tempDir, "lid.json"));
+    await harness.emit([
+      makeMessage(RAW_LID, "lid-form", { senderPn: CANONICAL_PHONE_JID }),
+      makeMessage(CANONICAL_PHONE_JID, "pn-form"),
+    ]);
+
+    expect(harness.deliveries).toHaveLength(2);
+    for (const delivery of harness.deliveries) {
+      expect(delivery.route).toMatchObject({
+        chatId: CANONICAL_PHONE_JID,
+        agentId: ROUTE_AGENT,
+        conversationId: ROUTE_CONVERSATION,
+      });
+    }
+    expect(getRoutesForChannel("whatsapp", ACCOUNT_ID)).toHaveLength(1);
+    expect(getPendingPairings("whatsapp", ACCOUNT_ID)).toHaveLength(0);
+    expect(harness.sendCount).toBe(0);
+  });
+
+  test("pairing approval converges future LID and PN forms", async () => {
+    const account = makeAccount();
+    __testOverrideLoadChannelAccounts(() => [account]);
+    const harness = await makeHarness(account, join(tempDir, "lid.json"));
+
+    await harness.emit([
+      makeMessage(RAW_LID, "pairing-request", {
+        senderPn: CANONICAL_PHONE_JID,
+      }),
+    ]);
+
+    const pending = getPendingPairings("whatsapp", ACCOUNT_ID);
+    expect(pending).toHaveLength(1);
+    expect(pending[0]).toEqual(
+      expect.objectContaining({
+        accountId: ACCOUNT_ID,
+        senderId: CANONICAL_PHONE,
+        chatId: CANONICAL_PHONE_JID,
+      }),
+    );
+    expect(harness.sendCount).toBe(1);
+
+    const code = pending[0]?.code;
+    if (!code) throw new Error("pairing code was not created");
+    expect(
+      completePairing(
+        "whatsapp",
+        code,
+        ROUTE_AGENT,
+        ROUTE_CONVERSATION,
+        ACCOUNT_ID,
+      ),
+    ).toMatchObject({
+      success: true,
+      chatId: CANONICAL_PHONE_JID,
+      accountId: ACCOUNT_ID,
+    });
+
+    const sendsAfterPairing = harness.sendCount;
+    await harness.emit([
+      makeMessage(RAW_LID, "approved-lid-form"),
+      makeMessage(CANONICAL_PHONE_JID, "approved-pn-form"),
+    ]);
+
+    expect(harness.deliveries).toHaveLength(2);
+    expect(
+      harness.deliveries.every(
+        (delivery) =>
+          delivery.route.chatId === CANONICAL_PHONE_JID &&
+          delivery.route.agentId === ROUTE_AGENT &&
+          delivery.route.conversationId === ROUTE_CONVERSATION,
+      ),
+    ).toBe(true);
+    expect(getRoutesForChannel("whatsapp", ACCOUNT_ID)).toHaveLength(1);
+    expect(getPendingPairings("whatsapp", ACCOUNT_ID)).toHaveLength(0);
+    const approved = getApprovedUsers("whatsapp", ACCOUNT_ID);
+    expect(approved).toHaveLength(1);
+    expect(approved[0]).toEqual(
+      expect.objectContaining({
+        accountId: ACCOUNT_ID,
+        senderId: CANONICAL_PHONE,
+      }),
+    );
+    expect(harness.sendCount).toBe(sendsAfterPairing);
+  });
+});

--- a/src/channels/whatsapp/adapter.test.ts
+++ b/src/channels/whatsapp/adapter.test.ts
@@ -273,6 +273,31 @@ describe("WhatsApp adapter canonical identity integration", () => {
     expect(store.flushes).toBe(1);
   });
 
+  test("PN-form DM senderLid is passed through and later LID DM resolves", async () => {
+    const store = instrumentStore(createLidStore(join(dir, "lid-sender.json")));
+    const received: InboundChannelMessage[] = [];
+    const harness = makeHarness(store, async (message) => {
+      received.push(message);
+    });
+    await harness.adapter.start();
+
+    const pn = phone("15550000018");
+    const senderLid = lid("91919191");
+    await harness.emit([
+      makeMessage(pn, "pn-with-lid", {
+        senderLid,
+      }),
+    ]);
+    expect(store.resolve(senderLid)).toBe(pn);
+
+    await harness.emit([makeMessage(senderLid, "lid-without-hints")]);
+    expect(received.map((message) => message.chatId)).toEqual([pn, pn]);
+    expect(received.map((message) => message.senderId)).toEqual([
+      "15550000018",
+      "15550000018",
+    ]);
+  });
+
   test("outbound send resolves known LID and rejects unknown LID", async () => {
     const store = instrumentStore(createLidStore(join(dir, "lid.json")));
     const known = lid("12121212");

--- a/src/channels/whatsapp/adapter.test.ts
+++ b/src/channels/whatsapp/adapter.test.ts
@@ -1,0 +1,354 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { InboundChannelMessage } from "@/channels/types";
+import {
+  createWhatsAppAdapter,
+  type WhatsAppAdapterDependencies,
+} from "@/channels/whatsapp/adapter";
+import {
+  WHATSAPP_GROUP_SUFFIX,
+  WHATSAPP_LID_SUFFIX,
+  WHATSAPP_PHONE_SUFFIX,
+} from "@/channels/whatsapp/jid";
+import { createLidStore, type LidStore } from "@/channels/whatsapp/lid-store";
+
+const account = {
+  channel: "whatsapp" as const,
+  accountId: "phase-b-test",
+  enabled: true,
+  dmPolicy: "pairing" as const,
+  allowedUsers: [],
+  createdAt: new Date(0).toISOString(),
+  updatedAt: new Date(0).toISOString(),
+  agentId: "agent-test",
+  selfChatMode: false,
+  groupMode: "open" as const,
+};
+
+const phone = (value: string) => `${value}${WHATSAPP_PHONE_SUFFIX}`;
+const lid = (value: string) => `${value}${WHATSAPP_LID_SUFFIX}`;
+const group = (value: string) => `${value}${WHATSAPP_GROUP_SUFFIX}`;
+
+function makeMessage(
+  remoteJid: string,
+  id: string,
+  key: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    key: { remoteJid, id, ...key },
+    message: { conversation: "hello" },
+    messageTimestamp: Math.floor(Date.now() / 1000),
+  };
+}
+
+function instrumentStore(store: LidStore): LidStore & { flushes: number } {
+  let flushes = 0;
+  return {
+    get flushes() {
+      return flushes;
+    },
+    resolve: (value) => store.resolve(value),
+    record: (key, value) => store.record(key, value),
+    flush: () => {
+      flushes += 1;
+      store.flush();
+    },
+  };
+}
+
+function makeHarness(
+  store: LidStore,
+  onMessage: (message: InboundChannelMessage) => Promise<void>,
+) {
+  let upsertHandler: ((payload: unknown) => unknown) | undefined;
+  const sentJids: string[] = [];
+  const socket = {
+    ev: {
+      on(event: string, handler: (payload: unknown) => void) {
+        if (event === "messages.upsert") upsertHandler = handler;
+      },
+    },
+    ws: { close() {} },
+    user: { id: phone("15551234567"), lid: lid("777000111") },
+    async sendMessage(jid: string) {
+      sentJids.push(jid);
+      return { key: { id: "outbound" } };
+    },
+  };
+  const createSocket: NonNullable<
+    WhatsAppAdapterDependencies["createSocket"]
+  > = async () => ({
+    sock: socket,
+    saveCreds: async () => undefined,
+    DisconnectReason: {},
+    release: () => undefined,
+  });
+  const dependencies: WhatsAppAdapterDependencies = {
+    createSocket,
+    loadRuntimeModule: async () => ({}),
+    lidStore: store,
+  };
+  const adapter = createWhatsAppAdapter(account, dependencies);
+  adapter.onMessage = onMessage;
+  return {
+    adapter,
+    async emit(messages: Record<string, unknown>[]) {
+      await upsertHandler?.({ type: "notify", messages });
+    },
+    sentJids,
+  };
+}
+
+describe("WhatsApp adapter canonical identity integration", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "adapter-identity-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("records a LID observation and flushes once per batch", async () => {
+    const store = instrumentStore(createLidStore(join(dir, "lid.json")));
+    const received: InboundChannelMessage[] = [];
+    const harness = makeHarness(store, async (message) => {
+      received.push(message);
+    });
+
+    await harness.adapter.start();
+    await harness.emit([
+      makeMessage(lid("12345678"), "one", {
+        senderPn: phone("15550000001"),
+      }),
+      makeMessage(lid("87654321"), "two", {
+        senderPn: phone("15550000002"),
+      }),
+    ]);
+
+    expect(received.map((message) => message.chatId)).toEqual([
+      phone("15550000001"),
+      phone("15550000002"),
+    ]);
+    expect(received.map((message) => message.senderId)).toEqual([
+      "15550000001",
+      "15550000002",
+    ]);
+    expect(store.flushes).toBe(1);
+    expect(store.resolve(lid("12345678"))).toBe(phone("15550000001"));
+    expect(received[0]?.raw).toBeDefined();
+  });
+
+  test("later LID DM resolves from the persisted store after restart", async () => {
+    const path = join(dir, "lid.json");
+    const first = instrumentStore(createLidStore(path));
+    const firstHarness = makeHarness(first, async () => undefined);
+    await firstHarness.adapter.start();
+    await firstHarness.emit([
+      makeMessage(lid("22223333"), "first", {
+        senderPn: phone("15550000003"),
+      }),
+    ]);
+    await firstHarness.adapter.stop();
+
+    const received: InboundChannelMessage[] = [];
+    const second = instrumentStore(createLidStore(path));
+    const secondHarness = makeHarness(second, async (message) => {
+      received.push(message);
+    });
+    await secondHarness.adapter.start();
+    await secondHarness.emit([makeMessage(lid("22223333"), "second")]);
+
+    expect(received[0]?.chatId).toBe(phone("15550000003"));
+    expect(received[0]?.senderId).toBe("15550000003");
+  });
+
+  test("unresolved and conflicting direct identities are not delivered", async () => {
+    const store = instrumentStore(createLidStore(join(dir, "lid.json")));
+    const existing = lid("33334444");
+    store.record(existing, phone("15550000004"));
+    const received: InboundChannelMessage[] = [];
+    const harness = makeHarness(store, async (message) => {
+      received.push(message);
+    });
+    await harness.adapter.start();
+
+    await harness.emit([
+      makeMessage(lid("55556666"), "unknown"),
+      makeMessage(existing, "conflict", { senderPn: phone("15550000005") }),
+    ]);
+
+    expect(received).toHaveLength(0);
+    expect(store.resolve(existing)).toBe(phone("15550000004"));
+    expect(store.flushes).toBe(0);
+  });
+
+  test("group observations canonicalize sender and support later LID-only messages", async () => {
+    const store = instrumentStore(createLidStore(join(dir, "lid.json")));
+    const received: InboundChannelMessage[] = [];
+    const harness = makeHarness(store, async (message) => {
+      received.push(message);
+    });
+    await harness.adapter.start();
+
+    await harness.emit([
+      makeMessage(group("120363"), "group-one", {
+        participant: lid("44445555"),
+        participantPn: phone("15550000006"),
+      }),
+      makeMessage(group("120363"), "group-two", {
+        participant: lid("44445555"),
+      }),
+    ]);
+
+    expect(received.map((message) => message.senderId)).toEqual([
+      "15550000006",
+      "15550000006",
+    ]);
+    expect(received[0]?.chatId).toBe(group("120363"));
+    expect(store.flushes).toBe(1);
+  });
+
+  test("conflicting group evidence is dropped without overwriting", async () => {
+    const store = instrumentStore(createLidStore(join(dir, "lid.json")));
+    const existing = lid("66667777");
+    store.record(existing, phone("15550000007"));
+    const received: InboundChannelMessage[] = [];
+    const harness = makeHarness(store, async (message) => {
+      received.push(message);
+    });
+    await harness.adapter.start();
+
+    await harness.emit([
+      makeMessage(group("120363"), "group-conflict", {
+        participant: existing,
+        participantPn: phone("15550000008"),
+      }),
+    ]);
+
+    expect(received).toHaveLength(0);
+    expect(store.resolve(existing)).toBe(phone("15550000007"));
+  });
+
+  test("canonical LID and PN forms share a dedupe key", async () => {
+    const store = instrumentStore(createLidStore(join(dir, "lid.json")));
+    const received: InboundChannelMessage[] = [];
+    const harness = makeHarness(store, async (message) => {
+      received.push(message);
+    });
+    await harness.adapter.start();
+
+    await harness.emit([
+      makeMessage(lid("88889999"), "same", {
+        senderPn: phone("15550000009"),
+      }),
+      makeMessage(phone("15550000009"), "same"),
+    ]);
+
+    expect(received).toHaveLength(1);
+    expect(store.flushes).toBe(1);
+  });
+
+  test("PN-first canonical dedupe still learns the later LID mapping", async () => {
+    const store = instrumentStore(createLidStore(join(dir, "lid.json")));
+    const received: InboundChannelMessage[] = [];
+    const legacy = lid("90909090");
+    const mapped = phone("15550000013");
+    const harness = makeHarness(store, async (message) => {
+      received.push(message);
+    });
+    await harness.adapter.start();
+
+    await harness.emit([
+      makeMessage(mapped, "same-reverse"),
+      makeMessage(legacy, "same-reverse", { senderPn: mapped }),
+    ]);
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.chatId).toBe(mapped);
+    expect(store.resolve(legacy)).toBe(mapped);
+    expect(store.flushes).toBe(1);
+  });
+
+  test("outbound send resolves known LID and rejects unknown LID", async () => {
+    const store = instrumentStore(createLidStore(join(dir, "lid.json")));
+    const known = lid("12121212");
+    const mapped = phone("15550000012");
+    store.record(known, mapped);
+    const harness = makeHarness(store, async () => undefined);
+    await harness.adapter.start();
+
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: known,
+      text: "outbound",
+    });
+    expect(harness.sentJids).toEqual([mapped]);
+
+    await expect(
+      harness.adapter.sendMessage({
+        channel: "whatsapp",
+        accountId: account.accountId,
+        chatId: lid("34343434"),
+        text: "unknown",
+      }),
+    ).rejects.toThrow(/unresolved/i);
+    expect(harness.sentJids).toEqual([mapped]);
+
+    await harness.adapter.sendDirectReply(known, "reply");
+    expect(harness.sentJids).toEqual([mapped, mapped]);
+  });
+
+  test("handler failure still flushes dirty observations", async () => {
+    const store = instrumentStore(createLidStore(join(dir, "lid.json")));
+    const harness = makeHarness(store, async () => {
+      throw new Error("handler failed");
+    });
+    await harness.adapter.start();
+
+    await harness.emit([
+      makeMessage(lid("99990000"), "failure", {
+        senderPn: phone("15550000010"),
+      }),
+    ]);
+
+    expect(store.flushes).toBe(1);
+    expect(store.resolve(lid("99990000"))).toBe(phone("15550000010"));
+  });
+
+  test("flush failure stays dirty and retries on the next batch", async () => {
+    const base = createLidStore(join(dir, "retry.json"));
+    let attempts = 0;
+    const store: LidStore = {
+      resolve: (value) => base.resolve(value),
+      record: (key, value) => base.record(key, value),
+      flush: () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("disk unavailable");
+        base.flush();
+      },
+    };
+    const harness = makeHarness(store, async () => undefined);
+    await harness.adapter.start();
+
+    await harness.emit([
+      makeMessage(lid("11110000"), "retry", {
+        senderPn: phone("15550000011"),
+      }),
+    ]);
+    expect(attempts).toBe(1);
+
+    await harness.emit([makeMessage(phone("15550000011"), "retry-second")]);
+    expect(attempts).toBe(2);
+
+    await harness.adapter.stop();
+    expect(attempts).toBe(2);
+    expect(
+      createLidStore(join(dir, "retry.json")).resolve(lid("11110000")),
+    ).toBe(phone("15550000011"));
+  });
+});

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { formatChannelControlRequestPrompt } from "@/channels/interactive";
 import { formatChannelLifecycleErrorMessage } from "@/channels/lifecycle-error";
 import type {
@@ -9,17 +10,16 @@ import type {
   OutboundChannelMessage,
   WhatsAppChannelAccount,
 } from "@/channels/types";
+import { resolveInboundIdentity } from "./identity";
 import {
   isGroupJid,
-  isLidJid,
   isSelfChat,
   isStatusOrBroadcastJid,
-  phoneDigitsToJid,
-  resolveLidToPhoneJid,
   resolveSendJid,
-  senderIdFromJid,
   stripDeviceSuffix,
 } from "./jid";
+import type { LidStore } from "./lid-store";
+import { createLidStore } from "./lid-store";
 import {
   buildWhatsAppOutboundPayload,
   collectWhatsAppAttachments,
@@ -45,7 +45,6 @@ type WhatsAppSocket = {
   ev?: EventEmitterLike;
   ws?: { close?: () => void };
   user?: { id?: string; lid?: string };
-  signalRepository?: { lidMapping?: Map<string, string> };
   sendMessage?: (
     jid: string,
     payload: Record<string, unknown>,
@@ -62,10 +61,18 @@ type WhatsAppMessage = {
     fromMe?: boolean | null;
     participant?: string | null;
     senderPn?: string | null;
+    participantPn?: string | null;
+    participantLid?: string | null;
   };
   message?: unknown;
   messageTimestamp?: number | { toNumber?: () => number } | null;
   pushName?: string | null;
+};
+
+export type WhatsAppAdapterDependencies = {
+  createSocket?: typeof createWhatsAppSocket;
+  loadRuntimeModule?: typeof loadWhatsAppModule;
+  lidStore?: LidStore;
 };
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -190,6 +197,7 @@ function getLifecycleErrorReplyKey(source: ChannelTurnSource): string | null {
 
 export function createWhatsAppAdapter(
   account: WhatsAppChannelAccount,
+  dependencies: WhatsAppAdapterDependencies = {},
 ): ChannelAdapter {
   let sock: WhatsAppSocket | null = null;
   let running = false;
@@ -206,8 +214,36 @@ export function createWhatsAppAdapter(
     | null = null;
   const sentMessageIds = new Set<string>();
   const seenMessageIds = new Set<string>();
-  const lidToJid = new Map<string, string>();
+  const lidStore =
+    dependencies.lidStore ??
+    createLidStore(
+      join(getWhatsAppAuthDir(account.accountId), "lid-mappings.json"),
+    );
+  let lidStoreDirty = false;
   const messageStore = new Map<string, unknown>();
+
+  function flushLidStoreIfDirty(): void {
+    if (!lidStoreDirty) return;
+    try {
+      lidStore.flush();
+      lidStoreDirty = false;
+    } catch {
+      console.warn(
+        `[WhatsApp:${account.accountId}] failed to flush LID mappings; will retry.`,
+      );
+    }
+  }
+
+  function applyObservedMappings(
+    mappings: Array<{ lidJid: string; phoneJid: string }>,
+  ): boolean {
+    for (const mapping of mappings) {
+      const result = lidStore.record(mapping.lidJid, mapping.phoneJid);
+      if (!result || result.status === "conflict") return false;
+      if (result.status === "recorded") lidStoreDirty = true;
+    }
+    return true;
+  }
 
   function rememberSeen(id: string): boolean {
     if (seenMessageIds.has(id)) return true;
@@ -249,7 +285,7 @@ export function createWhatsAppAdapter(
 
   async function ensureRuntimeHelpers(): Promise<void> {
     if (downloadContentFromMessage) return;
-    const mod = await loadWhatsAppModule();
+    const mod = await (dependencies.loadRuntimeModule ?? loadWhatsAppModule)();
     const helper = mod.downloadContentFromMessage;
     if (typeof helper === "function") {
       downloadContentFromMessage = helper as unknown as NonNullable<
@@ -284,7 +320,7 @@ export function createWhatsAppAdapter(
     clearActiveSocket(true);
     await ensureRuntimeHelpers();
     connectedAtMs = Date.now();
-    const result = await createWhatsAppSocket({
+    const result = await (dependencies.createSocket ?? createWhatsAppSocket)({
       accountId: account.accountId,
       printQr: true,
       messageStore,
@@ -339,38 +375,13 @@ export function createWhatsAppAdapter(
     sock = result.sock as WhatsAppSocket;
     releaseSocketLease = result.release;
     sock.ev?.on?.("messages.upsert", (event) => {
-      void handleMessagesUpsert(event).catch((error) => {
+      return handleMessagesUpsert(event).catch((error) => {
         console.error(
           `[WhatsApp:${account.accountId}] inbound handler failed:`,
           error instanceof Error ? error.message : error,
         );
       });
     });
-  }
-
-  function resolveInboundChatId(
-    remoteJid: string,
-    selfChat: boolean,
-    msg: WhatsAppMessage,
-  ): string {
-    const normalizedRemote = stripDeviceSuffix(remoteJid);
-    if (selfChat) {
-      if (selfPhoneJid) return selfPhoneJid;
-      const digits = senderIdFromJid(remoteJid);
-      return phoneDigitsToJid(digits) || normalizedRemote;
-    }
-    if (isLidJid(normalizedRemote)) {
-      const resolved = resolveLidToPhoneJid({
-        lidJid: normalizedRemote,
-        message: msg,
-        sock,
-      });
-      if (resolved) {
-        lidToJid.set(normalizedRemote, resolved);
-        return resolved;
-      }
-    }
-    return normalizedRemote;
   }
 
   async function getGroupLabel(groupJid: string): Promise<string | undefined> {
@@ -382,110 +393,123 @@ export function createWhatsAppAdapter(
   }
 
   async function handleMessagesUpsert(event: unknown): Promise<void> {
-    const record = asRecord(event);
-    if (record.type !== "notify" && record.type !== "append") return;
-    const messages = Array.isArray(record.messages)
-      ? (record.messages as WhatsAppMessage[])
-      : [];
-    const isHistory = record.type === "append";
-    for (const msg of messages) {
-      const remoteJid = msg.key?.remoteJid ?? "";
-      const messageId = msg.key?.id ?? "";
-      if (!remoteJid || !messageId || !msg.message) continue;
-      if (isStatusOrBroadcastJid(remoteJid)) continue;
-      if (sentMessageIds.has(messageId)) {
-        sentMessageIds.delete(messageId);
-        continue;
-      }
-      if (!messageStore.has(messageId)) {
-        messageStore.set(messageId, msg);
-        setTimeout(() => messageStore.delete(messageId), 24 * 60 * 60 * 1000);
-      }
+    try {
+      const record = asRecord(event);
+      if (record.type !== "notify" && record.type !== "append") return;
+      const messages = Array.isArray(record.messages)
+        ? (record.messages as WhatsAppMessage[])
+        : [];
+      const isHistory = record.type === "append";
+      for (const msg of messages) {
+        const remoteJid = msg.key?.remoteJid ?? "";
+        const messageId = msg.key?.id ?? "";
+        if (!remoteJid || !messageId || !msg.message) continue;
+        if (isStatusOrBroadcastJid(remoteJid)) continue;
+        if (sentMessageIds.has(messageId)) {
+          sentMessageIds.delete(messageId);
+          continue;
+        }
+        if (!messageStore.has(messageId)) {
+          messageStore.set(messageId, msg);
+          setTimeout(() => messageStore.delete(messageId), 24 * 60 * 60 * 1000);
+        }
 
-      const selfChat = isSelfChat(remoteJid, selfPhoneJid, selfLid);
-      const fromMe = msg.key?.fromMe === true;
-      if (fromMe && !(account.selfChatMode && selfChat)) continue;
-      if (account.selfChatMode && !selfChat) {
-        console.log(
-          `[WhatsApp:${account.accountId}] drop non-self message in self-chat mode remoteJid=${remoteJid}`,
-        );
-        continue;
-      }
+        const selfChat = isSelfChat(remoteJid, selfPhoneJid, selfLid);
+        const fromMe = msg.key?.fromMe === true;
+        if (fromMe && !(account.selfChatMode && selfChat)) continue;
+        if (account.selfChatMode && !selfChat) {
+          console.log(
+            `[WhatsApp:${account.accountId}] drop non-self message in self-chat mode remoteJid=${remoteJid}`,
+          );
+          continue;
+        }
 
-      const timestamp = timestampToMs(msg.messageTimestamp);
-      if (isHistory || timestamp < connectedAtMs - 1000) continue;
+        const timestamp = timestampToMs(msg.messageTimestamp);
+        if (isHistory || timestamp < connectedAtMs - 1000) continue;
 
-      const group = isGroupJid(remoteJid);
-      const chatId = group
-        ? stripDeviceSuffix(remoteJid)
-        : resolveInboundChatId(remoteJid, selfChat, msg);
-      if (rememberSeen(`${chatId}:${messageId}`)) continue;
-
-      const text = extractWhatsAppText(msg.message);
-      const attachmentResult = await collectWhatsAppAttachments({
-        accountId: account.accountId,
-        chatId,
-        messageId,
-        message: msg.message,
-        downloadContentFromMessage: downloadContentFromMessage ?? undefined,
-        downloadMedia: account.downloadMedia === true,
-        mediaMaxBytes: account.mediaMaxBytes,
-        transcribeVoice: account.transcribeVoice === true,
-      });
-      const body = attachmentResult.transcriptionText || text;
-      if (!body.trim() && attachmentResult.attachments.length === 0) continue;
-
-      const senderJid = group
-        ? (msg.key?.participant ?? msg.key?.senderPn ?? remoteJid)
-        : chatId;
-      const senderId = selfChat
-        ? senderIdFromJid(selfPhoneJid ?? chatId)
-        : senderIdFromJid(senderJid);
-
-      const mentionedJids = extractMentionedJids(msg.message);
-      const replyParticipant = extractReplyParticipant(msg.message);
-      const groupAllowed = !group
-        ? true
-        : shouldProcessGroup({
-            account,
-            groupJid: chatId,
-            text: body,
-            mentionedJids,
-            replyParticipant,
+        const identity = resolveInboundIdentity(
+          {
             selfPhoneJid,
             selfLid,
-          });
-      if (!groupAllowed) continue;
+            remoteJid,
+            participant: msg.key?.participant,
+            senderPn: msg.key?.senderPn,
+            participantPn: msg.key?.participantPn,
+            participantLid: msg.key?.participantLid,
+          },
+          lidStore,
+        );
+        if (!identity || !applyObservedMappings(identity.observedMappings)) {
+          continue;
+        }
 
-      const chatLabel = group
-        ? await getGroupLabel(chatId)
-        : selfChat
-          ? "Self (WhatsApp)"
-          : msg.pushName?.trim() || senderId;
+        const group = isGroupJid(remoteJid);
+        const chatId = identity.chatId;
+        if (rememberSeen(`${chatId}:${messageId}`)) continue;
 
-      const inbound: InboundChannelMessage = {
-        channel: CHANNEL_ID,
-        accountId: account.accountId,
-        chatId,
-        senderId,
-        senderName: msg.pushName?.trim() || senderId,
-        chatLabel,
-        text: body,
-        timestamp,
-        messageId,
-        chatType: group ? "channel" : "direct",
-        isMention: group ? account.groupMode !== "open" : true,
-        attachments:
-          attachmentResult.attachments.length > 0
-            ? attachmentResult.attachments
-            : undefined,
-        raw: msg,
-      };
+        const text = extractWhatsAppText(msg.message);
+        const attachmentResult = await collectWhatsAppAttachments({
+          accountId: account.accountId,
+          chatId,
+          messageId,
+          message: msg.message,
+          downloadContentFromMessage: downloadContentFromMessage ?? undefined,
+          downloadMedia: account.downloadMedia === true,
+          mediaMaxBytes: account.mediaMaxBytes,
+          transcribeVoice: account.transcribeVoice === true,
+        });
+        const body = attachmentResult.transcriptionText || text;
+        if (!body.trim() && attachmentResult.attachments.length === 0) continue;
 
-      console.log(
-        `[WhatsApp:${account.accountId}] inbound chatId=${chatId} sender=${senderId} text="${preview(body)}"`,
-      );
-      await adapter.onMessage?.(inbound);
+        const senderId = identity.senderId;
+
+        const mentionedJids = extractMentionedJids(msg.message);
+        const replyParticipant = extractReplyParticipant(msg.message);
+        const groupAllowed = !group
+          ? true
+          : shouldProcessGroup({
+              account,
+              groupJid: chatId,
+              text: body,
+              mentionedJids,
+              replyParticipant,
+              selfPhoneJid,
+              selfLid,
+            });
+        if (!groupAllowed) continue;
+
+        const chatLabel = group
+          ? await getGroupLabel(chatId)
+          : selfChat
+            ? "Self (WhatsApp)"
+            : msg.pushName?.trim() || senderId;
+
+        const inbound: InboundChannelMessage = {
+          channel: CHANNEL_ID,
+          accountId: account.accountId,
+          chatId,
+          senderId,
+          senderName: msg.pushName?.trim() || senderId,
+          chatLabel,
+          text: body,
+          timestamp,
+          messageId,
+          chatType: group ? "channel" : "direct",
+          isMention: group ? account.groupMode !== "open" : true,
+          attachments:
+            attachmentResult.attachments.length > 0
+              ? attachmentResult.attachments
+              : undefined,
+          raw: msg,
+        };
+
+        console.log(
+          `[WhatsApp:${account.accountId}] inbound chatId=${chatId} sender=${senderId} text="${preview(body)}"`,
+        );
+        await adapter.onMessage?.(inbound);
+      }
+    } finally {
+      flushLidStoreIfDirty();
     }
   }
 
@@ -499,8 +523,7 @@ export function createWhatsAppAdapter(
       chatId,
       selfPhoneJid,
       selfLid,
-      lidToJid,
-      sock,
+      resolveLid: (lidJid) => lidStore.resolve(lidJid),
     });
     return await sock.sendMessage(targetJid, payload, options);
   }
@@ -520,7 +543,10 @@ export function createWhatsAppAdapter(
     },
 
     async stop() {
-      if (!running) return;
+      if (!running) {
+        flushLidStoreIfDirty();
+        return;
+      }
       stopping = true;
       running = false;
       if (reconnectTimer) {
@@ -530,6 +556,7 @@ export function createWhatsAppAdapter(
       connectionGeneration += 1;
       clearActiveSocket(true);
       setWhatsAppConnectionState(account.accountId, { status: "disconnected" });
+      flushLidStoreIfDirty();
     },
 
     isRunning() {
@@ -545,8 +572,7 @@ export function createWhatsAppAdapter(
         chatId: msg.chatId,
         selfPhoneJid,
         selfLid,
-        lidToJid,
-        sock,
+        resolveLid: (lidJid) => lidStore.resolve(lidJid),
       });
       if (msg.reaction || msg.removeReaction) {
         const target = msg.targetMessageId ?? msg.replyToMessageId;
@@ -583,8 +609,7 @@ export function createWhatsAppAdapter(
         chatId,
         selfPhoneJid,
         selfLid,
-        lidToJid,
-        sock,
+        resolveLid: (lidJid) => lidStore.resolve(lidJid),
       });
       const result = await sendToWhatsApp(
         targetJid,

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -54,16 +54,19 @@ type WhatsAppSocket = {
   groupMetadata?: (jid: string) => Promise<{ subject?: string }>;
 };
 
+type WhatsAppMessageKey = {
+  remoteJid?: string | null;
+  id?: string | null;
+  fromMe?: boolean | null;
+  participant?: string | null;
+  senderPn?: string | null;
+  senderLid?: string | null;
+  participantPn?: string | null;
+  participantLid?: string | null;
+};
+
 type WhatsAppMessage = {
-  key?: {
-    remoteJid?: string | null;
-    id?: string | null;
-    fromMe?: boolean | null;
-    participant?: string | null;
-    senderPn?: string | null;
-    participantPn?: string | null;
-    participantLid?: string | null;
-  };
+  key?: WhatsAppMessageKey;
   message?: unknown;
   messageTimestamp?: number | { toNumber?: () => number } | null;
   pushName?: string | null;
@@ -434,6 +437,7 @@ export function createWhatsAppAdapter(
             remoteJid,
             participant: msg.key?.participant,
             senderPn: msg.key?.senderPn,
+            senderLid: msg.key?.senderLid,
             participantPn: msg.key?.participantPn,
             participantLid: msg.key?.participantLid,
           },

--- a/src/channels/whatsapp/identity.test.ts
+++ b/src/channels/whatsapp/identity.test.ts
@@ -468,18 +468,4 @@ describe("resolveInboundIdentity — groups", () => {
     expect(r?.senderId).toBe("58419000020");
     expect(r?.observedMappings).toEqual([{ lidJid: lj, phoneJid: pn }]);
   });
-
-  test("later LID-only group message resolves from store, observedMappings []", () => {
-    const store = createLidStore(join(dir, "s.json"));
-    const lj = lid("77889900");
-    const pn = phone("58417000002");
-    // Simulate: adapter recorded the observation from a prior message.
-    store.record(lj, pn);
-    const r = resolveInboundIdentity(
-      { selfPhoneJid: SELF_PHONE, remoteJid: GRP, participant: lj },
-      store,
-    );
-    expect(r?.senderId).toBe("58417000002");
-    expect(r?.observedMappings).toEqual([]);
-  });
 });

--- a/src/channels/whatsapp/identity.test.ts
+++ b/src/channels/whatsapp/identity.test.ts
@@ -1,0 +1,390 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { resolveInboundIdentity } from "@/channels/whatsapp/identity";
+import {
+  WHATSAPP_GROUP_SUFFIX,
+  WHATSAPP_LID_SUFFIX,
+  WHATSAPP_PHONE_SUFFIX,
+} from "@/channels/whatsapp/jid";
+import { createLidStore } from "@/channels/whatsapp/lid-store";
+
+const P = WHATSAPP_PHONE_SUFFIX;
+const L = WHATSAPP_LID_SUFFIX;
+const G = WHATSAPP_GROUP_SUFFIX;
+const lid = (n: string) => `${n}${L}`;
+const phone = (n: string) => `${n}${P}`;
+const group = (n: string) => `${n}${G}`;
+const SELF_PHONE = phone("58412000000");
+const SELF_LID = lid("999000999");
+const GRP = group("120363");
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "identity-test-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+// -- invalid input table --
+
+const INVALID_INPUTS: Array<
+  [label: string, transport: Record<string, unknown>]
+> = [
+  [
+    "malformed senderPn",
+    {
+      selfPhoneJid: SELF_PHONE,
+      remoteJid: lid("56565656"),
+      senderPn: `garbage${P}`,
+    },
+  ],
+  [
+    "bare-digit senderPn",
+    {
+      selfPhoneJid: SELF_PHONE,
+      remoteJid: lid("26262626"),
+      senderPn: "58412222222",
+    },
+  ],
+  [
+    "malformed phone remoteJid",
+    { selfPhoneJid: SELF_PHONE, remoteJid: `garbage${P}` },
+  ],
+  [
+    "bare-digit participantPn",
+    {
+      selfPhoneJid: SELF_PHONE,
+      remoteJid: GRP,
+      participant: lid("37373737"),
+      participantPn: "58412555555",
+    },
+  ],
+  [
+    "malformed participantPn",
+    {
+      selfPhoneJid: SELF_PHONE,
+      remoteJid: GRP,
+      participant: lid("13579024"),
+      participantPn: `garbage${P}`,
+    },
+  ],
+  [
+    "malformed selfPhoneJid self-chat",
+    { selfPhoneJid: `garbage${P}`, remoteJid: `garbage${P}` },
+  ],
+  [
+    "malformed LID selfLid match",
+    {
+      selfPhoneJid: SELF_PHONE,
+      selfLid: `garbage${L}`,
+      remoteJid: `garbage${L}`,
+    },
+  ],
+  [
+    "malformed LID remoteJid vs valid selfLid",
+    { selfPhoneJid: SELF_PHONE, selfLid: SELF_LID, remoteJid: `garbage${L}` },
+  ],
+  ["null selfPhoneJid", { selfPhoneJid: null, remoteJid: lid("99998888") }],
+  ["omitted selfPhoneJid", { remoteJid: lid("99998889") }],
+];
+
+describe("resolveInboundIdentity — invalid inputs", () => {
+  for (const [label, transport] of INVALID_INPUTS) {
+    test(`${label} => null`, () => {
+      expect(resolveInboundIdentity(transport as never, null)).toBeNull();
+    });
+  }
+});
+
+// -- direct --
+
+describe("resolveInboundIdentity — direct", () => {
+  test("phone DM: canonical + observedMappings []", () => {
+    const r = resolveInboundIdentity({
+      selfPhoneJid: SELF_PHONE,
+      remoteJid: phone("58412111111"),
+    });
+    expect(r?.chatId).toBe(phone("58412111111"));
+    expect(r?.senderId).toBe("58412111111");
+    expect(r?.observedMappings).toEqual([]);
+  });
+
+  test("self-chat phone: observedMappings []", () => {
+    const r = resolveInboundIdentity({
+      selfPhoneJid: SELF_PHONE,
+      selfLid: SELF_LID,
+      remoteJid: SELF_PHONE,
+    });
+    expect(r?.chatId).toBe(SELF_PHONE);
+    expect(r?.senderId).toBe("58412000000");
+    expect(r?.observedMappings).toEqual([]);
+  });
+
+  test("self-chat LID: observedMappings []", () => {
+    const r = resolveInboundIdentity({
+      selfPhoneJid: SELF_PHONE,
+      selfLid: SELF_LID,
+      remoteJid: SELF_LID,
+    });
+    expect(r?.chatId).toBe(SELF_PHONE);
+    expect(r?.observedMappings).toEqual([]);
+  });
+
+  test("LID DM first-seen senderPn: resolves + one observation", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    const lj = lid("12345678");
+    const pn = phone("58412222222");
+    const r = resolveInboundIdentity(
+      { selfPhoneJid: SELF_PHONE, remoteJid: lj, senderPn: pn },
+      store,
+    );
+    expect(r?.chatId).toBe(pn);
+    expect(r?.senderId).toBe("58412222222");
+    expect(r?.observedMappings).toEqual([{ lidJid: lj, phoneJid: pn }]);
+    // Resolver is pure — store NOT mutated.
+    expect(store.resolve(lj)).toBeNull();
+  });
+
+  test("LID DM existing matching mapping: resolves, no observation", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    const lj = lid("87654321");
+    const pn = phone("58412333333");
+    store.record(lj, pn);
+    const r = resolveInboundIdentity(
+      { selfPhoneJid: SELF_PHONE, remoteJid: lj, senderPn: pn },
+      store,
+    );
+    expect(r?.chatId).toBe(pn);
+    expect(r?.observedMappings).toEqual([]);
+  });
+
+  test("LID DM existing conflicting mapping: null", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    const lj = lid("14141414");
+    store.record(lj, phone("58415000001"));
+    const r = resolveInboundIdentity(
+      {
+        selfPhoneJid: SELF_PHONE,
+        remoteJid: lj,
+        senderPn: phone("58415000002"),
+      },
+      store,
+    );
+    expect(r).toBeNull();
+    expect(store.resolve(lj)).toBe(phone("58415000001"));
+  });
+
+  test("LID DM unresolved: null", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    expect(
+      resolveInboundIdentity(
+        { selfPhoneJid: SELF_PHONE, remoteJid: lid("00000000") },
+        store,
+      ),
+    ).toBeNull();
+  });
+
+  test("LID DM unresolved no store: null", () => {
+    expect(
+      resolveInboundIdentity(
+        { selfPhoneJid: SELF_PHONE, remoteJid: lid("77553311") },
+        null,
+      ),
+    ).toBeNull();
+  });
+});
+
+// -- groups --
+
+describe("resolveInboundIdentity — groups", () => {
+  test("phone participant: resolved directly, observedMappings []", () => {
+    const r = resolveInboundIdentity({
+      selfPhoneJid: SELF_PHONE,
+      remoteJid: GRP,
+      participant: phone("58412444444"),
+    });
+    expect(r?.chatId).toBe(GRP);
+    expect(r?.senderId).toBe("58412444444");
+    expect(r?.observedMappings).toEqual([]);
+  });
+
+  test("LID participant + participantPn: resolves + one observation", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    const lj = lid("44556677");
+    const pn = phone("58412555555");
+    const r = resolveInboundIdentity(
+      {
+        selfPhoneJid: SELF_PHONE,
+        remoteJid: GRP,
+        participant: lj,
+        participantPn: pn,
+      },
+      store,
+    );
+    expect(r?.senderId).toBe("58412555555");
+    expect(r?.observedMappings).toEqual([{ lidJid: lj, phoneJid: pn }]);
+    expect(store.resolve(lj)).toBeNull();
+  });
+
+  test("participantLid + participantPn (no participant): resolves + one observation", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    const lj = lid("88990011");
+    const pn = phone("58412666666");
+    const r = resolveInboundIdentity(
+      {
+        selfPhoneJid: SELF_PHONE,
+        remoteJid: GRP,
+        participantPn: pn,
+        participantLid: lj,
+      },
+      store,
+    );
+    expect(r?.senderId).toBe("58412666666");
+    expect(r?.observedMappings).toEqual([{ lidJid: lj, phoneJid: pn }]);
+  });
+
+  test("LID participant in store: resolves, observedMappings []", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    const lj = lid("22334455");
+    const pj = phone("58412777777");
+    store.record(lj, pj);
+    const r = resolveInboundIdentity(
+      { selfPhoneJid: SELF_PHONE, remoteJid: GRP, participant: lj },
+      store,
+    );
+    expect(r?.senderId).toBe("58412777777");
+    expect(r?.observedMappings).toEqual([]);
+  });
+
+  test("participantLid-only store resolution: observedMappings []", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    const lj = lid("66006600");
+    const pj = phone("58416000001");
+    store.record(lj, pj);
+    const r = resolveInboundIdentity(
+      { selfPhoneJid: SELF_PHONE, remoteJid: GRP, participantLid: lj },
+      store,
+    );
+    expect(r?.senderId).toBe("58416000001");
+    expect(r?.observedMappings).toEqual([]);
+  });
+
+  test("unresolved group LID participant: null", () => {
+    expect(
+      resolveInboundIdentity({
+        selfPhoneJid: SELF_PHONE,
+        remoteJid: GRP,
+        participant: lid("00000001"),
+      }),
+    ).toBeNull();
+  });
+
+  test("group conflict: stored LID disagrees with participantPn → null", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    const lj = lid("99887766");
+    store.record(lj, phone("58418000001"));
+    const r = resolveInboundIdentity(
+      {
+        selfPhoneJid: SELF_PHONE,
+        remoteJid: GRP,
+        participant: lj,
+        participantPn: phone("58418000002"),
+      },
+      store,
+    );
+    expect(r).toBeNull();
+    expect(store.resolve(lj)).toBe(phone("58418000001"));
+  });
+
+  test("same LID with conflicting participantPn + senderPn → null (store)", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    const lj = lid("44556600");
+    const r = resolveInboundIdentity(
+      {
+        selfPhoneJid: SELF_PHONE,
+        remoteJid: GRP,
+        participant: lj,
+        participantPn: phone("58419000001"),
+        senderPn: phone("58419000002"),
+      },
+      store,
+    );
+    expect(r).toBeNull();
+    expect(store.resolve(lj)).toBeNull();
+  });
+
+  test("no-store: same LID conflicting PNs → null", () => {
+    const r = resolveInboundIdentity(
+      {
+        selfPhoneJid: SELF_PHONE,
+        remoteJid: GRP,
+        participant: lid("44556601"),
+        participantPn: phone("58419000003"),
+        senderPn: phone("58419000004"),
+      },
+      null,
+    );
+    expect(r).toBeNull();
+  });
+
+  test("first new + second conflicts with existing store → null", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    const exLid = lid("55667701");
+    store.record(exLid, phone("58419000010"));
+    const newLid = lid("55667702");
+    const newPhone = phone("58419000011");
+    // exLid + participantPn=newPhone (conflicts) ; newLid also paired
+    const r = resolveInboundIdentity(
+      {
+        selfPhoneJid: SELF_PHONE,
+        remoteJid: GRP,
+        participant: exLid,
+        participantPn: newPhone,
+        participantLid: newLid,
+      },
+      store,
+    );
+    expect(r).toBeNull();
+    expect(store.resolve(exLid)).toBe(phone("58419000010"));
+    expect(store.resolve(newLid)).toBeNull();
+  });
+
+  test("duplicate identical observations → idempotent + normal resolution", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    const lj = lid("66778800");
+    const pn = phone("58419000020");
+    // participant=LID, participantPn=PN, senderPn=PN — deduped to one observation
+    const r = resolveInboundIdentity(
+      {
+        selfPhoneJid: SELF_PHONE,
+        remoteJid: GRP,
+        participant: lj,
+        participantPn: pn,
+        senderPn: pn,
+      },
+      store,
+    );
+    expect(r?.chatId).toBe(GRP);
+    expect(r?.senderId).toBe("58419000020");
+    expect(r?.observedMappings).toEqual([{ lidJid: lj, phoneJid: pn }]);
+  });
+
+  test("later LID-only group message resolves from store, observedMappings []", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    const lj = lid("77889900");
+    const pn = phone("58417000002");
+    // Simulate: adapter recorded the observation from a prior message.
+    store.record(lj, pn);
+    const r = resolveInboundIdentity(
+      { selfPhoneJid: SELF_PHONE, remoteJid: GRP, participant: lj },
+      store,
+    );
+    expect(r?.senderId).toBe("58417000002");
+    expect(r?.observedMappings).toEqual([]);
+  });
+});

--- a/src/channels/whatsapp/identity.test.ts
+++ b/src/channels/whatsapp/identity.test.ts
@@ -140,7 +140,12 @@ describe("resolveInboundIdentity — direct", () => {
     const lj = lid("12345678");
     const pn = phone("58412222222");
     const r = resolveInboundIdentity(
-      { selfPhoneJid: SELF_PHONE, remoteJid: lj, senderPn: pn },
+      {
+        selfPhoneJid: SELF_PHONE,
+        remoteJid: lj,
+        senderPn: pn,
+        senderLid: lj,
+      },
       store,
     );
     expect(r?.chatId).toBe(pn);
@@ -148,6 +153,69 @@ describe("resolveInboundIdentity — direct", () => {
     expect(r?.observedMappings).toEqual([{ lidJid: lj, phoneJid: pn }]);
     // Resolver is pure — store NOT mutated.
     expect(store.resolve(lj)).toBeNull();
+  });
+
+  test("PN-form DM with senderLid learns mapping for later hint-less LID DM", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    const lj = lid("12344321");
+    const pn = phone("58412222223");
+
+    const first = resolveInboundIdentity(
+      {
+        selfPhoneJid: SELF_PHONE,
+        remoteJid: pn,
+        senderPn: pn,
+        senderLid: lj,
+      },
+      store,
+    );
+    expect(first?.chatId).toBe(pn);
+    expect(first?.senderId).toBe("58412222223");
+    expect(first?.observedMappings).toEqual([{ lidJid: lj, phoneJid: pn }]);
+    expect(store.resolve(lj)).toBeNull();
+
+    store.record(lj, pn);
+    const later = resolveInboundIdentity(
+      { selfPhoneJid: SELF_PHONE, remoteJid: lj },
+      store,
+    );
+    expect(later?.chatId).toBe(pn);
+    expect(later?.senderId).toBe("58412222223");
+    expect(later?.observedMappings).toEqual([]);
+  });
+
+  test("conflicting direct PN candidates reject without persistence", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    const lj = lid("24681357");
+    const r = resolveInboundIdentity(
+      {
+        selfPhoneJid: SELF_PHONE,
+        remoteJid: phone("58412222225"),
+        senderPn: phone("58412222226"),
+        senderLid: lj,
+      },
+      store,
+    );
+    expect(r).toBeNull();
+    expect(store.resolve(lj)).toBeNull();
+  });
+
+  test("invalid optional hints cannot become canonical identities or mappings", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    const pn = phone("58412222227");
+    const r = resolveInboundIdentity(
+      {
+        selfPhoneJid: SELF_PHONE,
+        remoteJid: pn,
+        senderPn: `not-a-phone${P}`,
+        senderLid: `not-a-lid${L}`,
+      },
+      store,
+    );
+    expect(r?.chatId).toBe(pn);
+    expect(r?.senderId).toBe("58412222227");
+    expect(r?.observedMappings).toEqual([]);
+    expect(store.resolve(`not-a-lid${L}`)).toBeNull();
   });
 
   test("LID DM existing matching mapping: resolves, no observation", () => {
@@ -246,6 +314,33 @@ describe("resolveInboundIdentity — groups", () => {
     );
     expect(r?.senderId).toBe("58412666666");
     expect(r?.observedMappings).toEqual([{ lidJid: lj, phoneJid: pn }]);
+  });
+
+  test("PN-form group participant with participantLid learns later LID-only sender", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    const lj = lid("88990022");
+    const pn = phone("58412666667");
+    const first = resolveInboundIdentity(
+      {
+        selfPhoneJid: SELF_PHONE,
+        remoteJid: GRP,
+        participant: pn,
+        participantLid: lj,
+      },
+      store,
+    );
+    expect(first?.chatId).toBe(GRP);
+    expect(first?.senderId).toBe("58412666667");
+    expect(first?.observedMappings).toEqual([{ lidJid: lj, phoneJid: pn }]);
+    expect(store.resolve(lj)).toBeNull();
+
+    store.record(lj, pn);
+    const later = resolveInboundIdentity(
+      { selfPhoneJid: SELF_PHONE, remoteJid: GRP, participant: lj },
+      store,
+    );
+    expect(later?.senderId).toBe("58412666667");
+    expect(later?.observedMappings).toEqual([]);
   });
 
   test("LID participant in store: resolves, observedMappings []", () => {

--- a/src/channels/whatsapp/identity.ts
+++ b/src/channels/whatsapp/identity.ts
@@ -33,7 +33,6 @@ export interface ObservedMapping {
 export interface ResolvedIdentity {
   chatId: string;
   senderId: string;
-  senderPhoneJid: string;
   observedMappings: ObservedMapping[];
 }
 
@@ -52,7 +51,6 @@ function make(
   return {
     chatId,
     senderId: normalizePhoneLike(phoneJid),
-    senderPhoneJid: phoneJid,
     observedMappings: observed,
   };
 }

--- a/src/channels/whatsapp/identity.ts
+++ b/src/channels/whatsapp/identity.ts
@@ -21,6 +21,7 @@ export interface InboundTransport {
   remoteJid: string;
   participant?: string | null;
   senderPn?: string | null;
+  senderLid?: string | null;
   participantPn?: string | null;
   participantLid?: string | null;
 }
@@ -61,65 +62,76 @@ function resolveFromStore(
 ): string | null {
   if (!store) return null;
   const mapped = store.resolve(lidJid);
-  if (mapped && isStrictPhoneJid(mapped)) return mapped;
-  return null;
+  return toStrictPhoneJid(mapped);
 }
 
 /**
- * Collect, normalize, and deduplicate supported paired LID→PN observations.
- * Reject if one LID claims multiple different PNs.
- * Compare against store; any conflict returns null.
- * Returns only observations whose LID is not already in the store.
+ * Collect role-consistent identity candidates. Direct-chat fields and
+ * group-sender fields have different semantics, so they must not be mixed.
  */
-function collectObservations(
+function collectCandidates(
   transport: InboundTransport,
+  direct: boolean,
+): { lids: string[]; phones: string[] } {
+  const lids: string[] = [];
+  const phones: string[] = [];
+  const addLid = (candidate: string | null | undefined) => {
+    if (candidate && isStrictLidJid(candidate)) {
+      const normalized = stripDeviceSuffix(candidate);
+      if (!lids.includes(normalized)) lids.push(normalized);
+    }
+  };
+  const addPhone = (candidate: string | null | undefined) => {
+    const normalized = toStrictPhoneJid(candidate);
+    if (normalized && !phones.includes(normalized)) phones.push(normalized);
+  };
+
+  if (direct) {
+    addLid(transport.remoteJid);
+    addLid(transport.senderLid);
+    addPhone(transport.remoteJid);
+    addPhone(transport.senderPn);
+  } else {
+    addLid(transport.participant);
+    addLid(transport.participantLid);
+    addLid(transport.senderLid);
+    addPhone(transport.participant);
+    addPhone(transport.participantPn);
+    addPhone(transport.senderPn);
+  }
+
+  return { lids, phones };
+}
+
+/**
+ * Validate the observed candidates against one canonical phone identity.
+ * Returns only previously-unmapped LIDs; it never mutates the store.
+ */
+function resolveCandidates(
+  lids: string[],
+  phones: string[],
   store: LidStore | null,
-): ObservedMapping[] | null {
-  const { participant, participantPn, participantLid, senderPn } = transport;
-  const validPnP = toStrictPhoneJid(participantPn);
-  const validSenderPn = toStrictPhoneJid(senderPn);
+): { phoneJid: string; observedMappings: ObservedMapping[] } | null {
+  if (phones.length > 1) return null;
 
-  const rawPairs: Array<[string, string]> = [];
-  if (participant && isStrictLidJid(participant)) {
-    if (validPnP) rawPairs.push([participant, validPnP]);
-    if (validSenderPn) rawPairs.push([participant, validSenderPn]);
+  let phoneJid = phones[0] ?? null;
+  const storedMappings = new Map<string, string>();
+  for (const lidJid of lids) {
+    const stored = resolveFromStore(lidJid, store);
+    if (!stored) continue;
+    storedMappings.set(lidJid, stored);
+    if (phoneJid && phoneJid !== stored) return null;
+    phoneJid ??= stored;
   }
-  if (participantLid && isStrictLidJid(participantLid)) {
-    if (validPnP) rawPairs.push([participantLid, validPnP]);
-  }
+  if (!phoneJid) return null;
 
-  if (rawPairs.length === 0) return [];
-
-  const normalized = new Map<string, Set<string>>();
-  for (const [lidJid, phoneJid] of rawPairs) {
-    const key = stripDeviceSuffix(lidJid);
-    let phoneSet = normalized.get(key);
-    if (!phoneSet) {
-      phoneSet = new Set<string>();
-      normalized.set(key, phoneSet);
+  const observedMappings: ObservedMapping[] = [];
+  for (const lidJid of lids) {
+    if (!storedMappings.has(lidJid)) {
+      observedMappings.push({ lidJid, phoneJid });
     }
-    phoneSet.add(phoneJid);
   }
-
-  // Reject if any LID maps to multiple different phones.
-  for (const phones of normalized.values()) {
-    if (phones.size > 1) return null;
-  }
-
-  const result: ObservedMapping[] = [];
-  for (const [key, phones] of normalized) {
-    const phoneValue = phones.values().next().value as string;
-    // Check against store: conflict => reject entirely.
-    if (store) {
-      const existing = store.resolve(key);
-      if (existing && existing !== phoneValue) return null;
-      // Already mapped — no observation needed.
-      if (existing) continue;
-    }
-    result.push({ lidJid: key, phoneJid: phoneValue });
-  }
-
-  return result;
+  return { phoneJid, observedMappings };
 }
 
 // -- resolver --;
@@ -138,7 +150,7 @@ function resolveDirect(
   transport: InboundTransport,
   store: LidStore | null,
 ): ResolvedIdentity | null {
-  const { selfPhoneJid, selfLid, remoteJid, senderPn } = transport;
+  const { selfPhoneJid, selfLid, remoteJid } = transport;
 
   // Self-chat: phone-to-phone.
   if (
@@ -161,59 +173,20 @@ function resolveDirect(
     return make(c, c);
   }
 
-  // Phone remoteJid.
-  if (isStrictPhoneJid(remoteJid)) {
-    const c = stripDeviceSuffix(remoteJid);
-    return make(c, c);
-  }
-
-  // LID remoteJid.
-  if (!isStrictLidJid(remoteJid)) return null;
-
-  const validHint = toStrictPhoneJid(senderPn);
-  const stored = resolveFromStore(remoteJid, store);
-
-  // Existing conflicting mapping → fail closed.
-  if (stored && validHint && validHint !== stored) return null;
-
-  // Existing matching mapping → resolve as stored, no observation.
-  if (stored) return make(stored, stored);
-
-  // First-seen hint → resolve as hint, return observation.
-  if (validHint) {
-    return make(validHint, validHint, [
-      { lidJid: stripDeviceSuffix(remoteJid), phoneJid: validHint },
-    ]);
-  }
-
-  return null;
+  const candidates = collectCandidates(transport, true);
+  const resolved = resolveCandidates(candidates.lids, candidates.phones, store);
+  if (!resolved) return null;
+  return make(resolved.phoneJid, resolved.phoneJid, resolved.observedMappings);
 }
 
 function resolveGroup(
   transport: InboundTransport,
   store: LidStore | null,
 ): ResolvedIdentity | null {
-  const { remoteJid, participant, senderPn, participantPn, participantLid } =
-    transport;
+  const { remoteJid } = transport;
   const groupChatId = stripDeviceSuffix(remoteJid);
-
-  // Collect observations (also validates internal consistency + store conflicts).
-  const observations = collectObservations(transport, store);
-  if (observations === null) return null;
-
-  // Phase 1: direct phone-form candidates.
-  for (const candidate of [participant, participantPn, senderPn]) {
-    const canonical = toStrictPhoneJid(candidate);
-    if (canonical) return make(groupChatId, canonical, observations);
-  }
-
-  // Phase 2: store lookup on LID participants.
-  for (const lidCandidate of [participant, participantLid]) {
-    if (lidCandidate && isStrictLidJid(lidCandidate)) {
-      const phoneJid = resolveFromStore(lidCandidate, store);
-      if (phoneJid) return make(groupChatId, phoneJid, observations);
-    }
-  }
-
-  return null;
+  const candidates = collectCandidates(transport, false);
+  const resolved = resolveCandidates(candidates.lids, candidates.phones, store);
+  if (!resolved) return null;
+  return make(groupChatId, resolved.phoneJid, resolved.observedMappings);
 }

--- a/src/channels/whatsapp/identity.ts
+++ b/src/channels/whatsapp/identity.ts
@@ -1,0 +1,221 @@
+/**
+ * Canonical WhatsApp inbound identity resolver.
+ *
+ * Pure with respect to LidStore: only calls `store.resolve()`, never
+ * `record()` or `flush()`. Returns validated `observedMappings` that the
+ * caller may persist.
+ */
+
+import {
+  isGroupJid,
+  isStrictLidJid,
+  isStrictPhoneJid,
+  normalizePhoneLike,
+  stripDeviceSuffix,
+} from "@/channels/whatsapp/jid";
+import type { LidStore } from "@/channels/whatsapp/lid-store";
+
+export interface InboundTransport {
+  selfPhoneJid?: string | null;
+  selfLid?: string | null;
+  remoteJid: string;
+  participant?: string | null;
+  senderPn?: string | null;
+  participantPn?: string | null;
+  participantLid?: string | null;
+}
+
+export interface ObservedMapping {
+  lidJid: string;
+  phoneJid: string;
+}
+
+export interface ResolvedIdentity {
+  chatId: string;
+  senderId: string;
+  senderPhoneJid: string;
+  observedMappings: ObservedMapping[];
+}
+
+// -- helpers --;
+
+function toStrictPhoneJid(candidate: string | null | undefined): string | null {
+  if (!candidate || !isStrictPhoneJid(candidate)) return null;
+  return stripDeviceSuffix(candidate);
+}
+
+function make(
+  chatId: string,
+  phoneJid: string,
+  observed: ObservedMapping[] = [],
+): ResolvedIdentity {
+  return {
+    chatId,
+    senderId: normalizePhoneLike(phoneJid),
+    senderPhoneJid: phoneJid,
+    observedMappings: observed,
+  };
+}
+
+function resolveFromStore(
+  lidJid: string,
+  store: LidStore | null,
+): string | null {
+  if (!store) return null;
+  const mapped = store.resolve(lidJid);
+  if (mapped && isStrictPhoneJid(mapped)) return mapped;
+  return null;
+}
+
+/**
+ * Collect, normalize, and deduplicate supported paired LID→PN observations.
+ * Reject if one LID claims multiple different PNs.
+ * Compare against store; any conflict returns null.
+ * Returns only observations whose LID is not already in the store.
+ */
+function collectObservations(
+  transport: InboundTransport,
+  store: LidStore | null,
+): ObservedMapping[] | null {
+  const { participant, participantPn, participantLid, senderPn } = transport;
+  const validPnP = toStrictPhoneJid(participantPn);
+  const validSenderPn = toStrictPhoneJid(senderPn);
+
+  const rawPairs: Array<[string, string]> = [];
+  if (participant && isStrictLidJid(participant)) {
+    if (validPnP) rawPairs.push([participant, validPnP]);
+    if (validSenderPn) rawPairs.push([participant, validSenderPn]);
+  }
+  if (participantLid && isStrictLidJid(participantLid)) {
+    if (validPnP) rawPairs.push([participantLid, validPnP]);
+  }
+
+  if (rawPairs.length === 0) return [];
+
+  const normalized = new Map<string, Set<string>>();
+  for (const [lidJid, phoneJid] of rawPairs) {
+    const key = stripDeviceSuffix(lidJid);
+    let phoneSet = normalized.get(key);
+    if (!phoneSet) {
+      phoneSet = new Set<string>();
+      normalized.set(key, phoneSet);
+    }
+    phoneSet.add(phoneJid);
+  }
+
+  // Reject if any LID maps to multiple different phones.
+  for (const phones of normalized.values()) {
+    if (phones.size > 1) return null;
+  }
+
+  const result: ObservedMapping[] = [];
+  for (const [key, phones] of normalized) {
+    const phoneValue = phones.values().next().value as string;
+    // Check against store: conflict => reject entirely.
+    if (store) {
+      const existing = store.resolve(key);
+      if (existing && existing !== phoneValue) return null;
+      // Already mapped — no observation needed.
+      if (existing) continue;
+    }
+    result.push({ lidJid: key, phoneJid: phoneValue });
+  }
+
+  return result;
+}
+
+// -- resolver --;
+
+export function resolveInboundIdentity(
+  transport: InboundTransport,
+  store: LidStore | null = null,
+): ResolvedIdentity | null {
+  const { remoteJid } = transport;
+
+  if (!isGroupJid(remoteJid)) return resolveDirect(transport, store);
+  return resolveGroup(transport, store);
+}
+
+function resolveDirect(
+  transport: InboundTransport,
+  store: LidStore | null,
+): ResolvedIdentity | null {
+  const { selfPhoneJid, selfLid, remoteJid, senderPn } = transport;
+
+  // Self-chat: phone-to-phone.
+  if (
+    isStrictPhoneJid(remoteJid) &&
+    isStrictPhoneJid(selfPhoneJid) &&
+    stripDeviceSuffix(remoteJid) === stripDeviceSuffix(selfPhoneJid)
+  ) {
+    const c = stripDeviceSuffix(selfPhoneJid);
+    return make(c, c);
+  }
+
+  // Self-chat: LID-to-LID.
+  if (
+    isStrictLidJid(remoteJid) &&
+    isStrictLidJid(selfLid) &&
+    stripDeviceSuffix(remoteJid) === stripDeviceSuffix(selfLid) &&
+    isStrictPhoneJid(selfPhoneJid)
+  ) {
+    const c = stripDeviceSuffix(selfPhoneJid);
+    return make(c, c);
+  }
+
+  // Phone remoteJid.
+  if (isStrictPhoneJid(remoteJid)) {
+    const c = stripDeviceSuffix(remoteJid);
+    return make(c, c);
+  }
+
+  // LID remoteJid.
+  if (!isStrictLidJid(remoteJid)) return null;
+
+  const validHint = toStrictPhoneJid(senderPn);
+  const stored = resolveFromStore(remoteJid, store);
+
+  // Existing conflicting mapping → fail closed.
+  if (stored && validHint && validHint !== stored) return null;
+
+  // Existing matching mapping → resolve as stored, no observation.
+  if (stored) return make(stored, stored);
+
+  // First-seen hint → resolve as hint, return observation.
+  if (validHint) {
+    return make(validHint, validHint, [
+      { lidJid: stripDeviceSuffix(remoteJid), phoneJid: validHint },
+    ]);
+  }
+
+  return null;
+}
+
+function resolveGroup(
+  transport: InboundTransport,
+  store: LidStore | null,
+): ResolvedIdentity | null {
+  const { remoteJid, participant, senderPn, participantPn, participantLid } =
+    transport;
+  const groupChatId = stripDeviceSuffix(remoteJid);
+
+  // Collect observations (also validates internal consistency + store conflicts).
+  const observations = collectObservations(transport, store);
+  if (observations === null) return null;
+
+  // Phase 1: direct phone-form candidates.
+  for (const candidate of [participant, participantPn, senderPn]) {
+    const canonical = toStrictPhoneJid(candidate);
+    if (canonical) return make(groupChatId, canonical, observations);
+  }
+
+  // Phase 2: store lookup on LID participants.
+  for (const lidCandidate of [participant, participantLid]) {
+    if (lidCandidate && isStrictLidJid(lidCandidate)) {
+      const phoneJid = resolveFromStore(lidCandidate, store);
+      if (phoneJid) return make(groupChatId, phoneJid, observations);
+    }
+  }
+
+  return null;
+}

--- a/src/channels/whatsapp/jid.test.ts
+++ b/src/channels/whatsapp/jid.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isStrictLidJid,
+  isStrictPhoneJid,
+  stripDeviceSuffix,
+  WHATSAPP_LID_SUFFIX,
+  WHATSAPP_PHONE_SUFFIX,
+} from "@/channels/whatsapp/jid";
+
+const P = WHATSAPP_PHONE_SUFFIX;
+const L = WHATSAPP_LID_SUFFIX;
+
+describe("isStrictPhoneJid", () => {
+  test("valid phone JID", () => {
+    expect(isStrictPhoneJid(`58414111111${P}`)).toBe(true);
+  });
+
+  test("valid phone JID with device suffix", () => {
+    expect(isStrictPhoneJid(`58414111111:5${P}`)).toBe(true);
+  });
+
+  test("rejects non-numeric localpart", () => {
+    expect(isStrictPhoneJid(`garbage${P}`)).toBe(false);
+  });
+
+  test("rejects LID JID", () => {
+    expect(isStrictPhoneJid(`123456${L}`)).toBe(false);
+  });
+
+  test("rejects bare digits", () => {
+    expect(isStrictPhoneJid("58414111111")).toBe(false);
+  });
+
+  test("rejects empty/null/undefined", () => {
+    expect(isStrictPhoneJid("")).toBe(false);
+    expect(isStrictPhoneJid(null)).toBe(false);
+    expect(isStrictPhoneJid(undefined)).toBe(false);
+  });
+});
+
+describe("isStrictLidJid", () => {
+  test("valid LID JID", () => {
+    expect(isStrictLidJid(`123456789${L}`)).toBe(true);
+  });
+
+  test("valid LID JID with device suffix", () => {
+    expect(isStrictLidJid(`123456789:3${L}`)).toBe(true);
+  });
+
+  test("rejects non-numeric localpart", () => {
+    expect(isStrictLidJid(`garbage${L}`)).toBe(false);
+  });
+
+  test("rejects phone JID", () => {
+    expect(isStrictLidJid(`58414111111${P}`)).toBe(false);
+  });
+
+  test("rejects empty/null/undefined", () => {
+    expect(isStrictLidJid("")).toBe(false);
+    expect(isStrictLidJid(null)).toBe(false);
+  });
+});
+
+describe("stripDeviceSuffix", () => {
+  test("strips :N from phone JID", () => {
+    expect(stripDeviceSuffix(`58414${P}`)).toBe(`58414${P}`);
+    expect(stripDeviceSuffix(`58414:5${P}`)).toBe(`58414${P}`);
+  });
+
+  test("strips :N from LID JID", () => {
+    expect(stripDeviceSuffix(`123:7${L}`)).toBe(`123${L}`);
+  });
+
+  test("empty/null", () => {
+    expect(stripDeviceSuffix("")).toBe("");
+    expect(stripDeviceSuffix(null)).toBe("");
+  });
+});

--- a/src/channels/whatsapp/jid.test.ts
+++ b/src/channels/whatsapp/jid.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, test } from "bun:test";
 import {
   isStrictLidJid,
   isStrictPhoneJid,
-  stripDeviceSuffix,
   WHATSAPP_LID_SUFFIX,
   WHATSAPP_PHONE_SUFFIX,
 } from "@/channels/whatsapp/jid";
@@ -59,21 +58,5 @@ describe("isStrictLidJid", () => {
   test("rejects empty/null/undefined", () => {
     expect(isStrictLidJid("")).toBe(false);
     expect(isStrictLidJid(null)).toBe(false);
-  });
-});
-
-describe("stripDeviceSuffix", () => {
-  test("strips :N from phone JID", () => {
-    expect(stripDeviceSuffix(`58414${P}`)).toBe(`58414${P}`);
-    expect(stripDeviceSuffix(`58414:5${P}`)).toBe(`58414${P}`);
-  });
-
-  test("strips :N from LID JID", () => {
-    expect(stripDeviceSuffix(`123:7${L}`)).toBe(`123${L}`);
-  });
-
-  test("empty/null", () => {
-    expect(stripDeviceSuffix("")).toBe("");
-    expect(stripDeviceSuffix(null)).toBe("");
   });
 });

--- a/src/channels/whatsapp/jid.ts
+++ b/src/channels/whatsapp/jid.ts
@@ -20,6 +20,36 @@ export function isGroupJid(jid: string | null | undefined): boolean {
   return !!jid && stripDeviceSuffix(jid).endsWith(WHATSAPP_GROUP_SUFFIX);
 }
 
+/**
+ * Strict phone-JID check: suffix must be `@s.whatsapp.net` AND the localpart
+ * (before `@`) must be all digits (device suffix `:N` allowed and stripped).
+ *
+ * Use this instead of {@link isPhoneJid} when accepting external/untrusted
+ * input that could carry a non-numeric localpart (e.g. `garbage@s.whatsapp.net`).
+ */
+export function isStrictPhoneJid(jid: string | null | undefined): boolean {
+  if (!jid) return false;
+  const normalized = stripDeviceSuffix(jid);
+  if (!normalized.endsWith(WHATSAPP_PHONE_SUFFIX)) return false;
+  const localpart = normalized.slice(0, -WHATSAPP_PHONE_SUFFIX.length);
+  return localpart.length > 0 && /^\d+$/.test(localpart);
+}
+
+/**
+ * Strict LID-JID check: suffix must be `@lid` AND the localpart must be all
+ * digits (device suffix `:N` allowed and stripped).
+ *
+ * Use this instead of {@link isLidJid} when accepting external/untrusted
+ * input that could carry a non-numeric localpart.
+ */
+export function isStrictLidJid(jid: string | null | undefined): boolean {
+  if (!jid) return false;
+  const normalized = stripDeviceSuffix(jid);
+  if (!normalized.endsWith(WHATSAPP_LID_SUFFIX)) return false;
+  const localpart = normalized.slice(0, -WHATSAPP_LID_SUFFIX.length);
+  return localpart.length > 0 && /^\d+$/.test(localpart);
+}
+
 export function isStatusOrBroadcastJid(
   jid: string | null | undefined,
 ): boolean {

--- a/src/channels/whatsapp/jid.ts
+++ b/src/channels/whatsapp/jid.ts
@@ -117,39 +117,13 @@ export function allowedUsersIncludes(
   );
 }
 
-export function resolveLidToPhoneJid(params: {
-  lidJid: string;
-  message?: unknown;
-  sock?: unknown;
-}): string | null {
-  const { lidJid, message, sock } = params;
-  if (!isLidJid(lidJid)) return normalizeMaybePhoneJid(lidJid);
-
-  const msg = message as { key?: { senderPn?: string | null } } | undefined;
-  const senderPn = normalizeMaybePhoneJid(msg?.key?.senderPn ?? undefined);
-  if (senderPn) return senderPn;
-
-  const repo = (
-    sock as
-      | { signalRepository?: { lidMapping?: Map<string, string> } }
-      | undefined
-  )?.signalRepository;
-  const mapped = normalizeMaybePhoneJid(
-    repo?.lidMapping?.get(stripDeviceSuffix(lidJid)),
-  );
-  if (mapped) return mapped;
-
-  return null;
-}
-
 export function resolveSendJid(params: {
   chatId: string;
   selfPhoneJid?: string | null;
   selfLid?: string | null;
-  lidToJid?: Map<string, string>;
-  sock?: unknown;
+  resolveLid?: (lidJid: string) => string | null;
 }): string {
-  const { chatId, selfPhoneJid, selfLid, lidToJid, sock } = params;
+  const { chatId, selfPhoneJid, selfLid, resolveLid } = params;
   if (!isLidJid(chatId)) return stripDeviceSuffix(chatId);
 
   const normalized = stripDeviceSuffix(chatId);
@@ -157,18 +131,10 @@ export function resolveSendJid(params: {
     return stripDeviceSuffix(selfPhoneJid);
   }
 
-  const mapped = normalizeMaybePhoneJid(lidToJid?.get(normalized));
-  if (mapped) return mapped;
-
-  const repo = (
-    sock as
-      | { signalRepository?: { lidMapping?: Map<string, string> } }
-      | undefined
-  )?.signalRepository;
-  const signalMapped = normalizeMaybePhoneJid(
-    repo?.lidMapping?.get(normalized),
-  );
-  if (signalMapped) return signalMapped;
+  const mapped = resolveLid?.(normalized);
+  if (mapped && isStrictPhoneJid(mapped)) {
+    return stripDeviceSuffix(mapped);
+  }
 
   throw new Error(`Cannot send to unresolved WhatsApp LID: ${chatId}`);
 }

--- a/src/channels/whatsapp/lid-store.test.ts
+++ b/src/channels/whatsapp/lid-store.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  WHATSAPP_GROUP_SUFFIX,
+  WHATSAPP_LID_SUFFIX,
+  WHATSAPP_PHONE_SUFFIX,
+} from "@/channels/whatsapp/jid";
+import { createLidStore } from "@/channels/whatsapp/lid-store";
+
+const L = WHATSAPP_LID_SUFFIX;
+const P = WHATSAPP_PHONE_SUFFIX;
+const G = WHATSAPP_GROUP_SUFFIX;
+const lid = (n: string) => `${n}${L}`;
+const phone = (n: string) => `${n}${P}`;
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "lid-store-test-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const STORE_INVALID_INPUTS: Array<
+  [label: string, key: unknown, value: unknown]
+> = [
+  ["phone JID as key", phone("58414444444"), phone("58414111111")],
+  ["random string key", "not-a-jid", phone("58414111111")],
+  ["empty key", "", phone("58414111111")],
+  ["LID as value", lid("111222333"), lid("999888777")],
+  ["garbage value", lid("111222333"), "garbage"],
+  ["empty value", lid("111222333"), ""],
+  ["bare digits value", lid("16161616"), "58414111111"],
+  ["garbage localpart key", `garbage${L}`, phone("58414111111")],
+  ["group JID as key", `123${G}`, phone("58414111111")],
+  ["garbage localpart value", lid("222333444"), `garbage${P}`],
+  ["group JID as value", lid("222333444"), `123${G}`],
+];
+
+describe("lid-store", () => {
+  test("round-trip: record → resolve", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    expect(store.record(lid("123456789"), phone("58414111111"))).toEqual({
+      status: "recorded",
+    });
+    expect(store.resolve(lid("123456789"))).toBe(phone("58414111111"));
+  });
+
+  test("device suffix normalization (key + value)", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    store.record("123456789:5@lid", "58414222222:3@s.whatsapp.net");
+    expect(store.resolve("123456789@lid")).toBe(phone("58414222222"));
+    expect(store.resolve("123456789:7@lid")).toBe(phone("58414222222"));
+  });
+
+  test("invalid inputs rejected", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    for (const [label, key, value] of STORE_INVALID_INPUTS) {
+      expect(store.record(key as string, value as string), label).toBeNull();
+    }
+  });
+
+  test("idempotent: same mapping twice", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    const lj = lid("555666777");
+    const pj = phone("58414555555");
+    expect(store.record(lj, pj)).toEqual({ status: "recorded" });
+    expect(store.record(lj, pj)).toEqual({ status: "idempotent" });
+  });
+
+  test("conflict: old mapping preserved", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    const lj = lid("333444555");
+    store.record(lj, phone("58414666666"));
+    expect(store.record(lj, phone("58414777777"))).toEqual({
+      status: "conflict",
+      existingPhoneJid: phone("58414666666"),
+      requestedPhoneJid: phone("58414777777"),
+    });
+    expect(store.resolve(lj)).toBe(phone("58414666666"));
+  });
+
+  test("multiple LIDs → same phone", () => {
+    const store = createLidStore(join(dir, "s.json"));
+    const shared = phone("58414888888");
+    store.record(lid("100100100"), shared);
+    store.record(lid("200200200"), shared);
+    expect(store.resolve(lid("100100100"))).toBe(shared);
+    expect(store.resolve(lid("200200200"))).toBe(shared);
+  });
+
+  test("corrupt JSON safe startup", () => {
+    const fp = join(dir, "corrupt.json");
+    writeFileSync(fp, "{ invalid json :::", "utf8");
+    const store = createLidStore(fp);
+    store.record(lid("123"), phone("58414999999"));
+    expect(store.resolve(lid("123"))).toBe(phone("58414999999"));
+  });
+
+  test("invalid persisted entries ignored on load", () => {
+    const fp = join(dir, "mixed.json");
+    const vl = lid("777888999");
+    const vp = phone("58414000001");
+    writeFileSync(
+      fp,
+      JSON.stringify({
+        entries: [
+          { lid: vl, phone: vp },
+          { lid: phone("58414000002"), phone: vp },
+          { lid: vl, phone: lid("111222333") },
+          { lid: "not-a-jid", phone: vp },
+          { lid: lid("444555666"), phone: "garbage" },
+        ],
+      }),
+      "utf8",
+    );
+    const store = createLidStore(fp);
+    expect(store.resolve(vl)).toBe(vp);
+    expect(store.resolve(lid("444555666"))).toBeNull();
+  });
+
+  test("legacy object-map format not parsed", () => {
+    const fp = join(dir, "legacy.json");
+    const vl = lid("888999000");
+    writeFileSync(fp, JSON.stringify({ [vl]: phone("58414000020") }), "utf8");
+    expect(createLidStore(fp).resolve(vl)).toBeNull();
+  });
+
+  test("duplicate LID with conflicting phones omitted on load", () => {
+    const fp = join(dir, "cd.json");
+    const dl = lid("666777888");
+    const kl = lid("111222333");
+    writeFileSync(
+      fp,
+      JSON.stringify({
+        entries: [
+          { lid: dl, phone: phone("58414000030") },
+          { lid: kl, phone: phone("58414000032") },
+          { lid: dl, phone: phone("58414000031") },
+        ],
+      }),
+      "utf8",
+    );
+    const store = createLidStore(fp);
+    expect(store.resolve(dl)).toBeNull();
+    expect(store.resolve(kl)).toBe(phone("58414000032"));
+  });
+
+  test("duplicate identical entries keep one mapping on load", () => {
+    const fp = join(dir, "id.json");
+    const dl = lid("555666777");
+    const pj = phone("58414000040");
+    writeFileSync(
+      fp,
+      JSON.stringify({
+        entries: [
+          { lid: dl, phone: pj },
+          { lid: dl, phone: pj },
+        ],
+      }),
+      "utf8",
+    );
+    expect(createLidStore(fp).resolve(dl)).toBe(pj);
+  });
+
+  test("atomic flush writes valid JSON + reloads", () => {
+    const fp = join(dir, "atomic.json");
+    const store = createLidStore(fp);
+    store.record(lid("121212121"), phone("58414000003"));
+    store.record(lid("343434343"), phone("58414000004"));
+    store.flush();
+
+    expect(existsSync(fp)).toBe(true);
+    expect(JSON.parse(readFileSync(fp, "utf8")).entries).toHaveLength(2);
+
+    const reloaded = createLidStore(fp);
+    expect(reloaded.resolve(lid("121212121"))).toBe(phone("58414000003"));
+    expect(reloaded.resolve(lid("343434343"))).toBe(phone("58414000004"));
+  });
+
+  test("flush leaves no temp files", () => {
+    const fp = join(dir, "clean.json");
+    createLidStore(fp).flush();
+    const files = readdirSync(dir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toBe("clean.json");
+  });
+
+  test("relative path rejected", () => {
+    expect(() => createLidStore("relative/path.json")).toThrow("absolute path");
+  });
+});

--- a/src/channels/whatsapp/lid-store.ts
+++ b/src/channels/whatsapp/lid-store.ts
@@ -1,0 +1,202 @@
+/**
+ * Narrow persistent store: LID JID → phone JID.
+ *
+ * Invariants:
+ *   - Only strict-valid LID keys and strict-valid phone-JID values are accepted.
+ *   - Device suffixes are normalised on both keys and values.
+ *   - An existing mapping is never silently rebound. A conflicting `record()`
+ *     returns `{ status: "conflict" }` and preserves the old mapping.
+ *   - Multiple distinct LIDs may map to the same phone JID.
+ *   - Corrupt or invalid persisted entries are silently skipped.
+ *   - On load, if the same normalized LID appears with different phone JIDs,
+ *     that LID is omitted entirely (ambiguous data, not first-wins).
+ *
+ * Persistence:
+ *   - Construction loads once from disk. There is no public reload.
+ *   - `record()` mutates in-memory state only; it does NOT persist.
+ *   - `flush()` is caller-owned and writes atomically via an exclusive temp
+ *     file + rename. The caller is responsible for single-writer ownership;
+ *     no locking is provided.
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute } from "node:path";
+
+import {
+  isStrictLidJid,
+  isStrictPhoneJid,
+  stripDeviceSuffix,
+} from "@/channels/whatsapp/jid";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type RecordResult =
+  | { status: "recorded" }
+  | { status: "idempotent" }
+  | { status: "conflict"; existingPhoneJid: string; requestedPhoneJid: string };
+
+export interface LidStore {
+  /** Resolve a LID JID to its canonical phone JID, or `null` if unknown. */
+  resolve(lidJid: string): string | null;
+  /**
+   * Record a LID → phone mapping (in-memory only; does not persist).
+   *
+   * Returns `null` when either argument is invalid.
+   * Returns `"conflict"` when the LID is already mapped to a different phone;
+   * the old mapping is preserved.
+   */
+  record(lidJid: string, phoneJid: string): RecordResult | null;
+  /** Flush in-memory state to disk atomically. Caller-owned, single-writer. */
+  flush(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Persistence helpers
+// ---------------------------------------------------------------------------
+
+type StoreEntry = { lid: string; phone: string };
+
+function parseStoreFile(filePath: string): Map<string, string> {
+  let rawText: string;
+  try {
+    rawText = readFileSync(filePath, "utf8");
+  } catch {
+    return new Map();
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawText);
+  } catch {
+    return new Map();
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return new Map();
+  }
+
+  const obj = parsed as { entries?: unknown };
+  if (!Array.isArray(obj.entries)) return new Map();
+
+  // First pass: collect all normalized pairs per LID key.
+  const collected = new Map<string, Set<string>>();
+  for (const entry of obj.entries) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as { lid?: unknown; phone?: unknown };
+    if (
+      typeof e.lid !== "string" ||
+      typeof e.phone !== "string" ||
+      !isStrictLidJid(e.lid) ||
+      !isStrictPhoneJid(e.phone)
+    ) {
+      continue;
+    }
+    const key = stripDeviceSuffix(e.lid);
+    const value = stripDeviceSuffix(e.phone);
+    let phoneSet = collected.get(key);
+    if (!phoneSet) {
+      phoneSet = new Set<string>();
+      collected.set(key, phoneSet);
+    }
+    phoneSet.add(value);
+  }
+
+  // Second pass: keep only unambiguous LIDs (exactly one phone mapping).
+  const result = new Map<string, string>();
+  for (const [key, phones] of collected) {
+    if (phones.size === 1) {
+      result.set(key, phones.values().next().value as string);
+    }
+  }
+  return result;
+}
+
+function serializeStore(map: Map<string, string>): string {
+  const entries: StoreEntry[] = [];
+  for (const [lid, phone] of map) {
+    entries.push({ lid, phone });
+  }
+  return JSON.stringify({ entries }, null, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createLidStore(filePath: string): LidStore {
+  if (!isAbsolute(filePath)) {
+    throw new Error(
+      `createLidStore requires an absolute path, got: ${filePath}`,
+    );
+  }
+
+  const map = parseStoreFile(filePath);
+
+  return {
+    resolve(lidJid: string): string | null {
+      if (!isStrictLidJid(lidJid)) return null;
+      return map.get(stripDeviceSuffix(lidJid)) ?? null;
+    },
+
+    record(lidJid: string, phoneJid: string): RecordResult | null {
+      if (!isStrictLidJid(lidJid)) return null;
+      if (!isStrictPhoneJid(phoneJid)) return null;
+
+      const key = stripDeviceSuffix(lidJid);
+      const value = stripDeviceSuffix(phoneJid);
+
+      const existing = map.get(key);
+      if (existing) {
+        if (existing === value) return { status: "idempotent" };
+        return {
+          status: "conflict",
+          existingPhoneJid: existing,
+          requestedPhoneJid: value,
+        };
+      }
+
+      map.set(key, value);
+      return { status: "recorded" };
+    },
+
+    flush(): void {
+      const data = serializeStore(map);
+      const dir = dirname(filePath);
+      mkdirSync(dir, { recursive: true });
+
+      const tmpPath = `${filePath}.${randomUUID()}.tmp`;
+      let fd: number | null = null;
+      try {
+        fd = openSync(tmpPath, "wx", 0o600);
+        writeFileSync(fd, data, "utf8");
+        closeSync(fd);
+        fd = null;
+        renameSync(tmpPath, filePath);
+      } finally {
+        if (fd !== null) {
+          try {
+            closeSync(fd);
+          } catch {
+            // already closed or error during close
+          }
+        }
+        try {
+          unlinkSync(tmpPath);
+        } catch {
+          // temp file may not exist after successful rename
+        }
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds strict WhatsApp PN/LID validation plus a persistent per-account LID to phone-JID store written under the WhatsApp auth directory.
- Routes inbound WhatsApp messages through canonical identity resolution before access control, pairing, route lookup, and dedupe, including direct LID DMs, PN-form messages carrying `senderLid`, and group sender evidence from `participantPn` / `participantLid`.
- Resolves outbound sends and direct replies for known LID chats through the stored mapping, while failing closed for unknown, malformed, or conflicting LID identity evidence.

## Context
Current main can see Baileys LID traffic but still lets group senders and some route/pairing paths use LID digits instead of the canonical phone identity. Example proof run from this branch:

```text
origin/main group LID+PN senderId=44445555 from senderJid=44445555@lid
branch group LID+PN senderId=15550000006 chatId=120363@g.us
```

This is the clean identity-only replacement for the canonical LID subset of #3395. It intentionally does not introduce attachment policy, read receipt, typing, debounce, prefix, reconnect, or reaction changes.

## Validation
- `bun test ./src/channels/whatsapp*.test.ts ./src/channels/whatsapp/*.test.ts` → 104 pass, 0 fail
- `bun run check` → 12 checks passed
- Diff scope scan: no excluded feature terms in added diff
- Confidentiality scan: no raw secret markers or private coordination terms in added lines

## Claim audit and limits
- Covered behavior: strict identity parsing, direct and group LID canonicalization, stored LID recovery across restart, conflict rejection, canonical dedupe, pairing/allowlist/route convergence, and outbound known-LID resolution.
- Intentional limit: unresolved LID traffic is dropped until Baileys supplies phone evidence or a prior safe mapping exists.
- Intentional limit: old or corrupt `lid-mappings.json` content is skipped rather than migrated from arbitrary formats.
- Not live-device tested against WhatsApp; validation is through source-grounded unit and registry integration tests.

## Risk and rollback
- Highest-risk path is WhatsApp inbound identity before route lookup and pairing. A bad mapping would misroute a sender, so mappings are strict-valid, conflict-rejecting, and only flushed after safe observations.
- Rollback removes the adapter use of the mapping file. The stored file is inert if this branch is reverted.

👾 Generated with [Letta Code](https://letta.com)