### PR TITLE
feat(sdk): support request-scoped client toolsets

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -41,13 +41,13 @@
   "src/tools/impl/message-channel.ts": 1187,
   "src/tools/manager.ts": 3281,
   "src/tools/tool-execution-context.test.ts": 1422,
-  "src/types/protocol_v2.ts": 2967,
+  "src/types/protocol_v2.ts": 2980,
   "src/websocket/listen-client-concurrency.test.ts": 3017,
   "src/websocket/listen-client-protocol.test.ts": 6721,
   "src/websocket/listener/commands/channels.ts": 1315,
   "src/websocket/listener/commands/memory.ts": 1114,
   "src/websocket/listener/file-commands.ts": 1030,
   "src/websocket/listener/lifecycle.ts": 1656,
-  "src/websocket/listener/protocol-inbound.ts": 2293,
+  "src/websocket/listener/protocol-inbound.ts": 2332,
   "src/websocket/listener/protocol-outbound.ts": 1100
 }

--- a/src/tools/client-toolset.test.ts
+++ b/src/tools/client-toolset.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { clearCapturedToolExecutionContexts } from "@/tools/manager";
+import { prepareToolExecutionContextForResolvedTarget } from "@/tools/toolset";
+
+describe("request-scoped client toolsets", () => {
+  afterEach(() => {
+    clearCapturedToolExecutionContexts();
+  });
+
+  test("builds an exact read-only toolset from a none base", async () => {
+    const prepared = await prepareToolExecutionContextForResolvedTarget({
+      modelIdentifier: "anthropic/claude-sonnet-5",
+      toolsetPreference: "auto",
+      clientToolset: {
+        base: "none",
+        include: ["Read", "LS", "Glob", "Grep"],
+      },
+      clientToolAllowlist: ["Read", "LS", "Glob", "Grep"],
+    });
+
+    expect(prepared.toolset).toBe("none");
+    expect(prepared.toolsetPreference).toBe("auto");
+    expect(prepared.preparedToolContext.loadedToolNames).toEqual([
+      "Read",
+      "LS",
+      "Glob",
+      "Grep",
+    ]);
+    expect(
+      prepared.preparedToolContext.clientTools.map((tool) => tool.name),
+    ).toEqual(["Read", "LS", "Glob", "Grep"]);
+  });
+
+  test("applies exclusions after additive tool includes", async () => {
+    const prepared = await prepareToolExecutionContextForResolvedTarget({
+      modelIdentifier: "anthropic/claude-sonnet-5",
+      toolsetPreference: "auto",
+      clientToolset: { include: ["AskUserQuestion"] },
+      exclude: ["AskUserQuestion"],
+      clientToolAllowlist: ["Read", "AskUserQuestion"],
+    });
+
+    expect(prepared.preparedToolContext.loadedToolNames).toEqual(["Read"]);
+  });
+
+  test("rejects unknown bundled tool names", async () => {
+    expect(
+      prepareToolExecutionContextForResolvedTarget({
+        modelIdentifier: "anthropic/claude-sonnet-5",
+        toolsetPreference: "auto",
+        clientToolset: { include: ["NotABundledTool"] },
+      }),
+    ).rejects.toThrow("Unknown bundled client tool: NotABundledTool");
+  });
+});

--- a/src/tools/manager.ts
+++ b/src/tools/manager.ts
@@ -1644,11 +1644,6 @@ async function resolveBaseToolNamesForModel(
     baseToolNames = TOOL_NAMES;
   }
 
-  if (options?.exclude && options.exclude.length > 0) {
-    const excludeSet = new Set(options.exclude);
-    baseToolNames = baseToolNames.filter((name) => !excludeSet.has(name));
-  }
-
   if (options?.include && options.include.length > 0) {
     const seen = new Set(baseToolNames);
     for (const name of options.include) {
@@ -1657,6 +1652,11 @@ async function resolveBaseToolNamesForModel(
         seen.add(name);
       }
     }
+  }
+
+  if (options?.exclude && options.exclude.length > 0) {
+    const excludeSet = new Set(options.exclude);
+    baseToolNames = baseToolNames.filter((name) => !excludeSet.has(name));
   }
 
   baseToolNames = filterWorktreeTools(baseToolNames);

