### PR TITLE
feat(app-server): support stateful Responses chaining

### DIFF
--- a/src/websocket/app-server-openai-responses.test.ts
+++ b/src/websocket/app-server-openai-responses.test.ts
@@ -14,7 +14,11 @@ const TEST_AGENT = {
   created_at: "2026-01-01T00:00:00Z",
 };
 
-function fakeBackend(created: string[] = [], deleted: string[] = []): Backend {
+function fakeBackend(
+  created: string[] = [],
+  deleted: string[] = [],
+  forkedFrom: string[] = [],
+): Backend {
   return {
     listAgents: async () => [TEST_AGENT],
     createConversation: async () => {
@@ -25,6 +29,16 @@ function fakeBackend(created: string[] = [], deleted: string[] = []): Backend {
     deleteConversation: async (conversationId: string) => {
       deleted.push(conversationId);
       return {};
+    },
+    retrieveConversation: async (conversationId: string) => {
+      if (!created.includes(conversationId)) throw new Error("not found");
+      return { id: conversationId, agent_id: TEST_AGENT.id };
+    },
+    forkConversation: async (conversationId: string) => {
+      forkedFrom.push(conversationId);
+      const id = `conv-responses-${created.length + 1}`;
+      created.push(id);
+      return { id };
     },
   } as unknown as Backend;
 }
@@ -513,30 +527,102 @@ describe("app-server Responses API", () => {
     ]);
   });
 
-  test("rejects stored response state until retrieval and cleanup are supported", async () => {
+  test("stores Responses and continues them with previous_response_id", async () => {
+    const created: string[] = [];
+    const deleted: string[] = [];
+    const forkedFrom: string[] = [];
+    __testSetBackend(fakeBackend(created, deleted, forkedFrom));
+    const turns: Array<{ conversationId: string; messages: unknown[] }> = [];
+    stubToolTurn((conversationId, messages) => {
+      turns.push({ conversationId, messages });
+    });
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const first = await fetch(httpUrl(handle, "/v1/responses"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "Tutor (Letta Agent)",
+        input: "Remember that my favorite color is green.",
+        store: true,
+      }),
+    });
+    expect(first.status).toBe(200);
+    const firstBody = (await first.json()) as { id: string };
+
+    // Stored response IDs carry a durable conversation cursor rather than
+    // relying on an App Server process-local lookup table.
+    await handle.close();
+    handle = await startAppServer({
+      listen: "ws://127.0.0.1:0",
+      openaiApi: true,
+    });
+
+    const second = await fetch(httpUrl(handle, "/v1/responses"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "Tutor (Letta Agent)",
+        input: "What is my favorite color?",
+        previous_response_id: firstBody.id,
+        store: true,
+      }),
+    });
+    expect(second.status).toBe(200);
+    const secondBody = (await second.json()) as { id: string };
+    expect(secondBody.id).toStartWith("resp_");
+    expect(secondBody.id).not.toBe(firstBody.id);
+
+    expect(created).toEqual(["conv-responses-1", "conv-responses-2"]);
+    expect(forkedFrom).toEqual(["conv-responses-1"]);
+    expect(deleted).toEqual([]);
+    expect(turns.map((turn) => turn.conversationId)).toEqual([
+      "conv-responses-1",
+      "conv-responses-2",
+    ]);
+    expect(turns.map((turn) => turn.messages)).toMatchObject([
+      [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Remember that my favorite color is green.",
+            },
+          ],
+        },
+      ],
+      [
+        {
+          role: "user",
+          content: [{ type: "text", text: "What is my favorite color?" }],
+        },
+      ],
+    ]);
+  });
+
+  test("rejects unknown previous_response_id values", async () => {
     __testSetBackend(fakeBackend());
     handle = await startAppServer({
       listen: "ws://127.0.0.1:0",
       openaiApi: true,
     });
 
-    for (const unsupported of [
-      { store: true },
-      { previous_response_id: "resp_previous" },
-    ]) {
-      const response = await fetch(httpUrl(handle, "/v1/responses"), {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          model: "Tutor (Letta Agent)",
-          input: "Hello",
-          ...unsupported,
-        }),
-      });
-      expect(response.status).toBe(400);
-      const body = (await response.json()) as { error: { code: string } };
-      expect(body.error.code).toBe("unsupported_parameter");
-    }
+    const response = await fetch(httpUrl(handle, "/v1/responses"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "Tutor (Letta Agent)",
+        input: "Hello",
+        previous_response_id: "resp_missing",
+      }),
+    });
+    expect(response.status).toBe(404);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("response_not_found");
   });
 
   test("requires user input", async () => {

--- a/src/websocket/app-server-openai-responses.ts
+++ b/src/websocket/app-server-openai-responses.ts
@@ -49,6 +49,50 @@ interface ResponsesRequest {
   stream?: boolean;
 }
 
+interface StoredResponseState {
+  agentId: string;
+  conversationId: string;
+}
+
+const STORED_RESPONSE_PREFIX = "resp_letta_";
+
+function createStoredResponseId(state: StoredResponseState): string {
+  const cursor = Buffer.from(
+    JSON.stringify({
+      version: 1,
+      nonce: randomUUID(),
+      agent_id: state.agentId,
+      conversation_id: state.conversationId,
+    }),
+  ).toString("base64url");
+  return `${STORED_RESPONSE_PREFIX}${cursor}`;
+}
+
+function parseStoredResponseId(responseId: string): StoredResponseState | null {
+  if (!responseId.startsWith(STORED_RESPONSE_PREFIX)) return null;
+  try {
+    const parsed = JSON.parse(
+      Buffer.from(
+        responseId.slice(STORED_RESPONSE_PREFIX.length),
+        "base64url",
+      ).toString("utf8"),
+    ) as Record<string, unknown>;
+    if (
+      parsed.version !== 1 ||
+      typeof parsed.agent_id !== "string" ||
+      typeof parsed.conversation_id !== "string"
+    ) {
+      return null;
+    }
+    return {
+      agentId: parsed.agent_id,
+      conversationId: parsed.conversation_id,
+    };
+  } catch {
+    return null;
+  }
+}
+
 interface FunctionCallItem {
   type: "function_call";
   id: string;
@@ -514,31 +558,63 @@ export async function handleResponses(
     return;
   }
 
-  if (body.store === true) {
-    sendOpenAiError(
-      response,
-      400,
-      "stored Responses are not supported; use a stable chat identity header for conversation continuity",
-      "invalid_request_error",
-      "unsupported_parameter",
-    );
-    return;
-  }
-  if (body.previous_response_id) {
-    sendOpenAiError(
-      response,
-      400,
-      "previous_response_id is not supported; send the conversation input or a stable chat identity header",
-      "invalid_request_error",
-      "unsupported_parameter",
-    );
-    return;
-  }
-
   const input = normalizeInput(body.input);
   const streaming = body.stream === true;
   const headerChatKey = chatKeyFromHeaders(request, streaming);
-  const prepared = toBridgeMessages(input, Boolean(headerChatKey));
+  const previousResponse = body.previous_response_id
+    ? parseStoredResponseId(body.previous_response_id)
+    : null;
+  if (body.previous_response_id && !previousResponse) {
+    sendOpenAiError(
+      response,
+      404,
+      `The response '${body.previous_response_id}' does not exist or is no longer stored.`,
+      "invalid_request_error",
+      "response_not_found",
+    );
+    return;
+  }
+  if (previousResponse && previousResponse.agentId !== agent.id) {
+    sendOpenAiError(
+      response,
+      404,
+      `The response '${body.previous_response_id}' does not exist for model '${body.model}'.`,
+      "invalid_request_error",
+      "response_not_found",
+    );
+    return;
+  }
+  if (previousResponse) {
+    try {
+      const source = await getBackend().retrieveConversation(
+        previousResponse.conversationId,
+      );
+      if (source.agent_id !== agent.id) {
+        sendOpenAiError(
+          response,
+          404,
+          `The response '${body.previous_response_id}' does not exist for model '${body.model}'.`,
+          "invalid_request_error",
+          "response_not_found",
+        );
+        return;
+      }
+    } catch {
+      sendOpenAiError(
+        response,
+        404,
+        `The response '${body.previous_response_id}' does not exist or is no longer stored.`,
+        "invalid_request_error",
+        "response_not_found",
+      );
+      return;
+    }
+  }
+
+  const prepared = toBridgeMessages(
+    input,
+    Boolean(headerChatKey || previousResponse),
+  );
   applyInstructions(prepared.messages, [
     body.instructions,
     ...inputInstructions(body.input),
@@ -555,7 +631,31 @@ export async function handleResponses(
 
   let conversationId: string;
   try {
-    if (headerChatKey) {
+    if (previousResponse) {
+      const backend = getBackend();
+      if (!backend.forkConversation) {
+        sendOpenAiError(
+          response,
+          501,
+          "previous_response_id is unavailable because this backend cannot fork conversations",
+          "server_error",
+          "unsupported_backend",
+        );
+        return;
+      }
+      const forked = await backend.forkConversation(
+        previousResponse.conversationId,
+        {
+          agentId: agent.id,
+          hidden: true,
+        },
+      );
+      conversationId = forked.id;
+      if (headerChatKey) {
+        const key = `chat-key:${agent.id}:${headerChatKey}`;
+        rememberConversation(key, conversationId);
+      }
+    } else if (headerChatKey) {
       const key = `chat-key:${agent.id}:${headerChatKey}`;
       conversationId = await resolveConversationId(agent.id, key);
       rememberConversation(key, conversationId);
@@ -577,7 +677,10 @@ export async function handleResponses(
     return;
   }
 
-  const responseId = `resp_${randomUUID()}`;
+  const responseId =
+    body.store === true
+      ? createStoredResponseId({ agentId: agent.id, conversationId })
+      : `resp_${randomUUID()}`;
   const createdAt = Math.floor(Date.now() / 1000);
   let sequenceNumber = 0;
   let clientClosed = false;
@@ -649,10 +752,10 @@ export async function handleResponses(
   }
   builder.finish();
 
-  // Header-less requests replay the supplied input into a fresh conversation.
-  // The endpoint does not expose response retrieval, so retaining that
-  // internal conversation would only create unreachable state.
-  if (!headerChatKey) {
+  const shouldStore = body.store === true && !outcome.error;
+  // Stateless requests replay the supplied input into a fresh conversation.
+  // Stored Responses and header-keyed chats retain their conversation state.
+  if (!headerChatKey && !shouldStore) {
     void getBackend()
       .deleteConversation?.(conversationId)
       .catch(() => {


### PR DESCRIPTION
Enables OpenAI-compatible Responses clients to use `store: true` and continue with `previous_response_id` instead of relying on process-local chat-key state.

Stored response IDs carry a versioned cursor to the persisted Letta conversation. Continuations validate that the conversation belongs to the selected agent and fork it before running the next turn, preserving branching semantics and allowing continuation after an App Server restart. `store: false` remains ephemeral, and invalid or unavailable response IDs return `response_not_found`.

Coverage verifies storage, continuation, restart survival, conversation forking, newest-message-only forwarding, cleanup behavior, and invalid IDs. `bun run check` passes all 12 checks; the focused Responses suite passes 10 tests.