### PR TITLE
feat(whatsapp): add typing indicators

### DIFF
--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -66,6 +66,7 @@ const SNAKE_TO_CAMEL: Record<string, string> = {
   thread_policy_by_channel: "threadPolicyByChannel",
   transcribe_voice: "transcribeVoice",
   download_media: "downloadMedia",
+  waiting_behavior: "waitingBehavior",
 };
 
 let warnedAboutDualKeys = false;
@@ -357,6 +358,8 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
     next.mentionPatterns = [...(next.mentionPatterns ?? [])];
     next.downloadMedia = next.downloadMedia === true;
     next.transcribeVoice = next.transcribeVoice === true;
+    next.waitingBehavior =
+      next.waitingBehavior === "typing_indicator" ? "typing_indicator" : "off";
   }
   if (isSignalChannelAccount(next)) {
     next.baseUrl = next.baseUrl ?? "";
@@ -443,6 +446,7 @@ function makeDefaultLegacyAccount(
       transcribeVoice: config.transcribeVoice === true,
       downloadMedia: config.downloadMedia === true,
       mediaMaxBytes: config.mediaMaxBytes,
+      waitingBehavior: config.waitingBehavior ?? "off",
       createdAt: now,
       updatedAt: now,
     };

--- a/src/channels/config.ts
+++ b/src/channels/config.ts
@@ -28,11 +28,16 @@ import type {
   WhatsAppChannelConfig,
   WhatsAppGroupMode,
 } from "./types";
+import type { WhatsAppWaitingBehavior } from "./whatsapp/waiting-behavior-config-types";
 
 // ── Paths ─────────────────────────────────────────────────────────
 
 const CHANNELS_ROOT = join(homedir(), ".letta", "channels");
 let channelsRootOverride: string | null = null;
+
+function parseWhatsAppWaitingBehavior(value: unknown): WhatsAppWaitingBehavior {
+  return value === "typing_indicator" ? "typing_indicator" : "off";
+}
 
 export function getChannelsRoot(): string {
   return channelsRootOverride ?? CHANNELS_ROOT;
@@ -283,6 +288,7 @@ const whatsappConfigCodec: ChannelConfigCodec<WhatsAppChannelConfig> = {
         typeof parsed.media_max_bytes === "number"
           ? parsed.media_max_bytes
           : undefined,
+      waitingBehavior: parseWhatsAppWaitingBehavior(parsed.waiting_behavior),
     };
   },
 };

--- a/src/channels/plugin-types.ts
+++ b/src/channels/plugin-types.ts
@@ -13,6 +13,7 @@ import type {
   TelegramGroupMode,
   WhatsAppGroupMode,
 } from "./types";
+import type { WhatsAppWaitingBehavior } from "./whatsapp/waiting-behavior-config-types";
 
 export interface ChannelPluginMetadata {
   id: string;
@@ -182,6 +183,7 @@ export interface ChannelPluginAccountPatch {
   richDraftStreaming?: boolean;
   downloadMedia?: boolean;
   mediaMaxBytes?: number;
+  waitingBehavior?: WhatsAppWaitingBehavior;
 }
 
 export type ChannelAccountPatch = ChannelCommonAccountPatch &

--- a/src/channels/service-account-model.ts
+++ b/src/channels/service-account-model.ts
@@ -122,6 +122,7 @@ export function createAccountFromPatch(
       transcribeVoice: normalizedPatch.transcribeVoice === true,
       downloadMedia: normalizedPatch.downloadMedia === true,
       mediaMaxBytes: normalizedPatch.mediaMaxBytes,
+      waitingBehavior: normalizedPatch.waitingBehavior ?? "off",
       createdAt: now,
       updatedAt: now,
     };
@@ -282,6 +283,8 @@ export function mergeAccountPatch(
       downloadMedia:
         normalizedPatch.downloadMedia ?? existing.downloadMedia ?? false,
       mediaMaxBytes: normalizedPatch.mediaMaxBytes ?? existing.mediaMaxBytes,
+      waitingBehavior:
+        normalizedPatch.waitingBehavior ?? existing.waitingBehavior ?? "off",
       updatedAt: nextUpdatedAt,
     };
   }

--- a/src/channels/service-runtime.ts
+++ b/src/channels/service-runtime.ts
@@ -74,6 +74,7 @@ export async function setChannelConfigLive(
       richDraftStreaming: normalizedPatch.richDraftStreaming,
       downloadMedia: normalizedPatch.downloadMedia,
       mediaMaxBytes: normalizedPatch.mediaMaxBytes,
+      waitingBehavior: normalizedPatch.waitingBehavior,
       config: normalizedPatch.config,
       displayName: existing.displayName,
     });
@@ -114,6 +115,7 @@ export async function setChannelConfigLive(
         richDraftStreaming: normalizedPatch.richDraftStreaming,
         downloadMedia: normalizedPatch.downloadMedia,
         mediaMaxBytes: normalizedPatch.mediaMaxBytes,
+        waitingBehavior: normalizedPatch.waitingBehavior,
         config: normalizedPatch.config,
       },
       accountId ? { accountId } : undefined,

--- a/src/channels/service-snapshots.ts
+++ b/src/channels/service-snapshots.ts
@@ -196,6 +196,7 @@ export function toAccountSnapshot(
       transcribeVoice: account.transcribeVoice === true,
       downloadMedia: account.downloadMedia === true,
       mediaMaxBytes: account.mediaMaxBytes,
+      waitingBehavior: account.waitingBehavior ?? "off",
       createdAt: account.createdAt,
       updatedAt: account.updatedAt,
     };
@@ -387,6 +388,7 @@ export function getChannelConfigSnapshot(
       transcribeVoice: account.transcribeVoice === true,
       downloadMedia: account.downloadMedia === true,
       mediaMaxBytes: account.mediaMaxBytes,
+      waitingBehavior: account.waitingBehavior ?? "off",
     };
   }
 

