### PR TITLE
feat(whatsapp): add outbound message prefix

### DIFF
--- a/src/channels/accounts.ts
+++ b/src/channels/accounts.ts
@@ -57,6 +57,7 @@ const SNAKE_TO_CAMEL: Record<string, string> = {
   group_mode: "groupMode",
   inbound_debounce_ms: "inboundDebounceMs",
   listen_mode: "listenMode",
+  message_prefix: "messagePrefix",
   media_max_bytes: "mediaMaxBytes",
   mention_patterns: "mentionPatterns",
   recipient_aliases: "recipientAliases",
@@ -357,6 +358,8 @@ function normalizeLoadedAccount<T extends ChannelAccount>(account: T): T {
     next.mentionPatterns = [...(next.mentionPatterns ?? [])];
     next.downloadMedia = next.downloadMedia === true;
     next.transcribeVoice = next.transcribeVoice === true;
+    next.messagePrefix =
+      typeof next.messagePrefix === "string" ? next.messagePrefix : undefined;
   }
   if (isSignalChannelAccount(next)) {
     next.baseUrl = next.baseUrl ?? "";
@@ -443,6 +446,7 @@ function makeDefaultLegacyAccount(
       transcribeVoice: config.transcribeVoice === true,
       downloadMedia: config.downloadMedia === true,
       mediaMaxBytes: config.mediaMaxBytes,
+      messagePrefix: config.messagePrefix,
       createdAt: now,
       updatedAt: now,
     };

--- a/src/channels/config.ts
+++ b/src/channels/config.ts
@@ -283,6 +283,10 @@ const whatsappConfigCodec: ChannelConfigCodec<WhatsAppChannelConfig> = {
         typeof parsed.media_max_bytes === "number"
           ? parsed.media_max_bytes
           : undefined,
+      messagePrefix:
+        typeof parsed.message_prefix === "string"
+          ? parsed.message_prefix
+          : undefined,
     };
   },
 };

--- a/src/channels/plugin-types.ts
+++ b/src/channels/plugin-types.ts
@@ -172,6 +172,7 @@ export interface ChannelPluginAccountPatch {
   allowBots?: ChannelAllowBotsMode;
   removeStaleRoutes?: boolean;
   inboundDebounceMs?: number;
+  messagePrefix?: string;
   selfChatMode?: boolean;
   allowedGroups?: string[];
   mentionPatterns?: string[];

--- a/src/channels/service-account-model.ts
+++ b/src/channels/service-account-model.ts
@@ -122,6 +122,7 @@ export function createAccountFromPatch(
       transcribeVoice: normalizedPatch.transcribeVoice === true,
       downloadMedia: normalizedPatch.downloadMedia === true,
       mediaMaxBytes: normalizedPatch.mediaMaxBytes,
+      messagePrefix: normalizedPatch.messagePrefix,
       createdAt: now,
       updatedAt: now,
     };
@@ -282,6 +283,10 @@ export function mergeAccountPatch(
       downloadMedia:
         normalizedPatch.downloadMedia ?? existing.downloadMedia ?? false,
       mediaMaxBytes: normalizedPatch.mediaMaxBytes ?? existing.mediaMaxBytes,
+      messagePrefix:
+        normalizedPatch.messagePrefix !== undefined
+          ? normalizedPatch.messagePrefix
+          : existing.messagePrefix,
       updatedAt: nextUpdatedAt,
     };
   }

--- a/src/channels/service-runtime.ts
+++ b/src/channels/service-runtime.ts
@@ -74,6 +74,7 @@ export async function setChannelConfigLive(
       richDraftStreaming: normalizedPatch.richDraftStreaming,
       downloadMedia: normalizedPatch.downloadMedia,
       mediaMaxBytes: normalizedPatch.mediaMaxBytes,
+      messagePrefix: normalizedPatch.messagePrefix,
       config: normalizedPatch.config,
       displayName: existing.displayName,
     });
@@ -114,6 +115,7 @@ export async function setChannelConfigLive(
         richDraftStreaming: normalizedPatch.richDraftStreaming,
         downloadMedia: normalizedPatch.downloadMedia,
         mediaMaxBytes: normalizedPatch.mediaMaxBytes,
+        messagePrefix: normalizedPatch.messagePrefix,
         config: normalizedPatch.config,
       },
       accountId ? { accountId } : undefined,

--- a/src/channels/service-snapshots.ts
+++ b/src/channels/service-snapshots.ts
@@ -196,6 +196,7 @@ export function toAccountSnapshot(
       transcribeVoice: account.transcribeVoice === true,
       downloadMedia: account.downloadMedia === true,
       mediaMaxBytes: account.mediaMaxBytes,
+      messagePrefix: account.messagePrefix,
       createdAt: account.createdAt,
       updatedAt: account.updatedAt,
     };
@@ -387,6 +388,7 @@ export function getChannelConfigSnapshot(
       transcribeVoice: account.transcribeVoice === true,
       downloadMedia: account.downloadMedia === true,
       mediaMaxBytes: account.mediaMaxBytes,
+      messagePrefix: account.messagePrefix,
     };
   }
 

