### PR TITLE
ci: enforce AI contribution disclosure

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,106 @@
+name: Bug report
+description: Report a reproducible problem with Letta Code
+title: ""
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing, search existing issues and confirm the problem is reproducible on a current Letta Code release.
+
+  - type: checkboxes
+    id: ai-disclosure
+    attributes:
+      label: AI Disclosure
+      description: |
+        All issue authors must comply with our [AI Usage Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md).
+        Select **exactly one** authorship option, identify every AI tool used below, and acknowledge the policy.
+      options:
+        - label: This issue was written entirely by a human
+        - label: This issue was written with AI assistance and **reviewed and edited by a human**
+        - label: I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms
+          required: true
+    validations:
+      required: true
+
+  - type: input
+    id: ai-tools
+    attributes:
+      label: AI Tool(s) Used
+      description: List every AI tool used to research or write this issue. If no AI tool was used, enter `None`.
+      placeholder: "e.g. Letta Code and ChatGPT, or None"
+    validations:
+      required: true
+
+  - type: textarea
+    id: human-verification
+    attributes:
+      label: Human Verification
+      description: |
+        Copy and paste the following phrase **exactly**:
+        `I have personally reproduced or verified this issue, reviewed its contents, and take responsibility for its accuracy.`
+      placeholder: "I have personally reproduced or verified this issue, reviewed its contents, and take responsibility for its accuracy."
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: Explain what happened and what you expected to happen.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Letta Code version
+      description: Run `letta --version`.
+      placeholder: "e.g. 0.29.12"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where did this happen?
+      options:
+        - CLI
+        - Letta Code Desktop
+        - App Server / SDK
+        - Channel integration
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "e.g. macOS 15.6, Ubuntu 24.04, Windows 11"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest deterministic reproduction you can.
+      placeholder: |
+        1. Run ...
+        2. Configure ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs, screenshots, or recordings
+      description: Remove secrets and other sensitive data before posting.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Include any other information needed to understand or reproduce the problem.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Letta documentation
+    url: https://docs.letta.com
+    about: Check the documentation before filing an issue.
+  - name: Letta Discord
+    url: https://discord.gg/letta
+    about: Ask usage and support questions in the community.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,72 @@
+name: Feature request
+description: Propose a focused improvement to Letta Code
+title: ""
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing, search existing issues and explain the concrete user problem rather than submitting a generated feature list.
+
+  - type: checkboxes
+    id: ai-disclosure
+    attributes:
+      label: AI Disclosure
+      description: |
+        All issue authors must comply with our [AI Usage Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md).
+        Select **exactly one** authorship option, identify every AI tool used below, and acknowledge the policy.
+      options:
+        - label: This issue was written entirely by a human
+        - label: This issue was written with AI assistance and **reviewed and edited by a human**
+        - label: I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms
+          required: true
+    validations:
+      required: true
+
+  - type: input
+    id: ai-tools
+    attributes:
+      label: AI Tool(s) Used
+      description: List every AI tool used to research or write this issue. If no AI tool was used, enter `None`.
+      placeholder: "e.g. Letta Code and ChatGPT, or None"
+    validations:
+      required: true
+
+  - type: textarea
+    id: human-verification
+    attributes:
+      label: Human Verification
+      description: |
+        Copy and paste the following phrase **exactly**:
+        `I have personally reviewed this request, verified that it addresses a real use case, and take responsibility for its contents.`
+      placeholder: "I have personally reviewed this request, verified that it addresses a real use case, and take responsibility for its contents."
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: Describe the concrete workflow or limitation this request addresses.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Explain the behavior you want and why it solves the problem.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe workarounds or alternative designs you evaluated.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add examples, screenshots, or related issues that help explain the request.

--- a/.github/TRUSTED_CONTRIBUTORS
+++ b/.github/TRUSTED_CONTRIBUTORS
@@ -1,0 +1,5 @@
+# GitHub usernames listed here bypass automated contribution-policy checks.
+# Members of the letta-ai organization and contributors with write access are
+# already exempt and do not need to be listed.
+#
+# One GitHub username per line.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Summary
+
+<!-- Explain what changed, why it is needed, and any important failure modes or tradeoffs. -->
+
+## Verification
+
+<!-- List the exact checks you ran and their results. -->
+
+## AI Disclosure
+
+<!-- Select exactly one authorship option, then acknowledge the policy. -->
+
+- [ ] This pull request was written entirely by a human
+- [ ] This pull request was written with AI assistance and reviewed and edited by a human
+- [ ] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms
+
+## AI Tool(s) Used
+
+<!-- List every AI tool used to research, write, or modify this pull request. If none were used, enter: None -->
+
+## Human Verification
+
+<!-- Copy the following phrase exactly, without the surrounding comment:
+I have reviewed and understand every change in this pull request and take responsibility for its correctness.
+-->