--- a/src/channels/service-types.ts
+++ b/src/channels/service-types.ts
@@ -9,6 +9,7 @@ import type {
   TelegramGroupMode,
   WhatsAppGroupMode,
 } from "./types";
+import type { WhatsAppWaitingBehavior } from "./whatsapp/waiting-behavior-config-types";
 
 export interface ChannelSummary {
   channelId: string;
@@ -55,6 +56,7 @@ export interface ChannelConfigSnapshot {
   richDraftStreaming?: boolean;
   downloadMedia?: boolean;
   mediaMaxBytes?: number;
+  waitingBehavior?: WhatsAppWaitingBehavior;
 }
 
 export interface PendingPairingSnapshot {
@@ -132,6 +134,7 @@ export interface ChannelAccountSnapshot {
   recipientAliases?: Record<string, string>;
   downloadMedia?: boolean;
   mediaMaxBytes?: number;
+  waitingBehavior?: WhatsAppWaitingBehavior;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -13,6 +13,7 @@ import type {
   ListModelsResponseModelEntry,
   StopReasonType,
 } from "@/types/protocol_v2";
+import type { WhatsAppWaitingBehavior } from "./whatsapp/waiting-behavior-config-types";
 
 /**
  * Vendor-neutral model-picker payload produced by the generic channel
@@ -681,6 +682,8 @@ export interface WhatsAppChannelConfig {
   downloadMedia?: boolean;
   /** Maximum inbound media bytes to download. Undefined uses channel default. */
   mediaMaxBytes?: number;
+  /** Controls whether WhatsApp shows typing while a turn is processing. */
+  waitingBehavior?: WhatsAppWaitingBehavior;
 }
 
 export interface SignalChannelConfig {
@@ -866,6 +869,8 @@ export interface WhatsAppChannelAccount extends ChannelAccountBase {
   downloadMedia?: boolean;
   /** Maximum inbound media bytes to download. Undefined uses channel default. */
   mediaMaxBytes?: number;
+  /** Controls whether WhatsApp shows typing while a turn is processing. */
+  waitingBehavior?: WhatsAppWaitingBehavior;
 }
 
 export interface SignalChannelAccount extends ChannelAccountBase {

--- a/src/channels/whatsapp/account-config.ts
+++ b/src/channels/whatsapp/account-config.ts
@@ -4,6 +4,7 @@ import type {
   WhatsAppGroupMode,
 } from "@/channels/types";
 import { toWhatsAppConnectionConfig } from "./state";
+import type { WhatsAppWaitingBehavior } from "./waiting-behavior-config-types";
 
 const WHATSAPP_CONFIG_KEYS = new Set([
   "agent_id",
@@ -14,6 +15,7 @@ const WHATSAPP_CONFIG_KEYS = new Set([
   "transcribe_voice",
   "download_media",
   "media_max_bytes",
+  "waiting_behavior",
 ]);
 
 function isNullableString(value: unknown): value is string | null {
@@ -38,6 +40,10 @@ function isPositiveNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
 
+function isWaitingBehavior(value: unknown): value is WhatsAppWaitingBehavior {
+  return value === "off" || value === "typing_indicator";
+}
+
 export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppChannelAccount> =
   {
     isValidConfig(config) {
@@ -60,7 +66,9 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         (config.download_media === undefined ||
           isBoolean(config.download_media)) &&
         (config.media_max_bytes === undefined ||
-          isPositiveNumber(config.media_max_bytes))
+          isPositiveNumber(config.media_max_bytes)) &&
+        (config.waiting_behavior === undefined ||
+          isWaitingBehavior(config.waiting_behavior))
       );
     },
 
@@ -90,6 +98,9 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         mediaMaxBytes: isPositiveNumber(config.media_max_bytes)
           ? config.media_max_bytes
           : undefined,
+        waitingBehavior: isWaitingBehavior(config.waiting_behavior)
+          ? config.waiting_behavior
+          : undefined,
       };
     },
 
@@ -103,6 +114,7 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         transcribe_voice: account.transcribeVoice === true,
         download_media: account.downloadMedia === true,
         media_max_bytes: account.mediaMaxBytes,
+        waiting_behavior: account.waitingBehavior ?? "off",
         ...toWhatsAppConnectionConfig(account.accountId),
       };
     },
@@ -117,6 +129,7 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         transcribe_voice: account.transcribeVoice === true,
         download_media: account.downloadMedia === true,
         media_max_bytes: account.mediaMaxBytes,
+        waiting_behavior: account.waitingBehavior ?? "off",
         ...toWhatsAppConnectionConfig(account.accountId),
       };
     },

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -30,6 +30,11 @@ import {
 import { loadWhatsAppModule } from "./runtime";
 import { createWhatsAppSocket, getWhatsAppAuthDir } from "./session";
 import { setWhatsAppConnectionState } from "./state";
+import {
+  createWhatsAppTypingController,
+  type WhatsAppTypingController,
+  type WhatsAppTypingPresence,
+} from "./typing-controller";
 
 const CHANNEL_ID = "whatsapp";
 const DEDUPE_MAX_SIZE = 5000;
@@ -212,6 +217,7 @@ export function createWhatsAppAdapter(
   let connectedAtMs = 0;
   let connectionGeneration = 0;
   let releaseSocketLease: (() => void) | null = null;
+  let typing!: WhatsAppTypingController<WhatsAppSocket>;
   let downloadContentFromMessage:
     | ((message: unknown, type: string) => Promise<AsyncIterable<Uint8Array>>)
     | null = null;
@@ -297,6 +303,31 @@ export function createWhatsAppAdapter(
     }
   }
 
+  function canonicalizeChatId(chatId: string): string | null {
+    try {
+      return resolveSendJid({
+        chatId,
+        selfPhoneJid,
+        selfLid,
+        resolveLid: (lidJid) => lidStore.resolve(lidJid),
+      });
+    } catch {
+      return null;
+    }
+  }
+
+  function getTypingOwner(): WhatsAppSocket | null {
+    return sock;
+  }
+
+  function sendTypingPresence(
+    owner: WhatsAppSocket,
+    chatId: string,
+    presence: WhatsAppTypingPresence,
+  ): unknown {
+    return owner.sendPresenceUpdate?.(presence, chatId);
+  }
+
   function scheduleReconnect(reason?: string): void {
     if (stopping || !running || reconnectTimer) return;
     reconnectAttempts += 1;
@@ -320,6 +351,7 @@ export function createWhatsAppAdapter(
   async function connect(): Promise<void> {
     connectionGeneration += 1;
     const generation = connectionGeneration;
+    if (sock) await typing.clearOwner(sock);
     clearActiveSocket(true);
     await ensureRuntimeHelpers();
     connectedAtMs = Date.now();
@@ -341,6 +373,8 @@ export function createWhatsAppAdapter(
           );
         }
         if (update.connection === "close" && !stopping) {
+          const closingSocket = sock;
+          if (closingSocket) void typing.clearOwner(closingSocket);
           clearActiveSocket(false);
           const lastDisconnect = asRecord(update.lastDisconnect);
           const error = asRecord(lastDisconnect.error);
@@ -547,10 +581,7 @@ export function createWhatsAppAdapter(
     },
 
     async stop() {
-      if (!running) {
-        flushLidStoreIfDirty();
-        return;
-      }
+      const wasRunning = running;
       stopping = true;
       running = false;
       if (reconnectTimer) {
@@ -558,6 +589,11 @@ export function createWhatsAppAdapter(
         reconnectTimer = null;
       }
       connectionGeneration += 1;
+      await typing.clearAll();
+      if (!wasRunning) {
+        flushLidStoreIfDirty();
+        return;
+      }
       clearActiveSocket(true);
       setWhatsAppConnectionState(account.accountId, { status: "disconnected" });
       flushLidStoreIfDirty();
@@ -578,6 +614,8 @@ export function createWhatsAppAdapter(
         selfLid,
         resolveLid: (lidJid) => lidStore.resolve(lidJid),
       });
+      const hadManagedTyping = typing.isActive(targetJid);
+      await typing.clearChat(targetJid);
       if (msg.reaction || msg.removeReaction) {
         const target = msg.targetMessageId ?? msg.replyToMessageId;
         if (!target) throw new Error("WhatsApp reactions require messageId.");
@@ -591,10 +629,12 @@ export function createWhatsAppAdapter(
         rememberSent(id, result);
         return { messageId: id };
       }
-      try {
-        await sock?.sendPresenceUpdate?.("composing", targetJid);
-      } catch {
-        // Presence is best-effort.
+      if (!hadManagedTyping) {
+        try {
+          await sock?.sendPresenceUpdate?.("composing", targetJid);
+        } catch {
+          // Presence is best-effort.
+        }
       }
       const payload = buildWhatsAppOutboundPayload(msg);
       const result = await sendToWhatsApp(
@@ -615,6 +655,7 @@ export function createWhatsAppAdapter(
         selfLid,
         resolveLid: (lidJid) => lidStore.resolve(lidJid),
       });
+      await typing.clearChat(targetJid);
       const result = await sendToWhatsApp(
         targetJid,
         { text },
@@ -637,7 +678,22 @@ export function createWhatsAppAdapter(
     async handleTurnLifecycleEvent(
       event: ChannelTurnLifecycleEvent,
     ): Promise<void> {
-      if (!running || event.type !== "finished") return;
+      if (!running) return;
+      if (event.type === "queued") return;
+      if (event.type === "processing") {
+        if (account.waitingBehavior === "typing_indicator") {
+          for (const source of event.sources) {
+            typing.start({ batchId: event.batchId, source });
+          }
+        }
+        return;
+      }
+
+      await Promise.all(
+        event.sources.map((source) =>
+          typing.stop({ batchId: event.batchId, source }),
+        ),
+      );
 
       const errorText = event.outcome === "error" ? event.error?.trim() : null;
       if (!errorText) return;
@@ -669,6 +725,13 @@ export function createWhatsAppAdapter(
       );
     },
   };
+
+  typing = createWhatsAppTypingController<WhatsAppSocket>({
+    accountId: account.accountId,
+    canonicalizeChatId,
+    getOwner: getTypingOwner,
+    sendPresence: sendTypingPresence,
+  });
 
   return adapter;
 }

--- a/src/channels/whatsapp/typing-adapter.test.ts
+++ b/src/channels/whatsapp/typing-adapter.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  ChannelAdapter,
+  ChannelTurnLifecycleEvent,
+  ChannelTurnSource,
+} from "@/channels/types";
+import {
+  createWhatsAppAdapter,
+  type WhatsAppAdapterDependencies,
+} from "./adapter";
+import { createLidStore } from "./lid-store";
+
+const account = {
+  channel: "whatsapp" as const,
+  accountId: "typing-adapter",
+  displayName: "WhatsApp",
+  enabled: true,
+  dmPolicy: "pairing" as const,
+  allowedUsers: [],
+  agentId: "agent-1",
+  selfChatMode: false,
+  groupMode: "open" as const,
+  waitingBehavior: "typing_indicator" as const,
+  createdAt: new Date(0).toISOString(),
+  updatedAt: new Date(0).toISOString(),
+};
+
+function source(overrides: Partial<ChannelTurnSource> = {}): ChannelTurnSource {
+  return {
+    channel: "whatsapp",
+    accountId: account.accountId,
+    chatId: "15550000001@s.whatsapp.net",
+    messageId: "message-1",
+    threadId: null,
+    agentId: "agent-1",
+    conversationId: "conversation-1",
+    ...overrides,
+  };
+}
+
+function lifecycle(
+  type: ChannelTurnLifecycleEvent["type"],
+  overrides: Record<string, unknown> = {},
+): ChannelTurnLifecycleEvent {
+  if (type === "queued") {
+    return {
+      type,
+      source: source(),
+      ...overrides,
+    } as ChannelTurnLifecycleEvent;
+  }
+  return {
+    type,
+    batchId: "batch-1",
+    sources: [source()],
+    ...(type === "finished"
+      ? { outcome: "completed" as const, stopReason: "end_turn" as const }
+      : {}),
+    ...overrides,
+  } as ChannelTurnLifecycleEvent;
+}
+
+type PresenceCall = { jid?: string; presence: string };
+
+const temporaryDirectories: string[] = [];
+const trackedAdapters: ChannelAdapter[] = [];
+
+function temporaryDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "whatsapp-typing-test-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function presenceNames(harness: { presence: PresenceCall[] }): string[] {
+  return harness.presence.map((call) => call.presence);
+}
+
+function wait(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+afterEach(async () => {
+  try {
+    for (const adapter of trackedAdapters) {
+      await adapter.stop().catch(() => undefined);
+    }
+  } finally {
+    trackedAdapters.length = 0;
+    for (const directory of temporaryDirectories) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+    temporaryDirectories.length = 0;
+  }
+});
+
+function makeHarness(
+  directory: string,
+  options: {
+    sendPresence?: (presence: string, jid?: string) => Promise<void> | void;
+    waitingBehavior?: "off" | "typing_indicator";
+    lidMapping?: { lidJid: string; phoneJid: string };
+  } = {},
+) {
+  const presence: PresenceCall[] = [];
+  let connectionUpdate: ((update: Record<string, unknown>) => void) | undefined;
+  let socketClosed = false;
+  const socket = {
+    ev: {
+      on(_event: string, _handler: (payload: unknown) => void) {},
+    },
+    ws: {
+      close() {
+        socketClosed = true;
+      },
+    },
+    async sendMessage(_jid: string, _payload: Record<string, unknown>) {
+      return { key: { id: "sent" } };
+    },
+    sendPresenceUpdate(presenceName: string, jid?: string) {
+      presence.push({ jid, presence: presenceName });
+      return options.sendPresence?.(presenceName, jid);
+    },
+  };
+  const createSocket: NonNullable<
+    WhatsAppAdapterDependencies["createSocket"]
+  > = async (socketOptions) => {
+    connectionUpdate = socketOptions.onConnectionUpdate as unknown as (
+      update: Record<string, unknown>,
+    ) => void;
+    return {
+      sock: socket,
+      saveCreds: async () => undefined,
+      DisconnectReason: {},
+      release: () => undefined,
+    };
+  };
+  const lidStore = createLidStore(join(directory, "lid-mappings.json"));
+  if (options.lidMapping) {
+    lidStore.record(options.lidMapping.lidJid, options.lidMapping.phoneJid);
+  }
+  const adapter = createWhatsAppAdapter(
+    {
+      ...account,
+      waitingBehavior: options.waitingBehavior ?? account.waitingBehavior,
+    },
+    {
+      createSocket,
+      loadRuntimeModule: async () => ({}),
+      lidStore,
+    },
+  );
+  trackedAdapters.push(adapter);
+  return {
+    adapter,
+    presence,
+    get socketClosed() {
+      return socketClosed;
+    },
+    emitConnection(update: Record<string, unknown>) {
+      connectionUpdate?.(update);
+    },
+  };
+}
+
+describe("WhatsApp adapter typing lifecycle", () => {
+  test("queued is inert and processing-to-finished composes then pauses", async () => {
+    const harness = makeHarness(temporaryDirectory());
+    await harness.adapter.start();
+    const turn = source();
+    await harness.adapter.handleTurnLifecycleEvent?.(
+      lifecycle("queued", { source: turn }),
+    );
+    expect(presenceNames(harness)).toEqual([]);
+
+    await harness.adapter.handleTurnLifecycleEvent?.(
+      lifecycle("processing", { sources: [turn] }),
+    );
+    expect(presenceNames(harness)).toEqual(["composing"]);
+    await harness.adapter.handleTurnLifecycleEvent?.(
+      lifecycle("finished", { sources: [turn] }),
+    );
+    expect(presenceNames(harness)).toEqual(["composing", "paused"]);
+  });
+
+  test("off mode stays inert while normal sends preserve one-shot composing", async () => {
+    const harness = makeHarness(temporaryDirectory(), {
+      waitingBehavior: "off",
+    });
+    await harness.adapter.start();
+    await harness.adapter.handleTurnLifecycleEvent?.(lifecycle("processing"));
+    expect(presenceNames(harness)).toEqual([]);
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: source().chatId,
+      text: "hello",
+    });
+    expect(presenceNames(harness)).toEqual(["composing"]);
+  });
+
+  test("normal send, reaction, and direct reply clear managed typing", async () => {
+    const harness = makeHarness(temporaryDirectory());
+    await harness.adapter.start();
+    const turn = source();
+    await harness.adapter.handleTurnLifecycleEvent?.(
+      lifecycle("processing", { sources: [turn] }),
+    );
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: turn.chatId,
+      text: "hello",
+    });
+    expect(presenceNames(harness)).toEqual(["composing", "paused"]);
+
+    await harness.adapter.handleTurnLifecycleEvent?.(
+      lifecycle("processing", { sources: [turn] }),
+    );
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: turn.chatId,
+      text: "",
+      reaction: "👍",
+      targetMessageId: "target",
+    });
+    await harness.adapter.handleTurnLifecycleEvent?.(
+      lifecycle("processing", { sources: [turn] }),
+    );
+    await harness.adapter.sendDirectReply(turn.chatId, "reply");
+    expect(
+      harness.presence.filter((call) => call.presence === "paused"),
+    ).toHaveLength(3);
+    expect(
+      harness.presence.filter((call) => call.presence === "composing"),
+    ).toHaveLength(3);
+  });
+
+  test("routes presence through canonical LID mappings", async () => {
+    const harness = makeHarness(temporaryDirectory(), {
+      lidMapping: {
+        lidJid: "123456@lid",
+        phoneJid: "15550000001@s.whatsapp.net",
+      },
+    });
+    await harness.adapter.start();
+    await harness.adapter.handleTurnLifecycleEvent?.(
+      lifecycle("processing", {
+        sources: [source({ chatId: "123456@lid" })],
+      }),
+    );
+    expect(harness.presence[0]).toEqual({
+      jid: "15550000001@s.whatsapp.net",
+      presence: "composing",
+    });
+  });
+
+  test("transient reconnect and conflict clear owned typing without stale finish", async () => {
+    const harness = makeHarness(temporaryDirectory());
+    await harness.adapter.start();
+    const turn = source();
+    await harness.adapter.handleTurnLifecycleEvent?.(
+      lifecycle("processing", { sources: [turn] }),
+    );
+    harness.emitConnection({
+      connection: "close",
+      lastDisconnect: { error: { message: "timed out" } },
+    });
+    await wait(2100);
+    expect(presenceNames(harness)).toEqual(["composing", "paused"]);
+    await harness.adapter.handleTurnLifecycleEvent?.(
+      lifecycle("finished", { sources: [turn] }),
+    );
+    expect(presenceNames(harness)).toEqual(["composing", "paused"]);
+    expect(harness.adapter.isRunning?.()).toBe(true);
+    await harness.adapter.stop();
+
+    const second = makeHarness(temporaryDirectory());
+    await second.adapter.start();
+    await second.adapter.handleTurnLifecycleEvent?.(
+      lifecycle("processing", { sources: [turn] }),
+    );
+    second.emitConnection({
+      connection: "close",
+      lastDisconnect: { error: { message: "Stream Errored (conflict)" } },
+    });
+    await wait(0);
+    expect(presenceNames(second)).toEqual(["composing", "paused"]);
+    expect(second.adapter.isRunning?.()).toBe(false);
+  });
+
+  test("stop awaits delayed paused presence before socket close", async () => {
+    let release!: () => void;
+    const paused = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const harness = makeHarness(temporaryDirectory(), {
+      sendPresence: (presenceName) =>
+        presenceName === "paused" ? paused : undefined,
+    });
+    await harness.adapter.start();
+    await harness.adapter.handleTurnLifecycleEvent?.(lifecycle("processing"));
+    const stopping = harness.adapter.stop?.();
+    await Promise.resolve();
+    expect(harness.socketClosed).toBe(false);
+    release();
+    await stopping;
+    expect(harness.socketClosed).toBe(true);
+  });
+});

