### PR TITLE
fix(cli): reject implicit headless positional prompts

### DIFF
--- a/src/cli/startup-mode.test.ts
+++ b/src/cli/startup-mode.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { isHeadlessStartup } from "@/cli/startup-mode";
+
+describe("startup mode resolution", () => {
+  test("non-TTY unknown positional without explicit headless flag stays out of headless mode", () => {
+    expect(
+      isHeadlessStartup({ prompt: false, run: false }, false, "hello"),
+    ).toBe(false);
+  });
+
+  test("non-TTY startup without a positional uses stdin headless prompt transport", () => {
+    expect(
+      isHeadlessStartup({ prompt: false, run: false }, false, undefined),
+    ).toBe(true);
+  });
+
+  test("-p keeps positional prompts in headless mode", () => {
+    expect(
+      isHeadlessStartup({ prompt: true, run: false }, false, "hello"),
+    ).toBe(true);
+  });
+
+  test("--run keeps positional prompts in headless mode", () => {
+    expect(
+      isHeadlessStartup({ prompt: false, run: true }, false, "hello"),
+    ).toBe(true);
+  });
+
+  test("TTY startup without a positional is interactive", () => {
+    expect(
+      isHeadlessStartup({ prompt: false, run: false }, true, undefined),
+    ).toBe(false);
+  });
+});

--- a/src/cli/startup-mode.ts
+++ b/src/cli/startup-mode.ts
@@ -1,0 +1,18 @@
+export function isHeadlessStartup(
+  flags: { prompt?: boolean; run?: boolean },
+  stdinIsTTY: boolean | undefined,
+  firstPositional: string | null | undefined,
+): boolean {
+  if (flags.prompt || flags.run) {
+    return true;
+  }
+
+  // Subcommands have already been routed. A remaining positional is an unknown
+  // command unless the caller explicitly selected headless prompt mode.
+  if (firstPositional) {
+    return false;
+  }
+
+  // Preserve stdin-only prompt transport for pipes and spawned subagents.
+  return stdinIsTTY !== true;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ import {
   validateFlagConflicts,
   validateRegistryHandleOrThrow,
 } from "./cli/startup-flag-validation";
+import { isHeadlessStartup } from "./cli/startup-mode";
 import {
   runSubcommand,
   subcommandNeedsEarlyBackendMode,
@@ -830,7 +831,7 @@ async function main(): Promise<void> {
     importFlagValue: values.import,
     fromAfFlagValue: values["from-af"],
   });
-  const isHeadless = values.prompt || values.run || !process.stdin.isTTY;
+  const isHeadless = isHeadlessStartup(values, process.stdin.isTTY, command);
   const terminalThemePromise = !isHeadless
     ? initTerminalTheme().catch(() => undefined)
     : Promise.resolve(undefined);
@@ -944,7 +945,6 @@ async function main(): Promise<void> {
     });
   }
 
-  // Fail if an unknown command/argument is passed (and we're not in headless mode where it might be a prompt)
   if (command && !isHeadless) {
     console.error(`Error: Unknown command or argument "${command}"`);
     console.error("Run 'letta --help' for usage information.");

--- a/src/startup-flow.test.ts
+++ b/src/startup-flow.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { LETTA_CHAT_API_KEYS_URL } from "@/cli/helpers/app-urls";
 import { createIsolatedCliTestEnv } from "@/test-utils/test-process-env";
 
@@ -20,51 +23,60 @@ async function runCli(
   } = {},
 ): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
   const { timeoutMs = 30000, expectExit } = options;
+  const homeDir = await mkdtemp(join(tmpdir(), "letta-startup-flow-home-"));
 
