### PR TITLE
fix(windows): launch package manager shims safely

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@modelcontextprotocol/sdk": "1.30.0",
         "@pierre/diffs": "1.2.2",
         "@scarf/scarf": "^1.4.0",
+        "cross-spawn": "^7.0.6",
         "cron-parser": "^5.6.1",
         "glob": "^13.0.0",
         "ink-link": "^5.0.0",

--- a/bun.lock
+++ b/bun.lock
@@ -10,8 +10,8 @@
         "@modelcontextprotocol/sdk": "1.30.0",
         "@pierre/diffs": "1.2.2",
         "@scarf/scarf": "^1.4.0",
-        "cross-spawn": "^7.0.6",
         "cron-parser": "^5.6.1",
+        "cross-spawn": "^7.0.6",
         "glob": "^13.0.0",
         "ink-link": "^5.0.0",
         "node-pty": "^1.1.0",
@@ -26,6 +26,7 @@
         "@modelcontextprotocol/server-everything": "^2026.7.4",
         "@slack/bolt": "^4.7.0",
         "@types/bun": "^1.3.7",
+        "@types/cross-spawn": "^6.0.6",
         "@types/diff": "^8.0.0",
         "@types/picomatch": "^4.0.2",
         "@types/react": "^19.2.9",
@@ -286,6 +287,8 @@
     "@types/bun": ["@types/bun@1.3.7", "", { "dependencies": { "bun-types": "1.3.7" } }, "sha512-lmNuMda+Z9b7tmhA0tohwy8ZWFSnmQm1UDWXtH5r9F7wZCfkeO3Jx7wKQ1EOiKq43yHts7ky6r8SDJQWRNupkA=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
+
+    "@types/cross-spawn": ["@types/cross-spawn@6.0.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA=="],
 
     "@types/diff": ["@types/diff@8.0.0", "", { "dependencies": { "diff": "*" } }, "sha512-o7jqJM04gfaYrdCecCVMbZhNdG6T1MHg/oQoRFdERLV+4d+V7FijhiEAbFu0Usww84Yijk9yH58U4Jk4HbtzZw=="],
 

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "@modelcontextprotocol/server-everything": "^2026.7.4",
     "@slack/bolt": "^4.7.0",
     "@types/bun": "^1.3.7",
+    "@types/cross-spawn": "^6.0.6",
     "@types/diff": "^8.0.0",
     "@types/picomatch": "^4.0.2",
     "@types/react": "^19.2.9",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "@modelcontextprotocol/sdk": "1.30.0",
     "@pierre/diffs": "1.2.2",
     "@scarf/scarf": "^1.4.0",
+    "cross-spawn": "^7.0.6",
     "cron-parser": "^5.6.1",
     "glob": "^13.0.0",
     "ink-link": "^5.0.0",

--- a/src/channels/runtime-deps.test.ts
+++ b/src/channels/runtime-deps.test.ts
@@ -271,16 +271,21 @@ test("installChannelRuntime uses pnpm add for pnpm installs", async () => {
   ]);
 });
 