--- a/src/channels/whatsapp/typing-controller.test.ts
+++ b/src/channels/whatsapp/typing-controller.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, test } from "bun:test";
+import type { ChannelTurnSource } from "@/channels/types";
+import {
+  createWhatsAppTypingController,
+  type WhatsAppTypingPresence,
+  type WhatsAppTypingTurn,
+} from "./typing-controller";
+
+const wait = (milliseconds: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+
+function source(overrides: Partial<ChannelTurnSource> = {}): ChannelTurnSource {
+  return {
+    channel: "whatsapp",
+    accountId: "wa-1",
+    chatId: "15550000001@s.whatsapp.net",
+    messageId: "message-1",
+    threadId: null,
+    agentId: "agent-1",
+    conversationId: "conversation-1",
+    ...overrides,
+  };
+}
+
+function turn(
+  overrides: { batchId?: string; source?: Partial<ChannelTurnSource> } = {},
+): WhatsAppTypingTurn {
+  return {
+    batchId: overrides.batchId ?? "batch-1",
+    source: source(overrides.source),
+  };
+}
+
+type Owner = { id: string };
+type PresenceCall = {
+  owner: Owner;
+  chatId: string;
+  presence: WhatsAppTypingPresence;
+};
+
+function makeController(
+  calls: PresenceCall[],
+  options: {
+    owner?: Owner | null;
+    refreshMs?: number;
+    maxLifetimeMs?: number;
+    sendPresence?: (
+      owner: Owner,
+      chatId: string,
+      presence: WhatsAppTypingPresence,
+    ) => unknown;
+  } = {},
+) {
+  let owner: Owner | null = options.owner ?? { id: "socket-1" };
+  return {
+    setOwner(next: Owner | null) {
+      owner = next;
+    },
+    owner() {
+      return owner;
+    },
+    controller: createWhatsAppTypingController<Owner>({
+      accountId: "wa-1",
+      canonicalizeChatId: (chatId) =>
+        chatId.endsWith("@lid") ? "15550000001@s.whatsapp.net" : chatId,
+      getOwner: () => owner,
+      sendPresence:
+        options.sendPresence ??
+        ((callOwner, chatId, presence) => {
+          calls.push({ owner: callOwner, chatId, presence });
+        }),
+      refreshMs: options.refreshMs,
+      maxLifetimeMs: options.maxLifetimeMs,
+    }),
+  };
+}
+
+describe("WhatsApp typing controller", () => {
+  test("accepts only matching WhatsApp account sources with an active owner", () => {
+    const calls: PresenceCall[] = [];
+    const harness = makeController(calls);
+    harness.controller.start(turn({ source: { channel: "telegram" } }));
+    harness.controller.start(turn({ source: { accountId: "wa-2" } }));
+    harness.setOwner(null);
+    harness.controller.start(turn());
+    expect(calls).toEqual([]);
+  });
+
+  test("deduplicates processing and pauses after the final stop", async () => {
+    const calls: PresenceCall[] = [];
+    const { controller } = makeController(calls);
+    const activeTurn = turn();
+    controller.start(activeTurn);
+    controller.start(activeTurn);
+    expect(calls.map(({ chatId, presence }) => ({ chatId, presence }))).toEqual(
+      [{ chatId: activeTurn.source.chatId, presence: "composing" }],
+    );
+    await controller.stop(activeTurn);
+    expect(calls.at(-1)?.presence).toBe("paused");
+    expect(controller.isActive(activeTurn.source.chatId)).toBe(false);
+  });
+
+  test("reference-counts multiple sources in one batch and chat", async () => {
+    const calls: PresenceCall[] = [];
+    const { controller } = makeController(calls);
+    const first = turn({ source: { messageId: "message-1" } });
+    const second = turn({ source: { messageId: "message-2" } });
+    controller.start(first);
+    controller.start(second);
+    await controller.stop(first);
+    expect(calls).toHaveLength(1);
+    expect(controller.isActive(first.source.chatId)).toBe(true);
+    await controller.stop(second);
+    expect(calls.at(-1)?.presence).toBe("paused");
+  });
+
+  test("supersedes an older batch without letting its finish pause the new owner", async () => {
+    const calls: PresenceCall[] = [];
+    const { controller } = makeController(calls);
+    const older = turn({ batchId: "batch-1" });
+    const newer = turn({
+      batchId: "batch-2",
+      source: { messageId: "message-2" },
+    });
+
+    controller.start(older);
+    controller.start(newer);
+    await controller.stop(older);
+    expect(calls.map((call) => call.presence)).toEqual([
+      "composing",
+      "composing",
+    ]);
+    expect(controller.isActive(newer.source.chatId)).toBe(true);
+
+    await controller.stop(newer);
+    expect(calls.map((call) => call.presence)).toEqual([
+      "composing",
+      "composing",
+      "paused",
+    ]);
+  });
+
+  test("refreshes and enforces max lifetime with short timings", async () => {
+    const calls: PresenceCall[] = [];
+    const { controller } = makeController(calls, {
+      refreshMs: 8,
+      maxLifetimeMs: 25,
+    });
+    controller.start(turn());
+    await wait(15);
+    expect(
+      calls.filter((call) => call.presence === "composing").length,
+    ).toBeGreaterThan(1);
+    await wait(20);
+    expect(controller.isActive(source().chatId)).toBe(false);
+    expect(calls.at(-1)?.presence).toBe("paused");
+  });
+
+  test("canonicalizes JIDs and contains sync/async presence failures", async () => {
+    const calls: string[] = [];
+    const controller = createWhatsAppTypingController<Owner>({
+      accountId: "wa-1",
+      canonicalizeChatId: () => "15550000001@s.whatsapp.net",
+      getOwner: () => ({ id: "socket-1" }),
+      refreshMs: 8,
+      maxLifetimeMs: 30,
+      sendPresence: (_owner, _chatId, presence) => {
+        calls.push(presence);
+        if (presence === "composing") throw new Error("sync failure");
+        return Promise.reject(new Error("async failure"));
+      },
+    });
+    expect(() =>
+      controller.start(turn({ source: { chatId: "123@lid" } })),
+    ).not.toThrow();
+    await wait(12);
+    await controller.clearChat("123@lid");
+    expect(calls).toContain("paused");
+  });
+
+  test("deletes timer state before awaiting paused presence", async () => {
+    let releasePaused!: () => void;
+    const paused = new Promise<void>((resolve) => {
+      releasePaused = resolve;
+    });
+    const calls: PresenceCall[] = [];
+    const { controller } = makeController(calls, {
+      sendPresence: (owner, chatId, presence) => {
+        calls.push({ owner, chatId, presence });
+        return presence === "paused" ? paused : undefined;
+      },
+    });
+    const activeTurn = turn();
+    controller.start(activeTurn);
+    const clearing = controller.clearChat(activeTurn.source.chatId);
+    expect(controller.isActive(activeTurn.source.chatId)).toBe(false);
+    releasePaused();
+    await clearing;
+  });
+
+  test("clearOwner uses the socket that owns typing and does not touch newer sockets", async () => {
+    const calls: PresenceCall[] = [];
+    const ownerA = { id: "socket-a" };
+    const ownerB = { id: "socket-b" };
+    const harness = makeController(calls, { owner: ownerA });
+    harness.controller.start(turn({ batchId: "batch-a" }));
+    harness.setOwner(ownerB);
+    harness.controller.start(turn({ batchId: "batch-b" }));
+
+    await harness.controller.clearOwner(ownerA);
+    expect(harness.controller.isActive(source().chatId)).toBe(true);
+    expect(calls.map((call) => [call.owner.id, call.presence])).toEqual([
+      ["socket-a", "composing"],
+      ["socket-b", "composing"],
+    ]);
+
+    await harness.controller.clearOwner(ownerB);
+    expect(harness.controller.isActive(source().chatId)).toBe(false);
+    expect(calls.map((call) => [call.owner.id, call.presence])).toEqual([
+      ["socket-a", "composing"],
+      ["socket-b", "composing"],
+      ["socket-b", "paused"],
+    ]);
+  });
+
+  test("clearChat and clearAll cancel active chats", async () => {
+    const calls: PresenceCall[] = [];
+    const { controller } = makeController(calls);
+    const first = turn();
+    const second = turn({
+      source: {
+        chatId: "15550000002@s.whatsapp.net",
+        messageId: "message-2",
+      },
+    });
+    controller.start(first);
+    controller.start(second);
+    await controller.clearChat(first.source.chatId);
+    expect(controller.isActive(first.source.chatId)).toBe(false);
+    expect(controller.isActive(second.source.chatId)).toBe(true);
+    await controller.clearAll();
+    expect(controller.isActive(second.source.chatId)).toBe(false);
+    expect(calls.filter((call) => call.presence === "paused")).toHaveLength(2);
+  });
+});

--- a/src/channels/whatsapp/typing-controller.ts
+++ b/src/channels/whatsapp/typing-controller.ts
@@ -1,0 +1,218 @@
+import type { ChannelTurnSource } from "@/channels/types";
+
+export type WhatsAppTypingPresence = "composing" | "paused";
+
+export interface WhatsAppTypingTurn {
+  batchId: string;
+  source: ChannelTurnSource;
+}
+
+export interface WhatsAppTypingControllerOptions<Owner> {
+  accountId: string;
+  canonicalizeChatId: (chatId: string) => string | null;
+  getOwner: () => Owner | null | undefined;
+  sendPresence: (
+    owner: Owner,
+    chatId: string,
+    presence: WhatsAppTypingPresence,
+  ) => unknown;
+  refreshMs?: number;
+  maxLifetimeMs?: number;
+}
+
+export interface WhatsAppTypingController<Owner = unknown> {
+  start(turn: WhatsAppTypingTurn): void;
+  stop(turn: WhatsAppTypingTurn): Promise<void>;
+  isActive(chatId: string): boolean;
+  clearChat(
+    chatId: string,
+    options?: WhatsAppTypingClearOptions<Owner>,
+  ): Promise<void>;
+  clearOwner(
+    owner: Owner,
+    options?: WhatsAppTypingClearOptions<Owner>,
+  ): Promise<void>;
+  clearAll(options?: WhatsAppTypingClearOptions<Owner>): Promise<void>;
+}
+
+export interface WhatsAppTypingClearOptions<Owner = unknown> {
+  sendPaused?: boolean;
+  owner?: Owner;
+}
+
+interface TypingEntry<Owner> {
+  batchId: string;
+  sourceKeys: Set<string>;
+  owner: Owner;
+  refreshTimer: ReturnType<typeof setInterval>;
+  maxTimer: ReturnType<typeof setTimeout>;
+}
+
+const DEFAULT_REFRESH_MS = 12_000;
+const DEFAULT_MAX_LIFETIME_MS = 5 * 60_000;
+
+function timing(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : fallback;
+}
+
+export function createWhatsAppTypingController<Owner>(
+  options: WhatsAppTypingControllerOptions<Owner>,
+): WhatsAppTypingController<Owner> {
+  const refreshMs = timing(options.refreshMs, DEFAULT_REFRESH_MS);
+  const maxLifetimeMs = timing(options.maxLifetimeMs, DEFAULT_MAX_LIFETIME_MS);
+  const typingByChatId = new Map<string, TypingEntry<Owner>>();
+
+  function canonicalChatId(chatId: string): string | null {
+    if (!chatId) return null;
+    try {
+      return options.canonicalizeChatId(chatId);
+    } catch {
+      return null;
+    }
+  }
+
+  function sourceChatId(source: ChannelTurnSource): string | null {
+    if (
+      source.channel !== "whatsapp" ||
+      source.accountId !== options.accountId
+    ) {
+      return null;
+    }
+    return canonicalChatId(source.chatId);
+  }
+
+  function sourceKey(turn: WhatsAppTypingTurn, chatId: string): string {
+    const { source } = turn;
+    return [
+      options.accountId,
+      chatId,
+      turn.batchId,
+      source.threadId ?? "",
+      source.messageId ?? "",
+      source.agentId,
+      source.conversationId,
+    ].join(":");
+  }
+
+  function reportPresenceError(error: unknown): void {
+    void error;
+  }
+
+  async function sendPresence(
+    owner: Owner,
+    chatId: string,
+    presence: WhatsAppTypingPresence,
+  ): Promise<void> {
+    try {
+      await Promise.resolve(options.sendPresence(owner, chatId, presence));
+    } catch (error) {
+      reportPresenceError(error);
+    }
+  }
+
+  function sendPresenceFireAndForget(
+    owner: Owner,
+    chatId: string,
+    presence: WhatsAppTypingPresence,
+  ): void {
+    void sendPresence(owner, chatId, presence);
+  }
+
+  async function clearChat(
+    chatId: string,
+    clearOptions: WhatsAppTypingClearOptions<Owner> = {},
+  ): Promise<void> {
+    const canonical = canonicalChatId(chatId);
+    if (!canonical) return;
+    const entry = typingByChatId.get(canonical);
+    if (!entry) return;
+    if (
+      clearOptions.owner !== undefined &&
+      entry.owner !== clearOptions.owner
+    ) {
+      return;
+    }
+    clearInterval(entry.refreshTimer);
+    clearTimeout(entry.maxTimer);
+    typingByChatId.delete(canonical);
+    if (clearOptions.sendPaused !== false) {
+      await sendPresence(entry.owner, canonical, "paused");
+    }
+  }
+
+  function start(turn: WhatsAppTypingTurn): void {
+    const chatId = sourceChatId(turn.source);
+    if (!chatId) return;
+    const owner = options.getOwner();
+    if (owner === null || owner === undefined) return;
+    const key = sourceKey(turn, chatId);
+    const existing = typingByChatId.get(chatId);
+    if (existing) {
+      if (existing.owner === owner && existing.batchId === turn.batchId) {
+        existing.sourceKeys.add(key);
+        return;
+      }
+      void clearChat(chatId, { owner: existing.owner, sendPaused: false });
+    }
+
+    const refreshTimer = setInterval(() => {
+      const entry = typingByChatId.get(chatId);
+      if (!entry || entry.owner !== owner || entry.batchId !== turn.batchId) {
+        return;
+      }
+      sendPresenceFireAndForget(owner, chatId, "composing");
+    }, refreshMs);
+    const maxTimer = setTimeout(() => {
+      void clearChat(chatId, { owner });
+    }, maxLifetimeMs);
+    refreshTimer.unref?.();
+    maxTimer.unref?.();
+    typingByChatId.set(chatId, {
+      batchId: turn.batchId,
+      sourceKeys: new Set([key]),
+      owner,
+      refreshTimer,
+      maxTimer,
+    });
+    sendPresenceFireAndForget(owner, chatId, "composing");
+  }
+
+  async function stop(turn: WhatsAppTypingTurn): Promise<void> {
+    const chatId = sourceChatId(turn.source);
+    if (!chatId) return;
+    const entry = typingByChatId.get(chatId);
+    if (!entry || entry.batchId !== turn.batchId) return;
+    entry.sourceKeys.delete(sourceKey(turn, chatId));
+    if (entry.sourceKeys.size === 0) {
+      await clearChat(chatId, { owner: entry.owner });
+    }
+  }
+
+  function isActive(chatId: string): boolean {
+    const canonical = canonicalChatId(chatId);
+    return canonical !== null && typingByChatId.has(canonical);
+  }
+
+  async function clearOwner(
+    owner: Owner,
+    clearOptions: WhatsAppTypingClearOptions<Owner> = {},
+  ): Promise<void> {
+    const chats = [...typingByChatId.entries()]
+      .filter(([, entry]) => entry.owner === owner)
+      .map(([chatId]) => chatId);
+    await Promise.all(
+      chats.map((chatId) => clearChat(chatId, { ...clearOptions, owner })),
+    );
+  }
+
+  async function clearAll(
+    clearOptions: WhatsAppTypingClearOptions<Owner> = {},
+  ): Promise<void> {
+    const chats = [...typingByChatId.keys()];
+    await Promise.all(chats.map((chatId) => clearChat(chatId, clearOptions)));
+  }
+
+  return { start, stop, isActive, clearChat, clearOwner, clearAll };
+}

--- a/src/channels/whatsapp/waiting-behavior-config-types.ts
+++ b/src/channels/whatsapp/waiting-behavior-config-types.ts
@@ -1,0 +1,6 @@
+export type WhatsAppWaitingBehavior = "off" | "typing_indicator";
+
+export interface WhatsAppWaitingBehaviorConfig {
+  /** Controls whether WhatsApp shows typing while a turn is processing. */
+  waitingBehavior?: WhatsAppWaitingBehavior;
+}

--- a/src/channels/whatsapp/waiting-behavior-config.test.ts
+++ b/src/channels/whatsapp/waiting-behavior-config.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import type { WhatsAppChannelAccount } from "@/channels/types";
+import { whatsappAccountConfigAdapter } from "./account-config";
+
+function account(
+  overrides: Partial<WhatsAppChannelAccount> = {},
+): WhatsAppChannelAccount {
+  return {
+    channel: "whatsapp",
+    accountId: "wa-test",
+    displayName: "WhatsApp",
+    enabled: true,
+    dmPolicy: "pairing",
+    allowedUsers: [],
+    agentId: null,
+    selfChatMode: true,
+    groupMode: "disabled",
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+    ...overrides,
+  };
+}
+
+describe("WhatsApp waiting behavior config", () => {
+  test("accepts and round-trips the supported values", () => {
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({
+        waiting_behavior: "off",
+      }),
+    ).toBe(true);
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({
+        waiting_behavior: "typing_indicator",
+      }),
+    ).toBe(true);
+    expect(
+      whatsappAccountConfigAdapter.toAccountPatch({
+        waiting_behavior: "typing_indicator",
+      }),
+    ).toEqual({ waitingBehavior: "typing_indicator" });
+    expect(
+      whatsappAccountConfigAdapter.toAccountPatch({ waiting_behavior: "off" }),
+    ).toEqual({ waitingBehavior: "off" });
+    expect(
+      whatsappAccountConfigAdapter.toAccountConfig(
+        account({ waitingBehavior: "typing_indicator" }),
+      ).waiting_behavior,
+    ).toBe("typing_indicator");
+  });
+
+  test("rejects unknown values and defaults absent values to off", () => {
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({
+        waiting_behavior: "always",
+      }),
+    ).toBe(false);
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({
+        waiting_behavior: true,
+      }),
+    ).toBe(false);
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({ unexpected: true }),
+    ).toBe(false);
+    expect(
+      whatsappAccountConfigAdapter.toConfigSnapshotConfig(account())
+        .waiting_behavior,
+    ).toBe("off");
+  });
+});


