### PR TITLE
fix(cli): omit unavailable memory block counts

### DIFF
--- a/src/cli/components/AgentSelector.tsx
+++ b/src/cli/components/AgentSelector.tsx
@@ -23,6 +23,7 @@ import {
   AGENT_SELECTOR_TAB_EMPTY_STATES,
   type AgentSelectorListAgent,
   type AgentSelectorTabId,
+  formatAgentMemoryBlockCount,
   formatAgentModel,
   formatRelativeTime,
   getVisibleAgentSelectorTabs,
@@ -739,7 +740,6 @@ export function AgentSelector({
       setSearchInput((prev) => prev + input);
     }
   });
-
   // Render agent item (shared between tabs)
   const renderAgentItem = (
     agent: AgentSelectorListAgent,
@@ -750,13 +750,13 @@ export function AgentSelector({
     const isCurrent = agent.id === currentAgentId;
     const isLocalAgent = isLocalAgentId(agent.id);
     const relativeTime = formatRelativeTime(agent.last_run_completion);
-    const blockCount = agent.blocks?.length ?? 0;
+    const blockCountText = formatAgentMemoryBlockCount(agent.blocks?.length);
     const modelStr = formatAgentModel(agent);
     const metadataParts = [relativeTime];
     if (!isLocalAgent && extra?.backend !== "shared") {
-      metadataParts.push(
-        `${blockCount} memory block${blockCount === 1 ? "" : "s"}`,
-      );
+      if (blockCountText) {
+        metadataParts.push(blockCountText);
+      }
       metadataParts.push(modelStr);
     }
     if (extra?.backend === "shared" && agent.creator?.name) {

--- a/src/cli/components/agent-selector-utils.test.ts
+++ b/src/cli/components/agent-selector-utils.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { formatAgentMemoryBlockCount } from "@/cli/components/agent-selector-utils";
+
+describe("formatAgentMemoryBlockCount", () => {
+  test("omits unavailable block counts", () => {
+    expect(formatAgentMemoryBlockCount(undefined)).toBeNull();
+    expect(formatAgentMemoryBlockCount(null)).toBeNull();
+  });
+
+  test("omits zero block counts", () => {
+    expect(formatAgentMemoryBlockCount(0)).toBeNull();
+  });
+
+  test("formats positive singular and plural block counts", () => {
+    expect(formatAgentMemoryBlockCount(1)).toBe("1 memory block");
+    expect(formatAgentMemoryBlockCount(2)).toBe("2 memory blocks");
+  });
+});

--- a/src/cli/components/agent-selector-utils.ts
+++ b/src/cli/components/agent-selector-utils.ts
@@ -108,6 +108,15 @@ export function truncateAgentId(id: string, availableWidth: number): string {
   return `${id.slice(0, prefixLen)}...${id.slice(-suffixLen)}`;
 }
 
+export function formatAgentMemoryBlockCount(
+  blockCount: number | null | undefined,
+): string | null {
+  if (blockCount === null || blockCount === undefined || blockCount <= 0) {
+    return null;
+  }
+  return `${blockCount} memory block${blockCount === 1 ? "" : "s"}`;
+}
+
 export function formatAgentModel(agent: AgentSelectorListAgent): string {
   let handle: string | null = null;
   if (agent.model) {


### PR DESCRIPTION
## Summary
- only show an agent memory-block count when it is positive
- preserve singular/plural formatting while avoiding a misleading `0 memory blocks` label
- cover unavailable, empty, singular, and plural metadata with focused tests

## Why
Agent list responses can leave the optional blocks relationship unpopulated. The selector previously collapsed both unavailable metadata and a true empty relationship to zero, then presented that fallback as fact. Omitting non-positive counts keeps the compact selector truthful without adding an N+1 fetch.

## Risk
Display-only. Positive counts, model metadata, and local/shared selector behavior remain unchanged.

## Test plan
- [x] `bun run check`
- [x] `bun test src/cli/components/agent-selector-utils.test.ts`

Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

👾 Generated with [Letta Code](https://letta.com)