--- a/.github/scripts/contribution-guard.cjs
+++ b/.github/scripts/contribution-guard.cjs
@@ -1,6 +1,6 @@
 const fs = require("node:fs");
 
-const TRUSTED_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+const TRUSTED_ASSOCIATIONS = new Set(["OWNER", "MEMBER"]);
 const NO_AI_TOOLS = /^(none|n\/a|no ai(?: tools?)?)\.?$/i;
 
 const VERIFICATION_PHRASES = {

--- a/.github/scripts/contribution-guard.cjs
+++ b/.github/scripts/contribution-guard.cjs
@@ -1,0 +1,262 @@
+const fs = require("node:fs");
+
+const TRUSTED_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+const NO_AI_TOOLS = /^(none|n\/a|no ai(?: tools?)?)\.?$/i;
+
+const VERIFICATION_PHRASES = {
+  issue: [
+    "I have personally reproduced or verified this issue, reviewed its contents, and take responsibility for its accuracy.",
+    "I have personally reviewed this request, verified that it addresses a real use case, and take responsibility for its contents.",
+  ],
+  pull_request: [
+    "I have reviewed and understand every change in this pull request and take responsibility for its correctness.",
+  ],
+};
+
+function stripHtmlComments(body) {
+  return body.replace(/<!--[\s\S]*?-->/g, "");
+}
+
+function extractSection(body, heading) {
+  const escapedHeading = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = body.match(
+    new RegExp(
+      `(?:^|\\n)#{2,3}\\s+${escapedHeading}[^\\S\\r\\n]*\\r?\\n([\\s\\S]*?)(?=\\r?\\n#{2,3}\\s+|$)`,
+      "i",
+    ),
+  );
+  return (match?.[1] || "").trim();
+}
+
+function validateDisclosure(rawBody, kind) {
+  const body = stripHtmlComments(rawBody || "");
+  const failures = [];
+  const subject = kind === "pull_request" ? "pull request" : "issue";
+
+  const humanWritten = new RegExp(
+    `- \\[x\\] This ${subject} was written entirely by a human`,
+    "i",
+  ).test(body);
+  const aiAssisted = new RegExp(
+    `- \\[x\\] This ${subject} was written with AI assistance`,
+    "i",
+  ).test(body);
+
+  if (humanWritten === aiAssisted) {
+    failures.push(
+      "Select exactly one authorship option (human-written or AI-assisted)",
+    );
+  }
+
+  if (!/- \[x\] I have read the \[AI Policy\]/i.test(body)) {
+    failures.push("AI Policy acknowledgment checkbox not checked");
+  }
+
+  const aiTools = extractSection(body, "AI Tool(s) Used");
+  const noTools = NO_AI_TOOLS.test(aiTools);
+  if (!aiTools || /^_?no response_?$/i.test(aiTools)) {
+    failures.push("AI Tool(s) Used must list every tool used, or state None");
+  } else if (aiAssisted && noTools) {
+    failures.push("AI-assisted submissions must name the AI tool(s) used");
+  } else if (humanWritten && !noTools) {
+    failures.push(
+      "Human-written submissions must state None under AI Tool(s) Used",
+    );
+  }
+
+  const verificationPhrases = VERIFICATION_PHRASES[kind] || [];
+  if (!verificationPhrases.some((phrase) => body.includes(phrase))) {
+    failures.push("Missing exact Human Verification phrase");
+  }
+
+  return failures;
+}
+
+function trustedContributors() {
+  try {
+    return new Set(
+      fs
+        .readFileSync(".github/TRUSTED_CONTRIBUTORS", "utf8")
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line && !line.startsWith("#")),
+    );
+  } catch (error) {
+    console.log(`Unable to read TRUSTED_CONTRIBUTORS: ${error.message}`);
+    return new Set();
+  }
+}
+
+async function isExempt({
+  github,
+  context,
+  author,
+  userType,
+  authorAssociation,
+}) {
+  if (userType === "Bot") {
+    console.log(`Skipping ${author}: bot account`);
+    return true;
+  }
+
+  if (TRUSTED_ASSOCIATIONS.has(authorAssociation)) {
+    console.log(
+      `Skipping ${author}: author association is ${authorAssociation}`,
+    );
+    return true;
+  }
+
+  try {
+    const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      username: author,
+    });
+    if (["admin", "write", "maintain"].includes(data.permission)) {
+      console.log(
+        `Skipping ${author}: repository permission is ${data.permission}`,
+      );
+      return true;
+    }
+  } catch (error) {
+    console.log(
+      `Collaborator check failed (${error.status || error.message}); continuing`,
+    );
+  }
+
+  try {
+    await github.rest.orgs.checkPublicMembershipForUser({
+      org: "letta-ai",
+      username: author,
+    });
+    console.log(`Skipping ${author}: public letta-ai organization member`);
+    return true;
+  } catch (error) {
+    if (error.status !== 404) {
+      console.log(
+        `Organization membership check failed (${error.status || error.message}); continuing`,
+      );
+    }
+  }
+
+  if (trustedContributors().has(author)) {
+    console.log(`Skipping ${author}: listed in TRUSTED_CONTRIBUTORS`);
+    return true;
+  }
+
+  return false;
+}
+
+async function applyInvalidLabel({ github, context, number }) {
+  for (const label of ["invalid", "auto-closed", "spam"]) {
+    try {
+      await github.rest.issues.addLabels({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: number,
+        labels: [label],
+      });
+      return;
+    } catch {
+      console.log(`Unable to apply '${label}' label; trying next`);
+    }
+  }
+}
+
+async function closeSubmission({ github, context, kind, number, failures }) {
+  const label = kind === "pull_request" ? "pull request" : "issue";
+  const templateUrl =
+    kind === "pull_request"
+      ? `https://github.com/${context.repo.owner}/${context.repo.repo}/compare`
+      : `https://github.com/${context.repo.owner}/${context.repo.repo}/issues/new/choose`;
+
+  const comment = [
+    `**This ${label} was automatically closed** because it does not meet our submission requirements.`,
+    "",
+    "**What failed:**",
+    ...failures.map((failure) => `- ${failure}`),
+    "",
+    "Please use the repository template and provide the required AI disclosure, AI tool list, policy acknowledgment, and exact Human Verification phrase.",
+    "",
+    `- [Submission template](${templateUrl})`,
+    `- [AI Usage Policy](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/AI_POLICY.md)`,
+  ].join("\n");
+
+  await github.rest.issues.createComment({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: number,
+    body: comment,
+  });
+  await applyInvalidLabel({ github, context, number });
+
+  if (kind === "pull_request") {
+    await github.rest.pulls.update({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: number,
+      state: "closed",
+    });
+    return;
+  }
+
+  await github.rest.issues.update({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: number,
+    state: "closed",
+  });
+  await github.rest.issues.lock({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: number,
+    lock_reason: "spam",
+  });
+}
+
+async function runContributionGuard({ github, context }) {
+  const isPullRequest = context.eventName === "pull_request_target";
+  const submission = isPullRequest
+    ? context.payload.pull_request
+    : context.payload.issue;
+  const kind = isPullRequest ? "pull_request" : "issue";
+
+  if (!submission) {
+    throw new Error(`Unsupported event: ${context.eventName}`);
+  }
+
+  const author = submission.user.login;
+  if (
+    await isExempt({
+      github,
+      context,
+      author,
+      userType: submission.user.type,
+      authorAssociation: submission.author_association,
+    })
+  ) {
+    return;
+  }
+
+  const failures = validateDisclosure(submission.body || "", kind);
+  if (failures.length === 0) {
+    console.log(
+      `${kind} #${submission.number} passed contribution policy checks`,
+    );
+    return;
+  }
+
+  console.log(`${kind} #${submission.number} failed: ${failures.join(", ")}`);
+  await closeSubmission({
+    github,
+    context,
+    kind,
+    number: submission.number,
+    failures,
+  });
+}
+
+module.exports = runContributionGuard;
+module.exports.extractSection = extractSection;
+module.exports.stripHtmlComments = stripHtmlComments;
+module.exports.validateDisclosure = validateDisclosure;

