### PR TITLE
feat(whatsapp): support message reactions

### DIFF
--- a/src/channels/registry-inbound.ts
+++ b/src/channels/registry-inbound.ts
@@ -360,6 +360,9 @@ export function createChannelInboundRouter(deps: {
     // exact topic route exists; a disabled exact route remains authoritative.
     const route = loadRouteForInboundMessage(msg, accountId);
     if (!route) {
+      if (msg.reaction) {
+        return;
+      }
       await adapter.sendDirectReply(
         msg.chatId,
         buildUnboundRouteInstructions(msg.channel, msg.chatId),

--- a/src/channels/whatsapp-message-channel.test.ts
+++ b/src/channels/whatsapp-message-channel.test.ts
@@ -111,4 +111,21 @@ describe("WhatsApp MessageChannel actions", () => {
       }),
     );
   });
+
+  test("removes reactions without requiring an emoji", async () => {
+    const { ctx, sent } = makeContext("react", {
+      remove: true,
+      messageId: "target-msg",
+    });
+    await expect(whatsappMessageActions.handleAction(ctx)).resolves.toContain(
+      "Reaction removed",
+    );
+    expect(sent[0]).toEqual(
+      expect.objectContaining({
+        reaction: undefined,
+        removeReaction: true,
+        targetMessageId: "target-msg",
+      }),
+    );
+  });
 });

--- a/src/channels/whatsapp-registry.test.ts
+++ b/src/channels/whatsapp-registry.test.ts
@@ -61,6 +61,7 @@ type RegistryHarness = {
   deliveries: ChannelInboundDelivery[];
   sendCount: number;
   emit: (messages: Record<string, unknown>[]) => Promise<void>;
+  emitReaction: (entries: Record<string, unknown>[]) => Promise<void>;
 };
 
 function makeAccount(
@@ -93,11 +94,27 @@ function makeMessage(
   };
 }
 
+function makeReactionEntry(
+  remoteJid: string,
+  id: string,
+  key: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    key: { remoteJid, id: "target-message", fromMe: true },
+    reaction: {
+      key: { remoteJid, id, fromMe: false, ...key },
+      text: "👍",
+      senderTimestampMs: Date.now(),
+    },
+  };
+}
+
 async function makeHarness(
   account: WhatsAppChannelAccount,
   lidPath: string,
 ): Promise<RegistryHarness> {
   const upsertHandlers: Array<(payload: unknown) => unknown> = [];
+  const reactionHandlers: Array<(payload: unknown) => unknown> = [];
   const deliveries: ChannelInboundDelivery[] = [];
   let sendCount = 0;
 
@@ -108,6 +125,7 @@ async function makeHarness(
       ev: {
         on(event: string, handler: (payload: unknown) => void) {
           if (event === "messages.upsert") upsertHandlers.push(handler);
+          if (event === "messages.reaction") reactionHandlers.push(handler);
         },
       },
       ws: { close() {} },
@@ -147,6 +165,12 @@ async function makeHarness(
       const handler = upsertHandlers.at(-1);
       if (!handler) throw new Error("messages.upsert handler was not captured");
       await handler({ type: "notify", messages });
+    },
+    async emitReaction(entries) {
+      const handler = reactionHandlers.at(-1);
+      if (!handler)
+        throw new Error("messages.reaction handler was not captured");
+      await handler(entries);
     },
   };
 }
@@ -234,6 +258,23 @@ describe("WhatsApp canonical identity through ChannelRegistry", () => {
       });
     }
     expect(getRoutesForChannel("whatsapp", ACCOUNT_ID)).toHaveLength(1);
+    expect(getPendingPairings("whatsapp", ACCOUNT_ID)).toHaveLength(0);
+    expect(harness.sendCount).toBe(0);
+  });
+
+  test("unpaired reactions do not create pairing prompts", async () => {
+    const account = makeAccount();
+    __testOverrideLoadChannelAccounts(() => [account]);
+    const harness = await makeHarness(account, join(tempDir, "lid.json"));
+
+    await harness.emitReaction([
+      makeReactionEntry(RAW_LID, "pending-reaction", {
+        senderPn: CANONICAL_PHONE_JID,
+        senderLid: RAW_LID,
+      }),
+    ]);
+
+    expect(harness.deliveries).toHaveLength(0);
     expect(getPendingPairings("whatsapp", ACCOUNT_ID)).toHaveLength(0);
     expect(harness.sendCount).toBe(0);
   });

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -15,7 +15,9 @@ import {
   isGroupJid,
   isSelfChat,
   isStatusOrBroadcastJid,
+  isStrictPhoneJid,
   resolveSendJid,
+  senderIdFromJid,
   stripDeviceSuffix,
 } from "./jid";
 import type { LidStore } from "./lid-store";
@@ -27,6 +29,11 @@ import {
   extractReplyParticipant,
   extractWhatsAppText,
 } from "./media";
+import {
+  isWhatsAppReactionGroupEligible,
+  parseWhatsAppReactionEntry,
+  type WhatsAppReaction,
+} from "./reactions";
 import { loadWhatsAppModule } from "./runtime";
 import { createWhatsAppSocket, getWhatsAppAuthDir } from "./session";
 import { setWhatsAppConnectionState } from "./state";
@@ -385,6 +392,14 @@ export function createWhatsAppAdapter(
         );
       });
     });