--- a/src/channels/service-types.ts
+++ b/src/channels/service-types.ts
@@ -55,6 +55,7 @@ export interface ChannelConfigSnapshot {
   richDraftStreaming?: boolean;
   downloadMedia?: boolean;
   mediaMaxBytes?: number;
+  messagePrefix?: string;
 }
 
 export interface PendingPairingSnapshot {
@@ -132,6 +133,7 @@ export interface ChannelAccountSnapshot {
   recipientAliases?: Record<string, string>;
   downloadMedia?: boolean;
   mediaMaxBytes?: number;
+  messagePrefix?: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -319,6 +319,8 @@ export interface ChannelAdapter {
        * example Slack Block Kit) may render it; others fall back to text.
        */
       modelPicker?: ChannelModelPickerData;
+      /** Channel-specific opt-in for direct replies that should be treated as ordinary outbound agent text. */
+      applyMessagePrefix?: boolean;
     },
   ): Promise<void>;
 

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -7,6 +7,7 @@
  * platform chat IDs to agent+conversation pairs.
  */
 
+import type { WhatsAppMessagePrefixConfig } from "@/channels/whatsapp/message-prefix-config-types";
 import type { PermissionMode } from "@/permissions/mode";
 import type {
   ApprovalResponseBody,
@@ -661,7 +662,7 @@ export interface DiscordChannelConfig {
   allowBots?: DiscordAllowBotsMode;
 }
 
-export interface WhatsAppChannelConfig {
+export interface WhatsAppChannelConfig extends WhatsAppMessagePrefixConfig {
   channel: "whatsapp";
   enabled: boolean;
   dmPolicy: DmPolicy;
@@ -848,7 +849,9 @@ export interface DiscordChannelAccount extends ChannelAccountBase {
   allowBots?: DiscordAllowBotsMode;
 }
 
-export interface WhatsAppChannelAccount extends ChannelAccountBase {
+export interface WhatsAppChannelAccount
+  extends ChannelAccountBase,
+    WhatsAppMessagePrefixConfig {
   channel: "whatsapp";
   /** Agent ID used for account-bound DM and group auto-routing. */
   agentId: string | null;

--- a/src/channels/whatsapp-protocol.test.ts
+++ b/src/channels/whatsapp-protocol.test.ts
@@ -7,6 +7,7 @@ describe("whatsapp gateway config validators", () => {
       isValidChannelPluginConfigPayload("whatsapp", {
         config: {
           agent_id: "agent-1",
+          message_prefix: "[bot] ",
           self_chat_mode: true,
           group_mode: "disabled",
         },
@@ -33,6 +34,14 @@ describe("whatsapp gateway config validators", () => {
     expect(
       isValidChannelPluginConfigPayload("whatsapp", {
         config: { group_mode: "all" },
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects non-string message prefixes", () => {
+    expect(
+      isValidChannelPluginConfigPayload("whatsapp", {
+        config: { message_prefix: 42 },
       }),
     ).toBe(false);
   });

--- a/src/channels/whatsapp-service.test.ts
+++ b/src/channels/whatsapp-service.test.ts
@@ -1,8 +1,14 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   __testOverrideLoadChannelAccounts,
   __testOverrideSaveChannelAccounts,
   clearChannelAccountStores,
+  getChannelAccount,
+  loadChannelAccounts,
+  upsertChannelAccount,
 } from "@/channels/accounts";
 import {
   __testOverrideLoadPairingStore,
@@ -25,6 +31,12 @@ import {
   __testOverrideSaveTargetStore,
   clearTargetStores,
 } from "@/channels/targets";
+import { __testOverrideChannelsRoot, readChannelConfig } from "./config";
+import type {
+  ChannelAccount,
+  WhatsAppChannelAccount,
+  WhatsAppChannelConfig,
+} from "./types";
 
 describe("WhatsApp channel service", () => {
   beforeEach(() => {
@@ -55,6 +67,7 @@ describe("WhatsApp channel service", () => {
     __testOverrideSavePairingStore(null);
     __testOverrideLoadTargetStore(null);
     __testOverrideSaveTargetStore(null);
+    __testOverrideChannelsRoot(null);
   });
 
   test("creates conservative defaults", () => {
@@ -98,6 +111,7 @@ describe("WhatsApp channel service", () => {
           mention_patterns: ["\\bloop\\b"],
           download_media: true,
           media_max_bytes: 1048576,
+          message_prefix: "[bot] ",
         },
       },
       { accountId: "personal" },
@@ -110,12 +124,90 @@ describe("WhatsApp channel service", () => {
     expect(created.mentionPatterns).toEqual(["\\bloop\\b"]);
     expect(created.downloadMedia).toBe(true);
     expect(created.mediaMaxBytes).toBe(1048576);
+    expect(created.messagePrefix).toBe("[bot] ");
 
     const updated = updateChannelAccountLive("whatsapp", "personal", {
       config: { group_mode: "open", self_chat_mode: true },
     });
     expect(updated.groupMode).toBe("open");
     expect(updated.selfChatMode).toBe(true);
+    expect(updated.messagePrefix).toBe("[bot] ");
+    expect(updated.config).toEqual(
+      expect.objectContaining({ message_prefix: "[bot] " }),
+    );
+
+    const cleared = updateChannelAccountLive("whatsapp", "personal", {
+      config: { message_prefix: "" },
+    });
+    expect(cleared.messagePrefix).toBe("");
+  });
+
+  test("migrates snake_case message prefix and saves the canonical key", () => {
+    let persisted: Record<string, unknown> | undefined;
+    __testOverrideLoadChannelAccounts(() => [
+      {
+        channel: "whatsapp",
+        accountId: "personal",
+        enabled: true,
+        dmPolicy: "pairing",
+        allowedUsers: [],
+        agentId: null,
+        selfChatMode: true,
+        groupMode: "disabled",
+        message_prefix: "[bot] ",
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+      } as unknown as ChannelAccount,
+    ]);
+    __testOverrideSaveChannelAccounts((_channelId, accounts) => {
+      persisted = accounts[0] as unknown as Record<string, unknown>;
+    });
+
+    loadChannelAccounts("whatsapp");
+    const loaded = getChannelAccount("whatsapp", "personal");
+    expect((loaded as WhatsAppChannelAccount | null)?.messagePrefix).toBe(
+      "[bot] ",
+    );
+    if (!loaded) throw new Error("migrated account was not loaded");
+
+    upsertChannelAccount("whatsapp", loaded);
+    expect(persisted?.message_prefix).toBe("[bot] ");
+    expect(persisted).not.toHaveProperty("messagePrefix");
+  });
+
+  test("migrates message prefix from legacy YAML", () => {
+    const root = mkdtempSync(join(tmpdir(), "whatsapp-prefix-"));
+    try {
+      mkdirSync(join(root, "whatsapp"), { recursive: true });
+      writeFileSync(
+        join(root, "whatsapp", "config.yaml"),
+        [
+          "enabled: true",
+          "dm_policy: pairing",
+          "message_prefix: '[bot] '",
+          "",
+        ].join("\n"),
+      );
+      __testOverrideChannelsRoot(root);
+      __testOverrideLoadChannelAccounts(null);
+
+      expect(
+        (readChannelConfig("whatsapp") as WhatsAppChannelConfig | null)
+          ?.messagePrefix,
+      ).toBe("[bot] ");
+      loadChannelAccounts("whatsapp");
+      expect(
+        (
+          getChannelAccount(
+            "whatsapp",
+            "__legacy_migrated__",
+          ) as WhatsAppChannelAccount | null
+        )?.messagePrefix,
+      ).toBe("[bot] ");
+    } finally {
+      __testOverrideChannelsRoot(null);
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   test("bind updates the account-level agent id", () => {

--- a/src/channels/whatsapp/account-config.ts
+++ b/src/channels/whatsapp/account-config.ts
@@ -14,6 +14,7 @@ const WHATSAPP_CONFIG_KEYS = new Set([
   "transcribe_voice",
   "download_media",
   "media_max_bytes",
+  "message_prefix",
 ]);
 
 function isNullableString(value: unknown): value is string | null {
@@ -38,6 +39,10 @@ function isPositiveNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
 
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
 export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppChannelAccount> =
   {
     isValidConfig(config) {
@@ -60,7 +65,8 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         (config.download_media === undefined ||
           isBoolean(config.download_media)) &&
         (config.media_max_bytes === undefined ||
-          isPositiveNumber(config.media_max_bytes))
+          isPositiveNumber(config.media_max_bytes)) &&
+        (config.message_prefix === undefined || isString(config.message_prefix))
       );
     },
 
@@ -90,6 +96,9 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         mediaMaxBytes: isPositiveNumber(config.media_max_bytes)
           ? config.media_max_bytes
           : undefined,
+        messagePrefix: isString(config.message_prefix)
+          ? config.message_prefix
+          : undefined,
       };
     },
 
@@ -103,6 +112,7 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         transcribe_voice: account.transcribeVoice === true,
         download_media: account.downloadMedia === true,
         media_max_bytes: account.mediaMaxBytes,
+        message_prefix: account.messagePrefix,
         ...toWhatsAppConnectionConfig(account.accountId),
       };
     },
@@ -117,6 +127,7 @@ export const whatsappAccountConfigAdapter: ChannelAccountConfigAdapter<WhatsAppC
         transcribe_voice: account.transcribeVoice === true,
         download_media: account.downloadMedia === true,
         media_max_bytes: account.mediaMaxBytes,
+        message_prefix: account.messagePrefix,
         ...toWhatsAppConnectionConfig(account.accountId),
       };
     },

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -125,14 +125,25 @@ function applyMessagePrefix(text: string, prefix: string | undefined): string {
   return prefix && text.trim().length > 0 ? `${prefix}${text}` : text;
 }
 
-function withMessagePrefix(
-  message: OutboundChannelMessage,
+function withPayloadMessagePrefix(
+  payload: Record<string, unknown>,
   prefix: string | undefined,
-): OutboundChannelMessage {
-  if (message.reaction || message.removeReaction || !message.text) {
-    return message;
+): Record<string, unknown> {
+  if (!prefix) return payload;
+  if (typeof payload.text === "string") {
+    return { ...payload, text: applyMessagePrefix(payload.text, prefix) };
   }
-  return { ...message, text: applyMessagePrefix(message.text, prefix) };
+  if (typeof payload.caption === "string") {
+    return { ...payload, caption: applyMessagePrefix(payload.caption, prefix) };
+  }
+  return payload;
+}
+
+function buildPrefixedWhatsAppOutboundPayload(
+  msg: OutboundChannelMessage,
+  prefix: string | undefined,
+): Record<string, unknown> {
+  return withPayloadMessagePrefix(buildWhatsAppOutboundPayload(msg), prefix);
 }
 
 function matchesSelf(
@@ -610,12 +621,14 @@ export function createWhatsAppAdapter(
       } catch {
         // Presence is best-effort.
       }
-      const outbound = withMessagePrefix(msg, account.messagePrefix);
-      const payload = buildWhatsAppOutboundPayload(outbound);
+      const payload = buildPrefixedWhatsAppOutboundPayload(
+        msg,
+        account.messagePrefix,
+      );
       const result = await sendToWhatsApp(
         targetJid,
         payload,
-        buildQuotedOptions(targetJid, outbound.replyToMessageId),
+        buildQuotedOptions(targetJid, msg.replyToMessageId),
       );
       const id = result.key?.id ?? "";
       rememberSent(id, result);
@@ -630,9 +643,13 @@ export function createWhatsAppAdapter(
         selfLid,
         resolveLid: (lidJid) => lidStore.resolve(lidJid),
       });
+      const payload = withPayloadMessagePrefix(
+        { text },
+        options?.applyMessagePrefix ? account.messagePrefix : undefined,
+      );
       const result = await sendToWhatsApp(
         targetJid,
-        { text: applyMessagePrefix(text, account.messagePrefix) },
+        payload,
         buildQuotedOptions(targetJid, options?.replyToMessageId),
       );
       rememberSent(result.key?.id ?? "", result);
@@ -645,7 +662,10 @@ export function createWhatsAppAdapter(
       await adapter.sendDirectReply(
         event.source.chatId,
         formatChannelControlRequestPrompt(event),
-        { replyToMessageId: event.source.messageId },
+        {
+          replyToMessageId: event.source.messageId,
+          applyMessagePrefix: false,
+        },
       );
     },
 
@@ -672,7 +692,10 @@ export function createWhatsAppAdapter(
               formatChannelLifecycleErrorMessage(errorText, {
                 runId: event.runId,
               }),
-              { replyToMessageId: source.messageId },
+              {
+                replyToMessageId: source.messageId,
+                applyMessagePrefix: false,
+              },
             );
           } catch (error) {
             console.warn(

--- a/src/channels/whatsapp/adapter.ts
+++ b/src/channels/whatsapp/adapter.ts
@@ -121,6 +121,20 @@ function getDisplayName(account: WhatsAppChannelAccount): string {
   return account.displayName ?? "WhatsApp";
 }
 
+function applyMessagePrefix(text: string, prefix: string | undefined): string {
+  return prefix && text.trim().length > 0 ? `${prefix}${text}` : text;
+}
+
+function withMessagePrefix(
+  message: OutboundChannelMessage,
+  prefix: string | undefined,
+): OutboundChannelMessage {
+  if (message.reaction || message.removeReaction || !message.text) {
+    return message;
+  }
+  return { ...message, text: applyMessagePrefix(message.text, prefix) };
+}
+
 function matchesSelf(
   jid: string,
   selfPhoneJid: string | null,
@@ -596,11 +610,12 @@ export function createWhatsAppAdapter(
       } catch {
         // Presence is best-effort.
       }
-      const payload = buildWhatsAppOutboundPayload(msg);
+      const outbound = withMessagePrefix(msg, account.messagePrefix);
+      const payload = buildWhatsAppOutboundPayload(outbound);
       const result = await sendToWhatsApp(
         targetJid,
         payload,
-        buildQuotedOptions(targetJid, msg.replyToMessageId),
+        buildQuotedOptions(targetJid, outbound.replyToMessageId),
       );
       const id = result.key?.id ?? "";
       rememberSent(id, result);
@@ -617,7 +632,7 @@ export function createWhatsAppAdapter(
       });
       const result = await sendToWhatsApp(
         targetJid,
-        { text },
+        { text: applyMessagePrefix(text, account.messagePrefix) },
         buildQuotedOptions(targetJid, options?.replyToMessageId),
       );
       rememberSent(result.key?.id ?? "", result);

--- a/src/channels/whatsapp/message-prefix-adapter.test.ts
+++ b/src/channels/whatsapp/message-prefix-adapter.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { OutboundChannelMessage } from "@/channels/types";
+import type {
+  ChannelControlRequestEvent,
+  ChannelTurnLifecycleEvent,
+  ChannelTurnSource,
+  OutboundChannelMessage,
+} from "@/channels/types";
 import {
   createWhatsAppAdapter,
   type WhatsAppAdapterDependencies,
@@ -22,6 +27,9 @@ const account = {
   createdAt: new Date(0).toISOString(),
   updatedAt: new Date(0).toISOString(),
 };
+
+const chatId = "15550000001@s.whatsapp.net";
+const prefix = "[bot] ";
 
 const temporaryDirectories: string[] = [];
 const adapters: Array<Awaited<ReturnType<typeof createWhatsAppAdapter>>> = [];
@@ -66,6 +74,22 @@ function makeHarness(messagePrefix?: string) {
   return { adapter, payloads, presence };
 }
 
+function directSource(
+  overrides: Partial<ChannelTurnSource> = {},
+): ChannelTurnSource {
+  return {
+    channel: "whatsapp",
+    accountId: account.accountId,
+    chatId,
+    chatType: "direct",
+    senderId: "15550000001",
+    messageId: "incoming-1",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+    ...overrides,
+  };
+}
+
 afterEach(async () => {
   try {
     for (const adapter of adapters) await adapter.stop().catch(() => undefined);
@@ -86,104 +110,228 @@ async function send(
   await adapter.sendMessage(message);
 }
 
+function payloadText(payload: Record<string, unknown>): string {
+  if (typeof payload.text !== "string")
+    throw new Error("expected text payload");
+  return payload.text;
+}
+
 describe("WhatsApp message prefix adapter behavior", () => {
-  test("prefixes text exactly without mutating the caller object", async () => {
-    const harness = makeHarness("[bot] ");
+  test("prefixes text exactly once without mutating the caller object", async () => {
+    const harness = makeHarness(prefix);
     const message: OutboundChannelMessage = {
       channel: "whatsapp",
       accountId: account.accountId,
-      chatId: "15550000001@s.whatsapp.net",
+      chatId,
       text: "hello",
     };
     await send(harness.adapter, message);
-    expect(harness.payloads).toEqual([{ text: "[bot] hello" }]);
+    await harness.adapter.sendMessage(message);
+    expect(harness.payloads).toEqual([
+      { text: "[bot] hello" },
+      { text: "[bot] hello" },
+    ]);
     expect(message).toEqual({
       channel: "whatsapp",
       accountId: account.accountId,
-      chatId: "15550000001@s.whatsapp.net",
+      chatId,
       text: "hello",
     });
   });
 
-  test("prefixes non-empty media captions and leaves empty captions absent", async () => {
-    const captioned = makeHarness("[bot] ");
-    await send(captioned.adapter, {
-      channel: "whatsapp",
-      accountId: account.accountId,
-      chatId: "15550000001@s.whatsapp.net",
-      text: "caption",
-      mediaPath: "/tmp/photo.png",
-    });
-    expect(captioned.payloads[0]).toEqual({
-      image: { url: "/tmp/photo.png" },
-      caption: "[bot] caption",
-    });
+  test("prefixes final media captions exactly once after text/title selection", async () => {
+    const cases: Array<{
+      name: string;
+      message: OutboundChannelMessage;
+      payload: Record<string, unknown>;
+    }> = [
+      {
+        name: "image text caption",
+        message: {
+          channel: "whatsapp",
+          accountId: account.accountId,
+          chatId,
+          text: "caption",
+          mediaPath: "/tmp/photo.png",
+        },
+        payload: {
+          image: { url: "/tmp/photo.png" },
+          caption: "[bot] caption",
+        },
+      },
+      {
+        name: "video title caption",
+        message: {
+          channel: "whatsapp",
+          accountId: account.accountId,
+          chatId,
+          text: "",
+          title: "clip title",
+          mediaPath: "/tmp/clip.mp4",
+        },
+        payload: {
+          video: { url: "/tmp/clip.mp4" },
+          caption: "[bot] clip title",
+        },
+      },
+      {
+        name: "text beats title",
+        message: {
+          channel: "whatsapp",
+          accountId: account.accountId,
+          chatId,
+          text: "caption",
+          title: "ignored title",
+          mediaPath: "/tmp/second.jpg",
+        },
+        payload: {
+          image: { url: "/tmp/second.jpg" },
+          caption: "[bot] caption",
+        },
+      },
+      {
+        name: "document title caption",
+        message: {
+          channel: "whatsapp",
+          accountId: account.accountId,
+          chatId,
+          text: "",
+          title: "document title",
+          mediaPath: "/tmp/report.pdf",
+        },
+        payload: {
+          document: { url: "/tmp/report.pdf" },
+          fileName: "report.pdf",
+          mimetype: "application/octet-stream",
+          caption: "[bot] document title",
+        },
+      },
+    ];
 
-    for (const text of ["", "   "]) {
-      const emptyCaption = makeHarness("[bot] ");
-      await send(emptyCaption.adapter, {
-        channel: "whatsapp",
-        accountId: account.accountId,
-        chatId: "15550000001@s.whatsapp.net",
-        text,
-        mediaPath: "/tmp/photo.png",
-      });
-      expect(emptyCaption.payloads[0]).toEqual({
-        image: { url: "/tmp/photo.png" },
-      });
+    for (const testCase of cases) {
+      const harness = makeHarness(prefix);
+      await send(harness.adapter, testCase.message);
+      expect(harness.payloads[0]).toEqual(testCase.payload);
     }
   });
 
-  test("does not prefix reactions or removals and prefixes direct replies", async () => {
-    const harness = makeHarness("[bot] ");
+  test("leaves empty media captions absent and voice memos captionless", async () => {
+    for (const mediaPath of ["/tmp/photo.png", "/tmp/report.pdf"]) {
+      const emptyCaption = makeHarness(prefix);
+      await send(emptyCaption.adapter, {
+        channel: "whatsapp",
+        accountId: account.accountId,
+        chatId,
+        text: "   ",
+        title: "   ",
+        mediaPath,
+      });
+      expect(emptyCaption.payloads[0]).not.toHaveProperty("caption");
+    }
+
+    const voiceMemo = makeHarness(prefix);
+    await send(voiceMemo.adapter, {
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId,
+      text: "voice caption",
+      title: "voice title",
+      mediaPath: "/tmp/voice.ogg",
+    });
+    expect(voiceMemo.payloads[0]).toEqual({
+      audio: { url: "/tmp/voice.ogg" },
+      mimetype: "audio/ogg; codecs=opus",
+      ptt: true,
+    });
+  });
+
+  test("does not prefix reactions or removals and only prefixes opt-in direct replies", async () => {
+    const harness = makeHarness(prefix);
     await harness.adapter.start();
     await harness.adapter.sendMessage({
       channel: "whatsapp",
       accountId: account.accountId,
-      chatId: "15550000001@s.whatsapp.net",
+      chatId,
       text: "ignored",
-      reaction: "👍",
+      reaction: "ok",
       targetMessageId: "target",
     });
     await harness.adapter.sendMessage({
       channel: "whatsapp",
       accountId: account.accountId,
-      chatId: "15550000001@s.whatsapp.net",
+      chatId,
       text: "ignored",
       removeReaction: true,
       targetMessageId: "target",
     });
-    await harness.adapter.sendDirectReply(
-      "15550000001@s.whatsapp.net",
-      "reply",
-    );
+    await harness.adapter.sendDirectReply(chatId, "system reply");
+    await harness.adapter.sendDirectReply(chatId, "ordinary reply", {
+      applyMessagePrefix: true,
+    });
+
     expect(harness.payloads[0]).toEqual({
       react: {
-        text: "👍",
-        key: { remoteJid: "15550000001@s.whatsapp.net", id: "target" },
+        text: "ok",
+        key: { remoteJid: chatId, id: "target" },
       },
     });
     expect(harness.payloads[1]).toEqual({
       react: {
         text: "",
-        key: { remoteJid: "15550000001@s.whatsapp.net", id: "target" },
+        key: { remoteJid: chatId, id: "target" },
       },
     });
-    expect(harness.payloads[2]).toEqual({ text: "[bot] reply" });
+    expect(harness.payloads[2]).toEqual({ text: "system reply" });
+    expect(harness.payloads[3]).toEqual({ text: "[bot] ordinary reply" });
+  });
+
+  test("approval control prompts and lifecycle error replies are unprefixed", async () => {
+    const harness = makeHarness(prefix);
+    await harness.adapter.start();
+
+    await harness.adapter.handleControlRequestEvent?.({
+      requestId: "approval-1",
+      kind: "generic_tool_approval",
+      source: directSource(),
+      toolName: "Bash",
+      input: { command: "pwd" },
+    } satisfies ChannelControlRequestEvent);
+
+    await harness.adapter.handleTurnLifecycleEvent?.({
+      type: "finished",
+      outcome: "error",
+      batchId: "batch-1",
+      runId: "run-1",
+      stopReason: "error",
+      error: "boom",
+      sources: [directSource({ messageId: "incoming-2" })],
+    } satisfies ChannelTurnLifecycleEvent);
+
+    expect(harness.payloads).toHaveLength(2);
+    const [controlPayload, lifecyclePayload] = harness.payloads;
+    if (!controlPayload || !lifecyclePayload) {
+      throw new Error("expected control and lifecycle payloads");
+    }
+    const controlText = payloadText(controlPayload);
+    const lifecycleText = payloadText(lifecyclePayload);
+    expect(controlText).toStartWith("The agent wants approval");
+    expect(controlText).not.toStartWith(prefix);
+    expect(lifecycleText).toStartWith("Turn failed:");
+    expect(lifecycleText).not.toStartWith(prefix);
   });
 
   test("absent and empty prefixes preserve payloads and one-shot composing", async () => {
-    for (const prefix of [undefined, ""]) {
-      const harness = makeHarness(prefix);
+    for (const emptyPrefix of [undefined, ""]) {
+      const harness = makeHarness(emptyPrefix);
       await send(harness.adapter, {
         channel: "whatsapp",
         accountId: account.accountId,
-        chatId: "15550000001@s.whatsapp.net",
+        chatId,
         text: "hello",
       });
       expect(harness.payloads).toEqual([{ text: "hello" }]);
       expect(harness.presence).toEqual([
-        { presence: "composing", jid: "15550000001@s.whatsapp.net" },
+        { presence: "composing", jid: chatId },
       ]);
     }
   });

--- a/src/channels/whatsapp/message-prefix-adapter.test.ts
+++ b/src/channels/whatsapp/message-prefix-adapter.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { OutboundChannelMessage } from "@/channels/types";
+import {
+  createWhatsAppAdapter,
+  type WhatsAppAdapterDependencies,
+} from "./adapter";
+import { createLidStore } from "./lid-store";
+
+const account = {
+  channel: "whatsapp" as const,
+  accountId: "prefix-adapter",
+  displayName: "WhatsApp",
+  enabled: true,
+  dmPolicy: "pairing" as const,
+  allowedUsers: [],
+  agentId: "agent-1",
+  selfChatMode: false,
+  groupMode: "open" as const,
+  createdAt: new Date(0).toISOString(),
+  updatedAt: new Date(0).toISOString(),
+};
+
+const temporaryDirectories: string[] = [];
+const adapters: Array<Awaited<ReturnType<typeof createWhatsAppAdapter>>> = [];
+
+function temporaryDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "whatsapp-prefix-test-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function makeHarness(messagePrefix?: string) {
+  const payloads: Record<string, unknown>[] = [];
+  const presence: Array<{ presence: string; jid?: string }> = [];
+  const socket = {
+    ev: { on() {} },
+    ws: { close() {} },
+    async sendMessage(_jid: string, payload: Record<string, unknown>) {
+      payloads.push(payload);
+      return { key: { id: `sent-${payloads.length}` } };
+    },
+    async sendPresenceUpdate(presenceName: string, jid?: string) {
+      presence.push({ presence: presenceName, jid });
+    },
+  };
+  const createSocket: NonNullable<
+    WhatsAppAdapterDependencies["createSocket"]
+  > = async () => ({
+    sock: socket,
+    saveCreds: async () => undefined,
+    DisconnectReason: {},
+    release: () => undefined,
+  });
+  const adapter = createWhatsAppAdapter(
+    { ...account, messagePrefix },
+    {
+      createSocket,
+      loadRuntimeModule: async () => ({}),
+      lidStore: createLidStore(join(temporaryDirectory(), "lid-mappings.json")),
+    },
+  );
+  adapters.push(adapter);
+  return { adapter, payloads, presence };
+}
+
+afterEach(async () => {
+  try {
+    for (const adapter of adapters) await adapter.stop().catch(() => undefined);
+  } finally {
+    adapters.length = 0;
+    for (const directory of temporaryDirectories) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+    temporaryDirectories.length = 0;
+  }
+});
+
+async function send(
+  adapter: Awaited<ReturnType<typeof createWhatsAppAdapter>>,
+  message: OutboundChannelMessage,
+) {
+  await adapter.start();
+  await adapter.sendMessage(message);
+}
+
+describe("WhatsApp message prefix adapter behavior", () => {
+  test("prefixes text exactly without mutating the caller object", async () => {
+    const harness = makeHarness("[bot] ");
+    const message: OutboundChannelMessage = {
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: "15550000001@s.whatsapp.net",
+      text: "hello",
+    };
+    await send(harness.adapter, message);
+    expect(harness.payloads).toEqual([{ text: "[bot] hello" }]);
+    expect(message).toEqual({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: "15550000001@s.whatsapp.net",
+      text: "hello",
+    });
+  });
+
+  test("prefixes non-empty media captions and leaves empty captions absent", async () => {
+    const captioned = makeHarness("[bot] ");
+    await send(captioned.adapter, {
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: "15550000001@s.whatsapp.net",
+      text: "caption",
+      mediaPath: "/tmp/photo.png",
+    });
+    expect(captioned.payloads[0]).toEqual({
+      image: { url: "/tmp/photo.png" },
+      caption: "[bot] caption",
+    });
+
+    for (const text of ["", "   "]) {
+      const emptyCaption = makeHarness("[bot] ");
+      await send(emptyCaption.adapter, {
+        channel: "whatsapp",
+        accountId: account.accountId,
+        chatId: "15550000001@s.whatsapp.net",
+        text,
+        mediaPath: "/tmp/photo.png",
+      });
+      expect(emptyCaption.payloads[0]).toEqual({
+        image: { url: "/tmp/photo.png" },
+      });
+    }
+  });
+
+  test("does not prefix reactions or removals and prefixes direct replies", async () => {
+    const harness = makeHarness("[bot] ");
+    await harness.adapter.start();
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: "15550000001@s.whatsapp.net",
+      text: "ignored",
+      reaction: "👍",
+      targetMessageId: "target",
+    });
+    await harness.adapter.sendMessage({
+      channel: "whatsapp",
+      accountId: account.accountId,
+      chatId: "15550000001@s.whatsapp.net",
+      text: "ignored",
+      removeReaction: true,
+      targetMessageId: "target",
+    });
+    await harness.adapter.sendDirectReply(
+      "15550000001@s.whatsapp.net",
+      "reply",
+    );
+    expect(harness.payloads[0]).toEqual({
+      react: {
+        text: "👍",
+        key: { remoteJid: "15550000001@s.whatsapp.net", id: "target" },
+      },
+    });
+    expect(harness.payloads[1]).toEqual({
+      react: {
+        text: "",
+        key: { remoteJid: "15550000001@s.whatsapp.net", id: "target" },
+      },
+    });
+    expect(harness.payloads[2]).toEqual({ text: "[bot] reply" });
+  });
+
+  test("absent and empty prefixes preserve payloads and one-shot composing", async () => {
+    for (const prefix of [undefined, ""]) {
+      const harness = makeHarness(prefix);
+      await send(harness.adapter, {
+        channel: "whatsapp",
+        accountId: account.accountId,
+        chatId: "15550000001@s.whatsapp.net",
+        text: "hello",
+      });
+      expect(harness.payloads).toEqual([{ text: "hello" }]);
+      expect(harness.presence).toEqual([
+        { presence: "composing", jid: "15550000001@s.whatsapp.net" },
+      ]);
+    }
+  });
+});

--- a/src/channels/whatsapp/message-prefix-config-types.ts
+++ b/src/channels/whatsapp/message-prefix-config-types.ts
@@ -1,0 +1,4 @@
+export interface WhatsAppMessagePrefixConfig {
+  /** Optional exact text prepended to outbound WhatsApp messages. */
+  messagePrefix?: string;
+}

--- a/src/channels/whatsapp/message-prefix-config.test.ts
+++ b/src/channels/whatsapp/message-prefix-config.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import type { WhatsAppChannelAccount } from "@/channels/types";
+import { whatsappAccountConfigAdapter } from "./account-config";
+
+function account(
+  overrides: Partial<WhatsAppChannelAccount> = {},
+): WhatsAppChannelAccount {
+  return {
+    channel: "whatsapp",
+    accountId: "wa-test",
+    displayName: "WhatsApp",
+    enabled: true,
+    dmPolicy: "pairing",
+    allowedUsers: [],
+    agentId: null,
+    selfChatMode: true,
+    groupMode: "disabled",
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+    ...overrides,
+  };
+}
+
+describe("WhatsApp message prefix config", () => {
+  test("accepts empty and non-empty strings and round-trips them", () => {
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({ message_prefix: "" }),
+    ).toBe(true);
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({ message_prefix: "[bot] " }),
+    ).toBe(true);
+    expect(
+      whatsappAccountConfigAdapter.toAccountPatch({ message_prefix: "[bot] " }),
+    ).toEqual({ messagePrefix: "[bot] " });
+    expect(
+      whatsappAccountConfigAdapter.toAccountConfig(
+        account({ messagePrefix: "[bot] " }),
+      ).message_prefix,
+    ).toBe("[bot] ");
+    expect(
+      whatsappAccountConfigAdapter.toConfigSnapshotConfig(
+        account({ messagePrefix: "" }),
+      ).message_prefix,
+    ).toBe("");
+  });
+
+  test("rejects non-strings and unknown nested fields", () => {
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({ message_prefix: true }),
+    ).toBe(false);
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({ message_prefix: 1 }),
+    ).toBe(false);
+    expect(
+      whatsappAccountConfigAdapter.isValidConfig({ unexpected: true }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a default-off WhatsApp `message_prefix` setting and carries it through account creation, updates, legacy YAML loading, live config changes, and snapshots.
- Applies the prefix at the final WhatsApp payload boundary so ordinary outbound `text` and media `caption` payloads follow the same rule without mutating the caller message.
- Keeps control/system paths unprefixed: approval prompts, lifecycle error replies, reactions, reaction removals, and captionless voice memo payloads are excluded unless a direct reply explicitly opts in.

## Before / after
Before this, WhatsApp ordinary outbound messages had no account-level prefix, and the earlier prefix implementation operated before media caption selection, so title-derived captions could be missed and system replies could be decorated accidentally.

After this, configuring `message_prefix: "[bot] "` sends ordinary replies like `[bot] hello`. For media, WhatsApp uses `text` when present, otherwise `title`; the selected non-empty image/video/document caption gets the prefix exactly once. Empty text/title fields still omit captions, and voice memo payloads remain captionless.

## Config persistence
The setting is accepted as `message_prefix`, normalized to `messagePrefix`, preserved on account merge, migrated from legacy YAML config, exposed in account/config snapshots, and passed through live config updates.

## Risks / limits
- Default behavior is unchanged when `message_prefix` is absent or empty.
- The prefix is a literal prepend, not a template system.
- Direct replies stay unprefixed by default so system/control messages remain clean; only explicit ordinary-direct-reply callers can opt in.
- This PR only changes WhatsApp prefix behavior. It does not change inbound routing, LID identity handling, or other channel adapters.

## Tests
- 25 focused WhatsApp prefix/media/control/lifecycle/config tests and adversarial payload probes for text-only, title-only, text+title, empty fields, document/image/video captions, voice memos, reactions/removals, repeat send exact-once behavior, and control/lifecycle exclusions.
- `bun run typecheck`
- `bun run check` passed all 12 checks.

## Stacking / related PRs
Depends on public #3599 (`maintainer/whatsapp-lid-identity-clean`).

This cleanly replaces the outbound-prefix portion of public #3396.