--- a/.github/scripts/contribution-guard.test.cjs
+++ b/.github/scripts/contribution-guard.test.cjs
@@ -1,0 +1,156 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  extractSection,
+  stripHtmlComments,
+  validateDisclosure,
+} = require("./contribution-guard.cjs");
+
+const policyAcknowledgment =
+  "- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms";
+const bugVerification =
+  "I have personally reproduced or verified this issue, reviewed its contents, and take responsibility for its accuracy.";
+const featureVerification =
+  "I have personally reviewed this request, verified that it addresses a real use case, and take responsibility for its contents.";
+const pullRequestVerification =
+  "I have reviewed and understand every change in this pull request and take responsibility for its correctness.";
+
+function issueBody({ authorship, tools, verification = bugVerification }) {
+  return [
+    "## AI Disclosure",
+    authorship,
+    policyAcknowledgment,
+    "",
+    "### AI Tool(s) Used",
+    tools,
+    "",
+    "### Human Verification",
+    verification,
+    "",
+    "### Description",
+    "A verified report.",
+  ].join("\n");
+}
+
+function pullRequestBody({
+  authorship,
+  tools,
+  verification = pullRequestVerification,
+}) {
+  return [
+    "## AI Disclosure",
+    authorship,
+    policyAcknowledgment,
+    "",
+    "## AI Tool(s) Used",
+    tools,
+    "",
+    "## Human Verification",
+    verification,
+  ].join("\n");
+}
+
+test("accepts a human-written issue that explicitly states no AI tools", () => {
+  const failures = validateDisclosure(
+    issueBody({
+      authorship: "- [x] This issue was written entirely by a human",
+      tools: "None",
+    }),
+    "issue",
+  );
+  assert.deepEqual(failures, []);
+});
+
+test("accepts an AI-assisted feature request that names its tools", () => {
+  const failures = validateDisclosure(
+    issueBody({
+      authorship:
+        "- [x] This issue was written with AI assistance and reviewed and edited by a human",
+      tools: "Letta Code and ChatGPT",
+      verification: featureVerification,
+    }),
+    "issue",
+  );
+  assert.deepEqual(failures, []);
+});
+
+test("rejects contradictory authorship options", () => {
+  const body = issueBody({
+    authorship: [
+      "- [x] This issue was written entirely by a human",
+      "- [x] This issue was written with AI assistance and reviewed and edited by a human",
+    ].join("\n"),
+    tools: "ChatGPT",
+  });
+  assert.match(
+    validateDisclosure(body, "issue").join("\n"),
+    /exactly one authorship option/,
+  );
+});
+
+test("rejects AI-assisted submissions that do not name a tool", () => {
+  const failures = validateDisclosure(
+    issueBody({
+      authorship:
+        "- [x] This issue was written with AI assistance and reviewed and edited by a human",
+      tools: "None",
+    }),
+    "issue",
+  );
+  assert.match(failures.join("\n"), /must name the AI tool/);
+});
+
+test("rejects human-written submissions that list AI tools", () => {
+  const failures = validateDisclosure(
+    issueBody({
+      authorship: "- [x] This issue was written entirely by a human",
+      tools: "Copilot",
+    }),
+    "issue",
+  );
+  assert.match(failures.join("\n"), /must state None/);
+});
+
+test("accepts a compliant AI-assisted pull request", () => {
+  const failures = validateDisclosure(
+    pullRequestBody({
+      authorship:
+        "- [x] This pull request was written with AI assistance and reviewed and edited by a human",
+      tools: "Letta Code",
+    }),
+    "pull_request",
+  );
+  assert.deepEqual(failures, []);
+});
+
+test("template comments do not satisfy pull request requirements", () => {
+  const body = [
+    "## AI Disclosure",
+    "- [ ] This pull request was written entirely by a human",
+    "- [ ] This pull request was written with AI assistance and reviewed and edited by a human",
+    "- [ ] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md)",
+    "## AI Tool(s) Used",
+    "<!-- None -->",
+    "## Human Verification",
+    `<!-- ${pullRequestVerification} -->`,
+  ].join("\n");
+  const failures = validateDisclosure(body, "pull_request");
+  assert.equal(failures.length, 4);
+});
+
+test("extractSection preserves multiline tool disclosures", () => {
+  const body =
+    "## AI Tool(s) Used\nLetta Code\nChatGPT for research\n\n## Human Verification\nDone";
+  assert.equal(
+    extractSection(body, "AI Tool(s) Used"),
+    "Letta Code\nChatGPT for research",
+  );
+});
+
+test("stripHtmlComments removes multiline template instructions", () => {
+  assert.equal(
+    stripHtmlComments("before<!-- hidden\ntext -->after"),
+    "beforeafter",
+  );
+});