+    connectedSocket.ev?.on?.("messages.reaction", (event) => {
+      return handleReactionBatch(event).catch((error) => {
+        console.error(
+          `[WhatsApp:${account.accountId}] reaction handler failed:`,
+          error instanceof Error ? error.message : error,
+        );
+      });
+    });
   }
 
   async function getGroupLabel(groupJid: string): Promise<string | undefined> {
@@ -511,6 +526,120 @@ export function createWhatsAppAdapter(
           `[WhatsApp:${account.accountId}] inbound chatId=${chatId} sender=${senderId} text="${preview(body)}"`,
         );
         await adapter.onMessage?.(inbound);
+      }
+    } finally {
+      flushLidStoreIfDirty();
+    }
+  }
+
+  async function handleReactionEntry(
+    parsed: WhatsAppReaction,
+    raw: unknown,
+  ): Promise<void> {
+    if (parsed.targetFromMe !== true) return;
+    if (parsed.reactionKey.fromMe === true) return;
+    if (isStatusOrBroadcastJid(parsed.chatId)) return;
+    if (
+      parsed.timestampMs !== undefined &&
+      parsed.timestampMs < connectedAtMs - 1000
+    ) {
+      return;
+    }
+    if (sentMessageIds.has(parsed.reactionMessageId)) {
+      sentMessageIds.delete(parsed.reactionMessageId);
+      return;
+    }
+    const identity = resolveInboundIdentity(
+      {
+        selfPhoneJid,
+        selfLid,
+        remoteJid: parsed.chatId,
+        participant: parsed.reactorParticipant,
+      },
+      lidStore,
+    );
+    if (!identity || !applyObservedMappings(identity.observedMappings)) return;
+    if (
+      rememberSeen(`reaction:${identity.chatId}:${parsed.reactionMessageId}`)
+    ) {
+      return;
+    }
+
+    const selfChat = isSelfChat(parsed.chatId, selfPhoneJid, selfLid);
+    if (account.selfChatMode && !selfChat) return;
+
+    const group = isGroupJid(identity.chatId);
+    if (
+      group &&
+      !isWhatsAppReactionGroupEligible({
+        groupMode: account.groupMode,
+        allowedGroups: account.allowedGroups,
+        groupJid: identity.chatId,
+        targetFromMe: parsed.targetFromMe,
+      })
+    ) {
+      return;
+    }
+
+    const chatLabel = group
+      ? await getGroupLabel(identity.chatId)
+      : selfChat
+        ? "Self (WhatsApp)"
+        : identity.senderId;
+    const targetSenderId = isStrictPhoneJid(selfPhoneJid)
+      ? senderIdFromJid(selfPhoneJid)
+      : isStrictPhoneJid(parsed.targetKey.participant)
+        ? senderIdFromJid(parsed.targetKey.participant)
+        : undefined;
+    const actor = identity.senderId;
+    const text =
+      parsed.action === "added"
+        ? `${actor} reacted ${parsed.emoji}`
+        : `${actor} removed a reaction`;
+    const inbound: InboundChannelMessage = {
+      channel: CHANNEL_ID,
+      accountId: account.accountId,
+      chatId: identity.chatId,
+      senderId: actor,
+      senderName: actor,
+      chatLabel,
+      text,
+      timestamp: parsed.timestampMs ?? Date.now(),
+      messageId: parsed.reactionMessageId,
+      chatType: group ? "channel" : "direct",
+      isMention: !group || account.groupMode === "mention",
+      raw,
+      reaction: {
+        action: parsed.action,
+        emoji: parsed.emoji,
+        targetMessageId: parsed.targetMessageId,
+        ...(targetSenderId ? { targetSenderId } : {}),
+      },
+    };
+
+    try {
+      await adapter.onMessage?.(inbound);
+    } catch (error) {
+      console.error(
+        `[WhatsApp:${account.accountId}] reaction delivery failed:`,
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
+
+  async function handleReactionBatch(event: unknown): Promise<void> {
+    try {
+      if (!Array.isArray(event)) return;
+      for (const raw of event) {
+        try {
+          const parsed = parseWhatsAppReactionEntry(raw);
+          if (parsed) await handleReactionEntry(parsed, raw);
+        } catch (error) {
+          console.error(
+            `[WhatsApp:${account.accountId}] reaction entry failed:`,
+            error instanceof Error ? error.message : error,
+          );
+        }
       }
     } finally {
       flushLidStoreIfDirty();

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -278,6 +278,13 @@ export function createWhatsAppAdapter(
     );
   }
 
+  function isKnownOutboundMessage(messageId: string): boolean {
+    if (sentMessageIds.has(messageId)) return true;
+    const stored = messageStore.get(messageId);
+    if (!stored) return false;
+    return asRecord(asRecord(stored).key).fromMe === true;
+  }
+
   function clearActiveSocket(closeWebSocket: boolean): void {
     const currentSock = sock;
     const releaseLease = releaseSocketLease;
@@ -392,7 +399,7 @@ export function createWhatsAppAdapter(
         );
       });
     });
-    connectedSocket.ev?.on?.("messages.reaction", (event) => {
+    sock.ev?.on?.("messages.reaction", (event) => {
       return handleReactionBatch(event).catch((error) => {
         console.error(
           `[WhatsApp:${account.accountId}] reaction handler failed:`,
@@ -536,7 +543,14 @@ export function createWhatsAppAdapter(
     parsed: WhatsAppReaction,
     raw: unknown,
   ): Promise<void> {
-    if (parsed.targetFromMe !== true) return;
+    // Baileys may deliver reactions via a LID chat where it cannot equate
+    // our PN identity, producing targetFromMe:false for our own messages.
+    // isKnownOutboundMessage also checks sentMessageIds and the store's
+    // key.fromMe, but not mere store membership because inbound messages
+    // are stored there too.
+    const targetIsOurs =
+      parsed.targetFromMe === true || isKnownOutboundMessage(parsed.targetMessageId);
+    if (!targetIsOurs) return;
     if (parsed.reactionKey.fromMe === true) return;
     if (isStatusOrBroadcastJid(parsed.chatId)) return;
     if (
@@ -575,7 +589,7 @@ export function createWhatsAppAdapter(
         groupMode: account.groupMode,
         allowedGroups: account.allowedGroups,
         groupJid: identity.chatId,
-        targetFromMe: parsed.targetFromMe,
+        targetFromMe: targetIsOurs,
       })
     ) {
       return;

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -28,6 +28,7 @@ import {
   extractMentionedJids,
   extractReplyParticipant,
   extractWhatsAppText,
+  unwrapWhatsAppMessageContent,
 } from "./media";
 import {
   isWhatsAppReactionGroupEligible,
@@ -40,6 +41,8 @@ import { setWhatsAppConnectionState } from "./state";
 
 const CHANNEL_ID = "whatsapp";
 const DEDUPE_MAX_SIZE = 5000;
+const MESSAGE_STORE_MAX_SIZE = DEDUPE_MAX_SIZE;
+const MESSAGE_STORE_TTL_MS = 24 * 60 * 60 * 1000;
 const RECONNECT_MAX_MS = 30_000;
 const MAX_MENTION_PATTERN_LENGTH = 256;
 const MENTION_MATCH_TEXT_MAX_LENGTH = 2000;
@@ -89,6 +92,16 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object"
     ? (value as Record<string, unknown>)
     : {};
+}
+
+function unrefTimeout(timer: ReturnType<typeof setTimeout>): void {
+  const unref = (timer as { unref?: () => void }).unref;
+  if (typeof unref === "function") unref.call(timer);
+}
+
+function isSyntheticReactionMessage(message: unknown): boolean {
+  const content = unwrapWhatsAppMessageContent(message);
+  return !!content?.reactionMessage;
 }
 
 export function isWhatsAppConflictDisconnect(update: unknown): boolean {
@@ -230,7 +243,11 @@ export function createWhatsAppAdapter(
       join(getWhatsAppAuthDir(account.accountId), "lid-mappings.json"),
     );
   let lidStoreDirty = false;
+  // Process-local target cache. After restart we cannot prove ownership for
+  // LID target.fromMe:false reactions or reconstruct group participant keys
+  // until the target message is observed again.
   const messageStore = new Map<string, unknown>();
+  const messageStoreTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
   function flushLidStoreIfDirty(): void {
     if (!lidStoreDirty) return;
@@ -265,17 +282,62 @@ export function createWhatsAppAdapter(
     return false;
   }
 
+  function clearMessageStoreTimer(id: string): void {
+    const timer = messageStoreTimers.get(id);
+    if (timer) clearTimeout(timer);
+    messageStoreTimers.delete(id);
+  }
+
+  function dropStoredMessage(id: string): void {
+    sentMessageIds.delete(id);
+    messageStore.delete(id);
+    clearMessageStoreTimer(id);
+  }
+
+  function scheduleMessageStoreExpiry(id: string): void {
+    clearMessageStoreTimer(id);
+    const timer = setTimeout(() => {
+      sentMessageIds.delete(id);
+      messageStore.delete(id);
+      messageStoreTimers.delete(id);
+    }, MESSAGE_STORE_TTL_MS);
+    unrefTimeout(timer);
+    messageStoreTimers.set(id, timer);
+  }
+
+  function capMessageStore(): void {
+    while (messageStore.size > MESSAGE_STORE_MAX_SIZE) {
+      const first = messageStore.keys().next().value;
+      if (typeof first !== "string") break;
+      dropStoredMessage(first);
+    }
+    while (sentMessageIds.size > MESSAGE_STORE_MAX_SIZE) {
+      const first = sentMessageIds.values().next().value;
+      if (typeof first !== "string") break;
+      dropStoredMessage(first);
+    }
+  }
+
+  function rememberStoredMessage(id: string, message: unknown): void {
+    if (!id) return;
+    messageStore.set(id, message);
+    scheduleMessageStoreExpiry(id);
+    capMessageStore();
+  }
+
   function rememberSent(id: string, message?: unknown): void {
     if (!id) return;
     sentMessageIds.add(id);
-    if (message) messageStore.set(id, message);
-    setTimeout(
-      () => {
-        sentMessageIds.delete(id);
-        messageStore.delete(id);
-      },
-      24 * 60 * 60 * 1000,
-    );
+    if (message !== undefined) messageStore.set(id, message);
+    scheduleMessageStoreExpiry(id);
+    capMessageStore();
+  }
+
+  function clearMessageStore(): void {
+    for (const timer of messageStoreTimers.values()) clearTimeout(timer);
+    messageStoreTimers.clear();
+    messageStore.clear();
+    sentMessageIds.clear();
   }
 
   function isKnownOutboundMessage(messageId: string): boolean {
@@ -283,6 +345,31 @@ export function createWhatsAppAdapter(
     const stored = messageStore.get(messageId);
     if (!stored) return false;
     return asRecord(asRecord(stored).key).fromMe === true;
+  }
+
+  function getStoredTargetKey(
+    messageId: string,
+  ): Record<string, unknown> | null {
+    const key = asRecord(asRecord(messageStore.get(messageId)).key);
+    if (typeof key.id !== "string" || key.id !== messageId) return null;
+    const remoteJid =
+      typeof key.remoteJid === "string" ? stripDeviceSuffix(key.remoteJid) : "";
+    if (!remoteJid) return null;
+    return { ...key, remoteJid, id: messageId };
+  }
+
+  function buildReactionTargetKey(
+    targetJid: string,
+    messageId: string,
+  ): Record<string, unknown> {
+    const storedKey = getStoredTargetKey(messageId);
+    if (storedKey) return storedKey;
+    if (isGroupJid(targetJid)) {
+      throw new Error(
+        "WhatsApp group reactions require the original target message key from the current adapter process; after restart, react only after the target message is observed again.",
+      );
+    }
+    return { remoteJid: targetJid, id: messageId };
   }
 
   function clearActiveSocket(closeWebSocket: boolean): void {
@@ -430,13 +517,14 @@ export function createWhatsAppAdapter(
         const messageId = msg.key?.id ?? "";
         if (!remoteJid || !messageId || !msg.message) continue;
         if (isStatusOrBroadcastJid(remoteJid)) continue;
+        if (isSyntheticReactionMessage(msg.message)) continue;
         if (sentMessageIds.has(messageId)) {
+          rememberStoredMessage(messageId, msg);
           sentMessageIds.delete(messageId);
           continue;
         }
         if (!messageStore.has(messageId)) {
-          messageStore.set(messageId, msg);
-          setTimeout(() => messageStore.delete(messageId), 24 * 60 * 60 * 1000);
+          rememberStoredMessage(messageId, msg);
         }
 
         const selfChat = isSelfChat(remoteJid, selfPhoneJid, selfLid);
@@ -549,7 +637,8 @@ export function createWhatsAppAdapter(
     // key.fromMe, but not mere store membership because inbound messages
     // are stored there too.
     const targetIsOurs =
-      parsed.targetFromMe === true || isKnownOutboundMessage(parsed.targetMessageId);
+      parsed.targetFromMe === true ||
+      isKnownOutboundMessage(parsed.targetMessageId);
     if (!targetIsOurs) return;
     if (parsed.reactionKey.fromMe === true) return;
     if (isStatusOrBroadcastJid(parsed.chatId)) return;
@@ -569,6 +658,10 @@ export function createWhatsAppAdapter(
         selfLid,
         remoteJid: parsed.chatId,
         participant: parsed.reactorParticipant,
+        senderPn: parsed.reactionKey.senderPn,
+        senderLid: parsed.reactionKey.senderLid,
+        participantPn: parsed.reactionKey.participantPn,
+        participantLid: parsed.reactionKey.participantLid,
       },
       lidStore,
     );
@@ -691,6 +784,7 @@ export function createWhatsAppAdapter(
 
     async stop() {
       if (!running) {
+        clearMessageStore();
         flushLidStoreIfDirty();
         return;
       }
@@ -703,6 +797,7 @@ export function createWhatsAppAdapter(
       connectionGeneration += 1;
       clearActiveSocket(true);
       setWhatsAppConnectionState(account.accountId, { status: "disconnected" });
+      clearMessageStore();
       flushLidStoreIfDirty();
     },
 
@@ -712,7 +807,12 @@ export function createWhatsAppAdapter(
 
     async sendMessage(msg: OutboundChannelMessage) {
       if (!running) throw new Error("WhatsApp adapter is not running.");
-      if (!msg.text?.trim() && !msg.mediaPath?.trim() && !msg.reaction) {
+      if (
+        !msg.text?.trim() &&
+        !msg.mediaPath?.trim() &&
+        !msg.reaction &&
+        !msg.removeReaction
+      ) {
         throw new Error("WhatsApp send requires message or media.");
       }
       const targetJid = resolveSendJid({
@@ -727,7 +827,7 @@ export function createWhatsAppAdapter(
         const result = await sendToWhatsApp(targetJid, {
           react: {
             text: msg.removeReaction ? "" : (msg.reaction ?? ""),
-            key: { remoteJid: targetJid, id: target },
+            key: buildReactionTargetKey(targetJid, target),
           },
         });
         const id = result.key?.id ?? target;

--- a/src/channels/whatsapp/reactions-adapter.test.ts
+++ b/src/channels/whatsapp/reactions-adapter.test.ts
@@ -44,6 +44,10 @@ function reactionEntry(
     targetFromMe?: boolean;
     reactionFromMe?: boolean;
     participant?: string;
+    senderPn?: string;
+    senderLid?: string;
+    participantPn?: string;
+    participantLid?: string;
     text?: unknown;
     senderTimestampMs?: unknown;
   } = {},
@@ -60,7 +64,21 @@ function reactionEntry(
         remoteJid: chatId,
         id: overrides.reactionId ?? "reaction-event",
         fromMe: overrides.reactionFromMe ?? false,
-        participant: overrides.participant ?? REACTOR,
+        ...(overrides.participant === undefined
+          ? {}
+          : { participant: overrides.participant }),
+        ...(overrides.senderPn === undefined
+          ? {}
+          : { senderPn: overrides.senderPn }),
+        ...(overrides.senderLid === undefined
+          ? {}
+          : { senderLid: overrides.senderLid }),
+        ...(overrides.participantPn === undefined
+          ? {}
+          : { participantPn: overrides.participantPn }),
+        ...(overrides.participantLid === undefined
+          ? {}
+          : { participantLid: overrides.participantLid }),
       },
       text: overrides.text === undefined ? "👍" : overrides.text,
       senderTimestampMs:
@@ -89,6 +107,11 @@ function makeHarness(
   }
   const delivered: InboundChannelMessage[] = [];
   const eventNames: string[] = [];
+  const sentMessages: Array<{
+    jid: string;
+    payload: Record<string, unknown>;
+    options?: Record<string, unknown>;
+  }> = [];
   const handlers = new Map<string, (payload: unknown) => unknown>();
   let connectionUpdate: ((update: unknown) => void) | undefined;
   let readCalls = 0;
@@ -106,8 +129,13 @@ function makeHarness(
       readCalls += 1;
       return Promise.resolve();
     },
-    async sendMessage() {
-      return { key: { id: outboundId, fromMe: true, remoteJid: REACTOR } };
+    async sendMessage(
+      jid: string,
+      payload: Record<string, unknown>,
+      options?: Record<string, unknown>,
+    ) {
+      sentMessages.push({ jid, payload, options });
+      return { key: { id: outboundId, fromMe: true, remoteJid: jid } };
     },
     async sendPresenceUpdate() {},
   };
@@ -142,6 +170,7 @@ function makeHarness(
     adapter,
     delivered,
     eventNames,
+    sentMessages,
     readCalls: () => readCalls,
     async start() {
       await adapter.start();
@@ -270,6 +299,144 @@ describe("WhatsApp reaction adapter integration", () => {
       }),
     ]);
     expect(conflicting.delivered).toHaveLength(0);
+  });
+
+  test("resolves first LID reactions from Baileys key identity fields", async () => {
+    const directLid = "707070@lid";
+    const direct = makeHarness();
+    await direct.start();
+    await direct.emit([
+      reactionEntry({
+        chatId: directLid,
+        reactionId: "direct-lid-first-reaction",
+        senderPn: REACTOR,
+        senderLid: directLid,
+      }),
+    ]);
+    expect(direct.delivered[0]?.chatId).toBe(REACTOR);
+    expect(direct.delivered[0]?.senderId).toBe("15550000002");
+
+    const groupLid = "808080@lid";
+    const group = makeHarness();
+    await group.start();
+    await group.emit([
+      reactionEntry({
+        chatId: GROUP,
+        reactionId: "group-lid-first-reaction",
+        participant: groupLid,
+        participantPn: REACTOR,
+      }),
+    ]);
+    expect(group.delivered[0]?.chatId).toBe(GROUP);
+    expect(group.delivered[0]?.senderId).toBe("15550000002");
+  });
+
+  test("ignores synthetic reaction messages on messages.upsert", async () => {
+    const harness = makeHarness();
+    await harness.start();
+    await harness.emitUpsert([
+      {
+        key: { remoteJid: REACTOR, id: "synthetic-reaction", fromMe: false },
+        message: {
+          reactionMessage: {
+            key: { remoteJid: REACTOR, id: "target-message", fromMe: true },
+            text: "👍",
+          },
+        },
+        messageTimestamp: Math.floor(Date.now() / 1000),
+      },
+      {
+        key: { remoteJid: REACTOR, id: "ordinary", fromMe: false },
+        message: { conversation: "ordinary" },
+        messageTimestamp: Math.floor(Date.now() / 1000),
+      },
+    ]);
+    expect(harness.delivered.map((message) => message.messageId)).toEqual([
+      "ordinary",
+    ]);
+  });
+
+  test("uses stored group target keys for outbound add and removal reactions", async () => {
+    const harness = makeHarness();
+    await harness.start();
+    await harness.emitUpsert([
+      {
+        key: {
+          remoteJid: GROUP,
+          id: "group-target",
+          fromMe: false,
+          participant: REACTOR,
+        },
+        message: { conversation: "group message" },
+        messageTimestamp: Math.floor(Date.now() / 1000),
+      },
+    ]);
+
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: GROUP,
+      text: "",
+      reaction: "👍",
+      targetMessageId: "group-target",
+    });
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: GROUP,
+      text: "",
+      removeReaction: true,
+      targetMessageId: "group-target",
+    });
+
+    expect(harness.sentMessages.at(-2)).toEqual(
+      expect.objectContaining({
+        jid: GROUP,
+        payload: {
+          react: {
+            text: "👍",
+            key: expect.objectContaining({
+              remoteJid: GROUP,
+              id: "group-target",
+              fromMe: false,
+              participant: REACTOR,
+            }),
+          },
+        },
+      }),
+    );
+    expect(harness.sentMessages.at(-1)).toEqual(
+      expect.objectContaining({
+        jid: GROUP,
+        payload: {
+          react: {
+            text: "",
+            key: expect.objectContaining({
+              remoteJid: GROUP,
+              id: "group-target",
+              fromMe: false,
+              participant: REACTOR,
+            }),
+          },
+        },
+      }),
+    );
+  });
+
+  test("rejects group outbound reactions after target-key state is gone", async () => {
+    const harness = makeHarness();
+    await harness.start();
+    await expect(
+      harness.adapter.sendMessage({
+        channel: "whatsapp",
+        accountId: account.accountId,
+        chatId: GROUP,
+        text: "",
+        reaction: "👍",
+        targetMessageId: "missing-group-target",
+      }),
+    ).rejects.toThrow(/current adapter process/);
+    expect(harness.sentMessages).toHaveLength(0);
   });
 
   test("enforces group policy and preserves mention semantics", async () => {

--- a/src/channels/whatsapp/reactions-adapter.test.ts
+++ b/src/channels/whatsapp/reactions-adapter.test.ts
@@ -439,6 +439,81 @@ describe("WhatsApp reaction adapter integration", () => {
     expect(harness.sentMessages).toHaveLength(0);
   });
 
+  test("unrefs and clears message-store TTL timers", async () => {
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+    const timers: Array<
+      ReturnType<typeof setTimeout> & { unrefCalled: boolean }
+    > = [];
+    const cleared: unknown[] = [];
+    globalThis.setTimeout = ((callback: unknown, timeout?: number) => {
+      void callback;
+      void timeout;
+      const timer = {
+        unrefCalled: false,
+        unref() {
+          timer.unrefCalled = true;
+        },
+      } as ReturnType<typeof setTimeout> & { unrefCalled: boolean };
+      timers.push(timer);
+      return timer;
+    }) as unknown as typeof setTimeout;
+    globalThis.clearTimeout = ((timer?: unknown) => {
+      if (timer !== undefined) cleared.push(timer);
+    }) as unknown as typeof clearTimeout;
+    try {
+      const harness = makeHarness();
+      await harness.start();
+      await harness.emitUpsert([
+        {
+          key: { remoteJid: REACTOR, id: "timer-target", fromMe: false },
+          message: { conversation: "timer target" },
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        },
+      ]);
+      expect(timers).toHaveLength(1);
+      expect(timers[0]?.unrefCalled).toBe(true);
+      await harness.adapter.stop();
+      expect(cleared).toContain(timers[0]);
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+      globalThis.clearTimeout = originalClearTimeout;
+    }
+  });
+
+  test("caps outbound ownership cache", async () => {
+    const harness = makeHarness();
+    await harness.start();
+    const timestamp = Math.floor(Date.now() / 1000);
+    await harness.emitUpsert(
+      Array.from({ length: 5001 }, (_, index) => ({
+        key: {
+          remoteJid: REACTOR,
+          id: `cached-outbound-${index}`,
+          fromMe: true,
+        },
+        message: { conversation: `cached outbound ${index}` },
+        messageTimestamp: timestamp,
+      })),
+    );
+
+    await harness.emit([
+      reactionEntry({
+        targetId: "cached-outbound-0",
+        targetFromMe: false,
+        reactionId: "evicted-cache-target",
+      }),
+      reactionEntry({
+        targetId: "cached-outbound-5000",
+        targetFromMe: false,
+        reactionId: "retained-cache-target",
+      }),
+    ]);
+    expect(harness.delivered.map((message) => message.messageId)).toEqual([
+      "retained-cache-target",
+    ]);
+  });
+
   test("enforces group policy and preserves mention semantics", async () => {
     const cases: Array<{
       groupMode: "disabled" | "mention" | "open";

--- a/src/channels/whatsapp/reactions-adapter.test.ts
+++ b/src/channels/whatsapp/reactions-adapter.test.ts
@@ -78,6 +78,8 @@ function makeHarness(
     };
     lidEntries?: Array<{ lid: string; phone: string }>;
     deliver?: (message: InboundChannelMessage) => Promise<void> | void;
+    /** When set, sendMessage returns this as the outbound message ID. */
+    outboundMessageId?: string;
   } = {},
 ) {
   const directory = temporaryDirectory();
@@ -90,6 +92,7 @@ function makeHarness(
   const handlers = new Map<string, (payload: unknown) => unknown>();
   let connectionUpdate: ((update: unknown) => void) | undefined;
   let readCalls = 0;
+  const outboundId = options.outboundMessageId ?? "sent-echo";
   const socket = {
     ev: {
       on(event: string, handler: (payload: unknown) => unknown) {
@@ -104,7 +107,7 @@ function makeHarness(
       return Promise.resolve();
     },
     async sendMessage() {
-      return { key: { id: "sent-echo" } };
+      return { key: { id: outboundId, fromMe: true, remoteJid: REACTOR } };
     },
     async sendPresenceUpdate() {},
   };
@@ -146,6 +149,9 @@ function makeHarness(
     },
     async emit(entries: unknown[]) {
       await handlers.get("messages.reaction")?.(entries);
+    },
+    async emitUpsert(messages: unknown[], type: string = "notify") {
+      await handlers.get("messages.upsert")?.({ type, messages });
     },
   };
 }
@@ -388,5 +394,107 @@ describe("WhatsApp reaction adapter integration", () => {
       "reject-me",
       "after-rejection",
     ]);
+  });
+
+  test("LID reaction against own outbound with target.fromMe:false is recognized", async () => {
+    // Exact live-evidence shape: Baileys delivers the reaction via a LID chat
+    // where it cannot equate Samantha's PN identity, so target.fromMe is false
+    // even though we sent the message.
+    const LID = "210565536456917@lid";
+    const harness = makeHarness({
+      lidEntries: [{ lid: LID, phone: REACTOR }],
+      outboundMessageId: "outbound-1",
+    });
+    await harness.start();
+
+    // Step 1: send outbound text — populates sentMessageIds + messageStore.
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: REACTOR,
+      text: "hello",
+    });
+
+    // Step 2: emit outbound upsert echo — sentMessageIds entry consumed,
+    // but messageStore entry survives with key.fromMe: true.
+    await harness.emitUpsert([
+      {
+        key: {
+          remoteJid: LID,
+          id: "outbound-1",
+          fromMe: true,
+        },
+        message: { conversation: "hello" },
+        messageTimestamp: Math.floor(Date.now() / 1000),
+      },
+    ]);
+
+    // Step 3: emit real-shape LID reaction with target.fromMe: false.
+    await harness.emit([
+      reactionEntry({
+        chatId: LID,
+        targetId: "outbound-1",
+        targetFromMe: false,
+        reactionId: "lid-reaction-1",
+        participant: LID,
+      }),
+    ]);
+
+    expect(harness.delivered).toHaveLength(1);
+    expect(harness.delivered[0]?.reaction).toEqual({
+      action: "added",
+      emoji: "👍",
+      targetMessageId: "outbound-1",
+      targetSenderId: "15550000001",
+    });
+  });
+
+  test("unknown targetFromMe:false target remains dropped", async () => {
+    const harness = makeHarness();
+    await harness.start();
+
+    await harness.emit([
+      reactionEntry({
+        targetId: "not-in-any-store",
+        targetFromMe: false,
+        reactionId: "unknown-target",
+      }),
+    ]);
+    expect(harness.delivered).toHaveLength(0);
+  });
+
+  test("target stored from inbound message with key.fromMe:false remains dropped", async () => {
+    // An inbound message (fromMe: false) is stored in messageStore by the
+    // upsert handler. A reaction to it must NOT be treated as "ours."
+    const harness = makeHarness();
+    await harness.start();
+
+    // Simulate an inbound message arriving via upsert.
+    await harness.emitUpsert([
+      {
+        key: {
+          remoteJid: REACTOR,
+          id: "inbound-msg-1",
+          fromMe: false,
+        },
+        message: { conversation: "hi from user" },
+        messageTimestamp: Math.floor(Date.now() / 1000),
+        pushName: "User",
+      },
+    ]);
+    // The upsert handler should have delivered it as a normal inbound.
+    expect(harness.delivered).toHaveLength(1);
+
+    // Now react to that inbound message — target.fromMe is false and the
+    // messageStore entry has fromMe: false. Must be dropped.
+    await harness.emit([
+      reactionEntry({
+        targetId: "inbound-msg-1",
+        targetFromMe: false,
+        reactionId: "react-to-inbound",
+      }),
+    ]);
+    // Still just the original inbound, no reaction delivered.
+    expect(harness.delivered).toHaveLength(1);
   });
 });

--- a/src/channels/whatsapp/reactions-adapter.test.ts
+++ b/src/channels/whatsapp/reactions-adapter.test.ts
@@ -1,0 +1,392 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { InboundChannelMessage } from "@/channels/types";
+import {
+  createWhatsAppAdapter,
+  type WhatsAppAdapterDependencies,
+} from "./adapter";
+import { createLidStore } from "./lid-store";
+
+const PHONE = "15550000001@s.whatsapp.net";
+const REACTOR = "15550000002@s.whatsapp.net";
+const GROUP = "120363-987@g.us";
+
+const temporaryDirectories: string[] = [];
+const trackedAdapters: Array<ReturnType<typeof createWhatsAppAdapter>> = [];
+
+const account = {
+  channel: "whatsapp" as const,
+  accountId: "reaction-adapter",
+  displayName: "WhatsApp",
+  enabled: true,
+  dmPolicy: "pairing" as const,
+  allowedUsers: [],
+  agentId: "agent-1",
+  selfChatMode: false,
+  groupMode: "open" as const,
+  createdAt: new Date(0).toISOString(),
+  updatedAt: new Date(0).toISOString(),
+};
+
+function temporaryDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "whatsapp-reactions-test-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function reactionEntry(
+  overrides: {
+    chatId?: string;
+    targetId?: string;
+    reactionId?: string;
+    targetFromMe?: boolean;
+    reactionFromMe?: boolean;
+    participant?: string;
+    text?: unknown;
+    senderTimestampMs?: unknown;
+  } = {},
+): Record<string, unknown> {
+  const chatId = overrides.chatId ?? REACTOR;
+  return {
+    key: {
+      remoteJid: chatId,
+      id: overrides.targetId ?? "target-message",
+      fromMe: overrides.targetFromMe ?? true,
+    },
+    reaction: {
+      key: {
+        remoteJid: chatId,
+        id: overrides.reactionId ?? "reaction-event",
+        fromMe: overrides.reactionFromMe ?? false,
+        participant: overrides.participant ?? REACTOR,
+      },
+      text: overrides.text === undefined ? "👍" : overrides.text,
+      senderTimestampMs:
+        overrides.senderTimestampMs === undefined
+          ? Date.now()
+          : overrides.senderTimestampMs,
+    },
+  };
+}
+
+function makeHarness(
+  options: {
+    account?: Omit<Partial<typeof account>, "groupMode"> & {
+      groupMode?: "disabled" | "mention" | "open";
+    };
+    lidEntries?: Array<{ lid: string; phone: string }>;
+    deliver?: (message: InboundChannelMessage) => Promise<void> | void;
+  } = {},
+) {
+  const directory = temporaryDirectory();
+  const lidPath = join(directory, "lid-mappings.json");
+  if (options.lidEntries) {
+    writeFileSync(lidPath, JSON.stringify({ entries: options.lidEntries }));
+  }
+  const delivered: InboundChannelMessage[] = [];
+  const eventNames: string[] = [];
+  const handlers = new Map<string, (payload: unknown) => unknown>();
+  let connectionUpdate: ((update: unknown) => void) | undefined;
+  let readCalls = 0;
+  const socket = {
+    ev: {
+      on(event: string, handler: (payload: unknown) => unknown) {
+        eventNames.push(event);
+        handlers.set(event, handler);
+      },
+    },
+    user: { id: PHONE, lid: "999999@lid" },
+    ws: { close() {} },
+    readMessages() {
+      readCalls += 1;
+      return Promise.resolve();
+    },
+    async sendMessage() {
+      return { key: { id: "sent-echo" } };
+    },
+    async sendPresenceUpdate() {},
+  };
+  const createSocket: NonNullable<
+    WhatsAppAdapterDependencies["createSocket"]
+  > = async (params) => {
+    connectionUpdate = params.onConnectionUpdate as unknown as (
+      update: unknown,
+    ) => void;
+    return {
+      sock: socket,
+      saveCreds: async () => undefined,
+      DisconnectReason: {},
+      release: () => undefined,
+    };
+  };
+  const adapter = createWhatsAppAdapter(
+    { ...account, ...options.account },
+    {
+      createSocket,
+      loadRuntimeModule: async () => ({}),
+      lidStore: createLidStore(lidPath),
+    },
+  );
+  adapter.onMessage = async (message) => {
+    delivered.push(message);
+    await options.deliver?.(message);
+  };
+  trackedAdapters.push(adapter);
+
+  return {
+    adapter,
+    delivered,
+    eventNames,
+    readCalls: () => readCalls,
+    async start() {
+      await adapter.start();
+      connectionUpdate?.({ connection: "open" });
+    },
+    async emit(entries: unknown[]) {
+      await handlers.get("messages.reaction")?.(entries);
+    },
+  };
+}
+
+afterEach(async () => {
+  try {
+    for (const adapter of trackedAdapters) {
+      await adapter.stop().catch(() => undefined);
+    }
+  } finally {
+    trackedAdapters.length = 0;
+    for (const directory of temporaryDirectories) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+    temporaryDirectories.length = 0;
+  }
+});
+
+describe("WhatsApp reaction adapter integration", () => {
+  test("registers messages.reaction and dispatches a direct reaction", async () => {
+    const harness = makeHarness();
+    await harness.start();
+    expect(harness.eventNames).toEqual([
+      "messages.upsert",
+      "messages.reaction",
+    ]);
+    await harness.emit([reactionEntry()]);
+    expect(harness.delivered).toHaveLength(1);
+    expect(harness.delivered[0]?.reaction).toEqual({
+      action: "added",
+      emoji: "👍",
+      targetMessageId: "target-message",
+      targetSenderId: "15550000001",
+    });
+  });
+
+  test("emits structured text and canonical target metadata", async () => {
+    const harness = makeHarness();
+    await harness.start();
+    const raw = reactionEntry({ reactionId: "reaction-1" });
+    await harness.emit([raw]);
+    const message = harness.delivered[0];
+    expect(message).toEqual(
+      expect.objectContaining({
+        chatId: REACTOR,
+        senderId: "15550000002",
+        text: "15550000002 reacted 👍",
+        messageId: "reaction-1",
+        chatType: "direct",
+        isMention: true,
+        raw,
+      }),
+    );
+    expect(harness.readCalls()).toBe(0);
+  });
+
+  test("dispatches empty and null reactions as removals", async () => {
+    const harness = makeHarness();
+    await harness.start();
+    await harness.emit([
+      reactionEntry({ reactionId: "removed-empty", text: "" }),
+      reactionEntry({ reactionId: "removed-null", text: null }),
+    ]);
+    expect(harness.delivered.map((message) => message.reaction)).toEqual([
+      {
+        action: "removed",
+        emoji: "",
+        targetMessageId: "target-message",
+        targetSenderId: "15550000001",
+      },
+      {
+        action: "removed",
+        emoji: "",
+        targetMessageId: "target-message",
+        targetSenderId: "15550000001",
+      },
+    ]);
+  });
+
+  test("resolves known direct LIDs and fails closed for unknown/conflicting LIDs", async () => {
+    const known = makeHarness({
+      lidEntries: [{ lid: "777777@lid", phone: REACTOR }],
+    });
+    await known.start();
+    await known.emit([
+      reactionEntry({
+        chatId: "777777@lid",
+        participant: "777777@lid",
+      }),
+    ]);
+    expect(known.delivered[0]?.chatId).toBe(REACTOR);
+    expect(known.delivered[0]?.senderId).toBe("15550000002");
+    expect(known.delivered[0]?.reaction?.targetSenderId).toBe("15550000001");
+
+    const unknown = makeHarness();
+    await unknown.start();
+    await unknown.emit([
+      reactionEntry({
+        chatId: "888888@lid",
+        participant: "888888@lid",
+      }),
+    ]);
+    expect(unknown.delivered).toHaveLength(0);
+
+    const conflicting = makeHarness({
+      lidEntries: [
+        { lid: "999888@lid", phone: REACTOR },
+        { lid: "999888@lid", phone: "15550000003@s.whatsapp.net" },
+      ],
+    });
+    await conflicting.start();
+    await conflicting.emit([
+      reactionEntry({
+        chatId: "999888@lid",
+        participant: "999888@lid",
+      }),
+    ]);
+    expect(conflicting.delivered).toHaveLength(0);
+  });
+
+  test("enforces group policy and preserves mention semantics", async () => {
+    const cases: Array<{
+      groupMode: "disabled" | "mention" | "open";
+      allowedGroups?: string[];
+      expected: boolean;
+      id: string;
+    }> = [
+      { groupMode: "disabled", expected: false, id: "group-disabled" },
+      { groupMode: "open", expected: true, id: "group-open" },
+      {
+        groupMode: "open",
+        allowedGroups: ["120363-other@g.us"],
+        expected: false,
+        id: "group-denied",
+      },
+      {
+        groupMode: "mention",
+        allowedGroups: [GROUP],
+        expected: true,
+        id: "group-mention",
+      },
+    ];
+    for (const policy of cases) {
+      const harness = makeHarness({ account: policy });
+      await harness.start();
+      await harness.emit([
+        reactionEntry({
+          chatId: GROUP,
+          reactionId: policy.id,
+          participant: REACTOR,
+        }),
+      ]);
+      expect(harness.delivered).toHaveLength(policy.expected ? 1 : 0);
+      if (policy.expected) {
+        expect(harness.delivered[0]?.chatType).toBe("channel");
+        expect(harness.delivered[0]?.isMention).toBe(
+          policy.groupMode === "mention",
+        );
+      }
+    }
+  });
+
+  test("drops non-owned targets and own reaction envelopes", async () => {
+    const harness = makeHarness();
+    await harness.start();
+    await harness.emit([
+      reactionEntry({ targetId: "not-ours", targetFromMe: false }),
+      reactionEntry({ reactionId: "own-reaction", reactionFromMe: true }),
+    ]);
+    expect(harness.delivered).toHaveLength(0);
+  });
+
+  test("drops old, sent-echo, and duplicate reaction events", async () => {
+    const harness = makeHarness();
+    await harness.start();
+    await harness.emit([
+      reactionEntry({
+        reactionId: "old",
+        senderTimestampMs: Date.now() - 10_000,
+      }),
+    ]);
+    await harness.emit([
+      reactionEntry({ reactionId: "duplicate" }),
+      reactionEntry({ reactionId: "duplicate" }),
+    ]);
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: REACTOR,
+      text: "",
+      reaction: "👍",
+      targetMessageId: "target-message",
+    });
+    await harness.emit([reactionEntry({ reactionId: "sent-echo" })]);
+    expect(harness.delivered).toHaveLength(1);
+    expect(harness.delivered[0]?.messageId).toBe("duplicate");
+  });
+
+  test("deduplicates reaction IDs within a canonical chat only", async () => {
+    const harness = makeHarness();
+    await harness.start();
+    await harness.emit([
+      reactionEntry({
+        chatId: REACTOR,
+        reactionId: "shared-id",
+        participant: REACTOR,
+      }),
+      reactionEntry({
+        chatId: "15550000003@s.whatsapp.net",
+        reactionId: "shared-id",
+        participant: "15550000003@s.whatsapp.net",
+      }),
+      reactionEntry({
+        chatId: REACTOR,
+        reactionId: "shared-id",
+        participant: REACTOR,
+      }),
+    ]);
+    expect(harness.delivered.map((message) => message.chatId)).toEqual([
+      REACTOR,
+      "15550000003@s.whatsapp.net",
+    ]);
+  });
+
+  test("continues after malformed entries and rejected delivery", async () => {
+    const rejected = makeHarness({
+      deliver: async (message) => {
+        if (message.messageId === "reject-me") {
+          throw new Error("delivery failed");
+        }
+      },
+    });
+    await rejected.start();
+    await rejected.emit([
+      { malformed: true },
+      reactionEntry({ reactionId: "reject-me" }),
+      reactionEntry({ reactionId: "after-rejection" }),
+    ]);
+    expect(rejected.delivered.map((message) => message.messageId)).toEqual([
+      "reject-me",
+      "after-rejection",
+    ]);
+  });
+});

--- a/src/channels/whatsapp/reactions.test.ts
+++ b/src/channels/whatsapp/reactions.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isWhatsAppReactionGroupEligible,
+  parseWhatsAppReactionEntry,
+} from "./reactions";
+
+function entry(overrides: Record<string, unknown> = {}) {
+  return {
+    key: {
+      remoteJid: "120363-987@g.us",
+      id: "target-message",
+      fromMe: true,
+      participant: "15550000002@s.whatsapp.net",
+    },
+    reaction: {
+      key: {
+        remoteJid: "120363-987:4@g.us",
+        id: "reaction-event",
+        participant: "15550000003@s.whatsapp.net",
+      },
+      text: "👍",
+      senderTimestampMs: 1710000000123,
+    },
+    ...overrides,
+  };
+}
+
+describe("WhatsApp reaction parser", () => {
+  test("parses an added emoji and preserves both keys", () => {
+    const parsed = parseWhatsAppReactionEntry(entry());
+    expect(parsed).toEqual({
+      targetKey: expect.objectContaining({
+        id: "target-message",
+        remoteJid: "120363-987@g.us",
+      }),
+      reactionKey: expect.objectContaining({
+        id: "reaction-event",
+        remoteJid: "120363-987@g.us",
+      }),
+      chatId: "120363-987@g.us",
+      reactionMessageId: "reaction-event",
+      targetMessageId: "target-message",
+      targetFromMe: true,
+      reactorParticipant: "15550000003@s.whatsapp.net",
+      action: "added",
+      emoji: "👍",
+      timestampMs: 1710000000123,
+    });
+  });
+
+  test("parses empty, null, and undefined text as removals", () => {
+    for (const text of ["", "   ", null, undefined]) {
+      const parsed = parseWhatsAppReactionEntry(
+        entry({ reaction: { ...entry().reaction, text } }),
+      );
+      expect(parsed?.action).toBe("removed");
+      expect(parsed?.emoji).toBe("");
+    }
+  });
+
+  test("preserves group participants and accepts numeric/toNumber timestamps", () => {
+    const numeric = parseWhatsAppReactionEntry(entry());
+    expect(numeric?.reactorParticipant).toBe("15550000003@s.whatsapp.net");
+    expect(numeric?.timestampMs).toBe(1710000000123);
+
+    const boxed = parseWhatsAppReactionEntry(
+      entry({
+        reaction: {
+          ...entry().reaction,
+          senderTimestampMs: { toNumber: () => 1710000000999 },
+        },
+      }),
+    );
+    expect(boxed?.timestampMs).toBe(1710000000999);
+  });
+
+  test("rejects malformed entries without throwing", () => {
+    const invalidEntries: unknown[] = [
+      entry({ key: { remoteJid: "120363-987@g.us" } }),
+      entry({ reaction: { key: { remoteJid: "120363-987@g.us" } } }),
+      entry({ key: "not-an-object" }),
+      entry({
+        reaction: {
+          ...entry().reaction,
+          key: { remoteJid: "120363-988@g.us", id: "reaction-event" },
+        },
+      }),
+      entry({
+        reaction: { ...entry().reaction, text: { emoji: "👍" } },
+      }),
+      entry({
+        reaction: { ...entry().reaction, text: "x".repeat(65) },
+      }),
+      entry({ key: { remoteJid: "malformed", id: "target-message" } }),
+    ];
+
+    for (const invalid of invalidEntries) {
+      expect(() => parseWhatsAppReactionEntry(invalid)).not.toThrow();
+      expect(parseWhatsAppReactionEntry(invalid)).toBeNull();
+    }
+  });
+});
+
+describe("WhatsApp reaction group policy", () => {
+  const groupJid = "120363-987@g.us";
+
+  test("enforces disabled, allowlist, open, and mention behavior", () => {
+    expect(
+      isWhatsAppReactionGroupEligible({
+        groupMode: "disabled",
+        groupJid,
+        targetFromMe: true,
+      }),
+    ).toBe(false);
+    expect(
+      isWhatsAppReactionGroupEligible({
+        groupMode: "open",
+        allowedGroups: ["120363-other@g.us"],
+        groupJid,
+        targetFromMe: true,
+      }),
+    ).toBe(false);
+    expect(
+      isWhatsAppReactionGroupEligible({
+        groupMode: "open",
+        allowedGroups: [groupJid],
+        groupJid: "120363-987:4@g.us",
+        targetFromMe: true,
+      }),
+    ).toBe(true);
+    expect(
+      isWhatsAppReactionGroupEligible({
+        groupMode: "mention",
+        groupJid,
+        targetFromMe: true,
+      }),
+    ).toBe(true);
+    expect(
+      isWhatsAppReactionGroupEligible({
+        groupMode: "mention",
+        groupJid,
+        targetFromMe: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/channels/whatsapp/reactions.test.ts
+++ b/src/channels/whatsapp/reactions.test.ts
@@ -58,6 +58,35 @@ describe("WhatsApp reaction parser", () => {
     }
   });
 
+  test("preserves Baileys PN/LID identity fields on reaction keys", () => {
+    const parsed = parseWhatsAppReactionEntry(
+      entry({
+        reaction: {
+          ...entry().reaction,
+          key: {
+            remoteJid: "120363-987@g.us",
+            id: "reaction-event",
+            participant: "200000@lid",
+            participantPn: "15550000003@s.whatsapp.net",
+            participantLid: "200000@lid",
+            senderPn: "15550000004@s.whatsapp.net",
+            senderLid: "300000@lid",
+          },
+        },
+      }),
+    );
+
+    expect(parsed?.reactionKey).toEqual(
+      expect.objectContaining({
+        participant: "200000@lid",
+        participantPn: "15550000003@s.whatsapp.net",
+        participantLid: "200000@lid",
+        senderPn: "15550000004@s.whatsapp.net",
+        senderLid: "300000@lid",
+      }),
+    );
+  });
+
   test("preserves group participants and accepts numeric/toNumber timestamps", () => {
     const numeric = parseWhatsAppReactionEntry(entry());
     expect(numeric?.reactorParticipant).toBe("15550000003@s.whatsapp.net");
@@ -90,6 +119,16 @@ describe("WhatsApp reaction parser", () => {
       }),
       entry({
         reaction: { ...entry().reaction, text: "x".repeat(65) },
+      }),
+      entry({
+        reaction: {
+          ...entry().reaction,
+          key: {
+            remoteJid: "120363-987@g.us",
+            id: "reaction-event",
+            senderPn: 123,
+          },
+        },
       }),
       entry({ key: { remoteJid: "malformed", id: "target-message" } }),
     ];

--- a/src/channels/whatsapp/reactions.ts
+++ b/src/channels/whatsapp/reactions.ts
@@ -6,6 +6,10 @@ export interface WhatsAppReactionKey {
   id: string;
   fromMe?: boolean;
   participant?: string;
+  senderPn?: string;
+  senderLid?: string;
+  participantPn?: string;
+  participantLid?: string;
   [key: string]: unknown;
 }
 
@@ -49,20 +53,28 @@ function parseKey(value: unknown): WhatsAppReactionKey | null {
   if (value.fromMe !== undefined && typeof value.fromMe !== "boolean") {
     return null;
   }
-  if (
-    value.participant !== undefined &&
-    typeof value.participant !== "string"
-  ) {
-    return null;
+  const optionalJidFields = [
+    "participant",
+    "senderPn",
+    "senderLid",
+    "participantPn",
+    "participantLid",
+  ] as const;
+  for (const field of optionalJidFields) {
+    if (value[field] !== undefined && typeof value[field] !== "string") {
+      return null;
+    }
   }
   return {
     ...value,
     id: value.id,
     remoteJid: typeof value.remoteJid === "string" ? value.remoteJid : "",
     ...(value.fromMe === undefined ? {} : { fromMe: value.fromMe }),
-    ...(value.participant === undefined
-      ? {}
-      : { participant: value.participant }),
+    ...Object.fromEntries(
+      optionalJidFields.flatMap((field) =>
+        value[field] === undefined ? [] : [[field, value[field]]],
+      ),
+    ),
   };
 }
 

--- a/src/channels/whatsapp/reactions.ts
+++ b/src/channels/whatsapp/reactions.ts
@@ -1,0 +1,153 @@
+import type { WhatsAppGroupMode } from "@/channels/types";
+import { isStrictLidJid, isStrictPhoneJid, stripDeviceSuffix } from "./jid";
+
+export interface WhatsAppReactionKey {
+  remoteJid: string;
+  id: string;
+  fromMe?: boolean;
+  participant?: string;
+  [key: string]: unknown;
+}
+
+export interface WhatsAppReaction {
+  targetKey: WhatsAppReactionKey;
+  reactionKey: WhatsAppReactionKey;
+  chatId: string;
+  reactionMessageId: string;
+  targetMessageId: string;
+  targetFromMe: boolean;
+  reactorParticipant?: string;
+  action: "added" | "removed";
+  emoji: string;
+  timestampMs?: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+function canonicalChatJid(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = stripDeviceSuffix(value.trim());
+  if (!normalized) return null;
+  const isGroup = /^\d[\d-]*@g\.us$/.test(normalized);
+  if (
+    !isGroup &&
+    !isStrictPhoneJid(normalized) &&
+    !isStrictLidJid(normalized)
+  ) {
+    return null;
+  }
+  return normalized;
+}
+
+function parseKey(value: unknown): WhatsAppReactionKey | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.id !== "string" || value.id.trim().length === 0) {
+    return null;
+  }
+  if (value.fromMe !== undefined && typeof value.fromMe !== "boolean") {
+    return null;
+  }
+  if (
+    value.participant !== undefined &&
+    typeof value.participant !== "string"
+  ) {
+    return null;
+  }
+  return {
+    ...value,
+    id: value.id,
+    remoteJid: typeof value.remoteJid === "string" ? value.remoteJid : "",
+    ...(value.fromMe === undefined ? {} : { fromMe: value.fromMe }),
+    ...(value.participant === undefined
+      ? {}
+      : { participant: value.participant }),
+  };
+}
+
+function parseTimestamp(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value >= 0 ? value : undefined;
+  }
+  if (!isRecord(value) || typeof value.toNumber !== "function") {
+    return undefined;
+  }
+  try {
+    const numeric = value.toNumber();
+    return typeof numeric === "number" &&
+      Number.isFinite(numeric) &&
+      numeric >= 0
+      ? numeric
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Parse one Baileys `messages.reaction` entry without resolving identities. */
+export function parseWhatsAppReactionEntry(
+  entry: unknown,
+): WhatsAppReaction | null {
+  try {
+    if (!isRecord(entry) || !isRecord(entry.reaction)) return null;
+    const targetKey = parseKey(entry.key);
+    const reactionKey = parseKey(entry.reaction.key);
+    if (!targetKey || !reactionKey) return null;
+
+    const targetChatId = canonicalChatJid(targetKey.remoteJid);
+    const reactionChatId = canonicalChatJid(reactionKey.remoteJid);
+    if (!targetChatId || targetChatId !== reactionChatId) return null;
+
+    const text = entry.reaction.text;
+    if (text !== null && text !== undefined && typeof text !== "string") {
+      return null;
+    }
+    const emoji = typeof text === "string" ? text.trim() : "";
+    if (emoji.length > 64) return null;
+
+    return {
+      targetKey: {
+        ...targetKey,
+        remoteJid: targetChatId,
+        id: targetKey.id,
+      },
+      reactionKey: {
+        ...reactionKey,
+        remoteJid: targetChatId,
+        id: reactionKey.id,
+      },
+      chatId: targetChatId,
+      reactionMessageId: reactionKey.id,
+      targetMessageId: targetKey.id,
+      targetFromMe: targetKey.fromMe === true,
+      reactorParticipant:
+        typeof reactionKey.participant === "string"
+          ? reactionKey.participant
+          : undefined,
+      action: emoji ? "added" : "removed",
+      emoji: emoji || "",
+      timestampMs: parseTimestamp(entry.reaction.senderTimestampMs),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function isWhatsAppReactionGroupEligible(params: {
+  groupMode: WhatsAppGroupMode;
+  allowedGroups?: string[];
+  groupJid: string;
+  targetFromMe: boolean;
+}): boolean {
+  const canonicalGroupJid = stripDeviceSuffix(params.groupJid);
+  if (params.groupMode === "disabled") return false;
+  if (
+    params.allowedGroups?.length &&
+    !params.allowedGroups.includes(canonicalGroupJid)
+  ) {
+    return false;
+  }
+  if (params.targetFromMe !== true) return false;
+  return params.groupMode === "open" || params.groupMode === "mention";
+}


### PR DESCRIPTION
## Problem
WhatsApp message reactions were not handled at the Baileys reaction event boundary. In Baileys 6.7.21, real add/remove reactions arrive on `sock.ev.on("messages.reaction", entries)`; `reactionMessage` content seen through `messages.upsert` is only the synthetic wrapper and should not be routed as an inbound chat message.

## Before / after
Before, reactions could be missed, misattributed across PN/LID identities, or routed into pairing/unbound prompts. After, reactions parse into structured inbound messages with canonical sender/target metadata, dedupe by canonical chat, and leave ordinary text/media upserts unchanged.

## Controls and behavior
- Access and routing: denied, unpaired, or unrouted reactions are dropped silently. Only reactions to messages owned by the linked account are surfaced; unknown or inbound-owned targets fail closed.
- LID/PN: Baileys `senderPn`, `senderLid`, `participantPn`, and `participantLid` are preserved and used for first-reaction identity resolution.
- Removal/groups: empty reaction text removes a reaction and does not require an emoji. Group outbound reactions reuse the original stored Baileys target key, including participant, for add and removal.
- Restart limit: the target-key cache is process-local and bounded. After restart or expiry, outbound group reactions require the target message to be observed again.

## Risk
Channel adapter/parser change limited to WhatsApp. Main risk is Baileys event shape variance or process-local cache expiry; both fail closed instead of sending malformed group reaction keys or surfacing untrusted targets.

## Tests
- 34 focused WhatsApp reaction tests
- 130 WhatsApp tests
- `bun run check`

Depends on public letta-code PR #3599: https://github.com/letta-ai/letta-code/pull/3599
Replaces the reaction portion of public letta-code PR #3400 while preserving useful source material: https://github.com/letta-ai/letta-code/pull/3400

👾 Generated with [Letta Code](https://letta.com)