### PR TITLE
feat(memory): restore read-only file controls

### DIFF
--- a/scripts/source-file-size-baseline.json
+++ b/scripts/source-file-size-baseline.json
@@ -31,7 +31,7 @@
   "src/mods/package-installer.test.ts": 1248,
   "src/mods/package-installer.ts": 1201,
   "src/mods/package-registry.ts": 1033,
-  "src/permissions/checker.ts": 1009,
+  "src/permissions/checker.ts": 1007,
   "src/permissions/read-only-shell.test.ts": 1303,
   "src/permissions/read-only-shell.ts": 2009,
   "src/providers/chatgpt-usage-service.ts": 1112,

--- a/src/agent/memory-git-hooks.ts
+++ b/src/agent/memory-git-hooks.ts
@@ -32,6 +32,10 @@ AGENT_EDITABLE_KEYS="description"
 PROTECTED_KEYS="read_only"
 ALL_KNOWN_KEYS="description read_only limit"
 errors=""
+allow_read_only_change=false
+if [ "$LETTA_APPROVED_READ_ONLY_CHANGE" = "1" ]; then
+  allow_read_only_change=true
+fi
 
 # Skills must always be directories: skills/<name>/SKILL.md
 # Reject legacy flat skill files (both current and legacy repo layouts).
@@ -47,6 +51,19 @@ get_fm_value() {
   [ -z "$closing_line" ] && return
   echo "$content" | tail -n +2 | head -n $((closing_line - 1)) | grep "^$key:" | cut -d: -f2- | sed 's/^ *//;s/ *$//'
 }
+
+# Deleting or renaming a read-only file must be rejected too. Deleted paths do
+# not appear in the ACM validation loop below, so inspect their HEAD content
+# separately.
+if [ "$allow_read_only_change" = "false" ]; then
+  for file in $(git diff --cached --no-renames --name-only --diff-filter=D | grep -E '^(memory/)?(system|reference)/.*\\.md$' || true); do
+    head_content=$(git show "HEAD:$file" 2>/dev/null || true)
+    head_ro=$(get_fm_value "$head_content" "read_only")
+    if [ "$head_ro" = "true" ]; then
+      errors="$errors\n  $file: file is read_only and cannot be deleted or renamed"
+    fi
+  done
+fi
 
 # Match .md files under system/ or reference/ (with optional memory/ prefix).
 # Skip skill SKILL.md files — they use a different frontmatter format.
