### PR TITLE
fix(auth): preserve local backend after login

### DIFF
--- a/src/auth/LettaLoginView.tsx
+++ b/src/auth/LettaLoginView.tsx
@@ -4,15 +4,47 @@ import { useEffect, useRef, useState } from "react";
 import { configureBackendMode } from "@/backend";
 import { Text } from "@/cli/components/Text";
 import { settingsManager } from "@/settings-manager";
-import { pollForToken, requestDeviceCode } from "./oauth";
+import { pollForToken, requestDeviceCode, type TokenResponse } from "./oauth";
+
+interface CloudLoginSettingsWriter {
+  updateSettings: typeof settingsManager.updateSettings;
+  flush: typeof settingsManager.flush;
+}
+
+interface CompleteLettaLoginOptions {
+  activateCloudBackend: boolean;
+  settings?: CloudLoginSettingsWriter;
+  now?: () => number;
+}
+
+export async function completeLettaLogin(
+  tokens: TokenResponse,
+  options: CompleteLettaLoginOptions,
+): Promise<void> {
+  const settings = options.settings ?? settingsManager;
+  const now = options.now?.() ?? Date.now();
+  settings.updateSettings({
+    env: { LETTA_API_KEY: tokens.access_token },
+    refreshToken: tokens.refresh_token,
+    tokenExpiresAt: now + tokens.expires_in * 1000,
+    preferredBackendMode: "api",
+  });
+  await settings.flush();
+
+  if (options.activateCloudBackend) {
+    configureBackendMode("api");
+  }
+}
 
 interface LettaLoginViewProps {
+  activateCloudBackend: boolean;
   onComplete?: () => void;
   onCancel?: () => void;
   successMessage?: string;
 }
 
 export function LettaLoginView({
+  activateCloudBackend,
   onComplete,
   onCancel,
   successMessage = "Signed in with Letta. Switch agents with /agents.",
@@ -82,15 +114,7 @@ export function LettaLoginView({
           controller.signal,
         );
 
-        const now = Date.now();
-        settingsManager.updateSettings({
-          env: { LETTA_API_KEY: tokens.access_token },
-          refreshToken: tokens.refresh_token,
-          tokenExpiresAt: now + tokens.expires_in * 1000,
-          preferredBackendMode: "api",
-        });
-        await settingsManager.flush();
-        configureBackendMode("api");
+        await completeLettaLogin(tokens, { activateCloudBackend });
 
         setDoneMessage(successMessage);
         setTimeout(() => onCompleteRef.current?.(), 500);
@@ -110,7 +134,7 @@ export function LettaLoginView({
       cancelledRef.current = true;
       abortControllerRef.current?.abort();
     };
-  }, [successMessage]);
+  }, [activateCloudBackend, successMessage]);
 
   if (doneMessage) {
     return (

--- a/src/auth/letta-login-view.test.ts
+++ b/src/auth/letta-login-view.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  configureBackendMode,
+  getBackend,
+  isLocalBackendEnabled,
+} from "@/backend";
+import type { Settings } from "@/settings-manager";
+import { completeLettaLogin } from "./LettaLoginView";
+
+const TOKENS = {
+  access_token: "cloud-access-token",
+  refresh_token: "cloud-refresh-token",
+  token_type: "bearer",
+  expires_in: 60,
+};
+
+function createSettingsWriter() {
+  const state = {
+    updates: [] as Partial<Settings>[],
+    flushCount: 0,
+  };
+  return {
+    state,
+    writer: {
+      updateSettings(updates: Partial<Settings>): void {
+        state.updates.push(updates);
+      },
+      async flush(): Promise<void> {
+        state.flushCount += 1;
+      },
+    },
+  };
+}
+
+afterEach(() => {
+  configureBackendMode("api");
+});
+
+describe("completeLettaLogin", () => {
+  test("preserves the active local backend for in-session login", async () => {
+    configureBackendMode("local");
+    const localBackend = getBackend();
+    const { state, writer } = createSettingsWriter();
+
+    await completeLettaLogin(TOKENS, {
+      activateCloudBackend: false,
+      settings: writer,
+      now: () => 1_000,
+    });
+
+    expect(getBackend()).toBe(localBackend);
+    expect(isLocalBackendEnabled()).toBe(true);
+    expect(state.updates).toEqual([
+      {
+        env: { LETTA_API_KEY: "cloud-access-token" },
+        refreshToken: "cloud-refresh-token",
+        tokenExpiresAt: 61_000,
+        preferredBackendMode: "api",
+      },
+    ]);
+    expect(state.flushCount).toBe(1);
+  });
+
+  test("activates the cloud backend when setup requests it", async () => {
+    configureBackendMode("local");
+    const { writer } = createSettingsWriter();
+
+    await completeLettaLogin(TOKENS, {
+      activateCloudBackend: true,
+      settings: writer,
+    });
+
+    expect(isLocalBackendEnabled()).toBe(false);
+    expect(getBackend().capabilities.remoteMemfs).toBe(true);
+  });
+});

--- a/src/auth/setup-ui.tsx
+++ b/src/auth/setup-ui.tsx
@@ -119,6 +119,7 @@ export function SetupUI({
         <Text bold>{AUTH_LOGIN_LABEL}</Text>
         <Text> </Text>
         <LettaLoginView
+          activateCloudBackend
           onComplete={() => onComplete({ kind: "cloud-login" })}
           onCancel={() => setMode("menu")}
           successMessage="Signed in with Letta. Starting Letta Code..."

--- a/src/cli/components/LettaLoginOverlay.tsx
+++ b/src/cli/components/LettaLoginOverlay.tsx
@@ -130,7 +130,11 @@ export function LettaLoginOverlay({
 
   return (
     <OverlayShell command="/login" title="Sign in with Letta">
-      <LettaLoginView onComplete={onComplete} onCancel={onCancel} />
+      <LettaLoginView
+        activateCloudBackend={false}
+        onComplete={onComplete}
+        onCancel={onCancel}
+      />
     </OverlayShell>
   );
 }

--- a/src/cli/local-first-setup-wiring.test.ts
+++ b/src/cli/local-first-setup-wiring.test.ts
@@ -29,14 +29,12 @@ describe("local-first setup wiring", () => {
     expect(source).not.toContain("Choose where your agents should live");
   });
 
-  test("successful cloud login records the api backend preference", () => {
-    const source = readSource("../auth/LettaLoginView.tsx");
-    const start = source.indexOf("settingsManager.updateSettings({");
-    const end = source.indexOf("await settingsManager.flush();", start);
+  test("in-session login preserves the active backend while setup activates cloud", () => {
+    const overlaySource = readSource("./components/LettaLoginOverlay.tsx");
+    const setupSource = readSource("../auth/setup-ui.tsx");
 
-    expect(start).toBeGreaterThan(-1);
-    expect(end).toBeGreaterThan(start);
-    expect(source.slice(start, end)).toContain('preferredBackendMode: "api"');
+    expect(overlaySource).toContain("activateCloudBackend={false}");
+    expect(setupSource).toContain("activateCloudBackend");
   });
 
   test("reauthentication paths do not trust stale stored credentials", () => {


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Summary
- Keep an in-session `/login` from replacing the active local backend while the local agent and conversation remain selected.
- Preserve the existing first-time setup behavior that activates the Cloud backend after login.
- Add behavioral coverage for both activation modes plus a caller-wiring regression guard.

## Before / after
Before, signing into Cloud during a local-agent session immediately replaced the global backend, so the next prompt recompile and user turn sent the local agent ID to Cloud and returned 404.

After, login still saves Cloud credentials and the future Cloud preference, but the live backend changes only when the caller explicitly requests it. Initial setup requests the switch; the in-session login overlay does not.

## Risk
Scoped to backend activation after successful login. Credential persistence and initial setup behavior are unchanged.

## Test plan
- [x] `bun test src/auth/letta-login-view.test.ts src/cli/local-first-setup-wiring.test.ts`
- [x] `bun run check`
- [x] Confirmed the wiring regression test fails when the in-session overlay re-enables Cloud activation
- [x] Independent adversarial review of the final patch

👾 Generated with [Letta Code](https://letta.com)