### PR TITLE
fix(models): repair persisted mod handles on startup

### DIFF
--- a/src/backend/local/local-model-normalization.test.ts
+++ b/src/backend/local/local-model-normalization.test.ts
@@ -85,6 +85,29 @@ describe("local model normalization", () => {
     }
   });
 
+  test("preserves and repairs prefixed mod handles before the provider loads", () => {
+    const handle = "chatgpt-oss/gpt-5.6-sol";
+
+    expect(
+      normalizeLocalModelHandle(handle, {
+        provider_type: "chatgpt-oss",
+      }),
+    ).toBe(handle);
+    expect(
+      normalizeLocalModelHandle(`chatgpt-oss/${handle}`, {
+        provider_type: "chatgpt-oss",
+      }),
+    ).toBe(handle);
+  });
+
+  test("still canonicalizes prefixed built-in provider types", () => {
+    expect(
+      normalizeLocalModelHandle("chatgpt_oauth/gpt-5.5", {
+        provider_type: "chatgpt_oauth",
+      }),
+    ).toBe("chatgpt-plus-pro/gpt-5.5");
+  });
+
   test("preserves handles owned by registered provider mods", () => {
     registerPiProvider("custom-provider", {
       baseUrl: "http://localhost:8000/v1",
@@ -107,6 +130,12 @@ describe("local model normalization", () => {
       normalizeLocalModelHandle("custom-provider/custom-model", {
         provider_type: "openai",
       }),
+    ).toBe("custom-provider/custom-model");
+    expect(
+      normalizeLocalModelHandle(
+        "custom-provider/custom-provider/custom-model",
+        { provider_type: "custom-provider" },
+      ),
     ).toBe("custom-provider/custom-model");
   });
 

--- a/src/backend/local/local-model-normalization.ts
+++ b/src/backend/local/local-model-normalization.ts
@@ -3,7 +3,10 @@ import {
   resolveModelHandleFromLlmConfig,
 } from "@/agent/model-handles";
 import { resolveRegisteredPiProviderFromModelHandle } from "@/backend/dev/pi-provider-mod-registry";
-import { isResolvablePiModelHandle } from "@/backend/dev/pi-provider-registry";
+import {
+  isResolvablePiModelHandle,
+  resolveProviderFromProviderType,
+} from "@/backend/dev/pi-provider-registry";
 import { isRecord } from "@/utils/type-guards";
 
 export function supportedModelSettingsFromBody(
@@ -43,13 +46,19 @@ export function normalizeLocalModelHandle(
   modelSettings?: Record<string, unknown>,
   legacyLlmConfig?: Record<string, unknown>,
 ): string {
-  if (
-    isResolvablePiModelHandle(model) ||
-    resolveRegisteredPiProviderFromModelHandle(model)
-  ) {
-    return model;
-  }
+  if (isResolvablePiModelHandle(model)) return model;
+
   const providerType = providerTypeFromModelSettings(modelSettings);
+  if (providerType && !resolveProviderFromProviderType(providerType)) {
+    const prefix = `${providerType}/`;
+    if (model.startsWith(`${prefix}${prefix}`)) {
+      return model.slice(prefix.length);
+    }
+    if (model.startsWith(prefix)) return model;
+  }
+
+  if (resolveRegisteredPiProviderFromModelHandle(model)) return model;
+
   const legacyEndpointType = legacyLlmConfig?.model_endpoint_type;
   return (
     resolveModelHandleFromLlmConfig({


### PR DESCRIPTION
Local agents can load persisted model handles before provider mods register. Older normalization can prepend the provider twice, causing cold-start model resolution to target a nonexistent provider/model until the user reselects the model.

Preserve valid mod handles and collapse one duplicated provider prefix both before and after mod registration. Keep built-in provider aliases on their existing canonicalization path.

👾 Generated with [Letta Code](https://letta.com)

## Summary

- Preserve persisted custom-provider model handles when local agents start before their provider mod is registered.
- Collapse duplicated provider prefixes both before and after provider registration.
- Keep built-in provider aliases on the existing canonicalization path.

Without this fix, a persisted handle such as `chatgpt-oss/chatgpt-oss/gpt-5.6-sol` targets a nonexistent model until the user reselects it through `/model`.

## Verification

- `bun test src/backend/local/local-model-normalization.test.ts`
  - 9 tests passed
  - 57 assertions passed
- `bun run check`
  - 12 checks passed

## AI Disclosure

- [x] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code and GPT Sol 5.6

## Human Verification

I have reviewed and understand every change in this pull request and take responsibility for its correctness.