--- a/.github/workflows/contribution-guard.yml
+++ b/.github/workflows/contribution-guard.yml
@@ -1,0 +1,34 @@
+name: Contribution policy guard
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request_target:
+    branches: [main]
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  validate:
+    if: github.event_name == 'issues' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      # pull_request_target deliberately checks out the trusted base branch, not
+      # the contributor's branch. No pull request code is executed.
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/scripts/contribution-guard.cjs
+            .github/TRUSTED_CONTRIBUTORS
+          sparse-checkout-cone-mode: false
+
+      - name: Validate contribution policy
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runContributionGuard = require('./.github/scripts/contribution-guard.cjs');
+            await runContributionGuard({ github, context });

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,32 @@
+# AI Usage Policy
+
+> This policy is adapted from [Ghostty's AI Policy](https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md) for the Letta Code project.
+
+AI tools are welcome in Letta Code contributions, but the human submitting the work remains responsible for its accuracy, relevance, and quality.
+
+## Rules
+
+- **Disclose all AI usage.** State every AI tool used to research, write, or modify an issue or pull request (for example, Letta Code, Claude Code, Cursor, Copilot, or ChatGPT) and describe the extent of its involvement. If no AI tool was used, explicitly state `None`.
+- **A human must fully understand the submission.** Do not submit code, claims, reproduction steps, or analysis that you cannot independently explain and defend.
+- **Review and edit AI-assisted content before submitting it.** Remove speculation, unsupported claims, irrelevant detail, and generated filler. Reproduce bugs yourself and verify proposed changes.
+- **Do not make maintainers validate raw model output.** The submitter is responsible for checking the relevant code, documentation, tests, and existing issues before opening a contribution.
+- **AI-generated media is not accepted.** Text and code are the only acceptable AI-generated contribution content under this policy.
+
+## Required Disclosure
+
+Issues and pull requests must:
+
+1. Select exactly one authorship option indicating whether the submission was human-written or AI-assisted.
+2. Name every AI tool used, or explicitly state `None`.
+3. Acknowledge this policy.
+4. Include the exact human-verification phrase shown in the issue or pull request template.
+
+Noncompliant issues are automatically closed and locked. Noncompliant pull requests are automatically closed. Draft pull requests are checked when marked ready for review.
+
+Members of the [letta-ai](https://github.com/letta-ai) GitHub organization and [trusted contributors](.github/TRUSTED_CONTRIBUTORS) are exempt from automated checks, but are still expected to follow the spirit of this policy.
+
+## There Are Humans Here
+
+Every issue and pull request consumes maintainer attention. Low-effort, unverified output transfers the cost of understanding and validating generated work to someone else. That is not an acceptable contribution workflow.
+
+The strictness of this policy is not anti-AI. Letta builds and uses AI tools extensively. The goal is to preserve a high-signal project where AI helps people do better work instead of generating review burden.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,9 @@
 # Contributing to Letta Code
 
+## AI Usage Policy
+
+All issues and pull requests must comply with the [AI Usage Policy](AI_POLICY.md). Disclose every AI tool used and ensure a human has reviewed, verified, and understands the complete submission. Noncompliant contributions are automatically closed unless the author is a trusted contributor or Letta maintainer.
+
 ## Fork the repo
 
 Fork the repository on GitHub by [clicking this link](https://github.com/letta-ai/letta-code/fork), then clone your fork:


### PR DESCRIPTION
## Summary
- add an AI usage policy plus structured issue and pull request templates requiring authorship, tool, and human-verification disclosures
- automatically close noncompliant issues and non-draft pull requests while exempting bots, Letta organization members, maintainers with write access, and explicitly trusted contributors
- validate the guard against compliant, contradictory, incomplete, and untouched-template submissions with nine passing unit tests

👾 Generated with [Letta Code](https://letta.com)