-test("installChannelRuntime uses cmd shims for npm on Windows", async () => {
+test("installChannelRuntime uses the npm cmd shim on Windows without shell", async () => {
   const spawnCalls: Array<{
     cmd: string;
     args: string[];
     cwd?: string;
+    shell?: boolean | string;
   }> = [];
 
   const spawnImpl = mock(
-    (cmd: string, args: string[], opts?: { cwd?: string }) => {
-      spawnCalls.push({ cmd, args, cwd: opts?.cwd });
+    (
+      cmd: string,
+      args: string[],
+      opts?: { cwd?: string; shell?: boolean | string },
+    ) => {
+      spawnCalls.push({ cmd, args, cwd: opts?.cwd, shell: opts?.shell });
       const proc = new EventEmitter();
       queueMicrotask(() => {
         proc.emit("exit", 0);
@@ -303,20 +308,26 @@ test("installChannelRuntime uses cmd shims for npm on Windows", async () => {
       cmd: "npm.cmd",
       args: ["install", "--no-save", "--no-bin-links", "grammy@1.42.0"],
       cwd: getChannelRuntimeDir("telegram"),
+      shell: undefined,
     },
   ]);
 });
 
-test("installChannelRuntime uses cmd shims for pnpm on Windows", async () => {
+test("installChannelRuntime uses the pnpm cmd shim on Windows without shell", async () => {
   const spawnCalls: Array<{
     cmd: string;
     args: string[];
     cwd?: string;
+    shell?: boolean | string;
   }> = [];
 
   const spawnImpl = mock(
-    (cmd: string, args: string[], opts?: { cwd?: string }) => {
-      spawnCalls.push({ cmd, args, cwd: opts?.cwd });
+    (
+      cmd: string,
+      args: string[],
+      opts?: { cwd?: string; shell?: boolean | string },
+    ) => {
+      spawnCalls.push({ cmd, args, cwd: opts?.cwd, shell: opts?.shell });
       const proc = new EventEmitter();
       queueMicrotask(() => {
         proc.emit("exit", 0);
@@ -339,6 +350,7 @@ test("installChannelRuntime uses cmd shims for pnpm on Windows", async () => {
       cmd: "pnpm.cmd",
       args: ["add", "--no-bin-links", "grammy@1.42.0"],
       cwd: getChannelRuntimeDir("telegram"),
+      shell: undefined,
     },
   ]);
 });

--- a/src/channels/runtime-deps.ts
+++ b/src/channels/runtime-deps.ts
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdir, symlink, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
@@ -8,13 +7,17 @@ import {
   detectPackageManager,
   type PackageManager,
 } from "@/updater/auto-update";
+import {
+  getPackageManagerProcessFactory,
+  type PackageManagerProcessFactory,
+} from "@/utils/package-manager-spawn";
 import { getChannelDir } from "./config";
 import { getChannelPluginMetadata } from "./plugin-registry";
 import type { SupportedChannelId } from "./types";
 
 export const CHANNEL_RUNTIME_ROOT_ENV = "LETTA_CHANNEL_RUNTIME_ROOT";
 
-type InstallProcessFactory = typeof spawn;
+type InstallProcessFactory = PackageManagerProcessFactory;
 type RuntimePackageManager = PackageManager;
 
 type RuntimeResolver = {
@@ -22,7 +25,7 @@ type RuntimeResolver = {
   resolve: (moduleName: string) => string;
 };
 
-let spawnInstallProcess: InstallProcessFactory = spawn;
+let spawnInstallProcessOverride: InstallProcessFactory | null = null;
 let userRuntimeRootOverride: string | null = null;
 let bundledRuntimeRootOverride: string | null | undefined;
 let packageManagerOverride: RuntimePackageManager | null = null;
@@ -238,6 +241,9 @@ export async function installChannelRuntime(
   const packageManager = resolveInstallPackageManager();
   const command = getPackageManagerExecutable(packageManager);
   const args = getInstallArgs(packageManager, spec.runtimePackages);
+  const spawnInstallProcess =
+    spawnInstallProcessOverride ??
+    getPackageManagerProcessFactory({ platform: resolveInstallPlatform() });
 
   await new Promise<void>((resolve, reject) => {
     const proc = spawnInstallProcess(command, args, {
@@ -314,7 +320,7 @@ export function __testOverrideChannelRuntimeDeps(
   bundledRuntimeRootOverride = overrides
     ? (overrides.bundledRuntimeRoot ?? null)
     : undefined;
-  spawnInstallProcess = overrides?.spawnImpl ?? spawn;
+  spawnInstallProcessOverride = overrides?.spawnImpl ?? null;
   packageManagerOverride = overrides?.packageManager ?? null;
   platformOverride = overrides?.platform ?? null;
 }

--- a/src/lsp/servers/python.ts
+++ b/src/lsp/servers/python.ts
@@ -4,6 +4,7 @@
  */
 
 import type { LSPServerInfo } from "@/lsp/types.js";
+import { getPackageManagerProcessFactory } from "@/utils/package-manager-spawn";
 
 /**
  * Python Language Server (Pyright)
@@ -43,13 +44,18 @@ export const PythonServer: LSPServerInfo = {
 
       console.log("[LSP] Installing pyright...");
 
-      const { spawn } = await import("node:child_process");
+      const platform = process.platform;
+      const command = platform === "win32" ? "npm.cmd" : "npm";
+      const spawnPackageManager = getPackageManagerProcessFactory({ platform });
 
       return new Promise((resolve, reject) => {
-        const proc = spawn("npm", ["install", "-g", "pyright"], {
-          stdio: "inherit",
-        });
+        const proc = spawnPackageManager(
+          command,
+          ["install", "-g", "pyright"],
+          { stdio: "inherit" },
+        );
 
+        proc.on("error", reject);
         proc.on("exit", (code) => {
           if (code === 0) {
             console.log("[LSP] Successfully installed pyright");

--- a/src/mods/package-installer.ts
+++ b/src/mods/package-installer.ts
@@ -1,8 +1,4 @@
-import {
-  type ChildProcess,
-  type SpawnOptions,
-  spawn,
-} from "node:child_process";
+import { spawn } from "node:child_process";
 import {
   copyFileSync,
   existsSync,
@@ -31,6 +27,10 @@ import {
   upsertManagedModPackage,
   validateManagedModPackageRegistryForMutation,
 } from "@/mods/package-registry";
+import {
+  getPackageManagerProcessFactory,
+  type PackageManagerProcessFactory,
+} from "@/utils/package-manager-spawn";
 
 export interface InstallLocalManagedModPackageResult {
   capabilities: LettaPackageCapability[];
@@ -92,15 +92,11 @@ interface InstallPreparedManagedModPackageParams {
   packageInfo?: PackageSourceInfo;
 }
 
-type ManagedPackageProcessFactory = (
-  command: string,
-  args: string[],
-  options: SpawnOptions,
-) => ChildProcess;
+type ManagedPackageProcessFactory = PackageManagerProcessFactory;
 
 const SKIPPED_PACKAGE_COPY_NAMES = new Set([".git", "node_modules"]);
 
-let spawnNpmInstallProcess: ManagedPackageProcessFactory = spawn;
+let spawnNpmInstallProcessOverride: ManagedPackageProcessFactory | null = null;
 let spawnGitInstallProcess: ManagedPackageProcessFactory = spawn;
 let platformOverride: NodeJS.Platform | null = null;
 
@@ -616,7 +612,11 @@ async function runNpmInstall(params: {
       args: getNpmInstallArgs(params.installSpec),
       command: getNpmExecutable(),
       cwd: params.tempRoot,
-      spawnImpl: spawnNpmInstallProcess,
+      spawnImpl:
+        spawnNpmInstallProcessOverride ??
+        getPackageManagerProcessFactory({
+          platform: platformOverride ?? process.platform,
+        }),
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -1196,6 +1196,6 @@ export function __testOverrideNpmManagedModPackageInstaller(params: {
   spawnImpl?: ManagedPackageProcessFactory | null;
 }): void {
   spawnGitInstallProcess = params.gitSpawnImpl ?? spawn;
-  spawnNpmInstallProcess = params.spawnImpl ?? spawn;
+  spawnNpmInstallProcessOverride = params.spawnImpl ?? null;
   platformOverride = params.platform ?? null;
 }

--- a/src/utils/package-manager-spawn.test.ts
+++ b/src/utils/package-manager-spawn.test.ts
@@ -1,0 +1,161 @@
+import { expect, test } from "bun:test";
+import type { ChildProcess, SpawnOptions } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  getPackageManagerProcessFactory,
+  type PackageManagerProcessFactory,
+} from "@/utils/package-manager-spawn";
+
+function createChildProcess(): ChildProcess {
+  return new EventEmitter() as ChildProcess;
+}
+
+test("selects the Windows shim launcher instead of native spawn on win32", () => {
+  const child = createChildProcess();
+  const calls: Array<{
+    args: string[];
+    command: string;
+    options: SpawnOptions;
+  }> = [];
+  const nativeSpawn: PackageManagerProcessFactory = () => {
+    throw new Error("spawn EINVAL");
+  };
+  const windowsSpawn: PackageManagerProcessFactory = (
+    command,
+    args,
+    options,
+  ) => {
+    calls.push({ args, command, options });
+    return child;
+  };
+
+  const launcher = getPackageManagerProcessFactory({
+    nativeSpawn,
+    platform: "win32",
+    windowsSpawn,
+  });
+
+  expect(
+    launcher("npm.cmd", ["install", "pkg@1.0.0"], { stdio: "ignore" }),
+  ).toBe(child);
+  expect(calls).toEqual([
+    {
+      command: "npm.cmd",
+      args: ["install", "pkg@1.0.0"],
+      options: { stdio: "ignore" },
+    },
+  ]);
+});
+
+test.skipIf(process.platform !== "win32")(
+  "executes a cmd shim with argument boundaries intact on Windows",
+  async () => {
+    const root = mkdtempSync(join(tmpdir(), "letta-package-manager-spawn-"));
+    const scriptPath = join(root, "print-args.cjs");
+    const shimPath = join(root, "npm.cmd");
+    writeFileSync(
+      scriptPath,
+      "process.stdout.write(JSON.stringify(process.argv.slice(2)));\n",
+    );
+    writeFileSync(shimPath, '@echo off\r\nnode "%~dp0\\print-args.cjs" %*\r\n');
+
+    try {
+      const launcher = getPackageManagerProcessFactory();
+      const child = launcher(shimPath, ["package name", "literal&value"], {
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const stdout: string[] = [];
+      const stderr: string[] = [];
+      child.stdout?.on("data", (chunk) => stdout.push(String(chunk)));
+      child.stderr?.on("data", (chunk) => stderr.push(String(chunk)));
+      const code = await new Promise<number | null>((resolve, reject) => {
+        child.once("error", reject);
+        child.once("close", resolve);
+      });
+
+      expect(code).toBe(0);
+      expect(stderr.join("")).toBe("");
+      expect(JSON.parse(stdout.join(""))).toEqual([
+        "package name",
+        "literal&value",
+      ]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
+
+test("uses native spawn for non-shim commands on Windows", () => {
+  const child = createChildProcess();
+  const calls: Array<{
+    args: string[];
+    command: string;
+    options: SpawnOptions;
+  }> = [];
+  const nativeSpawn: PackageManagerProcessFactory = (
+    command,
+    args,
+    options,
+  ) => {
+    calls.push({ args, command, options });
+    return child;
+  };
+  const windowsSpawn: PackageManagerProcessFactory = () => {
+    throw new Error("windows launcher should not run");
+  };
+
+  const launcher = getPackageManagerProcessFactory({
+    nativeSpawn,
+    platform: "win32",
+    windowsSpawn,
+  });
+
+  expect(launcher("bun", ["add", "pkg@1.0.0"], { cwd: "/tmp" })).toBe(child);
+  expect(calls).toEqual([
+    {
+      command: "bun",
+      args: ["add", "pkg@1.0.0"],
+      options: { cwd: "/tmp" },
+    },
+  ]);
+});
+
+test("keeps native spawn selected off Windows", () => {
+  const child = createChildProcess();
+  const calls: Array<{
+    args: string[];
+    command: string;
+    options: SpawnOptions;
+  }> = [];
+  const nativeSpawn: PackageManagerProcessFactory = (
+    command,
+    args,
+    options,
+  ) => {
+    calls.push({ args, command, options });
+    return child;
+  };
+  const windowsSpawn: PackageManagerProcessFactory = () => {
+    throw new Error("windows launcher should not run");
+  };
+
+  const launcher = getPackageManagerProcessFactory({
+    nativeSpawn,
+    platform: "linux",
+    windowsSpawn,
+  });
+
+  expect(launcher("npm", ["install", "pkg@1.0.0"], { cwd: "/tmp" })).toBe(
+    child,
+  );
+  expect(calls).toEqual([
+    {
+      command: "npm",
+      args: ["install", "pkg@1.0.0"],
+      options: { cwd: "/tmp" },
+    },
+  ]);
+});

--- a/src/utils/package-manager-spawn.test.ts
+++ b/src/utils/package-manager-spawn.test.ts
@@ -13,42 +13,45 @@ function createChildProcess(): ChildProcess {
   return new EventEmitter() as ChildProcess;
 }
 
-test("selects the Windows shim launcher instead of native spawn on win32", () => {
-  const child = createChildProcess();
-  const calls: Array<{
-    args: string[];
-    command: string;
-    options: SpawnOptions;
-  }> = [];
-  const nativeSpawn: PackageManagerProcessFactory = () => {
-    throw new Error("spawn EINVAL");
-  };
-  const windowsSpawn: PackageManagerProcessFactory = (
-    command,
-    args,
-    options,
-  ) => {
-    calls.push({ args, command, options });
-    return child;
-  };
+test.each(["npm.cmd", "npm.bat"])(
+  "selects the Windows shim launcher for %s",
+  (command) => {
+    const child = createChildProcess();
+    const calls: Array<{
+      args: string[];
+      command: string;
+      options: SpawnOptions;
+    }> = [];
+    const nativeSpawn: PackageManagerProcessFactory = () => {
+      throw new Error("spawn EINVAL");
+    };
+    const windowsSpawn: PackageManagerProcessFactory = (
+      command,
+      args,
+      options,
+    ) => {
+      calls.push({ args, command, options });
+      return child;
+    };
 
-  const launcher = getPackageManagerProcessFactory({
-    nativeSpawn,
-    platform: "win32",
-    windowsSpawn,
-  });
+    const launcher = getPackageManagerProcessFactory({
+      nativeSpawn,
+      platform: "win32",
+      windowsSpawn,
+    });
 
-  expect(
-    launcher("npm.cmd", ["install", "pkg@1.0.0"], { stdio: "ignore" }),
-  ).toBe(child);
-  expect(calls).toEqual([
-    {
-      command: "npm.cmd",
-      args: ["install", "pkg@1.0.0"],
-      options: { stdio: "ignore" },
-    },
-  ]);
-});
+    expect(
+      launcher(command, ["install", "pkg@1.0.0"], { stdio: "ignore" }),
+    ).toBe(child);
+    expect(calls).toEqual([
+      {
+        command,
+        args: ["install", "pkg@1.0.0"],
+        options: { stdio: "ignore" },
+      },
+    ]);
+  },
+);
 
 test.skipIf(process.platform !== "win32")(
   "executes a cmd shim with argument boundaries intact on Windows",

--- a/src/utils/package-manager-spawn.ts
+++ b/src/utils/package-manager-spawn.ts
@@ -1,0 +1,44 @@
+import {
+  type ChildProcess,
+  type SpawnOptions,
+  spawn,
+} from "node:child_process";
+import { createRequire } from "node:module";
+
+export type PackageManagerProcessFactory = (
+  command: string,
+  args: string[],
+  options: SpawnOptions,
+) => ChildProcess;
+
+const requireFromHere = createRequire(import.meta.url);
+const crossSpawn = requireFromHere(
+  "cross-spawn",
+) as PackageManagerProcessFactory;
+
+function isWindowsCommandShim(command: string): boolean {
+  return command.toLowerCase().endsWith(".cmd");
+}
+
+export function getPackageManagerProcessFactory({
+  nativeSpawn = spawn,
+  platform = process.platform,
+  windowsSpawn = crossSpawn,
+}: {
+  nativeSpawn?: PackageManagerProcessFactory;
+  platform?: NodeJS.Platform;
+  windowsSpawn?: PackageManagerProcessFactory;
+} = {}): PackageManagerProcessFactory {
+  if (platform !== "win32") {
+    return nativeSpawn;
+  }
+
+  return (command, args, options) => {
+    // Native Node spawn rejects npm/pnpm .cmd shims with EINVAL on Windows.
+    // cross-spawn preserves argv boundaries while safely routing shims through cmd.exe.
+    const spawnImpl = isWindowsCommandShim(command)
+      ? windowsSpawn
+      : nativeSpawn;
+    return spawnImpl(command, args, options);
+  };
+}

--- a/src/utils/package-manager-spawn.ts
+++ b/src/utils/package-manager-spawn.ts
@@ -3,7 +3,7 @@ import {
   type SpawnOptions,
   spawn,
 } from "node:child_process";
-import { createRequire } from "node:module";
+import crossSpawn from "cross-spawn";
 
 export type PackageManagerProcessFactory = (
   command: string,
@@ -11,13 +11,8 @@ export type PackageManagerProcessFactory = (
   options: SpawnOptions,
 ) => ChildProcess;
 
-const requireFromHere = createRequire(import.meta.url);
-const crossSpawn = requireFromHere(
-  "cross-spawn",
-) as PackageManagerProcessFactory;
-
 function isWindowsCommandShim(command: string): boolean {
-  return command.toLowerCase().endsWith(".cmd");
+  return /\.(?:cmd|bat)$/i.test(command);
 }
 
 export function getPackageManagerProcessFactory({


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Summary

- route Windows `.cmd` and `.bat` package-manager shims through `cross-spawn` without enabling raw shell execution
- use the shared launcher for managed mod installs, channel runtime dependencies, and Pyright auto-install
- preserve native `spawn` behavior for non-Windows platforms and executable package managers such as Bun

## Problem

Supported Node versions cannot directly spawn npm and pnpm Windows command shims. Letta Code selected `npm.cmd` or `pnpm.cmd` and passed it to `child_process.spawn`, causing `spawn EINVAL` before the package manager started.

Before: native Windows mod and channel dependency installation could fail at process creation. Pyright auto-install also invoked `npm` through the same unsupported boundary.

After: only Windows command shims use `cross-spawn`, which routes through the Windows command processor while preserving argument boundaries. Ordinary executables continue using native spawn.

## Risk and limits

- normal GitHub, direct-URL, and registry skill-source resolution is unchanged
- package spec parsing and package-manager arguments are unchanged
- the Windows-only test executes a real temporary `.cmd` shim and checks spaces and command metacharacters survive as literal arguments
- that real-shim test is skipped locally on macOS and will run in the existing `windows-latest` CI matrix

## Test plan

- [x] `bun test src/utils/package-manager-spawn.test.ts src/mods/package-installer.test.ts src/channels/runtime-deps.test.ts` — 44 passed, one Windows-only test skipped locally
- [x] `bun run check`
- [x] `bun run build`
- [x] built `letta.js` runs with the external `node_modules/cross-spawn` directory temporarily unavailable, proving the static import is bundled
- [ ] existing Windows CI executes the real `.cmd` regression test

👾 Generated with [Letta Code](https://letta.com)