### PR TITLE
fix(slack): restore immediate status in existing threads

### DIFF
--- a/src/channels/slack/adapter.ts
+++ b/src/channels/slack/adapter.ts
@@ -179,17 +179,24 @@ export function createSlackAdapter(
   ): Promise<void> {
     if (!running) return;
     if (event.type === "queued") {
-      if (
-        isSlackFlatChannelThreadOpener(event.source) &&
-        isNonEmptyString(event.source.messageId) &&
-        !agentThreadTracker.has(event.source.chatId, event.source.messageId)
-      ) {
-        await status.activate(
-          event.source,
-          SLACK_ASSISTANT_STARTUP_STATUS,
-          SLACK_ASSISTANT_STARTUP_STATUS,
-        );
+      if (isSlackFlatChannelThreadOpener(event.source)) {
+        if (
+          isNonEmptyString(event.source.messageId) &&
+          !agentThreadTracker.has(event.source.chatId, event.source.messageId)
+        ) {
+          await status.activateIfIdle(
+            event.source,
+            SLACK_ASSISTANT_STARTUP_STATUS,
+            SLACK_ASSISTANT_STARTUP_STATUS,
+          );
+        }
+        return;
       }
+      await status.activateIfIdle(
+        event.source,
+        SLACK_ASSISTANT_STARTUP_STATUS,
+        SLACK_ASSISTANT_STARTUP_STATUS,
+      );
       return;
     }
 

--- a/src/channels/slack/status-controller.test.ts
+++ b/src/channels/slack/status-controller.test.ts
@@ -30,7 +30,32 @@ test("slack status event table: flat mention queues a pinned thinking status", a
   expect(client.chat.postMessage).not.toHaveBeenCalled();
 });
 
-test("slack status event table: established turns stay quiet and clear a stale ghost once", async () => {
+test("slack status event table: established turns queue a generic thinking status", async () => {
+  const adapter = await createStartedSlackAdapter();
+  const source = createSlackTurnSource();
+
+  await adapter.handleTurnLifecycleEvent?.({ type: "queued", source });
+
+  const client = getSlackWriteClient();
+  expect(client.assistant.threads.setStatus).toHaveBeenCalledTimes(1);
+  expect(client.assistant.threads.setStatus).toHaveBeenLastCalledWith({
+    channel_id: "C123",
+    thread_ts: "1712800000.000100",
+    status: "is thinking...",
+    loading_messages: ["is thinking..."],
+  });
+
+  await adapter.handleTurnLifecycleEvent?.({
+    type: "processing",
+    batchId: "batch-1",
+    sources: [source],
+  });
+
+  expect(client.assistant.threads.setStatus).toHaveBeenCalledTimes(1);
+  expect(client.chat.postMessage).not.toHaveBeenCalled();
+});
+
+test("slack status event table: processing clears a stale ghost once when idle", async () => {
   const adapter = await createStartedSlackAdapter();
   const source = createSlackTurnSource();
 
@@ -209,7 +234,7 @@ test("slack status event table: concurrent title swaps are sent in event order",
   expect(sentTitles).toEqual(["Reading the adapter", "Running the tests"]);
 });
 
-test("slack status event table: queued mid-turn input does not clear live status", async () => {
+test("slack status event table: queued mid-turn input does not overwrite live status", async () => {
   const adapter = await createStartedSlackAdapter();
   const source = createSlackTurnSource();
   await adapter.handleTurnProgressEvent?.({
@@ -229,7 +254,37 @@ test("slack status event table: queued mid-turn input does not clear live status
   });
 
   expect(client.assistant.threads.setStatus).toHaveBeenCalledTimes(1);
+  expect(client.assistant.threads.setStatus).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      status: "is working...",
+      loading_messages: ["Working through the turn"],
+    }),
+  );
   expect(client.chat.postMessage).not.toHaveBeenCalled();
+});
+
+test("slack status event table: known root-shaped queued events after a reply stay quiet", async () => {
+  const adapter = await createStartedSlackAdapter();
+  const source = createSlackTurnSource({
+    messageId: "1712800000.000100",
+    threadId: "1712800000.000100",
+  });
+
+  await adapter.handleTurnLifecycleEvent?.({ type: "queued", source });
+  const client = getSlackWriteClient();
+  await adapter.sendMessage({
+    channel: "slack",
+    chatId: "C123",
+    text: "A durable reply",
+    threadId: "1712800000.000100",
+    agentId: "agent-1",
+    conversationId: "conv-1",
+  });
+
+  client.assistant.threads.setStatus.mockClear();
+  await adapter.handleTurnLifecycleEvent?.({ type: "queued", source });
+
+  expect(client.assistant.threads.setStatus).not.toHaveBeenCalled();
 });
 
 test("slack status event table: flat-channel activity remains status-only", async () => {

--- a/src/channels/slack/status-controller.ts
+++ b/src/channels/slack/status-controller.ts
@@ -39,6 +39,11 @@ export type SlackStatusController = {
     footerText: string,
     loadingText: string,
   ) => Promise<void>;
+  activateIfIdle: (
+    source: ChannelTurnSource,
+    footerText: string,
+    loadingText: string,
+  ) => Promise<void>;
   deactivate: (source: ChannelTurnSource) => Promise<void>;
   clearStale: (source: ChannelTurnSource) => Promise<void>;
   markAutoCleared: (source: ChannelTurnSource) => void;
@@ -225,6 +230,17 @@ export function createSlackStatusController(params: {
     else if (!sent) state.isThinkingActive = false;
   }
 
+  async function activateIfIdle(
+    source: ChannelTurnSource,
+    footerText: string,
+    loadingText: string,
+  ): Promise<void> {
+    const key = getConversationKey(source);
+    if (!key || !getLifecycleReplyKey(source)) return;
+    if (stateByConversation.get(key)?.isThinkingActive) return;
+    await activate(source, footerText, loadingText);
+  }
+
   function markAutoClearedByKey(key: string): void {
     clearKeepalive(key);
     const state = stateByConversation.get(key);
@@ -265,6 +281,7 @@ export function createSlackStatusController(params: {
     getUniqueSources,
     getLifecycleErrorReplyKey,
     activate,
+    activateIfIdle,
     deactivate,
     clearStale,
     markAutoCleared(source): void {


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Summary
- show the native Slack assistant status as soon as a follow-up turn is queued in an existing thread, rather than waiting for the first tool or final reply
- activate generic thinking copy only while status is idle, preserving concrete tool titles when another message queues mid-turn
- keep known root-shaped retry/continuation events quiet after the bot has already replied

## Test plan
- [x] Regression test fails on `main` and passes with this patch
- [x] `bun test src/channels/slack/status-controller.test.ts` (16 passed)
- [x] `bun test src/channels/slack/media.test.ts` (18 passed; isolated control for the Slack mock boundary)
- [x] `bun run check` (12/12 passed)

👾 Generated with [Letta Code](https://letta.com)