@@ -69,7 +86,7 @@ for file in $(git diff --cached --name-only --diff-filter=ACM | grep -E '^(memor
 
   # Check read_only protection against HEAD version
   head_content=$(git show "HEAD:$file" 2>/dev/null || true)
-  if [ -n "$head_content" ]; then
+  if [ "$allow_read_only_change" = "false" ] && [ -n "$head_content" ]; then
     head_ro=$(get_fm_value "$head_content" "read_only")
     if [ "$head_ro" = "true" ]; then
       errors="$errors\\n  $file: file is read_only and cannot be modified"
@@ -110,6 +127,7 @@ for file in $(git diff --cached --name-only --diff-filter=ACM | grep -E '^(memor
     # Check if agent is trying to modify a protected key
     for k in $PROTECTED_KEYS; do
       if [ "$key" = "$k" ]; then
+        [ "$allow_read_only_change" = "true" ] && continue
         # Compare against HEAD — if value changed (or key was added), reject
         if [ -n "$head_content" ]; then
           head_val=$(get_fm_value "$head_content" "$key")
@@ -143,7 +161,7 @@ for file in $(git diff --cached --name-only --diff-filter=ACM | grep -E '^(memor
   fi
 
   # Check if protected keys were removed (existed in HEAD but not in staged)
-  if [ -n "$head_content" ]; then
+  if [ "$allow_read_only_change" = "false" ] && [ -n "$head_content" ]; then
     for k in $PROTECTED_KEYS; do
       head_val=$(get_fm_value "$head_content" "$k")
       if [ -n "$head_val" ]; then

--- a/src/agent/memory-git.precommit.test.ts
+++ b/src/agent/memory-git.precommit.test.ts
@@ -141,6 +141,36 @@ describe("pre-commit hook: field validation", () => {
 });
 
 describe("pre-commit hook: read_only protection", () => {
+  test("rejects deleting or renaming a read_only file", () => {
+    const hookPath = join(tempDir, ".git", "hooks", "pre-commit");
+    rmSync(hookPath);
+    writeAndStage(
+      "system/locked.md",
+      "---\ndescription: Locked\nread_only: true\n---\n\nContent.\n",
+    );
+    tryCommit();
+    writeFileSync(hookPath, PRE_COMMIT_HOOK_SCRIPT, { mode: 0o755 });
+
+    git("rm system/locked.md");
+    expect(tryCommit().success).toBe(false);
+    git("reset --hard HEAD");
+    git("mv system/locked.md system/renamed.md");
+    expect(tryCommit().success).toBe(false);
+  });
+
+  test("allows an approved read_only change", () => {
+    writeAndStage(
+      "system/locked.md",
+      "---\ndescription: Locked\nread_only: true\n---\n",
+    );
+    expect(() =>
+      execSync('git commit -m "approved"', {
+        cwd: tempDir,
+        env: { ...GIT_ENV, LETTA_APPROVED_READ_ONLY_CHANGE: "1" },
+      }),
+    ).not.toThrow();
+  });
+
   test("rejects modifying a read_only file", () => {
     // First commit: create a read_only file (bypass hook for setup)
     const hookPath = join(tempDir, ".git", "hooks", "pre-commit");

--- a/src/cli/subcommands/memory-read-only.spec.ts
+++ b/src/cli/subcommands/memory-read-only.spec.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "bun:\u0074est";
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PRE_COMMIT_HOOK_SCRIPT } from "@/agent/memory-git-hooks";
+import { checkPermission } from "@/permissions/checker";
+import type { PermissionRules } from "@/permissions/types";
+import {
+  runMemoryReadOnlyAction,
+  updateReadOnlyFrontmatter,
+} from "./memory-read-only";
+
+const EMPTY_PERMISSIONS: PermissionRules = {
+  allow: [],
+  deny: [],
+  ask: [],
+  alwaysAsk: [],
+  additionalDirectories: [],
+};
+
+describe("read-only memory frontmatter", () => {
+  it("adds and toggles read_only without rewriting other content", () => {
+    const original =
+      "---\ndescription: Keep this exactly\nlimit: legacy\n---\n\nBody\n";
+    const enabled = updateReadOnlyFrontmatter(original, true);
+    expect(enabled.previous).toBeNull();
+    expect(enabled.content).toBe(
+      "---\ndescription: Keep this exactly\nlimit: legacy\nread_only: true\n---\n\nBody\n",
+    );
+
+    const disabled = updateReadOnlyFrontmatter(enabled.content, false);
+    expect(disabled.previous).toBe(true);
+    expect(disabled.content).toContain("read_only: false");
+    expect(updateReadOnlyFrontmatter(disabled.content, false).changed).toBe(
+      false,
+    );
+  });
+
+  it("preserves CRLF line endings", () => {
+    const result = updateReadOnlyFrontmatter(
+      "---\r\ndescription: Windows\r\n---\r\nBody\r\n",
+      true,
+    );
+    expect(result.content).toBe(
+      "---\r\ndescription: Windows\r\nread_only: true\r\n---\r\nBody\r\n",
+    );
+  });
+});
+
+describe("read-only memory approval", () => {
+  it("always asks even when the permission mode is unrestricted", () => {
+    const result = checkPermission(
+      "Bash",
+      { command: "letta memory read-only system/persona.md true" },
+      EMPTY_PERMISSIONS,
+    );
+    expect(result.decision).toBe("alwaysAsk");
+    expect(result.reason).toContain("explicit user approval");
+  });
+
+  it("recognizes toggles after a chained command", () => {
+    const result = checkPermission(
+      "exec_command",
+      { cmd: "cd /tmp && letta memfs read-only system/persona.md false" },
+      EMPTY_PERMISSIONS,
+    );
+    expect(result.decision).toBe("alwaysAsk");
+  });
+
+  it("recognizes an absolute letta executable path", () => {
+    const result = checkPermission(
+      "Bash",
+      {
+        command:
+          "/usr/local/bin/letta memory read-only reference/policy.md true",
+      },
+      EMPTY_PERMISSIONS,
+    );
+    expect(result.decision).toBe("alwaysAsk");
+  });
+
+  it("recognizes shell-wrapped toggles", () => {
+    for (const command of [
+      `sh -c "letta memory read-only system/persona.md true"`,
+      `bash -c 'letta.js memfs read-only reference/policy.md false'`,
+    ]) {
+      expect(
+        checkPermission("Bash", { command }, EMPTY_PERMISSIONS).decision,
+      ).toBe("alwaysAsk");
+    }
+  });
+});
+
+describe("read-only memory commits", () => {
+  it("blocks deletion and rename while allowing the approved CLI toggle", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "letta-read-only-"));
+    const git = (args: string[], env?: NodeJS.ProcessEnv) =>
+      execFileSync("git", args, {
+        cwd: dir,
+        env: {
+          ...process.env,
+          GIT_AUTHOR_NAME: "Fixture",
+          GIT_AUTHOR_EMAIL: "fixture@example.com",
+          GIT_COMMITTER_NAME: "Fixture",
+          GIT_COMMITTER_EMAIL: "fixture@example.com",
+          ...env,
+        },
+        encoding: "utf8",
+        stdio: "pipe",
+      });
+
+    try {
+      git(["init"]);
+      mkdirSync(join(dir, "system"), { recursive: true });
+      const file = join(dir, "system", "locked.md");
+      writeFileSync(
+        file,
+        "---\ndescription: Locked\nread_only: true\n---\n\nBody\n",
+      );
+      git(["add", "system/locked.md"]);
+      git(["commit", "-m", "fixture"]);
+
+      const hook = join(dir, ".git", "hooks", "pre-commit");
+      writeFileSync(hook, PRE_COMMIT_HOOK_SCRIPT, { mode: 0o755 });
+      git(["rm", "system/locked.md"]);
+      expect(() => git(["commit", "-m", "delete"])).toThrow();
+      git(["reset", "--hard", "HEAD"]);
+
+      git(["mv", "system/locked.md", "system/renamed.md"]);
+      expect(() => git(["commit", "-m", "rename"])).toThrow();
+      git(["reset", "--hard", "HEAD"]);
+
+      const exitCode = await runMemoryReadOnlyAction({
+        agentId: "agent-fixture",
+        memoryDir: dir,
+        path: "system/locked.md",
+        value: "false",
+        extraPositionals: [],
+      });
+      expect(exitCode).toBe(0);
+
+      expect(readFileSync(file, "utf8")).toContain("read_only: false");
+      expect(git(["log", "-1", "--pretty=%s"]).trim()).toBe(
+        "Unmark system/locked.md as read-only",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/subcommands/memory-read-only.spec.ts
+++ b/src/cli/subcommands/memory-read-only.spec.ts
@@ -1,23 +1,9 @@
 import { describe, expect, it } from "bun:\u0074est";
-import { execFileSync } from "node:child_process";
-import {
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { PRE_COMMIT_HOOK_SCRIPT } from "@/agent/memory-git-hooks";
 import { checkPermission } from "@/permissions/checker";
 import type { PermissionRules } from "@/permissions/types";
-import {
-  runMemoryReadOnlyAction,
-  updateReadOnlyFrontmatter,
-} from "./memory-read-only";
+import { updateReadOnlyFrontmatter } from "./memory-read-only";
 
-const EMPTY_PERMISSIONS: PermissionRules = {
+const permissions: PermissionRules = {
   allow: [],
   deny: [],
   ask: [],
@@ -25,133 +11,29 @@ const EMPTY_PERMISSIONS: PermissionRules = {
   additionalDirectories: [],
 };
 
-describe("read-only memory frontmatter", () => {
-  it("adds and toggles read_only without rewriting other content", () => {
-    const original =
-      "---\ndescription: Keep this exactly\nlimit: legacy\n---\n\nBody\n";
+describe("memory read-only", () => {
+  it("adds and toggles read_only without changing the body", () => {
+    const original = "---\ndescription: Keep\n---\n\nBody\n";
     const enabled = updateReadOnlyFrontmatter(original, true);
-    expect(enabled.previous).toBeNull();
-    expect(enabled.content).toBe(
-      "---\ndescription: Keep this exactly\nlimit: legacy\nread_only: true\n---\n\nBody\n",
+    expect(enabled).toBe(
+      "---\ndescription: Keep\nread_only: true\n---\n\nBody\n",
     );
-
-    const disabled = updateReadOnlyFrontmatter(enabled.content, false);
-    expect(disabled.previous).toBe(true);
-    expect(disabled.content).toContain("read_only: false");
-    expect(updateReadOnlyFrontmatter(disabled.content, false).changed).toBe(
-      false,
+    expect(updateReadOnlyFrontmatter(enabled ?? "", false)).toContain(
+      "read_only: false\n---\n\nBody\n",
     );
+    expect(
+      updateReadOnlyFrontmatter("---\r\ndescription: CRLF\r\n---\r\n", true),
+    ).toContain("read_only: true\r\n---");
   });
 
-  it("preserves CRLF line endings", () => {
-    const result = updateReadOnlyFrontmatter(
-      "---\r\ndescription: Windows\r\n---\r\nBody\r\n",
-      true,
-    );
-    expect(result.content).toBe(
-      "---\r\ndescription: Windows\r\nread_only: true\r\n---\r\nBody\r\n",
-    );
-  });
-});
-
-describe("read-only memory approval", () => {
-  it("always asks even when the permission mode is unrestricted", () => {
-    const result = checkPermission(
-      "Bash",
-      { command: "letta memory read-only system/persona.md true" },
-      EMPTY_PERMISSIONS,
-    );
-    expect(result.decision).toBe("alwaysAsk");
-    expect(result.reason).toContain("explicit user approval");
-  });
-
-  it("recognizes toggles after a chained command", () => {
-    const result = checkPermission(
-      "exec_command",
-      { cmd: "cd /tmp && letta memfs read-only system/persona.md false" },
-      EMPTY_PERMISSIONS,
-    );
-    expect(result.decision).toBe("alwaysAsk");
-  });
-
-  it("recognizes an absolute letta executable path", () => {
-    const result = checkPermission(
-      "Bash",
-      {
-        command:
-          "/usr/local/bin/letta memory read-only reference/policy.md true",
-      },
-      EMPTY_PERMISSIONS,
-    );
-    expect(result.decision).toBe("alwaysAsk");
-  });
-
-  it("recognizes shell-wrapped toggles", () => {
+  it("always requires approval", () => {
     for (const command of [
-      `sh -c "letta memory read-only system/persona.md true"`,
-      `bash -c 'letta.js memfs read-only reference/policy.md false'`,
+      "letta memory read-only system/persona.md true",
+      `sh -c "letta memfs read-only reference/policy.md false"`,
     ]) {
-      expect(
-        checkPermission("Bash", { command }, EMPTY_PERMISSIONS).decision,
-      ).toBe("alwaysAsk");
-    }
-  });
-});
-
-describe("read-only memory commits", () => {
-  it("blocks deletion and rename while allowing the approved CLI toggle", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "letta-read-only-"));
-    const git = (args: string[], env?: NodeJS.ProcessEnv) =>
-      execFileSync("git", args, {
-        cwd: dir,
-        env: {
-          ...process.env,
-          GIT_AUTHOR_NAME: "Fixture",
-          GIT_AUTHOR_EMAIL: "fixture@example.com",
-          GIT_COMMITTER_NAME: "Fixture",
-          GIT_COMMITTER_EMAIL: "fixture@example.com",
-          ...env,
-        },
-        encoding: "utf8",
-        stdio: "pipe",
-      });
-
-    try {
-      git(["init"]);
-      mkdirSync(join(dir, "system"), { recursive: true });
-      const file = join(dir, "system", "locked.md");
-      writeFileSync(
-        file,
-        "---\ndescription: Locked\nread_only: true\n---\n\nBody\n",
+      expect(checkPermission("Bash", { command }, permissions).decision).toBe(
+        "alwaysAsk",
       );
-      git(["add", "system/locked.md"]);
-      git(["commit", "-m", "fixture"]);
-
-      const hook = join(dir, ".git", "hooks", "pre-commit");
-      writeFileSync(hook, PRE_COMMIT_HOOK_SCRIPT, { mode: 0o755 });
-      git(["rm", "system/locked.md"]);
-      expect(() => git(["commit", "-m", "delete"])).toThrow();
-      git(["reset", "--hard", "HEAD"]);
-
-      git(["mv", "system/locked.md", "system/renamed.md"]);
-      expect(() => git(["commit", "-m", "rename"])).toThrow();
-      git(["reset", "--hard", "HEAD"]);
-
-      const exitCode = await runMemoryReadOnlyAction({
-        agentId: "agent-fixture",
-        memoryDir: dir,
-        path: "system/locked.md",
-        value: "false",
-        extraPositionals: [],
-      });
-      expect(exitCode).toBe(0);
-
-      expect(readFileSync(file, "utf8")).toContain("read_only: false");
-      expect(git(["log", "-1", "--pretty=%s"]).trim()).toBe(
-        "Unmark system/locked.md as read-only",
-      );
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/src/cli/subcommands/memory-read-only.ts
+++ b/src/cli/subcommands/memory-read-only.ts
@@ -1,0 +1,219 @@
+import { execFile } from "node:child_process";
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
+import { isAbsolute, relative, resolve } from "node:path";
+import { promisify } from "node:util";
+import {
+  assertMemoryRepoCleanForWrite,
+  buildNonInteractiveGitEnv,
+} from "@/agent/memory-git";
+import {
+  installPostCommitHook,
+  installPreCommitHook,
+} from "@/agent/memory-git-hooks";
+
+const execFileAsync = promisify(execFile);
+
+export interface ReadOnlyFrontmatterUpdate {
+  content: string;
+  changed: boolean;
+  previous: boolean | null;
+}
+
+/** Update only the protected read_only key while preserving the rest verbatim. */
+export function updateReadOnlyFrontmatter(
+  content: string,
+  readOnly: boolean,
+): ReadOnlyFrontmatterUpdate {
+  const match = content.match(/^(---(\r?\n))([\s\S]*?)(\r?\n)---(?=\r?\n|$)/);
+  if (!match) {
+    throw new Error("Memory file is missing required frontmatter.");
+  }
+
+  const newline = match[2] ?? "\n";
+  const frontmatter = match[3] ?? "";
+  if (/^description\s*:/m.exec(frontmatter) === null) {
+    throw new Error("Memory file frontmatter is missing 'description'.");
+  }
+
+  const readOnlyLines = [
+    ...frontmatter.matchAll(/^read_only\s*:\s*(.*?)\s*$/gm),
+  ];
+  if (readOnlyLines.length > 1) {
+    throw new Error("Memory file has duplicate read_only fields.");
+  }
+
+  let previous: boolean | null = null;
+  if (readOnlyLines.length === 1) {
+    const value = readOnlyLines[0]?.[1]?.trim();
+    if (value !== "true" && value !== "false") {
+      throw new Error("Memory file read_only field must be true or false.");
+    }
+    previous = value === "true";
+    if (previous === readOnly) {
+      return { content, changed: false, previous };
+    }
+  }
+
+  const updatedFrontmatter =
+    previous === null
+      ? `${frontmatter}${newline}read_only: ${readOnly}`
+      : frontmatter.replace(
+          /^read_only\s*:\s*(.*?)\s*$/m,
+          `read_only: ${readOnly}`,
+        );
+  const updated = `${match[1]}${updatedFrontmatter}${match[4]}---${content.slice(match[0].length)}`;
+  return { content: updated, changed: true, previous };
+}
+
+function resolveMemoryFile(
+  memoryDir: string,
+  inputPath: string,
+): {
+  absolutePath: string;
+  relativePath: string;
+} {
+  if (!inputPath || isAbsolute(inputPath)) {
+    throw new Error(
+      "Memory file path must be relative to the memory directory.",
+    );
+  }
+
+  const absolutePath = resolve(memoryDir, inputPath);
+  const relativePath = relative(memoryDir, absolutePath).replace(/\\/g, "/");
+  if (
+    !relativePath ||
+    relativePath.startsWith("../") ||
+    /^(system|reference)\/.+\.md$/.exec(relativePath) === null
+  ) {
+    throw new Error(
+      "Memory file must be a .md file under system/ or reference/.",
+    );
+  }
+  if (!existsSync(absolutePath) || !lstatSync(absolutePath).isFile()) {
+    throw new Error(`Memory file not found: ${relativePath}`);
+  }
+
+  const realRoot = realpathSync(memoryDir);
+  const realFile = realpathSync(absolutePath);
+  const realRelative = relative(realRoot, realFile);
+  if (realRelative.startsWith("..") || isAbsolute(realRelative)) {
+    throw new Error("Memory file resolves outside the memory directory.");
+  }
+
+  return { absolutePath, relativePath };
+}
+
+async function commitReadOnlyToggle(args: {
+  memoryDir: string;
+  relativePath: string;
+  agentId: string;
+  reason: string;
+}): Promise<string> {
+  installPreCommitHook(args.memoryDir);
+  installPostCommitHook(args.memoryDir);
+  const runGit = (gitArgs: string[], env = process.env) =>
+    execFileAsync("git", gitArgs, {
+      cwd: args.memoryDir,
+      env: buildNonInteractiveGitEnv(env),
+      maxBuffer: 10 * 1024 * 1024,
+    });
+
+  await runGit(["add", "--", args.relativePath]);
+  try {
+    await runGit(
+      [
+        "-c",
+        "commit.gpgsign=false",
+        "-c",
+        `user.name=${args.agentId}`,
+        "-c",
+        `user.email=${args.agentId}@letta.com`,
+        "commit",
+        "-m",
+        args.reason,
+      ],
+      { ...process.env, LETTA_APPROVED_READ_ONLY_CHANGE: "1" },
+    );
+  } catch (error) {
+    await runGit(["reset", "HEAD", "--", args.relativePath]).catch(() => {});
+    throw error;
+  }
+  const { stdout } = await runGit(["rev-parse", "HEAD"]);
+  return stdout.toString().trim();
+}
+
+export async function runMemoryReadOnlyAction(args: {
+  agentId: string;
+  memoryDir: string;
+  path?: string;
+  value?: string;
+  extraPositionals: string[];
+}): Promise<number> {
+  if (!args.path || !args.value || args.extraPositionals.length > 0) {
+    console.error(
+      "Usage: letta memory read-only <system/or/reference/file.md> <true|false> --agent <id>",
+    );
+    return 1;
+  }
+  if (args.value !== "true" && args.value !== "false") {
+    console.error("read-only value must be true or false.");
+    return 1;
+  }
+
+  await assertMemoryRepoCleanForWrite(args.memoryDir);
+  const { absolutePath, relativePath } = resolveMemoryFile(
+    args.memoryDir,
+    args.path,
+  );
+  const original = readFileSync(absolutePath, "utf8");
+  const desired = args.value === "true";
+  const update = updateReadOnlyFrontmatter(original, desired);
+  if (!update.changed) {
+    console.log(
+      JSON.stringify(
+        {
+          agentId: args.agentId,
+          path: relativePath,
+          readOnly: desired,
+          changed: false,
+        },
+        null,
+        2,
+      ),
+    );
+    return 0;
+  }
+
+  writeFileSync(absolutePath, update.content, "utf8");
+  try {
+    const sha = await commitReadOnlyToggle({
+      memoryDir: args.memoryDir,
+      relativePath,
+      agentId: args.agentId,
+      reason: `${desired ? "Mark" : "Unmark"} ${relativePath} as read-only`,
+    });
+    console.log(
+      JSON.stringify(
+        {
+          agentId: args.agentId,
+          path: relativePath,
+          readOnly: desired,
+          changed: true,
+          commit: sha,
+        },
+        null,
+        2,
+      ),
+    );
+    return 0;
+  } catch (error) {
+    writeFileSync(absolutePath, original, "utf8");
+    throw error;
+  }
+}

--- a/src/cli/subcommands/memory-read-only.ts
+++ b/src/cli/subcommands/memory-read-only.ts
@@ -1,151 +1,54 @@
-import { execFile } from "node:child_process";
-import {
-  existsSync,
-  lstatSync,
-  readFileSync,
-  realpathSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { isAbsolute, relative, resolve } from "node:path";
-import { promisify } from "node:util";
 import {
   assertMemoryRepoCleanForWrite,
-  buildNonInteractiveGitEnv,
+  commitMemoryWrite,
 } from "@/agent/memory-git";
-import {
-  installPostCommitHook,
-  installPreCommitHook,
-} from "@/agent/memory-git-hooks";
+import { isLocalBackendEnvEnabled } from "@/backend/local/paths";
 
-const execFileAsync = promisify(execFile);
-
-export interface ReadOnlyFrontmatterUpdate {
-  content: string;
-  changed: boolean;
-  previous: boolean | null;
-}
-
-/** Update only the protected read_only key while preserving the rest verbatim. */
 export function updateReadOnlyFrontmatter(
   content: string,
-  readOnly: boolean,
-): ReadOnlyFrontmatterUpdate {
-  const match = content.match(/^(---(\r?\n))([\s\S]*?)(\r?\n)---(?=\r?\n|$)/);
-  if (!match) {
-    throw new Error("Memory file is missing required frontmatter.");
+  value: boolean,
+): string | null {
+  const frontmatter = /^---\r?\n[\s\S]*?\r?\n---/.exec(content);
+  if (!frontmatter) throw new Error("Memory file is missing frontmatter.");
+
+  const field = /^read_only\s*:\s*(.*?)\s*$/m.exec(frontmatter[0]);
+  if (field && field[1] !== "true" && field[1] !== "false") {
+    throw new Error("Memory file read_only must be true or false.");
+  }
+  if (field?.[1] === String(value)) return null;
+  if (field) {
+    return content.replace(
+      /^read_only\s*:\s*(?:true|false)\s*$/m,
+      `read_only: ${value}`,
+    );
   }
 
-  const newline = match[2] ?? "\n";
-  const frontmatter = match[3] ?? "";
-  if (/^description\s*:/m.exec(frontmatter) === null) {
-    throw new Error("Memory file frontmatter is missing 'description'.");
-  }
-
-  const readOnlyLines = [
-    ...frontmatter.matchAll(/^read_only\s*:\s*(.*?)\s*$/gm),
-  ];
-  if (readOnlyLines.length > 1) {
-    throw new Error("Memory file has duplicate read_only fields.");
-  }
-
-  let previous: boolean | null = null;
-  if (readOnlyLines.length === 1) {
-    const value = readOnlyLines[0]?.[1]?.trim();
-    if (value !== "true" && value !== "false") {
-      throw new Error("Memory file read_only field must be true or false.");
-    }
-    previous = value === "true";
-    if (previous === readOnly) {
-      return { content, changed: false, previous };
-    }
-  }
-
-  const updatedFrontmatter =
-    previous === null
-      ? `${frontmatter}${newline}read_only: ${readOnly}`
-      : frontmatter.replace(
-          /^read_only\s*:\s*(.*?)\s*$/m,
-          `read_only: ${readOnly}`,
-        );
-  const updated = `${match[1]}${updatedFrontmatter}${match[4]}---${content.slice(match[0].length)}`;
-  return { content: updated, changed: true, previous };
+  const newline = frontmatter[0].includes("\r\n") ? "\r\n" : "\n";
+  const closing = frontmatter.index + frontmatter[0].length - 3;
+  return `${content.slice(0, closing)}read_only: ${value}${newline}${content.slice(closing)}`;
 }
 
-function resolveMemoryFile(
-  memoryDir: string,
-  inputPath: string,
-): {
-  absolutePath: string;
-  relativePath: string;
-} {
-  if (!inputPath || isAbsolute(inputPath)) {
-    throw new Error(
-      "Memory file path must be relative to the memory directory.",
-    );
-  }
-
-  const absolutePath = resolve(memoryDir, inputPath);
+function resolveMemoryFile(memoryDir: string, input: string) {
+  if (isAbsolute(input)) throw new Error("Memory path must be relative.");
+  const absolutePath = resolve(memoryDir, input);
   const relativePath = relative(memoryDir, absolutePath).replace(/\\/g, "/");
-  if (
-    !relativePath ||
-    relativePath.startsWith("../") ||
-    /^(system|reference)\/.+\.md$/.exec(relativePath) === null
-  ) {
+  if (!/^(system|reference)\/.+\.md$/.test(relativePath)) {
     throw new Error(
-      "Memory file must be a .md file under system/ or reference/.",
+      "Memory path must be a .md file under system/ or reference/.",
     );
   }
-  if (!existsSync(absolutePath) || !lstatSync(absolutePath).isFile()) {
-    throw new Error(`Memory file not found: ${relativePath}`);
-  }
-
-  const realRoot = realpathSync(memoryDir);
-  const realFile = realpathSync(absolutePath);
-  const realRelative = relative(realRoot, realFile);
-  if (realRelative.startsWith("..") || isAbsolute(realRelative)) {
+  if (!existsSync(absolutePath))
+    throw new Error(`Memory file not found: ${input}`);
+  if (
+    relative(realpathSync(memoryDir), realpathSync(absolutePath)).startsWith(
+      "..",
+    )
+  ) {
     throw new Error("Memory file resolves outside the memory directory.");
   }
-
   return { absolutePath, relativePath };
-}
-
-async function commitReadOnlyToggle(args: {
-  memoryDir: string;
-  relativePath: string;
-  agentId: string;
-  reason: string;
-}): Promise<string> {
-  installPreCommitHook(args.memoryDir);
-  installPostCommitHook(args.memoryDir);
-  const runGit = (gitArgs: string[], env = process.env) =>
-    execFileAsync("git", gitArgs, {
-      cwd: args.memoryDir,
-      env: buildNonInteractiveGitEnv(env),
-      maxBuffer: 10 * 1024 * 1024,
-    });
-
-  await runGit(["add", "--", args.relativePath]);
-  try {
-    await runGit(
-      [
-        "-c",
-        "commit.gpgsign=false",
-        "-c",
-        `user.name=${args.agentId}`,
-        "-c",
-        `user.email=${args.agentId}@letta.com`,
-        "commit",
-        "-m",
-        args.reason,
-      ],
-      { ...process.env, LETTA_APPROVED_READ_ONLY_CHANGE: "1" },
-    );
-  } catch (error) {
-    await runGit(["reset", "HEAD", "--", args.relativePath]).catch(() => {});
-    throw error;
-  }
-  const { stdout } = await runGit(["rev-parse", "HEAD"]);
-  return stdout.toString().trim();
 }
 
 export async function runMemoryReadOnlyAction(args: {
@@ -155,10 +58,8 @@ export async function runMemoryReadOnlyAction(args: {
   value?: string;
   extraPositionals: string[];
 }): Promise<number> {
-  if (!args.path || !args.value || args.extraPositionals.length > 0) {
-    console.error(
-      "Usage: letta memory read-only <system/or/reference/file.md> <true|false> --agent <id>",
-    );
+  if (!args.path || !args.value || args.extraPositionals.length) {
+    console.error("Usage: letta memory read-only <path> <true|false>");
     return 1;
   }
   if (args.value !== "true" && args.value !== "false") {
@@ -167,53 +68,41 @@ export async function runMemoryReadOnlyAction(args: {
   }
 
   await assertMemoryRepoCleanForWrite(args.memoryDir);
-  const { absolutePath, relativePath } = resolveMemoryFile(
-    args.memoryDir,
-    args.path,
-  );
-  const original = readFileSync(absolutePath, "utf8");
+  const file = resolveMemoryFile(args.memoryDir, args.path);
+  const original = readFileSync(file.absolutePath, "utf8");
   const desired = args.value === "true";
-  const update = updateReadOnlyFrontmatter(original, desired);
-  if (!update.changed) {
-    console.log(
-      JSON.stringify(
-        {
-          agentId: args.agentId,
-          path: relativePath,
-          readOnly: desired,
-          changed: false,
-        },
-        null,
-        2,
-      ),
-    );
-    return 0;
-  }
+  const updated = updateReadOnlyFrontmatter(original, desired);
+  if (updated === null) return 0;
 
-  writeFileSync(absolutePath, update.content, "utf8");
+  writeFileSync(file.absolutePath, updated, "utf8");
+  const previousApproval = process.env.LETTA_APPROVED_READ_ONLY_CHANGE;
+  process.env.LETTA_APPROVED_READ_ONLY_CHANGE = "1";
   try {
-    const sha = await commitReadOnlyToggle({
+    const result = await commitMemoryWrite({
       memoryDir: args.memoryDir,
-      relativePath,
-      agentId: args.agentId,
-      reason: `${desired ? "Mark" : "Unmark"} ${relativePath} as read-only`,
+      pathspecs: [file.relativePath],
+      reason: `${desired ? "Mark" : "Unmark"} ${file.relativePath} as read-only`,
+      author: {
+        agentId: args.agentId,
+        authorName: args.agentId,
+        authorEmail: `${args.agentId}@letta.com`,
+      },
+      syncMode: isLocalBackendEnvEnabled() ? "local" : "remote",
     });
+    if (!result.committed) {
+      writeFileSync(file.absolutePath, original, "utf8");
+      return 1;
+    }
     console.log(
-      JSON.stringify(
-        {
-          agentId: args.agentId,
-          path: relativePath,
-          readOnly: desired,
-          changed: true,
-          commit: sha,
-        },
-        null,
-        2,
-      ),
+      JSON.stringify({ ...result, path: file.relativePath, readOnly: desired }),
     );
     return 0;
   } catch (error) {
-    writeFileSync(absolutePath, original, "utf8");
+    writeFileSync(file.absolutePath, original, "utf8");
     throw error;
+  } finally {
+    if (previousApproval === undefined)
+      delete process.env.LETTA_APPROVED_READ_ONLY_CHANGE;
+    else process.env.LETTA_APPROVED_READ_ONLY_CHANGE = previousApproval;
   }
 }

--- a/src/cli/subcommands/memory.ts
+++ b/src/cli/subcommands/memory.ts
@@ -5,6 +5,7 @@ import { parseArgs } from "node:util";
 import { getScopedMemoryFilesystemRoot } from "@/agent/memory-filesystem";
 import { getMemoryGitStatus, isGitRepo, pullMemory } from "@/agent/memory-git";
 import { isLocalBackendEnvEnabled } from "@/backend/local/paths";
+import { runMemoryReadOnlyAction } from "./memory-read-only";
 import { runMemoryTokensAction } from "./memory-tokens";
 
 function printUsage(): void {
@@ -18,6 +19,7 @@ Usage:
   letta memory restore --from <backup> --force [--agent <id>]
   letta memory export --agent <id> --out <dir>
   letta memory pull [--agent <id>]
+  letta memory read-only <system/or/reference/file.md> <true|false> [--agent <id>]
   letta memory tokens [--memory-dir <path>] [--agent <id>] [--top <N>]
                      [--format text|json] [--quiet]
 
@@ -34,6 +36,7 @@ Examples:
   letta memory backup --agent agent-123
   letta memory export --agent agent-123 --out /tmp/letta-memory-agent-123
   letta memory tokens
+  letta memory read-only system/persona.md true --agent agent-123
   letta memory tokens --memory-dir ~/.letta/agents/agent-123/memory --format json
 `.trim(),
   );
@@ -132,7 +135,8 @@ export async function runMemorySubcommand(argv: string[]): Promise<number> {
     return 1;
   }
 
-  const [action] = parsed.positionals;
+  const [action, firstPositional, secondPositional, ...extraPositionals] =
+    parsed.positionals;
 
   if (parsed.values.help || !action || action === "help") {
     printUsage();
@@ -161,6 +165,16 @@ export async function runMemorySubcommand(argv: string[]): Promise<number> {
   }
 
   try {
+    if (action === "read-only") {
+      return runMemoryReadOnlyAction({
+        agentId,
+        memoryDir: getMemoryRoot(agentId),
+        path: firstPositional,
+        value: secondPositional,
+        extraPositionals,
+      });
+    }
+
     if (action === "status") {
       if (!isGitRepo(agentId)) {
         console.log(

--- a/src/permissions/checker.ts
+++ b/src/permissions/checker.ts
@@ -19,6 +19,7 @@ import type { PermissionModeState } from "@/tools/permission-mode-state";
 import { canonicalToolName, isShellToolName } from "./canonical";
 import { cliPermissions } from "./cli-permissions-instance";
 import { evaluateCrossAgentGuard, extractFilePath } from "./cross-agent-guard";
+import { envFlagEnabled, getMandatoryApproval } from "./mandatory-approval";
 import {
   type MatcherOptions,
   matchesBashPattern,
@@ -107,12 +108,6 @@ interface ModPermissionCheckOptions {
   modContext?: ModContext | null;
   phase?: "approval" | "execution";
   toolCallId?: string | null;
-}
-
-function envFlagEnabled(name: string): boolean {
-  const value = process.env[name];
-  if (!value) return false;
-  return value === "1" || value.toLowerCase() === "true";
 }
 
 function isPermissionsV2Enabled(): boolean {
@@ -361,6 +356,9 @@ function checkPermissionForEngine(
       };
     }
   }
+
+  const mandatoryApproval = getMandatoryApproval(canonicalTool, toolArgs);
+  if (mandatoryApproval) return { result: mandatoryApproval, trace };
 
   if (sessionRules.alwaysAsk) {
     for (const pattern of sessionRules.alwaysAsk) {

--- a/src/permissions/mandatory-approval.ts
+++ b/src/permissions/mandatory-approval.ts
@@ -1,0 +1,37 @@
+import type { PermissionCheckResult } from "./types";
+
+type ToolArgs = Record<string, unknown>;
+
+export function envFlagEnabled(name: string): boolean {
+  const value = process.env[name];
+  if (!value) return false;
+  return value === "1" || value.toLowerCase() === "true";
+}
+
+function extractShellCommand(toolArgs: ToolArgs): string | null {
+  const command =
+    typeof toolArgs.cmd === "string" ? toolArgs.cmd : toolArgs.command;
+  if (typeof command === "string") return command;
+  return Array.isArray(command) ? command.join(" ") : null;
+}
+
+export function getMandatoryApproval(
+  canonicalTool: string,
+  toolArgs: ToolArgs,
+): PermissionCheckResult | null {
+  if (canonicalTool !== "Bash") return null;
+  const command = extractShellCommand(toolArgs);
+  if (
+    !command ||
+    /(?:^|[\s;&|'"])(?:[^\s;&|]*\/)?letta(?:\.js)?['"]?\s+(?:memory|memfs)\s+read-only(?:\s|$)/.exec(
+      command,
+    ) === null
+  ) {
+    return null;
+  }
+  return {
+    decision: "alwaysAsk",
+    matchedRule: "Bash(letta memory read-only:*)",
+    reason: "Changing memory read-only status requires explicit user approval",
+  };
+}


### PR DESCRIPTION
## Summary

- restore pre-commit protection for memory files marked `read_only: true`, including edits, deletion, and renames
- add `letta memory read-only <path> <true|false>` as the narrow authorized path for toggling the protected field
- force every agent invocation of that command through an unpersistable `alwaysAsk` permission decision
- preserve existing frontmatter/body formatting and reject unsafe or out-of-scope paths

## Validation

- `bun test src/cli/subcommands/memory-read-only.spec.ts src/agent/memory-git.precommit.*.ts src/permissions/permissions-checker.*.ts src/permissions/permissions-mode.*.ts`
- `bun test src/tools/memory-tool.*.ts src/tools/memory-apply-patch.*.ts`
- `bun run check`

Generated with [Letta Code](https://letta.com)