### PR DESCRIPTION
## Summary
WhatsApp users currently get no active waiting signal while Letta is processing a turn, so a long-running reply can look idle. This adds an opt-in waiting behavior (`waiting_behavior: "typing_indicator"`) that sends WhatsApp composing presence while the turn is processing and pauses it when the turn finishes or is otherwise cleared.

## Behavior
- Default remains off. Existing configs/accounts normalize missing `waiting_behavior` to `off`; account config accepts only `off` and `typing_indicator`.
- Lifecycle/socket/batch ownership: `queued` is inert, `processing` starts managed typing per batch/source, and terminal lifecycle events, including error outcomes, stop only matching batch/source entries before any error reply handling. Multiple sources in the same batch/chat are reference-counted; a newer batch supersedes older typing without letting the older finish pause the new entry.
- Socket/chat ownership: typing entries keep the socket that started them, refresh composing presence, cap lifetime, canonicalize WhatsApp LID JIDs through the existing LID resolver, and clear the correct owner on reconnect/session conflict/stop.
- Cancellation and sends: outbound messages, direct replies, and reactions clear managed typing before sending. When typing was not lifecycle-managed, ordinary message sends keep the existing one-shot composing presence. Presence errors are best-effort and contained.
- Ordinary negative cases: off mode does nothing for lifecycle events; non-WhatsApp/mismatched-account sources, invalid waiting behavior values, queued events, stale finishes, and absent sockets are inert.

## Risk
Channel runtime change for WhatsApp presence only. The feature is default-off, the managed state is in-memory per adapter/socket, and failure to send presence is swallowed so message delivery is not blocked. The main risk is stale presence state across reconnect/stop paths, covered by focused lifecycle tests.

## Tests
- `bun test src/channels/whatsapp/typing-controller.test.ts src/channels/whatsapp/typing-adapter.test.ts src/channels/whatsapp/waiting-behavior-config.test.ts` (17 pass)
- `bun run check` (12 checks passed)

## Stacking / related work
Depends on #3599.

This cleanly replaces the typing-indicator portion of #3396 without changing that PR.

👾 Generated with [Letta Code](https://letta.com)