### PR TITLE
feat(whatsapp): debounce inbound messages

### DIFF
--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -207,6 +207,13 @@ function prepareAccountForStorage(account: ChannelAccount): ChannelAccount {
   return cloned;
 }
 
+function normalizeInboundDebounceMs(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return undefined;
+  }
+  return Math.trunc(Math.min(value, 10000));
+}
+
 function cloneAccount<T extends ChannelAccount>(account: T): T {
   const cloned = {
     ...account,
@@ -357,6 +364,7 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
     next.mentionPatterns = [...(next.mentionPatterns ?? [])];
     next.downloadMedia = next.downloadMedia === true;
     next.transcribeVoice = next.transcribeVoice === true;
+    next.inboundDebounceMs = normalizeInboundDebounceMs(next.inboundDebounceMs);
   }
   if (isSignalChannelAccount(next)) {
     next.baseUrl = next.baseUrl ?? "";
@@ -443,6 +451,7 @@ function makeDefaultLegacyAccount(
       transcribeVoice: config.transcribeVoice === true,
       downloadMedia: config.downloadMedia === true,
       mediaMaxBytes: config.mediaMaxBytes,
+      inboundDebounceMs: config.inboundDebounceMs,
       createdAt: now,
       updatedAt: now,
     };

--- a/src/channels/config.ts
+++ b/src/channels/config.ts
@@ -283,6 +283,12 @@ const whatsappConfigCodec: ChannelConfigCodec<WhatsAppChannelConfig> = {
         typeof parsed.media_max_bytes === "number"
           ? parsed.media_max_bytes
           : undefined,
+      inboundDebounceMs:
+        typeof parsed.inbound_debounce_ms === "number" &&
+        Number.isFinite(parsed.inbound_debounce_ms) &&
+        parsed.inbound_debounce_ms >= 0
+          ? Math.trunc(Math.min(parsed.inbound_debounce_ms, 10000))
+          : undefined,
     };
   },
 };

--- a/src/channels/inbound-debounce.test.ts
+++ b/src/channels/inbound-debounce.test.ts
@@ -165,6 +165,41 @@ describe("createInboundDebouncer", () => {
     expect(flushed).toEqual([["a", "b"]]);
   });
 