--- a/src/tools/toolset.ts
+++ b/src/tools/toolset.ts
@@ -30,6 +30,7 @@ import {
   filterBuiltInToolNamesByClientAllowlist,
   GEMINI_DEFAULT_TOOLS,
   GEMINI_PASCAL_TOOLS,
+  getInternalToolName,
   getToolNames,
   isOpenAIModel,
   loadSpecificTools,
@@ -41,7 +42,7 @@ import {
   prepareToolExecutionContextForSpecificTools,
 } from "./manager";
 import type { PermissionModeState } from "./permission-mode-state";
-import type { ToolName } from "./tool-definitions";
+import { TOOL_DEFINITIONS, type ToolName } from "./tool-definitions";
 
 // Toolset definitions from manager.ts (single source of truth)
 
@@ -82,6 +83,40 @@ export type ToolsetName =
   | "gemini_snake"
   | "none";
 export type ToolsetPreference = ToolsetName | "auto";
+
+export interface ClientToolsetConfig {
+  /** Request-scoped base toolset. Omitted preserves the runtime preference. */
+  base?: ToolsetPreference;
+  /** Additional bundled client tools to load before applying the allowlist. */
+  include?: string[];
+}
+
+function resolveIncludedToolNames(toolNames: string[] | undefined): ToolName[] {
+  if (!toolNames) return [];
+
+  return toolNames.map((toolName) => {
+    const internalName = getInternalToolName(toolName);
+    if (!Object.hasOwn(TOOL_DEFINITIONS, internalName)) {
+      throw new Error(`Unknown bundled client tool: ${toolName}`);
+    }
+    return internalName as ToolName;
+  });
+}
+
+function appendUniqueToolNames(
+  baseToolNames: ToolName[],
+  includedToolNames: ToolName[],
+): ToolName[] {
+  const result = [...baseToolNames];
+  const seen = new Set(result);
+  for (const toolName of includedToolNames) {
+    if (!seen.has(toolName)) {
+      result.push(toolName);
+      seen.add(toolName);
+    }
+  }
+  return result;
+}
 
 export function deriveToolsetFromModel(
   modelIdentifier: string,
@@ -189,6 +224,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
   providerType?: string | null;
   conversationId?: string | null;
   toolsetPreference: ToolsetPreference;
+  clientToolset?: ClientToolsetConfig;
   exclude?: ToolName[];
   clientToolAllowlist?: string[];
   externalToolScopeIds?: string[];
@@ -206,6 +242,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
     providerType,
     conversationId,
     toolsetPreference,
+    clientToolset,
     exclude,
     clientToolAllowlist,
     externalToolScopeIds,
@@ -222,8 +259,10 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
     modelIdentifier && modelIdentifier.length > 0
       ? (resolveModel(modelIdentifier) ?? modelIdentifier)
       : null;
+  const effectiveToolsetPreference = clientToolset?.base ?? toolsetPreference;
+  const includedToolNames = resolveIncludedToolNames(clientToolset?.include);
 
-  if (toolsetPreference === "auto") {
+  if (effectiveToolsetPreference === "auto") {
     const derivedToolset = effectiveModel
       ? deriveToolsetFromModel(effectiveModel, providerType)
       : "default";
@@ -245,6 +284,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
       effectiveModel ?? undefined,
       {
         exclude,
+        include: includedToolNames,
         clientToolAllowlist,
         externalToolScopeIds,
         workingDirectory,
@@ -274,7 +314,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
     modelIdentifier: effectiveModel,
     permissionMode:
       permissionModeState?.mode ?? runtimeContext?.permissionMode ?? null,
-    toolset: toolsetPreference,
+    toolset: effectiveToolsetPreference,
     workingDirectory,
   });
   const modCapabilities = mergeModAdapterCapabilities(
@@ -283,9 +323,10 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
   );
   const preparedToolContext = await prepareToolExecutionContextForSpecificTools(
     filterBuiltInToolNamesByClientAllowlist(
-      getToolNamesForToolset(toolsetPreference, channelToolScope).filter(
-        (toolName) => (exclude ? !exclude.includes(toolName) : true),
-      ),
+      appendUniqueToolNames(
+        getToolNamesForToolset(effectiveToolsetPreference, channelToolScope),
+        includedToolNames,
+      ).filter((toolName) => (exclude ? !exclude.includes(toolName) : true)),
       clientToolAllowlist,
     ),
     {
@@ -304,7 +345,7 @@ export async function prepareToolExecutionContextForResolvedTarget(params: {
 
   return {
     preparedToolContext,
-    toolset: toolsetPreference,
+    toolset: effectiveToolsetPreference,
     toolsetPreference,
     effectiveModel,
     agent: null,
@@ -464,6 +505,7 @@ export async function prepareToolExecutionContextForScope(params: {
   overrideProviderType?: string | null;
   cachedEffectiveModel?: string | null;
   exclude?: ToolName[];
+  clientToolset?: ClientToolsetConfig;
   clientToolAllowlist?: string[];
   externalToolScopeIds?: string[];
   workingDirectory?: string;
@@ -483,6 +525,7 @@ export async function prepareToolExecutionContextForScope(params: {
     overrideProviderType,
     cachedEffectiveModel,
     exclude,
+    clientToolset,
     clientToolAllowlist,
     externalToolScopeIds,
     workingDirectory,
@@ -559,6 +602,7 @@ export async function prepareToolExecutionContextForScope(params: {
     providerType: effectiveProviderType,
     conversationId: conversationId ?? undefined,
     toolsetPreference,
+    clientToolset,
     exclude,
     clientToolAllowlist,
     externalToolScopeIds,

--- a/src/types/protocol_v2.ts
+++ b/src/types/protocol_v2.ts
@@ -173,6 +173,13 @@ export type ToolsetName =
 
 export type ToolsetPreference = ToolsetName | "auto";
 
+export interface ClientToolsetConfig {
+  /** Request-scoped base toolset. Omitted preserves the runtime preference. */
+  base?: ToolsetPreference;
+  /** Additional bundled client tools to load before applying the allowlist. */
+  include?: string[];
+}
+
 export interface AvailableSkillSummary {
   id: string;
   name: string;
@@ -737,6 +744,12 @@ export interface InputCreateMessagePayload {
    * client tools for this turn.
    */
   client_tool_allowlist?: string[];
+  /**
+   * Optional request-scoped built-in toolset selection. The base chooses the
+   * harness preset without changing persisted settings; include adds bundled
+   * client tools before the allowlist is applied.
+   */
+  client_toolset?: ClientToolsetConfig;
   /**
    * Optional scoped external tools to expose for this turn. Runtime-start
    * external tools with a scope_id stay hidden unless selected here; unscoped

--- a/src/websocket/listener/client-toolset-protocol.test.ts
+++ b/src/websocket/listener/client-toolset-protocol.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { parseServerMessage } from "@/websocket/listener/protocol-inbound";
+
+describe("client toolset protocol", () => {
+  test("parses request-scoped toolset configuration", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "input",
+          runtime: { agent_id: "agent-1", conversation_id: "default" },
+          payload: {
+            kind: "create_message",
+            messages: [{ role: "user", content: "hello" }],
+            client_toolset: {
+              base: "none",
+              include: ["Read", "LS", "Glob", "Grep"],
+            },
+            client_tool_allowlist: ["Read", "LS", "Glob", "Grep"],
+          },
+        }),
+      ),
+    );
+
+    expect(parsed).toMatchObject({
+      type: "input",
+      payload: {
+        kind: "create_message",
+        client_toolset: {
+          base: "none",
+          include: ["Read", "LS", "Glob", "Grep"],
+        },
+      },
+    });
+  });
+
+  test("rejects invalid request-scoped toolset configuration", () => {
+    const parsed = parseServerMessage(
+      Buffer.from(
+        JSON.stringify({
+          type: "input",
+          runtime: { agent_id: "agent-1", conversation_id: "default" },
+          payload: {
+            kind: "create_message",
+            messages: [{ role: "user", content: "hello" }],
+            client_toolset: {
+              base: "invented",
+              include: ["Read"],
+            },
+          },
+        }),
+      ),
+    );
+
+    expect(parsed).toEqual({
+      type: "__invalid_input",
+      runtime: { agent_id: "agent-1", conversation_id: "default" },
+      reason:
+        "Protocol violation: input.payload.client_toolset must contain an optional valid base and string[] include",
+    });
+  });
+});

--- a/src/websocket/listener/message-router.ts
+++ b/src/websocket/listener/message-router.ts
@@ -211,6 +211,14 @@ function summarizeInputPayload(payload: unknown): string[] {
   if (payload.kind === "create_message") {
     pushField(fields, "messages", payload.messages);
     pushField(fields, "client_tool_allowlist", payload.client_tool_allowlist);
+    if (isRecord(payload.client_toolset)) {
+      pushField(fields, "client_toolset.base", payload.client_toolset.base);
+      pushField(
+        fields,
+        "client_toolset.include",
+        payload.client_toolset.include,
+      );
+    }
     pushField(
       fields,
       "external_tool_scope_ids",
@@ -568,6 +576,7 @@ export function createListenerMessageHandler(
           agentId: parsed.runtime.agent_id,
           conversationId: parsed.runtime.conversation_id,
           clientToolAllowlist: inputPayload.client_tool_allowlist,
+          clientToolset: inputPayload.client_toolset,
           externalToolScopeIds: inputPayload.external_tool_scope_ids,
           excludeInteractiveTools: inputPayload.exclude_interactive_tools,
           messages: inputPayload.messages,

--- a/src/websocket/listener/protocol-ergonomics.test.ts
+++ b/src/websocket/listener/protocol-ergonomics.test.ts
@@ -94,6 +94,7 @@ describe("listener protocol ergonomics", () => {
           },
         ],
         client_tool_allowlist: undefined,
+        client_toolset: undefined,
         external_tool_scope_ids: undefined,
       },
     });

--- a/src/websocket/listener/protocol-inbound.ts
+++ b/src/websocket/listener/protocol-inbound.ts
@@ -33,6 +33,7 @@ import type {
   ChannelTargetsListCommand,
   ChatGPTUsageReadCommand,
   CheckoutBranchCommand,
+  ClientToolsetConfig,
   ConnectProviderCommand,
   ConversationCompactCommand,
   ConversationCreateCommand,
@@ -124,6 +125,26 @@ function isStringArray(value: unknown): value is string[] {
     Array.isArray(value) && value.every((item) => typeof item === "string")
   );
 }
+const TOOLSET_PREFERENCES = new Set([
+  "auto",
+  "codex",
+  "codex_snake",
+  "default",
+  "gemini",
+  "gemini_snake",
+  "none",
+]);
+
+function isClientToolsetConfig(value: unknown): value is ClientToolsetConfig {
+  if (!isObjectRecord(value)) return false;
+  return (
+    (value.base === undefined ||
+      (typeof value.base === "string" &&
+        TOOLSET_PREFERENCES.has(value.base))) &&
+    (value.include === undefined || isStringArray(value.include))
+  );
+}
+
 function isStringRecord(value: unknown): value is Record<string, string> {
   return (
     !!value &&
@@ -170,6 +191,7 @@ function isInputCommand(value: unknown): value is InputCommand {
     kind?: unknown;
     messages?: unknown;
     client_tool_allowlist?: unknown;
+    client_toolset?: unknown;
     external_tool_scope_ids?: unknown;
     exclude_interactive_tools?: unknown;
     request_id?: unknown;
@@ -181,6 +203,8 @@ function isInputCommand(value: unknown): value is InputCommand {
       Array.isArray(payload.messages) &&
       (payload.client_tool_allowlist === undefined ||
         isStringArray(payload.client_tool_allowlist)) &&
+      (payload.client_toolset === undefined ||
+        isClientToolsetConfig(payload.client_toolset)) &&
       (payload.external_tool_scope_ids === undefined ||
         isStringArray(payload.external_tool_scope_ids)) &&
       (payload.exclude_interactive_tools === undefined ||
@@ -206,6 +230,7 @@ function legacyEnvironmentMessageToInputCommand(
     conversation_id?: unknown;
     messages?: unknown;
     clientToolAllowlist?: unknown;
+    clientToolset?: unknown;
     externalToolScopeIds?: unknown;
   };
   if (
@@ -233,6 +258,9 @@ function legacyEnvironmentMessageToInputCommand(
       messages: candidate.messages as InputCreateMessagePayload["messages"],
       client_tool_allowlist: isStringArray(candidate.clientToolAllowlist)
         ? candidate.clientToolAllowlist
+        : undefined,
+      client_toolset: isClientToolsetConfig(candidate.clientToolset)
+        ? candidate.clientToolset
         : undefined,
       external_tool_scope_ids: isStringArray(candidate.externalToolScopeIds)
         ? candidate.externalToolScopeIds
@@ -266,6 +294,7 @@ function getInvalidInputReason(value: unknown): {
     kind?: unknown;
     messages?: unknown;
     client_tool_allowlist?: unknown;
+    client_toolset?: unknown;
     external_tool_scope_ids?: unknown;
     exclude_interactive_tools?: unknown;
     request_id?: unknown;
@@ -288,6 +317,16 @@ function getInvalidInputReason(value: unknown): {
         runtime: candidate.runtime,
         reason:
           "Protocol violation: input.payload.client_tool_allowlist must be string[]",
+      };
+    }
+    if (
+      payload.client_toolset !== undefined &&
+      !isClientToolsetConfig(payload.client_toolset)
+    ) {
+      return {
+        runtime: candidate.runtime,
+        reason:
+          "Protocol violation: input.payload.client_toolset must contain an optional valid base and string[] include",
       };
     }
     if (

--- a/src/websocket/listener/turn-setup.ts
+++ b/src/websocket/listener/turn-setup.ts
@@ -259,6 +259,7 @@ export async function prepareListenerTurn(params: {
     connectionId,
     agentId,
     conversationId,
+    clientToolset: msg.clientToolset,
     clientToolAllowlist: msg.clientToolAllowlist,
     // Headless clients (SDK sessions, automation) opt out of tools that
     // prompt the human mid-turn; the interactive set is owned by the harness.

--- a/src/websocket/listener/types.ts
+++ b/src/websocket/listener/types.ts
@@ -21,6 +21,7 @@ import type { SharedReminderState } from "@/reminders/state";
 import type { ToolsetName, ToolsetPreference } from "@/tools/toolset";
 import type {
   ApprovalResponseBody,
+  ClientToolsetConfig,
   ControlRequest,
   ExternalToolCallResult,
   LoopStatus,
@@ -74,6 +75,7 @@ export interface IncomingMessage {
   noCoalesce?: boolean;
   channelTurnSources?: ChannelTurnSource[];
   clientToolAllowlist?: string[];
+  clientToolset?: ClientToolsetConfig;
   externalToolScopeIds?: string[];
   /** Exclude interactive user-input tools (AskUserQuestion) from this turn's toolset. */
   excludeInteractiveTools?: boolean;


### PR DESCRIPTION
## Summary
- add a request-scoped client toolset override with a temporary base preset and additive bundled tools
- apply explicit includes before exclusions and the existing client-tool allowlist, preserving the allowlist as the security ceiling
- validate and route the new App Server input field with focused protocol and tool-resolution coverage

## Test plan
- [x] `bun run check`
- [x] `bun test src/tools/client-toolset.test.ts src/websocket/listener/client-toolset-protocol.test.ts src/websocket/listener/protocol-ergonomics.test.ts`

👾 Generated with [Letta Code](https://letta.com)