### PR TITLE
fix(whatsapp): stop unstable reconnect loops

### DIFF
--- a/src/channels/whatsapp-adapter.test.ts
+++ b/src/channels/whatsapp-adapter.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { rmSync } from "node:fs";
 import {
   createWhatsAppAdapter,
   isWhatsAppConflictDisconnect,
@@ -7,8 +8,13 @@ import {
 } from "@/channels/whatsapp/adapter";
 import type { LidStore } from "@/channels/whatsapp/lid-store";
 import {
+  createWhatsAppSocket,
+  getWhatsAppAuthDir,
+} from "@/channels/whatsapp/session";
+import {
   clearWhatsAppConnectionState,
   getWhatsAppConnectionState,
+  setWhatsAppConnectionState,
 } from "@/channels/whatsapp/state";
 
 const activeHarnesses: Array<{
@@ -100,6 +106,46 @@ type SchedulerEntry = {
   unref: boolean;
 };
 
+type SocketResult = Awaited<
+  ReturnType<NonNullable<WhatsAppAdapterDependencies["createSocket"]>>
+>;
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, reject, resolve };
+}
+
+function createSessionRuntimeHarness() {
+  const handlers = new Map<
+    string,
+    (payload?: unknown) => void | Promise<void>
+  >();
+  const sock = {
+    ev: {
+      on(event: string, handler: (payload?: unknown) => void | Promise<void>) {
+        handlers.set(event, handler);
+      },
+    },
+    user: { id: "15551234567@s.whatsapp.net", lid: "15551234567@lid" },
+    ws: { close() {} },
+  };
+  const runtime = {
+    makeWASocket: () => sock,
+    useMultiFileAuthState: async () => ({
+      state: { creds: {}, keys: {} },
+      saveCreds: async () => undefined,
+    }),
+    fetchLatestBaileysVersion: async () => ({ version: [2, 3000, 0] }),
+    DisconnectReason: { loggedOut: 401 },
+  };
+  return { handlers, runtime };
+}
+
 function createTestScheduler() {
   const entries: SchedulerEntry[] = [];
   let nowMs = 0;
@@ -165,7 +211,12 @@ function createTestScheduler() {
   };
 }
 