+  test("flushAll forces every pending key to flush", async () => {
+    const debouncer = createInboundDebouncer<Item>({
+      debounceMs: 1000,
+      buildKey: (item) => item.key,
+      onFlush: async (items) => {
+        flushed.push(items.map((i) => i.value));
+      },
+    });
+
+    await debouncer.enqueue({ key: "a", value: "a1" });
+    await debouncer.enqueue({ key: "b", value: "b1" });
+    await debouncer.enqueue({ key: "a", value: "a2" });
+    await debouncer.flushAll();
+    const sorted = flushed.map((batch) => [...batch].sort()).sort();
+    expect(sorted).toEqual([["a1", "a2"], ["b1"]]);
+  });
+
+  test("cancelAll drops pending debounced buffers", async () => {
+    const debouncer = createInboundDebouncer<Item>({
+      debounceMs: 20,
+      buildKey: (item) => item.key,
+      onFlush: async (items) => {
+        flushed.push(items.map((i) => i.value));
+      },
+    });
+
+    await debouncer.enqueue({ key: "k", value: "a" });
+    debouncer.cancelAll();
+    await sleep(50);
+    expect(flushed).toEqual([]);
+    await debouncer.enqueue({ key: "k", value: "b" });
+    await sleep(50);
+    expect(flushed).toEqual([["b"]]);
+  });
+
   test("null key forces immediate flush", async () => {
     const debouncer = createInboundDebouncer<Item>({
       debounceMs: 50,

--- a/src/channels/inbound-debounce.ts
+++ b/src/channels/inbound-debounce.ts
@@ -54,6 +54,10 @@ export interface InboundDebouncer<T> {
   enqueue: (item: T) => Promise<void>;
   /** Force an immediate flush for a specific key, if any buffer is pending. */
   flushKey: (key: string) => Promise<void>;
+  /** Force every pending key to flush immediately. */
+  flushAll: () => Promise<void>;
+  /** Cancel every pending debounced buffer without calling `onFlush`. */
+  cancelAll: () => void;
 }
 
 export function createInboundDebouncer<T>(
@@ -151,6 +155,27 @@ export function createInboundDebouncer<T>(
     await flushBuffer(key, buffer);
   };
 
+  const flushAllInternal = async (): Promise<void> => {
+    await Promise.all(
+      Array.from(buffers.entries()).map(([key, buffer]) =>
+        flushBuffer(key, buffer),
+      ),
+    );
+  };
+
+  const cancelAllInternal = (): void => {
+    for (const [key, buffer] of Array.from(buffers.entries())) {
+      buffers.delete(key);
+      if (buffer.timeout) {
+        clearTimeout(buffer.timeout);
+        buffer.timeout = null;
+      }
+      buffer.items = [];
+      releaseBuffer(buffer);
+      void buffer.task.catch(() => undefined);
+    }
+  };
+
   const scheduleFlush = (key: string, buffer: DebounceBuffer<T>): void => {
     if (buffer.timeout) {
       clearTimeout(buffer.timeout);
@@ -240,5 +265,7 @@ export function createInboundDebouncer<T>(
   return {
     enqueue,
     flushKey: flushKeyInternal,
+    flushAll: flushAllInternal,
+    cancelAll: cancelAllInternal,
   };
 }

--- a/src/channels/service-account-model.ts
+++ b/src/channels/service-account-model.ts
@@ -122,6 +122,7 @@ export function createAccountFromPatch(
       transcribeVoice: normalizedPatch.transcribeVoice === true,
       downloadMedia: normalizedPatch.downloadMedia === true,
       mediaMaxBytes: normalizedPatch.mediaMaxBytes,
+      inboundDebounceMs: normalizedPatch.inboundDebounceMs,
       createdAt: now,
       updatedAt: now,
     };
@@ -282,6 +283,8 @@ export function mergeAccountPatch(
       downloadMedia:
         normalizedPatch.downloadMedia ?? existing.downloadMedia ?? false,
       mediaMaxBytes: normalizedPatch.mediaMaxBytes ?? existing.mediaMaxBytes,
+      inboundDebounceMs:
+        normalizedPatch.inboundDebounceMs ?? existing.inboundDebounceMs,
       updatedAt: nextUpdatedAt,
     };
   }

--- a/src/channels/service-snapshots.ts
+++ b/src/channels/service-snapshots.ts
@@ -196,6 +196,7 @@ export function toAccountSnapshot(
       transcribeVoice: account.transcribeVoice === true,
       downloadMedia: account.downloadMedia === true,
       mediaMaxBytes: account.mediaMaxBytes,
+      inboundDebounceMs: account.inboundDebounceMs,
       createdAt: account.createdAt,
       updatedAt: account.updatedAt,
     };
@@ -387,6 +388,7 @@ export function getChannelConfigSnapshot(
       transcribeVoice: account.transcribeVoice === true,
       downloadMedia: account.downloadMedia === true,
       mediaMaxBytes: account.mediaMaxBytes,
+      inboundDebounceMs: account.inboundDebounceMs,
     };
   }
 

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -681,6 +681,8 @@ export interface WhatsAppChannelConfig {
   downloadMedia?: boolean;
   /** Maximum inbound media bytes to download. Undefined uses channel default. */
   mediaMaxBytes?: number;
+  /** Inbound text debounce window in ms; 0/default disables. */
+  inboundDebounceMs?: number;
 }
 
 export interface SignalChannelConfig {
@@ -866,6 +868,8 @@ export interface WhatsAppChannelAccount extends ChannelAccountBase {
   downloadMedia?: boolean;
   /** Maximum inbound media bytes to download. Undefined uses channel default. */
   mediaMaxBytes?: number;
+  /** Inbound text debounce window in ms; 0/default disables. */
+  inboundDebounceMs?: number;
 }
 
 export interface SignalChannelAccount extends ChannelAccountBase {

--- a/src/channels/whatsapp-service.test.ts
+++ b/src/channels/whatsapp-service.test.ts
@@ -98,6 +98,7 @@ describe("WhatsApp channel service", () => {
           mention_patterns: ["\\bloop\\b"],
           download_media: true,
           media_max_bytes: 1048576,
+          inbound_debounce_ms: 250.9,
         },
       },
       { accountId: "personal" },
@@ -110,12 +111,69 @@ describe("WhatsApp channel service", () => {
     expect(created.mentionPatterns).toEqual(["\\bloop\\b"]);
     expect(created.downloadMedia).toBe(true);
     expect(created.mediaMaxBytes).toBe(1048576);
+    expect(created.inboundDebounceMs).toBe(250);
+    expect(created.config).toEqual(
+      expect.objectContaining({ inbound_debounce_ms: 250 }),
+    );
+
+    const clamped = updateChannelAccountLive("whatsapp", "personal", {
+      config: { inbound_debounce_ms: 20_000 },
+    });
+    expect(clamped.inboundDebounceMs).toBe(10_000);
 
     const updated = updateChannelAccountLive("whatsapp", "personal", {
       config: { group_mode: "open", self_chat_mode: true },
     });
     expect(updated.groupMode).toBe("open");
     expect(updated.selfChatMode).toBe(true);
+    expect(updated.inboundDebounceMs).toBe(10_000);
+  });
+
+  test("loads old WhatsApp accounts without debounce and accepts stored snake_case debounce", () => {
+    const oldAccount = {
+      channel: "whatsapp" as const,
+      accountId: "old",
+      enabled: true,
+      dmPolicy: "pairing" as const,
+      allowedUsers: [],
+      agentId: null,
+      selfChatMode: true,
+      groupMode: "disabled" as const,
+      allowedGroups: [],
+      mentionPatterns: [],
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    };
+    const storedSnakeAccount = {
+      channel: "whatsapp" as const,
+      accountId: "snake",
+      enabled: true,
+      dmPolicy: "pairing" as const,
+      allowedUsers: [],
+      agentId: null,
+      selfChatMode: true,
+      groupMode: "disabled" as const,
+      allowedGroups: [],
+      mentionPatterns: [],
+      inbound_debounce_ms: 999.8,
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    };
+    __testOverrideLoadChannelAccounts(() => [oldAccount, storedSnakeAccount]);
+    clearChannelAccountStores();
+
+    expect(getChannelConfigSnapshot("whatsapp", "old")).toEqual(
+      expect.objectContaining({
+        inboundDebounceMs: undefined,
+        config: expect.objectContaining({ inbound_debounce_ms: 0 }),
+      }),
+    );
+    expect(getChannelConfigSnapshot("whatsapp", "snake")).toEqual(
+      expect.objectContaining({
+        inboundDebounceMs: 999,
+        config: expect.objectContaining({ inbound_debounce_ms: 999 }),
+      }),
+    );
   });
 
   test("bind updates the account-level agent id", () => {

--- a/src/channels/whatsapp/account-config.ts
+++ b/src/channels/whatsapp/account-config.ts
@@ -14,6 +14,7 @@ const WHATSAPP_CONFIG_KEYS = new Set([
   "transcribe_voice",
   "download_media",
   "media_max_bytes",
+  "inbound_debounce_ms",
 ]);
 
 function isNullableString(value: unknown): value is string | null {
@@ -38,6 +39,10 @@ function isPositiveNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
 
+function isValidInboundDebounceMs(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
 export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppChannelAccount> =
   {
     isValidConfig(config) {
@@ -60,7 +65,9 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         (config.download_media === undefined ||
           isBoolean(config.download_media)) &&
         (config.media_max_bytes === undefined ||
-          isPositiveNumber(config.media_max_bytes))
+          isPositiveNumber(config.media_max_bytes)) &&
+        (config.inbound_debounce_ms === undefined ||
+          isValidInboundDebounceMs(config.inbound_debounce_ms))
       );
     },
 
@@ -90,6 +97,9 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         mediaMaxBytes: isPositiveNumber(config.media_max_bytes)
           ? config.media_max_bytes
           : undefined,
+        inboundDebounceMs: isValidInboundDebounceMs(config.inbound_debounce_ms)
+          ? Math.trunc(Math.min(config.inbound_debounce_ms, 10000))
+          : undefined,
       };
     },
 
@@ -103,6 +113,7 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         transcribe_voice: account.transcribeVoice === true,
         download_media: account.downloadMedia === true,
         media_max_bytes: account.mediaMaxBytes,
+        inbound_debounce_ms: account.inboundDebounceMs ?? 0,
         ...toWhatsAppConnectionConfig(account.accountId),
       };
     },
@@ -117,6 +128,7 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         transcribe_voice: account.transcribeVoice === true,
         download_media: account.downloadMedia === true,
         media_max_bytes: account.mediaMaxBytes,
+        inbound_debounce_ms: account.inboundDebounceMs ?? 0,
         ...toWhatsAppConnectionConfig(account.accountId),
       };
     },

--- a/src/channels/whatsapp/adapter.test.ts
+++ b/src/channels/whatsapp/adapter.test.ts
@@ -117,8 +117,15 @@ function makeHarness(
   };
 }
 
+type DebounceConnectionUpdateHandler = NonNullable<
+  Parameters<
+    NonNullable<WhatsAppAdapterDependencies["createSocket"]>
+  >[0]["onConnectionUpdate"]
+>;
+
 type DebounceHarnessSocket = {
   upsertHandler?: (payload: unknown) => unknown;
+  connectionUpdate?: DebounceConnectionUpdateHandler;
   readCalls: string[][];
   closed: number;
 };
@@ -137,8 +144,12 @@ function makeDebounceHarness(options: {
   };
   const createSocket: NonNullable<
     WhatsAppAdapterDependencies["createSocket"]
-  > = async () => {
-    const socketRecord: DebounceHarnessSocket = { readCalls: [], closed: 0 };
+  > = async (runtimeOptions) => {
+    const socketRecord: DebounceHarnessSocket = {
+      connectionUpdate: runtimeOptions.onConnectionUpdate,
+      readCalls: [],
+      closed: 0,
+    };
     const socket = {
       ev: {
         on(event: string, handler: (payload: unknown) => void) {
@@ -185,6 +196,12 @@ function makeDebounceHarness(options: {
       await sockets[socketIndex]?.upsertHandler?.({
         type: emitOptions?.type ?? "notify",
         messages,
+      });
+    },
+    closeConnection(socketIndex = sockets.length - 1) {
+      sockets[socketIndex]?.connectionUpdate?.({
+        connection: "close",
+        lastDisconnect: { error: { message: "network" } },
       });
     },
   };
@@ -499,10 +516,11 @@ describe("WhatsApp adapter inbound debounce and read receipts", () => {
       }),
     ]);
 
-    expect(harness.sockets[0]?.readCalls).toEqual([["one", "two"]]);
     expect(received).toEqual([]);
+    expect(harness.sockets[0]?.readCalls).toEqual([]);
     await sleep(60);
     expect(received).toHaveLength(1);
+    expect(harness.sockets[0]?.readCalls).toEqual([["one", "two"]]);
     expect(received[0]?.chatId).toBe(group("120363"));
     expect(received[0]?.senderId).toBe("15550000006");
     expect(received[0]?.text).toBe("first\nsecond");
@@ -619,9 +637,11 @@ describe("WhatsApp adapter inbound debounce and read receipts", () => {
     await harness.adapter.start();
 
     await harness.emit([makeTextMessage(phone("15550000061"), "old", "old")]);
+    expect(harness.sockets[0]?.readCalls).toEqual([]);
     await harness.adapter.stop();
     await sleep(70);
     expect(received).toEqual([]);
+    expect(harness.sockets[0]?.readCalls).toEqual([]);
 
     await harness.adapter.start();
     await harness.emit(
@@ -630,13 +650,60 @@ describe("WhatsApp adapter inbound debounce and read receipts", () => {
     );
     await sleep(70);
     expect(received).toEqual([]);
+    expect(harness.sockets[0]?.readCalls).toEqual([]);
     expect(harness.sockets[1]?.readCalls).toEqual([]);
 
     await harness.emit([
       makeTextMessage(phone("15550000063"), "fresh", "fresh"),
     ]);
-    expect(harness.sockets[1]?.readCalls).toEqual([["fresh"]]);
+    expect(harness.sockets[1]?.readCalls).toEqual([]);
     await sleep(70);
     expect(received.map((message) => message.text)).toEqual(["fresh"]);
+    expect(harness.sockets[1]?.readCalls).toEqual([["fresh"]]);
+  });
+
+  test("connection close invalidates pending debounce and stale socket traffic without reads", async () => {
+    const received: InboundChannelMessage[] = [];
+    const harness = makeDebounceHarness({
+      store: createLidStore(join(dir, "lid.json")),
+      accountPatch: { inboundDebounceMs: 40 },
+      onMessage: async (message) => {
+        received.push(message);
+      },
+    });
+    await harness.adapter.start();
+
+    await harness.emit([makeTextMessage(phone("15550000071"), "old", "old")]);
+    expect(harness.sockets[0]?.readCalls).toEqual([]);
+    harness.closeConnection(0);
+    await sleep(70);
+    expect(received).toEqual([]);
+    expect(harness.sockets[0]?.readCalls).toEqual([]);
+
+    await harness.emit(
+      [makeTextMessage(phone("15550000072"), "stale", "stale")],
+      { socketIndex: 0 },
+    );
+    await sleep(70);
+    expect(received).toEqual([]);
+    expect(harness.sockets[0]?.readCalls).toEqual([]);
+    await harness.adapter.stop();
+  });
+
+  test("handler rejection does not mark messages read", async () => {
+    const harness = makeDebounceHarness({
+      store: createLidStore(join(dir, "lid.json")),
+      accountPatch: { inboundDebounceMs: 20 },
+      onMessage: async () => {
+        throw new Error("handler failed");
+      },
+    });
+    await harness.adapter.start();
+
+    await harness.emit([
+      makeTextMessage(phone("15550000081"), "rejected", "rejected"),
+    ]);
+    await sleep(60);
+    expect(harness.sockets[0]?.readCalls).toEqual([]);
   });
 });

--- a/src/channels/whatsapp/adapter.test.ts
+++ b/src/channels/whatsapp/adapter.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { InboundChannelMessage } from "@/channels/types";
+import type {
+  InboundChannelMessage,
+  WhatsAppChannelAccount,
+} from "@/channels/types";
 import {
   createWhatsAppAdapter,
   type WhatsAppAdapterDependencies,
@@ -36,11 +39,24 @@ function makeMessage(
   id: string,
   key: Record<string, unknown> = {},
 ): Record<string, unknown> {
+  return makeTextMessage(remoteJid, id, "hello", key);
+}
+
+function makeTextMessage(
+  remoteJid: string,
+  id: string,
+  text: string,
+  key: Record<string, unknown> = {},
+): Record<string, unknown> {
   return {
     key: { remoteJid, id, ...key },
-    message: { conversation: "hello" },
+    message: { conversation: text },
     messageTimestamp: Math.floor(Date.now() / 1000),
   };
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function instrumentStore(store: LidStore): LidStore & { flushes: number } {
@@ -98,6 +114,79 @@ function makeHarness(
       await upsertHandler?.({ type: "notify", messages });
     },
     sentJids,
+  };
+}
+
+type DebounceHarnessSocket = {
+  upsertHandler?: (payload: unknown) => unknown;
+  readCalls: string[][];
+  closed: number;
+};
+
+function makeDebounceHarness(options: {
+  store: LidStore;
+  accountPatch?: Partial<WhatsAppChannelAccount>;
+  onMessage: (message: InboundChannelMessage) => Promise<void>;
+  readMessages?: (keys: Record<string, unknown>[]) => Promise<unknown>;
+}) {
+  const sockets: DebounceHarnessSocket[] = [];
+  const testAccount: WhatsAppChannelAccount = {
+    ...account,
+    accountId: options.accountPatch?.accountId ?? "debounce-test",
+    ...options.accountPatch,
+  };
+  const createSocket: NonNullable<
+    WhatsAppAdapterDependencies["createSocket"]
+  > = async () => {
+    const socketRecord: DebounceHarnessSocket = { readCalls: [], closed: 0 };
+    const socket = {
+      ev: {
+        on(event: string, handler: (payload: unknown) => void) {
+          if (event === "messages.upsert") socketRecord.upsertHandler = handler;
+        },
+      },
+      ws: {
+        close() {
+          socketRecord.closed += 1;
+        },
+      },
+      user: { id: phone("15551234567"), lid: lid("777000111") },
+      async readMessages(keys: Record<string, unknown>[]) {
+        socketRecord.readCalls.push(keys.map((key) => String(key.id)));
+        if (options.readMessages) return options.readMessages(keys);
+        return undefined;
+      },
+      async sendMessage() {
+        return { key: { id: "outbound" } };
+      },
+    };
+    sockets.push(socketRecord);
+    return {
+      sock: socket,
+      saveCreds: async () => undefined,
+      DisconnectReason: {},
+      release: () => undefined,
+    };
+  };
+  const adapter = createWhatsAppAdapter(testAccount, {
+    createSocket,
+    loadRuntimeModule: async () => ({}),
+    lidStore: options.store,
+  });
+  adapter.onMessage = options.onMessage;
+  return {
+    adapter,
+    sockets,
+    async emit(
+      messages: Record<string, unknown>[],
+      emitOptions?: { socketIndex?: number; type?: "notify" | "append" },
+    ) {
+      const socketIndex = emitOptions?.socketIndex ?? sockets.length - 1;
+      await sockets[socketIndex]?.upsertHandler?.({
+        type: emitOptions?.type ?? "notify",
+        messages,
+      });
+    },
   };
 }
 
@@ -375,5 +464,179 @@ describe("WhatsApp adapter canonical identity integration", () => {
     expect(
       createLidStore(join(dir, "retry.json")).resolve(lid("11110000")),
     ).toBe(phone("15550000011"));
+  });
+});
+
+describe("WhatsApp adapter inbound debounce and read receipts", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "adapter-debounce-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("batches canonical sender/chat text and marks one socket-bound read receipt batch", async () => {
+    const received: InboundChannelMessage[] = [];
+    const harness = makeDebounceHarness({
+      store: createLidStore(join(dir, "lid.json")),
+      accountPatch: { inboundDebounceMs: 20, groupMode: "open" },
+      onMessage: async (message) => {
+        received.push(message);
+      },
+    });
+    await harness.adapter.start();
+
+    await harness.emit([
+      makeTextMessage(group("120363"), "one", "first", {
+        participant: lid("44445555"),
+        participantPn: phone("15550000006"),
+      }),
+      makeTextMessage(group("120363"), "two", "second", {
+        participant: lid("44445555"),
+      }),
+    ]);
+
+    expect(harness.sockets[0]?.readCalls).toEqual([["one", "two"]]);
+    expect(received).toEqual([]);
+    await sleep(60);
+    expect(received).toHaveLength(1);
+    expect(received[0]?.chatId).toBe(group("120363"));
+    expect(received[0]?.senderId).toBe("15550000006");
+    expect(received[0]?.text).toBe("first\nsecond");
+    expect(Array.isArray(received[0]?.raw)).toBe(true);
+  });
+
+  test("keeps unrelated chats and senders independent", async () => {
+    const received: InboundChannelMessage[] = [];
+    const harness = makeDebounceHarness({
+      store: createLidStore(join(dir, "lid.json")),
+      accountPatch: { inboundDebounceMs: 20, groupMode: "open" },
+      onMessage: async (message) => {
+        received.push(message);
+      },
+    });
+    await harness.adapter.start();
+
+    await harness.emit([
+      makeTextMessage(group("120363"), "sender-a", "sender a", {
+        participant: phone("15550000021"),
+      }),
+      makeTextMessage(group("120363"), "sender-b", "sender b", {
+        participant: phone("15550000022"),
+      }),
+      makeTextMessage(phone("15550000023"), "direct", "direct"),
+    ]);
+
+    await sleep(60);
+    expect(received.map((message) => message.text).sort()).toEqual([
+      "direct",
+      "sender a",
+      "sender b",
+    ]);
+  });
+
+  test("default debounce remains immediate while read receipt ownership is per upsert", async () => {
+    const received: InboundChannelMessage[] = [];
+    const harness = makeDebounceHarness({
+      store: createLidStore(join(dir, "lid.json")),
+      onMessage: async (message) => {
+        received.push(message);
+      },
+    });
+    await harness.adapter.start();
+
+    await harness.emit([
+      makeTextMessage(phone("15550000031"), "one", "one"),
+      makeTextMessage(phone("15550000031"), "two", "two"),
+    ]);
+
+    expect(received.map((message) => message.text)).toEqual(["one", "two"]);
+    expect(harness.sockets[0]?.readCalls).toEqual([["one", "two"]]);
+  });
+
+  test("read receipt failures do not block delivery", async () => {
+    const received: InboundChannelMessage[] = [];
+    const harness = makeDebounceHarness({
+      store: createLidStore(join(dir, "lid.json")),
+      onMessage: async (message) => {
+        received.push(message);
+      },
+      readMessages: async () => {
+        throw new Error("read receipt failed");
+      },
+    });
+    await harness.adapter.start();
+
+    await harness.emit([makeTextMessage(phone("15550000041"), "one", "body")]);
+
+    expect(received.map((message) => message.text)).toEqual(["body"]);
+    expect(harness.sockets[0]?.readCalls).toEqual([["one"]]);
+  });
+
+  test("does not mark read or deliver dropped group traffic and reactions", async () => {
+    const received: InboundChannelMessage[] = [];
+    const harness = makeDebounceHarness({
+      store: createLidStore(join(dir, "lid.json")),
+      accountPatch: { groupMode: "mention" },
+      onMessage: async (message) => {
+        received.push(message);
+      },
+    });
+    await harness.adapter.start();
+
+    await harness.emit([
+      makeTextMessage(group("120363"), "unmentioned", "not for you", {
+        participant: phone("15550000051"),
+      }),
+      {
+        key: {
+          remoteJid: group("120363"),
+          id: "reaction",
+          participant: phone("15550000051"),
+        },
+        message: { reactionMessage: { text: "👍" } },
+        messageTimestamp: Math.floor(Date.now() / 1000),
+      },
+    ]);
+
+    await sleep(20);
+    expect(received).toEqual([]);
+    expect(harness.sockets[0]?.readCalls).toEqual([]);
+  });
+
+  test("stop and restarted socket ownership cancel pending debounce batches", async () => {
+    const received: InboundChannelMessage[] = [];
+    const harness = makeDebounceHarness({
+      store: createLidStore(join(dir, "lid.json")),
+      accountPatch: { inboundDebounceMs: 40 },
+      onMessage: async (message) => {
+        received.push(message);
+      },
+    });
+    await harness.adapter.start();
+
+    await harness.emit([makeTextMessage(phone("15550000061"), "old", "old")]);
+    await harness.adapter.stop();
+    await sleep(70);
+    expect(received).toEqual([]);
+
+    await harness.adapter.start();
+    await harness.emit(
+      [makeTextMessage(phone("15550000062"), "stale", "stale")],
+      { socketIndex: 0 },
+    );
+    await sleep(70);
+    expect(received).toEqual([]);
+    expect(harness.sockets[1]?.readCalls).toEqual([]);
+
+    await harness.emit([
+      makeTextMessage(phone("15550000063"), "fresh", "fresh"),
+    ]);
+    expect(harness.sockets[1]?.readCalls).toEqual([["fresh"]]);
+    await sleep(70);
+    expect(received.map((message) => message.text)).toEqual(["fresh"]);
   });
 });

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -12,6 +12,11 @@ import type {
 } from "@/channels/types";
 import { resolveInboundIdentity } from "./identity";
 import {
+  createWhatsAppInboundDebounceController,
+  type WhatsAppInboundDebounceController,
+  type WhatsAppInboundDebounceEntry,
+} from "./inbound-debounce";
+import {
   isGroupJid,
   isSelfChat,
   isStatusOrBroadcastJid,
@@ -26,6 +31,7 @@ import {
   extractMentionedJids,
   extractReplyParticipant,
   extractWhatsAppText,
+  unwrapWhatsAppMessageContent,
 } from "./media";
 import { loadWhatsAppModule } from "./runtime";
 import { createWhatsAppSocket, getWhatsAppAuthDir } from "./session";
@@ -52,6 +58,7 @@ type WhatsAppSocket = {
   ) => Promise<{ key?: { id?: string }; message?: unknown }>;
   sendPresenceUpdate?: (presence: string, jid?: string) => Promise<void>;
   groupMetadata?: (jid: string) => Promise<{ subject?: string }>;
+  readMessages?: (keys: WhatsAppMessageKey[]) => Promise<unknown>;
 };
 
 type WhatsAppMessageKey = {
@@ -198,6 +205,11 @@ function getLifecycleErrorReplyKey(source: ChannelTurnSource): string | null {
   return `${source.chatId}:${source.messageId ?? ""}`;
 }
 
+function isWhatsAppReactionMessage(message: unknown): boolean {
+  const content = unwrapWhatsAppMessageContent(message);
+  return !!content?.reactionMessage;
+}
+
 export function createWhatsAppAdapter(
   account: WhatsAppChannelAccount,
   dependencies: WhatsAppAdapterDependencies = {},
@@ -224,6 +236,10 @@ export function createWhatsAppAdapter(
     );
   let lidStoreDirty = false;
   const messageStore = new Map<string, unknown>();
+  let inboundDebounce: WhatsAppInboundDebounceController<
+    WhatsAppSocket,
+    WhatsAppMessageKey
+  > | null = null;
 
   function flushLidStoreIfDirty(): void {
     if (!lidStoreDirty) return;
@@ -262,18 +278,20 @@ export function createWhatsAppAdapter(
     if (!id) return;
     sentMessageIds.add(id);
     if (message) messageStore.set(id, message);
-    setTimeout(
+    const cleanupTimer = setTimeout(
       () => {
         sentMessageIds.delete(id);
         messageStore.delete(id);
       },
       24 * 60 * 60 * 1000,
     );
+    cleanupTimer.unref?.();
   }
 
   function clearActiveSocket(closeWebSocket: boolean): void {
     const currentSock = sock;
     const releaseLease = releaseSocketLease;
+    inboundDebounce?.cancelPending();
     sock = null;
     releaseSocketLease = null;
     if (closeWebSocket) {
@@ -315,6 +333,7 @@ export function createWhatsAppAdapter(
         scheduleReconnect(message);
       });
     }, delay);
+    reconnectTimer.unref?.();
   }
 
   async function connect(): Promise<void> {
@@ -375,28 +394,54 @@ export function createWhatsAppAdapter(
       result.release();
       return;
     }
-    sock = result.sock as WhatsAppSocket;
+    const connectedSocket = result.sock as WhatsAppSocket;
+    sock = connectedSocket;
     releaseSocketLease = result.release;
-    sock.ev?.on?.("messages.upsert", (event) => {
-      return handleMessagesUpsert(event).catch((error) => {
-        console.error(
-          `[WhatsApp:${account.accountId}] inbound handler failed:`,
-          error instanceof Error ? error.message : error,
-        );
-      });
+    connectedSocket.ev?.on?.("messages.upsert", (event) => {
+      return handleMessagesUpsert(event, connectedSocket, generation).catch(
+        (error) => {
+          console.error(
+            `[WhatsApp:${account.accountId}] inbound handler failed:`,
+            error instanceof Error ? error.message : error,
+          );
+        },
+      );
     });
   }
 
-  async function getGroupLabel(groupJid: string): Promise<string | undefined> {
+  async function getGroupLabel(
+    groupJid: string,
+    batchSocket: WhatsAppSocket,
+  ): Promise<string | undefined> {
     try {
-      return (await sock?.groupMetadata?.(groupJid))?.subject;
+      return (await batchSocket.groupMetadata?.(groupJid))?.subject;
     } catch {
       return undefined;
     }
   }
 
-  async function handleMessagesUpsert(event: unknown): Promise<void> {
+  function isActiveBatch(
+    batchSocket: WhatsAppSocket,
+    generation: number,
+  ): boolean {
+    return (
+      running &&
+      !stopping &&
+      sock === batchSocket &&
+      generation === connectionGeneration
+    );
+  }
+
+  async function handleMessagesUpsert(
+    event: unknown,
+    batchSocket: WhatsAppSocket,
+    generation: number,
+  ): Promise<void> {
+    const acceptedEntries: Array<
+      WhatsAppInboundDebounceEntry<WhatsAppSocket, WhatsAppMessageKey>
+    > = [];
     try {
+      if (!isActiveBatch(batchSocket, generation)) return;
       const record = asRecord(event);
       if (record.type !== "notify" && record.type !== "append") return;
       const messages = Array.isArray(record.messages)
@@ -404,9 +449,11 @@ export function createWhatsAppAdapter(
         : [];
       const isHistory = record.type === "append";
       for (const msg of messages) {
+        if (!isActiveBatch(batchSocket, generation)) return;
         const remoteJid = msg.key?.remoteJid ?? "";
         const messageId = msg.key?.id ?? "";
         if (!remoteJid || !messageId || !msg.message) continue;
+        if (isWhatsAppReactionMessage(msg.message)) continue;
         if (isStatusOrBroadcastJid(remoteJid)) continue;
         if (sentMessageIds.has(messageId)) {
           sentMessageIds.delete(messageId);
@@ -414,7 +461,11 @@ export function createWhatsAppAdapter(
         }
         if (!messageStore.has(messageId)) {
           messageStore.set(messageId, msg);
-          setTimeout(() => messageStore.delete(messageId), 24 * 60 * 60 * 1000);
+          const cleanupTimer = setTimeout(
+            () => messageStore.delete(messageId),
+            24 * 60 * 60 * 1000,
+          );
+          cleanupTimer.unref?.();
         }
 
         const selfChat = isSelfChat(remoteJid, selfPhoneJid, selfLid);
@@ -462,6 +513,7 @@ export function createWhatsAppAdapter(
           mediaMaxBytes: account.mediaMaxBytes,
           transcribeVoice: account.transcribeVoice === true,
         });
+        if (!isActiveBatch(batchSocket, generation)) return;
         const body = attachmentResult.transcriptionText || text;
         if (!body.trim() && attachmentResult.attachments.length === 0) continue;
 
@@ -483,10 +535,11 @@ export function createWhatsAppAdapter(
         if (!groupAllowed) continue;
 
         const chatLabel = group
-          ? await getGroupLabel(chatId)
+          ? await getGroupLabel(chatId, batchSocket)
           : selfChat
             ? "Self (WhatsApp)"
             : msg.pushName?.trim() || senderId;
+        if (!isActiveBatch(batchSocket, generation)) return;
 
         const inbound: InboundChannelMessage = {
           channel: CHANNEL_ID,
@@ -510,10 +563,26 @@ export function createWhatsAppAdapter(
         console.log(
           `[WhatsApp:${account.accountId}] inbound chatId=${chatId} sender=${senderId} text="${preview(body)}"`,
         );
-        await adapter.onMessage?.(inbound);
+        acceptedEntries.push({
+          inbound,
+          receipt:
+            msg.key && batchSocket.readMessages
+              ? {
+                  owner: batchSocket,
+                  key: msg.key,
+                  markRead: (keys) => batchSocket.readMessages?.(keys),
+                }
+              : undefined,
+        });
       }
     } finally {
       flushLidStoreIfDirty();
+      if (
+        acceptedEntries.length > 0 &&
+        isActiveBatch(batchSocket, generation)
+      ) {
+        await inboundDebounce?.dispatch(acceptedEntries);
+      }
     }
   }
 
@@ -548,11 +617,13 @@ export function createWhatsAppAdapter(
 
     async stop() {
       if (!running) {
+        inboundDebounce?.cancelPending();
         flushLidStoreIfDirty();
         return;
       }
       stopping = true;
       running = false;
+      inboundDebounce?.cancelPending();
       if (reconnectTimer) {
         clearTimeout(reconnectTimer);
         reconnectTimer = null;
@@ -669,6 +740,23 @@ export function createWhatsAppAdapter(
       );
     },
   };
+
+  inboundDebounce = createWhatsAppInboundDebounceController({
+    account,
+    getDeliver: () => adapter.onMessage,
+    onDeliveryError(error) {
+      console.warn(
+        `[WhatsApp:${account.accountId}] failed to deliver inbound batch:`,
+        error instanceof Error ? error.message : error,
+      );
+    },
+    onReadReceiptError(error) {
+      console.warn(
+        `[WhatsApp:${account.accountId}] failed to mark messages read:`,
+        error instanceof Error ? error.message : error,
+      );
+    },
+  });
 
   return adapter;
 }

--- a/src/channels/whatsapp/inbound-debounce.ts
+++ b/src/channels/whatsapp/inbound-debounce.ts
@@ -1,0 +1,206 @@
+import { createInboundDebouncer } from "@/channels/inbound-debounce";
+import type {
+  InboundChannelMessage,
+  WhatsAppChannelAccount,
+} from "@/channels/types";
+import { stripDeviceSuffix } from "./jid";
+
+const MAX_WHATSAPP_INBOUND_DEBOUNCE_MS = 10_000;
+
+type MaybePromise<T> = T | Promise<T>;
+
+export interface WhatsAppInboundReadReceipt<TOwner, TKey> {
+  owner: TOwner;
+  key: TKey;
+  markRead: (keys: TKey[]) => MaybePromise<unknown>;
+}
+
+export interface WhatsAppInboundDebounceEntry<TOwner, TKey> {
+  inbound: InboundChannelMessage;
+  receipt?: WhatsAppInboundReadReceipt<TOwner, TKey>;
+}
+
+interface PendingWhatsAppInboundDebounceEntry<TOwner, TKey>
+  extends WhatsAppInboundDebounceEntry<TOwner, TKey> {
+  generation: number;
+}
+
+export interface WhatsAppInboundDebounceController<TOwner, TKey> {
+  dispatch(
+    entries: WhatsAppInboundDebounceEntry<TOwner, TKey>[],
+  ): Promise<void>;
+  flushAll(): Promise<void>;
+  cancelPending(): void;
+}
+
+export interface WhatsAppInboundDebounceControllerParams<TOwner, TKey> {
+  account: Pick<WhatsAppChannelAccount, "accountId" | "inboundDebounceMs">;
+  getDeliver: () =>
+    | ((message: InboundChannelMessage) => Promise<void>)
+    | undefined;
+  onDeliveryError?: (
+    error: unknown,
+    entries: WhatsAppInboundDebounceEntry<TOwner, TKey>[],
+  ) => void;
+  onReadReceiptError?: (error: unknown, keys: TKey[]) => void;
+}
+
+export function resolveWhatsAppInboundDebounceMs(
+  account: Pick<WhatsAppChannelAccount, "inboundDebounceMs">,
+): number {
+  const value = account.inboundDebounceMs;
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  return Math.trunc(Math.min(value, MAX_WHATSAPP_INBOUND_DEBOUNCE_MS));
+}
+
+function shouldDebounceMessage(message: InboundChannelMessage): boolean {
+  return message.text.trim().length > 0 && !(message.attachments?.length ?? 0);
+}
+
+function buildDebounceKey(message: InboundChannelMessage): string {
+  return [
+    message.accountId ?? "",
+    stripDeviceSuffix(message.chatId),
+    stripDeviceSuffix(message.senderId),
+  ].join(":");
+}
+
+function mergeInboundMessages<TOwner, TKey>(
+  entries: WhatsAppInboundDebounceEntry<TOwner, TKey>[],
+): InboundChannelMessage {
+  const latest = entries[entries.length - 1]?.inbound;
+  if (!latest) {
+    throw new Error("Cannot merge an empty WhatsApp inbound debounce batch.");
+  }
+  return {
+    ...latest,
+    text: entries
+      .map((entry) => entry.inbound.text.trim())
+      .filter((text) => text.length > 0)
+      .join("\n"),
+    raw: entries.map((entry) => entry.inbound.raw),
+  };
+}
+
+export function createWhatsAppInboundDebounceController<TOwner, TKey>(
+  params: WhatsAppInboundDebounceControllerParams<TOwner, TKey>,
+): WhatsAppInboundDebounceController<TOwner, TKey> {
+  const debounceMs = resolveWhatsAppInboundDebounceMs(params.account);
+  let generation = 0;
+
+  const reportDeliveryError = (
+    error: unknown,
+    entries: WhatsAppInboundDebounceEntry<TOwner, TKey>[],
+  ): void => {
+    try {
+      params.onDeliveryError?.(error, entries);
+    } catch {
+      // Error reporting must not break the debounce pipeline.
+    }
+  };
+
+  const reportReadReceiptError = (error: unknown, keys: TKey[]): void => {
+    try {
+      params.onReadReceiptError?.(error, keys);
+    } catch {
+      // Receipt error reporting is best-effort.
+    }
+  };
+
+  const startReadReceipts = (
+    entries: WhatsAppInboundDebounceEntry<TOwner, TKey>[],
+  ): void => {
+    const groups = new Map<
+      TOwner,
+      { keys: TKey[]; markRead: (keys: TKey[]) => MaybePromise<unknown> }
+    >();
+    for (const entry of entries) {
+      if (!entry.receipt) continue;
+      const existing = groups.get(entry.receipt.owner);
+      if (existing) {
+        existing.keys.push(entry.receipt.key);
+        continue;
+      }
+      groups.set(entry.receipt.owner, {
+        keys: [entry.receipt.key],
+        markRead: entry.receipt.markRead,
+      });
+    }
+
+    for (const { keys, markRead } of groups.values()) {
+      if (keys.length === 0) continue;
+      try {
+        const result = markRead(keys);
+        if (result && typeof (result as Promise<unknown>).then === "function") {
+          void (result as Promise<unknown>).catch((error) => {
+            reportReadReceiptError(error, keys);
+          });
+        }
+      } catch (error) {
+        reportReadReceiptError(error, keys);
+      }
+    }
+  };
+
+  const deliver = async (
+    entries: WhatsAppInboundDebounceEntry<TOwner, TKey>[],
+  ): Promise<void> => {
+    const deliverMessage = params.getDeliver();
+    const first = entries[0];
+    if (!deliverMessage || !first) return;
+    const inbound =
+      entries.length === 1 ? first.inbound : mergeInboundMessages(entries);
+    await deliverMessage(inbound);
+  };
+
+  const debouncer = createInboundDebouncer<
+    PendingWhatsAppInboundDebounceEntry<TOwner, TKey>
+  >({
+    debounceMs,
+    buildKey: (entry) => buildDebounceKey(entry.inbound),
+    shouldDebounce: (entry) => shouldDebounceMessage(entry.inbound),
+    onFlush: async (entries) => {
+      const activeEntries = entries.filter(
+        (entry) => entry.generation === generation,
+      );
+      if (activeEntries.length === 0) return;
+      await deliver(activeEntries);
+    },
+    onError: (error, entries) => {
+      reportDeliveryError(error, entries);
+    },
+  });
+
+  return {
+    async dispatch(entries) {
+      if (entries.length === 0) return;
+      const entryGeneration = generation;
+      startReadReceipts(entries);
+      if (debounceMs === 0) {
+        for (const entry of entries) {
+          if (entryGeneration !== generation) return;
+          try {
+            await deliver([entry]);
+          } catch (error) {
+            reportDeliveryError(error, [entry]);
+          }
+        }
+        return;
+      }
+      await Promise.all(
+        entries.map((entry) =>
+          debouncer.enqueue({ ...entry, generation: entryGeneration }),
+        ),
+      );
+    },
+    async flushAll() {
+      await debouncer.flushAll();
+    },
+    cancelPending() {
+      generation += 1;
+      debouncer.cancelAll();
+    },
+  };
+}

--- a/src/channels/whatsapp/inbound-debounce.ts
+++ b/src/channels/whatsapp/inbound-debounce.ts
@@ -146,13 +146,14 @@ export function createWhatsAppInboundDebounceController<TOwner, TKey>(
 
   const deliver = async (
     entries: WhatsAppInboundDebounceEntry<TOwner, TKey>[],
-  ): Promise<void> => {
+  ): Promise<boolean> => {
     const deliverMessage = params.getDeliver();
     const first = entries[0];
-    if (!deliverMessage || !first) return;
+    if (!deliverMessage || !first) return false;
     const inbound =
       entries.length === 1 ? first.inbound : mergeInboundMessages(entries);
     await deliverMessage(inbound);
+    return true;
   };
 
   const debouncer = createInboundDebouncer<
@@ -166,7 +167,13 @@ export function createWhatsAppInboundDebounceController<TOwner, TKey>(
         (entry) => entry.generation === generation,
       );
       if (activeEntries.length === 0) return;
-      await deliver(activeEntries);
+      const delivered = await deliver(activeEntries);
+      if (
+        delivered &&
+        activeEntries.every((entry) => entry.generation === generation)
+      ) {
+        startReadReceipts(activeEntries);
+      }
     },
     onError: (error, entries) => {
       reportDeliveryError(error, entries);
@@ -177,15 +184,21 @@ export function createWhatsAppInboundDebounceController<TOwner, TKey>(
     async dispatch(entries) {
       if (entries.length === 0) return;
       const entryGeneration = generation;
-      startReadReceipts(entries);
       if (debounceMs === 0) {
+        const deliveredEntries: WhatsAppInboundDebounceEntry<TOwner, TKey>[] =
+          [];
         for (const entry of entries) {
           if (entryGeneration !== generation) return;
           try {
-            await deliver([entry]);
+            if (await deliver([entry])) {
+              deliveredEntries.push(entry);
+            }
           } catch (error) {
             reportDeliveryError(error, [entry]);
           }
+        }
+        if (entryGeneration === generation) {
+          startReadReceipts(deliveredEntries);
         }
         return;
       }


### PR DESCRIPTION
## User problem
WhatsApp users can send several short messages in a burst. Without a debounce window, each fragment becomes a separate inbound turn, while read receipts must still avoid acknowledging messages that were dropped, canceled, stale, or failed during handoff.

## What changed
- Adds optional WhatsApp inbound text debouncing keyed by canonical account/chat/sender identity.
- Keeps the default behavior at zero milliseconds, so existing accounts continue immediate delivery unless configured otherwise.
- Delivers debounced text on the trailing edge and combines delivered text with newline separators.
- Marks WhatsApp messages read only after successful inbound handoff, preserving best-effort non-blocking read failure handling.
- Ties pending delivery and read receipts to socket generation so stop, reconnect, and stale socket traffic do not leak delivery or read state.
- Keeps dropped group traffic, unauthorized traffic, reactions, empty bodies, and attachment paths from being accidentally read or merged.

## Before / after
Before: rapid WhatsApp text fragments were dispatched separately, and an early read-receipt implementation could mark messages read before delivery was guaranteed.

After: configured accounts batch same sender/chat text bursts, default accounts behave as before, and only successfully handed-off entries are acknowledged as read.

## Risks and limits
- Debounce applies only to plain inbound text with no attachments; attachment and non-text paths continue immediate handling.
- Read receipt failures are logged but intentionally do not block delivery after a successful handoff.
- This is stacked on #3599 and targets `maintainer/whatsapp-lid-identity-clean`.
- This cleanly replaces the debounce/read-receipt portions of public #3396 and #3400.

## Tests
- 37 focused WhatsApp/debounce tests
- 40 sibling debounce/ingress tests
- `bun run check` passed

👾 Generated with [Letta Code](https://letta.com)