### PR TITLE
fix(models): preserve unloaded mod provider handles

### DIFF
--- a/src/backend/local/local-model-normalization.test.ts
+++ b/src/backend/local/local-model-normalization.test.ts
@@ -85,6 +85,29 @@ describe("local model normalization", () => {
     }
   });
 
+  test("preserves and repairs prefixed mod handles before the provider loads", () => {
+    const handle = "chatgpt-oss/gpt-5.6-sol";
+
+    expect(
+      normalizeLocalModelHandle(handle, {
+        provider_type: "chatgpt-oss",
+      }),
+    ).toBe(handle);
+    expect(
+      normalizeLocalModelHandle(`chatgpt-oss/${handle}`, {
+        provider_type: "chatgpt-oss",
+      }),
+    ).toBe(handle);
+  });
+
+  test("still canonicalizes prefixed built-in provider types", () => {
+    expect(
+      normalizeLocalModelHandle("chatgpt_oauth/gpt-5.5", {
+        provider_type: "chatgpt_oauth",
+      }),
+    ).toBe("chatgpt-plus-pro/gpt-5.5");
+  });
+
   test("preserves handles owned by registered provider mods", () => {
     registerPiProvider("custom-provider", {
       baseUrl: "http://localhost:8000/v1",

--- a/src/backend/local/local-model-normalization.ts
+++ b/src/backend/local/local-model-normalization.ts
@@ -3,7 +3,10 @@ import {
   resolveModelHandleFromLlmConfig,
 } from "@/agent/model-handles";
 import { resolveRegisteredPiProviderFromModelHandle } from "@/backend/dev/pi-provider-mod-registry";
-import { isResolvablePiModelHandle } from "@/backend/dev/pi-provider-registry";
+import {
+  isResolvablePiModelHandle,
+  resolveProviderFromProviderType,
+} from "@/backend/dev/pi-provider-registry";
 import { isRecord } from "@/utils/type-guards";
 
 export function supportedModelSettingsFromBody(
@@ -50,6 +53,14 @@ export function normalizeLocalModelHandle(
     return model;
   }
   const providerType = providerTypeFromModelSettings(modelSettings);
+  if (providerType && !resolveProviderFromProviderType(providerType)) {
+    const prefix = `${providerType}/`;
+    if (model.startsWith(`${prefix}${prefix}`)) {
+      return model.slice(prefix.length);
+    }
+    if (model.startsWith(prefix)) return model;
+  }
+
   const legacyEndpointType = legacyLlmConfig?.model_endpoint_type;
   return (
     resolveModelHandleFromLlmConfig({


### PR DESCRIPTION
Persisted mod model handles can be normalized before their provider is registered. Preserve an unknown provider prefix and collapse a duplicated prefix while retaining canonical built-in alias conversion.

👾 Generated with [Letta Code](https://letta.com)