-  return new Promise((resolve, reject) => {
-    const proc = spawn("bun", ["run", "dev", ...args], {
-      cwd: projectRoot,
-      env: createIsolatedCliTestEnv(),
-    });
+  try {
+    return await new Promise((resolve, reject) => {
+      const proc = spawn("bun", ["run", "dev", ...args], {
+        cwd: projectRoot,
+        env: createIsolatedCliTestEnv({
+          HOME: homeDir,
+          LETTA_DISABLE_MODS: "1",
+        }),
+      });
+      proc.stdin?.end();
 
-    let stdout = "";
-    let stderr = "";
+      let stdout = "";
+      let stderr = "";
 
-    proc.stdout?.on("data", (data) => {
-      stdout += data.toString();
-    });
+      proc.stdout?.on("data", (data) => {
+        stdout += data.toString();
+      });
 
-    proc.stderr?.on("data", (data) => {
-      stderr += data.toString();
-    });
+      proc.stderr?.on("data", (data) => {
+        stderr += data.toString();
+      });
 
-    const timeout = setTimeout(() => {
-      proc.kill();
-      reject(
-        new Error(
-          `Timeout after ${timeoutMs}ms. stdout: ${stdout}, stderr: ${stderr}`,
-        ),
-      );
-    }, timeoutMs);
-
-    proc.on("close", (code) => {
-      clearTimeout(timeout);
-      if (expectExit !== undefined && code !== expectExit) {
+      const timeout = setTimeout(() => {
+        proc.kill();
         reject(
           new Error(
-            `Expected exit code ${expectExit}, got ${code}. stdout: ${stdout}, stderr: ${stderr}`,
+            `Timeout after ${timeoutMs}ms. stdout: ${stdout}, stderr: ${stderr}`,
           ),
         );
-      } else {
-        resolve({ stdout, stderr, exitCode: code });
-      }
-    });
+      }, timeoutMs);
 
-    proc.on("error", (err) => {
-      clearTimeout(timeout);
-      reject(err);
+      proc.on("close", (code) => {
+        clearTimeout(timeout);
+        if (expectExit !== undefined && code !== expectExit) {
+          reject(
+            new Error(
+              `Expected exit code ${expectExit}, got ${code}. stdout: ${stdout}, stderr: ${stderr}`,
+            ),
+          );
+        } else {
+          resolve({ stdout, stderr, exitCode: code });
+        }
+      });
+
+      proc.on("error", (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
     });
-  });
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
 }
 
 describe("Startup Flow - Flag Conflicts", () => {
@@ -179,6 +191,23 @@ describe("Startup Flow - Smoke", () => {
     );
     expect(result.stderr).not.toContain("https://app.letta.com/api-keys");
     expect(result.stderr).not.toContain("No recent session found");
+  });
+
+  test("unknown positional with non-TTY stdin rejects before headless credential path", async () => {
+    const result = await runCli(["whoami"], { expectExit: 1 });
+    expect(result.stderr).toContain(
+      'Error: Unknown command or argument "whoami"',
+    );
+    expect(result.stderr).toContain(
+      "Run 'letta --help' for usage information.",
+    );
+    expect(result.stderr).not.toContain("Missing LETTA_API_KEY");
+  });
+
+  test("stdin-only non-TTY startup still uses the headless path", async () => {
+    const result = await runCli([], { expectExit: 1 });
+    expect(result.stderr).toContain("Missing LETTA_API_KEY");
+    expect(result.stderr).not.toContain("Unknown command or argument");
   });
 
   test("--toolset auto is accepted", async () => {


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Summary

- Reject unknown positional CLI arguments in non-TTY shells unless `-p`/`--prompt` or internal `--run` explicitly selects headless mode.
- Preserve stdin-only headless prompt transport when no positional argument is present.
- Isolate startup process tests from the user’s real home, credentials, and mods.

## Before / after

Before, `letta whoami </dev/null` could interpret `whoami` as agent prompt text, create a conversation, and consume tokens. It now exits 1 with the existing `Unknown command or argument` error.

Piped stdin without a positional remains supported, so stdin-based subagent prompt transport continues to enter headless mode.

## Risk

The change is limited to startup mode selection after real subcommands have already been routed. Explicit headless invocations are unchanged.

## Test plan

- [x] Exact non-TTY repro against the source CLI
- [x] `bun test src/cli/startup-mode.test.ts src/startup-flow.test.ts` (23 passed)
- [x] `bun run check` (12 checks passed)

👾 Generated with [Letta Code](https://letta.com)