### PR TITLE
test(api): verify local chat-key conversation reuse

### DIFF
--- a/src/websocket/app-server-openai.test.ts
+++ b/src/websocket/app-server-openai.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Backend } from "@/backend";
 import { __testSetBackend } from "@/backend";
+import { LocalBackend } from "@/backend/local/local-backend";
 import { type AppServerHandle, startAppServer } from "@/websocket/app-server";
 import { parseAppServerWebsocketAuthSettings } from "@/websocket/app-server-auth";
 import {
@@ -419,6 +423,73 @@ describe("app-server OpenAI-compatible API", () => {
       "conv-test-1",
     ]);
     expect(created.length).toBe(2);
+  });
+
+  test("chat-key header creates and reuses a local conversation", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "letta-openai-chat-key-"));
+    try {
+      const backend = new LocalBackend({
+        storageDir,
+        executionMode: "deterministic",
+        memfsEnabled: false,
+      });
+      const agent = await backend.createAgent({
+        name: "telegram-agent",
+      } as never);
+      __testSetBackend(backend);
+
+      const conversationsUsed: string[] = [];
+      stubTurn((conversationId) => {
+        conversationsUsed.push(conversationId);
+      });
+      handle = await startAppServer({
+        listen: "ws://127.0.0.1:0",
+        openaiApi: true,
+      });
+
+      const listConversations = async () =>
+        (await backend.listConversations({
+          agent_id: agent.id,
+        } as never)) as unknown as Array<{ id: string }>;
+      const send = (message: string) =>
+        fetch(httpUrl(handle as AppServerHandle, "/v1/chat/completions"), {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-letta-chat-key": "telegram:123456789",
+          },
+          body: JSON.stringify({
+            model: "telegram-agent",
+            messages: [{ role: "user", content: message }],
+          }),
+        });
+
+      expect(await listConversations()).toEqual([]);
+
+      const first = await send("Hello");
+      expect(first.status).toBe(200);
+      const conversationsAfterFirstTurn = await listConversations();
+      expect(conversationsAfterFirstTurn).toHaveLength(1);
+      const createdConversation = conversationsAfterFirstTurn[0];
+      if (!createdConversation) {
+        throw new Error("Expected the first request to create a conversation");
+      }
+      expect(conversationsUsed).toEqual([createdConversation.id]);
+
+      const second = await send("Follow-up");
+      expect(second.status).toBe(200);
+      expect(await listConversations()).toHaveLength(1);
+      expect(conversationsUsed).toEqual([
+        createdConversation.id,
+        createdConversation.id,
+      ]);
+    } finally {
+      if (handle) {
+        await handle.close();
+        handle = null;
+      }
+      await rm(storageDir, { recursive: true, force: true });
+    }
   });
 
   test("openwebui chat id is honored only for streaming requests", async () => {

--- a/src/websocket/app-server-openai.test.ts
+++ b/src/websocket/app-server-openai.test.ts
@@ -5,6 +5,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Backend } from "@/backend";
 import { __testSetBackend } from "@/backend";
+import {
+  createAssistantMessageStream,
+  type HeadlessTurnExecutor,
+} from "@/backend/dev/headless-turn-executor";
 import { LocalBackend } from "@/backend/local/local-backend";
 import { type AppServerHandle, startAppServer } from "@/websocket/app-server";
 import { parseAppServerWebsocketAuthSettings } from "@/websocket/app-server-auth";
@@ -428,20 +432,34 @@ describe("app-server OpenAI-compatible API", () => {
   test("chat-key header creates and reuses a local conversation", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "letta-openai-chat-key-"));
     try {
+      const secret = "violet-river-7391";
+      let turnCount = 0;
+      const executor: HeadlessTurnExecutor = {
+        async execute(input) {
+          turnCount += 1;
+          const historyContainsSecret = JSON.stringify(input.history).includes(
+            secret,
+          );
+          const text =
+            turnCount === 1
+              ? "I'll remember it."
+              : historyContainsSecret
+                ? `The secret was ${secret}.`
+                : "I don't know the secret.";
+          return createAssistantMessageStream({
+            content: [{ type: "text", text }],
+          });
+        },
+      };
       const backend = new LocalBackend({
         storageDir,
-        executionMode: "deterministic",
+        executor,
         memfsEnabled: false,
       });
       const agent = await backend.createAgent({
-        name: "telegram-agent",
+        name: "continuity-agent",
       } as never);
       __testSetBackend(backend);
-
-      const conversationsUsed: string[] = [];
-      stubTurn((conversationId) => {
-        conversationsUsed.push(conversationId);
-      });
       handle = await startAppServer({
         listen: "ws://127.0.0.1:0",
         openaiApi: true,
@@ -456,32 +474,60 @@ describe("app-server OpenAI-compatible API", () => {
           method: "POST",
           headers: {
             "content-type": "application/json",
-            "x-letta-chat-key": "telegram:123456789",
+            "x-letta-chat-key": "external-chat:conversation-123",
           },
           body: JSON.stringify({
-            model: "telegram-agent",
+            model: "continuity-agent",
             messages: [{ role: "user", content: message }],
           }),
         });
 
       expect(await listConversations()).toEqual([]);
 
-      const first = await send("Hello");
+      const first = await send(`Remember this secret: ${secret}`);
       expect(first.status).toBe(200);
+      const firstBody = (await first.json()) as {
+        choices: Array<{ message: { content: string } }>;
+      };
+      expect(firstBody.choices[0]?.message.content).toBe("I'll remember it.");
       const conversationsAfterFirstTurn = await listConversations();
       expect(conversationsAfterFirstTurn).toHaveLength(1);
       const createdConversation = conversationsAfterFirstTurn[0];
       if (!createdConversation) {
         throw new Error("Expected the first request to create a conversation");
       }
-      expect(conversationsUsed).toEqual([createdConversation.id]);
 
-      const second = await send("Follow-up");
+      const second = await send("What was the secret?");
       expect(second.status).toBe(200);
+      const secondBody = (await second.json()) as {
+        choices: Array<{ message: { content: string } }>;
+      };
+      expect(secondBody.choices[0]?.message.content).toBe(
+        `The secret was ${secret}.`,
+      );
       expect(await listConversations()).toHaveLength(1);
-      expect(conversationsUsed).toEqual([
+
+      const messagePage = await backend.listConversationMessages(
         createdConversation.id,
-        createdConversation.id,
+        { agent_id: agent.id, order: "asc" } as never,
+      );
+      const messages = messagePage.getPaginatedItems() as Array<{
+        message_type: string;
+        content: unknown;
+      }>;
+      expect(messages.map((message) => message.message_type)).toEqual([
+        "user_message",
+        "assistant_message",
+        "user_message",
+        "assistant_message",
+      ]);
+      expect(
+        messages.map((message) => JSON.stringify(message.content)),
+      ).toEqual([
+        expect.stringContaining(`Remember this secret: ${secret}`),
+        expect.stringContaining("I'll remember it."),
+        expect.stringContaining("What was the secret?"),
+        expect.stringContaining(`The secret was ${secret}.`),
       ]);
     } finally {
       if (handle) {


### PR DESCRIPTION
## Summary

- add an OpenAI-compatible chat completions continuity test backed by the real `LocalBackend`
- use a generic external chat key rather than a channel-specific identifier
- send a secret in the first request and verify a second request with the same `X-Letta-Chat-Key` recalls it through persisted conversation history
- list the stored messages and assert the complete two-turn user/assistant transcript

## Verification

- `bun test src/websocket/app-server-openai.test.ts` — 20 passed
- `bun run check` — all 12 checks passed

## AI Disclosure

- [ ] This pull request was written entirely by a human
- [ ] This pull request was written with AI assistance and reviewed and edited by a human
- [x] I have read the [AI Policy](https://github.com/letta-ai/letta-code/blob/main/AI_POLICY.md) and agree to its terms

## AI Tool(s) Used

Letta Code researched the existing OpenAI compatibility tests, implemented the LocalBackend-backed continuity test, and ran the verification commands.

## Human Verification

Pending human review before this draft is marked ready.