-function createReconnectHarness(accountId: string) {
+function createReconnectHarness(
+  accountId: string,
+  options: {
+    socketResults?: Array<Promise<SocketResult> | SocketResult | undefined>;
+  } = {},
+) {
   type ConnectionUpdate = (update: Record<string, unknown>) => void;
   const scheduler = createTestScheduler();
   const updates: ConnectionUpdate[] = [];
@@ -180,11 +231,7 @@ function createReconnectHarness(accountId: string) {
     },
     flush() {},
   };
-  const createSocket: NonNullable<
-    WhatsAppAdapterDependencies["createSocket"]
-  > = async ({ onConnectionUpdate }) => {
-    createSocketCalls += 1;
-    updates.push(onConnectionUpdate as ConnectionUpdate);
+  function createDefaultSocketResult(): SocketResult {
     return {
       sock: {
         ev: { on: () => undefined },
@@ -197,6 +244,15 @@ function createReconnectHarness(accountId: string) {
         releaseCalls += 1;
       },
     };
+  }
+  const createSocket: NonNullable<
+    WhatsAppAdapterDependencies["createSocket"]
+  > = async ({ onConnectionUpdate }) => {
+    createSocketCalls += 1;
+    updates.push(onConnectionUpdate as ConnectionUpdate);
+    const plannedResult = options.socketResults?.[createSocketCalls - 1];
+    if (plannedResult) return await plannedResult;
+    return createDefaultSocketResult();
   };
   const adapter = createWhatsAppAdapter(
     {
@@ -258,7 +314,7 @@ describe("WhatsApp reconnect circuit breaker", () => {
     harness.open(0);
     expect(harness.scheduler.pending()).toHaveLength(1);
     expect(harness.scheduler.pending()[0]?.delayMs).toBe(2000);
-    expect(harness.scheduler.pending()[0]?.unref).toBe(false);
+    expect(harness.scheduler.pending()[0]?.unref).toBe(true);
 
     harness.scheduler.advanceToNext();
     await flushReconnectMicrotasks();
@@ -280,6 +336,27 @@ describe("WhatsApp reconnect circuit breaker", () => {
 
     harness.close(1);
     expect(harness.scheduler.pending()).toHaveLength(1);
+  });
+
+  test("ignores a stale close from a stopped socket after a newer start", async () => {
+    const accountId = "reconnect-stale-after-restart";
+    const harness = createReconnectHarness(accountId);
+    await harness.adapter.start();
+    await harness.adapter.stop();
+    await harness.adapter.start();
+    const releaseCallsAfterRestart = harness.releaseCalls;
+    setWhatsAppConnectionState(accountId, {
+      status: "connected",
+      phoneJid: "current@s.whatsapp.net",
+    });
+    const currentState = getWhatsAppConnectionState(accountId);
+
+    harness.close(0, "late generation one close");
+
+    expect(harness.createSocketCalls).toBe(2);
+    expect(harness.releaseCalls).toBe(releaseCallsAfterRestart);
+    expect(harness.scheduler.pending()).toHaveLength(0);
+    expect(getWhatsAppConnectionState(accountId)).toEqual(currentState);
   });
 
   test("trips after six distinct unstable generations despite brief opens", async () => {
@@ -321,7 +398,7 @@ describe("WhatsApp reconnect circuit breaker", () => {
     harness.scheduler.advanceBy(59_999);
     harness.close();
     expect(harness.scheduler.pending()[0]?.delayMs).toBe(4000);
-    expect(harness.scheduler.pending()[0]?.unref).toBe(false);
+    expect(harness.scheduler.pending()[0]?.unref).toBe(true);
 
     harness.scheduler.advanceToNext();
     await flushReconnectMicrotasks();
@@ -350,6 +427,104 @@ describe("WhatsApp reconnect circuit breaker", () => {
     harness.scheduler.runCanceled();
     await flushReconnectMicrotasks();
     expect(harness.createSocketCalls).toBe(2);
+  });
+
+  test("stale reconnect rejection after stop does not write error state", async () => {
+    const accountId = "reconnect-reject-after-stop";
+    const reconnectAttempt = createDeferred<SocketResult>();
+    const harness = createReconnectHarness(accountId, {
+      socketResults: [undefined, reconnectAttempt.promise],
+    });
+    await harness.adapter.start();
+    harness.close();
+    harness.scheduler.advanceToNext();
+    await flushReconnectMicrotasks();
+    expect(harness.createSocketCalls).toBe(2);
+
+    await harness.adapter.stop();
+    const stoppedState = getWhatsAppConnectionState(accountId);
+    reconnectAttempt.reject(new Error("late stale reconnect failure"));
+    await flushReconnectMicrotasks();
+
+    expect(getWhatsAppConnectionState(accountId)).toEqual(stoppedState);
+    expect(harness.scheduler.pending()).toHaveLength(0);
+  });
+
+  test("stale reconnect rejection after newer start does not overwrite current state", async () => {
+    const accountId = "reconnect-reject-after-restart";
+    const reconnectAttempt = createDeferred<SocketResult>();
+    const harness = createReconnectHarness(accountId, {
+      socketResults: [undefined, reconnectAttempt.promise],
+    });
+    await harness.adapter.start();
+    harness.close();
+    harness.scheduler.advanceToNext();
+    await flushReconnectMicrotasks();
+    expect(harness.createSocketCalls).toBe(2);
+
+    await harness.adapter.stop();
+    await harness.adapter.start();
+    setWhatsAppConnectionState(accountId, {
+      status: "connected",
+      phoneJid: "current@s.whatsapp.net",
+    });
+    const currentState = getWhatsAppConnectionState(accountId);
+    reconnectAttempt.reject(new Error("late stale reconnect failure"));
+    await flushReconnectMicrotasks();
+
+    expect(harness.createSocketCalls).toBe(3);
+    expect(getWhatsAppConnectionState(accountId)).toEqual(currentState);
+    expect(harness.scheduler.pending()).toHaveLength(0);
+  });
+
+  test("preserves conflict error through real session close ordering", async () => {
+    const accountId = `reconnect-session-conflict-${Date.now()}-${Math.random()}`;
+    const scheduler = createTestScheduler();
+    const session = createSessionRuntimeHarness();
+    const adapter = createWhatsAppAdapter(
+      {
+        channel: "whatsapp",
+        accountId,
+        enabled: true,
+        dmPolicy: "pairing",
+        allowedUsers: [],
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+        agentId: "agent-whatsapp",
+        selfChatMode: false,
+        groupMode: "disabled",
+      },
+      {
+        createSocket: async (params) =>
+          createWhatsAppSocket({
+            ...params,
+            printQr: false,
+            loadRuntimeModule: async () => session.runtime,
+          }),
+        loadRuntimeModule: async () => ({}),
+        reconnectScheduler: scheduler.scheduler,
+      },
+    );
+
+    try {
+      await adapter.start();
+      await session.handlers.get("connection.update")?.({
+        connection: "close",
+        lastDisconnect: { error: { message: "Stream Errored (conflict)" } },
+      });
+
+      expect(adapter.isRunning()).toBe(false);
+      expect(scheduler.pending()).toHaveLength(0);
+      expect(getWhatsAppConnectionState(accountId)).toMatchObject({
+        status: "error",
+        lastError:
+          "Stream Errored (conflict). Another WhatsApp client is using this linked-device session; not reconnecting automatically.",
+      });
+    } finally {
+      await adapter.stop();
+      clearWhatsAppConnectionState(accountId);
+      rmSync(getWhatsAppAuthDir(accountId), { recursive: true, force: true });
+    }
   });
 
   test("explicit conflict stops without another reconnect and preserves conflict error", async () => {

--- a/src/channels/whatsapp-adapter.test.ts
+++ b/src/channels/whatsapp-adapter.test.ts
@@ -1,8 +1,28 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import {
   createWhatsAppAdapter,
   isWhatsAppConflictDisconnect,
+  type WhatsAppAdapterDependencies,
+  type WhatsAppReconnectScheduler,
 } from "@/channels/whatsapp/adapter";
+import type { LidStore } from "@/channels/whatsapp/lid-store";
+import {
+  clearWhatsAppConnectionState,
+  getWhatsAppConnectionState,
+} from "@/channels/whatsapp/state";
+
+const activeHarnesses: Array<{
+  accountId: string;
+  adapter: { stop(): Promise<void> };
+}> = [];
+
+afterEach(async () => {
+  for (const harness of activeHarnesses) {
+    await harness.adapter.stop();
+    clearWhatsAppConnectionState(harness.accountId);
+  }
+  activeHarnesses.length = 0;
+});
 
 describe("WhatsApp adapter helpers", () => {
   test("detects session conflict disconnects by message", () => {
@@ -67,5 +87,313 @@ describe("WhatsApp adapter helpers", () => {
         ],
       }),
     ).resolves.toBeUndefined();
+    await adapter.stop();
+  });
+});
+
+type SchedulerEntry = {
+  callback: () => void;
+  canceled: boolean;
+  delayMs: number;
+  dueAt: number;
+  fired: boolean;
+  unref: boolean;
+};
+
+function createTestScheduler() {
+  const entries: SchedulerEntry[] = [];
+  let nowMs = 0;
+  const scheduler: WhatsAppReconnectScheduler = {
+    now: () => nowMs,
+    schedule(delayMs, callback, options) {
+      const entry: SchedulerEntry = {
+        callback,
+        canceled: false,
+        delayMs,
+        dueAt: nowMs + delayMs,
+        fired: false,
+        unref: options?.unref === true,
+      };
+      entries.push(entry);
+      return {
+        cancel() {
+          entry.canceled = true;
+        },
+      };
+    },
+  };
+
+  function run(entry: SchedulerEntry): void {
+    entry.fired = true;
+    nowMs = entry.dueAt;
+    entry.callback();
+  }
+
+  return {
+    entries,
+    scheduler,
+    advanceToNext() {
+      const next = entries
+        .filter((entry) => !entry.canceled && !entry.fired)
+        .sort((left, right) => left.dueAt - right.dueAt)[0];
+      if (!next) throw new Error("expected pending scheduler task");
+      run(next);
+    },
+    advanceBy(delayMs: number) {
+      const target = nowMs + delayMs;
+      for (;;) {
+        const next = entries
+          .filter(
+            (entry) => !entry.canceled && !entry.fired && entry.dueAt <= target,
+          )
+          .sort((left, right) => left.dueAt - right.dueAt)[0];
+        if (!next) break;
+        run(next);
+      }
+      nowMs = target;
+    },
+    pending() {
+      return entries.filter((entry) => !entry.canceled && !entry.fired);
+    },
+    runCanceled() {
+      for (const entry of entries.filter(
+        (candidate) => candidate.canceled && !candidate.fired,
+      )) {
+        run(entry);
+      }
+    },
+  };
+}
+
+function createReconnectHarness(accountId: string) {
+  type ConnectionUpdate = (update: Record<string, unknown>) => void;
+  const scheduler = createTestScheduler();
+  const updates: ConnectionUpdate[] = [];
+  let createSocketCalls = 0;
+  let releaseCalls = 0;
+  const emptyStore: LidStore = {
+    resolve() {
+      return null;
+    },
+    record() {
+      return { status: "idempotent" };
+    },
+    flush() {},
+  };
+  const createSocket: NonNullable<
+    WhatsAppAdapterDependencies["createSocket"]
+  > = async ({ onConnectionUpdate }) => {
+    createSocketCalls += 1;
+    updates.push(onConnectionUpdate as ConnectionUpdate);
+    return {
+      sock: {
+        ev: { on: () => undefined },
+        ws: { close: () => undefined },
+        user: { id: "15551234567@s.whatsapp.net", lid: undefined },
+      },
+      saveCreds: async () => undefined,
+      DisconnectReason: {},
+      release: () => {
+        releaseCalls += 1;
+      },
+    };
+  };
+  const adapter = createWhatsAppAdapter(
+    {
+      channel: "whatsapp",
+      accountId,
+      enabled: true,
+      dmPolicy: "pairing",
+      allowedUsers: [],
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+      agentId: "agent-whatsapp",
+      selfChatMode: false,
+      groupMode: "disabled",
+    },
+    {
+      createSocket,
+      loadRuntimeModule: async () => ({}),
+      lidStore: emptyStore,
+      reconnectScheduler: scheduler.scheduler,
+    },
+  );
+  activeHarnesses.push({ accountId, adapter });
+
+  return {
+    adapter,
+    scheduler,
+    get createSocketCalls() {
+      return createSocketCalls;
+    },
+    get releaseCalls() {
+      return releaseCalls;
+    },
+    close(index = updates.length - 1, message = "timed out") {
+      updates[index]?.({
+        connection: "close",
+        lastDisconnect: { error: { message } },
+      });
+    },
+    open(index = updates.length - 1) {
+      updates[index]?.({ connection: "open" });
+    },
+  };
+}
+
+async function flushReconnectMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("WhatsApp reconnect circuit breaker", () => {
+  test("counts duplicate closes from one socket generation once", async () => {
+    const harness = createReconnectHarness("reconnect-duplicate-close");
+    await harness.adapter.start();
+
+    for (let index = 0; index < 6; index += 1) {
+      harness.close();
+    }
+    harness.open(0);
+    expect(harness.scheduler.pending()).toHaveLength(1);
+    expect(harness.scheduler.pending()[0]?.delayMs).toBe(2000);
+    expect(harness.scheduler.pending()[0]?.unref).toBe(false);
+
+    harness.scheduler.advanceToNext();
+    await flushReconnectMicrotasks();
+    expect(harness.createSocketCalls).toBe(2);
+    expect(harness.adapter.isRunning()).toBe(true);
+  });
+
+  test("ignores stale closes from older socket generations", async () => {
+    const harness = createReconnectHarness("reconnect-stale-generation");
+    await harness.adapter.start();
+
+    harness.close(0);
+    harness.scheduler.advanceToNext();
+    await flushReconnectMicrotasks();
+    expect(harness.createSocketCalls).toBe(2);
+
+    harness.close(0, "late stale close");
+    expect(harness.scheduler.pending()).toHaveLength(0);
+
+    harness.close(1);
+    expect(harness.scheduler.pending()).toHaveLength(1);
+  });
+
+  test("trips after six distinct unstable generations despite brief opens", async () => {
+    const accountId = "reconnect-six-generations";
+    const harness = createReconnectHarness(accountId);
+    await harness.adapter.start();
+
+    for (let index = 0; index < 6; index += 1) {
+      harness.open();
+      harness.close(index, `unstable ${index}`);
+      if (index < 5) {
+        harness.scheduler.advanceToNext();
+        await flushReconnectMicrotasks();
+      }
+    }
+
+    expect(harness.adapter.isRunning()).toBe(false);
+    expect(harness.scheduler.pending()).toHaveLength(0);
+    expect(getWhatsAppConnectionState(accountId).lastError).toContain(
+      "disconnected 6 times in 60s",
+    );
+    expect(getWhatsAppConnectionState(accountId).lastError).toContain(
+      "Another client may be competing",
+    );
+    expect(harness.releaseCalls).toBe(6);
+  });
+
+  test("resets history and backoff only after sixty seconds of stable uptime", async () => {
+    const harness = createReconnectHarness("reconnect-stable-reset");
+    await harness.adapter.start();
+
+    harness.close();
+    expect(harness.scheduler.pending()[0]?.delayMs).toBe(2000);
+    harness.scheduler.advanceToNext();
+    await flushReconnectMicrotasks();
+    harness.open();
+    expect(harness.scheduler.pending()[0]?.delayMs).toBe(60_000);
+    expect(harness.scheduler.pending()[0]?.unref).toBe(true);
+    harness.scheduler.advanceBy(59_999);
+    harness.close();
+    expect(harness.scheduler.pending()[0]?.delayMs).toBe(4000);
+    expect(harness.scheduler.pending()[0]?.unref).toBe(false);
+
+    harness.scheduler.advanceToNext();
+    await flushReconnectMicrotasks();
+    harness.open();
+    harness.scheduler.advanceBy(60_000);
+    harness.close();
+    expect(harness.scheduler.pending()[0]?.delayMs).toBe(2000);
+  });
+
+  test("stop cancels reconnect and stability tasks and stale callbacks cannot reconnect", async () => {
+    const harness = createReconnectHarness("reconnect-stop-cancels");
+    await harness.adapter.start();
+    harness.open();
+    const stableTask = harness.scheduler.pending()[0];
+
+    await harness.adapter.stop();
+    expect(stableTask?.canceled).toBe(true);
+    harness.scheduler.runCanceled();
+    expect(harness.createSocketCalls).toBe(1);
+
+    await harness.adapter.start();
+    harness.close();
+    const reconnectTask = harness.scheduler.pending()[0];
+    await harness.adapter.stop();
+    expect(reconnectTask?.canceled).toBe(true);
+    harness.scheduler.runCanceled();
+    await flushReconnectMicrotasks();
+    expect(harness.createSocketCalls).toBe(2);
+  });
+
+  test("explicit conflict stops without another reconnect and preserves conflict error", async () => {
+    const accountId = "reconnect-explicit-conflict";
+    const harness = createReconnectHarness(accountId);
+    await harness.adapter.start();
+    harness.close();
+    const reconnectTask = harness.scheduler.pending()[0];
+
+    harness.close(undefined, "Stream Errored (conflict)");
+
+    expect(harness.adapter.isRunning()).toBe(false);
+    expect(reconnectTask?.canceled).toBe(true);
+    expect(harness.scheduler.pending()).toHaveLength(0);
+    harness.scheduler.runCanceled();
+    await flushReconnectMicrotasks();
+    expect(harness.createSocketCalls).toBe(1);
+    expect(getWhatsAppConnectionState(accountId).lastError).toContain(
+      "Another WhatsApp client is using this linked-device session",
+    );
+  });
+
+  test("explicit start after circuit-breaker stop begins with clean history", async () => {
+    const harness = createReconnectHarness("reconnect-explicit-start");
+    await harness.adapter.start();
+    for (let index = 0; index < 6; index += 1) {
+      harness.close();
+      if (index < 5) {
+        harness.scheduler.advanceToNext();
+        await flushReconnectMicrotasks();
+      }
+    }
+    expect(harness.adapter.isRunning()).toBe(false);
+
+    await harness.adapter.start();
+    harness.close();
+    expect(harness.scheduler.pending()[0]?.delayMs).toBe(2000);
+    harness.scheduler.advanceToNext();
+    await flushReconnectMicrotasks();
+    for (let index = 0; index < 4; index += 1) {
+      harness.close();
+      harness.scheduler.advanceToNext();
+      await flushReconnectMicrotasks();
+    }
+    expect(harness.adapter.isRunning()).toBe(true);
   });
 });

--- a/src/channels/whatsapp-session.test.ts
+++ b/src/channels/whatsapp-session.test.ts
@@ -4,8 +4,41 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   acquireWhatsAppSessionLease,
+  createWhatsAppSocket,
+  getWhatsAppAuthDir,
   renderQrTerminal,
 } from "@/channels/whatsapp/session";
+import {
+  clearWhatsAppConnectionState,
+  getWhatsAppConnectionState,
+  setWhatsAppConnectionState,
+} from "@/channels/whatsapp/state";
+
+function createSocketRuntimeHarness() {
+  const handlers = new Map<
+    string,
+    (payload?: unknown) => void | Promise<void>
+  >();
+  const sock = {
+    ev: {
+      on(event: string, handler: (payload?: unknown) => void | Promise<void>) {
+        handlers.set(event, handler);
+      },
+    },
+    user: { id: "15551234567@s.whatsapp.net", lid: "15551234567@lid" },
+    ws: { close() {} },
+  };
+  const runtime = {
+    makeWASocket: () => sock,
+    useMultiFileAuthState: async () => ({
+      state: { creds: {}, keys: {} },
+      saveCreds: async () => undefined,
+    }),
+    fetchLatestBaileysVersion: async () => ({ version: [2, 3000, 0] }),
+    DisconnectReason: { loggedOut: 401 },
+  };
+  return { handlers, runtime };
+}
 
 describe("WhatsApp session", () => {
   test("renders qrcode-terminal with the module as this", () => {
@@ -37,6 +70,42 @@ describe("WhatsApp session", () => {
     };
 
     expect(renderQrTerminal(qrMod, "pairing-payload")).toBeUndefined();
+  });
+
+  test("preserves adapter-claimed terminal close state", async () => {
+    const accountId = `session-claimed-close-${Date.now()}-${Math.random()}`;
+    const { handlers, runtime } = createSocketRuntimeHarness();
+    let result: Awaited<ReturnType<typeof createWhatsAppSocket>> | null = null;
+
+    try {
+      result = await createWhatsAppSocket({
+        accountId,
+        printQr: false,
+        loadRuntimeModule: async () => runtime,
+        onConnectionUpdate(update) {
+          if (update.connection !== "close") return;
+          setWhatsAppConnectionState(accountId, {
+            status: "error",
+            lastError: "terminal conflict wins",
+          });
+          return { claimedConnectionState: true };
+        },
+      });
+
+      await handlers.get("connection.update")?.({
+        connection: "close",
+        lastDisconnect: { error: { message: "generic disconnected loser" } },
+      });
+
+      expect(getWhatsAppConnectionState(accountId)).toMatchObject({
+        status: "error",
+        lastError: "terminal conflict wins",
+      });
+    } finally {
+      result?.release();
+      clearWhatsAppConnectionState(accountId);
+      rmSync(getWhatsAppAuthDir(accountId), { recursive: true, force: true });
+    }
   });
 
   test("prevents concurrent session leases for the same account", () => {

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -34,6 +34,9 @@ import { setWhatsAppConnectionState } from "./state";
 const CHANNEL_ID = "whatsapp";
 const DEDUPE_MAX_SIZE = 5000;
 const RECONNECT_MAX_MS = 30_000;
+const MAX_UNSTABLE_DISCONNECTS = 6;
+const RECONNECT_WINDOW_MS = 60_000;
+const STABLE_OPEN_RESET_MS = RECONNECT_WINDOW_MS;
 const MAX_MENTION_PATTERN_LENGTH = 256;
 const MENTION_MATCH_TEXT_MAX_LENGTH = 2000;
 
@@ -72,10 +75,38 @@ type WhatsAppMessage = {
   pushName?: string | null;
 };
 
+export type WhatsAppReconnectScheduler = {
+  now(): number;
+  schedule(
+    delayMs: number,
+    callback: () => void,
+    options?: { unref?: boolean },
+  ): { cancel(): void };
+};
+
+function createDefaultReconnectScheduler(): WhatsAppReconnectScheduler {
+  return {
+    now: () => Date.now(),
+    schedule(delayMs, callback, options) {
+      const timer = setTimeout(callback, delayMs) as ReturnType<
+        typeof setTimeout
+      > & { unref?: () => void };
+      if (options?.unref) timer.unref?.();
+      return { cancel: () => clearTimeout(timer) };
+    },
+  };
+}
+
 export type WhatsAppAdapterDependencies = {
   createSocket?: typeof createWhatsAppSocket;
   loadRuntimeModule?: typeof loadWhatsAppModule;
   lidStore?: LidStore;
+  reconnectScheduler?: WhatsAppReconnectScheduler;
+};
+
+type ReconnectTimer = {
+  generation: number;
+  task: { cancel(): void } | null;
 };
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -206,11 +237,16 @@ export function createWhatsAppAdapter(
   let running = false;
   let stopping = false;
   let reconnectAttempts = 0;
-  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let reconnectTimer: ReconnectTimer | null = null;
+  let stableOpenTimer: ReconnectTimer | null = null;
   let selfPhoneJid: string | null = null;
   let selfLid: string | null = null;
   let connectedAtMs = 0;
   let connectionGeneration = 0;
+  const recentDisconnects: number[] = [];
+  let closedGeneration: number | null = null;
+  const reconnectScheduler =
+    dependencies.reconnectScheduler ?? createDefaultReconnectScheduler();
   let releaseSocketLease: (() => void) | null = null;
   let downloadContentFromMessage:
     | ((message: unknown, type: string) => Promise<AsyncIterable<Uint8Array>>)
@@ -272,6 +308,7 @@ export function createWhatsAppAdapter(
   }
 
   function clearActiveSocket(closeWebSocket: boolean): void {
+    clearStableOpenTimer();
     const currentSock = sock;
     const releaseLease = releaseSocketLease;
     sock = null;
@@ -284,6 +321,40 @@ export function createWhatsAppAdapter(
       }
     }
     releaseLease?.();
+  }
+
+  function clearReconnectTimer(): void {
+    const timer = reconnectTimer;
+    reconnectTimer = null;
+    timer?.task?.cancel();
+  }
+
+  function clearStableOpenTimer(): void {
+    const timer = stableOpenTimer;
+    stableOpenTimer = null;
+    timer?.task?.cancel();
+  }
+
+  function scheduleStableOpenReset(generation: number): void {
+    clearStableOpenTimer();
+    const timer: ReconnectTimer = {
+      generation,
+      task: null,
+    };
+    stableOpenTimer = timer;
+    timer.task = reconnectScheduler.schedule(
+      STABLE_OPEN_RESET_MS,
+      () => {
+        if (stableOpenTimer !== timer) return;
+        stableOpenTimer = null;
+        if (timer.generation !== connectionGeneration || stopping || !running) {
+          return;
+        }
+        reconnectAttempts = 0;
+        recentDisconnects.length = 0;
+      },
+      { unref: true },
+    );
   }
 
   async function ensureRuntimeHelpers(): Promise<void> {
@@ -301,11 +372,21 @@ export function createWhatsAppAdapter(
     if (stopping || !running || reconnectTimer) return;
     reconnectAttempts += 1;
     const delay = Math.min(RECONNECT_MAX_MS, 1000 * 2 ** reconnectAttempts);
+    const generation = connectionGeneration;
+    const timer: ReconnectTimer = {
+      generation,
+      task: null,
+    };
     console.warn(
       `[WhatsApp:${account.accountId}] disconnected${reason ? ` (${reason})` : ""}; reconnecting in ${Math.round(delay / 1000)}s.`,
     );
-    reconnectTimer = setTimeout(() => {
+    reconnectTimer = timer;
+    timer.task = reconnectScheduler.schedule(delay, () => {
+      if (reconnectTimer !== timer) return;
       reconnectTimer = null;
+      if (timer.generation !== connectionGeneration || stopping || !running) {
+        return;
+      }
       void connect().catch((error) => {
         const message = error instanceof Error ? error.message : String(error);
         setWhatsAppConnectionState(account.accountId, {
@@ -314,15 +395,16 @@ export function createWhatsAppAdapter(
         });
         scheduleReconnect(message);
       });
-    }, delay);
+    });
   }
 
   async function connect(): Promise<void> {
+    clearReconnectTimer();
     connectionGeneration += 1;
     const generation = connectionGeneration;
     clearActiveSocket(true);
     await ensureRuntimeHelpers();
-    connectedAtMs = Date.now();
+    connectedAtMs = reconnectScheduler.now();
     const result = await (dependencies.createSocket ?? createWhatsAppSocket)({
       accountId: account.accountId,
       printQr: true,
@@ -330,7 +412,8 @@ export function createWhatsAppAdapter(
       onConnectionUpdate(update) {
         if (generation !== connectionGeneration) return;
         if (update.connection === "open") {
-          reconnectAttempts = 0;
+          if (stopping || !running || closedGeneration === generation) return;
+          scheduleStableOpenReset(generation);
           selfPhoneJid = stripDeviceSuffix(sock?.user?.id ?? null) || null;
           selfLid = stripDeviceSuffix(sock?.user?.lid ?? null) || null;
           const mode = account.selfChatMode
@@ -341,12 +424,16 @@ export function createWhatsAppAdapter(
           );
         }
         if (update.connection === "close" && !stopping) {
-          clearActiveSocket(false);
-          const lastDisconnect = asRecord(update.lastDisconnect);
-          const error = asRecord(lastDisconnect.error);
-          if (isWhatsAppConflictDisconnect(update)) {
+          const isConflict = isWhatsAppConflictDisconnect(update);
+          if (isConflict) {
+            closedGeneration = generation;
+            clearActiveSocket(false);
+            const lastDisconnect = asRecord(update.lastDisconnect);
+            const error = asRecord(lastDisconnect.error);
             running = false;
             stopping = true;
+            clearReconnectTimer();
+            clearStableOpenTimer();
             const message =
               typeof error.message === "string"
                 ? error.message
@@ -358,6 +445,33 @@ export function createWhatsAppAdapter(
             console.warn(
               `[WhatsApp:${account.accountId}] disconnected due to session conflict; not reconnecting automatically. Stop any other WhatsApp server using this account/auth session, then restart this server.`,
             );
+            return;
+          }
+          if (closedGeneration === generation) return;
+          closedGeneration = generation;
+          clearActiveSocket(false);
+          const lastDisconnect = asRecord(update.lastDisconnect);
+          const error = asRecord(lastDisconnect.error);
+          const now = reconnectScheduler.now();
+          while (recentDisconnects.length > 0) {
+            const oldest = recentDisconnects[0];
+            if (oldest === undefined || now - oldest <= RECONNECT_WINDOW_MS) {
+              break;
+            }
+            recentDisconnects.shift();
+          }
+          recentDisconnects.push(now);
+          if (recentDisconnects.length >= MAX_UNSTABLE_DISCONNECTS) {
+            running = false;
+            stopping = true;
+            clearReconnectTimer();
+            clearStableOpenTimer();
+            const loopMessage = `WhatsApp disconnected ${recentDisconnects.length} times in ${RECONNECT_WINDOW_MS / 1000}s; stopping to avoid reconnect loop. Another client may be competing for this session. Restart this WhatsApp channel to retry.`;
+            setWhatsAppConnectionState(account.accountId, {
+              status: "error",
+              lastError: loopMessage,
+            });
+            console.warn(`[WhatsApp:${account.accountId}] ${loopMessage}`);
             return;
           }
           scheduleReconnect(
@@ -542,24 +656,26 @@ export function createWhatsAppAdapter(
       if (running) return;
       running = true;
       stopping = false;
+      reconnectAttempts = 0;
+      recentDisconnects.length = 0;
+      closedGeneration = null;
       await connect();
       console.log(`[WhatsApp:${account.accountId}] Adapter started.`);
     },
 
     async stop() {
-      if (!running) {
-        flushLidStoreIfDirty();
-        return;
-      }
+      const wasRunning = running;
       stopping = true;
       running = false;
-      if (reconnectTimer) {
-        clearTimeout(reconnectTimer);
-        reconnectTimer = null;
-      }
+      clearReconnectTimer();
+      clearStableOpenTimer();
       connectionGeneration += 1;
       clearActiveSocket(true);
-      setWhatsAppConnectionState(account.accountId, { status: "disconnected" });
+      if (wasRunning) {
+        setWhatsAppConnectionState(account.accountId, {
+          status: "disconnected",
+        });
+      }
       flushLidStoreIfDirty();
     },
 

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -109,6 +109,8 @@ type ReconnectTimer = {
   task: { cancel(): void } | null;
 };
 
+const CLAIM_CONNECTION_STATE = { claimedConnectionState: true } as const;
+
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object"
     ? (value as Record<string, unknown>)
@@ -381,21 +383,34 @@ export function createWhatsAppAdapter(
       `[WhatsApp:${account.accountId}] disconnected${reason ? ` (${reason})` : ""}; reconnecting in ${Math.round(delay / 1000)}s.`,
     );
     reconnectTimer = timer;
-    timer.task = reconnectScheduler.schedule(delay, () => {
-      if (reconnectTimer !== timer) return;
-      reconnectTimer = null;
-      if (timer.generation !== connectionGeneration || stopping || !running) {
-        return;
-      }
-      void connect().catch((error) => {
-        const message = error instanceof Error ? error.message : String(error);
-        setWhatsAppConnectionState(account.accountId, {
-          status: "error",
-          lastError: message,
+    timer.task = reconnectScheduler.schedule(
+      delay,
+      () => {
+        if (reconnectTimer !== timer) return;
+        reconnectTimer = null;
+        if (timer.generation !== connectionGeneration || stopping || !running) {
+          return;
+        }
+        const reconnectGeneration = connectionGeneration + 1;
+        void connect().catch((error) => {
+          if (
+            reconnectGeneration !== connectionGeneration ||
+            stopping ||
+            !running
+          ) {
+            return;
+          }
+          const message =
+            error instanceof Error ? error.message : String(error);
+          setWhatsAppConnectionState(account.accountId, {
+            status: "error",
+            lastError: message,
+          });
+          scheduleReconnect(message);
         });
-        scheduleReconnect(message);
-      });
-    });
+      },
+      { unref: true },
+    );
   }
 
   async function connect(): Promise<void> {
@@ -410,9 +425,11 @@ export function createWhatsAppAdapter(
       printQr: true,
       messageStore,
       onConnectionUpdate(update) {
-        if (generation !== connectionGeneration) return;
+        if (generation !== connectionGeneration) return CLAIM_CONNECTION_STATE;
         if (update.connection === "open") {
-          if (stopping || !running || closedGeneration === generation) return;
+          if (stopping || !running || closedGeneration === generation) {
+            return CLAIM_CONNECTION_STATE;
+          }
           scheduleStableOpenReset(generation);
           selfPhoneJid = stripDeviceSuffix(sock?.user?.id ?? null) || null;
           selfLid = stripDeviceSuffix(sock?.user?.lid ?? null) || null;
@@ -445,9 +462,9 @@ export function createWhatsAppAdapter(
             console.warn(
               `[WhatsApp:${account.accountId}] disconnected due to session conflict; not reconnecting automatically. Stop any other WhatsApp server using this account/auth session, then restart this server.`,
             );
-            return;
+            return CLAIM_CONNECTION_STATE;
           }
-          if (closedGeneration === generation) return;
+          if (closedGeneration === generation) return CLAIM_CONNECTION_STATE;
           closedGeneration = generation;
           clearActiveSocket(false);
           const lastDisconnect = asRecord(update.lastDisconnect);
@@ -472,12 +489,16 @@ export function createWhatsAppAdapter(
               lastError: loopMessage,
             });
             console.warn(`[WhatsApp:${account.accountId}] ${loopMessage}`);
-            return;
+            return CLAIM_CONNECTION_STATE;
           }
           scheduleReconnect(
             typeof error.message === "string" ? error.message : undefined,
           );
         }
+        if (update.connection === "close" && stopping) {
+          return CLAIM_CONNECTION_STATE;
+        }
+        return undefined;
       },
     });
     if (generation !== connectionGeneration || stopping || !running) {

--- a/src/channels/whatsapp/session.ts
+++ b/src/channels/whatsapp/session.ts
@@ -89,6 +89,10 @@ type WhatsAppConnectionUpdate = Record<string, unknown> & {
   };
 };
 
+export type WhatsAppConnectionUpdateResult = {
+  claimedConnectionState?: boolean;
+};
+
 type WhatsAppAuthState = {
   creds: unknown;
   keys: unknown;
@@ -265,7 +269,10 @@ export async function createWhatsAppSocket(params: {
   accountId: string;
   printQr?: boolean;
   messageStore?: Map<string, unknown>;
-  onConnectionUpdate?: (update: WhatsAppConnectionUpdate) => void;
+  loadRuntimeModule?: typeof loadWhatsAppModule;
+  onConnectionUpdate?: (
+    update: WhatsAppConnectionUpdate,
+  ) => WhatsAppConnectionUpdateResult | undefined;
 }): Promise<CreateSocketResult> {
   installWhatsAppConsoleFilters();
   const authDir = getWhatsAppAuthDir(params.accountId);
@@ -274,7 +281,7 @@ export async function createWhatsAppSocket(params: {
   setWhatsAppConnectionState(params.accountId, { status: "connecting" });
 
   try {
-    const mod = await loadWhatsAppModule();
+    const mod = await (params.loadRuntimeModule ?? loadWhatsAppModule)();
     const runtime = mod as WhatsAppRuntimeRecord;
     const makeWASocket = resolveMakeWASocket(runtime);
     const useMultiFileAuthState = runtime.useMultiFileAuthState;
@@ -333,8 +340,10 @@ export async function createWhatsAppSocket(params: {
 
     sock.ev?.on?.("connection.update", async (payload?: unknown) => {
       const update = (payload ?? {}) as WhatsAppConnectionUpdate;
-      params.onConnectionUpdate?.(update);
-      if (update.qr) {
+      const updateResult = params.onConnectionUpdate?.(update);
+      const claimedConnectionState =
+        updateResult?.claimedConnectionState === true;
+      if (update.qr && !claimedConnectionState) {
         const qrMod = await loadQrCodeTerminalModule().catch(() => null);
         const qrTerminal = renderQrTerminal(qrMod, update.qr);
         setWhatsAppConnectionState(params.accountId, {
@@ -353,7 +362,7 @@ export async function createWhatsAppSocket(params: {
           }
         }
       }
-      if (update.connection === "open") {
+      if (update.connection === "open" && !claimedConnectionState) {
         setWhatsAppConnectionState(params.accountId, {
           status: "connected",
           phoneJid: sock.user?.id,
@@ -362,6 +371,7 @@ export async function createWhatsAppSocket(params: {
       }
       if (update.connection === "close") {
         sessionLease.release();
+        if (claimedConnectionState) return;
         const statusCode = update.lastDisconnect?.error?.output?.statusCode;
         const disconnectReason = runtime.DisconnectReason as
           | Record<string, number>


### PR DESCRIPTION
## Summary
WhatsApp can get stuck in a tight reconnect loop when Baileys repeatedly closes a linked-device socket, usually from a competing session. This PR adds a generation-based reconnect state machine and terminal-state ownership so late or duplicate events cannot keep restarting the channel or overwrite the useful error.

Depends on #3599.
Credits and replaces #3398.

## What changed
- Tracks socket generations and counts only one close per generation, so duplicate close events from the same socket do not inflate the unstable disconnect threshold.
- Stops the adapter after 6 distinct unstable disconnect generations inside 60s, with exponential backoff before that and a 60s stable-open reset. Reconnect and stable-reset timers are unrefed.
- Lets the adapter claim terminal connection state from the session layer, so conflict and circuit-breaker errors are not overwritten by generic `disconnected` or `logged_out` fallback state.
- Guards reconnect timer callbacks and rejected reconnect attempts by generation plus running/stopping state, so stop, restart, and account reconfigure paths do not let stale async failures mutate current state or schedule more reconnects.

## Before / after
Before: repeated close events or a stale reconnect failure could leave the channel retrying indefinitely, or replace a conflict/circuit-breaker error with generic session close state.

After: unstable reconnects stop with explicit user-facing guidance; stable connections reset history; late closes and rejections from old generations are ignored.

## Explicitly not included
This does not change the PID/container session lease behavior. Existing lease locking remains as-is.

No live WhatsApp network session was exercised or claimed; validation is unit/integration coverage around adapter/session ordering and lifecycle edges.

## Tests
- `bun test src/channels/whatsapp-adapter.test.ts src/channels/whatsapp-session.test.ts src/channels/registry-lifecycle.test.ts src/channels/lifecycle-error.test.ts` (`40 pass`)
- `bun run check` (`12 checks passed`)

👾 Generated with [Letta Code](https://letta.com)